### PR TITLE
feat(deploy): production env plumbing, Postgres hardening, backups

### DIFF
--- a/dockerize/production/.env.sample
+++ b/dockerize/production/.env.sample
@@ -1,0 +1,124 @@
+# Production environment for goldentempo.co
+# ------------------------------------------
+# Copy to /opt/goldentempo/.env (chmod 600, root-owned) next to
+# docker-compose.yml. This single file serves two purposes:
+#   1. compose ${...} interpolation (POSTGRES_PASSWORD, IMAGE_TAG), and
+#   2. env_file passthrough into the api container (everything else).
+# Values pinned by the compose file itself (GO_ENV=production, CHROME_WS_URL,
+# DATABASE_URL composed from POSTGRES_PASSWORD) do NOT belong here — the
+# compose `environment:` block overrides env_file, so setting them here is
+# at best redundant and at worst confusing.
+
+# ---------------------------------------------------------------------------
+# Stack / compose interpolation
+# ---------------------------------------------------------------------------
+
+# REQUIRED — compose refuses to start without it (no default on purpose).
+# Used both as the postgres superuser password and, via interpolation, inside
+# the api's DATABASE_URL. Because it is spliced into a URL, use a long random
+# ALPHANUMERIC value (e.g. `openssl rand -hex 32`); characters like @ : / # %
+# would break the DSN.
+POSTGRES_PASSWORD=
+
+# Image tag to run (CI publishes :latest and :<git-sha>). Deploys usually
+# override this per-command (IMAGE_TAG=<sha> docker compose up -d); the value
+# here is only the fallback when the shell doesn't set one.
+IMAGE_TAG=latest
+
+# ---------------------------------------------------------------------------
+# Core API config
+# ---------------------------------------------------------------------------
+
+# Leave EMPTY in production. The nginx gateway serves the UI and API
+# same-origin (goldentempo.co), so no CORS headers are needed; an allowlist
+# here would only widen the surface. Localhost origins are a dev-only thing.
+ALLOWED_ORIGINS=
+
+# Public URL used in transactional email links (verification, password
+# reset, price alerts). Static for this deployment.
+PUBLIC_BASE_URL=https://goldentempo.co
+
+# Path prefix the Flutter app is served under (deep links in emails).
+PUBLIC_APP_PATH=/app/
+
+# API listen port inside the container. The gateway proxies to api:8080;
+# leave as-is unless the image changes.
+PORT=8080
+
+# ---------------------------------------------------------------------------
+# Provider keys
+# ---------------------------------------------------------------------------
+
+# REQUIRED for core product function: /places/* endpoints, the /plan agent's
+# search_places tool, and the local-content publish gate (coordinate
+# verification). The API boots without it, but planning is crippled.
+GOOGLE_PLACES_API_KEY=
+
+# REQUIRED for /api/v1/plan (the AI planner) and admin local-content
+# ingestion. The API boots without it, but the core product doesn't work.
+ANTHROPIC_API_KEY=
+
+# Flight search (Duffel). Use a LIVE token (duffel_live_...) in production;
+# a test token returns sandbox data. Missing => /flights/* return a
+# configured-error, rest of the API unaffected (degraded, not fatal).
+DUFFEL_ACCESS_TOKEN=
+# Rarely need changing.
+DUFFEL_BASE_URL=https://api.duffel.com
+DUFFEL_VERSION=v2
+
+# Local events (Ticketmaster Discovery, free key). Missing => /events/search
+# and the agent's search_events return a configured-error; rest unaffected.
+TICKETMASTER_API_KEY=
+# Rarely needs changing.
+TICKETMASTER_BASE_URL=https://app.ticketmaster.com/discovery/v2
+
+# Affiliate IDs — LEAVE EMPTY until the affiliate programs are approved AND
+# the seller-of-travel / affiliate-disclosure review in
+# docs/legal/llc-formation-playbook.md is cleared. Links work without them,
+# just unattributed (no revenue, no legal exposure).
+FERRYHOPPER_AFFILIATE_ID=
+BOOKING_AFFILIATE_ID=
+
+# ---------------------------------------------------------------------------
+# Email (transactional: verification, password reset, price alerts)
+# ---------------------------------------------------------------------------
+# Any SMTP provider (Resend/Postmark/SES). Empty SMTP_HOST => email delivery
+# DISABLED and verify/reset tokens are only logged — users cannot complete
+# signup. Effectively required in production.
+SMTP_HOST=
+SMTP_PORT=587
+SMTP_USERNAME=
+SMTP_PASSWORD=
+SMTP_FROM=
+
+# ---------------------------------------------------------------------------
+# Observability
+# ---------------------------------------------------------------------------
+
+# Sentry DSN. Empty => Sentry is fully inert (no goroutines, no network).
+# Set it in production so handler panics and Error-level logs are reported.
+SENTRY_DSN=
+# Release tag for Sentry events. CI sets this to the git SHA at deploy time;
+# only set here if deploying manually.
+# SENTRY_RELEASE=
+
+# ---------------------------------------------------------------------------
+# Tuning (optional — sensible defaults compiled in; uncomment to override)
+# ---------------------------------------------------------------------------
+
+# Price-alerts checker cadence.
+# ALERT_TICK_MINUTES=5    # how often the checker wakes up
+# ALERT_CHECK_HOURS=6     # per-alert re-check freshness window
+
+# Free-cap soft instrumentation (measurement only, nothing enforced).
+# FREE_PLAN_SESSIONS_PER_MONTH=20
+# FREE_ACTIVE_TRIPS=3
+
+# ---------------------------------------------------------------------------
+# Backups (read by backup.sh, not the api)
+# ---------------------------------------------------------------------------
+# backup.sh defaults match this deployment; override only for non-standard
+# layouts. See backup.sh header for the full list.
+# BACKUP_DIR=/opt/goldentempo/backups
+# RETENTION_DAYS=14
+# RCLONE_REMOTE=r2:goldentempo-backups

