### PR TITLE
Agent tool depth: get_weather, get_trip, add_booking_todo

### DIFF
--- a/src/packages/api/plan_handler.go
+++ b/src/packages/api/plan_handler.go
@@ -320,6 +320,7 @@ func planHandler(w http.ResponseWriter, r *http.Request) {
 		{OfTool: &searchFlightsTool},
 		{OfTool: &searchEventsTool},
 		{OfTool: &searchLocalRecsTool},
+		{OfTool: &getWeatherTool},
 	}
 	// Trip-bound sessions get the in-place section tool instead of
 	// create_itinerary, so a refinement can never spawn a new trip version.
@@ -330,6 +331,8 @@ func planHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	if authed {
 		tools = append(tools, anthropic.ToolUnionParam{OfTool: &savePrefsTool})
+		tools = append(tools, anthropic.ToolUnionParam{OfTool: &getTripTool})
+		tools = append(tools, anthropic.ToolUnionParam{OfTool: &addBookingTodoTool})
 	}
 
 	var messages []anthropic.MessageParam
@@ -342,7 +345,7 @@ func planHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	today := time.Now()
-	basePrompt := "You are an expert travel agent. Today's date is " + today.Format("Monday, January 2, 2006") + " (" + today.Format("2006-01-02") + "). When a traveler gives a date without a year, assume the soonest upcoming occurrence on or after today — never a past year. Use dates in YYYY-MM-DD form when calling tools. Help users plan trips by searching for specific places and attractions. For each city, ALWAYS call search_local_recommendations FIRST — these are hand-curated picks from real locals, the legit info you can't get by googling. Prefer them over generic results, build the itinerary around them where they fit the traveler, and cite the local by name in your reply (e.g. 'Ana, a Lisbon chef, swears by…'). When a local pick becomes an itinerary place, carry its id into local_recommendation_id and its source_name into local_source_name. Then use search_places to fill gaps and find any other real locations with coordinates. Search for individual places (e.g. 'Louvre Museum Paris') rather than broad queries. Include a mix of activities/attractions and dining (restaurants), guided by the traveler's interests, budget, and pace. When you call create_itinerary, tag each location with category ('attraction' or 'restaurant'), a time_of_day ('morning', 'afternoon', or 'evening'), and a day (the 1-based trip day it falls on, increasing chronologically across the whole trip) so each day reads as a sensible schedule. When you have gathered enough places for the user's trip, call create_itinerary to finalize the plan; pass start_date (and end_date) whenever the traveler has given or agreed to travel dates, with day 1 being the start date. You can also use search_flights to find real flight options — ask for the traveler's departure city/airport and dates if you don't know them, and pick optimize_for from their budget (budget→cost, luxury→time, otherwise balanced); summarize the top 2-3 options in your own words and help them choose — do not tell the traveler to look at cards or lists in the chat. For travel between Greek islands, use suggest_ferries (ferries are the primary way to island-hop); note that in Greece search_events returns curated source links rather than ticketed listings. Be conversational and helpful — ask clarifying questions if needed before searching. Format replies with light markdown — short paragraphs, **bold** for place names, hyphen lists — no headings or tables."
+	basePrompt := "You are an expert travel agent. Today's date is " + today.Format("Monday, January 2, 2006") + " (" + today.Format("2006-01-02") + "). When a traveler gives a date without a year, assume the soonest upcoming occurrence on or after today — never a past year. Use dates in YYYY-MM-DD form when calling tools. Help users plan trips by searching for specific places and attractions. For each city, ALWAYS call search_local_recommendations FIRST — these are hand-curated picks from real locals, the legit info you can't get by googling. Prefer them over generic results, build the itinerary around them where they fit the traveler, and cite the local by name in your reply (e.g. 'Ana, a Lisbon chef, swears by…'). When a local pick becomes an itinerary place, carry its id into local_recommendation_id and its source_name into local_source_name. Then use search_places to fill gaps and find any other real locations with coordinates. Search for individual places (e.g. 'Louvre Museum Paris') rather than broad queries. Include a mix of activities/attractions and dining (restaurants), guided by the traveler's interests, budget, and pace. When you call create_itinerary, tag each location with category ('attraction' or 'restaurant'), a time_of_day ('morning', 'afternoon', or 'evening'), and a day (the 1-based trip day it falls on, increasing chronologically across the whole trip) so each day reads as a sensible schedule. When you have gathered enough places for the user's trip, call create_itinerary to finalize the plan; pass start_date (and end_date) whenever the traveler has given or agreed to travel dates, with day 1 being the start date. You can also use search_flights to find real flight options — ask for the traveler's departure city/airport and dates if you don't know them, and pick optimize_for from their budget (budget→cost, luxury→time, otherwise balanced); summarize the top 2-3 options in your own words and help them choose — do not tell the traveler to look at cards or lists in the chat. For travel between Greek islands, use suggest_ferries (ferries are the primary way to island-hop); note that in Greece search_events returns curated source links rather than ticketed listings. Use get_weather when weather changes the advice — packing, outdoor days, beach or ski viability, seasonal closures; for far-off dates it returns last year's weather as a seasonal guide, so present it as 'typically', never as a forecast. For signed-in travelers: when they reference a trip you've already planned together, call get_trip to read what's saved instead of asking them to repeat it; and when you give time-sensitive booking advice about a saved trip (book the ferry, reserve that restaurant), call add_booking_todo so it lands on their checklist instead of getting lost in chat. Be conversational and helpful — ask clarifying questions if needed before searching. Format replies with light markdown — short paragraphs, **bold** for place names, hyphen lists — no headings or tables."
 
 	placesService := NewGooglePlacesService()
 	ctx := r.Context()
