### PR TITLE
Postgres-backed handler/authorization integration test suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,23 @@ jobs:
     defaults:
       run:
         working-directory: src/packages/api
+    services:
+      # Separate database from the migrations job's: this one backs the
+      # integration test suite (TRUNCATE isolation), that one validates the
+      # `go run . migrate` entrypoint against a pristine DB.
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: travel_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
     steps:
       - uses: actions/checkout@v4
 
@@ -36,7 +53,12 @@ jobs:
         run: go vet ./...
 
       - name: go test
-        run: go test ./...
+        env:
+          TEST_DATABASE_URL: postgres://postgres:postgres@localhost:5432/travel_test?sslmode=disable
+        run: go test -race ./...
+
+      - name: govulncheck
+        run: go run golang.org/x/vuln/cmd/govulncheck@latest ./...
 
       - name: sqlc drift check
         run: |

--- a/src/packages/api/admin_integration_test.go
+++ b/src/packages/api/admin_integration_test.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestAdminRoutesRequireAdmin(t *testing.T) {
+	resetDB(t)
+	_, userToken := createTestUser(t, "civilian@example.com")
+
+	paths := []string{
+		"/api/v1/admin/metrics",
+		"/api/v1/admin/local/sources",
+		"/api/v1/admin/local/coverage",
+		"/api/v1/trips/versions",
+	}
+	for _, p := range paths {
+		if rec := doJSON(t, "GET", p, userToken, nil); rec.Code != http.StatusForbidden {
+			t.Fatalf("non-admin GET %s = %d, want 403", p, rec.Code)
+		}
+		if rec := doJSON(t, "GET", p, "", nil); rec.Code != http.StatusUnauthorized {
+			t.Fatalf("anonymous GET %s = %d, want 401", p, rec.Code)
+		}
+	}
+}
+
+func TestAdminMetricsForAdmin(t *testing.T) {
+	resetDB(t)
+	admin, adminToken := createTestUser(t, "admin@example.com")
+	makeAdmin(t, admin.ID)
+
+	rec := doJSON(t, "GET", "/api/v1/admin/metrics?days=7", adminToken, nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("admin metrics = %d: %s", rec.Code, rec.Body.String())
+	}
+	body := decode(t, rec)
+	if body["days"] != float64(7) {
+		t.Fatalf("days = %v, want 7", body["days"])
+	}
+}

