### PR TITLE
feat: flight search depth — cabin class + child passengers

### DIFF
--- a/src/packages/api/duffel_service.go
+++ b/src/packages/api/duffel_service.go
@@ -74,7 +74,15 @@ type FlightSearchRequest struct {
 	DepartDate  string `json:"depart_date"` // YYYY-MM-DD
 	ReturnDate  string `json:"return_date,omitempty"`
 	Adults      int    `json:"adults"`
+	ChildAges   []int  `json:"child_ages,omitempty"` // one entry per child; Duffel requires an age
+	CabinClass  string `json:"cabin_class,omitempty"`
 	OptimizeFor string `json:"optimize_for"` // "cost" | "time" | "balanced"
+}
+
+// allowedCabinClasses are Duffel's cabin_class values; empty input defaults
+// to economy.
+var allowedCabinClasses = map[string]bool{
+	"economy": true, "premium_economy": true, "business": true, "first": true,
 }
 
 // maxOffers caps how many offers we keep from a Duffel search before ranking,
@@ -223,7 +231,8 @@ func (d *DuffelService) SearchFlightOffers(ctx context.Context, req FlightSearch
 		DepartureDate string `json:"departure_date"`
 	}
 	type passengerReq struct {
-		Type string `json:"type"`
+		Type string `json:"type,omitempty"`
+		Age  *int   `json:"age,omitempty"`
 	}
 	slices := []sliceReq{{
 		Origin:        strings.ToUpper(req.Origin),
@@ -237,15 +246,24 @@ func (d *DuffelService) SearchFlightOffers(ctx context.Context, req FlightSearch
 			DepartureDate: req.ReturnDate,
 		})
 	}
-	passengers := make([]passengerReq, adults)
-	for i := range passengers {
-		passengers[i] = passengerReq{Type: "adult"}
+	passengers := make([]passengerReq, 0, adults+len(req.ChildAges))
+	for i := 0; i < adults; i++ {
+		passengers = append(passengers, passengerReq{Type: "adult"})
+	}
+	// Duffel identifies non-adult passengers by age, not a type string.
+	for _, age := range req.ChildAges {
+		a := age
+		passengers = append(passengers, passengerReq{Age: &a})
+	}
+	cabin := strings.ToLower(strings.TrimSpace(req.CabinClass))
+	if cabin == "" {
+		cabin = "economy"
 	}
 	payload := map[string]any{
 		"data": map[string]any{
 			"slices":      slices,
 			"passengers":  passengers,
-			"cabin_class": "economy",
+			"cabin_class": cabin,
 		},
 	}
 	buf, err := json.Marshal(payload)

--- a/src/packages/api/duffel_service_test.go
+++ b/src/packages/api/duffel_service_test.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// stubDuffel captures the offer-request payload the service sends.
+func stubDuffel(t *testing.T, captured *map[string]any) *DuffelService {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		if err := json.Unmarshal(body, captured); err != nil {
+			t.Fatalf("stub could not parse request body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"data":{"offers":[]}}`))
+	}))
+	t.Cleanup(srv.Close)
+	return &DuffelService{
+		Token:   "test-token",
+		BaseURL: srv.URL,
+		Version: "v2",
+		Client:  &http.Client{Timeout: 5 * time.Second},
+	}
+}
+
+func TestSearchFlightOffersPassengerAndCabinPayload(t *testing.T) {
+	var captured map[string]any
+	d := stubDuffel(t, &captured)
+
+	_, err := d.SearchFlightOffers(context.Background(), FlightSearchRequest{
+		Origin: "bos", Destination: "cdg", DepartDate: "2026-09-01",
+		Adults: 2, ChildAges: []int{5, 9}, CabinClass: "Business",
+	})
+	if err != nil {
+		t.Fatalf("SearchFlightOffers: %v", err)
+	}
+
+	data := captured["data"].(map[string]any)
+	if got := data["cabin_class"]; got != "business" {
+		t.Fatalf("cabin_class = %v, want business (lowercased)", got)
+	}
+	passengers := data["passengers"].([]any)
+	if len(passengers) != 4 {
+		t.Fatalf("passengers = %d, want 4 (2 adults + 2 children)", len(passengers))
+	}
+	adults, children := 0, 0
+	for _, p := range passengers {
+		pm := p.(map[string]any)
+		switch {
+		case pm["type"] == "adult":
+			adults++
+		case pm["age"] != nil:
+			children++
+			if _, hasType := pm["type"]; hasType {
+				t.Fatal("child passenger must not carry a type field")
+			}
+		default:
+			t.Fatalf("unexpected passenger entry: %v", pm)
+		}
+	}
+	if adults != 2 || children != 2 {
+		t.Fatalf("adults=%d children=%d, want 2/2", adults, children)
+	}
+}
+
+func TestSearchFlightOffersDefaultsToEconomy(t *testing.T) {
+	var captured map[string]any
+	d := stubDuffel(t, &captured)
+
+	if _, err := d.SearchFlightOffers(context.Background(), FlightSearchRequest{
+		Origin: "BOS", Destination: "CDG", DepartDate: "2026-09-01", Adults: 1,
+	}); err != nil {
+		t.Fatalf("SearchFlightOffers: %v", err)
+	}
+	data := captured["data"].(map[string]any)
+	if got := data["cabin_class"]; got != "economy" {
+		t.Fatalf("cabin_class = %v, want economy default", got)
+	}
+	if got := len(data["passengers"].([]any)); got != 1 {
+		t.Fatalf("passengers = %d, want 1", got)
+	}
+}

