### PR TITLE
feat: path-style web URLs with legacy hash-link shim

### DIFF
--- a/dockerize/deployment/Dockerfile
+++ b/dockerize/deployment/Dockerfile
@@ -33,7 +33,8 @@ RUN dart run build_runner build --delete-conflicting-outputs
 RUN flutter build web --release \
     --web-renderer canvaskit \
     --base-href /app/ \
-    --dart-define=API_BASE_URL=/api/v1
+    --dart-define=API_BASE_URL=/api/v1 \
+    --dart-define=APP_BASE_PATH=/app/
 
 # Serve static files and proxy API via nginx
 FROM nginx:alpine

--- a/src/packages/flutter-app/lib/main.dart
+++ b/src/packages/flutter-app/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_web_plugins/url_strategy.dart';
 import 'constants/app_info.dart';
 import 'providers/auth_provider.dart';
 import 'theme/app_theme.dart';
@@ -10,6 +11,10 @@ import 'screens/shared_trip_screen.dart';
 import 'screens/splash_screen.dart';
 
 void main() {
+  // Path-style URLs on web (https://host/app/share/x instead of /#/share/x).
+  // The engine strips the base href before routing, so onGenerateRoute sees
+  // clean paths in both dev (/) and deployment (/app/). No-op off web.
+  usePathUrlStrategy();
   runApp(
     const ProviderScope(
       child: TravelRoutePlannerApp(),
@@ -26,9 +31,9 @@ class TravelRoutePlannerApp extends StatelessWidget {
       title: AppInfo.name,
       debugShowCheckedModeBanner: false,
       theme: AppTheme.light,
-      // Route by URL so share links work signed-out (Flutter web hash URLs:
-      // https://host/#/share/<token>). Everything else lands on AuthGate,
-      // preserving the existing splash -> landing/quiz/shell flow.
+      // Route by URL so share links work signed-out. Everything else lands
+      // on AuthGate, preserving the existing splash -> landing/quiz/shell
+      // flow. Legacy /#/share links are rewritten by the index.html shim.
       onGenerateRoute: (settings) {
         final uri = Uri.tryParse(settings.name ?? '/');
         final segments = uri?.pathSegments ?? const <String>[];

--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -669,8 +669,14 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
     }
   }
 
+  /// Where the app is mounted on its host: '/' in dev, '/app/' in the
+  /// deployment build (set via --dart-define, like API_BASE_URL). Dart can't
+  /// portably read the base href, so the build injects it.
+  static const _appBasePath =
+      String.fromEnvironment('APP_BASE_PATH', defaultValue: '/');
+
   /// Mints (or reuses) the trip's share link and copies it to the clipboard.
-  /// Flutter web uses hash URLs, so the shareable form is origin + /#/share/….
+  /// Path-style form: origin + basePath + share/<token>.
   Future<void> _shareLink() async {
     try {
       final token = await ref
@@ -682,7 +688,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
       } catch (_) {
         origin = ''; // non-http platform; copy a relative link
       }
-      final url = '$origin/#/share/$token';
+      final url = '$origin${_appBasePath}share/$token';
       await Clipboard.setData(ClipboardData(text: url));
       _showSnack('Share link copied to clipboard');
     } catch (e) {

--- a/src/packages/flutter-app/pubspec.lock
+++ b/src/packages/flutter-app/pubspec.lock
@@ -340,7 +340,7 @@ packages:
     source: sdk
     version: "0.0.0"
   flutter_web_plugins:
-    dependency: transitive
+    dependency: "direct main"
     description: flutter
     source: sdk
     version: "0.0.0"

--- a/src/packages/flutter-app/pubspec.yaml
+++ b/src/packages/flutter-app/pubspec.yaml
@@ -30,6 +30,9 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  # Path-style web URLs (usePathUrlStrategy in main.dart).
+  flutter_web_plugins:
+    sdk: flutter
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.

--- a/src/packages/flutter-app/web/index.html
+++ b/src/packages/flutter-app/web/index.html
@@ -16,6 +16,17 @@
   -->
   <base href="$FLUTTER_BASE_HREF">
 
+  <!-- Legacy hash-URL shim: pre-path-strategy links look like /#/share/abc.
+       Rewrite them to the real path (base-href aware) before the Flutter
+       engine reads the URL, so old links in chats and emails keep working. -->
+  <script>
+    if (location.hash.startsWith('#/')) {
+      var base = document.querySelector('base').getAttribute('href') || '/';
+      history.replaceState(null, '',
+          base.replace(/\/$/, '') + location.hash.slice(1) + location.search);
+    }
+  </script>
+
   <meta charset="UTF-8">
   <meta content="IE=Edge" http-equiv="X-UA-Compatible">
   <meta name="description" content="Golden Tempo Travel - Plan trips, optimize routes, and build itineraries with AI.">


### PR DESCRIPTION
## Summary
Wave 5 item #1 — foundation for the rest of the wave (reset/verify deep links, OG previews, collab invites all want clean URLs). Share links change from `https://host/#/share/<token>` to `https://host/app/share/<token>`.

- `usePathUrlStrategy()` at app start (`flutter_web_plugins`, SDK package — no new external dep). Flutter strips the base href before routing, so the existing `onGenerateRoute` parsing is untouched.
- **Legacy links keep working**: an inline `<head>` shim rewrites `/#/path` → base-href-aware real path via `history.replaceState` before the engine boots — old links in chats/emails land correctly in both dev (`/`) and deployment (`/app/`).
- Link builder now uses `String.fromEnvironment('APP_BASE_PATH')` (same pattern as `API_BASE_URL`); deployment Dockerfile passes `/app/`.
- No nginx changes: deployment `try_files … /app/index.html` is already deep-link-safe.

## Verification
- `flutter analyze` exit 0, all 26 tests pass, `flutter build web` succeeds with the shim present in the built `index.html`.
- Dev deep-path check: `curl localhost:3000/share/xyz` → 200 serving index.html (Flutter dev server falls back correctly through the nginx proxy).
- Full browser round-trip (open path link, refresh, legacy-hash link) will be exercised again in the collab-Flutter PR's two-user test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)