### PR TITLE
feat(api): metrics truth — grouped counts, MAU + dollar COGS, second-trip retention

### DIFF
--- a/specs/instrumentation-events/spec.md
+++ b/specs/instrumentation-events/spec.md
@@ -63,7 +63,10 @@ conversions live in partner dashboards); clicks are the in-product proxy, with
 - [x] An admin can fetch a metrics summary for a chosen window: signups,
       activation rate (signups that saved a first trip), trips created,
       attach rate (trips with ≥1 booking click), clicks by provider, todos
-      marked booked, returning users, plan sessions and total tokens.
+      marked booked, second-trip retention, session-frequency returning
+      users, active users (MAU), plan sessions, total tokens, and estimated
+      Claude cost (total and per active user) — see Derived Metric
+      Definitions.
 - [x] Non-admins cannot record arbitrary event types or read metrics.
 - [x] With the database down, every instrumented flow (signup, planning,
       booking links) behaves exactly as it does today — events are silently
@@ -90,11 +93,62 @@ conversions live in partner dashboards); clicks are the in-product proxy, with
 - **Request:** optional `days` window (default 30).
 - **Response:** counts and rates for the window — signups, activated users and
   activation rate, trips created, trips with ≥1 booking click and attach rate,
-  booking clicks by provider, todos marked booked, returning users (≥2
-  planning sessions on different days), plan sessions, total input/output
-  tokens.
+  booking clicks by provider, todos marked booked, the derived metrics below,
+  plan sessions, total input/output/cache tokens, and cost estimates.
 - **Errors:** 401 unauthenticated; 403 non-admin; 503 when persistence is
   unavailable.
+
+## Derived Metric Definitions
+
+These numbers drive pricing and phase-gate decisions (`docs/business-model.md`
+§8), so their definitions are normative here — the SQL implements this spec,
+not the other way around.
+
+- **`second_trip_retention`** — the business model's retention metric ("users
+  returning for a second trip", the Phase 3 trigger): count of signed-in users
+  with **≥ 2 `trip_created` events at least 7 days apart** inside the window
+  (implemented as `max(created_at) − min(created_at) ≥ 7 days` per user, which
+  implies ≥ 2 events). The 7-day gap is what separates "came back for another
+  trip" from "kept editing the same planning burst"; two trips created the
+  same week count once.
+- **`session_frequency_returning`** — the metric formerly (and misleadingly)
+  named `returning_users`: users with planning sessions on ≥ 2 distinct days
+  in the window. It is a **session-frequency proxy**, not trip retention — a
+  user polishing one trip across two evenings counts. Kept because it is still
+  a useful engagement signal; renamed so nobody reads it as the §8 retention
+  number.
+- **`active_users` (MAU)** — distinct signed-in users with ≥ 1
+  `plan_session_started` event in the window. Anonymous sessions are
+  excluded (no stable identity). This is the denominator for COGS per active
+  user.
+- **`est_claude_cost_usd` / `est_cogs_per_active_user`** — **estimates
+  covering Claude spend only** (Google Places and other provider calls are
+  not metered — deferred, see Out of Scope). Computed from the
+  `plan_session_completed` token sums at the published claude-sonnet-4-6
+  prices, pinned in one const block in `analytics.go` (update it if the /plan
+  model changes):
+
+  | Token class | USD per MTok |
+  |---|---|
+  | input (uncached) | 3.00 |
+  | output | 15.00 |
+  | cache write (5-minute TTL, 1.25× input) | 3.75 |
+  | cache read (0.1× input) | 0.30 |
+
+  `est_claude_cost_usd = (input·3.00 + output·15.00 + cache_write·3.75 +
+  cache_read·0.30) / 1,000,000`, and `est_cogs_per_active_user =
+  est_claude_cost_usd / active_users` (0 when there are no active users).
+  `input_tokens` is the uncached remainder as reported by the API — cache
+  reads/writes are billed separately, so the four classes are summed, never
+  double-counted.
+- **`agent_loop_cap_hits`** — the metric formerly named `plan_cap_hits`:
+  completed plan sessions whose metadata carries `max_iterations_hit = true`.
+  The underlying event is unchanged; only the label moved. Rationale: the cap
+  it counts is the **agent-loop max-iterations safety cap** in
+  `plan_handler.go` — a runaway-agent-loop signal — not a free-tier usage cap,
+  so calling it "cap hits" next to the business model's "cap-hit rate" (% of
+  users hitting free limits) invited a wrong pricing read. When free-tier
+  limits exist, their metric will be a separate, user-denominated number.
 
 Server-side events have no API surface — they are recorded inside the existing
 flows they describe.
@@ -144,5 +198,7 @@ flows they describe.
 
 None — resolved with the product owner before implementation:
 - "Returning user" = planning sessions on ≥2 distinct days within the window.
+  (Later renamed `session_frequency_returning`; true trip retention is the
+  separate `second_trip_retention` — see Derived Metric Definitions.)
 - `onboarding_completed` does not distinguish finish vs. skip; the existing
   onboarding-complete contract stays untouched.

