### PR TITLE
API resilience: panic recovery, request IDs, /plan loop cap & cache metrics

### DIFF
--- a/src/packages/api/analytics.go
+++ b/src/packages/api/analytics.go
@@ -31,9 +31,15 @@ const maxEventMetadataBytes = 2048
 
 // recordEvent writes one analytics event. Fire-and-forget semantics: errors
 // are logged, never returned — callers must not branch on instrumentation.
-// Uses its own timeout off context.Background() so recording survives handler
-// teardown (several call sites are goroutines or post-stream code).
 func recordEvent(userID uuid.UUID, eventType string, tripID *uuid.UUID, metadata map[string]any) {
+	recordEventOpt(&userID, eventType, tripID, metadata)
+}
+
+// recordEventOpt is recordEvent for flows where the caller may be anonymous
+// (nil userID), e.g. the public /plan endpoint. Uses its own timeout off
+// context.Background() so recording survives handler teardown (several call
+// sites are goroutines or post-stream code).
+func recordEventOpt(userID *uuid.UUID, eventType string, tripID *uuid.UUID, metadata map[string]any) {
 	if dbPool == nil {
 		return
 	}
@@ -53,8 +59,12 @@ func recordEvent(userID uuid.UUID, eventType string, tripID *uuid.UUID, metadata
 	if tripID != nil {
 		tid = pgtype.UUID{Bytes: *tripID, Valid: true}
 	}
+	var uidParam pgtype.UUID
+	if userID != nil {
+		uidParam = pgtype.UUID{Bytes: *userID, Valid: true}
+	}
 	if err := store.New(dbPool).CreateAnalyticsEvent(ctx, store.CreateAnalyticsEventParams{
-		UserID:    userID,
+		UserID:    uidParam,
 		EventType: eventType,
 		TripID:    tid,
 		Metadata:  meta,
@@ -107,8 +117,12 @@ type MetricsResponse struct {
 	TodosMarkedBooked     int64            `json:"todos_marked_booked"`
 	ReturningUsers        int64            `json:"returning_users"`
 	PlanSessions          int64            `json:"plan_sessions"`
+	PlanSessionsAnonymous int64            `json:"plan_sessions_anonymous"`
+	PlanCapHits           int64            `json:"plan_cap_hits"`
 	PlanInputTokens       int64            `json:"plan_input_tokens"`
 	PlanOutputTokens      int64            `json:"plan_output_tokens"`
+	PlanCacheReadTokens   int64            `json:"plan_cache_read_tokens"`
+	PlanCacheCreateTokens int64            `json:"plan_cache_creation_tokens"`
 }
 
 // adminMetricsHandler is GET /api/v1/admin/metrics?days= (admin only; gated
@@ -167,6 +181,14 @@ func adminMetricsHandler(w http.ResponseWriter, r *http.Request) {
 		resp.PlanSessions = totals.Sessions
 		resp.PlanInputTokens = totals.InputTokens
 		resp.PlanOutputTokens = totals.OutputTokens
+		resp.PlanCacheReadTokens = totals.CacheReadTokens
+		resp.PlanCacheCreateTokens = totals.CacheCreationTokens
+	}
+	if n, err := q.CountAnonymousPlanSessions(ctx, since); err == nil {
+		resp.PlanSessionsAnonymous = n
+	}
+	if n, err := q.CountPlanCapHits(ctx, since); err == nil {
+		resp.PlanCapHits = n
 	}
 	if n, err := q.CountReturningUsers(ctx, since); err == nil {
 		resp.ReturningUsers = n

--- a/src/packages/api/main.go
+++ b/src/packages/api/main.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"log/slog"
 	"net/http"
 	"os"
 	"strconv"
@@ -26,21 +27,6 @@ type HealthResponse struct {
 	Timestamp time.Time `json:"timestamp"`
 	Service   string    `json:"service"`
 	Database  string    `json:"database"`
-}
-
-// loggingMiddleware logs incoming requests
-func loggingMiddleware(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		start := time.Now()
-		next.ServeHTTP(w, r)
-		log.Printf(
-			"%s %s %s %v",
-			r.Method,
-			r.RequestURI,
-			r.RemoteAddr,
-			time.Since(start),
-		)
-	})
 }
 
 // corsMiddleware adds CORS headers for origins listed in ALLOWED_ORIGINS
@@ -511,6 +497,11 @@ func summarizeStructure(node interface{}, depth int) interface{} {
 }
 
 func main() {
+	// slog is the canonical logger; SetDefault also routes the stdlib log
+	// package through the same handler, so existing log.Printf call sites
+	// keep working and share the format.
+	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, nil)))
+
 	ctx := context.Background()
 	dbURL := os.Getenv("DATABASE_URL")
 
@@ -567,7 +558,8 @@ func main() {
 	generalLimiter := newIPRateLimiter(60, 30)
 	strictLimiter := newIPRateLimiter(5, 3)
 	strict := rateLimitMiddleware(strictLimiter)
-	router.Use(loggingMiddleware)
+	router.Use(requestIDMiddleware)
+	router.Use(recoveryMiddleware)
 	router.Use(corsMiddleware)
 	router.Use(func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/src/packages/api/middleware.go
+++ b/src/packages/api/middleware.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"runtime/debug"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+const requestIDContextKey contextKey = "request_id"
+
+// requestIDFromContext returns the request ID stamped by requestIDMiddleware,
+// or "" outside a request.
+func requestIDFromContext(ctx context.Context) string {
+	id, _ := ctx.Value(requestIDContextKey).(string)
+	return id
+}
+
+// ctxLog returns a logger pre-tagged with the request ID, for handlers that
+// want correlated log lines. Falls back to the default logger untagged.
+func ctxLog(ctx context.Context) *slog.Logger {
+	if id := requestIDFromContext(ctx); id != "" {
+		return slog.Default().With("request_id", id)
+	}
+	return slog.Default()
+}
+
+// statusRecorder captures the response status for the request log. It must
+// forward Flush: the SSE /plan handler type-asserts http.Flusher on the
+// writer it receives, and losing that capability here would break streaming.
+type statusRecorder struct {
+	http.ResponseWriter
+	status int
+}
+
+func (s *statusRecorder) WriteHeader(code int) {
+	s.status = code
+	s.ResponseWriter.WriteHeader(code)
+}
+
+func (s *statusRecorder) Flush() {
+	if f, ok := s.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+// requestIDMiddleware assigns each request an ID (honoring an inbound
+// X-Request-ID from the gateway), echoes it on the response, and emits the
+// structured request log line.
+func requestIDMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		id := r.Header.Get("X-Request-ID")
+		if id == "" || len(id) > 128 {
+			id = uuid.NewString()
+		}
+		w.Header().Set("X-Request-ID", id)
+
+		rec := &statusRecorder{ResponseWriter: w, status: http.StatusOK}
+		start := time.Now()
+		next.ServeHTTP(rec, r.WithContext(context.WithValue(r.Context(), requestIDContextKey, id)))
+
+		slog.Info("request",
+			"request_id", id,
+			"method", r.Method,
+			"path", r.URL.Path,
+			"status", rec.status,
+			"duration_ms", time.Since(start).Milliseconds(),
+			"remote", clientIP(r),
+		)
+	})
+}
+
+// recoveryMiddleware converts a handler panic into a JSON 500 instead of a
+// dropped connection, logging the stack with the request ID. net/http already
+// keeps the process alive on handler panics; the value here is the clean
+// response and the structured log. For a stream that has already committed
+// headers (SSE), the 500 write is a harmless no-op on the wire.
+func recoveryMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer func() {
+			rec := recover()
+			if rec == nil {
+				return
+			}
+			if rec == http.ErrAbortHandler {
+				// net/http uses this sentinel to abort silently; preserve it.
+				panic(rec)
+			}
+			slog.Error("panic recovered",
+				"request_id", requestIDFromContext(r.Context()),
+				"method", r.Method,
+				"path", r.URL.Path,
+				"panic", fmt.Sprint(rec),
+				"stack", string(debug.Stack()),
+			)
+			writeJSONError(w, http.StatusInternalServerError, "internal server error")
+		}()
+		next.ServeHTTP(w, r)
+	})
+}

