### PR TITLE
fix: correct ferry links + unify island legs into one ferry row

### DIFF
--- a/src/packages/api/ferry_service.go
+++ b/src/packages/api/ferry_service.go
@@ -53,10 +53,43 @@ func NewFerryService() *FerryService {
 // ferryService is a process-wide singleton (it holds only static config).
 var ferryService = NewFerryService()
 
+// greekPortCodes maps the island/port names we recognize (lowercased) to their
+// Ferryhopper port codes, sourced authoritatively from the Ferryhopper MCP
+// get_ports tool (not guessed — ferry-only ports like Rafina/Hydra/Aegina have
+// no IATA code). Covers the same set as the Flutter _greekIslands gate, so every
+// ferry leg we offer resolves to a real port code. Athens/Piraeus → PIR (the
+// main ferry hub); multi-port islands use their "all ports" code.
+var greekPortCodes = map[string]string{
+	"athens": "PIR", "piraeus": "PIR",
+	"santorini": "JTR", "thira": "JTR", "fira": "JTR", "oia": "JTR",
+	"mykonos": "JMK", "naxos": "JNX", "paros": "PAS", "ios": "IOS",
+	"milos": "MLO", "syros": "JSY", "tinos": "TIN", "folegandros": "FOL",
+	"crete": "HER", "heraklion": "HER", "chania": "CHA", "rethymno": "RNO",
+	"rhodes": "RHO", "kos": "KGS", "corfu": "CFU", "kefalonia": "KE00",
+	"zakynthos": "ZTH", "lefkada": "LEF00", "skiathos": "JSI", "skopelos": "SKO",
+	"samos": "SMS", "chios": "CHI", "lesbos": "LES", "mytilene": "LES",
+	"karpathos": "AOK", "symi": "SYM", "hydra": "HYD", "spetses": "SPE",
+	"aegina": "AEG",
+}
+
+// ferryPortCode resolves a port/island name to its Ferryhopper code, handling a
+// trailing ", Greece" and surrounding whitespace. Empty string when unknown.
+func ferryPortCode(name string) string {
+	n := strings.ToLower(strings.TrimSpace(name))
+	if c, ok := greekPortCodes[n]; ok {
+		return c
+	}
+	if i := strings.IndexByte(n, ','); i > 0 {
+		if c, ok := greekPortCodes[strings.TrimSpace(n[:i])]; ok {
+			return c
+		}
+	}
+	return ""
+}
+
 // SearchFerries returns ferry options for a route. v1 returns a single
-// link-only option pointing at the Ferryhopper route page (which lists real
-// schedules and prices and has a date picker). Returns nil when origin or
-// destination is missing.
+// link-only option pointing at the Ferryhopper booking-results search for the
+// exact route and date. Returns nil when origin or destination is missing.
 func (s *FerryService) SearchFerries(q FerryQuery) []FerryOption {
 	from := strings.TrimSpace(q.Origin)
 	to := strings.TrimSpace(q.Destination)
@@ -67,31 +100,30 @@ func (s *FerryService) SearchFerries(q FerryQuery) []FerryOption {
 		From:       from,
 		To:         to,
 		Date:       strings.TrimSpace(q.Date),
-		BookingURL: s.ferryhopperURL(from, to),
+		BookingURL: s.ferryhopperURL(from, to, strings.TrimSpace(q.Date)),
 	}}
 }
 
