### PR TITLE
Design refresh + persistent nav shell for core screens

### DIFF
--- a/src/packages/flutter-app/lib/main.dart
+++ b/src/packages/flutter-app/lib/main.dart
@@ -2,8 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'constants/app_info.dart';
 import 'providers/auth_provider.dart';
+import 'theme/app_theme.dart';
 import 'screens/auth_screen.dart';
-import 'screens/home_screen.dart';
+import 'screens/app_shell.dart';
 
 void main() {
   runApp(
@@ -21,43 +22,7 @@ class TravelRoutePlannerApp extends StatelessWidget {
     return MaterialApp(
       title: AppInfo.name,
       debugShowCheckedModeBanner: false,
-      theme: ThemeData(
-        colorScheme: ColorScheme.fromSeed(
-          seedColor: Colors.teal.shade700, // Teal theme (matches the home banner)
-          brightness: Brightness.light,
-        ),
-        useMaterial3: true,
-        appBarTheme: const AppBarTheme(
-          centerTitle: true,
-          elevation: 2,
-        ),
-        cardTheme: const CardThemeData(
-          elevation: 4,
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.all(Radius.circular(12)),
-          ),
-        ),
-        inputDecorationTheme: InputDecorationTheme(
-          border: OutlineInputBorder(
-            borderRadius: BorderRadius.circular(8),
-          ),
-          filled: true,
-          fillColor: Colors.grey[50],
-        ),
-        elevatedButtonTheme: ElevatedButtonThemeData(
-          style: ElevatedButton.styleFrom(
-            padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
-            shape: RoundedRectangleBorder(
-              borderRadius: BorderRadius.circular(8),
-            ),
-          ),
-        ),
-        chipTheme: ChipThemeData(
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(20),
-          ),
-        ),
-      ),
+      theme: AppTheme.light,
       home: const AuthGate(),
     );
   }
@@ -76,6 +41,6 @@ class AuthGate extends ConsumerWidget {
         body: Center(child: CircularProgressIndicator()),
       );
     }
-    return auth.isSignedIn ? const HomeScreen() : const AuthScreen();
+    return auth.isSignedIn ? const AppShell() : const AuthScreen();
   }
 }

--- a/src/packages/flutter-app/lib/navigation/app_nav.dart
+++ b/src/packages/flutter-app/lib/navigation/app_nav.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Top-level destinations. Keeping it to three keeps the choice trivial
+/// (Hick's Law) and puts the chat and saved trips one tap away instead of
+/// buried in a menu.
+enum AppTab { home, plan, trips }
+
+/// The selected top-level tab. A provider (rather than local state) so any
+/// screen — e.g. the home hero, or a pushed page's nav rail — can switch tabs
+/// without prop-drilling callbacks.
+final navIndexProvider = StateProvider<int>((ref) => AppTab.home.index);
+
+/// One nav destination's display data. Shared so the shell's rail and bar render
+/// the exact same set, in lockstep.
+class NavDestinationData {
+  final IconData icon;
+  final IconData selectedIcon;
+  final String label;
+
+  const NavDestinationData({
+    required this.icon,
+    required this.selectedIcon,
+    required this.label,
+  });
+}
+
+/// The single source of truth for the three top-level destinations, ordered to
+/// match [AppTab].
+const List<NavDestinationData> navDestinations = [
+  NavDestinationData(
+    icon: Icons.home_outlined,
+    selectedIcon: Icons.home,
+    label: 'Home',
+  ),
+  NavDestinationData(
+    icon: Icons.auto_awesome_outlined,
+    selectedIcon: Icons.auto_awesome,
+    label: 'Plan',
+  ),
+  NavDestinationData(
+    icon: Icons.luggage_outlined,
+    selectedIcon: Icons.luggage,
+    label: 'Trips',
+  ),
+];
+
+/// Width at or above which the persistent rail (rather than a bottom bar) is
+/// shown.
+const double kRailBreakpoint = 800;

--- a/src/packages/flutter-app/lib/providers/recent_trip_provider.dart
+++ b/src/packages/flutter-app/lib/providers/recent_trip_provider.dart
@@ -6,12 +6,20 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'auth_provider.dart';
 
 /// The trip detail screen the user last opened, remembered on-device so the
