### PR TITLE
feat(flutter): today-mode spec, trip-day helpers, TripMap fit/empty params

### DIFF
--- a/specs/today-mode/plan.md
+++ b/specs/today-mode/plan.md
@@ -1,0 +1,112 @@
+# Plan: Today Mode & Map Day-Filtering
+
+> **HOW.** See `spec.md`. Flutter-only; no Go, endpoint, model-codegen, or env
+> changes (API Surface: none). Ships in three PRs: (1) shared day-math helpers
+> + `TripMap` re-fit/empty-label parameters, (2) map day-filter chips on the
+> trip detail and shared screens, (3) Today auto-scroll + highlight.
+
+## Technical Approach
+
+All behavior derives client-side from fields the app already has
+(`Trip.startDate`/`endDate`, `ItineraryItem.day`, `Accommodation.checkIn`/
+`checkOut`). The design decisions, and why:
+
+1. **Offset-reveal scroll, not `Scrollable.ensureVisible`.** The itinerary is
+   a `CustomScrollView` with `sliver_tools` pinned headers; `ensureVisible`
+   relies on `showOnScreen`, which is unreliable under `SliverPinnedHeader` /
+   `MultiSliver` (targets land hidden beneath pinned chrome or the request is
+   swallowed). Instead: resolve the target's `RenderBox` offset relative to
+   the scroll view, jump/animate to that offset **minus the pinned-chrome
+   height** (city header + day header compensation), then run **one
+   correction pass** post-frame — expanding a collapsed section changes
+   layout, so the first scroll is an estimate and the second pass fixes
+   residual error. One pass only; no loops chasing layout.
+2. **`GlobalKey`s keyed `'$cityKey#$day'`.** The day-header key namespace
+   already exists as the collapse key (`_collapsedDays` uses `'$cityKey#$day'`
+   in `trip_detail_screen.dart` `_buildGroupItemSlivers`); reusing it for a
+   `Map<String, GlobalKey>` gives a stable identity per rendered day header
+   without inventing a parallel scheme. Keys are created lazily per build and
+   looked up by the scroller.
+3. **One-shot trigger, device-local time.** "Today" =
+   `tripDayOn(trip.startDate, trip.endDate, DateTime.now())` (local calendar
+   date, truncated). The scroll fires once per screen visit from the first
+   *non-silent* load; the silent `_refresh()` path (see chat-panel invariants)
+   never re-triggers it, and it is suppressed while `_panelOpen` (refine
+   panel) — a mid-conversation viewport jump would fight the user.
+4. **Day filtering happens upstream of `TripMap`.** The map widget stays
+   day-agnostic: the screens filter `items`/`accommodations`/`segmentLabels`
+   before passing them in. Within a single day the itinerary positions are
+   contiguous, so the polyline and walking-time labels stay ON — the existing
+   `position + 1` adjacency guard in `TripMap` already suppresses labels and
+   route continuity across gaps, so no new segment logic is needed.
+5. **`fitSignature` over remount-by-key.** Re-keying `TripMap` per chip would
+   re-fit for free but remounts `FlutterMap` and flashes tiles. Instead
+   `TripMap` gains a defaulted `Object? fitSignature`; when it changes,
+   `didUpdateWidget` re-fits post-frame via the existing `_fitToTrip`. A
+   defaulted `String emptyLabel` lets the screens phrase the empty state per
+   day ("No mapped places on Day 3") while the chips stay outside the map and
+   thus never disappear.
+6. **Checkout-exclusive stay coverage.** `stayCoversDate(checkIn, checkOut,
+   date)` implements `checkIn <= d < checkOut` — the night you *sleep* there,
+   so a stay never shows on its checkout day and back-to-back stays never
+   double-book a night.
+
+## Go API Changes
+
+None.
+
+## Flutter Changes
+
+`src/packages/flutter-app/`:
+
+- **PR 1 — helpers + map params (this PR):**
+  - `lib/utils/trip_days.dart` (new) — pure, string-based, no model imports
+    (same style as `lib/utils/trip_format.dart`):
+    - `int? tripDayOn(String? startDate, String? endDate, DateTime now)` —
+      truncate `now` to the local date; date-only strings parse as local
+      midnight; day = `diff.inDays + 1`; null when the start is unparseable or
+      the date falls outside `[1, span]`. Same formula as the former
+      `_eventDayFor` in `add_to_trip_sheet.dart`.
+    - `int dayCount(String? startDate, String? endDate, Iterable<int?>
+      itemDays)` — max of the highest tagged day and the date span (lifted
+      from `add_to_trip_sheet.dart` `_dayCount`).
+    - `bool stayCoversDate(String? checkIn, String? checkOut, DateTime date)`
+      — checkout-exclusive; false when either date is missing/unparseable.
+  - `lib/widgets/add_to_trip_sheet.dart` — `_eventDayFor`/`_dayCount` delegate
+    to the helpers (behavior-neutral; its tests pass unchanged).
+  - `lib/widgets/trip_map.dart` — defaulted `Object? fitSignature` (re-fit
+    post-frame in `didUpdateWidget` via `_fitToTrip`) and `String emptyLabel =
+    'No mapped places'` (existing empty state). Existing call sites compile
+    unchanged.
+  - Tests: `test/trip_days_test.dart` (new), `test/trip_map_test.dart`
+    (extended).
+- **PR 2 — map chips:** chip row widget + upstream filtering and
+  `fitSignature`/`emptyLabel` wiring in `trip_detail_screen.dart` and
+  `shared_trip_screen.dart`; today-chip preselection on live owned trips; All
+  default on shared views; row hidden when `dayCount == 0`.
+- **PR 3 — Today auto-scroll:** GlobalKey registry + offset-reveal scroller +
+  today highlight in `trip_detail_screen.dart`; fallback-day selection
+  (nearest prior with items → nearest following → no-op); one-shot /
+  refine-panel / silent-refresh guards.
+
+## Contract Parity
+
+| JSON key | Go type | Dart type | Nullable? | ✓ |
+|----------|---------|-----------|-----------|---|
+| _(none — no contract changes)_ | | | | ✓ |
+
+## Cross-cutting
+
+None (no env vars, routes, or gateway changes). Offline works by construction:
+everything is computed from the cached trip.
+
+## Verification
+
+- `make flutter-analyze`, `make flutter-test` — including
+  `add_to_trip_sheet_test.dart` **unchanged** (refactor is behavior-neutral).
+- `test/trip_days_test.dart`: in/before/after range, day-1 and last-day
+  boundaries, garbage dates, checkout-exclusive boundary, span-vs-tagged
+  day count.
+- Manual via `make docker-dev` → `http://localhost:3000`: walk the acceptance
+  criteria in `spec.md` on a live-dated, past-dated, and undated trip, plus a
+  shared link and offline view-only.