--- a/src/packages/api/middleware_test.go
+++ b/src/packages/api/middleware_test.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestRecoveryMiddlewareReturns500JSON(t *testing.T) {
+	h := recoveryMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		panic("boom")
+	}))
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest("GET", "/api/v1/anything", nil))
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); !strings.Contains(ct, "application/json") {
+		t.Fatalf("Content-Type = %q, want JSON", ct)
+	}
+	if !strings.Contains(rec.Body.String(), "internal server error") {
+		t.Fatalf("body = %q, want internal server error message", rec.Body.String())
+	}
+}
+
+func TestRecoveryMiddlewareServesAfterPanic(t *testing.T) {
+	calls := 0
+	h := recoveryMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if calls == 1 {
+			panic("first request dies")
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	h.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", "/", nil))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest("GET", "/", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("second request status = %d, want 200", rec.Code)
+	}
+}
+
+func TestRecoveryMiddlewareRepanicsErrAbortHandler(t *testing.T) {
+	h := recoveryMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		panic(http.ErrAbortHandler)
+	}))
+
+	defer func() {
+		if recover() != http.ErrAbortHandler {
+			t.Fatal("ErrAbortHandler was swallowed; must propagate")
+		}
+	}()
+	h.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", "/", nil))
+	t.Fatal("expected panic to propagate")
+}
+
+func TestRequestIDGeneratedAndEchoed(t *testing.T) {
+	var seenInCtx string
+	h := requestIDMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenInCtx = requestIDFromContext(r.Context())
+	}))
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest("GET", "/", nil))
+
+	got := rec.Header().Get("X-Request-ID")
+	if got == "" {
+		t.Fatal("no X-Request-ID on response")
+	}
+	if seenInCtx != got {
+		t.Fatalf("context ID %q != header ID %q", seenInCtx, got)
+	}
+}
+
+func TestRequestIDInboundReused(t *testing.T) {
+	h := requestIDMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+
+	req := httptest.NewRequest("GET", "/", nil)
+	req.Header.Set("X-Request-ID", "gateway-abc-123")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if got := rec.Header().Get("X-Request-ID"); got != "gateway-abc-123" {
+		t.Fatalf("X-Request-ID = %q, want inbound value reused", got)
+	}
+}
+
+// The SSE /plan handler requires http.Flusher on the writer it receives; the
+// status-recording wrapper must not hide it.
+func TestStatusRecorderForwardsFlusher(t *testing.T) {
+	var isFlusher bool
+	h := requestIDMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, isFlusher = w.(http.Flusher)
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+	}))
+
+	rec := httptest.NewRecorder() // httptest.ResponseRecorder implements Flusher
+	h.ServeHTTP(rec, httptest.NewRequest("GET", "/", nil))
+
+	if !isFlusher {
+		t.Fatal("statusRecorder does not expose http.Flusher — SSE /plan would break")
+	}
+	if !rec.Flushed {
+		t.Fatal("Flush was not forwarded to the underlying writer")
+	}
+}

