### PR TITLE
feat: privacy policy + terms of service pages; retire dead Airbnb affiliate hook

### DIFF
--- a/dockerize/deployment/Dockerfile
+++ b/dockerize/deployment/Dockerfile
@@ -40,6 +40,7 @@ RUN flutter build web --release \
 FROM nginx:alpine
 
 COPY dockerize/deployment/nginx/default.conf /etc/nginx/conf.d/default.conf
+COPY dockerize/static /usr/share/nginx/html/static
 COPY --from=flutter-build /app/build/web /usr/share/nginx/html/app
 
 EXPOSE 80

--- a/dockerize/deployment/nginx/default.conf
+++ b/dockerize/deployment/nginx/default.conf
@@ -52,6 +52,19 @@ server {
         add_header Cross-Origin-Opener-Policy same-origin;
     }
 
+    # Legal pages — static HTML, shared source of truth in dockerize/static/
+    # (copied into this image; the development gateway mounts the same
+    # directory so /privacy and /terms behave identically on :3000).
+    location = /privacy {
+        default_type text/html;
+        alias /usr/share/nginx/html/static/privacy.html;
+    }
+
+    location = /terms {
+        default_type text/html;
+        alias /usr/share/nginx/html/static/terms.html;
+    }
+
     location = / {
         return 302 /app/;
     }

--- a/dockerize/development/docker-compose.yml
+++ b/dockerize/development/docker-compose.yml
@@ -75,6 +75,7 @@ services:
       - "3000:80"
     volumes:
       - ./nginx/default.conf:/etc/nginx/conf.d/default.conf:ro
+      - ../static:/usr/share/nginx/html/static:ro
     depends_on:
       api:
         condition: service_healthy

