### PR TITLE
Admin metrics dashboard: the Phase-1 funnel, visible

### DIFF
--- a/src/packages/flutter-app/lib/models/admin_metrics.dart
+++ b/src/packages/flutter-app/lib/models/admin_metrics.dart
@@ -1,0 +1,80 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'admin_metrics.g.dart';
+
+/// Mirror of the API's MetricsResponse (GET /admin/metrics?days=) — the
+/// Phase-1 growth funnel: activation, attach rate, retention, AI cost.
+@JsonSerializable()
+class AdminMetrics {
+  final int days;
+  final int signups;
+  @JsonKey(name: 'activated_signups')
+  final int activatedSignups;
+  @JsonKey(name: 'activation_rate')
+  final double activationRate;
+  @JsonKey(name: 'onboardings_completed')
+  final int onboardingsCompleted;
+  @JsonKey(name: 'trips_created')
+  final int tripsCreated;
+  @JsonKey(name: 'trips_refined')
+  final int tripsRefined;
+  @JsonKey(name: 'trips_with_booking_click')
+  final int tripsWithBookingClick;
+  @JsonKey(name: 'attach_rate')
+  final double attachRate;
+  @JsonKey(name: 'booking_clicks')
+  final int bookingClicks;
+  @JsonKey(name: 'clicks_by_provider')
+  final Map<String, int> clicksByProvider;
+  @JsonKey(name: 'todos_marked_booked')
+  final int todosMarkedBooked;
+  @JsonKey(name: 'returning_users')
+  final int returningUsers;
+  @JsonKey(name: 'plan_sessions')
+  final int planSessions;
+  @JsonKey(name: 'plan_sessions_anonymous')
+  final int planSessionsAnonymous;
+  @JsonKey(name: 'plan_cap_hits')
+  final int planCapHits;
+  @JsonKey(name: 'plan_input_tokens')
+  final int planInputTokens;
+  @JsonKey(name: 'plan_output_tokens')
+  final int planOutputTokens;
+  @JsonKey(name: 'plan_cache_read_tokens')
+  final int planCacheReadTokens;
+  @JsonKey(name: 'plan_cache_creation_tokens')
+  final int planCacheCreationTokens;
+  @JsonKey(name: 'alerts_created')
+  final int alertsCreated;
+  @JsonKey(name: 'alerts_triggered')
+  final int alertsTriggered;
+
+  const AdminMetrics({
+    this.days = 30,
+    this.signups = 0,
+    this.activatedSignups = 0,
+    this.activationRate = 0,
+    this.onboardingsCompleted = 0,
+    this.tripsCreated = 0,
+    this.tripsRefined = 0,
+    this.tripsWithBookingClick = 0,
+    this.attachRate = 0,
+    this.bookingClicks = 0,
+    this.clicksByProvider = const {},
+    this.todosMarkedBooked = 0,
+    this.returningUsers = 0,
+    this.planSessions = 0,
+    this.planSessionsAnonymous = 0,
+    this.planCapHits = 0,
+    this.planInputTokens = 0,
+    this.planOutputTokens = 0,
+    this.planCacheReadTokens = 0,
+    this.planCacheCreationTokens = 0,
+    this.alertsCreated = 0,
+    this.alertsTriggered = 0,
+  });
+
+  factory AdminMetrics.fromJson(Map<String, dynamic> json) =>
+      _$AdminMetricsFromJson(json);
+  Map<String, dynamic> toJson() => _$AdminMetricsToJson(this);
+}