--- a/src/packages/api/migrations/00028_analytics_anonymous_user.sql
+++ b/src/packages/api/migrations/00028_analytics_anonymous_user.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+-- Anonymous /plan sessions are now instrumented too: a null user_id marks an
+-- unauthenticated caller, so total AI spend covers everyone while per-user
+-- funnel queries filter to user_id IS NOT NULL.
+ALTER TABLE analytics_events ALTER COLUMN user_id DROP NOT NULL;
+
+-- +goose Down
+DELETE FROM analytics_events WHERE user_id IS NULL;
+ALTER TABLE analytics_events ALTER COLUMN user_id SET NOT NULL;

--- a/src/packages/api/plan_cache_test.go
+++ b/src/packages/api/plan_cache_test.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	anthropic "github.com/anthropics/anthropic-sdk-go"
+)
+
+// The /plan loop moves its conversation cache breakpoint each iteration by
+// zeroing the previous marker in place. That only works if a zeroed
+// CacheControlEphemeralParam is dropped from the request JSON entirely —
+// otherwise stale markers accumulate and the API 400s at the 5th breakpoint.
+func TestZeroedCacheControlOmittedFromJSON(t *testing.T) {
+	msg := anthropic.NewUserMessage(anthropic.NewToolResultBlock("tool_1", "result", false))
+	blocks := msg.Content
+	cc := blocks[len(blocks)-1].GetCacheControl()
+	if cc == nil {
+		t.Fatal("tool result block has no addressable cache control")
+	}
+
+	*cc = anthropic.NewCacheControlEphemeralParam()
+	withMarker, err := msg.MarshalJSON()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(withMarker), "cache_control") {
+		t.Fatalf("set marker missing from JSON: %s", withMarker)
+	}
+
+	*cc = anthropic.CacheControlEphemeralParam{}
+	cleared, err := msg.MarshalJSON()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(cleared), "cache_control") {
+		t.Fatalf("zeroed marker still present in JSON: %s", cleared)
+	}
+}

