### PR TITLE
feat: AI-maintained traveler profile notes that refine over time

### DIFF
--- a/specs/traveler-profile-notes/plan.md
+++ b/specs/traveler-profile-notes/plan.md
@@ -1,0 +1,92 @@
+# Plan: Traveler Profile Notes
+
+> **HOW.** See `../../CLAUDE.md` for conventions. Builds on traveler-preferences.
+
+## Technical Approach
+
+One new nullable `profile_notes text` column on `traveler_preferences`, flowing
+through the existing COALESCE merge-upsert. Two writers, one mechanism: the
+model always returns the **complete rewritten notes document** (current notes
+are in its prompt; it merges + dedupes, ≤ ~15 bullet lines), and the server
+does a wholesale replace — nil keeps, non-nil replaces — capped at 2000 runes
+by a `normalizeNotes` helper. Live path extends the existing `save_preferences`
+tool; post-trip path is a fire-and-forget goroutine (`profile_distiller.go`)
+launched after `persistTrip` succeeds, making one non-streamed Claude call over
+the text transcript with a forced tool. A new `profile_updated` SSE event gives
+in-chat feedback for live saves only.
+
+## Go API Changes
+
+`src/packages/api/`:
+- **Migration `migrations/00016_profile_notes.sql`:**
+  `ALTER TABLE traveler_preferences ADD COLUMN profile_notes text` (+ Down drop).
+- **`query/preferences.sql`:** add `profile_notes` to `UpsertPreferences`
+  insert list / `sqlc.narg('profile_notes')` / `DO UPDATE … COALESCE(...)`.
+  `GetPreferences` is `SELECT *` — no change. Then `make api-sqlc`
+  (`store.TravelerPreference`/`UpsertPreferencesParams` gain `ProfileNotes *string`).
+- **`preferences_handler.go`:** `const maxProfileNotesLen = 2000`;
+  `normalizeNotes(v *string) *string` — nil→nil, trim, rune-boundary truncate;
+  on the PUT path `""` stays pointer-to-empty (user clear). Add
+  `ProfileNotes *string \`json:"profile_notes"\`` to response/request structs.
+
+## Agent integration (`plan_handler.go`)
+
+- **`save_preferences` tool:** optional `profile_notes` string; description
+  demands the COMPLETE updated profile (merged + deduped), never just the new fact.
+- **`personalizedSystemPrompt`:** when notes exist, append a
+  "Traveler profile notes (maintained by you)" block; always (authed) append a
+  standing instruction to save the full rewritten profile when learning
+  something durable — no one-off trip details, no sensitive data.
+- **Tool branch:** `normalizeNotes`, coerce pointer-to-empty → nil (agent can't
+  wipe), upsert, then `sendSSE(w, "profile_updated", {fields, notes_preview})`
+  before the existing `tool_result`.
+- **After `persistTrip` succeeds** (authed, once per request):
+  `go distillTravelerProfile(context.Background(), client, uid, req.Messages)` —
+  request ctx dies on return; `pgxpool` is goroutine-safe.
+
+## Distiller (`profile_distiller.go`, new)
+
+- `distillTavelerProfile(ctx, client, uid, transcript)` — 60s timeout; load
+  current prefs (ignore no-rows); one non-streamed `Messages.New`
+  (claude-sonnet-4-6, MaxTokens 1024) with forced tool
+  `update_traveler_profile` (same schema as `save_preferences`); normalize all
+  fields through the same helpers; same upsert. All errors logged + swallowed.
+- `buildDistillationTranscript(msgs, maxMsgs, maxChars)` — pure; text turns
+  only, newest-biased, ~40 msgs / ~30k chars.
+
+## Flutter Changes
+
+`src/packages/flutter-app/lib/`:
+- **`models/traveler_preferences.dart`:** `profileNotes String?`
+  (`@JsonKey(name: 'profile_notes')`) + `make flutter-build-models`.
+- **`services/preferences_api_service.dart` / `providers/preferences_provider.dart`:**
+  thread `profileNotes` through `savePreferences`/`save()`.
+- **`providers/plan_provider.dart`:** `PlanState.profileUpdateNote String?`
+  (sentinel copyWith); handle `profile_updated`; clear on each `sendMessage`.
+- **`screens/preferences_screen.dart`:** "Profile notes" section — caption +
+  multiline `TextField` (maxLength 2000), saved via the existing Save button
+  (empty text clears).
+- **`screens/agent_screen.dart`:** transient "Noted" chip beside the tool
+  chips when `profileUpdateNote` is set, excerpt as tooltip.
+
+## Contract Parity
+| JSON key | Go | Dart | Nullable | ✓ |
+|---|---|---|---|---|
+| `profile_notes` | `*string` (`preferences_handler.go`) | `String? profileNotes` | yes | [x] |
+| `profile_updated.fields` | `[]string` | read loosely | no | [x] |
+| `profile_updated.notes_preview` | `string` | `String?` | yes | [x] |
+
+## Cross-cutting
+- No new env vars; distiller reuses the plan handler's Anthropic client.
+- Known race: live save vs distillation — last-writer-wins, acceptable since
+  both send full rewrites.
+
+## Verification
+1. `make api-sqlc`; `make api-fmt && make api-vet`; `go test ./...` (table
+   tests: `normalizeNotes`, `buildDistillationTranscript`,
+   `personalizedSystemPrompt` with/without notes).
+2. `make flutter-build-models`; `make flutter-analyze`; `make flutter-test`.
+3. `make docker-dev` (API needs `up --build` for Go + migration changes):
+   live save → "Noted" chip + GET shows notes; full trip → distilled notes in
+   DB within ~10s; edit/clear on profile screen persists; anonymous session
+   unaffected; distill failure only logs.

