### PR TITLE
refactor(flutter): dedup sweep — headers, snacks, pills, weather, guides list

### DIFF
--- a/src/packages/api/weather_service.go
+++ b/src/packages/api/weather_service.go
@@ -158,9 +158,9 @@ func (s *WeatherService) GetTripWeather(ctx context.Context, city, startDate, en
 	}
 	var report WeatherReport
 	if !end.Before(today) && time.Until(end) <= forecastHorizonDays*24*time.Hour {
-		report, err = s.fetchForecast(ctx, geo, fcStart, end)
+		report, err = s.fetchDaily(ctx, geo, fcStart, end, true)
 	} else {
-		report, err = s.fetchArchive(ctx, geo, start.AddDate(-1, 0, 0), end.AddDate(-1, 0, 0))
+		report, err = s.fetchDaily(ctx, geo, start.AddDate(-1, 0, 0), end.AddDate(-1, 0, 0), false)
 	}
 	if err != nil {
 		return WeatherReport{}, err
@@ -170,7 +170,10 @@ func (s *WeatherService) GetTripWeather(ctx context.Context, city, startDate, en
 	return report, nil
 }
 
-func (s *WeatherService) fetchForecast(ctx context.Context, geo geoResult, start, end time.Time) (WeatherReport, error) {
+// fetchDaily hits Open-Meteo's forecast or archive endpoint — the two share
+// the same daily-series shape, except the archive carries no precipitation
+// probability — and maps the response onto a WeatherReport.
+func (s *WeatherService) fetchDaily(ctx context.Context, geo geoResult, start, end time.Time, forecast bool) (WeatherReport, error) {
 	var out struct {
 		Daily struct {
 			Time         []string  `json:"time"`
@@ -180,12 +183,18 @@ func (s *WeatherService) fetchForecast(ctx context.Context, geo geoResult, start
 			PrecipChance []int     `json:"precipitation_probability_mean"`
 		} `json:"daily"`
 	}
-	u := fmt.Sprintf("%s/v1/forecast?latitude=%f&longitude=%f&daily=temperature_2m_max,temperature_2m_min,precipitation_sum,precipitation_probability_mean&timezone=auto&start_date=%s&end_date=%s",
-		s.ForecastBaseURL, geo.Lat, geo.Lon, start.Format(dateLayout), end.Format(dateLayout))
+	base, endpoint, daily, kind := s.ArchiveBaseURL, "archive",
+		"temperature_2m_max,temperature_2m_min,precipitation_sum", "historical"
+	if forecast {
+		base, endpoint, kind = s.ForecastBaseURL, "forecast", "forecast"
+		daily += ",precipitation_probability_mean"
+	}
+	u := fmt.Sprintf("%s/v1/%s?latitude=%f&longitude=%f&daily=%s&timezone=auto&start_date=%s&end_date=%s",
+		base, endpoint, geo.Lat, geo.Lon, daily, start.Format(dateLayout), end.Format(dateLayout))
 	if err := s.getJSON(ctx, u, &out); err != nil {
 		return WeatherReport{}, err
 	}
-	report := WeatherReport{Kind: "forecast"}
+	report := WeatherReport{Kind: kind}
 	for i, d := range out.Daily.Time {
 		day := WeatherDay{Date: d}
 		if i < len(out.Daily.TempMax) {
@@ -197,40 +206,9 @@ func (s *WeatherService) fetchForecast(ctx context.Context, geo geoResult, start
 		if i < len(out.Daily.PrecipSum) {
 			day.PrecipMM = out.Daily.PrecipSum[i]
 		}
-		if i < len(out.Daily.PrecipChance) {
+		if forecast && i < len(out.Daily.PrecipChance) {
 			p := out.Daily.PrecipChance[i]
 			day.PrecipPct = &p
-		}
-		report.Days = append(report.Days, day)
-	}
-	return report, nil
-}
-
-func (s *WeatherService) fetchArchive(ctx context.Context, geo geoResult, start, end time.Time) (WeatherReport, error) {
-	var out struct {
-		Daily struct {
-			Time      []string  `json:"time"`
-			TempMax   []float64 `json:"temperature_2m_max"`
-			TempMin   []float64 `json:"temperature_2m_min"`
-			PrecipSum []float64 `json:"precipitation_sum"`
-		} `json:"daily"`
-	}
-	u := fmt.Sprintf("%s/v1/archive?latitude=%f&longitude=%f&daily=temperature_2m_max,temperature_2m_min,precipitation_sum&timezone=auto&start_date=%s&end_date=%s",
-		s.ArchiveBaseURL, geo.Lat, geo.Lon, start.Format(dateLayout), end.Format(dateLayout))
-	if err := s.getJSON(ctx, u, &out); err != nil {
-		return WeatherReport{}, err
-	}
-	report := WeatherReport{Kind: "historical"}
-	for i, d := range out.Daily.Time {
-		day := WeatherDay{Date: d}
-		if i < len(out.Daily.TempMax) {
-			day.TempMaxC = out.Daily.TempMax[i]
-		}
-		if i < len(out.Daily.TempMin) {
-			day.TempMinC = out.Daily.TempMin[i]
-		}
-		if i < len(out.Daily.PrecipSum) {
-			day.PrecipMM = out.Daily.PrecipSum[i]
 		}
 		report.Days = append(report.Days, day)
 	}

--- a/src/packages/flutter-app/lib/screens/account_settings_screen.dart
+++ b/src/packages/flutter-app/lib/screens/account_settings_screen.dart
@@ -7,6 +7,7 @@ import '../theme/spacing.dart';
 import '../widgets/legal_links.dart';
 import '../widgets/page_container.dart';
 import '../widgets/section_header.dart';
+import '../utils/snack.dart';
 
 final accountApiServiceProvider = Provider<AccountApiService>((ref) {
   return AccountApiService(ref.watch(apiClientProvider));
@@ -45,8 +46,7 @@ class _AccountSettingsScreenState extends ConsumerState<AccountSettingsScreen> {
   }
 
   void _snack(String msg) {
-    if (!mounted) return;
-    ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(msg)));
+    if (mounted) showSnack(context, msg);
   }
 
   String _errText(Object e) => '$e'.replaceFirst('Exception: ', '');

--- a/src/packages/flutter-app/lib/screens/airbnb_parser_screen.dart
+++ b/src/packages/flutter-app/lib/screens/airbnb_parser_screen.dart
@@ -8,6 +8,7 @@ import '../providers/accommodations_provider.dart';
 import '../providers/auth_provider.dart';
 import '../providers/trips_provider.dart';
 import 'trip_detail_screen.dart';
+import '../utils/snack.dart';
 
 class AirbnbParserScreen extends ConsumerStatefulWidget {
   const AirbnbParserScreen({super.key});
@@ -202,9 +203,7 @@ class _AirbnbParserScreenState extends ConsumerState<AirbnbParserScreen> {
   }
 
   void _snack(String msg) {
-    if (mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(msg)));
-    }
+    if (mounted) showSnack(context, msg);
   }
 
   List<Widget> _buildResults(BuildContext context, AirbnbListing listing) {

--- a/src/packages/flutter-app/lib/screens/alerts_screen.dart
+++ b/src/packages/flutter-app/lib/screens/alerts_screen.dart
@@ -6,6 +6,7 @@ import '../providers/auth_provider.dart';
 import '../theme/spacing.dart';
 import '../widgets/empty_state.dart';
 import '../widgets/page_container.dart';
+import '../widgets/status_pill.dart';
 import 'auth_screen.dart';
 import '../utils/snack.dart';
 
@@ -247,20 +248,6 @@ class _AlertPill extends StatelessWidget {
       bg = theme.colorScheme.primaryContainer.withValues(alpha: 0.5);
       fg = theme.colorScheme.onPrimaryContainer;
     }
-    return Container(
-      padding:
-          const EdgeInsets.symmetric(horizontal: AppSpacing.sm, vertical: 3),
-      decoration: BoxDecoration(
-        color: bg,
-        borderRadius: BorderRadius.circular(AppRadius.lg),
-      ),
-      child: Text(
-        label,
-        style: theme.textTheme.labelSmall?.copyWith(
-          color: fg,
-          fontWeight: FontWeight.w600,
-        ),
-      ),
-    );
+    return StatusPill.custom(label: label, background: bg, foreground: fg);
   }
 }

--- a/src/packages/flutter-app/lib/screens/alerts_screen.dart
+++ b/src/packages/flutter-app/lib/screens/alerts_screen.dart
@@ -7,6 +7,7 @@ import '../theme/spacing.dart';
 import '../widgets/empty_state.dart';
 import '../widgets/page_container.dart';
 import 'auth_screen.dart';
+import '../utils/snack.dart';
 
 /// The traveler's watched routes (specs/price-alerts): state at a glance,
 /// pause/resume/delete. Creation happens from flight search results.
@@ -154,10 +155,7 @@ class _AlertCard extends ConsumerWidget {
       try {
         await action();
       } catch (e) {
-        if (context.mounted) {
-          ScaffoldMessenger.of(context)
-              .showSnackBar(SnackBar(content: Text('$e')));
-        }
+        if (context.mounted) showSnack(context, '$e');
       }
     }
 

--- a/src/packages/flutter-app/lib/screens/auth_screen.dart
+++ b/src/packages/flutter-app/lib/screens/auth_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../providers/auth_provider.dart';
 import '../widgets/brand_logo.dart';
 import '../widgets/legal_links.dart';
+import '../utils/snack.dart';
 
 class AuthScreen extends ConsumerStatefulWidget {
   /// Whether the form opens in sign-in (true) or create-account (false) mode.
@@ -71,8 +72,7 @@ class _AuthScreenState extends ConsumerState<AuthScreen> {
       ),
     );
     if (done == true && mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
-          content: Text('Password updated — sign in with your new password')));
+      showSnack(context, 'Password updated — sign in with your new password');
     }
   }
 

--- a/src/packages/flutter-app/lib/screens/guides_screen.dart
+++ b/src/packages/flutter-app/lib/screens/guides_screen.dart
@@ -49,25 +49,38 @@ class GuidesScreen extends ConsumerWidget {
               final city = g.city.isEmpty ? 'Elsewhere' : g.city;
               byCity.putIfAbsent(city, () => []).add(g);
             }
-            final cities = byCity.keys.toList();
+            // One flat entry per visual row (header / guide tile / group
+            // spacer) so ListView.builder can inflate rows lazily instead of
+            // building every group's children up front.
+            final rows = <({String? header, LocalGuide? guide})>[
+              for (final entry in byCity.entries) ...[
+                (header: entry.key, guide: null),
+                for (final g in entry.value) (header: null, guide: g),
+                (header: null, guide: null), // spacer after each group
+              ],
+            ];
 
-            return ListView(
+            return ListView.builder(
               padding: const EdgeInsets.all(AppSpacing.lg),
-              children: [
-                for (final city in cities) ...[
-                  Padding(
+              itemCount: rows.length,
+              itemBuilder: (context, i) {
+                final row = rows[i];
+                if (row.header != null) {
+                  return Padding(
                     padding: const EdgeInsets.only(bottom: AppSpacing.sm),
                     child: Text(
-                      city,
+                      row.header!,
                       style: Theme.of(context).textTheme.titleMedium?.copyWith(
                             fontWeight: FontWeight.bold,
                           ),
                     ),
-                  ),
-                  for (final g in byCity[city]!) _GuideListTile(guide: g),
-                  const SizedBox(height: AppSpacing.lg),
-                ],
-              ],
+                  );
+                }
+                if (row.guide != null) {
+                  return _GuideListTile(guide: row.guide!);
+                }
+                return const SizedBox(height: AppSpacing.lg);
+              },
             );
           },
         ),

--- a/src/packages/flutter-app/lib/screens/local_admin_screen.dart
+++ b/src/packages/flutter-app/lib/screens/local_admin_screen.dart
@@ -5,6 +5,7 @@ import '../services/api_client.dart';
 import '../theme/spacing.dart';
 import '../widgets/empty_state.dart';
 import '../widgets/gradient_app_bar.dart';
+import '../utils/snack.dart';
 
 /// Admin-only console for curating local-sourced content. Three panes:
 ///   Ingest   — paste raw research text + pick a local source → AI drafts pins.
@@ -343,16 +344,10 @@ class _ReviewPaneState extends ConsumerState<_ReviewPane> {
   Future<void> _publish(String id) async {
     try {
       await ref.read(localApiServiceProvider).publish(id);
-      if (mounted) {
-        ScaffoldMessenger.of(context)
-            .showSnackBar(const SnackBar(content: Text('Published.')));
-      }
+      if (mounted) showSnack(context, 'Published.');
       await _load();
     } on ApiException catch (e) {
-      if (mounted) {
-        ScaffoldMessenger.of(context)
-            .showSnackBar(SnackBar(content: Text(e.message)));
-      }
+      if (mounted) showSnack(context, e.message);
     }
   }
 

--- a/src/packages/flutter-app/lib/screens/onboarding_quiz_screen.dart
+++ b/src/packages/flutter-app/lib/screens/onboarding_quiz_screen.dart
@@ -9,6 +9,7 @@ import '../widgets/airport_field.dart';
 import '../widgets/choice_chip_row.dart';
 import '../widgets/gradient_app_bar.dart';
 import '../widgets/page_container.dart';
+import '../utils/snack.dart';
 
 const _budgets = ['budget', 'mid', 'luxury'];
 const _paces = ['relaxed', 'balanced', 'packed'];
@@ -150,17 +151,14 @@ class _OnboardingQuizScreenState extends ConsumerState<OnboardingQuizScreen> {
     if (!ok) {
       if (!mounted) return;
       setState(() => _submitting = false);
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Could not save your answers — try again, or skip for now.')),
-      );
+      showSnack(
+          context, 'Could not save your answers — try again, or skip for now.');
       return;
     }
     if (widget.retake) {
       if (!mounted) return;
       Navigator.of(context).pop();
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Travel profile updated')),
-      );
+      showSnack(context, 'Travel profile updated');
       return;
     }
     await ref.read(authProvider.notifier).completeOnboarding();

--- a/src/packages/flutter-app/lib/screens/preferences_screen.dart
+++ b/src/packages/flutter-app/lib/screens/preferences_screen.dart
@@ -5,6 +5,7 @@ import '../widgets/airport_field.dart';
 import '../widgets/choice_chip_row.dart';
 import '../widgets/gradient_app_bar.dart';
 import '../providers/preferences_provider.dart';
+import '../utils/snack.dart';
 
 const _budgets = ['budget', 'mid', 'luxury'];
 const _paces = ['relaxed', 'balanced', 'packed'];
@@ -77,9 +78,7 @@ class _PreferencesScreenState extends ConsumerState<PreferencesScreen> {
           profileNotes: _notesController.text.trim(),
         );
     if (!mounted) return;
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(content: Text(ok ? 'Preferences saved' : 'Could not save preferences')),
-    );
+    showSnack(context, ok ? 'Preferences saved' : 'Could not save preferences');
   }
 
   @override

