### PR TITLE
feat: voice dictation in the chat composer

### DIFF
--- a/dockerize/deployment/nginx/snippets/app-locations.conf
+++ b/dockerize/deployment/nginx/snippets/app-locations.conf
@@ -12,6 +12,9 @@ index index.html;
 location /api/ {
     proxy_pass http://api:8080;
     proxy_http_version 1.1;
+    # Above nginx's 1 MiB default for /transcribe audio clips; the Go
+    # bodyLimitMiddleware enforces the real per-endpoint caps.
+    client_max_body_size 10m;
     proxy_read_timeout 180s;
     proxy_send_timeout 180s;
     proxy_set_header Host $host;

--- a/dockerize/development/nginx/default.conf
+++ b/dockerize/development/nginx/default.conf
@@ -10,6 +10,9 @@ server {
     location /api/ {
         proxy_pass http://api:8080;
         proxy_http_version 1.1;
+        # Above nginx's 1 MiB default for /transcribe audio clips; the Go
+        # bodyLimitMiddleware enforces the real per-endpoint caps.
+        client_max_body_size 10m;
         proxy_read_timeout 180s;
         proxy_send_timeout 180s;
         proxy_set_header Host $host;

--- a/dockerize/static/privacy.html
+++ b/dockerize/static/privacy.html
@@ -136,12 +136,20 @@
       <tr><td>Ticketmaster</td><td>City and date window</td><td>Local events lookup</td></tr>
       <tr><td>Open-Meteo</td><td>Destination coordinates and dates</td><td>Weather forecasts</td></tr>
       <tr><td>Anthropic</td><td>Your planning conversation and trip context</td><td>Generating AI itineraries</td></tr>
+      <tr><td>Speech services</td><td>Voice-dictation audio (only while you use the mic)</td><td>Turning your speech into text</td></tr>
     </table>
     <p>
       These lookups are made server-side through our API; the providers do not
       receive your email address or account identity from us. Results you
       choose to keep (for example a place added to an itinerary) are stored as
       part of your trip data.
+    </p>
+    <p>
+      <strong>Voice dictation is optional.</strong> If you tap the microphone,
+      audio is transcribed either by your browser's built-in speech service
+      (for example Google in Chrome or Apple in Safari) or by our configured
+      transcription provider, then discarded — we never store your audio, and
+      nothing is sent unless you choose to send the resulting text.
     </p>
 
     <h2>3. Affiliate and outbound links</h2>

--- a/specs/voice-dictation/plan.md
+++ b/specs/voice-dictation/plan.md
@@ -1,0 +1,161 @@
+# Plan: Voice Dictation
+
+> **HOW.** Translates `spec.md` into a file-level technical approach. Every
+> decision should trace back to an acceptance criterion. See `../../CLAUDE.md`
+> for repo conventions referenced below — don't restate them, point to them.
+
+## Technical Approach
+
+Two capture paths behind one Dart abstraction, one insertion contract:
+
+1. **Primary — `speech_to_text` plugin** (Web Speech API on web; native
+   recognizers on iOS/Android for free). Live partial transcripts. On web,
+   `initialize()` only feature-detects — the browser permission prompt happens
+   at first `listen()`, satisfying the user-gesture requirement.
+2. **Fallback — `record` plugin** (MediaRecorder on web): capture opus audio
+   (`audio/webm` on Chromium, `audio/ogg` on Firefox), POST raw bytes to
+   `POST /api/v1/transcribe`, which forwards multipart to an
+   **OpenAI-compatible** transcription provider. Default is Groq
+   `whisper-large-v3-turbo` (fast, ~$0.04/audio-hour); OpenAI is a two-env-var
+   swap via the configurable base URL — mirrors the `ANTHROPIC_BASE_URL` seam
+   and the Duffel one-file-provider convention (CLAUDE.md → Key Constraints).
+3. Capability detection: Web Speech availability from `initialize()`; server
+   availability from `GET /api/v1/transcribe/availability` (cached
+   FutureProvider). Neither → mic not rendered. Browsers that advertise Web
+   Speech but fail at `start()` (Brave) degrade to the recorder path for the
+   session.
+
+Transcripts are **appended** into the composer's existing
+`TextEditingController` (base-snapshot + partial overlay, finals commit to the
+base); the existing send path and queue-while-streaming behavior are untouched.
+
+Key sizing decisions: raw bytes (not multipart/base64) client→server because
+the Flutter codebase has no multipart precedent and base64 inflates 33%;
+60 s / 10 MiB caps; nginx `client_max_body_size 10m` on `/api/` with Go's
+`bodyLimitMiddleware` staying the real per-endpoint enforcement (256 KiB
+default, dedicated 10 MiB lane for `/transcribe`).
+
+## Go API Changes
+
+`src/packages/api/` (all files are `package main`):
+
+- **Service:** new `transcription_service.go` following the
+  `duffel_service.go` template — `TranscriptionService{APIKey, BaseURL, Model,
+  Client}`, process-wide `transcriptionService` singleton, startup warning
+  when the key is absent. One method `Transcribe(ctx, audio []byte, mimeType
+  string) (string, error)`: builds a `mime/multipart` body (`file` part named
+  `audio.<ext>` derived from the MIME type — Whisper-family endpoints key
+  format off the filename — plus `model` field), POSTs
+  `{BaseURL}/audio/transcriptions`, parses `{"text": ...}`.
+- **Handlers:** new `transcribe_handler.go`:
+  - `transcribeHandler` (POST): allowlist `Content-Type` (`audio/webm`,
+    `audio/ogg`, `audio/mp4`, `audio/wav`; parameters like `;codecs=opus`
+    stripped), reject empty body → 400; unconfigured service → 503
+    configured-error (Duffel-style); upstream failure → 502 with generic
+    message, details via `ctxLog`; success → `200 {"text","status":"success"}`.
+  - `transcribeAvailabilityHandler` (GET): `200 {"available": bool}`.
+- **Routes (`main.go`):** no auth (parity with `/plan`); dedicated
+  `transcribeLimiter := newIPRateLimiter(10, 5)` following the `anonEvents`
+  precedent — sharing `strict` (5/min) would starve `/plan` since each
+  fallback dictation+send costs two tokens. Availability GET rides the
+  general tier. Startup log line.
+- **Middleware (`middleware.go`):** add a `/api/v1/transcribe` lane to
+  `bodyLimitMiddleware` (`transcribeMaxRequestBodyBytes = 10 << 20`), same
+  style as the `/plan` 4 MiB lane.
+- **Types:** `TranscribeResponse{Text, Status}` and
+  `TranscribeAvailabilityResponse{Available}` in `transcribe_handler.go`;
+  errors reuse the existing `Response` shape.
+
+## Flutter Changes
+
+`src/packages/flutter-app/lib/`:
+
+- **Models:** none — the two response shapes are tiny and parsed inline by the
+  service (no `@JsonSerializable` model files needed; parity is still tracked
+  below).
+- **Service (`services/`):**
+  - `dictation_engine.dart` — abstract `DictationEngine`
+    (`initialize()`, `start()`, `stop()`, `cancel()`, event stream of
+    `partial`/`final`/`done`/`error`) with `SpeechToTextEngine` (wraps
+    `speech_to_text`; `pauseFor: 3s`, `listenFor: 60s`) and `RecorderEngine`
+    (wraps `record` → stop → upload via the transcribe service → one final).
+  - `transcribe_api_service.dart` — `transcribe(bytes, mimeType)` POSTs raw
+    bytes with the recorder's reported MIME passed through verbatim (Firefox
+    emits ogg); `availability()` GET.
+  - `dictation_controller.dart` — `DictationController extends
+    ChangeNotifier`, one per composer, owned next to the composer's
+    `TextEditingController`. Status machine `idle → listening →
+    (transcribing) → idle` + transient error. Append semantics: snapshot
+    `_base` at session start, render `_base + sep + partial` with caret at
+    end, commit finals into `_base`; a genuine user edit while listening
+    stops the session and keeps the edit (self-write guard flag). Engine
+    selection + Brave-style runtime fallback lives here.
+- **Provider (`providers/`):** `dictation_provider.dart` — engine factory
+  provider (overridable in tests) and a cached availability `FutureProvider`;
+  a 503 from `/transcribe` flips availability false (mic hides going
+  forward).
+- **Widget (`widgets/chat_panel.dart`):** `_ChatPanelState` owns the
+  `DictationController`; `_InputBar` stays stateless and gains a `dictation`
+  param — mic `IconButton` between the text field and send button inside a
+  `ListenableBuilder` (`mic_none` idle, accented `mic` listening, small
+  `CircularProgressIndicator` transcribing, absent when unavailable). Errors
+  via `SnackBar` — the chat error banner stays reserved for stream failures.
+- **Platform permissions** (needed by `speech_to_text`/`record`; web needs
+  nothing): iOS `NSMicrophoneUsageDescription` +
+  `NSSpeechRecognitionUsageDescription`; Android `RECORD_AUDIO` + speech
+  recognition `<queries>` intent; macOS `com.apple.security.device.audio-input`
+  entitlements + usage string.
+
+## Contract Parity  ← anti-drift gate
+
+| JSON key | Go type (`transcribe_handler.go`) | Dart type (`transcribe_api_service.dart`) | Nullable? | ✓ |
+|----------|-----------------------------------|-------------------------------------------|-----------|---|
+| *(request body)* | raw `[]byte`, `Content-Type: audio/*` | `Uint8List` + explicit content-type header | n/a | ☑ |
+| `text` | `string` | `String` | no | ☑ |
+| `status` | `string` (`"success"`) | `String` (unused, informational) | no | ☑ |
+| `message` (errors) | `string` (existing `Response`) | `String` | no | ☑ |
+| `available` | `bool` | `bool` | no | ☑ |
+
+## Cross-cutting
+
+- **Env vars** (added to `src/packages/api/.env.sample`):
+  - `TRANSCRIPTION_API_KEY` — empty ⇒ fallback disabled (degraded mode); mic
+    still works in Web-Speech browsers.
+  - `TRANSCRIPTION_BASE_URL` — default `https://api.groq.com/openai/v1`; any
+    OpenAI-compatible endpoint works; doubles as the httptest seam.
+  - `TRANSCRIPTION_MODEL` — default `whisper-large-v3-turbo`.
+- **Gateway:** new paths need no proxy config, but both gateways need
+  `client_max_body_size 10m;` in the `/api/` location
+  (`dockerize/development/nginx/default.conf`,
+  `dockerize/deployment/nginx/snippets/app-locations.conf` — the snippet is
+  included by both :80 and :443 servers). nginx default is 1 MiB, below the
+  audio clip cap.
+- **COOP/COEP:** the deployed app is cross-origin-isolated; `getUserMedia`,
+  `MediaRecorder`, and Web Speech are device APIs, not embedded cross-origin
+  subresources, so COEP does not gate them — but verify once on a deployment
+  build (rarely-tested combination).
+- **Privacy page:** add a dictation sentence to `dockerize/static/privacy.html`
+  (browser vendor speech service on the live path; configured provider on the
+  fallback; audio never stored).
+
+## Verification
+
+(Mirror into `tasks.md` as the final tasks.)
+
+- `make api-fmt && make api-vet && make api-test`.
+- `make flutter-analyze && make flutter-test`.
+- Go unit tests: service (httptest stub asserting outbound multipart + auth
+  header, MIME→filename mapping, upstream errors), handler (503 unconfigured,
+  400 bad content type/empty body, happy path via BaseURL stub, availability
+  both ways), middleware (10 MiB transcribe lane).
+- Flutter tests: controller (append semantics, status transitions,
+  edit-stops-session, errors) with a fake engine; widget (mic states, hidden
+  when unavailable, dictated send goes through the normal queue path);
+  transcribe service with `MockClient`.
+- Manual end-to-end via the gateway (`make docker-dev` →
+  `http://localhost:3000`): Chrome live path; Firefox fallback path (needs
+  `TRANSCRIPTION_API_KEY`); no-key + Firefox → mic hidden; dictate while
+  streaming → queued. `curl` example:
+  `curl -X POST http://localhost:3000/api/v1/transcribe -H 'Content-Type: audio/webm' --data-binary @clip.webm`.
+- One deployment-build check that dictation works under the COOP/COEP
+  isolation headers.

--- a/specs/voice-dictation/spec.md
+++ b/specs/voice-dictation/spec.md
@@ -1,0 +1,132 @@
+# Spec: Voice Dictation
+
+> **WHAT & WHY only.** No tech choices, file names, libraries, or code. If a
+> sentence names a file or a package, it belongs in `plan.md`, not here.
+
+## Context
+
+Typing a full trip request or follow-up on a phone (or while multitasking) is
+slow; speaking it is faster and more natural. This feature lets the user
+dictate a chat message: tap a mic button in the composer, speak, and the
+transcript appears in the text field for review before sending. It is
+**dictation, not voice chat** — the assistant's replies stay text-only, and
+nothing is sent until the user taps send.
+
+## User Stories
+
+- As a **traveler planning a trip**, I want to **speak my request instead of
+  typing it** so that **I can describe a trip quickly and hands-free**.
+- As a **user who made a dictation mistake**, I want the **transcript to land
+  in the input box, editable**, so that **I can fix errors before the agent
+  sees them and wastes a turn**.
+- As a **user of a browser without built-in speech recognition**, I want
+  **dictation to still work** so that **the feature isn't Chrome-only**.
+- As a **user whose browser and server both lack speech support**, I want the
+  **mic button to simply not appear** so that **I'm never offered a button
+  that fails**.
+
+## Acceptance Criteria
+
+- [ ] A mic button appears in the chat composer (both the Agent tab and the
+      trip refine panel) when at least one dictation path is available.
+- [ ] Tapping the mic starts listening (after the browser's permission prompt
+      on first use); the button visibly changes state while listening.
+- [ ] In browsers with built-in speech recognition, the transcript appears
+      live in the input field as the user speaks.
+- [ ] In browsers without built-in speech recognition (when the server-side
+      fallback is configured), audio is recorded, a transcribing indicator is
+      shown after stopping, and the final transcript is inserted.
+- [ ] Dictated text is **appended** to whatever the user had already typed —
+      existing text is never overwritten.
+- [ ] The user can edit the transcript and must tap send (or press enter) to
+      send it; nothing is auto-sent.
+- [ ] Listening stops on: tapping the mic again, ~3 seconds of silence, or a
+      60-second maximum.
+- [ ] Typing in the input field while listening stops the dictation session
+      and keeps the user's edit.
+- [ ] Dictating while the assistant is streaming a reply works; the sent
+      message queues exactly like a typed one.
+- [ ] When neither dictation path is available (unsupported browser and no
+      server transcription configured), the mic button is not rendered.
+- [ ] Microphone-permission denial and transcription failures surface as a
+      brief, non-blocking notice — never as a chat error.
+
+## API Surface
+
+### `POST /api/v1/transcribe`
+- **Purpose:** transcribe a short recorded audio clip to text (fallback path
+  for browsers without built-in speech recognition).
+- **Request:** raw audio bytes in the request body; the content type declares
+  the audio format (webm/ogg/mp4/wav). No other fields.
+- **Response:** the transcribed `text` and a `status` of `success`.
+- **Errors:** missing/unsupported content type or empty body → invalid-request
+  error; clip larger than the size cap → too-large error; transcription
+  provider not configured → service-unavailable error (same degraded-mode
+  behavior as other optional providers); provider failure → upstream error
+  with a generic message.
+- **Auth:** none required — mirrors the plan chat, which works anonymously.
+  Protected by its own rate limit.
+
+### `GET /api/v1/transcribe/availability`
+- **Purpose:** let the client decide up front whether the fallback path
+  exists, so the mic can be hidden instead of failing after the user speaks.
+- **Request:** none.
+- **Response:** `available` — whether server-side transcription is configured.
+- **Errors:** none (always answers).
+
+## Data Model
+
+None. Nothing about a dictation is persisted — audio is transcribed and
+discarded; the resulting text only exists as a normal chat message if and when
+the user sends it.
+
+## UI Behavior
+
+- **Screen / surface:** the chat composer — the mic button sits between the
+  text field and the send button, in both the Agent tab and the trip refine
+  panel.
+- **Happy path:** tap mic → (first time) grant permission → speak → words
+  appear in the field (live path) or after a short transcribing state
+  (fallback path) → edit if needed → tap send.
+- **States:**
+  - *Idle:* outlined mic icon.
+  - *Listening:* filled/accented mic icon, visually distinct.
+  - *Transcribing (fallback only):* small progress indicator in place of the
+    mic.
+  - *Unavailable:* button absent.
+  - *Error:* transient notice (e.g. "Microphone access was blocked",
+    "Couldn't transcribe audio — you can type instead"); composer unaffected.
+
+## Edge Cases & Error States
+
+- **Permission denied:** transient notice; button returns to idle.
+- **No speech detected / empty transcript:** silent no-op; no message, no
+  error.
+- **Browser advertises speech recognition but it fails at start** (some
+  privacy-focused browsers): fall back to the record-and-upload path for the
+  rest of the session if it's available, else show the unavailable notice.
+- **Server fallback not configured:** the availability check reports false;
+  in browsers that also lack built-in recognition the mic is hidden. A
+  service-unavailable response mid-session likewise hides the mic going
+  forward.
+- **Recording caps:** 60 seconds / 10 MiB per clip — enough for a long spoken
+  message, small enough to bound cost and abuse on an unauthenticated
+  endpoint (which also has its own rate limit).
+- **Privacy:** built-in browser recognition sends audio to the browser
+  vendor's speech service (e.g. Google for Chrome, Apple for Safari); the
+  fallback sends audio to our configured transcription provider. Audio is
+  never stored by this app. The public privacy page should mention this when
+  the feature ships.
+
+## Out of Scope
+
+- Voice chat / spoken assistant replies (text-to-speech).
+- Auto-sending on end of speech.
+- Language selection UI (browser/provider defaults are used).
+- Persisting or replaying audio.
+- Dictation anywhere other than the chat composer (e.g. search fields).
+
+## Open Questions
+
+None — transcription approach (browser-native with server fallback) and send
+behavior (fill composer, user sends) were decided with the product owner.

--- a/specs/voice-dictation/tasks.md
+++ b/specs/voice-dictation/tasks.md
@@ -1,0 +1,59 @@
+# Tasks: Voice Dictation
+
+> Dependency-ordered. `[P]` = can run in parallel with its siblings (no shared
+> files / no ordering dependency). Work top to bottom; verification is last.
+
+## API (Go)
+
+- [x] Implement `transcription_service.go` (OpenAI-compatible multipart
+      forwarder, Groq defaults, env config, startup warning) + service tests
+- [x] Implement `transcribe_handler.go` (POST /transcribe raw-bytes,
+      GET /transcribe/availability, degraded-mode 503) + handler tests
+- [x] Register routes + dedicated `transcribeLimiter` + startup log in
+      `main.go`
+- [x] Add 10 MiB `/api/v1/transcribe` lane to `bodyLimitMiddleware`
+      (+ extend middleware test)
+- [x] Add `TRANSCRIPTION_API_KEY` / `TRANSCRIPTION_BASE_URL` /
+      `TRANSCRIPTION_MODEL` to `.env.sample`
+
+## Gateway
+
+- [x] [P] `client_max_body_size 10m;` in `dockerize/development/nginx/default.conf`
+      `/api/` location
+- [x] [P] `client_max_body_size 10m;` in
+      `dockerize/deployment/nginx/snippets/app-locations.conf` `/api/` location
+
+## Flutter — deps & platform
+
+- [x] Add `speech_to_text` + `record` to `pubspec.yaml` (verify pins against
+      Flutter 3.35.4) and pub get
+- [x] [P] iOS `Info.plist` mic + speech usage strings
+- [x] [P] Android `RECORD_AUDIO` permission + speech `<queries>` intent
+- [x] [P] macOS audio-input entitlements + usage string
+
+## Flutter — services & UI
+
+- [x] `lib/services/dictation_engine.dart` (abstract + `SpeechToTextEngine` +
+      `RecorderEngine`)
+- [x] [P] `lib/services/transcribe_api_service.dart`
+- [x] `lib/services/dictation_controller.dart` (append semantics, status
+      machine, runtime fallback)
+- [x] `lib/providers/dictation_provider.dart` (engine factory + availability
+      FutureProvider)
+- [x] `chat_panel.dart`: `_ChatPanelState` owns the controller; `_InputBar`
+      mic button states; SnackBar errors
+- [x] Complete the Contract Parity table in `plan.md` (every row ✓)
+
+## Verification
+
+- [x] Flutter tests: `dictation_controller_test.dart`,
+      `chat_panel_dictation_test.dart`, `transcribe_api_service_test.dart`
+- [x] `make api-fmt && make api-vet` clean
+- [x] `make flutter-analyze` clean
+- [x] `make flutter-test` / `make api-test` pass
+- [ ] Manual end-to-end via gateway (`make docker-dev` →
+      `http://localhost:3000`): every acceptance criterion in `spec.md`
+      checked off (Chrome live path; fallback path; hidden-mic case;
+      dictate-while-streaming)
+- [ ] Deployment-build COOP/COEP check
+- [x] Privacy page sentence (`dockerize/static/privacy.html`)

--- a/src/packages/api/.env.sample
+++ b/src/packages/api/.env.sample
@@ -12,6 +12,14 @@ DUFFEL_VERSION=v2
 # rest of the API is unaffected. TICKETMASTER_BASE_URL rarely needs changing.
 TICKETMASTER_API_KEY=your_ticketmaster_api_key_here
 TICKETMASTER_BASE_URL=https://app.ticketmaster.com/discovery/v2
+# Voice-dictation fallback transcription (specs/voice-dictation). Any
+# OpenAI-compatible /audio/transcriptions endpoint works; defaults target Groq
+# (free key at https://console.groq.com). Absent key => the fallback is
+# disabled and the mic only appears in browsers with built-in speech
+# recognition; the rest of the API is unaffected.
+TRANSCRIPTION_API_KEY=
+TRANSCRIPTION_BASE_URL=https://api.groq.com/openai/v1
+TRANSCRIPTION_MODEL=whisper-large-v3-turbo
 CHROME_WS_URL=ws://chrome:9222/   # Set when running in Docker; leave empty to launch Chrome locally
 # Postgres connection. For local `make api-run`, point at localhost. In Docker the
 # compose stacks override this to use the `postgres` service host.

--- a/src/packages/api/main.go
+++ b/src/packages/api/main.go
@@ -671,6 +671,13 @@ func buildRouter() *mux.Router {
 	api.HandleFunc("/ferries/search", ferriesSearchHandler).Methods("GET")
 	api.HandleFunc("/events/greece-links", greeceEventsLinksHandler).Methods("GET")
 	api.Handle("/plan", strict(http.HandlerFunc(planHandler))).Methods("POST")
+	// Voice dictation fallback (specs/voice-dictation). Unauthenticated to
+	// match /plan, but on its own limiter bucket — sharing strict (5/min)
+	// would starve /plan, since each fallback dictation+send costs two tokens.
+	transcribeLimiter := newIPRateLimiter(10, 5)
+	transcribe := rateLimitMiddleware(transcribeLimiter)
+	api.Handle("/transcribe", transcribe(http.HandlerFunc(transcribeHandler))).Methods("POST")
+	api.HandleFunc("/transcribe/availability", transcribeAvailabilityHandler).Methods("GET")
 	api.HandleFunc("/airbnb/parse", airbnbParseHandler).Methods("POST")
 	api.HandleFunc("/airbnb/debug", airbnbDebugHandler).Methods("POST")
 	api.Handle("/auth/register", strict(http.HandlerFunc(registerHandler))).Methods("POST")

--- a/src/packages/api/middleware.go
+++ b/src/packages/api/middleware.go
@@ -90,8 +90,9 @@ func requestIDMiddleware(next http.Handler) http.Handler {
 // handler would accept (or reject with a friendly SSE error event) never die
 // here first with a bare 413, which an SSE client surfaces poorly.
 const (
-	maxRequestBodyBytes     = 256 << 10 // 256 KiB, all endpoints by default
-	planMaxRequestBodyBytes = 4 << 20   // 4 MiB for the /plan chat history (see above)
+	maxRequestBodyBytes       = 256 << 10 // 256 KiB, all endpoints by default
+	planMaxRequestBodyBytes   = 4 << 20   // 4 MiB for the /plan chat history (see above)
+	transcribeMaxRequestBytes = 10 << 20  // 10 MiB for /transcribe audio clips (60s opus is well under)
 )
 
 // bodyLimitMiddleware caps request body size. It wraps the request body ONLY
@@ -103,8 +104,11 @@ const (
 func bodyLimitMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		limit := int64(maxRequestBodyBytes)
-		if r.URL.Path == "/api/v1/plan" {
+		switch r.URL.Path {
+		case "/api/v1/plan":
 			limit = planMaxRequestBodyBytes
+		case "/api/v1/transcribe":
+			limit = transcribeMaxRequestBytes
 		}
 		if r.ContentLength > limit {
 			writeJSONError(w, http.StatusRequestEntityTooLarge, "request body too large")

--- a/src/packages/api/middleware_test.go
+++ b/src/packages/api/middleware_test.go
@@ -241,6 +241,32 @@ func TestBodyLimitPlanGetsWiderLane(t *testing.T) {
 	}
 }
 
+// /transcribe carries a recorded audio clip, so it gets the 10 MiB lane: a
+// body over the general 256 KiB cap must pass, and one over the audio cap
+// must still die with a 413.
+func TestBodyLimitTranscribeGetsWiderLane(t *testing.T) {
+	handlerRan := false
+	h := bodyLimitMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handlerRan = true
+		if _, err := io.Copy(io.Discard, r.Body); err != nil {
+			t.Fatalf("reading a 2MiB /transcribe body failed: %v", err)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest("POST", "/api/v1/transcribe", bytes.NewReader(make([]byte, 2<<20))))
+	if !handlerRan || rec.Code != http.StatusOK {
+		t.Fatalf("handlerRan = %v, status = %d; want 2MiB /transcribe body to pass", handlerRan, rec.Code)
+	}
+
+	rec = httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest("POST", "/api/v1/transcribe", bytes.NewReader(make([]byte, transcribeMaxRequestBytes+1))))
+	if rec.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status = %d, want 413 for over-cap /transcribe body", rec.Code)
+	}
+}
+
 // Clients that lie about (or omit) Content-Length can't be rejected up front;
 // MaxBytesReader must stop the read mid-body instead.
 func TestBodyLimitStopsUndeclaredOversizedRead(t *testing.T) {

--- a/src/packages/api/transcribe_handler.go
+++ b/src/packages/api/transcribe_handler.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"io"
+	"mime"
+	"net/http"
+)
+
+// TranscribeResponse is the success shape for POST /transcribe.
+type TranscribeResponse struct {
+	Text   string `json:"text"`
+	Status string `json:"status"`
+}
+
+// TranscribeAvailabilityResponse tells the client whether the server-side
+// dictation fallback is configured, so the mic button can be hidden up front
+// instead of failing after the user has already spoken.
+type TranscribeAvailabilityResponse struct {
+	Available bool `json:"available"`
+}
+
+// transcribeHandler accepts a short recorded audio clip as raw request-body
+// bytes (Content-Type declares the container format) and returns the
+// transcribed text. It is the fallback path for browsers without built-in
+// speech recognition; see specs/voice-dictation. Unauthenticated to match
+// /plan, bounded by its own rate limiter and the 10 MiB body lane in
+// bodyLimitMiddleware.
+func transcribeHandler(w http.ResponseWriter, r *http.Request) {
+	if !transcriptionService.Configured() {
+		writeJSONError(w, http.StatusServiceUnavailable, "Transcription is not configured")
+		return
+	}
+
+	// MediaRecorder reports types like "audio/webm;codecs=opus" — parse down
+	// to the bare media type before the allowlist check.
+	mediaType, _, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, "Content-Type must be a supported audio type")
+		return
+	}
+	if _, ok := transcribeMimeExtensions[mediaType]; !ok {
+		writeJSONError(w, http.StatusBadRequest, "Content-Type must be one of: audio/webm, audio/ogg, audio/mp4, audio/wav")
+		return
+	}
+
+	audio, err := io.ReadAll(r.Body)
+	if err != nil {
+		// MaxBytesReader trips mid-read for chunked bodies over the cap.
+		writeJSONError(w, http.StatusRequestEntityTooLarge, "request body too large")
+		return
+	}
+	if len(audio) == 0 {
+		writeJSONError(w, http.StatusBadRequest, "audio body is required")
+		return
+	}
+
+	text, err := transcriptionService.Transcribe(r.Context(), audio, mediaType)
+	if err != nil {
+		ctxLog(r.Context()).Error("transcription failed", "error", err, "bytes", len(audio), "mime", mediaType)
+		writeJSONError(w, http.StatusBadGateway, "Failed to transcribe audio")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, TranscribeResponse{Text: text, Status: "success"})
+}
+
+// transcribeAvailabilityHandler reports whether the fallback path exists.
+// Always answers; leaks no key material.
+func transcribeAvailabilityHandler(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, http.StatusOK, TranscribeAvailabilityResponse{
+		Available: transcriptionService.Configured(),
+	})
+}

--- a/src/packages/api/transcribe_handler_test.go
+++ b/src/packages/api/transcribe_handler_test.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// swapTranscription swaps the process-wide singleton for a test and restores
+// it afterward (same pattern as other singleton-backed handler tests).
+func swapTranscription(t *testing.T, svc *TranscriptionService) {
+	t.Helper()
+	prev := transcriptionService
+	transcriptionService = svc
+	t.Cleanup(func() { transcriptionService = prev })
+}
+
+func postTranscribe(contentType string, body []byte) *httptest.ResponseRecorder {
+	req := httptest.NewRequest("POST", "/api/v1/transcribe", bytes.NewReader(body))
+	if contentType != "" {
+		req.Header.Set("Content-Type", contentType)
+	}
+	rec := httptest.NewRecorder()
+	transcribeHandler(rec, req)
+	return rec
+}
+
+func TestTranscribeHandlerUnconfigured(t *testing.T) {
+	swapTranscription(t, &TranscriptionService{Client: http.DefaultClient})
+
+	rec := postTranscribe("audio/webm", []byte("audio"))
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503", rec.Code)
+	}
+	var resp Response
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("bad JSON: %v", err)
+	}
+	if resp.Status != "error" || resp.Message != "Transcription is not configured" {
+		t.Fatalf("resp = %+v, want degraded-mode configured error", resp)
+	}
+}
+
+func TestTranscribeHandlerValidation(t *testing.T) {
+	var captured capturedTranscribeRequest
+	swapTranscription(t, stubTranscription(t, http.StatusOK, `{"text":"ok"}`, &captured))
+
+	cases := []struct {
+		name        string
+		contentType string
+		body        []byte
+		wantCode    int
+	}{
+		{"missing content type", "", []byte("audio"), http.StatusBadRequest},
+		{"unsupported content type", "text/plain", []byte("audio"), http.StatusBadRequest},
+		{"empty body", "audio/webm", nil, http.StatusBadRequest},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if rec := postTranscribe(tc.contentType, tc.body); rec.Code != tc.wantCode {
+				t.Fatalf("status = %d, want %d", rec.Code, tc.wantCode)
+			}
+		})
+	}
+}
+
+func TestTranscribeHandlerHappyPath(t *testing.T) {
+	var captured capturedTranscribeRequest
+	swapTranscription(t, stubTranscription(t, http.StatusOK, `{"text":"two days in athens"}`, &captured))
+
+	// MediaRecorder reports parameters; the handler must strip them.
+	rec := postTranscribe("audio/webm;codecs=opus", []byte("fake-opus"))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body: %s)", rec.Code, rec.Body.String())
+	}
+	var resp TranscribeResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("bad JSON: %v", err)
+	}
+	if resp.Text != "two days in athens" || resp.Status != "success" {
+		t.Fatalf("resp = %+v", resp)
+	}
+	if captured.filename != "audio.webm" {
+		t.Fatalf("upstream filename = %q, want audio.webm", captured.filename)
+	}
+	if string(captured.fileBytes) != "fake-opus" {
+		t.Fatal("audio bytes not forwarded verbatim")
+	}
+}
+
+func TestTranscribeHandlerUpstreamFailure(t *testing.T) {
+	var captured capturedTranscribeRequest
+	swapTranscription(t, stubTranscription(t, http.StatusTooManyRequests, `{"error":"rate limited"}`, &captured))
+
+	rec := postTranscribe("audio/ogg", []byte("fake-ogg"))
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502", rec.Code)
+	}
+	var resp Response
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("bad JSON: %v", err)
+	}
+	if resp.Message != "Failed to transcribe audio" {
+		t.Fatalf("message = %q, want generic upstream-failure message", resp.Message)
+	}
+}
+
+func TestTranscribeAvailabilityHandler(t *testing.T) {
+	cases := []struct {
+		key  string
+		want bool
+	}{
+		{"", false},
+		{"gsk_test", true},
+	}
+	for _, tc := range cases {
+		swapTranscription(t, &TranscriptionService{
+			APIKey: tc.key,
+			Client: &http.Client{Timeout: time.Second},
+		})
+		rec := httptest.NewRecorder()
+		transcribeAvailabilityHandler(rec, httptest.NewRequest("GET", "/api/v1/transcribe/availability", nil))
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200", rec.Code)
+		}
+		var resp TranscribeAvailabilityResponse
+		if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("bad JSON: %v", err)
+		}
+		if resp.Available != tc.want {
+			t.Fatalf("available = %v with key %q, want %v", resp.Available, tc.key, tc.want)
+		}
+	}
+}

