### PR TITLE
feat: local guides discover row on home + list-all guides endpoint

### DIFF
--- a/specs/guides-discover-row/spec.md
+++ b/specs/guides-discover-row/spec.md
@@ -1,0 +1,61 @@
+# Spec: Local Guides Discover Row
+
+## Context
+
+Published narrative guides (authored by named locals) are only reachable today
+from within a trip's city-scoped "Local intel" section — a traveler who hasn't
+started a trip for that city never sees them. The home screen should surface
+the newest published guides across **all** cities as a horizontal discover row,
+giving the locally-sourced content layer a front door and a browse entry point
+into `LocalGuideDetailScreen`.
+
+## User Stories
+
+- As a **traveler**, I want to see recent local guides on the home screen so
+  that I can discover locally-sourced trip ideas before I've planned anything.
+- As a **traveler**, I want to tap a guide card and read the full guide (story,
+  byline, pinned places, map) so that discovery flows straight into content.
+
+## Acceptance Criteria
+
+- [ ] The home screen shows a "Local guides" section between the recent-trip
+      card and the "Planning toolkit" tile: a section header plus a
+      horizontally scrollable row of guide cards.
+- [ ] Each card shows the guide's hero image (branded fallback when missing or
+      broken), title, city, and the local's name; tapping it opens the existing
+      guide detail screen.
+- [ ] The section shows guides from **multiple cities**, newest first, capped
+      at 20.
+- [ ] When there are no published guides, or the request is loading or fails,
+      the entire section (header included) renders nothing — the home screen
+      looks exactly as it did before this feature.
+- [ ] Only `published` guides ever appear; drafts never leak.
+
+## API Surface
+
+### `GET /api/v1/local/guides` — contract parity
+
+The `city` query parameter is now **optional** (it previously returned
+`400 city is required` when blank).
+
+- **`?city=<name>` (unchanged, backward compatible):** published guides for
+  that city, newest first, with source attribution — exactly the prior
+  behavior and response shape.
+- **No / blank `city` (new):** the newest published guides across all cities,
+  capped at 20, same row shape (guide fields + `source_name` /
+  `source_photo_url`). Response is `{"city": "", "guides": [...]}`.
+- **Degraded mode (no DB):** `{"city": "", "guides": []}` with 200, unchanged.
+- **Errors:** 500 on a query failure; the blank-city 400 is removed.
+
+## Data Model
+
+No schema changes. Adds one read query (`ListPublishedGuides`): all
+`status = 'published'` rows of `local_guides` joined with `local_sources`
+attribution (same join as the per-city list), ordered `created_at DESC`,
+limited by parameter.
+
+## Out of Scope
+
+- Pagination / "see all guides" screen.
+- Personalization (ordering by traveler preferences or profile).
+- Any change to the per-city guide list, guide detail, or admin curation flows.

--- a/src/packages/api/local_public_handler.go
+++ b/src/packages/api/local_public_handler.go
@@ -30,7 +30,13 @@ func localRecommendationsHandler(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]any{"city": city, "recommendations": recs})
 }
 
+// maxDiscoverGuides caps the cross-city guide list served when no ?city=
+// filter is given (the home-screen discover row).
+const maxDiscoverGuides = 20
+
 // GET /api/v1/local/guides?city=
