### PR TITLE
feat: show travel time from hub city on day-trip sub-headers

### DIFF
--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -624,7 +624,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
       final dt = items[i].dayTripFrom?.trim();
       if (dt != null && dt.isNotEmpty) {
         final town = _cityOf(items[i]) ?? 'Day trip';
-        widgets.add(_dayTripSubHeader(town, theme));
+        widgets.add(_dayTripSubHeader(town, theme, _dayTripTravelLabel(items[i])));
         prev = null; // don't draw a connector across the sub-header
         while (i < items.length) {
           final it = items[i];
@@ -712,6 +712,28 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
     return out;
   }
 
+  /// Travel time from the hub city to a day trip, e.g. "45 min from Paris",
+  /// taken from the already-computed leg into the day trip's first stop. Null
+  /// unless the preceding item is actually in the hub city (so a town-to-town
+  /// or cross-city leg is never mislabeled), or while a category filter is
+  /// active (filtered tiles aren't globally adjacent).
+  String? _dayTripTravelLabel(ItineraryItem first) {
+    if (_itemFilter != 'all') return null;
+    final hub = first.dayTripFrom?.trim();
+    if (hub == null || hub.isEmpty) return null;
+    ItineraryItem? prev;
+    for (final it in _trip?.items ?? const <ItineraryItem>[]) {
+      if (it.position == first.position - 1) prev = it;
+    }
+    if (prev == null) return null;
+    final prevDayTrip = prev.dayTripFrom?.trim();
+    if (prevDayTrip != null && prevDayTrip.isNotEmpty) return null;
+    if (_hubOf(prev) != _hubOf(first)) return null;
+    final timing = _travelByPos[prev.position];
+    if (timing == null || timing.travelToNextMin <= 0) return null;
+    return '${_fmtTravel(timing.travelToNextMin)} from $hub';
+  }
+
   /// Formats a travel duration: "45 min", "1h", or "1h 20m".
   String _fmtTravel(int min) {
     if (min < 60) return '$min min';
@@ -772,19 +794,32 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
     );
   }
 
