### PR TITLE
feat(flutter): offline trip cache — read-only trips without a network

### DIFF
--- a/specs/offline-trips/plan.md
+++ b/specs/offline-trips/plan.md
@@ -1,0 +1,124 @@
+# Plan: Offline Trip Cache
+
+> Flutter-only. No Go API changes, no schema changes, no new endpoints.
+
+## Technical Approach
+
+Write-through cache at the service/provider seam, read on network failure
+only. On every successful `listTrips()` / `getTrip()` the payload is written
+(fire-and-forget, `unawaited`) to `shared_preferences` under user-scoped keys
+— the same storage and keying convention as `recent_trip_provider.dart`. When
+a fetch throws a **network-level** error, the caller reads the cache and, on
+a hit, renders it read-only with an offline banner.
+
+Key decisions:
+
+- **shared_preferences, not a DB (v1).** Matches the existing on-device
+  storage pattern; zero new dependencies; web backing is localStorage. Trip
+  JSON is small (tens of KB); the 10-trip LRU cap bounds total size. The size
+  trade-off is documented in the spec; a drift/sqflite upgrade slots in
+  behind the same `TripCache` API later.
+- **Network-error classification, not connectivity plugins.** `package:http`
+  ≥1.0 wraps all socket/IO failures in `http.ClientException`; timeouts are
+  `TimeoutException`. HTTP non-200s in `TripsApiService` are thrown as plain
+  `Exception('… (status)')` and therefore never classify as network errors —
+  so 403/404/500 can never fall back to cache. Classifier:
+  `TripCache.isNetworkError(e)` = `ClientException || TimeoutException ||
+  toString contains 'SocketException'` (belt-and-braces for raw dart:io
+  errors; `dart:io` itself is not importable on web).
+- **Online path untouched.** The only additions on success are (a) an
+  `unawaited` cache write and (b) clearing the `offlineSince` marker. No new
+  awaits before state updates, no changes to `_load(silent:)`, `_refresh()`
+  coalescing, `tripUpdateCount`, or any chat-panel behavior (PRs #51/#53
+  invariants). Cache fallback happens only inside existing `catch` blocks,
+  and only on the **loud** path (`!quiet`) — silent-refresh failures keep
+  their "stay quiet, keep stale trip" behavior.
+
+## Flutter Changes
+
+`src/packages/flutter-app/lib/`:
+
+- **`services/trip_cache.dart`** (new) — `TripCache(userId)`:
+  - Keys: `trip_cache.<userId>.list`, `trip_cache.<userId>.trip.<tripId>`,
+    `trip_cache.<userId>.index` (MRU list of trip ids for eviction).
+  - `writeList / readList` and `writeTrip / readTrip`; payloads are
+    `{saved_at: ISO-8601, …Trip.toJson()}`; reads return a
+    `(value, savedAt)` record or null on any parse error.
+  - `writeTrip` bumps the id to the front of the MRU index and evicts beyond
+    `maxCachedTrips = 10` (removes the evicted trips' keys).
+  - `removeTrip(id)` — called on trip deletion; also drops the trip from the
+    cached list payload.
+  - All writes swallow exceptions (best-effort); `userId == null` no-ops.
+  - `static clearForUser(userId)` — removes every `trip_cache.<userId>.` key.
+  - `static isNetworkError(Object)` — the classifier above.
+- **`providers/trip_cache_provider.dart`** (new) — provides `TripCache`
+  scoped to `authProvider`'s user id (same pattern as `recentTripProvider`).
+- **`providers/trips_provider.dart`** — `TripsState` gains
+  `DateTime? offlineSince` (null = live data). `TripsNotifier` takes the
+  cache; `loadTrips()` success → `offlineSince: null` + unawaited
+  `writeList`; failure → if network error and cache hit, serve cached trips
+  with `offlineSince`; otherwise the existing error path, verbatim.
+  `deleteTrip()` additionally calls unawaited `removeTrip(id)`.
+- **`widgets/offline_banner.dart`** (new) — "Offline — showing saved copy
+  from <relative time>" + Retry button; exposes a testable
+  `relativeTime(DateTime, {DateTime? now})` helper.
+- **`screens/trips_list_screen.dart`** — when `state.offlineSince != null`,
+  pin `OfflineBanner` above the body (Retry = `loadTrips()`).
+- **`screens/trip_detail_screen.dart`** (surgical) —
+  - New field `DateTime? _offlineSince`; getter `_isOffline`.
+  - `_load()`: success block clears `_offlineSince` and unawaited-writes the
+    trip to cache (before the existing follow-ups; `recentTripProvider`
+    recording unchanged). Catch block: when `!quiet` and
+    `isNetworkError(e)`, read cache; on hit set `_trip`/`_bookingTodos` from
+    the copy + `_offlineSince`, and skip the network follow-ups
+    (todo sync / travel times / prefs) — they already only run on live
+    success. On miss fall through to the existing error handling, verbatim.
+  - Banner: wrap the existing `refreshable` in a Column with `OfflineBanner`
+    (Retry = loud `_load()`) when offline-serving.
+  - Mutations: hide owner appbar actions (share/delete) while offline;
+    disable header affordances (rename, dates, status, Refine with AI) and
+    "Add place"/"Add booking"; a one-line `_guardOffline()` (snackbar +
+    early-return) at the top of every mutation method — `_openRefine`,
+    `_editTitle`, `_editDates`, `_patch`, `_delete`, `_addPlace`,
+    `_addBooking`, `_setBooked`, `_deleteTodo`, `_addStay`, `_deleteStay`,
+    `_addSegment`, `_deleteSegment`, `_editItem`, `_deleteItem`,
+    `_reorderSection` — covers deep entry points (item menus, todo cards,
+    per-day/city refine icons) without touching their widget subtrees.
+- **`providers/auth_provider.dart`** — `signOutLocally()` (the shared funnel
+  for logout, sign-out-everywhere, and account deletion) captures the user id
+  before clearing state and calls `TripCache.clearForUser(userId)`.
+
+## Contract Parity
+
+No wire contract changes; the cache round-trips the existing
+`Trip.toJson()`/`Trip.fromJson()` pair (json_serializable, already in parity
+with the Go API).
+
+## Cross-cutting
+
+- No new env vars, no gateway changes, no new packages
+  (`shared_preferences` is already a dependency).
+- Chat invariants (PRs #51/#53): untouched — no changes to
+  `plan_provider.dart`, `chat_panel.dart`, `trip_refine_panel.dart`;
+  `_refresh()`/`_load(silent:)` logic byte-identical; the refine panel can
+  never open while offline-serving (`_openRefine` guard) so its listeners
+  never observe cached state.
+
+## Verification
+
+- `flutter analyze` clean (no new infos); `make flutter-test` green.
+- New tests:
+  - `test/trip_cache_test.dart` — round-trip, savedAt, LRU eviction at 10,
+    per-user isolation, corrupt-entry miss, `clearForUser`, classifier.
+  - `test/trips_provider_offline_test.dart` — network error → cache serve
+    with `offlineSince`; HTTP-status error → no fallback; success clears
+    offline state + writes through; delete removes cache entry.
+  - `test/trip_detail_offline_test.dart` — widget: banner text, disabled
+    mutation affordances, no share/delete actions, retry exits offline mode;
+    403 shows error page not cache.
+  - `test/trips_list_offline_test.dart` — widget: banner over cached list.
+- Existing `trip_detail_silent_refresh_test.dart` must pass unmodified
+  (proves the silent path didn't change).
+- Manual airplane-mode walk-through (requires a device/browser; listed in the
+  PR): load list + a trip online → go offline → relaunch → verify banner,
+  read-only, retry; sign out offline → cache gone after re-login.

--- a/specs/offline-trips/spec.md
+++ b/specs/offline-trips/spec.md
@@ -1,0 +1,127 @@
+# Spec: Offline Trip Cache
+
+## Context
+
+A traveler mid-trip is exactly the user most likely to open the app — and
+exactly the user most likely to have no network (airplane mode, roaming off,
+subway, island dead zone). Today the trips list and trip detail screens show a
+spinner and then an error. Everything the traveler needs (the itinerary, the
+day plan, booking references) was already downloaded on a previous visit; we
+just threw it away. This feature keeps a local, read-only copy of
+previously-loaded trips so the app degrades gracefully to "here's your saved
+plan" instead of a dead end.
+
+## User Stories
+
+- As a **traveler with no connectivity**, I want to open the app and still see
+  my trips list and full trip details (itinerary, bookings, to-dos), so my
+  plan is usable exactly when I'm on the move.
+- As a **traveler viewing a saved copy**, I want an unmistakable indicator of
+  when that copy was saved, so I know how stale it might be.
+- As a **traveler back online**, I want one tap to retry the live fetch, and
+  the offline state to disappear automatically once a live load succeeds.
+- As a **privacy-conscious user on a shared device**, I want my cached trips
+  removed when I sign out or delete my account, so the next user can't read
+  my plans.
+
+## Acceptance Criteria
+
+- [ ] After viewing the trips list online, disabling the network and reopening
+  the list shows the same trips with an offline banner instead of an error.
+- [ ] After viewing a trip's detail online, disabling the network and
+  reopening that trip shows the full saved detail — itinerary items (grouped
+  as usual), bookings, booking to-dos — with an offline banner.
+- [ ] The banner reads "Offline — showing saved copy from <relative time>"
+  (e.g. "5 minutes ago", "2 days ago") and offers a Retry action that
+  re-attempts the live fetch.
+- [ ] While offline-serving, every mutation affordance is disabled or hidden:
+  rename, edit dates, change status, Refine with AI (all entry points: trip,
+  city, day), add place, edit/reorder/delete itinerary items, add/delete
+  bookings and stays/transport, toggle booking to-dos, share, delete trip.
+  Any deep entry point that can't be visually disabled shows a "you're
+  offline" notice instead of firing a request.
+- [ ] Serving from cache happens **only** for network-level failures
+  (no connection, timeout). An HTTP error response — 403, 404, 500 — shows
+  the normal error state and never falls back to the cache (a revoked or
+  deleted trip must not resurrect from a stale copy).
+- [ ] A trip never loaded before is not available offline; the normal error +
+  Retry state shows.
+- [ ] When a live fetch later succeeds, the banner disappears and the screen
+  behaves exactly as before this feature existed.
+- [ ] At most the last 10 viewed trip details are kept; opening an 11th evicts
+  the least-recently-viewed one.
+- [ ] Signing out (including "sign out everywhere") and deleting the account
+  remove all cached trip data for that user from the device.
+- [ ] Two users on the same device never see each other's cached trips.
+
+## Not Available Offline (explicit)
+
+These remain online-only; they must fail gracefully (disabled affordance,
+quiet empty section, or a clear error) rather than half-work:
+
+- Chat / AI refine (all refine panels and seeds).
+- Route optimization and travel-time computation.
+- Flight, event, ferry, local-recommendation and guide lookups (their embedded
+  sections simply don't render, as they already do on lookup failure).
+- All mutations (anything that would POST/PATCH/PUT/DELETE).
+- Shared-with-me trips and the public shared-trip view (not cached in v1).
+- Pull-to-refresh still works as "try live again" — it either succeeds and
+  exits offline mode or leaves the saved copy in place.
+
+## API Surface
+
+None. This feature is entirely client-side; no new endpoints and no changes
+to existing request/response contracts.
+
+## Data Model
+
+Client-side cache only (no server entities):
+
+- **Cached trip list** — the last successfully fetched trips list for a user,
+  plus the timestamp it was saved.
+- **Cached trip detail** — the last successfully fetched full detail of one
+  trip (itinerary items, accommodations, segments, booking to-dos), plus the
+  timestamp it was saved. At most 10 per user, evicted least-recently-viewed.
+- All cached entries are keyed by the signed-in user's id; anonymous sessions
+  cache nothing (trips require sign-in).
+
+## UI Behavior
+
+- **Trips list:** loads live as today. On a network-level failure with a
+  cached copy present, the list renders from the copy with the offline banner
+  pinned above it; Retry re-runs the live load. Without a cached copy the
+  existing "Could not load trips" empty state shows.
+- **Trip detail:** loads live as today. On a network-level failure of the
+  initial (loud) load with a cached copy present, the saved detail renders
+  with the banner above the scroll area and mutations disabled. Silent
+  refreshes keep their existing behavior (failures keep showing the current
+  trip quietly). A later successful load clears the banner and re-enables
+  everything.
+- **Staleness:** relative time ("just now", "N minutes/hours/days ago"),
+  computed from the saved-at timestamp at render time.
+
+## Edge Cases & Error States
+
+- **HTTP 4xx/5xx:** never served from cache (see acceptance criteria).
+- **Corrupt/unreadable cache entry:** treated as a miss; the normal error
+  state shows. Reads never crash the app.
+- **Cache write failure** (storage full, platform quirk): silently ignored —
+  caching is best-effort and must never affect the online path.
+- **Deleted trip:** deleting a trip (online) also removes its cached detail
+  and removes it from the cached list, so offline mode can't reopen it.
+- **Large trips:** payloads are stored as JSON strings in on-device
+  preferences (web: localStorage). This bounds practical size (~5 MB origin
+  quota on web); the 10-trip cap plus single-list entry keeps usage well
+  under it for realistic trips. Revisit with a real database (drift/sqflite)
+  if trips grow media-heavy. This trade-off is accepted for v1.
+
+## Out of Scope
+
+- Offline **mutations** / write queueing / conflict resolution.
+- Caching shared-with-me trips, public share links, guides, local recs,
+  flights, events, ferries.
+- Proactive connectivity detection (no connectivity_plus); offline mode is
+  entered reactively when a fetch fails at the network level.
+- Background sync / prefetching trips never opened.
+- Images/map tiles offline (maps may render blank offline; the itinerary list
+  is the offline surface).

--- a/specs/offline-trips/tasks.md
+++ b/specs/offline-trips/tasks.md
@@ -1,0 +1,20 @@
+# Tasks: Offline Trip Cache
+
+## PR 1 — Flutter (`wave8/offline-trips`)
+- [x] Spec + plan
+- [x] `services/trip_cache.dart` (user-scoped shared_preferences store, MRU
+  eviction at 10, network-error classifier, `clearForUser`)
+- [x] `providers/trip_cache_provider.dart` (auth-scoped)
+- [x] `trips_provider.dart` — write-through + offline fallback, `offlineSince`
+- [x] `trip_detail_screen.dart` — write-through + offline fallback (loud path
+  only), `_guardOffline()` on every mutation, disabled/hidden affordances
+- [x] `widgets/offline_banner.dart` (+ `relativeTime`) on list + detail
+- [x] `auth_provider.signOutLocally()` clears the cache (logout, logout-all,
+  account deletion)
+- [x] Tests: cache unit, provider offline paths, detail + list widget tests
+- [ ] Manual airplane-mode verification (Brian; steps in PR body)
+
+## Deferred (spec Out of Scope)
+- Offline mutations / write queueing; shared-with-me + public share caching;
+  connectivity_plus proactive detection; drift/sqflite storage upgrade;
+  offline map tiles.

--- a/src/packages/flutter-app/lib/providers/auth_provider.dart
+++ b/src/packages/flutter-app/lib/providers/auth_provider.dart
@@ -6,6 +6,7 @@ import '../models/user.dart';
 import '../services/api_client.dart';
 import '../services/auth_service.dart';
 import '../services/auth_storage.dart';
+import '../services/trip_cache.dart';
 import 'api_client_provider.dart';
 
 final authServiceProvider = Provider<AuthService>((ref) {
@@ -148,9 +149,13 @@ class AuthNotifier extends StateNotifier<AuthState> {
   /// Clears local auth state without calling the server — for flows where
   /// the session is already gone server-side (logout-all, account deletion).
   Future<void> signOutLocally() async {
+    final userId = state.user?.id;
     await _storage.clearToken();
     _apiClient.authToken = null;
     state = state.copyWith(clearUser: true, clearError: true);
+    // Privacy: drop the offline trip cache alongside the credentials so the
+    // next user of this device can't read the previous user's plans.
+    if (userId != null) await TripCache.clearForUser(userId);
   }
 
   /// Replaces the in-memory user (e.g. after a profile edit).

--- a/src/packages/flutter-app/lib/providers/trip_cache_provider.dart
+++ b/src/packages/flutter-app/lib/providers/trip_cache_provider.dart
@@ -1,0 +1,11 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../services/trip_cache.dart';
+import 'auth_provider.dart';
+
+/// Per-user offline trip cache. Rebuilds on sign-in/out so each user only
+/// ever reads their own cached trips (same pattern as [recentTripProvider]).
+final tripCacheProvider = Provider<TripCache>((ref) {
+  final userId = ref.watch(authProvider.select((s) => s.user?.id));
+  return TripCache(userId);
+});

--- a/src/packages/flutter-app/lib/providers/trips_provider.dart
+++ b/src/packages/flutter-app/lib/providers/trips_provider.dart
@@ -1,7 +1,11 @@
+import 'dart:async';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../models/trip.dart';
+import '../services/trip_cache.dart';
 import '../services/trips_api_service.dart';
 import 'api_client_provider.dart';
+import 'trip_cache_provider.dart';
 
 final tripsApiServiceProvider = Provider<TripsApiService>((ref) {
   return TripsApiService(ref.watch(apiClientProvider));
@@ -12,13 +16,25 @@ class TripsState {
   final bool loading;
   final String? error;
 
-  const TripsState({this.trips = const [], this.loading = false, this.error});
+  /// When non-null, [trips] is a cached copy served because the network was
+  /// unreachable; the value is when that copy was saved. Null = live data.
+  final DateTime? offlineSince;
 
-  TripsState copyWith({List<Trip>? trips, bool? loading, Object? error = _sentinel}) {
+  const TripsState(
+      {this.trips = const [], this.loading = false, this.error, this.offlineSince});
+
+  TripsState copyWith(
+      {List<Trip>? trips,
+      bool? loading,
+      Object? error = _sentinel,
+      Object? offlineSince = _sentinel}) {
     return TripsState(
       trips: trips ?? this.trips,
       loading: loading ?? this.loading,
       error: error == _sentinel ? this.error : error as String?,
+      offlineSince: offlineSince == _sentinel
+          ? this.offlineSince
+          : offlineSince as DateTime?,
     );
   }
 }
@@ -27,15 +43,32 @@ const _sentinel = Object();
 
 class TripsNotifier extends StateNotifier<TripsState> {
   final TripsApiService _service;
+  final TripCache _cache;
 
-  TripsNotifier(this._service) : super(const TripsState());
+  TripsNotifier(this._service, this._cache) : super(const TripsState());
 
   Future<void> loadTrips() async {
     state = state.copyWith(loading: true, error: null);
     try {
       final trips = await _service.listTrips();
-      state = state.copyWith(trips: trips, loading: false);
+      state = state.copyWith(trips: trips, loading: false, offlineSince: null);
+      // Write-through for offline viewing; fire-and-forget (never throws) so
+      // the online path is unaffected.
+      unawaited(_cache.writeList(trips));
     } catch (e) {
+      // Only a network-level failure may fall back to the cached copy; an
+      // HTTP error (401/403/500...) keeps the normal error path.
+      if (TripCache.isNetworkError(e)) {
+        final cached = await _cache.readList();
+        if (cached != null) {
+          state = state.copyWith(
+            trips: cached.trips,
+            loading: false,
+            offlineSince: cached.savedAt,
+          );
+          return;
+        }
+      }
       state = state.copyWith(loading: false, error: e.toString());
     }
   }
@@ -43,9 +76,11 @@ class TripsNotifier extends StateNotifier<TripsState> {
   Future<void> deleteTrip(String id) async {
     await _service.deleteTrip(id);
     state = state.copyWith(trips: state.trips.where((t) => t.id != id).toList());
+    unawaited(_cache.removeTrip(id));
   }
 }
 
 final tripsProvider = StateNotifierProvider<TripsNotifier, TripsState>((ref) {
-  return TripsNotifier(ref.watch(tripsApiServiceProvider));
+  return TripsNotifier(
+      ref.watch(tripsApiServiceProvider), ref.watch(tripCacheProvider));
 });

--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -24,6 +26,8 @@ import '../providers/plan_provider.dart';
 import '../providers/events_provider.dart';
 import '../providers/ferries_provider.dart';
 import '../providers/local_provider.dart';
+import '../providers/trip_cache_provider.dart';
+import '../services/trip_cache.dart';
 import '../theme/app_colors.dart';
 import '../theme/spacing.dart';
 import '../utils/tracked_launch.dart';
@@ -34,6 +38,7 @@ import '../widgets/bookings_section.dart';
 import '../widgets/empty_state.dart';
 import '../widgets/event_card.dart';
 import '../widgets/local_rec_card.dart';
+import '../widgets/offline_banner.dart';
 import '../widgets/source_links_card.dart';
 import '../widgets/status_pill.dart';
 import '../widgets/trip_map.dart';
@@ -57,6 +62,10 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
   Trip? _trip;
   bool _loading = true;
   String? _error;
+  // Non-null while _trip is a cached copy served because the network was
+  // unreachable (value = when the copy was saved). The screen is read-only
+  // in this mode; a successful live load clears it.
+  DateTime? _offlineSince;
   // In-page AI refinement panel (side dock on wide layouts, bottom sheet on
   // narrow ones); null target while closed.
   bool _panelOpen = false;
@@ -124,9 +133,13 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
       final trip =
           await ref.read(tripsApiServiceProvider).getTrip(widget.tripId);
       if (mounted) {
+        // Write-through for offline viewing; fire-and-forget (never throws)
+        // so the online path is unaffected.
+        unawaited(ref.read(tripCacheProvider).writeTrip(trip));
         setState(() {
           _trip = trip;
           _bookingTodos = trip.bookingTodos ?? [];
+          _offlineSince = null; // live data — leave offline mode if we were in it
         });
         // Remember this as the most recently viewed trip (home screen tile).
         ref.read(recentTripProvider.notifier).record(
@@ -145,12 +158,40 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
         await _computeTravelTimes(trip);
       }
     } catch (e) {
-      // Quiet failures keep showing the stale trip; the next refresh or a
-      // loud load will surface a persistent problem.
+      // Loud path + network-level failure: fall back to the cached copy and
+      // render it read-only. HTTP errors (403/404/500) never reach here —
+      // isNetworkError excludes them — so a revoked or deleted trip can't
+      // resurrect from a stale copy. Quiet failures keep their existing
+      // behavior: the stale trip stays; the next refresh or a loud load will
+      // surface a persistent problem.
+      if (mounted && !quiet && TripCache.isNetworkError(e)) {
+        final cached = await ref.read(tripCacheProvider).readTrip(widget.tripId);
+        if (cached != null && mounted) {
+          setState(() {
+            _trip = cached.trip;
+            _bookingTodos = cached.trip.bookingTodos ?? [];
+            _offlineSince = cached.savedAt;
+            _error = null;
+          });
+          return; // finally still clears _loading
+        }
+      }
       if (mounted && !quiet) setState(() => _error = e.toString());
     } finally {
       if (mounted && !quiet) setState(() => _loading = false);
     }
+  }
+
+  bool get _isOffline => _offlineSince != null;
+
+  /// Belt-and-braces offline gate at the top of every mutation method. The
+  /// primary affordances are also visually disabled/hidden while offline;
+  /// this covers deep entry points (item menus, todo cards, per-day refine
+  /// icons) without touching their widget subtrees.
+  bool _guardOffline() {
+    if (!_isOffline) return false;
+    _showSnack("You're offline — reconnect to make changes.");
+    return true;
   }
 
   bool _refreshQueued = false;
@@ -415,6 +456,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
   }
 
   Future<void> _setBooked(BookingTodo todo, bool booked) async {
+    if (_guardOffline()) return;
     final prev = _bookingTodos;
     setState(() {
       _bookingTodos = [
@@ -433,6 +475,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
   }
 
   Future<void> _deleteTodo(BookingTodo todo) async {
+    if (_guardOffline()) return;
     try {
       await ref
           .read(bookingTodosApiServiceProvider)
@@ -447,6 +490,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
   }
 
   Future<void> _addBooking() async {
+    if (_guardOffline()) return;
     final added = await showDialog<bool>(
       context: context,
       builder: (_) => _AddBookingTodoDialog(tripId: widget.tripId),
@@ -455,6 +499,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
   }
 
   Future<void> _addPlace() async {
+    if (_guardOffline()) return;
     final trip = _trip;
     if (trip == null) return;
     final added = await showDialog<bool>(
@@ -469,6 +514,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
       String? startDate,
       String? endDate,
       String? status}) async {
+    if (_guardOffline()) return;
     try {
       final updated = await ref.read(tripsApiServiceProvider).patchTrip(
             widget.tripId,
@@ -485,6 +531,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
   }
 
   Future<void> _editTitle() async {
+    if (_guardOffline()) return;
     final controller = TextEditingController(text: _trip?.title ?? '');
     final result = await showDialog<String>(
       context: context,
@@ -508,6 +555,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
   }
 
   Future<void> _editDates() async {
+    if (_guardOffline()) return;
     final now = DateTime.now();
     final range = await showDateRangePicker(
       context: context,
@@ -523,6 +571,9 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
   /// with the section's current contents. The session is bound to this trip
   /// server-side, so changes patch the trip in place (no new versions).
   void _openRefine(Trip trip, RefineTarget target) {
+    // Chat/refine needs the network; also keeps the refine panel from ever
+    // observing a cached (read-only) trip.
+    if (_guardOffline()) return;
     // AI refine is owner-only (keeps the version lineage single-writer);
     // the buttons are hidden for editors, this is the belt-and-braces guard.
     if (!trip.isOwner) {
@@ -618,6 +669,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
   }
 
   Future<void> _delete() async {
+    if (_guardOffline()) return;
     final confirm = await showDialog<bool>(
       context: context,
       builder: (context) => AlertDialog(
@@ -656,6 +708,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
   }
 
   Future<void> _addStay() async {
+    if (_guardOffline()) return;
     final body = await showModalBottomSheet<Map<String, dynamic>>(
       context: context,
       isScrollControlled: true,
@@ -673,6 +726,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
   }
 
   Future<void> _deleteStay(Accommodation a) async {
+    if (_guardOffline()) return;
     try {
       await ref
           .read(accommodationsApiServiceProvider)
@@ -684,6 +738,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
   }
 
   Future<void> _addSegment() async {
+    if (_guardOffline()) return;
     final body = await showModalBottomSheet<Map<String, dynamic>>(
       context: context,
       isScrollControlled: true,
@@ -701,6 +756,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
   }
 
   Future<void> _deleteSegment(TripSegment s) async {
+    if (_guardOffline()) return;
     try {
       await ref
           .read(transportApiServiceProvider)
@@ -933,8 +989,9 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
             }
           });
         },
-            // Refine is owner-only; editors get no per-day refine icon.
-            (_trip?.isOwner ?? true)
+            // Refine is owner-only (and online-only); editors and offline
+            // viewers get no per-day refine icon.
+            (!_isOffline && (_trip?.isOwner ?? true))
                 ? () {
                     final trip = _trip;
                     if (trip == null) return;
@@ -1014,8 +1071,11 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
                           ?.copyWith(color: theme.colorScheme.primary),
                     ),
                   ],
-                  // 'Other places' has no hub the section tool can target.
-                  if (group.label != 'Other places' && trip.isOwner)
+                  // 'Other places' has no hub the section tool can target;
+                  // refine also needs the network.
+                  if (group.label != 'Other places' &&
+                      trip.isOwner &&
+                      !_isOffline)
                     IconButton(
                       icon: const Icon(Icons.auto_awesome, size: 16),
                       tooltip: 'Refine ${group.label}',
@@ -1648,6 +1708,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
   /// order back onto the full item-id permutation and submits it through the
   /// same PUT /items/order path as Move up/down.
   Future<void> _reorderSection(ItineraryItem item) async {
+    if (_guardOffline()) return;
     final trip = _trip;
     if (trip == null) return;
     final section = _sectionOf(item);
@@ -1681,6 +1742,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
   }
 
   Future<void> _moveItem(ItineraryItem item, int delta) async {
+    if (_guardOffline()) return;
     final trip = _trip;
     final other = _moveNeighbor(item, delta);
     if (trip == null || other == null) return;
@@ -1703,6 +1765,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
   }
 
   Future<void> _deleteItem(ItineraryItem item) async {
+    if (_guardOffline()) return;
     final trip = _trip;
     if (trip == null) return;
     try {
@@ -1752,6 +1815,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
   }
 
   Future<void> _editItem(ItineraryItem item) async {
+    if (_guardOffline()) return;
     final changes = await showModalBottomSheet<Map<String, dynamic>>(
       context: context,
       isScrollControlled: true,
@@ -2027,7 +2091,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
                 IconButton(
                   icon: const Icon(Icons.edit, size: 20),
                   tooltip: 'Rename',
-                  onPressed: _editTitle,
+                  onPressed: _isOffline ? null : _editTitle,
                 ),
               ],
             ),
@@ -2042,10 +2106,11 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
                   label: Text(hasDates
                       ? '${trip.startDate} → ${trip.endDate}'
                       : 'Add dates'),
-                  onPressed: _editDates,
+                  onPressed: _isOffline ? null : _editDates,
                 ),
                 PopupMenuButton<String>(
                   tooltip: 'Change status',
+                  enabled: !_isOffline,
                   onSelected: (v) => _patch(status: v),
                   itemBuilder: (_) => const [
                     PopupMenuItem(value: 'draft', child: Text('Draft')),
@@ -2080,7 +2145,10 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
               SizedBox(
                 width: double.infinity,
                 child: FilledButton.tonalIcon(
-                  onPressed: () => _openRefine(trip, const RefineTarget.trip()),
+                  // Chat/refine needs the network — disabled while offline.
+                  onPressed: _isOffline
+                      ? null
+                      : () => _openRefine(trip, const RefineTarget.trip()),
                   icon: const Icon(Icons.auto_awesome),
                   label: const Text('Refine with AI'),
                 ),
@@ -2132,8 +2200,9 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
       appBar: GradientAppBar(
         title: Text(trip != null ? _displayTitle(trip) : 'Trip'),
         actions: [
-          // Sharing and deletion are owner-only surfaces; editors see neither.
-          if (trip != null && trip.isOwner)
+          // Sharing and deletion are owner-only surfaces; editors see
+          // neither. Both mutate, so they're hidden while offline-serving.
+          if (trip != null && trip.isOwner && !_isOffline)
             PopupMenuButton<String>(
               icon: const Icon(Icons.share_outlined),
               tooltip: 'Share trip',
@@ -2153,7 +2222,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
                 PopupMenuItem(value: 'revoke', child: Text('Turn off sharing')),
               ],
             ),
-          if (trip != null && trip.isOwner)
+          if (trip != null && trip.isOwner && !_isOffline)
             IconButton(
               icon: const Icon(Icons.delete_outline),
               tooltip: 'Delete trip',
@@ -2267,7 +2336,8 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
                                                     .textTheme.titleMedium),
                                           ),
                                           TextButton.icon(
-                                            onPressed: _addPlace,
+                                            onPressed:
+                                                _isOffline ? null : _addPlace,
                                             style: TextButton.styleFrom(
                                               visualDensity:
                                                   VisualDensity.compact,
@@ -2397,7 +2467,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
                                     Align(
                                       alignment: Alignment.centerRight,
                                       child: TextButton.icon(
-                                        onPressed: _addBooking,
+                                        onPressed: _isOffline ? null : _addBooking,
                                         icon: const Icon(Icons.add, size: 18),
                                         label: const Text('Add booking'),
                                       ),
@@ -2411,7 +2481,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
                                                 style: theme
                                                     .textTheme.titleMedium)),
                                         TextButton.icon(
-                                          onPressed: _addBooking,
+                                          onPressed: _isOffline ? null : _addBooking,
                                           icon: const Icon(Icons.add, size: 18),
                                           label: const Text('Add'),
                                         ),
@@ -2446,10 +2516,24 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
 
                       // Pull-to-refresh: with async co-editing, this is how a
                       // user picks up a collaborator's latest changes.
-                      final refreshable = RefreshIndicator(
+                      Widget refreshable = RefreshIndicator(
                         onRefresh: _refresh,
                         child: scrollView,
                       );
+                      // Offline: the trip on screen is a cached copy — pin
+                      // the banner above it. Retry takes the loud load path,
+                      // which exits offline mode on success or re-serves the
+                      // copy on another network failure.
+                      final offlineSince = _offlineSince;
+                      if (offlineSince != null) {
+                        refreshable = Column(
+                          children: [
+                            OfflineBanner(
+                                savedAt: offlineSince, onRetry: _load),
+                            Expanded(child: refreshable),
+                          ],
+                        );
+                      }
 
                       if (!_panelOpen || _refineTarget == null) {
                         return refreshable;

--- a/src/packages/flutter-app/lib/screens/trips_list_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trips_list_screen.dart
@@ -6,6 +6,7 @@ import '../utils/trip_format.dart';
 import '../widgets/account_menu.dart';
 import '../widgets/empty_state.dart';
 import '../widgets/gradient_app_bar.dart';
+import '../widgets/offline_banner.dart';
 import '../widgets/status_pill.dart';
 import '../models/trip.dart';
 import '../providers/auth_provider.dart';
@@ -91,6 +92,21 @@ class _TripsListScreenState extends ConsumerState<TripsListScreen> {
             ],
           ],
         ),
+      );
+    }
+
+    // Offline: the list is a cached copy — pin the banner above it so the
+    // staleness (and the way back online) is always visible.
+    final offlineSince = state.offlineSince;
+    if (offlineSince != null) {
+      body = Column(
+        children: [
+          OfflineBanner(
+            savedAt: offlineSince,
+            onRetry: () => ref.read(tripsProvider.notifier).loadTrips(),
+          ),
+          Expanded(child: body),
+        ],
       );
     }
 

--- a/src/packages/flutter-app/lib/services/trip_cache.dart
+++ b/src/packages/flutter-app/lib/services/trip_cache.dart
@@ -1,0 +1,167 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../models/trip.dart';
+
+/// A cached payload plus the moment it was saved, so the UI can say how
+/// stale the copy is ("saved 2 hours ago").
+typedef CachedTrips = ({List<Trip> trips, DateTime savedAt});
+typedef CachedTrip = ({Trip trip, DateTime savedAt});
+
+/// On-device, per-user cache of previously fetched trips so they stay
+/// viewable (read-only) without a network. Backed by shared_preferences —
+/// the same storage and user-scoped keying as `recent_trip_provider.dart` —
+/// which is acceptable for v1 payload sizes (see specs/offline-trips).
+///
+/// Writes are best-effort: every write swallows storage errors so a cache
+/// problem can never affect the online path. Reads treat any malformed entry
+/// as a miss.
+class TripCache {
+  /// Signed-in user the cache belongs to; null when anonymous, in which case
+  /// every operation no-ops (trips require sign-in anyway).
+  final String? userId;
+
+  TripCache(this.userId);
+
+  /// Most-recently-viewed trip details kept per user; older ones are evicted.
+  static const int maxCachedTrips = 10;
+
+  static String _prefix(String userId) => 'trip_cache.$userId.';
+
+  String get _listKey => '${_prefix(userId!)}list';
+  String get _indexKey => '${_prefix(userId!)}index';
+  String _tripKey(String tripId) => '${_prefix(userId!)}trip.$tripId';
+
+  /// True when [e] is a network-level failure (no connection, timeout) as
+  /// opposed to an HTTP error response. `package:http` >=1.0 wraps socket/IO
+  /// failures in [http.ClientException] on every platform; the string check
+  /// is belt-and-braces for raw dart:io SocketExceptions (dart:io itself is
+  /// not importable on web). HTTP non-200s in TripsApiService are thrown as
+  /// plain `Exception('... (status)')` and therefore never match — a
+  /// 403/404/500 must NOT fall back to the cache.
+  static bool isNetworkError(Object e) =>
+      e is http.ClientException ||
+      e is TimeoutException ||
+      e.toString().contains('SocketException');
+
+  /// Remembers the trips list. Fire-and-forget: never throws.
+  Future<void> writeList(List<Trip> trips) async {
+    if (userId == null) return;
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setString(
+        _listKey,
+        jsonEncode({
+          'saved_at': DateTime.now().toIso8601String(),
+          'trips': [for (final t in trips) t.toJson()],
+        }),
+      );
+    } catch (_) {
+      // Best-effort — a failed cache write must never surface.
+    }
+  }
+
+  /// The last successfully fetched trips list, or null on miss/corruption.
+  Future<CachedTrips?> readList() async {
+    if (userId == null) return null;
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final raw = prefs.getString(_listKey);
+      if (raw == null) return null;
+      final m = jsonDecode(raw) as Map<String, dynamic>;
+      final savedAt = DateTime.parse(m['saved_at'] as String);
+      final trips = [
+        for (final e in m['trips'] as List<dynamic>)
+          Trip.fromJson(e as Map<String, dynamic>)
+      ];
+      return (trips: trips, savedAt: savedAt);
+    } catch (_) {
+      return null; // Malformed entry — treat as a miss.
+    }
+  }
+
+  /// Remembers one trip's full detail and bumps it to the front of the MRU
+  /// index, evicting beyond [maxCachedTrips]. Fire-and-forget: never throws.
+  Future<void> writeTrip(Trip trip) async {
+    if (userId == null) return;
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setString(
+        _tripKey(trip.id),
+        jsonEncode({
+          'saved_at': DateTime.now().toIso8601String(),
+          'trip': trip.toJson(),
+        }),
+      );
+      final index = _readIndex(prefs)..remove(trip.id);
+      index.insert(0, trip.id);
+      for (final evicted in index.skip(maxCachedTrips)) {
+        await prefs.remove(_tripKey(evicted));
+      }
+      await prefs.setStringList(
+          _indexKey, index.take(maxCachedTrips).toList());
+    } catch (_) {
+      // Best-effort — a failed cache write must never surface.
+    }
+  }
+
+  /// The last successfully fetched detail for [tripId], or null.
+  Future<CachedTrip?> readTrip(String tripId) async {
+    if (userId == null) return null;
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final raw = prefs.getString(_tripKey(tripId));
+      if (raw == null) return null;
+      final m = jsonDecode(raw) as Map<String, dynamic>;
+      return (
+        trip: Trip.fromJson(m['trip'] as Map<String, dynamic>),
+        savedAt: DateTime.parse(m['saved_at'] as String),
+      );
+    } catch (_) {
+      return null; // Malformed entry — treat as a miss.
+    }
+  }
+
+  /// Forgets a deleted trip so offline mode can't reopen it: drops its
+  /// detail entry, its index slot, and its row in the cached list.
+  Future<void> removeTrip(String tripId) async {
+    if (userId == null) return;
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.remove(_tripKey(tripId));
+      final index = _readIndex(prefs)..remove(tripId);
+      await prefs.setStringList(_indexKey, index);
+      final raw = prefs.getString(_listKey);
+      if (raw != null) {
+        final m = jsonDecode(raw) as Map<String, dynamic>;
+        final trips = (m['trips'] as List<dynamic>)
+            .where((e) => (e as Map<String, dynamic>)['id'] != tripId)
+            .toList();
+        await prefs.setString(
+            _listKey, jsonEncode({'saved_at': m['saved_at'], 'trips': trips}));
+      }
+    } catch (_) {
+      // Best-effort.
+    }
+  }
+
+  List<String> _readIndex(SharedPreferences prefs) =>
+      prefs.getStringList(_indexKey)?.toList() ?? <String>[];
+
+  /// Removes every cached entry belonging to [userId]. Called on sign-out
+  /// and account deletion (privacy: shared devices).
+  static Future<void> clearForUser(String userId) async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final prefix = _prefix(userId);
+      for (final key in prefs.getKeys().toList()) {
+        if (key.startsWith(prefix)) await prefs.remove(key);
+      }
+    } catch (_) {
+      // Best-effort.
+    }
+  }
+}

--- a/src/packages/flutter-app/lib/widgets/offline_banner.dart
+++ b/src/packages/flutter-app/lib/widgets/offline_banner.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/material.dart';
+
+/// Coarse relative-time label for cache staleness: "just now",
+/// "5 minutes ago", "2 hours ago", "3 days ago". [now] is injectable for
+/// tests; precision is deliberately low — travelers need "how stale", not a
+/// timestamp.
+String relativeTime(DateTime savedAt, {DateTime? now}) {
+  final d = (now ?? DateTime.now()).difference(savedAt);
+  if (d.inMinutes < 1) return 'just now';
+  if (d.inHours < 1) {
+    return d.inMinutes == 1 ? '1 minute ago' : '${d.inMinutes} minutes ago';
+  }
+  if (d.inDays < 1) {
+    return d.inHours == 1 ? '1 hour ago' : '${d.inHours} hours ago';
+  }
+  return d.inDays == 1 ? '1 day ago' : '${d.inDays} days ago';
+}
+
+/// Pinned notice shown while a screen serves a cached (read-only) copy of
+/// trip data because the network is unreachable. Says when the copy was
+/// saved and offers a retry of the live fetch.
+class OfflineBanner extends StatelessWidget {
+  final DateTime savedAt;
+  final VoidCallback onRetry;
+
+  const OfflineBanner({super.key, required this.savedAt, required this.onRetry});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final scheme = theme.colorScheme;
+    return Material(
+      color: scheme.tertiaryContainer,
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(16, 6, 8, 6),
+        child: Row(
+          children: [
+            Icon(Icons.cloud_off, size: 18, color: scheme.onTertiaryContainer),
+            const SizedBox(width: 10),
+            Expanded(
+              child: Text(
+                'Offline — showing saved copy from ${relativeTime(savedAt)}',
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: scheme.onTertiaryContainer,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ),
+            TextButton(
+              onPressed: onRetry,
+              style: TextButton.styleFrom(
+                foregroundColor: scheme.onTertiaryContainer,
+                visualDensity: VisualDensity.compact,
+              ),
+              child: const Text('Retry'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/src/packages/flutter-app/test/trip_cache_test.dart
+++ b/src/packages/flutter-app/test/trip_cache_test.dart
@@ -1,0 +1,141 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:travel_route_planner/models/trip.dart';
+import 'package:travel_route_planner/services/trip_cache.dart';
+
+Trip _trip(String id, {String title = 'Trip'}) => Trip(
+      id: id,
+      title: title,
+      status: 'planned',
+      createdAt: '2026-06-01',
+      updatedAt: '2026-06-01',
+    );
+
+void main() {
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  group('isNetworkError', () {
+    test('classifies connection-level failures as network errors', () {
+      expect(TripCache.isNetworkError(http.ClientException('refused')), isTrue);
+      expect(TripCache.isNetworkError(TimeoutException('slow')), isTrue);
+      expect(
+          TripCache.isNetworkError(
+              Exception('SocketException: Failed host lookup')),
+          isTrue);
+    });
+
+    test('HTTP status errors are NOT network errors (no cache fallback)', () {
+      // TripsApiService throws these for non-200 responses; a 403/404 must
+      // never resurrect a trip from cache.
+      expect(TripCache.isNetworkError(Exception('Failed to load trip (403)')),
+          isFalse);
+      expect(TripCache.isNetworkError(Exception('Failed to load trips (404)')),
+          isFalse);
+      expect(TripCache.isNetworkError(Exception('Failed to load trips (500)')),
+          isFalse);
+      expect(TripCache.isNetworkError(StateError('bug')), isFalse);
+    });
+  });
+
+  group('trip list cache', () {
+    test('round-trips the list with a saved-at timestamp', () async {
+      final cache = TripCache('u1');
+      final before = DateTime.now();
+      await cache.writeList([_trip('a', title: 'Athens'), _trip('b')]);
+      final cached = await cache.readList();
+      expect(cached, isNotNull);
+      expect(cached!.trips.map((t) => t.id), ['a', 'b']);
+      expect(cached.trips.first.title, 'Athens');
+      expect(cached.savedAt.isBefore(before), isFalse);
+      expect(cached.savedAt.isAfter(DateTime.now()), isFalse);
+    });
+
+    test('users are isolated and anonymous sessions no-op', () async {
+      await TripCache('u1').writeList([_trip('a')]);
+      expect(await TripCache('u2').readList(), isNull);
+      final anon = TripCache(null);
+      await anon.writeList([_trip('x')]); // no-op, no throw
+      expect(await anon.readList(), isNull);
+    });
+
+    test('corrupt entry reads as a miss', () async {
+      SharedPreferences.setMockInitialValues(
+          {'trip_cache.u1.list': 'not json'});
+      expect(await TripCache('u1').readList(), isNull);
+    });
+  });
+
+  group('trip detail cache', () {
+    test('round-trips a trip with a saved-at timestamp', () async {
+      final cache = TripCache('u1');
+      await cache.writeTrip(_trip('t1', title: 'Greece'));
+      final cached = await cache.readTrip('t1');
+      expect(cached, isNotNull);
+      expect(cached!.trip.title, 'Greece');
+      expect(await cache.readTrip('missing'), isNull);
+    });
+
+    test('evicts the least-recently-written beyond maxCachedTrips', () async {
+      final cache = TripCache('u1');
+      for (var i = 0; i < TripCache.maxCachedTrips + 2; i++) {
+        await cache.writeTrip(_trip('t$i'));
+      }
+      // t0 and t1 evicted; the newest 10 remain.
+      expect(await cache.readTrip('t0'), isNull);
+      expect(await cache.readTrip('t1'), isNull);
+      expect(await cache.readTrip('t2'), isNotNull);
+      expect(await cache.readTrip('t${TripCache.maxCachedTrips + 1}'),
+          isNotNull);
+    });
+
+    test('re-writing an existing trip bumps it to most-recent', () async {
+      final cache = TripCache('u1');
+      for (var i = 0; i < TripCache.maxCachedTrips; i++) {
+        await cache.writeTrip(_trip('t$i'));
+      }
+      await cache.writeTrip(_trip('t0')); // refresh the oldest
+      await cache.writeTrip(_trip('new')); // should evict t1, not t0
+      expect(await cache.readTrip('t0'), isNotNull);
+      expect(await cache.readTrip('t1'), isNull);
+    });
+
+    test('removeTrip drops the detail and the row in the cached list',
+        () async {
+      final cache = TripCache('u1');
+      await cache.writeList([_trip('t1'), _trip('t2')]);
+      await cache.writeTrip(_trip('t1'));
+      await cache.removeTrip('t1');
+      expect(await cache.readTrip('t1'), isNull);
+      final list = await cache.readList();
+      expect(list!.trips.map((t) => t.id), ['t2']);
+    });
+  });
+
+  group('clearForUser (sign-out / account deletion)', () {
+    test('removes every trip_cache key for that user only', () async {
+      final cache = TripCache('u1');
+      await cache.writeList([_trip('a')]);
+      await cache.writeTrip(_trip('a'));
+      await TripCache('u2').writeTrip(_trip('b'));
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setString('recent_trip.u1', jsonEncode({'id': 'a'}));
+
+      await TripCache.clearForUser('u1');
+
+      expect(await TripCache('u1').readList(), isNull);
+      expect(await TripCache('u1').readTrip('a'), isNull);
+      expect(prefs.getKeys().where((k) => k.startsWith('trip_cache.u1.')),
+          isEmpty);
+      // Other users' caches and unrelated keys are untouched.
+      expect(await TripCache('u2').readTrip('b'), isNotNull);
+      expect(prefs.getString('recent_trip.u1'), isNotNull);
+    });
+  });
+}

--- a/src/packages/flutter-app/test/trip_detail_offline_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_offline_test.dart
@@ -1,0 +1,178 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:travel_route_planner/models/itinerary_item.dart';
+import 'package:travel_route_planner/models/trip.dart';
+import 'package:travel_route_planner/providers/trip_cache_provider.dart';
+import 'package:travel_route_planner/providers/trips_provider.dart';
+import 'package:travel_route_planner/screens/trip_detail_screen.dart';
+import 'package:travel_route_planner/services/api_client.dart';
+import 'package:travel_route_planner/services/trip_cache.dart';
+import 'package:travel_route_planner/services/trips_api_service.dart';
+import 'package:travel_route_planner/widgets/offline_banner.dart';
+
+/// getTrip answers from a queue: a Trip resolves, anything else throws it.
+class _QueuedTripsApiService extends TripsApiService {
+  final List<Object> responses;
+  int calls = 0;
+
+  _QueuedTripsApiService(this.responses)
+      : super(ApiClient(baseUrl: 'http://test'));
+
+  @override
+  Future<Trip> getTrip(String id) {
+    final next =
+        responses[calls < responses.length ? calls : responses.length - 1];
+    calls++;
+    if (next is Trip) return Future.value(next);
+    return Future.error(next);
+  }
+}
+
+Trip _trip(String title) => Trip(
+      id: 't1',
+      title: title,
+      status: 'planned',
+      createdAt: '2026-06-01',
+      updatedAt: '2026-06-01',
+      items: [
+        // Zero coords so the screen skips the map widget in the test env.
+        ItineraryItem(
+          id: 'i0',
+          position: 0,
+          name: 'Acropolis',
+          address: 'Athens, Greece',
+          latitude: 0,
+          longitude: 0,
+          category: 'attraction',
+        ),
+      ],
+    );
+
+/// FilledButton.tonalIcon / TextButton.icon build private subclasses, so
+/// byType-based finders miss them; match by subtype around the label instead.
+T _labeledButton<T extends ButtonStyleButton>(
+        WidgetTester tester, String label) =>
+    tester.widget<T>(find.ancestor(
+      of: find.text(label),
+      matching: find.bySubtype<T>(),
+    ));
+
+Future<void> _pumpDetail(
+    WidgetTester tester, _QueuedTripsApiService service, TripCache cache) {
+  return tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        tripsApiServiceProvider.overrideWithValue(service),
+        tripCacheProvider.overrideWithValue(cache),
+      ],
+      child: MaterialApp(home: TripDetailScreen(tripId: 't1')),
+    ),
+  );
+}
+
+void main() {
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  group('relativeTime', () {
+    test('formats coarse staleness labels', () {
+      final now = DateTime(2026, 7, 6, 12, 0);
+      DateTime ago(Duration d) => now.subtract(d);
+      expect(relativeTime(ago(const Duration(seconds: 20)), now: now),
+          'just now');
+      expect(relativeTime(ago(const Duration(minutes: 5)), now: now),
+          '5 minutes ago');
+      expect(
+          relativeTime(ago(const Duration(hours: 1)), now: now), '1 hour ago');
+      expect(
+          relativeTime(ago(const Duration(days: 2)), now: now), '2 days ago');
+    });
+  });
+
+  testWidgets(
+      'network failure serves the cached trip read-only with an offline banner',
+      (WidgetTester tester) async {
+    final cache = TripCache('u1');
+    await cache.writeTrip(_trip('Athens Trip'));
+    final service =
+        _QueuedTripsApiService([http.ClientException('connection refused')]);
+
+    await _pumpDetail(tester, service, cache);
+    await tester.pumpAndSettle();
+
+    // The saved copy renders, clearly marked stale.
+    expect(find.text('Acropolis'), findsOneWidget);
+    expect(find.textContaining('Offline — showing saved copy from'),
+        findsOneWidget);
+    expect(find.text('Could not load this trip'), findsNothing);
+
+    // Mutation affordances are disabled or hidden.
+    final refine = _labeledButton<FilledButton>(tester, 'Refine with AI');
+    expect(refine.onPressed, isNull, reason: 'chat/refine needs the network');
+    final addPlace = _labeledButton<TextButton>(tester, 'Add place');
+    expect(addPlace.onPressed, isNull);
+    final rename = tester.widget<IconButton>(find.ancestor(
+      of: find.byTooltip('Rename'),
+      matching: find.byType(IconButton),
+    ));
+    expect(rename.onPressed, isNull);
+    expect(find.byTooltip('Share trip'), findsNothing);
+    expect(find.byTooltip('Delete trip'), findsNothing);
+  });
+
+  testWidgets('Retry re-fetches live and exits offline mode',
+      (WidgetTester tester) async {
+    final cache = TripCache('u1');
+    await cache.writeTrip(_trip('Athens Trip'));
+    final service = _QueuedTripsApiService(
+        [http.ClientException('down'), _trip('Athens Trip (live)')]);
+
+    await _pumpDetail(tester, service, cache);
+    await tester.pumpAndSettle();
+    expect(find.textContaining('Offline — showing saved copy from'),
+        findsOneWidget);
+
+    await tester.tap(find.text('Retry'));
+    await tester.pumpAndSettle();
+
+    expect(service.calls, 2);
+    expect(find.textContaining('Offline — showing saved copy from'),
+        findsNothing);
+    expect(find.text('Athens Trip (live)'), findsWidgets);
+    final refine = _labeledButton<FilledButton>(tester, 'Refine with AI');
+    expect(refine.onPressed, isNotNull, reason: 'back online — re-enabled');
+  });
+
+  testWidgets('an HTTP 403 shows the error page, never the cached copy',
+      (WidgetTester tester) async {
+    final cache = TripCache('u1');
+    await cache.writeTrip(_trip('Athens Trip'));
+    final service =
+        _QueuedTripsApiService([Exception('Failed to load trip (403)')]);
+
+    await _pumpDetail(tester, service, cache);
+    await tester.pumpAndSettle();
+
+    expect(find.text('Could not load this trip'), findsOneWidget);
+    expect(find.text('Acropolis'), findsNothing);
+    expect(find.textContaining('Offline — showing saved copy from'),
+        findsNothing);
+  });
+
+  testWidgets('a network failure with no cached copy shows the error page',
+      (WidgetTester tester) async {
+    final service = _QueuedTripsApiService([http.ClientException('down')]);
+
+    await _pumpDetail(tester, service, TripCache('u1'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Could not load this trip'), findsOneWidget);
+    expect(find.textContaining('Offline — showing saved copy from'),
+        findsNothing);
+  });
+}

--- a/src/packages/flutter-app/test/trips_list_offline_test.dart
+++ b/src/packages/flutter-app/test/trips_list_offline_test.dart
@@ -1,0 +1,107 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:travel_route_planner/models/trip.dart';
+import 'package:travel_route_planner/providers/trip_cache_provider.dart';
+import 'package:travel_route_planner/providers/trips_provider.dart';
+import 'package:travel_route_planner/screens/trips_list_screen.dart';
+import 'package:travel_route_planner/services/api_client.dart';
+import 'package:travel_route_planner/services/trip_cache.dart';
+import 'package:travel_route_planner/services/trips_api_service.dart';
+
+class _QueuedTripsApiService extends TripsApiService {
+  final List<Object> responses;
+  int calls = 0;
+
+  _QueuedTripsApiService(this.responses)
+      : super(ApiClient(baseUrl: 'http://test'));
+
+  @override
+  Future<List<Trip>> listTrips() {
+    final next =
+        responses[calls < responses.length ? calls : responses.length - 1];
+    calls++;
+    if (next is List<Trip>) return Future.value(next);
+    return Future.error(next);
+  }
+}
+
+Trip _trip(String id, String title) => Trip(
+      id: id,
+      title: title,
+      status: 'planned',
+      createdAt: '2026-06-01',
+      updatedAt: '2026-06-01',
+    );
+
+Future<void> _pumpList(
+    WidgetTester tester, _QueuedTripsApiService service, TripCache cache) {
+  return tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        tripsApiServiceProvider.overrideWithValue(service),
+        tripCacheProvider.overrideWithValue(cache),
+      ],
+      child: const MaterialApp(home: TripsListScreen()),
+    ),
+  );
+}
+
+void main() {
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  testWidgets('network failure shows the cached list under an offline banner',
+      (WidgetTester tester) async {
+    final cache = TripCache('u1');
+    await cache.writeList([_trip('a', 'Athens Trip')]);
+    final service = _QueuedTripsApiService([http.ClientException('down')]);
+
+    await _pumpList(tester, service, cache);
+    await tester.pumpAndSettle();
+
+    expect(find.text('Athens Trip'), findsOneWidget);
+    expect(find.textContaining('Offline — showing saved copy from'),
+        findsOneWidget);
+    expect(find.text('Could not load trips'), findsNothing);
+  });
+
+  testWidgets('banner Retry re-attempts the live fetch and clears on success',
+      (WidgetTester tester) async {
+    final cache = TripCache('u1');
+    await cache.writeList([_trip('a', 'Athens Trip')]);
+    final service = _QueuedTripsApiService([
+      http.ClientException('down'),
+      [_trip('a', 'Athens Trip'), _trip('b', 'Lisbon Trip')]
+    ]);
+
+    await _pumpList(tester, service, cache);
+    await tester.pumpAndSettle();
+    expect(find.textContaining('Offline — showing saved copy from'),
+        findsOneWidget);
+
+    await tester.tap(find.text('Retry'));
+    await tester.pumpAndSettle();
+
+    expect(service.calls, 2);
+    expect(find.textContaining('Offline — showing saved copy from'),
+        findsNothing);
+    expect(find.text('Lisbon Trip'), findsOneWidget);
+  });
+
+  testWidgets('a network failure with no cached copy keeps the error state',
+      (WidgetTester tester) async {
+    final service = _QueuedTripsApiService([http.ClientException('down')]);
+
+    await _pumpList(tester, service, TripCache('u1'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Could not load trips'), findsOneWidget);
+    expect(find.textContaining('Offline — showing saved copy from'),
+        findsNothing);
+  });
+}

--- a/src/packages/flutter-app/test/trips_provider_offline_test.dart
+++ b/src/packages/flutter-app/test/trips_provider_offline_test.dart
@@ -1,0 +1,122 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:travel_route_planner/models/trip.dart';
+import 'package:travel_route_planner/providers/trips_provider.dart';
+import 'package:travel_route_planner/services/api_client.dart';
+import 'package:travel_route_planner/services/trip_cache.dart';
+import 'package:travel_route_planner/services/trips_api_service.dart';
+
+/// listTrips answers from a queue: a List<Trip> resolves, anything else
+/// throws it.
+class _QueuedTripsApiService extends TripsApiService {
+  final List<Object> responses;
+  int calls = 0;
+
+  _QueuedTripsApiService(this.responses)
+      : super(ApiClient(baseUrl: 'http://test'));
+
+  @override
+  Future<List<Trip>> listTrips() {
+    final next =
+        responses[calls < responses.length ? calls : responses.length - 1];
+    calls++;
+    if (next is List<Trip>) return Future.value(next);
+    return Future.error(next);
+  }
+}
+
+Trip _trip(String id, {String title = 'Trip'}) => Trip(
+      id: id,
+      title: title,
+      status: 'planned',
+      createdAt: '2026-06-01',
+      updatedAt: '2026-06-01',
+    );
+
+void main() {
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('a successful load serves live data and writes through to the cache',
+      () async {
+    final cache = TripCache('u1');
+    final notifier = TripsNotifier(
+        _QueuedTripsApiService([
+          [_trip('a', title: 'Athens')]
+        ]),
+        cache);
+
+    await notifier.loadTrips();
+
+    expect(notifier.state.trips.single.title, 'Athens');
+    expect(notifier.state.offlineSince, isNull);
+    expect(notifier.state.error, isNull);
+    // Write-through is fire-and-forget; give the microtask a beat.
+    await Future<void>.delayed(Duration.zero);
+    final cached = await cache.readList();
+    expect(cached!.trips.single.title, 'Athens');
+  });
+
+  test('a network error serves the cached copy, marked offline', () async {
+    final cache = TripCache('u1');
+    await cache.writeList([_trip('a', title: 'Athens')]);
+    final notifier = TripsNotifier(
+        _QueuedTripsApiService([http.ClientException('connection refused')]),
+        cache);
+
+    await notifier.loadTrips();
+
+    expect(notifier.state.trips.single.title, 'Athens');
+    expect(notifier.state.offlineSince, isNotNull);
+    expect(notifier.state.error, isNull);
+    expect(notifier.state.loading, isFalse);
+  });
+
+  test('an HTTP error (403) does NOT fall back to the cache', () async {
+    final cache = TripCache('u1');
+    await cache.writeList([_trip('a', title: 'Athens')]);
+    final notifier = TripsNotifier(
+        _QueuedTripsApiService([Exception('Failed to load trips (403)')]),
+        cache);
+
+    await notifier.loadTrips();
+
+    expect(notifier.state.trips, isEmpty);
+    expect(notifier.state.offlineSince, isNull);
+    expect(notifier.state.error, contains('403'));
+  });
+
+  test('a network error with no cached copy keeps the normal error path',
+      () async {
+    final notifier = TripsNotifier(
+        _QueuedTripsApiService([http.ClientException('connection refused')]),
+        TripCache('u1'));
+
+    await notifier.loadTrips();
+
+    expect(notifier.state.trips, isEmpty);
+    expect(notifier.state.offlineSince, isNull);
+    expect(notifier.state.error, isNotNull);
+  });
+
+  test('a later successful load clears the offline marker', () async {
+    final cache = TripCache('u1');
+    await cache.writeList([_trip('a')]);
+    final notifier = TripsNotifier(
+        _QueuedTripsApiService([
+          http.ClientException('down'),
+          [_trip('a'), _trip('b')]
+        ]),
+        cache);
+
+    await notifier.loadTrips();
+    expect(notifier.state.offlineSince, isNotNull);
+
+    await notifier.loadTrips();
+    expect(notifier.state.offlineSince, isNull);
+    expect(notifier.state.trips, hasLength(2));
+  });
+}


### PR DESCRIPTION
Wave 8 item 1 — the top user-impact item from Wave 7 planning: a traveler mid-trip (airplane mode, dead zone) opens the app and currently gets nothing. Now previously-loaded trips remain viewable offline, read-only, clearly marked stale.

Spec first: **`specs/offline-trips/`** (spec.md / plan.md / tasks.md).

## What's cached, when, and when it's served
- **Write-through** on every successful trips-list and trip-detail fetch: full JSON (itinerary items, bookings, todos) into `shared_preferences` under user-scoped keys (`trip_cache.<userId>.…`), same pattern as the recent-trip prefs. Writes are `unawaited` and swallow errors — the online path can't be affected.
- **Served only on network-level failures.** `TripCache.isNetworkError` matches `http.ClientException` / `TimeoutException` / raw SocketExceptions; `TripsApiService` throws HTTP non-200s as plain `Exception('… (status)')`, so a **403/404/500 never falls back to cache** (tested).
- **Eviction:** last **10** viewed trip details per user, MRU index; deleting a trip also purges its cache entry and its row in the cached list.
- **Privacy:** `signOutLocally()` — the shared funnel for logout, sign-out-everywhere, and account deletion — clears every `trip_cache.<userId>.` key.

## UI
- `OfflineBanner` ("Offline — showing saved copy from *5 minutes ago*" + **Retry**) pinned above the trips list and trip detail while offline-serving; a successful live load clears it.
- Read-only while offline: share/delete hidden; rename, dates, status, Refine with AI (trip/city/day entry points), Add place/booking disabled; every mutation method additionally gated by `_guardOffline()` (snackbar: "You're offline — reconnect to make changes") so deep entry points (item menus, todo cards, reorder) can't fire.

## Why the online path is provably unchanged (PR #51/#53 invariants)
- No changes to `plan_provider.dart`, `chat_panel.dart`, `trip_refine_panel.dart`.
- `_load(silent:)` / `_refresh()` logic untouched: cache fallback lives **only inside the existing catch block on the loud path** (`!quiet`); quiet failures keep the exact "stay silent, keep stale trip" behavior — `trip_detail_silent_refresh_test.dart` passes unmodified.
- On success the only additions are an `unawaited` cache write and `_offlineSince = null` inside the same setState — no new awaits, no reordering, `tripUpdateCount` / flush-timer / record-select code untouched.
- The refine panel can never open while offline-serving (`_openRefine` guard), so it never observes a cached trip.

## Tests (all green: 86/86; analyze exit 0, 12 pre-existing infos, none added)
- `trip_cache_test.dart` — round-trip + savedAt, MRU eviction at 10, re-write bumps recency, per-user isolation + anonymous no-op, corrupt-entry miss, `removeTrip`, `clearForUser` (leaves other users/keys), network-vs-HTTP classifier.
- `trips_provider_offline_test.dart` — write-through, cache serve on network error, **403 no-fallback**, no-cache error path, recovery clears `offlineSince`.
- `trip_detail_offline_test.dart` — banner + read-only affordances (Refine/Add place/Rename disabled, share/delete hidden), Retry exits offline mode, 403 → error page, no-cache → error page, `relativeTime` labels.
- `trips_list_offline_test.dart` — banner over cached list, Retry recovery, no-cache error state.

## Manual verification needed (can't be done headlessly)
Full airplane-mode verification requires a real browser/device network toggle — not possible in this harness. Steps for Brian:

1. `make docker-dev`, sign in at `http://localhost:3000`, open **My Trips**, then open a trip's detail (this populates the cache).
2. DevTools → Network → **Offline** (or airplane mode on device). Hard-navigate back to My Trips and re-open the trip: both should render with the "Offline — showing saved copy from …" banner; itinerary/bookings/todos visible.
3. While offline: confirm share/delete are gone from the app bar; rename/dates/status/Refine/Add place are disabled; tapping a todo checkbox or item-menu action shows the "You're offline" snackbar; embedded events/local-intel sections simply don't render.
4. Tap **Retry** while still offline → banner stays. Re-enable network → **Retry** → banner clears, editing works again.
5. Open a trip you never viewed before while offline → normal "Could not load this trip" + Retry (no cache leak).
6. Sign out (or delete a test account), sign back in offline-style: no cached trips from the previous session (localStorage `trip_cache.*` keys for that user are gone).

## Trade-offs / notes
- `shared_preferences` (web: localStorage, ~5 MB origin quota) is accepted for v1 and documented in the spec; the `TripCache` API is the seam for a later drift/sqflite upgrade.
- Shared-with-me trips, public share views, guides/local recs/events are explicitly online-only (spec "Not Available Offline").

🤖 Generated with [Claude Code](https://claude.com/claude-code)