--- a/src/packages/api/plan_handler.go
+++ b/src/packages/api/plan_handler.go
@@ -17,6 +17,12 @@ import (
 	"travel-route-planner/store"
 )
 
+// planMaxIterations bounds the agent tool loop. A rich session (local recs +
+// several place searches + flights/events/stays + one create_itinerary) runs
+// 8–11 iterations; parallel tool calls share an iteration. Hitting the cap
+// ends the stream gracefully instead of letting a pathological loop burn cost.
+const planMaxIterations = 15
+
 type PlanRequest struct {
 	Messages []PlanChatMessage `json:"messages"`
 	ChatID   string            `json:"chat_id"`
@@ -65,22 +71,32 @@ func planHandler(w http.ResponseWriter, r *http.Request) {
 	// preference-writing tool; signed-in sessions get both.
 	uid, authed := userIDFromRequest(r)
 
-	// Session-level instrumentation (signed-in only; anonymous stays untracked).
-	// Completion carries token usage and tool-call count so AI cost per user
-	// can be summed. Deferred so it records however the stream ends.
+	// Session-level instrumentation for every caller — anonymous sessions
+	// carry a null user id, so total AI spend and the authed/anonymous split
+	// are both measurable. Completion carries token usage, tool calls, cache
+	// hits and cap state. Deferred so it records however the stream ends.
 	var planTokensIn, planTokensOut int64
-	var planToolCalls int
+	var planCacheRead, planCacheWrite int64
+	var planToolCalls, planIterations int
+	var planCapHit bool
 	var planTripID *uuid.UUID
+	var planUID *uuid.UUID
 	if authed {
-		go recordEvent(uid, "plan_session_started", nil, nil)
-		defer func() {
-			recordEvent(uid, "plan_session_completed", planTripID, map[string]any{
-				"input_tokens":  planTokensIn,
-				"output_tokens": planTokensOut,
-				"tool_calls":    planToolCalls,
-			})
-		}()
+		planUID = &uid
 	}
+	go recordEventOpt(planUID, "plan_session_started", nil, map[string]any{"authenticated": authed})
+	defer func() {
+		recordEventOpt(planUID, "plan_session_completed", planTripID, map[string]any{
+			"authenticated":         authed,
+			"input_tokens":          planTokensIn,
+			"output_tokens":         planTokensOut,
+			"tool_calls":            planToolCalls,
+			"iterations":            planIterations,
+			"max_iterations_hit":    planCapHit,
+			"cache_read_tokens":     planCacheRead,
+			"cache_creation_tokens": planCacheWrite,
+		})
+	}()
 
 	// A trip-bound session must verifiably own the trip before anything streams;
 	// failing closed here guarantees a refine panel can never fall back to the
@@ -346,10 +362,22 @@ func planHandler(w http.ResponseWriter, r *http.Request) {
 		systemPrompt += "\n\nYou are refining an existing saved trip in place. The conversation's first message describes the current itinerary and which section the traveler wants to change. Apply changes by calling update_itinerary_section with the targeted scope and the COMPLETE updated list of places for that section — include unchanged places with their existing coordinates, city, day, time_of_day and category tags so they aren't lost. Use search_places to find real coordinates for any new place before adding it. Only change the section the traveler asked about unless they broaden the request."
 	}
 
+	// prevCacheMarker tracks the conversation cache breakpoint set on the
+	// newest tool-results message; it must be cleared before setting the next
+	// one (the API allows at most 4 breakpoints per request).
+	var prevCacheMarker *anthropic.CacheControlEphemeralParam
+
 	for {
+		planIterations++
+		if planIterations > planMaxIterations {
+			planCapHit = true
+			sendSSE(w, "error", map[string]string{"message": "This planning session hit its step limit. Send another message to continue from where we left off."})
+			return
+		}
+
 		params := anthropic.MessageNewParams{
 			Model:     anthropic.ModelClaudeSonnet4_6,
-			MaxTokens: 4096,
+			MaxTokens: 8192,
 			System: []anthropic.TextBlockParam{
 				{
 					Text:         systemPrompt,
@@ -379,7 +407,16 @@ func planHandler(w http.ResponseWriter, r *http.Request) {
 		}
 		planTokensIn += resp.Usage.InputTokens
 		planTokensOut += resp.Usage.OutputTokens
+		planCacheRead += resp.Usage.CacheReadInputTokens
+		planCacheWrite += resp.Usage.CacheCreationInputTokens
 
+		// A max_tokens stop mid-tool-call means truncated tool input JSON —
+		// previously this failed silently and produced an empty itinerary.
+		// Surface it instead of continuing with garbage.
+		if resp.StopReason == anthropic.StopReasonMaxTokens {
+			sendSSE(w, "error", map[string]string{"message": "The response was cut off before it finished. Try asking for a shorter plan or fewer places at once."})
+			return
+		}
 		if resp.StopReason != anthropic.StopReasonToolUse {
 			break
 		}
@@ -705,6 +742,22 @@ func planHandler(w http.ResponseWriter, r *http.Request) {
 		}
 
 		messages = append(messages, anthropic.NewUserMessage(toolResults...))
+
+		// Move the conversation cache breakpoint onto the newest tool-results
+		// message so each iteration re-reads the growing history from cache
+		// instead of paying full input cost for it. The system-prompt
+		// breakpoint (above) covers tools + system; this one covers the turn
+		// transcript.
+		if prevCacheMarker != nil {
+			*prevCacheMarker = anthropic.CacheControlEphemeralParam{}
+			prevCacheMarker = nil
+		}
+		if blocks := messages[len(messages)-1].Content; len(blocks) > 0 {
+			if cc := blocks[len(blocks)-1].GetCacheControl(); cc != nil {
+				*cc = anthropic.NewCacheControlEphemeralParam()
+				prevCacheMarker = cc
+			}
+		}
 
 		select {
 		case <-ctx.Done():

--- a/src/packages/api/query/analytics.sql
+++ b/src/packages/api/query/analytics.sql
@@ -26,15 +26,29 @@ GROUP BY 1 ORDER BY clicks DESC;
 -- Sessions + token spend from plan_session_completed metadata.
 SELECT count(*) AS sessions,
        COALESCE(sum((metadata->>'input_tokens')::bigint), 0)::bigint AS input_tokens,
-       COALESCE(sum((metadata->>'output_tokens')::bigint), 0)::bigint AS output_tokens
+       COALESCE(sum((metadata->>'output_tokens')::bigint), 0)::bigint AS output_tokens,
+       COALESCE(sum((metadata->>'cache_read_tokens')::bigint), 0)::bigint AS cache_read_tokens,
+       COALESCE(sum((metadata->>'cache_creation_tokens')::bigint), 0)::bigint AS cache_creation_tokens
 FROM analytics_events
 WHERE event_type = 'plan_session_completed' AND created_at >= $1;
 
+-- name: CountAnonymousPlanSessions :one
+SELECT count(*) FROM analytics_events
+WHERE event_type = 'plan_session_started' AND user_id IS NULL AND created_at >= $1;
+
+-- name: CountPlanCapHits :one
+-- Sessions that hit the agent-loop iteration cap (free-tier pressure signal).
+SELECT count(*) FROM analytics_events
+WHERE event_type = 'plan_session_completed'
+  AND (metadata->>'max_iterations_hit')::boolean
+  AND created_at >= $1;
+
 -- name: CountReturningUsers :one
 -- Users with planning sessions on at least two distinct days in the window.
+-- user_id IS NOT NULL: anonymous sessions must not group into a phantom user.
 SELECT count(*) FROM (
   SELECT user_id FROM analytics_events
-  WHERE event_type = 'plan_session_started' AND created_at >= $1
+  WHERE event_type = 'plan_session_started' AND user_id IS NOT NULL AND created_at >= $1
   GROUP BY user_id
   HAVING count(DISTINCT date(created_at)) >= 2
 ) returning_users;

--- a/src/packages/api/store/analytics.sql.go
+++ b/src/packages/api/store/analytics.sql.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
@@ -59,6 +58,18 @@ func (q *Queries) CountActivatedSignups(ctx context.Context, createdAt time.Time
 	return count, err
 }
 
+const countAnonymousPlanSessions = `-- name: CountAnonymousPlanSessions :one
+SELECT count(*) FROM analytics_events
+WHERE event_type = 'plan_session_started' AND user_id IS NULL AND created_at >= $1
+`
+
+func (q *Queries) CountAnonymousPlanSessions(ctx context.Context, createdAt time.Time) (int64, error) {
+	row := q.db.QueryRow(ctx, countAnonymousPlanSessions, createdAt)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
 const countEventsByType = `-- name: CountEventsByType :one
 SELECT count(*) FROM analytics_events
 WHERE event_type = $1 AND created_at >= $2
@@ -76,16 +87,32 @@ func (q *Queries) CountEventsByType(ctx context.Context, arg CountEventsByTypePa
 	return count, err
 }
 
+const countPlanCapHits = `-- name: CountPlanCapHits :one
+SELECT count(*) FROM analytics_events
+WHERE event_type = 'plan_session_completed'
+  AND (metadata->>'max_iterations_hit')::boolean
+  AND created_at >= $1
+`
+
+// Sessions that hit the agent-loop iteration cap (free-tier pressure signal).
+func (q *Queries) CountPlanCapHits(ctx context.Context, createdAt time.Time) (int64, error) {
+	row := q.db.QueryRow(ctx, countPlanCapHits, createdAt)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
 const countReturningUsers = `-- name: CountReturningUsers :one
 SELECT count(*) FROM (
   SELECT user_id FROM analytics_events
-  WHERE event_type = 'plan_session_started' AND created_at >= $1
+  WHERE event_type = 'plan_session_started' AND user_id IS NOT NULL AND created_at >= $1
   GROUP BY user_id
   HAVING count(DISTINCT date(created_at)) >= 2
 ) returning_users
 `
 
 // Users with planning sessions on at least two distinct days in the window.
+// user_id IS NOT NULL: anonymous sessions must not group into a phantom user.
 func (q *Queries) CountReturningUsers(ctx context.Context, createdAt time.Time) (int64, error) {
 	row := q.db.QueryRow(ctx, countReturningUsers, createdAt)
 	var count int64
@@ -111,7 +138,7 @@ VALUES ($1, $2, $3, $4)
 `
 
 type CreateAnalyticsEventParams struct {
-	UserID    uuid.UUID   `json:"user_id"`
+	UserID    pgtype.UUID `json:"user_id"`
 	EventType string      `json:"event_type"`
 	TripID    pgtype.UUID `json:"trip_id"`
 	Metadata  []byte      `json:"metadata"`
@@ -130,21 +157,31 @@ func (q *Queries) CreateAnalyticsEvent(ctx context.Context, arg CreateAnalyticsE
 const planSessionTotals = `-- name: PlanSessionTotals :one
 SELECT count(*) AS sessions,
        COALESCE(sum((metadata->>'input_tokens')::bigint), 0)::bigint AS input_tokens,
-       COALESCE(sum((metadata->>'output_tokens')::bigint), 0)::bigint AS output_tokens
+       COALESCE(sum((metadata->>'output_tokens')::bigint), 0)::bigint AS output_tokens,
+       COALESCE(sum((metadata->>'cache_read_tokens')::bigint), 0)::bigint AS cache_read_tokens,
+       COALESCE(sum((metadata->>'cache_creation_tokens')::bigint), 0)::bigint AS cache_creation_tokens
 FROM analytics_events
 WHERE event_type = 'plan_session_completed' AND created_at >= $1
 `
 
 type PlanSessionTotalsRow struct {
-	Sessions     int64 `json:"sessions"`
-	InputTokens  int64 `json:"input_tokens"`
-	OutputTokens int64 `json:"output_tokens"`
+	Sessions            int64 `json:"sessions"`
+	InputTokens         int64 `json:"input_tokens"`
+	OutputTokens        int64 `json:"output_tokens"`
+	CacheReadTokens     int64 `json:"cache_read_tokens"`
+	CacheCreationTokens int64 `json:"cache_creation_tokens"`
 }
 
 // Sessions + token spend from plan_session_completed metadata.
 func (q *Queries) PlanSessionTotals(ctx context.Context, createdAt time.Time) (PlanSessionTotalsRow, error) {
 	row := q.db.QueryRow(ctx, planSessionTotals, createdAt)
 	var i PlanSessionTotalsRow
-	err := row.Scan(&i.Sessions, &i.InputTokens, &i.OutputTokens)
+	err := row.Scan(
+		&i.Sessions,
+		&i.InputTokens,
+		&i.OutputTokens,
+		&i.CacheReadTokens,
+		&i.CacheCreationTokens,
+	)
 	return i, err
 }

--- a/src/packages/api/store/models.go
+++ b/src/packages/api/store/models.go
@@ -29,7 +29,7 @@ type Accommodation struct {
 
 type AnalyticsEvent struct {
 	ID        uuid.UUID   `json:"id"`
-	UserID    uuid.UUID   `json:"user_id"`
+	UserID    pgtype.UUID `json:"user_id"`
 	EventType string      `json:"event_type"`
 	TripID    pgtype.UUID `json:"trip_id"`
 	Metadata  []byte      `json:"metadata"`


### PR DESCRIPTION
## What

**Middleware (new `middleware.go`)**
- `recoveryMiddleware`: handler panics become a JSON 500 with a structured stack log (request ID included) instead of a dropped connection; `http.ErrAbortHandler` is re-panicked to preserve the net/http contract.
- `requestIDMiddleware` (replaces `loggingMiddleware`): honors inbound `X-Request-ID` (gateway) or generates one, echoes it on the response, stores it in context, and emits a structured request log via slog. The `statusRecorder` wrapper **forwards `Flush()`** — regression-tested, since SSE `/plan` type-asserts `http.Flusher`.
- `slog.SetDefault` in `main()` routes the stdlib `log` package through the same handler — existing `log.Printf` call sites unchanged.

**/plan agent-loop hardening**
- `planMaxIterations = 15` cap with a graceful SSE error (was an unbounded `for {}`).
- Explicit `max_tokens` stop handling — previously a truncated `create_itinerary` tool input failed silently and produced an empty itinerary.
- `MaxTokens` 4096 → 8192 (streaming already on; removes the itinerary-truncation failure mode).
- Moving conversation cache breakpoint: each iteration re-reads the growing transcript from prompt cache (previous marker cleared first — 4-breakpoint API limit). System-prompt breakpoint already existed and covers tools+system.
- Cache read/creation tokens accumulated into session metadata.

**Anonymous /plan attribution** (endpoint stays public)
- Migration 00028: `analytics_events.user_id` nullable; NULL = anonymous caller.
- `recordEventOpt` (nil-able user) wrapper; `recordEvent` signature unchanged for all existing call sites.
- `plan_session_started/completed` now recorded for every caller with `authenticated`, `iterations`, `max_iterations_hit`, and cache-token metadata.
- `CountReturningUsers` guarded with `user_id IS NOT NULL` (no phantom anonymous "user").
- Metrics endpoint additions: `plan_sessions_anonymous`, `plan_cap_hits`, `plan_cache_read_tokens`, `plan_cache_creation_tokens`.

## Tests
- 6 new middleware tests (recovery 500 + continue-serving + ErrAbortHandler propagation; request-ID generate/reuse; **Flusher forwarding**).
- `gofmt` / `go vet` / full `go test ./...` green locally.

Part of Wave 6, PR 1 of ~8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)