--- a/src/packages/api/transcription_service.go
+++ b/src/packages/api/transcription_service.go
@@ -1,0 +1,143 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+// TranscriptionService transcribes short audio clips via an OpenAI-compatible
+// /audio/transcriptions endpoint (Groq by default; OpenAI works by swapping
+// TRANSCRIPTION_BASE_URL). It backs the voice-dictation fallback path for
+// browsers without built-in speech recognition — see specs/voice-dictation.
+// Like Duffel/Ticketmaster, the provider is isolated to this one file so it
+// can be swapped without touching the handler or the Flutter app.
+type TranscriptionService struct {
+	APIKey  string
+	BaseURL string
+	Model   string
+	Client  *http.Client
+}
+
+// transcribeMimeExtensions is the allowlist of inbound audio content types,
+// mapped to the filename extension the upstream provider keys the container
+// format off. MediaRecorder emits audio/webm on Chromium and audio/ogg on
+// Firefox; mp4/wav cover native mobile recorders later.
+var transcribeMimeExtensions = map[string]string{
+	"audio/webm": "webm",
+	"audio/ogg":  "ogg",
+	"audio/mp4":  "mp4",
+	"audio/wav":  "wav",
+}
+
+// NewTranscriptionService reads provider config from the environment. A
+// missing key is a soft failure (a warning, like Duffel) — the mic still
+// works in browsers with built-in speech recognition; only the server
+// fallback is disabled.
+func NewTranscriptionService() *TranscriptionService {
+	key := os.Getenv("TRANSCRIPTION_API_KEY")
+	if key == "" {
+		fmt.Println("Warning: TRANSCRIPTION_API_KEY not set; voice dictation fallback disabled")
+	}
+
+	baseURL := os.Getenv("TRANSCRIPTION_BASE_URL")
+	if baseURL == "" {
+		baseURL = "https://api.groq.com/openai/v1"
+	}
+	model := os.Getenv("TRANSCRIPTION_MODEL")
+	if model == "" {
+		model = "whisper-large-v3-turbo"
+	}
+
+	return &TranscriptionService{
+		APIKey:  key,
+		BaseURL: strings.TrimRight(baseURL, "/"),
+		Model:   model,
+		Client:  &http.Client{Timeout: 60 * time.Second},
+	}
+}
+
+// Configured reports whether the provider key is present (drives the
+// /transcribe/availability capability check and the 503 degraded mode).
+func (t *TranscriptionService) Configured() bool {
+	return t.APIKey != ""
+}
+
+// Transcribe sends the audio clip upstream as multipart form data and returns
+// the transcribed text. mimeType must be one of transcribeMimeExtensions
+// (the handler validates before calling).
+func (t *TranscriptionService) Transcribe(ctx context.Context, audio []byte, mimeType string) (string, error) {
+	if !t.Configured() {
+		return "", fmt.Errorf("transcription API key not configured")
+	}
+	ext, ok := transcribeMimeExtensions[mimeType]
+	if !ok {
+		return "", fmt.Errorf("unsupported audio type %q", mimeType)
+	}
+
+	var body bytes.Buffer
+	mw := multipart.NewWriter(&body)
+	part, err := mw.CreateFormFile("file", "audio."+ext)
+	if err != nil {
+		return "", fmt.Errorf("failed to build multipart body: %w", err)
+	}
+	if _, err := part.Write(audio); err != nil {
+		return "", fmt.Errorf("failed to write audio part: %w", err)
+	}
+	if err := mw.WriteField("model", t.Model); err != nil {
+		return "", fmt.Errorf("failed to write model field: %w", err)
+	}
+	if err := mw.Close(); err != nil {
+		return "", fmt.Errorf("failed to finalize multipart body: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, t.BaseURL+"/audio/transcriptions", &body)
+	if err != nil {
+		return "", fmt.Errorf("failed to build request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+t.APIKey)
+	req.Header.Set("Content-Type", mw.FormDataContentType())
+
+	resp, err := t.Client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("transcription request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return "", fmt.Errorf("failed to read transcription response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("transcription API returned %d: %s", resp.StatusCode, truncateForLog(respBody))
+	}
+
+	var parsed struct {
+		Text string `json:"text"`
+	}
+	if err := json.Unmarshal(respBody, &parsed); err != nil {
+		return "", fmt.Errorf("failed to parse transcription response: %w", err)
+	}
+	return strings.TrimSpace(parsed.Text), nil
+}
+
+// truncateForLog keeps upstream error payloads readable in logs.
+func truncateForLog(b []byte) string {
+	const max = 500
+	s := string(b)
+	if len(s) > max {
+		return s[:max] + "…"
+	}
+	return s
+}
+
+// transcriptionService is the process-wide singleton, matching the Duffel /
+// Ticketmaster convention.
+var transcriptionService = NewTranscriptionService()

--- a/src/packages/api/transcription_service_test.go
+++ b/src/packages/api/transcription_service_test.go
@@ -1,0 +1,143 @@
+package main
+
+import (
+	"context"
+	"io"
+	"mime"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// capturedTranscribeRequest is what the stub records about the outbound
+// multipart request the service builds.
+type capturedTranscribeRequest struct {
+	authHeader string
+	filename   string
+	fileBytes  []byte
+	model      string
+}
+
+// stubTranscription serves a canned {"text": ...} payload and captures the
+// multipart request, mirroring the stubDuffel base-URL seam.
+func stubTranscription(t *testing.T, status int, respBody string, captured *capturedTranscribeRequest) *TranscriptionService {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured.authHeader = r.Header.Get("Authorization")
+
+		mediaType, params, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
+		if err != nil || mediaType != "multipart/form-data" {
+			t.Errorf("upstream Content-Type = %q, want multipart/form-data", r.Header.Get("Content-Type"))
+		}
+		mr := multipart.NewReader(r.Body, params["boundary"])
+		for {
+			part, err := mr.NextPart()
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				t.Errorf("reading multipart: %v", err)
+				break
+			}
+			data, _ := io.ReadAll(part)
+			switch part.FormName() {
+			case "file":
+				captured.filename = part.FileName()
+				captured.fileBytes = data
+			case "model":
+				captured.model = string(data)
+			}
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		w.Write([]byte(respBody))
+	}))
+	t.Cleanup(srv.Close)
+	return &TranscriptionService{
+		APIKey:  "test-key",
+		BaseURL: srv.URL,
+		Model:   "whisper-large-v3-turbo",
+		Client:  &http.Client{Timeout: 5 * time.Second},
+	}
+}
+
+func TestTranscribeSendsMultipartAndParsesText(t *testing.T) {
+	var captured capturedTranscribeRequest
+	svc := stubTranscription(t, http.StatusOK, `{"text":" hello world "}`, &captured)
+
+	audio := []byte{0x1a, 0x45, 0xdf, 0xa3} // arbitrary bytes; format is opaque
+	text, err := svc.Transcribe(context.Background(), audio, "audio/webm")
+	if err != nil {
+		t.Fatalf("Transcribe: %v", err)
+	}
+	if text != "hello world" {
+		t.Fatalf("text = %q, want trimmed %q", text, "hello world")
+	}
+	if captured.authHeader != "Bearer test-key" {
+		t.Fatalf("auth header = %q, want Bearer test-key", captured.authHeader)
+	}
+	if captured.model != "whisper-large-v3-turbo" {
+		t.Fatalf("model field = %q", captured.model)
+	}
+	if captured.filename != "audio.webm" {
+		t.Fatalf("filename = %q, want audio.webm", captured.filename)
+	}
+	if string(captured.fileBytes) != string(audio) {
+		t.Fatal("uploaded file bytes do not match input audio")
+	}
+}
+
+// Whisper-family endpoints key the container format off the filename
+// extension, so each allowed MIME must map to a distinct name.
+func TestTranscribeFilenameFollowsMime(t *testing.T) {
+	cases := map[string]string{
+		"audio/webm": "audio.webm",
+		"audio/ogg":  "audio.ogg",
+		"audio/mp4":  "audio.mp4",
+		"audio/wav":  "audio.wav",
+	}
+	for mimeType, wantName := range cases {
+		var captured capturedTranscribeRequest
+		svc := stubTranscription(t, http.StatusOK, `{"text":"ok"}`, &captured)
+		if _, err := svc.Transcribe(context.Background(), []byte("a"), mimeType); err != nil {
+			t.Fatalf("%s: %v", mimeType, err)
+		}
+		if captured.filename != wantName {
+			t.Fatalf("%s: filename = %q, want %q", mimeType, captured.filename, wantName)
+		}
+	}
+}
+
+func TestTranscribeRejectsUnsupportedMime(t *testing.T) {
+	var captured capturedTranscribeRequest
+	svc := stubTranscription(t, http.StatusOK, `{"text":"ok"}`, &captured)
+	if _, err := svc.Transcribe(context.Background(), []byte("a"), "video/mp4"); err == nil {
+		t.Fatal("want error for unsupported mime type")
+	}
+}
+
+func TestTranscribeUpstreamErrorSurfaces(t *testing.T) {
+	var captured capturedTranscribeRequest
+	svc := stubTranscription(t, http.StatusInternalServerError, `{"error":"boom"}`, &captured)
+	_, err := svc.Transcribe(context.Background(), []byte("a"), "audio/webm")
+	if err == nil {
+		t.Fatal("want error on upstream 500")
+	}
+	if !strings.Contains(err.Error(), "500") {
+		t.Fatalf("error should carry upstream status, got: %v", err)
+	}
+}
+
+func TestTranscribeUnconfigured(t *testing.T) {
+	svc := &TranscriptionService{Client: http.DefaultClient}
+	if svc.Configured() {
+		t.Fatal("empty key should report unconfigured")
+	}
+	if _, err := svc.Transcribe(context.Background(), []byte("a"), "audio/webm"); err == nil {
+		t.Fatal("want error when key is missing")
+	}
+}

--- a/src/packages/flutter-app/android/app/src/main/AndroidManifest.xml
+++ b/src/packages/flutter-app/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- Voice dictation in the chat composer (specs/voice-dictation). -->
+    <uses-permission android:name="android.permission.RECORD_AUDIO"/>
     <application
         android:label="Golden Tempo Travel"
         android:name="${applicationName}"
@@ -40,6 +42,11 @@
         <intent>
             <action android:name="android.intent.action.PROCESS_TEXT"/>
             <data android:mimeType="text/plain"/>
+        </intent>
+        <!-- Android 11+ package visibility for the on-device speech
+             recognizer (required by speech_to_text). -->
+        <intent>
+            <action android:name="android.speech.RecognitionService"/>
         </intent>
     </queries>
 </manifest>

--- a/src/packages/flutter-app/ios/Runner/Info.plist
+++ b/src/packages/flutter-app/ios/Runner/Info.plist
@@ -47,5 +47,9 @@
 		<true/>
 		<key>UIStatusBarHidden</key>
 		<false/>
+		<key>NSMicrophoneUsageDescription</key>
+		<string>The microphone is used to dictate chat messages to the trip planner.</string>
+		<key>NSSpeechRecognitionUsageDescription</key>
+		<string>Speech recognition turns your dictated words into text you can review before sending.</string>
 	</dict>
 </plist>

--- a/src/packages/flutter-app/lib/providers/dictation_provider.dart
+++ b/src/packages/flutter-app/lib/providers/dictation_provider.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../services/dictation_controller.dart';
+import '../services/dictation_engine.dart';
+import '../services/transcribe_api_service.dart';
+import 'api_client_provider.dart';
+
+/// Wraps the /transcribe endpoints (voice-dictation fallback path).
+final transcribeApiServiceProvider = Provider<TranscribeApiService>((ref) {
+  return TranscribeApiService(ref.watch(apiClientProvider));
+});
+
+/// Whether server-side transcription is configured, checked once per app
+/// session so the mic can be hidden up front in browsers that also lack
+/// built-in speech recognition.
+final transcribeAvailabilityProvider = FutureProvider<bool>((ref) {
+  return ref.watch(transcribeApiServiceProvider).availability();
+});
+
+/// Builds a per-composer [DictationController] bound to that composer's text
+/// field. Widget tests override this to inject fake engines.
+final dictationControllerFactoryProvider =
+    Provider<DictationController Function(TextEditingController)>((ref) {
+  return (textController) => DictationController(
+        textController: textController,
+        primary: SpeechToTextEngine(),
+        fallback: RecorderEngine(ref.read(transcribeApiServiceProvider)),
+        fallbackAvailable: () =>
+            ref.read(transcribeAvailabilityProvider.future),
+      );
+});

--- a/src/packages/flutter-app/lib/services/dictation_controller.dart
+++ b/src/packages/flutter-app/lib/services/dictation_controller.dart
@@ -1,0 +1,221 @@
+import 'dart:async';
+
+import 'package:flutter/widgets.dart';
+
+import 'dictation_engine.dart';
+
+enum DictationStatus { idle, listening, transcribing }
+
+/// Drives one composer's mic button (specs/voice-dictation). Owned by the
+/// chat panel state alongside its [TextEditingController] — dictation state
+/// is per-composer (the agent tab and the trip refine panel each have one),
+/// so it lives here rather than in a global provider.
+///
+/// Transcripts are appended, never clobbering typed text: the session
+/// snapshots the field as `_base`, partials render as an overlay on top of
+/// it, and each final result is committed into it. A genuine user edit while
+/// listening cancels the session and keeps the edit.
+class DictationController extends ChangeNotifier {
+  final TextEditingController textController;
+  final DictationEngine? primary;
+  final DictationEngine? fallback;
+
+  /// Whether the server-side fallback is configured (cached provider read).
+  final Future<bool> Function() fallbackAvailable;
+
+  DictationController({
+    required this.textController,
+    required this.primary,
+    required this.fallback,
+    required this.fallbackAvailable,
+  }) {
+    textController.addListener(_onTextChanged);
+    _init();
+  }
+
+  DictationEngine? _engine;
+  DictationStatus _status = DictationStatus.idle;
+  bool _available = false;
+  bool _initDone = false;
+  bool _fallbackDead = false;
+  bool _disposed = false;
+
+  StreamSubscription<DictationEvent>? _session;
+  String _base = '';
+  bool _applyingTranscript = false;
+  bool _retriedWithFallback = false;
+
+  /// One-shot user-facing error message; the widget shows it (SnackBar) and
+  /// clears it via [consumeError].
+  String? _errorMessage;
+
+  DictationStatus get status => _status;
+
+  /// False until init resolves, and false when no capture path exists — the
+  /// mic button isn't rendered in either case.
+  bool get available => _initDone && _available;
+
+  String? consumeError() {
+    final message = _errorMessage;
+    _errorMessage = null;
+    return message;
+  }
+
+  Future<void> _init() async {
+    var primaryOk = false;
+    if (primary != null) primaryOk = await primary!.initialize();
+    if (_disposed) return;
+    if (primaryOk) {
+      _engine = primary;
+      _available = true;
+    } else if (await _fallbackUsable()) {
+      _engine = fallback;
+      _available = true;
+    } else {
+      _available = false;
+    }
+    if (_disposed) return;
+    _initDone = true;
+    notifyListeners();
+  }
+
+  Future<bool> _fallbackUsable() async {
+    if (fallback == null || _fallbackDead) return false;
+    try {
+      return await fallbackAvailable();
+    } catch (_) {
+      return false;
+    }
+  }
+
+  /// Mic tap: idle starts a session, listening stops it (finals still
+  /// arrive), transcribing ignores taps.
+  Future<void> toggle() async {
+    switch (_status) {
+      case DictationStatus.idle:
+        _startSession();
+      case DictationStatus.listening:
+        await _engine?.stop();
+      case DictationStatus.transcribing:
+        break;
+    }
+  }
+
+  void _startSession() {
+    final engine = _engine;
+    if (engine == null || !_available) return;
+    _base = textController.text.trimRight();
+    _retriedWithFallback = false;
+    _status = DictationStatus.listening;
+    _session = engine.start().listen(_onEvent, onDone: _onSessionEnd);
+    notifyListeners();
+  }
+
+  void _onEvent(DictationEvent event) {
+    switch (event.type) {
+      case 'partial':
+        if (event.text.isNotEmpty) _setText(_joined(event.text));
+      case 'final':
+        if (event.text.isNotEmpty) {
+          _base = _joined(event.text);
+          _setText(_base);
+        }
+      case 'transcribing':
+        _status = DictationStatus.transcribing;
+        notifyListeners();
+      case 'error':
+        _onError(event.errorCode);
+    }
+  }
+
+  String _joined(String transcript) {
+    if (_base.isEmpty) return transcript;
+    return '$_base $transcript';
+  }
+
+  void _setText(String text) {
+    _applyingTranscript = true;
+    textController.value = TextEditingValue(
+      text: text,
+      selection: TextSelection.collapsed(offset: text.length),
+    );
+    _applyingTranscript = false;
+  }
+
+  void _onError(String code) {
+    switch (code) {
+      case 'permission':
+        _errorMessage =
+            'Microphone access was blocked. Check your browser settings.';
+      case 'engine-failed':
+        // The live engine exists but doesn't work here (Brave-style forks).
+        // Degrade to the recorder path for the rest of the app session and
+        // retry this dictation once, so the tap isn't wasted.
+        if (_engine == primary) {
+          _switchToFallbackAndRetry();
+          return;
+        }
+        _errorMessage = "Voice input isn't available in this browser.";
+      case 'unavailable':
+        // Server says the fallback is not configured — hide the mic.
+        _fallbackDead = true;
+        if (_engine == fallback) _available = false;
+        _errorMessage = "Voice input isn't available right now.";
+      default:
+        _errorMessage = "Couldn't transcribe audio. You can type instead.";
+    }
+    notifyListeners();
+  }
+
+  Future<void> _switchToFallbackAndRetry() async {
+    final retry = !_retriedWithFallback;
+    _retriedWithFallback = true;
+    await _endSession(cancelEngine: true);
+    if (_disposed) return;
+    if (await _fallbackUsable()) {
+      _engine = fallback;
+      if (retry) {
+        _startSession();
+        return;
+      }
+    } else {
+      _available = false;
+      _errorMessage = "Voice input isn't available in this browser.";
+    }
+    notifyListeners();
+  }
+
+  void _onSessionEnd() {
+    _session = null;
+    if (_status != DictationStatus.idle) {
+      _status = DictationStatus.idle;
+      notifyListeners();
+    }
+  }
+
+  Future<void> _endSession({bool cancelEngine = false}) async {
+    final session = _session;
+    _session = null;
+    if (cancelEngine) await _engine?.cancel();
+    await session?.cancel();
+    if (_status != DictationStatus.idle) {
+      _status = DictationStatus.idle;
+      if (!_disposed) notifyListeners();
+    }
+  }
+
+  void _onTextChanged() {
+    // A user edit mid-session takes precedence: stop dictating, keep the
+    // edit. Our own transcript writes are guarded.
+    if (_applyingTranscript || _status != DictationStatus.listening) return;
+    _endSession(cancelEngine: true);
+  }
+
+  @override
+  void dispose() {
+    _disposed = true;
+    textController.removeListener(_onTextChanged);
+    _endSession(cancelEngine: true);
+    super.dispose();
+  }
+}

--- a/src/packages/flutter-app/lib/services/dictation_engine.dart
+++ b/src/packages/flutter-app/lib/services/dictation_engine.dart
@@ -1,0 +1,299 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:http/http.dart' as http;
+import 'package:record/record.dart';
+import 'package:speech_to_text/speech_recognition_error.dart';
+import 'package:speech_to_text/speech_to_text.dart' as stt;
+
+import 'transcribe_api_service.dart';
+
+/// One dictation session's worth of events. The stream a [DictationEngine]
+/// returns closes when the session ends (event style matches [PlanEvent]).
+class DictationEvent {
+  /// `partial` | `final` | `transcribing` | `error`
+  final String type;
+
+  /// Transcript text for partial/final events.
+  final String text;
+
+  /// Machine error code for error events:
+  /// `permission` | `engine-failed` | `unavailable` | `failed`.
+  final String errorCode;
+
+  const DictationEvent(this.type, {this.text = '', this.errorCode = ''});
+}
+
+/// One speech-capture backend. Sessions are one-shot: [start] returns a fresh
+/// event stream; [stop] ends the session gracefully (final results still
+/// arrive), [cancel] discards it. Only one session runs at a time per app —
+/// there is only one microphone.
+abstract class DictationEngine {
+  /// Feature-detects the backend. False means this engine can never run in
+  /// the current environment (e.g. no Web Speech API in this browser).
+  Future<bool> initialize();
+
+  Stream<DictationEvent> start();
+
+  Future<void> stop();
+
+  Future<void> cancel();
+}
+
+/// Session caps shared by both engines: dictation is for a spoken chat
+/// message, not long-form recording.
+const dictationMaxDuration = Duration(seconds: 60);
+const dictationPauseFor = Duration(seconds: 3);
+
+/// Live path: the `speech_to_text` plugin (Web Speech API on web, native
+/// recognizers on iOS/Android). Emits partial transcripts as the user speaks.
+///
+/// The plugin registers its platform callbacks per [stt.SpeechToText]
+/// instance at initialize time, and a second instance's initialize would
+/// steal them — with two live composers (agent tab + trip refine panel) that
+/// would silently drop the other composer's results. So all engine instances
+/// share one plugin object and route events to whichever engine owns the
+/// active session.
+class SpeechToTextEngine implements DictationEngine {
+  static final stt.SpeechToText _sharedSpeech = stt.SpeechToText();
+  static SpeechToTextEngine? _active;
+
+  final stt.SpeechToText _speech;
+  StreamController<DictationEvent>? _events;
+
+  SpeechToTextEngine({stt.SpeechToText? speech})
+      : _speech = speech ?? _sharedSpeech;
+
+  @override
+  Future<bool> initialize() async {
+    try {
+      return await _speech.initialize(
+        onError: _routeError,
+        onStatus: _routeStatus,
+      );
+    } catch (_) {
+      return false;
+    }
+  }
+
+  static void _routeError(SpeechRecognitionError error) =>
+      _active?._onError(error);
+
+  static void _routeStatus(String status) => _active?._onStatus(status);
+
+  @override
+  Stream<DictationEvent> start() {
+    final events = StreamController<DictationEvent>();
+    _events = events;
+    _active = this;
+
+    _speech
+        .listen(
+      onResult: (result) {
+        if (events.isClosed) return;
+        events.add(DictationEvent(
+          result.finalResult ? 'final' : 'partial',
+          text: result.recognizedWords,
+        ));
+      },
+      listenOptions: stt.SpeechListenOptions(
+        partialResults: true,
+        pauseFor: dictationPauseFor,
+        listenFor: dictationMaxDuration,
+        cancelOnError: true,
+      ),
+    )
+        .catchError((Object e) {
+      _emitError('engine-failed');
+      _endSession();
+    });
+
+    return events.stream;
+  }
+
+  void _onError(SpeechRecognitionError error) {
+    final code = error.errorMsg;
+    // Silence isn't an error for dictation — the session just ends.
+    if (code.contains('no-speech') ||
+        code.contains('no_match') ||
+        code.contains('speech_timeout') ||
+        code.contains('aborted')) {
+      _endSession();
+      return;
+    }
+    if (code.contains('not-allowed') ||
+        code.contains('permission') ||
+        code.contains('audio-capture')) {
+      _emitError('permission');
+    } else if (code.contains('network') ||
+        code.contains('service-not-allowed') ||
+        code.contains('not_supported') ||
+        code.contains('not supported') ||
+        code.contains('language-not-supported')) {
+      // The API exists but doesn't work here (Brave-style forks) — the
+      // controller switches to the recorder fallback on this code.
+      _emitError('engine-failed');
+    } else {
+      _emitError('failed');
+    }
+    if (error.permanent) _endSession();
+  }
+
+  void _onStatus(String status) {
+    // 'done' / 'doneNoResult' mark the end of a session (silence auto-stop,
+    // listenFor cap, or an explicit stop once final results have flushed).
+    if (status.startsWith('done')) _endSession();
+  }
+
+  void _emitError(String code) {
+    final events = _events;
+    if (events == null || events.isClosed) return;
+    events.add(DictationEvent('error', errorCode: code));
+  }
+
+  void _endSession() {
+    final events = _events;
+    _events = null;
+    if (_active == this) _active = null;
+    if (events != null && !events.isClosed) events.close();
+  }
+
+  @override
+  Future<void> stop() => _speech.stop();
+
+  @override
+  Future<void> cancel() async {
+    await _speech.cancel();
+    _endSession();
+  }
+}
+
+/// Fetches the recorded clip's bytes and content type. On web the `record`
+/// plugin's stop() returns a blob URL; an HTTP GET on it yields the blob's
+/// bytes with its MIME as Content-Type. Injectable so tests never touch a
+/// real blob URL.
+typedef BlobFetcher = Future<(Uint8List, String)> Function(String url);
+
+Future<(Uint8List, String)> _httpBlobFetcher(String url) async {
+  final response = await http.get(Uri.parse(url));
+  if (response.statusCode != 200) {
+    throw Exception('Failed to read recording (HTTP ${response.statusCode})');
+  }
+  return (
+    response.bodyBytes,
+    response.headers['content-type'] ?? 'audio/webm',
+  );
+}
+
+/// Fallback path for browsers without (working) Web Speech: record with
+/// MediaRecorder via the `record` plugin, then upload to POST /transcribe.
+/// No partials — one final transcript after a `transcribing` event.
+///
+/// Web-oriented by design: on native platforms the live engine is always
+/// available, so this engine is never selected there.
+class RecorderEngine implements DictationEngine {
+  final TranscribeApiService service;
+  final AudioRecorder Function() _newRecorder;
+  final BlobFetcher _fetchBlob;
+
+  AudioRecorder? _recorder;
+  StreamController<DictationEvent>? _events;
+  Timer? _maxTimer;
+
+  RecorderEngine(
+    this.service, {
+    AudioRecorder Function()? recorderFactory,
+    BlobFetcher? blobFetcher,
+  })  : _newRecorder = recorderFactory ?? AudioRecorder.new,
+        _fetchBlob = blobFetcher ?? _httpBlobFetcher;
+
+  @override
+  Future<bool> initialize() async {
+    // MediaRecorder is universal in current browsers; whether the *server*
+    // side of this path exists is the controller's availability check.
+    return true;
+  }
+
+  @override
+  Stream<DictationEvent> start() {
+    final events = StreamController<DictationEvent>();
+    _events = events;
+    _startRecording(events);
+    return events.stream;
+  }
+
+  Future<void> _startRecording(StreamController<DictationEvent> events) async {
+    final recorder = _newRecorder();
+    _recorder = recorder;
+    try {
+      // Prompts for the microphone on first use.
+      if (!await recorder.hasPermission()) {
+        events.add(const DictationEvent('error', errorCode: 'permission'));
+        await _teardown();
+        return;
+      }
+      await recorder.start(
+        const RecordConfig(encoder: AudioEncoder.opus, numChannels: 1),
+        path: '', // ignored on web (blob-backed)
+      );
+      _maxTimer = Timer(dictationMaxDuration, stop);
+    } catch (_) {
+      if (!events.isClosed) {
+        events.add(const DictationEvent('error', errorCode: 'failed'));
+      }
+      await _teardown();
+    }
+  }
+
+  @override
+  Future<void> stop() async {
+    final events = _events;
+    final recorder = _recorder;
+    if (events == null || events.isClosed || recorder == null) return;
+    _maxTimer?.cancel();
+    _maxTimer = null;
+
+    try {
+      final url = await recorder.stop();
+      if (url == null) {
+        // Nothing was captured — treat like silence.
+        await _teardown();
+        return;
+      }
+      events.add(const DictationEvent('transcribing'));
+      final (audio, mimeType) = await _fetchBlob(url);
+      final text = await service.transcribe(audio, mimeType);
+      if (!events.isClosed && text.trim().isNotEmpty) {
+        events.add(DictationEvent('final', text: text.trim()));
+      }
+    } on TranscribeUnavailableException {
+      if (!events.isClosed) {
+        events.add(const DictationEvent('error', errorCode: 'unavailable'));
+      }
+    } catch (_) {
+      if (!events.isClosed) {
+        events.add(const DictationEvent('error', errorCode: 'failed'));
+      }
+    }
+    await _teardown();
+  }
+
+  @override
+  Future<void> cancel() async {
+    _maxTimer?.cancel();
+    _maxTimer = null;
+    try {
+      await _recorder?.cancel();
+    } catch (_) {}
+    await _teardown();
+  }
+
+  Future<void> _teardown() async {
+    final events = _events;
+    final recorder = _recorder;
+    _events = null;
+    _recorder = null;
+    if (events != null && !events.isClosed) await events.close();
+    await recorder?.dispose();
+  }
+}

--- a/src/packages/flutter-app/lib/services/transcribe_api_service.dart
+++ b/src/packages/flutter-app/lib/services/transcribe_api_service.dart
@@ -1,0 +1,64 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'api_client.dart';
+
+/// Thrown when the server reports the transcription provider is not
+/// configured (503) — callers hide the dictation fallback going forward
+/// instead of retrying.
+class TranscribeUnavailableException implements Exception {
+  @override
+  String toString() => 'TranscribeUnavailableException';
+}
+
+/// Wraps the voice-dictation fallback endpoints (specs/voice-dictation):
+/// POST /transcribe (raw audio bytes -> text) and GET /transcribe/availability.
+class TranscribeApiService {
+  final ApiClient apiClient;
+
+  TranscribeApiService(this.apiClient);
+
+  /// Whether the server-side transcription fallback is configured. Any
+  /// failure reads as unavailable — the mic simply won't offer the fallback.
+  Future<bool> availability() async {
+    try {
+      final response = await apiClient.httpClient
+          .get(Uri.parse('${apiClient.baseUrl}/transcribe/availability'),
+              headers: apiClient.jsonHeaders())
+          .timeout(const Duration(seconds: 10));
+      if (response.statusCode != 200) return false;
+      final decoded = jsonDecode(response.body);
+      return decoded is Map<String, dynamic> && decoded['available'] == true;
+    } catch (_) {
+      return false;
+    }
+  }
+
+  /// Transcribes a recorded clip. [mimeType] is the recorder's reported
+  /// content type passed through verbatim (Chromium emits audio/webm,
+  /// Firefox audio/ogg; the server strips codec parameters).
+  Future<String> transcribe(Uint8List audio, String mimeType) async {
+    final headers = apiClient.jsonHeaders()..['Content-Type'] = mimeType;
+    final response = await apiClient.httpClient
+        .post(Uri.parse('${apiClient.baseUrl}/transcribe'),
+            headers: headers, body: audio)
+        .timeout(const Duration(seconds: 60));
+
+    if (response.statusCode == 503) throw TranscribeUnavailableException();
+    if (response.statusCode != 200) {
+      var message = 'Transcription failed (HTTP ${response.statusCode})';
+      try {
+        final decoded = jsonDecode(response.body);
+        final msg = decoded is Map<String, dynamic> ? decoded['message'] : null;
+        if (msg is String && msg.isNotEmpty) message = msg;
+      } catch (_) {}
+      throw Exception(message);
+    }
+
+    final decoded = jsonDecode(response.body);
+    if (decoded is! Map<String, dynamic> || decoded['text'] is! String) {
+      throw Exception('Malformed transcription response');
+    }
+    return decoded['text'] as String;
+  }
+}

--- a/src/packages/flutter-app/lib/widgets/chat_panel.dart
+++ b/src/packages/flutter-app/lib/widgets/chat_panel.dart
@@ -3,7 +3,9 @@ import 'package:flutter/rendering.dart' show ScrollDirection;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:gpt_markdown/gpt_markdown.dart';
 import '../models/plan_message.dart';
+import '../providers/dictation_provider.dart';
 import '../providers/plan_provider.dart';
+import '../services/dictation_controller.dart';
 import '../theme/app_colors.dart';
 import '../utils/tracked_launch.dart';
 import 'result_summary_chip.dart';
@@ -53,6 +55,10 @@ class _ChatPanelState extends ConsumerState<ChatPanel> {
   final _controller = TextEditingController();
   final _scrollController = ScrollController();
 
+  /// Voice dictation for this composer (specs/voice-dictation): writes
+  /// transcripts into [_controller]; the user reviews and sends normally.
+  late final DictationController _dictation;
+
   /// Autoscroll follows the stream only while the user is at the bottom;
   /// scrolling up to re-read pauses it until they return to the bottom.
   bool _stickToBottom = true;
@@ -62,7 +68,25 @@ class _ChatPanelState extends ConsumerState<ChatPanel> {
   bool _scrollScheduled = false;
 
   @override
+  void initState() {
+    super.initState();
+    _dictation = ref.read(dictationControllerFactoryProvider)(_controller);
+    _dictation.addListener(_onDictationChanged);
+  }
+
+  void _onDictationChanged() {
+    final error = _dictation.consumeError();
+    if (error != null && mounted) {
+      ScaffoldMessenger.of(context)
+        ..hideCurrentSnackBar()
+        ..showSnackBar(SnackBar(content: Text(error)));
+    }
+  }
+
+  @override
   void dispose() {
+    _dictation.removeListener(_onDictationChanged);
+    _dictation.dispose();
     _controller.dispose();
     _scrollController.dispose();
     super.dispose();
@@ -162,6 +186,7 @@ class _ChatPanelState extends ConsumerState<ChatPanel> {
           isStreaming: isStreaming,
           hint: widget.inputHint,
           onSend: _send,
+          dictation: _dictation,
         ),
       ],
     );
@@ -751,12 +776,14 @@ class _InputBar extends StatelessWidget {
   final bool isStreaming;
   final String hint;
   final VoidCallback onSend;
+  final DictationController dictation;
 
   const _InputBar({
     required this.controller,
     required this.isStreaming,
     required this.hint,
     required this.onSend,
+    required this.dictation,
   });
 
   @override
@@ -794,6 +821,7 @@ class _InputBar extends StatelessWidget {
               ),
             ),
           ),
+          _MicButton(dictation: dictation),
           const SizedBox(width: 8),
           IconButton.filled(
             onPressed: onSend,
@@ -801,6 +829,48 @@ class _InputBar extends StatelessWidget {
           ),
         ],
       ),
+    );
+  }
+}
+
+/// The dictation mic (specs/voice-dictation). Rebuilds only itself on
+/// dictation state changes; absent entirely when no capture path exists.
+class _MicButton extends StatelessWidget {
+  final DictationController dictation;
+
+  const _MicButton({required this.dictation});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return ListenableBuilder(
+      listenable: dictation,
+      builder: (context, _) {
+        if (!dictation.available) return const SizedBox.shrink();
+        switch (dictation.status) {
+          case DictationStatus.transcribing:
+            return const Padding(
+              padding: EdgeInsets.symmetric(horizontal: 12),
+              child: SizedBox(
+                width: 20,
+                height: 20,
+                child: CircularProgressIndicator(strokeWidth: 2),
+              ),
+            );
+          case DictationStatus.listening:
+            return IconButton(
+              tooltip: 'Stop dictating',
+              onPressed: dictation.toggle,
+              icon: Icon(Icons.mic, color: theme.colorScheme.error),
+            );
+          case DictationStatus.idle:
+            return IconButton(
+              tooltip: 'Dictate',
+              onPressed: dictation.toggle,
+              icon: const Icon(Icons.mic_none),
+            );
+        }
+      },
     );
   }
 }