--- a/specs/today-mode/spec.md
+++ b/specs/today-mode/spec.md
@@ -1,0 +1,129 @@
+# Spec: Today Mode & Map Day-Filtering
+
+## Context
+
+A trip that is happening *right now* renders exactly like one planned for next
+year: the itinerary opens at Day 1 and the map always shows every pin from the
+whole trip. Mid-trip, the user's actual question is "what am I doing today, and
+where?" — answering it takes manual scrolling through past days and squinting
+at a map cluttered with places from other days. The outcome: opening a live
+trip lands you on today's plan automatically, and a chip row on the map lets
+you look at any single day — its places, its walking route, and where you're
+sleeping that night — with the camera framed to just that day.
+
+## User Stories
+
+- As a **traveler on an active trip**, I want the itinerary to open scrolled to
+  today's plan so that I don't wade through the days already behind me.
+- As a **traveler on an active trip**, I want the map to open showing just
+  today's places and route so that the map answers "where am I going today?"
+- As a **trip owner**, I want to flip the map between All and any single day so
+  that I can sanity-check one day's geography at a time.
+- As a **recipient of a shared trip link**, I want the familiar whole-trip view
+  with the option to filter by day so that someone else's "today" is never
+  forced on me.
+
+## Acceptance Criteria
+
+### Today auto-scroll (trip detail)
+
+- [ ] Opening a trip whose date range includes today (by the device's local
+      date) scrolls the itinerary once, automatically, to today's day section,
+      which is visibly highlighted as "today".
+- [ ] The auto-scroll happens at most once per screen visit: silent background
+      refreshes never re-trigger it, and it never fires while the refine panel
+      is open.
+- [ ] If the target day's section (or its city group) is collapsed, it expands
+      first, then the scroll lands on it.
+- [ ] If today has no itinerary items, the scroll targets the nearest prior
+      day that has items; if no prior day has items, the nearest following day
+      with items; if the trip has no day-tagged items at all, no scroll occurs.
+- [ ] Trips without dates, and trips whose range is entirely in the past or
+      future, open exactly as they do now (top of list, no highlight, no
+      scroll).
+
+### Map day-filter chips
+
+- [ ] The trip map gains a chip row — `All · Day 1 · Day 2 · … · Day N` —
+      where N is the trip's day count (the later of the date span and the
+      highest day-tagged item).
+- [ ] Selecting a day chip filters the map to that day: only that day's pins,
+      the route line between them, their walking-time labels, and the stay(s)
+      covering that night are shown. A stay covers a night checkout-exclusively:
+      it shows on day *d* when `checkIn <= d < checkOut`.
+- [ ] Changing chips re-frames the camera (auto-fit) to the newly visible
+      pins/stays without the map remounting or flashing tiles.
+- [ ] Selecting a day with nothing mappable shows an on-map message for that
+      day; the chip row remains visible and usable (the chips never disappear
+      because of an empty selection).
+- [ ] Items without a day tag appear only under **All**, never under a day chip.
+- [ ] When the trip's day count is 0 (no dates and no day-tagged items), the
+      chip row is hidden entirely and the map behaves as today.
+- [ ] On a live trip (today inside the date range), the map preselects today's
+      day chip; otherwise **All** is preselected.
+
+### Shared views, offline, and API
+
+- [ ] Shared read-only trip views get the same chip row defaulting to **All**,
+      and none of the Today behaviors (no auto-scroll, no highlight, no today
+      preselection).
+- [ ] Everything above works offline in view-only mode (chips filter cached
+      data; no network required).
+- [ ] No API changes: all behavior is derived client-side from data the app
+      already receives.
+
+## API Surface
+
+None. No new endpoints, no request/response changes. Day membership, "today",
+and stay coverage are all computed on the client from existing trip fields
+(`start_date`, `end_date`, item `day`, stay `check_in`/`check_out`).
+
+## Data Model
+
+No persisted entities change. Client-side derived concepts only:
+
+- **Today's trip day** — the 1-based day number the device's local date falls
+  on within the trip's date range; undefined (absent) when the trip is undated,
+  the dates don't parse, or today is outside the range.
+- **Day count** — how many day chips to offer: the later of the trip's date
+  span and the highest day tag on any item.
+- **Stay-night coverage** — whether an accommodation covers the night of a
+  given date: check-in date ≤ date < check-out date (checkout day excluded).
+
+## UI Behavior
+
+- **Surface:** trip detail screen (itinerary list + map) and the shared
+  read-only trip screen (map only — no Today behaviors).
+- **Happy path (live trip):** owner opens the trip mid-trip → list scrolls to
+  today's highlighted section → map shows today's chip selected, today's pins,
+  route, and tonight's stay → owner taps `Day 5` to preview → camera re-fits
+  to Day 5 → taps `All` to see the whole trip again.
+- **States:** day with no mappable places → on-map message with chips still
+  shown; undated trip → no chips, no highlight; offline → identical filtering
+  over cached data.
+
+## Edge Cases & Error States
+
+- Today is inside the range but that day has no items → scroll falls back to
+  the nearest prior day with items, then nearest following, then no-op.
+- Collapsed city group or day section containing the target → expanded before
+  scrolling.
+- Unparseable or missing dates anywhere degrade to the undated behavior — no
+  crash, no chips (unless items carry day tags), no scroll.
+- Timezones: "today" is the device's local calendar date; trip dates are
+  date-only strings interpreted as local dates.
+- A stay whose check-in/check-out is missing or unparseable never matches a
+  day chip (it still shows under All).
+- Day chips must reflect day tags beyond the date span (e.g. an item tagged
+  Day 9 on a 7-day trip still yields a Day 9 chip).
+
+## Out of Scope
+
+- Persisting the selected chip or any server-side notion of "today".
+- Filtering the itinerary *list* by day (chips are a map affordance only).
+- Notifications / reminders about today's plan.
+- Any change to the Go API or the shared-trip payload.
+
+## Open Questions
+
+None.

