### PR TITLE
feat: collaborative trip editing — Flutter (join flow, Shared with you, gating)

### DIFF
--- a/src/packages/flutter-app/lib/models/shared_trip.dart
+++ b/src/packages/flutter-app/lib/models/shared_trip.dart
@@ -7,10 +7,21 @@ class SharedTrip {
   final Trip trip;
   final String ownerName;
 
-  const SharedTrip({required this.trip, required this.ownerName});
+  /// Role of the link this trip was opened with: 'viewer' (read-only,
+  /// save-a-copy) or 'editor' (offers "Join as co-planner").
+  final String role;
+
+  const SharedTrip({
+    required this.trip,
+    required this.ownerName,
+    this.role = 'viewer',
+  });
+
+  bool get isEditorLink => role == 'editor';
 
   factory SharedTrip.fromJson(Map<String, dynamic> json) => SharedTrip(
         trip: Trip.fromJson(json['trip'] as Map<String, dynamic>),
         ownerName: (json['owner_name'] as String?) ?? 'A traveler',
+        role: (json['role'] as String?) ?? 'viewer',
       );
 }

--- a/src/packages/flutter-app/lib/models/trip.dart
+++ b/src/packages/flutter-app/lib/models/trip.dart
@@ -31,6 +31,13 @@ class Trip {
   @JsonKey(name: 'booking_todos')
   final List<BookingTodo>? bookingTodos;
 
+  /// 'owner' or 'editor' (collaborator). Missing on older responses ⇒ owner.
+  final String? access;
+
+  /// The owner's display name, set when access == 'editor'.
+  @JsonKey(name: 'owner_name')
+  final String? ownerName;
+
   const Trip({
     required this.id,
     required this.title,
@@ -47,7 +54,13 @@ class Trip {
     this.accommodations,
     this.segments,
     this.bookingTodos,
+    this.access,
+    this.ownerName,
   });
+
+  /// True when the current user owns this trip (missing access ⇒ owner,
+  /// for responses that predate collaboration).
+  bool get isOwner => access == null || access == 'owner';
 
   factory Trip.fromJson(Map<String, dynamic> json) => _$TripFromJson(json);
   Map<String, dynamic> toJson() => _$TripToJson(this);

--- a/src/packages/flutter-app/lib/models/trip.g.dart
+++ b/src/packages/flutter-app/lib/models/trip.g.dart
@@ -31,6 +31,8 @@ Trip _$TripFromJson(Map<String, dynamic> json) => Trip(
       bookingTodos: (json['booking_todos'] as List<dynamic>?)
           ?.map((e) => BookingTodo.fromJson(e as Map<String, dynamic>))
           .toList(),
+      access: json['access'] as String?,
+      ownerName: json['owner_name'] as String?,
     );
 
 Map<String, dynamic> _$TripToJson(Trip instance) => <String, dynamic>{
@@ -50,4 +52,6 @@ Map<String, dynamic> _$TripToJson(Trip instance) => <String, dynamic>{
           instance.accommodations?.map((e) => e.toJson()).toList(),
       'segments': instance.segments?.map((e) => e.toJson()).toList(),
       'booking_todos': instance.bookingTodos?.map((e) => e.toJson()).toList(),
+      'access': instance.access,
+      'owner_name': instance.ownerName,
     };

--- a/src/packages/flutter-app/lib/providers/shared_with_me_provider.dart
+++ b/src/packages/flutter-app/lib/providers/shared_with_me_provider.dart
@@ -1,0 +1,13 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../models/trip.dart';
+import 'auth_provider.dart';
+import 'trips_provider.dart';
+
+/// Trips shared with the signed-in user as an editor-collaborator (latest
+/// version per lineage). Rebuilds on sign-in/out; refresh via
+/// ref.refresh(sharedWithMeProvider).
+final sharedWithMeProvider = FutureProvider<List<Trip>>((ref) async {
+  final auth = ref.watch(authProvider);
+  if (!auth.isSignedIn) return const <Trip>[];
+  return ref.read(tripsApiServiceProvider).listSharedWithMe();
+});

--- a/src/packages/flutter-app/lib/screens/shared_trip_screen.dart
+++ b/src/packages/flutter-app/lib/screens/shared_trip_screen.dart
@@ -13,6 +13,7 @@ import '../widgets/empty_state.dart';
 import '../widgets/gradient_app_bar.dart';
 import '../widgets/trip_map.dart';
 import 'auth_screen.dart';
+import 'trip_detail_screen.dart';
 
 /// Public read-only view of a shared trip, reachable at /#/share/<token>
 /// without an account. Signed-in viewers can save a copy to their own trips.
@@ -78,14 +79,17 @@ class _SharedTripBodyState extends ConsumerState<_SharedTripBody> {
     return groups;
   }
 
+  /// Routes through sign-in if needed; true when a session exists after.
+  Future<bool> _ensureSignedIn() async {
+    if (ref.read(authProvider).isSignedIn) return true;
+    await Navigator.of(context).push(
+      MaterialPageRoute(builder: (_) => const AuthScreen()),
+    );
+    return ref.read(authProvider).isSignedIn;
+  }
+
   Future<void> _saveCopy() async {
-    final auth = ref.read(authProvider);
-    if (!auth.isSignedIn) {
-      await Navigator.of(context).push(
-        MaterialPageRoute(builder: (_) => const AuthScreen()),
-      );
-      if (!ref.read(authProvider).isSignedIn) return;
-    }
+    if (!await _ensureSignedIn()) return;
     setState(() => _saving = true);
     try {
       await ref
@@ -100,6 +104,33 @@ class _SharedTripBodyState extends ConsumerState<_SharedTripBody> {
       if (mounted) {
         ScaffoldMessenger.of(context)
             .showSnackBar(SnackBar(content: Text('Could not save a copy: $e')));
+      }
+    } finally {
+      if (mounted) setState(() => _saving = false);
+    }
+  }
+
+  /// Editor links: redeem membership, then land in the shared trip itself
+  /// (Trips tab underneath so back lands somewhere sensible).
+  Future<void> _joinAsCoPlanner() async {
+    if (!await _ensureSignedIn()) return;
+    setState(() => _saving = true);
+    try {
+      final tripId =
+          await ref.read(tripsApiServiceProvider).joinSharedTrip(widget.token);
+      if (!mounted) return;
+      ref.read(navIndexProvider.notifier).state = AppTab.trips.index;
+      Navigator.of(context).pushNamedAndRemoveUntil('/', (route) => false);
+      // Give the shell a frame to mount, then open the trip on the Trips tab.
+      final navKeys = ref.read(tabNavKeysProvider);
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        navKeys[AppTab.trips.index].currentState?.push(MaterialPageRoute(
+            builder: (_) => TripDetailScreen(tripId: tripId)));
+      });
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context)
+            .showSnackBar(SnackBar(content: Text('Could not join trip: $e')));
       }
     } finally {
       if (mounted) setState(() => _saving = false);
@@ -212,17 +243,40 @@ class _SharedTripBodyState extends ConsumerState<_SharedTripBody> {
             padding: const EdgeInsets.all(AppSpacing.md),
             color: theme.scaffoldBackgroundColor,
             child: SafeArea(
-              child: FilledButton.icon(
-                onPressed: _saving ? null : _saveCopy,
-                icon: _saving
-                    ? const SizedBox(
-                        width: 16,
-                        height: 16,
-                        child: CircularProgressIndicator(strokeWidth: 2),
-                      )
-                    : const Icon(Icons.library_add_outlined),
-                label: const Text('Save a copy to my trips'),
-              ),
+              child: widget.shared.isEditorLink
+                  ? Column(
+                      mainAxisSize: MainAxisSize.min,
+                      crossAxisAlignment: CrossAxisAlignment.stretch,
+                      children: [
+                        FilledButton.icon(
+                          onPressed: _saving ? null : _joinAsCoPlanner,
+                          icon: _saving
+                              ? const SizedBox(
+                                  width: 16,
+                                  height: 16,
+                                  child:
+                                      CircularProgressIndicator(strokeWidth: 2),
+                                )
+                              : const Icon(Icons.group_add_outlined),
+                          label: const Text('Join as co-planner'),
+                        ),
+                        TextButton(
+                          onPressed: _saving ? null : _saveCopy,
+                          child: const Text('Or save a separate copy'),
+                        ),
+                      ],
+                    )
+                  : FilledButton.icon(
+                      onPressed: _saving ? null : _saveCopy,
+                      icon: _saving
+                          ? const SizedBox(
+                              width: 16,
+                              height: 16,
+                              child: CircularProgressIndicator(strokeWidth: 2),
+                            )
+                          : const Icon(Icons.library_add_outlined),
+                      label: const Text('Save a copy to my trips'),
+                    ),
             ),
           ),
         ),

--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -488,6 +488,12 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
   /// with the section's current contents. The session is bound to this trip
   /// server-side, so changes patch the trip in place (no new versions).
   void _openRefine(Trip trip, RefineTarget target) {
+    // AI refine is owner-only (keeps the version lineage single-writer);
+    // the buttons are hidden for editors, this is the belt-and-braces guard.
+    if (!trip.isOwner) {
+      _showSnack('Only the trip owner can refine with AI.');
+      return;
+    }
     final items = trip.items ?? [];
     if (items.isEmpty) {
       _showSnack('Add some places before refining with AI.');
@@ -669,8 +675,14 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
     }
   }
 
+  /// Where the app is mounted on its host: '/' in dev, '/app/' in the
+  /// deployment build (set via --dart-define, like API_BASE_URL). Dart can't
+  /// portably read the base href, so the build injects it.
+  static const _appBasePath =
+      String.fromEnvironment('APP_BASE_PATH', defaultValue: '/');
+
   /// Mints (or reuses) the trip's share link and copies it to the clipboard.
-  /// Flutter web uses hash URLs, so the shareable form is origin + /#/share/….
+  /// Path-style form: origin + basePath + share/<token>.
   Future<void> _shareLink() async {
     try {
       final token = await ref
@@ -682,7 +694,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
       } catch (_) {
         origin = ''; // non-http platform; copy a relative link
       }
-      final url = '$origin/#/share/$token';
+      final url = '$origin${_appBasePath}share/$token';
       await Clipboard.setData(ClipboardData(text: url));
       _showSnack('Share link copied to clipboard');
     } catch (e) {
@@ -693,10 +705,43 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
   Future<void> _revokeLink() async {
     try {
       await ref.read(tripsApiServiceProvider).revokeShareLink(widget.tripId);
-      _showSnack('Sharing turned off — old links no longer work');
+      _showSnack(
+          'Sharing turned off — links no longer work (existing co-planners keep access)');
     } catch (e) {
       _showSnack('Could not turn off sharing: $e');
     }
+  }
+
+  /// Mints an editor link and copies it — the recipient can join as a
+  /// co-planner and edit this trip.
+  Future<void> _inviteCoPlanner() async {
+    try {
+      final token = await ref
+          .read(tripsApiServiceProvider)
+          .createShareLink(widget.tripId, role: 'editor');
+      String origin;
+      try {
+        origin = Uri.base.origin;
+      } catch (_) {
+        origin = '';
+      }
+      final url = '$origin${_appBasePath}share/$token';
+      await Clipboard.setData(ClipboardData(text: url));
+      _showSnack('Co-planner invite copied — anyone with it can edit');
+    } catch (e) {
+      _showSnack('Could not create invite: $e');
+    }
+  }
+
+  /// Owner-only sheet listing active co-planners with per-person removal.
+  Future<void> _manageCoPlanners() async {
+    await showModalBottomSheet<void>(
+      context: context,
+      builder: (sheetContext) => _CoPlannersSheet(
+        tripId: widget.tripId,
+        onRemoved: () => _showSnack('Co-planner removed'),
+      ),
+    );
   }
 
   String _fmt(DateTime d) =>
@@ -851,16 +896,21 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
               _collapsedDays.add(dayKey);
             }
           });
