### PR TITLE
feat(deploy): production gateway — TLS termination + Cloudflare-aware client IP

### DIFF
--- a/dockerize/README.md
+++ b/dockerize/README.md
@@ -7,7 +7,8 @@ Docker orchestration lives here instead of in individual app packages. A single 
 ```
 dockerize/
 ├── development/     # Flutter dev server (hot reload) + Go API + nginx
-└── deployment/      # Static Flutter build + Go API + nginx
+├── deployment/      # Static Flutter build + Go API + nginx
+└── production/      # goldentempo.co: prebuilt GHCR images + TLS gateway behind Cloudflare (see its README)
 ```
 
 ## Quick start

--- a/dockerize/deployment/Dockerfile
+++ b/dockerize/deployment/Dockerfile
@@ -11,7 +11,8 @@ RUN apt-get update && apt-get install -y \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ARG FLUTTER_VERSION=3.24.0
+# Keep in lockstep with dockerize/development/flutter/Dockerfile.
+ARG FLUTTER_VERSION=3.35.4
 RUN git clone https://github.com/flutter/flutter.git /flutter --depth 1 --branch ${FLUTTER_VERSION}
 ENV PATH="/flutter/bin:/flutter/bin/cache/dart-sdk/bin:${PATH}"
 
@@ -25,13 +26,14 @@ RUN flutter pub get
 
 COPY src/packages/flutter-app/lib/ lib/
 COPY src/packages/flutter-app/web/ web/
+COPY src/packages/flutter-app/assets/ assets/
 COPY src/packages/flutter-app/analysis_options.yaml ./
 
 RUN mkdir -p web/icons
 RUN dart run build_runner build --delete-conflicting-outputs
 
+# --web-renderer was removed in Flutter 3.32+ (canvaskit is the default).
 RUN flutter build web --release \
-    --web-renderer canvaskit \
     --base-href /app/ \
     --dart-define=API_BASE_URL=/api/v1 \
     --dart-define=APP_BASE_PATH=/app/
@@ -39,7 +41,13 @@ RUN flutter build web --release \
 # Serve static files and proxy API via nginx
 FROM nginx:alpine
 
+# default.conf is the local :80 server shell; the production stack
+# volume-mounts dockerize/production/nginx/prod.conf over it. The shared
+# location snippet and the http-scope $share_prerender map are baked in
+# separately so both shells can include/rely on them.
 COPY dockerize/deployment/nginx/default.conf /etc/nginx/conf.d/default.conf
+COPY dockerize/deployment/nginx/share-prerender-map.conf /etc/nginx/conf.d/share-prerender-map.conf
+COPY dockerize/deployment/nginx/snippets/ /etc/nginx/snippets/
 COPY dockerize/static /usr/share/nginx/html/static
 COPY --from=flutter-build /app/build/web /usr/share/nginx/html/app
 

