### PR TITLE
feat(api): round-trip-aware flight ranking (time/balanced use total duration + stops)

### DIFF
--- a/src/packages/api/analytics_integration_test.go
+++ b/src/packages/api/analytics_integration_test.go
@@ -103,7 +103,6 @@ func TestClientEventOwnTripIDIsKept(t *testing.T) {
 	}
 }
 
-<<<<<<< HEAD
 // itinerary_item_added (specs/add-to-itinerary): accepted as a client event,
 // with metadata "source" constrained to the closed value set the dashboard
 // groups on — anything else is dropped, never stored.
@@ -162,7 +161,6 @@ func TestClientEventItineraryItemAdded(t *testing.T) {
 	}
 }
 
-=======
 // --- anonymous top-of-funnel events (Wave 8) ---
 
 // countAnonymousEvents counts rows with a NULL user_id for one event type.
@@ -332,7 +330,6 @@ func TestAuthedEventsNotOnStrictTier(t *testing.T) {
 	waitForEventCount(t, user.ID, "booking_link_clicked", 10)
 }
 
->>>>>>> origin/main
 func TestClientEventMetadataSanitized(t *testing.T) {
 	resetDB(t)
 	user, token := createTestUser(t, "meta-abuser@example.com")

--- a/src/packages/api/flight_optimizer.go
+++ b/src/packages/api/flight_optimizer.go
@@ -40,6 +40,29 @@ func invScore(value, min, max float64) float64 {
 	return (max - value) / (max - min) * 10.0
 }
 
+// scoringDuration is the duration an offer is *ranked* on: the trip total
+// (outbound + return). For one-way offers ReturnDurationMin is zero, so this
+// is exactly the outbound duration and one-way scoring is unchanged. The
+// displayed per-slice fields (DurationMin, Stops, times) are never touched —
+// only the score inputs consider the return slice. In mixed one-way/round-trip
+// lists the totals are compared as-is: a one-way's total is its outbound, so a
+// round-trip offer is naturally (and correctly) penalized for the extra flown
+// time relative to a one-way in the same result set.
+func scoringDuration(o FlightOffer) float64 {
+	return float64(o.DurationMin + o.ReturnDurationMin)
+}
+
+// scoringStops is the stop count an offer is ranked on: outbound stops plus
+// return stops (derived as len(ReturnSegments)-1; a nonstop return slice has
+// one segment). Zero return segments means one-way, adding nothing.
+func scoringStops(o FlightOffer) float64 {
+	stops := o.Stops
+	if n := len(o.ReturnSegments); n > 1 {
+		stops += n - 1
+	}
+	return float64(stops)
+}
+
 // scheduleSignature identifies an offer at the level a traveler perceives it on
 // a summary card: origin, final destination, overall departure/arrival times,
 // and the ordered list of connecting airports. Offers that share a signature
@@ -90,6 +113,9 @@ func dedupBySchedule(offers []FlightOffer) []FlightOffer {
 // then scores each remaining offer on price, duration, and stops (each
 // normalized to 0-10 across the result set, lower being better), combines them
 // using the preset weights, and returns the offers sorted by descending score.
+// Round-trip offers are scored on trip TOTALS — duration and stops across both
+// slices (price already totals both) — while one-way scoring and the displayed
+// per-slice fields are unchanged; see scoringDuration/scoringStops.
 // The *_score and Score fields on each offer are populated in place.
 func RankFlightOffers(offers []FlightOffer, optimizeFor string) []FlightOffer {
 	if len(offers) == 0 {
@@ -105,15 +131,15 @@ func RankFlightOffers(offers []FlightOffer, optimizeFor string) []FlightOffer {
 	minStops, maxStops := math.Inf(1), math.Inf(-1)
 	for _, o := range offers {
 		minPrice, maxPrice = math.Min(minPrice, o.Price), math.Max(maxPrice, o.Price)
-		minDur, maxDur = math.Min(minDur, float64(o.DurationMin)), math.Max(maxDur, float64(o.DurationMin))
-		minStops, maxStops = math.Min(minStops, float64(o.Stops)), math.Max(maxStops, float64(o.Stops))
+		minDur, maxDur = math.Min(minDur, scoringDuration(o)), math.Max(maxDur, scoringDuration(o))
+		minStops, maxStops = math.Min(minStops, scoringStops(o)), math.Max(maxStops, scoringStops(o))
 	}
 
 	for i := range offers {
 		o := &offers[i]
 		o.PriceScore = round2(invScore(o.Price, minPrice, maxPrice))
-		o.DurationScore = round2(invScore(float64(o.DurationMin), minDur, maxDur))
-		o.StopsScore = round2(invScore(float64(o.Stops), minStops, maxStops))
+		o.DurationScore = round2(invScore(scoringDuration(*o), minDur, maxDur))
+		o.StopsScore = round2(invScore(scoringStops(*o), minStops, maxStops))
 		o.Score = round2(o.PriceScore*w.price + o.DurationScore*w.duration + o.StopsScore*w.stops)
 	}
 

--- a/src/packages/api/flight_optimizer_test.go
+++ b/src/packages/api/flight_optimizer_test.go
@@ -111,3 +111,120 @@ func TestDedupBySchedulePreservesOrderAndKeepsCheapest(t *testing.T) {
 		t.Errorf("expected b-other preserved in second slot, got %q", got[1].ID)
 	}
 }
+
+// roundTrip extends offer() with a return slice: retLegs segments (return
+// stops = retLegs-1) and a return duration. Top-level fields stay
+// outbound-based, mirroring how duffel_service.go builds round-trip offers.
+func roundTrip(id string, price float64, from, to, dep, arr string, dur, stops, retDur, retLegs int) FlightOffer {
+	o := offer(id, price, from, to, dep, arr, dur, stops)
+	o.ReturnDurationMin = retDur
+	for i := 0; i < retLegs; i++ {
+		o.ReturnSegments = append(o.ReturnSegments, FlightLeg{From: to, To: from})
+	}
+	return o
+}
+
+// Round-trip "time" ranking must use TOTAL duration (outbound + return), not
+// outbound alone: a fast-outbound/slow-return offer with the larger total must
+// lose to a slow-outbound/fast-return offer with the smaller total.
+func TestRankRoundTripTimeUsesTotalDuration(t *testing.T) {
+	in := []FlightOffer{
+		// Fast outbound (300) but slow return (600): total 900. Outbound-only
+		// ranking would put this first.
+		roundTrip("fast-out", 400, "JFK", "CDG", "T1", "T2", 300, 0, 600, 1),
+		// Slow outbound (500) but fast return (200): total 700 — the real winner.
+		roundTrip("fast-total", 400, "JFK", "CDG", "T3", "T4", 500, 0, 200, 1),
+	}
+	got := RankFlightOffers(in, "time")
+	if got[0].ID != "fast-total" {
+		t.Fatalf("time ranking should pick the smaller TOTAL duration (fast-total), got %q first", got[0].ID)
+	}
+	// Score fields must reflect totals: 700 beats 900.
+	if got[0].DurationScore <= got[1].DurationScore {
+		t.Errorf("expected fast-total DurationScore (%v) > fast-out (%v)", got[0].DurationScore, got[1].DurationScore)
+	}
+	// Displayed per-slice fields must be untouched by ranking.
+	if got[0].DurationMin != 500 || got[0].ReturnDurationMin != 200 {
+		t.Errorf("displayed durations changed: outbound=%d return=%d", got[0].DurationMin, got[0].ReturnDurationMin)
+	}
+}
+
+// Round-trip stops scoring counts return-slice stops (len(ReturnSegments)-1):
+// a nonstop outbound with a 2-stop return (total 2) must lose to a 1-stop
+// outbound with a nonstop return (total 1) when durations and price are equal.
+func TestRankRoundTripStopsUseTotalStops(t *testing.T) {
+	in := []FlightOffer{
+		roundTrip("nonstop-out-2stop-back", 400, "JFK", "CDG", "T1", "T2", 480, 0, 480, 3),
+		roundTrip("1stop-out-nonstop-back", 400, "JFK", "CDG", "T3", "T4", 480, 1, 480, 1),
+	}
+	got := RankFlightOffers(in, "balanced")
+	if got[0].ID != "1stop-out-nonstop-back" {
+		t.Fatalf("balanced ranking should pick the lower TOTAL stops, got %q first", got[0].ID)
+	}
+	if got[0].StopsScore <= got[1].StopsScore {
+		t.Errorf("expected total-stops=1 StopsScore (%v) > total-stops=2 (%v)", got[0].StopsScore, got[1].StopsScore)
+	}
+	// Displayed outbound stop counts stay per-slice.
+	if got[0].Stops != 1 || got[1].Stops != 0 {
+		t.Errorf("displayed outbound stops changed: got %d and %d", got[0].Stops, got[1].Stops)
+	}
+}
+
+// One-way scoring is byte-identical to the pre-round-trip behavior: with no
+// return slice, scoringDuration/scoringStops reduce to the outbound fields.
+// Pin exact scores on a known one-way fixture so any drift is caught.
+func TestRankOneWayScoringUnchanged(t *testing.T) {
+	in := []FlightOffer{
+		offer("slow-cheap", 200, "JFK", "CDG", "T1", "T2", 600, 1),
+		offer("fast-pricey", 400, "JFK", "ORY", "T3", "T4", 400, 0),
+	}
+	got := RankFlightOffers(in, "time")
+	if got[0].ID != "fast-pricey" {
+		t.Fatalf("time preset should favor the faster one-way, got %q first", got[0].ID)
+	}
+	// fast-pricey: price 10->0, duration 10, stops 10 => 0*0.15 + 10*0.60 + 10*0.25 = 8.5
+	if got[0].Score != 8.5 {
+		t.Errorf("expected fast-pricey score 8.5, got %v", got[0].Score)
+	}
+	// slow-cheap: price 10, duration 0, stops 0 => 10*0.15 = 1.5
+	if got[1].Score != 1.5 {
+		t.Errorf("expected slow-cheap score 1.5, got %v", got[1].Score)
+	}
+}
+
+// Mixed one-way/round-trip lists compare TOTALS as-is: a one-way's total is
+// just its outbound, so a round-trip offer with more total flown time scores
+// below a one-way with less — no per-slice averaging or trip-type buckets.
+func TestRankMixedOneWayAndRoundTripComparesTotals(t *testing.T) {
+	in := []FlightOffer{
+		// One-way: total 500, 0 stops.
+		offer("oneway", 300, "JFK", "CDG", "T1", "T2", 500, 0),
+		// Round-trip: outbound 400 (faster than the one-way's outbound!) but
+		// total 800 with 1 total stop.
+		roundTrip("roundtrip", 300, "JFK", "CDG", "T3", "T4", 400, 0, 400, 2),
+	}
+	got := RankFlightOffers(in, "time")
+	if got[0].ID != "oneway" {
+		t.Fatalf("expected the smaller-total one-way to rank first, got %q", got[0].ID)
+	}
+	if got[0].DurationScore != 10.0 || got[1].DurationScore != 0.0 {
+		t.Errorf("expected totals 500 vs 800 to score 10 vs 0, got %v and %v", got[0].DurationScore, got[1].DurationScore)
+	}
+	if got[0].StopsScore != 10.0 || got[1].StopsScore != 0.0 {
+		t.Errorf("expected total stops 0 vs 1 to score 10 vs 0, got %v and %v", got[0].StopsScore, got[1].StopsScore)
+	}
+}
+
+// cost ranking is unaffected by the round-trip totals change: total_amount
+// already prices both slices, so price weighting alone decides equal-price
+// factors the same way it did before.
+func TestRankRoundTripCostStillPriceDriven(t *testing.T) {
+	in := []FlightOffer{
+		roundTrip("cheap-slow", 200, "JFK", "CDG", "T1", "T2", 500, 1, 500, 2),
+		roundTrip("pricey-fast", 900, "JFK", "CDG", "T3", "T4", 300, 0, 300, 1),
+	}
+	got := RankFlightOffers(in, "cost")
+	if got[0].ID != "cheap-slow" {
+		t.Fatalf("cost preset should still favor the cheaper round-trip, got %q first", got[0].ID)
+	}
+}


### PR DESCRIPTION
## What

Wave 7's #69 added `return_segments`/`return_duration_minutes` to `FlightOffer` but deliberately left ranking on **outbound** duration/stops only. This closes that gap without touching display semantics.

### Scoring changes (`flight_optimizer.go`)

- New helpers `scoringDuration` / `scoringStops` feed `RankFlightOffers`:
  - `scoringDuration = DurationMin + ReturnDurationMin` (trip total)
  - `scoringStops = Stops + max(0, len(ReturnSegments)-1)` (a nonstop return slice has one segment)
- `time` and `balanced` now rank round-trip offers on TOTAL duration and TOTAL stops. `cost` semantics are unaffected — `total_amount` already prices both slices, and preset weights are unchanged.
- **One-way scoring is byte-identical**: with no return slice both helpers reduce exactly to `DurationMin`/`Stops`.
- **Displayed per-slice fields are untouched everywhere** — `duration_minutes`, `stops`, times, and segments keep their outbound-based meaning; only score inputs changed. No API shape changes.

### Mixed-list semantics

Mixed one-way/round-trip result sets compare **totals as-is**: a one-way's total is just its outbound, so a round-trip offer is naturally penalized for its extra flown time relative to a one-way in the same set. No per-slice averaging or trip-type bucketing. (In practice a single search is all-one-way or all-round-trip, so this only matters for hypothetical merged lists — documented in code and pinned by a test.)

### Price alerts interaction (verified)

`price_alert_checker.go` does **not** use the optimizer: it calls `duffel.SearchFlightOffers` directly and picks the tracked offer via `lowestOffer` (min price scan). Ranking changes therefore **cannot** change which offer any existing alert tracks — round-trip or otherwise. No alert behavior change to call out beyond this confirmation.

### Repair commit: committed conflict markers on main

`main` (81b5177, #76) contained **unresolved merge-conflict markers** in `src/packages/api/analytics_integration_test.go` (`<<<<<<< HEAD` … `>>>>>>> origin/main` between #76's `TestClientEventItineraryItemAdded` and #73's Wave 8 anonymous-events tests), breaking `go fmt`/`go vet`/`go test` on main. Both sides are additive test functions; the first commit here keeps both and removes the markers. All affected tests pass.

## Tests

New in `flight_optimizer_test.go`:
- `TestRankRoundTripTimeUsesTotalDuration` — fast-outbound/slow-return (total 900) loses to slow-outbound/fast-return (total 700) under `time`; displayed per-slice durations unchanged.
- `TestRankRoundTripStopsUseTotalStops` — nonstop-out/2-stop-back loses to 1-stop-out/nonstop-back; displayed outbound stops unchanged.
- `TestRankOneWayScoringUnchanged` — exact pre-change scores (8.5 / 1.5) pinned on a one-way fixture.
- `TestRankMixedOneWayAndRoundTripComparesTotals` — totals-as-is semantics pinned.
- `TestRankRoundTripCostStillPriceDriven` — `cost` still price-led.

Gates: `make api-fmt`, `make api-vet`, `go test ./...`, and `TEST_DATABASE_URL=...travel_test_w8f go test -count=1 ./...` (fresh DB) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)