### PR TITLE
feat: add landing page for logged-out users

### DIFF
--- a/src/packages/flutter-app/lib/main.dart
+++ b/src/packages/flutter-app/lib/main.dart
@@ -3,7 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'constants/app_info.dart';
 import 'providers/auth_provider.dart';
 import 'theme/app_theme.dart';
-import 'screens/auth_screen.dart';
+import 'screens/landing_screen.dart';
 import 'screens/app_shell.dart';
 
 void main() {
@@ -29,7 +29,7 @@ class TravelRoutePlannerApp extends StatelessWidget {
 }
 
 /// Shows a loading splash until the stored session is checked, then routes to
-/// the login screen (signed out) or the home screen (signed in).
+/// the landing page (signed out) or the home screen (signed in).
 class AuthGate extends ConsumerWidget {
   const AuthGate({super.key});
 
@@ -41,6 +41,6 @@ class AuthGate extends ConsumerWidget {
         body: Center(child: CircularProgressIndicator()),
       );
     }
-    return auth.isSignedIn ? const AppShell() : const AuthScreen();
+    return auth.isSignedIn ? const AppShell() : const LandingScreen();
   }
 }

--- a/src/packages/flutter-app/lib/screens/auth_screen.dart
+++ b/src/packages/flutter-app/lib/screens/auth_screen.dart
@@ -3,7 +3,10 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../providers/auth_provider.dart';
 
 class AuthScreen extends ConsumerStatefulWidget {
-  const AuthScreen({super.key});
+  /// Whether the form opens in sign-in (true) or create-account (false) mode.
+  final bool initialIsLogin;
+
+  const AuthScreen({super.key, this.initialIsLogin = true});
 
   @override
   ConsumerState<AuthScreen> createState() => _AuthScreenState();
@@ -14,7 +17,7 @@ class _AuthScreenState extends ConsumerState<AuthScreen> {
   final _emailController = TextEditingController();
   final _passwordController = TextEditingController();
   final _displayNameController = TextEditingController();
-  bool _isLogin = true;
+  late bool _isLogin = widget.initialIsLogin;
 
   @override
   void dispose() {
@@ -29,13 +32,16 @@ class _AuthScreenState extends ConsumerState<AuthScreen> {
     final notifier = ref.read(authProvider.notifier);
     final email = _emailController.text.trim();
     final password = _passwordController.text;
-    if (_isLogin) {
-      await notifier.login(email, password);
-    } else {
-      await notifier.register(email, password,
-          displayName: _displayNameController.text.trim());
+    final ok = _isLogin
+        ? await notifier.login(email, password)
+        : await notifier.register(email, password,
+            displayName: _displayNameController.text.trim());
+    // On success the AuthGate swaps the root from the landing page to the app.
+    // When this screen was pushed on top of the landing page, pop it so the
+    // app (now the root) is revealed instead of this form staying on top.
+    if (ok && mounted && Navigator.of(context).canPop()) {
+      Navigator.of(context).pop();
     }
-    // On success the AuthGate swaps this screen for the app automatically.
   }
 
   void _toggleMode() {

--- a/src/packages/flutter-app/lib/screens/landing_screen.dart
+++ b/src/packages/flutter-app/lib/screens/landing_screen.dart
@@ -1,0 +1,305 @@
+import 'package:flutter/material.dart';
+import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
+import '../constants/app_info.dart';
+import '../theme/app_colors.dart';
+import '../theme/spacing.dart';
+import '../widgets/gradient_app_bar.dart';
+import '../widgets/page_container.dart';
+import 'auth_screen.dart';
+
+/// Marketing entry point shown to logged-out visitors. Brands the product and
+/// showcases the core features, then funnels into the existing auth form:
+/// "Get started" opens sign-up, "Sign in" opens login. On success the AuthGate
+/// swaps this screen for the app automatically.
+class LandingScreen extends StatelessWidget {
+  const LandingScreen({super.key});
+
+  static void _openAuth(BuildContext context, {required bool isLogin}) {
+    Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (_) => AuthScreen(initialIsLogin: isLogin),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Scaffold(
+      appBar: GradientAppBar(
+        centerTitle: false,
+        title: const Text(
+          AppInfo.name,
+          style: TextStyle(
+            fontFamily: 'Playfair Display',
+            fontWeight: FontWeight.w600,
+            fontSize: 24,
+            letterSpacing: 0.5,
+          ),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => _openAuth(context, isLogin: true),
+            style: TextButton.styleFrom(foregroundColor: Colors.white),
+            child: const Text('Sign in'),
+          ),
+          const SizedBox(width: AppSpacing.sm),
+        ],
+      ),
+      body: SafeArea(
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.all(AppSpacing.lg),
+          child: PageContainer(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                const SizedBox(height: AppSpacing.sm),
+
+                _LandingHero(
+                  onGetStarted: () => _openAuth(context, isLogin: false),
+                  onSignIn: () => _openAuth(context, isLogin: true),
+                ),
+
+                const SizedBox(height: AppSpacing.xl + AppSpacing.xs),
+
+                Text(
+                  'Everything you need to plan the trip',
+                  style: theme.textTheme.titleMedium?.copyWith(
+                    fontWeight: FontWeight.bold,
+                    color: theme.colorScheme.onSurface,
+                  ),
+                ),
+
+                const SizedBox(height: AppSpacing.md),
+
+                const _FeatureCard(
+                  icon: Icons.auto_awesome,
+                  title: 'AI Travel Agent',
+                  description:
+                      'Describe your dream trip and get a complete itinerary in seconds.',
+                ),
+                _FeatureCard(
+                  icon: MdiIcons.mapMarkerMultiple,
+                  color: AppColors.toolRoute,
+                  title: 'Route Optimizer',
+                  description:
+                      'Map the smartest path between your stops in a city.',
+                ),
+                _FeatureCard(
+                  icon: MdiIcons.earth,
+                  color: AppColors.toolCountry,
+                  title: 'Country Planner',
+                  description:
+                      'Order countries around the best weather and seasons.',
+                ),
+                _FeatureCard(
+                  icon: MdiIcons.airplane,
+                  color: AppColors.toolFlights,
+                  title: 'Find Flights',
+                  description:
+                      'Compare flights by price, schedule, and stops.',
+                ),
+
+                const SizedBox(height: AppSpacing.xl),
+
+                SizedBox(
+                  width: double.infinity,
+                  child: FilledButton(
+                    onPressed: () => _openAuth(context, isLogin: false),
+                    style: FilledButton.styleFrom(
+                      padding: const EdgeInsets.symmetric(vertical: 16),
+                    ),
+                    child: const Text(
+                      'Get started',
+                      style:
+                          TextStyle(fontWeight: FontWeight.bold, fontSize: 16),
+                    ),
+                  ),
+                ),
+
+                const SizedBox(height: AppSpacing.lg),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Branded hero: full-bleed photo, teal scrim, tagline, and the primary CTAs.
+/// Mirrors the home screen's `_AgentHeroCard` so the logged-out and logged-in
+/// experiences read as one product.
+class _LandingHero extends StatelessWidget {
+  final VoidCallback onGetStarted;
+  final VoidCallback onSignIn;
+
+  const _LandingHero({required this.onGetStarted, required this.onSignIn});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      decoration: BoxDecoration(
+        borderRadius: AppRadius.lgAll,
+        boxShadow: [
+          BoxShadow(
+            color: AppColors.brandDark.withValues(alpha: 0.4),
+            blurRadius: 16,
+            offset: const Offset(0, 6),
+          ),
+        ],
+      ),
+      child: ClipRRect(
+        borderRadius: AppRadius.lgAll,
+        child: Stack(
+          children: [
+            Positioned.fill(
+              child: Image.asset(
+                'assets/images/hero_santorini.jpg',
+                fit: BoxFit.cover,
+              ),
+            ),
+            Positioned.fill(
+              child: DecoratedBox(
+                decoration: BoxDecoration(gradient: AppColors.heroScrim),
+              ),
+            ),
+            Container(
+              constraints: const BoxConstraints(minHeight: 340),
+              padding: const EdgeInsets.all(28),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Container(
+                    padding: const EdgeInsets.all(12),
+                    decoration: BoxDecoration(
+                      color: Colors.white.withValues(alpha: 0.15),
+                      shape: BoxShape.circle,
+                    ),
+                    child: const Icon(Icons.flight_takeoff,
+                        size: 44, color: Colors.white),
+                  ),
+                  const SizedBox(height: 16),
+                  Text(
+                    'Plan less. Travel more.',
+                    style: theme.textTheme.headlineSmall?.copyWith(
+                      color: Colors.white,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    'Your AI travel companion — describe the trip you want and '
+                    'get a full day-by-day itinerary with routes, places, and '
+                    'flights.',
+                    style: theme.textTheme.bodyLarge?.copyWith(
+                      color: Colors.white.withValues(alpha: 0.85),
+                    ),
+                  ),
+                  const SizedBox(height: 24),
+                  SizedBox(
+                    width: double.infinity,
+                    child: FilledButton(
+                      onPressed: onGetStarted,
+                      style: FilledButton.styleFrom(
+                        backgroundColor: Colors.white,
+                        foregroundColor: Colors.teal.shade800,
+                        padding: const EdgeInsets.symmetric(vertical: 16),
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(12),
+                        ),
+                      ),
+                      child: const Text(
+                        'Get started',
+                        style: TextStyle(
+                            fontWeight: FontWeight.bold, fontSize: 16),
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: 12),
+                  SizedBox(
+                    width: double.infinity,
+                    child: TextButton(
+                      onPressed: onSignIn,
+                      style: TextButton.styleFrom(
+                        foregroundColor: Colors.white,
+                        padding: const EdgeInsets.symmetric(vertical: 12),
+                      ),
+                      child: const Text('I already have an account'),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Informational feature row: colored icon chip + title + description. Mirrors
+/// the home screen's `_ToolRow` minus the trailing chevron (these don't
+/// navigate).
+class _FeatureCard extends StatelessWidget {
+  final IconData icon;
+  final Color? color;
+  final String title;
+  final String description;
+
+  const _FeatureCard({
+    required this.icon,
+    required this.title,
+    required this.description,
+    this.color,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final accent = color ?? AppColors.brand;
+    return Card(
+      elevation: 1,
+      margin: const EdgeInsets.only(bottom: AppSpacing.md),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+        child: Row(
+          children: [
+            Container(
+              padding: const EdgeInsets.all(10),
+              decoration: BoxDecoration(
+                color: accent.withValues(alpha: 0.1),
+                borderRadius: BorderRadius.circular(10),
+              ),
+              child: Icon(icon, color: accent, size: 26),
+            ),
+            const SizedBox(width: 16),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    title,
+                    style: theme.textTheme.titleMedium?.copyWith(
+                      fontWeight: FontWeight.bold,
+                      color: theme.colorScheme.onSurface,
+                    ),
+                  ),
+                  const SizedBox(height: 2),
+                  Text(
+                    description,
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: theme.colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- Add a branded `LandingScreen` as the logged-out entry point (replacing the bare auth form): Wayfare wordmark app bar, photo hero with the "Plan less. Travel more." tagline, and cards for the four core features (AI Travel Agent, Route Optimizer, Country Planner, Find Flights).
- CTAs push the existing auth form in the right mode — **Get started** → sign-up, **Sign in** → login — via a new `initialIsLogin` param on `AuthScreen`.
- Fix the resulting navigation bug: when `AuthScreen` is pushed on top of the landing page, it now pops itself on successful auth so the `AuthGate`'s swapped-in app shell is revealed (previously the form stayed on top and login appeared to do nothing until a refresh).
- Reuses existing design tokens and the home screen's hero/tool-row visual patterns; no new theme tokens or assets.

## Testing
- `flutter analyze` — clean on all changed files.
- `flutter test` — all 16 tests pass.
- Manual (docker-dev @ localhost:3000, logged out): landing page renders; **Get started** opens sign-up, **Sign in** opens login; completing login lands on the app shell with no refresh needed (the original bug, now fixed and confirmed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)