### PR TITLE
ci: GHCR image build/push + SSH deploy on green main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,10 +4,23 @@ on:
   push:
     branches: [main]
   pull_request:
+  # Manual deploy/rollback: run the workflow on main with the git SHA of a
+  # previously pushed image (CI tags every main image with its SHA). The
+  # build-push job is skipped on dispatch — only deploy runs, pointing the
+  # server at the requested tag.
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: "Image tag to deploy (git SHA of a previous green main build)"
+        required: true
+        type: string
 
 concurrency:
   group: ci-${{ github.ref }}
-  cancel-in-progress: true
+  # Cancel superseded PR runs, but never a main run: killing one mid-deploy
+  # could interrupt the ssh step on the server. Main runs queue instead
+  # (GitHub keeps only the newest pending run), preserving deploy order.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   go:
@@ -124,3 +137,139 @@ jobs:
         env:
           DATABASE_URL: postgres://postgres:postgres@localhost:5432/travel?sslmode=disable
         run: go run . migrate
+
+  build-push:
+    name: Build & push images (GHCR)
+    runs-on: ubuntu-latest
+    # The gateway image includes a full Flutter web build (~several minutes).
+    timeout-minutes: 30
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: [go, flutter, migrations]
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Same context/dockerfile the deployment compose uses for the api
+      # service (dockerize/deployment/docker-compose.yml).
+      - name: Build & push api image
+        uses: docker/build-push-action@v6
+        with:
+          context: src/packages/api
+          file: src/packages/api/Dockerfile
+          push: true
+          tags: |
+            ghcr.io/bdowe/goldentempo-api:latest
+            ghcr.io/bdowe/goldentempo-api:${{ github.sha }}
+          build-args: |
+            SENTRY_RELEASE=${{ github.sha }}
+          cache-from: type=gha,scope=api
+          cache-to: type=gha,mode=max,scope=api
+
+      # The gateway Dockerfile COPYs both src/packages/flutter-app/ and
+      # dockerize/ paths, so its context is the repo root.
+      - name: Build & push gateway image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: dockerize/deployment/Dockerfile
+          push: true
+          tags: |
+            ghcr.io/bdowe/goldentempo-gateway:latest
+            ghcr.io/bdowe/goldentempo-gateway:${{ github.sha }}
+          cache-from: type=gha,scope=gateway
+          cache-to: type=gha,mode=max,scope=gateway
+
+  deploy:
+    name: Deploy to production
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: build-push
+    # Two ways in:
+    #   - push to main with a successful build-push (normal deploy of the
+    #     freshly pushed :<sha> images);
+    #   - workflow_dispatch on main (manual deploy/rollback of an existing
+    #     tag; build-push is skipped, hence the explicit result check and
+    #     !cancelled() to override the implicit success() gate).
+    if: >-
+      ${{ !cancelled() && github.ref == 'refs/heads/main' &&
+          ((github.event_name == 'push' && needs.build-push.result == 'success') ||
+           github.event_name == 'workflow_dispatch') }}
+    env:
+      IMAGE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.image_tag || github.sha }}
+    steps:
+      # The DEPLOY_* secrets arrive with Track B step 3 (server provisioning).
+      # Until then this job self-skips with a notice instead of failing, so
+      # main CI stays green. Delete this gate once the secrets exist, if you
+      # want missing config to be loud.
+      - name: Check deploy secrets
+        id: gate
+        env:
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
+          DEPLOY_KNOWN_HOSTS: ${{ secrets.DEPLOY_KNOWN_HOSTS }}
+        run: |
+          if [ -z "$DEPLOY_HOST" ] || [ -z "$DEPLOY_SSH_KEY" ] || [ -z "$DEPLOY_KNOWN_HOSTS" ]; then
+            echo "::notice::deploy secrets not configured — skipping deploy (Track B step 3)"
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          case "$IMAGE_TAG" in
+            (*[!A-Za-z0-9._-]*|"")
+              echo "::error::invalid IMAGE_TAG '$IMAGE_TAG' (expected a git SHA / docker tag)"
+              exit 1 ;;
+          esac
+          echo "configured=true" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/checkout@v4
+        if: steps.gate.outputs.configured == 'true'
+
+      - uses: webfactory/ssh-agent@v0.9.0
+        if: steps.gate.outputs.configured == 'true'
+        with:
+          ssh-private-key: ${{ secrets.DEPLOY_SSH_KEY }}
+
+      - name: Add server to known_hosts
+        if: steps.gate.outputs.configured == 'true'
+        env:
+          DEPLOY_KNOWN_HOSTS: ${{ secrets.DEPLOY_KNOWN_HOSTS }}
+        run: |
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+          printf '%s\n' "$DEPLOY_KNOWN_HOSTS" >> ~/.ssh/known_hosts
+          chmod 600 ~/.ssh/known_hosts
+
+      # Everything under dockerize/production/ that's in git (compose, nginx
+      # confs, README). No --delete: /opt/goldentempo/ also holds the .env,
+      # .image_tag, and backups/ that must never be touched from CI. Certs
+      # live outside the tree in /etc/goldentempo/certs.
+      - name: Sync production stack files
+        if: steps.gate.outputs.configured == 'true'
+        env:
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+        run: rsync -rtvz dockerize/production/ "deploy@${DEPLOY_HOST}:/opt/goldentempo/"
+
+      # .image_tag records what's live so manual server-side restarts can
+      # reuse it (see dockerize/production/README.md) instead of silently
+      # falling back to :latest.
+      - name: Pull images and restart stack
+        if: steps.gate.outputs.configured == 'true'
+        env:
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+        run: |
+          ssh "deploy@${DEPLOY_HOST}" "set -eu
+            cd /opt/goldentempo
+            printf 'IMAGE_TAG=%s\n' '${IMAGE_TAG}' > .image_tag
+            export IMAGE_TAG='${IMAGE_TAG}'
+            docker compose pull
+            docker compose up -d --remove-orphans
+            docker image prune -f"

