### PR TITLE
feat: embed booking todos inside itinerary city groups

### DIFF
--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -222,6 +222,57 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
     return todos;
   }
 
+  /// Partitions [_bookingTodos] into per-city embedded slots — the flight that
+  /// arrives at the city, its stay, and (for the last city) the return flight
+  /// home — plus the residual list of everything that matched no city
+  /// (user-added `custom:*` todos, stale auto todos). Each todo is claimed at
+  /// most once, so repeated city labels still render each booking exactly once.
+  ({
+    List<({BookingTodo? arrival, BookingTodo? stay, BookingTodo? departure})> slots,
+    List<BookingTodo> residual,
+  }) _groupedBookings(List<String> groupLabels) {
+    final claimed = <String>{};
+    BookingTodo? claim(bool Function(BookingTodo) test) {
+      for (final t in _bookingTodos) {
+        if (!claimed.contains(t.id) && test(t)) {
+          claimed.add(t.id);
+          return t;
+        }
+      }
+      return null;
+    }
+
+    final arrivals = <BookingTodo?>[];
+    final stays = <BookingTodo?>[];
+    for (final label in groupLabels) {
+      final l = label.toLowerCase();
+      arrivals.add(claim(
+          (t) => t.kind == 'transport' && t.todoKey.endsWith('>>$l')));
+      stays.add(claim((t) => t.todoKey == 'stay:$l'));
+    }
+    // Claimed after all arrivals so an inter-city leg can't be taken as its
+    // origin's departure — only the final leg home remains unclaimed by then.
+    BookingTodo? departure;
+    if (groupLabels.isNotEmpty) {
+      final last = groupLabels.last.toLowerCase();
+      departure = claim((t) =>
+          t.kind == 'transport' && t.todoKey.startsWith('transport:$last>>'));
+    }
+
+    return (
+      slots: [
+        for (var i = 0; i < groupLabels.length; i++)
+          (
+            arrival: arrivals[i],
+            stay: stays[i],
+            departure: i == groupLabels.length - 1 ? departure : null,
+          ),
+      ],
+      residual:
+          _bookingTodos.where((t) => !claimed.contains(t.id)).toList(),
+    );
+  }
+
   Future<void> _setBooked(BookingTodo todo, bool booked) async {
     final prev = _bookingTodos;
     setState(() {
@@ -601,6 +652,28 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
       }
     }
     return widgets;
+  }
+
+  /// Compact booking rows for a city group's slot: arrival flight + stay when
+  /// [departureOnly] is false, the return-home flight when true.
+  List<Widget> _bookingRowWidgets(
+    ({BookingTodo? arrival, BookingTodo? stay, BookingTodo? departure}) slot, {
+    required bool departureOnly,
+  }) {
+    final todos = departureOnly
+        ? [slot.departure]
+        : [slot.arrival, slot.stay];
+    return [
+      for (final todo in todos)
+        if (todo != null)
+          BookingTodoRow(
+            todo: todo,
+            onBookedChanged: (v) => _setBooked(todo, v),
+            onOpen: _openCallbackFor(todo),
+            openLabelOverride:
+                _flightLegs.containsKey(todo.todoKey) ? 'Find flights' : null,
+          ),
+    ];
   }
 
   /// Batches consecutive day-trip places (by town) under an indented
