### PR TITLE
feat: auto-compact long plan chats instead of rejecting them

### DIFF
--- a/specs/conversation-compaction/plan.md
+++ b/specs/conversation-compaction/plan.md
@@ -1,0 +1,108 @@
+# Plan: Conversation Compaction
+
+## Technical Approach
+
+Server-side compaction, done once per threshold crossing, with the result
+handed back to the client via a new SSE event so subsequent turns send the
+compacted form. The server rewrites `req.Messages` in place to
+`[summary-as-first-user-message] + last N messages` before the session is
+constructed, so everything downstream (Anthropic message building, the profile
+distiller reading `s.req.Messages`) works unchanged. The client keeps its full
+display transcript and tracks only `(compactedSummary, compactedCount)` used
+when projecting the wire history.
+
+Key decisions:
+- **Summarizer = one non-streamed forced-tool Haiku 4.5 call**
+  (`record_summary`, MaxTokens 1024), mirroring `profile_distiller.go` — no
+  preamble to parse, cheap (~$0.01–0.02), 1–3s.
+- **Threshold 24 / keep 10**: compaction fires roughly every 6 turns; the kept
+  window preserves ~5 verbatim exchanges for local coherence and always
+  contains the just-sent user message (makes retry safe by construction).
+- **`planMaxMessages` 40 → 60**: now purely a runaway/abuse backstop. Old
+  clients that ignore the new events get re-compacted server-side every turn
+  between 24 and 60 messages.
+- **Failure = proceed uncompacted** and log; never fail a turn the user is
+  waiting on. History is ≤ 60 messages so cost stays bounded.
+- Compaction *reduces* total spend — the original reason for the cap — because
+  a compacted ~13-message history is re-billed across up to 15 agent
+  iterations instead of a growing 40+.
+
+## Go API Changes
+
+`src/packages/api/`:
+
+- **New `plan_compactor.go`** (modeled on `profile_distiller.go`):
+  - `planCompactThreshold = 24`, `planCompactKeep = 10`,
+    `compactTimeout = 30s`, `compactMaxInputChars = 60000`.
+  - `summarizePlanConversation(ctx, client, prevSummary, older)` — forced-tool
+    Haiku call; system prompt requires preserving dates, cities/order,
+    travelers, chosen flights/ferries/stays, budget/pace/constraints, agreed
+    vs rejected places, itinerary-created state, open questions; never invent;
+    newest state wins; merge `prevSummary`; ≤ ~1,500 chars.
+  - `compactPlanMessages(ctx, client, msgs)` →
+    `(newMessages, summary, throughIndex, error)`;
+    `throughIndex = len(msgs) - planCompactKeep`; reuses the
+    `buildDistillationTranscript` flattening with oldest-first trim.
+  - Summary rendered as a first user message:
+    `"Summary of the conversation so far (earlier messages were removed to
+    save space — treat this as established context):\n\n" + summary`;
+    defensively rune-truncated to `planMaxMessageChars`.
+- **`plan_handler.go`:**
+  - `PlanRequest.Summary string` + rune-length validation.
+  - `planMaxMessages` → 60; comment block rewritten (threshold = UX lever,
+    cap = backstop). Existing guards stay first and unchanged in order.
+  - Compaction block runs **before** `session := &planSession{...}` (which
+    captures `req` by value — the ordering trap). At/above threshold: emit
+    `compacting`, call the compactor under `compactTimeout`; on success
+    replace `req.Messages`/`req.Summary` and emit `compacted`; on failure log
+    and proceed. Below threshold with a `summary`: just prepend the rendered
+    summary message.
+  - `plan_session_completed` instrumentation gains `compacted` /
+    `compaction_failed` bools.
+  - Prompt caching unaffected (only `messages` changes).
+
+## Flutter Changes
+
+`src/packages/flutter-app/lib/`:
+
+- **`services/plan_service.dart`:** `streamPlan` gains `String? summary`;
+  body includes `summary` when non-empty. (All test fakes overriding
+  `streamPlan` need signature updates.)
+- **`providers/plan_provider.dart`:**
+  - `PlanState` gains `String? compactedSummary` (sentinel copyWith),
+    `int compactedCount` (default 0), `bool isCompacting`. Scalars only —
+    no interaction with the chat-panel list invariants. `reset()` clears them.
+  - `_sendNow` sends `messages.sublist(compactedCount)` +
+    `summary: compactedSummary`.
+  - New cases: `compacting` → `isCompacting: true`; `compacted` → store
+    summary, `compactedCount += through_index` (clamped), clear
+    `isCompacting`. Also clear `isCompacting` on `error` and stream end (the
+    server sends no failure event).
+- **`widgets/chat_panel.dart`:** transient "Summarizing earlier conversation…"
+  chip via a narrow `select` on `isCompacting` (same pattern as tool chips).
+- No models/codegen: the wire additions are a plain string field and SSE
+  events handled as dynamic maps, like the rest of the plan protocol.
+
+## Contract Parity
+
+| JSON key | Go type | Dart side | Nullable? | ✓ |
+|----------|---------|-----------|-----------|---|
+| `summary` (request) | `string` (`omitempty` semantics via guard) | `String?` named param | yes | ☑ |
+| `compacted.summary` (SSE) | `string` | `event.data['summary'] as String?` | no | ☑ |
+| `compacted.through_index` (SSE) | `int` | `(event.data['through_index'] as num?)?.toInt()` | no | ☑ |
+
+## Cross-cutting
+
+- No new env vars; the compactor uses the existing `ANTHROPIC_API_KEY` client
+  and the `ANTHROPIC_BASE_URL` test seam.
+- No gateway changes (same endpoint).
+
+## Verification
+
+- `make api-fmt && make api-vet`; `cd src/packages/api && go test ./...`
+  (fake-Anthropic harness covers the compactor and integration paths).
+- `make flutter-analyze && make flutter-test`.
+- Cheap live E2E: 25 short scripted messages with a fact buried early; assert
+  `compacting`/`compacted` in the SSE stream and recall of the buried fact.
+- In-app: temporarily set `planCompactThreshold = 6`, `make docker-dev`
+  (API image rebuild), watch the chip and the shrinking request payload.