-// ferryhopperURL builds a Ferryhopper route-page deep link from island/port
-// names (verified scheme: /en/ferry-routes/direct/{from}-to-{to}). The route
-// page resolves by name and shows live schedules/prices. The affiliate id, when
-// configured, is appended per the Ferryhopper affiliate agreement.
-//
-// Upgrade path: Ferryhopper's booking-results page is date-aware
-// (/en/booking/results?itinerary=PIR,JTR&dates=YYYYMMDD) but needs port codes;
-// switch to it once a port-code map or FerryhAPI is available.
-func (s *FerryService) ferryhopperURL(from, to string) string {
-	u := "https://www.ferryhopper.com/en/ferry-routes/direct/" +
-		ferrySlug(from) + "-to-" + ferrySlug(to)
+// ferryhopperURL builds a Ferryhopper booking-results deep link for a specific
+// route and date — the same format Ferryhopper's own "Find tickets" buttons use:
+// /en/booking/results?itinerary=CODE1,CODE2&dates=YYYYMMDD. The query is built
+// by hand so the comma in itinerary stays literal (matching Ferryhopper), not
+// percent-encoded. When either port code is unknown, falls back to the ferries
+// schedules landing page rather than a broken route (never the homepage).
+func (s *FerryService) ferryhopperURL(from, to, date string) string {
+	fromCode := ferryPortCode(from)
+	toCode := ferryPortCode(to)
+	if fromCode == "" || toCode == "" {
+		return "https://www.ferryhopper.com/en/ferries"
+	}
+	u := "https://www.ferryhopper.com/en/booking/results?itinerary=" + fromCode + "," + toCode
+	if d := strings.ReplaceAll(date, "-", ""); len(d) == 8 {
+		u += "&dates=" + d
+	}
 	if s.AffiliateID != "" {
-		u += "?" + url.Values{"aff": {s.AffiliateID}}.Encode()
+		u += "&aff=" + url.QueryEscape(s.AffiliateID)
 	}
 	return u
-}
-
-// ferrySlug lowercases and hyphenates a port/island name for Ferryhopper's
-// route-page path segments.
-func ferrySlug(s string) string {
-	return url.PathEscape(strings.ToLower(strings.ReplaceAll(strings.TrimSpace(s), " ", "-")))
 }
 
 // ferriesSearchHandler handles ferry route search requests. Mirrors

--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -25,7 +25,6 @@ import '../widgets/add_itinerary_item_dialog.dart';
 import '../widgets/booking_todo_card.dart';
 import '../widgets/empty_state.dart';
 import '../widgets/event_card.dart';
-import '../widgets/ferry_card.dart';
 import '../widgets/source_links_card.dart';
 import '../widgets/status_pill.dart';
 import '../widgets/trip_map.dart';
@@ -61,6 +60,10 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
       _homeAirport; // traveler's saved home airport (IATA), for outbound/return flights
   // todo_key -> flight leg, so a transport booking item can open Find Flights prefilled.
   Map<String, ({String origin, String destination, String? date})> _flightLegs =
+      {};
+  // todo_key -> ferry leg (Greek port<->port), so the booking item opens the
+  // Ferryhopper search for that route instead of a flight.
+  Map<String, ({String origin, String destination, String? date})> _ferryLegs =
       {};
   // Per-leg travel timings keyed by the source item's position (the leg leaving
   // that item, to the next item in itinerary order). Empty until computed and on
@@ -183,6 +186,8 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
     final todos = <Map<String, dynamic>>[];
     final legs =
         <String, ({String origin, String destination, String? date})>{};
+    final ferryLegs =
+        <String, ({String origin, String destination, String? date})>{};
     var pos = 0;
     final home = _homeAirport;
     final hasHome = home != null && home.isNotEmpty && ranges.isNotEmpty;
@@ -206,6 +211,37 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
         'passengers': 1,
       });
       legs[key] = (origin: origin, destination: destination, date: date);
+    }
+
+    // Adds a transport (ferry) todo for a Greek port<->port leg and records it so
+    // the booking item opens the Ferryhopper search for that route.
+    void addFerry(String origin, String destination, DateTime? when) {
+      final date = when == null ? null : _fmt(when);
+      final key =
+          'transport:${origin.toLowerCase()}>>${destination.toLowerCase()}';
+      todos.add({
+        'kind': 'transport',
+        'todo_key': key,
+        'title': '$origin → $destination',
+        if (when != null) 'subtitle': _fmtShortDt(when),
+        'provider': 'ferry',
+        'position': pos++,
+        'origin': origin,
+        'destination': destination,
+        if (date != null) 'depart_date': date,
+        'passengers': 1,
+      });
+      ferryLegs[key] = (origin: origin, destination: destination, date: date);
+    }
+
+    // A leg between two Greek ports/islands (incl. Athens/Piraeus) is a ferry;
+    // the long-haul home<->Greece legs stay flights.
+    void addLeg(String origin, String destination, DateTime? when) {
+      if (_isGreekIsland(origin) && _isGreekIsland(destination)) {
+        addFerry(origin, destination, when);
+      } else {
+        addFlight(origin, destination, when);
+      }
     }
 
     // Outbound: home airport -> first city, on the trip's start date.
