### PR TITLE
refactor(api): /plan tool dispatch table

### DIFF
--- a/src/packages/api/fake_anthropic_test.go
+++ b/src/packages/api/fake_anthropic_test.go
@@ -1,0 +1,282 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"unicode/utf8"
+)
+
+// fake_anthropic_test.go — a reusable, scriptable stand-in for the Anthropic
+// API behind the ANTHROPIC_BASE_URL seam (anthropic_client.go).
+//
+// Construct it with a sequence of scripted assistant turns; each streaming
+// /v1/messages call is answered with the turn matching how far the tool loop
+// has progressed. Turn selection is keyed off the REQUEST BODY, not a call
+// counter: the number of user messages carrying tool_result blocks equals the
+// number of completed tool round-trips, which is exactly the turn index. That
+// keeps the fake deterministic when background callers also hit the seam, and
+// it means repeated /plan sessions each replay the script from turn 0.
+//
+// The wire format is accumulator-faithful to anthropic-sdk-go v1.45.0
+// (messageutil.go): message_start carries the message envelope,
+// content_block_start opens each block (tool_use input starts as the literal
+// `{}` the accumulator replaces), deltas arrive as text_delta /
+// input_json_delta partials split across frames, message_delta carries the
+// stop_reason, message_stop closes. Text and tool input are deliberately
+// split into multiple delta frames so tests exercise real accumulation, not
+// single-frame shortcuts.
+//
+// NON-streaming calls (no "stream":true in the body) are served too, because
+// the /plan flow's background profile distiller (profile_distiller.go) and
+// the admin ingest's extraction (local_extraction_service.go) share the seam
+// and use client.Messages.New. The default non-streaming answer is a harmless
+// text-only end_turn message (the forced-tool callers find no tool_use block
+// and no-op); scriptNonStreamingTool swaps in a forced-tool response for
+// tests that exercise those callers directly.
+//
+// Anything else — wrong path, wrong method, an unscripted turn — fails the
+// test loudly and returns 500.
+
+// fakeTurn is one scripted assistant turn for a streaming call.
+type fakeTurn struct {
+	kind      string // "text" | "tool" | "error"
+	text      string
+	toolName  string
+	toolInput string // raw JSON object
+	errMsg    string
+}
+
+// textTurn streams the given text (split across multiple text_delta frames)
+// and ends the conversation with stop_reason end_turn.
+func textTurn(text string) fakeTurn { return fakeTurn{kind: "text", text: text} }
+
+// toolTurn requests the named tool with the given JSON input, streamed as
+// split input_json_delta partials, and stops with stop_reason tool_use.
+func toolTurn(name, inputJSON string) fakeTurn {
+	return fakeTurn{kind: "tool", toolName: name, toolInput: inputJSON}
+}
+
+// errorTurn starts a normal text answer, then kills the stream mid-turn with
+// an SSE `error` event (the shape a real overloaded_error takes on the wire),
+// so stream.Err() fires client-side.
+func errorTurn(message string) fakeTurn { return fakeTurn{kind: "error", errMsg: message} }
+
+type fakeAnthropic struct {
+	t   *testing.T
+	srv *httptest.Server
+
+	mu               sync.Mutex
+	turns            []fakeTurn
+	requests         [][]byte
+	nonStreamContent json.RawMessage
+	nonStreamStop    string
+}
+
+// newFakeAnthropic starts the fake and points the whole process at it for the
+// duration of the test (ANTHROPIC_API_KEY + ANTHROPIC_BASE_URL via t.Setenv).
+func newFakeAnthropic(t *testing.T, script ...fakeTurn) *fakeAnthropic {
+	t.Helper()
+	f := &fakeAnthropic{
+		t:                t,
+		turns:            script,
+		nonStreamContent: json.RawMessage(`[{"type":"text","text":"OK."}]`),
+		nonStreamStop:    "end_turn",
+	}
+	f.srv = httptest.NewServer(http.HandlerFunc(f.handle))
+	t.Cleanup(f.srv.Close)
+	t.Setenv("ANTHROPIC_API_KEY", "test-key")
+	t.Setenv("ANTHROPIC_BASE_URL", f.srv.URL)
+	return f
+}
+
+// scriptNonStreamingTool makes every non-streaming call answer with a single
+// tool_use block — the forced-tool shape profile_distiller.go and
+// local_extraction_service.go expect. Streaming turns are unaffected.
+func (f *fakeAnthropic) scriptNonStreamingTool(name, inputJSON string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.nonStreamContent = json.RawMessage(fmt.Sprintf(
+		`[{"type":"tool_use","id":"toolu_fake_ns","name":%q,"input":%s}]`, name, inputJSON))
+	f.nonStreamStop = "tool_use"
+}
+
+// requestBodies returns a copy of every /v1/messages request body received,
+// in arrival order — for asserting what round-tripped back to the "model".
+func (f *fakeAnthropic) requestBodies() [][]byte {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([][]byte, len(f.requests))
+	copy(out, f.requests)
+	return out
+}
+
+func (f *fakeAnthropic) handle(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost || r.URL.Path != "/v1/messages" {
+		f.t.Errorf("fake anthropic: unexpected request %s %s", r.Method, r.URL.Path)
+		http.Error(w, "unexpected path", http.StatusInternalServerError)
+		return
+	}
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		f.t.Errorf("fake anthropic: read body: %v", err)
+		http.Error(w, "bad body", http.StatusInternalServerError)
+		return
+	}
+
+	f.mu.Lock()
+	f.requests = append(f.requests, body)
+	turns := f.turns
+	nonStreamContent := f.nonStreamContent
+	nonStreamStop := f.nonStreamStop
+	f.mu.Unlock()
+
+	var req struct {
+		Stream   bool `json:"stream"`
+		Messages []struct {
+			Role    string          `json:"role"`
+			Content json.RawMessage `json:"content"`
+		} `json:"messages"`
+	}
+	if err := json.Unmarshal(body, &req); err != nil {
+		f.t.Errorf("fake anthropic: unparseable request body: %v", err)
+		http.Error(w, "bad json", http.StatusInternalServerError)
+		return
+	}
+
+	if !req.Stream {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"id":"msg_fake_ns","type":"message","role":"assistant","model":"claude-sonnet-4-6","content":%s,"stop_reason":%q,"stop_sequence":null,"usage":{"input_tokens":10,"output_tokens":5}}`,
+			nonStreamContent, nonStreamStop)
+		return
+	}
+
+	// Turn index = completed tool round-trips = user messages with tool_result.
+	idx := 0
+	for _, m := range req.Messages {
+		if m.Role == "user" && contentHasToolResult(m.Content) {
+			idx++
+		}
+	}
+	if idx >= len(turns) {
+		f.t.Errorf("fake anthropic: unscripted streaming turn %d (script has %d turns)", idx, len(turns))
+		http.Error(w, "unscripted turn", http.StatusInternalServerError)
+		return
+	}
+	f.streamTurn(w, idx, turns[idx])
+}
+
+// contentHasToolResult reports whether a message's content array carries a
+// tool_result block. Plain-string content (no blocks) never does.
+func contentHasToolResult(content json.RawMessage) bool {
+	var blocks []struct {
+		Type string `json:"type"`
+	}
+	if err := json.Unmarshal(content, &blocks); err != nil {
+		return false
+	}
+	for _, b := range blocks {
+		if b.Type == "tool_result" {
+			return true
+		}
+	}
+	return false
+}
+
+// sseFrame writes one frame in the anthropic SSE wire format.
+func (f *fakeAnthropic) sseFrame(w http.ResponseWriter, event string, data any) {
+	b, err := json.Marshal(data)
+	if err != nil {
+		f.t.Errorf("fake anthropic: marshal %s frame: %v", event, err)
+		return
+	}
+	io.WriteString(w, "event: "+event+"\ndata: "+string(b)+"\n\n")
+}
+
+func (f *fakeAnthropic) streamTurn(w http.ResponseWriter, idx int, turn fakeTurn) {
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.WriteHeader(http.StatusOK)
+
+	f.sseFrame(w, "message_start", map[string]any{
+		"type": "message_start",
+		"message": map[string]any{
+			"id": fmt.Sprintf("msg_fake_%d", idx), "type": "message", "role": "assistant",
+			"model": "claude-sonnet-4-6", "content": []any{},
+			"stop_reason": nil, "stop_sequence": nil,
+			"usage": map[string]any{"input_tokens": 10, "output_tokens": 0},
+		},
+	})
+
+	blockDelta := func(delta map[string]any) {
+		f.sseFrame(w, "content_block_delta", map[string]any{
+			"type": "content_block_delta", "index": 0, "delta": delta,
+		})
+	}
+
+	stopReason := "end_turn"
+	switch turn.kind {
+	case "text":
+		f.sseFrame(w, "content_block_start", map[string]any{
+			"type": "content_block_start", "index": 0,
+			"content_block": map[string]any{"type": "text", "text": ""},
+		})
+		for _, chunk := range splitForStreaming(turn.text) {
+			blockDelta(map[string]any{"type": "text_delta", "text": chunk})
+		}
+
+	case "tool":
+		stopReason = "tool_use"
+		f.sseFrame(w, "content_block_start", map[string]any{
+			"type": "content_block_start", "index": 0,
+			"content_block": map[string]any{
+				"type": "tool_use", "id": fmt.Sprintf("toolu_fake_%d", idx),
+				"name": turn.toolName, "input": map[string]any{},
+			},
+		})
+		for _, chunk := range splitForStreaming(turn.toolInput) {
+			blockDelta(map[string]any{"type": "input_json_delta", "partial_json": chunk})
+		}
+
+	case "error":
+		// Start a real answer, then die mid-turn: the client sees the leading
+		// delta and then stream.Err().
+		f.sseFrame(w, "content_block_start", map[string]any{
+			"type": "content_block_start", "index": 0,
+			"content_block": map[string]any{"type": "text", "text": ""},
+		})
+		blockDelta(map[string]any{"type": "text_delta", "text": "One moment"})
+		f.sseFrame(w, "error", map[string]any{
+			"type":  "error",
+			"error": map[string]any{"type": "overloaded_error", "message": turn.errMsg},
+		})
+		return
+
+	default:
+		f.t.Errorf("fake anthropic: unknown turn kind %q", turn.kind)
+		return
+	}
+
+	f.sseFrame(w, "content_block_stop", map[string]any{"type": "content_block_stop", "index": 0})
+	f.sseFrame(w, "message_delta", map[string]any{
+		"type":  "message_delta",
+		"delta": map[string]any{"stop_reason": stopReason, "stop_sequence": nil},
+		"usage": map[string]any{"output_tokens": 7},
+	})
+	f.sseFrame(w, "message_stop", map[string]any{"type": "message_stop"})
+}
+
+// splitForStreaming cuts s into two rune-safe halves so every scripted turn
+// arrives as MULTIPLE delta frames — tests that pass against this fake prove
+// the client accumulates partial frames, not just whole payloads.
+func splitForStreaming(s string) []string {
+	if utf8.RuneCountInString(s) < 2 {
+		return []string{s}
+	}
+	runes := []rune(s)
+	mid := len(runes) / 2
+	return []string{string(runes[:mid]), string(runes[mid:])}
+}

--- a/src/packages/api/free_cap_integration_test.go
+++ b/src/packages/api/free_cap_integration_test.go
@@ -3,9 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
-	"io"
 	"net/http"
-	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
@@ -18,31 +16,6 @@ import (
 // free_cap_would_hit per crossing — the only-on-crossing rule's off-by-ones,
 // (b) the dashboard rollup, and (c) that every capped request still SUCCEEDS
 // (measurement only, nothing enforced).
-
-// fakeAnthropicServer stands in for the Anthropic API behind the
-// ANTHROPIC_BASE_URL seam: every /v1/messages call streams a minimal
-// text-only SSE response ending in end_turn, so a real /plan session runs
-// end-to-end through buildRouter with zero external calls.
-func fakeAnthropicServer(t *testing.T) *httptest.Server {
-	t.Helper()
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "text/event-stream")
-		w.WriteHeader(http.StatusOK)
-		frames := []struct{ event, data string }{
-			{"message_start", `{"type":"message_start","message":{"id":"msg_fake","type":"message","role":"assistant","model":"claude-sonnet-4-6","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":10,"output_tokens":0}}}`},
-			{"content_block_start", `{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`},
-			{"content_block_delta", `{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Where would you like to go?"}}`},
-			{"content_block_stop", `{"type":"content_block_stop","index":0}`},
-			{"message_delta", `{"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":7}}`},
-			{"message_stop", `{"type":"message_stop"}`},
-		}
-		for _, f := range frames {
-			io.WriteString(w, "event: "+f.event+"\ndata: "+f.data+"\n\n")
-		}
-	}))
-	t.Cleanup(srv.Close)
-	return srv
-}
 
 // waitForEventCount polls until the user has exactly want events of the given
 // type. plan_session_started is recorded by a goroutine that writes any
