### PR TITLE
feat: reset & verify email deep links into the app

### DIFF
--- a/specs/auth-deep-links/spec.md
+++ b/specs/auth-deep-links/spec.md
@@ -1,0 +1,56 @@
+# Spec: Reset & Verify Email Deep Links
+
+> **WHAT & WHY only.**
+
+## Context
+
+Email auth shipped with a paste-a-code password reset (two dialogs on the sign-in
+screen) and a verification link that lands on a bare API-rendered HTML page. Both
+work, but neither takes the user *into the app*. This feature adds app deep links
+to the emails — `/reset/<token>` and `/verify/<token>` — so tapping the email link
+opens a proper in-app screen that completes the action. The existing code-paste
+dialogs and the API's HTML verify endpoint are kept so older emails and manual
+fallback still work.
+
+## User Stories
+
+- As a **user who forgot my password**, I want the reset email's link to open a
+  form in the app so that I can set a new password without copying a code.
+- As a **new user**, I want the verification email's link to open the app and
+  confirm my address with a clear success message so that I know it worked.
+- As an **operator**, I want the emailed links to respect where the app is
+  publicly served (base URL and path prefix) so links work in every deployment.
+
+## Acceptance Criteria
+
+- [ ] Opening `/reset/<token>` shows a standalone screen with new-password +
+      confirm fields; passwords must be at least 8 characters and match.
+- [ ] Submitting a valid token updates the password, shows "Password updated",
+      and a "Sign in" button returns to the app root; an invalid/expired token
+      shows the server's error inline without leaving the screen.
+- [ ] Opening `/verify/<token>` verifies the email automatically, showing a
+      spinner, then "Email verified ✓" on success or "Link expired or already
+      used" on failure, with a "Continue" button to the app root.
+- [ ] The password-reset email leads with the `/reset/<token>` app link and
+      still includes the paste-able code as a fallback.
+- [ ] The verification email's primary link is the `/verify/<token>` app route
+      and states it expires in 24 hours; the old API GET verify link keeps
+      working for previously sent emails.
+- [ ] Email links honor the configured public base URL and an optional app
+      path prefix (default `/`).
+
+## API Surface
+
+No new endpoints. The existing `POST /api/v1/auth/verify-email` (JSON `{token}`)
+and `POST /api/v1/auth/reset-password` are consumed by the new screens; the
+`GET /api/v1/auth/verify-email?token=` HTML page is unchanged.
+
+## Data Model
+
+No changes.
+
+## Out of Scope
+
+- URL strategy (hash vs path) — the routes work under either; clean path URLs
+  ship separately.
+- Auto sign-in after reset or verify.

--- a/src/packages/api/.env.sample
+++ b/src/packages/api/.env.sample
@@ -40,3 +40,6 @@ SMTP_PASSWORD=
 SMTP_FROM=
 # Public app URL used in email links (defaults to http://localhost:3000).
 PUBLIC_BASE_URL=
+# Path prefix the Flutter app is served under, for app deep links in emails
+# ("/" default, "/app/" in deployment). Normalized to start+end with "/".
+PUBLIC_APP_PATH=

--- a/src/packages/api/email_auth_handler.go
+++ b/src/packages/api/email_auth_handler.go
@@ -62,6 +62,29 @@ func publicBaseURL() string {
 	return "http://localhost:3000"
 }
 
