### PR TITLE
feat: local guides surface — guide detail screen + trip entry points

### DIFF
--- a/src/packages/flutter-app/lib/providers/local_provider.dart
+++ b/src/packages/flutter-app/lib/providers/local_provider.dart
@@ -24,3 +24,11 @@ final localGuidesByCityProvider =
   final service = ref.watch(localApiServiceProvider);
   return service.guides(city.trim());
 });
+
+/// One published guide plus its ordered pins, keyed by guide id.
+final localGuideDetailProvider = FutureProvider.family<
+    ({LocalGuide guide, List<LocalRecommendation> recommendations}),
+    String>((ref, id) async {
+  final service = ref.watch(localApiServiceProvider);
+  return service.guideById(id);
+});

--- a/src/packages/flutter-app/lib/screens/local_guide_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/local_guide_detail_screen.dart
@@ -1,0 +1,381 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:latlong2/latlong.dart';
+import '../models/local_guide.dart';
+import '../models/local_recommendation.dart';
+import '../providers/local_provider.dart';
+import '../theme/app_colors.dart';
+import '../theme/spacing.dart';
+import '../widgets/empty_state.dart';
+import '../widgets/gradient_app_bar.dart';
+import '../widgets/local_rec_card.dart';
+
+/// One narrative local guide: hero image, the local's byline, the story itself,
+/// then the guide's pins in narrative order (as [LocalRecCard]s) and a small map
+/// of every pin that has coordinates. Reached from the "Local intel" section of
+/// a trip; [guide] is the list row, which carries the source attribution the
+/// detail endpoint's guide object omits.
+class LocalGuideDetailScreen extends ConsumerWidget {
+  final LocalGuide guide;
+
+  const LocalGuideDetailScreen({super.key, required this.guide});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final theme = Theme.of(context);
+    final detail = ref.watch(localGuideDetailProvider(guide.id));
+
+    return Scaffold(
+      appBar: GradientAppBar(
+        title: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Icon(Icons.menu_book, size: 20),
+            const SizedBox(width: AppSpacing.sm),
+            Flexible(
+              child: Text('Local guide', overflow: TextOverflow.ellipsis),
+            ),
+          ],
+        ),
+      ),
+      body: detail.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (_, __) => EmptyState(
+          icon: Icons.menu_book,
+          title: 'Could not load this guide',
+          message: 'Check your connection and try again.',
+          actions: [
+            FilledButton.icon(
+              onPressed: () => ref.invalidate(localGuideDetailProvider(guide.id)),
+              icon: const Icon(Icons.refresh),
+              label: const Text('Retry'),
+            ),
+          ],
+        ),
+        data: (data) => _GuideBody(
+          // The detail row is canonical for the narrative; the list row fills
+          // in the attribution fields the detail join omits.
+          guide: data.guide,
+          fallback: guide,
+          pins: data.recommendations,
+          theme: theme,
+        ),
+      ),
+    );
+  }
+}
+
+class _GuideBody extends StatelessWidget {
+  final LocalGuide guide;
+  final LocalGuide fallback;
+  final List<LocalRecommendation> pins;
+  final ThemeData theme;
+
+  const _GuideBody({
+    required this.guide,
+    required this.fallback,
+    required this.pins,
+    required this.theme,
+  });
+
+  String _pick(String primary, String secondary) =>
+      primary.isNotEmpty ? primary : secondary;
+
+  @override
+  Widget build(BuildContext context) {
+    final accent = AppColors.toolLocal;
+    final title = _pick(guide.title, fallback.title);
+    final body = _pick(guide.body, fallback.body);
+    final heroUrl = _pick(guide.heroImageUrl, fallback.heroImageUrl);
+    final sourceName = _pick(guide.sourceName, fallback.sourceName);
+    final sourcePhotoUrl = _pick(guide.sourcePhotoUrl, fallback.sourcePhotoUrl);
+    final placeLine = [
+      _pick(guide.neighborhood, fallback.neighborhood),
+      _pick(guide.city, fallback.city),
+    ].where((s) => s.isNotEmpty).join(' · ');
+    final mapped = pins
+        .where((p) => p.latitude != null && p.longitude != null)
+        .toList();
+
+    return ListView(
+      padding: const EdgeInsets.all(AppSpacing.lg),
+      children: [
+        if (heroUrl.isNotEmpty) ...[
+          _HeroImage(url: heroUrl),
+          const SizedBox(height: AppSpacing.lg),
+        ],
+        Text(
+          title,
+          style: theme.textTheme.headlineSmall
+              ?.copyWith(fontWeight: FontWeight.bold),
+        ),
+        if (placeLine.isNotEmpty) ...[
+          const SizedBox(height: AppSpacing.xs),
+          Text(
+            placeLine,
+            style: theme.textTheme.bodyMedium
+                ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+          ),
+        ],
+        // The local behind the guide — same face + name treatment as the
+        // recommendation cards, so attribution reads consistently.
+        if (sourceName.isNotEmpty) ...[
+          const SizedBox(height: AppSpacing.md),
+          Row(
+            children: [
+              CircleAvatar(
+                radius: 16,
+                backgroundColor: accent.withValues(alpha: 0.15),
+                foregroundImage: sourcePhotoUrl.isNotEmpty
+                    ? NetworkImage(sourcePhotoUrl)
+                    : null,
+                child: Text(
+                  sourceName.characters.first.toUpperCase(),
+                  style: theme.textTheme.labelSmall
+                      ?.copyWith(color: accent, fontWeight: FontWeight.w700),
+                ),
+              ),
+              const SizedBox(width: AppSpacing.sm),
+              Expanded(
+                child: Text(
+                  'By $sourceName',
+                  style: theme.textTheme.labelLarge?.copyWith(
+                      color: accent, fontWeight: FontWeight.w600),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+              Icon(Icons.verified, size: 18, color: accent),
+            ],
+          ),
+        ],
+        if (body.isNotEmpty) ...[
+          const SizedBox(height: AppSpacing.lg),
+          Text(
+            body,
+            style: theme.textTheme.bodyMedium?.copyWith(height: 1.6),
+          ),
+        ],
+        if (pins.isNotEmpty) ...[
+          const SizedBox(height: AppSpacing.xl),
+          Row(
+            children: [
+              Icon(Icons.place, size: 18, color: accent),
+              const SizedBox(width: 6),
+              Text(
+                'Places in this guide',
+                style: theme.textTheme.titleSmall?.copyWith(
+                    fontWeight: FontWeight.w700, color: accent),
+              ),
+              const SizedBox(width: AppSpacing.sm),
+              Text(
+                '${pins.length}',
+                style: theme.textTheme.labelMedium
+                    ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+              ),
+            ],
+          ),
+          const SizedBox(height: AppSpacing.xs),
+          if (mapped.isNotEmpty) ...[
+            _GuideMap(pins: mapped),
+            const SizedBox(height: AppSpacing.sm),
+          ],
+          for (final pin in pins) LocalRecCard(rec: pin),
+        ] else ...[
+          const SizedBox(height: AppSpacing.xl),
+          EmptyState(
+            icon: Icons.place,
+            title: 'No places pinned yet',
+            message: 'This guide is all narrative for now.',
+            iconColor: accent.withValues(alpha: 0.5),
+          ),
+        ],
+        const SizedBox(height: AppSpacing.xl),
+      ],
+    );
+  }
+}
+
+/// The guide's hero photo, rounded like a card; falls back to a branded
+/// placeholder block if the image fails to load.
+class _HeroImage extends StatelessWidget {
+  final String url;
+
+  const _HeroImage({required this.url});
+
+  @override
+  Widget build(BuildContext context) {
+    return ClipRRect(
+      borderRadius: AppRadius.mdAll,
+      child: SizedBox(
+        height: 200,
+        width: double.infinity,
+        child: Image.network(
+          url,
+          fit: BoxFit.cover,
+          errorBuilder: (context, _, __) => Container(
+            decoration: BoxDecoration(gradient: AppColors.brandGradient),
+            alignment: Alignment.center,
+            child: const Icon(Icons.photo_outlined,
+                size: 40, color: Colors.white70),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// A small OSM map of the guide's mapped pins, numbered in narrative order.
+/// TripMap is keyed to ItineraryItem (positions, categories, route line), so
+/// this stays a purpose-built lightweight map with the same tile usage and the
+/// same scroll-wheel opt-out (the map lives inside a ListView).
+class _GuideMap extends StatefulWidget {
+  final List<LocalRecommendation> pins;
+
+  const _GuideMap({required this.pins});
+
+  @override
+  State<_GuideMap> createState() => _GuideMapState();
+}
+
+class _GuideMapState extends State<_GuideMap> {
+  final MapController _controller = MapController();
+
+  void _zoomBy(double delta) {
+    try {
+      _controller.move(
+        _controller.camera.center,
+        _controller.camera.zoom + delta,
+      );
+    } catch (_) {}
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final points = [
+      for (final p in widget.pins) LatLng(p.latitude!, p.longitude!),
+    ];
+
+    const interaction = InteractionOptions(
+      flags: InteractiveFlag.all & ~InteractiveFlag.scrollWheelZoom,
+    );
+    final options = points.length == 1
+        ? MapOptions(
+            initialCenter: points.first,
+            initialZoom: 13,
+            interactionOptions: interaction,
+          )
+        : MapOptions(
+            initialCameraFit: CameraFit.bounds(
+              bounds: LatLngBounds.fromPoints(points),
+              padding: const EdgeInsets.all(32),
+            ),
+            interactionOptions: interaction,
+          );
+
+    return ClipRRect(
+      borderRadius: AppRadius.mdAll,
+      child: SizedBox(
+        height: 240,
+        child: Stack(
+          children: [
+            FlutterMap(
+              mapController: _controller,
+              options: options,
+              children: [
+                TileLayer(
+                  urlTemplate: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+                  userAgentPackageName: 'com.travelrouteplanner.app',
+                ),
+                MarkerLayer(
+                  markers: [
+                    for (var i = 0; i < points.length; i++)
+                      Marker(
+                        point: points[i],
+                        width: 30,
+                        height: 30,
+                        child: _GuidePin(label: '${i + 1}'),
+                      ),
+                  ],
+                ),
+              ],
+            ),
+            Positioned(
+              right: 8,
+              bottom: 8,
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  _MapButton(icon: Icons.add, onTap: () => _zoomBy(1)),
+                  const SizedBox(height: AppSpacing.sm),
+                  _MapButton(icon: Icons.remove, onTap: () => _zoomBy(-1)),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// A numbered, local-accent map pin matching the trip map's pin look.
+class _GuidePin extends StatelessWidget {
+  final String label;
+
+  const _GuidePin({required this.label});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        color: AppColors.toolLocal,
+        shape: BoxShape.circle,
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withValues(alpha: 0.25),
+            blurRadius: 3,
+            offset: const Offset(0, 1),
+          ),
+        ],
+      ),
+      alignment: Alignment.center,
+      child: Text(
+        label,
+        style: const TextStyle(
+          color: Colors.white,
+          fontSize: 13,
+          fontWeight: FontWeight.bold,
+        ),
+      ),
+    );
+  }
+}
+
+/// Small circular zoom control, matching the trip map's overlay buttons.
+class _MapButton extends StatelessWidget {
+  final IconData icon;
+  final VoidCallback onTap;
+
+  const _MapButton({required this.icon, required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    return Material(
+      color: scheme.surface,
+      shape: const CircleBorder(),
+      elevation: 2,
+      child: InkWell(
+        customBorder: const CircleBorder(),
+        onTap: onTap,
+        child: SizedBox(
+          width: 36,
+          height: 36,
+          child: Icon(icon, size: 20, color: scheme.onSurface),
+        ),
+      ),
+    );
+  }
+}

--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -7,6 +7,7 @@ import '../models/trip.dart';
 import '../models/itinerary_item.dart';
 import '../models/accommodation.dart';
 import '../models/booking_todo.dart';
+import '../models/local_guide.dart';
 import '../models/location.dart';
 import '../models/location_timing.dart';
 import '../models/route_request.dart';
@@ -32,6 +33,7 @@ import '../widgets/status_pill.dart';
 import '../widgets/trip_map.dart';
 import '../widgets/trip_refine_panel.dart';
 import 'flight_search_screen.dart';
+import 'local_guide_detail_screen.dart';
 
 /// A geographic coordinate used to resolve an itinerary place to its nearest
 /// bookable airport when the place name has no IATA match.
@@ -872,7 +874,9 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
       child: Consumer(builder: (context, ref, _) {
         final recs =
             ref.watch(localRecsByCityProvider(label)).valueOrNull ?? [];
-        if (recs.isEmpty) return const SizedBox.shrink();
+        final guides =
+            ref.watch(localGuidesByCityProvider(label)).valueOrNull ?? [];
+        if (recs.isEmpty && guides.isEmpty) return const SizedBox.shrink();
         return Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
@@ -893,10 +897,69 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
                 ],
               ),
             ),
+            for (final g in guides) _guideChip(g, theme),
             for (final r in recs.take(6)) LocalRecCard(rec: r),
           ],
         );
       }),
+    );
+  }
+
+  /// A tappable "Local guide" row inside the Local intel section that opens the
+  /// full narrative guide (story + ordered pins + map).
+  Widget _guideChip(LocalGuide guide, ThemeData theme) {
+    final accent = AppColors.toolLocal;
+    return Card(
+      margin: const EdgeInsets.symmetric(vertical: AppSpacing.xs),
+      clipBehavior: Clip.antiAlias,
+      child: InkWell(
+        onTap: () => Navigator.of(context).push(MaterialPageRoute(
+              builder: (_) => LocalGuideDetailScreen(guide: guide),
+            )),
+        child: Padding(
+          padding: const EdgeInsets.all(AppSpacing.md),
+          child: Row(
+            children: [
+              Container(
+                padding: const EdgeInsets.all(AppSpacing.sm),
+                decoration: BoxDecoration(
+                  color: accent.withValues(alpha: 0.12),
+                  borderRadius: BorderRadius.circular(AppRadius.sm),
+                ),
+                child: Icon(Icons.menu_book, size: 20, color: accent),
+              ),
+              const SizedBox(width: AppSpacing.md),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      'Local guide: ${guide.title}',
+                      style: theme.textTheme.titleSmall
+                          ?.copyWith(fontWeight: FontWeight.w600),
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                    if (guide.sourceName.isNotEmpty) ...[
+                      const SizedBox(height: 2),
+                      Text(
+                        'By ${guide.sourceName}',
+                        style: theme.textTheme.bodySmall?.copyWith(
+                            color: accent, fontWeight: FontWeight.w600),
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ],
+                  ],
+                ),
+              ),
+              const SizedBox(width: AppSpacing.sm),
+              Icon(Icons.chevron_right,
+                  color: theme.colorScheme.onSurfaceVariant),
+            ],
+          ),
+        ),
+      ),
     );
   }
 

--- a/src/packages/flutter-app/lib/services/local_api_service.dart
+++ b/src/packages/flutter-app/lib/services/local_api_service.dart
@@ -66,6 +66,30 @@ class LocalApiService {
     );
   }
 
+  /// One published guide by [id], plus its ordered pins. The detail endpoint's
+  /// guide row omits the source attribution join, so callers that came from the
+  /// list should keep the list row's source fields for display.
+  Future<({LocalGuide guide, List<LocalRecommendation> recommendations})>
+      guideById(String id) async {
+    final uri = Uri.parse('${apiClient.baseUrl}/local/guides/$id');
+    final res = await apiClient.httpClient.get(uri, headers: _headers());
+    if (res.statusCode == 200) {
+      final body = jsonDecode(res.body) as Map<String, dynamic>;
+      final recs = (body['recommendations'] as List<dynamic>? ?? [])
+          .map((e) => LocalRecommendation.fromJson(e as Map<String, dynamic>))
+          .toList();
+      return (
+        guide: LocalGuide.fromJson(body['guide'] as Map<String, dynamic>),
+        recommendations: recs,
+      );
+    }
+    throw ApiException(
+      statusCode: res.statusCode,
+      message: 'Failed to load guide: ${res.body}',
+      endpoint: 'local/guides/$id',
+    );
+  }
+
   // --- admin / curation ------------------------------------------------------
 
   /// Lists the local sources (people) the curator can attribute content to.

--- a/src/packages/flutter-app/lib/widgets/place_search_dialog.dart
+++ b/src/packages/flutter-app/lib/widgets/place_search_dialog.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../models/location.dart';
 import '../models/place_search_result.dart';
-import '../models/place_autocomplete_result.dart';
 import '../providers/places_api_provider.dart';
 
 class PlaceSearchDialog extends ConsumerStatefulWidget {


### PR DESCRIPTION
## Summary

First UI surface for the published narrative local guides the backend already serves (`GET /api/v1/local/guides?city=` and `GET /api/v1/local/guides/{id}`). Flutter-only; no API changes.

- **New screen** `lib/screens/local_guide_detail_screen.dart` — one guide end to end: hero image (graceful branded fallback on load failure), title, neighborhood/city line, the local's byline with avatar (same attribution treatment as `LocalRecCard`), the narrative body, then the guide's pins in narrative order as `LocalRecCard`s, plus a lightweight OSM `FlutterMap` of every pin with coordinates (numbered in narrative order). Loading spinner while fetching; `EmptyState` with Retry on error.
- **Service** — added `LocalApiService.guideById(id)` returning the guide + its ordered pins. The detail endpoint's guide row omits the source-attribution join, so the screen keeps the list row's source fields as fallback (documented on the method).
- **Provider** — `localGuideDetailProvider` (`FutureProvider.family` by guide id) in `lib/providers/local_provider.dart`.
- **Entry point (trip detail)** — the per-city "Local intel" section (`_localIntelSliver`) now also watches `localGuidesByCityProvider(city)` and renders a tappable "Local guide: \<title\>" card (amber `toolLocal` accent, byline, chevron) that pushes `LocalGuideDetailScreen`. The section now appears when a city has guides even if it has no standalone recommendation pins. Change kept additive/minimal to reduce conflicts with concurrent Wave-4 branches touching `trip_detail_screen.dart`.
- **Drive-by fix** — removed a pre-existing unused import in `lib/widgets/place_search_dialog.dart` so `flutter analyze --fatal-warnings` exits 0.

## What was reused

- `LocalRecCard` for pin rendering (guide-pin rows parse cleanly into `LocalRecommendation`; extra fields ignored, missing bio/expertise default to empty).
- `GradientAppBar`, `EmptyState`, `AppColors.toolLocal`, `AppSpacing`/`AppRadius` theme tokens.
- `TripMap`'s conventions (OSM tile URL + user agent, scroll-wheel-zoom opt-out inside scrollables, overlay zoom buttons, pin styling) — but not `TripMap` itself, since its API is keyed to `ItineraryItem` (positions, categories, route polyline) which doesn't fit guide pins; a small purpose-built map is embedded instead.
- Existing `MaterialPageRoute` push style from `trip_detail_screen.dart`.

## Verification

- `flutter analyze --no-fatal-infos --fatal-warnings` exits 0.
- `flutter test` — all 23 tests pass.
- JSON shapes cross-checked against the Go handler (`local_public_handler.go`) and sqlc row structs (`store.LocalGuide`, `ListRecommendationsByGuideRow`): nullable `neighborhood`/`hero_image_url`/`latitude`/`longitude` are handled by the existing model defaults, and publish-gated pins always carry coordinates.

## Future work

- **Home-screen "Local guides" discover row** intentionally skipped: there is no list-all-guides endpoint (guides are only queryable per city), so a discover surface would require a new `GET /api/v1/local/guides` (no city) or coverage-driven endpoint first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)