### PR TITLE
fix(flutter): trip pull-to-refresh enters offline mode on network failure

### DIFF
--- a/specs/offline-trips/spec.md
+++ b/specs/offline-trips/spec.md
@@ -93,10 +93,19 @@ Client-side cache only (no server entities):
   existing "Could not load trips" empty state shows.
 - **Trip detail:** loads live as today. On a network-level failure of the
   initial (loud) load with a cached copy present, the saved detail renders
-  with the banner above the scroll area and mutations disabled. Silent
-  refreshes keep their existing behavior (failures keep showing the current
-  trip quietly). A later successful load clears the banner and re-enables
-  everything.
+  with the banner above the scroll area and mutations disabled. A silent
+  refresh that fails at the **network level** (e.g. pull-to-refresh while
+  offline) also enters offline mode — banner shown, mutations disabled —
+  but keeps the trip already on screen (it is at least as fresh as the
+  cache; nothing is swapped in). This closes the original v1 asymmetry
+  where the detail screen's pull-to-refresh failed silently while the
+  trips list flipped into offline mode for the same gesture. Two carve-outs
+  remain deliberate: silent refreshes that fail with a **non-network**
+  error stay fully silent (the current trip keeps showing — transient
+  server errors during a streaming turn must not flash error UI), and the
+  offline flip is skipped while the AI refine panel is open (its refreshes
+  are driven by a live SSE stream, so the connection is demonstrably up).
+  A later successful load clears the banner and re-enables everything.
 - **Staleness:** relative time ("just now", "N minutes/hours/days ago"),
   computed from the saved-at timestamp at render time.
 

--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -163,9 +163,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
       // Loud path + network-level failure: fall back to the cached copy and
       // render it read-only. HTTP errors (403/404/500) never reach here —
       // isNetworkError excludes them — so a revoked or deleted trip can't
-      // resurrect from a stale copy. Quiet failures keep their existing
-      // behavior: the stale trip stays; the next refresh or a loud load will
-      // surface a persistent problem.
+      // resurrect from a stale copy.
       if (mounted && !quiet && TripCache.isNetworkError(e)) {
         final cached = await ref.read(tripCacheProvider).readTrip(widget.tripId);
         if (cached != null && mounted) {
@@ -177,6 +175,32 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
           });
           return; // finally still clears _loading
         }
+      }
+      // Quiet path + network-level failure on the trip already on screen
+      // (pull-to-refresh while offline): flip into offline mode — banner +
+      // mutation guards — instead of completing the indicator silently with
+      // edits still armed. The on-screen trip is at least as fresh as the
+      // cache (every successful load writes through), so keep it; only the
+      // offline state changes. Skipped while the refine panel is open: its
+      // quiet refreshes are driven by trip_updated events on a live SSE
+      // stream, so declaring the app offline mid-conversation would
+      // contradict the working connection and strand the panel (which is
+      // never allowed to observe offline mode — see _openRefine). Quiet
+      // NON-network failures stay fully silent: a transient server error
+      // during a streaming turn must not flash error UI (PR #51/#53).
+      if (mounted &&
+          quiet &&
+          !_panelOpen &&
+          _trip?.id == widget.tripId &&
+          TripCache.isNetworkError(e)) {
+        final cached =
+            await ref.read(tripCacheProvider).readTrip(widget.tripId);
+        if (mounted) {
+          // The cache entry's timestamp is when the on-screen data was
+          // fetched (write-through); fall back to "now" on a cache miss.
+          setState(() => _offlineSince = cached?.savedAt ?? DateTime.now());
+        }
+        return;
       }
       if (mounted && !quiet) setState(() => _error = e.toString());
     } finally {

--- a/src/packages/flutter-app/test/trip_detail_offline_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_offline_test.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -60,6 +62,14 @@ T _labeledButton<T extends ButtonStyleButton>(
       of: find.text(label),
       matching: find.bySubtype<T>(),
     ));