--- a/specs/conversation-compaction/spec.md
+++ b/specs/conversation-compaction/spec.md
@@ -1,0 +1,107 @@
+# Spec: Conversation Compaction
+
+## Context
+
+Long planning chats currently die with "This conversation is too long to
+continue. Please start a new chat to keep planning." — a hard cap on how many
+messages the planner accepts, added to bound cost (the whole history is
+re-billed on every agent step). Travelers hit it mid-trip, exactly when the
+conversation is most valuable, and "Try again" cannot recover because the
+transcript is still too long. Instead of forcing a new chat, the planner
+should automatically condense the older part of the conversation into a
+compact summary and keep going.
+
+## User Stories
+
+- As a **traveler deep into planning a trip**, I want **the chat to keep
+  working no matter how long the conversation gets** so that **I never lose my
+  planning context or have to start over**.
+- As a **traveler**, I want **decisions I made early in the chat (dates,
+  travelers, chosen flights, rejected ideas) to still be respected late in the
+  chat** so that **the assistant doesn't re-ask or contradict them**.
+- As the **operator**, I want **long conversations to cost less, not more**,
+  so that **the feature removes the cost problem the old cap papered over**.
+
+## Acceptance Criteria
+
+- [ ] A conversation that previously hit the "too long" error can continue
+      past that point with no user action.
+- [ ] When compaction happens, the full visible transcript is unchanged — the
+      user sees every message they and the assistant ever exchanged.
+- [ ] After compaction, the assistant still recalls decisions made in the
+      summarized portion (dates, traveler count, constraints, chosen options).
+- [ ] While the conversation is being summarized, the chat shows a brief
+      status indicator ("Summarizing earlier conversation…").
+- [ ] If summarization fails, the turn still completes normally (no error
+      shown; the system just tries again on a later turn).
+- [ ] Older app builds that don't understand compaction keep working for many
+      more turns than before (the server compacts on their behalf), and only
+      truly runaway conversations are rejected.
+
+## API Surface
+
+### `POST /api/v1/plan` (existing SSE endpoint — additions only)
+
+- **Request:** gains optional `summary` — the compacted context from earlier
+  turns, previously handed to the client by this endpoint. When present, the
+  server treats it as established conversation context preceding `messages`.
+  Rejected with a friendly error if it exceeds the per-message length limit.
+- **New SSE events:**
+  - `compacting` `{}` — emitted just before summarization starts (drives the
+    status indicator).
+  - `compacted` `{"summary": string, "through_index": int}` — emitted after a
+    successful compaction. `summary` replaces any summary the client held;
+    `through_index` is how many of the messages the client just sent are now
+    covered by the summary and must be excluded from future requests.
+- **Behavior:** when the incoming message count reaches the compaction
+  threshold, the server summarizes all but the most recent messages (merging
+  any incoming `summary`) before running the turn. The hard message cap
+  remains, raised, as a runaway/abuse backstop only.
+- **Errors:** unchanged, plus oversized `summary` → the existing friendly
+  "too long" style SSE error.
+
+## Data Model
+
+Nothing persisted. The summary lives in the client's in-memory chat state and
+travels with each request, like the rest of the transcript.
+
+## UI Behavior
+
+- **Surface:** the existing plan chat panel; no new screens.
+- **Happy path:** the user chats normally; around the threshold the
+  "Summarizing earlier conversation…" chip appears for a couple of seconds,
+  then the reply streams as usual. Subsequent turns are faster/cheaper because
+  the request carries a summary plus recent messages.
+- **States:** compacting (chip visible), normal streaming, error (existing
+  banner; compaction failure itself never surfaces as an error).
+
+## Edge Cases & Error States
+
+- Summarization call fails or times out → the turn proceeds on the full
+  (still-capped) history; the client's state is untouched; compaction retries
+  next turn.
+- The turn errors after compaction succeeded → the client keeps the new
+  summary state; retry benefits from it.
+- Retry ("Try again") after any error → resends the compacted projection; the
+  kept-recent window always includes the retried user message, so retry can
+  never cut into summarized history.
+- Messages queued while streaming → each send reads the compaction state
+  current at send time.
+- The long refinement seed message eventually falls into the summary; trip-
+  bound sessions re-read authoritative trip state via tools, so no special
+  casing.
+- The summary itself can never exceed the per-message limit (the server caps
+  and truncates its own output defensively).
+
+## Out of Scope
+
+- Persisting chat transcripts or summaries server-side.
+- Compacting based on token counts rather than message counts.
+- User-visible controls over compaction (manual "compact now", viewing the
+  summary).
+- Anthropic's server-side compaction beta (targets ~150K-token contexts and an
+  opaque block format; wrong scale and shape for this chat).
+
+## Open Questions
+
+None — resolved during planning.

--- a/specs/conversation-compaction/tasks.md
+++ b/specs/conversation-compaction/tasks.md
@@ -1,0 +1,38 @@
+# Tasks: Conversation Compaction
+
+> Dependency-ordered. `[P]` = can run in parallel with its siblings.
+
+## API (Go)
+
+- [ ] `plan_compactor.go`: constants, `summarizePlanConversation`,
+      `compactPlanMessages`, summary-message rendering, defensive truncation
+- [ ] `plan_compactor_test.go`: split/threshold logic, transcript trimming,
+      forced-tool call via fake-Anthropic, failure path (default non-tool answer)
+- [ ] `plan_handler.go`: `Summary` field + validation, `planMaxMessages` → 60,
+      compaction block **before** session construction, `compacting`/`compacted`
+      SSE events, instrumentation bools, comment rewrite
+- [ ] `plan_integration_test.go`: threshold crossing (events + wire shape),
+      summarizer failure (graceful), summary pass-through below threshold,
+      oversized summary rejection
+
+## UI (Flutter)
+
+- [ ] `plan_service.dart`: `summary` named param, body field; update fake
+      signatures in `plan_provider_stream_test.dart`,
+      `plan_provider_queue_test.dart`, `plan_service_error_test.dart`
+- [ ] `plan_provider.dart`: `compactedSummary`/`compactedCount`/`isCompacting`
+      state, `_sendNow` projection, `compacting`/`compacted` cases,
+      `isCompacting` cleared on error/stream end
+- [ ] `chat_panel.dart`: "Summarizing earlier conversation…" chip
+- [ ] `plan_provider_compaction_test.dart`: compacted-state update, next-send
+      projection, retry-after-error, queued-drain across boundary,
+      `isCompacting` lifecycle
+- [ ] `plan_service` body test: `summary` serialized when present, absent otherwise
+
+## Verification
+
+- [ ] `make api-fmt && make api-vet` clean
+- [ ] `cd src/packages/api && go test ./...` pass
+- [ ] `make flutter-analyze` clean, `make flutter-test` pass
+- [ ] Cheap live E2E (25 scripted messages, buried fact recalled) or in-app
+      check with `planCompactThreshold = 6` via `make docker-dev`