--- a/dockerize/production/README.md
+++ b/dockerize/production/README.md
@@ -11,16 +11,33 @@ Cloudflare edge IPs.
 ```
 /opt/goldentempo/
 ├── docker-compose.yml        # this directory's compose file
-├── .env                      # secrets: API keys, POSTGRES_PASSWORD, DATABASE_URL (PR A2)
+├── .env                      # secrets — copy .env.sample and fill in (chmod 600)
+├── backup.sh                 # nightly pg_dump + prune + optional rclone off-site copy
 ├── nginx/
 │   ├── prod.conf             # TLS server blocks (mounted over conf.d/default.conf)
 │   └── cloudflare-realip.conf# CF ranges + real_ip_header (mounted into conf.d/)
-└── backups/                  # pg_dump output
+└── backups/                  # backup.sh output (gzipped pg_dump custom format)
 
 /etc/goldentempo/certs/
 ├── origin.crt                # Cloudflare Origin CA certificate (goldentempo.co + *.goldentempo.co)
 └── origin.key                # its private key (chmod 600, root-owned)
 ```
+
+## Environment / secrets
+
+All runtime configuration lives in one file: `/opt/goldentempo/.env`
+(`cp .env.sample .env`, fill in, `chmod 600`). It is used two ways:
+
+1. **Compose interpolation** — `POSTGRES_PASSWORD` (required, no default:
+   `docker compose config` fails fast if it's missing) and `IMAGE_TAG`.
+2. **`env_file` passthrough into the api** — provider keys, SMTP, Sentry,
+   `PUBLIC_*`, tuning vars. See `.env.sample` for the annotated inventory
+   of what's required vs degraded-mode-optional.
+
+`DATABASE_URL` is **not** set in `.env` — the compose file composes it from
+`POSTGRES_PASSWORD` (so api and postgres can never disagree) with
+`sslmode=disable`, which is safe because 5432 is never published to the
+host; it exists only on the private compose network.
 
 ## How config reaches the containers
 
@@ -78,9 +95,27 @@ docker compose up -d --force-recreate gateway
 docker compose ps
 docker compose logs -f gateway api
 
-# DB backup before risky deploys
-docker compose exec postgres pg_dump -U travel travel_planner > backups/$(date +%F).sql
+# DB backup before risky deploys (same script cron runs nightly)
+./backup.sh
 ```
+
+## Backups & restore
+
+`backup.sh` dumps the database (`pg_dump -Fc | gzip`) into `backups/`,
+prunes dumps older than 14 days, and — when `rclone` is installed with an
+`r2:goldentempo-backups` remote configured — copies the new dump off-site
+(otherwise it warns and still exits 0). Nightly cron (as root):
+
+```cron
+10 4 * * * /opt/goldentempo/backup.sh >> /var/log/goldentempo-backup.log 2>&1
+```
+
+Paths/services are overridable via env (`COMPOSE_FILE`, `COMPOSE_PROJECT`,
+`BACKUP_DIR`, …) — see the header of `backup.sh`.
+
+To restore a dump, follow [`restore.md`](restore.md): verify the dump in a
+fresh scratch volume first, then swap it under the live stack and confirm
+`/api/v1/health` reports `database: ok`.
 
 ## Sanity checks after a deploy
 

--- a/dockerize/production/backup.sh
+++ b/dockerize/production/backup.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Nightly Postgres backup for the goldentempo.co production stack.
+#
+# Dumps the database from the running postgres container (pg_dump custom
+# format, gzipped), prunes local dumps older than RETENTION_DAYS, and — if
+# rclone is installed with the configured remote — copies the new dump
+# off-site. Designed for cron:
+#
+#   10 4 * * * /opt/goldentempo/backup.sh >> /var/log/goldentempo-backup.log 2>&1
+#
+# Exit status: non-zero if the dump itself fails (cron mails/logs it);
+# a missing/unconfigured rclone only warns and exits 0 (off-site copy is
+# best-effort, the local dump already succeeded).
+#
+# Every path/name is overridable via env so the script can be dry-run
+# against another stack (e.g. the dev compose) without touching this file:
+#
+#   COMPOSE_FILE      compose file of the stack to back up
+#                     (default /opt/goldentempo/docker-compose.yml)
+#   COMPOSE_PROJECT   compose project name; empty => derived by compose
+#                     from the compose-file directory (default empty)
+#   BACKUP_DIR        where dumps land (default /opt/goldentempo/backups)
+#   PG_SERVICE        compose service name of postgres (default postgres)
+#   PG_USER / PG_DB   database credentials (default travel / travel_planner)
+#   RETENTION_DAYS    local prune horizon (default 14)
+#   RCLONE_REMOTE     rclone destination (default r2:goldentempo-backups)
+set -euo pipefail
+
+COMPOSE_FILE="${COMPOSE_FILE:-/opt/goldentempo/docker-compose.yml}"
+COMPOSE_PROJECT="${COMPOSE_PROJECT:-}"
+BACKUP_DIR="${BACKUP_DIR:-/opt/goldentempo/backups}"
+PG_SERVICE="${PG_SERVICE:-postgres}"
+PG_USER="${PG_USER:-travel}"
+PG_DB="${PG_DB:-travel_planner}"
+RETENTION_DAYS="${RETENTION_DAYS:-14}"
+RCLONE_REMOTE="${RCLONE_REMOTE:-r2:goldentempo-backups}"
+
+compose() {
+    if [ -n "$COMPOSE_PROJECT" ]; then
+        docker compose -f "$COMPOSE_FILE" -p "$COMPOSE_PROJECT" "$@"
+    else
+        docker compose -f "$COMPOSE_FILE" "$@"
+    fi
+}
+
+mkdir -p "$BACKUP_DIR"
+
+out="$BACKUP_DIR/${PG_DB}-$(date +%F).dump.gz"
+tmp="$out.tmp"
+trap 'rm -f "$tmp"' EXIT
+
+echo "[backup] $(date -u +%FT%TZ) dumping $PG_DB from service '$PG_SERVICE' to $out"
+
+# pipefail makes a pg_dump failure fail the whole pipeline; the tmp+mv dance
+# means a failed run never leaves a truncated file behind as "the backup".
+compose exec -T "$PG_SERVICE" pg_dump -Fc -U "$PG_USER" "$PG_DB" | gzip >"$tmp"
+mv "$tmp" "$out"
+
+echo "[backup] wrote $(du -h "$out" | cut -f1) $out"
+
+# Prune local dumps older than the retention horizon.
+find "$BACKUP_DIR" -maxdepth 1 -name "${PG_DB}-*.dump.gz" -type f \
+    -mtime +"$RETENTION_DAYS" -print -delete |
+    sed 's/^/[backup] pruned /'
+
+# Off-site copy (best-effort): requires rclone AND the remote to exist.
+remote_name="${RCLONE_REMOTE%%:*}"
+if ! command -v rclone >/dev/null 2>&1; then
+    echo "[backup] WARNING: rclone not installed — skipping off-site copy of $out" >&2
+    exit 0
+fi
+if ! rclone listremotes | grep -qx "${remote_name}:"; then
+    echo "[backup] WARNING: rclone remote '${remote_name}:' not configured — skipping off-site copy of $out" >&2
+    exit 0
+fi
+rclone copy "$out" "$RCLONE_REMOTE/"
+echo "[backup] copied $out to $RCLONE_REMOTE/"

--- a/dockerize/production/docker-compose.yml
+++ b/dockerize/production/docker-compose.yml
@@ -6,7 +6,9 @@
 # not an image rebuild.
 #
 # Runs from /opt/goldentempo/ on the VPS with a .env file next to it
-# (secrets/env plumbing is intentionally minimal here — see PR A2).
+# (copy .env.sample in this directory and fill it in). Compose reads that
+# same .env automatically for ${...} interpolation, so POSTGRES_PASSWORD /
+# IMAGE_TAG below and the api's env_file all come from one file.
 services:
   chrome:
     image: chromedp/headless-shell:latest
@@ -19,13 +21,20 @@ services:
 
   postgres:
     image: postgres:16-alpine
-    # .env provides POSTGRES_PASSWORD (must match the DATABASE_URL the api
-    # receives from the same .env).
-    env_file:
-      - .env
+    # No env_file here on purpose: postgres only needs its own three vars,
+    # not the API keys and SMTP credentials the rest of .env carries.
+    # POSTGRES_PASSWORD is interpolated from the same .env (compose loads it
+    # automatically) with NO default — `docker compose config/up` fails fast
+    # with a clear error instead of booting a database with a known password.
+    # The api's DATABASE_URL below is composed from the same variable, so the
+    # two can never drift.
     environment:
       POSTGRES_USER: travel
       POSTGRES_DB: travel_planner
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set}
+    # No `ports:` on purpose — 5432 must stay unpublished. The database is
+    # reachable only from containers on the private compose bridge network,
+    # which is also why sslmode=disable on the api's DATABASE_URL is safe.
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:
@@ -41,11 +50,29 @@ services:
     image: ghcr.io/bdowe/goldentempo-api:${IMAGE_TAG:-latest}
     expose:
       - "8080"
+    # All runtime config reaches the api via env_file passthrough from .env:
+    # provider keys (GOOGLE_PLACES_API_KEY, ANTHROPIC_API_KEY,
+    # DUFFEL_ACCESS_TOKEN, TICKETMASTER_API_KEY, FERRYHOPPER_AFFILIATE_ID,
+    # BOOKING_AFFILIATE_ID), SMTP_*, PUBLIC_BASE_URL / PUBLIC_APP_PATH,
+    # SENTRY_DSN / SENTRY_RELEASE, ALLOWED_ORIGINS, ALERT_* / FREE_* tuning.
+    # See .env.sample in this directory for the full annotated inventory.
+    # The `environment:` block holds only values that are composed or pinned
+    # by the stack itself; compose gives `environment:` precedence over
+    # env_file, so anything stale in .env (e.g. a localhost DATABASE_URL)
+    # cannot leak in.
     env_file:
       - .env
     environment:
       - GO_ENV=production
       - CHROME_WS_URL=ws://chrome:9222/
+      # Composed from the same POSTGRES_PASSWORD the postgres service boots
+      # with, so credentials cannot drift between the two services.
+      # sslmode=disable is acceptable here — and only here — because the
+      # connection never leaves the host: postgres publishes no host port
+      # (no `ports:` above, keep it that way) and both containers sit on the
+      # same private compose bridge network. TLS would only encrypt
+      # loopback-equivalent traffic between two containers on one machine.
+      - DATABASE_URL=postgres://travel:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set}@postgres:5432/travel_planner?sslmode=disable
     depends_on:
       chrome:
         condition: service_started

--- a/dockerize/production/restore.md
+++ b/dockerize/production/restore.md
@@ -1,0 +1,111 @@
+# Restore runbook — goldentempo.co Postgres
+
+Restores a `backup.sh` dump (`pg_dump -Fc | gzip`) into a **fresh volume
+first**, verifies it there, and only then swaps it under the live stack.
+The old volume's data is preserved until you delete it, so every step is
+reversible.
+
+Assumptions: stack at `/opt/goldentempo` (compose project `goldentempo`,
+data volume `goldentempo_postgres_data`), dumps in
+`/opt/goldentempo/backups/`. Confirm the volume name first:
+
+```bash
+docker volume ls | grep postgres_data
+```
+
+## 0. Pick the dump and sanity-check it
+
+```bash
+cd /opt/goldentempo
+DUMP=backups/travel_planner-2026-07-06.dump.gz   # <-- pick the one you want
+
+gunzip -t "$DUMP"                                # gzip integrity
+gunzip -c "$DUMP" | pg_restore --list | head -30 # table of contents (host psql tools,
+                                                 # or pipe through the container as below)
+```
+
+## 1. Stop writers (leave postgres up for now)
+
+```bash
+docker compose stop api
+```
+
+The gateway will serve 502s for `/api/` while the api is down; the static
+app keeps loading. Keep this window short.
+
+## 2. Restore into a fresh scratch volume
+
+```bash
+source .env   # for POSTGRES_PASSWORD
+
+docker volume create goldentempo_postgres_restore
+
+docker run -d --name pg-restore \
+  -v goldentempo_postgres_restore:/var/lib/postgresql/data \
+  -e POSTGRES_USER=travel \
+  -e POSTGRES_DB=travel_planner \
+  -e POSTGRES_PASSWORD="$POSTGRES_PASSWORD" \
+  postgres:16-alpine
+
+# wait for it to accept connections
+until docker exec pg-restore pg_isready -U travel -d travel_planner; do sleep 1; done
+
+gunzip -c "$DUMP" | docker exec -i pg-restore \
+  pg_restore -U travel -d travel_planner --no-owner --exit-on-error
+```
+
+## 3. Verify the scratch restore
+
+```bash
+docker exec pg-restore psql -U travel -d travel_planner -c '\dt'      # tables present
+docker exec pg-restore psql -U travel -d travel_planner \
+  -c 'SELECT count(*) FROM users; SELECT count(*) FROM trips;'        # plausible counts
+docker exec pg-restore psql -U travel -d travel_planner \
+  -c 'SELECT version_id, tstamp FROM goose_db_version ORDER BY id DESC LIMIT 1;'
+```
+
+Do **not** proceed past this point until the scratch data looks right.
+
+```bash
+docker stop pg-restore && docker rm pg-restore
+```
+
+## 4. Swap the restored data under the live stack
+
+```bash
+docker compose stop postgres
+
+# Copy scratch volume over the live data volume. The live volume is only
+# overwritten here — if anything above failed, you haven't touched it.
+docker run --rm \
+  -v goldentempo_postgres_restore:/src:ro \
+  -v goldentempo_postgres_data:/dst \
+  alpine sh -c 'rm -rf /dst/* && cp -a /src/. /dst/'
+
+docker compose up -d postgres
+docker compose up -d api      # api boot re-applies any missing migrations
+```
+
+## 5. Verify end to end
+
+```bash
+docker compose ps                                        # postgres healthy, api healthy
+docker compose logs --tail 50 api                        # migrations applied, no errors
+curl -fsS https://goldentempo.co/api/v1/health           # "database":"ok"
+```
+
+Then a real user check: log in at <https://goldentempo.co/app/> and open a
+trip.
+
+## 6. Clean up
+
+```bash
+docker volume rm goldentempo_postgres_restore
+```
+
+## Rollback
+
+If the swapped data is wrong, the pre-swap state is gone from the live
+volume (step 4 overwrote it) — restore an earlier dump by repeating from
+step 0. If you want a zero-risk swap instead, run `backup.sh` once more
+immediately before step 4 so "current state" is itself a restorable dump.


### PR DESCRIPTION
Wave 9 PR A2. Builds on #84's `dockerize/production/` stack — env/secrets plumbing, Postgres hardening, and a backup/restore story.

## Changes

### `docker-compose.yml` — Postgres hardening
- `POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set}` — no default; `docker compose config/up` fails fast with a clear error instead of booting a DB with a known password.
- The api's `DATABASE_URL` is now **composed in the compose file** from the same variable (`postgres://travel:${POSTGRES_PASSWORD:?}@postgres:5432/travel_planner?sslmode=disable`), so api and postgres credentials can never drift. Compose `environment:` overrides `env_file`, so a stale localhost `DATABASE_URL` in `.env` can't leak in.
- `sslmode=disable` justified inline: postgres publishes **no host port** (verified — only the gateway has `ports:`) and lives on the private compose bridge; keep it that way.
- postgres loses `env_file:` — it doesn't need the API keys / SMTP creds the rest of `.env` carries.