@@ -1190,6 +1263,10 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
               : trip == null
                   ? const SizedBox.shrink()
                   : LayoutBuilder(builder: (context, constraints) {
+                      // City-matched bookings render inside their city group;
+                      // the rest fall through to the "Other bookings" section.
+                      final grouped = _groupedBookings(
+                          [for (final r in _locationGroupRanges(trip)) r.label]);
                       final scrollView = CustomScrollView(
                         slivers: [
                         SliverPadding(
@@ -1317,7 +1394,8 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
                                     final groups = _buildGroups(filtered, _locationDates(trip));
                                     return Column(
                                       children: [
-                                        for (final group in groups) ...[
+                                        for (final (gi, group)
+                                            in groups.indexed) ...[
                                           Builder(builder: (_) {
                                             final cityCollapsed =
                                                 _collapsedCities.contains(group.label);
@@ -1400,36 +1478,58 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
                                               ),
                                             );
                                           }),
-                                          if (!_collapsedCities.contains(group.label))
+                                          if (!_collapsedCities.contains(group.label)) ...[
+                                            // Embedded bookings render only in the
+                                            // unfiltered view: a category filter can
+                                            // merge adjacent same-label runs, which
+                                            // would break the slot<->group mapping.
+                                            if (_itemFilter == 'all' &&
+                                                gi < grouped.slots.length)
+                                              ..._bookingRowWidgets(
+                                                  grouped.slots[gi],
+                                                  departureOnly: false),
                                             ..._buildGroupItemWidgets(
                                                 group.label,
                                                 group.items,
                                                 theme,
                                                 DateTime.tryParse(trip.startDate ?? '')),
+                                            if (_itemFilter == 'all' &&
+                                                gi == groups.length - 1 &&
+                                                gi < grouped.slots.length)
+                                              ..._bookingRowWidgets(
+                                                  grouped.slots[gi],
+                                                  departureOnly: true),
+                                          ],
                                         ],
                                       ],
                                     );
                                   }),
-                                const Divider(height: 32),
-                                Row(
-                                  children: [
-                                    Expanded(child: Text('Bookings', style: theme.textTheme.titleMedium)),
-                                    TextButton.icon(
+                                // Bookings live embedded in their city groups;
+                                // this section appears only when something
+                                // didn't match a city (custom or stale todos).
+                                if (grouped.residual.isEmpty)
+                                  Align(
+                                    alignment: Alignment.centerRight,
+                                    child: TextButton.icon(
                                       onPressed: _addBooking,
                                       icon: const Icon(Icons.add, size: 18),
-                                      label: const Text('Add'),
+                                      label: const Text('Add booking'),
                                     ),
-                                  ],
-                                ),
-                                const SizedBox(height: 8),
-                                if (_bookingTodos.isEmpty)
-                                  const Padding(
-                                    padding: EdgeInsets.symmetric(vertical: 8),
-                                    child: Text(
-                                        'No bookings yet — they appear here once your itinerary has places.'),
                                   )
-                                else
-                                  for (final todo in _bookingTodos)
+                                else ...[
+                                  const Divider(height: 32),
+                                  Row(
+                                    children: [
+                                      Expanded(child: Text('Other bookings', style: theme.textTheme.titleMedium)),
+                                      TextButton.icon(
+                                        onPressed: _addBooking,
+                                        icon: const Icon(Icons.add, size: 18),
+                                        label: const Text('Add'),
+                                      ),
+                                    ],
+                                  ),
+                                  const SizedBox(height: 8),
+                                  for (final todo in grouped.residual)
                                     Padding(
                                       padding: const EdgeInsets.symmetric(vertical: 4),
                                       child: BookingTodoCard(
@@ -1444,6 +1544,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
                                             todo.auto ? null : () => _deleteTodo(todo),
                                       ),
                                     ),
+                                ],
                               ],
                             ),
                           ),

--- a/src/packages/flutter-app/lib/widgets/booking_todo_card.dart
+++ b/src/packages/flutter-app/lib/widgets/booking_todo_card.dart
@@ -1,6 +1,35 @@
 import 'package:flutter/material.dart';
 import '../models/booking_todo.dart';
 
+IconData _kindIcon(BookingTodo todo) {
+  switch (todo.kind) {
+    case 'transport':
+      return Icons.flight;
+    case 'stay':
+      return Icons.hotel;
+    default:
+      return Icons.check_circle_outline;
+  }
+}
+
+String _providerOpenLabel(BookingTodo todo, String? override) {
+  if (override != null) return override;
+  switch (todo.provider) {
+    case 'airbnb':
+      return 'Open in Airbnb';
+    case 'booking':
+      return 'Open in Booking.com';
+    case 'google_flights':
+      return 'Open in Google Flights';
+    case 'kayak':
+      return 'Open in Kayak';
+    case 'rome2rio':
+      return 'Open in Rome2Rio';
+    default:
+      return 'Open search';
+  }
+}
+
 /// A styled booking checklist card: an icon by kind, the title + dates, a
 /// "Booked" checkbox, and a button that opens the pre-filled search link.
 class BookingTodoCard extends StatelessWidget {
@@ -22,34 +51,9 @@ class BookingTodoCard extends StatelessWidget {
     this.openLabelOverride,
   });
 
-  IconData get _icon {
-    switch (todo.kind) {
-      case 'transport':
-        return Icons.flight;
-      case 'stay':
-        return Icons.hotel;
-      default:
-        return Icons.check_circle_outline;
-    }
-  }
+  IconData get _icon => _kindIcon(todo);
 
-  String get _openLabel {
-    if (openLabelOverride != null) return openLabelOverride!;
-    switch (todo.provider) {
-      case 'airbnb':
-        return 'Open in Airbnb';
-      case 'booking':
-        return 'Open in Booking.com';
-      case 'google_flights':
-        return 'Open in Google Flights';
-      case 'kayak':
-        return 'Open in Kayak';
-      case 'rome2rio':
-        return 'Open in Rome2Rio';
-      default:
-        return 'Open search';
-    }
-  }
+  String get _openLabel => _providerOpenLabel(todo, openLabelOverride);
 
   @override
   Widget build(BuildContext context) {
@@ -105,6 +109,73 @@ class BookingTodoCard extends StatelessWidget {
             ),
           ],
         ),
