### PR TITLE
feat: bulk local-content seeding path — spec, script, make target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,13 @@ temp/
 # Air live reload (if you use it later)
 .air.toml
 tmp/
+
+# Local-content seeding corpus (specs/local-content-seeding): real research
+# never lands in git — only the format README and the _example fixture do.
+content/*
+!content/local/
+content/local/*
+!content/local/README.md
+!content/local/_example/
+# seeder ledgers are machine state, never committed (including the fixture's)
+.ingested

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Travel Route Planner - Development Makefile
-.PHONY: help build run test clean docker-build docker-run docker-dev docker-deploy docker-stop docker-logs api-build api-run api-test
+.PHONY: help build run test clean docker-build docker-run docker-dev docker-deploy docker-stop docker-logs api-build api-run api-test seed-local
 
 # Variables
 API_DIR = src/packages/api
@@ -147,6 +147,13 @@ test-countries: ## Test country optimization via gateway
 	curl -s -X POST $(GATEWAY_URL)/api/v1/optimize-countries \
 		-H "Content-Type: application/json" \
 		-d '{"countries":[{"code":"US","name":"United States","latitude":39.8283,"longitude":-98.5795,"min_stay_days":7}],"optimize_for":"balanced"}' | jq '.'
+
+# Content seeding (see specs/local-content-seeding and content/local/README.md)
+# Credentials come from the environment: SEED_TOKEN, or SEED_EMAIL+SEED_PASSWORD.
+seed-local: ## Bulk-ingest local content via admin API (CONTENT_DIR=./content/local, CITY=<slug>, BASE_URL=gateway)
+	@BASE_URL="$(if $(BASE_URL),$(BASE_URL),$(GATEWAY_URL))" \
+		CONTENT_DIR="$(CONTENT_DIR)" CITY="$(CITY)" \
+		./scripts/seed_local_content.sh
 
 # Documentation
 docs: ## Show application URLs and documentation

--- a/content/local/README.md
+++ b/content/local/README.md
@@ -1,0 +1,74 @@
+# Local-Content Seeding Corpus
+
+This directory holds raw local-sourced research, organized so
+`scripts/seed_local_content.sh` (or `make seed-local`) can bulk-ingest it
+through the admin API. See `specs/local-content-seeding/` for the full spec.
+
+**Everything here except this README and `_example/` is gitignored** — real
+research (interview transcripts, voice-memo notes) never lands in git.
+
+## Layout
+
+```
+content/local/
+  <city-slug>/                  e.g. athens, new-york
+    city.json                   optional: {"name": "New York"} — overrides the
+                                slug→name guess (hyphens→spaces, Title Case)
+    <source-slug>/              one folder per local source, e.g. maria-the-baker
+      source.json               the person's profile (required; see below)
+      01-first-interview.txt    raw material, ingested in filename order
+      02-followup-notes.md      (must match NN-*.txt or NN-*.md)
+      .ingested                 machine-written ledger — do not edit or commit
+```
+
+## `source.json`
+
+Exactly the fields `POST /api/v1/admin/local/sources` accepts. `name` is
+required and is the find-or-create match key (exact match — don't rename a
+source between runs unless you mean to create a new one).
+
+```json
+{
+  "name": "Maria Papadopoulos",
+  "bio": "Third-generation baker in Pangrati.",
+  "photo_url": "",
+  "location": "Athens, Greece",
+  "expertise": "Bakeries, tavernas, Pangrati neighborhood",
+  "credibility": "Runs Fournos Maria since 1998; featured in local press.",
+  "consent_ref": "consent/2026-07-01-maria.pdf"
+}
+```
+
+All fields except `name` are optional — omit them or leave them empty.
+
+## Material files
+
+Plain text or markdown. The whole file is submitted as raw research text for
+AI extraction, except an optional **first line**:
+
+```
+kind: transcript
+```
+
+Accepted kinds: `transcript`, `notes`, `voice_memo` (default: `notes`). The
+header line is stripped before submission.
+
+## Running
+
+```bash
+# whole corpus against the local dev stack
+SEED_EMAIL=admin@example.com SEED_PASSWORD=... make seed-local
+
+# one city, pre-issued token, other environment
+BASE_URL=https://your-host SEED_TOKEN=... CITY=athens ./scripts/seed_local_content.sh
+```
+
+- Re-runs skip anything already in a `.ingested` ledger (content-hash based:
+  editing a file re-ingests it as new drafts; renaming does not).
+- The **target server** needs `ANTHROPIC_API_KEY` and `GOOGLE_PLACES_API_KEY`
+  live — extraction and place-verification happen server-side.
+- Seeding creates **drafts only**. Curation and publishing stay human, and
+  pins without verified coordinates remain unpublishable (anti-hallucination
+  gate).
+- `_example/` is a fictional fixture city used by tests. Underscore-prefixed
+  city folders are skipped unless explicitly targeted with `CITY=_example`.

--- a/content/local/_example/casey-the-fixture/01-cafe-notes.md
+++ b/content/local/_example/casey-the-fixture/01-cafe-notes.md
@@ -1,0 +1,17 @@
+kind: notes
+
+Quick notes from walking around Exampleville with Casey.
+
+Casey's favorite coffee spot is Cafe Perpetuum on Mill Lane — tiny room,
+roasts on Tuesdays, and the flat white is the one to order. "Everyone queues
+at the big chain on the square; the locals are all in here," Casey says. Go
+before 9am on weekdays to get the window seat.
+
+Second stop: The Brass Kettle, a tea house hidden inside the old clockmakers'
+courtyard off Pendulum Street. You have to push through an unmarked green
+door. Casey says the honey cake is baked by the owner's mother and sells out
+by noon.
+
+For a quiet walk, Casey swears by the towpath along the Miller's Canal,
+starting at the Old Lock Bridge and heading east — herons at dusk, and no
+tour groups because it isn't on any map app's suggested route.

--- a/content/local/_example/casey-the-fixture/02-dinner-transcript.txt
+++ b/content/local/_example/casey-the-fixture/02-dinner-transcript.txt
@@ -1,0 +1,14 @@
+kind: transcript
+
+Interviewer: Where do you actually eat dinner in Exampleville?
+
+Casey: Honestly? The Salt Cellar, every time. It's a twelve-seat place in the
+basement under the fishmongers on Quay Row. No menu — the chef cooks whatever
+came off the boats that morning. Book by phone, they don't do apps.
+
+Interviewer: And if someone wants something cheap?
+
+Casey: Nonna Fortuna's window on Cobble Walk. It's literally a window in a
+wall. Two kinds of pasta a night, cash only, and you eat standing on the
+steps with everyone else. Best five euros in town. Skip anything with a
+laminated menu on the main square — that's the tourist tax.

--- a/content/local/_example/casey-the-fixture/source.json
+++ b/content/local/_example/casey-the-fixture/source.json
@@ -1,0 +1,8 @@
+{
+  "name": "Casey Fixture (Seed Test)",
+  "bio": "A fictional local used by the seeding script's committed example fixture. Not a real person.",
+  "location": "Exampleville",
+  "expertise": "Coffee, hidden courtyards, canal walks",
+  "credibility": "Fictional — exists only to exercise the seeding pipeline end to end.",
+  "consent_ref": "n/a (fictional fixture data)"
+}

--- a/content/local/_example/city.json
+++ b/content/local/_example/city.json
@@ -1,0 +1,3 @@
+{
+  "name": "Exampleville"
+}

--- a/scripts/seed_local_content.sh
+++ b/scripts/seed_local_content.sh
@@ -1,0 +1,267 @@
+#!/usr/bin/env bash
+# seed_local_content.sh — bulk-ingest local-sourced content through the admin API.
+#
+# Walks a content directory (see content/local/README.md and
+# specs/local-content-seeding/ for the format) and drives the EXISTING admin
+# endpoints: find-or-create each source, ingest each material file, then print
+# the coverage table. No new API surface; drafts only — publishing stays human.
+#
+# Environment:
+#   BASE_URL       target server (default http://localhost:3000 — the gateway)
+#   SEED_TOKEN     pre-issued admin bearer token; or
+#   SEED_EMAIL / SEED_PASSWORD   admin credentials for POST /auth/login
+#   CONTENT_DIR    corpus root (default ./content/local)
+#   CITY           optional city-slug filter (also the only way to seed
+#                  underscore-prefixed fixture cities like _example)
+#   SEED_SLEEP     seconds between API calls (default 1; general limiter is 60/min)
+#
+# Idempotent: successful ingests append "sha256  filename" to the source dir's
+# .ingested ledger; matching files are skipped on re-runs. Exit is non-zero if
+# any source or file failed.
+
+set -u
+
+BASE_URL="${BASE_URL:-http://localhost:3000}"
+CONTENT_DIR="${CONTENT_DIR:-./content/local}"
+CITY="${CITY:-}"
+SEED_TOKEN="${SEED_TOKEN:-}"
+SEED_EMAIL="${SEED_EMAIL:-}"
+SEED_PASSWORD="${SEED_PASSWORD:-}"
+SEED_SLEEP="${SEED_SLEEP:-1}"
+API="$BASE_URL/api/v1"
+
+FAILURES=0
+INGESTED=0
+SKIPPED=0
+
+log()  { printf '%s\n' "$*"; }
+warn() { printf 'WARN: %s\n' "$*" >&2; }
+fail() { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
+
+for dep in curl jq; do
+  command -v "$dep" >/dev/null 2>&1 || fail "missing dependency: $dep"
+done
+
+sha256_of() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+  else
+    shasum -a 256 "$1" | awk '{print $1}'
+  fi
+}
+
+# api_call METHOD PATH [JSON_BODY] — sets the globals RESP_BODY and LAST_STATUS
+# (must run in the current shell, never in $(...), so both survive). Ingest can
+# block on a synchronous Claude extraction, hence the generous --max-time.
+LAST_STATUS=""
+RESP_BODY=""
+api_call() {
+  local method="$1" path="$2" body="${3:-}" tmp status
+  tmp="$(mktemp)"
+  if [ -n "$body" ]; then
+    status="$(curl -sS -o "$tmp" -w '%{http_code}' --max-time 180 \
+      -X "$method" "$API$path" \
+      -H "Authorization: Bearer $SEED_TOKEN" \
+      -H 'Content-Type: application/json' \
+      -d "$body")" || status="000"
+  else
+    status="$(curl -sS -o "$tmp" -w '%{http_code}' --max-time 180 \
+      -X "$method" "$API$path" \
+      -H "Authorization: Bearer $SEED_TOKEN")" || status="000"
+  fi
+  LAST_STATUS="$status"
+  RESP_BODY="$(cat "$tmp")"
+  rm -f "$tmp"
+}
+
+error_of() { # best-effort {"error": ...} extraction from a response body
+  printf '%s' "$1" | jq -r '.error // empty' 2>/dev/null || true
+}
+
+# --- auth ---------------------------------------------------------------------
+
+if [ -z "$SEED_TOKEN" ]; then
+  [ -n "$SEED_EMAIL" ] && [ -n "$SEED_PASSWORD" ] \
+    || fail "set SEED_TOKEN, or SEED_EMAIL and SEED_PASSWORD"
+  login_body="$(jq -n --arg email "$SEED_EMAIL" --arg password "$SEED_PASSWORD" \
+    '{email: $email, password: $password}')"
+  api_call POST /auth/login "$login_body"
+  [ "$LAST_STATUS" = "200" ] || fail "login failed ($LAST_STATUS): $(error_of "$RESP_BODY")"
+  SEED_TOKEN="$(printf '%s' "$RESP_BODY" | jq -r '.token // empty')"
+  [ -n "$SEED_TOKEN" ] || fail "login succeeded but no token in response"
+  log "Logged in as $SEED_EMAIL"
+fi
+
+# Probe an admin route so bad/non-admin credentials fail fast and clearly.
+api_call GET /admin/local/sources
+case "$LAST_STATUS" in
+  200) : ;;
+  401) fail "token rejected (401) — not logged in?" ;;
+  403) fail "account is not an admin (403)" ;;
+  *)   fail "cannot reach $API/admin/local/sources ($LAST_STATUS): $(error_of "$RESP_BODY")" ;;
+esac
+
+[ -d "$CONTENT_DIR" ] || fail "content directory not found: $CONTENT_DIR"
+
+# --- helpers ------------------------------------------------------------------
+
+title_case_slug() { # new-york -> New York
+  printf '%s' "$1" | tr '-' ' ' \
+    | awk '{for (i = 1; i <= NF; i++) $i = toupper(substr($i,1,1)) substr($i,2)} 1'
+}
+
+# find_or_create_source $1=source.json — sets SRC_ID on success. Runs in the
+# current shell (not $(...)) so counters and logs behave normally.
+SRC_ID=""
+find_or_create_source() {
+  local file="$1" name create_body
+  SRC_ID=""
+  name="$(jq -r '.name // empty' "$file")"
+  if [ -z "$name" ]; then
+    warn "$file: missing required \"name\" — skipping source"
+    return 1
+  fi
+  api_call GET /admin/local/sources
+  if [ "$LAST_STATUS" != "200" ]; then
+    warn "could not list sources ($LAST_STATUS) — skipping $name"
+    return 1
+  fi
+  SRC_ID="$(printf '%s' "$RESP_BODY" \
+    | jq -r --arg n "$name" 'map(select(.name == $n)) | first | .id // empty')"
+  if [ -n "$SRC_ID" ]; then
+    log "  source: $name (exists)"
+    return 0
+  fi
+  # Keep only the fields the endpoint accepts; drop absent optionals.
+  create_body="$(jq '{name, bio, photo_url, location, expertise, credibility, consent_ref}
+                     | with_entries(select(.value != null))' "$file")"
+  api_call POST /admin/local/sources "$create_body"
+  sleep "$SEED_SLEEP"
+  if [ "$LAST_STATUS" != "201" ]; then
+    warn "could not create source $name ($LAST_STATUS): $(error_of "$RESP_BODY")"
+    return 1
+  fi
+  SRC_ID="$(printf '%s' "$RESP_BODY" | jq -r '.id // empty')"
+  log "  source: $name (created)"
+  [ -n "$SRC_ID" ]
+}
+
+ingest_file() { # $1=source id  $2=city name  $3=material file  $4=ledger path
+  local src_id="$1" city_name="$2" file="$3" ledger="$4"
+  local hash first_line kind body payload drafts verified unverified guide
+
+  hash="$(sha256_of "$file")"
+  if [ -f "$ledger" ] && grep -q "^$hash" "$ledger"; then
+    log "    $(basename "$file"): skipped (already ingested)"
+    SKIPPED=$((SKIPPED + 1))
+    return 0
+  fi
+
+  # Optional first-line header: "kind: transcript|notes|voice_memo" (stripped).
+  first_line="$(head -n 1 "$file")"
+  if [[ "$first_line" =~ ^kind:[[:space:]]*(transcript|notes|voice_memo)[[:space:]]*$ ]]; then
+    kind="${BASH_REMATCH[1]}"
+    body="$(tail -n +2 "$file")"
+    body="${body#$'\n'}" # drop the conventional blank line after the header
+  else
+    kind="notes"
+    body="$(cat "$file")"
+  fi
+  if [ -z "$(printf '%s' "$body" | tr -d '[:space:]')" ]; then
+    warn "    $(basename "$file"): empty after header — skipping (not ledgered)"
+    FAILURES=$((FAILURES + 1))
+    return 1
+  fi
+
+  # jq does the JSON string encoding, so any raw text is safe in the payload.
+  payload="$(printf '%s' "$body" | jq -Rs \
+    --arg source_id "$src_id" --arg city "$city_name" --arg kind "$kind" \
+    '{source_id: $source_id, city: $city, kind: $kind, raw_text: .}')"
+
+  api_call POST /admin/local/ingest "$payload"
+  sleep "$SEED_SLEEP"
+  if [ "$LAST_STATUS" != "201" ]; then
+    warn "    $(basename "$file"): ingest failed ($LAST_STATUS): $(error_of "$RESP_BODY")"
+    FAILURES=$((FAILURES + 1))
+    return 1
+  fi
+
+  drafts="$(printf '%s' "$RESP_BODY" | jq -r '.recommendations | length')"
+  verified="$(printf '%s' "$RESP_BODY" | jq -r '.verified')"
+  unverified="$(printf '%s' "$RESP_BODY" | jq -r '.unverified')"
+  guide="$(printf '%s' "$RESP_BODY" | jq -r '.guide_id // empty')"
+  log "    $(basename "$file"): $drafts drafts ($verified verified, $unverified unverified)${guide:+, guide $guide}"
+  printf '%s  %s\n' "$hash" "$(basename "$file")" >> "$ledger"
+  INGESTED=$((INGESTED + 1))
+}
+
+# --- walk the corpus ------------------------------------------------------------
+
+log "Seeding from $CONTENT_DIR into $BASE_URL${CITY:+ (city filter: $CITY)}"
+matched_city=0
+
+while IFS= read -r city_dir; do
+  city_slug="$(basename "$city_dir")"
+  if [ -n "$CITY" ]; then
+    [ "$city_slug" = "$CITY" ] || continue
+  else
+    case "$city_slug" in _*)
+      log "Skipping fixture city $city_slug (target it explicitly with CITY=$city_slug)"
+      continue ;;
+    esac
+  fi
+  matched_city=1
+
+  if [ -f "$city_dir/city.json" ]; then
+    city_name="$(jq -r '.name // empty' "$city_dir/city.json")"
+  else
+    city_name=""
+  fi
+  [ -n "$city_name" ] || city_name="$(title_case_slug "$city_slug")"
+  log "City: $city_name ($city_slug)"
+
+  found_source=0
+  while IFS= read -r src_dir; do
+    found_source=1
+    if [ ! -f "$src_dir/source.json" ]; then
+      warn "  $(basename "$src_dir"): no source.json — skipping"
+      FAILURES=$((FAILURES + 1))
+      continue
+    fi
+    if ! find_or_create_source "$src_dir/source.json"; then
+      FAILURES=$((FAILURES + 1))
+      continue
+    fi
+
+    found_material=0
+    while IFS= read -r material; do
+      found_material=1
+      ingest_file "$SRC_ID" "$city_name" "$material" "$src_dir/.ingested" || true
+    done < <(find "$src_dir" -maxdepth 1 -type f \
+               \( -name '[0-9][0-9]-*.txt' -o -name '[0-9][0-9]-*.md' \) | sort)
+    [ "$found_material" = 1 ] || log "    (no NN-*.txt|md material files)"
+  done < <(find "$city_dir" -mindepth 1 -maxdepth 1 -type d | sort)
+  [ "$found_source" = 1 ] || log "  (no source directories)"
+done < <(find "$CONTENT_DIR" -mindepth 1 -maxdepth 1 -type d | sort)
+
+if [ "$matched_city" = 0 ]; then
+  log "Nothing to seed${CITY:+ (no city directory named \"$CITY\")}."
+fi
+
+# --- coverage ---------------------------------------------------------------------
+
+log ""
+log "Coverage ($API/admin/local/coverage):"
+api_call GET /admin/local/coverage
+if [ "$LAST_STATUS" = "200" ]; then
+  printf '%s' "$RESP_BODY" | jq -r '
+    (["CITY", "PUBLISHED", "DRAFT", "ARCHIVED"] | @tsv),
+    (.[] | [.city, (.published|tostring), (.draft|tostring), (.archived|tostring)] | @tsv)' \
+    | column -t -s "$(printf '\t')"
+else
+  warn "could not fetch coverage ($LAST_STATUS)"
+fi
+
+log ""
+log "Done: $INGESTED ingested, $SKIPPED skipped, $FAILURES failed."
+[ "$FAILURES" = 0 ] || exit 1

--- a/specs/local-content-seeding/plan.md
+++ b/specs/local-content-seeding/plan.md
@@ -1,0 +1,138 @@
+# Plan: Local-Content Seeding
+
+> **HOW.** Translates `spec.md` into a file-level technical approach. Every
+> decision should trace back to an acceptance criterion. See `../../CLAUDE.md`
+> for repo conventions referenced below — don't restate them, point to them.
+
+## Technical Approach
+
+A single bash script (`scripts/seed_local_content.sh`, bash + curl + jq,
+shellcheck-clean) walks the content directory and drives the **existing**
+admin endpoints — no Go or Flutter changes. Rationale: the ingest pipeline
+(extraction → Places verification → draft insert) already does all the hard
+work server-side; a client-side batch runner keeps the anti-hallucination
+gate and curation queue untouched by construction, and a shell script is the
+cheapest thing Brian can run against any environment (dev gateway or prod)
+with just a URL and credentials.
+
+Idempotency is client-side: a `.ingested` ledger of sha256 content hashes per
+source directory. Hash-of-content (not filename or mtime) means renames don't
+re-ingest but edits do — matching the spec's "edited material is new drafts"
+decision.
+
+## Go API Changes
+
+**None.** The script is a pure client of:
+
+- `POST /api/v1/auth/login` → `{user, token}` (`auth_handler.go`,
+  `AuthResponse.Token` is the bearer session id).
+- `GET /api/v1/admin/local/sources` → `store.LocalSource[]` (match by exact
+  `.name`); `POST` same path with
+  `{name, bio, photo_url, location, expertise, credibility, consent_ref}`
+  (`createLocalSourceRequest` in `local_ingest_handler.go`) → 201 + source
+  (take `.id`).
+- `POST /api/v1/admin/local/ingest` with
+  `{source_id, city, kind, raw_text}` (`ingestRequest`; kind ∈
+  `transcript|notes|voice_memo`, empty → `notes`) → 201 `ingestResponse`:
+  `{recommendations: [...], guide_id?, verified, unverified}` — the script
+  reports `recommendations | length`, `verified`, `unverified`, `guide_id`.
+- `GET /api/v1/admin/local/coverage` → `coverageRow[]`
+  `{city, published, draft, archived}` for the closing table.
+
+All admin routes sit behind `authMiddleware` + `adminMiddleware`; the script
+sends `Authorization: Bearer <token>` and fails fast with a clear message on
+401/403 (probe = the sources GET).
+
+## Script Design (`scripts/seed_local_content.sh`)
+
+- **Env contract:** `BASE_URL` (default `http://localhost:3000` — the nginx
+  gateway), `SEED_TOKEN` **or** `SEED_EMAIL`+`SEED_PASSWORD`, `CONTENT_DIR`
+  (default `./content/local`), `CITY` (optional slug filter),
+  `SEED_SLEEP` (seconds between API calls, default 1 — stays well under the
+  general 60/min per-IP limiter in `main.go`).
+- **Traversal:** `find -maxdepth 1` + `sort` piped into `while read` loops
+  (no `mapfile`/arrays — keeps macOS's stock bash 3.2 happy). City dirs
+  starting with `_` are skipped unless `CITY` names them exactly.
+- **City name:** slug → spaces + title-case in awk; `city.json` `.name`
+  overrides when present.
+- **Find-or-create source:** GET the source list once per source dir, exact
+  `jq 'select(.name == $n)'` match; otherwise POST `source.json` filtered
+  through jq to the accepted fields (`with_entries(select(.value != null))`
+  so absent optionals stay absent).
+- **Material files:** `NN-*.txt` / `NN-*.md`, filename-sorted. First line
+  `kind: (transcript|notes|voice_memo)` is matched with a bash regex,
+  stripped (plus one following blank line); body is passed to jq via
+  `--rawfile`/`--arg`-style safe encoding (`jq -n --arg`) so any text is
+  valid JSON.
+- **Ingest call:** `curl --max-time 180` (extraction is a synchronous Claude
+  call), capture HTTP status + body separately; on 201 print the draft /
+  verified / unverified counts and append `sha256  filename` to
+  `<source-dir>/.ingested`; on anything else print the server's `error`
+  field, count a failure, continue.
+- **Exit code:** non-zero iff any source/profile/file failed; skipped-via-
+  ledger and nothing-matched are success.
+
+## Repository Layout Changes
+
+- `.gitignore`: ignore `content/*` and everything under `content/local/*`
+  **except** `content/local/README.md` and `content/local/_example/`; ignore
+  `.ingested` ledgers everywhere (so the fixture's ledger never lands in
+  git).
+- `content/local/README.md`: the operator-facing copy of the file-format
+  contract + a run example.
+- `content/local/_example/`: one fictional city (`city.json` naming it
+  "Exampleville", one source with `source.json` + two material files, one
+  exercising the `kind:` header). Safe fake data; used by the live test.
+- `Makefile`: `seed-local` target (added to `.PHONY`) wrapping the script,
+  `## help` text in the existing format; passes `CONTENT_DIR`/`CITY`
+  through and defaults `BASE_URL` to `$(GATEWAY_URL)`.
+
+## Flutter Changes
+
+None.
+
+## Contract Parity  ← anti-drift gate
+
+No Go/Dart model changes. The script-side contract rows to hold against the
+handlers:
+
+| JSON key | Go type (handler) | Script use | Nullable? | ✓ |
+|----------|-------------------|------------|-----------|---|
+| `token` (login resp) | `string` (`AuthResponse`) | bearer token | no | ☑ |
+| `name` (source) | `string` | exact-match key / create | no | ☑ |
+| `bio`,`photo_url`,`location`,`expertise`,`credibility`,`consent_ref` | `string` (empty → NULL via `strPtrOrNil`) | passthrough from `source.json` | yes | ☑ |
+| `id` (source resp) | `uuid.UUID` | becomes `source_id` | no | ☑ |
+| `source_id`,`city`,`kind`,`raw_text` (ingest req) | `string` | request body | `kind` empty→`notes` | ☑ |
+| `recommendations` (ingest resp) | `[]store.LocalRecommendation` | `length` = drafts created | no | ☑ |
+| `verified`,`unverified` (ingest resp) | `int` | per-file report | no | ☑ |
+| `guide_id` (ingest resp) | `*string`, `omitempty` | mentioned when present | yes | ☑ |
+| `city`,`published`,`draft`,`archived` (coverage) | `string`/`int64` | closing table | no | ☑ |
+
+## Cross-cutting
+
+- **Env vars:** none added server-side. `ANTHROPIC_API_KEY` and
+  `GOOGLE_PLACES_API_KEY` must be live on the **target server** (already
+  documented in `.env.sample`); the seeder itself carries only credentials.
+- **Gateway:** default `BASE_URL` is the gateway (`:3000`); paths are all
+  `/api/v1/*` so no proxy changes.
+- **Rate limits:** sequential + `SEED_SLEEP` respects the 60/min general
+  limiter; login is on the strict tier but is a single call.
+
+## Verification
+
+(Mirror into `tasks.md` as the final tasks.)
+
+- `shellcheck scripts/seed_local_content.sh` — clean.
+- `make api-fmt && make api-vet` — confirm no Go drift (no Go changes made).
+- Live end-to-end against `make docker-dev` at `http://localhost:3000`:
+  1. Register a throwaway user via the API, flip `is_admin` in Postgres.
+  2. `SEED_TOKEN=… CITY=_example ./scripts/seed_local_content.sh` — expect
+     source created, both fixture files ingested, drafts visible via
+     `GET /api/v1/admin/local/recommendations?status=draft`, coverage table
+     printed.
+  3. Re-run — expect every file reported skipped (ledger), exit 0.
+  4. Clean up: delete the fixture's drafts/guides/materials/source and the
+     throwaway user (children first — the `local_*` FKs are `ON DELETE
+     RESTRICT`).
+- `make seed-local CITY=_example` — Makefile wiring works, help text shows
+  in `make help`.

--- a/specs/local-content-seeding/spec.md
+++ b/specs/local-content-seeding/spec.md
@@ -1,0 +1,151 @@
+# Spec: Local-Content Seeding
+
+> **WHAT & WHY only.** No tech choices, file names, libraries, or code. If a
+> sentence names a file or a package, it belongs in `plan.md`, not here.
+
+## Context
+
+The local-sourced content layer is the product's stated moat, but it currently
+has zero content: the only way in is an admin manually posting one blob of raw
+research text at a time through the admin ingest endpoint. Seeding even one
+city that way is tedious; seeding ten is untenable. This feature defines a
+simple on-disk contract for organizing research material per city and per
+local source, plus a batch runner that walks that directory and drives the
+**existing** admin endpoints to ingest everything. No new API surface is
+added; the coordinate anti-hallucination gate and the human curation/publish
+queue remain exactly as they are — seeding produces *drafts*, never published
+content.
+
+## User Stories
+
+- As **Brian (admin/curator)**, I want to **drop research files into a folder
+  per city and run one command** so that an entire city's local content is
+  ingested as drafts without hand-crafting API calls.
+- As **Brian**, I want **re-runs to skip material that was already ingested**
+  so that adding one new file to a city doesn't duplicate every draft.
+- As **Brian**, I want a **per-file report and a final coverage table** so I
+  can see how many drafts were created, how many verified against a real
+  place, and where each city stands.
+- As a **traveler**, I (indirectly) benefit because cities gain curated local
+  recommendations faster — still human-reviewed before anything is published.
+
+## Acceptance Criteria
+
+- [ ] A documented content-directory format exists: one folder per city, one
+      folder per local source inside it, a source profile file, and numbered
+      raw-material files (see File Format Contract below).
+- [ ] Running the seeder against a content directory logs in, creates any
+      local sources that don't already exist (matched by exact name), and
+      ingests every material file through the existing admin ingest endpoint.
+- [ ] Each ingested file prints: city, source, file name, number of drafts
+      created, and how many were place-verified vs unverified.
+- [ ] The run ends with the per-city coverage table (published/draft counts)
+      from the existing admin coverage endpoint.
+- [ ] Re-running the seeder over the same directory ingests nothing (every
+      previously ingested file is reported as skipped), based on a per-source
+      ledger of content hashes.
+- [ ] A partial failure (one file errors) does not stop the run, is clearly
+      reported, leaves that file out of the ledger (so a re-run retries it),
+      and makes the overall run exit non-zero.
+- [ ] The real content directory is not committed to git; a README explaining
+      the format and one clearly-fake example fixture city **are** committed.
+- [ ] The example fixture city is skipped by normal runs and only seeded when
+      explicitly targeted, so fixture data can never leak into a real
+      environment by default.
+- [ ] Drafts created by seeding are indistinguishable from manually ingested
+      drafts: same curation queue, same publish-blocked-without-coordinates
+      gate, same attribution.
+
+## File Format Contract
+
+The seeder reads a content directory (default `content/local/`) shaped as:
+
+```
+content/local/
+  <city-slug>/                     e.g. athens, new-york
+    city.json                      optional: {"name": "<display name>"}
+    <source-slug>/                 e.g. maria-the-baker
+      source.json                  the local source's profile (required)
+      01-<anything>.txt|.md        raw material, ingested in filename order
+      02-<anything>.md
+      .ingested                    machine-written ledger (never committed)
+```
+
+- **City name.** The city name sent to the ingest endpoint is the city
+  folder's slug with hyphens turned into spaces and each word capitalized
+  (`new-york` → `New York`). When that transformation can't produce the right
+  name (accents, casing), `city.json`'s `name` field overrides it.
+- **`source.json`** carries exactly the fields the existing create-source
+  admin endpoint accepts: `name` (required — also the find-or-create match
+  key, exact match), and optional `bio`, `photo_url`, `location`,
+  `expertise`, `credibility`, `consent_ref`. Unknown fields are ignored.
+- **Material files** are plain text or markdown named `NN-*.txt` or
+  `NN-*.md` (two leading digits give deterministic order). The file's whole
+  content is submitted as the raw research text, except an optional first
+  line of the form `kind: transcript`, `kind: notes`, or `kind: voice_memo`
+  (the kinds the ingest endpoint accepts), which sets the material kind and
+  is stripped from the submitted text. Without the header the kind defaults
+  to `notes`.
+- **Ledger.** After a successful ingest the seeder appends the file's content
+  hash to a `.ingested` file next to the material. Files whose hash already
+  appears in the ledger are skipped on re-runs. Editing a file changes its
+  hash, so edited material is (deliberately) re-ingested as new drafts.
+- **Fixture.** `content/local/_example/` is a committed, clearly-fictional
+  city used by tests and as living documentation of the format.
+  Underscore-prefixed city folders are skipped unless explicitly targeted.
+
+## API Surface
+
+**None added or changed.** The seeder is a pure client of existing admin
+endpoints: login, list/create local sources, ingest, list recommendations,
+and coverage. Authentication is a normal admin session (email/password login
+or a pre-issued token).
+
+## Data Model
+
+**No schema changes.** Seeding writes through the existing pipeline: raw
+material provenance, draft recommendations (verified against the places
+provider where possible), and optional draft guides — all attributed to the
+local source.
+
+## UI Behavior
+
+None. This is an operator tool: a command-line runner plus a make target. Its
+output surfaces in the existing admin curation queue and coverage screens.
+
+## Edge Cases & Error States
+
+- **Missing/bad credentials or non-admin account** → the run aborts up front
+  with a clear message before touching any content.
+- **Source folder without a profile file, or a profile missing `name`** → that
+  source is skipped with a warning; the run continues and exits non-zero.
+- **Ingest failure for one file** (extraction error, upstream outage, rate
+  limit) → reported, not added to the ledger, run continues, exit non-zero.
+- **Server without the AI or places keys configured** → ingest returns its
+  existing configured-error; the seeder surfaces it per file. The keys must
+  be live on the **target server** at seed time (the seeder itself needs no
+  API keys). Place verification failures are not errors: unverified drafts
+  are kept, per existing behavior — publishing them stays blocked until a
+  human fixes the pin.
+- **Rate limits** — the seeder paces itself (sequential, small delay) to stay
+  under the server's general per-IP request limit; extraction calls are slow
+  and given a generous per-request timeout.
+- **Empty content directory / filter matching nothing** → reported, exits
+  zero (nothing to do is not a failure).
+
+## Out of Scope
+
+- No new API endpoints, no server-side batch mode, no async job queue.
+- No auto-publish: the coordinate gate and human curation are untouched.
+- No de-duplication of *drafts* (only of *input files*): re-ingesting edited
+  material intentionally creates new drafts for the curator to reconcile.
+- No deletion/sync: removing a file does not archive its drafts.
+- No non-text material (audio, images) — transcribe first, then seed.
+
+## Open Questions
+
+None — resolved during spec review:
+- Ledger lives next to the content (not centrally) so moving a city folder
+  keeps its ingest state.
+- Exact-name matching for find-or-create is acceptable at this scale; a
+  rename creates a new source, which the admin UI already surfaces.


### PR DESCRIPTION
## Summary

The local-content layer (the product's stated moat) has zero content; the only input was an admin manually POSTing raw text to `/api/v1/admin/local/ingest`. This ships a batch path: drop research files per city under `content/local/` and `make seed-local` ingests them all through the **existing** admin endpoints. **No new API surface**; the coordinate anti-hallucination gate and human curation/publish queue are untouched by construction — seeding produces drafts only.

## What's in here

- **Spec first** — `specs/local-content-seeding/spec.md` + `plan.md` define the content-directory contract:
  - `content/local/<city-slug>/<source-slug>/source.json` — exactly the `POST /admin/local/sources` fields (`name` required + optional `bio`, `photo_url`, `location`, `expertise`, `credibility`, `consent_ref`); `name` is the exact-match find-or-create key.
  - `content/local/<city-slug>/<source-slug>/NN-*.txt|md` — raw material in filename order; optional first line `kind: transcript|notes|voice_memo` (the kinds ingest accepts; default `notes`), stripped before submission.
  - Optional `city.json` `{"name": ...}` overrides the slug→Title Case city-name guess.
  - `content/` is gitignored except the committed format README and the fictional `_example` fixture (used by the live test). Underscore-prefixed cities are skipped unless explicitly targeted with `CITY=_example` — fixture data can't leak into a real environment by default.
  - `ANTHROPIC_API_KEY` + `GOOGLE_PLACES_API_KEY` must be live on the **target server** at seed time; unverified drafts are kept (existing behavior); publishing remains human.
- **`scripts/seed_local_content.sh`** (bash + curl + jq, shellcheck-clean, macOS bash-3.2 safe):
  - `BASE_URL` (default `http://localhost:3000`), `SEED_TOKEN` or `SEED_EMAIL`/`SEED_PASSWORD`, `CONTENT_DIR` (default `./content/local`), optional `CITY` filter, `SEED_SLEEP` pacing (default 1s — respects the 60/min general limiter).
  - Login → admin-probe (fails fast on 401/403) → find-or-create source by exact name → ingest each material file (`jq -Rs` raw-text encoding, `--max-time 180` for the synchronous Claude extraction) → append `sha256  filename` to `<source-dir>/.ingested` on success.
  - Idempotent: ledger-matched files are skipped on re-runs; edited files (new hash) re-ingest deliberately. Per-file report (drafts created, verified vs unverified, guide id when present), closing coverage table from `/admin/local/coverage`, non-zero exit if anything failed.
- **`make seed-local`** — wraps the script; `CONTENT_DIR`/`CITY`/`BASE_URL` pass-through; listed in `make help`.

## Verification

- `shellcheck scripts/seed_local_content.sh` clean; `make api-fmt && make api-vet` clean (zero Go changes).
- Live test against the dev stack (throwaway admin, then deleted along with all fixture rows):
  - First run: source created, `01-cafe-notes.md` → 3 drafts (3 verified), `02-dinner-transcript.txt` → 2 drafts (1 verified, 1 unverified — kept, as specced); all 5 visible via `GET /admin/local/recommendations?status=draft` with `source_name` attribution; coverage table printed.
  - Re-run (script and `make seed-local` + login path): both files `skipped (already ingested)`, exit 0.
  - Bad token: fails fast `token rejected (401)`, exit 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)