### PR TITLE
feat: OG link previews for shared trips

### DIFF
--- a/dockerize/deployment/nginx/default.conf
+++ b/dockerize/deployment/nginx/default.conf
@@ -1,3 +1,11 @@
+# Link-preview crawlers don't run JS, so shared-trip pages would preview
+# blank. Bot UAs on /app/share/* get rewritten to the API's OG-tag page;
+# humans get the SPA as usual.
+map $http_user_agent $share_prerender {
+    default 0;
+    ~*(facebookexternalhit|twitterbot|slackbot|linkedinbot|whatsapp|telegrambot|discordbot|skypeuripreview|pinterest|embedly|iframely|googlebot|bingbot) 1;
+}
+
 server {
     listen 80;
     server_name localhost;
@@ -14,6 +22,20 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # Must precede the generic /app/ block. `if` here is the documented-safe
+    # rewrite-only form; `last` re-enters location matching and lands in the
+    # /api/ proxy above. Headers repeated: nested blocks don't inherit
+    # add_header from siblings.
+    location ~ ^/app/share/ {
+        if ($share_prerender) {
+            rewrite ^/app/share/(.*)$ /api/v1/share-preview/$1 last;
+        }
+        try_files $uri /app/index.html;
+
+        add_header Cross-Origin-Embedder-Policy require-corp;
+        add_header Cross-Origin-Opener-Policy same-origin;
     }
 
     location /app/ {

--- a/src/packages/api/main.go
+++ b/src/packages/api/main.go
@@ -624,6 +624,9 @@ func main() {
 	// else; it is the one endpoint deliberately open to anonymous strangers.
 	api.HandleFunc("/shared/{token}", sharedTripHandler).Methods("GET")
 	api.Handle("/shared/{token}/duplicate", authMiddleware(http.HandlerFunc(duplicateSharedTripHandler))).Methods("POST")
+	// OG link-preview page for crawlers; deployment nginx rewrites bot
+	// requests for /app/share/* here.
+	api.HandleFunc("/share-preview/{token}", sharePreviewHandler).Methods("GET")
 	api.Handle("/trips/{id}/items", authMiddleware(http.HandlerFunc(addItineraryItemHandler))).Methods("POST")
 	api.Handle("/trips/{id}/items/order", authMiddleware(http.HandlerFunc(reorderItineraryItemsHandler))).Methods("PUT")
 	api.Handle("/trips/{id}/items/{itemId}", authMiddleware(http.HandlerFunc(patchItineraryItemHandler))).Methods("PATCH")

--- a/src/packages/api/share_preview_handler.go
+++ b/src/packages/api/share_preview_handler.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"html/template"
+	"net/http"
+	"strings"
+
+	"travel-route-planner/store"
+)
+
+// Link previews for shared trips. Crawlers (Slack/iMessage/WhatsApp/Twitter…)
+// don't execute JS, so the SPA share page renders blank for them. The
+// deployment nginx UA-sniffs known bots on /app/share/* and rewrites here;
+// humans keep the clean app URL and never touch this page (the meta-refresh
+// below is only a fallback for bot-like browsers).
+
+// sharePreviewTmpl uses html/template — all fields are auto-escaped; never
+// build this page with fmt.Sprintf.
+var sharePreviewTmpl = template.Must(template.New("share-preview").Parse(`<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>{{.Title}} — Golden Tempo Travel</title>
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="Golden Tempo Travel">
+  <meta property="og:title" content="{{.Title}}">
+  <meta property="og:description" content="{{.Description}}">
+  <meta property="og:url" content="{{.URL}}">
+  <meta property="og:image" content="{{.Image}}">
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="{{.Title}}">
+  <meta name="twitter:description" content="{{.Description}}">
+  <meta http-equiv="refresh" content="0;url={{.URL}}">
+</head>
+<body>
+  <p><a href="{{.URL}}">{{.Title}}</a> — {{.Description}}</p>
+</body>
+</html>`))
+
+type sharePreviewData struct {
+	Title       string
+	Description string
+	URL         string
+	Image       string
+}
+
+// previewBaseURL reconstructs the public origin from the proxy headers the
+// nginx gateway already sets; falls back to the request host.
+func previewBaseURL(r *http.Request) string {
+	scheme := r.Header.Get("X-Forwarded-Proto")
+	if scheme == "" {
+		scheme = "http"
+	}
+	return scheme + "://" + r.Host
+}
+
+// truncatePreview keeps OG text within preview-card limits at a rune
+// boundary.
+func truncatePreview(s string, max int) string {
+	runes := []rune(strings.TrimSpace(s))
+	if len(runes) <= max {
+		return string(runes)
+	}
+	return strings.TrimSpace(string(runes[:max-1])) + "…"
+}
+
+// sharePreviewHandler is GET /api/v1/share-preview/{token}: a minimal HTML
+// page with OG tags for link-preview crawlers. Same data path and 404
+// posture as sharedTripHandler; no new queries.
+func sharePreviewHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	if dbPool == nil {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		w.Write([]byte("<html><body><h2>Temporarily unavailable</h2></body></html>"))
+		return
+	}
+	share, trip, ok := resolveShare(r)
+	if !ok {
+		w.WriteHeader(http.StatusNotFound)
+		w.Write([]byte("<html><body><h2>This trip isn't available</h2><p>The link may have been turned off.</p></body></html>"))
+		return
+	}
+
+	ownerName := "a traveler"
+	if owner, err := store.New(dbPool).GetUserByID(r.Context(), share.OwnerID); err == nil &&
+		owner.DisplayName != nil && *owner.DisplayName != "" {
+		ownerName = *owner.DisplayName
+	}
+
+	var descParts []string
+	if trip.StartDate.Valid && trip.EndDate.Valid {
+		descParts = append(descParts,
+			trip.StartDate.Time.Format("Jan 2")+" – "+trip.EndDate.Time.Format("Jan 2, 2006"))
+	}
+	descParts = append(descParts, "Planned by "+ownerName)
+	if trip.Summary != nil {
+		if first := strings.TrimSpace(strings.SplitN(*trip.Summary, "\n", 2)[0]); first != "" {
+			descParts = append(descParts, first)
+		}
+	}
+
+	base := previewBaseURL(r)
+	data := sharePreviewData{
+		Title:       truncatePreview(trip.Title, 70),
+		Description: truncatePreview(strings.Join(descParts, " · "), 200),
+		URL:         base + "/app/share/" + share.Token,
+		Image:       base + "/app/icons/Icon-512.png",
+	}
+	if err := sharePreviewTmpl.Execute(w, data); err != nil {
+		// Headers already sent; nothing sensible left to do.
+		return
+	}
+}


### PR DESCRIPTION
## Summary
Wave 5 item #3. Shared-trip links preview blank in Slack/iMessage/WhatsApp — crawlers don't run the SPA's JS. Canonical share URLs stay the clean app form (`/app/share/{token}`, from #44); the deployment nginx UA-sniffs known preview bots and rewrites only those requests to a new API-rendered OG page.

- **`GET /api/v1/share-preview/{token}`** — minimal `html/template` page (auto-escaped): `og:title` (trip title, 70-char cap), `og:description` (date range · "Planned by {owner}" · summary first line), absolute `og:url`/`og:image` from the proxy's `X-Forwarded-Proto`/`Host`, `twitter:card`, and a 0s meta-refresh so bot-like human agents still reach the app. Reuses `resolveShare` — no new queries, same uniform-404 posture.
- **Deployment nginx**: `map $http_user_agent $share_prerender` (12-bot alternation) + a `location ~ ^/app/share/` that rewrites bots to the preview (`if` in its rewrite-only documented-safe form) and serves humans via `try_files`. COEP/COOP headers re-added in the new block (nginx nested blocks don't inherit `add_header`). Dev nginx untouched.

Depends on #44 for the canonical URL shape (merge after it).

## Verification
- Live against dev Postgres with an XSS-bait trip title (`Kyoto <script>alert(1)</script> & Osaka`) → all fields correctly escaped; date/owner/summary description; absolute URLs honoring `X-Forwarded-Proto: https`; bogus token → 404 HTML.
- **Real nginx container** wired to the test API: Slackbot UA → OG page; Mozilla UA → SPA index; WhatsApp UA + bad token → 404; non-share deep path (`/app/reset/abc`) still SPA. `nginx -t` clean.
- `gofmt`/`vet`/`go test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)