### PR TITLE
feat: de-jank the agent chat — smooth streaming, markdown, summary chips

### DIFF
--- a/specs/chat-streaming-polish/plan.md
+++ b/specs/chat-streaming-polish/plan.md
@@ -1,0 +1,84 @@
+# Plan: Chat Streaming Polish
+
+> **HOW.** See `spec.md` for what & why. No new endpoints, models, or env vars —
+> this is a rendering/state-flow change in the Flutter chat plus prompt wording
+> in the Go API.
+
+## Technical Approach
+
+Three root causes, three fixes:
+
+1. **Per-token full rebuilds** — every SSE `text_delta` did a whole-state
+   `copyWith` and `ChatPanel` watched the whole `PlanState`, rebuilding the
+   entire conversation per token. Fix: coalesce delta flushes in `PlanNotifier`
+   (~48ms one-shot timer), and restructure `ChatPanel` so committed messages
+   live in a `ListView.builder` with keys and the live tail (streaming bubble,
+   tool chips, result chips, footer) is a column of leaf widgets each watching
+   a narrow `select`.
+2. **Scroll fighting** — a fresh 200ms `animateTo` per token. Fix: a single
+   pending post-frame `jumpTo(maxScrollExtent)` gated by a bool, triggered by
+   selects on `streamingText` / `messages.length`.
+3. **Raw markdown + card pile-up** — assistant text rendered as plain `Text`;
+   five card sections inserted mid-stream. Fix: render assistant bubbles with
+   `gpt_markdown` (streaming-oriented flutter_markdown successor), replace the
+   in-bubble spinner with a blinking cursor, and replace the card sections with
+   one generic `ResultSummaryChip` per result set that links to trip detail
+   when a trip id exists.
+
+## Go API Changes
+
+`src/packages/api/plan_handler.go` only — prompt wording:
+
+- Base prompt: drop "shown to the traveler as cards"; instruct summarizing the
+  top 2–3 flight options in prose. Add one line asking for light markdown
+  (short paragraphs, bold place names, hyphen lists, no headings/tables).
+- `summarizeOffers` / `summarizeEvents` tool-result texts (and the nearby
+  comment): stop pointing at chat cards; the full list is saved with the trip.
+
+## Flutter Changes
+
+`src/packages/flutter-app/`:
+
+- **pubspec.yaml:** add `gpt_markdown` (transitively pulls `flutter_math_fork`;
+  verify web build).
+- **providers/plan_provider.dart:** buffer `text_delta` and flush
+  `streamingText` on a ~48ms one-shot `Timer`; flush synchronously before
+  tool/done/error transitions; cancel the timer *before* the end-of-stream /
+  error `copyWith` that clears `streamingText` (a late timer would resurrect a
+  ghost bubble) and in `dispose()` (refine-panel family instances dispose
+  mid-stream). `PlanState` shape unchanged.
+- **widgets/result_summary_chip.dart (new):** generic
+  `{icon, accent, label, onTap?}` one-line chip; tappable variant shows
+  "View in trip".
+- **widgets/chat_panel.dart:** `ListView.builder` + keyed bubbles + `_ChatTail`
+  leaf widgets with per-field selects; delete `_FlightOptions`,
+  `_EventOptions`, `_LocalRecsSection`, `_FerryOptions`, inline
+  `SourceLinksCard`; add `onViewTrip` callback param; scroll fix; markdown
+  bubbles + `_StreamingCursor`.
+- **screens/agent_screen.dart:** pass `onViewTrip` → push `TripDetailScreen`.
+- **Untouched:** `trip_refine_panel.dart`, `trip_detail_screen.dart`, all card
+  widget files (still used by flight search / trip detail).
+
+## Contract Parity
+
+No request/response contract changes — the SSE event shapes are unchanged.
+
+| JSON key | Go type | Dart type | Nullable? | ✓ |
+|----------|---------|-----------|-----------|---|
+| _(none — no contract changes)_ | | | | ✓ |
+
+## Cross-cutting
+
+- No new env vars, routes, or gateway config.
+- Chip accents reuse `AppColors.tool*` tokens (design-system conventions).
+
+## Verification
+
+- `make api-fmt && make api-vet` — Go clean.
+- `make flutter-analyze` — catches dead imports after card-section removal.
+- `make flutter-test` — includes new `test/plan_provider_stream_test.dart`
+  (fake `PlanService`: N deltas → far fewer state emissions; committed text
+  equals concatenation; no ghost `streamingText` at end).
+- Manual via `make docker-dev` → `http://localhost:3000` (API container needs
+  `up --build` for the prompt change): walk the acceptance criteria in
+  `spec.md` with a flights + Greek-ferries trip ask.

