### PR TITLE
test(api): reusable fake-Anthropic SSE harness + /plan e2e tests

### DIFF
--- a/src/packages/api/fake_anthropic_test.go
+++ b/src/packages/api/fake_anthropic_test.go
@@ -1,0 +1,282 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"unicode/utf8"
+)
+
+// fake_anthropic_test.go — a reusable, scriptable stand-in for the Anthropic
+// API behind the ANTHROPIC_BASE_URL seam (anthropic_client.go).
+//
+// Construct it with a sequence of scripted assistant turns; each streaming
+// /v1/messages call is answered with the turn matching how far the tool loop
+// has progressed. Turn selection is keyed off the REQUEST BODY, not a call
+// counter: the number of user messages carrying tool_result blocks equals the
+// number of completed tool round-trips, which is exactly the turn index. That
+// keeps the fake deterministic when background callers also hit the seam, and
+// it means repeated /plan sessions each replay the script from turn 0.
+//
+// The wire format is accumulator-faithful to anthropic-sdk-go v1.45.0
+// (messageutil.go): message_start carries the message envelope,
+// content_block_start opens each block (tool_use input starts as the literal
+// `{}` the accumulator replaces), deltas arrive as text_delta /
+// input_json_delta partials split across frames, message_delta carries the
+// stop_reason, message_stop closes. Text and tool input are deliberately
+// split into multiple delta frames so tests exercise real accumulation, not
+// single-frame shortcuts.
+//
+// NON-streaming calls (no "stream":true in the body) are served too, because
+// the /plan flow's background profile distiller (profile_distiller.go) and
+// the admin ingest's extraction (local_extraction_service.go) share the seam
+// and use client.Messages.New. The default non-streaming answer is a harmless
+// text-only end_turn message (the forced-tool callers find no tool_use block
+// and no-op); scriptNonStreamingTool swaps in a forced-tool response for
+// tests that exercise those callers directly.
+//
+// Anything else — wrong path, wrong method, an unscripted turn — fails the
+// test loudly and returns 500.
+
+// fakeTurn is one scripted assistant turn for a streaming call.
+type fakeTurn struct {
+	kind      string // "text" | "tool" | "error"
+	text      string
+	toolName  string
+	toolInput string // raw JSON object
+	errMsg    string
+}
+
+// textTurn streams the given text (split across multiple text_delta frames)
+// and ends the conversation with stop_reason end_turn.
+func textTurn(text string) fakeTurn { return fakeTurn{kind: "text", text: text} }
+
+// toolTurn requests the named tool with the given JSON input, streamed as
+// split input_json_delta partials, and stops with stop_reason tool_use.
+func toolTurn(name, inputJSON string) fakeTurn {
+	return fakeTurn{kind: "tool", toolName: name, toolInput: inputJSON}
+}
+
+// errorTurn starts a normal text answer, then kills the stream mid-turn with
+// an SSE `error` event (the shape a real overloaded_error takes on the wire),
+// so stream.Err() fires client-side.
+func errorTurn(message string) fakeTurn { return fakeTurn{kind: "error", errMsg: message} }
+
+type fakeAnthropic struct {
+	t   *testing.T
+	srv *httptest.Server
+
+	mu               sync.Mutex
+	turns            []fakeTurn
+	requests         [][]byte
+	nonStreamContent json.RawMessage
+	nonStreamStop    string
+}
+
+// newFakeAnthropic starts the fake and points the whole process at it for the
+// duration of the test (ANTHROPIC_API_KEY + ANTHROPIC_BASE_URL via t.Setenv).
+func newFakeAnthropic(t *testing.T, script ...fakeTurn) *fakeAnthropic {
+	t.Helper()
+	f := &fakeAnthropic{
+		t:                t,
+		turns:            script,
+		nonStreamContent: json.RawMessage(`[{"type":"text","text":"OK."}]`),
+		nonStreamStop:    "end_turn",
+	}
+	f.srv = httptest.NewServer(http.HandlerFunc(f.handle))
+	t.Cleanup(f.srv.Close)
+	t.Setenv("ANTHROPIC_API_KEY", "test-key")
+	t.Setenv("ANTHROPIC_BASE_URL", f.srv.URL)
+	return f
+}
+
+// scriptNonStreamingTool makes every non-streaming call answer with a single
+// tool_use block — the forced-tool shape profile_distiller.go and
+// local_extraction_service.go expect. Streaming turns are unaffected.
+func (f *fakeAnthropic) scriptNonStreamingTool(name, inputJSON string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.nonStreamContent = json.RawMessage(fmt.Sprintf(
+		`[{"type":"tool_use","id":"toolu_fake_ns","name":%q,"input":%s}]`, name, inputJSON))
+	f.nonStreamStop = "tool_use"
+}
+
+// requestBodies returns a copy of every /v1/messages request body received,
+// in arrival order — for asserting what round-tripped back to the "model".
+func (f *fakeAnthropic) requestBodies() [][]byte {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([][]byte, len(f.requests))
+	copy(out, f.requests)
+	return out
+}
+
+func (f *fakeAnthropic) handle(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost || r.URL.Path != "/v1/messages" {
+		f.t.Errorf("fake anthropic: unexpected request %s %s", r.Method, r.URL.Path)
+		http.Error(w, "unexpected path", http.StatusInternalServerError)
+		return
+	}
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		f.t.Errorf("fake anthropic: read body: %v", err)
+		http.Error(w, "bad body", http.StatusInternalServerError)
+		return
+	}
+
+	f.mu.Lock()
+	f.requests = append(f.requests, body)
+	turns := f.turns
+	nonStreamContent := f.nonStreamContent
+	nonStreamStop := f.nonStreamStop
+	f.mu.Unlock()
+
+	var req struct {
+		Stream   bool `json:"stream"`
+		Messages []struct {
+			Role    string          `json:"role"`
+			Content json.RawMessage `json:"content"`
+		} `json:"messages"`
+	}
+	if err := json.Unmarshal(body, &req); err != nil {
+		f.t.Errorf("fake anthropic: unparseable request body: %v", err)
+		http.Error(w, "bad json", http.StatusInternalServerError)
+		return
+	}
+
+	if !req.Stream {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"id":"msg_fake_ns","type":"message","role":"assistant","model":"claude-sonnet-4-6","content":%s,"stop_reason":%q,"stop_sequence":null,"usage":{"input_tokens":10,"output_tokens":5}}`,
+			nonStreamContent, nonStreamStop)
+		return
+	}
+
+	// Turn index = completed tool round-trips = user messages with tool_result.
+	idx := 0
+	for _, m := range req.Messages {
+		if m.Role == "user" && contentHasToolResult(m.Content) {
+			idx++
+		}
+	}
+	if idx >= len(turns) {
+		f.t.Errorf("fake anthropic: unscripted streaming turn %d (script has %d turns)", idx, len(turns))
+		http.Error(w, "unscripted turn", http.StatusInternalServerError)
+		return
+	}
+	f.streamTurn(w, idx, turns[idx])
+}
+
+// contentHasToolResult reports whether a message's content array carries a
+// tool_result block. Plain-string content (no blocks) never does.
+func contentHasToolResult(content json.RawMessage) bool {
+	var blocks []struct {
+		Type string `json:"type"`
+	}
+	if err := json.Unmarshal(content, &blocks); err != nil {
+		return false
+	}
+	for _, b := range blocks {
+		if b.Type == "tool_result" {
+			return true
+		}
+	}
+	return false
+}
+
+// sseFrame writes one frame in the anthropic SSE wire format.
+func (f *fakeAnthropic) sseFrame(w http.ResponseWriter, event string, data any) {
+	b, err := json.Marshal(data)
+	if err != nil {
+		f.t.Errorf("fake anthropic: marshal %s frame: %v", event, err)
+		return
+	}
+	io.WriteString(w, "event: "+event+"\ndata: "+string(b)+"\n\n")
+}
+
+func (f *fakeAnthropic) streamTurn(w http.ResponseWriter, idx int, turn fakeTurn) {
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.WriteHeader(http.StatusOK)
+
+	f.sseFrame(w, "message_start", map[string]any{
+		"type": "message_start",
+		"message": map[string]any{
+			"id": fmt.Sprintf("msg_fake_%d", idx), "type": "message", "role": "assistant",
+			"model": "claude-sonnet-4-6", "content": []any{},
+			"stop_reason": nil, "stop_sequence": nil,
+			"usage": map[string]any{"input_tokens": 10, "output_tokens": 0},
+		},
+	})
+
+	blockDelta := func(delta map[string]any) {
+		f.sseFrame(w, "content_block_delta", map[string]any{
+			"type": "content_block_delta", "index": 0, "delta": delta,
+		})
+	}
+
+	stopReason := "end_turn"
+	switch turn.kind {
+	case "text":
+		f.sseFrame(w, "content_block_start", map[string]any{
+			"type": "content_block_start", "index": 0,
+			"content_block": map[string]any{"type": "text", "text": ""},
+		})
+		for _, chunk := range splitForStreaming(turn.text) {
+			blockDelta(map[string]any{"type": "text_delta", "text": chunk})
+		}
+
+	case "tool":
+		stopReason = "tool_use"
+		f.sseFrame(w, "content_block_start", map[string]any{
+			"type": "content_block_start", "index": 0,
+			"content_block": map[string]any{
+				"type": "tool_use", "id": fmt.Sprintf("toolu_fake_%d", idx),
+				"name": turn.toolName, "input": map[string]any{},
+			},
+		})
+		for _, chunk := range splitForStreaming(turn.toolInput) {
+			blockDelta(map[string]any{"type": "input_json_delta", "partial_json": chunk})
+		}
+
+	case "error":
+		// Start a real answer, then die mid-turn: the client sees the leading
+		// delta and then stream.Err().
+		f.sseFrame(w, "content_block_start", map[string]any{
+			"type": "content_block_start", "index": 0,
+			"content_block": map[string]any{"type": "text", "text": ""},
+		})
+		blockDelta(map[string]any{"type": "text_delta", "text": "One moment"})
+		f.sseFrame(w, "error", map[string]any{
+			"type":  "error",
+			"error": map[string]any{"type": "overloaded_error", "message": turn.errMsg},
+		})
+		return
+
+	default:
+		f.t.Errorf("fake anthropic: unknown turn kind %q", turn.kind)
+		return
+	}
+
+	f.sseFrame(w, "content_block_stop", map[string]any{"type": "content_block_stop", "index": 0})
+	f.sseFrame(w, "message_delta", map[string]any{
+		"type":  "message_delta",
+		"delta": map[string]any{"stop_reason": stopReason, "stop_sequence": nil},
+		"usage": map[string]any{"output_tokens": 7},
+	})
+	f.sseFrame(w, "message_stop", map[string]any{"type": "message_stop"})
+}
+
+// splitForStreaming cuts s into two rune-safe halves so every scripted turn
+// arrives as MULTIPLE delta frames — tests that pass against this fake prove
+// the client accumulates partial frames, not just whole payloads.
+func splitForStreaming(s string) []string {
+	if utf8.RuneCountInString(s) < 2 {
+		return []string{s}
+	}
+	runes := []rune(s)
+	mid := len(runes) / 2
+	return []string{string(runes[:mid]), string(runes[mid:])}
+}

--- a/src/packages/api/free_cap_integration_test.go
+++ b/src/packages/api/free_cap_integration_test.go
@@ -3,9 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
-	"io"
 	"net/http"
-	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
@@ -18,31 +16,6 @@ import (
 // free_cap_would_hit per crossing — the only-on-crossing rule's off-by-ones,
 // (b) the dashboard rollup, and (c) that every capped request still SUCCEEDS
 // (measurement only, nothing enforced).
-
-// fakeAnthropicServer stands in for the Anthropic API behind the
-// ANTHROPIC_BASE_URL seam: every /v1/messages call streams a minimal
-// text-only SSE response ending in end_turn, so a real /plan session runs
-// end-to-end through buildRouter with zero external calls.
-func fakeAnthropicServer(t *testing.T) *httptest.Server {
-	t.Helper()
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "text/event-stream")
-		w.WriteHeader(http.StatusOK)
-		frames := []struct{ event, data string }{
-			{"message_start", `{"type":"message_start","message":{"id":"msg_fake","type":"message","role":"assistant","model":"claude-sonnet-4-6","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":10,"output_tokens":0}}}`},
-			{"content_block_start", `{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`},
-			{"content_block_delta", `{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Where would you like to go?"}}`},
-			{"content_block_stop", `{"type":"content_block_stop","index":0}`},
-			{"message_delta", `{"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":7}}`},
-			{"message_stop", `{"type":"message_stop"}`},
-		}
-		for _, f := range frames {
-			io.WriteString(w, "event: "+f.event+"\ndata: "+f.data+"\n\n")
-		}
-	}))
-	t.Cleanup(srv.Close)
-	return srv
-}
 
 // waitForEventCount polls until the user has exactly want events of the given
 // type. plan_session_started is recorded by a goroutine that writes any
