### PR TITLE
Wave 7 review sweep: 6 confirmed fixes across security, caps, metrics, flights UI

### DIFF
--- a/specs/instrumentation-events/spec.md
+++ b/specs/instrumentation-events/spec.md
@@ -106,11 +106,18 @@ not the other way around.
 
 - **`second_trip_retention`** — the business model's retention metric ("users
   returning for a second trip", the Phase 3 trigger): count of signed-in users
-  with **≥ 2 `trip_created` events at least 7 days apart** inside the window
-  (implemented as `max(created_at) − min(created_at) ≥ 7 days` per user, which
-  implies ≥ 2 events). The 7-day gap is what separates "came back for another
-  trip" from "kept editing the same planning burst"; two trips created the
-  same week count once.
+  whose `trip_created` events span **≥ 2 distinct trip lineages with first
+  creations at least 7 days apart** inside the window. A *lineage* is the My
+  Trips grouping (`COALESCE(trips.chat_id, trips.id)`): `trip_created` fires
+  on every finalize, including a new **version** of an existing chat lineage,
+  so events are deduplicated to one first-creation timestamp per lineage
+  before the spread check (`max(first_at) − min(first_at) ≥ 7 days` per user,
+  which implies ≥ 2 lineages). The 7-day gap is what separates "came back for
+  another trip" from "kept editing the same planning burst"; two trips created
+  the same week count once, and re-finalizing one trip weeks later counts
+  zero. Known trade-off: the lineage lookup joins `trips`, so events whose
+  trip row was later deleted drop out (slight undercount, preferred over the
+  version-save overcount).
 - **`session_frequency_returning`** — the metric formerly (and misleadingly)
   named `returning_users`: users with planning sessions on ≥ 2 distinct days
   in the window. It is a **session-frequency proxy**, not trip retention — a

--- a/src/packages/api/admin_integration_test.go
+++ b/src/packages/api/admin_integration_test.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+
+	"travel-route-planner/store"
 )
 
 func TestAdminRoutesRequireAdmin(t *testing.T) {
@@ -60,8 +62,36 @@ func insertEvent(t *testing.T, userID uuid.UUID, eventType string, at time.Time,
 	}
 }
 
+// insertTripCreated writes a trip_created event carrying its trip_id, the way
+// plan_handler records it — second_trip_retention dedupes by the referenced
+// trip's lineage, so the linkage matters.
+func insertTripCreated(t *testing.T, userID, tripID uuid.UUID, at time.Time) {
+	t.Helper()
+	_, err := dbPool.Exec(context.Background(),
+		`INSERT INTO analytics_events (user_id, event_type, trip_id, created_at)
+		 VALUES ($1, 'trip_created', $2, $3)`, userID, tripID, at)
+	if err != nil {
+		t.Fatalf("insertTripCreated: %v", err)
+	}
+}
+
+// createTripInLineage inserts a bare trips row in the given chat lineage —
+// two calls with the same chatID model a version save (one lineage, two
+// trip_created events).
+func createTripInLineage(t *testing.T, owner uuid.UUID, chatID string) uuid.UUID {
+	t.Helper()
+	trip, err := store.New(dbPool).CreateTrip(context.Background(), store.CreateTripParams{
+		UserID: owner, Title: "Lineage Trip", Status: "draft", ChatID: &chatID,
+	})
+	if err != nil {
+		t.Fatalf("createTripInLineage(%s): %v", chatID, err)
+	}
+	return trip.ID
+}
+
 // TestAdminMetricsValues seeds a shaped event log and asserts the grouped
