### PR TITLE
feat(api): anonymous top-of-funnel analytics events

### DIFF
--- a/specs/instrumentation-events/spec.md
+++ b/specs/instrumentation-events/spec.md
@@ -38,16 +38,55 @@ Recorded server-side (no client involvement):
 | `trip_refined` | the agent updates an existing trip | trip id |
 | `booking_marked_booked` | user checks off a booking todo as booked | trip id, todo kind, provider |
 
-Recorded from the client (the one moment only the client can see):
+Recorded from the client (the moments only the client can see):
 
 | Event | When | Notable detail carried |
 |---|---|---|
 | `booking_link_clicked` | user opens a booking handoff link | trip id, todo id, provider, kind |
+| `landing_viewed` | a signed-out visitor renders the landing page (once per app session) | — |
 
 `booking_link_clicked` is the **attach-rate numerator** — the reason this
 feature exists. Completed bookings cannot be observed directly (affiliate
 conversions live in partner dashboards); clicks are the in-product proxy, with
 `booking_marked_booked` as the self-reported completion signal.
+
+### Anonymous client events (Wave 8)
+
+Everything above `user_registered` used to be invisible: the events endpoint
+required authentication and the client dropped events for signed-out sessions,
+so the funnel had no top. `POST /events` now also accepts **unauthenticated**
+requests, restricted to a deliberately tiny whitelist — this is a
+spam-writable surface with no identity to hold accountable, so every accepted
+type must be a moment a signed-out visitor can actually produce:
+
+| Anonymous event | Why it's on the whitelist |
+|---|---|
+| `landing_viewed` | the top of the funnel: landing-page views over signups is the first conversion number |
+| `booking_link_clicked` | signed-out booking handoffs (e.g. from future public surfaces) still count toward total clicks |
+
+There is intentionally **no** `plan_started_anonymous`: the Flutter app has no
+signed-out planning entry point (AuthGate routes signed-out visitors to the
+landing page), and anonymous direct `/plan` API calls are already recorded
+server-side as `plan_session_started` with a NULL user id (surfaced as
+`plan_sessions_anonymous`).
+
+Spam-bounding measures on the anonymous path:
+
+- **Strict rate limiter** — the anonymous route sits behind the strict per-IP
+  tier (same as `/plan` and credential routes), bounding write volume.
+- **Whitelist rejection** — an anonymous `event_type` off the whitelist is a
+  400; server-side types cannot be spoofed.
+- **`trip_id` always dropped** — ownership cannot be verified without a user,
+  and the attach-rate numerator counts DISTINCT trip ids, so anonymous events
+  are stored with `trip_id` NULL unconditionally.
+- **Metadata whitelist** — the same closed key set (`provider`, `surface`,
+  `kind`, `todo_key`), 64-char string values, provider lowercased, 2 KB cap.
+- **No silent auth downgrade** — a request presenting *any* Authorization
+  header is routed through the authenticated path and validated; an invalid
+  token is a 401, never treated as anonymous.
+- **Client-side once-per-session guard** — the app records `landing_viewed`
+  at most once per app session (a static guard, so rebuilds and sign-out
+  round trips don't re-record).
 
 ## Acceptance Criteria
 
@@ -78,23 +117,54 @@ conversions live in partner dashboards); clicks are the in-product proxy, with
 
 ### `POST /api/v1/events`
 - **Purpose:** record a client-observed event. Fire-and-forget semantics.
-- **Request:** `event_type` (must be a client-permitted type —
-  `booking_link_clicked` only for now), optional `trip_id`, optional
-  `metadata` (small, flat key/value detail: todo id, provider, kind).
-  Requires authentication.
+- **Request:** `event_type` (must be a client-permitted type), optional
+  `trip_id`, optional `metadata` (small, flat key/value detail: todo id,
+  provider, kind).
+- **Authentication:** optional, with two distinct paths matched by the
+  presence of an `Authorization` header:
+  - **Authenticated** (header present): the token is validated and the event
+    attributed to the user; the full client whitelist applies and `trip_id`
+    survives only if the caller can access the trip. An invalid token is a
+    401 — never a silent downgrade to anonymous.
+  - **Anonymous** (no header): only the anonymous whitelist
+    (`landing_viewed`, `booking_link_clicked`) is accepted; the row is stored
+    with `user_id` NULL and `trip_id` NULL unconditionally; the route sits
+    behind the strict per-IP rate limiter.
 - **Response:** `202 Accepted`, empty body — returned even when persistence is
   degraded (the event is dropped, not errored).
-- **Errors:** 401 when not authenticated; 400 when `event_type` is missing or
-  not client-permitted (server-side types cannot be spoofed through this
-  endpoint).
+- **Errors:** 401 when a presented token is invalid or expired; 400 when
+  `event_type` is missing or not permitted for the request's auth level
+  (server-side types cannot be spoofed through this endpoint); 429 when the
+  anonymous strict tier is exceeded.
 
 ### `GET /api/v1/admin/metrics?days=`
 - **Purpose:** the Phase 1 dashboard-in-an-endpoint. **Admin only.**
 - **Request:** optional `days` window (default 30).