+// city is optional: when present, returns that city's published guides; when
+// blank, returns the newest published guides across all cities (capped).
 func localGuidesHandler(w http.ResponseWriter, r *http.Request) {
 	if dbPool == nil {
 		writeJSON(w, http.StatusOK, map[string]any{"city": "", "guides": []any{}})
@@ -38,7 +44,15 @@ func localGuidesHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	city := strings.TrimSpace(r.URL.Query().Get("city"))
 	if city == "" {
-		writeJSONError(w, http.StatusBadRequest, "city is required")
+		guides, err := store.New(dbPool).ListPublishedGuides(r.Context(), maxDiscoverGuides)
+		if err != nil {
+			writeJSONError(w, http.StatusInternalServerError, "could not load guides")
+			return
+		}
+		if guides == nil {
+			guides = []store.ListPublishedGuidesRow{}
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"city": "", "guides": guides})
 		return
 	}
 	guides, err := store.New(dbPool).ListPublishedGuidesByCity(r.Context(), city)

--- a/src/packages/api/query/local.sql
+++ b/src/packages/api/query/local.sql
@@ -105,6 +105,16 @@ JOIN local_sources s ON s.id = g.source_id
 WHERE g.city ILIKE $1 AND g.status = 'published'
 ORDER BY g.created_at DESC;
 
+-- name: ListPublishedGuides :many
+-- Cross-city discover list (home screen row): newest published guides first,
+-- with the same source attribution join as ListPublishedGuidesByCity.
+SELECT g.*, s.name AS source_name, s.photo_url AS source_photo_url
+FROM local_guides g
+JOIN local_sources s ON s.id = g.source_id
+WHERE g.status = 'published'
+ORDER BY g.created_at DESC
+LIMIT $1;
+
 -- name: LinkGuideRecommendation :exec
 INSERT INTO local_guide_recommendations (guide_id, recommendation_id, position)
 VALUES ($1, $2, $3)

--- a/src/packages/api/store/local.sql.go
+++ b/src/packages/api/store/local.sql.go
@@ -433,6 +433,65 @@ func (q *Queries) ListLocalSources(ctx context.Context) ([]LocalSource, error) {
 	return items, nil
 }
 
+const listPublishedGuides = `-- name: ListPublishedGuides :many
+SELECT g.id, g.source_id, g.title, g.city, g.neighborhood, g.body, g.hero_image_url, g.status, g.created_at, g.updated_at, s.name AS source_name, s.photo_url AS source_photo_url
+FROM local_guides g
+JOIN local_sources s ON s.id = g.source_id
+WHERE g.status = 'published'
+ORDER BY g.created_at DESC
+LIMIT $1
+`
+
+type ListPublishedGuidesRow struct {
+	ID             uuid.UUID `json:"id"`
+	SourceID       uuid.UUID `json:"source_id"`
+	Title          string    `json:"title"`
+	City           string    `json:"city"`
+	Neighborhood   *string   `json:"neighborhood"`
+	Body           string    `json:"body"`
+	HeroImageUrl   *string   `json:"hero_image_url"`
+	Status         string    `json:"status"`
+	CreatedAt      time.Time `json:"created_at"`
+	UpdatedAt      time.Time `json:"updated_at"`
+	SourceName     string    `json:"source_name"`
+	SourcePhotoUrl *string   `json:"source_photo_url"`
+}
+
+// Cross-city discover list (home screen row): newest published guides first,
+// with the same source attribution join as ListPublishedGuidesByCity.
+func (q *Queries) ListPublishedGuides(ctx context.Context, limit int32) ([]ListPublishedGuidesRow, error) {
+	rows, err := q.db.Query(ctx, listPublishedGuides, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListPublishedGuidesRow
+	for rows.Next() {
+		var i ListPublishedGuidesRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.SourceID,
+			&i.Title,
+			&i.City,
+			&i.Neighborhood,
+			&i.Body,
+			&i.HeroImageUrl,
+			&i.Status,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+			&i.SourceName,
+			&i.SourcePhotoUrl,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listPublishedGuidesByCity = `-- name: ListPublishedGuidesByCity :many
 SELECT g.id, g.source_id, g.title, g.city, g.neighborhood, g.body, g.hero_image_url, g.status, g.created_at, g.updated_at, s.name AS source_name, s.photo_url AS source_photo_url
 FROM local_guides g

--- a/src/packages/flutter-app/lib/providers/local_provider.dart
+++ b/src/packages/flutter-app/lib/providers/local_provider.dart
@@ -25,6 +25,12 @@ final localGuidesByCityProvider =
   return service.guides(city.trim());
 });
 
+/// Newest published guides across all cities (home-screen discover row).
+final allGuidesProvider = FutureProvider<List<LocalGuide>>((ref) async {
+  final service = ref.watch(localApiServiceProvider);
+  return service.guides();
+});
+
 /// One published guide plus its ordered pins, keyed by guide id.
 final localGuideDetailProvider = FutureProvider.family<
     ({LocalGuide guide, List<LocalRecommendation> recommendations}),

--- a/src/packages/flutter-app/lib/screens/home_screen.dart
+++ b/src/packages/flutter-app/lib/screens/home_screen.dart
@@ -2,19 +2,24 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
 import '../constants/app_info.dart';
+import '../models/local_guide.dart';
 import '../providers/auth_provider.dart';
+import '../providers/local_provider.dart';
 import '../providers/plan_provider.dart';
 import '../providers/recent_trip_provider.dart';
 import '../navigation/app_nav.dart';
 import '../theme/app_colors.dart';
+import '../theme/app_shadows.dart';
 import '../theme/spacing.dart';
 import '../widgets/account_menu.dart';
 import '../widgets/brand_logo.dart';
 import '../widgets/gradient_app_bar.dart';
 import '../widgets/page_container.dart';
+import '../widgets/section_header.dart';
 import 'route_optimizer_screen.dart';
 import 'airbnb_parser_screen.dart';
 import 'flight_search_screen.dart';
+import 'local_guide_detail_screen.dart';
 import 'trip_detail_screen.dart';
 
 /// Time-of-day greeting for the home header.
@@ -107,6 +112,12 @@ class HomeScreen extends ConsumerWidget {
                   ),
                   const SizedBox(height: 16),
                 ],
+
+                // Local guides discover row — published narrative guides
+                // across all cities. Renders nothing while loading, on
+                // error, or when there are none, so the section (header
+                // included) only appears when there is something to show.
+                const _LocalGuidesRow(),
 
                 // Remaining manual tools, collapsed by default.
                 Card(
@@ -445,6 +456,159 @@ class _RecentTripCard extends StatelessWidget {
           ),
         ),
       ),
+    );
+  }
+}
+
+/// Horizontal discover row of published local guides across all cities.
+/// Collapses to nothing (header included) while loading, on error, or when
+/// no guides are published yet — the home screen just reads as before.
+class _LocalGuidesRow extends ConsumerWidget {
+  const _LocalGuidesRow();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final guides = ref.watch(allGuidesProvider).maybeWhen(
+          data: (g) => g,
+          orElse: () => const <LocalGuide>[],
+        );
+    if (guides.isEmpty) return const SizedBox.shrink();
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        const SectionHeader(title: 'Local guides'),
+        const SizedBox(height: AppSpacing.md),
+        SizedBox(
+          height: 190,
+          child: ListView.separated(
+            scrollDirection: Axis.horizontal,
+            // Room below the cards so their drop shadow isn't clipped by
+            // the horizontal viewport.
+            padding: const EdgeInsets.only(bottom: AppSpacing.sm),
+            itemCount: guides.length,
+            separatorBuilder: (_, __) =>
+                const SizedBox(width: AppSpacing.md),
+            itemBuilder: (context, i) => _GuideCard(guide: guides[i]),
+          ),
+        ),
+        const SizedBox(height: AppSpacing.lg),
+      ],
+    );
+  }
+}
+
+/// One tappable guide card in the discover row: hero image (branded fallback
+/// when missing/broken), title, city, and the local's byline.
+class _GuideCard extends StatelessWidget {
+  final LocalGuide guide;
+
+  const _GuideCard({required this.guide});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final accent = AppColors.toolLocal;
+
+    return Container(
+      width: 230,
+      clipBehavior: Clip.antiAlias,
+      decoration: BoxDecoration(
+        color: theme.colorScheme.surface,
+        borderRadius: AppRadius.mdAll,
+        boxShadow: AppShadows.soft,
+      ),
+      child: Material(
+        color: Colors.transparent,
+        child: InkWell(
+          onTap: () => Navigator.of(context).push(
+            MaterialPageRoute(
+              builder: (_) => LocalGuideDetailScreen(guide: guide),
+            ),
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              SizedBox(
+                height: 88,
+                width: double.infinity,
+                child: guide.heroImageUrl.isNotEmpty
+                    ? Image.network(
+                        guide.heroImageUrl,
+                        fit: BoxFit.cover,
+                        errorBuilder: (_, __, ___) =>
+                            const _GuideImageFallback(),
+                      )
+                    : const _GuideImageFallback(),
+              ),
+              Expanded(
+                child: Padding(
+                  padding: const EdgeInsets.all(AppSpacing.md),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        guide.title,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: theme.textTheme.titleSmall?.copyWith(
+                          fontWeight: FontWeight.bold,
+                          color: theme.colorScheme.onSurface,
+                        ),
+                      ),
+                      if (guide.city.isNotEmpty) ...[
+                        const SizedBox(height: AppSpacing.xs),
+                        Text(
+                          guide.city,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: theme.textTheme.bodySmall?.copyWith(
+                            color: theme.colorScheme.onSurfaceVariant,
+                          ),
+                        ),
+                      ],
+                      const Spacer(),
+                      if (guide.sourceName.isNotEmpty)
+                        Row(
+                          children: [
+                            Icon(Icons.verified, size: 14, color: accent),
+                            const SizedBox(width: AppSpacing.xs),
+                            Expanded(
+                              child: Text(
+                                'By ${guide.sourceName}',
+                                maxLines: 1,
+                                overflow: TextOverflow.ellipsis,
+                                style: theme.textTheme.labelSmall?.copyWith(
+                                  color: accent,
+                                  fontWeight: FontWeight.w600,
+                                ),
+                              ),
+                            ),
+                          ],
+                        ),
+                    ],
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Branded placeholder for a guide card whose hero image is missing or fails
+/// to load — same treatment as the detail screen's hero fallback.
+class _GuideImageFallback extends StatelessWidget {
+  const _GuideImageFallback();
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(gradient: AppColors.brandGradient),
+      alignment: Alignment.center,
+      child: const Icon(Icons.menu_book, size: 28, color: Colors.white70),
     );
   }
 }

--- a/src/packages/flutter-app/lib/services/local_api_service.dart
+++ b/src/packages/flutter-app/lib/services/local_api_service.dart
@@ -47,10 +47,14 @@ class LocalApiService {
     );
   }
 
-  /// Published narrative guides for [city].
-  Future<List<LocalGuide>> guides(String city) async {
-    final uri = Uri.parse('${apiClient.baseUrl}/local/guides')
-        .replace(queryParameters: {'city': city});
+  /// Published narrative guides. With a [city] this returns that city's
+  /// guides; with none (null/blank) the server returns the newest published
+  /// guides across all cities (the home-screen discover row).
+  Future<List<LocalGuide>> guides([String? city]) async {
+    var uri = Uri.parse('${apiClient.baseUrl}/local/guides');
+    if (city != null && city.trim().isNotEmpty) {
+      uri = uri.replace(queryParameters: {'city': city.trim()});
+    }
     final res = await apiClient.httpClient.get(uri, headers: _headers());
     if (res.statusCode == 200) {
       final body = jsonDecode(res.body) as Map<String, dynamic>;


### PR DESCRIPTION
## Summary
- **API**: `GET /api/v1/local/guides` — the `city` query param is now optional. Blank/absent `city` returns the newest **published** guides across all cities (capped at 20) via a new `ListPublishedGuides` sqlc query, with the same source-attribution join and row shape as the per-city list. The `?city=` path is byte-for-byte unchanged (backward compatible); the blank-city 400 is removed. Degraded mode (no DB) still returns `{"city":"","guides":[]}`.
- **Flutter**: `LocalApiService.guides()` city is now optional (query param omitted when null/blank); new plain `allGuidesProvider`; home screen gains a "Local guides" section between the recent-trip card and the Planning toolkit — `SectionHeader` + horizontal row of tappable cards (hero image with branded fallback, title, city, local's byline) pushing the existing `LocalGuideDetailScreen`. The whole section renders `SizedBox.shrink()` while loading, on error, or when empty.
- **Spec**: `specs/guides-discover-row/spec.md` (context, acceptance criteria, contract parity).

## Verification
- `gofmt -l` clean, `go vet ./...` clean, `go test ./...` green (src/packages/api).
- `flutter analyze --no-fatal-infos --fatal-warnings` exit 0 (only pre-existing deprecation infos), `flutter test` all 26 passing.
- Live check against dev Postgres (`travel_planner`): built the binary, ran on PORT=18091 with `DATABASE_URL` set; `/health` reported `database: ok`.
  - `GET /api/v1/local/guides` → `200 {"city":"","guides":[]}` (previously 400)
  - `GET /api/v1/local/guides?city=Athens` → `200 {"city":"Athens","guides":[]}` (unchanged)
  - No published guides exist in the shared dev DB, so only the empty-array shape was verified (no test data created, per Wave 5 rules).

🤖 Generated with [Claude Code](https://claude.com/claude-code)