### PR TITLE
fix: Find Flights prefill + auto-search from trip detail

### DIFF
--- a/src/packages/api/duffel_service.go
+++ b/src/packages/api/duffel_service.go
@@ -148,7 +148,27 @@ func (d *DuffelService) do(req *http.Request) ([]byte, error) {
 func (d *DuffelService) SearchAirports(ctx context.Context, keyword string) ([]Airport, error) {
 	params := url.Values{}
 	params.Set("query", keyword)
+	return d.placeSuggestions(ctx, params)
+}
 
+// nearbyAirportRadiusMeters bounds the geographic airport lookup. 100km comfortably
+// covers an island/metro area; Duffel returns matches sorted nearest-first.
+const nearbyAirportRadiusMeters = 100000
+
+// NearbyAirports resolves a coordinate to nearby airports/cities, sorted
+// nearest-first. Used to map an itinerary place (e.g. a village like Imerovigli)
+// to a bookable airport (e.g. Santorini/JTR) when its name has no IATA match.
+func (d *DuffelService) NearbyAirports(ctx context.Context, lat, lng float64) ([]Airport, error) {
+	params := url.Values{}
+	params.Set("lat", strconv.FormatFloat(lat, 'f', -1, 64))
+	params.Set("lng", strconv.FormatFloat(lng, 'f', -1, 64))
+	params.Set("rad", strconv.Itoa(nearbyAirportRadiusMeters))
+	return d.placeSuggestions(ctx, params)
+}
+
+// placeSuggestions queries Duffel's /places/suggestions with the given params and
+// normalizes the response to []Airport (skipping entries without an IATA code).
+func (d *DuffelService) placeSuggestions(ctx context.Context, params url.Values) ([]Airport, error) {
 	req, err := d.newRequest(ctx, http.MethodGet, "/places/suggestions?"+params.Encode(), nil)
 	if err != nil {
 		return nil, err

--- a/src/packages/api/main.go
+++ b/src/packages/api/main.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -272,17 +273,33 @@ type FlightSearchResponse struct {
 // client and config are shared; auth is a static token).
 var duffelService = NewDuffelService()
 
-// airportsSearchHandler resolves a keyword to airports/cities for autocomplete.
+// airportsSearchHandler resolves airports/cities for autocomplete. It supports
+// two modes: free-text (?q=) and geographic (?lat=&lng=, nearest-first) — the
+// latter maps an itinerary coordinate to a bookable airport when the place name
+// has no IATA match.
 func airportsSearchHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 
-	query := r.URL.Query().Get("q")
-	if query == "" {
-		http.Error(w, "Missing query parameter 'q'", http.StatusBadRequest)
+	q := r.URL.Query()
+	latStr, lngStr := q.Get("lat"), q.Get("lng")
+
+	var results []Airport
+	var err error
+	switch {
+	case latStr != "" && lngStr != "":
+		lat, latErr := strconv.ParseFloat(latStr, 64)
+		lng, lngErr := strconv.ParseFloat(lngStr, 64)
+		if latErr != nil || lngErr != nil {
+			http.Error(w, "Invalid 'lat'/'lng' parameters", http.StatusBadRequest)
+			return
+		}
+		results, err = duffelService.NearbyAirports(r.Context(), lat, lng)
+	case q.Get("q") != "":
+		results, err = duffelService.SearchAirports(r.Context(), q.Get("q"))
+	default:
+		http.Error(w, "Missing query parameter: provide 'q' or 'lat'+'lng'", http.StatusBadRequest)
 		return
 	}
-
-	results, err := duffelService.SearchAirports(r.Context(), query)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("Failed to search airports: %v", err), http.StatusInternalServerError)
 		return

--- a/src/packages/flutter-app/lib/screens/flight_search_screen.dart
+++ b/src/packages/flutter-app/lib/screens/flight_search_screen.dart
@@ -20,11 +20,19 @@ class FlightSearchScreen extends ConsumerStatefulWidget {
   final String? prefillDestination;
   final String? prefillDepartDate;
 
+  /// Optional coordinates for the prefilled origin/destination. When the name
+  /// has no IATA match (e.g. a village like Imerovigli), these resolve to the
+  /// nearest bookable airport (e.g. Santorini/JTR).
+  final ({double lat, double lng})? prefillOriginCoord;
+  final ({double lat, double lng})? prefillDestinationCoord;
+
   const FlightSearchScreen({
     super.key,
     this.prefillOrigin,
     this.prefillDestination,
     this.prefillDepartDate,
+    this.prefillOriginCoord,
+    this.prefillDestinationCoord,
   });
 
   @override
@@ -62,50 +70,100 @@ class _FlightSearchScreenState extends ConsumerState<FlightSearchScreen> {
       setState(() => _departDate = date);
     }
 
-    if (w.prefillOrigin != null && w.prefillOrigin!.isNotEmpty) {
-      final a = await _resolve(w.prefillOrigin!);
-      if (a != null && _origin == null && mounted) setState(() => _origin = a);
-    } else {
-      // No explicit origin → fall back to the traveler's home airport.
-      await ref.read(preferencesProvider.notifier).load();
-      final code = ref.read(preferencesProvider).prefs?.homeAirport;
-      if (code != null && code.isNotEmpty && _origin == null && mounted) {
-        setState(() => _origin = Airport(iataCode: code, name: code));
-      }
+    // Resolve origin and destination concurrently so a slow/failed lookup on one
+    // side doesn't delay or blank the other. Each result is applied on its own.
+    final originFuture = (w.prefillOrigin != null && w.prefillOrigin!.isNotEmpty)
+        ? _resolve(w.prefillOrigin!, coord: w.prefillOriginCoord)
+        : _homeAirportSeed();
+    final destFuture =
+        (w.prefillDestination != null && w.prefillDestination!.isNotEmpty)
+            ? _resolve(w.prefillDestination!, coord: w.prefillDestinationCoord)
+            : Future<Airport?>.value(null);
+
+    final resolved = await Future.wait([originFuture, destFuture]);
+    final origin = resolved[0];
+    final dest = resolved[1];
+    if (origin != null && _origin == null && mounted) {
+      setState(() => _origin = origin);
+    }
+    if (dest != null && _destination == null && mounted) {
+      setState(() => _destination = dest);
     }
 
-    if (w.prefillDestination != null && w.prefillDestination!.isNotEmpty) {
-      final a = await _resolve(w.prefillDestination!);
-      if (a != null && _destination == null && mounted) {
-        setState(() => _destination = a);
-      }
-    }
+    // Run the search as soon as it's runnable (both endpoints resolved + a date),
+    // regardless of which inputs were prefilled vs. seeded — so the caller lands
+    // on results without tapping Search.
+    if (mounted && _canSearch) _search();
+  }
 
-    // Fully prefilled (origin + destination + date all given and resolved) →
-    // run the search immediately so the caller lands on results.
-    if (mounted &&
-        w.prefillOrigin != null &&
-        w.prefillDestination != null &&
-        w.prefillDepartDate != null &&
-        _canSearch) {
-      _search();
-    }
+  /// Falls back to the traveler's saved home airport when no explicit origin was
+  /// prefilled. Returns null when none is set.
+  Future<Airport?> _homeAirportSeed() async {
+    await ref.read(preferencesProvider.notifier).load();
+    final code = ref.read(preferencesProvider).prefs?.homeAirport;
+    if (code == null || code.isEmpty) return null;
+    return Airport(iataCode: code, name: code);
   }
 
   /// Resolves an IATA code or city name to an [Airport]. A 3-letter alphabetic
-  /// input is used as-is; otherwise the Duffel airport search resolves it (first
-  /// match). Mirrors the backend's resolveIATA.
-  Future<Airport?> _resolve(String query) async {
+  /// input is used as-is; otherwise the Duffel airport search resolves it. When
+  /// the raw label finds nothing (e.g. a label with a postal/qualifier prefix),
+  /// it retries once with a cleaned query, then — if [coord] is given — falls
+  /// back to the nearest airport by coordinate (e.g. a village -> its island
+  /// airport). Mirrors the backend's resolveIATA.
+  Future<Airport?> _resolve(String query, {({double lat, double lng})? coord}) async {
     final q = query.trim();
     final isCode = q.length == 3 && RegExp(r'^[A-Za-z]{3}$').hasMatch(q);
     if (isCode) return Airport(iataCode: q.toUpperCase(), name: q.toUpperCase());
+
+    final cleaned = _cleanLabel(q);
+    final attempts = <String>[q, if (cleaned != q) cleaned];
+    for (final attempt in attempts) {
+      final hit = await _lookupAirport(attempt);
+      if (hit != null) return hit;
+    }
+    if (coord != null) return _nearestAirport(coord.lat, coord.lng);
+    return null;
+  }
+
+  /// Looks up the nearest bookable airport to a coordinate. Returns null on
+  /// empty results or any error.
+  Future<Airport?> _nearestAirport(double lat, double lng) async {
     try {
       final results =
-          await ref.read(flightsApiServiceProvider).searchAirports(q);
-      return results.isNotEmpty ? results.first : null;
+          await ref.read(flightsApiServiceProvider).nearestAirports(lat, lng);
+      return results.isEmpty ? null : results.first;
     } catch (_) {
       return null;
     }
+  }
+
+  /// Runs one airport lookup, preferring an `airport`-type result over a `city`
+  /// (so we book against a concrete airport when the typeahead returns both).
+  /// Returns null on empty results or any error so the caller can retry/fall back.
+  Future<Airport?> _lookupAirport(String query) async {
+    try {
+      final results =
+          await ref.read(flightsApiServiceProvider).searchAirports(query);
+      if (results.isEmpty) return null;
+      return results.firstWhere(
+        (a) => a.subType.toLowerCase() == 'airport',
+        orElse: () => results.first,
+      );
+    } catch (_) {
+      return null;
+    }
+  }
+
+  /// Drops any trailing qualifier after a comma and collapses a leading
+  /// postal/qualifier token, e.g. "1400 Lisboa, Portugal" -> "Lisboa".
+  String _cleanLabel(String label) {
+    var s = label.split(',').first.trim();
+    final tokens = s.split(RegExp(r'\s+'));
+    if (tokens.length > 1 && RegExp(r'\d').hasMatch(tokens.first)) {
+      s = tokens.sublist(1).join(' ').trim();
+    }
+    return s.isEmpty ? label : s;
   }
 
   bool get _canSearch =>

--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -31,6 +31,10 @@ import '../widgets/trip_map.dart';
 import '../widgets/trip_refine_panel.dart';
 import 'flight_search_screen.dart';
 
+/// A geographic coordinate used to resolve an itinerary place to its nearest
+/// bookable airport when the place name has no IATA match.
+typedef _Coord = ({double lat, double lng});
+
 class TripDetailScreen extends ConsumerStatefulWidget {
   final String tripId;
   const TripDetailScreen({super.key, required this.tripId});
@@ -58,8 +62,17 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
   final Set<String> _collapsedDays = {};
   String?
       _homeAirport; // traveler's saved home airport (IATA), for outbound/return flights
-  // todo_key -> flight leg, so a transport booking item can open Find Flights prefilled.
-  Map<String, ({String origin, String destination, String? date})> _flightLegs =
+  // todo_key -> flight leg, so a transport booking item can open Find Flights
+  // prefilled. Coords resolve an endpoint to its nearest airport when the city
+  // label has no IATA match (e.g. a village like Imerovigli -> Santorini/JTR).
+  Map<String,
+          ({
+            String origin,
+            String destination,
+            String? date,
+            _Coord? originCoord,
+            _Coord? destCoord
+          })> _flightLegs =
       {};
   // todo_key -> ferry leg (Greek port<->port), so the booking item opens the
   // Ferryhopper search for that route instead of a flight.
@@ -184,8 +197,14 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
   List<Map<String, dynamic>> _deriveTodos(Trip trip) {
     final ranges = _locationGroupRanges(trip);
     final todos = <Map<String, dynamic>>[];
-    final legs =
-        <String, ({String origin, String destination, String? date})>{};
+    final legs = <String,
+        ({
+          String origin,
+          String destination,
+          String? date,
+          _Coord? originCoord,
+          _Coord? destCoord
+        })>{};
     final ferryLegs =
         <String, ({String origin, String destination, String? date})>{};
     var pos = 0;
@@ -193,8 +212,10 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
     final hasHome = home != null && home.isNotEmpty && ranges.isNotEmpty;
 
     // Adds a transport (flight) todo and records its leg so the booking item can
-    // open Find Flights prefilled.
-    void addFlight(String origin, String destination, DateTime? when) {
+    // open Find Flights prefilled. Coords (when known) resolve an endpoint to its
+    // nearest airport if the city label itself has no IATA match.
+    void addFlight(String origin, String destination, DateTime? when,
+        {_Coord? originCoord, _Coord? destCoord}) {
       final date = when == null ? null : _fmt(when);
       final key =
           'transport:${origin.toLowerCase()}>>${destination.toLowerCase()}';
@@ -210,7 +231,13 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
         if (date != null) 'depart_date': date,
         'passengers': 1,
       });
-      legs[key] = (origin: origin, destination: destination, date: date);
+      legs[key] = (
+        origin: origin,
+        destination: destination,
+        date: date,
+        originCoord: originCoord,
+        destCoord: destCoord,
+      );
     }
 
     // Adds a transport (ferry) todo for a Greek port<->port leg and records it so
@@ -236,17 +263,20 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
 
     // A leg between two Greek ports/islands (incl. Athens/Piraeus) is a ferry;
     // the long-haul home<->Greece legs stay flights.
-    void addLeg(String origin, String destination, DateTime? when) {
+    void addLeg(String origin, String destination, DateTime? when,
+        {_Coord? originCoord, _Coord? destCoord}) {
       if (_isGreekIsland(origin) && _isGreekIsland(destination)) {
         addFerry(origin, destination, when);
       } else {
-        addFlight(origin, destination, when);
+        addFlight(origin, destination, when,
+            originCoord: originCoord, destCoord: destCoord);
       }
     }
 
     // Outbound: home airport -> first city, on the trip's start date.
     if (hasHome) {
-      addFlight(home, ranges.first.label, ranges.first.start);
+      addFlight(home, ranges.first.label, ranges.first.start,
+          destCoord: ranges.first.coord);
     }
 
     for (var i = 0; i < ranges.length; i++) {
@@ -268,13 +298,15 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
         'guests': 1,
       });
       if (i < ranges.length - 1) {
-        addLeg(label, ranges[i + 1].label, r.end);
+        addLeg(label, ranges[i + 1].label, r.end,
+            originCoord: r.coord, destCoord: ranges[i + 1].coord);
       }
     }
 
     // Return: last city -> home airport, on the trip's end date.
     if (hasHome) {
-      addFlight(ranges.last.label, home, ranges.last.end);
+      addFlight(ranges.last.label, home, ranges.last.end,
+          originCoord: ranges.last.coord);
     }
 
     _flightLegs = legs;
@@ -1264,8 +1296,8 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
   /// slice of the trip's start–end span, weighted by how many places it has; an
   /// accommodation with its own dates overrides the computed slice. Computed over
   /// the full itinerary so the category filter doesn't shift the allocation.
-  List<({String label, DateTime? start, DateTime? end})> _locationGroupRanges(
-      Trip trip) {
+  List<({String label, DateTime? start, DateTime? end, _Coord? coord})>
+      _locationGroupRanges(Trip trip) {
     final items = trip.items ?? const <ItineraryItem>[];
     if (items.isEmpty) return const [];
     final stays = trip.accommodations ?? const <Accommodation>[];
@@ -1313,7 +1345,8 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
       }
     }
 
-    final result = <({String label, DateTime? start, DateTime? end})>[];
+    final result =
+        <({String label, DateTime? start, DateTime? end, _Coord? coord})>[];
     for (var i = 0; i < groups.length; i++) {
       final g = groups[i];
       final locality = _hubOf(g.first);
@@ -1324,9 +1357,21 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
         label: locality ?? 'Other places',
         start: accRange?.start ?? dayRange?.start ?? a?.start,
         end: accRange?.end ?? dayRange?.end ?? a?.end,
+        coord: _groupCoord(g),
       ));
     }
     return result;
+  }
+
+  /// A representative coordinate for a location group: the first item with real
+  /// coordinates. (0,0) is the "no location" sentinel for manually-added places.
+  _Coord? _groupCoord(List<ItineraryItem> group) {
+    for (final it in group) {
+      if (it.latitude != 0 || it.longitude != 0) {
+        return (lat: it.latitude, lng: it.longitude);
+      }
+    }
+    return null;
   }
 
   /// Date range for a location group from its items' AI-assigned day numbers,
@@ -1914,6 +1959,8 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
                 prefillOrigin: leg.origin,
                 prefillDestination: leg.destination,
                 prefillDepartDate: leg.date,
+                prefillOriginCoord: leg.originCoord,
+                prefillDestinationCoord: leg.destCoord,
               ),
             ));
       }

