### PR TITLE
fix(flutter): signed-out alerts deep-link sign-in + chat stream retry

### DIFF
--- a/src/packages/flutter-app/lib/providers/plan_provider.dart
+++ b/src/packages/flutter-app/lib/providers/plan_provider.dart
@@ -383,6 +383,29 @@ class PlanNotifier extends StateNotifier<PlanState> {
     }
   }
 
+  /// Re-runs the last user turn after a failed stream. [sendMessage] appends
+  /// the user message to history before streaming, and the error paths keep it
+  /// (plus any committed partial reply), so retrying by calling [sendMessage]
+  /// again would double-append. Instead this rolls the transcript back to just
+  /// before that user message (whole-list replacement, never in-place) and
+  /// re-enters the one and only send path — exactly one copy of the user
+  /// message ends up in history and in the server payload.
+  Future<void> retryLastSend() async {
+    if (state.isStreaming || state.error == null) return;
+    final messages = state.messages;
+    final lastUser = messages.lastIndexWhere((m) => m.role == MessageRole.user);
+    if (lastUser == -1) return;
+    final failed = messages[lastUser];
+    // Cancel-before-clear: both error paths already ended the stream buffer,
+    // but never replace messages/streaming state with a flush timer live.
+    _endStreamBuffer();
+    state = state.copyWith(
+      messages: messages.sublist(0, lastUser),
+      error: null,
+    );
+    await sendMessage(failed.content, displayLabel: failed.displayLabel);
+  }
+
   void reset() {
     _chatId = null;
     _endStreamBuffer();

--- a/src/packages/flutter-app/lib/screens/alerts_screen.dart
+++ b/src/packages/flutter-app/lib/screens/alerts_screen.dart
@@ -6,6 +6,7 @@ import '../providers/auth_provider.dart';
 import '../theme/spacing.dart';
 import '../widgets/empty_state.dart';
 import '../widgets/page_container.dart';
+import 'auth_screen.dart';
 
 /// The traveler's watched routes (specs/price-alerts): state at a glance,
 /// pause/resume/delete. Creation happens from flight search results.
@@ -27,6 +28,25 @@ class _AlertsScreenState extends ConsumerState<AlertsScreen> {
     });
   }
 