--- a/dockerize/deployment/nginx/default.conf
+++ b/dockerize/deployment/nginx/default.conf
@@ -1,77 +1,12 @@
-# Link-preview crawlers don't run JS, so shared-trip pages would preview
-# blank. Bot UAs on /app/share/* get rewritten to the API's OG-tag page;
-# humans get the SPA as usual.
-map $http_user_agent $share_prerender {
-    default 0;
-    ~*(facebookexternalhit|twitterbot|slackbot|linkedinbot|whatsapp|telegrambot|discordbot|skypeuripreview|pinterest|embedly|iframely|googlebot|bingbot) 1;
-}
-
+# Deployment gateway — plain :80, used locally and as the base the
+# production stack overrides. All routing lives in the shared snippet
+# (snippets/app-locations.conf, baked to /etc/nginx/snippets/) so the
+# production TLS server (dockerize/production/nginx/prod.conf) serves the
+# exact same location set. The $share_prerender map the snippet needs is in
+# share-prerender-map.conf (http scope, conf.d).
 server {
     listen 80;
     server_name localhost;
 
-    root /usr/share/nginx/html;
-    index index.html;
-
-    location /api/ {
-        proxy_pass http://api:8080;
-        proxy_http_version 1.1;
-        proxy_read_timeout 180s;
-        proxy_send_timeout 180s;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-    }
-
-    # Must precede the generic /app/ block. `if` here is the documented-safe
-    # rewrite-only form; `last` re-enters location matching and lands in the
-    # /api/ proxy above. Headers repeated: nested blocks don't inherit
-    # add_header from siblings.
-    location ~ ^/app/share/ {
-        if ($share_prerender) {
-            rewrite ^/app/share/(.*)$ /api/v1/share-preview/$1 last;
-        }
-        try_files $uri /app/index.html;
-
-        add_header Cross-Origin-Embedder-Policy require-corp;
-        add_header Cross-Origin-Opener-Policy same-origin;
-    }
-
-    location /app/ {
-        try_files $uri $uri/ /app/index.html;
-
-        add_header Cross-Origin-Embedder-Policy require-corp;
-        add_header Cross-Origin-Opener-Policy same-origin;
-    }
-
-    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot|wasm)$ {
-        expires 1y;
-        add_header Cache-Control "public, immutable";
-        add_header Cross-Origin-Embedder-Policy require-corp;
-        add_header Cross-Origin-Opener-Policy same-origin;
-    }
-
-    # Legal pages — static HTML, shared source of truth in dockerize/static/
-    # (copied into this image; the development gateway mounts the same
-    # directory so /privacy and /terms behave identically on :3000).
-    location = /privacy {
-        default_type text/html;
-        alias /usr/share/nginx/html/static/privacy.html;
-    }
-
-    location = /terms {
-        default_type text/html;
-        alias /usr/share/nginx/html/static/terms.html;
-    }
-
-    location = / {
-        return 302 /app/;
-    }
-
-    location /health {
-        access_log off;
-        return 200 "healthy\n";
-        add_header Content-Type text/plain;
-    }
+    include /etc/nginx/snippets/app-locations.conf;
 }

--- a/dockerize/deployment/nginx/share-prerender-map.conf
+++ b/dockerize/deployment/nginx/share-prerender-map.conf
@@ -1,0 +1,12 @@
+# Link-preview crawlers don't run JS, so shared-trip pages would preview
+# blank. Bot UAs on /app/share/* get rewritten to the API's OG-tag page;
+# humans get the SPA as usual.
+#
+# Lives in its own conf.d file (http scope — `map` is not valid inside a
+# server block) so that snippets/app-locations.conf can rely on it under
+# both the deployment default.conf and the production prod.conf, which is
+# volume-mounted OVER conf.d/default.conf and would otherwise lose the map.
+map $http_user_agent $share_prerender {
+    default 0;
+    ~*(facebookexternalhit|twitterbot|slackbot|linkedinbot|whatsapp|telegrambot|discordbot|skypeuripreview|pinterest|embedly|iframely|googlebot|bingbot) 1;
+}

