### PR TITLE
feat(api): free-cap soft instrumentation + Anthropic base-URL seam

### DIFF
--- a/specs/free-cap-instrumentation/plan.md
+++ b/specs/free-cap-instrumentation/plan.md
@@ -1,0 +1,125 @@
+# Plan: Free-Cap Soft Instrumentation
+
+> **HOW.** Translates `spec.md` into a file-level technical approach. Every
+> decision should trace back to an acceptance criterion. See `../../CLAUDE.md`
+> for repo conventions referenced below — don't restate them, point to them.
+
+## Technical Approach
+
+Reuse the Wave-6 analytics seam end to end: counts come from
+`analytics_events` (no migration; schema stays 00030), recording goes
+through the existing fire-and-forget `recordEvent`/`recordEventOpt`
+helpers, and the dashboard reads two new grouped fields off
+`GET /admin/metrics`. The enforcement *template* is
+`price_alert_handler.go`'s `maxActiveAlertsPerUser` +
+`CountActivePriceAlertsByUser` — same shape (env-tunable cap + one count
+query), but deliberately **without** the 422 branch: the count only decides
+whether to emit an event. Cap values are read via the existing `envInt`
+helper at call time (the `ALERT_TICK_MINUTES` pattern), which is what makes
+them per-test overridable with `t.Setenv`.
+
+## Go API Changes
+
+`src/packages/api/` (all files are `package main`):
+
+- **`free_cap.go` (new):** the whole feature's logic.
+  - `freePlanSessionsPerMonth()` / `freeActiveTrips()` — `envInt` reads of
+    `FREE_PLAN_SESSIONS_PER_MONTH` (20) / `FREE_ACTIVE_TRIPS` (3).
+  - `recordPlanSessionStart(userID *uuid.UUID, authed bool)` — replaces the
+    bare `go recordEventOpt(..., "plan_session_started", ...)` call in
+    `planHandler`. Inside one goroutine, **in this order**: (1) if authed
+    and `dbPool != nil`, run `CountEventsByTypeAndUserSince` for
+    `plan_session_started` over the trailing 30 days (prior count —
+    excludes this session because its own event isn't written yet); (2) if
+    the prior count == cap, record `free_cap_would_hit`
+    (`cap_kind=plan_runs`, `count=prior+1`); (3) record
+    `plan_session_started`. Writing the would-hit *before* the started
+    event makes tests deterministic: once session N's started row is
+    visible, any would-hit it implies is also visible. Errors at any step
+    fall through — the started event is always attempted.
+  - `recordActiveTripsCapSignal(userID, tripID uuid.UUID)` — after a
+    committed trip creation: `CountActiveTripLineagesByOwner`; emit iff
+    count == cap+1 (`cap_kind=active_trips`, `count=n`). Nil-pool and
+    error ⇒ return silently.
+- **`query/analytics.sql`:** `CountEventsByTypeAndUserSince` (`:one`) and
+  `FreeCapWouldHitCounts` (`:many`, GROUP BY `metadata->>'cap_kind'`,
+  `count(*)` + `count(DISTINCT user_id)`).
+- **`query/trips.sql`:** `CountActiveTripLineagesByOwner` (`:one`) —
+  `count(DISTINCT COALESCE(chat_id, id::text))`, the same lineage key
+  `ListLatestTripsByOwner`'s `DISTINCT ON` uses, so "active trips" here is
+  exactly what My Trips shows.
+- **`store/`:** regenerated via `make api-sqlc` (never hand-edit).
+- **Call sites:**
+  - `plan_handler.go` line ~113: `go recordPlanSessionStart(planUID, authed)`.
+  - `plan_handler.go` `create_itinerary` branch (after `persistTrip`
+    succeeds and `trip_created` is recorded): `go
+    recordActiveTripsCapSignal(uid, parsed)` — async, matching the
+    surrounding `go recordEvent` calls in the SSE loop.
+  - `share_handler.go` `duplicateSharedTripHandler` (after commit, before
+    the response is loaded): synchronous `recordActiveTripsCapSignal(user.ID,
+    copyTrip.ID)` — the handler just finished a transaction, one more count
+    query is negligible, and a synchronous call makes the
+    exactly-one-event integration assertion deterministic. It still cannot
+    fail the request (the helper swallows everything).
+- **`analytics.go`:** `MetricsResponse` gains `FreeCapWouldHits` /
+  `FreeCapUsersAffected` (`map[string]int64`, initialized empty);
+  `adminMetricsHandler` fills them from `FreeCapWouldHitCounts` (one extra
+  round trip, admin-only endpoint).
+- **Guardrail:** `clientEventTypes` is untouched — `free_cap_would_hit`
+  stays server-recorded only.
+- **Rider — `anthropic_client.go` (new):** `newAnthropicClient(apiKey)`
+  builds the client with `option.WithAPIKey` plus `option.WithBaseURL`
+  when `ANTHROPIC_BASE_URL` is set. Used by both constructions
+  (`plan_handler.go` ~line 94, `local_ingest_handler.go` ~line 146). The
+  vendored SDK (v1.45.0) already honors `ANTHROPIC_BASE_URL` in
+  `DefaultClientOptions`, but the explicit option pins the seam so it
+  survives SDK upgrades and documents it at the call site.
+- **`.env.sample`:** document `FREE_PLAN_SESSIONS_PER_MONTH`,
+  `FREE_ACTIVE_TRIPS`, `ANTHROPIC_BASE_URL`.
+
+## Tests
+
+- **Unit** (`free_cap_test.go`): env parsing defaults/overrides; nil-pool
+  fail-open (helpers return without panicking when `dbPool == nil`).
+- **Integration** (`free_cap_integration_test.go`, `TEST_DATABASE_URL`
+  harness: `resetDB` / `doJSON` / `createTestUser`, unique X-Forwarded-For
+  per request):
+  - **plan_runs:** `t.Setenv(FREE_PLAN_SESSIONS_PER_MONTH=2,
+    ANTHROPIC_API_KEY=test, ANTHROPIC_BASE_URL=<httptest fake>)`. The fake
+    Anthropic server returns a minimal `text/event-stream`
+    (message_start → text delta → message_delta `end_turn` →
+    message_stop), so `POST /api/v1/plan` runs a full authed session
+    through `buildRouter` with zero external calls. Run 4 sequential
+    sessions, polling between them until the user's
+    `plan_session_started` count reaches N (the instrumentation goroutine
+    is async; the would-hit-before-started ordering makes this poll
+    sufficient). Assert: every response is 200 with a `text_delta` and no
+    SSE `error`; after session 3 exactly one `free_cap_would_hit`
+    (`cap_kind=plan_runs`, `count=3`); after session 4 still exactly one;
+    dashboard shows `free_cap_would_hits.plan_runs == 1` and
+    `free_cap_users_affected.plan_runs == 1`.
+  - **active_trips:** `FREE_ACTIVE_TRIPS=1`; owner shares a trip; a second
+    user duplicates it 3 times (each 201). Exactly one
+    `free_cap_would_hit` (`cap_kind=active_trips`, `count=2`, trip id set)
+    — deterministic because the duplicate-path signal is synchronous.
+  - Both tests assert the crossing rule's off-by-one edges explicitly
+    (cap-th unit emits nothing; cap+1-th emits; cap+2-th emits nothing).
+
+## Flutter Changes
+
+`src/packages/flutter-app/lib/`:
+
+- **`models/admin_metrics.dart`:** `freeCapWouldHits` /
+  `freeCapUsersAffected` (`Map<String, int>`, default `{}`); regenerate via
+  `make flutter-build-models` (with `--delete-conflicting-outputs` if
+  prompted). Never hand-edit `.g.dart`.
+- **`screens/admin_metrics_screen.dart`:** two tiles in the AI-planning
+  grid next to "Agent loop cap hits": "Would hit plan cap" and "Would hit
+  trip cap", value = crossings, caption = distinct users affected.
+
+## Contract Parity  ← anti-drift gate
+
+| JSON key | Go type (`analytics.go`) | Dart type (`admin_metrics.dart`) | Nullable? | ✓ |
+|----------|--------------------------|----------------------------------|-----------|---|
+| `free_cap_would_hits` | `map[string]int64` (always initialized) | `Map<String, int>` (default `{}`) | no | ☑ |
+| `free_cap_users_affected` | `map[string]int64` (always initialized) | `Map<String, int>` (default `{}`) | no | ☑ |

--- a/specs/free-cap-instrumentation/spec.md
+++ b/specs/free-cap-instrumentation/spec.md
@@ -1,0 +1,211 @@
+# Spec: Free-Cap Soft Instrumentation
+
+> **WHAT & WHY only.** No tech choices, file names, libraries, or code. If a
+> sentence names a file or a package, it belongs in `plan.md`, not here.
+
+## Context
+
+`docs/business-model.md` §7 gates Phase 3 (the paid tier) on "a measured
+cohort actually hitting the free caps" — but no cap exists anywhere in the
+product, so the trigger condition is currently unmeasurable. This feature
+adds **measurement only**: the placeholder caps from §4 (~20 AI planning
+sessions/month, 3 active trips) become counters that record a
+`free_cap_would_hit` analytics event at the moment a signed-in user *would
+have* been stopped if the caps were enforced. **Nothing is enforced. No
+paywall. No request is ever rejected, slowed, or altered by this feature —
+if any part of the measurement fails, the request proceeds exactly as
+before (fail-open).** The output is the §8 "cap-hit rate" metric on the
+admin dashboard: how many would-hit events fired and how many distinct
+users they touched, per cap kind — the demand signal Phase-3 pricing will
+be read off of.
+
+## User Stories
+
+- As the **operator**, I want to see how many users would hit the free caps
+  so that I can decide when (and at what limits) to launch the paid tier.
+- As the **operator**, I want the caps to be tunable via configuration so
+  that I can test lower thresholds and recalibrate the placeholder numbers
+  from usage data without a deploy.
+- As a **traveler** (free or otherwise), I want zero behavior change: my
+  planning sessions and trips work identically whether or not I am past any
+  cap, and identically when the measurement layer is broken.
+
+## Cap Semantics (normative)
+
+Two cap kinds are measured. Both apply to **signed-in users only** —
+anonymous planning sessions carry no durable identity, so no per-user count
+is meaningful (and anonymous users can't be converted to a paid tier
+anyway).
+
+### `plan_runs` — AI planning sessions per month
+
+- **Cap:** `FREE_PLAN_SESSIONS_PER_MONTH`, default **20** (the §4
+  placeholder). Read from the environment at evaluation time, so tests and
+  ops can lower it without a restart-order dependency.
+- **Window:** trailing 30 days (rolling), not calendar month. "Per month"
+  in the tier table is a marketing phrasing; a rolling window avoids
+  month-boundary cliffs and is what a future enforcement layer would want.
+- **Counted unit:** one `plan_session_started` event by that user inside
+  the window.
+- **Crossing rule (only-on-crossing):** when a signed-in session starts,
+  count the user's *prior* `plan_session_started` events in the window —
+  i.e. the count is taken **before** this session's own start event is
+  recorded, so the session being started is not part of its own count.
+  Emit `free_cap_would_hit` **iff that prior count equals the cap
+  exactly**. In other words: sessions 1..cap are free; the (cap+1)-th
+  session in a window is the first that would have been blocked, and it is
+  the *only* one that emits. Sessions cap+2, cap+3, … see a prior count
+  greater than the cap and emit nothing.
+
+### `active_trips` — concurrently saved trips
+
+- **Cap:** `FREE_ACTIVE_TRIPS`, default **3** (the §4 placeholder). Read
+  from the environment at evaluation time.
+- **Counted unit:** one trip *lineage* — the same grouping My Trips uses,
+  where repeated refinements of one conversation collapse to a single trip
+  with versions. Saving a new **version** of an existing trip does not
+  increase the count and can never emit. All saved trips count as active
+  (there is no archived state today; if one is added, archived lineages
+  leave the count).
+- **Crossing rule (only-on-crossing):** after a trip is successfully
+  created (a brand-new lineage — via the planning agent finalizing an
+  itinerary, or via duplicating a shared trip), count the owner's distinct
+  lineages. Emit `free_cap_would_hit` **iff the post-creation count equals
+  cap + 1 exactly** — the creation that takes the user from "at the cap" to
+  "one past it". A user already far past the cap (e.g. crossed while the
+  database was down, or before this feature shipped) emits nothing on
+  their next creation: the crossing was missed, not deferred.
+
+### Why only-on-crossing
+
+The dashboard reports raw would-hit event counts. If every over-cap session
+or trip creation emitted an event, a single power user running 40 sessions
+in a month would register 20 events and dominate the count — the metric
+would measure *usage past the cap*, not *users encountering the cap*.
+Emitting only at the crossing makes each event mean "one user, one moment
+of would-have-been-blocked", so the event count approximates crossing
+moments and the distinct-user count approximates the cohort size. Both
+numbers are surfaced; distinct-users-affected is the primary Phase-3
+signal.
+
+**Re-crossing is a new crossing.** The plan-runs window rolls, so a user
+can drop back under the cap next month and cross again — that emits again,
+correctly: recurring monthly pressure is a stronger demand signal than a
+one-time spike. Likewise a user who deletes trips below the cap and later
+creates past it again emits again. At most one event fires per crossing.
+
+## Accuracy Model (accepted limitations)
+
+- **Counting off the analytics event log undercounts in degraded mode.**
+  Plan-run counts derive from the same best-effort analytics stream that
+  powers the rest of the dashboard: when the database is unavailable,
+  sessions happen but no events are recorded, and those sessions are
+  invisible to the cap counter forever. This is acceptable — the feature is
+  a *demand signal*, not a billing meter. A systematic undercount makes the
+  signal conservative (we see *at least* this much cap pressure), which is
+  the safe direction for a launch-the-paid-tier trigger.
+- **Concurrent session starts can race.** Two simultaneous sessions by the
+  same user may both observe the same prior count and double-emit, or
+  straddle the threshold and emit nothing. No locking is added; the
+  distinct-user number is unaffected either way and the event count is
+  approximate by design.
+- **Future strict metering path.** If enforcement ever ships, counting off
+  the event log is not good enough (fail-open + undercount = free
+  overage). The upgrade path is a dedicated `usage_counters` table —
+  per-user, per-cap-kind, per-window running counters incremented
+  transactionally with the counted action (session start committed with
+  the counter; trip insert and counter in one transaction) — at which
+  point the counter becomes authoritative, the crossing check reads it,
+  and enforcement can fail-closed. The event schema defined here is
+  deliberately independent of how the count is produced, so that migration
+  changes no dashboards.
+
+## Event Schema (normative)
+
+**`free_cap_would_hit`** — recorded **server-side only**. It must never be
+accepted from the client event-reporting endpoint (clients could otherwise
+spoof demand); the client event whitelist is unchanged.
+
+| Field | Meaning |
+|---|---|
+| user id | The signed-in user who crossed. Never null — anonymous flows never emit. |
+| trip id | For `active_trips`: the trip whose creation crossed the line. Absent for `plan_runs`. |
+| `metadata.cap_kind` | `"plan_runs"` or `"active_trips"`. |
+| `metadata.count` | The count that crossed: for `plan_runs` the ordinal of the crossing session (prior count + 1 = cap + 1); for `active_trips` the post-creation lineage count (= cap + 1). Recording cap+1 rather than the cap makes each event self-describing about the threshold in force when it fired, even after the env var changes. |
+
+## Configuration
+
+| Variable | Default | Meaning |
+|---|---|---|
+| `FREE_PLAN_SESSIONS_PER_MONTH` | 20 | plan_runs cap; trailing-30-day window. |
+| `FREE_ACTIVE_TRIPS` | 3 | active_trips cap (distinct lineages). |
+
+Both are read at evaluation time (per check, not at boot), must be positive
+integers, and fall back to the default when unset or invalid. Changing them
+changes only *future* crossing decisions; recorded events keep the `count`
+they fired with.
+
+## API Surface
+
+### `GET /api/v1/admin/metrics?days=` (existing endpoint, two new fields)
+
+- **Purpose:** surface the §8 cap-hit rate next to the existing funnel
+  numbers.
+- **Response additions:**
+  - `free_cap_would_hits` — map of cap kind → number of would-hit events in
+    the window (crossings observed).
+  - `free_cap_users_affected` — map of cap kind → distinct users who
+    emitted at least one would-hit event in the window (the cohort size;
+    the primary Phase-3 trigger number).
+- Both maps are empty (not absent) when no events exist. Admin-only, as
+  before.
+
+### Rider: outbound AI base-URL override
+
+The two places the backend constructs an Anthropic client (the planning
+agent and the admin local-content ingest) honor an optional
+`ANTHROPIC_BASE_URL` environment variable redirecting API traffic. Unset ⇒
+behavior identical to today. This is the seam a fake-AI end-to-end test
+harness needs (and what this feature's own integration test uses to drive a
+real planning session without external calls).
+
+## Data Model
+
+No schema change. `free_cap_would_hit` rows live in the existing analytics
+event log alongside every other event type.
+
+## UI Behavior
+
+- **Admin metrics dashboard**, AI-planning section, next to the agent-loop
+  cap-hits tile: one tile per cap kind showing would-hit crossings with the
+  distinct-users-affected as the caption. Zero states show 0 (the number
+  being reliably zero is itself the Phase-3 answer "not yet").
+
+## Edge Cases & Error States
+
+- **Database unavailable (degraded mode):** no counting, no recording, no
+  logging noise beyond the standard analytics drop; the request proceeds.
+- **Count query fails:** treated as "no crossing"; request proceeds.
+- **Anonymous session:** skipped entirely — no count query is issued.
+- **Env var set to 0, negative, or garbage:** default applies.
+- **Version save vs new trip:** a new version of an existing lineage never
+  changes the active-trip count and never emits.
+- **Hot path:** the plan-session check adds at most one count query, and it
+  runs off the request path (fire-and-forget alongside the existing session
+  instrumentation) — a slow analytics database cannot delay first-token
+  time.
+
+## Out of Scope
+
+- **Any enforcement, throttling, messaging, or paywall UI.** No user-facing
+  surface changes for non-admins.
+- Anonymous-user cap measurement (no durable identity).
+- Places/Duffel/Ticketmaster quota measurement (COGS metering is separate).
+- The `usage_counters` strict-metering table (documented above as the
+  upgrade path; built only if enforcement is decided).
+- Backfilling crossings that happened before this shipped.
+
+## Open Questions
+
+- None blocking. The cap defaults remain the §4 placeholders on purpose —
+  this feature exists to produce the data that replaces them.

--- a/src/packages/api/.env.sample
+++ b/src/packages/api/.env.sample
@@ -47,3 +47,12 @@ PUBLIC_APP_PATH=
 # Price alerts checker cadence (optional; defaults shown)
 # ALERT_TICK_MINUTES=5    # how often the checker wakes up
 # ALERT_CHECK_HOURS=6     # per-alert re-check freshness window
+
+# Free-cap soft instrumentation (specs/free-cap-instrumentation): measurement
+# only, nothing is enforced. Read at evaluation time; defaults shown.
+# FREE_PLAN_SESSIONS_PER_MONTH=20  # plan_runs cap, trailing 30 days
+# FREE_ACTIVE_TRIPS=3              # active_trips cap (distinct trip lineages)
+
+# Optional Anthropic API base-URL override (test seam for a fake-Anthropic
+# harness). Leave unset in production.
+# ANTHROPIC_BASE_URL=

--- a/src/packages/api/analytics.go
+++ b/src/packages/api/analytics.go
@@ -160,6 +160,15 @@ type MetricsResponse struct {
 	EstCogsPerActiveUser float64 `json:"est_cogs_per_active_user"`
 	AlertsCreated        int64   `json:"alerts_created"`
 	AlertsTriggered      int64   `json:"alerts_triggered"`
+	// FreeCapWouldHits / FreeCapUsersAffected are the §8 cap-hit rate — the
+	// Phase-3 demand signal, keyed by cap_kind (plan_runs / active_trips).
+	// Would-hits counts crossing events (only-on-crossing, so one per user
+	// per crossing — see specs/free-cap-instrumentation); users-affected is
+	// the distinct-user cohort, the primary trigger number. Nothing is
+	// enforced anywhere — these are measurements of a cap that doesn't exist
+	// in code yet.
+	FreeCapWouldHits     map[string]int64 `json:"free_cap_would_hits"`
+	FreeCapUsersAffected map[string]int64 `json:"free_cap_users_affected"`
 }
 
 // adminMetricsHandler is GET /api/v1/admin/metrics?days= (admin only; gated
@@ -198,6 +207,8 @@ func adminMetricsHandler(w http.ResponseWriter, r *http.Request) {
 		AlertsCreated:        counts["alert_created"],
 		AlertsTriggered:      counts["alert_triggered"],
 		ClicksByProvider:     map[string]int64{},
+		FreeCapWouldHits:     map[string]int64{},
+		FreeCapUsersAffected: map[string]int64{},
 	}
 	if n, err := q.CountActivatedSignups(ctx, since); err == nil {
 		resp.ActivatedSignups = n
@@ -224,6 +235,12 @@ func adminMetricsHandler(w http.ResponseWriter, r *http.Request) {
 		resp.PlanOutputTokens = totals.OutputTokens
 		resp.PlanCacheReadTokens = totals.CacheReadTokens
 		resp.PlanCacheCreateTokens = totals.CacheCreationTokens
+	}
+	if rows, err := q.FreeCapWouldHitCounts(ctx, since); err == nil {
+		for _, row := range rows {
+			resp.FreeCapWouldHits[row.CapKind] = row.WouldHits
+			resp.FreeCapUsersAffected[row.CapKind] = row.UsersAffected
+		}
 	}
 	if eng, err := q.UserEngagementCounts(ctx, since); err == nil {
 		resp.ActiveUsers = eng.ActiveUsers

--- a/src/packages/api/anthropic_client.go
+++ b/src/packages/api/anthropic_client.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"os"
+
+	anthropic "github.com/anthropics/anthropic-sdk-go"
+	"github.com/anthropics/anthropic-sdk-go/option"
+)
+
+// newAnthropicClient builds the Anthropic client used by the /plan agent and
+// the admin local-content ingest. An optional ANTHROPIC_BASE_URL env var
+// redirects API traffic — the seam a fake-Anthropic test harness needs (the
+// free-cap integration test drives real /plan sessions through it). Unset
+// means production behavior, byte-identical to before. The SDK's default
+// option chain also reads ANTHROPIC_BASE_URL, but pinning it explicitly here
+// keeps the seam independent of SDK-version behavior and documents it at the
+// one place clients are constructed.
+func newAnthropicClient(apiKey string) anthropic.Client {
+	opts := []option.RequestOption{option.WithAPIKey(apiKey)}
+	if base := os.Getenv("ANTHROPIC_BASE_URL"); base != "" {
+		opts = append(opts, option.WithBaseURL(base))
+	}
+	return anthropic.NewClient(opts...)
+}

--- a/src/packages/api/free_cap.go
+++ b/src/packages/api/free_cap.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"travel-route-planner/store"
+)
+
+// Free-cap soft instrumentation (specs/free-cap-instrumentation): measure the
+// business model's placeholder free caps WITHOUT enforcing anything. When a
+// signed-in user crosses a cap — the first unit past it, never subsequent
+// ones — a server-side free_cap_would_hit analytics event is recorded so the
+// admin dashboard can answer the Phase-3 trigger question ("is a measured
+// cohort actually hitting the free caps?"). Everything here is strictly
+// fail-open: counting off the best-effort analytics_events log undercounts in
+// degraded mode (acceptable for a demand signal — see the spec's accuracy
+// model and its usage_counters upgrade path for strict metering), and any
+// error simply skips the signal. No request is ever rejected, delayed, or
+// altered. Cribbed from price_alert_handler.go's maxActiveAlertsPerUser
+// template, minus the enforcement branch.
+
+const (
+	defaultFreePlanSessionsPerMonth = 20 // business-model §4 placeholder
+	defaultFreeActiveTrips          = 3  // business-model §4 placeholder
+
+	// freeCapWindowDays is the trailing window for the plan_runs cap —
+	// rolling, not calendar-month, to avoid month-boundary cliffs.
+	freeCapWindowDays = 30
+)
+
+// Read at call time (the ALERT_TICK_MINUTES pattern) so tests and ops can
+// lower a cap via env without a boot-order dependency. Invalid/zero/negative
+// values fall back to the default.
+func freePlanSessionsPerMonth() int {
+	return envInt("FREE_PLAN_SESSIONS_PER_MONTH", defaultFreePlanSessionsPerMonth)
+}
+
+func freeActiveTrips() int {
+	return envInt("FREE_ACTIVE_TRIPS", defaultFreeActiveTrips)
+}
+
+// recordPlanSessionStart is the /plan session-start instrumentation: it
+// records the plan_session_started event (for every caller, as before) and,
+// for signed-in users, the plan_runs free-cap crossing signal. Run it in a
+// goroutine — nothing here may sit on the SSE hot path.
+//
+// Crossing rule (only-on-crossing): count the user's PRIOR
+// plan_session_started events in the trailing 30 days — prior, because this
+// session's own started event is written afterwards, so the session being
+// started never counts itself. Emit free_cap_would_hit iff prior == cap:
+// sessions 1..cap are within the free tier, session cap+1 is the first that
+// would have been blocked and the only one that emits (prior > cap emits
+// nothing). The would-hit is written BEFORE the started event so that once a
+// session's started row is visible, any crossing it implies is visible too
+// (what the integration test polls on). Concurrent same-user starts can race
+// the threshold either way; accepted — the signal is approximate by design.
+func recordPlanSessionStart(userID *uuid.UUID, authed bool) {
+	var crossingCount int64
+	if userID != nil && dbPool != nil {
+		limit := freePlanSessionsPerMonth()
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		prior, err := store.New(dbPool).CountEventsByTypeAndUserSince(ctx, store.CountEventsByTypeAndUserSinceParams{
+			EventType: "plan_session_started",
+			UserID:    pgtype.UUID{Bytes: *userID, Valid: true},
+			CreatedAt: time.Now().AddDate(0, 0, -freeCapWindowDays),
+		})
+		cancel()
+		switch {
+		case err != nil:
+			// Fail open: no crossing signal, session proceeds untouched.
+			log.Printf("free cap: plan_runs count failed (skipping signal): %v", err)
+		case prior == int64(limit):
+			crossingCount = prior + 1
+		}
+	}
+	if crossingCount > 0 {
+		recordEventOpt(userID, "free_cap_would_hit", nil, map[string]any{
+			"cap_kind": "plan_runs",
+			"count":    crossingCount,
+		})
+	}
+	recordEventOpt(userID, "plan_session_started", nil, map[string]any{"authenticated": authed})
+}
+
+// recordActiveTripsCapSignal emits the active_trips crossing signal after a
+// trip creation has committed (persistTrip via the agent's create_itinerary,
+// or duplicating a shared trip).
+//
+// Crossing rule (only-on-crossing): count the owner's distinct trip lineages
+// (COALESCE(chat_id, id) — the My Trips grouping, so new versions of an
+// existing lineage never move the count) AFTER the creation, and emit iff the
+// count == cap+1 exactly: the creation that took the user from at-the-cap to
+// one past it. A user already beyond cap+1 (crossed while degraded, or before
+// this shipped) emits nothing — that crossing was missed, not deferred.
+// Deleting back under the cap and crossing again emits again (recurring
+// pressure is signal). Strictly fail-open; never fails the caller.
+func recordActiveTripsCapSignal(userID, tripID uuid.UUID) {
+	if dbPool == nil {
+		return
+	}
+	limit := freeActiveTrips()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	n, err := store.New(dbPool).CountActiveTripLineagesByOwner(ctx, userID)
+	if err != nil {
+		log.Printf("free cap: active_trips count failed (skipping signal): %v", err)
+		return
+	}
+	if n == int64(limit)+1 {
+		recordEvent(userID, "free_cap_would_hit", &tripID, map[string]any{
+			"cap_kind": "active_trips",
+			"count":    n,
+		})
+	}
+}

--- a/src/packages/api/free_cap_integration_test.go
+++ b/src/packages/api/free_cap_integration_test.go
@@ -1,0 +1,224 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Integration coverage for specs/free-cap-instrumentation: env-lowered caps
+// drive a user across each line, and we assert (a) exactly ONE
+// free_cap_would_hit per crossing — the only-on-crossing rule's off-by-ones,
+// (b) the dashboard rollup, and (c) that every capped request still SUCCEEDS
+// (measurement only, nothing enforced).
+
+// fakeAnthropicServer stands in for the Anthropic API behind the
+// ANTHROPIC_BASE_URL seam: every /v1/messages call streams a minimal
+// text-only SSE response ending in end_turn, so a real /plan session runs
+// end-to-end through buildRouter with zero external calls.
+func fakeAnthropicServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		frames := []struct{ event, data string }{
+			{"message_start", `{"type":"message_start","message":{"id":"msg_fake","type":"message","role":"assistant","model":"claude-sonnet-4-6","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":10,"output_tokens":0}}}`},
+			{"content_block_start", `{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`},
+			{"content_block_delta", `{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Where would you like to go?"}}`},
+			{"content_block_stop", `{"type":"content_block_stop","index":0}`},
+			{"message_delta", `{"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":7}}`},
+			{"message_stop", `{"type":"message_stop"}`},
+		}
+		for _, f := range frames {
+			io.WriteString(w, "event: "+f.event+"\ndata: "+f.data+"\n\n")
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// waitForEventCount polls until the user has exactly want events of the given
+// type. plan_session_started is recorded by a goroutine that writes any
+// crossing signal FIRST, so once the started count is visible the would-hit
+// state for that session is settled too.
+func waitForEventCount(t *testing.T, userID uuid.UUID, eventType string, want int) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		n := countUserEvents(t, userID, eventType)
+		if n == want {
+			return
+		}
+		if n > want {
+			t.Fatalf("%s count = %d, exceeded expected %d", eventType, n, want)
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for %d %s events (have %d)", want, eventType, n)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func countUserEvents(t *testing.T, userID uuid.UUID, eventType string) int {
+	t.Helper()
+	var n int
+	err := dbPool.QueryRow(context.Background(),
+		`SELECT count(*) FROM analytics_events WHERE user_id = $1 AND event_type = $2`,
+		userID, eventType).Scan(&n)
+	if err != nil {
+		t.Fatalf("countUserEvents(%s): %v", eventType, err)
+	}
+	return n
+}
+
+// freeCapWouldHits returns how many free_cap_would_hit rows the user has for
+// a cap kind, plus the recorded metadata count of the newest one (0 if none).
+func freeCapWouldHits(t *testing.T, userID uuid.UUID, capKind string) (hits, lastCount int) {
+	t.Helper()
+	err := dbPool.QueryRow(context.Background(),
+		`SELECT count(*), COALESCE(max((metadata->>'count')::int), 0)
+		 FROM analytics_events
+		 WHERE user_id = $1 AND event_type = 'free_cap_would_hit'
+		   AND metadata->>'cap_kind' = $2`,
+		userID, capKind).Scan(&hits, &lastCount)
+	if err != nil {
+		t.Fatalf("freeCapWouldHits(%s): %v", capKind, err)
+	}
+	return hits, lastCount
+}
+
+// plan_runs: with the cap lowered to 2, sessions 1 and 2 are free, session 3
+// is the crossing (prior count == cap) and emits exactly one signal, session
+// 4 (prior > cap) emits nothing more. Every session must succeed.
+func TestFreeCapPlanRunsCrossingSignal(t *testing.T) {
+	resetDB(t)
+	srv := fakeAnthropicServer(t)
+	t.Setenv("ANTHROPIC_API_KEY", "test-key")
+	t.Setenv("ANTHROPIC_BASE_URL", srv.URL)
+	t.Setenv("FREE_PLAN_SESSIONS_PER_MONTH", "2")
+
+	user, token := createTestUser(t, "capped@example.com")
+
+	for i := 1; i <= 4; i++ {
+		rec := doJSON(t, "POST", "/api/v1/plan", token, PlanRequest{
+			ChatID:   fmt.Sprintf("chat-%d", i),
+			Messages: []PlanChatMessage{{Role: "user", Content: "plan me a weekend trip"}},
+		})
+		// Fail-open guarantee: the request SUCCEEDS whether or not the cap
+		// would have been hit.
+		if rec.Code != http.StatusOK {
+			t.Fatalf("session %d: /plan = %d, want 200 (never rejected)", i, rec.Code)
+		}
+		out := rec.Body.String()
+		if !strings.Contains(out, `"type":"text_delta"`) || strings.Contains(out, `"type":"error"`) {
+			t.Fatalf("session %d: stream = %q, want a normal text stream with no error event", i, out)
+		}
+
+		waitForEventCount(t, user.ID, "plan_session_started", i)
+
+		wantHits := 0
+		if i >= 3 {
+			wantHits = 1 // crossing at session cap+1 = 3, and only there
+		}
+		hits, lastCount := freeCapWouldHits(t, user.ID, "plan_runs")
+		if hits != wantHits {
+			t.Fatalf("after session %d: plan_runs would-hits = %d, want %d", i, hits, wantHits)
+		}
+		if i >= 3 && lastCount != 3 {
+			t.Fatalf("would-hit metadata count = %d, want 3 (cap+1)", lastCount)
+		}
+	}
+
+	// Dashboard rollup: one crossing, one distinct user affected.
+	admin, adminToken := createTestUser(t, "metrics-admin@example.com")
+	makeAdmin(t, admin.ID)
+	rec := doJSON(t, "GET", "/api/v1/admin/metrics?days=30", adminToken, nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("admin metrics = %d: %s", rec.Code, rec.Body.String())
+	}
+	body := decode(t, rec)
+	wouldHits, _ := body["free_cap_would_hits"].(map[string]any)
+	usersAffected, _ := body["free_cap_users_affected"].(map[string]any)
+	if wouldHits["plan_runs"] != float64(1) {
+		t.Fatalf("free_cap_would_hits.plan_runs = %v, want 1", wouldHits["plan_runs"])
+	}
+	if usersAffected["plan_runs"] != float64(1) {
+		t.Fatalf("free_cap_users_affected.plan_runs = %v, want 1", usersAffected["plan_runs"])
+	}
+}
+
+// active_trips: with the cap lowered to 1, the copier's first duplicate is
+// within the cap, the second is the crossing (post-creation lineages ==
+// cap+1) and emits exactly once, the third emits nothing. Every duplicate
+// must succeed.
+func TestFreeCapActiveTripsCrossingSignal(t *testing.T) {
+	resetDB(t)
+	t.Setenv("FREE_ACTIVE_TRIPS", "1")
+
+	owner, ownerToken := createTestUser(t, "owner@example.com")
+	copier, copierToken := createTestUser(t, "copier@example.com")
+	trip := createTestTrip(t, owner.ID, 2)
+	shareToken := createShare(t, ownerToken, trip.ID.String(), "")
+
+	for i := 1; i <= 3; i++ {
+		rec := doJSON(t, "POST", "/api/v1/shared/"+shareToken+"/duplicate", copierToken, nil)
+		if rec.Code != http.StatusCreated {
+			t.Fatalf("duplicate %d = %d, want 201 (never rejected): %s", i, rec.Code, rec.Body.String())
+		}
+
+		// The duplicate-path signal is synchronous, so this is settled here.
+		wantHits := 0
+		if i >= 2 {
+			wantHits = 1 // crossing at trip cap+1 = 2, and only there
+		}
+		hits, lastCount := freeCapWouldHits(t, copier.ID, "active_trips")
+		if hits != wantHits {
+			t.Fatalf("after duplicate %d: active_trips would-hits = %d, want %d", i, hits, wantHits)
+		}
+		if i >= 2 && lastCount != 2 {
+			t.Fatalf("would-hit metadata count = %d, want 2 (cap+1)", lastCount)
+		}
+	}
+
+	// The crossing event carries the trip that crossed the line.
+	var withTrip int
+	if err := dbPool.QueryRow(context.Background(),
+		`SELECT count(*) FROM analytics_events
+		 WHERE user_id = $1 AND event_type = 'free_cap_would_hit' AND trip_id IS NOT NULL`,
+		copier.ID).Scan(&withTrip); err != nil {
+		t.Fatalf("trip_id check: %v", err)
+	}
+	if withTrip != 1 {
+		t.Fatalf("would-hit rows with trip_id = %d, want 1", withTrip)
+	}
+
+	// The owner never crossed anything.
+	if hits, _ := freeCapWouldHits(t, owner.ID, "active_trips"); hits != 0 {
+		t.Fatalf("owner would-hits = %d, want 0", hits)
+	}
+}
+
+// free_cap_would_hit is a SERVER-recorded event: the client event endpoint
+// must keep rejecting it (spoofable demand signal otherwise).
+func TestFreeCapEventNotClientRecordable(t *testing.T) {
+	resetDB(t)
+	user, token := createTestUser(t, "spoofer@example.com")
+
+	rec := doJSON(t, "POST", "/api/v1/events", token, map[string]any{
+		"event_type": "free_cap_would_hit",
+		"metadata":   map[string]any{"cap_kind": "plan_runs", "count": 999},
+	})
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("client-recorded free_cap_would_hit = %d, want 400", rec.Code)
+	}
+	if n := countUserEvents(t, user.ID, "free_cap_would_hit"); n != 0 {
+		t.Fatalf("spoofed events recorded = %d, want 0", n)
+	}
+}

--- a/src/packages/api/free_cap_test.go
+++ b/src/packages/api/free_cap_test.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+// Cap values must be read from the environment at call time (per-test
+// overridable) and fall back to the business-model placeholders on anything
+// unset or invalid.
+func TestFreeCapEnvValues(t *testing.T) {
+	t.Setenv("FREE_PLAN_SESSIONS_PER_MONTH", "")
+	t.Setenv("FREE_ACTIVE_TRIPS", "")
+	if got := freePlanSessionsPerMonth(); got != defaultFreePlanSessionsPerMonth {
+		t.Fatalf("unset plan cap = %d, want %d", got, defaultFreePlanSessionsPerMonth)
+	}
+	if got := freeActiveTrips(); got != defaultFreeActiveTrips {
+		t.Fatalf("unset trips cap = %d, want %d", got, defaultFreeActiveTrips)
+	}
+
+	t.Setenv("FREE_PLAN_SESSIONS_PER_MONTH", "2")
+	t.Setenv("FREE_ACTIVE_TRIPS", "1")
+	if got := freePlanSessionsPerMonth(); got != 2 {
+		t.Fatalf("plan cap = %d, want 2", got)
+	}
+	if got := freeActiveTrips(); got != 1 {
+		t.Fatalf("trips cap = %d, want 1", got)
+	}
+
+	// Zero, negative, and garbage all fall back to the defaults.
+	for _, bad := range []string{"0", "-5", "twenty"} {
+		t.Setenv("FREE_PLAN_SESSIONS_PER_MONTH", bad)
+		if got := freePlanSessionsPerMonth(); got != defaultFreePlanSessionsPerMonth {
+			t.Fatalf("plan cap with %q = %d, want default %d", bad, got, defaultFreePlanSessionsPerMonth)
+		}
+	}
+}
+
+// Degraded mode (no database) must be a silent no-op: the signal helpers may
+// never panic or block a request when dbPool is nil.
+func TestFreeCapHelpersFailOpenWithoutDB(t *testing.T) {
+	if dbPool != nil {
+		t.Skip("requires degraded mode (run without TEST_DATABASE_URL)")
+	}
+	recordActiveTripsCapSignal(uuid.New(), uuid.New())
+	uid := uuid.New()
+	recordPlanSessionStart(&uid, true)
+	recordPlanSessionStart(nil, false)
+}

--- a/src/packages/api/local_ingest_handler.go
+++ b/src/packages/api/local_ingest_handler.go
@@ -6,8 +6,6 @@ import (
 	"os"
 	"strings"
 
-	anthropic "github.com/anthropics/anthropic-sdk-go"
-	"github.com/anthropics/anthropic-sdk-go/option"
 	"github.com/google/uuid"
 	"github.com/gorilla/mux"
 
@@ -143,7 +141,7 @@ func ingestLocalHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// 2. Extract structured drafts.
-	client := anthropic.NewClient(option.WithAPIKey(apiKey))
+	client := newAnthropicClient(apiKey)
 	content, err := extractLocalContent(r.Context(), client, city, req.RawText)
 	if err != nil {
 		writeJSONError(w, http.StatusBadGateway, "extraction failed: "+err.Error())

--- a/src/packages/api/plan_handler.go
+++ b/src/packages/api/plan_handler.go
@@ -12,7 +12,6 @@ import (
 	"unicode/utf8"
 
 	anthropic "github.com/anthropics/anthropic-sdk-go"
-	"github.com/anthropics/anthropic-sdk-go/option"
 	"github.com/google/uuid"
 
 	"travel-route-planner/store"
@@ -91,7 +90,7 @@ func planHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	client := anthropic.NewClient(option.WithAPIKey(apiKey))
+	client := newAnthropicClient(apiKey)
 
 	// Resolve the caller once: anonymous sessions get no personalization and no
 	// preference-writing tool; signed-in sessions get both.
@@ -110,7 +109,10 @@ func planHandler(w http.ResponseWriter, r *http.Request) {
 	if authed {
 		planUID = &uid
 	}
-	go recordEventOpt(planUID, "plan_session_started", nil, map[string]any{"authenticated": authed})
+	// Also runs the free-cap plan_runs crossing check (free_cap.go) — one
+	// count query, entirely off the SSE hot path, skipped when unauthed or
+	// degraded.
+	go recordPlanSessionStart(planUID, authed)
 	defer func() {
 		recordEventOpt(planUID, "plan_session_completed", planTripID, map[string]any{
 			"authenticated":         authed,
@@ -505,6 +507,10 @@ func planHandler(w http.ResponseWriter, r *http.Request) {
 							go recordEvent(uid, "trip_created", &parsed, map[string]any{
 								"item_count": len(in.Locations),
 							})
+							// Free-cap active_trips crossing signal — a new
+							// lineage may take the user past the cap; new
+							// versions of an existing lineage never do.
+							go recordActiveTripsCapSignal(uid, parsed)
 						}
 						// Distill what this conversation revealed about the traveler
 						// in the background — it must never delay or fail the trip.

--- a/src/packages/api/query/analytics.sql
+++ b/src/packages/api/query/analytics.sql
@@ -9,6 +9,23 @@ SELECT event_type, count(*)::bigint AS n FROM analytics_events
 WHERE created_at >= $1
 GROUP BY event_type;
 
+-- name: CountEventsByTypeAndUserSince :one
+-- Per-user event count for a trailing window — the free-cap crossing check
+-- (specs/free-cap-instrumentation). Counting off analytics_events undercounts
+-- in degraded mode; acceptable for a demand signal (see the spec).
+SELECT count(*) FROM analytics_events
+WHERE event_type = $1 AND user_id = $2 AND created_at >= $3;
+
+-- name: FreeCapWouldHitCounts :many
+-- Dashboard rollup for free_cap_would_hit: crossings observed plus the
+-- distinct users affected, per cap_kind (plan_runs / active_trips).
+SELECT COALESCE(metadata->>'cap_kind', 'unknown')::text AS cap_kind,
+       count(*)::bigint AS would_hits,
+       count(DISTINCT user_id)::bigint AS users_affected
+FROM analytics_events
+WHERE event_type = 'free_cap_would_hit' AND created_at >= $1
+GROUP BY 1;
+
 -- name: CountActivatedSignups :one
 -- Users who registered in the window and have saved at least one trip (ever).
 SELECT count(DISTINCT r.user_id) FROM analytics_events r

--- a/src/packages/api/query/trips.sql
+++ b/src/packages/api/query/trips.sql
@@ -39,6 +39,14 @@ LEFT JOIN LATERAL (
 ) c ON true
 ORDER BY latest.created_at DESC;
 
+-- name: CountActiveTripLineagesByOwner :one
+-- Active trips for the free-cap signal (specs/free-cap-instrumentation):
+-- one per chat lineage, the same COALESCE(chat_id, id::text) grouping
+-- ListLatestTripsByOwner's DISTINCT ON uses — new versions of an existing
+-- lineage don't add to the count. All saved trips count as active (no
+-- archived status exists today).
+SELECT count(DISTINCT COALESCE(chat_id, id::text)) FROM trips WHERE user_id = $1;
+
 -- name: ListTripVersionsByChat :many
 SELECT * FROM trips WHERE user_id = $1 AND chat_id = $2 ORDER BY created_at DESC;
 

--- a/src/packages/api/share_handler.go
+++ b/src/packages/api/share_handler.go
@@ -304,6 +304,11 @@ func duplicateSharedTripHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Free-cap active_trips crossing signal (free_cap.go) — a duplicate is
+	// always a fresh lineage. Synchronous but strictly fail-open: it can log,
+	// never fail the request.
+	recordActiveTripsCapSignal(user.ID, copyTrip.ID)
+
 	qr := store.New(dbPool)
 	final, err := qr.GetTripByIDAndOwner(ctx, store.GetTripByIDAndOwnerParams{ID: copyTrip.ID, UserID: user.ID})
 	if err != nil {

--- a/src/packages/api/store/analytics.sql.go
+++ b/src/packages/api/store/analytics.sql.go
@@ -58,6 +58,27 @@ func (q *Queries) CountActivatedSignups(ctx context.Context, createdAt time.Time
 	return count, err
 }
 
+const countEventsByTypeAndUserSince = `-- name: CountEventsByTypeAndUserSince :one
+SELECT count(*) FROM analytics_events
+WHERE event_type = $1 AND user_id = $2 AND created_at >= $3
+`
+
+type CountEventsByTypeAndUserSinceParams struct {
+	EventType string      `json:"event_type"`
+	UserID    pgtype.UUID `json:"user_id"`
+	CreatedAt time.Time   `json:"created_at"`
+}
+
+// Per-user event count for a trailing window — the free-cap crossing check
+// (specs/free-cap-instrumentation). Counting off analytics_events undercounts
+// in degraded mode; acceptable for a demand signal (see the spec).
+func (q *Queries) CountEventsByTypeAndUserSince(ctx context.Context, arg CountEventsByTypeAndUserSinceParams) (int64, error) {
+	row := q.db.QueryRow(ctx, countEventsByTypeAndUserSince, arg.EventType, arg.UserID, arg.CreatedAt)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
 const countEventsByTypeGrouped = `-- name: CountEventsByTypeGrouped :many
 SELECT event_type, count(*)::bigint AS n FROM analytics_events
 WHERE created_at >= $1
@@ -123,6 +144,43 @@ func (q *Queries) CreateAnalyticsEvent(ctx context.Context, arg CreateAnalyticsE
 		arg.Metadata,
 	)
 	return err
+}
+
+const freeCapWouldHitCounts = `-- name: FreeCapWouldHitCounts :many
+SELECT COALESCE(metadata->>'cap_kind', 'unknown')::text AS cap_kind,
+       count(*)::bigint AS would_hits,
+       count(DISTINCT user_id)::bigint AS users_affected
+FROM analytics_events
+WHERE event_type = 'free_cap_would_hit' AND created_at >= $1
+GROUP BY 1
+`
+
+type FreeCapWouldHitCountsRow struct {
+	CapKind       string `json:"cap_kind"`
+	WouldHits     int64  `json:"would_hits"`
+	UsersAffected int64  `json:"users_affected"`
+}
+
+// Dashboard rollup for free_cap_would_hit: crossings observed plus the
+// distinct users affected, per cap_kind (plan_runs / active_trips).
+func (q *Queries) FreeCapWouldHitCounts(ctx context.Context, createdAt time.Time) ([]FreeCapWouldHitCountsRow, error) {
+	rows, err := q.db.Query(ctx, freeCapWouldHitCounts, createdAt)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []FreeCapWouldHitCountsRow
+	for rows.Next() {
+		var i FreeCapWouldHitCountsRow
+		if err := rows.Scan(&i.CapKind, &i.WouldHits, &i.UsersAffected); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }
 
 const planSessionTotals = `-- name: PlanSessionTotals :one

--- a/src/packages/api/store/trips.sql.go
+++ b/src/packages/api/store/trips.sql.go
@@ -29,6 +29,22 @@ func (q *Queries) CloseItineraryItemPositionGap(ctx context.Context, arg CloseIt
 	return err
 }
 
+const countActiveTripLineagesByOwner = `-- name: CountActiveTripLineagesByOwner :one
+SELECT count(DISTINCT COALESCE(chat_id, id::text)) FROM trips WHERE user_id = $1
+`
+
+// Active trips for the free-cap signal (specs/free-cap-instrumentation):
+// one per chat lineage, the same COALESCE(chat_id, id::text) grouping
+// ListLatestTripsByOwner's DISTINCT ON uses — new versions of an existing
+// lineage don't add to the count. All saved trips count as active (no
+// archived status exists today).
+func (q *Queries) CountActiveTripLineagesByOwner(ctx context.Context, userID uuid.UUID) (int64, error) {
+	row := q.db.QueryRow(ctx, countActiveTripLineagesByOwner, userID)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
 const createItineraryItem = `-- name: CreateItineraryItem :one
 INSERT INTO itinerary_items (trip_id, position, name, place_id, address, latitude, longitude, category, time_of_day, city, day_trip_from, day, local_source_name, local_recommendation_id)
 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)

--- a/src/packages/flutter-app/lib/models/admin_metrics.dart
+++ b/src/packages/flutter-app/lib/models/admin_metrics.dart
@@ -73,6 +73,16 @@ class AdminMetrics {
   @JsonKey(name: 'alerts_triggered')
   final int alertsTriggered;
 
+  /// Free-cap would-hit crossings per cap kind (plan_runs / active_trips) —
+  /// the Phase-3 demand signal. Measurement only; nothing is enforced.
+  @JsonKey(name: 'free_cap_would_hits')
+  final Map<String, int> freeCapWouldHits;
+
+  /// Distinct users who crossed each cap at least once in the window — the
+  /// cohort size the paid-tier trigger reads.
+  @JsonKey(name: 'free_cap_users_affected')
+  final Map<String, int> freeCapUsersAffected;
+
   const AdminMetrics({
     this.days = 30,
     this.signups = 0,
@@ -100,6 +110,8 @@ class AdminMetrics {
     this.estCogsPerActiveUser = 0,
     this.alertsCreated = 0,
     this.alertsTriggered = 0,
+    this.freeCapWouldHits = const {},
+    this.freeCapUsersAffected = const {},
   });
 
   factory AdminMetrics.fromJson(Map<String, dynamic> json) =>

--- a/src/packages/flutter-app/lib/models/admin_metrics.g.dart
+++ b/src/packages/flutter-app/lib/models/admin_metrics.g.dart
@@ -45,6 +45,16 @@ AdminMetrics _$AdminMetricsFromJson(Map<String, dynamic> json) => AdminMetrics(
           (json['est_cogs_per_active_user'] as num?)?.toDouble() ?? 0,
       alertsCreated: (json['alerts_created'] as num?)?.toInt() ?? 0,
       alertsTriggered: (json['alerts_triggered'] as num?)?.toInt() ?? 0,
+      freeCapWouldHits:
+          (json['free_cap_would_hits'] as Map<String, dynamic>?)?.map(
+                (k, e) => MapEntry(k, (e as num).toInt()),
+              ) ??
+              const {},
+      freeCapUsersAffected:
+          (json['free_cap_users_affected'] as Map<String, dynamic>?)?.map(
+                (k, e) => MapEntry(k, (e as num).toInt()),
+              ) ??
+              const {},
     );
 
 Map<String, dynamic> _$AdminMetricsToJson(AdminMetrics instance) =>
@@ -75,4 +85,6 @@ Map<String, dynamic> _$AdminMetricsToJson(AdminMetrics instance) =>
       'est_cogs_per_active_user': instance.estCogsPerActiveUser,
       'alerts_created': instance.alertsCreated,
       'alerts_triggered': instance.alertsTriggered,
+      'free_cap_would_hits': instance.freeCapWouldHits,
+      'free_cap_users_affected': instance.freeCapUsersAffected,
     };

--- a/src/packages/flutter-app/lib/screens/admin_metrics_screen.dart
+++ b/src/packages/flutter-app/lib/screens/admin_metrics_screen.dart
@@ -127,6 +127,13 @@ class _MetricsBody extends StatelessWidget {
               caption: '${m.planSessionsAnonymous} anonymous'),
           _Stat('Agent loop cap hits', '${m.agentLoopCapHits}',
               caption: 'runaway-loop signal'),
+          _Stat('Would hit plan cap', '${m.freeCapWouldHits['plan_runs'] ?? 0}',
+              caption:
+                  '${m.freeCapUsersAffected['plan_runs'] ?? 0} users affected'),
+          _Stat(
+              'Would hit trip cap', '${m.freeCapWouldHits['active_trips'] ?? 0}',
+              caption:
+                  '${m.freeCapUsersAffected['active_trips'] ?? 0} users affected'),
           _Stat('Tokens in', _tokens(m.planInputTokens),
               caption: '${_tokens(m.planCacheReadTokens)} from cache'),
           _Stat('Tokens out', _tokens(m.planOutputTokens),

--- a/src/packages/flutter-app/test/admin_metrics_screen_test.dart
+++ b/src/packages/flutter-app/test/admin_metrics_screen_test.dart
@@ -34,6 +34,8 @@ void main() {
       estCogsPerActiveUser: 0.21,
       alertsCreated: 5,
       alertsTriggered: 1,
+      freeCapWouldHits: {'plan_runs': 3, 'active_trips': 1},
+      freeCapUsersAffected: {'plan_runs': 2, 'active_trips': 1},
     );
 
     await tester.pumpWidget(
@@ -58,6 +60,11 @@ void main() {
     expect(find.text('\$0.21'), findsOneWidget); // est. cost / active user
     expect(find.text('Claude only, estimate'), findsOneWidget);
     expect(find.text('Agent loop cap hits'), findsOneWidget);
+    expect(find.text('Would hit plan cap'), findsOneWidget);
+    expect(find.text('2 users affected'), findsOneWidget); // plan_runs cohort
+    expect(find.text('Would hit trip cap'), findsOneWidget);
+    expect(
+        find.text('1 users affected'), findsOneWidget); // active_trips cohort
     expect(find.text('Clicks by provider'), findsOneWidget);
     expect(find.text('booking'), findsOneWidget);
     expect(find.text('Price alerts'), findsOneWidget);


### PR DESCRIPTION
## What

Phase 3 of `docs/business-model.md` triggers on "a measured cohort actually hitting the free caps" — but no cap existed in code, so the trigger was unmeasurable. This PR adds **fail-open measurement only**: a server-side `free_cap_would_hit` analytics event fires at the moment a signed-in user *would have* been blocked if the §4 placeholder caps were enforced. **No enforcement, no paywall — no request is ever rejected, delayed, or altered by this feature.**

## Spec first

`specs/free-cap-instrumentation/` (spec.md + plan.md) fixes what Phase-3 pricing will read off of:
- **Only-on-crossing emission rule** and why — per-event dashboard counts would otherwise inflate with over-cap usage instead of measuring users encountering the cap.
- **Degraded-mode undercount is accepted** — counting off the best-effort `analytics_events` log makes the signal conservative, the safe direction for a launch trigger.
- **`usage_counters` upgrade path** documented for if strict metering/enforcement ever ships.
- Cap defaults + env vars: `FREE_PLAN_SESSIONS_PER_MONTH` (20, trailing 30 days) and `FREE_ACTIVE_TRIPS` (3), read at call time via `envInt` (the `ALERT_TICK_MINUTES` pattern) so tests/ops can lower them with no deploy.

## Crossing rules (exact)

- **plan_runs:** at authed session start, count the user's *prior* `plan_session_started` events in the trailing 30 days (prior = before this session's own event is written, so a session never counts itself). Emit iff `prior == cap` — the (cap+1)-th session in a window, and only it. Runs inside the existing instrumentation goroutine: zero queries on the SSE hot path, skipped entirely when unauthed or degraded. The would-hit is written *before* the started event so a visible started row implies settled crossing state (what the test polls on).
- **active_trips:** after a committed trip creation (`persistTrip` via `create_itinerary`, or duplicate-shared-trip), count the owner's distinct trip lineages (`COALESCE(chat_id, id)` — the same grouping My Trips uses, so new *versions* never move the count). Emit iff `count == cap + 1` exactly. Duplicate-path call is synchronous (still fail-open) for deterministic tests; agent-path stays fire-and-forget like its neighbors.
- Re-crossing (rolling window, or delete-then-recreate) emits again — recurring pressure is signal. `metadata.count` records cap+1 so each event is self-describing about the threshold in force when it fired.

## Dashboard

`GET /admin/metrics` gains `free_cap_would_hits` + `free_cap_users_affected` maps (per cap_kind, one grouped query), with Flutter tiles next to *Agent loop cap hits* (post-#68 naming). `free_cap_would_hit` is **not** added to the client `POST /events` whitelist (spoofable demand otherwise) — with a test pinning that.

## Rider: Anthropic base-URL seam

`newAnthropicClient()` pins `option.WithBaseURL(ANTHROPIC_BASE_URL)` at both client constructions (`plan_handler.go`, `local_ingest_handler.go`); unset ⇒ behavior identical. This is the seam a fake-Anthropic e2e harness needs — and this PR's own integration test already uses it: a `httptest` server streams a minimal SSE response, so **real authed `/plan` sessions run end-to-end through `buildRouter` with zero external calls**.

## Tests

- Integration (`resetDB`/`doJSON`/`createTestUser`, unique X-Forwarded-For): `FREE_PLAN_SESSIONS_PER_MONTH=2` drives 4 real `/plan` sessions — exactly one `free_cap_would_hit` (fires at session 3, not 2, not 4), `count=3`, dashboard fields correct, every request 200 with a clean stream. Same for `FREE_ACTIVE_TRIPS=1` via 3 shared-trip duplicates (fires at #2 only, `count=2`, trip_id set, all 201).
- Unit: env parsing defaults/overrides/garbage; degraded-mode helpers never panic.
- No migrations; schema stays 00030. `store/` regenerated via `make api-sqlc`.

## Gates

- `make api-sqlc` (committed), `make api-fmt`, `make api-vet` ✅
- `go test ./...` (unit) ✅; `TEST_DATABASE_URL=…travel_test_pr7… go test -count=1 ./...` all pass ✅
- `flutter pub get`, `dart run build_runner build --delete-conflicting-outputs`, `flutter test` (44/44), `flutter analyze --no-fatal-infos --fatal-warnings` exit 0 (12 pre-existing infos, none added) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)