+  /// Routes through sign-in, then loads alerts once a session exists — the
+  /// /alerts email deep link lands here signed-out on a fresh device, and a
+  /// prompt without an action is a dead end (same pattern as
+  /// shared_trip_screen's _ensureSignedIn).
+  Future<void> _signIn() async {
+    if (!ref.read(authProvider).isSignedIn) {
+      await Navigator.of(context).push(
+        MaterialPageRoute(builder: (_) => const AuthScreen()),
+      );
+    }
+    if (!mounted || !ref.read(authProvider).isSignedIn) return;
+    // The isSignedIn listener in build usually kicks off the load the moment
+    // the session lands; only load here if it hasn't already.
+    final alerts = ref.read(alertsProvider);
+    if (!alerts.loaded && !alerts.loading) {
+      ref.read(alertsProvider.notifier).load();
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     // The /alerts email deep link routes here directly, often before the
@@ -41,10 +61,16 @@ class _AlertsScreenState extends ConsumerState<AlertsScreen> {
 
     Widget body;
     if (!auth.isSignedIn) {
-      body = const EmptyState(
+      body = EmptyState(
         icon: Icons.notifications_none,
         title: 'Sign in to watch fares',
         message: 'Price alerts email you when a flight you care about drops.',
+        actions: [
+          FilledButton(
+            onPressed: _signIn,
+            child: const Text('Sign in'),
+          ),
+        ],
       );
     } else if (state.loading && !state.loaded) {
       body = const Center(child: CircularProgressIndicator());

--- a/src/packages/flutter-app/lib/widgets/chat_panel.dart
+++ b/src/packages/flutter-app/lib/widgets/chat_panel.dart
@@ -195,7 +195,7 @@ class _ChatTail extends StatelessWidget {
         _ResultChips(state: state, notifier: notifier, onViewTrip: onViewTrip),
         if (footerBuilder != null)
           _ChatFooter(state: state, footerBuilder: footerBuilder!),
-        _ErrorBanner(state: state),
+        _ErrorBanner(state: state, notifier: notifier),
       ],
     );
   }
@@ -460,13 +460,18 @@ class _ChatFooter extends ConsumerWidget {
 
 class _ErrorBanner extends ConsumerWidget {
   final ProviderListenable<PlanState> state;
+  final ProviderListenable<PlanNotifier> notifier;
 
-  const _ErrorBanner({required this.state});
+  const _ErrorBanner({required this.state, required this.notifier});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final error = ref.watch(state.select((s) => s.error));
     if (error == null) return const SizedBox.shrink();
+    // Narrow derived select: retry only makes sense once a user turn exists
+    // for [PlanNotifier.retryLastSend] to re-run.
+    final canRetry = ref.watch(state
+        .select((s) => s.messages.any((m) => m.role == MessageRole.user)));
     final theme = Theme.of(context);
     return Container(
       margin: const EdgeInsets.symmetric(vertical: 8),
@@ -475,9 +480,26 @@ class _ErrorBanner extends ConsumerWidget {
         color: theme.colorScheme.errorContainer,
         borderRadius: BorderRadius.circular(8),
       ),
-      child: Text(
-        error,
-        style: TextStyle(color: theme.colorScheme.onErrorContainer),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            error,
+            style: TextStyle(color: theme.colorScheme.onErrorContainer),
+          ),
+          if (canRetry)
+            Align(
+              alignment: Alignment.centerRight,
+              child: TextButton.icon(
+                style: TextButton.styleFrom(
+                  foregroundColor: theme.colorScheme.onErrorContainer,
+                ),
+                onPressed: () => ref.read(notifier).retryLastSend(),
+                icon: const Icon(Icons.refresh, size: 18),
+                label: const Text('Try again'),
+              ),
+            ),
+        ],
       ),
     );
   }

--- a/src/packages/flutter-app/test/alerts_screen_test.dart
+++ b/src/packages/flutter-app/test/alerts_screen_test.dart
@@ -7,6 +7,7 @@ import 'package:travel_route_planner/models/user.dart';
 import 'package:travel_route_planner/providers/alerts_provider.dart';
 import 'package:travel_route_planner/providers/auth_provider.dart';
 import 'package:travel_route_planner/screens/alerts_screen.dart';
+import 'package:travel_route_planner/screens/auth_screen.dart';
 import 'package:travel_route_planner/services/alerts_api_service.dart';
 import 'package:travel_route_planner/services/api_client.dart';
 
@@ -14,6 +15,12 @@ class _FakeAuthNotifier extends StateNotifier<AuthState>
     implements AuthNotifier {
   _FakeAuthNotifier(UserModel? user)
       : super(AuthState(user: user, initialized: true));
+
+  /// Simulates a session arriving (e.g. sign-in completing on the pushed
+  /// AuthScreen) without driving the auth UI.
+  void signInAs(UserModel user) {
+    state = AuthState(user: user, initialized: true);
+  }
 
   @override
   Future<bool> login(String email, String password) async => false;
@@ -94,13 +101,14 @@ Future<_FakeAlertsApiService> _pump(
   WidgetTester tester, {
   List<PriceAlert> alerts = const [],
   bool signedIn = true,
+  _FakeAuthNotifier? auth,
 }) async {
   final service = _FakeAlertsApiService(alerts);
   await tester.pumpWidget(
     ProviderScope(
       overrides: [
-        authProvider
-            .overrideWith((ref) => _FakeAuthNotifier(signedIn ? _user() : null)),
+        authProvider.overrideWith(
+            (ref) => auth ?? _FakeAuthNotifier(signedIn ? _user() : null)),
         alertsApiServiceProvider.overrideWithValue(service),
       ],
       child: const MaterialApp(home: AlertsScreen()),
@@ -111,9 +119,29 @@ Future<_FakeAlertsApiService> _pump(
 }
 
 void main() {
-  testWidgets('signed out shows sign-in prompt', (tester) async {
+  testWidgets('signed out shows sign-in prompt with a working action',
+      (tester) async {
     await _pump(tester, signedIn: false);
     expect(find.text('Sign in to watch fares'), findsOneWidget);
+
+    // The email deep link lands here signed out — the prompt must offer a
+    // route into auth, not a dead end.
+    await tester.tap(find.widgetWithText(FilledButton, 'Sign in'));
+    await tester.pumpAndSettle();
+    expect(find.byType(AuthScreen), findsOneWidget);
+  });
+
+  testWidgets('deep link lands on loaded alerts once the session arrives',
+      (tester) async {
+    final auth = _FakeAuthNotifier(null);
+    await _pump(tester, alerts: [_alert(id: 'a1')], auth: auth);
+    expect(find.text('Sign in to watch fares'), findsOneWidget);
+
+    auth.signInAs(_user());
+    await tester.pumpAndSettle();
+
+    expect(find.text('Sign in to watch fares'), findsNothing);
+    expect(find.text('BOS → CDG'), findsOneWidget);
   });
 
   testWidgets('empty list shows how-to empty state', (tester) async {

--- a/src/packages/flutter-app/test/plan_provider_stream_test.dart
+++ b/src/packages/flutter-app/test/plan_provider_stream_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:travel_route_planner/models/plan_message.dart';
 import 'package:travel_route_planner/providers/plan_provider.dart';
 import 'package:travel_route_planner/services/api_client.dart';
 import 'package:travel_route_planner/services/plan_service.dart';
@@ -96,6 +97,44 @@ void main() {
     await notifier.sendMessage('thanks');
     expect(notifier.state.tripUpdatedThisTurn, isFalse);
     expect(notifier.state.tripUpdateCount, 2);
+  });
+
+  test('retryLastSend re-runs the failed turn with no duplicate user message',
+      () async {
+    final service = _ScriptedPlanService([
+      const PlanEvent(type: 'text_delta', data: {'text': 'Half an ans'}),
+      const PlanEvent(type: 'error', data: {'message': 'stream died'}),
+    ]);
+    final notifier = PlanNotifier(service, ApiClient());
+
+    await notifier.sendMessage('plan athens');
+    expect(notifier.state.error, 'stream died');
+    expect(notifier.state.isStreaming, isFalse);
+    // The failed turn kept the user message plus the committed partial reply.
+    expect(notifier.state.messages.map((m) => m.role).toList(),
+        [MessageRole.user, MessageRole.assistant]);
+
+    // The retry succeeds.
+    service.events
+      ..clear()
+      ..add(const PlanEvent(type: 'text_delta', data: {'text': 'Full answer.'}));
+    await notifier.retryLastSend();
+
+    expect(notifier.state.error, isNull);
+    // Exactly one copy of the user message; the partial was rolled back and
+    // regenerated as a fresh turn.
+    final users =
+        notifier.state.messages.where((m) => m.role == MessageRole.user);
+    expect(users.length, 1);
+    expect(users.single.content, 'plan athens');
+    expect(notifier.state.messages.last.role, MessageRole.assistant);
+    expect(notifier.state.messages.last.content, 'Full answer.');
+    // The server payload for the retry carried no duplicate either.
+    expect(service.lastHistory!.where((m) => m['role'] == 'user').length, 1);
+
+    // Retry is a no-op when there is nothing to retry.
+    await notifier.retryLastSend();
+    expect(notifier.state.messages.length, 2);
   });
 
   test('displayLabel collapses the bubble but the full content reaches history',


### PR DESCRIPTION
Wave 7, PR 5 — two verified dead ends that break Wave-6 retention loops (Flutter only).

## 1. Alerts email deep link (signed out)

`/alerts` routes outside AuthGate, but the signed-out body was an actionless EmptyState — a price-drop email click on a sessionless device stranded the user at "Sign in to watch fares" with nothing to tap.

- The EmptyState now carries a **Sign in** action (`EmptyState.actions`, `FilledButton`) using the `_ensureSignedIn` pattern from `shared_trip_screen.dart`: push `AuthScreen`, re-check auth on return, then load alerts.
- The explicit post-auth load is guarded by `loaded`/`loading` so it doesn't race the screen's existing `isSignedIn` listener into a duplicate fetch.

## 2. Chat SSE retry

When `/plan` fails, the error banner was static text while the provider kept the failed turn in history — the only way forward was retyping the message.

- New `PlanNotifier.retryLastSend()`: `sendMessage` appends the user message **before** streaming and both error paths keep it (plus any committed partial reply), so retry first rolls the transcript back to just before the last user message — **whole-list replacement** via `sublist`, never in-place — then re-enters `sendMessage`, the one and only send path. Exactly one copy of the user message ends up in the UI transcript and in the server payload; `displayLabel` (refine seeds) is preserved.
- `_ErrorBanner` gains a **Try again** button; it stays on narrow `select()`s (`s.error` + a derived has-user-turn bool) and reads the notifier only in the tap handler.

### Chat invariants (PRs #51/#53) respected

- Narrow `select()` watches only in the banner; no whole-state watch added.
- Cancel-before-clear: `retryLastSend` calls `_endStreamBuffer()` before replacing messages (defensive — both error paths already ended the buffer).
- Whole-list replacement for the transcript rollback (record selects keep firing).
- `tripUpdateCount` untouched (stays monotonic); `_refresh()` untouched.
- Diff around the error banner is surgical; the `launchUrl` call site (~line 495) is untouched for the parallel PR.

## Tests

- `plan_provider_stream_test.dart`: failed turn (partial text + `error` event) → `retryLastSend` → exactly one user message in state and in the captured server history, fresh assistant reply, no-op when there's nothing to retry.
- `alerts_screen_test.dart`: signed-out prompt exposes a working Sign in button that pushes `AuthScreen`; a session arriving after the deep link lands on loaded alerts.

`flutter analyze --no-fatal-infos --fatal-warnings` (CI mode) and `flutter test` (41/41) pass; the 12 info-level findings are pre-existing on main in untouched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)