### PR TITLE
feat: per-child age picker in flight search

### DIFF
--- a/src/packages/api/duffel_service_test.go
+++ b/src/packages/api/duffel_service_test.go
@@ -50,14 +50,15 @@ func TestSearchFlightOffersPassengerAndCabinPayload(t *testing.T) {
 	if len(passengers) != 4 {
 		t.Fatalf("passengers = %d, want 4 (2 adults + 2 children)", len(passengers))
 	}
-	adults, children := 0, 0
+	adults := 0
+	var childAges []int
 	for _, p := range passengers {
 		pm := p.(map[string]any)
 		switch {
 		case pm["type"] == "adult":
 			adults++
 		case pm["age"] != nil:
-			children++
+			childAges = append(childAges, int(pm["age"].(float64)))
 			if _, hasType := pm["type"]; hasType {
 				t.Fatal("child passenger must not carry a type field")
 			}
@@ -65,8 +66,12 @@ func TestSearchFlightOffersPassengerAndCabinPayload(t *testing.T) {
 			t.Fatalf("unexpected passenger entry: %v", pm)
 		}
 	}
-	if adults != 2 || children != 2 {
-		t.Fatalf("adults=%d children=%d, want 2/2", adults, children)
+	if adults != 2 {
+		t.Fatalf("adults=%d, want 2", adults)
+	}
+	// Each child must carry its own distinct age through to Duffel.
+	if len(childAges) != 2 || childAges[0] != 5 || childAges[1] != 9 {
+		t.Fatalf("child ages = %v, want [5 9]", childAges)
 	}
 }
 

--- a/src/packages/flutter-app/lib/screens/flight_search_screen.dart
+++ b/src/packages/flutter-app/lib/screens/flight_search_screen.dart
@@ -44,8 +44,14 @@ class _FlightSearchScreenState extends ConsumerState<FlightSearchScreen> {
   Airport? _destination;
   DateTime? _departDate;
   int _adults = 1;
-  int _children = 0;
+
+  /// One entry per child passenger; the value is the child's age (0–17).
+  /// Duffel prices children by real age, so each child gets its own picker.
+  final List<int> _childAges = [];
   String _cabinClass = 'economy';
+
+  /// Age a newly added child starts at before the traveler adjusts it.
+  static const _defaultChildAge = 8;
   String _optimizeFor = 'balanced';
 
   static const _cabinLabels = {
@@ -199,10 +205,7 @@ class _FlightSearchScreenState extends ConsumerState<FlightSearchScreen> {
           destination: _destination!.iataCode,
           departDate: _fmtDate(_departDate!),
           adults: _adults,
-          // Duffel needs an age per child; without a per-child age picker we
-          // send a mid-range child age for each.
-          childAges:
-              _children > 0 ? List.filled(_children, 8) : null,
+          childAges: _childAges.isEmpty ? null : List.of(_childAges),
           cabinClass: _cabinClass == 'economy' ? null : _cabinClass,
           optimizeFor: _optimizeFor,
         ));
@@ -261,12 +264,52 @@ class _FlightSearchScreenState extends ConsumerState<FlightSearchScreen> {
                     const SizedBox(width: 8),
                     _PassengerStepper(
                       icon: Icons.child_care_outlined,
-                      count: _children,
+                      count: _childAges.length,
                       min: 0,
-                      onChanged: (v) => setState(() => _children = v),
+                      onChanged: (v) => setState(() {
+                        while (_childAges.length < v) {
+                          _childAges.add(_defaultChildAge);
+                        }
+                        while (_childAges.length > v) {
+                          _childAges.removeLast();
+                        }
+                      }),
                     ),
                   ],
                 ),
+                if (_childAges.isNotEmpty) ...[
+                  const SizedBox(height: 12),
+                  Align(
+                    alignment: Alignment.centerLeft,
+                    child: Wrap(
+                      spacing: 12,
+                      runSpacing: 8,
+                      crossAxisAlignment: WrapCrossAlignment.center,
+                      children: [
+                        Text('Child ages',
+                            style: theme.textTheme.bodySmall?.copyWith(
+                                color: theme.colorScheme.onSurfaceVariant)),
+                        for (var i = 0; i < _childAges.length; i++)
+                          DropdownButton<int>(
+                            value: _childAges[i],
+                            isDense: true,
+                            items: [
+                              for (var age = 0; age <= 17; age++)
+                                DropdownMenuItem(
+                                  value: age,
+                                  child: Text('$age'),
+                                ),
+                            ],
+                            onChanged: (age) {
+                              if (age != null) {
+                                setState(() => _childAges[i] = age);
+                              }
+                            },
+                          ),
+                      ],
+                    ),
+                  ),
+                ],
                 const SizedBox(height: 12),
                 Align(
                   alignment: Alignment.centerLeft,


### PR DESCRIPTION
## Summary

Flight search was faking child ages — the screen kept only a child *count* and sent `List.filled(_children, 8)`, so every child was priced as an 8-year-old even though Duffel prices by real age.

- `flight_search_screen.dart`: replaced the `_children` int with `final List<int> _childAges`. The children stepper drives the list (add appends the default age 8, remove pops the last). When non-empty, a compact "Child ages" `Wrap` of per-child `DropdownButton<int>` (0–17) renders directly under the passenger stepper row. `_search()` sends `childAges: _childAges.isEmpty ? null : List.of(_childAges)`.
- `duffel_service_test.go`: the stub-server test previously only counted children and checked each had *some* age; it now asserts the distinct ages `[5, 9]` are forwarded per child in order.
- No model or API changes — `child_ages` already flows end-to-end (`FlightSearchRequest.childAges` in Dart, Go validation 0–17 / max 8).

No spec: this is a small UI change completing the already-spec'd flight search feature.

## Verification

- `flutter analyze --no-fatal-infos --fatal-warnings` — clean (exit 0; no lints in the touched file)
- `flutter test` — all 26 tests pass
- `go vet ./...`, `gofmt -l` — clean
- `go test -run TestSearchFlightOffers ./...` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)