@@ -99,9 +72,7 @@ func freeCapWouldHits(t *testing.T, userID uuid.UUID, capKind string) (hits, las
 // 4 (prior > cap) emits nothing more. Every session must succeed.
 func TestFreeCapPlanRunsCrossingSignal(t *testing.T) {
 	resetDB(t)
-	srv := fakeAnthropicServer(t)
-	t.Setenv("ANTHROPIC_API_KEY", "test-key")
-	t.Setenv("ANTHROPIC_BASE_URL", srv.URL)
+	newFakeAnthropic(t, textTurn("Where would you like to go?"))
 	t.Setenv("FREE_PLAN_SESSIONS_PER_MONTH", "2")
 
 	user, token := createTestUser(t, "capped@example.com")
@@ -223,47 +194,6 @@ func TestFreeCapEventNotClientRecordable(t *testing.T) {
 	}
 }
 
-// fakeAnthropicItineraryServer stands in for the Anthropic API for sessions
-// that finalize a trip: any request that does not yet carry a tool_result
-// gets a create_itinerary tool_use (driving plan_handler's persistTrip
-// branch), and the follow-up request (which echoes the tool result back)
-// gets a plain end_turn text answer. Keying on the request body rather than
-// a call counter keeps it deterministic when background callers (the profile
-// distiller) also hit the seam.
-func fakeAnthropicItineraryServer(t *testing.T) *httptest.Server {
-	t.Helper()
-	textFrames := []struct{ event, data string }{
-		{"message_start", `{"type":"message_start","message":{"id":"msg_fake","type":"message","role":"assistant","model":"claude-sonnet-4-6","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":10,"output_tokens":0}}}`},
-		{"content_block_start", `{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`},
-		{"content_block_delta", `{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Your itinerary is saved."}}`},
-		{"content_block_stop", `{"type":"content_block_stop","index":0}`},
-		{"message_delta", `{"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":7}}`},
-		{"message_stop", `{"type":"message_stop"}`},
-	}
-	toolFrames := []struct{ event, data string }{
-		{"message_start", `{"type":"message_start","message":{"id":"msg_tool","type":"message","role":"assistant","model":"claude-sonnet-4-6","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":10,"output_tokens":0}}}`},
-		{"content_block_start", `{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_01","name":"create_itinerary","input":{}}}`},
-		{"content_block_delta", `{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"title\":\"Athens Weekend\",\"locations\":[{\"name\":\"Acropolis\",\"latitude\":37.97,\"longitude\":23.72,\"day\":1}]}"}}`},
-		{"content_block_stop", `{"type":"content_block_stop","index":0}`},
-		{"message_delta", `{"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"output_tokens":9}}`},
-		{"message_stop", `{"type":"message_stop"}`},
-	}
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		body, _ := io.ReadAll(r.Body)
-		frames := toolFrames
-		if strings.Contains(string(body), "tool_result") {
-			frames = textFrames
-		}
-		w.Header().Set("Content-Type", "text/event-stream")
-		w.WriteHeader(http.StatusOK)
-		for _, f := range frames {
-			io.WriteString(w, "event: "+f.event+"\ndata: "+f.data+"\n\n")
-		}
-	}))
-	t.Cleanup(srv.Close)
-	return srv
-}
-
 // Version saves must never re-emit the active_trips crossing signal
 // (specs/free-cap-instrumentation: "Saving a new version of an existing trip
 // does not increase the count and can never emit"). With the cap at 1 and one