+
+/// Crosses the RefreshIndicator's arm threshold to fire a quiet _load.
+Future<void> _triggerRefresh(WidgetTester tester) async {
+  await tester.fling(
+      find.byType(CustomScrollView), const Offset(0, 400), 1000);
+  await tester.pump(); // start the indicator
+  await tester.pump(const Duration(seconds: 1)); // cross the arm threshold
+}
 
 Future<void> _pumpDetail(
     WidgetTester tester, _QueuedTripsApiService service, TripCache cache) {
@@ -174,5 +184,103 @@ void main() {
     expect(find.text('Could not load this trip'), findsOneWidget);
     expect(find.textContaining('Offline — showing saved copy from'),
         findsNothing);
+  });
+
+  testWidgets(
+      'quiet network failure (pull-to-refresh) enters offline mode without '
+      'swapping the on-screen trip', (WidgetTester tester) async {
+    final cache = TripCache('u1');
+    final service = _QueuedTripsApiService(
+        [_trip('Athens Trip (live)'), http.ClientException('down')]);
+
+    await _pumpDetail(tester, service, cache);
+    await tester.pumpAndSettle();
+    expect(find.text('Athens Trip (live)'), findsWidgets);
+
+    // Plant a divergent, older cache entry AFTER the initial load's
+    // write-through, so a swap-from-cache would be visible and the banner's
+    // timestamp provably comes from the cache entry, not DateTime.now().
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(
+      'trip_cache.u1.trip.t1',
+      jsonEncode({
+        'saved_at': DateTime.now()
+            .subtract(const Duration(days: 2))
+            .toIso8601String(),
+        'trip': _trip('Cached Stale Copy').toJson(),
+      }),
+    );
+
+    await _triggerRefresh(tester);
+    await tester.pumpAndSettle();
+    expect(service.calls, 2);
+
+    // Offline mode entered: banner up, dated from the cache entry.
+    expect(find.textContaining('Offline — showing saved copy from'),
+        findsOneWidget);
+    expect(find.textContaining('2 days ago'), findsOneWidget);
+    // The on-screen trip is untouched — never swapped for the cached copy.
+    expect(find.text('Athens Trip (live)'), findsWidgets);
+    expect(find.text('Cached Stale Copy'), findsNothing);
+    expect(find.text('Could not load this trip'), findsNothing);
+
+    // Mutation affordances are guarded, same as a loud offline entry.
+    final refine = _labeledButton<FilledButton>(tester, 'Refine with AI');
+    expect(refine.onPressed, isNull);
+    final addPlace = _labeledButton<TextButton>(tester, 'Add place');
+    expect(addPlace.onPressed, isNull);
+  });
+
+  testWidgets('quiet NON-network failure stays fully silent',
+      (WidgetTester tester) async {
+    final cache = TripCache('u1');
+    final service = _QueuedTripsApiService(
+        [_trip('Athens Trip'), Exception('Failed to load trip (500)')]);
+
+    await _pumpDetail(tester, service, cache);
+    await tester.pumpAndSettle();
+
+    await _triggerRefresh(tester);
+    await tester.pumpAndSettle();
+    expect(service.calls, 2);
+
+    // No banner, no error page, mutations still armed — the PR #51/#53
+    // silent-refresh invariant for transient server errors.
+    expect(find.textContaining('Offline — showing saved copy from'),
+        findsNothing);
+    expect(find.text('Could not load this trip'), findsNothing);
+    expect(find.text('Athens Trip'), findsWidgets);
+    final refine = _labeledButton<FilledButton>(tester, 'Refine with AI');
+    expect(refine.onPressed, isNotNull);
+  });
+
+  testWidgets(
+      'a successful load after a quiet offline entry clears the banner',
+      (WidgetTester tester) async {
+    final cache = TripCache('u1');
+    final service = _QueuedTripsApiService([
+      _trip('Athens Trip'),
+      http.ClientException('down'),
+      _trip('Athens Trip (back online)'),
+    ]);
+
+    await _pumpDetail(tester, service, cache);
+    await tester.pumpAndSettle();
+
+    await _triggerRefresh(tester);
+    await tester.pumpAndSettle();
+    expect(find.textContaining('Offline — showing saved copy from'),
+        findsOneWidget);
+
+    // Reconnect: another pull-to-refresh succeeds and exits offline mode.
+    await _triggerRefresh(tester);
+    await tester.pumpAndSettle();
+    expect(service.calls, 3);
+
+    expect(find.textContaining('Offline — showing saved copy from'),
+        findsNothing);
+    expect(find.text('Athens Trip (back online)'), findsWidgets);
+    final refine = _labeledButton<FilledButton>(tester, 'Refine with AI');
+    expect(refine.onPressed, isNotNull, reason: 'back online — re-enabled');
   });
 }


