### PR TITLE
feat(flutter): queue chat messages sent while a turn is streaming

### DIFF
--- a/src/packages/flutter-app/lib/providers/plan_provider.dart
+++ b/src/packages/flutter-app/lib/providers/plan_provider.dart
@@ -12,6 +12,17 @@ import '../services/api_client.dart';
 import '../services/plan_service.dart';
 import 'api_client_provider.dart';
 
+/// A user message waiting to be sent once the in-flight turn finishes.
+/// [id] is a notifier-local monotonic id — stable identity for remove buttons
+/// and widget keys while the queue head is popped by the drain.
+class QueuedMessage {
+  final int id;
+  final String text;
+  final String? displayLabel;
+
+  const QueuedMessage({required this.id, required this.text, this.displayLabel});
+}
+
 class PlanState {
   final List<PlanMessage> messages;
   final bool isStreaming;
@@ -31,6 +42,10 @@ class PlanState {
   final List<LocalRecommendation>? localRecs;
   final String? localRecsCity;
   final String? error;
+
+  /// Messages the user sent while a turn was streaming, waiting FIFO to be
+  /// sent. Always replaced whole, never mutated in place.
+  final List<QueuedMessage> queuedMessages;
 
   /// Short excerpt of profile notes the agent just saved (server
   /// `profile_updated` event); shown as a transient "Noted" chip in the chat.
@@ -64,6 +79,7 @@ class PlanState {
     this.localRecs,
     this.localRecsCity,
     this.error,
+    this.queuedMessages = const [],
     this.profileUpdateNote,
     this.tripUpdateCount = 0,
     this.tripUpdatedThisTurn = false,
@@ -88,6 +104,7 @@ class PlanState {
     Object? localRecs = _sentinel,
     Object? localRecsCity = _sentinel,
     Object? error = _sentinel,
+    List<QueuedMessage>? queuedMessages,
     Object? profileUpdateNote = _sentinel,
     int? tripUpdateCount,
     bool? tripUpdatedThisTurn,
@@ -113,6 +130,7 @@ class PlanState {
       localRecs: localRecs == _sentinel ? this.localRecs : localRecs as List<LocalRecommendation>?,
       localRecsCity: localRecsCity == _sentinel ? this.localRecsCity : localRecsCity as String?,
       error: error == _sentinel ? this.error : error as String?,
+      queuedMessages: queuedMessages ?? this.queuedMessages,
       profileUpdateNote:
           profileUpdateNote == _sentinel ? this.profileUpdateNote : profileUpdateNote as String?,
       tripUpdateCount: tripUpdateCount ?? this.tripUpdateCount,
@@ -135,6 +153,9 @@ class PlanNotifier extends StateNotifier<PlanState> {
   // is stamped with it server-side so refinements collapse to one trip in My
   // Trips instead of spawning duplicate drafts. Regenerated on reset().
   String? _chatId;
+
+  // Identity source for QueuedMessage.id.
+  int _nextQueuedId = 0;
 
   PlanNotifier(this._service, this._apiClient, {this.tripId}) : super(const PlanState());
 
@@ -197,9 +218,44 @@ class PlanNotifier extends StateNotifier<PlanState> {
     }).toList();
   }
 
-  Future<void> sendMessage(String text, {String? displayLabel}) async {
-    if (state.isStreaming) return;
+  /// Sends [text], or queues it if a turn is already streaming (or a backlog
+  /// exists post-error). Queued messages drain FIFO as each turn completes
+  /// successfully; the returned future completes once the whole chain settles.
+  Future<void> sendMessage(String text, {String? displayLabel}) {
+    if (state.isStreaming || state.queuedMessages.isNotEmpty) {
+      state = state.copyWith(queuedMessages: [
+        ...state.queuedMessages,
+        QueuedMessage(id: _nextQueuedId++, text: text, displayLabel: displayLabel),
+      ]);
+      // Idle with a backlog (post-error state): an explicit send is fresh user
+      // intent — start draining now. FIFO holds because the new message went
+      // to the back and the drain pops the head.
+      if (!state.isStreaming) return _drainQueue();
+      return Future.value();
+    }
+    return _sendNow(text, displayLabel: displayLabel);
+  }
 
+  /// Removes a not-yet-sent queued message by its [QueuedMessage.id].
+  void removeQueued(int id) {
+    state = state.copyWith(
+      queuedMessages: state.queuedMessages.where((m) => m.id != id).toList(),
+    );
+  }
+
+  /// Pops the queue head and sends it. Dequeues BEFORE sending and bypasses
+  /// the [sendMessage] gatekeeper — otherwise the still-queued head would be
+  /// re-enqueued at the back. Chained by each turn's success tail; errors stop
+  /// the chain with the remainder still queued.
+  Future<void> _drainQueue() async {
+    if (!mounted) return;
+    if (state.isStreaming || state.queuedMessages.isEmpty) return;
+    final next = state.queuedMessages.first;
+    state = state.copyWith(queuedMessages: state.queuedMessages.sublist(1));
+    await _sendNow(next.text, displayLabel: next.displayLabel);
+  }
+
+  Future<void> _sendNow(String text, {String? displayLabel}) async {
     _chatId ??= _newChatId();
 
     final userMessage = PlanMessage(
@@ -371,6 +427,10 @@ class PlanNotifier extends StateNotifier<PlanState> {
         streamingText: null,
         activeTools: [],
       );
+
+      // Success is the only drain point: after an error the queue stays put
+      // (visible next to the error banner) until the user retries or resends.
+      await _drainQueue();
     } catch (e) {
       _endStreamBuffer();
       if (!mounted) return;
@@ -403,7 +463,10 @@ class PlanNotifier extends StateNotifier<PlanState> {
       messages: messages.sublist(0, lastUser),
       error: null,
     );
-    await sendMessage(failed.content, displayLabel: failed.displayLabel);
+    // _sendNow, not sendMessage: with a post-error backlog the gatekeeper
+    // would enqueue the retried turn at the BACK. The retried turn must run
+    // first; on success its tail drains the queue.
+    await _sendNow(failed.content, displayLabel: failed.displayLabel);
   }
 
   void reset() {

--- a/src/packages/flutter-app/lib/widgets/chat_panel.dart
+++ b/src/packages/flutter-app/lib/widgets/chat_panel.dart
@@ -107,12 +107,14 @@ class _ChatPanelState extends ConsumerState<ChatPanel> {
   Widget build(BuildContext context) {
     final messages = ref.watch(widget.state.select((s) => s.messages));
     final isStreaming = ref.watch(widget.state.select((s) => s.isStreaming));
-    final isEmpty = ref.watch(widget.state
-        .select((s) => s.messages.isEmpty && s.streamingText == null));
+    final isEmpty = ref.watch(widget.state.select((s) =>
+        s.messages.isEmpty && s.streamingText == null && s.queuedMessages.isEmpty));
 
     ref.listen(widget.state.select((s) => s.streamingText),
         (_, __) => _scrollToBottom());
     ref.listen(widget.state.select((s) => s.messages.length),
+        (_, __) => _scrollToBottom());
+    ref.listen(widget.state.select((s) => s.queuedMessages.length),
         (_, __) => _scrollToBottom());
 
     return Column(
@@ -157,7 +159,7 @@ class _ChatPanelState extends ConsumerState<ChatPanel> {
         ),
         _InputBar(
           controller: _controller,
-          enabled: !isStreaming,
+          isStreaming: isStreaming,
           hint: widget.inputHint,
           onSend: _send,
         ),
@@ -196,6 +198,9 @@ class _ChatTail extends StatelessWidget {
         if (footerBuilder != null)
           _ChatFooter(state: state, footerBuilder: footerBuilder!),
         _ErrorBanner(state: state, notifier: notifier),
+        // Last: queued messages read as "up next", below the current turn and
+        // any error it produced.
+        _QueuedMessages(state: state, notifier: notifier),
       ],
     );
   }
@@ -505,6 +510,99 @@ class _ErrorBanner extends ConsumerWidget {
   }
 }
 
+/// User messages queued while a turn streams, rendered below the tail as
+/// dimmed "up next" bubbles with a remove affordance. Kept out of the
+/// committed-messages ListView so its append-only index keys stay valid.
+class _QueuedMessages extends ConsumerWidget {
+  final ProviderListenable<PlanState> state;
+  final ProviderListenable<PlanNotifier> notifier;
+
+  const _QueuedMessages({required this.state, required this.notifier});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    // Identity select works because the notifier replaces the list whole.
+    final queued = ref.watch(state.select((s) => s.queuedMessages));
+    if (queued.isEmpty) return const SizedBox.shrink();
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        for (final m in queued)
+          _QueuedBubble(
+            key: ValueKey('queued-${m.id}'),
+            message: m,
+            onRemove: () => ref.read(notifier).removeQueued(m.id),
+          ),
+      ],
+    );
+  }
+}
+
+class _QueuedBubble extends StatelessWidget {
+  final QueuedMessage message;
+  final VoidCallback onRemove;
+
+  const _QueuedBubble({super.key, required this.message, required this.onRemove});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Align(
+      alignment: Alignment.centerRight,
+      child: Container(
+        margin: const EdgeInsets.symmetric(vertical: 4),
+        padding: const EdgeInsets.fromLTRB(14, 6, 6, 6),
+        constraints: BoxConstraints(
+          maxWidth: MediaQuery.of(context).size.width * 0.78,
+        ),
+        decoration: BoxDecoration(
+          color: theme.colorScheme.primary.withValues(alpha: 0.45),
+          borderRadius: const BorderRadius.only(
+            topLeft: Radius.circular(16),
+            topRight: Radius.circular(16),
+            bottomLeft: Radius.circular(16),
+            bottomRight: Radius.circular(4),
+          ),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Flexible(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.end,
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(
+                    message.displayLabel ?? message.text,
+                    style: TextStyle(color: theme.colorScheme.onPrimary),
+                  ),
+                  Text(
+                    'Queued',
+                    style: theme.textTheme.labelSmall?.copyWith(
+                      color: theme.colorScheme.onPrimary.withValues(alpha: 0.8),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(width: 4),
+            IconButton(
+              visualDensity: VisualDensity.compact,
+              tooltip: 'Remove queued message',
+              onPressed: onRemove,
+              icon: Icon(
+                Icons.close,
+                size: 16,
+                color: theme.colorScheme.onPrimary,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
 class ChatMessageBubble extends StatelessWidget {
   final PlanMessage message;
   final bool isStreaming;
@@ -617,13 +715,13 @@ class _StreamingCursorState extends State<_StreamingCursor>
 
 class _InputBar extends StatelessWidget {
   final TextEditingController controller;
-  final bool enabled;
+  final bool isStreaming;
   final String hint;
   final VoidCallback onSend;
 
   const _InputBar({
     required this.controller,
-    required this.enabled,
+    required this.isStreaming,
     required this.hint,
     required this.onSend,
   });
@@ -648,12 +746,11 @@ class _InputBar extends StatelessWidget {
           Expanded(
             child: TextField(
               controller: controller,
-              enabled: enabled,
               maxLines: null,
               textInputAction: TextInputAction.send,
-              onSubmitted: enabled ? (_) => onSend() : null,
+              onSubmitted: (_) => onSend(),
               decoration: InputDecoration(
-                hintText: enabled ? hint : 'Thinking...',
+                hintText: isStreaming ? 'Ask a follow-up…' : hint,
                 border: OutlineInputBorder(
                   borderRadius: BorderRadius.circular(24),
                   borderSide: BorderSide.none,
@@ -666,7 +763,7 @@ class _InputBar extends StatelessWidget {
           ),
           const SizedBox(width: 8),
           IconButton.filled(
-            onPressed: enabled ? onSend : null,
+            onPressed: onSend,
             icon: const Icon(Icons.send),
           ),
         ],

--- a/src/packages/flutter-app/test/chat_panel_queue_test.dart
+++ b/src/packages/flutter-app/test/chat_panel_queue_test.dart
@@ -1,0 +1,118 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:travel_route_planner/providers/plan_provider.dart';
+import 'package:travel_route_planner/services/api_client.dart';
+import 'package:travel_route_planner/services/plan_service.dart';
+import 'package:travel_route_planner/widgets/chat_panel.dart';
+
+/// Yields one text_delta per call ('reply N'), parking on [gate] after the
+/// delta when set so tests can interact mid-stream. No network.
+class _GatedPlanService extends PlanService {
+  int calls = 0;
+
+  /// Consumed by the next call: the stream parks on it after its first delta.
+  Completer<void>? gate;
+
+  _GatedPlanService() : super('http://unused');
+
+  @override
+  Stream<PlanEvent> streamPlan(
+    List<Map<String, String>> messages, {
+    String? bearerToken,
+    String? chatId,
+    String? tripId,
+  }) async* {
+    final call = calls++;
+    yield PlanEvent(type: 'text_delta', data: {'text': 'reply $call'});
+    final parked = gate;
+    gate = null;
+    if (parked != null) await parked.future;
+  }
+}
+
+Future<StateNotifierProvider<PlanNotifier, PlanState>> _pumpPanel(
+    WidgetTester tester, _GatedPlanService service) async {
+  final notifier = PlanNotifier(service, ApiClient());
+  final provider =
+      StateNotifierProvider<PlanNotifier, PlanState>((ref) => notifier);
+  await tester.pumpWidget(
+    ProviderScope(
+      child: MaterialApp(
+        home: Scaffold(
+          body: ChatPanel(state: provider, notifier: provider.notifier),
+        ),
+      ),
+    ),
+  );
+  return provider;
+}
+
+void main() {
+  testWidgets('input stays enabled mid-stream; sends queue and are removable',
+      (WidgetTester tester) async {
+    final service = _GatedPlanService();
+    final gate = Completer<void>();
+    service.gate = gate;
+    await _pumpPanel(tester, service);
+
+    await tester.enterText(find.byType(TextField), 'plan athens');
+    await tester.tap(find.byIcon(Icons.send));
+    // Start the stream and let the 48ms token flush land.
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 60));
+
+    // Mid-stream the input is still usable, with the follow-up hint.
+    final field = tester.widget<TextField>(find.byType(TextField));
+    expect(field.enabled, isNot(false));
+    expect(field.decoration?.hintText, 'Ask a follow-up…');
+
+    await tester.enterText(find.byType(TextField), 'also add delphi');
+    await tester.tap(find.byIcon(Icons.send));
+    await tester.pump();
+
+    expect(find.text('also add delphi'), findsOneWidget);
+    expect(find.text('Queued'), findsOneWidget);
+
+    // The queued bubble's close affordance removes it before it sends.
+    await tester.tap(find.byIcon(Icons.close));
+    await tester.pump();
+    expect(find.text('Queued'), findsNothing);
+    expect(find.text('also add delphi'), findsNothing);
+
+    gate.complete();
+    await tester.pumpAndSettle();
+    expect(find.text('reply 0'), findsOneWidget);
+    expect(service.calls, 1);
+  });
+
+  testWidgets('a queued message auto-sends when the turn completes',
+      (WidgetTester tester) async {
+    final service = _GatedPlanService();
+    final gate = Completer<void>();
+    service.gate = gate;
+    await _pumpPanel(tester, service);
+
+    await tester.enterText(find.byType(TextField), 'plan athens');
+    await tester.tap(find.byIcon(Icons.send));
+    await tester.pump();
+
+    await tester.enterText(find.byType(TextField), 'also add delphi');
+    await tester.tap(find.byIcon(Icons.send));
+    await tester.pump();
+    expect(find.text('Queued'), findsOneWidget);
+
+    gate.complete();
+    await tester.pumpAndSettle();
+
+    // The queued bubble became a committed user turn with its own reply.
+    expect(find.text('Queued'), findsNothing);
+    expect(find.text('also add delphi'), findsOneWidget);
+    expect(find.text('reply 0'), findsOneWidget);
+    expect(find.text('reply 1'), findsOneWidget);
+    expect(service.calls, 2);
+  });
+}

--- a/src/packages/flutter-app/test/plan_provider_queue_test.dart
+++ b/src/packages/flutter-app/test/plan_provider_queue_test.dart
@@ -1,0 +1,206 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:travel_route_planner/models/plan_message.dart';
+import 'package:travel_route_planner/providers/plan_provider.dart';
+import 'package:travel_route_planner/services/api_client.dart';
+import 'package:travel_route_planner/services/plan_service.dart';
+
+/// Yields one text_delta per call ('reply N'), optionally parking on [gate]
+/// after the delta so tests can enqueue mid-stream, and optionally ending the
+/// turn with an SSE error. Records the history payload of every call.
+class _GatedPlanService extends PlanService {
+  final List<List<Map<String, String>>> histories = [];
+
+  /// Consumed by the next call: the stream parks on it after its first delta.
+  Completer<void>? gate;
+
+  /// Consumed by the next call: end the turn with an error event.
+  bool failNext = false;
+
+  _GatedPlanService() : super('http://unused');
+
+  @override
+  Stream<PlanEvent> streamPlan(
+    List<Map<String, String>> messages, {
+    String? bearerToken,
+    String? chatId,
+    String? tripId,
+  }) async* {
+    final call = histories.length;
+    histories.add(List.of(messages));
+    yield PlanEvent(type: 'text_delta', data: {'text': 'reply $call'});
+    final parked = gate;
+    gate = null;
+    if (parked != null) await parked.future;
+    if (failNext) {
+      failNext = false;
+      yield const PlanEvent(type: 'error', data: {'message': 'boom'});
+    }
+  }
+}
+
+/// Starts a gated turn for 'a' and queues 'b' behind it, then fails the turn:
+/// the shared setup for the error-path tests.
+Future<void> _failedTurnWithBacklog(
+    _GatedPlanService service, PlanNotifier notifier) async {
+  final gate = Completer<void>();
+  service.gate = gate;
+  service.failNext = true;
+  final first = notifier.sendMessage('a');
+  await notifier.sendMessage('b');
+  gate.complete();
+  await first;
+}
+
+void main() {
+  test('messages sent mid-stream queue up and drain FIFO on completion',
+      () async {
+    final service = _GatedPlanService();
+    final notifier = PlanNotifier(service, ApiClient());
+
+    final gate = Completer<void>();
+    service.gate = gate;
+    final first = notifier.sendMessage('a');
+    expect(notifier.state.isStreaming, isTrue);
+
+    await notifier.sendMessage('b');
+    await notifier.sendMessage('c');
+    expect(
+        notifier.state.queuedMessages.map((m) => m.text).toList(), ['b', 'c']);
+    // Mid-stream sends are queued, not committed to the transcript.
+    expect(notifier.state.messages.map((m) => m.content).toList(), ['a']);
+
+    gate.complete();
+    await first;
+
+    expect(notifier.state.queuedMessages, isEmpty);
+    expect(notifier.state.isStreaming, isFalse);
+    expect(notifier.state.messages.map((m) => m.role).toList(), [
+      MessageRole.user,
+      MessageRole.assistant,
+      MessageRole.user,
+      MessageRole.assistant,
+      MessageRole.user,
+      MessageRole.assistant,
+    ]);
+    expect(
+      notifier.state.messages
+          .where((m) => m.role == MessageRole.user)
+          .map((m) => m.content)
+          .toList(),
+      ['a', 'b', 'c'],
+    );
+    // Each drained turn carried the full transcript so far.
+    expect(service.histories.length, 3);
+    expect(service.histories[1].map((m) => m['content']).toList(),
+        ['a', 'reply 0', 'b']);
+    expect(service.histories[2].map((m) => m['content']).toList(),
+        ['a', 'reply 0', 'b', 'reply 1', 'c']);
+  });
+
+  test('removeQueued drops a pending message before it sends', () async {
+    final service = _GatedPlanService();
+    final notifier = PlanNotifier(service, ApiClient());
+
+    final gate = Completer<void>();
+    service.gate = gate;
+    final first = notifier.sendMessage('a');
+    await notifier.sendMessage('b');
+    await notifier.sendMessage('c');
+
+    notifier.removeQueued(notifier.state.queuedMessages.first.id);
+    expect(notifier.state.queuedMessages.map((m) => m.text).toList(), ['c']);
+
+    gate.complete();
+    await first;
+
+    expect(
+      notifier.state.messages
+          .where((m) => m.role == MessageRole.user)
+          .map((m) => m.content)
+          .toList(),
+      ['a', 'c'],
+    );
+    expect(service.histories.length, 2);
+  });
+
+  test('an error keeps the queue; retry runs the failed turn first, then drains',
+      () async {
+    final service = _GatedPlanService();
+    final notifier = PlanNotifier(service, ApiClient());
+    await _failedTurnWithBacklog(service, notifier);
+
+    expect(notifier.state.error, 'boom');
+    expect(notifier.state.isStreaming, isFalse);
+    expect(notifier.state.queuedMessages.map((m) => m.text).toList(), ['b']);
+    // No drain on error.
+    expect(service.histories.length, 1);
+
+    await notifier.retryLastSend();
+
+    expect(notifier.state.error, isNull);
+    expect(notifier.state.queuedMessages, isEmpty);
+    expect(
+      notifier.state.messages
+          .where((m) => m.role == MessageRole.user)
+          .map((m) => m.content)
+          .toList(),
+      ['a', 'b'],
+    );
+    // The retried turn ran before the queued one, with no duplicate user turn.
+    expect(service.histories.length, 3);
+    expect(
+        service.histories[1].where((m) => m['role'] == 'user').length, 1);
+    expect(service.histories[1].first['content'], 'a');
+  });
+
+  test('sending while idle with a backlog goes to the back, head sends first',
+      () async {
+    final service = _GatedPlanService();
+    final notifier = PlanNotifier(service, ApiClient());
+    await _failedTurnWithBacklog(service, notifier);
+
+    // Idle, error shown, 'b' still queued. A fresh send must not jump it.
+    await notifier.sendMessage('c');
+
+    expect(notifier.state.error, isNull);
+    expect(notifier.state.queuedMessages, isEmpty);
+    expect(
+      notifier.state.messages
+          .where((m) => m.role == MessageRole.user)
+          .map((m) => m.content)
+          .toList(),
+      ['a', 'b', 'c'],
+    );
+  });
+
+  test('reset clears the queue', () async {
+    final service = _GatedPlanService();
+    final notifier = PlanNotifier(service, ApiClient());
+    await _failedTurnWithBacklog(service, notifier);
+    expect(notifier.state.queuedMessages, isNotEmpty);
+
+    notifier.reset();
+
+    expect(notifier.state.queuedMessages, isEmpty);
+    expect(notifier.state.messages, isEmpty);
+  });
+
+  test('dispose mid-stream with queued messages neither throws nor drains',
+      () async {
+    final service = _GatedPlanService();
+    final notifier = PlanNotifier(service, ApiClient());
+
+    final gate = Completer<void>();
+    service.gate = gate;
+    final first = notifier.sendMessage('a');
+    await notifier.sendMessage('b');
+
+    notifier.dispose();
+    gate.complete();
+    await first;
+
+    expect(service.histories.length, 1);
+  });
+}


### PR DESCRIPTION
## Summary
- Chat input stays enabled while a response streams (hint becomes "Ask a follow-up…"); messages sent mid-stream are queued FIFO instead of silently dropped by the `isStreaming` guard.
- Queued messages render below the streaming reply as dimmed "Queued" bubbles with a ✕ remove affordance (`_QueuedMessages`/`_QueuedBubble` in the chat tail — the committed-messages list keeps its append-only index keys).
- Queue drains one turn at a time on success only; on error it stays parked next to the retry banner. `retryLastSend` bypasses the enqueue gatekeeper so the retried turn runs before the backlog; a fresh send while idle with a backlog goes to the back (no queue-jumping).
- `QueuedMessage` carries a notifier-local monotonic id so remove-while-draining can't hit the wrong item; all queue updates are whole-list replacements per the panel's select-identity invariant.
- Applies to both the Agent tab and trip-refine panels via the shared `ChatPanel`.

## Testing
- `flutter analyze` — no new issues (12 pre-existing infos in unrelated files).
- `flutter test` — 110/110 pass, including 8 new tests: `plan_provider_queue_test.dart` (FIFO drain with server-history assertions, removeQueued, error-keeps-queue + retry ordering, idle-with-backlog ordering, reset, dispose mid-stream) and `chat_panel_queue_test.dart` (enabled input + queued bubble + remove; queued message auto-sends and commits after the turn).

🤖 Generated with [Claude Code](https://claude.com/claude-code)