--- a/specs/chat-streaming-polish/spec.md
+++ b/specs/chat-streaming-polish/spec.md
@@ -1,0 +1,85 @@
+# Spec: Chat Streaming Polish
+
+## Context
+
+The AI planning chat feels janky: streamed text stutters and repaints the whole
+conversation as it arrives, the auto-scroll fights itself, the assistant's
+formatting (bold, lists) shows as raw asterisks, and large result cards
+(flights, events, local picks, ferries) jump into the conversation while text
+is still loading. All of that card content already has a durable home in the
+trip detail view (booking checklist, embedded events, itinerary pins). The
+outcome: a calm, professional chat — smooth live text, proper formatting, and
+quiet one-line result summaries that link to the trip instead of inline cards.
+
+## User Stories
+
+- As a **traveler planning a trip in the chat**, I want streamed replies to
+  render smoothly with real formatting so that the assistant feels polished
+  and readable.
+- As a **traveler**, I want search results summarized in one quiet line that
+  links to my trip so that the conversation isn't buried under cards.
+- As a **traveler re-reading earlier messages mid-stream**, I want the chat to
+  stop auto-scrolling until I return to the bottom so that I don't lose my
+  place.
+
+## Acceptance Criteria
+
+- [ ] Streamed reply text appears smoothly (no visible stutter/flicker) even in
+      long conversations.
+- [ ] Assistant messages render markdown: bold, lists, links — no raw `**` or
+      `-` artifacts once the message completes.
+- [ ] While streaming, a subtle blinking cursor marks the live message (no
+      spinner inside the text bubble).
+- [ ] Flight / event / local-pick / ferry / event-source results appear as a
+      single compact summary line each (icon + count + route/city), not as
+      stacks of cards.
+- [ ] Once the trip is saved, tapping a summary line opens the trip detail
+      view; before that it is a plain non-tappable label.
+- [ ] In the trip-detail refine panel, summary lines are plain labels (the trip
+      is already on screen).
+- [ ] Scrolling up during a stream pauses auto-follow; scrolling back to the
+      bottom resumes it without rubber-banding.
+- [ ] The assistant no longer tells the traveler to look at "cards" in the
+      chat.
+- [ ] Trip detail continues to surface the full results (booking checklist,
+      embedded events, itinerary pins) unchanged.
+
+## API Surface
+
+No endpoint changes. The `/api/v1/plan` SSE stream and its event types are
+unchanged; only the assistant's prompt wording changes (how it refers to
+results shown in the app).
+
+## Data Model
+
+No new or changed entities.
+
+## UI Behavior
+
+- **Surface:** the Agent tab chat and the trip-detail refine panel (shared
+  chat surface).
+- **Happy path:** traveler asks for a trip → text streams in smoothly with a
+  blinking cursor → tool activity shows as small chips → each result set
+  arrives as one summary line → on completion the itinerary banner appears and
+  summary lines become tappable links to the trip.
+- **States:** empty (existing empty state), streaming (cursor + tool chips),
+  results (summary lines), error (existing error banner) — all unchanged in
+  placement, only calmer in rendering.
+
+## Edge Cases & Error States
+
+- Mid-stream markdown (unclosed `**`, half-finished lists) may render literally
+  for a moment and snap to styled when the token closing it arrives — accepted.
+- A stream that errors or is disposed mid-flight must not leave a ghost
+  streaming bubble behind.
+- Result sets with zero items produce no summary line (same as today's cards).
+
+## Out of Scope
+
+- Adding new result surfaces to trip detail (it already covers the content).
+- Persisting flight/event/ferry results beyond what is saved today.
+- Typewriter/character-by-character animation effects.
+
+## Open Questions
+
+None.

--- a/specs/chat-streaming-polish/tasks.md
+++ b/specs/chat-streaming-polish/tasks.md
@@ -1,0 +1,27 @@
+# Tasks: Chat Streaming Polish
+
+> Dependency-ordered. `[P]` = can run in parallel with its siblings.
+
+## API (Go)
+
+- [x] [P] Reword `plan_handler.go` prompts: no "cards", summarize top options
+      in prose, light-markdown formatting line
+
+## Flutter
+
+- [x] Add `gpt_markdown` to `pubspec.yaml` + `flutter pub get`
+- [x] [P] Coalesce `text_delta` flushes in `plan_provider.dart` (timer +
+      cancel-before-clear + `dispose`)
+- [x] [P] New `widgets/result_summary_chip.dart`
+- [x] Restructure `chat_panel.dart`: `ListView.builder` + keyed bubbles,
+      `_ChatTail` leaf selects, delete card sections, `onViewTrip` param,
+      `jumpTo` scroll fix, markdown bubbles + `_StreamingCursor`
+- [x] Wire `onViewTrip` in `agent_screen.dart` → `TripDetailScreen`
+
+## Verification
+
+- [x] `make api-fmt && make api-vet` clean
+- [x] `make flutter-analyze` clean
+- [x] New `test/plan_provider_stream_test.dart` passes; `make flutter-test`
+- [x] Manual end-to-end via gateway (`make docker-dev` →
+      `http://localhost:3000`): every acceptance criterion in `spec.md`

--- a/src/packages/api/plan_handler.go
+++ b/src/packages/api/plan_handler.go
@@ -326,7 +326,7 @@ func planHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	today := time.Now()
-	basePrompt := "You are an expert travel agent. Today's date is " + today.Format("Monday, January 2, 2006") + " (" + today.Format("2006-01-02") + "). When a traveler gives a date without a year, assume the soonest upcoming occurrence on or after today — never a past year. Use dates in YYYY-MM-DD form when calling tools. Help users plan trips by searching for specific places and attractions. For each city, ALWAYS call search_local_recommendations FIRST — these are hand-curated picks from real locals, the legit info you can't get by googling. Prefer them over generic results, build the itinerary around them where they fit the traveler, and cite the local by name in your reply (e.g. 'Ana, a Lisbon chef, swears by…'). When a local pick becomes an itinerary place, carry its id into local_recommendation_id and its source_name into local_source_name. Then use search_places to fill gaps and find any other real locations with coordinates. Search for individual places (e.g. 'Louvre Museum Paris') rather than broad queries. Include a mix of activities/attractions and dining (restaurants), guided by the traveler's interests, budget, and pace. When you call create_itinerary, tag each location with category ('attraction' or 'restaurant'), a time_of_day ('morning', 'afternoon', or 'evening'), and a day (the 1-based trip day it falls on, increasing chronologically across the whole trip) so each day reads as a sensible schedule. When you have gathered enough places for the user's trip, call create_itinerary to finalize the plan; pass start_date (and end_date) whenever the traveler has given or agreed to travel dates, with day 1 being the start date. You can also use search_flights to find real flight options — ask for the traveler's departure city/airport and dates if you don't know them, and pick optimize_for from their budget (budget→cost, luxury→time, otherwise balanced); the ranked options are shown to the traveler as cards, so summarize and help them choose. For travel between Greek islands, use suggest_ferries (ferries are the primary way to island-hop); note that in Greece search_events returns curated source links rather than ticketed listings. Be conversational and helpful — ask clarifying questions if needed before searching."
+	basePrompt := "You are an expert travel agent. Today's date is " + today.Format("Monday, January 2, 2006") + " (" + today.Format("2006-01-02") + "). When a traveler gives a date without a year, assume the soonest upcoming occurrence on or after today — never a past year. Use dates in YYYY-MM-DD form when calling tools. Help users plan trips by searching for specific places and attractions. For each city, ALWAYS call search_local_recommendations FIRST — these are hand-curated picks from real locals, the legit info you can't get by googling. Prefer them over generic results, build the itinerary around them where they fit the traveler, and cite the local by name in your reply (e.g. 'Ana, a Lisbon chef, swears by…'). When a local pick becomes an itinerary place, carry its id into local_recommendation_id and its source_name into local_source_name. Then use search_places to fill gaps and find any other real locations with coordinates. Search for individual places (e.g. 'Louvre Museum Paris') rather than broad queries. Include a mix of activities/attractions and dining (restaurants), guided by the traveler's interests, budget, and pace. When you call create_itinerary, tag each location with category ('attraction' or 'restaurant'), a time_of_day ('morning', 'afternoon', or 'evening'), and a day (the 1-based trip day it falls on, increasing chronologically across the whole trip) so each day reads as a sensible schedule. When you have gathered enough places for the user's trip, call create_itinerary to finalize the plan; pass start_date (and end_date) whenever the traveler has given or agreed to travel dates, with day 1 being the start date. You can also use search_flights to find real flight options — ask for the traveler's departure city/airport and dates if you don't know them, and pick optimize_for from their budget (budget→cost, luxury→time, otherwise balanced); summarize the top 2-3 options in your own words and help them choose — do not tell the traveler to look at cards or lists in the chat. For travel between Greek islands, use suggest_ferries (ferries are the primary way to island-hop); note that in Greece search_events returns curated source links rather than ticketed listings. Be conversational and helpful — ask clarifying questions if needed before searching. Format replies with light markdown — short paragraphs, **bold** for place names, hyphen lists — no headings or tables."
 
 	placesService := NewGooglePlacesService()
 	ctx := r.Context()
@@ -745,8 +745,8 @@ func isAlpha(s string) bool {
 }
 
 // summarizeOffers builds a compact text summary of ranked offers for the model,
-// so it can describe and compare them without re-sending the full payload (which
-// already reached the UI via the "flights" event).
+// so it can describe and compare them without re-sending the full payload (the
+// UI already received it via the "flights" event, shown as a summary chip).
 func summarizeOffers(origin, dest string, offers []FlightOffer) string {
 	if len(offers) == 0 {
 		return fmt.Sprintf("No flights found from %s to %s for those dates.", origin, dest)
@@ -767,12 +767,13 @@ func summarizeOffers(origin, dest string, offers []FlightOffer) string {
 		fmt.Fprintf(&b, "%d. %s — %s %.0f, %s, %dh%02dm (score %.1f)\n",
 			i+1, airline, o.Currency, o.Price, stops, o.DurationMin/60, o.DurationMin%60, o.Score)
 	}
-	b.WriteString("These option cards are already shown to the traveler; summarize and help them choose.")
+	b.WriteString("Summarize the top 2-3 options in your own words and help the traveler choose; the full ranked list is saved with their trip.")
 	return b.String()
 }
 
 // summarizeEvents renders the events returned for a city into a compact text
-// block for the model (the event cards themselves are streamed to the UI).
+// block for the model (the events themselves are streamed to the UI, shown as
+// a summary chip).
 func summarizeEvents(city string, events []Event) string {
 	if len(events) == 0 {
 		return fmt.Sprintf("No events found in %s for those dates.", city)
@@ -793,7 +794,7 @@ func summarizeEvents(city string, events []Event) string {
 		}
 		b.WriteString(line + "\n")
 	}
-	b.WriteString("These event cards are already shown to the traveler; highlight ones that fit their interests and dates.")
+	b.WriteString("In your reply, highlight the events that fit the traveler's interests and dates; the full list is saved with their trip.")
 	return b.String()
 }
 

--- a/src/packages/flutter-app/lib/providers/plan_provider.dart
+++ b/src/packages/flutter-app/lib/providers/plan_provider.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:math';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../models/plan_message.dart';
@@ -129,6 +130,40 @@ class PlanNotifier extends StateNotifier<PlanState> {
 
   PlanNotifier(this._service, this._apiClient, {this.tripId}) : super(const PlanState());
 
+  // Streamed text_deltas arrive faster than a frame; pushing a new state per
+  // token rebuilds the chat per token. Deltas accumulate in [_streamBuffer]
+  // and reach [state] at most once per [_streamFlushInterval].
+  static const _streamFlushInterval = Duration(milliseconds: 48);
+  Timer? _streamFlushTimer;
+  StringBuffer? _streamBuffer;
+
+  void _scheduleStreamFlush() {
+    _streamFlushTimer ??= Timer(_streamFlushInterval, _flushStreamText);
+  }
+
+  void _flushStreamText() {
+    _streamFlushTimer?.cancel();
+    _streamFlushTimer = null;
+    final buffer = _streamBuffer;
+    if (buffer == null || !mounted) return;
+    state = state.copyWith(streamingText: buffer.toString());
+  }
+
+  // Must run before any state change that clears streamingText, or a pending
+  // timer fires afterwards and resurrects a ghost streaming bubble.
+  void _endStreamBuffer() {
+    _streamFlushTimer?.cancel();
+    _streamFlushTimer = null;
+    _streamBuffer = null;
+  }
+
+  @override
+  void dispose() {
+    // Refine-panel family instances can be disposed mid-stream.
+    _endStreamBuffer();
+    super.dispose();
+  }
+
   // 0x7fffffff (not 1 << 32) because on the web target `1 << 32` overflows JS's
   // 32-bit bitwise ops to 0, and Random.nextInt(0) throws RangeError.
   static String _newChatId() =>
@@ -186,14 +221,19 @@ class PlanNotifier extends StateNotifier<PlanState> {
         .toList();
 
     final textBuffer = StringBuffer();
+    _streamBuffer = textBuffer;
 
     try {
       await for (final event in _service.streamPlan(history,
           bearerToken: _apiClient.authToken, chatId: _chatId, tripId: tripId)) {
+        // Keep buffered text ahead of any other state transition so tool chips
+        // and results never appear before the text that introduced them.
+        if (event.type != 'text_delta') _flushStreamText();
+
         switch (event.type) {
           case 'text_delta':
             textBuffer.write(event.data['text'] as String? ?? '');
-            state = state.copyWith(streamingText: textBuffer.toString());
+            _scheduleStreamFlush();
 
           case 'tool_call':
             final name = event.data['name'] as String? ?? '';
@@ -214,7 +254,7 @@ class PlanNotifier extends StateNotifier<PlanState> {
               savedTripId: event.data['trip_id'] as String?,
             );
 
-            case 'trip_updated':
+          case 'trip_updated':
             state = state.copyWith(tripUpdateCount: state.tripUpdateCount + 1);
 
           case 'profile_updated':
@@ -277,6 +317,7 @@ class PlanNotifier extends StateNotifier<PlanState> {
             );
 
           case 'error':
+            _endStreamBuffer();
             state = state.copyWith(
               isStreaming: false,
               streamingText: null,
@@ -286,6 +327,9 @@ class PlanNotifier extends StateNotifier<PlanState> {
             return;
         }
       }
+
+      _endStreamBuffer();
+      if (!mounted) return;
 
       // Commit streamed assistant text as a message
       final assistantText = textBuffer.toString();
@@ -304,6 +348,8 @@ class PlanNotifier extends StateNotifier<PlanState> {
         activeTools: [],
       );
     } catch (e) {
+      _endStreamBuffer();
+      if (!mounted) return;
       state = state.copyWith(
         isStreaming: false,
         streamingText: null,
@@ -315,6 +361,7 @@ class PlanNotifier extends StateNotifier<PlanState> {
 
   void reset() {
     _chatId = null;
+    _endStreamBuffer();
     state = const PlanState();
   }
 

--- a/src/packages/flutter-app/lib/screens/agent_screen.dart
+++ b/src/packages/flutter-app/lib/screens/agent_screen.dart
@@ -56,15 +56,23 @@ class _AgentScreenState extends ConsumerState<AgentScreen> {
     );
   }
 
+  void _openTrip(String tripId) {
+    Navigator.of(context).push(
+      MaterialPageRoute(builder: (_) => TripDetailScreen(tripId: tripId)),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
-    final planState = ref.watch(planProvider);
+    // Narrow select so streaming-text flushes don't rebuild the Scaffold.
+    final showReset = ref.watch(planProvider.select(
+        (s) => s.messages.isNotEmpty || s.completedLocations != null));
 
     return Scaffold(
       appBar: GradientAppBar(
         title: const Text('Plan your trip'),
         actions: [
-          if (planState.messages.isNotEmpty || planState.completedLocations != null)
+          if (showReset)
             IconButton(
               icon: const Icon(Icons.refresh),
               onPressed: () => ref.read(planProvider.notifier).reset(),
@@ -77,6 +85,7 @@ class _AgentScreenState extends ConsumerState<AgentScreen> {
         state: planProvider,
         notifier: planProvider.notifier,
         emptyState: _EmptyState(),
+        onViewTrip: _openTrip,
         footerBuilder: (context, state) => state.completedLocations == null
             ? const SizedBox.shrink()
             : _ItineraryBanner(
@@ -85,11 +94,7 @@ class _AgentScreenState extends ConsumerState<AgentScreen> {
                 onLoad: _loadIntoPlanner,
                 onViewTrip: state.savedTripId == null
                     ? null
-                    : () => Navigator.of(context).push(
-                          MaterialPageRoute(
-                            builder: (_) => TripDetailScreen(tripId: state.savedTripId!),
-                          ),
-                        ),
+                    : () => _openTrip(state.savedTripId!),
               ),
       ),
     );

--- a/src/packages/flutter-app/lib/widgets/chat_panel.dart
+++ b/src/packages/flutter-app/lib/widgets/chat_panel.dart
@@ -1,24 +1,23 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart' show ScrollDirection;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import '../models/flight_offer.dart';
-import '../models/event.dart';
-import '../models/ferry_option.dart';
-import '../models/local_recommendation.dart';
+import 'package:gpt_markdown/gpt_markdown.dart';
+import 'package:url_launcher/url_launcher.dart';
 import '../models/plan_message.dart';
 import '../providers/plan_provider.dart';
 import '../theme/app_colors.dart';
-import 'flight_offer_card.dart';
-import 'event_card.dart';
-import 'ferry_card.dart';
-import 'local_rec_card.dart';
-import 'source_links_card.dart';
+import 'result_summary_chip.dart';
 
-/// The plan-agent chat surface (messages, tool chips, flight cards, input bar)
+/// The plan-agent chat surface (messages, tool chips, result chips, input bar)
 /// decoupled from any screen, so the full-screen Agent tab and the trip-detail
 /// refine panel share one implementation. The provider pair is passed in:
 /// AgentScreen hands the global [planProvider], the refine panel hands its
 /// per-trip [tripRefineProvider] instance.
+///
+/// Streamed tokens arrive many times per frame, so the widget tree is split so
+/// a token flush rebuilds only the streaming bubble: committed messages live in
+/// a keyed ListView.builder, and the live tail (_ChatTail) is a column of leaf
+/// widgets each watching a narrow select of PlanState.
 class ChatPanel extends ConsumerStatefulWidget {
   final ProviderListenable<PlanState> state;
   final ProviderListenable<PlanNotifier> notifier;
@@ -31,6 +30,11 @@ class ChatPanel extends ConsumerStatefulWidget {
   /// completed-itinerary banner).
   final Widget Function(BuildContext context, PlanState state)? footerBuilder;
 
+  /// When set, result summary chips (flights, events, local picks, ferries)
+  /// become tappable once a trip id exists and open that trip. The refine
+  /// panel leaves this null — the trip is already on screen.
+  final void Function(String tripId)? onViewTrip;
+
   const ChatPanel({
     super.key,
     required this.state,
@@ -38,6 +42,7 @@ class ChatPanel extends ConsumerStatefulWidget {
     this.inputHint = 'Describe your trip...',
     this.emptyState,
     this.footerBuilder,
+    this.onViewTrip,
   });
 
   @override
@@ -52,6 +57,10 @@ class _ChatPanelState extends ConsumerState<ChatPanel> {
   /// scrolling up to re-read pauses it until they return to the bottom.
   bool _stickToBottom = true;
 
+  /// At most one bottom-jump pending per frame, no matter how many state
+  /// changes request one.
+  bool _scrollScheduled = false;
+
   @override
   void dispose() {
     _controller.dispose();
@@ -60,20 +69,18 @@ class _ChatPanelState extends ConsumerState<ChatPanel> {
   }
 
   void _scrollToBottom() {
+    if (_scrollScheduled) return;
+    _scrollScheduled = true;
     WidgetsBinding.instance.addPostFrameCallback((_) {
+      _scrollScheduled = false;
       if (_stickToBottom && _scrollController.hasClients) {
-        _scrollController.animateTo(
-          _scrollController.position.maxScrollExtent,
-          duration: const Duration(milliseconds: 200),
-          curve: Curves.easeOut,
-        );
+        _scrollController.jumpTo(_scrollController.position.maxScrollExtent);
       }
     });
   }
 
-  // Only UserScrollNotification flips the flag off — the programmatic
-  // animateTo also moves the position, and may be mid-flight (away from the
-  // bottom) when the next stream chunk arrives.
+  // Only UserScrollNotification flips the flag off — the programmatic jumpTo
+  // emits only ScrollUpdateNotifications, so it can't disarm itself.
   bool _onScrollNotification(ScrollNotification notification) {
     if (notification is UserScrollNotification &&
         notification.direction == ScrollDirection.forward) {
@@ -98,132 +105,135 @@ class _ChatPanelState extends ConsumerState<ChatPanel> {
 
   @override
   Widget build(BuildContext context) {
-    final planState = ref.watch(widget.state);
-    final theme = Theme.of(context);
+    final messages = ref.watch(widget.state.select((s) => s.messages));
+    final isStreaming = ref.watch(widget.state.select((s) => s.isStreaming));
+    final isEmpty = ref.watch(widget.state
+        .select((s) => s.messages.isEmpty && s.streamingText == null));
 
-    ref.listen(widget.state, (_, next) {
-      if (next.isStreaming || next.streamingText != null) {
-        _scrollToBottom();
-      }
-    });
+    ref.listen(widget.state.select((s) => s.streamingText),
+        (_, __) => _scrollToBottom());
+    ref.listen(widget.state.select((s) => s.messages.length),
+        (_, __) => _scrollToBottom());
 
     return Column(
       children: [
         Expanded(
-          child: planState.messages.isEmpty && planState.streamingText == null
+          child: isEmpty
               ? (widget.emptyState ?? const SizedBox.shrink())
               : NotificationListener<ScrollNotification>(
                   onNotification: _onScrollNotification,
-                  child: ListView(
+                  child: ListView.builder(
                     controller: _scrollController,
                     padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-                    children: [
-                      for (final msg in planState.messages)
-                        ChatMessageBubble(message: msg),
-                      if (planState.streamingText != null && planState.streamingText!.isNotEmpty)
-                        ChatMessageBubble(
-                          message: PlanMessage(
-                            role: MessageRole.assistant,
-                            content: planState.streamingText!,
-                          ),
-                          isStreaming: true,
-                        ),
-                      if (planState.activeTools.isNotEmpty)
-                        Padding(
-                          padding: const EdgeInsets.symmetric(vertical: 8),
-                          child: Wrap(
-                            spacing: 8,
-                            children: planState.activeTools.map((tool) {
-                              return Chip(
-                                avatar: const SizedBox(
-                                  width: 16,
-                                  height: 16,
-                                  child: CircularProgressIndicator(strokeWidth: 2),
-                                ),
-                                label: Text(_toolLabel(tool)),
-                              );
-                            }).toList(),
-                          ),
-                        ),
-                      if (planState.profileUpdateNote != null)
-                        Padding(
-                          padding: const EdgeInsets.symmetric(vertical: 8),
-                          child: Align(
-                            alignment: Alignment.centerLeft,
-                            child: Tooltip(
-                              message: planState.profileUpdateNote!.isEmpty
-                                  ? 'Travel profile updated'
-                                  : planState.profileUpdateNote!,
-                              child: Chip(
-                                avatar: Icon(Icons.check_circle_outline,
-                                    size: 16, color: theme.colorScheme.primary),
-                                label: const Text('Noted — travel profile updated'),
-                              ),
-                            ),
-                          ),
-                        ),
-                      if (planState.flightOffers != null && planState.flightOffers!.isNotEmpty)
-                        _FlightOptions(
-                          routeLabel: planState.flightRouteLabel,
-                          offers: planState.flightOffers!,
-                        ),
-                      if (planState.localRecs != null && planState.localRecs!.isNotEmpty)
-                        _LocalRecsSection(
-                          cityLabel: planState.localRecsCity,
-                          recs: planState.localRecs!,
-                        ),
-                      if (planState.eventResults != null && planState.eventResults!.isNotEmpty)
-                        _EventOptions(
-                          cityLabel: planState.eventsCityLabel,
-                          events: planState.eventResults!,
-                        ),
-                      if (planState.ferryOptions != null && planState.ferryOptions!.isNotEmpty)
-                        _FerryOptions(
-                          routeLabel: planState.ferryRouteLabel,
-                          options: planState.ferryOptions!,
-                        ),
-                      if (planState.eventLinks != null && planState.eventLinks!.isNotEmpty)
-                        Padding(
-                          padding: const EdgeInsets.symmetric(vertical: 4),
-                          child: SourceLinksCard(
-                            icon: Icons.local_activity,
-                            accent: AppColors.toolEvents,
-                            title: planState.eventLinksCity == null
-                                ? 'Find local events'
-                                : 'Find events in ${planState.eventLinksCity}',
-                            links: planState.eventLinks!,
-                          ),
-                        ),
-                      if (widget.footerBuilder != null)
-                        widget.footerBuilder!(context, planState),
-                      if (planState.error != null)
-                        Container(
-                          margin: const EdgeInsets.symmetric(vertical: 8),
-                          padding: const EdgeInsets.all(12),
-                          decoration: BoxDecoration(
-                            color: theme.colorScheme.errorContainer,
-                            borderRadius: BorderRadius.circular(8),
-                          ),
-                          child: Text(
-                            planState.error!,
-                            style: TextStyle(color: theme.colorScheme.onErrorContainer),
-                          ),
-                        ),
-                    ],
+                    itemCount: messages.length + 1,
+                    itemBuilder: (context, i) {
+                      if (i < messages.length) {
+                        // Append-only list, so index keys are stable.
+                        return ChatMessageBubble(
+                          key: ValueKey('msg-$i'),
+                          message: messages[i],
+                        );
+                      }
+                      return _ChatTail(
+                        key: const ValueKey('chat-tail'),
+                        state: widget.state,
+                        notifier: widget.notifier,
+                        footerBuilder: widget.footerBuilder,
+                        onViewTrip: widget.onViewTrip,
+                      );
+                    },
                   ),
                 ),
         ),
         _InputBar(
           controller: _controller,
-          enabled: !planState.isStreaming,
+          enabled: !isStreaming,
           hint: widget.inputHint,
           onSend: _send,
         ),
       ],
     );
   }
+}
 
-  String _toolLabel(String tool) {
+/// Everything below the committed messages — the live streaming bubble, tool
+/// chips, result chips, footer, and error banner. Each child watches its own
+/// narrow select so a token flush rebuilds only [_StreamingBubble].
+class _ChatTail extends StatelessWidget {
+  final ProviderListenable<PlanState> state;
+  final ProviderListenable<PlanNotifier> notifier;
+  final Widget Function(BuildContext context, PlanState state)? footerBuilder;
+  final void Function(String tripId)? onViewTrip;
+
+  const _ChatTail({
+    super.key,
+    required this.state,
+    required this.notifier,
+    required this.footerBuilder,
+    required this.onViewTrip,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        _StreamingBubble(state: state),
+        _ActiveToolChips(state: state),
+        _ProfileNoteChip(state: state),
+        _ResultChips(state: state, notifier: notifier, onViewTrip: onViewTrip),
+        if (footerBuilder != null)
+          _ChatFooter(state: state, footerBuilder: footerBuilder!),
+        _ErrorBanner(state: state),
+      ],
+    );
+  }
+}
+
+class _StreamingBubble extends ConsumerWidget {
+  final ProviderListenable<PlanState> state;
+
+  const _StreamingBubble({required this.state});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final text = ref.watch(state.select((s) => s.streamingText));
+    if (text == null || text.isEmpty) return const SizedBox.shrink();
+    return ChatMessageBubble(
+      message: PlanMessage(role: MessageRole.assistant, content: text),
+      isStreaming: true,
+    );
+  }
+}
+
+class _ActiveToolChips extends ConsumerWidget {
+  final ProviderListenable<PlanState> state;
+
+  const _ActiveToolChips({required this.state});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final activeTools = ref.watch(state.select((s) => s.activeTools));
+    if (activeTools.isEmpty) return const SizedBox.shrink();
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      child: Wrap(
+        spacing: 8,
+        children: activeTools.map((tool) {
+          return Chip(
+            avatar: const SizedBox(
+              width: 16,
+              height: 16,
+              child: CircularProgressIndicator(strokeWidth: 2),
+            ),
+            label: Text(_toolLabel(tool)),
+          );
+        }).toList(),
+      ),
+    );
+  }
+
+  static String _toolLabel(String tool) {
     switch (tool) {
       case 'search_places':
         return 'Searching places...';
@@ -243,11 +253,180 @@ class _ChatPanelState extends ConsumerState<ChatPanel> {
   }
 }
 
+class _ProfileNoteChip extends ConsumerWidget {
+  final ProviderListenable<PlanState> state;
+
+  const _ProfileNoteChip({required this.state});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final note = ref.watch(state.select((s) => s.profileUpdateNote));
+    if (note == null) return const SizedBox.shrink();
+    final theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      child: Align(
+        alignment: Alignment.centerLeft,
+        child: Tooltip(
+          message: note.isEmpty ? 'Travel profile updated' : note,
+          child: Chip(
+            avatar: Icon(Icons.check_circle_outline,
+                size: 16, color: theme.colorScheme.primary),
+            label: const Text('Noted — travel profile updated'),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// One quiet summary line per result set the agent found. The full results
+/// live on the trip detail screen (booking checklist, embedded events,
+/// itinerary pins), so the chat only names what arrived and links there.
+class _ResultChips extends ConsumerWidget {
+  final ProviderListenable<PlanState> state;
+  final ProviderListenable<PlanNotifier> notifier;
+  final void Function(String tripId)? onViewTrip;
+
+  const _ResultChips({
+    required this.state,
+    required this.notifier,
+    required this.onViewTrip,
+  });
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    // Record equality compares the lists by identity, which works because the
+    // provider replaces each list whole on its SSE event — never mutates one
+    // in place. In-place mutation would silently stop chip updates.
+    final r = ref.watch(state.select((s) => (
+          flights: s.flightOffers,
+          flightRoute: s.flightRouteLabel,
+          localRecs: s.localRecs,
+          localRecsCity: s.localRecsCity,
+          events: s.eventResults,
+          eventsCity: s.eventsCityLabel,
+          ferries: s.ferryOptions,
+          ferryRoute: s.ferryRouteLabel,
+          eventLinks: s.eventLinks,
+          eventLinksCity: s.eventLinksCity,
+          savedTripId: s.savedTripId,
+        )));
+
+    // Agent-tab chips are plain labels until `done` delivers savedTripId,
+    // then flip tappable; the refine panel passes no onViewTrip at all.
+    final tripId = r.savedTripId ?? ref.read(notifier).tripId;
+    final onTap = (onViewTrip != null && tripId != null)
+        ? () => onViewTrip!(tripId)
+        : null;
+
+    String label(int count, String singular, String plural, String? suffix) {
+      final base = '$count ${count == 1 ? singular : plural}';
+      return (suffix == null || suffix.trim().isEmpty) ? base : '$base · $suffix';
+    }
+
+    final chips = <Widget>[
+      if (r.flights != null && r.flights!.isNotEmpty)
+        ResultSummaryChip(
+          icon: Icons.flight,
+          accent: AppColors.toolFlights,
+          label: label(r.flights!.length, 'flight option', 'flight options',
+              r.flightRoute),
+          onTap: onTap,
+        ),
+      if (r.localRecs != null && r.localRecs!.isNotEmpty)
+        ResultSummaryChip(
+          icon: Icons.verified,
+          accent: AppColors.toolLocal,
+          label: label(r.localRecs!.length, 'local pick', 'local picks',
+              r.localRecsCity),
+          onTap: onTap,
+        ),
+      if (r.events != null && r.events!.isNotEmpty)
+        ResultSummaryChip(
+          icon: Icons.local_activity,
+          accent: AppColors.toolEvents,
+          label: label(r.events!.length, 'event', 'events', r.eventsCity),
+          onTap: onTap,
+        ),
+      if (r.ferries != null && r.ferries!.isNotEmpty)
+        ResultSummaryChip(
+          icon: Icons.directions_boat,
+          accent: AppColors.toolFerries,
+          label: label(r.ferries!.length, 'ferry option', 'ferry options',
+              r.ferryRoute),
+          onTap: onTap,
+        ),
+      if (r.eventLinks != null && r.eventLinks!.isNotEmpty)
+        ResultSummaryChip(
+          icon: Icons.link,
+          accent: AppColors.toolEvents,
+          label: label(r.eventLinks!.length, 'event source', 'event sources',
+              r.eventLinksCity),
+          onTap: onTap,
+        ),
+    ];
+
+    if (chips.isEmpty) return const SizedBox.shrink();
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 4),
+      child: Column(crossAxisAlignment: CrossAxisAlignment.start, children: chips),
+    );
+  }
+}
+
+/// Bridges the whole-state `footerBuilder(context, state)` contract into the
+/// select-based tail. Watching the full state here is fine — this leaf is
+/// nearly empty until the itinerary completes.
+class _ChatFooter extends ConsumerWidget {
+  final ProviderListenable<PlanState> state;
+  final Widget Function(BuildContext context, PlanState state) footerBuilder;
+
+  const _ChatFooter({required this.state, required this.footerBuilder});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final planState = ref.watch(state);
+    return footerBuilder(context, planState);
+  }
+}
+
+class _ErrorBanner extends ConsumerWidget {
+  final ProviderListenable<PlanState> state;
+
+  const _ErrorBanner({required this.state});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final error = ref.watch(state.select((s) => s.error));
+    if (error == null) return const SizedBox.shrink();
+    final theme = Theme.of(context);
+    return Container(
+      margin: const EdgeInsets.symmetric(vertical: 8),
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.errorContainer,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Text(
+        error,
+        style: TextStyle(color: theme.colorScheme.onErrorContainer),
+      ),
+    );
+  }
+}
+
 class ChatMessageBubble extends StatelessWidget {
   final PlanMessage message;
   final bool isStreaming;
 
   const ChatMessageBubble({super.key, required this.message, this.isStreaming = false});
+
+  Future<void> _openLink(String url) async {
+    final uri = Uri.tryParse(url);
+    if (uri == null) return;
+    await launchUrl(uri, mode: LaunchMode.externalApplication);
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -278,23 +457,20 @@ class ChatMessageBubble extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.end,
           children: [
             Flexible(
-              child: Text(
-                message.content,
-                style: TextStyle(
-                  color: isUser ? theme.colorScheme.onPrimary : theme.colorScheme.onSurface,
-                ),
-              ),
+              child: isUser
+                  ? Text(
+                      message.content,
+                      style: TextStyle(color: theme.colorScheme.onPrimary),
+                    )
+                  : GptMarkdown(
+                      message.content,
+                      style: TextStyle(color: theme.colorScheme.onSurface),
+                      onLinkTap: (url, title) => _openLink(url),
+                    ),
             ),
             if (isStreaming) ...[
               const SizedBox(width: 6),
-              SizedBox(
-                width: 8,
-                height: 8,
-                child: CircularProgressIndicator(
-                  strokeWidth: 1.5,
-                  color: theme.colorScheme.onSurface.withOpacity(0.5),
-                ),
-              ),
+              const _StreamingCursor(),
             ],
           ],
         ),
@@ -303,197 +479,41 @@ class ChatMessageBubble extends StatelessWidget {
   }
 }
 
-/// Inline flight results in the chat — a header plus the agent's top ranked
-/// options as shared FlightOfferCards (first = best match).
-class _FlightOptions extends StatelessWidget {
-  final String? routeLabel;
-  final List<FlightOffer> offers;
-
-  const _FlightOptions({required this.routeLabel, required this.offers});
+/// A softly blinking caret shown at the end of the live streaming bubble —
+/// quieter than a spinner.
+class _StreamingCursor extends StatefulWidget {
+  const _StreamingCursor();
 
   @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    final label = (routeLabel == null || routeLabel!.trim().isEmpty)
-        ? 'Flight options'
-        : 'Flight options · $routeLabel';
-    return Container(
-      margin: const EdgeInsets.symmetric(vertical: 12),
-      padding: const EdgeInsets.all(12),
-      decoration: BoxDecoration(
-        color: Colors.teal.shade50,
-        borderRadius: BorderRadius.circular(12),
-        border: Border.all(color: Colors.teal.shade200),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Row(
-            children: [
-              Icon(Icons.flight, color: Colors.teal.shade700, size: 20),
-              const SizedBox(width: 8),
-              Expanded(
-                child: Text(
-                  label,
-                  style: theme.textTheme.titleSmall?.copyWith(
-                    color: Colors.teal.shade800,
-                    fontWeight: FontWeight.bold,
-                  ),
-                ),
-              ),
-            ],
-          ),
-          const SizedBox(height: 8),
-          for (var i = 0; i < offers.length; i++)
-            FlightOfferCard(offer: offers[i], isBest: i == 0),
-        ],
-      ),
-    );
-  }
+  State<_StreamingCursor> createState() => _StreamingCursorState();
 }
 
-/// Inline local-events results in the chat — a header plus the agent's events
-/// for a city as shared EventCards.
-class _EventOptions extends StatelessWidget {
-  final String? cityLabel;
-  final List<Event> events;
-
-  const _EventOptions({required this.cityLabel, required this.events});
+class _StreamingCursorState extends State<_StreamingCursor>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller = AnimationController(
+    vsync: this,
+    duration: const Duration(milliseconds: 600),
+  )..repeat(reverse: true);
 
   @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    final accent = AppColors.toolEvents;
-    final label = (cityLabel == null || cityLabel!.trim().isEmpty)
-        ? 'Local events'
-        : 'Local events · $cityLabel';
-    return Container(
-      margin: const EdgeInsets.symmetric(vertical: 12),
-      padding: const EdgeInsets.all(12),
-      decoration: BoxDecoration(
-        color: accent.withValues(alpha: 0.08),
-        borderRadius: BorderRadius.circular(12),
-        border: Border.all(color: accent.withValues(alpha: 0.4)),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Row(
-            children: [
-              Icon(Icons.local_activity, color: accent, size: 20),
-              const SizedBox(width: 8),
-              Expanded(
-                child: Text(
-                  label,
-                  style: theme.textTheme.titleSmall?.copyWith(
-                    color: accent,
-                    fontWeight: FontWeight.bold,
-                  ),
-                ),
-              ),
-            ],
-          ),
-          const SizedBox(height: 8),
-          for (final e in events) EventCard(event: e),
-        ],
-      ),
-    );
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
   }
-}
-
-/// Inline curated local recommendations in the chat — the "legit info you can't
-/// google" surface, shown as attributed LocalRecCards under a tinted header.
-class _LocalRecsSection extends StatelessWidget {
-  final String? cityLabel;
-  final List<LocalRecommendation> recs;
-
-  const _LocalRecsSection({required this.cityLabel, required this.recs});
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final accent = AppColors.toolLocal;
-    final label = (cityLabel == null || cityLabel!.trim().isEmpty)
-        ? 'Local intel'
-        : 'Local intel · $cityLabel';
-    return Container(
-      margin: const EdgeInsets.symmetric(vertical: 12),
-      padding: const EdgeInsets.all(12),
-      decoration: BoxDecoration(
-        color: accent.withValues(alpha: 0.08),
-        borderRadius: BorderRadius.circular(12),
-        border: Border.all(color: accent.withValues(alpha: 0.4)),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Row(
-            children: [
-              Icon(Icons.verified, color: accent, size: 20),
-              const SizedBox(width: 8),
-              Expanded(
-                child: Text(
-                  label,
-                  style: theme.textTheme.titleSmall?.copyWith(
-                    color: accent,
-                    fontWeight: FontWeight.bold,
-                  ),
-                ),
-              ),
-            ],
-          ),
-          const SizedBox(height: 8),
-          for (final r in recs) LocalRecCard(rec: r),
-        ],
-      ),
-    );
-  }
-}
-
-/// Inline ferry results in the chat — a header plus the agent's ferry option(s)
-/// for a route as shared FerryCards.
-class _FerryOptions extends StatelessWidget {
-  final String? routeLabel;
-  final List<FerryOption> options;
-
-  const _FerryOptions({required this.routeLabel, required this.options});
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    final accent = AppColors.toolFerries;
-    final label = (routeLabel == null || routeLabel!.trim().isEmpty)
-        ? 'Ferries'
-        : 'Ferries · $routeLabel';
-    return Container(
-      margin: const EdgeInsets.symmetric(vertical: 12),
-      padding: const EdgeInsets.all(12),
-      decoration: BoxDecoration(
-        color: accent.withValues(alpha: 0.08),
-        borderRadius: BorderRadius.circular(12),
-        border: Border.all(color: accent.withValues(alpha: 0.4)),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Row(
-            children: [
-              Icon(Icons.directions_boat, color: accent, size: 20),
-              const SizedBox(width: 8),
-              Expanded(
-                child: Text(
-                  label,
-                  style: theme.textTheme.titleSmall?.copyWith(
-                    color: accent,
-                    fontWeight: FontWeight.bold,
-                  ),
-                ),
-              ),
-            ],
-          ),
-          const SizedBox(height: 8),
-          for (final o in options) FerryCard(option: o),
-        ],
+    return FadeTransition(
+      opacity: _controller.drive(Tween(begin: 0.15, end: 0.7)),
+      child: Container(
+        width: 2.5,
+        height: 16,
+        margin: const EdgeInsets.only(bottom: 2),
+        decoration: BoxDecoration(
+          color: theme.colorScheme.onSurface,
+          borderRadius: BorderRadius.circular(1.25),
+        ),
       ),
     );
   }
@@ -520,7 +540,7 @@ class _InputBar extends StatelessWidget {
         color: theme.colorScheme.surface,
         boxShadow: [
           BoxShadow(
-            color: Colors.black.withOpacity(0.06),
+            color: Colors.black.withValues(alpha: 0.06),
             blurRadius: 8,
             offset: const Offset(0, -2),
           ),

--- a/src/packages/flutter-app/lib/widgets/result_summary_chip.dart
+++ b/src/packages/flutter-app/lib/widgets/result_summary_chip.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/material.dart';
+
+/// A quiet one-line summary of a result set the agent found (flights, events,
+/// local picks, ferries) — replaces inline card stacks in the chat. The full
+/// results live on the trip detail screen; when [onTap] is set the chip shows
+/// a "View in trip" affordance and links there.
+class ResultSummaryChip extends StatelessWidget {
+  final IconData icon;
+  final Color accent;
+  final String label;
+  final VoidCallback? onTap;
+
+  const ResultSummaryChip({
+    super.key,
+    required this.icon,
+    required this.accent,
+    required this.label,
+    this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Align(
+      alignment: Alignment.centerLeft,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 2),
+        child: Material(
+          color: accent.withValues(alpha: 0.08),
+          borderRadius: BorderRadius.circular(20),
+          child: InkWell(
+            onTap: onTap,
+            borderRadius: BorderRadius.circular(20),
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Icon(icon, size: 18, color: accent),
+                  const SizedBox(width: 8),
+                  Flexible(
+                    child: Text(
+                      label,
+                      overflow: TextOverflow.ellipsis,
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: theme.colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                  ),
+                  if (onTap != null) ...[
+                    const SizedBox(width: 8),
+                    Text(
+                      'View in trip',
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: accent,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                    Icon(Icons.chevron_right, size: 16, color: accent),
+                  ],
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/src/packages/flutter-app/pubspec.lock
+++ b/src/packages/flutter-app/pubspec.lock
@@ -270,6 +270,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "8.1.1"
+  flutter_math_fork:
+    dependency: transitive
+    description:
+      name: flutter_math_fork
+      sha256: "6d5f2f1aa57ae539ffb0a04bb39d2da67af74601d685a161aff7ce5bda5fa407"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.4"
   flutter_riverpod:
     dependency: "direct main"
     description:
@@ -360,6 +368,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.3"
+  gpt_markdown:
+    dependency: "direct main"
+    description:
+      name: gpt_markdown
+      sha256: c14c2a4599a67df5b6a984808cbb7631b8d15c91984ffdd7998597b93a6ff136
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.7"
   graphs:
     dependency: transitive
     description:
@@ -861,6 +877,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.2"
+  tuple:
+    dependency: transitive
+    description:
+      name: tuple
+      sha256: a97ce2013f240b2f3807bcbaf218765b6f301c3eff91092bcfa23a039e7dd151
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.2"
   typed_data:
     dependency: transitive
     description:

--- a/src/packages/flutter-app/pubspec.yaml
+++ b/src/packages/flutter-app/pubspec.yaml
@@ -65,6 +65,9 @@ dependencies:
   # Sticky city/day section headers in scroll views (MultiSliver + SliverPinnedHeader)
   sliver_tools: ^0.2.12
 
+  # Markdown rendering for streamed assistant chat replies
+  gpt_markdown: ^1.1.7
+
   # Interactive map (OpenStreetMap tiles) for trip itineraries
   flutter_map: ^8.0.0
   flutter_map_marker_cluster: ^8.2.2

--- a/src/packages/flutter-app/test/plan_provider_stream_test.dart
+++ b/src/packages/flutter-app/test/plan_provider_stream_test.dart
@@ -1,0 +1,58 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:travel_route_planner/providers/plan_provider.dart';
+import 'package:travel_route_planner/services/api_client.dart';
+import 'package:travel_route_planner/services/plan_service.dart';
+
+/// Emits [deltaCount] text_delta events a couple of milliseconds apart —
+/// far faster than the notifier's flush interval, like the real SSE stream.
+class _FakePlanService extends PlanService {
+  final int deltaCount;
+
+  _FakePlanService(this.deltaCount) : super('http://unused');
+
+  @override
+  Stream<PlanEvent> streamPlan(
+    List<Map<String, String>> messages, {
+    String? bearerToken,
+    String? chatId,
+    String? tripId,
+  }) async* {
+    for (var i = 0; i < deltaCount; i++) {
+      await Future<void>.delayed(const Duration(milliseconds: 2));
+      yield PlanEvent(type: 'text_delta', data: {'text': 'tok$i '});
+    }
+  }
+}
+
+void main() {
+  test('text deltas are coalesced into far fewer state emissions', () async {
+    const deltas = 60;
+    final notifier = PlanNotifier(_FakePlanService(deltas), ApiClient());
+
+    var streamingEmissions = 0;
+    String? lastStreaming;
+    notifier.addListener((state) {
+      if (state.streamingText != lastStreaming) {
+        lastStreaming = state.streamingText;
+        if (state.streamingText != null) streamingEmissions++;
+      }
+    });
+
+    await notifier.sendMessage('hi');
+
+    // ~120ms of 2ms-apart deltas against a 48ms flush interval → a handful of
+    // emissions, never one per token.
+    expect(streamingEmissions, greaterThan(0));
+    expect(streamingEmissions, lessThan(deltas ~/ 3));
+
+    // No token lost to coalescing: the committed message is the concatenation.
+    final expected = List.generate(deltas, (i) => 'tok$i ').join();
+    expect(notifier.state.messages.last.content, expected);
+    expect(notifier.state.isStreaming, isFalse);
+    expect(notifier.state.streamingText, isNull);
+
+    // A late flush timer must not resurrect a ghost streaming bubble.
+    await Future<void>.delayed(const Duration(milliseconds: 80));
+    expect(notifier.state.streamingText, isNull);
+  });
+}


### PR DESCRIPTION
## Summary
- Coalesce SSE `text_delta` state updates in `PlanNotifier` to ~1 per 48ms (was one full-state emission per token), with cancel-before-clear so no ghost streaming bubble survives stream end, error, or dispose
- Restructure `ChatPanel`: keyed `ListView.builder` for committed messages + a `_ChatTail` of leaf widgets on narrow Riverpod selects, so a token flush repaints only the live bubble; auto-scroll is one frame-gated `jumpTo` instead of competing 200ms `animateTo` calls
- Render assistant replies as markdown via `gpt_markdown` (bold/lists/links instead of raw `**`); subtle blinking cursor replaces the in-bubble spinner
- Replace the inline flight/event/local-rec/ferry card stacks with one quiet `ResultSummaryChip` per result set — a plain label mid-stream that flips to a tappable "View in trip ›" once the trip saves (trip detail already owns that content: booking checklist, embedded events, itinerary pins); refine panel shows plain labels
- Reword `plan_handler.go` prompts: no "cards" references, summarize top options in prose, ask for light markdown formatting
- Spec at `specs/chat-streaming-polish/`

## Testing
- New `test/plan_provider_stream_test.dart`: 60 rapid tokens → a handful of state emissions, committed text equals concatenation, no ghost `streamingText`
- `flutter test` 27/27 passing; `flutter analyze` clean (only pre-existing infos); `go vet` + build clean; `flutter build web` succeeds with the new dependency
- Manual end-to-end via the dev stack + headless browser: streamed a full Athens/Santorini plan — rendered markdown mid-stream, chips instead of cards, tool chips + cursor while streaming, chips flipped tappable on completion and navigated to trip detail

🤖 Generated with [Claude Code](https://claude.com/claude-code)