--- a/dockerize/deployment/nginx/snippets/app-locations.conf
+++ b/dockerize/deployment/nginx/snippets/app-locations.conf
@@ -1,0 +1,83 @@
+# Shared gateway location set — included at *server* scope by both the
+# deployment :80 server (nginx/default.conf) and the production :443 TLS
+# server (dockerize/production/nginx/prod.conf). Keep anything server-shape
+# specific (listen/server_name/ssl) out of this file.
+#
+# Depends on the $share_prerender map defined in share-prerender-map.conf
+# (http scope — maps are not allowed inside server blocks).
+
+root /usr/share/nginx/html;
+index index.html;
+
+location /api/ {
+    proxy_pass http://api:8080;
+    proxy_http_version 1.1;
+    proxy_read_timeout 180s;
+    proxy_send_timeout 180s;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    # REPLACE (not append) X-Forwarded-For with the single peer address this
+    # gateway vouches for. The Go rate limiter (ratelimit.go clientIP) takes
+    # the RIGHTMOST XFF entry; appending would make that entry whatever peer
+    # dialed nginx — behind Cloudflare that is a CF edge IP, collapsing all
+    # users into shared rate-limit buckets. In production the realip module
+    # (production/nginx/cloudflare-realip.conf) has already rewritten
+    # $remote_addr to CF-Connecting-IP for connections from Cloudflare's
+    # ranges; direct peers keep their socket IP, so the value stays
+    # unspoofable either way. In the deployment stack (no realip conf)
+    # $remote_addr is nginx's actual peer — the same value
+    # $proxy_add_x_forwarded_for used to put rightmost.
+    proxy_set_header X-Forwarded-For $remote_addr;
+    proxy_set_header X-Forwarded-Proto $scheme;
+}
+
+# Must precede the generic /app/ block. `if` here is the documented-safe
+# rewrite-only form; `last` re-enters location matching and lands in the
+# /api/ proxy above. Headers repeated: nested blocks don't inherit
+# add_header from siblings.
+location ~ ^/app/share/ {
+    if ($share_prerender) {
+        rewrite ^/app/share/(.*)$ /api/v1/share-preview/$1 last;
+    }
+    try_files $uri /app/index.html;
+
+    add_header Cross-Origin-Embedder-Policy require-corp;
+    add_header Cross-Origin-Opener-Policy same-origin;
+}
+
+location /app/ {
+    try_files $uri $uri/ /app/index.html;
+
+    add_header Cross-Origin-Embedder-Policy require-corp;
+    add_header Cross-Origin-Opener-Policy same-origin;
+}
+
+location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot|wasm)$ {
+    expires 1y;
+    add_header Cache-Control "public, immutable";
+    add_header Cross-Origin-Embedder-Policy require-corp;
+    add_header Cross-Origin-Opener-Policy same-origin;
+}
+
+# Legal pages — static HTML, shared source of truth in dockerize/static/
+# (copied into this image; the development gateway mounts the same
+# directory so /privacy and /terms behave identically on :3000).
+location = /privacy {
+    default_type text/html;
+    alias /usr/share/nginx/html/static/privacy.html;
+}
+
+location = /terms {
+    default_type text/html;
+    alias /usr/share/nginx/html/static/terms.html;
+}
+
+location = / {
+    return 302 /app/;
+}
+
+location /health {
+    access_log off;
+    return 200 "healthy\n";
+    add_header Content-Type text/plain;
+}

