### PR TITLE
docs: business model strategy + sales pitch

### DIFF
--- a/docs/business-model.md
+++ b/docs/business-model.md
@@ -1,0 +1,193 @@
+# Business Model
+
+Working strategy doc — the reasoning behind how `<Name>` makes money, not
+investor copy. Companion to [`sales-pitch.md`](sales-pitch.md); uses the same
+`<Name>` placeholder. Numbers marked *(placeholder)* or *(directional)* are
+starting points to be replaced with measured data.
+
+> **Thesis:** a three-layer hybrid, phased for growth. Booking-linked revenue
+> is the always-on base that scales with free users. The free tier is generous
+> but usage-capped, and keeps the entire core loop free. A paid "power
+> traveler" tier — annual or per-trip, never monthly — monetizes heavy users
+> without gating the funnel. Right now we optimize for growth and adoption;
+> the paid tier ships later, on evidence.
+
+---
+
+## 1. The two revenue streams
+
+`<Name>` has two fundamentally different ways to earn:
+
+1. **Booking-linked revenue** (commissions/markup when a user books). Earns
+   from *every* user, free or paid. Scales with top-of-funnel volume and with
+   how good the product is at getting trips actually booked.
+2. **Direct user monetization** (a paid tier). Earns from the small fraction
+   of users who travel heavily enough to pay.
+
+These are complementary, not competing — but only if the funnel stays open.
+Every user we'd lose to a paywall is a user whose bookings we'd never see.
+**Keeping the product free is a revenue decision, not just a growth one.**
+
+---
+
+## 2. Booking-revenue reality check
+
+The pitch's "affiliate-revenue path" needs precision, because the three
+booking handoffs earn very differently:
+
+- **Airbnb — earns $0.** Airbnb shut down its affiliate program in 2021. The
+  Airbnb deep links are pure user value; do not count them as revenue.
+- **Booking.com — earns today.** A real affiliate program paying roughly
+  25–40% of Booking's own commission — call it **~4% of booking value**
+  *(directional)*. On a $500 stay, that's ~$20. This is the actual base layer
+  right now.
+- **Flights (Duffel) — earns only with in-app booking.** Duffel is a
+  *merchant* model, not affiliate: revenue is a markup on tickets **sold
+  in-app**. Deep links out to airlines earn ~nothing. Consequence: the
+  roadmap's "in-app booking" isn't a nice-to-have — **it is the unlock for
+  all flight revenue.** (Interim option: metasearch referral programs à la
+  Travelpayouts/Skyscanner — thin but nonzero.)
+
+So near-term booking revenue = accommodation attach rate × Booking.com
+commission. Flight revenue arrives with Phase 2 (§8).
+
+---
+
+## 3. Why not the obvious two models
+
+**Monthly subscription — no.** Travelers plan 2–4 trips a year. A monthly sub
+is churn-by-design: users subscribe in March to plan the summer, cancel in
+April, and feel vaguely ripped off. The products that survive in travel
+charge on a cadence that matches travel (annual, per-trip), not a cadence
+that matches SaaS habit.
+
+**Free trial → paywall — no.** A hard gate after a trial:
+- suppresses the booking funnel (§1) — every bounced user is lost commission;
+- kills the collaboration viral loop before it exists — shared trips can't
+  spread if the recipient hits a paywall;
+- contradicts the landing page's "Start planning free →" positioning;
+- and is the worst possible fit for a growth-first phase.
+
+The right question isn't "when does the meter start" but "where does the
+power-user line sit."
+
+---
+
+## 4. Tiers
+
+The line: **the entire core loop is free** — chat → itinerary → map →
+optimized route → booking checklist → booking handoff. Free caps exist to
+bound COGS, not to frustrate. Paid gates ride on power usage and roadmap
+features.
+
+| | **Free** | **Power Traveler (paid)** |
+|---|---|---|
+| AI planning sessions | ~20 agent runs / month *(placeholder)* | Unlimited |
+| Active trips | 3 *(placeholder)* | Unlimited |
+| Itinerary, map, route optimization | ✅ Full | ✅ Full |
+| Booking checklist + handoff links | ✅ Full | ✅ Full |
+| Traveler preferences / profile | ✅ Full | ✅ Full |
+| Collaboration / shared trips | — | ✅ *(roadmap)* |
+| Price / fare alerts | — | ✅ *(roadmap)* |
+| Richer in-app accommodation search | — | ✅ *(roadmap)* |
+| Offline itineraries | — | ✅ *(roadmap)* |
+| Priority / faster model | — | ✅ |
+
+Shipped vs. roadmap follows the honesty rule at the bottom of
+`sales-pitch.md`: nothing roadmap-only is claimed as live. At launch of the
+paid tier, "unlimited + priority" may be the only shipped gates — which is
+another reason the tier ships in Phase 3, after at least one roadmap anchor
+feature (most likely price alerts or collaboration) exists.
+
+---
+
+## 5. Paid cadence and price
+
+- **Primary: annual membership, $30–50/yr** *(placeholder)*. Comparables
+  cluster tightly: Wanderlog Pro ~$40/yr, TripIt Pro ~$49/yr. Annual matches
+  the "I travel a few times a year" rhythm and prices below a single checked
+  bag.
+- **Experiment: per-trip unlock, $5–10/trip** *(placeholder)*. Charges at the
+  moment of maximum perceived value ("this trip matters"). Worth an A/B once
+  the paid tier exists; risk is it trains users to think per-trip and caps
+  LTV.
+- Note: several VC-funded AI planners (Mindtrip, Layla) are entirely free —
+  one more reason the *core loop* must stay free and paid must sell *power*,
+  not access.
+
+---
+
+## 6. Unit economics *(directional)*
+
+Per-use cost drivers for one planning session:
+
+| Driver | Rough cost |
+|---|---|
+| Claude API (Sonnet, tool-use loop) | $0.30–1.50 / session |
+| Google Places (search/details calls) | $0.02–0.03 / call |
+| Duffel flight search | ~free at this volume |
+
+→ A free user planning one full trip costs on the order of **$1–5**.
+
+**Worked example** *(directional)*: one attached Booking.com reservation on a
+$500 stay earns ~$20. At $3 average trip-planning COGS, one booking pays for
+~6–7 free planned trips. Break-even attach rate ≈ **15%** of planned trips
+producing one $500 booked stay — ambitious but not absurd for a product whose
+whole job is getting trips to "booked." **Attach rate is the single number
+the growth phase exists to measure.**
+
+COGS levers if the math runs hot:
+- the free-tier caps themselves (§4);
+- cheaper/faster model on the free tier, premium model as a paid perk;
+- cache Google Places results (popular places repeat across users);
+- prefer autocomplete over text-search where the UX allows.
+
+---
+
+## 7. Growth-phase sequencing
+
+**Phase 1 — now: free + Booking affiliate.** Minimal friction, no paywall
+anywhere. Instrument everything: activation, retention, attach rate, per-user
+COGS. The product's job is to prove people come back for trip #2.
+
+**Phase 2 — in-app flight booking (Duffel markup).** The flight-revenue
+unlock (§2). Also the roadmap's biggest UX claim ("from plan to booked"
+without leaving the app), so it's a product win and a revenue win in one.
+
+**Phase 3 — paid tier.** Trigger conditions, not a date:
+- retention proven across ≥2 trips for a meaningful cohort;
+- a measured cohort actually hitting the free caps (demand signal);
+- at least one roadmap anchor feature (alerts or collaboration) shipped to
+  gate behind it.
+
+---
+
+## 8. Metrics to watch
+
+- **Activation** — signup → first saved trip.
+- **Retention** — users returning for a second trip (the compounding claim).
+- **Booking attach rate** — planned trips → booking-link clicks → completed
+  bookings. The break-even number (§6).
+- **COGS per active user** — Claude + Places spend / MAU.
+- **Cap-hit rate** — % of users hitting free limits; the paid-tier demand
+  signal and Phase 3 trigger.
+- **Free→paid conversion** — later, once the tier exists (expect 1–5%).
+
+---
+
+## 9. Open questions
+
+- Exact free caps — 3 trips / 20 runs are guesses; set from usage data.
+- Annual vs. per-trip as the *primary* paid cadence (annual assumed; per-trip
+  as experiment).
+- Price points within the $30–50/yr and $5–10/trip anchors.
+- Timing of Phase 3 — which trigger condition binds first.
+- **Collaboration: anchor paid feature or free growth lever?** It's the viral
+  loop *and* the most gate-worthy roadmap feature — it can't be both.
+  (Possible split: viewing/commenting free, co-editing paid.)
+
+---
+
+*Everything above is strategy, not commitment. The only decisions treated as
+settled: hybrid model, growth-first priority, non-monthly paid cadence, and
+the core loop staying free.*