--- a/src/packages/api/main.go
+++ b/src/packages/api/main.go
@@ -358,6 +358,21 @@ func flightsSearchHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if cc := strings.ToLower(strings.TrimSpace(request.CabinClass)); cc != "" && !allowedCabinClasses[cc] {
+		writeErr("cabin_class must be one of: 'economy', 'premium_economy', 'business', 'first'")
+		return
+	}
+	if len(request.ChildAges) > 8 {
+		writeErr("at most 8 children per search")
+		return
+	}
+	for _, age := range request.ChildAges {
+		if age < 0 || age > 17 {
+			writeErr("child_ages entries must be between 0 and 17")
+			return
+		}
+	}
+
 	offers, err := duffelService.SearchFlightOffers(r.Context(), request)
 	if err != nil {
 		w.Header().Set("Content-Type", "application/json")

--- a/src/packages/api/plan_handler.go
+++ b/src/packages/api/plan_handler.go
@@ -213,6 +213,8 @@ func planHandler(w http.ResponseWriter, r *http.Request) {
 				"depart_date":  map[string]any{"type": "string", "description": "YYYY-MM-DD"},
 				"return_date":  map[string]any{"type": "string", "description": "Optional YYYY-MM-DD for round trips"},
 				"adults":       map[string]any{"type": "integer", "description": "Optional, defaults to 1"},
+				"child_ages":   map[string]any{"type": "array", "items": map[string]any{"type": "integer"}, "description": "Optional ages of child travelers (one per child, 0-17) — include when the traveler mentions kids"},
+				"cabin_class":  map[string]any{"type": "string", "enum": []string{"economy", "premium_economy", "business", "first"}, "description": "Optional cabin, defaults to economy — set when the traveler asks for a specific class"},
 				"optimize_for": map[string]any{"type": "string", "enum": []string{"cost", "time", "balanced"}, "description": "Ranking emphasis"},
 			},
 			Required: []string{"origin", "destination", "depart_date"},
@@ -568,6 +570,8 @@ func planHandler(w http.ResponseWriter, r *http.Request) {
 					DepartDate  string `json:"depart_date"`
 					ReturnDate  string `json:"return_date"`
 					Adults      int    `json:"adults"`
+					ChildAges   []int  `json:"child_ages"`
+					CabinClass  string `json:"cabin_class"`
 					OptimizeFor string `json:"optimize_for"`
 				}
 				json.Unmarshal(variant.Input, &in)
@@ -587,7 +591,8 @@ func planHandler(w http.ResponseWriter, r *http.Request) {
 				}
 				offers, err := duffelService.SearchFlightOffers(ctx, FlightSearchRequest{
 					Origin: originIata, Destination: destIata, DepartDate: in.DepartDate,
-					ReturnDate: in.ReturnDate, Adults: adults, OptimizeFor: in.OptimizeFor,
+					ReturnDate: in.ReturnDate, Adults: adults, ChildAges: in.ChildAges,
+					CabinClass: in.CabinClass, OptimizeFor: in.OptimizeFor,
 				})
 				if err != nil {
 					sendSSE(w, "tool_result", map[string]string{"name": "search_flights"})

--- a/src/packages/flutter-app/lib/models/flight_search_request.dart
+++ b/src/packages/flutter-app/lib/models/flight_search_request.dart
@@ -11,6 +11,10 @@ class FlightSearchRequest {
   @JsonKey(name: 'return_date', includeIfNull: false)
   final String? returnDate;
   final int adults;
+  @JsonKey(name: 'child_ages', includeIfNull: false)
+  final List<int>? childAges; // one entry per child (0-17)
+  @JsonKey(name: 'cabin_class', includeIfNull: false)
+  final String? cabinClass; // economy | premium_economy | business | first
   @JsonKey(name: 'optimize_for')
   final String optimizeFor; // cost | time | balanced
 
@@ -20,6 +24,8 @@ class FlightSearchRequest {
     required this.departDate,
     this.returnDate,
     this.adults = 1,
+    this.childAges,
+    this.cabinClass,
     this.optimizeFor = 'balanced',
   });
 

--- a/src/packages/flutter-app/lib/models/flight_search_request.g.dart
+++ b/src/packages/flutter-app/lib/models/flight_search_request.g.dart
@@ -13,6 +13,10 @@ FlightSearchRequest _$FlightSearchRequestFromJson(Map<String, dynamic> json) =>
       departDate: json['depart_date'] as String,
       returnDate: json['return_date'] as String?,
       adults: (json['adults'] as num?)?.toInt() ?? 1,
+      childAges: (json['child_ages'] as List<dynamic>?)
+          ?.map((e) => (e as num).toInt())
+          .toList(),
+      cabinClass: json['cabin_class'] as String?,
       optimizeFor: json['optimize_for'] as String? ?? 'balanced',
     );
 
@@ -31,6 +35,8 @@ Map<String, dynamic> _$FlightSearchRequestToJson(FlightSearchRequest instance) {
 
   writeNotNull('return_date', instance.returnDate);
   val['adults'] = instance.adults;
+  writeNotNull('child_ages', instance.childAges);
+  writeNotNull('cabin_class', instance.cabinClass);
   val['optimize_for'] = instance.optimizeFor;
   return val;
 }

--- a/src/packages/flutter-app/lib/screens/flight_search_screen.dart
+++ b/src/packages/flutter-app/lib/screens/flight_search_screen.dart
@@ -44,7 +44,16 @@ class _FlightSearchScreenState extends ConsumerState<FlightSearchScreen> {
   Airport? _destination;
   DateTime? _departDate;
   int _adults = 1;
+  int _children = 0;
+  String _cabinClass = 'economy';
   String _optimizeFor = 'balanced';
+
+  static const _cabinLabels = {
+    'economy': 'Economy',
+    'premium_economy': 'Premium economy',
+    'business': 'Business',
+    'first': 'First',
+  };
 
   static const _presets = {
     'cost': 'Cheapest',
@@ -190,6 +199,11 @@ class _FlightSearchScreenState extends ConsumerState<FlightSearchScreen> {
           destination: _destination!.iataCode,
           departDate: _fmtDate(_departDate!),
           adults: _adults,
+          // Duffel needs an age per child; without a per-child age picker we
+          // send a mid-range child age for each.
+          childAges:
+              _children > 0 ? List.filled(_children, 8) : null,
+          cabinClass: _cabinClass == 'economy' ? null : _cabinClass,
           optimizeFor: _optimizeFor,
         ));
   }
@@ -239,10 +253,35 @@ class _FlightSearchScreenState extends ConsumerState<FlightSearchScreen> {
                     ),
                     const SizedBox(width: 12),
                     _PassengerStepper(
-                      adults: _adults,
+                      icon: Icons.person_outline,
+                      count: _adults,
+                      min: 1,
                       onChanged: (v) => setState(() => _adults = v),
                     ),
+                    const SizedBox(width: 8),
+                    _PassengerStepper(
+                      icon: Icons.child_care_outlined,
+                      count: _children,
+                      min: 0,
+                      onChanged: (v) => setState(() => _children = v),
+                    ),
                   ],
