### PR TITLE
feat: manual itinerary add + in-place AI section refinement

### DIFF
--- a/specs/itinerary-editing/plan.md
+++ b/specs/itinerary-editing/plan.md
@@ -1,0 +1,146 @@
+# Plan: Itinerary Editing — Manual Add & In-Place AI Section Refinement
+
+> **HOW.** Translates `spec.md` into a file-level technical approach. Every
+> decision should trace back to an acceptance criterion. See `../../CLAUDE.md`
+> for repo conventions referenced below — don't restate them, point to them.
+
+## Technical Approach
+
+Two independent writers for `itinerary_items`, sharing one coercion helper so
+they can't drift:
+
+1. **Manual add** — a small REST sub-resource handler
+   (`POST /trips/{id}/items`) following the accommodations pattern: ownership
+   guard, validation against the existing category/time-of-day allow-lists,
+   position computed server-side (end of the chosen day), positions shifted in
+   a transaction.
+2. **Section refinement** — the existing `/plan` SSE agent, bound to a trip by
+   a new `trip_id` request field. When bound, the `create_itinerary` tool is
+   **replaced** by `update_itinerary_section` (deterministically prevents new
+   version rows). The tool replaces one section's items in place via a
+   delete-all + reinsert rewrite (keeps `position` dense; item ids aren't
+   referenced externally; the `(trip_id, position)` index is non-unique so
+   shifts are safe). The replacement section is run through the existing
+   `reorderItineraryByDistance` before persisting. A new `trip_updated` SSE
+   event tells the client to refresh — distinct from `done` so the fresh-plan
+   completion banner path is untouched.
+
+On the Flutter side, the chat UI is extracted from `AgentScreen` into a
+reusable `ChatPanel`, driven by a **scoped** provider
+(`tripRefineProvider(tripId)`) so panel sessions never clobber the global
+agent-tab conversation. The trip detail page hosts the panel adaptively:
+docked right column ≥900px, `DraggableScrollableSheet` below.
+
+## Go API Changes
+
+`src/packages/api/` (all files are `package main`):
+
+- **Queries** (`query/trips.sql`, then `make api-sqlc`):
+  `ShiftItineraryItemPositions` (position+1 from an index),
+  `DeleteItineraryItemsByTrip`, `TouchTrip` (bump `updated_at` — item writes
+  don't touch the trips row otherwise).
+- **Routes** (`main.go`, next to accommodations):
+  `POST /trips/{id}/items` behind `authMiddleware`, plus startup log line.
+- **Handlers:** new `itinerary_item_handler.go` — `addItineraryItemHandler`
+  (uses `ownedTrip` guard from accommodation_handler.go; pure helper
+  `insertPositionForDay`; tx: shift → insert → touch; responds 201 with full
+  `TripResponse`). Nil coords stored as `0,0` (columns NOT NULL; Flutter map
+  already excludes `(0,0)`).
+- **Section logic:** new `itinerary_section.go` — `sectionSelector`
+  (scope day|city|trip, day, city), `hubOfItem` (mirrors Flutter `_hubOf`:
+  `day_trip_from ?? city`, case-insensitive), `spliceSection` (pure; errors
+  with valid days/hubs on selector miss so the model self-corrects),
+  `itemParamsFromLocation` (extracted from `persistTrip`'s coercion loop and
+  reused by it), `replaceTripSection` (tx rewrite).
+- **Plan handler** (`plan_handler.go`): `PlanRequest.TripID`; ownership check
+  via `GetTripByIDAndOwner` right after user resolution — failure emits SSE
+  `error` and aborts (never silently falls back to version-creating mode);
+  tool list swap + system-prompt addendum when bound; dispatch case runs
+  `reorderItineraryByDistance` then `replaceTripSection`, emits
+  `trip_updated`. Shared `itineraryLocationSchema` var feeds both tools'
+  `items`/`locations` schemas.
+- **Types:** `AddItineraryItemRequest` in the new handler file; tool input
+  decoded inline in the dispatch case (matches existing tool cases).
+
+Convention reminders: request coords are `*float64` (nil = not provided); SSE
+already runs with `WriteTimeout: 0`; no new env vars; no CORS changes.
+
+## Flutter Changes
+
+`src/packages/flutter-app/lib/`:
+
+- **Models:** none — `ItineraryItem`/`Trip` already match the responses. No
+  codegen run needed.
+- **Service:** `services/trips_api_service.dart` → `addItineraryItem(tripId,
+  body)` (POST, expects 201 → `Trip`); `services/plan_service.dart` →
+  `streamPlan(..., tripId)` adds `trip_id` to the body.
+- **Provider:** `providers/plan_provider.dart` — `PlanState.tripUpdateCount`
+  (monotonic counter; listen-friendly for repeated patches),
+  `'trip_updated'` event case, `PlanNotifier.tripId` ctor param,
+  `beginSectionRefinement(seed)` (no server chat-id round trip), and
+  `tripRefineProvider` = `StateNotifierProvider.autoDispose.family` keyed by
+  trip id with `keepAlive` so the conversation survives panel close/reopen.
+- **Widgets:**
+  - `widgets/chat_panel.dart` — `ChatPanel(state, notifier, inputHint,
+    emptyState?, footerBuilder?)` extracted from `agent_screen.dart`
+    (bubbles, input bar, tool chips + `update_itinerary_section` label,
+    flight cards, error display, autoscroll). `agent_screen.dart` becomes a
+    thin shell; behavior unchanged.
+  - `widgets/trip_refine_panel.dart` — `RefineTarget{scope, day?, city?}` +
+    `TripRefinePanel{tripId, target, onClose, onTripUpdated}`; listens to
+    `tripUpdateCount` → `onTripUpdated`.
+  - `widgets/add_itinerary_item_dialog.dart` — debounced Places autocomplete
+    (via existing `placesApiServiceProvider`), details fetch on select,
+    manual-name fallback, day/time-of-day/category pickers.
+- **Screen:** `screens/trip_detail_screen.dart` — adaptive layout
+  (`LayoutBuilder`: ≥900px Row + 400px panel; else Stack +
+  `DraggableScrollableSheet` .15/.45/.92 with keyboard inset padding);
+  `_openRefine` + `_buildSectionSeed` replace the AgentScreen push; refine
+  icons on trip header / day sub-headers / city group headers ("Other places"
+  disabled); "Add place" button on the Itinerary header; `_computeTravelTimes`
+  sends null coords for `(0,0)` items.
+
+## Contract Parity  ← anti-drift gate
+
+| JSON key | Go type | Dart type | Nullable? | ✓ |
+|----------|---------|-----------|-----------|---|
+| `name` (add-item req) | `string` | `String` | no | ✓ |
+| `place_id` | `*string` | `String?` (key omitted when unset) | yes | ✓ |
+| `address` | `*string` | `String?` (key omitted when unset) | yes | ✓ |
+| `latitude` / `longitude` | `*float64` | `double` (keys omitted when no Places match) | yes (omitted → no location) | ✓ |
+| `category` | `*string` | `String?` (key omitted when unset) | yes | ✓ |
+| `time_of_day` | `*string` | `String?` (key omitted when unset) | yes | ✓ |
+| `city` | `*string` | not sent (server stores NULL; UI groups by address) | yes | ✓ |
+| `day` | `*int` | `int?` (key omitted when unset) | yes | ✓ |
+| add-item 201 body | `TripResponse` | `Trip` (existing model, field-for-field) | — | ✓ |
+| `trip_id` (PlanRequest) | `string` | `String?` (key omitted when null) | yes | ✓ |
+| `trip_updated.data.trip_id` | `string` | unread (event arrival alone triggers reload) | no | ✓ |
+
+Rules: optional Go fields (pointers / `omitempty`) → nullable Dart fields;
+JSON tag on the Go side must equal the `@JsonKey`/field name on the Dart side.
+
+## Cross-cutting
+
+- **Env vars:** none added.
+- **Gateway:** new path is under `/api/v1/` — no proxy config changes.
+- **In-flight work:** builds on the uncommitted `itinerary_optimizer.go`,
+  `plan_handler.go` reorder call, and the trip-detail sliver refactor.
+- **Deprecation flag:** `POST /trips/{id}/refine` and the admin versions view
+  become unused by the UI for refinement; kept, cleanup later.
+
+## Verification
+
+(Mirror into `tasks.md` as the final tasks.)
+
+- `make api-fmt && make api-vet` — Go formatting/vet clean.
+- `make api-test` — includes new `itinerary_section_test.go` pure-function
+  tests (`insertPositionForDay`, `spliceSection`, `hubOfItem`).
+- `make flutter-analyze` && `make flutter-test` — clean (no codegen needed).
+- Manual end-to-end via the gateway at `http://localhost:3000`
+  (`make docker-dev`; API container needs `up --build` after Go changes;
+  Flutter container restart + browser hard refresh): walk each acceptance
+  criterion from `spec.md`, including: version count flat after refinements,
+  items outside a refined section byte-identical, AgentScreen regression.
+- `curl` examples:
+  - `curl -X POST :3000/api/v1/trips/{id}/items -H 'Authorization: Bearer …' -d '{"name":"Café X","day":2,"time_of_day":"morning","category":"restaurant"}'` → 201
+  - same without auth → 401; `"category":"bar"` → 400.

--- a/specs/itinerary-editing/spec.md
+++ b/specs/itinerary-editing/spec.md
@@ -1,0 +1,145 @@
+# Spec: Itinerary Editing — Manual Add & In-Place AI Section Refinement
+
+> **WHAT & WHY only.** No tech choices, file names, libraries, or code. If a
+> sentence names a file or a package, it belongs in `plan.md`, not here.
+
+## Context
+
+Once the AI agent saves a trip, the itinerary is effectively frozen: the only
+way to change it is to reopen a full-screen chat that hides the trip page and
+saves an entirely new version of the trip per refinement. Travelers can't make
+a small tweak ("add this restaurant my friend recommended", "make Day 2 more
+relaxed") without losing sight of the plan they're editing. This feature makes
+a saved trip directly editable: travelers can manually add a single place, and
+can ask the AI to refine a targeted slice of the itinerary — one day, one city,
+or the whole trip — in a chat panel that keeps the trip page visible, with
+changes applied to the same trip in place.
+
+## User Stories
+
+- As a **traveler**, I want to **manually add a place to my saved itinerary**
+  (picking the day, time of day, and category) so that **recommendations I get
+  outside the app make it into my plan**.
+- As a **traveler**, I want to **ask the AI to rework just one day or one city
+  of my trip** so that **the rest of my plan stays exactly as I approved it**.
+- As a **traveler**, I want the **trip page to stay visible while I chat with
+  the AI** so that **I can see the changes land as we talk**.
+- As a **traveler**, I want refinements to **update my existing trip rather
+  than create copies** so that **My Trips doesn't fill with near-duplicate
+  versions**.
+
+## Acceptance Criteria
+
+- [ ] The trip detail page has an "Add place" action; the dialog lets me search
+      real places (name/address/coordinates auto-filled) and pick a day, time
+      of day, and category before saving.
+- [ ] If place search finds nothing (or is unavailable), I can still add the
+      item by typing a name; it appears in the itinerary but not on the map.
+- [ ] A manually added place appears at the end of its chosen day immediately
+      after saving and is still there after a reload.
+- [ ] Each "Day N" sub-header, each city group header, and the trip header
+      offer a "refine" action that opens an AI chat panel.
+- [ ] On a wide window (desktop/web), the chat panel docks to the right of the
+      itinerary; on a narrow window it appears as a collapsible/draggable
+      bottom sheet. In both cases the itinerary remains visible and scrollable.
+- [ ] Asking the panel for a change updates only the targeted section; items
+      outside the section are unchanged, and the page refreshes in place
+      without navigation.
+- [ ] Section refinements do not create new trip versions (the trip count in
+      My Trips and the admin versions list stay flat).
+- [ ] The existing fresh-planning chat (Agent tab) is unaffected: it still
+      creates and saves new trips.
+
+## API Surface
+
+### `POST /api/v1/trips/{id}/items`
+- **Purpose:** Manually add one itinerary item to an owned trip.
+- **Request:** `name` (required); optional `place_id`, `address`, `latitude`,
+  `longitude`, `category` (attraction|restaurant), `time_of_day`
+  (morning|afternoon|evening), `city`, `day` (1-based). Omitted coordinates
+  mean "no location" (item is excluded from the map). Omitted `day` means
+  unscheduled (item lands at the end of the trip).
+- **Response:** the full updated trip, including all items in order.
+- **Errors:** 401 unauthenticated; 404 trip not found or not owned; 400 for
+  empty name, unknown category/time_of_day, or `day < 1`.
+
+### `POST /api/v1/plan` (extended)
+- **Purpose:** Existing SSE planning chat, now bindable to a saved trip.
+- **Request:** adds optional `trip_id`. When present, the caller must be
+  authenticated and own the trip; the session then refines that trip **in
+  place** and can never create a new trip.
+- **Response:** existing SSE stream, plus a new `trip_updated` event emitted
+  each time the trip's itinerary is rewritten, carrying the trip id. Clients
+  refresh the trip when they see it.
+- **Errors:** an SSE `error` event (and no refinement session) when `trip_id`
+  is invalid, unowned, or the caller is unauthenticated.
+
+## Data Model
+
+- **Itinerary item** — unchanged shape; this feature adds new writers. A
+  manually added item may have no coordinates (rendered in the list but not on
+  the map) and no city (grouped by address, or under "Other places").
+- **Trip** — unchanged; section refinement rewrites the trip's items in place.
+  Item identity is not stable across a refinement (items are replaced as a
+  set); nothing external references item ids.
+- **Section** — a targeting concept, not a stored entity: one trip day
+  (optionally qualified by city, since day numbers can repeat across cities in
+  older trips), one city/hub (a city and its day trips), or the whole trip.
+
+## UI Behavior
+
+- **Surface:** the trip detail page.
+- **Manual add happy path:** Itinerary header → "Add place" → type a query →
+  pick a suggestion (place details auto-fill) → choose day / time of day /
+  category → Save → dialog closes, itinerary refreshes with the new item at
+  the end of its day.
+- **Refine happy path:** tap the refine icon on a day, city, or the trip
+  header → chat panel opens (right dock ≥ ~900px, bottom sheet below) seeded
+  with that section's contents → user types a request → AI streams its
+  reasoning, shows an "Updating itinerary…" indicator while applying → the
+  itinerary refreshes in place → conversation can continue for further tweaks.
+- **States:** dialog shows a spinner while searching/saving and inline errors
+  on failure; the panel shows streamed text, active-tool chips, an error
+  banner on stream failure, and is closable at any time (the conversation for
+  that trip survives close/reopen while the page is open).
+
+## Edge Cases & Error States
+
+- Trip with no items or days yet: "Add place" still works; day picker offers
+  "Unscheduled" and "Day 1".
+- Place search unavailable (no API key / network failure): the dialog falls
+  back to manual name entry rather than blocking.
+- The AI targets a day/city that doesn't exist: the tool call fails with the
+  valid options and the model self-corrects; the trip is untouched.
+- The AI omits items it was told to keep: the section is replaced by what the
+  model sends — the prompt demands the complete list; if this proves flaky a
+  size guard can be added (see Open Questions).
+- "Other places" group (items with no resolvable city) is not refinable as a
+  city section; its refine affordance is disabled.
+- Manual add while a refinement is streaming: last write wins (the refinement
+  rewrites items from its earlier read). Accepted for single-user trips.
+- Unauthenticated users: manual add and refinement both require sign-in
+  (the trip page itself already does).
+
+## Out of Scope
+
+- Editing or deleting an individual itinerary item by hand (add only).
+- Drag-and-drop reordering of items.
+- Undo / version history for in-place refinements (snapshots were considered
+  and deferred).
+- Refining accommodations, booking todos, or flights from the panel.
+- Multi-user / concurrent-edit conflict resolution.
+
+## Open Questions
+
+- ~~[NEEDS CLARIFICATION] Persist refinements as new versions or in place?~~
+  **Resolved: in place** (user decision, 2026-06-10). Accepted consequence:
+  the per-refinement version history stops accumulating and the old
+  full-screen refine flow is replaced.
+- ~~[NEEDS CLARIFICATION] Manual add: search-backed or freeform?~~ **Resolved:
+  Places-search dialog with manual fallback.**
+- ~~[NEEDS CLARIFICATION] Panel layout?~~ **Resolved: adaptive** (right dock
+  wide, bottom sheet narrow).
+- [NEEDS CLARIFICATION → default chosen] Guard against the model dropping kept
+  items: ship without a size guard; add one (reject replacement lists smaller
+  than ~1/3 of the section) only if real sessions lose items.

--- a/specs/itinerary-editing/tasks.md
+++ b/specs/itinerary-editing/tasks.md
@@ -1,0 +1,61 @@
+# Tasks: Itinerary Editing — Manual Add & In-Place AI Section Refinement
+
+> Dependency-ordered. `[P]` = can run in parallel with its siblings (no shared
+> files / no ordering dependency). Work top to bottom; verification is last.
+
+## API (Go)
+
+- [ ] Add `ShiftItineraryItemPositions`, `DeleteItineraryItemsByTrip`,
+      `TouchTrip` to `query/trips.sql`; run `make api-sqlc`
+- [ ] `itinerary_item_handler.go`: `AddItineraryItemRequest`,
+      `insertPositionForDay`, `addItineraryItemHandler` (tx: shift → insert →
+      touch; 201 with full `TripResponse`)
+- [ ] Register `POST /trips/{id}/items` + startup log line in `main.go`
+- [ ] `itinerary_section.go`: `sectionSelector`, `hubOfItem`,
+      `spliceSection`, `itemParamsFromLocation` (+ refactor `persistTrip` to
+      use it), `replaceTripSection`
+- [ ] `plan_handler.go`: `PlanRequest.TripID`, ownership bind (SSE error on
+      failure), tool swap (`update_itinerary_section` replaces
+      `create_itinerary` when bound), shared `itineraryLocationSchema`,
+      dispatch case + `trip_updated` SSE event, system-prompt addendum
+- [ ] `itinerary_section_test.go`: table tests for `insertPositionForDay`,
+      `spliceSection` (all scopes, disambiguation, miss errors, tag
+      preservation), `hubOfItem`
+
+## Models & codegen (Flutter)
+
+- [ ] No model changes needed (verify `ItineraryItem`/`Trip` parity)
+- [ ] Complete the Contract Parity table in `plan.md` (every row ✓)
+
+## UI (Flutter)
+
+- [ ] [P] `trips_api_service.dart`: `addItineraryItem`
+- [ ] [P] `plan_service.dart`: `trip_id` in `streamPlan` body
+- [ ] `plan_provider.dart`: `tripUpdateCount`, `'trip_updated'` case,
+      `tripId` ctor param, `beginSectionRefinement`, `tripRefineProvider`
+      autoDispose family with keepAlive
+- [ ] `widgets/chat_panel.dart`: extract from `agent_screen.dart`; rewrite
+      AgentScreen as thin shell (behavior unchanged — verify before
+      continuing)
+- [ ] `widgets/trip_refine_panel.dart`: `RefineTarget`, `TripRefinePanel`,
+      `tripUpdateCount` listener
+- [ ] `trip_detail_screen.dart`: adaptive layout (right dock ≥900px /
+      bottom sheet), `_openRefine` + `_buildSectionSeed`, refine icons on
+      trip/day/city headers ("Other places" disabled), remove AgentScreen
+      push + `_refining`
+- [ ] `widgets/add_itinerary_item_dialog.dart`: autocomplete + manual
+      fallback + day/time/category pickers; "Add place" header button;
+      `_computeTravelTimes` null-coord fix
+- [ ] Handle loading / empty / error states (dialog spinner + inline errors;
+      panel error banner; empty-trip add flow)
+
+## Verification
+
+- [ ] `make api-fmt && make api-vet` clean
+- [ ] `make api-test` passes (incl. `itinerary_section_test.go`)
+- [ ] `make flutter-analyze` clean
+- [ ] `make flutter-test` passes
+- [ ] Manual end-to-end via gateway (`make docker-dev` → `http://localhost:3000`):
+      every acceptance criterion in `spec.md` checked off (incl. flat version
+      count, untouched out-of-section items, AgentScreen regression,
+      narrow-window bottom sheet + keyboard)

--- a/src/packages/api/itinerary_item_handler.go
+++ b/src/packages/api/itinerary_item_handler.go
@@ -1,0 +1,154 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"travel-route-planner/store"
+)
+
+type AddItineraryItemRequest struct {
+	Name      string   `json:"name"`
+	PlaceID   *string  `json:"place_id"`
+	Address   *string  `json:"address"`
+	Latitude  *float64 `json:"latitude"`
+	Longitude *float64 `json:"longitude"`
+	Category  *string  `json:"category"`
+	TimeOfDay *string  `json:"time_of_day"`
+	City      *string  `json:"city"`
+	Day       *int     `json:"day"`
+}
+
+// insertPositionForDay places a new item at the end of its day: just after the
+// last item whose day is set and <= the requested day. Unscheduled items (nil
+// day) don't advance the cursor, so a day-tagged insert lands before the
+// trailing unscheduled block. A nil requested day appends to the very end.
+func insertPositionForDay(items []store.ItineraryItem, day *int) int {
+	if day == nil {
+		return len(items)
+	}
+	pos := 0
+	for i, it := range items {
+		if it.Day != nil && int(*it.Day) <= *day {
+			pos = i + 1
+		}
+	}
+	return pos
+}
+
+func addItineraryItemHandler(w http.ResponseWriter, r *http.Request) {
+	tripID, ok := ownedTrip(w, r)
+	if !ok {
+		return
+	}
+	var req AddItineraryItemRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid JSON")
+		return
+	}
+	name := strings.TrimSpace(req.Name)
+	if name == "" {
+		writeJSONError(w, http.StatusBadRequest, "name is required")
+		return
+	}
+	var category *string
+	if req.Category != nil {
+		c := strings.ToLower(strings.TrimSpace(*req.Category))
+		if !allowedItemCategories[c] {
+			writeJSONError(w, http.StatusBadRequest, "category must be 'attraction' or 'restaurant'")
+			return
+		}
+		category = &c
+	}
+	var timeOfDay *string
+	if req.TimeOfDay != nil {
+		t := strings.ToLower(strings.TrimSpace(*req.TimeOfDay))
+		if !allowedTimesOfDay[t] {
+			writeJSONError(w, http.StatusBadRequest, "time_of_day must be 'morning', 'afternoon' or 'evening'")
+			return
+		}
+		timeOfDay = &t
+	}
+	var day *int32
+	if req.Day != nil {
+		if *req.Day < 1 {
+			writeJSONError(w, http.StatusBadRequest, "day must be >= 1")
+			return
+		}
+		d := int32(*req.Day)
+		day = &d
+	}
+	var city *string
+	if req.City != nil {
+		if c := strings.TrimSpace(*req.City); c != "" {
+			city = &c
+		}
+	}
+	// Columns are NOT NULL; (0,0) is the established "no location" sentinel the
+	// app already excludes from the map and travel times.
+	var lat, lng float64
+	if req.Latitude != nil && req.Longitude != nil {
+		lat, lng = *req.Latitude, *req.Longitude
+	}
+
+	ctx := r.Context()
+	tx, err := dbPool.Begin(ctx)
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "could not save place")
+		return
+	}
+	defer tx.Rollback(ctx)
+	q := store.New(tx)
+
+	items, err := q.GetItineraryItemsByTrip(ctx, tripID)
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "could not load itinerary")
+		return
+	}
+	pos := insertPositionForDay(items, req.Day)
+	if err := q.ShiftItineraryItemPositions(ctx, store.ShiftItineraryItemPositionsParams{
+		TripID: tripID, Position: int32(pos),
+	}); err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "could not save place")
+		return
+	}
+	if _, err := q.CreateItineraryItem(ctx, store.CreateItineraryItemParams{
+		TripID:    tripID,
+		Position:  int32(pos),
+		Name:      name,
+		PlaceID:   req.PlaceID,
+		Address:   req.Address,
+		Latitude:  lat,
+		Longitude: lng,
+		Category:  category,
+		TimeOfDay: timeOfDay,
+		City:      city,
+		Day:       day,
+	}); err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "could not save place")
+		return
+	}
+	if err := q.TouchTrip(ctx, tripID); err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "could not save place")
+		return
+	}
+	if err := tx.Commit(ctx); err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "could not save place")
+		return
+	}
+
+	user, _ := userFromContext(ctx)
+	qr := store.New(dbPool)
+	trip, err := qr.GetTripByIDAndOwner(ctx, store.GetTripByIDAndOwnerParams{ID: tripID, UserID: user.ID})
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "could not load trip")
+		return
+	}
+	updated, err := qr.GetItineraryItemsByTrip(ctx, tripID)
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "could not load itinerary")
+		return
+	}
+	writeJSON(w, http.StatusCreated, toTripResponse(trip, updated, nil, nil, nil))
+}