--- a/src/packages/api/auth_integration_test.go
+++ b/src/packages/api/auth_integration_test.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestRegisterLoginFlow(t *testing.T) {
+	resetDB(t)
+
+	rec := doJSON(t, "POST", "/api/v1/auth/register", "", map[string]any{
+		"email": "traveler@example.com", "password": "hunter2hunter2",
+	})
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("register = %d: %s", rec.Code, rec.Body.String())
+	}
+	token, _ := decode(t, rec)["token"].(string)
+	if token == "" {
+		t.Fatal("register returned no token")
+	}
+
+	me := doJSON(t, "GET", "/api/v1/auth/me", token, nil)
+	if me.Code != http.StatusOK {
+		t.Fatalf("/auth/me with fresh token = %d", me.Code)
+	}
+	if decode(t, me)["email"] != "traveler@example.com" {
+		t.Fatalf("/auth/me user payload wrong: %s", me.Body.String())
+	}
+
+	login := doJSON(t, "POST", "/api/v1/auth/login", "", map[string]any{
+		"email": "traveler@example.com", "password": "hunter2hunter2",
+	})
+	if login.Code != http.StatusOK {
+		t.Fatalf("login = %d: %s", login.Code, login.Body.String())
+	}
+}
+
+func TestRegisterDuplicateEmail(t *testing.T) {
+	resetDB(t)
+	createTestUser(t, "taken@example.com")
+
+	rec := doJSON(t, "POST", "/api/v1/auth/register", "", map[string]any{
+		"email": "taken@example.com", "password": "hunter2hunter2",
+	})
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("duplicate register = %d, want 409", rec.Code)
+	}
+}
+
+func TestRegisterValidation(t *testing.T) {
+	resetDB(t)
+
+	if rec := doJSON(t, "POST", "/api/v1/auth/register", "", map[string]any{
+		"email": "not-an-email", "password": "hunter2hunter2",
+	}); rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("bad email = %d, want 422", rec.Code)
+	}
+	if rec := doJSON(t, "POST", "/api/v1/auth/register", "", map[string]any{
+		"email": "ok@example.com", "password": "short",
+	}); rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("short password = %d, want 422", rec.Code)
+	}
+}
+
+// Wrong password and unknown email must be indistinguishable (no account
+// enumeration).
+func TestLoginFailuresIdentical(t *testing.T) {
+	resetDB(t)
+	createTestUser(t, "real@example.com")
+
+	wrongPw := doJSON(t, "POST", "/api/v1/auth/login", "", map[string]any{
+		"email": "real@example.com", "password": "wrong-password",
+	})
+	noUser := doJSON(t, "POST", "/api/v1/auth/login", "", map[string]any{
+		"email": "ghost@example.com", "password": "wrong-password",
+	})
+	if wrongPw.Code != http.StatusUnauthorized || noUser.Code != http.StatusUnauthorized {
+		t.Fatalf("login failures = %d/%d, want 401/401", wrongPw.Code, noUser.Code)
+	}
+	if wrongPw.Body.String() != noUser.Body.String() {
+		t.Fatalf("failure bodies differ (enumeration risk): %q vs %q",
+			wrongPw.Body.String(), noUser.Body.String())
+	}
+}
+
+func TestAuthMeRejectsBadTokens(t *testing.T) {
+	resetDB(t)
+
+	if rec := doJSON(t, "GET", "/api/v1/auth/me", "", nil); rec.Code != http.StatusUnauthorized {
+		t.Fatalf("no token = %d, want 401", rec.Code)
+	}
+	if rec := doJSON(t, "GET", "/api/v1/auth/me", "totally-fake-token", nil); rec.Code != http.StatusUnauthorized {
+		t.Fatalf("garbage token = %d, want 401", rec.Code)
+	}
+}
+
+func TestLogoutInvalidatesToken(t *testing.T) {
+	resetDB(t)
+	_, token := createTestUser(t, "bye@example.com")
+
+	if rec := doJSON(t, "POST", "/api/v1/auth/logout", token, nil); rec.Code >= 300 {
+		t.Fatalf("logout = %d", rec.Code)
+	}
+	if rec := doJSON(t, "GET", "/api/v1/auth/me", token, nil); rec.Code != http.StatusUnauthorized {
+		t.Fatalf("token after logout = %d, want 401", rec.Code)
+	}
+}
+
+// The strict limiter allows a burst of 3 per IP on auth routes; a 4th
+// register from the same IP must 429. Every other test uses a unique IP.
+func TestStrictRateLimiterOnRegister(t *testing.T) {
+	resetDB(t)
+	ip := nextTestIP()
+
+	var last int
+	for i := 0; i < 4; i++ {
+		rec := doJSONFromIP(t, "POST", "/api/v1/auth/register", "", ip, map[string]any{
+			"email": "spam" + nextTestIP() + "@example.com", "password": "hunter2hunter2",
+		})
+		last = rec.Code
+	}
+	if last != http.StatusTooManyRequests {
+		t.Fatalf("4th register from one IP = %d, want 429", last)
+	}
+}