--- a/dockerize/production/README.md
+++ b/dockerize/production/README.md
@@ -1,0 +1,92 @@
+# Production stack — goldentempo.co
+
+Runs the prebuilt GHCR images on a VPS behind **Cloudflare** (proxied DNS,
+SSL mode **Full (strict)**). The gateway terminates TLS with a **Cloudflare
+Origin CA** certificate and restores the real client IP from
+`CF-Connecting-IP` so the API's per-IP rate limiter sees end users, not
+Cloudflare edge IPs.
+
+## Server layout
+
+```
+/opt/goldentempo/
+├── docker-compose.yml        # this directory's compose file
+├── .env                      # secrets: API keys, POSTGRES_PASSWORD, DATABASE_URL (PR A2)
+├── nginx/
+│   ├── prod.conf             # TLS server blocks (mounted over conf.d/default.conf)
+│   └── cloudflare-realip.conf# CF ranges + real_ip_header (mounted into conf.d/)
+└── backups/                  # pg_dump output
+
+/etc/goldentempo/certs/
+├── origin.crt                # Cloudflare Origin CA certificate (goldentempo.co + *.goldentempo.co)
+└── origin.key                # its private key (chmod 600, root-owned)
+```
+
+## How config reaches the containers
+
+**Mounted, never baked.** The gateway image (built by
+`dockerize/deployment/Dockerfile`) bakes in:
+
+- `/etc/nginx/snippets/app-locations.conf` — the shared location set
+  (API proxy, SPA, share-preview rewrite, static caching, legal pages),
+  used verbatim by both the deployment `:80` server and the production
+  `:443` server;
+- `/etc/nginx/conf.d/share-prerender-map.conf` — the `$share_prerender`
+  bot-UA `map` (must live at `http` scope);
+- `/etc/nginx/conf.d/default.conf` — the local `:80` server shell.
+
+The production compose then **mounts** `nginx/prod.conf` *over*
+`conf.d/default.conf` (replacing the `:80 localhost` shell with the
+`:80→301` + `:443 ssl` servers), mounts `nginx/cloudflare-realip.conf` into
+`conf.d/`, and mounts `/etc/goldentempo/certs` read-only. Editing a conf on
+the host therefore needs only a gateway restart, not an image rebuild:
+
+```bash
+docker compose exec gateway nginx -t && docker compose exec gateway nginx -s reload
+```
+
+## Client-IP chain (rate limiting correctness)
+
+1. Cloudflare edge connects to nginx `:443` and sets `CF-Connecting-IP`.
+2. `cloudflare-realip.conf`: the peer IP is in Cloudflare's published
+   ranges, so the realip module rewrites `$remote_addr` to the header's
+   value (the end user). Non-Cloudflare peers keep their socket IP and the
+   header is ignored — unspoofable.
+3. The shared `/api/` proxy block sends
+   `X-Forwarded-For: $remote_addr` — **replace, not append** — a single
+   trusted value.
+4. The Go rate limiter (`src/packages/api/ratelimit.go` `clientIP()`) takes
+   the rightmost `X-Forwarded-For` entry → the real user IP.
+
+When Cloudflare publishes new ranges, refresh `cloudflare-realip.conf`
+from <https://www.cloudflare.com/ips/> and reload the gateway.
+
+## Deploy / rollback
+
+```bash
+# Deploy a new build (images published by CI as :latest and :<sha>)
+cd /opt/goldentempo
+IMAGE_TAG=<sha> docker compose pull && IMAGE_TAG=<sha> docker compose up -d
+
+# Rollback: same command with the previous sha
+IMAGE_TAG=<previous-sha> docker compose pull && IMAGE_TAG=<previous-sha> docker compose up -d
+
+# Config-only change (no new images)
+docker compose up -d --force-recreate gateway
+
+# Status / logs
+docker compose ps
+docker compose logs -f gateway api
+
+# DB backup before risky deploys
+docker compose exec postgres pg_dump -U travel travel_planner > backups/$(date +%F).sql
+```
+
+## Sanity checks after a deploy
+
+```bash
+curl -fsS https://goldentempo.co/health              # gateway
+curl -fsS https://goldentempo.co/api/v1/health       # API through the proxy
+curl -sI  http://goldentempo.co/                     # 301 → https apex
+curl -sI  https://www.goldentempo.co/                # 301 → apex
+```

--- a/dockerize/production/docker-compose.yml
+++ b/dockerize/production/docker-compose.yml
@@ -1,0 +1,97 @@
+# Production stack for https://goldentempo.co — same topology as
+# dockerize/deployment/docker-compose.yml, but runs prebuilt images from
+# GHCR (no build:) and terminates TLS on the gateway (:80 + :443) behind
+# Cloudflare. All nginx config and certs are volume-mounted, never baked,
+# so a config change is `docker compose up -d --force-recreate gateway`,
+# not an image rebuild.
+#
+# Runs from /opt/goldentempo/ on the VPS with a .env file next to it
+# (secrets/env plumbing is intentionally minimal here — see PR A2).
+services:
+  chrome:
+    image: chromedp/headless-shell:latest
+    expose:
+      - "9222"
+    shm_size: '2gb'
+    restart: unless-stopped
+    networks:
+      - travel-planner-network
+
+  postgres:
+    image: postgres:16-alpine
+    # .env provides POSTGRES_PASSWORD (must match the DATABASE_URL the api
+    # receives from the same .env).
+    env_file:
+      - .env
+    environment:
+      POSTGRES_USER: travel
+      POSTGRES_DB: travel_planner
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U travel -d travel_planner"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+    restart: unless-stopped
+    networks:
+      - travel-planner-network
+
+  api:
+    image: ghcr.io/bdowe/goldentempo-api:${IMAGE_TAG:-latest}
+    expose:
+      - "8080"
+    env_file:
+      - .env
+    environment:
+      - GO_ENV=production
+      - CHROME_WS_URL=ws://chrome:9222/
+    depends_on:
+      chrome:
+        condition: service_started
+      postgres:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8080/api/v1/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+    restart: unless-stopped
+    networks:
+      - travel-planner-network
+
+  gateway:
+    image: ghcr.io/bdowe/goldentempo-gateway:${IMAGE_TAG:-latest}
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      # prod.conf replaces the baked-in :80 localhost server; the shared
+      # location snippet + $share_prerender map stay from the image.
+      - ./nginx/prod.conf:/etc/nginx/conf.d/default.conf:ro
+      - ./nginx/cloudflare-realip.conf:/etc/nginx/conf.d/cloudflare-realip.conf:ro
+      # Cloudflare Origin CA cert + key (origin.crt / origin.key).
+      - /etc/goldentempo/certs:/etc/goldentempo/certs:ro
+    depends_on:
+      - api
+    healthcheck:
+      # :80 is a wholesale 301 to https://goldentempo.co, so probe :443
+      # directly; the apex server is default_server, so "localhost" lands
+      # there. --no-check-certificate: the Origin CA cert isn't in the
+      # container's trust store (it's only trusted by Cloudflare).
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "--no-check-certificate", "https://localhost/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 10s
+    restart: unless-stopped
+    networks:
+      - travel-planner-network
+
+volumes:
+  postgres_data:
+
+networks:
+  travel-planner-network:
+    driver: bridge