--- a/dockerize/production/README.md
+++ b/dockerize/production/README.md
@@ -12,6 +12,7 @@ Cloudflare edge IPs.
 /opt/goldentempo/
 ├── docker-compose.yml        # this directory's compose file
 ├── .env                      # secrets: API keys, POSTGRES_PASSWORD, DATABASE_URL (PR A2)
+├── .image_tag                # IMAGE_TAG=<sha> of the live deploy (written by CI)
 ├── nginx/
 │   ├── prod.conf             # TLS server blocks (mounted over conf.d/default.conf)
 │   └── cloudflare-realip.conf# CF ranges + real_ip_header (mounted into conf.d/)
@@ -63,13 +64,28 @@ from <https://www.cloudflare.com/ips/> and reload the gateway.
 
 ## Deploy / rollback
 
-```bash
-# Deploy a new build (images published by CI as :latest and :<sha>)
-cd /opt/goldentempo
-IMAGE_TAG=<sha> docker compose pull && IMAGE_TAG=<sha> docker compose up -d
+**Normal path is hands-off:** every green push to `main` builds + pushes
+both images to GHCR (`:latest` and `:<sha>`) and the CI `deploy` job
+rsyncs this directory to `/opt/goldentempo/` and restarts the stack with
+`IMAGE_TAG=<sha>`. It also writes the live tag to
+`/opt/goldentempo/.image_tag` so manual restarts don't fall back to
+`:latest`. (Until the `DEPLOY_HOST` / `DEPLOY_SSH_KEY` /
+`DEPLOY_KNOWN_HOSTS` secrets exist, the deploy job self-skips with a
+notice.)
 
-# Rollback: same command with the previous sha
-IMAGE_TAG=<previous-sha> docker compose pull && IMAGE_TAG=<previous-sha> docker compose up -d
+**Rollback** = re-deploy an older image: GitHub → Actions → CI →
+*Run workflow* on `main` with `image_tag` set to the git SHA of a previous
+green main build. Manual fallback on the server:
+
+```bash
+cd /opt/goldentempo
+
+# Restart whatever is currently deployed (reads .image_tag written by CI)
+set -a; . ./.image_tag; set +a
+docker compose pull && docker compose up -d
+
+# Deploy/rollback a specific build by hand
+IMAGE_TAG=<sha> docker compose pull && IMAGE_TAG=<sha> docker compose up -d
 
 # Config-only change (no new images)
 docker compose up -d --force-recreate gateway

