### PR TITLE
Distance-optimized AI itineraries + recent-trip home tile

### DIFF
--- a/src/packages/api/itinerary_optimizer.go
+++ b/src/packages/api/itinerary_optimizer.go
@@ -1,0 +1,101 @@
+package main
+
+import "strconv"
+
+// reorderItineraryByDistance reorders the places Claude returns so that
+// geographically close stops are consecutive, while leaving Claude's day and
+// time-of-day scheduling untouched. Reordering happens only within each
+// (day, time_of_day, day_trip_from) block, so meal timing and pacing are
+// preserved and the order can never read as e.g. dinner before breakfast.
+//
+// Each place's tags travel with its map entry (entries are moved whole), so
+// day/time_of_day/city/category survive. Blocks with fewer than two
+// coordinate-bearing places, or whose places lack coordinates, are left in
+// their original order.
+func reorderItineraryByDistance(locations []map[string]any) []map[string]any {
+	if len(locations) < 2 {
+		return locations
+	}
+
+	// Group indices into blocks keyed by (day, time_of_day, day_trip_from),
+	// preserving the first-seen order of both blocks and their members.
+	type blockKey struct {
+		day         string
+		timeOfDay   string
+		dayTripFrom string
+	}
+	keyOf := func(loc map[string]any) blockKey {
+		var k blockKey
+		if v, ok := loc["day"].(float64); ok {
+			k.day = strconv.FormatFloat(v, 'f', -1, 64)
+		}
+		if s, ok := loc["time_of_day"].(string); ok {
+			k.timeOfDay = s
+		}
+		if s, ok := loc["day_trip_from"].(string); ok {
+			k.dayTripFrom = s
+		}
+		return k
+	}
+
+	var order []blockKey
+	blocks := make(map[blockKey][]int)
+	for i, loc := range locations {
+		k := keyOf(loc)
+		if _, seen := blocks[k]; !seen {
+			order = append(order, k)
+		}
+		blocks[k] = append(blocks[k], i)
+	}
+
+	result := make([]map[string]any, 0, len(locations))
+	for _, k := range order {
+		idxs := blocks[k]
+		result = append(result, optimizeBlockOrder(locations, idxs)...)
+	}
+	return result
+}
+
+// optimizeBlockOrder returns the maps at idxs reordered to shorten the walking
+// path between them. If fewer than two of them have coordinates it returns them
+// in their original order.
+func optimizeBlockOrder(locations []map[string]any, idxs []int) []map[string]any {
+	locs := make([]Location, 0, len(idxs))
+	for _, gi := range idxs {
+		lat, latOK := locations[gi]["latitude"].(float64)
+		lng, lngOK := locations[gi]["longitude"].(float64)
+		if !latOK || !lngOK {
+			// A coordinate-less place means we can't optimize this block
+			// reliably; keep Claude's order.
+			return collect(locations, idxs)
+		}
+		locs = append(locs, Location{
+			ID:        strconv.Itoa(len(locs)),
+			Latitude:  &lat,
+			Longitude: &lng,
+		})
+	}
+	if len(locs) < 2 {
+		return collect(locations, idxs)
+	}
+
+	// Reuse the location-route optimizer's lower-level steps directly; we only
+	// need the reordered sequence, not its timing/Places-resolution machinery.
+	ro := NewRouteOptimizer(locs)
+	route := ro.optimizeWith2Opt(ro.nearestNeighborRoute(0, false), false, 100)
+
+	out := make([]map[string]any, 0, len(idxs))
+	for _, local := range route {
+		out = append(out, locations[idxs[local]])
+	}
+	return out
+}
+
+// collect returns the maps at idxs in their original order.
+func collect(locations []map[string]any, idxs []int) []map[string]any {
+	out := make([]map[string]any, 0, len(idxs))
+	for _, gi := range idxs {
+		out = append(out, locations[gi])
+	}
+	return out
+}

