### PR TITLE
feat: funnel dashboard completion — landing views tile + anonymous booking-click split

### DIFF
--- a/specs/instrumentation-events/spec.md
+++ b/specs/instrumentation-events/spec.md
@@ -142,9 +142,10 @@ Spam-bounding measures on the anonymous path:
 - **Request:** optional `days` window (default 30).
 - **Response:** counts and rates for the window — landing views (anonymous;
   see below), signups, activated users and activation rate, trips created,
-  trips with ≥1 booking click and attach rate, booking clicks by provider,
-  todos marked booked, the derived metrics below, plan sessions, total
-  input/output/cache tokens, and cost estimates.
+  trips with ≥1 booking click and attach rate, booking clicks by provider
+  (totals plus the anonymous split; see below), todos marked booked, the
+  derived metrics below, plan sessions, total input/output/cache tokens, and
+  cost estimates.
 
 #### Anonymous rows and the derived metrics
 
@@ -163,6 +164,19 @@ Anonymous events (`user_id` NULL) must never distort the signed-in numbers:
   is NULL by construction (dropped at ingest, ownership unverifiable), and
   the numerator counts DISTINCT non-NULL trip ids. This is deliberate: attach
   rate stays a signed-in, per-trip metric.
+- **Booking-click anonymous split** (`booking_clicks_anonymous`,
+  `clicks_by_provider_anonymous`): `booking_clicks` and `clicks_by_provider`
+  remain **totals** (authenticated + anonymous — backward compatible), and
+  the `user_id IS NULL` slice is exposed alongside them. Rationale (Wave-8
+  security review): anonymous clicks are unauthenticated writes — rate-limit
+  bounded but spoofable at per-IP-limiter cost — so any partner-facing claim
+  ("N clicks sent to provider X") must be quotable as *total minus anonymous*,
+  not just the conflated total. Both splits are FILTER columns on the
+  existing grouped queries, not extra round trips (the dashboard's 7-query
+  load budget holds); `booking_clicks_anonymous` comes from the per-type
+  grouped count (exact — not a sum of the LIMITed per-provider rows), and
+  `clicks_by_provider_anonymous` is a parallel map carrying only providers
+  with ≥ 1 anonymous click.
 - **`activation_rate`** joins `user_registered` to `trip_created` on
   `user_id`; NULL never joins, so anonymous rows are inert there.
 - **Errors:** 401 unauthenticated; 403 non-admin; 503 when persistence is

--- a/src/packages/api/admin_integration_test.go
+++ b/src/packages/api/admin_integration_test.go
@@ -95,6 +95,23 @@ func insertEvent(t *testing.T, userID uuid.UUID, eventType string, at time.Time,
 	}
 }
 
+// insertAnonymousEvent writes an analytics event with a NULL user_id, the way
+// the anonymous /events ingest stores landing_viewed and signed-out
+// booking_link_clicked rows.
+func insertAnonymousEvent(t *testing.T, eventType string, at time.Time, metadata string) {
+	t.Helper()
+	var meta any
+	if metadata != "" {
+		meta = metadata
+	}
+	_, err := dbPool.Exec(context.Background(),
+		`INSERT INTO analytics_events (user_id, event_type, metadata, created_at)
+		 VALUES (NULL, $1, $2, $3)`, eventType, meta, at)
+	if err != nil {
+		t.Fatalf("insertAnonymousEvent(%s): %v", eventType, err)
+	}
+}
+
 // insertTripCreated writes a trip_created event carrying its trip_id, the way
 // plan_handler records it — second_trip_retention dedupes by the referenced
 // trip's lineage, so the linkage matters.