--- a/dockerize/production/nginx/cloudflare-realip.conf
+++ b/dockerize/production/nginx/cloudflare-realip.conf
@@ -1,0 +1,41 @@
+# Restore the real client IP behind Cloudflare (http scope; mounted into
+# /etc/nginx/conf.d/ by dockerize/production/docker-compose.yml).
+#
+# For connections whose peer address is inside one of the trusted ranges
+# below, nginx rewrites $remote_addr to the value of CF-Connecting-IP (the
+# header Cloudflare sets to the end user's IP). Connections from anywhere
+# else keep their socket peer address and the header is ignored — so a
+# direct (non-Cloudflare) client cannot spoof its identity by sending
+# CF-Connecting-IP itself.
+#
+# The shared /api/ proxy block (snippets/app-locations.conf) then forwards
+# X-Forwarded-For: $remote_addr — a single trusted value — which is exactly
+# what the Go rate limiter's clientIP() reads (rightmost XFF entry).
+
+# Cloudflare IPv4 ranges — refresh from https://www.cloudflare.com/ips/
+set_real_ip_from 173.245.48.0/20;
+set_real_ip_from 103.21.244.0/22;
+set_real_ip_from 103.22.200.0/22;
+set_real_ip_from 103.31.4.0/22;
+set_real_ip_from 141.101.64.0/18;
+set_real_ip_from 108.162.192.0/18;
+set_real_ip_from 190.93.240.0/20;
+set_real_ip_from 188.114.96.0/20;
+set_real_ip_from 197.234.240.0/22;
+set_real_ip_from 198.41.128.0/17;
+set_real_ip_from 162.158.0.0/15;
+set_real_ip_from 104.16.0.0/13;
+set_real_ip_from 104.24.0.0/14;
+set_real_ip_from 172.64.0.0/13;
+set_real_ip_from 131.0.72.0/22;
+
+# Cloudflare IPv6 ranges — refresh from https://www.cloudflare.com/ips/
+set_real_ip_from 2400:cb00::/32;
+set_real_ip_from 2606:4700::/32;
+set_real_ip_from 2803:f800::/32;
+set_real_ip_from 2405:b500::/32;
+set_real_ip_from 2405:8100::/32;
+set_real_ip_from 2a06:98c0::/29;
+set_real_ip_from 2c0f:f248::/32;
+
+real_ip_header CF-Connecting-IP;