--- a/specs/today-mode/tasks.md
+++ b/specs/today-mode/tasks.md
@@ -1,0 +1,52 @@
+# Tasks: Today Mode & Map Day-Filtering
+
+> Dependency-ordered. `[P]` = can run in parallel with its siblings (no shared
+> files / no ordering dependency). Work top to bottom; verification is last.
+> Flutter-only — no Go/API tasks. Ships as three PRs.
+
+## PR 1 — Spec + day helpers + TripMap params
+
+- [x] Copy `specs/_template/` → `specs/today-mode/`; write spec/plan/tasks
+- [x] [P] `lib/utils/trip_days.dart`: `tripDayOn`, `dayCount`,
+      `stayCoversDate` (pure, string-based, device-local doc comments)
+- [x] [P] `lib/widgets/trip_map.dart`: defaulted `fitSignature` (post-frame
+      re-fit in `didUpdateWidget`) + `emptyLabel` params
+- [x] Refactor `add_to_trip_sheet.dart` `_eventDayFor`/`_dayCount` to delegate
+      to the helpers (behavior-neutral)
+- [x] `test/trip_days_test.dart`: range boundaries, garbage dates,
+      checkout-exclusive boundary, span-vs-tagged day count
+- [x] Extend `test/trip_map_test.dart`: custom `emptyLabel` renders;
+      `fitSignature` change smoke test
+
+## PR 2 — Map day-filter chips
+
+- [ ] Day-chip row widget (`All · Day 1…N`), hidden when `dayCount == 0`
+- [ ] Upstream filtering in `trip_detail_screen.dart`: items by `day`, stays
+      by `stayCoversDate` (checkout-exclusive night), segment labels to match
+- [ ] Wire `fitSignature` (selected day) + per-day `emptyLabel`; chips live
+      outside the map so an empty day never hides them
+- [ ] Undated items only under All; live trips preselect today's chip
+- [ ] `shared_trip_screen.dart`: same chips defaulting to All, no Today
+      behaviors
+- [ ] Widget tests: filtering, empty-day message, chip-row visibility rules
+
+## PR 3 — Today auto-scroll + highlight
+
+- [ ] `Map<String, GlobalKey>` registry keyed `'$cityKey#$day'` on day headers
+- [ ] Offset-reveal scroller: pinned-chrome compensation + one correction pass
+- [ ] Expand collapsed city/day sections containing the target before scrolling
+- [ ] Fallback: today-with-no-items → nearest prior day with items → nearest
+      following → no-op
+- [ ] One-shot guard: first non-silent load only; never on silent `_refresh()`,
+      never while the refine panel is open; today highlight on the day header
+- [ ] Widget tests: auto-scroll happy path, fallbacks, guards, undated/past
+      trips unchanged
+
+## Verification
+
+- [x] `flutter analyze --no-fatal-infos --fatal-warnings` clean (no new infos)
+- [x] `make flutter-test` passes, including `add_to_trip_sheet_test.dart`
+      unchanged (PR 1)
+- [ ] Manual end-to-end via gateway (`make docker-dev` →
+      `http://localhost:3000`): every acceptance criterion in `spec.md` on
+      live-dated / past / undated trips, a shared link, and offline (PRs 2–3)