--- a/src/packages/flutter-app/lib/models/admin_metrics.g.dart
+++ b/src/packages/flutter-app/lib/models/admin_metrics.g.dart
@@ -1,0 +1,67 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'admin_metrics.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+AdminMetrics _$AdminMetricsFromJson(Map<String, dynamic> json) => AdminMetrics(
+      days: (json['days'] as num?)?.toInt() ?? 30,
+      signups: (json['signups'] as num?)?.toInt() ?? 0,
+      activatedSignups: (json['activated_signups'] as num?)?.toInt() ?? 0,
+      activationRate: (json['activation_rate'] as num?)?.toDouble() ?? 0,
+      onboardingsCompleted:
+          (json['onboardings_completed'] as num?)?.toInt() ?? 0,
+      tripsCreated: (json['trips_created'] as num?)?.toInt() ?? 0,
+      tripsRefined: (json['trips_refined'] as num?)?.toInt() ?? 0,
+      tripsWithBookingClick:
+          (json['trips_with_booking_click'] as num?)?.toInt() ?? 0,
+      attachRate: (json['attach_rate'] as num?)?.toDouble() ?? 0,
+      bookingClicks: (json['booking_clicks'] as num?)?.toInt() ?? 0,
+      clicksByProvider:
+          (json['clicks_by_provider'] as Map<String, dynamic>?)?.map(
+                (k, e) => MapEntry(k, (e as num).toInt()),
+              ) ??
+              const {},
+      todosMarkedBooked: (json['todos_marked_booked'] as num?)?.toInt() ?? 0,
+      returningUsers: (json['returning_users'] as num?)?.toInt() ?? 0,
+      planSessions: (json['plan_sessions'] as num?)?.toInt() ?? 0,
+      planSessionsAnonymous:
+          (json['plan_sessions_anonymous'] as num?)?.toInt() ?? 0,
+      planCapHits: (json['plan_cap_hits'] as num?)?.toInt() ?? 0,
+      planInputTokens: (json['plan_input_tokens'] as num?)?.toInt() ?? 0,
+      planOutputTokens: (json['plan_output_tokens'] as num?)?.toInt() ?? 0,
+      planCacheReadTokens:
+          (json['plan_cache_read_tokens'] as num?)?.toInt() ?? 0,
+      planCacheCreationTokens:
+          (json['plan_cache_creation_tokens'] as num?)?.toInt() ?? 0,
+      alertsCreated: (json['alerts_created'] as num?)?.toInt() ?? 0,
+      alertsTriggered: (json['alerts_triggered'] as num?)?.toInt() ?? 0,
+    );
+
+Map<String, dynamic> _$AdminMetricsToJson(AdminMetrics instance) =>
+    <String, dynamic>{
+      'days': instance.days,
+      'signups': instance.signups,
+      'activated_signups': instance.activatedSignups,
+      'activation_rate': instance.activationRate,
+      'onboardings_completed': instance.onboardingsCompleted,
+      'trips_created': instance.tripsCreated,
+      'trips_refined': instance.tripsRefined,
+      'trips_with_booking_click': instance.tripsWithBookingClick,
+      'attach_rate': instance.attachRate,
+      'booking_clicks': instance.bookingClicks,
+      'clicks_by_provider': instance.clicksByProvider,
+      'todos_marked_booked': instance.todosMarkedBooked,
+      'returning_users': instance.returningUsers,
+      'plan_sessions': instance.planSessions,
+      'plan_sessions_anonymous': instance.planSessionsAnonymous,
+      'plan_cap_hits': instance.planCapHits,
+      'plan_input_tokens': instance.planInputTokens,
+      'plan_output_tokens': instance.planOutputTokens,
+      'plan_cache_read_tokens': instance.planCacheReadTokens,
+      'plan_cache_creation_tokens': instance.planCacheCreationTokens,
+      'alerts_created': instance.alertsCreated,
+      'alerts_triggered': instance.alertsTriggered,
+    };

--- a/src/packages/flutter-app/lib/providers/admin_metrics_provider.dart
+++ b/src/packages/flutter-app/lib/providers/admin_metrics_provider.dart
@@ -1,0 +1,16 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../models/admin_metrics.dart';
+import '../services/admin_metrics_api_service.dart';
+import 'api_client_provider.dart';
+
+final adminMetricsApiServiceProvider =
+    Provider<AdminMetricsApiService>((ref) {
+  return AdminMetricsApiService(ref.watch(apiClientProvider));
+});
+
+/// Metrics for a trailing window in days. FutureProvider.family so switching
+/// 7/30/90 re-fetches and caches per window.
+final adminMetricsProvider =
+    FutureProvider.family<AdminMetrics, int>((ref, days) async {
+  return ref.watch(adminMetricsApiServiceProvider).fetch(days: days);
+});

