### PR TITLE
Show travel times between itinerary destinations

### DIFF
--- a/src/packages/api/route_optimizer.go
+++ b/src/packages/api/route_optimizer.go
@@ -39,6 +39,7 @@ type RouteRequest struct {
 	ReturnToStart bool       `json:"return_to_start"`       // Round trip vs one-way
 	StartTime     *string    `json:"start_time,omitempty"`  // Start time in format "15:04" (24-hour) or RFC3339
 	StartDate     *string    `json:"start_date,omitempty"`  // Start date in format "2006-01-02" or full datetime
+	PreserveOrder bool       `json:"preserve_order"`        // Skip NN/2-opt and keep input order; only compute per-leg timings
 }
 
 // LocationTiming represents timing information for a specific location
@@ -48,6 +49,7 @@ type LocationTiming struct {
 	VisitDurationMin int      `json:"visit_duration_minutes"`
 	DepartureTime    string   `json:"departure_time,omitempty"`
 	TravelToNextMin  int      `json:"travel_to_next_minutes"`
+	TravelToNextKm   float64  `json:"travel_to_next_km"`
 }
 
 // RouteResponse represents the optimized route result
@@ -586,18 +588,33 @@ func (ro *RouteOptimizer) OptimizeRoute(request RouteRequest) RouteResponse {
 		startIndex = *request.StartIndex
 	}
 
-	// Create initial route using nearest neighbor
-	initialRoute := ro.nearestNeighborRoute(startIndex, request.ReturnToStart)
-	originalDistance := ro.calculateRouteDistance(initialRoute, request.ReturnToStart)
+	var optimizedRoute []int
+	var originalDistance, optimizedDistance float64
+	algorithm := "nearest-neighbor + 2-opt"
 
