### PR TITLE
Wave 8 review sweep: 4 confirmed fixes across ranking, limits, add-to-trip

### DIFF
--- a/src/packages/api/analytics_integration_test.go
+++ b/src/packages/api/analytics_integration_test.go
@@ -293,9 +293,10 @@ func TestAnonymousEventsAreStrictRateLimited(t *testing.T) {
 	resetDB(t)
 	ip := nextTestIP()
 	limited := false
-	// Strict tier is burst 3 at 5/min: within a burst from one IP, a 429
-	// must appear well before 10 requests.
-	for i := 0; i < 10; i++ {
+	// Anonymous /events has its own bucket (burst 5 at 10/min — separate from
+	// the strict tier so pre-signup pings can't 429 /auth/register): within a
+	// burst from one IP, a 429 must appear well before 20 requests.
+	for i := 0; i < 20; i++ {
 		rec := doJSONFromIP(t, "POST", "/api/v1/events", "", ip, map[string]any{
 			"event_type": "landing_viewed",
 		})
@@ -308,7 +309,31 @@ func TestAnonymousEventsAreStrictRateLimited(t *testing.T) {
 		}
 	}
 	if !limited {
-		t.Fatalf("anonymous /events never rate limited within a 10-request burst")
+		t.Fatalf("anonymous /events never rate limited within a 20-request burst")
+	}
+}
+
+// TestAnonymousEventsDoNotDrainAuthBudget pins the review fix: a visitor's
+// pre-signup analytics pings must not consume the strict bucket that
+// /auth/register depends on at the conversion moment.
+func TestAnonymousEventsDoNotDrainAuthBudget(t *testing.T) {
+	resetDB(t)
+	ip := nextTestIP()
+	for i := 0; i < 3; i++ {
+		rec := doJSONFromIP(t, "POST", "/api/v1/events", "", ip, map[string]any{
+			"event_type": "booking_link_clicked",
+		})
+		if rec.Code != 202 {
+			t.Fatalf("event %d = %d, want 202", i+1, rec.Code)
+		}
+	}
+	rec := doJSONFromIP(t, "POST", "/api/v1/auth/register", "", ip, map[string]any{
+		"email":    "converts@example.com",
+		"password": "a-strong-password-1",
+		"name":     "Converting Visitor",
+	})
+	if rec.Code == 429 {
+		t.Fatalf("register 429 after anonymous analytics pings — events drained the auth budget")
 	}
 }
 

--- a/src/packages/api/flight_optimizer.go
+++ b/src/packages/api/flight_optimizer.go
@@ -82,6 +82,18 @@ func scheduleSignature(o FlightOffer) string {
 	for i := 0; i < len(o.Segments)-1; i++ {
 		parts = append(parts, o.Segments[i].To) // connecting airport
 	}
+	// Round trips: the return slice is part of the perceived schedule. Without
+	// it, same-outbound offers differing only in return legs collapse to the
+	// cheapest — discarding exactly the alternatives that total-duration/stops
+	// ranking exists to rank.
+	if len(o.ReturnSegments) > 0 {
+		rFirst := o.ReturnSegments[0]
+		rLast := o.ReturnSegments[len(o.ReturnSegments)-1]
+		parts = append(parts, "R", rFirst.From, rLast.To, rFirst.DepartTime, rLast.ArriveTime)
+		for i := 0; i < len(o.ReturnSegments)-1; i++ {
+			parts = append(parts, o.ReturnSegments[i].To)
+		}
+	}
 	return strings.Join(parts, "|")
 }
 

--- a/src/packages/api/flight_optimizer_test.go
+++ b/src/packages/api/flight_optimizer_test.go
@@ -124,6 +124,27 @@ func roundTrip(id string, price float64, from, to, dep, arr string, dur, stops, 
 	return o
 }
 
+// Same outbound paired with different return slices must NOT collapse in
+// dedup: pre-fix, scheduleSignature hashed only o.Segments, so the cheapest
+// pairing swallowed the alternatives that total-duration ranking exists to
+// rank (Wave-8 review finding).
+func TestDedupKeepsSameOutboundDifferentReturns(t *testing.T) {
+	// Identical outbound; A = nonstop 8h return at $600, B = 2-leg 20h return
+	// at $550. Price-keyed dedup on an outbound-only signature keeps only B.
+	a := roundTrip("fast-return", 600, "JFK", "CDG", "T1", "T2", 420, 0, 480, 1)
+	b := roundTrip("slow-return", 550, "JFK", "CDG", "T1", "T2", 420, 0, 1200, 2)
+
+	got := dedupBySchedule([]FlightOffer{a, b})
+	if len(got) != 2 {
+		t.Fatalf("dedup collapsed distinct return slices: kept %d offers, want 2", len(got))
+	}
+
+	ranked := RankFlightOffers([]FlightOffer{a, b}, "time")
+	if ranked[0].ID != "fast-return" {
+		t.Errorf("time ranking picked %q, want fast-return", ranked[0].ID)
+	}
+}
+
 // Round-trip "time" ranking must use TOTAL duration (outbound + return), not
 // outbound alone: a fast-outbound/slow-return offer with the larger total must
 // lose to a slow-outbound/fast-return offer with the smaller total.

--- a/src/packages/api/main.go
+++ b/src/packages/api/main.go
@@ -575,6 +575,12 @@ func buildRouter() *mux.Router {
 	generalLimiter := newIPRateLimiter(60, 30)
 	strictLimiter := newIPRateLimiter(5, 3)
 	strict := rateLimitMiddleware(strictLimiter)
+	// Anonymous analytics gets its own bucket: sharing the strict one would let
+	// a visitor's pre-signup pings (landing view + booking clicks) drain the
+	// budget that /auth/register and /auth/login depend on, 429-ing the signup
+	// at the exact conversion moment the events exist to measure.
+	anonEventsLimiter := newIPRateLimiter(10, 5)
+	anonEvents := rateLimitMiddleware(anonEventsLimiter)
 	router.Use(requestIDMiddleware)
 	router.Use(recoveryMiddleware)
 	router.Use(corsMiddleware)
@@ -659,11 +665,12 @@ func buildRouter() *mux.Router {
 	// 401, never a silent downgrade to anonymous); a request without
 	// credentials falls through to the anonymous route, which accepts only
 	// the tiny anonymousClientEventTypes whitelist, always drops trip_id, and
-	// sits behind the strict limiter to bound spam writes (it is an
-	// unauthenticated INSERT surface).
+	// sits behind its own rate-limit bucket to bound spam writes (it is an
+	// unauthenticated INSERT surface) without draining the strict bucket that
+	// the auth endpoints share.
 	api.Handle("/events", authMiddleware(http.HandlerFunc(recordClientEventHandler))).
 		Methods("POST").HeadersRegexp("Authorization", ".+")
-	api.Handle("/events", strict(http.HandlerFunc(recordAnonymousClientEventHandler))).Methods("POST")
+	api.Handle("/events", anonEvents(http.HandlerFunc(recordAnonymousClientEventHandler))).Methods("POST")
 	// Price alerts (specs/price-alerts): creation is strict-tier (each alert
 	// commits the server to recurring provider searches).
 	api.Handle("/alerts", strict(authMiddleware(http.HandlerFunc(createPriceAlertHandler)))).Methods("POST")

--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -1586,7 +1586,10 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
   Future<void> _addToTrip(AddToTripPayload payload) async {
     final added =
         await showAddToTripSheet(context, payload, currentTripId: widget.tripId);
-    if (added != null && added.id == widget.tripId) _load(silent: true);
+    // _refresh(), not a bare silent _load(): it serializes with any reload the
+    // refine panel has in flight, so a pre-add snapshot can't land after us
+    // and momentarily erase the just-added item.
+    if (added != null && added.id == widget.tripId) _refresh();
   }
 
   Widget _itemTile(ItineraryItem item, double indentLeft, ThemeData theme) =>

--- a/src/packages/flutter-app/lib/widgets/add_to_trip_sheet.dart
+++ b/src/packages/flutter-app/lib/widgets/add_to_trip_sheet.dart
@@ -119,13 +119,17 @@ Future<Trip?> showAddToTripSheet(
     ),
   );
   if (trip != null && context.mounted) {
+    // Capture the navigator now: the snackbar outlives a route pop (root
+    // ScaffoldMessenger), so resolving it inside onPressed would look up a
+    // deactivated context. NavigatorState outlives the launching route.
+    final navigator = Navigator.of(context);
     ScaffoldMessenger.of(context).showSnackBar(SnackBar(
       content: Text('Added to ${trip.title}'),
       action: trip.id == currentTripId
           ? null
           : SnackBarAction(
               label: 'View trip',
-              onPressed: () => Navigator.of(context).push(MaterialPageRoute(
+              onPressed: () => navigator.push(MaterialPageRoute(
                 builder: (_) => TripDetailScreen(tripId: trip.id),
               )),
             ),


### PR DESCRIPTION
Three-angle adversarial review of the merged Wave 8 diff (Go correctness, Flutter state/UX, security — security came back clean, all candidates refuted with evidence).

**Fixed (all confirmed with concrete failure scenarios):**
1. **[major] Round-trip dedup vs ranking conflict** — `scheduleSignature` hashed only the outbound slice, so Duffel's same-outbound/different-return offers collapsed to the cheapest before #77's total-duration scoring ran. Signature now includes the return slice; regression test proves both survive and time-ranking picks the fast return.
2. **[minor] Anonymous /events drained the auth rate budget** — it shared the strict per-IP bucket with /auth/register and /auth/login, so a visitor's pre-signup pings could 429 the signup. Own bucket (10/min, burst 5) + regression test.
3. **[minor] 'View trip' snackbar action after route pop** — deactivated-context lookup; NavigatorState captured at show time.
4. **[minor] Post-add refresh raced the refine panel** — `_addToTrip` now goes through the `_refresh()` coalescer.

**Noted, not changed:** trip-detail pull-to-refresh while offline stays silent (quiet-failure invariant, a considered tradeoff from #74's design — documented in memory as a known asymmetry vs the trips list).

Gates: api-fmt/vet clean, Go unit + integration green on a fresh DB, Flutter 96 tests pass, analyze at the 12 known pre-existing infos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)