--- a/src/packages/flutter-app/linux/flutter/generated_plugin_registrant.cc
+++ b/src/packages/flutter-app/linux/flutter/generated_plugin_registrant.cc
@@ -7,12 +7,16 @@
 #include "generated_plugin_registrant.h"
 
 #include <flutter_secure_storage_linux/flutter_secure_storage_linux_plugin.h>
+#include <record_linux/record_linux_plugin.h>
 #include <url_launcher_linux/url_launcher_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) flutter_secure_storage_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "FlutterSecureStorageLinuxPlugin");
   flutter_secure_storage_linux_plugin_register_with_registrar(flutter_secure_storage_linux_registrar);
+  g_autoptr(FlPluginRegistrar) record_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "RecordLinuxPlugin");
+  record_linux_plugin_register_with_registrar(record_linux_registrar);
   g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
   url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);

--- a/src/packages/flutter-app/linux/flutter/generated_plugins.cmake
+++ b/src/packages/flutter-app/linux/flutter/generated_plugins.cmake
@@ -4,6 +4,7 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   flutter_secure_storage_linux
+  record_linux
   url_launcher_linux
 )
 

--- a/src/packages/flutter-app/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/src/packages/flutter-app/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -7,12 +7,16 @@ import Foundation
 
 import flutter_secure_storage_macos
 import path_provider_foundation
