### PR TITLE
Price alerts UI: watch a route from flight search, manage alerts

### DIFF
--- a/src/packages/flutter-app/lib/main.dart
+++ b/src/packages/flutter-app/lib/main.dart
@@ -4,6 +4,7 @@ import 'package:flutter_web_plugins/url_strategy.dart';
 import 'constants/app_info.dart';
 import 'providers/auth_provider.dart';
 import 'theme/app_theme.dart';
+import 'screens/alerts_screen.dart';
 import 'screens/landing_screen.dart';
 import 'screens/app_shell.dart';
 import 'screens/onboarding_quiz_screen.dart';
@@ -55,6 +56,14 @@ class TravelRoutePlannerApp extends StatelessWidget {
           return MaterialPageRoute(
             settings: settings,
             builder: (_) => VerifyEmailScreen(token: segments[1]),
+          );
+        }
+        // Price-alert emails deep-link here; the screen itself handles the
+        // signed-out case with a sign-in prompt.
+        if (segments.length == 1 && segments[0] == 'alerts') {
+          return MaterialPageRoute(
+            settings: settings,
+            builder: (_) => const AlertsScreen(),
           );
         }
         return MaterialPageRoute(

--- a/src/packages/flutter-app/lib/models/price_alert.dart
+++ b/src/packages/flutter-app/lib/models/price_alert.dart
@@ -1,0 +1,62 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'price_alert.g.dart';
+
+/// A watched flight route (specs/price-alerts). `targetPrice` null means
+/// any-drop mode. `lastNotifiedAt` non-null means the price dropped at least
+/// once since creation.
+@JsonSerializable()
+class PriceAlert {
+  final String id;
+  final String origin;
+  final String destination;
+  @JsonKey(name: 'depart_date')
+  final String departDate;
+  @JsonKey(name: 'return_date')
+  final String? returnDate;
+  @JsonKey(name: 'cabin_class')
+  final String cabinClass;
+  final int adults;
+  @JsonKey(name: 'target_price')
+  final double? targetPrice;
+  final String? currency;
+  @JsonKey(name: 'last_checked_price')
+  final double? lastCheckedPrice;
+  @JsonKey(name: 'last_checked_at')
+  final String? lastCheckedAt;
+  @JsonKey(name: 'last_notified_price')
+  final double? lastNotifiedPrice;
+  @JsonKey(name: 'last_notified_at')
+  final String? lastNotifiedAt;
+  final String status; // active | paused | expired
+  @JsonKey(name: 'trip_id')
+  final String? tripId;
+  @JsonKey(name: 'created_at')
+  final String createdAt;
+
+  const PriceAlert({
+    required this.id,
+    required this.origin,
+    required this.destination,
+    required this.departDate,
+    this.returnDate,
+    this.cabinClass = 'economy',
+    this.adults = 1,
+    this.targetPrice,
+    this.currency,
+    this.lastCheckedPrice,
+    this.lastCheckedAt,
+    this.lastNotifiedPrice,
+    this.lastNotifiedAt,
+    this.status = 'active',
+    this.tripId,
+    this.createdAt = '',
+  });
+
+  bool get isAnyDrop => targetPrice == null;
+  bool get hasTriggered => lastNotifiedAt != null;
+
+  factory PriceAlert.fromJson(Map<String, dynamic> json) =>
+      _$PriceAlertFromJson(json);
+  Map<String, dynamic> toJson() => _$PriceAlertToJson(this);
+}

--- a/src/packages/flutter-app/lib/models/price_alert.g.dart
+++ b/src/packages/flutter-app/lib/models/price_alert.g.dart
@@ -1,0 +1,46 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'price_alert.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+PriceAlert _$PriceAlertFromJson(Map<String, dynamic> json) => PriceAlert(
+      id: json['id'] as String,
+      origin: json['origin'] as String,
+      destination: json['destination'] as String,
+      departDate: json['depart_date'] as String,
+      returnDate: json['return_date'] as String?,
+      cabinClass: json['cabin_class'] as String? ?? 'economy',
+      adults: (json['adults'] as num?)?.toInt() ?? 1,
+      targetPrice: (json['target_price'] as num?)?.toDouble(),
+      currency: json['currency'] as String?,
+      lastCheckedPrice: (json['last_checked_price'] as num?)?.toDouble(),
+      lastCheckedAt: json['last_checked_at'] as String?,
+      lastNotifiedPrice: (json['last_notified_price'] as num?)?.toDouble(),
+      lastNotifiedAt: json['last_notified_at'] as String?,
+      status: json['status'] as String? ?? 'active',
+      tripId: json['trip_id'] as String?,
+      createdAt: json['created_at'] as String? ?? '',
+    );
+
+Map<String, dynamic> _$PriceAlertToJson(PriceAlert instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'origin': instance.origin,
+      'destination': instance.destination,
+      'depart_date': instance.departDate,
+      'return_date': instance.returnDate,
+      'cabin_class': instance.cabinClass,
+      'adults': instance.adults,
+      'target_price': instance.targetPrice,
+      'currency': instance.currency,
+      'last_checked_price': instance.lastCheckedPrice,
+      'last_checked_at': instance.lastCheckedAt,
+      'last_notified_price': instance.lastNotifiedPrice,
+      'last_notified_at': instance.lastNotifiedAt,
+      'status': instance.status,
+      'trip_id': instance.tripId,
+      'created_at': instance.createdAt,
+    };

