### PR TITLE
feat(api): Places call counters + estimated spend on the admin dashboard

### DIFF
--- a/src/packages/api/admin_integration_test.go
+++ b/src/packages/api/admin_integration_test.go
@@ -44,6 +44,39 @@ func TestAdminMetricsForAdmin(t *testing.T) {
 	if body["days"] != float64(7) {
 		t.Fatalf("days = %v, want 7", body["days"])
 	}
+
+	// The process-lifetime provider counters must always be present (they
+	// come off in-process singletons, not the DB) under names that say they
+	// are NOT window-scoped. Values depend on what earlier tests did to the
+	// shared singletons, so assert shape + non-negativity, not exact counts.
+	places, ok := body["places_calls_since_process_start"].(map[string]any)
+	if !ok {
+		t.Fatalf("places_calls_since_process_start missing or not an object: %v", body["places_calls_since_process_start"])
+	}
+	for _, class := range []string{"search", "autocomplete", "details"} {
+		c, ok := places[class].(map[string]any)
+		if !ok {
+			t.Fatalf("places_calls_since_process_start.%s missing: %v", class, places[class])
+		}
+		for _, field := range []string{"upstream", "cache_hits"} {
+			n, ok := c[field].(float64)
+			if !ok || n < 0 {
+				t.Fatalf("places %s.%s = %v, want non-negative number", class, field, c[field])
+			}
+		}
+	}
+	if cost, ok := places["est_places_cost_usd"].(float64); !ok || cost < 0 {
+		t.Fatalf("est_places_cost_usd = %v, want non-negative number", places["est_places_cost_usd"])
+	}
+	events, ok := body["events_calls_since_process_start"].(map[string]any)
+	if !ok {
+		t.Fatalf("events_calls_since_process_start missing or not an object: %v", body["events_calls_since_process_start"])
+	}
+	for _, field := range []string{"upstream", "cache_hits"} {
+		if n, ok := events[field].(float64); !ok || n < 0 {
+			t.Fatalf("events %s = %v, want non-negative number", field, events[field])
+		}
+	}
 }
 
 // insertEvent writes an analytics event with an explicit created_at so tests