--- a/src/packages/api/collaborator_integration_test.go
+++ b/src/packages/api/collaborator_integration_test.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func joinShare(t *testing.T, userToken, shareToken string) *httptest.ResponseRecorder {
+	t.Helper()
+	return doJSON(t, "POST", "/api/v1/shared/"+shareToken+"/join", userToken, nil)
+}
+
+func TestEditorJoinAndEdit(t *testing.T) {
+	resetDB(t)
+	owner, ownerToken := createTestUser(t, "owner@example.com")
+	_, editorToken := createTestUser(t, "editor@example.com")
+	trip := createTestTrip(t, owner.ID, 2)
+	shareToken := createShare(t, ownerToken, trip.ID.String(), "editor")
+
+	if rec := joinShare(t, editorToken, shareToken); rec.Code >= 300 {
+		t.Fatalf("join = %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// Membership grants item-level editing on the trip.
+	add := doJSON(t, "POST", "/api/v1/trips/"+trip.ID.String()+"/items", editorToken, map[string]any{
+		"name": "Editor's Pick", "latitude": 37.98, "longitude": 23.73,
+	})
+	if add.Code != http.StatusCreated && add.Code != http.StatusOK {
+		t.Fatalf("editor add item = %d: %s", add.Code, add.Body.String())
+	}
+}
+
+func TestViewerTokenCannotJoin(t *testing.T) {
+	resetDB(t)
+	owner, ownerToken := createTestUser(t, "owner@example.com")
+	_, viewerToken := createTestUser(t, "viewer@example.com")
+	trip := createTestTrip(t, owner.ID, 1)
+	shareToken := createShare(t, ownerToken, trip.ID.String(), "viewer")
+
+	if rec := joinShare(t, viewerToken, shareToken); rec.Code != http.StatusForbidden {
+		t.Fatalf("viewer join = %d, want 403", rec.Code)
+	}
+}
+
+func TestNonMemberCannotEdit(t *testing.T) {
+	resetDB(t)
+	owner, _ := createTestUser(t, "owner@example.com")
+	_, strangerToken := createTestUser(t, "stranger@example.com")
+	trip := createTestTrip(t, owner.ID, 1)
+
+	rec := doJSON(t, "POST", "/api/v1/trips/"+trip.ID.String()+"/items", strangerToken, map[string]any{
+		"name": "Intrusion", "latitude": 1.0, "longitude": 1.0,
+	})
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("non-member add item = %d, want 404", rec.Code)
+	}
+}
+
+// Membership binds to the lineage, not the link: revoking share links must
+// not eject existing collaborators.
+func TestMembershipSurvivesLinkRevocation(t *testing.T) {
+	resetDB(t)
+	owner, ownerToken := createTestUser(t, "owner@example.com")
+	_, editorToken := createTestUser(t, "editor@example.com")
+	trip := createTestTrip(t, owner.ID, 1)
+	shareToken := createShare(t, ownerToken, trip.ID.String(), "editor")
+
+	if rec := joinShare(t, editorToken, shareToken); rec.Code >= 300 {
+		t.Fatalf("join = %d", rec.Code)
+	}
+	if rec := doJSON(t, "DELETE", "/api/v1/trips/"+trip.ID.String()+"/share", ownerToken, nil); rec.Code >= 300 {
+		t.Fatalf("revoke = %d", rec.Code)
+	}
+
+	add := doJSON(t, "POST", "/api/v1/trips/"+trip.ID.String()+"/items", editorToken, map[string]any{
+		"name": "Still Here", "latitude": 37.98, "longitude": 23.73,
+	})
+	if add.Code != http.StatusCreated && add.Code != http.StatusOK {
+		t.Fatalf("editor edit after revoke = %d, want success", add.Code)
+	}
+}
+
+func TestCollaboratorListAndRemoval(t *testing.T) {
+	resetDB(t)
+	owner, ownerToken := createTestUser(t, "owner@example.com")
+	editor, editorToken := createTestUser(t, "editor@example.com")
+	trip := createTestTrip(t, owner.ID, 1)
+	shareToken := createShare(t, ownerToken, trip.ID.String(), "editor")
+	if rec := joinShare(t, editorToken, shareToken); rec.Code >= 300 {
+		t.Fatalf("join = %d", rec.Code)
+	}
+
+	list := doJSON(t, "GET", "/api/v1/trips/"+trip.ID.String()+"/collaborators", ownerToken, nil)
+	if list.Code != http.StatusOK {
+		t.Fatalf("owner list collaborators = %d", list.Code)
+	}
+
+	// Non-owner cannot enumerate collaborators (404, no existence leak).
+	if rec := doJSON(t, "GET", "/api/v1/trips/"+trip.ID.String()+"/collaborators", editorToken, nil); rec.Code != http.StatusNotFound {
+		t.Fatalf("non-owner list = %d, want 404", rec.Code)
+	}
+
+	remove := doJSON(t, "DELETE", "/api/v1/trips/"+trip.ID.String()+"/collaborators/"+editor.ID.String(), ownerToken, nil)
+	if remove.Code >= 300 {
+		t.Fatalf("remove collaborator = %d", remove.Code)
+	}
+	add := doJSON(t, "POST", "/api/v1/trips/"+trip.ID.String()+"/items", editorToken, map[string]any{
+		"name": "Ghost Edit", "latitude": 1.0, "longitude": 1.0,
+	})
+	if add.Code != http.StatusNotFound {
+		t.Fatalf("removed editor add item = %d, want 404", add.Code)
+	}
+}

--- a/src/packages/api/integration_test.go
+++ b/src/packages/api/integration_test.go
@@ -1,0 +1,173 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http/httptest"
+	"os"
+	"sync/atomic"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/gorilla/mux"
+	"golang.org/x/crypto/bcrypt"
+
+	"travel-route-planner/store"
+)
+
+// Postgres-backed handler/authorization tests. They activate only when
+// TEST_DATABASE_URL is set (CI provides a postgres:16 service); without it
+// every integration test skips and the pure test suite runs as before.
+//
+// Isolation is TRUNCATE-between-tests (resetDB), so integration tests must
+// not use t.Parallel(). goose_db_version is never truncated.
+
+var testRouter *mux.Router
+
+func TestMain(m *testing.M) {
+	if url := os.Getenv("TEST_DATABASE_URL"); url != "" {
+		if err := runMigrations(url); err != nil {
+			log.Fatalf("test DB migration failed: %v", err)
+		}
+		pool, err := initDB(context.Background(), url)
+		if err != nil {
+			log.Fatalf("test DB unreachable: %v", err)
+		}
+		dbPool = pool
+		testRouter = buildRouter()
+	}
+	os.Exit(m.Run())
+}
+
+func requireDB(t *testing.T) {
+	t.Helper()
+	if dbPool == nil {
+		t.Skip("TEST_DATABASE_URL not set")
+	}
+}
+
+// resetDB truncates all application tables so each test starts clean.
+func resetDB(t *testing.T) {
+	t.Helper()
+	requireDB(t)
+	_, err := dbPool.Exec(context.Background(), `TRUNCATE
+		users, sessions, trips, itinerary_items, traveler_preferences,
+		accommodations, trip_segments, booking_todos, trip_shares,
+		trip_collaborators, email_tokens, analytics_events,
+		local_sources, local_recommendations, local_guides,
+		local_guide_recommendations, local_source_material CASCADE`)
+	if err != nil {
+		t.Fatalf("resetDB: %v", err)
+	}
+}
+
+// testIPCounter hands every request a unique client IP. clientIP() trusts the
+// rightmost X-Forwarded-For entry, so this keeps the strict per-IP rate
+// limiter (5/min on auth routes) from bleeding between tests.
+var testIPCounter atomic.Uint64
+
+func nextTestIP() string {
+	n := testIPCounter.Add(1)
+	return fmt.Sprintf("10.99.%d.%d", (n>>8)&0xff, n&0xff)
+}
+
+// doJSON drives the shared router in-process. token "" means anonymous;
+// ip "" means a fresh unique IP (pass a fixed ip to exercise rate limiting).
+func doJSON(t *testing.T, method, path, token string, body any) *httptest.ResponseRecorder {
+	t.Helper()
+	return doJSONFromIP(t, method, path, token, nextTestIP(), body)
+}
+
+func doJSONFromIP(t *testing.T, method, path, token, ip string, body any) *httptest.ResponseRecorder {
+	t.Helper()
+	var buf bytes.Buffer
+	if body != nil {
+		if err := json.NewEncoder(&buf).Encode(body); err != nil {
+			t.Fatalf("encode body: %v", err)
+		}
+	}
+	req := httptest.NewRequest(method, path, &buf)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Forwarded-For", ip)
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	rec := httptest.NewRecorder()
+	testRouter.ServeHTTP(rec, req)
+	return rec
+}
+
+// decode unmarshals a recorder body into a map for loose assertions.
+func decode(t *testing.T, rec *httptest.ResponseRecorder) map[string]any {
+	t.Helper()
+	var m map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &m); err != nil {
+		t.Fatalf("decode %q: %v", rec.Body.String(), err)
+	}
+	return m
+}
+
+// testPasswordHash is bcrypt.MinCost so fixtures don't pay the production
+// cost-12 hash (~300ms each). Only the tests that exercise the real
+// register/login flow go through full-cost hashing.
+var testPasswordHash = func() string {
+	b, err := bcrypt.GenerateFromPassword([]byte("password123"), bcrypt.MinCost)
+	if err != nil {
+		panic(err)
+	}
+	return string(b)
+}()
+
+// createTestUser inserts a user directly (bypassing bcrypt cost 12 and the
+// rate-limited register route) and returns it with a live session token.
+func createTestUser(t *testing.T, email string) (store.User, string) {
+	t.Helper()
+	ctx := context.Background()
+	q := store.New(dbPool)
+	name := "Test User"
+	u, err := q.CreateUser(ctx, store.CreateUserParams{
+		Email: email, PasswordHash: testPasswordHash, DisplayName: &name,
+	})
+	if err != nil {
+		t.Fatalf("createTestUser(%s): %v", email, err)
+	}
+	s, err := issueSession(ctx, q, u.ID)
+	if err != nil {
+		t.Fatalf("issueSession(%s): %v", email, err)
+	}
+	return u, s.ID
+}
+
+func makeAdmin(t *testing.T, id uuid.UUID) {
+	t.Helper()
+	if _, err := dbPool.Exec(context.Background(), `UPDATE users SET is_admin = true WHERE id = $1`, id); err != nil {
+		t.Fatalf("makeAdmin: %v", err)
+	}
+}
+
+// createTestTrip inserts a trip with n itinerary items owned by owner.
+func createTestTrip(t *testing.T, owner uuid.UUID, items int) store.Trip {
+	t.Helper()
+	ctx := context.Background()
+	q := store.New(dbPool)
+	chat := uuid.NewString()
+	trip, err := q.CreateTrip(ctx, store.CreateTripParams{
+		UserID: owner, Title: "Test Trip", Status: "draft", ChatID: &chat,
+	})
+	if err != nil {
+		t.Fatalf("createTestTrip: %v", err)
+	}
+	for i := 0; i < items; i++ {
+		_, err := q.CreateItineraryItem(ctx, store.CreateItineraryItemParams{
+			TripID: trip.ID, Position: int32(i), Name: fmt.Sprintf("Place %d", i+1),
+			Latitude: 37.97 + float64(i)*0.01, Longitude: 23.72,
+		})
+		if err != nil {
+			t.Fatalf("createTestTrip item %d: %v", i, err)
+		}
+	}
+	return trip
+}