@@ -232,7 +268,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
         'guests': 1,
       });
       if (i < ranges.length - 1) {
-        addFlight(label, ranges[i + 1].label, r.end);
+        addLeg(label, ranges[i + 1].label, r.end);
       }
     }
 
@@ -242,6 +278,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
     }
 
     _flightLegs = legs;
+    _ferryLegs = ferryLegs;
     return todos;
   }
 
@@ -901,52 +938,6 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
     return false;
   }
 
-  /// Ferry connector between two consecutive Greek-island groups. Renders
-  /// nothing unless both stops are Greek islands. The lookup is keyed by route +
-  /// the next stop's start date.
-  Widget _ferrySliver(
-      String fromLabel, String toLabel, DateTime? toStart, ThemeData theme) {
-    if (!_isGreekIsland(fromLabel) || !_isGreekIsland(toLabel)) {
-      return const SliverToBoxAdapter(child: SizedBox.shrink());
-    }
-    final query = FerryQuery(
-      origin: fromLabel,
-      destination: toLabel,
-      date: toStart == null ? null : _fmt(toStart),
-    );
-    return SliverToBoxAdapter(
-      child: Consumer(builder: (context, ref, _) {
-        final options = ref.watch(ferriesByRouteProvider(query)).valueOrNull;
-        if (options == null || options.isEmpty) {
-          return const SizedBox.shrink();
-        }
-        return Column(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            Padding(
-              padding: const EdgeInsets.only(
-                  top: AppSpacing.sm, bottom: AppSpacing.xs),
-              child: Row(
-                children: [
-                  Icon(Icons.directions_boat,
-                      size: 16, color: AppColors.toolFerries),
-                  const SizedBox(width: 6),
-                  Text(
-                    'Ferry to $toLabel',
-                    style: theme.textTheme.labelLarge?.copyWith(
-                      fontWeight: FontWeight.w600,
-                      color: AppColors.toolFerries,
-                    ),
-                  ),
-                ],
-              ),
-            ),
-            FerryCard(option: options.first),
-          ],
-        );
-      }),
-    );
-  }
 
   /// Compact booking rows for a city group's slot: arrival flight + stay when
   /// [departureOnly] is false, the return-home flight when true.
@@ -962,8 +953,11 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
             todo: todo,
             onBookedChanged: (v) => _setBooked(todo, v),
             onOpen: _openCallbackFor(todo),
-            openLabelOverride:
-                _flightLegs.containsKey(todo.todoKey) ? 'Find flights' : null,
+            openLabelOverride: _ferryLegs.containsKey(todo.todoKey)
+                ? 'Find ferries'
+                : _flightLegs.containsKey(todo.todoKey)
+                    ? 'Find flights'
+                    : null,
           ),
     ];
   }
@@ -1763,19 +1757,6 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
                                               group.label,
                                               groupRanges[group.label],
                                               theme),
-                                        // Island-hopping connector: a ferry
-                                        // suggestion to the next stop when both
-                                        // this and the next group are Greek
-                                        // islands, dated at the next stop's start.
-                                        if (_itemFilter == 'all' &&
-                                            gi < groups.length - 1)
-                                          _ferrySliver(
-                                            group.label,
-                                            groups[gi + 1].label,
-                                            groupRanges[groups[gi + 1].label]
-                                                ?.start,
-                                            theme,
-                                          ),
                                         if (_itemFilter == 'all' &&
                                             gi == groups.length - 1 &&
                                             gi < grouped.slots.length)