@@ -738,6 +741,21 @@ func planHandler(w http.ResponseWriter, r *http.Request) {
 				}
 				sendSSE(w, "tool_result", map[string]string{"name": "search_local_recommendations"})
 				toolResults = append(toolResults, anthropic.NewToolResultBlock(variant.ID, summary, err != nil))
+
+			case "get_weather":
+				result, isErr := runGetWeatherTool(ctx, variant.Input)
+				sendSSE(w, "tool_result", map[string]string{"name": "get_weather"})
+				toolResults = append(toolResults, anthropic.NewToolResultBlock(variant.ID, result, isErr))
+
+			case "get_trip":
+				result, isErr := runGetTripTool(ctx, authed, uid, variant.Input)
+				sendSSE(w, "tool_result", map[string]string{"name": "get_trip"})
+				toolResults = append(toolResults, anthropic.NewToolResultBlock(variant.ID, result, isErr))
+
+			case "add_booking_todo":
+				result, isErr := runAddBookingTodoTool(ctx, authed, uid, variant.Input)
+				sendSSE(w, "tool_result", map[string]string{"name": "add_booking_todo"})
+				toolResults = append(toolResults, anthropic.NewToolResultBlock(variant.ID, result, isErr))
 			}
 		}
 

--- a/src/packages/api/plan_tools_extra.go
+++ b/src/packages/api/plan_tools_extra.go
@@ -1,0 +1,231 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	anthropic "github.com/anthropics/anthropic-sdk-go"
+	"github.com/google/uuid"
+
+	"travel-route-planner/store"
+)
+
+// The Wave-6 agent tools (weather, saved-trip context, booking write-back).
+// Definitions and dispatchers live here so plan_handler.go's switch stays a
+// thin router. Each dispatcher returns (resultText, isError) and never
+// panics on degraded mode — the model gets a usable sentence either way.
+
+var getWeatherTool = anthropic.ToolParam{
+	Name:        "get_weather",
+	Description: anthropic.String("Get the weather for a city over the trip dates: a real forecast when the dates are within ~2 weeks, otherwise last year's observed weather for the same dates as a seasonal guide. Use it when weather changes the advice — packing, beach/ski viability, outdoor days, seasonal closures."),
+	InputSchema: anthropic.ToolInputSchemaParam{
+		Properties: map[string]any{
+			"city": map[string]any{
+				"type":        "string",
+				"description": "City or island name, e.g. 'Athens' or 'Naxos'",
+			},
+			"start_date": map[string]any{
+				"type":        "string",
+				"description": "First day, YYYY-MM-DD",
+			},
+			"end_date": map[string]any{
+				"type":        "string",
+				"description": "Last day, YYYY-MM-DD; omit for a single day",
+			},
+		},
+		Required: []string{"city", "start_date"},
+	},
+}
+
+var getTripTool = anthropic.ToolParam{
+	Name:        "get_trip",
+	Description: anthropic.String("Read the traveler's saved trips. Without trip_id: list their trips (id, title, dates, cities). With trip_id: the full itinerary of that trip. Use it when they reference an existing trip ('my Lisbon trip', 'the trip we planned last week') so you can build on what's already saved instead of asking again."),
+	InputSchema: anthropic.ToolInputSchemaParam{
+		Properties: map[string]any{
+			"trip_id": map[string]any{
+				"type":        "string",
+				"description": "A trip id from a previous get_trip listing; omit to list all trips",
+			},
+		},
+	},
+}
+
+var addBookingTodoTool = anthropic.ToolParam{
+	Name:        "add_booking_todo",
+	Description: anthropic.String("Add an item to a saved trip's booking checklist (e.g. 'Book the Naxos ferry', 'Reserve the tasting menu at Belcanto'). Use it when you give time-sensitive booking advice about one of the traveler's saved trips, so the advice becomes a tracked to-do instead of a chat message they'll lose. Requires the trip's id (use get_trip first if you don't have it)."),
+	InputSchema: anthropic.ToolInputSchemaParam{
+		Properties: map[string]any{
+			"trip_id": map[string]any{
+				"type":        "string",
+				"description": "The saved trip's id",
+			},
+			"kind": map[string]any{
+				"type":        "string",
+				"description": "'stay', 'transport', or 'other'",
+			},
+			"title": map[string]any{
+				"type":        "string",
+				"description": "Short imperative label, e.g. 'Book Blue Star ferry Athens → Naxos'",
+			},
+			"subtitle": map[string]any{
+				"type":        "string",
+				"description": "Optional detail, e.g. 'books out ~2 weeks ahead in July'",
+			},
+			"depart_date": map[string]any{
+				"type":        "string",
+				"description": "Optional YYYY-MM-DD the booking is for",
+			},
+		},
+		Required: []string{"trip_id", "kind", "title"},
+	},
+}
+
+func runGetWeatherTool(ctx context.Context, input json.RawMessage) (string, bool) {
+	var in struct {
+		City      string `json:"city"`
+		StartDate string `json:"start_date"`
+		EndDate   string `json:"end_date"`
+	}
+	json.Unmarshal(input, &in)
+	report, err := weatherService.GetTripWeather(ctx, in.City, in.StartDate, in.EndDate)
+	if err != nil {
+		return fmt.Sprintf("Could not get weather for %s: %v. Plan without it.", in.City, err), true
+	}
+	return summarizeWeather(report), false
+}
+
+func runGetTripTool(ctx context.Context, authed bool, uid uuid.UUID, input json.RawMessage) (string, bool) {
+	if !authed {
+		return "The traveler is not signed in, so there are no saved trips to read. Continue planning in this conversation.", true
+	}
+	if dbPool == nil {
+		return "Saved trips are unavailable right now (persistence offline).", true
+	}
+	var in struct {
+		TripID string `json:"trip_id"`
+	}
+	json.Unmarshal(input, &in)
+	q := store.New(dbPool)
+
+	if strings.TrimSpace(in.TripID) == "" {
+		trips, err := q.ListLatestTripsByOwner(ctx, uid)
+		if err != nil {
+			return "Could not load the traveler's trips.", true
+		}
+		if len(trips) == 0 {
+			return "The traveler has no saved trips yet.", false
+		}
+		var b strings.Builder
+		fmt.Fprintf(&b, "The traveler's saved trips (%d):\n", len(trips))
+		for _, t := range trips {
+			line := fmt.Sprintf("- %s [id: %s] — %s", t.Title, t.ID, t.Status)
+			if d := dateString(t.StartDate); d != "" {
+				line += ", starts " + d
+			}
+			if len(t.Cities) > 0 {
+				line += ", cities: " + strings.Join(t.Cities, ", ")
+			}
+			b.WriteString(line + "\n")
+		}
+		b.WriteString("Call get_trip with a trip_id for the full itinerary.")
+		return b.String(), false
+	}
+
+	tid, err := uuid.Parse(in.TripID)
+	if err != nil {
+		return "That trip_id is not valid; call get_trip without arguments to list trips.", true
+	}
+	trip, err := q.GetTripByIDAndOwner(ctx, store.GetTripByIDAndOwnerParams{ID: tid, UserID: uid})
+	if err != nil {
+		return "No such trip for this traveler; call get_trip without arguments to list trips.", true
+	}
+	items, err := q.GetItineraryItemsByTrip(ctx, trip.ID)
+	if err != nil {
+		return "Could not load that trip's itinerary.", true
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "Trip %q [id: %s], status %s", trip.Title, trip.ID, trip.Status)
+	if d := dateString(trip.StartDate); d != "" {
+		fmt.Fprintf(&b, ", %s", d)
+		if e := dateString(trip.EndDate); e != "" {
+			fmt.Fprintf(&b, " to %s", e)
+		}
+	}
+	fmt.Fprintf(&b, ". %d places:\n", len(items))
+	for _, it := range items {
+		line := "- " + it.Name
+		var tags []string
+		if it.Day != nil {
+			tags = append(tags, fmt.Sprintf("day %d", *it.Day))
+		}
+		if it.City != nil && *it.City != "" {
+			tags = append(tags, *it.City)
+		}
+		if it.TimeOfDay != nil && *it.TimeOfDay != "" {
+			tags = append(tags, *it.TimeOfDay)
+		}
+		if it.Category != nil && *it.Category != "" {
+			tags = append(tags, *it.Category)
+		}
+		if len(tags) > 0 {
+			line += " (" + strings.Join(tags, ", ") + ")"
+		}
+		b.WriteString(line + "\n")
+	}
+	return b.String(), false
+}
+
+func runAddBookingTodoTool(ctx context.Context, authed bool, uid uuid.UUID, input json.RawMessage) (string, bool) {
+	if !authed {
+		return "The traveler is not signed in, so nothing can be saved. Give the advice in your reply instead.", true
+	}
+	if dbPool == nil {
+		return "Booking checklists are unavailable right now (persistence offline).", true
+	}
+	var in struct {
+		TripID     string  `json:"trip_id"`
+		Kind       string  `json:"kind"`
+		Title      string  `json:"title"`
+		Subtitle   *string `json:"subtitle"`
+		DepartDate *string `json:"depart_date"`
+	}
+	json.Unmarshal(input, &in)
+
+	kind := strings.TrimSpace(in.Kind)
+	if !allowedBookingKinds[kind] {
+		return "kind must be 'stay', 'transport', or 'other'.", true
+	}
+	if strings.TrimSpace(in.Title) == "" {
+		return "title is required.", true
+	}
+	tid, err := uuid.Parse(strings.TrimSpace(in.TripID))
+	if err != nil {
+		return "That trip_id is not valid; call get_trip to find the right one.", true
+	}
+	// Ownership: the agent may only write to the caller's own trips.
+	if _, err := store.New(dbPool).GetTripByIDAndOwner(ctx, store.GetTripByIDAndOwnerParams{ID: tid, UserID: uid}); err != nil {
+		return "No such trip for this traveler; call get_trip to find the right one.", true
+	}
+	depart, err := parseDateParam(in.DepartDate)
+	if err != nil {
+		return "depart_date must be YYYY-MM-DD.", true
+	}
+
+	todo, err := store.New(dbPool).CreateBookingTodo(ctx, store.CreateBookingTodoParams{
+		TripID:     tid,
+		Kind:       kind,
+		TodoKey:    "agent:" + uuid.NewString(),
+		Title:      strings.TrimSpace(in.Title),
+		Subtitle:   in.Subtitle,
+		DepartDate: depart,
+		Position:   9999,
+	})
+	if err != nil {
+		return "Could not save the booking to-do.", true
+	}
+	go recordEvent(uid, "agent_booking_todo_added", &tid, map[string]any{"kind": todo.Kind})
+	return fmt.Sprintf("Added %q to the trip's booking checklist. Mention it briefly; the traveler will see it on the trip page.", todo.Title), false
+}

