### PR TITLE
feat(flutter): tabbed admin analytics dashboard (trends, totals, activity, users)

### DIFF
--- a/src/packages/flutter-app/lib/models/admin_insights.dart
+++ b/src/packages/flutter-app/lib/models/admin_insights.dart
@@ -1,0 +1,242 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'admin_insights.g.dart';
+
+/// Models for the admin dashboard extensions (GET /admin/metrics/timeseries,
+/// /totals, /activity, /users). Kept separate from [AdminMetrics] so the
+/// original /admin/metrics contract stays untouched.
+
+/// One UTC day bucket in a trend series. Days with zero events are absent
+/// from the API payload; [AdminTimeseries.denseSeries] fills the gaps.
+@JsonSerializable()
+class DailyCount {
+  /// Parsed from YYYY-MM-DD — a UTC calendar day.
+  final DateTime day;
+  final int n;
+
+  const DailyCount({required this.day, this.n = 0});
+
+  factory DailyCount.fromJson(Map<String, dynamic> json) =>
+      _$DailyCountFromJson(json);
+  Map<String, dynamic> toJson() => _$DailyCountToJson(this);
+}
+
+/// Mirror of /admin/metrics/timeseries: sparse daily buckets per event type.
+/// Every dashboard series key is always present (empty list included), so the
+/// Trends tab renders stable chart slots.
+@JsonSerializable()
+class AdminTimeseries {
+  final int days;
+  @JsonKey(name: 'start_day')
+  final DateTime startDay;
+  final Map<String, List<DailyCount>> series;
+
+  const AdminTimeseries({
+    this.days = 30,
+    required this.startDay,
+    this.series = const {},
+  });
+
+  /// The sparse series for [key] expanded to one entry per day of the window,
+  /// zero-filled. Chart-ready: length is always [days].
+  ///
+  /// Days are compared as UTC calendar dates: DateTime.parse on the API's
+  /// bare "YYYY-MM-DD" yields a LOCAL midnight, which would never equal a
+  /// DateTime.utc key, so both sides are normalized through [_utcDay].
+  List<DailyCount> denseSeries(String key) {
+    final byDay = <DateTime, int>{
+      for (final c in series[key] ?? const <DailyCount>[]) _utcDay(c.day): c.n,
+    };
+    return List.generate(days, (i) {
+      final day = DateTime.utc(startDay.year, startDay.month, startDay.day + i);
+      return DailyCount(day: day, n: byDay[day] ?? 0);
+    });
+  }
+
+  static DateTime _utcDay(DateTime d) => DateTime.utc(d.year, d.month, d.day);
+
+  factory AdminTimeseries.fromJson(Map<String, dynamic> json) =>
+      _$AdminTimeseriesFromJson(json);
+  Map<String, dynamic> toJson() => _$AdminTimeseriesToJson(this);
+}
+
+/// Mirror of /admin/metrics/totals: all-time counts straight off the domain
+/// tables — not scoped to a days window, unlike [AdminMetrics].
+@JsonSerializable()
+class AdminTotals {
+  final int users;
+  @JsonKey(name: 'verified_users')
+  final int verifiedUsers;
+  @JsonKey(name: 'onboarded_users')
+  final int onboardedUsers;
+  final int trips;
+
+  /// Distinct trip lineages (COALESCE(chat_id, id) — the My Trips grouping).
+  @JsonKey(name: 'trip_lineages')
+  final int tripLineages;
+  @JsonKey(name: 'itinerary_items')
+  final int itineraryItems;
+  @JsonKey(name: 'booking_todos')
+  final int bookingTodos;
+  @JsonKey(name: 'active_price_alerts')
+  final int activePriceAlerts;
+  @JsonKey(name: 'published_local_recs')
+  final int publishedLocalRecs;
+  @JsonKey(name: 'local_guides')
+  final int localGuides;
+  @JsonKey(name: 'active_collaborators')
+  final int activeCollaborators;
+  @JsonKey(name: 'active_shares')
+  final int activeShares;
+  @JsonKey(name: 'active_sessions')
+  final int activeSessions;
+  @JsonKey(name: 'analytics_events')
+  final int analyticsEvents;
+
+  const AdminTotals({
+    this.users = 0,
+    this.verifiedUsers = 0,
+    this.onboardedUsers = 0,
+    this.trips = 0,
+    this.tripLineages = 0,
+    this.itineraryItems = 0,
+    this.bookingTodos = 0,
+    this.activePriceAlerts = 0,
+    this.publishedLocalRecs = 0,
+    this.localGuides = 0,
+    this.activeCollaborators = 0,
+    this.activeShares = 0,
+    this.activeSessions = 0,
+    this.analyticsEvents = 0,
+  });
+
+  factory AdminTotals.fromJson(Map<String, dynamic> json) =>
+      _$AdminTotalsFromJson(json);
+  Map<String, dynamic> toJson() => _$AdminTotalsToJson(this);
+}
+
+/// One row of the activity tail. [userEmail] is null for anonymous events
+/// (the API keys anonymity off user_id, never an empty email).
+@JsonSerializable()
+class AdminActivityEvent {
+  final String id;
+  @JsonKey(name: 'event_type')
+  final String eventType;
+  @JsonKey(name: 'user_email')
+  final String? userEmail;
+  @JsonKey(name: 'user_is_admin')
+  final bool userIsAdmin;
+  @JsonKey(name: 'trip_id')
+  final String? tripId;
+
+  /// Sanitized-at-ingest metadata (provider, surface, source, …), echoed
+  /// verbatim by the API. Null when the event carried none.
+  final Map<String, dynamic>? metadata;
+  @JsonKey(name: 'created_at')
+  final DateTime createdAt;
+
+  const AdminActivityEvent({
+    required this.id,
+    required this.eventType,
+    this.userEmail,
+    this.userIsAdmin = false,
+    this.tripId,
+    this.metadata,
+    required this.createdAt,
+  });
+
+  factory AdminActivityEvent.fromJson(Map<String, dynamic> json) =>
+      _$AdminActivityEventFromJson(json);
+  Map<String, dynamic> toJson() => _$AdminActivityEventToJson(this);
+}
+
+/// Mirror of /admin/metrics/activity: one page of the event tail plus the
+/// keyset cursor for the next page (null on the last page).
+@JsonSerializable()
+class AdminActivityFeed {
+  final List<AdminActivityEvent> events;
+  @JsonKey(name: 'next_before')
+  final String? nextBefore;
+
+  const AdminActivityFeed({this.events = const [], this.nextBefore});
+
+  factory AdminActivityFeed.fromJson(Map<String, dynamic> json) =>
+      _$AdminActivityFeedFromJson(json);
+  Map<String, dynamic> toJson() => _$AdminActivityFeedToJson(this);
+}
+
+/// One row of /admin/metrics/users: a user plus their activity aggregates.
+@JsonSerializable()
+class AdminUserRow {
+  final String id;
+  final String email;
+  @JsonKey(name: 'display_name')
+  final String? displayName;
+  @JsonKey(name: 'is_admin')
+  final bool isAdmin;
+  @JsonKey(name: 'signed_up_at')
+  final DateTime signedUpAt;
+  final bool onboarded;
+  @JsonKey(name: 'email_verified')
+  final bool emailVerified;
+  final int trips;
+  @JsonKey(name: 'trip_lineages')
+  final int tripLineages;
+  @JsonKey(name: 'plan_sessions')
+  final int planSessions;
+  @JsonKey(name: 'booking_clicks')
+  final int bookingClicks;
+  @JsonKey(name: 'plan_input_tokens')
+  final int planInputTokens;
+  @JsonKey(name: 'plan_output_tokens')
+  final int planOutputTokens;
+  @JsonKey(name: 'plan_cache_read_tokens')
+  final int planCacheReadTokens;
+  @JsonKey(name: 'plan_cache_creation_tokens')
+  final int planCacheCreationTokens;
+
+  /// Same pricing basis as [AdminMetrics.estClaudeCostUsd] — estimate only.
+  @JsonKey(name: 'est_claude_cost_usd')
+  final double estClaudeCostUsd;
+
+  /// Null for users with no analytics events yet.
+  @JsonKey(name: 'last_event_at')
+  final DateTime? lastEventAt;
+
+  const AdminUserRow({
+    required this.id,
+    required this.email,
+    this.displayName,
+    this.isAdmin = false,
+    required this.signedUpAt,
+    this.onboarded = false,
+    this.emailVerified = false,
+    this.trips = 0,
+    this.tripLineages = 0,
+    this.planSessions = 0,
+    this.bookingClicks = 0,
+    this.planInputTokens = 0,
+    this.planOutputTokens = 0,
+    this.planCacheReadTokens = 0,
+    this.planCacheCreationTokens = 0,
+    this.estClaudeCostUsd = 0,
+    this.lastEventAt,
+  });
+
+  factory AdminUserRow.fromJson(Map<String, dynamic> json) =>
+      _$AdminUserRowFromJson(json);
+  Map<String, dynamic> toJson() => _$AdminUserRowToJson(this);
+}
+
+/// Mirror of /admin/metrics/users: one offset page plus the all-time total.
+@JsonSerializable()
+class AdminUserList {
+  final int total;
+  final List<AdminUserRow> users;
+
+  const AdminUserList({this.total = 0, this.users = const []});
+
+  factory AdminUserList.fromJson(Map<String, dynamic> json) =>
+      _$AdminUserListFromJson(json);
+  Map<String, dynamic> toJson() => _$AdminUserListToJson(this);
+}