@@ -160,6 +177,15 @@ func TestAdminMetricsValues(t *testing.T) {
 	insertEvent(t, userA.ID, "plan_session_completed", now,
 		`{"input_tokens":1000000,"output_tokens":1000000,"cache_read_tokens":0,"cache_creation_tokens":0,"max_iterations_hit":true}`)
 
+	// Top-of-funnel + the booking-click split: one anonymous landing view, one
+	// AUTHED booking click and one ANONYMOUS booking click on the same
+	// provider. booking_clicks stays the total (2); the anonymous slice (1)
+	// must surface in booking_clicks_anonymous and clicks_by_provider_anonymous
+	// without disturbing the clicks_by_provider totals.
+	insertAnonymousEvent(t, "landing_viewed", now, "")
+	insertEvent(t, userA.ID, "booking_link_clicked", now, `{"provider":"duffel"}`)
+	insertAnonymousEvent(t, "booking_link_clicked", now, `{"provider":"duffel"}`)
+
 	rec := doJSON(t, "GET", "/api/v1/admin/metrics?days=30", adminToken, nil)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("admin metrics = %d: %s", rec.Code, rec.Body.String())
@@ -170,6 +196,9 @@ func TestAdminMetricsValues(t *testing.T) {
 	for field, want := range map[string]float64{
 		"signups":                     3,
 		"trips_created":               6,
+		"landing_views":               1,
+		"booking_clicks":              2, // total: 1 authed + 1 anonymous
+		"booking_clicks_anonymous":    1,
 		"second_trip_retention":       1, // A only: B lacks the 7-day gap, C's gap is within one lineage
 		"session_frequency_returning": 0, // A's sessions all on one day
 		"active_users":                1,
@@ -187,6 +216,16 @@ func TestAdminMetricsValues(t *testing.T) {
 
 	if body["est_cost_model"] != "claude-sonnet-4-6" {
 		t.Errorf("est_cost_model = %v, want claude-sonnet-4-6", body["est_cost_model"])
+	}
+
+	// Per-provider split: totals keep counting everyone; the anonymous map is
+	// the user_id IS NULL slice of the SAME grouped query (no extra round
+	// trip — the dashboard load must stay at 7 queries).
+	if byProvider, ok := body["clicks_by_provider"].(map[string]any); !ok || byProvider["duffel"] != float64(2) {
+		t.Errorf("clicks_by_provider = %v, want duffel: 2", body["clicks_by_provider"])
+	}
+	if anon, ok := body["clicks_by_provider_anonymous"].(map[string]any); !ok || anon["duffel"] != float64(1) {
+		t.Errorf("clicks_by_provider_anonymous = %v, want duffel: 1", body["clicks_by_provider_anonymous"])
 	}
 
 	// The old, misleading field names must be gone.

--- a/src/packages/api/analytics.go
+++ b/src/packages/api/analytics.go
@@ -309,11 +309,20 @@ type MetricsResponse struct {
 	// booking_link_clicked. Anonymous clicks always have trip_id NULL (ingest
 	// drops it — ownership is unverifiable), so they appear in BookingClicks
 	// and ClicksByProvider but can never move the attach rate.
-	TripsWithBookingClick int64            `json:"trips_with_booking_click"`
-	AttachRate            float64          `json:"attach_rate"`
-	BookingClicks         int64            `json:"booking_clicks"`
-	ClicksByProvider      map[string]int64 `json:"clicks_by_provider"`
-	TodosMarkedBooked     int64            `json:"todos_marked_booked"`
+	TripsWithBookingClick int64   `json:"trips_with_booking_click"`
+	AttachRate            float64 `json:"attach_rate"`
+	// BookingClicks stays the TOTAL (authenticated + anonymous) for backward
+	// compatibility; BookingClicksAnonymous is the user_id IS NULL slice —
+	// unauthenticated ingest, rate-limit bounded but unaudited, so
+	// partner-facing reads should quote total minus anonymous (Wave-8 security
+	// review). Same split for ClicksByProvider / ClicksByProviderAnonymous
+	// (parallel maps off one grouped query; the anonymous map carries only
+	// providers with >= 1 anonymous click).
+	BookingClicksAnonymous    int64            `json:"booking_clicks_anonymous"`
+	BookingClicks             int64            `json:"booking_clicks"`
+	ClicksByProvider          map[string]int64 `json:"clicks_by_provider"`
+	ClicksByProviderAnonymous map[string]int64 `json:"clicks_by_provider_anonymous"`
+	TodosMarkedBooked         int64            `json:"todos_marked_booked"`
 	// SecondTripRetention answers the business model's actual retention
 	// question: users who created >= 2 trips at least 7 days apart in the
 	// window (the Phase 3 "retention proven across >= 2 trips" trigger).
@@ -382,29 +391,35 @@ func adminMetricsHandler(w http.ResponseWriter, r *http.Request) {
 	q := store.New(dbPool)
 
 	// One GROUP BY round trip replaces the previous per-type count queries.
+	// anonCounts is the same rows' user_id IS NULL slice (a FILTER column,
+	// not another query) — today only booking_link_clicked reads it.
 	counts := map[string]int64{}
+	anonCounts := map[string]int64{}
 	if rows, err := q.CountEventsByTypeGrouped(ctx, since); err == nil {
 		for _, row := range rows {
 			counts[row.EventType] = row.N
+			anonCounts[row.EventType] = row.NAnonymous
 		}
 	} else {
 		log.Printf("metrics: grouped counts: %v", err)
 	}
 
 	resp := MetricsResponse{
-		Days:                 days,
-		LandingViews:         counts["landing_viewed"],
-		Signups:              counts["user_registered"],
-		OnboardingsCompleted: counts["onboarding_completed"],
-		TripsCreated:         counts["trip_created"],
-		TripsRefined:         counts["trip_refined"],
-		BookingClicks:        counts["booking_link_clicked"],
-		TodosMarkedBooked:    counts["booking_marked_booked"],
-		AlertsCreated:        counts["alert_created"],
-		AlertsTriggered:      counts["alert_triggered"],
-		ClicksByProvider:     map[string]int64{},
-		FreeCapWouldHits:     map[string]int64{},
-		FreeCapUsersAffected: map[string]int64{},
+		Days:                      days,
+		LandingViews:              counts["landing_viewed"],
+		Signups:                   counts["user_registered"],
+		OnboardingsCompleted:      counts["onboarding_completed"],
+		TripsCreated:              counts["trip_created"],
+		TripsRefined:              counts["trip_refined"],
+		BookingClicks:             counts["booking_link_clicked"],
+		BookingClicksAnonymous:    anonCounts["booking_link_clicked"],
+		TodosMarkedBooked:         counts["booking_marked_booked"],
+		AlertsCreated:             counts["alert_created"],
+		AlertsTriggered:           counts["alert_triggered"],
+		ClicksByProvider:          map[string]int64{},
+		ClicksByProviderAnonymous: map[string]int64{},
+		FreeCapWouldHits:          map[string]int64{},
+		FreeCapUsersAffected:      map[string]int64{},
 	}
 	if n, err := q.CountActivatedSignups(ctx, since); err == nil {
 		resp.ActivatedSignups = n
@@ -421,6 +436,9 @@ func adminMetricsHandler(w http.ResponseWriter, r *http.Request) {
 	if rows, err := q.BookingClicksByProvider(ctx, since); err == nil {
 		for _, row := range rows {
 			resp.ClicksByProvider[row.Provider] = row.Clicks
+			if row.AnonymousClicks > 0 {
+				resp.ClicksByProviderAnonymous[row.Provider] = row.AnonymousClicks
+			}
 		}
 	}
 	if totals, err := q.PlanSessionTotals(ctx, since); err == nil {

--- a/src/packages/api/query/analytics.sql
+++ b/src/packages/api/query/analytics.sql
@@ -5,7 +5,14 @@ VALUES ($1, $2, $3, $4);
 -- name: CountEventsByTypeGrouped :many
 -- All per-type counts for the metrics window in one round trip (the dashboard
 -- previously issued one CountEventsByType query per headline number).
-SELECT event_type, count(*)::bigint AS n FROM analytics_events
+-- n_anonymous is the user_id IS NULL slice of each type — today only
+-- booking_link_clicked can be mixed (landing_viewed is all-anonymous,
+-- everything else all-authenticated), but the FILTER costs nothing and keeps
+-- the split exact (unlike summing BookingClicksByProvider, which is LIMITed).
+SELECT event_type,
+       count(*)::bigint AS n,
+       count(*) FILTER (WHERE user_id IS NULL)::bigint AS n_anonymous
+FROM analytics_events
 WHERE created_at >= $1
 GROUP BY event_type;
 
@@ -40,7 +47,12 @@ WHERE event_type = 'booking_link_clicked' AND trip_id IS NOT NULL AND created_at
 -- provider is client-supplied (sanitized at ingest since Wave 7, but older
 -- rows predate that): left(..., 64) + LIMIT 20 bound the admin dashboard's
 -- rollup against arbitrary historical values.
-SELECT COALESCE(left(metadata->>'provider', 64), 'unknown')::text AS provider, count(*) AS clicks
+-- anonymous_clicks (user_id IS NULL — unauthenticated ingest, rate-limit
+-- bounded but unaudited) rides the same GROUP BY so partner-facing reads can
+-- discount it without a second round trip.
+SELECT COALESCE(left(metadata->>'provider', 64), 'unknown')::text AS provider,
+       count(*) AS clicks,
+       count(*) FILTER (WHERE user_id IS NULL)::bigint AS anonymous_clicks
 FROM analytics_events
 WHERE event_type = 'booking_link_clicked' AND created_at >= $1
 GROUP BY 1 ORDER BY clicks DESC, provider

--- a/src/packages/api/store/analytics.sql.go
+++ b/src/packages/api/store/analytics.sql.go
@@ -13,7 +13,9 @@ import (
 )
 
 const bookingClicksByProvider = `-- name: BookingClicksByProvider :many
-SELECT COALESCE(left(metadata->>'provider', 64), 'unknown')::text AS provider, count(*) AS clicks
+SELECT COALESCE(left(metadata->>'provider', 64), 'unknown')::text AS provider,
+       count(*) AS clicks,
+       count(*) FILTER (WHERE user_id IS NULL)::bigint AS anonymous_clicks
 FROM analytics_events
 WHERE event_type = 'booking_link_clicked' AND created_at >= $1
 GROUP BY 1 ORDER BY clicks DESC, provider
@@ -21,13 +23,17 @@ LIMIT 20
 `
 
 type BookingClicksByProviderRow struct {
-	Provider string `json:"provider"`
-	Clicks   int64  `json:"clicks"`
+	Provider        string `json:"provider"`
+	Clicks          int64  `json:"clicks"`
+	AnonymousClicks int64  `json:"anonymous_clicks"`
 }
 
 // provider is client-supplied (sanitized at ingest since Wave 7, but older
 // rows predate that): left(..., 64) + LIMIT 20 bound the admin dashboard's
 // rollup against arbitrary historical values.
+// anonymous_clicks (user_id IS NULL — unauthenticated ingest, rate-limit
+// bounded but unaudited) rides the same GROUP BY so partner-facing reads can
+// discount it without a second round trip.
 func (q *Queries) BookingClicksByProvider(ctx context.Context, createdAt time.Time) ([]BookingClicksByProviderRow, error) {
 	rows, err := q.db.Query(ctx, bookingClicksByProvider, createdAt)
 	if err != nil {
@@ -37,7 +43,7 @@ func (q *Queries) BookingClicksByProvider(ctx context.Context, createdAt time.Ti
 	var items []BookingClicksByProviderRow
 	for rows.Next() {
 		var i BookingClicksByProviderRow
-		if err := rows.Scan(&i.Provider, &i.Clicks); err != nil {
+		if err := rows.Scan(&i.Provider, &i.Clicks, &i.AnonymousClicks); err != nil {
 			return nil, err
 		}
 		items = append(items, i)
@@ -84,18 +90,26 @@ func (q *Queries) CountEventsByTypeAndUserSince(ctx context.Context, arg CountEv
 }
 
 const countEventsByTypeGrouped = `-- name: CountEventsByTypeGrouped :many
-SELECT event_type, count(*)::bigint AS n FROM analytics_events
+SELECT event_type,
+       count(*)::bigint AS n,
+       count(*) FILTER (WHERE user_id IS NULL)::bigint AS n_anonymous
+FROM analytics_events
 WHERE created_at >= $1
 GROUP BY event_type
 `
 
 type CountEventsByTypeGroupedRow struct {
-	EventType string `json:"event_type"`
-	N         int64  `json:"n"`
+	EventType  string `json:"event_type"`
+	N          int64  `json:"n"`
+	NAnonymous int64  `json:"n_anonymous"`
 }
 
 // All per-type counts for the metrics window in one round trip (the dashboard
 // previously issued one CountEventsByType query per headline number).
+// n_anonymous is the user_id IS NULL slice of each type — today only
+// booking_link_clicked can be mixed (landing_viewed is all-anonymous,
+// everything else all-authenticated), but the FILTER costs nothing and keeps
+// the split exact (unlike summing BookingClicksByProvider, which is LIMITed).
 func (q *Queries) CountEventsByTypeGrouped(ctx context.Context, createdAt time.Time) ([]CountEventsByTypeGroupedRow, error) {
 	rows, err := q.db.Query(ctx, countEventsByTypeGrouped, createdAt)
 	if err != nil {
@@ -105,7 +119,7 @@ func (q *Queries) CountEventsByTypeGrouped(ctx context.Context, createdAt time.T
 	var items []CountEventsByTypeGroupedRow
 	for rows.Next() {
 		var i CountEventsByTypeGroupedRow
-		if err := rows.Scan(&i.EventType, &i.N); err != nil {
+		if err := rows.Scan(&i.EventType, &i.N, &i.NAnonymous); err != nil {
 			return nil, err
 		}
 		items = append(items, i)

--- a/src/packages/flutter-app/lib/models/admin_metrics.dart
+++ b/src/packages/flutter-app/lib/models/admin_metrics.dart
@@ -51,6 +51,12 @@ class PlacesCalls {
 @JsonSerializable()
 class AdminMetrics {
   final int days;
+
+  /// Anonymous landing_viewed count — the top of the funnel, above signups.
+  /// Directional only (unauthenticated, rate-limit bounded). Nullable: absent
+  /// on API builds older than this field, and the tile is hidden then.
+  @JsonKey(name: 'landing_views')
+  final int? landingViews;
   final int signups;
   @JsonKey(name: 'activated_signups')
   final int activatedSignups;
@@ -66,10 +72,22 @@ class AdminMetrics {
   final int tripsWithBookingClick;
   @JsonKey(name: 'attach_rate')
   final double attachRate;
+  /// Total booking-link clicks, authenticated + anonymous (unchanged field).
   @JsonKey(name: 'booking_clicks')
   final int bookingClicks;
+
+  /// The user_id-NULL slice of [bookingClicks] — signed-out clicks, rate-limit
+  /// bounded but unaudited, split out so partner-facing reads can discount
+  /// them. Nullable: absent on older API builds (caption hidden then).
+  @JsonKey(name: 'booking_clicks_anonymous')
+  final int? bookingClicksAnonymous;
   @JsonKey(name: 'clicks_by_provider')
   final Map<String, int> clicksByProvider;
+
+  /// Anonymous slice of [clicksByProvider] (parallel map; only providers with
+  /// >= 1 anonymous click appear). Nullable: absent on older API builds.
+  @JsonKey(name: 'clicks_by_provider_anonymous')
+  final Map<String, int>? clicksByProviderAnonymous;
   @JsonKey(name: 'todos_marked_booked')
   final int todosMarkedBooked;
 
@@ -140,6 +158,7 @@ class AdminMetrics {
 
   const AdminMetrics({
     this.days = 30,
+    this.landingViews,
     this.signups = 0,
     this.activatedSignups = 0,
     this.activationRate = 0,
@@ -149,7 +168,9 @@ class AdminMetrics {
     this.tripsWithBookingClick = 0,
     this.attachRate = 0,
     this.bookingClicks = 0,
+    this.bookingClicksAnonymous,
     this.clicksByProvider = const {},
+    this.clicksByProviderAnonymous,
     this.todosMarkedBooked = 0,
     this.secondTripRetention = 0,
     this.sessionFrequencyReturning = 0,

--- a/src/packages/flutter-app/lib/models/admin_metrics.g.dart
+++ b/src/packages/flutter-app/lib/models/admin_metrics.g.dart
@@ -43,6 +43,7 @@ Map<String, dynamic> _$PlacesCallsToJson(PlacesCalls instance) =>
 
 AdminMetrics _$AdminMetricsFromJson(Map<String, dynamic> json) => AdminMetrics(
       days: (json['days'] as num?)?.toInt() ?? 30,
+      landingViews: (json['landing_views'] as num?)?.toInt(),
       signups: (json['signups'] as num?)?.toInt() ?? 0,
       activatedSignups: (json['activated_signups'] as num?)?.toInt() ?? 0,
       activationRate: (json['activation_rate'] as num?)?.toDouble() ?? 0,
@@ -54,11 +55,17 @@ AdminMetrics _$AdminMetricsFromJson(Map<String, dynamic> json) => AdminMetrics(
           (json['trips_with_booking_click'] as num?)?.toInt() ?? 0,
       attachRate: (json['attach_rate'] as num?)?.toDouble() ?? 0,
       bookingClicks: (json['booking_clicks'] as num?)?.toInt() ?? 0,
+      bookingClicksAnonymous:
+          (json['booking_clicks_anonymous'] as num?)?.toInt(),
       clicksByProvider:
           (json['clicks_by_provider'] as Map<String, dynamic>?)?.map(
                 (k, e) => MapEntry(k, (e as num).toInt()),
               ) ??
               const {},
+      clicksByProviderAnonymous:
+          (json['clicks_by_provider_anonymous'] as Map<String, dynamic>?)?.map(
+        (k, e) => MapEntry(k, (e as num).toInt()),
+      ),
       todosMarkedBooked: (json['todos_marked_booked'] as num?)?.toInt() ?? 0,
       secondTripRetention:
           (json['second_trip_retention'] as num?)?.toInt() ?? 0,
@@ -105,6 +112,7 @@ AdminMetrics _$AdminMetricsFromJson(Map<String, dynamic> json) => AdminMetrics(
 Map<String, dynamic> _$AdminMetricsToJson(AdminMetrics instance) =>
     <String, dynamic>{
       'days': instance.days,
+      'landing_views': instance.landingViews,
       'signups': instance.signups,
       'activated_signups': instance.activatedSignups,
       'activation_rate': instance.activationRate,
@@ -114,7 +122,9 @@ Map<String, dynamic> _$AdminMetricsToJson(AdminMetrics instance) =>
       'trips_with_booking_click': instance.tripsWithBookingClick,
       'attach_rate': instance.attachRate,
       'booking_clicks': instance.bookingClicks,
+      'booking_clicks_anonymous': instance.bookingClicksAnonymous,
       'clicks_by_provider': instance.clicksByProvider,
+      'clicks_by_provider_anonymous': instance.clicksByProviderAnonymous,
       'todos_marked_booked': instance.todosMarkedBooked,
       'second_trip_retention': instance.secondTripRetention,
       'session_frequency_returning': instance.sessionFrequencyReturning,

--- a/src/packages/flutter-app/lib/screens/admin_metrics_screen.dart
+++ b/src/packages/flutter-app/lib/screens/admin_metrics_screen.dart
@@ -92,6 +92,11 @@ class _MetricsBody extends StatelessWidget {
         const SectionHeader(title: 'Funnel'),
         const SizedBox(height: AppSpacing.sm),
         _TileGrid(tiles: [
+          // Hidden (not zero) when the API predates landing_views — null
+          // means "old API", 0 means "no views".
+          if (m.landingViews != null)
+            _Stat('Landing views', '${m.landingViews}',
+                caption: 'directional — anonymous, rate-limit bounded'),
           _Stat('Signups', '${m.signups}'),
           _Stat('Activated', '${m.activatedSignups}',
               caption: _pct(m.activationRate)),
@@ -109,7 +114,13 @@ class _MetricsBody extends StatelessWidget {
           _Stat('Trips refined', '${m.tripsRefined}'),
           _Stat('Attach rate', _pct(m.attachRate),
               caption: '${m.tripsWithBookingClick} trips w/ click'),
-          _Stat('Booking clicks', '${m.bookingClicks}'),
+          // The anonymous share (signed-out clicks, rate-limit bounded but
+          // unaudited) rides as a caption so partner-facing reads can
+          // discount it; caption absent on APIs that predate the split.
+          _Stat('Booking clicks', '${m.bookingClicks}',
+              caption: m.bookingClicksAnonymous != null
+                  ? '${m.bookingClicksAnonymous} anonymous'
+                  : null),
           _Stat('Marked booked', '${m.todosMarkedBooked}'),
         ]),
         if (m.clicksByProvider.isNotEmpty) ...[

--- a/src/packages/flutter-app/test/admin_metrics_screen_test.dart
+++ b/src/packages/flutter-app/test/admin_metrics_screen_test.dart
@@ -15,13 +15,16 @@ void main() {
 
     const metrics = AdminMetrics(
       days: 30,
+      landingViews: 350,
       signups: 42,
       activatedSignups: 21,
       activationRate: 0.5,
       tripsCreated: 30,
       attachRate: 0.15,
       bookingClicks: 12,
+      bookingClicksAnonymous: 3,
       clicksByProvider: {'booking': 8, 'airbnb': 4},
+      clicksByProviderAnonymous: {'booking': 3},
       secondTripRetention: 7,
       activeUsers: 60,
       planSessions: 100,
@@ -57,6 +60,13 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('42'), findsOneWidget); // signups
+    expect(find.text('Landing views'), findsOneWidget);
+    expect(find.text('350'), findsOneWidget);
+    expect(find.text('directional — anonymous, rate-limit bounded'),
+        findsOneWidget);
+    // Booking-clicks tile carries the anonymous share as its caption.
+    expect(find.text('12'), findsOneWidget);
+    expect(find.text('3 anonymous'), findsOneWidget);
     expect(find.text('50.0%'), findsOneWidget); // activation rate
     expect(find.text('15.0%'), findsOneWidget); // attach rate
     expect(find.text('40 anonymous'), findsOneWidget);
@@ -100,6 +110,11 @@ void main() {
     final metrics = AdminMetrics.fromJson(const {'days': 30, 'signups': 1});
     expect(metrics.placesCallsSinceProcessStart, isNull);
     expect(metrics.eventsCallsSinceProcessStart, isNull);
+    // Same tolerance for the funnel-completion fields (Wave 10): null when
+    // absent, and the landing tile / anonymous caption are hidden below.
+    expect(metrics.landingViews, isNull);
+    expect(metrics.bookingClicksAnonymous, isNull);
+    expect(metrics.clicksByProviderAnonymous, isNull);
 
     await tester.pumpWidget(
       ProviderScope(
@@ -112,6 +127,8 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('Provider APIs (since restart)'), findsNothing);
+    expect(find.text('Landing views'), findsNothing);
+    expect(find.textContaining('anonymous, rate-limit bounded'), findsNothing);
     expect(find.text('Price alerts'), findsOneWidget);
   });
 


### PR DESCRIPTION
## Summary

Closes out the two Wave-8 funnel-dashboard loose ends:

1. **Landing views tile** — `landing_views` was added to `MetricsResponse` in #73 but the Flutter dashboard never rendered it (skipped then to avoid a codegen cycle). It now leads the Funnel section, captioned "directional — anonymous, rate-limit bounded". Nullable in the Dart model (the #79 old-API tolerance pattern): an API build that predates the field hides the tile rather than showing a misleading 0.

2. **Anonymous booking-click split** — the Wave-8 security review flagged that anonymous `booking_link_clicked` events (rate-limit bounded but unauthenticated) were conflated into `booking_clicks` / `clicks_by_provider`, which partner-facing decisions may ride on.

## SQL approach (7-query invariant holds)

Both splits are `count(*) FILTER (WHERE user_id IS NULL)` columns added to the **existing** grouped queries — zero extra round trips; the dashboard load stays at exactly 7 queries:

- `CountEventsByTypeGrouped` gains `n_anonymous` → feeds `booking_clicks_anonymous`. Read from here (not by summing provider rows) so the total is **exact** — `BookingClicksByProvider` is `LIMIT 20`, so summing it could undercount.
- `BookingClicksByProvider` gains `anonymous_clicks` → feeds `clicks_by_provider_anonymous`, a parallel map carrying only providers with ≥ 1 anonymous click. Included because it falls out of the same GROUP BY for free.

`booking_clicks` and `clicks_by_provider` remain totals (backward compatible). `store/` regenerated via `make api-sqlc`, committed clean.

## Flutter

- `admin_metrics.dart`: `landingViews`, `bookingClicksAnonymous`, `clicksByProviderAnonymous` — all nullable; `.g.dart` regenerated with `build_runner --delete-conflicting-outputs`.
- Dashboard: Landing-views tile in the Funnel section; booking-clicks tile shows the share as an "N anonymous" caption (matching the plan-sessions tile's caption style), hidden against older APIs. The per-provider anonymous map is modeled but not yet rendered (no tile asked for it; available for the provider-bars view later).

## Spec

`specs/instrumentation-events/spec.md` metric definitions amended: totals stay conflated for compatibility, the anonymous slice is separately exposed, and partner-facing numbers should be quoted as *total minus anonymous* (anonymous rows are spoofable at per-IP-limiter cost).

## Tests

- `go vet` / `go test ./...` clean; integration suite green on a dedicated DB (`travel_test_w10`): seeds one authed + one anonymous click on the same provider and asserts `booking_clicks=2`, `booking_clicks_anonymous=1`, `landing_views=1`, `clicks_by_provider={duffel:2}`, `clicks_by_provider_anonymous={duffel:1}`. No existing query-count assertion mechanism was found, so the 7-query invariant is documented (spec + comments), not machine-checked.
- `flutter test`: 96/96 pass, including new tile assertions and old-API-null tolerance; `flutter analyze --no-fatal-infos --fatal-warnings` exit 0 with only the 12 known pre-existing infos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)