--- a/specs/traveler-profile-notes/spec.md
+++ b/specs/traveler-profile-notes/spec.md
@@ -1,0 +1,115 @@
+# Spec: Traveler Profile Notes (knowledge that refines over time)
+
+> **WHAT & WHY only.** No tech choices, file names, libraries, or code.
+
+## Context
+
+The agent's knowledge of a traveler is limited to four structured fields
+(budget, pace, interests, home airport). Everything else it learns while
+planning — travel companions, dietary needs, accommodation style, dislikes —
+evaporates when the session ends. This feature adds a **free-text profile**
+the agent maintains and refines across trips: it records durable facts the
+moment the traveler reveals them, and after each trip is planned it distills
+the whole conversation for anything it missed. The traveler can always see
+and edit what's been learned. Builds on traveler-preferences (profile storage
+and agent read/write) and user accounts.
+
+## User Stories
+
+- As a **traveler**, when I mention something durable about myself mid-chat
+  ("I'm vegetarian", "we travel with two kids"), I want the agent to remember
+  it for every future trip without me repeating it.
+- As a **traveler**, I want the system to learn from the *whole* planning
+  conversation — including things the agent didn't think to note at the time —
+  so its picture of me improves with every trip I plan.
+- As a **traveler**, I want to see everything the AI has noted about me and
+  edit or clear it, so wrong inferences never stick.
+- As a **traveler**, I want subtle in-chat feedback when the agent notes
+  something, so I know it's learning (and what).
+
+## Acceptance Criteria
+
+- [ ] The profile gains a free-text **notes** section alongside the existing
+      structured fields; notes persist across sessions and feed the agent's
+      context on every authenticated chat.
+- [ ] When a signed-in user reveals a durable fact mid-conversation, the agent
+      saves it into the notes and the chat shows a brief "noted" indicator.
+- [ ] After a signed-in user's itinerary is created, the system distills the
+      conversation and merges what it learned (notes, and structured fields
+      only when clearly established) into the profile — without delaying or
+      ever failing the itinerary.
+- [ ] Notes are merged and de-duplicated over time, not appended forever; they
+      stay within a fixed size cap (2000 characters).
+- [ ] The Travel profile screen shows the notes; the user can edit or clear
+      them, and edits persist.
+- [ ] The agent can never wipe the notes wholesale; only the user can clear them.
+- [ ] Anonymous sessions: no notes are read, written, or distilled; planning
+      works as before.
+
+## API Surface
+
+### `GET /api/v1/preferences` (existing, extended)
+- **Response:** adds `profile_notes` (string or null).
+
+### `PUT /api/v1/preferences` (existing, extended)
+- **Request:** adds optional `profile_notes`. Omitted = unchanged; empty
+  string = clear. Over-long values are truncated to the cap.
+- **Response:** the updated profile including `profile_notes`.
+
+### `POST /api/v1/plan` (existing, extended)
+- New SSE event **`profile_updated`** emitted when the agent saves profile
+  learnings live: `fields` (list of field names that changed) and
+  `notes_preview` (short excerpt of the saved notes, may be empty).
+- Post-trip distillation produces **no** SSE event (it runs after the
+  response completes); its results appear on the next profile load/session.
+
+## Data Model
+
+- **Traveler Preferences** (existing, extended) — adds *Profile notes*: a
+  short free-text document (bullet-style lines) maintained primarily by the
+  AI; optional/unset; capped at 2000 characters. Each write replaces the
+  whole document with a merged, de-duplicated rewrite.
+
+## UI Behavior
+
+- **Travel profile screen:** a "Profile notes" section with a multiline text
+  field pre-filled with current notes, a caption explaining the AI maintains
+  it, and the existing Save action (clearing the field clears the notes).
+- **Agent chat:** when the agent saves learnings live, a small transient
+  "Noted" indicator appears alongside the existing tool-activity chips, with
+  the notes excerpt available on hover/long-press. No indicator for post-trip
+  distillation.
+
+## Edge Cases & Error States
+
+- Distillation failure (model error, timeout, missing key) → logged only; the
+  trip and the chat response are unaffected.
+- Agent sends empty/whitespace notes → treated as "no change", never a wipe.
+- User PUT with empty string → clears notes (distinct from omitting the key).
+- Notes over the cap (any writer) → truncated safely (no broken characters).
+- Concurrent live save and distillation → last write wins; acceptable because
+  every write is a full merged rewrite built from recent state.
+- Older/other clients that don't know `profile_updated` ignore it.
+
+## Out of Scope
+
+- Periodic/background re-analysis across all past trips (no job infra yet).
+- Per-trip notes or trip-scoped overrides (global profile only).
+- Structured expansion of the schema (dietary/companions as typed columns) —
+  the notes field is deliberately free-form.
+- Surfacing distillation results in the same chat session.
+
+## Resolved Decisions
+
+- **Representation:** hybrid — keep structured fields, add one free-text
+  notes document (not a separate notes-per-fact table, not more columns).
+- **Learning timing:** both live (agent tool during chat) and post-trip
+  distillation (one extra model pass over the transcript after the itinerary
+  is created). No periodic background jobs.
+- **Visibility:** fully visible and editable by the user, with live in-chat
+  feedback on saves.
+- **Merge mechanism:** the model always rewrites the complete notes document
+  (merge + dedupe, ≤ ~15 short lines); storage does wholesale replace with a
+  hard size cap. No server-side diffing.
+- **Distillation runs asynchronously** after the itinerary persists, so it can
+  never delay or fail trip creation; in exchange it gets no in-chat feedback.

--- a/specs/traveler-profile-notes/tasks.md
+++ b/specs/traveler-profile-notes/tasks.md
@@ -1,0 +1,34 @@
+# Tasks: Traveler Profile Notes
+
+> Dependency-ordered. `[P]` = parallel-safe. Verification last.
+
+## Schema & codegen (Go)
+- [x] Write `migrations/00016_profile_notes.sql` (add/drop `profile_notes`)
+- [x] Extend `query/preferences.sql` `UpsertPreferences` with `profile_notes` COALESCE merge
+- [x] `make api-sqlc`; confirm `store` regenerates + compiles
+
+## API (Go)
+- [x] `preferences_handler.go`: `normalizeNotes` (trim, rune-safe 2000 cap) + `profile_notes` on GET/PUT structs
+
+## Agent (Go)
+- [x] Extend `save_preferences` tool schema + description (complete-rewrite contract)
+- [x] `personalizedSystemPrompt`: notes block + standing profile-keeping instruction
+- [x] Tool branch: normalize, empty→nil (no agent wipe), upsert, emit `profile_updated` SSE
+- [x] New `profile_distiller.go`: `buildDistillationTranscript` + `distillTravelerProfile` (forced tool, errors logged only)
+- [x] Hook distiller goroutine after `persistTrip` (authed, once per request, `context.Background()`)
+
+## Verify backend
+- [x] `make api-fmt && make api-vet` clean
+- [x] `go test ./...`: `normalizeNotes`, `buildDistillationTranscript`, `personalizedSystemPrompt` notes cases
+
+## Flutter
+- [x] [P] `models/traveler_preferences.dart`: `profileNotes` + `make flutter-build-models`
+- [x] [P] `services/preferences_api_service.dart` + `providers/preferences_provider.dart`: thread `profileNotes`
+- [x] `providers/plan_provider.dart`: `profileUpdateNote` state + `profile_updated` case
+- [x] `screens/preferences_screen.dart`: Profile notes section (multiline field, clear = empty)
+- [x] `screens/agent_screen.dart`: transient "Noted" chip with excerpt tooltip
+- [x] Complete Contract Parity table in `plan.md`
+
+## Verify frontend
+- [x] `make flutter-analyze` clean; `make flutter-test` passes
+- [x] docker-dev end-to-end: live save, distillation, edit/clear, anonymous unaffected

--- a/src/packages/api/migrations/00016_profile_notes.sql
+++ b/src/packages/api/migrations/00016_profile_notes.sql
@@ -1,0 +1,5 @@
+-- +goose Up
+ALTER TABLE traveler_preferences ADD COLUMN profile_notes text; -- AI-maintained bullet profile, capped at 2000 chars
+
+-- +goose Down
+ALTER TABLE traveler_preferences DROP COLUMN IF EXISTS profile_notes;

