### PR TITLE
Flighty-style satellite basemap for all maps

### DIFF
--- a/src/packages/flutter-app/lib/screens/local_guide_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/local_guide_detail_screen.dart
@@ -7,6 +7,7 @@ import '../models/local_recommendation.dart';
 import '../providers/local_provider.dart';
 import '../theme/app_colors.dart';
 import '../theme/spacing.dart';
+import '../widgets/app_map.dart';
 import '../widgets/empty_state.dart';
 import '../widgets/gradient_app_bar.dart';
 import '../widgets/local_rec_card.dart';
@@ -226,10 +227,10 @@ class _HeroImage extends StatelessWidget {
   }
 }
 
-/// A small OSM map of the guide's mapped pins, numbered in narrative order.
-/// TripMap is keyed to ItineraryItem (positions, categories, route line), so
-/// this stays a purpose-built lightweight map with the same tile usage and the
-/// same scroll-wheel opt-out (the map lives inside a ListView).
+/// A small satellite map of the guide's mapped pins, numbered in narrative
+/// order. TripMap is keyed to ItineraryItem (positions, categories, route
+/// line), so this stays a purpose-built lightweight map on the same shared
+/// basemap, with the same scroll-wheel opt-out (the map lives in a ListView).
 class _GuideMap extends StatefulWidget {
   final List<LocalRecommendation> pins;
 
@@ -265,6 +266,7 @@ class _GuideMapState extends State<_GuideMap> {
             initialCenter: points.first,
             initialZoom: 13,
             interactionOptions: interaction,
+            backgroundColor: appMapBackground,
           )
         : MapOptions(
             initialCameraFit: CameraFit.bounds(
@@ -272,10 +274,11 @@ class _GuideMapState extends State<_GuideMap> {
               padding: const EdgeInsets.all(32),
             ),
             interactionOptions: interaction,
+            backgroundColor: appMapBackground,
           );
 
     return ClipRRect(
-      borderRadius: AppRadius.mdAll,
+      borderRadius: AppRadius.lgAll,
       child: SizedBox(
         height: 240,
         child: Stack(
@@ -284,21 +287,19 @@ class _GuideMapState extends State<_GuideMap> {
               mapController: _controller,
               options: options,
               children: [
-                TileLayer(
-                  urlTemplate: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
-                  userAgentPackageName: 'com.travelrouteplanner.app',
-                ),
+                ...appMapTileLayers(context),
                 MarkerLayer(
                   markers: [
                     for (var i = 0; i < points.length; i++)
                       Marker(
                         point: points[i],
-                        width: 30,
-                        height: 30,
+                        width: 24,
+                        height: 24,
                         child: _GuidePin(label: '${i + 1}'),
                       ),
                   ],
                 ),
+                appMapAttribution(),
               ],
             ),
             Positioned(
@@ -307,9 +308,17 @@ class _GuideMapState extends State<_GuideMap> {
               child: Column(
                 mainAxisSize: MainAxisSize.min,
                 children: [
-                  _MapButton(icon: Icons.add, onTap: () => _zoomBy(1)),
+                  MapControlButton(
+                    icon: Icons.add,
+                    tooltip: 'Zoom in',
+                    onTap: () => _zoomBy(1),
+                  ),
                   const SizedBox(height: AppSpacing.sm),
-                  _MapButton(icon: Icons.remove, onTap: () => _zoomBy(-1)),
+                  MapControlButton(
+                    icon: Icons.remove,
+                    tooltip: 'Zoom out',
+                    onTap: () => _zoomBy(-1),
+                  ),
                 ],
               ),
             ),
@@ -332,10 +341,11 @@ class _GuidePin extends StatelessWidget {
       decoration: BoxDecoration(
         color: AppColors.toolLocal,
         shape: BoxShape.circle,
+        border: Border.all(color: Colors.white, width: 2),
         boxShadow: [
           BoxShadow(
-            color: Colors.black.withValues(alpha: 0.25),
-            blurRadius: 3,
+            color: Colors.black.withValues(alpha: 0.35),
+            blurRadius: 4,
             offset: const Offset(0, 1),
           ),
         ],
@@ -345,35 +355,8 @@ class _GuidePin extends StatelessWidget {
         label,
         style: const TextStyle(
           color: Colors.white,
-          fontSize: 13,
+          fontSize: 11,
           fontWeight: FontWeight.bold,
-        ),
-      ),
-    );
-  }
-}
-
-/// Small circular zoom control, matching the trip map's overlay buttons.
-class _MapButton extends StatelessWidget {
-  final IconData icon;
-  final VoidCallback onTap;
-
-  const _MapButton({required this.icon, required this.onTap});
-
-  @override
-  Widget build(BuildContext context) {
-    final scheme = Theme.of(context).colorScheme;
-    return Material(
-      color: scheme.surface,
-      shape: const CircleBorder(),
-      elevation: 2,
-      child: InkWell(
-        customBorder: const CircleBorder(),
-        onTap: onTap,
-        child: SizedBox(
-          width: 36,
-          height: 36,
-          child: Icon(icon, size: 20, color: scheme.onSurface),
         ),
       ),
     );

--- a/src/packages/flutter-app/lib/screens/shared_trip_screen.dart
+++ b/src/packages/flutter-app/lib/screens/shared_trip_screen.dart
@@ -166,7 +166,7 @@ class _SharedTripBodyState extends ConsumerState<_SharedTripBody> {
             if (hasCoords) ...[
               const SizedBox(height: AppSpacing.lg),
               ClipRRect(
-                borderRadius: BorderRadius.circular(AppRadius.md),
+                borderRadius: AppRadius.lgAll,
                 child: SizedBox(
                   height: 240,
                   child: TripMap(

--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -2122,7 +2122,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
                                 padding:
                                     const EdgeInsets.fromLTRB(16, 12, 16, 12),
                                 child: ClipRRect(
-                                  borderRadius: BorderRadius.circular(12),
+                                  borderRadius: AppRadius.lgAll,
                                   child: TripMap(
                                     items: _filtered(trip),
                                     selectedPosition: _selectedPosition,

--- a/src/packages/flutter-app/lib/widgets/app_map.dart
+++ b/src/packages/flutter-app/lib/widgets/app_map.dart
@@ -1,0 +1,96 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
+
+/// Space-dark canvas behind the tiles: unloaded/failed satellite tiles read as
+/// "not lit yet" instead of a broken grey hole. Pass as
+/// `MapOptions.backgroundColor` wherever [appMapTileLayers] is used.
+const Color appMapBackground = Color(0xFF0A0F1A);
+
+/// Shared basemap for every map in the app: Esri World Imagery satellite
+/// tiles with a labels-only overlay designed for dark imagery, so maps get a
+/// premium "satellite globe" look (à la Flighty) with readable place names.
+///
+/// Use [appMapTileLayers] as the first children of a [FlutterMap] and
+/// [appMapAttribution] as the last child (attribution is required by both
+/// Esri's and CARTO's tile usage terms).
+List<Widget> appMapTileLayers(BuildContext context) {
+  // panBuffer 0: two stacked layers double every tile request, and the default
+  // 1-tile offscreen ring can exhaust the browser's request pool in bursts
+  // (net::ERR_INSUFFICIENT_RESOURCES), leaving permanent grey holes. The evict
+  // strategy re-fetches errored tiles when they scroll back into view instead
+  // of keeping the hole.
+  return [
+    // Satellite base. Note the ArcGIS {z}/{y}/{x} path order.
+    TileLayer(
+      urlTemplate:
+          'https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}',
+      userAgentPackageName: 'com.travelrouteplanner.app',
+      panBuffer: 0,
+      evictErrorTileStrategy: EvictErrorTileStrategy.notVisibleRespectMargin,
+    ),
+    // Place/street names with a light halo, made to sit over dark basemaps.
+    TileLayer(
+      urlTemplate:
+          'https://basemaps.cartocdn.com/rastertiles/dark_only_labels/{z}/{x}/{y}{r}.png',
+      userAgentPackageName: 'com.travelrouteplanner.app',
+      retinaMode: RetinaMode.isHighDensity(context),
+      panBuffer: 0,
+      evictErrorTileStrategy: EvictErrorTileStrategy.notVisibleRespectMargin,
+    ),
+  ];
+}
+
+/// Collapsed-to-an-icon attribution for the layers in [appMapTileLayers].
+Widget appMapAttribution() {
+  return RichAttributionWidget(
+    alignment: AttributionAlignment.bottomLeft,
+    showFlutterMapAttribution: false,
+    openButton: (context, open) => IconButton(
+      onPressed: open,
+      tooltip: 'Map credits',
+      icon: const Icon(Icons.info_outline, size: 16, color: Colors.white70),
+    ),
+    attributions: const [
+      TextSourceAttribution(
+        'Powered by Esri — Source: Esri, Maxar, Earthstar Geographics',
+        prependCopyright: false,
+      ),
+      TextSourceAttribution('CARTO'),
+      TextSourceAttribution('OpenStreetMap contributors'),
+    ],
+  );
+}
+
+/// A small circular control overlaid on the map (zoom in/out, reset). Dark
+/// and translucent so it reads as a frosted chip over satellite imagery.
+class MapControlButton extends StatelessWidget {
+  final IconData icon;
+  final String? tooltip;
+  final VoidCallback onTap;
+
+  const MapControlButton({
+    super.key,
+    required this.icon,
+    this.tooltip,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final button = Material(
+      color: Colors.black.withValues(alpha: 0.55),
+      shape: const CircleBorder(side: BorderSide(color: Colors.white24)),
+      child: InkWell(
+        customBorder: const CircleBorder(),
+        onTap: onTap,
+        child: SizedBox(
+          width: 36,
+          height: 36,
+          child: Icon(icon, size: 20, color: Colors.white),
+        ),
+      ),
+    );
+    if (tooltip == null) return button;
+    return Tooltip(message: tooltip!, child: button);
+  }
+}

--- a/src/packages/flutter-app/lib/widgets/trip_map.dart
+++ b/src/packages/flutter-app/lib/widgets/trip_map.dart
@@ -6,10 +6,11 @@ import 'package:flutter_map_marker_cluster/flutter_map_marker_cluster.dart';
 import 'package:latlong2/latlong.dart';
 import '../models/itinerary_item.dart';
 import '../theme/app_colors.dart';
+import 'app_map.dart';
 
-/// Plots a trip's itinerary on an OpenStreetMap: a numbered, category-tinted pin
-/// per place, a route line connecting them in itinerary order, auto-fit to the
-/// trip's extent. Tapping a pin calls [onPinTap] with that item's position.
+/// Plots a trip's itinerary on a satellite basemap: a numbered, category-tinted
+/// pin per place, a route line connecting them in itinerary order, auto-fit to
+/// the trip's extent. Tapping a pin calls [onPinTap] with that item's position.
 /// When [selectedPosition] changes the camera recenters on that place.
 class TripMap extends StatefulWidget {
   final List<ItineraryItem> items;
@@ -195,6 +196,7 @@ class _TripMapState extends State<TripMap> {
             initialCenter: selected,
             initialZoom: 15,
             interactionOptions: interaction,
+            backgroundColor: appMapBackground,
           )
         : points.length == 1
             // Single point: bounds collapse, so center with a sensible zoom.
@@ -202,6 +204,7 @@ class _TripMapState extends State<TripMap> {
                 initialCenter: points.first,
                 initialZoom: 13,
                 interactionOptions: interaction,
+                backgroundColor: appMapBackground,
               )
             : MapOptions(
                 initialCameraFit: CameraFit.bounds(
@@ -209,6 +212,7 @@ class _TripMapState extends State<TripMap> {
                   padding: const EdgeInsets.all(32),
                 ),
                 interactionOptions: interaction,
+                backgroundColor: appMapBackground,
               );
 
     return Stack(
@@ -217,17 +221,21 @@ class _TripMapState extends State<TripMap> {
           mapController: _controller,
           options: options,
           children: [
-            TileLayer(
-              urlTemplate: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
-              userAgentPackageName: 'com.travelrouteplanner.app',
-            ),
+            ...appMapTileLayers(context),
             if (points.length >= 2)
               PolylineLayer(
                 polylines: [
+                  // Two passes make a thin line with a soft glow that stays
+                  // legible over satellite imagery.
                   Polyline(
                     points: points,
-                    strokeWidth: 3,
-                    color: theme.colorScheme.primary.withValues(alpha: 0.7),
+                    strokeWidth: 6,
+                    color: Colors.white.withValues(alpha: 0.25),
+                  ),
+                  Polyline(
+                    points: points,
+                    strokeWidth: 2,
+                    color: Colors.white.withValues(alpha: 0.95),
                   ),
                 ],
               ),
@@ -236,14 +244,18 @@ class _TripMapState extends State<TripMap> {
             MarkerClusterLayerWidget(
               options: MarkerClusterLayerOptions(
                 maxClusterRadius: 45,
-                size: const Size(40, 40),
+                size: const Size(32, 32),
                 padding: const EdgeInsets.all(40),
                 markers: [
                   for (final m in mapped)
                     Marker(
                       point: m.point,
-                      width: 32,
-                      height: 32,
+                      width: widget.selectedPosition == m.item.position
+                          ? 28
+                          : 24,
+                      height: widget.selectedPosition == m.item.position
+                          ? 28
+                          : 24,
                       child: _Pin(
                         label: '${m.item.position + 1}',
                         category: m.item.category,
@@ -258,6 +270,7 @@ class _TripMapState extends State<TripMap> {
                     _ClusterBubble(count: clusterMarkers.length),
               ),
             ),
+            appMapAttribution(),
           ],
         ),
         Positioned(
@@ -266,19 +279,19 @@ class _TripMapState extends State<TripMap> {
           child: Column(
             mainAxisSize: MainAxisSize.min,
             children: [
-              _MapButton(
+              MapControlButton(
                 icon: Icons.add,
                 tooltip: 'Zoom in',
                 onTap: () => _zoomBy(1),
               ),
               const SizedBox(height: 8),
-              _MapButton(
+              MapControlButton(
                 icon: Icons.remove,
                 tooltip: 'Zoom out',
                 onTap: () => _zoomBy(-1),
               ),
               const SizedBox(height: 8),
-              _MapButton(
+              MapControlButton(
                 icon: Icons.center_focus_strong,
                 tooltip: 'Reset map',
                 onTap: () => _fitToTrip(points),
@@ -287,41 +300,6 @@ class _TripMapState extends State<TripMap> {
           ),
         ),
       ],
-    );
-  }
-}
-
-/// A small circular control overlaid on the map (zoom in/out, reset).
-class _MapButton extends StatelessWidget {
-  final IconData icon;
-  final String tooltip;
-  final VoidCallback onTap;
-
-  const _MapButton({
-    required this.icon,
-    required this.tooltip,
-    required this.onTap,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    final scheme = Theme.of(context).colorScheme;
-    return Tooltip(
-      message: tooltip,
-      child: Material(
-        color: scheme.surface,
-        shape: const CircleBorder(),
-        elevation: 2,
-        child: InkWell(
-          customBorder: const CircleBorder(),
-          onTap: onTap,
-          child: SizedBox(
-            width: 36,
-            height: 36,
-            child: Icon(icon, size: 20, color: scheme.onSurface),
-          ),
-        ),
-      ),
     );
   }
 }
@@ -335,16 +313,15 @@ class _SegmentArrow extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final scheme = Theme.of(context).colorScheme;
     return Transform.rotate(
       angle: angle,
-      child: Icon(
+      child: const Icon(
         Icons.navigation,
         size: 14,
-        color: scheme.primary,
-        shadows: const [
-          Shadow(color: Colors.white, blurRadius: 3),
-          Shadow(color: Colors.white, blurRadius: 6),
+        color: Colors.white,
+        shadows: [
+          Shadow(color: Colors.black54, blurRadius: 3),
+          Shadow(color: Colors.black54, blurRadius: 6),
         ],
       ),
     );
@@ -358,30 +335,22 @@ class _SegmentLabel extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final scheme = Theme.of(context).colorScheme;
     return Center(
       child: Container(
         padding: const EdgeInsets.symmetric(horizontal: 7, vertical: 3),
         decoration: BoxDecoration(
-          // Fully opaque with a soft shadow and a stronger border so the time
-          // reads cleanly over the map tiles and the route line beneath it.
-          color: scheme.surface,
+          // Dark translucent chip so the time reads cleanly over satellite
+          // imagery and the route line beneath it.
+          color: Colors.black.withValues(alpha: 0.6),
           borderRadius: BorderRadius.circular(10),
-          border: Border.all(color: scheme.outline),
-          boxShadow: [
-            BoxShadow(
-              color: Colors.black.withValues(alpha: 0.15),
-              blurRadius: 3,
-              offset: const Offset(0, 1),
-            ),
-          ],
+          border: Border.all(color: Colors.white24),
         ),
         child: Text(
           text,
           maxLines: 1,
           overflow: TextOverflow.clip,
-          style: TextStyle(
-            color: scheme.onSurface,
+          style: const TextStyle(
+            color: Colors.white,
             fontSize: 11,
             fontWeight: FontWeight.w600,
           ),
@@ -397,15 +366,14 @@ class _ClusterBubble extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final scheme = Theme.of(context).colorScheme;
     return Container(
       decoration: BoxDecoration(
-        color: scheme.primary,
+        color: Colors.black.withValues(alpha: 0.65),
         shape: BoxShape.circle,
         border: Border.all(color: Colors.white, width: 2),
         boxShadow: [
           BoxShadow(
-            color: Colors.black.withValues(alpha: 0.3),
+            color: Colors.black.withValues(alpha: 0.35),
             blurRadius: 4,
             offset: const Offset(0, 1),
           ),
@@ -416,7 +384,7 @@ class _ClusterBubble extends StatelessWidget {
         '$count',
         style: const TextStyle(
           color: Colors.white,
-          fontSize: 14,
+          fontSize: 13,
           fontWeight: FontWeight.bold,
         ),
       ),
@@ -446,17 +414,16 @@ class _Pin extends StatelessWidget {
     return GestureDetector(
       onTap: onTap,
       child: Container(
+        // A permanent white ring keeps the small dots crisp over satellite
+        // imagery; selection thickens the ring (and the marker itself grows).
         decoration: BoxDecoration(
           color: color,
           shape: BoxShape.circle,
-          border: Border.all(
-            color: selected ? Colors.white : color.withValues(alpha: 0.0),
-            width: 2,
-          ),
+          border: Border.all(color: Colors.white, width: selected ? 3 : 2),
           boxShadow: [
             BoxShadow(
-              color: Colors.black.withValues(alpha: selected ? 0.4 : 0.25),
-              blurRadius: selected ? 6 : 3,
+              color: Colors.black.withValues(alpha: selected ? 0.5 : 0.35),
+              blurRadius: selected ? 6 : 4,
               offset: const Offset(0, 1),
             ),
           ],
@@ -466,7 +433,7 @@ class _Pin extends StatelessWidget {
           label,
           style: const TextStyle(
             color: Colors.white,
-            fontSize: 13,
+            fontSize: 11,
             fontWeight: FontWeight.bold,
           ),
         ),


### PR DESCRIPTION
## Summary
- New shared `lib/widgets/app_map.dart`: Esri World Imagery satellite tiles + CARTO dark labels-only overlay, collapsible tile attribution (previously missing entirely — required by Esri/CARTO/OSM policies), space-dark map background, and a frosted-dark `MapControlButton`.
- `TripMap` (trip detail + shared trip) restyled for dark imagery: white two-pass glow route line, 24px white-ringed category-colored numbered dots (grow on selection), dark translucent cluster bubbles and travel-time pills, white direction arrows.
- Local guide map unified onto the shared basemap/controls; its duplicated `_MapButton` deleted; amber pins get the same white-ring treatment.
- Map cards upgraded to the `AppRadius.lg` corner token on trip detail, shared trip, and guide screens.
- `panBuffer: 0` + error-tile eviction on both tile layers: stacked layers double tile requests and the default offscreen ring can exhaust the browser request pool, leaving permanent grey holes.

## Testing
- `make flutter-analyze`: only the 14 pre-existing infos in untouched files.
- `make flutter-test`: all 26 tests pass.
- Manual verification in the docker-dev stack via headless Chrome: satellite tiles + place labels render, pin tap recenters/selects and shows the snackbar, zoom-out clusters into the dark ringed bubble, zoom/reset controls work, attribution popup expands with full credits. Zero tile failures in a normally-resourced browser (earlier grey holes traced to the test container's 64MB /dev/shm, not the app).
- Local guide map not visually verified (no published guides in dev DB); it renders the identical shared layers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)