+      ),
+    );
+  }
+}
+
+/// A slim one-line booking row for embedding inside the itinerary's city
+/// groups: kind icon, title + dates, a compact "Booked" checkbox, and the
+/// open-search action. Auto bookings only — no delete affordance.
+class BookingTodoRow extends StatelessWidget {
+  final BookingTodo todo;
+  final ValueChanged<bool> onBookedChanged;
+  final VoidCallback? onOpen;
+
+  /// Same override as [BookingTodoCard.openLabelOverride].
+  final String? openLabelOverride;
+
+  const BookingTodoRow({
+    super.key,
+    required this.todo,
+    required this.onBookedChanged,
+    this.onOpen,
+    this.openLabelOverride,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final muted = theme.colorScheme.onSurfaceVariant;
+    return Padding(
+      padding: const EdgeInsets.only(left: 12, top: 2, bottom: 2),
+      child: Row(
+        children: [
+          Icon(_kindIcon(todo), size: 18, color: theme.colorScheme.primary),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  todo.title,
+                  style: theme.textTheme.bodyMedium?.copyWith(
+                    color: todo.booked ? muted : null,
+                    decoration: todo.booked ? TextDecoration.lineThrough : null,
+                  ),
+                ),
+                if (todo.subtitle != null && todo.subtitle!.isNotEmpty)
+                  Text(
+                    todo.subtitle!,
+                    style: theme.textTheme.bodySmall?.copyWith(color: muted),
+                  ),
+              ],
+            ),
+          ),
+          TextButton.icon(
+            onPressed: onOpen,
+            icon: const Icon(Icons.open_in_new, size: 16),
+            label: Text(_providerOpenLabel(todo, openLabelOverride)),
+          ),
+          // Last so the fixed-width checkboxes stay flush right and aligned
+          // across rows despite varying button-label widths.
+          Checkbox(
+            value: todo.booked,
+            onChanged: (v) => onBookedChanged(v ?? false),
+            visualDensity: VisualDensity.compact,
+            materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+          ),
+        ],
       ),
     );
   }