-        }, () {
-          final trip = _trip;
-          if (trip == null) return;
-          // 'Other places' is a fallback label, not a real hub — omit the city
-          // qualifier so the server matches on the day alone.
-          _openRefine(
-              trip,
-              RefineTarget.day(day,
-                  city: cityKey == 'Other places' ? null : cityKey));
-        });
+        },
+            // Refine is owner-only; editors get no per-day refine icon.
+            (_trip?.isOwner ?? true)
+                ? () {
+                    final trip = _trip;
+                    if (trip == null) return;
+                    // 'Other places' is a fallback label, not a real hub —
+                    // omit the city qualifier so the server matches on the
+                    // day alone.
+                    _openRefine(
+                        trip,
+                        RefineTarget.day(day,
+                            city: cityKey == 'Other places' ? null : cityKey));
+                  }
+                : null);
         slivers.add(MultiSliver(
           pushPinnedChildren: true,
           children: [
@@ -929,7 +979,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
                     ),
                   ],
                   // 'Other places' has no hub the section tool can target.
-                  if (group.label != 'Other places')
+                  if (group.label != 'Other places' && trip.isOwner)
                     IconButton(
                       icon: const Icon(Icons.auto_awesome, size: 16),
                       tooltip: 'Refine ${group.label}',
@@ -1341,7 +1391,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
       bool collapsed,
       int travelMin,
       VoidCallback onTap,
-      VoidCallback onRefine) {
+      VoidCallback? onRefine) {
     final label = tripStart != null
         ? _fmtDayHeader(tripStart.add(Duration(days: day - 1)))
         : 'Day $day';
@@ -1374,13 +1424,14 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
                 ),
                 const SizedBox(width: 8),
               ],