--- a/src/packages/api/plan_compactor.go
+++ b/src/packages/api/plan_compactor.go
@@ -1,0 +1,135 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	anthropic "github.com/anthropics/anthropic-sdk-go"
+)
+
+// plan_compactor.go — automatic conversation compaction for /api/v1/plan.
+//
+// When a chat's resent history reaches planCompactThreshold messages, the
+// handler folds everything but the newest planCompactKeep messages into a
+// short state summary via one cheap non-streamed Haiku call (same forced-tool
+// pattern as profile_distiller.go), then runs the turn on
+// [summary-as-first-user-message] + kept messages. The summary is streamed
+// back to the client (SSE `compacted`), which sends it as PlanRequest.Summary
+// on later turns instead of the folded messages — so each stretch of history
+// is summarized once, not per turn.
+
+const (
+	// planCompactThreshold triggers compaction; planCompactKeep messages stay
+	// verbatim. Each turn adds 2 wire messages, so post-compaction turns send
+	// 1 (summary) + 10 + 2 and compaction re-fires roughly every 6 turns. The
+	// keep window always contains the turn's own user message, which keeps the
+	// client's retry flow (drop last user message, resend) from ever cutting
+	// into summarized history.
+	planCompactThreshold = 24
+	planCompactKeep      = 10
+
+	// compactTimeout bounds the synchronous summarizer call — the traveler is
+	// watching the stream while it runs.
+	compactTimeout       = 30 * time.Second
+	compactMaxInputChars = 60000
+	compactToolName      = "record_summary"
+
+	compactSystemPrompt = "You compress the older part of a trip-planning conversation into a factual state summary so the planning agent can continue seamlessly. " +
+		"Call record_summary once. Preserve, when present: travel dates (exact YYYY-MM-DD) and how flexible they are; origin and destination cities and their order; the travelers (count, names, relationships); flights discussed and which one was CHOSEN (airline, price, times); ferries, trains, or accommodation chosen; budget level and pace; dietary, accessibility, and interest constraints; places already agreed into the itinerary and places explicitly rejected (with the reason); whether an itinerary was already created or saved; and open questions or decisions still pending. " +
+		"Never invent details, add suggestions, or editorialize. When the conversation contradicts itself, keep the most recent state. " +
+		"If a previous summary is provided, merge it in as prior established state, superseded only by newer messages. " +
+		"Format as short labeled bullet lines, under 1500 characters total."
+)
+
+// summaryAsMessage renders a compacted summary as the conversation's first
+// user message — the shape the model sees whether the summary was just
+// produced or arrived from the client on a later turn.
+func summaryAsMessage(summary string) PlanChatMessage {
+	return PlanChatMessage{
+		Role:    "user",
+		Content: "Summary of the conversation so far (earlier messages were removed to save space — treat this as established context):\n\n" + summary,
+	}
+}
+
+// summarizePlanConversation folds the given older messages (plus any previous
+// summary) into a new state summary with one non-streamed forced-tool Haiku
+// call.
+func summarizePlanConversation(ctx context.Context, client anthropic.Client, prevSummary string, older []PlanChatMessage) (string, error) {
+	text := buildDistillationTranscript(older, len(older), compactMaxInputChars)
+	if text == "" {
+		return "", fmt.Errorf("empty transcript")
+	}
+
+	system := compactSystemPrompt
+	if strings.TrimSpace(prevSummary) != "" {
+		system += "\n\nPrevious summary:\n" + strings.TrimSpace(prevSummary)
+	}
+
+	tool := anthropic.ToolParam{
+		Name:        compactToolName,
+		Description: anthropic.String("Record the compacted conversation summary."),
+		InputSchema: anthropic.ToolInputSchemaParam{
+			Properties: map[string]any{
+				"summary": map[string]any{"type": "string", "description": "The factual state summary as short labeled bullet lines"},
+			},
+			Required: []string{"summary"},
+		},
+	}
+
+	resp, err := client.Messages.New(ctx, anthropic.MessageNewParams{
+		Model:      anthropic.ModelClaudeHaiku4_5,
+		MaxTokens:  1024,
+		System:     []anthropic.TextBlockParam{{Text: system}},
+		Tools:      []anthropic.ToolUnionParam{{OfTool: &tool}},
+		ToolChoice: anthropic.ToolChoiceParamOfTool(compactToolName),
+		Messages: []anthropic.MessageParam{
+			anthropic.NewUserMessage(anthropic.NewTextBlock("Older conversation to summarize:\n\n" + text)),
+		},
+	})
+	if err != nil {
+		return "", err
+	}
+
+	for _, block := range resp.Content {
+		if variant, ok := block.AsAny().(anthropic.ToolUseBlock); ok && variant.Name == compactToolName {
+			var in struct {
+				Summary string `json:"summary"`
+			}
+			if err := json.Unmarshal(variant.Input, &in); err != nil {
+				return "", fmt.Errorf("parse tool input: %w", err)
+			}
+			summary := strings.TrimSpace(in.Summary)
+			if summary == "" {
+				return "", fmt.Errorf("model returned empty summary")
+			}
+			// Our own output must never trip the per-message guard next turn.
+			// Unreachable at MaxTokens 1024, but cheap to hold as an invariant.
+			if utf8.RuneCountInString(summary) > planMaxMessageChars {
+				summary = string([]rune(summary)[:planMaxMessageChars])
+			}
+			return summary, nil
+		}
+	}
+	return "", fmt.Errorf("no %s tool call in response", compactToolName)
+}
+
+// compactPlanMessages summarizes all but the newest planCompactKeep messages
+// (merging prevSummary) and returns the replacement wire history — the summary
+// rendered as the first user message, then the kept tail — along with the new
+// summary and how many incoming messages it folded away.
+func compactPlanMessages(ctx context.Context, client anthropic.Client, prevSummary string, msgs []PlanChatMessage) ([]PlanChatMessage, string, int, error) {
+	if len(msgs) <= planCompactKeep {
+		return msgs, "", 0, fmt.Errorf("nothing to compact: %d messages", len(msgs))
+	}
+	through := len(msgs) - planCompactKeep
+	summary, err := summarizePlanConversation(ctx, client, prevSummary, msgs[:through])
+	if err != nil {
+		return msgs, "", 0, err
+	}
+	newMsgs := append([]PlanChatMessage{summaryAsMessage(summary)}, msgs[through:]...)
+	return newMsgs, summary, through, nil
+}