--- a/src/packages/api/plan_handler.go
+++ b/src/packages/api/plan_handler.go
@@ -127,7 +127,7 @@ func planHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	savePrefsTool := anthropic.ToolParam{
 		Name:        "save_preferences",
-		Description: anthropic.String("Save what you learn about the traveler's preferences so future trips are personalized. Call this when the user reveals a budget level, trip pace, interests, or which airport they fly from. Only include fields you actually learned."),
+		Description: anthropic.String("Save what you learn about the traveler so future trips are personalized. Call this when the user reveals a budget level, trip pace, interests, which airport they fly from, or any other durable fact about how they travel. Only include fields you actually learned."),
 		InputSchema: anthropic.ToolInputSchemaParam{
 			Properties: map[string]any{
 				"budget": map[string]any{
@@ -148,6 +148,10 @@ func planHandler(w http.ResponseWriter, r *http.Request) {
 				"home_airport": map[string]any{
 					"type":        "string",
 					"description": "The traveler's home/departure airport as an IATA code, e.g. BOS — save it when they mention where they usually fly from",
+				},
+				"profile_notes": map[string]any{
+					"type":        "string",
+					"description": "The COMPLETE updated traveler profile as short bullet lines — your current notes (shown in the system prompt) merged with the new fact, de-duplicated, max ~15 lines. Never send only the new fact; always send the full rewritten profile.",
 				},
 			},
 		},
@@ -260,13 +264,17 @@ func planHandler(w http.ResponseWriter, r *http.Request) {
 
 	placesService := NewGooglePlacesService()
 	ctx := r.Context()
+	distilled := false
 
 	// Fold the signed-in traveler's saved preferences into the system prompt.
+	// The profile-keeping instruction applies even before any row exists, so
+	// the first durable fact a traveler reveals gets captured.
 	systemPrompt := basePrompt
 	if authed {
 		if prefs, err := store.New(dbPool).GetPreferences(ctx, uid); err == nil {
 			systemPrompt = personalizedSystemPrompt(basePrompt, &prefs)
 		}
+		systemPrompt += profileNotesInstruction
 	}
 	if boundTripID != nil {
 		systemPrompt += "\n\nYou are refining an existing saved trip in place. The conversation's first message describes the current itinerary and which section the traveler wants to change. Apply changes by calling update_itinerary_section with the targeted scope and the COMPLETE updated list of places for that section — include unchanged places with their existing coordinates, city, day, time_of_day and category tags so they aren't lost. Use search_places to find real coordinates for any new place before adding it. Only change the section the traveler asked about unless they broaden the request."
@@ -358,6 +366,13 @@ func planHandler(w http.ResponseWriter, r *http.Request) {
 						log.Printf("failed to persist trip: %v", err)
 					} else {
 						donePayload["trip_id"] = tripID
+						// Distill what this conversation revealed about the traveler
+						// in the background — it must never delay or fail the trip.
+						// context.Background(): the request ctx dies with the handler.
+						if !distilled {
+							distilled = true
+							go distillTravelerProfile(context.Background(), client, uid, req.Messages)
+						}
 					}
 				}
 				sendSSE(w, "done", donePayload)
@@ -391,10 +406,11 @@ func planHandler(w http.ResponseWriter, r *http.Request) {
 
 			case "save_preferences":
 				var in struct {
-					Budget      *string  `json:"budget"`
-					Pace        *string  `json:"pace"`
-					Interests   []string `json:"interests"`
-					HomeAirport *string  `json:"home_airport"`
+					Budget       *string  `json:"budget"`
+					Pace         *string  `json:"pace"`
+					Interests    []string `json:"interests"`
+					HomeAirport  *string  `json:"home_airport"`
+					ProfileNotes *string  `json:"profile_notes"`
 				}
 				json.Unmarshal(variant.Input, &in)
 
@@ -405,12 +421,39 @@ func planHandler(w http.ResponseWriter, r *http.Request) {
 				if in.Interests != nil {
 					interestsArg = normalizeInterests(in.Interests)
 				}
+				notes := normalizeNotes(in.ProfileNotes)
+				if notes != nil && *notes == "" {
+					// The agent can never wipe notes; only the user (PUT) can clear.
+					notes = nil
+				}
 				_, err := store.New(dbPool).UpsertPreferences(ctx, store.UpsertPreferencesParams{
-					UserID: uid, Budget: budget, Pace: pace, Interests: interestsArg, HomeAirport: homeAirport,
+					UserID: uid, Budget: budget, Pace: pace, Interests: interestsArg, HomeAirport: homeAirport, ProfileNotes: notes,
 				})
 				msg := "Preferences saved."
 				if err != nil {
 					msg = fmt.Sprintf("Could not save preferences: %v", err)
+				} else {
+					var changed []string
+					if budget != nil {
+						changed = append(changed, "budget")
+					}
+					if pace != nil {
+						changed = append(changed, "pace")
+					}
+					if interestsArg != nil {
+						changed = append(changed, "interests")
+					}
+					if homeAirport != nil {
+						changed = append(changed, "home_airport")
+					}
+					if notes != nil {
+						changed = append(changed, "profile_notes")
+					}
+					if len(changed) > 0 {
+						sendSSE(w, "profile_updated", map[string]any{
+							"fields": changed, "notes_preview": notesPreview(notes),
+						})
+					}
 				}
 				sendSSE(w, "tool_result", map[string]string{"name": "save_preferences"})
 				toolResults = append(toolResults, anthropic.NewToolResultBlock(variant.ID, msg, err != nil))
@@ -573,9 +616,13 @@ func summarizeOffers(origin, dest string, offers []FlightOffer) string {
 	return b.String()
 }
 
-// personalizedSystemPrompt appends the traveler's saved preferences to the base
-// prompt, omitting any fields that are unset. Returns base unchanged when there
-// are no preferences to add.
+// profileNotesInstruction is the standing profile-keeping rule appended to every
+// authenticated session's system prompt, whether or not notes exist yet.
+const profileNotesInstruction = "\n\nWhen you learn something durable about this traveler — travel companions, dietary needs, accommodation style, accessibility needs, likes or dislikes — call save_preferences with profile_notes set to the COMPLETE updated profile: your current notes merged with the new fact, de-duplicated, as short bullet lines (max ~15). Never send only the new fact. Don't store one-off trip details or sensitive information (health, religion, politics) unless the traveler explicitly asks you to remember it."
+
+// personalizedSystemPrompt appends the traveler's saved preferences and
+// AI-maintained profile notes to the base prompt, omitting any fields that are
+// unset. Returns base unchanged when there is nothing to add.
 func personalizedSystemPrompt(base string, p *store.TravelerPreference) string {
 	if p == nil {
 		return base
@@ -597,9 +644,26 @@ func personalizedSystemPrompt(base string, p *store.TravelerPreference) string {
 			*p.HomeAirport + ") and state the assumption (e.g. 'flying from " + *p.HomeAirport +
 			"'); only use a different origin if the trip clearly starts elsewhere or they say so."
 	}
-	if len(parts) == 0 {
-		return base
+	out := base
+	if len(parts) > 0 {
+		out += "\n\nTraveler preferences — " + strings.Join(parts, "; ") +
+			". Tailor your suggestions accordingly." + homeNote
 	}
-	return base + "\n\nTraveler preferences — " + strings.Join(parts, "; ") +
-		". Tailor your suggestions accordingly." + homeNote
+	if p.ProfileNotes != nil && strings.TrimSpace(*p.ProfileNotes) != "" {
+		out += "\n\nTraveler profile notes (maintained by you):\n" + strings.TrimSpace(*p.ProfileNotes)
+	}
+	return out
+}
+
+// notesPreview returns a short excerpt of saved notes for the profile_updated
+// SSE event; empty when no notes were part of the save.
+func notesPreview(notes *string) string {
+	if notes == nil {
+		return ""
+	}
+	r := []rune(strings.TrimSpace(*notes))
+	if len(r) > 80 {
+		return string(r[:80]) + "…"
+	}
+	return string(r)
 }

--- a/src/packages/api/plan_handler_test.go
+++ b/src/packages/api/plan_handler_test.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"travel-route-planner/store"
+)
+
+func TestPersonalizedSystemPromptNilPrefs(t *testing.T) {
+	if got := personalizedSystemPrompt("base", nil); got != "base" {
+		t.Fatalf("prompt = %q, want base unchanged", got)
+	}
+}
+
+func TestPersonalizedSystemPromptEmptyPrefs(t *testing.T) {
+	if got := personalizedSystemPrompt("base", &store.TravelerPreference{}); got != "base" {
+		t.Fatalf("prompt = %q, want base unchanged", got)
+	}
+}
+
+func TestPersonalizedSystemPromptIncludesNotesAlone(t *testing.T) {
+	p := &store.TravelerPreference{ProfileNotes: strPtr("- vegetarian\n- travels with kids")}
+	got := personalizedSystemPrompt("base", p)
+	if !strings.Contains(got, "Traveler profile notes (maintained by you):\n- vegetarian\n- travels with kids") {
+		t.Fatalf("prompt missing notes block: %q", got)
+	}
+	if strings.Contains(got, "Traveler preferences —") {
+		t.Fatalf("prompt should have no preferences line when fields are unset: %q", got)
+	}
+}
+
+func TestPersonalizedSystemPromptCombinesFieldsAndNotes(t *testing.T) {
+	p := &store.TravelerPreference{
+		Budget:       strPtr("mid"),
+		ProfileNotes: strPtr("- prefers boutique stays"),
+	}
+	got := personalizedSystemPrompt("base", p)
+	if !strings.Contains(got, "budget: mid") {
+		t.Fatalf("prompt missing budget: %q", got)
+	}
+	if !strings.Contains(got, "- prefers boutique stays") {
+		t.Fatalf("prompt missing notes: %q", got)
+	}
+}
+
+func TestPersonalizedSystemPromptIgnoresWhitespaceNotes(t *testing.T) {
+	p := &store.TravelerPreference{ProfileNotes: strPtr("  \n ")}
+	if got := personalizedSystemPrompt("base", p); got != "base" {
+		t.Fatalf("prompt = %q, want base unchanged for blank notes", got)
+	}
+}
+
+func TestNotesPreview(t *testing.T) {
+	if got := notesPreview(nil); got != "" {
+		t.Fatalf("preview = %q, want empty for nil", got)
+	}
+	if got := notesPreview(strPtr("short")); got != "short" {
+		t.Fatalf("preview = %q", got)
+	}
+	long := strings.Repeat("é", 100)
+	got := notesPreview(&long)
+	if r := []rune(got); len(r) != 81 || !strings.HasSuffix(got, "…") {
+		t.Fatalf("preview should be 80 runes + ellipsis, got %d runes: %q", len([]rune(got)), got)
+	}
+}

--- a/src/packages/api/preferences_handler.go
+++ b/src/packages/api/preferences_handler.go
@@ -15,10 +15,11 @@ var allowedBudgets = map[string]bool{"budget": true, "mid": true, "luxury": true
 var allowedPaces = map[string]bool{"relaxed": true, "balanced": true, "packed": true}
 
 type PreferencesResponse struct {
-	Budget      *string  `json:"budget"`
-	Pace        *string  `json:"pace"`
-	Interests   []string `json:"interests"`
-	HomeAirport *string  `json:"home_airport"`
+	Budget       *string  `json:"budget"`
+	Pace         *string  `json:"pace"`
+	Interests    []string `json:"interests"`
+	HomeAirport  *string  `json:"home_airport"`
+	ProfileNotes *string  `json:"profile_notes"`
 }
 
 type PutPreferencesRequest struct {
@@ -27,6 +28,8 @@ type PutPreferencesRequest struct {
 	// Pointer distinguishes omitted (nil -> keep) from cleared ([] -> clear).
 	Interests   *[]string `json:"interests"`
 	HomeAirport *string   `json:"home_airport"`
+	// Pointer distinguishes omitted (nil -> keep) from cleared ("" -> clear).
+	ProfileNotes *string `json:"profile_notes"`
 }
 
 func toPreferencesResponse(p store.TravelerPreference) PreferencesResponse {
@@ -34,7 +37,7 @@ func toPreferencesResponse(p store.TravelerPreference) PreferencesResponse {
 	if interests == nil {
 		interests = []string{}
 	}
-	return PreferencesResponse{Budget: p.Budget, Pace: p.Pace, Interests: interests, HomeAirport: p.HomeAirport}
+	return PreferencesResponse{Budget: p.Budget, Pace: p.Pace, Interests: interests, HomeAirport: p.HomeAirport, ProfileNotes: p.ProfileNotes}
 }
 
 func getPreferencesHandler(w http.ResponseWriter, r *http.Request) {
@@ -92,11 +95,12 @@ func putPreferencesHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	p, err := store.New(dbPool).UpsertPreferences(r.Context(), store.UpsertPreferencesParams{
-		UserID:      user.ID,
-		Budget:      budget,
-		Pace:        pace,
-		Interests:   interestsArg,
-		HomeAirport: homeAirport,
+		UserID:       user.ID,
+		Budget:       budget,
+		Pace:         pace,
+		Interests:    interestsArg,
+		HomeAirport:  homeAirport,
+		ProfileNotes: normalizeNotes(req.ProfileNotes),
 	})
 	if err != nil {
 		writeJSONError(w, http.StatusInternalServerError, "could not save preferences")
@@ -135,6 +139,22 @@ func normalizeAirportCode(v *string) (*string, error) {
 		return nil, errors.New("home_airport must be a 3-letter IATA code")
 	}
 	return &s, nil
+}
+
+const maxProfileNotesLen = 2000
+
+// normalizeNotes trims and caps the AI-maintained profile notes. nil -> nil
+// (omit, keep existing); a provided value — including "" — replaces, so the
+// user can clear notes. Truncation counts runes to avoid splitting characters.
+func normalizeNotes(v *string) *string {
+	if v == nil {
+		return nil
+	}
+	s := strings.TrimSpace(*v)
+	if r := []rune(s); len(r) > maxProfileNotesLen {
+		s = string(r[:maxProfileNotesLen])
+	}
+	return &s
 }
 
 // normalizeInterests trims, drops blanks, and de-duplicates (case-insensitive,

--- a/src/packages/api/preferences_handler_test.go
+++ b/src/packages/api/preferences_handler_test.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func strPtr(s string) *string { return &s }
+
+func TestNormalizeNotes(t *testing.T) {
+	long := strings.Repeat("a", maxProfileNotesLen+50)
+	// Multibyte runes: truncation must count runes, not bytes.
+	multibyte := strings.Repeat("é", maxProfileNotesLen+1)
+
+	tests := []struct {
+		name string
+		in   *string
+		want *string
+	}{
+		{"nil keeps existing", nil, nil},
+		{"empty clears", strPtr(""), strPtr("")},
+		{"whitespace-only clears", strPtr("  \n\t "), strPtr("")},
+		{"trims surrounding whitespace", strPtr("  - likes food\n"), strPtr("- likes food")},
+		{"under cap unchanged", strPtr("- vegetarian"), strPtr("- vegetarian")},
+		{"over cap truncated", strPtr(long), strPtr(long[:maxProfileNotesLen])},
+		{"multibyte truncated at rune boundary", strPtr(multibyte), strPtr(strings.Repeat("é", maxProfileNotesLen))},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := normalizeNotes(tt.in)
+			if (got == nil) != (tt.want == nil) {
+				t.Fatalf("normalizeNotes() = %v, want %v", got, tt.want)
+			}
+			if got != nil && *got != *tt.want {
+				t.Fatalf("normalizeNotes() = %q (len %d), want %q (len %d)", *got, len(*got), *tt.want, len(*tt.want))
+			}
+		})
+	}
+}

--- a/src/packages/api/profile_distiller.go
+++ b/src/packages/api/profile_distiller.go
@@ -1,0 +1,168 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	anthropic "github.com/anthropics/anthropic-sdk-go"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	"travel-route-planner/store"
+)
+
+const (
+	distillTimeout      = 60 * time.Second
+	distillMaxMessages  = 40
+	distillMaxChars     = 30000
+	distillToolName     = "update_traveler_profile"
+	distillSystemPrompt = "You distill what was learned about a traveler from a trip-planning conversation, so future trips are personalized. " +
+		"Call update_traveler_profile once. Set profile_notes to the COMPLETE traveler profile: the current notes merged with anything new from the conversation, de-duplicated, as short bullet lines (max ~15, under 1800 characters). " +
+		"Keep only durable facts about how this person travels (companions, dietary needs, accommodation style, likes/dislikes, accessibility) — no one-off trip details, no sensitive information (health, religion, politics). " +
+		"Only set budget, pace, interests, or home_airport if the conversation clearly establishes them; omit any field you are unsure about. If nothing durable was learned, omit profile_notes too."
+)
+
+// distillTravelerProfile runs one non-streamed Claude call over the chat
+// transcript and merges what it learned into the traveler's preferences. It is
+// fired as a goroutine after a trip persists and never fails the caller: every
+// error is logged and swallowed. Pass context.Background() — the request
+// context is canceled when the handler returns.
+func distillTravelerProfile(ctx context.Context, client anthropic.Client, uid uuid.UUID, transcript []PlanChatMessage) {
+	ctx, cancel := context.WithTimeout(ctx, distillTimeout)
+	defer cancel()
+
+	if dbPool == nil {
+		return
+	}
+	text := buildDistillationTranscript(transcript, distillMaxMessages, distillMaxChars)
+	if text == "" {
+		return
+	}
+
+	queries := store.New(dbPool)
+	system := distillSystemPrompt
+	current, err := queries.GetPreferences(ctx, uid)
+	switch {
+	case err == nil:
+		if current.ProfileNotes != nil && strings.TrimSpace(*current.ProfileNotes) != "" {
+			system += "\n\nCurrent notes:\n" + strings.TrimSpace(*current.ProfileNotes)
+		} else {
+			system += "\n\nCurrent notes: (none yet)"
+		}
+	case errors.Is(err, pgx.ErrNoRows):
+		system += "\n\nCurrent notes: (none yet)"
+	default:
+		log.Printf("profile distill: load preferences: %v", err)
+		return
+	}
+
+	tool := anthropic.ToolParam{
+		Name:        distillToolName,
+		Description: anthropic.String("Record the merged traveler profile learned from this conversation."),
+		InputSchema: anthropic.ToolInputSchemaParam{
+			Properties: map[string]any{
+				"budget":        map[string]any{"type": "string", "enum": []string{"budget", "mid", "luxury"}},
+				"pace":          map[string]any{"type": "string", "enum": []string{"relaxed", "balanced", "packed"}},
+				"interests":     map[string]any{"type": "array", "items": map[string]any{"type": "string"}},
+				"home_airport":  map[string]any{"type": "string", "description": "IATA code, e.g. BOS"},
+				"profile_notes": map[string]any{"type": "string", "description": "The complete merged profile as short bullet lines"},
+			},
+		},
+	}
+
+	resp, err := client.Messages.New(ctx, anthropic.MessageNewParams{
+		Model:      anthropic.ModelClaudeSonnet4_6,
+		MaxTokens:  1024,
+		System:     []anthropic.TextBlockParam{{Text: system}},
+		Tools:      []anthropic.ToolUnionParam{{OfTool: &tool}},
+		ToolChoice: anthropic.ToolChoiceParamOfTool(distillToolName),
+		Messages: []anthropic.MessageParam{
+			anthropic.NewUserMessage(anthropic.NewTextBlock("Planning conversation transcript:\n\n" + text)),
+		},
+	})
+	if err != nil {
+		log.Printf("profile distill: model call: %v", err)
+		return
+	}
+
+	var in struct {
+		Budget       *string  `json:"budget"`
+		Pace         *string  `json:"pace"`
+		Interests    []string `json:"interests"`
+		HomeAirport  *string  `json:"home_airport"`
+		ProfileNotes *string  `json:"profile_notes"`
+	}
+	found := false
+	for _, block := range resp.Content {
+		if variant, ok := block.AsAny().(anthropic.ToolUseBlock); ok && variant.Name == distillToolName {
+			if err := json.Unmarshal(variant.Input, &in); err != nil {
+				log.Printf("profile distill: parse tool input: %v", err)
+				return
+			}
+			found = true
+			break
+		}
+	}
+	if !found {
+		return
+	}
+
+	budget, _ := normalizeChoice(in.Budget, allowedBudgets, "budget")
+	pace, _ := normalizeChoice(in.Pace, allowedPaces, "pace")
+	homeAirport, _ := normalizeAirportCode(in.HomeAirport)
+	var interestsArg interface{}
+	if in.Interests != nil {
+		interestsArg = normalizeInterests(in.Interests)
+	}
+	notes := normalizeNotes(in.ProfileNotes)
+	if notes != nil && *notes == "" {
+		// Like the live tool, distillation can never wipe existing notes.
+		notes = nil
+	}
+	if budget == nil && pace == nil && homeAirport == nil && interestsArg == nil && notes == nil {
+		return
+	}
+	if _, err := queries.UpsertPreferences(ctx, store.UpsertPreferencesParams{
+		UserID: uid, Budget: budget, Pace: pace, Interests: interestsArg, HomeAirport: homeAirport, ProfileNotes: notes,
+	}); err != nil {
+		log.Printf("profile distill: save preferences: %v", err)
+	}
+}
+
+// buildDistillationTranscript flattens the chat's text turns into a single
+// labeled transcript, keeping the most recent maxMsgs messages and trimming
+// oldest-first to stay under maxChars.
+func buildDistillationTranscript(msgs []PlanChatMessage, maxMsgs, maxChars int) string {
+	if len(msgs) > maxMsgs {
+		msgs = msgs[len(msgs)-maxMsgs:]
+	}
+	var lines []string
+	for _, m := range msgs {
+		content := strings.TrimSpace(m.Content)
+		if content == "" {
+			continue
+		}
+		role := "Traveler"
+		if m.Role != "user" {
+			role = "Agent"
+		}
+		lines = append(lines, fmt.Sprintf("%s: %s", role, content))
+	}
+	for len(lines) > 0 && transcriptLen(lines) > maxChars {
+		lines = lines[1:]
+	}
+	return strings.Join(lines, "\n\n")
+}
+
+func transcriptLen(lines []string) int {
+	n := 0
+	for _, l := range lines {
+		n += len(l) + 2
+	}
+	return n
+}

--- a/src/packages/api/profile_distiller_test.go
+++ b/src/packages/api/profile_distiller_test.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildDistillationTranscriptLabelsRoles(t *testing.T) {
+	got := buildDistillationTranscript([]PlanChatMessage{
+		{Role: "user", Content: "I'm vegetarian"},
+		{Role: "assistant", Content: "Noted!"},
+	}, 40, 30000)
+	want := "Traveler: I'm vegetarian\n\nAgent: Noted!"
+	if got != want {
+		t.Fatalf("transcript = %q, want %q", got, want)
+	}
+}
+
+func TestBuildDistillationTranscriptSkipsBlankMessages(t *testing.T) {
+	got := buildDistillationTranscript([]PlanChatMessage{
+		{Role: "user", Content: "   "},
+		{Role: "user", Content: "hello"},
+	}, 40, 30000)
+	if got != "Traveler: hello" {
+		t.Fatalf("transcript = %q", got)
+	}
+}
+
+func TestBuildDistillationTranscriptKeepsNewestMessages(t *testing.T) {
+	msgs := []PlanChatMessage{
+		{Role: "user", Content: "oldest"},
+		{Role: "user", Content: "middle"},
+		{Role: "user", Content: "newest"},
+	}
+	got := buildDistillationTranscript(msgs, 2, 30000)
+	if strings.Contains(got, "oldest") {
+		t.Fatalf("transcript should drop oldest beyond maxMsgs: %q", got)
+	}
+	if !strings.Contains(got, "middle") || !strings.Contains(got, "newest") {
+		t.Fatalf("transcript should keep the newest messages: %q", got)
+	}
+}
+
+func TestBuildDistillationTranscriptTrimsOldestToCharCap(t *testing.T) {
+	msgs := []PlanChatMessage{
+		{Role: "user", Content: strings.Repeat("x", 100)},
+		{Role: "user", Content: "recent"},
+	}
+	got := buildDistillationTranscript(msgs, 40, 50)
+	if strings.Contains(got, "xxx") {
+		t.Fatalf("oldest oversized message should be trimmed: %q", got)
+	}
+	if got != "Traveler: recent" {
+		t.Fatalf("transcript = %q", got)
+	}
+}
+
+func TestBuildDistillationTranscriptEmpty(t *testing.T) {
+	if got := buildDistillationTranscript(nil, 40, 30000); got != "" {
+		t.Fatalf("transcript = %q, want empty", got)
+	}
+}

--- a/src/packages/api/query/preferences.sql
+++ b/src/packages/api/query/preferences.sql
@@ -2,17 +2,19 @@
 SELECT * FROM traveler_preferences WHERE user_id = $1;
 
 -- name: UpsertPreferences :one
-INSERT INTO traveler_preferences (user_id, budget, pace, interests, home_airport)
+INSERT INTO traveler_preferences (user_id, budget, pace, interests, home_airport, profile_notes)
 VALUES (
     sqlc.arg('user_id'),
     sqlc.narg('budget'),
     sqlc.narg('pace'),
     COALESCE(sqlc.narg('interests'), '{}'::text[]),
-    sqlc.narg('home_airport')
+    sqlc.narg('home_airport'),
+    sqlc.narg('profile_notes')
 )
 ON CONFLICT (user_id) DO UPDATE SET
-    budget       = COALESCE(sqlc.narg('budget'), traveler_preferences.budget),
-    pace         = COALESCE(sqlc.narg('pace'), traveler_preferences.pace),
-    interests    = COALESCE(sqlc.narg('interests'), traveler_preferences.interests),
-    home_airport = COALESCE(sqlc.narg('home_airport'), traveler_preferences.home_airport)
+    budget        = COALESCE(sqlc.narg('budget'), traveler_preferences.budget),
+    pace          = COALESCE(sqlc.narg('pace'), traveler_preferences.pace),
+    interests     = COALESCE(sqlc.narg('interests'), traveler_preferences.interests),
+    home_airport  = COALESCE(sqlc.narg('home_airport'), traveler_preferences.home_airport),
+    profile_notes = COALESCE(sqlc.narg('profile_notes'), traveler_preferences.profile_notes)
 RETURNING *;

--- a/src/packages/api/store/models.go
+++ b/src/packages/api/store/models.go
@@ -70,13 +70,14 @@ type Session struct {
 }
 
 type TravelerPreference struct {
-	UserID      uuid.UUID `json:"user_id"`
-	Budget      *string   `json:"budget"`
-	Pace        *string   `json:"pace"`
-	Interests   []string  `json:"interests"`
-	CreatedAt   time.Time `json:"created_at"`
-	UpdatedAt   time.Time `json:"updated_at"`
-	HomeAirport *string   `json:"home_airport"`
+	UserID       uuid.UUID `json:"user_id"`
+	Budget       *string   `json:"budget"`
+	Pace         *string   `json:"pace"`
+	Interests    []string  `json:"interests"`
+	CreatedAt    time.Time `json:"created_at"`
+	UpdatedAt    time.Time `json:"updated_at"`
+	HomeAirport  *string   `json:"home_airport"`
+	ProfileNotes *string   `json:"profile_notes"`
 }
 
 type Trip struct {

--- a/src/packages/api/store/preferences.sql.go
+++ b/src/packages/api/store/preferences.sql.go
@@ -12,7 +12,7 @@ import (
 )
 
 const getPreferences = `-- name: GetPreferences :one
-SELECT user_id, budget, pace, interests, created_at, updated_at, home_airport FROM traveler_preferences WHERE user_id = $1
+SELECT user_id, budget, pace, interests, created_at, updated_at, home_airport, profile_notes FROM traveler_preferences WHERE user_id = $1
 `
 
 func (q *Queries) GetPreferences(ctx context.Context, userID uuid.UUID) (TravelerPreference, error) {
@@ -26,33 +26,37 @@ func (q *Queries) GetPreferences(ctx context.Context, userID uuid.UUID) (Travele
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.HomeAirport,
+		&i.ProfileNotes,
 	)
 	return i, err
 }
 
 const upsertPreferences = `-- name: UpsertPreferences :one
-INSERT INTO traveler_preferences (user_id, budget, pace, interests, home_airport)
+INSERT INTO traveler_preferences (user_id, budget, pace, interests, home_airport, profile_notes)
 VALUES (
     $1,
     $2,
     $3,
     COALESCE($4, '{}'::text[]),
-    $5
+    $5,
+    $6
 )
 ON CONFLICT (user_id) DO UPDATE SET
-    budget       = COALESCE($2, traveler_preferences.budget),
-    pace         = COALESCE($3, traveler_preferences.pace),
-    interests    = COALESCE($4, traveler_preferences.interests),
-    home_airport = COALESCE($5, traveler_preferences.home_airport)
-RETURNING user_id, budget, pace, interests, created_at, updated_at, home_airport
+    budget        = COALESCE($2, traveler_preferences.budget),
+    pace          = COALESCE($3, traveler_preferences.pace),
+    interests     = COALESCE($4, traveler_preferences.interests),
+    home_airport  = COALESCE($5, traveler_preferences.home_airport),
+    profile_notes = COALESCE($6, traveler_preferences.profile_notes)
+RETURNING user_id, budget, pace, interests, created_at, updated_at, home_airport, profile_notes
 `
 
 type UpsertPreferencesParams struct {
-	UserID      uuid.UUID   `json:"user_id"`
-	Budget      *string     `json:"budget"`
-	Pace        *string     `json:"pace"`
-	Interests   interface{} `json:"interests"`
-	HomeAirport *string     `json:"home_airport"`
+	UserID       uuid.UUID   `json:"user_id"`
+	Budget       *string     `json:"budget"`
+	Pace         *string     `json:"pace"`
+	Interests    interface{} `json:"interests"`
+	HomeAirport  *string     `json:"home_airport"`
+	ProfileNotes *string     `json:"profile_notes"`
 }
 
 func (q *Queries) UpsertPreferences(ctx context.Context, arg UpsertPreferencesParams) (TravelerPreference, error) {
@@ -62,6 +66,7 @@ func (q *Queries) UpsertPreferences(ctx context.Context, arg UpsertPreferencesPa
 		arg.Pace,
 		arg.Interests,
 		arg.HomeAirport,
+		arg.ProfileNotes,
 	)
 	var i TravelerPreference
 	err := row.Scan(
@@ -72,6 +77,7 @@ func (q *Queries) UpsertPreferences(ctx context.Context, arg UpsertPreferencesPa
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.HomeAirport,
+		&i.ProfileNotes,
 	)
 	return i, err
 }

--- a/src/packages/flutter-app/lib/models/traveler_preferences.dart
+++ b/src/packages/flutter-app/lib/models/traveler_preferences.dart
@@ -9,12 +9,15 @@ class TravelerPreferences {
   final List<String> interests;
   @JsonKey(name: 'home_airport')
   final String? homeAirport;
+  @JsonKey(name: 'profile_notes')
+  final String? profileNotes;
 
   const TravelerPreferences({
     this.budget,
     this.pace,
     this.interests = const [],
     this.homeAirport,
+    this.profileNotes,
   });
 
   factory TravelerPreferences.fromJson(Map<String, dynamic> json) =>

--- a/src/packages/flutter-app/lib/models/traveler_preferences.g.dart
+++ b/src/packages/flutter-app/lib/models/traveler_preferences.g.dart
@@ -15,6 +15,7 @@ TravelerPreferences _$TravelerPreferencesFromJson(Map<String, dynamic> json) =>
               .toList() ??
           const [],
       homeAirport: json['home_airport'] as String?,
+      profileNotes: json['profile_notes'] as String?,
     );
 
 Map<String, dynamic> _$TravelerPreferencesToJson(
@@ -24,4 +25,5 @@ Map<String, dynamic> _$TravelerPreferencesToJson(
       'pace': instance.pace,
       'interests': instance.interests,
       'home_airport': instance.homeAirport,
+      'profile_notes': instance.profileNotes,
     };

--- a/src/packages/flutter-app/lib/providers/plan_provider.dart
+++ b/src/packages/flutter-app/lib/providers/plan_provider.dart
@@ -19,6 +19,10 @@ class PlanState {
   final String? flightRouteLabel;
   final String? error;
 
+  /// Short excerpt of profile notes the agent just saved (server
+  /// `profile_updated` event); shown as a transient "Noted" chip in the chat.
+  final String? profileUpdateNote;
+
   /// Bumped each time a trip-bound session patches the trip in place
   /// (server `trip_updated` event); listeners reload the trip when it grows.
   final int tripUpdateCount;
@@ -34,6 +38,7 @@ class PlanState {
     this.flightOffers,
     this.flightRouteLabel,
     this.error,
+    this.profileUpdateNote,
     this.tripUpdateCount = 0,
   });
 
@@ -48,6 +53,7 @@ class PlanState {
     Object? flightOffers = _sentinel,
     Object? flightRouteLabel = _sentinel,
     Object? error = _sentinel,
+    Object? profileUpdateNote = _sentinel,
     int? tripUpdateCount,
   }) {
     return PlanState(
@@ -63,6 +69,8 @@ class PlanState {
       flightOffers: flightOffers == _sentinel ? this.flightOffers : flightOffers as List<FlightOffer>?,
       flightRouteLabel: flightRouteLabel == _sentinel ? this.flightRouteLabel : flightRouteLabel as String?,
       error: error == _sentinel ? this.error : error as String?,
+      profileUpdateNote:
+          profileUpdateNote == _sentinel ? this.profileUpdateNote : profileUpdateNote as String?,
       tripUpdateCount: tripUpdateCount ?? this.tripUpdateCount,
     );
   }
@@ -126,6 +134,7 @@ class PlanNotifier extends StateNotifier<PlanState> {
       flightOffers: null,
       flightRouteLabel: null,
       error: null,
+      profileUpdateNote: null,
     );
 
     final history = updatedMessages
@@ -163,6 +172,10 @@ class PlanNotifier extends StateNotifier<PlanState> {
 
             case 'trip_updated':
             state = state.copyWith(tripUpdateCount: state.tripUpdateCount + 1);
+
+          case 'profile_updated':
+            state = state.copyWith(
+                profileUpdateNote: event.data['notes_preview'] as String? ?? '');
 
           case 'flights':
             final raw = event.data['offers'] as List<dynamic>? ?? [];

--- a/src/packages/flutter-app/lib/providers/preferences_provider.dart
+++ b/src/packages/flutter-app/lib/providers/preferences_provider.dart
@@ -52,11 +52,16 @@ class PreferencesNotifier extends StateNotifier<PreferencesState> {
     String? pace,
     required List<String> interests,
     String? homeAirport,
+    String? profileNotes,
   }) async {
     state = state.copyWith(saving: true, error: null);
     try {
       final prefs = await _service.savePreferences(
-          budget: budget, pace: pace, interests: interests, homeAirport: homeAirport);
+          budget: budget,
+          pace: pace,
+          interests: interests,
+          homeAirport: homeAirport,
+          profileNotes: profileNotes);
       state = state.copyWith(prefs: prefs, saving: false);
       return true;
     } catch (e) {

--- a/src/packages/flutter-app/lib/screens/preferences_screen.dart
+++ b/src/packages/flutter-app/lib/screens/preferences_screen.dart
@@ -24,6 +24,7 @@ class _PreferencesScreenState extends ConsumerState<PreferencesScreen> {
   final Set<String> _interests = {};
   Airport? _homeAirport;
   final _interestController = TextEditingController();
+  final _notesController = TextEditingController();
   bool _initialized = false;
 
   @override
@@ -41,6 +42,7 @@ class _PreferencesScreenState extends ConsumerState<PreferencesScreen> {
           if (home != null && home.isNotEmpty) {
             _homeAirport = Airport(iataCode: home, name: home);
           }
+          _notesController.text = prefs.profileNotes ?? '';
           _initialized = true;
         });
       } else if (mounted) {
@@ -52,6 +54,7 @@ class _PreferencesScreenState extends ConsumerState<PreferencesScreen> {
   @override
   void dispose() {
     _interestController.dispose();
+    _notesController.dispose();
     super.dispose();
   }
 
@@ -69,6 +72,8 @@ class _PreferencesScreenState extends ConsumerState<PreferencesScreen> {
           pace: _pace,
           interests: _interests.toList(),
           homeAirport: _homeAirport?.iataCode,
+          // Always send the field's text: an emptied field clears the notes.
+          profileNotes: _notesController.text.trim(),
         );
     if (!mounted) return;
     ScaffoldMessenger.of(context).showSnackBar(
@@ -157,6 +162,25 @@ class _PreferencesScreenState extends ConsumerState<PreferencesScreen> {
                   icon: Icons.home,
                   selected: _homeAirport,
                   onSelected: (a) => setState(() => _homeAirport = a),
+                ),
+                const SizedBox(height: 24),
+                Text('Profile notes', style: theme.textTheme.titleMedium),
+                const SizedBox(height: 4),
+                Text(
+                  'Your AI agent keeps these notes as it learns about you. Edit or clear them anytime.',
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: theme.colorScheme.onSurfaceVariant,
+                  ),
+                ),
+                const SizedBox(height: 8),
+                TextField(
+                  controller: _notesController,
+                  maxLines: 6,
+                  maxLength: 2000,
+                  decoration: const InputDecoration(
+                    hintText: 'Nothing noted yet — the agent adds to this as you plan trips.',
+                    border: OutlineInputBorder(),
+                  ),
                 ),
                 const SizedBox(height: 32),
                 FilledButton(

--- a/src/packages/flutter-app/lib/services/preferences_api_service.dart
+++ b/src/packages/flutter-app/lib/services/preferences_api_service.dart
@@ -30,6 +30,7 @@ class PreferencesApiService {
     String? pace,
     required List<String> interests,
     String? homeAirport,
+    String? profileNotes,
   }) async {
     final res = await apiClient.httpClient.put(
       Uri.parse('${apiClient.baseUrl}/preferences'),
@@ -39,6 +40,7 @@ class PreferencesApiService {
         'pace': pace,
         'interests': interests,
         'home_airport': homeAirport,
+        'profile_notes': profileNotes,
       }),
     );
     if (res.statusCode == 200) {

--- a/src/packages/flutter-app/lib/widgets/chat_panel.dart
+++ b/src/packages/flutter-app/lib/widgets/chat_panel.dart
@@ -137,6 +137,23 @@ class _ChatPanelState extends ConsumerState<ChatPanel> {
                             }).toList(),
                           ),
                         ),
+                      if (planState.profileUpdateNote != null)
+                        Padding(
+                          padding: const EdgeInsets.symmetric(vertical: 8),
+                          child: Align(
+                            alignment: Alignment.centerLeft,
+                            child: Tooltip(
+                              message: planState.profileUpdateNote!.isEmpty
+                                  ? 'Travel profile updated'
+                                  : planState.profileUpdateNote!,
+                              child: Chip(
+                                avatar: Icon(Icons.check_circle_outline,
+                                    size: 16, color: theme.colorScheme.primary),
+                                label: const Text('Noted — travel profile updated'),
+                              ),
+                            ),
+                          ),
+                        ),
                       if (planState.flightOffers != null && planState.flightOffers!.isNotEmpty)
                         _FlightOptions(
                           routeLabel: planState.flightRouteLabel,


### PR DESCRIPTION
## What

Gives the agent a persistent, free-text **traveler profile** (`profile_notes` on `traveler_preferences`) that refines across trips, alongside the existing budget/pace/interests/home_airport fields. Spec: `specs/traveler-profile-notes/`.

## How it learns

- **Live during chat** — `save_preferences` gains a `profile_notes` field. The model is instructed to always send the *complete* rewritten profile (current notes are in its system prompt; it merges + dedupes, ≤ ~15 bullets), so the server just does a wholesale replace through the existing COALESCE upsert. Successful saves emit a new `profile_updated` SSE event, shown as a "Noted — travel profile updated" chip in the chat panel.
- **Post-trip distillation** — after `persistTrip` succeeds, a fire-and-forget goroutine (`profile_distiller.go`) makes one non-streamed Claude call over the text transcript with a forced `update_traveler_profile` tool and merges the result (notes + conservatively, structured fields). Uses `context.Background()` + 60s timeout; all errors are logged and swallowed so distillation can never delay or fail trip creation.

## Guardrails

- `normalizeNotes`: trim + rune-safe 2000-char cap (REST PUT with `""` clears; the agent path coerces empty → nil so the model can never wipe notes — only the user can clear them, via the new editable "Profile notes" section on the Travel profile screen).
- Anonymous sessions: unchanged — no tool, no distillation.
- Known race (documented in spec): a live save landing after distillation is last-writer-wins; acceptable since both writers send full rewrites.

## Testing

- Go table tests for `normalizeNotes`, `buildDistillationTranscript`, `personalizedSystemPrompt` (with/without notes), `notesPreview`; `go vet` + `flutter analyze`/`flutter test` clean.
- Verified end-to-end on docker-dev: live save produced the `profile_updated` event and persisted merged notes; planning a real trip triggered distillation (DB row updated ~3s after the trip persisted, no errors logged); partial PUTs preserve notes, empty PUT clears; migration 00016 applies on boot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)