-/// home screen can offer a one-tap way back into it.
+/// home screen can offer a one-tap way back into it. Carries a snapshot of the
+/// date range and status so the tile can surface state, not just a name.
 class RecentTrip {
   final String tripId;
   final String title;
+  final String? dateRange;
+  final String status;
 
-  const RecentTrip({required this.tripId, required this.title});
+  const RecentTrip({
+    required this.tripId,
+    required this.title,
+    this.dateRange,
+    this.status = '',
+  });
 }
 
 class RecentTripNotifier extends StateNotifier<RecentTrip?> {
@@ -34,7 +42,12 @@ class RecentTripNotifier extends StateNotifier<RecentTrip?> {
       final id = m['id'] as String?;
       final title = m['title'] as String?;
       if (id != null && id.isNotEmpty && title != null) {
-        state = RecentTrip(tripId: id, title: title);
+        state = RecentTrip(
+          tripId: id,
+          title: title,
+          dateRange: m['dateRange'] as String?,
+          status: (m['status'] as String?) ?? '',
+        );
       }
     } catch (_) {
       // Malformed value — ignore and stay empty.
@@ -42,12 +55,31 @@ class RecentTripNotifier extends StateNotifier<RecentTrip?> {
   }
 
   /// Remember [tripId] as the most recently viewed trip. Call after a trip
-  /// detail screen successfully loads.
-  Future<void> record(String tripId, String title) async {
+  /// detail screen successfully loads. [dateRange] and [status] are a snapshot
+  /// for the home tile.
+  Future<void> record(
+    String tripId,
+    String title, {
+    String? dateRange,
+    String status = '',
+  }) async {
     if (_userId == null) return;
-    state = RecentTrip(tripId: tripId, title: title);
+    state = RecentTrip(
+      tripId: tripId,
+      title: title,
+      dateRange: dateRange,
+      status: status,
+    );
     final prefs = await SharedPreferences.getInstance();
-    await prefs.setString(_key, jsonEncode({'id': tripId, 'title': title}));
+    await prefs.setString(
+      _key,
+      jsonEncode({
+        'id': tripId,
+        'title': title,
+        if (dateRange != null) 'dateRange': dateRange,
+        'status': status,
+      }),
+    );
   }
 
   /// Forget the recent trip if it points at [tripId] (used when a trip is

--- a/src/packages/flutter-app/lib/screens/agent_screen.dart
+++ b/src/packages/flutter-app/lib/screens/agent_screen.dart
@@ -1,7 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../theme/app_colors.dart';
+import '../theme/spacing.dart';
 import '../widgets/gradient_app_bar.dart';
 import '../widgets/chat_panel.dart';
+import '../widgets/empty_state.dart';
 import '../providers/plan_provider.dart';
 import '../providers/route_provider.dart';
 import 'route_optimizer_screen.dart';
@@ -45,7 +48,9 @@ class _AgentScreenState extends ConsumerState<AgentScreen> {
     for (final loc in locations) {
       routeNotifier.addLocation(loc);
     }
-    Navigator.of(context).pushReplacement(
+    // Push (not replace) so the chat stays beneath the planner in this tab's
+    // stack — back returns to the conversation.
+    Navigator.of(context).push(
       MaterialPageRoute(builder: (_) => const RouteOptimizerScreen()),
     );
   }
@@ -92,48 +97,16 @@ class _AgentScreenState extends ConsumerState<AgentScreen> {
 class _EmptyState extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    return Center(
-      child: Padding(
-        padding: const EdgeInsets.all(32),
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            Icon(
-              Icons.chat_bubble_outline,
-              size: 64,
-              color: theme.colorScheme.primary.withOpacity(0.5),
-            ),
-            const SizedBox(height: 16),
-            Text(
-              'Tell me about your dream trip',
-              style: theme.textTheme.titleLarge?.copyWith(
-                fontWeight: FontWeight.bold,
-              ),
-              textAlign: TextAlign.center,
-            ),
-            const SizedBox(height: 8),
-            Text(
-              'I\'ll search for places and build an itinerary you can load into the route planner.',
-              style: theme.textTheme.bodyMedium?.copyWith(
-                color: theme.colorScheme.onSurfaceVariant,
-              ),
-              textAlign: TextAlign.center,
-            ),
-            const SizedBox(height: 24),
-            Wrap(
-              spacing: 8,
-              runSpacing: 8,
-              alignment: WrapAlignment.center,
-              children: const [
-                _SuggestionChip('2 days in Paris'),
-                _SuggestionChip('Museums in Rome'),
-                _SuggestionChip('Weekend in Tokyo'),
-              ],
-            ),
-          ],
-        ),
-      ),
+    return const EmptyState(
+      icon: Icons.chat_bubble_outline,
+      title: 'Tell me about your dream trip',
+      message:
+          "I'll search for places and build an itinerary you can load into the route planner.",
+      actions: [
+        _SuggestionChip('2 days in Paris'),
+        _SuggestionChip('Museums in Rome'),
+        _SuggestionChip('Weekend in Tokyo'),
+      ],
     );
   }
 }
@@ -168,39 +141,41 @@ class _ItineraryBanner extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     return Container(
-      margin: const EdgeInsets.symmetric(vertical: 12),
-      padding: const EdgeInsets.all(16),
+      margin: const EdgeInsets.symmetric(vertical: AppSpacing.md),
+      padding: const EdgeInsets.all(AppSpacing.lg),
       decoration: BoxDecoration(
-        color: Colors.teal.shade50,
-        borderRadius: BorderRadius.circular(12),
-        border: Border.all(color: Colors.teal.shade200),
+        color: AppColors.brandTint,
+        borderRadius: AppRadius.mdAll,
+        border: Border.all(color: AppColors.brand.withValues(alpha: 0.3)),
       ),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Row(
             children: [
-              Icon(Icons.check_circle, color: Colors.teal.shade700, size: 20),
-              const SizedBox(width: 8),
-              Text(
-                'Itinerary ready — $locationCount locations',
-                style: theme.textTheme.titleSmall?.copyWith(
-                  color: Colors.teal.shade800,
-                  fontWeight: FontWeight.bold,
+              Icon(Icons.check_circle, color: AppColors.brand, size: 22),
+              const SizedBox(width: AppSpacing.sm),
+              Expanded(
+                child: Text(
+                  'Itinerary ready — $locationCount locations',
+                  style: theme.textTheme.titleMedium?.copyWith(
+                    color: AppColors.brandDark,
+                    fontWeight: FontWeight.bold,
+                  ),
                 ),
               ),
             ],
           ),
           if (summary != null && summary!.isNotEmpty) ...[
-            const SizedBox(height: 8),
+            const SizedBox(height: AppSpacing.sm),
             Text(
               summary!,
-              style: theme.textTheme.bodySmall?.copyWith(
-                color: Colors.teal.shade700,
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: AppColors.brandDark.withValues(alpha: 0.85),
               ),
             ),
           ],
-          const SizedBox(height: 12),
+          const SizedBox(height: AppSpacing.md),
           // When the trip was saved, opening it is the primary action (it has the
           // full itinerary, bookings, etc.); loading into the route planner stays
           // available as a secondary option. Anonymous sessions have no saved
@@ -213,11 +188,11 @@ class _ItineraryBanner extends StatelessWidget {
                 icon: const Icon(Icons.luggage),
                 label: const Text('View trip'),
                 style: FilledButton.styleFrom(
-                  backgroundColor: Colors.teal.shade600,
+                  backgroundColor: AppColors.brandLight,
                 ),
               ),
             ),
-            const SizedBox(height: 8),
+            const SizedBox(height: AppSpacing.sm),
             SizedBox(
               width: double.infinity,
               child: OutlinedButton.icon(
@@ -234,7 +209,7 @@ class _ItineraryBanner extends StatelessWidget {
                 icon: const Icon(Icons.map),
                 label: const Text('Load into Planner'),
                 style: FilledButton.styleFrom(
-                  backgroundColor: Colors.teal.shade600,
+                  backgroundColor: AppColors.brandLight,
                 ),
               ),
             ),

--- a/src/packages/flutter-app/lib/screens/app_shell.dart
+++ b/src/packages/flutter-app/lib/screens/app_shell.dart
@@ -1,0 +1,125 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../navigation/app_nav.dart';
+import 'home_screen.dart';
+import 'agent_screen.dart';
+import 'trips_list_screen.dart';
+
+/// Persistent navigation shell. The rail (wide) / bar (narrow) lives here,
+/// outside the per-tab navigators, so it never moves when a page is pushed —
+/// only the content area animates. Each tab keeps its own push stack, so a trip
+/// opened in one tab stays put when you switch away and back.
+class AppShell extends ConsumerStatefulWidget {
+  const AppShell({super.key});
+
+  @override
+  ConsumerState<AppShell> createState() => _AppShellState();
+}
+
+class _AppShellState extends ConsumerState<AppShell> {
+  // One navigator per tab. Pushes from inside a tab resolve to its navigator
+  // (via the ambient `Navigator.of(context)`), animating only the content
+  // region rather than the whole screen.
+  late final List<GlobalKey<NavigatorState>> _navKeys =
+      List.generate(AppTab.values.length, (_) => GlobalKey<NavigatorState>());
+
+  static const List<Widget> _tabRoots = [
+    HomeScreen(),
+    AgentScreen(),
+    TripsListScreen(),
+  ];
+
+  void _onSelect(int i) {
+    final current = ref.read(navIndexProvider);
+    if (i == current) {
+      // Tapping the active tab again returns it to its root.
+      _navKeys[i].currentState?.popUntil((r) => r.isFirst);
+    } else {
+      ref.read(navIndexProvider.notifier).state = i;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final index = ref.watch(navIndexProvider);
+    final isWide = MediaQuery.sizeOf(context).width >= kRailBreakpoint;
+
+    // The root navigator only holds the shell, so forward a system/browser back
+    // to the active tab's navigator — otherwise nested pushes (trip detail, etc.)
+    // couldn't be dismissed with the back button. At a tab root this is a no-op.
+    final content = PopScope(
+      canPop: false,
+      onPopInvokedWithResult: (didPop, _) {
+        if (didPop) return;
+        _navKeys[ref.read(navIndexProvider)].currentState?.maybePop();
+      },
+      child: IndexedStack(
+        index: index,
+        children: [
+          for (var i = 0; i < _tabRoots.length; i++)
+            _TabNavigator(navKey: _navKeys[i], child: _tabRoots[i]),
+        ],
+      ),
+    );
+
+    if (isWide) {
+      return Scaffold(
+        body: Row(
+          children: [
+            NavigationRail(
+              selectedIndex: index,
+              onDestinationSelected: _onSelect,
+              labelType: NavigationRailLabelType.all,
+              destinations: [
+                for (final d in navDestinations)
+                  NavigationRailDestination(
+                    icon: Icon(d.icon),
+                    selectedIcon: Icon(d.selectedIcon),
+                    label: Text(d.label),
+                  ),
+              ],
+            ),
+            const VerticalDivider(width: 1),
+            Expanded(child: content),
+          ],
+        ),
+      );
+    }
+
+    return Scaffold(
+      body: content,
+      bottomNavigationBar: NavigationBar(
+        selectedIndex: index,
+        onDestinationSelected: _onSelect,
+        destinations: [
+          for (final d in navDestinations)
+            NavigationDestination(
+              icon: Icon(d.icon),
+              selectedIcon: Icon(d.selectedIcon),
+              label: d.label,
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+/// A tab's own [Navigator]: its root route is the tab screen; in-app pushes from
+/// within the tab stack here so they animate inside the content area only.
+class _TabNavigator extends StatelessWidget {
+  final GlobalKey<NavigatorState> navKey;
+  final Widget child;
+
+  const _TabNavigator({required this.navKey, required this.child});
+
+  @override
+  Widget build(BuildContext context) {
+    return Navigator(
+      key: navKey,
+      onGenerateRoute: (settings) => MaterialPageRoute(
+        builder: (_) => child,
+        settings: settings,
+      ),
+    );
+  }
+}

--- a/src/packages/flutter-app/lib/screens/home_screen.dart
+++ b/src/packages/flutter-app/lib/screens/home_screen.dart
@@ -3,15 +3,17 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
 import '../constants/app_info.dart';
 import '../providers/auth_provider.dart';
+import '../providers/plan_provider.dart';
 import '../providers/recent_trip_provider.dart';
+import '../navigation/app_nav.dart';
+import '../theme/app_colors.dart';
+import '../theme/spacing.dart';
 import '../widgets/gradient_app_bar.dart';
 import '../widgets/page_container.dart';
 import 'route_optimizer_screen.dart';
 import 'country_optimizer_screen.dart';
-import 'agent_screen.dart';
 import 'airbnb_parser_screen.dart';
 import 'flight_search_screen.dart';
-import 'trips_list_screen.dart';
 import 'trip_detail_screen.dart';
 import 'preferences_screen.dart';
 
@@ -32,19 +34,20 @@ String _initialFor(String displayName) {
 class HomeScreen extends ConsumerWidget {
   const HomeScreen({super.key});
 
-  void _openAgent(BuildContext context, {String? initialMessage}) {
-    Navigator.of(context).push(
-      MaterialPageRoute(
-        builder: (context) => AgentScreen(initialMessage: initialMessage),
-      ),
-    );
-  }
-
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final theme = Theme.of(context);
     final user = ref.watch(authProvider).user;
     final recentTrip = ref.watch(recentTripProvider);
+
+    // The chat is a persistent tab, so "Let's go" / a suggestion switches to it
+    // (and seeds the message) rather than pushing a one-off screen.
+    void startPlanning({String? initialMessage}) {
+      ref.read(navIndexProvider.notifier).state = AppTab.plan.index;
+      if (initialMessage != null && initialMessage.isNotEmpty) {
+        ref.read(planProvider.notifier).sendMessage(initialMessage);
+      }
+    }
 
     return Scaffold(
       appBar: GradientAppBar(
@@ -74,7 +77,7 @@ class HomeScreen extends ConsumerWidget {
             icon: user != null
                 ? CircleAvatar(
                     radius: 16,
-                    backgroundColor: Colors.white.withOpacity(0.25),
+                    backgroundColor: Colors.white.withValues(alpha: 0.25),
                     child: Text(
                       _initialFor(user.displayName),
                       style: const TextStyle(
@@ -91,10 +94,6 @@ class HomeScreen extends ConsumerWidget {
               } else if (value == 'preferences') {
                 Navigator.of(context).push(
                   MaterialPageRoute(builder: (_) => const PreferencesScreen()),
-                );
-              } else if (value == 'my_trips') {
-                Navigator.of(context).push(
-                  MaterialPageRoute(builder: (_) => const TripsListScreen()),
                 );
               }
             },
@@ -150,17 +149,6 @@ class HomeScreen extends ConsumerWidget {
                 const PopupMenuDivider(),
               ],
               PopupMenuItem<String>(
-                value: 'my_trips',
-                child: Row(
-                  children: [
-                    Icon(Icons.luggage,
-                        size: 20, color: theme.colorScheme.onSurfaceVariant),
-                    const SizedBox(width: 12),
-                    const Text('My Trips'),
-                  ],
-                ),
-              ),
-              PopupMenuItem<String>(
                 value: 'preferences',
                 child: Row(
                   children: [
@@ -201,7 +189,7 @@ class HomeScreen extends ConsumerWidget {
                 const SizedBox(height: 16),
 
                 // AI Travel Agent hero card
-                _AgentHeroCard(onStart: _openAgent),
+                _AgentHeroCard(onStart: startPlanning),
 
                 const SizedBox(height: 28),
 
@@ -209,6 +197,8 @@ class HomeScreen extends ConsumerWidget {
                 if (recentTrip != null) ...[
                   _RecentTripCard(
                     title: recentTrip.title,
+                    dateRange: recentTrip.dateRange,
+                    status: recentTrip.status,
                     onTap: () => Navigator.of(context).push(
                       MaterialPageRoute(
                         builder: (_) =>
@@ -231,11 +221,11 @@ class HomeScreen extends ConsumerWidget {
                     leading: Container(
                       padding: const EdgeInsets.all(10),
                       decoration: BoxDecoration(
-                        color: Colors.teal.shade700.withOpacity(0.1),
+                        color: AppColors.brand.withValues(alpha: 0.1),
                         borderRadius: BorderRadius.circular(10),
                       ),
                       child: Icon(Icons.explore_outlined,
-                          color: Colors.teal.shade700, size: 26),
+                          color: AppColors.brand, size: 26),
                     ),
                     title: Text(
                       'Planning toolkit',
@@ -249,7 +239,7 @@ class HomeScreen extends ConsumerWidget {
                         padding: const EdgeInsets.fromLTRB(12, 0, 12, 12),
                         child: _ToolRow(
                           icon: MdiIcons.mapMarkerMultiple,
-                          color: Colors.deepOrange.shade600,
+                          color: AppColors.toolRoute,
                           title: 'Route Optimizer',
                           description:
                               'Map out the smartest path between your stops in a city',
@@ -263,7 +253,7 @@ class HomeScreen extends ConsumerWidget {
                         padding: const EdgeInsets.fromLTRB(12, 0, 12, 12),
                         child: _ToolRow(
                           icon: MdiIcons.airplane,
-                          color: Colors.blue.shade700,
+                          color: AppColors.toolFlights,
                           title: 'Find Flights',
                           description:
                               'Compare flights by price, schedule, and stops',
@@ -277,7 +267,7 @@ class HomeScreen extends ConsumerWidget {
                         padding: const EdgeInsets.fromLTRB(12, 0, 12, 12),
                         child: _ToolRow(
                           icon: MdiIcons.earth,
-                          color: Colors.green.shade700,
+                          color: AppColors.toolCountry,
                           title: 'Country Planner',
                           description:
                               'Order your countries around the best weather and seasons',
@@ -291,7 +281,7 @@ class HomeScreen extends ConsumerWidget {
                         padding: const EdgeInsets.fromLTRB(12, 0, 12, 12),
                         child: _ToolRow(
                           icon: Icons.home_work_outlined,
-                          color: Colors.pink.shade600,
+                          color: AppColors.toolAirbnb,
                           title: 'Airbnb Lookup',
                           description:
                               'Paste an Airbnb link to preview photos, pricing, and details',
@@ -349,7 +339,7 @@ class _GreetingHeader extends StatelessWidget {
 }
 
 class _AgentHeroCard extends StatelessWidget {
-  final void Function(BuildContext context, {String? initialMessage}) onStart;
+  final void Function({String? initialMessage}) onStart;
 
   const _AgentHeroCard({required this.onStart});
 
@@ -363,17 +353,17 @@ class _AgentHeroCard extends StatelessWidget {
   Widget build(BuildContext context) {
     return Container(
       decoration: BoxDecoration(
-        borderRadius: BorderRadius.circular(20),
+        borderRadius: AppRadius.lgAll,
         boxShadow: [
           BoxShadow(
-            color: Colors.teal.shade900.withOpacity(0.4),
+            color: AppColors.brandDark.withValues(alpha: 0.4),
             blurRadius: 16,
             offset: const Offset(0, 6),
           ),
         ],
       ),
       child: ClipRRect(
-        borderRadius: BorderRadius.circular(20),
+        borderRadius: AppRadius.lgAll,
         child: Stack(
           children: [
             Positioned.fill(
@@ -386,16 +376,7 @@ class _AgentHeroCard extends StatelessWidget {
             // lighter toward the upper-right so the photo shows through.
             Positioned.fill(
               child: DecoratedBox(
-                decoration: BoxDecoration(
-                  gradient: LinearGradient(
-                    begin: Alignment.bottomLeft,
-                    end: Alignment.topRight,
-                    colors: [
-                      Colors.teal.shade900.withOpacity(0.88),
-                      Colors.teal.shade900.withOpacity(0.35),
-                    ],
-                  ),
-                ),
+                decoration: BoxDecoration(gradient: AppColors.heroScrim),
               ),
             ),
             _heroContent(context),
@@ -415,7 +396,7 @@ class _AgentHeroCard extends StatelessWidget {
           Container(
             padding: const EdgeInsets.all(12),
             decoration: BoxDecoration(
-              color: Colors.white.withOpacity(0.15),
+              color: Colors.white.withValues(alpha: 0.15),
               shape: BoxShape.circle,
             ),
             child:
@@ -433,14 +414,14 @@ class _AgentHeroCard extends StatelessWidget {
           Text(
             'Describe the trip you\'re dreaming of and I\'ll build the full itinerary — places, days, and routes.',
             style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                  color: Colors.white.withOpacity(0.85),
+                  color: Colors.white.withValues(alpha: 0.85),
                 ),
           ),
           const SizedBox(height: 24),
           SizedBox(
             width: double.infinity,
             child: FilledButton(
-              onPressed: () => onStart(context),
+              onPressed: () => onStart(),
               style: FilledButton.styleFrom(
                 backgroundColor: Colors.white,
                 foregroundColor: Colors.teal.shade800,
@@ -468,7 +449,7 @@ class _AgentHeroCard extends StatelessWidget {
                               fontWeight: FontWeight.w500)),
                       backgroundColor: Colors.white,
                       side: BorderSide.none,
-                      onPressed: () => onStart(context, initialMessage: s),
+                      onPressed: () => onStart(initialMessage: s),
                     ))
                 .toList(),
           ),
@@ -482,24 +463,37 @@ class _AgentHeroCard extends StatelessWidget {
 /// sibling of the hero card (same teal family as the app bar gradient).
 class _RecentTripCard extends StatelessWidget {
   final String title;
+  final String? dateRange;
+  final String status;
   final VoidCallback onTap;
 
-  const _RecentTripCard({required this.title, required this.onTap});
+  const _RecentTripCard({
+    required this.title,
+    required this.dateRange,
+    required this.status,
+    required this.onTap,
+  });
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    // Date + status snapshot, styled white-on-teal to match the card rather
+    // than the light-surface StatusPill used elsewhere.
+    final meta = <String>[
+      if (dateRange != null && dateRange!.isNotEmpty) dateRange!,
+      if (status.isNotEmpty)
+        '${status[0].toUpperCase()}${status.substring(1)}'
+      else
+        'Draft',
+    ].join('  ·  ');
+
     return Container(
       decoration: BoxDecoration(
-        borderRadius: BorderRadius.circular(16),
-        gradient: LinearGradient(
-          begin: Alignment.topLeft,
-          end: Alignment.bottomRight,
-          colors: [Colors.teal.shade600, Colors.teal.shade900],
-        ),
+        borderRadius: AppRadius.mdAll,
+        gradient: AppColors.brandGradient,
         boxShadow: [
           BoxShadow(
-            color: Colors.teal.shade900.withOpacity(0.3),
+            color: AppColors.brandDark.withValues(alpha: 0.3),
             blurRadius: 10,
             offset: const Offset(0, 4),
           ),
@@ -509,21 +503,21 @@ class _RecentTripCard extends StatelessWidget {
         color: Colors.transparent,
         child: InkWell(
           onTap: onTap,
-          borderRadius: BorderRadius.circular(16),
+          borderRadius: AppRadius.mdAll,
           child: Padding(
-            padding: const EdgeInsets.all(16),
+            padding: const EdgeInsets.all(AppSpacing.lg),
             child: Row(
               children: [
                 Container(
-                  padding: const EdgeInsets.all(10),
+                  padding: const EdgeInsets.all(AppSpacing.sm + 2),
                   decoration: BoxDecoration(
-                    color: Colors.white.withOpacity(0.15),
+                    color: Colors.white.withValues(alpha: 0.15),
                     shape: BoxShape.circle,
                   ),
                   child:
                       const Icon(Icons.luggage, color: Colors.white, size: 26),
                 ),
-                const SizedBox(width: 16),
+                const SizedBox(width: AppSpacing.lg),
                 Expanded(
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
@@ -545,6 +539,15 @@ class _RecentTripCard extends StatelessWidget {
                         style: theme.textTheme.titleMedium?.copyWith(
                           fontWeight: FontWeight.bold,
                           color: Colors.white,
+                        ),
+                      ),
+                      const SizedBox(height: 2),
+                      Text(
+                        meta,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: theme.textTheme.bodySmall?.copyWith(
+                          color: Colors.white.withValues(alpha: 0.85),
                         ),
                       ),
                     ],
@@ -590,7 +593,7 @@ class _ToolRow extends StatelessWidget {
               Container(
                 padding: const EdgeInsets.all(10),
                 decoration: BoxDecoration(
-                  color: color.withOpacity(0.1),
+                  color: color.withValues(alpha: 0.1),
                   borderRadius: BorderRadius.circular(10),
                 ),
                 child: Icon(icon, color: color, size: 26),

--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -16,8 +16,12 @@ import '../providers/booking_todos_provider.dart';
 import '../providers/preferences_provider.dart';
 import '../providers/api_client_provider.dart';
 import '../providers/plan_provider.dart';
+import '../theme/spacing.dart';
+import '../utils/trip_format.dart';
 import '../widgets/add_itinerary_item_dialog.dart';
 import '../widgets/booking_todo_card.dart';
+import '../widgets/empty_state.dart';
+import '../widgets/status_pill.dart';
 import '../widgets/trip_map.dart';
 import '../widgets/trip_refine_panel.dart';
 import 'flight_search_screen.dart';
@@ -86,7 +90,12 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
           _bookingTodos = trip.bookingTodos ?? [];
         });
         // Remember this as the most recently viewed trip (home screen tile).
-        ref.read(recentTripProvider.notifier).record(trip.id, trip.title);
+        ref.read(recentTripProvider.notifier).record(
+              trip.id,
+              trip.title,
+              dateRange: tripDateRange(trip.startDate, trip.endDate),
+              status: trip.status,
+            );
       }
       // Load the home airport so the booking checklist can derive the outbound
       // and return flights (no-op / null for anonymous sessions).
@@ -1318,26 +1327,15 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
                   onPressed: _editDates,
                 ),
                 PopupMenuButton<String>(
+                  tooltip: 'Change status',
                   onSelected: (v) => _patch(status: v),
                   itemBuilder: (_) => const [
                     PopupMenuItem(value: 'draft', child: Text('Draft')),
                     PopupMenuItem(value: 'planned', child: Text('Planned')),
                   ],
-                  child: Chip(
-                    avatar: Icon(
-                      Icons.circle,
-                      size: 12,
-                      color: trip.status == 'planned'
-                          ? Colors.green
-                          : theme.colorScheme.outline,
-                    ),
-                    label: Row(
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        Text(trip.status == 'planned' ? 'Planned' : 'Draft'),
-                        const Icon(Icons.arrow_drop_down, size: 18),
-                      ],
-                    ),
+                  child: StatusPill(
+                    status: trip.status,
+                    trailing: const Icon(Icons.arrow_drop_down),
                   ),
                 ),
               ],
@@ -1544,24 +1542,20 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
                             ),
                           ),
                           if ((trip.items ?? []).isEmpty)
-                            const SliverPadding(
-                              padding: EdgeInsets.fromLTRB(16, 4, 16, 0),
-                              sliver: SliverToBoxAdapter(
-                                child: Padding(
-                                  padding: EdgeInsets.symmetric(vertical: 16),
-                                  child: Text('No places added.'),
+                            const SliverToBoxAdapter(
+                              child: SizedBox(
+                                height: 260,
+                                child: EmptyState(
+                                  icon: Icons.place_outlined,
+                                  title: 'No places yet',
+                                  message:
+                                      'Refine with AI or add a place to start your itinerary.',
                                 ),
                               ),
                             )
                           else if (filtered.isEmpty)
-                            const SliverPadding(
-                              padding: EdgeInsets.fromLTRB(16, 4, 16, 0),
-                              sliver: SliverToBoxAdapter(
-                                child: Padding(
-                                  padding: EdgeInsets.symmetric(vertical: 16),
-                                  child: Text('No items match this filter.'),
-                                ),
-                              ),
+                            SliverToBoxAdapter(
+                              child: _FilterMissNotice(theme: theme),
                             )
                           else
                             // Each city is a MultiSliver whose header pins
@@ -1901,6 +1895,37 @@ class _AddBookingTodoDialogState extends ConsumerState<_AddBookingTodoDialog> {
               : const Text('Save'),
         ),
       ],
+    );
+  }
+}
+
+/// Compact, centered notice shown when a category filter hides every item — a
+/// lighter touch than the full empty state since the fix (clearing the filter)
+/// is right above it.
+class _FilterMissNotice extends StatelessWidget {
+  final ThemeData theme;
+  const _FilterMissNotice({required this.theme});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: AppSpacing.xl),
+      child: Column(
+        children: [
+          Icon(
+            Icons.filter_alt_off_outlined,
+            size: 32,
+            color: theme.colorScheme.onSurfaceVariant,
+          ),
+          const SizedBox(height: AppSpacing.sm),
+          Text(
+            'No places match this filter.',
+            style: theme.textTheme.bodyMedium?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/src/packages/flutter-app/lib/screens/trips_list_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trips_list_screen.dart
@@ -1,6 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../navigation/app_nav.dart';
+import '../theme/spacing.dart';
+import '../utils/trip_format.dart';
+import '../widgets/empty_state.dart';
 import '../widgets/gradient_app_bar.dart';
+import '../widgets/status_pill.dart';
 import '../models/trip.dart';
 import '../providers/auth_provider.dart';
 import '../providers/trips_provider.dart';
@@ -31,47 +36,38 @@ class _TripsListScreenState extends ConsumerState<TripsListScreen> {
     if (state.loading && state.trips.isEmpty) {
       body = const Center(child: CircularProgressIndicator());
     } else if (state.error != null && state.trips.isEmpty) {
-      body = Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            Text('Could not load trips', style: theme.textTheme.titleMedium),
-            const SizedBox(height: 8),
-            FilledButton(
-              onPressed: () => ref.read(tripsProvider.notifier).loadTrips(),
-              child: const Text('Retry'),
-            ),
-          ],
-        ),
+      body = EmptyState(
+        icon: Icons.cloud_off,
+        title: 'Could not load trips',
+        message: 'Check your connection and try again.',
+        iconColor: theme.colorScheme.error.withValues(alpha: 0.6),
+        actions: [
+          FilledButton(
+            onPressed: () => ref.read(tripsProvider.notifier).loadTrips(),
+            child: const Text('Retry'),
+          ),
+        ],
       );
     } else if (state.trips.isEmpty) {
-      body = Center(
-        child: Padding(
-          padding: const EdgeInsets.all(32),
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              Icon(Icons.luggage, size: 64, color: theme.colorScheme.primary.withValues(alpha: 0.5)),
-              const SizedBox(height: 16),
-              Text('No trips yet', style: theme.textTheme.titleLarge),
-              const SizedBox(height: 8),
-              Text(
-                'Chat with the AI agent to create your first trip.',
-                textAlign: TextAlign.center,
-                style: theme.textTheme.bodyMedium?.copyWith(
-                  color: theme.colorScheme.onSurfaceVariant,
-                ),
-              ),
-            ],
+      body = EmptyState(
+        icon: Icons.luggage,
+        title: 'No trips yet',
+        message: 'Chat with the AI agent to create your first trip.',
+        actions: [
+          FilledButton.icon(
+            onPressed: () => ref.read(navIndexProvider.notifier).state =
+                AppTab.plan.index,
+            icon: const Icon(Icons.auto_awesome),
+            label: const Text('Plan a trip'),
           ),
-        ),
+        ],
       );
     } else {
       final isAdmin = ref.watch(authProvider).user?.isAdmin ?? false;
       body = RefreshIndicator(
         onRefresh: () => ref.read(tripsProvider.notifier).loadTrips(),
         child: ListView.builder(
-          padding: const EdgeInsets.all(12),
+          padding: const EdgeInsets.all(AppSpacing.md),
           itemCount: state.trips.length,
           itemBuilder: (context, i) => _TripCard(trip: state.trips[i], isAdmin: isAdmin),
         ),
@@ -85,29 +81,6 @@ class _TripsListScreenState extends ConsumerState<TripsListScreen> {
       body: body,
     );
   }
-}
-
-String _shortDate(String iso) {
-  final d = DateTime.tryParse(iso);
-  if (d == null) return iso;
-  return '${d.year}-${d.month.toString().padLeft(2, '0')}-${d.day.toString().padLeft(2, '0')}';
-}
-
-const _mon = [
-  'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
-  'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
-];
-
-String _fmtDt(DateTime d) => '${_mon[d.month - 1]} ${d.day}';
-
-/// "Mon d – Mon d" from the trip's start/end (same day collapses to one);
-/// null when either date is missing/unparseable.
-String? _dateRange(Trip t) {
-  final a = DateTime.tryParse(t.startDate ?? '');
-  final b = DateTime.tryParse(t.endDate ?? '');
-  if (a == null || b == null) return null;
-  final sameDay = a.year == b.year && a.month == b.month && a.day == b.day;
-  return sameDay ? _fmtDt(a) : '${_fmtDt(a)} – ${_fmtDt(b)}';
 }
 
 /// A short destination summary from the trip's hub cities: "Paris",
@@ -139,7 +112,7 @@ class _TripCard extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final versions = trip.versionCount ?? 1;
     final hasHistory = isAdmin && versions > 1 && trip.chatId != null;
-    final range = _dateRange(trip);
+    final range = tripDateRange(trip.startDate, trip.endDate);
 
     final title = Text(
       _locationLabel(trip) ?? trip.title,
@@ -152,24 +125,17 @@ class _TripCard extends ConsumerWidget {
     );
 
     final subtitle = Padding(
-      padding: const EdgeInsets.only(top: 4),
+      padding: const EdgeInsets.only(top: AppSpacing.sm),
       child: Wrap(
-        spacing: 10,
-        runSpacing: 4,
+        spacing: AppSpacing.sm,
+        runSpacing: AppSpacing.xs,
         crossAxisAlignment: WrapCrossAlignment.center,
         children: [
           if (range != null)
-            Row(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                const Icon(Icons.event, size: 14),
-                const SizedBox(width: 4),
-                Text(range),
-              ],
-            )
+            _DateChip(label: range)
           else
-            Text('Created ${_shortDate(trip.createdAt)}'),
-          _StatusChip(status: trip.status),
+            Text('Created ${shortDate(trip.createdAt)}'),
+          StatusPill(status: trip.status),
         ],
       ),
     );
@@ -206,29 +172,38 @@ class _TripCard extends ConsumerWidget {
   }
 }
 
-/// Small display-only status pill: a colored dot + capitalized label.
-class _StatusChip extends StatelessWidget {
-  final String status;
-  const _StatusChip({required this.status});
+/// Display-only date range, styled as a tonal pill so it pairs with the
+/// [StatusPill] beside it and matches the trip-detail header's date chip.
+class _DateChip extends StatelessWidget {
+  final String label;
+  const _DateChip({required this.label});
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final isPlanned = status == 'planned';
-    final label = status.isEmpty
-        ? 'Draft'
-        : '${status[0].toUpperCase()}${status.substring(1)}';
-    return Row(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        Icon(
-          Icons.circle,
-          size: 10,
-          color: isPlanned ? Colors.green : theme.colorScheme.outline,
-        ),
-        const SizedBox(width: 4),
-        Text(label, style: theme.textTheme.bodySmall),
-      ],
+    return Container(
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppSpacing.sm,
+        vertical: 3,
+      ),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.surfaceContainerHighest,
+        borderRadius: BorderRadius.circular(AppRadius.lg),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(Icons.event, size: 13, color: theme.colorScheme.onSurfaceVariant),
+          const SizedBox(width: AppSpacing.xs),
+          Text(
+            label,
+            style: theme.textTheme.labelMedium?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+        ],
+      ),
     );
   }
 }
@@ -292,8 +267,8 @@ class _VersionList extends ConsumerWidget {
                 title: Text(versions[i].title, maxLines: 2, overflow: TextOverflow.ellipsis),
                 subtitle: Text(
                   i == 0
-                      ? 'latest · ${_shortDate(versions[i].createdAt)}'
-                      : 'v${versions.length - i} · ${_shortDate(versions[i].createdAt)}',
+                      ? 'latest · ${shortDate(versions[i].createdAt)}'
+                      : 'v${versions.length - i} · ${shortDate(versions[i].createdAt)}',
                 ),
                 trailing: const Icon(Icons.chevron_right),
                 onTap: () => _openTrip(context, versions[i].id),

--- a/src/packages/flutter-app/lib/theme/app_colors.dart
+++ b/src/packages/flutter-app/lib/theme/app_colors.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/material.dart';
+
+/// Brand and category colors in one place. The teal family is the spine of the
+/// app (the Material 3 scheme is seeded from `Colors.teal.shade700`); the
+/// gradients below are the exact pair the app bar, hero, and recent-trip card
+/// were each declaring inline.
+abstract final class AppColors {
+  // Brand teal ramp.
+  static final Color brand = Colors.teal.shade700;
+  static final Color brandLight = Colors.teal.shade600;
+  static final Color brandDark = Colors.teal.shade900;
+  static final Color brandTint = Colors.teal.shade50;
+
+  /// Top-left → bottom-right teal gradient used by the app bar and recent-trip
+  /// card.
+  static LinearGradient get brandGradient => LinearGradient(
+        begin: Alignment.topLeft,
+        end: Alignment.bottomRight,
+        colors: [brandLight, brandDark],
+      );
+
+  /// Scrim for image heroes: darkest in the lower-left where text/buttons sit,
+  /// lighter toward the upper-right so the photo shows through.
+  static LinearGradient get heroScrim => LinearGradient(
+        begin: Alignment.bottomLeft,
+        end: Alignment.topRight,
+        colors: [
+          brandDark.withValues(alpha: 0.88),
+          brandDark.withValues(alpha: 0.35),
+        ],
+      );
+
+  /// Accent color for an itinerary place by its category. `scheme` supplies the
+  /// theme-derived fallbacks so this stays in sync with the seed.
+  static Color forCategory(String? category, ColorScheme scheme) {
+    switch (category) {
+      case 'restaurant':
+        return Colors.deepOrange;
+      case 'attraction':
+        return scheme.primary;
+      default:
+        return scheme.secondary;
+    }
+  }
+
+  // Planning-toolkit tool accents (Home screen).
+  static Color get toolRoute => Colors.deepOrange.shade600;
+  static Color get toolFlights => Colors.blue.shade700;
+  static Color get toolCountry => Colors.green.shade700;
+  static Color get toolAirbnb => Colors.pink.shade600;
+}

--- a/src/packages/flutter-app/lib/theme/app_theme.dart
+++ b/src/packages/flutter-app/lib/theme/app_theme.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+import 'spacing.dart';
+
+/// Central app theme. Kept in one place (out of `main.dart`) so styling is
+/// enforceable rather than re-declared per screen, and so a `dark` variant can
+/// be added later without touching call sites.
+abstract final class AppTheme {
+  static ThemeData get light => _build(Brightness.light);
+
+  static ThemeData _build(Brightness brightness) {
+    final colorScheme = ColorScheme.fromSeed(
+      seedColor: Colors.teal.shade700, // Teal theme (matches the home banner)
+      brightness: brightness,
+    );
+
+    return ThemeData(
+      colorScheme: colorScheme,
+      useMaterial3: true,
+      appBarTheme: const AppBarTheme(
+        centerTitle: true,
+        elevation: 2,
+      ),
+      cardTheme: const CardThemeData(
+        elevation: 4,
+        shape: RoundedRectangleBorder(borderRadius: AppRadius.mdAll),
+      ),
+      inputDecorationTheme: InputDecorationTheme(
+        border: const OutlineInputBorder(borderRadius: AppRadius.smAll),
+        filled: true,
+        fillColor: Colors.grey[50],
+      ),
+      elevatedButtonTheme: ElevatedButtonThemeData(
+        style: ElevatedButton.styleFrom(
+          padding: const EdgeInsets.symmetric(
+            horizontal: AppSpacing.xl,
+            vertical: AppSpacing.md,
+          ),
+          shape: const RoundedRectangleBorder(borderRadius: AppRadius.smAll),
+        ),
+      ),
+      // Matches the home hero button so primary actions read the same app-wide.
+      filledButtonTheme: FilledButtonThemeData(
+        style: FilledButton.styleFrom(
+          padding: const EdgeInsets.symmetric(
+            horizontal: AppSpacing.xl,
+            vertical: AppSpacing.md,
+          ),
+          shape: const RoundedRectangleBorder(borderRadius: AppRadius.mdAll),
+        ),
+      ),
+      chipTheme: ChipThemeData(
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(AppRadius.lg),
+        ),
+      ),
+    );
+  }
+}

--- a/src/packages/flutter-app/lib/theme/spacing.dart
+++ b/src/packages/flutter-app/lib/theme/spacing.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+
+/// Spacing scale used across the app. These are the values that were already
+/// repeated inline everywhere (4 / 8 / 12 / 16 / 24); naming them keeps padding
+/// and gaps consistent instead of being magic numbers per screen.
+abstract final class AppSpacing {
+  static const double xs = 4;
+  static const double sm = 8;
+  static const double md = 12;
+  static const double lg = 16;
+  static const double xl = 24;
+  static const double xxl = 32;
+}
+
+/// Corner-radius scale. `sm` = inputs/small badges, `md` = cards/sections,
+/// `lg` = hero / large containers.
+abstract final class AppRadius {
+  static const double sm = 8;
+  static const double md = 12;
+  static const double lg = 20;
+
+  static const BorderRadius smAll = BorderRadius.all(Radius.circular(sm));
+  static const BorderRadius mdAll = BorderRadius.all(Radius.circular(md));
+  static const BorderRadius lgAll = BorderRadius.all(Radius.circular(lg));
+}
+
+/// Minimum interactive height for full-width rows/tiles (Fitts's Law — comfy
+/// touch targets).
+const double kMinTouchTarget = 48;

--- a/src/packages/flutter-app/lib/utils/trip_format.dart
+++ b/src/packages/flutter-app/lib/utils/trip_format.dart
@@ -1,0 +1,27 @@
+// Shared trip-formatting helpers so the trips list, the home recent-trip tile,
+// and the trip-detail header all speak the same language.
+
+const _months = [
+  'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', //
+  'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
+];
+
+String _fmt(DateTime d) => '${_months[d.month - 1]} ${d.day}';
+
+/// "Mon d – Mon d" from ISO start/end (same day collapses to one); null when
+/// either date is missing or unparseable.
+String? tripDateRange(String? startIso, String? endIso) {
+  final a = DateTime.tryParse(startIso ?? '');
+  final b = DateTime.tryParse(endIso ?? '');
+  if (a == null || b == null) return null;
+  final sameDay = a.year == b.year && a.month == b.month && a.day == b.day;
+  return sameDay ? _fmt(a) : '${_fmt(a)} – ${_fmt(b)}';
+}
+
+/// "YYYY-MM-DD" from an ISO timestamp, falling back to the raw value.
+String shortDate(String iso) {
+  final d = DateTime.tryParse(iso);
+  if (d == null) return iso;
+  return '${d.year}-${d.month.toString().padLeft(2, '0')}-'
+      '${d.day.toString().padLeft(2, '0')}';
+}

--- a/src/packages/flutter-app/lib/widgets/booking_todo_card.dart
+++ b/src/packages/flutter-app/lib/widgets/booking_todo_card.dart
@@ -164,7 +164,7 @@ class BookingTodoRow extends StatelessWidget {
           ),
           TextButton.icon(
             onPressed: onOpen,
-            icon: const Icon(Icons.open_in_new, size: 16),
+            icon: const Icon(Icons.open_in_new, size: 18),
             label: Text(_providerOpenLabel(todo, openLabelOverride)),
           ),
           // Last so the fixed-width checkboxes stay flush right and aligned

--- a/src/packages/flutter-app/lib/widgets/empty_state.dart
+++ b/src/packages/flutter-app/lib/widgets/empty_state.dart
@@ -1,0 +1,73 @@
+import 'package:flutter/material.dart';
+import '../theme/spacing.dart';
+
+/// A centered icon + title + message, with optional actions. One implementation
+/// for every "nothing here yet", error, or "no results" state so they read the
+/// same across the app instead of some being styled and others plain text.
+class EmptyState extends StatelessWidget {
+  final IconData icon;
+  final String title;
+  final String? message;
+
+  /// Optional buttons (e.g. a Retry or a CTA) rendered below the message.
+  final List<Widget> actions;
+
+  /// Tints the icon. Defaults to a muted primary.
+  final Color? iconColor;
+
+  const EmptyState({
+    super.key,
+    required this.icon,
+    required this.title,
+    this.message,
+    this.actions = const [],
+    this.iconColor,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(AppSpacing.xxl),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(
+              icon,
+              size: 64,
+              color: iconColor ?? theme.colorScheme.primary.withValues(alpha: 0.5),
+            ),
+            const SizedBox(height: AppSpacing.lg),
+            Text(
+              title,
+              style: theme.textTheme.titleLarge?.copyWith(
+                fontWeight: FontWeight.bold,
+              ),
+              textAlign: TextAlign.center,
+            ),
+            if (message != null) ...[
+              const SizedBox(height: AppSpacing.sm),
+              Text(
+                message!,
+                textAlign: TextAlign.center,
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              ),
+            ],
+            if (actions.isNotEmpty) ...[
+              const SizedBox(height: AppSpacing.xl),
+              Wrap(
+                spacing: AppSpacing.sm,
+                runSpacing: AppSpacing.sm,
+                alignment: WrapAlignment.center,
+                children: actions,
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/src/packages/flutter-app/lib/widgets/section_header.dart
+++ b/src/packages/flutter-app/lib/widgets/section_header.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/material.dart';
+
+/// A section title with an optional trailing action (e.g. "Itinerary" + "Add
+/// place"). Gives related groups a consistent header so the eye reads them as
+/// sections rather than loose rows.
+class SectionHeader extends StatelessWidget {
+  final String title;
+  final Widget? action;
+
+  const SectionHeader({super.key, required this.title, this.action});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Row(
+      children: [
+        Expanded(
+          child: Text(
+            title,
+            style: theme.textTheme.titleMedium?.copyWith(
+              fontWeight: FontWeight.bold,
+              color: theme.colorScheme.onSurface,
+            ),
+          ),
+        ),
+        if (action != null) action!,
+      ],
+    );
+  }
+}

--- a/src/packages/flutter-app/lib/widgets/status_pill.dart
+++ b/src/packages/flutter-app/lib/widgets/status_pill.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+import '../theme/spacing.dart';
+
+/// A filled tonal pill for a trip's status (Draft / Planned). Reads at a glance
+/// and stays colorblind-safe by carrying its label, not just a colored dot.
+/// Shared by the trips list and the trip-detail header.
+class StatusPill extends StatelessWidget {
+  final String status;
+
+  /// Optional trailing widget (e.g. a dropdown arrow when the pill doubles as a
+  /// status picker trigger). Tinted to match the label.
+  final Widget? trailing;
+
+  const StatusPill({super.key, required this.status, this.trailing});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final isPlanned = status == 'planned';
+    final label = status.isEmpty
+        ? 'Draft'
+        : '${status[0].toUpperCase()}${status.substring(1)}';
+
+    // Planned reads as a positive, completed state (green); anything else is a
+    // neutral surface tone so it doesn't compete for attention.
+    final Color bg = isPlanned
+        ? Colors.green.withValues(alpha: 0.15)
+        : theme.colorScheme.surfaceContainerHighest;
+    final Color fg =
+        isPlanned ? Colors.green.shade800 : theme.colorScheme.onSurfaceVariant;
+
+    return Container(
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppSpacing.sm,
+        vertical: 3,
+      ),
+      decoration: BoxDecoration(
+        color: bg,
+        borderRadius: BorderRadius.circular(AppRadius.lg),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(
+            isPlanned ? Icons.check_circle : Icons.edit_note,
+            size: 13,
+            color: fg,
+          ),
+          const SizedBox(width: AppSpacing.xs),
+          Text(
+            label,
+            style: theme.textTheme.labelMedium?.copyWith(
+              color: fg,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+          if (trailing != null)
+            IconTheme.merge(
+              data: IconThemeData(color: fg, size: 18),
+              child: trailing!,
+            ),
+        ],
+      ),
+    );
+  }
+}

--- a/src/packages/flutter-app/lib/widgets/trip_map.dart
+++ b/src/packages/flutter-app/lib/widgets/trip_map.dart
@@ -5,6 +5,7 @@ import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map_marker_cluster/flutter_map_marker_cluster.dart';
 import 'package:latlong2/latlong.dart';
 import '../models/itinerary_item.dart';
+import '../theme/app_colors.dart';
 
 /// Plots a trip's itinerary on an OpenStreetMap: a numbered, category-tinted pin
 /// per place, a route line connecting them in itinerary order, auto-fit to the
@@ -150,8 +151,8 @@ class _TripMapState extends State<TripMap> {
             (a.point.latitude + b.point.latitude) / 2,
             (a.point.longitude + b.point.longitude) / 2,
           ),
-          width: 70,
-          height: 22,
+          width: 84,
+          height: 26,
           child: _SegmentLabel(text: label),
         ),
       );
@@ -360,11 +361,20 @@ class _SegmentLabel extends StatelessWidget {
     final scheme = Theme.of(context).colorScheme;
     return Center(
       child: Container(
-        padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+        padding: const EdgeInsets.symmetric(horizontal: 7, vertical: 3),
         decoration: BoxDecoration(
-          color: scheme.surface.withValues(alpha: 0.9),
+          // Fully opaque with a soft shadow and a stronger border so the time
+          // reads cleanly over the map tiles and the route line beneath it.
+          color: scheme.surface,
           borderRadius: BorderRadius.circular(10),
-          border: Border.all(color: scheme.outlineVariant),
+          border: Border.all(color: scheme.outline),
+          boxShadow: [
+            BoxShadow(
+              color: Colors.black.withValues(alpha: 0.15),
+              blurRadius: 3,
+              offset: const Offset(0, 1),
+            ),
+          ],
         ),
         child: Text(
           text,
@@ -372,7 +382,7 @@ class _SegmentLabel extends StatelessWidget {
           overflow: TextOverflow.clip,
           style: TextStyle(
             color: scheme.onSurface,
-            fontSize: 10,
+            fontSize: 11,
             fontWeight: FontWeight.w600,
           ),
         ),
@@ -427,16 +437,7 @@ class _Pin extends StatelessWidget {
     this.onTap,
   });
 
-  Color _color(ColorScheme scheme) {
-    switch (category) {
-      case 'restaurant':
-        return Colors.deepOrange;
-      case 'attraction':
-        return scheme.primary;
-      default:
-        return scheme.secondary;
-    }
-  }
+  Color _color(ColorScheme scheme) => AppColors.forCategory(category, scheme);
 
   @override
   Widget build(BuildContext context) {


### PR DESCRIPTION
## Summary
- **Design system**: extract `lib/theme/` tokens (`AppTheme`, `AppSpacing`/`AppRadius`, `AppColors`) out of `main.dart`, plus shared `EmptyState`, `SectionHeader`, `StatusPill` widgets and `trip_format` helpers — applied across Home, Plan chat, My Trips, and Trip detail for consistent spacing, color, empty states, and status pills.
- **Persistent nav shell**: Home / Plan / Trips as top-level destinations (NavigationRail on wide, NavigationBar on narrow), surfacing the AI chat and saved trips instead of burying them in the account menu.
- **No more rail-slide jank**: per-tab nested navigators keep the rail in the shell — pushing a detail/tool page animates only the content area, the rail never moves, and the active tab stays highlighted. A root `PopScope` forwards system/browser back to the active tab's navigator.
- **Polish**: enriched recent-trip card (date + status), promoted itinerary "ready" banner, unified trip-detail/My-Trips status + date chips, stronger map travel-time labels, centralized category colors.

## Testing
- `make flutter-analyze` — clean for all changed files (no new issues; pre-existing repo lints unchanged).
- `make flutter-test` — all 16 unit/widget tests pass.
- `flutter build web --dart-define=API_BASE_URL=/api/v1` — compiles.
- Note: the signed-in shell/rail tree has no automated coverage; recommend a quick live check that the rail stays fixed on navigation and the browser back button pops detail pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)