--- a/src/packages/flutter-app/lib/screens/admin_metrics_screen.dart
+++ b/src/packages/flutter-app/lib/screens/admin_metrics_screen.dart
@@ -1,0 +1,262 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../models/admin_metrics.dart';
+import '../providers/admin_metrics_provider.dart';
+import '../theme/spacing.dart';
+import '../widgets/empty_state.dart';
+import '../widgets/page_container.dart';
+import '../widgets/section_header.dart';
+
+/// Growth metrics dashboard (admin-only; the API enforces adminMiddleware).
+/// Stat tiles over the Phase-1 funnel from docs/business-model.md §8 —
+/// activation, attach rate, retention, AI cost — plus the alerts counters.
+/// Deliberately chartless: every number here is a headline, not a trend.
+class AdminMetricsScreen extends ConsumerStatefulWidget {
+  const AdminMetricsScreen({super.key});
+
+  @override
+  ConsumerState<AdminMetricsScreen> createState() =>
+      _AdminMetricsScreenState();
+}
+
+class _AdminMetricsScreenState extends ConsumerState<AdminMetricsScreen> {
+  int _days = 30;
+
+  @override
+  Widget build(BuildContext context) {
+    final metrics = ref.watch(adminMetricsProvider(_days));
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Metrics')),
+      body: PageContainer(
+        child: Column(
+          children: [
+            Padding(
+              padding: const EdgeInsets.all(AppSpacing.lg),
+              child: SegmentedButton<int>(
+                segments: const [
+                  ButtonSegment(value: 7, label: Text('7 days')),
+                  ButtonSegment(value: 30, label: Text('30 days')),
+                  ButtonSegment(value: 90, label: Text('90 days')),
+                ],
+                selected: {_days},
+                onSelectionChanged: (s) => setState(() => _days = s.first),
+              ),
+            ),
+            Expanded(
+              child: metrics.when(
+                loading: () =>
+                    const Center(child: CircularProgressIndicator()),
+                error: (e, _) => EmptyState(
+                  icon: Icons.cloud_off,
+                  title: 'Could not load metrics',
+                  message: '$e',
+                  actions: [
+                    FilledButton(
+                      onPressed: () =>
+                          ref.invalidate(adminMetricsProvider(_days)),
+                      child: const Text('Retry'),
+                    ),
+                  ],
+                ),
+                data: (m) => _MetricsBody(metrics: m),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _MetricsBody extends StatelessWidget {
+  final AdminMetrics metrics;
+  const _MetricsBody({required this.metrics});
+
+  String _pct(double v) => '${(v * 100).toStringAsFixed(1)}%';
+
+  String _tokens(int v) {
+    if (v >= 1000000) return '${(v / 1000000).toStringAsFixed(1)}M';
+    if (v >= 1000) return '${(v / 1000).toStringAsFixed(1)}k';
+    return '$v';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final m = metrics;
+    return ListView(
+      padding: const EdgeInsets.all(AppSpacing.lg),
+      children: [
+        const SectionHeader(title: 'Funnel'),
+        const SizedBox(height: AppSpacing.sm),
+        _TileGrid(tiles: [
+          _Stat('Signups', '${m.signups}'),
+          _Stat('Activated', '${m.activatedSignups}',
+              caption: _pct(m.activationRate)),
+          _Stat('Onboardings', '${m.onboardingsCompleted}'),
+          _Stat('Returning users', '${m.returningUsers}'),
+        ]),
+        const SizedBox(height: AppSpacing.xl),
+        const SectionHeader(title: 'Trips & bookings'),
+        const SizedBox(height: AppSpacing.sm),
+        _TileGrid(tiles: [
+          _Stat('Trips created', '${m.tripsCreated}'),
+          _Stat('Trips refined', '${m.tripsRefined}'),
+          _Stat('Attach rate', _pct(m.attachRate),
+              caption: '${m.tripsWithBookingClick} trips w/ click'),
+          _Stat('Booking clicks', '${m.bookingClicks}'),
+          _Stat('Marked booked', '${m.todosMarkedBooked}'),
+        ]),
+        if (m.clicksByProvider.isNotEmpty) ...[
+          const SizedBox(height: AppSpacing.lg),
+          _ProviderClicks(clicks: m.clicksByProvider),
+        ],
+        const SizedBox(height: AppSpacing.xl),
+        const SectionHeader(title: 'AI planning'),
+        const SizedBox(height: AppSpacing.sm),
+        _TileGrid(tiles: [
+          _Stat('Plan sessions', '${m.planSessions}',
+              caption: '${m.planSessionsAnonymous} anonymous'),
+          _Stat('Cap hits', '${m.planCapHits}'),
+          _Stat('Tokens in', _tokens(m.planInputTokens),
+              caption: '${_tokens(m.planCacheReadTokens)} from cache'),
+          _Stat('Tokens out', _tokens(m.planOutputTokens)),
+        ]),
+        const SizedBox(height: AppSpacing.xl),
+        const SectionHeader(title: 'Price alerts'),
+        const SizedBox(height: AppSpacing.sm),
+        _TileGrid(tiles: [
+          _Stat('Created', '${m.alertsCreated}'),
+          _Stat('Triggered', '${m.alertsTriggered}'),
+        ]),
+        const SizedBox(height: AppSpacing.xxl),
+      ],
+    );
+  }
+}
+
+class _Stat {
+  final String label;
+  final String value;
+  final String? caption;
+  const _Stat(this.label, this.value, {this.caption});
+}
+
+/// Responsive tile row: fixed-min-width tiles that wrap. Values wear text
+/// tokens (never a series color) per the dataviz rules — these are headline
+/// numbers, not encoded marks.
+class _TileGrid extends StatelessWidget {
+  final List<_Stat> tiles;
+  const _TileGrid({required this.tiles});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Wrap(
+      spacing: AppSpacing.md,
+      runSpacing: AppSpacing.md,
+      children: [
+        for (final t in tiles)
+          Container(
+            constraints: const BoxConstraints(minWidth: 140),
+            padding: const EdgeInsets.all(AppSpacing.lg),
+            decoration: BoxDecoration(
+              color: theme.colorScheme.surfaceContainerLow,
+              borderRadius: AppRadius.mdAll,
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  t.label,
+                  style: theme.textTheme.labelMedium?.copyWith(
+                    color: theme.colorScheme.onSurfaceVariant,
+                  ),
+                ),
+                const SizedBox(height: AppSpacing.xs),
+                Text(
+                  t.value,
+                  style: theme.textTheme.headlineSmall?.copyWith(
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+                if (t.caption != null)
+                  Text(
+                    t.caption!,
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: theme.colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+              ],
+            ),
+          ),
+      ],
+    );
+  }
+}
+
+/// Booking clicks by provider: labeled rows with a single-hue proportional
+/// bar. One hue on purpose — the bars encode magnitude, the labels carry
+/// identity, so no categorical palette is needed.
+class _ProviderClicks extends StatelessWidget {
+  final Map<String, int> clicks;
+  const _ProviderClicks({required this.clicks});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final entries = clicks.entries.toList()
+      ..sort((a, b) => b.value.compareTo(a.value));
+    final max = entries.first.value;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text('Clicks by provider', style: theme.textTheme.labelLarge),
+        const SizedBox(height: AppSpacing.sm),
+        for (final e in entries)
+          Padding(
+            padding: const EdgeInsets.only(bottom: AppSpacing.xs),
+            child: Row(
+              children: [
+                SizedBox(
+                  width: 110,
+                  child: Text(
+                    e.key,
+                    style: theme.textTheme.bodySmall,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+                Expanded(
+                  child: LayoutBuilder(
+                    builder: (context, constraints) => Align(
+                      alignment: Alignment.centerLeft,
+                      child: Container(
+                        height: 10,
+                        width: max == 0
+                            ? 0
+                            : constraints.maxWidth * (e.value / max),
+                        decoration: BoxDecoration(
+                          color: theme.colorScheme.primary,
+                          borderRadius: BorderRadius.circular(4),
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+                const SizedBox(width: AppSpacing.sm),
+                SizedBox(
+                  width: 40,
+                  child: Text(
+                    '${e.value}',
+                    textAlign: TextAlign.end,
+                    style: theme.textTheme.bodySmall,
+                  ),
+                ),
+              ],
+            ),
+          ),
+      ],
+    );
+  }
+}

--- a/src/packages/flutter-app/lib/services/admin_metrics_api_service.dart
+++ b/src/packages/flutter-app/lib/services/admin_metrics_api_service.dart
@@ -1,0 +1,26 @@
+import 'dart:convert';
+import '../models/admin_metrics.dart';
+import 'api_client.dart';
+
+/// GET /admin/metrics — requires an admin bearer token (enforced
+/// server-side by adminMiddleware).
+class AdminMetricsApiService {
+  final ApiClient apiClient;
+
+  AdminMetricsApiService(this.apiClient);
+
+  Future<AdminMetrics> fetch({int days = 30}) async {
+    final token = apiClient.authToken;
+    final res = await apiClient.httpClient.get(
+      Uri.parse('${apiClient.baseUrl}/admin/metrics?days=$days'),
+      headers: {
+        'Accept': 'application/json',
+        if (token != null) 'Authorization': 'Bearer $token',
+      },
+    );
+    if (res.statusCode == 200) {
+      return AdminMetrics.fromJson(jsonDecode(res.body));
+    }
+    throw Exception('Failed to load metrics (${res.statusCode})');
+  }
+}

--- a/src/packages/flutter-app/lib/widgets/account_menu.dart
+++ b/src/packages/flutter-app/lib/widgets/account_menu.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../navigation/app_nav.dart';
 import '../providers/auth_provider.dart';
+import '../screens/admin_metrics_screen.dart';
 import '../screens/alerts_screen.dart';
 import '../screens/preferences_screen.dart';
 import '../screens/local_admin_screen.dart';
@@ -24,6 +25,8 @@ void _onSelected(BuildContext context, WidgetRef ref, String value) {
     pushOnActiveTab(ref, const AlertsScreen());
   } else if (value == 'local_admin') {
     pushOnActiveTab(ref, const LocalAdminScreen());
+  } else if (value == 'admin_metrics') {
+    pushOnActiveTab(ref, const AdminMetricsScreen());
   }
 }
 
@@ -116,6 +119,17 @@ List<PopupMenuEntry<String>> _items(
             Icon(Icons.verified, size: 20, color: AppColors.toolLocal),
             const SizedBox(width: AppSpacing.md),
             const Text('Local intel admin'),
+          ],
+        ),
+      ),
+      PopupMenuItem<String>(
+        value: 'admin_metrics',
+        child: Row(
+          children: [
+            Icon(Icons.insights,
+                size: 20, color: theme.colorScheme.onSurfaceVariant),
+            const SizedBox(width: AppSpacing.md),
+            const Text('Metrics'),
           ],
         ),
       ),

--- a/src/packages/flutter-app/test/admin_metrics_screen_test.dart
+++ b/src/packages/flutter-app/test/admin_metrics_screen_test.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:travel_route_planner/models/admin_metrics.dart';
+import 'package:travel_route_planner/providers/admin_metrics_provider.dart';
+import 'package:travel_route_planner/screens/admin_metrics_screen.dart';
+
+void main() {
+  testWidgets('renders funnel, AI, and alert tiles from metrics',
+      (tester) async {
+    tester.view.physicalSize = const Size(800, 2400);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+
+    const metrics = AdminMetrics(
+      days: 30,
+      signups: 42,
+      activatedSignups: 21,
+      activationRate: 0.5,
+      tripsCreated: 30,
+      attachRate: 0.15,
+      bookingClicks: 12,
+      clicksByProvider: {'booking': 8, 'airbnb': 4},
+      planSessions: 100,
+      planSessionsAnonymous: 40,
+      planCapHits: 2,
+      planInputTokens: 1500000,
+      planOutputTokens: 250000,
+      planCacheReadTokens: 900000,
+      alertsCreated: 5,
+      alertsTriggered: 1,
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          adminMetricsProvider(30).overrideWith((ref) async => metrics),
+        ],
+        child: const MaterialApp(home: AdminMetricsScreen()),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('42'), findsOneWidget); // signups
+    expect(find.text('50.0%'), findsOneWidget); // activation rate
+    expect(find.text('15.0%'), findsOneWidget); // attach rate
+    expect(find.text('40 anonymous'), findsOneWidget);
+    expect(find.text('1.5M'), findsOneWidget); // tokens in
+    expect(find.text('900.0k from cache'), findsOneWidget);
+    expect(find.text('Clicks by provider'), findsOneWidget);
+    expect(find.text('booking'), findsOneWidget);
+    expect(find.text('Price alerts'), findsOneWidget);
+  });
+
+  testWidgets('error state offers retry', (tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          adminMetricsProvider(30)
+              .overrideWith((ref) async => throw Exception('403')),
+        ],
+        child: const MaterialApp(home: AdminMetricsScreen()),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Could not load metrics'), findsOneWidget);
+    expect(find.text('Retry'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## What

`GET /admin/metrics` has been "a dashboard-in-an-endpoint" with no client since #42. This adds the Flutter surface:

- **Stat tiles** across four sections — Funnel (signups, activation %, onboardings, returning users), Trips & bookings (attach rate, booking clicks, marked-booked), AI planning (sessions with anonymous split, cap hits, token in/out with cache-read split — the metrics added in #54), and Price alerts (created/triggered, added in #56).
- **Clicks by provider** as single-hue proportional bars — labels carry identity, color carries magnitude only (no categorical palette needed).
- 7/30/90-day window switcher (`FutureProvider.family` caches per window).
- Entry: "Metrics" in the account menu, admin-visible only (server enforces `adminMiddleware` regardless).

Deliberately chartless v1: every number here is a headline, not a trend. Trend lines can come once there's enough history to plot.

## Tests
2 widget tests (tile rendering incl. rate formatting and token abbreviations; error + retry state). Full `flutter test` + `analyze` green.

Part of Wave 6, PR 5 of ~8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)