-- **Response:** counts and rates for the window — signups, activated users and
-  activation rate, trips created, trips with ≥1 booking click and attach rate,
-  booking clicks by provider, todos marked booked, the derived metrics below,
-  plan sessions, total input/output/cache tokens, and cost estimates.
+- **Response:** counts and rates for the window — landing views (anonymous;
+  see below), signups, activated users and activation rate, trips created,
+  trips with ≥1 booking click and attach rate, booking clicks by provider,
+  todos marked booked, the derived metrics below, plan sessions, total
+  input/output/cache tokens, and cost estimates.
+
+#### Anonymous rows and the derived metrics
+
+Anonymous events (`user_id` NULL) must never distort the signed-in numbers:
+
+- **`landing_views`** counts anonymous `landing_viewed` events — the top of
+  the funnel, above signups. Client-guarded to once per app session and
+  strict-rate-limited at ingest, but still an unauthenticated count: read it
+  as directional, not audited.
+- **MAU / engagement** (`active_users`, `session_frequency_returning`,
+  `second_trip_retention`) filter `user_id IS NOT NULL` explicitly — NULL
+  rows can never group into a phantom user.
+- **Attach rate**: anonymous `booking_link_clicked` events count toward
+  `booking_clicks` and `clicks_by_provider`, but they **cannot** count toward
+  `trips_with_booking_click` (and therefore `attach_rate`) — their `trip_id`
+  is NULL by construction (dropped at ingest, ownership unverifiable), and
+  the numerator counts DISTINCT non-NULL trip ids. This is deliberate: attach
+  rate stays a signed-in, per-trip metric.
+- **`activation_rate`** joins `user_registered` to `trip_created` on
+  `user_id`; NULL never joins, so anonymous rows are inert there.
 - **Errors:** 401 unauthenticated; 403 non-admin; 503 when persistence is
   unavailable.
 
@@ -185,15 +255,22 @@ flows they describe.
   events endpoint still returns 202; nothing user-facing changes.
 - Event recording must never fail its parent flow: a failed insert during
   signup or trip save is logged server-side and swallowed.
-- Client event with an unknown or server-only `event_type` → 400.
+- Client event with an unknown or server-only `event_type` → 400 (on both the
+  authenticated and anonymous paths; the anonymous whitelist is stricter).
 - Oversized metadata is rejected or truncated safely (bounded payload).
-- Anonymous planning sessions (unauthenticated `/plan` use, if any) are not
-  recorded — events require a user.
+- A request presenting an invalid/expired token → 401, never recorded as
+  anonymous.
+- Anonymous planning sessions (unauthenticated `/plan` use) are recorded
+  server-side with a NULL user id (`plan_sessions_anonymous`); they are
+  excluded from every user-denominated metric.
 
 ## Out of Scope
 
 - Third-party analytics (PostHog, GA, etc.) and any data export.
-- Anonymous / pre-signup tracking (landing page visits, marketing funnels).
+- Broad anonymous / pre-signup tracking (marketing funnels, referrer/UTM
+  capture, anonymous identity stitching). The Wave 8 anonymous whitelist
+  covers exactly two in-product moments — nothing about the visitor is stored
+  beyond the event itself (no IP, no user agent, no fingerprint).
 - Dashboards or Flutter admin UI for metrics (endpoint only).
 - A/B testing, feature flags, experiment assignment.
 - Client-side event batching/queueing — one best-effort request per event.

--- a/src/packages/api/analytics.go
+++ b/src/packages/api/analytics.go
@@ -21,9 +21,28 @@ import (
 // database down every instrumented flow behaves exactly as before and events
 // are silently dropped. No PII beyond the user id.
 
-// clientEventTypes are the only types POST /events accepts — server-side
-// types cannot be spoofed through the client endpoint.
+// clientEventTypes are the only types authenticated POST /events accepts —
+// server-side types cannot be spoofed through the client endpoint.
 var clientEventTypes = map[string]bool{
+	"booking_link_clicked": true,
+}
+
+// anonymousClientEventTypes is the tighter whitelist for UNAUTHENTICATED
+// POST /events — the pre-signup top of the funnel. Deliberately tiny: this is
+// a spam-writable surface (no identity, only the strict per-IP limiter
+// bounding it), so only the moments a signed-out visitor can actually produce
+// are accepted:
+//   - landing_viewed        — the marketing landing page rendered (once per
+//     app session, guarded client-side).
+//   - booking_link_clicked  — a signed-out booking handoff (the attach-rate
+//     event; anonymous rows never carry a trip_id, see below).
+//
+// There is intentionally no plan_started_anonymous: the Flutter app has no
+// signed-out planning entry point, and anonymous direct /plan calls are
+// already recorded server-side as plan_session_started with a NULL user_id
+// (the plan_sessions_anonymous metric).
+var anonymousClientEventTypes = map[string]bool{
+	"landing_viewed":       true,
 	"booking_link_clicked": true,
 }
 
@@ -114,16 +133,21 @@ func recordEventOpt(userID *uuid.UUID, eventType string, tripID *uuid.UUID, meta
 	}
 }
 
