### PR TITLE
feat: de-jank the trip refine panel — silent refresh, seed chip, update ack

### DIFF
--- a/specs/refine-panel-polish/plan.md
+++ b/specs/refine-panel-polish/plan.md
@@ -1,0 +1,59 @@
+# Plan: Refine Panel Polish
+
+> **HOW.** See `spec.md`. Flutter-only; no Go, endpoint, model-codegen, or env
+> changes. Builds directly on the chat-streaming-polish architecture (keyed
+> ListView.builder + `_ChatTail` leaf selects in `chat_panel.dart`).
+
+## Technical Approach
+
+Three fixes, all client-side:
+
+1. **Silent in-place refresh.** `trip_updated` currently routes to `_load()`,
+   which flips `_loading = true` and swaps the whole screen for a spinner,
+   unmounting the streaming chat. Add `_load({bool silent})` — when silent and
+   a trip is already displayed, skip the loading/error setStates and swallow
+   fetch errors (stale trip stays). New `_refresh()` coalesces bursts with a
+   trailing re-run (a `trip_updated` landing mid-fetch queues exactly one more
+   pass) and is shared by the panel listener and `RefreshIndicator`.
+2. **Seed context chip.** `PlanMessage` gains a UI-only `displayLabel`;
+   `sendMessage`/`beginSectionRefinement` thread it through. ChatPanel renders
+   labeled messages as a centered `_SeedContextChip` instead of a bubble. The
+   server history maps `m.content`, so the full seed still reaches the model.
+3. **"Itinerary updated" chip.** New `PlanState.tripUpdatedThisTurn` mirroring
+   the `profileUpdateNote` lifecycle (reset on send, set on `trip_updated`);
+   rendered by a `_ItineraryUpdatedChip` leaf in `_ChatTail`. Not keyed on
+   `tripUpdateCount` — that counter is monotonic and must never reset.
+
+## Go API Changes
+
+None.
+
+## Flutter Changes
+
+- `lib/models/plan_message.dart` — add `displayLabel` (plain in-memory class,
+  no codegen).
+- `lib/providers/plan_provider.dart` — `sendMessage`/`beginSectionRefinement`
+  `displayLabel` params; `tripUpdatedThisTurn` state.
+- `lib/widgets/chat_panel.dart` — `_SeedContextChip` branch in itemBuilder;
+  `_ItineraryUpdatedChip` in `_ChatTail`.
+- `lib/screens/trip_detail_screen.dart` — `_load(silent:)`, `_refresh()`,
+  rewire `onTripUpdated` and `RefreshIndicator`, pass the seed displayLabel.
+- `lib/widgets/trip_refine_panel.dart` — unchanged.
+
+## Contract Parity
+
+| JSON key | Go type | Dart type | Nullable? | ✓ |
+|----------|---------|-----------|-----------|---|
+| _(none — no contract changes)_ | | | | ✓ |
+
+## Cross-cutting
+
+None (no env vars, routes, or gateway changes).
+
+## Verification
+
+- `make flutter-analyze`, `make flutter-test` (extended stream test + two new
+  widget tests).
+- Manual via `make docker-dev` → `http://localhost:3000` (restart flutter
+  container + hard refresh): walk the acceptance criteria in `spec.md` on wide
+  and narrow layouts.