--- a/src/packages/api/admin_integration_test.go
+++ b/src/packages/api/admin_integration_test.go
@@ -1,8 +1,12 @@
 package main
 
 import (
+	"context"
 	"net/http"
 	"testing"
+	"time"
+
+	"github.com/google/uuid"
 )
 
 func TestAdminRoutesRequireAdmin(t *testing.T) {
@@ -37,5 +41,87 @@ func TestAdminMetricsForAdmin(t *testing.T) {
 	body := decode(t, rec)
 	if body["days"] != float64(7) {
 		t.Fatalf("days = %v, want 7", body["days"])
+	}
+}
+
+// insertEvent writes an analytics event with an explicit created_at so tests
+// can shape retention windows (recordEvent always stamps now()).
+func insertEvent(t *testing.T, userID uuid.UUID, eventType string, at time.Time, metadata string) {
+	t.Helper()
+	var meta any
+	if metadata != "" {
+		meta = metadata
+	}
+	_, err := dbPool.Exec(context.Background(),
+		`INSERT INTO analytics_events (user_id, event_type, metadata, created_at)
+		 VALUES ($1, $2, $3, $4)`, userID, eventType, meta, at)
+	if err != nil {
+		t.Fatalf("insertEvent(%s): %v", eventType, err)
+	}
+}
+
+// TestAdminMetricsValues seeds a shaped event log and asserts the grouped
+// counts, second-trip retention (≥2 trip_created events ≥7 days apart), MAU,
+// the Claude cost estimate, and the plan_cap_hits → agent_loop_cap_hits /
+// returning_users → session_frequency_returning renames.
+func TestAdminMetricsValues(t *testing.T) {
+	resetDB(t)
+	admin, adminToken := createTestUser(t, "admin2@example.com")
+	makeAdmin(t, admin.ID)
+	userA, _ := createTestUser(t, "retained@example.com")
+	userB, _ := createTestUser(t, "notyet@example.com")
+
+	now := time.Now()
+	insertEvent(t, userA.ID, "user_registered", now, "")
+	insertEvent(t, userB.ID, "user_registered", now, "")
+
+	// A: two trips 8 days apart => counts toward second_trip_retention.
+	insertEvent(t, userA.ID, "trip_created", now.AddDate(0, 0, -8), "")
+	insertEvent(t, userA.ID, "trip_created", now, "")
+	// B: two trips only 2 days apart => session enthusiasm, not retention.
+	insertEvent(t, userB.ID, "trip_created", now.AddDate(0, 0, -2), "")
+	insertEvent(t, userB.ID, "trip_created", now, "")
+
+	// A is the sole active (MAU) user; one completed session that hit the
+	// agent-loop cap and burned exactly 1M input + 1M output tokens
+	// => est cost $3 + $15 = $18, all attributed to the one active user.
+	insertEvent(t, userA.ID, "plan_session_started", now, "")
+	insertEvent(t, userA.ID, "plan_session_completed", now,
+		`{"input_tokens":1000000,"output_tokens":1000000,"cache_read_tokens":0,"cache_creation_tokens":0,"max_iterations_hit":true}`)
+
+	rec := doJSON(t, "GET", "/api/v1/admin/metrics?days=30", adminToken, nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("admin metrics = %d: %s", rec.Code, rec.Body.String())
+	}
+	body := decode(t, rec)
+
+	// Grouped per-type counts (one GROUP BY query feeds all of these).
+	for field, want := range map[string]float64{
+		"signups":                     2,
+		"trips_created":               4,
+		"second_trip_retention":       1,
+		"session_frequency_returning": 0, // A's sessions all on one day
+		"active_users":                1,
+		"plan_sessions":               1,
+		"agent_loop_cap_hits":         1,
+		"plan_input_tokens":           1000000,
+		"plan_output_tokens":          1000000,
+		"est_claude_cost_usd":         18,
+		"est_cogs_per_active_user":    18,
+	} {
+		if body[field] != want {
+			t.Errorf("%s = %v, want %v", field, body[field], want)
+		}
+	}
+
+	if body["est_cost_model"] != "claude-sonnet-4-6" {
+		t.Errorf("est_cost_model = %v, want claude-sonnet-4-6", body["est_cost_model"])
+	}
+
+	// The old, misleading field names must be gone.
+	for _, gone := range []string{"plan_cap_hits", "returning_users"} {
+		if _, ok := body[gone]; ok {
+			t.Errorf("response still contains renamed field %q", gone)
+		}
 	}
 }

--- a/src/packages/api/analytics.go
+++ b/src/packages/api/analytics.go
@@ -101,7 +101,22 @@ func recordClientEventHandler(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusAccepted)
 }
 