--- a/dockerize/production/nginx/prod.conf
+++ b/dockerize/production/nginx/prod.conf
@@ -1,0 +1,53 @@
+# Production gateway for https://goldentempo.co — TLS termination behind
+# Cloudflare (proxied DNS, SSL mode "Full (strict)", Cloudflare Origin CA
+# certificate on the origin).
+#
+# This file is volume-mounted over /etc/nginx/conf.d/default.conf by
+# dockerize/production/docker-compose.yml (config is mounted, never baked).
+# The shared location set (snippets/app-locations.conf) and the
+# $share_prerender bot-UA map (share-prerender-map.conf) are baked into the
+# gateway image by dockerize/deployment/Dockerfile and remain in place;
+# cloudflare-realip.conf is mounted alongside this file to restore the real
+# client IP from CF-Connecting-IP before any of this runs.
+
+# Plain HTTP → canonical HTTPS. Cloudflare in Full (strict) mode always dials
+# the origin on :443; this catches direct hits and misconfigured edges.
+server {
+    listen 80;
+    listen [::]:80;
+    server_name goldentempo.co www.goldentempo.co;
+    return 301 https://goldentempo.co$request_uri;
+}
+
+# Canonical apex. default_server so requests without a matching SNI/Host —
+# notably the in-container health check against https://localhost/health —
+# land here instead of falling into the www redirect below.
+server {
+    listen 443 ssl default_server;
+    listen [::]:443 ssl default_server;
+    http2 on;
+    server_name goldentempo.co;
+
+    ssl_certificate     /etc/goldentempo/certs/origin.crt;
+    ssl_certificate_key /etc/goldentempo/certs/origin.key;
+    ssl_protocols       TLSv1.2 TLSv1.3;
+    ssl_session_cache   shared:SSL:10m;
+    ssl_session_timeout 1d;
+
+    include /etc/nginx/snippets/app-locations.conf;
+}
+
+# www → apex 301 (the Origin CA cert covers goldentempo.co and
+# *.goldentempo.co, so terminating www here is fine).
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+    http2 on;
+    server_name www.goldentempo.co;
+
+    ssl_certificate     /etc/goldentempo/certs/origin.crt;
+    ssl_certificate_key /etc/goldentempo/certs/origin.key;
+    ssl_protocols       TLSv1.2 TLSv1.3;
+
+    return 301 https://goldentempo.co$request_uri;
+}


### PR DESCRIPTION
Wave 9 PR A1. Launches https://goldentempo.co on a VPS behind Cloudflare (proxied DNS, SSL Full (strict), Cloudflare Origin CA cert in nginx — no Caddy), and fixes the client-IP correctness bug this would otherwise create in the Go rate limiter.

## Why the XFF change is load-bearing

`clientIP()` (`src/packages/api/ratelimit.go`, unmodified) takes the **rightmost** `X-Forwarded-For` entry. With the old `$proxy_add_x_forwarded_for` (append), the rightmost entry is whatever peer dialed nginx — behind Cloudflare that's a CF edge IP, collapsing all users into a handful of shared rate-limit buckets. Fix is nginx-only:

1. **`cloudflare-realip.conf`** (http scope, production only): `set_real_ip_from` for every published Cloudflare IPv4/IPv6 range + `real_ip_header CF-Connecting-IP`. Connections from CF ranges get `$remote_addr` rewritten to the end user's IP; direct peers keep their socket IP and the header is ignored — **CF-Connecting-IP cannot be spoofed**.
2. **Shared snippet** `/api/` proxy: `X-Forwarded-For: $remote_addr` — **replace, not append**. One trusted value; the rightmost-entry contract now always resolves to the realip-restored client (prod) or the actual socket peer (everywhere else).

Chain: CF edge → nginx `:443` (`CF-Connecting-IP: <user>`) → realip rewrites `$remote_addr` → snippet sends `X-Forwarded-For: <user>` → Go `clientIP()` rightmost entry → per-user buckets.

**Dev parity:** in the deployment stack there's no realip conf, so `$remote_addr` is nginx's docker peer — exactly the value `$proxy_add_x_forwarded_for` used to put rightmost (and if a client sent its own XFF, append still made the rightmost entry `$remote_addr`). Verified live: with `X-Forwarded-For: 9.9.9.9` spoofed, the API rate-limit log still shows the docker peer `192.168.65.1`.