--- a/src/packages/flutter-app/lib/providers/alerts_provider.dart
+++ b/src/packages/flutter-app/lib/providers/alerts_provider.dart
@@ -1,0 +1,87 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../models/price_alert.dart';
+import '../services/alerts_api_service.dart';
+import 'api_client_provider.dart';
+
+final alertsApiServiceProvider = Provider<AlertsApiService>((ref) {
+  return AlertsApiService(ref.watch(apiClientProvider));
+});
+
+class AlertsState {
+  final List<PriceAlert> alerts;
+  final bool loading;
+  final String? error;
+  final bool loaded;
+
+  const AlertsState({
+    this.alerts = const [],
+    this.loading = false,
+    this.error,
+    this.loaded = false,
+  });
+
+  AlertsState copyWith({
+    List<PriceAlert>? alerts,
+    bool? loading,
+    Object? error = _sentinel,
+    bool? loaded,
+  }) {
+    return AlertsState(
+      alerts: alerts ?? this.alerts,
+      loading: loading ?? this.loading,
+      error: error == _sentinel ? this.error : error as String?,
+      loaded: loaded ?? this.loaded,
+    );
+  }
+}
+
+const _sentinel = Object();
+
+class AlertsNotifier extends StateNotifier<AlertsState> {
+  final AlertsApiService _service;
+
+  AlertsNotifier(this._service) : super(const AlertsState());
+
+  Future<void> load() async {
+    state = state.copyWith(loading: true, error: null);
+    try {
+      final alerts = await _service.list();
+      state = state.copyWith(alerts: alerts, loading: false, loaded: true);
+    } catch (e) {
+      state = state.copyWith(loading: false, error: '$e', loaded: true);
+    }
+  }
+
+  /// Creates an alert; rethrows so callers can surface the message (cap,
+  /// duplicate) inline.
+  Future<PriceAlert> create(Map<String, dynamic> body) async {
+    final alert = await _service.create(body);
+    state = state.copyWith(alerts: [alert, ...state.alerts]);
+    return alert;
+  }
+
+  Future<void> setPaused(String id, bool paused) async {
+    final updated =
+        await _service.patch(id, {'status': paused ? 'paused' : 'active'});
+    state = state.copyWith(
+      alerts: [
+        for (final a in state.alerts) a.id == id ? updated : a,
+      ],
+    );
+  }
+
+  Future<void> remove(String id) async {
+    await _service.delete(id);
+    state = state.copyWith(
+      alerts: [
+        for (final a in state.alerts)
+          if (a.id != id) a,
+      ],
+    );
+  }
+}
+
+final alertsProvider =
+    StateNotifierProvider<AlertsNotifier, AlertsState>((ref) {
+  return AlertsNotifier(ref.watch(alertsApiServiceProvider));
+});

