### PR TITLE
fix(ci): pin Go toolchain 1.26.5 — GO-2026-5856 fails govulncheck on 1.26.4

### DIFF
--- a/src/packages/api/go.mod
+++ b/src/packages/api/go.mod
@@ -2,6 +2,8 @@ module travel-route-planner
 
 go 1.26
 
+toolchain go1.26.5
+
 require (
 	github.com/anthropics/anthropic-sdk-go v1.45.0
 	github.com/chromedp/cdproto v0.0.0-20260321001828-e3e3800016bc


### PR DESCRIPTION
Time-based CI breakage: the GO-2026-5856 crypto/tls advisory (published 2026-07-09, fixed in go1.26.5) makes govulncheck fail every run on go1.26.4 — this is what broke main's run on #89 and the Go job on #90/#91/#92's PR runs; no wave code is at fault. `toolchain go1.26.5` in go.mod forces the fixed patch in CI (setup-go reads go.mod) and local builds. govulncheck verified clean locally on 1.26.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)