-	// Optimize using 2-opt (limit iterations for performance)
-	maxIterations := 100
-	if len(request.Locations) > 20 {
-		maxIterations = 50 // Reduce iterations for larger problems
+	if request.PreserveOrder {
+		// Keep the caller-supplied order; only compute per-leg timings below.
+		optimizedRoute = make([]int, len(request.Locations))
+		for i := range optimizedRoute {
+			optimizedRoute[i] = i
+		}
+		optimizedDistance = ro.calculateRouteDistance(optimizedRoute, request.ReturnToStart)
+		originalDistance = optimizedDistance
+		algorithm = "preserve-order"
+	} else {
+		// Create initial route using nearest neighbor
+		initialRoute := ro.nearestNeighborRoute(startIndex, request.ReturnToStart)
+		originalDistance = ro.calculateRouteDistance(initialRoute, request.ReturnToStart)
+
+		// Optimize using 2-opt (limit iterations for performance)
+		maxIterations := 100
+		if len(request.Locations) > 20 {
+			maxIterations = 50 // Reduce iterations for larger problems
+		}
+
+		optimizedRoute = ro.optimizeWith2Opt(initialRoute, request.ReturnToStart, maxIterations)
+		optimizedDistance = ro.calculateRouteDistance(optimizedRoute, request.ReturnToStart)
 	}
-
-	optimizedRoute := ro.optimizeWith2Opt(initialRoute, request.ReturnToStart, maxIterations)
-	optimizedDistance := ro.calculateRouteDistance(optimizedRoute, request.ReturnToStart)
 
 	// Convert indices back to locations
 	result := make([]Location, len(optimizedRoute))
@@ -659,21 +676,22 @@ func (ro *RouteOptimizer) OptimizeRoute(request RouteRequest) RouteResponse {
 
 		// Calculate travel time to next location
 		travelToNext := 0
+		travelToNextKm := 0.0
 		if i < len(result)-1 {
 			// Find indices in original locations array
 			currentIdx := ro.findLocationIndex(location.ID)
 			nextIdx := ro.findLocationIndex(result[i+1].ID)
 			if currentIdx != -1 && nextIdx != -1 {
-				travelDistance := ro.getDistance(currentIdx, nextIdx)
-				travelToNext = int(math.Ceil(travelDistance / 40.0 * 60)) // 40 km/h average
+				travelToNextKm = ro.getDistance(currentIdx, nextIdx)
+				travelToNext = int(math.Ceil(travelToNextKm / 40.0 * 60)) // 40 km/h average
 			}
 		} else if request.ReturnToStart && len(result) > 1 {
 			// Travel time back to start
 			currentIdx := ro.findLocationIndex(location.ID)
 			startIdx := ro.findLocationIndex(result[0].ID)
 			if currentIdx != -1 && startIdx != -1 {
-				travelDistance := ro.getDistance(currentIdx, startIdx)
-				travelToNext = int(math.Ceil(travelDistance / 40.0 * 60))
+				travelToNextKm = ro.getDistance(currentIdx, startIdx)
+				travelToNext = int(math.Ceil(travelToNextKm / 40.0 * 60))
 			}
 		}
 
@@ -683,6 +701,7 @@ func (ro *RouteOptimizer) OptimizeRoute(request RouteRequest) RouteResponse {
 			VisitDurationMin: visitDuration,
 			DepartureTime:    departureTime,
 			TravelToNextMin:  travelToNext,
+			TravelToNextKm:   math.Round(travelToNextKm*100) / 100,
 		}
 
 		// Update current time for next location (departure time + travel time)
@@ -699,7 +718,7 @@ func (ro *RouteOptimizer) OptimizeRoute(request RouteRequest) RouteResponse {
 		TotalTripTimeMin:   totalTripTime,
 		LocationTimings:    locationTimings,
 		LocationCount:      len(request.Locations),
-		Algorithm:          "nearest-neighbor + 2-opt",
+		Algorithm:          algorithm,
 		OriginalDistance:   math.Round(originalDistance*100) / 100,
 		ImprovementPct:     math.Round(improvementPct*100) / 100,
 		Status:             "success",

--- a/src/packages/api/route_optimizer_test.go
+++ b/src/packages/api/route_optimizer_test.go
@@ -1,0 +1,59 @@
+package main
+
+import "testing"
+
+func f64(v float64) *float64 { return &v }
+
+// TestOptimizeRoutePreserveOrder verifies that with PreserveOrder set, the route
+// keeps the caller-supplied order (no NN/2-opt reshuffle) while still populating
+// per-leg travel timings. Locations carry coordinates so no Places API is hit.
+func TestOptimizeRoutePreserveOrder(t *testing.T) {
+	ro := NewRouteOptimizer(nil)
+
+	// Three points laid out so that the nearest-neighbor optimum would NOT match
+	// input order: A and C are close together, B is far away in the middle.
+	req := RouteRequest{
+		PreserveOrder: true,
+		Locations: []Location{
+			{ID: "a", Name: "A", Latitude: f64(40.7128), Longitude: f64(-74.0060)}, // NYC
+			{ID: "b", Name: "B", Latitude: f64(34.0522), Longitude: f64(-118.2437)}, // LA (far)
+			{ID: "c", Name: "C", Latitude: f64(40.7138), Longitude: f64(-74.0050)}, // ~NYC
+		},
+	}
+
+	resp := ro.OptimizeRoute(req)
+
+	if resp.Status != "success" {
+		t.Fatalf("expected success, got %q", resp.Status)
+	}
+	if resp.Algorithm != "preserve-order" {
+		t.Errorf("expected algorithm %q, got %q", "preserve-order", resp.Algorithm)
+	}
+
+	gotOrder := []string{}
+	for _, loc := range resp.OptimizedRoute {
+		gotOrder = append(gotOrder, loc.ID)
+	}
+	wantOrder := []string{"a", "b", "c"}
+	for i := range wantOrder {
+		if gotOrder[i] != wantOrder[i] {
+			t.Fatalf("order not preserved: want %v, got %v", wantOrder, gotOrder)
+		}
+	}
+
+	if len(resp.LocationTimings) != 3 {
+		t.Fatalf("expected 3 timings, got %d", len(resp.LocationTimings))
+	}
+	// Legs leaving A and B must have positive distance/time; the last item has none.
+	for i := 0; i < 2; i++ {
+		if resp.LocationTimings[i].TravelToNextMin <= 0 {
+			t.Errorf("timing[%d].TravelToNextMin = %d, want > 0", i, resp.LocationTimings[i].TravelToNextMin)
+		}
+		if resp.LocationTimings[i].TravelToNextKm <= 0 {
+			t.Errorf("timing[%d].TravelToNextKm = %f, want > 0", i, resp.LocationTimings[i].TravelToNextKm)
+		}
+	}
+	if resp.LocationTimings[2].TravelToNextMin != 0 {
+		t.Errorf("last leg TravelToNextMin = %d, want 0", resp.LocationTimings[2].TravelToNextMin)
+	}
+}

--- a/src/packages/flutter-app/lib/models/location_timing.dart
+++ b/src/packages/flutter-app/lib/models/location_timing.dart
@@ -19,12 +19,16 @@ class LocationTiming {
   @JsonKey(name: 'travel_to_next_minutes', defaultValue: 0)
   final int travelToNextMin;
 
+  @JsonKey(name: 'travel_to_next_km', defaultValue: 0.0)
+  final double travelToNextKm;
+
   const LocationTiming({
     required this.location,
     required this.arrivalTime,
     required this.departureTime,
     required this.visitDurationMin,
     required this.travelToNextMin,
+    this.travelToNextKm = 0.0,
   });
 
   factory LocationTiming.fromJson(Map<String, dynamic> json) =>
@@ -34,7 +38,7 @@ class LocationTiming {
 
   @override
   String toString() {
-    return 'LocationTiming(location: ${location.name}, arrivalTime: $arrivalTime, departureTime: $departureTime, visitDurationMin: $visitDurationMin, travelToNextMin: $travelToNextMin)';
+    return 'LocationTiming(location: ${location.name}, arrivalTime: $arrivalTime, departureTime: $departureTime, visitDurationMin: $visitDurationMin, travelToNextMin: $travelToNextMin, travelToNextKm: $travelToNextKm)';
   }
 
   @override
@@ -45,7 +49,8 @@ class LocationTiming {
         other.arrivalTime == arrivalTime &&
         other.departureTime == departureTime &&
         other.visitDurationMin == visitDurationMin &&
-        other.travelToNextMin == travelToNextMin;
+        other.travelToNextMin == travelToNextMin &&
+        other.travelToNextKm == travelToNextKm;
   }
 
   @override
@@ -54,6 +59,7 @@ class LocationTiming {
         arrivalTime.hashCode ^
         departureTime.hashCode ^
         visitDurationMin.hashCode ^
-        travelToNextMin.hashCode;
+        travelToNextMin.hashCode ^
+        travelToNextKm.hashCode;
   }
 }

--- a/src/packages/flutter-app/lib/models/location_timing.g.dart
+++ b/src/packages/flutter-app/lib/models/location_timing.g.dart
@@ -13,6 +13,7 @@ LocationTiming _$LocationTimingFromJson(Map<String, dynamic> json) =>
       departureTime: json['departure_time'] as String? ?? '',
       visitDurationMin: (json['visit_duration_minutes'] as num).toInt(),
       travelToNextMin: (json['travel_to_next_minutes'] as num?)?.toInt() ?? 0,
+      travelToNextKm: (json['travel_to_next_km'] as num?)?.toDouble() ?? 0.0,
     );
 
 Map<String, dynamic> _$LocationTimingToJson(LocationTiming instance) =>
@@ -22,4 +23,5 @@ Map<String, dynamic> _$LocationTimingToJson(LocationTiming instance) =>
       'departure_time': instance.departureTime,
       'visit_duration_minutes': instance.visitDurationMin,
       'travel_to_next_minutes': instance.travelToNextMin,
+      'travel_to_next_km': instance.travelToNextKm,
     };

--- a/src/packages/flutter-app/lib/models/route_request.dart
+++ b/src/packages/flutter-app/lib/models/route_request.dart
@@ -19,12 +19,18 @@ class RouteRequest {
   @JsonKey(name: 'start_date')
   final String? startDate;
 
+  /// When true, the API keeps the supplied location order and only computes
+  /// per-leg travel timings (no nearest-neighbor / 2-opt reordering).
+  @JsonKey(name: 'preserve_order')
+  final bool preserveOrder;
+
   const RouteRequest({
     required this.locations,
     this.startIndex,
     required this.returnToStart,
     this.startTime,
     this.startDate,
+    this.preserveOrder = false,
   });
 
   factory RouteRequest.fromJson(Map<String, dynamic> json) =>
@@ -38,6 +44,7 @@ class RouteRequest {
     bool? returnToStart,
     String? startTime,
     String? startDate,
+    bool? preserveOrder,
   }) {
     return RouteRequest(
       locations: locations ?? this.locations,
@@ -45,12 +52,13 @@ class RouteRequest {
       returnToStart: returnToStart ?? this.returnToStart,
       startTime: startTime ?? this.startTime,
       startDate: startDate ?? this.startDate,
+      preserveOrder: preserveOrder ?? this.preserveOrder,
     );
   }
 
   @override
   String toString() {
-    return 'RouteRequest(locations: ${locations.length} locations, startIndex: $startIndex, returnToStart: $returnToStart, startTime: $startTime, startDate: $startDate)';
+    return 'RouteRequest(locations: ${locations.length} locations, startIndex: $startIndex, returnToStart: $returnToStart, startTime: $startTime, startDate: $startDate, preserveOrder: $preserveOrder)';
   }
 
   @override
@@ -61,7 +69,8 @@ class RouteRequest {
         other.startIndex == startIndex &&
         other.returnToStart == returnToStart &&
         other.startTime == startTime &&
-        other.startDate == startDate;
+        other.startDate == startDate &&
+        other.preserveOrder == preserveOrder;
   }
 
   @override
@@ -70,6 +79,7 @@ class RouteRequest {
         startIndex.hashCode ^
         returnToStart.hashCode ^
         startTime.hashCode ^
-        startDate.hashCode;
+        startDate.hashCode ^
+        preserveOrder.hashCode;
   }
 }

--- a/src/packages/flutter-app/lib/models/route_request.g.dart
+++ b/src/packages/flutter-app/lib/models/route_request.g.dart
@@ -14,6 +14,7 @@ RouteRequest _$RouteRequestFromJson(Map<String, dynamic> json) => RouteRequest(
       returnToStart: json['return_to_start'] as bool,
       startTime: json['start_time'] as String?,
       startDate: json['start_date'] as String?,
+      preserveOrder: json['preserve_order'] as bool? ?? false,
     );
 
 Map<String, dynamic> _$RouteRequestToJson(RouteRequest instance) =>
@@ -23,4 +24,5 @@ Map<String, dynamic> _$RouteRequestToJson(RouteRequest instance) =>
       'return_to_start': instance.returnToStart,
       'start_time': instance.startTime,
       'start_date': instance.startDate,
+      'preserve_order': instance.preserveOrder,
     };

--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -6,9 +6,13 @@ import '../models/trip.dart';
 import '../models/itinerary_item.dart';
 import '../models/accommodation.dart';
 import '../models/booking_todo.dart';
+import '../models/location.dart';
+import '../models/location_timing.dart';
+import '../models/route_request.dart';
 import '../providers/trips_provider.dart';
 import '../providers/booking_todos_provider.dart';
 import '../providers/preferences_provider.dart';
+import '../providers/api_client_provider.dart';
 import '../widgets/booking_todo_card.dart';
 import '../widgets/trip_map.dart';
 import 'agent_screen.dart';
@@ -39,6 +43,10 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
   String? _homeAirport; // traveler's saved home airport (IATA), for outbound/return flights
   // todo_key -> flight leg, so a transport booking item can open Find Flights prefilled.
   Map<String, ({String origin, String destination, String? date})> _flightLegs = {};
+  // Per-leg travel timings keyed by the source item's position (the leg leaving
+  // that item, to the next item in itinerary order). Empty until computed and on
+  // any failure — travel times are an enhancement and never block the itinerary.
+  Map<int, LocationTiming> _travelByPos = {};
 
   /// Itinerary items matching the active category filter, used by both the map
   /// and the list so they stay in sync.
@@ -74,6 +82,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
       _homeAirport = ref.read(preferencesProvider).prefs?.homeAirport;
       if (mounted && (trip.items ?? const []).isNotEmpty) {
         await _syncBookingTodos(trip);
+        await _computeTravelTimes(trip);
       }
     } catch (e) {
       if (mounted) setState(() => _error = e.toString());
@@ -92,6 +101,46 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
       if (mounted) setState(() => _bookingTodos = todos);
     } catch (_) {
       // Non-fatal: keep whatever booking todos came with the trip.
+    }
+  }
+
+  /// Computes per-leg travel times for the itinerary in its existing display
+  /// order by calling /optimize-route in preserve-order mode (no reordering).
+  /// Results are keyed by the source item's position; failures leave the map
+  /// empty so the itinerary still renders.
+  Future<void> _computeTravelTimes(Trip trip) async {
+    final items = trip.items ?? const <ItineraryItem>[];
+    final withCoords =
+        items.where((i) => i.latitude != 0 || i.longitude != 0).length;
+    if (withCoords < 2) return;
+    try {
+      final locations = [
+        for (final it in items)
+          Location(
+            id: it.id,
+            name: it.name,
+            placeId: it.placeId,
+            address: it.address,
+            latitude: it.latitude,
+            longitude: it.longitude,
+            category: it.category,
+          ),
+      ];
+      final resp = await ref.read(apiClientProvider).optimizeRoute(
+            RouteRequest(
+              locations: locations,
+              returnToStart: false,
+              preserveOrder: true,
+            ),
+          );
+      final timings = resp.locationTimings;
+      final map = <int, LocationTiming>{};
+      for (var i = 0; i < items.length && i < timings.length; i++) {
+        map[items[i].position] = timings[i];
+      }
+      if (mounted) setState(() => _travelByPos = map);
+    } catch (_) {
+      // Non-fatal: leave travel times empty.
     }
   }
 
