### PR TITLE
feat(api): COGS hardening — Places singleton, events TTL cache, request body limits

### DIFF
--- a/src/packages/api/events_service.go
+++ b/src/packages/api/events_service.go
@@ -22,6 +22,12 @@ type EventsService struct {
 	APIKey  string
 	BaseURL string
 	Client  *http.Client
+
+	// The free Ticketmaster key allows 5 req/s and 5k calls/day, and a plan
+	// session can re-ask for the same city/window several times, so identical
+	// searches within the TTL are served from memory (same pattern as the
+	// Duffel airport cache). Short TTL: event inventory shifts.
+	cache *ttlCache[[]Event]
 }
 
 // Event is a normalized local event (concert, sport, festival, show) used by
@@ -48,6 +54,9 @@ const (
 	fetchSize = 100
 )
 
+// eventsCacheTTL bounds how long an events search result is reused.
+const eventsCacheTTL = 20 * time.Minute
+
 // NewEventsService creates a new events service, reading the Ticketmaster key
 // from the environment. A missing key is a soft failure (a warning, like the
 // Google/Duffel keys) so the rest of the API stays healthy; calls fail clearly.
@@ -66,6 +75,7 @@ func NewEventsService() *EventsService {
 		APIKey:  apiKey,
 		BaseURL: strings.TrimRight(baseURL, "/"),
 		Client:  &http.Client{Timeout: 30 * time.Second},
+		cache:   newTTLCache[[]Event](eventsCacheTTL, 1000),
 	}
 }
 
@@ -84,6 +94,17 @@ func (s *EventsService) SearchEvents(ctx context.Context, city, startDate, endDa
 	endDT, err := toTicketmasterDateTime(endDate, true)
 	if err != nil {
 		return nil, fmt.Errorf("invalid end_date: %w", err)
+	}
+
+	// Cache identical searches for the TTL. Key covers every input that
+	// changes the result set: city, window, and optional category.
+	cat := ""
+	if category != nil {
+		cat = strings.ToLower(strings.TrimSpace(*category))
+	}
+	cacheKey := strings.ToLower(strings.TrimSpace(city)) + "|" + strings.TrimSpace(startDate) + "|" + strings.TrimSpace(endDate) + "|" + cat
+	if cached, ok := s.cache.get(cacheKey); ok {
+		return cached, nil
 	}
 
 	params := url.Values{}
@@ -208,6 +229,7 @@ func (s *EventsService) SearchEvents(ctx context.Context, city, startDate, endDa
 			break
 		}
 	}
+	s.cache.set(cacheKey, events)
 	return events, nil
 }
 