-// MetricsResponse is the Phase 1 dashboard-in-an-endpoint.
+// Claude pricing used for the dashboard's COGS estimates (USD per million
+// tokens), pinned to the model plan_handler.go actually calls. If the /plan
+// model changes, update this block in the same commit. The resulting est_*
+// fields cover Claude spend ONLY — Google Places (and other provider) calls
+// are not metered yet (deferred, per specs/instrumentation-events).
+const (
+	planCostModelID              = "claude-sonnet-4-6"
+	planCostInputUSDPerMTok      = 3.00
+	planCostOutputUSDPerMTok     = 15.00
+	planCostCacheWriteUSDPerMTok = 3.75 // 5-minute-TTL cache write (1.25x input)
+	planCostCacheReadUSDPerMTok  = 0.30 // cache read (0.1x input)
+)
+
+// MetricsResponse is the Phase 1 dashboard-in-an-endpoint, keyed to the
+// questions in docs/business-model.md §8 (activation, second-trip retention,
+// attach rate, COGS per active user, cap-hit rate).
 type MetricsResponse struct {
 	Days                  int              `json:"days"`
 	Signups               int64            `json:"signups"`
@@ -115,16 +130,36 @@ type MetricsResponse struct {
 	BookingClicks         int64            `json:"booking_clicks"`
 	ClicksByProvider      map[string]int64 `json:"clicks_by_provider"`
 	TodosMarkedBooked     int64            `json:"todos_marked_booked"`
-	ReturningUsers        int64            `json:"returning_users"`
-	PlanSessions          int64            `json:"plan_sessions"`
-	PlanSessionsAnonymous int64            `json:"plan_sessions_anonymous"`
-	PlanCapHits           int64            `json:"plan_cap_hits"`
-	PlanInputTokens       int64            `json:"plan_input_tokens"`
-	PlanOutputTokens      int64            `json:"plan_output_tokens"`
-	PlanCacheReadTokens   int64            `json:"plan_cache_read_tokens"`
-	PlanCacheCreateTokens int64            `json:"plan_cache_creation_tokens"`
-	AlertsCreated         int64            `json:"alerts_created"`
-	AlertsTriggered       int64            `json:"alerts_triggered"`
+	// SecondTripRetention answers the business model's actual retention
+	// question: users who created >= 2 trips at least 7 days apart in the
+	// window (the Phase 3 "retention proven across >= 2 trips" trigger).
+	SecondTripRetention int64 `json:"second_trip_retention"`
+	// SessionFrequencyReturning is the old "returning users" number — plan
+	// sessions on >= 2 distinct days. Kept as a session-frequency signal;
+	// it is NOT trip retention (hence the rename from returning_users).
+	SessionFrequencyReturning int64 `json:"session_frequency_returning"`
+	// ActiveUsers is MAU within the window: distinct signed-in users with
+	// >= 1 plan_session_started. The COGS-per-user denominator.
+	ActiveUsers           int64 `json:"active_users"`
+	PlanSessions          int64 `json:"plan_sessions"`
+	PlanSessionsAnonymous int64 `json:"plan_sessions_anonymous"`
+	// AgentLoopCapHits counts sessions whose agent loop hit the
+	// max-iterations safety cap (metadata max_iterations_hit) — a
+	// runaway-loop signal, not free-tier pressure. Formerly plan_cap_hits.
+	AgentLoopCapHits      int64 `json:"agent_loop_cap_hits"`
+	PlanInputTokens       int64 `json:"plan_input_tokens"`
+	PlanOutputTokens      int64 `json:"plan_output_tokens"`
+	PlanCacheReadTokens   int64 `json:"plan_cache_read_tokens"`
+	PlanCacheCreateTokens int64 `json:"plan_cache_creation_tokens"`
+	// EstClaudeCostUSD / EstCogsPerActiveUser are ESTIMATES covering Claude
+	// spend only, from the planCost* pricing constants (Places calls are
+	// not counted — deferred). EstCostModel names the model whose pricing
+	// produced them, so the number is self-describing.
+	EstCostModel         string  `json:"est_cost_model"`
+	EstClaudeCostUSD     float64 `json:"est_claude_cost_usd"`
+	EstCogsPerActiveUser float64 `json:"est_cogs_per_active_user"`
+	AlertsCreated        int64   `json:"alerts_created"`
+	AlertsTriggered      int64   `json:"alerts_triggered"`
 }
 
 // adminMetricsHandler is GET /api/v1/admin/metrics?days= (admin only; gated
@@ -142,26 +177,26 @@ func adminMetricsHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	q := store.New(dbPool)
 
-	count := func(eventType string) int64 {
-		n, err := q.CountEventsByType(ctx, store.CountEventsByTypeParams{
-			EventType: eventType, CreatedAt: since,
-		})
-		if err != nil {
-			log.Printf("metrics: count %s: %v", eventType, err)
+	// One GROUP BY round trip replaces the previous per-type count queries.
+	counts := map[string]int64{}
+	if rows, err := q.CountEventsByTypeGrouped(ctx, since); err == nil {
+		for _, row := range rows {
+			counts[row.EventType] = row.N
 		}
-		return n
+	} else {
+		log.Printf("metrics: grouped counts: %v", err)
 	}
 
 	resp := MetricsResponse{
 		Days:                 days,
-		Signups:              count("user_registered"),
-		OnboardingsCompleted: count("onboarding_completed"),
-		TripsCreated:         count("trip_created"),
-		TripsRefined:         count("trip_refined"),
-		BookingClicks:        count("booking_link_clicked"),
-		TodosMarkedBooked:    count("booking_marked_booked"),
-		AlertsCreated:        count("alert_created"),
-		AlertsTriggered:      count("alert_triggered"),
+		Signups:              counts["user_registered"],
+		OnboardingsCompleted: counts["onboarding_completed"],
+		TripsCreated:         counts["trip_created"],
+		TripsRefined:         counts["trip_refined"],
+		BookingClicks:        counts["booking_link_clicked"],
+		TodosMarkedBooked:    counts["booking_marked_booked"],
+		AlertsCreated:        counts["alert_created"],
+		AlertsTriggered:      counts["alert_triggered"],
 		ClicksByProvider:     map[string]int64{},
 	}
 	if n, err := q.CountActivatedSignups(ctx, since); err == nil {
@@ -183,19 +218,28 @@ func adminMetricsHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	if totals, err := q.PlanSessionTotals(ctx, since); err == nil {
 		resp.PlanSessions = totals.Sessions
+		resp.PlanSessionsAnonymous = totals.AnonymousSessions
+		resp.AgentLoopCapHits = totals.AgentLoopCapHits
 		resp.PlanInputTokens = totals.InputTokens
 		resp.PlanOutputTokens = totals.OutputTokens
 		resp.PlanCacheReadTokens = totals.CacheReadTokens
 		resp.PlanCacheCreateTokens = totals.CacheCreationTokens
 	}
-	if n, err := q.CountAnonymousPlanSessions(ctx, since); err == nil {
-		resp.PlanSessionsAnonymous = n
+	if eng, err := q.UserEngagementCounts(ctx, since); err == nil {
+		resp.ActiveUsers = eng.ActiveUsers
+		resp.SessionFrequencyReturning = eng.SessionFrequencyReturning
+		resp.SecondTripRetention = eng.SecondTripRetention
 	}
-	if n, err := q.CountPlanCapHits(ctx, since); err == nil {
-		resp.PlanCapHits = n
-	}
-	if n, err := q.CountReturningUsers(ctx, since); err == nil {
-		resp.ReturningUsers = n
+	// Estimated Claude spend for the window (Claude only; Places not
+	// counted). input_tokens is the uncached remainder — cache reads and
+	// writes are billed separately at their own rates.
+	resp.EstCostModel = planCostModelID
+	resp.EstClaudeCostUSD = (float64(resp.PlanInputTokens)*planCostInputUSDPerMTok +
+		float64(resp.PlanOutputTokens)*planCostOutputUSDPerMTok +
+		float64(resp.PlanCacheCreateTokens)*planCostCacheWriteUSDPerMTok +
+		float64(resp.PlanCacheReadTokens)*planCostCacheReadUSDPerMTok) / 1e6
+	if resp.ActiveUsers > 0 {
+		resp.EstCogsPerActiveUser = resp.EstClaudeCostUSD / float64(resp.ActiveUsers)
 	}
 	writeJSON(w, http.StatusOK, resp)
 }

--- a/src/packages/api/query/analytics.sql
+++ b/src/packages/api/query/analytics.sql
@@ -2,9 +2,12 @@
 INSERT INTO analytics_events (user_id, event_type, trip_id, metadata)
 VALUES ($1, $2, $3, $4);
 
--- name: CountEventsByType :one
-SELECT count(*) FROM analytics_events
-WHERE event_type = $1 AND created_at >= $2;
+-- name: CountEventsByTypeGrouped :many
+-- All per-type counts for the metrics window in one round trip (the dashboard
+-- previously issued one CountEventsByType query per headline number).
+SELECT event_type, count(*)::bigint AS n FROM analytics_events
+WHERE created_at >= $1
+GROUP BY event_type;
 
 -- name: CountActivatedSignups :one
 -- Users who registered in the window and have saved at least one trip (ever).
@@ -23,8 +26,12 @@ WHERE event_type = 'booking_link_clicked' AND created_at >= $1
 GROUP BY 1 ORDER BY clicks DESC;
 
 -- name: PlanSessionTotals :one
--- Sessions + token spend from plan_session_completed metadata.
+-- Sessions + token spend from plan_session_completed metadata, plus the
+-- anonymous split and agent-loop cap hits (all filters over the same
+-- completed-session denominator, folded into one round trip).
 SELECT count(*) AS sessions,
+       count(*) FILTER (WHERE user_id IS NULL)::bigint AS anonymous_sessions,
+       count(*) FILTER (WHERE (metadata->>'max_iterations_hit')::boolean)::bigint AS agent_loop_cap_hits,
        COALESCE(sum((metadata->>'input_tokens')::bigint), 0)::bigint AS input_tokens,
        COALESCE(sum((metadata->>'output_tokens')::bigint), 0)::bigint AS output_tokens,
        COALESCE(sum((metadata->>'cache_read_tokens')::bigint), 0)::bigint AS cache_read_tokens,
@@ -32,25 +39,34 @@ SELECT count(*) AS sessions,
 FROM analytics_events
 WHERE event_type = 'plan_session_completed' AND created_at >= $1;
 
--- name: CountAnonymousPlanSessions :one
--- Counts COMPLETED sessions so the anonymous split shares PlanSessionTotals'
--- denominator (started vs completed would mix event streams).
-SELECT count(*) FROM analytics_events
-WHERE event_type = 'plan_session_completed' AND user_id IS NULL AND created_at >= $1;
-
--- name: CountPlanCapHits :one
--- Sessions that hit the agent-loop iteration cap (free-tier pressure signal).
-SELECT count(*) FROM analytics_events
-WHERE event_type = 'plan_session_completed'
-  AND (metadata->>'max_iterations_hit')::boolean
-  AND created_at >= $1;
-
--- name: CountReturningUsers :one
--- Users with planning sessions on at least two distinct days in the window.
--- user_id IS NOT NULL: anonymous sessions must not group into a phantom user.
-SELECT count(*) FROM (
-  SELECT user_id FROM analytics_events
-  WHERE event_type = 'plan_session_started' AND user_id IS NOT NULL AND created_at >= $1
-  GROUP BY user_id
-  HAVING count(DISTINCT date(created_at)) >= 2
-) returning_users;
+-- name: UserEngagementCounts :one
+-- The three user-level engagement numbers in one round trip.
+-- user_id IS NOT NULL everywhere: anonymous sessions must not group into a
+-- phantom user.
+--   active_users               — MAU: distinct users who started >= 1 planning
+--                                session in the window.
+--   session_frequency_returning — users with planning sessions on >= 2 distinct
+--                                days (a session-frequency proxy; NOT trip
+--                                retention).
+--   second_trip_retention      — users with >= 2 trip_created events >= 7 days
+--                                apart (the business model's "returned for a
+--                                second trip" signal; max-min >= 7 days implies
+--                                >= 2 events).
+SELECT
+  (SELECT count(DISTINCT a.user_id) FROM analytics_events a
+   WHERE a.event_type = 'plan_session_started' AND a.user_id IS NOT NULL
+     AND a.created_at >= $1)::bigint AS active_users,
+  (SELECT count(*) FROM (
+     SELECT b.user_id FROM analytics_events b
+     WHERE b.event_type = 'plan_session_started' AND b.user_id IS NOT NULL
+       AND b.created_at >= $1
+     GROUP BY b.user_id
+     HAVING count(DISTINCT date(b.created_at)) >= 2
+   ) s)::bigint AS session_frequency_returning,
+  (SELECT count(*) FROM (
+     SELECT c.user_id FROM analytics_events c
+     WHERE c.event_type = 'trip_created' AND c.user_id IS NOT NULL
+       AND c.created_at >= $1
+     GROUP BY c.user_id
+     HAVING max(c.created_at) - min(c.created_at) >= interval '7 days'
+   ) t)::bigint AS second_trip_retention;

--- a/src/packages/api/store/analytics.sql.go
+++ b/src/packages/api/store/analytics.sql.go
@@ -58,68 +58,37 @@ func (q *Queries) CountActivatedSignups(ctx context.Context, createdAt time.Time
 	return count, err
 }
 
-const countAnonymousPlanSessions = `-- name: CountAnonymousPlanSessions :one
-SELECT count(*) FROM analytics_events
-WHERE event_type = 'plan_session_completed' AND user_id IS NULL AND created_at >= $1
+const countEventsByTypeGrouped = `-- name: CountEventsByTypeGrouped :many
+SELECT event_type, count(*)::bigint AS n FROM analytics_events
+WHERE created_at >= $1
+GROUP BY event_type
 `
 
-// Counts COMPLETED sessions so the anonymous split shares PlanSessionTotals'
-// denominator (started vs completed would mix event streams).
-func (q *Queries) CountAnonymousPlanSessions(ctx context.Context, createdAt time.Time) (int64, error) {
-	row := q.db.QueryRow(ctx, countAnonymousPlanSessions, createdAt)
-	var count int64
-	err := row.Scan(&count)
-	return count, err
+type CountEventsByTypeGroupedRow struct {
+	EventType string `json:"event_type"`
+	N         int64  `json:"n"`
 }
 
-const countEventsByType = `-- name: CountEventsByType :one
-SELECT count(*) FROM analytics_events
-WHERE event_type = $1 AND created_at >= $2
-`
-
-type CountEventsByTypeParams struct {
-	EventType string    `json:"event_type"`
-	CreatedAt time.Time `json:"created_at"`
-}
-
-func (q *Queries) CountEventsByType(ctx context.Context, arg CountEventsByTypeParams) (int64, error) {
-	row := q.db.QueryRow(ctx, countEventsByType, arg.EventType, arg.CreatedAt)
-	var count int64
-	err := row.Scan(&count)
-	return count, err
-}
-
-const countPlanCapHits = `-- name: CountPlanCapHits :one
-SELECT count(*) FROM analytics_events
-WHERE event_type = 'plan_session_completed'
-  AND (metadata->>'max_iterations_hit')::boolean
-  AND created_at >= $1
-`
-
-// Sessions that hit the agent-loop iteration cap (free-tier pressure signal).
-func (q *Queries) CountPlanCapHits(ctx context.Context, createdAt time.Time) (int64, error) {
-	row := q.db.QueryRow(ctx, countPlanCapHits, createdAt)
-	var count int64
-	err := row.Scan(&count)
-	return count, err
-}
-
-const countReturningUsers = `-- name: CountReturningUsers :one
-SELECT count(*) FROM (
-  SELECT user_id FROM analytics_events
-  WHERE event_type = 'plan_session_started' AND user_id IS NOT NULL AND created_at >= $1
-  GROUP BY user_id
-  HAVING count(DISTINCT date(created_at)) >= 2
-) returning_users
-`
-
-// Users with planning sessions on at least two distinct days in the window.
-// user_id IS NOT NULL: anonymous sessions must not group into a phantom user.
-func (q *Queries) CountReturningUsers(ctx context.Context, createdAt time.Time) (int64, error) {
-	row := q.db.QueryRow(ctx, countReturningUsers, createdAt)
-	var count int64
-	err := row.Scan(&count)
-	return count, err
+// All per-type counts for the metrics window in one round trip (the dashboard
+// previously issued one CountEventsByType query per headline number).
+func (q *Queries) CountEventsByTypeGrouped(ctx context.Context, createdAt time.Time) ([]CountEventsByTypeGroupedRow, error) {
+	rows, err := q.db.Query(ctx, countEventsByTypeGrouped, createdAt)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []CountEventsByTypeGroupedRow
+	for rows.Next() {
+		var i CountEventsByTypeGroupedRow
+		if err := rows.Scan(&i.EventType, &i.N); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }
 
 const countTripsWithBookingClick = `-- name: CountTripsWithBookingClick :one
@@ -158,6 +127,8 @@ func (q *Queries) CreateAnalyticsEvent(ctx context.Context, arg CreateAnalyticsE
 
 const planSessionTotals = `-- name: PlanSessionTotals :one
 SELECT count(*) AS sessions,
+       count(*) FILTER (WHERE user_id IS NULL)::bigint AS anonymous_sessions,
+       count(*) FILTER (WHERE (metadata->>'max_iterations_hit')::boolean)::bigint AS agent_loop_cap_hits,
        COALESCE(sum((metadata->>'input_tokens')::bigint), 0)::bigint AS input_tokens,
        COALESCE(sum((metadata->>'output_tokens')::bigint), 0)::bigint AS output_tokens,
        COALESCE(sum((metadata->>'cache_read_tokens')::bigint), 0)::bigint AS cache_read_tokens,
@@ -168,22 +139,75 @@ WHERE event_type = 'plan_session_completed' AND created_at >= $1
 
 type PlanSessionTotalsRow struct {
 	Sessions            int64 `json:"sessions"`
+	AnonymousSessions   int64 `json:"anonymous_sessions"`
+	AgentLoopCapHits    int64 `json:"agent_loop_cap_hits"`
 	InputTokens         int64 `json:"input_tokens"`
 	OutputTokens        int64 `json:"output_tokens"`
 	CacheReadTokens     int64 `json:"cache_read_tokens"`
 	CacheCreationTokens int64 `json:"cache_creation_tokens"`
 }
 
-// Sessions + token spend from plan_session_completed metadata.
+// Sessions + token spend from plan_session_completed metadata, plus the
+// anonymous split and agent-loop cap hits (all filters over the same
+// completed-session denominator, folded into one round trip).
 func (q *Queries) PlanSessionTotals(ctx context.Context, createdAt time.Time) (PlanSessionTotalsRow, error) {
 	row := q.db.QueryRow(ctx, planSessionTotals, createdAt)
 	var i PlanSessionTotalsRow
 	err := row.Scan(
 		&i.Sessions,
+		&i.AnonymousSessions,
+		&i.AgentLoopCapHits,
 		&i.InputTokens,
 		&i.OutputTokens,
 		&i.CacheReadTokens,
 		&i.CacheCreationTokens,
 	)
+	return i, err
+}
+
+const userEngagementCounts = `-- name: UserEngagementCounts :one
+SELECT
+  (SELECT count(DISTINCT a.user_id) FROM analytics_events a
+   WHERE a.event_type = 'plan_session_started' AND a.user_id IS NOT NULL
+     AND a.created_at >= $1)::bigint AS active_users,
+  (SELECT count(*) FROM (
+     SELECT b.user_id FROM analytics_events b
+     WHERE b.event_type = 'plan_session_started' AND b.user_id IS NOT NULL
+       AND b.created_at >= $1
+     GROUP BY b.user_id
+     HAVING count(DISTINCT date(b.created_at)) >= 2
+   ) s)::bigint AS session_frequency_returning,
+  (SELECT count(*) FROM (
+     SELECT c.user_id FROM analytics_events c
+     WHERE c.event_type = 'trip_created' AND c.user_id IS NOT NULL
+       AND c.created_at >= $1
+     GROUP BY c.user_id
+     HAVING max(c.created_at) - min(c.created_at) >= interval '7 days'
+   ) t)::bigint AS second_trip_retention
+`
+
+type UserEngagementCountsRow struct {
+	ActiveUsers               int64 `json:"active_users"`
+	SessionFrequencyReturning int64 `json:"session_frequency_returning"`
+	SecondTripRetention       int64 `json:"second_trip_retention"`
+}
+
+// The three user-level engagement numbers in one round trip.
+// user_id IS NOT NULL everywhere: anonymous sessions must not group into a
+// phantom user.
+//
+//	active_users               — MAU: distinct users who started >= 1 planning
+//	                             session in the window.
+//	session_frequency_returning — users with planning sessions on >= 2 distinct
+//	                             days (a session-frequency proxy; NOT trip
+//	                             retention).
+//	second_trip_retention      — users with >= 2 trip_created events >= 7 days
+//	                             apart (the business model's "returned for a
+//	                             second trip" signal; max-min >= 7 days implies
+//	                             >= 2 events).
+func (q *Queries) UserEngagementCounts(ctx context.Context, createdAt time.Time) (UserEngagementCountsRow, error) {
+	row := q.db.QueryRow(ctx, userEngagementCounts, createdAt)
+	var i UserEngagementCountsRow
+	err := row.Scan(&i.ActiveUsers, &i.SessionFrequencyReturning, &i.SecondTripRetention)
 	return i, err
 }

--- a/src/packages/flutter-app/lib/models/admin_metrics.dart
+++ b/src/packages/flutter-app/lib/models/admin_metrics.dart
@@ -28,14 +28,29 @@ class AdminMetrics {
   final Map<String, int> clicksByProvider;
   @JsonKey(name: 'todos_marked_booked')
   final int todosMarkedBooked;
-  @JsonKey(name: 'returning_users')
-  final int returningUsers;
+
+  /// Users with >= 2 trip_created events >= 7 days apart in the window —
+  /// the business model's "returned for a second trip" retention signal.
+  @JsonKey(name: 'second_trip_retention')
+  final int secondTripRetention;
+
+  /// Users with plan sessions on >= 2 distinct days (session frequency,
+  /// NOT trip retention — formerly `returning_users`).
+  @JsonKey(name: 'session_frequency_returning')
+  final int sessionFrequencyReturning;
+
+  /// MAU: distinct signed-in users with >= 1 plan session in the window.
+  @JsonKey(name: 'active_users')
+  final int activeUsers;
   @JsonKey(name: 'plan_sessions')
   final int planSessions;
   @JsonKey(name: 'plan_sessions_anonymous')
   final int planSessionsAnonymous;
-  @JsonKey(name: 'plan_cap_hits')
-  final int planCapHits;
+
+  /// Sessions whose agent loop hit the max-iterations safety cap (a
+  /// runaway-loop signal — formerly `plan_cap_hits`).
+  @JsonKey(name: 'agent_loop_cap_hits')
+  final int agentLoopCapHits;
   @JsonKey(name: 'plan_input_tokens')
   final int planInputTokens;
   @JsonKey(name: 'plan_output_tokens')
@@ -44,6 +59,15 @@ class AdminMetrics {
   final int planCacheReadTokens;
   @JsonKey(name: 'plan_cache_creation_tokens')
   final int planCacheCreationTokens;
+
+  /// Estimated Claude spend for the window in USD (Claude only — Places
+  /// calls are not counted).
+  @JsonKey(name: 'est_claude_cost_usd')
+  final double estClaudeCostUsd;
+
+  /// estClaudeCostUsd / activeUsers — the §8 COGS-per-active-user estimate.
+  @JsonKey(name: 'est_cogs_per_active_user')
+  final double estCogsPerActiveUser;
   @JsonKey(name: 'alerts_created')
   final int alertsCreated;
   @JsonKey(name: 'alerts_triggered')
@@ -62,14 +86,18 @@ class AdminMetrics {
     this.bookingClicks = 0,
     this.clicksByProvider = const {},
     this.todosMarkedBooked = 0,
-    this.returningUsers = 0,
+    this.secondTripRetention = 0,
+    this.sessionFrequencyReturning = 0,
+    this.activeUsers = 0,
     this.planSessions = 0,
     this.planSessionsAnonymous = 0,
-    this.planCapHits = 0,
+    this.agentLoopCapHits = 0,
     this.planInputTokens = 0,
     this.planOutputTokens = 0,
     this.planCacheReadTokens = 0,
     this.planCacheCreationTokens = 0,
+    this.estClaudeCostUsd = 0,
+    this.estCogsPerActiveUser = 0,
     this.alertsCreated = 0,
     this.alertsTriggered = 0,
   });

--- a/src/packages/flutter-app/lib/models/admin_metrics.g.dart
+++ b/src/packages/flutter-app/lib/models/admin_metrics.g.dart
@@ -25,17 +25,24 @@ AdminMetrics _$AdminMetricsFromJson(Map<String, dynamic> json) => AdminMetrics(
               ) ??
               const {},
       todosMarkedBooked: (json['todos_marked_booked'] as num?)?.toInt() ?? 0,
-      returningUsers: (json['returning_users'] as num?)?.toInt() ?? 0,
+      secondTripRetention:
+          (json['second_trip_retention'] as num?)?.toInt() ?? 0,
+      sessionFrequencyReturning:
+          (json['session_frequency_returning'] as num?)?.toInt() ?? 0,
+      activeUsers: (json['active_users'] as num?)?.toInt() ?? 0,
       planSessions: (json['plan_sessions'] as num?)?.toInt() ?? 0,
       planSessionsAnonymous:
           (json['plan_sessions_anonymous'] as num?)?.toInt() ?? 0,
-      planCapHits: (json['plan_cap_hits'] as num?)?.toInt() ?? 0,
+      agentLoopCapHits: (json['agent_loop_cap_hits'] as num?)?.toInt() ?? 0,
       planInputTokens: (json['plan_input_tokens'] as num?)?.toInt() ?? 0,
       planOutputTokens: (json['plan_output_tokens'] as num?)?.toInt() ?? 0,
       planCacheReadTokens:
           (json['plan_cache_read_tokens'] as num?)?.toInt() ?? 0,
       planCacheCreationTokens:
           (json['plan_cache_creation_tokens'] as num?)?.toInt() ?? 0,
+      estClaudeCostUsd: (json['est_claude_cost_usd'] as num?)?.toDouble() ?? 0,
+      estCogsPerActiveUser:
+          (json['est_cogs_per_active_user'] as num?)?.toDouble() ?? 0,
       alertsCreated: (json['alerts_created'] as num?)?.toInt() ?? 0,
       alertsTriggered: (json['alerts_triggered'] as num?)?.toInt() ?? 0,
     );
@@ -54,14 +61,18 @@ Map<String, dynamic> _$AdminMetricsToJson(AdminMetrics instance) =>
       'booking_clicks': instance.bookingClicks,
       'clicks_by_provider': instance.clicksByProvider,
       'todos_marked_booked': instance.todosMarkedBooked,
-      'returning_users': instance.returningUsers,
+      'second_trip_retention': instance.secondTripRetention,
+      'session_frequency_returning': instance.sessionFrequencyReturning,
+      'active_users': instance.activeUsers,
       'plan_sessions': instance.planSessions,
       'plan_sessions_anonymous': instance.planSessionsAnonymous,
-      'plan_cap_hits': instance.planCapHits,
+      'agent_loop_cap_hits': instance.agentLoopCapHits,
       'plan_input_tokens': instance.planInputTokens,
       'plan_output_tokens': instance.planOutputTokens,
       'plan_cache_read_tokens': instance.planCacheReadTokens,
       'plan_cache_creation_tokens': instance.planCacheCreationTokens,
+      'est_claude_cost_usd': instance.estClaudeCostUsd,
+      'est_cogs_per_active_user': instance.estCogsPerActiveUser,
       'alerts_created': instance.alertsCreated,
       'alerts_triggered': instance.alertsTriggered,
     };

--- a/src/packages/flutter-app/lib/screens/admin_metrics_screen.dart
+++ b/src/packages/flutter-app/lib/screens/admin_metrics_screen.dart
@@ -81,6 +81,8 @@ class _MetricsBody extends StatelessWidget {
     return '$v';
   }
 
+  String _usd(double v) => '\$${v.toStringAsFixed(2)}';
+
   @override
   Widget build(BuildContext context) {
     final m = metrics;
@@ -94,7 +96,10 @@ class _MetricsBody extends StatelessWidget {
           _Stat('Activated', '${m.activatedSignups}',
               caption: _pct(m.activationRate)),
           _Stat('Onboardings', '${m.onboardingsCompleted}'),
-          _Stat('Returning users', '${m.returningUsers}'),
+          _Stat('Second-trip retention', '${m.secondTripRetention}',
+              caption: '≥2 trips ≥7 days apart'),
+          _Stat('Multi-day planners', '${m.sessionFrequencyReturning}',
+              caption: 'sessions on ≥2 days'),
         ]),
         const SizedBox(height: AppSpacing.xl),
         const SectionHeader(title: 'Trips & bookings'),
@@ -115,12 +120,17 @@ class _MetricsBody extends StatelessWidget {
         const SectionHeader(title: 'AI planning'),
         const SizedBox(height: AppSpacing.sm),
         _TileGrid(tiles: [
+          _Stat('Active users (MAU)', '${m.activeUsers}'),
+          _Stat('Est. cost / active user', _usd(m.estCogsPerActiveUser),
+              caption: 'Claude only, estimate'),
           _Stat('Plan sessions', '${m.planSessions}',
               caption: '${m.planSessionsAnonymous} anonymous'),
-          _Stat('Cap hits', '${m.planCapHits}'),
+          _Stat('Agent loop cap hits', '${m.agentLoopCapHits}',
+              caption: 'runaway-loop signal'),
           _Stat('Tokens in', _tokens(m.planInputTokens),
               caption: '${_tokens(m.planCacheReadTokens)} from cache'),
-          _Stat('Tokens out', _tokens(m.planOutputTokens)),
+          _Stat('Tokens out', _tokens(m.planOutputTokens),
+              caption: 'est. ${_usd(m.estClaudeCostUsd)} total'),
         ]),
         const SizedBox(height: AppSpacing.xl),
         const SectionHeader(title: 'Price alerts'),

--- a/src/packages/flutter-app/test/admin_metrics_screen_test.dart
+++ b/src/packages/flutter-app/test/admin_metrics_screen_test.dart
@@ -22,12 +22,16 @@ void main() {
       attachRate: 0.15,
       bookingClicks: 12,
       clicksByProvider: {'booking': 8, 'airbnb': 4},
+      secondTripRetention: 7,
+      activeUsers: 60,
       planSessions: 100,
       planSessionsAnonymous: 40,
-      planCapHits: 2,
+      agentLoopCapHits: 2,
       planInputTokens: 1500000,
       planOutputTokens: 250000,
       planCacheReadTokens: 900000,
+      estClaudeCostUsd: 12.5,
+      estCogsPerActiveUser: 0.21,
       alertsCreated: 5,
       alertsTriggered: 1,
     );
@@ -48,6 +52,12 @@ void main() {
     expect(find.text('40 anonymous'), findsOneWidget);
     expect(find.text('1.5M'), findsOneWidget); // tokens in
     expect(find.text('900.0k from cache'), findsOneWidget);
+    expect(find.text('7'), findsOneWidget); // second-trip retention
+    expect(find.text('≥2 trips ≥7 days apart'), findsOneWidget);
+    expect(find.text('60'), findsOneWidget); // MAU
+    expect(find.text('\$0.21'), findsOneWidget); // est. cost / active user
+    expect(find.text('Claude only, estimate'), findsOneWidget);
+    expect(find.text('Agent loop cap hits'), findsOneWidget);
     expect(find.text('Clicks by provider'), findsOneWidget);
     expect(find.text('booking'), findsOneWidget);
     expect(find.text('Price alerts'), findsOneWidget);


### PR DESCRIPTION
## What

Makes the admin metrics endpoint/dashboard answer docs/business-model.md §8's actual questions, and clears the deferred per-type-count N+1.

### GROUP BY collapse (N+1 fix)
- The ~8 sequential `CountEventsByType` round-trips are replaced by one `SELECT event_type, count(*) ... GROUP BY event_type` (`CountEventsByTypeGrouped`).
- The anonymous-session split and cap hits fold into `PlanSessionTotals` (`FILTER` clauses over the same denominator); MAU + both retention numbers fold into one `UserEngagementCounts` query.
- **Dashboard load: ~15 queries → 6.**

### MAU + dollar COGS
- `active_users`: distinct signed-in users with ≥1 `plan_session_started` in the window.
- Token sums converted to `est_claude_cost_usd` / `est_cogs_per_active_user` via one named const block pinned to `claude-sonnet-4-6` (per MTok: input $3.00, output $15.00, 5-min cache write $3.75, cache read $0.30); `est_cost_model` names the model so the estimate is self-describing. Labeled as estimates covering **Claude only** — Places metering stays deferred.

### Second-trip retention
- `second_trip_retention`: users with ≥2 `trip_created` events ≥7 days apart (`max(created_at) − min(created_at) ≥ 7 days` per user) — the Phase 3 "retention proven across ≥2 trips" trigger.
- The old ≥2-distinct-days plan-session metric is kept but renamed `returning_users` → `session_frequency_returning` (it's a session-frequency proxy, not trip retention).

### Honest cap label
- `plan_cap_hits` → `agent_loop_cap_hits`: verified it counts `max_iterations_hit` from the plan handler's agent-loop safety cap — a runaway-loop signal, not free-tier pressure. Event name unchanged; label only.

### Flutter + spec
- `AdminMetrics` model updated for all renames/additions (`make flutter-build-models` regenerated the `.g.dart`); new tiles for MAU, est. cost/active user (captioned "Claude only, estimate"), second-trip retention; cap-hits tile relabeled.
- `specs/instrumentation-events/spec.md` gains a normative **Derived Metric Definitions** section (7-day rule, MAU definition, cost formula + pricing table, relabel rationale).

## Testing
- `make api-sqlc` (regenerated store committed), `make api-fmt`, `make api-vet`.
- `go test ./...` unit + full integration run against an isolated `travel_test_pr6` DB — new `TestAdminMetricsValues` seeds a shaped event log and asserts grouped counts, second-trip retention (8-days-apart pair counts, 2-days-apart pair doesn't), MAU, the $18/1M+1M cost math, renamed fields present and old names absent.
- `flutter analyze` (parity with main's pre-existing infos; zero errors) and `flutter test` (39 passing, widget test extended for the new tiles).

🤖 Generated with [Claude Code](https://claude.com/claude-code)