@@ -1923,18 +1904,43 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
   /// leg opens the in-app Find Flights screen prefilled; everything else falls
   /// back to its external provider search link.
   VoidCallback? _openCallbackFor(BookingTodo todo) {
-    final leg = todo.kind == 'transport' ? _flightLegs[todo.todoKey] : null;
-    if (leg != null) {
-      return () => Navigator.of(context).push(MaterialPageRoute(
-            builder: (_) => FlightSearchScreen(
-              prefillOrigin: leg.origin,
-              prefillDestination: leg.destination,
-              prefillDepartDate: leg.date,
-            ),
-          ));
+    if (todo.kind == 'transport') {
+      final ferry = _ferryLegs[todo.todoKey];
+      if (ferry != null) return () => _openFerry(ferry);
+      final leg = _flightLegs[todo.todoKey];
+      if (leg != null) {
+        return () => Navigator.of(context).push(MaterialPageRoute(
+              builder: (_) => FlightSearchScreen(
+                prefillOrigin: leg.origin,
+                prefillDestination: leg.destination,
+                prefillDepartDate: leg.date,
+              ),
+            ));
+      }
     }
     if (todo.searchUrl != null) return () => _launch(todo.searchUrl!);
     return null;
+  }
+
+  /// Opens the Ferryhopper search for a ferry leg. The booking URL (with the
+  /// correct port codes) is built server-side, so we fetch it on tap — a single
+  /// quick GET — keeping the port-code map a single source of truth in the API.
+  Future<void> _openFerry(
+      ({String origin, String destination, String? date}) leg) async {
+    try {
+      final options = await ref.read(ferryApiServiceProvider).searchFerries(
+            leg.origin,
+            leg.destination,
+            date: leg.date,
+          );
+      if (options.isNotEmpty && options.first.bookingUrl.isNotEmpty) {
+        await _launch(options.first.bookingUrl);
+        return;
+      }
+    } catch (_) {
+      // fall through to the generic failure snack
+    }
+    _showSnack('Could not open ferry search');
   }
 
   Future<void> _launch(String url) async {

--- a/src/packages/flutter-app/lib/widgets/booking_todo_card.dart
+++ b/src/packages/flutter-app/lib/widgets/booking_todo_card.dart
@@ -4,7 +4,7 @@ import '../models/booking_todo.dart';
 IconData _kindIcon(BookingTodo todo) {
   switch (todo.kind) {
     case 'transport':
-      return Icons.flight;
+      return todo.provider == 'ferry' ? Icons.directions_boat : Icons.flight;
     case 'stay':
       return Icons.hotel;
     default:
@@ -21,6 +21,8 @@ String _providerOpenLabel(BookingTodo todo, String? override) {
       return 'Open in Booking.com';
     case 'google_flights':
       return 'Open in Google Flights';
+    case 'ferry':
+      return 'Open in Ferryhopper';
     case 'kayak':
       return 'Open in Kayak';
     case 'rome2rio':


### PR DESCRIPTION
## Summary
Two defects in the shipped Greece ferry feature (PR #27), found while testing an island-hopping trip:

- **Ferryhopper links landed on the homepage.** The code guessed a route-page slug (`/ferry-routes/direct/{from}-to-{to}`), but Ferryhopper's canonical slugs aren't derivable (Athens = `athens-piraeus`; many island pairs redirect to the directory). Switched to Ferryhopper's **real booking-results deep link** — `…/en/booking/results?itinerary=CODE1,CODE2&dates=YYYYMMDD` (the format their own "Find tickets" buttons use) — backed by an **authoritative `greekPortCodes` map** harvested from Ferryhopper's public MCP `get_ports` tool (not guessed). Unknown ports fall back to the schedules page, never the homepage.
- **Duplicate flight/ferry UI on trip detail.** An island leg showed both an auto-generated "Find flights" booking row *and* a separate ferry card. Unified into a **single transport booking row** per leg: `provider: 'ferry'` (boat icon + "Find ferries", opens Ferryhopper) for any leg between two Greek ports incl. Athens/Piraeus; home↔Greece legs stay flights. Removed the redundant `_ferrySliver`.

## Testing
- Backend `go build`/`go vet`/`go test` pass; `gofmt` clean.
- Flutter `analyze` 0 errors; `flutter test` all pass.
- Live through the gateway:
  - Athens→Santorini → `…/booking/results?itinerary=PIR,JTR&dates=20260910`
  - Santorini→Naxos → `itinerary=JTR,JNX&dates=20260912`
  - Lisbon→Santorini (unknown port) → `/en/ferries` schedules fallback
- Note: the booking-results page is JS-rendered, so tooling can't confirm the rendered result — but the URL strings exactly match Ferryhopper's documented format with their own port codes (real-browser click is the final check).

## Follow-up
- Ferryhopper's public, key-less **MCP server** (`mcp.ferryhopper.com`, `search_trips`) would replace the hand-maintained port-code map and fill the structured `FerryOption` fields (operator/time/price) with real sailings — the natural next quality step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)