### PR TITLE
Wave 6 review sweep: 10 confirmed fixes across alerts, agent, quiz

### DIFF
--- a/src/packages/api/middleware.go
+++ b/src/packages/api/middleware.go
@@ -63,14 +63,18 @@ func requestIDMiddleware(next http.Handler) http.Handler {
 		start := time.Now()
 		next.ServeHTTP(rec, r.WithContext(context.WithValue(r.Context(), requestIDContextKey, id)))
 
-		slog.Info("request",
+		attrs := []any{
 			"request_id", id,
 			"method", r.Method,
 			"path", r.URL.Path,
 			"status", rec.status,
 			"duration_ms", time.Since(start).Milliseconds(),
 			"remote", clientIP(r),
-		)
+		}
+		if q := r.URL.RawQuery; q != "" {
+			attrs = append(attrs, "query", q)
+		}
+		slog.Info("request", attrs...)
 	})
 }
 

--- a/src/packages/api/migrations/00030_price_alert_baseline.sql
+++ b/src/packages/api/migrations/00030_price_alert_baseline.sql
@@ -1,0 +1,11 @@
+-- +goose Up
+-- Fixed any-drop reference price. last_checked_price re-baselined every
+-- cycle, so slow cumulative declines never crossed the 5%/$5 threshold and a
+-- spike-then-revert notified above the price the user was watching.
+-- baseline_price is set once (client seed or first check) and only moves
+-- forward via notifications (last_notified_price takes over as reference).
+ALTER TABLE price_alerts ADD COLUMN baseline_price DOUBLE PRECISION;
+UPDATE price_alerts SET baseline_price = last_checked_price;
+
+-- +goose Down
+ALTER TABLE price_alerts DROP COLUMN baseline_price;

--- a/src/packages/api/plan_tools_extra_test.go
+++ b/src/packages/api/plan_tools_extra_test.go
@@ -95,6 +95,27 @@ func TestGetTripWeatherFallsBackToArchive(t *testing.T) {
 	}
 }
 
+// Mid-trip queries (start date already past) must still use the real
+// forecast for the remaining days, clamped to today — not last year's data.
+func TestGetTripWeatherMidTripUsesForecast(t *testing.T) {
+	s, paths := stubWeather(t)
+	start := time.Now().AddDate(0, 0, -3).Format(dateLayout)
+	end := time.Now().AddDate(0, 0, 4).Format(dateLayout)
+
+	report, err := s.GetTripWeather(context.Background(), "Athens", start, end)
+	if err != nil {
+		t.Fatalf("GetTripWeather: %v", err)
+	}
+	if report.Kind != "forecast" {
+		t.Fatalf("mid-trip kind = %s, want forecast", report.Kind)
+	}
+	for _, p := range *paths {
+		if strings.HasPrefix(p, "/v1/archive") {
+			t.Fatal("mid-trip query hit the archive API")
+		}
+	}
+}
+
 func TestGetTripWeatherCaches(t *testing.T) {
 	s, paths := stubWeather(t)
 	start := time.Now().AddDate(0, 0, 3).Format(dateLayout)

--- a/src/packages/api/price_alert_checker.go
+++ b/src/packages/api/price_alert_checker.go
@@ -144,13 +144,17 @@ func (c *alertChecker) runOnce(ctx context.Context) {
 			Adults: int(a.Adults), CabinClass: a.CabinClass,
 		})
 		if err != nil {
-			// Deliberately not marked checked: the alert retries next tick.
+			// Touch (timestamp only) so a permanently-failing route rotates
+			// to the back of the due queue instead of retrying every tick
+			// and starving the batch.
 			log.Printf("price alerts: search %s failed: %v", key, err)
+			c.touch(ctx, q, rows)
 			continue
 		}
 		lowest, ok := lowestOffer(offers)
 		if !ok {
 			log.Printf("price alerts: search %s returned no offers", key)
+			c.touch(ctx, q, rows)
 			continue
 		}
 		for _, row := range rows {
@@ -159,11 +163,28 @@ func (c *alertChecker) runOnce(ctx context.Context) {
 	}
 }
 
