### PR TITLE
feat: local events lookup for trip cities and dates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,10 +89,11 @@ Create `src/packages/api/.env` (see `.env.sample`):
 GOOGLE_PLACES_API_KEY=...   # Required for /places/* endpoints
 ANTHROPIC_API_KEY=...       # Required for /api/v1/plan SSE endpoint
 DUFFEL_ACCESS_TOKEN=...     # Required for /flights/* endpoints (Duffel; test or live token)
+TICKETMASTER_API_KEY=...    # Required for /events/* endpoint (Ticketmaster Discovery; free key)
 DATABASE_URL=...            # Postgres connection; absent/unreachable => degraded mode (no persistence)
 ```
 
-Without `GOOGLE_PLACES_API_KEY`, place search endpoints return errors. The `/plan` handler also calls `search_places` internally, which will fail without the key. Without `DUFFEL_ACCESS_TOKEN`, the `/flights/*` endpoints return a configured-error; the rest of the API is unaffected.
+Without `GOOGLE_PLACES_API_KEY`, place search endpoints return errors. The `/plan` handler also calls `search_places` internally, which will fail without the key. Without `DUFFEL_ACCESS_TOKEN`, the `/flights/*` endpoints return a configured-error; the rest of the API is unaffected. Without `TICKETMASTER_API_KEY`, the `/events/search` endpoint (and the `/plan` agent's `search_events` tool) returns a configured-error; the rest of the API is unaffected.
 
 ## API Endpoints
 
@@ -105,6 +106,7 @@ Without `GOOGLE_PLACES_API_KEY`, place search endpoints return errors. The `/pla
 | GET | `/api/v1/places/details?place_id=` | Google Places Details |
 | GET | `/api/v1/flights/airports?q=` | Duffel airport/city autocomplete (IATA codes) |
 | POST | `/api/v1/flights/search` | Duffel flight offers, ranked by `optimize_for` (`cost`/`time`/`balanced`) |
+| GET | `/api/v1/events/search?city=&start_date=&end_date=` | Ticketmaster Discovery events in a city for a date window (optional `category`) |
 | POST | `/api/v1/plan` | SSE stream; Claude claude-sonnet-4-6 with `search_places` tool |
 
 ## Key Constraints
@@ -114,4 +116,5 @@ Without `GOOGLE_PLACES_API_KEY`, place search endpoints return errors. The `/pla
 - Flutter models use `json_serializable`; never edit `.g.dart` files by hand.
 - The `optimize_for` field on country routes accepts only `"distance"`, `"season"`, or `"balanced"` (empty string defaults to balanced). On flight search it accepts `"cost"`, `"time"`, or `"balanced"` (empty defaults to balanced).
 - Flight search inputs are **IATA codes** (e.g. `JFK`, `CDG`), not city names — resolve names via `/flights/airports?q=` first. Flight data comes from **Duffel** (`duffel_service.go`, process-wide `duffelService` singleton, static `DUFFEL_ACCESS_TOKEN`); the provider is isolated to that one file behind the `FlightOffer`/`Airport` types so it can be swapped without touching the handler, optimizer, or Flutter app.
+- Local events come from **Ticketmaster Discovery** (`events_service.go`, process-wide `eventsService` singleton, static `TICKETMASTER_API_KEY` passed as an `apikey` query param). Inputs are a **city name** + a `start_date`/`end_date` window (YYYY-MM-DD), with an optional `category`. Like Duffel, the provider is isolated to that one file behind the `Event` type so it can be swapped without touching the handler, the `/plan` agent's `search_events` tool, or the Flutter app. Events are **looked up live** — nothing is persisted.
 - Persistence uses **pgx + sqlc + goose** (Postgres). The `store/` package is sqlc-generated — run `make api-sqlc` after editing `query/*.sql` or the schema; never hand-edit it. UUID primary keys; migrations run on boot and via `make api-migrate`.

--- a/src/packages/api/.env.sample
+++ b/src/packages/api/.env.sample
@@ -7,6 +7,11 @@ ANTHROPIC_API_KEY=your_anthropic_api_key_here
 DUFFEL_ACCESS_TOKEN=your_duffel_test_token_here
 DUFFEL_BASE_URL=https://api.duffel.com
 DUFFEL_VERSION=v2
+# Ticketmaster Discovery API key for local-events lookup (free key at
+# https://developer.ticketmaster.com). Absent => events lookup is disabled; the
+# rest of the API is unaffected. TICKETMASTER_BASE_URL rarely needs changing.
+TICKETMASTER_API_KEY=your_ticketmaster_api_key_here
+TICKETMASTER_BASE_URL=https://app.ticketmaster.com/discovery/v2
 CHROME_WS_URL=ws://chrome:9222/   # Set when running in Docker; leave empty to launch Chrome locally
 # Postgres connection. For local `make api-run`, point at localhost. In Docker the
 # compose stacks override this to use the `postgres` service host.

--- a/src/packages/api/events_service.go
+++ b/src/packages/api/events_service.go
@@ -1,0 +1,285 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// EventsService handles local-events lookups via the Ticketmaster Discovery
+// API. Like Duffel, it authenticates with a static key (passed as an `apikey`
+// query param), so the service just attaches the key and decodes the response.
+// The provider is isolated behind the Event type so it can be swapped without
+// touching the handler, the plan agent, or the Flutter app.
+type EventsService struct {
+	APIKey  string
+	BaseURL string
+	Client  *http.Client
+}
+
+// Event is a normalized local event (concert, sport, festival, show) used by
+// both the REST endpoint and the /plan agent's search_events tool.
+type Event struct {
+	ID        string  `json:"id"`
+	Name      string  `json:"name"`
+	Category  string  `json:"category"`             // e.g. "Music", "Sports", "Arts & Theatre"
+	Venue     string  `json:"venue,omitempty"`      // venue name
+	City      string  `json:"city,omitempty"`       // venue city
+	StartDate string  `json:"start_date"`           // YYYY-MM-DD (local)
+	StartTime string  `json:"start_time,omitempty"` // HH:MM (local), empty for all-day
+	Latitude  float64 `json:"latitude,omitempty"`
+	Longitude float64 `json:"longitude,omitempty"`
+	URL       string  `json:"url,omitempty"`
+	ImageURL  string  `json:"image_url,omitempty"`
+}
+
+// maxEvents caps how many events we return, to bound response size. fetchSize
+// is the wider page we request from Ticketmaster before post-filtering to the
+// trip window (its date filter is loose, so we ask for more and trim).
+const (
+	maxEvents = 30
+	fetchSize = 100
+)
+
+// NewEventsService creates a new events service, reading the Ticketmaster key
+// from the environment. A missing key is a soft failure (a warning, like the
+// Google/Duffel keys) so the rest of the API stays healthy; calls fail clearly.
+func NewEventsService() *EventsService {
+	apiKey := os.Getenv("TICKETMASTER_API_KEY")
+	if apiKey == "" {
+		fmt.Println("Warning: TICKETMASTER_API_KEY not set; events lookup disabled")
+	}
+
+	baseURL := os.Getenv("TICKETMASTER_BASE_URL")
+	if baseURL == "" {
+		baseURL = "https://app.ticketmaster.com/discovery/v2"
+	}
+
+	return &EventsService{
+		APIKey:  apiKey,
+		BaseURL: strings.TrimRight(baseURL, "/"),
+		Client:  &http.Client{Timeout: 30 * time.Second},
+	}
+}
+
+// SearchEvents returns events in a city between startDate and endDate
+// (inclusive, YYYY-MM-DD). category is optional and maps to Ticketmaster's
+// classificationName (e.g. "music", "sports", "arts"). Returns a clear error
+// when the key is missing or the dates are malformed.
+func (s *EventsService) SearchEvents(ctx context.Context, city, startDate, endDate string, category *string) ([]Event, error) {
+	if s.APIKey == "" {
+		return nil, fmt.Errorf("Ticketmaster API key not configured")
+	}
+	startDT, err := toTicketmasterDateTime(startDate, false)
+	if err != nil {
+		return nil, fmt.Errorf("invalid start_date: %w", err)
+	}
+	endDT, err := toTicketmasterDateTime(endDate, true)
+	if err != nil {
+		return nil, fmt.Errorf("invalid end_date: %w", err)
+	}
+
+	params := url.Values{}
+	params.Set("apikey", s.APIKey)
+	params.Set("city", city)
+	params.Set("startDateTime", startDT)
+	params.Set("endDateTime", endDT)
+	params.Set("sort", "date,asc")
+	// Over-fetch: Ticketmaster's date filter is loose and surfaces ongoing/flex
+	// runs whose start date predates the window, so we fetch a wider page and
+	// post-filter to the trip window below before capping at maxEvents.
+	params.Set("size", strconv.Itoa(fetchSize))
+	if category != nil {
+		if c := strings.TrimSpace(*category); c != "" {
+			params.Set("classificationName", c)
+		}
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, s.BaseURL+"/events.json?"+params.Encode(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := s.Client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("Ticketmaster API error (%d): %s", resp.StatusCode, string(body))
+	}
+
+	var result struct {
+		Embedded struct {
+			Events []struct {
+				ID    string `json:"id"`
+				Name  string `json:"name"`
+				URL   string `json:"url"`
+				Dates struct {
+					Start struct {
+						LocalDate string `json:"localDate"`
+						LocalTime string `json:"localTime"`
+					} `json:"start"`
+				} `json:"dates"`
+				Images []struct {
+					URL   string `json:"url"`
+					Width int    `json:"width"`
+				} `json:"images"`
+				Classifications []struct {
+					Segment struct {
+						Name string `json:"name"`
+					} `json:"segment"`
+				} `json:"classifications"`
+				Embedded struct {
+					Venues []struct {
+						Name string `json:"name"`
+						City struct {
+							Name string `json:"name"`
+						} `json:"city"`
+						Location struct {
+							Latitude  string `json:"latitude"`
+							Longitude string `json:"longitude"`
+						} `json:"location"`
+					} `json:"venues"`
+				} `json:"_embedded"`
+			} `json:"events"`
+		} `json:"_embedded"`
+	}
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse events response: %w", err)
+	}
+
+	// Trip window bounds (YYYY-MM-DD) for post-filtering. Lexicographic compares
+	// are correct for zero-padded ISO dates.
+	winStart := strings.TrimSpace(startDate)
+	winEnd := strings.TrimSpace(endDate)
+
+	events := make([]Event, 0, len(result.Embedded.Events))
+	// Collapse near-duplicates: timed-entry attractions list the same event at
+	// many slots (every 15 min), so we keep one card per name (the earliest,
+	// since results are sorted date,asc) and let distinct events through.
+	seen := map[string]bool{}
+	for _, e := range result.Embedded.Events {
+		// Keep only events whose local start date falls within the trip window.
+		// Ticketmaster also returns ongoing/flex runs whose start date predates
+		// the window (with a misleading single date), which we drop here.
+		sd := e.Dates.Start.LocalDate
+		if sd == "" || sd < winStart || sd > winEnd {
+			continue
+		}
+		nameKey := strings.ToLower(strings.TrimSpace(e.Name))
+		if seen[nameKey] {
+			continue
+		}
+		seen[nameKey] = true
+		ev := Event{
+			ID:        e.ID,
+			Name:      e.Name,
+			URL:       e.URL,
+			StartDate: e.Dates.Start.LocalDate,
+			StartTime: trimSeconds(e.Dates.Start.LocalTime),
+			ImageURL:  pickImage(e.Images),
+		}
+		if len(e.Classifications) > 0 {
+			ev.Category = e.Classifications[0].Segment.Name
+		}
+		if len(e.Embedded.Venues) > 0 {
+			v := e.Embedded.Venues[0]
+			ev.Venue = v.Name
+			ev.City = v.City.Name
+			ev.Latitude, _ = strconv.ParseFloat(v.Location.Latitude, 64)
+			ev.Longitude, _ = strconv.ParseFloat(v.Location.Longitude, 64)
+		}
+		events = append(events, ev)
+		if len(events) >= maxEvents {
+			break
+		}
+	}
+	return events, nil
+}
+
+// toTicketmasterDateTime converts a YYYY-MM-DD date into the ISO-8601 UTC
+// instant Ticketmaster expects (no millis, trailing Z). endOfDay picks the
+// inclusive end of the window.
+func toTicketmasterDateTime(date string, endOfDay bool) (string, error) {
+	t, err := time.Parse("2006-01-02", strings.TrimSpace(date))
+	if err != nil {
+		return "", fmt.Errorf("expected YYYY-MM-DD: %w", err)
+	}
+	if endOfDay {
+		return t.Format("2006-01-02") + "T23:59:59Z", nil
+	}
+	return t.Format("2006-01-02") + "T00:00:00Z", nil
+}
+
+// trimSeconds normalizes Ticketmaster's "HH:MM:SS" local time to "HH:MM".
+func trimSeconds(t string) string {
+	if len(t) >= 5 {
+		return t[:5]
+	}
+	return t
+}
+
+// pickImage returns the widest image URL, falling back to the first.
+func pickImage(images []struct {
+	URL   string `json:"url"`
+	Width int    `json:"width"`
+}) string {
+	best := ""
+	bestW := -1
+	for _, img := range images {
+		if img.Width > bestW {
+			bestW = img.Width
+			best = img.URL
+		}
+	}
+	return best
+}
+
+// eventsService is a process-wide singleton reused across requests (the HTTP
+// client and config are shared; auth is a static key).
+var eventsService = NewEventsService()
+
+// eventsSearchHandler handles local-events search requests for a city + date
+// window. Mirrors placesSearchHandler's response shape.
+func eventsSearchHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	q := r.URL.Query()
+	city := strings.TrimSpace(q.Get("city"))
+	startDate := strings.TrimSpace(q.Get("start_date"))
+	endDate := strings.TrimSpace(q.Get("end_date"))
+	if city == "" || startDate == "" || endDate == "" {
+		http.Error(w, "Missing required query parameters 'city', 'start_date', and 'end_date'", http.StatusBadRequest)
+		return
+	}
+
+	var category *string
+	if c := strings.TrimSpace(q.Get("category")); c != "" {
+		category = &c
+	}
+
+	events, err := eventsService.SearchEvents(r.Context(), city, startDate, endDate, category)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("Failed to search events: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"events": events,
+		"status": "success",
+	})
+}

--- a/src/packages/api/main.go
+++ b/src/packages/api/main.go
@@ -651,6 +651,7 @@ func main() {
 	api.HandleFunc("/places/details", placesDetailsHandler).Methods("GET")
 	api.HandleFunc("/flights/search", flightsSearchHandler).Methods("POST")
 	api.HandleFunc("/flights/airports", airportsSearchHandler).Methods("GET")
+	api.HandleFunc("/events/search", eventsSearchHandler).Methods("GET")
 	api.HandleFunc("/plan", planHandler).Methods("POST")
 	api.HandleFunc("/airbnb/parse", airbnbParseHandler).Methods("POST")
 	api.HandleFunc("/airbnb/debug", airbnbDebugHandler).Methods("POST")

--- a/src/packages/api/plan_handler.go
+++ b/src/packages/api/plan_handler.go
@@ -205,6 +205,22 @@ func planHandler(w http.ResponseWriter, r *http.Request) {
 		},
 	}
 
+	searchEventsTool := anthropic.ToolParam{
+		Name: "search_events",
+		Description: anthropic.String("Find local events (concerts, sports, festivals, theatre/shows) happening in a city during specific dates, so the itinerary can account for what's on while the traveler is there. " +
+			"Use the city and the dates the traveler is in that city; you already know the trip's cities and dates from the itinerary. " +
+			"Present a few that fit the traveler's interests."),
+		InputSchema: anthropic.ToolInputSchemaParam{
+			Properties: map[string]any{
+				"city":       map[string]any{"type": "string", "description": "City name, e.g. 'Paris'"},
+				"start_date": map[string]any{"type": "string", "description": "First day to look from, YYYY-MM-DD (when the traveler arrives in the city)"},
+				"end_date":   map[string]any{"type": "string", "description": "Last day to look through, YYYY-MM-DD (when the traveler leaves the city)"},
+				"category":   map[string]any{"type": "string", "enum": []string{"music", "sports", "arts", "film", "miscellaneous"}, "description": "Optional event category filter"},
+			},
+			Required: []string{"city", "start_date", "end_date"},
+		},
+	}
+
 	updateSectionTool := anthropic.ToolParam{
 		Name:        "update_itinerary_section",
 		Description: anthropic.String("Replace one section of the traveler's saved itinerary in place. Pass the COMPLETE updated list of places for the targeted section, in visit order — places you omit are removed from that section. Places outside the section are untouched. Use scope 'day' for a single trip day, 'city' for one city/hub and its day trips, or 'trip' for the whole itinerary."),
@@ -238,6 +254,7 @@ func planHandler(w http.ResponseWriter, r *http.Request) {
 		{OfTool: &suggestStaysTool},
 		{OfTool: &suggestTransportTool},
 		{OfTool: &searchFlightsTool},
+		{OfTool: &searchEventsTool},
 	}
 	// Trip-bound sessions get the in-place section tool instead of
 	// create_itinerary, so a refinement can never spawn a new trip version.
@@ -546,6 +563,33 @@ func planHandler(w http.ResponseWriter, r *http.Request) {
 				}
 				sendSSE(w, "tool_result", map[string]string{"name": "search_flights"})
 				toolResults = append(toolResults, anthropic.NewToolResultBlock(variant.ID, summarizeOffers(originIata, destIata, bestN), false))
+
+			case "search_events":
+				var in struct {
+					City      string  `json:"city"`
+					StartDate string  `json:"start_date"`
+					EndDate   string  `json:"end_date"`
+					Category  *string `json:"category"`
+				}
+				json.Unmarshal(variant.Input, &in)
+
+				events, err := eventsService.SearchEvents(ctx, in.City, in.StartDate, in.EndDate, in.Category)
+				if err != nil {
+					sendSSE(w, "tool_result", map[string]string{"name": "search_events"})
+					toolResults = append(toolResults, anthropic.NewToolResultBlock(variant.ID, fmt.Sprintf("Error searching events: %v", err), true))
+					break
+				}
+
+				if len(events) > 0 {
+					sendSSE(w, "events", map[string]any{
+						"city":       in.City,
+						"start_date": in.StartDate,
+						"end_date":   in.EndDate,
+						"events":     events,
+					})
+				}
+				sendSSE(w, "tool_result", map[string]string{"name": "search_events"})
+				toolResults = append(toolResults, anthropic.NewToolResultBlock(variant.ID, summarizeEvents(in.City, events), false))
 			}
 		}
 
@@ -613,6 +657,32 @@ func summarizeOffers(origin, dest string, offers []FlightOffer) string {
 			i+1, airline, o.Currency, o.Price, stops, o.DurationMin/60, o.DurationMin%60, o.Score)
 	}
 	b.WriteString("These option cards are already shown to the traveler; summarize and help them choose.")
+	return b.String()
+}
+
+// summarizeEvents renders the events returned for a city into a compact text
+// block for the model (the event cards themselves are streamed to the UI).
+func summarizeEvents(city string, events []Event) string {
+	if len(events) == 0 {
+		return fmt.Sprintf("No events found in %s for those dates.", city)
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "Found %d events in %s (soonest first):\n", len(events), city)
+	for i, e := range events {
+		when := e.StartDate
+		if e.StartTime != "" {
+			when += " " + e.StartTime
+		}
+		line := fmt.Sprintf("%d. %s — %s", i+1, e.Name, when)
+		if e.Venue != "" {
+			line += " @ " + e.Venue
+		}
+		if e.Category != "" {
+			line += " (" + e.Category + ")"
+		}
+		b.WriteString(line + "\n")
+	}
+	b.WriteString("These event cards are already shown to the traveler; highlight ones that fit their interests and dates.")
 	return b.String()
 }
 

--- a/src/packages/flutter-app/lib/models/event.dart
+++ b/src/packages/flutter-app/lib/models/event.dart
@@ -1,0 +1,62 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'event.g.dart';
+
+/// A local event (concert, sport, festival, show) returned by /events/search,
+/// matching the Go API's Event type.
+@JsonSerializable()
+class Event {
+  final String id;
+  final String name;
+  @JsonKey(defaultValue: '')
+  final String category;
+  @JsonKey(defaultValue: '')
+  final String venue;
+  @JsonKey(defaultValue: '')
+  final String city;
+  @JsonKey(name: 'start_date', defaultValue: '')
+  final String startDate;
+  @JsonKey(name: 'start_time', defaultValue: '')
+  final String startTime;
+  @JsonKey(defaultValue: 0)
+  final double latitude;
+  @JsonKey(defaultValue: 0)
+  final double longitude;
+  @JsonKey(defaultValue: '')
+  final String url;
+  @JsonKey(name: 'image_url', defaultValue: '')
+  final String imageUrl;
+
+  const Event({
+    required this.id,
+    required this.name,
+    this.category = '',
+    this.venue = '',
+    this.city = '',
+    this.startDate = '',
+    this.startTime = '',
+    this.latitude = 0,
+    this.longitude = 0,
+    this.url = '',
+    this.imageUrl = '',
+  });
+
+  /// "Wed, Jul 1" style date label; empty if unparseable.
+  String get dateLabel {
+    final d = DateTime.tryParse(startDate);
+    if (d == null) return startDate;
+    const days = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+    const months = [
+      'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+      'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'
+    ];
+    return '${days[d.weekday - 1]}, ${months[d.month - 1]} ${d.day}';
+  }
+
+  /// Combined date + time label, e.g. "Wed, Jul 1 · 20:00".
+  String get whenLabel =>
+      startTime.isEmpty ? dateLabel : '$dateLabel · $startTime';
+
+  factory Event.fromJson(Map<String, dynamic> json) => _$EventFromJson(json);
+  Map<String, dynamic> toJson() => _$EventToJson(this);
+}

--- a/src/packages/flutter-app/lib/models/event.g.dart
+++ b/src/packages/flutter-app/lib/models/event.g.dart
@@ -1,0 +1,35 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'event.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+Event _$EventFromJson(Map<String, dynamic> json) => Event(
+      id: json['id'] as String,
+      name: json['name'] as String,
+      category: json['category'] as String? ?? '',
+      venue: json['venue'] as String? ?? '',
+      city: json['city'] as String? ?? '',
+      startDate: json['start_date'] as String? ?? '',
+      startTime: json['start_time'] as String? ?? '',
+      latitude: (json['latitude'] as num?)?.toDouble() ?? 0,
+      longitude: (json['longitude'] as num?)?.toDouble() ?? 0,
+      url: json['url'] as String? ?? '',
+      imageUrl: json['image_url'] as String? ?? '',
+    );
+
+Map<String, dynamic> _$EventToJson(Event instance) => <String, dynamic>{
+      'id': instance.id,
+      'name': instance.name,
+      'category': instance.category,
+      'venue': instance.venue,
+      'city': instance.city,
+      'start_date': instance.startDate,
+      'start_time': instance.startTime,
+      'latitude': instance.latitude,
+      'longitude': instance.longitude,
+      'url': instance.url,
+      'image_url': instance.imageUrl,
+    };

--- a/src/packages/flutter-app/lib/providers/events_provider.dart
+++ b/src/packages/flutter-app/lib/providers/events_provider.dart
@@ -1,0 +1,53 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../models/event.dart';
+import '../services/events_api_service.dart';
+import 'api_client_provider.dart';
+
+final eventsApiServiceProvider = Provider<EventsApiService>((ref) {
+  return EventsApiService(ref.watch(apiClientProvider));
+});
+
+/// Identifies one events lookup: a city and its date window. Used as the
+/// family key so each city group in a trip caches its own results.
+class EventsQuery {
+  final String city;
+  final String startDate; // YYYY-MM-DD
+  final String endDate; // YYYY-MM-DD
+  final String? category;
+
+  const EventsQuery({
+    required this.city,
+    required this.startDate,
+    required this.endDate,
+    this.category,
+  });
+
+  @override
+  bool operator ==(Object other) =>
+      other is EventsQuery &&
+      other.city == city &&
+      other.startDate == startDate &&
+      other.endDate == endDate &&
+      other.category == category;
+
+  @override
+  int get hashCode => Object.hash(city, startDate, endDate, category);
+}
+
+/// Live events lookup for a city + date window. Returns [] for incomplete
+/// queries so callers can render an empty state without special-casing.
+final eventsByCityProvider =
+    FutureProvider.family<List<Event>, EventsQuery>((ref, query) async {
+  if (query.city.trim().isEmpty ||
+      query.startDate.isEmpty ||
+      query.endDate.isEmpty) {
+    return [];
+  }
+  final service = ref.watch(eventsApiServiceProvider);
+  return service.searchEvents(
+    query.city.trim(),
+    query.startDate,
+    query.endDate,
+    category: query.category,
+  );
+});

--- a/src/packages/flutter-app/lib/providers/plan_provider.dart
+++ b/src/packages/flutter-app/lib/providers/plan_provider.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../models/plan_message.dart';
 import '../models/location.dart';
 import '../models/flight_offer.dart';
+import '../models/event.dart';
 import '../services/api_client.dart';
 import '../services/plan_service.dart';
 import 'api_client_provider.dart';
@@ -17,6 +18,8 @@ class PlanState {
   final String? savedTripId;
   final List<FlightOffer>? flightOffers;
   final String? flightRouteLabel;
+  final List<Event>? eventResults;
+  final String? eventsCityLabel;
   final String? error;
 
   /// Short excerpt of profile notes the agent just saved (server
@@ -37,6 +40,8 @@ class PlanState {
     this.savedTripId,
     this.flightOffers,
     this.flightRouteLabel,
+    this.eventResults,
+    this.eventsCityLabel,
     this.error,
     this.profileUpdateNote,
     this.tripUpdateCount = 0,
@@ -52,6 +57,8 @@ class PlanState {
     Object? savedTripId = _sentinel,
     Object? flightOffers = _sentinel,
     Object? flightRouteLabel = _sentinel,
+    Object? eventResults = _sentinel,
+    Object? eventsCityLabel = _sentinel,
     Object? error = _sentinel,
     Object? profileUpdateNote = _sentinel,
     int? tripUpdateCount,
@@ -68,6 +75,8 @@ class PlanState {
       savedTripId: savedTripId == _sentinel ? this.savedTripId : savedTripId as String?,
       flightOffers: flightOffers == _sentinel ? this.flightOffers : flightOffers as List<FlightOffer>?,
       flightRouteLabel: flightRouteLabel == _sentinel ? this.flightRouteLabel : flightRouteLabel as String?,
+      eventResults: eventResults == _sentinel ? this.eventResults : eventResults as List<Event>?,
+      eventsCityLabel: eventsCityLabel == _sentinel ? this.eventsCityLabel : eventsCityLabel as String?,
       error: error == _sentinel ? this.error : error as String?,
       profileUpdateNote:
           profileUpdateNote == _sentinel ? this.profileUpdateNote : profileUpdateNote as String?,
@@ -133,6 +142,8 @@ class PlanNotifier extends StateNotifier<PlanState> {
       activeTools: [],
       flightOffers: null,
       flightRouteLabel: null,
+      eventResults: null,
+      eventsCityLabel: null,
       error: null,
       profileUpdateNote: null,
     );
@@ -187,6 +198,16 @@ class PlanNotifier extends StateNotifier<PlanState> {
             state = state.copyWith(
               flightOffers: offers,
               flightRouteLabel: '$origin → $dest',
+            );
+
+          case 'events':
+            final raw = event.data['events'] as List<dynamic>? ?? [];
+            final events = raw
+                .map((e) => Event.fromJson(e as Map<String, dynamic>))
+                .toList();
+            state = state.copyWith(
+              eventResults: events,
+              eventsCityLabel: event.data['city'] as String?,
             );
 
           case 'error':

--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -16,11 +16,14 @@ import '../providers/booking_todos_provider.dart';
 import '../providers/preferences_provider.dart';
 import '../providers/api_client_provider.dart';
 import '../providers/plan_provider.dart';
+import '../providers/events_provider.dart';
+import '../theme/app_colors.dart';
 import '../theme/spacing.dart';
 import '../utils/trip_format.dart';
 import '../widgets/add_itinerary_item_dialog.dart';
 import '../widgets/booking_todo_card.dart';
 import '../widgets/empty_state.dart';
+import '../widgets/event_card.dart';
 import '../widgets/status_pill.dart';
 import '../widgets/trip_map.dart';
 import '../widgets/trip_refine_panel.dart';
@@ -784,6 +787,79 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
     );
   }
 
+  /// Live local-events section for a city group, looked up for the group's date
+  /// window. Returns an empty box (no sliver content) when the group has no
+  /// real city/dates to query. Wrapped in a [Consumer] so only this section
+  /// rebuilds as the async lookup resolves.
+  Widget _eventsSliver(
+    String label,
+    ({DateTime? start, DateTime? end})? range,
+    ThemeData theme,
+  ) {
+    if (label == 'Other places' ||
+        range?.start == null ||
+        range?.end == null) {
+      return const SliverToBoxAdapter(child: SizedBox.shrink());
+    }
+    final query = EventsQuery(
+      city: label,
+      startDate: _fmt(range!.start!),
+      endDate: _fmt(range.end!),
+    );
+    return SliverToBoxAdapter(
+      child: Consumer(builder: (context, ref, _) {
+        final async = ref.watch(eventsByCityProvider(query));
+        final header = Padding(
+          padding: const EdgeInsets.only(top: AppSpacing.sm, bottom: AppSpacing.xs),
+          child: Row(
+            children: [
+              Icon(Icons.local_activity, size: 16, color: AppColors.toolEvents),
+              const SizedBox(width: 6),
+              Text(
+                'Events while you\'re here',
+                style: theme.textTheme.labelLarge?.copyWith(
+                  fontWeight: FontWeight.w600,
+                  color: AppColors.toolEvents,
+                ),
+              ),
+            ],
+          ),
+        );
+        return async.when(
+          loading: () => Padding(
+            padding: const EdgeInsets.symmetric(vertical: AppSpacing.sm),
+            child: Row(
+              children: [
+                const SizedBox(
+                  width: 14,
+                  height: 14,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                ),
+                const SizedBox(width: AppSpacing.sm),
+                Text('Finding events in $label…',
+                    style: theme.textTheme.bodySmall?.copyWith(
+                        color: theme.colorScheme.onSurfaceVariant)),
+              ],
+            ),
+          ),
+          // Stay quiet on errors (e.g. provider key not set) — events are a
+          // nice-to-have, not core to the itinerary.
+          error: (_, __) => const SizedBox.shrink(),
+          data: (events) {
+            if (events.isEmpty) return const SizedBox.shrink();
+            return Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                header,
+                for (final e in events.take(5)) EventCard(event: e),
+              ],
+            );
+          },
+        );
+      }),
+    );
+  }
+
   /// Compact booking rows for a city group's slot: arrival flight + stay when
   /// [departureOnly] is false, the return-home flight when true.
   List<Widget> _bookingRowWidgets(
@@ -1429,6 +1505,12 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
                       final filtered = _filtered(trip);
                       final groups =
                           _buildGroups(filtered, _locationDates(trip));
+                      // Date window per city group, for the embedded events
+                      // lookup (keyed by the same label _buildGroups uses).
+                      final groupRanges = {
+                        for (final r in _locationGroupRanges(trip))
+                          r.label: (start: r.start, end: r.end)
+                      };
                       final tripStart = DateTime.tryParse(trip.startDate ?? '');
                       final scrollView = CustomScrollView(
                         slivers: [
@@ -1585,6 +1667,14 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
                                               departureOnly: false)),
                                         ..._buildGroupItemSlivers(group.label,
                                             group.items, theme, tripStart),
+                                        // Local events for this city's dates —
+                                        // only in the unfiltered view, where
+                                        // group labels map 1:1 to date ranges.
+                                        if (_itemFilter == 'all')
+                                          _eventsSliver(
+                                              group.label,
+                                              groupRanges[group.label],
+                                              theme),
                                         if (_itemFilter == 'all' &&
                                             gi == groups.length - 1 &&
                                             gi < grouped.slots.length)

--- a/src/packages/flutter-app/lib/services/events_api_service.dart
+++ b/src/packages/flutter-app/lib/services/events_api_service.dart
@@ -1,0 +1,49 @@
+import 'dart:convert';
+import '../models/event.dart';
+import 'api_client.dart';
+
+/// Wraps the /events/search endpoint (Ticketmaster-backed local events). The
+/// endpoint is public, but we still send the bearer token when present, matching
+/// the other services.
+class EventsApiService {
+  final ApiClient apiClient;
+
+  EventsApiService(this.apiClient);
+
+  Map<String, String> _headers() {
+    final h = <String, String>{'Accept': 'application/json'};
+    final token = apiClient.authToken;
+    if (token != null) h['Authorization'] = 'Bearer $token';
+    return h;
+  }
+
+  /// Looks up events in [city] between [startDate] and [endDate] (YYYY-MM-DD).
+  Future<List<Event>> searchEvents(
+    String city,
+    String startDate,
+    String endDate, {
+    String? category,
+  }) async {
+    final uri = Uri.parse('${apiClient.baseUrl}/events/search').replace(
+      queryParameters: {
+        'city': city,
+        'start_date': startDate,
+        'end_date': endDate,
+        if (category != null && category.isNotEmpty) 'category': category,
+      },
+    );
+    final res = await apiClient.httpClient.get(uri, headers: _headers());
+    if (res.statusCode == 200) {
+      final body = jsonDecode(res.body) as Map<String, dynamic>;
+      final list = (body['events'] as List<dynamic>? ?? []);
+      return list
+          .map((e) => Event.fromJson(e as Map<String, dynamic>))
+          .toList();
+    }
+    throw ApiException(
+      statusCode: res.statusCode,
+      message: 'Failed to search events: ${res.body}',
+      endpoint: 'events/search',
+    );
+  }
+}

--- a/src/packages/flutter-app/lib/theme/app_colors.dart
+++ b/src/packages/flutter-app/lib/theme/app_colors.dart
@@ -48,4 +48,5 @@ abstract final class AppColors {
   static Color get toolFlights => Colors.blue.shade700;
   static Color get toolCountry => Colors.green.shade700;
   static Color get toolAirbnb => Colors.pink.shade600;
+  static Color get toolEvents => Colors.purple.shade600;
 }

--- a/src/packages/flutter-app/lib/widgets/chat_panel.dart
+++ b/src/packages/flutter-app/lib/widgets/chat_panel.dart
@@ -2,9 +2,12 @@ import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart' show ScrollDirection;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../models/flight_offer.dart';
+import '../models/event.dart';
 import '../models/plan_message.dart';
 import '../providers/plan_provider.dart';
+import '../theme/app_colors.dart';
 import 'flight_offer_card.dart';
+import 'event_card.dart';
 
 /// The plan-agent chat surface (messages, tool chips, flight cards, input bar)
 /// decoupled from any screen, so the full-screen Agent tab and the trip-detail
@@ -159,6 +162,11 @@ class _ChatPanelState extends ConsumerState<ChatPanel> {
                           routeLabel: planState.flightRouteLabel,
                           offers: planState.flightOffers!,
                         ),
+                      if (planState.eventResults != null && planState.eventResults!.isNotEmpty)
+                        _EventOptions(
+                          cityLabel: planState.eventsCityLabel,
+                          events: planState.eventResults!,
+                        ),
                       if (widget.footerBuilder != null)
                         widget.footerBuilder!(context, planState),
                       if (planState.error != null)
@@ -198,6 +206,8 @@ class _ChatPanelState extends ConsumerState<ChatPanel> {
         return 'Updating itinerary...';
       case 'search_flights':
         return 'Searching flights...';
+      case 'search_events':
+        return 'Finding events...';
       default:
         return '$tool...';
     }
@@ -307,6 +317,55 @@ class _FlightOptions extends StatelessWidget {
           const SizedBox(height: 8),
           for (var i = 0; i < offers.length; i++)
             FlightOfferCard(offer: offers[i], isBest: i == 0),
+        ],
+      ),
+    );
+  }
+}
+
+/// Inline local-events results in the chat — a header plus the agent's events
+/// for a city as shared EventCards.
+class _EventOptions extends StatelessWidget {
+  final String? cityLabel;
+  final List<Event> events;
+
+  const _EventOptions({required this.cityLabel, required this.events});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final accent = AppColors.toolEvents;
+    final label = (cityLabel == null || cityLabel!.trim().isEmpty)
+        ? 'Local events'
+        : 'Local events · $cityLabel';
+    return Container(
+      margin: const EdgeInsets.symmetric(vertical: 12),
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: accent.withValues(alpha: 0.08),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: accent.withValues(alpha: 0.4)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Icon(Icons.local_activity, color: accent, size: 20),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Text(
+                  label,
+                  style: theme.textTheme.titleSmall?.copyWith(
+                    color: accent,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          for (final e in events) EventCard(event: e),
         ],
       ),
     );

--- a/src/packages/flutter-app/lib/widgets/event_card.dart
+++ b/src/packages/flutter-app/lib/widgets/event_card.dart
@@ -1,0 +1,89 @@
+import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
+import '../models/event.dart';
+import '../theme/app_colors.dart';
+import '../theme/spacing.dart';
+
+/// A single local event: name, when, venue/category, opening the ticket/info
+/// page externally on tap. Styled to sit beside itinerary and booking rows.
+class EventCard extends StatelessWidget {
+  final Event event;
+
+  const EventCard({super.key, required this.event});
+
+  Future<void> _open() async {
+    if (event.url.isEmpty) return;
+    final uri = Uri.tryParse(event.url);
+    if (uri != null) {
+      await launchUrl(uri, mode: LaunchMode.externalApplication);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final accent = AppColors.toolEvents;
+    final subtitle = [
+      if (event.venue.isNotEmpty) event.venue,
+      if (event.category.isNotEmpty) event.category,
+    ].join(' · ');
+
+    return Card(
+      margin: const EdgeInsets.symmetric(vertical: AppSpacing.xs),
+      clipBehavior: Clip.antiAlias,
+      child: InkWell(
+        onTap: event.url.isEmpty ? null : _open,
+        child: Padding(
+          padding: const EdgeInsets.all(AppSpacing.md),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Container(
+                padding: const EdgeInsets.all(AppSpacing.sm),
+                decoration: BoxDecoration(
+                  color: accent.withValues(alpha: 0.12),
+                  borderRadius: BorderRadius.circular(AppRadius.sm),
+                ),
+                child: Icon(Icons.local_activity, size: 20, color: accent),
+              ),
+              const SizedBox(width: AppSpacing.md),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      event.name,
+                      style: theme.textTheme.titleSmall
+                          ?.copyWith(fontWeight: FontWeight.w600),
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                    const SizedBox(height: 2),
+                    Text(
+                      event.whenLabel,
+                      style: theme.textTheme.labelMedium
+                          ?.copyWith(color: accent, fontWeight: FontWeight.w600),
+                    ),
+                    if (subtitle.isNotEmpty) ...[
+                      const SizedBox(height: 2),
+                      Text(
+                        subtitle,
+                        style: theme.textTheme.bodySmall?.copyWith(
+                            color: theme.colorScheme.onSurfaceVariant),
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ],
+                  ],
+                ),
+              ),
+              if (event.url.isNotEmpty)
+                Icon(Icons.open_in_new,
+                    size: 16, color: theme.colorScheme.onSurfaceVariant),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- Add a **Ticketmaster Discovery**-backed events provider so travelers see what's on in each city during the dates they'll be there.
- Surfaced two ways: a new **`search_events` tool** for the `/plan` AI agent (streams an `events` SSE event into the chat), and a per-city **"Events while you're here"** section in the trip detail screen, scoped to each city's date window.
- New REST endpoint: `GET /api/v1/events/search?city=&start_date=&end_date=` (optional `category`).
- Provider isolated in `events_service.go` behind the `Event` type (mirrors the Duffel pattern) so it can be swapped without touching the handler, agent, or Flutter app.
- `SearchEvents` post-filters results to the trip window and dedupes by event name — Ticketmaster's own date filter is loose (leaks ongoing/flex runs) and timed-entry attractions list many per-slot duplicates.
- Events are **looked up live** — nothing is persisted.
- Config/docs: `TICKETMASTER_API_KEY` added to `.env.sample` and `CLAUDE.md` (env var, endpoint table, provider note).

## Testing
- `go build ./...`, `go vet ./...`, `go test ./...` — all pass.
- `flutter analyze` — 0 errors (only pre-existing info/warning lints in unrelated files).
- `flutter test` — all pass.
- Manual: verified `GET /api/v1/events/search` end-to-end through the gateway for a Chicago trip (Aug 17–21) — returns in-window, de-duplicated events; confirmed the per-city section and AI chat card render.

### Known limitation
Ticketmaster Discovery coverage is US/UK-centric — continental Europe (e.g. Paris) returns few/no events. The provider abstraction allows swapping to a Europe-capable source (e.g. PredictHQ) later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)