### PR TITLE
feat: Duffel flight search, AI flight planning, per-day itineraries

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,10 +88,11 @@ Create `src/packages/api/.env` (see `.env.sample`):
 ```
 GOOGLE_PLACES_API_KEY=...   # Required for /places/* endpoints
 ANTHROPIC_API_KEY=...       # Required for /api/v1/plan SSE endpoint
+DUFFEL_ACCESS_TOKEN=...     # Required for /flights/* endpoints (Duffel; test or live token)
 DATABASE_URL=...            # Postgres connection; absent/unreachable => degraded mode (no persistence)
 ```
 
-Without `GOOGLE_PLACES_API_KEY`, place search endpoints return errors. The `/plan` handler also calls `search_places` internally, which will fail without the key.
+Without `GOOGLE_PLACES_API_KEY`, place search endpoints return errors. The `/plan` handler also calls `search_places` internally, which will fail without the key. Without `DUFFEL_ACCESS_TOKEN`, the `/flights/*` endpoints return a configured-error; the rest of the API is unaffected.
 
 ## API Endpoints
 
@@ -102,6 +103,8 @@ Without `GOOGLE_PLACES_API_KEY`, place search endpoints return errors. The `/pla
 | GET | `/api/v1/places/search?q=` | Google Places Text Search |
 | GET | `/api/v1/places/autocomplete?input=` | Google Places Autocomplete |
 | GET | `/api/v1/places/details?place_id=` | Google Places Details |
+| GET | `/api/v1/flights/airports?q=` | Duffel airport/city autocomplete (IATA codes) |
+| POST | `/api/v1/flights/search` | Duffel flight offers, ranked by `optimize_for` (`cost`/`time`/`balanced`) |
 | POST | `/api/v1/plan` | SSE stream; Claude claude-sonnet-4-6 with `search_places` tool |
 
 ## Key Constraints
@@ -109,5 +112,6 @@ Without `GOOGLE_PLACES_API_KEY`, place search endpoints return errors. The `/pla
 - `Location.Latitude` and `Location.Longitude` in the Go API are `*float64` (pointers) to distinguish "not provided" from zero — coordinate validation is skipped when nil to support name-only location resolution.
 - The `/plan` endpoint uses `text/event-stream` with `http.Flusher`; the server `WriteTimeout` must stay at `0`.
 - Flutter models use `json_serializable`; never edit `.g.dart` files by hand.
-- The `optimize_for` field on country routes accepts only `"distance"`, `"season"`, or `"balanced"` (empty string defaults to balanced).
+- The `optimize_for` field on country routes accepts only `"distance"`, `"season"`, or `"balanced"` (empty string defaults to balanced). On flight search it accepts `"cost"`, `"time"`, or `"balanced"` (empty defaults to balanced).
+- Flight search inputs are **IATA codes** (e.g. `JFK`, `CDG`), not city names — resolve names via `/flights/airports?q=` first. Flight data comes from **Duffel** (`duffel_service.go`, process-wide `duffelService` singleton, static `DUFFEL_ACCESS_TOKEN`); the provider is isolated to that one file behind the `FlightOffer`/`Airport` types so it can be swapped without touching the handler, optimizer, or Flutter app.
 - Persistence uses **pgx + sqlc + goose** (Postgres). The `store/` package is sqlc-generated — run `make api-sqlc` after editing `query/*.sql` or the schema; never hand-edit it. UUID primary keys; migrations run on boot and via `make api-migrate`.

--- a/src/packages/api/.env.sample
+++ b/src/packages/api/.env.sample
@@ -1,5 +1,12 @@
 GOOGLE_PLACES_API_KEY=your_google_places_api_key_here
 ANTHROPIC_API_KEY=your_anthropic_api_key_here
+# Duffel access token for flight search (sign up at https://app.duffel.com).
+# A test token (duffel_test_...) returns sandbox flight data for free; swap to a
+# live token (duffel_live_...) for real bookings. DUFFEL_BASE_URL/VERSION rarely
+# need changing.
+DUFFEL_ACCESS_TOKEN=your_duffel_test_token_here
+DUFFEL_BASE_URL=https://api.duffel.com
+DUFFEL_VERSION=v2
 CHROME_WS_URL=ws://chrome:9222/   # Set when running in Docker; leave empty to launch Chrome locally
 # Postgres connection. For local `make api-run`, point at localhost. In Docker the
 # compose stacks override this to use the `postgres` service host.

--- a/src/packages/api/airline_links.go
+++ b/src/packages/api/airline_links.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"net/url"
+	"strings"
+)
+
+// airlineSites maps an airline IATA code to its booking/home page. Best-effort
+// for major carriers; offers from any other airline fall back to an
+// airline-filtered Google Flights link (see flightBookingURL). Duffel does not
+// expose a per-flight airline booking link, so these land on the carrier's own
+// booking/search page rather than the exact itinerary.
+var airlineSites = map[string]string{
+	"AA": "https://www.aa.com",
+	"DL": "https://www.delta.com",
+	"UA": "https://www.united.com",
+	"B6": "https://www.jetblue.com",
+	"AS": "https://www.alaskaair.com",
+	"WN": "https://www.southwest.com",
+	"NK": "https://www.spirit.com",
+	"F9": "https://www.flyfrontier.com",
+	"HA": "https://www.hawaiianairlines.com",
+	"AC": "https://www.aircanada.com",
+	"WS": "https://www.westjet.com",
+	"AM": "https://www.aeromexico.com",
+	"AV": "https://www.avianca.com",
+	"CM": "https://www.copaair.com",
+	"LA": "https://www.latamairlines.com",
+	"BA": "https://www.britishairways.com",
+	"VS": "https://www.virginatlantic.com",
+	"AF": "https://www.airfrance.com",
+	"KL": "https://www.klm.com",
+	"LH": "https://www.lufthansa.com",
+	"LX": "https://www.swiss.com",
+	"OS": "https://www.austrian.com",
+	"IB": "https://www.iberia.com",
+	"TP": "https://www.flytap.com",
+	"EI": "https://www.aerlingus.com",
+	"AY": "https://www.finnair.com",
+	"SK": "https://www.flysas.com",
+	"AZ": "https://www.ita-airways.com",
+	"TK": "https://www.turkishairlines.com",
+	"EK": "https://www.emirates.com",
+	"QR": "https://www.qatarairways.com",
+	"EY": "https://www.etihad.com",
+	"SQ": "https://www.singaporeair.com",
+	"CX": "https://www.cathaypacific.com",
+	"QF": "https://www.qantas.com",
+	"NH": "https://www.ana.co.jp",
+	"JL": "https://www.jal.co.jp",
+	"ET": "https://www.ethiopianairlines.com",
+}
+
+// flightBookingURL returns the airline's own booking site when the carrier is
+// known, otherwise an airline-filtered Google Flights deep link for the route
+// and dates (the airline name is added to the query so Google pre-filters to
+// that carrier).
+func flightBookingURL(airlineCode, airlineName, origin, destination, departDate, returnDate string) string {
+	if site, ok := airlineSites[strings.ToUpper(strings.TrimSpace(airlineCode))]; ok {
+		return site
+	}
+
+	parts := []string{"flights"}
+	if origin != "" {
+		parts = append(parts, "from", origin)
+	}
+	if destination != "" {
+		parts = append(parts, "to", destination)
+	}
+	if departDate != "" {
+		parts = append(parts, "on", departDate)
+	}
+	if returnDate != "" {
+		parts = append(parts, "returning", returnDate)
+	}
+	if airlineName != "" {
+		parts = append(parts, "on", airlineName)
+	}
+	query := strings.Join(parts, " ")
+	return "https://www.google.com/travel/flights?" + url.Values{"q": {query}}.Encode()
+}
+
+// attachBookingURLs sets BookingURL on each offer from its airline plus the
+// request's route and dates. Shared by the standalone /flights/search handler
+// and the agent's search_flights tool so both surface a working link.
+func attachBookingURLs(offers []FlightOffer, req FlightSearchRequest) {
+	for i := range offers {
+		name := ""
+		if len(offers[i].Airlines) > 0 {
+			name = offers[i].Airlines[0]
+		}
+		offers[i].BookingURL = flightBookingURL(
+			offers[i].AirlineCode, name, req.Origin, req.Destination, req.DepartDate, req.ReturnDate)
+	}
+}

--- a/src/packages/api/duffel_service.go
+++ b/src/packages/api/duffel_service.go
@@ -1,0 +1,355 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// DuffelService handles Duffel flight API interactions. Unlike Amadeus, Duffel
+// authenticates with a static access token (no OAuth exchange), so the service
+// just attaches a bearer header and version to each request.
+type DuffelService struct {
+	Token   string
+	BaseURL string
+	Version string
+	Client  *http.Client
+}
+
+// Airport is a normalized airport/city result used for origin/destination
+// autocomplete. Inputs to flight search are IATA codes.
+type Airport struct {
+	IataCode string `json:"iata_code"`
+	Name     string `json:"name"`
+	City     string `json:"city,omitempty"`
+	Country  string `json:"country,omitempty"`
+	SubType  string `json:"sub_type,omitempty"` // airport | city
+}
+
+// FlightLeg is a single flown segment within an offer.
+type FlightLeg struct {
+	From         string `json:"from"`
+	To           string `json:"to"`
+	Carrier      string `json:"carrier"`
+	FlightNumber string `json:"flight_number"`
+	DepartTime   string `json:"depart_time"`
+	ArriveTime   string `json:"arrive_time"`
+}
+
+// FlightOffer is a normalized flight offer. The *_score fields are populated by
+// the optimizer (see flight_optimizer.go); they are zero until ranking runs.
+type FlightOffer struct {
+	ID             string      `json:"id"`
+	Price          float64     `json:"price"`
+	Currency       string      `json:"currency"`
+	Stops          int         `json:"stops"`
+	DurationMin    int         `json:"duration_minutes"`
+	Airlines       []string    `json:"airlines"`
+	AirlineCode    string      `json:"airline_code,omitempty"`     // owner.iata_code
+	AirlineLogoURL string      `json:"airline_logo_url,omitempty"` // owner.logo_symbol_url (SVG)
+	DepartTime     string      `json:"depart_time"`
+	ArriveTime     string      `json:"arrive_time"`
+	Segments       []FlightLeg `json:"segments"`
+	BookingURL     string      `json:"booking_url,omitempty"`
+
+	// Scoring (filled by RankFlightOffers)
+	Score         float64 `json:"score"`
+	PriceScore    float64 `json:"price_score"`
+	DurationScore float64 `json:"duration_score"`
+	StopsScore    float64 `json:"stops_score"`
+}
+
+// FlightSearchRequest is the inbound request shape for /flights/search.
+type FlightSearchRequest struct {
+	Origin      string `json:"origin"`      // IATA code
+	Destination string `json:"destination"` // IATA code
+	DepartDate  string `json:"depart_date"` // YYYY-MM-DD
+	ReturnDate  string `json:"return_date,omitempty"`
+	Adults      int    `json:"adults"`
+	OptimizeFor string `json:"optimize_for"` // "cost" | "time" | "balanced"
+}
+
+// maxOffers caps how many offers we keep from a Duffel search before ranking,
+// to bound work and response size (Duffel can return hundreds).
+const maxOffers = 50
+
+// NewDuffelService creates a new Duffel service, reading the access token from
+// the environment. A missing token is a soft failure (a warning, like the
+// Google key) so the rest of the API stays healthy; calls fail clearly later.
+func NewDuffelService() *DuffelService {
+	token := os.Getenv("DUFFEL_ACCESS_TOKEN")
+	if token == "" {
+		fmt.Println("Warning: DUFFEL_ACCESS_TOKEN not set; flight search disabled")
+	}
+
+	baseURL := os.Getenv("DUFFEL_BASE_URL")
+	if baseURL == "" {
+		baseURL = "https://api.duffel.com"
+	}
+	version := os.Getenv("DUFFEL_VERSION")
+	if version == "" {
+		version = "v2"
+	}
+
+	return &DuffelService{
+		Token:   token,
+		BaseURL: strings.TrimRight(baseURL, "/"),
+		Version: version,
+		Client:  &http.Client{Timeout: 60 * time.Second},
+	}
+}
+
+// newRequest builds a Duffel request with the standard auth/version headers.
+func (d *DuffelService) newRequest(ctx context.Context, method, path string, body io.Reader) (*http.Request, error) {
+	if d.Token == "" {
+		return nil, fmt.Errorf("Duffel access token not configured")
+	}
+	req, err := http.NewRequestWithContext(ctx, method, d.BaseURL+path, body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+d.Token)
+	req.Header.Set("Duffel-Version", d.Version)
+	req.Header.Set("Accept", "application/json")
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	return req, nil
+}
+
+// do executes the request and returns the raw body, surfacing API error payloads.
+func (d *DuffelService) do(req *http.Request) ([]byte, error) {
+	resp, err := d.Client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("Duffel API error (%d): %s", resp.StatusCode, string(body))
+	}
+	return body, nil
+}
+
+// SearchAirports resolves a free-text keyword to airports/cities (for origin
+// and destination autocomplete).
+func (d *DuffelService) SearchAirports(ctx context.Context, keyword string) ([]Airport, error) {
+	params := url.Values{}
+	params.Set("query", keyword)
+
+	req, err := d.newRequest(ctx, http.MethodGet, "/places/suggestions?"+params.Encode(), nil)
+	if err != nil {
+		return nil, err
+	}
+	body, err := d.do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	var result struct {
+		Data []struct {
+			Type            string `json:"type"`
+			Name            string `json:"name"`
+			IataCode        string `json:"iata_code"`
+			CityName        string `json:"city_name"`
+			IataCountryCode string `json:"iata_country_code"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse places response: %w", err)
+	}
+
+	airports := make([]Airport, 0, len(result.Data))
+	for _, p := range result.Data {
+		if p.IataCode == "" {
+			continue
+		}
+		airports = append(airports, Airport{
+			IataCode: p.IataCode,
+			Name:     p.Name,
+			City:     p.CityName,
+			Country:  p.IataCountryCode,
+			SubType:  p.Type,
+		})
+	}
+	return airports, nil
+}
+
+// SearchFlightOffers creates a Duffel offer request (with offers returned
+// inline) and returns normalized offers (unranked). Stops/duration/times are
+// taken from the outbound slice.
+func (d *DuffelService) SearchFlightOffers(ctx context.Context, req FlightSearchRequest) ([]FlightOffer, error) {
+	adults := req.Adults
+	if adults < 1 {
+		adults = 1
+	}
+
+	// Build the request payload. One slice for one-way, two for round-trip.
+	type sliceReq struct {
+		Origin        string `json:"origin"`
+		Destination   string `json:"destination"`
+		DepartureDate string `json:"departure_date"`
+	}
+	type passengerReq struct {
+		Type string `json:"type"`
+	}
+	slices := []sliceReq{{
+		Origin:        strings.ToUpper(req.Origin),
+		Destination:   strings.ToUpper(req.Destination),
+		DepartureDate: req.DepartDate,
+	}}
+	if req.ReturnDate != "" {
+		slices = append(slices, sliceReq{
+			Origin:        strings.ToUpper(req.Destination),
+			Destination:   strings.ToUpper(req.Origin),
+			DepartureDate: req.ReturnDate,
+		})
+	}
+	passengers := make([]passengerReq, adults)
+	for i := range passengers {
+		passengers[i] = passengerReq{Type: "adult"}
+	}
+	payload := map[string]any{
+		"data": map[string]any{
+			"slices":      slices,
+			"passengers":  passengers,
+			"cabin_class": "economy",
+		},
+	}
+	buf, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode offer request: %w", err)
+	}
+
+	httpReq, err := d.newRequest(ctx, http.MethodPost, "/air/offer_requests?return_offers=true", bytes.NewReader(buf))
+	if err != nil {
+		return nil, err
+	}
+	body, err := d.do(httpReq)
+	if err != nil {
+		return nil, err
+	}
+
+	var result struct {
+		Data struct {
+			Offers []struct {
+				ID            string `json:"id"`
+				TotalAmount   string `json:"total_amount"`
+				TotalCurrency string `json:"total_currency"`
+				Owner         struct {
+					IataCode      string `json:"iata_code"`
+					Name          string `json:"name"`
+					LogoSymbolURL string `json:"logo_symbol_url"`
+				} `json:"owner"`
+				Slices []struct {
+					Duration string `json:"duration"`
+					Segments []struct {
+						Origin struct {
+							IataCode string `json:"iata_code"`
+						} `json:"origin"`
+						Destination struct {
+							IataCode string `json:"iata_code"`
+						} `json:"destination"`
+						DepartingAt      string `json:"departing_at"`
+						ArrivingAt       string `json:"arriving_at"`
+						MarketingCarrier struct {
+							Name     string `json:"name"`
+							IataCode string `json:"iata_code"`
+						} `json:"marketing_carrier"`
+						MarketingCarrierFlightNumber string `json:"marketing_carrier_flight_number"`
+					} `json:"segments"`
+				} `json:"slices"`
+			} `json:"offers"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse offers response: %w", err)
+	}
+
+	offers := make([]FlightOffer, 0, len(result.Data.Offers))
+	for _, o := range result.Data.Offers {
+		if len(o.Slices) == 0 || len(o.Slices[0].Segments) == 0 {
+			continue
+		}
+		outbound := o.Slices[0]
+		segs := outbound.Segments
+
+		legs := make([]FlightLeg, 0, len(segs))
+		airlineSet := map[string]bool{}
+		airlines := []string{}
+		for _, s := range segs {
+			name := s.MarketingCarrier.Name
+			if name == "" {
+				name = s.MarketingCarrier.IataCode
+			}
+			if name != "" && !airlineSet[name] {
+				airlineSet[name] = true
+				airlines = append(airlines, name)
+			}
+			legs = append(legs, FlightLeg{
+				From:         s.Origin.IataCode,
+				To:           s.Destination.IataCode,
+				Carrier:      name,
+				FlightNumber: s.MarketingCarrier.IataCode + s.MarketingCarrierFlightNumber,
+				DepartTime:   s.DepartingAt,
+				ArriveTime:   s.ArrivingAt,
+			})
+		}
+
+		price, _ := strconv.ParseFloat(o.TotalAmount, 64)
+		offers = append(offers, FlightOffer{
+			ID:             o.ID,
+			Price:          price,
+			Currency:       o.TotalCurrency,
+			Stops:          len(segs) - 1,
+			DurationMin:    parseISO8601Duration(outbound.Duration),
+			Airlines:       airlines,
+			AirlineCode:    o.Owner.IataCode,
+			AirlineLogoURL: o.Owner.LogoSymbolURL,
+			DepartTime:     segs[0].DepartingAt,
+			ArriveTime:     segs[len(segs)-1].ArrivingAt,
+			Segments:       legs,
+		})
+		if len(offers) >= maxOffers {
+			break
+		}
+	}
+	return offers, nil
+}
+
+// parseISO8601Duration converts an ISO-8601 duration like "PT5H30M" to minutes.
+// Duffel slice durations use hours and minutes (e.g. "PT02H26M").
+func parseISO8601Duration(s string) int {
+	s = strings.TrimPrefix(s, "PT")
+	total := 0
+	num := strings.Builder{}
+	for _, r := range s {
+		switch {
+		case r >= '0' && r <= '9':
+			num.WriteRune(r)
+		case r == 'H':
+			h, _ := strconv.Atoi(num.String())
+			total += h * 60
+			num.Reset()
+		case r == 'M':
+			m, _ := strconv.Atoi(num.String())
+			total += m
+			num.Reset()
+		default:
+			num.Reset()
+		}
+	}
+	return total
+}

--- a/src/packages/api/flight_optimizer.go
+++ b/src/packages/api/flight_optimizer.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"math"
+	"sort"
+	"strings"
+)
+
+// flightWeights are the per-factor weights for each optimization preset. They
+// mirror the optimize_for contract used by the country optimizer: an empty
+// value defaults to "balanced".
+type flightWeights struct {
+	price    float64
+	duration float64
+	stops    float64
+}
+
+var flightPresets = map[string]flightWeights{
+	"cost":     {price: 0.70, duration: 0.20, stops: 0.10},
+	"time":     {price: 0.15, duration: 0.60, stops: 0.25},
+	"balanced": {price: 0.40, duration: 0.40, stops: 0.20},
+}
+
+// normalizeOptimizeFor returns a valid preset name; empty/unknown -> "balanced".
+func normalizeOptimizeFor(optimizeFor string) string {
+	key := strings.ToLower(strings.TrimSpace(optimizeFor))
+	if _, ok := flightPresets[key]; ok {
+		return key
+	}
+	return "balanced"
+}
+
+// invScore maps a value into a 0-10 score where the minimum value in the set
+// scores 10 and the maximum scores 0 (lower is better for price/duration/stops).
+// When all values are equal the factor is neutral (10) so it doesn't penalize.
+func invScore(value, min, max float64) float64 {
+	if max <= min {
+		return 10.0
+	}
+	return (max - value) / (max - min) * 10.0
+}
+
+// scheduleSignature identifies an offer at the level a traveler perceives it on
+// a summary card: origin, final destination, overall departure/arrival times,
+// and the ordered list of connecting airports. Offers that share a signature
+// look identical in the list, so we treat them as one option and keep only the
+// cheapest. This intentionally ignores the *timing* of intermediate legs: two
+// itineraries on the same route through the same hubs that differ only in, say,
+// a 5h vs 7h layout in a connecting city (with the same total duration) are
+// indistinguishable on the card and otherwise appear as confusing duplicates.
+// Routes through different hubs keep different signatures and stay separate.
+func scheduleSignature(o FlightOffer) string {
+	if len(o.Segments) == 0 {
+		return ""
+	}
+	first := o.Segments[0]
+	last := o.Segments[len(o.Segments)-1]
+	parts := []string{first.From, last.To, first.DepartTime, last.ArriveTime}
+	for i := 0; i < len(o.Segments)-1; i++ {
+		parts = append(parts, o.Segments[i].To) // connecting airport
+	}
+	return strings.Join(parts, "|")
+}
+
+// dedupBySchedule collapses offers that share an identical schedule, keeping the
+// lowest-priced offer for each. Order of first appearance is preserved so the
+// result is stable before ranking. Offers without segments fall back to a
+// signature of their top-level depart/arrive times so they are never dropped.
+func dedupBySchedule(offers []FlightOffer) []FlightOffer {
+	best := make(map[string]int, len(offers)) // signature -> index in result
+	result := make([]FlightOffer, 0, len(offers))
+	for _, o := range offers {
+		sig := scheduleSignature(o)
+		if sig == "" {
+			sig = o.DepartTime + "-" + o.ArriveTime
+		}
+		if idx, ok := best[sig]; ok {
+			if o.Price < result[idx].Price {
+				result[idx] = o
+			}
+			continue
+		}
+		best[sig] = len(result)
+		result = append(result, o)
+	}
+	return result
+}
+
+// RankFlightOffers collapses duplicate schedules (keeping the cheapest of each),
+// then scores each remaining offer on price, duration, and stops (each
+// normalized to 0-10 across the result set, lower being better), combines them
+// using the preset weights, and returns the offers sorted by descending score.
+// The *_score and Score fields on each offer are populated in place.
+func RankFlightOffers(offers []FlightOffer, optimizeFor string) []FlightOffer {
+	if len(offers) == 0 {
+		return offers
+	}
+
+	offers = dedupBySchedule(offers)
+
+	w := flightPresets[normalizeOptimizeFor(optimizeFor)]
+
+	minPrice, maxPrice := math.Inf(1), math.Inf(-1)
+	minDur, maxDur := math.Inf(1), math.Inf(-1)
+	minStops, maxStops := math.Inf(1), math.Inf(-1)
+	for _, o := range offers {
+		minPrice, maxPrice = math.Min(minPrice, o.Price), math.Max(maxPrice, o.Price)
+		minDur, maxDur = math.Min(minDur, float64(o.DurationMin)), math.Max(maxDur, float64(o.DurationMin))
+		minStops, maxStops = math.Min(minStops, float64(o.Stops)), math.Max(maxStops, float64(o.Stops))
+	}
+
+	for i := range offers {
+		o := &offers[i]
+		o.PriceScore = round2(invScore(o.Price, minPrice, maxPrice))
+		o.DurationScore = round2(invScore(float64(o.DurationMin), minDur, maxDur))
+		o.StopsScore = round2(invScore(float64(o.Stops), minStops, maxStops))
+		o.Score = round2(o.PriceScore*w.price + o.DurationScore*w.duration + o.StopsScore*w.stops)
+	}
+
+	sort.SliceStable(offers, func(i, j int) bool {
+		return offers[i].Score > offers[j].Score
+	})
+	return offers
+}
+
+func round2(f float64) float64 {
+	return math.Round(f*100) / 100
+}