--- a/src/packages/flutter-app/lib/utils/trip_days.dart
+++ b/src/packages/flutter-app/lib/utils/trip_days.dart
@@ -1,0 +1,54 @@
+// Shared trip-day math (specs/today-mode) so the trip detail screen, the
+// shared trip view, and the add-to-trip sheet all agree on what "Day N" means.
+//
+// Pure and string-based like trip_format.dart: callers pass the raw ISO
+// date-only strings (YYYY-MM-DD) straight off the models — no model imports.
+// Dart parses date-only strings as **local** midnight, so all day math here is
+// in the device's local calendar; "today" is wherever the device is.
+
+/// The 1-based trip day that [when]'s **device-local calendar date** falls on,
+/// or null when [startDate] is missing/unparseable or the date lands outside
+/// the trip (before day 1, or past [endDate] when that parses).
+///
+/// [when]'s time of day is ignored (truncated to the local date), so passing
+/// `DateTime.now()` answers "which trip day is today?".
+int? tripDayOn(String? startDate, String? endDate, DateTime when) {
+  final start = DateTime.tryParse(startDate ?? '');
+  if (start == null) return null;
+  final date = DateTime(when.year, when.month, when.day);
+  final day = date.difference(start).inDays + 1;
+  if (day < 1) return null;
+  final end = DateTime.tryParse(endDate ?? '');
+  if (end != null && day > end.difference(start).inDays + 1) return null;
+  return day;
+}
+
+/// How many days a trip spans for day chips / pickers: the later of the
+/// highest tagged day in [itemDays] and the [startDate]–[endDate] span (so an
+/// empty dated trip still offers its real days, and an item tagged beyond the
+/// span still gets a chip). 0 when the trip has neither dates nor tagged items.
+int dayCount(String? startDate, String? endDate, Iterable<int?> itemDays) {
+  var max = 0;
+  for (final d in itemDays) {
+    if (d != null && d > max) max = d;
+  }
+  final start = DateTime.tryParse(startDate ?? '');
+  final end = DateTime.tryParse(endDate ?? '');
+  if (start != null && end != null) {
+    final span = end.difference(start).inDays + 1;
+    if (span > max) max = span;
+  }
+  return max;
+}
+
+/// Whether a stay covers the night of [date] (device-local calendar date):
+/// check-in <= date < check-out — **checkout-exclusive**, since nobody sleeps
+/// there on checkout day. False when either date is missing or unparseable.
+bool stayCoversDate(String? checkIn, String? checkOut, DateTime date) {
+  final a = DateTime.tryParse(checkIn ?? '');
+  final b = DateTime.tryParse(checkOut ?? '');
+  if (a == null || b == null) return false;
+  final d = DateTime(date.year, date.month, date.day);
+  return !d.isBefore(DateTime(a.year, a.month, a.day)) &&
+      d.isBefore(DateTime(b.year, b.month, b.day));
+}

