### PR TITLE
feat: show trip title in trip-detail app bar

### DIFF
--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -1164,7 +1164,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
 
     return Scaffold(
       appBar: GradientAppBar(
-        title: const Text('Trip'),
+        title: Text(trip != null ? _displayTitle(trip) : 'Trip'),
         actions: [
           if (trip != null)
             IconButton(


### PR DESCRIPTION
## Summary
- Replace the hardcoded "Trip" AppBar title on the trip detail screen with the trip's actual title
- Reuses the existing `_displayTitle` helper, so the bar matches the hero header card (including the computed "cities + dates" title when the stored title is a long AI summary)
- Falls back to "Trip" while the trip is loading or on load failure

## Testing
- `flutter analyze`: no issues in the changed file (pre-existing deprecation infos elsewhere)

🤖 Generated with [Claude Code](https://claude.com/claude-code)