-  Widget _dayTripSubHeader(String town, ThemeData theme) => Padding(
+  Widget _dayTripSubHeader(String town, ThemeData theme, String? travelLabel) =>
+      Padding(
         padding: const EdgeInsets.fromLTRB(20, 8, 16, 0),
         child: Row(
           children: [
             Icon(Icons.directions_bus, size: 16, color: theme.colorScheme.secondary),
             const SizedBox(width: 6),
-            Text(
-              'Day trip · $town',
-              style: theme.textTheme.labelLarge?.copyWith(
-                color: theme.colorScheme.secondary,
-                fontWeight: FontWeight.w600,
+            Expanded(
+              child: Text(
+                'Day trip · $town',
+                style: theme.textTheme.labelLarge?.copyWith(
+                  color: theme.colorScheme.secondary,
+                  fontWeight: FontWeight.w600,
+                ),
               ),
             ),
+            if (travelLabel != null) ...[
+              Icon(Icons.directions_car_outlined, size: 14,
+                  color: theme.colorScheme.onSurfaceVariant),
+              const SizedBox(width: 4),
+              Text(
+                travelLabel,
+                style: theme.textTheme.bodySmall
+                    ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+              ),
+            ],
           ],
         ),
       );

--- a/src/packages/flutter-app/test/trip_detail_travel_times_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_travel_times_test.dart
@@ -1,0 +1,117 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:travel_route_planner/models/trip.dart';
+import 'package:travel_route_planner/models/itinerary_item.dart';
+import 'package:travel_route_planner/models/location_timing.dart';
+import 'package:travel_route_planner/models/route_request.dart';
+import 'package:travel_route_planner/models/route_response.dart';
+import 'package:travel_route_planner/services/api_client.dart';
+import 'package:travel_route_planner/services/trips_api_service.dart';
+import 'package:travel_route_planner/providers/api_client_provider.dart';
+import 'package:travel_route_planner/providers/trips_provider.dart';
+import 'package:travel_route_planner/screens/trip_detail_screen.dart';
+
+/// Returns a fixed trip without hitting the network, so we can exercise the
+/// real TripDetailScreen render path.
+class _FakeTripsApiService extends TripsApiService {
+  final Trip trip;
+  _FakeTripsApiService(this.trip) : super(ApiClient(baseUrl: 'http://test'));
+
+  @override
+  Future<Trip> getTrip(String id) async => trip;
+}
+
+/// Serves canned per-leg timings for /optimize-route (preserve-order mode), so
+/// the screen's travel-time labels render without a backend.
+class _FakeApiClient extends ApiClient {
+  final List<int> legMinutes; // travel_to_next per location, by input order
+  _FakeApiClient(this.legMinutes) : super(baseUrl: 'http://test');
+
+  @override
+  Future<RouteResponse> optimizeRoute(RouteRequest request) async {
+    final timings = [
+      for (var i = 0; i < request.locations.length; i++)
+        LocationTiming(
+          location: request.locations[i],
+          arrivalTime: '09:00',
+          departureTime: '10:00',
+          visitDurationMin: 60,
+          travelToNextMin: i < legMinutes.length ? legMinutes[i] : 0,
+          travelToNextKm: 10,
+        ),
+    ];
+    return RouteResponse(
+      optimizedRoute: request.locations,
+      totalDistanceKm: 0,
+      totalTravelTimeMin: 0,
+      totalVisitTimeMin: 0,
+      totalTripTimeMin: 0,
+      locationTimings: timings,
+      algorithm: 'preserve_order',
+      locationCount: request.locations.length,
+      status: 'success',
+    );
+  }
+}
+
+ItineraryItem _item(int pos, String name, String address, String category,
+        {int? day, String? city, String? dayTripFrom}) =>
+    ItineraryItem(
+      id: 'i$pos',
+      position: pos,
+      name: name,
+      address: address,
+      // Nonzero coords so the screen requests travel times.
+      latitude: 48.8 + pos,
+      longitude: 2.3 + pos,
+      category: category,
+      day: day,
+      city: city,
+      dayTripFrom: dayTripFrom,
+    );
+
+void main() {
+  testWidgets('day-trip sub-header shows travel time from the hub city',
+      (WidgetTester tester) async {
+    // Tall viewport: with coords present the pinned map takes the top of the
+    // screen, and the lazily-built list must reach the day-trip rows.
+    tester.view.physicalSize = const Size(1200, 3000);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+
+    final trip = Trip(
+      id: 't1',
+      title: 'Europe',
+      status: 'planned',
+      startDate: '2026-06-10',
+      endDate: '2026-06-14',
+      createdAt: '2026-06-01',
+      updatedAt: '2026-06-01',
+      items: [
+        _item(0, 'Louvre', 'Paris, France', 'attraction', day: 1, city: 'Paris'),
+        _item(1, 'Café de Flore', 'Paris, France', 'restaurant', day: 1, city: 'Paris'),
+        // Day 2 in Paris is a day trip to Versailles.
+        _item(2, 'Versailles', 'Versailles, France', 'attraction',
+            day: 2, city: 'Versailles', dayTripFrom: 'Paris'),
+      ],
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          tripsApiServiceProvider.overrideWithValue(_FakeTripsApiService(trip)),
+          // Leg 0: Louvre -> Café (12 min); leg 1: Café -> Versailles (45 min).
+          apiClientProvider.overrideWithValue(_FakeApiClient([12, 45])),
+        ],
+        child: MaterialApp(home: TripDetailScreen(tripId: 't1')),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Day trip · Versailles'), findsOneWidget);
+    // The sub-header carries the hub -> day-trip leg time.
+    expect(find.text('45 min from Paris'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- The "Day trip · <town>" sub-header in the trip detail itinerary now shows how long it takes to get there from its hub city (e.g. "45 min from Paris"), styled like the existing day-header travel chip.
- No new API work: it reuses the hub → day-trip leg already returned by the preserve-order `/optimize-route` call; the UI was previously skipping that leg when suppressing connectors across the sub-header.
- The label is omitted when the preceding stop isn't actually in the hub city (consecutive day-trip towns, a day trip opening the itinerary) and while a category filter is active — consistent with the other travel-time displays.
- Follow-up idea (out of scope): measure from the booked accommodation instead of the last hub stop.

## Test plan
- New widget test `test/trip_detail_travel_times_test.dart` fakes `ApiClient.optimizeRoute` with canned leg timings and asserts the Paris → Versailles fixture renders "45 min from Paris".
- `make flutter-test` (8/8 pass) and `make flutter-analyze` (no new findings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)