--- a/src/packages/api/itinerary_optimizer_test.go
+++ b/src/packages/api/itinerary_optimizer_test.go
@@ -1,0 +1,86 @@
+package main
+
+import "testing"
+
+// place builds an itinerary-location map the way create_itinerary's JSON
+// decodes it (numbers as float64).
+func place(name string, day float64, timeOfDay string, lat, lng float64) map[string]any {
+	return map[string]any{
+		"name":        name,
+		"day":         day,
+		"time_of_day": timeOfDay,
+		"latitude":    lat,
+		"longitude":   lng,
+	}
+}
+
+func names(locs []map[string]any) []string {
+	out := make([]string, len(locs))
+	for i, l := range locs {
+		out[i], _ = l["name"].(string)
+	}
+	return out
+}
+
+// Within a single day/time-of-day block, three colinear places handed over in a
+// back-and-forth order should be reordered into the shorter monotonic walk.
+func TestReorderItineraryByDistanceShortensBlock(t *testing.T) {
+	in := []map[string]any{
+		place("A", 1, "morning", 0.0, 0.0),
+		place("C", 1, "morning", 0.0, 2.0), // far end first => detour
+		place("B", 1, "morning", 0.0, 1.0),
+	}
+	got := names(reorderItineraryByDistance(in))
+	want := []string{"A", "B", "C"}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("order = %v, want %v", got, want)
+		}
+	}
+}
+
+// Tags must survive the reordering: each place keeps its own day/time_of_day.
+func TestReorderItineraryByDistancePreservesTags(t *testing.T) {
+	in := []map[string]any{
+		place("A", 2, "afternoon", 0.0, 0.0),
+		place("B", 2, "afternoon", 0.0, 1.0),
+	}
+	for _, l := range reorderItineraryByDistance(in) {
+		if l["day"].(float64) != 2 || l["time_of_day"].(string) != "afternoon" {
+			t.Fatalf("tags lost on %v: %+v", l["name"], l)
+		}
+	}
+}
+
+// Different time-of-day blocks must never interleave, and block order is kept.
+func TestReorderItineraryByDistanceKeepsBlocksSeparate(t *testing.T) {
+	in := []map[string]any{
+		place("m1", 1, "morning", 0.0, 0.0),
+		place("e1", 1, "evening", 0.0, 5.0),
+		place("m2", 1, "morning", 0.0, 0.1),
+		place("e2", 1, "evening", 0.0, 5.1),
+	}
+	got := names(reorderItineraryByDistance(in))
+	// morning block (m1,m2 in some order) comes wholly before the evening block.
+	morning := map[string]bool{"m1": true, "m2": true}
+	if !morning[got[0]] || !morning[got[1]] || morning[got[2]] || morning[got[3]] {
+		t.Fatalf("blocks interleaved or reordered: %v", got)
+	}
+}
+
+// A block containing a coordinate-less place is left in Claude's order.
+func TestReorderItineraryByDistanceSkipsMissingCoords(t *testing.T) {
+	noCoords := map[string]any{"name": "X", "day": 1.0, "time_of_day": "morning"}
+	in := []map[string]any{
+		place("A", 1, "morning", 0.0, 0.0),
+		noCoords,
+		place("C", 1, "morning", 0.0, 2.0),
+	}
+	got := names(reorderItineraryByDistance(in))
+	want := []string{"A", "X", "C"}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("order = %v, want %v (block with missing coords should be untouched)", got, want)
+		}
+	}
+}

--- a/src/packages/api/plan_handler.go
+++ b/src/packages/api/plan_handler.go
@@ -319,6 +319,10 @@ func planHandler(w http.ResponseWriter, r *http.Request) {
 				}
 				json.Unmarshal(variant.Input, &in)
 
+				// Distance-optimize the walking order within each day/time-of-day
+				// block, leaving Claude's day and time-of-day assignments intact.
+				in.Locations = reorderItineraryByDistance(in.Locations)
+
 				donePayload := map[string]any{"locations": in.Locations, "summary": in.Summary}
 				// Persist the trip only for signed-in callers; anonymous sessions
 				// stay ephemeral (no trip_id in the done event).

--- a/src/packages/flutter-app/lib/providers/recent_trip_provider.dart
+++ b/src/packages/flutter-app/lib/providers/recent_trip_provider.dart
@@ -1,0 +1,68 @@
+import 'dart:convert';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'auth_provider.dart';
+
+/// The trip detail screen the user last opened, remembered on-device so the
+/// home screen can offer a one-tap way back into it.
+class RecentTrip {
+  final String tripId;
+  final String title;
+
+  const RecentTrip({required this.tripId, required this.title});
+}
+
+class RecentTripNotifier extends StateNotifier<RecentTrip?> {
+  /// Signed-in user the stored value belongs to; null when anonymous, in which
+  /// case nothing is recorded (trips require sign-in anyway).
+  final String? _userId;
+
+  RecentTripNotifier(this._userId) : super(null);
+
+  String get _key => 'recent_trip.$_userId';
+
+  /// Restore the last viewed trip for this user from device storage.
+  Future<void> load() async {
+    if (_userId == null) return;
+    final prefs = await SharedPreferences.getInstance();
+    final raw = prefs.getString(_key);
+    if (raw == null) return;
+    try {
+      final m = jsonDecode(raw) as Map<String, dynamic>;
+      final id = m['id'] as String?;
+      final title = m['title'] as String?;
+      if (id != null && id.isNotEmpty && title != null) {
+        state = RecentTrip(tripId: id, title: title);
+      }
+    } catch (_) {
+      // Malformed value — ignore and stay empty.
+    }
+  }
+
+  /// Remember [tripId] as the most recently viewed trip. Call after a trip
+  /// detail screen successfully loads.
+  Future<void> record(String tripId, String title) async {
+    if (_userId == null) return;
+    state = RecentTrip(tripId: tripId, title: title);
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_key, jsonEncode({'id': tripId, 'title': title}));
+  }
+
+  /// Forget the recent trip if it points at [tripId] (used when a trip is
+  /// deleted, so the home tile never targets a dead trip).
+  Future<void> clearIfMatches(String tripId) async {
+    if (_userId == null || state?.tripId != tripId) return;
+    state = null;
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove(_key);
+  }
+}
+
+/// Rebuilds on sign-in/out so each user only ever sees their own recent trip.
+final recentTripProvider =
+    StateNotifierProvider<RecentTripNotifier, RecentTrip?>((ref) {
+  final userId = ref.watch(authProvider.select((s) => s.user?.id));
+  return RecentTripNotifier(userId)..load();
+});