+                ),
+                const SizedBox(height: 12),
+                Align(
+                  alignment: Alignment.centerLeft,
+                  child: Wrap(
+                    spacing: 8,
+                    children: [
+                      for (final e in _cabinLabels.entries)
+                        ChoiceChip(
+                          label: Text(e.value),
+                          selected: _cabinClass == e.key,
+                          onSelected: (_) =>
+                              setState(() => _cabinClass = e.key),
+                        ),
+                    ],
+                  ),
                 ),
                 const SizedBox(height: 12),
                 SegmentedButton<String>(
@@ -382,9 +421,16 @@ class _Hint extends StatelessWidget {
 }
 
 class _PassengerStepper extends StatelessWidget {
-  final int adults;
+  final IconData icon;
+  final int count;
+  final int min;
   final ValueChanged<int> onChanged;
-  const _PassengerStepper({required this.adults, required this.onChanged});
+  const _PassengerStepper({
+    required this.icon,
+    required this.count,
+    required this.min,
+    required this.onChanged,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -396,16 +442,20 @@ class _PassengerStepper extends StatelessWidget {
       child: Row(
         mainAxisSize: MainAxisSize.min,
         children: [
+          Padding(
+            padding: const EdgeInsets.only(left: 6),
+            child: Icon(icon, size: 16),
+          ),
           IconButton(
             icon: const Icon(Icons.remove, size: 18),
-            onPressed: adults > 1 ? () => onChanged(adults - 1) : null,
+            onPressed: count > min ? () => onChanged(count - 1) : null,
             visualDensity: VisualDensity.compact,
           ),
-          Text('$adults',
+          Text('$count',
               style: const TextStyle(fontWeight: FontWeight.bold)),
           IconButton(
             icon: const Icon(Icons.add, size: 18),
-            onPressed: adults < 9 ? () => onChanged(adults + 1) : null,
+            onPressed: count < 8 ? () => onChanged(count + 1) : null,
             visualDensity: VisualDensity.compact,
           ),
         ],


### PR DESCRIPTION
## Summary
Wave 4 item #6. Duffel flight search was hardcoded `"cabin_class": "economy"` with adults-only passengers — results never matched real travel parties. Now cabin class and children flow end-to-end: REST API, the AI agent's `search_flights` tool, and the flight search screen.

- **Go**: `FlightSearchRequest` += `cabin_class` (validated against Duffel's four cabins, empty → economy) and `child_ages []int` (Duffel identifies non-adult passengers by age, not a type string; validated 0–17, max 8). Threaded through `flightsSearchHandler` and the `/plan` agent tool schema + execution, so "find business-class flights for 2 adults and 2 kids" works in chat.
- **Flutter**: model + `.g.dart` regenerated; search screen gains an adults/children stepper pair and a cabin-class chip row. Children send a mid-range age (8) per child until a per-child age picker exists — noted in code.

### Scope note
The roadmap's "outbound click tracking" add-on was intentionally dropped from this PR: the untracked draft `specs/instrumentation-events/spec.md` specs a full first-party event log (server events + client `booking_link_clicked` + admin metrics) that supersedes a one-off `outbound_clicks` table. That should be implemented as its own feature following that spec, rather than shipping a conflicting half-measure here.

## Verification
New unit tests point `DuffelService` at a stub HTTP server and assert on the **actual offer-request payload**: 2 adults + ages [5, 9] → 4 passengers (typed adults, age-only children), `cabin_class` lowercased to `business`; default request stays economy with 1 adult. `gofmt`/`vet`/`go test` and `flutter analyze`/`test` (23/23) green. Not exercised against the live Duffel sandbox (no token in this environment) — worth one manual search after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)