### PR TITLE
feat: SEO baseline — robots.txt, sitemap, landing OG tags

### DIFF
--- a/dockerize/deployment/nginx/snippets/app-locations.conf
+++ b/dockerize/deployment/nginx/snippets/app-locations.conf
@@ -72,8 +72,22 @@ location = /terms {
     alias /usr/share/nginx/html/static/terms.html;
 }
 
+# SEO plumbing — same shared static directory as the legal pages.
+location = /robots.txt {
+    default_type text/plain;
+    alias /usr/share/nginx/html/static/robots.txt;
+}
+
+location = /sitemap.xml {
+    # Empty types{} so default_type wins; mime.types maps .xml to the
+    # older text/xml.
+    types {}
+    default_type application/xml;
+    alias /usr/share/nginx/html/static/sitemap.xml;
+}
+
 location = / {
-    return 302 /app/;
+    return 301 /app/;
 }
 
 location /health {

--- a/dockerize/development/nginx/default.conf
+++ b/dockerize/development/nginx/default.conf
@@ -31,6 +31,20 @@ server {
         alias /usr/share/nginx/html/static/terms.html;
     }
 
+    # SEO plumbing — same shared static directory as the legal pages.
+    location = /robots.txt {
+        default_type text/plain;
+        alias /usr/share/nginx/html/static/robots.txt;
+    }
+
+    location = /sitemap.xml {
+        # Empty types{} so default_type wins; mime.types maps .xml to the
+        # older text/xml.
+        types {}
+        default_type application/xml;
+        alias /usr/share/nginx/html/static/sitemap.xml;
+    }
+
     location / {
         proxy_pass http://flutter:8080;
         proxy_http_version 1.1;

--- a/dockerize/static/robots.txt
+++ b/dockerize/static/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Disallow: /api/
+
+Sitemap: https://goldentempo.co/sitemap.xml

--- a/dockerize/static/sitemap.xml
+++ b/dockerize/static/sitemap.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://goldentempo.co/</loc></url>
+  <url><loc>https://goldentempo.co/app/</loc></url>
+  <url><loc>https://goldentempo.co/privacy</loc></url>
+  <url><loc>https://goldentempo.co/terms</loc></url>
+</urlset>

--- a/src/packages/flutter-app/web/index.html
+++ b/src/packages/flutter-app/web/index.html
@@ -31,6 +31,17 @@
   <meta content="IE=Edge" http-equiv="X-UA-Compatible">
   <meta name="description" content="Golden Tempo Travel - Plan trips, optimize routes, and build itineraries with AI.">
 
+  <!-- SEO / social sharing (app landing; per-trip share links are prerendered
+       server-side via /api/v1/share-preview and don't use these). -->
+  <link rel="canonical" href="https://goldentempo.co/app/">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="Golden Tempo Travel">
+  <meta property="og:title" content="Golden Tempo Travel">
+  <meta property="og:description" content="Golden Tempo Travel - Plan trips, optimize routes, and build itineraries with AI.">
+  <meta property="og:url" content="https://goldentempo.co/app/">
+  <meta property="og:image" content="https://goldentempo.co/app/icons/Icon-512.png">
+  <meta name="twitter:card" content="summary">
+
   <!-- iOS meta tags & icons -->
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black">


### PR DESCRIPTION
## Summary

Wave 9 A5 — minimal SEO plumbing for goldentempo.co.

- **`dockerize/static/robots.txt`** — allow all crawlers, `Disallow: /api/`, sitemap pointer.
- **`dockerize/static/sitemap.xml`** — simple urlset: `/`, `/app/`, `/privacy`, `/terms` (no lastmod).
- **Shared nginx snippet** (`dockerize/deployment/nginx/snippets/app-locations.conf`) — `location = /robots.txt` / `= /sitemap.xml` alias blocks next to the /privacy//terms pattern, serving from the shared `dockerize/static/` dir. Sitemap uses an empty `types {}` + `default_type application/xml` so nginx's mime.types (`.xml → text/xml`) doesn't win. Both deployment (:80) and production (:443) shells get the locations via the snippet include.
- **Dev gateway** (`dockerize/development/nginx/default.conf`) — same two locations for :3000 parity (static dir is already volume-mounted), matching how PR #66 added /privacy//terms to both configs.
- **Root redirect** `/ → /app/` upgraded **302 → 301** (SEO permanence). Grepped for anything depending on it being temporary — only the snippet itself references it.
- **`web/index.html`** — `<link rel="canonical">`, `og:type/site_name/title/description/url/image` (reuses the existing meta-description copy; image is `icons/Icon-512.png`, verified present), `twitter:card=summary`. Splash/bootstrap script and the `serviceWorkerVersion` line untouched. Per-trip share links keep using the server-side `/api/v1/share-preview` prerender — these tags only cover the app landing.

## Verification

Deployment stack built and run on :3100 (port override; dev stack on :3000 untouched):

| Check | Result |
|---|---|
| `GET /robots.txt` | 200 `text/plain`, correct body |
| `GET /sitemap.xml` | 200 `application/xml`, correct body |
| `GET /` | **301** → `/app/` |
| `GET /privacy`, `/terms` | 200 `text/html` |
| `curl -A twitterbot /app/share/x` | 404 with the **API's** share-preview "trip isn't available" HTML — rewrite still reaches the API (invalid token, expected) |
| `GET /app/` | 200 |

Flutter: `flutter build web --release --base-href /app/ --dart-define=API_BASE_URL=/api/v1` succeeds; built `index.html` contains all og:/twitter/canonical tags and a properly injected `serviceWorkerVersion`.

Note for A6 (parallel snippet PR): edits here are confined to two new location blocks after `/terms` and the one-word 302→301 change — the caching region is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)