--- a/specs/refine-panel-polish/spec.md
+++ b/specs/refine-panel-polish/spec.md
@@ -1,0 +1,82 @@
+# Spec: Refine Panel Polish
+
+## Context
+
+The trip-detail "Refine with AI" panel shares the recently polished chat
+surface, but the surrounding screen still behaves roughly: every time the
+assistant patches the itinerary mid-conversation, the whole page (itinerary
+and the open chat) blanks to a loading spinner and remounts; the panel opens
+on a huge machine-generated first message full of coordinates; and nothing in
+the chat says "your change landed". The outcome: refining a trip feels as calm
+as the main planning chat — the itinerary updates in place behind the panel,
+the conversation starts with a tidy context marker, and each applied change is
+acknowledged inline.
+
+## User Stories
+
+- As a **trip owner refining a day**, I want the itinerary to update in place
+  while the assistant works so that the screen never blanks mid-conversation.
+- As a **trip owner**, I want the refine chat to open with a short "Refining
+  Day 2 — Athens" marker instead of a wall of coordinates so that the
+  conversation reads naturally.
+- As a **trip owner**, I want an inline "Itinerary updated" acknowledgment so
+  that I know a change landed without watching the list behind the panel.
+
+## Acceptance Criteria
+
+- [x] While a refine response streams, the trip screen never shows the
+      full-screen loading spinner; the itinerary list/map update in place.
+- [x] The chat's scroll position and any half-typed input survive an
+      itinerary update.
+- [x] The refine conversation opens with a compact context chip (e.g.
+      "Refining · Day 2 — Athens"); the raw seed text is not shown.
+- [x] The assistant still receives the full seed detail (its edits remain as
+      accurate as before).
+- [x] An "Itinerary updated" chip appears in the chat when a change is
+      applied and clears when the next message is sent.
+- [x] Pull-to-refresh on an already-loaded trip shows only the pull indicator,
+      never the full-screen spinner, and a failed refresh keeps showing the
+      current trip.
+- [x] The Agent tab's planning chat is unchanged (no new chips, seeds render
+      as before).
+- [x] Both layouts behave identically: wide (side dock) and narrow (bottom
+      sheet).
+
+## API Surface
+
+No endpoint or SSE changes. The existing mid-stream `trip_updated` event is
+consumed differently on the client.
+
+## Data Model
+
+No persisted entities change. The in-memory chat message gains an optional
+display label (UI-only; never sent to the server).
+
+## UI Behavior
+
+- **Surface:** trip detail screen (refine panel host) and the shared chat.
+- **Happy path:** owner taps Refine → panel opens with the context chip →
+  owner asks for a change → assistant streams, patches the section →
+  "Itinerary updated" chip appears, itinerary refreshes silently behind the
+  panel → conversation continues.
+- **States:** first load keeps today's spinner; refresh failures during a
+  refine are silent (stale trip stays); the full-screen error state remains
+  for the initial load only.
+
+## Edge Cases & Error States
+
+- Several itinerary patches in one assistant turn → refreshes coalesce; the
+  final state always reflects the last patch.
+- Refresh failing mid-refine must not replace the screen with an error page.
+- Re-opening Refine on another section re-seeds; each session starts with its
+  own context chip.
+
+## Out of Scope
+
+- Silent refresh for user-driven mutations (add/edit/delete/reorder) — they
+  keep their current reload behavior this pass.
+- Collapsing the Agent tab's trip-reopen seed message.
+
+## Open Questions
+
+None.

--- a/specs/refine-panel-polish/tasks.md
+++ b/specs/refine-panel-polish/tasks.md
@@ -1,0 +1,25 @@
+# Tasks: Refine Panel Polish
+
+> Dependency-ordered. `[P]` = can run in parallel with its siblings.
+
+## Flutter
+
+- [x] [P] `plan_message.dart`: add `displayLabel`
+- [x] [P] `trip_detail_screen.dart`: `_load(silent:)` + coalescing `_refresh()`;
+      rewire `onTripUpdated` + `RefreshIndicator`
+- [x] `plan_provider.dart`: thread `displayLabel` through
+      `sendMessage`/`beginSectionRefinement`; add `tripUpdatedThisTurn`
+- [x] `chat_panel.dart`: `_SeedContextChip` itemBuilder branch +
+      `_ItineraryUpdatedChip` in `_ChatTail`
+- [x] `trip_detail_screen.dart`: pass `displayLabel: 'Refining ${target.label}'`
+      in `_openRefine`
+
+## Verification
+
+- [x] Extend `test/plan_provider_stream_test.dart` (trip_updated lifecycle +
+      history integrity with displayLabel)
+- [x] New `test/chat_panel_seed_chip_test.dart`
+- [x] New `test/trip_detail_silent_refresh_test.dart`
+- [x] `make flutter-analyze` clean; `make flutter-test` green
+- [x] Manual end-to-end (`http://localhost:3000`): every acceptance criterion
+      in `spec.md`, wide + narrow layouts