--- a/docs/sales-pitch.md
+++ b/docs/sales-pitch.md
@@ -1,0 +1,112 @@
+# Sales Pitch
+
+The pitch is written around a `<Name>` placeholder — pick a name from the candidates below (or bring your own) and find-and-replace.
+
+The spine of every variant: **chat gives you advice; `<Name>` gives you a trip** — saved, mapped, optimized, and ready to book.
+
+---
+
+## 1. Name candidates
+
+> Before committing, check domain availability and trademark conflicts — several of these are common travel words.
+
+**Agent / companion vibe** (leans into the AI travel agent)
+
+- **Voyagent** — voyage + agent in one word; says exactly what it is. Distinctive and likely available.
+- **Tripmate** — friendly, the AI as a travel companion rather than a tool.
+
+**Hub vibe** (leans into "everything in one place")
+
+- **Tripfolio** — your trips as a living portfolio: saved, revisitable, refinable.
+- **TripHQ** — headquarters for the whole trip; punchy, easy to say, easy to remember.
+
+**Wayfinding vibe** (leans into routes, maps, and optimization)
+
+- **Waypoint** — every stop on your itinerary is one; clean, evocative, travel-native.
+- **Wayfare** — wayfaring + fares (flights); subtle double meaning.
+- **Lodestar** — the star travelers steer by; premium feel, strong metaphor for guidance.
+
+**Recommendation:** *Voyagent* if you want the AI front and center, *TripHQ* if you want the hub story front and center.
+
+---
+
+## 2. The one-liner
+
+> **`<Name>` is the AI travel agent that turns a conversation into a real trip — live flight prices, real places, an optimized route, and a booking checklist, all saved in one place.**
+
+---
+
+## 3. Elevator pitch (~100 words)
+
+> I built `<Name>` out of frustration with planning trips using ChatGPT. It gave me great advice on where to go and what to do — but advice isn't a trip. I still had twelve tabs open: flights in one, maps in another, a spreadsheet holding it all together.
+>
+> `<Name>` is the hub that didn't exist: an AI travel agent that plans your trip in conversation, using real flight prices and real places — then turns it into a saved itinerary with an interactive map, optimized routes, and a booking checklist. The power of AI, bundled into a tool made by travelers, for travelers.
+
+---
+
+## 4. Core narrative — the founder story
+
+Like everyone else, I started planning trips with ChatGPT. And honestly? It was great. It told me which neighborhoods to stay in, which museums were worth it, where the locals actually eat. Super helpful.
+
+But I wanted more — because advice isn't a trip. The moment the chat ended, the real work began: a flight search in one tab, Google Maps in another, a notes app full of restaurant names, a spreadsheet trying to hold the itinerary together. The AI had done the fun part and left me with all the hassle. And when I came back a week later to keep planning, the conversation was gone.
+
+What I wanted was a hub — one place where all the pain of travel planning was organized and powered by AI. Not a chatbot that *describes* a trip, but an agent that *builds* one: searching real places, pulling live flight prices, putting every stop on a map, working out the smartest route between them, and saving the whole thing so the trip gets better every time you come back to it.
+
+No such product existed. So I built it. `<Name>` is the power of AI, bundled into a tool made by travelers, for travelers.
+
+---
+
+## 5. Landing page copy
+
+### Hero
+
+# Stop planning trips in twelve tabs.
+
+**`<Name>` is your AI travel agent. Describe the trip you want — it finds real flights and real places, maps the smartest route, and saves it all as an itinerary you can actually book.**
+
+[ Plan my trip → ]
+
+### Feature blocks
+
+**🗣️ From conversation to itinerary**
+Tell `<Name>` where you're dreaming of going. The AI agent plans with you in real time — and when you're happy, the plan becomes a saved trip, not a chat transcript that disappears.
+
+**✈️ Real flights, real places — not AI guesses**
+Every suggestion is grounded in live data: actual attractions and restaurants from Google Places, and real flight offers with live prices, ranked by cost, time, or the best balance.
+
+**🗺️ The smartest route through your trip**
+Route optimization puts your stops in the best order — whether that's ten museums and restaurants in one city or a multi-country trip sequenced around the seasons — with travel times between every stop.
+
+**🧳 A trip that remembers you**
+Set your budget, pace, interests, and home airport once. `<Name>` remembers, and every plan it makes is shaped around how *you* travel.
+
+**✅ From plan to booked**
+Every trip comes with an auto-generated booking checklist — flights between cities, stays in each one — with one-click handoffs to book, and a checkbox to track what's done.
+
+### Closing CTA
+
+**The power of AI, made by travelers, for travelers.**
+Your next trip is one conversation away.
+
+[ Start planning free → ]
+
+---
+
+## 6. Investor framing
+
+**Problem.** Trip planning is broken into silos: inspiration (ChatGPT, blogs, social), logistics (flight search, maps), and organization (spreadsheets, notes apps). LLMs solved inspiration — and made the gap worse. Travelers now get a wonderful AI-written plan, then face hours of manual labor turning it into something real. The chat doesn't know real prices, can't draw a map, and forgets everything when the tab closes.
+
+**Solution.** `<Name>` is an AI travel agent with hands, not just opinions. Through tool use, the agent searches real places (Google Places), pulls live, ranked flight offers (Duffel API), and assembles the result into a persistent trip: an interactive map, algorithmically optimized routing (Nearest Neighbor + 2-Opt for city routes; seasonal weighting for multi-country sequencing), travel times between stops, and an auto-generated booking checklist. Traveler preferences — budget, pace, interests, home airport — persist across sessions, so the product compounds in value with use.
+
+**Why now.** LLM tool use has only recently become reliable enough for an agent to orchestrate real APIs mid-conversation. The wave of "AI trip planner" products are thin prompt wrappers — text in, text out. The opening is for the product that owns the full loop from conversation to booked trip.
+
+**Differentiation.** Three things pure-chat planners don't have:
+1. **Real data** — live flight offers and verified places, not plausible-sounding hallucinations.
+2. **Persistence** — trips are durable objects you revisit and refine, not transcripts; preferences make every plan personal.
+3. **Optimization** — actual routing algorithms ordering the trip, something no prompt can do.
+
+**What's next.** Today, booking hands off via deep links to Airbnb, Booking.com, and flight providers; the Booking.com handoff carries affiliate commission — the first revenue layer. The roadmap: in-app flight booking (transaction margin via Duffel — the unlock for flight revenue), collaborative trip planning (the viral loop — trips are inherently shared), and richer in-app accommodation search. Business model detail lives in [`business-model.md`](business-model.md).
+
+---
+
+*Every claim above maps to a shipped, wired feature. Do not add claims for: in-app booking/payments, in-app accommodation listings, collaboration/sharing, or offline mode — those are roadmap, and are framed as such in the investor section only.*


### PR DESCRIPTION
## Summary
- Adds `docs/business-model.md`: the monetization strategy — a three-layer hybrid (Booking.com affiliate as the always-on base, a usage-capped free tier that keeps the entire core planning loop free, and a non-monthly "power traveler" paid tier), sequenced growth-first with directional unit economics, phase triggers, and open questions.
- Adds `docs/sales-pitch.md` (previously untracked): name candidates, one-liner, elevator pitch, landing copy, investor framing.
- Corrects the pitch's revenue wording per the reality check in the business-model doc: Booking.com handoffs carry the affiliate commission (Airbnb's program is defunct), and flight revenue unlocks with in-app Duffel booking rather than deep links.

## Notes
- Docs only — no code changes.
- Caps, price points, and COGS figures are flagged as placeholders/directional in the doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)