-// recordClientEventHandler is POST /api/v1/events — the one client-observed
-// moment (opening a booking link). Always 202 once the payload is valid, even
-// when persistence is degraded: tracking must never surface as a user error.
+// clientEventRequest is the POST /api/v1/events payload, shared by the
+// authenticated and anonymous handlers.
+type clientEventRequest struct {
+	EventType string         `json:"event_type"`
+	TripID    *string        `json:"trip_id"`
+	Metadata  map[string]any `json:"metadata"`
+}
+
+// recordClientEventHandler is authenticated POST /api/v1/events — client
+// funnel moments from signed-in users. Always 202 once the payload is valid,
+// even when persistence is degraded: tracking must never surface as a user
+// error.
 func recordClientEventHandler(w http.ResponseWriter, r *http.Request) {
 	user, _ := userFromContext(r.Context())
-	var req struct {
-		EventType string         `json:"event_type"`
-		TripID    *string        `json:"trip_id"`
-		Metadata  map[string]any `json:"metadata"`
-	}
+	var req clientEventRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		writeJSONError(w, http.StatusBadRequest, "invalid JSON")
 		return
@@ -161,6 +185,35 @@ func recordClientEventHandler(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusAccepted)
 }
 
+// recordAnonymousClientEventHandler is unauthenticated POST /api/v1/events —
+// the pre-signup top of the funnel. Route registration (main.go) sends only
+// requests WITHOUT an Authorization header here, behind the strict per-IP
+// limiter; anything presenting a token goes through authMiddleware instead
+// (validated and attributed, or 401 — never silently downgraded to
+// anonymous).
+//
+// Spam bounding, since there is no identity to hold accountable:
+//   - event_type must be on anonymousClientEventTypes (400 otherwise);
+//   - trip_id is ALWAYS dropped — ownership cannot be verified without a
+//     user, and the attach-rate numerator counts DISTINCT trip_id, so a
+//     fabricated reference must never be stored;
+//   - metadata passes the same closed key/value whitelist as authed events;
+//   - the strict rate limiter caps write volume per IP.
+func recordAnonymousClientEventHandler(w http.ResponseWriter, r *http.Request) {
+	var req clientEventRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid JSON")
+		return
+	}
+	if !anonymousClientEventTypes[req.EventType] {
+		writeJSONError(w, http.StatusBadRequest, "event_type is missing or not permitted for anonymous requests")
+		return
+	}
+	meta := sanitizeClientEventMetadata(req.Metadata)
+	go recordEventOpt(nil, req.EventType, nil, meta)
+	w.WriteHeader(http.StatusAccepted)
+}
+
 // Claude pricing used for the dashboard's COGS estimates (USD per million
 // tokens), pinned to the model plan_handler.go actually calls. If the /plan
 // model changes, update this block in the same commit. The resulting est_*