--- a/src/packages/api/plan_compactor_test.go
+++ b/src/packages/api/plan_compactor_test.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func compactorTestMessages(n int) []PlanChatMessage {
+	msgs := make([]PlanChatMessage, n)
+	for i := range msgs {
+		role := "user"
+		if i%2 == 1 {
+			role = "assistant"
+		}
+		msgs[i] = PlanChatMessage{Role: role, Content: fmt.Sprintf("message %d", i)}
+	}
+	return msgs
+}
+
+func TestSummaryAsMessage(t *testing.T) {
+	m := summaryAsMessage("- 3 travelers")
+	if m.Role != "user" {
+		t.Fatalf("role = %q, want user", m.Role)
+	}
+	if !strings.HasPrefix(m.Content, "Summary of the conversation so far") {
+		t.Fatalf("content missing summary preamble: %q", m.Content)
+	}
+	if !strings.HasSuffix(m.Content, "- 3 travelers") {
+		t.Fatalf("content missing summary body: %q", m.Content)
+	}
+}
+
+func TestCompactPlanMessagesFoldsAllButKeepWindow(t *testing.T) {
+	fa := newFakeAnthropic(t)
+	fa.scriptNonStreamingTool(compactToolName, `{"summary":"- travelers: 3, one vegetarian"}`)
+	client := newAnthropicClient("test-key")
+
+	msgs := compactorTestMessages(planCompactThreshold)
+	newMsgs, summary, through, err := compactPlanMessages(context.Background(), client, "", msgs)
+	if err != nil {
+		t.Fatalf("compactPlanMessages: %v", err)
+	}
+	if summary != "- travelers: 3, one vegetarian" {
+		t.Fatalf("summary = %q", summary)
+	}
+	if want := planCompactThreshold - planCompactKeep; through != want {
+		t.Fatalf("through = %d, want %d", through, want)
+	}
+	if len(newMsgs) != planCompactKeep+1 {
+		t.Fatalf("len(newMsgs) = %d, want %d", len(newMsgs), planCompactKeep+1)
+	}
+	if !strings.HasPrefix(newMsgs[0].Content, "Summary of the conversation so far") {
+		t.Fatalf("newMsgs[0] is not the summary message: %q", newMsgs[0].Content)
+	}
+	if got, want := newMsgs[1].Content, msgs[through].Content; got != want {
+		t.Fatalf("first kept message = %q, want %q", got, want)
+	}
+	if got, want := newMsgs[len(newMsgs)-1].Content, msgs[len(msgs)-1].Content; got != want {
+		t.Fatalf("last kept message = %q, want %q", got, want)
+	}
+}
+
+func TestCompactPlanMessagesSendsOlderMessagesAndPrevSummary(t *testing.T) {
+	fa := newFakeAnthropic(t)
+	fa.scriptNonStreamingTool(compactToolName, `{"summary":"- merged"}`)
+	client := newAnthropicClient("test-key")
+
+	msgs := compactorTestMessages(planCompactThreshold)
+	if _, _, _, err := compactPlanMessages(context.Background(), client, "- prior state: Lisbon chosen", msgs); err != nil {
+		t.Fatalf("compactPlanMessages: %v", err)
+	}
+
+	bodies := fa.requestBodies()
+	if len(bodies) != 1 {
+		t.Fatalf("expected 1 summarizer call, got %d", len(bodies))
+	}
+	body := string(bodies[0])
+	if !strings.Contains(body, "Previous summary:") || !strings.Contains(body, "prior state: Lisbon chosen") {
+		t.Fatalf("summarizer system prompt missing previous summary: %s", body)
+	}
+	// Only the folded messages go to the summarizer; the keep window stays out.
+	if !strings.Contains(body, "message 0") || !strings.Contains(body, fmt.Sprintf("message %d", planCompactThreshold-planCompactKeep-1)) {
+		t.Fatalf("summarizer transcript missing folded messages: %s", body)
+	}
+	if strings.Contains(body, fmt.Sprintf("message %d", planCompactThreshold-planCompactKeep)) {
+		t.Fatalf("summarizer transcript should not include kept messages: %s", body)
+	}
+}
+
+func TestCompactPlanMessagesFailsWhenModelReturnsNoToolCall(t *testing.T) {
+	// The fake's default non-streaming answer is text-only — the forced-tool
+	// caller finds no record_summary block, which is the failure path.
+	newFakeAnthropic(t)
+	client := newAnthropicClient("test-key")
+
+	msgs := compactorTestMessages(planCompactThreshold)
+	newMsgs, _, _, err := compactPlanMessages(context.Background(), client, "", msgs)
+	if err == nil {
+		t.Fatal("expected error when no tool call is returned")
+	}
+	if len(newMsgs) != len(msgs) {
+		t.Fatalf("messages must be returned unchanged on failure: got %d, want %d", len(newMsgs), len(msgs))
+	}
+}
+
+func TestCompactPlanMessagesRefusesTinyHistories(t *testing.T) {
+	newFakeAnthropic(t)
+	client := newAnthropicClient("test-key")
+	msgs := compactorTestMessages(planCompactKeep)
+	if _, _, _, err := compactPlanMessages(context.Background(), client, "", msgs); err == nil {
+		t.Fatal("expected error when history fits in the keep window")
+	}
+}
+
+func TestSummarizePlanConversationTruncatesOversizedSummary(t *testing.T) {
+	fa := newFakeAnthropic(t)
+	huge := strings.Repeat("s", planMaxMessageChars+50)
+	fa.scriptNonStreamingTool(compactToolName, fmt.Sprintf(`{"summary":%q}`, huge))
+	client := newAnthropicClient("test-key")
+
+	summary, err := summarizePlanConversation(context.Background(), client, "", compactorTestMessages(4))
+	if err != nil {
+		t.Fatalf("summarizePlanConversation: %v", err)
+	}
+	if got := len([]rune(summary)); got != planMaxMessageChars {
+		t.Fatalf("summary rune length = %d, want %d", got, planMaxMessageChars)
+	}
+}
+
+func TestSummarizePlanConversationRejectsEmptySummary(t *testing.T) {
+	fa := newFakeAnthropic(t)
+	fa.scriptNonStreamingTool(compactToolName, `{"summary":"   "}`)
+	client := newAnthropicClient("test-key")
+
+	if _, err := summarizePlanConversation(context.Background(), client, "", compactorTestMessages(4)); err == nil {
+		t.Fatal("expected error for blank summary")
+	}
+}

--- a/src/packages/api/plan_handler.go
+++ b/src/packages/api/plan_handler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log"
 	"net/http"
 	"os"
 	"strings"
@@ -24,19 +25,26 @@ const planMaxIterations = 15
 
 // planMaxMessages / planMaxMessageChars bound the resent conversation history.
 // Every agent-loop iteration (up to planMaxIterations) re-pays input tokens on
-// the full history, so an unbounded history multiplies token cost by up to
-// 15x. Both caps sit far above anything the Flutter chat UI produces (a few
-// dozen short turns, plus one long itinerary-context first message on refine);
-// hitting them means a runaway or abusive client. Violations return a friendly
-// SSE `error` event, not a 500.
+// the full history, so these bounds are a hard cost lever. The working limit
+// is compaction (plan_compactor.go): histories reaching planCompactThreshold
+// are summarized down before the turn runs, and an updated client keeps its
+// wire history small by resending the summary instead of the folded messages.
+// planMaxMessages is only the backstop above that — old clients that ignore
+// the compaction events get re-compacted server-side every turn until this
+// cap, so hitting it means a runaway or abusive client. Violations return a
+// friendly SSE `error` event, not a 500.
 const (
-	planMaxMessages     = 40
+	planMaxMessages     = 60
 	planMaxMessageChars = 20000
 )
 
 type PlanRequest struct {
 	Messages []PlanChatMessage `json:"messages"`
-	ChatID   string            `json:"chat_id"`
+	// Summary is the compacted context from earlier turns, previously handed to
+	// the client via the `compacted` SSE event; it stands in for the messages it
+	// folded away and precedes Messages as established context.
+	Summary string `json:"summary"`
+	ChatID  string `json:"chat_id"`
 	// TripID binds the session to an existing saved trip: the agent then refines
 	// that trip in place (update_itinerary_section) and can never create a new
 	// trip version. Requires an authenticated owner.
@@ -82,6 +90,10 @@ func planHandler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
+	if utf8.RuneCountInString(req.Summary) > planMaxMessageChars {
+		sendSSE(w, "error", map[string]string{"message": "This conversation is too long to continue. Please start a new chat to keep planning."})
+		return
+	}
 
 	apiKey := os.Getenv("ANTHROPIC_API_KEY")
 	if apiKey == "" {
@@ -95,6 +107,35 @@ func planHandler(w http.ResponseWriter, r *http.Request) {
 	// preference-writing tool; signed-in sessions get both.
 	uid, authed := userIDFromRequest(r)
 	ctx := r.Context()
+
+	// Compaction must rewrite req.Messages BEFORE the session below captures
+	// req by value (the profile distiller reads session.req.Messages). On
+	// threshold, fold the older messages into a summary and hand it back to
+	// the client (`compacted`), which resends it as req.Summary instead of the
+	// folded messages — so each stretch of history is summarized once. A
+	// summarizer failure is never surfaced: the turn proceeds on the full
+	// (≤ planMaxMessages) history and compaction retries next turn.
+	var planCompacted, planCompactFailed bool
+	if len(req.Messages) >= planCompactThreshold {
+		sendSSE(w, "compacting", map[string]string{})
+		cctx, cancel := context.WithTimeout(ctx, compactTimeout)
+		newMsgs, summary, through, err := compactPlanMessages(cctx, client, req.Summary, req.Messages)
+		cancel()
+		if err != nil {
+			log.Printf("plan compact: %v", err)
+			planCompactFailed = true
+			if strings.TrimSpace(req.Summary) != "" {
+				req.Messages = append([]PlanChatMessage{summaryAsMessage(req.Summary)}, req.Messages...)
+			}
+		} else {
+			req.Messages = newMsgs
+			req.Summary = summary
+			planCompacted = true
+			sendSSE(w, "compacted", map[string]any{"summary": summary, "through_index": through})
+		}
+	} else if strings.TrimSpace(req.Summary) != "" {
+		req.Messages = append([]PlanChatMessage{summaryAsMessage(req.Summary)}, req.Messages...)
+	}
 
 	// session carries the per-request state the tool dispatchers need
 	// (plan_tool_registry.go) and the outcomes read back below: the persisted
@@ -134,6 +175,8 @@ func planHandler(w http.ResponseWriter, r *http.Request) {
 			"max_iterations_hit":    planCapHit,
 			"cache_read_tokens":     planCacheRead,
 			"cache_creation_tokens": planCacheWrite,
+			"compacted":             planCompacted,
+			"compaction_failed":     planCompactFailed,
 		})
 	}()
 

--- a/src/packages/api/plan_handler_test.go
+++ b/src/packages/api/plan_handler_test.go
@@ -103,6 +103,21 @@ func TestPlanHandlerRejectsOversizedMessage(t *testing.T) {
 	}
 }
 