--- a/src/packages/api/events_service_test.go
+++ b/src/packages/api/events_service_test.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+const fakeTicketmasterJSON = `{"_embedded":{"events":[{"id":"e1","name":"Test Show","url":"https://tickets.example/e1","dates":{"start":{"localDate":"2026-08-02","localTime":"19:00:00"}},"classifications":[{"segment":{"name":"Music"}}],"_embedded":{"venues":[{"name":"Test Hall","city":{"name":"Paris"},"location":{"latitude":"48.86","longitude":"2.34"}}]}}]}}`
+
+func newTestEventsService(t *testing.T) (*EventsService, *int) {
+	t.Helper()
+	calls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(fakeTicketmasterJSON))
+	}))
+	t.Cleanup(srv.Close)
+	return &EventsService{
+		APIKey:  "test-key",
+		BaseURL: srv.URL,
+		Client:  srv.Client(),
+		cache:   newTTLCache[[]Event](eventsCacheTTL, 100),
+	}, &calls
+}
+
+// The free Ticketmaster tier is 5 req/s / 5k per day: identical searches
+// within the TTL must be served from memory, keyed on city+window+category
+// (city case/whitespace-insensitively).
+func TestSearchEventsServedFromCache(t *testing.T) {
+	svc, calls := newTestEventsService(t)
+	ctx := context.Background()
+
+	first, err := svc.SearchEvents(ctx, "Paris", "2026-08-01", "2026-08-03", nil)
+	if err != nil {
+		t.Fatalf("first search failed: %v", err)
+	}
+	second, err := svc.SearchEvents(ctx, "  paris ", "2026-08-01", "2026-08-03", nil)
+	if err != nil {
+		t.Fatalf("second search failed: %v", err)
+	}
+
+	if *calls != 1 {
+		t.Fatalf("Ticketmaster called %d times, want 1 (second lookup must come from cache)", *calls)
+	}
+	if len(first) != 1 || len(second) != 1 || second[0].ID != "e1" {
+		t.Fatalf("cached result mismatch: first=%v second=%v", first, second)
+	}
+}
+
+func TestSearchEventsCacheKeyCoversInputs(t *testing.T) {
+	svc, calls := newTestEventsService(t)
+	ctx := context.Background()
+
+	if _, err := svc.SearchEvents(ctx, "Paris", "2026-08-01", "2026-08-03", nil); err != nil {
+		t.Fatalf("search failed: %v", err)
+	}
+	// A different category is a different result set — must not reuse the entry.
+	cat := "music"
+	if _, err := svc.SearchEvents(ctx, "Paris", "2026-08-01", "2026-08-03", &cat); err != nil {
+		t.Fatalf("category search failed: %v", err)
+	}
+	// A different window likewise.
+	if _, err := svc.SearchEvents(ctx, "Paris", "2026-08-02", "2026-08-03", nil); err != nil {
+		t.Fatalf("window search failed: %v", err)
+	}
+	if *calls != 3 {
+		t.Fatalf("Ticketmaster called %d times, want 3 (distinct inputs must not share entries)", *calls)
+	}
+}
+
+func TestSearchEventsWithoutKeyErrors(t *testing.T) {
+	svc, calls := newTestEventsService(t)
+	svc.APIKey = ""
+	if _, err := svc.SearchEvents(context.Background(), "Paris", "2026-08-01", "2026-08-03", nil); err == nil {
+		t.Fatal("expected not-configured error without API key")
+	}
+	if *calls != 0 {
+		t.Fatalf("Ticketmaster called %d times without a key, want 0", *calls)
+	}
+}

--- a/src/packages/api/local_ingest_handler.go
+++ b/src/packages/api/local_ingest_handler.go
@@ -150,8 +150,9 @@ func ingestLocalHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// 3. Verify + insert each recommendation.
-	places := NewGooglePlacesService()
+	// 3. Verify + insert each recommendation (shared singleton — verification
+	// lookups hit the Places TTL caches).
+	places := placesService
 	resp := ingestResponse{Recommendations: []store.LocalRecommendation{}}
 	var recIDs []uuid.UUID
 	for _, rec := range content.Recommendations {

--- a/src/packages/api/main.go
+++ b/src/packages/api/main.go
@@ -201,7 +201,6 @@ func placesSearchHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	placesService := NewGooglePlacesService()
 	results, err := placesService.SearchPlaces(query)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("Failed to search places: %v", err), http.StatusInternalServerError)
@@ -224,7 +223,6 @@ func placesAutocompleteHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	placesService := NewGooglePlacesService()
 	results, err := placesService.GetPlaceAutocomplete(input)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("Failed to get autocomplete: %v", err), http.StatusInternalServerError)
@@ -247,7 +245,6 @@ func placesDetailsHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	placesService := NewGooglePlacesService()
 	result, err := placesService.GetPlaceDetails(placeID)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("Failed to get place details: %v", err), http.StatusInternalServerError)