+// publicAppPath is the path prefix under which the Flutter app is served
+// (env PUBLIC_APP_PATH; "/" by default, e.g. "/app/" in deployment).
+// Normalized to always start and end with "/".
+func publicAppPath() string {
+	p := strings.TrimSpace(os.Getenv("PUBLIC_APP_PATH"))
+	if p == "" {
+		return "/"
+	}
+	if !strings.HasPrefix(p, "/") {
+		p = "/" + p
+	}
+	if !strings.HasSuffix(p, "/") {
+		p += "/"
+	}
+	return p
+}
+
+// publicAppURL builds a user-facing app deep link, e.g.
+// publicAppURL("reset/", token) => https://host/reset/<token>.
+func publicAppURL(parts ...string) string {
+	return publicBaseURL() + publicAppPath() + strings.Join(parts, "")
+}
+
 // sendVerificationEmail is called fire-and-forget after registration (same
 // pattern as the profile distiller kickoff) and from the resend endpoint.
 func sendVerificationEmail(user store.User) {
@@ -73,10 +96,10 @@ func sendVerificationEmail(user store.User) {
 		log.Printf("verification email: could not issue token for %s: %v", user.Email, err)
 		return
 	}
-	link := fmt.Sprintf("%s/api/v1/auth/verify-email?token=%s", publicBaseURL(), token)
+	link := publicAppURL("verify/", token)
 	body := "Welcome to Golden Tempo Travel!\n\n" +
 		"Confirm your email address by opening this link:\n\n" + link + "\n\n" +
-		"The link is valid for 24 hours. If you didn't create an account, you can ignore this email."
+		"The link expires in 24 hours. If you didn't create an account, you can ignore this email."
 	if err := emailService.Send(user.Email, "Confirm your email — Golden Tempo Travel", body); err != nil {
 		log.Printf("verification email: send to %s failed: %v", user.Email, err)
 	}
@@ -182,9 +205,10 @@ func requestPasswordResetHandler(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 			body := "Someone (hopefully you) asked to reset your Golden Tempo Travel password.\n\n" +
-				"Your reset code:\n\n    " + token + "\n\n" +
+				"Reset your password: " + publicAppURL("reset/", token) + "\n\n" +
+				"If the link doesn't open, use this reset code instead:\n\n    " + token + "\n\n" +
 				"In the app, choose \"Forgot password?\", paste the code, and pick a new password. " +
-				"The code is valid for 1 hour and works once. If this wasn't you, ignore this email — your password is unchanged."
+				"The link and code are valid for 1 hour and work once. If this wasn't you, ignore this email — your password is unchanged."
 			if err := emailService.Send(u.Email, "Reset your password — Golden Tempo Travel", body); err != nil {
 				log.Printf("password reset: send to %s failed: %v", u.Email, err)
 			}

--- a/src/packages/flutter-app/lib/main.dart
+++ b/src/packages/flutter-app/lib/main.dart
@@ -6,7 +6,9 @@ import 'theme/app_theme.dart';
 import 'screens/landing_screen.dart';
 import 'screens/app_shell.dart';
 import 'screens/onboarding_quiz_screen.dart';
+import 'screens/reset_password_screen.dart';
 import 'screens/shared_trip_screen.dart';
+import 'screens/verify_email_screen.dart';
 import 'screens/splash_screen.dart';
 
 void main() {
@@ -36,6 +38,18 @@ class TravelRoutePlannerApp extends StatelessWidget {
           return MaterialPageRoute(
             settings: settings,
             builder: (_) => SharedTripScreen(token: segments[1]),
+          );
+        }
+        if (segments.length == 2 && segments[0] == 'reset') {
+          return MaterialPageRoute(
+            settings: settings,
+            builder: (_) => ResetPasswordScreen(token: segments[1]),
+          );
+        }
+        if (segments.length == 2 && segments[0] == 'verify') {
+          return MaterialPageRoute(
+            settings: settings,
+            builder: (_) => VerifyEmailScreen(token: segments[1]),
           );
         }
         return MaterialPageRoute(

--- a/src/packages/flutter-app/lib/screens/reset_password_screen.dart
+++ b/src/packages/flutter-app/lib/screens/reset_password_screen.dart
@@ -1,0 +1,172 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../providers/auth_provider.dart';
+import '../widgets/gradient_app_bar.dart';
+
+/// Deep-link password reset, reachable at /reset/<token> straight from the
+/// email. Works signed-out — the token from the URL is the credential. The
+/// paste-a-code dialog flow on the auth screen remains as a fallback.
+class ResetPasswordScreen extends ConsumerStatefulWidget {
+  final String token;
+  const ResetPasswordScreen({super.key, required this.token});
+
+  @override
+  ConsumerState<ResetPasswordScreen> createState() =>
+      _ResetPasswordScreenState();
+}
+
+class _ResetPasswordScreenState extends ConsumerState<ResetPasswordScreen> {
+  final _formKey = GlobalKey<FormState>();
+  final _passwordController = TextEditingController();
+  final _confirmController = TextEditingController();
+  bool _saving = false;
+  bool _done = false;
+  String? _error;
+
+  @override
+  void dispose() {
+    _passwordController.dispose();
+    _confirmController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _submit() async {
+    if (!_formKey.currentState!.validate()) return;
+    setState(() {
+      _saving = true;
+      _error = null;
+    });
+    try {
+      await ref
+          .read(authServiceProvider)
+          .resetPassword(widget.token, _passwordController.text);
+      if (mounted) setState(() => _done = true);
+    } catch (e) {
+      if (mounted) {
+        setState(() {
+          _saving = false;
+          _error = e.toString();
+        });
+      }
+    }
+  }
+
+  void _goToSignIn() {
+    Navigator.of(context).pushNamedAndRemoveUntil('/', (route) => false);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Scaffold(
+      appBar: const GradientAppBar(title: Text('Reset password')),
+      body: Center(
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.all(24),
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 420),
+            child: _done ? _buildSuccess(theme) : _buildForm(theme),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildSuccess(ThemeData theme) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Icon(Icons.check_circle_outline,
+            size: 64, color: theme.colorScheme.primary),
+        const SizedBox(height: 16),
+        Text(
+          'Password updated',
+          style: theme.textTheme.headlineSmall
+              ?.copyWith(fontWeight: FontWeight.bold),
+          textAlign: TextAlign.center,
+        ),
+        const SizedBox(height: 8),
+        const Text(
+          'Sign in with your new password. Any other sessions were signed out.',
+          textAlign: TextAlign.center,
+        ),
+        const SizedBox(height: 24),
+        FilledButton(
+          onPressed: _goToSignIn,
+          style: FilledButton.styleFrom(
+            padding: const EdgeInsets.symmetric(vertical: 16),
+          ),
+          child: const Text('Sign in'),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildForm(ThemeData theme) {
+    return Form(
+      key: _formKey,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Text(
+            'Choose a new password',
+            style: theme.textTheme.headlineSmall
+                ?.copyWith(fontWeight: FontWeight.bold),
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 24),
+          TextFormField(
+            controller: _passwordController,
+            obscureText: true,
+            decoration: const InputDecoration(labelText: 'New password'),
+            validator: (v) {
+              if ((v ?? '').isEmpty) return 'Password is required';
+              if (v!.length < 8) {
+                return 'Password must be at least 8 characters';
+              }
+              return null;
+            },
+          ),
+          const SizedBox(height: 12),
+          TextFormField(
+            controller: _confirmController,
+            obscureText: true,
+            decoration:
+                const InputDecoration(labelText: 'Confirm new password'),
+            validator: (v) {
+              if ((v ?? '').isEmpty) return 'Confirm your new password';
+              if (v != _passwordController.text) {
+                return 'Passwords don\'t match';
+              }
+              return null;
+            },
+          ),
+          if (_error != null) ...[
+            const SizedBox(height: 16),
+            Text(
+              _error!,
+              style: TextStyle(color: theme.colorScheme.error),
+              textAlign: TextAlign.center,
+            ),
+          ],
+          const SizedBox(height: 24),
+          FilledButton(
+            onPressed: _saving ? null : _submit,
+            style: FilledButton.styleFrom(
+              padding: const EdgeInsets.symmetric(vertical: 16),
+            ),
+            child: _saving
+                ? const SizedBox(
+                    height: 20,
+                    width: 20,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  )
+                : const Text('Set new password'),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/src/packages/flutter-app/lib/screens/verify_email_screen.dart
+++ b/src/packages/flutter-app/lib/screens/verify_email_screen.dart
@@ -1,0 +1,102 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../providers/auth_provider.dart';
+import '../widgets/gradient_app_bar.dart';
+
+/// Deep-link email verification, reachable at /verify/<token> straight from
+/// the email. Consumes the token on load (POST /auth/verify-email) and shows
+/// the outcome. The API's GET link endpoint remains for old emails.
+class VerifyEmailScreen extends ConsumerStatefulWidget {
+  final String token;
+  const VerifyEmailScreen({super.key, required this.token});
+
+  @override
+  ConsumerState<VerifyEmailScreen> createState() => _VerifyEmailScreenState();
+}
+
+class _VerifyEmailScreenState extends ConsumerState<VerifyEmailScreen> {
+  bool _loading = true;
+  String? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    _verify();
+  }
+
+  Future<void> _verify() async {
+    try {
+      await ref.read(authServiceProvider).verifyEmail(widget.token);
+      if (mounted) setState(() => _loading = false);
+    } catch (_) {
+      if (mounted) {
+        setState(() {
+          _loading = false;
+          _error = 'Link expired or already used';
+        });
+      }
+    }
+  }
+
+  void _continue() {
+    Navigator.of(context).pushNamedAndRemoveUntil('/', (route) => false);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final Widget body;
+    if (_loading) {
+      body = const CircularProgressIndicator();
+    } else {
+      final failed = _error != null;
+      body = ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 420),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Icon(
+              failed ? Icons.link_off : Icons.mark_email_read_outlined,
+              size: 64,
+              color: failed
+                  ? theme.colorScheme.error
+                  : theme.colorScheme.primary,
+            ),
+            const SizedBox(height: 16),
+            Text(
+              failed ? 'Link expired or already used' : 'Email verified ✓',
+              style: theme.textTheme.headlineSmall
+                  ?.copyWith(fontWeight: FontWeight.bold),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 8),
+            Text(
+              failed
+                  ? 'Request a new verification email from your account.'
+                  : 'You\'re all set — thanks for confirming your address.',
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 24),
+            FilledButton(
+              onPressed: _continue,
+              style: FilledButton.styleFrom(
+                padding: const EdgeInsets.symmetric(vertical: 16),
+              ),
+              child: const Text('Continue'),
+            ),
+          ],
+        ),
+      );
+    }
+    return Scaffold(
+      appBar: const GradientAppBar(title: Text('Verify email')),
+      body: Center(
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.all(24),
+          child: body,
+        ),
+      ),
+    );
+  }
+}

--- a/src/packages/flutter-app/lib/services/auth_service.dart
+++ b/src/packages/flutter-app/lib/services/auth_service.dart
@@ -85,6 +85,17 @@ class AuthService {
     if (res.statusCode != 202) throw _error(res);
   }
 
+  /// Consumes the emailed verification token and marks the account's email
+  /// as verified. Used by the /verify/{token} deep-link screen.
+  Future<void> verifyEmail(String token) async {
+    final res = await httpClient.post(
+      Uri.parse('$baseUrl/auth/verify-email'),
+      headers: const {'Content-Type': 'application/json'},
+      body: jsonEncode({'token': token}),
+    );
+    if (res.statusCode != 200) throw _error(res);
+  }
+
   /// Consumes the emailed reset code and sets the new password. All existing
   /// sessions are invalidated server-side.
   Future<void> resetPassword(String token, String newPassword) async {


### PR DESCRIPTION
## What

Auth emails now lead with **app deep links** instead of raw codes / bare API pages:

- **`/reset/{token}`** → new `ResetPasswordScreen` — new-password + confirm form (≥8 chars, must match), calls `AuthService.resetPassword`, success shows "Password updated" + a "Sign in" button back to the app root; server errors shown inline.
- **`/verify/{token}`** → new `VerifyEmailScreen` — POSTs the token on load via new `AuthService.verifyEmail`, spinner → "Email verified ✓" or "Link expired or already used", with a "Continue" button.
- Both are added as two more segment cases in `onGenerateRoute` in `lib/main.dart`, mirroring the existing `/share/{token}` case exactly (minimal, additive).
- **Go** (`email_auth_handler.go`): new `publicAppPath()` (env `PUBLIC_APP_PATH`, default `/`, normalized to start+end with `/`) and `publicAppURL()` builder. The reset email leads with the `/reset/<token>` link and **keeps the paste-a-code fallback** (the auth-screen dialogs still exist); the verify email's primary link is now the `/verify/<token>` app route with the 24h expiry noted. The `GET /api/v1/auth/verify-email` HTML endpoint is untouched, so links in already-sent emails keep working.
- `.env.sample`: documents `PUBLIC_APP_PATH` next to `PUBLIC_BASE_URL`.
- Spec: `specs/auth-deep-links/spec.md`.

## Verification

- `gofmt` clean, `go vet` clean, `go test ./...` green; `flutter analyze --no-fatal-infos --fatal-warnings` exit 0; `flutter test` all 26 passing.
- Live against the dev DB (SMTP unset → emails logged): registered a throwaway user; logged verify email contained `http://localhost:3000/verify/<token>`; `POST /auth/verify-email {token}` → `{"status":"verified"}`. Requested a reset; logged email led with `http://localhost:3000/reset/<token>` and kept the code fallback; `POST /auth/reset-password` → 200; login with the new password → 200. Throwaway user deleted afterwards.

## Note

Functional **direct-URL opens require PR #44** (path URLs) — with today's hash strategy the links open the app but land on the default route. The routes themselves are strategy-agnostic (`onGenerateRoute` sees the same path segments under hash or path URLs), so this merges independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)