--- a/src/packages/flutter-app/lib/models/admin_insights.g.dart
+++ b/src/packages/flutter-app/lib/models/admin_insights.g.dart
@@ -1,0 +1,172 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'admin_insights.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+DailyCount _$DailyCountFromJson(Map<String, dynamic> json) => DailyCount(
+      day: DateTime.parse(json['day'] as String),
+      n: (json['n'] as num?)?.toInt() ?? 0,
+    );
+
+Map<String, dynamic> _$DailyCountToJson(DailyCount instance) =>
+    <String, dynamic>{
+      'day': instance.day.toIso8601String(),
+      'n': instance.n,
+    };
+
+AdminTimeseries _$AdminTimeseriesFromJson(Map<String, dynamic> json) =>
+    AdminTimeseries(
+      days: (json['days'] as num?)?.toInt() ?? 30,
+      startDay: DateTime.parse(json['start_day'] as String),
+      series: (json['series'] as Map<String, dynamic>?)?.map(
+            (k, e) => MapEntry(
+                k,
+                (e as List<dynamic>)
+                    .map((e) => DailyCount.fromJson(e as Map<String, dynamic>))
+                    .toList()),
+          ) ??
+          const {},
+    );
+
+Map<String, dynamic> _$AdminTimeseriesToJson(AdminTimeseries instance) =>
+    <String, dynamic>{
+      'days': instance.days,
+      'start_day': instance.startDay.toIso8601String(),
+      'series': instance.series,
+    };
+
+AdminTotals _$AdminTotalsFromJson(Map<String, dynamic> json) => AdminTotals(
+      users: (json['users'] as num?)?.toInt() ?? 0,
+      verifiedUsers: (json['verified_users'] as num?)?.toInt() ?? 0,
+      onboardedUsers: (json['onboarded_users'] as num?)?.toInt() ?? 0,
+      trips: (json['trips'] as num?)?.toInt() ?? 0,
+      tripLineages: (json['trip_lineages'] as num?)?.toInt() ?? 0,
+      itineraryItems: (json['itinerary_items'] as num?)?.toInt() ?? 0,
+      bookingTodos: (json['booking_todos'] as num?)?.toInt() ?? 0,
+      activePriceAlerts: (json['active_price_alerts'] as num?)?.toInt() ?? 0,
+      publishedLocalRecs: (json['published_local_recs'] as num?)?.toInt() ?? 0,
+      localGuides: (json['local_guides'] as num?)?.toInt() ?? 0,
+      activeCollaborators: (json['active_collaborators'] as num?)?.toInt() ?? 0,
+      activeShares: (json['active_shares'] as num?)?.toInt() ?? 0,
+      activeSessions: (json['active_sessions'] as num?)?.toInt() ?? 0,
+      analyticsEvents: (json['analytics_events'] as num?)?.toInt() ?? 0,
+    );
+
+Map<String, dynamic> _$AdminTotalsToJson(AdminTotals instance) =>
+    <String, dynamic>{
+      'users': instance.users,
+      'verified_users': instance.verifiedUsers,
+      'onboarded_users': instance.onboardedUsers,
+      'trips': instance.trips,
+      'trip_lineages': instance.tripLineages,
+      'itinerary_items': instance.itineraryItems,
+      'booking_todos': instance.bookingTodos,
+      'active_price_alerts': instance.activePriceAlerts,
+      'published_local_recs': instance.publishedLocalRecs,
+      'local_guides': instance.localGuides,
+      'active_collaborators': instance.activeCollaborators,
+      'active_shares': instance.activeShares,
+      'active_sessions': instance.activeSessions,
+      'analytics_events': instance.analyticsEvents,
+    };
+
+AdminActivityEvent _$AdminActivityEventFromJson(Map<String, dynamic> json) =>
+    AdminActivityEvent(
+      id: json['id'] as String,
+      eventType: json['event_type'] as String,
+      userEmail: json['user_email'] as String?,
+      userIsAdmin: json['user_is_admin'] as bool? ?? false,
+      tripId: json['trip_id'] as String?,
+      metadata: json['metadata'] as Map<String, dynamic>?,
+      createdAt: DateTime.parse(json['created_at'] as String),
+    );
+
+Map<String, dynamic> _$AdminActivityEventToJson(AdminActivityEvent instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'event_type': instance.eventType,
+      'user_email': instance.userEmail,
+      'user_is_admin': instance.userIsAdmin,
+      'trip_id': instance.tripId,
+      'metadata': instance.metadata,
+      'created_at': instance.createdAt.toIso8601String(),
+    };
+
+AdminActivityFeed _$AdminActivityFeedFromJson(Map<String, dynamic> json) =>
+    AdminActivityFeed(
+      events: (json['events'] as List<dynamic>?)
+              ?.map(
+                  (e) => AdminActivityEvent.fromJson(e as Map<String, dynamic>))
+              .toList() ??
+          const [],
+      nextBefore: json['next_before'] as String?,
+    );
+
+Map<String, dynamic> _$AdminActivityFeedToJson(AdminActivityFeed instance) =>
+    <String, dynamic>{
+      'events': instance.events,
+      'next_before': instance.nextBefore,
+    };
+
+AdminUserRow _$AdminUserRowFromJson(Map<String, dynamic> json) => AdminUserRow(
+      id: json['id'] as String,
+      email: json['email'] as String,
+      displayName: json['display_name'] as String?,
+      isAdmin: json['is_admin'] as bool? ?? false,
+      signedUpAt: DateTime.parse(json['signed_up_at'] as String),
+      onboarded: json['onboarded'] as bool? ?? false,
+      emailVerified: json['email_verified'] as bool? ?? false,
+      trips: (json['trips'] as num?)?.toInt() ?? 0,
+      tripLineages: (json['trip_lineages'] as num?)?.toInt() ?? 0,
+      planSessions: (json['plan_sessions'] as num?)?.toInt() ?? 0,
+      bookingClicks: (json['booking_clicks'] as num?)?.toInt() ?? 0,
+      planInputTokens: (json['plan_input_tokens'] as num?)?.toInt() ?? 0,
+      planOutputTokens: (json['plan_output_tokens'] as num?)?.toInt() ?? 0,
+      planCacheReadTokens:
+          (json['plan_cache_read_tokens'] as num?)?.toInt() ?? 0,
+      planCacheCreationTokens:
+          (json['plan_cache_creation_tokens'] as num?)?.toInt() ?? 0,
+      estClaudeCostUsd: (json['est_claude_cost_usd'] as num?)?.toDouble() ?? 0,
+      lastEventAt: json['last_event_at'] == null
+          ? null
+          : DateTime.parse(json['last_event_at'] as String),
+    );
+
+Map<String, dynamic> _$AdminUserRowToJson(AdminUserRow instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'email': instance.email,
+      'display_name': instance.displayName,
+      'is_admin': instance.isAdmin,
+      'signed_up_at': instance.signedUpAt.toIso8601String(),
+      'onboarded': instance.onboarded,
+      'email_verified': instance.emailVerified,
+      'trips': instance.trips,
+      'trip_lineages': instance.tripLineages,
+      'plan_sessions': instance.planSessions,
+      'booking_clicks': instance.bookingClicks,
+      'plan_input_tokens': instance.planInputTokens,
+      'plan_output_tokens': instance.planOutputTokens,
+      'plan_cache_read_tokens': instance.planCacheReadTokens,
+      'plan_cache_creation_tokens': instance.planCacheCreationTokens,
+      'est_claude_cost_usd': instance.estClaudeCostUsd,
+      'last_event_at': instance.lastEventAt?.toIso8601String(),
+    };
+
+AdminUserList _$AdminUserListFromJson(Map<String, dynamic> json) =>
+    AdminUserList(
+      total: (json['total'] as num?)?.toInt() ?? 0,
+      users: (json['users'] as List<dynamic>?)
+              ?.map((e) => AdminUserRow.fromJson(e as Map<String, dynamic>))
+              .toList() ??
+          const [],
+    );
+
+Map<String, dynamic> _$AdminUserListToJson(AdminUserList instance) =>
+    <String, dynamic>{
+      'total': instance.total,
+      'users': instance.users,
+    };