--- a/src/packages/api/Dockerfile
+++ b/src/packages/api/Dockerfile
@@ -22,6 +22,11 @@ RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o main .
 # Final stage
 FROM alpine:latest
 
+# Release identifier for Sentry (main.go reads SENTRY_RELEASE). CI passes the
+# git SHA via --build-arg; local builds leave it empty (Sentry omits release).
+ARG SENTRY_RELEASE=
+ENV SENTRY_RELEASE=${SENTRY_RELEASE}
+
 # Install ca-certificates for HTTPS requests
 RUN apk --no-cache add ca-certificates
 


### PR DESCRIPTION
Wave 9 PR A3. Extends the existing CI workflow (no `workflow_run` indirection) with image publishing and deployment on green main.

## Job graph

```
go ─┐
flutter ─┼─▶ build-push (main pushes only) ─▶ deploy
migrations ─┘
```

- **build-push** (`needs: [go, flutter, migrations]`, `if: push to main`, 30m timeout, `permissions: packages: write`):
  - `ghcr.io/bdowe/goldentempo-api` — context `src/packages/api` + its `Dockerfile` (exactly how `dockerize/deployment/docker-compose.yml` builds the api service). Passes `--build-arg SENTRY_RELEASE=<sha>`; the api Dockerfile gains `ARG SENTRY_RELEASE` / `ENV SENTRY_RELEASE` so Sentry events carry the release (read by `main.go`).
  - `ghcr.io/bdowe/goldentempo-gateway` — context **repo root** + `dockerize/deployment/Dockerfile` (it COPYs `src/packages/flutter-app/` and `dockerize/` paths).
  - Both tagged `:latest` + `:${{ github.sha }}`; GHA build cache with distinct `scope=api` / `scope=gateway`.
- **deploy** (`needs: build-push`): rsyncs `dockerize/production/` (git-tracked files only; **no `--delete`** so the server-side `.env`, `.image_tag`, `backups/` are never touched) to `deploy@$DEPLOY_HOST:/opt/goldentempo/`, then over ssh: `IMAGE_TAG=<sha> docker compose pull && up -d --remove-orphans && docker image prune -f`. Also writes `IMAGE_TAG=<sha>` to `/opt/goldentempo/.image_tag` so manual server restarts can source the live tag instead of drifting to `:latest` (README updated with the recipe).

## Deploy self-skips until secrets exist

The `DEPLOY_HOST` / `DEPLOY_SSH_KEY` / `DEPLOY_KNOWN_HOSTS` secrets arrive with **Track B step 3**. Until then, the deploy job's first step detects the missing config and exits 0 with a `::notice::` ("deploy secrets not configured — skipping"); every later step is gated on that output, so main CI stays green in the meantime.

## Manual rollback

`workflow_dispatch` now takes an `image_tag` input: Actions → CI → *Run workflow* on `main` with the git SHA of a previous green build. On dispatch, build-push is skipped and deploy re-points the server at the existing tag (input validated against `[A-Za-z0-9._-]` before it reaches the ssh command).

## Other changes

- `concurrency.cancel-in-progress` is now `pull_request`-only: a new main push queues behind (rather than cancels) a run that may be mid-deploy. PR behavior unchanged.

## Verification

- Both images built locally with the exact workflow contexts/dockerfiles; api built with `--build-arg SENTRY_RELEASE=test` and `docker run … env` shows `SENTRY_RELEASE=test`.
- Workflow YAML parses (ruby psych); actionlint not installed locally, so the expressions got a careful manual pass instead.
- `make api-fmt && make api-vet && go test ./...` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)