### Env passthrough decision
Everything else reaches the api via the existing `env_file: .env` passthrough (provider keys, SMTP_*, PUBLIC_*, SENTRY_*, ALLOWED_ORIGINS, ALERT_*/FREE_* tuning). Explicit `environment:` entries are only the stack-pinned values: `GO_ENV=production`, `CHROME_WS_URL`, and the composed `DATABASE_URL`. Documented in a comment block on the api service.

### `dockerize/production/.env.sample` (new)
Full annotated inventory against the API's actual `os.Getenv` surface — required-at-boot vs degraded-mode-optional per var, `PUBLIC_BASE_URL=https://goldentempo.co` / `PUBLIC_APP_PATH=/app/` pre-filled, `ALLOWED_ORIGINS=` empty with the same-origin explanation, affiliate IDs empty with the legal-gate note referencing `docs/legal/llc-formation-playbook.md`, URL-safe-password note for `POSTGRES_PASSWORD` (it's spliced into a DSN).

### `dockerize/production/backup.sh` (new)
`set -euo pipefail`; `pg_dump -Fc | gzip` via `docker compose exec -T`; writes to `.tmp` then `mv` so a failed dump never leaves a truncated "backup"; prunes local dumps older than 14 days; `rclone copy` to `r2:goldentempo-backups` only when rclone is installed **and** the remote is configured (else warning + exit 0). All paths/names env-overridable (`COMPOSE_FILE`, `COMPOSE_PROJECT`, `BACKUP_DIR`, `PG_*`, `RETENTION_DAYS`, `RCLONE_REMOTE`) for dry-runs against other stacks. Shellcheck-clean.

### `dockerize/production/restore.md` (new)
Runbook: stop api → restore into a fresh scratch volume → verify tables/counts/goose version there → swap over the live volume → `up -d` → confirm `/api/v1/health` `database: ok`.

### `README.md`
New Environment/secrets and Backups & restore sections; cron line `10 4 * * * /opt/goldentempo/backup.sh >> /var/log/goldentempo-backup.log 2>&1`; the ad-hoc pg_dump one-liner replaced with `./backup.sh`.

## Verification
- `shellcheck backup.sh` clean.
- `docker compose config` without `POSTGRES_PASSWORD` → `required variable POSTGRES_PASSWORD is missing a value: POSTGRES_PASSWORD must be set`; with a stub `.env` → validates, composed `DATABASE_URL` correct, postgres has no published ports.
- Dry-run of `backup.sh` against the dev stack (`COMPOSE_FILE`/`COMPOSE_PROJECT` overrides, scratch `BACKUP_DIR`): 48K dump produced, `gunzip -t` OK, `pg_restore --list` shows all 19 tables. Failure path (`PG_DB=nonexistent_db`): exit 1, no partial file left.
- `make api-fmt && make api-vet` (no Go changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)