--- a/src/packages/api/itinerary_item_integration_test.go
+++ b/src/packages/api/itinerary_item_integration_test.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"travel-route-planner/store"
+)
+
+func TestItemOwnerCRUDAndReorder(t *testing.T) {
+	resetDB(t)
+	owner, token := createTestUser(t, "owner@example.com")
+	trip := createTestTrip(t, owner.ID, 3)
+	base := "/api/v1/trips/" + trip.ID.String()
+
+	add := doJSON(t, "POST", base+"/items", token, map[string]any{
+		"name": "New Stop", "latitude": 37.99, "longitude": 23.74, "category": "restaurant",
+	})
+	if add.Code != http.StatusCreated && add.Code != http.StatusOK {
+		t.Fatalf("add = %d: %s", add.Code, add.Body.String())
+	}
+	// The add response is the whole updated trip; find the new item's id in
+	// the store by its name.
+	var newID string
+	created, err := store.New(dbPool).GetItineraryItemsByTrip(context.Background(), trip.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, it := range created {
+		if it.Name == "New Stop" {
+			newID = it.ID.String()
+		}
+	}
+	if newID == "" {
+		t.Fatalf("added item not found in store; add response: %s", add.Body.String())
+	}
+
+	patch := doJSON(t, "PATCH", base+"/items/"+newID, token, map[string]any{"name": "Renamed Stop"})
+	if patch.Code != http.StatusOK {
+		t.Fatalf("patch = %d: %s", patch.Code, patch.Body.String())
+	}
+
+	// Reorder: reverse the full item list.
+	items, err := store.New(dbPool).GetItineraryItemsByTrip(context.Background(), trip.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ids := make([]string, 0, len(items))
+	for i := len(items) - 1; i >= 0; i-- {
+		ids = append(ids, items[i].ID.String())
+	}
+	reorder := doJSON(t, "PUT", base+"/items/order", token, map[string]any{"item_ids": ids})
+	if reorder.Code != http.StatusOK && reorder.Code != http.StatusNoContent {
+		t.Fatalf("reorder = %d: %s", reorder.Code, reorder.Body.String())
+	}
+	after, err := store.New(dbPool).GetItineraryItemsByTrip(context.Background(), trip.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if after[0].ID.String() != ids[0] {
+		t.Fatalf("reorder not applied: first item %s, want %s", after[0].ID, ids[0])
+	}
+
+	del := doJSON(t, "DELETE", base+"/items/"+newID, token, nil)
+	if del.Code != http.StatusNoContent && del.Code != http.StatusOK {
+		t.Fatalf("delete = %d", del.Code)
+	}
+}
+
+func TestItemCrossUserIsolation(t *testing.T) {
+	resetDB(t)
+	owner, ownerToken := createTestUser(t, "owner@example.com")
+	_, intruderToken := createTestUser(t, "intruder@example.com")
+	trip := createTestTrip(t, owner.ID, 2)
+	base := "/api/v1/trips/" + trip.ID.String()
+
+	items, err := store.New(dbPool).GetItineraryItemsByTrip(context.Background(), trip.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	itemID := items[0].ID.String()
+
+	cases := []struct {
+		method, path string
+		body         any
+	}{
+		{"POST", base + "/items", map[string]any{"name": "X", "latitude": 1.0, "longitude": 1.0}},
+		{"PATCH", base + "/items/" + itemID, map[string]any{"name": "Hijack"}},
+		{"DELETE", base + "/items/" + itemID, nil},
+		{"PUT", base + "/items/order", map[string]any{"item_ids": []string{itemID}}},
+	}
+	for _, tc := range cases {
+		if rec := doJSON(t, tc.method, tc.path, intruderToken, tc.body); rec.Code != http.StatusNotFound {
+			t.Fatalf("intruder %s %s = %d, want 404", tc.method, tc.path, rec.Code)
+		}
+	}
+
+	// Sanity: the owner still can.
+	if rec := doJSON(t, "PATCH", base+"/items/"+itemID, ownerToken, map[string]any{"name": "Mine"}); rec.Code != http.StatusOK {
+		t.Fatalf("owner patch after intrusion attempts = %d", rec.Code)
+	}
+}
+
+func TestItemValidation(t *testing.T) {
+	resetDB(t)
+	owner, token := createTestUser(t, "owner@example.com")
+	trip := createTestTrip(t, owner.ID, 1)
+	base := "/api/v1/trips/" + trip.ID.String()
+
+	if rec := doJSON(t, "POST", base+"/items", token, map[string]any{
+		"name": "Bad Cat", "latitude": 1.0, "longitude": 1.0, "category": "spaceport",
+	}); rec.Code != http.StatusBadRequest {
+		t.Fatalf("invalid category = %d, want 400", rec.Code)
+	}
+	if rec := doJSON(t, "POST", base+"/items", token, map[string]any{
+		"name": "Bad Time", "latitude": 1.0, "longitude": 1.0, "time_of_day": "brunch",
+	}); rec.Code != http.StatusBadRequest {
+		t.Fatalf("invalid time_of_day = %d, want 400", rec.Code)
+	}
+
+	// A stale/partial reorder list conflicts.
+	rec := doJSON(t, "PUT", base+"/items/order", token, map[string]any{"item_ids": []string{}})
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("stale reorder = %d, want 409", rec.Code)
+	}
+}

--- a/src/packages/api/main.go
+++ b/src/packages/api/main.go
@@ -538,7 +538,13 @@ func main() {
 		log.Println("Connected to database; migrations applied")
 	}
 
-	// Create a new router
+	startServer(buildRouter())
+}
+
+// buildRouter wires all routes and middleware. It reads only package globals
+// (dbPool, service singletons), so main() and the integration tests construct
+// identical routers.
+func buildRouter() *mux.Router {
 	router := mux.NewRouter()
 
 	// mux skips router.Use middleware when the request method matches no
@@ -658,6 +664,12 @@ func main() {
 	api.HandleFunc("/local/guides", localGuidesHandler).Methods("GET")
 	api.HandleFunc("/local/guides/{id}", localGuideDetailHandler).Methods("GET")
 
+	return router
+}
+
+// startServer configures and runs the HTTP server; split from main() so the
+// boot sequence reads env → DB → buildRouter → serve.
+func startServer(router *mux.Router) {
 	// Server configuration
 	port := os.Getenv("PORT")
 	if port == "" {

--- a/src/packages/api/share_integration_test.go
+++ b/src/packages/api/share_integration_test.go
@@ -1,0 +1,149 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"travel-route-planner/store"
+)
+
+// mustChatID returns the trip's chat lineage id or fails the test.
+func mustChatID(t *testing.T, trip store.Trip) *string {
+	t.Helper()
+	if trip.ChatID == nil || *trip.ChatID == "" {
+		t.Fatal("test trip has no chat_id")
+	}
+	return trip.ChatID
+}
+
+// createTestTripInLineage appends a newer trip version to an existing chat
+// lineage (what the /plan agent does when it re-creates an itinerary).
+func createTestTripInLineage(t *testing.T, owner uuid.UUID, chatID, title string) store.Trip {
+	t.Helper()
+	trip, err := store.New(dbPool).CreateTrip(context.Background(), store.CreateTripParams{
+		UserID: owner, Title: title, Status: "draft", ChatID: &chatID,
+	})
+	if err != nil {
+		t.Fatalf("createTestTripInLineage: %v", err)
+	}
+	return trip
+}
+
+func containsCopy(body []byte) bool {
+	return bytes.Contains(body, []byte("(copy)"))
+}
+
+// createShare mints a share link for the trip and returns its token.
+func createShare(t *testing.T, ownerToken, tripID, role string) string {
+	t.Helper()
+	var body any
+	if role != "" {
+		body = map[string]any{"role": role}
+	}
+	rec := doJSON(t, "POST", "/api/v1/trips/"+tripID+"/share", ownerToken, body)
+	if rec.Code != http.StatusCreated && rec.Code != http.StatusOK {
+		t.Fatalf("create share = %d: %s", rec.Code, rec.Body.String())
+	}
+	token, _ := decode(t, rec)["token"].(string)
+	if token == "" {
+		t.Fatal("share response has no token")
+	}
+	return token
+}
+
+func TestSharedTripAnonymousRead(t *testing.T) {
+	resetDB(t)
+	owner, ownerToken := createTestUser(t, "owner@example.com")
+	trip := createTestTrip(t, owner.ID, 2)
+	shareToken := createShare(t, ownerToken, trip.ID.String(), "")
+
+	rec := doJSON(t, "GET", "/api/v1/shared/"+shareToken, "", nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("anonymous shared read = %d: %s", rec.Code, rec.Body.String())
+	}
+	body := decode(t, rec)
+	if body["owner_name"] == "" || body["owner_name"] == nil {
+		t.Fatal("shared trip missing owner_name")
+	}
+	tripBody, _ := body["trip"].(map[string]any)
+	if tripBody == nil {
+		t.Fatalf("shared trip missing trip payload: %s", rec.Body.String())
+	}
+	// chat_id is the private lineage handle; it must never leak on a share.
+	if cid, present := tripBody["chat_id"]; present && cid != nil {
+		t.Fatalf("shared trip leaked chat_id: %v", cid)
+	}
+}
+
+func TestSharedTripUnknownAndRevokedTokens(t *testing.T) {
+	resetDB(t)
+	owner, ownerToken := createTestUser(t, "owner@example.com")
+	trip := createTestTrip(t, owner.ID, 1)
+	shareToken := createShare(t, ownerToken, trip.ID.String(), "")
+
+	if rec := doJSON(t, "GET", "/api/v1/shared/no-such-token", "", nil); rec.Code != http.StatusNotFound {
+		t.Fatalf("unknown token = %d, want 404", rec.Code)
+	}
+
+	if rec := doJSON(t, "DELETE", "/api/v1/trips/"+trip.ID.String()+"/share", ownerToken, nil); rec.Code >= 300 {
+		t.Fatalf("revoke = %d", rec.Code)
+	}
+	rec := doJSON(t, "GET", "/api/v1/shared/"+shareToken, "", nil)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("revoked token = %d, want 404 (same as unknown)", rec.Code)
+	}
+}
+
+func TestShareNonOwnerCannotMint(t *testing.T) {
+	resetDB(t)
+	owner, _ := createTestUser(t, "owner@example.com")
+	_, intruderToken := createTestUser(t, "intruder@example.com")
+	trip := createTestTrip(t, owner.ID, 1)
+
+	rec := doJSON(t, "POST", "/api/v1/trips/"+trip.ID.String()+"/share", intruderToken, nil)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("non-owner share mint = %d, want 404", rec.Code)
+	}
+}
+
+func TestSharedTripDuplicate(t *testing.T) {
+	resetDB(t)
+	owner, ownerToken := createTestUser(t, "owner@example.com")
+	_, copierToken := createTestUser(t, "copier@example.com")
+	trip := createTestTrip(t, owner.ID, 3)
+	shareToken := createShare(t, ownerToken, trip.ID.String(), "")
+
+	rec := doJSON(t, "POST", "/api/v1/shared/"+shareToken+"/duplicate", copierToken, nil)
+	if rec.Code != http.StatusCreated && rec.Code != http.StatusOK {
+		t.Fatalf("duplicate = %d: %s", rec.Code, rec.Body.String())
+	}
+
+	list := doJSON(t, "GET", "/api/v1/trips", copierToken, nil)
+	if list.Code != http.StatusOK || !containsCopy(list.Body.Bytes()) {
+		t.Fatalf("copier's trip list missing the copy: %s", list.Body.String())
+	}
+}
+
+// The share must resolve the lineage's LATEST version: creating a newer trip
+// with the same chat_id retargets existing links.
+func TestSharedTripResolvesLatestVersion(t *testing.T) {
+	resetDB(t)
+	owner, ownerToken := createTestUser(t, "owner@example.com")
+	trip := createTestTrip(t, owner.ID, 1)
+	shareToken := createShare(t, ownerToken, trip.ID.String(), "")
+
+	newer := createTestTripInLineage(t, owner.ID, *mustChatID(t, trip), "Newer Version")
+
+	rec := doJSON(t, "GET", "/api/v1/shared/"+shareToken, "", nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("shared read = %d", rec.Code)
+	}
+	tripBody, _ := decode(t, rec)["trip"].(map[string]any)
+	if tripBody == nil || tripBody["id"] != newer.ID.String() {
+		t.Fatalf("share resolved %v, want latest version %s", tripBody["id"], newer.ID)
+	}
+}

--- a/src/packages/api/trip_integration_test.go
+++ b/src/packages/api/trip_integration_test.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+func TestTripOwnerCRUD(t *testing.T) {
+	resetDB(t)
+	owner, token := createTestUser(t, "owner@example.com")
+	trip := createTestTrip(t, owner.ID, 2)
+
+	get := doJSON(t, "GET", "/api/v1/trips/"+trip.ID.String(), token, nil)
+	if get.Code != http.StatusOK {
+		t.Fatalf("owner GET = %d: %s", get.Code, get.Body.String())
+	}
+
+	patch := doJSON(t, "PATCH", "/api/v1/trips/"+trip.ID.String(), token, map[string]any{
+		"status": "planned",
+	})
+	if patch.Code != http.StatusOK {
+		t.Fatalf("owner PATCH = %d: %s", patch.Code, patch.Body.String())
+	}
+
+	del := doJSON(t, "DELETE", "/api/v1/trips/"+trip.ID.String(), token, nil)
+	if del.Code != http.StatusNoContent && del.Code != http.StatusOK {
+		t.Fatalf("owner DELETE = %d", del.Code)
+	}
+	if again := doJSON(t, "GET", "/api/v1/trips/"+trip.ID.String(), token, nil); again.Code != http.StatusNotFound {
+		t.Fatalf("GET after delete = %d, want 404", again.Code)
+	}
+}
+
+// Cross-user access must 404 (not 403) so trip existence never leaks.
+func TestTripOwnershipIsolation(t *testing.T) {
+	resetDB(t)
+	owner, _ := createTestUser(t, "owner@example.com")
+	_, intruderToken := createTestUser(t, "intruder@example.com")
+	trip := createTestTrip(t, owner.ID, 1)
+	path := "/api/v1/trips/" + trip.ID.String()
+
+	for _, tc := range []struct {
+		method string
+		body   any
+	}{
+		{"GET", nil},
+		{"PATCH", map[string]any{"status": "planned"}},
+		{"DELETE", nil},
+	} {
+		if rec := doJSON(t, tc.method, path, intruderToken, tc.body); rec.Code != http.StatusNotFound {
+			t.Fatalf("intruder %s = %d, want 404", tc.method, rec.Code)
+		}
+	}
+}
+
+func TestTripListFiltersToCaller(t *testing.T) {
+	resetDB(t)
+	a, tokenA := createTestUser(t, "a@example.com")
+	b, _ := createTestUser(t, "b@example.com")
+	createTestTrip(t, a.ID, 1)
+	createTestTrip(t, b.ID, 1)
+	createTestTrip(t, b.ID, 1)
+
+	rec := doJSON(t, "GET", "/api/v1/trips", tokenA, nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("list = %d", rec.Code)
+	}
+	var trips []map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &trips); err != nil {
+		t.Fatalf("decode trips list: %v (%s)", err, rec.Body.String())
+	}
+	if len(trips) != 1 {
+		t.Fatalf("user A sees %d trips, want 1 (own only)", len(trips))
+	}
+}
+
+func TestTripListRequiresAuth(t *testing.T) {
+	resetDB(t)
+	if rec := doJSON(t, "GET", "/api/v1/trips", "", nil); rec.Code != http.StatusUnauthorized {
+		t.Fatalf("anonymous /trips = %d, want 401", rec.Code)
+	}
+}
+
+func TestTripPatchValidation(t *testing.T) {
+	resetDB(t)
+	owner, token := createTestUser(t, "owner@example.com")
+	trip := createTestTrip(t, owner.ID, 1)
+
+	rec := doJSON(t, "PATCH", "/api/v1/trips/"+trip.ID.String(), token, map[string]any{
+		"status": "abandoned",
+	})
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("invalid status = %d, want 400", rec.Code)
+	}
+}