+func TestPlanHandlerRejectsOversizedSummary(t *testing.T) {
+	rec := runPlanHandler(t, PlanRequest{
+		Summary:  strings.Repeat("a", planMaxMessageChars+1),
+		Messages: []PlanChatMessage{{Role: "user", Content: "hi"}},
+	})
+
+	out := rec.Body.String()
+	if !strings.Contains(out, `"type":"error"`) || !strings.Contains(out, "too long") {
+		t.Fatalf("stream = %q, want an SSE error event about an oversized summary", out)
+	}
+	if strings.Count(out, "data: ") != 1 {
+		t.Fatalf("stream = %q, want exactly one event", out)
+	}
+}
+
 func TestNotesPreview(t *testing.T) {
 	if got := notesPreview(nil); got != "" {
 		t.Fatalf("preview = %q, want empty for nil", got)

--- a/src/packages/api/plan_integration_test.go
+++ b/src/packages/api/plan_integration_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"strings"
 	"testing"
@@ -346,5 +347,182 @@ func TestLocalIngestUnverifiedDraftCannotPublish(t *testing.T) {
 	}
 	if status != "draft" {
 		t.Fatalf("status after blocked publish = %q, want draft", status)
+	}
+}
+
+// anthropicRequests splits the fake's captured bodies into (nonStreaming,
+// streaming) parsed request payloads, in arrival order.
+func anthropicRequests(t *testing.T, fa *fakeAnthropic) (nonStreaming, streaming []map[string]any) {
+	t.Helper()
+	for _, body := range fa.requestBodies() {
+		var m map[string]any
+		if err := json.Unmarshal(body, &m); err != nil {
+			t.Fatalf("unparseable fake-anthropic request: %v", err)
+		}
+		if s, _ := m["stream"].(bool); s {
+			streaming = append(streaming, m)
+		} else {
+			nonStreaming = append(nonStreaming, m)
+		}
+	}
+	return nonStreaming, streaming
+}
+
+// firstMessageText extracts the text of the first message in a parsed
+// /v1/messages request body (string or single-text-block content).
+func firstMessageText(t *testing.T, req map[string]any) string {
+	t.Helper()
+	msgs, _ := req["messages"].([]any)
+	if len(msgs) == 0 {
+		t.Fatal("request has no messages")
+	}
+	m, _ := msgs[0].(map[string]any)
+	switch c := m["content"].(type) {
+	case string:
+		return c
+	case []any:
+		if len(c) > 0 {
+			if block, ok := c[0].(map[string]any); ok {
+				if txt, ok := block["text"].(string); ok {
+					return txt
+				}
+			}
+		}
+	}
+	t.Fatalf("first message has no text content: %v", m)
+	return ""
+}
+
+func longPlanConversation(n int) []PlanChatMessage {
+	msgs := make([]PlanChatMessage, n)
+	for i := range msgs {
+		role, text := "user", fmt.Sprintf("user turn %d", i)
+		if i%2 == 1 {
+			role, text = "assistant", fmt.Sprintf("assistant turn %d", i)
+		}
+		msgs[i] = PlanChatMessage{Role: role, Content: text}
+	}
+	return msgs
+}
+
+// (f) Compaction: a history at the threshold gets summarized before the turn.
+// The stream carries `compacting` then `compacted` (summary + how many wire
+// messages it folded), and the model sees [summary message + kept tail], not
+// the full history.
+func TestPlanCompactsLongConversation(t *testing.T) {
+	resetDB(t)
+	fa := newFakeAnthropic(t, textTurn("Got it — picking up where we left off."))
+	fa.scriptNonStreamingTool(compactToolName, `{"summary":"- travelers: 3, one vegetarian\n- dates: 2026-07-23 to 2026-07-30"}`)
+
+	rec := doJSON(t, "POST", "/api/v1/plan", "", PlanRequest{
+		ChatID:   "chat-compact",
+		Messages: longPlanConversation(planCompactThreshold),
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("/plan = %d, want 200", rec.Code)
+	}
+	events := planEvents(t, rec.Body.String())
+
+	if got := len(eventsOfType(events, "compacting")); got != 1 {
+		t.Fatalf("compacting events = %d, want 1", got)
+	}
+	compacted := eventsOfType(events, "compacted")
+	if len(compacted) != 1 {
+		t.Fatalf("compacted events = %d, want 1", len(compacted))
+	}
+	data := eventData(compacted[0])
+	if s, _ := data["summary"].(string); !strings.Contains(s, "travelers: 3") {
+		t.Fatalf("compacted summary = %v", data["summary"])
+	}
+	wantThrough := float64(planCompactThreshold - planCompactKeep)
+	if data["through_index"] != wantThrough {
+		t.Fatalf("through_index = %v, want %v", data["through_index"], wantThrough)
+	}
+	if errs := eventsOfType(events, "error"); len(errs) != 0 {
+		t.Fatalf("unexpected error events: %v", errs)
+	}
+
+	nonStreaming, streaming := anthropicRequests(t, fa)
+	if len(nonStreaming) != 1 || len(streaming) != 1 {
+		t.Fatalf("model requests = %d non-streaming / %d streaming, want 1/1", len(nonStreaming), len(streaming))
+	}
+	msgs, _ := streaming[0]["messages"].([]any)
+	if len(msgs) != 1+planCompactKeep {
+		t.Fatalf("streamed request messages = %d, want %d (summary + keep window)", len(msgs), 1+planCompactKeep)
+	}
+	first := firstMessageText(t, streaming[0])
+	if !strings.HasPrefix(first, "Summary of the conversation so far") || !strings.Contains(first, "travelers: 3") {
+		t.Fatalf("first streamed message is not the summary: %q", first)
+	}
+}
+
+// (g) Compaction failure is invisible: when the summarizer returns no tool
+// call (the fake's default non-streaming answer), the turn proceeds on the
+// full history with no error and no compacted event.
+func TestPlanCompactionFailureFallsBackToFullHistory(t *testing.T) {
+	resetDB(t)
+	fa := newFakeAnthropic(t, textTurn("Continuing without compaction."))
+
+	msgs := longPlanConversation(planCompactThreshold)
+	rec := doJSON(t, "POST", "/api/v1/plan", "", PlanRequest{ChatID: "chat-compact-fail", Messages: msgs})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("/plan = %d, want 200", rec.Code)
+	}
+	events := planEvents(t, rec.Body.String())
+
+	if got := len(eventsOfType(events, "compacted")); got != 0 {
+		t.Fatalf("compacted events = %d, want 0 on summarizer failure", got)
+	}
+	if errs := eventsOfType(events, "error"); len(errs) != 0 {
+		t.Fatalf("compaction failure must not surface an error: %v", errs)
+	}
+	if got := joinedText(events); got != "Continuing without compaction." {
+		t.Fatalf("final text = %q", got)
+	}
+
+	_, streaming := anthropicRequests(t, fa)
+	if len(streaming) != 1 {
+		t.Fatalf("streaming requests = %d, want 1", len(streaming))
+	}
+	if got, _ := streaming[0]["messages"].([]any); len(got) != len(msgs) {
+		t.Fatalf("streamed request messages = %d, want the full %d on fallback", len(got), len(msgs))
+	}
+}
+
+// (h) A client-held summary below the threshold is prepended as established
+// context with no summarizer call.
+func TestPlanSummaryPrependedBelowThreshold(t *testing.T) {
+	resetDB(t)
+	fa := newFakeAnthropic(t, textTurn("Right — three of you, one vegetarian."))
+
+	rec := doJSON(t, "POST", "/api/v1/plan", "", PlanRequest{
+		ChatID:  "chat-summary",
+		Summary: "- travelers: 3, one vegetarian",
+		Messages: []PlanChatMessage{
+			{Role: "user", Content: "remind me of our group's constraints"},
+		},
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("/plan = %d, want 200", rec.Code)
+	}
+	events := planEvents(t, rec.Body.String())
+	if got := len(eventsOfType(events, "compacting")); got != 0 {
+		t.Fatalf("compacting events = %d, want 0 below threshold", got)
+	}
+	if errs := eventsOfType(events, "error"); len(errs) != 0 {
+		t.Fatalf("unexpected error events: %v", errs)
+	}
+
+	nonStreaming, streaming := anthropicRequests(t, fa)
+	if len(nonStreaming) != 0 || len(streaming) != 1 {
+		t.Fatalf("model requests = %d non-streaming / %d streaming, want 0/1", len(nonStreaming), len(streaming))
+	}
+	msgs, _ := streaming[0]["messages"].([]any)
+	if len(msgs) != 2 {
+		t.Fatalf("streamed request messages = %d, want 2 (summary + user turn)", len(msgs))
+	}
+	first := firstMessageText(t, streaming[0])
+	if !strings.HasPrefix(first, "Summary of the conversation so far") || !strings.Contains(first, "one vegetarian") {
+		t.Fatalf("first streamed message is not the summary: %q", first)
 	}
 }

--- a/src/packages/flutter-app/lib/providers/plan_provider.dart
+++ b/src/packages/flutter-app/lib/providers/plan_provider.dart
@@ -60,6 +60,20 @@ class PlanState {
   /// unlike [tripUpdateCount] it is not monotonic.
   final bool tripUpdatedThisTurn;
 
+  /// Server-produced summary of the conversation's compacted-away prefix
+  /// (SSE `compacted`). Sent back as the request's `summary` so the server
+  /// doesn't re-summarize; the visible transcript is never touched.
+  final String? compactedSummary;
+
+  /// How many leading [messages] are covered by [compactedSummary] and must be
+  /// excluded from the wire history. Start-anchored, so appends never shift it.
+  final int compactedCount;
+
+  /// Whether the server is currently summarizing the conversation (between
+  /// SSE `compacting` and the first event that follows it) — drives the
+  /// transient "Summarizing earlier conversation…" chip.
+  final bool isCompacting;
+
   const PlanState({
     this.messages = const [],
     this.isStreaming = false,
@@ -83,6 +97,9 @@ class PlanState {
     this.profileUpdateNote,
     this.tripUpdateCount = 0,
     this.tripUpdatedThisTurn = false,
+    this.compactedSummary,
+    this.compactedCount = 0,
+    this.isCompacting = false,
   });
 
   PlanState copyWith({
@@ -108,6 +125,9 @@ class PlanState {
     Object? profileUpdateNote = _sentinel,
     int? tripUpdateCount,
     bool? tripUpdatedThisTurn,
+    Object? compactedSummary = _sentinel,
+    int? compactedCount,
+    bool? isCompacting,
   }) {
     return PlanState(
       messages: messages ?? this.messages,
@@ -135,6 +155,10 @@ class PlanState {
           profileUpdateNote == _sentinel ? this.profileUpdateNote : profileUpdateNote as String?,
       tripUpdateCount: tripUpdateCount ?? this.tripUpdateCount,
       tripUpdatedThisTurn: tripUpdatedThisTurn ?? this.tripUpdatedThisTurn,
+      compactedSummary:
+          compactedSummary == _sentinel ? this.compactedSummary : compactedSummary as String?,
+      compactedCount: compactedCount ?? this.compactedCount,
+      isCompacting: isCompacting ?? this.isCompacting,
     );
   }
 }
@@ -282,7 +306,10 @@ class PlanNotifier extends StateNotifier<PlanState> {
       tripUpdatedThisTurn: false,
     );
 
+    // Messages covered by the compacted summary stay visible but leave the
+    // wire history — the summary stands in for them server-side.
     final history = updatedMessages
+        .sublist(state.compactedCount.clamp(0, updatedMessages.length))
         .map((m) => {'role': m.role == MessageRole.user ? 'user' : 'assistant', 'content': m.content})
         .toList();
 
@@ -291,10 +318,19 @@ class PlanNotifier extends StateNotifier<PlanState> {
 
     try {
       await for (final event in _service.streamPlan(history,
-          bearerToken: _apiClient.authToken, chatId: _chatId, tripId: tripId)) {
+          bearerToken: _apiClient.authToken,
+          chatId: _chatId,
+          tripId: tripId,
+          summary: state.compactedSummary)) {
         // Keep buffered text ahead of any other state transition so tool chips
         // and results never appear before the text that introduced them.
         if (event.type != 'text_delta') _flushStreamText();
+
+        // A failed compaction sends no `compacted` terminator — whatever event
+        // follows `compacting` ends the chip.
+        if (state.isCompacting && event.type != 'compacting') {
+          state = state.copyWith(isCompacting: false);
+        }
 
         switch (event.type) {
           case 'text_delta':
@@ -329,6 +365,23 @@ class PlanNotifier extends StateNotifier<PlanState> {
           case 'profile_updated':
             state = state.copyWith(
                 profileUpdateNote: event.data['notes_preview'] as String? ?? '');
+
+          case 'compacting':
+            state = state.copyWith(isCompacting: true);
+
+          case 'compacted':
+            // through_index counts wire messages, and the wire history was
+            // exactly messages.sublist(compactedCount) at send time — so the
+            // new boundary is the old one advanced by through_index.
+            final through =
+                (event.data['through_index'] as num?)?.toInt() ?? 0;
+            state = state.copyWith(
+              isCompacting: false,
+              compactedSummary:
+                  event.data['summary'] as String? ?? state.compactedSummary,
+              compactedCount: (state.compactedCount + through)
+                  .clamp(0, state.messages.length),
+            );
 
           case 'flights':
             final raw = event.data['offers'] as List<dynamic>? ?? [];
@@ -395,6 +448,7 @@ class PlanNotifier extends StateNotifier<PlanState> {
               isStreaming: false,
               streamingText: null,
               activeTools: [],
+              isCompacting: false,
               messages: partial.isEmpty
                   ? state.messages
                   : [
@@ -426,6 +480,7 @@ class PlanNotifier extends StateNotifier<PlanState> {
         isStreaming: false,
         streamingText: null,
         activeTools: [],
+        isCompacting: false,
       );
 
       // Success is the only drain point: after an error the queue stays put
@@ -438,6 +493,7 @@ class PlanNotifier extends StateNotifier<PlanState> {
         isStreaming: false,
         streamingText: null,
         activeTools: [],
+        isCompacting: false,
         error: e.toString(),
       );
     }

--- a/src/packages/flutter-app/lib/services/plan_service.dart
+++ b/src/packages/flutter-app/lib/services/plan_service.dart
@@ -25,6 +25,7 @@ class PlanService {
     String? bearerToken,
     String? chatId,
     String? tripId,
+    String? summary,
   }) async* {
     final request = http.Request('POST', Uri.parse('$baseUrl/plan'));
     request.headers['Content-Type'] = 'application/json';
@@ -35,6 +36,7 @@ class PlanService {
       'messages': messages,
       if (chatId != null) 'chat_id': chatId,
       if (tripId != null) 'trip_id': tripId,
+      if (summary != null && summary.isNotEmpty) 'summary': summary,
     });
 
     final client = _newClient();

--- a/src/packages/flutter-app/lib/widgets/chat_panel.dart
+++ b/src/packages/flutter-app/lib/widgets/chat_panel.dart
@@ -190,6 +190,8 @@ class _ChatTail extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
+        // Compaction runs before the model call, so its chip leads the tail.
+        _CompactingChip(state: state),
         _StreamingBubble(state: state),
         _ActiveToolChips(state: state),
         _ProfileNoteChip(state: state),
@@ -266,6 +268,35 @@ class _ActiveToolChips extends ConsumerWidget {
       default:
         return '$tool...';
     }
+  }
+}
+
+/// Transient indicator that the server is summarizing the conversation's
+/// older messages before this turn (SSE `compacting`); cleared by whatever
+/// event follows.
+class _CompactingChip extends ConsumerWidget {
+  final ProviderListenable<PlanState> state;
+
+  const _CompactingChip({required this.state});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final compacting = ref.watch(state.select((s) => s.isCompacting));
+    if (!compacting) return const SizedBox.shrink();
+    return const Padding(
+      padding: EdgeInsets.symmetric(vertical: 8),
+      child: Align(
+        alignment: Alignment.centerLeft,
+        child: Chip(
+          avatar: SizedBox(
+            width: 16,
+            height: 16,
+            child: CircularProgressIndicator(strokeWidth: 2),
+          ),
+          label: Text('Summarizing earlier conversation…'),
+        ),
+      ),
+    );
   }
 }
 

--- a/src/packages/flutter-app/test/chat_panel_queue_test.dart
+++ b/src/packages/flutter-app/test/chat_panel_queue_test.dart
@@ -25,6 +25,7 @@ class _GatedPlanService extends PlanService {
     String? bearerToken,
     String? chatId,
     String? tripId,
+    String? summary,
   }) async* {
     final call = calls++;
     yield PlanEvent(type: 'text_delta', data: {'text': 'reply $call'});

--- a/src/packages/flutter-app/test/chat_panel_seed_chip_test.dart
+++ b/src/packages/flutter-app/test/chat_panel_seed_chip_test.dart
@@ -19,6 +19,7 @@ class _ScriptedPlanService extends PlanService {
     String? bearerToken,
     String? chatId,
     String? tripId,
+    String? summary,
   }) async* {
     for (final e in events) {
       yield e;

--- a/src/packages/flutter-app/test/plan_provider_compaction_test.dart
+++ b/src/packages/flutter-app/test/plan_provider_compaction_test.dart
@@ -1,0 +1,182 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:travel_route_planner/providers/plan_provider.dart';
+import 'package:travel_route_planner/services/api_client.dart';
+import 'package:travel_route_planner/services/plan_service.dart';
+
+/// Replays a scripted event list per call and records every request's history
+/// and summary — the seam for asserting the compacted wire projection.
+class _CompactionPlanService extends PlanService {
+  /// Script consumed one list per call; the last list repeats when exhausted.
+  final List<List<PlanEvent>> scripts;
+  final List<List<Map<String, String>>> histories = [];
+  final List<String?> summaries = [];
+
+  /// Consumed by the next call: the stream parks on it after its first event.
+  Completer<void>? gate;
+
+  _CompactionPlanService(this.scripts) : super('http://unused');
+
+  @override
+  Stream<PlanEvent> streamPlan(
+    List<Map<String, String>> messages, {
+    String? bearerToken,
+    String? chatId,
+    String? tripId,
+    String? summary,
+  }) async* {
+    final call = histories.length;
+    histories.add(List.of(messages));
+    summaries.add(summary);
+    final events = scripts[call < scripts.length ? call : scripts.length - 1];
+    var first = true;
+    for (final e in events) {
+      yield e;
+      if (first) {
+        first = false;
+        final parked = gate;
+        gate = null;
+        if (parked != null) await parked.future;
+      }
+    }
+  }
+}
+
+PlanEvent _compacted(String summary, int through) => PlanEvent(
+    type: 'compacted', data: {'summary': summary, 'through_index': through});
+
+const _compacting = PlanEvent(type: 'compacting', data: {});
+
+PlanEvent _delta(String text) =>
+    PlanEvent(type: 'text_delta', data: {'text': text});
+
+void main() {
+  test('compacted event stores the summary and advances the wire boundary',
+      () async {
+    final service = _CompactionPlanService([
+      [_delta('a1')],
+      [_delta('a2')],
+      [
+        _compacting,
+        _compacted('- travelers: 3', 4), // folds all 4 pre-send messages
+        _delta('a3'),
+      ],
+      [_delta('a4')],
+    ]);
+    final notifier = PlanNotifier(service, ApiClient());
+
+    await notifier.sendMessage('u1');
+    await notifier.sendMessage('u2');
+    expect(service.summaries, [null, null]);
+
+    await notifier.sendMessage('u3');
+    expect(notifier.state.compactedSummary, '- travelers: 3');
+    expect(notifier.state.compactedCount, 4);
+    expect(notifier.state.isCompacting, isFalse);
+    // Display transcript is untouched: 3 user + 3 assistant messages.
+    expect(notifier.state.messages, hasLength(6));
+
+    // Next send projects: summary carried, covered prefix excluded.
+    await notifier.sendMessage('u4');
+    expect(service.summaries.last, '- travelers: 3');
+    expect(
+      service.histories.last.map((m) => m['content']).toList(),
+      ['u3', 'a3', 'u4'],
+    );
+  });
+
+  test('compacting toggles the chip on and the next event clears it',
+      () async {
+    final service = _CompactionPlanService([
+      [_compacting, _delta('reply')],
+    ]);
+    final notifier = PlanNotifier(service, ApiClient());
+
+    final gate = Completer<void>();
+    service.gate = gate;
+    final send = notifier.sendMessage('hello');
+    await Future<void>.delayed(Duration.zero);
+    expect(notifier.state.isCompacting, isTrue);
+
+    gate.complete();
+    await send;
+    expect(notifier.state.isCompacting, isFalse);
+    // No compacted event followed (failed compaction): state untouched.
+    expect(notifier.state.compactedSummary, isNull);
+    expect(notifier.state.compactedCount, 0);
+  });
+
+  test('error after compacted keeps the advanced state; retry resends the '
+      'compacted projection', () async {
+    final service = _CompactionPlanService([
+      [_delta('a1')],
+      [
+        _compacting,
+        _compacted('- summary', 2),
+        const PlanEvent(type: 'error', data: {'message': 'boom'}),
+      ],
+      [_delta('recovered')],
+    ]);
+    final notifier = PlanNotifier(service, ApiClient());
+
+    await notifier.sendMessage('u1');
+    await notifier.sendMessage('u2');
+    expect(notifier.state.error, 'boom');
+    expect(notifier.state.compactedCount, 2);
+
+    await notifier.retryLastSend();
+    expect(notifier.state.error, isNull);
+    expect(service.summaries.last, '- summary');
+    // The retried turn resends only the uncovered tail: just 'u2'.
+    expect(
+      service.histories.last.map((m) => m['content']).toList(),
+      ['u2'],
+    );
+    expect(notifier.state.messages.last.content, 'recovered');
+  });
+
+  test('queued message drained after a compaction uses the new boundary',
+      () async {
+    final service = _CompactionPlanService([
+      [
+        _compacting,
+        _compacted('- state', 1), // folds the sole pre-send user message
+        _delta('a1'),
+      ],
+      [_delta('a2')],
+    ]);
+    final notifier = PlanNotifier(service, ApiClient());
+
+    final gate = Completer<void>();
+    service.gate = gate;
+    final first = notifier.sendMessage('u1');
+    await notifier.sendMessage('u2'); // queued mid-stream
+    gate.complete();
+    await first;
+
+    expect(service.histories, hasLength(2));
+    expect(service.summaries.last, '- state');
+    // u1 is covered by the summary; the drained send carries a1 + u2 only.
+    expect(
+      service.histories.last.map((m) => m['content']).toList(),
+      ['a1', 'u2'],
+    );
+    expect(notifier.state.messages.map((m) => m.content).toList(),
+        ['u1', 'a1', 'u2', 'a2']);
+  });
+
+  test('reset clears compaction state', () async {
+    final service = _CompactionPlanService([
+      [_compacting, _compacted('- s', 1), _delta('a')],
+    ]);
+    final notifier = PlanNotifier(service, ApiClient());
+    await notifier.sendMessage('u1');
+    expect(notifier.state.compactedCount, 1);
+
+    notifier.reset();
+    expect(notifier.state.compactedSummary, isNull);
+    expect(notifier.state.compactedCount, 0);
+    expect(notifier.state.isCompacting, isFalse);
+  });
+}

--- a/src/packages/flutter-app/test/plan_provider_queue_test.dart
+++ b/src/packages/flutter-app/test/plan_provider_queue_test.dart
@@ -26,6 +26,7 @@ class _GatedPlanService extends PlanService {
     String? bearerToken,
     String? chatId,
     String? tripId,
+    String? summary,
   }) async* {
     final call = histories.length;
     histories.add(List.of(messages));

--- a/src/packages/flutter-app/test/plan_provider_stream_test.dart
+++ b/src/packages/flutter-app/test/plan_provider_stream_test.dart
@@ -17,6 +17,7 @@ class _FakePlanService extends PlanService {
     String? bearerToken,
     String? chatId,
     String? tripId,
+    String? summary,
   }) async* {
     for (var i = 0; i < deltaCount; i++) {
       await Future<void>.delayed(const Duration(milliseconds: 2));
@@ -39,6 +40,7 @@ class _ScriptedPlanService extends PlanService {
     String? bearerToken,
     String? chatId,
     String? tripId,
+    String? summary,
   }) async* {
     lastHistory = messages;
     for (final e in events) {

--- a/src/packages/flutter-app/test/plan_service_body_test.dart
+++ b/src/packages/flutter-app/test/plan_service_body_test.dart
@@ -1,0 +1,40 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:travel_route_planner/services/plan_service.dart';
+
+/// The request body carries `summary` only when a compacted summary exists —
+/// absent (not empty/null) otherwise, so the server-side presence check works.
+void main() {
+  const sse = 'data: {"type":"done","data":{}}\n\n';
+  const history = [
+    {'role': 'user', 'content': 'plan athens'}
+  ];
+
+  Future<Map<String, dynamic>> capturedBody({String? summary}) async {
+    late Map<String, dynamic> body;
+    final service = PlanService(
+      'http://test/api/v1',
+      clientFactory: () => MockClient.streaming((request, bodyStream) async {
+        body = jsonDecode(await utf8.decodeStream(bodyStream))
+            as Map<String, dynamic>;
+        return http.StreamedResponse(Stream.value(utf8.encode(sse)), 200);
+      }),
+    );
+    await service.streamPlan(history, summary: summary).toList();
+    return body;
+  }
+
+  test('summary is serialized when present', () async {
+    final body = await capturedBody(summary: '- travelers: 3');
+    expect(body['summary'], '- travelers: 3');
+    expect(body['messages'], hasLength(1));
+  });
+
+  test('summary key is absent when null or empty', () async {
+    expect(await capturedBody(), isNot(contains('summary')));
+    expect(await capturedBody(summary: ''), isNot(contains('summary')));
+  });
+}


### PR DESCRIPTION
## Summary
- Replaces the hard "This conversation is too long to continue" rejection with automatic conversation compaction: at 24 messages the server summarizes all but the newest 10 via one forced-tool Haiku 4.5 call (`plan_compactor.go`), emits new `compacting`/`compacted` SSE events, and runs the turn on `[summary + recent messages]`.
- The Flutter client keeps the full visible transcript but tracks `compactedSummary`/`compactedCount`, resending the summary (new `PlanRequest.summary` field) instead of the folded messages on later turns — compaction happens once per stretch, not per turn. A transient "Summarizing earlier conversation…" chip covers the 1–3s pause.
- `planMaxMessages` raised 40 → 60 and demoted to a runaway backstop; old clients that ignore the new events degrade to per-turn server-side compaction. Summarizer failure logs and proceeds uncompacted — a turn the user is waiting on never fails because of compaction. `plan_session_completed` instrumentation gains `compacted`/`compaction_failed`.
- Spec under `specs/conversation-compaction/`.

## Testing
- `go test ./...` with the fake-Anthropic harness + test DB: new compactor unit tests (split logic, prev-summary merge, no-tool-call failure, oversized-summary truncation) and integration tests (threshold crossing event shape + wire projection, graceful fallback, below-threshold summary prepend, oversized-summary rejection). `gofmt`/`go vet` clean.
- `flutter test` (143 pass) incl. new provider tests (boundary advance, retry-after-error, queued-drain across a compaction, chip lifecycle, reset) and request-body serialization tests. `flutter analyze` clean.
- Live E2E against the real Anthropic API: 25-message scripted conversation with facts buried in message 3 → `compacted` fired (`through_index` 15), summary preserved the facts, and the model recalled them correctly in the final turn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)