--- a/src/packages/api/flight_optimizer_test.go
+++ b/src/packages/api/flight_optimizer_test.go
@@ -1,0 +1,113 @@
+package main
+
+import "testing"
+
+// leg is a tiny helper to build a single-segment offer with a given schedule.
+func offer(id string, price float64, from, to, dep, arr string, dur, stops int) FlightOffer {
+	return FlightOffer{
+		ID:          id,
+		Price:       price,
+		Currency:    "USD",
+		Stops:       stops,
+		DurationMin: dur,
+		DepartTime:  dep,
+		ArriveTime:  arr,
+		Segments:    []FlightLeg{{From: from, To: to, DepartTime: dep, ArriveTime: arr}},
+	}
+}
+
+// Mirrors the real EWR->PAR Duffel response: four offers sharing one cheap
+// nonstop schedule (resold under different carriers), plus two distinct ones.
+func TestRankFlightOffersDedupesSharedSchedule(t *testing.T) {
+	in := []FlightOffer{
+		offer("iberia", 226.81, "EWR", "BVA", "2026-07-15T10:50:00", "2026-07-16T01:09:00", 499, 0),
+		offer("ba", 234.23, "EWR", "BVA", "2026-07-15T10:50:00", "2026-07-16T01:09:00", 499, 0),
+		offer("aa", 239.74, "EWR", "BVA", "2026-07-15T10:50:00", "2026-07-16T01:09:00", 499, 0),
+		offer("duffel", 241.21, "EWR", "BVA", "2026-07-15T10:50:00", "2026-07-16T01:09:00", 499, 0),
+		offer("tap", 374.00, "EWR", "ORY", "2026-07-15T17:30:00", "2026-07-16T11:00:00", 690, 1),
+		offer("frenchbee", 424.50, "EWR", "ORY", "2026-07-15T23:00:00", "2026-07-16T12:15:00", 435, 0),
+	}
+
+	got := RankFlightOffers(in, "balanced")
+
+	if len(got) != 3 {
+		t.Fatalf("expected 3 distinct schedules after dedup, got %d", len(got))
+	}
+	// The shared cheap schedule must be represented exactly once, by Iberia (cheapest).
+	count := 0
+	for _, o := range got {
+		if o.Segments[0].To == "BVA" {
+			count++
+			if o.ID != "iberia" {
+				t.Errorf("expected cheapest BVA offer (iberia) to survive, got %q at $%.2f", o.ID, o.Price)
+			}
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected the shared BVA schedule to appear once, got %d", count)
+	}
+}
+
+// twoStop builds a 3-leg EWR->hub1->hub2->FCO itinerary with fixed endpoints,
+// varying only the middle (hub1->hub2) leg's timing — mirroring the real Duffel
+// case where the same route at the same price appears several times.
+func twoStop(id string, price float64, hub1, hub2, midDep, midArr string) FlightOffer {
+	return FlightOffer{
+		ID: id, Price: price, Currency: "USD", Stops: 2, DurationMin: 1145,
+		DepartTime: "2026-07-15T23:10:00", ArriveTime: "2026-07-16T00:15:00",
+		Segments: []FlightLeg{
+			{From: "EWR", To: hub1, DepartTime: "2026-07-15T23:10:00", ArriveTime: "2026-07-16T10:55:00"},
+			{From: hub1, To: hub2, DepartTime: midDep, ArriveTime: midArr},
+			{From: hub2, To: "FCO", DepartTime: "2026-07-16T20:15:00", ArriveTime: "2026-07-16T00:15:00"},
+		},
+	}
+}
+
+func TestDedupCollapsesSameRouteDifferentLayoverTiming(t *testing.T) {
+	// Same endpoints, same total times, same hubs (OPO, LIS), same price —
+	// differ only in the OPO->LIS leg timing. These look identical on the card
+	// and must collapse to one.
+	in := []FlightOffer{
+		twoStop("a", 390, "OPO", "LIS", "2026-07-16T12:35:00", "2026-07-16T13:25:00"),
+		twoStop("b", 390, "OPO", "LIS", "2026-07-16T18:00:00", "2026-07-16T19:05:00"),
+		twoStop("c", 390, "OPO", "LIS", "2026-07-16T16:00:00", "2026-07-16T17:00:00"),
+	}
+	got := dedupBySchedule(in)
+	if len(got) != 1 {
+		t.Fatalf("expected same-route/different-layover offers to collapse to 1, got %d", len(got))
+	}
+}
+
+func TestDedupKeepsDifferentConnectingAirports(t *testing.T) {
+	// Same endpoints and overall times but routed through different hubs — these
+	// are genuinely different itineraries and must both survive.
+	in := []FlightOffer{
+		twoStop("via-opo", 390, "OPO", "LIS", "2026-07-16T12:35:00", "2026-07-16T13:25:00"),
+		twoStop("via-mad", 390, "MAD", "LIS", "2026-07-16T12:35:00", "2026-07-16T13:25:00"),
+	}
+	got := dedupBySchedule(in)
+	if len(got) != 2 {
+		t.Fatalf("expected different-hub itineraries to stay separate, got %d", len(got))
+	}
+}
+
+func TestDedupBySchedulePreservesOrderAndKeepsCheapest(t *testing.T) {
+	in := []FlightOffer{
+		offer("a-expensive", 500, "JFK", "CDG", "T1", "T2", 480, 0),
+		offer("b-other", 300, "JFK", "ORY", "T3", "T4", 500, 1),
+		offer("a-cheap", 250, "JFK", "CDG", "T1", "T2", 480, 0),
+	}
+	got := dedupBySchedule(in)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 schedules, got %d", len(got))
+	}
+	if got[0].ID != "a-cheap" {
+		t.Errorf("expected cheapest of shared schedule (a-cheap) in first slot, got %q", got[0].ID)
+	}
+	if got[0].Price != 250 {
+		t.Errorf("expected price 250, got %v", got[0].Price)
+	}
+	if got[1].ID != "b-other" {
+		t.Errorf("expected b-other preserved in second slot, got %q", got[1].ID)
+	}
+}

--- a/src/packages/api/main.go
+++ b/src/packages/api/main.go
@@ -386,6 +386,121 @@ func placesDetailsHandler(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// FlightSearchResponse is the ranked result of a flight search.
+type FlightSearchResponse struct {
+	Offers      []FlightOffer `json:"offers"`
+	BestOfferID string        `json:"best_offer_id,omitempty"`
+	OptimizeFor string        `json:"optimize_for"`
+	Count       int           `json:"count"`
+	Status      string        `json:"status"`
+}
+
+// duffelService is a process-wide singleton reused across requests (the HTTP
+// client and config are shared; auth is a static token).
+var duffelService = NewDuffelService()
+
+// airportsSearchHandler resolves a keyword to airports/cities for autocomplete.
+func airportsSearchHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	query := r.URL.Query().Get("q")
+	if query == "" {
+		http.Error(w, "Missing query parameter 'q'", http.StatusBadRequest)
+		return
+	}
+
+	results, err := duffelService.SearchAirports(r.Context(), query)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("Failed to search airports: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"results": results,
+		"status":  "success",
+	})
+}
+
+// flightsSearchHandler searches for flights and returns them ranked by the
+// requested optimization preset (cost | time | balanced).
+func flightsSearchHandler(w http.ResponseWriter, r *http.Request) {
+	var request FlightSearchRequest
+
+	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(Response{
+			Message: fmt.Sprintf("Invalid JSON: %v", err),
+			Status:  "error",
+		})
+		return
+	}
+
+	// Validate input
+	writeErr := func(msg string) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(Response{Message: msg, Status: "error"})
+	}
+	if strings.TrimSpace(request.Origin) == "" {
+		writeErr("origin (IATA code) is required")
+		return
+	}
+	if strings.TrimSpace(request.Destination) == "" {
+		writeErr("destination (IATA code) is required")
+		return
+	}
+	if strings.TrimSpace(request.DepartDate) == "" {
+		writeErr("depart_date (YYYY-MM-DD) is required")
+		return
+	}
+	if request.Adults == 0 {
+		request.Adults = 1
+	}
+	if request.Adults < 1 || request.Adults > 9 {
+		writeErr("adults must be between 1 and 9")
+		return
+	}
+
+	validOptimizations := map[string]bool{"cost": true, "time": true, "balanced": true, "": true}
+	if !validOptimizations[strings.ToLower(request.OptimizeFor)] {
+		writeErr("optimize_for must be one of: 'cost', 'time', 'balanced'")
+		return
+	}
+
+	offers, err := duffelService.SearchFlightOffers(r.Context(), request)
+	if err != nil {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(Response{
+			Message: fmt.Sprintf("Failed to search flights: %v", err),
+			Status:  "error",
+		})
+		return
+	}
+
+	ranked := RankFlightOffers(offers, request.OptimizeFor)
+
+	// Attach a per-airline booking link to each offer (airline site when known,
+	// else airline-filtered Google Flights).
+	attachBookingURLs(ranked, request)
+
+	bestID := ""
+	if len(ranked) > 0 {
+		bestID = ranked[0].ID
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(FlightSearchResponse{
+		Offers:      ranked,
+		BestOfferID: bestID,
+		OptimizeFor: normalizeOptimizeFor(request.OptimizeFor),
+		Count:       len(ranked),
+		Status:      "success",
+	})
+}
+
 func airbnbParseHandler(w http.ResponseWriter, r *http.Request) {
 	var req AirbnbParseRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -534,6 +649,8 @@ func main() {
 	api.HandleFunc("/places/search", placesSearchHandler).Methods("GET")
 	api.HandleFunc("/places/autocomplete", placesAutocompleteHandler).Methods("GET")
 	api.HandleFunc("/places/details", placesDetailsHandler).Methods("GET")
+	api.HandleFunc("/flights/search", flightsSearchHandler).Methods("POST")
+	api.HandleFunc("/flights/airports", airportsSearchHandler).Methods("GET")
 	api.HandleFunc("/plan", planHandler).Methods("POST")
 	api.HandleFunc("/airbnb/parse", airbnbParseHandler).Methods("POST")
 	api.HandleFunc("/airbnb/debug", airbnbDebugHandler).Methods("POST")
@@ -582,6 +699,8 @@ func main() {
 	log.Printf("  GET  /api/v1/places/search      - Search Places")
 	log.Printf("  GET  /api/v1/places/autocomplete - Place Autocomplete")
 	log.Printf("  GET  /api/v1/places/details     - Place Details")
+	log.Printf("  POST /api/v1/flights/search     - Ranked Flight Search (Duffel)")
+	log.Printf("  GET  /api/v1/flights/airports   - Airport/City Autocomplete (Duffel)")
 	log.Printf("  POST /api/v1/auth/register      - Register")
 	log.Printf("  POST /api/v1/auth/login         - Login")
 	log.Printf("  POST /api/v1/auth/logout        - Logout (auth)")

--- a/src/packages/api/migrations/00014_home_airport.sql
+++ b/src/packages/api/migrations/00014_home_airport.sql
@@ -1,0 +1,5 @@
+-- +goose Up
+ALTER TABLE traveler_preferences ADD COLUMN home_airport text; -- IATA code, e.g. BOS
+
+-- +goose Down
+ALTER TABLE traveler_preferences DROP COLUMN IF EXISTS home_airport;

--- a/src/packages/api/migrations/00015_itinerary_day.sql
+++ b/src/packages/api/migrations/00015_itinerary_day.sql
@@ -1,0 +1,8 @@
+-- +goose Up
+-- The trip day this place belongs to (1-based, increasing chronologically); all
+-- places on the same day share the same number. Used to group the itinerary into
+-- "Day 1 / Day 2…" sections within each city. NULL for legacy items.
+ALTER TABLE itinerary_items ADD COLUMN day integer;
+
+-- +goose Down
+ALTER TABLE itinerary_items DROP COLUMN IF EXISTS day;

--- a/src/packages/api/plan_handler.go
+++ b/src/packages/api/plan_handler.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -141,6 +142,10 @@ func planHandler(w http.ResponseWriter, r *http.Request) {
 					"items":       map[string]any{"type": "string"},
 					"description": "Theme tags, e.g. museums, food, nightlife, nature",
 				},
+				"home_airport": map[string]any{
+					"type":        "string",
+					"description": "The traveler's home/departure airport as an IATA code, e.g. BOS — save it when they mention where they usually fly from",
+				},
 			},
 		},
 	}
@@ -175,11 +180,30 @@ func planHandler(w http.ResponseWriter, r *http.Request) {
 		},
 	}
 