--- a/dockerize/development/nginx/default.conf
+++ b/dockerize/development/nginx/default.conf
@@ -18,6 +18,19 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 
+    # Legal pages — static HTML, shared source of truth in dockerize/static/
+    # (mounted read-only by docker-compose; the deployment image copies the
+    # same directory so /privacy and /terms behave identically on :3000).
+    location = /privacy {
+        default_type text/html;
+        alias /usr/share/nginx/html/static/privacy.html;
+    }
+
+    location = /terms {
+        default_type text/html;
+        alias /usr/share/nginx/html/static/terms.html;
+    }
+
     location / {
         proxy_pass http://flutter:8080;
         proxy_http_version 1.1;

--- a/dockerize/static/privacy.html
+++ b/dockerize/static/privacy.html
@@ -1,0 +1,219 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="robots" content="noindex">
+  <title>Privacy Policy — Golden Tempo Travel</title>
+  <style>
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+        Helvetica, Arial, sans-serif;
+      color: #263238;
+      background: #fafafa;
+      line-height: 1.6;
+    }
+    .draft-banner {
+      background: #fff3cd;
+      color: #664d03;
+      border-bottom: 1px solid #ffe69c;
+      text-align: center;
+      padding: 10px 16px;
+      font-weight: 600;
+      font-size: 0.95rem;
+    }
+    header {
+      background: linear-gradient(to bottom right, #00897B, #004D40);
+      color: #fff;
+      padding: 40px 24px 32px;
+    }
+    header .wrap, main { max-width: 760px; margin: 0 auto; }
+    header .brand {
+      font-size: 0.9rem;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+      opacity: 0.85;
+      margin: 0 0 8px;
+    }
+    header h1 { margin: 0; font-size: 1.9rem; }
+    header .meta { margin: 10px 0 0; opacity: 0.85; font-size: 0.95rem; }
+    main { padding: 32px 24px 64px; }
+    h2 {
+      color: #00695C;
+      font-size: 1.25rem;
+      margin: 36px 0 10px;
+      border-bottom: 2px solid #B2DFDB;
+      padding-bottom: 6px;
+    }
+    ul { padding-left: 22px; }
+    li { margin: 6px 0; }
+    a { color: #00695C; }
+    .callout {
+      background: #E0F2F1;
+      border-left: 4px solid #00897B;
+      padding: 12px 16px;
+      border-radius: 0 8px 8px 0;
+      margin: 20px 0;
+    }
+    table { border-collapse: collapse; width: 100%; margin: 12px 0; }
+    th, td {
+      text-align: left;
+      padding: 8px 10px;
+      border-bottom: 1px solid #CFD8DC;
+      vertical-align: top;
+      font-size: 0.95rem;
+    }
+    th { color: #00695C; }
+    footer {
+      border-top: 1px solid #CFD8DC;
+      margin-top: 48px;
+      padding-top: 16px;
+      font-size: 0.9rem;
+      color: #607D8B;
+    }
+    footer a { margin-right: 16px; }
+  </style>
+</head>
+<body>
+  <div class="draft-banner">DRAFT — pending legal review. This document is not yet final.</div>
+  <header>
+    <div class="wrap">
+      <p class="brand">Golden Tempo Travel</p>
+      <h1>Privacy Policy</h1>
+      <p class="meta">Draft of July 6, 2026 · Golden Tempo LLC</p>
+    </div>
+  </header>
+  <main>
+    <p>
+      Golden Tempo Travel is operated by <strong>Golden Tempo LLC</strong>, a
+      New Jersey limited liability company ("we", "us"). This policy explains
+      what information the service collects, how it is used, and the choices
+      you have. Questions or requests:
+      <a href="mailto:goldentempollc@gmail.com">goldentempollc@gmail.com</a>.
+    </p>
+
+    <div class="callout">
+      <strong>The short version:</strong> we store your account email, your
+      trips and travel preferences, and first-party usage events. We do not
+      sell personal data, we do not use third-party analytics or advertising
+      trackers, and you can delete your account (and the data that goes with
+      it) yourself, in the app, at any time.
+    </div>
+
+    <h2>1. Information we collect</h2>
+    <ul>
+      <li><strong>Account information.</strong> Your email address, an optional
+        display name, and your password — stored only as a cryptographic hash;
+        we cannot see your actual password.</li>
+      <li><strong>Trip and planning data.</strong> Trips, itineraries, saved
+        places, booking checklists, price alerts, and the traveler preferences
+        you set (for example travel style or pace) — including messages you
+        send to the AI planning assistant.</li>
+      <li><strong>Usage events.</strong> A first-party log of product events
+        (for example: account created, trip saved, booking link clicked, AI
+        planning session token counts). These events are tied to your account
+        ID only — by design they contain <strong>no email address, no IP
+        address, no browser user-agent, and no free text</strong>. They live in
+        our own database; we use no third-party analytics services.</li>
+      <li><strong>Email delivery records.</strong> When we send you a
+        verification email, a password-reset code, or a price-alert
+        notification, your email address is processed by our transactional
+        email provider for delivery.</li>
+    </ul>
+
+    <h2>2. Third-party services we use to answer your requests</h2>
+    <p>
+      When you plan a trip, parts of your request are sent to third-party
+      providers <em>transiently</em> — to look up an answer, not to build a
+      profile of you:
+    </p>
+    <table>
+      <tr><th>Provider</th><th>What is sent</th><th>Why</th></tr>
+      <tr><td>Google Places</td><td>Place and destination search terms</td><td>Finding and verifying places</td></tr>
+      <tr><td>Duffel</td><td>Airports, dates, passenger counts</td><td>Flight search</td></tr>
+      <tr><td>Ticketmaster</td><td>City and date window</td><td>Local events lookup</td></tr>
+      <tr><td>Open-Meteo</td><td>Destination coordinates and dates</td><td>Weather forecasts</td></tr>
+      <tr><td>Anthropic</td><td>Your planning conversation and trip context</td><td>Generating AI itineraries</td></tr>
+    </table>
+    <p>
+      These lookups are made server-side through our API; the providers do not
+      receive your email address or account identity from us. Results you
+      choose to keep (for example a place added to an itinerary) are stored as
+      part of your trip data.
+    </p>
+
+    <h2>3. Affiliate and outbound links</h2>
+    <p>
+      Booking handoff links (for example to Booking.com) open the provider's
+      own site and may include an affiliate identifier so the provider can
+      credit us if you book. Once you leave Golden Tempo Travel, the
+      provider's own privacy policy applies. We record that a booking link was
+      clicked (see usage events above); we do not receive your payment or
+      booking details.
+    </p>
+
+    <h2>4. Cookies and local storage</h2>
+    <p>
+      We use browser local storage to keep your session token so you stay
+      signed in. We do not use advertising cookies, cross-site trackers, or
+      third-party analytics scripts.
+    </p>
+
+    <h2>5. We do not sell personal data</h2>
+    <p>
+      We do not sell, rent, or trade your personal data, and we do not share
+      it with third parties for their own marketing.
+    </p>
+
+    <h2>6. Data retention and deletion</h2>
+    <ul>
+      <li>Account, trip, and preference data is kept for as long as your
+        account exists.</li>
+      <li>You can <strong>delete your account in the app</strong> (Account
+        settings → Delete account). Deletion permanently removes your account,
+        trips, itineraries, preferences, alerts, and sessions.</li>
+      <li>Usage events are pseudonymous by design (account ID only, no email,
+        IP, or user-agent) and are retained after account deletion as part of
+        aggregate product statistics; after deletion they no longer link to
+        any identifiable account record.</li>
+      <li>You can also request deletion or a copy of your data by emailing
+        <a href="mailto:goldentempollc@gmail.com">goldentempollc@gmail.com</a>.</li>
+    </ul>
+
+    <h2>7. Security</h2>
+    <p>
+      Passwords are stored only as salted hashes, sessions use expiring
+      tokens, and access to production data is limited. No online service can
+      promise perfect security, but we design for storing as little personal
+      data as possible in the first place.
+    </p>
+
+    <h2>8. Children</h2>
+    <p>
+      The service is not directed to children under 13, and we do not
+      knowingly collect personal information from them. If you believe a child
+      has created an account, contact us and we will delete it.
+    </p>
+
+    <h2>9. Changes to this policy</h2>
+    <p>
+      We may update this policy as the product evolves. Material changes will
+      be reflected on this page with an updated date. Continued use of the
+      service after a change means you accept the updated policy.
+    </p>
+
+    <h2>10. Contact</h2>
+    <p>
+      Golden Tempo LLC (New Jersey, USA)<br>
+      <a href="mailto:goldentempollc@gmail.com">goldentempollc@gmail.com</a>
+    </p>
+
+    <footer>
+      <a href="/terms">Terms of Service</a>
+      <a href="/">Back to the app</a>
+    </footer>
+  </main>
+</body>
+</html>

--- a/dockerize/static/terms.html
+++ b/dockerize/static/terms.html
@@ -1,0 +1,207 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="robots" content="noindex">
+  <title>Terms of Service — Golden Tempo Travel</title>
+  <style>
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+        Helvetica, Arial, sans-serif;
+      color: #263238;
+      background: #fafafa;
+      line-height: 1.6;
+    }
+    .draft-banner {
+      background: #fff3cd;
+      color: #664d03;
+      border-bottom: 1px solid #ffe69c;
+      text-align: center;
+      padding: 10px 16px;
+      font-weight: 600;
+      font-size: 0.95rem;
+    }
+    header {
+      background: linear-gradient(to bottom right, #00897B, #004D40);
+      color: #fff;
+      padding: 40px 24px 32px;
+    }
+    header .wrap, main { max-width: 760px; margin: 0 auto; }
+    header .brand {
+      font-size: 0.9rem;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+      opacity: 0.85;
+      margin: 0 0 8px;
+    }
+    header h1 { margin: 0; font-size: 1.9rem; }
+    header .meta { margin: 10px 0 0; opacity: 0.85; font-size: 0.95rem; }
+    main { padding: 32px 24px 64px; }
+    h2 {
+      color: #00695C;
+      font-size: 1.25rem;
+      margin: 36px 0 10px;
+      border-bottom: 2px solid #B2DFDB;
+      padding-bottom: 6px;
+    }
+    ul { padding-left: 22px; }
+    li { margin: 6px 0; }
+    a { color: #00695C; }
+    .callout {
+      background: #E0F2F1;
+      border-left: 4px solid #00897B;
+      padding: 12px 16px;
+      border-radius: 0 8px 8px 0;
+      margin: 20px 0;
+    }
+    footer {
+      border-top: 1px solid #CFD8DC;
+      margin-top: 48px;
+      padding-top: 16px;
+      font-size: 0.9rem;
+      color: #607D8B;
+    }
+    footer a { margin-right: 16px; }
+  </style>
+</head>
+<body>
+  <div class="draft-banner">DRAFT — pending legal review. This document is not yet final.</div>
+  <header>
+    <div class="wrap">
+      <p class="brand">Golden Tempo Travel</p>
+      <h1>Terms of Service</h1>
+      <p class="meta">Draft of July 6, 2026 · Golden Tempo LLC</p>
+    </div>
+  </header>
+  <main>
+    <p>
+      These Terms of Service ("Terms") govern your use of Golden Tempo Travel
+      (the "Service"), operated by <strong>Golden Tempo LLC</strong>, a New
+      Jersey limited liability company. By creating an account or using the
+      Service, you agree to these Terms. If you do not agree, do not use the
+      Service. Questions:
+      <a href="mailto:goldentempollc@gmail.com">goldentempollc@gmail.com</a>.
+    </p>
+
+    <h2>1. What the Service is (and is not)</h2>
+    <p>
+      Golden Tempo Travel is a trip-planning tool: it helps you build
+      itineraries, optimize routes, and find flights, stays, events, and
+      ferries — including with AI-generated suggestions.
+    </p>
+    <div class="callout">
+      <strong>We are not a travel agency.</strong> The Service does not sell,
+      book, or resell travel. Booking links hand you off to third-party
+      providers (for example Booking.com, airlines, or ferry operators); any
+      purchase is a transaction between you and that provider, under that
+      provider's own terms. Some outbound links are affiliate links, meaning
+      the provider may pay us a commission if you book — at no extra cost to
+      you.
+    </div>
+
+    <h2>2. Accuracy of information</h2>
+    <p>
+      Itineraries, place details, prices, schedules, weather, and event
+      listings come from third-party sources or are AI-generated, and can be
+      incomplete, outdated, or wrong. <strong>Verify anything that matters
+      (prices, opening hours, visas, schedules, safety guidance) with the
+      provider or an official source before you commit to it.</strong> You are
+      responsible for your own travel decisions.
+    </p>
+
+    <h2>3. Your account</h2>
+    <ul>
+      <li>You must provide a valid email address and keep your password
+        secure. You are responsible for activity under your account.</li>
+      <li>You must be at least 13 years old (and old enough to consent to
+        these Terms where you live) to use the Service.</li>
+      <li>You can delete your account at any time in Account settings; see the
+        <a href="/privacy">Privacy Policy</a> for what deletion removes.</li>
+    </ul>
+
+    <h2>4. Acceptable use</h2>
+    <p>You agree not to:</p>
+    <ul>
+      <li>use the Service for anything unlawful, or to plan unlawful
+        activity;</li>
+      <li>probe, disrupt, overload, or attempt to gain unauthorized access to
+        the Service or other users' data;</li>
+      <li>scrape, harvest, or bulk-extract content or data from the Service,
+        or resell the Service;</li>
+      <li>abuse the AI planning assistant (for example, attempting to use it
+        for purposes unrelated to travel planning at volume, or to generate
+        harmful content);</li>
+      <li>impersonate others or misrepresent your affiliation with any person
+        or entity.</li>
+    </ul>
+
+    <h2>5. Your content</h2>
+    <p>
+      Trips, itineraries, preferences, and messages you create remain yours.
+      You grant Golden Tempo LLC a limited license to store and process them
+      solely to operate and improve the Service, as described in the
+      <a href="/privacy">Privacy Policy</a>. If you share a trip via a share
+      link, anyone with the link can view (or, for co-planner invites, edit)
+      that trip.
+    </p>
+
+    <h2>6. Suspension and termination</h2>
+    <p>
+      We may suspend or terminate accounts that violate these Terms, abuse the
+      Service, or create risk for us or other users. Where reasonable, we will
+      warn you first. You may stop using the Service and delete your account
+      at any time.
+    </p>
+
+    <h2>7. Disclaimers</h2>
+    <p>
+      THE SERVICE IS PROVIDED "AS IS" AND "AS AVAILABLE", WITHOUT WARRANTIES
+      OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING MERCHANTABILITY, FITNESS FOR
+      A PARTICULAR PURPOSE, AND NON-INFRINGEMENT. WE DO NOT WARRANT THAT THE
+      SERVICE WILL BE UNINTERRUPTED, ERROR-FREE, OR THAT ANY INFORMATION
+      (INCLUDING AI-GENERATED CONTENT) WILL BE ACCURATE OR RELIABLE.
+    </p>
+
+    <h2>8. Limitation of liability</h2>
+    <p>
+      TO THE MAXIMUM EXTENT PERMITTED BY LAW, GOLDEN TEMPO LLC WILL NOT BE
+      LIABLE FOR INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL, OR PUNITIVE
+      DAMAGES, OR FOR LOST PROFITS, DATA, OR TRAVEL COSTS, ARISING FROM YOUR
+      USE OF THE SERVICE OR FROM ANY THIRD-PARTY PROVIDER YOU REACH THROUGH
+      IT. OUR TOTAL LIABILITY FOR ANY CLAIM RELATING TO THE SERVICE IS LIMITED
+      TO THE GREATER OF $100 OR THE AMOUNT YOU PAID US IN THE 12 MONTHS BEFORE
+      THE CLAIM. Some jurisdictions do not allow certain limitations, so parts
+      of this section may not apply to you.
+    </p>
+
+    <h2>9. Governing law</h2>
+    <p>
+      These Terms are governed by the laws of the State of New Jersey, USA,
+      without regard to conflict-of-law rules. Disputes will be resolved in
+      the state or federal courts located in New Jersey, and you consent to
+      their jurisdiction.
+    </p>
+
+    <h2>10. Changes to these Terms</h2>
+    <p>
+      We may update these Terms as the Service evolves. Material changes will
+      be reflected on this page with an updated date. Continued use of the
+      Service after a change means you accept the updated Terms.
+    </p>
+
+    <h2>11. Contact</h2>
+    <p>
+      Golden Tempo LLC (New Jersey, USA)<br>
+      <a href="mailto:goldentempollc@gmail.com">goldentempollc@gmail.com</a>
+    </p>
+
+    <footer>
+      <a href="/privacy">Privacy Policy</a>
+      <a href="/">Back to the app</a>
+    </footer>
+  </main>
+</body>
+</html>

--- a/specs/accommodation-search/plan.md
+++ b/specs/accommodation-search/plan.md
@@ -18,8 +18,8 @@ tool surfaces the same links.
   `DeleteAccommodation` (`WHERE id=$1 AND trip_id=$2`). `make api-sqlc`.
 - **`accommodation_service.go`:** `AccommodationQuery`, `AccommodationProvider`
   interface, `airbnbProvider`/`bookingProvider` `SearchURL` (encoded destination +
-  checkin/checkout + guests; affiliate params from `BOOKING_AFFILIATE_ID`/`AIRBNB_AFFILIATE_ID`
-  when set). `providerLinks(q)` helper returning `[]{provider,url}`.
+  checkin/checkout + guests; Booking affiliate param from `BOOKING_AFFILIATE_ID`
+  when set; Airbnb has no affiliate program). `providerLinks(q)` helper returning `[]{provider,url}`.
 - **`accommodation_handler.go`:** `accommodationLinksHandler` (parse query, 400 if no
   destination), `addAccommodationHandler` (verify trip ownership via `GetTripByIDAndOwner`,
   then `CreateAccommodation`), `deleteAccommodationHandler` (404 if 0 rows). Reuse

--- a/src/packages/api/.env.sample
+++ b/src/packages/api/.env.sample
@@ -16,9 +16,9 @@ CHROME_WS_URL=ws://chrome:9222/   # Set when running in Docker; leave empty to l
 # Postgres connection. For local `make api-run`, point at localhost. In Docker the
 # compose stacks override this to use the `postgres` service host.
 DATABASE_URL=postgres://travel:travel@localhost:5432/travel_planner?sslmode=disable
-# Optional affiliate IDs appended to accommodation browse links (leave empty until approved).
+# Optional Booking.com affiliate ID appended to accommodation browse links
+# (leave empty until approved). Airbnb has no affiliate program (shut down 2021).
 BOOKING_AFFILIATE_ID=
-AIRBNB_AFFILIATE_ID=
 # Optional Ferryhopper affiliate id appended to ferry booking links (leave empty
 # until approved at affiliates.ferryhopper.com). Ferry links work without it,
 # just unattributed.

--- a/src/packages/api/accommodation_service.go
+++ b/src/packages/api/accommodation_service.go
@@ -43,9 +43,8 @@ func (airbnbProvider) SearchURL(q AccommodationQuery) string {
 	if q.Guests > 0 {
 		params.Set("adults", strconv.Itoa(q.Guests))
 	}
-	if id := os.Getenv("AIRBNB_AFFILIATE_ID"); id != "" {
-		params.Set("af", id)
-	}
+	// No affiliate param: Airbnb shut down its affiliate program in 2021
+	// (docs/business-model.md) — these links are pure user value, $0 revenue.
 	if enc := params.Encode(); enc != "" {
 		u += "?" + enc
 	}

--- a/src/packages/flutter-app/lib/screens/account_settings_screen.dart
+++ b/src/packages/flutter-app/lib/screens/account_settings_screen.dart
@@ -4,6 +4,7 @@ import '../providers/api_client_provider.dart';
 import '../providers/auth_provider.dart';
 import '../services/account_api_service.dart';
 import '../theme/spacing.dart';
+import '../widgets/legal_links.dart';
 import '../widgets/page_container.dart';
 import '../widgets/section_header.dart';
 
@@ -218,6 +219,27 @@ class _AccountSettingsScreenState extends ConsumerState<AccountSettingsScreen> {
                 icon: const Icon(Icons.logout),
                 label: const Text('Sign out everywhere'),
                 onPressed: _busy ? null : _logoutAll,
+              ),
+            ),
+            const SizedBox(height: AppSpacing.xl),
+            const SectionHeader(title: 'Legal'),
+            const SizedBox(height: AppSpacing.sm),
+            Align(
+              alignment: Alignment.centerLeft,
+              child: Wrap(
+                spacing: AppSpacing.sm,
+                children: [
+                  TextButton.icon(
+                    icon: const Icon(Icons.open_in_new, size: 18),
+                    label: const Text('Privacy Policy'),
+                    onPressed: openPrivacyPolicy,
+                  ),
+                  TextButton.icon(
+                    icon: const Icon(Icons.open_in_new, size: 18),
+                    label: const Text('Terms of Service'),
+                    onPressed: openTermsOfService,
+                  ),
+                ],
               ),
             ),
             const SizedBox(height: AppSpacing.xl),

--- a/src/packages/flutter-app/lib/screens/auth_screen.dart
+++ b/src/packages/flutter-app/lib/screens/auth_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../providers/auth_provider.dart';
 import '../widgets/brand_logo.dart';
+import '../widgets/legal_links.dart';
 
 class AuthScreen extends ConsumerStatefulWidget {
   /// Whether the form opens in sign-in (true) or create-account (false) mode.
@@ -159,6 +160,10 @@ class _AuthScreenState extends ConsumerState<AuthScreen> {
                           )
                         : Text(_isLogin ? 'Sign in' : 'Create account'),
                   ),
+                  if (!_isLogin) ...[
+                    const SizedBox(height: 12),
+                    const LegalAgreementText(),
+                  ],
                   const SizedBox(height: 12),
                   TextButton(
                     onPressed: auth.loading ? null : _toggleMode,

--- a/src/packages/flutter-app/lib/screens/landing_screen.dart
+++ b/src/packages/flutter-app/lib/screens/landing_screen.dart
@@ -4,6 +4,7 @@ import '../theme/app_colors.dart';
 import '../theme/spacing.dart';
 import '../widgets/brand_logo.dart';
 import '../widgets/gradient_app_bar.dart';
+import '../widgets/legal_links.dart';
 import '../widgets/page_container.dart';
 import 'auth_screen.dart';
 
@@ -108,11 +109,50 @@ class LandingScreen extends StatelessWidget {
                 ),
 
                 const SizedBox(height: AppSpacing.lg),
+
+                const _LandingFooter(),
+
+                const SizedBox(height: AppSpacing.lg),
               ],
             ),
           ),
         ),
       ),