--- a/src/packages/flutter-app/lib/screens/home_screen.dart
+++ b/src/packages/flutter-app/lib/screens/home_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
 import '../providers/auth_provider.dart';
+import '../providers/recent_trip_provider.dart';
 import '../widgets/gradient_app_bar.dart';
 import 'route_optimizer_screen.dart';
 import 'country_optimizer_screen.dart';
@@ -9,6 +10,7 @@ import 'agent_screen.dart';
 import 'airbnb_parser_screen.dart';
 import 'flight_search_screen.dart';
 import 'trips_list_screen.dart';
+import 'trip_detail_screen.dart';
 import 'preferences_screen.dart';
 
 class HomeScreen extends ConsumerWidget {
@@ -26,6 +28,7 @@ class HomeScreen extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final theme = Theme.of(context);
     final user = ref.watch(authProvider).user;
+    final recentTrip = ref.watch(recentTripProvider);
 
     return Scaffold(
       appBar: GradientAppBar(
@@ -104,6 +107,22 @@ class HomeScreen extends ConsumerWidget {
               ),
 
               const SizedBox(height: 16),
+
+              // Most recently viewed trip — hidden until one has been opened.
+              if (recentTrip != null) ...[
+                _ToolRow(
+                  icon: Icons.history,
+                  color: Colors.teal.shade700,
+                  title: 'Continue planning',
+                  description: recentTrip.title,
+                  onTap: () => Navigator.of(context).push(
+                    MaterialPageRoute(
+                      builder: (_) => TripDetailScreen(tripId: recentTrip.tripId),
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 12),
+              ],
 
               // My Trips
               _ToolRow(

--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -10,6 +10,7 @@ import '../models/location.dart';
 import '../models/location_timing.dart';
 import '../models/route_request.dart';
 import '../providers/trips_provider.dart';
+import '../providers/recent_trip_provider.dart';
 import '../providers/booking_todos_provider.dart';
 import '../providers/preferences_provider.dart';
 import '../providers/api_client_provider.dart';
@@ -74,6 +75,8 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
           _trip = trip;
           _bookingTodos = trip.bookingTodos ?? [];
         });
+        // Remember this as the most recently viewed trip (home screen tile).
+        ref.read(recentTripProvider.notifier).record(trip.id, trip.title);
       }
       // Load the home airport so the booking checklist can derive the outbound
       // and return flights (no-op / null for anonymous sessions).
@@ -354,6 +357,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
     if (confirm == true) {
       try {
         await ref.read(tripsProvider.notifier).deleteTrip(widget.tripId);
+        await ref.read(recentTripProvider.notifier).clearIfMatches(widget.tripId);
         if (mounted) Navigator.of(context).pop();
       } catch (e) {
         _showSnack('Delete failed: $e');

--- a/src/packages/flutter-app/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/src/packages/flutter-app/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -7,10 +7,12 @@ import Foundation
 
 import flutter_secure_storage_macos
 import path_provider_foundation
+import shared_preferences_foundation
 import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FlutterSecureStoragePlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStoragePlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
+  SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
 }

--- a/src/packages/flutter-app/pubspec.lock
+++ b/src/packages/flutter-app/pubspec.lock
@@ -688,6 +688,62 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.6.1"
+  shared_preferences:
+    dependency: "direct main"
+    description:
+      name: shared_preferences
+      sha256: c3025c5534b01739267eb7d76959bbc25a6d10f6988e1c2a3036940133dd10bf
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.5"
+  shared_preferences_android:
+    dependency: transitive
+    description:
+      name: shared_preferences_android
+      sha256: e8d4762b1e2e8578fc4d0fd548cebf24afd24f49719c08974df92834565e2c53
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.23"
+  shared_preferences_foundation:
+    dependency: transitive
+    description:
+      name: shared_preferences_foundation
+      sha256: "4e7eaffc2b17ba398759f1151415869a34771ba11ebbccd1b0145472a619a64f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.6"
+  shared_preferences_linux:
+    dependency: transitive
+    description:
+      name: shared_preferences_linux
+      sha256: "580abfd40f415611503cae30adf626e6656dfb2f0cee8f465ece7b6defb40f2f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  shared_preferences_platform_interface:
+    dependency: transitive
+    description:
+      name: shared_preferences_platform_interface
+      sha256: "649dc798a33931919ea356c4305c2d1f81619ea6e92244070b520187b5140ef9"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.2"
+  shared_preferences_web:
+    dependency: transitive
+    description:
+      name: shared_preferences_web
+      sha256: c49bd060261c9a3f0ff445892695d6212ff603ef3115edbb448509d407600019
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.3"
+  shared_preferences_windows:
+    dependency: transitive
+    description:
+      name: shared_preferences_windows
+      sha256: "94ef0f72b2d71bc3e700e025db3710911bd51a71cefb65cc609dd0d9a982e3c1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
   shelf:
     dependency: transitive
     description:

--- a/src/packages/flutter-app/pubspec.yaml
+++ b/src/packages/flutter-app/pubspec.yaml
@@ -50,6 +50,9 @@ dependencies:
   # Secure on-device storage for the session token
   flutter_secure_storage: ^9.2.2
 
+  # Plain on-device storage (last viewed trip)
+  shared_preferences: ^2.3.0
+
   # Open external Airbnb/Booking links
   url_launcher: ^6.3.0
 

--- a/src/packages/flutter-app/test/recent_trip_provider_test.dart
+++ b/src/packages/flutter-app/test/recent_trip_provider_test.dart
@@ -1,0 +1,56 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:travel_route_planner/providers/recent_trip_provider.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('record then load round-trips the trip under the user-scoped key', () async {
+    final writer = RecentTripNotifier('user-1');
+    await writer.record('trip-42', 'Luxury Paris Weekend');
+
+    final reader = RecentTripNotifier('user-1');
+    await reader.load();
+    expect(reader.state?.tripId, 'trip-42');
+    expect(reader.state?.title, 'Luxury Paris Weekend');
+  });
+
+  test('recent trip is scoped per user', () async {
+    final u1 = RecentTripNotifier('user-1');
+    await u1.record('trip-42', 'Paris');
+
+    final u2 = RecentTripNotifier('user-2');
+    await u2.load();
+    expect(u2.state, isNull);
+  });
+
+  test('anonymous (null userId) never records', () async {
+    final anon = RecentTripNotifier(null);
+    await anon.record('trip-42', 'Paris');
+    expect(anon.state, isNull);
+
+    await anon.load();
+    expect(anon.state, isNull);
+  });
+
+  test('clearIfMatches clears only on a matching id', () async {
+    final n = RecentTripNotifier('user-1');
+    await n.record('trip-42', 'Paris');
+
+    await n.clearIfMatches('other-trip');
+    expect(n.state?.tripId, 'trip-42');
+
+    await n.clearIfMatches('trip-42');
+    expect(n.state, isNull);
+
+    // The cleared value must not resurrect on reload.
+    final reader = RecentTripNotifier('user-1');
+    await reader.load();
+    expect(reader.state, isNull);
+  });
+}


### PR DESCRIPTION
## Summary

Two features, one commit each:

### 1. Distance-optimize AI itinerary ordering (`src/packages/api`)
- Previously the `create_itinerary` location order was taken verbatim from Claude; the Nearest Neighbor + 2-Opt optimizer was only reachable via the manual Route Optimizer screen.
- New `reorderItineraryByDistance` reorders places **within each (day, time_of_day, day_trip_from) block** right after Claude's tool call, before persistence and the SSE `done` event — nearby stops become consecutive while Claude's day/meal-time scheduling is preserved (never produces dinner-before-breakfast).
- Blocks with <2 coordinate-bearing places keep Claude's order. Reuses the existing optimizer's `nearestNeighborRoute` + `optimizeWith2Opt`.

### 2. "Continue planning" home tile (`src/packages/flutter-app`)
- Opening a trip detail screen records it (id + title) in `shared_preferences`, keyed per signed-in user id.
- The home page shows a tile above "My Trips" that jumps straight back to the most recently viewed trip; hidden until one has been viewed, cleared when that trip is deleted.

## Testing
- `go test ./... && go vet ./...` — pass (4 new unit tests covering block shortening, tag preservation, block separation, missing-coords skip)
- `flutter analyze && flutter test` — pass (4 new tests: persistence round-trip, per-user scoping, anonymous no-op, clear-on-delete)
- Verified manually in the running app

🤖 Generated with [Claude Code](https://claude.com/claude-code)