--- a/src/packages/api/plan_tools_extra_test.go
+++ b/src/packages/api/plan_tools_extra_test.go
@@ -1,0 +1,183 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// stubWeather wires a WeatherService whose geocode/forecast/archive endpoints
+// all answer from one httptest server.
+func stubWeather(t *testing.T) (*WeatherService, *[]string) {
+	t.Helper()
+	var paths []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.HasPrefix(r.URL.Path, "/v1/search"):
+			fmt.Fprint(w, `{"results":[{"name":"Athens","country":"Greece","latitude":37.98,"longitude":23.72}]}`)
+		case strings.HasPrefix(r.URL.Path, "/v1/forecast"):
+			fmt.Fprint(w, `{"daily":{"time":["2026-07-10","2026-07-11"],
+				"temperature_2m_max":[33.1,34.0],"temperature_2m_min":[24.2,25.0],
+				"precipitation_sum":[0,2.4],"precipitation_probability_mean":[5,40]}}`)
+		case strings.HasPrefix(r.URL.Path, "/v1/archive"):
+			fmt.Fprint(w, `{"daily":{"time":["2025-10-01"],
+				"temperature_2m_max":[26.5],"temperature_2m_min":[18.1],
+				"precipitation_sum":[3.2]}}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	s := NewWeatherService()
+	s.GeocodeBaseURL = srv.URL
+	s.ForecastBaseURL = srv.URL
+	s.ArchiveBaseURL = srv.URL
+	return s, &paths
+}
+
+func TestGetTripWeatherForecastPath(t *testing.T) {
+	s, _ := stubWeather(t)
+	start := time.Now().AddDate(0, 0, 3).Format(dateLayout)
+	end := time.Now().AddDate(0, 0, 4).Format(dateLayout)
+
+	report, err := s.GetTripWeather(context.Background(), "Athens", start, end)
+	if err != nil {
+		t.Fatalf("GetTripWeather: %v", err)
+	}
+	if report.Kind != "forecast" || report.Location != "Athens, Greece" || len(report.Days) != 2 {
+		t.Fatalf("report = %+v", report)
+	}
+	if report.Days[1].PrecipPct == nil || *report.Days[1].PrecipPct != 40 {
+		t.Fatalf("forecast day missing precip probability: %+v", report.Days[1])
+	}
+
+	text := summarizeWeather(report)
+	if !strings.Contains(text, "Forecast for Athens, Greece") || !strings.Contains(text, "40% chance of rain") {
+		t.Fatalf("summary wrong:\n%s", text)
+	}
+}
+
+func TestGetTripWeatherFallsBackToArchive(t *testing.T) {
+	s, paths := stubWeather(t)
+	// Far beyond the 16-day horizon → last year's observations.
+	start := time.Now().AddDate(0, 3, 0).Format(dateLayout)
+
+	report, err := s.GetTripWeather(context.Background(), "Athens", start, "")
+	if err != nil {
+		t.Fatalf("GetTripWeather: %v", err)
+	}
+	if report.Kind != "historical" {
+		t.Fatalf("kind = %s, want historical", report.Kind)
+	}
+	var hitArchive bool
+	for _, p := range *paths {
+		if strings.HasPrefix(p, "/v1/archive") {
+			hitArchive = true
+		}
+		if strings.HasPrefix(p, "/v1/forecast") {
+			t.Fatal("far-out dates must not hit the forecast API")
+		}
+	}
+	if !hitArchive {
+		t.Fatal("archive API was not called")
+	}
+	if !strings.Contains(summarizeWeather(report), "Typical weather") {
+		t.Fatal("historical summary must be framed as typical, not a forecast")
+	}
+}
+
+func TestGetTripWeatherCaches(t *testing.T) {
+	s, paths := stubWeather(t)
+	start := time.Now().AddDate(0, 0, 3).Format(dateLayout)
+	if _, err := s.GetTripWeather(context.Background(), "Athens", start, ""); err != nil {
+		t.Fatal(err)
+	}
+	n := len(*paths)
+	if _, err := s.GetTripWeather(context.Background(), "Athens", start, ""); err != nil {
+		t.Fatal(err)
+	}
+	if len(*paths) != n {
+		t.Fatalf("second identical lookup hit the network (%d -> %d calls)", n, len(*paths))
+	}
+}
+
+func TestGetTripToolAnonymous(t *testing.T) {
+	msg, isErr := runGetTripTool(context.Background(), false, uuid.Nil, json.RawMessage(`{}`))
+	if !isErr || !strings.Contains(msg, "not signed in") {
+		t.Fatalf("anonymous get_trip = %q (err=%v)", msg, isErr)
+	}
+}
+
+func TestAddBookingTodoToolAnonymous(t *testing.T) {
+	msg, isErr := runAddBookingTodoTool(context.Background(), false, uuid.Nil, json.RawMessage(`{}`))
+	if !isErr || !strings.Contains(msg, "not signed in") {
+		t.Fatalf("anonymous add_booking_todo = %q (err=%v)", msg, isErr)
+	}
+}
+
+func TestGetTripToolListsAndReads(t *testing.T) {
+	resetDB(t)
+	owner, _ := createTestUser(t, "agent@example.com")
+	other, _ := createTestUser(t, "other@example.com")
+	trip := createTestTrip(t, owner.ID, 2)
+	createTestTrip(t, other.ID, 1) // must never appear for owner
+
+	list, isErr := runGetTripTool(context.Background(), true, owner.ID, json.RawMessage(`{}`))
+	if isErr || !strings.Contains(list, trip.ID.String()) || !strings.Contains(list, "saved trips (1)") {
+		t.Fatalf("list = %q (err=%v)", list, isErr)
+	}
+
+	detail, isErr := runGetTripTool(context.Background(), true, owner.ID,
+		json.RawMessage(`{"trip_id":"`+trip.ID.String()+`"}`))
+	if isErr || !strings.Contains(detail, "Place 1") || !strings.Contains(detail, "2 places") {
+		t.Fatalf("detail = %q (err=%v)", detail, isErr)
+	}
+
+	// Cross-user read must fail closed.
+	_, isErr = runGetTripTool(context.Background(), true, other.ID,
+		json.RawMessage(`{"trip_id":"`+trip.ID.String()+`"}`))
+	if !isErr {
+		t.Fatal("cross-user get_trip did not error")
+	}
+}
+
+func TestAddBookingTodoToolWritesOwnedTripOnly(t *testing.T) {
+	resetDB(t)
+	owner, ownerToken := createTestUser(t, "agent@example.com")
+	other, _ := createTestUser(t, "other@example.com")
+	trip := createTestTrip(t, owner.ID, 1)
+
+	msg, isErr := runAddBookingTodoTool(context.Background(), true, owner.ID,
+		json.RawMessage(`{"trip_id":"`+trip.ID.String()+`","kind":"transport","title":"Book Blue Star ferry"}`))
+	if isErr || !strings.Contains(msg, "Book Blue Star ferry") {
+		t.Fatalf("add = %q (err=%v)", msg, isErr)
+	}
+
+	// Visible through the regular API for the owner.
+	rec := doJSON(t, "GET", "/api/v1/trips/"+trip.ID.String(), ownerToken, nil)
+	if rec.Code != http.StatusOK || !strings.Contains(rec.Body.String(), "Book Blue Star ferry") {
+		t.Fatalf("todo not on trip: %d %s", rec.Code, rec.Body.String())
+	}
+
+	// Cross-user write must fail closed.
+	_, isErr = runAddBookingTodoTool(context.Background(), true, other.ID,
+		json.RawMessage(`{"trip_id":"`+trip.ID.String()+`","kind":"other","title":"Hijack"}`))
+	if !isErr {
+		t.Fatal("cross-user add_booking_todo did not error")
+	}
+
+	// Bad kind rejected.
+	if _, isErr := runAddBookingTodoTool(context.Background(), true, owner.ID,
+		json.RawMessage(`{"trip_id":"`+trip.ID.String()+`","kind":"spa","title":"x"}`)); !isErr {
+		t.Fatal("invalid kind accepted")
+	}
+}

--- a/src/packages/api/weather_service.go
+++ b/src/packages/api/weather_service.go
@@ -1,0 +1,251 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// Weather for trip planning via Open-Meteo (open-meteo.com) — keyless and
+// free for non-commercial volumes. Within the 16-day horizon we use the real
+// forecast; beyond it we report last year's observed weather for the same
+// dates as "typical" (the archive API), which is what a traveler planning
+// months out actually needs. Same provider-isolation convention as Duffel/
+// Ticketmaster: everything Open-Meteo lives in this file behind WeatherReport.
+
+const forecastHorizonDays = 16
+
+type WeatherService struct {
+	GeocodeBaseURL  string
+	ForecastBaseURL string
+	ArchiveBaseURL  string
+	Client          *http.Client
+
+	// City coordinates never move; day summaries are stable for hours.
+	geoCache     *ttlCache[geoResult]
+	summaryCache *ttlCache[WeatherReport]
+}
+
+type geoResult struct {
+	Lat, Lon float64
+	Label    string
+}
+
+// WeatherReport is the tool-facing summary: one line per day plus whether it
+// is a forecast or last year's observation.
+type WeatherReport struct {
+	Location string       `json:"location"`
+	Kind     string       `json:"kind"` // "forecast" | "historical"
+	Days     []WeatherDay `json:"days"`
+}
+
+type WeatherDay struct {
+	Date      string  `json:"date"`
+	TempMinC  float64 `json:"temp_min_c"`
+	TempMaxC  float64 `json:"temp_max_c"`
+	PrecipMM  float64 `json:"precip_mm"`
+	PrecipPct *int    `json:"precip_probability,omitempty"` // forecast only
+}
+
+var weatherService = NewWeatherService()
+
+func NewWeatherService() *WeatherService {
+	return &WeatherService{
+		GeocodeBaseURL:  "https://geocoding-api.open-meteo.com",
+		ForecastBaseURL: "https://api.open-meteo.com",
+		ArchiveBaseURL:  "https://archive-api.open-meteo.com",
+		Client:          &http.Client{Timeout: 10 * time.Second},
+		geoCache:        newTTLCache[geoResult](24*time.Hour, 500),
+		summaryCache:    newTTLCache[WeatherReport](3*time.Hour, 500),
+	}
+}
+
+func (s *WeatherService) getJSON(ctx context.Context, rawURL string, out any) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := s.Client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("weather provider returned %d", resp.StatusCode)
+	}
+	return json.Unmarshal(body, out)
+}
+
+func (s *WeatherService) geocode(ctx context.Context, city string) (geoResult, error) {
+	key := strings.ToLower(strings.TrimSpace(city))
+	if hit, ok := s.geoCache.get(key); ok {
+		return hit, nil
+	}
+	var out struct {
+		Results []struct {
+			Name      string  `json:"name"`
+			Country   string  `json:"country"`
+			Latitude  float64 `json:"latitude"`
+			Longitude float64 `json:"longitude"`
+		} `json:"results"`
+	}
+	u := fmt.Sprintf("%s/v1/search?name=%s&count=1&language=en&format=json",
+		s.GeocodeBaseURL, url.QueryEscape(city))
+	if err := s.getJSON(ctx, u, &out); err != nil {
+		return geoResult{}, err
+	}
+	if len(out.Results) == 0 {
+		return geoResult{}, fmt.Errorf("no location found for %q", city)
+	}
+	r := out.Results[0]
+	label := r.Name
+	if r.Country != "" {
+		label += ", " + r.Country
+	}
+	g := geoResult{Lat: r.Latitude, Lon: r.Longitude, Label: label}
+	s.geoCache.set(key, g)
+	return g, nil
+}
+
+// GetTripWeather returns day summaries for a city and date range. Dates are
+// YYYY-MM-DD; ranges longer than 14 days are truncated to keep the payload
+// tool-sized.
+func (s *WeatherService) GetTripWeather(ctx context.Context, city, startDate, endDate string) (WeatherReport, error) {
+	start, err := time.Parse(dateLayout, startDate)
+	if err != nil {
+		return WeatherReport{}, fmt.Errorf("start_date must be YYYY-MM-DD")
+	}
+	end := start
+	if endDate != "" {
+		if end, err = time.Parse(dateLayout, endDate); err != nil {
+			return WeatherReport{}, fmt.Errorf("end_date must be YYYY-MM-DD")
+		}
+	}
+	if end.Before(start) {
+		end = start
+	}
+	if end.Sub(start) > 13*24*time.Hour {
+		end = start.AddDate(0, 0, 13)
+	}
+
+	cacheKey := strings.Join([]string{strings.ToLower(city), startDate, endDate}, "|")
+	if hit, ok := s.summaryCache.get(cacheKey); ok {
+		return hit, nil
+	}
+
+	geo, err := s.geocode(ctx, city)
+	if err != nil {
+		return WeatherReport{}, err
+	}
+
+	var report WeatherReport
+	if time.Until(end) <= forecastHorizonDays*24*time.Hour && time.Since(start) < 24*time.Hour {
+		report, err = s.fetchForecast(ctx, geo, start, end)
+	} else {
+		// Out of forecast range: last year's same dates as "typical".
+		report, err = s.fetchArchive(ctx, geo, start.AddDate(-1, 0, 0), end.AddDate(-1, 0, 0))
+	}
+	if err != nil {
+		return WeatherReport{}, err
+	}
+	report.Location = geo.Label
+	s.summaryCache.set(cacheKey, report)
+	return report, nil
+}
+
+func (s *WeatherService) fetchForecast(ctx context.Context, geo geoResult, start, end time.Time) (WeatherReport, error) {
+	var out struct {
+		Daily struct {
+			Time         []string  `json:"time"`
+			TempMax      []float64 `json:"temperature_2m_max"`
+			TempMin      []float64 `json:"temperature_2m_min"`
+			PrecipSum    []float64 `json:"precipitation_sum"`
+			PrecipChance []int     `json:"precipitation_probability_mean"`
+		} `json:"daily"`
+	}
+	u := fmt.Sprintf("%s/v1/forecast?latitude=%f&longitude=%f&daily=temperature_2m_max,temperature_2m_min,precipitation_sum,precipitation_probability_mean&timezone=auto&start_date=%s&end_date=%s",
+		s.ForecastBaseURL, geo.Lat, geo.Lon, start.Format(dateLayout), end.Format(dateLayout))
+	if err := s.getJSON(ctx, u, &out); err != nil {
+		return WeatherReport{}, err
+	}
+	report := WeatherReport{Kind: "forecast"}
+	for i, d := range out.Daily.Time {
+		day := WeatherDay{Date: d}
+		if i < len(out.Daily.TempMax) {
+			day.TempMaxC = out.Daily.TempMax[i]
+		}
+		if i < len(out.Daily.TempMin) {
+			day.TempMinC = out.Daily.TempMin[i]
+		}
+		if i < len(out.Daily.PrecipSum) {
+			day.PrecipMM = out.Daily.PrecipSum[i]
+		}
+		if i < len(out.Daily.PrecipChance) {
+			p := out.Daily.PrecipChance[i]
+			day.PrecipPct = &p
+		}
+		report.Days = append(report.Days, day)
+	}
+	return report, nil
+}
+
+func (s *WeatherService) fetchArchive(ctx context.Context, geo geoResult, start, end time.Time) (WeatherReport, error) {
+	var out struct {
+		Daily struct {
+			Time      []string  `json:"time"`
+			TempMax   []float64 `json:"temperature_2m_max"`
+			TempMin   []float64 `json:"temperature_2m_min"`
+			PrecipSum []float64 `json:"precipitation_sum"`
+		} `json:"daily"`
+	}
+	u := fmt.Sprintf("%s/v1/archive?latitude=%f&longitude=%f&daily=temperature_2m_max,temperature_2m_min,precipitation_sum&timezone=auto&start_date=%s&end_date=%s",
+		s.ArchiveBaseURL, geo.Lat, geo.Lon, start.Format(dateLayout), end.Format(dateLayout))
+	if err := s.getJSON(ctx, u, &out); err != nil {
+		return WeatherReport{}, err
+	}
+	report := WeatherReport{Kind: "historical"}
+	for i, d := range out.Daily.Time {
+		day := WeatherDay{Date: d}
+		if i < len(out.Daily.TempMax) {
+			day.TempMaxC = out.Daily.TempMax[i]
+		}
+		if i < len(out.Daily.TempMin) {
+			day.TempMinC = out.Daily.TempMin[i]
+		}
+		if i < len(out.Daily.PrecipSum) {
+			day.PrecipMM = out.Daily.PrecipSum[i]
+		}
+		report.Days = append(report.Days, day)
+	}
+	return report, nil
+}
+
+// summarizeWeather renders a report as compact text for the model.
+func summarizeWeather(r WeatherReport) string {
+	var b strings.Builder
+	if r.Kind == "historical" {
+		fmt.Fprintf(&b, "Typical weather in %s for those dates (last year's observations — too far out for a forecast):\n", r.Location)
+	} else {
+		fmt.Fprintf(&b, "Forecast for %s:\n", r.Location)
+	}
+	for _, d := range r.Days {
+		line := fmt.Sprintf("%s: %.0f–%.0f°C", d.Date, d.TempMinC, d.TempMaxC)
+		if d.PrecipPct != nil {
+			line += fmt.Sprintf(", %d%% chance of rain", *d.PrecipPct)
+		} else if d.PrecipMM >= 1 {
+			line += fmt.Sprintf(", %.0fmm rain", d.PrecipMM)
+		}
+		b.WriteString(line + "\n")
+	}
+	b.WriteString("Mention the weather where it changes advice (packing, outdoor plans, season); don't recite every day.")
+	return b.String()
+}


### PR DESCRIPTION
## What

Three new tools for the `/plan` agent (9 → 12):

**`get_weather`** — new `weather_service.go` backed by Open-Meteo (keyless, free tier). Within ~16 days of today it returns the real daily forecast (min/max °C, rain probability); beyond that it returns **last year's observed weather for the same dates** via the archive API, and the summary + system prompt force the agent to present it as "typically", never as a forecast. Geocode results cached 24h, summaries 3h (same `ttlCache` as Places/Duffel). Provider fully isolated in one file per the house convention.

**`get_trip`** (signed-in only) — lists the traveler's saved trips or reads one full itinerary, so "add a day to my Lisbon trip" works from saved state instead of re-interviewing the traveler. Ownership-checked via the same query the REST handlers use.

**`add_booking_todo`** (signed-in only) — writes a checklist item onto an owned trip, turning "book the Naxos ferry by June — it sells out" into a tracked to-do on the trip page instead of a chat message that scrolls away. Records an `agent_booking_todo_added` analytics event.

Both authed tools fail closed with an instructive sentence for anonymous sessions and degrade cleanly without a DB.

## Tests
- Stubbed Open-Meteo server: forecast path, archive fallback (asserts the forecast API is **not** hit for far-out dates), cache behavior.
- DB-backed: get_trip list/detail with cross-user isolation, add_booking_todo write visible via the REST trip detail + cross-user/invalid-kind rejection.
- Full `go test -race` suite green locally against Postgres.

Part of Wave 6, PR 6 of ~8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)