### PR TITLE
Align home CTAs with the "Plan less. Travel more." tagline

### DIFF
--- a/src/packages/flutter-app/lib/screens/home_screen.dart
+++ b/src/packages/flutter-app/lib/screens/home_screen.dart
@@ -129,25 +129,6 @@ class HomeScreen extends ConsumerWidget {
 
                 const SizedBox(height: 28),
 
-                // Divider label
-                Row(
-                  children: [
-                    const Expanded(child: Divider()),
-                    Padding(
-                      padding: const EdgeInsets.symmetric(horizontal: 12),
-                      child: Text(
-                        'or plan it your way',
-                        style: theme.textTheme.bodySmall?.copyWith(
-                          color: theme.colorScheme.onSurfaceVariant,
-                        ),
-                      ),
-                    ),
-                    const Expanded(child: Divider()),
-                  ],
-                ),
-
-                const SizedBox(height: 20),
-
                 // Most recently viewed trip — hidden until one has been opened.
                 if (recentTrip != null) ...[
                   _RecentTripCard(
@@ -393,7 +374,7 @@ class _AgentHeroCard extends StatelessWidget {
                 ),
               ),
               child: const Text(
-                'Start Planning',
+                'Let\'s go',
                 style: TextStyle(fontWeight: FontWeight.bold, fontSize: 16),
               ),
             ),
@@ -472,7 +453,9 @@ class _RecentTripCard extends StatelessWidget {
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
                       Text(
-                        'CONTINUE PLANNING',
+                        'PICK UP WHERE YOU LEFT OFF',
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
                         style: theme.textTheme.labelSmall?.copyWith(
                           color: Colors.white70,
                           letterSpacing: 1.2,


### PR DESCRIPTION
## Summary
- Hero button: "Start Planning" → "Let's go" — stops contradicting the "Plan less. Travel more." tagline
- Recent-trip card overline: "CONTINUE PLANNING" → "PICK UP WHERE YOU LEFT OFF", with maxLines/ellipsis for narrow screens
- Removed the "or plan it your way" divider row and its extra spacer; the hero now flows straight into the cards

## Testing
- `flutter analyze` — no new issues (only pre-existing withOpacity deprecation infos)
- Manual verification in the dockerized dev stack via headless Chrome: logged in, confirmed the new hero button, the removed divider with clean spacing, and the new recent-trip overline after opening a trip; no layout overflows in the console

🤖 Generated with [Claude Code](https://claude.com/claude-code)