### PR TITLE
feat(flutter): enlarge the nav-rail brand mark

### DIFF
--- a/src/packages/flutter-app/lib/screens/app_shell.dart
+++ b/src/packages/flutter-app/lib/screens/app_shell.dart
@@ -115,7 +115,7 @@ class _RailBrand extends StatelessWidget {
       padding: EdgeInsets.only(top: AppSpacing.lg, bottom: AppSpacing.sm),
       child: BrandBadge(
         padding: EdgeInsets.all(AppSpacing.sm),
-        child: BrandLogo.mark(size: 26),
+        child: BrandLogo.mark(size: 36),
       ),
     );
   }


### PR DESCRIPTION
## Summary
- Bump the sidebar nav-rail Golden Tempo mark from 26px to 36px (`_RailBrand` in `app_shell.dart`); the white brand badge grows from ~42px to ~52px square, still comfortably inside the rail

## Testing
- `flutter analyze` — no errors or warnings from the change (12 pre-existing `withOpacity` deprecation infos remain in `route_results_widget.dart`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)