-              IconButton(
-                icon: const Icon(Icons.auto_awesome, size: 16),
-                tooltip: 'Refine this day',
-                visualDensity: VisualDensity.compact,
-                color: theme.colorScheme.primary,
-                onPressed: onRefine,
-              ),
+              if (onRefine != null)
+                IconButton(
+                  icon: const Icon(Icons.auto_awesome, size: 16),
+                  tooltip: 'Refine this day',
+                  visualDensity: VisualDensity.compact,
+                  color: theme.colorScheme.primary,
+                  onPressed: onRefine,
+                ),
               Icon(
                 collapsed ? Icons.chevron_right : Icons.expand_more,
                 size: 18,
@@ -1910,14 +1961,32 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
               ],
             ),
             const SizedBox(height: 12),
-            SizedBox(
-              width: double.infinity,
-              child: FilledButton.tonalIcon(
-                onPressed: () => _openRefine(trip, const RefineTarget.trip()),
-                icon: const Icon(Icons.auto_awesome),
-                label: const Text('Refine with AI'),
+            if (!trip.isOwner)
+              Row(
+                children: [
+                  Icon(Icons.group_outlined,
+                      size: 16, color: theme.colorScheme.onSurfaceVariant),
+                  const SizedBox(width: 6),
+                  Expanded(
+                    child: Text(
+                      trip.ownerName != null
+                          ? 'Co-planning with ${trip.ownerName} — your changes save for everyone.'
+                          : 'Co-planning a shared trip — your changes save for everyone.',
+                      style: theme.textTheme.bodySmall?.copyWith(
+                          color: theme.colorScheme.onSurfaceVariant),
+                    ),
+                  ),
+                ],
+              )
+            else
+              SizedBox(
+                width: double.infinity,
+                child: FilledButton.tonalIcon(
+                  onPressed: () => _openRefine(trip, const RefineTarget.trip()),
+                  icon: const Icon(Icons.auto_awesome),
+                  label: const Text('Refine with AI'),
+                ),
               ),
-            ),
             if (overview != null) ...[
               const SizedBox(height: 16),
               Text(
@@ -1965,17 +2034,28 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
       appBar: GradientAppBar(
         title: Text(trip != null ? _displayTitle(trip) : 'Trip'),
         actions: [
-          if (trip != null)
+          // Sharing and deletion are owner-only surfaces; editors see neither.
+          if (trip != null && trip.isOwner)
             PopupMenuButton<String>(
               icon: const Icon(Icons.share_outlined),
               tooltip: 'Share trip',
-              onSelected: (v) => v == 'copy' ? _shareLink() : _revokeLink(),
+              onSelected: (v) => switch (v) {
+                'copy' => _shareLink(),
+                'invite' => _inviteCoPlanner(),
+                'manage' => _manageCoPlanners(),
+                _ => _revokeLink(),
+              },
               itemBuilder: (context) => const [
                 PopupMenuItem(value: 'copy', child: Text('Copy share link')),
+                PopupMenuItem(
+                    value: 'invite',
+                    child: Text('Invite co-planner (can edit)')),
+                PopupMenuItem(
+                    value: 'manage', child: Text('Manage co-planners')),
                 PopupMenuItem(value: 'revoke', child: Text('Turn off sharing')),
               ],
             ),
-          if (trip != null)
+          if (trip != null && trip.isOwner)
             IconButton(
               icon: const Icon(Icons.delete_outline),
               tooltip: 'Delete trip',
@@ -2266,8 +2346,15 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
                         ],
                       );
 
+                      // Pull-to-refresh: with async co-editing, this is how a
+                      // user picks up a collaborator's latest changes.
+                      final refreshable = RefreshIndicator(
+                        onRefresh: _load,
+                        child: scrollView,
+                      );
+
                       if (!_panelOpen || _refineTarget == null) {
-                        return scrollView;
+                        return refreshable;
                       }
                       final panel = TripRefinePanel(
                         tripId: widget.tripId,
@@ -2279,7 +2366,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
                         // Wide: dock the chat beside the itinerary.
                         return Row(
                           children: [
-                            Expanded(child: scrollView),
+                            Expanded(child: refreshable),
                             const VerticalDivider(width: 1),
                             SizedBox(width: 400, child: panel),
                           ],
@@ -2289,7 +2376,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
                       // inset keeps the input above the keyboard.
                       return Stack(
                         children: [
-                          scrollView,
+                          refreshable,
                           DraggableScrollableSheet(
                             initialChildSize: 0.45,
                             minChildSize: 0.15,
@@ -2823,6 +2910,96 @@ class _EditItineraryItemSheetState extends State<_EditItineraryItemSheet> {
             ],
           ),
         ],
+      ),
+    );
+  }
+}
+
+/// Owner-only bottom sheet: lists active co-planners with per-person removal.
+/// Removal revokes their access immediately; the invite link (if still on)
+/// would let them rejoin, so the empty state reminds the owner of that.
+class _CoPlannersSheet extends ConsumerStatefulWidget {
+  final String tripId;
+  final VoidCallback onRemoved;
+  const _CoPlannersSheet({required this.tripId, required this.onRemoved});
+
+  @override
+  ConsumerState<_CoPlannersSheet> createState() => _CoPlannersSheetState();
+}
+
+class _CoPlannersSheetState extends ConsumerState<_CoPlannersSheet> {
+  List<({String userId, String displayName, String email})>? _collaborators;
+  String? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadCollaborators();
+  }
+
+  Future<void> _loadCollaborators() async {
+    try {
+      final list =
+          await ref.read(tripsApiServiceProvider).listCollaborators(widget.tripId);
+      if (mounted) setState(() => _collaborators = list);
+    } catch (e) {
+      if (mounted) setState(() => _error = e.toString());
+    }
+  }
+
+  Future<void> _remove(String userId) async {
+    try {
+      await ref
+          .read(tripsApiServiceProvider)
+          .removeCollaborator(widget.tripId, userId);
+      widget.onRemoved();
+      await _loadCollaborators();
+    } catch (e) {
+      if (mounted) setState(() => _error = e.toString());
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final collaborators = _collaborators;
+    return SafeArea(
+      child: Padding(
+        padding: const EdgeInsets.all(AppSpacing.lg),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text('Co-planners', style: theme.textTheme.titleMedium),
+            const SizedBox(height: AppSpacing.sm),
+            if (_error != null)
+              Text(_error!,
+                  style: TextStyle(color: theme.colorScheme.error))
+            else if (collaborators == null)
+              const Center(child: CircularProgressIndicator())
+            else if (collaborators.isEmpty)
+              Text(
+                'No co-planners yet. Use "Invite co-planner (can edit)" to '
+                'share an invite link.',
+                style: theme.textTheme.bodyMedium
+                    ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+              )
+            else
+              for (final c in collaborators)
+                ListTile(
+                  contentPadding: EdgeInsets.zero,
+                  leading: const CircleAvatar(child: Icon(Icons.person, size: 18)),
+                  title: Text(
+                      c.displayName.isNotEmpty ? c.displayName : c.email),
+                  subtitle: c.displayName.isNotEmpty ? Text(c.email) : null,
+                  trailing: IconButton(
+                    icon: const Icon(Icons.person_remove_outlined),
+                    tooltip: 'Remove access',
+                    onPressed: () => _remove(c.userId),
+                  ),
+                ),
+          ],
+        ),
       ),
     );
   }

--- a/src/packages/flutter-app/lib/screens/trips_list_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trips_list_screen.dart
@@ -9,6 +9,7 @@ import '../widgets/gradient_app_bar.dart';
 import '../widgets/status_pill.dart';
 import '../models/trip.dart';
 import '../providers/auth_provider.dart';
+import '../providers/shared_with_me_provider.dart';
 import '../providers/trips_provider.dart';
 import 'trip_detail_screen.dart';
 
@@ -65,12 +66,30 @@ class _TripsListScreenState extends ConsumerState<TripsListScreen> {
       );
     } else {
       final isAdmin = ref.watch(authProvider).user?.isAdmin ?? false;
+      final shared =
+          ref.watch(sharedWithMeProvider).valueOrNull ?? const <Trip>[];
       body = RefreshIndicator(
-        onRefresh: () => ref.read(tripsProvider.notifier).loadTrips(),
-        child: ListView.builder(
+        onRefresh: () async {
+          ref.invalidate(sharedWithMeProvider);
+          await ref.read(tripsProvider.notifier).loadTrips();
+        },
+        child: ListView(
           padding: const EdgeInsets.all(AppSpacing.md),
-          itemCount: state.trips.length,
-          itemBuilder: (context, i) => _TripCard(trip: state.trips[i], isAdmin: isAdmin),
+          children: [
+            for (final t in state.trips) _TripCard(trip: t, isAdmin: isAdmin),
+            // Trips others invited this user to co-plan. Kept as a separate
+            // section: "mine" vs "shared with me" is the mental model, and
+            // the card shows the owner instead of admin version chrome.
+            if (shared.isNotEmpty) ...[
+              Padding(
+                padding: const EdgeInsets.fromLTRB(
+                    AppSpacing.xs, AppSpacing.lg, 0, AppSpacing.sm),
+                child: Text('Shared with you',
+                    style: theme.textTheme.titleMedium),
+              ),
+              for (final t in shared) _TripCard(trip: t, isAdmin: false),
+            ],
+          ],
         ),
       );
     }
@@ -138,6 +157,12 @@ class _TripCard extends ConsumerWidget {
           else
             Text('Created ${shortDate(trip.createdAt)}'),
           StatusPill(status: trip.status),
+          if (!trip.isOwner && (trip.ownerName ?? '').isNotEmpty)
+            Text(
+              'Planned with ${trip.ownerName}',
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                  color: Theme.of(context).colorScheme.onSurfaceVariant),
+            ),
         ],
       ),
     );