--- a/src/packages/api/itinerary_section.go
+++ b/src/packages/api/itinerary_section.go
@@ -1,0 +1,279 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/google/uuid"
+
+	"travel-route-planner/store"
+)
+
+// itineraryLocationSchema is the JSON schema for a single itinerary place, shared
+// by the create_itinerary and update_itinerary_section tools so the two writers
+// accept the same shape.
+var itineraryLocationSchema = map[string]any{
+	"type": "object",
+	"properties": map[string]any{
+		"name":     map[string]any{"type": "string"},
+		"place_id": map[string]any{"type": "string"},
+		"address":  map[string]any{"type": "string"},
+		"city": map[string]any{
+			"type":        "string",
+			"description": "The city/town the place is physically located in — use the actual municipality, not the nearest major city (e.g. 'Versailles', not 'Paris'). Used to group the itinerary by city.",
+		},
+		"day_trip_from": map[string]any{
+			"type":        "string",
+			"description": "If this place is a day trip from the city the traveler is staying in (a nearby town visited and returned from the same day, e.g. Versailles from Paris), set this to that hub city's name. Leave unset for places in the city you're staying in.",
+		},
+		"latitude":  map[string]any{"type": "number"},
+		"longitude": map[string]any{"type": "number"},
+		"category": map[string]any{
+			"type":        "string",
+			"enum":        []string{"attraction", "restaurant"},
+			"description": "What kind of place this is — 'attraction' for sights/activities, 'restaurant' for places to eat.",
+		},
+		"time_of_day": map[string]any{
+			"type":        "string",
+			"enum":        []string{"morning", "afternoon", "evening"},
+			"description": "Which part of the day to do this — spread a day's places sensibly (sights/activities across morning–afternoon, meals at their natural times).",
+		},
+		"day": map[string]any{
+			"type":        "integer",
+			"description": "The trip day this place belongs to, starting at 1 and increasing chronologically across the whole trip; all places on the same day share the same number (e.g. days 1–3 in Paris, then day 4 onward in Rome). Combined with time_of_day this makes each day read as a sequential schedule.",
+		},
+	},
+	"required": []string{"name", "latitude", "longitude"},
+}
+
+// sectionSelector targets one slice of a saved itinerary for in-place
+// replacement: a single day (optionally qualified by city, since day numbers
+// can repeat across cities in legacy trips), one city/hub including its day
+// trips, or the whole trip.
+type sectionSelector struct {
+	Scope string // "day" | "city" | "trip"
+	Day   *int
+	City  string
+}
+
+// hubOfItem mirrors the Flutter app's _hubOf grouping: an item belongs to its
+// day-trip hub when set, otherwise its own city. Empty when neither is set.
+func hubOfItem(it store.ItineraryItem) string {
+	if it.DayTripFrom != nil {
+		if h := strings.TrimSpace(*it.DayTripFrom); h != "" {
+			return h
+		}
+	}
+	if it.City != nil {
+		return strings.TrimSpace(*it.City)
+	}
+	return ""
+}
+
+func (sel sectionSelector) matches(it store.ItineraryItem) bool {
+	switch sel.Scope {
+	case "trip":
+		return true
+	case "day":
+		if it.Day == nil || sel.Day == nil || int(*it.Day) != *sel.Day {
+			return false
+		}
+		if sel.City != "" {
+			return strings.EqualFold(hubOfItem(it), strings.TrimSpace(sel.City))
+		}
+		return true
+	case "city":
+		return strings.EqualFold(hubOfItem(it), strings.TrimSpace(sel.City))
+	}
+	return false
+}
+
+// locationFromItem converts a stored item back into the agent's location map
+// shape, so kept items and the model's replacements share one persist path.
+func locationFromItem(it store.ItineraryItem) map[string]any {
+	loc := map[string]any{
+		"name":      it.Name,
+		"latitude":  it.Latitude,
+		"longitude": it.Longitude,
+	}
+	setStr := func(key string, v *string) {
+		if v != nil && *v != "" {
+			loc[key] = *v
+		}
+	}
+	setStr("place_id", it.PlaceID)
+	setStr("address", it.Address)
+	setStr("city", it.City)
+	setStr("day_trip_from", it.DayTripFrom)
+	setStr("category", it.Category)
+	setStr("time_of_day", it.TimeOfDay)
+	if it.Day != nil {
+		// JSON numbers decode as float64; keep the shape consistent for
+		// itemParamsFromLocation.
+		loc["day"] = float64(*it.Day)
+	}
+	return loc
+}
+
+// spliceSection returns the trip's full new ordered location list: items
+// matching sel are removed and newLocs take their place at the position of the
+// first match. Errors when a day/city selector matches nothing, listing the
+// valid options so the calling model can self-correct.
+func spliceSection(existing []store.ItineraryItem, sel sectionSelector, newLocs []map[string]any) ([]map[string]any, error) {
+	switch sel.Scope {
+	case "trip":
+		return newLocs, nil
+	case "day":
+		if sel.Day == nil {
+			return nil, fmt.Errorf("scope 'day' requires a day number")
+		}
+	case "city":
+		if strings.TrimSpace(sel.City) == "" {
+			return nil, fmt.Errorf("scope 'city' requires a city name")
+		}
+	default:
+		return nil, fmt.Errorf("unknown scope %q (use 'day', 'city' or 'trip')", sel.Scope)
+	}
+
+	insertAt := -1
+	var out []map[string]any
+	for _, it := range existing {
+		if sel.matches(it) {
+			if insertAt == -1 {
+				insertAt = len(out)
+			}
+			continue
+		}
+		out = append(out, locationFromItem(it))
+	}
+	if insertAt == -1 {
+		return nil, fmt.Errorf("no itinerary items matched %s; the trip has %s", describeSelector(sel), describeSections(existing))
+	}
+	spliced := make([]map[string]any, 0, len(out)+len(newLocs))
+	spliced = append(spliced, out[:insertAt]...)
+	spliced = append(spliced, newLocs...)
+	spliced = append(spliced, out[insertAt:]...)
+	return spliced, nil
+}
+
+func describeSelector(sel sectionSelector) string {
+	if sel.Scope == "day" {
+		s := fmt.Sprintf("day %d", *sel.Day)
+		if sel.City != "" {
+			s += " in " + sel.City
+		}
+		return s
+	}
+	return "city " + sel.City
+}
+
+// describeSections summarizes the days and hubs present in a trip for the
+// model's error feedback.
+func describeSections(items []store.ItineraryItem) string {
+	daySet := map[int]bool{}
+	hubSet := map[string]bool{}
+	for _, it := range items {
+		if it.Day != nil {
+			daySet[int(*it.Day)] = true
+		}
+		if h := hubOfItem(it); h != "" {
+			hubSet[h] = true
+		}
+	}
+	days := make([]int, 0, len(daySet))
+	for d := range daySet {
+		days = append(days, d)
+	}
+	sort.Ints(days)
+	hubs := make([]string, 0, len(hubSet))
+	for h := range hubSet {
+		hubs = append(hubs, h)
+	}
+	sort.Strings(hubs)
+	return fmt.Sprintf("days %v and cities %v", days, hubs)
+}
+
+// itemParamsFromLocation coerces one agent/location map into insert params.
+// Unknown category/time_of_day values are dropped rather than rejected, and
+// only sensible 1-based day numbers are kept (JSON numbers decode as float64).
+func itemParamsFromLocation(tripID uuid.UUID, position int32, loc map[string]any) store.CreateItineraryItemParams {
+	name, _ := loc["name"].(string)
+	lat, _ := loc["latitude"].(float64)
+	lng, _ := loc["longitude"].(float64)
+	params := store.CreateItineraryItemParams{
+		TripID:    tripID,
+		Position:  position,
+		Name:      name,
+		Latitude:  lat,
+		Longitude: lng,
+	}
+	if s, ok := loc["place_id"].(string); ok && s != "" {
+		params.PlaceID = &s
+	}
+	if s, ok := loc["address"].(string); ok && s != "" {
+		params.Address = &s
+	}
+	if s, ok := loc["city"].(string); ok {
+		if c := strings.TrimSpace(s); c != "" {
+			params.City = &c
+		}
+	}
+	if s, ok := loc["day_trip_from"].(string); ok {
+		if d := strings.TrimSpace(s); d != "" {
+			params.DayTripFrom = &d
+		}
+	}
+	if s, ok := loc["category"].(string); ok {
+		c := strings.ToLower(strings.TrimSpace(s))
+		if allowedItemCategories[c] {
+			params.Category = &c
+		}
+	}
+	if s, ok := loc["time_of_day"].(string); ok {
+		t := strings.ToLower(strings.TrimSpace(s))
+		if allowedTimesOfDay[t] {
+			params.TimeOfDay = &t
+		}
+	}
+	if v, ok := loc["day"].(float64); ok && v >= 1 {
+		d := int32(v)
+		params.Day = &d
+	}
+	return params
+}
+
+// replaceTripSection rewrites the trip's itinerary in one transaction: load the
+// current items, splice the targeted section, then reinsert everything with a
+// dense 0-based position sequence. Item ids are not stable across a rewrite;
+// nothing external references them.
+func replaceTripSection(ctx context.Context, tripID uuid.UUID, sel sectionSelector, newLocs []map[string]any) error {
+	tx, err := dbPool.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback(ctx)
+	q := store.New(tx)
+
+	existing, err := q.GetItineraryItemsByTrip(ctx, tripID)
+	if err != nil {
+		return err
+	}
+	spliced, err := spliceSection(existing, sel, newLocs)
+	if err != nil {
+		return err
+	}
+	if err := q.DeleteItineraryItemsByTrip(ctx, tripID); err != nil {
+		return err
+	}
+	for i, loc := range spliced {
+		if _, err := q.CreateItineraryItem(ctx, itemParamsFromLocation(tripID, int32(i), loc)); err != nil {
+			return err
+		}
+	}
+	if err := q.TouchTrip(ctx, tripID); err != nil {
+		return err
+	}
+	return tx.Commit(ctx)
+}