@@ -571,6 +568,7 @@ func buildRouter() *mux.Router {
 	router.Use(requestIDMiddleware)
 	router.Use(recoveryMiddleware)
 	router.Use(corsMiddleware)
+	router.Use(bodyLimitMiddleware)
 	router.Use(func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if r.URL.Path == "/health" || r.URL.Path == "/api/v1/health" {

--- a/src/packages/api/middleware.go
+++ b/src/packages/api/middleware.go
@@ -78,6 +78,37 @@ func requestIDMiddleware(next http.Handler) http.Handler {
 	})
 }
 
+// Request body caps. Generous headroom over the largest legitimate payloads:
+// a full 50-location optimize-route or an admin ingest of raw research text is
+// tens of KB; /plan resends the whole chat history so it gets a wider lane.
+const (
+	maxRequestBodyBytes     = 256 << 10 // 256 KiB, all endpoints by default
+	planMaxRequestBodyBytes = 1 << 20   // 1 MiB for the /plan chat history
+)
+
+// bodyLimitMiddleware caps request body size. It wraps the request body ONLY
+// (http.MaxBytesReader) — the response path is untouched, so SSE streaming on
+// /plan and the server's WriteTimeout=0 invariant are unaffected. A declared
+// Content-Length over the cap is rejected up front with a clean 413; chunked
+// or lying clients are stopped by MaxBytesReader mid-read, which surfaces as
+// the handler's normal decode-error response.
+func bodyLimitMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		limit := int64(maxRequestBodyBytes)
+		if r.URL.Path == "/api/v1/plan" {
+			limit = planMaxRequestBodyBytes
+		}
+		if r.ContentLength > limit {
+			writeJSONError(w, http.StatusRequestEntityTooLarge, "request body too large")
+			return
+		}
+		if r.Body != nil {
+			r.Body = http.MaxBytesReader(w, r.Body, limit)
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
 // recoveryMiddleware converts a handler panic into a JSON 500 instead of a
 // dropped connection, logging the stack with the request ID. net/http already
 // keeps the process alive on handler panics; the value here is the clean

--- a/src/packages/api/middleware_test.go
+++ b/src/packages/api/middleware_test.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"bytes"
+	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -108,5 +111,91 @@ func TestStatusRecorderForwardsFlusher(t *testing.T) {
 	}
 	if !rec.Flushed {
 		t.Fatal("Flush was not forwarded to the underlying writer")
+	}
+}
+
+func TestBodyLimitRejectsOversizedDeclaredBody(t *testing.T) {
+	h := bodyLimitMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("handler must not run for an over-limit declared body")
+	}))
+
+	body := bytes.NewReader(make([]byte, maxRequestBodyBytes+1))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest("POST", "/api/v1/optimize-route", body))
+
+	if rec.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status = %d, want 413", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "request body too large") {
+		t.Fatalf("body = %q, want body-too-large message", rec.Body.String())
+	}
+}
+
+func TestBodyLimitAllowsNormalBody(t *testing.T) {
+	h := bodyLimitMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if _, err := io.Copy(io.Discard, r.Body); err != nil {
+			t.Fatalf("reading an under-limit body failed: %v", err)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest("POST", "/api/v1/optimize-route", bytes.NewReader(make([]byte, 64<<10))))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+}
+
+// /plan resends the whole chat history, so it gets the wider 1 MiB lane: a
+// body over the general cap but under the plan cap must pass through.
+func TestBodyLimitPlanGetsWiderLane(t *testing.T) {
+	handlerRan := false
+	h := bodyLimitMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handlerRan = true
+		if _, err := io.Copy(io.Discard, r.Body); err != nil {
+			t.Fatalf("reading a 512KiB /plan body failed: %v", err)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest("POST", "/api/v1/plan", bytes.NewReader(make([]byte, 512<<10))))
+	if !handlerRan || rec.Code != http.StatusOK {
+		t.Fatalf("handlerRan = %v, status = %d; want 512KiB /plan body to pass", handlerRan, rec.Code)
+	}
+
+	rec = httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest("POST", "/api/v1/plan", bytes.NewReader(make([]byte, planMaxRequestBodyBytes+1))))
+	if rec.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status = %d, want 413 for over-cap /plan body", rec.Code)
+	}
+}
+
+// Clients that lie about (or omit) Content-Length can't be rejected up front;
+// MaxBytesReader must stop the read mid-body instead.
+func TestBodyLimitStopsUndeclaredOversizedRead(t *testing.T) {
+	var readErr error
+	h := bodyLimitMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, readErr = io.Copy(io.Discard, r.Body)
+	}))
+
+	req := httptest.NewRequest("POST", "/api/v1/optimize-route", bytes.NewReader(make([]byte, maxRequestBodyBytes+1)))
+	req.ContentLength = -1 // unknown length (e.g. chunked)
+	h.ServeHTTP(httptest.NewRecorder(), req)
+
+	var maxErr *http.MaxBytesError
+	if !errors.As(readErr, &maxErr) {
+		t.Fatalf("read error = %v, want *http.MaxBytesError", readErr)
+	}
+}
+
+// End-to-end through buildRouter: the middleware is actually wired, and an
+// oversized request dies with a 413 before reaching any handler (no DB needed).
+func TestRouterRejectsOversizedBody(t *testing.T) {
+	router := buildRouter()
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, httptest.NewRequest("POST", "/api/v1/optimize-route", bytes.NewReader(make([]byte, maxRequestBodyBytes+1))))
+	if rec.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status = %d, want 413", rec.Code)
 	}
 }

