### PR TITLE
feat(flutter): round-trip flight search — return date end-to-end

### DIFF
--- a/src/packages/api/duffel_service.go
+++ b/src/packages/api/duffel_service.go
@@ -64,6 +64,13 @@ type FlightOffer struct {
 	Segments       []FlightLeg `json:"segments"`
 	BookingURL     string      `json:"booking_url,omitempty"`
 
+	// Round-trip only: the return slice's legs and duration. Empty/zero for
+	// one-way searches. Price is always the total across all slices; the
+	// top-level Stops/DurationMin/times stay outbound-based so ranking and
+	// existing one-way consumers are unchanged.
+	ReturnSegments    []FlightLeg `json:"return_segments,omitempty"`
+	ReturnDurationMin int         `json:"return_duration_minutes,omitempty"`
+
 	// Scoring (filled by RankFlightOffers)
 	Score         float64 `json:"score"`
 	PriceScore    float64 `json:"price_score"`
@@ -228,7 +235,8 @@ func (d *DuffelService) placeSuggestions(ctx context.Context, params url.Values)
 
 // SearchFlightOffers creates a Duffel offer request (with offers returned
 // inline) and returns normalized offers (unranked). Stops/duration/times are
-// taken from the outbound slice.
+// taken from the outbound slice; on round trips the return slice is exposed
+// via ReturnSegments/ReturnDurationMin (price is always the round-trip total).
 func (d *DuffelService) SearchFlightOffers(ctx context.Context, req FlightSearchRequest) ([]FlightOffer, error) {
 	adults := req.Adults
 	if adults < 1 {
@@ -291,6 +299,25 @@ func (d *DuffelService) SearchFlightOffers(ctx context.Context, req FlightSearch
 		return nil, err
 	}
 
+	type duffelSegment struct {
+		Origin struct {
+			IataCode string `json:"iata_code"`
+		} `json:"origin"`
+		Destination struct {
+			IataCode string `json:"iata_code"`
+		} `json:"destination"`
+		DepartingAt      string `json:"departing_at"`
+		ArrivingAt       string `json:"arriving_at"`
+		MarketingCarrier struct {
+			Name     string `json:"name"`
+			IataCode string `json:"iata_code"`
+		} `json:"marketing_carrier"`
+		MarketingCarrierFlightNumber string `json:"marketing_carrier_flight_number"`
+	}
+	type duffelSlice struct {
+		Duration string          `json:"duration"`
+		Segments []duffelSegment `json:"segments"`
+	}
 	var result struct {
 		Data struct {
 			Offers []struct {
@@ -302,24 +329,7 @@ func (d *DuffelService) SearchFlightOffers(ctx context.Context, req FlightSearch
 					Name          string `json:"name"`
 					LogoSymbolURL string `json:"logo_symbol_url"`
 				} `json:"owner"`
-				Slices []struct {
-					Duration string `json:"duration"`
-					Segments []struct {
-						Origin struct {
-							IataCode string `json:"iata_code"`
-						} `json:"origin"`
-						Destination struct {
-							IataCode string `json:"iata_code"`
-						} `json:"destination"`
-						DepartingAt      string `json:"departing_at"`
-						ArrivingAt       string `json:"arriving_at"`
-						MarketingCarrier struct {
-							Name     string `json:"name"`
-							IataCode string `json:"iata_code"`
-						} `json:"marketing_carrier"`
-						MarketingCarrierFlightNumber string `json:"marketing_carrier_flight_number"`
-					} `json:"segments"`
-				} `json:"slices"`
+				Slices []duffelSlice `json:"slices"`
 			} `json:"offers"`
 		} `json:"data"`
 	}
@@ -335,41 +345,56 @@ func (d *DuffelService) SearchFlightOffers(ctx context.Context, req FlightSearch
 		outbound := o.Slices[0]
 		segs := outbound.Segments
 
-		legs := make([]FlightLeg, 0, len(segs))
 		airlineSet := map[string]bool{}
 		airlines := []string{}
-		for _, s := range segs {
-			name := s.MarketingCarrier.Name
-			if name == "" {
-				name = s.MarketingCarrier.IataCode
+		toLegs := func(segs []duffelSegment) []FlightLeg {
+			legs := make([]FlightLeg, 0, len(segs))
+			for _, s := range segs {
+				name := s.MarketingCarrier.Name
+				if name == "" {
+					name = s.MarketingCarrier.IataCode
+				}
+				if name != "" && !airlineSet[name] {
+					airlineSet[name] = true
+					airlines = append(airlines, name)
+				}
+				legs = append(legs, FlightLeg{
+					From:         s.Origin.IataCode,
+					To:           s.Destination.IataCode,
+					Carrier:      name,
+					FlightNumber: s.MarketingCarrier.IataCode + s.MarketingCarrierFlightNumber,
+					DepartTime:   s.DepartingAt,
+					ArriveTime:   s.ArrivingAt,
+				})
 			}
-			if name != "" && !airlineSet[name] {
-				airlineSet[name] = true
-				airlines = append(airlines, name)
-			}
-			legs = append(legs, FlightLeg{
-				From:         s.Origin.IataCode,
-				To:           s.Destination.IataCode,
-				Carrier:      name,
-				FlightNumber: s.MarketingCarrier.IataCode + s.MarketingCarrierFlightNumber,
-				DepartTime:   s.DepartingAt,
-				ArriveTime:   s.ArrivingAt,
-			})
+			return legs
+		}
+		legs := toLegs(segs)
+
+		// Round-trip: normalize the return slice too so callers can render
+		// both directions. TotalAmount already covers all slices.
+		var returnLegs []FlightLeg
+		returnDur := 0
+		if len(o.Slices) > 1 && len(o.Slices[1].Segments) > 0 {
+			returnLegs = toLegs(o.Slices[1].Segments)
+			returnDur = parseISO8601Duration(o.Slices[1].Duration)
 		}
 
 		price, _ := strconv.ParseFloat(o.TotalAmount, 64)
 		offers = append(offers, FlightOffer{
-			ID:             o.ID,
-			Price:          price,
-			Currency:       o.TotalCurrency,
-			Stops:          len(segs) - 1,
-			DurationMin:    parseISO8601Duration(outbound.Duration),
-			Airlines:       airlines,
-			AirlineCode:    o.Owner.IataCode,
-			AirlineLogoURL: o.Owner.LogoSymbolURL,
-			DepartTime:     segs[0].DepartingAt,
-			ArriveTime:     segs[len(segs)-1].ArrivingAt,
-			Segments:       legs,
+			ID:                o.ID,
+			Price:             price,
+			Currency:          o.TotalCurrency,
+			Stops:             len(segs) - 1,
+			DurationMin:       parseISO8601Duration(outbound.Duration),
+			Airlines:          airlines,
+			AirlineCode:       o.Owner.IataCode,
+			AirlineLogoURL:    o.Owner.LogoSymbolURL,
+			DepartTime:        segs[0].DepartingAt,
+			ArriveTime:        segs[len(segs)-1].ArrivingAt,
+			Segments:          legs,
+			ReturnSegments:    returnLegs,
+			ReturnDurationMin: returnDur,
 		})
 		if len(offers) >= maxOffers {
 			break

--- a/src/packages/api/duffel_service_test.go
+++ b/src/packages/api/duffel_service_test.go
@@ -75,6 +75,111 @@ func TestSearchFlightOffersPassengerAndCabinPayload(t *testing.T) {
 	}
 }
 
+// stubDuffelWithOffers serves a canned offers payload and captures the request.
+func stubDuffelWithOffers(t *testing.T, captured *map[string]any, offersJSON string) *DuffelService {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		if err := json.Unmarshal(body, captured); err != nil {
+			t.Fatalf("stub could not parse request body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(offersJSON))
+	}))
+	t.Cleanup(srv.Close)
+	return &DuffelService{
+		Token:   "test-token",
+		BaseURL: srv.URL,
+		Version: "v2",
+		Client:  &http.Client{Timeout: 5 * time.Second},
+	}
+}
+
+func TestSearchFlightOffersRoundTrip(t *testing.T) {
+	var captured map[string]any
+	d := stubDuffelWithOffers(t, &captured, `{"data":{"offers":[{
+		"id":"off_rt","total_amount":"842.40","total_currency":"USD",
+		"owner":{"iata_code":"AF","name":"Air France"},
+		"slices":[
+			{"duration":"PT7H30M","segments":[{
+				"origin":{"iata_code":"JFK"},"destination":{"iata_code":"CDG"},
+				"departing_at":"2026-09-01T18:00:00","arriving_at":"2026-09-02T07:30:00",
+				"marketing_carrier":{"name":"Air France","iata_code":"AF"},
+				"marketing_carrier_flight_number":"11"}]},
+			{"duration":"PT8H15M","segments":[{
+				"origin":{"iata_code":"CDG"},"destination":{"iata_code":"JFK"},
+				"departing_at":"2026-09-10T10:00:00","arriving_at":"2026-09-10T12:15:00",
+				"marketing_carrier":{"name":"Delta","iata_code":"DL"},
+				"marketing_carrier_flight_number":"263"}]}
+		]}]}}`)
+
+	offers, err := d.SearchFlightOffers(context.Background(), FlightSearchRequest{
+		Origin: "JFK", Destination: "CDG",
+		DepartDate: "2026-09-01", ReturnDate: "2026-09-10", Adults: 1,
+	})
+	if err != nil {
+		t.Fatalf("SearchFlightOffers: %v", err)
+	}
+
+	// The request must carry two slices, with the return reversed.
+	slices := captured["data"].(map[string]any)["slices"].([]any)
+	if len(slices) != 2 {
+		t.Fatalf("request slices = %d, want 2", len(slices))
+	}
+	ret := slices[1].(map[string]any)
+	if ret["origin"] != "CDG" || ret["destination"] != "JFK" || ret["departure_date"] != "2026-09-10" {
+		t.Fatalf("return slice = %v, want CDG->JFK on 2026-09-10", ret)
+	}
+
+	if len(offers) != 1 {
+		t.Fatalf("offers = %d, want 1", len(offers))
+	}
+	o := offers[0]
+	// Outbound-based fields are unchanged from one-way behavior.
+	if len(o.Segments) != 1 || o.Segments[0].From != "JFK" || o.Segments[0].To != "CDG" {
+		t.Fatalf("outbound segments = %v, want JFK->CDG", o.Segments)
+	}
+	if o.Stops != 0 || o.DurationMin != 7*60+30 {
+		t.Fatalf("stops=%d dur=%d, want 0/450", o.Stops, o.DurationMin)
+	}
+	// The return slice must be preserved for the UI to render both directions.
+	if len(o.ReturnSegments) != 1 || o.ReturnSegments[0].From != "CDG" || o.ReturnSegments[0].To != "JFK" {
+		t.Fatalf("return segments = %v, want CDG->JFK", o.ReturnSegments)
+	}
+	if o.ReturnDurationMin != 8*60+15 {
+		t.Fatalf("return duration = %d, want 495", o.ReturnDurationMin)
+	}
+	// Carriers from both directions are surfaced.
+	if len(o.Airlines) != 2 || o.Airlines[0] != "Air France" || o.Airlines[1] != "Delta" {
+		t.Fatalf("airlines = %v, want [Air France Delta]", o.Airlines)
+	}
+}
+
+func TestSearchFlightOffersOneWayHasNoReturnFields(t *testing.T) {
+	var captured map[string]any
+	d := stubDuffelWithOffers(t, &captured, `{"data":{"offers":[{
+		"id":"off_ow","total_amount":"420.00","total_currency":"USD",
+		"owner":{"iata_code":"AF","name":"Air France"},
+		"slices":[{"duration":"PT7H30M","segments":[{
+			"origin":{"iata_code":"JFK"},"destination":{"iata_code":"CDG"},
+			"departing_at":"2026-09-01T18:00:00","arriving_at":"2026-09-02T07:30:00",
+			"marketing_carrier":{"name":"Air France","iata_code":"AF"},
+			"marketing_carrier_flight_number":"11"}]}]}]}}`)
+
+	offers, err := d.SearchFlightOffers(context.Background(), FlightSearchRequest{
+		Origin: "JFK", Destination: "CDG", DepartDate: "2026-09-01", Adults: 1,
+	})
+	if err != nil {
+		t.Fatalf("SearchFlightOffers: %v", err)
+	}
+	if got := len(captured["data"].(map[string]any)["slices"].([]any)); got != 1 {
+		t.Fatalf("request slices = %d, want 1", got)
+	}
+	if len(offers) != 1 || offers[0].ReturnSegments != nil || offers[0].ReturnDurationMin != 0 {
+		t.Fatalf("one-way offer must carry no return fields: %+v", offers)
+	}
+}
+
 func TestSearchFlightOffersDefaultsToEconomy(t *testing.T) {
 	var captured map[string]any
 	d := stubDuffel(t, &captured)

--- a/src/packages/flutter-app/lib/models/flight_offer.dart
+++ b/src/packages/flutter-app/lib/models/flight_offer.dart
@@ -26,6 +26,14 @@ class FlightOffer {
   @JsonKey(name: 'booking_url')
   final String? bookingUrl;
 
+  /// Round-trip only: the return slice's legs and duration (empty/zero for
+  /// one-way offers). [price] is always the total across both directions;
+  /// [stops]/[durationMinutes]/[departTime]/[arriveTime] stay outbound-based.
+  @JsonKey(name: 'return_segments', defaultValue: <FlightLeg>[])
+  final List<FlightLeg> returnSegments;
+  @JsonKey(name: 'return_duration_minutes', defaultValue: 0)
+  final int returnDurationMinutes;
+
   final double score;
   @JsonKey(name: 'price_score')
   final double priceScore;
@@ -47,22 +55,50 @@ class FlightOffer {
     required this.arriveTime,
     required this.segments,
     this.bookingUrl,
+    this.returnSegments = const [],
+    this.returnDurationMinutes = 0,
     this.score = 0,
     this.priceScore = 0,
     this.durationScore = 0,
     this.stopsScore = 0,
   });
 
-  /// "5h 30m" style duration label.
-  String get durationLabel {
-    final h = durationMinutes ~/ 60;
-    final m = durationMinutes % 60;
+  /// True when the offer carries a return slice (round-trip search).
+  bool get isRoundTrip => returnSegments.isNotEmpty;
+
+  /// Stops on the return slice (0 when one-way or nonstop).
+  int get returnStops => returnSegments.isEmpty ? 0 : returnSegments.length - 1;
+
+  /// "5h 30m" style duration label for the outbound slice.
+  String get durationLabel => _fmtDuration(durationMinutes);
+
+  /// "5h 30m" style duration label for the return slice.
+  String get returnDurationLabel => _fmtDuration(returnDurationMinutes);
+
+  String get stopsLabel => _fmtStops(stops);
+
+  String get returnStopsLabel => _fmtStops(returnStops);
+
+  /// One stops label covering both directions of a round trip — "Nonstop",
+  /// "1 stop each way", or "Nonstop / 1 stop" when they differ. Falls back to
+  /// [stopsLabel] for one-way offers.
+  String get combinedStopsLabel {
+    if (!isRoundTrip) return stopsLabel;
+    if (stops == returnStops) {
+      return stops == 0 ? 'Nonstop' : '$stopsLabel each way';
+    }
+    return '$stopsLabel / $returnStopsLabel';
+  }
+
+  static String _fmtDuration(int minutes) {
+    final h = minutes ~/ 60;
+    final m = minutes % 60;
     if (h == 0) return '${m}m';
     if (m == 0) return '${h}h';
     return '${h}h ${m}m';
   }
 
-  String get stopsLabel => switch (stops) {
+  static String _fmtStops(int stops) => switch (stops) {
         0 => 'Nonstop',
         1 => '1 stop',
         _ => '$stops stops',

--- a/src/packages/flutter-app/lib/models/flight_offer.g.dart
+++ b/src/packages/flutter-app/lib/models/flight_offer.g.dart
@@ -25,6 +25,12 @@ FlightOffer _$FlightOfferFromJson(Map<String, dynamic> json) => FlightOffer(
               .toList() ??
           [],
       bookingUrl: json['booking_url'] as String?,
+      returnSegments: (json['return_segments'] as List<dynamic>?)
+              ?.map((e) => FlightLeg.fromJson(e as Map<String, dynamic>))
+              .toList() ??
+          [],
+      returnDurationMinutes:
+          (json['return_duration_minutes'] as num?)?.toInt() ?? 0,
       score: (json['score'] as num?)?.toDouble() ?? 0,
       priceScore: (json['price_score'] as num?)?.toDouble() ?? 0,
       durationScore: (json['duration_score'] as num?)?.toDouble() ?? 0,
@@ -45,6 +51,9 @@ Map<String, dynamic> _$FlightOfferToJson(FlightOffer instance) =>
       'arrive_time': instance.arriveTime,
       'segments': instance.segments.map((e) => e.toJson()).toList(),
       'booking_url': instance.bookingUrl,
+      'return_segments':
+          instance.returnSegments.map((e) => e.toJson()).toList(),
+      'return_duration_minutes': instance.returnDurationMinutes,
       'score': instance.score,
       'price_score': instance.priceScore,
       'duration_score': instance.durationScore,

--- a/src/packages/flutter-app/lib/screens/flight_search_screen.dart
+++ b/src/packages/flutter-app/lib/screens/flight_search_screen.dart
@@ -45,6 +45,9 @@ class _FlightSearchScreenState extends ConsumerState<FlightSearchScreen> {
   Airport? _origin;
   Airport? _destination;
   DateTime? _departDate;
+
+  /// Optional round-trip return date; null = one-way (the default).
+  DateTime? _returnDate;
   int _adults = 1;
 
   /// One entry per child passenger; the value is the child's age (0–17).
@@ -59,6 +62,7 @@ class _FlightSearchScreenState extends ConsumerState<FlightSearchScreen> {
     String origin,
     String destination,
     String departDate,
+    String? returnDate,
     int adults,
     String cabinClass,
     bool hasChildren,
@@ -209,17 +213,48 @@ class _FlightSearchScreenState extends ConsumerState<FlightSearchScreen> {
       firstDate: now,
       lastDate: now.add(const Duration(days: 365)),
     );
-    if (picked != null) setState(() => _departDate = picked);
+    if (picked != null) {
+      setState(() {
+        _departDate = picked;
+        // A return before the new departure is impossible; clear it rather
+        // than silently guessing a new one.
+        if (_returnDate != null && _returnDate!.isBefore(picked)) {
+          _returnDate = null;
+        }
+      });
+    }
+  }
+
+  /// Picks the optional return date. The picker's floor is the departure date,
+  /// so return < departure is impossible to select (same-day return allowed).
+  Future<void> _pickReturnDate() async {
+    final now = DateTime.now();
+    final first = _departDate ?? now;
+    final last = now.add(const Duration(days: 365));
+    var initial = _returnDate ??
+        _departDate?.add(const Duration(days: 7)) ??
+        now.add(const Duration(days: 21));
+    if (initial.isBefore(first)) initial = first;
+    if (initial.isAfter(last)) initial = last;
+    final picked = await showDatePicker(
+      context: context,
+      initialDate: initial,
+      firstDate: first,
+      lastDate: last,
+    );
+    if (picked != null) setState(() => _returnDate = picked);
   }
 
   void _search() {
     if (!_canSearch) return;
     // Snapshot what was actually searched: the "Watch this route" alert must
     // describe these parameters, not whatever the form says later.
+    final returnDate = _returnDate == null ? null : _fmtDate(_returnDate!);
     _watched = (
       origin: _origin!.iataCode,
       destination: _destination!.iataCode,
       departDate: _fmtDate(_departDate!),
+      returnDate: returnDate,
       adults: _adults,
       cabinClass: _cabinClass,
       hasChildren: _childAges.isNotEmpty,
@@ -228,6 +263,7 @@ class _FlightSearchScreenState extends ConsumerState<FlightSearchScreen> {
           origin: _origin!.iataCode,
           destination: _destination!.iataCode,
           departDate: _fmtDate(_departDate!),
+          returnDate: returnDate,
           adults: _adults,
           childAges: _childAges.isEmpty ? null : List.of(_childAges),
           cabinClass: _cabinClass == 'economy' ? null : _cabinClass,
@@ -279,6 +315,30 @@ class _FlightSearchScreenState extends ConsumerState<FlightSearchScreen> {
                       ),
                     ),
                     const SizedBox(width: 12),
+                    Expanded(
+                      child: OutlinedButton.icon(
+                        onPressed: _pickReturnDate,
+                        icon: const Icon(Icons.calendar_today, size: 18),
+                        label: Text(_returnDate == null
+                            ? 'Return (optional)'
+                            : _fmtDate(_returnDate!)),
+                        style: OutlinedButton.styleFrom(
+                          padding: const EdgeInsets.symmetric(vertical: 14),
+                        ),
+                      ),
+                    ),
+                    if (_returnDate != null)
+                      IconButton(
+                        tooltip: 'Clear return date',
+                        visualDensity: VisualDensity.compact,
+                        icon: const Icon(Icons.close, size: 18),
+                        onPressed: () => setState(() => _returnDate = null),
+                      ),
+                  ],
+                ),
+                const SizedBox(height: 12),
+                Row(
+                  children: [
                     _PassengerStepper(
                       icon: Icons.person_outline,
                       count: _adults,
@@ -413,6 +473,7 @@ class _FlightSearchScreenState extends ConsumerState<FlightSearchScreen> {
                         origin: w.origin,
                         destination: w.destination,
                         departDate: w.departDate,
+                        returnDate: w.returnDate,
                         adults: w.adults,
                         cabinClass: w.cabinClass,
                         currentPrice: w.hasChildren ? null : cheapest.price,

--- a/src/packages/flutter-app/lib/widgets/create_alert_sheet.dart
+++ b/src/packages/flutter-app/lib/widgets/create_alert_sheet.dart
@@ -10,6 +10,7 @@ class CreateAlertSheet extends ConsumerStatefulWidget {
   final String origin;
   final String destination;
   final String departDate; // YYYY-MM-DD
+  final String? returnDate; // YYYY-MM-DD; null = one-way
   final int adults;
   final String cabinClass;
   final double? currentPrice;
@@ -20,6 +21,7 @@ class CreateAlertSheet extends ConsumerStatefulWidget {
     required this.origin,
     required this.destination,
     required this.departDate,
+    this.returnDate,
     this.adults = 1,
     this.cabinClass = 'economy',
     this.currentPrice,
@@ -83,6 +85,7 @@ class _CreateAlertSheetState extends ConsumerState<CreateAlertSheet> {
         'origin': widget.origin,
         'destination': widget.destination,
         'depart_date': widget.departDate,
+        if (widget.returnDate != null) 'return_date': widget.returnDate,
         'adults': widget.adults,
         'cabin_class': widget.cabinClass,
         if (target != null) 'target_price': target,
@@ -121,6 +124,7 @@ class _CreateAlertSheetState extends ConsumerState<CreateAlertSheet> {
           const SizedBox(height: AppSpacing.sm),
           Text(
             '${widget.origin} → ${widget.destination} · ${widget.departDate}'
+            '${widget.returnDate != null ? ' → ${widget.returnDate}' : ''}'
             '${widget.adults > 1 ? ' · ${widget.adults} adults' : ''}'
             '${widget.cabinClass != 'economy' ? ' · ${widget.cabinClass.replaceAll('_', ' ')}' : ''}',
             style: theme.textTheme.bodyMedium

--- a/src/packages/flutter-app/lib/widgets/flight_details_sheet.dart
+++ b/src/packages/flutter-app/lib/widgets/flight_details_sheet.dart
@@ -33,15 +33,21 @@ class _FlightDetailsSheet extends StatelessWidget {
     final from = segments.isNotEmpty ? segments.first.from : '';
     final to = segments.isNotEmpty ? segments.last.to : '';
 
+    // One-way: a flat segment list. Round-trip: an Outbound and a Return
+    // section, each with its own duration/stops summary.
     final rows = <Widget>[];
-    for (var i = 0; i < segments.length; i++) {
-      rows.add(_SegmentRow(leg: segments[i]));
-      if (i < segments.length - 1) {
-        rows.add(_LayoverRow(
-          airport: segments[i].to,
-          duration: _layover(segments[i], segments[i + 1]),
-        ));
-      }
+    if (offer.isRoundTrip) {
+      rows.add(_DirectionHeader(
+          label: 'Outbound',
+          detail: '${offer.durationLabel} · ${offer.stopsLabel}'));
+      rows.addAll(_sliceRows(offer.segments));
+      rows.add(const Divider(height: 24));
+      rows.add(_DirectionHeader(
+          label: 'Return',
+          detail: '${offer.returnDurationLabel} · ${offer.returnStopsLabel}'));
+      rows.addAll(_sliceRows(offer.returnSegments));
+    } else {
+      rows.addAll(_sliceRows(segments));
     }
 
     return SafeArea(
@@ -63,7 +69,7 @@ class _FlightDetailsSheet extends StatelessWidget {
                     const SizedBox(width: 10),
                   Expanded(
                     child: Text(
-                      '$from → $to',
+                      offer.isRoundTrip ? '$from ⇄ $to' : '$from → $to',
                       style: theme.textTheme.titleLarge
                           ?.copyWith(fontWeight: FontWeight.bold),
                     ),
@@ -72,7 +78,9 @@ class _FlightDetailsSheet extends StatelessWidget {
               ),
               const SizedBox(height: 4),
               Text(
-                '${offer.durationLabel} · ${offer.stopsLabel}',
+                offer.isRoundTrip
+                    ? 'Round trip'
+                    : '${offer.durationLabel} · ${offer.stopsLabel}',
                 style: theme.textTheme.bodyMedium
                     ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
               ),
@@ -97,6 +105,48 @@ class _FlightDetailsSheet extends StatelessWidget {
             ],
           ),
         ),
+      ),
+    );
+  }
+}
+
+/// Segment rows for one slice, with layover rows between consecutive legs.
+List<Widget> _sliceRows(List<FlightLeg> segments) {
+  final rows = <Widget>[];
+  for (var i = 0; i < segments.length; i++) {
+    rows.add(_SegmentRow(leg: segments[i]));
+    if (i < segments.length - 1) {
+      rows.add(_LayoverRow(
+        airport: segments[i].to,
+        duration: _layover(segments[i], segments[i + 1]),
+      ));
+    }
+  }
+  return rows;
+}
+
+/// Section header for one direction of a round trip, e.g.
+/// "Outbound · 7h 30m · Nonstop".
+class _DirectionHeader extends StatelessWidget {
+  final String label;
+  final String detail;
+  const _DirectionHeader({required this.label, required this.detail});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 4),
+      child: Row(
+        children: [
+          Text(label,
+              style: theme.textTheme.titleSmall
+                  ?.copyWith(fontWeight: FontWeight.bold)),
+          const SizedBox(width: 8),
+          Text(detail,
+              style: theme.textTheme.bodySmall
+                  ?.copyWith(color: theme.colorScheme.onSurfaceVariant)),
+        ],
       ),
     );
   }

--- a/src/packages/flutter-app/lib/widgets/flight_offer_card.dart
+++ b/src/packages/flutter-app/lib/widgets/flight_offer_card.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import '../models/flight_leg.dart';
 import '../models/flight_offer.dart';
 import '../utils/tracked_launch.dart';
 import 'airline_logo.dart';
@@ -86,7 +87,12 @@ class FlightOfferCard extends StatelessWidget {
                           ],
                         ),
                         const SizedBox(height: 2),
-                        if (offer.segments.isNotEmpty) _Times(offer: offer),
+                        if (offer.segments.isNotEmpty)
+                          _SliceTimes(legs: offer.segments),
+                        if (offer.isRoundTrip) ...[
+                          const SizedBox(height: 2),
+                          _SliceTimes(legs: offer.returnSegments),
+                        ],
                       ],
                     ),
                   ),
@@ -108,11 +114,16 @@ class FlightOfferCard extends StatelessWidget {
               const SizedBox(height: 12),
               Row(
                 children: [
-                  _Stat(icon: Icons.schedule, label: offer.durationLabel),
+                  _Stat(
+                      icon: Icons.schedule,
+                      label: offer.isRoundTrip
+                          ? '${offer.durationLabel} + ${offer.returnDurationLabel}'
+                          : offer.durationLabel),
                   const SizedBox(width: 16),
                   _Stat(
-                      icon: Icons.connecting_airports, label: offer.stopsLabel),
-                  if (offer.stops > 0) ...[
+                      icon: Icons.connecting_airports,
+                      label: offer.combinedStopsLabel),
+                  if (offer.stops > 0 || offer.returnStops > 0) ...[
                     const SizedBox(width: 6),
                     Icon(Icons.chevron_right,
                         size: 16, color: theme.colorScheme.onSurfaceVariant),
@@ -134,17 +145,22 @@ class FlightOfferCard extends StatelessWidget {
   }
 }
 
-/// Route line with departure/arrival clock times, e.g. "EWR 10:50 → GIG 00:47 +1".
-class _Times extends StatelessWidget {
-  final FlightOffer offer;
-  const _Times({required this.offer});
+/// Route line for one slice with departure/arrival clock times, e.g.
+/// "EWR 10:50 → GIG 00:47 +1". Round-trip offers render one per direction
+/// (the reversed airport codes make the direction self-evident).
+class _SliceTimes extends StatelessWidget {
+  final List<FlightLeg> legs;
+  const _SliceTimes({required this.legs});
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final muted = theme.colorScheme.onSurfaceVariant;
-    final from = offer.segments.first.from;
-    final to = offer.segments.last.to;
+    final from = legs.first.from;
+    final to = legs.last.to;
+    final departClock = _clock(legs.first.departTime);
+    final arriveClock = _clock(legs.last.arriveTime);
+    final dayOffset = _dayOffset(legs.first.departTime, legs.last.arriveTime);
     final bold = theme.textTheme.bodyMedium?.copyWith(
         color: theme.colorScheme.onSurface, fontWeight: FontWeight.w600);
     final base = theme.textTheme.bodyMedium?.copyWith(color: muted);
@@ -154,21 +170,36 @@ class _Times extends StatelessWidget {
         style: base,
         children: [
           TextSpan(text: '$from '),
-          if (offer.departClock.isNotEmpty)
-            TextSpan(text: offer.departClock, style: bold),
+          if (departClock.isNotEmpty) TextSpan(text: departClock, style: bold),
           const TextSpan(text: '  →  '),
           TextSpan(text: '$to '),
-          if (offer.arriveClock.isNotEmpty)
-            TextSpan(text: offer.arriveClock, style: bold),
-          if (offer.arrivalDayOffset > 0)
+          if (arriveClock.isNotEmpty) TextSpan(text: arriveClock, style: bold),
+          if (dayOffset > 0)
             TextSpan(
-              text: ' +${offer.arrivalDayOffset}',
+              text: ' +$dayOffset',
               style: theme.textTheme.labelSmall
                   ?.copyWith(color: theme.colorScheme.error),
             ),
         ],
       ),
     );
+  }
+
+  /// "hh:mm" for an ISO8601 time, empty if unparseable.
+  static String _clock(String iso) {
+    final t = DateTime.tryParse(iso);
+    if (t == null) return '';
+    return '${t.hour.toString().padLeft(2, '0')}:${t.minute.toString().padLeft(2, '0')}';
+  }
+
+  /// Calendar days the arrival falls after the departure (for the "+N" badge).
+  static int _dayOffset(String depart, String arrive) {
+    final d = DateTime.tryParse(depart);
+    final a = DateTime.tryParse(arrive);
+    if (d == null || a == null) return 0;
+    return DateTime(a.year, a.month, a.day)
+        .difference(DateTime(d.year, d.month, d.day))
+        .inDays;
   }
 }
 

--- a/src/packages/flutter-app/test/flight_round_trip_test.dart
+++ b/src/packages/flutter-app/test/flight_round_trip_test.dart
@@ -1,0 +1,465 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:travel_route_planner/models/airport.dart';
+import 'package:travel_route_planner/models/flight_leg.dart';
+import 'package:travel_route_planner/models/flight_offer.dart';
+import 'package:travel_route_planner/models/flight_search_request.dart';
+import 'package:travel_route_planner/models/flight_search_response.dart';
+import 'package:travel_route_planner/models/price_alert.dart';
+import 'package:travel_route_planner/models/user.dart';
+import 'package:travel_route_planner/providers/alerts_provider.dart';
+import 'package:travel_route_planner/providers/auth_provider.dart';
+import 'package:travel_route_planner/providers/flights_provider.dart';
+import 'package:travel_route_planner/screens/flight_search_screen.dart';
+import 'package:travel_route_planner/services/alerts_api_service.dart';
+import 'package:travel_route_planner/services/api_client.dart';
+import 'package:travel_route_planner/services/flights_api_service.dart';
+import 'package:travel_route_planner/widgets/create_alert_sheet.dart';
+import 'package:travel_route_planner/widgets/flight_offer_card.dart';
+
+// ---------------------------------------------------------------------------
+// Fakes
+// ---------------------------------------------------------------------------
+
+class _FakeAuthNotifier extends StateNotifier<AuthState>
+    implements AuthNotifier {
+  _FakeAuthNotifier(UserModel? user)
+      : super(AuthState(user: user, initialized: true));
+
+  @override
+  Future<bool> login(String email, String password) async => false;
+
+  @override
+  Future<bool> register(String email, String password,
+          {String? displayName}) async =>
+      false;
+
+  @override
+  Future<void> completeOnboarding() async {}
+
+  @override
+  Future<void> logout() async {}
+
+  @override
+  Future<void> signOutLocally() async {}
+
+  @override
+  void setUser(UserModel user) {}
+
+  @override
+  Future<void> adoptSession(String token, UserModel user) async {}
+}
+
+class _FakeAlertsApiService extends AlertsApiService {
+  final List<Map<String, dynamic>> created = [];
+  _FakeAlertsApiService() : super(ApiClient(baseUrl: 'http://test'));
+
+  @override
+  Future<PriceAlert> create(Map<String, dynamic> body) async {
+    created.add(body);
+    return PriceAlert(
+      id: 'a1',
+      origin: body['origin'] as String,
+      destination: body['destination'] as String,
+      departDate: body['depart_date'] as String,
+      returnDate: body['return_date'] as String?,
+    );
+  }
+}
+
+/// Captures every search request; answers with one offer that mirrors the
+/// request's shape (round-trip offers carry return segments, like the API).
+class _FakeFlightsApiService extends FlightsApiService {
+  final List<FlightSearchRequest> requests = [];
+  _FakeFlightsApiService() : super(ApiClient(baseUrl: 'http://test'));
+
+  @override
+  Future<FlightSearchResponse> searchFlights(FlightSearchRequest request) async {
+    requests.add(request);
+    final offer = request.returnDate == null ? _oneWayOffer() : _roundTripOffer();
+    return FlightSearchResponse(
+      offers: [offer],
+      bestOfferId: offer.id,
+      optimizeFor: request.optimizeFor,
+      count: 1,
+      status: 'success',
+    );
+  }
+
+  @override
+  Future<List<Airport>> searchAirports(String query) async => [];
+}
+
+UserModel _user() => UserModel(
+      id: 'user-1',
+      email: 'test@example.com',
+      displayName: 'Test',
+      createdAt: DateTime(2026, 1, 1),
+    );
+
+const _outboundLeg = FlightLeg(
+  from: 'JFK',
+  to: 'CDG',
+  carrier: 'Air France',
+  flightNumber: 'AF11',
+  departTime: '2026-09-01T18:00:00',
+  arriveTime: '2026-09-02T07:30:00',
+);
+
+const _returnLeg = FlightLeg(
+  from: 'CDG',
+  to: 'JFK',
+  carrier: 'Air France',
+  flightNumber: 'AF22',
+  departTime: '2026-09-10T10:00:00',
+  arriveTime: '2026-09-10T12:15:00',
+);
+
+FlightOffer _oneWayOffer() => const FlightOffer(
+      id: 'off_ow',
+      price: 420,
+      currency: 'USD',
+      stops: 0,
+      durationMinutes: 450,
+      airlines: ['Air France'],
+      departTime: '2026-09-01T18:00:00',
+      arriveTime: '2026-09-02T07:30:00',
+      segments: [_outboundLeg],
+      bookingUrl: 'https://example.com/book',
+    );
+
+FlightOffer _roundTripOffer() => const FlightOffer(
+      id: 'off_rt',
+      price: 842,
+      currency: 'USD',
+      stops: 0,
+      durationMinutes: 450,
+      airlines: ['Air France'],
+      departTime: '2026-09-01T18:00:00',
+      arriveTime: '2026-09-02T07:30:00',
+      segments: [_outboundLeg],
+      returnSegments: [_returnLeg],
+      returnDurationMinutes: 495,
+      bookingUrl: 'https://example.com/book',
+    );
+
+String _fmt(DateTime d) =>
+    '${d.year.toString().padLeft(4, '0')}-${d.month.toString().padLeft(2, '0')}-${d.day.toString().padLeft(2, '0')}';
+
+void main() {
+  group('FlightSearchRequest JSON', () {
+    test('omits return_date when null (one-way unchanged)', () {
+      const req = FlightSearchRequest(
+          origin: 'JFK', destination: 'CDG', departDate: '2026-09-01');
+      expect(req.toJson().containsKey('return_date'), isFalse);
+    });
+
+    test('carries return_date when set', () {
+      const req = FlightSearchRequest(
+          origin: 'JFK',
+          destination: 'CDG',
+          departDate: '2026-09-01',
+          returnDate: '2026-09-10');
+      expect(req.toJson()['return_date'], '2026-09-10');
+    });
+  });
+
+  group('FlightOffer model', () {
+    test('parses return_segments from API JSON', () {
+      final offer = FlightOffer.fromJson({
+        'id': 'off_rt',
+        'price': 842.4,
+        'currency': 'USD',
+        'stops': 0,
+        'duration_minutes': 450,
+        'airlines': ['Air France'],
+        'depart_time': '2026-09-01T18:00:00',
+        'arrive_time': '2026-09-02T07:30:00',
+        'segments': [
+          {
+            'from': 'JFK',
+            'to': 'CDG',
+            'carrier': 'Air France',
+            'flight_number': 'AF11',
+            'depart_time': '2026-09-01T18:00:00',
+            'arrive_time': '2026-09-02T07:30:00',
+          }
+        ],
+        'return_segments': [
+          {
+            'from': 'CDG',
+            'to': 'JFK',
+            'carrier': 'Air France',
+            'flight_number': 'AF22',
+            'depart_time': '2026-09-10T10:00:00',
+            'arrive_time': '2026-09-10T12:15:00',
+          }
+        ],
+        'return_duration_minutes': 495,
+        'score': 0,
+        'price_score': 0,
+        'duration_score': 0,
+        'stops_score': 0,
+      });
+      expect(offer.isRoundTrip, isTrue);
+      expect(offer.returnSegments.single.from, 'CDG');
+      expect(offer.returnDurationLabel, '8h 15m');
+      expect(offer.combinedStopsLabel, 'Nonstop');
+    });
+
+    test('one-way offer without return fields is unchanged', () {
+      final offer = _oneWayOffer();
+      expect(offer.isRoundTrip, isFalse);
+      expect(offer.returnSegments, isEmpty);
+      expect(offer.combinedStopsLabel, offer.stopsLabel);
+    });
+
+    test('combinedStopsLabel covers matching and differing directions', () {
+      FlightOffer offer({required int stops, required int returnLegs}) =>
+          FlightOffer(
+            id: 'o',
+            price: 1,
+            currency: 'USD',
+            stops: stops,
+            durationMinutes: 60,
+            airlines: const [],
+            departTime: '',
+            arriveTime: '',
+            segments: List.filled(stops + 1, _outboundLeg),
+            returnSegments: List.filled(returnLegs, _returnLeg),
+            returnDurationMinutes: 60,
+          );
+      expect(offer(stops: 1, returnLegs: 2).combinedStopsLabel,
+          '1 stop each way');
+      expect(offer(stops: 0, returnLegs: 2).combinedStopsLabel,
+          'Nonstop / 1 stop');
+    });
+  });
+
+  group('FlightOfferCard', () {
+    Future<void> pumpCard(WidgetTester tester, FlightOffer offer) async {
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(body: FlightOfferCard(offer: offer)),
+      ));
+    }
+
+    testWidgets('round trip renders both slices and combined stats',
+        (tester) async {
+      await pumpCard(tester, _roundTripOffer());
+      expect(
+          find.textContaining('JFK 18:00', findRichText: true), findsOneWidget);
+      expect(
+          find.textContaining('CDG 10:00', findRichText: true), findsOneWidget);
+      expect(find.text('7h 30m + 8h 15m'), findsOneWidget);
+      expect(find.text('Nonstop'), findsOneWidget);
+    });
+
+    testWidgets('one way renders a single slice exactly as before',
+        (tester) async {
+      await pumpCard(tester, _oneWayOffer());
+      expect(
+          find.textContaining('JFK 18:00', findRichText: true), findsOneWidget);
+      expect(
+          find.textContaining('CDG 10:00', findRichText: true), findsNothing);
+      expect(find.text('7h 30m'), findsOneWidget);
+      expect(find.text('Nonstop'), findsOneWidget);
+    });
+
+    testWidgets('details sheet shows Outbound and Return sections',
+        (tester) async {
+      await pumpCard(tester, _roundTripOffer());
+      await tester.tap(find.byType(FlightOfferCard));
+      await tester.pumpAndSettle();
+      expect(find.text('Outbound'), findsOneWidget);
+      expect(find.text('Return'), findsOneWidget);
+      expect(find.text('Round trip'), findsOneWidget);
+      expect(find.text('JFK ⇄ CDG'), findsOneWidget);
+    });
+
+    testWidgets('details sheet for one way has no direction sections',
+        (tester) async {
+      await pumpCard(tester, _oneWayOffer());
+      await tester.tap(find.byType(FlightOfferCard));
+      await tester.pumpAndSettle();
+      expect(find.text('Outbound'), findsNothing);
+      expect(find.text('Return'), findsNothing);
+      expect(find.text('JFK → CDG'), findsOneWidget);
+    });
+  });
+
+  group('CreateAlertSheet', () {
+    Future<_FakeAlertsApiService> openSheet(
+        WidgetTester tester, CreateAlertSheet sheet) async {
+      final service = _FakeAlertsApiService();
+      await tester.pumpWidget(ProviderScope(
+        overrides: [alertsApiServiceProvider.overrideWithValue(service)],
+        child: MaterialApp(
+          home: Scaffold(
+            body: Builder(
+              builder: (context) => FilledButton(
+                onPressed: () => CreateAlertSheet.show(context, sheet),
+                child: const Text('open'),
+              ),
+            ),
+          ),
+        ),
+      ));
+      await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
+      return service;
+    }
+
+    testWidgets('round-trip search stores return_date on the alert',
+        (tester) async {
+      final service = await openSheet(
+        tester,
+        const CreateAlertSheet(
+          origin: 'JFK',
+          destination: 'CDG',
+          departDate: '2026-09-01',
+          returnDate: '2026-09-10',
+        ),
+      );
+      // The summary shows what will be watched, including the return.
+      expect(find.textContaining('2026-09-01 → 2026-09-10'), findsOneWidget);
+
+      await tester.tap(find.text('Create alert'));
+      await tester.pumpAndSettle();
+
+      expect(service.created.single['return_date'], '2026-09-10');
+    });
+
+    testWidgets('one-way search omits return_date', (tester) async {
+      final service = await openSheet(
+        tester,
+        const CreateAlertSheet(
+          origin: 'JFK',
+          destination: 'CDG',
+          departDate: '2026-09-01',
+        ),
+      );
+      await tester.tap(find.text('Create alert'));
+      await tester.pumpAndSettle();
+
+      expect(service.created.single.containsKey('return_date'), isFalse);
+    });
+  });
+
+  group('FlightSearchScreen round trip', () {
+    Future<(_FakeFlightsApiService, _FakeAlertsApiService)> pumpScreen(
+        WidgetTester tester, String departDate) async {
+      tester.view.physicalSize = const Size(1200, 2000);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      final flights = _FakeFlightsApiService();
+      final alerts = _FakeAlertsApiService();
+      await tester.pumpWidget(ProviderScope(
+        overrides: [
+          flightsApiServiceProvider.overrideWithValue(flights),
+          alertsApiServiceProvider.overrideWithValue(alerts),
+          authProvider.overrideWith((ref) => _FakeAuthNotifier(_user())),
+        ],
+        child: MaterialApp(
+          home: FlightSearchScreen(
+            prefillOrigin: 'JFK',
+            prefillDestination: 'CDG',
+            prefillDepartDate: departDate,
+          ),
+        ),
+      ));
+      await tester.pumpAndSettle();
+      return (flights, alerts);
+    }
+
+    testWidgets(
+        'return date threads through search request and Watch this route',
+        (tester) async {
+      final depart = DateTime.now().add(const Duration(days: 30));
+      final (flights, alerts) = await pumpScreen(tester, _fmt(depart));
+
+      // Prefill auto-search runs one-way: no return_date, current behavior.
+      expect(flights.requests, hasLength(1));
+      expect(flights.requests.first.returnDate, isNull);
+      expect(find.text('Return (optional)'), findsOneWidget);
+
+      // Pick a return date; the picker opens at departure + 7, accept it.
+      await tester.tap(find.text('Return (optional)'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('OK'));
+      await tester.pumpAndSettle();
+      final expectedReturn = _fmt(depart.add(const Duration(days: 7)));
+      expect(find.text(expectedReturn), findsOneWidget);
+
+      await tester.tap(find.text('Search Flights'));
+      await tester.pumpAndSettle();
+      expect(flights.requests, hasLength(2));
+      expect(flights.requests.last.returnDate, expectedReturn);
+      expect(flights.requests.last.origin, 'JFK');
+      expect(flights.requests.last.destination, 'CDG');
+
+      // Both slices render on the result card.
+      expect(
+          find.textContaining('CDG 10:00', findRichText: true), findsOneWidget);
+
+      // "Watch this route" carries the searched return date into the alert.
+      await tester
+          .tap(find.textContaining('Watch this route'), warnIfMissed: false);
+      await tester.pumpAndSettle();
+      expect(find.textContaining('→ $expectedReturn'), findsOneWidget);
+      await tester.tap(find.text('Create alert'));
+      await tester.pumpAndSettle();
+      expect(alerts.created.single['return_date'], expectedReturn);
+      expect(alerts.created.single['depart_date'], _fmt(depart));
+    });
+
+    testWidgets('clear button removes the return date (back to one-way)',
+        (tester) async {
+      final depart = DateTime.now().add(const Duration(days: 30));
+      final (flights, _) = await pumpScreen(tester, _fmt(depart));
+
+      await tester.tap(find.text('Return (optional)'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('OK'));
+      await tester.pumpAndSettle();
+      expect(find.text('Return (optional)'), findsNothing);
+
+      await tester.tap(find.byTooltip('Clear return date'));
+      await tester.pumpAndSettle();
+      expect(find.text('Return (optional)'), findsOneWidget);
+
+      await tester.tap(find.text('Search Flights'));
+      await tester.pumpAndSettle();
+      expect(flights.requests.last.returnDate, isNull);
+    });
+
+    testWidgets('moving departure past the return clears the return',
+        (tester) async {
+      final depart = DateTime.now().add(const Duration(days: 30));
+      await pumpScreen(tester, _fmt(depart));
+
+      // Set return = departure + 7.
+      await tester.tap(find.text('Return (optional)'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('OK'));
+      await tester.pumpAndSettle();
+      expect(find.text('Return (optional)'), findsNothing);
+
+      // Move the departure into the next month (always past return).
+      await tester.tap(find.text(_fmt(depart)));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byTooltip('Next month'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('28'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('OK'));
+      await tester.pumpAndSettle();
+
+      // The stale return is gone rather than silently invalid.
+      expect(find.text('Return (optional)'), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## What

Round-trip flight search, end to end: an optional return-date picker, the return date threaded into the search request and price alerts, and both slices rendered on the offer card and details sheet.

## Why

`FlightSearchRequest.returnDate` existed but nothing in the UI could set it — one-way-only pricing understates trip cost and weakens the affiliate funnel and the price-alert loop.

## Flagged risk, confirmed and fixed

The task flagged that the card/sheet may assume a single slice. It ran deeper: **the Go normalizer in `duffel_service.go` only read `o.Slices[0]`**, so the return slice never reached the client at all (the round-trip *price* was correct — `total_amount` covers all slices — but only outbound legs survived). A minimal API addition was required to make "both slices visible" possible:

- `FlightOffer` gains `return_segments` / `return_duration_minutes` (`omitempty` — one-way JSON is byte-identical to before). Outbound-based `stops`/`duration_minutes`/times are unchanged, so ranking and existing consumers behave the same.
- Return-direction carriers are now included in `airlines`.

## Changes

- **flight_search_screen.dart** — return-date picker next to departure; empty = one-way (exact current behavior). Clear via an X button. Picker floor = departure date, so return < departure is unselectable; moving departure past the return auto-clears it. Return date snapshots into `_watched` so alerts describe what was actually searched.
- **duffel_service.go** — preserves the return slice (see above); doc comments updated.
- **flight_offer.dart** — `returnSegments`/`returnDurationMinutes` + `isRoundTrip`/`returnStops`/label helpers; `.g.dart` regenerated via build_runner.
- **flight_offer_card.dart** — one route-times row per direction ("JFK 18:00 → CDG 07:30 +1" / "CDG 10:00 → JFK 12:15"), combined duration ("7h 30m + 8h 15m") and stops ("Nonstop", "1 stop each way", "Nonstop / 1 stop") stats. One-way rendering unchanged. `trackedLaunchUrl` booking flow untouched.
- **flight_details_sheet.dart** — Outbound / Return sections with per-direction duration·stops and layovers; "JFK ⇄ CDG" header + "Round trip" subtitle. One-way layout unchanged.
- **create_alert_sheet.dart** — accepts `returnDate`, shows it in the watch summary, sends `return_date` in the create payload (API validation and the alerts screen already supported it).
- **flights_provider.dart** — no change needed: it already forwards the whole `FlightSearchRequest`.

## Tests

- Go: round-trip request carries two slices (return reversed) and the response keeps both slices; one-way carries no return fields.
- Dart: request JSON omits/includes `return_date`; model parses `return_segments`; card + sheet render both directions (and one-way exactly as before); alert payload stores `return_date` (and omits it one-way); picker threading, clear button, and departure-past-return auto-clear driven through real date-picker dialogs.

Gates: `make flutter-test` (58 pass), `flutter analyze --no-fatal-infos --fatal-warnings` exit 0 (same 12 pre-existing infos as main), `gofmt`/`go vet`/`go test .` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)