@@ -145,7 +170,7 @@ class _TripCard extends ConsumerWidget {
     if (!hasHistory) {
       return Card(
         child: ListTile(
-          leading: const Icon(Icons.map_outlined),
+          leading: Icon(trip.isOwner ? Icons.map_outlined : Icons.group_outlined),
           title: title,
           subtitle: subtitle,
           trailing: const Icon(Icons.chevron_right),

--- a/src/packages/flutter-app/lib/services/trips_api_service.dart
+++ b/src/packages/flutter-app/lib/services/trips_api_service.dart
@@ -101,16 +101,76 @@ class TripsApiService {
     throw Exception('Failed to add place (${res.statusCode})');
   }
 
-  /// Mints (or returns the existing) share link token for a trip. Idempotent.
-  Future<String> createShareLink(String tripId) async {
+  /// Mints (or returns the existing) share link token for a trip.
+  /// Idempotent per (trip lineage, role); role is 'viewer' or 'editor'.
+  Future<String> createShareLink(String tripId,
+      {String role = 'viewer'}) async {
     final res = await apiClient.httpClient.post(
       Uri.parse('${apiClient.baseUrl}/trips/$tripId/share'),
       headers: _headers(json: true),
+      body: jsonEncode({'role': role}),
     );
     if (res.statusCode == 200 || res.statusCode == 201) {
       return (jsonDecode(res.body) as Map<String, dynamic>)['token'] as String;
     }
     throw Exception('Failed to create share link (${res.statusCode})');
+  }
+
+  /// Redeems an editor-role share token; returns the trip id to open.
+  Future<String> joinSharedTrip(String token) async {
+    final res = await apiClient.httpClient.post(
+      Uri.parse('${apiClient.baseUrl}/shared/$token/join'),
+      headers: _headers(json: true),
+    );
+    if (res.statusCode == 200) {
+      return (jsonDecode(res.body) as Map<String, dynamic>)['trip_id']
+          as String;
+    }
+    throw Exception('Failed to join trip (${res.statusCode})');
+  }
+
+  /// Trips shared with the signed-in user (latest version per lineage).
+  Future<List<Trip>> listSharedWithMe() async {
+    final res = await apiClient.httpClient.get(
+      Uri.parse('${apiClient.baseUrl}/trips/shared-with-me'),
+      headers: _headers(),
+    );
+    if (res.statusCode == 200) {
+      final list = jsonDecode(res.body) as List<dynamic>;
+      return list.map((e) => Trip.fromJson(e as Map<String, dynamic>)).toList();
+    }
+    throw Exception('Failed to load shared trips (${res.statusCode})');
+  }
+
+  /// Owner-only: active co-planners on a trip.
+  Future<List<({String userId, String displayName, String email})>>
+      listCollaborators(String tripId) async {
+    final res = await apiClient.httpClient.get(
+      Uri.parse('${apiClient.baseUrl}/trips/$tripId/collaborators'),
+      headers: _headers(),
+    );
+    if (res.statusCode == 200) {
+      final list = jsonDecode(res.body) as List<dynamic>;
+      return list
+          .map((e) => (
+                userId: e['user_id'] as String,
+                displayName: (e['display_name'] as String?) ?? '',
+                email: (e['email'] as String?) ?? '',
+              ))
+          .toList();
+    }
+    throw Exception('Failed to load co-planners (${res.statusCode})');
+  }
+
+  /// Owner-only: removes a co-planner's access.
+  Future<void> removeCollaborator(String tripId, String userId) async {
+    final res = await apiClient.httpClient.delete(
+      Uri.parse('${apiClient.baseUrl}/trips/$tripId/collaborators/$userId'),
+      headers: _headers(),
+    );
+    if (res.statusCode != 204) {
+      throw Exception('Failed to remove co-planner (${res.statusCode})');
+    }
   }
 
   Future<void> revokeShareLink(String tripId) async {


### PR DESCRIPTION
## Summary
Wave 5 flagship, part 2 of 2 — the client half of async co-editing. **Stacked on #46** (base = `collab-api`; will retarget to main when that merges).

- **Join flow**: editor-role share links render a "Join as co-planner" CTA on the shared-trip page (routes through sign-in when needed), joins via `POST /shared/{token}/join`, and lands the new collaborator directly inside the trip on their Trips tab. "Save a separate copy" stays as the secondary action; viewer links are unchanged.
- **"Shared with you"**: new section under My Trips backed by `GET /trips/shared-with-me` — trip cards with a group icon and "Planned with {owner}" subtitle; pull-to-refresh reloads both lists.
- **Editor experience in trip detail**: share menu, delete, and all four AI-refine affordances hidden (plus a belt-and-braces guard inside `_openRefine`); a "Co-planning with {owner} — your changes save for everyone" note replaces the Refine button; **`RefreshIndicator` added** — the async-v1 way to pick up a collaborator's edits.
- **Owner tools**: "Invite co-planner (can edit)" (mints an editor link, copies path-form URL) and "Manage co-planners" (bottom sheet, per-person removal) in the share menu; revoke-link snack now explains existing co-planners keep access.
- Models: `Trip.access`/`ownerName` (+ regen), `SharedTrip.role`. The `_shareLink`/`_appBasePath` hunk is intentionally identical to #44 so the branches merge cleanly.

## Verification
`flutter analyze` exit 0; all 26 tests pass. The API side of every flow used here was verified live two-user in #46 (join, walls, removal, revocation semantics). Full browser two-user run (join from a real link → edit → owner pull-to-refresh) is the post-merge smoke once #44/#46 land in the dev stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)