## What's in here

- **`dockerize/deployment/nginx/`** — behavior-neutral snippet refactor: all location blocks move to `snippets/app-locations.conf` (server scope, baked to `/etc/nginx/snippets/`); the `$share_prerender` bot-UA `map` moves to `share-prerender-map.conf` (own conf.d file — `map` is http-scope only, and production mounts prod.conf *over* `conf.d/default.conf`, which would have dropped a map living there); `default.conf` is now the `:80 localhost` shell.
- **`dockerize/production/nginx/prod.conf`** — `:80` → `301 https://goldentempo.co$request_uri`; `:443 ssl` + `http2 on` apex (TLSv1.2/1.3, Origin CA cert at `/etc/goldentempo/certs/`) including the shared snippet; `www` → apex 301. Apex is `default_server` so the in-container healthcheck (`https://localhost/health`) lands on it.
- **`dockerize/production/nginx/cloudflare-realip.conf`** — all current CF ranges, commented to refresh from https://www.cloudflare.com/ips/.
- **`dockerize/production/docker-compose.yml`** — deployment topology (postgres + chrome + api + gateway) with `ghcr.io/bdowe/goldentempo-{api,gateway}:${IMAGE_TAG:-latest}` (no `build:`), gateway on `80:80`+`443:443`, prod.conf mounted over `conf.d/default.conf`, realip conf into `conf.d/`, certs read-only. Env kept minimal (`env_file: .env` on api + postgres) — full plumbing is PR A2.
- **`dockerize/production/README.md`** — `/opt/goldentempo/` layout, mounted-never-baked config model, deploy/rollback one-liners.
- **`dockerize/deployment/Dockerfile`** — *pre-existing breakage fixed en route* (the image didn't build on main, which blocked the neutrality gate): Flutter 3.24.0 → 3.35.4 (`gpt_markdown ^1.1.7` needs Dart ≥3.7.0), dropped the removed `--web-renderer` flag, added the missing `COPY assets/` (fonts + images). Plus the three nginx COPY lines for the snippet/map.

## Gates

**Behavior neutrality** — deployment stack built & run before/after (gateway remapped to :3100; dev stack on :3000 untouched). `nginx -T` diff, normalized (comments/indentation stripped), is exactly:
```
- map $share_prerender {...}        # moved from default.conf head…
+ include /etc/nginx/snippets/app-locations.conf;
- proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+ proxy_set_header X-Forwarded-For $remote_addr;
+ map $share_prerender {...}        # …to conf.d/share-prerender-map.conf
```
Curls identical before/after: `/health` 200, `/api/v1/health` 200 (`database":"ok"`), `/privacy` + `/terms` 200, `curl -A twitterbot /app/share/xyz` → 404 from the **API** share-preview handler ("This trip isn't available" HTML), plain UA → 200 SPA shell, `/` → 302 `/app/`.

**Prod conf** — `nginx -t` passes on `nginx:1.27-alpine` with the exact in-container layout (prod.conf as default.conf + realip conf + baked map/snippet) and openssl dummy certs; `with-http_realip_module` and `with-http_v2_module` confirmed compiled in. Live smoke on the built gateway image: `:80` → `301 https://goldentempo.co/app/x`, `https://www.goldentempo.co/deep/path?q=1` → `301 https://goldentempo.co/deep/path?q=1`, apex `/health` 200 over h2, `/app/` 200 over TLS. `docker compose -f dockerize/production/docker-compose.yml config` validates with a stub `.env`.

## Notes / follow-ups

- `ghcr.io/bdowe/goldentempo-{api,gateway}` images aren't published by CI yet — the publish workflow is a follow-up (PR A2 territory).
- When Cloudflare updates its ranges, refresh `cloudflare-realip.conf` and reload the gateway (documented in both files).
- The stale comment on `clientIP()` in `ratelimit.go` still mentions `$proxy_add_x_forwarded_for`; left untouched per scope (do-not-modify).

🤖 Generated with [Claude Code](https://claude.com/claude-code)