### PR TITLE
fix(flutter): re-fit trip map when destinations change

### DIFF
--- a/src/packages/flutter-app/lib/widgets/trip_map.dart
+++ b/src/packages/flutter-app/lib/widgets/trip_map.dart
@@ -1,5 +1,6 @@
 import 'dart:math' as math;
 
+import 'package:flutter/foundation.dart' show setEquals;
 import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map_marker_cluster/flutter_map_marker_cluster.dart';
@@ -114,13 +115,17 @@ class _TripMapState extends State<TripMap> {
   }
 
   /// Every coordinate the camera should frame: mapped items plus geocoded
-  /// stays. Mirrors the fitPoints assembled in [build].
-  List<LatLng> _fitPoints() {
+  /// stays. Mirrors the fitPoints assembled in [build]. Static so it can run
+  /// against an oldWidget's lists in [didUpdateWidget].
+  static List<LatLng> _fitPointsOf(
+    List<ItineraryItem> items,
+    List<Accommodation> accommodations,
+  ) {
     final points = <LatLng>[
-      for (final it in widget.items)
+      for (final it in items)
         if (_hasCoords(it)) LatLng(it.latitude, it.longitude),
     ];
-    for (final a in widget.accommodations) {
+    for (final a in accommodations) {
       final lat = a.latitude;
       final lng = a.longitude;
       if (lat != null && lng != null && (lat != 0 || lng != 0)) {
@@ -130,10 +135,27 @@ class _TripMapState extends State<TripMap> {
     return points;
   }
 
+  List<LatLng> _fitPoints() => _fitPointsOf(widget.items, widget.accommodations);
+
   @override
   void didUpdateWidget(covariant TripMap oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (widget.fitSignature != oldWidget.fitSignature) {
+    final signatureChanged = widget.fitSignature != oldWidget.fitSignature;
+    // The set of mappable coordinates changed (a place added/removed/moved,
+    // e.g. AI-streamed additions or a refresh delivering geocodes) while no
+    // pin is selected: reframe so nothing sits off-screen. Order-insensitive
+    // so a pure reorder never touches the camera. Skipped when the previous
+    // frame had nothing mappable: build() then swaps the empty-state
+    // Container for a freshly mounted FlutterMap whose initialCameraFit
+    // already frames the new content.
+    bool contentChanged() {
+      if (widget.selectedPosition != null) return false;
+      final oldPoints = _fitPointsOf(oldWidget.items, oldWidget.accommodations);
+      if (oldPoints.isEmpty) return false;
+      return !setEquals(_fitPoints().toSet(), oldPoints.toSet());
+    }
+
+    if (signatureChanged || contentChanged()) {
       // Re-fit after the frame that renders the new (filtered) content, so
       // the controller sees the updated layout. No-op when nothing is
       // mappable (the empty state has no live map to move).

--- a/src/packages/flutter-app/test/trip_map_test.dart
+++ b/src/packages/flutter-app/test/trip_map_test.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:latlong2/latlong.dart';
 
 import 'package:travel_route_planner/models/accommodation.dart';
 import 'package:travel_route_planner/models/itinerary_item.dart';
@@ -23,6 +25,11 @@ Widget _host(Widget child) => MaterialApp(
         ),
       ),
     );
+
+/// The live camera of the mounted FlutterMap, read from an element inside its
+/// subtree (TileLayer is always present).
+MapCamera _camera(WidgetTester tester) =>
+    MapCamera.of(tester.element(find.byType(TileLayer).first));
 
 void main() {
   // Tight cluster of Paris-area coordinates so every marker stays in the
@@ -126,6 +133,89 @@ void main() {
     await tester.pump();
 
     expect(find.text('No mapped places'), findsOneWidget);
+  });
+
+  testWidgets(
+      'adding a far-away item with unchanged fitSignature re-fits the camera '
+      'to contain all points', (WidgetTester tester) async {
+    await tester.pumpWidget(_host(TripMap(items: items, fitSignature: 'all')));
+    await tester.pump();
+
+    // Marseille: well outside the Paris-fit viewport, so the final assertions
+    // below are exactly what the pre-fix code violates.
+    const far = LatLng(43.2965, 5.3698);
+    expect(_camera(tester).visibleBounds.contains(far), isFalse);
+
+    await tester.pumpWidget(_host(TripMap(
+      items: [...items, _item(2, 'Vieux-Port', far.latitude, far.longitude)],
+      fitSignature: 'all', // unchanged — the bug condition
+    )));
+    await tester.pump(); // frame rendering the new pin schedules the re-fit
+    await tester.pump(); // post-frame callback has run; camera updated
+
+    final bounds = _camera(tester).visibleBounds;
+    expect(bounds.contains(far), isTrue);
+    for (final it in items) {
+      expect(bounds.contains(LatLng(it.latitude, it.longitude)), isTrue);
+    }
+  });
+
+  testWidgets('content change while a pin is selected does not yank the camera',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(
+      _host(TripMap(items: items, selectedPosition: 0, fitSignature: 'all')),
+    );
+    await tester.pump();
+
+    // Initial mount centers on the selected item at zoom 15.
+    expect(_camera(tester).zoom, 15);
+
+    const far = LatLng(43.2965, 5.3698);
+    await tester.pumpWidget(_host(TripMap(
+      items: [...items, _item(2, 'Vieux-Port', far.latitude, far.longitude)],
+      selectedPosition: 0,
+      fitSignature: 'all',
+    )));
+    await tester.pump();
+    await tester.pump();
+
+    final camera = _camera(tester);
+    expect(camera.zoom, 15);
+    expect(camera.center.latitude, closeTo(48.8606, 1e-4)); // still on Louvre
+    expect(camera.visibleBounds.contains(far), isFalse);
+  });
+
+  testWidgets('empty state to mapped content frames all points',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(_host(const TripMap(items: [])));
+    await tester.pump();
+    expect(find.text('No mapped places'), findsOneWidget);
+
+    await tester.pumpWidget(_host(TripMap(items: items)));
+    await tester.pump();
+    await tester.pump();
+
+    final bounds = _camera(tester).visibleBounds;
+    for (final it in items) {
+      expect(bounds.contains(LatLng(it.latitude, it.longitude)), isTrue);
+    }
+  });
+
+  testWidgets('reordering items does not move the camera',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(_host(TripMap(items: items)));
+    await tester.pump();
+
+    final before = _camera(tester);
+    await tester.pumpWidget(
+      _host(TripMap(items: items.reversed.toList())),
+    );
+    await tester.pump();
+    await tester.pump();
+
+    final after = _camera(tester);
+    expect(after.zoom, before.zoom);
+    expect(after.center, before.center);
   });
 
   testWidgets('stays alone (no mapped items) still render a map',


### PR DESCRIPTION
## Summary
- The trip map could leave a destination off-screen: the camera only reframed on first mount or on a day-chip (`fitSignature`) change, so places added or geocoded afterward (AI chat adds, silent refreshes) rendered outside the fitted bounds.
- `TripMap.didUpdateWidget` now also re-fits when the set of mappable coordinates (items + stays) changes. The comparison is order-insensitive so pure reorders never move the camera, it's skipped while a pin is selected so background updates can't yank the view off it, and the empty→nonempty transition still relies on the fresh mount's `initialCameraFit`.
- Day-chip `fitSignature` semantics and both call sites (`trip_detail_screen`, `shared_trip_screen`) are unchanged.

## Testing
- Four new widget tests in `test/trip_map_test.dart` read the live camera via `MapCamera.of` and assert visible bounds: far-away add with unchanged `fitSignature` re-fits to contain all points (verified to fail pre-fix), active selection suppresses the auto-refit, empty→mapped frames all points, reorder leaves the camera untouched.
- `flutter test`: 172 tests pass. `flutter analyze`: only the 12 pre-existing `withOpacity` deprecation infos in unrelated files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)