--- a/src/packages/flutter-app/lib/providers/admin_metrics_provider.dart
+++ b/src/packages/flutter-app/lib/providers/admin_metrics_provider.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../models/admin_insights.dart';
 import '../models/admin_metrics.dart';
 import '../services/admin_metrics_api_service.dart';
 import 'api_client_provider.dart';
@@ -13,4 +14,28 @@ final adminMetricsApiServiceProvider =
 final adminMetricsProvider =
     FutureProvider.family<AdminMetrics, int>((ref, days) async {
   return ref.watch(adminMetricsApiServiceProvider).fetch(days: days);
+});
+
+/// Daily trend buckets, keyed by the same days window as [adminMetricsProvider].
+final adminTimeseriesProvider =
+    FutureProvider.family<AdminTimeseries, int>((ref, days) async {
+  return ref.watch(adminMetricsApiServiceProvider).fetchTimeseries(days: days);
+});
+
+/// All-time domain-table counts — no window key, there is exactly one answer.
+final adminTotalsProvider = FutureProvider<AdminTotals>((ref) async {
+  return ref.watch(adminMetricsApiServiceProvider).fetchTotals();
+});
+
+/// First page of the activity tail. Older pages are fetched imperatively by
+/// the Activity pane (keyset cursor) and appended to local widget state —
+/// invalidating this provider resets to the newest page.
+final adminActivityProvider = FutureProvider<AdminActivityFeed>((ref) async {
+  return ref.watch(adminMetricsApiServiceProvider).fetchActivity();
+});
+
+/// One offset page of the per-user aggregates, keyed by offset.
+final adminUsersProvider =
+    FutureProvider.family<AdminUserList, int>((ref, offset) async {
+  return ref.watch(adminMetricsApiServiceProvider).fetchUsers(offset: offset);
 });

--- a/src/packages/flutter-app/lib/screens/admin_metrics_screen.dart
+++ b/src/packages/flutter-app/lib/screens/admin_metrics_screen.dart
@@ -1,16 +1,22 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../models/admin_insights.dart';
 import '../models/admin_metrics.dart';
 import '../providers/admin_metrics_provider.dart';
 import '../theme/spacing.dart';
+import '../widgets/daily_count_chart.dart';
 import '../widgets/empty_state.dart';
 import '../widgets/page_container.dart';
 import '../widgets/section_header.dart';
+import '../widgets/status_pill.dart';
 