### PR DESCRIPTION
## What

The API had 41 test functions — all pure/algorithmic. The entire handler surface (auth, trips, shares, collaborators, itinerary items, admin gating) had **zero** tests. This PR adds the harness and the highest-value authorization matrix.

**Harness (`integration_test.go`)**
- `buildRouter()` extracted from `main()` (pure move) — tests drive the identical router in-process via `httptest`, no network.
- Activates on `TEST_DATABASE_URL`; without it every integration test skips and `go test ./...` behaves exactly as before.
- TRUNCATE-between-tests isolation (never `goose_db_version`); integration tests are serial by design.
- Unique `X-Forwarded-For` per request (`clientIP()` trusts the rightmost entry) so the strict per-IP limiter can't bleed between tests — with one dedicated test asserting the limiter itself (4th register from one IP → 429).
- Fixtures insert users via the store with a `bcrypt.MinCost` hash + direct `issueSession` — bypassing the ~300ms cost-12 hash per user that would otherwise dominate CI runtime. Only the real register/login tests pay full cost.

**20 integration tests**
- Auth: register→me→login flow, duplicate email 409, validation 422s, wrong-password vs unknown-email **identical 401 bodies** (no enumeration), bad/absent token 401, logout invalidates.
- Trips: owner CRUD, cross-user GET/PATCH/DELETE → **404 not 403** (no existence leak), list filtered to caller, status validation.
- Shares: anonymous read (asserts `chat_id` never leaks), unknown/revoked token → 404, non-owner can't mint, save-a-copy, **share resolves latest version in chat lineage**.
- Collaborators: editor join+edit, viewer-token join 403, non-member 404, **membership survives link revocation**, owner list/remove, removed editor loses access.
- Items: CRUD + full reorder verified against the store, cross-user 404s on all four mutations, category/time_of_day validation, stale reorder 409.
- Admin: non-admin 403 / anonymous 401 on `/admin/*` + `/trips/versions`, admin 200.

**CI**
- postgres:16 service on the Go job (separate `travel_test` DB from the migrations job), `TEST_DATABASE_URL` env, `go test -race`, and a `govulncheck` step.

## Verification
Full suite run locally against a real postgres:16 with `-race`: all green in ~13s. Found and fixed two wrong assumptions in my own tests along the way (add-item returns the whole trip; `/auth/me` returns the bare user).

Part of Wave 6, PR 2 of ~8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)