@@ -454,7 +503,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
       if (day != null) {
         final dayKey = '$cityKey#$day';
         final collapsed = _collapsedDays.contains(dayKey);
-        widgets.add(_daySubHeader(day, tripStart, theme, collapsed, () {
+        widgets.add(_daySubHeader(day, tripStart, theme, collapsed, _runTravelMin(run), () {
           setState(() {
             if (collapsed) {
               _collapsedDays.remove(dayKey);
@@ -473,40 +522,129 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
 
   /// Batches consecutive day-trip places (by town) under an indented
   /// "Day trip · <town>" sub-header so nearby towns read as excursions from the
-  /// hub city rather than separate stops.
+  /// hub city rather than separate stops. Inserts a within-city travel-time
+  /// connector between adjacent tiles of the same indent run.
   List<Widget> _buildDayTripWidgets(List<ItineraryItem> items, ThemeData theme) {
     final widgets = <Widget>[];
+    ItineraryItem? prev;
+    void addTile(ItineraryItem it, double indent) {
+      if (prev != null) {
+        final connector = _travelConnector(prev!, it, indent, theme);
+        if (connector != null) widgets.add(connector);
+      }
+      widgets.add(_itemTile(it, indent, theme));
+      prev = it;
+    }
+
     var i = 0;
     while (i < items.length) {
       final dt = items[i].dayTripFrom?.trim();
       if (dt != null && dt.isNotEmpty) {
         final town = _cityOf(items[i]) ?? 'Day trip';
         widgets.add(_dayTripSubHeader(town, theme));
+        prev = null; // don't draw a connector across the sub-header
         while (i < items.length) {
           final it = items[i];
           final d = it.dayTripFrom?.trim();
           if (d != null && d.isNotEmpty && _cityOf(it) == town) {
-            widgets.add(_itemTile(it, 32, theme));
+            addTile(it, 32);
             i++;
           } else {
             break;
           }
         }
+        prev = null; // leaving the day-trip batch
       } else {
-        widgets.add(_itemTile(items[i], 12, theme));
+        addTile(items[i], 12);
         i++;
       }
     }
     return widgets;
   }
 
+  /// A small "↓ 12 min · 4.3 km" row shown between two consecutive itinerary
+  /// tiles, but only for within-city hops (same hub, truly adjacent in the
+  /// itinerary order). Returns null when it shouldn't render — including while a
+  /// category filter is active, since filtered tiles aren't globally adjacent.
+  Widget? _travelConnector(
+      ItineraryItem from, ItineraryItem to, double indentLeft, ThemeData theme) {
+    if (_itemFilter != 'all') return null;
+    if (to.position != from.position + 1) return null;
+    if (_hubOf(from) != _hubOf(to)) return null;
+    final timing = _travelByPos[from.position];
+    if (timing == null || timing.travelToNextMin <= 0) return null;
+
+    final km = timing.travelToNextKm;
+    final dist = km > 0 ? ' · ${km.toStringAsFixed(1)} km' : '';
+    final muted = theme.colorScheme.onSurfaceVariant;
+    final icon = km > 0 && km <= 1.2
+        ? Icons.directions_walk
+        : Icons.directions_car_outlined;
+    return Padding(
+      padding: EdgeInsets.only(left: indentLeft + 28, top: 2, bottom: 2),
+      child: Row(
+        children: [
+          Icon(icon, size: 14, color: muted),
+          const SizedBox(width: 6),
+          Text(
+            '${_fmtTravel(timing.travelToNextMin)}$dist',
+            style: theme.textTheme.bodySmall?.copyWith(color: muted),
+          ),
+        ],
+      ),
+    );
+  }
+
+  /// Total within-city travel time (minutes) across the consecutive legs of a
+  /// day's run. Zero while a category filter is active (legs aren't adjacent).
+  int _runTravelMin(List<ItineraryItem> run) {
+    if (_itemFilter != 'all') return 0;
+    var total = 0;
+    for (var k = 0; k < run.length - 1; k++) {
+      final a = run[k];
+      final b = run[k + 1];
+      if (b.position == a.position + 1 && _hubOf(a) == _hubOf(b)) {
+        total += _travelByPos[a.position]?.travelToNextMin ?? 0;
+      }
+    }
+    return total;
+  }
+
+  /// Travel-time labels for the trip map, keyed by the source item's position:
+  /// one entry per within-city leg (same hub, adjacent in itinerary order).
+  /// Empty while a category filter is active (legs aren't globally adjacent).
+  Map<int, String> _segmentLabels() {
+    final trip = _trip;
+    if (_itemFilter != 'all' || trip == null) return const {};
+    final items = trip.items ?? const <ItineraryItem>[];
+    final byPos = {for (final it in items) it.position: it};
+    final out = <int, String>{};
+    for (final it in items) {
+      final next = byPos[it.position + 1];
+      if (next == null || _hubOf(it) != _hubOf(next)) continue;
+      final t = _travelByPos[it.position];
+      if (t == null || t.travelToNextMin <= 0) continue;
+      out[it.position] = _fmtTravel(t.travelToNextMin);
+    }
+    return out;
+  }
+
+  /// Formats a travel duration: "45 min", "1h", or "1h 20m".
+  String _fmtTravel(int min) {
+    if (min < 60) return '$min min';
+    final h = min ~/ 60;
+    final m = min % 60;
+    return m == 0 ? '${h}h' : '${h}h ${m}m';
+  }
+
   /// Day section header: shows the calendar date (day N -> startDate + (N-1))
   /// when the trip start is known, otherwise falls back to "Day N".
   Widget _daySubHeader(int day, DateTime? tripStart, ThemeData theme,
-      bool collapsed, VoidCallback onTap) {
+      bool collapsed, int travelMin, VoidCallback onTap) {
     final label = tripStart != null
         ? _fmtDayHeader(tripStart.add(Duration(days: day - 1)))
         : 'Day $day';
+    final muted = theme.colorScheme.onSurfaceVariant;
     return InkWell(
       onTap: onTap,
       child: Padding(
@@ -524,6 +662,15 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
                 ),
               ),
             ),
+            if (travelMin > 0) ...[
+              Icon(Icons.directions_car_outlined, size: 14, color: muted),
+              const SizedBox(width: 4),
+              Text(
+                '${_fmtTravel(travelMin)} travel',
+                style: theme.textTheme.bodySmall?.copyWith(color: muted),
+              ),
+              const SizedBox(width: 8),
+            ],
             Icon(
               collapsed ? Icons.chevron_right : Icons.expand_more,
               size: 18,
@@ -948,6 +1095,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
                               child: TripMap(
                                 items: _filtered(trip),
                                 selectedPosition: _selectedPosition,
+                                segmentLabels: _segmentLabels(),
                                 onPinTap: (pos) {
                                   setState(() => _selectedPosition = pos);
                                   final it = trip.items!.firstWhere((i) => i.position == pos);

--- a/src/packages/flutter-app/lib/widgets/trip_map.dart
+++ b/src/packages/flutter-app/lib/widgets/trip_map.dart
@@ -13,11 +13,16 @@ class TripMap extends StatefulWidget {
   final int? selectedPosition;
   final void Function(int position)? onPinTap;
 
+  /// Label text (e.g. "12 min") for the within-city leg leaving the item at the
+  /// given position. Drawn at the midpoint of that segment. Empty => no labels.
+  final Map<int, String> segmentLabels;
+
   const TripMap({
     super.key,
     required this.items,
     this.selectedPosition,
     this.onPinTap,
+    this.segmentLabels = const {},
   });
 
   @override
@@ -117,6 +122,28 @@ class _TripMapState extends State<TripMap> {
     final points = mapped.map((m) => m.point).toList();
     final selected = _selectedPoint();
 
+    // Travel-time labels at the midpoint of each within-city leg (only between
+    // truly adjacent itinerary stops that are both mapped).
+    final labelMarkers = <Marker>[];
+    for (var k = 0; k < mapped.length - 1; k++) {
+      final a = mapped[k];
+      final b = mapped[k + 1];
+      if (b.item.position != a.item.position + 1) continue;
+      final label = widget.segmentLabels[a.item.position];
+      if (label == null) continue;
+      labelMarkers.add(
+        Marker(
+          point: LatLng(
+            (a.point.latitude + b.point.latitude) / 2,
+            (a.point.longitude + b.point.longitude) / 2,
+          ),
+          width: 70,
+          height: 22,
+          child: _SegmentLabel(text: label),
+        ),
+      );
+    }
+
     // Wheel scroll stays with the page (the map lives inside a ListView);
     // zooming is done via the on-map buttons or touch pinch.
     const interaction = InteractionOptions(
@@ -166,6 +193,7 @@ class _TripMapState extends State<TripMap> {
                   ),
                 ],
               ),
+            if (labelMarkers.isNotEmpty) MarkerLayer(markers: labelMarkers),
             MarkerClusterLayerWidget(
               options: MarkerClusterLayerOptions(
                 maxClusterRadius: 45,
@@ -252,6 +280,37 @@ class _MapButton extends StatelessWidget {
             width: 36,
             height: 36,
             child: Icon(icon, size: 20, color: scheme.onSurface),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// A small pill showing a leg's travel time, centered on the route line.
+class _SegmentLabel extends StatelessWidget {
+  final String text;
+  const _SegmentLabel({required this.text});
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    return Center(
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+        decoration: BoxDecoration(
+          color: scheme.surface.withValues(alpha: 0.9),
+          borderRadius: BorderRadius.circular(10),
+          border: Border.all(color: scheme.outlineVariant),
+        ),
+        child: Text(
+          text,
+          maxLines: 1,
+          overflow: TextOverflow.clip,
+          style: TextStyle(
+            color: scheme.onSurface,
+            fontSize: 10,
+            fontWeight: FontWeight.w600,
           ),
         ),
       ),


### PR DESCRIPTION
## Summary
Surfaces per-leg travel times in the trip detail UI, reusing the existing `/optimize-route` haversine timings. A new `preserve_order` flag makes the endpoint return timings in the itinerary's display order instead of reordering the route.

## Changes
- **API** (`route_optimizer.go`): `preserve_order` on `RouteRequest` (skips NN/2-opt, keeps input order); per-leg `TravelToNextKm` on `LocationTiming`; new preserve-order unit test.
- **Flutter**: travel-time connectors between within-city tiles (`↓ 12 min · 4.3 km`), per-day travel total in the day sub-header, and midpoint travel-time labels on the map polyline. Within-city hops only; suppressed while a category filter is active.

## Implementation note
Travel times are computed imperatively in `trip_detail_screen` after the trip loads (matching how the screen already loads its trip into local state), rather than via a separate provider. Failures leave the timings empty so the itinerary always renders.

## Verification
- `go vet` + `go test` pass (incl. new preserve-order test)
- `flutter analyze` clean, `flutter test` passes
- Verified manually in the browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)