+func (c *alertChecker) touch(ctx context.Context, q *store.Queries, rows []store.ListDuePriceAlertsRow) {
+	ids := make([]uuid.UUID, 0, len(rows))
+	for _, row := range rows {
+		ids = append(ids, row.PriceAlert.ID)
+	}
+	if err := q.TouchPriceAlerts(ctx, ids); err != nil {
+		log.Printf("price alerts: touch failed: %v", err)
+	}
+}
+
 // settle applies one search result to one alert: record the check, and
 // notify if the trigger condition is met. MarkPriceAlertNotified runs BEFORE
 // the send so a crashed/retried send can never double-notify.
 func (c *alertChecker) settle(ctx context.Context, q *store.Queries, row store.ListDuePriceAlertsRow, lowest FlightOffer) {
 	a := row.PriceAlert
+	// A cross-currency offer is unusable: never write its price into the row
+	// (it would display under the wrong currency label and poison the
+	// baseline) — just advance the timestamp.
+	if a.Currency != nil && *a.Currency != "" && *a.Currency != lowest.Currency {
+		c.touch(ctx, q, []store.ListDuePriceAlertsRow{row})
+		return
+	}
 	notify := evaluateAlert(a, lowest.Price, lowest.Currency)
 
 	if err := q.MarkPriceAlertChecked(ctx, store.MarkPriceAlertCheckedParams{
@@ -191,9 +212,9 @@ func (c *alertChecker) settle(ctx context.Context, q *store.Queries, row store.L
 }
 
 // evaluateAlert decides whether the freshly observed lowest price should
-// notify the owner. Pure — the unit-test target.
+// notify the owner. Pure — the unit-test target. Callers must have already
+// excluded cross-currency offers (settle touches those without recording).
 func evaluateAlert(a store.PriceAlert, lowestPrice float64, lowestCurrency string) bool {
-	// Never compare across currencies; just let the check record it.
 	if a.Currency != nil && *a.Currency != "" && *a.Currency != lowestCurrency {
 		return false
 	}
@@ -205,12 +226,19 @@ func evaluateAlert(a store.PriceAlert, lowestPrice float64, lowestCurrency strin
 	if a.TargetPrice != nil {
 		return lowestPrice <= *a.TargetPrice
 	}
-	// Any-drop mode needs a baseline; the first check only records one.
-	if a.LastCheckedPrice == nil {
+	// Any-drop compares against a FIXED reference — the last notified price,
+	// else the creation/first-check baseline — never the rolling last check,
+	// so slow cumulative declines accumulate toward the threshold and a
+	// spike-then-revert can't notify above what the user was watching.
+	ref := a.BaselinePrice
+	if a.LastNotifiedPrice != nil {
+		ref = a.LastNotifiedPrice
+	}
+	if ref == nil {
+		// First check: record the baseline only.
 		return false
 	}
-	base := *a.LastCheckedPrice
-	return lowestPrice <= base-minDropAbs && lowestPrice <= base*(1-minDropFraction)
+	return lowestPrice <= *ref-minDropAbs && lowestPrice <= *ref*(1-minDropFraction)
 }
 
 // alertSearchKey collapses alerts that would issue an identical Duffel

--- a/src/packages/api/price_alert_checker_test.go
+++ b/src/packages/api/price_alert_checker_test.go
@@ -63,11 +63,22 @@ func TestEvaluateAlertAnyDropMode(t *testing.T) {
 		want   bool
 	}{
 		{"no baseline yet records only", nil, 400, false},
-		{"real drop", func(a *store.PriceAlert) { a.LastCheckedPrice = f64(500) }, 450, true},
-		{"under 5 percent", func(a *store.PriceAlert) { a.LastCheckedPrice = f64(500) }, 480, false},
+		{"real drop", func(a *store.PriceAlert) { a.BaselinePrice = f64(500) }, 450, true},
+		{"under 5 percent", func(a *store.PriceAlert) { a.BaselinePrice = f64(500) }, 480, false},
 		// 4 < $5 absolute even though >= 5% of a small fare.
-		{"under 5 dollars", func(a *store.PriceAlert) { a.LastCheckedPrice = f64(60) }, 56, false},
-		{"jitter up never notifies", func(a *store.PriceAlert) { a.LastCheckedPrice = f64(500) }, 520, false},
+		{"under 5 dollars", func(a *store.PriceAlert) { a.BaselinePrice = f64(60) }, 56, false},
+		{"jitter up never notifies", func(a *store.PriceAlert) { a.BaselinePrice = f64(500) }, 520, false},
+		// The reference is FIXED: a rolling last-checked price must not
+		// mask a slow cumulative decline...
+		{"cumulative decline notifies vs baseline", func(a *store.PriceAlert) {
+			a.BaselinePrice = f64(500)
+			a.LastCheckedPrice = f64(445) // previous check, already lower
+		}, 430, true},
+		// ...and a recorded spike must not turn a revert into a "drop".
+		{"spike then revert never notifies above baseline", func(a *store.PriceAlert) {
+			a.BaselinePrice = f64(600)
+			a.LastCheckedPrice = f64(800) // spike recorded by a prior check
+		}, 640, false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/src/packages/api/price_alert_handler.go
+++ b/src/packages/api/price_alert_handler.go
@@ -105,7 +105,9 @@ func validateCreateAlert(req *CreatePriceAlertRequest, today time.Time) error {
 	if err != nil {
 		return fmt.Errorf("depart_date must be YYYY-MM-DD")
 	}
-	if depart.Before(today.Truncate(24 * time.Hour)) {
+	// Compare calendar dates as strings — Truncate(24h) works on UTC epoch
+	// boundaries and misjudges "today" on any non-UTC server.
+	if req.DepartDate < today.Format(dateLayout) {
 		return fmt.Errorf("depart_date must be today or later")
 	}
 	if req.ReturnDate != nil && *req.ReturnDate != "" {
@@ -290,6 +292,13 @@ func patchPriceAlertHandler(w http.ResponseWriter, r *http.Request) {
 		ID: id, UserID: user.ID, Status: status, TargetPrice: target,
 	})
 	if err != nil {
+		// Resuming can collide with an identical active alert created while
+		// this one was paused (the unique index only covers active rows).
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+			writeJSONError(w, http.StatusConflict, "you already have an active alert for this exact search — delete one of them")
+			return
+		}
 		writeJSONError(w, http.StatusInternalServerError, "could not update alert")
 		return
 	}

--- a/src/packages/api/query/analytics.sql
+++ b/src/packages/api/query/analytics.sql
@@ -33,8 +33,10 @@ FROM analytics_events
 WHERE event_type = 'plan_session_completed' AND created_at >= $1;
 
 -- name: CountAnonymousPlanSessions :one
+-- Counts COMPLETED sessions so the anonymous split shares PlanSessionTotals'
+-- denominator (started vs completed would mix event streams).
 SELECT count(*) FROM analytics_events
-WHERE event_type = 'plan_session_started' AND user_id IS NULL AND created_at >= $1;
+WHERE event_type = 'plan_session_completed' AND user_id IS NULL AND created_at >= $1;
 
 -- name: CountPlanCapHits :one
 -- Sessions that hit the agent-loop iteration cap (free-tier pressure signal).

--- a/src/packages/api/query/price_alerts.sql
+++ b/src/packages/api/query/price_alerts.sql
@@ -2,8 +2,8 @@
 INSERT INTO price_alerts (
     user_id, trip_id, origin, destination, depart_date, return_date,
     cabin_class, adults, target_price, currency, last_checked_price,
-    last_checked_at
-) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+    last_checked_at, baseline_price
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $11)
 RETURNING *;
 
 -- name: ListPriceAlertsByUser :many
@@ -46,10 +46,19 @@ LIMIT $2;
 -- name: MarkPriceAlertChecked :exec
 UPDATE price_alerts
 SET last_checked_price = $2,
+    baseline_price = COALESCE(baseline_price, $2),
     currency = COALESCE(currency, $3),
     last_checked_at = now(),
     updated_at = now()
 WHERE id = $1;
+
+-- name: TouchPriceAlerts :exec
+-- Failed or skipped checks (provider error, currency mismatch) advance only
+-- the timestamp so the alert rotates to the back of the due queue instead of
+-- retrying every tick, and no cross-currency price pollutes the row.
+UPDATE price_alerts
+SET last_checked_at = now(), updated_at = now()
+WHERE id = ANY($1::uuid[]);
 
 -- name: MarkPriceAlertNotified :exec
 UPDATE price_alerts

--- a/src/packages/api/store/analytics.sql.go
+++ b/src/packages/api/store/analytics.sql.go
@@ -60,9 +60,11 @@ func (q *Queries) CountActivatedSignups(ctx context.Context, createdAt time.Time
 
 const countAnonymousPlanSessions = `-- name: CountAnonymousPlanSessions :one
 SELECT count(*) FROM analytics_events
-WHERE event_type = 'plan_session_started' AND user_id IS NULL AND created_at >= $1
+WHERE event_type = 'plan_session_completed' AND user_id IS NULL AND created_at >= $1
 `
 
+// Counts COMPLETED sessions so the anonymous split shares PlanSessionTotals'
+// denominator (started vs completed would mix event streams).
 func (q *Queries) CountAnonymousPlanSessions(ctx context.Context, createdAt time.Time) (int64, error) {
 	row := q.db.QueryRow(ctx, countAnonymousPlanSessions, createdAt)
 	var count int64

--- a/src/packages/api/store/models.go
+++ b/src/packages/api/store/models.go
@@ -162,6 +162,7 @@ type PriceAlert struct {
 	Status            string             `json:"status"`
 	CreatedAt         time.Time          `json:"created_at"`
 	UpdatedAt         time.Time          `json:"updated_at"`
+	BaselinePrice     *float64           `json:"baseline_price"`
 }
 
 type Session struct {

--- a/src/packages/api/store/price_alerts.sql.go
+++ b/src/packages/api/store/price_alerts.sql.go
@@ -28,9 +28,9 @@ const createPriceAlert = `-- name: CreatePriceAlert :one
 INSERT INTO price_alerts (
     user_id, trip_id, origin, destination, depart_date, return_date,
     cabin_class, adults, target_price, currency, last_checked_price,
-    last_checked_at
-) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
-RETURNING id, user_id, trip_id, origin, destination, depart_date, return_date, cabin_class, adults, target_price, currency, last_checked_price, last_checked_at, last_notified_price, last_notified_at, status, created_at, updated_at
+    last_checked_at, baseline_price
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $11)
+RETURNING id, user_id, trip_id, origin, destination, depart_date, return_date, cabin_class, adults, target_price, currency, last_checked_price, last_checked_at, last_notified_price, last_notified_at, status, created_at, updated_at, baseline_price
 `
 
 type CreatePriceAlertParams struct {
@@ -83,6 +83,7 @@ func (q *Queries) CreatePriceAlert(ctx context.Context, arg CreatePriceAlertPara
 		&i.Status,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.BaselinePrice,
 	)
 	return i, err
 }
@@ -120,7 +121,7 @@ func (q *Queries) ExpirePastPriceAlerts(ctx context.Context) (int64, error) {
 }
 
 const getPriceAlertForUser = `-- name: GetPriceAlertForUser :one
-SELECT id, user_id, trip_id, origin, destination, depart_date, return_date, cabin_class, adults, target_price, currency, last_checked_price, last_checked_at, last_notified_price, last_notified_at, status, created_at, updated_at FROM price_alerts
+SELECT id, user_id, trip_id, origin, destination, depart_date, return_date, cabin_class, adults, target_price, currency, last_checked_price, last_checked_at, last_notified_price, last_notified_at, status, created_at, updated_at, baseline_price FROM price_alerts
 WHERE id = $1 AND user_id = $2
 `
 
@@ -151,12 +152,13 @@ func (q *Queries) GetPriceAlertForUser(ctx context.Context, arg GetPriceAlertFor
 		&i.Status,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.BaselinePrice,
 	)
 	return i, err
 }
 
 const listDuePriceAlerts = `-- name: ListDuePriceAlerts :many
-SELECT price_alerts.id, price_alerts.user_id, price_alerts.trip_id, price_alerts.origin, price_alerts.destination, price_alerts.depart_date, price_alerts.return_date, price_alerts.cabin_class, price_alerts.adults, price_alerts.target_price, price_alerts.currency, price_alerts.last_checked_price, price_alerts.last_checked_at, price_alerts.last_notified_price, price_alerts.last_notified_at, price_alerts.status, price_alerts.created_at, price_alerts.updated_at, users.email AS owner_email
+SELECT price_alerts.id, price_alerts.user_id, price_alerts.trip_id, price_alerts.origin, price_alerts.destination, price_alerts.depart_date, price_alerts.return_date, price_alerts.cabin_class, price_alerts.adults, price_alerts.target_price, price_alerts.currency, price_alerts.last_checked_price, price_alerts.last_checked_at, price_alerts.last_notified_price, price_alerts.last_notified_at, price_alerts.status, price_alerts.created_at, price_alerts.updated_at, price_alerts.baseline_price, users.email AS owner_email
 FROM price_alerts
 JOIN users ON users.id = price_alerts.user_id
 WHERE price_alerts.status = 'active'
@@ -206,6 +208,7 @@ func (q *Queries) ListDuePriceAlerts(ctx context.Context, arg ListDuePriceAlerts
 			&i.PriceAlert.Status,
 			&i.PriceAlert.CreatedAt,
 			&i.PriceAlert.UpdatedAt,
+			&i.PriceAlert.BaselinePrice,
 			&i.OwnerEmail,
 		); err != nil {
 			return nil, err
@@ -219,7 +222,7 @@ func (q *Queries) ListDuePriceAlerts(ctx context.Context, arg ListDuePriceAlerts
 }
 
 const listPriceAlertsByUser = `-- name: ListPriceAlertsByUser :many
-SELECT id, user_id, trip_id, origin, destination, depart_date, return_date, cabin_class, adults, target_price, currency, last_checked_price, last_checked_at, last_notified_price, last_notified_at, status, created_at, updated_at FROM price_alerts
+SELECT id, user_id, trip_id, origin, destination, depart_date, return_date, cabin_class, adults, target_price, currency, last_checked_price, last_checked_at, last_notified_price, last_notified_at, status, created_at, updated_at, baseline_price FROM price_alerts
 WHERE user_id = $1
 ORDER BY created_at DESC
 `
@@ -252,6 +255,7 @@ func (q *Queries) ListPriceAlertsByUser(ctx context.Context, userID uuid.UUID) (
 			&i.Status,
 			&i.CreatedAt,
 			&i.UpdatedAt,
+			&i.BaselinePrice,
 		); err != nil {
 			return nil, err
 		}
@@ -266,6 +270,7 @@ func (q *Queries) ListPriceAlertsByUser(ctx context.Context, userID uuid.UUID) (
 const markPriceAlertChecked = `-- name: MarkPriceAlertChecked :exec
 UPDATE price_alerts
 SET last_checked_price = $2,
+    baseline_price = COALESCE(baseline_price, $2),
     currency = COALESCE(currency, $3),
     last_checked_at = now(),
     updated_at = now()
@@ -301,13 +306,27 @@ func (q *Queries) MarkPriceAlertNotified(ctx context.Context, arg MarkPriceAlert
 	return err
 }
 
+const touchPriceAlerts = `-- name: TouchPriceAlerts :exec
+UPDATE price_alerts
+SET last_checked_at = now(), updated_at = now()
+WHERE id = ANY($1::uuid[])
+`
+
+// Failed or skipped checks (provider error, currency mismatch) advance only
+// the timestamp so the alert rotates to the back of the due queue instead of
+// retrying every tick, and no cross-currency price pollutes the row.
+func (q *Queries) TouchPriceAlerts(ctx context.Context, dollar_1 []uuid.UUID) error {
+	_, err := q.db.Exec(ctx, touchPriceAlerts, dollar_1)
+	return err
+}
+
 const updatePriceAlert = `-- name: UpdatePriceAlert :one
 UPDATE price_alerts
 SET status = $3,
     target_price = $4,
     updated_at = now()
 WHERE id = $1 AND user_id = $2
-RETURNING id, user_id, trip_id, origin, destination, depart_date, return_date, cabin_class, adults, target_price, currency, last_checked_price, last_checked_at, last_notified_price, last_notified_at, status, created_at, updated_at
+RETURNING id, user_id, trip_id, origin, destination, depart_date, return_date, cabin_class, adults, target_price, currency, last_checked_price, last_checked_at, last_notified_price, last_notified_at, status, created_at, updated_at, baseline_price
 `
 
 type UpdatePriceAlertParams struct {
@@ -344,6 +363,7 @@ func (q *Queries) UpdatePriceAlert(ctx context.Context, arg UpdatePriceAlertPara
 		&i.Status,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.BaselinePrice,
 	)
 	return i, err
 }

--- a/src/packages/api/weather_service.go
+++ b/src/packages/api/weather_service.go
@@ -147,11 +147,19 @@ func (s *WeatherService) GetTripWeather(ctx context.Context, city, startDate, en
 		return WeatherReport{}, err
 	}
 
+	// Real forecast whenever the range's REMAINING days fit the horizon —
+	// including mid-trip queries whose start date is already past (clamp the
+	// fetch to today). Only ranges ending beyond the horizon (or entirely in
+	// the past) fall back to last year's observations as "typical".
+	today := time.Now().UTC().Truncate(24 * time.Hour)
+	fcStart := start
+	if fcStart.Before(today) {
+		fcStart = today
+	}
 	var report WeatherReport
-	if time.Until(end) <= forecastHorizonDays*24*time.Hour && time.Since(start) < 24*time.Hour {
-		report, err = s.fetchForecast(ctx, geo, start, end)
+	if !end.Before(today) && time.Until(end) <= forecastHorizonDays*24*time.Hour {
+		report, err = s.fetchForecast(ctx, geo, fcStart, end)
 	} else {
-		// Out of forecast range: last year's same dates as "typical".
 		report, err = s.fetchArchive(ctx, geo, start.AddDate(-1, 0, 0), end.AddDate(-1, 0, 0))
 	}
 	if err != nil {

--- a/src/packages/flutter-app/lib/providers/plan_provider.dart
+++ b/src/packages/flutter-app/lib/providers/plan_provider.dart
@@ -331,10 +331,21 @@ class PlanNotifier extends StateNotifier<PlanState> {
 
           case 'error':
             _endStreamBuffer();
+            // Commit whatever the model already said before the error —
+            // iteration-cap / max_tokens stops arrive mid-turn, and the
+            // streamed reply must not vanish from the transcript.
+            final partial = textBuffer.toString();
             state = state.copyWith(
               isStreaming: false,
               streamingText: null,
               activeTools: [],
+              messages: partial.isEmpty
+                  ? state.messages
+                  : [
+                      ...state.messages,
+                      PlanMessage(
+                          role: MessageRole.assistant, content: partial),
+                    ],
               error: event.data['message'] as String? ?? 'Unknown error',
             );
             return;

--- a/src/packages/flutter-app/lib/screens/alerts_screen.dart
+++ b/src/packages/flutter-app/lib/screens/alerts_screen.dart
@@ -29,6 +29,13 @@ class _AlertsScreenState extends ConsumerState<AlertsScreen> {
 
   @override
   Widget build(BuildContext context) {
+    // The /alerts email deep link routes here directly, often before the
+    // async session restore finishes — reload once sign-in state arrives.
+    ref.listen(authProvider.select((s) => s.isSignedIn), (prev, signedIn) {
+      if (signedIn && !ref.read(alertsProvider).loaded) {
+        ref.read(alertsProvider.notifier).load();
+      }
+    });
     final auth = ref.watch(authProvider);
     final state = ref.watch(alertsProvider);
 

--- a/src/packages/flutter-app/lib/screens/flight_search_screen.dart
+++ b/src/packages/flutter-app/lib/screens/flight_search_screen.dart
@@ -52,6 +52,18 @@ class _FlightSearchScreenState extends ConsumerState<FlightSearchScreen> {
   final List<int> _childAges = [];
   String _cabinClass = 'economy';
 
+  /// The parameters of the last submitted search (see _search); the alert
+  /// entry point reads these so an edited-but-unsearched form can't mislabel
+  /// a watch.
+  ({
+    String origin,
+    String destination,
+    String departDate,
+    int adults,
+    String cabinClass,
+    bool hasChildren,
+  })? _watched;
+
   /// Age a newly added child starts at before the traveler adjusts it.
   static const _defaultChildAge = 8;
   String _optimizeFor = 'balanced';
@@ -202,6 +214,16 @@ class _FlightSearchScreenState extends ConsumerState<FlightSearchScreen> {
 
   void _search() {
     if (!_canSearch) return;
+    // Snapshot what was actually searched: the "Watch this route" alert must
+    // describe these parameters, not whatever the form says later.
+    _watched = (
+      origin: _origin!.iataCode,
+      destination: _destination!.iataCode,
+      departDate: _fmtDate(_departDate!),
+      adults: _adults,
+      cabinClass: _cabinClass,
+      hasChildren: _childAges.isNotEmpty,
+    );
     ref.read(flightsProvider.notifier).search(FlightSearchRequest(
           origin: _origin!.iataCode,
           destination: _destination!.iataCode,
@@ -366,10 +388,14 @@ class _FlightSearchScreenState extends ConsumerState<FlightSearchScreen> {
           const Divider(height: 1),
           // Watch-this-route entry (specs/price-alerts): only over a real
           // result set and only signed in — alerts need an email to notify.
+          // Uses the searched snapshot, never the live form (which may have
+          // been edited since), and skips the price baseline when children
+          // were in the search (the checker re-searches adults only, so a
+          // family-priced baseline would read as a fake drop).
           if (state.hasSearched &&
               state.offers.isNotEmpty &&
-              ref.watch(authProvider).isSignedIn &&
-              _canSearch)
+              _watched != null &&
+              ref.watch(authProvider.select((s) => s.isSignedIn)))
             Align(
               alignment: Alignment.centerLeft,
               child: Padding(
@@ -378,18 +404,19 @@ class _FlightSearchScreenState extends ConsumerState<FlightSearchScreen> {
                   icon: const Icon(Icons.notifications_none, size: 18),
                   label: const Text('Watch this route — email me on a drop'),
                   onPressed: () {
+                    final w = _watched!;
                     final cheapest = state.offers
                         .reduce((a, b) => a.price <= b.price ? a : b);
                     CreateAlertSheet.show(
                       context,
                       CreateAlertSheet(
-                        origin: _origin!.iataCode,
-                        destination: _destination!.iataCode,
-                        departDate: _fmtDate(_departDate!),
-                        adults: _adults,
-                        cabinClass: _cabinClass,
-                        currentPrice: cheapest.price,
-                        currency: cheapest.currency,
+                        origin: w.origin,
+                        destination: w.destination,
+                        departDate: w.departDate,
+                        adults: w.adults,
+                        cabinClass: w.cabinClass,
+                        currentPrice: w.hasChildren ? null : cheapest.price,
+                        currency: w.hasChildren ? null : cheapest.currency,
                       ),
                     );
                   },

--- a/src/packages/flutter-app/lib/screens/onboarding_quiz_screen.dart
+++ b/src/packages/flutter-app/lib/screens/onboarding_quiz_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../models/airport.dart';
+import '../models/traveler_preferences.dart';
 import '../providers/auth_provider.dart';
 import '../providers/preferences_provider.dart';
 import '../theme/spacing.dart';
@@ -55,11 +56,39 @@ class _OnboardingQuizScreenState extends ConsumerState<OnboardingQuizScreen> {
   final _pageController = PageController();
   int _step = 0;
   bool _submitting = false;
+  bool _seededFromPrefs = false;
 
   String? _budget;
   String? _pace;
   final Set<String> _interests = {};
   String? _companions;
+
+  @override
+  void initState() {
+    super.initState();
+    // A retake edits the EXISTING profile: seed the form from saved
+    // preferences so an untouched step keeps its values instead of wiping
+    // them (save() sends interests as provided-including-empty).
+    if (widget.retake) {
+      final prefs = ref.read(preferencesProvider).prefs;
+      if (prefs != null) {
+        _seedFrom(prefs);
+      } else {
+        ref.read(preferencesProvider.notifier).load();
+      }
+    }
+  }
+
+  void _seedFrom(TravelerPreferences prefs) {
+    _seededFromPrefs = true;
+    _budget = prefs.budget;
+    _pace = prefs.pace;
+    _interests.addAll(prefs.interests);
+    final home = prefs.homeAirport;
+    if (home != null && home.isNotEmpty) {
+      _homeAirport = Airport(iataCode: home, name: home);
+    }
+  }
   Airport? _homeAirport;
   final _interestController = TextEditingController();
   final _tripsController = TextEditingController();
@@ -114,7 +143,9 @@ class _OnboardingQuizScreenState extends ConsumerState<OnboardingQuizScreen> {
           interests: _interests.toList(),
           homeAirport: _homeAirport?.iataCode,
           // null keeps notes untouched (they're empty for a brand-new user).
-          profileNotes: notes.isEmpty ? null : notes,
+          // A retake NEVER writes notes: the accumulated AI-distilled profile
+          // must not be replaced by one or two quiz bullets.
+          profileNotes: widget.retake || notes.isEmpty ? null : notes,
         );
     if (!ok) {
       if (!mounted) return;
@@ -137,6 +168,14 @@ class _OnboardingQuizScreenState extends ConsumerState<OnboardingQuizScreen> {
 
   @override
   Widget build(BuildContext context) {
+    // Retake with preferences still loading at initState: seed once they land.
+    if (widget.retake && !_seededFromPrefs) {
+      ref.listen(preferencesProvider.select((s) => s.prefs), (prev, prefs) {
+        if (prefs != null && !_seededFromPrefs) {
+          setState(() => _seedFrom(prefs));
+        }
+      });
+    }
     final theme = Theme.of(context);
     final isLast = _step == _stepCount - 1;
 


### PR DESCRIPTION
## What

After merging the 8 Wave 6 PRs, I ran an adversarial 8-angle review over the cumulative diff (line scan, removed-behavior audit, cross-file trace, reuse/simplification/efficiency/altitude/conventions) with a verification pass. 13 findings confirmed; this PR fixes the 10 that matter most.

**Price alerts (5 fixes)**
1. **Fixed any-drop reference** (migration 00030 `baseline_price`): the old code compared against the rolling last check, so a fare declining 4%/check never notified despite a 14% cumulative drop, and a spike-then-revert emailed a "drop" above the user's original price. Now: reference = last notified price, else the creation/first-check baseline. Regression-tested both scenarios.
2. **Currency mismatch** no longer writes a foreign-denominated price under the old currency label — timestamp-only touch.
3. **Failing searches back off**: dead routes previously kept `last_checked_at` stale, sorted to the front of the due queue, and retried every 5-minute tick (288 provider calls/day each; 25 of them would starve every healthy alert). Now touched to the back of the queue.
4. **"Watch this route" integrity**: seeds from a snapshot of the actually-searched parameters (editing the form after a search can't mislabel the watch) and skips the price baseline when children were in the search — the checker re-searches adults-only, so a family-priced baseline produced a guaranteed false "price drop" email.
5. **Resume collision** with an identical active alert now returns 409 with guidance (was a raw 500); same-day departures no longer rejected on non-UTC servers.

**Agent/plan (2 fixes)**
6. The client now **commits already-streamed text** before showing a mid-turn error (iteration cap / max_tokens) — previously the entire streamed reply vanished from the transcript.
7. `get_weather` uses the **real forecast for mid-trip queries** (start clamped to today) instead of serving last year's archive to a traveler currently on the ground.

**Quiz retake (1 fix, data loss)**
8. A retake previously **wiped saved interests** (unseeded form sends `interests: []`, which the API treats as "clear") and **overwrote the AI-distilled profile notes** with one quiz bullet. Now the form seeds from saved preferences and a retake never writes notes.

**Plus**: `/alerts` email deep link loads once async auth restore completes (was stuck on "No alerts yet"); query strings restored to request logs; anonymous plan-session metric uses the completed-event stream (consistent denominator); narrow auth select on flight search.

Remaining confirmed-but-deferred cleanups (header-builder dedup across ~13 services, `StatusPill` generalization, tool dispatch table, spec docs for the three spec-less features) are noted in the wave report.

## Tests
Both suites green (`go test -race` against Postgres, `flutter test`), including new regression tests for the fixed-baseline semantics and mid-trip forecasts.

Wave 6, PR 9 of 9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)