@@ -99,9 +72,7 @@ func freeCapWouldHits(t *testing.T, userID uuid.UUID, capKind string) (hits, las
 // 4 (prior > cap) emits nothing more. Every session must succeed.
 func TestFreeCapPlanRunsCrossingSignal(t *testing.T) {
 	resetDB(t)
-	srv := fakeAnthropicServer(t)
-	t.Setenv("ANTHROPIC_API_KEY", "test-key")
-	t.Setenv("ANTHROPIC_BASE_URL", srv.URL)
+	newFakeAnthropic(t, textTurn("Where would you like to go?"))
 	t.Setenv("FREE_PLAN_SESSIONS_PER_MONTH", "2")
 
 	user, token := createTestUser(t, "capped@example.com")
@@ -223,47 +194,6 @@ func TestFreeCapEventNotClientRecordable(t *testing.T) {
 	}
 }
 
-// fakeAnthropicItineraryServer stands in for the Anthropic API for sessions
-// that finalize a trip: any request that does not yet carry a tool_result
-// gets a create_itinerary tool_use (driving plan_handler's persistTrip
-// branch), and the follow-up request (which echoes the tool result back)
-// gets a plain end_turn text answer. Keying on the request body rather than
-// a call counter keeps it deterministic when background callers (the profile
-// distiller) also hit the seam.
-func fakeAnthropicItineraryServer(t *testing.T) *httptest.Server {
-	t.Helper()
-	textFrames := []struct{ event, data string }{
-		{"message_start", `{"type":"message_start","message":{"id":"msg_fake","type":"message","role":"assistant","model":"claude-sonnet-4-6","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":10,"output_tokens":0}}}`},
-		{"content_block_start", `{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`},
-		{"content_block_delta", `{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Your itinerary is saved."}}`},
-		{"content_block_stop", `{"type":"content_block_stop","index":0}`},
-		{"message_delta", `{"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":7}}`},
-		{"message_stop", `{"type":"message_stop"}`},
-	}
-	toolFrames := []struct{ event, data string }{
-		{"message_start", `{"type":"message_start","message":{"id":"msg_tool","type":"message","role":"assistant","model":"claude-sonnet-4-6","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":10,"output_tokens":0}}}`},
-		{"content_block_start", `{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_01","name":"create_itinerary","input":{}}}`},
-		{"content_block_delta", `{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"title\":\"Athens Weekend\",\"locations\":[{\"name\":\"Acropolis\",\"latitude\":37.97,\"longitude\":23.72,\"day\":1}]}"}}`},
-		{"content_block_stop", `{"type":"content_block_stop","index":0}`},
-		{"message_delta", `{"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"output_tokens":9}}`},
-		{"message_stop", `{"type":"message_stop"}`},
-	}
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		body, _ := io.ReadAll(r.Body)
-		frames := toolFrames
-		if strings.Contains(string(body), "tool_result") {
-			frames = textFrames
-		}
-		w.Header().Set("Content-Type", "text/event-stream")
-		w.WriteHeader(http.StatusOK)
-		for _, f := range frames {
-			io.WriteString(w, "event: "+f.event+"\ndata: "+f.data+"\n\n")
-		}
-	}))
-	t.Cleanup(srv.Close)
-	return srv
-}
-
 // Version saves must never re-emit the active_trips crossing signal
 // (specs/free-cap-instrumentation: "Saving a new version of an existing trip
 // does not increase the count and can never emit"). With the cap at 1 and one