+import record_macos
 import shared_preferences_foundation
+import speech_to_text
 import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FlutterSecureStoragePlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStoragePlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
+  RecordMacOsPlugin.register(with: registry.registrar(forPlugin: "RecordMacOsPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
+  SpeechToTextPlugin.register(with: registry.registrar(forPlugin: "SpeechToTextPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
 }

--- a/src/packages/flutter-app/macos/Runner/DebugProfile.entitlements
+++ b/src/packages/flutter-app/macos/Runner/DebugProfile.entitlements
@@ -4,6 +4,8 @@
 <dict>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
+	<key>com.apple.security.device.audio-input</key>
+	<true/>
 	<key>com.apple.security.cs.allow-jit</key>
 	<true/>
 	<key>com.apple.security.network.server</key>

--- a/src/packages/flutter-app/macos/Runner/Info.plist
+++ b/src/packages/flutter-app/macos/Runner/Info.plist
@@ -28,5 +28,9 @@
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>The microphone is used to dictate chat messages to the trip planner.</string>
+	<key>NSSpeechRecognitionUsageDescription</key>
+	<string>Speech recognition turns your dictated words into text you can review before sending.</string>
 </dict>
 </plist>

--- a/src/packages/flutter-app/macos/Runner/Release.entitlements
+++ b/src/packages/flutter-app/macos/Runner/Release.entitlements
@@ -4,5 +4,7 @@
 <dict>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
+	<key>com.apple.security.device.audio-input</key>
+	<true/>
 </dict>
 </plist>

--- a/src/packages/flutter-app/pubspec.lock
+++ b/src/packages/flutter-app/pubspec.lock
@@ -752,6 +752,70 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
+  record:
+    dependency: "direct main"
+    description:
+      name: record
+      sha256: "10911465138fafacef459a780564e883e01bd48eabf87ab20543684884492870"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.2.1"
+  record_android:
+    dependency: transitive
+    description:
+      name: record_android
+      sha256: eb1732e42d0d2a1895b8db86e4fc917287e6d8491b6ed59918aea8bed6c69de4
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.5.2"
+  record_ios:
+    dependency: transitive
+    description:
+      name: record_ios
+      sha256: c051fb48edd7a0e265daafb9108730dc827c27b551728a3fdfb3ef69efd89c73
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.1"
+  record_linux:
+    dependency: transitive
+    description:
+      name: record_linux
+      sha256: "31181787bf7eccb0e298835836b69b3cd0a903863b75d70e937de3dec71cd8f3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.1"
+  record_macos:
+    dependency: transitive
+    description:
+      name: record_macos
+      sha256: cfe1b61435e27db418bf513dc36820d10c9f7eb1843786c2c9a52e07e2f4f627
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.2"
+  record_platform_interface:
+    dependency: transitive
+    description:
+      name: record_platform_interface
+      sha256: "8e56cbe06c6984137fb86132ff03459f29938d927496d9b2d0962e2d6345d488"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.6.0"
+  record_web:
+    dependency: transitive
+    description:
+      name: record_web
+      sha256: "7e9846981c1f2d111d86f0ae3309071f5bba8b624d1c977316706f08fc31d16d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.0"
+  record_windows:
+    dependency: transitive
+    description:
+      name: record_windows
+      sha256: "223258060a1d25c62bae18282c16783f28581ec19401d17e56b5205b9f039d78"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.7"
   riverpod:
     dependency: transitive
     description:
@@ -869,6 +933,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.10.0"
+  speech_to_text:
+    dependency: "direct main"
+    description:
+      name: speech_to_text
+      sha256: "75587f7400f485fdf166beacd471549d98fe5d58e634f708916bb65dec05d6a4"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.4.0"
+  speech_to_text_platform_interface:
+    dependency: transitive
+    description:
+      name: speech_to_text_platform_interface
+      sha256: a7e16e02853853ed7534ac2bde9a1c4f39c8879970a7974ac6ff832d4bdaa4b0
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.0"
+  speech_to_text_windows:
+    dependency: transitive
+    description:
+      name: speech_to_text_windows
+      sha256: "2d1d10565b23262386b453b33656299608dc7a66784453735d6c1318f13f44d7"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.1"
   stack_trace:
     dependency: transitive
     description:

--- a/src/packages/flutter-app/pubspec.yaml
+++ b/src/packages/flutter-app/pubspec.yaml
@@ -72,6 +72,8 @@ dependencies:
   flutter_map: ^8.0.0
   flutter_map_marker_cluster: ^8.2.2
   latlong2: ^0.9.1
+  speech_to_text: ^7.4.0
+  record: ^6.2.1
 
 dev_dependencies:
   flutter_test:

--- a/src/packages/flutter-app/test/chat_panel_dictation_test.dart
+++ b/src/packages/flutter-app/test/chat_panel_dictation_test.dart
@@ -1,0 +1,171 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:travel_route_planner/providers/dictation_provider.dart';
+import 'package:travel_route_planner/providers/plan_provider.dart';
+import 'package:travel_route_planner/services/api_client.dart';
+import 'package:travel_route_planner/services/dictation_controller.dart';
+import 'package:travel_route_planner/services/dictation_engine.dart';
+import 'package:travel_route_planner/services/plan_service.dart';
+import 'package:travel_route_planner/widgets/chat_panel.dart';
+
+class _FakeEngine implements DictationEngine {
+  final bool initOk;
+  StreamController<DictationEvent>? _events;
+
+  _FakeEngine({this.initOk = true});
+
+  @override
+  Future<bool> initialize() async => initOk;
+
+  @override
+  Stream<DictationEvent> start() {
+    _events = StreamController<DictationEvent>();
+    return _events!.stream;
+  }
+
+  @override
+  Future<void> stop() async {}
+
+  @override
+  Future<void> cancel() async => end();
+
+  void emit(DictationEvent event) => _events!.add(event);
+
+  Future<void> end() async {
+    final events = _events;
+    _events = null;
+    if (events != null && !events.isClosed) await events.close();
+  }
+}
+
+/// Replies instantly with one delta; records sent messages. No network.
+class _FakePlanService extends PlanService {
+  final sent = <String>[];
+
+  _FakePlanService() : super('http://unused');
+
+  @override
+  Stream<PlanEvent> streamPlan(
+    List<Map<String, String>> messages, {
+    String? bearerToken,
+    String? chatId,
+    String? tripId,
+    String? summary,
+  }) async* {
+    sent.add(messages.last['content'] ?? '');
+    yield PlanEvent(type: 'text_delta', data: {'text': 'ok'});
+  }
+}
+
+Future<_FakePlanService> _pumpPanel(
+  WidgetTester tester, {
+  required _FakeEngine engine,
+  bool serverAvailable = false,
+}) async {
+  final service = _FakePlanService();
+  final notifier = PlanNotifier(service, ApiClient());
+  final provider =
+      StateNotifierProvider<PlanNotifier, PlanState>((ref) => notifier);
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        dictationControllerFactoryProvider.overrideWithValue(
+          (textController) => DictationController(
+            textController: textController,
+            primary: engine,
+            fallback: null,
+            fallbackAvailable: () async => serverAvailable,
+          ),
+        ),
+      ],
+      child: MaterialApp(
+        home: Scaffold(
+          body: ChatPanel(state: provider, notifier: provider.notifier),
+        ),
+      ),
+    ),
+  );
+  await tester.pump(); // let async engine init resolve
+  return service;
+}
+
+void main() {
+  testWidgets('mic dictates into the field and the send path is the normal one',
+      (WidgetTester tester) async {
+    final engine = _FakeEngine();
+    final service = await _pumpPanel(tester, engine: engine);
+
+    expect(find.byIcon(Icons.mic_none), findsOneWidget);
+
+    await tester.tap(find.byIcon(Icons.mic_none));
+    await tester.pump();
+    expect(find.byIcon(Icons.mic), findsOneWidget,
+        reason: 'listening state icon');
+
+    engine.emit(const DictationEvent('partial', text: 'three days'));
+    await tester.pump();
+    expect(find.text('three days'), findsOneWidget);
+
+    engine.emit(const DictationEvent('final', text: 'three days in crete'));
+    await engine.end();
+    await tester.pump();
+    expect(find.byIcon(Icons.mic_none), findsOneWidget, reason: 'back to idle');
+    expect(find.text('three days in crete'), findsOneWidget);
+
+    // Nothing was auto-sent; the user sends explicitly.
+    expect(service.sent, isEmpty);
+    await tester.tap(find.byIcon(Icons.send));
+    await tester.pumpAndSettle();
+    expect(service.sent, ['three days in crete']);
+  });
+
+  testWidgets('mic is absent when no dictation path exists',
+      (WidgetTester tester) async {
+    await _pumpPanel(tester,
+        engine: _FakeEngine(initOk: false), serverAvailable: false);
+    await tester.pump();
+
+    expect(find.byIcon(Icons.mic_none), findsNothing);
+    expect(find.byIcon(Icons.mic), findsNothing);
+    expect(find.byIcon(Icons.send), findsOneWidget,
+        reason: 'composer otherwise intact');
+  });
+
+  testWidgets('transcribing state shows a spinner instead of the mic',
+      (WidgetTester tester) async {
+    final engine = _FakeEngine();
+    await _pumpPanel(tester, engine: engine);
+
+    await tester.tap(find.byIcon(Icons.mic_none));
+    await tester.pump();
+    engine.emit(const DictationEvent('transcribing'));
+    await tester.pump();
+
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    expect(find.byIcon(Icons.mic), findsNothing);
+
+    engine.emit(const DictationEvent('final', text: 'hi'));
+    await engine.end();
+    await tester.pump();
+    expect(find.byIcon(Icons.mic_none), findsOneWidget);
+  });
+
+  testWidgets('dictation errors surface as a SnackBar, not a chat error',
+      (WidgetTester tester) async {
+    final engine = _FakeEngine();
+    await _pumpPanel(tester, engine: engine);
+
+    await tester.tap(find.byIcon(Icons.mic_none));
+    await tester.pump();
+    engine.emit(const DictationEvent('error', errorCode: 'permission'));
+    await engine.end();
+    await tester.pump();
+
+    expect(find.byType(SnackBar), findsOneWidget);
+    expect(find.textContaining('Microphone access'), findsOneWidget);
+  });
+}