-// counts, second-trip retention (≥2 trip_created events ≥7 days apart), MAU,
+// counts, second-trip retention (≥2 distinct trip LINEAGES with first
+// creations ≥7 days apart — version saves of one lineage never count), MAU,
 // the Claude cost estimate, and the plan_cap_hits → agent_loop_cap_hits /
 // returning_users → session_frequency_returning renames.
 func TestAdminMetricsValues(t *testing.T) {
@@ -70,17 +100,25 @@ func TestAdminMetricsValues(t *testing.T) {
 	makeAdmin(t, admin.ID)
 	userA, _ := createTestUser(t, "retained@example.com")
 	userB, _ := createTestUser(t, "notyet@example.com")
+	userC, _ := createTestUser(t, "versioner@example.com")
 
 	now := time.Now()
 	insertEvent(t, userA.ID, "user_registered", now, "")
 	insertEvent(t, userB.ID, "user_registered", now, "")
+	insertEvent(t, userC.ID, "user_registered", now, "")
 
-	// A: two trips 8 days apart => counts toward second_trip_retention.
-	insertEvent(t, userA.ID, "trip_created", now.AddDate(0, 0, -8), "")
-	insertEvent(t, userA.ID, "trip_created", now, "")
-	// B: two trips only 2 days apart => session enthusiasm, not retention.
-	insertEvent(t, userB.ID, "trip_created", now.AddDate(0, 0, -2), "")
-	insertEvent(t, userB.ID, "trip_created", now, "")
+	// A: two DISTINCT lineages 8 days apart => counts toward
+	// second_trip_retention.
+	insertTripCreated(t, userA.ID, createTripInLineage(t, userA.ID, "chat-a1"), now.AddDate(0, 0, -8))
+	insertTripCreated(t, userA.ID, createTripInLineage(t, userA.ID, "chat-a2"), now)
+	// B: two distinct lineages only 2 days apart => session enthusiasm, not
+	// retention.
+	insertTripCreated(t, userB.ID, createTripInLineage(t, userB.ID, "chat-b1"), now.AddDate(0, 0, -2))
+	insertTripCreated(t, userB.ID, createTripInLineage(t, userB.ID, "chat-b2"), now)
+	// C: two trip_created events 8 days apart but on the SAME lineage (a
+	// re-finalized chat, i.e. a version save) => must NOT count as retention.
+	insertTripCreated(t, userC.ID, createTripInLineage(t, userC.ID, "chat-c1"), now.AddDate(0, 0, -8))
+	insertTripCreated(t, userC.ID, createTripInLineage(t, userC.ID, "chat-c1"), now)
 
 	// A is the sole active (MAU) user; one completed session that hit the
 	// agent-loop cap and burned exactly 1M input + 1M output tokens
@@ -97,9 +135,9 @@ func TestAdminMetricsValues(t *testing.T) {
 
 	// Grouped per-type counts (one GROUP BY query feeds all of these).
 	for field, want := range map[string]float64{
-		"signups":                     2,
-		"trips_created":               4,
-		"second_trip_retention":       1,
+		"signups":                     3,
+		"trips_created":               6,
+		"second_trip_retention":       1, // A only: B lacks the 7-day gap, C's gap is within one lineage
 		"session_frequency_returning": 0, // A's sessions all on one day
 		"active_users":                1,
 		"plan_sessions":               1,

--- a/src/packages/api/analytics.go
+++ b/src/packages/api/analytics.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -28,6 +29,46 @@ var clientEventTypes = map[string]bool{
 
 // maxEventMetadataBytes caps the metadata bag (small, flat detail only).
 const maxEventMetadataBytes = 2048
+
+// clientEventMetadataKeys is the closed set of metadata keys POST /events
+// accepts — exactly what lib/utils/tracked_launch.dart sends. Metadata feeds
+// GROUP BYs on the admin dashboard (BookingClicksByProvider), so arbitrary
+// client-chosen keys/values must not reach storage.
+var clientEventMetadataKeys = map[string]bool{
+	"provider": true,
+	"surface":  true,
+	"kind":     true,
+	"todo_key": true,
+}
+
+// maxClientMetadataValueLen caps each accepted metadata value; real values
+// are short slugs ("duffel", "booking_checklist").
+const maxClientMetadataValueLen = 64
+
+// sanitizeClientEventMetadata keeps only whitelisted keys whose values are
+// non-empty strings within the length cap; everything else is dropped
+// (best-effort tracking, never an error). provider is lowercased because the
+// dashboard groups on it verbatim.
+func sanitizeClientEventMetadata(in map[string]any) map[string]any {
+	var out map[string]any
+	for k, v := range in {
+		if !clientEventMetadataKeys[k] {
+			continue
+		}
+		s, ok := v.(string)
+		if !ok || s == "" || len(s) > maxClientMetadataValueLen {
+			continue
+		}
+		if k == "provider" {
+			s = strings.ToLower(s)
+		}
+		if out == nil {
+			out = map[string]any{}
+		}
+		out[k] = s
+	}
+	return out
+}
 
 // recordEvent writes one analytics event. Fire-and-forget semantics: errors
 // are logged, never returned — callers must not branch on instrumentation.
@@ -97,7 +138,26 @@ func recordClientEventHandler(w http.ResponseWriter, r *http.Request) {
 			tripID = &tid
 		}
 	}
-	go recordEvent(user.ID, req.EventType, tripID, req.Metadata)
+	meta := sanitizeClientEventMetadata(req.Metadata)
+	go func() {
+		// Best-effort trip validation off the response path: attach-rate
+		// counts DISTINCT trip_id, so a fabricated/foreign UUID must not be
+		// stored. A trip_id survives only when the trip exists and the caller
+		// may access it (owner or editor collaborator — the same
+		// GetEditableTripByID gate the trip endpoints use); any mismatch or
+		// lookup error nulls the reference instead of rejecting the event.
+		// Skipped in degraded mode (recordEvent drops the event then anyway).
+		if tripID != nil && dbPool != nil {
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			if _, err := store.New(dbPool).GetEditableTripByID(ctx, store.GetEditableTripByIDParams{
+				ID: *tripID, UserID: user.ID,
+			}); err != nil {
+				tripID = nil
+			}
+			cancel()
+		}
+		recordEvent(user.ID, req.EventType, tripID, meta)
+	}()
 	w.WriteHeader(http.StatusAccepted)
 }
 

--- a/src/packages/api/analytics_integration_test.go
+++ b/src/packages/api/analytics_integration_test.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+// Integration coverage for POST /api/v1/events hardening: trip_id must be
+// verified (exists + caller may access it) before it can feed the attach-rate
+// numerator, and metadata is constrained to the closed key set the Flutter
+// tracker sends. Everything stays best-effort — bad inputs degrade the event,
+// never reject it.
+
+// clientEventRow fetches the caller's single booking_link_clicked row.
+func clientEventRow(t *testing.T, userID uuid.UUID) (tripID *string, metadata map[string]any) {
+	t.Helper()
+	var meta map[string]any
+	err := dbPool.QueryRow(context.Background(),
+		`SELECT trip_id::text, metadata FROM analytics_events
+		 WHERE user_id = $1 AND event_type = 'booking_link_clicked'`,
+		userID).Scan(&tripID, &meta)
+	if err != nil {
+		t.Fatalf("clientEventRow: %v", err)
+	}
+	return tripID, meta
+}
+
+func postBookingClick(t *testing.T, token string, tripID *string, metadata map[string]any) {
+	t.Helper()
+	body := map[string]any{"event_type": "booking_link_clicked", "metadata": metadata}
+	if tripID != nil {
+		body["trip_id"] = *tripID
+	}
+	rec := doJSON(t, "POST", "/api/v1/events", token, body)
+	if rec.Code != 202 {
+		t.Fatalf("POST /events = %d, want 202: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestClientEventForeignTripIDIsNulled(t *testing.T) {
+	resetDB(t)
+	owner, _ := createTestUser(t, "trip-owner@example.com")
+	stranger, strangerToken := createTestUser(t, "stranger@example.com")
+	trip := createTestTrip(t, owner.ID, 1)
+
+	tid := trip.ID.String()
+	postBookingClick(t, strangerToken, &tid, map[string]any{"provider": "duffel"})
+	waitForEventCount(t, stranger.ID, "booking_link_clicked", 1)
+
+	gotTrip, _ := clientEventRow(t, stranger.ID)
+	if gotTrip != nil {
+		t.Fatalf("foreign trip_id stored as %v, want NULL", *gotTrip)
+	}
+}
+
+func TestClientEventFabricatedTripIDIsNulled(t *testing.T) {
+	resetDB(t)
+	user, token := createTestUser(t, "fabricator@example.com")
+
+	fake := uuid.NewString()
+	postBookingClick(t, token, &fake, map[string]any{"provider": "duffel"})
+	waitForEventCount(t, user.ID, "booking_link_clicked", 1)
+
+	gotTrip, _ := clientEventRow(t, user.ID)
+	if gotTrip != nil {
+		t.Fatalf("fabricated trip_id stored as %v, want NULL", *gotTrip)
+	}
+
+	// The attach-rate numerator must not have moved.
+	var n int
+	if err := dbPool.QueryRow(context.Background(),
+		`SELECT count(DISTINCT trip_id) FROM analytics_events
+		 WHERE event_type = 'booking_link_clicked' AND trip_id IS NOT NULL`).Scan(&n); err != nil {
+		t.Fatalf("attach count: %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("trips_with_booking_click = %d, want 0", n)
+	}
+}
+
+func TestClientEventOwnTripIDIsKept(t *testing.T) {
+	resetDB(t)
+	owner, token := createTestUser(t, "legit-owner@example.com")
+	trip := createTestTrip(t, owner.ID, 1)
+
+	tid := trip.ID.String()
+	postBookingClick(t, token, &tid, map[string]any{"provider": "Duffel", "surface": "flight_card"})
+	waitForEventCount(t, owner.ID, "booking_link_clicked", 1)
+
+	gotTrip, meta := clientEventRow(t, owner.ID)
+	if gotTrip == nil || *gotTrip != tid {
+		t.Fatalf("own trip_id = %v, want %s", gotTrip, tid)
+	}
+	// provider is lowercased at ingest (the dashboard groups on it verbatim).
+	if meta["provider"] != "duffel" {
+		t.Fatalf("provider = %v, want %q", meta["provider"], "duffel")
+	}
+	if meta["surface"] != "flight_card" {
+		t.Fatalf("surface = %v, want flight_card", meta["surface"])
+	}
+}
+
+func TestClientEventMetadataSanitized(t *testing.T) {
+	resetDB(t)
+	user, token := createTestUser(t, "meta-abuser@example.com")
+
+	long := make([]byte, maxClientMetadataValueLen+1)
+	for i := range long {
+		long[i] = 'x'
+	}
+	postBookingClick(t, token, nil, map[string]any{
+		"provider": "FerryHopper",
+		"surface":  string(long),     // oversized value: dropped
+		"kind":     42,               // non-string value: dropped
+		"evil_key": "not-in-the-set", // unknown key: dropped
+		"todo_key": "flight_JFK_CDG", // allowed, kept
+		"cap_kind": "active_trips",   // unknown key (server-event field): dropped
+	})
+	waitForEventCount(t, user.ID, "booking_link_clicked", 1)
+
+	_, meta := clientEventRow(t, user.ID)
+	want := map[string]any{"provider": "ferryhopper", "todo_key": "flight_JFK_CDG"}
+	if len(meta) != len(want) {
+		t.Fatalf("metadata = %v, want exactly %v", meta, want)
+	}
+	for k, v := range want {
+		if meta[k] != v {
+			t.Fatalf("metadata[%s] = %v, want %v", k, meta[k], v)
+		}
+	}
+}

--- a/src/packages/api/events_service.go
+++ b/src/packages/api/events_service.go
@@ -131,7 +131,10 @@ func (s *EventsService) SearchEvents(ctx context.Context, city, startDate, endDa
 
 	resp, err := s.Client.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("request failed: %w", err)
+		// redactTransportError: a *url.Error would embed the request URL,
+		// apikey= included, into the error chain (and from there into
+		// responses/tool results).
+		return nil, fmt.Errorf("request failed: %w", redactTransportError(err))
 	}
 	defer resp.Body.Close()
 
@@ -296,7 +299,11 @@ func eventsSearchHandler(w http.ResponseWriter, r *http.Request) {
 
 	events, err := eventsService.SearchEvents(r.Context(), city, startDate, endDate, category)
 	if err != nil {
-		http.Error(w, fmt.Sprintf("Failed to search events: %v", err), http.StatusInternalServerError)
+		// Log the detail server-side; clients get a generic message so
+		// provider/internal error strings never reach an unauthenticated
+		// caller.
+		ctxLog(r.Context()).Error("events search failed", "error", err)
+		http.Error(w, "Failed to search events", http.StatusInternalServerError)
 		return
 	}
 

--- a/src/packages/api/events_service_test.go
+++ b/src/packages/api/events_service_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -79,5 +80,29 @@ func TestSearchEventsWithoutKeyErrors(t *testing.T) {
 	}
 	if *calls != 0 {
 		t.Fatalf("Ticketmaster called %d times without a key, want 0", *calls)
+	}
+}
+
+// Transport-level failures must never put the Ticketmaster key (an `apikey=`
+// query param) into the error chain — eventsSearchHandler and the /plan
+// agent's search_events tool both surface these error strings.
+func TestSearchEventsTransportErrorOmitsAPIKey(t *testing.T) {
+	const secret = "SECRET-TICKETMASTER-KEY"
+	svc := &EventsService{
+		APIKey:  secret,
+		BaseURL: "https://app.ticketmaster.example/discovery/v2",
+		Client:  &http.Client{Transport: failingTransport{}},
+		cache:   newTTLCache[[]Event](eventsCacheTTL, 100),
+	}
+	_, err := svc.SearchEvents(context.Background(), "Paris", "2026-08-01", "2026-08-03", nil)
+	if err == nil {
+		t.Fatal("expected a transport error")
+	}
+	msg := err.Error()
+	if strings.Contains(msg, secret) || strings.Contains(msg, "apikey=") {
+		t.Fatalf("error leaks the API key: %q", msg)
+	}
+	if !strings.Contains(msg, "connection refused") {
+		t.Fatalf("redaction lost the underlying cause: %q", msg)
 	}
 }

--- a/src/packages/api/free_cap_integration_test.go
+++ b/src/packages/api/free_cap_integration_test.go
@@ -222,3 +222,102 @@ func TestFreeCapEventNotClientRecordable(t *testing.T) {
 		t.Fatalf("spoofed events recorded = %d, want 0", n)
 	}
 }
+
+// fakeAnthropicItineraryServer stands in for the Anthropic API for sessions
+// that finalize a trip: any request that does not yet carry a tool_result
+// gets a create_itinerary tool_use (driving plan_handler's persistTrip
+// branch), and the follow-up request (which echoes the tool result back)
+// gets a plain end_turn text answer. Keying on the request body rather than
+// a call counter keeps it deterministic when background callers (the profile
+// distiller) also hit the seam.
+func fakeAnthropicItineraryServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	textFrames := []struct{ event, data string }{
+		{"message_start", `{"type":"message_start","message":{"id":"msg_fake","type":"message","role":"assistant","model":"claude-sonnet-4-6","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":10,"output_tokens":0}}}`},
+		{"content_block_start", `{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`},
+		{"content_block_delta", `{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Your itinerary is saved."}}`},
+		{"content_block_stop", `{"type":"content_block_stop","index":0}`},
+		{"message_delta", `{"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":7}}`},
+		{"message_stop", `{"type":"message_stop"}`},
+	}
+	toolFrames := []struct{ event, data string }{
+		{"message_start", `{"type":"message_start","message":{"id":"msg_tool","type":"message","role":"assistant","model":"claude-sonnet-4-6","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":10,"output_tokens":0}}}`},
+		{"content_block_start", `{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_01","name":"create_itinerary","input":{}}}`},
+		{"content_block_delta", `{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"title\":\"Athens Weekend\",\"locations\":[{\"name\":\"Acropolis\",\"latitude\":37.97,\"longitude\":23.72,\"day\":1}]}"}}`},
+		{"content_block_stop", `{"type":"content_block_stop","index":0}`},
+		{"message_delta", `{"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"output_tokens":9}}`},
+		{"message_stop", `{"type":"message_stop"}`},
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		frames := toolFrames
+		if strings.Contains(string(body), "tool_result") {
+			frames = textFrames
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		for _, f := range frames {
+			io.WriteString(w, "event: "+f.event+"\ndata: "+f.data+"\n\n")
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// Version saves must never re-emit the active_trips crossing signal
+// (specs/free-cap-instrumentation: "Saving a new version of an existing trip
+// does not increase the count and can never emit"). With the cap at 1 and one
+// pre-existing lineage, the FIRST finalize of a new chat is the crossing
+// (2 lineages == cap+1) and emits once; re-finalizing the SAME chat creates
+// new versions, leaves the lineage count parked at exactly cap+1, and — the
+// regression this guards — must not emit again.
+func TestFreeCapActiveTripsVersionSaveNeverReemits(t *testing.T) {
+	resetDB(t)
+	srv := fakeAnthropicItineraryServer(t)
+	t.Setenv("ANTHROPIC_API_KEY", "test-key")
+	t.Setenv("ANTHROPIC_BASE_URL", srv.URL)
+	t.Setenv("FREE_ACTIVE_TRIPS", "1") // envInt treats 0 as invalid, so park the user at cap via a seed trip
+
+	user, token := createTestUser(t, "re-finalizer@example.com")
+	createTestTrip(t, user.ID, 1) // lineage #1: the user sits exactly at the cap
+
+	for i := 1; i <= 3; i++ {
+		rec := doJSON(t, "POST", "/api/v1/plan", token, PlanRequest{
+			ChatID:   "chat-refinalize", // SAME chat: saves 2 and 3 are versions
+			Messages: []PlanChatMessage{{Role: "user", Content: "plan athens"}},
+		})
+		if rec.Code != http.StatusOK {
+			t.Fatalf("session %d: /plan = %d, want 200", i, rec.Code)
+		}
+		if out := rec.Body.String(); !strings.Contains(out, `"trip_id"`) {
+			t.Fatalf("session %d: stream carried no persisted trip_id: %q", i, out)
+		}
+		// trip_created still fires per version (the event stream is not what
+		// changed); poll it so the version row is committed and the signal
+		// goroutine for this save has been decided.
+		waitForEventCount(t, user.ID, "trip_created", i)
+	}
+
+	// All three finalizes landed in one lineage (plus the seed).
+	var lineages int
+	if err := dbPool.QueryRow(context.Background(),
+		`SELECT count(DISTINCT COALESCE(chat_id, id::text)) FROM trips WHERE user_id = $1`,
+		user.ID).Scan(&lineages); err != nil {
+		t.Fatalf("lineage count: %v", err)
+	}
+	if lineages != 2 {
+		t.Fatalf("lineages = %d, want 2 (seed + one chat lineage; same-chat saves must be versions)", lineages)
+	}
+
+	// The crossing emitted exactly once — on the first save. The signal for a
+	// version save is gated out synchronously (never spawned), so after the
+	// settle window any extra emission would be visible.
+	time.Sleep(300 * time.Millisecond)
+	hits, lastCount := freeCapWouldHits(t, user.ID, "active_trips")
+	if hits != 1 {
+		t.Fatalf("active_trips would-hits = %d, want exactly 1 (version saves must not re-emit)", hits)
+	}
+	if lastCount != 2 {
+		t.Fatalf("would-hit metadata count = %d, want 2 (cap+1)", lastCount)
+	}
+}

--- a/src/packages/api/main.go
+++ b/src/packages/api/main.go
@@ -203,7 +203,10 @@ func placesSearchHandler(w http.ResponseWriter, r *http.Request) {
 
 	results, err := placesService.SearchPlaces(query)
 	if err != nil {
-		http.Error(w, fmt.Sprintf("Failed to search places: %v", err), http.StatusInternalServerError)
+		// Detail goes to the server log only: provider/internal error strings
+		// must never reach an unauthenticated caller.
+		ctxLog(r.Context()).Error("places search failed", "error", err)
+		http.Error(w, "Failed to search places", http.StatusInternalServerError)
 		return
 	}
 
@@ -225,7 +228,8 @@ func placesAutocompleteHandler(w http.ResponseWriter, r *http.Request) {
 
 	results, err := placesService.GetPlaceAutocomplete(input)
 	if err != nil {
-		http.Error(w, fmt.Sprintf("Failed to get autocomplete: %v", err), http.StatusInternalServerError)
+		ctxLog(r.Context()).Error("places autocomplete failed", "error", err)
+		http.Error(w, "Failed to get autocomplete", http.StatusInternalServerError)
 		return
 	}
 
@@ -247,7 +251,8 @@ func placesDetailsHandler(w http.ResponseWriter, r *http.Request) {
 
 	result, err := placesService.GetPlaceDetails(placeID)
 	if err != nil {
-		http.Error(w, fmt.Sprintf("Failed to get place details: %v", err), http.StatusInternalServerError)
+		ctxLog(r.Context()).Error("place details failed", "error", err)
+		http.Error(w, "Failed to get place details", http.StatusInternalServerError)
 		return
 	}
 
@@ -298,7 +303,11 @@ func airportsSearchHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err != nil {
-		http.Error(w, fmt.Sprintf("Failed to search airports: %v", err), http.StatusInternalServerError)
+		// Duffel's key travels in a header (no URL leak), but its error
+		// strings can echo upstream response bodies — same policy: log the
+		// detail, answer generically.
+		ctxLog(r.Context()).Error("airport search failed", "error", err)
+		http.Error(w, "Failed to search airports", http.StatusInternalServerError)
 		return
 	}
 
@@ -372,10 +381,11 @@ func flightsSearchHandler(w http.ResponseWriter, r *http.Request) {
 
 	offers, err := duffelService.SearchFlightOffers(r.Context(), request)
 	if err != nil {
+		ctxLog(r.Context()).Error("flight search failed", "error", err)
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusInternalServerError)
 		json.NewEncoder(w).Encode(Response{
-			Message: fmt.Sprintf("Failed to search flights: %v", err),
+			Message: "Failed to search flights",
 			Status:  "error",
 		})
 		return

--- a/src/packages/api/middleware.go
+++ b/src/packages/api/middleware.go
@@ -81,9 +81,16 @@ func requestIDMiddleware(next http.Handler) http.Handler {
 // Request body caps. Generous headroom over the largest legitimate payloads:
 // a full 50-location optimize-route or an admin ingest of raw research text is
 // tens of KB; /plan resends the whole chat history so it gets a wider lane.
+//
+// The /plan lane must comfortably cover everything plan_handler.go's own
+// rune caps admit: planMaxMessages (40) x planMaxMessageChars (20,000 runes)
+// of 4-byte UTF-8 is ~3.2 MiB of content plus JSON framing, so 4 MiB keeps
+// the byte lane strictly wider than the rune lane. That way conversations the
+// handler would accept (or reject with a friendly SSE error event) never die
+// here first with a bare 413, which an SSE client surfaces poorly.
 const (
 	maxRequestBodyBytes     = 256 << 10 // 256 KiB, all endpoints by default
-	planMaxRequestBodyBytes = 1 << 20   // 1 MiB for the /plan chat history
+	planMaxRequestBodyBytes = 4 << 20   // 4 MiB for the /plan chat history (see above)
 )
 
 // bodyLimitMiddleware caps request body size. It wraps the request body ONLY

--- a/src/packages/api/middleware_test.go
+++ b/src/packages/api/middleware_test.go
@@ -146,8 +146,9 @@ func TestBodyLimitAllowsNormalBody(t *testing.T) {
 	}
 }
 
-// /plan resends the whole chat history, so it gets the wider 1 MiB lane: a
-// body over the general cap but under the plan cap must pass through.
+// /plan resends the whole chat history, so it gets the wider 4 MiB lane
+// (sized to exceed what the handler's own rune caps admit): a body over the
+// general cap but under the plan cap must pass through.
 func TestBodyLimitPlanGetsWiderLane(t *testing.T) {
 	handlerRan := false
 	h := bodyLimitMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/src/packages/api/places_service.go
+++ b/src/packages/api/places_service.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -10,6 +11,23 @@ import (
 	"strings"
 	"time"
 )
+
+// redactTransportError strips the request URL from transport-level HTTP
+// errors before they enter an error chain. http.Client failures come back as
+// *url.Error, whose Error() embeds the FULL request URL — including secret
+// query parameters like key=/apikey= (Go redacts only userinfo passwords,
+// never the query string). Wrapping ue.Err instead keeps the useful cause
+// (DNS failure, timeout, connection refused) while guaranteeing the secret
+// can never reach handler responses or the /plan agent's tool results.
+// Defense-in-depth: handlers additionally return generic messages and log
+// the detail server-side.
+func redactTransportError(err error) error {
+	var ue *url.Error
+	if errors.As(err, &ue) {
+		return ue.Err
+	}
+	return err
+}
 
 // GooglePlacesService handles Google Places API interactions
 type GooglePlacesService struct {
@@ -107,7 +125,7 @@ func (gps *GooglePlacesService) SearchPlaces(query string) ([]PlaceSearchResult,
 
 	resp, err := gps.Client.Get(baseURL + "?" + params.Encode())
 	if err != nil {
-		return nil, fmt.Errorf("failed to search places: %w", err)
+		return nil, fmt.Errorf("failed to search places: %w", redactTransportError(err))
 	}
 	defer resp.Body.Close()
 
@@ -178,7 +196,7 @@ func (gps *GooglePlacesService) GetPlaceAutocomplete(input string) ([]PlaceAutoc
 
 	resp, err := gps.Client.Get(baseURL + "?" + params.Encode())
 	if err != nil {
-		return nil, fmt.Errorf("failed to get autocomplete: %w", err)
+		return nil, fmt.Errorf("failed to get autocomplete: %w", redactTransportError(err))
 	}
 	defer resp.Body.Close()
 
@@ -235,7 +253,7 @@ func (gps *GooglePlacesService) GetPlaceDetails(placeID string) (*PlaceDetailsRe
 
 	resp, err := gps.Client.Get(baseURL + "?" + params.Encode())
 	if err != nil {
-		return nil, fmt.Errorf("failed to get place details: %w", err)
+		return nil, fmt.Errorf("failed to get place details: %w", redactTransportError(err))
 	}
 	defer resp.Body.Close()
 

--- a/src/packages/api/places_service_test.go
+++ b/src/packages/api/places_service_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"io"
 	"net/http"
 	"strings"
@@ -92,5 +93,49 @@ func TestPlacesServiceSingletonSafeWithoutKey(t *testing.T) {
 	}
 	if _, err := svc.GetPlaceDetails("p1"); err == nil {
 		t.Fatal("GetPlaceDetails without key must error")
+	}
+}
+
+// failingTransport fails every round trip at the transport level, the way a
+// DNS failure / upstream outage / client timeout does. http.Client wraps such
+// failures in a *url.Error whose string embeds the full request URL — query
+// secrets included — which is exactly what redactTransportError must strip.
+type failingTransport struct{}
+
+func (failingTransport) RoundTrip(*http.Request) (*http.Response, error) {
+	return nil, errFakeTransport
+}
+
+var errFakeTransport = fmt.Errorf("dial tcp 1.2.3.4:443: connection refused")
+
+// Transport-level failures must never put the Google key (sent as a `key=`
+// query param) into the error chain: these errors are surfaced to /plan tool
+// results and, pre-redaction, were echoed by public handlers.
+func TestPlacesTransportErrorsOmitAPIKey(t *testing.T) {
+	const secret = "SECRET-GOOGLE-KEY"
+	svc := NewGooglePlacesService()
+	svc.APIKey = secret
+	svc.Client = &http.Client{Transport: failingTransport{}}
+
+	calls := []struct {
+		name string
+		call func() error
+	}{
+		{"SearchPlaces", func() error { _, err := svc.SearchPlaces("louvre"); return err }},
+		{"GetPlaceAutocomplete", func() error { _, err := svc.GetPlaceAutocomplete("lou"); return err }},
+		{"GetPlaceDetails", func() error { _, err := svc.GetPlaceDetails("p1"); return err }},
+	}
+	for _, c := range calls {
+		err := c.call()
+		if err == nil {
+			t.Fatalf("%s: expected a transport error", c.name)
+		}
+		msg := err.Error()
+		if strings.Contains(msg, secret) || strings.Contains(msg, "key=") {
+			t.Fatalf("%s: error leaks the API key: %q", c.name, msg)
+		}
+		if !strings.Contains(msg, "connection refused") {
+			t.Fatalf("%s: redaction lost the underlying cause: %q", c.name, msg)
+		}
 	}
 }

--- a/src/packages/api/plan_handler.go
+++ b/src/packages/api/plan_handler.go
@@ -498,7 +498,7 @@ func planHandler(w http.ResponseWriter, r *http.Request) {
 				// Persist the trip only for signed-in callers; anonymous sessions
 				// stay ephemeral (no trip_id in the done event).
 				if authed {
-					if tripID, err := persistTrip(ctx, uid, req.ChatID, in.Title, in.Summary, in.StartDate, in.EndDate, in.Locations); err != nil {
+					if tripID, newLineage, err := persistTrip(ctx, uid, req.ChatID, in.Title, in.Summary, in.StartDate, in.EndDate, in.Locations); err != nil {
 						log.Printf("failed to persist trip: %v", err)
 					} else {
 						donePayload["trip_id"] = tripID
@@ -507,10 +507,14 @@ func planHandler(w http.ResponseWriter, r *http.Request) {
 							go recordEvent(uid, "trip_created", &parsed, map[string]any{
 								"item_count": len(in.Locations),
 							})
-							// Free-cap active_trips crossing signal — a new
-							// lineage may take the user past the cap; new
-							// versions of an existing lineage never do.
-							go recordActiveTripsCapSignal(uid, parsed)
+							// Free-cap active_trips crossing signal — only a
+							// brand-new lineage can move the lineage count; a
+							// version save of an existing chat lineage leaves
+							// it unchanged and must never emit
+							// (specs/free-cap-instrumentation).
+							if newLineage {
+								go recordActiveTripsCapSignal(uid, parsed)
+							}
 						}
 						// Distill what this conversation revealed about the traveler
 						// in the background — it must never delay or fail the trip.

--- a/src/packages/api/query/analytics.sql
+++ b/src/packages/api/query/analytics.sql
@@ -37,10 +37,14 @@ SELECT count(DISTINCT trip_id) FROM analytics_events
 WHERE event_type = 'booking_link_clicked' AND trip_id IS NOT NULL AND created_at >= $1;
 
 -- name: BookingClicksByProvider :many
-SELECT COALESCE(metadata->>'provider', 'unknown')::text AS provider, count(*) AS clicks
+-- provider is client-supplied (sanitized at ingest since Wave 7, but older
+-- rows predate that): left(..., 64) + LIMIT 20 bound the admin dashboard's
+-- rollup against arbitrary historical values.
+SELECT COALESCE(left(metadata->>'provider', 64), 'unknown')::text AS provider, count(*) AS clicks
 FROM analytics_events
 WHERE event_type = 'booking_link_clicked' AND created_at >= $1
-GROUP BY 1 ORDER BY clicks DESC;
+GROUP BY 1 ORDER BY clicks DESC, provider
+LIMIT 20;
 
 -- name: PlanSessionTotals :one
 -- Sessions + token spend from plan_session_completed metadata, plus the
@@ -65,10 +69,20 @@ WHERE event_type = 'plan_session_completed' AND created_at >= $1;
 --   session_frequency_returning — users with planning sessions on >= 2 distinct
 --                                days (a session-frequency proxy; NOT trip
 --                                retention).
---   second_trip_retention      — users with >= 2 trip_created events >= 7 days
---                                apart (the business model's "returned for a
---                                second trip" signal; max-min >= 7 days implies
---                                >= 2 events).
+--   second_trip_retention      — users whose trip_created events span >= 2
+--                                DISTINCT trip lineages (COALESCE(chat_id,
+--                                id) — the My Trips grouping) with first
+--                                creations >= 7 days apart (the business
+--                                model's "returned for a second trip" signal;
+--                                max-min >= 7 days implies >= 2 lineages).
+--                                Grouping by lineage keeps re-finalizing one
+--                                chat — a version save, which also emits
+--                                trip_created — from counting as a second
+--                                trip. Trade-off: the trips join drops events
+--                                whose trip row was later deleted, a slight
+--                                undercount (vs. the per-event overcount it
+--                                replaces); acceptable until trip deletion is
+--                                a real flow.
 SELECT
   (SELECT count(DISTINCT a.user_id) FROM analytics_events a
    WHERE a.event_type = 'plan_session_started' AND a.user_id IS NOT NULL
@@ -81,9 +95,14 @@ SELECT
      HAVING count(DISTINCT date(b.created_at)) >= 2
    ) s)::bigint AS session_frequency_returning,
   (SELECT count(*) FROM (
-     SELECT c.user_id FROM analytics_events c
-     WHERE c.event_type = 'trip_created' AND c.user_id IS NOT NULL
-       AND c.created_at >= $1
-     GROUP BY c.user_id
-     HAVING max(c.created_at) - min(c.created_at) >= interval '7 days'
+     SELECT l.user_id FROM (
+       SELECT c.user_id, min(c.created_at) AS first_at
+       FROM analytics_events c
+       JOIN trips tr ON tr.id = c.trip_id
+       WHERE c.event_type = 'trip_created' AND c.user_id IS NOT NULL
+         AND c.created_at >= $1
+       GROUP BY c.user_id, COALESCE(tr.chat_id, tr.id::text)
+     ) l
+     GROUP BY l.user_id
+     HAVING max(l.first_at) - min(l.first_at) >= interval '7 days'
    ) t)::bigint AS second_trip_retention;

--- a/src/packages/api/query/trips.sql
+++ b/src/packages/api/query/trips.sql
@@ -47,6 +47,17 @@ ORDER BY latest.created_at DESC;
 -- archived status exists today).
 SELECT count(DISTINCT COALESCE(chat_id, id::text)) FROM trips WHERE user_id = $1;
 
+-- name: TripLineageExists :one
+-- Whether the owner already has any trip in this chat lineage. persistTrip
+-- runs it inside the same transaction as its insert to distinguish a
+-- brand-new lineage from a new version of an existing one: the free-cap
+-- active_trips signal may only fire for new lineages (a version save never
+-- moves the lineage count and can never emit —
+-- specs/free-cap-instrumentation).
+SELECT EXISTS(
+  SELECT 1 FROM trips WHERE user_id = $1 AND chat_id = $2
+) AS lineage_exists;
+
 -- name: ListTripVersionsByChat :many
 SELECT * FROM trips WHERE user_id = $1 AND chat_id = $2 ORDER BY created_at DESC;
 

--- a/src/packages/api/store/analytics.sql.go
+++ b/src/packages/api/store/analytics.sql.go
@@ -13,10 +13,11 @@ import (
 )
 
 const bookingClicksByProvider = `-- name: BookingClicksByProvider :many
-SELECT COALESCE(metadata->>'provider', 'unknown')::text AS provider, count(*) AS clicks
+SELECT COALESCE(left(metadata->>'provider', 64), 'unknown')::text AS provider, count(*) AS clicks
 FROM analytics_events
 WHERE event_type = 'booking_link_clicked' AND created_at >= $1
-GROUP BY 1 ORDER BY clicks DESC
+GROUP BY 1 ORDER BY clicks DESC, provider
+LIMIT 20
 `
 
 type BookingClicksByProviderRow struct {
@@ -24,6 +25,9 @@ type BookingClicksByProviderRow struct {
 	Clicks   int64  `json:"clicks"`
 }
 
+// provider is client-supplied (sanitized at ingest since Wave 7, but older
+// rows predate that): left(..., 64) + LIMIT 20 bound the admin dashboard's
+// rollup against arbitrary historical values.
 func (q *Queries) BookingClicksByProvider(ctx context.Context, createdAt time.Time) ([]BookingClicksByProviderRow, error) {
 	rows, err := q.db.Query(ctx, bookingClicksByProvider, createdAt)
 	if err != nil {
@@ -236,11 +240,16 @@ SELECT
      HAVING count(DISTINCT date(b.created_at)) >= 2
    ) s)::bigint AS session_frequency_returning,
   (SELECT count(*) FROM (
-     SELECT c.user_id FROM analytics_events c
-     WHERE c.event_type = 'trip_created' AND c.user_id IS NOT NULL
-       AND c.created_at >= $1
-     GROUP BY c.user_id
-     HAVING max(c.created_at) - min(c.created_at) >= interval '7 days'
+     SELECT l.user_id FROM (
+       SELECT c.user_id, min(c.created_at) AS first_at
+       FROM analytics_events c
+       JOIN trips tr ON tr.id = c.trip_id
+       WHERE c.event_type = 'trip_created' AND c.user_id IS NOT NULL
+         AND c.created_at >= $1
+       GROUP BY c.user_id, COALESCE(tr.chat_id, tr.id::text)
+     ) l
+     GROUP BY l.user_id
+     HAVING max(l.first_at) - min(l.first_at) >= interval '7 days'
    ) t)::bigint AS second_trip_retention
 `
 
@@ -259,10 +268,20 @@ type UserEngagementCountsRow struct {
 //	session_frequency_returning — users with planning sessions on >= 2 distinct
 //	                             days (a session-frequency proxy; NOT trip
 //	                             retention).
-//	second_trip_retention      — users with >= 2 trip_created events >= 7 days
-//	                             apart (the business model's "returned for a
-//	                             second trip" signal; max-min >= 7 days implies
-//	                             >= 2 events).
+//	second_trip_retention      — users whose trip_created events span >= 2
+//	                             DISTINCT trip lineages (COALESCE(chat_id,
+//	                             id) — the My Trips grouping) with first
+//	                             creations >= 7 days apart (the business
+//	                             model's "returned for a second trip" signal;
+//	                             max-min >= 7 days implies >= 2 lineages).
+//	                             Grouping by lineage keeps re-finalizing one
+//	                             chat — a version save, which also emits
+//	                             trip_created — from counting as a second
+//	                             trip. Trade-off: the trips join drops events
+//	                             whose trip row was later deleted, a slight
+//	                             undercount (vs. the per-event overcount it
+//	                             replaces); acceptable until trip deletion is
+//	                             a real flow.
 func (q *Queries) UserEngagementCounts(ctx context.Context, createdAt time.Time) (UserEngagementCountsRow, error) {
 	row := q.db.QueryRow(ctx, userEngagementCounts, createdAt)
 	var i UserEngagementCountsRow

--- a/src/packages/api/store/trips.sql.go
+++ b/src/packages/api/store/trips.sql.go
@@ -458,6 +458,30 @@ func (q *Queries) TouchTrip(ctx context.Context, id uuid.UUID) error {
 	return err
 }
 
+const tripLineageExists = `-- name: TripLineageExists :one
+SELECT EXISTS(
+  SELECT 1 FROM trips WHERE user_id = $1 AND chat_id = $2
+) AS lineage_exists
+`
+
+type TripLineageExistsParams struct {
+	UserID uuid.UUID `json:"user_id"`
+	ChatID *string   `json:"chat_id"`
+}
+
+// Whether the owner already has any trip in this chat lineage. persistTrip
+// runs it inside the same transaction as its insert to distinguish a
+// brand-new lineage from a new version of an existing one: the free-cap
+// active_trips signal may only fire for new lineages (a version save never
+// moves the lineage count and can never emit —
+// specs/free-cap-instrumentation).
+func (q *Queries) TripLineageExists(ctx context.Context, arg TripLineageExistsParams) (bool, error) {
+	row := q.db.QueryRow(ctx, tripLineageExists, arg.UserID, arg.ChatID)
+	var lineage_exists bool
+	err := row.Scan(&lineage_exists)
+	return lineage_exists, err
+}
+
 const updateItineraryItem = `-- name: UpdateItineraryItem :one
 UPDATE itinerary_items
 SET name        = COALESCE($1, name),

--- a/src/packages/api/trip_handler.go
+++ b/src/packages/api/trip_handler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"log"
 	"net/http"
 	"strings"
 	"time"
@@ -132,10 +133,15 @@ func toTripResponse(t store.Trip, items []store.ItineraryItem, accommodations []
 // transaction. Called from the agent's create_itinerary step for signed-in users.
 // chatID stamps the trip with its conversation so My Trips can collapse repeated
 // refinements to the latest version; an empty chatID is stored as NULL.
-func persistTrip(ctx context.Context, userID uuid.UUID, chatID, title, summary, startDate, endDate string, locations []map[string]any) (string, error) {
+//
+// newLineage reports whether this save started a brand-new trip lineage (as
+// opposed to adding a version to an existing chat lineage). The caller uses
+// it to gate the free-cap active_trips crossing signal, which a version save
+// must never emit (specs/free-cap-instrumentation).
+func persistTrip(ctx context.Context, userID uuid.UUID, chatID, title, summary, startDate, endDate string, locations []map[string]any) (tripID string, newLineage bool, err error) {
 	tx, err := dbPool.Begin(ctx)
 	if err != nil {
-		return "", err
+		return "", false, err
 	}
 	defer tx.Rollback(ctx)
 	q := store.New(tx)
@@ -165,9 +171,26 @@ func persistTrip(ctx context.Context, userID uuid.UUID, chatID, title, summary, 
 	if c := strings.TrimSpace(chatID); c != "" {
 		chatPtr = &c
 	}
+
+	// Detect new-lineage vs version save inside the same transaction as the
+	// insert (a chat-less save always stands alone, i.e. a new lineage).
+	// Fail-open: if the check errors, treat the lineage as existing so the
+	// free-cap signal is skipped rather than over-emitted.
+	newLineage = true
+	if chatPtr != nil {
+		exists, lerr := q.TripLineageExists(ctx, store.TripLineageExistsParams{UserID: userID, ChatID: chatPtr})
+		switch {
+		case lerr != nil:
+			log.Printf("trip lineage check failed (treating as existing lineage): %v", lerr)
+			newLineage = false
+		case exists:
+			newLineage = false
+		}
+	}
+
 	trip, err := q.CreateTrip(ctx, store.CreateTripParams{UserID: userID, Title: finalTitle, Status: "draft", ChatID: chatPtr, Summary: summaryPtr})
 	if err != nil {
-		return "", err
+		return "", false, err
 	}
 
 	maxDay := 1
@@ -177,7 +200,7 @@ func persistTrip(ctx context.Context, userID uuid.UUID, chatID, title, summary, 
 			maxDay = int(*params.Day)
 		}
 		if _, err := q.CreateItineraryItem(ctx, params); err != nil {
-			return "", err
+			return "", false, err
 		}
 	}
 
@@ -199,15 +222,15 @@ func persistTrip(ctx context.Context, userID uuid.UUID, chatID, title, summary, 
 				StartDate: startD,
 				EndDate:   endD,
 			}); err != nil {
-				return "", err
+				return "", false, err
 			}
 		}
 	}
 
 	if err := tx.Commit(ctx); err != nil {
-		return "", err
+		return "", false, err
 	}
-	return trip.ID.String(), nil
+	return trip.ID.String(), newLineage, nil
 }
 
 func tripIDFromPath(r *http.Request) (uuid.UUID, bool) {

--- a/src/packages/flutter-app/lib/screens/flight_search_screen.dart
+++ b/src/packages/flutter-app/lib/screens/flight_search_screen.dart
@@ -96,9 +96,19 @@ class _FlightSearchScreenState extends ConsumerState<FlightSearchScreen> {
   /// still editable.
   Future<void> _seedInitial() async {
     final w = widget;
-    final date = w.prefillDepartDate == null
+    var date = w.prefillDepartDate == null
         ? null
         : DateTime.tryParse(w.prefillDepartDate!);
+    if (date != null) {
+      // Prefill dates come from itinerary legs, which are unbounded (past
+      // trips, trips >1 year out). Clamp into the pickers' bookable window
+      // [today, today+365d] so neither date picker can be handed an
+      // out-of-range initial/first date (showDatePicker asserts on those).
+      final today = DateUtils.dateOnly(DateTime.now());
+      final windowEnd = today.add(const Duration(days: 365));
+      if (date.isBefore(today)) date = today;
+      if (date.isAfter(windowEnd)) date = windowEnd;
+    }
     if (date != null && _departDate == null) {
       setState(() => _departDate = date);
     }
@@ -207,11 +217,18 @@ class _FlightSearchScreenState extends ConsumerState<FlightSearchScreen> {
 
   Future<void> _pickDate() async {
     final now = DateTime.now();
+    final first = now;
+    final last = now.add(const Duration(days: 365));
+    // Defensive initial clamp: _departDate is clamped at seed time, but keep
+    // the picker safe against any out-of-window value regardless of source.
+    var initial = _departDate ?? now.add(const Duration(days: 14));
+    if (initial.isBefore(first)) initial = first;
+    if (initial.isAfter(last)) initial = last;
     final picked = await showDatePicker(
       context: context,
-      initialDate: _departDate ?? now.add(const Duration(days: 14)),
-      firstDate: now,
-      lastDate: now.add(const Duration(days: 365)),
+      initialDate: initial,
+      firstDate: first,
+      lastDate: last,
     );
     if (picked != null) {
       setState(() {
@@ -229,8 +246,15 @@ class _FlightSearchScreenState extends ConsumerState<FlightSearchScreen> {
   /// so return < departure is impossible to select (same-day return allowed).
   Future<void> _pickReturnDate() async {
     final now = DateTime.now();
-    final first = _departDate ?? now;
-    final last = now.add(const Duration(days: 365));
+    // Reconcile the range before handing it to the picker: a stale or
+    // prefilled departure can sit outside [today, today+365d], and
+    // showDatePicker asserts when firstDate > lastDate. Floor the start at
+    // today (no past returns), then extend the end if the departure still
+    // overruns it.
+    var first = _departDate ?? now;
+    if (first.isBefore(now)) first = now;
+    var last = now.add(const Duration(days: 365));
+    if (last.isBefore(first)) last = first;
     var initial = _returnDate ??
         _departDate?.add(const Duration(days: 7)) ??
         now.add(const Duration(days: 21));

--- a/src/packages/flutter-app/lib/services/plan_service.dart
+++ b/src/packages/flutter-app/lib/services/plan_service.dart
@@ -12,7 +12,13 @@ class PlanEvent {
 class PlanService {
   final String baseUrl;
 
-  PlanService(this.baseUrl);
+  /// Builds the HTTP client used for one streaming request. Injectable so
+  /// tests can substitute a fake transport; defaults to a fresh client per
+  /// stream (closed when the stream ends).
+  final http.Client Function() _newClient;
+
+  PlanService(this.baseUrl, {http.Client Function()? clientFactory})
+      : _newClient = clientFactory ?? http.Client.new;
 
   Stream<PlanEvent> streamPlan(
     List<Map<String, String>> messages, {
@@ -31,27 +37,56 @@ class PlanService {
       if (tripId != null) 'trip_id': tripId,
     });
 
-    final response = await request.send();
+    final client = _newClient();
+    try {
+      final response = await client.send(request);
 
-    final buffer = StringBuffer();
-    await for (final chunk in response.stream.transform(utf8.decoder)) {
-      buffer.write(chunk);
-      final raw = buffer.toString();
-      final parts = raw.split('\n\n');
-      buffer.clear();
-      buffer.write(parts.last);
+      // A non-200 is a middleware/gateway rejection (e.g. the request-body
+      // 413, or an nginx 502) whose body carries no SSE frames at all —
+      // without this check the stream would end silently: no reply, no error
+      // banner, no retry. Convert it into the same synthetic `error` event
+      // the server uses for in-handler failures, so the provider's existing
+      // error path (banner + retryLastSend) engages.
+      if (response.statusCode != 200) {
+        var message = 'Request failed (HTTP ${response.statusCode})';
+        try {
+          final body = await response.stream.bytesToString();
+          final decoded = jsonDecode(body);
+          if (decoded is Map<String, dynamic>) {
+            // writeJSONError uses {"message": ...}; tolerate {"error": ...}.
+            final msg = decoded['message'] ?? decoded['error'];
+            if (msg is String && msg.isNotEmpty) message = msg;
+          }
+        } catch (_) {
+          // Non-JSON body (gateway HTML error page): keep the generic text.
+        }
+        yield PlanEvent(type: 'error', data: {'message': message});
+        return;
+      }
 
-      for (final part in parts.sublist(0, parts.length - 1)) {
-        for (final line in part.split('\n')) {
-          if (line.startsWith('data: ')) {
-            final decoded = jsonDecode(line.substring(6)) as Map<String, dynamic>;
-            yield PlanEvent(
-              type: decoded['type'] as String,
-              data: (decoded['data'] as Map<String, dynamic>?) ?? {},
-            );
+      final buffer = StringBuffer();
+      await for (final chunk in response.stream.transform(utf8.decoder)) {
+        buffer.write(chunk);
+        final raw = buffer.toString();
+        final parts = raw.split('\n\n');
+        buffer.clear();
+        buffer.write(parts.last);
+
+        for (final part in parts.sublist(0, parts.length - 1)) {
+          for (final line in part.split('\n')) {
+            if (line.startsWith('data: ')) {
+              final decoded =
+                  jsonDecode(line.substring(6)) as Map<String, dynamic>;
+              yield PlanEvent(
+                type: decoded['type'] as String,
+                data: (decoded['data'] as Map<String, dynamic>?) ?? {},
+              );
+            }
           }
         }
       }
+    } finally {
+      client.close();
     }
   }
 }

--- a/src/packages/flutter-app/test/flight_round_trip_test.dart
+++ b/src/packages/flutter-app/test/flight_round_trip_test.dart
@@ -436,6 +436,49 @@ void main() {
       expect(flights.requests.last.returnDate, isNull);
     });
 
+    // Prefill dates come from itinerary legs and are unbounded; before the
+    // Wave 7 sweep a departure outside [today, today+365d] made the return
+    // picker's firstDate exceed its lastDate — a DatePickerDialog assertion
+    // crash (debug) / broken calendar (release).
+    testWidgets(
+        'prefilled departure beyond the 365-day window is clamped and the '
+        'return picker still opens', (tester) async {
+      final farOut = DateTime.now().add(const Duration(days: 400));
+      await pumpScreen(tester, _fmt(farOut));
+
+      // The departure was clamped to the window's end, not kept raw.
+      final windowEnd =
+          DateUtils.dateOnly(DateTime.now()).add(const Duration(days: 365));
+      expect(find.text(_fmt(farOut)), findsNothing);
+      expect(find.text(_fmt(windowEnd)), findsOneWidget);
+
+      // The return picker opens and a return can be picked without asserting.
+      await tester.tap(find.text('Return (optional)'));
+      await tester.pumpAndSettle();
+      expect(tester.takeException(), isNull);
+      await tester.tap(find.text('OK'));
+      await tester.pumpAndSettle();
+      // Depart == window end, so the only pickable return is that same day.
+      expect(find.text('Return (optional)'), findsNothing);
+      expect(find.text(_fmt(windowEnd)), findsNWidgets(2));
+    });
+
+    testWidgets('prefilled past departure is floored at today', (tester) async {
+      final past = DateTime.now().subtract(const Duration(days: 30));
+      await pumpScreen(tester, _fmt(past));
+
+      final today = DateUtils.dateOnly(DateTime.now());
+      expect(find.text(_fmt(past)), findsNothing);
+      expect(find.text(_fmt(today)), findsOneWidget);
+
+      await tester.tap(find.text('Return (optional)'));
+      await tester.pumpAndSettle();
+      expect(tester.takeException(), isNull);
+      await tester.tap(find.text('OK'));
+      await tester.pumpAndSettle();
+      expect(find.text('Return (optional)'), findsNothing);
+    });
+
     testWidgets('moving departure past the return clears the return',
         (tester) async {
       final depart = DateTime.now().add(const Duration(days: 30));

--- a/src/packages/flutter-app/test/plan_service_error_test.dart
+++ b/src/packages/flutter-app/test/plan_service_error_test.dart
@@ -1,0 +1,55 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:travel_route_planner/services/plan_service.dart';
+
+/// A non-200 /plan response (middleware 413, gateway 502, ...) carries no SSE
+/// frames. streamPlan must convert it into a synthetic `error` event so the
+/// provider's error banner + retry path engages instead of a silent no-reply.
+void main() {
+  PlanService serviceReturning(int status, String body) => PlanService(
+        'http://test/api/v1',
+        clientFactory: () => MockClient.streaming((request, bodyStream) async {
+          await bodyStream.drain<void>();
+          return http.StreamedResponse(
+              Stream.value(utf8.encode(body)), status);
+        }),
+      );
+
+  const history = [
+    {'role': 'user', 'content': 'plan athens'}
+  ];
+
+  test('JSON 413 becomes an error event carrying the server message',
+      () async {
+    final events = await serviceReturning(
+      413,
+      '{"message":"request body too large","status":"error"}',
+    ).streamPlan(history).toList();
+
+    expect(events, hasLength(1));
+    expect(events.single.type, 'error');
+    expect(events.single.data['message'], 'request body too large');
+  });
+
+  test('non-JSON error body falls back to a generic HTTP message', () async {
+    final events = await serviceReturning(502, '<html>Bad Gateway</html>')
+        .streamPlan(history)
+        .toList();
+
+    expect(events.single.type, 'error');
+    expect(events.single.data['message'], contains('502'));
+  });
+
+  test('200 SSE stream still parses events unchanged', () async {
+    const sse = 'data: {"type":"text_delta","data":{"text":"hello"}}\n\n'
+        'data: {"type":"done","data":{}}\n\n';
+    final events =
+        await serviceReturning(200, sse).streamPlan(history).toList();
+
+    expect(events.map((e) => e.type).toList(), ['text_delta', 'done']);
+    expect(events.first.data['text'], 'hello');
+  });
+}


### PR DESCRIPTION
Adversarial multi-agent review of the merged Wave 7 diff confirmed six findings; this sweep fixes all of them. Schema stays at migration 00030 (no new migrations); `store/` regenerated via `make api-sqlc`.

## Findings → fixes

### 1. [MAJOR] Provider API keys leaked into unauthenticated error responses
Transport-level `*url.Error` strings embed the full request URL — `apikey=` (Ticketmaster) / `key=` (Google Places) included — and `eventsSearchHandler` plus the three places handlers echoed `%v` of the error straight to clients. Fixed at **both layers**:
- **Handlers** (`events_service.go`, `main.go`): log the detailed error server-side via `ctxLog(...).Error` and return generic messages. Sweep also caught the **airports** and **flight-search** handlers echoing Duffel errors verbatim (key is in a header, but upstream bodies were echoed) — same treatment.
- **Services** (defense-in-depth): new `redactTransportError` unwraps `*url.Error` and wraps only its cause when `events_service.go`/`places_service.go` wrap `Client.Do`/`Get` failures, so secrets never enter the error chain — this also covers the `/plan` agent's `search_places`/`search_events` tool-result path. Weather (no key) and ferry (no HTTP) need no service change.
- **Tests**: unit tests assert a wrapped transport error string contains neither the key value nor `key=`/`apikey=`, while preserving the underlying cause.

### 2. [minor] `active_trips` free_cap_would_hit re-emitted on version saves
`plan_handler.go` fired `recordActiveTripsCapSignal` after every successful `create_itinerary` persist, so a user parked at exactly cap+1 lineages re-emitted on each same-chat version save — violating `specs/free-cap-instrumentation` ("a version save … can never emit"). `persistTrip` now checks the lineage inside its own transaction (new sqlc query `TripLineageExists`; fail-open: check error ⇒ treated as existing ⇒ signal skipped) and returns `newLineage`; the signal is gated on it. `duplicateSharedTripHandler` confirmed correct as-is (every duplicate mints a fresh `chat-…` lineage). New integration test (`TestFreeCapActiveTripsVersionSaveNeverReemits`) drives `create_itinerary` through `/plan` three times on one chat via a stateful fake Anthropic server and asserts exactly one crossing emission.

### 3. [minor] `second_trip_retention` counted per-version `trip_created` events
`UserEngagementCounts` grouped `trip_created` only by user, so re-finalizing one chat ≥7 days later counted as a "second trip". The subquery now dedupes by trip lineage (join `trips`, per-lineage `min(created_at)` on `COALESCE(chat_id, id::text)`, then the 7-day spread), with the deleted-trip undercount trade-off noted in the query comment. `specs/instrumentation-events/spec.md`'s normative definition updated to match. `TestAdminMetricsValues` reworked to link events to real trips: two events on the SAME lineage 8 days apart must NOT count; two distinct lineages 8 days apart must.

### 4. [minor] Oversized `/plan` 413 silently swallowed by the Flutter SSE client
Reachable seam: the handler's caps are rune-based (40 × 20k runes ⇒ ~3.2 MB of multibyte UTF-8) while the middleware capped bytes at 1 MiB, and `plan_service.dart` never checked `statusCode` — a JSON 413 yielded zero SSE events, no banner, no retry. Both lanes fixed: `streamPlan` now converts any non-200 into a synthetic `error` PlanEvent (best-effort parsing the JSON `message`, falling back to `HTTP <code>`), routing into the provider's existing error case and PR #64's retry banner; the HTTP client is injectable for tests. Server side, `planMaxRequestBodyBytes` raised to **4 MiB** so the byte lane strictly exceeds what the rune caps admit (rationale documented in `middleware.go`). New `plan_service_error_test.dart` covers JSON 413, non-JSON 502, and the unchanged 200 path.

### 5. [minor] Return-date picker crashed on out-of-window prefilled departures
`_pickReturnDate` used `firstDate = _departDate` against `lastDate = now+365d`; itinerary-leg prefills are unbounded, so a >365d departure inverted the range (DatePicker assertion crash) and a past one allowed past returns. `_seedInitial` now clamps the prefill into `[today, today+365d]`; the return picker floors `first` at today and extends `last` when the departure overruns it; the depart picker gets a defensive `initialDate` clamp. Widget tests cover +400-day and −30-day prefills end-to-end (picker opens, no exception, valid selection).

### 6. [minor] Attach-rate metrics inflatable via unvalidated `trip_id`/`provider` on POST `/api/v1/events`
- `trip_id` is now verified off the response path (202 semantics kept): stored only when the trip exists and the caller may access it via `GetEditableTripByID` (owner **or** editor collaborator, so shared-trip clicks stay attributed); mismatch/lookup error nulls it — never rejects.
- Metadata constrained to the exact key set `trackedLaunchUrl` sends (`provider`, `surface`, `kind`, `todo_key`), string values only, capped at 64 chars, `provider` lowercased (the dashboard groups on it).
- `BookingClicksByProvider` adds `left(…, 64)` + `LIMIT 20` as a belt-and-suspenders bound for pre-sanitization rows.
- Event-type whitelist unchanged. Integration tests: foreign/fabricated `trip_id` nulled (attach numerator unmoved), own `trip_id` kept, oversized/unknown/non-string metadata dropped.

## Verification
- `make api-sqlc` committed clean; `make api-fmt` / `make api-vet` clean.
- Unit: `go test ./...` green.
- Integration: full suite green against `travel_test_sweep` (`TEST_DATABASE_URL=… go test -count=1 ./...`), including the four new client-event tests and the version-save re-emit regression test.
- Flutter: `flutter test` 63/63 green; `flutter analyze --no-fatal-infos --fatal-warnings` exit 0 (the 12 known pre-existing infos; none added).

🤖 Generated with [Claude Code](https://claude.com/claude-code)