--- a/src/packages/api/itinerary_section_test.go
+++ b/src/packages/api/itinerary_section_test.go
@@ -1,0 +1,224 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"travel-route-planner/store"
+)
+
+// item builds a stored itinerary row the way GetItineraryItemsByTrip returns
+// it. day 0 means unscheduled (nil); city/dayTripFrom "" mean unset.
+func item(name string, day int, city, dayTripFrom string) store.ItineraryItem {
+	it := store.ItineraryItem{Name: name, Latitude: 1, Longitude: 1}
+	if day > 0 {
+		d := int32(day)
+		it.Day = &d
+	}
+	if city != "" {
+		it.City = &city
+	}
+	if dayTripFrom != "" {
+		it.DayTripFrom = &dayTripFrom
+	}
+	return it
+}
+
+func intPtr(v int) *int { return &v }
+
+func itemNames(locs []map[string]any) []string {
+	out := make([]string, len(locs))
+	for i, l := range locs {
+		out[i], _ = l["name"].(string)
+	}
+	return out
+}
+
+func assertOrder(t *testing.T, got []map[string]any, want []string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("order = %v, want %v", itemNames(got), want)
+	}
+	for i, n := range itemNames(got) {
+		if n != want[i] {
+			t.Fatalf("order = %v, want %v", itemNames(got), want)
+		}
+	}
+}
+
+// --- hubOfItem ---
+
+func TestHubOfItemPrefersDayTripHub(t *testing.T) {
+	if h := hubOfItem(item("Versailles", 2, "Versailles", "Paris")); h != "Paris" {
+		t.Fatalf("hub = %q, want Paris", h)
+	}
+	if h := hubOfItem(item("Louvre", 1, "Paris", "")); h != "Paris" {
+		t.Fatalf("hub = %q, want Paris", h)
+	}
+	if h := hubOfItem(item("Mystery", 0, "", "")); h != "" {
+		t.Fatalf("hub = %q, want empty", h)
+	}
+}
+
+func TestHubOfItemTrimsWhitespace(t *testing.T) {
+	if h := hubOfItem(item("x", 1, " Lisbon ", "")); h != "Lisbon" {
+		t.Fatalf("hub = %q, want Lisbon", h)
+	}
+}
+
+// --- insertPositionForDay ---
+
+func TestInsertPositionForDay(t *testing.T) {
+	items := []store.ItineraryItem{
+		item("a", 1, "Paris", ""),
+		item("b", 1, "Paris", ""),
+		item("c", 2, "Paris", ""),
+		item("u", 0, "", ""), // unscheduled tail
+	}
+	cases := []struct {
+		name string
+		day  *int
+		want int
+	}{
+		{"nil day appends", nil, 4},
+		{"end of day 1", intPtr(1), 2},
+		{"end of day 2 before unscheduled", intPtr(2), 3},
+		{"day past end lands after last dated item", intPtr(9), 3},
+	}
+	for _, c := range cases {
+		if got := insertPositionForDay(items, c.day); got != c.want {
+			t.Fatalf("%s: pos = %d, want %d", c.name, got, c.want)
+		}
+	}
+}
+
+func TestInsertPositionForDayEmptyTrip(t *testing.T) {
+	if got := insertPositionForDay(nil, intPtr(1)); got != 0 {
+		t.Fatalf("pos = %d, want 0", got)
+	}
+	if got := insertPositionForDay(nil, nil); got != 0 {
+		t.Fatalf("pos = %d, want 0", got)
+	}
+}
+
+// --- spliceSection ---
+
+func parisRome() []store.ItineraryItem {
+	return []store.ItineraryItem{
+		item("Louvre", 1, "Paris", ""),
+		item("Orsay", 1, "Paris", ""),
+		item("Versailles", 2, "Versailles", "Paris"),
+		item("Colosseum", 3, "Rome", ""),
+		item("Forum", 3, "Rome", ""),
+	}
+}
+
+func TestSpliceSectionDayKeepsOtherDays(t *testing.T) {
+	repl := []map[string]any{{"name": "Pompidou", "latitude": 1.0, "longitude": 1.0}}
+	got, err := spliceSection(parisRome(), sectionSelector{Scope: "day", Day: intPtr(1)}, repl)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertOrder(t, got, []string{"Pompidou", "Versailles", "Colosseum", "Forum"})
+}
+
+func TestSpliceSectionCityFoldsDayTrips(t *testing.T) {
+	// City scope on the hub removes its day trips too (Versailles → Paris hub).
+	repl := []map[string]any{{"name": "Montmartre", "latitude": 1.0, "longitude": 1.0}}
+	got, err := spliceSection(parisRome(), sectionSelector{Scope: "city", City: "paris"}, repl)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertOrder(t, got, []string{"Montmartre", "Colosseum", "Forum"})
+}
+
+func TestSpliceSectionDayWithCityDisambiguator(t *testing.T) {
+	// Legacy trips can repeat day numbers across cities: two "day 1" blocks.
+	items := []store.ItineraryItem{
+		item("Louvre", 1, "Paris", ""),
+		item("Colosseum", 1, "Rome", ""),
+	}
+	repl := []map[string]any{{"name": "Pantheon", "latitude": 1.0, "longitude": 1.0}}
+	got, err := spliceSection(items, sectionSelector{Scope: "day", Day: intPtr(1), City: "Rome"}, repl)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertOrder(t, got, []string{"Louvre", "Pantheon"})
+}
+
+func TestSpliceSectionTripReplacesEverything(t *testing.T) {
+	repl := []map[string]any{{"name": "Only", "latitude": 1.0, "longitude": 1.0}}
+	got, err := spliceSection(parisRome(), sectionSelector{Scope: "trip"}, repl)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertOrder(t, got, []string{"Only"})
+}
+
+func TestSpliceSectionMissErrorsWithValidOptions(t *testing.T) {
+	_, err := spliceSection(parisRome(), sectionSelector{Scope: "day", Day: intPtr(9)}, nil)
+	if err == nil {
+		t.Fatal("expected error for unmatched day")
+	}
+	for _, want := range []string{"day 9", "Paris", "Rome"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error %q should mention %q", err, want)
+		}
+	}
+	if _, err := spliceSection(parisRome(), sectionSelector{Scope: "city", City: "Lisbon"}, nil); err == nil {
+		t.Fatal("expected error for unmatched city")
+	}
+}
+
+func TestSpliceSectionValidatesSelector(t *testing.T) {
+	if _, err := spliceSection(parisRome(), sectionSelector{Scope: "day"}, nil); err == nil {
+		t.Fatal("scope day without day number should error")
+	}
+	if _, err := spliceSection(parisRome(), sectionSelector{Scope: "city"}, nil); err == nil {
+		t.Fatal("scope city without city should error")
+	}
+	if _, err := spliceSection(parisRome(), sectionSelector{Scope: "week"}, nil); err == nil {
+		t.Fatal("unknown scope should error")
+	}
+}
+
+func TestSpliceSectionKeptItemsPreserveTags(t *testing.T) {
+	cat, tod := "attraction", "morning"
+	items := parisRome()
+	items[3].Category = &cat
+	items[3].TimeOfDay = &tod
+	got, err := spliceSection(items, sectionSelector{Scope: "day", Day: intPtr(1)},
+		[]map[string]any{{"name": "Pompidou", "latitude": 1.0, "longitude": 1.0}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var colosseum map[string]any
+	for _, l := range got {
+		if l["name"] == "Colosseum" {
+			colosseum = l
+		}
+	}
+	if colosseum == nil {
+		t.Fatal("Colosseum missing from spliced result")
+	}
+	if colosseum["category"] != "attraction" || colosseum["time_of_day"] != "morning" ||
+		colosseum["city"] != "Rome" || colosseum["day"] != float64(3) {
+		t.Fatalf("kept item lost tags: %+v", colosseum)
+	}
+}
+
+// Round-trip: locationFromItem output must coerce back losslessly.
+func TestLocationFromItemRoundTrip(t *testing.T) {
+	src := item("Versailles", 2, "Versailles", "Paris")
+	pid, addr := "pid-1", "Place d'Armes"
+	src.PlaceID = &pid
+	src.Address = &addr
+	params := itemParamsFromLocation(src.TripID, 0, locationFromItem(src))
+	if params.Name != "Versailles" || params.PlaceID == nil || *params.PlaceID != "pid-1" ||
+		params.Address == nil || *params.Address != addr ||
+		params.City == nil || *params.City != "Versailles" ||
+		params.DayTripFrom == nil || *params.DayTripFrom != "Paris" ||
+		params.Day == nil || *params.Day != 2 {
+		t.Fatalf("round trip lost fields: %+v", params)
+	}
+}

--- a/src/packages/api/main.go
+++ b/src/packages/api/main.go
@@ -664,6 +664,7 @@ func main() {
 	api.Handle("/trips/{id}", authMiddleware(http.HandlerFunc(patchTripHandler))).Methods("PATCH")
 	api.Handle("/trips/{id}", authMiddleware(http.HandlerFunc(deleteTripHandler))).Methods("DELETE")
 	api.Handle("/trips/{id}/refine", authMiddleware(http.HandlerFunc(refineTripHandler))).Methods("POST")
+	api.Handle("/trips/{id}/items", authMiddleware(http.HandlerFunc(addItineraryItemHandler))).Methods("POST")
 	api.Handle("/preferences", authMiddleware(http.HandlerFunc(getPreferencesHandler))).Methods("GET")
 	api.Handle("/preferences", authMiddleware(http.HandlerFunc(putPreferencesHandler))).Methods("PUT")
 	api.HandleFunc("/accommodation-links", accommodationLinksHandler).Methods("GET")
@@ -710,6 +711,7 @@ func main() {
 	log.Printf("  GET/PUT /api/v1/preferences      - Traveler preferences (auth)")
 	log.Printf("  GET  /api/v1/accommodation-links - Airbnb/Booking browse links")
 	log.Printf("  POST/DELETE /api/v1/trips/{id}/accommodations - Trip stays (auth)")
+	log.Printf("  POST /api/v1/trips/{id}/items   - Add itinerary item (auth)")
 	log.Printf("  GET  /api/v1/transport-links     - Google Flights/Kayak/Rome2Rio browse links")
 	log.Printf("  POST/DELETE /api/v1/trips/{id}/segments - Trip travel segments (auth)")
 

--- a/src/packages/api/plan_handler.go
+++ b/src/packages/api/plan_handler.go
@@ -12,6 +12,7 @@ import (
 
 	anthropic "github.com/anthropics/anthropic-sdk-go"
 	"github.com/anthropics/anthropic-sdk-go/option"
+	"github.com/google/uuid"
 
 	"travel-route-planner/store"
 )
@@ -19,6 +20,10 @@ import (
 type PlanRequest struct {
 	Messages []PlanChatMessage `json:"messages"`
 	ChatID   string            `json:"chat_id"`
+	// TripID binds the session to an existing saved trip: the agent then refines
+	// that trip in place (update_itinerary_section) and can never create a new
+	// trip version. Requires an authenticated owner.
+	TripID string `json:"trip_id"`
 }
 
 type PlanChatMessage struct {
@@ -60,6 +65,23 @@ func planHandler(w http.ResponseWriter, r *http.Request) {
 	// preference-writing tool; signed-in sessions get both.
 	uid, authed := userIDFromRequest(r)
 
+	// A trip-bound session must verifiably own the trip before anything streams;
+	// failing closed here guarantees a refine panel can never fall back to the
+	// version-creating create_itinerary flow.
+	var boundTripID *uuid.UUID
+	if strings.TrimSpace(req.TripID) != "" {
+		tid, err := uuid.Parse(req.TripID)
+		if err != nil || !authed {
+			sendSSE(w, "error", map[string]string{"message": "sign in to refine this trip"})
+			return
+		}
+		if _, err := store.New(dbPool).GetTripByIDAndOwner(r.Context(), store.GetTripByIDAndOwnerParams{ID: tid, UserID: uid}); err != nil {
+			sendSSE(w, "error", map[string]string{"message": "trip not found"})
+			return
+		}
+		boundTripID = &tid
+	}
+
 	searchTool := anthropic.ToolParam{
 		Name:        "search_places",
 		Description: anthropic.String("Search for travel destinations, attractions, restaurants, or points of interest by name or description."),
@@ -81,39 +103,7 @@ func planHandler(w http.ResponseWriter, r *http.Request) {
 				"locations": map[string]any{
 					"type":        "array",
 					"description": "Ordered list of locations to visit",
-					"items": map[string]any{
-						"type": "object",
-						"properties": map[string]any{
-							"name":     map[string]any{"type": "string"},
-							"place_id": map[string]any{"type": "string"},
-							"address":  map[string]any{"type": "string"},
-							"city": map[string]any{
-								"type":        "string",
-								"description": "The city/town the place is physically located in — use the actual municipality, not the nearest major city (e.g. 'Versailles', not 'Paris'). Used to group the itinerary by city.",
-							},
-							"day_trip_from": map[string]any{
-								"type":        "string",
-								"description": "If this place is a day trip from the city the traveler is staying in (a nearby town visited and returned from the same day, e.g. Versailles from Paris), set this to that hub city's name. Leave unset for places in the city you're staying in.",
-							},
-							"latitude":  map[string]any{"type": "number"},
-							"longitude": map[string]any{"type": "number"},
-							"category": map[string]any{
-								"type":        "string",
-								"enum":        []string{"attraction", "restaurant"},
-								"description": "What kind of place this is — 'attraction' for sights/activities, 'restaurant' for places to eat.",
-							},
-							"time_of_day": map[string]any{
-								"type":        "string",
-								"enum":        []string{"morning", "afternoon", "evening"},
-								"description": "Which part of the day to do this — spread a day's places sensibly (sights/activities across morning–afternoon, meals at their natural times).",
-							},
-							"day": map[string]any{
-								"type":        "integer",
-								"description": "The trip day this place belongs to, starting at 1 and increasing chronologically across the whole trip; all places on the same day share the same number (e.g. days 1–3 in Paris, then day 4 onward in Rome). Combined with time_of_day this makes each day read as a sequential schedule.",
-							},
-						},
-						"required": []string{"name", "latitude", "longitude"},
-					},
+					"items":       itineraryLocationSchema,
 				},
 				"title": map[string]any{
 					"type":        "string",
@@ -211,12 +201,46 @@ func planHandler(w http.ResponseWriter, r *http.Request) {
 		},
 	}
 
+	updateSectionTool := anthropic.ToolParam{
+		Name:        "update_itinerary_section",
+		Description: anthropic.String("Replace one section of the traveler's saved itinerary in place. Pass the COMPLETE updated list of places for the targeted section, in visit order — places you omit are removed from that section. Places outside the section are untouched. Use scope 'day' for a single trip day, 'city' for one city/hub and its day trips, or 'trip' for the whole itinerary."),
+		InputSchema: anthropic.ToolInputSchemaParam{
+			Properties: map[string]any{
+				"scope": map[string]any{
+					"type":        "string",
+					"enum":        []string{"day", "city", "trip"},
+					"description": "Which slice of the itinerary to replace.",
+				},
+				"day": map[string]any{
+					"type":        "integer",
+					"description": "Required when scope is 'day': the 1-based trip day being replaced.",
+				},
+				"city": map[string]any{
+					"type":        "string",
+					"description": "Required when scope is 'city' (the hub city whose items are replaced); optional with scope 'day' to disambiguate when day numbers repeat across cities.",
+				},
+				"items": map[string]any{
+					"type":        "array",
+					"description": "The full replacement list for the section, in visit order. Include unchanged places with their existing coordinates and tags so they aren't lost.",
+					"items":       itineraryLocationSchema,
+				},
+			},
+			Required: []string{"scope", "items"},
+		},
+	}
+
 	tools := []anthropic.ToolUnionParam{
 		{OfTool: &searchTool},
-		{OfTool: &createTool},
 		{OfTool: &suggestStaysTool},
 		{OfTool: &suggestTransportTool},
 		{OfTool: &searchFlightsTool},
+	}
+	// Trip-bound sessions get the in-place section tool instead of
+	// create_itinerary, so a refinement can never spawn a new trip version.
+	if boundTripID != nil {
+		tools = append(tools, anthropic.ToolUnionParam{OfTool: &updateSectionTool})
+	} else {
+		tools = append(tools, anthropic.ToolUnionParam{OfTool: &createTool})
 	}
 	if authed {
 		tools = append(tools, anthropic.ToolUnionParam{OfTool: &savePrefsTool})
@@ -243,6 +267,9 @@ func planHandler(w http.ResponseWriter, r *http.Request) {
 		if prefs, err := store.New(dbPool).GetPreferences(ctx, uid); err == nil {
 			systemPrompt = personalizedSystemPrompt(basePrompt, &prefs)
 		}
+	}
+	if boundTripID != nil {
+		systemPrompt += "\n\nYou are refining an existing saved trip in place. The conversation's first message describes the current itinerary and which section the traveler wants to change. Apply changes by calling update_itinerary_section with the targeted scope and the COMPLETE updated list of places for that section — include unchanged places with their existing coordinates, city, day, time_of_day and category tags so they aren't lost. Use search_places to find real coordinates for any new place before adding it. Only change the section the traveler asked about unless they broaden the request."
 	}
 
 	for {
@@ -335,6 +362,32 @@ func planHandler(w http.ResponseWriter, r *http.Request) {
 				}
 				sendSSE(w, "done", donePayload)
 				toolResults = append(toolResults, anthropic.NewToolResultBlock(variant.ID, "Itinerary created successfully.", false))
+
+			case "update_itinerary_section":
+				var in struct {
+					Scope string           `json:"scope"`
+					Day   *int             `json:"day"`
+					City  string           `json:"city"`
+					Items []map[string]any `json:"items"`
+				}
+				json.Unmarshal(variant.Input, &in)
+
+				msg := "Section updated — the traveler's trip page has refreshed."
+				var err error
+				if boundTripID == nil {
+					err = fmt.Errorf("no trip is bound to this session")
+					msg = "This session is not bound to a saved trip; update_itinerary_section is unavailable."
+				} else {
+					// Same in-block walking-distance cleanup create_itinerary gets.
+					in.Items = reorderItineraryByDistance(in.Items)
+					if err = replaceTripSection(ctx, *boundTripID, sectionSelector{Scope: in.Scope, Day: in.Day, City: in.City}, in.Items); err != nil {
+						msg = fmt.Sprintf("Could not update the section: %v", err)
+					} else {
+						sendSSE(w, "trip_updated", map[string]string{"trip_id": boundTripID.String()})
+					}
+				}
+				sendSSE(w, "tool_result", map[string]string{"name": "update_itinerary_section"})
+				toolResults = append(toolResults, anthropic.NewToolResultBlock(variant.ID, msg, err != nil))
 
 			case "save_preferences":
 				var in struct {

--- a/src/packages/api/query/trips.sql
+++ b/src/packages/api/query/trips.sql
@@ -48,6 +48,19 @@ SELECT * FROM trips WHERE id = $1 AND user_id = $2;
 -- name: GetItineraryItemsByTrip :many
 SELECT * FROM itinerary_items WHERE trip_id = $1 ORDER BY position ASC;
 
+-- name: ShiftItineraryItemPositions :exec
+-- Opens a gap at the given position for an insert; the (trip_id, position)
+-- index is non-unique, so the unordered update cannot collide.
+UPDATE itinerary_items SET position = position + 1
+WHERE trip_id = $1 AND position >= $2;
+
+-- name: DeleteItineraryItemsByTrip :exec
+DELETE FROM itinerary_items WHERE trip_id = $1;
+
+-- name: TouchTrip :exec
+-- Itinerary-item writes don't touch the trips row, so bump updated_at by hand.
+UPDATE trips SET updated_at = now() WHERE id = $1;
+
 -- name: UpdateTrip :one
 UPDATE trips
 SET title      = COALESCE(sqlc.narg('title'), title),

--- a/src/packages/api/route_optimizer_test.go
+++ b/src/packages/api/route_optimizer_test.go
@@ -15,9 +15,9 @@ func TestOptimizeRoutePreserveOrder(t *testing.T) {
 	req := RouteRequest{
 		PreserveOrder: true,
 		Locations: []Location{
-			{ID: "a", Name: "A", Latitude: f64(40.7128), Longitude: f64(-74.0060)}, // NYC
+			{ID: "a", Name: "A", Latitude: f64(40.7128), Longitude: f64(-74.0060)},  // NYC
 			{ID: "b", Name: "B", Latitude: f64(34.0522), Longitude: f64(-118.2437)}, // LA (far)
-			{ID: "c", Name: "C", Latitude: f64(40.7138), Longitude: f64(-74.0050)}, // ~NYC
+			{ID: "c", Name: "C", Latitude: f64(40.7138), Longitude: f64(-74.0050)},  // ~NYC
 		},
 	}
 

--- a/src/packages/api/store/trips.sql.go
+++ b/src/packages/api/store/trips.sql.go
@@ -107,6 +107,15 @@ func (q *Queries) CreateTrip(ctx context.Context, arg CreateTripParams) (Trip, e
 	return i, err
 }
 
+const deleteItineraryItemsByTrip = `-- name: DeleteItineraryItemsByTrip :exec
+DELETE FROM itinerary_items WHERE trip_id = $1
+`
+
+func (q *Queries) DeleteItineraryItemsByTrip(ctx context.Context, tripID uuid.UUID) error {
+	_, err := q.db.Exec(ctx, deleteItineraryItemsByTrip, tripID)
+	return err
+}
+
 const deleteTrip = `-- name: DeleteTrip :execrows
 DELETE FROM trips t
 WHERE t.user_id = $1
@@ -348,6 +357,33 @@ func (q *Queries) ListTripsByOwner(ctx context.Context, userID uuid.UUID) ([]Tri
 		return nil, err
 	}
 	return items, nil
+}
+
+const shiftItineraryItemPositions = `-- name: ShiftItineraryItemPositions :exec
+UPDATE itinerary_items SET position = position + 1
+WHERE trip_id = $1 AND position >= $2
+`
+
+type ShiftItineraryItemPositionsParams struct {
+	TripID   uuid.UUID `json:"trip_id"`
+	Position int32     `json:"position"`
+}
+
+// Opens a gap at the given position for an insert; the (trip_id, position)
+// index is non-unique, so the unordered update cannot collide.
+func (q *Queries) ShiftItineraryItemPositions(ctx context.Context, arg ShiftItineraryItemPositionsParams) error {
+	_, err := q.db.Exec(ctx, shiftItineraryItemPositions, arg.TripID, arg.Position)
+	return err
+}
+
+const touchTrip = `-- name: TouchTrip :exec
+UPDATE trips SET updated_at = now() WHERE id = $1
+`
+
+// Itinerary-item writes don't touch the trips row, so bump updated_at by hand.
+func (q *Queries) TouchTrip(ctx context.Context, id uuid.UUID) error {
+	_, err := q.db.Exec(ctx, touchTrip, id)
+	return err
 }
 
 const updateTrip = `-- name: UpdateTrip :one

--- a/src/packages/api/trip_handler.go
+++ b/src/packages/api/trip_handler.go
@@ -168,63 +168,11 @@ func persistTrip(ctx context.Context, userID uuid.UUID, chatID, title, summary, 
 
 	maxDay := 1
 	for i, loc := range locations {
-		name, _ := loc["name"].(string)
-		lat, _ := loc["latitude"].(float64)
-		lng, _ := loc["longitude"].(float64)
-		var placeID, address, city, dayTripFrom, category, timeOfDay *string
-		var day *int32
-		if s, ok := loc["place_id"].(string); ok && s != "" {
-			placeID = &s
+		params := itemParamsFromLocation(trip.ID, int32(i), loc)
+		if params.Day != nil && int(*params.Day) > maxDay {
+			maxDay = int(*params.Day)
 		}
-		if s, ok := loc["address"].(string); ok && s != "" {
-			address = &s
-		}
-		if s, ok := loc["city"].(string); ok {
-			c := strings.TrimSpace(s)
-			if c != "" {
-				city = &c
-			}
-		}
-		if s, ok := loc["day_trip_from"].(string); ok {
-			d := strings.TrimSpace(s)
-			if d != "" {
-				dayTripFrom = &d
-			}
-		}
-		if s, ok := loc["category"].(string); ok {
-			c := strings.ToLower(strings.TrimSpace(s))
-			if allowedItemCategories[c] {
-				category = &c
-			}
-		}
-		if s, ok := loc["time_of_day"].(string); ok {
-			t := strings.ToLower(strings.TrimSpace(s))
-			if allowedTimesOfDay[t] {
-				timeOfDay = &t
-			}
-		}
-		// JSON numbers decode as float64; keep only sensible 1-based day numbers.
-		if v, ok := loc["day"].(float64); ok && v >= 1 {
-			d := int32(v)
-			day = &d
-			if int(d) > maxDay {
-				maxDay = int(d)
-			}
-		}
-		if _, err := q.CreateItineraryItem(ctx, store.CreateItineraryItemParams{
-			TripID:      trip.ID,
-			Position:    int32(i),
-			Name:        name,
-			PlaceID:     placeID,
-			Address:     address,
-			Latitude:    lat,
-			Longitude:   lng,
-			Category:    category,
-			TimeOfDay:   timeOfDay,
-			City:        city,
-			DayTripFrom: dayTripFrom,
-			Day:         day,
-		}); err != nil {
+		if _, err := q.CreateItineraryItem(ctx, params); err != nil {
 			return "", err
 		}
 	}

--- a/src/packages/flutter-app/lib/providers/plan_provider.dart
+++ b/src/packages/flutter-app/lib/providers/plan_provider.dart
@@ -19,6 +19,10 @@ class PlanState {
   final String? flightRouteLabel;
   final String? error;
 
+  /// Bumped each time a trip-bound session patches the trip in place
+  /// (server `trip_updated` event); listeners reload the trip when it grows.
+  final int tripUpdateCount;
+
   const PlanState({
     this.messages = const [],
     this.isStreaming = false,
@@ -30,6 +34,7 @@ class PlanState {
     this.flightOffers,
     this.flightRouteLabel,
     this.error,
+    this.tripUpdateCount = 0,
   });
 
   PlanState copyWith({
@@ -43,6 +48,7 @@ class PlanState {
     Object? flightOffers = _sentinel,
     Object? flightRouteLabel = _sentinel,
     Object? error = _sentinel,
+    int? tripUpdateCount,
   }) {
     return PlanState(
       messages: messages ?? this.messages,
@@ -57,6 +63,7 @@ class PlanState {
       flightOffers: flightOffers == _sentinel ? this.flightOffers : flightOffers as List<FlightOffer>?,
       flightRouteLabel: flightRouteLabel == _sentinel ? this.flightRouteLabel : flightRouteLabel as String?,
       error: error == _sentinel ? this.error : error as String?,
+      tripUpdateCount: tripUpdateCount ?? this.tripUpdateCount,
     );
   }
 }
@@ -67,12 +74,16 @@ class PlanNotifier extends StateNotifier<PlanState> {
   final PlanService _service;
   final ApiClient _apiClient;
 
+  /// When set, every request carries trip_id and the server refines that saved
+  /// trip in place (update_itinerary_section) instead of creating new versions.
+  final String? tripId;
+
   // Stable id for the current conversation. Every create_itinerary in this chat
   // is stamped with it server-side so refinements collapse to one trip in My
   // Trips instead of spawning duplicate drafts. Regenerated on reset().
   String? _chatId;
 
-  PlanNotifier(this._service, this._apiClient) : super(const PlanState());
+  PlanNotifier(this._service, this._apiClient, {this.tripId}) : super(const PlanState());
 
   // 0x7fffffff (not 1 << 32) because on the web target `1 << 32` overflows JS's
   // 32-bit bitwise ops to 0, and Random.nextInt(0) throws RangeError.
@@ -124,7 +135,8 @@ class PlanNotifier extends StateNotifier<PlanState> {
     final textBuffer = StringBuffer();
 
     try {
-      await for (final event in _service.streamPlan(history, bearerToken: _apiClient.authToken, chatId: _chatId)) {
+      await for (final event in _service.streamPlan(history,
+          bearerToken: _apiClient.authToken, chatId: _chatId, tripId: tripId)) {
         switch (event.type) {
           case 'text_delta':
             textBuffer.write(event.data['text'] as String? ?? '');
@@ -148,6 +160,9 @@ class PlanNotifier extends StateNotifier<PlanState> {
               completedSummary: summary,
               savedTripId: event.data['trip_id'] as String?,
             );
+
+            case 'trip_updated':
+            state = state.copyWith(tripUpdateCount: state.tripUpdateCount + 1);
 
           case 'flights':
             final raw = event.data['offers'] as List<dynamic>? ?? [];
@@ -211,9 +226,28 @@ class PlanNotifier extends StateNotifier<PlanState> {
     _chatId = chatId;
     sendMessage(seedMessage);
   }
+
+  /// Start (or restart) an in-place section refinement on the bound trip:
+  /// clears any prior conversation and sends the seed describing the targeted
+  /// section. Requires [tripId]; the server patches that trip directly, so no
+  /// chat-group binding is needed.
+  void beginSectionRefinement(String seedMessage) {
+    reset();
+    sendMessage(seedMessage);
+  }
 }
 
 final planProvider = StateNotifierProvider<PlanNotifier, PlanState>((ref) {
   final apiClient = ref.watch(apiClientProvider);
   return PlanNotifier(PlanService(apiClient.baseUrl), apiClient);
+});
+
+/// Per-trip refinement session for the trip-detail panel, kept separate from
+/// the global [planProvider] so panel chats never clobber the Agent tab's
+/// conversation. keepAlive preserves the conversation across panel
+/// close/reopen while the app runs; it is reset explicitly when a new
+/// refinement target is chosen.
+final tripRefineProvider = StateNotifierProvider.family<PlanNotifier, PlanState, String>((ref, tripId) {
+  final apiClient = ref.watch(apiClientProvider);
+  return PlanNotifier(PlanService(apiClient.baseUrl), apiClient, tripId: tripId);
 });

--- a/src/packages/flutter-app/lib/screens/agent_screen.dart
+++ b/src/packages/flutter-app/lib/screens/agent_screen.dart
@@ -1,9 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../widgets/gradient_app_bar.dart';
-import '../widgets/flight_offer_card.dart';
-import '../models/flight_offer.dart';
-import '../models/plan_message.dart';
+import '../widgets/chat_panel.dart';
 import '../providers/plan_provider.dart';
 import '../providers/route_provider.dart';
 import 'route_optimizer_screen.dart';
@@ -24,9 +22,6 @@ class AgentScreen extends ConsumerStatefulWidget {
 }
 
 class _AgentScreenState extends ConsumerState<AgentScreen> {
-  final _controller = TextEditingController();
-  final _scrollController = ScrollController();
-
   @override
   void initState() {
     super.initState();
@@ -40,33 +35,6 @@ class _AgentScreenState extends ConsumerState<AgentScreen> {
         }
       });
     }
-  }
-
-  @override
-  void dispose() {
-    _controller.dispose();
-    _scrollController.dispose();
-    super.dispose();
-  }
-
-  void _scrollToBottom() {
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (_scrollController.hasClients) {
-        _scrollController.animateTo(
-          _scrollController.position.maxScrollExtent,
-          duration: const Duration(milliseconds: 200),
-          curve: Curves.easeOut,
-        );
-      }
-    });
-  }
-
-  void _send() {
-    final text = _controller.text.trim();
-    if (text.isEmpty) return;
-    _controller.clear();
-    ref.read(planProvider.notifier).sendMessage(text);
-    _scrollToBottom();
   }
 
   void _loadIntoPlanner() {
@@ -85,13 +53,6 @@ class _AgentScreenState extends ConsumerState<AgentScreen> {
   @override
   Widget build(BuildContext context) {
     final planState = ref.watch(planProvider);
-    final theme = Theme.of(context);
-
-    ref.listen(planProvider, (_, next) {
-      if (next.isStreaming || next.streamingText != null) {
-        _scrollToBottom();
-      }
-    });
 
     return Scaffold(
       appBar: GradientAppBar(
@@ -105,97 +66,26 @@ class _AgentScreenState extends ConsumerState<AgentScreen> {
             ),
         ],
       ),
-      body: Column(
-        children: [
-          Expanded(
-            child: planState.messages.isEmpty && planState.streamingText == null
-                ? _EmptyState()
-                : ListView(
-                    controller: _scrollController,
-                    padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-                    children: [
-                      for (final msg in planState.messages)
-                        _MessageBubble(message: msg),
-                      if (planState.streamingText != null && planState.streamingText!.isNotEmpty)
-                        _MessageBubble(
-                          message: PlanMessage(
-                            role: MessageRole.assistant,
-                            content: planState.streamingText!,
-                          ),
-                          isStreaming: true,
-                        ),
-                      if (planState.activeTools.isNotEmpty)
-                        Padding(
-                          padding: const EdgeInsets.symmetric(vertical: 8),
-                          child: Wrap(
-                            spacing: 8,
-                            children: planState.activeTools.map((tool) {
-                              return Chip(
-                                avatar: const SizedBox(
-                                  width: 16,
-                                  height: 16,
-                                  child: CircularProgressIndicator(strokeWidth: 2),
-                                ),
-                                label: Text(_toolLabel(tool)),
-                              );
-                            }).toList(),
+      body: ChatPanel(
+        state: planProvider,
+        notifier: planProvider.notifier,
+        emptyState: _EmptyState(),
+        footerBuilder: (context, state) => state.completedLocations == null
+            ? const SizedBox.shrink()
+            : _ItineraryBanner(
+                summary: state.completedSummary,
+                locationCount: state.completedLocations!.length,
+                onLoad: _loadIntoPlanner,
+                onViewTrip: state.savedTripId == null
+                    ? null
+                    : () => Navigator.of(context).push(
+                          MaterialPageRoute(
+                            builder: (_) => TripDetailScreen(tripId: state.savedTripId!),
                           ),
                         ),
-                      if (planState.flightOffers != null && planState.flightOffers!.isNotEmpty)
-                        _FlightOptions(
-                          routeLabel: planState.flightRouteLabel,
-                          offers: planState.flightOffers!,
-                        ),
-                      if (planState.completedLocations != null)
-                        _ItineraryBanner(
-                          summary: planState.completedSummary,
-                          locationCount: planState.completedLocations!.length,
-                          onLoad: _loadIntoPlanner,
-                          onViewTrip: planState.savedTripId == null
-                              ? null
-                              : () => Navigator.of(context).push(
-                                    MaterialPageRoute(
-                                      builder: (_) => TripDetailScreen(tripId: planState.savedTripId!),
-                                    ),
-                                  ),
-                        ),
-                      if (planState.error != null)
-                        Container(
-                          margin: const EdgeInsets.symmetric(vertical: 8),
-                          padding: const EdgeInsets.all(12),
-                          decoration: BoxDecoration(
-                            color: theme.colorScheme.errorContainer,
-                            borderRadius: BorderRadius.circular(8),
-                          ),
-                          child: Text(
-                            planState.error!,
-                            style: TextStyle(color: theme.colorScheme.onErrorContainer),
-                          ),
-                        ),
-                    ],
-                  ),
-          ),
-          _InputBar(
-            controller: _controller,
-            enabled: !planState.isStreaming,
-            onSend: _send,
-          ),
-        ],
+              ),
       ),
     );
-  }
-
-  String _toolLabel(String tool) {
-    switch (tool) {
-      case 'search_places':
-        return 'Searching places...';
-      case 'create_itinerary':
-        return 'Building itinerary...';
-      case 'search_flights':
-        return 'Searching flights...';
-      default:
-        return '$tool...';
-    }
   }
 }
 
@@ -257,115 +147,6 @@ class _SuggestionChip extends ConsumerWidget {
     return ActionChip(
       label: Text(text),
       onPressed: () => ref.read(planProvider.notifier).sendMessage(text),
-    );
-  }
-}
-
-class _MessageBubble extends StatelessWidget {
-  final PlanMessage message;
-  final bool isStreaming;
-
-  const _MessageBubble({required this.message, this.isStreaming = false});
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    final isUser = message.role == MessageRole.user;
-
-    return Align(
-      alignment: isUser ? Alignment.centerRight : Alignment.centerLeft,
-      child: Container(
-        margin: const EdgeInsets.symmetric(vertical: 4),
-        padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
-        constraints: BoxConstraints(
-          maxWidth: MediaQuery.of(context).size.width * 0.78,
-        ),
-        decoration: BoxDecoration(
-          color: isUser
-              ? theme.colorScheme.primary
-              : theme.colorScheme.surfaceContainerHighest,
-          borderRadius: BorderRadius.only(
-            topLeft: const Radius.circular(16),
-            topRight: const Radius.circular(16),
-            bottomLeft: Radius.circular(isUser ? 16 : 4),
-            bottomRight: Radius.circular(isUser ? 4 : 16),
-          ),
-        ),
-        child: Row(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.end,
-          children: [
-            Flexible(
-              child: Text(
-                message.content,
-                style: TextStyle(
-                  color: isUser ? theme.colorScheme.onPrimary : theme.colorScheme.onSurface,
-                ),
-              ),
-            ),
-            if (isStreaming) ...[
-              const SizedBox(width: 6),
-              SizedBox(
-                width: 8,
-                height: 8,
-                child: CircularProgressIndicator(
-                  strokeWidth: 1.5,
-                  color: theme.colorScheme.onSurface.withOpacity(0.5),
-                ),
-              ),
-            ],
-          ],
-        ),
-      ),
-    );
-  }
-}
-
-/// Inline flight results in the chat — a header plus the agent's top ranked
-/// options as shared FlightOfferCards (first = best match).
-class _FlightOptions extends StatelessWidget {
-  final String? routeLabel;
-  final List<FlightOffer> offers;
-
-  const _FlightOptions({required this.routeLabel, required this.offers});
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    final label = (routeLabel == null || routeLabel!.trim().isEmpty)
-        ? 'Flight options'
-        : 'Flight options · $routeLabel';
-    return Container(
-      margin: const EdgeInsets.symmetric(vertical: 12),
-      padding: const EdgeInsets.all(12),
-      decoration: BoxDecoration(
-        color: Colors.teal.shade50,
-        borderRadius: BorderRadius.circular(12),
-        border: Border.all(color: Colors.teal.shade200),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Row(
-            children: [
-              Icon(Icons.flight, color: Colors.teal.shade700, size: 20),
-              const SizedBox(width: 8),
-              Expanded(
-                child: Text(
-                  label,
-                  style: theme.textTheme.titleSmall?.copyWith(
-                    color: Colors.teal.shade800,
-                    fontWeight: FontWeight.bold,
-                  ),
-                ),
-              ),
-            ],
-          ),
-          const SizedBox(height: 8),
-          for (var i = 0; i < offers.length; i++)
-            FlightOfferCard(offer: offers[i], isBest: i == 0),
-        ],
-      ),
     );
   }
 }
@@ -457,64 +238,6 @@ class _ItineraryBanner extends StatelessWidget {
                 ),
               ),
             ),
-        ],
-      ),
-    );
-  }
-}
-
-class _InputBar extends StatelessWidget {
-  final TextEditingController controller;
-  final bool enabled;
-  final VoidCallback onSend;
-
-  const _InputBar({
-    required this.controller,
-    required this.enabled,
-    required this.onSend,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    return Container(
-      decoration: BoxDecoration(
-        color: theme.colorScheme.surface,
-        boxShadow: [
-          BoxShadow(
-            color: Colors.black.withOpacity(0.06),
-            blurRadius: 8,
-            offset: const Offset(0, -2),
-          ),
-        ],
-      ),
-      padding: const EdgeInsets.fromLTRB(16, 8, 8, 16),
-      child: Row(
-        children: [
-          Expanded(
-            child: TextField(
-              controller: controller,
-              enabled: enabled,
-              maxLines: null,
-              textInputAction: TextInputAction.send,
-              onSubmitted: enabled ? (_) => onSend() : null,
-              decoration: InputDecoration(
-                hintText: enabled ? 'Describe your trip...' : 'Thinking...',
-                border: OutlineInputBorder(
-                  borderRadius: BorderRadius.circular(24),
-                  borderSide: BorderSide.none,
-                ),
-                filled: true,
-                fillColor: theme.colorScheme.surfaceContainerHighest,
-                contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
-              ),
-            ),
-          ),
-          const SizedBox(width: 8),
-          IconButton.filled(
-            onPressed: enabled ? onSend : null,
-            icon: const Icon(Icons.send),
-          ),
         ],
       ),
     );

--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -14,9 +14,11 @@ import '../providers/recent_trip_provider.dart';
 import '../providers/booking_todos_provider.dart';
 import '../providers/preferences_provider.dart';
 import '../providers/api_client_provider.dart';
+import '../providers/plan_provider.dart';
+import '../widgets/add_itinerary_item_dialog.dart';
 import '../widgets/booking_todo_card.dart';
 import '../widgets/trip_map.dart';
-import 'agent_screen.dart';
+import '../widgets/trip_refine_panel.dart';
 import 'flight_search_screen.dart';
 
 class TripDetailScreen extends ConsumerStatefulWidget {
@@ -30,8 +32,11 @@ class TripDetailScreen extends ConsumerStatefulWidget {
 class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
   Trip? _trip;
   bool _loading = true;
-  bool _refining = false;
   String? _error;
+  // In-page AI refinement panel (side dock on wide layouts, bottom sheet on
+  // narrow ones); null target while closed.
+  bool _panelOpen = false;
+  RefineTarget? _refineTarget;
   String _itemFilter = 'all'; // 'all' | 'attraction' | 'restaurant'
   int? _selectedPosition; // position of the place focused via a map pin / list tap
   List<BookingTodo> _bookingTodos = [];
@@ -123,8 +128,11 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
             name: it.name,
             placeId: it.placeId,
             address: it.address,
-            latitude: it.latitude,
-            longitude: it.longitude,
+            // (0,0) is the "no location" sentinel (e.g. manually added places
+            // without a Places match) — send null so the optimizer skips the
+            // coordinate rather than routing via the Gulf of Guinea.
+            latitude: it.latitude == 0 && it.longitude == 0 ? null : it.latitude,
+            longitude: it.latitude == 0 && it.longitude == 0 ? null : it.longitude,
             category: it.category,
           ),
       ];
@@ -252,6 +260,16 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
     if (added == true) await _load();
   }
 
+  Future<void> _addPlace() async {
+    final trip = _trip;
+    if (trip == null) return;
+    final added = await showDialog<bool>(
+      context: context,
+      builder: (_) => AddItineraryItemDialog(trip: trip),
+    );
+    if (added == true) await _load();
+  }
+
   Future<void> _patch({String? title, String? startDate, String? endDate, String? status}) async {
     try {
       final updated = await ref.read(tripsApiServiceProvider).patchTrip(
@@ -301,40 +319,93 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
     }
   }
 
-  Future<void> _refine(Trip trip) async {
+  /// Opens the in-page refinement panel on [target], seeding a fresh session
+  /// with the section's current contents. The session is bound to this trip
+  /// server-side, so changes patch the trip in place (no new versions).
+  void _openRefine(Trip trip, RefineTarget target) {
     final items = trip.items ?? [];
     if (items.isEmpty) {
       _showSnack('Add some places before refining with AI.');
       return;
     }
-    setState(() => _refining = true);
-    try {
-      final chatId = await ref.read(tripsApiServiceProvider).startRefineSession(trip.id);
-      if (!mounted) return;
-      Navigator.of(context).push(
-        MaterialPageRoute(
-          builder: (_) => AgentScreen(chatId: chatId, initialMessage: _buildRefineSeed(trip)),
-        ),
-      );
-    } catch (e) {
-      _showSnack('Could not start refine session: $e');
-    } finally {
-      if (mounted) setState(() => _refining = false);
+    ref
+        .read(tripRefineProvider(widget.tripId).notifier)
+        .beginSectionRefinement(_buildSectionSeed(trip, target));
+    setState(() {
+      _panelOpen = true;
+      _refineTarget = target;
+    });
+  }
+
+  /// Whether an item falls inside the refinement target (client-side mirror of
+  /// the server's section selector, using the same hub grouping as the list).
+  bool _inTarget(ItineraryItem it, RefineTarget t) {
+    switch (t.scope) {
+      case 'day':
+        if (it.day != t.day) return false;
+        return t.city == null ||
+            (_hubOf(it)?.toLowerCase() == t.city!.toLowerCase());
+      case 'city':
+        return _hubOf(it)?.toLowerCase() == t.city!.toLowerCase();
+      default:
+        return true;
     }
   }
 
-  /// Builds the seed message that hands the agent the trip's current itinerary,
-  /// including coordinates so it can keep unchanged places without re-searching.
-  String _buildRefineSeed(Trip trip) {
-    final b = StringBuffer("Here's my current itinerary for \"${trip.title}\":\n");
+  /// One compact line per item with everything the agent must echo back to
+  /// keep the item unchanged (coordinates and all tags).
+  String _seedLine(ItineraryItem it) {
+    final b = StringBuffer('- ${it.name}');
+    if (it.category != null) b.write(' [${it.category}]');
+    b.write(' (${it.latitude}, ${it.longitude})');
+    final city = it.city?.trim();
+    if (city != null && city.isNotEmpty) b.write(', city: $city');
+    final hub = it.dayTripFrom?.trim();
+    if (hub != null && hub.isNotEmpty) b.write(', day trip from $hub');
+    if (it.day != null) b.write(', day ${it.day}');
+    if (it.timeOfDay != null) b.write(', ${it.timeOfDay}');
+    return b.toString();
+  }
+
+  /// Builds the panel's seed message: trip context, the target section's items
+  /// in full detail, and explicit instructions to patch only that section via
+  /// update_itinerary_section.
+  String _buildSectionSeed(Trip trip, RefineTarget t) {
     final items = trip.items ?? [];
-    for (var i = 0; i < items.length; i++) {
-      final it = items[i];
-      final category = it.category != null ? ' [${it.category}]' : '';
-      b.writeln('${i + 1}. ${it.name}$category (${it.latitude}, ${it.longitude})');
+    final b = StringBuffer('I want to refine my saved trip "${_displayTitle(trip)}"');
+    if (trip.startDate != null && trip.endDate != null) {
+      b.write(' (${trip.startDate} to ${trip.endDate})');
     }
-    b.write("\nI'd like to refine this trip. When we're done, call create_itinerary "
-        "with the full updated list of places.");
+    b.writeln('.');
+
+    final inTarget = items.where((it) => _inTarget(it, t)).toList();
+    if (t.scope == 'trip') {
+      b.writeln('\nThe full itinerary:');
+    } else {
+      // A one-line digest of the rest of the trip so the agent has context
+      // without treating it as editable.
+      b.writeln('\nFor context, the rest of the trip (do not change these): '
+          '${items.where((it) => !_inTarget(it, t)).map((it) => it.name).join(', ')}.');
+      b.writeln('\nThe section to refine — ${t.label}:');
+    }
+    for (final it in inTarget) {
+      b.writeln(_seedLine(it));
+    }
+
+    b.write('\nOnly change this section unless I broaden the request. When you '
+        'apply a change, call update_itinerary_section with ');
+    switch (t.scope) {
+      case 'day':
+        b.write("scope='day', day=${t.day}");
+        if (t.city != null) b.write(", city='${t.city}'");
+      case 'city':
+        b.write("scope='city', city='${t.city}'");
+      default:
+        b.write("scope='trip'");
+    }
+    b.write(' and the COMPLETE updated list for the section, keeping unchanged '
+        'places exactly as listed above (same coordinates and tags). '
+        'Start by asking what I want to change.');
     return b.toString();
   }
 
@@ -514,6 +585,15 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
               _collapsedDays.add(dayKey);
             }
           });
+        }, () {
+          final trip = _trip;
+          if (trip == null) return;
+          // 'Other places' is a fallback label, not a real hub — omit the city
+          // qualifier so the server matches on the day alone.
+          _openRefine(
+              trip,
+              RefineTarget.day(day,
+                  city: cityKey == 'Other places' ? null : cityKey));
         }));
         if (!collapsed) widgets.addAll(_buildDayTripWidgets(run, theme));
       } else {
@@ -643,7 +723,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
   /// Day section header: shows the calendar date (day N -> startDate + (N-1))
   /// when the trip start is known, otherwise falls back to "Day N".
   Widget _daySubHeader(int day, DateTime? tripStart, ThemeData theme,
-      bool collapsed, int travelMin, VoidCallback onTap) {
+      bool collapsed, int travelMin, VoidCallback onTap, VoidCallback onRefine) {
     final label = tripStart != null
         ? _fmtDayHeader(tripStart.add(Duration(days: day - 1)))
         : 'Day $day';
@@ -674,6 +754,13 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
               ),
               const SizedBox(width: 8),
             ],
+            IconButton(
+              icon: const Icon(Icons.auto_awesome, size: 16),
+              tooltip: 'Refine this day',
+              visualDensity: VisualDensity.compact,
+              color: theme.colorScheme.primary,
+              onPressed: onRefine,
+            ),
             Icon(
               collapsed ? Icons.chevron_right : Icons.expand_more,
               size: 18,
@@ -992,15 +1079,9 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
             SizedBox(
               width: double.infinity,
               child: FilledButton.tonalIcon(
-                onPressed: _refining ? null : () => _refine(trip),
-                icon: _refining
-                    ? const SizedBox(
-                        width: 18,
-                        height: 18,
-                        child: CircularProgressIndicator(strokeWidth: 2),
-                      )
-                    : const Icon(Icons.auto_awesome),
-                label: Text(_refining ? 'Opening…' : 'Refine with AI'),
+                onPressed: () => _openRefine(trip, const RefineTarget.trip()),
+                icon: const Icon(Icons.auto_awesome),
+                label: const Text('Refine with AI'),
               ),
             ),
             if (overview != null) ...[
@@ -1073,8 +1154,9 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
                 )
               : trip == null
                   ? const SizedBox.shrink()
-                  : CustomScrollView(
-                      slivers: [
+                  : LayoutBuilder(builder: (context, constraints) {
+                      final scrollView = CustomScrollView(
+                        slivers: [
                         SliverPadding(
                           padding: const EdgeInsets.fromLTRB(16, 16, 16, 0),
                           sliver: SliverToBoxAdapter(
@@ -1116,10 +1198,10 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
                         SliverPersistentHeader(
                           pinned: true,
                           delegate: _PinnedHeaderDelegate(
-                            // title (24) + gap (8) + chip row (48) + bottom
-                            // padding (8); title-only when there are no items.
+                            // title row (36) + gap (8) + chip row (48) + bottom
+                            // padding (8); title-row-only when there are no items.
                             height:
-                                (trip.items ?? const []).isNotEmpty ? 92 : 40,
+                                (trip.items ?? const []).isNotEmpty ? 100 : 48,
                             backgroundColor: theme.scaffoldBackgroundColor,
                             padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
                             // Align fills the header's full extent so the child's
@@ -1132,8 +1214,27 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
                                 crossAxisAlignment: CrossAxisAlignment.start,
                                 mainAxisSize: MainAxisSize.min,
                                 children: [
-                                  Text('Itinerary',
-                                      style: theme.textTheme.titleMedium),
+                                  SizedBox(
+                                    height: 36,
+                                    child: Row(
+                                      children: [
+                                        Expanded(
+                                          child: Text('Itinerary',
+                                              style:
+                                                  theme.textTheme.titleMedium),
+                                        ),
+                                        TextButton.icon(
+                                          onPressed: _addPlace,
+                                          style: TextButton.styleFrom(
+                                            visualDensity:
+                                                VisualDensity.compact,
+                                          ),
+                                          icon: const Icon(Icons.add, size: 18),
+                                          label: const Text('Add place'),
+                                        ),
+                                      ],
+                                    ),
+                                  ),
                                   if ((trip.items ?? const []).isNotEmpty) ...[
                                     const SizedBox(height: 8),
                                     Wrap(
@@ -1229,6 +1330,24 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
                                                                         .colorScheme.primary),
                                                           ),
                                                         ],
+                                                        // 'Other places' has no hub the
+                                                        // section tool can target.
+                                                        if (group.label != 'Other places')
+                                                          IconButton(
+                                                            icon: const Icon(
+                                                                Icons.auto_awesome,
+                                                                size: 16),
+                                                            tooltip:
+                                                                'Refine ${group.label}',
+                                                            visualDensity:
+                                                                VisualDensity.compact,
+                                                            color: theme
+                                                                .colorScheme.primary,
+                                                            onPressed: () => _openRefine(
+                                                                trip,
+                                                                RefineTarget.city(
+                                                                    group.label)),
+                                                          ),
                                                         const SizedBox(width: 4),
                                                         Icon(
                                                           cityCollapsed
@@ -1295,7 +1414,75 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
                           ),
                         ),
                       ],
-                    ),
+                    );
+
+                      if (!_panelOpen || _refineTarget == null) {
+                        return scrollView;
+                      }
+                      final panel = TripRefinePanel(
+                        tripId: widget.tripId,
+                        target: _refineTarget!,
+                        onClose: () => setState(() => _panelOpen = false),
+                        onTripUpdated: _load,
+                      );
+                      if (constraints.maxWidth >= 900) {
+                        // Wide: dock the chat beside the itinerary.
+                        return Row(
+                          children: [
+                            Expanded(child: scrollView),
+                            const VerticalDivider(width: 1),
+                            SizedBox(width: 400, child: panel),
+                          ],
+                        );
+                      }
+                      // Narrow: collapsible bottom sheet over the page; bottom
+                      // inset keeps the input above the keyboard.
+                      return Stack(
+                        children: [
+                          scrollView,
+                          DraggableScrollableSheet(
+                            initialChildSize: 0.45,
+                            minChildSize: 0.15,
+                            maxChildSize: 0.92,
+                            snap: true,
+                            builder: (context, scrollController) => Material(
+                              elevation: 8,
+                              borderRadius: const BorderRadius.vertical(
+                                  top: Radius.circular(16)),
+                              clipBehavior: Clip.antiAlias,
+                              child: Padding(
+                                padding: EdgeInsets.only(
+                                    bottom:
+                                        MediaQuery.of(context).viewInsets.bottom),
+                                child: Column(
+                                  children: [
+                                    // Drag handle (also a scrollable so the
+                                    // sheet responds to drags at its header).
+                                    SingleChildScrollView(
+                                      controller: scrollController,
+                                      child: Center(
+                                        child: Container(
+                                          width: 36,
+                                          height: 4,
+                                          margin: const EdgeInsets.symmetric(
+                                              vertical: 8),
+                                          decoration: BoxDecoration(
+                                            color: theme.colorScheme.outlineVariant,
+                                            borderRadius:
+                                                BorderRadius.circular(2),
+                                          ),
+                                        ),
+                                      ),
+                                    ),
+                                    Expanded(child: panel),
+                                  ],
+                                ),
+                              ),
+                            ),
+                          ),
+                        ],
+                      );
+                    }),
     );
   }
 

--- a/src/packages/flutter-app/lib/services/plan_service.dart
+++ b/src/packages/flutter-app/lib/services/plan_service.dart
@@ -18,6 +18,7 @@ class PlanService {
     List<Map<String, String>> messages, {
     String? bearerToken,
     String? chatId,
+    String? tripId,
   }) async* {
     final request = http.Request('POST', Uri.parse('$baseUrl/plan'));
     request.headers['Content-Type'] = 'application/json';
@@ -27,6 +28,7 @@ class PlanService {
     request.body = jsonEncode({
       'messages': messages,
       if (chatId != null) 'chat_id': chatId,
+      if (tripId != null) 'trip_id': tripId,
     });
 
     final response = await request.send();

--- a/src/packages/flutter-app/lib/services/trips_api_service.dart
+++ b/src/packages/flutter-app/lib/services/trips_api_service.dart
@@ -85,6 +85,20 @@ class TripsApiService {
     throw Exception('Failed to update trip (${res.statusCode})');
   }
 
+  /// Manually adds one itinerary item; the server slots it at the end of its
+  /// chosen day. Returns the full updated trip (items reloaded, in order).
+  Future<Trip> addItineraryItem(String tripId, Map<String, dynamic> body) async {
+    final res = await apiClient.httpClient.post(
+      Uri.parse('${apiClient.baseUrl}/trips/$tripId/items'),
+      headers: _headers(json: true),
+      body: jsonEncode(body),
+    );
+    if (res.statusCode == 201) {
+      return Trip.fromJson(jsonDecode(res.body));
+    }
+    throw Exception('Failed to add place (${res.statusCode})');
+  }
+
   Future<void> deleteTrip(String id) async {
     final res = await apiClient.httpClient
         .delete(Uri.parse('${apiClient.baseUrl}/trips/$id'), headers: _headers());

--- a/src/packages/flutter-app/lib/widgets/add_itinerary_item_dialog.dart
+++ b/src/packages/flutter-app/lib/widgets/add_itinerary_item_dialog.dart
@@ -1,0 +1,326 @@
+import 'dart:async';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../models/trip.dart';
+import '../models/itinerary_item.dart';
+import '../models/place_search_result.dart';
+import '../providers/places_api_provider.dart';
+import '../providers/trips_provider.dart';
+
+/// Manually adds one place to a trip's itinerary: Google Places search picks a
+/// real place (coordinates/address auto-filled), with a typed-name fallback
+/// when search finds nothing or is unavailable. Pops `true` after saving.
+class AddItineraryItemDialog extends ConsumerStatefulWidget {
+  final Trip trip;
+  final int? initialDay;
+
+  const AddItineraryItemDialog({super.key, required this.trip, this.initialDay});
+
+  @override
+  ConsumerState<AddItineraryItemDialog> createState() =>
+      _AddItineraryItemDialogState();
+}
+
+class _AddItineraryItemDialogState
+    extends ConsumerState<AddItineraryItemDialog> {
+  final _searchController = TextEditingController();
+  final _nameController = TextEditingController();
+  Timer? _debounce;
+  String _query = ''; // debounced search text driving placeSearchProvider
+  PlaceSearchResult? _selected;
+  bool _manual = false;
+  int? _day;
+  String? _timeOfDay;
+  String? _category;
+  bool _saving = false;
+  String? _error;
+
+  int get _maxDay {
+    var max = 0;
+    for (final it in widget.trip.items ?? const <ItineraryItem>[]) {
+      if (it.day != null && it.day! > max) max = it.day!;
+    }
+    return max;
+  }
+
+  /// The hub city of the chosen day's existing items, so the new place joins
+  /// that city group. Without this the group key falls back to the address
+  /// parse, whose locale spelling (e.g. "Lisboa") can split the group the AI
+  /// tagged as "Lisbon".
+  String? _cityForDay(int? day) {
+    if (day == null) return null;
+    for (final it in widget.trip.items ?? const <ItineraryItem>[]) {
+      if (it.day != day) continue;
+      final hub = it.dayTripFrom?.trim();
+      if (hub != null && hub.isNotEmpty) return hub;
+      final city = it.city?.trim();
+      if (city != null && city.isNotEmpty) return city;
+    }
+    return null;
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    _day = widget.initialDay;
+  }
+
+  @override
+  void dispose() {
+    _debounce?.cancel();
+    _searchController.dispose();
+    _nameController.dispose();
+    super.dispose();
+  }
+
+  void _onSearchChanged(String value) {
+    _debounce?.cancel();
+    _debounce = Timer(const Duration(milliseconds: 350), () {
+      if (mounted) setState(() => _query = value.trim());
+    });
+  }
+
+  Future<void> _save() async {
+    final name = _manual ? _nameController.text.trim() : _selected?.name ?? '';
+    if (name.isEmpty) {
+      setState(() => _error =
+          _manual ? 'Enter a name for the place.' : 'Pick a place first.');
+      return;
+    }
+    setState(() {
+      _saving = true;
+      _error = null;
+    });
+    try {
+      final sel = _manual ? null : _selected;
+      final city = _cityForDay(_day);
+      await ref.read(tripsApiServiceProvider).addItineraryItem(widget.trip.id, {
+        'name': name,
+        if (sel != null) 'place_id': sel.placeId,
+        if (sel != null && sel.address.isNotEmpty) 'address': sel.address,
+        if (sel != null) 'latitude': sel.latitude,
+        if (sel != null) 'longitude': sel.longitude,
+        if (_category != null) 'category': _category,
+        if (_timeOfDay != null) 'time_of_day': _timeOfDay,
+        if (_day != null) 'day': _day,
+        if (city != null) 'city': city,
+      });
+      if (mounted) Navigator.pop(context, true);
+    } catch (e) {
+      if (mounted) {
+        setState(() {
+          _saving = false;
+          _error = 'Could not add the place: $e';
+        });
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return AlertDialog(
+      title: const Text('Add place'),
+      content: SizedBox(
+        width: 420,
+        child: SingleChildScrollView(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              if (!_manual) ...[
+                if (_selected == null) ...[
+                  TextField(
+                    controller: _searchController,
+                    autofocus: true,
+                    decoration: const InputDecoration(
+                      labelText: 'Search for a place',
+                      hintText: 'e.g. Pastéis de Belém, Lisbon',
+                      prefixIcon: Icon(Icons.search),
+                      border: OutlineInputBorder(),
+                    ),
+                    onChanged: _onSearchChanged,
+                  ),
+                  if (_query.isNotEmpty) _buildResults(theme),
+                ] else
+                  Card(
+                    margin: const EdgeInsets.only(bottom: 4),
+                    child: ListTile(
+                      leading: const Icon(Icons.place, color: Colors.green),
+                      title: Text(_selected!.name),
+                      subtitle: _selected!.address.isEmpty
+                          ? null
+                          : Text(_selected!.address),
+                      trailing: IconButton(
+                        icon: const Icon(Icons.clear),
+                        tooltip: 'Pick a different place',
+                        onPressed: () => setState(() => _selected = null),
+                      ),
+                    ),
+                  ),
+                if (_selected == null)
+                  Align(
+                    alignment: Alignment.centerLeft,
+                    child: TextButton(
+                      onPressed: () => setState(() => _manual = true),
+                      child: const Text("Can't find it? Add manually"),
+                    ),
+                  ),
+              ] else ...[
+                TextField(
+                  controller: _nameController,
+                  autofocus: true,
+                  decoration: const InputDecoration(
+                    labelText: 'Place name',
+                    border: OutlineInputBorder(),
+                  ),
+                ),
+                Align(
+                  alignment: Alignment.centerLeft,
+                  child: TextButton(
+                    onPressed: () => setState(() => _manual = false),
+                    child: const Text('Search places instead'),
+                  ),
+                ),
+              ],
+              const SizedBox(height: 12),
+              Row(
+                children: [
+                  Expanded(
+                    child: DropdownButtonFormField<int?>(
+                      initialValue: _day,
+                      decoration: const InputDecoration(
+                        labelText: 'Day',
+                        border: OutlineInputBorder(),
+                        isDense: true,
+                      ),
+                      items: [
+                        const DropdownMenuItem(
+                            value: null, child: Text('Unscheduled')),
+                        for (var d = 1; d <= _maxDay; d++)
+                          DropdownMenuItem(value: d, child: Text('Day $d')),
+                        DropdownMenuItem(
+                            value: _maxDay + 1,
+                            child: Text(_maxDay == 0
+                                ? 'Day 1'
+                                : 'New day (${_maxDay + 1})')),
+                      ],
+                      onChanged: (v) => setState(() => _day = v),
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: DropdownButtonFormField<String?>(
+                      initialValue: _timeOfDay,
+                      decoration: const InputDecoration(
+                        labelText: 'Time of day',
+                        border: OutlineInputBorder(),
+                        isDense: true,
+                      ),
+                      items: const [
+                        DropdownMenuItem(value: null, child: Text('Any')),
+                        DropdownMenuItem(
+                            value: 'morning', child: Text('Morning')),
+                        DropdownMenuItem(
+                            value: 'afternoon', child: Text('Afternoon')),
+                        DropdownMenuItem(
+                            value: 'evening', child: Text('Evening')),
+                      ],
+                      onChanged: (v) => setState(() => _timeOfDay = v),
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 12),
+              Wrap(
+                spacing: 8,
+                children: [
+                  for (final c in const [
+                    ('attraction', 'Attraction'),
+                    ('restaurant', 'Restaurant'),
+                  ])
+                    ChoiceChip(
+                      label: Text(c.$2),
+                      selected: _category == c.$1,
+                      onSelected: (sel) =>
+                          setState(() => _category = sel ? c.$1 : null),
+                    ),
+                ],
+              ),
+              if (_error != null) ...[
+                const SizedBox(height: 12),
+                Text(_error!, style: TextStyle(color: theme.colorScheme.error)),
+              ],
+            ],
+          ),
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: _saving ? null : () => Navigator.pop(context),
+          child: const Text('Cancel'),
+        ),
+        FilledButton(
+          onPressed: _saving ? null : _save,
+          child: _saving
+              ? const SizedBox(
+                  width: 18,
+                  height: 18,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                )
+              : const Text('Add'),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildResults(ThemeData theme) {
+    return Consumer(builder: (context, ref, _) {
+      final results = ref.watch(placeSearchProvider(_query));
+      return results.when(
+        data: (list) {
+          if (list.isEmpty) {
+            return const Padding(
+              padding: EdgeInsets.all(12),
+              child: Text('No places found — try a different search, '
+                  'or add the place manually.'),
+            );
+          }
+          return Container(
+            constraints: const BoxConstraints(maxHeight: 240),
+            margin: const EdgeInsets.only(top: 8),
+            decoration: BoxDecoration(
+              border: Border.all(color: theme.colorScheme.outlineVariant),
+              borderRadius: BorderRadius.circular(8),
+            ),
+            child: ListView.builder(
+              shrinkWrap: true,
+              itemCount: list.length,
+              itemBuilder: (context, i) {
+                final place = list[i] as PlaceSearchResult;
+                return ListTile(
+                  dense: true,
+                  leading: const Icon(Icons.place),
+                  title: Text(place.name),
+                  subtitle:
+                      place.address.isEmpty ? null : Text(place.address),
+                  onTap: () => setState(() => _selected = place),
+                );
+              },
+            ),
+          );
+        },
+        loading: () => const Padding(
+          padding: EdgeInsets.all(12),
+          child: Center(child: CircularProgressIndicator()),
+        ),
+        // Search unavailable (e.g. no Places key): steer to manual entry.
+        error: (e, _) => Padding(
+          padding: const EdgeInsets.all(12),
+          child: Text('Search unavailable — add the place manually below.',
+              style: TextStyle(color: theme.colorScheme.error)),
+        ),
+      );
+    });
+  }
+}

--- a/src/packages/flutter-app/lib/widgets/chat_panel.dart
+++ b/src/packages/flutter-app/lib/widgets/chat_panel.dart
@@ -1,0 +1,332 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../models/flight_offer.dart';
+import '../models/plan_message.dart';
+import '../providers/plan_provider.dart';
+import 'flight_offer_card.dart';
+
+/// The plan-agent chat surface (messages, tool chips, flight cards, input bar)
+/// decoupled from any screen, so the full-screen Agent tab and the trip-detail
+/// refine panel share one implementation. The provider pair is passed in:
+/// AgentScreen hands the global [planProvider], the refine panel hands its
+/// per-trip [tripRefineProvider] instance.
+class ChatPanel extends ConsumerStatefulWidget {
+  final ProviderListenable<PlanState> state;
+  final ProviderListenable<PlanNotifier> notifier;
+  final String inputHint;
+
+  /// Shown instead of the message list while the conversation is empty.
+  final Widget? emptyState;
+
+  /// Optional extra content rendered after the messages (e.g. the Agent tab's
+  /// completed-itinerary banner).
+  final Widget Function(BuildContext context, PlanState state)? footerBuilder;
+
+  const ChatPanel({
+    super.key,
+    required this.state,
+    required this.notifier,
+    this.inputHint = 'Describe your trip...',
+    this.emptyState,
+    this.footerBuilder,
+  });
+
+  @override
+  ConsumerState<ChatPanel> createState() => _ChatPanelState();
+}
+
+class _ChatPanelState extends ConsumerState<ChatPanel> {
+  final _controller = TextEditingController();
+  final _scrollController = ScrollController();
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  void _scrollToBottom() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (_scrollController.hasClients) {
+        _scrollController.animateTo(
+          _scrollController.position.maxScrollExtent,
+          duration: const Duration(milliseconds: 200),
+          curve: Curves.easeOut,
+        );
+      }
+    });
+  }
+
+  void _send() {
+    final text = _controller.text.trim();
+    if (text.isEmpty) return;
+    _controller.clear();
+    ref.read(widget.notifier).sendMessage(text);
+    _scrollToBottom();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final planState = ref.watch(widget.state);
+    final theme = Theme.of(context);
+
+    ref.listen(widget.state, (_, next) {
+      if (next.isStreaming || next.streamingText != null) {
+        _scrollToBottom();
+      }
+    });
+
+    return Column(
+      children: [
+        Expanded(
+          child: planState.messages.isEmpty && planState.streamingText == null
+              ? (widget.emptyState ?? const SizedBox.shrink())
+              : ListView(
+                  controller: _scrollController,
+                  padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+                  children: [
+                    for (final msg in planState.messages)
+                      ChatMessageBubble(message: msg),
+                    if (planState.streamingText != null && planState.streamingText!.isNotEmpty)
+                      ChatMessageBubble(
+                        message: PlanMessage(
+                          role: MessageRole.assistant,
+                          content: planState.streamingText!,
+                        ),
+                        isStreaming: true,
+                      ),
+                    if (planState.activeTools.isNotEmpty)
+                      Padding(
+                        padding: const EdgeInsets.symmetric(vertical: 8),
+                        child: Wrap(
+                          spacing: 8,
+                          children: planState.activeTools.map((tool) {
+                            return Chip(
+                              avatar: const SizedBox(
+                                width: 16,
+                                height: 16,
+                                child: CircularProgressIndicator(strokeWidth: 2),
+                              ),
+                              label: Text(_toolLabel(tool)),
+                            );
+                          }).toList(),
+                        ),
+                      ),
+                    if (planState.flightOffers != null && planState.flightOffers!.isNotEmpty)
+                      _FlightOptions(
+                        routeLabel: planState.flightRouteLabel,
+                        offers: planState.flightOffers!,
+                      ),
+                    if (widget.footerBuilder != null)
+                      widget.footerBuilder!(context, planState),
+                    if (planState.error != null)
+                      Container(
+                        margin: const EdgeInsets.symmetric(vertical: 8),
+                        padding: const EdgeInsets.all(12),
+                        decoration: BoxDecoration(
+                          color: theme.colorScheme.errorContainer,
+                          borderRadius: BorderRadius.circular(8),
+                        ),
+                        child: Text(
+                          planState.error!,
+                          style: TextStyle(color: theme.colorScheme.onErrorContainer),
+                        ),
+                      ),
+                  ],
+                ),
+        ),
+        _InputBar(
+          controller: _controller,
+          enabled: !planState.isStreaming,
+          hint: widget.inputHint,
+          onSend: _send,
+        ),
+      ],
+    );
+  }
+
+  String _toolLabel(String tool) {
+    switch (tool) {
+      case 'search_places':
+        return 'Searching places...';
+      case 'create_itinerary':
+        return 'Building itinerary...';
+      case 'update_itinerary_section':
+        return 'Updating itinerary...';
+      case 'search_flights':
+        return 'Searching flights...';
+      default:
+        return '$tool...';
+    }
+  }
+}
+
+class ChatMessageBubble extends StatelessWidget {
+  final PlanMessage message;
+  final bool isStreaming;
+
+  const ChatMessageBubble({super.key, required this.message, this.isStreaming = false});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final isUser = message.role == MessageRole.user;
+
+    return Align(
+      alignment: isUser ? Alignment.centerRight : Alignment.centerLeft,
+      child: Container(
+        margin: const EdgeInsets.symmetric(vertical: 4),
+        padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+        constraints: BoxConstraints(
+          maxWidth: MediaQuery.of(context).size.width * 0.78,
+        ),
+        decoration: BoxDecoration(
+          color: isUser
+              ? theme.colorScheme.primary
+              : theme.colorScheme.surfaceContainerHighest,
+          borderRadius: BorderRadius.only(
+            topLeft: const Radius.circular(16),
+            topRight: const Radius.circular(16),
+            bottomLeft: Radius.circular(isUser ? 16 : 4),
+            bottomRight: Radius.circular(isUser ? 4 : 16),
+          ),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.end,
+          children: [
+            Flexible(
+              child: Text(
+                message.content,
+                style: TextStyle(
+                  color: isUser ? theme.colorScheme.onPrimary : theme.colorScheme.onSurface,
+                ),
+              ),
+            ),
+            if (isStreaming) ...[
+              const SizedBox(width: 6),
+              SizedBox(
+                width: 8,
+                height: 8,
+                child: CircularProgressIndicator(
+                  strokeWidth: 1.5,
+                  color: theme.colorScheme.onSurface.withOpacity(0.5),
+                ),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Inline flight results in the chat — a header plus the agent's top ranked
+/// options as shared FlightOfferCards (first = best match).
+class _FlightOptions extends StatelessWidget {
+  final String? routeLabel;
+  final List<FlightOffer> offers;
+
+  const _FlightOptions({required this.routeLabel, required this.offers});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final label = (routeLabel == null || routeLabel!.trim().isEmpty)
+        ? 'Flight options'
+        : 'Flight options · $routeLabel';
+    return Container(
+      margin: const EdgeInsets.symmetric(vertical: 12),
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: Colors.teal.shade50,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: Colors.teal.shade200),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Icon(Icons.flight, color: Colors.teal.shade700, size: 20),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Text(
+                  label,
+                  style: theme.textTheme.titleSmall?.copyWith(
+                    color: Colors.teal.shade800,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          for (var i = 0; i < offers.length; i++)
+            FlightOfferCard(offer: offers[i], isBest: i == 0),
+        ],
+      ),
+    );
+  }
+}
+
+class _InputBar extends StatelessWidget {
+  final TextEditingController controller;
+  final bool enabled;
+  final String hint;
+  final VoidCallback onSend;
+
+  const _InputBar({
+    required this.controller,
+    required this.enabled,
+    required this.hint,
+    required this.onSend,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      decoration: BoxDecoration(
+        color: theme.colorScheme.surface,
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withOpacity(0.06),
+            blurRadius: 8,
+            offset: const Offset(0, -2),
+          ),
+        ],
+      ),
+      padding: const EdgeInsets.fromLTRB(16, 8, 8, 16),
+      child: Row(
+        children: [
+          Expanded(
+            child: TextField(
+              controller: controller,
+              enabled: enabled,
+              maxLines: null,
+              textInputAction: TextInputAction.send,
+              onSubmitted: enabled ? (_) => onSend() : null,
+              decoration: InputDecoration(
+                hintText: enabled ? hint : 'Thinking...',
+                border: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(24),
+                  borderSide: BorderSide.none,
+                ),
+                filled: true,
+                fillColor: theme.colorScheme.surfaceContainerHighest,
+                contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+              ),
+            ),
+          ),
+          const SizedBox(width: 8),
+          IconButton.filled(
+            onPressed: enabled ? onSend : null,
+            icon: const Icon(Icons.send),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/src/packages/flutter-app/lib/widgets/trip_refine_panel.dart
+++ b/src/packages/flutter-app/lib/widgets/trip_refine_panel.dart
@@ -1,0 +1,93 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../providers/plan_provider.dart';
+import 'chat_panel.dart';
+
+/// Which slice of the itinerary an AI refinement session targets. Mirrors the
+/// server tool's section selector: one day (optionally qualified by city,
+/// since day numbers repeat across cities in legacy trips), one city/hub, or
+/// the whole trip.
+class RefineTarget {
+  final String scope; // 'trip' | 'day' | 'city'
+  final int? day;
+  final String? city;
+
+  const RefineTarget._(this.scope, this.day, this.city);
+  const RefineTarget.trip() : this._('trip', null, null);
+  const RefineTarget.day(int day, {String? city}) : this._('day', day, city);
+  const RefineTarget.city(String city) : this._('city', null, city);
+
+  String get label {
+    switch (scope) {
+      case 'day':
+        return city == null ? 'Day $day' : 'Day $day — $city';
+      case 'city':
+        return city!;
+      default:
+        return 'Whole trip';
+    }
+  }
+}
+
+/// The in-page AI refinement chat for one trip, shown beside (wide layouts) or
+/// over (bottom sheet) the trip detail page. Drives the per-trip
+/// [tripRefineProvider] session and calls [onTripUpdated] whenever the server
+/// reports the trip was patched in place, so the host screen can reload.
+class TripRefinePanel extends ConsumerWidget {
+  final String tripId;
+  final RefineTarget target;
+  final VoidCallback onClose;
+  final VoidCallback onTripUpdated;
+
+  const TripRefinePanel({
+    super.key,
+    required this.tripId,
+    required this.target,
+    required this.onClose,
+    required this.onTripUpdated,
+  });
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final theme = Theme.of(context);
+    ref.listen(tripRefineProvider(tripId).select((s) => s.tripUpdateCount),
+        (prev, next) {
+      if (next > (prev ?? 0)) onTripUpdated();
+    });
+
+    return Column(
+      children: [
+        Padding(
+          padding: const EdgeInsets.fromLTRB(16, 12, 8, 8),
+          child: Row(
+            children: [
+              Icon(Icons.auto_awesome, size: 18, color: theme.colorScheme.primary),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Text(
+                  'Refining · ${target.label}',
+                  style: theme.textTheme.titleSmall
+                      ?.copyWith(fontWeight: FontWeight.bold),
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+              IconButton(
+                icon: const Icon(Icons.close),
+                tooltip: 'Close',
+                onPressed: onClose,
+              ),
+            ],
+          ),
+        ),
+        const Divider(height: 1),
+        Expanded(
+          child: ChatPanel(
+            state: tripRefineProvider(tripId),
+            notifier: tripRefineProvider(tripId).notifier,
+            inputHint: 'Ask for changes...',
+          ),
+        ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
## Summary

Makes a saved trip directly editable from the trip detail page (spec: `specs/itinerary-editing/`):

- **Add place** — `POST /api/v1/trips/{id}/items` inserts one item at the end of its chosen day (positions shifted transactionally). New dialog with Google Places search (coords/address auto-filled), manual-name fallback, and day / time-of-day / category pickers. Added items inherit their day's hub city so address-locale spellings ("Lisboa") don't split the AI-tagged "Lisbon" group.
- **Refine sections with AI** — `/plan` accepts a `trip_id`; a trip-bound session replaces `create_itinerary` with a new `update_itinerary_section` tool (scope `day` / `city` / `trip`) that splices only the targeted items **on the same trip row** and emits a `trip_updated` SSE event so the open page refreshes. Refine (✨) entry points on each day sub-header, each city group header, and the trip header open a chat panel that keeps the trip visible: docked right panel ≥900px, draggable bottom sheet on narrow screens.

## Behavioral change

Refinement no longer creates trip-version rows — it patches in place. The full-screen AgentScreen refine flow is replaced by the in-page panel; `POST /trips/{id}/refine` and the admin versions view become unused by the UI (kept for now, flagged in the spec).

## Implementation notes

- Chat UI extracted from `AgentScreen` into a reusable `ChatPanel`; the panel uses a per-trip `tripRefineProvider` so it never clobbers the Agent tab's conversation. AgentScreen behavior is unchanged.
- `persistTrip`'s per-location coercion is factored into `itemParamsFromLocation`, shared with the section writer so the two `itinerary_items` writers can't drift; both run `reorderItineraryByDistance` before persisting.
- Trip binding fails closed: invalid/unowned/unauthenticated `trip_id` aborts the stream with an SSE error before any tool runs.

## Testing

- `go vet` / `go test` (new table tests for `insertPositionForDay`, `spliceSection`, `hubOfItem`, round-trip coercion), `flutter analyze` / `flutter test` — all green.
- Verified end-to-end on the docker dev stack: curl probes (401/400/404 paths), a live agent session that patched Day 2 in place (items outside the section byte-identical, trip row count flat), and the full add-place + refine-panel flows driven through the real UI in headless Chrome (wide dock + narrow bottom sheet + AgentScreen regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)