--- a/src/packages/flutter-app/lib/widgets/add_to_trip_sheet.dart
+++ b/src/packages/flutter-app/lib/widgets/add_to_trip_sheet.dart
@@ -9,6 +9,7 @@ import '../providers/trips_provider.dart';
 import '../screens/trip_detail_screen.dart';
 import '../theme/app_colors.dart';
 import '../theme/spacing.dart';
+import '../utils/trip_days.dart';
 
 /// What a browse surface (local rec card, event card, guide pin) hands the
 /// add-to-trip sheet: the place fields that map onto an itinerary item, the
@@ -199,30 +200,17 @@ class _AddToTripSheetState extends ConsumerState<_AddToTripSheet> {
   /// no start date, the date doesn't parse, or it lands outside the trip.
   int? _eventDayFor(Trip trip) {
     final eventDate = DateTime.tryParse(widget.payload.eventDate ?? '');
-    final start = DateTime.tryParse(trip.startDate ?? '');
-    if (eventDate == null || start == null) return null;
-    final day = eventDate.difference(start).inDays + 1;
-    if (day < 1) return null;
-    final end = DateTime.tryParse(trip.endDate ?? '');
-    if (end != null && day > end.difference(start).inDays + 1) return null;
-    return day;
+    if (eventDate == null) return null;
+    return tripDayOn(trip.startDate, trip.endDate, eventDate);
   }
 
   /// How many day chips to offer: the later of the highest tagged item day and
   /// the trip's date span (so an empty dated trip still offers its real days).
-  int _dayCount(Trip trip) {
-    var max = 0;
-    for (final it in trip.items ?? const <ItineraryItem>[]) {
-      if (it.day != null && it.day! > max) max = it.day!;
-    }
-    final start = DateTime.tryParse(trip.startDate ?? '');
-    final end = DateTime.tryParse(trip.endDate ?? '');
-    if (start != null && end != null) {
-      final span = end.difference(start).inDays + 1;
-      if (span > max) max = span;
-    }
-    return max;
-  }
+  int _dayCount(Trip trip) => dayCount(
+        trip.startDate,
+        trip.endDate,
+        (trip.items ?? const <ItineraryItem>[]).map((it) => it.day),
+      );
 
   /// Already on the chosen trip? Matched by recommendation id when the payload
   /// carries one, with a case-insensitive name fallback (events have no id).

--- a/src/packages/flutter-app/lib/widgets/trip_map.dart
+++ b/src/packages/flutter-app/lib/widgets/trip_map.dart
@@ -29,6 +29,17 @@ class TripMap extends StatefulWidget {
   /// given position. Drawn at the midpoint of that segment. Empty => no labels.
   final Map<int, String> segmentLabels;
 
+  /// When this value changes (by `==`), the camera re-fits to the current
+  /// trip extent after the next frame. Lets callers that filter [items] /
+  /// [accommodations] upstream (e.g. a day-chip selection) reframe the view
+  /// without remounting the map by key, which would flash tiles. The default
+  /// (never changing) keeps existing call sites unchanged.
+  final Object? fitSignature;
+
+  /// Message shown when nothing is mappable (no items or stays with
+  /// coordinates). The default keeps existing call sites unchanged.
+  final String emptyLabel;
+
   const TripMap({
     super.key,
     required this.items,
@@ -36,6 +47,8 @@ class TripMap extends StatefulWidget {
     this.onPinTap,
     this.segmentLabels = const {},
     this.accommodations = const [],
+    this.fitSignature,
+    this.emptyLabel = 'No mapped places',
   });
 
   @override
@@ -100,9 +113,35 @@ class _TripMapState extends State<TripMap> {
     } catch (_) {}
   }
 
+  /// Every coordinate the camera should frame: mapped items plus geocoded
+  /// stays. Mirrors the fitPoints assembled in [build].
+  List<LatLng> _fitPoints() {
+    final points = <LatLng>[
+      for (final it in widget.items)
+        if (_hasCoords(it)) LatLng(it.latitude, it.longitude),
+    ];
+    for (final a in widget.accommodations) {
+      final lat = a.latitude;
+      final lng = a.longitude;
+      if (lat != null && lng != null && (lat != 0 || lng != 0)) {
+        points.add(LatLng(lat, lng));
+      }
+    }
+    return points;
+  }
+
   @override
   void didUpdateWidget(covariant TripMap oldWidget) {
     super.didUpdateWidget(oldWidget);
+    if (widget.fitSignature != oldWidget.fitSignature) {
+      // Re-fit after the frame that renders the new (filtered) content, so
+      // the controller sees the updated layout. No-op when nothing is
+      // mappable (the empty state has no live map to move).
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted) return;
+        _fitToTrip(_fitPoints());
+      });
+    }
     if (widget.selectedPosition != null &&
         widget.selectedPosition != oldWidget.selectedPosition) {
       final target = _selectedPoint();
@@ -146,7 +185,7 @@ class _TripMapState extends State<TripMap> {
         color: theme.colorScheme.surfaceContainerHighest,
         alignment: Alignment.center,
         child: Text(
-          'No mapped places',
+          widget.emptyLabel,
           style: theme.textTheme.bodySmall
               ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
         ),

--- a/src/packages/flutter-app/test/trip_days_test.dart
+++ b/src/packages/flutter-app/test/trip_days_test.dart
@@ -1,0 +1,102 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:travel_route_planner/utils/trip_days.dart';
+
+void main() {
+  group('tripDayOn', () {
+    const start = '2026-06-10';
+    const end = '2026-06-14'; // 5-day trip
+
+    test('a date inside the range maps to its 1-based day', () {
+      expect(tripDayOn(start, end, DateTime(2026, 6, 12)), 3);
+    });
+
+    test('day-1 boundary: the start date itself is day 1', () {
+      expect(tripDayOn(start, end, DateTime(2026, 6, 10)), 1);
+    });
+
+    test('last-day boundary: the end date is the final day', () {
+      expect(tripDayOn(start, end, DateTime(2026, 6, 14)), 5);
+    });
+
+    test('before the range is null', () {
+      expect(tripDayOn(start, end, DateTime(2026, 6, 9)), isNull);
+    });
+
+    test('after the range is null', () {
+      expect(tripDayOn(start, end, DateTime(2026, 6, 15)), isNull);
+    });
+
+    test('time of day is ignored (truncated to the local date)', () {
+      expect(tripDayOn(start, end, DateTime(2026, 6, 12, 23, 59)), 3);
+      expect(tripDayOn(start, end, DateTime(2026, 6, 14, 18, 30)), 5);
+    });
+
+    test('missing or garbage start date is null', () {
+      expect(tripDayOn(null, end, DateTime(2026, 6, 12)), isNull);
+      expect(tripDayOn('', end, DateTime(2026, 6, 12)), isNull);
+      expect(tripDayOn('not-a-date', end, DateTime(2026, 6, 12)), isNull);
+    });
+
+    test('missing end date leaves the trip open-ended past day 1', () {
+      // Mirrors the add-to-trip sheet's original behavior: only the lower
+      // bound applies when the end does not parse.
+      expect(tripDayOn(start, null, DateTime(2026, 7, 1)), 22);
+      expect(tripDayOn(start, 'garbage', DateTime(2026, 6, 9)), isNull);
+    });
+  });
+
+  group('dayCount', () {
+    test('date span wins when items are untagged', () {
+      expect(dayCount('2026-06-10', '2026-06-14', [null, null]), 5);
+    });
+
+    test('a tagged day beyond the span wins', () {
+      expect(dayCount('2026-06-10', '2026-06-14', [2, 9, null]), 9);
+    });
+
+    test('tagged days alone work without trip dates', () {
+      expect(dayCount(null, null, [1, 3]), 3);
+    });
+
+    test('no dates and no tags is 0', () {
+      expect(dayCount(null, null, const <int?>[]), 0);
+      expect(dayCount('junk', 'junk', [null]), 0);
+    });
+  });
+
+  group('stayCoversDate', () {
+    const checkIn = '2026-06-10';
+    const checkOut = '2026-06-13';
+
+    test('the check-in date is covered', () {
+      expect(stayCoversDate(checkIn, checkOut, DateTime(2026, 6, 10)), isTrue);
+    });
+
+    test('nights in between are covered', () {
+      expect(stayCoversDate(checkIn, checkOut, DateTime(2026, 6, 12)), isTrue);
+    });
+
+    test('the check-out date is NOT covered (checkout-exclusive)', () {
+      expect(stayCoversDate(checkIn, checkOut, DateTime(2026, 6, 13)), isFalse);
+    });
+
+    test('dates outside the stay are not covered', () {
+      expect(stayCoversDate(checkIn, checkOut, DateTime(2026, 6, 9)), isFalse);
+      expect(stayCoversDate(checkIn, checkOut, DateTime(2026, 6, 14)), isFalse);
+    });
+
+    test('missing or garbage dates are never covered', () {
+      expect(stayCoversDate(null, checkOut, DateTime(2026, 6, 11)), isFalse);
+      expect(stayCoversDate(checkIn, null, DateTime(2026, 6, 11)), isFalse);
+      expect(stayCoversDate('junk', checkOut, DateTime(2026, 6, 11)), isFalse);
+    });
+
+    test("the queried date's time of day is ignored", () {
+      expect(
+        stayCoversDate(checkIn, checkOut, DateTime(2026, 6, 12, 23, 59)),
+        isTrue,
+      );
+    });
+  });
+}

--- a/src/packages/flutter-app/test/trip_map_test.dart
+++ b/src/packages/flutter-app/test/trip_map_test.dart
@@ -81,6 +81,53 @@ void main() {
     expect(tooltips, contains('Left Bank Flat')); // no dates -> name only
   });
 
+  testWidgets('custom emptyLabel renders when nothing is mappable',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(
+      _host(const TripMap(items: [], emptyLabel: 'No mapped places on Day 3')),
+    );
+    await tester.pump();
+
+    expect(find.text('No mapped places on Day 3'), findsOneWidget);
+    expect(find.text('No mapped places'), findsNothing);
+  });
+
+  testWidgets('default emptyLabel keeps the existing message',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(_host(const TripMap(items: [])));
+    await tester.pump();
+
+    expect(find.text('No mapped places'), findsOneWidget);
+  });
+
+  testWidgets('changing fitSignature re-fits without crashing (smoke)',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(
+      _host(TripMap(items: items, fitSignature: 'all')),
+    );
+    await tester.pump();
+
+    // Filtered down to one item under a new signature: the post-frame re-fit
+    // must run against the live controller without throwing.
+    await tester.pumpWidget(
+      _host(TripMap(items: [items.first], fitSignature: 'day-1')),
+    );
+    await tester.pump();
+    await tester.pump();
+
+    expect(find.byType(TripMap), findsOneWidget);
+
+    // Signature change while nothing is mappable (empty state, no live map)
+    // must be a no-op, not a crash.
+    await tester.pumpWidget(
+      _host(const TripMap(items: [], fitSignature: 'day-2')),
+    );
+    await tester.pump();
+    await tester.pump();
+
+    expect(find.text('No mapped places'), findsOneWidget);
+  });
+
   testWidgets('stays alone (no mapped items) still render a map',
       (WidgetTester tester) async {
     const stays = [


### PR DESCRIPTION
PR 1 of 3 for **Today mode + map day-filtering** (`specs/today-mode/`). Flutter-only; no API changes.

## What's here

- **`specs/today-mode/{spec,plan,tasks}.md`** — acceptance criteria for the whole wave (later PRs implement most): one-shot auto-scroll to today's highlighted section on live trips (device-local; never on silent refreshes or with the refine panel open; collapsed target expands first; nearest prior/following day fallback), map day-chip row (`All · Day 1…N`) filtering pins/route/walking-time labels/covering stays (checkout-exclusive `checkIn <= d < checkOut`), auto-fit on chip change, chips-never-disappear empty state, undated items only under All, `dayCount==0` hides the row, live trips preselect today, shared views default to All with no Today behaviors, offline view-only works, **API Surface: none**. `plan.md` records the design decisions: offset-reveal scroll (not `ensureVisible` — unreliable `showOnScreen` under sliver_tools pins), GlobalKeys keyed `'$cityKey#$day'`, pinned-chrome compensation + one correction pass, polyline/labels stay on within a day (contiguous positions + existing `position+1` adjacency guard), `fitSignature` over remount-by-key (tile flash), upstream filtering.
- **`lib/utils/trip_days.dart`** (new; `trip_format.dart` style — pure, string-based, no model imports):
  - `int? tripDayOn(String? startDate, String? endDate, DateTime when)` — device-local calendar day, `_eventDayFor` formula
  - `int dayCount(String? startDate, String? endDate, Iterable<int?> itemDays)` — max of highest tagged day and date span
  - `bool stayCoversDate(String? checkIn, String? checkOut, DateTime date)` — checkout-exclusive
- **`add_to_trip_sheet.dart`** — `_eventDayFor`/`_dayCount` now delegate to the helpers; behavior-neutral, its tests pass **unchanged**.
- **`trip_map.dart`** — defaulted `Object? fitSignature` (change → post-frame re-fit via the existing `_fitToTrip`) and `String emptyLabel = 'No mapped places'`; existing call sites compile unchanged.

## Tests

- New `test/trip_days_test.dart`: in/before/after range, day-1/last-day boundaries, garbage dates, checkout-exclusive boundary (`date == checkOut` → false, `date == checkIn` → true), span-vs-tagged day count.
- Extended `test/trip_map_test.dart`: custom `emptyLabel` renders, default preserved, `fitSignature` change smoke (live map → filtered → empty state).
- `make flutter-test`: **123 tests, all pass** (including `add_to_trip_sheet_test.dart` untouched).
- `flutter analyze --no-fatal-infos --fatal-warnings`: exit 0, the 12 known pre-existing infos, none added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)