@@ -273,9 +203,11 @@ func fakeAnthropicItineraryServer(t *testing.T) *httptest.Server {
 // regression this guards — must not emit again.
 func TestFreeCapActiveTripsVersionSaveNeverReemits(t *testing.T) {
 	resetDB(t)
-	srv := fakeAnthropicItineraryServer(t)
-	t.Setenv("ANTHROPIC_API_KEY", "test-key")
-	t.Setenv("ANTHROPIC_BASE_URL", srv.URL)
+	// Turn 0: finalize a trip (drives plan_handler's persistTrip branch);
+	// turn 1 (after the tool_result round-trips): a plain end_turn answer.
+	newFakeAnthropic(t,
+		toolTurn("create_itinerary", `{"title":"Athens Weekend","locations":[{"name":"Acropolis","latitude":37.97,"longitude":23.72,"day":1}]}`),
+		textTurn("Your itinerary is saved."))
 	t.Setenv("FREE_ACTIVE_TRIPS", "1") // envInt treats 0 as invalid, so park the user at cap via a seed trip
 
 	user, token := createTestUser(t, "re-finalizer@example.com")

--- a/src/packages/api/plan_integration_test.go
+++ b/src/packages/api/plan_integration_test.go
@@ -1,0 +1,350 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+// End-to-end /plan coverage through buildRouter, with the Anthropic API
+// replaced by the scriptable fake (fake_anthropic_test.go). Each test drives
+// a real SSE session — request validation, the agent tool loop, tool
+// execution against the test DB, persistence, and the client-facing event
+// stream — with zero external calls.
+
+// planEvents parses every `data: {...}` SSE line the /plan handler wrote.
+func planEvents(t *testing.T, body string) []map[string]any {
+	t.Helper()
+	var events []map[string]any
+	for _, line := range strings.Split(body, "\n") {
+		data, ok := strings.CutPrefix(line, "data: ")
+		if !ok {
+			continue
+		}
+		var m map[string]any
+		if err := json.Unmarshal([]byte(data), &m); err != nil {
+			t.Fatalf("unparseable SSE data line %q: %v", line, err)
+		}
+		events = append(events, m)
+	}
+	return events
+}
+
+func eventsOfType(events []map[string]any, typ string) []map[string]any {
+	var out []map[string]any
+	for _, e := range events {
+		if e["type"] == typ {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// eventData returns the event's data payload as a map (nil if absent).
+func eventData(e map[string]any) map[string]any {
+	d, _ := e["data"].(map[string]any)
+	return d
+}
+
+// joinedText reassembles the streamed answer from text_delta events.
+func joinedText(events []map[string]any) string {
+	var b strings.Builder
+	for _, e := range eventsOfType(events, "text_delta") {
+		if txt, ok := eventData(e)["text"].(string); ok {
+			b.WriteString(txt)
+		}
+	}
+	return b.String()
+}
+
+// (a) A text-only turn streams multiple deltas that reassemble to the full
+// answer, with no error event — the plain conversational path.
+func TestPlanTextTurnStreamsDeltas(t *testing.T) {
+	resetDB(t)
+	const answer = "Lisbon in May is lovely — shall I plan three days?"
+	newFakeAnthropic(t, textTurn(answer))
+
+	rec := doJSON(t, "POST", "/api/v1/plan", "", PlanRequest{
+		ChatID:   "chat-text",
+		Messages: []PlanChatMessage{{Role: "user", Content: "where should I go in May?"}},
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("/plan = %d, want 200", rec.Code)
+	}
+	events := planEvents(t, rec.Body.String())
+	if deltas := eventsOfType(events, "text_delta"); len(deltas) < 2 {
+		t.Fatalf("text_delta events = %d, want >= 2 (the fake splits text across frames)", len(deltas))
+	}
+	if got := joinedText(events); got != answer {
+		t.Fatalf("reassembled text = %q, want %q", got, answer)
+	}
+	if errs := eventsOfType(events, "error"); len(errs) != 0 {
+		t.Fatalf("unexpected error events: %v", errs)
+	}
+}
+
+// (b) Tool loop: the model requests the DB-backed get_trip tool, the handler
+// executes it against the test DB, the tool_result round-trips to the model
+// (asserted on the fake's second request body), and the final text streams.
+func TestPlanToolLoopRoundTripsToolResult(t *testing.T) {
+	resetDB(t)
+	fa := newFakeAnthropic(t,
+		toolTurn("get_trip", `{}`),
+		textTurn("You have one saved trip: Test Trip."))
+
+	user, token := createTestUser(t, "tool-loop@example.com")
+	createTestTrip(t, user.ID, 2)
+
+	rec := doJSON(t, "POST", "/api/v1/plan", token, PlanRequest{
+		ChatID:   "chat-tools",
+		Messages: []PlanChatMessage{{Role: "user", Content: "what trips do I have saved?"}},
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("/plan = %d, want 200", rec.Code)
+	}
+	events := planEvents(t, rec.Body.String())
+
+	calls := eventsOfType(events, "tool_call")
+	if len(calls) != 1 || eventData(calls[0])["name"] != "get_trip" {
+		t.Fatalf("tool_call events = %v, want exactly one get_trip", calls)
+	}
+	results := eventsOfType(events, "tool_result")
+	if len(results) != 1 || eventData(results[0])["name"] != "get_trip" {
+		t.Fatalf("tool_result events = %v, want exactly one get_trip", results)
+	}
+	if got := joinedText(events); got != "You have one saved trip: Test Trip." {
+		t.Fatalf("final text = %q", got)
+	}
+	if errs := eventsOfType(events, "error"); len(errs) != 0 {
+		t.Fatalf("unexpected error events: %v", errs)
+	}
+
+	// The second model request must carry the executed tool's result back —
+	// including content that only exists in the database.
+	reqs := fa.requestBodies()
+	if len(reqs) != 2 {
+		t.Fatalf("model requests = %d, want 2 (tool turn + follow-up)", len(reqs))
+	}
+	followUp := string(reqs[1])
+	if !strings.Contains(followUp, `"tool_result"`) {
+		t.Fatalf("follow-up request carries no tool_result block: %s", followUp)
+	}
+	if !strings.Contains(followUp, "Test Trip") {
+		t.Fatalf("tool_result did not round-trip DB content (missing trip title): %s", followUp)
+	}
+}
+
+// (c) create_itinerary end-to-end: the streamed `done` event carries a
+// trip_id, and that trip — title, summary and items — is really persisted.
+func TestPlanCreateItineraryPersistsTrip(t *testing.T) {
+	resetDB(t)
+	newFakeAnthropic(t,
+		toolTurn("create_itinerary", `{
+			"title":"Athens Weekend","summary":"Two easy days in Athens.",
+			"locations":[
+				{"name":"Acropolis","latitude":37.9715,"longitude":23.7267,"day":1,"city":"Athens","category":"attraction","time_of_day":"morning"},
+				{"name":"Ta Karamanlidika","latitude":37.9808,"longitude":23.7247,"day":1,"city":"Athens","category":"restaurant","time_of_day":"evening"}
+			]}`),
+		textTurn("Saved your Athens weekend!"))
+
+	user, token := createTestUser(t, "finalizer@example.com")
+
+	rec := doJSON(t, "POST", "/api/v1/plan", token, PlanRequest{
+		ChatID:   "chat-athens",
+		Messages: []PlanChatMessage{{Role: "user", Content: "plan me a weekend in Athens"}},
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("/plan = %d, want 200", rec.Code)
+	}
+	events := planEvents(t, rec.Body.String())
+
+	dones := eventsOfType(events, "done")
+	if len(dones) != 1 {
+		t.Fatalf("done events = %d, want 1", len(dones))
+	}
+	done := eventData(dones[0])
+	tripID, _ := done["trip_id"].(string)
+	if tripID == "" {
+		t.Fatalf("done event carries no trip_id: %v", done)
+	}
+	if locs, _ := done["locations"].([]any); len(locs) != 2 {
+		t.Fatalf("done event locations = %v, want 2", done["locations"])
+	}
+	if errs := eventsOfType(events, "error"); len(errs) != 0 {
+		t.Fatalf("unexpected error events: %v", errs)
+	}
+
+	// The trip is readable through the normal REST surface.
+	tripRec := doJSON(t, "GET", "/api/v1/trips/"+tripID, token, nil)
+	if tripRec.Code != http.StatusOK {
+		t.Fatalf("GET trip = %d: %s", tripRec.Code, tripRec.Body.String())
+	}
+	trip := decode(t, tripRec)
+	if trip["title"] != "Athens Weekend" {
+		t.Fatalf("persisted title = %v, want Athens Weekend", trip["title"])
+	}
+	items, _ := trip["items"].([]any)
+	if len(items) != 2 {
+		t.Fatalf("persisted items = %d, want 2", len(items))
+	}
+
+	// Settle the async trip_created analytics before the next test truncates.
+	waitForEventCount(t, user.ID, "trip_created", 1)
+}
+
+// (c, trip-bound) update_itinerary_section on a bound trip replaces the
+// section in the DB and streams a trip_updated event with the trip's id.
+func TestPlanBoundSessionUpdatesSectionAndStreamsTripUpdated(t *testing.T) {
+	resetDB(t)
+	newFakeAnthropic(t,
+		toolTurn("update_itinerary_section", `{"scope":"trip","items":[{"name":"New Cafe","latitude":37.98,"longitude":23.74,"day":1}]}`),
+		textTurn("Swapped the whole plan for the cafe."))
+
+	user, token := createTestUser(t, "refiner@example.com")
+	trip := createTestTrip(t, user.ID, 2)
+
+	rec := doJSON(t, "POST", "/api/v1/plan", token, PlanRequest{
+		TripID:   trip.ID.String(),
+		Messages: []PlanChatMessage{{Role: "user", Content: "replace everything with one cafe"}},
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("/plan = %d, want 200", rec.Code)
+	}
+	events := planEvents(t, rec.Body.String())
+
+	updated := eventsOfType(events, "trip_updated")
+	if len(updated) != 1 || eventData(updated[0])["trip_id"] != trip.ID.String() {
+		t.Fatalf("trip_updated events = %v, want exactly one for trip %s", updated, trip.ID)
+	}
+	if errs := eventsOfType(events, "error"); len(errs) != 0 {
+		t.Fatalf("unexpected error events: %v", errs)
+	}
+	// A bound session must never create a new trip version.
+	if dones := eventsOfType(events, "done"); len(dones) != 0 {
+		t.Fatalf("unexpected done events on a bound session: %v", dones)
+	}
+
+	var count int
+	var name string
+	if err := dbPool.QueryRow(context.Background(),
+		`SELECT count(*), min(name) FROM itinerary_items WHERE trip_id = $1`,
+		trip.ID).Scan(&count, &name); err != nil {
+		t.Fatalf("items query: %v", err)
+	}
+	if count != 1 || name != "New Cafe" {
+		t.Fatalf("items after update = %d/%q, want 1/\"New Cafe\"", count, name)
+	}
+}
+
+// (d) A mid-turn model error (SSE `error` event after deltas already
+// streamed) surfaces to the client as a /plan error event, not a hang or a
+// silent truncation.
+func TestPlanMidTurnModelErrorSurfaces(t *testing.T) {
+	resetDB(t)
+	newFakeAnthropic(t, errorTurn("Overloaded"))
+
+	rec := doJSON(t, "POST", "/api/v1/plan", "", PlanRequest{
+		ChatID:   "chat-err",
+		Messages: []PlanChatMessage{{Role: "user", Content: "plan something"}},
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("/plan = %d, want 200 (headers are sent before the model call)", rec.Code)
+	}
+	events := planEvents(t, rec.Body.String())
+
+	// The pre-error delta proves the failure hit MID-turn.
+	if deltas := eventsOfType(events, "text_delta"); len(deltas) == 0 {
+		t.Fatal("no text_delta before the error; the error was not mid-turn")
+	}
+	errs := eventsOfType(events, "error")
+	if len(errs) != 1 {
+		t.Fatalf("error events = %d, want 1", len(errs))
+	}
+	if msg, _ := eventData(errs[0])["message"].(string); msg == "" {
+		t.Fatalf("error event carries no message: %v", errs[0])
+	}
+	if dones := eventsOfType(events, "done"); len(dones) != 0 {
+		t.Fatalf("unexpected done events after error: %v", dones)
+	}
+}
+
+// (e) The local-ingest anti-hallucination gate: extraction (a NON-streaming
+// forced-tool call through the same seam) drafts a pin, Google verification
+// cannot fill coordinates (no Places key), and publish is refused while the
+// draft has no coordinates.
+func TestLocalIngestUnverifiedDraftCannotPublish(t *testing.T) {
+	resetDB(t)
+	fa := newFakeAnthropic(t)
+	fa.scriptNonStreamingTool("draft_local_content",
+		`{"recommendations":[{"name":"To Steki","category":"restaurant","neighborhood":"Psyrri","tip":"Go before 8pm","quote":"","tags":["food"],"search_hint":"To Steki taverna, Athens"}]}`)
+
+	// Force the verify step to fail: the Places singleton captured its key at
+	// process init, so blank it directly (integration tests never run parallel).
+	oldKey := placesService.APIKey
+	placesService.APIKey = ""
+	t.Cleanup(func() { placesService.APIKey = oldKey })
+
+	admin, adminToken := createTestUser(t, "curator@example.com")
+	makeAdmin(t, admin.ID)
+
+	srcRec := doJSON(t, "POST", "/api/v1/admin/local/sources", adminToken,
+		map[string]any{"name": "Maria", "location": "Athens"})
+	if srcRec.Code != http.StatusCreated {
+		t.Fatalf("create source = %d: %s", srcRec.Code, srcRec.Body.String())
+	}
+	sourceID, _ := decode(t, srcRec)["id"].(string)
+
+	ingRec := doJSON(t, "POST", "/api/v1/admin/local/ingest", adminToken, map[string]any{
+		"source_id": sourceID,
+		"city":      "Athens",
+		"kind":      "notes",
+		"raw_text":  "Maria says To Steki in Psyrri is the move, go before 8pm.",
+	})
+	if ingRec.Code != http.StatusCreated {
+		t.Fatalf("ingest = %d: %s", ingRec.Code, ingRec.Body.String())
+	}
+	var ing struct {
+		Recommendations []struct {
+			ID            uuid.UUID `json:"id"`
+			Status        string    `json:"status"`
+			Latitude      *float64  `json:"latitude"`
+			PlaceVerified bool      `json:"place_verified"`
+		} `json:"recommendations"`
+		Verified   int `json:"verified"`
+		Unverified int `json:"unverified"`
+	}
+	if err := json.Unmarshal(ingRec.Body.Bytes(), &ing); err != nil {
+		t.Fatalf("decode ingest response: %v", err)
+	}
+	if len(ing.Recommendations) != 1 || ing.Verified != 0 || ing.Unverified != 1 {
+		t.Fatalf("ingest = %d recs / %d verified / %d unverified, want 1/0/1: %s",
+			len(ing.Recommendations), ing.Verified, ing.Unverified, ingRec.Body.String())
+	}
+	draft := ing.Recommendations[0]
+	if draft.Status != "draft" || draft.Latitude != nil || draft.PlaceVerified {
+		t.Fatalf("draft = %+v, want unverified draft with nil coordinates", draft)
+	}
+
+	// The gate: a coordinate-less draft cannot be published.
+	pubRec := doJSON(t, "POST", "/api/v1/admin/local/recommendations/"+draft.ID.String()+"/publish", adminToken, nil)
+	if pubRec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("publish unverified draft = %d, want 422: %s", pubRec.Code, pubRec.Body.String())
+	}
+	if body := pubRec.Body.String(); !strings.Contains(body, "not verified") {
+		t.Fatalf("publish rejection reason = %s, want the not-verified message", body)
+	}
+
+	// Still a draft afterwards — the gate blocked, it didn't archive or mutate.
+	var status string
+	if err := dbPool.QueryRow(context.Background(),
+		`SELECT status FROM local_recommendations WHERE id = $1`, draft.ID).Scan(&status); err != nil {
+		t.Fatalf("status query: %v", err)
+	}
+	if status != "draft" {
+		t.Fatalf("status after blocked publish = %q, want draft", status)
+	}
+}


### PR DESCRIPTION
## What

Wave 7 deliberately shipped only the seam (`anthropic_client.go` honors `ANTHROPIC_BASE_URL`) plus one ad-hoc fake. This PR generalizes that fake into a reusable, scriptable harness and uses it for real end-to-end `/plan` coverage through `buildRouter`.

## The harness (`fake_anthropic_test.go`)

```go
fa := newFakeAnthropic(t,                       // sets ANTHROPIC_API_KEY + ANTHROPIC_BASE_URL
    toolTurn("get_trip", `{}`),                 // streams a tool_use, stop_reason tool_use
    textTurn("You have one saved trip."))       // streams text, stop_reason end_turn
fa.scriptNonStreamingTool(name, inputJSON)      // forced-tool answer for Messages.New callers
fa.requestBodies()                              // every request body received, in order
// errorTurn("Overloaded")                      // delta, then SSE `error` mid-turn
```

- **Body-keyed, not counter-keyed**: the turn index is the number of `tool_result`-bearing user messages in the request — deterministic under background callers and across repeated sessions (each new `/plan` POST replays from turn 0), generalizing the existing ad-hoc fake's keying.
- **Accumulator-faithful wire format** (verified against anthropic-sdk-go v1.45.0 `messageutil.go` / `ssestream.go`): `message_start` envelope, `content_block_start` (tool input opens as the literal `{}` the accumulator replaces), text/tool-input **always split across multiple** `text_delta`/`input_json_delta` frames so passing tests prove real accumulation, `message_delta` carries `stop_reason`, `message_stop` closes.
- **Non-streaming served too** — verified, not assumed: the profile distiller (fires after every authed `create_itinerary`) and the local-ingest extractor both call `client.Messages.New` through the same seam. Streaming requests are detected via the SDK's `"stream":true` body field; non-streaming ones get a valid JSON message (harmless text by default → the forced-tool callers no-op; scriptable for tests that target them).
- Unexpected paths/methods and unscripted turns `t.Errorf` + 500.

## E2E scenarios (`plan_integration_test.go`, all through `buildRouter` on the test DB)

- (a) text-only turn: ≥2 deltas reassemble to the full answer, no error event
- (b) tool loop with DB-backed `get_trip` (Places has no base-URL seam, so per the plan a DB tool): `tool_call`/`tool_result` events, and the follow-up model request provably carries the DB-sourced trip title inside the `tool_result` round-trip
- (c) `create_itinerary` → `done` event with `trip_id`, trip + 2 items readable via `GET /trips/{id}`; plus trip-bound `update_itinerary_section` → section rewritten in the DB + `trip_updated` SSE event (and no `done`, proving bound sessions can't version)
- (d) mid-turn model `error` event → client-visible SSE `error` after real deltas, no `done`
- (e) anti-hallucination gate: scripted non-streaming extraction drafts a pin, Google verify can't fill coordinates (Places key blanked), ingest reports `1 unverified`, publish → 422 "not verified", pin stays `draft`

Both free-cap ad-hoc fakes are migrated onto the harness with assertions unchanged.

## Runtime

All fakes are local `httptest` servers; the new tests add ~0.5s (integration suite total ~4.5s).

## Gates

- `make api-fmt` / `make api-vet` clean
- `go test ./...` green (unit)
- `TEST_DATABASE_URL=...travel_test_w8b go test -count=1 ./...` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)