### PR TITLE
feat: Greece-specific ferries + Greek event source links

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,7 +92,7 @@ TICKETMASTER_API_KEY=...    # Required for /events/* endpoint (Ticketmaster Disc
 DATABASE_URL=...            # Postgres connection; absent/unreachable => degraded mode (no persistence)
 ```
 
-Without `GOOGLE_PLACES_API_KEY`, place search endpoints return errors. The `/plan` handler also calls `search_places` internally, which will fail without the key. Without `DUFFEL_ACCESS_TOKEN`, the `/flights/*` endpoints return a configured-error; the rest of the API is unaffected. Without `TICKETMASTER_API_KEY`, the `/events/search` endpoint (and the `/plan` agent's `search_events` tool) returns a configured-error; the rest of the API is unaffected.
+Without `GOOGLE_PLACES_API_KEY`, place search endpoints return errors. The `/plan` handler also calls `search_places` internally, which will fail without the key. Without `DUFFEL_ACCESS_TOKEN`, the `/flights/*` endpoints return a configured-error; the rest of the API is unaffected. Without `TICKETMASTER_API_KEY`, the `/events/search` endpoint (and the `/plan` agent's `search_events` tool) returns a configured-error; the rest of the API is unaffected. `FERRYHOPPER_AFFILIATE_ID` is optional — ferry links work without it (just unattributed).
 
 ## API Endpoints
 
@@ -105,6 +105,7 @@ Without `GOOGLE_PLACES_API_KEY`, place search endpoints return errors. The `/pla
 | GET | `/api/v1/flights/airports?q=` | Duffel airport/city autocomplete (IATA codes) |
 | POST | `/api/v1/flights/search` | Duffel flight offers, ranked by `optimize_for` (`cost`/`time`/`balanced`) |
 | GET | `/api/v1/events/search?city=&start_date=&end_date=` | Ticketmaster Discovery events in a city for a date window (optional `category`) |
+| GET | `/api/v1/ferries/search?origin=&destination=&date=` | Ferryhopper ferry booking link for a route (Greek island-hopping); returns `FerryOption[]` |
 | POST | `/api/v1/plan` | SSE stream; Claude claude-sonnet-4-6 with `search_places` tool |
 
 ## Key Constraints
@@ -115,4 +116,7 @@ Without `GOOGLE_PLACES_API_KEY`, place search endpoints return errors. The `/pla
 - The `optimize_for` field on flight search accepts only `"cost"`, `"time"`, or `"balanced"` (empty defaults to balanced).
 - Flight search inputs are **IATA codes** (e.g. `JFK`, `CDG`), not city names — resolve names via `/flights/airports?q=` first. Flight data comes from **Duffel** (`duffel_service.go`, process-wide `duffelService` singleton, static `DUFFEL_ACCESS_TOKEN`); the provider is isolated to that one file behind the `FlightOffer`/`Airport` types so it can be swapped without touching the handler, optimizer, or Flutter app.
 - Local events come from **Ticketmaster Discovery** (`events_service.go`, process-wide `eventsService` singleton, static `TICKETMASTER_API_KEY` passed as an `apikey` query param). Inputs are a **city name** + a `start_date`/`end_date` window (YYYY-MM-DD), with an optional `category`. Like Duffel, the provider is isolated to that one file behind the `Event` type so it can be swapped without touching the handler, the `/plan` agent's `search_events` tool, or the Flutter app. Events are **looked up live** — nothing is persisted.
+- **Greece** has two dedicated provider helpers (deep-links, no API yet):
+  - **Ferries** (`ferry_service.go`, `ferryService` singleton, optional `FERRYHOPPER_AFFILIATE_ID`): builds a **Ferryhopper** route-page deep link from island/port names. Exposed via `GET /api/v1/ferries/search` and the `/plan` agent's `suggest_ferries` tool. The `FerryOption` type carries structured fields (operator/time/price) that stay empty in link mode — designed so the **FerryhAPI** B2B upgrade fills the same shape without touching callers.
+  - **Greek events** (`greece_events_service.go`): Ticketmaster is empty for Greece, so `search_events` falls back to curated source links (more.com/Viva.gr, visitgreece.gr, seasonal Athens-Epidaurus) when the structured lookup is empty **and** `isGreekLocation(city)` is true (hardcoded Greek city/island set). Surfaced as an `event_links` SSE event.
 - Persistence uses **pgx + sqlc + goose** (Postgres). The `store/` package is sqlc-generated — run `make api-sqlc` after editing `query/*.sql` or the schema; never hand-edit it. UUID primary keys; migrations run on boot and via `make api-migrate`.

--- a/src/packages/api/.env.sample
+++ b/src/packages/api/.env.sample
@@ -19,3 +19,7 @@ DATABASE_URL=postgres://travel:travel@localhost:5432/travel_planner?sslmode=disa
 # Optional affiliate IDs appended to accommodation browse links (leave empty until approved).
 BOOKING_AFFILIATE_ID=
 AIRBNB_AFFILIATE_ID=
+# Optional Ferryhopper affiliate id appended to ferry booking links (leave empty
+# until approved at affiliates.ferryhopper.com). Ferry links work without it,
+# just unattributed.
+FERRYHOPPER_AFFILIATE_ID=

--- a/src/packages/api/ferry_service.go
+++ b/src/packages/api/ferry_service.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// FerryQuery describes a ferry search between two ports/islands.
+type FerryQuery struct {
+	Origin      string // island/port name, e.g. "Santorini"
+	Destination string // island/port name, e.g. "Naxos"
+	Date        string // YYYY-MM-DD (optional)
+	Passengers  int    // optional
+}
+
+// FerryOption is the normalized, forward-compatible ferry result. The v1
+// (affiliate deep-link) path fills only From/To/Date/BookingURL; the structured
+// fields stay empty until a real ferry API (Ferryhopper FerryhAPI) is wired in
+// behind the same SearchFerries signature, populating the same shape without
+// touching callers, the agent, or the Flutter app.
+type FerryOption struct {
+	Operator    string  `json:"operator,omitempty"`
+	From        string  `json:"from"`
+	To          string  `json:"to"`
+	Date        string  `json:"date,omitempty"` // YYYY-MM-DD
+	DepartTime  string  `json:"depart_time,omitempty"`
+	ArriveTime  string  `json:"arrive_time,omitempty"`
+	DurationMin int     `json:"duration_minutes,omitempty"`
+	Price       float64 `json:"price,omitempty"`
+	Currency    string  `json:"currency,omitempty"`
+	BookingURL  string  `json:"booking_url"` // Ferryhopper (affiliate) deep link
+}
+
+// FerryService builds ferry booking links. Today it produces Ferryhopper
+// deep links; a future listing-returning provider (FerryhAPI) can replace
+// SearchFerries' body without changing the FerryOption shape or callers.
+type FerryService struct {
+	AffiliateID string
+}
+
+// NewFerryService reads the optional Ferryhopper affiliate id. Absence is fine —
+// links still work, they're just unattributed.
+func NewFerryService() *FerryService {
+	return &FerryService{
+		AffiliateID: os.Getenv("FERRYHOPPER_AFFILIATE_ID"),
+	}
+}
+
+// ferryService is a process-wide singleton (it holds only static config).
+var ferryService = NewFerryService()
+
+// SearchFerries returns ferry options for a route. v1 returns a single
+// link-only option pointing at the Ferryhopper route page (which lists real
+// schedules and prices and has a date picker). Returns nil when origin or
+// destination is missing.
+func (s *FerryService) SearchFerries(q FerryQuery) []FerryOption {
+	from := strings.TrimSpace(q.Origin)
+	to := strings.TrimSpace(q.Destination)
+	if from == "" || to == "" {
+		return nil
+	}
+	return []FerryOption{{
+		From:       from,
+		To:         to,
+		Date:       strings.TrimSpace(q.Date),
+		BookingURL: s.ferryhopperURL(from, to),
+	}}
+}
+
+// ferryhopperURL builds a Ferryhopper route-page deep link from island/port
+// names (verified scheme: /en/ferry-routes/direct/{from}-to-{to}). The route
+// page resolves by name and shows live schedules/prices. The affiliate id, when
+// configured, is appended per the Ferryhopper affiliate agreement.
+//
+// Upgrade path: Ferryhopper's booking-results page is date-aware
+// (/en/booking/results?itinerary=PIR,JTR&dates=YYYYMMDD) but needs port codes;
+// switch to it once a port-code map or FerryhAPI is available.
+func (s *FerryService) ferryhopperURL(from, to string) string {
+	u := "https://www.ferryhopper.com/en/ferry-routes/direct/" +
+		ferrySlug(from) + "-to-" + ferrySlug(to)
+	if s.AffiliateID != "" {
+		u += "?" + url.Values{"aff": {s.AffiliateID}}.Encode()
+	}
+	return u
+}
+
+// ferrySlug lowercases and hyphenates a port/island name for Ferryhopper's
+// route-page path segments.
+func ferrySlug(s string) string {
+	return url.PathEscape(strings.ToLower(strings.ReplaceAll(strings.TrimSpace(s), " ", "-")))
+}
+
+// ferriesSearchHandler handles ferry route search requests. Mirrors
+// eventsSearchHandler's response shape.
+func ferriesSearchHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	q := r.URL.Query()
+	origin := strings.TrimSpace(q.Get("origin"))
+	destination := strings.TrimSpace(q.Get("destination"))
+	date := strings.TrimSpace(q.Get("date"))
+	if origin == "" || destination == "" {
+		http.Error(w, "Missing required query parameters 'origin' and 'destination'", http.StatusBadRequest)
+		return
+	}
+	passengers, _ := strconv.Atoi(q.Get("passengers"))
+
+	options := ferryService.SearchFerries(FerryQuery{
+		Origin:      origin,
+		Destination: destination,
+		Date:        date,
+		Passengers:  passengers,
+	})
+
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"options": options,
+		"status":  "success",
+	})
+}

--- a/src/packages/api/greece_events_service.go
+++ b/src/packages/api/greece_events_service.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// GreekEventLink is a deep link to a Greek event/ticketing source. Greece has no
+// public events API (Ticketmaster is effectively empty there), so for Greek
+// cities we surface curated source links instead of structured Event cards —
+// the same deep-link pattern as transport_service.go.
+type GreekEventLink struct {
+	Provider string `json:"provider"`
+	URL      string `json:"url"`
+	Label    string `json:"label"`
+}
+
+// greekCities is the set used to decide whether a city is in Greece. A robust
+// country lookup (via Google Places details) is a follow-up; this hardcoded set
+// covers the mainland hubs and the islands travelers actually plan around.
+var greekCities = map[string]bool{
+	"greece": true, "gr": true,
+	"athens": true, "piraeus": true, "thessaloniki": true,
+	"santorini": true, "thira": true, "fira": true, "oia": true,
+	"mykonos": true, "naxos": true, "paros": true, "ios": true,
+	"milos": true, "syros": true, "tinos": true, "folegandros": true,
+	"crete": true, "heraklion": true, "chania": true, "rethymno": true,
+	"rhodes": true, "kos": true, "corfu": true, "kefalonia": true,
+	"zakynthos": true, "lefkada": true, "skiathos": true, "skopelos": true,
+	"samos": true, "chios": true, "lesbos": true, "mytilene": true,
+	"karpathos": true, "symi": true, "hydra": true, "spetses": true,
+	"aegina": true, "nafplio": true, "delphi": true, "meteora": true,
+	"kalamata": true, "patras": true,
+}
+
+// isGreekLocation reports whether a city/place name is in Greece, using the
+// hardcoded greekCities set (case-insensitive, also matches a trailing
+// ", Greece"). Used to switch the events flow to Greek source links.
+func isGreekLocation(name string) bool {
+	n := strings.ToLower(strings.TrimSpace(name))
+	if n == "" {
+		return false
+	}
+	if strings.Contains(n, "greece") {
+		return true
+	}
+	// Match the first token (e.g. "Santorini, Greece" -> "santorini") and the
+	// whole string.
+	if greekCities[n] {
+		return true
+	}
+	if i := strings.IndexAny(n, ","); i > 0 {
+		if greekCities[strings.TrimSpace(n[:i])] {
+			return true
+		}
+	}
+	return false
+}
+
+// greekEventLinks returns curated event-discovery links for a Greek city over a
+// date window (YYYY-MM-DD). more.com/Viva.gr is Greece's dominant ticketing
+// platform; visitgreece.gr is the official tourism events calendar; the
+// Athens-Epidaurus Festival is added only when the window overlaps its season
+// (roughly May–October).
+func greekEventLinks(city, startDate, endDate string) []GreekEventLink {
+	c := strings.TrimSpace(city)
+	links := []GreekEventLink{
+		{
+			Provider: "more.com",
+			Label:    "Concerts, theatre & festivals on more.com",
+			URL:      "https://www.more.com/gr-en/tickets/search/?q=" + url.QueryEscape(c),
+		},
+		{
+			Provider: "visitgreece.gr",
+			Label:    "Official events calendar",
+			URL:      "https://www.visitgreece.gr/events/",
+		},
+	}
+	if windowOverlapsFestivalSeason(startDate, endDate) {
+		links = append(links, GreekEventLink{
+			Provider: "Athens-Epidaurus Festival",
+			Label:    "Athens & Epidaurus Festival (summer)",
+			URL:      "https://aefestival.gr/schedule/?lang=en",
+		})
+	}
+	return links
+}
+
+// greeceEventsLinksHandler returns curated Greek event-discovery links for a
+// city + date window. Used by the trip-detail events section as the fallback
+// when the structured (Ticketmaster) lookup is empty for a Greek city. Returns
+// an empty list (not an error) for non-Greek cities so callers stay simple.
+func greeceEventsLinksHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	q := r.URL.Query()
+	city := strings.TrimSpace(q.Get("city"))
+	if city == "" {
+		http.Error(w, "Missing required query parameter 'city'", http.StatusBadRequest)
+		return
+	}
+
+	var links []GreekEventLink
+	if isGreekLocation(city) {
+		links = greekEventLinks(city, q.Get("start_date"), q.Get("end_date"))
+	} else {
+		links = []GreekEventLink{}
+	}
+
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"links":  links,
+		"status": "success",
+	})
+}
+
+// windowOverlapsFestivalSeason reports whether [startDate,endDate] overlaps the
+// Athens-Epidaurus Festival season (May–October), comparing on month so it
+// holds across years. Defaults to true when dates are missing/unparseable so we
+// don't hide the link on incomplete input.
+func windowOverlapsFestivalSeason(startDate, endDate string) bool {
+	s, errS := time.Parse("2006-01-02", strings.TrimSpace(startDate))
+	e, errE := time.Parse("2006-01-02", strings.TrimSpace(endDate))
+	if errS != nil || errE != nil {
+		return true
+	}
+	for d := s; !d.After(e); d = d.AddDate(0, 0, 1) {
+		if m := d.Month(); m >= time.May && m <= time.October {
+			return true
+		}
+		// Bail out early once we're past October of the start year and the
+		// window can't loop back into season.
+		if d.Sub(s) > 366*24*time.Hour {
+			break
+		}
+	}
+	return false
+}

--- a/src/packages/api/main.go
+++ b/src/packages/api/main.go
@@ -524,6 +524,8 @@ func main() {
 	api.HandleFunc("/flights/search", flightsSearchHandler).Methods("POST")
 	api.HandleFunc("/flights/airports", airportsSearchHandler).Methods("GET")
 	api.HandleFunc("/events/search", eventsSearchHandler).Methods("GET")
+	api.HandleFunc("/ferries/search", ferriesSearchHandler).Methods("GET")
+	api.HandleFunc("/events/greece-links", greeceEventsLinksHandler).Methods("GET")
 	api.HandleFunc("/plan", planHandler).Methods("POST")
 	api.HandleFunc("/airbnb/parse", airbnbParseHandler).Methods("POST")
 	api.HandleFunc("/airbnb/debug", airbnbDebugHandler).Methods("POST")

--- a/src/packages/api/plan_handler.go
+++ b/src/packages/api/plan_handler.go
@@ -173,7 +173,7 @@ func planHandler(w http.ResponseWriter, r *http.Request) {
 
 	suggestTransportTool := anthropic.ToolParam{
 		Name:        "suggest_transport",
-		Description: anthropic.String("Give the traveler links to browse transport options. Call this when they need to get to or between destinations. Mode 'flight' returns Google Flights + Kayak; mode 'ground' returns Rome2Rio (covers trains, buses, cars, ferries)."),
+		Description: anthropic.String("Give the traveler links to browse transport options. Call this when they need to get to or between destinations. Mode 'flight' returns Google Flights + Kayak; mode 'ground' returns Rome2Rio (covers trains, buses, cars, ferries). For travel between Greek islands, prefer suggest_ferries instead."),
 		InputSchema: anthropic.ToolInputSchemaParam{
 			Properties: map[string]any{
 				"mode":        map[string]any{"type": "string", "enum": []string{"flight", "ground"}, "description": "flight or ground (multimodal)"},
@@ -184,6 +184,20 @@ func planHandler(w http.ResponseWriter, r *http.Request) {
 				"passengers":  map[string]any{"type": "integer", "description": "Optional passenger count"},
 			},
 			Required: []string{"mode", "origin", "destination"},
+		},
+	}
+
+	suggestFerriesTool := anthropic.ToolParam{
+		Name:        "suggest_ferries",
+		Description: anthropic.String("Give the traveler a ferry booking link for a route between two ports/islands — use this for Greek island-hopping (e.g. Santorini→Naxos) and other ferry legs. Backed by Ferryhopper, which aggregates the major Greek operators (Blue Star, SeaJets, etc.)."),
+		InputSchema: anthropic.ToolInputSchemaParam{
+			Properties: map[string]any{
+				"origin":      map[string]any{"type": "string", "description": "Departure port or island, e.g. 'Santorini' or 'Piraeus'"},
+				"destination": map[string]any{"type": "string", "description": "Arrival port or island, e.g. 'Naxos'"},
+				"date":        map[string]any{"type": "string", "description": "Optional YYYY-MM-DD travel date"},
+				"passengers":  map[string]any{"type": "integer", "description": "Optional passenger count"},
+			},
+			Required: []string{"origin", "destination"},
 		},
 	}
 
@@ -253,6 +267,7 @@ func planHandler(w http.ResponseWriter, r *http.Request) {
 		{OfTool: &searchTool},
 		{OfTool: &suggestStaysTool},
 		{OfTool: &suggestTransportTool},
+		{OfTool: &suggestFerriesTool},
 		{OfTool: &searchFlightsTool},
 		{OfTool: &searchEventsTool},
 	}
@@ -277,7 +292,7 @@ func planHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	today := time.Now()
-	basePrompt := "You are an expert travel agent. Today's date is " + today.Format("Monday, January 2, 2006") + " (" + today.Format("2006-01-02") + "). When a traveler gives a date without a year, assume the soonest upcoming occurrence on or after today — never a past year. Use dates in YYYY-MM-DD form when calling tools. Help users plan trips by searching for specific places and attractions. Use search_places to find real locations with coordinates. Search for individual places (e.g. 'Louvre Museum Paris') rather than broad queries. Include a mix of activities/attractions and dining (restaurants), guided by the traveler's interests, budget, and pace. When you call create_itinerary, tag each location with category ('attraction' or 'restaurant'), a time_of_day ('morning', 'afternoon', or 'evening'), and a day (the 1-based trip day it falls on, increasing chronologically across the whole trip) so each day reads as a sensible schedule. When you have gathered enough places for the user's trip, call create_itinerary to finalize the plan; pass start_date (and end_date) whenever the traveler has given or agreed to travel dates, with day 1 being the start date. You can also use search_flights to find real flight options — ask for the traveler's departure city/airport and dates if you don't know them, and pick optimize_for from their budget (budget→cost, luxury→time, otherwise balanced); the ranked options are shown to the traveler as cards, so summarize and help them choose. Be conversational and helpful — ask clarifying questions if needed before searching."
+	basePrompt := "You are an expert travel agent. Today's date is " + today.Format("Monday, January 2, 2006") + " (" + today.Format("2006-01-02") + "). When a traveler gives a date without a year, assume the soonest upcoming occurrence on or after today — never a past year. Use dates in YYYY-MM-DD form when calling tools. Help users plan trips by searching for specific places and attractions. Use search_places to find real locations with coordinates. Search for individual places (e.g. 'Louvre Museum Paris') rather than broad queries. Include a mix of activities/attractions and dining (restaurants), guided by the traveler's interests, budget, and pace. When you call create_itinerary, tag each location with category ('attraction' or 'restaurant'), a time_of_day ('morning', 'afternoon', or 'evening'), and a day (the 1-based trip day it falls on, increasing chronologically across the whole trip) so each day reads as a sensible schedule. When you have gathered enough places for the user's trip, call create_itinerary to finalize the plan; pass start_date (and end_date) whenever the traveler has given or agreed to travel dates, with day 1 being the start date. You can also use search_flights to find real flight options — ask for the traveler's departure city/airport and dates if you don't know them, and pick optimize_for from their budget (budget→cost, luxury→time, otherwise balanced); the ranked options are shown to the traveler as cards, so summarize and help them choose. For travel between Greek islands, use suggest_ferries (ferries are the primary way to island-hop); note that in Greece search_events returns curated source links rather than ticketed listings. Be conversational and helpful — ask clarifying questions if needed before searching."
 
 	placesService := NewGooglePlacesService()
 	ctx := r.Context()
@@ -512,6 +527,25 @@ func planHandler(w http.ResponseWriter, r *http.Request) {
 				b, _ := json.Marshal(links)
 				toolResults = append(toolResults, anthropic.NewToolResultBlock(variant.ID, "Provided browse links: "+string(b), false))
 
+			case "suggest_ferries":
+				var in struct {
+					Origin      string `json:"origin"`
+					Destination string `json:"destination"`
+					Date        string `json:"date"`
+					Passengers  int    `json:"passengers"`
+				}
+				json.Unmarshal(variant.Input, &in)
+				options := ferryService.SearchFerries(FerryQuery{
+					Origin: in.Origin, Destination: in.Destination,
+					Date: in.Date, Passengers: in.Passengers,
+				})
+				sendSSE(w, "ferries", map[string]any{
+					"origin": in.Origin, "destination": in.Destination, "options": options,
+				})
+				sendSSE(w, "tool_result", map[string]string{"name": "suggest_ferries"})
+				b, _ := json.Marshal(options)
+				toolResults = append(toolResults, anthropic.NewToolResultBlock(variant.ID, "Provided ferry booking link(s): "+string(b), false))
+
 			case "search_flights":
 				var in struct {
 					Origin      string `json:"origin"`
@@ -574,12 +608,6 @@ func planHandler(w http.ResponseWriter, r *http.Request) {
 				json.Unmarshal(variant.Input, &in)
 
 				events, err := eventsService.SearchEvents(ctx, in.City, in.StartDate, in.EndDate, in.Category)
-				if err != nil {
-					sendSSE(w, "tool_result", map[string]string{"name": "search_events"})
-					toolResults = append(toolResults, anthropic.NewToolResultBlock(variant.ID, fmt.Sprintf("Error searching events: %v", err), true))
-					break
-				}
-
 				if len(events) > 0 {
 					sendSSE(w, "events", map[string]any{
 						"city":       in.City,
@@ -588,8 +616,23 @@ func planHandler(w http.ResponseWriter, r *http.Request) {
 						"events":     events,
 					})
 				}
+
+				// Greece has no usable events API, so when the structured lookup
+				// comes back empty (or errors, e.g. no key) for a Greek city, fall
+				// back to curated Greek source links instead of nothing.
+				summary := summarizeEvents(in.City, events)
+				if len(events) == 0 && isGreekLocation(in.City) {
+					links := greekEventLinks(in.City, in.StartDate, in.EndDate)
+					sendSSE(w, "event_links", map[string]any{"city": in.City, "links": links})
+					b, _ := json.Marshal(links)
+					summary = "No ticketed listings via the events provider for " + in.City +
+						". Provided Greek event-discovery links: " + string(b)
+				} else if err != nil {
+					summary = fmt.Sprintf("Error searching events: %v", err)
+				}
+
 				sendSSE(w, "tool_result", map[string]string{"name": "search_events"})
-				toolResults = append(toolResults, anthropic.NewToolResultBlock(variant.ID, summarizeEvents(in.City, events), false))
+				toolResults = append(toolResults, anthropic.NewToolResultBlock(variant.ID, summary, err != nil && len(events) == 0 && !isGreekLocation(in.City)))
 			}
 		}
 

--- a/src/packages/flutter-app/lib/models/ferry_option.dart
+++ b/src/packages/flutter-app/lib/models/ferry_option.dart
@@ -1,0 +1,51 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'ferry_option.g.dart';
+
+/// A ferry option returned by /ferries/search, matching the Go API's
+/// FerryOption. In v1 (Ferryhopper deep-link mode) only [from], [to], [date],
+/// and [bookingUrl] are populated; the structured fields fill once a real ferry
+/// API is wired in.
+@JsonSerializable()
+class FerryOption {
+  @JsonKey(defaultValue: '')
+  final String operator;
+  @JsonKey(defaultValue: '')
+  final String from;
+  @JsonKey(defaultValue: '')
+  final String to;
+  @JsonKey(defaultValue: '')
+  final String date;
+  @JsonKey(name: 'depart_time', defaultValue: '')
+  final String departTime;
+  @JsonKey(name: 'arrive_time', defaultValue: '')
+  final String arriveTime;
+  @JsonKey(name: 'duration_minutes', defaultValue: 0)
+  final int durationMinutes;
+  @JsonKey(defaultValue: 0)
+  final double price;
+  @JsonKey(defaultValue: '')
+  final String currency;
+  @JsonKey(name: 'booking_url', defaultValue: '')
+  final String bookingUrl;
+
+  const FerryOption({
+    this.operator = '',
+    this.from = '',
+    this.to = '',
+    this.date = '',
+    this.departTime = '',
+    this.arriveTime = '',
+    this.durationMinutes = 0,
+    this.price = 0,
+    this.currency = '',
+    this.bookingUrl = '',
+  });
+
+  /// "Santorini → Naxos" route label.
+  String get routeLabel => '$from → $to';
+
+  factory FerryOption.fromJson(Map<String, dynamic> json) =>
+      _$FerryOptionFromJson(json);
+  Map<String, dynamic> toJson() => _$FerryOptionToJson(this);
+}

--- a/src/packages/flutter-app/lib/models/ferry_option.g.dart
+++ b/src/packages/flutter-app/lib/models/ferry_option.g.dart
@@ -1,0 +1,34 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'ferry_option.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+FerryOption _$FerryOptionFromJson(Map<String, dynamic> json) => FerryOption(
+      operator: json['operator'] as String? ?? '',
+      from: json['from'] as String? ?? '',
+      to: json['to'] as String? ?? '',
+      date: json['date'] as String? ?? '',
+      departTime: json['depart_time'] as String? ?? '',
+      arriveTime: json['arrive_time'] as String? ?? '',
+      durationMinutes: (json['duration_minutes'] as num?)?.toInt() ?? 0,
+      price: (json['price'] as num?)?.toDouble() ?? 0,
+      currency: json['currency'] as String? ?? '',
+      bookingUrl: json['booking_url'] as String? ?? '',
+    );
+
+Map<String, dynamic> _$FerryOptionToJson(FerryOption instance) =>
+    <String, dynamic>{
+      'operator': instance.operator,
+      'from': instance.from,
+      'to': instance.to,
+      'date': instance.date,
+      'depart_time': instance.departTime,
+      'arrive_time': instance.arriveTime,
+      'duration_minutes': instance.durationMinutes,
+      'price': instance.price,
+      'currency': instance.currency,
+      'booking_url': instance.bookingUrl,
+    };

--- a/src/packages/flutter-app/lib/models/source_link.dart
+++ b/src/packages/flutter-app/lib/models/source_link.dart
@@ -1,0 +1,23 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'source_link.g.dart';
+
+/// A labeled deep link to an external discovery/booking source, matching the Go
+/// API's GreekEventLink (and reusable for any provider-link list). Used where
+/// there's no structured data to show — e.g. Greek events via more.com /
+/// visitgreece.gr / Athens-Epidaurus.
+@JsonSerializable()
+class SourceLink {
+  @JsonKey(defaultValue: '')
+  final String provider;
+  @JsonKey(defaultValue: '')
+  final String url;
+  @JsonKey(defaultValue: '')
+  final String label;
+
+  const SourceLink({this.provider = '', this.url = '', this.label = ''});
+
+  factory SourceLink.fromJson(Map<String, dynamic> json) =>
+      _$SourceLinkFromJson(json);
+  Map<String, dynamic> toJson() => _$SourceLinkToJson(this);
+}

--- a/src/packages/flutter-app/lib/models/source_link.g.dart
+++ b/src/packages/flutter-app/lib/models/source_link.g.dart
@@ -1,0 +1,20 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'source_link.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+SourceLink _$SourceLinkFromJson(Map<String, dynamic> json) => SourceLink(
+      provider: json['provider'] as String? ?? '',
+      url: json['url'] as String? ?? '',
+      label: json['label'] as String? ?? '',
+    );
+
+Map<String, dynamic> _$SourceLinkToJson(SourceLink instance) =>
+    <String, dynamic>{
+      'provider': instance.provider,
+      'url': instance.url,
+      'label': instance.label,
+    };

--- a/src/packages/flutter-app/lib/providers/events_provider.dart
+++ b/src/packages/flutter-app/lib/providers/events_provider.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../models/event.dart';
+import '../models/source_link.dart';
 import '../services/events_api_service.dart';
 import 'api_client_provider.dart';
 
@@ -49,5 +50,19 @@ final eventsByCityProvider =
     query.startDate,
     query.endDate,
     category: query.category,
+  );
+});
+
+/// Curated Greek event-discovery links for a city + date window (empty for
+/// non-Greek cities). Used as the trip-detail fallback when [eventsByCityProvider]
+/// returns nothing for a Greek city.
+final greeceEventLinksProvider =
+    FutureProvider.family<List<SourceLink>, EventsQuery>((ref, query) async {
+  if (query.city.trim().isEmpty) return [];
+  final service = ref.watch(eventsApiServiceProvider);
+  return service.greeceEventLinks(
+    query.city.trim(),
+    query.startDate,
+    query.endDate,
   );
 });

--- a/src/packages/flutter-app/lib/providers/ferries_provider.dart
+++ b/src/packages/flutter-app/lib/providers/ferries_provider.dart
@@ -1,0 +1,47 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../models/ferry_option.dart';
+import '../services/ferry_api_service.dart';
+import 'api_client_provider.dart';
+
+final ferryApiServiceProvider = Provider<FerryApiService>((ref) {
+  return FerryApiService(ref.watch(apiClientProvider));
+});
+
+/// Identifies one ferry lookup: a route and (optional) date. Used as the family
+/// key so each island-hop leg caches its own result.
+class FerryQuery {
+  final String origin;
+  final String destination;
+  final String? date; // YYYY-MM-DD
+
+  const FerryQuery({
+    required this.origin,
+    required this.destination,
+    this.date,
+  });
+
+  @override
+  bool operator ==(Object other) =>
+      other is FerryQuery &&
+      other.origin == origin &&
+      other.destination == destination &&
+      other.date == date;
+
+  @override
+  int get hashCode => Object.hash(origin, destination, date);
+}
+
+/// Ferry options for a route. Returns [] for incomplete queries so callers can
+/// render nothing without special-casing.
+final ferriesByRouteProvider =
+    FutureProvider.family<List<FerryOption>, FerryQuery>((ref, query) async {
+  if (query.origin.trim().isEmpty || query.destination.trim().isEmpty) {
+    return [];
+  }
+  final service = ref.watch(ferryApiServiceProvider);
+  return service.searchFerries(
+    query.origin.trim(),
+    query.destination.trim(),
+    date: query.date,
+  );
+});

--- a/src/packages/flutter-app/lib/providers/plan_provider.dart
+++ b/src/packages/flutter-app/lib/providers/plan_provider.dart
@@ -4,6 +4,8 @@ import '../models/plan_message.dart';
 import '../models/location.dart';
 import '../models/flight_offer.dart';
 import '../models/event.dart';
+import '../models/ferry_option.dart';
+import '../models/source_link.dart';
 import '../services/api_client.dart';
 import '../services/plan_service.dart';
 import 'api_client_provider.dart';
@@ -20,6 +22,10 @@ class PlanState {
   final String? flightRouteLabel;
   final List<Event>? eventResults;
   final String? eventsCityLabel;
+  final List<FerryOption>? ferryOptions;
+  final String? ferryRouteLabel;
+  final List<SourceLink>? eventLinks;
+  final String? eventLinksCity;
   final String? error;
 
   /// Short excerpt of profile notes the agent just saved (server
@@ -42,6 +48,10 @@ class PlanState {
     this.flightRouteLabel,
     this.eventResults,
     this.eventsCityLabel,
+    this.ferryOptions,
+    this.ferryRouteLabel,
+    this.eventLinks,
+    this.eventLinksCity,
     this.error,
     this.profileUpdateNote,
     this.tripUpdateCount = 0,
@@ -59,6 +69,10 @@ class PlanState {
     Object? flightRouteLabel = _sentinel,
     Object? eventResults = _sentinel,
     Object? eventsCityLabel = _sentinel,
+    Object? ferryOptions = _sentinel,
+    Object? ferryRouteLabel = _sentinel,
+    Object? eventLinks = _sentinel,
+    Object? eventLinksCity = _sentinel,
     Object? error = _sentinel,
     Object? profileUpdateNote = _sentinel,
     int? tripUpdateCount,
@@ -77,6 +91,10 @@ class PlanState {
       flightRouteLabel: flightRouteLabel == _sentinel ? this.flightRouteLabel : flightRouteLabel as String?,
       eventResults: eventResults == _sentinel ? this.eventResults : eventResults as List<Event>?,
       eventsCityLabel: eventsCityLabel == _sentinel ? this.eventsCityLabel : eventsCityLabel as String?,
+      ferryOptions: ferryOptions == _sentinel ? this.ferryOptions : ferryOptions as List<FerryOption>?,
+      ferryRouteLabel: ferryRouteLabel == _sentinel ? this.ferryRouteLabel : ferryRouteLabel as String?,
+      eventLinks: eventLinks == _sentinel ? this.eventLinks : eventLinks as List<SourceLink>?,
+      eventLinksCity: eventLinksCity == _sentinel ? this.eventLinksCity : eventLinksCity as String?,
       error: error == _sentinel ? this.error : error as String?,
       profileUpdateNote:
           profileUpdateNote == _sentinel ? this.profileUpdateNote : profileUpdateNote as String?,
@@ -144,6 +162,10 @@ class PlanNotifier extends StateNotifier<PlanState> {
       flightRouteLabel: null,
       eventResults: null,
       eventsCityLabel: null,
+      ferryOptions: null,
+      ferryRouteLabel: null,
+      eventLinks: null,
+      eventLinksCity: null,
       error: null,
       profileUpdateNote: null,
     );
@@ -208,6 +230,28 @@ class PlanNotifier extends StateNotifier<PlanState> {
             state = state.copyWith(
               eventResults: events,
               eventsCityLabel: event.data['city'] as String?,
+            );
+
+          case 'ferries':
+            final raw = event.data['options'] as List<dynamic>? ?? [];
+            final options = raw
+                .map((e) => FerryOption.fromJson(e as Map<String, dynamic>))
+                .toList();
+            final origin = event.data['origin'] as String? ?? '';
+            final dest = event.data['destination'] as String? ?? '';
+            state = state.copyWith(
+              ferryOptions: options,
+              ferryRouteLabel: '$origin → $dest',
+            );
+
+          case 'event_links':
+            final raw = event.data['links'] as List<dynamic>? ?? [];
+            final links = raw
+                .map((e) => SourceLink.fromJson(e as Map<String, dynamic>))
+                .toList();
+            state = state.copyWith(
+              eventLinks: links,
+              eventLinksCity: event.data['city'] as String?,
             );
 
           case 'error':

--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -17,6 +17,7 @@ import '../providers/preferences_provider.dart';
 import '../providers/api_client_provider.dart';
 import '../providers/plan_provider.dart';
 import '../providers/events_provider.dart';
+import '../providers/ferries_provider.dart';
 import '../theme/app_colors.dart';
 import '../theme/spacing.dart';
 import '../utils/trip_format.dart';
@@ -24,6 +25,8 @@ import '../widgets/add_itinerary_item_dialog.dart';
 import '../widgets/booking_todo_card.dart';
 import '../widgets/empty_state.dart';
 import '../widgets/event_card.dart';
+import '../widgets/ferry_card.dart';
+import '../widgets/source_links_card.dart';
 import '../widgets/status_pill.dart';
 import '../widgets/trip_map.dart';
 import '../widgets/trip_refine_panel.dart';
@@ -842,11 +845,11 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
               ],
             ),
           ),
-          // Stay quiet on errors (e.g. provider key not set) — events are a
-          // nice-to-have, not core to the itinerary.
-          error: (_, __) => const SizedBox.shrink(),
+          // On error (e.g. provider key not set), try the Greek source-links
+          // fallback rather than going silent.
+          error: (_, __) => _greekEventsFallback(query, theme),
           data: (events) {
-            if (events.isEmpty) return const SizedBox.shrink();
+            if (events.isEmpty) return _greekEventsFallback(query, theme);
             return Column(
               crossAxisAlignment: CrossAxisAlignment.stretch,
               children: [
@@ -855,6 +858,91 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
               ],
             );
           },
+        );
+      }),
+    );
+  }
+
+  /// When the structured events lookup is empty/errored, show curated Greek
+  /// event-discovery links for Greek cities (empty for everywhere else, so this
+  /// renders nothing). Keeps the section useful where Ticketmaster has no data.
+  Widget _greekEventsFallback(EventsQuery query, ThemeData theme) {
+    return Consumer(builder: (context, ref, _) {
+      final links = ref.watch(greeceEventLinksProvider(query)).valueOrNull;
+      if (links == null || links.isEmpty) return const SizedBox.shrink();
+      return SourceLinksCard(
+        icon: Icons.local_activity,
+        accent: AppColors.toolEvents,
+        title: 'Find events in ${query.city}',
+        links: links,
+      );
+    });
+  }
+
+  /// Greek islands/ports we offer ferry connectors between (mirrors the API's
+  /// isGreekLocation set; kept small and local since it only gates the UI hint).
+  static const _greekIslands = {
+    'athens', 'piraeus', 'santorini', 'thira', 'fira', 'oia', 'mykonos',
+    'naxos', 'paros', 'ios', 'milos', 'syros', 'tinos', 'folegandros',
+    'crete', 'heraklion', 'chania', 'rethymno', 'rhodes', 'kos', 'corfu',
+    'kefalonia', 'zakynthos', 'lefkada', 'skiathos', 'skopelos', 'samos',
+    'chios', 'lesbos', 'mytilene', 'karpathos', 'symi', 'hydra', 'spetses',
+    'aegina',
+  };
+
+  bool _isGreekIsland(String label) {
+    final n = label.toLowerCase().trim();
+    if (n.contains('greece')) return true;
+    if (_greekIslands.contains(n)) return true;
+    final comma = n.indexOf(',');
+    if (comma > 0 && _greekIslands.contains(n.substring(0, comma).trim())) {
+      return true;
+    }
+    return false;
+  }
+
+  /// Ferry connector between two consecutive Greek-island groups. Renders
+  /// nothing unless both stops are Greek islands. The lookup is keyed by route +
+  /// the next stop's start date.
+  Widget _ferrySliver(
+      String fromLabel, String toLabel, DateTime? toStart, ThemeData theme) {
+    if (!_isGreekIsland(fromLabel) || !_isGreekIsland(toLabel)) {
+      return const SliverToBoxAdapter(child: SizedBox.shrink());
+    }
+    final query = FerryQuery(
+      origin: fromLabel,
+      destination: toLabel,
+      date: toStart == null ? null : _fmt(toStart),
+    );
+    return SliverToBoxAdapter(
+      child: Consumer(builder: (context, ref, _) {
+        final options = ref.watch(ferriesByRouteProvider(query)).valueOrNull;
+        if (options == null || options.isEmpty) {
+          return const SizedBox.shrink();
+        }
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Padding(
+              padding: const EdgeInsets.only(
+                  top: AppSpacing.sm, bottom: AppSpacing.xs),
+              child: Row(
+                children: [
+                  Icon(Icons.directions_boat,
+                      size: 16, color: AppColors.toolFerries),
+                  const SizedBox(width: 6),
+                  Text(
+                    'Ferry to $toLabel',
+                    style: theme.textTheme.labelLarge?.copyWith(
+                      fontWeight: FontWeight.w600,
+                      color: AppColors.toolFerries,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            FerryCard(option: options.first),
+          ],
         );
       }),
     );
@@ -1675,6 +1763,19 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
                                               group.label,
                                               groupRanges[group.label],
                                               theme),
+                                        // Island-hopping connector: a ferry
+                                        // suggestion to the next stop when both
+                                        // this and the next group are Greek
+                                        // islands, dated at the next stop's start.
+                                        if (_itemFilter == 'all' &&
+                                            gi < groups.length - 1)
+                                          _ferrySliver(
+                                            group.label,
+                                            groups[gi + 1].label,
+                                            groupRanges[groups[gi + 1].label]
+                                                ?.start,
+                                            theme,
+                                          ),
                                         if (_itemFilter == 'all' &&
                                             gi == groups.length - 1 &&
                                             gi < grouped.slots.length)

--- a/src/packages/flutter-app/lib/services/events_api_service.dart
+++ b/src/packages/flutter-app/lib/services/events_api_service.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 import '../models/event.dart';
+import '../models/source_link.dart';
 import 'api_client.dart';
 
 /// Wraps the /events/search endpoint (Ticketmaster-backed local events). The
@@ -44,6 +45,36 @@ class EventsApiService {
       statusCode: res.statusCode,
       message: 'Failed to search events: ${res.body}',
       endpoint: 'events/search',
+    );
+  }
+
+  /// Curated Greek event-discovery links for a city + date window. Returns []
+  /// for non-Greek cities (the API decides). Used as the trip-detail fallback
+  /// when the structured events lookup is empty for a Greek city.
+  Future<List<SourceLink>> greeceEventLinks(
+    String city,
+    String startDate,
+    String endDate,
+  ) async {
+    final uri = Uri.parse('${apiClient.baseUrl}/events/greece-links').replace(
+      queryParameters: {
+        'city': city,
+        'start_date': startDate,
+        'end_date': endDate,
+      },
+    );
+    final res = await apiClient.httpClient.get(uri, headers: _headers());
+    if (res.statusCode == 200) {
+      final body = jsonDecode(res.body) as Map<String, dynamic>;
+      final list = (body['links'] as List<dynamic>? ?? []);
+      return list
+          .map((e) => SourceLink.fromJson(e as Map<String, dynamic>))
+          .toList();
+    }
+    throw ApiException(
+      statusCode: res.statusCode,
+      message: 'Failed to fetch Greek event links: ${res.body}',
+      endpoint: 'events/greece-links',
     );
   }
 }

--- a/src/packages/flutter-app/lib/services/ferry_api_service.dart
+++ b/src/packages/flutter-app/lib/services/ferry_api_service.dart
@@ -1,0 +1,49 @@
+import 'dart:convert';
+import '../models/ferry_option.dart';
+import 'api_client.dart';
+
+/// Wraps the /ferries/search endpoint (Ferryhopper-backed ferry booking links).
+/// Public, but sends the bearer token when present, matching the other services.
+class FerryApiService {
+  final ApiClient apiClient;
+
+  FerryApiService(this.apiClient);
+
+  Map<String, String> _headers() {
+    final h = <String, String>{'Accept': 'application/json'};
+    final token = apiClient.authToken;
+    if (token != null) h['Authorization'] = 'Bearer $token';
+    return h;
+  }
+
+  /// Looks up ferry options for a route between two ports/islands.
+  Future<List<FerryOption>> searchFerries(
+    String origin,
+    String destination, {
+    String? date,
+    int? passengers,
+  }) async {
+    final uri = Uri.parse('${apiClient.baseUrl}/ferries/search').replace(
+      queryParameters: {
+        'origin': origin,
+        'destination': destination,
+        if (date != null && date.isNotEmpty) 'date': date,
+        if (passengers != null && passengers > 0)
+          'passengers': '$passengers',
+      },
+    );
+    final res = await apiClient.httpClient.get(uri, headers: _headers());
+    if (res.statusCode == 200) {
+      final body = jsonDecode(res.body) as Map<String, dynamic>;
+      final list = (body['options'] as List<dynamic>? ?? []);
+      return list
+          .map((e) => FerryOption.fromJson(e as Map<String, dynamic>))
+          .toList();
+    }
+    throw ApiException(
+      statusCode: res.statusCode,
+      message: 'Failed to search ferries: ${res.body}',
+      endpoint: 'ferries/search',
+    );
+  }
+}

--- a/src/packages/flutter-app/lib/theme/app_colors.dart
+++ b/src/packages/flutter-app/lib/theme/app_colors.dart
@@ -48,4 +48,5 @@ abstract final class AppColors {
   static Color get toolFlights => Colors.blue.shade700;
   static Color get toolAirbnb => Colors.pink.shade600;
   static Color get toolEvents => Colors.purple.shade600;
+  static Color get toolFerries => Colors.cyan.shade700;
 }

--- a/src/packages/flutter-app/lib/widgets/chat_panel.dart
+++ b/src/packages/flutter-app/lib/widgets/chat_panel.dart
@@ -3,11 +3,14 @@ import 'package:flutter/rendering.dart' show ScrollDirection;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../models/flight_offer.dart';
 import '../models/event.dart';
+import '../models/ferry_option.dart';
 import '../models/plan_message.dart';
 import '../providers/plan_provider.dart';
 import '../theme/app_colors.dart';
 import 'flight_offer_card.dart';
 import 'event_card.dart';
+import 'ferry_card.dart';
+import 'source_links_card.dart';
 
 /// The plan-agent chat surface (messages, tool chips, flight cards, input bar)
 /// decoupled from any screen, so the full-screen Agent tab and the trip-detail
@@ -167,6 +170,23 @@ class _ChatPanelState extends ConsumerState<ChatPanel> {
                           cityLabel: planState.eventsCityLabel,
                           events: planState.eventResults!,
                         ),
+                      if (planState.ferryOptions != null && planState.ferryOptions!.isNotEmpty)
+                        _FerryOptions(
+                          routeLabel: planState.ferryRouteLabel,
+                          options: planState.ferryOptions!,
+                        ),
+                      if (planState.eventLinks != null && planState.eventLinks!.isNotEmpty)
+                        Padding(
+                          padding: const EdgeInsets.symmetric(vertical: 4),
+                          child: SourceLinksCard(
+                            icon: Icons.local_activity,
+                            accent: AppColors.toolEvents,
+                            title: planState.eventLinksCity == null
+                                ? 'Find local events'
+                                : 'Find events in ${planState.eventLinksCity}',
+                            links: planState.eventLinks!,
+                          ),
+                        ),
                       if (widget.footerBuilder != null)
                         widget.footerBuilder!(context, planState),
                       if (planState.error != null)
@@ -208,6 +228,8 @@ class _ChatPanelState extends ConsumerState<ChatPanel> {
         return 'Searching flights...';
       case 'search_events':
         return 'Finding events...';
+      case 'suggest_ferries':
+        return 'Finding ferries...';
       default:
         return '$tool...';
     }
@@ -366,6 +388,55 @@ class _EventOptions extends StatelessWidget {
           ),
           const SizedBox(height: 8),
           for (final e in events) EventCard(event: e),
+        ],
+      ),
+    );
+  }
+}
+
+/// Inline ferry results in the chat — a header plus the agent's ferry option(s)
+/// for a route as shared FerryCards.
+class _FerryOptions extends StatelessWidget {
+  final String? routeLabel;
+  final List<FerryOption> options;
+
+  const _FerryOptions({required this.routeLabel, required this.options});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final accent = AppColors.toolFerries;
+    final label = (routeLabel == null || routeLabel!.trim().isEmpty)
+        ? 'Ferries'
+        : 'Ferries · $routeLabel';
+    return Container(
+      margin: const EdgeInsets.symmetric(vertical: 12),
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: accent.withValues(alpha: 0.08),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: accent.withValues(alpha: 0.4)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Icon(Icons.directions_boat, color: accent, size: 20),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Text(
+                  label,
+                  style: theme.textTheme.titleSmall?.copyWith(
+                    color: accent,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          for (final o in options) FerryCard(option: o),
         ],
       ),
     );

--- a/src/packages/flutter-app/lib/widgets/ferry_card.dart
+++ b/src/packages/flutter-app/lib/widgets/ferry_card.dart
@@ -1,0 +1,85 @@
+import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
+import '../models/ferry_option.dart';
+import '../theme/app_colors.dart';
+import '../theme/spacing.dart';
+
+/// A ferry option: route, date, and (when available) operator/time/price,
+/// opening the Ferryhopper booking page on tap. In v1 link mode it renders as a
+/// "Find ferries" CTA for the route.
+class FerryCard extends StatelessWidget {
+  final FerryOption option;
+
+  const FerryCard({super.key, required this.option});
+
+  Future<void> _open() async {
+    if (option.bookingUrl.isEmpty) return;
+    final uri = Uri.tryParse(option.bookingUrl);
+    if (uri != null) {
+      await launchUrl(uri, mode: LaunchMode.externalApplication);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final accent = AppColors.toolFerries;
+    // Structured detail line (filled once a real ferry API replaces link mode).
+    final detail = [
+      if (option.operator.isNotEmpty) option.operator,
+      if (option.departTime.isNotEmpty) option.departTime,
+      if (option.price > 0)
+        '${option.currency.isEmpty ? '' : '${option.currency} '}${option.price.toStringAsFixed(0)}',
+    ].join(' · ');
+
+    return Card(
+      margin: const EdgeInsets.symmetric(vertical: AppSpacing.xs),
+      clipBehavior: Clip.antiAlias,
+      child: InkWell(
+        onTap: option.bookingUrl.isEmpty ? null : _open,
+        child: Padding(
+          padding: const EdgeInsets.all(AppSpacing.md),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Container(
+                padding: const EdgeInsets.all(AppSpacing.sm),
+                decoration: BoxDecoration(
+                  color: accent.withValues(alpha: 0.12),
+                  borderRadius: BorderRadius.circular(AppRadius.sm),
+                ),
+                child: Icon(Icons.directions_boat, size: 20, color: accent),
+              ),
+              const SizedBox(width: AppSpacing.md),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      option.routeLabel,
+                      style: theme.textTheme.titleSmall
+                          ?.copyWith(fontWeight: FontWeight.w600),
+                    ),
+                    const SizedBox(height: 2),
+                    Text(
+                      detail.isNotEmpty
+                          ? detail
+                          : (option.date.isNotEmpty
+                              ? 'Find ferries · ${option.date}'
+                              : 'Find ferries on Ferryhopper'),
+                      style: theme.textTheme.labelMedium
+                          ?.copyWith(color: accent, fontWeight: FontWeight.w600),
+                    ),
+                  ],
+                ),
+              ),
+              if (option.bookingUrl.isNotEmpty)
+                Icon(Icons.open_in_new,
+                    size: 16, color: theme.colorScheme.onSurfaceVariant),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/src/packages/flutter-app/lib/widgets/source_links_card.dart
+++ b/src/packages/flutter-app/lib/widgets/source_links_card.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
+import '../models/source_link.dart';
+import '../theme/spacing.dart';
+
+/// A compact card listing external discovery links as tappable chips. Used where
+/// there's no structured data to show — e.g. Greek events via more.com /
+/// visitgreece.gr / Athens-Epidaurus.
+class SourceLinksCard extends StatelessWidget {
+  final IconData icon;
+  final Color accent;
+  final String title;
+  final List<SourceLink> links;
+
+  const SourceLinksCard({
+    super.key,
+    required this.icon,
+    required this.accent,
+    required this.title,
+    required this.links,
+  });
+
+  Future<void> _open(String url) async {
+    if (url.isEmpty) return;
+    final uri = Uri.tryParse(url);
+    if (uri != null) {
+      await launchUrl(uri, mode: LaunchMode.externalApplication);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    if (links.isEmpty) return const SizedBox.shrink();
+    return Card(
+      margin: const EdgeInsets.symmetric(vertical: AppSpacing.xs),
+      child: Padding(
+        padding: const EdgeInsets.all(AppSpacing.md),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Icon(icon, size: 16, color: accent),
+                const SizedBox(width: 6),
+                Expanded(
+                  child: Text(
+                    title,
+                    style: theme.textTheme.labelLarge?.copyWith(
+                      fontWeight: FontWeight.w600,
+                      color: accent,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: AppSpacing.sm),
+            Wrap(
+              spacing: AppSpacing.sm,
+              runSpacing: AppSpacing.xs,
+              children: [
+                for (final link in links)
+                  ActionChip(
+                    avatar: Icon(Icons.open_in_new, size: 14, color: accent),
+                    label: Text(link.label.isEmpty ? link.provider : link.label),
+                    onPressed: () => _open(link.url),
+                  ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
A concentrated, Greece-focused feature set wired into the existing generic flow (no special "Greece mode"), as deep-link providers behind swappable types.

- **Ferries / island-hopping** — `ferry_service.go` builds **Ferryhopper** route-page links from island names. Exposed via `GET /api/v1/ferries/search` and the `/plan` agent's new **`suggest_ferries`** tool (SSE `ferries`). The `FerryOption` type carries structured fields (operator/time/price) that stay empty in v1 link mode — designed so the Ferryhopper **FerryhAPI** B2B upgrade fills the same shape without touching callers, agent, or Flutter.
- **Greek events** — Ticketmaster is effectively empty for Greece, so `search_events` now falls back to curated **source links** (more.com/Viva.gr, visitgreece.gr, seasonal Athens-Epidaurus) when results are empty for a Greek city. Surfaced via an `event_links` SSE event and a `GET /api/v1/events/greece-links` endpoint that the trip-detail events section uses **instead of going blank**.
- **Trip detail** — ferry connector cards between adjacent Greek-island groups (dated at the next stop's arrival); the events section renders a "Find events in {city}" links card for Greek cities.
- **Chat** — `_FerryOptions` + event-links cards; `suggest_ferries` → "Finding ferries…" label.
- **No API key required** — everything is deep-links (`FERRYHOPPER_AFFILIATE_ID` optional, attribution only). Greek detection uses a hardcoded island/city set in Go and Dart.

## Testing
- Backend: `go build`/`go vet`/`go test` pass; `gofmt` clean.
- Flutter: `flutter analyze` 0 errors; `flutter test` all pass; models regenerated.
- Manual (live through the gateway, no keys configured):
  - `GET /ferries/search?origin=Santorini&destination=Naxos&date=2026-09-10` → working Ferryhopper link; confirmed the URL resolves to a real schedules/prices page (Blue Star/Seajets, €31.50).
  - `GET /events/greece-links?city=Athens&...` → 3 sources (Athens-Epidaurus included in season); `city=Paris` → empty as designed.

## Known limitations / follow-ups
- Structured ferry sailings (schedules/prices) need a Ferryhopper FerryhAPI/MCP B2B partnership — `FerryOption` is shaped for that drop-in upgrade.
- Greece detection is a hardcoded island set; a robust Google Places country lookup is a follow-up.
- The ferry deep-link lands on the route page (date picked there); date pre-fill into Ferryhopper is part of the FerryhAPI upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)