+    );
+  }
+}
+
+/// Footer: legal links + company line, so the policy pages are reachable
+/// before sign-up (affiliate programs require a discoverable privacy policy).
+class _LandingFooter extends StatelessWidget {
+  const _LandingFooter();
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final muted = theme.textTheme.bodySmall
+        ?.copyWith(color: theme.colorScheme.onSurfaceVariant);
+    return Column(
+      children: [
+        Wrap(
+          alignment: WrapAlignment.center,
+          crossAxisAlignment: WrapCrossAlignment.center,
+          spacing: AppSpacing.sm,
+          children: [
+            TextButton(
+              onPressed: openPrivacyPolicy,
+              child: const Text('Privacy Policy'),
+            ),
+            Text('·', style: muted),
+            TextButton(
+              onPressed: openTermsOfService,
+              child: const Text('Terms of Service'),
+            ),
+          ],
+        ),
+        const SizedBox(height: AppSpacing.xs),
+        Text('© 2026 Golden Tempo LLC', style: muted),
+      ],
     );
   }
 }

--- a/src/packages/flutter-app/lib/widgets/legal_links.dart
+++ b/src/packages/flutter-app/lib/widgets/legal_links.dart
@@ -1,0 +1,77 @@
+import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+/// Same-origin legal pages served by the nginx gateway at the site root
+/// (`/privacy`, `/terms`) — outside the Flutter app's own base path, so they
+/// are opened as absolute URLs off the current origin rather than routed
+/// in-app (the same origin-derivation trick trip sharing uses).
+Future<void> openLegalPage(String path) async {
+  String origin;
+  try {
+    origin = Uri.base.origin; // http(s) platforms
+  } catch (_) {
+    // Non-web platform: fall back to the gateway default (PUBLIC_BASE_URL's
+    // documented default), where the pages are served in dev and deploy.
+    origin = 'http://localhost:3000';
+  }
+  final uri = Uri.tryParse('$origin$path');
+  if (uri != null) {
+    await launchUrl(uri, mode: LaunchMode.externalApplication);
+  }
+}
+
+Future<void> openPrivacyPolicy() => openLegalPage('/privacy');
+Future<void> openTermsOfService() => openLegalPage('/terms');
+
+/// "By signing up you agree to the Terms of Service and Privacy Policy" —
+/// small print with tappable links, shown under the sign-up form.
+class LegalAgreementText extends StatelessWidget {
+  const LegalAgreementText({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final base = theme.textTheme.bodySmall
+        ?.copyWith(color: theme.colorScheme.onSurfaceVariant);
+    return Wrap(
+      alignment: WrapAlignment.center,
+      crossAxisAlignment: WrapCrossAlignment.center,
+      children: [
+        Text('By signing up you agree to the ', style: base),
+        _InlineLink(
+            label: 'Terms of Service',
+            style: base,
+            onTap: openTermsOfService),
+        Text(' and ', style: base),
+        _InlineLink(
+            label: 'Privacy Policy', style: base, onTap: openPrivacyPolicy),
+        Text('.', style: base),
+      ],
+    );
+  }
+}
+
+class _InlineLink extends StatelessWidget {
+  final String label;
+  final TextStyle? style;
+  final Future<void> Function() onTap;
+
+  const _InlineLink(
+      {required this.label, required this.style, required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return InkWell(
+      onTap: onTap,
+      child: Text(
+        label,
+        style: (style ?? const TextStyle()).copyWith(
+          color: theme.colorScheme.primary,
+          decoration: TextDecoration.underline,
+          decorationColor: theme.colorScheme.primary,
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Why

The last in-repo blocker on Phase-1 affiliate revenue: **Booking.com partner approval requires a live privacy policy**, and the app stores PII (account emails, trips, analytics events) with no policy content anywhere in the product.

> **Both pages are DRAFT — pending Brian's legal review.** Each page carries a prominent draft banner and stays marked that way until reviewed.

## What

### Privacy Policy + Terms of Service (`/privacy`, `/terms`)
- **One shared source of truth**: `dockerize/static/privacy.html` + `terms.html` — self-contained static pages, lightly styled to match the app (teal gradient header, same palette as the boot splash).
- **Privacy** accurately reflects what the product actually stores/processes: account email + password hash, trips/itineraries/preferences, first-party analytics events (account-ID-only — no IP/UA per the instrumentation-events spec, retained post-deletion by design since they're PII-free), transient third-party lookups (Google Places, Duffel, Ticketmaster, Open-Meteo, Anthropic), outbound Booking.com affiliate links, transactional email, session token in browser local storage. Includes in-app account deletion, retention, and a "we do not sell personal data" statement. No compliance certifications claimed.
- **Terms**: as-is service, explicit *not-a-travel-agency* section (booking links hand off to third-party providers under their terms, affiliate disclosure), AI-accuracy disclaimer, acceptable use, termination, NJ governing law. Entity: **Golden Tempo LLC** (NJ), contact goldentempollc@gmail.com.

### Serving (identical on :3000 in dev and prod)
- **Deployment**: `Dockerfile` COPYs `dockerize/static/` into the gateway image; exact-match `location = /privacy` / `= /terms` blocks (alias + `default_type text/html`) in `dockerize/deployment/nginx/default.conf`.
- **Development**: compose mounts the same `dockerize/static/` read-only into the nginx gateway; identical location blocks in `dockerize/development/nginx/default.conf`.

### Flutter links
- New shared helper `lib/widgets/legal_links.dart` — opens `/privacy` / `/terms` same-origin via `Uri.base.origin` + `url_launcher` (the origin-derivation pattern trip sharing uses).
- `landing_screen.dart`: footer with Privacy / Terms links + © Golden Tempo LLC.
- `auth_screen.dart`: sign-up mode shows "By signing up you agree to the Terms of Service and Privacy Policy" with tappable links.
- `account_settings_screen.dart`: new "Legal" section.

### Retired dead Airbnb affiliate hook
- Airbnb shut its affiliate program in 2021 (`docs/business-model.md`) — the `AIRBNB_AFFILIATE_ID` env hook was a false ops task. Removed from `accommodation_service.go`, `.env.sample`, and the accommodation spec plan. `grep -rn AIRBNB_AFFILIATE_ID` is clean; the `BOOKING_AFFILIATE_ID` → `aid` injection path is untouched.

## Verification
- `make api-fmt && make api-vet` clean; `go test ./...` passes.
- `flutter analyze`: 12 pre-existing infos in untouched files (`route_results_widget.dart` etc.), none new; `flutter test` all pass.
- Both nginx configs pass `nginx -t`; a live container with the dev config + mounted static dir served `/privacy` and `/terms` with `200` and `Content-Type: text/html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)