--- a/src/packages/flutter-app/test/dictation_controller_test.dart
+++ b/src/packages/flutter-app/test/dictation_controller_test.dart
@@ -1,0 +1,269 @@
+import 'dart:async';
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:travel_route_planner/services/dictation_controller.dart';
+import 'package:travel_route_planner/services/dictation_engine.dart';
+
+/// Scripted engine: the test drives events onto the active session's stream.
+class _FakeEngine implements DictationEngine {
+  final bool initOk;
+  int startCalls = 0;
+  int stopCalls = 0;
+  int cancelCalls = 0;
+  StreamController<DictationEvent>? _events;
+
+  _FakeEngine({this.initOk = true});
+
+  @override
+  Future<bool> initialize() async => initOk;
+
+  @override
+  Stream<DictationEvent> start() {
+    startCalls++;
+    _events = StreamController<DictationEvent>();
+    return _events!.stream;
+  }
+
+  @override
+  Future<void> stop() async {
+    stopCalls++;
+  }
+
+  @override
+  Future<void> cancel() async {
+    cancelCalls++;
+    await end();
+  }
+
+  void emit(DictationEvent event) => _events!.add(event);
+
+  Future<void> end() async {
+    final events = _events;
+    _events = null;
+    if (events != null && !events.isClosed) await events.close();
+  }
+}
+
+DictationController _controller(
+  TextEditingController text, {
+  _FakeEngine? primary,
+  _FakeEngine? fallback,
+  bool serverAvailable = false,
+}) {
+  return DictationController(
+    textController: text,
+    primary: primary,
+    fallback: fallback,
+    fallbackAvailable: () async => serverAvailable,
+  );
+}
+
+void main() {
+  test('available when the primary engine initializes', () async {
+    final text = TextEditingController();
+    final dictation = _controller(text, primary: _FakeEngine());
+    await pumpEventQueue();
+    expect(dictation.available, isTrue);
+  });
+
+  test('falls back to the recorder engine when primary cannot initialize',
+      () async {
+    final text = TextEditingController();
+    final primary = _FakeEngine(initOk: false);
+    final fallback = _FakeEngine();
+    final dictation = _controller(text,
+        primary: primary, fallback: fallback, serverAvailable: true);
+    await pumpEventQueue();
+    expect(dictation.available, isTrue);
+
+    await dictation.toggle();
+    expect(fallback.startCalls, 1);
+    expect(primary.startCalls, 0);
+  });
+
+  test('unavailable when no path exists — mic hidden', () async {
+    final text = TextEditingController();
+    final dictation = _controller(text,
+        primary: _FakeEngine(initOk: false),
+        fallback: _FakeEngine(),
+        serverAvailable: false);
+    await pumpEventQueue();
+    expect(dictation.available, isFalse);
+
+    await dictation.toggle();
+    expect(dictation.status, DictationStatus.idle);
+  });
+
+  test('appends transcripts to typed text; partials overlay, finals commit',
+      () async {
+    final text = TextEditingController(text: 'Also: ');
+    final engine = _FakeEngine();
+    final dictation = _controller(text, primary: engine);
+    await pumpEventQueue();
+
+    await dictation.toggle();
+    expect(dictation.status, DictationStatus.listening);
+
+    // Web Speech partials are cumulative — each replaces the previous
+    // overlay rather than stacking.
+    engine.emit(const DictationEvent('partial', text: 'two'));
+    await pumpEventQueue();
+    expect(text.text, 'Also: two');
+
+    engine.emit(const DictationEvent('partial', text: 'two days in'));
+    await pumpEventQueue();
+    expect(text.text, 'Also: two days in');
+
+    engine.emit(const DictationEvent('final', text: 'two days in athens'));
+    await pumpEventQueue();
+    expect(text.text, 'Also: two days in athens');
+    expect(text.selection.baseOffset, text.text.length,
+        reason: 'caret pinned to the end');
+
+    await engine.end();
+    await pumpEventQueue();
+    expect(dictation.status, DictationStatus.idle);
+    expect(text.text, 'Also: two days in athens',
+        reason: 'transcript survives the session ending');
+  });
+
+  test('a session that ends with no speech leaves the field untouched',
+      () async {
+    final text = TextEditingController(text: 'typed');
+    final engine = _FakeEngine();
+    final dictation = _controller(text, primary: engine);
+    await pumpEventQueue();
+
+    await dictation.toggle();
+    await engine.end();
+    await pumpEventQueue();
+    expect(text.text, 'typed');
+    expect(dictation.status, DictationStatus.idle);
+    expect(dictation.consumeError(), isNull);
+  });
+
+  test('a user edit while listening cancels the session and keeps the edit',
+      () async {
+    final text = TextEditingController();
+    final engine = _FakeEngine();
+    final dictation = _controller(text, primary: engine);
+    await pumpEventQueue();
+
+    await dictation.toggle();
+    engine.emit(const DictationEvent('partial', text: 'hello'));
+    await pumpEventQueue();
+    expect(text.text, 'hello');
+
+    text.text = 'hello everyone'; // genuine user edit
+    await pumpEventQueue();
+    expect(engine.cancelCalls, 1);
+    expect(dictation.status, DictationStatus.idle);
+    expect(text.text, 'hello everyone');
+  });
+
+  test('permission errors surface a one-shot message', () async {
+    final text = TextEditingController();
+    final engine = _FakeEngine();
+    final dictation = _controller(text, primary: engine);
+    await pumpEventQueue();
+
+    await dictation.toggle();
+    engine.emit(const DictationEvent('error', errorCode: 'permission'));
+    await engine.end();
+    await pumpEventQueue();
+
+    expect(dictation.consumeError(), contains('Microphone access'));
+    expect(dictation.consumeError(), isNull, reason: 'one-shot');
+    expect(dictation.status, DictationStatus.idle);
+  });
+
+  test(
+      'engine-failed on the live path switches to the fallback and retries once',
+      () async {
+    final text = TextEditingController();
+    final primary = _FakeEngine();
+    final fallback = _FakeEngine();
+    final dictation = _controller(text,
+        primary: primary, fallback: fallback, serverAvailable: true);
+    await pumpEventQueue();
+
+    await dictation.toggle();
+    expect(primary.startCalls, 1);
+
+    // Brave-style: API present, start fails at runtime.
+    primary.emit(const DictationEvent('error', errorCode: 'engine-failed'));
+    await pumpEventQueue();
+
+    expect(fallback.startCalls, 1, reason: 'retried on the recorder path');
+    expect(dictation.status, DictationStatus.listening);
+    expect(dictation.available, isTrue);
+
+    // Later sessions go straight to the fallback.
+    fallback.emit(const DictationEvent('final', text: 'hi'));
+    await fallback.end();
+    await pumpEventQueue();
+    await dictation.toggle();
+    expect(fallback.startCalls, 2);
+    expect(primary.startCalls, 1);
+  });
+
+  test('engine-failed with no usable fallback hides the mic', () async {
+    final text = TextEditingController();
+    final primary = _FakeEngine();
+    final dictation = _controller(text,
+        primary: primary, fallback: _FakeEngine(), serverAvailable: false);
+    await pumpEventQueue();
+
+    await dictation.toggle();
+    primary.emit(const DictationEvent('error', errorCode: 'engine-failed'));
+    await pumpEventQueue();
+
+    expect(dictation.available, isFalse);
+    expect(dictation.consumeError(), contains("isn't available"));
+  });
+
+  test('a 503 mid-session hides the mic going forward', () async {
+    final text = TextEditingController();
+    final fallback = _FakeEngine();
+    final dictation = _controller(text,
+        primary: _FakeEngine(initOk: false),
+        fallback: fallback,
+        serverAvailable: true);
+    await pumpEventQueue();
+    expect(dictation.available, isTrue);
+
+    await dictation.toggle();
+    fallback.emit(const DictationEvent('error', errorCode: 'unavailable'));
+    await fallback.end();
+    await pumpEventQueue();
+
+    expect(dictation.available, isFalse);
+    expect(dictation.consumeError(), contains("isn't available"));
+  });
+
+  test('transcribing status is reported for the recorder path', () async {
+    final text = TextEditingController();
+    final fallback = _FakeEngine();
+    final dictation = _controller(text,
+        primary: _FakeEngine(initOk: false),
+        fallback: fallback,
+        serverAvailable: true);
+    await pumpEventQueue();
+
+    await dictation.toggle();
+    await dictation.toggle(); // stop -> engine uploads
+    expect(fallback.stopCalls, 1);
+
+    fallback.emit(const DictationEvent('transcribing'));
+    await pumpEventQueue();
+    expect(dictation.status, DictationStatus.transcribing);
+
+    fallback.emit(const DictationEvent('final', text: 'ferry to naxos'));
+    await fallback.end();
+    await pumpEventQueue();
+    expect(text.text, 'ferry to naxos');
+    expect(dictation.status, DictationStatus.idle);
+  });
+}