--- a/src/packages/flutter-app/lib/screens/shared_trip_screen.dart
+++ b/src/packages/flutter-app/lib/screens/shared_trip_screen.dart
@@ -14,6 +14,7 @@ import '../widgets/gradient_app_bar.dart';
 import '../widgets/trip_map.dart';
 import 'auth_screen.dart';
 import 'trip_detail_screen.dart';
+import '../utils/snack.dart';
 
 /// Public read-only view of a shared trip, reachable at /#/share/<token>
 /// without an account. Signed-in viewers can save a copy to their own trips.
@@ -101,10 +102,7 @@ class _SharedTripBodyState extends ConsumerState<_SharedTripBody> {
       Navigator.of(context)
           .pushNamedAndRemoveUntil('/', (route) => false);
     } catch (e) {
-      if (mounted) {
-        ScaffoldMessenger.of(context)
-            .showSnackBar(SnackBar(content: Text('Could not save a copy: $e')));
-      }
+      if (mounted) showSnack(context, 'Could not save a copy: $e');
     } finally {
       if (mounted) setState(() => _saving = false);
     }
@@ -128,10 +126,7 @@ class _SharedTripBodyState extends ConsumerState<_SharedTripBody> {
             builder: (_) => TripDetailScreen(tripId: tripId)));
       });
     } catch (e) {
-      if (mounted) {
-        ScaffoldMessenger.of(context)
-            .showSnackBar(SnackBar(content: Text('Could not join trip: $e')));
-      }
+      if (mounted) showSnack(context, 'Could not join trip: $e');
     } finally {
       if (mounted) setState(() => _saving = false);
     }

