### PR TITLE
feat(flutter): day chips filter the trip map

### DIFF
--- a/src/packages/flutter-app/lib/screens/shared_trip_screen.dart
+++ b/src/packages/flutter-app/lib/screens/shared_trip_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../models/accommodation.dart';
 import '../models/itinerary_item.dart';
 import '../models/shared_trip.dart';
 import '../models/trip.dart';
@@ -8,9 +9,11 @@ import '../providers/auth_provider.dart';
 import '../providers/shared_trip_provider.dart';
 import '../providers/trips_provider.dart';
 import '../theme/spacing.dart';
+import '../utils/trip_days.dart';
 import '../utils/trip_format.dart';
 import '../widgets/empty_state.dart';
 import '../widgets/gradient_app_bar.dart';
+import '../widgets/map_day_chips.dart';
 import '../widgets/trip_map.dart';
 import 'auth_screen.dart';
 import 'trip_detail_screen.dart';
@@ -58,6 +61,9 @@ class _SharedTripBody extends ConsumerStatefulWidget {
 class _SharedTripBodyState extends ConsumerState<_SharedTripBody> {
   bool _saving = false;
   int? _selectedPosition;
+  // Map day-chip selection; null = All. Shared views always default to All
+  // and get none of the Today behaviors (specs/today-mode).
+  int? _selectedDay;
 
   Trip get _trip => widget.shared.trip;
 
@@ -138,7 +144,34 @@ class _SharedTripBodyState extends ConsumerState<_SharedTripBody> {
     final trip = _trip;
     final items = trip.items ?? const <ItineraryItem>[];
     final dates = tripDateRange(trip.startDate, trip.endDate);
+    // The map-visibility gate stays keyed to the unfiltered items so the
+    // chip row never disappears when the selected day has nothing mappable.
     final hasCoords = items.any((i) => i.latitude != 0 || i.longitude != 0);
+    final mapDayCount =
+        dayCount(trip.startDate, trip.endDate, items.map((i) => i.day));
+    if (_selectedDay != null && _selectedDay! > mapDayCount) {
+      _selectedDay = null; // trip shrank under a stale selection
+    }
+    final dayItems = _selectedDay == null
+        ? items
+        : items.where((i) => i.day == _selectedDay).toList();
+    final stays = trip.accommodations ?? const <Accommodation>[];
+    // Under Day N, only the stay(s) covering that night (checkout-exclusive);
+    // without a parseable start date no stay can match a day.
+    final tripStart = DateTime.tryParse(trip.startDate ?? '');
+    final dayStays = _selectedDay == null
+        ? stays
+        : tripStart == null
+            ? const <Accommodation>[]
+            : stays
+                .where((a) => stayCoversDate(
+                    a.checkIn,
+                    a.checkOut,
+                    // Calendar-day arithmetic (constructor normalizes
+                    // overflow) so a DST transition can't drift the date.
+                    DateTime(tripStart.year, tripStart.month,
+                        tripStart.day + _selectedDay! - 1)))
+                .toList();
 
     return Stack(
       children: [
@@ -164,12 +197,35 @@ class _SharedTripBodyState extends ConsumerState<_SharedTripBody> {
                 borderRadius: AppRadius.lgAll,
                 child: SizedBox(
                   height: 240,
-                  child: TripMap(
-                    items: items,
-                    accommodations: trip.accommodations ?? const [],
-                    selectedPosition: _selectedPosition,
-                    onPinTap: (pos) =>
-                        setState(() => _selectedPosition = pos),
+                  child: Stack(
+                    children: [
+                      Positioned.fill(
+                        child: TripMap(
+                          items: dayItems,
+                          accommodations: dayStays,
+                          selectedPosition: _selectedPosition,
+                          fitSignature: _selectedDay,
+                          emptyLabel: _selectedDay == null
+                              ? 'No mapped places'
+                              : 'No mapped places on this day',
+                          onPinTap: (pos) =>
+                              setState(() => _selectedPosition = pos),
+                        ),
+                      ),
+                      // Above the map's gesture layer, so chip taps and row
+                      // scrolls never pan the map.
+                      Positioned(
+                        top: 8,
+                        left: 8,
+                        right: 8,
+                        child: MapDayChips(
+                          dayCount: mapDayCount,
+                          selected: _selectedDay,
+                          onSelected: (d) =>
+                              setState(() => _selectedDay = d),
+                        ),
+                      ),
+                    ],
                   ),
                 ),
               ),

--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -31,6 +31,7 @@ import '../services/trip_cache.dart';
 import '../theme/app_colors.dart';
 import '../theme/spacing.dart';
 import '../utils/tracked_launch.dart';
+import '../utils/trip_days.dart';
 import '../utils/trip_format.dart';
 import '../widgets/add_itinerary_item_dialog.dart';
 import '../widgets/add_to_trip_sheet.dart';
@@ -39,6 +40,7 @@ import '../widgets/bookings_section.dart';
 import '../widgets/empty_state.dart';
 import '../widgets/event_card.dart';
 import '../widgets/local_rec_card.dart';
+import '../widgets/map_day_chips.dart';
 import '../widgets/offline_banner.dart';
 import '../widgets/source_links_card.dart';
 import '../widgets/status_pill.dart';
@@ -73,6 +75,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
   bool _panelOpen = false;
   RefineTarget? _refineTarget;
   String _itemFilter = 'all'; // 'all' | 'attraction' | 'restaurant'
+  int? _selectedDay; // map day-chip selection; null = All (specs/today-mode)
   int?
       _selectedPosition; // position of the place focused via a map pin / list tap
   List<BookingTodo> _bookingTodos = [];
@@ -111,6 +114,33 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
     return _itemFilter == 'all'
         ? items.toList()
         : items.where((i) => i.category == _itemFilter).toList();
+  }
+
+  /// [_filtered] further narrowed to the selected map day chip. The map is
+  /// the only consumer — the itinerary list never day-filters. Untagged
+  /// items (day == null) show only under All.
+  List<ItineraryItem> _dayFiltered(Trip trip) {
+    return _filtered(trip)
+        .where((i) => _selectedDay == null || i.day == _selectedDay)
+        .toList();
+  }
+
+  /// Stays the map should plot for the selected day chip: under All, every
+  /// stay; under Day N, only stays covering that night (checkout-exclusive).
+  /// A trip without a parseable start date can't map Day N to a calendar
+  /// date, so no stay matches (they all still show under All).
+  List<Accommodation> _dayFilteredStays(Trip trip) {
+    final all = trip.accommodations ?? const <Accommodation>[];
+    final day = _selectedDay;
+    if (day == null) return all;
+    final start = DateTime.tryParse(trip.startDate ?? '');
+    if (start == null) return const [];
+    // Calendar-day arithmetic (constructor normalizes overflow) rather than
+    // Duration, which drifts a date across a DST transition.
+    final night = DateTime(start.year, start.month, start.day + day - 1);
+    return all
+        .where((a) => stayCoversDate(a.checkIn, a.checkOut, night))
+        .toList();
   }
 
   @override
@@ -2336,6 +2366,22 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
                           r.label: (start: r.start, end: r.end)
                       };
                       final tripStart = DateTime.tryParse(trip.startDate ?? '');
+                      // Map day chips (specs/today-mode). Day count spans the
+                      // whole trip, not the category filter, so chips never
+                      // come and go with the Attractions/Restaurants toggle.
+                      final mapDayCount = dayCount(
+                        trip.startDate,
+                        trip.endDate,
+                        (trip.items ?? const <ItineraryItem>[])
+                            .map((i) => i.day),
+                      );
+                      // A refresh can shrink the trip below a stale selection
+                      // (fewer days after an edit); fall back to All. Plain
+                      // assignment: we're already in build, so this frame
+                      // renders the clamped value.
+                      if (_selectedDay != null && _selectedDay! > mapDayCount) {
+                        _selectedDay = null;
+                      }
                       final scrollView = CustomScrollView(
                         slivers: [
                           SliverPadding(
@@ -2364,18 +2410,48 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
                                     const EdgeInsets.fromLTRB(16, 12, 16, 12),
                                 child: ClipRRect(
                                   borderRadius: AppRadius.lgAll,
-                                  child: TripMap(
-                                    items: _filtered(trip),
-                                    accommodations:
-                                        trip.accommodations ?? const [],
-                                    selectedPosition: _selectedPosition,
-                                    segmentLabels: _segmentLabels(),
-                                    onPinTap: (pos) {
-                                      setState(() => _selectedPosition = pos);
-                                      final it = trip.items!
-                                          .firstWhere((i) => i.position == pos);
-                                      _showSnack(it.name);
-                                    },
+                                  child: Stack(
+                                    children: [
+                                      Positioned.fill(
+                                        child: TripMap(
+                                          items: _dayFiltered(trip),
+                                          accommodations:
+                                              _dayFilteredStays(trip),
+                                          selectedPosition: _selectedPosition,
+                                          // Unfiltered by day: TripMap's
+                                          // position+1 adjacency guard drops
+                                          // labels across the gaps a day
+                                          // filter creates, and the category
+                                          // filter already empties this map.
+                                          segmentLabels: _segmentLabels(),
+                                          fitSignature: _selectedDay,
+                                          emptyLabel: _selectedDay == null
+                                              ? 'No mapped places'
+                                              : 'No mapped places on this day',
+                                          onPinTap: (pos) {
+                                            setState(
+                                                () => _selectedPosition = pos);
+                                            final it = trip.items!.firstWhere(
+                                                (i) => i.position == pos);
+                                            _showSnack(it.name);
+                                          },
+                                        ),
+                                      ),
+                                      // Above the map's gesture layer, so
+                                      // chip taps and row scrolls never pan
+                                      // the map.
+                                      Positioned(
+                                        top: 8,
+                                        left: 8,
+                                        right: 8,
+                                        child: MapDayChips(
+                                          dayCount: mapDayCount,
+                                          selected: _selectedDay,
+                                          onSelected: (d) => setState(
+                                              () => _selectedDay = d),
+                                        ),
+                                      ),
+                                    ],
                                   ),
                                 ),
                               ),

--- a/src/packages/flutter-app/lib/widgets/map_day_chips.dart
+++ b/src/packages/flutter-app/lib/widgets/map_day_chips.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/material.dart';
+
+/// Day-filter chips overlaid on a trip map: `All · Day 1 · … · Day N`
+/// (specs/today-mode). [selected] is the 1-based day, null meaning All;
+/// tapping a chip reports the new value through [onSelected] (tapping the
+/// already-selected chip re-reports it — harmless for a filter).
+///
+/// Renders nothing when [dayCount] is 0 (undated trip with no day-tagged
+/// items). Untagged items are an All-only affair, so there is deliberately
+/// no "Unscheduled" chip.
+///
+/// The chips sit over satellite imagery, so they use the same translucent
+/// dark scrim treatment as the map's segment labels and control buttons.
+class MapDayChips extends StatelessWidget {
+  final int dayCount;
+  final int? selected;
+  final ValueChanged<int?> onSelected;
+
+  const MapDayChips({
+    super.key,
+    required this.dayCount,
+    required this.selected,
+    required this.onSelected,
+  });
+
+  Widget _chip({required String label, required int? value}) {
+    final isSelected = selected == value;
+    return ChoiceChip(
+      label: Text(label),
+      selected: isSelected,
+      onSelected: (_) => onSelected(value),
+      // Compact: the row floats over the map and must not eat into it.
+      visualDensity: VisualDensity.compact,
+      materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+      labelPadding: EdgeInsets.zero,
+      showCheckmark: false,
+      // Dark translucent scrim so the text reads over satellite imagery
+      // (same treatment as TripMap's segment labels); selection is a solid
+      // white ring + brighter fill rather than a theme tint, which would
+      // vanish against imagery.
+      backgroundColor: Colors.black.withValues(alpha: 0.6),
+      selectedColor: Colors.black.withValues(alpha: 0.8),
+      side: BorderSide(color: isSelected ? Colors.white : Colors.white24),
+      labelStyle: TextStyle(
+        color: Colors.white,
+        fontSize: 11,
+        fontWeight: isSelected ? FontWeight.w700 : FontWeight.w600,
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (dayCount == 0) return const SizedBox.shrink();
+    return SingleChildScrollView(
+      scrollDirection: Axis.horizontal,
+      child: Row(
+        children: [
+          _chip(label: 'All', value: null),
+          for (var d = 1; d <= dayCount; d++) ...[
+            const SizedBox(width: 6),
+            _chip(label: 'Day $d', value: d),
+          ],
+        ],
+      ),
+    );
+  }
+}

--- a/src/packages/flutter-app/test/shared_trip_day_chips_test.dart
+++ b/src/packages/flutter-app/test/shared_trip_day_chips_test.dart
@@ -1,0 +1,136 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:travel_route_planner/models/accommodation.dart';
+import 'package:travel_route_planner/models/itinerary_item.dart';
+import 'package:travel_route_planner/models/shared_trip.dart';
+import 'package:travel_route_planner/models/trip.dart';
+import 'package:travel_route_planner/services/api_client.dart';
+import 'package:travel_route_planner/services/trips_api_service.dart';
+import 'package:travel_route_planner/providers/trips_provider.dart';
+import 'package:travel_route_planner/screens/shared_trip_screen.dart';
+import 'package:travel_route_planner/widgets/map_day_chips.dart';
+import 'package:travel_route_planner/widgets/trip_map.dart';
+
+class _FakeTripsApiService extends TripsApiService {
+  final SharedTrip shared;
+  _FakeTripsApiService(this.shared) : super(ApiClient(baseUrl: 'http://test'));
+
+  @override
+  Future<SharedTrip> getSharedTrip(String token) async => shared;
+}
+
+ItineraryItem _item(int pos, String name, double lat, double lng, int day) =>
+    ItineraryItem(
+      id: 'i$pos',
+      position: pos,
+      name: name,
+      latitude: lat,
+      longitude: lng,
+      category: 'attraction',
+      day: day,
+      city: 'Paris',
+    );
+
+void main() {
+  final shared = SharedTrip(
+    ownerName: 'Ann',
+    trip: Trip(
+      id: 't1',
+      title: 'Paris getaway',
+      status: 'planned',
+      createdAt: '2026-06-01',
+      updatedAt: '2026-06-01',
+      startDate: '2026-09-01',
+      endDate: '2026-09-02',
+      items: [
+        _item(0, 'Louvre', 48.8606, 2.3376, 1),
+        _item(1, 'Orsay', 48.8600, 2.3266, 1),
+        _item(2, 'Pantheon', 48.8462, 2.3464, 2),
+      ],
+      accommodations: const [
+        // Night of day 1 only (checkout-exclusive).
+        Accommodation(
+          id: 'a1',
+          name: 'Night One Hotel',
+          latitude: 48.8630,
+          longitude: 2.3364,
+          checkIn: '2026-09-01',
+          checkOut: '2026-09-02',
+        ),
+        // Night of day 2 only.
+        Accommodation(
+          id: 'a2',
+          name: 'Night Two Flat',
+          latitude: 48.8520,
+          longitude: 2.3330,
+          checkIn: '2026-09-02',
+          checkOut: '2026-09-03',
+        ),
+      ],
+    ),
+  );
+
+  Future<void> pumpScreen(WidgetTester tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          tripsApiServiceProvider
+              .overrideWithValue(_FakeTripsApiService(shared)),
+        ],
+        child: const MaterialApp(home: SharedTripScreen(token: 'tok')),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  /// Scoped to MapDayChips: the shared list renders its own "Day N" chips on
+  /// item tiles.
+  Future<void> tapChip(WidgetTester tester, String label) async {
+    await tester.tap(find.descendant(
+      of: find.byType(MapDayChips),
+      matching: find.text(label),
+    ));
+    await tester.pump();
+    await tester.pump(); // post-frame camera re-fit
+  }
+
+  TripMap map(WidgetTester tester) =>
+      tester.widget<TripMap>(find.byType(TripMap));
+
+  testWidgets('shared view gets the chip row, defaulting to All',
+      (WidgetTester tester) async {
+    await pumpScreen(tester);
+
+    final chips = find.byType(MapDayChips);
+    expect(chips, findsOneWidget);
+    for (final label in ['All', 'Day 1', 'Day 2']) {
+      expect(
+        find.descendant(of: chips, matching: find.text(label)),
+        findsOneWidget,
+      );
+    }
+
+    // Defaults to All (no Today preselection on shared views).
+    expect(map(tester).fitSignature, isNull);
+    expect(map(tester).items, hasLength(3));
+    expect(map(tester).accommodations, hasLength(2));
+  });
+
+  testWidgets('day chip filters the shared map; All restores',
+      (WidgetTester tester) async {
+    await pumpScreen(tester);
+
+    await tapChip(tester, 'Day 2');
+
+    expect(map(tester).items.map((i) => i.name), ['Pantheon']);
+    expect(map(tester).accommodations.map((a) => a.name), ['Night Two Flat']);
+    expect(map(tester).fitSignature, 2);
+
+    await tapChip(tester, 'All');
+
+    expect(map(tester).items, hasLength(3));
+    expect(map(tester).accommodations, hasLength(2));
+  });
+}

--- a/src/packages/flutter-app/test/trip_detail_day_chips_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_day_chips_test.dart
@@ -1,0 +1,159 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:travel_route_planner/models/accommodation.dart';
+import 'package:travel_route_planner/models/trip.dart';
+import 'package:travel_route_planner/models/itinerary_item.dart';
+import 'package:travel_route_planner/services/api_client.dart';
+import 'package:travel_route_planner/services/trips_api_service.dart';
+import 'package:travel_route_planner/providers/trips_provider.dart';
+import 'package:travel_route_planner/screens/trip_detail_screen.dart';
+import 'package:travel_route_planner/widgets/map_day_chips.dart';
+import 'package:travel_route_planner/widgets/trip_map.dart';
+
+class _FakeTripsApiService extends TripsApiService {
+  final Trip trip;
+  _FakeTripsApiService(this.trip) : super(ApiClient(baseUrl: 'http://test'));
+
+  @override
+  Future<Trip> getTrip(String id) async => trip;
+}
+
+/// Real (tight Paris-cluster) coordinates so the trip detail screen mounts a
+/// live TripMap instead of skipping it.
+ItineraryItem _item(int pos, String name, double lat, double lng, int day) =>
+    ItineraryItem(
+      id: 'i$pos',
+      position: pos,
+      name: name,
+      latitude: lat,
+      longitude: lng,
+      category: 'attraction',
+      day: day,
+      city: 'Paris',
+    );
+
+void main() {
+  // Sept 1–3 => Day 1..3 chips; Day 3 deliberately has no items and no
+  // covering stay, so selecting it exercises the on-map empty state.
+  final trip = Trip(
+    id: 't1',
+    title: 'Paris',
+    status: 'planned',
+    createdAt: '2026-06-01',
+    updatedAt: '2026-06-01',
+    startDate: '2026-09-01',
+    endDate: '2026-09-03',
+    items: [
+      _item(0, 'Louvre', 48.8606, 2.3376, 1),
+      _item(1, 'Orsay', 48.8600, 2.3266, 1),
+      _item(2, 'Pantheon', 48.8462, 2.3464, 2),
+    ],
+    accommodations: const [
+      // Covers the night of day 1 only (checkout-exclusive).
+      Accommodation(
+        id: 'a1',
+        name: 'Night One Hotel',
+        latitude: 48.8630,
+        longitude: 2.3364,
+        checkIn: '2026-09-01',
+        checkOut: '2026-09-02',
+      ),
+      // Covers the night of day 2 only.
+      Accommodation(
+        id: 'a2',
+        name: 'Night Two Flat',
+        latitude: 48.8520,
+        longitude: 2.3330,
+        checkIn: '2026-09-02',
+        checkOut: '2026-09-03',
+      ),
+    ],
+  );
+
+  Future<void> pumpScreen(WidgetTester tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          tripsApiServiceProvider.overrideWithValue(_FakeTripsApiService(trip)),
+        ],
+        child: MaterialApp(home: TripDetailScreen(tripId: 't1')),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  /// Taps the chip labelled [label] inside the map's chip row (the itinerary
+  /// list renders its own "Day N" headers and an "All" category chip, so the
+  /// find must be scoped to MapDayChips).
+  Future<void> tapChip(WidgetTester tester, String label) async {
+    await tester.tap(find.descendant(
+      of: find.byType(MapDayChips),
+      matching: find.text(label),
+    ));
+    await tester.pump();
+    await tester.pump(); // post-frame camera re-fit
+  }
+
+  TripMap map(WidgetTester tester) =>
+      tester.widget<TripMap>(find.byType(TripMap));
+
+  testWidgets('renders All + Day 1..N chips over the map',
+      (WidgetTester tester) async {
+    await pumpScreen(tester);
+
+    final chips = find.byType(MapDayChips);
+    expect(chips, findsOneWidget);
+    for (final label in ['All', 'Day 1', 'Day 2', 'Day 3']) {
+      expect(
+        find.descendant(of: chips, matching: find.text(label)),
+        findsOneWidget,
+      );
+    }
+    // No chip beyond the trip's day count, and no "Unscheduled" chip.
+    expect(find.descendant(of: chips, matching: find.text('Day 4')),
+        findsNothing);
+    expect(find.descendant(of: chips, matching: find.text('Unscheduled')),
+        findsNothing);
+
+    // All is the default: the map sees the whole trip.
+    expect(map(tester).items, hasLength(3));
+    expect(map(tester).accommodations, hasLength(2));
+  });
+
+  testWidgets('Day 2 filters the map to that day and its covering stay; '
+      'All restores', (WidgetTester tester) async {
+    await pumpScreen(tester);
+
+    await tapChip(tester, 'Day 2');
+
+    expect(map(tester).items.map((i) => i.name), ['Pantheon']);
+    expect(map(tester).accommodations.map((a) => a.name), ['Night Two Flat']);
+    expect(map(tester).fitSignature, 2);
+
+    await tapChip(tester, 'All');
+
+    expect(map(tester).items, hasLength(3));
+    expect(map(tester).accommodations, hasLength(2));
+    expect(map(tester).fitSignature, isNull);
+  });
+
+  testWidgets('a day with nothing mappable shows the on-map empty message '
+      'while the chips stay', (WidgetTester tester) async {
+    await pumpScreen(tester);
+
+    await tapChip(tester, 'Day 3');
+
+    expect(map(tester).items, isEmpty);
+    expect(map(tester).accommodations, isEmpty);
+    expect(find.text('No mapped places on this day'), findsOneWidget);
+    // The chip row survives the empty selection (the gate is keyed to the
+    // unfiltered items) and can navigate back out.
+    expect(find.byType(MapDayChips), findsOneWidget);
+
+    await tapChip(tester, 'All');
+    expect(find.text('No mapped places on this day'), findsNothing);
+    expect(map(tester).items, hasLength(3));
+  });
+}


### PR DESCRIPTION
## Summary

Wave 11 PR 2 of specs/today-mode (plan step D4): a compact **All · Day 1 … Day N** chip row floats over the trip map and filters what it plots to a single day — that day's pins, route, and the stay covering that night — with the camera re-fitting in place (no remount, no tile flash).

- **`lib/widgets/map_day_chips.dart`** (new, reusable): horizontally scrollable ChoiceChips with the same translucent dark scrim treatment as TripMap's segment labels so they read over satellite imagery. Renders nothing when `dayCount == 0`. No "Unscheduled" chip — untagged items appear only under **All**.
- **`trip_detail_screen.dart`** (map call-site region only): `_selectedDay` state, `_dayFiltered` beside `_filtered`, `_dayFilteredStays` (checkout-exclusive `stayCoversDate`; calendar-day arithmetic so DST can't drift the night), Stack overlay in the pinned map header, `fitSignature: _selectedDay`, day-aware `emptyLabel`. Day count spans the whole trip (`dayCount(startDate, endDate, item days)`), the map-visibility gate stays keyed to the **unfiltered** items so the chip row never disappears on an empty day, and a stale selection clamps to All if a refresh shrinks the trip. Segment labels pass through unchanged — TripMap's `position + 1` adjacency guard already drops pairs a day filter separates, and the category-filter rule still empties them first.
- **`shared_trip_screen.dart`**: same pattern at its map; shared views default to **All** and get none of the Today behaviors.

## Tests

- `test/trip_detail_day_chips_test.dart` (new, fake-service pattern with real coords so a live TripMap mounts): chips render All + Day 1..N (no Day N+1, no Unscheduled); tapping **Day 2** narrows the mounted TripMap's `items` to day-2 items and `accommodations` to the covering stay; **All** restores; a day with nothing mappable shows "No mapped places on this day" while the chip row stays.
- `test/shared_trip_day_chips_test.dart` (new — no shared-trip widget test existed): chip presence, All default, day filtering + restore.
- `make flutter-test`: **136/136 pass**. `flutter analyze --no-fatal-infos --fatal-warnings`: exit 0 (12 known pre-existing infos, none added). `git diff --check` clean.

Today-chip preselection on live trips is deliberately left to PR 3, which owns the `_load`/today plumbing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)