--- a/src/packages/api/places_service.go
+++ b/src/packages/api/places_service.go
@@ -80,6 +80,14 @@ func NewGooglePlacesService() *GooglePlacesService {
 	}
 }
 
+// placesService is a process-wide singleton reused across requests, matching
+// duffelService/eventsService/weatherService. Constructing it once is what
+// makes the TTL caches above effective — a per-request instance would discard
+// them and re-bill Google on every call. A missing GOOGLE_PLACES_API_KEY stays
+// a soft failure (one boot-time warning; each method returns a clear error),
+// so degraded mode keeps working.
+var placesService = NewGooglePlacesService()
+
 // SearchPlaces searches for places by text query
 func (gps *GooglePlacesService) SearchPlaces(query string) ([]PlaceSearchResult, error) {
 	if gps.APIKey == "" {

--- a/src/packages/api/places_service_test.go
+++ b/src/packages/api/places_service_test.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// countingTransport serves a canned JSON body and counts round trips, so tests
+// can assert how many billable Google calls a code path would make.
+type countingTransport struct {
+	calls int
+	body  string
+}
+
+func (c *countingTransport) RoundTrip(*http.Request) (*http.Response, error) {
+	c.calls++
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(c.body)),
+	}, nil
+}
+
+const fakeTextSearchJSON = `{"status":"OK","results":[{"place_id":"p1","name":"Louvre Museum","formatted_address":"Paris","geometry":{"location":{"lat":48.86,"lng":2.34}},"types":["museum"]}]}`
+
+const fakePlaceDetailsJSON = `{"status":"OK","result":{"place_id":"p1","name":"Louvre Museum","formatted_address":"Paris","geometry":{"location":{"lat":48.86,"lng":2.34}},"types":["museum"]}}`
+
+// The whole point of the placesService singleton is that the TTL caches
+// survive across calls: identical searches must hit Google exactly once.
+func TestSearchPlacesServedFromCache(t *testing.T) {
+	rt := &countingTransport{body: fakeTextSearchJSON}
+	svc := NewGooglePlacesService()
+	svc.APIKey = "test-key"
+	svc.Client = &http.Client{Transport: rt}
+
+	first, err := svc.SearchPlaces("Louvre Museum Paris")
+	if err != nil {
+		t.Fatalf("first search failed: %v", err)
+	}
+	// Same query modulo case/whitespace must hit the cache, not Google.
+	second, err := svc.SearchPlaces("  louvre museum paris ")
+	if err != nil {
+		t.Fatalf("second search failed: %v", err)
+	}
+
+	if rt.calls != 1 {
+		t.Fatalf("Google called %d times, want 1 (second lookup must come from cache)", rt.calls)
+	}
+	if len(first) != 1 || len(second) != 1 || second[0].PlaceID != "p1" {
+		t.Fatalf("cached result mismatch: first=%v second=%v", first, second)
+	}
+}
+
+func TestGetPlaceDetailsServedFromCache(t *testing.T) {
+	rt := &countingTransport{body: fakePlaceDetailsJSON}
+	svc := NewGooglePlacesService()
+	svc.APIKey = "test-key"
+	svc.Client = &http.Client{Transport: rt}
+
+	if _, err := svc.GetPlaceDetails("p1"); err != nil {
+		t.Fatalf("first details call failed: %v", err)
+	}
+	got, err := svc.GetPlaceDetails("p1")
+	if err != nil {
+		t.Fatalf("second details call failed: %v", err)
+	}
+	if rt.calls != 1 {
+		t.Fatalf("Google called %d times, want 1", rt.calls)
+	}
+	if got == nil || got.Name != "Louvre Museum" {
+		t.Fatalf("cached details mismatch: %+v", got)
+	}
+}
+
+// Degraded mode: the process-wide singleton is constructed at init even when
+// GOOGLE_PLACES_API_KEY is absent; methods must fail with a clear error, not
+// panic, so the rest of the API stays healthy.
+func TestPlacesServiceSingletonSafeWithoutKey(t *testing.T) {
+	if placesService == nil {
+		t.Fatal("placesService singleton is nil")
+	}
+
+	svc := NewGooglePlacesService()
+	svc.APIKey = ""
+	if _, err := svc.SearchPlaces("anything"); err == nil || !strings.Contains(err.Error(), "not configured") {
+		t.Fatalf("SearchPlaces without key: err = %v, want not-configured error", err)
+	}
+	if _, err := svc.GetPlaceAutocomplete("any"); err == nil {
+		t.Fatal("GetPlaceAutocomplete without key must error")
+	}
+	if _, err := svc.GetPlaceDetails("p1"); err == nil {
+		t.Fatal("GetPlaceDetails without key must error")
+	}
+}