@@ -273,9 +203,11 @@ func fakeAnthropicItineraryServer(t *testing.T) *httptest.Server {
 // regression this guards — must not emit again.
 func TestFreeCapActiveTripsVersionSaveNeverReemits(t *testing.T) {
 	resetDB(t)
-	srv := fakeAnthropicItineraryServer(t)
-	t.Setenv("ANTHROPIC_API_KEY", "test-key")
-	t.Setenv("ANTHROPIC_BASE_URL", srv.URL)
+	// Turn 0: finalize a trip (drives plan_handler's persistTrip branch);
+	// turn 1 (after the tool_result round-trips): a plain end_turn answer.
+	newFakeAnthropic(t,
+		toolTurn("create_itinerary", `{"title":"Athens Weekend","locations":[{"name":"Acropolis","latitude":37.97,"longitude":23.72,"day":1}]}`),
+		textTurn("Your itinerary is saved."))
 	t.Setenv("FREE_ACTIVE_TRIPS", "1") // envInt treats 0 as invalid, so park the user at cap via a seed trip
 
 	user, token := createTestUser(t, "re-finalizer@example.com")

--- a/src/packages/api/plan_handler.go
+++ b/src/packages/api/plan_handler.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
 	"net/http"
 	"os"
 	"strings"
@@ -95,6 +94,19 @@ func planHandler(w http.ResponseWriter, r *http.Request) {
 	// Resolve the caller once: anonymous sessions get no personalization and no
 	// preference-writing tool; signed-in sessions get both.
 	uid, authed := userIDFromRequest(r)
+	ctx := r.Context()
+
+	// session carries the per-request state the tool dispatchers need
+	// (plan_tool_registry.go) and the outcomes read back below: the persisted
+	// or refined trip id, and whether the profile distiller already fired.
+	session := &planSession{
+		ctx:    ctx,
+		w:      w,
+		req:    req,
+		client: client,
+		authed: authed,
+		uid:    uid,
+	}
 
 	// Session-level instrumentation for every caller — anonymous sessions
 	// carry a null user id, so total AI spend and the authed/anonymous split
@@ -104,7 +116,6 @@ func planHandler(w http.ResponseWriter, r *http.Request) {
 	var planCacheRead, planCacheWrite int64
 	var planToolCalls, planIterations int
 	var planCapHit bool
-	var planTripID *uuid.UUID
 	var planUID *uuid.UUID
 	if authed {
 		planUID = &uid
@@ -114,7 +125,7 @@ func planHandler(w http.ResponseWriter, r *http.Request) {
 	// degraded.
 	go recordPlanSessionStart(planUID, authed)
 	defer func() {
-		recordEventOpt(planUID, "plan_session_completed", planTripID, map[string]any{
+		recordEventOpt(planUID, "plan_session_completed", session.tripID, map[string]any{
 			"authenticated":         authed,
 			"input_tokens":          planTokensIn,
 			"output_tokens":         planTokensOut,
@@ -142,226 +153,16 @@ func planHandler(w http.ResponseWriter, r *http.Request) {
 		}
 		boundTripID = &tid
 	}
+	session.boundTripID = boundTripID
 
-	searchTool := anthropic.ToolParam{
-		Name:        "search_places",
-		Description: anthropic.String("Search for travel destinations, attractions, restaurants, or points of interest by name or description."),
-		InputSchema: anthropic.ToolInputSchemaParam{
-			Properties: map[string]any{
-				"query": map[string]any{
-					"type":        "string",
-					"description": "Search query, e.g. 'Eiffel Tower Paris' or 'best museums in Rome'",
-				},
-			},
-			Required: []string{"query"},
-		},
-	}
-	createTool := anthropic.ToolParam{
-		Name:        "create_itinerary",
-		Description: anthropic.String("Finalize the itinerary with the chosen list of locations to visit. Call this when you have identified all the places for the trip."),
-		InputSchema: anthropic.ToolInputSchemaParam{
-			Properties: map[string]any{
-				"locations": map[string]any{
-					"type":        "array",
-					"description": "Ordered list of locations to visit",
-					"items":       itineraryLocationSchema,
-				},
-				"title": map[string]any{
-					"type":        "string",
-					"description": "A short, human-friendly trip name, 3–6 words (e.g. 'Luxury Paris Weekend'). Distinct from the longer summary.",
-				},
-				"summary": map[string]any{
-					"type":        "string",
-					"description": "A 1–2 sentence overview of the trip to show the user (the per-day breakdown already appears in the itinerary list, so keep this brief).",
-				},
-				"start_date": map[string]any{
-					"type":        "string",
-					"description": "The trip's first day as YYYY-MM-DD (day 1). Include it whenever the traveler has given or agreed to travel dates.",
-				},
-				"end_date": map[string]any{
-					"type":        "string",
-					"description": "The trip's last day as YYYY-MM-DD. Optional — if omitted it's derived from start_date plus the number of days in the itinerary.",
-				},
-			},
-			Required: []string{"locations"},
-		},
-	}
-	savePrefsTool := anthropic.ToolParam{
-		Name:        "save_preferences",
-		Description: anthropic.String("Save what you learn about the traveler so future trips are personalized. Call this when the user reveals a budget level, trip pace, interests, which airport they fly from, or any other durable fact about how they travel. Only include fields you actually learned."),
-		InputSchema: anthropic.ToolInputSchemaParam{
-			Properties: map[string]any{
-				"budget": map[string]any{
-					"type":        "string",
-					"enum":        []string{"budget", "mid", "luxury"},
-					"description": "Overall spending level",
-				},
-				"pace": map[string]any{
-					"type":        "string",
-					"enum":        []string{"relaxed", "balanced", "packed"},
-					"description": "How packed the days should be",
-				},
-				"interests": map[string]any{
-					"type":        "array",
-					"items":       map[string]any{"type": "string"},
-					"description": "Theme tags, e.g. museums, food, nightlife, nature",
-				},
-				"home_airport": map[string]any{
-					"type":        "string",
-					"description": "The traveler's home/departure airport as an IATA code, e.g. BOS — save it when they mention where they usually fly from",
-				},
-				"profile_notes": map[string]any{
-					"type":        "string",
-					"description": "The COMPLETE updated traveler profile as short bullet lines — your current notes (shown in the system prompt) merged with the new fact, de-duplicated, max ~15 lines. Never send only the new fact; always send the full rewritten profile.",
-				},
-			},
-		},
-	}
-
-	suggestStaysTool := anthropic.ToolParam{
-		Name:        "suggest_stays",
-		Description: anthropic.String("Give the traveler links to browse accommodations on Airbnb and Booking.com for a destination. Call this when they want lodging suggestions."),
-		InputSchema: anthropic.ToolInputSchemaParam{
-			Properties: map[string]any{
-				"destination": map[string]any{"type": "string", "description": "City or area, e.g. 'Paris'"},
-				"check_in":    map[string]any{"type": "string", "description": "Optional YYYY-MM-DD"},
-				"check_out":   map[string]any{"type": "string", "description": "Optional YYYY-MM-DD"},
-				"guests":      map[string]any{"type": "integer", "description": "Optional number of guests"},
-			},
-			Required: []string{"destination"},
-		},
-	}
-
-	suggestTransportTool := anthropic.ToolParam{
-		Name:        "suggest_transport",
-		Description: anthropic.String("Give the traveler links to browse transport options. Call this when they need to get to or between destinations. Mode 'flight' returns Google Flights + Kayak; mode 'ground' returns Rome2Rio (covers trains, buses, cars, ferries). For travel between Greek islands, prefer suggest_ferries instead."),
-		InputSchema: anthropic.ToolInputSchemaParam{
-			Properties: map[string]any{
-				"mode":        map[string]any{"type": "string", "enum": []string{"flight", "ground"}, "description": "flight or ground (multimodal)"},
-				"origin":      map[string]any{"type": "string", "description": "Origin city or airport, e.g. 'NYC' or 'Paris'"},
-				"destination": map[string]any{"type": "string", "description": "Destination city or airport"},
-				"depart_date": map[string]any{"type": "string", "description": "Optional YYYY-MM-DD"},
-				"return_date": map[string]any{"type": "string", "description": "Optional YYYY-MM-DD (flights only)"},
-				"passengers":  map[string]any{"type": "integer", "description": "Optional passenger count"},
-			},
-			Required: []string{"mode", "origin", "destination"},
-		},
-	}
-
-	suggestFerriesTool := anthropic.ToolParam{
-		Name:        "suggest_ferries",
-		Description: anthropic.String("Give the traveler a ferry booking link for a route between two ports/islands — use this for Greek island-hopping (e.g. Santorini→Naxos) and other ferry legs. Backed by Ferryhopper, which aggregates the major Greek operators (Blue Star, SeaJets, etc.)."),
-		InputSchema: anthropic.ToolInputSchemaParam{
-			Properties: map[string]any{
-				"origin":      map[string]any{"type": "string", "description": "Departure port or island, e.g. 'Santorini' or 'Piraeus'"},
-				"destination": map[string]any{"type": "string", "description": "Arrival port or island, e.g. 'Naxos'"},
-				"date":        map[string]any{"type": "string", "description": "Optional YYYY-MM-DD travel date"},
-				"passengers":  map[string]any{"type": "integer", "description": "Optional passenger count"},
-			},
-			Required: []string{"origin", "destination"},
-		},
-	}
-
-	searchFlightsTool := anthropic.ToolParam{
-		Name: "search_flights",
-		Description: anthropic.String("Search real flight options between two places for given dates and present a few good ones (ranked by overall desirability). " +
-			"Ask the traveler for their departure city/airport and travel dates first if you don't know them. " +
-			"origin/destination may be city names or IATA codes. Choose optimize_for from the traveler's budget: budget→'cost', luxury→'time', otherwise 'balanced'."),
-		InputSchema: anthropic.ToolInputSchemaParam{
-			Properties: map[string]any{
-				"origin":       map[string]any{"type": "string", "description": "Departure city or IATA code, e.g. 'Boston' or 'BOS'"},
-				"destination":  map[string]any{"type": "string", "description": "Arrival city or IATA code"},
-				"depart_date":  map[string]any{"type": "string", "description": "YYYY-MM-DD"},
-				"return_date":  map[string]any{"type": "string", "description": "Optional YYYY-MM-DD for round trips"},
-				"adults":       map[string]any{"type": "integer", "description": "Optional, defaults to 1"},
-				"child_ages":   map[string]any{"type": "array", "items": map[string]any{"type": "integer"}, "description": "Optional ages of child travelers (one per child, 0-17) — include when the traveler mentions kids"},
-				"cabin_class":  map[string]any{"type": "string", "enum": []string{"economy", "premium_economy", "business", "first"}, "description": "Optional cabin, defaults to economy — set when the traveler asks for a specific class"},
-				"optimize_for": map[string]any{"type": "string", "enum": []string{"cost", "time", "balanced"}, "description": "Ranking emphasis"},
-			},
-			Required: []string{"origin", "destination", "depart_date"},
-		},
-	}
-
-	searchEventsTool := anthropic.ToolParam{
-		Name: "search_events",
-		Description: anthropic.String("Find local events (concerts, sports, festivals, theatre/shows) happening in a city during specific dates, so the itinerary can account for what's on while the traveler is there. " +
-			"Use the city and the dates the traveler is in that city; you already know the trip's cities and dates from the itinerary. " +
-			"Present a few that fit the traveler's interests."),
-		InputSchema: anthropic.ToolInputSchemaParam{
-			Properties: map[string]any{
-				"city":       map[string]any{"type": "string", "description": "City name, e.g. 'Paris'"},
-				"start_date": map[string]any{"type": "string", "description": "First day to look from, YYYY-MM-DD (when the traveler arrives in the city)"},
-				"end_date":   map[string]any{"type": "string", "description": "Last day to look through, YYYY-MM-DD (when the traveler leaves the city)"},
-				"category":   map[string]any{"type": "string", "enum": []string{"music", "sports", "arts", "film", "miscellaneous"}, "description": "Optional event category filter"},
-			},
-			Required: []string{"city", "start_date", "end_date"},
-		},
-	}
-
-	searchLocalRecsTool := anthropic.ToolParam{
-		Name: "search_local_recommendations",
-		Description: anthropic.String("Find hand-curated recommendations from real locals for a city — vetted spots you can't get by googling. " +
-			"ALWAYS call this FIRST for each city, before search_places. Prefer these picks over generic search results, and when you use one, cite the local by name in your reply (their name is in 'source_name'). " +
-			"When you pass a local pick into create_itinerary, copy its 'id' into local_recommendation_id and its 'source_name' into local_source_name so the saved trip credits them."),
-		InputSchema: anthropic.ToolInputSchemaParam{
-			Properties: map[string]any{
-				"city":     map[string]any{"type": "string", "description": "City name, e.g. 'Lisbon'"},
-				"category": map[string]any{"type": "string", "enum": []string{"attraction", "restaurant"}, "description": "Optional filter to only sights or only places to eat"},
-			},
-			Required: []string{"city"},
-		},
-	}
-
-	updateSectionTool := anthropic.ToolParam{
-		Name:        "update_itinerary_section",
-		Description: anthropic.String("Replace one section of the traveler's saved itinerary in place. Pass the COMPLETE updated list of places for the targeted section, in visit order — places you omit are removed from that section. Places outside the section are untouched. Use scope 'day' for a single trip day, 'city' for one city/hub and its day trips, or 'trip' for the whole itinerary."),
-		InputSchema: anthropic.ToolInputSchemaParam{
-			Properties: map[string]any{
-				"scope": map[string]any{
-					"type":        "string",
-					"enum":        []string{"day", "city", "trip"},
-					"description": "Which slice of the itinerary to replace.",
-				},
-				"day": map[string]any{
-					"type":        "integer",
-					"description": "Required when scope is 'day': the 1-based trip day being replaced.",
-				},
-				"city": map[string]any{
-					"type":        "string",
-					"description": "Required when scope is 'city' (the hub city whose items are replaced); optional with scope 'day' to disambiguate when day numbers repeat across cities.",
-				},
-				"items": map[string]any{
-					"type":        "array",
-					"description": "The full replacement list for the section, in visit order. Include unchanged places with their existing coordinates and tags so they aren't lost.",
-					"items":       itineraryLocationSchema,
-				},
-			},
-			Required: []string{"scope", "items"},
-		},
-	}
-
-	tools := []anthropic.ToolUnionParam{
-		{OfTool: &searchTool},
-		{OfTool: &suggestStaysTool},
-		{OfTool: &suggestTransportTool},
-		{OfTool: &suggestFerriesTool},
-		{OfTool: &searchFlightsTool},
-		{OfTool: &searchEventsTool},
-		{OfTool: &searchLocalRecsTool},
-		{OfTool: &getWeatherTool},
-	}
-	// Trip-bound sessions get the in-place section tool instead of
-	// create_itinerary, so a refinement can never spawn a new trip version.
-	if boundTripID != nil {
-		tools = append(tools, anthropic.ToolUnionParam{OfTool: &updateSectionTool})
-	} else {
-		tools = append(tools, anthropic.ToolUnionParam{OfTool: &createTool})
-	}
-	if authed {
-		tools = append(tools, anthropic.ToolUnionParam{OfTool: &savePrefsTool})
-		tools = append(tools, anthropic.ToolUnionParam{OfTool: &getTripTool})
-		tools = append(tools, anthropic.ToolUnionParam{OfTool: &addBookingTodoTool})
-	}
+	// The tool table (plan_tool_registry.go) is the single source of truth for
+	// what the agent can do: the tools slice sent to the API is generated from
+	// it in registry order (order-stable — the tools array is part of the
+	// prompt-cache prefix that the system-prompt cache breakpoint covers), and
+	// tool_use blocks dispatch through it below. Trip-bound sessions get the
+	// in-place section tool instead of create_itinerary, so a refinement can
+	// never spawn a new trip version; personalization tools are signed-in only.
+	tools := planSessionTools(session)
 
 	var messages []anthropic.MessageParam
 	for _, m := range req.Messages {
@@ -374,9 +175,6 @@ func planHandler(w http.ResponseWriter, r *http.Request) {
 
 	today := time.Now()
 	basePrompt := "You are an expert travel agent. Today's date is " + today.Format("Monday, January 2, 2006") + " (" + today.Format("2006-01-02") + "). When a traveler gives a date without a year, assume the soonest upcoming occurrence on or after today — never a past year. Use dates in YYYY-MM-DD form when calling tools. Help users plan trips by searching for specific places and attractions. For each city, ALWAYS call search_local_recommendations FIRST — these are hand-curated picks from real locals, the legit info you can't get by googling. Prefer them over generic results, build the itinerary around them where they fit the traveler, and cite the local by name in your reply (e.g. 'Ana, a Lisbon chef, swears by…'). When a local pick becomes an itinerary place, carry its id into local_recommendation_id and its source_name into local_source_name. Then use search_places to fill gaps and find any other real locations with coordinates. Search for individual places (e.g. 'Louvre Museum Paris') rather than broad queries. Include a mix of activities/attractions and dining (restaurants), guided by the traveler's interests, budget, and pace. When you call create_itinerary, tag each location with category ('attraction' or 'restaurant'), a time_of_day ('morning', 'afternoon', or 'evening'), and a day (the 1-based trip day it falls on, increasing chronologically across the whole trip) so each day reads as a sensible schedule. When you have gathered enough places for the user's trip, call create_itinerary to finalize the plan; pass start_date (and end_date) whenever the traveler has given or agreed to travel dates, with day 1 being the start date. You can also use search_flights to find real flight options — ask for the traveler's departure city/airport and dates if you don't know them, and pick optimize_for from their budget (budget→cost, luxury→time, otherwise balanced); summarize the top 2-3 options in your own words and help them choose — do not tell the traveler to look at cards or lists in the chat. For travel between Greek islands, use suggest_ferries (ferries are the primary way to island-hop); note that in Greece search_events returns curated source links rather than ticketed listings. Use get_weather when weather changes the advice — packing, outdoor days, beach or ski viability, seasonal closures; for far-off dates it returns last year's weather as a seasonal guide, so present it as 'typically', never as a forecast. For signed-in travelers: when they reference a trip you've already planned together, call get_trip to read what's saved instead of asking them to repeat it; and when you give time-sensitive booking advice about a saved trip (book the ferry, reserve that restaurant), call add_booking_todo so it lands on their checklist instead of getting lost in chat. Be conversational and helpful — ask clarifying questions if needed before searching. Format replies with light markdown — short paragraphs, **bold** for place names, hyphen lists — no headings or tables."
-
-	ctx := r.Context()
-	distilled := false
 
 	// Fold the signed-in traveler's saved preferences into the system prompt.
 	// The profile-keeping instruction applies even before any row exists, so
@@ -462,336 +260,17 @@ func planHandler(w http.ResponseWriter, r *http.Request) {
 			sendSSE(w, "tool_call", map[string]string{"name": variant.Name})
 			planToolCalls++
 
-			switch variant.Name {
-			case "search_places":
-				var in struct {
-					Query string `json:"query"`
-				}
-				json.Unmarshal(variant.Input, &in)
-
-				results, err := placesService.SearchPlaces(in.Query)
-				var resultStr string
-				if err != nil {
-					resultStr = fmt.Sprintf("Error searching places: %v", err)
-				} else {
-					b, _ := json.Marshal(results)
-					resultStr = string(b)
-				}
-				sendSSE(w, "tool_result", map[string]string{"name": "search_places"})
-				toolResults = append(toolResults, anthropic.NewToolResultBlock(variant.ID, resultStr, err != nil))
-
-			case "create_itinerary":
-				var in struct {
-					Locations []map[string]any `json:"locations"`
-					Title     string           `json:"title"`
-					Summary   string           `json:"summary"`
-					StartDate string           `json:"start_date"`
-					EndDate   string           `json:"end_date"`
-				}
-				json.Unmarshal(variant.Input, &in)
-
-				// Distance-optimize the walking order within each day/time-of-day
-				// block, leaving Claude's day and time-of-day assignments intact.
-				in.Locations = reorderItineraryByDistance(in.Locations)
-
-				donePayload := map[string]any{"locations": in.Locations, "summary": in.Summary}
-				// Persist the trip only for signed-in callers; anonymous sessions
-				// stay ephemeral (no trip_id in the done event).
-				if authed {
-					if tripID, newLineage, err := persistTrip(ctx, uid, req.ChatID, in.Title, in.Summary, in.StartDate, in.EndDate, in.Locations); err != nil {
-						log.Printf("failed to persist trip: %v", err)
-					} else {
-						donePayload["trip_id"] = tripID
-						if parsed, err := uuid.Parse(tripID); err == nil {
-							planTripID = &parsed
-							go recordEvent(uid, "trip_created", &parsed, map[string]any{
-								"item_count": len(in.Locations),
-							})
-							// Free-cap active_trips crossing signal — only a
-							// brand-new lineage can move the lineage count; a
-							// version save of an existing chat lineage leaves
-							// it unchanged and must never emit
-							// (specs/free-cap-instrumentation).
-							if newLineage {
-								go recordActiveTripsCapSignal(uid, parsed)
-							}
-						}
-						// Distill what this conversation revealed about the traveler
-						// in the background — it must never delay or fail the trip.
-						// context.Background(): the request ctx dies with the handler.
-						if !distilled {
-							distilled = true
-							go distillTravelerProfile(context.Background(), client, uid, req.Messages)
-						}
-					}
-				}
-				sendSSE(w, "done", donePayload)
-				toolResults = append(toolResults, anthropic.NewToolResultBlock(variant.ID, "Itinerary created successfully.", false))
-
-			case "update_itinerary_section":
-				var in struct {
-					Scope string           `json:"scope"`
-					Day   *int             `json:"day"`
-					City  string           `json:"city"`
-					Items []map[string]any `json:"items"`
-				}
-				json.Unmarshal(variant.Input, &in)
-
-				msg := "Section updated — the traveler's trip page has refreshed."
-				var err error
-				if boundTripID == nil {
-					err = fmt.Errorf("no trip is bound to this session")
-					msg = "This session is not bound to a saved trip; update_itinerary_section is unavailable."
-				} else {
-					// Same in-block walking-distance cleanup create_itinerary gets.
-					in.Items = reorderItineraryByDistance(in.Items)
-					if err = replaceTripSection(ctx, *boundTripID, sectionSelector{Scope: in.Scope, Day: in.Day, City: in.City}, in.Items); err != nil {
-						msg = fmt.Sprintf("Could not update the section: %v", err)
-					} else {
-						sendSSE(w, "trip_updated", map[string]string{"trip_id": boundTripID.String()})
-						planTripID = boundTripID
-						go recordEvent(uid, "trip_refined", boundTripID, map[string]any{
-							"scope": in.Scope,
-						})
-					}
-				}
-				sendSSE(w, "tool_result", map[string]string{"name": "update_itinerary_section"})
-				toolResults = append(toolResults, anthropic.NewToolResultBlock(variant.ID, msg, err != nil))
-
-			case "save_preferences":
-				var in struct {
-					Budget       *string  `json:"budget"`
-					Pace         *string  `json:"pace"`
-					Interests    []string `json:"interests"`
-					HomeAirport  *string  `json:"home_airport"`
-					ProfileNotes *string  `json:"profile_notes"`
-				}
-				json.Unmarshal(variant.Input, &in)
-
-				budget, _ := normalizeChoice(in.Budget, allowedBudgets, "budget")
-				pace, _ := normalizeChoice(in.Pace, allowedPaces, "pace")
-				homeAirport, _ := normalizeAirportCode(in.HomeAirport)
-				var interestsArg interface{}
-				if in.Interests != nil {
-					interestsArg = normalizeInterests(in.Interests)
-				}
-				notes := normalizeNotes(in.ProfileNotes)
-				if notes != nil && *notes == "" {
-					// The agent can never wipe notes; only the user (PUT) can clear.
-					notes = nil
-				}
-				_, err := store.New(dbPool).UpsertPreferences(ctx, store.UpsertPreferencesParams{
-					UserID: uid, Budget: budget, Pace: pace, Interests: interestsArg, HomeAirport: homeAirport, ProfileNotes: notes,
-				})
-				msg := "Preferences saved."
-				if err != nil {
-					msg = fmt.Sprintf("Could not save preferences: %v", err)
-				} else {
-					var changed []string
-					if budget != nil {
-						changed = append(changed, "budget")
-					}
-					if pace != nil {
-						changed = append(changed, "pace")
-					}
-					if interestsArg != nil {
-						changed = append(changed, "interests")
-					}
-					if homeAirport != nil {
-						changed = append(changed, "home_airport")
-					}
-					if notes != nil {
-						changed = append(changed, "profile_notes")
-					}
-					if len(changed) > 0 {
-						sendSSE(w, "profile_updated", map[string]any{
-							"fields": changed, "notes_preview": notesPreview(notes),
-						})
-					}
-				}
-				sendSSE(w, "tool_result", map[string]string{"name": "save_preferences"})
-				toolResults = append(toolResults, anthropic.NewToolResultBlock(variant.ID, msg, err != nil))
-
-			case "suggest_stays":
-				var in struct {
-					Destination string `json:"destination"`
-					CheckIn     string `json:"check_in"`
-					CheckOut    string `json:"check_out"`
-					Guests      int    `json:"guests"`
-				}
-				json.Unmarshal(variant.Input, &in)
-				links := providerLinks(AccommodationQuery{
-					Destination: in.Destination, CheckIn: in.CheckIn, CheckOut: in.CheckOut, Guests: in.Guests,
-				})
-				sendSSE(w, "stays", map[string]any{"destination": in.Destination, "links": links})
-				sendSSE(w, "tool_result", map[string]string{"name": "suggest_stays"})
-				b, _ := json.Marshal(links)
-				toolResults = append(toolResults, anthropic.NewToolResultBlock(variant.ID, "Provided browse links: "+string(b), false))
-
-			case "suggest_transport":
-				var in struct {
-					Mode        string `json:"mode"`
-					Origin      string `json:"origin"`
-					Destination string `json:"destination"`
-					DepartDate  string `json:"depart_date"`
-					ReturnDate  string `json:"return_date"`
-					Passengers  int    `json:"passengers"`
-				}
-				json.Unmarshal(variant.Input, &in)
-				links := transportLinks(TransportQuery{
-					Mode: in.Mode, Origin: in.Origin, Destination: in.Destination,
-					DepartDate: in.DepartDate, ReturnDate: in.ReturnDate, Passengers: in.Passengers,
-				})
-				sendSSE(w, "transport", map[string]any{
-					"mode": in.Mode, "origin": in.Origin, "destination": in.Destination, "links": links,
-				})
-				sendSSE(w, "tool_result", map[string]string{"name": "suggest_transport"})
-				b, _ := json.Marshal(links)
-				toolResults = append(toolResults, anthropic.NewToolResultBlock(variant.ID, "Provided browse links: "+string(b), false))
-
-			case "suggest_ferries":
-				var in struct {
-					Origin      string `json:"origin"`
-					Destination string `json:"destination"`
-					Date        string `json:"date"`
-					Passengers  int    `json:"passengers"`
-				}
-				json.Unmarshal(variant.Input, &in)
-				options := ferryService.SearchFerries(FerryQuery{
-					Origin: in.Origin, Destination: in.Destination,
-					Date: in.Date, Passengers: in.Passengers,
-				})
-				sendSSE(w, "ferries", map[string]any{
-					"origin": in.Origin, "destination": in.Destination, "options": options,
-				})
-				sendSSE(w, "tool_result", map[string]string{"name": "suggest_ferries"})
-				b, _ := json.Marshal(options)
-				toolResults = append(toolResults, anthropic.NewToolResultBlock(variant.ID, "Provided ferry booking link(s): "+string(b), false))
-
-			case "search_flights":
-				var in struct {
-					Origin      string `json:"origin"`
-					Destination string `json:"destination"`
-					DepartDate  string `json:"depart_date"`
-					ReturnDate  string `json:"return_date"`
-					Adults      int    `json:"adults"`
-					ChildAges   []int  `json:"child_ages"`
-					CabinClass  string `json:"cabin_class"`
-					OptimizeFor string `json:"optimize_for"`
-				}
-				json.Unmarshal(variant.Input, &in)
-
-				originIata := resolveIATA(ctx, in.Origin)
-				destIata := resolveIATA(ctx, in.Destination)
-				if originIata == "" || destIata == "" {
-					sendSSE(w, "tool_result", map[string]string{"name": "search_flights"})
-					msg := fmt.Sprintf("Could not resolve %q or %q to an airport. Ask the traveler to clarify the city or airport.", in.Origin, in.Destination)
-					toolResults = append(toolResults, anthropic.NewToolResultBlock(variant.ID, msg, true))
-					break
-				}
-
-				adults := in.Adults
-				if adults < 1 {
-					adults = 1
-				}
-				offers, err := duffelService.SearchFlightOffers(ctx, FlightSearchRequest{
-					Origin: originIata, Destination: destIata, DepartDate: in.DepartDate,
-					ReturnDate: in.ReturnDate, Adults: adults, ChildAges: in.ChildAges,
-					CabinClass: in.CabinClass, OptimizeFor: in.OptimizeFor,
-				})
-				if err != nil {
-					sendSSE(w, "tool_result", map[string]string{"name": "search_flights"})
-					toolResults = append(toolResults, anthropic.NewToolResultBlock(variant.ID, fmt.Sprintf("Error searching flights: %v", err), true))
-					break
-				}
-
-				bestN := RankFlightOffers(offers, in.OptimizeFor)
-				if len(bestN) > 4 {
-					bestN = bestN[:4]
-				}
-				attachBookingURLs(bestN, FlightSearchRequest{
-					Origin: originIata, Destination: destIata,
-					DepartDate: in.DepartDate, ReturnDate: in.ReturnDate, Adults: adults,
-				})
-				if len(bestN) > 0 {
-					sendSSE(w, "flights", map[string]any{
-						"origin": originIata, "destination": destIata,
-						"depart_date": in.DepartDate, "optimize_for": normalizeOptimizeFor(in.OptimizeFor),
-						"offers": bestN,
-					})
-				}
-				sendSSE(w, "tool_result", map[string]string{"name": "search_flights"})
-				toolResults = append(toolResults, anthropic.NewToolResultBlock(variant.ID, summarizeOffers(originIata, destIata, bestN), false))
-
-			case "search_events":
-				var in struct {
-					City      string  `json:"city"`
-					StartDate string  `json:"start_date"`
-					EndDate   string  `json:"end_date"`
-					Category  *string `json:"category"`
-				}
-				json.Unmarshal(variant.Input, &in)
-
-				events, err := eventsService.SearchEvents(ctx, in.City, in.StartDate, in.EndDate, in.Category)
-				if len(events) > 0 {
-					sendSSE(w, "events", map[string]any{
-						"city":       in.City,
-						"start_date": in.StartDate,
-						"end_date":   in.EndDate,
-						"events":     events,
-					})
-				}
-
-				// Greece has no usable events API, so when the structured lookup
-				// comes back empty (or errors, e.g. no key) for a Greek city, fall
-				// back to curated Greek source links instead of nothing.
-				summary := summarizeEvents(in.City, events)
-				if len(events) == 0 && isGreekLocation(in.City) {
-					links := greekEventLinks(in.City, in.StartDate, in.EndDate)
-					sendSSE(w, "event_links", map[string]any{"city": in.City, "links": links})
-					b, _ := json.Marshal(links)
-					summary = "No ticketed listings via the events provider for " + in.City +
-						". Provided Greek event-discovery links: " + string(b)
-				} else if err != nil {
-					summary = fmt.Sprintf("Error searching events: %v", err)
-				}
-
-				sendSSE(w, "tool_result", map[string]string{"name": "search_events"})
-				toolResults = append(toolResults, anthropic.NewToolResultBlock(variant.ID, summary, err != nil && len(events) == 0 && !isGreekLocation(in.City)))
-
-			case "search_local_recommendations":
-				var in struct {
-					City     string `json:"city"`
-					Category string `json:"category"`
-				}
-				json.Unmarshal(variant.Input, &in)
-
-				recs, err := localRecsService.SearchByCity(ctx, in.City, in.Category)
-				if len(recs) > 0 {
-					sendSSE(w, "local_recs", map[string]any{"city": in.City, "recommendations": recs})
-				}
-				summary := summarizeLocalRecs(in.City, recs)
-				if err != nil {
-					summary = fmt.Sprintf("Error searching local recommendations: %v", err)
-				}
-				sendSSE(w, "tool_result", map[string]string{"name": "search_local_recommendations"})
-				toolResults = append(toolResults, anthropic.NewToolResultBlock(variant.ID, summary, err != nil))
-
-			case "get_weather":
-				result, isErr := runGetWeatherTool(ctx, variant.Input)
-				sendSSE(w, "tool_result", map[string]string{"name": "get_weather"})
-				toolResults = append(toolResults, anthropic.NewToolResultBlock(variant.ID, result, isErr))
-
-			case "get_trip":
-				result, isErr := runGetTripTool(ctx, authed, uid, variant.Input)
-				sendSSE(w, "tool_result", map[string]string{"name": "get_trip"})
-				toolResults = append(toolResults, anthropic.NewToolResultBlock(variant.ID, result, isErr))
-
-			case "add_booking_todo":
-				result, isErr := runAddBookingTodoTool(ctx, authed, uid, variant.Input)
-				sendSSE(w, "tool_result", map[string]string{"name": "add_booking_todo"})
-				toolResults = append(toolResults, anthropic.NewToolResultBlock(variant.ID, result, isErr))
+			entry := planToolByName[variant.Name]
+			if entry == nil {
+				// Matches the old switch's no-case fallthrough: an unknown tool
+				// name gets no result block (the API only calls defined tools).
+				continue
 			}
+			result, isErr := entry.run(session, variant.Input)
+			if !entry.noResultEvent {
+				sendSSE(w, "tool_result", map[string]string{"name": variant.Name})
+			}
+			toolResults = append(toolResults, anthropic.NewToolResultBlock(variant.ID, result, isErr))
 		}
 
 		messages = append(messages, anthropic.NewUserMessage(toolResults...))

--- a/src/packages/api/plan_integration_test.go
+++ b/src/packages/api/plan_integration_test.go
@@ -1,0 +1,350 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+// End-to-end /plan coverage through buildRouter, with the Anthropic API
+// replaced by the scriptable fake (fake_anthropic_test.go). Each test drives
+// a real SSE session — request validation, the agent tool loop, tool
+// execution against the test DB, persistence, and the client-facing event
+// stream — with zero external calls.
+
+// planEvents parses every `data: {...}` SSE line the /plan handler wrote.
+func planEvents(t *testing.T, body string) []map[string]any {
+	t.Helper()
+	var events []map[string]any
+	for _, line := range strings.Split(body, "\n") {
+		data, ok := strings.CutPrefix(line, "data: ")
+		if !ok {
+			continue
+		}
+		var m map[string]any
+		if err := json.Unmarshal([]byte(data), &m); err != nil {
+			t.Fatalf("unparseable SSE data line %q: %v", line, err)
+		}
+		events = append(events, m)
+	}
+	return events
+}
+
+func eventsOfType(events []map[string]any, typ string) []map[string]any {
+	var out []map[string]any
+	for _, e := range events {
+		if e["type"] == typ {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// eventData returns the event's data payload as a map (nil if absent).
+func eventData(e map[string]any) map[string]any {
+	d, _ := e["data"].(map[string]any)
+	return d
+}
+
+// joinedText reassembles the streamed answer from text_delta events.
+func joinedText(events []map[string]any) string {
+	var b strings.Builder
+	for _, e := range eventsOfType(events, "text_delta") {
+		if txt, ok := eventData(e)["text"].(string); ok {
+			b.WriteString(txt)
+		}
+	}
+	return b.String()
+}
+
+// (a) A text-only turn streams multiple deltas that reassemble to the full
+// answer, with no error event — the plain conversational path.
+func TestPlanTextTurnStreamsDeltas(t *testing.T) {
+	resetDB(t)
+	const answer = "Lisbon in May is lovely — shall I plan three days?"
+	newFakeAnthropic(t, textTurn(answer))
+
+	rec := doJSON(t, "POST", "/api/v1/plan", "", PlanRequest{
+		ChatID:   "chat-text",
+		Messages: []PlanChatMessage{{Role: "user", Content: "where should I go in May?"}},
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("/plan = %d, want 200", rec.Code)
+	}
+	events := planEvents(t, rec.Body.String())
+	if deltas := eventsOfType(events, "text_delta"); len(deltas) < 2 {
+		t.Fatalf("text_delta events = %d, want >= 2 (the fake splits text across frames)", len(deltas))
+	}
+	if got := joinedText(events); got != answer {
+		t.Fatalf("reassembled text = %q, want %q", got, answer)
+	}
+	if errs := eventsOfType(events, "error"); len(errs) != 0 {
+		t.Fatalf("unexpected error events: %v", errs)
+	}
+}
+
+// (b) Tool loop: the model requests the DB-backed get_trip tool, the handler
+// executes it against the test DB, the tool_result round-trips to the model
+// (asserted on the fake's second request body), and the final text streams.
+func TestPlanToolLoopRoundTripsToolResult(t *testing.T) {
+	resetDB(t)
+	fa := newFakeAnthropic(t,
+		toolTurn("get_trip", `{}`),
+		textTurn("You have one saved trip: Test Trip."))
+
+	user, token := createTestUser(t, "tool-loop@example.com")
+	createTestTrip(t, user.ID, 2)
+
+	rec := doJSON(t, "POST", "/api/v1/plan", token, PlanRequest{
+		ChatID:   "chat-tools",
+		Messages: []PlanChatMessage{{Role: "user", Content: "what trips do I have saved?"}},
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("/plan = %d, want 200", rec.Code)
+	}
+	events := planEvents(t, rec.Body.String())
+
+	calls := eventsOfType(events, "tool_call")
+	if len(calls) != 1 || eventData(calls[0])["name"] != "get_trip" {
+		t.Fatalf("tool_call events = %v, want exactly one get_trip", calls)
+	}
+	results := eventsOfType(events, "tool_result")
+	if len(results) != 1 || eventData(results[0])["name"] != "get_trip" {
+		t.Fatalf("tool_result events = %v, want exactly one get_trip", results)
+	}
+	if got := joinedText(events); got != "You have one saved trip: Test Trip." {
+		t.Fatalf("final text = %q", got)
+	}
+	if errs := eventsOfType(events, "error"); len(errs) != 0 {
+		t.Fatalf("unexpected error events: %v", errs)
+	}
+
+	// The second model request must carry the executed tool's result back —
+	// including content that only exists in the database.
+	reqs := fa.requestBodies()
+	if len(reqs) != 2 {
+		t.Fatalf("model requests = %d, want 2 (tool turn + follow-up)", len(reqs))
+	}
+	followUp := string(reqs[1])
+	if !strings.Contains(followUp, `"tool_result"`) {
+		t.Fatalf("follow-up request carries no tool_result block: %s", followUp)
+	}
+	if !strings.Contains(followUp, "Test Trip") {
+		t.Fatalf("tool_result did not round-trip DB content (missing trip title): %s", followUp)
+	}
+}
+
+// (c) create_itinerary end-to-end: the streamed `done` event carries a
+// trip_id, and that trip — title, summary and items — is really persisted.
+func TestPlanCreateItineraryPersistsTrip(t *testing.T) {
+	resetDB(t)
+	newFakeAnthropic(t,
+		toolTurn("create_itinerary", `{
+			"title":"Athens Weekend","summary":"Two easy days in Athens.",
+			"locations":[
+				{"name":"Acropolis","latitude":37.9715,"longitude":23.7267,"day":1,"city":"Athens","category":"attraction","time_of_day":"morning"},
+				{"name":"Ta Karamanlidika","latitude":37.9808,"longitude":23.7247,"day":1,"city":"Athens","category":"restaurant","time_of_day":"evening"}
+			]}`),
+		textTurn("Saved your Athens weekend!"))
+
+	user, token := createTestUser(t, "finalizer@example.com")
+
+	rec := doJSON(t, "POST", "/api/v1/plan", token, PlanRequest{
+		ChatID:   "chat-athens",
+		Messages: []PlanChatMessage{{Role: "user", Content: "plan me a weekend in Athens"}},
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("/plan = %d, want 200", rec.Code)
+	}
+	events := planEvents(t, rec.Body.String())
+
+	dones := eventsOfType(events, "done")
+	if len(dones) != 1 {
+		t.Fatalf("done events = %d, want 1", len(dones))
+	}
+	done := eventData(dones[0])
+	tripID, _ := done["trip_id"].(string)
+	if tripID == "" {
+		t.Fatalf("done event carries no trip_id: %v", done)
+	}
+	if locs, _ := done["locations"].([]any); len(locs) != 2 {
+		t.Fatalf("done event locations = %v, want 2", done["locations"])
+	}
+	if errs := eventsOfType(events, "error"); len(errs) != 0 {
+		t.Fatalf("unexpected error events: %v", errs)
+	}
+
+	// The trip is readable through the normal REST surface.
+	tripRec := doJSON(t, "GET", "/api/v1/trips/"+tripID, token, nil)
+	if tripRec.Code != http.StatusOK {
+		t.Fatalf("GET trip = %d: %s", tripRec.Code, tripRec.Body.String())
+	}
+	trip := decode(t, tripRec)
+	if trip["title"] != "Athens Weekend" {
+		t.Fatalf("persisted title = %v, want Athens Weekend", trip["title"])
+	}
+	items, _ := trip["items"].([]any)
+	if len(items) != 2 {
+		t.Fatalf("persisted items = %d, want 2", len(items))
+	}
+
+	// Settle the async trip_created analytics before the next test truncates.
+	waitForEventCount(t, user.ID, "trip_created", 1)
+}
+
+// (c, trip-bound) update_itinerary_section on a bound trip replaces the
+// section in the DB and streams a trip_updated event with the trip's id.
+func TestPlanBoundSessionUpdatesSectionAndStreamsTripUpdated(t *testing.T) {
+	resetDB(t)
+	newFakeAnthropic(t,
+		toolTurn("update_itinerary_section", `{"scope":"trip","items":[{"name":"New Cafe","latitude":37.98,"longitude":23.74,"day":1}]}`),
+		textTurn("Swapped the whole plan for the cafe."))
+
+	user, token := createTestUser(t, "refiner@example.com")
+	trip := createTestTrip(t, user.ID, 2)
+
+	rec := doJSON(t, "POST", "/api/v1/plan", token, PlanRequest{
+		TripID:   trip.ID.String(),
+		Messages: []PlanChatMessage{{Role: "user", Content: "replace everything with one cafe"}},
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("/plan = %d, want 200", rec.Code)
+	}
+	events := planEvents(t, rec.Body.String())
+
+	updated := eventsOfType(events, "trip_updated")
+	if len(updated) != 1 || eventData(updated[0])["trip_id"] != trip.ID.String() {
+		t.Fatalf("trip_updated events = %v, want exactly one for trip %s", updated, trip.ID)
+	}
+	if errs := eventsOfType(events, "error"); len(errs) != 0 {
+		t.Fatalf("unexpected error events: %v", errs)
+	}
+	// A bound session must never create a new trip version.
+	if dones := eventsOfType(events, "done"); len(dones) != 0 {
+		t.Fatalf("unexpected done events on a bound session: %v", dones)
+	}
+
+	var count int
+	var name string
+	if err := dbPool.QueryRow(context.Background(),
+		`SELECT count(*), min(name) FROM itinerary_items WHERE trip_id = $1`,
+		trip.ID).Scan(&count, &name); err != nil {
+		t.Fatalf("items query: %v", err)
+	}
+	if count != 1 || name != "New Cafe" {
+		t.Fatalf("items after update = %d/%q, want 1/\"New Cafe\"", count, name)
+	}
+}
+
+// (d) A mid-turn model error (SSE `error` event after deltas already
+// streamed) surfaces to the client as a /plan error event, not a hang or a
+// silent truncation.
+func TestPlanMidTurnModelErrorSurfaces(t *testing.T) {
+	resetDB(t)
+	newFakeAnthropic(t, errorTurn("Overloaded"))
+
+	rec := doJSON(t, "POST", "/api/v1/plan", "", PlanRequest{
+		ChatID:   "chat-err",
+		Messages: []PlanChatMessage{{Role: "user", Content: "plan something"}},
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("/plan = %d, want 200 (headers are sent before the model call)", rec.Code)
+	}
+	events := planEvents(t, rec.Body.String())
+
+	// The pre-error delta proves the failure hit MID-turn.
+	if deltas := eventsOfType(events, "text_delta"); len(deltas) == 0 {
+		t.Fatal("no text_delta before the error; the error was not mid-turn")
+	}
+	errs := eventsOfType(events, "error")
+	if len(errs) != 1 {
+		t.Fatalf("error events = %d, want 1", len(errs))
+	}
+	if msg, _ := eventData(errs[0])["message"].(string); msg == "" {
+		t.Fatalf("error event carries no message: %v", errs[0])
+	}
+	if dones := eventsOfType(events, "done"); len(dones) != 0 {
+		t.Fatalf("unexpected done events after error: %v", dones)
+	}
+}
+
+// (e) The local-ingest anti-hallucination gate: extraction (a NON-streaming
+// forced-tool call through the same seam) drafts a pin, Google verification
+// cannot fill coordinates (no Places key), and publish is refused while the
+// draft has no coordinates.
+func TestLocalIngestUnverifiedDraftCannotPublish(t *testing.T) {
+	resetDB(t)
+	fa := newFakeAnthropic(t)
+	fa.scriptNonStreamingTool("draft_local_content",
+		`{"recommendations":[{"name":"To Steki","category":"restaurant","neighborhood":"Psyrri","tip":"Go before 8pm","quote":"","tags":["food"],"search_hint":"To Steki taverna, Athens"}]}`)
+
+	// Force the verify step to fail: the Places singleton captured its key at
+	// process init, so blank it directly (integration tests never run parallel).
+	oldKey := placesService.APIKey
+	placesService.APIKey = ""
+	t.Cleanup(func() { placesService.APIKey = oldKey })
+
+	admin, adminToken := createTestUser(t, "curator@example.com")
+	makeAdmin(t, admin.ID)
+
+	srcRec := doJSON(t, "POST", "/api/v1/admin/local/sources", adminToken,
+		map[string]any{"name": "Maria", "location": "Athens"})
+	if srcRec.Code != http.StatusCreated {
+		t.Fatalf("create source = %d: %s", srcRec.Code, srcRec.Body.String())
+	}
+	sourceID, _ := decode(t, srcRec)["id"].(string)
+
+	ingRec := doJSON(t, "POST", "/api/v1/admin/local/ingest", adminToken, map[string]any{
+		"source_id": sourceID,
+		"city":      "Athens",
+		"kind":      "notes",
+		"raw_text":  "Maria says To Steki in Psyrri is the move, go before 8pm.",
+	})
+	if ingRec.Code != http.StatusCreated {
+		t.Fatalf("ingest = %d: %s", ingRec.Code, ingRec.Body.String())
+	}
+	var ing struct {
+		Recommendations []struct {
+			ID            uuid.UUID `json:"id"`
+			Status        string    `json:"status"`
+			Latitude      *float64  `json:"latitude"`
+			PlaceVerified bool      `json:"place_verified"`
+		} `json:"recommendations"`
+		Verified   int `json:"verified"`
+		Unverified int `json:"unverified"`
+	}
+	if err := json.Unmarshal(ingRec.Body.Bytes(), &ing); err != nil {
+		t.Fatalf("decode ingest response: %v", err)
+	}
+	if len(ing.Recommendations) != 1 || ing.Verified != 0 || ing.Unverified != 1 {
+		t.Fatalf("ingest = %d recs / %d verified / %d unverified, want 1/0/1: %s",
+			len(ing.Recommendations), ing.Verified, ing.Unverified, ingRec.Body.String())
+	}
+	draft := ing.Recommendations[0]
+	if draft.Status != "draft" || draft.Latitude != nil || draft.PlaceVerified {
+		t.Fatalf("draft = %+v, want unverified draft with nil coordinates", draft)
+	}
+
+	// The gate: a coordinate-less draft cannot be published.
+	pubRec := doJSON(t, "POST", "/api/v1/admin/local/recommendations/"+draft.ID.String()+"/publish", adminToken, nil)
+	if pubRec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("publish unverified draft = %d, want 422: %s", pubRec.Code, pubRec.Body.String())
+	}
+	if body := pubRec.Body.String(); !strings.Contains(body, "not verified") {
+		t.Fatalf("publish rejection reason = %s, want the not-verified message", body)
+	}
+
+	// Still a draft afterwards — the gate blocked, it didn't archive or mutate.
+	var status string
+	if err := dbPool.QueryRow(context.Background(),
+		`SELECT status FROM local_recommendations WHERE id = $1`, draft.ID).Scan(&status); err != nil {
+		t.Fatalf("status query: %v", err)
+	}
+	if status != "draft" {
+		t.Fatalf("status after blocked publish = %q, want draft", status)
+	}
+}

--- a/src/packages/api/plan_tool_registry.go
+++ b/src/packages/api/plan_tool_registry.go
@@ -1,0 +1,619 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+
+	anthropic "github.com/anthropics/anthropic-sdk-go"
+	"github.com/google/uuid"
+
+	"travel-route-planner/store"
+)
+
+// plan_tool_registry.go — the /plan agent's tool table. Every tool the agent
+// can call is ONE entry in planToolRegistry: the anthropic tool definition,
+// an optional availability gate, and a dispatcher. plan_handler.go generates
+// the tools slice sent to the API from this registry and dispatches tool_use
+// blocks through it; adding a tool means adding one entry here.
+//
+// ORDER MATTERS: planToolRegistry is an ordered slice, not a map, because the
+// tools array is part of the prompt-cache prefix (the system-prompt cache
+// breakpoint covers tools + system — see the Wave-6 moving-cache-breakpoint
+// work in plan_handler.go). Registry order is the serialization order; keep
+// it byte-stable so cache hits survive across iterations and sessions.
+
+// planSession carries the per-request state a tool dispatcher may need:
+// which caller this is, what trip (if any) the session is bound to, the SSE
+// writer for side events, and the mutable outcomes the handler reads back
+// (persisted trip id, whether the profile distiller already fired).
+type planSession struct {
+	ctx    context.Context
+	w      http.ResponseWriter
+	req    PlanRequest
+	client anthropic.Client
+
+	authed      bool
+	uid         uuid.UUID
+	boundTripID *uuid.UUID
+
+	// tripID is the trip this session persisted or refined (nil if none);
+	// the handler's completion instrumentation reads it.
+	tripID *uuid.UUID
+	// distilled guards the once-per-session background profile distillation.
+	distilled bool
+}
+
+// planTool is one registry entry.
+type planTool struct {
+	def anthropic.ToolParam
+	// enabled gates whether the tool is offered to the model for this
+	// session; nil means always offered.
+	enabled func(s *planSession) bool
+	// run executes the tool and returns (resultText, isError) — the payload
+	// of the tool_result block sent back to the model. Side events (done,
+	// flights, stays, ...) are emitted inside run, before the generic
+	// tool_result event.
+	run func(s *planSession, input json.RawMessage) (string, bool)
+	// noResultEvent suppresses the generic tool_result SSE event
+	// (create_itinerary emits done instead).
+	noResultEvent bool
+}
+
+func authedOnly(s *planSession) bool { return s.authed }
+
+// planToolRegistry lists every agent tool in serialization order. The
+// conditional slots keep today's order: the trip-bound section tool replaces
+// create_itinerary (a refinement can never spawn a new trip version), and the
+// personalization tools are signed-in only.
+var planToolRegistry = []planTool{
+	{def: searchPlacesTool, run: runSearchPlacesTool},
+	{def: suggestStaysTool, run: runSuggestStaysTool},
+	{def: suggestTransportTool, run: runSuggestTransportTool},
+	{def: suggestFerriesTool, run: runSuggestFerriesTool},
+	{def: searchFlightsTool, run: runSearchFlightsTool},
+	{def: searchEventsTool, run: runSearchEventsTool},
+	{def: searchLocalRecsTool, run: runSearchLocalRecsTool},
+	{def: getWeatherTool, run: func(s *planSession, input json.RawMessage) (string, bool) {
+		return runGetWeatherTool(s.ctx, input)
+	}},
+	{def: updateSectionTool, enabled: func(s *planSession) bool { return s.boundTripID != nil },
+		run: runUpdateItinerarySectionTool},
+	{def: createItineraryTool, enabled: func(s *planSession) bool { return s.boundTripID == nil },
+		run: runCreateItineraryTool, noResultEvent: true},
+	{def: savePrefsTool, enabled: authedOnly, run: runSavePreferencesTool},
+	{def: getTripTool, enabled: authedOnly, run: func(s *planSession, input json.RawMessage) (string, bool) {
+		return runGetTripTool(s.ctx, s.authed, s.uid, input)
+	}},
+	{def: addBookingTodoTool, enabled: authedOnly, run: func(s *planSession, input json.RawMessage) (string, bool) {
+		return runAddBookingTodoTool(s.ctx, s.authed, s.uid, input)
+	}},
+}
+
+// planToolByName dispatches tool_use blocks; derived from the registry so the
+// two can never drift.
+var planToolByName = func() map[string]*planTool {
+	m := make(map[string]*planTool, len(planToolRegistry))
+	for i := range planToolRegistry {
+		m[planToolRegistry[i].def.Name] = &planToolRegistry[i]
+	}
+	return m
+}()
+
+// planSessionTools generates the tools slice sent to the API, in registry
+// order, filtered to what this session may use.
+func planSessionTools(s *planSession) []anthropic.ToolUnionParam {
+	tools := make([]anthropic.ToolUnionParam, 0, len(planToolRegistry))
+	for i := range planToolRegistry {
+		pt := &planToolRegistry[i]
+		if pt.enabled == nil || pt.enabled(s) {
+			tools = append(tools, anthropic.ToolUnionParam{OfTool: &pt.def})
+		}
+	}
+	return tools
+}
+
+// --- tool definitions ---------------------------------------------------------
+
+var searchPlacesTool = anthropic.ToolParam{
+	Name:        "search_places",
+	Description: anthropic.String("Search for travel destinations, attractions, restaurants, or points of interest by name or description."),
+	InputSchema: anthropic.ToolInputSchemaParam{
+		Properties: map[string]any{
+			"query": map[string]any{
+				"type":        "string",
+				"description": "Search query, e.g. 'Eiffel Tower Paris' or 'best museums in Rome'",
+			},
+		},
+		Required: []string{"query"},
+	},
+}
+
+var createItineraryTool = anthropic.ToolParam{
+	Name:        "create_itinerary",
+	Description: anthropic.String("Finalize the itinerary with the chosen list of locations to visit. Call this when you have identified all the places for the trip."),
+	InputSchema: anthropic.ToolInputSchemaParam{
+		Properties: map[string]any{
+			"locations": map[string]any{
+				"type":        "array",
+				"description": "Ordered list of locations to visit",
+				"items":       itineraryLocationSchema,
+			},
+			"title": map[string]any{
+				"type":        "string",
+				"description": "A short, human-friendly trip name, 3–6 words (e.g. 'Luxury Paris Weekend'). Distinct from the longer summary.",
+			},
+			"summary": map[string]any{
+				"type":        "string",
+				"description": "A 1–2 sentence overview of the trip to show the user (the per-day breakdown already appears in the itinerary list, so keep this brief).",
+			},
+			"start_date": map[string]any{
+				"type":        "string",
+				"description": "The trip's first day as YYYY-MM-DD (day 1). Include it whenever the traveler has given or agreed to travel dates.",
+			},
+			"end_date": map[string]any{
+				"type":        "string",
+				"description": "The trip's last day as YYYY-MM-DD. Optional — if omitted it's derived from start_date plus the number of days in the itinerary.",
+			},
+		},
+		Required: []string{"locations"},
+	},
+}
+
+var savePrefsTool = anthropic.ToolParam{
+	Name:        "save_preferences",
+	Description: anthropic.String("Save what you learn about the traveler so future trips are personalized. Call this when the user reveals a budget level, trip pace, interests, which airport they fly from, or any other durable fact about how they travel. Only include fields you actually learned."),
+	InputSchema: anthropic.ToolInputSchemaParam{
+		Properties: map[string]any{
+			"budget": map[string]any{
+				"type":        "string",
+				"enum":        []string{"budget", "mid", "luxury"},
+				"description": "Overall spending level",
+			},
+			"pace": map[string]any{
+				"type":        "string",
+				"enum":        []string{"relaxed", "balanced", "packed"},
+				"description": "How packed the days should be",
+			},
+			"interests": map[string]any{
+				"type":        "array",
+				"items":       map[string]any{"type": "string"},
+				"description": "Theme tags, e.g. museums, food, nightlife, nature",
+			},
+			"home_airport": map[string]any{
+				"type":        "string",
+				"description": "The traveler's home/departure airport as an IATA code, e.g. BOS — save it when they mention where they usually fly from",
+			},
+			"profile_notes": map[string]any{
+				"type":        "string",
+				"description": "The COMPLETE updated traveler profile as short bullet lines — your current notes (shown in the system prompt) merged with the new fact, de-duplicated, max ~15 lines. Never send only the new fact; always send the full rewritten profile.",
+			},
+		},
+	},
+}
+
+var suggestStaysTool = anthropic.ToolParam{
+	Name:        "suggest_stays",
+	Description: anthropic.String("Give the traveler links to browse accommodations on Airbnb and Booking.com for a destination. Call this when they want lodging suggestions."),
+	InputSchema: anthropic.ToolInputSchemaParam{
+		Properties: map[string]any{
+			"destination": map[string]any{"type": "string", "description": "City or area, e.g. 'Paris'"},
+			"check_in":    map[string]any{"type": "string", "description": "Optional YYYY-MM-DD"},
+			"check_out":   map[string]any{"type": "string", "description": "Optional YYYY-MM-DD"},
+			"guests":      map[string]any{"type": "integer", "description": "Optional number of guests"},
+		},
+		Required: []string{"destination"},
+	},
+}
+
+var suggestTransportTool = anthropic.ToolParam{
+	Name:        "suggest_transport",
+	Description: anthropic.String("Give the traveler links to browse transport options. Call this when they need to get to or between destinations. Mode 'flight' returns Google Flights + Kayak; mode 'ground' returns Rome2Rio (covers trains, buses, cars, ferries). For travel between Greek islands, prefer suggest_ferries instead."),
+	InputSchema: anthropic.ToolInputSchemaParam{
+		Properties: map[string]any{
+			"mode":        map[string]any{"type": "string", "enum": []string{"flight", "ground"}, "description": "flight or ground (multimodal)"},
+			"origin":      map[string]any{"type": "string", "description": "Origin city or airport, e.g. 'NYC' or 'Paris'"},
+			"destination": map[string]any{"type": "string", "description": "Destination city or airport"},
+			"depart_date": map[string]any{"type": "string", "description": "Optional YYYY-MM-DD"},
+			"return_date": map[string]any{"type": "string", "description": "Optional YYYY-MM-DD (flights only)"},
+			"passengers":  map[string]any{"type": "integer", "description": "Optional passenger count"},
+		},
+		Required: []string{"mode", "origin", "destination"},
+	},
+}
+
+var suggestFerriesTool = anthropic.ToolParam{
+	Name:        "suggest_ferries",
+	Description: anthropic.String("Give the traveler a ferry booking link for a route between two ports/islands — use this for Greek island-hopping (e.g. Santorini→Naxos) and other ferry legs. Backed by Ferryhopper, which aggregates the major Greek operators (Blue Star, SeaJets, etc.)."),
+	InputSchema: anthropic.ToolInputSchemaParam{
+		Properties: map[string]any{
+			"origin":      map[string]any{"type": "string", "description": "Departure port or island, e.g. 'Santorini' or 'Piraeus'"},
+			"destination": map[string]any{"type": "string", "description": "Arrival port or island, e.g. 'Naxos'"},
+			"date":        map[string]any{"type": "string", "description": "Optional YYYY-MM-DD travel date"},
+			"passengers":  map[string]any{"type": "integer", "description": "Optional passenger count"},
+		},
+		Required: []string{"origin", "destination"},
+	},
+}
+
+var searchFlightsTool = anthropic.ToolParam{
+	Name: "search_flights",
+	Description: anthropic.String("Search real flight options between two places for given dates and present a few good ones (ranked by overall desirability). " +
+		"Ask the traveler for their departure city/airport and travel dates first if you don't know them. " +
+		"origin/destination may be city names or IATA codes. Choose optimize_for from the traveler's budget: budget→'cost', luxury→'time', otherwise 'balanced'."),
+	InputSchema: anthropic.ToolInputSchemaParam{
+		Properties: map[string]any{
+			"origin":       map[string]any{"type": "string", "description": "Departure city or IATA code, e.g. 'Boston' or 'BOS'"},
+			"destination":  map[string]any{"type": "string", "description": "Arrival city or IATA code"},
+			"depart_date":  map[string]any{"type": "string", "description": "YYYY-MM-DD"},
+			"return_date":  map[string]any{"type": "string", "description": "Optional YYYY-MM-DD for round trips"},
+			"adults":       map[string]any{"type": "integer", "description": "Optional, defaults to 1"},
+			"child_ages":   map[string]any{"type": "array", "items": map[string]any{"type": "integer"}, "description": "Optional ages of child travelers (one per child, 0-17) — include when the traveler mentions kids"},
+			"cabin_class":  map[string]any{"type": "string", "enum": []string{"economy", "premium_economy", "business", "first"}, "description": "Optional cabin, defaults to economy — set when the traveler asks for a specific class"},
+			"optimize_for": map[string]any{"type": "string", "enum": []string{"cost", "time", "balanced"}, "description": "Ranking emphasis"},
+		},
+		Required: []string{"origin", "destination", "depart_date"},
+	},
+}
+
+var searchEventsTool = anthropic.ToolParam{
+	Name: "search_events",
+	Description: anthropic.String("Find local events (concerts, sports, festivals, theatre/shows) happening in a city during specific dates, so the itinerary can account for what's on while the traveler is there. " +
+		"Use the city and the dates the traveler is in that city; you already know the trip's cities and dates from the itinerary. " +
+		"Present a few that fit the traveler's interests."),
+	InputSchema: anthropic.ToolInputSchemaParam{
+		Properties: map[string]any{
+			"city":       map[string]any{"type": "string", "description": "City name, e.g. 'Paris'"},
+			"start_date": map[string]any{"type": "string", "description": "First day to look from, YYYY-MM-DD (when the traveler arrives in the city)"},
+			"end_date":   map[string]any{"type": "string", "description": "Last day to look through, YYYY-MM-DD (when the traveler leaves the city)"},
+			"category":   map[string]any{"type": "string", "enum": []string{"music", "sports", "arts", "film", "miscellaneous"}, "description": "Optional event category filter"},
+		},
+		Required: []string{"city", "start_date", "end_date"},
+	},
+}
+
+var searchLocalRecsTool = anthropic.ToolParam{
+	Name: "search_local_recommendations",
+	Description: anthropic.String("Find hand-curated recommendations from real locals for a city — vetted spots you can't get by googling. " +
+		"ALWAYS call this FIRST for each city, before search_places. Prefer these picks over generic search results, and when you use one, cite the local by name in your reply (their name is in 'source_name'). " +
+		"When you pass a local pick into create_itinerary, copy its 'id' into local_recommendation_id and its 'source_name' into local_source_name so the saved trip credits them."),
+	InputSchema: anthropic.ToolInputSchemaParam{
+		Properties: map[string]any{
+			"city":     map[string]any{"type": "string", "description": "City name, e.g. 'Lisbon'"},
+			"category": map[string]any{"type": "string", "enum": []string{"attraction", "restaurant"}, "description": "Optional filter to only sights or only places to eat"},
+		},
+		Required: []string{"city"},
+	},
+}
+
+var updateSectionTool = anthropic.ToolParam{
+	Name:        "update_itinerary_section",
+	Description: anthropic.String("Replace one section of the traveler's saved itinerary in place. Pass the COMPLETE updated list of places for the targeted section, in visit order — places you omit are removed from that section. Places outside the section are untouched. Use scope 'day' for a single trip day, 'city' for one city/hub and its day trips, or 'trip' for the whole itinerary."),
+	InputSchema: anthropic.ToolInputSchemaParam{
+		Properties: map[string]any{
+			"scope": map[string]any{
+				"type":        "string",
+				"enum":        []string{"day", "city", "trip"},
+				"description": "Which slice of the itinerary to replace.",
+			},
+			"day": map[string]any{
+				"type":        "integer",
+				"description": "Required when scope is 'day': the 1-based trip day being replaced.",
+			},
+			"city": map[string]any{
+				"type":        "string",
+				"description": "Required when scope is 'city' (the hub city whose items are replaced); optional with scope 'day' to disambiguate when day numbers repeat across cities.",
+			},
+			"items": map[string]any{
+				"type":        "array",
+				"description": "The full replacement list for the section, in visit order. Include unchanged places with their existing coordinates and tags so they aren't lost.",
+				"items":       itineraryLocationSchema,
+			},
+		},
+		Required: []string{"scope", "items"},
+	},
+}
+
+// --- dispatchers ----------------------------------------------------------------
+
+func runSearchPlacesTool(s *planSession, input json.RawMessage) (string, bool) {
+	var in struct {
+		Query string `json:"query"`
+	}
+	json.Unmarshal(input, &in)
+
+	results, err := placesService.SearchPlaces(in.Query)
+	if err != nil {
+		return fmt.Sprintf("Error searching places: %v", err), true
+	}
+	b, _ := json.Marshal(results)
+	return string(b), false
+}
+
+func runCreateItineraryTool(s *planSession, input json.RawMessage) (string, bool) {
+	var in struct {
+		Locations []map[string]any `json:"locations"`
+		Title     string           `json:"title"`
+		Summary   string           `json:"summary"`
+		StartDate string           `json:"start_date"`
+		EndDate   string           `json:"end_date"`
+	}
+	json.Unmarshal(input, &in)
+
+	// Distance-optimize the walking order within each day/time-of-day
+	// block, leaving Claude's day and time-of-day assignments intact.
+	in.Locations = reorderItineraryByDistance(in.Locations)
+
+	donePayload := map[string]any{"locations": in.Locations, "summary": in.Summary}
+	// Persist the trip only for signed-in callers; anonymous sessions
+	// stay ephemeral (no trip_id in the done event).
+	if s.authed {
+		if tripID, newLineage, err := persistTrip(s.ctx, s.uid, s.req.ChatID, in.Title, in.Summary, in.StartDate, in.EndDate, in.Locations); err != nil {
+			log.Printf("failed to persist trip: %v", err)
+		} else {
+			donePayload["trip_id"] = tripID
+			if parsed, err := uuid.Parse(tripID); err == nil {
+				s.tripID = &parsed
+				go recordEvent(s.uid, "trip_created", &parsed, map[string]any{
+					"item_count": len(in.Locations),
+				})
+				// Free-cap active_trips crossing signal — only a
+				// brand-new lineage can move the lineage count; a
+				// version save of an existing chat lineage leaves
+				// it unchanged and must never emit
+				// (specs/free-cap-instrumentation).
+				if newLineage {
+					go recordActiveTripsCapSignal(s.uid, parsed)
+				}
+			}
+			// Distill what this conversation revealed about the traveler
+			// in the background — it must never delay or fail the trip.
+			// context.Background(): the request ctx dies with the handler.
+			if !s.distilled {
+				s.distilled = true
+				go distillTravelerProfile(context.Background(), s.client, s.uid, s.req.Messages)
+			}
+		}
+	}
+	sendSSE(s.w, "done", donePayload)
+	return "Itinerary created successfully.", false
+}
+
+func runUpdateItinerarySectionTool(s *planSession, input json.RawMessage) (string, bool) {
+	var in struct {
+		Scope string           `json:"scope"`
+		Day   *int             `json:"day"`
+		City  string           `json:"city"`
+		Items []map[string]any `json:"items"`
+	}
+	json.Unmarshal(input, &in)
+
+	if s.boundTripID == nil {
+		return "This session is not bound to a saved trip; update_itinerary_section is unavailable.", true
+	}
+	// Same in-block walking-distance cleanup create_itinerary gets.
+	in.Items = reorderItineraryByDistance(in.Items)
+	if err := replaceTripSection(s.ctx, *s.boundTripID, sectionSelector{Scope: in.Scope, Day: in.Day, City: in.City}, in.Items); err != nil {
+		return fmt.Sprintf("Could not update the section: %v", err), true
+	}
+	sendSSE(s.w, "trip_updated", map[string]string{"trip_id": s.boundTripID.String()})
+	s.tripID = s.boundTripID
+	go recordEvent(s.uid, "trip_refined", s.boundTripID, map[string]any{
+		"scope": in.Scope,
+	})
+	return "Section updated — the traveler's trip page has refreshed.", false
+}
+
+func runSavePreferencesTool(s *planSession, input json.RawMessage) (string, bool) {
+	var in struct {
+		Budget       *string  `json:"budget"`
+		Pace         *string  `json:"pace"`
+		Interests    []string `json:"interests"`
+		HomeAirport  *string  `json:"home_airport"`
+		ProfileNotes *string  `json:"profile_notes"`
+	}
+	json.Unmarshal(input, &in)
+
+	budget, _ := normalizeChoice(in.Budget, allowedBudgets, "budget")
+	pace, _ := normalizeChoice(in.Pace, allowedPaces, "pace")
+	homeAirport, _ := normalizeAirportCode(in.HomeAirport)
+	var interestsArg interface{}
+	if in.Interests != nil {
+		interestsArg = normalizeInterests(in.Interests)
+	}
+	notes := normalizeNotes(in.ProfileNotes)
+	if notes != nil && *notes == "" {
+		// The agent can never wipe notes; only the user (PUT) can clear.
+		notes = nil
+	}
+	_, err := store.New(dbPool).UpsertPreferences(s.ctx, store.UpsertPreferencesParams{
+		UserID: s.uid, Budget: budget, Pace: pace, Interests: interestsArg, HomeAirport: homeAirport, ProfileNotes: notes,
+	})
+	if err != nil {
+		return fmt.Sprintf("Could not save preferences: %v", err), true
+	}
+	var changed []string
+	if budget != nil {
+		changed = append(changed, "budget")
+	}
+	if pace != nil {
+		changed = append(changed, "pace")
+	}
+	if interestsArg != nil {
+		changed = append(changed, "interests")
+	}
+	if homeAirport != nil {
+		changed = append(changed, "home_airport")
+	}
+	if notes != nil {
+		changed = append(changed, "profile_notes")
+	}
+	if len(changed) > 0 {
+		sendSSE(s.w, "profile_updated", map[string]any{
+			"fields": changed, "notes_preview": notesPreview(notes),
+		})
+	}
+	return "Preferences saved.", false
+}
+
+func runSuggestStaysTool(s *planSession, input json.RawMessage) (string, bool) {
+	var in struct {
+		Destination string `json:"destination"`
+		CheckIn     string `json:"check_in"`
+		CheckOut    string `json:"check_out"`
+		Guests      int    `json:"guests"`
+	}
+	json.Unmarshal(input, &in)
+	links := providerLinks(AccommodationQuery{
+		Destination: in.Destination, CheckIn: in.CheckIn, CheckOut: in.CheckOut, Guests: in.Guests,
+	})
+	sendSSE(s.w, "stays", map[string]any{"destination": in.Destination, "links": links})
+	b, _ := json.Marshal(links)
+	return "Provided browse links: " + string(b), false
+}
+
+func runSuggestTransportTool(s *planSession, input json.RawMessage) (string, bool) {
+	var in struct {
+		Mode        string `json:"mode"`
+		Origin      string `json:"origin"`
+		Destination string `json:"destination"`
+		DepartDate  string `json:"depart_date"`
+		ReturnDate  string `json:"return_date"`
+		Passengers  int    `json:"passengers"`
+	}
+	json.Unmarshal(input, &in)
+	links := transportLinks(TransportQuery{
+		Mode: in.Mode, Origin: in.Origin, Destination: in.Destination,
+		DepartDate: in.DepartDate, ReturnDate: in.ReturnDate, Passengers: in.Passengers,
+	})
+	sendSSE(s.w, "transport", map[string]any{
+		"mode": in.Mode, "origin": in.Origin, "destination": in.Destination, "links": links,
+	})
+	b, _ := json.Marshal(links)
+	return "Provided browse links: " + string(b), false
+}
+
+func runSuggestFerriesTool(s *planSession, input json.RawMessage) (string, bool) {
+	var in struct {
+		Origin      string `json:"origin"`
+		Destination string `json:"destination"`
+		Date        string `json:"date"`
+		Passengers  int    `json:"passengers"`
+	}
+	json.Unmarshal(input, &in)
+	options := ferryService.SearchFerries(FerryQuery{
+		Origin: in.Origin, Destination: in.Destination,
+		Date: in.Date, Passengers: in.Passengers,
+	})
+	sendSSE(s.w, "ferries", map[string]any{
+		"origin": in.Origin, "destination": in.Destination, "options": options,
+	})
+	b, _ := json.Marshal(options)
+	return "Provided ferry booking link(s): " + string(b), false
+}
+
+func runSearchFlightsTool(s *planSession, input json.RawMessage) (string, bool) {
+	var in struct {
+		Origin      string `json:"origin"`
+		Destination string `json:"destination"`
+		DepartDate  string `json:"depart_date"`
+		ReturnDate  string `json:"return_date"`
+		Adults      int    `json:"adults"`
+		ChildAges   []int  `json:"child_ages"`
+		CabinClass  string `json:"cabin_class"`
+		OptimizeFor string `json:"optimize_for"`
+	}
+	json.Unmarshal(input, &in)
+
+	originIata := resolveIATA(s.ctx, in.Origin)
+	destIata := resolveIATA(s.ctx, in.Destination)
+	if originIata == "" || destIata == "" {
+		return fmt.Sprintf("Could not resolve %q or %q to an airport. Ask the traveler to clarify the city or airport.", in.Origin, in.Destination), true
+	}
+
+	adults := in.Adults
+	if adults < 1 {
+		adults = 1
+	}
+	offers, err := duffelService.SearchFlightOffers(s.ctx, FlightSearchRequest{
+		Origin: originIata, Destination: destIata, DepartDate: in.DepartDate,
+		ReturnDate: in.ReturnDate, Adults: adults, ChildAges: in.ChildAges,
+		CabinClass: in.CabinClass, OptimizeFor: in.OptimizeFor,
+	})
+	if err != nil {
+		return fmt.Sprintf("Error searching flights: %v", err), true
+	}
+
+	bestN := RankFlightOffers(offers, in.OptimizeFor)
+	if len(bestN) > 4 {
+		bestN = bestN[:4]
+	}
+	attachBookingURLs(bestN, FlightSearchRequest{
+		Origin: originIata, Destination: destIata,
+		DepartDate: in.DepartDate, ReturnDate: in.ReturnDate, Adults: adults,
+	})
+	if len(bestN) > 0 {
+		sendSSE(s.w, "flights", map[string]any{
+			"origin": originIata, "destination": destIata,
+			"depart_date": in.DepartDate, "optimize_for": normalizeOptimizeFor(in.OptimizeFor),
+			"offers": bestN,
+		})
+	}
+	return summarizeOffers(originIata, destIata, bestN), false
+}
+
+func runSearchEventsTool(s *planSession, input json.RawMessage) (string, bool) {
+	var in struct {
+		City      string  `json:"city"`
+		StartDate string  `json:"start_date"`
+		EndDate   string  `json:"end_date"`
+		Category  *string `json:"category"`
+	}
+	json.Unmarshal(input, &in)
+
+	events, err := eventsService.SearchEvents(s.ctx, in.City, in.StartDate, in.EndDate, in.Category)
+	if len(events) > 0 {
+		sendSSE(s.w, "events", map[string]any{
+			"city":       in.City,
+			"start_date": in.StartDate,
+			"end_date":   in.EndDate,
+			"events":     events,
+		})
+	}
+
+	// Greece has no usable events API, so when the structured lookup
+	// comes back empty (or errors, e.g. no key) for a Greek city, fall
+	// back to curated Greek source links instead of nothing.
+	summary := summarizeEvents(in.City, events)
+	if len(events) == 0 && isGreekLocation(in.City) {
+		links := greekEventLinks(in.City, in.StartDate, in.EndDate)
+		sendSSE(s.w, "event_links", map[string]any{"city": in.City, "links": links})
+		b, _ := json.Marshal(links)
+		summary = "No ticketed listings via the events provider for " + in.City +
+			". Provided Greek event-discovery links: " + string(b)
+	} else if err != nil {
+		summary = fmt.Sprintf("Error searching events: %v", err)
+	}
+
+	return summary, err != nil && len(events) == 0 && !isGreekLocation(in.City)
+}
+
+func runSearchLocalRecsTool(s *planSession, input json.RawMessage) (string, bool) {
+	var in struct {
+		City     string `json:"city"`
+		Category string `json:"category"`
+	}
+	json.Unmarshal(input, &in)
+
+	recs, err := localRecsService.SearchByCity(s.ctx, in.City, in.Category)
+	if len(recs) > 0 {
+		sendSSE(s.w, "local_recs", map[string]any{"city": in.City, "recommendations": recs})
+	}
+	summary := summarizeLocalRecs(in.City, recs)
+	if err != nil {
+		summary = fmt.Sprintf("Error searching local recommendations: %v", err)
+	}
+	return summary, err != nil
+}

--- a/src/packages/api/plan_tool_registry_test.go
+++ b/src/packages/api/plan_tool_registry_test.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+// The tools slice is part of the prompt-cache prefix: its order must be
+// byte-stable per session shape, and must match the pre-refactor hardcoded
+// order exactly (a reorder silently invalidates the system-prompt cache
+// breakpoint on every request). These sequences are the pre-dispatch-table
+// behavior, pinned.
+func TestPlanSessionToolsOrderStable(t *testing.T) {
+	base := []string{
+		"search_places", "suggest_stays", "suggest_transport", "suggest_ferries",
+		"search_flights", "search_events", "search_local_recommendations", "get_weather",
+	}
+	tid := uuid.New()
+
+	cases := []struct {
+		name    string
+		session *planSession
+		want    []string
+	}{
+		{"anonymous", &planSession{}, append(append([]string{}, base...), "create_itinerary")},
+		{"authed", &planSession{authed: true},
+			append(append([]string{}, base...), "create_itinerary", "save_preferences", "get_trip", "add_booking_todo")},
+		{"authed trip-bound", &planSession{authed: true, boundTripID: &tid},
+			append(append([]string{}, base...), "update_itinerary_section", "save_preferences", "get_trip", "add_booking_todo")},
+	}
+	for _, tc := range cases {
+		tools := planSessionTools(tc.session)
+		var got []string
+		for _, tool := range tools {
+			got = append(got, tool.OfTool.Name)
+		}
+		if len(got) != len(tc.want) {
+			t.Fatalf("%s: tools = %v, want %v", tc.name, got, tc.want)
+		}
+		for i := range got {
+			if got[i] != tc.want[i] {
+				t.Fatalf("%s: tools[%d] = %s, want %s (full: %v)", tc.name, i, got[i], tc.want[i], got)
+			}
+		}
+	}
+}
+
+// Every registry entry must be dispatchable and unambiguous.
+func TestPlanToolRegistryNamesUniqueAndDispatchable(t *testing.T) {
+	if len(planToolByName) != len(planToolRegistry) {
+		t.Fatalf("planToolByName has %d entries for %d registry entries — duplicate tool name",
+			len(planToolByName), len(planToolRegistry))
+	}
+	for i := range planToolRegistry {
+		pt := &planToolRegistry[i]
+		if pt.def.Name == "" {
+			t.Fatalf("registry entry %d has no name", i)
+		}
+		if pt.run == nil {
+			t.Fatalf("tool %s has no dispatcher", pt.def.Name)
+		}
+		if planToolByName[pt.def.Name] != pt {
+			t.Fatalf("planToolByName[%s] does not point at its registry entry", pt.def.Name)
+		}
+	}
+}


### PR DESCRIPTION
> **Stacked on #72** — retarget to `main` after PR A merges.

## What

Pure refactor, zero behavior change: `plan_handler.go`'s 13-case tool switch and ~340 lines of inline tool definitions become **`plan_tool_registry.go`** — an ordered table of `planTool` entries:

```go
type planTool struct {
    def           anthropic.ToolParam                                  // what the model sees
    enabled       func(*planSession) bool                              // nil = always offered
    run           func(*planSession, json.RawMessage) (string, bool)   // (resultText, isError)
    noResultEvent bool                                                 // create_itinerary emits done instead
}
```

Adding a tool is now one registry entry. `planSession` carries the per-request state dispatchers need (ctx, SSE writer, caller identity, bound trip) and the outcomes the handler reads back (persisted trip id for the completion instrumentation, the distiller-once flag).

## Tool-order stability (the cache question)

Investigated before choosing: the tools array serializes ahead of the system prompt in the request, and the system-prompt cache breakpoint (Wave-6 moving-breakpoint work) covers that whole prefix — any reorder silently invalidates the conversation cache on every request. So the registry is deliberately an **ordered slice, not a map** (`planToolByName` is derived from it for dispatch, so the two can't drift), and the generated order matches the old hardcoded order byte-for-byte:

`search_places, suggest_stays, suggest_transport, suggest_ferries, search_flights, search_events, search_local_recommendations, get_weather, [update_itinerary_section | create_itinerary], save_preferences, get_trip, add_booking_todo`

`TestPlanSessionToolsOrderStable` pins these sequences for all three session shapes (anonymous / authed / trip-bound).

## Behavior edges preserved

- `tool_call` SSE + tool counter fire before registry lookup; unknown tool names fall through with no result block (the old switch's no-case path)
- `create_itinerary` emits `done` and suppresses the generic `tool_result` event
- Every dispatcher keeps its exact side-event ordering (`trip_updated`/`profile_updated`/`flights`/... before `tool_result`), result strings, and isError expressions (including `search_events`' Greek-fallback condition and `search_flights`' early-return paths)
- Trip-bound sessions still get `update_itinerary_section` **instead of** `create_itinerary`; personalization tools stay signed-in-only

## Proof

- PR A's fake-Anthropic e2e suite passes **unchanged** (text turn, tool loop round-trip, create_itinerary persistence, bound-session section update, mid-turn error, free-cap sessions)
- Whole existing suite green: `make api-fmt` / `make api-vet`, `go test ./...`, and `TEST_DATABASE_URL=...travel_test_w8b go test -count=1 ./...` (~5s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)