@@ -178,13 +231,22 @@ const (
 // questions in docs/business-model.md §8 (activation, second-trip retention,
 // attach rate, COGS per active user, cap-hit rate).
 type MetricsResponse struct {
-	Days                  int              `json:"days"`
-	Signups               int64            `json:"signups"`
-	ActivatedSignups      int64            `json:"activated_signups"`
-	ActivationRate        float64          `json:"activation_rate"`
-	OnboardingsCompleted  int64            `json:"onboardings_completed"`
-	TripsCreated          int64            `json:"trips_created"`
-	TripsRefined          int64            `json:"trips_refined"`
+	Days int `json:"days"`
+	// LandingViews counts anonymous landing_viewed events — the top of the
+	// funnel, above signups. Client-guarded to once per app session and
+	// strict-rate-limited at ingest, but still an unauthenticated count:
+	// read it as directional, not audited.
+	LandingViews         int64   `json:"landing_views"`
+	Signups              int64   `json:"signups"`
+	ActivatedSignups     int64   `json:"activated_signups"`
+	ActivationRate       float64 `json:"activation_rate"`
+	OnboardingsCompleted int64   `json:"onboardings_completed"`
+	TripsCreated         int64   `json:"trips_created"`
+	TripsRefined         int64   `json:"trips_refined"`
+	// TripsWithBookingClick / AttachRate count DISTINCT non-NULL trip_id on
+	// booking_link_clicked. Anonymous clicks always have trip_id NULL (ingest
+	// drops it — ownership is unverifiable), so they appear in BookingClicks
+	// and ClicksByProvider but can never move the attach rate.
 	TripsWithBookingClick int64            `json:"trips_with_booking_click"`
 	AttachRate            float64          `json:"attach_rate"`
 	BookingClicks         int64            `json:"booking_clicks"`
@@ -258,6 +320,7 @@ func adminMetricsHandler(w http.ResponseWriter, r *http.Request) {
 
 	resp := MetricsResponse{
 		Days:                 days,
+		LandingViews:         counts["landing_viewed"],
 		Signups:              counts["user_registered"],
 		OnboardingsCompleted: counts["onboarding_completed"],
 		TripsCreated:         counts["trip_created"],

--- a/src/packages/api/analytics_integration_test.go
+++ b/src/packages/api/analytics_integration_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 )
@@ -100,6 +101,175 @@ func TestClientEventOwnTripIDIsKept(t *testing.T) {
 	if meta["surface"] != "flight_card" {
 		t.Fatalf("surface = %v, want flight_card", meta["surface"])
 	}
+}
+
+// --- anonymous top-of-funnel events (Wave 8) ---
+
+// countAnonymousEvents counts rows with a NULL user_id for one event type.
+func countAnonymousEvents(t *testing.T, eventType string) int {
+	t.Helper()
+	var n int
+	err := dbPool.QueryRow(context.Background(),
+		`SELECT count(*) FROM analytics_events WHERE user_id IS NULL AND event_type = $1`,
+		eventType).Scan(&n)
+	if err != nil {
+		t.Fatalf("countAnonymousEvents(%s): %v", eventType, err)
+	}
+	return n
+}
+
+// waitForAnonymousEventCount polls for the async insert like waitForEventCount.
+func waitForAnonymousEventCount(t *testing.T, eventType string, want int) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		n := countAnonymousEvents(t, eventType)
+		if n == want {
+			return
+		}
+		if n > want {
+			t.Fatalf("anonymous %s count = %d, exceeded expected %d", eventType, n, want)
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for %d anonymous %s events (have %d)", want, eventType, n)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func TestAnonymousEventWhitelistedRecordsNullUser(t *testing.T) {
+	resetDB(t)
+	rec := doJSON(t, "POST", "/api/v1/events", "", map[string]any{
+		"event_type": "landing_viewed",
+	})
+	if rec.Code != 202 {
+		t.Fatalf("anonymous POST /events = %d, want 202: %s", rec.Code, rec.Body.String())
+	}
+	waitForAnonymousEventCount(t, "landing_viewed", 1)
+
+	var tripID *string
+	if err := dbPool.QueryRow(context.Background(),
+		`SELECT trip_id::text FROM analytics_events
+		 WHERE user_id IS NULL AND event_type = 'landing_viewed'`).Scan(&tripID); err != nil {
+		t.Fatalf("row: %v", err)
+	}
+	if tripID != nil {
+		t.Fatalf("trip_id = %v, want NULL", *tripID)
+	}
+}
+
+func TestAnonymousEventNonWhitelistedRejected(t *testing.T) {
+	resetDB(t)
+	// A server-side type must not be spoofable anonymously.
+	rec := doJSON(t, "POST", "/api/v1/events", "", map[string]any{
+		"event_type": "user_registered",
+	})
+	if rec.Code != 400 {
+		t.Fatalf("anonymous POST /events (server type) = %d, want 400: %s", rec.Code, rec.Body.String())
+	}
+	if n := countAnonymousEvents(t, "user_registered"); n != 0 {
+		t.Fatalf("spoofed rows = %d, want 0", n)
+	}
+}
+
+func TestAnonymousEventTripIDAlwaysNulled(t *testing.T) {
+	resetDB(t)
+	owner, _ := createTestUser(t, "anon-trip-owner@example.com")
+	trip := createTestTrip(t, owner.ID, 1)
+
+	// Even a real trip id is dropped: ownership is unverifiable without a
+	// user, so anonymous clicks must never feed the attach-rate numerator.
+	rec := doJSON(t, "POST", "/api/v1/events", "", map[string]any{
+		"event_type": "booking_link_clicked",
+		"trip_id":    trip.ID.String(),
+		"metadata":   map[string]any{"provider": "Duffel", "evil_key": "nope"},
+	})
+	if rec.Code != 202 {
+		t.Fatalf("anonymous POST /events = %d, want 202: %s", rec.Code, rec.Body.String())
+	}
+	waitForAnonymousEventCount(t, "booking_link_clicked", 1)
+
+	var tripID *string
+	var meta map[string]any
+	if err := dbPool.QueryRow(context.Background(),
+		`SELECT trip_id::text, metadata FROM analytics_events
+		 WHERE user_id IS NULL AND event_type = 'booking_link_clicked'`).Scan(&tripID, &meta); err != nil {
+		t.Fatalf("row: %v", err)
+	}
+	if tripID != nil {
+		t.Fatalf("trip_id = %v, want NULL", *tripID)
+	}
+	// The #71 metadata whitelist applies to anonymous events too.
+	if meta["provider"] != "duffel" || len(meta) != 1 {
+		t.Fatalf("metadata = %v, want exactly {provider: duffel}", meta)
+	}
+
+	// And the attach-rate numerator must not have moved.
+	var n int
+	if err := dbPool.QueryRow(context.Background(),
+		`SELECT count(DISTINCT trip_id) FROM analytics_events
+		 WHERE event_type = 'booking_link_clicked' AND trip_id IS NOT NULL`).Scan(&n); err != nil {
+		t.Fatalf("attach count: %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("trips_with_booking_click = %d, want 0", n)
+	}
+}
+
+func TestEventsInvalidTokenIs401NotAnonymous(t *testing.T) {
+	resetDB(t)
+	// A presented-but-invalid token must be rejected by the authed route,
+	// never silently downgraded to an anonymous write.
+	rec := doJSON(t, "POST", "/api/v1/events", "not-a-real-session", map[string]any{
+		"event_type": "landing_viewed",
+	})
+	if rec.Code != 401 {
+		t.Fatalf("POST /events with bad token = %d, want 401: %s", rec.Code, rec.Body.String())
+	}
+	if n := countAnonymousEvents(t, "landing_viewed"); n != 0 {
+		t.Fatalf("anonymous rows after 401 = %d, want 0", n)
+	}
+}
+
+func TestAnonymousEventsAreStrictRateLimited(t *testing.T) {
+	resetDB(t)
+	ip := nextTestIP()
+	limited := false
+	// Strict tier is burst 3 at 5/min: within a burst from one IP, a 429
+	// must appear well before 10 requests.
+	for i := 0; i < 10; i++ {
+		rec := doJSONFromIP(t, "POST", "/api/v1/events", "", ip, map[string]any{
+			"event_type": "landing_viewed",
+		})
+		if rec.Code == 429 {
+			limited = true
+			break
+		}
+		if rec.Code != 202 {
+			t.Fatalf("request %d = %d, want 202 or 429: %s", i+1, rec.Code, rec.Body.String())
+		}
+	}
+	if !limited {
+		t.Fatalf("anonymous /events never rate limited within a 10-request burst")
+	}
+}
+
+func TestAuthedEventsNotOnStrictTier(t *testing.T) {
+	resetDB(t)
+	user, token := createTestUser(t, "authed-clicker@example.com")
+	ip := nextTestIP()
+	// Authed clicks stay on the general limiter only (burst 30): a burst of
+	// 10 from one IP — over the strict tier's burst — must all be accepted.
+	for i := 0; i < 10; i++ {
+		rec := doJSONFromIP(t, "POST", "/api/v1/events", token, ip, map[string]any{
+			"event_type": "booking_link_clicked",
+			"metadata":   map[string]any{"provider": "duffel"},
+		})
+		if rec.Code != 202 {
+			t.Fatalf("authed request %d = %d, want 202: %s", i+1, rec.Code, rec.Body.String())
+		}
+	}
+	waitForEventCount(t, user.ID, "booking_link_clicked", 10)
 }
 
 func TestClientEventMetadataSanitized(t *testing.T) {

--- a/src/packages/api/main.go
+++ b/src/packages/api/main.go
@@ -653,7 +653,17 @@ func buildRouter() *mux.Router {
 	api.Handle("/trips/{id}/items/order", authMiddleware(http.HandlerFunc(reorderItineraryItemsHandler))).Methods("PUT")
 	api.Handle("/trips/{id}/items/{itemId}", authMiddleware(http.HandlerFunc(patchItineraryItemHandler))).Methods("PATCH")
 	api.Handle("/trips/{id}/items/{itemId}", authMiddleware(http.HandlerFunc(deleteItineraryItemHandler))).Methods("DELETE")
-	api.Handle("/events", authMiddleware(http.HandlerFunc(recordClientEventHandler))).Methods("POST")
+	// Client analytics events. Two registrations, matched in order: a request
+	// presenting ANY Authorization header takes the authenticated route
+	// (token validated + attributed by authMiddleware — an invalid token is a
+	// 401, never a silent downgrade to anonymous); a request without
+	// credentials falls through to the anonymous route, which accepts only
+	// the tiny anonymousClientEventTypes whitelist, always drops trip_id, and
+	// sits behind the strict limiter to bound spam writes (it is an
+	// unauthenticated INSERT surface).
+	api.Handle("/events", authMiddleware(http.HandlerFunc(recordClientEventHandler))).
+		Methods("POST").HeadersRegexp("Authorization", ".+")
+	api.Handle("/events", strict(http.HandlerFunc(recordAnonymousClientEventHandler))).Methods("POST")
 	// Price alerts (specs/price-alerts): creation is strict-tier (each alert
 	// commits the server to recurring provider searches).
 	api.Handle("/alerts", strict(authMiddleware(http.HandlerFunc(createPriceAlertHandler)))).Methods("POST")

--- a/src/packages/flutter-app/lib/screens/landing_screen.dart
+++ b/src/packages/flutter-app/lib/screens/landing_screen.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
+import '../providers/analytics_provider.dart';
 import '../theme/app_colors.dart';
 import '../theme/spacing.dart';
 import '../widgets/brand_logo.dart';
@@ -12,8 +14,42 @@ import 'auth_screen.dart';
 /// showcases the core features, then funnels into the existing auth form:
 /// "Get started" opens sign-up, "Sign in" opens login. On success the AuthGate
 /// swaps this screen for the app automatically.
-class LandingScreen extends StatelessWidget {
+///
+/// Rendering this screen records the anonymous `landing_viewed` analytics
+/// event — the top of the activation funnel — at most once per app session
+/// (guarded by a static, so rebuilds and sign-out round trips don't
+/// re-record).
+class LandingScreen extends StatefulWidget {
   const LandingScreen({super.key});
+
+  /// True once this app session has recorded `landing_viewed`.
+  static bool _viewRecorded = false;
+
+  /// Resets the once-per-session guard so widget tests can assert on it.
+  @visibleForTesting
+  static void resetViewRecordedForTest() => _viewRecorded = false;
+
+  @override
+  State<LandingScreen> createState() => _LandingScreenState();
+}
+
+class _LandingScreenState extends State<LandingScreen> {
+  @override
+  void initState() {
+    super.initState();
+    if (!LandingScreen._viewRecorded) {
+      LandingScreen._viewRecorded = true;
+      try {
+        // Fire-and-forget; listen: false is safe in initState. A widget tree
+        // without a ProviderScope must never break the landing page.
+        ProviderScope.containerOf(context, listen: false)
+            .read(analyticsApiServiceProvider)
+            .recordLandingViewed();
+      } catch (_) {
+        // Tracking must never affect the visitor's experience.
+      }
+    }
+  }
 
   static void _openAuth(BuildContext context, {required bool isLogin}) {
     Navigator.of(context).push(

--- a/src/packages/flutter-app/lib/services/analytics_api_service.dart
+++ b/src/packages/flutter-app/lib/services/analytics_api_service.dart
@@ -1,39 +1,69 @@
 import 'dart:convert';
 import 'api_client.dart';
 
-/// First-party analytics: records the one client-observed funnel moment
-/// (opening a booking link). Strictly fire-and-forget — failures are
-/// swallowed, tracking must never slow down or break the experience.
+/// First-party analytics: records the client-observed funnel moments (the
+/// landing page rendering, opening a booking link). Strictly fire-and-forget —
+/// failures are swallowed, tracking must never slow down or break the
+/// experience.
 class AnalyticsApiService {
   final ApiClient apiClient;
 
   AnalyticsApiService(this.apiClient);
 
+  /// Events the API accepts without authentication (mirrors the server's
+  /// anonymousClientEventTypes whitelist). Anything else is silently dropped
+  /// when there is no session token.
+  static const Set<String> _anonymousEventTypes = {
+    'landing_viewed',
+    'booking_link_clicked',
+  };
+
+  /// The attach-rate numerator: a booking handoff link was opened. Sent
+  /// anonymously when signed out (the server drops trip_id for anonymous
+  /// events — ownership can't be verified).
   Future<void> recordBookingLinkClicked({
     String? tripId,
     String? todoKey,
     String? provider,
     String? surface,
     String? kind,
+  }) {
+    return _record(
+      'booking_link_clicked',
+      tripId: tripId,
+      metadata: {
+        if (todoKey != null) 'todo_key': todoKey,
+        if (provider != null) 'provider': provider,
+        if (surface != null) 'surface': surface,
+        if (kind != null) 'kind': kind,
+      },
+    );
+  }
+
+  /// Top of the funnel: a signed-out visitor rendered the landing page.
+  /// Call sites guard this to once per app session.
+  Future<void> recordLandingViewed() => _record('landing_viewed');
+
+  Future<void> _record(
+    String eventType, {
+    String? tripId,
+    Map<String, String>? metadata,
   }) async {
     final token = apiClient.authToken;
-    if (token == null) return; // anonymous sessions are untracked
+    if (token == null && !_anonymousEventTypes.contains(eventType)) {
+      return; // this event is untracked for anonymous sessions
+    }
     try {
       await apiClient.httpClient.post(
         Uri.parse('${apiClient.baseUrl}/events'),
         headers: {
           'Content-Type': 'application/json',
-          'Authorization': 'Bearer $token',
+          if (token != null) 'Authorization': 'Bearer $token',
         },
         body: jsonEncode({
-          'event_type': 'booking_link_clicked',
+          'event_type': eventType,
           if (tripId != null) 'trip_id': tripId,
-          'metadata': {
-            if (todoKey != null) 'todo_key': todoKey,
-            if (provider != null) 'provider': provider,
-            if (surface != null) 'surface': surface,
-            if (kind != null) 'kind': kind,
-          },
+          if (metadata != null && metadata.isNotEmpty) 'metadata': metadata,
         }),
       );
     } catch (_) {

--- a/src/packages/flutter-app/lib/utils/tracked_launch.dart
+++ b/src/packages/flutter-app/lib/utils/tracked_launch.dart
@@ -13,6 +13,10 @@ import '../providers/analytics_provider.dart';
 /// Returns whether the launch succeeded, so call sites can keep their own
 /// "Could not open link" handling.
 ///
+/// Signed-out clicks are recorded too: `booking_link_clicked` is on the API's
+/// anonymous whitelist, so the service sends it without an Authorization
+/// header (the server stores it with a NULL user id and drops any trip_id).
+///
 /// [provider] is who the user is being handed to (duffel, ferryhopper,
 /// ticketmaster, booking.com, airbnb, …) and [surface] is which UI element the
 /// click came from (booking_checklist, flight_card, chat, …). Keep both short:

--- a/src/packages/flutter-app/test/analytics_anonymous_test.dart
+++ b/src/packages/flutter-app/test/analytics_anonymous_test.dart
@@ -1,0 +1,77 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+import 'package:travel_route_planner/services/analytics_api_service.dart';
+import 'package:travel_route_planner/services/api_client.dart';
+
+/// The anonymous top-of-funnel contract: whitelisted events POST without an
+/// Authorization header when signed out instead of being dropped, and signed-in
+/// events still carry the bearer token.
+void main() {
+  late List<http.Request> requests;
+  late ApiClient apiClient;
+  late AnalyticsApiService service;
+
+  setUp(() {
+    requests = [];
+    apiClient = ApiClient(
+      baseUrl: 'http://api.test/api/v1',
+      client: MockClient((request) async {
+        requests.add(request);
+        return http.Response('', 202);
+      }),
+    );
+    service = AnalyticsApiService(apiClient);
+  });
+
+  test('signed-out booking click is sent anonymously (no Authorization)',
+      () async {
+    apiClient.authToken = null;
+    await service.recordBookingLinkClicked(
+      tripId: 'trip-1',
+      provider: 'duffel',
+      surface: 'flight_card',
+    );
+
+    expect(requests, hasLength(1));
+    final req = requests.single;
+    expect(req.url.path, '/api/v1/events');
+    expect(req.headers.containsKey('Authorization'), isFalse,
+        reason: 'anonymous events must not carry a credential');
+    final body = jsonDecode(req.body) as Map<String, dynamic>;
+    expect(body['event_type'], 'booking_link_clicked');
+    expect((body['metadata'] as Map)['provider'], 'duffel');
+  });
+
+  test('signed-out landing view is sent anonymously', () async {
+    apiClient.authToken = null;
+    await service.recordLandingViewed();
+
+    expect(requests, hasLength(1));
+    final req = requests.single;
+    expect(req.headers.containsKey('Authorization'), isFalse);
+    final body = jsonDecode(req.body) as Map<String, dynamic>;
+    expect(body['event_type'], 'landing_viewed');
+    expect(body.containsKey('trip_id'), isFalse);
+  });
+
+  test('signed-in booking click still carries the bearer token', () async {
+    apiClient.authToken = 'session-token';
+    await service.recordBookingLinkClicked(provider: 'duffel');
+
+    expect(requests, hasLength(1));
+    expect(requests.single.headers['Authorization'], 'Bearer session-token');
+  });
+
+  test('a transport failure is swallowed, never thrown', () async {
+    final failing = AnalyticsApiService(ApiClient(
+      baseUrl: 'http://api.test/api/v1',
+      client: MockClient((_) async => throw Exception('network down')),
+    ));
+    await failing.recordLandingViewed(); // must not throw
+    await failing.recordBookingLinkClicked(provider: 'duffel');
+  });
+}

--- a/src/packages/flutter-app/test/landing_screen_analytics_test.dart
+++ b/src/packages/flutter-app/test/landing_screen_analytics_test.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:travel_route_planner/providers/analytics_provider.dart';
+import 'package:travel_route_planner/screens/landing_screen.dart';
+import 'package:travel_route_planner/services/analytics_api_service.dart';
+import 'package:travel_route_planner/services/api_client.dart';
+
+/// Counts landing-view records instead of hitting the network.
+class _CountingAnalytics implements AnalyticsApiService {
+  int landingViews = 0;
+
+  @override
+  ApiClient get apiClient => throw UnimplementedError();
+
+  @override
+  Future<void> recordLandingViewed() {
+    landingViews++;
+    return Future.value();
+  }
+
+  @override
+  Future<void> recordBookingLinkClicked({
+    String? tripId,
+    String? todoKey,
+    String? provider,
+    String? surface,
+    String? kind,
+  }) =>
+      Future.value();
+}
+
+Widget _harness(_CountingAnalytics analytics) {
+  return ProviderScope(
+    overrides: [analyticsApiServiceProvider.overrideWithValue(analytics)],
+    child: const MaterialApp(home: LandingScreen()),
+  );
+}
+
+void main() {
+  setUp(LandingScreen.resetViewRecordedForTest);
+
+  testWidgets('landing screen records landing_viewed once per app session',
+      (tester) async {
+    final analytics = _CountingAnalytics();
+    await tester.pumpWidget(_harness(analytics));
+    expect(analytics.landingViews, 1);
+
+    // Rebuilds don't re-record.
+    await tester.pumpWidget(_harness(analytics));
+    expect(analytics.landingViews, 1);
+
+    // Nor does a fresh LandingScreen instance later in the same session
+    // (e.g. returning to the landing page after signing out).
+    await tester.pumpWidget(const SizedBox());
+    await tester.pumpWidget(_harness(analytics));
+    expect(analytics.landingViews, 1);
+  });
+
+  testWidgets('an analytics failure never breaks the landing page',
+      (tester) async {
+    final analytics = _ThrowingAnalytics();
+    await tester.pumpWidget(ProviderScope(
+      overrides: [analyticsApiServiceProvider.overrideWithValue(analytics)],
+      child: const MaterialApp(home: LandingScreen()),
+    ));
+    expect(find.text('Plan less. Travel more.'), findsOneWidget);
+  });
+}
+
+class _ThrowingAnalytics implements AnalyticsApiService {
+  @override
+  ApiClient get apiClient => throw UnimplementedError();
+
+  @override
+  Future<void> recordLandingViewed() => throw Exception('analytics down');
+
+  @override
+  Future<void> recordBookingLinkClicked({
+    String? tripId,
+    String? todoKey,
+    String? provider,
+    String? surface,
+    String? kind,
+  }) =>
+      Future.value();
+}

--- a/src/packages/flutter-app/test/tracked_launch_test.dart
+++ b/src/packages/flutter-app/test/tracked_launch_test.dart
@@ -39,6 +39,9 @@ class _RecordingAnalytics implements AnalyticsApiService {
   ApiClient get apiClient => throw UnimplementedError();
 
   @override
+  Future<void> recordLandingViewed() => Future.value();
+
+  @override
   Future<void> recordBookingLinkClicked({
     String? tripId,
     String? todoKey,


### PR DESCRIPTION
## Summary

The activation funnel's top was invisible: `POST /api/v1/events` sat behind `authMiddleware` and the Flutter `AnalyticsApiService` bailed on a null token, so everything before signup went unrecorded. This PR opens a **tightly bounded** anonymous lane on the events endpoint, building on #71's hardening.

### Anonymous whitelist (final)

| Event | Rationale |
|---|---|
| `landing_viewed` | top of funnel — landing views over signups is the first conversion number; client-guarded to once per app session |
| `booking_link_clicked` | signed-out booking handoffs still count toward total clicks |

**No `plan_started_anonymous`** — studied the screens first: the Flutter app has no signed-out planning entry point (AuthGate routes signed-out visitors to the landing page only), and anonymous direct `/plan` API calls are already recorded server-side as `plan_session_started` with a NULL user id (the existing `plan_sessions_anonymous` metric).

### Route/middleware design

Two mux registrations on `POST /events`, matched in order:

- `HeadersRegexp("Authorization", ".+")` → `authMiddleware(recordClientEventHandler)` — **authed path byte-for-byte unchanged**; any presented token is validated and attributed, an invalid token is a **401, never a silent downgrade to anonymous**.
- fallback (no credential) → `strict(recordAnonymousClientEventHandler)`.

### Spam bounding (the core requirement)

- Anonymous route sits behind the **strict per-IP limiter** (5/min, burst 3 — same tier as `/plan` and credential routes).
- Off-whitelist anonymous `event_type` → **400**; server-side types cannot be spoofed.
- **`trip_id` always dropped** for anonymous events (ownership unverifiable; attach-rate numerator counts DISTINCT trip_id).
- Metadata passes the same #71 closed key set (`provider`/`surface`/`kind`/`todo_key`), 64-char values, provider lowercased, 2 KB cap.
- Written via `recordEventOpt(nil, …)` — never `recordEvent(uuid.Nil, …)`.

### Metrics impact

- New `landing_views` on `GET /admin/metrics` (from the existing grouped count; documented as directional, not audited).
- Verified all admin queries are NULL-safe: MAU/engagement filter `user_id IS NOT NULL`; activation joins on `user_id` (NULL never joins); `PlanSessionTotals` already splits anonymous.
- **Documented decision:** anonymous booking clicks count in `booking_clicks` / `clicks_by_provider` but can never move `trips_with_booking_click` / `attach_rate` — their `trip_id` is NULL by construction. Attach rate stays a signed-in, per-trip metric.

### Flutter

- `AnalyticsApiService`: whitelisted events POST without `Authorization` when signed out instead of bailing; everything else still requires a token; failures still swallowed.
- Landing screen records `landing_viewed` once per app session (static guard — rebuilds and sign-out round trips don't re-record; guard resettable for tests).
- `trackedLaunchUrl` booking clicks now record anonymously for signed-out users (no call-site changes needed — the drop was in the service).

### Spec

`specs/instrumentation-events/spec.md` amended: anonymous whitelist + rationale, spam-bounding measures, optional-auth API contract, anonymous-rows metric semantics, narrowed Out of Scope.

## Testing

- `make api-fmt && make api-vet` clean; full Go suite green.
- Integration (own DB `travel_test_w8d`): anonymous whitelisted → 202 + NULL `user_id` row; anonymous off-whitelist → 400 + no row; anonymous with a real `trip_id` → NULL `trip_id` + sanitized metadata + attach numerator unmoved; invalid token → 401 + no anonymous row; strict limiter 429s an anonymous burst from one IP; authed burst of 10 from one IP all 202 (not on the strict tier); all pre-existing authed-path tests unchanged and green.
- Flutter: `flutter pub get`, all 69 tests pass (4 new service tests + 2 new landing-screen tests), `flutter analyze --no-fatal-infos --fatal-warnings` exit 0 at the 12 known pre-existing infos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)