--- a/src/packages/flutter-app/lib/services/flights_api_service.dart
+++ b/src/packages/flutter-app/lib/services/flights_api_service.dart
@@ -37,9 +37,18 @@ class FlightsApiService {
     );
   }
 
-  Future<List<Airport>> searchAirports(String query) async {
+  Future<List<Airport>> searchAirports(String query) =>
+      _airports({'q': query});
+
+  /// Resolves a coordinate to nearby airports/cities, sorted nearest-first. Used
+  /// to map an itinerary place (e.g. a village) to a bookable airport when its
+  /// name has no IATA match.
+  Future<List<Airport>> nearestAirports(double lat, double lng) =>
+      _airports({'lat': '$lat', 'lng': '$lng'});
+
+  Future<List<Airport>> _airports(Map<String, String> params) async {
     final uri = Uri.parse('${apiClient.baseUrl}/flights/airports')
-        .replace(queryParameters: {'q': query});
+        .replace(queryParameters: params);
     final res = await apiClient.httpClient.get(uri, headers: _headers());
     if (res.statusCode == 200) {
       final body = jsonDecode(res.body) as Map<String, dynamic>;


### PR DESCRIPTION
## Summary
- Tapping **Find flights** on a trip's transport booking todo now opens the in-app search with **From/To prefilled** and **auto-runs the search**, landing on a flight list.
- Resolve origin/destination **concurrently** and populate each **independently**, so one failed lookup no longer blanks the other; auto-search fires whenever it's runnable (both endpoints resolved + a date).
- Hardened text resolution: prefer an `airport`-type result, and retry once with a cleaned label (strips a `, country` qualifier / leading postal token).
- Added a **geographic fallback** for places with no IATA match (e.g. the village *Imerovigli* → *Santorini/JTR*): itinerary coordinates are threaded through the flight leg and resolved to the nearest airport via Duffel `/places/suggestions` (`lat`/`lng`/`rad`). Exposed as `GET /flights/airports?lat=&lng=` (nearest-first).

## Testing
- **Go**: `go build ./...` and `go vet ./...` clean.
- **API handler (live)**: ran the API and curled the new endpoint — `?lat=36.43&lng=25.44` → `JTR  Santorini (Thira) International Airport` first; `?q=Paris` still returns `PAR, CDG, ORY, …`; missing params → `400`.
- **Flutter**: `flutter analyze` — no issues in the changed files.
- **Manual**: open a trip → tap **Find flights** on the EWR → Imerovigli leg → From=EWR, To resolves to Santorini (JTR), date prefilled, offers auto-load. (Requires API image rebuild for the Go change + Flutter restart/hard refresh.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)