+	searchFlightsTool := anthropic.ToolParam{
+		Name: "search_flights",
+		Description: anthropic.String("Search real flight options between two places for given dates and present a few good ones (ranked by overall desirability). " +
+			"Ask the traveler for their departure city/airport and travel dates first if you don't know them. " +
+			"origin/destination may be city names or IATA codes. Choose optimize_for from the traveler's budget: budget→'cost', luxury→'time', otherwise 'balanced'."),
+		InputSchema: anthropic.ToolInputSchemaParam{
+			Properties: map[string]any{
+				"origin":       map[string]any{"type": "string", "description": "Departure city or IATA code, e.g. 'Boston' or 'BOS'"},
+				"destination":  map[string]any{"type": "string", "description": "Arrival city or IATA code"},
+				"depart_date":  map[string]any{"type": "string", "description": "YYYY-MM-DD"},
+				"return_date":  map[string]any{"type": "string", "description": "Optional YYYY-MM-DD for round trips"},
+				"adults":       map[string]any{"type": "integer", "description": "Optional, defaults to 1"},
+				"optimize_for": map[string]any{"type": "string", "enum": []string{"cost", "time", "balanced"}, "description": "Ranking emphasis"},
+			},
+			Required: []string{"origin", "destination", "depart_date"},
+		},
+	}
+
 	tools := []anthropic.ToolUnionParam{
 		{OfTool: &searchTool},
 		{OfTool: &createTool},
 		{OfTool: &suggestStaysTool},
 		{OfTool: &suggestTransportTool},
+		{OfTool: &searchFlightsTool},
 	}
 	if authed {
 		tools = append(tools, anthropic.ToolUnionParam{OfTool: &savePrefsTool})
@@ -294,20 +318,22 @@ func planHandler(w http.ResponseWriter, r *http.Request) {
 
 			case "save_preferences":
 				var in struct {
-					Budget    *string  `json:"budget"`
-					Pace      *string  `json:"pace"`
-					Interests []string `json:"interests"`
+					Budget      *string  `json:"budget"`
+					Pace        *string  `json:"pace"`
+					Interests   []string `json:"interests"`
+					HomeAirport *string  `json:"home_airport"`
 				}
 				json.Unmarshal(variant.Input, &in)
 
 				budget, _ := normalizeChoice(in.Budget, allowedBudgets, "budget")
 				pace, _ := normalizeChoice(in.Pace, allowedPaces, "pace")
+				homeAirport, _ := normalizeAirportCode(in.HomeAirport)
 				var interestsArg interface{}
 				if in.Interests != nil {
 					interestsArg = normalizeInterests(in.Interests)
 				}
 				_, err := store.New(dbPool).UpsertPreferences(ctx, store.UpsertPreferencesParams{
-					UserID: uid, Budget: budget, Pace: pace, Interests: interestsArg,
+					UserID: uid, Budget: budget, Pace: pace, Interests: interestsArg, HomeAirport: homeAirport,
 				})
 				msg := "Preferences saved."
 				if err != nil {
@@ -352,6 +378,58 @@ func planHandler(w http.ResponseWriter, r *http.Request) {
 				sendSSE(w, "tool_result", map[string]string{"name": "suggest_transport"})
 				b, _ := json.Marshal(links)
 				toolResults = append(toolResults, anthropic.NewToolResultBlock(variant.ID, "Provided browse links: "+string(b), false))
+
+			case "search_flights":
+				var in struct {
+					Origin      string `json:"origin"`
+					Destination string `json:"destination"`
+					DepartDate  string `json:"depart_date"`
+					ReturnDate  string `json:"return_date"`
+					Adults      int    `json:"adults"`
+					OptimizeFor string `json:"optimize_for"`
+				}
+				json.Unmarshal(variant.Input, &in)
+
+				originIata := resolveIATA(ctx, in.Origin)
+				destIata := resolveIATA(ctx, in.Destination)
+				if originIata == "" || destIata == "" {
+					sendSSE(w, "tool_result", map[string]string{"name": "search_flights"})
+					msg := fmt.Sprintf("Could not resolve %q or %q to an airport. Ask the traveler to clarify the city or airport.", in.Origin, in.Destination)
+					toolResults = append(toolResults, anthropic.NewToolResultBlock(variant.ID, msg, true))
+					break
+				}
+
+				adults := in.Adults
+				if adults < 1 {
+					adults = 1
+				}
+				offers, err := duffelService.SearchFlightOffers(ctx, FlightSearchRequest{
+					Origin: originIata, Destination: destIata, DepartDate: in.DepartDate,
+					ReturnDate: in.ReturnDate, Adults: adults, OptimizeFor: in.OptimizeFor,
+				})
+				if err != nil {
+					sendSSE(w, "tool_result", map[string]string{"name": "search_flights"})
+					toolResults = append(toolResults, anthropic.NewToolResultBlock(variant.ID, fmt.Sprintf("Error searching flights: %v", err), true))
+					break
+				}
+
+				bestN := RankFlightOffers(offers, in.OptimizeFor)
+				if len(bestN) > 4 {
+					bestN = bestN[:4]
+				}
+				attachBookingURLs(bestN, FlightSearchRequest{
+					Origin: originIata, Destination: destIata,
+					DepartDate: in.DepartDate, ReturnDate: in.ReturnDate, Adults: adults,
+				})
+				if len(bestN) > 0 {
+					sendSSE(w, "flights", map[string]any{
+						"origin": originIata, "destination": destIata,
+						"depart_date": in.DepartDate, "optimize_for": normalizeOptimizeFor(in.OptimizeFor),
+						"offers": bestN,
+					})
+				}
+				sendSSE(w, "tool_result", map[string]string{"name": "search_flights"})
+				toolResults = append(toolResults, anthropic.NewToolResultBlock(variant.ID, summarizeOffers(originIata, destIata, bestN), false))
 			}
 		}
 
@@ -363,6 +441,63 @@ func planHandler(w http.ResponseWriter, r *http.Request) {
 		default:
 		}
 	}
+}
+
+// resolveIATA turns a city name or IATA code into an IATA code for flight
+// search. A 3-letter alphabetic input is treated as a code; anything else is
+// looked up via Duffel, preferring a city (metropolitan) code so the search
+// spans all of a city's airports. Returns "" when nothing resolves.
+func resolveIATA(ctx context.Context, s string) string {
+	s = strings.TrimSpace(s)
+	if len(s) == 3 && isAlpha(s) {
+		return strings.ToUpper(s)
+	}
+	results, err := duffelService.SearchAirports(ctx, s)
+	if err != nil || len(results) == 0 {
+		return ""
+	}
+	for _, a := range results {
+		if a.SubType == "city" && a.IataCode != "" {
+			return a.IataCode
+		}
+	}
+	return results[0].IataCode
+}
+
+func isAlpha(s string) bool {
+	for _, r := range s {
+		if !((r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z')) {
+			return false
+		}
+	}
+	return s != ""
+}
+
+// summarizeOffers builds a compact text summary of ranked offers for the model,
+// so it can describe and compare them without re-sending the full payload (which
+// already reached the UI via the "flights" event).
+func summarizeOffers(origin, dest string, offers []FlightOffer) string {
+	if len(offers) == 0 {
+		return fmt.Sprintf("No flights found from %s to %s for those dates.", origin, dest)
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "Found %d ranked flight options %s→%s (best first):\n", len(offers), origin, dest)
+	for i, o := range offers {
+		airline := "—"
+		if len(o.Airlines) > 0 {
+			airline = strings.Join(o.Airlines, "/")
+		}
+		stops := "nonstop"
+		if o.Stops == 1 {
+			stops = "1 stop"
+		} else if o.Stops > 1 {
+			stops = fmt.Sprintf("%d stops", o.Stops)
+		}
+		fmt.Fprintf(&b, "%d. %s — %s %.0f, %s, %dh%02dm (score %.1f)\n",
+			i+1, airline, o.Currency, o.Price, stops, o.DurationMin/60, o.DurationMin%60, o.Score)
+	}
+	b.WriteString("These option cards are already shown to the traveler; summarize and help them choose.")
+	return b.String()
 }
 
 // personalizedSystemPrompt appends the traveler's saved preferences to the base
@@ -382,9 +517,16 @@ func personalizedSystemPrompt(base string, p *store.TravelerPreference) string {
 	if len(p.Interests) > 0 {
 		parts = append(parts, "interests: "+strings.Join(p.Interests, ", "))
 	}
+	var homeNote string
+	if p.HomeAirport != nil && *p.HomeAirport != "" {
+		parts = append(parts, "home airport: "+*p.HomeAirport)
+		homeNote = " When searching flights, default the origin to the traveler's home airport (" +
+			*p.HomeAirport + ") and state the assumption (e.g. 'flying from " + *p.HomeAirport +
+			"'); only use a different origin if the trip clearly starts elsewhere or they say so."
+	}
 	if len(parts) == 0 {
 		return base
 	}
 	return base + "\n\nTraveler preferences — " + strings.Join(parts, "; ") +
-		". Tailor your suggestions accordingly."
+		". Tailor your suggestions accordingly." + homeNote
 }

--- a/src/packages/api/plan_handler.go
+++ b/src/packages/api/plan_handler.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"time"
 
 	anthropic "github.com/anthropics/anthropic-sdk-go"
 	"github.com/anthropics/anthropic-sdk-go/option"
@@ -106,6 +107,10 @@ func planHandler(w http.ResponseWriter, r *http.Request) {
 								"enum":        []string{"morning", "afternoon", "evening"},
 								"description": "Which part of the day to do this — spread a day's places sensibly (sights/activities across morning–afternoon, meals at their natural times).",
 							},
+							"day": map[string]any{
+								"type":        "integer",
+								"description": "The trip day this place belongs to, starting at 1 and increasing chronologically across the whole trip; all places on the same day share the same number (e.g. days 1–3 in Paris, then day 4 onward in Rome). Combined with time_of_day this makes each day read as a sequential schedule.",
+							},
 						},
 						"required": []string{"name", "latitude", "longitude"},
 					},
@@ -118,13 +123,21 @@ func planHandler(w http.ResponseWriter, r *http.Request) {
 					"type":        "string",
 					"description": "A 1–2 sentence overview of the trip to show the user (the per-day breakdown already appears in the itinerary list, so keep this brief).",
 				},