--- a/src/packages/flutter-app/test/transcribe_api_service_test.dart
+++ b/src/packages/flutter-app/test/transcribe_api_service_test.dart
@@ -1,0 +1,72 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+import 'package:travel_route_planner/services/api_client.dart';
+import 'package:travel_route_planner/services/transcribe_api_service.dart';
+
+TranscribeApiService _service(MockClient client) {
+  return TranscribeApiService(
+      ApiClient(baseUrl: 'http://test/api/v1', client: client));
+}
+
+void main() {
+  test('transcribe POSTs raw bytes with the recorder MIME passed through',
+      () async {
+    late http.Request captured;
+    final service = _service(MockClient((request) async {
+      captured = request;
+      return http.Response(jsonEncode({'text': 'hello', 'status': 'success'}),
+          200,
+          headers: {'content-type': 'application/json'});
+    }));
+
+    final audio = Uint8List.fromList([1, 2, 3, 4]);
+    final text = await service.transcribe(audio, 'audio/ogg; codecs=opus');
+
+    expect(text, 'hello');
+    expect(captured.method, 'POST');
+    expect(captured.url.path, '/api/v1/transcribe');
+    expect(captured.headers['Content-Type'], startsWith('audio/ogg'));
+    expect(captured.bodyBytes, audio);
+  });
+
+  test('a 503 surfaces as TranscribeUnavailableException', () async {
+    final service = _service(MockClient((request) async {
+      return http.Response(
+          jsonEncode({'message': 'Transcription is not configured'}), 503);
+    }));
+
+    expect(() => service.transcribe(Uint8List.fromList([1]), 'audio/webm'),
+        throwsA(isA<TranscribeUnavailableException>()));
+  });
+
+  test('other errors surface the server message', () async {
+    final service = _service(MockClient((request) async {
+      return http.Response(
+          jsonEncode({'message': 'Failed to transcribe audio'}), 502);
+    }));
+
+    expect(
+        () => service.transcribe(Uint8List.fromList([1]), 'audio/webm'),
+        throwsA(predicate(
+            (e) => e.toString().contains('Failed to transcribe audio'))));
+  });
+
+  test('availability parses the flag and fails closed', () async {
+    for (final (body, code, want) in [
+      ('{"available": true}', 200, true),
+      ('{"available": false}', 200, false),
+      ('oops', 200, false),
+      ('{"available": true}', 500, false),
+    ]) {
+      final service =
+          _service(MockClient((request) async => http.Response(body, code)));
+      expect(await service.availability(), want,
+          reason: 'body=$body code=$code');
+    }
+  });
+}