-/// Growth metrics dashboard (admin-only; the API enforces adminMiddleware).
-/// Stat tiles over the Phase-1 funnel from docs/business-model.md §8 —
-/// activation, attach rate, retention, AI cost — plus the alerts counters.
-/// Deliberately chartless: every number here is a headline, not a trend.
+/// Growth analytics dashboard (admin-only; the API enforces adminMiddleware).
+/// Four tabs:
+///   Overview — all-time totals off the domain tables + the windowed Phase-1
+///              funnel stat tiles from docs/business-model.md §8.
+///   Trends   — daily bar charts (small multiples) for the funnel events.
+///   Activity — the latest analytics events, newest first, load-more.
+///   Users    — per-user activity aggregates, most recently active first.
 class AdminMetricsScreen extends ConsumerStatefulWidget {
   const AdminMetricsScreen({super.key});
 
@@ -20,48 +26,37 @@ class AdminMetricsScreen extends ConsumerStatefulWidget {
 }
 
 class _AdminMetricsScreenState extends ConsumerState<AdminMetricsScreen> {
+  // Shared by Overview and Trends so switching tabs keeps the same window.
   int _days = 30;
 
   @override
   Widget build(BuildContext context) {
-    final metrics = ref.watch(adminMetricsProvider(_days));
-
-    return Scaffold(
-      appBar: AppBar(title: const Text('Metrics')),
-      body: PageContainer(
-        child: Column(
+    return DefaultTabController(
+      length: 4,
+      child: Scaffold(
+        appBar: AppBar(
+          title: const Text('Metrics'),
+          bottom: const TabBar(
+            tabs: [
+              Tab(text: 'Overview'),
+              Tab(text: 'Trends'),
+              Tab(text: 'Activity'),
+              Tab(text: 'Users'),
+            ],
+          ),
+        ),
+        body: TabBarView(
           children: [
-            Padding(
-              padding: const EdgeInsets.all(AppSpacing.lg),
-              child: SegmentedButton<int>(
-                segments: const [
-                  ButtonSegment(value: 7, label: Text('7 days')),
-                  ButtonSegment(value: 30, label: Text('30 days')),
-                  ButtonSegment(value: 90, label: Text('90 days')),
-                ],
-                selected: {_days},
-                onSelectionChanged: (s) => setState(() => _days = s.first),
-              ),
+            _OverviewPane(
+              days: _days,
+              onDaysChanged: (d) => setState(() => _days = d),
             ),
-            Expanded(
-              child: metrics.when(
-                loading: () =>
-                    const Center(child: CircularProgressIndicator()),
-                error: (e, _) => EmptyState(
-                  icon: Icons.cloud_off,
-                  title: 'Could not load metrics',
-                  message: '$e',
-                  actions: [
-                    FilledButton(
-                      onPressed: () =>
-                          ref.invalidate(adminMetricsProvider(_days)),
-                      child: const Text('Retry'),
-                    ),
-                  ],
-                ),
-                data: (m) => _MetricsBody(metrics: m),
-              ),
+            _TrendsPane(
+              days: _days,
+              onDaysChanged: (d) => setState(() => _days = d),
             ),
+            const _ActivityPane(),
+            const _UsersPane(),
           ],
         ),
       ),
@@ -69,9 +64,189 @@ class _AdminMetricsScreenState extends ConsumerState<AdminMetricsScreen> {
   }
 }
 
+/// The 7/30/90-day window selector shared by Overview and Trends.
+class _DaysSelector extends StatelessWidget {
+  final int days;
+  final ValueChanged<int> onChanged;
+  const _DaysSelector({required this.days, required this.onChanged});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(AppSpacing.lg),
+      child: SegmentedButton<int>(
+        segments: const [
+          ButtonSegment(value: 7, label: Text('7 days')),
+          ButtonSegment(value: 30, label: Text('30 days')),
+          ButtonSegment(value: 90, label: Text('90 days')),
+        ],
+        selected: {days},
+        onSelectionChanged: (s) => onChanged(s.first),
+      ),
+    );
+  }
+}
+
+class _OverviewPane extends ConsumerWidget {
+  final int days;
+  final ValueChanged<int> onDaysChanged;
+  const _OverviewPane({required this.days, required this.onDaysChanged});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final metrics = ref.watch(adminMetricsProvider(days));
+
+    return PageContainer(
+      child: Column(
+        children: [
+          _DaysSelector(days: days, onChanged: onDaysChanged),
+          Expanded(
+            child: metrics.when(
+              loading: () => const Center(child: CircularProgressIndicator()),
+              error: (e, _) => EmptyState(
+                icon: Icons.cloud_off,
+                title: 'Could not load metrics',
+                message: '$e',
+                actions: [
+                  FilledButton(
+                    onPressed: () =>
+                        ref.invalidate(adminMetricsProvider(days)),
+                    child: const Text('Retry'),
+                  ),
+                ],
+              ),
+              data: (m) => _MetricsBody(metrics: m, header: _TotalsSection()),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// All-time counts off the domain tables — rides at the top of Overview's
+/// scroll with its own async lifecycle (a totals failure never blanks the
+/// windowed metrics below it).
+class _TotalsSection extends ConsumerWidget {
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final theme = Theme.of(context);
+    final totals = ref.watch(adminTotalsProvider);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const SectionHeader(title: 'All-time totals'),
+        const SizedBox(height: AppSpacing.sm),
+        totals.when(
+          loading: () => const Padding(
+            padding: EdgeInsets.all(AppSpacing.lg),
+            child: Center(child: CircularProgressIndicator()),
+          ),
+          error: (e, _) => Row(
+            children: [
+              Expanded(
+                child: Text(
+                  'Could not load totals',
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: theme.colorScheme.onSurfaceVariant,
+                  ),
+                ),
+              ),
+              TextButton(
+                onPressed: () => ref.invalidate(adminTotalsProvider),
+                child: const Text('Retry'),
+              ),
+            ],
+          ),
+          data: (t) => _TileGrid(tiles: [
+            _Stat('Users', '${t.users}',
+                caption:
+                    '${t.verifiedUsers} verified · ${t.onboardedUsers} onboarded'),
+            _Stat('Trips', '${t.trips}',
+                caption: '${t.tripLineages} lineages'),
+            _Stat('Itinerary items', '${t.itineraryItems}'),
+            _Stat('Booking todos', '${t.bookingTodos}'),
+            _Stat('Active price alerts', '${t.activePriceAlerts}'),
+            _Stat('Published local recs', '${t.publishedLocalRecs}',
+                caption: '${t.localGuides} guides'),
+            _Stat('Sharing', '${t.activeShares}',
+                caption: '${t.activeCollaborators} collaborators'),
+            _Stat('Active sessions', '${t.activeSessions}'),
+            _Stat('Analytics events', '${t.analyticsEvents}'),
+          ]),
+        ),
+        const SizedBox(height: AppSpacing.xl),
+      ],
+    );
+  }
+}
+
+/// The Trends tab: one [DailyCountChart] small-multiple per funnel event.
+class _TrendsPane extends ConsumerWidget {
+  final int days;
+  final ValueChanged<int> onDaysChanged;
+  const _TrendsPane({required this.days, required this.onDaysChanged});
+
+  // Series key → chart title, top-of-funnel to bottom (matches the API's
+  // timeseriesEventTypes; unknown keys in the payload are simply not shown).
+  static const _series = [
+    ('landing_viewed', 'Landing views'),
+    ('user_registered', 'Signups'),
+    ('trip_created', 'Trips created'),
+    ('plan_session_started', 'Plan sessions'),
+    ('booking_link_clicked', 'Booking clicks'),
+    ('itinerary_item_added', 'Itinerary items added'),
+    ('alert_created', 'Price alerts created'),
+  ];
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final ts = ref.watch(adminTimeseriesProvider(days));
+
+    return PageContainer(
+      child: Column(
+        children: [
+          _DaysSelector(days: days, onChanged: onDaysChanged),
+          Expanded(
+            child: ts.when(
+              loading: () => const Center(child: CircularProgressIndicator()),
+              error: (e, _) => EmptyState(
+                icon: Icons.cloud_off,
+                title: 'Could not load trends',
+                message: '$e',
+                actions: [
+                  FilledButton(
+                    onPressed: () =>
+                        ref.invalidate(adminTimeseriesProvider(days)),
+                    child: const Text('Retry'),
+                  ),
+                ],
+              ),
+              data: (t) => ListView(
+                padding: const EdgeInsets.all(AppSpacing.lg),
+                children: [
+                  for (final (key, title) in _series) ...[
+                    DailyCountChart(title: title, data: t.denseSeries(key)),
+                    const SizedBox(height: AppSpacing.xl),
+                  ],
+                  const SizedBox(height: AppSpacing.xl),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
 class _MetricsBody extends StatelessWidget {
   final AdminMetrics metrics;
-  const _MetricsBody({required this.metrics});
+
+  /// Optional widget above the windowed sections (Overview's all-time
+  /// totals) — inside this ListView so the whole pane scrolls as one.
+  final Widget? header;
+  const _MetricsBody({required this.metrics, this.header});
 
   String _pct(double v) => '${(v * 100).toStringAsFixed(1)}%';
 
@@ -89,6 +264,7 @@ class _MetricsBody extends StatelessWidget {
     return ListView(
       padding: const EdgeInsets.all(AppSpacing.lg),
       children: [
+        if (header != null) header!,
         const SectionHeader(title: 'Funnel'),
         const SizedBox(height: AppSpacing.sm),
         _TileGrid(tiles: [
@@ -326,6 +502,341 @@ class _ProviderClicks extends StatelessWidget {
               ],
             ),
           ),
+      ],
+    );
+  }
+}
+
+// --- Activity ----------------------------------------------------------------
+
+String _relTime(DateTime t) {
+  final d = DateTime.now().difference(t);
+  if (d.inMinutes < 1) return 'just now';
+  if (d.inMinutes < 60) return '${d.inMinutes}m ago';
+  if (d.inHours < 24) return '${d.inHours}h ago';
+  if (d.inDays < 30) return '${d.inDays}d ago';
+  return '${t.year}-${t.month.toString().padLeft(2, '0')}-${t.day.toString().padLeft(2, '0')}';
+}
+
+/// "booking_link_clicked" → "Booking link clicked".
+String _humanize(String eventType) {
+  final s = eventType.replaceAll('_', ' ');
+  return s.isEmpty ? s : '${s[0].toUpperCase()}${s.substring(1)}';
+}
+
+/// The latest analytics events, newest first. First page via
+/// [adminActivityProvider]; older pages are fetched imperatively with the
+/// keyset cursor and appended locally. Keep-alive so paging survives tab
+/// switches; pull-to-refresh resets to the newest page.
+class _ActivityPane extends ConsumerStatefulWidget {
+  const _ActivityPane();
+  @override
+  ConsumerState<_ActivityPane> createState() => _ActivityPaneState();
+}
+
+class _ActivityPaneState extends ConsumerState<_ActivityPane>
+    with AutomaticKeepAliveClientMixin {
+  final List<AdminActivityEvent> _older = [];
+  String? _olderCursor; // non-null once _older extends the first page
+  bool _loadingMore = false;
+
+  @override
+  bool get wantKeepAlive => true;
+
+  Future<void> _loadMore(String cursor) async {
+    setState(() => _loadingMore = true);
+    try {
+      final page = await ref
+          .read(adminMetricsApiServiceProvider)
+          .fetchActivity(before: cursor);
+      if (!mounted) return;
+      setState(() {
+        _older.addAll(page.events);
+        _olderCursor = page.nextBefore;
+      });
+    } catch (_) {
+      // Leave the cursor as-is so the button retries.
+    } finally {
+      if (mounted) setState(() => _loadingMore = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    super.build(context);
+    final feed = ref.watch(adminActivityProvider);
+
+    return PageContainer(
+      child: feed.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (e, _) => EmptyState(
+          icon: Icons.cloud_off,
+          title: 'Could not load activity',
+          message: '$e',
+          actions: [
+            FilledButton(
+              onPressed: () => ref.invalidate(adminActivityProvider),
+              child: const Text('Retry'),
+            ),
+          ],
+        ),
+        data: (first) {
+          final events = [...first.events, ..._older];
+          if (events.isEmpty) {
+            return const EmptyState(
+              icon: Icons.timeline,
+              title: 'No activity yet',
+              message: 'Events show up here as people use the app.',
+            );
+          }
+          // _olderCursor is set the moment paging starts; before that the
+          // first page's cursor drives the button.
+          final cursor = _older.isEmpty ? first.nextBefore : _olderCursor;
+          return RefreshIndicator(
+            onRefresh: () async {
+              setState(() {
+                _older.clear();
+                _olderCursor = null;
+              });
+              ref.invalidate(adminActivityProvider);
+              await ref.read(adminActivityProvider.future);
+            },
+            child: ListView.builder(
+              physics: const AlwaysScrollableScrollPhysics(),
+              padding: const EdgeInsets.symmetric(vertical: AppSpacing.sm),
+              itemCount: events.length + (cursor != null ? 1 : 0),
+              itemBuilder: (context, i) {
+                if (i == events.length) {
+                  return Padding(
+                    padding: const EdgeInsets.all(AppSpacing.lg),
+                    child: Center(
+                      child: _loadingMore
+                          ? const CircularProgressIndicator()
+                          : OutlinedButton(
+                              onPressed: () => _loadMore(cursor!),
+                              child: const Text('Load more'),
+                            ),
+                    ),
+                  );
+                }
+                return _ActivityTile(event: events[i]);
+              },
+            ),
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _ActivityTile extends StatelessWidget {
+  final AdminActivityEvent event;
+  const _ActivityTile({required this.event});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final who = event.userEmail ?? 'anonymous';
+    final meta = event.metadata;
+    // Surface the two metadata keys that identify what was acted on.
+    final detail = [
+      if (meta?['provider'] != null) '${meta!['provider']}',
+      if (meta?['source'] != null) '${meta!['source']}',
+    ].join(' · ');
+
+    return ListTile(
+      dense: true,
+      title: Text(_humanize(event.eventType)),
+      subtitle: Text(detail.isEmpty ? who : '$who · $detail'),
+      leading: event.userEmail == null
+          ? Icon(Icons.person_off_outlined,
+              size: 20, color: theme.colorScheme.onSurfaceVariant)
+          : Icon(Icons.person_outline,
+              size: 20, color: theme.colorScheme.onSurfaceVariant),
+      trailing: Text(
+        _relTime(event.createdAt),
+        style: theme.textTheme.bodySmall?.copyWith(
+          color: theme.colorScheme.onSurfaceVariant,
+        ),
+      ),
+    );
+  }
+}
+
+// --- Users ---------------------------------------------------------------
+
+/// Per-user drill-down: most recently active first, expandable rows, offset
+/// paging. Keep-alive for the same reason as the Activity pane.
+class _UsersPane extends ConsumerStatefulWidget {
+  const _UsersPane();
+  @override
+  ConsumerState<_UsersPane> createState() => _UsersPaneState();
+}
+
+class _UsersPaneState extends ConsumerState<_UsersPane>
+    with AutomaticKeepAliveClientMixin {
+  final List<AdminUserRow> _more = [];
+  bool _loadingMore = false;
+
+  @override
+  bool get wantKeepAlive => true;
+
+  Future<void> _loadMore(int offset) async {
+    setState(() => _loadingMore = true);
+    try {
+      final page =
+          await ref.read(adminMetricsApiServiceProvider).fetchUsers(offset: offset);
+      if (!mounted) return;
+      setState(() => _more.addAll(page.users));
+    } catch (_) {
+      // Button stays; tapping retries.
+    } finally {
+      if (mounted) setState(() => _loadingMore = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    super.build(context);
+    final list = ref.watch(adminUsersProvider(0));
+
+    return PageContainer(
+      child: list.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (e, _) => EmptyState(
+          icon: Icons.cloud_off,
+          title: 'Could not load users',
+          message: '$e',
+          actions: [
+            FilledButton(
+              onPressed: () => ref.invalidate(adminUsersProvider(0)),
+              child: const Text('Retry'),
+            ),
+          ],
+        ),
+        data: (first) {
+          final users = [...first.users, ..._more];
+          final hasMore = users.length < first.total;
+          return RefreshIndicator(
+            onRefresh: () async {
+              setState(() => _more.clear());
+              ref.invalidate(adminUsersProvider(0));
+              await ref.read(adminUsersProvider(0).future);
+            },
+            child: ListView.builder(
+              physics: const AlwaysScrollableScrollPhysics(),
+              padding: const EdgeInsets.symmetric(vertical: AppSpacing.sm),
+              itemCount: users.length + (hasMore ? 1 : 0) + 1,
+              itemBuilder: (context, i) {
+                if (i == 0) {
+                  return Padding(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: AppSpacing.lg,
+                      vertical: AppSpacing.xs,
+                    ),
+                    child: Text(
+                      '${first.total} users',
+                      style: Theme.of(context).textTheme.labelLarge,
+                    ),
+                  );
+                }
+                if (i == users.length + 1) {
+                  return Padding(
+                    padding: const EdgeInsets.all(AppSpacing.lg),
+                    child: Center(
+                      child: _loadingMore
+                          ? const CircularProgressIndicator()
+                          : OutlinedButton(
+                              onPressed: () => _loadMore(users.length),
+                              child: const Text('Load more'),
+                            ),
+                    ),
+                  );
+                }
+                return _UserTile(user: users[i - 1]);
+              },
+            ),
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _UserTile extends StatelessWidget {
+  final AdminUserRow user;
+  const _UserTile({required this.user});
+
+  String _tokens(int v) {
+    if (v >= 1000000) return '${(v / 1000000).toStringAsFixed(1)}M';
+    if (v >= 1000) return '${(v / 1000).toStringAsFixed(1)}k';
+    return '$v';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return ExpansionTile(
+      title: Row(
+        children: [
+          Flexible(
+            child: Text(user.email, overflow: TextOverflow.ellipsis),
+          ),
+          if (user.isAdmin) ...[
+            const SizedBox(width: AppSpacing.sm),
+            StatusPill.custom(
+              label: 'admin',
+              background: theme.colorScheme.tertiaryContainer,
+              foreground: theme.colorScheme.onTertiaryContainer,
+            ),
+          ],
+        ],
+      ),
+      subtitle: Text(
+        '${user.trips} trips · ${user.lastEventAt != null ? 'active ${_relTime(user.lastEventAt!)}' : 'no activity'}',
+        style: theme.textTheme.bodySmall?.copyWith(
+          color: theme.colorScheme.onSurfaceVariant,
+        ),
+      ),
+      childrenPadding: const EdgeInsets.fromLTRB(
+        AppSpacing.lg, 0, AppSpacing.lg, AppSpacing.lg,
+      ),
+      expandedCrossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Wrap(
+          spacing: AppSpacing.xl,
+          runSpacing: AppSpacing.sm,
+          children: [
+            _kv(theme, 'Trip lineages', '${user.tripLineages}'),
+            _kv(theme, 'Plan sessions', '${user.planSessions}'),
+            _kv(theme, 'Booking clicks', '${user.bookingClicks}'),
+            _kv(theme, 'Tokens in / out',
+                '${_tokens(user.planInputTokens)} / ${_tokens(user.planOutputTokens)}'),
+            _kv(theme, 'Est. Claude cost',
+                '\$${user.estClaudeCostUsd.toStringAsFixed(2)}'),
+            _kv(theme, 'Signed up',
+                '${user.signedUpAt.year}-${user.signedUpAt.month.toString().padLeft(2, '0')}-${user.signedUpAt.day.toString().padLeft(2, '0')}'),
+            _kv(theme, 'Onboarded', user.onboarded ? 'yes' : 'no'),
+            _kv(theme, 'Email verified', user.emailVerified ? 'yes' : 'no'),
+          ],
+        ),
+      ],
+    );
+  }
+
+  Widget _kv(ThemeData theme, String label, String value) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Text(label,
+            style: theme.textTheme.labelSmall?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+            )),
+        Text(value,
+            style: theme.textTheme.bodyMedium?.copyWith(
+              fontWeight: FontWeight.w600,
+            )),
       ],
     );
   }

--- a/src/packages/flutter-app/lib/services/admin_metrics_api_service.dart
+++ b/src/packages/flutter-app/lib/services/admin_metrics_api_service.dart
@@ -1,22 +1,47 @@
 import 'dart:convert';
+import '../models/admin_insights.dart';
 import '../models/admin_metrics.dart';
 import 'api_client.dart';
 
-/// GET /admin/metrics — requires an admin bearer token (enforced
-/// server-side by adminMiddleware).
+/// GET /admin/metrics and its /timeseries, /totals, /activity, /users
+/// siblings — all require an admin bearer token (enforced server-side by
+/// adminMiddleware).
 class AdminMetricsApiService {
   final ApiClient apiClient;
 
   AdminMetricsApiService(this.apiClient);
 
-  Future<AdminMetrics> fetch({int days = 30}) async {
+  Future<T> _get<T>(String pathAndQuery, T Function(dynamic) parse) async {
     final res = await apiClient.httpClient.get(
-      Uri.parse('${apiClient.baseUrl}/admin/metrics?days=$days'),
+      Uri.parse('${apiClient.baseUrl}$pathAndQuery'),
       headers: apiClient.jsonHeaders(),
     );
     if (res.statusCode == 200) {
-      return AdminMetrics.fromJson(jsonDecode(res.body));
+      return parse(jsonDecode(res.body));
     }
-    throw Exception('Failed to load metrics (${res.statusCode})');
+    throw Exception('Failed to load $pathAndQuery (${res.statusCode})');
   }
+
+  Future<AdminMetrics> fetch({int days = 30}) => _get(
+      '/admin/metrics?days=$days', (json) => AdminMetrics.fromJson(json));
+
+  Future<AdminTimeseries> fetchTimeseries({int days = 30}) => _get(
+      '/admin/metrics/timeseries?days=$days',
+      (json) => AdminTimeseries.fromJson(json));
+
+  Future<AdminTotals> fetchTotals() =>
+      _get('/admin/metrics/totals', (json) => AdminTotals.fromJson(json));
+
+  /// [before] is the keyset cursor from [AdminActivityFeed.nextBefore];
+  /// null fetches the newest page.
+  Future<AdminActivityFeed> fetchActivity({int limit = 50, String? before}) {
+    final cursor =
+        before == null ? '' : '&before=${Uri.encodeQueryComponent(before)}';
+    return _get('/admin/metrics/activity?limit=$limit$cursor',
+        (json) => AdminActivityFeed.fromJson(json));
+  }
+
+  Future<AdminUserList> fetchUsers({int limit = 50, int offset = 0}) => _get(
+      '/admin/metrics/users?limit=$limit&offset=$offset',
+      (json) => AdminUserList.fromJson(json));
 }

--- a/src/packages/flutter-app/lib/widgets/daily_count_chart.dart
+++ b/src/packages/flutter-app/lib/widgets/daily_count_chart.dart
@@ -1,0 +1,212 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+
+import '../models/admin_insights.dart';
+import '../theme/spacing.dart';
+
+const _months = [
+  'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+  'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
+];
+
+String _fmtDay(DateTime d) => '${_months[d.month - 1]} ${d.day}';
+
+/// One small-multiple in the Trends tab: a single-series daily bar chart.
+///
+/// Follows the dashboard's dataviz conventions (see _ProviderClicks in
+/// admin_metrics_screen.dart): one hue — the bars encode magnitude, the title
+/// carries identity, so no legend or categorical palette. Labels wear text
+/// tokens, never the series color; only the peak and latest values are
+/// direct-labeled. Tap or drag across the bars to inspect a day (the caption
+/// below is the touch equivalent of a hover tooltip).
+///
+/// [data] must be dense — one entry per day, zero-filled — which is what
+/// [AdminTimeseries.denseSeries] returns.
+class DailyCountChart extends StatefulWidget {
+  final String title;
+  final List<DailyCount> data;
+
+  const DailyCountChart({super.key, required this.title, required this.data});
+
+  @override
+  State<DailyCountChart> createState() => _DailyCountChartState();
+}
+
+class _DailyCountChartState extends State<DailyCountChart> {
+  int? _selected;
+
+  int get _total => widget.data.fold(0, (sum, c) => sum + c.n);
+
+  void _select(Offset localPos, double width) {
+    if (widget.data.isEmpty || width <= 0) return;
+    final slot = width / widget.data.length;
+    final i = (localPos.dx / slot).floor().clamp(0, widget.data.length - 1);
+    if (i != _selected) setState(() => _selected = i);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final data = widget.data;
+    final captionStyle = theme.textTheme.bodySmall?.copyWith(
+      color: theme.colorScheme.onSurfaceVariant,
+    );
+    final selected =
+        (_selected != null && _selected! < data.length) ? data[_selected!] : null;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: [
+            Expanded(
+              child: Text(widget.title, style: theme.textTheme.labelLarge),
+            ),
+            // Window total as a headline — text tokens, never the bar hue.
+            Text('$_total', style: theme.textTheme.labelLarge),
+          ],
+        ),
+        const SizedBox(height: AppSpacing.xs),
+        LayoutBuilder(
+          builder: (context, constraints) => GestureDetector(
+            onTapDown: (d) => _select(d.localPosition, constraints.maxWidth),
+            onHorizontalDragUpdate: (d) =>
+                _select(d.localPosition, constraints.maxWidth),
+            child: CustomPaint(
+              size: Size(constraints.maxWidth, 84),
+              painter: _DailyBarsPainter(
+                data: data,
+                selected: _selected,
+                barColor: theme.colorScheme.primary,
+                gridColor: theme.colorScheme.outlineVariant,
+                labelStyle: captionStyle,
+              ),
+            ),
+          ),
+        ),
+        const SizedBox(height: AppSpacing.xs),
+        Row(
+          children: [
+            if (data.isNotEmpty)
+              Text(_fmtDay(data.first.day), style: captionStyle),
+            const Spacer(),
+            // The inspect caption — the touch stand-in for a hover tooltip.
+            if (selected != null)
+              Text('${_fmtDay(selected.day)} · ${selected.n}',
+                  style: captionStyle?.copyWith(
+                    color: theme.colorScheme.onSurface,
+                    fontWeight: FontWeight.w600,
+                  )),
+            const Spacer(),
+            if (data.length > 1)
+              Text(_fmtDay(data.last.day), style: captionStyle),
+          ],
+        ),
+      ],
+    );
+  }
+}
+
+class _DailyBarsPainter extends CustomPainter {
+  final List<DailyCount> data;
+  final int? selected;
+  final Color barColor;
+  final Color gridColor;
+  final TextStyle? labelStyle;
+
+  _DailyBarsPainter({
+    required this.data,
+    required this.selected,
+    required this.barColor,
+    required this.gridColor,
+    required this.labelStyle,
+  });
+
+  static const _labelBand = 16.0; // reserved above the bars for direct labels
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    if (data.isEmpty) return;
+    final baseline = size.height - 1;
+    final plotHeight = baseline - _labelBand;
+
+    // Hairline baseline (recessive, solid).
+    final grid = Paint()
+      ..color = gridColor
+      ..strokeWidth = 1;
+    canvas.drawLine(Offset(0, baseline), Offset(size.width, baseline), grid);
+
+    final maxN = data.fold(0, (m, c) => math.max(m, c.n));
+    if (maxN == 0) return;
+
+    // One gridline at the max of the scale; the peak's direct label carries
+    // its value, so the line is unlabeled.
+    canvas.drawLine(
+        Offset(0, _labelBand), Offset(size.width, _labelBand), grid);
+
+    // Slot geometry: 2px surface gaps between bars, collapsing when slots get
+    // narrower than 4px (90-day windows on phones); bars capped at 24px.
+    final slot = size.width / data.length;
+    final gap = slot >= 4 ? 2.0 : (slot >= 2 ? 1.0 : 0.0);
+    final barWidth = math.min(24.0, math.max(1.0, slot - gap));
+
+    final paint = Paint()..color = barColor;
+    final dimmed = Paint()..color = barColor.withValues(alpha: 0.45);
+    int peak = 0;
+    for (var i = 1; i < data.length; i++) {
+      if (data[i].n > data[peak].n) peak = i;
+    }
+
+    for (var i = 0; i < data.length; i++) {
+      final n = data[i].n;
+      if (n == 0) continue;
+      final h = plotHeight * n / maxN;
+      final left = i * slot + (slot - barWidth) / 2;
+      final topRadius = Radius.circular(math.min(4.0, barWidth / 2));
+      // Rounded data-end, square at the baseline. Selection dims the other
+      // bars rather than recoloring the selected one — color never changes
+      // meaning, only emphasis.
+      canvas.drawRRect(
+        RRect.fromRectAndCorners(
+          Rect.fromLTWH(left, baseline - h, barWidth, h),
+          topLeft: topRadius,
+          topRight: topRadius,
+        ),
+        selected != null && selected != i ? dimmed : paint,
+      );
+    }
+
+    // Selective direct labels: the peak, and the latest non-zero day (they
+    // may coincide, and the latest yields when the two would collide).
+    // Everything else is the tap caption's job.
+    final peakRect = _label(canvas, size, slot, peak);
+    final latest = data.length - 1;
+    if (latest != peak && data[latest].n > 0) {
+      _label(canvas, size, slot, latest, avoid: peakRect);
+    }
+  }
+
+  /// Paints the value label for bar [i] centered above it (clamped to the
+  /// canvas) and returns its rect. Skipped — returning null — when it would
+  /// collide with [avoid].
+  Rect? _label(Canvas canvas, Size size, double slot, int i, {Rect? avoid}) {
+    final tp = TextPainter(
+      text: TextSpan(text: '${data[i].n}', style: labelStyle),
+      textDirection: TextDirection.ltr,
+    )..layout();
+    final center = i * slot + slot / 2;
+    final dx = (center - tp.width / 2).clamp(0.0, size.width - tp.width);
+    final rect = Rect.fromLTWH(dx, 0, tp.width, tp.height);
+    if (avoid != null && rect.inflate(4).overlaps(avoid)) return null;
+    tp.paint(canvas, rect.topLeft);
+    return rect;
+  }
+
+  @override
+  bool shouldRepaint(_DailyBarsPainter old) =>
+      old.data != data ||
+      old.selected != selected ||
+      old.barColor != barColor ||
+      old.gridColor != gridColor;
+}

--- a/src/packages/flutter-app/test/admin_insights_test.dart
+++ b/src/packages/flutter-app/test/admin_insights_test.dart
@@ -1,0 +1,63 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:travel_route_planner/models/admin_insights.dart';
+
+void main() {
+  group('AdminTimeseries.denseSeries', () {
+    final start = DateTime.utc(2026, 7, 1);
+
+    test('zero-fills missing days across the whole window', () {
+      final ts = AdminTimeseries(
+        days: 5,
+        startDay: start,
+        series: {
+          'user_registered': [
+            DailyCount(day: DateTime.utc(2026, 7, 2), n: 3),
+            DailyCount(day: DateTime.utc(2026, 7, 5), n: 1),
+          ],
+        },
+      );
+
+      final dense = ts.denseSeries('user_registered');
+      expect(dense.length, 5);
+      expect(dense.map((c) => c.n), [0, 3, 0, 0, 1]);
+      expect(dense.first.day, start);
+      expect(dense.last.day, DateTime.utc(2026, 7, 5));
+    });
+
+    test('unknown key yields an all-zero window (stable chart slots)', () {
+      final ts = AdminTimeseries(days: 3, startDay: start, series: const {});
+      final dense = ts.denseSeries('landing_viewed');
+      expect(dense.length, 3);
+      expect(dense.every((c) => c.n == 0), isTrue);
+    });
+
+    test('crosses month boundaries day by day', () {
+      final ts = AdminTimeseries(
+        days: 3,
+        startDay: DateTime.utc(2026, 6, 29),
+        series: {
+          'trip_created': [DailyCount(day: DateTime.utc(2026, 7, 1), n: 2)],
+        },
+      );
+      final dense = ts.denseSeries('trip_created');
+      expect(dense.map((c) => c.n), [0, 0, 2]);
+      expect(dense.last.day, DateTime.utc(2026, 7, 1));
+    });
+
+    test('parses the API payload shape (sparse map of day lists)', () {
+      final ts = AdminTimeseries.fromJson({
+        'days': 2,
+        'start_day': '2026-07-01T00:00:00Z',
+        'series': {
+          'user_registered': [
+            {'day': '2026-07-02T00:00:00Z', 'n': 4},
+          ],
+          'landing_viewed': <Map<String, dynamic>>[],
+        },
+      });
+      expect(ts.denseSeries('user_registered').map((c) => c.n), [0, 4]);
+      expect(ts.denseSeries('landing_viewed').map((c) => c.n), [0, 0]);
+    });
+  });
+}

--- a/src/packages/flutter-app/test/admin_metrics_screen_test.dart
+++ b/src/packages/flutter-app/test/admin_metrics_screen_test.dart
@@ -2,14 +2,36 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import 'package:travel_route_planner/models/admin_insights.dart';
 import 'package:travel_route_planner/models/admin_metrics.dart';
 import 'package:travel_route_planner/providers/admin_metrics_provider.dart';
 import 'package:travel_route_planner/screens/admin_metrics_screen.dart';
 
+// The Overview tab (default) watches totals alongside the windowed metrics;
+// tests that only exercise Overview still need this override so the totals
+// section resolves instead of hitting the (blocked) test network.
+const _totals = AdminTotals(
+  users: 9,
+  verifiedUsers: 4,
+  onboardedUsers: 6,
+  trips: 17,
+  tripLineages: 11,
+  itineraryItems: 88,
+  bookingTodos: 21,
+  activePriceAlerts: 2,
+  publishedLocalRecs: 14,
+  localGuides: 3,
+  activeCollaborators: 1,
+  activeShares: 5,
+  // Distinct from every value the Overview assertions look for by exact text.
+  activeSessions: 19,
+  analyticsEvents: 1234,
+);
+
 void main() {
   testWidgets('renders funnel, AI, and alert tiles from metrics',
       (tester) async {
-    tester.view.physicalSize = const Size(800, 2400);
+    tester.view.physicalSize = const Size(800, 3600);
     tester.view.devicePixelRatio = 1.0;
     addTearDown(tester.view.reset);
 
@@ -53,11 +75,18 @@ void main() {
       ProviderScope(
         overrides: [
           adminMetricsProvider(30).overrideWith((ref) async => metrics),
+          adminTotalsProvider.overrideWith((ref) async => _totals),
         ],
         child: const MaterialApp(home: AdminMetricsScreen()),
       ),
     );
     await tester.pumpAndSettle();
+
+    // All-time totals ride above the windowed funnel on the Overview tab.
+    expect(find.text('All-time totals'), findsOneWidget);
+    expect(find.text('1234'), findsOneWidget); // analytics events
+    expect(find.text('4 verified · 6 onboarded'), findsOneWidget);
+    expect(find.text('11 lineages'), findsOneWidget);
 
     expect(find.text('42'), findsOneWidget); // signups
     expect(find.text('Landing views'), findsOneWidget);
@@ -101,7 +130,7 @@ void main() {
 
   testWidgets('omits provider-call section when the API predates it',
       (tester) async {
-    tester.view.physicalSize = const Size(800, 2400);
+    tester.view.physicalSize = const Size(800, 3600);
     tester.view.devicePixelRatio = 1.0;
     addTearDown(tester.view.reset);
 
@@ -120,6 +149,7 @@ void main() {
       ProviderScope(
         overrides: [
           adminMetricsProvider(30).overrideWith((ref) async => metrics),
+          adminTotalsProvider.overrideWith((ref) async => _totals),
         ],
         child: const MaterialApp(home: AdminMetricsScreen()),
       ),
@@ -146,5 +176,176 @@ void main() {
 
     expect(find.text('Could not load metrics'), findsOneWidget);
     expect(find.text('Retry'), findsOneWidget);
+  });
+
+  testWidgets('Trends tab renders one chart per funnel series', (tester) async {
+    tester.view.physicalSize = const Size(800, 3600);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+
+    final start = DateTime.utc(2026, 7, 1);
+    final ts = AdminTimeseries(
+      days: 7,
+      startDay: start,
+      series: {
+        'user_registered': [
+          DailyCount(day: start, n: 2),
+          DailyCount(day: start.add(const Duration(days: 3)), n: 5),
+        ],
+        'trip_created': [DailyCount(day: start, n: 1)],
+      },
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          adminMetricsProvider(30).overrideWith((ref) async =>
+              const AdminMetrics(days: 30)),
+          adminTotalsProvider.overrideWith((ref) async => _totals),
+          // The pane inherits Overview's 30-day default window.
+          adminTimeseriesProvider(30).overrideWith((ref) async => ts),
+        ],
+        child: const MaterialApp(home: AdminMetricsScreen()),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Trends'));
+    await tester.pumpAndSettle();
+
+    // One chart slot per series, present even when the series is empty.
+    for (final title in [
+      'Landing views',
+      'Signups',
+      'Trips created',
+      'Plan sessions',
+      'Booking clicks',
+      'Itinerary items added',
+      'Price alerts created',
+    ]) {
+      expect(find.text(title), findsOneWidget);
+    }
+    // Signups window total = 2 + 5.
+    expect(find.text('7'), findsWidgets);
+  });
+
+  testWidgets('Activity tab lists events with anonymous handling and paging',
+      (tester) async {
+    tester.view.physicalSize = const Size(800, 1600);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+
+    final now = DateTime.now();
+    final feed = AdminActivityFeed(
+      events: [
+        AdminActivityEvent(
+          id: 'e1',
+          eventType: 'trip_created',
+          userEmail: 'brian@example.com',
+          createdAt: now.subtract(const Duration(minutes: 5)),
+        ),
+        AdminActivityEvent(
+          id: 'e2',
+          eventType: 'booking_link_clicked',
+          metadata: const {'provider': 'duffel'},
+          createdAt: now.subtract(const Duration(hours: 2)),
+        ),
+      ],
+      nextBefore: now.toIso8601String(),
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          adminMetricsProvider(30).overrideWith((ref) async =>
+              const AdminMetrics(days: 30)),
+          adminTotalsProvider.overrideWith((ref) async => _totals),
+          adminActivityProvider.overrideWith((ref) async => feed),
+        ],
+        child: const MaterialApp(home: AdminMetricsScreen()),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Activity'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Trip created'), findsOneWidget);
+    expect(find.text('brian@example.com'), findsOneWidget);
+    expect(find.text('5m ago'), findsOneWidget);
+    expect(find.text('Booking link clicked'), findsOneWidget);
+    expect(find.text('anonymous · duffel'), findsOneWidget);
+    expect(find.text('2h ago'), findsOneWidget);
+    // A full cursor means more pages.
+    expect(find.text('Load more'), findsOneWidget);
+  });
+
+  testWidgets('Users tab shows aggregates, admin badge, and expands',
+      (tester) async {
+    tester.view.physicalSize = const Size(800, 1600);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+
+    final list = AdminUserList(
+      total: 2,
+      users: [
+        AdminUserRow(
+          id: 'u1',
+          email: 'active@example.com',
+          signedUpAt: DateTime(2026, 6, 1),
+          onboarded: true,
+          emailVerified: true,
+          trips: 3,
+          tripLineages: 2,
+          planSessions: 4,
+          bookingClicks: 1,
+          planInputTokens: 1500000,
+          planOutputTokens: 250000,
+          estClaudeCostUsd: 8.25,
+          lastEventAt: DateTime.now().subtract(const Duration(days: 2)),
+        ),
+        AdminUserRow(
+          id: 'u2',
+          email: 'owner@example.com',
+          isAdmin: true,
+          signedUpAt: DateTime(2026, 5, 1),
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          adminMetricsProvider(30).overrideWith((ref) async =>
+              const AdminMetrics(days: 30)),
+          adminTotalsProvider.overrideWith((ref) async => _totals),
+          adminUsersProvider(0).overrideWith((ref) async => list),
+        ],
+        child: const MaterialApp(home: AdminMetricsScreen()),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // 'Users' is also a totals tile label — target the tab specifically.
+    await tester.tap(find.descendant(
+        of: find.byType(TabBar), matching: find.text('Users')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('2 users'), findsOneWidget);
+    expect(find.text('active@example.com'), findsOneWidget);
+    expect(find.text('3 trips · active 2d ago'), findsOneWidget);
+    expect(find.text('owner@example.com'), findsOneWidget);
+    expect(find.text('admin'), findsOneWidget); // StatusPill on the admin row
+    expect(find.text('0 trips · no activity'), findsOneWidget);
+    // Both pages fit in total=2, so no load-more.
+    expect(find.text('Load more'), findsNothing);
+
+    // Expanding surfaces the aggregates.
+    await tester.tap(find.text('active@example.com'));
+    await tester.pumpAndSettle();
+    expect(find.text('Trip lineages'), findsOneWidget);
+    expect(find.text('1.5M / 250.0k'), findsOneWidget);
+    expect(find.text('\$8.25'), findsOneWidget);
+    expect(find.text('2026-06-01'), findsOneWidget);
   });
 }


### PR DESCRIPTION
Flutter half of the admin analytics dashboard — pairs with #104 (the `/admin/metrics/*` sibling endpoints). `AdminMetricsScreen` becomes a four-tab dashboard; each pane lazy-loads its own provider, so nothing fetches until first viewed.

| Tab | What it shows |
|---|---|
| **Overview** | New all-time totals tile grid (own async lifecycle — a totals failure never blanks the funnel below) above the existing windowed stat tiles; the 7/30/90 selector is shared with Trends. |
| **Trends** | `DailyCountChart` small multiples — hand-rolled `CustomPaint`, **no chart dependency**: single hue, 4px rounded data-ends / square baseline, 2px surface gaps, hairline baseline + max gridline, direct labels on peak + latest only, tap/drag caption as the touch tooltip. |
| **Activity** | Latest analytics events: humanized type, email or "anonymous", provider/source from metadata, relative time; keyset load-more + pull-to-refresh; keep-alive across tab switches. |
| **Users** | `ExpansionTile` per user — admin `StatusPill` badge, trips/lineages, plan sessions, booking clicks, token in/out, est. Claude cost, signup/onboarded/verified; offset load-more. |

Data layer mirrors the existing metrics stack: new `admin_insights.dart` json_serializable models, four fetchers on `AdminMetricsApiService`, four providers. No `account_menu.dart` change — the existing admin-only Metrics entry opens this screen, and every endpoint is independently admin-enforced server-side.

Bug caught while building: `DateTime.parse` on the API's bare `YYYY-MM-DD` yields **local** midnight, which never equals a `DateTime.utc` map key — `AdminTimeseries.denseSeries` normalizes both sides to UTC calendar days (unit-tested, including a month boundary).

Graceful against an older API: the new tabs show their error/retry states until #104 is deployed; Overview's funnel keeps working.

Tests: 4 new/updated widget tests (tab shell, trends slots, activity anonymity + paging, users badge + expansion) + `denseSeries` unit tests. Full suite: 179 passing; analyzer clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)