--- a/src/packages/flutter-app/test/trip_detail_bookings_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_bookings_test.dart
@@ -1,0 +1,144 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:travel_route_planner/models/trip.dart';
+import 'package:travel_route_planner/models/itinerary_item.dart';
+import 'package:travel_route_planner/models/booking_todo.dart';
+import 'package:travel_route_planner/services/api_client.dart';
+import 'package:travel_route_planner/services/trips_api_service.dart';
+import 'package:travel_route_planner/providers/trips_provider.dart';
+import 'package:travel_route_planner/screens/trip_detail_screen.dart';
+import 'package:travel_route_planner/widgets/booking_todo_card.dart';
+
+/// Returns a fixed trip without hitting the network, so we can exercise the
+/// real TripDetailScreen render path. The booking-todo sync call fails in the
+/// test env and is swallowed, so the todos seeded on the trip survive.
+class _FakeTripsApiService extends TripsApiService {
+  final Trip trip;
+  _FakeTripsApiService(this.trip) : super(ApiClient(baseUrl: 'http://test'));
+
+  @override
+  Future<Trip> getTrip(String id) async => trip;
+}
+
+ItineraryItem _item(int pos, String name, String address, String category,
+        {int? day, String? city}) =>
+    ItineraryItem(
+      id: 'i$pos',
+      position: pos,
+      name: name,
+      address: address,
+      // Zero coords so the screen skips the map widget in the test env.
+      latitude: 0,
+      longitude: 0,
+      category: category,
+      day: day,
+      city: city,
+    );
+
+BookingTodo _todo(String kind, String key, String title, {bool auto = true}) =>
+    BookingTodo(id: key, kind: kind, todoKey: key, title: title, auto: auto);
+
+void main() {
+  testWidgets('city-matched bookings embed in their group; rest are residual',
+      (WidgetTester tester) async {
+    final trip = Trip(
+      id: 't1',
+      title: 'Europe',
+      status: 'planned',
+      startDate: '2026-06-10',
+      endDate: '2026-06-13',
+      createdAt: '2026-06-01',
+      updatedAt: '2026-06-01',
+      items: [
+        _item(0, 'Louvre', 'Paris, France', 'attraction', day: 1, city: 'Paris'),
+        _item(1, 'Café de Flore', 'Paris, France', 'restaurant', day: 2, city: 'Paris'),
+        _item(2, 'Colosseum', 'Rome, Italy', 'attraction', day: 3, city: 'Rome'),
+        _item(3, 'Trastevere', 'Rome, Italy', 'restaurant', day: 4, city: 'Rome'),
+      ],
+      bookingTodos: [
+        _todo('transport', 'transport:jfk>>paris', 'JFK → Paris'),
+        _todo('stay', 'stay:paris', 'Stay in Paris'),
+        _todo('transport', 'transport:paris>>rome', 'Paris → Rome'),
+        _todo('stay', 'stay:rome', 'Stay in Rome'),
+        _todo('transport', 'transport:rome>>jfk', 'Rome → JFK'),
+        _todo('other', 'custom:x', 'Museum tickets', auto: false),
+      ],
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          tripsApiServiceProvider.overrideWithValue(_FakeTripsApiService(trip)),
+        ],
+        child: MaterialApp(home: TripDetailScreen(tripId: 't1')),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // City-matched bookings render once each, as compact embedded rows.
+    expect(find.widgetWithText(BookingTodoRow, 'Stay in Paris'), findsOneWidget);
+    expect(find.widgetWithText(BookingTodoRow, 'Stay in Rome'), findsOneWidget);
+    expect(find.widgetWithText(BookingTodoRow, 'JFK → Paris'), findsOneWidget);
+    expect(find.widgetWithText(BookingTodoRow, 'Paris → Rome'), findsOneWidget);
+    expect(find.widgetWithText(BookingTodoRow, 'Rome → JFK'), findsOneWidget);
+
+    // Arrival + stay sit above the city's first item; the return flight home
+    // comes after the last city's last item.
+    expect(tester.getTopLeft(find.text('JFK → Paris')).dy,
+        lessThan(tester.getTopLeft(find.text('Louvre')).dy));
+    expect(tester.getTopLeft(find.text('Paris → Rome')).dy,
+        lessThan(tester.getTopLeft(find.text('Colosseum')).dy));
+    expect(tester.getTopLeft(find.text('Rome → JFK')).dy,
+        greaterThan(tester.getTopLeft(find.text('Trastevere')).dy));
+
+    // Only the unmatched custom todo remains in "Other bookings", as a card.
+    expect(find.text('Other bookings'), findsOneWidget);
+    expect(find.byType(BookingTodoCard), findsOneWidget);
+    expect(find.widgetWithText(BookingTodoCard, 'Museum tickets'), findsOneWidget);
+  });
+
+  testWidgets('collapsing a city hides its embedded booking rows',
+      (WidgetTester tester) async {
+    final trip = Trip(
+      id: 't2',
+      title: 'Weekend away',
+      status: 'planned',
+      startDate: '2026-06-10',
+      endDate: '2026-06-12',
+      createdAt: '2026-06-01',
+      updatedAt: '2026-06-01',
+      items: [
+        _item(0, 'Louvre', 'Paris, France', 'attraction', day: 1, city: 'Paris'),
+      ],
+      bookingTodos: [
+        _todo('transport', 'transport:jfk>>paris', 'JFK → Paris'),
+        _todo('stay', 'stay:paris', 'Stay in Paris'),
+      ],
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          tripsApiServiceProvider.overrideWithValue(_FakeTripsApiService(trip)),
+        ],
+        child: MaterialApp(home: TripDetailScreen(tripId: 't2')),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byType(BookingTodoRow), findsNWidgets(2));
+
+    // No unmatched bookings -> no "Other bookings" section, just the inline
+    // add affordance.
+    expect(find.text('Other bookings'), findsNothing);
+    expect(find.text('Add booking'), findsOneWidget);
+
+    await tester.tap(find.text('Paris'));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(BookingTodoRow), findsNothing);
+    expect(find.text('Louvre'), findsNothing);
+  });
+}


### PR DESCRIPTION
## Summary
- Each itinerary city group now embeds its bookings as compact rows: the arriving flight + stay directly under the city header, and the return-home flight after the last city's final item. Rows collapse with the city and show only in the unfiltered view.
- New slim `BookingTodoRow` widget (kind icon, struck-through title when booked, open-search action, checkbox flush right so checkboxes align across rows); shares icon/label helpers with the existing `BookingTodoCard`.
- Todos match cities by `todo_key` (`stay:paris`, `transport:paris>>rome`) with each claimed at most once, so repeated city labels still render every booking exactly once.
- The old flat "Bookings" checklist becomes a residual "Other bookings" section that renders only when something didn't match a city (custom `custom:*` todos, stale auto legs); when empty, a right-aligned "Add booking" button keeps custom bookings reachable.

## Testing
- `make flutter-test` — all 10 tests pass, including new `test/trip_detail_bookings_test.dart` (embedding positions, exactly-once rendering, residual section hidden when empty, collapse hides rows).
- `flutter analyze` — zero issues in touched files (the `make flutter-analyze` target fails on 34 pre-existing infos/warnings in unrelated widgets).
- Manual: verified in the dev stack — embedded rows under Paris, checkbox alignment, Find Flights routing, residual section hidden on a fully-matched trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)