--- a/src/packages/flutter-app/windows/flutter/generated_plugin_registrant.cc
+++ b/src/packages/flutter-app/windows/flutter/generated_plugin_registrant.cc
@@ -7,11 +7,17 @@
 #include "generated_plugin_registrant.h"
 
 #include <flutter_secure_storage_windows/flutter_secure_storage_windows_plugin.h>
+#include <record_windows/record_windows_plugin_c_api.h>
+#include <speech_to_text_windows/speech_to_text_windows.h>
 #include <url_launcher_windows/url_launcher_windows.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
   FlutterSecureStorageWindowsPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FlutterSecureStorageWindowsPlugin"));
+  RecordWindowsPluginCApiRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("RecordWindowsPluginCApi"));
+  SpeechToTextWindowsRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("SpeechToTextWindows"));
   UrlLauncherWindowsRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("UrlLauncherWindows"));
 }

--- a/src/packages/flutter-app/windows/flutter/generated_plugins.cmake
+++ b/src/packages/flutter-app/windows/flutter/generated_plugins.cmake
@@ -4,6 +4,8 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   flutter_secure_storage_windows
+  record_windows
+  speech_to_text_windows
   url_launcher_windows
 )
 


### PR DESCRIPTION
## Summary
- Mic button in the chat composer (agent tab + trip refine panel): tap, speak, and the transcript lands in the text field for review — appended to typed text, sent manually through the normal path (queue-while-streaming intact)
- Primary path: browser-native Web Speech via `speech_to_text` (live partial transcripts; Chrome/Safari/Edge, native recognizers on mobile with permission entries added)
- Fallback path: `record` (MediaRecorder opus) → new `POST /api/v1/transcribe` → any OpenAI-compatible provider (Groq `whisper-large-v3-turbo` default via `TRANSCRIPTION_API_KEY/_BASE_URL/_MODEL`); no key ⇒ Duffel-style 503 degraded mode
- Mic hides when neither path exists (`GET /transcribe/availability` capability check); Brave-style browsers with broken Web Speech degrade to the recorder at runtime and retry the tap
- Plumbing: dedicated IP rate-limit bucket, 10 MiB `bodyLimitMiddleware` lane for `/transcribe`, `client_max_body_size 10m` on both nginx gateways, privacy-page disclosure, `specs/voice-dictation/` (spec, plan with parity table, tasks)

## Testing
- Go: `gofmt`/`go vet` clean; new service/handler/middleware tests (multipart forwarding, MIME→filename mapping, 503/400/502 paths, body lanes); full package passes
- Flutter: 19 new tests (controller append/error/fallback semantics, widget mic states, API service); full suite 168/168; analyze clean under CI flags
- Live dev stack: mic renders in the composer, turns red on tap (listening), silence auto-stop is a clean no-op; through the gateway 2 MB audio reaches the app, 11 MB → 413, other endpoints keep the tight 256 KiB lane; availability/503 degraded mode verified without a key
- Still needs a human pass (tracked in specs/voice-dictation/tasks.md): real-mic Chrome dictation, Firefox fallback with a Groq key, one COOP/COEP check on a deployment build

🤖 Generated with [Claude Code](https://claude.com/claude-code)