### PR TITLE
Account settings: name, password, sign-out-everywhere, deletion

### DIFF
--- a/src/packages/api/account_handler.go
+++ b/src/packages/api/account_handler.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"strings"
+	"unicode/utf8"
+
+	"travel-route-planner/store"
+)
+
+// Account self-service: display name, password change, session revocation,
+// deletion. All behind authMiddleware; the destructive/credential routes sit
+// on the strict rate tier and re-verify the password (a stolen session must
+// not be enough to take over or destroy the account).
+
+func patchAccountHandler(w http.ResponseWriter, r *http.Request) {
+	if dbPool == nil {
+		writeJSONError(w, http.StatusServiceUnavailable, "database unavailable")
+		return
+	}
+	user, _ := userFromContext(r.Context())
+	var req struct {
+		DisplayName *string `json:"display_name"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid JSON")
+		return
+	}
+	if req.DisplayName == nil {
+		writeJSONError(w, http.StatusBadRequest, "nothing to update")
+		return
+	}
+	name := strings.TrimSpace(*req.DisplayName)
+	if name == "" || utf8.RuneCountInString(name) > 60 {
+		writeJSONError(w, http.StatusUnprocessableEntity, "display_name must be 1-60 characters")
+		return
+	}
+	updated, err := store.New(dbPool).UpdateUserDisplayName(r.Context(), store.UpdateUserDisplayNameParams{
+		ID: user.ID, DisplayName: &name,
+	})
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "could not update account")
+		return
+	}
+	writeJSON(w, http.StatusOK, toUserResponse(updated))
+}
+
+func changePasswordHandler(w http.ResponseWriter, r *http.Request) {
+	if dbPool == nil {
+		writeJSONError(w, http.StatusServiceUnavailable, "database unavailable")
+		return
+	}
+	user, _ := userFromContext(r.Context())
+	var req struct {
+		CurrentPassword string `json:"current_password"`
+		NewPassword     string `json:"new_password"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid JSON")
+		return
+	}
+	if !checkPassword(user.PasswordHash, req.CurrentPassword) {
+		writeJSONError(w, http.StatusUnauthorized, "current password is incorrect")
+		return
+	}
+	if len(req.NewPassword) < 8 {
+		writeJSONError(w, http.StatusUnprocessableEntity, "password must be at least 8 characters")
+		return
+	}
+	hash, err := hashPassword(req.NewPassword)
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "could not secure password")
+		return
+	}
+	q := store.New(dbPool)
+	if err := q.UpdateUserPassword(r.Context(), store.UpdateUserPasswordParams{ID: user.ID, PasswordHash: hash}); err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "could not update password")
+		return
+	}
+	// Same policy as password reset: every existing session dies with the old
+	// password; a fresh one keeps this device signed in.
+	if err := q.DeleteSessionsByUser(r.Context(), user.ID); err != nil {
+		log.Printf("change password: could not revoke sessions for %s: %v", user.ID, err)
+	}
+	session, err := issueSession(r.Context(), q, user.ID)
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "password changed — sign in again")
+		return
+	}
+	writeJSON(w, http.StatusOK, AuthResponse{User: toUserResponse(user), Token: session.ID})
+}
+
+func logoutAllHandler(w http.ResponseWriter, r *http.Request) {
+	if dbPool == nil {
+		writeJSONError(w, http.StatusServiceUnavailable, "database unavailable")
+		return
+	}
+	user, _ := userFromContext(r.Context())
+	if err := store.New(dbPool).DeleteSessionsByUser(r.Context(), user.ID); err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "could not sign out other devices")
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func deleteAccountHandler(w http.ResponseWriter, r *http.Request) {
+	if dbPool == nil {
+		writeJSONError(w, http.StatusServiceUnavailable, "database unavailable")
+		return
+	}
+	user, _ := userFromContext(r.Context())
+	var req struct {
+		Password string `json:"password"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid JSON")
+		return
+	}
+	if !checkPassword(user.PasswordHash, req.Password) {
+		writeJSONError(w, http.StatusUnauthorized, "password is incorrect")
+		return
+	}
+	// Every user-owned table cascades off users(id); analytics_events keeps
+	// its (PII-free) rows by design — the event log is append-only.
+	n, err := store.New(dbPool).DeleteUser(r.Context(), user.ID)
+	if err != nil || n == 0 {
+		writeJSONError(w, http.StatusInternalServerError, "could not delete account")
+		return
+	}
+	log.Printf("account deleted: %s", user.ID)
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/src/packages/api/account_integration_test.go
+++ b/src/packages/api/account_integration_test.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"net/http"
+	"testing"
+
+	"travel-route-planner/store"
+)
+
+func TestAccountDisplayNameUpdate(t *testing.T) {
+	resetDB(t)
+	_, token := createTestUser(t, "me@example.com")
+
+	rec := doJSON(t, "PATCH", "/api/v1/auth/account", token, map[string]any{
+		"display_name": "Brian D",
+	})
+	if rec.Code != http.StatusOK || decode(t, rec)["display_name"] != "Brian D" {
+		t.Fatalf("patch = %d: %s", rec.Code, rec.Body.String())
+	}
+
+	if rec := doJSON(t, "PATCH", "/api/v1/auth/account", token, map[string]any{
+		"display_name": "   ",
+	}); rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("blank name = %d, want 422", rec.Code)
+	}
+}
+
+func TestChangePasswordRevokesOtherSessions(t *testing.T) {
+	resetDB(t)
+	user, tokenA := createTestUser(t, "me@example.com")
+	// A second device.
+	sessionB, err := issueSession(t.Context(), store.New(dbPool), user.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Wrong current password rejected.
+	if rec := doJSON(t, "POST", "/api/v1/auth/change-password", tokenA, map[string]any{
+		"current_password": "wrong", "new_password": "brand-new-pass",
+	}); rec.Code != http.StatusUnauthorized {
+		t.Fatalf("wrong current = %d, want 401", rec.Code)
+	}
+
+	rec := doJSON(t, "POST", "/api/v1/auth/change-password", tokenA, map[string]any{
+		"current_password": "password123", "new_password": "brand-new-pass",
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("change = %d: %s", rec.Code, rec.Body.String())
+	}
+	fresh, _ := decode(t, rec)["token"].(string)
+	if fresh == "" {
+		t.Fatal("no fresh token returned")
+	}
+
+	// Old sessions (both devices) are dead; the fresh one works; the new
+	// password logs in.
+	if r := doJSON(t, "GET", "/api/v1/auth/me", tokenA, nil); r.Code != http.StatusUnauthorized {
+		t.Fatalf("old session A alive = %d", r.Code)
+	}
+	if r := doJSON(t, "GET", "/api/v1/auth/me", sessionB.ID, nil); r.Code != http.StatusUnauthorized {
+		t.Fatalf("old session B alive = %d", r.Code)
+	}
+	if r := doJSON(t, "GET", "/api/v1/auth/me", fresh, nil); r.Code != http.StatusOK {
+		t.Fatalf("fresh session dead = %d", r.Code)
+	}
+	if r := doJSON(t, "POST", "/api/v1/auth/login", "", map[string]any{
+		"email": "me@example.com", "password": "brand-new-pass",
+	}); r.Code != http.StatusOK {
+		t.Fatalf("login with new password = %d", r.Code)
+	}
+}
+
+func TestLogoutAllDevices(t *testing.T) {
+	resetDB(t)
+	user, token := createTestUser(t, "me@example.com")
+	other, err := issueSession(t.Context(), store.New(dbPool), user.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if rec := doJSON(t, "POST", "/api/v1/auth/logout-all", token, nil); rec.Code != http.StatusNoContent {
+		t.Fatalf("logout-all = %d", rec.Code)
+	}
+	if r := doJSON(t, "GET", "/api/v1/auth/me", other.ID, nil); r.Code != http.StatusUnauthorized {
+		t.Fatalf("other device still signed in = %d", r.Code)
+	}
+}
+
+func TestDeleteAccountCascades(t *testing.T) {
+	resetDB(t)
+	user, token := createTestUser(t, "gone@example.com")
+	trip := createTestTrip(t, user.ID, 2)
+
+	// Wrong password refuses deletion.
+	if rec := doJSON(t, "DELETE", "/api/v1/auth/account", token, map[string]any{
+		"password": "wrong",
+	}); rec.Code != http.StatusUnauthorized {
+		t.Fatalf("wrong password delete = %d, want 401", rec.Code)
+	}
+
+	rec := doJSON(t, "DELETE", "/api/v1/auth/account", token, map[string]any{
+		"password": "password123",
+	})
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("delete = %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// Session dead, login dead, trips gone (FK cascade).
+	if r := doJSON(t, "GET", "/api/v1/auth/me", token, nil); r.Code != http.StatusUnauthorized {
+		t.Fatalf("session survived deletion = %d", r.Code)
+	}
+	if r := doJSON(t, "POST", "/api/v1/auth/login", "", map[string]any{
+		"email": "gone@example.com", "password": "password123",
+	}); r.Code != http.StatusUnauthorized {
+		t.Fatalf("login after deletion = %d", r.Code)
+	}
+	var count int
+	if err := dbPool.QueryRow(t.Context(),
+		`SELECT count(*) FROM trips WHERE id = $1`, trip.ID).Scan(&count); err != nil || count != 0 {
+		t.Fatalf("trip survived deletion (count=%d, err=%v)", count, err)
+	}
+}

--- a/src/packages/api/main.go
+++ b/src/packages/api/main.go
@@ -612,6 +612,12 @@ func buildRouter() *mux.Router {
 	api.Handle("/auth/logout", authMiddleware(http.HandlerFunc(logoutHandler))).Methods("POST")
 	api.Handle("/auth/me", authMiddleware(http.HandlerFunc(meHandler))).Methods("GET")
 	api.Handle("/auth/onboarding-complete", authMiddleware(http.HandlerFunc(completeOnboardingHandler))).Methods("POST")
+	// Account self-service (specs/user-accounts follow-ups). Credential and
+	// destructive routes re-verify the password and sit on the strict tier.
+	api.Handle("/auth/account", authMiddleware(http.HandlerFunc(patchAccountHandler))).Methods("PATCH")
+	api.Handle("/auth/account", strict(authMiddleware(http.HandlerFunc(deleteAccountHandler)))).Methods("DELETE")
+	api.Handle("/auth/change-password", strict(authMiddleware(http.HandlerFunc(changePasswordHandler)))).Methods("POST")
+	api.Handle("/auth/logout-all", authMiddleware(http.HandlerFunc(logoutAllHandler))).Methods("POST")
 	// admin composes the auth + admin gate; used for curation and version-history routes.
 	admin := func(h http.HandlerFunc) http.Handler { return authMiddleware(adminMiddleware(h)) }
 	api.Handle("/trips", authMiddleware(http.HandlerFunc(listTripsHandler))).Methods("GET")

--- a/src/packages/api/query/users.sql
+++ b/src/packages/api/query/users.sql
@@ -20,3 +20,10 @@ UPDATE users SET password_hash = $2 WHERE id = $1;
 -- name: MarkUserEmailVerified :exec
 UPDATE users SET email_verified_at = COALESCE(email_verified_at, now())
 WHERE id = $1;
+
+-- name: UpdateUserDisplayName :one
+UPDATE users SET display_name = $2 WHERE id = $1
+RETURNING *;
+
+-- name: DeleteUser :execrows
+DELETE FROM users WHERE id = $1;

--- a/src/packages/api/store/users.sql.go
+++ b/src/packages/api/store/users.sql.go
@@ -40,6 +40,18 @@ func (q *Queries) CreateUser(ctx context.Context, arg CreateUserParams) (User, e
 	return i, err
 }
 
+const deleteUser = `-- name: DeleteUser :execrows
+DELETE FROM users WHERE id = $1
+`
+
+func (q *Queries) DeleteUser(ctx context.Context, id uuid.UUID) (int64, error) {
+	result, err := q.db.Exec(ctx, deleteUser, id)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
 const getUserByEmail = `-- name: GetUserByEmail :one
 SELECT id, created_at, updated_at, email, password_hash, display_name, is_admin, onboarded_at, email_verified_at FROM users WHERE email = $1
 `
@@ -100,6 +112,33 @@ RETURNING id, created_at, updated_at, email, password_hash, display_name, is_adm
 
 func (q *Queries) MarkUserOnboarded(ctx context.Context, id uuid.UUID) (User, error) {
 	row := q.db.QueryRow(ctx, markUserOnboarded, id)
+	var i User
+	err := row.Scan(
+		&i.ID,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.Email,
+		&i.PasswordHash,
+		&i.DisplayName,
+		&i.IsAdmin,
+		&i.OnboardedAt,
+		&i.EmailVerifiedAt,
+	)
+	return i, err
+}
+
+const updateUserDisplayName = `-- name: UpdateUserDisplayName :one
+UPDATE users SET display_name = $2 WHERE id = $1
+RETURNING id, created_at, updated_at, email, password_hash, display_name, is_admin, onboarded_at, email_verified_at
+`
+
+type UpdateUserDisplayNameParams struct {
+	ID          uuid.UUID `json:"id"`
+	DisplayName *string   `json:"display_name"`
+}
+
+func (q *Queries) UpdateUserDisplayName(ctx context.Context, arg UpdateUserDisplayNameParams) (User, error) {
+	row := q.db.QueryRow(ctx, updateUserDisplayName, arg.ID, arg.DisplayName)
 	var i User
 	err := row.Scan(
 		&i.ID,

--- a/src/packages/flutter-app/lib/providers/auth_provider.dart
+++ b/src/packages/flutter-app/lib/providers/auth_provider.dart
@@ -142,9 +142,28 @@ class AuthNotifier extends StateNotifier<AuthState> {
         await _service.logout(token);
       } catch (_) {/* best effort */}
     }
+    await signOutLocally();
+  }
+
+  /// Clears local auth state without calling the server — for flows where
+  /// the session is already gone server-side (logout-all, account deletion).
+  Future<void> signOutLocally() async {
     await _storage.clearToken();
     _apiClient.authToken = null;
     state = state.copyWith(clearUser: true, clearError: true);
+  }
+
+  /// Replaces the in-memory user (e.g. after a profile edit).
+  void setUser(UserModel user) {
+    state = state.copyWith(user: user);
+  }
+
+  /// Adopts a fresh session minted by the server (e.g. after a password
+  /// change revoked every other session).
+  Future<void> adoptSession(String token, UserModel user) async {
+    await _storage.saveToken(token);
+    _apiClient.authToken = token;
+    state = state.copyWith(user: user, clearError: true);
   }
 }
 

--- a/src/packages/flutter-app/lib/screens/account_settings_screen.dart
+++ b/src/packages/flutter-app/lib/screens/account_settings_screen.dart
@@ -1,0 +1,245 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../providers/api_client_provider.dart';
+import '../providers/auth_provider.dart';
+import '../services/account_api_service.dart';
+import '../theme/spacing.dart';
+import '../widgets/page_container.dart';
+import '../widgets/section_header.dart';
+
+final accountApiServiceProvider = Provider<AccountApiService>((ref) {
+  return AccountApiService(ref.watch(apiClientProvider));
+});
+
+/// Account self-service: display name, password change, sign-out-everywhere,
+/// account deletion (user-accounts spec follow-ups).
+class AccountSettingsScreen extends ConsumerStatefulWidget {
+  const AccountSettingsScreen({super.key});
+
+  @override
+  ConsumerState<AccountSettingsScreen> createState() =>
+      _AccountSettingsScreenState();
+}
+
+class _AccountSettingsScreenState extends ConsumerState<AccountSettingsScreen> {
+  late final TextEditingController _nameController;
+  final _currentPwController = TextEditingController();
+  final _newPwController = TextEditingController();
+  bool _busy = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _nameController = TextEditingController(
+      text: ref.read(authProvider).user?.displayName ?? '',
+    );
+  }
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    _currentPwController.dispose();
+    _newPwController.dispose();
+    super.dispose();
+  }
+
+  void _snack(String msg) {
+    if (!mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(msg)));
+  }
+
+  String _errText(Object e) => '$e'.replaceFirst('Exception: ', '');
+
+  Future<void> _run(Future<void> Function() action) async {
+    if (_busy) return;
+    setState(() => _busy = true);
+    try {
+      await action();
+    } catch (e) {
+      _snack(_errText(e));
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+
+  Future<void> _saveName() => _run(() async {
+        final name = _nameController.text.trim();
+        final user =
+            await ref.read(accountApiServiceProvider).updateDisplayName(name);
+        ref.read(authProvider.notifier).setUser(user);
+        _snack('Name updated');
+      });
+
+  Future<void> _changePassword() => _run(() async {
+        final res = await ref.read(accountApiServiceProvider).changePassword(
+              _currentPwController.text,
+              _newPwController.text,
+            );
+        await ref
+            .read(authProvider.notifier)
+            .adoptSession(res.token, res.user);
+        _currentPwController.clear();
+        _newPwController.clear();
+        _snack('Password changed — other devices were signed out');
+      });
+
+  Future<void> _logoutAll() => _run(() async {
+        await ref.read(accountApiServiceProvider).logoutAll();
+        // Our own session died too; sign out locally and let AuthGate route.
+        await ref.read(authProvider.notifier).signOutLocally();
+      });
+
+  Future<void> _deleteAccount() async {
+    final pwController = TextEditingController();
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Delete account?'),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text(
+              'This permanently deletes your account, trips, preferences '
+              'and alerts. There is no undo.',
+            ),
+            const SizedBox(height: AppSpacing.md),
+            TextField(
+              controller: pwController,
+              obscureText: true,
+              decoration: const InputDecoration(
+                labelText: 'Confirm your password',
+                border: OutlineInputBorder(),
+              ),
+            ),
+          ],
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            style: FilledButton.styleFrom(
+              backgroundColor: Theme.of(context).colorScheme.error,
+            ),
+            onPressed: () => Navigator.of(context).pop(true),
+            child: const Text('Delete forever'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true) {
+      pwController.dispose();
+      return;
+    }
+    await _run(() async {
+      await ref
+          .read(accountApiServiceProvider)
+          .deleteAccount(pwController.text);
+      await ref.read(authProvider.notifier).signOutLocally();
+    });
+    pwController.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final user = ref.watch(authProvider).user;
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Account settings')),
+      body: PageContainer(
+        child: ListView(
+          padding: const EdgeInsets.all(AppSpacing.lg),
+          children: [
+            const SectionHeader(title: 'Profile'),
+            const SizedBox(height: AppSpacing.md),
+            if (user != null)
+              Padding(
+                padding: const EdgeInsets.only(bottom: AppSpacing.md),
+                child: Text(user.email, style: theme.textTheme.bodyMedium),
+              ),
+            TextField(
+              controller: _nameController,
+              decoration: const InputDecoration(
+                labelText: 'Display name',
+                border: OutlineInputBorder(),
+              ),
+            ),
+            const SizedBox(height: AppSpacing.sm),
+            Align(
+              alignment: Alignment.centerRight,
+              child: FilledButton(
+                onPressed: _busy ? null : _saveName,
+                child: const Text('Save name'),
+              ),
+            ),
+            const SizedBox(height: AppSpacing.xl),
+            const SectionHeader(title: 'Password'),
+            const SizedBox(height: AppSpacing.md),
+            TextField(
+              controller: _currentPwController,
+              obscureText: true,
+              decoration: const InputDecoration(
+                labelText: 'Current password',
+                border: OutlineInputBorder(),
+              ),
+            ),
+            const SizedBox(height: AppSpacing.md),
+            TextField(
+              controller: _newPwController,
+              obscureText: true,
+              decoration: const InputDecoration(
+                labelText: 'New password (8+ characters)',
+                border: OutlineInputBorder(),
+              ),
+            ),
+            const SizedBox(height: AppSpacing.sm),
+            Align(
+              alignment: Alignment.centerRight,
+              child: FilledButton(
+                onPressed: _busy ? null : _changePassword,
+                child: const Text('Change password'),
+              ),
+            ),
+            const SizedBox(height: AppSpacing.xl),
+            const SectionHeader(title: 'Sessions'),
+            const SizedBox(height: AppSpacing.sm),
+            Text(
+              'Signs you out on every device, including this one.',
+              style: theme.textTheme.bodySmall
+                  ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+            ),
+            const SizedBox(height: AppSpacing.sm),
+            Align(
+              alignment: Alignment.centerLeft,
+              child: OutlinedButton.icon(
+                icon: const Icon(Icons.logout),
+                label: const Text('Sign out everywhere'),
+                onPressed: _busy ? null : _logoutAll,
+              ),
+            ),
+            const SizedBox(height: AppSpacing.xl),
+            const SectionHeader(title: 'Danger zone'),
+            const SizedBox(height: AppSpacing.sm),
+            Align(
+              alignment: Alignment.centerLeft,
+              child: OutlinedButton.icon(
+                icon: Icon(Icons.delete_forever,
+                    color: theme.colorScheme.error),
+                label: Text('Delete account',
+                    style: TextStyle(color: theme.colorScheme.error)),
+                style: OutlinedButton.styleFrom(
+                  side: BorderSide(color: theme.colorScheme.error),
+                ),
+                onPressed: _busy ? null : _deleteAccount,
+              ),
+            ),
+            const SizedBox(height: AppSpacing.xxl),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/src/packages/flutter-app/lib/services/account_api_service.dart
+++ b/src/packages/flutter-app/lib/services/account_api_service.dart
@@ -1,0 +1,85 @@
+import 'dart:convert';
+import '../models/user.dart';
+import 'api_client.dart';
+
+/// Account self-service endpoints (PATCH/DELETE /auth/account,
+/// change-password, logout-all).
+class AccountApiService {
+  final ApiClient apiClient;
+
+  AccountApiService(this.apiClient);
+
+  Map<String, String> _headers() {
+    final token = apiClient.authToken;
+    return {
+      'Accept': 'application/json',
+      'Content-Type': 'application/json',
+      if (token != null) 'Authorization': 'Bearer $token',
+    };
+  }
+
+  String _message(String body, int status) {
+    try {
+      final decoded = jsonDecode(body);
+      if (decoded is Map && decoded['message'] is String) {
+        return decoded['message'] as String;
+      }
+    } catch (_) {}
+    return 'Request failed ($status)';
+  }
+
+  Future<UserModel> updateDisplayName(String displayName) async {
+    final res = await apiClient.httpClient.patch(
+      Uri.parse('${apiClient.baseUrl}/auth/account'),
+      headers: _headers(),
+      body: jsonEncode({'display_name': displayName}),
+    );
+    if (res.statusCode == 200) {
+      return UserModel.fromJson(jsonDecode(res.body));
+    }
+    throw Exception(_message(res.body, res.statusCode));
+  }
+
+  /// Returns the fresh session token minted after the change (every other
+  /// session is revoked server-side).
+  Future<({UserModel user, String token})> changePassword(
+      String current, String newPassword) async {
+    final res = await apiClient.httpClient.post(
+      Uri.parse('${apiClient.baseUrl}/auth/change-password'),
+      headers: _headers(),
+      body: jsonEncode({
+        'current_password': current,
+        'new_password': newPassword,
+      }),
+    );
+    if (res.statusCode == 200) {
+      final body = jsonDecode(res.body) as Map<String, dynamic>;
+      return (
+        user: UserModel.fromJson(body['user'] as Map<String, dynamic>),
+        token: body['token'] as String,
+      );
+    }
+    throw Exception(_message(res.body, res.statusCode));
+  }
+
+  Future<void> logoutAll() async {
+    final res = await apiClient.httpClient.post(
+      Uri.parse('${apiClient.baseUrl}/auth/logout-all'),
+      headers: _headers(),
+    );
+    if (res.statusCode != 204) {
+      throw Exception(_message(res.body, res.statusCode));
+    }
+  }
+
+  Future<void> deleteAccount(String password) async {
+    final res = await apiClient.httpClient.delete(
+      Uri.parse('${apiClient.baseUrl}/auth/account'),
+      headers: _headers(),
+      body: jsonEncode({'password': password}),
+    );
+    if (res.statusCode != 204) {
+      throw Exception(_message(res.body, res.statusCode));
+    }
+  }
+}

--- a/src/packages/flutter-app/lib/widgets/account_menu.dart
+++ b/src/packages/flutter-app/lib/widgets/account_menu.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../navigation/app_nav.dart';
 import '../providers/auth_provider.dart';
+import '../screens/account_settings_screen.dart';
 import '../screens/admin_metrics_screen.dart';
 import '../screens/alerts_screen.dart';
 import '../screens/onboarding_quiz_screen.dart';
@@ -26,6 +27,8 @@ void _onSelected(BuildContext context, WidgetRef ref, String value) {
     pushOnActiveTab(ref, const AlertsScreen());
   } else if (value == 'retake_quiz') {
     pushOnActiveTab(ref, const OnboardingQuizScreen(retake: true));
+  } else if (value == 'account_settings') {
+    pushOnActiveTab(ref, const AccountSettingsScreen());
   } else if (value == 'local_admin') {
     pushOnActiveTab(ref, const LocalAdminScreen());
   } else if (value == 'admin_metrics') {
@@ -121,6 +124,17 @@ List<PopupMenuEntry<String>> _items(
               size: 20, color: theme.colorScheme.onSurfaceVariant),
           const SizedBox(width: AppSpacing.md),
           const Text('Retake travel quiz'),
+        ],
+      ),
+    ),
+    PopupMenuItem<String>(
+      value: 'account_settings',
+      child: Row(
+        children: [
+          Icon(Icons.manage_accounts_outlined,
+              size: 20, color: theme.colorScheme.onSurfaceVariant),
+          const SizedBox(width: AppSpacing.md),
+          const Text('Account settings'),
         ],
       ),
     ),

--- a/src/packages/flutter-app/test/alerts_screen_test.dart
+++ b/src/packages/flutter-app/test/alerts_screen_test.dart
@@ -28,6 +28,16 @@ class _FakeAuthNotifier extends StateNotifier<AuthState>
 
   @override
   Future<void> logout() async {}
+
+  @override
+  Future<void> signOutLocally() async {}
+
+  @override
+  void setUser(UserModel user) {}
+
+  @override
+  Future<void> adoptSession(String token, UserModel user) async {}
+
 }
 
 class _FakeAlertsApiService extends AlertsApiService {

--- a/src/packages/flutter-app/test/home_greeting_test.dart
+++ b/src/packages/flutter-app/test/home_greeting_test.dart
@@ -27,6 +27,16 @@ class _FakeAuthNotifier extends StateNotifier<AuthState>
 
   @override
   Future<void> logout() async {}
+
+  @override
+  Future<void> signOutLocally() async {}
+
+  @override
+  void setUser(UserModel user) {}
+
+  @override
+  Future<void> adoptSession(String token, UserModel user) async {}
+
 }
 
 UserModel _user(String displayName) => UserModel(

--- a/src/packages/flutter-app/test/onboarding_quiz_test.dart
+++ b/src/packages/flutter-app/test/onboarding_quiz_test.dart
@@ -28,6 +28,16 @@ class _FakeAuthNotifier extends StateNotifier<AuthState>
 
   @override
   Future<void> logout() async {}
+
+  @override
+  Future<void> signOutLocally() async {}
+
+  @override
+  void setUser(UserModel user) {}
+
+  @override
+  Future<void> adoptSession(String token, UserModel user) async {}
+
 }
 
 UserModel _user({required bool needsOnboarding}) => UserModel(


### PR DESCRIPTION
## What

The `user-accounts` spec's deferred self-service items:

**API** (new `account_handler.go`, all authed; credential/destructive routes on the strict rate tier and re-verifying the password — a stolen session must not be enough):
- `PATCH /auth/account` — display name (1–60 chars).
- `POST /auth/change-password` — verifies the current password, updates the hash, **revokes every session** (same policy as password reset), and returns a fresh token so the current device stays signed in.
- `POST /auth/logout-all` — kills all sessions.
- `DELETE /auth/account` — password-confirmed hard delete; every user-owned table already cascades off `users(id)` (verified across all 29 migrations). Append-only `analytics_events` rows (PII-free ids) remain by design.

**Flutter**: `AccountSettingsScreen` (Profile / Password / Sessions / Danger zone) behind a new "Account settings" account-menu entry. `AuthNotifier` gains `setUser` / `adoptSession` / `signOutLocally` so the password-change flow adopts the fresh token and deletion lands back on the landing screen via AuthGate.

## Tests
4 integration tests including: change-password kills a second device's session *and* the calling token while the returned fresh token works and the new password logs in; deletion verified to cascade (trip row count 0). Full Go `-race` + Flutter suites green.

Part of Wave 6, PR 8 of 8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)