--- a/src/packages/flutter-app/lib/screens/alerts_screen.dart
+++ b/src/packages/flutter-app/lib/screens/alerts_screen.dart
@@ -1,0 +1,235 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../models/price_alert.dart';
+import '../providers/alerts_provider.dart';
+import '../providers/auth_provider.dart';
+import '../theme/spacing.dart';
+import '../widgets/empty_state.dart';
+import '../widgets/page_container.dart';
+
+/// The traveler's watched routes (specs/price-alerts): state at a glance,
+/// pause/resume/delete. Creation happens from flight search results.
+class AlertsScreen extends ConsumerStatefulWidget {
+  const AlertsScreen({super.key});
+
+  @override
+  ConsumerState<AlertsScreen> createState() => _AlertsScreenState();
+}
+
+class _AlertsScreenState extends ConsumerState<AlertsScreen> {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (ref.read(authProvider).isSignedIn) {
+        ref.read(alertsProvider.notifier).load();
+      }
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final auth = ref.watch(authProvider);
+    final state = ref.watch(alertsProvider);
+
+    Widget body;
+    if (!auth.isSignedIn) {
+      body = const EmptyState(
+        icon: Icons.notifications_none,
+        title: 'Sign in to watch fares',
+        message: 'Price alerts email you when a flight you care about drops.',
+      );
+    } else if (state.loading && !state.loaded) {
+      body = const Center(child: CircularProgressIndicator());
+    } else if (state.error != null && state.alerts.isEmpty) {
+      body = EmptyState(
+        icon: Icons.cloud_off,
+        title: 'Could not load alerts',
+        message: state.error,
+        actions: [
+          FilledButton(
+            onPressed: () => ref.read(alertsProvider.notifier).load(),
+            child: const Text('Retry'),
+          ),
+        ],
+      );
+    } else if (state.alerts.isEmpty) {
+      body = const EmptyState(
+        icon: Icons.notifications_none,
+        title: 'No alerts yet',
+        message:
+            'Search a flight and tap "Watch this route" — we\'ll email you '
+            'when the price drops.',
+      );
+    } else {
+      body = RefreshIndicator(
+        onRefresh: () => ref.read(alertsProvider.notifier).load(),
+        child: ListView.separated(
+          physics: const AlwaysScrollableScrollPhysics(),
+          padding: const EdgeInsets.all(AppSpacing.lg),
+          itemCount: state.alerts.length,
+          separatorBuilder: (_, __) => const SizedBox(height: AppSpacing.md),
+          itemBuilder: (context, i) => _AlertCard(alert: state.alerts[i]),
+        ),
+      );
+    }
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Price alerts')),
+      body: PageContainer(child: body),
+    );
+  }
+}
+
+class _AlertCard extends ConsumerWidget {
+  final PriceAlert alert;
+  const _AlertCard({required this.alert});
+
+  String _priceLine() {
+    final cur = alert.currency ?? '';
+    final checked = alert.lastCheckedPrice;
+    final parts = <String>[];
+    if (checked != null) {
+      parts.add('Last seen $cur ${checked.toStringAsFixed(0)}');
+    }
+    if (alert.targetPrice != null) {
+      parts.add('target $cur ${alert.targetPrice!.toStringAsFixed(0)}');
+    } else {
+      parts.add('watching for any drop');
+    }
+    return parts.join(' · ');
+  }
+
+  String _datesLine() {
+    var s = alert.departDate;
+    if (alert.returnDate != null) s += ' → ${alert.returnDate}';
+    if (alert.adults > 1) s += ' · ${alert.adults} adults';
+    if (alert.cabinClass != 'economy') {
+      s += ' · ${alert.cabinClass.replaceAll('_', ' ')}';
+    }
+    return s;
+  }
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final theme = Theme.of(context);
+    final notifier = ref.read(alertsProvider.notifier);
+    final paused = alert.status == 'paused';
+    final expired = alert.status == 'expired';
+
+    Future<void> guard(Future<void> Function() action) async {
+      try {
+        await action();
+      } catch (e) {
+        if (context.mounted) {
+          ScaffoldMessenger.of(context)
+              .showSnackBar(SnackBar(content: Text('$e')));
+        }
+      }
+    }
+
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(AppSpacing.lg),
+        child: Row(
+          children: [
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Row(
+                    children: [
+                      Flexible(
+                        child: Text(
+                          '${alert.origin} → ${alert.destination}',
+                          style: theme.textTheme.titleMedium,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      ),
+                      const SizedBox(width: AppSpacing.sm),
+                      _AlertPill(alert: alert),
+                    ],
+                  ),
+                  const SizedBox(height: 2),
+                  Text(_datesLine(), style: theme.textTheme.bodySmall),
+                  const SizedBox(height: 2),
+                  Text(
+                    _priceLine(),
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: theme.colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            PopupMenuButton<String>(
+              tooltip: 'Alert actions',
+              onSelected: (v) {
+                if (v == 'pause') guard(() => notifier.setPaused(alert.id, true));
+                if (v == 'resume') {
+                  guard(() => notifier.setPaused(alert.id, false));
+                }
+                if (v == 'delete') guard(() => notifier.remove(alert.id));
+              },
+              itemBuilder: (_) => [
+                if (!expired)
+                  PopupMenuItem(
+                    value: paused ? 'resume' : 'pause',
+                    child: Text(paused ? 'Resume' : 'Pause'),
+                  ),
+                const PopupMenuItem(value: 'delete', child: Text('Delete')),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Small tonal pill carrying the alert's state. "Price dropped" (green) wins
+/// over the raw status because it is the state the traveler cares about.
+class _AlertPill extends StatelessWidget {
+  final PriceAlert alert;
+  const _AlertPill({required this.alert});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final String label;
+    final Color bg;
+    final Color fg;
+    if (alert.status == 'expired') {
+      label = 'Expired';
+      bg = theme.colorScheme.surfaceContainerHighest;
+      fg = theme.colorScheme.onSurfaceVariant;
+    } else if (alert.status == 'paused') {
+      label = 'Paused';
+      bg = theme.colorScheme.surfaceContainerHighest;
+      fg = theme.colorScheme.onSurfaceVariant;
+    } else if (alert.hasTriggered) {
+      label = 'Price dropped';
+      bg = Colors.green.withValues(alpha: 0.15);
+      fg = Colors.green.shade800;
+    } else {
+      label = 'Watching';
+      bg = theme.colorScheme.primaryContainer.withValues(alpha: 0.5);
+      fg = theme.colorScheme.onPrimaryContainer;
+    }
+    return Container(
+      padding:
+          const EdgeInsets.symmetric(horizontal: AppSpacing.sm, vertical: 3),
+      decoration: BoxDecoration(
+        color: bg,
+        borderRadius: BorderRadius.circular(AppRadius.lg),
+      ),
+      child: Text(
+        label,
+        style: theme.textTheme.labelSmall?.copyWith(
+          color: fg,
+          fontWeight: FontWeight.w600,
+        ),
+      ),
+    );
+  }
+}

--- a/src/packages/flutter-app/lib/screens/flight_search_screen.dart
+++ b/src/packages/flutter-app/lib/screens/flight_search_screen.dart
@@ -2,9 +2,11 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../models/airport.dart';
 import '../models/flight_search_request.dart';
+import '../providers/auth_provider.dart';
 import '../providers/flights_provider.dart';
 import '../providers/preferences_provider.dart';
 import '../widgets/airport_field.dart';
+import '../widgets/create_alert_sheet.dart';
 import '../widgets/flight_offer_card.dart';
 import '../widgets/gradient_app_bar.dart';
 
@@ -362,6 +364,38 @@ class _FlightSearchScreenState extends ConsumerState<FlightSearchScreen> {
             ),
           ),
           const Divider(height: 1),
+          // Watch-this-route entry (specs/price-alerts): only over a real
+          // result set and only signed in — alerts need an email to notify.
+          if (state.hasSearched &&
+              state.offers.isNotEmpty &&
+              ref.watch(authProvider).isSignedIn &&
+              _canSearch)
+            Align(
+              alignment: Alignment.centerLeft,
+              child: Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 8),
+                child: TextButton.icon(
+                  icon: const Icon(Icons.notifications_none, size: 18),
+                  label: const Text('Watch this route — email me on a drop'),
+                  onPressed: () {
+                    final cheapest = state.offers
+                        .reduce((a, b) => a.price <= b.price ? a : b);
+                    CreateAlertSheet.show(
+                      context,
+                      CreateAlertSheet(
+                        origin: _origin!.iataCode,
+                        destination: _destination!.iataCode,
+                        departDate: _fmtDate(_departDate!),
+                        adults: _adults,
+                        cabinClass: _cabinClass,
+                        currentPrice: cheapest.price,
+                        currency: cheapest.currency,
+                      ),
+                    );
+                  },
+                ),
+              ),
+            ),
           // Results
           Expanded(child: _Results(state: state)),
         ],

--- a/src/packages/flutter-app/lib/services/alerts_api_service.dart
+++ b/src/packages/flutter-app/lib/services/alerts_api_service.dart
@@ -1,0 +1,75 @@
+import 'dart:convert';
+import '../models/price_alert.dart';
+import 'api_client.dart';
+
+class AlertsApiService {
+  final ApiClient apiClient;
+
+  AlertsApiService(this.apiClient);
+
+  Map<String, String> _headers({bool json = false}) {
+    final h = <String, String>{'Accept': 'application/json'};
+    if (json) h['Content-Type'] = 'application/json';
+    final token = apiClient.authToken;
+    if (token != null) h['Authorization'] = 'Bearer $token';
+    return h;
+  }
+
+  String _errorMessage(String body, int status) {
+    try {
+      final decoded = jsonDecode(body);
+      if (decoded is Map && decoded['message'] is String) {
+        return decoded['message'] as String;
+      }
+    } catch (_) {}
+    return 'Request failed ($status)';
+  }
+
+  Future<List<PriceAlert>> list() async {
+    final res = await apiClient.httpClient.get(
+      Uri.parse('${apiClient.baseUrl}/alerts'),
+      headers: _headers(),
+    );
+    if (res.statusCode == 200) {
+      final list = jsonDecode(res.body) as List<dynamic>;
+      return list
+          .map((e) => PriceAlert.fromJson(e as Map<String, dynamic>))
+          .toList();
+    }
+    throw Exception(_errorMessage(res.body, res.statusCode));
+  }
+
+  Future<PriceAlert> create(Map<String, dynamic> body) async {
+    final res = await apiClient.httpClient.post(
+      Uri.parse('${apiClient.baseUrl}/alerts'),
+      headers: _headers(json: true),
+      body: jsonEncode(body),
+    );
+    if (res.statusCode == 201) {
+      return PriceAlert.fromJson(jsonDecode(res.body));
+    }
+    throw Exception(_errorMessage(res.body, res.statusCode));
+  }
+
+  Future<PriceAlert> patch(String id, Map<String, dynamic> body) async {
+    final res = await apiClient.httpClient.patch(
+      Uri.parse('${apiClient.baseUrl}/alerts/$id'),
+      headers: _headers(json: true),
+      body: jsonEncode(body),
+    );
+    if (res.statusCode == 200) {
+      return PriceAlert.fromJson(jsonDecode(res.body));
+    }
+    throw Exception(_errorMessage(res.body, res.statusCode));
+  }
+
+  Future<void> delete(String id) async {
+    final res = await apiClient.httpClient.delete(
+      Uri.parse('${apiClient.baseUrl}/alerts/$id'),
+      headers: _headers(),
+    );
+    if (res.statusCode != 204) {
+      throw Exception(_errorMessage(res.body, res.statusCode));
+    }
+  }
+}

--- a/src/packages/flutter-app/lib/widgets/account_menu.dart
+++ b/src/packages/flutter-app/lib/widgets/account_menu.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../navigation/app_nav.dart';
 import '../providers/auth_provider.dart';
+import '../screens/alerts_screen.dart';
 import '../screens/preferences_screen.dart';
 import '../screens/local_admin_screen.dart';
 import '../theme/app_colors.dart';
@@ -19,6 +20,8 @@ void _onSelected(BuildContext context, WidgetRef ref, String value) {
   } else if (value == 'preferences') {
     // Push onto the active tab's navigator so the rail/bar stays put.
     pushOnActiveTab(ref, const PreferencesScreen());
+  } else if (value == 'alerts') {
+    pushOnActiveTab(ref, const AlertsScreen());
   } else if (value == 'local_admin') {
     pushOnActiveTab(ref, const LocalAdminScreen());
   }
@@ -90,6 +93,17 @@ List<PopupMenuEntry<String>> _items(
           Icon(Icons.tune, size: 20, color: theme.colorScheme.onSurfaceVariant),
           const SizedBox(width: AppSpacing.md),
           const Text('Travel profile'),
+        ],
+      ),
+    ),
+    PopupMenuItem<String>(
+      value: 'alerts',
+      child: Row(
+        children: [
+          Icon(Icons.notifications_none,
+              size: 20, color: theme.colorScheme.onSurfaceVariant),
+          const SizedBox(width: AppSpacing.md),
+          const Text('Price alerts'),
         ],
       ),
     ),

