### PR TITLE
feat(flutter): complete attach-rate tracking across all outbound booking surfaces

### DIFF
--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -14,7 +14,6 @@ import '../models/location_timing.dart';
 import '../models/route_request.dart';
 import '../models/trip_segment.dart';
 import '../providers/accommodations_provider.dart';
-import '../providers/analytics_provider.dart';
 import '../providers/transport_provider.dart';
 import '../providers/trips_provider.dart';
 import '../providers/recent_trip_provider.dart';
@@ -27,6 +26,7 @@ import '../providers/ferries_provider.dart';
 import '../providers/local_provider.dart';
 import '../theme/app_colors.dart';
 import '../theme/spacing.dart';
+import '../utils/tracked_launch.dart';
 import '../utils/trip_format.dart';
 import '../widgets/add_itinerary_item_dialog.dart';
 import '../widgets/booking_todo_card.dart';
@@ -2528,28 +2528,25 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
   /// back to its external provider search link.
   VoidCallback? _openCallbackFor(BookingTodo todo) {
     // The attach-rate numerator (specs/instrumentation-events): opening any
-    // booking handoff counts as a click. Fire-and-forget; the action below
-    // proceeds immediately regardless.
-    void track(String provider) =>
-        ref.read(analyticsApiServiceProvider).recordBookingLinkClicked(
-              tripId: widget.tripId,
-              todoKey: todo.todoKey,
-              provider: provider,
-              kind: todo.kind,
-            );
-
+    // booking handoff counts as a click. External links record-then-launch via
+    // trackedLaunchUrl; the one in-app handoff (Find Flights) records via the
+    // same helper before navigating. Fire-and-forget either way.
     if (todo.kind == 'transport') {
       final ferry = _ferryLegs[todo.todoKey];
       if (ferry != null) {
-        return () {
-          track('Ferryhopper');
-          _openFerry(ferry);
-        };
+        return () => _openFerry(ferry, todo);
       }
       final leg = _flightLegs[todo.todoKey];
       if (leg != null) {
         return () {
-          track('Duffel');
+          trackBookingLinkClick(
+            context,
+            provider: 'duffel',
+            surface: 'booking_checklist',
+            tripId: widget.tripId,
+            todoKey: todo.todoKey,
+            kind: todo.kind,
+          );
           Navigator.of(context).push(MaterialPageRoute(
             builder: (_) => FlightSearchScreen(
               prefillOrigin: leg.origin,
@@ -2563,9 +2560,17 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
       }
     }
     if (todo.searchUrl != null) {
-      return () {
-        track(todo.provider ?? 'unknown');
-        _launch(todo.searchUrl!);
+      return () async {
+        final ok = await trackedLaunchUrl(
+          context,
+          todo.searchUrl!,
+          provider: (todo.provider ?? 'unknown').toLowerCase(),
+          surface: 'booking_checklist',
+          tripId: widget.tripId,
+          todoKey: todo.todoKey,
+          kind: todo.kind,
+        );
+        if (!ok) _showSnack('Could not open link');
       };
     }
     return null;
@@ -2575,15 +2580,26 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
   /// correct port codes) is built server-side, so we fetch it on tap — a single
   /// quick GET — keeping the port-code map a single source of truth in the API.
   Future<void> _openFerry(
-      ({String origin, String destination, String? date}) leg) async {
+      ({String origin, String destination, String? date}) leg,
+      BookingTodo todo) async {
     try {
       final options = await ref.read(ferryApiServiceProvider).searchFerries(
             leg.origin,
             leg.destination,
             date: leg.date,
           );
+      if (!mounted) return;
       if (options.isNotEmpty && options.first.bookingUrl.isNotEmpty) {
-        await _launch(options.first.bookingUrl);
+        final ok = await trackedLaunchUrl(
+          context,
+          options.first.bookingUrl,
+          provider: 'ferryhopper',
+          surface: 'booking_checklist',
+          tripId: widget.tripId,
+          todoKey: todo.todoKey,
+          kind: todo.kind,
+        );
+        if (!ok) _showSnack('Could not open link');
         return;
       }
     } catch (_) {
@@ -2592,6 +2608,8 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
     _showSnack('Could not open ferry search');
   }
 
+  // Raw launcher for non-booking links only (the per-item "Open in Google
+  // Maps" action) — booking handoffs must go through trackedLaunchUrl.
   Future<void> _launch(String url) async {
     final ok =
         await launchUrl(Uri.parse(url), mode: LaunchMode.externalApplication);

--- a/src/packages/flutter-app/lib/services/analytics_api_service.dart
+++ b/src/packages/flutter-app/lib/services/analytics_api_service.dart
@@ -13,6 +13,7 @@ class AnalyticsApiService {
     String? tripId,
     String? todoKey,
     String? provider,
+    String? surface,
     String? kind,
   }) async {
     final token = apiClient.authToken;
@@ -30,6 +31,7 @@ class AnalyticsApiService {
           'metadata': {
             if (todoKey != null) 'todo_key': todoKey,
             if (provider != null) 'provider': provider,
+            if (surface != null) 'surface': surface,
             if (kind != null) 'kind': kind,
           },
         }),

--- a/src/packages/flutter-app/lib/utils/tracked_launch.dart
+++ b/src/packages/flutter-app/lib/utils/tracked_launch.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+import '../providers/analytics_provider.dart';
+
+/// The single pathway for opening an outbound booking/provider link: records a
+/// `booking_link_clicked` analytics event (the attach-rate numerator,
+/// specs/instrumentation-events) and then launches [url] externally.
+///
+/// Recording is strictly fire-and-forget — an analytics failure (or a widget
+/// tree without a ProviderScope) must never block, delay, or break the launch.
+/// Returns whether the launch succeeded, so call sites can keep their own
+/// "Could not open link" handling.
+///
+/// [provider] is who the user is being handed to (duffel, ferryhopper,
+/// ticketmaster, booking.com, airbnb, …) and [surface] is which UI element the
+/// click came from (booking_checklist, flight_card, chat, …). Keep both short:
+/// the API caps event metadata at 2KB.
+Future<bool> trackedLaunchUrl(
+  BuildContext context,
+  String url, {
+  required String provider,
+  required String surface,
+  String? tripId,
+  String? todoKey,
+  String? kind,
+}) async {
+  final uri = Uri.tryParse(url);
+  if (url.isEmpty || uri == null) return false;
+  trackBookingLinkClick(
+    context,
+    provider: provider,
+    surface: surface,
+    tripId: tripId,
+    todoKey: todoKey,
+    kind: kind,
+  );
+  return launchUrl(uri, mode: LaunchMode.externalApplication);
+}
+
+/// Records the booking-click event without launching anything — for the rare
+/// booking handoff that stays in-app (e.g. the checklist's prefilled Find
+/// Flights screen). External links should use [trackedLaunchUrl] instead.
+void trackBookingLinkClick(
+  BuildContext context, {
+  required String provider,
+  required String surface,
+  String? tripId,
+  String? todoKey,
+  String? kind,
+}) {
+  try {
+    ProviderScope.containerOf(context, listen: false)
+        .read(analyticsApiServiceProvider)
+        .recordBookingLinkClicked(
+          tripId: tripId,
+          todoKey: todoKey,
+          provider: provider,
+          surface: surface,
+          kind: kind,
+        );
+  } catch (_) {
+    // Tracking must never break the user's action.
+  }
+}

--- a/src/packages/flutter-app/lib/widgets/bookings_section.dart
+++ b/src/packages/flutter-app/lib/widgets/bookings_section.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
-import 'package:url_launcher/url_launcher.dart';
 import '../models/accommodation.dart';
 import '../models/trip.dart';
 import '../models/trip_segment.dart';
 import '../theme/spacing.dart';
+import '../utils/tracked_launch.dart';
 
 /// "Your bookings" hub in trip detail: the stays and transport segments the
 /// user has actually saved (distinct from the auto-derived booking checklist).
@@ -34,11 +34,20 @@ class BookingsSection extends StatelessWidget {
         _ => Icons.route_outlined,
       };
 
-  Future<void> _open(String url) async {
-    final uri = Uri.tryParse(url);
-    if (uri != null) {
-      await launchUrl(uri, mode: LaunchMode.externalApplication);
-    }
+  /// Opens a saved booking's own link — still a booking handoff, so it counts
+  /// toward the attach rate under the provider the user recorded (if any).
+  Future<void> _open(BuildContext context, String url,
+      {String? provider, required String kind}) async {
+    await trackedLaunchUrl(
+      context,
+      url,
+      provider: (provider == null || provider.isEmpty)
+          ? 'unknown'
+          : provider.toLowerCase(),
+      surface: 'bookings_hub',
+      tripId: trip.id,
+      kind: kind,
+    );
   }
 
   @override
@@ -98,7 +107,8 @@ class BookingsSection extends StatelessWidget {
                     IconButton(
                       icon: const Icon(Icons.open_in_new, size: 18),
                       tooltip: 'Open listing',
-                      onPressed: () => _open(a.url!),
+                      onPressed: () => _open(context, a.url!,
+                          provider: a.provider, kind: 'stay'),
                     ),
                   IconButton(
                     icon: const Icon(Icons.delete_outline, size: 18),
@@ -132,7 +142,8 @@ class BookingsSection extends StatelessWidget {
                     IconButton(
                       icon: const Icon(Icons.open_in_new, size: 18),
                       tooltip: 'Open booking',
-                      onPressed: () => _open(s.url!),
+                      onPressed: () => _open(context, s.url!,
+                          provider: s.provider, kind: 'transport'),
                     ),
                   IconButton(
                     icon: const Icon(Icons.delete_outline, size: 18),

--- a/src/packages/flutter-app/lib/widgets/chat_panel.dart
+++ b/src/packages/flutter-app/lib/widgets/chat_panel.dart
@@ -2,10 +2,10 @@ import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart' show ScrollDirection;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:gpt_markdown/gpt_markdown.dart';
-import 'package:url_launcher/url_launcher.dart';
 import '../models/plan_message.dart';
 import '../providers/plan_provider.dart';
 import '../theme/app_colors.dart';
+import '../utils/tracked_launch.dart';
 import 'result_summary_chip.dart';
 
 /// The plan-agent chat surface (messages, tool chips, result chips, input bar)
@@ -489,10 +489,17 @@ class ChatMessageBubble extends StatelessWidget {
 
   const ChatMessageBubble({super.key, required this.message, this.isStreaming = false});
 
-  Future<void> _openLink(String url) async {
+  Future<void> _openLink(BuildContext context, String url) async {
     final uri = Uri.tryParse(url);
     if (uri == null) return;
-    await launchUrl(uri, mode: LaunchMode.externalApplication);
+    // Agent-emitted markdown links can point at any provider, so the link
+    // host stands in as the provider label.
+    await trackedLaunchUrl(
+      context,
+      url,
+      provider: uri.host.isEmpty ? 'unknown' : uri.host,
+      surface: 'chat',
+    );
   }
 
   @override
@@ -532,7 +539,7 @@ class ChatMessageBubble extends StatelessWidget {
                   : GptMarkdown(
                       message.content,
                       style: TextStyle(color: theme.colorScheme.onSurface),
-                      onLinkTap: (url, title) => _openLink(url),
+                      onLinkTap: (url, title) => _openLink(context, url),
                     ),
             ),
             if (isStreaming) ...[

--- a/src/packages/flutter-app/lib/widgets/event_card.dart
+++ b/src/packages/flutter-app/lib/widgets/event_card.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
-import 'package:url_launcher/url_launcher.dart';
 import '../models/event.dart';
 import '../theme/app_colors.dart';
 import '../theme/spacing.dart';
+import '../utils/tracked_launch.dart';
 
 /// A single local event: name, when, venue/category, opening the ticket/info
 /// page externally on tap. Styled to sit beside itinerary and booking rows.
@@ -11,12 +11,10 @@ class EventCard extends StatelessWidget {
 
   const EventCard({super.key, required this.event});
 
-  Future<void> _open() async {
+  Future<void> _open(BuildContext context) async {
     if (event.url.isEmpty) return;
-    final uri = Uri.tryParse(event.url);
-    if (uri != null) {
-      await launchUrl(uri, mode: LaunchMode.externalApplication);
-    }
+    await trackedLaunchUrl(context, event.url,
+        provider: 'ticketmaster', surface: 'event_card');
   }
 
   @override
@@ -32,7 +30,7 @@ class EventCard extends StatelessWidget {
       margin: const EdgeInsets.symmetric(vertical: AppSpacing.xs),
       clipBehavior: Clip.antiAlias,
       child: InkWell(
-        onTap: event.url.isEmpty ? null : _open,
+        onTap: event.url.isEmpty ? null : () => _open(context),
         child: Padding(
           padding: const EdgeInsets.all(AppSpacing.md),
           child: Row(

--- a/src/packages/flutter-app/lib/widgets/ferry_card.dart
+++ b/src/packages/flutter-app/lib/widgets/ferry_card.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
-import 'package:url_launcher/url_launcher.dart';
 import '../models/ferry_option.dart';
 import '../theme/app_colors.dart';
 import '../theme/spacing.dart';
+import '../utils/tracked_launch.dart';
 
 /// A ferry option: route, date, and (when available) operator/time/price,
 /// opening the Ferryhopper booking page on tap. In v1 link mode it renders as a
@@ -12,12 +12,10 @@ class FerryCard extends StatelessWidget {
 
   const FerryCard({super.key, required this.option});
 
-  Future<void> _open() async {
+  Future<void> _open(BuildContext context) async {
     if (option.bookingUrl.isEmpty) return;
-    final uri = Uri.tryParse(option.bookingUrl);
-    if (uri != null) {
-      await launchUrl(uri, mode: LaunchMode.externalApplication);
-    }
+    await trackedLaunchUrl(context, option.bookingUrl,
+        provider: 'ferryhopper', surface: 'ferry_card');
   }
 
   @override
@@ -36,7 +34,7 @@ class FerryCard extends StatelessWidget {
       margin: const EdgeInsets.symmetric(vertical: AppSpacing.xs),
       clipBehavior: Clip.antiAlias,
       child: InkWell(
-        onTap: option.bookingUrl.isEmpty ? null : _open,
+        onTap: option.bookingUrl.isEmpty ? null : () => _open(context),
         child: Padding(
           padding: const EdgeInsets.all(AppSpacing.md),
           child: Row(

--- a/src/packages/flutter-app/lib/widgets/flight_details_sheet.dart
+++ b/src/packages/flutter-app/lib/widgets/flight_details_sheet.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
-import 'package:url_launcher/url_launcher.dart';
 import '../models/flight_leg.dart';
 import '../models/flight_offer.dart';
+import '../utils/tracked_launch.dart';
 import 'airline_logo.dart';
 
 /// Opens a modal bottom sheet with the segment-by-segment breakdown of [offer]:
@@ -192,7 +192,8 @@ class _LayoverRow extends StatelessWidget {
 /// Opens the offer's booking link (airline site or airline-filtered Google
 /// Flights) in an external tab.
 Future<void> _book(BuildContext context, String url) async {
-  final ok = await launchUrl(Uri.parse(url), mode: LaunchMode.externalApplication);
+  final ok = await trackedLaunchUrl(context, url,
+      provider: 'duffel', surface: 'flight_details');
   if (!ok && context.mounted) {
     ScaffoldMessenger.of(context)
         .showSnackBar(const SnackBar(content: Text('Could not open link')));

--- a/src/packages/flutter-app/lib/widgets/flight_offer_card.dart
+++ b/src/packages/flutter-app/lib/widgets/flight_offer_card.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:url_launcher/url_launcher.dart';
 import '../models/flight_offer.dart';
+import '../utils/tracked_launch.dart';
 import 'airline_logo.dart';
 import 'flight_details_sheet.dart';
 
@@ -16,8 +16,8 @@ class FlightOfferCard extends StatelessWidget {
   Future<void> _book(BuildContext context) async {
     final url = offer.bookingUrl;
     if (url == null || url.isEmpty) return;
-    final ok =
-        await launchUrl(Uri.parse(url), mode: LaunchMode.externalApplication);
+    final ok = await trackedLaunchUrl(context, url,
+        provider: 'duffel', surface: 'flight_card');
     if (!ok && context.mounted) {
       ScaffoldMessenger.of(context)
           .showSnackBar(const SnackBar(content: Text('Could not open link')));

--- a/src/packages/flutter-app/lib/widgets/source_links_card.dart
+++ b/src/packages/flutter-app/lib/widgets/source_links_card.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
-import 'package:url_launcher/url_launcher.dart';
 import '../models/source_link.dart';
 import '../theme/spacing.dart';
+import '../utils/tracked_launch.dart';
 
 /// A compact card listing external discovery links as tappable chips. Used where
 /// there's no structured data to show — e.g. Greek events via more.com /
@@ -20,12 +20,15 @@ class SourceLinksCard extends StatelessWidget {
     required this.links,
   });
 
-  Future<void> _open(String url) async {
-    if (url.isEmpty) return;
-    final uri = Uri.tryParse(url);
-    if (uri != null) {
-      await launchUrl(uri, mode: LaunchMode.externalApplication);
-    }
+  Future<void> _open(BuildContext context, SourceLink link) async {
+    if (link.url.isEmpty) return;
+    await trackedLaunchUrl(
+      context,
+      link.url,
+      provider:
+          link.provider.isEmpty ? 'unknown' : link.provider.toLowerCase(),
+      surface: 'source_links',
+    );
   }
 
   @override
@@ -63,7 +66,7 @@ class SourceLinksCard extends StatelessWidget {
                   ActionChip(
                     avatar: Icon(Icons.open_in_new, size: 14, color: accent),
                     label: Text(link.label.isEmpty ? link.provider : link.label),
-                    onPressed: () => _open(link.url),
+                    onPressed: () => _open(context, link),
                   ),
               ],
             ),

--- a/src/packages/flutter-app/pubspec.lock
+++ b/src/packages/flutter-app/pubspec.lock
@@ -942,7 +942,7 @@ packages:
     source: hosted
     version: "3.2.2"
   url_launcher_platform_interface:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: url_launcher_platform_interface
       sha256: "552f8a1e663569be95a8190206a38187b531910283c3e982193e4f2733f01029"

--- a/src/packages/flutter-app/pubspec.yaml
+++ b/src/packages/flutter-app/pubspec.yaml
@@ -88,6 +88,9 @@ dev_dependencies:
   json_serializable: ^6.7.1
   build_runner: ^2.4.7
 
+  # Faking the URL launcher in widget tests (tracked_launch_test.dart)
+  url_launcher_platform_interface: ^2.3.2
+
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec
 

--- a/src/packages/flutter-app/test/tracked_launch_test.dart
+++ b/src/packages/flutter-app/test/tracked_launch_test.dart
@@ -1,0 +1,129 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:url_launcher_platform_interface/link.dart'
+    show LinkDelegate;
+import 'package:url_launcher_platform_interface/url_launcher_platform_interface.dart';
+
+import 'package:travel_route_planner/providers/analytics_provider.dart';
+import 'package:travel_route_planner/services/analytics_api_service.dart';
+import 'package:travel_route_planner/services/api_client.dart';
+import 'package:travel_route_planner/utils/tracked_launch.dart';
+
+/// Captures launch calls instead of hitting a real platform.
+class _FakeUrlLauncher extends UrlLauncherPlatform {
+  final launched = <String>[];
+
+  @override
+  LinkDelegate? get linkDelegate => null;
+
+  @override
+  Future<bool> canLaunch(String url) async => true;
+
+  @override
+  Future<bool> launchUrl(String url, LaunchOptions options) async {
+    launched.add(url);
+    return true;
+  }
+}
+
+/// Captures booking-click records; can be told to blow up to prove that
+/// analytics failure never blocks the launch.
+class _RecordingAnalytics implements AnalyticsApiService {
+  final calls = <Map<String, String?>>[];
+  final bool throwOnRecord;
+
+  _RecordingAnalytics({this.throwOnRecord = false});
+
+  @override
+  ApiClient get apiClient => throw UnimplementedError();
+
+  @override
+  Future<void> recordBookingLinkClicked({
+    String? tripId,
+    String? todoKey,
+    String? provider,
+    String? surface,
+    String? kind,
+  }) {
+    if (throwOnRecord) throw Exception('analytics is down');
+    calls.add({
+      'trip_id': tripId,
+      'todo_key': todoKey,
+      'provider': provider,
+      'surface': surface,
+      'kind': kind,
+    });
+    return Future.value();
+  }
+}
+
+Widget _harness(_RecordingAnalytics analytics, {String url = 'https://duffel.example/offer'}) {
+  return ProviderScope(
+    overrides: [
+      analyticsApiServiceProvider.overrideWithValue(analytics),
+    ],
+    child: MaterialApp(
+      home: Scaffold(
+        body: Builder(
+          builder: (context) => ElevatedButton(
+            onPressed: () => trackedLaunchUrl(
+              context,
+              url,
+              provider: 'duffel',
+              surface: 'flight_card',
+              tripId: 'trip-1',
+            ),
+            child: const Text('Book'),
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+void main() {
+  late _FakeUrlLauncher launcher;
+
+  setUp(() {
+    launcher = _FakeUrlLauncher();
+    UrlLauncherPlatform.instance = launcher;
+  });
+
+  testWidgets('trackedLaunchUrl records booking_link_clicked then launches',
+      (tester) async {
+    final analytics = _RecordingAnalytics();
+    await tester.pumpWidget(_harness(analytics));
+
+    await tester.tap(find.text('Book'));
+    await tester.pump();
+
+    expect(launcher.launched, ['https://duffel.example/offer']);
+    expect(analytics.calls, hasLength(1));
+    expect(analytics.calls.single['provider'], 'duffel');
+    expect(analytics.calls.single['surface'], 'flight_card');
+    expect(analytics.calls.single['trip_id'], 'trip-1');
+  });
+
+  testWidgets('analytics failure never blocks the launch', (tester) async {
+    final analytics = _RecordingAnalytics(throwOnRecord: true);
+    await tester.pumpWidget(_harness(analytics));
+
+    await tester.tap(find.text('Book'));
+    await tester.pump();
+
+    expect(launcher.launched, ['https://duffel.example/offer']);
+  });
+
+  testWidgets('an unparseable/empty url neither records nor launches',
+      (tester) async {
+    final analytics = _RecordingAnalytics();
+    await tester.pumpWidget(_harness(analytics, url: ''));
+
+    await tester.tap(find.text('Book'));
+    await tester.pump();
+
+    expect(launcher.launched, isEmpty);
+    expect(analytics.calls, isEmpty);
+  });
+}


### PR DESCRIPTION
## Why

Attach rate is the single number the growth phase exists to measure (docs/business-model.md §6), yet `booking_link_clicked` fired from exactly **one** call site (the trip-detail booking checklist) while eight outbound booking-link surfaces existed. Every other handoff — flight cards, ferry cards, event cards, the bookings hub, source-link chips, chat links — was invisible to the funnel.

## What

**New helper — `lib/utils/tracked_launch.dart`** (Flutter only; no Go/API change — the event type is already whitelisted in `analytics.go`):

- `trackedLaunchUrl(context, url, {provider, surface, tripId?, todoKey?, kind?})` — fire-and-forget records `booking_link_clicked` (via `ProviderScope.containerOf` → `analyticsApiServiceProvider`, wrapped in try/catch), then launches the URL externally. **Analytics failure can never block or delay the launch.** Returns the launch result so call sites keep their own "Could not open link" handling.
- `trackBookingLinkClick(...)` — record-only, for the one booking handoff that stays in-app (checklist → prefilled Find Flights screen).

`AnalyticsApiService.recordBookingLinkClicked` gains a `surface` metadata field (metadata stays flat and tiny, well under the 2KB cap).

**All 8 surfaces now route through the helper** — the old direct `recordBookingLinkClicked` call site is migrated, so there is exactly one pathway:

| Call site | Surface | Provider |
|---|---|---|
| `trip_detail_screen.dart` checklist — search link | `booking_checklist` | `todo.provider` (lowercased, `unknown` fallback) |
| `trip_detail_screen.dart` checklist — ferry leg | `booking_checklist` | `ferryhopper` |
| `trip_detail_screen.dart` checklist — flight leg (in-app) | `booking_checklist` | `duffel` |
| `widgets/bookings_section.dart` saved stays/transport | `bookings_hub` | user-recorded provider (lowercased); kind `stay`/`transport` |
| `widgets/flight_offer_card.dart` Book button | `flight_card` | `duffel` |
| `widgets/flight_details_sheet.dart` Book button | `flight_details` | `duffel` |
| `widgets/ferry_card.dart` | `ferry_card` | `ferryhopper` |
| `widgets/event_card.dart` | `event_card` | `ticketmaster` |
| `widgets/source_links_card.dart` chips | `source_links` | `link.provider` (more.com, visitgreece.gr, …) |
| `widgets/chat_panel.dart` markdown links | `chat` | link host (chat links can point anywhere) |

The only remaining raw `launchUrl` in `lib/` is trip-detail's `_launch`, now maps-only and comment-exempted (non-booking link).

## Tests

New `test/tracked_launch_test.dart` (fakes `UrlLauncherPlatform`; adds `url_launcher_platform_interface` as a dev dependency):
- records `booking_link_clicked` with provider/surface/trip_id, then launches
- a throwing analytics service never blocks the launch
- empty/unparseable URL neither records nor launches

`flutter test`: 42/42 pass. `flutter analyze --no-fatal-infos --fatal-warnings` (the CI gate): clean. (`make flutter-analyze` exits 1 on 12 pre-existing info lints that also fail on clean main — untouched by this PR.)

## Known limits (accepted)

- Anonymous users stay uncounted — `AnalyticsApiService` bails on a null token (fine for now).
- The attach-rate trend steps up discontinuously when this merges: surfaces that existed before simply weren't counted.
- Ferry checklist clicks now record at launch time (after the booking-URL fetch) rather than at tap time — no count when nothing actually opens, which is a slightly stricter numerator than before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)