--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -46,6 +46,7 @@ import '../widgets/trip_map.dart';
 import '../widgets/trip_refine_panel.dart';
 import 'flight_search_screen.dart';
 import 'local_guide_detail_screen.dart';
+import '../utils/snack.dart';
 
 /// A geographic coordinate used to resolve an itinerary place to its nearest
 /// bookable airport when the place name has no IATA match.
@@ -703,9 +704,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
   }
 
   void _showSnack(String msg) {
-    if (mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(msg)));
-    }
+    if (mounted) showSnack(context, msg);
   }
 
   Future<void> _addStay() async {

--- a/src/packages/flutter-app/lib/services/accommodations_api_service.dart
+++ b/src/packages/flutter-app/lib/services/accommodations_api_service.dart
@@ -9,14 +9,6 @@ class AccommodationsApiService {
 
   AccommodationsApiService(this.apiClient);
 
-  Map<String, String> _headers({bool json = false}) {
-    final h = <String, String>{'Accept': 'application/json'};
-    if (json) h['Content-Type'] = 'application/json';
-    final token = apiClient.authToken;
-    if (token != null) h['Authorization'] = 'Bearer $token';
-    return h;
-  }
-
   Future<List<ProviderLink>> links({
     required String destination,
     String? checkIn,
@@ -30,7 +22,7 @@ class AccommodationsApiService {
       if (guests != null) 'guests': '$guests',
     };
     final uri = Uri.parse('${apiClient.baseUrl}/accommodation-links').replace(queryParameters: qp);
-    final res = await apiClient.httpClient.get(uri, headers: _headers());
+    final res = await apiClient.httpClient.get(uri, headers: apiClient.jsonHeaders());
     if (res.statusCode == 200) {
       final list = jsonDecode(res.body) as List<dynamic>;
       return list
@@ -43,7 +35,7 @@ class AccommodationsApiService {
   Future<Accommodation> add(String tripId, Map<String, dynamic> body) async {
     final res = await apiClient.httpClient.post(
       Uri.parse('${apiClient.baseUrl}/trips/$tripId/accommodations'),
-      headers: _headers(json: true),
+      headers: apiClient.jsonHeaders(json: true),
       body: jsonEncode(body),
     );
     if (res.statusCode == 201) {
@@ -55,7 +47,7 @@ class AccommodationsApiService {
   Future<void> delete(String tripId, String accId) async {
     final res = await apiClient.httpClient.delete(
       Uri.parse('${apiClient.baseUrl}/trips/$tripId/accommodations/$accId'),
-      headers: _headers(),
+      headers: apiClient.jsonHeaders(),
     );
     if (res.statusCode != 204) {
       throw Exception('Failed to delete accommodation (${res.statusCode})');

--- a/src/packages/flutter-app/lib/services/account_api_service.dart
+++ b/src/packages/flutter-app/lib/services/account_api_service.dart
@@ -9,15 +9,6 @@ class AccountApiService {
 
   AccountApiService(this.apiClient);
 
-  Map<String, String> _headers() {
-    final token = apiClient.authToken;
-    return {
-      'Accept': 'application/json',
-      'Content-Type': 'application/json',
-      if (token != null) 'Authorization': 'Bearer $token',
-    };
-  }
-
   String _message(String body, int status) {
     try {
       final decoded = jsonDecode(body);
@@ -31,7 +22,7 @@ class AccountApiService {
   Future<UserModel> updateDisplayName(String displayName) async {
     final res = await apiClient.httpClient.patch(
       Uri.parse('${apiClient.baseUrl}/auth/account'),
-      headers: _headers(),
+      headers: apiClient.jsonHeaders(json: true),
       body: jsonEncode({'display_name': displayName}),
     );
     if (res.statusCode == 200) {
@@ -46,7 +37,7 @@ class AccountApiService {
       String current, String newPassword) async {
     final res = await apiClient.httpClient.post(
       Uri.parse('${apiClient.baseUrl}/auth/change-password'),
-      headers: _headers(),
+      headers: apiClient.jsonHeaders(json: true),
       body: jsonEncode({
         'current_password': current,
         'new_password': newPassword,
@@ -65,7 +56,7 @@ class AccountApiService {
   Future<void> logoutAll() async {
     final res = await apiClient.httpClient.post(
       Uri.parse('${apiClient.baseUrl}/auth/logout-all'),
-      headers: _headers(),
+      headers: apiClient.jsonHeaders(json: true),
     );
     if (res.statusCode != 204) {
       throw Exception(_message(res.body, res.statusCode));
@@ -75,7 +66,7 @@ class AccountApiService {
   Future<void> deleteAccount(String password) async {
     final res = await apiClient.httpClient.delete(
       Uri.parse('${apiClient.baseUrl}/auth/account'),
-      headers: _headers(),
+      headers: apiClient.jsonHeaders(json: true),
       body: jsonEncode({'password': password}),
     );
     if (res.statusCode != 204) {

--- a/src/packages/flutter-app/lib/services/admin_metrics_api_service.dart
+++ b/src/packages/flutter-app/lib/services/admin_metrics_api_service.dart
@@ -10,13 +10,9 @@ class AdminMetricsApiService {
   AdminMetricsApiService(this.apiClient);
 
   Future<AdminMetrics> fetch({int days = 30}) async {
-    final token = apiClient.authToken;
     final res = await apiClient.httpClient.get(
       Uri.parse('${apiClient.baseUrl}/admin/metrics?days=$days'),
-      headers: {
-        'Accept': 'application/json',
-        if (token != null) 'Authorization': 'Bearer $token',
-      },
+      headers: apiClient.jsonHeaders(),
     );
     if (res.statusCode == 200) {
       return AdminMetrics.fromJson(jsonDecode(res.body));

--- a/src/packages/flutter-app/lib/services/alerts_api_service.dart
+++ b/src/packages/flutter-app/lib/services/alerts_api_service.dart
@@ -7,14 +7,6 @@ class AlertsApiService {
 
   AlertsApiService(this.apiClient);
 
-  Map<String, String> _headers({bool json = false}) {
-    final h = <String, String>{'Accept': 'application/json'};
-    if (json) h['Content-Type'] = 'application/json';
-    final token = apiClient.authToken;
-    if (token != null) h['Authorization'] = 'Bearer $token';
-    return h;
-  }
-
   String _errorMessage(String body, int status) {
     try {
       final decoded = jsonDecode(body);
@@ -28,7 +20,7 @@ class AlertsApiService {
   Future<List<PriceAlert>> list() async {
     final res = await apiClient.httpClient.get(
       Uri.parse('${apiClient.baseUrl}/alerts'),
-      headers: _headers(),
+      headers: apiClient.jsonHeaders(),
     );
     if (res.statusCode == 200) {
       final list = jsonDecode(res.body) as List<dynamic>;
@@ -42,7 +34,7 @@ class AlertsApiService {
   Future<PriceAlert> create(Map<String, dynamic> body) async {
     final res = await apiClient.httpClient.post(
       Uri.parse('${apiClient.baseUrl}/alerts'),
-      headers: _headers(json: true),
+      headers: apiClient.jsonHeaders(json: true),
       body: jsonEncode(body),
     );
     if (res.statusCode == 201) {
@@ -54,7 +46,7 @@ class AlertsApiService {
   Future<PriceAlert> patch(String id, Map<String, dynamic> body) async {
     final res = await apiClient.httpClient.patch(
       Uri.parse('${apiClient.baseUrl}/alerts/$id'),
-      headers: _headers(json: true),
+      headers: apiClient.jsonHeaders(json: true),
       body: jsonEncode(body),
     );
     if (res.statusCode == 200) {
@@ -66,7 +58,7 @@ class AlertsApiService {
   Future<void> delete(String id) async {
     final res = await apiClient.httpClient.delete(
       Uri.parse('${apiClient.baseUrl}/alerts/$id'),
-      headers: _headers(),
+      headers: apiClient.jsonHeaders(),
     );
     if (res.statusCode != 204) {
       throw Exception(_errorMessage(res.body, res.statusCode));

--- a/src/packages/flutter-app/lib/services/api_client.dart
+++ b/src/packages/flutter-app/lib/services/api_client.dart
@@ -26,6 +26,18 @@ class ApiClient {
   String get baseUrl => _baseUrl;
   http.Client get httpClient => _client;
 
+  /// Standard request headers for the JSON API: `Accept` always, a JSON
+  /// `Content-Type` when the request carries a body ([json] is true), and the
+  /// bearer token whenever a session exists. Shared by the feature services so
+  /// each one doesn't re-implement its own copy.
+  Map<String, String> jsonHeaders({bool json = false}) {
+    final h = <String, String>{'Accept': 'application/json'};
+    if (json) h['Content-Type'] = 'application/json';
+    final token = authToken;
+    if (token != null) h['Authorization'] = 'Bearer $token';
+    return h;
+  }
+
   /// Optimize a route for locations
   Future<RouteResponse> optimizeRoute(RouteRequest request) async {
     try {

--- a/src/packages/flutter-app/lib/services/booking_todos_api_service.dart
+++ b/src/packages/flutter-app/lib/services/booking_todos_api_service.dart
@@ -7,14 +7,6 @@ class BookingTodosApiService {
 
   BookingTodosApiService(this.apiClient);
 
-  Map<String, String> _headers({bool json = false}) {
-    final h = <String, String>{'Accept': 'application/json'};
-    if (json) h['Content-Type'] = 'application/json';
-    final token = apiClient.authToken;
-    if (token != null) h['Authorization'] = 'Bearer $token';
-    return h;
-  }
-
   List<BookingTodo> _parseList(String body) {
     final list = jsonDecode(body) as List<dynamic>;
     return list
@@ -28,7 +20,7 @@ class BookingTodosApiService {
       String tripId, List<Map<String, dynamic>> derived) async {
     final res = await apiClient.httpClient.put(
       Uri.parse('${apiClient.baseUrl}/trips/$tripId/booking-todos'),
-      headers: _headers(json: true),
+      headers: apiClient.jsonHeaders(json: true),
       body: jsonEncode(derived),
     );
     if (res.statusCode == 200) return _parseList(res.body);
@@ -38,7 +30,7 @@ class BookingTodosApiService {
   Future<BookingTodo> addTodo(String tripId, Map<String, dynamic> body) async {
     final res = await apiClient.httpClient.post(
       Uri.parse('${apiClient.baseUrl}/trips/$tripId/booking-todos'),
-      headers: _headers(json: true),
+      headers: apiClient.jsonHeaders(json: true),
       body: jsonEncode(body),
     );
     if (res.statusCode == 201) {
@@ -51,7 +43,7 @@ class BookingTodosApiService {
       String tripId, String todoId, bool booked) async {
     final res = await apiClient.httpClient.patch(
       Uri.parse('${apiClient.baseUrl}/trips/$tripId/booking-todos/$todoId'),
-      headers: _headers(json: true),
+      headers: apiClient.jsonHeaders(json: true),
       body: jsonEncode({'booked': booked}),
     );
     if (res.statusCode == 200) {
@@ -63,7 +55,7 @@ class BookingTodosApiService {
   Future<void> delete(String tripId, String todoId) async {
     final res = await apiClient.httpClient.delete(
       Uri.parse('${apiClient.baseUrl}/trips/$tripId/booking-todos/$todoId'),
-      headers: _headers(),
+      headers: apiClient.jsonHeaders(),
     );
     if (res.statusCode != 204) {
       throw Exception('Failed to delete booking todo (${res.statusCode})');

--- a/src/packages/flutter-app/lib/services/events_api_service.dart
+++ b/src/packages/flutter-app/lib/services/events_api_service.dart
@@ -11,13 +11,6 @@ class EventsApiService {
 
   EventsApiService(this.apiClient);
 
-  Map<String, String> _headers() {
-    final h = <String, String>{'Accept': 'application/json'};
-    final token = apiClient.authToken;
-    if (token != null) h['Authorization'] = 'Bearer $token';
-    return h;
-  }
-
   /// Looks up events in [city] between [startDate] and [endDate] (YYYY-MM-DD).
   Future<List<Event>> searchEvents(
     String city,
@@ -33,7 +26,7 @@ class EventsApiService {
         if (category != null && category.isNotEmpty) 'category': category,
       },
     );
-    final res = await apiClient.httpClient.get(uri, headers: _headers());
+    final res = await apiClient.httpClient.get(uri, headers: apiClient.jsonHeaders());
     if (res.statusCode == 200) {
       final body = jsonDecode(res.body) as Map<String, dynamic>;
       final list = (body['events'] as List<dynamic>? ?? []);
@@ -63,7 +56,7 @@ class EventsApiService {
         'end_date': endDate,
       },
     );
-    final res = await apiClient.httpClient.get(uri, headers: _headers());
+    final res = await apiClient.httpClient.get(uri, headers: apiClient.jsonHeaders());
     if (res.statusCode == 200) {
       final body = jsonDecode(res.body) as Map<String, dynamic>;
       final list = (body['links'] as List<dynamic>? ?? []);

--- a/src/packages/flutter-app/lib/services/ferry_api_service.dart
+++ b/src/packages/flutter-app/lib/services/ferry_api_service.dart
@@ -9,13 +9,6 @@ class FerryApiService {
 
   FerryApiService(this.apiClient);
 
-  Map<String, String> _headers() {
-    final h = <String, String>{'Accept': 'application/json'};
-    final token = apiClient.authToken;
-    if (token != null) h['Authorization'] = 'Bearer $token';
-    return h;
-  }
-
   /// Looks up ferry options for a route between two ports/islands.
   Future<List<FerryOption>> searchFerries(
     String origin,
@@ -32,7 +25,7 @@ class FerryApiService {
           'passengers': '$passengers',
       },
     );
-    final res = await apiClient.httpClient.get(uri, headers: _headers());
+    final res = await apiClient.httpClient.get(uri, headers: apiClient.jsonHeaders());
     if (res.statusCode == 200) {
       final body = jsonDecode(res.body) as Map<String, dynamic>;
       final list = (body['options'] as List<dynamic>? ?? []);

--- a/src/packages/flutter-app/lib/services/flights_api_service.dart
+++ b/src/packages/flutter-app/lib/services/flights_api_service.dart
@@ -12,18 +12,10 @@ class FlightsApiService {
 
   FlightsApiService(this.apiClient);
 
-  Map<String, String> _headers({bool json = false}) {
-    final h = <String, String>{'Accept': 'application/json'};
-    if (json) h['Content-Type'] = 'application/json';
-    final token = apiClient.authToken;
-    if (token != null) h['Authorization'] = 'Bearer $token';
-    return h;
-  }
-
   Future<FlightSearchResponse> searchFlights(FlightSearchRequest request) async {
     final res = await apiClient.httpClient.post(
       Uri.parse('${apiClient.baseUrl}/flights/search'),
-      headers: _headers(json: true),
+      headers: apiClient.jsonHeaders(json: true),
       body: jsonEncode(request.toJson()),
     );
     if (res.statusCode == 200) {
@@ -49,7 +41,7 @@ class FlightsApiService {
   Future<List<Airport>> _airports(Map<String, String> params) async {
     final uri = Uri.parse('${apiClient.baseUrl}/flights/airports')
         .replace(queryParameters: params);
-    final res = await apiClient.httpClient.get(uri, headers: _headers());
+    final res = await apiClient.httpClient.get(uri, headers: apiClient.jsonHeaders());
     if (res.statusCode == 200) {
       final body = jsonDecode(res.body) as Map<String, dynamic>;
       final list = (body['results'] as List<dynamic>? ?? []);

--- a/src/packages/flutter-app/lib/services/local_api_service.dart
+++ b/src/packages/flutter-app/lib/services/local_api_service.dart
@@ -12,13 +12,6 @@ class LocalApiService {
 
   LocalApiService(this.apiClient);
 
-  Map<String, String> _headers() {
-    final h = <String, String>{'Accept': 'application/json'};
-    final token = apiClient.authToken;
-    if (token != null) h['Authorization'] = 'Bearer $token';
-    return h;
-  }
-
   // --- public reads ----------------------------------------------------------
 
   /// Published local recommendations for [city], optionally filtered by category.
@@ -32,7 +25,7 @@ class LocalApiService {
         if (category != null && category.isNotEmpty) 'category': category,
       },
     );
-    final res = await apiClient.httpClient.get(uri, headers: _headers());
+    final res = await apiClient.httpClient.get(uri, headers: apiClient.jsonHeaders());
     if (res.statusCode == 200) {
       final body = jsonDecode(res.body) as Map<String, dynamic>;
       final list = (body['recommendations'] as List<dynamic>? ?? []);
@@ -55,7 +48,7 @@ class LocalApiService {
     if (city != null && city.trim().isNotEmpty) {
       uri = uri.replace(queryParameters: {'city': city.trim()});
     }
-    final res = await apiClient.httpClient.get(uri, headers: _headers());
+    final res = await apiClient.httpClient.get(uri, headers: apiClient.jsonHeaders());
     if (res.statusCode == 200) {
       final body = jsonDecode(res.body) as Map<String, dynamic>;
       final list = (body['guides'] as List<dynamic>? ?? []);
@@ -76,7 +69,7 @@ class LocalApiService {
   Future<({LocalGuide guide, List<LocalRecommendation> recommendations})>
       guideById(String id) async {
     final uri = Uri.parse('${apiClient.baseUrl}/local/guides/$id');
-    final res = await apiClient.httpClient.get(uri, headers: _headers());
+    final res = await apiClient.httpClient.get(uri, headers: apiClient.jsonHeaders());
     if (res.statusCode == 200) {
       final body = jsonDecode(res.body) as Map<String, dynamic>;
       final recs = (body['recommendations'] as List<dynamic>? ?? [])
@@ -99,7 +92,7 @@ class LocalApiService {
   /// Lists the local sources (people) the curator can attribute content to.
   Future<List<Map<String, dynamic>>> listSources() async {
     final uri = Uri.parse('${apiClient.baseUrl}/admin/local/sources');
-    final res = await apiClient.httpClient.get(uri, headers: _headers());
+    final res = await apiClient.httpClient.get(uri, headers: apiClient.jsonHeaders());
     if (res.statusCode == 200) {
       final list = jsonDecode(res.body) as List<dynamic>;
       return list.cast<Map<String, dynamic>>();
@@ -117,7 +110,7 @@ class LocalApiService {
     final uri = Uri.parse('${apiClient.baseUrl}/admin/local/sources');
     final res = await apiClient.httpClient.post(
       uri,
-      headers: {..._headers(), 'Content-Type': 'application/json'},
+      headers: apiClient.jsonHeaders(json: true),
       body: jsonEncode(fields),
     );
     if (res.statusCode == 201) {
@@ -141,7 +134,7 @@ class LocalApiService {
     final uri = Uri.parse('${apiClient.baseUrl}/admin/local/ingest');
     final res = await apiClient.httpClient.post(
       uri,
-      headers: {..._headers(), 'Content-Type': 'application/json'},
+      headers: apiClient.jsonHeaders(json: true),
       body: jsonEncode({
         'source_id': sourceId,
         'city': city,
@@ -163,7 +156,7 @@ class LocalApiService {
   Future<List<Map<String, dynamic>>> listByStatus(String status) async {
     final uri = Uri.parse('${apiClient.baseUrl}/admin/local/recommendations')
         .replace(queryParameters: {'status': status});
-    final res = await apiClient.httpClient.get(uri, headers: _headers());
+    final res = await apiClient.httpClient.get(uri, headers: apiClient.jsonHeaders());
     if (res.statusCode == 200) {
       final list = jsonDecode(res.body) as List<dynamic>;
       return list.cast<Map<String, dynamic>>();
@@ -180,7 +173,7 @@ class LocalApiService {
   Future<void> publish(String id) async {
     final uri = Uri.parse(
         '${apiClient.baseUrl}/admin/local/recommendations/$id/publish');
-    final res = await apiClient.httpClient.post(uri, headers: _headers());
+    final res = await apiClient.httpClient.post(uri, headers: apiClient.jsonHeaders());
     if (res.statusCode != 200) {
       throw ApiException(
         statusCode: res.statusCode,
@@ -193,7 +186,7 @@ class LocalApiService {
   /// Coverage: per-city published/draft/archived counts.
   Future<List<Map<String, dynamic>>> coverage() async {
     final uri = Uri.parse('${apiClient.baseUrl}/admin/local/coverage');
-    final res = await apiClient.httpClient.get(uri, headers: _headers());
+    final res = await apiClient.httpClient.get(uri, headers: apiClient.jsonHeaders());
     if (res.statusCode == 200) {
       final list = jsonDecode(res.body) as List<dynamic>;
       return list.cast<Map<String, dynamic>>();

--- a/src/packages/flutter-app/lib/services/preferences_api_service.dart
+++ b/src/packages/flutter-app/lib/services/preferences_api_service.dart
@@ -8,17 +8,9 @@ class PreferencesApiService {
 
   PreferencesApiService(this.apiClient);
 
-  Map<String, String> _headers({bool json = false}) {
-    final h = <String, String>{'Accept': 'application/json'};
-    if (json) h['Content-Type'] = 'application/json';
-    final token = apiClient.authToken;
-    if (token != null) h['Authorization'] = 'Bearer $token';
-    return h;
-  }
-
   Future<TravelerPreferences> getPreferences() async {
     final res = await apiClient.httpClient
-        .get(Uri.parse('${apiClient.baseUrl}/preferences'), headers: _headers());
+        .get(Uri.parse('${apiClient.baseUrl}/preferences'), headers: apiClient.jsonHeaders());
     if (res.statusCode == 200) {
       return TravelerPreferences.fromJson(jsonDecode(res.body));
     }
@@ -34,7 +26,7 @@ class PreferencesApiService {
   }) async {
     final res = await apiClient.httpClient.put(
       Uri.parse('${apiClient.baseUrl}/preferences'),
-      headers: _headers(json: true),
+      headers: apiClient.jsonHeaders(json: true),
       body: jsonEncode({
         'budget': budget,
         'pace': pace,

--- a/src/packages/flutter-app/lib/services/transport_api_service.dart
+++ b/src/packages/flutter-app/lib/services/transport_api_service.dart
@@ -9,14 +9,6 @@ class TransportApiService {
 
   TransportApiService(this.apiClient);
 
-  Map<String, String> _headers({bool json = false}) {
-    final h = <String, String>{'Accept': 'application/json'};
-    if (json) h['Content-Type'] = 'application/json';
-    final token = apiClient.authToken;
-    if (token != null) h['Authorization'] = 'Bearer $token';
-    return h;
-  }
-
   Future<List<TransportLink>> links({
     required String mode, // 'flight' | 'ground'
     required String origin,
@@ -34,7 +26,7 @@ class TransportApiService {
       if (passengers != null) 'passengers': '$passengers',
     };
     final uri = Uri.parse('${apiClient.baseUrl}/transport-links').replace(queryParameters: qp);
-    final res = await apiClient.httpClient.get(uri, headers: _headers());
+    final res = await apiClient.httpClient.get(uri, headers: apiClient.jsonHeaders());
     if (res.statusCode == 200) {
       final list = jsonDecode(res.body) as List<dynamic>;
       return list
@@ -51,7 +43,7 @@ class TransportApiService {
   Future<TripSegment> addSegment(String tripId, Map<String, dynamic> body) async {
     final res = await apiClient.httpClient.post(
       Uri.parse('${apiClient.baseUrl}/trips/$tripId/segments'),
-      headers: _headers(json: true),
+      headers: apiClient.jsonHeaders(json: true),
       body: jsonEncode(body),
     );
     if (res.statusCode == 201) {
@@ -63,7 +55,7 @@ class TransportApiService {
   Future<void> deleteSegment(String tripId, String segmentId) async {
     final res = await apiClient.httpClient.delete(
       Uri.parse('${apiClient.baseUrl}/trips/$tripId/segments/$segmentId'),
-      headers: _headers(),
+      headers: apiClient.jsonHeaders(),
     );
     if (res.statusCode != 204) {
       throw Exception('Failed to delete segment (${res.statusCode})');

--- a/src/packages/flutter-app/lib/services/trips_api_service.dart
+++ b/src/packages/flutter-app/lib/services/trips_api_service.dart
@@ -11,17 +11,9 @@ class TripsApiService {
 
   TripsApiService(this.apiClient);
 
-  Map<String, String> _headers({bool json = false}) {
-    final h = <String, String>{'Accept': 'application/json'};
-    if (json) h['Content-Type'] = 'application/json';
-    final token = apiClient.authToken;
-    if (token != null) h['Authorization'] = 'Bearer $token';
-    return h;
-  }
-
   Future<List<Trip>> listTrips() async {
     final res = await apiClient.httpClient
-        .get(Uri.parse('${apiClient.baseUrl}/trips'), headers: _headers());
+        .get(Uri.parse('${apiClient.baseUrl}/trips'), headers: apiClient.jsonHeaders());
     if (res.statusCode == 200) {
       final list = jsonDecode(res.body) as List<dynamic>;
       return list.map((e) => Trip.fromJson(e as Map<String, dynamic>)).toList();
@@ -34,7 +26,7 @@ class TripsApiService {
   Future<String> startRefineSession(String tripId) async {
     final res = await apiClient.httpClient.post(
       Uri.parse('${apiClient.baseUrl}/trips/$tripId/refine'),
-      headers: _headers(json: true),
+      headers: apiClient.jsonHeaders(json: true),
     );
     if (res.statusCode == 200) {
       return (jsonDecode(res.body) as Map<String, dynamic>)['chat_id'] as String;
@@ -46,7 +38,7 @@ class TripsApiService {
   Future<List<Trip>> listTripVersions(String chatId) async {
     final uri = Uri.parse('${apiClient.baseUrl}/trips/versions')
         .replace(queryParameters: {'chat_id': chatId});
-    final res = await apiClient.httpClient.get(uri, headers: _headers());
+    final res = await apiClient.httpClient.get(uri, headers: apiClient.jsonHeaders());
     if (res.statusCode == 200) {
       final list = jsonDecode(res.body) as List<dynamic>;
       return list.map((e) => Trip.fromJson(e as Map<String, dynamic>)).toList();
@@ -56,7 +48,7 @@ class TripsApiService {
 
   Future<Trip> getTrip(String id) async {
     final res = await apiClient.httpClient
-        .get(Uri.parse('${apiClient.baseUrl}/trips/$id'), headers: _headers());
+        .get(Uri.parse('${apiClient.baseUrl}/trips/$id'), headers: apiClient.jsonHeaders());
     if (res.statusCode == 200) {
       return Trip.fromJson(jsonDecode(res.body));
     }
@@ -78,7 +70,7 @@ class TripsApiService {
 
     final res = await apiClient.httpClient.patch(
       Uri.parse('${apiClient.baseUrl}/trips/$id'),
-      headers: _headers(json: true),
+      headers: apiClient.jsonHeaders(json: true),
       body: jsonEncode(body),
     );
     if (res.statusCode == 200) {
@@ -92,7 +84,7 @@ class TripsApiService {
   Future<Trip> addItineraryItem(String tripId, Map<String, dynamic> body) async {
     final res = await apiClient.httpClient.post(
       Uri.parse('${apiClient.baseUrl}/trips/$tripId/items'),
-      headers: _headers(json: true),
+      headers: apiClient.jsonHeaders(json: true),
       body: jsonEncode(body),
     );
     if (res.statusCode == 201) {
@@ -107,7 +99,7 @@ class TripsApiService {
       {String role = 'viewer'}) async {
     final res = await apiClient.httpClient.post(
       Uri.parse('${apiClient.baseUrl}/trips/$tripId/share'),
-      headers: _headers(json: true),
+      headers: apiClient.jsonHeaders(json: true),
       body: jsonEncode({'role': role}),
     );
     if (res.statusCode == 200 || res.statusCode == 201) {
@@ -120,7 +112,7 @@ class TripsApiService {
   Future<String> joinSharedTrip(String token) async {
     final res = await apiClient.httpClient.post(
       Uri.parse('${apiClient.baseUrl}/shared/$token/join'),
-      headers: _headers(json: true),
+      headers: apiClient.jsonHeaders(json: true),
     );
     if (res.statusCode == 200) {
       return (jsonDecode(res.body) as Map<String, dynamic>)['trip_id']
@@ -133,7 +125,7 @@ class TripsApiService {
   Future<List<Trip>> listSharedWithMe() async {
     final res = await apiClient.httpClient.get(
       Uri.parse('${apiClient.baseUrl}/trips/shared-with-me'),
-      headers: _headers(),
+      headers: apiClient.jsonHeaders(),
     );
     if (res.statusCode == 200) {
       final list = jsonDecode(res.body) as List<dynamic>;
@@ -147,7 +139,7 @@ class TripsApiService {
       listCollaborators(String tripId) async {
     final res = await apiClient.httpClient.get(
       Uri.parse('${apiClient.baseUrl}/trips/$tripId/collaborators'),
-      headers: _headers(),
+      headers: apiClient.jsonHeaders(),
     );
     if (res.statusCode == 200) {
       final list = jsonDecode(res.body) as List<dynamic>;
@@ -166,7 +158,7 @@ class TripsApiService {
   Future<void> removeCollaborator(String tripId, String userId) async {
     final res = await apiClient.httpClient.delete(
       Uri.parse('${apiClient.baseUrl}/trips/$tripId/collaborators/$userId'),
-      headers: _headers(),
+      headers: apiClient.jsonHeaders(),
     );
     if (res.statusCode != 204) {
       throw Exception('Failed to remove co-planner (${res.statusCode})');
@@ -176,7 +168,7 @@ class TripsApiService {
   Future<void> revokeShareLink(String tripId) async {
     final res = await apiClient.httpClient.delete(
       Uri.parse('${apiClient.baseUrl}/trips/$tripId/share'),
-      headers: _headers(),
+      headers: apiClient.jsonHeaders(),
     );
     if (res.statusCode != 204) {
       throw Exception('Failed to revoke share link (${res.statusCode})');
@@ -187,7 +179,7 @@ class TripsApiService {
   Future<SharedTrip> getSharedTrip(String token) async {
     final res = await apiClient.httpClient.get(
       Uri.parse('${apiClient.baseUrl}/shared/$token'),
-      headers: _headers(),
+      headers: apiClient.jsonHeaders(),
     );
     if (res.statusCode == 200) {
       return SharedTrip.fromJson(jsonDecode(res.body));
@@ -199,7 +191,7 @@ class TripsApiService {
   Future<Trip> duplicateSharedTrip(String token) async {
     final res = await apiClient.httpClient.post(
       Uri.parse('${apiClient.baseUrl}/shared/$token/duplicate'),
-      headers: _headers(json: true),
+      headers: apiClient.jsonHeaders(json: true),
     );
     if (res.statusCode == 201) {
       return Trip.fromJson(jsonDecode(res.body));
@@ -212,7 +204,7 @@ class TripsApiService {
       String tripId, String itemId, Map<String, dynamic> body) async {
     final res = await apiClient.httpClient.patch(
       Uri.parse('${apiClient.baseUrl}/trips/$tripId/items/$itemId'),
-      headers: _headers(json: true),
+      headers: apiClient.jsonHeaders(json: true),
       body: jsonEncode(body),
     );
     if (res.statusCode == 200) {
@@ -224,7 +216,7 @@ class TripsApiService {
   Future<void> deleteItineraryItem(String tripId, String itemId) async {
     final res = await apiClient.httpClient.delete(
       Uri.parse('${apiClient.baseUrl}/trips/$tripId/items/$itemId'),
-      headers: _headers(),
+      headers: apiClient.jsonHeaders(),
     );
     if (res.statusCode != 204) {
       throw Exception('Failed to delete place (${res.statusCode})');
@@ -236,7 +228,7 @@ class TripsApiService {
   Future<void> reorderItineraryItems(String tripId, List<String> itemIds) async {
     final res = await apiClient.httpClient.put(
       Uri.parse('${apiClient.baseUrl}/trips/$tripId/items/order'),
-      headers: _headers(json: true),
+      headers: apiClient.jsonHeaders(json: true),
       body: jsonEncode({'item_ids': itemIds}),
     );
     if (res.statusCode != 204) {
@@ -246,7 +238,7 @@ class TripsApiService {
 
   Future<void> deleteTrip(String id) async {
     final res = await apiClient.httpClient
-        .delete(Uri.parse('${apiClient.baseUrl}/trips/$id'), headers: _headers());
+        .delete(Uri.parse('${apiClient.baseUrl}/trips/$id'), headers: apiClient.jsonHeaders());
     if (res.statusCode != 204) {
       throw Exception('Failed to delete trip (${res.statusCode})');
     }

--- a/src/packages/flutter-app/lib/utils/snack.dart
+++ b/src/packages/flutter-app/lib/utils/snack.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/material.dart';
+
+/// Shows the app's standard plain-text snack bar — the one-liner every screen
+/// used to spell out as `ScaffoldMessenger.of(context).showSnackBar(...)`.
+/// Callers keep their own `mounted` checks after async gaps, exactly as they
+/// did when the boilerplate lived inline.
+void showSnack(BuildContext context, String message) {
+  ScaffoldMessenger.of(context)
+      .showSnackBar(SnackBar(content: Text(message)));
+}

--- a/src/packages/flutter-app/lib/widgets/create_alert_sheet.dart
+++ b/src/packages/flutter-app/lib/widgets/create_alert_sheet.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../providers/alerts_provider.dart';
 import '../theme/spacing.dart';
+import '../utils/snack.dart';
 
 /// Bottom sheet that turns the current flight search into a price alert
 /// (specs/price-alerts). Seeded with the route/date/cheapest price the
@@ -94,13 +95,10 @@ class _CreateAlertSheetState extends ConsumerState<CreateAlertSheet> {
       });
       if (mounted) {
         Navigator.of(context).pop();
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text(
-                'Watching ${widget.origin} → ${widget.destination} — we\'ll '
-                'email you on a drop'),
-          ),
-        );
+        showSnack(
+            context,
+            'Watching ${widget.origin} → ${widget.destination} — we\'ll '
+            'email you on a drop');
       }
     } catch (e) {
       setState(() {

--- a/src/packages/flutter-app/lib/widgets/flight_details_sheet.dart
+++ b/src/packages/flutter-app/lib/widgets/flight_details_sheet.dart
@@ -3,6 +3,7 @@ import '../models/flight_leg.dart';
 import '../models/flight_offer.dart';
 import '../utils/tracked_launch.dart';
 import 'airline_logo.dart';
+import '../utils/snack.dart';
 
 /// Opens a modal bottom sheet with the segment-by-segment breakdown of [offer]:
 /// each leg's carrier/flight number and depart→arrive clock times, plus the
@@ -244,10 +245,7 @@ class _LayoverRow extends StatelessWidget {
 Future<void> _book(BuildContext context, String url) async {
   final ok = await trackedLaunchUrl(context, url,
       provider: 'duffel', surface: 'flight_details');
-  if (!ok && context.mounted) {
-    ScaffoldMessenger.of(context)
-        .showSnackBar(const SnackBar(content: Text('Could not open link')));
-  }
+  if (!ok && context.mounted) showSnack(context, 'Could not open link');
 }
 
 /// "TAP TP204" — carrier name with flight number, de-duplicating when the

--- a/src/packages/flutter-app/lib/widgets/flight_offer_card.dart
+++ b/src/packages/flutter-app/lib/widgets/flight_offer_card.dart
@@ -4,6 +4,7 @@ import '../models/flight_offer.dart';
 import '../utils/tracked_launch.dart';
 import 'airline_logo.dart';
 import 'flight_details_sheet.dart';
+import '../utils/snack.dart';
 
 /// A single ranked flight offer rendered as a card — airline(s), route, price,
 /// score, duration/stops, and a Book deep-link. Shared by the standalone
@@ -19,10 +20,7 @@ class FlightOfferCard extends StatelessWidget {
     if (url == null || url.isEmpty) return;
     final ok = await trackedLaunchUrl(context, url,
         provider: 'duffel', surface: 'flight_card');
-    if (!ok && context.mounted) {
-      ScaffoldMessenger.of(context)
-          .showSnackBar(const SnackBar(content: Text('Could not open link')));
-    }
+    if (!ok && context.mounted) showSnack(context, 'Could not open link');
   }
 
   @override

--- a/src/packages/flutter-app/lib/widgets/status_pill.dart
+++ b/src/packages/flutter-app/lib/widgets/status_pill.dart
@@ -4,6 +4,10 @@ import '../theme/spacing.dart';
 /// A filled tonal pill for a trip's status (Draft / Planned). Reads at a glance
 /// and stays colorblind-safe by carrying its label, not just a colored dot.
 /// Shared by the trips list and the trip-detail header.
+///
+/// [StatusPill.custom] renders the same pill chrome with an explicit label and
+/// colors (no leading icon, smaller type) for non-trip states — e.g. the price
+/// alerts screen.
 class StatusPill extends StatelessWidget {
   final String status;
 
@@ -11,23 +15,56 @@ class StatusPill extends StatelessWidget {
   /// status picker trigger). Tinted to match the label.
   final Widget? trailing;
 
-  const StatusPill({super.key, required this.status, this.trailing});
+  final String? _label;
+  final Color? _background;
+  final Color? _foreground;
+
+  const StatusPill({super.key, required this.status, this.trailing})
+      : _label = null,
+        _background = null,
+        _foreground = null;
+
+  const StatusPill.custom({
+    super.key,
+    required String label,
+    required Color background,
+    required Color foreground,
+  })  : status = '',
+        trailing = null,
+        _label = label,
+        _background = background,
+        _foreground = foreground;
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final isPlanned = status == 'planned';
-    final label = status.isEmpty
-        ? 'Draft'
-        : '${status[0].toUpperCase()}${status.substring(1)}';
+    final String label;
+    final Color bg;
+    final Color fg;
+    IconData? icon;
+    final TextStyle? style;
+    if (_label != null) {
+      label = _label;
+      bg = _background!;
+      fg = _foreground!;
+      style = theme.textTheme.labelSmall;
+    } else {
+      final isPlanned = status == 'planned';
+      label = status.isEmpty
+          ? 'Draft'
+          : '${status[0].toUpperCase()}${status.substring(1)}';
 
-    // Planned reads as a positive, completed state (green); anything else is a
-    // neutral surface tone so it doesn't compete for attention.
-    final Color bg = isPlanned
-        ? Colors.green.withValues(alpha: 0.15)
-        : theme.colorScheme.surfaceContainerHighest;
-    final Color fg =
-        isPlanned ? Colors.green.shade800 : theme.colorScheme.onSurfaceVariant;
+      // Planned reads as a positive, completed state (green); anything else is
+      // a neutral surface tone so it doesn't compete for attention.
+      bg = isPlanned
+          ? Colors.green.withValues(alpha: 0.15)
+          : theme.colorScheme.surfaceContainerHighest;
+      fg = isPlanned
+          ? Colors.green.shade800
+          : theme.colorScheme.onSurfaceVariant;
+      icon = isPlanned ? Icons.check_circle : Icons.edit_note;
+      style = theme.textTheme.labelMedium;
+    }
 
     return Container(
       padding: const EdgeInsets.symmetric(
@@ -41,15 +78,13 @@ class StatusPill extends StatelessWidget {
       child: Row(
         mainAxisSize: MainAxisSize.min,
         children: [
-          Icon(
-            isPlanned ? Icons.check_circle : Icons.edit_note,
-            size: 13,
-            color: fg,
-          ),
-          const SizedBox(width: AppSpacing.xs),
+          if (icon != null) ...[
+            Icon(icon, size: 13, color: fg),
+            const SizedBox(width: AppSpacing.xs),
+          ],
           Text(
             label,
-            style: theme.textTheme.labelMedium?.copyWith(
+            style: style?.copyWith(
               color: fg,
               fontWeight: FontWeight.w600,
             ),


### PR DESCRIPTION
Pure refactor, zero behavior change — the Wave-6 deferred dedup ledger, finally swept. Tests pass **unmodified** (no test file touched); `flutter analyze --no-fatal-infos --fatal-warnings` still reports exactly the 12 pre-existing infos; `gofmt`/`go vet`/`go test` clean.

## Items (one commit each)

1. **`_headers()` → `ApiClient.jsonHeaders({bool json})`** — 11 private header-builder methods plus admin-metrics' inline map collapse onto one implementation. Every call site keeps its exact header set (the `{bool json}` variants map 1:1; the no-arg GET-only variants map to `jsonHeaders()`; `local_api_service`'s two spread-with-Content-Type sites and all of `account_api_service` become `json: true`). **Deliberately untouched:** `analytics_api_service` (its requests carry no `Accept` header and must stay token-optional post-#73 — converting would change the wire headers), `auth_service`/`plan_service` (explicit-token flows), and `ApiClient`'s own anonymous endpoints.
2. **Shared `showSnack` helper** (`lib/utils/snack.dart`) — 13 plain-text `ScaffoldMessenger…showSnackBar(SnackBar(content: Text(…)))` sites and 3 per-screen `_snack` wrappers now delegate to one helper. Call sites keep their own `mounted` guards; SnackBars with actions (undo / view-trip) stay inline. Note: the ledger described an `errorContainer`-styled snack pattern — no such SnackBar exists on main (all app snacks are default-styled), so the dedup covers the pattern as it actually exists.
3. **`_AlertPill` → `StatusPill.custom`** — the alerts screen's private pill duplicated the design-system pill chrome. `StatusPill` gains a `.custom` variant (explicit label/colors, no leading icon, `labelSmall`) that renders pixel-identically; the alert-state → label/color mapping stays in the alerts screen. Default `StatusPill` output unchanged.
4. **Weather `fetchForecast`/`fetchArchive` → `fetchDaily`** — this one lives in the **Go API** (`weather_service.go`), not Flutter. The two Open-Meteo fetchers differed only in base URL, endpoint, daily-series field list, and report `Kind`; now parameterized on forecast-vs-archive. Query strings are byte-identical and `PrecipPct` is still only ever set on the forecast path.
5. **Guides index → `ListView.builder`** — the city-grouped children were built eagerly; they're now flattened into one row list (header / tile / group spacer) inflated lazily. Row order, widgets, and spacing unchanged.

## Notes for review

- Branch was rebased onto `main` after #77/#78 landed mid-flight (#78 fixed conflict markers that broke `go test` compilation at the original base).
- Net: **+202 / −280** across 29 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)