### PR TITLE
fix(deploy): web caching correctness + PWA install metadata

### DIFF
--- a/dockerize/deployment/nginx/snippets/app-locations.conf
+++ b/dockerize/deployment/nginx/snippets/app-locations.conf
@@ -52,9 +52,28 @@ location /app/ {
     add_header Cross-Origin-Opener-Policy same-origin;
 }
 
-location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot|wasm)$ {
-    expires 1y;
-    add_header Cache-Control "public, immutable";
+# App-shell files that change IN PLACE on every deploy — flutter build does
+# NOT content-hash their filenames (verified against a real build/web output),
+# so they must never be immutable. `no-cache` (not no-store) lets browsers
+# keep a copy but forces ETag revalidation, so returning visitors pick up a
+# new release on the next load. index.html is also the try_files fallback for
+# /app/ deep links and bare /app/, which land here via internal redirect.
+# Headers repeated: add_header is not inherited between blocks.
+location ~ ^/app/(?:index\.html|flutter_service_worker\.js|flutter_bootstrap\.js|main\.dart\.js|flutter\.js|version\.json|manifest\.json)$ {
+    add_header Cache-Control "no-cache";
+    add_header Cross-Origin-Embedder-Policy require-corp;
+    add_header Cross-Origin-Opener-Policy same-origin;
+}
+
+# Long-lived caching ONLY for the service-worker-managed resource trees
+# (fonts live under assets/). Their URLs are stable across deploys;
+# flutter_service_worker.js (no-cache above) owns their versioning via its
+# content-hash manifest and re-fetches entries whose hash changed. Anything
+# else that used to match a blanket *.js/*.css/... extension rule (e.g.
+# favicon.png, splash/) now falls through to the /app/ prefix block and gets
+# default ETag-validated caching instead of being pinned for a year.
+location ~ ^/app/(?:assets|canvaskit|icons)/ {
+    add_header Cache-Control "public, max-age=31536000, immutable";
     add_header Cross-Origin-Embedder-Policy require-corp;
     add_header Cross-Origin-Opener-Policy same-origin;
 }

--- a/src/packages/flutter-app/web/index.html
+++ b/src/packages/flutter-app/web/index.html
@@ -56,8 +56,8 @@
   <meta name="theme-color" content="#00695C">
 
   <!--
-    Boot splash shown while flutter.js + main.dart.js download and the engine
-    starts. Pixel-matched to the in-app SplashScreen (lib/screens/
+    Boot splash shown while flutter_bootstrap.js + main.dart.js download and
+    the engine starts. Pixel-matched to the in-app SplashScreen (lib/screens/
     splash_screen.dart) — same gradient, badge geometry, and spinner position —
     so the flutter-first-frame handoff reads as one continuous screen. If you
     change dimensions here, change splash_screen.dart too.
@@ -122,12 +122,6 @@
     @keyframes splash-spin { to { transform: rotate(360deg); } }
   </style>
 
-  <script>
-    // The value below is injected by flutter build, do not touch.
-    const serviceWorkerVersion = null;
-  </script>
-  <!-- This script adds the flutter initialization JS code -->
-  <script src="flutter.js" defer></script>
 </head>
 <body>
   <div id="splash">
@@ -138,20 +132,6 @@
   </div>
 
   <script>
-    window.addEventListener('load', function(ev) {
-      // Download main.dart.js
-      _flutter.loader.loadEntrypoint({
-        serviceWorker: {
-          serviceWorkerVersion: serviceWorkerVersion,
-        },
-        onEntrypointLoaded: function(engineInitializer) {
-          engineInitializer.initializeEngine().then(function(appRunner) {
-            appRunner.runApp();
-          });
-        }
-      });
-    });
-
     // Fade the boot splash out once Flutter paints its first frame (the in-app
     // SplashScreen, pixel-matched to the markup above).
     window.addEventListener('flutter-first-frame', function () {
@@ -163,5 +143,12 @@
       setTimeout(remove, 600); // fallback if transitionend never fires
     });
   </script>
+
+  <!-- Flutter initialization: build-generated bootstrap (inlines the loader,
+       the build config, and the injected service-worker version — verified in
+       build/web/flutter_bootstrap.js). Replaces the deprecated
+       serviceWorkerVersion/loadEntrypoint pattern, which Flutter 3.35 warns
+       about at build time. -->
+  <script src="flutter_bootstrap.js" async></script>
 </body>
 </html>

--- a/src/packages/flutter-app/web/manifest.json
+++ b/src/packages/flutter-app/web/manifest.json
@@ -1,7 +1,9 @@
 {
     "name": "Golden Tempo Travel",
     "short_name": "Golden Tempo",
-    "start_url": ".",
+    "start_url": "/app/",
+    "scope": "/app/",
+    "id": "/app/",
     "display": "standalone",
     "background_color": "#00695C",
     "theme_color": "#00695C",


### PR DESCRIPTION
## Problem

The deployment nginx served **every** `.js` file with `expires 1y` + `Cache-Control: public, immutable` — including the non-content-hashed app shell (`main.dart.js`, `flutter.js`, `flutter_bootstrap.js`, `flutter_service_worker.js`) — while `index.html` had no explicit policy (heuristic caching). Returning visitors could be pinned to a year-stale app.

## Changes

**`dockerize/deployment/nginx/snippets/app-locations.conf`** (shared by the :80 deployment shell and the production :443 TLS shell)
- New `no-cache` (ETag revalidation, not no-store) location for the in-place-updated app shell: `index.html`, `flutter_service_worker.js`, `flutter_bootstrap.js`, `main.dart.js`, `flutter.js`, `version.json`, `manifest.json`. Bare `/app/` and SPA deep links land here too via the `try_files` internal redirect.
- Replaced the blanket extension regex with 1y-immutable scoped to the service-worker-managed trees only: `/app/assets/` (incl. fonts), `/app/canvaskit/`, `/app/icons/`. Side effect: `assets/*.otf` fonts, previously missed by the extension list, now get the 1y policy; `favicon.png`/`splash/` fall back to default ETag-validated caching.
- COEP/COOP headers repeated in both new blocks (`add_header` non-inheritance), verified present before/after on every URL class.
- Single `Cache-Control` header per response now (the old `expires` + `add_header` combo emitted two).

**`src/packages/flutter-app/web/manifest.json`** — `start_url`/`scope`/`id` = `/app/` for correct PWA install (was `start_url: "."`, no scope/id).

**`src/packages/flutter-app/web/index.html`** — Flutter 3.35.4 warns on the old `const serviceWorkerVersion = null` + `_flutter.loader.loadEntrypoint` pattern (verified in build logs), so migrated to the build-generated `flutter_bootstrap.js` (async script; splash fade via `flutter-first-frame` unchanged). Build is now warning-free; the injected service-worker version lands in `flutter_bootstrap.js` (`serviceWorkerVersion: "<hash>"`, grep-verified in the served bundle).

## Verification (deployment image, full stack on :3200)

| URL | Before (main) | After |
|---|---|---|
| `/app/`, `/app/index.html` | *(none — heuristic)* | `no-cache` + ETag |
| `/app/flutter_service_worker.js` | **1y immutable** | `no-cache` + ETag |
| `/app/main.dart.js`, `/app/flutter.js`, `/app/flutter_bootstrap.js` | **1y immutable** | `no-cache` + ETag |
| `/app/version.json`, `/app/manifest.json` | *(none — heuristic)* | `no-cache` + ETag |
| `/app/assets/...otf` | *(none — missed by ext list)* | `public, max-age=31536000, immutable` |
| `/app/icons/Icon-512.png`, `/app/canvaskit/canvaskit.wasm` | 1y immutable | 1y immutable (unchanged) |

- COEP `require-corp` / COOP `same-origin` present on all of the above, before and after.
- `manifest.json` → `start_url`/`scope`/`id` all `/app/`.
- `curl -A twitterbot /app/share/x` still rewrites to the API share-preview (same 404 body as baseline); browser UA still gets the SPA.
- Post-rebase sanity on #87's SEO additions: `/robots.txt` 200, `/sitemap.xml` 200 `application/xml`, `/` → 301 `/app/`, OG tags in served index.
- `flutter build web --release --base-href /app/ --dart-define=API_BASE_URL=/api/v1` — the two index.html deprecation warnings are gone; no new warnings (wasm dry-run + icon tree-shake notes pre-existing).

## Note

`assets/`/`canvaskit/`/`icons/` filenames are **not** content-hashed by `flutter build web` (verified against real build output); they're kept long-cached because `flutter_service_worker.js` (now no-cache) owns their versioning via its content-hash manifest and serves them SW-cache-first. Residual risk: on an engine/asset upgrade a SW cache-miss re-fetch can hit a stale HTTP-cache entry — accepted per the agreed matrix; a future hardening could add cache-busting queries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)