--- a/src/packages/api/plan_handler.go
+++ b/src/packages/api/plan_handler.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	anthropic "github.com/anthropics/anthropic-sdk-go"
 	"github.com/anthropics/anthropic-sdk-go/option"
@@ -22,6 +23,18 @@ import (
 // 8–11 iterations; parallel tool calls share an iteration. Hitting the cap
 // ends the stream gracefully instead of letting a pathological loop burn cost.
 const planMaxIterations = 15
+
+// planMaxMessages / planMaxMessageChars bound the resent conversation history.
+// Every agent-loop iteration (up to planMaxIterations) re-pays input tokens on
+// the full history, so an unbounded history multiplies token cost by up to
+// 15x. Both caps sit far above anything the Flutter chat UI produces (a few
+// dozen short turns, plus one long itinerary-context first message on refine);
+// hitting them means a runaway or abusive client. Violations return a friendly
+// SSE `error` event, not a 500.
+const (
+	planMaxMessages     = 40
+	planMaxMessageChars = 20000
+)
 
 type PlanRequest struct {
 	Messages []PlanChatMessage `json:"messages"`
@@ -57,6 +70,19 @@ func planHandler(w http.ResponseWriter, r *http.Request) {
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		sendSSE(w, "error", map[string]string{"message": "invalid request body"})
 		return
+	}
+
+	// Cap the conversation before any model call: the whole history is resent
+	// on every agent-loop iteration, so these bounds are a hard cost lever.
+	if len(req.Messages) > planMaxMessages {
+		sendSSE(w, "error", map[string]string{"message": "This conversation is too long to continue. Please start a new chat to keep planning."})
+		return
+	}
+	for _, m := range req.Messages {
+		if utf8.RuneCountInString(m.Content) > planMaxMessageChars {
+			sendSSE(w, "error", map[string]string{"message": "One of the messages is too long for the planner. Please shorten it and try again."})
+			return
+		}
 	}
 
 	apiKey := os.Getenv("ANTHROPIC_API_KEY")
@@ -347,7 +373,6 @@ func planHandler(w http.ResponseWriter, r *http.Request) {
 	today := time.Now()
 	basePrompt := "You are an expert travel agent. Today's date is " + today.Format("Monday, January 2, 2006") + " (" + today.Format("2006-01-02") + "). When a traveler gives a date without a year, assume the soonest upcoming occurrence on or after today — never a past year. Use dates in YYYY-MM-DD form when calling tools. Help users plan trips by searching for specific places and attractions. For each city, ALWAYS call search_local_recommendations FIRST — these are hand-curated picks from real locals, the legit info you can't get by googling. Prefer them over generic results, build the itinerary around them where they fit the traveler, and cite the local by name in your reply (e.g. 'Ana, a Lisbon chef, swears by…'). When a local pick becomes an itinerary place, carry its id into local_recommendation_id and its source_name into local_source_name. Then use search_places to fill gaps and find any other real locations with coordinates. Search for individual places (e.g. 'Louvre Museum Paris') rather than broad queries. Include a mix of activities/attractions and dining (restaurants), guided by the traveler's interests, budget, and pace. When you call create_itinerary, tag each location with category ('attraction' or 'restaurant'), a time_of_day ('morning', 'afternoon', or 'evening'), and a day (the 1-based trip day it falls on, increasing chronologically across the whole trip) so each day reads as a sensible schedule. When you have gathered enough places for the user's trip, call create_itinerary to finalize the plan; pass start_date (and end_date) whenever the traveler has given or agreed to travel dates, with day 1 being the start date. You can also use search_flights to find real flight options — ask for the traveler's departure city/airport and dates if you don't know them, and pick optimize_for from their budget (budget→cost, luxury→time, otherwise balanced); summarize the top 2-3 options in your own words and help them choose — do not tell the traveler to look at cards or lists in the chat. For travel between Greek islands, use suggest_ferries (ferries are the primary way to island-hop); note that in Greece search_events returns curated source links rather than ticketed listings. Use get_weather when weather changes the advice — packing, outdoor days, beach or ski viability, seasonal closures; for far-off dates it returns last year's weather as a seasonal guide, so present it as 'typically', never as a forecast. For signed-in travelers: when they reference a trip you've already planned together, call get_trip to read what's saved instead of asking them to repeat it; and when you give time-sensitive booking advice about a saved trip (book the ferry, reserve that restaurant), call add_booking_todo so it lands on their checklist instead of getting lost in chat. Be conversational and helpful — ask clarifying questions if needed before searching. Format replies with light markdown — short paragraphs, **bold** for place names, hyphen lists — no headings or tables."
 
-	placesService := NewGooglePlacesService()
 	ctx := r.Context()
 	distilled := false
 

--- a/src/packages/api/plan_handler_test.go
+++ b/src/packages/api/plan_handler_test.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"bytes"
+	"encoding/json"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -48,6 +51,55 @@ func TestPersonalizedSystemPromptIgnoresWhitespaceNotes(t *testing.T) {
 	p := &store.TravelerPreference{ProfileNotes: strPtr("  \n ")}
 	if got := personalizedSystemPrompt("base", p); got != "base" {
 		t.Fatalf("prompt = %q, want base unchanged for blank notes", got)
+	}
+}
+
+// runPlanHandler posts a PlanRequest to planHandler directly (the recorder
+// implements http.Flusher, which the SSE handler requires) and returns the
+// raw event-stream body.
+func runPlanHandler(t *testing.T, req PlanRequest) *httptest.ResponseRecorder {
+	t.Helper()
+	body, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	rec := httptest.NewRecorder()
+	planHandler(rec, httptest.NewRequest("POST", "/api/v1/plan", bytes.NewReader(body)))
+	return rec
+}
+
+// Oversized histories must be rejected with a friendly SSE error event (the
+// stream's normal error shape), before any model call or session bookkeeping.
+func TestPlanHandlerRejectsTooManyMessages(t *testing.T) {
+	msgs := make([]PlanChatMessage, planMaxMessages+1)
+	for i := range msgs {
+		msgs[i] = PlanChatMessage{Role: "user", Content: "hi"}
+	}
+	rec := runPlanHandler(t, PlanRequest{Messages: msgs})
+
+	out := rec.Body.String()
+	if !strings.Contains(out, `"type":"error"`) {
+		t.Fatalf("stream = %q, want an SSE error event", out)
+	}
+	if !strings.Contains(out, "too long") || !strings.Contains(out, "start a new chat") {
+		t.Fatalf("stream = %q, want the conversation-too-long message", out)
+	}
+	if strings.Count(out, "data: ") != 1 {
+		t.Fatalf("stream = %q, want exactly one event (handler must stop after rejecting)", out)
+	}
+}
+
+func TestPlanHandlerRejectsOversizedMessage(t *testing.T) {
+	rec := runPlanHandler(t, PlanRequest{Messages: []PlanChatMessage{
+		{Role: "user", Content: strings.Repeat("a", planMaxMessageChars+1)},
+	}})
+
+	out := rec.Body.String()
+	if !strings.Contains(out, `"type":"error"`) || !strings.Contains(out, "too long") {
+		t.Fatalf("stream = %q, want an SSE error event about an oversized message", out)
+	}
+	if strings.Count(out, "data: ") != 1 {
+		t.Fatalf("stream = %q, want exactly one event", out)
 	}
 }
 

--- a/src/packages/api/route_optimizer.go
+++ b/src/packages/api/route_optimizer.go
@@ -528,10 +528,8 @@ func (ro *RouteOptimizer) OptimizeRoute(request RouteRequest) RouteResponse {
 		}
 	}
 
-	// Initialize Google Places service
-	placesService := NewGooglePlacesService()
-
-	// Resolve locations that don't have coordinates
+	// Resolve locations that don't have coordinates (via the shared
+	// placesService singleton so lookups hit its TTL caches)
 	for i := range request.Locations {
 		if err := ro.resolveLocation(&request.Locations[i], placesService); err != nil {
 			return RouteResponse{


### PR DESCRIPTION
Three verified cost/reliability leaks in the Go API, fixed with zero behavior change for legitimate traffic.

## 1. GooglePlacesService hoisted to a process-wide singleton

`NewGooglePlacesService()` was called fresh at **6 sites** (`main.go` ×3 places handlers, `plan_handler.go` agent loop, `route_optimizer.go` location resolution, `local_ingest_handler.go` verification), so the three TTL caches built into the service (1h text search, 24h autocomplete/details) never survived a single request — nearly every Google call was billed. Now a `placesService` singleton in `places_service.go`, matching the existing `duffelService`/`eventsService`/`weatherService` pattern. A missing `GOOGLE_PLACES_API_KEY` remains a soft failure (boot warning + per-call error), so degraded mode is unchanged.

## 2. Ticketmaster 20-minute TTL cache

The free Discovery key allows 5 req/s and 5k calls/day, and a plan session can re-ask for the same city/window repeatedly. `EventsService` now carries a `ttlCache[[]Event]` (20 min, keyed on normalized `city|start_date|end_date|category`), reusing the generic cache in `cache.go` — same pattern as Duffel's 24h airport cache. Cost cap **and** rate-limit reliability lever.

## 3. Request body limits (first `MaxBytesReader` usage in the API)

New `bodyLimitMiddleware` wired in `buildRouter`: **256 KiB** general, **1 MiB** for `/plan` (it resends full chat history). It wraps the **request body only** — the SSE response path and the server's `WriteTimeout=0` invariant are untouched. Declared-oversize bodies get a clean JSON 413 before the handler runs; chunked/lying clients are cut off mid-read by `MaxBytesReader`. Additionally, `/plan` caps input at **40 messages / 20k chars per message** (each of up to 15 agent-loop iterations re-pays input tokens on the resent history); violations return the stream's friendly SSE `error` event, not a 500. Both caps sit far above anything the Flutter UI produces (largest real body is the refine flow's itinerary-context first message).

## Verification

- `make api-fmt && make api-vet` — clean
- `go test ./...` — **130 tests, 0 failures, 0 skips** against a dedicated `travel_test_pr1` database (`TEST_DATABASE_URL`), including all pre-existing degraded-mode and integration tests
- 13 new tests: Places cache-hit via counting transport (search + details), no-key safety on the singleton; events cache-hit / distinct-key / no-key via `httptest` upstream; body-limit 413, under-limit pass-through, `/plan` wider lane, mid-read `*http.MaxBytesError` cutoff, and end-to-end 413 through `buildRouter`; oversized `/plan` history and oversized single message both rejected via a single SSE `error` event

🤖 Generated with [Claude Code](https://claude.com/claude-code)