+				"start_date": map[string]any{
+					"type":        "string",
+					"description": "The trip's first day as YYYY-MM-DD (day 1). Include it whenever the traveler has given or agreed to travel dates.",
+				},
+				"end_date": map[string]any{
+					"type":        "string",
+					"description": "The trip's last day as YYYY-MM-DD. Optional — if omitted it's derived from start_date plus the number of days in the itinerary.",
+				},
 			},
 			Required: []string{"locations"},
 		},
 	}
 	savePrefsTool := anthropic.ToolParam{
 		Name:        "save_preferences",
-		Description: anthropic.String("Save what you learn about the traveler's preferences so future trips are personalized. Call this when the user reveals a budget level, trip pace, or interests. Only include fields you actually learned."),
+		Description: anthropic.String("Save what you learn about the traveler's preferences so future trips are personalized. Call this when the user reveals a budget level, trip pace, interests, or which airport they fly from. Only include fields you actually learned."),
 		InputSchema: anthropic.ToolInputSchemaParam{
 			Properties: map[string]any{
 				"budget": map[string]any{
@@ -218,7 +231,8 @@ func planHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	basePrompt := "You are an expert travel agent. Help users plan trips by searching for specific places and attractions. Use search_places to find real locations with coordinates. Search for individual places (e.g. 'Louvre Museum Paris') rather than broad queries. Include a mix of activities/attractions and dining (restaurants), guided by the traveler's interests, budget, and pace. When you call create_itinerary, tag each location with category ('attraction' or 'restaurant') and a time_of_day ('morning', 'afternoon', or 'evening') so each day reads as a sensible schedule. When you have gathered enough places for the user's trip, call create_itinerary to finalize the plan. Be conversational and helpful — ask clarifying questions if needed before searching."
+	today := time.Now()
+	basePrompt := "You are an expert travel agent. Today's date is " + today.Format("Monday, January 2, 2006") + " (" + today.Format("2006-01-02") + "). When a traveler gives a date without a year, assume the soonest upcoming occurrence on or after today — never a past year. Use dates in YYYY-MM-DD form when calling tools. Help users plan trips by searching for specific places and attractions. Use search_places to find real locations with coordinates. Search for individual places (e.g. 'Louvre Museum Paris') rather than broad queries. Include a mix of activities/attractions and dining (restaurants), guided by the traveler's interests, budget, and pace. When you call create_itinerary, tag each location with category ('attraction' or 'restaurant'), a time_of_day ('morning', 'afternoon', or 'evening'), and a day (the 1-based trip day it falls on, increasing chronologically across the whole trip) so each day reads as a sensible schedule. When you have gathered enough places for the user's trip, call create_itinerary to finalize the plan; pass start_date (and end_date) whenever the traveler has given or agreed to travel dates, with day 1 being the start date. You can also use search_flights to find real flight options — ask for the traveler's departure city/airport and dates if you don't know them, and pick optimize_for from their budget (budget→cost, luxury→time, otherwise balanced); the ranked options are shown to the traveler as cards, so summarize and help them choose. Be conversational and helpful — ask clarifying questions if needed before searching."
 
 	placesService := NewGooglePlacesService()
 	ctx := r.Context()
@@ -300,6 +314,8 @@ func planHandler(w http.ResponseWriter, r *http.Request) {
 					Locations []map[string]any `json:"locations"`
 					Title     string           `json:"title"`
 					Summary   string           `json:"summary"`
+					StartDate string           `json:"start_date"`
+					EndDate   string           `json:"end_date"`
 				}
 				json.Unmarshal(variant.Input, &in)
 
@@ -307,7 +323,7 @@ func planHandler(w http.ResponseWriter, r *http.Request) {
 				// Persist the trip only for signed-in callers; anonymous sessions
 				// stay ephemeral (no trip_id in the done event).
 				if authed {
-					if tripID, err := persistTrip(ctx, uid, req.ChatID, in.Title, in.Summary, in.Locations); err != nil {
+					if tripID, err := persistTrip(ctx, uid, req.ChatID, in.Title, in.Summary, in.StartDate, in.EndDate, in.Locations); err != nil {
 						log.Printf("failed to persist trip: %v", err)
 					} else {
 						donePayload["trip_id"] = tripID

--- a/src/packages/api/preferences_handler.go
+++ b/src/packages/api/preferences_handler.go
@@ -15,16 +15,18 @@ var allowedBudgets = map[string]bool{"budget": true, "mid": true, "luxury": true
 var allowedPaces = map[string]bool{"relaxed": true, "balanced": true, "packed": true}
 
 type PreferencesResponse struct {
-	Budget    *string  `json:"budget"`
-	Pace      *string  `json:"pace"`
-	Interests []string `json:"interests"`
+	Budget      *string  `json:"budget"`
+	Pace        *string  `json:"pace"`
+	Interests   []string `json:"interests"`
+	HomeAirport *string  `json:"home_airport"`
 }
 
 type PutPreferencesRequest struct {
 	Budget *string `json:"budget"`
 	Pace   *string `json:"pace"`
 	// Pointer distinguishes omitted (nil -> keep) from cleared ([] -> clear).
-	Interests *[]string `json:"interests"`
+	Interests   *[]string `json:"interests"`
+	HomeAirport *string   `json:"home_airport"`
 }
 
 func toPreferencesResponse(p store.TravelerPreference) PreferencesResponse {
@@ -32,7 +34,7 @@ func toPreferencesResponse(p store.TravelerPreference) PreferencesResponse {
 	if interests == nil {
 		interests = []string{}
 	}
-	return PreferencesResponse{Budget: p.Budget, Pace: p.Pace, Interests: interests}
+	return PreferencesResponse{Budget: p.Budget, Pace: p.Pace, Interests: interests, HomeAirport: p.HomeAirport}
 }
 
 func getPreferencesHandler(w http.ResponseWriter, r *http.Request) {
@@ -77,6 +79,12 @@ func putPreferencesHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	homeAirport, err := normalizeAirportCode(req.HomeAirport)
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
 	// nil interests -> leave unchanged; provided (incl. empty) -> set/clear.
 	var interestsArg interface{}
 	if req.Interests != nil {
@@ -84,10 +92,11 @@ func putPreferencesHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	p, err := store.New(dbPool).UpsertPreferences(r.Context(), store.UpsertPreferencesParams{
-		UserID:    user.ID,
-		Budget:    budget,
-		Pace:      pace,
-		Interests: interestsArg,
+		UserID:      user.ID,
+		Budget:      budget,
+		Pace:        pace,
+		Interests:   interestsArg,
+		HomeAirport: homeAirport,
 	})
 	if err != nil {
 		writeJSONError(w, http.StatusInternalServerError, "could not save preferences")
@@ -108,6 +117,22 @@ func normalizeChoice(v *string, allowed map[string]bool, field string) (*string,
 	}
 	if !allowed[s] {
 		return nil, errors.New(field + " is not a recognized value")
+	}
+	return &s, nil
+}
+
+// normalizeAirportCode validates and upper-cases a home airport. Empty/nil ->
+// nil (omit, keep existing); anything other than a 3-letter IATA code -> error.
+func normalizeAirportCode(v *string) (*string, error) {
+	if v == nil {
+		return nil, nil
+	}
+	s := strings.ToUpper(strings.TrimSpace(*v))
+	if s == "" {
+		return nil, nil
+	}
+	if len(s) != 3 || !isAlpha(s) {
+		return nil, errors.New("home_airport must be a 3-letter IATA code")
 	}
 	return &s, nil
 }

--- a/src/packages/api/query/preferences.sql
+++ b/src/packages/api/query/preferences.sql
@@ -2,15 +2,17 @@
 SELECT * FROM traveler_preferences WHERE user_id = $1;
 
 -- name: UpsertPreferences :one
-INSERT INTO traveler_preferences (user_id, budget, pace, interests)
+INSERT INTO traveler_preferences (user_id, budget, pace, interests, home_airport)
 VALUES (
     sqlc.arg('user_id'),
     sqlc.narg('budget'),
     sqlc.narg('pace'),
-    COALESCE(sqlc.narg('interests'), '{}'::text[])
+    COALESCE(sqlc.narg('interests'), '{}'::text[]),
+    sqlc.narg('home_airport')
 )
 ON CONFLICT (user_id) DO UPDATE SET
-    budget    = COALESCE(sqlc.narg('budget'), traveler_preferences.budget),
-    pace      = COALESCE(sqlc.narg('pace'), traveler_preferences.pace),
-    interests = COALESCE(sqlc.narg('interests'), traveler_preferences.interests)
+    budget       = COALESCE(sqlc.narg('budget'), traveler_preferences.budget),
+    pace         = COALESCE(sqlc.narg('pace'), traveler_preferences.pace),
+    interests    = COALESCE(sqlc.narg('interests'), traveler_preferences.interests),
+    home_airport = COALESCE(sqlc.narg('home_airport'), traveler_preferences.home_airport)
 RETURNING *;

--- a/src/packages/api/query/trips.sql
+++ b/src/packages/api/query/trips.sql
@@ -4,8 +4,8 @@ VALUES ($1, $2, $3, $4, $5)
 RETURNING *;
 
 -- name: CreateItineraryItem :one
-INSERT INTO itinerary_items (trip_id, position, name, place_id, address, latitude, longitude, category, time_of_day, city, day_trip_from)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+INSERT INTO itinerary_items (trip_id, position, name, place_id, address, latitude, longitude, category, time_of_day, city, day_trip_from, day)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
 RETURNING *;
 
 -- name: ListTripsByOwner :many

--- a/src/packages/api/store/models.go
+++ b/src/packages/api/store/models.go
@@ -59,6 +59,7 @@ type ItineraryItem struct {
 	TimeOfDay   *string   `json:"time_of_day"`
 	City        *string   `json:"city"`
 	DayTripFrom *string   `json:"day_trip_from"`
+	Day         *int32    `json:"day"`
 }
 
 type Session struct {

--- a/src/packages/api/store/models.go
+++ b/src/packages/api/store/models.go
@@ -69,12 +69,13 @@ type Session struct {
 }
 
 type TravelerPreference struct {
-	UserID    uuid.UUID `json:"user_id"`
-	Budget    *string   `json:"budget"`
-	Pace      *string   `json:"pace"`
-	Interests []string  `json:"interests"`
-	CreatedAt time.Time `json:"created_at"`
-	UpdatedAt time.Time `json:"updated_at"`
+	UserID      uuid.UUID `json:"user_id"`
+	Budget      *string   `json:"budget"`
+	Pace        *string   `json:"pace"`
+	Interests   []string  `json:"interests"`
+	CreatedAt   time.Time `json:"created_at"`
+	UpdatedAt   time.Time `json:"updated_at"`
+	HomeAirport *string   `json:"home_airport"`
 }
 
 type Trip struct {

--- a/src/packages/api/store/preferences.sql.go
+++ b/src/packages/api/store/preferences.sql.go
@@ -12,7 +12,7 @@ import (
 )
 
 const getPreferences = `-- name: GetPreferences :one
-SELECT user_id, budget, pace, interests, created_at, updated_at FROM traveler_preferences WHERE user_id = $1
+SELECT user_id, budget, pace, interests, created_at, updated_at, home_airport FROM traveler_preferences WHERE user_id = $1
 `
 
 func (q *Queries) GetPreferences(ctx context.Context, userID uuid.UUID) (TravelerPreference, error) {
@@ -25,30 +25,34 @@ func (q *Queries) GetPreferences(ctx context.Context, userID uuid.UUID) (Travele
 		&i.Interests,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.HomeAirport,
 	)
 	return i, err
 }
 
 const upsertPreferences = `-- name: UpsertPreferences :one
-INSERT INTO traveler_preferences (user_id, budget, pace, interests)
+INSERT INTO traveler_preferences (user_id, budget, pace, interests, home_airport)
 VALUES (
     $1,
     $2,
     $3,
-    COALESCE($4, '{}'::text[])
+    COALESCE($4, '{}'::text[]),
+    $5
 )
 ON CONFLICT (user_id) DO UPDATE SET
-    budget    = COALESCE($2, traveler_preferences.budget),
-    pace      = COALESCE($3, traveler_preferences.pace),
-    interests = COALESCE($4, traveler_preferences.interests)
-RETURNING user_id, budget, pace, interests, created_at, updated_at
+    budget       = COALESCE($2, traveler_preferences.budget),
+    pace         = COALESCE($3, traveler_preferences.pace),
+    interests    = COALESCE($4, traveler_preferences.interests),
+    home_airport = COALESCE($5, traveler_preferences.home_airport)
+RETURNING user_id, budget, pace, interests, created_at, updated_at, home_airport
 `
 
 type UpsertPreferencesParams struct {
-	UserID    uuid.UUID   `json:"user_id"`
-	Budget    *string     `json:"budget"`
-	Pace      *string     `json:"pace"`
-	Interests interface{} `json:"interests"`
+	UserID      uuid.UUID   `json:"user_id"`
+	Budget      *string     `json:"budget"`
+	Pace        *string     `json:"pace"`
+	Interests   interface{} `json:"interests"`
+	HomeAirport *string     `json:"home_airport"`
 }
 
 func (q *Queries) UpsertPreferences(ctx context.Context, arg UpsertPreferencesParams) (TravelerPreference, error) {
@@ -57,6 +61,7 @@ func (q *Queries) UpsertPreferences(ctx context.Context, arg UpsertPreferencesPa
 		arg.Budget,
 		arg.Pace,
 		arg.Interests,
+		arg.HomeAirport,
 	)
 	var i TravelerPreference
 	err := row.Scan(
@@ -66,6 +71,7 @@ func (q *Queries) UpsertPreferences(ctx context.Context, arg UpsertPreferencesPa
 		&i.Interests,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.HomeAirport,
 	)
 	return i, err
 }

--- a/src/packages/api/store/trips.sql.go
+++ b/src/packages/api/store/trips.sql.go
@@ -14,9 +14,9 @@ import (
 )
 
 const createItineraryItem = `-- name: CreateItineraryItem :one
-INSERT INTO itinerary_items (trip_id, position, name, place_id, address, latitude, longitude, category, time_of_day, city, day_trip_from)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
-RETURNING id, trip_id, position, name, place_id, address, latitude, longitude, created_at, category, time_of_day, city, day_trip_from
+INSERT INTO itinerary_items (trip_id, position, name, place_id, address, latitude, longitude, category, time_of_day, city, day_trip_from, day)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+RETURNING id, trip_id, position, name, place_id, address, latitude, longitude, created_at, category, time_of_day, city, day_trip_from, day
 `
 
 type CreateItineraryItemParams struct {
@@ -31,6 +31,7 @@ type CreateItineraryItemParams struct {
 	TimeOfDay   *string   `json:"time_of_day"`
 	City        *string   `json:"city"`
 	DayTripFrom *string   `json:"day_trip_from"`
+	Day         *int32    `json:"day"`
 }
 
 func (q *Queries) CreateItineraryItem(ctx context.Context, arg CreateItineraryItemParams) (ItineraryItem, error) {
@@ -46,6 +47,7 @@ func (q *Queries) CreateItineraryItem(ctx context.Context, arg CreateItineraryIt
 		arg.TimeOfDay,
 		arg.City,
 		arg.DayTripFrom,
+		arg.Day,
 	)
 	var i ItineraryItem
 	err := row.Scan(
@@ -62,6 +64,7 @@ func (q *Queries) CreateItineraryItem(ctx context.Context, arg CreateItineraryIt
 		&i.TimeOfDay,
 		&i.City,
 		&i.DayTripFrom,
+		&i.Day,
 	)
 	return i, err
 }
@@ -132,7 +135,7 @@ func (q *Queries) DeleteTrip(ctx context.Context, arg DeleteTripParams) (int64, 
 }
 
 const getItineraryItemsByTrip = `-- name: GetItineraryItemsByTrip :many
-SELECT id, trip_id, position, name, place_id, address, latitude, longitude, created_at, category, time_of_day, city, day_trip_from FROM itinerary_items WHERE trip_id = $1 ORDER BY position ASC
+SELECT id, trip_id, position, name, place_id, address, latitude, longitude, created_at, category, time_of_day, city, day_trip_from, day FROM itinerary_items WHERE trip_id = $1 ORDER BY position ASC
 `
 
 func (q *Queries) GetItineraryItemsByTrip(ctx context.Context, tripID uuid.UUID) ([]ItineraryItem, error) {
@@ -158,6 +161,7 @@ func (q *Queries) GetItineraryItemsByTrip(ctx context.Context, tripID uuid.UUID)
 			&i.TimeOfDay,
 			&i.City,
 			&i.DayTripFrom,
+			&i.Day,
 		); err != nil {
 			return nil, err
 		}

--- a/src/packages/api/trip_handler.go
+++ b/src/packages/api/trip_handler.go
@@ -32,6 +32,7 @@ type ItineraryItemResponse struct {
 	TimeOfDay   *string `json:"time_of_day,omitempty"`
 	City        *string `json:"city,omitempty"`
 	DayTripFrom *string `json:"day_trip_from,omitempty"`
+	Day         *int    `json:"day,omitempty"`
 }
 
 var allowedItemCategories = map[string]bool{"attraction": true, "restaurant": true}
@@ -75,6 +76,14 @@ func dateToPtr(d pgtype.Date) *string {
 	return &s
 }
 
+func int32PtrToIntPtr(p *int32) *int {
+	if p == nil {
+		return nil
+	}
+	v := int(*p)
+	return &v
+}
+
 func toTripResponse(t store.Trip, items []store.ItineraryItem, accommodations []store.Accommodation, segments []store.TripSegment, bookingTodos []store.BookingTodo) TripResponse {
 	resp := TripResponse{
 		ID:        t.ID.String(),
@@ -100,6 +109,7 @@ func toTripResponse(t store.Trip, items []store.ItineraryItem, accommodations []
 			TimeOfDay:   it.TimeOfDay,
 			City:        it.City,
 			DayTripFrom: it.DayTripFrom,
+			Day:         int32PtrToIntPtr(it.Day),
 		})
 	}
 	for _, a := range accommodations {
@@ -118,7 +128,7 @@ func toTripResponse(t store.Trip, items []store.ItineraryItem, accommodations []
 // transaction. Called from the agent's create_itinerary step for signed-in users.
 // chatID stamps the trip with its conversation so My Trips can collapse repeated
 // refinements to the latest version; an empty chatID is stored as NULL.
-func persistTrip(ctx context.Context, userID uuid.UUID, chatID, title, summary string, locations []map[string]any) (string, error) {
+func persistTrip(ctx context.Context, userID uuid.UUID, chatID, title, summary, startDate, endDate string, locations []map[string]any) (string, error) {
 	tx, err := dbPool.Begin(ctx)
 	if err != nil {
 		return "", err
@@ -156,11 +166,13 @@ func persistTrip(ctx context.Context, userID uuid.UUID, chatID, title, summary s
 		return "", err
 	}
 
+	maxDay := 1
 	for i, loc := range locations {
 		name, _ := loc["name"].(string)
 		lat, _ := loc["latitude"].(float64)
 		lng, _ := loc["longitude"].(float64)
 		var placeID, address, city, dayTripFrom, category, timeOfDay *string
+		var day *int32
 		if s, ok := loc["place_id"].(string); ok && s != "" {
 			placeID = &s
 		}
@@ -191,6 +203,14 @@ func persistTrip(ctx context.Context, userID uuid.UUID, chatID, title, summary s
 				timeOfDay = &t
 			}
 		}
+		// JSON numbers decode as float64; keep only sensible 1-based day numbers.
+		if v, ok := loc["day"].(float64); ok && v >= 1 {
+			d := int32(v)
+			day = &d
+			if int(d) > maxDay {
+				maxDay = int(d)
+			}
+		}
 		if _, err := q.CreateItineraryItem(ctx, store.CreateItineraryItemParams{
 			TripID:      trip.ID,
 			Position:    int32(i),
@@ -203,8 +223,32 @@ func persistTrip(ctx context.Context, userID uuid.UUID, chatID, title, summary s
 			TimeOfDay:   timeOfDay,
 			City:        city,
 			DayTripFrom: dayTripFrom,
+			Day:         day,
 		}); err != nil {
 			return "", err
+		}
+	}
+
+	// Save the trip's date span when the agent supplied a start date. A missing
+	// end date is derived from the start plus the itinerary's day span.
+	if start := strings.TrimSpace(startDate); start != "" {
+		end := strings.TrimSpace(endDate)
+		if end == "" {
+			if t, perr := time.Parse("2006-01-02", start); perr == nil {
+				end = t.AddDate(0, 0, maxDay-1).Format("2006-01-02")
+			}
+		}
+		startD, serr := parseDateParam(&start)
+		endD, eerr := parseDateParam(&end)
+		if serr == nil && eerr == nil {
+			if _, err := q.UpdateTrip(ctx, store.UpdateTripParams{
+				ID:        trip.ID,
+				UserID:    userID,
+				StartDate: startD,
+				EndDate:   endD,
+			}); err != nil {
+				return "", err
+			}
 		}
 	}
 

--- a/src/packages/flutter-app/lib/models/airport.dart
+++ b/src/packages/flutter-app/lib/models/airport.dart
@@ -1,0 +1,34 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'airport.g.dart';
+
+@JsonSerializable()
+class Airport {
+  @JsonKey(name: 'iata_code')
+  final String iataCode;
+  final String name;
+  final String city;
+  final String country;
+  @JsonKey(name: 'sub_type')
+  final String subType;
+
+  const Airport({
+    required this.iataCode,
+    required this.name,
+    this.city = '',
+    this.country = '',
+    this.subType = '',
+  });
+
+  /// "Paris (CDG)" style label for autocomplete rows and field display. Falls
+  /// back to the bare code when no place name is known (e.g. a placeholder built
+  /// from just a saved IATA code).
+  String get label {
+    final place = city.isNotEmpty ? city : name;
+    if (place.isEmpty || place == iataCode) return iataCode;
+    return '$place ($iataCode)';
+  }
+
+  factory Airport.fromJson(Map<String, dynamic> json) => _$AirportFromJson(json);
+  Map<String, dynamic> toJson() => _$AirportToJson(this);
+}

--- a/src/packages/flutter-app/lib/models/airport.g.dart
+++ b/src/packages/flutter-app/lib/models/airport.g.dart
@@ -1,0 +1,23 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'airport.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+Airport _$AirportFromJson(Map<String, dynamic> json) => Airport(
+      iataCode: json['iata_code'] as String,
+      name: json['name'] as String,
+      city: json['city'] as String? ?? '',
+      country: json['country'] as String? ?? '',
+      subType: json['sub_type'] as String? ?? '',
+    );
+
+Map<String, dynamic> _$AirportToJson(Airport instance) => <String, dynamic>{
+      'iata_code': instance.iataCode,
+      'name': instance.name,
+      'city': instance.city,
+      'country': instance.country,
+      'sub_type': instance.subType,
+    };

--- a/src/packages/flutter-app/lib/models/flight_leg.dart
+++ b/src/packages/flutter-app/lib/models/flight_leg.dart
@@ -1,0 +1,29 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'flight_leg.g.dart';
+
+@JsonSerializable()
+class FlightLeg {
+  final String from;
+  final String to;
+  final String carrier;
+  @JsonKey(name: 'flight_number')
+  final String flightNumber;
+  @JsonKey(name: 'depart_time')
+  final String departTime;
+  @JsonKey(name: 'arrive_time')
+  final String arriveTime;
+
+  const FlightLeg({
+    required this.from,
+    required this.to,
+    required this.carrier,
+    required this.flightNumber,
+    required this.departTime,
+    required this.arriveTime,
+  });
+
+  factory FlightLeg.fromJson(Map<String, dynamic> json) =>
+      _$FlightLegFromJson(json);
+  Map<String, dynamic> toJson() => _$FlightLegToJson(this);
+}

--- a/src/packages/flutter-app/lib/models/flight_leg.g.dart
+++ b/src/packages/flutter-app/lib/models/flight_leg.g.dart
@@ -1,0 +1,25 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'flight_leg.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+FlightLeg _$FlightLegFromJson(Map<String, dynamic> json) => FlightLeg(
+      from: json['from'] as String,
+      to: json['to'] as String,
+      carrier: json['carrier'] as String,
+      flightNumber: json['flight_number'] as String,
+      departTime: json['depart_time'] as String,
+      arriveTime: json['arrive_time'] as String,
+    );
+
+Map<String, dynamic> _$FlightLegToJson(FlightLeg instance) => <String, dynamic>{
+      'from': instance.from,
+      'to': instance.to,
+      'carrier': instance.carrier,
+      'flight_number': instance.flightNumber,
+      'depart_time': instance.departTime,
+      'arrive_time': instance.arriveTime,
+    };

--- a/src/packages/flutter-app/lib/models/flight_offer.dart
+++ b/src/packages/flutter-app/lib/models/flight_offer.dart
@@ -1,0 +1,97 @@
+import 'package:json_annotation/json_annotation.dart';
+import 'flight_leg.dart';
+
+part 'flight_offer.g.dart';
+
+@JsonSerializable(explicitToJson: true)
+class FlightOffer {
+  final String id;
+  final double price;
+  final String currency;
+  final int stops;
+  @JsonKey(name: 'duration_minutes')
+  final int durationMinutes;
+  @JsonKey(defaultValue: <String>[])
+  final List<String> airlines;
+  @JsonKey(name: 'airline_code')
+  final String? airlineCode;
+  @JsonKey(name: 'airline_logo_url')
+  final String? airlineLogoUrl;
+  @JsonKey(name: 'depart_time')
+  final String departTime;
+  @JsonKey(name: 'arrive_time')
+  final String arriveTime;
+  @JsonKey(defaultValue: <FlightLeg>[])
+  final List<FlightLeg> segments;
+  @JsonKey(name: 'booking_url')
+  final String? bookingUrl;
+
+  final double score;
+  @JsonKey(name: 'price_score')
+  final double priceScore;
+  @JsonKey(name: 'duration_score')
+  final double durationScore;
+  @JsonKey(name: 'stops_score')
+  final double stopsScore;
+
+  const FlightOffer({
+    required this.id,
+    required this.price,
+    required this.currency,
+    required this.stops,
+    required this.durationMinutes,
+    required this.airlines,
+    this.airlineCode,
+    this.airlineLogoUrl,
+    required this.departTime,
+    required this.arriveTime,
+    required this.segments,
+    this.bookingUrl,
+    this.score = 0,
+    this.priceScore = 0,
+    this.durationScore = 0,
+    this.stopsScore = 0,
+  });
+
+  /// "5h 30m" style duration label.
+  String get durationLabel {
+    final h = durationMinutes ~/ 60;
+    final m = durationMinutes % 60;
+    if (h == 0) return '${m}m';
+    if (m == 0) return '${h}h';
+    return '${h}h ${m}m';
+  }
+
+  String get stopsLabel => switch (stops) {
+        0 => 'Nonstop',
+        1 => '1 stop',
+        _ => '$stops stops',
+      };
+
+  /// Departure clock time, e.g. "10:50". Empty if unparseable.
+  String get departClock => _clock(departTime);
+
+  /// Arrival clock time, e.g. "00:47". Empty if unparseable.
+  String get arriveClock => _clock(arriveTime);
+
+  /// How many calendar days after departure the flight arrives (0 = same day,
+  /// 1 = next day) — for the "+1" overnight indicator.
+  int get arrivalDayOffset {
+    final d = DateTime.tryParse(departTime);
+    final a = DateTime.tryParse(arriveTime);
+    if (d == null || a == null) return 0;
+    return DateTime(a.year, a.month, a.day)
+        .difference(DateTime(d.year, d.month, d.day))
+        .inDays;
+  }
+
+  static String _clock(String iso) {
+    final t = DateTime.tryParse(iso);
+    if (t == null) return '';
+    return '${t.hour.toString().padLeft(2, '0')}:${t.minute.toString().padLeft(2, '0')}';
+  }
+
+  factory FlightOffer.fromJson(Map<String, dynamic> json) =>
+      _$FlightOfferFromJson(json);
+  Map<String, dynamic> toJson() => _$FlightOfferToJson(this);
+}

--- a/src/packages/flutter-app/lib/models/flight_offer.g.dart
+++ b/src/packages/flutter-app/lib/models/flight_offer.g.dart
@@ -1,0 +1,52 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'flight_offer.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+FlightOffer _$FlightOfferFromJson(Map<String, dynamic> json) => FlightOffer(
+      id: json['id'] as String,
+      price: (json['price'] as num).toDouble(),
+      currency: json['currency'] as String,
+      stops: (json['stops'] as num).toInt(),
+      durationMinutes: (json['duration_minutes'] as num).toInt(),
+      airlines: (json['airlines'] as List<dynamic>?)
+              ?.map((e) => e as String)
+              .toList() ??
+          [],
+      airlineCode: json['airline_code'] as String?,
+      airlineLogoUrl: json['airline_logo_url'] as String?,
+      departTime: json['depart_time'] as String,
+      arriveTime: json['arrive_time'] as String,
+      segments: (json['segments'] as List<dynamic>?)
+              ?.map((e) => FlightLeg.fromJson(e as Map<String, dynamic>))
+              .toList() ??
+          [],
+      bookingUrl: json['booking_url'] as String?,
+      score: (json['score'] as num?)?.toDouble() ?? 0,
+      priceScore: (json['price_score'] as num?)?.toDouble() ?? 0,
+      durationScore: (json['duration_score'] as num?)?.toDouble() ?? 0,
+      stopsScore: (json['stops_score'] as num?)?.toDouble() ?? 0,
+    );
+
+Map<String, dynamic> _$FlightOfferToJson(FlightOffer instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'price': instance.price,
+      'currency': instance.currency,
+      'stops': instance.stops,
+      'duration_minutes': instance.durationMinutes,
+      'airlines': instance.airlines,
+      'airline_code': instance.airlineCode,
+      'airline_logo_url': instance.airlineLogoUrl,
+      'depart_time': instance.departTime,
+      'arrive_time': instance.arriveTime,
+      'segments': instance.segments.map((e) => e.toJson()).toList(),
+      'booking_url': instance.bookingUrl,
+      'score': instance.score,
+      'price_score': instance.priceScore,
+      'duration_score': instance.durationScore,
+      'stops_score': instance.stopsScore,
+    };

--- a/src/packages/flutter-app/lib/models/flight_search_request.dart
+++ b/src/packages/flutter-app/lib/models/flight_search_request.dart
@@ -1,0 +1,29 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'flight_search_request.g.dart';
+
+@JsonSerializable()
+class FlightSearchRequest {
+  final String origin; // IATA code
+  final String destination; // IATA code
+  @JsonKey(name: 'depart_date')
+  final String departDate; // YYYY-MM-DD
+  @JsonKey(name: 'return_date', includeIfNull: false)
+  final String? returnDate;
+  final int adults;
+  @JsonKey(name: 'optimize_for')
+  final String optimizeFor; // cost | time | balanced
+
+  const FlightSearchRequest({
+    required this.origin,
+    required this.destination,
+    required this.departDate,
+    this.returnDate,
+    this.adults = 1,
+    this.optimizeFor = 'balanced',
+  });
+
+  factory FlightSearchRequest.fromJson(Map<String, dynamic> json) =>
+      _$FlightSearchRequestFromJson(json);
+  Map<String, dynamic> toJson() => _$FlightSearchRequestToJson(this);
+}

--- a/src/packages/flutter-app/lib/models/flight_search_request.g.dart
+++ b/src/packages/flutter-app/lib/models/flight_search_request.g.dart
@@ -1,0 +1,36 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'flight_search_request.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+FlightSearchRequest _$FlightSearchRequestFromJson(Map<String, dynamic> json) =>
+    FlightSearchRequest(
+      origin: json['origin'] as String,
+      destination: json['destination'] as String,
+      departDate: json['depart_date'] as String,
+      returnDate: json['return_date'] as String?,
+      adults: (json['adults'] as num?)?.toInt() ?? 1,
+      optimizeFor: json['optimize_for'] as String? ?? 'balanced',
+    );
+
+Map<String, dynamic> _$FlightSearchRequestToJson(FlightSearchRequest instance) {
+  final val = <String, dynamic>{
+    'origin': instance.origin,
+    'destination': instance.destination,
+    'depart_date': instance.departDate,
+  };
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('return_date', instance.returnDate);
+  val['adults'] = instance.adults;
+  val['optimize_for'] = instance.optimizeFor;
+  return val;
+}

--- a/src/packages/flutter-app/lib/models/flight_search_response.dart
+++ b/src/packages/flutter-app/lib/models/flight_search_response.dart
@@ -1,0 +1,28 @@
+import 'package:json_annotation/json_annotation.dart';
+import 'flight_offer.dart';
+
+part 'flight_search_response.g.dart';
+
+@JsonSerializable(explicitToJson: true)
+class FlightSearchResponse {
+  @JsonKey(defaultValue: <FlightOffer>[])
+  final List<FlightOffer> offers;
+  @JsonKey(name: 'best_offer_id')
+  final String? bestOfferId;
+  @JsonKey(name: 'optimize_for')
+  final String optimizeFor;
+  final int count;
+  final String status;
+
+  const FlightSearchResponse({
+    required this.offers,
+    this.bestOfferId,
+    required this.optimizeFor,
+    required this.count,
+    required this.status,
+  });
+
+  factory FlightSearchResponse.fromJson(Map<String, dynamic> json) =>
+      _$FlightSearchResponseFromJson(json);
+  Map<String, dynamic> toJson() => _$FlightSearchResponseToJson(this);
+}

--- a/src/packages/flutter-app/lib/models/flight_search_response.g.dart
+++ b/src/packages/flutter-app/lib/models/flight_search_response.g.dart
@@ -1,0 +1,30 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'flight_search_response.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+FlightSearchResponse _$FlightSearchResponseFromJson(
+        Map<String, dynamic> json) =>
+    FlightSearchResponse(
+      offers: (json['offers'] as List<dynamic>?)
+              ?.map((e) => FlightOffer.fromJson(e as Map<String, dynamic>))
+              .toList() ??
+          [],
+      bestOfferId: json['best_offer_id'] as String?,
+      optimizeFor: json['optimize_for'] as String,
+      count: (json['count'] as num).toInt(),
+      status: json['status'] as String,
+    );
+
+Map<String, dynamic> _$FlightSearchResponseToJson(
+        FlightSearchResponse instance) =>
+    <String, dynamic>{
+      'offers': instance.offers.map((e) => e.toJson()).toList(),
+      'best_offer_id': instance.bestOfferId,
+      'optimize_for': instance.optimizeFor,
+      'count': instance.count,
+      'status': instance.status,
+    };

--- a/src/packages/flutter-app/lib/models/itinerary_item.dart
+++ b/src/packages/flutter-app/lib/models/itinerary_item.dart
@@ -18,6 +18,7 @@ class ItineraryItem {
   final String? city;
   @JsonKey(name: 'day_trip_from')
   final String? dayTripFrom;
+  final int? day;
 
   const ItineraryItem({
     required this.id,
@@ -31,6 +32,7 @@ class ItineraryItem {
     this.timeOfDay,
     this.city,
     this.dayTripFrom,
+    this.day,
   });
 
   factory ItineraryItem.fromJson(Map<String, dynamic> json) =>

--- a/src/packages/flutter-app/lib/models/itinerary_item.g.dart
+++ b/src/packages/flutter-app/lib/models/itinerary_item.g.dart
@@ -19,6 +19,7 @@ ItineraryItem _$ItineraryItemFromJson(Map<String, dynamic> json) =>
       timeOfDay: json['time_of_day'] as String?,
       city: json['city'] as String?,
       dayTripFrom: json['day_trip_from'] as String?,
+      day: (json['day'] as num?)?.toInt(),
     );
 
 Map<String, dynamic> _$ItineraryItemToJson(ItineraryItem instance) =>
@@ -34,4 +35,5 @@ Map<String, dynamic> _$ItineraryItemToJson(ItineraryItem instance) =>
       'time_of_day': instance.timeOfDay,
       'city': instance.city,
       'day_trip_from': instance.dayTripFrom,
+      'day': instance.day,
     };

--- a/src/packages/flutter-app/lib/models/traveler_preferences.dart
+++ b/src/packages/flutter-app/lib/models/traveler_preferences.dart
@@ -7,8 +7,15 @@ class TravelerPreferences {
   final String? budget;
   final String? pace;
   final List<String> interests;
+  @JsonKey(name: 'home_airport')
+  final String? homeAirport;
 
-  const TravelerPreferences({this.budget, this.pace, this.interests = const []});
+  const TravelerPreferences({
+    this.budget,
+    this.pace,
+    this.interests = const [],
+    this.homeAirport,
+  });
 
   factory TravelerPreferences.fromJson(Map<String, dynamic> json) =>
       _$TravelerPreferencesFromJson(json);

--- a/src/packages/flutter-app/lib/models/traveler_preferences.g.dart
+++ b/src/packages/flutter-app/lib/models/traveler_preferences.g.dart
@@ -14,6 +14,7 @@ TravelerPreferences _$TravelerPreferencesFromJson(Map<String, dynamic> json) =>
               ?.map((e) => e as String)
               .toList() ??
           const [],
+      homeAirport: json['home_airport'] as String?,
     );
 
 Map<String, dynamic> _$TravelerPreferencesToJson(
@@ -22,4 +23,5 @@ Map<String, dynamic> _$TravelerPreferencesToJson(
       'budget': instance.budget,
       'pace': instance.pace,
       'interests': instance.interests,
+      'home_airport': instance.homeAirport,
     };

--- a/src/packages/flutter-app/lib/providers/flights_provider.dart
+++ b/src/packages/flutter-app/lib/providers/flights_provider.dart
@@ -1,0 +1,92 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../models/airport.dart';
+import '../models/flight_offer.dart';
+import '../models/flight_search_request.dart';
+import '../services/flights_api_service.dart';
+import 'api_client_provider.dart';
+
+final flightsApiServiceProvider = Provider<FlightsApiService>((ref) {
+  return FlightsApiService(ref.watch(apiClientProvider));
+});
+
+/// Airport/city autocomplete for origin & destination fields.
+final airportSearchProvider =
+    FutureProvider.family<List<Airport>, String>((ref, query) async {
+  if (query.trim().length < 2) return [];
+  final service = ref.watch(flightsApiServiceProvider);
+  return service.searchAirports(query.trim());
+});
+
+class FlightsState {
+  final List<FlightOffer> offers;
+  final String? bestOfferId;
+  final String optimizeFor;
+  final bool loading;
+  final String? error;
+  final bool hasSearched;
+
+  const FlightsState({
+    this.offers = const [],
+    this.bestOfferId,
+    this.optimizeFor = 'balanced',
+    this.loading = false,
+    this.error,
+    this.hasSearched = false,
+  });
+
+  FlightsState copyWith({
+    List<FlightOffer>? offers,
+    Object? bestOfferId = _sentinel,
+    String? optimizeFor,
+    bool? loading,
+    Object? error = _sentinel,
+    bool? hasSearched,
+  }) {
+    return FlightsState(
+      offers: offers ?? this.offers,
+      bestOfferId:
+          bestOfferId == _sentinel ? this.bestOfferId : bestOfferId as String?,
+      optimizeFor: optimizeFor ?? this.optimizeFor,
+      loading: loading ?? this.loading,
+      error: error == _sentinel ? this.error : error as String?,
+      hasSearched: hasSearched ?? this.hasSearched,
+    );
+  }
+}
+
+const _sentinel = Object();
+
+class FlightsNotifier extends StateNotifier<FlightsState> {
+  final FlightsApiService _service;
+
+  FlightsNotifier(this._service) : super(const FlightsState());
+
+  Future<void> search(FlightSearchRequest request) async {
+    state = state.copyWith(
+      loading: true,
+      error: null,
+      optimizeFor: request.optimizeFor,
+      hasSearched: true,
+    );
+    try {
+      final res = await _service.searchFlights(request);
+      state = state.copyWith(
+        offers: res.offers,
+        bestOfferId: res.bestOfferId,
+        optimizeFor: res.optimizeFor,
+        loading: false,
+      );
+    } catch (e) {
+      state = state.copyWith(loading: false, error: e.toString());
+    }
+  }
+
+  void reset() {
+    state = const FlightsState();
+  }
+}
+
+final flightsProvider =
+    StateNotifierProvider<FlightsNotifier, FlightsState>((ref) {
+  return FlightsNotifier(ref.watch(flightsApiServiceProvider));
+});

--- a/src/packages/flutter-app/lib/providers/plan_provider.dart
+++ b/src/packages/flutter-app/lib/providers/plan_provider.dart
@@ -2,6 +2,7 @@ import 'dart:math';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../models/plan_message.dart';
 import '../models/location.dart';
+import '../models/flight_offer.dart';
 import '../services/api_client.dart';
 import '../services/plan_service.dart';
 import 'api_client_provider.dart';
@@ -14,6 +15,8 @@ class PlanState {
   final List<Map<String, dynamic>>? completedLocations;
   final String? completedSummary;
   final String? savedTripId;
+  final List<FlightOffer>? flightOffers;
+  final String? flightRouteLabel;
   final String? error;
 
   const PlanState({
@@ -24,6 +27,8 @@ class PlanState {
     this.completedLocations,
     this.completedSummary,
     this.savedTripId,
+    this.flightOffers,
+    this.flightRouteLabel,
     this.error,
   });
 
@@ -35,6 +40,8 @@ class PlanState {
     Object? completedLocations = _sentinel,
     Object? completedSummary = _sentinel,
     Object? savedTripId = _sentinel,
+    Object? flightOffers = _sentinel,
+    Object? flightRouteLabel = _sentinel,
     Object? error = _sentinel,
   }) {
     return PlanState(
@@ -47,6 +54,8 @@ class PlanState {
           : completedLocations as List<Map<String, dynamic>>?,
       completedSummary: completedSummary == _sentinel ? this.completedSummary : completedSummary as String?,
       savedTripId: savedTripId == _sentinel ? this.savedTripId : savedTripId as String?,
+      flightOffers: flightOffers == _sentinel ? this.flightOffers : flightOffers as List<FlightOffer>?,
+      flightRouteLabel: flightRouteLabel == _sentinel ? this.flightRouteLabel : flightRouteLabel as String?,
       error: error == _sentinel ? this.error : error as String?,
     );
   }
@@ -103,6 +112,8 @@ class PlanNotifier extends StateNotifier<PlanState> {
       isStreaming: true,
       streamingText: '',
       activeTools: [],
+      flightOffers: null,
+      flightRouteLabel: null,
       error: null,
     );
 
@@ -136,6 +147,18 @@ class PlanNotifier extends StateNotifier<PlanState> {
               completedLocations: locations,
               completedSummary: summary,
               savedTripId: event.data['trip_id'] as String?,
+            );
+
+          case 'flights':
+            final raw = event.data['offers'] as List<dynamic>? ?? [];
+            final offers = raw
+                .map((e) => FlightOffer.fromJson(e as Map<String, dynamic>))
+                .toList();
+            final origin = event.data['origin'] as String? ?? '';
+            final dest = event.data['destination'] as String? ?? '';
+            state = state.copyWith(
+              flightOffers: offers,
+              flightRouteLabel: '$origin → $dest',
             );
 
           case 'error':

--- a/src/packages/flutter-app/lib/providers/preferences_provider.dart
+++ b/src/packages/flutter-app/lib/providers/preferences_provider.dart
@@ -47,10 +47,16 @@ class PreferencesNotifier extends StateNotifier<PreferencesState> {
     }
   }
 
-  Future<bool> save({String? budget, String? pace, required List<String> interests}) async {
+  Future<bool> save({
+    String? budget,
+    String? pace,
+    required List<String> interests,
+    String? homeAirport,
+  }) async {
     state = state.copyWith(saving: true, error: null);
     try {
-      final prefs = await _service.savePreferences(budget: budget, pace: pace, interests: interests);
+      final prefs = await _service.savePreferences(
+          budget: budget, pace: pace, interests: interests, homeAirport: homeAirport);
       state = state.copyWith(prefs: prefs, saving: false);
       return true;
     } catch (e) {

--- a/src/packages/flutter-app/lib/screens/agent_screen.dart
+++ b/src/packages/flutter-app/lib/screens/agent_screen.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../widgets/gradient_app_bar.dart';
+import '../widgets/flight_offer_card.dart';
+import '../models/flight_offer.dart';
 import '../models/plan_message.dart';
 import '../providers/plan_provider.dart';
 import '../providers/route_provider.dart';
@@ -139,6 +141,11 @@ class _AgentScreenState extends ConsumerState<AgentScreen> {
                             }).toList(),
                           ),
                         ),
+                      if (planState.flightOffers != null && planState.flightOffers!.isNotEmpty)
+                        _FlightOptions(
+                          routeLabel: planState.flightRouteLabel,
+                          offers: planState.flightOffers!,
+                        ),
                       if (planState.completedLocations != null)
                         _ItineraryBanner(
                           summary: planState.completedSummary,
@@ -184,6 +191,8 @@ class _AgentScreenState extends ConsumerState<AgentScreen> {
         return 'Searching places...';
       case 'create_itinerary':
         return 'Building itinerary...';
+      case 'search_flights':
+        return 'Searching flights...';
       default:
         return '$tool...';
     }
@@ -307,6 +316,55 @@ class _MessageBubble extends StatelessWidget {
             ],
           ],
         ),
+      ),
+    );
+  }
+}
+
+/// Inline flight results in the chat — a header plus the agent's top ranked
+/// options as shared FlightOfferCards (first = best match).
+class _FlightOptions extends StatelessWidget {
+  final String? routeLabel;
+  final List<FlightOffer> offers;
+
+  const _FlightOptions({required this.routeLabel, required this.offers});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final label = (routeLabel == null || routeLabel!.trim().isEmpty)
+        ? 'Flight options'
+        : 'Flight options · $routeLabel';
+    return Container(
+      margin: const EdgeInsets.symmetric(vertical: 12),
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: Colors.teal.shade50,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: Colors.teal.shade200),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Icon(Icons.flight, color: Colors.teal.shade700, size: 20),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Text(
+                  label,
+                  style: theme.textTheme.titleSmall?.copyWith(
+                    color: Colors.teal.shade800,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          for (var i = 0; i < offers.length; i++)
+            FlightOfferCard(offer: offers[i], isBest: i == 0),
+        ],
       ),
     );
   }

--- a/src/packages/flutter-app/lib/screens/flight_search_screen.dart
+++ b/src/packages/flutter-app/lib/screens/flight_search_screen.dart
@@ -1,0 +1,358 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../models/airport.dart';
+import '../models/flight_search_request.dart';
+import '../providers/flights_provider.dart';
+import '../providers/preferences_provider.dart';
+import '../widgets/airport_field.dart';
+import '../widgets/flight_offer_card.dart';
+import '../widgets/gradient_app_bar.dart';
+
+/// Standalone flight search: pick origin/destination/date/passengers and a
+/// ranking preset, then browse offers ranked by the Duffel-backed API.
+///
+/// Optional prefill ([prefillOrigin]/[prefillDestination] may be an IATA code or
+/// a city name; [prefillDepartDate] is YYYY-MM-DD) lets callers (e.g. a trip's
+/// flight booking item) open the screen ready to search. Prefill takes
+/// precedence over the saved home-airport origin seed.
+class FlightSearchScreen extends ConsumerStatefulWidget {
+  final String? prefillOrigin;
+  final String? prefillDestination;
+  final String? prefillDepartDate;
+
+  const FlightSearchScreen({
+    super.key,
+    this.prefillOrigin,
+    this.prefillDestination,
+    this.prefillDepartDate,
+  });
+
+  @override
+  ConsumerState<FlightSearchScreen> createState() => _FlightSearchScreenState();
+}
+
+class _FlightSearchScreenState extends ConsumerState<FlightSearchScreen> {
+  Airport? _origin;
+  Airport? _destination;
+  DateTime? _departDate;
+  int _adults = 1;
+  String _optimizeFor = 'balanced';
+
+  static const _presets = {
+    'cost': 'Cheapest',
+    'time': 'Fastest',
+    'balanced': 'Balanced',
+  };
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) => _seedInitial());
+  }
+
+  /// Seeds the form from explicit prefill (origin/destination/date) when given,
+  /// otherwise falls back to the saved home airport for the origin. Both are
+  /// still editable.
+  Future<void> _seedInitial() async {
+    final w = widget;
+    final date = w.prefillDepartDate == null
+        ? null
+        : DateTime.tryParse(w.prefillDepartDate!);
+    if (date != null && _departDate == null) {
+      setState(() => _departDate = date);
+    }
+
+    if (w.prefillOrigin != null && w.prefillOrigin!.isNotEmpty) {
+      final a = await _resolve(w.prefillOrigin!);
+      if (a != null && _origin == null && mounted) setState(() => _origin = a);
+    } else {
+      // No explicit origin → fall back to the traveler's home airport.
+      await ref.read(preferencesProvider.notifier).load();
+      final code = ref.read(preferencesProvider).prefs?.homeAirport;
+      if (code != null && code.isNotEmpty && _origin == null && mounted) {
+        setState(() => _origin = Airport(iataCode: code, name: code));
+      }
+    }
+
+    if (w.prefillDestination != null && w.prefillDestination!.isNotEmpty) {
+      final a = await _resolve(w.prefillDestination!);
+      if (a != null && _destination == null && mounted) {
+        setState(() => _destination = a);
+      }
+    }
+
+    // Fully prefilled (origin + destination + date all given and resolved) →
+    // run the search immediately so the caller lands on results.
+    if (mounted &&
+        w.prefillOrigin != null &&
+        w.prefillDestination != null &&
+        w.prefillDepartDate != null &&
+        _canSearch) {
+      _search();
+    }
+  }
+
+  /// Resolves an IATA code or city name to an [Airport]. A 3-letter alphabetic
+  /// input is used as-is; otherwise the Duffel airport search resolves it (first
+  /// match). Mirrors the backend's resolveIATA.
+  Future<Airport?> _resolve(String query) async {
+    final q = query.trim();
+    final isCode = q.length == 3 && RegExp(r'^[A-Za-z]{3}$').hasMatch(q);
+    if (isCode) return Airport(iataCode: q.toUpperCase(), name: q.toUpperCase());
+    try {
+      final results =
+          await ref.read(flightsApiServiceProvider).searchAirports(q);
+      return results.isNotEmpty ? results.first : null;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  bool get _canSearch =>
+      _origin != null && _destination != null && _departDate != null;
+
+  String _fmtDate(DateTime d) =>
+      '${d.year.toString().padLeft(4, '0')}-${d.month.toString().padLeft(2, '0')}-${d.day.toString().padLeft(2, '0')}';
+
+  Future<void> _pickDate() async {
+    final now = DateTime.now();
+    final picked = await showDatePicker(
+      context: context,
+      initialDate: _departDate ?? now.add(const Duration(days: 14)),
+      firstDate: now,
+      lastDate: now.add(const Duration(days: 365)),
+    );
+    if (picked != null) setState(() => _departDate = picked);
+  }
+
+  void _search() {
+    if (!_canSearch) return;
+    ref.read(flightsProvider.notifier).search(FlightSearchRequest(
+          origin: _origin!.iataCode,
+          destination: _destination!.iataCode,
+          departDate: _fmtDate(_departDate!),
+          adults: _adults,
+          optimizeFor: _optimizeFor,
+        ));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final state = ref.watch(flightsProvider);
+    final theme = Theme.of(context);
+
+    return Scaffold(
+      appBar: const GradientAppBar(title: Text('Find Flights')),
+      body: Column(
+        children: [
+          // Search form
+          Container(
+            color: theme.colorScheme.surface,
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              children: [
+                AirportField(
+                  label: 'From',
+                  icon: Icons.flight_takeoff,
+                  selected: _origin,
+                  onSelected: (a) => setState(() => _origin = a),
+                ),
+                const SizedBox(height: 12),
+                AirportField(
+                  label: 'To',
+                  icon: Icons.flight_land,
+                  selected: _destination,
+                  onSelected: (a) => setState(() => _destination = a),
+                ),
+                const SizedBox(height: 12),
+                Row(
+                  children: [
+                    Expanded(
+                      child: OutlinedButton.icon(
+                        onPressed: _pickDate,
+                        icon: const Icon(Icons.calendar_today, size: 18),
+                        label: Text(_departDate == null
+                            ? 'Departure date'
+                            : _fmtDate(_departDate!)),
+                        style: OutlinedButton.styleFrom(
+                          padding: const EdgeInsets.symmetric(vertical: 14),
+                        ),
+                      ),
+                    ),
+                    const SizedBox(width: 12),
+                    _PassengerStepper(
+                      adults: _adults,
+                      onChanged: (v) => setState(() => _adults = v),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 12),
+                SegmentedButton<String>(
+                  segments: _presets.entries
+                      .map((e) => ButtonSegment(
+                            value: e.key,
+                            label: Text(e.value),
+                          ))
+                      .toList(),
+                  selected: {_optimizeFor},
+                  onSelectionChanged: (s) =>
+                      setState(() => _optimizeFor = s.first),
+                ),
+                const SizedBox(height: 12),
+                SizedBox(
+                  width: double.infinity,
+                  child: FilledButton.icon(
+                    onPressed:
+                        _canSearch && !state.loading ? _search : null,
+                    icon: state.loading
+                        ? const SizedBox(
+                            width: 18,
+                            height: 18,
+                            child: CircularProgressIndicator(
+                                strokeWidth: 2, color: Colors.white),
+                          )
+                        : const Icon(Icons.search),
+                    label: Text(state.loading ? 'Searching…' : 'Search Flights'),
+                    style: FilledButton.styleFrom(
+                      padding: const EdgeInsets.symmetric(vertical: 14),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const Divider(height: 1),
+          // Results
+          Expanded(child: _Results(state: state)),
+        ],
+      ),
+    );
+  }
+}
+
+class _Results extends StatelessWidget {
+  final FlightsState state;
+  const _Results({required this.state});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    if (state.error != null) {
+      return Center(
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(Icons.error_outline,
+                  size: 48, color: theme.colorScheme.error),
+              const SizedBox(height: 12),
+              Text('Could not load flights',
+                  style: theme.textTheme.titleMedium),
+              const SizedBox(height: 4),
+              Text(
+                state.error!,
+                textAlign: TextAlign.center,
+                style: theme.textTheme.bodySmall
+                    ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
+    if (!state.hasSearched) {
+      return _Hint(
+        icon: Icons.flight,
+        text: 'Choose an origin, destination, and date to find flights.',
+      );
+    }
+
+    if (state.loading) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    if (state.offers.isEmpty) {
+      return const _Hint(
+        icon: Icons.search_off,
+        text: 'No flights found for this route and date.',
+      );
+    }
+
+    return ListView.builder(
+      padding: const EdgeInsets.all(16),
+      itemCount: state.offers.length,
+      itemBuilder: (context, i) {
+        final offer = state.offers[i];
+        return FlightOfferCard(
+          offer: offer,
+          isBest: offer.id == state.bestOfferId,
+        );
+      },
+    );
+  }
+}
+
+class _Hint extends StatelessWidget {
+  final IconData icon;
+  final String text;
+  const _Hint({required this.icon, required this.text});
+
+  @override
+  Widget build(BuildContext context) {
+    final color = Theme.of(context).colorScheme.onSurfaceVariant;
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(icon, size: 56, color: color),
+            const SizedBox(height: 12),
+            Text(text, textAlign: TextAlign.center,
+                style: Theme.of(context)
+                    .textTheme
+                    .bodyMedium
+                    ?.copyWith(color: color)),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _PassengerStepper extends StatelessWidget {
+  final int adults;
+  final ValueChanged<int> onChanged;
+  const _PassengerStepper({required this.adults, required this.onChanged});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        border: Border.all(color: Theme.of(context).dividerColor),
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          IconButton(
+            icon: const Icon(Icons.remove, size: 18),
+            onPressed: adults > 1 ? () => onChanged(adults - 1) : null,
+            visualDensity: VisualDensity.compact,
+          ),
+          Text('$adults',
+              style: const TextStyle(fontWeight: FontWeight.bold)),
+          IconButton(
+            icon: const Icon(Icons.add, size: 18),
+            onPressed: adults < 9 ? () => onChanged(adults + 1) : null,
+            visualDensity: VisualDensity.compact,
+          ),
+        ],
+      ),
+    );
+  }
+}
+

--- a/src/packages/flutter-app/lib/screens/home_screen.dart
+++ b/src/packages/flutter-app/lib/screens/home_screen.dart
@@ -7,6 +7,7 @@ import 'route_optimizer_screen.dart';
 import 'country_optimizer_screen.dart';
 import 'agent_screen.dart';
 import 'airbnb_parser_screen.dart';
+import 'flight_search_screen.dart';
 import 'trips_list_screen.dart';
 import 'preferences_screen.dart';
 
@@ -125,6 +126,19 @@ class HomeScreen extends ConsumerWidget {
                 description: 'Optimize routes for multiple locations in a city',
                 onTap: () => Navigator.of(context).push(
                   MaterialPageRoute(builder: (_) => const RouteOptimizerScreen()),
+                ),
+              ),
+
+              const SizedBox(height: 12),
+
+              // Find Flights
+              _ToolRow(
+                icon: MdiIcons.airplane,
+                color: Colors.teal.shade700,
+                title: 'Find Flights',
+                description: 'Search and rank flights by price, time, and stops',
+                onTap: () => Navigator.of(context).push(
+                  MaterialPageRoute(builder: (_) => const FlightSearchScreen()),
                 ),
               ),
 

--- a/src/packages/flutter-app/lib/screens/preferences_screen.dart
+++ b/src/packages/flutter-app/lib/screens/preferences_screen.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../models/airport.dart';
+import '../widgets/airport_field.dart';
 import '../widgets/gradient_app_bar.dart';
 import '../providers/preferences_provider.dart';
 
@@ -20,6 +22,7 @@ class _PreferencesScreenState extends ConsumerState<PreferencesScreen> {
   String? _budget;
   String? _pace;
   final Set<String> _interests = {};
+  Airport? _homeAirport;
   final _interestController = TextEditingController();
   bool _initialized = false;
 
@@ -34,6 +37,10 @@ class _PreferencesScreenState extends ConsumerState<PreferencesScreen> {
           _budget = prefs.budget;
           _pace = prefs.pace;
           _interests.addAll(prefs.interests);
+          final home = prefs.homeAirport;
+          if (home != null && home.isNotEmpty) {
+            _homeAirport = Airport(iataCode: home, name: home);
+          }
           _initialized = true;
         });
       } else if (mounted) {
@@ -61,6 +68,7 @@ class _PreferencesScreenState extends ConsumerState<PreferencesScreen> {
           budget: _budget,
           pace: _pace,
           interests: _interests.toList(),
+          homeAirport: _homeAirport?.iataCode,
         );
     if (!mounted) return;
     ScaffoldMessenger.of(context).showSnackBar(
@@ -133,6 +141,22 @@ class _PreferencesScreenState extends ConsumerState<PreferencesScreen> {
                     ),
                     IconButton(icon: const Icon(Icons.add), onPressed: _addInterest),
                   ],
+                ),
+                const SizedBox(height: 24),
+                Text('Home airport', style: theme.textTheme.titleMedium),
+                const SizedBox(height: 4),
+                Text(
+                  'Used as the default origin when planning flights.',
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: theme.colorScheme.onSurfaceVariant,
+                  ),
+                ),
+                const SizedBox(height: 8),
+                AirportField(
+                  label: 'Home airport',
+                  icon: Icons.home,
+                  selected: _homeAirport,
+                  onSelected: (a) => setState(() => _homeAirport = a),
                 ),
                 const SizedBox(height: 32),
                 FilledButton(

--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -8,9 +8,11 @@ import '../models/accommodation.dart';
 import '../models/booking_todo.dart';
 import '../providers/trips_provider.dart';
 import '../providers/booking_todos_provider.dart';
+import '../providers/preferences_provider.dart';
 import '../widgets/booking_todo_card.dart';
 import '../widgets/trip_map.dart';
 import 'agent_screen.dart';
+import 'flight_search_screen.dart';
 
 class TripDetailScreen extends ConsumerStatefulWidget {
   final String tripId;
@@ -34,6 +36,9 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
   final Set<String> _collapsedCities = {};
   final Set<String> _collapsedDays = {};
   final GlobalKey _mapKey = GlobalKey(); // for scrolling the trip map into view on tap
+  String? _homeAirport; // traveler's saved home airport (IATA), for outbound/return flights
+  // todo_key -> flight leg, so a transport booking item can open Find Flights prefilled.
+  Map<String, ({String origin, String destination, String? date})> _flightLegs = {};
 
   /// Itinerary items matching the active category filter, used by both the map
   /// and the list so they stay in sync.
@@ -63,6 +68,10 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
           _bookingTodos = trip.bookingTodos ?? [];
         });
       }
+      // Load the home airport so the booking checklist can derive the outbound
+      // and return flights (no-op / null for anonymous sessions).
+      await ref.read(preferencesProvider.notifier).load();
+      _homeAirport = ref.read(preferencesProvider).prefs?.homeAirport;
       if (mounted && (trip.items ?? const []).isNotEmpty) {
         await _syncBookingTodos(trip);
       }
@@ -91,7 +100,37 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
   List<Map<String, dynamic>> _deriveTodos(Trip trip) {
     final ranges = _locationGroupRanges(trip);
     final todos = <Map<String, dynamic>>[];
+    final legs = <String, ({String origin, String destination, String? date})>{};
     var pos = 0;
+    final home = _homeAirport;
+    final hasHome = home != null && home.isNotEmpty && ranges.isNotEmpty;
+
+    // Adds a transport (flight) todo and records its leg so the booking item can
+    // open Find Flights prefilled.
+    void addFlight(String origin, String destination, DateTime? when) {
+      final date = when == null ? null : _fmt(when);
+      final key =
+          'transport:${origin.toLowerCase()}>>${destination.toLowerCase()}';
+      todos.add({
+        'kind': 'transport',
+        'todo_key': key,
+        'title': '$origin → $destination',
+        if (when != null) 'subtitle': _fmtShortDt(when),
+        'provider': 'google_flights',
+        'position': pos++,
+        'origin': origin,
+        'destination': destination,
+        if (date != null) 'depart_date': date,
+        'passengers': 1,
+      });
+      legs[key] = (origin: origin, destination: destination, date: date);
+    }
+
+    // Outbound: home airport -> first city, on the trip's start date.
+    if (hasHome) {
+      addFlight(home, ranges.first.label, ranges.first.start);
+    }
+
     for (var i = 0; i < ranges.length; i++) {
       final r = ranges[i];
       final label = r.label;
@@ -111,23 +150,16 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
         'guests': 1,
       });
       if (i < ranges.length - 1) {
-        final next = ranges[i + 1];
-        final depart = r.end == null ? null : _fmt(r.end!);
-        todos.add({
-          'kind': 'transport',
-          'todo_key':
-              'transport:${label.toLowerCase()}>>${next.label.toLowerCase()}',
-          'title': '$label → ${next.label}',
-          if (r.end != null) 'subtitle': _fmtShortDt(r.end!),
-          'provider': 'google_flights',
-          'position': pos++,
-          'origin': label,
-          'destination': next.label,
-          if (depart != null) 'depart_date': depart,
-          'passengers': 1,
-        });
+        addFlight(label, ranges[i + 1].label, r.end);
       }
     }
+
+    // Return: last city -> home airport, on the trip's end date.
+    if (hasHome) {
+      addFlight(ranges.last.label, home, ranges.last.end);
+    }
+
+    _flightLegs = legs;
     return todos;
   }
 
@@ -1061,9 +1093,11 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
                               child: BookingTodoCard(
                                 todo: todo,
                                 onBookedChanged: (v) => _setBooked(todo, v),
-                                onOpen: todo.searchUrl != null
-                                    ? () => _launch(todo.searchUrl!)
-                                    : null,
+                                onOpen: _openCallbackFor(todo),
+                                openLabelOverride:
+                                    _flightLegs.containsKey(todo.todoKey)
+                                        ? 'Find flights'
+                                        : null,
                                 onDelete:
                                     todo.auto ? null : () => _deleteTodo(todo),
                               ),
@@ -1071,6 +1105,24 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
                       ],
                     ),
     );
+  }
+
+  /// The open action for a booking item: a transport item with a known flight
+  /// leg opens the in-app Find Flights screen prefilled; everything else falls
+  /// back to its external provider search link.
+  VoidCallback? _openCallbackFor(BookingTodo todo) {
+    final leg = todo.kind == 'transport' ? _flightLegs[todo.todoKey] : null;
+    if (leg != null) {
+      return () => Navigator.of(context).push(MaterialPageRoute(
+            builder: (_) => FlightSearchScreen(
+              prefillOrigin: leg.origin,
+              prefillDestination: leg.destination,
+              prefillDepartDate: leg.date,
+            ),
+          ));
+    }
+    if (todo.searchUrl != null) return () => _launch(todo.searchUrl!);
+    return null;
   }
 
   Future<void> _launch(String url) async {

--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -29,6 +29,11 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
   int? _selectedPosition; // position of the place focused via a map pin / list tap
   List<BookingTodo> _bookingTodos = [];
   bool _overviewExpanded = false;
+  // Collapsed sets (empty => all expanded). Cities keyed by group label; days
+  // keyed by "<city>#<day>" since day numbers repeat across cities.
+  final Set<String> _collapsedCities = {};
+  final Set<String> _collapsedDays = {};
+  final GlobalKey _mapKey = GlobalKey(); // for scrolling the trip map into view on tap
 
   /// Itinerary items matching the active category filter, used by both the map
   /// and the list so they stay in sync.
@@ -397,10 +402,47 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
     return groups;
   }
 
-  /// Renders a hub group's items, batching consecutive day-trip places (by town)
-  /// under an indented "Day trip · <town>" sub-header so nearby towns read as
-  /// excursions from the hub city rather than separate stops.
-  List<Widget> _buildGroupItemWidgets(List<ItineraryItem> items, ThemeData theme) {
+  /// Renders a hub group's items, split into "Day N" sub-sections when items
+  /// carry day numbers (day-trip batching applied within each day). Legacy items
+  /// with no day fall back to flat day-trip batching with no day headers.
+  List<Widget> _buildGroupItemWidgets(String cityKey, List<ItineraryItem> items,
+      ThemeData theme, DateTime? tripStart) {
+    if (!items.any((it) => it.day != null)) {
+      return _buildDayTripWidgets(items, theme);
+    }
+    final widgets = <Widget>[];
+    var i = 0;
+    while (i < items.length) {
+      final day = items[i].day;
+      final run = <ItineraryItem>[];
+      while (i < items.length && items[i].day == day) {
+        run.add(items[i]);
+        i++;
+      }
+      if (day != null) {
+        final dayKey = '$cityKey#$day';
+        final collapsed = _collapsedDays.contains(dayKey);
+        widgets.add(_daySubHeader(day, tripStart, theme, collapsed, () {
+          setState(() {
+            if (collapsed) {
+              _collapsedDays.remove(dayKey);
+            } else {
+              _collapsedDays.add(dayKey);
+            }
+          });
+        }));
+        if (!collapsed) widgets.addAll(_buildDayTripWidgets(run, theme));
+      } else {
+        widgets.addAll(_buildDayTripWidgets(run, theme));
+      }
+    }
+    return widgets;
+  }
+
+  /// Batches consecutive day-trip places (by town) under an indented
+  /// "Day trip · <town>" sub-header so nearby towns read as excursions from the
+  /// hub city rather than separate stops.
+  List<Widget> _buildDayTripWidgets(List<ItineraryItem> items, ThemeData theme) {
     final widgets = <Widget>[];
     var i = 0;
     while (i < items.length) {
@@ -426,6 +468,41 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
     return widgets;
   }
 
+  /// Day section header: shows the calendar date (day N -> startDate + (N-1))
+  /// when the trip start is known, otherwise falls back to "Day N".
+  Widget _daySubHeader(int day, DateTime? tripStart, ThemeData theme,
+      bool collapsed, VoidCallback onTap) {
+    final label = tripStart != null
+        ? _fmtDayHeader(tripStart.add(Duration(days: day - 1)))
+        : 'Day $day';
+    return InkWell(
+      onTap: onTap,
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(16, 12, 16, 2),
+        child: Row(
+          children: [
+            Icon(Icons.today, size: 16, color: theme.colorScheme.primary),
+            const SizedBox(width: 6),
+            Expanded(
+              child: Text(
+                label,
+                style: theme.textTheme.labelLarge?.copyWith(
+                  color: theme.colorScheme.primary,
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+            ),
+            Icon(
+              collapsed ? Icons.chevron_right : Icons.expand_more,
+              size: 18,
+              color: theme.colorScheme.primary,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
   Widget _dayTripSubHeader(String town, ThemeData theme) => Padding(
         padding: const EdgeInsets.fromLTRB(20, 8, 16, 0),
         child: Row(
@@ -449,14 +526,49 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
           leading: _itemLeading(item.category, item.position),
           title: Text(item.name),
           subtitle: item.address != null ? Text(item.address!) : null,
-          trailing: item.timeOfDay == null
-              ? null
-              : _TimeOfDayChip(timeOfDay: item.timeOfDay!),
+          trailing: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              if (item.timeOfDay != null)
+                _TimeOfDayChip(timeOfDay: item.timeOfDay!),
+              IconButton(
+                icon: const Icon(Icons.map_outlined),
+                tooltip: 'Open in Google Maps',
+                onPressed: () => _launch(_mapsUrl(item)),
+              ),
+            ],
+          ),
           selected: _selectedPosition == item.position,
           selectedTileColor: theme.colorScheme.primary.withValues(alpha: 0.08),
-          onTap: () => setState(() => _selectedPosition = item.position),
+          onTap: () {
+            setState(() => _selectedPosition = item.position);
+            _scrollToMap();
+          },
         ),
       );
+
+  /// Scrolls the page so the trip map is visible (focusing the tapped pin). No-op
+  /// when the trip has no mappable items, so the map isn't built.
+  void _scrollToMap() {
+    final ctx = _mapKey.currentContext;
+    if (ctx != null) {
+      Scrollable.ensureVisible(ctx,
+          duration: const Duration(milliseconds: 350), curve: Curves.easeInOut);
+    }
+  }
+
+  /// Google Maps deep link for a place: prefer place_id, then coordinates, then a
+  /// name/address text search.
+  String _mapsUrl(ItineraryItem it) {
+    const base = 'https://www.google.com/maps/search/?api=1';
+    if (it.placeId != null && it.placeId!.isNotEmpty) {
+      return '$base&query=${Uri.encodeComponent(it.name)}&query_place_id=${it.placeId}';
+    }
+    if (it.latitude != 0 || it.longitude != 0) {
+      return '$base&query=${it.latitude},${it.longitude}';
+    }
+    return '$base&query=${Uri.encodeComponent('${it.name} ${it.address ?? ''}'.trim())}';
+  }
 
   /// Maps each itinerary item's position to its location's formatted date range.
   /// Delegates to [_locationGroupRanges] so the itinerary labels and the booking
@@ -536,14 +648,35 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
       final g = groups[i];
       final locality = _hubOf(g.first);
       final accRange = _accDateRangeFor(locality, stays);
+      final dayRange = _dayRangeFor(g, start);
       final a = auto[i];
       result.add((
         label: locality ?? 'Other places',
-        start: accRange?.start ?? a?.start,
-        end: accRange?.end ?? a?.end,
+        start: accRange?.start ?? dayRange?.start ?? a?.start,
+        end: accRange?.end ?? dayRange?.end ?? a?.end,
       ));
     }
     return result;
+  }
+
+  /// Date range for a location group from its items' AI-assigned day numbers,
+  /// anchored to the trip start: day N -> startDate + (N-1). Null when the trip
+  /// has no start date or none of the items carry a day.
+  ({DateTime start, DateTime end})? _dayRangeFor(
+      List<ItineraryItem> items, DateTime? tripStart) {
+    if (tripStart == null) return null;
+    int? lo, hi;
+    for (final it in items) {
+      final d = it.day;
+      if (d == null || d < 1) continue;
+      if (lo == null || d < lo) lo = d;
+      if (hi == null || d > hi) hi = d;
+    }
+    if (lo == null || hi == null) return null;
+    return (
+      start: tripStart.add(Duration(days: lo - 1)),
+      end: tripStart.add(Duration(days: hi - 1)),
+    );
   }
 
   /// First accommodation in [locality] with both check-in/out dates, as DateTimes.
@@ -602,9 +735,17 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
 
   String _fmtShortDt(DateTime d) => '${_months[d.month - 1]} ${d.day}';
 
+  /// Day-header date, e.g. "Tue, Jul 15" (weekday + month + day).
+  String _fmtDayHeader(DateTime d) =>
+      '${_weekdays[d.weekday - 1]}, ${_months[d.month - 1]} ${d.day}';
+
   static const _months = [
     'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
     'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
+  ];
+
+  static const _weekdays = [
+    'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun',
   ];
 
   /// The trip's hero header: title (+ rename), date/status chips, a Refine
@@ -768,6 +909,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
                         const Divider(height: 32),
                         if (_filtered(trip).any((i) => i.latitude != 0 || i.longitude != 0)) ...[
                           ClipRRect(
+                            key: _mapKey,
                             borderRadius: BorderRadius.circular(12),
                             child: SizedBox(
                               height: 240,
@@ -820,47 +962,76 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
                             return Column(
                               children: [
                                 for (final group in groups) ...[
-                                  Padding(
-                                    padding: const EdgeInsets.fromLTRB(16, 16, 16, 4),
-                                    child: Column(
-                                      crossAxisAlignment: CrossAxisAlignment.start,
-                                      children: [
-                                        Row(
+                                  Builder(builder: (_) {
+                                    final cityCollapsed =
+                                        _collapsedCities.contains(group.label);
+                                    return InkWell(
+                                      onTap: () => setState(() {
+                                        if (cityCollapsed) {
+                                          _collapsedCities.remove(group.label);
+                                        } else {
+                                          _collapsedCities.add(group.label);
+                                        }
+                                      }),
+                                      child: Padding(
+                                        padding:
+                                            const EdgeInsets.fromLTRB(16, 16, 16, 4),
+                                        child: Column(
+                                          crossAxisAlignment:
+                                              CrossAxisAlignment.start,
                                           children: [
-                                            Icon(Icons.location_on,
-                                                size: 18, color: theme.colorScheme.primary),
-                                            const SizedBox(width: 6),
-                                            Expanded(
-                                              child: Text(
-                                                group.label,
-                                                style: theme.textTheme.titleSmall
-                                                    ?.copyWith(fontWeight: FontWeight.bold),
-                                              ),
-                                            ),
-                                            if (group.dateRange != null)
-                                              Row(
-                                                children: [
+                                            Row(
+                                              children: [
+                                                Icon(Icons.location_on,
+                                                    size: 18,
+                                                    color: theme.colorScheme.primary),
+                                                const SizedBox(width: 6),
+                                                Expanded(
+                                                  child: Text(
+                                                    group.label,
+                                                    style: theme.textTheme.titleSmall
+                                                        ?.copyWith(
+                                                            fontWeight:
+                                                                FontWeight.bold),
+                                                  ),
+                                                ),
+                                                if (group.dateRange != null) ...[
                                                   Icon(Icons.event,
                                                       size: 14,
-                                                      color: theme.colorScheme.primary),
+                                                      color:
+                                                          theme.colorScheme.primary),
                                                   const SizedBox(width: 4),
                                                   Text(
                                                     group.dateRange!,
                                                     style: theme.textTheme.labelMedium
                                                         ?.copyWith(
-                                                            color:
-                                                                theme.colorScheme.primary),
+                                                            color: theme
+                                                                .colorScheme.primary),
                                                   ),
                                                 ],
-                                              ),
+                                                const SizedBox(width: 4),
+                                                Icon(
+                                                  cityCollapsed
+                                                      ? Icons.chevron_right
+                                                      : Icons.expand_more,
+                                                  size: 20,
+                                                  color: theme.colorScheme.primary,
+                                                ),
+                                              ],
+                                            ),
+                                            const SizedBox(height: 4),
+                                            const Divider(height: 1),
                                           ],
                                         ),
-                                        const SizedBox(height: 4),
-                                        const Divider(height: 1),
-                                      ],
-                                    ),
-                                  ),
-                                  ..._buildGroupItemWidgets(group.items, theme),
+                                      ),
+                                    );
+                                  }),
+                                  if (!_collapsedCities.contains(group.label))
+                                    ..._buildGroupItemWidgets(
+                                        group.label,
+                                        group.items,
+                                        theme,
+                                        DateTime.tryParse(trip.startDate ?? '')),
                                 ],
                               ],
                             );

--- a/src/packages/flutter-app/lib/services/flights_api_service.dart
+++ b/src/packages/flutter-app/lib/services/flights_api_service.dart
@@ -1,0 +1,57 @@
+import 'dart:convert';
+import '../models/airport.dart';
+import '../models/flight_search_request.dart';
+import '../models/flight_search_response.dart';
+import 'api_client.dart';
+
+/// Wraps the /flights/* endpoints (Amadeus-backed flight search + airport
+/// autocomplete). These endpoints are public, but we still send the bearer
+/// token when present, matching the other services.
+class FlightsApiService {
+  final ApiClient apiClient;
+
+  FlightsApiService(this.apiClient);
+
+  Map<String, String> _headers({bool json = false}) {
+    final h = <String, String>{'Accept': 'application/json'};
+    if (json) h['Content-Type'] = 'application/json';
+    final token = apiClient.authToken;
+    if (token != null) h['Authorization'] = 'Bearer $token';
+    return h;
+  }
+
+  Future<FlightSearchResponse> searchFlights(FlightSearchRequest request) async {
+    final res = await apiClient.httpClient.post(
+      Uri.parse('${apiClient.baseUrl}/flights/search'),
+      headers: _headers(json: true),
+      body: jsonEncode(request.toJson()),
+    );
+    if (res.statusCode == 200) {
+      return FlightSearchResponse.fromJson(
+          jsonDecode(res.body) as Map<String, dynamic>);
+    }
+    throw ApiException(
+      statusCode: res.statusCode,
+      message: 'Failed to search flights: ${res.body}',
+      endpoint: 'flights/search',
+    );
+  }
+
+  Future<List<Airport>> searchAirports(String query) async {
+    final uri = Uri.parse('${apiClient.baseUrl}/flights/airports')
+        .replace(queryParameters: {'q': query});
+    final res = await apiClient.httpClient.get(uri, headers: _headers());
+    if (res.statusCode == 200) {
+      final body = jsonDecode(res.body) as Map<String, dynamic>;
+      final list = (body['results'] as List<dynamic>? ?? []);
+      return list
+          .map((e) => Airport.fromJson(e as Map<String, dynamic>))
+          .toList();
+    }
+    throw ApiException(
+      statusCode: res.statusCode,
+      message: 'Failed to search airports: ${res.body}',
+      endpoint: 'flights/airports',
+    );
+  }
+}

--- a/src/packages/flutter-app/lib/services/preferences_api_service.dart
+++ b/src/packages/flutter-app/lib/services/preferences_api_service.dart
@@ -29,11 +29,17 @@ class PreferencesApiService {
     String? budget,
     String? pace,
     required List<String> interests,
+    String? homeAirport,
   }) async {
     final res = await apiClient.httpClient.put(
       Uri.parse('${apiClient.baseUrl}/preferences'),
       headers: _headers(json: true),
-      body: jsonEncode({'budget': budget, 'pace': pace, 'interests': interests}),
+      body: jsonEncode({
+        'budget': budget,
+        'pace': pace,
+        'interests': interests,
+        'home_airport': homeAirport,
+      }),
     );
     if (res.statusCode == 200) {
       return TravelerPreferences.fromJson(jsonDecode(res.body));

--- a/src/packages/flutter-app/lib/widgets/airline_logo.dart
+++ b/src/packages/flutter-app/lib/widgets/airline_logo.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+
+/// Renders an airline's logo from Duffel's `owner.logo_symbol_url` (an SVG).
+/// Shows nothing (zero-size) when [url] is null/empty or fails to load, so
+/// callers can place it unconditionally.
+class AirlineLogo extends StatelessWidget {
+  final String? url;
+  final double size;
+  const AirlineLogo({super.key, required this.url, this.size = 22});
+
+  @override
+  Widget build(BuildContext context) {
+    final u = url;
+    if (u == null || u.isEmpty) return const SizedBox.shrink();
+    return SvgPicture.network(
+      u,
+      width: size,
+      height: size,
+      placeholderBuilder: (_) => SizedBox(width: size, height: size),
+    );
+  }
+}

--- a/src/packages/flutter-app/lib/widgets/airport_field.dart
+++ b/src/packages/flutter-app/lib/widgets/airport_field.dart
@@ -1,0 +1,123 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../models/airport.dart';
+import '../providers/flights_provider.dart';
+
+/// An airport/city autocomplete field backed by [airportSearchProvider]. When a
+/// place is selected it shows the chosen label with a clear button; otherwise it
+/// shows a search box with a live suggestion dropdown. Shared by the Find
+/// Flights screen and the Travel profile (home airport).
+class AirportField extends ConsumerStatefulWidget {
+  final String label;
+  final IconData icon;
+  final Airport? selected;
+  final ValueChanged<Airport?> onSelected;
+
+  const AirportField({
+    super.key,
+    required this.label,
+    required this.icon,
+    required this.selected,
+    required this.onSelected,
+  });
+
+  @override
+  ConsumerState<AirportField> createState() => _AirportFieldState();
+}
+
+class _AirportFieldState extends ConsumerState<AirportField> {
+  final _controller = TextEditingController();
+  String _query = '';
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final selected = widget.selected;
+
+    if (selected != null) {
+      return InputDecorator(
+        decoration: InputDecoration(
+          labelText: widget.label,
+          prefixIcon: Icon(widget.icon),
+          border: const OutlineInputBorder(),
+          suffixIcon: IconButton(
+            icon: const Icon(Icons.close),
+            onPressed: () {
+              widget.onSelected(null);
+              _controller.clear();
+              setState(() => _query = '');
+            },
+          ),
+        ),
+        child: Text(selected.label,
+            style: const TextStyle(fontWeight: FontWeight.w500)),
+      );
+    }
+
+    return Column(
+      children: [
+        TextField(
+          controller: _controller,
+          decoration: InputDecoration(
+            labelText: widget.label,
+            hintText: 'City or airport',
+            prefixIcon: Icon(widget.icon),
+            border: const OutlineInputBorder(),
+          ),
+          onChanged: (v) => setState(() => _query = v),
+        ),
+        if (_query.trim().length >= 2)
+          Consumer(
+            builder: (context, ref, _) {
+              final results = ref.watch(airportSearchProvider(_query));
+              return results.when(
+                data: (airports) => airports.isEmpty
+                    ? const SizedBox.shrink()
+                    : Container(
+                        margin: const EdgeInsets.only(top: 4),
+                        constraints: const BoxConstraints(maxHeight: 220),
+                        decoration: BoxDecoration(
+                          border:
+                              Border.all(color: Theme.of(context).dividerColor),
+                          borderRadius: BorderRadius.circular(8),
+                        ),
+                        child: ListView(
+                          shrinkWrap: true,
+                          children: airports
+                              .map((a) => ListTile(
+                                    dense: true,
+                                    leading: Icon(
+                                        a.subType.toLowerCase() == 'city'
+                                            ? Icons.location_city
+                                            : Icons.local_airport,
+                                        size: 20),
+                                    title: Text(a.label),
+                                    subtitle: a.country.isEmpty
+                                        ? null
+                                        : Text(a.country),
+                                    onTap: () {
+                                      widget.onSelected(a);
+                                      _controller.clear();
+                                      setState(() => _query = '');
+                                    },
+                                  ))
+                              .toList(),
+                        ),
+                      ),
+                loading: () => const Padding(
+                  padding: EdgeInsets.all(8),
+                  child: LinearProgressIndicator(),
+                ),
+                error: (_, __) => const SizedBox.shrink(),
+              );
+            },
+          ),
+      ],
+    );
+  }
+}

--- a/src/packages/flutter-app/lib/widgets/booking_todo_card.dart
+++ b/src/packages/flutter-app/lib/widgets/booking_todo_card.dart
@@ -9,12 +9,17 @@ class BookingTodoCard extends StatelessWidget {
   final VoidCallback? onOpen;
   final VoidCallback? onDelete;
 
+  /// Overrides the open-button text (e.g. 'Find flights' when the action opens
+  /// the in-app flight search instead of an external provider link).
+  final String? openLabelOverride;
+
   const BookingTodoCard({
     super.key,
     required this.todo,
     required this.onBookedChanged,
     this.onOpen,
     this.onDelete,
+    this.openLabelOverride,
   });
 
   IconData get _icon {
@@ -29,6 +34,7 @@ class BookingTodoCard extends StatelessWidget {
   }
 
   String get _openLabel {
+    if (openLabelOverride != null) return openLabelOverride!;
     switch (todo.provider) {
       case 'airbnb':
         return 'Open in Airbnb';

--- a/src/packages/flutter-app/lib/widgets/flight_details_sheet.dart
+++ b/src/packages/flutter-app/lib/widgets/flight_details_sheet.dart
@@ -1,0 +1,247 @@
+import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
+import '../models/flight_leg.dart';
+import '../models/flight_offer.dart';
+import 'airline_logo.dart';
+
+/// Opens a modal bottom sheet with the segment-by-segment breakdown of [offer]:
+/// each leg's carrier/flight number and depart→arrive clock times, plus the
+/// connecting airport and layover duration between consecutive legs.
+///
+/// Layovers are computed from two timestamps at the *same* airport
+/// (`segments[i].arriveTime` and `segments[i+1].departTime`), so they are
+/// timezone-safe. We deliberately do not show a per-leg flight duration: the
+/// ISO8601 segment times carry no offset and crossing timezones would be wrong —
+/// total duration comes from the API via [FlightOffer.durationLabel].
+Future<void> showFlightDetails(BuildContext context, FlightOffer offer) {
+  return showModalBottomSheet<void>(
+    context: context,
+    showDragHandle: true,
+    isScrollControlled: true,
+    builder: (context) => _FlightDetailsSheet(offer: offer),
+  );
+}
+
+class _FlightDetailsSheet extends StatelessWidget {
+  final FlightOffer offer;
+  const _FlightDetailsSheet({required this.offer});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final segments = offer.segments;
+    final from = segments.isNotEmpty ? segments.first.from : '';
+    final to = segments.isNotEmpty ? segments.last.to : '';
+
+    final rows = <Widget>[];
+    for (var i = 0; i < segments.length; i++) {
+      rows.add(_SegmentRow(leg: segments[i]));
+      if (i < segments.length - 1) {
+        rows.add(_LayoverRow(
+          airport: segments[i].to,
+          duration: _layover(segments[i], segments[i + 1]),
+        ));
+      }
+    }
+
+    return SafeArea(
+      child: ConstrainedBox(
+        constraints: BoxConstraints(
+          maxHeight: MediaQuery.of(context).size.height * 0.8,
+        ),
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.fromLTRB(20, 0, 20, 20),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Row(
+                children: [
+                  AirlineLogo(url: offer.airlineLogoUrl, size: 28),
+                  if (offer.airlineLogoUrl != null &&
+                      offer.airlineLogoUrl!.isNotEmpty)
+                    const SizedBox(width: 10),
+                  Expanded(
+                    child: Text(
+                      '$from → $to',
+                      style: theme.textTheme.titleLarge
+                          ?.copyWith(fontWeight: FontWeight.bold),
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 4),
+              Text(
+                '${offer.durationLabel} · ${offer.stopsLabel}',
+                style: theme.textTheme.bodyMedium
+                    ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+              ),
+              const Divider(height: 24),
+              ...rows,
+              if (offer.bookingUrl != null) ...[
+                const SizedBox(height: 16),
+                SizedBox(
+                  width: double.infinity,
+                  child: FilledButton.icon(
+                    onPressed: () => _book(context, offer.bookingUrl!),
+                    icon: const Icon(Icons.open_in_new, size: 18),
+                    label: Text(offer.airlines.isEmpty
+                        ? 'Book this flight'
+                        : 'Book with ${offer.airlines.first}'),
+                    style: FilledButton.styleFrom(
+                      padding: const EdgeInsets.symmetric(vertical: 14),
+                    ),
+                  ),
+                ),
+              ],
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// One flown leg: carrier + flight number, then "FROM hh:mm → TO hh:mm (+N)".
+class _SegmentRow extends StatelessWidget {
+  final FlightLeg leg;
+  const _SegmentRow({required this.leg});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final muted = theme.colorScheme.onSurfaceVariant;
+    final bold = theme.textTheme.bodyLarge?.copyWith(
+        color: theme.colorScheme.onSurface, fontWeight: FontWeight.w600);
+    final base = theme.textTheme.bodyLarge?.copyWith(color: muted);
+    final dayOffset = _dayOffset(leg.departTime, leg.arriveTime);
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 6),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Icon(Icons.flight_takeoff,
+                  size: 18, color: theme.colorScheme.primary),
+              const SizedBox(width: 8),
+              Text(
+                _carrierLabel(leg),
+                style: theme.textTheme.titleSmall
+                    ?.copyWith(fontWeight: FontWeight.w600),
+              ),
+            ],
+          ),
+          const SizedBox(height: 4),
+          Padding(
+            padding: const EdgeInsets.only(left: 26),
+            child: Text.rich(
+              TextSpan(
+                style: base,
+                children: [
+                  TextSpan(text: '${leg.from} '),
+                  TextSpan(text: _clock(leg.departTime), style: bold),
+                  const TextSpan(text: '  →  '),
+                  TextSpan(text: '${leg.to} '),
+                  TextSpan(text: _clock(leg.arriveTime), style: bold),
+                  if (dayOffset > 0)
+                    TextSpan(
+                      text: ' +$dayOffset',
+                      style: theme.textTheme.labelSmall
+                          ?.copyWith(color: theme.colorScheme.error),
+                    ),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Layover row between two legs, e.g. "Layover LIS · 1h 25m".
+class _LayoverRow extends StatelessWidget {
+  final String airport;
+  final Duration? duration;
+  const _LayoverRow({required this.airport, required this.duration});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final muted = theme.colorScheme.onSurfaceVariant;
+    final label = duration == null
+        ? 'Layover $airport'
+        : 'Layover $airport · ${_hm(duration!)}';
+    return Padding(
+      padding: const EdgeInsets.only(left: 26, top: 4, bottom: 4),
+      child: Row(
+        children: [
+          Icon(Icons.timelapse, size: 16, color: muted),
+          const SizedBox(width: 8),
+          Text(label,
+              style: theme.textTheme.bodySmall
+                  ?.copyWith(color: muted, fontStyle: FontStyle.italic)),
+        ],
+      ),
+    );
+  }
+}
+
+/// Opens the offer's booking link (airline site or airline-filtered Google
+/// Flights) in an external tab.
+Future<void> _book(BuildContext context, String url) async {
+  final ok = await launchUrl(Uri.parse(url), mode: LaunchMode.externalApplication);
+  if (!ok && context.mounted) {
+    ScaffoldMessenger.of(context)
+        .showSnackBar(const SnackBar(content: Text('Could not open link')));
+  }
+}
+
+/// "TAP TP204" — carrier name with flight number, de-duplicating when the
+/// flight number already starts with the carrier text.
+String _carrierLabel(FlightLeg leg) {
+  final carrier = leg.carrier.trim();
+  final number = leg.flightNumber.trim();
+  if (number.isEmpty) return carrier.isEmpty ? 'Flight' : carrier;
+  if (carrier.isEmpty) return number;
+  return '$carrier $number';
+}
+
+/// "hh:mm" for an ISO8601 time, empty if unparseable.
+String _clock(String iso) {
+  final t = DateTime.tryParse(iso);
+  if (t == null) return '';
+  return '${t.hour.toString().padLeft(2, '0')}:${t.minute.toString().padLeft(2, '0')}';
+}
+
+/// Calendar days a leg's arrival falls after its departure (for the "+N" badge).
+int _dayOffset(String depart, String arrive) {
+  final d = DateTime.tryParse(depart);
+  final a = DateTime.tryParse(arrive);
+  if (d == null || a == null) return 0;
+  return DateTime(a.year, a.month, a.day)
+      .difference(DateTime(d.year, d.month, d.day))
+      .inDays;
+}
+
+/// Layover between the arrival of [prev] and the departure of [next] — both at
+/// the same airport, so the local-time subtraction is correct. Null if either
+/// time is unparseable or the gap is negative.
+Duration? _layover(FlightLeg prev, FlightLeg next) {
+  final arrive = DateTime.tryParse(prev.arriveTime);
+  final depart = DateTime.tryParse(next.departTime);
+  if (arrive == null || depart == null) return null;
+  final gap = depart.difference(arrive);
+  return gap.isNegative ? null : gap;
+}
+
+/// "Xh Ym" duration label, matching FlightOffer.durationLabel's style.
+String _hm(Duration d) {
+  final h = d.inHours;
+  final m = d.inMinutes % 60;
+  if (h == 0) return '${m}m';
+  if (m == 0) return '${h}h';
+  return '${h}h ${m}m';
+}

--- a/src/packages/flutter-app/lib/widgets/flight_offer_card.dart
+++ b/src/packages/flutter-app/lib/widgets/flight_offer_card.dart
@@ -1,0 +1,194 @@
+import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
+import '../models/flight_offer.dart';
+import 'airline_logo.dart';
+import 'flight_details_sheet.dart';
+
+/// A single ranked flight offer rendered as a card — airline(s), route, price,
+/// score, duration/stops, and a Book deep-link. Shared by the standalone
+/// FlightSearchScreen and the AI agent chat. Set [isBest] to highlight the top
+/// pick with a teal border and "BEST MATCH" badge.
+class FlightOfferCard extends StatelessWidget {
+  final FlightOffer offer;
+  final bool isBest;
+  const FlightOfferCard({super.key, required this.offer, this.isBest = false});
+
+  Future<void> _book(BuildContext context) async {
+    final url = offer.bookingUrl;
+    if (url == null || url.isEmpty) return;
+    final ok =
+        await launchUrl(Uri.parse(url), mode: LaunchMode.externalApplication);
+    if (!ok && context.mounted) {
+      ScaffoldMessenger.of(context)
+          .showSnackBar(const SnackBar(content: Text('Could not open link')));
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final accent = Colors.teal.shade700;
+
+    return Card(
+      elevation: isBest ? 4 : 1,
+      clipBehavior: Clip.antiAlias,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(12),
+        side: isBest ? BorderSide(color: accent, width: 2) : BorderSide.none,
+      ),
+      child: InkWell(
+        onTap: () => showFlightDetails(context, offer),
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              if (isBest)
+                Padding(
+                  padding: const EdgeInsets.only(bottom: 8),
+                  child: Container(
+                    padding:
+                        const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+                    decoration: BoxDecoration(
+                      color: accent,
+                      borderRadius: BorderRadius.circular(8),
+                    ),
+                    child: const Text('BEST MATCH',
+                        style: TextStyle(
+                            color: Colors.white,
+                            fontSize: 11,
+                            fontWeight: FontWeight.bold)),
+                  ),
+                ),
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Row(
+                          children: [
+                            AirlineLogo(url: offer.airlineLogoUrl, size: 22),
+                            if (offer.airlineLogoUrl != null &&
+                                offer.airlineLogoUrl!.isNotEmpty)
+                              const SizedBox(width: 8),
+                            Flexible(
+                              child: Text(
+                                offer.airlines.isEmpty
+                                    ? 'Flight'
+                                    : offer.airlines.join(', '),
+                                overflow: TextOverflow.ellipsis,
+                                style: theme.textTheme.titleMedium
+                                    ?.copyWith(fontWeight: FontWeight.bold),
+                              ),
+                            ),
+                          ],
+                        ),
+                        const SizedBox(height: 2),
+                        if (offer.segments.isNotEmpty) _Times(offer: offer),
+                      ],
+                    ),
+                  ),
+                  Column(
+                    crossAxisAlignment: CrossAxisAlignment.end,
+                    children: [
+                      Text(
+                        '${offer.currency} ${offer.price.toStringAsFixed(0)}',
+                        style: theme.textTheme.titleLarge?.copyWith(
+                            fontWeight: FontWeight.bold, color: accent),
+                      ),
+                      Text('score ${offer.score.toStringAsFixed(1)}',
+                          style: theme.textTheme.labelSmall?.copyWith(
+                              color: theme.colorScheme.onSurfaceVariant)),
+                    ],
+                  ),
+                ],
+              ),
+              const SizedBox(height: 12),
+              Row(
+                children: [
+                  _Stat(icon: Icons.schedule, label: offer.durationLabel),
+                  const SizedBox(width: 16),
+                  _Stat(
+                      icon: Icons.connecting_airports, label: offer.stopsLabel),
+                  if (offer.stops > 0) ...[
+                    const SizedBox(width: 6),
+                    Icon(Icons.chevron_right,
+                        size: 16, color: theme.colorScheme.onSurfaceVariant),
+                  ],
+                  const Spacer(),
+                  if (offer.bookingUrl != null)
+                    TextButton.icon(
+                      onPressed: () => _book(context),
+                      icon: const Icon(Icons.open_in_new, size: 16),
+                      label: const Text('Book'),
+                    ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Route line with departure/arrival clock times, e.g. "EWR 10:50 → GIG 00:47 +1".
+class _Times extends StatelessWidget {
+  final FlightOffer offer;
+  const _Times({required this.offer});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final muted = theme.colorScheme.onSurfaceVariant;
+    final from = offer.segments.first.from;
+    final to = offer.segments.last.to;
+    final bold = theme.textTheme.bodyMedium?.copyWith(
+        color: theme.colorScheme.onSurface, fontWeight: FontWeight.w600);
+    final base = theme.textTheme.bodyMedium?.copyWith(color: muted);
+
+    return Text.rich(
+      TextSpan(
+        style: base,
+        children: [
+          TextSpan(text: '$from '),
+          if (offer.departClock.isNotEmpty)
+            TextSpan(text: offer.departClock, style: bold),
+          const TextSpan(text: '  →  '),
+          TextSpan(text: '$to '),
+          if (offer.arriveClock.isNotEmpty)
+            TextSpan(text: offer.arriveClock, style: bold),
+          if (offer.arrivalDayOffset > 0)
+            TextSpan(
+              text: ' +${offer.arrivalDayOffset}',
+              style: theme.textTheme.labelSmall
+                  ?.copyWith(color: theme.colorScheme.error),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _Stat extends StatelessWidget {
+  final IconData icon;
+  final String label;
+  const _Stat({required this.icon, required this.label});
+
+  @override
+  Widget build(BuildContext context) {
+    final color = Theme.of(context).colorScheme.onSurfaceVariant;
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Icon(icon, size: 16, color: color),
+        const SizedBox(width: 4),
+        Text(label,
+            style:
+                Theme.of(context).textTheme.bodySmall?.copyWith(color: color)),
+      ],
+    );
+  }
+}

--- a/src/packages/flutter-app/lib/widgets/trip_map.dart
+++ b/src/packages/flutter-app/lib/widgets/trip_map.dart
@@ -7,7 +7,8 @@ import '../models/itinerary_item.dart';
 /// Plots a trip's itinerary on an OpenStreetMap: a numbered, category-tinted pin
 /// per place, a route line connecting them in itinerary order, auto-fit to the
 /// trip's extent. Tapping a pin calls [onPinTap] with that item's position.
-class TripMap extends StatelessWidget {
+/// When [selectedPosition] changes the camera recenters on that place.
+class TripMap extends StatefulWidget {
   final List<ItineraryItem> items;
   final int? selectedPosition;
   final void Function(int position)? onPinTap;
@@ -19,15 +20,83 @@ class TripMap extends StatelessWidget {
     this.onPinTap,
   });
 
+  @override
+  State<TripMap> createState() => _TripMapState();
+}
+
+class _TripMapState extends State<TripMap> {
+  final MapController _controller = MapController();
+
   static bool _hasCoords(ItineraryItem i) =>
       i.latitude != 0 || i.longitude != 0;
+
+  /// The coordinate of the currently selected itinerary item, if mappable.
+  LatLng? _selectedPoint() {
+    final sel = widget.selectedPosition;
+    if (sel == null) return null;
+    for (final it in widget.items) {
+      if (it.position == sel && _hasCoords(it)) {
+        return LatLng(it.latitude, it.longitude);
+      }
+    }
+    return null;
+  }
+
+  /// Frames the camera on the whole trip, mirroring the initial fit in [build] so
+  /// the reset button returns to the opening view. Called from a button tap when
+  /// the controller is already live, so it runs synchronously (a post-frame
+  /// deferral would not fire without a frame being scheduled).
+  void _fitToTrip(List<LatLng> points) {
+    if (points.isEmpty) return;
+    try {
+      if (points.length == 1) {
+        _controller.move(points.first, 13);
+      } else {
+        _controller.fitCamera(
+          CameraFit.bounds(
+            bounds: LatLngBounds.fromPoints(points),
+            padding: const EdgeInsets.all(32),
+          ),
+        );
+      }
+    } catch (_) {}
+  }
+
+  void _zoomBy(double delta) {
+    try {
+      _controller.move(
+        _controller.camera.center,
+        _controller.camera.zoom + delta,
+      );
+    } catch (_) {}
+  }
+
+  @override
+  void didUpdateWidget(covariant TripMap oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.selectedPosition != null &&
+        widget.selectedPosition != oldWidget.selectedPosition) {
+      final target = _selectedPoint();
+      if (target == null) return;
+      // Defer until after layout so the map controller is ready; zoom in enough
+      // to break the place out of any marker cluster.
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted) return;
+        var zoom = 15.0;
+        try {
+          zoom = _controller.camera.zoom < 15 ? 15 : _controller.camera.zoom;
+        } catch (_) {}
+        _controller.move(target, zoom);
+      });
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
 
     final mapped = <({ItineraryItem item, LatLng point})>[];
-    for (final it in items) {
+    for (final it in widget.items) {
       if (_hasCoords(it)) {
         mapped.add((item: it, point: LatLng(it.latitude, it.longitude)));
       }
@@ -46,58 +115,146 @@ class TripMap extends StatelessWidget {
     }
 
     final points = mapped.map((m) => m.point).toList();
+    final selected = _selectedPoint();
 
-    // Single point: bounds collapse, so center with a sensible zoom.
-    final MapOptions options = points.length == 1
-        ? MapOptions(initialCenter: points.first, initialZoom: 13)
-        : MapOptions(
-            initialCameraFit: CameraFit.bounds(
-              bounds: LatLngBounds.fromPoints(points),
-              padding: const EdgeInsets.all(32),
-            ),
-          );
+    // Wheel scroll stays with the page (the map lives inside a ListView);
+    // zooming is done via the on-map buttons or touch pinch.
+    const interaction = InteractionOptions(
+      flags: InteractiveFlag.all & ~InteractiveFlag.scrollWheelZoom,
+    );
 
-    return FlutterMap(
-      options: options,
+    // Center on the selected place when one is set (e.g. the map was just
+    // (re)built after a list tap); otherwise fit the whole trip.
+    final MapOptions options = selected != null
+        ? MapOptions(
+            initialCenter: selected,
+            initialZoom: 15,
+            interactionOptions: interaction,
+          )
+        : points.length == 1
+            // Single point: bounds collapse, so center with a sensible zoom.
+            ? MapOptions(
+                initialCenter: points.first,
+                initialZoom: 13,
+                interactionOptions: interaction,
+              )
+            : MapOptions(
+                initialCameraFit: CameraFit.bounds(
+                  bounds: LatLngBounds.fromPoints(points),
+                  padding: const EdgeInsets.all(32),
+                ),
+                interactionOptions: interaction,
+              );
+
+    return Stack(
       children: [
-        TileLayer(
-          urlTemplate: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
-          userAgentPackageName: 'com.travelrouteplanner.app',
+        FlutterMap(
+          mapController: _controller,
+          options: options,
+          children: [
+            TileLayer(
+              urlTemplate: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+              userAgentPackageName: 'com.travelrouteplanner.app',
+            ),
+            if (points.length >= 2)
+              PolylineLayer(
+                polylines: [
+                  Polyline(
+                    points: points,
+                    strokeWidth: 3,
+                    color: theme.colorScheme.primary.withValues(alpha: 0.7),
+                  ),
+                ],
+              ),
+            MarkerClusterLayerWidget(
+              options: MarkerClusterLayerOptions(
+                maxClusterRadius: 45,
+                size: const Size(40, 40),
+                padding: const EdgeInsets.all(40),
+                markers: [
+                  for (final m in mapped)
+                    Marker(
+                      point: m.point,
+                      width: 32,
+                      height: 32,
+                      child: _Pin(
+                        label: '${m.item.position + 1}',
+                        category: m.item.category,
+                        selected: widget.selectedPosition == m.item.position,
+                        onTap: widget.onPinTap == null
+                            ? null
+                            : () => widget.onPinTap!(m.item.position),
+                      ),
+                    ),
+                ],
+                builder: (context, clusterMarkers) =>
+                    _ClusterBubble(count: clusterMarkers.length),
+              ),
+            ),
+          ],
         ),
-        if (points.length >= 2)
-          PolylineLayer(
-            polylines: [
-              Polyline(
-                points: points,
-                strokeWidth: 3,
-                color: theme.colorScheme.primary.withValues(alpha: 0.7),
+        Positioned(
+          right: 8,
+          bottom: 8,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              _MapButton(
+                icon: Icons.add,
+                tooltip: 'Zoom in',
+                onTap: () => _zoomBy(1),
+              ),
+              const SizedBox(height: 8),
+              _MapButton(
+                icon: Icons.remove,
+                tooltip: 'Zoom out',
+                onTap: () => _zoomBy(-1),
+              ),
+              const SizedBox(height: 8),
+              _MapButton(
+                icon: Icons.center_focus_strong,
+                tooltip: 'Reset map',
+                onTap: () => _fitToTrip(points),
               ),
             ],
           ),
-        MarkerClusterLayerWidget(
-          options: MarkerClusterLayerOptions(
-            maxClusterRadius: 45,
-            size: const Size(40, 40),
-            padding: const EdgeInsets.all(40),
-            markers: [
-              for (final m in mapped)
-                Marker(
-                  point: m.point,
-                  width: 32,
-                  height: 32,
-                  child: _Pin(
-                    label: '${m.item.position + 1}',
-                    category: m.item.category,
-                    selected: selectedPosition == m.item.position,
-                    onTap: onPinTap == null ? null : () => onPinTap!(m.item.position),
-                  ),
-                ),
-            ],
-            builder: (context, clusterMarkers) =>
-                _ClusterBubble(count: clusterMarkers.length),
-          ),
         ),
       ],
+    );
+  }
+}
+
+/// A small circular control overlaid on the map (zoom in/out, reset).
+class _MapButton extends StatelessWidget {
+  final IconData icon;
+  final String tooltip;
+  final VoidCallback onTap;
+
+  const _MapButton({
+    required this.icon,
+    required this.tooltip,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    return Tooltip(
+      message: tooltip,
+      child: Material(
+        color: scheme.surface,
+        shape: const CircleBorder(),
+        elevation: 2,
+        child: InkWell(
+          customBorder: const CircleBorder(),
+          onTap: onTap,
+          child: SizedBox(
+            width: 36,
+            height: 36,
+            child: Icon(icon, size: 20, color: scheme.onSurface),
+          ),
+        ),
+      ),
     );
   }
 }

--- a/src/packages/flutter-app/pubspec.lock
+++ b/src/packages/flutter-app/pubspec.lock
@@ -326,6 +326,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.2"
+  flutter_svg:
+    dependency: "direct main"
+    description:
+      name: flutter_svg
+      sha256: "35882981abcbfb8c15b286f0cd690ff25bac12d95eff3e25ee207f37d4c42e7f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -552,6 +560,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
+  path_parsing:
+    dependency: transitive
+    description:
+      name: path_parsing
+      sha256: "883402936929eac138ee0a45da5b0f2c80f89913e6dc3bf77eb65b84b409c6ca"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
   path_provider:
     dependency: transitive
     description:
@@ -600,6 +616,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.0"
+  petitparser:
+    dependency: transitive
+    description:
+      name: petitparser
+      sha256: "91bd59303e9f769f108f8df05e371341b15d59e995e6806aefab827b58336675"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.2"
   platform:
     dependency: transitive
     description:
@@ -861,6 +885,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.5.3"
+  vector_graphics:
+    dependency: transitive
+    description:
+      name: vector_graphics
+      sha256: "2306c03da2ba81724afeb589c351ebbc0aa7d86005925be8f8735856dbe5e42d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.2"
+  vector_graphics_codec:
+    dependency: transitive
+    description:
+      name: vector_graphics_codec
+      sha256: "99fd9fbd34d9f9a32efd7b6a6aae14125d8237b10403b422a6a6dfeac2806146"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.13"
+  vector_graphics_compiler:
+    dependency: transitive
+    description:
+      name: vector_graphics_compiler
+      sha256: b9b3f391857781aa96acacef96066f2f49b4cd03cf9fce3ca4d8da2ef5ea129e
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.3"
   vector_math:
     dependency: transitive
     description:
@@ -933,6 +981,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
+  xml:
+    dependency: transitive
+    description:
+      name: xml
+      sha256: "971043b3a0d3da28727e40ed3e0b5d18b742fa5a68665cca88e74b7876d5e025"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.6.1"
   yaml:
     dependency: transitive
     description:
@@ -942,5 +998,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.8.0-0 <4.0.0"
-  flutter: ">=3.27.0"
+  dart: ">=3.9.0 <4.0.0"
+  flutter: ">=3.35.0"

--- a/src/packages/flutter-app/pubspec.yaml
+++ b/src/packages/flutter-app/pubspec.yaml
@@ -53,6 +53,9 @@ dependencies:
   # Open external Airbnb/Booking links
   url_launcher: ^6.3.0
 
+  # Render airline logos (Duffel serves them as SVG)
+  flutter_svg: ^2.0.10
+
   # Interactive map (OpenStreetMap tiles) for trip itineraries
   flutter_map: ^8.0.0
   flutter_map_marker_cluster: ^8.2.2

--- a/src/packages/flutter-app/test/trip_detail_grouping_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_grouping_test.dart
@@ -20,7 +20,8 @@ class _FakeTripsApiService extends TripsApiService {
   Future<Trip> getTrip(String id) async => trip;
 }
 
-ItineraryItem _item(int pos, String name, String address, String category) =>
+ItineraryItem _item(int pos, String name, String address, String category,
+        {int? day, String? city, String? dayTripFrom}) =>
     ItineraryItem(
       id: 'i$pos',
       position: pos,
@@ -30,6 +31,9 @@ ItineraryItem _item(int pos, String name, String address, String category) =>
       latitude: 0,
       longitude: 0,
       category: category,
+      day: day,
+      city: city,
+      dayTripFrom: dayTripFrom,
     );
 
 void main() {
@@ -42,10 +46,10 @@ void main() {
       createdAt: '2026-06-01',
       updatedAt: '2026-06-01',
       items: [
-        _item(0, "Brendal's Dive Center", 'Green Turtle Cay, Abaco, Bahamas', 'attraction'),
-        _item(1, "Miss Emily's Blue Bee Bar", 'Green Turtle Cay, Abaco, Bahamas', 'restaurant'),
-        _item(2, 'Dive Guana', 'Great Guana Cay, Abaco, Bahamas', 'attraction'),
-        _item(3, "Nipper's Beach Bar", 'Great Guana Cay, Abaco, Bahamas', 'restaurant'),
+        _item(0, "Brendal's Dive Center", 'Green Turtle Cay, Abaco, Bahamas', 'attraction', city: 'Green Turtle Cay'),
+        _item(1, "Miss Emily's Blue Bee Bar", 'Green Turtle Cay, Abaco, Bahamas', 'restaurant', city: 'Green Turtle Cay'),
+        _item(2, 'Dive Guana', 'Great Guana Cay, Abaco, Bahamas', 'attraction', city: 'Great Guana Cay'),
+        _item(3, "Nipper's Beach Bar", 'Great Guana Cay, Abaco, Bahamas', 'restaurant', city: 'Great Guana Cay'),
       ],
       // A stay in Green Turtle Cay supplies that group's dates; Great Guana has none.
       accommodations: const [
@@ -79,5 +83,57 @@ void main() {
     // Items still render under their groups.
     expect(find.text("Brendal's Dive Center"), findsOneWidget);
     expect(find.text('Dive Guana'), findsOneWidget);
+
+    // Legacy items (no day) render with no "Day N" sub-headers.
+    expect(find.textContaining('Day 1'), findsNothing);
+  });
+
+  testWidgets('items with day numbers render Day sub-sections and city dates',
+      (WidgetTester tester) async {
+    final trip = Trip(
+      id: 't2',
+      title: 'Europe',
+      status: 'planned',
+      startDate: '2026-06-10',
+      endDate: '2026-06-14',
+      createdAt: '2026-06-01',
+      updatedAt: '2026-06-01',
+      items: [
+        _item(0, 'Louvre', 'Paris, France', 'attraction', day: 1, city: 'Paris'),
+        _item(1, 'Café de Flore', 'Paris, France', 'restaurant', day: 1, city: 'Paris'),
+        // Day 2 in Paris is a day trip to Versailles.
+        _item(2, 'Versailles', 'Versailles, France', 'attraction',
+            day: 2, city: 'Versailles', dayTripFrom: 'Paris'),
+        // Day 4 jumps to Rome — day numbers stay continuous across the trip.
+        _item(3, 'Colosseum', 'Rome, Italy', 'attraction', day: 4, city: 'Rome'),
+      ],
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          tripsApiServiceProvider.overrideWithValue(_FakeTripsApiService(trip)),
+        ],
+        child: MaterialApp(home: TripDetailScreen(tripId: 't2')),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // City headers.
+    expect(find.text('Paris'), findsOneWidget);
+    expect(find.text('Rome'), findsOneWidget);
+
+    // Day sub-headers show the weekday + date derived from the trip start
+    // (day N -> startDate + (N-1)). Jun 10 2026 is a Wednesday.
+    expect(find.text('Wed, Jun 10'), findsOneWidget);
+    expect(find.text('Thu, Jun 11'), findsOneWidget);
+    expect(find.text('Sat, Jun 13'), findsOneWidget);
+
+    // Paris spans days 1–2 -> Jun 10 – Jun 11 next to the city name.
+    expect(find.text('Jun 10 – Jun 11'), findsOneWidget);
+
+    // The Versailles day trip still nests under its day.
+    expect(find.text('Day trip · Versailles'), findsOneWidget);
+    expect(find.text('Colosseum'), findsOneWidget);
   });
 }

--- a/src/packages/flutter-app/test/widget_test.dart
+++ b/src/packages/flutter-app/test/widget_test.dart
@@ -9,8 +9,12 @@ void main() {
     // Build our app and trigger a frame.
     await tester.pumpWidget(const ProviderScope(child: TravelRoutePlannerApp()));
 
-    // Verify that the app title is shown
-    expect(find.text('Travel Route Planner'), findsOneWidget);
-    expect(find.text('Welcome to Travel Route Planner'), findsOneWidget);
+    // The app builds its MaterialApp shell. On the first frame the AuthGate
+    // shows a loading splash while the stored session is checked (no network in
+    // the test env), then routes to sign-in/home — so we assert the shell builds
+    // cleanly rather than coupling to any one screen's text.
+    expect(find.byType(MaterialApp), findsOneWidget);
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    expect(tester.takeException(), isNull);
   });
 }


### PR DESCRIPTION
Five commits, split by feature (A→B→C→D) plus a test fix:

- **Duffel flight search API + dedicated search screen** — `/flights/search` (ranked by cost/time/balanced) and `/flights/airports` (IATA autocomplete) endpoints; Find-Flights UI with airport autocomplete and offer cards.
- **Home-airport preference + AI agent flight search** — `search_flights` agent tool (resolves city names → IATA, streams ranked option cards) and a saved `home_airport` traveler preference that defaults the flight origin.
- **Per-day itinerary numbering and grouping** — 1-based `day` field end-to-end; trip detail screen renders collapsible "Day N" sections with calendar dates; trips store a date span.
- **Trip-detail flight booking + map route lines** — booking checklist derives outbound/return flights from the home airport and opens Find Flights prefilled; trip map draws route polylines; home-screen "Find Flights" entry.
- **Test maintenance** — replaced a stale app smoke test that asserted long-gone welcome text (and had been failing on `main`) with a real "builds without crashing" check.

## Testing
- Go: `build` / `vet` / `test` pass
- Flutter: `analyze lib` clean (no errors in changed code); `flutter test` all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)