--- a/src/packages/flutter-app/lib/models/plan_message.dart
+++ b/src/packages/flutter-app/lib/models/plan_message.dart
@@ -4,5 +4,14 @@ class PlanMessage {
   final MessageRole role;
   final String content;
 
-  const PlanMessage({required this.role, required this.content});
+  /// Compact UI stand-in. When set, the chat renders a system-style context
+  /// chip with this label instead of a message bubble; [content] (e.g. the
+  /// full refine seed) still goes to the server history untouched.
+  final String? displayLabel;
+
+  const PlanMessage({
+    required this.role,
+    required this.content,
+    this.displayLabel,
+  });
 }

--- a/src/packages/flutter-app/lib/providers/plan_provider.dart
+++ b/src/packages/flutter-app/lib/providers/plan_provider.dart
@@ -40,6 +40,11 @@ class PlanState {
   /// (server `trip_updated` event); listeners reload the trip when it grows.
   final int tripUpdateCount;
 
+  /// Whether the current/most recent turn patched the trip — drives the
+  /// transient "Itinerary updated" chip. Reset at the start of each send;
+  /// unlike [tripUpdateCount] it is not monotonic.
+  final bool tripUpdatedThisTurn;
+
   const PlanState({
     this.messages = const [],
     this.isStreaming = false,
@@ -61,6 +66,7 @@ class PlanState {
     this.error,
     this.profileUpdateNote,
     this.tripUpdateCount = 0,
+    this.tripUpdatedThisTurn = false,
   });
 
   PlanState copyWith({
@@ -84,6 +90,7 @@ class PlanState {
     Object? error = _sentinel,
     Object? profileUpdateNote = _sentinel,
     int? tripUpdateCount,
+    bool? tripUpdatedThisTurn,
   }) {
     return PlanState(
       messages: messages ?? this.messages,
@@ -109,6 +116,7 @@ class PlanState {
       profileUpdateNote:
           profileUpdateNote == _sentinel ? this.profileUpdateNote : profileUpdateNote as String?,
       tripUpdateCount: tripUpdateCount ?? this.tripUpdateCount,
+      tripUpdatedThisTurn: tripUpdatedThisTurn ?? this.tripUpdatedThisTurn,
     );
   }
 }
@@ -189,12 +197,13 @@ class PlanNotifier extends StateNotifier<PlanState> {
     }).toList();
   }
 
-  Future<void> sendMessage(String text) async {
+  Future<void> sendMessage(String text, {String? displayLabel}) async {
     if (state.isStreaming) return;
 
     _chatId ??= _newChatId();
 
-    final userMessage = PlanMessage(role: MessageRole.user, content: text);
+    final userMessage = PlanMessage(
+        role: MessageRole.user, content: text, displayLabel: displayLabel);
     final updatedMessages = [...state.messages, userMessage];
 
     state = state.copyWith(
@@ -214,6 +223,7 @@ class PlanNotifier extends StateNotifier<PlanState> {
       localRecsCity: null,
       error: null,
       profileUpdateNote: null,
+      tripUpdatedThisTurn: false,
     );
 
     final history = updatedMessages
@@ -255,7 +265,10 @@ class PlanNotifier extends StateNotifier<PlanState> {
             );
 
           case 'trip_updated':
-            state = state.copyWith(tripUpdateCount: state.tripUpdateCount + 1);
+            state = state.copyWith(
+              tripUpdateCount: state.tripUpdateCount + 1,
+              tripUpdatedThisTurn: true,
+            );
 
           case 'profile_updated':
             state = state.copyWith(
@@ -378,9 +391,9 @@ class PlanNotifier extends StateNotifier<PlanState> {
   /// clears any prior conversation and sends the seed describing the targeted
   /// section. Requires [tripId]; the server patches that trip directly, so no
   /// chat-group binding is needed.
-  void beginSectionRefinement(String seedMessage) {
+  void beginSectionRefinement(String seedMessage, {String? displayLabel}) {
     reset();
-    sendMessage(seedMessage);
+    sendMessage(seedMessage, displayLabel: displayLabel);
   }
 }
 

--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -108,11 +108,18 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
     _load();
   }
 
-  Future<void> _load() async {
-    setState(() {
-      _loading = true;
-      _error = null;
-    });
+  Future<void> _load({bool silent = false}) async {
+    // Silent mode refreshes an already-displayed trip in place — no
+    // full-screen spinner, no error page — so the refine panel (and the
+    // conversation streaming inside it) stays mounted. First load always
+    // takes the loud path.
+    final quiet = silent && _trip != null;
+    if (!quiet) {
+      setState(() {
+        _loading = true;
+        _error = null;
+      });
+    }
     try {
       final trip =
           await ref.read(tripsApiServiceProvider).getTrip(widget.tripId);
@@ -138,10 +145,38 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
         await _computeTravelTimes(trip);
       }
     } catch (e) {
-      if (mounted) setState(() => _error = e.toString());
+      // Quiet failures keep showing the stale trip; the next refresh or a
+      // loud load will surface a persistent problem.
+      if (mounted && !quiet) setState(() => _error = e.toString());
     } finally {
-      if (mounted) setState(() => _loading = false);
+      if (mounted && !quiet) setState(() => _loading = false);
     }
+  }
+
+  bool _refreshQueued = false;
+  Future<void>? _refreshFuture;
+
+  /// Silent in-place reload with trailing coalescing. The server can emit
+  /// several `trip_updated` events in one streaming turn; a bump that lands
+  /// mid-fetch queues exactly one more pass so the final state always
+  /// reflects the last patch. Concurrent user-driven `_load()` calls
+  /// (add/edit/delete flows) are a pre-existing last-write-wins race and are
+  /// not handled here.
+  Future<void> _refresh() {
+    final inFlight = _refreshFuture;
+    if (inFlight != null) {
+      _refreshQueued = true;
+      return inFlight;
+    }
+    final future = () async {
+      do {
+        _refreshQueued = false;
+        await _load(silent: true);
+      } while (mounted && _refreshQueued);
+      _refreshFuture = null;
+    }();
+    _refreshFuture = future;
+    return future;
   }
 
   /// Pushes the itinerary-derived booking checklist to the server, which upserts
@@ -501,7 +536,8 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
     }
     ref
         .read(tripRefineProvider(widget.tripId).notifier)
-        .beginSectionRefinement(_buildSectionSeed(trip, target));
+        .beginSectionRefinement(_buildSectionSeed(trip, target),
+            displayLabel: 'Refining ${target.label}');
     setState(() {
       _panelOpen = true;
       _refineTarget = target;
@@ -2349,7 +2385,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
                       // Pull-to-refresh: with async co-editing, this is how a
                       // user picks up a collaborator's latest changes.
                       final refreshable = RefreshIndicator(
-                        onRefresh: _load,
+                        onRefresh: _refresh,
                         child: scrollView,
                       );
 
@@ -2360,7 +2396,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
                         tripId: widget.tripId,
                         target: _refineTarget!,
                         onClose: () => setState(() => _panelOpen = false),
-                        onTripUpdated: _load,
+                        onTripUpdated: _refresh,
                       );
                       if (constraints.maxWidth >= 900) {
                         // Wide: dock the chat beside the itinerary.

--- a/src/packages/flutter-app/lib/widgets/chat_panel.dart
+++ b/src/packages/flutter-app/lib/widgets/chat_panel.dart
@@ -128,10 +128,20 @@ class _ChatPanelState extends ConsumerState<ChatPanel> {
                     itemCount: messages.length + 1,
                     itemBuilder: (context, i) {
                       if (i < messages.length) {
+                        final msg = messages[i];
+                        // Labeled messages (e.g. the machine-built refine
+                        // seed) collapse to a context chip; the full content
+                        // still went to the server history.
+                        if (msg.displayLabel != null) {
+                          return _SeedContextChip(
+                            key: ValueKey('msg-$i'),
+                            label: msg.displayLabel!,
+                          );
+                        }
                         // Append-only list, so index keys are stable.
                         return ChatMessageBubble(
                           key: ValueKey('msg-$i'),
-                          message: messages[i],
+                          message: msg,
                         );
                       }
                       return _ChatTail(
@@ -181,6 +191,7 @@ class _ChatTail extends StatelessWidget {
         _StreamingBubble(state: state),
         _ActiveToolChips(state: state),
         _ProfileNoteChip(state: state),
+        _ItineraryUpdatedChip(state: state),
         _ResultChips(state: state, notifier: notifier, onViewTrip: onViewTrip),
         if (footerBuilder != null)
           _ChatFooter(state: state, footerBuilder: footerBuilder!),
@@ -274,6 +285,62 @@ class _ProfileNoteChip extends ConsumerWidget {
                 size: 16, color: theme.colorScheme.primary),
             label: const Text('Noted — travel profile updated'),
           ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Transient acknowledgment that the current turn patched the bound trip
+/// (server `trip_updated` event — only fires in refine sessions). Cleared at
+/// the start of the next send, mirroring the profile-note chip lifecycle.
+class _ItineraryUpdatedChip extends ConsumerWidget {
+  final ProviderListenable<PlanState> state;
+
+  const _ItineraryUpdatedChip({required this.state});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final updated = ref.watch(state.select((s) => s.tripUpdatedThisTurn));
+    if (!updated) return const SizedBox.shrink();
+    final theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      child: Align(
+        alignment: Alignment.centerLeft,
+        child: Chip(
+          avatar: Icon(Icons.check_circle_outline,
+              size: 16, color: theme.colorScheme.primary),
+          label: const Text('Itinerary updated'),
+        ),
+      ),
+    );
+  }
+}
+
+/// Centered session marker rendered in place of a machine-built message (the
+/// refine seed) — keeps the conversation readable without hiding that a new
+/// refinement session started here.
+class _SeedContextChip extends StatelessWidget {
+  final String label;
+
+  const _SeedContextChip({super.key, required this.label});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      child: Center(
+        child: Chip(
+          avatar: Icon(Icons.auto_awesome,
+              size: 14, color: theme.colorScheme.onSurfaceVariant),
+          label: Text(label),
+          labelStyle: theme.textTheme.labelSmall?.copyWith(
+            color: theme.colorScheme.onSurfaceVariant,
+          ),
+          visualDensity: VisualDensity.compact,
+          side: BorderSide(color: theme.colorScheme.outlineVariant),
         ),
       ),
     );

--- a/src/packages/flutter-app/test/chat_panel_seed_chip_test.dart
+++ b/src/packages/flutter-app/test/chat_panel_seed_chip_test.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:travel_route_planner/providers/plan_provider.dart';
+import 'package:travel_route_planner/services/api_client.dart';
+import 'package:travel_route_planner/services/plan_service.dart';
+import 'package:travel_route_planner/widgets/chat_panel.dart';
+
+/// Replays a canned event list; no network.
+class _ScriptedPlanService extends PlanService {
+  final List<PlanEvent> events;
+
+  _ScriptedPlanService(this.events) : super('http://unused');
+
+  @override
+  Stream<PlanEvent> streamPlan(
+    List<Map<String, String>> messages, {
+    String? bearerToken,
+    String? chatId,
+    String? tripId,
+  }) async* {
+    for (final e in events) {
+      yield e;
+    }
+  }
+}
+
+void main() {
+  testWidgets(
+      'seed collapses to a context chip and trip_updated shows the ack chip',
+      (WidgetTester tester) async {
+    final service = _ScriptedPlanService([
+      const PlanEvent(type: 'trip_updated', data: {}),
+      const PlanEvent(type: 'text_delta', data: {'text': 'Swapped it out.'}),
+    ]);
+    final notifier = PlanNotifier(service, ApiClient(), tripId: 't1');
+    final provider =
+        StateNotifierProvider<PlanNotifier, PlanState>((ref) => notifier);
+
+    const seed = 'I want to refine my saved trip "Athens & Santorini". '
+        '- Acropolis [attraction] (37.9715, 23.7257), city: Athens, day 1';
+    notifier.beginSectionRefinement(seed,
+        displayLabel: 'Refining Day 1 — Athens');
+
+    await tester.pumpWidget(
+      ProviderScope(
+        child: MaterialApp(
+          home: Scaffold(
+            body: ChatPanel(state: provider, notifier: provider.notifier),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // The machine seed renders as a compact session marker, not a bubble.
+    expect(find.text('Refining Day 1 — Athens'), findsOneWidget);
+    expect(find.textContaining('37.9715'), findsNothing);
+    expect(find.textContaining('I want to refine'), findsNothing);
+
+    // The turn patched the trip, so the acknowledgment chip is visible.
+    expect(find.text('Itinerary updated'), findsOneWidget);
+  });
+}

--- a/src/packages/flutter-app/test/plan_provider_stream_test.dart
+++ b/src/packages/flutter-app/test/plan_provider_stream_test.dart
@@ -24,6 +24,28 @@ class _FakePlanService extends PlanService {
   }
 }
 
+/// Captures the history payload and replays a canned event list, so tests can
+/// assert what the server would receive and how events mutate state.
+class _ScriptedPlanService extends PlanService {
+  final List<PlanEvent> events;
+  List<Map<String, String>>? lastHistory;
+
+  _ScriptedPlanService(this.events) : super('http://unused');
+
+  @override
+  Stream<PlanEvent> streamPlan(
+    List<Map<String, String>> messages, {
+    String? bearerToken,
+    String? chatId,
+    String? tripId,
+  }) async* {
+    lastHistory = messages;
+    for (final e in events) {
+      yield e;
+    }
+  }
+}
+
 void main() {
   test('text deltas are coalesced into far fewer state emissions', () async {
     const deltas = 60;
@@ -54,5 +76,43 @@ void main() {
     // A late flush timer must not resurrect a ghost streaming bubble.
     await Future<void>.delayed(const Duration(milliseconds: 80));
     expect(notifier.state.streamingText, isNull);
+  });
+
+  test('trip_updated bumps the counter and flags the turn, reset on next send',
+      () async {
+    final service = _ScriptedPlanService([
+      const PlanEvent(type: 'trip_updated', data: {}),
+      const PlanEvent(type: 'trip_updated', data: {}),
+      const PlanEvent(type: 'text_delta', data: {'text': 'Swapped it out.'}),
+    ]);
+    final notifier = PlanNotifier(service, ApiClient(), tripId: 't1');
+
+    await notifier.sendMessage('replace the museum');
+    expect(notifier.state.tripUpdateCount, 2);
+    expect(notifier.state.tripUpdatedThisTurn, isTrue);
+
+    // The flag is per-turn; the monotonic counter is not.
+    service.events.clear();
+    await notifier.sendMessage('thanks');
+    expect(notifier.state.tripUpdatedThisTurn, isFalse);
+    expect(notifier.state.tripUpdateCount, 2);
+  });
+
+  test('displayLabel collapses the bubble but the full content reaches history',
+      () async {
+    final service = _ScriptedPlanService([
+      const PlanEvent(type: 'text_delta', data: {'text': 'On it.'}),
+    ]);
+    final notifier = PlanNotifier(service, ApiClient(), tripId: 't1');
+
+    const seed = 'I want to refine my saved trip "Athens" ... - Acropolis '
+        '[attraction] (37.97, 23.72), day 1, morning';
+    await notifier.sendMessage(seed, displayLabel: 'Refining Day 1 — Athens');
+
+    // UI-facing message carries the label; the server history carries the
+    // untouched machine seed.
+    expect(notifier.state.messages.first.displayLabel, 'Refining Day 1 — Athens');
+    expect(notifier.state.messages.first.content, seed);
+    expect(service.lastHistory!.first['content'], seed);
   });
 }

--- a/src/packages/flutter-app/test/trip_detail_silent_refresh_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_silent_refresh_test.dart
@@ -1,0 +1,108 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:travel_route_planner/models/trip.dart';
+import 'package:travel_route_planner/models/itinerary_item.dart';
+import 'package:travel_route_planner/services/api_client.dart';
+import 'package:travel_route_planner/services/trips_api_service.dart';
+import 'package:travel_route_planner/providers/trips_provider.dart';
+import 'package:travel_route_planner/screens/trip_detail_screen.dart';
+
+/// getTrip answers from a queue: a Trip resolves immediately, a Completer
+/// stays pending until the test completes it, an Exception throws.
+class _QueuedTripsApiService extends TripsApiService {
+  final List<Object> responses;
+  int calls = 0;
+
+  _QueuedTripsApiService(this.responses)
+      : super(ApiClient(baseUrl: 'http://test'));
+
+  @override
+  Future<Trip> getTrip(String id) {
+    final next = responses[calls < responses.length ? calls : responses.length - 1];
+    calls++;
+    if (next is Trip) return Future.value(next);
+    if (next is Completer<Trip>) return next.future;
+    return Future.error(next);
+  }
+}
+
+Trip _trip(String title) => Trip(
+      id: 't1',
+      title: title,
+      status: 'planned',
+      createdAt: '2026-06-01',
+      updatedAt: '2026-06-01',
+      items: [
+        // Zero coords so the screen skips the map widget in the test env.
+        ItineraryItem(
+          id: 'i0',
+          position: 0,
+          name: 'Acropolis',
+          address: 'Athens, Greece',
+          latitude: 0,
+          longitude: 0,
+          category: 'attraction',
+        ),
+      ],
+    );
+
+Future<void> _triggerRefresh(WidgetTester tester) async {
+  await tester.fling(find.byType(CustomScrollView), const Offset(0, 400), 1000);
+  await tester.pump(); // start the indicator
+  await tester.pump(const Duration(seconds: 1)); // cross the arm threshold
+}
+
+void main() {
+  testWidgets('pull-to-refresh updates in place with no full-screen spinner',
+      (WidgetTester tester) async {
+    final pending = Completer<Trip>();
+    final service = _QueuedTripsApiService([_trip('Athens Trip'), pending]);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [tripsApiServiceProvider.overrideWithValue(service)],
+        child: MaterialApp(home: TripDetailScreen(tripId: 't1')),
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(find.text('Acropolis'), findsOneWidget);
+
+    await _triggerRefresh(tester);
+    expect(service.calls, 2);
+
+    // Mid-refresh the trip stays on screen — the loud path would have
+    // replaced the CustomScrollView with a centered spinner.
+    expect(find.byType(CustomScrollView), findsOneWidget);
+    expect(find.text('Acropolis'), findsOneWidget);
+
+    pending.complete(_trip('Athens Trip (updated)'));
+    await tester.pumpAndSettle();
+    expect(find.text('Athens Trip (updated)'), findsWidgets);
+  });
+
+  testWidgets('a failed silent refresh keeps showing the stale trip',
+      (WidgetTester tester) async {
+    final service = _QueuedTripsApiService(
+        [_trip('Athens Trip'), Exception('network down')]);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [tripsApiServiceProvider.overrideWithValue(service)],
+        child: MaterialApp(home: TripDetailScreen(tripId: 't1')),
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(find.text('Acropolis'), findsOneWidget);
+
+    await _triggerRefresh(tester);
+    await tester.pumpAndSettle();
+
+    // No error page, no blanking — the stale trip stays.
+    expect(find.text('Could not load this trip'), findsNothing);
+    expect(find.text('Acropolis'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- Silent in-place refresh: `_load(silent:)` plus a coalescing `_refresh()` so mid-stream `trip_updated` events (and pull-to-refresh) reload the trip without swapping the screen for a full-page spinner — the open refine panel, its scroll position, and half-typed input all survive; multiple patches in one turn coalesce to a single trailing re-fetch; a failed silent refresh keeps showing the stale trip
- Seed context chip: `PlanMessage.displayLabel` collapses the machine-built refine seed (coordinate dump) into a centered "Refining · <target>" marker; the full seed still reaches the server history untouched, so edit accuracy is unchanged
- "Itinerary updated" chip: new per-turn `PlanState.tripUpdatedThisTurn` (deliberately separate from the monotonic `tripUpdateCount` the reload listener depends on) drives a transient acknowledgment in the chat, mirroring the profile-note chip lifecycle
- Agent tab unaffected: all new params are optional with null/false defaults; `trip_updated` only fires in trip-bound sessions
- Spec at `specs/refine-panel-polish/`

## Testing
- 5 new tests: trip_updated lifecycle (counter + per-turn flag reset), displayLabel-to-history integrity, seed chip + ack chip widget rendering, silent pull-to-refresh keeps the trip on screen mid-fetch, failed silent refresh keeps the stale trip with no error page
- `flutter test` 32/32 passing; `flutter analyze` clean (pre-existing infos only)
- Manual end-to-end via the dev stack + headless browser: refined the Athens/Santorini trip (swapped a restaurant) — screen never blanked during the patch, itinerary and travel times updated in place behind the open panel, seed rendered as the context chip, "Itinerary updated" chip appeared; verified both wide (side dock) and narrow (bottom sheet) layouts, conversation preserved across the layout change

🤖 Generated with [Claude Code](https://claude.com/claude-code)