### PR TITLE
feat(flutter): accommodation pins on the trip map

### DIFF
--- a/src/packages/flutter-app/lib/screens/shared_trip_screen.dart
+++ b/src/packages/flutter-app/lib/screens/shared_trip_screen.dart
@@ -166,6 +166,7 @@ class _SharedTripBodyState extends ConsumerState<_SharedTripBody> {
                   height: 240,
                   child: TripMap(
                     items: items,
+                    accommodations: trip.accommodations ?? const [],
                     selectedPosition: _selectedPosition,
                     onPinTap: (pos) =>
                         setState(() => _selectedPosition = pos),

--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -2342,6 +2342,8 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
                                   borderRadius: AppRadius.lgAll,
                                   child: TripMap(
                                     items: _filtered(trip),
+                                    accommodations:
+                                        trip.accommodations ?? const [],
                                     selectedPosition: _selectedPosition,
                                     segmentLabels: _segmentLabels(),
                                     onPinTap: (pos) {

--- a/src/packages/flutter-app/lib/widgets/trip_map.dart
+++ b/src/packages/flutter-app/lib/widgets/trip_map.dart
@@ -4,18 +4,26 @@ import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map_marker_cluster/flutter_map_marker_cluster.dart';
 import 'package:latlong2/latlong.dart';
+import '../models/accommodation.dart';
 import '../models/itinerary_item.dart';
 import '../theme/app_colors.dart';
+import '../utils/trip_format.dart';
 import 'app_map.dart';
 
 /// Plots a trip's itinerary on a satellite basemap: a numbered, category-tinted
 /// pin per place, a route line connecting them in itinerary order, auto-fit to
 /// the trip's extent. Tapping a pin calls [onPinTap] with that item's position.
 /// When [selectedPosition] changes the camera recenters on that place.
+/// [accommodations] render as distinct stay markers (see [_StayPin]) that join
+/// the auto-fit bounds but stay out of the route line and numbering.
 class TripMap extends StatefulWidget {
   final List<ItineraryItem> items;
   final int? selectedPosition;
   final void Function(int position)? onPinTap;
+
+  /// Stays to plot alongside the itinerary. Entries without coordinates are
+  /// skipped; the default keeps existing call sites unchanged.
+  final List<Accommodation> accommodations;
 
   /// Label text (e.g. "12 min") for the within-city leg leaving the item at the
   /// given position. Drawn at the midpoint of that segment. Empty => no labels.
@@ -27,6 +35,7 @@ class TripMap extends StatefulWidget {
     this.selectedPosition,
     this.onPinTap,
     this.segmentLabels = const {},
+    this.accommodations = const [],
   });
 
   @override
@@ -122,7 +131,17 @@ class _TripMapState extends State<TripMap> {
       }
     }
 
-    if (mapped.isEmpty) {
+    // Stays with real coordinates (null means "not geocoded"; 0,0 is junk).
+    final stays = <({Accommodation stay, LatLng point})>[];
+    for (final a in widget.accommodations) {
+      final lat = a.latitude;
+      final lng = a.longitude;
+      if (lat != null && lng != null && (lat != 0 || lng != 0)) {
+        stays.add((stay: a, point: LatLng(lat, lng)));
+      }
+    }
+
+    if (mapped.isEmpty && stays.isEmpty) {
       return Container(
         color: theme.colorScheme.surfaceContainerHighest,
         alignment: Alignment.center,
@@ -135,6 +154,8 @@ class _TripMapState extends State<TripMap> {
     }
 
     final points = mapped.map((m) => m.point).toList();
+    // Camera framing covers stays too; the route polyline sticks to [points].
+    final fitPoints = [...points, for (final s in stays) s.point];
     final selected = _selectedPoint();
 
     // Travel-time labels at the midpoint of each within-city leg (only between
@@ -198,17 +219,17 @@ class _TripMapState extends State<TripMap> {
             interactionOptions: interaction,
             backgroundColor: appMapBackground,
           )
-        : points.length == 1
+        : fitPoints.length == 1
             // Single point: bounds collapse, so center with a sensible zoom.
             ? MapOptions(
-                initialCenter: points.first,
+                initialCenter: fitPoints.first,
                 initialZoom: 13,
                 interactionOptions: interaction,
                 backgroundColor: appMapBackground,
               )
             : MapOptions(
                 initialCameraFit: CameraFit.bounds(
-                  bounds: LatLngBounds.fromPoints(points),
+                  bounds: LatLngBounds.fromPoints(fitPoints),
                   padding: const EdgeInsets.all(32),
                 ),
                 interactionOptions: interaction,
@@ -241,6 +262,26 @@ class _TripMapState extends State<TripMap> {
               ),
             if (arrowMarkers.isNotEmpty) MarkerLayer(markers: arrowMarkers),
             if (labelMarkers.isNotEmpty) MarkerLayer(markers: labelMarkers),
+            // Stays live in their own layer, outside the clusterer: a trip has
+            // few of them and "where am I sleeping" should never collapse into
+            // an anonymous count bubble with sightseeing pins. Drawn beneath
+            // the numbered pins so the primary interaction stays on top.
+            if (stays.isNotEmpty)
+              MarkerLayer(
+                markers: [
+                  for (final s in stays)
+                    Marker(
+                      point: s.point,
+                      width: 26,
+                      height: 26,
+                      child: _StayPin(
+                        name: s.stay.name,
+                        dates: tripDateRange(
+                            s.stay.checkIn, s.stay.checkOut),
+                      ),
+                    ),
+                ],
+              ),
             MarkerClusterLayerWidget(
               options: MarkerClusterLayerOptions(
                 maxClusterRadius: 45,
@@ -294,7 +335,7 @@ class _TripMapState extends State<TripMap> {
               MapControlButton(
                 icon: Icons.center_focus_strong,
                 tooltip: 'Reset map',
-                onTap: () => _fitToTrip(points),
+                onTap: () => _fitToTrip(fitPoints),
               ),
             ],
           ),
@@ -437,6 +478,45 @@ class _Pin extends StatelessWidget {
             fontWeight: FontWeight.bold,
           ),
         ),
+      ),
+    );
+  }
+}
+
+/// A stay (accommodation) marker: a rounded square with a bed glyph in the
+/// stays accent color, deliberately unlike the circular numbered itinerary
+/// pins. Stays sit outside the position-based selection sync, so a tap shows
+/// a self-contained tooltip (name + dates) instead of driving [TripMap.onPinTap].
+class _StayPin extends StatelessWidget {
+  final String name;
+
+  /// Pre-formatted check-in – check-out range; null when dates are missing.
+  final String? dates;
+
+  const _StayPin({required this.name, this.dates});
+
+  @override
+  Widget build(BuildContext context) {
+    return Tooltip(
+      message: dates == null ? name : '$name\n$dates',
+      triggerMode: TooltipTriggerMode.tap,
+      child: Container(
+        // Same white ring + shadow treatment as _Pin so it reads as part of
+        // the family, but square where itinerary pins are round.
+        decoration: BoxDecoration(
+          color: AppColors.toolAirbnb,
+          borderRadius: BorderRadius.circular(7),
+          border: Border.all(color: Colors.white, width: 2),
+          boxShadow: [
+            BoxShadow(
+              color: Colors.black.withValues(alpha: 0.35),
+              blurRadius: 4,
+              offset: const Offset(0, 1),
+            ),
+          ],
+        ),
+        alignment: Alignment.center,
+        child: const Icon(Icons.hotel, size: 14, color: Colors.white),
       ),
     );
   }

--- a/src/packages/flutter-app/test/trip_map_test.dart
+++ b/src/packages/flutter-app/test/trip_map_test.dart
@@ -1,0 +1,103 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:travel_route_planner/models/accommodation.dart';
+import 'package:travel_route_planner/models/itinerary_item.dart';
+import 'package:travel_route_planner/widgets/trip_map.dart';
+
+ItineraryItem _item(int pos, String name, double lat, double lng) =>
+    ItineraryItem(
+      id: 'i$pos',
+      position: pos,
+      name: name,
+      latitude: lat,
+      longitude: lng,
+      category: 'attraction',
+    );
+
+/// Hosts the map at a fixed size (FlutterMap needs bounded constraints).
+Widget _host(Widget child) => MaterialApp(
+      home: Scaffold(
+        body: Center(
+          child: SizedBox(width: 400, height: 300, child: child),
+        ),
+      ),
+    );
+
+void main() {
+  // Tight cluster of Paris-area coordinates so every marker stays in the
+  // viewport at the auto-fit zoom.
+  final items = [
+    _item(0, 'Louvre', 48.8606, 2.3376),
+    _item(1, 'Café de Flore', 48.8540, 2.3326),
+  ];
+
+  testWidgets('builds without accommodations (default keeps old call sites)',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(_host(TripMap(items: items)));
+    await tester.pump();
+
+    expect(find.byType(TripMap), findsOneWidget);
+    expect(find.byIcon(Icons.hotel), findsNothing);
+  });
+
+  testWidgets('renders one stay marker per stay with coordinates',
+      (WidgetTester tester) async {
+    const stays = [
+      Accommodation(
+        id: 'a1',
+        name: 'Hôtel du Louvre',
+        latitude: 48.8630,
+        longitude: 2.3364,
+        checkIn: '2026-06-10',
+        checkOut: '2026-06-12',
+      ),
+      Accommodation(
+        id: 'a2',
+        name: 'Left Bank Flat',
+        latitude: 48.8520,
+        longitude: 2.3330,
+      ),
+      // No coordinates: must be skipped, not plotted at (0, 0).
+      Accommodation(id: 'a3', name: 'Ungeocoded Stay'),
+    ];
+
+    await tester.pumpWidget(
+      _host(TripMap(items: items, accommodations: stays)),
+    );
+    await tester.pump();
+
+    expect(find.byIcon(Icons.hotel), findsNWidgets(2));
+
+    // Tapping a stay is a tooltip affair (name + dates), not selection sync.
+    final tooltips = tester
+        .widgetList<Tooltip>(find.ancestor(
+          of: find.byIcon(Icons.hotel),
+          matching: find.byType(Tooltip),
+        ))
+        .map((t) => t.message)
+        .toList();
+    expect(tooltips, contains('Hôtel du Louvre\nJun 10 – Jun 12'));
+    expect(tooltips, contains('Left Bank Flat')); // no dates -> name only
+  });
+
+  testWidgets('stays alone (no mapped items) still render a map',
+      (WidgetTester tester) async {
+    const stays = [
+      Accommodation(
+        id: 'a1',
+        name: 'Hôtel du Louvre',
+        latitude: 48.8630,
+        longitude: 2.3364,
+      ),
+    ];
+
+    await tester.pumpWidget(
+      _host(const TripMap(items: [], accommodations: stays)),
+    );
+    await tester.pump();
+
+    expect(find.text('No mapped places'), findsNothing);
+    expect(find.byIcon(Icons.hotel), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## What

The trip map plotted only itinerary items; accommodations carry coordinates (`Accommodation.latitude`/`longitude`, nullable `double?`) but were never passed, so a traveler couldn't see where they're sleeping relative to their pins.

- **`TripMap` gains an optional `accommodations` parameter** (default `const []` — all existing call sites compile unchanged). Stays without coordinates are skipped inside the widget.
- **Distinct marker**: a rounded *square* with a white bed glyph (`Icons.hotel`) in the stays accent color `AppColors.toolAirbnb`, with the same white-ring + shadow treatment as the numbered pins so it reads as part of the family — but square where itinerary pins are round circles, un-numbered, and never on the route polyline. Not confusable with category-tinted numbered pins.
- **Auto-fit**: stays join the camera-fit bounds (initial fit, single-point centering, and the reset-view button) via a `fitPoints` list; the polyline sticks to itinerary `points`.
- **Tap behavior**: item selection sync is position-index-based, so stays stay out of it. A tapped stay shows a tap-triggered `Tooltip` with its name + check-in/out range (formatted with the existing `tripDateRange` helper; name only when dates are missing).
- **Both call sites pass stays**: `trip_detail_screen.dart` and `shared_trip_screen.dart` now pass `trip.accommodations ?? const []` (2-line and 1-line diffs respectively — trip_detail deliberately untouched outside the call site).
- No legend added: the map has no existing legend affordance, so none was invented.

## Clustering decision

Stays render in their **own `MarkerLayer`, outside the `MarkerClusterLayerWidget`**. Rationale: a trip has few stays (usually one per city), and "where am I sleeping" is exactly the signal that must never collapse into an anonymous count bubble alongside sightseeing pins — a cluster of "3" that secretly contains your hotel is the most surprising possible behavior. Clustering stays separately would add a second bubble style for groups that essentially never form. The stays layer draws beneath the numbered-pin/cluster layer so the primary (selectable) pins stay on top when overlapping.

## Tests

- New `test/trip_map_test.dart`: builds with no accommodations (default path), renders exactly one bed marker per stay with coordinates (null-coordinate stay skipped) with correct tooltip messages, and renders a map when only stays are mapped.
- `make flutter-test`: 99/99 pass.
- `flutter analyze --no-fatal-infos --fatal-warnings`: exit 0 (12 pre-existing infos, none added).

🤖 Generated with [Claude Code](https://claude.com/claude-code)