--- a/src/packages/flutter-app/lib/widgets/create_alert_sheet.dart
+++ b/src/packages/flutter-app/lib/widgets/create_alert_sheet.dart
@@ -1,0 +1,186 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../providers/alerts_provider.dart';
+import '../theme/spacing.dart';
+
+/// Bottom sheet that turns the current flight search into a price alert
+/// (specs/price-alerts). Seeded with the route/date/cheapest price the
+/// traveler is looking at; they pick any-drop or a target price.
+class CreateAlertSheet extends ConsumerStatefulWidget {
+  final String origin;
+  final String destination;
+  final String departDate; // YYYY-MM-DD
+  final int adults;
+  final String cabinClass;
+  final double? currentPrice;
+  final String? currency;
+
+  const CreateAlertSheet({
+    super.key,
+    required this.origin,
+    required this.destination,
+    required this.departDate,
+    this.adults = 1,
+    this.cabinClass = 'economy',
+    this.currentPrice,
+    this.currency,
+  });
+
+  static Future<void> show(BuildContext context, CreateAlertSheet sheet) {
+    return showModalBottomSheet(
+      context: context,
+      isScrollControlled: true,
+      useSafeArea: true,
+      builder: (_) => Padding(
+        padding:
+            EdgeInsets.only(bottom: MediaQuery.of(context).viewInsets.bottom),
+        child: sheet,
+      ),
+    );
+  }
+
+  @override
+  ConsumerState<CreateAlertSheet> createState() => _CreateAlertSheetState();
+}
+
+class _CreateAlertSheetState extends ConsumerState<CreateAlertSheet> {
+  bool _anyDrop = true;
+  late final TextEditingController _targetController;
+  bool _saving = false;
+  String? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    // Prefill a plausible target: a bit under the current best fare.
+    final seed = widget.currentPrice;
+    _targetController = TextEditingController(
+      text: seed == null ? '' : (seed * 0.9).floorToDouble().toStringAsFixed(0),
+    );
+  }
+
+  @override
+  void dispose() {
+    _targetController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _create() async {
+    double? target;
+    if (!_anyDrop) {
+      target = double.tryParse(_targetController.text.trim());
+      if (target == null || target <= 0) {
+        setState(() => _error = 'Enter a valid target price');
+        return;
+      }
+    }
+    setState(() {
+      _saving = true;
+      _error = null;
+    });
+    try {
+      await ref.read(alertsProvider.notifier).create({
+        'origin': widget.origin,
+        'destination': widget.destination,
+        'depart_date': widget.departDate,
+        'adults': widget.adults,
+        'cabin_class': widget.cabinClass,
+        if (target != null) 'target_price': target,
+        if (widget.currentPrice != null) 'current_price': widget.currentPrice,
+        if (widget.currency != null) 'currency': widget.currency,
+      });
+      if (mounted) {
+        Navigator.of(context).pop();
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(
+                'Watching ${widget.origin} → ${widget.destination} — we\'ll '
+                'email you on a drop'),
+          ),
+        );
+      }
+    } catch (e) {
+      setState(() {
+        _saving = false;
+        _error = '$e'.replaceFirst('Exception: ', '');
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final cur = widget.currency ?? '';
+    return Padding(
+      padding: const EdgeInsets.all(AppSpacing.xl),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text('Watch this route', style: theme.textTheme.titleLarge),
+          const SizedBox(height: AppSpacing.sm),
+          Text(
+            '${widget.origin} → ${widget.destination} · ${widget.departDate}'
+            '${widget.adults > 1 ? ' · ${widget.adults} adults' : ''}'
+            '${widget.cabinClass != 'economy' ? ' · ${widget.cabinClass.replaceAll('_', ' ')}' : ''}',
+            style: theme.textTheme.bodyMedium
+                ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+          ),
+          if (widget.currentPrice != null)
+            Padding(
+              padding: const EdgeInsets.only(top: AppSpacing.xs),
+              child: Text(
+                'Best price now: $cur ${widget.currentPrice!.toStringAsFixed(0)}',
+                style: theme.textTheme.bodyMedium,
+              ),
+            ),
+          const SizedBox(height: AppSpacing.lg),
+          SwitchListTile(
+            contentPadding: EdgeInsets.zero,
+            title: const Text('Notify me on any real price drop'),
+            subtitle: const Text('At least 5% and \$5 below the last price'),
+            value: _anyDrop,
+            onChanged: (v) => setState(() => _anyDrop = v),
+          ),
+          if (!_anyDrop) ...[
+            const SizedBox(height: AppSpacing.sm),
+            TextField(
+              controller: _targetController,
+              keyboardType:
+                  const TextInputType.numberWithOptions(decimal: true),
+              decoration: InputDecoration(
+                labelText: 'Notify me at or below',
+                prefixText: cur.isEmpty ? null : '$cur ',
+                border: const OutlineInputBorder(),
+              ),
+            ),
+          ],
+          if (_error != null)
+            Padding(
+              padding: const EdgeInsets.only(top: AppSpacing.sm),
+              child: Text(
+                _error!,
+                style: theme.textTheme.bodySmall
+                    ?.copyWith(color: theme.colorScheme.error),
+              ),
+            ),
+          const SizedBox(height: AppSpacing.lg),
+          SizedBox(
+            width: double.infinity,
+            child: FilledButton.icon(
+              onPressed: _saving ? null : _create,
+              icon: _saving
+                  ? const SizedBox(
+                      width: 18,
+                      height: 18,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : const Icon(Icons.notifications_active_outlined),
+              label: Text(_saving ? 'Creating…' : 'Create alert'),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/src/packages/flutter-app/test/alerts_screen_test.dart
+++ b/src/packages/flutter-app/test/alerts_screen_test.dart
@@ -1,0 +1,169 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:travel_route_planner/models/price_alert.dart';
+import 'package:travel_route_planner/models/user.dart';
+import 'package:travel_route_planner/providers/alerts_provider.dart';
+import 'package:travel_route_planner/providers/auth_provider.dart';
+import 'package:travel_route_planner/screens/alerts_screen.dart';
+import 'package:travel_route_planner/services/alerts_api_service.dart';
+import 'package:travel_route_planner/services/api_client.dart';
+
+class _FakeAuthNotifier extends StateNotifier<AuthState>
+    implements AuthNotifier {
+  _FakeAuthNotifier(UserModel? user)
+      : super(AuthState(user: user, initialized: true));
+
+  @override
+  Future<bool> login(String email, String password) async => false;
+
+  @override
+  Future<bool> register(String email, String password,
+          {String? displayName}) async =>
+      false;
+
+  @override
+  Future<void> completeOnboarding() async {}
+
+  @override
+  Future<void> logout() async {}
+}
+
+class _FakeAlertsApiService extends AlertsApiService {
+  final List<PriceAlert> alerts;
+  final List<String> patched = [];
+  _FakeAlertsApiService(this.alerts)
+      : super(ApiClient(baseUrl: 'http://test'));
+
+  @override
+  Future<List<PriceAlert>> list() async => alerts;
+
+  @override
+  Future<PriceAlert> patch(String id, Map<String, dynamic> body) async {
+    patched.add('$id:${body['status']}');
+    final a = alerts.firstWhere((a) => a.id == id);
+    return PriceAlert(
+      id: a.id,
+      origin: a.origin,
+      destination: a.destination,
+      departDate: a.departDate,
+      status: body['status'] as String,
+      targetPrice: a.targetPrice,
+      currency: a.currency,
+    );
+  }
+}
+
+UserModel _user() => UserModel(
+      id: 'user-1',
+      email: 'test@example.com',
+      displayName: 'Test',
+      createdAt: DateTime(2026, 1, 1),
+    );
+
+PriceAlert _alert({
+  String id = 'a1',
+  String status = 'active',
+  double? target,
+  String? lastNotifiedAt,
+}) =>
+    PriceAlert(
+      id: id,
+      origin: 'BOS',
+      destination: 'CDG',
+      departDate: '2026-09-01',
+      targetPrice: target,
+      currency: 'USD',
+      lastCheckedPrice: 498,
+      status: status,
+      lastNotifiedAt: lastNotifiedAt,
+    );
+
+Future<_FakeAlertsApiService> _pump(
+  WidgetTester tester, {
+  List<PriceAlert> alerts = const [],
+  bool signedIn = true,
+}) async {
+  final service = _FakeAlertsApiService(alerts);
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        authProvider
+            .overrideWith((ref) => _FakeAuthNotifier(signedIn ? _user() : null)),
+        alertsApiServiceProvider.overrideWithValue(service),
+      ],
+      child: const MaterialApp(home: AlertsScreen()),
+    ),
+  );
+  await tester.pumpAndSettle();
+  return service;
+}
+
+void main() {
+  testWidgets('signed out shows sign-in prompt', (tester) async {
+    await _pump(tester, signedIn: false);
+    expect(find.text('Sign in to watch fares'), findsOneWidget);
+  });
+
+  testWidgets('empty list shows how-to empty state', (tester) async {
+    await _pump(tester);
+    expect(find.text('No alerts yet'), findsOneWidget);
+  });
+
+  testWidgets('renders alert states', (tester) async {
+    await _pump(tester, alerts: [
+      _alert(id: 'a1', target: 450),
+      _alert(id: 'a2', lastNotifiedAt: '2026-07-01T00:00:00Z'),
+      _alert(id: 'a3', status: 'paused'),
+      _alert(id: 'a4', status: 'expired'),
+    ]);
+    expect(find.text('BOS → CDG'), findsNWidgets(4));
+    expect(find.text('Watching'), findsOneWidget);
+    expect(find.text('Price dropped'), findsOneWidget);
+    expect(find.text('Paused'), findsOneWidget);
+    expect(find.text('Expired'), findsOneWidget);
+    expect(find.textContaining('target USD 450'), findsOneWidget);
+    expect(find.textContaining('Last seen USD 498'), findsNWidgets(4));
+  });
+
+  testWidgets('pause action patches the alert', (tester) async {
+    final service = await _pump(tester, alerts: [_alert(id: 'a1')]);
+
+    await tester.tap(find.byTooltip('Alert actions'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Pause'));
+    await tester.pumpAndSettle();
+
+    expect(service.patched, ['a1:paused']);
+    expect(find.text('Paused'), findsOneWidget);
+  });
+
+  test('model round-trips snake_case JSON', () {
+    final json = {
+      'id': 'a1',
+      'origin': 'BOS',
+      'destination': 'CDG',
+      'depart_date': '2026-09-01',
+      'return_date': null,
+      'cabin_class': 'economy',
+      'adults': 2,
+      'target_price': 450.0,
+      'currency': 'USD',
+      'last_checked_price': 498.0,
+      'last_checked_at': '2026-07-05T12:00:00Z',
+      'last_notified_price': null,
+      'last_notified_at': null,
+      'status': 'active',
+      'trip_id': null,
+      'created_at': '2026-07-05T10:00:00Z',
+    };
+    final alert = PriceAlert.fromJson(json);
+    expect(alert.origin, 'BOS');
+    expect(alert.adults, 2);
+    expect(alert.targetPrice, 450.0);
+    expect(alert.isAnyDrop, false);
+    expect(alert.hasTriggered, false);
+    expect(alert.toJson()['depart_date'], '2026-09-01');
+  });
+}


### PR DESCRIPTION
## What

Flutter half of `specs/price-alerts/` (API merged in #56).

- **Create**: after a flight search (signed in, offers present) a "Watch this route — email me on a drop" button opens a bottom sheet seeded with the route/date/passengers and the current cheapest fare. Toggle between any-drop mode and a target price (prefilled ~10% under the best fare). The observed fare seeds the server-side baseline so the first check can already compare.
- **Manage**: Price alerts screen (account menu + `/alerts` deep link — the link used in notification emails). Each alert shows route, dates, last-seen price, and a state pill: Watching / **Price dropped** (green, wins over raw status) / Paused / Expired, with pause/resume/delete actions and pull-to-refresh. Signed-out visitors get a sign-in prompt instead of a broken screen.
- API errors (10-alert cap, duplicate watch) surface inline in the sheet with the server's message.

## Tests
4 widget tests + model JSON round-trip; full `flutter test` suite (37) green, `flutter analyze` clean.

Part of Wave 6, PR 4 of ~8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)