### PR DESCRIPTION
## What

Closes the known offline-trips asymmetry (documented in specs/offline-trips as a v1 tradeoff, revisited deliberately): with a trip on screen, pull-to-refresh while offline ran a quiet `_load` whose failure was completely silent — the indicator completed, no banner, mutation affordances stayed enabled, and edits then failed with raw exception snacks. The trips list handled the same gesture loudly and entered offline mode.

## How

In `_load`'s quiet-failure branch: when `TripCache.isNetworkError(e)` and the failure is for the currently-displayed trip, set `_offlineSince` — from the cache entry's write-through timestamp when available (that IS when the on-screen data was fetched), else `DateTime.now()` — **without swapping `_trip`**. The on-screen copy is at least as fresh as the cache, so only the banner and `_guardOffline` state flip. The banner appearing is the only new visible effect; no spinner, no error page.

**Recovery**: no change needed — the success path already clears `_offlineSince` unconditionally (not gated on `quiet`), so any later successful load (Retry, pull-to-refresh, post-mutation reload) exits offline mode.

**Preserved invariants**:
- Quiet **non-network** failures (HTTP 4xx/5xx, transient server errors) stay fully silent — the PR #51/#53 silent-refresh invariant for streaming turns is untouched.
- Loud-path cache fallback and the HTTP-error-never-resurrects rule are unchanged.

## Streaming-panel decision

The offline flip is **skipped while the refine panel is open** (`_panelOpen`). Rationale: with the panel open, quiet loads are `_refresh()` calls driven by `trip_updated` events arriving on a live SSE stream — the stream working is direct evidence the network is up, so a failed ancillary `getTrip` (transient blip, race) must not declare the app offline mid-conversation. Entering offline mode would also strand the panel in a contradictory state: `_openRefine` deliberately guards so the panel can never observe offline/cached data, and offline mode disables the very affordances the active session is using. `_panelOpen` is the screen's own state (checked at failure time, not load start) and is the conservative superset of "stream active"; if the network genuinely dies while the panel is open, the stream itself errors visibly in the panel, and the user's next quiet refresh after closing it flips the banner.

## Spec

Amended the "silent refreshes keep their existing behavior" note in `specs/offline-trips/spec.md` (UI Behavior → Trip detail) to describe the new quiet-network-failure entry into offline mode and the two deliberate carve-outs (non-network stays silent; panel-open skips the flip).

## Tests

Extended `test/trip_detail_offline_test.dart` (+3):
- quiet network failure → banner appears (timestamped from the cache entry, proven with a planted divergent 2-days-old entry), on-screen trip **not** swapped for the cached copy, Refine/Add-place disabled
- quiet non-network failure → no banner, no error page, mutations still enabled
- subsequent successful pull-to-refresh clears the banner and re-enables everything

Gates: `flutter test` 99/99 pass; `flutter analyze --no-fatal-infos --fatal-warnings` exit 0 (12 pre-existing infos, none added). trip_detail_screen.dart diff confined to the `_load` catch block (nothing near the TripMap call site being edited in parallel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)