--- a/src/packages/api/analytics.go
+++ b/src/packages/api/analytics.go
@@ -233,8 +233,9 @@ func recordAnonymousClientEventHandler(w http.ResponseWriter, r *http.Request) {
 // Claude pricing used for the dashboard's COGS estimates (USD per million
 // tokens), pinned to the model plan_handler.go actually calls. If the /plan
 // model changes, update this block in the same commit. The resulting est_*
-// fields cover Claude spend ONLY — Google Places (and other provider) calls
-// are not metered yet (deferred, per specs/instrumentation-events).
+// fields cover Claude spend ONLY — Google Places spend is estimated
+// separately from the process-lifetime counters below (a different, non-
+// window-scoped basis, so the two estimates are never summed).
 const (
 	planCostModelID              = "claude-sonnet-4-6"
 	planCostInputUSDPerMTok      = 3.00
@@ -242,6 +243,51 @@ const (
 	planCostCacheWriteUSDPerMTok = 3.75 // 5-minute-TTL cache write (1.25x input)
 	planCostCacheReadUSDPerMTok  = 0.30 // cache read (0.1x input)
 )
+
+// Google Places pricing used for est_places_cost_usd, in USD per call.
+// Source: Google Maps Platform pricing table
+// (https://developers.google.com/maps/billing-and-pricing/pricing), list
+// prices for the legacy Places API endpoints places_service.go calls:
+//   - Text Search:            $32 / 1000 requests
+//   - Autocomplete (per-req): $2.83 / 1000 requests (no session tokens used)
+//   - Place Details:          $17 / 1000 requests (contact+atmosphere fields)
+//
+// ESTIMATES ONLY: actual billing varies with field masks, session tokens,
+// volume tiers, and the monthly free credit. Update alongside any endpoint
+// or field-mask change in places_service.go.
+const (
+	placesCostSearchUSDPerCall       = 32.0 / 1000
+	placesCostAutocompleteUSDPerCall = 2.83 / 1000
+	placesCostDetailsUSDPerCall      = 17.0 / 1000
+)
+
+// PlacesCallsSnapshot is the places_calls_since_process_start object: per-
+// endpoint-class upstream calls vs cache hits, plus the estimated upstream
+// spend those calls represent. PROCESS-LIFETIME (reset on restart/deploy) —
+// deliberately NOT scoped to the days window like the rest of
+// MetricsResponse, hence the loud field name.
+type PlacesCallsSnapshot struct {
+	Search       UpstreamCallCounts `json:"search"`
+	Autocomplete UpstreamCallCounts `json:"autocomplete"`
+	Details      UpstreamCallCounts `json:"details"`
+	// EstPlacesCostUSD prices the upstream counts with the placesCost*
+	// constants above. An estimate of list price, not a bill.
+	EstPlacesCostUSD float64 `json:"est_places_cost_usd"`
+}
+
+// placesCallsSnapshot prices a point-in-time read of the placesService
+// counters.
+func placesCallsSnapshot(gps *GooglePlacesService) PlacesCallsSnapshot {
+	s := PlacesCallsSnapshot{
+		Search:       gps.searchCalls.snapshot(),
+		Autocomplete: gps.autocompleteCalls.snapshot(),
+		Details:      gps.detailsCalls.snapshot(),
+	}
+	s.EstPlacesCostUSD = float64(s.Search.Upstream)*placesCostSearchUSDPerCall +
+		float64(s.Autocomplete.Upstream)*placesCostAutocompleteUSDPerCall +
+		float64(s.Details.Upstream)*placesCostDetailsUSDPerCall
+	return s
+}
 
 // MetricsResponse is the Phase 1 dashboard-in-an-endpoint, keyed to the
 // questions in docs/business-model.md §8 (activation, second-trip retention,
@@ -290,9 +336,11 @@ type MetricsResponse struct {
 	PlanCacheReadTokens   int64 `json:"plan_cache_read_tokens"`
 	PlanCacheCreateTokens int64 `json:"plan_cache_creation_tokens"`
 	// EstClaudeCostUSD / EstCogsPerActiveUser are ESTIMATES covering Claude
-	// spend only, from the planCost* pricing constants (Places calls are
-	// not counted — deferred). EstCostModel names the model whose pricing
-	// produced them, so the number is self-describing.
+	// spend only, from the planCost* pricing constants. Places spend is
+	// estimated separately in PlacesCallsSinceProcessStart (process-lifetime
+	// basis, so it cannot be folded into these windowed numbers).
+	// EstCostModel names the model whose pricing produced them, so the
+	// number is self-describing.
 	EstCostModel         string  `json:"est_cost_model"`
 	EstClaudeCostUSD     float64 `json:"est_claude_cost_usd"`
 	EstCogsPerActiveUser float64 `json:"est_cogs_per_active_user"`
@@ -307,6 +355,15 @@ type MetricsResponse struct {
 	// in code yet.
 	FreeCapWouldHits     map[string]int64 `json:"free_cap_would_hits"`
 	FreeCapUsersAffected map[string]int64 `json:"free_cap_users_affected"`
+	// PlacesCallsSinceProcessStart / EventsCallsSinceProcessStart are
+	// PROCESS-LIFETIME provider-call counters: they start at zero on API boot
+	// and reset on every restart/deploy. Unlike every field above they are
+	// NOT scoped to the Days window — the *_since_process_start names exist
+	// so nobody reads them as period metrics. Places carries an estimated
+	// upstream cost (COGS visibility); events is quota/cache visibility only
+	// (free tier).
+	PlacesCallsSinceProcessStart PlacesCallsSnapshot `json:"places_calls_since_process_start"`
+	EventsCallsSinceProcessStart UpstreamCallCounts  `json:"events_calls_since_process_start"`
 }
 
 // adminMetricsHandler is GET /api/v1/admin/metrics?days= (admin only; gated
@@ -386,9 +443,10 @@ func adminMetricsHandler(w http.ResponseWriter, r *http.Request) {
 		resp.SessionFrequencyReturning = eng.SessionFrequencyReturning
 		resp.SecondTripRetention = eng.SecondTripRetention
 	}
-	// Estimated Claude spend for the window (Claude only; Places not
-	// counted). input_tokens is the uncached remainder — cache reads and
-	// writes are billed separately at their own rates.
+	// Estimated Claude spend for the window (Claude only; Places is the
+	// separate process-lifetime estimate below). input_tokens is the
+	// uncached remainder — cache reads and writes are billed separately at
+	// their own rates.
 	resp.EstCostModel = planCostModelID
 	resp.EstClaudeCostUSD = (float64(resp.PlanInputTokens)*planCostInputUSDPerMTok +
 		float64(resp.PlanOutputTokens)*planCostOutputUSDPerMTok +
@@ -397,5 +455,9 @@ func adminMetricsHandler(w http.ResponseWriter, r *http.Request) {
 	if resp.ActiveUsers > 0 {
 		resp.EstCogsPerActiveUser = resp.EstClaudeCostUSD / float64(resp.ActiveUsers)
 	}
+	// Process-lifetime provider-call telemetry (not window-scoped; see the
+	// field comments). Read straight off the singletons — no DB involved.
+	resp.PlacesCallsSinceProcessStart = placesCallsSnapshot(placesService)
+	resp.EventsCallsSinceProcessStart = eventsService.calls.snapshot()
 	writeJSON(w, http.StatusOK, resp)
 }

--- a/src/packages/api/analytics_integration_test.go
+++ b/src/packages/api/analytics_integration_test.go
@@ -103,7 +103,6 @@ func TestClientEventOwnTripIDIsKept(t *testing.T) {
 	}
 }
 
-<<<<<<< HEAD
 // itinerary_item_added (specs/add-to-itinerary): accepted as a client event,
 // with metadata "source" constrained to the closed value set the dashboard
 // groups on — anything else is dropped, never stored.
@@ -162,7 +161,6 @@ func TestClientEventItineraryItemAdded(t *testing.T) {
 	}
 }
 
-=======
 // --- anonymous top-of-funnel events (Wave 8) ---
 
 // countAnonymousEvents counts rows with a NULL user_id for one event type.
@@ -332,7 +330,6 @@ func TestAuthedEventsNotOnStrictTier(t *testing.T) {
 	waitForEventCount(t, user.ID, "booking_link_clicked", 10)
 }
 
->>>>>>> origin/main
 func TestClientEventMetadataSanitized(t *testing.T) {
 	resetDB(t)
 	user, token := createTestUser(t, "meta-abuser@example.com")

--- a/src/packages/api/events_service.go
+++ b/src/packages/api/events_service.go
@@ -28,6 +28,12 @@ type EventsService struct {
 	// searches within the TTL are served from memory (same pattern as the
 	// Duffel airport cache). Short TTL: event inventory shifts.
 	cache *ttlCache[[]Event]
+
+	// Process-lifetime upstream-vs-cache-hit counters (reset on restart,
+	// atomic — see upstreamCallCounters in places_service.go). No cost
+	// estimate: the Ticketmaster key is free tier; this is quota/cache
+	// visibility only.
+	calls upstreamCallCounters
 }
 
 // Event is a normalized local event (concert, sport, festival, show) used by
@@ -104,6 +110,7 @@ func (s *EventsService) SearchEvents(ctx context.Context, city, startDate, endDa
 	}
 	cacheKey := strings.ToLower(strings.TrimSpace(city)) + "|" + strings.TrimSpace(startDate) + "|" + strings.TrimSpace(endDate) + "|" + cat
 	if cached, ok := s.cache.get(cacheKey); ok {
+		s.calls.cacheHits.Add(1)
 		return cached, nil
 	}
 
@@ -129,6 +136,7 @@ func (s *EventsService) SearchEvents(ctx context.Context, city, startDate, endDa
 	}
 	req.Header.Set("Accept", "application/json")
 
+	s.calls.upstream.Add(1)
 	resp, err := s.Client.Do(req)
 	if err != nil {
 		// redactTransportError: a *url.Error would embed the request URL,

--- a/src/packages/api/events_service_test.go
+++ b/src/packages/api/events_service_test.go
@@ -49,6 +49,10 @@ func TestSearchEventsServedFromCache(t *testing.T) {
 	if len(first) != 1 || len(second) != 1 || second[0].ID != "e1" {
 		t.Fatalf("cached result mismatch: first=%v second=%v", first, second)
 	}
+	// Quota-visibility counters mirror the traffic: one upstream, one hit.
+	if c := svc.calls.snapshot(); c.Upstream != 1 || c.CacheHits != 1 {
+		t.Fatalf("events counters = %+v, want upstream=1 cache_hits=1", c)
+	}
 }
 
 func TestSearchEventsCacheKeyCoversInputs(t *testing.T) {

--- a/src/packages/api/places_service.go
+++ b/src/packages/api/places_service.go
@@ -9,8 +9,33 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"sync/atomic"
 	"time"
 )
+
+// upstreamCallCounters tracks billable upstream calls vs cache hits for one
+// endpoint class of a provider service. PROCESS-LIFETIME: counters start at
+// zero on boot and reset on every restart/deploy — they are telemetry for
+// directional spend visibility, not audited, window-scoped analytics (nothing
+// here is persisted). Atomic adds only, so the hot path takes no locks and
+// gains no contention.
+type upstreamCallCounters struct {
+	upstream  atomic.Int64
+	cacheHits atomic.Int64
+}
+
+// UpstreamCallCounts is the JSON snapshot of one counter pair, as exposed by
+// the admin metrics endpoint.
+type UpstreamCallCounts struct {
+	Upstream  int64 `json:"upstream"`
+	CacheHits int64 `json:"cache_hits"`
+}
+
+// snapshot reads both counters. The two loads are not a single atomic unit,
+// which is fine for a dashboard tile.
+func (c *upstreamCallCounters) snapshot() UpstreamCallCounts {
+	return UpstreamCallCounts{Upstream: c.upstream.Load(), CacheHits: c.cacheHits.Load()}
+}
 
 // redactTransportError strips the request URL from transport-level HTTP
 // errors before they enter an error chain. http.Client failures come back as
@@ -40,6 +65,16 @@ type GooglePlacesService struct {
 	searchCache       *ttlCache[[]PlaceSearchResult]
 	autocompleteCache *ttlCache[[]PlaceAutocompleteResult]
 	detailsCache      *ttlCache[*PlaceDetailsResult]
+
+	// Process-lifetime call counters per endpoint class (see
+	// upstreamCallCounters — reset on restart, atomic, never persisted).
+	// "upstream" increments at the exact point an HTTP request to Google is
+	// issued (the billable moment); "cacheHits" where the TTL cache
+	// short-circuits. Snapshotted by the admin metrics endpoint for
+	// directional Places-spend visibility.
+	searchCalls       upstreamCallCounters
+	autocompleteCalls upstreamCallCounters
+	detailsCalls      upstreamCallCounters
 }
 
 // PlaceSearchResult represents a place from Google Places API
@@ -114,6 +149,7 @@ func (gps *GooglePlacesService) SearchPlaces(query string) ([]PlaceSearchResult,
 
 	cacheKey := strings.ToLower(strings.TrimSpace(query))
 	if cached, ok := gps.searchCache.get(cacheKey); ok {
+		gps.searchCalls.cacheHits.Add(1)
 		return cached, nil
 	}
 
@@ -123,6 +159,7 @@ func (gps *GooglePlacesService) SearchPlaces(query string) ([]PlaceSearchResult,
 	params.Add("query", query)
 	params.Add("key", gps.APIKey)
 
+	gps.searchCalls.upstream.Add(1)
 	resp, err := gps.Client.Get(baseURL + "?" + params.Encode())
 	if err != nil {
 		return nil, fmt.Errorf("failed to search places: %w", redactTransportError(err))
@@ -186,6 +223,7 @@ func (gps *GooglePlacesService) GetPlaceAutocomplete(input string) ([]PlaceAutoc
 
 	cacheKey := strings.ToLower(strings.TrimSpace(input))
 	if cached, ok := gps.autocompleteCache.get(cacheKey); ok {
+		gps.autocompleteCalls.cacheHits.Add(1)
 		return cached, nil
 	}
 
@@ -194,6 +232,7 @@ func (gps *GooglePlacesService) GetPlaceAutocomplete(input string) ([]PlaceAutoc
 	params.Add("input", input)
 	params.Add("key", gps.APIKey)
 
+	gps.autocompleteCalls.upstream.Add(1)
 	resp, err := gps.Client.Get(baseURL + "?" + params.Encode())
 	if err != nil {
 		return nil, fmt.Errorf("failed to get autocomplete: %w", redactTransportError(err))
@@ -242,6 +281,7 @@ func (gps *GooglePlacesService) GetPlaceDetails(placeID string) (*PlaceDetailsRe
 	}
 
 	if cached, ok := gps.detailsCache.get(placeID); ok {
+		gps.detailsCalls.cacheHits.Add(1)
 		return cached, nil
 	}
 
@@ -251,6 +291,7 @@ func (gps *GooglePlacesService) GetPlaceDetails(placeID string) (*PlaceDetailsRe
 	params.Add("fields", "place_id,name,formatted_address,geometry,types,rating,price_level,opening_hours,website,formatted_phone_number")
 	params.Add("key", gps.APIKey)
 
+	gps.detailsCalls.upstream.Add(1)
 	resp, err := gps.Client.Get(baseURL + "?" + params.Encode())
 	if err != nil {
 		return nil, fmt.Errorf("failed to get place details: %w", redactTransportError(err))

--- a/src/packages/api/places_service_test.go
+++ b/src/packages/api/places_service_test.go
@@ -52,6 +52,15 @@ func TestSearchPlacesServedFromCache(t *testing.T) {
 	if len(first) != 1 || len(second) != 1 || second[0].PlaceID != "p1" {
 		t.Fatalf("cached result mismatch: first=%v second=%v", first, second)
 	}
+
+	// The COGS counters must mirror what actually happened: one billable
+	// upstream call (the miss), one cache hit (no upstream increment).
+	if got := svc.searchCalls.snapshot(); got.Upstream != 1 || got.CacheHits != 1 {
+		t.Fatalf("search counters = %+v, want upstream=1 cache_hits=1", got)
+	}
+	if got := svc.autocompleteCalls.snapshot(); got.Upstream != 0 || got.CacheHits != 0 {
+		t.Fatalf("autocomplete counters moved on a search-only path: %+v", got)
+	}
 }
 
 func TestGetPlaceDetailsServedFromCache(t *testing.T) {
@@ -72,6 +81,50 @@ func TestGetPlaceDetailsServedFromCache(t *testing.T) {
 	}
 	if got == nil || got.Name != "Louvre Museum" {
 		t.Fatalf("cached details mismatch: %+v", got)
+	}
+	if c := svc.detailsCalls.snapshot(); c.Upstream != 1 || c.CacheHits != 1 {
+		t.Fatalf("details counters = %+v, want upstream=1 cache_hits=1", c)
+	}
+}
+
+const fakeAutocompleteJSON = `{"status":"OK","predictions":[{"place_id":"p1","description":"Louvre Museum, Paris","types":["museum"]}]}`
+
+func TestAutocompleteCountersTrackMissAndHit(t *testing.T) {
+	rt := &countingTransport{body: fakeAutocompleteJSON}
+	svc := NewGooglePlacesService()
+	svc.APIKey = "test-key"
+	svc.Client = &http.Client{Transport: rt}
+
+	if _, err := svc.GetPlaceAutocomplete("louvre"); err != nil {
+		t.Fatalf("first autocomplete failed: %v", err)
+	}
+	if _, err := svc.GetPlaceAutocomplete(" LOUVRE "); err != nil {
+		t.Fatalf("second autocomplete failed: %v", err)
+	}
+	if rt.calls != 1 {
+		t.Fatalf("Google called %d times, want 1", rt.calls)
+	}
+	if c := svc.autocompleteCalls.snapshot(); c.Upstream != 1 || c.CacheHits != 1 {
+		t.Fatalf("autocomplete counters = %+v, want upstream=1 cache_hits=1", c)
+	}
+}
+
+// placesCallsSnapshot must price exactly the UPSTREAM counts (cache hits are
+// free) with the per-class constants — the dashboard's est_places_cost_usd.
+func TestPlacesCallsSnapshotPricing(t *testing.T) {
+	svc := NewGooglePlacesService()
+	svc.searchCalls.upstream.Add(1000)       // $32
+	svc.searchCalls.cacheHits.Add(500)       // free
+	svc.autocompleteCalls.upstream.Add(1000) // $2.83
+	svc.detailsCalls.upstream.Add(1000)      // $17
+
+	snap := placesCallsSnapshot(svc)
+	if snap.Search.Upstream != 1000 || snap.Search.CacheHits != 500 {
+		t.Fatalf("search snapshot = %+v", snap.Search)
+	}
+	want := 32.0 + 2.83 + 17.0
+	if diff := snap.EstPlacesCostUSD - want; diff > 1e-9 || diff < -1e-9 {
+		t.Fatalf("est_places_cost_usd = %v, want %v", snap.EstPlacesCostUSD, want)
 	}
 }
 

--- a/src/packages/flutter-app/lib/models/admin_metrics.dart
+++ b/src/packages/flutter-app/lib/models/admin_metrics.dart
@@ -2,6 +2,50 @@ import 'package:json_annotation/json_annotation.dart';
 
 part 'admin_metrics.g.dart';
 
+/// One provider-call counter pair: billable upstream calls vs cache hits.
+/// PROCESS-LIFETIME on the API side — resets on every restart/deploy, and is
+/// NOT scoped to the dashboard's days window.
+@JsonSerializable()
+class UpstreamCallCounts {
+  final int upstream;
+  @JsonKey(name: 'cache_hits')
+  final int cacheHits;
+
+  const UpstreamCallCounts({this.upstream = 0, this.cacheHits = 0});
+
+  factory UpstreamCallCounts.fromJson(Map<String, dynamic> json) =>
+      _$UpstreamCallCountsFromJson(json);
+  Map<String, dynamic> toJson() => _$UpstreamCallCountsToJson(this);
+}
+
+/// Mirror of the API's places_calls_since_process_start object: per-class
+/// Google Places call counters plus the estimated upstream spend (list-price
+/// estimate, not a bill). Process-lifetime — see [UpstreamCallCounts].
+@JsonSerializable()
+class PlacesCalls {
+  final UpstreamCallCounts search;
+  final UpstreamCallCounts autocomplete;
+  final UpstreamCallCounts details;
+  @JsonKey(name: 'est_places_cost_usd')
+  final double estPlacesCostUsd;
+
+  const PlacesCalls({
+    this.search = const UpstreamCallCounts(),
+    this.autocomplete = const UpstreamCallCounts(),
+    this.details = const UpstreamCallCounts(),
+    this.estPlacesCostUsd = 0,
+  });
+
+  int get totalUpstream =>
+      search.upstream + autocomplete.upstream + details.upstream;
+  int get totalCacheHits =>
+      search.cacheHits + autocomplete.cacheHits + details.cacheHits;
+
+  factory PlacesCalls.fromJson(Map<String, dynamic> json) =>
+      _$PlacesCallsFromJson(json);
+  Map<String, dynamic> toJson() => _$PlacesCallsToJson(this);
+}
+
 /// Mirror of the API's MetricsResponse (GET /admin/metrics?days=) — the
 /// Phase-1 growth funnel: activation, attach rate, retention, AI cost.
 @JsonSerializable()
@@ -83,6 +127,17 @@ class AdminMetrics {
   @JsonKey(name: 'free_cap_users_affected')
   final Map<String, int> freeCapUsersAffected;
 
+  /// PROCESS-LIFETIME Google Places call counters + estimated spend, reset on
+  /// every API restart/deploy — NOT scoped to the days window like the rest
+  /// of this model. Nullable: absent on API builds older than this field.
+  @JsonKey(name: 'places_calls_since_process_start')
+  final PlacesCalls? placesCallsSinceProcessStart;
+
+  /// PROCESS-LIFETIME Ticketmaster call counters (free tier — quota/cache
+  /// visibility, no cost estimate). Nullable: absent on older API builds.
+  @JsonKey(name: 'events_calls_since_process_start')
+  final UpstreamCallCounts? eventsCallsSinceProcessStart;
+
   const AdminMetrics({
     this.days = 30,
     this.signups = 0,
@@ -112,6 +167,8 @@ class AdminMetrics {
     this.alertsTriggered = 0,
     this.freeCapWouldHits = const {},
     this.freeCapUsersAffected = const {},
+    this.placesCallsSinceProcessStart,
+    this.eventsCallsSinceProcessStart,
   });
 
   factory AdminMetrics.fromJson(Map<String, dynamic> json) =>

--- a/src/packages/flutter-app/lib/models/admin_metrics.g.dart
+++ b/src/packages/flutter-app/lib/models/admin_metrics.g.dart
@@ -6,6 +6,41 @@ part of 'admin_metrics.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
+UpstreamCallCounts _$UpstreamCallCountsFromJson(Map<String, dynamic> json) =>
+    UpstreamCallCounts(
+      upstream: (json['upstream'] as num?)?.toInt() ?? 0,
+      cacheHits: (json['cache_hits'] as num?)?.toInt() ?? 0,
+    );
+
+Map<String, dynamic> _$UpstreamCallCountsToJson(UpstreamCallCounts instance) =>
+    <String, dynamic>{
+      'upstream': instance.upstream,
+      'cache_hits': instance.cacheHits,
+    };
+
+PlacesCalls _$PlacesCallsFromJson(Map<String, dynamic> json) => PlacesCalls(
+      search: json['search'] == null
+          ? const UpstreamCallCounts()
+          : UpstreamCallCounts.fromJson(json['search'] as Map<String, dynamic>),
+      autocomplete: json['autocomplete'] == null
+          ? const UpstreamCallCounts()
+          : UpstreamCallCounts.fromJson(
+              json['autocomplete'] as Map<String, dynamic>),
+      details: json['details'] == null
+          ? const UpstreamCallCounts()
+          : UpstreamCallCounts.fromJson(
+              json['details'] as Map<String, dynamic>),
+      estPlacesCostUsd: (json['est_places_cost_usd'] as num?)?.toDouble() ?? 0,
+    );
+
+Map<String, dynamic> _$PlacesCallsToJson(PlacesCalls instance) =>
+    <String, dynamic>{
+      'search': instance.search,
+      'autocomplete': instance.autocomplete,
+      'details': instance.details,
+      'est_places_cost_usd': instance.estPlacesCostUsd,
+    };
+
 AdminMetrics _$AdminMetricsFromJson(Map<String, dynamic> json) => AdminMetrics(
       days: (json['days'] as num?)?.toInt() ?? 30,
       signups: (json['signups'] as num?)?.toInt() ?? 0,
@@ -55,6 +90,16 @@ AdminMetrics _$AdminMetricsFromJson(Map<String, dynamic> json) => AdminMetrics(
                 (k, e) => MapEntry(k, (e as num).toInt()),
               ) ??
               const {},
+      placesCallsSinceProcessStart: json['places_calls_since_process_start'] ==
+              null
+          ? null
+          : PlacesCalls.fromJson(
+              json['places_calls_since_process_start'] as Map<String, dynamic>),
+      eventsCallsSinceProcessStart: json['events_calls_since_process_start'] ==
+              null
+          ? null
+          : UpstreamCallCounts.fromJson(
+              json['events_calls_since_process_start'] as Map<String, dynamic>),
     );
 
 Map<String, dynamic> _$AdminMetricsToJson(AdminMetrics instance) =>
@@ -87,4 +132,6 @@ Map<String, dynamic> _$AdminMetricsToJson(AdminMetrics instance) =>
       'alerts_triggered': instance.alertsTriggered,
       'free_cap_would_hits': instance.freeCapWouldHits,
       'free_cap_users_affected': instance.freeCapUsersAffected,
+      'places_calls_since_process_start': instance.placesCallsSinceProcessStart,
+      'events_calls_since_process_start': instance.eventsCallsSinceProcessStart,
     };

--- a/src/packages/flutter-app/lib/screens/admin_metrics_screen.dart
+++ b/src/packages/flutter-app/lib/screens/admin_metrics_screen.dart
@@ -139,6 +139,48 @@ class _MetricsBody extends StatelessWidget {
           _Stat('Tokens out', _tokens(m.planOutputTokens),
               caption: 'est. ${_usd(m.estClaudeCostUsd)} total'),
         ]),
+        if (m.placesCallsSinceProcessStart != null ||
+            m.eventsCallsSinceProcessStart != null) ...[
+          const SizedBox(height: AppSpacing.xl),
+          // Deliberately labeled "(since restart)": these counters are
+          // process-lifetime on the API and reset on every deploy — they are
+          // NOT scoped to the selected window above.
+          const SectionHeader(title: 'Provider APIs (since restart)'),
+          const SizedBox(height: AppSpacing.xs),
+          Text(
+            'Process-lifetime counters — reset on API restart, '
+            'not scoped to the selected window.',
+            style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                  color: Theme.of(context).colorScheme.onSurfaceVariant,
+                ),
+          ),
+          const SizedBox(height: AppSpacing.sm),
+          _TileGrid(tiles: [
+            if (m.placesCallsSinceProcessStart != null) ...[
+              _Stat(
+                'Places API (since restart)',
+                '${m.placesCallsSinceProcessStart!.totalUpstream}',
+                caption:
+                    '${m.placesCallsSinceProcessStart!.totalCacheHits} cache hits'
+                    ' · est. ${_usd(m.placesCallsSinceProcessStart!.estPlacesCostUsd)}',
+              ),
+              _Stat(
+                'Places by class',
+                '${m.placesCallsSinceProcessStart!.search.upstream} search',
+                caption:
+                    '${m.placesCallsSinceProcessStart!.autocomplete.upstream} autocomplete'
+                    ' · ${m.placesCallsSinceProcessStart!.details.upstream} details',
+              ),
+            ],
+            if (m.eventsCallsSinceProcessStart != null)
+              _Stat(
+                'Events API (since restart)',
+                '${m.eventsCallsSinceProcessStart!.upstream}',
+                caption:
+                    '${m.eventsCallsSinceProcessStart!.cacheHits} cache hits · free tier',
+              ),
+          ]),
+        ],
         const SizedBox(height: AppSpacing.xl),
         const SectionHeader(title: 'Price alerts'),
         const SizedBox(height: AppSpacing.sm),

--- a/src/packages/flutter-app/test/admin_metrics_screen_test.dart
+++ b/src/packages/flutter-app/test/admin_metrics_screen_test.dart
@@ -36,6 +36,14 @@ void main() {
       alertsTriggered: 1,
       freeCapWouldHits: {'plan_runs': 3, 'active_trips': 1},
       freeCapUsersAffected: {'plan_runs': 2, 'active_trips': 1},
+      placesCallsSinceProcessStart: PlacesCalls(
+        search: UpstreamCallCounts(upstream: 100, cacheHits: 400),
+        autocomplete: UpstreamCallCounts(upstream: 50, cacheHits: 10),
+        details: UpstreamCallCounts(upstream: 25, cacheHits: 5),
+        estPlacesCostUsd: 3.77,
+      ),
+      eventsCallsSinceProcessStart:
+          UpstreamCallCounts(upstream: 9, cacheHits: 3),
     );
 
     await tester.pumpWidget(
@@ -67,6 +75,43 @@ void main() {
         find.text('1 users affected'), findsOneWidget); // active_trips cohort
     expect(find.text('Clicks by provider'), findsOneWidget);
     expect(find.text('booking'), findsOneWidget);
+    expect(find.text('Price alerts'), findsOneWidget);
+
+    // Provider-call counters: honestly labeled as since-restart, with the
+    // per-class breakdown and the Places cost estimate.
+    expect(find.text('Provider APIs (since restart)'), findsOneWidget);
+    expect(find.text('Places API (since restart)'), findsOneWidget);
+    expect(find.text('175'), findsOneWidget); // total upstream
+    expect(find.text('415 cache hits · est. \$3.77'), findsOneWidget);
+    expect(find.text('100 search'), findsOneWidget);
+    expect(find.text('50 autocomplete · 25 details'), findsOneWidget);
+    expect(find.text('Events API (since restart)'), findsOneWidget);
+    expect(find.text('3 cache hits · free tier'), findsOneWidget);
+  });
+
+  testWidgets('omits provider-call section when the API predates it',
+      (tester) async {
+    tester.view.physicalSize = const Size(800, 2400);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+
+    // An older API omits the *_since_process_start fields entirely — the
+    // model must parse (nullable) and the screen must skip the section.
+    final metrics = AdminMetrics.fromJson(const {'days': 30, 'signups': 1});
+    expect(metrics.placesCallsSinceProcessStart, isNull);
+    expect(metrics.eventsCallsSinceProcessStart, isNull);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          adminMetricsProvider(30).overrideWith((ref) async => metrics),
+        ],
+        child: const MaterialApp(home: AdminMetricsScreen()),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Provider APIs (since restart)'), findsNothing);
     expect(find.text('Price alerts'), findsOneWidget);
   });
 


### PR DESCRIPTION
## What

Wave 7's dashboard (#68) labeled COGS "est. (Claude only)" because Google Places calls were invisible. This gives the admin dashboard directional Places-spend visibility — the deliberately simple v1 (per-user attribution was cut as fiddly).

### API
- **Atomic counters on the Places singleton** (`places_service.go`): per endpoint class (search / autocomplete / details), `upstream` increments at the exact point an HTTP request to Google is issued (the billable moment); `cache_hits` where the TTL cache short-circuits. `sync/atomic` adds only — zero locks/contention on the hot path.
- **Exposed in `MetricsResponse`** (`analytics.go`) as `places_calls_since_process_start`: per-class `{upstream, cache_hits}` + `est_places_cost_usd` computed from a named const block with sourced list prices (Text Search $32/1000, Autocomplete per-request $2.83/1000, Place Details $17/1000 — Google Maps Platform pricing table; clearly labeled estimates).
- **Ticketmaster events cache** gets the same counter pair (`events_calls_since_process_start`) — it dropped out naturally from the shared `upstreamCallCounters` type. No cost estimate (free tier).
- **Honesty**: these are process-lifetime counters that reset on restart/deploy — the `*_since_process_start` JSON names and the "(since restart)" dashboard labels exist so they can never read as period-scoped alongside the windowed metrics. No migrations, no `analytics_events` writes, degraded mode unaffected (counters live on in-process singletons, no DB involved).

### Flutter
- `AdminMetrics` gains nullable `placesCallsSinceProcessStart` / `eventsCallsSinceProcessStart` (`PlacesCalls` / `UpstreamCallCounts`) — older API builds simply omit the section.
- Admin metrics screen: "Provider APIs (since restart)" tile group with upstream/cache-hit counts, per-class breakdown, and the est. cost, plus an explicit "reset on API restart, not scoped to the selected window" caption.

### Also
- Removes committed merge-conflict markers in `analytics_integration_test.go` (landed on main in 81b5177/#76; broke compilation of the whole API test package). Both conflict sides were additive test blocks — kept both. Separate commit.

## Tests
- Go unit: counters increment upstream-on-miss / cache-hit-without-upstream for all three Places classes + events; snapshot pricing math ($51.83 for 1000 of each class, cache hits free).
- Go integration (own DB `travel_test_w8e`): admin metrics response asserted to carry the new objects with non-negative counts under the since-process-start names.
- Flutter: tile rendering with counters present; section omitted + `fromJson` tolerant when the API predates the fields. `flutter analyze --no-fatal-infos --fatal-warnings` exit 0 (12 pre-existing infos, none added).

🤖 Generated with [Claude Code](https://claude.com/claude-code)