### PR TITLE
feat(flutter): Today mode — auto-scroll, jump chip, header highlight

### DIFF
--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart' show RenderAbstractViewport;
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:sliver_tools/sliver_tools.dart';
@@ -76,6 +77,19 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
   RefineTarget? _refineTarget;
   String _itemFilter = 'all'; // 'all' | 'attraction' | 'restaurant'
   int? _selectedDay; // map day-chip selection; null = All (specs/today-mode)
+  // Today mode (specs/today-mode): the itinerary auto-scrolls to today's day
+  // header at most once per screen visit, and only from loud load paths.
+  final ScrollController _scroll = ScrollController();
+  bool _autoScrolledToday = false;
+  // Day set by a loud load, consumed by the first build that has the scroll
+  // view on screen (the load's own setState still shows the loading spinner,
+  // so the scroll can't be kicked off from there).
+  int? _pendingTodayScroll;
+  // Stable identities for the pinned headers so the Today scroller can find
+  // their render objects. Days share the `'$cityKey#$day'` scheme with
+  // _collapsedDays; cities are keyed by group label like _collapsedCities.
+  final Map<String, GlobalKey> _dayHeaderKeys = {};
+  final Map<String, GlobalKey> _cityHeaderKeys = {};
   int?
       _selectedPosition; // position of the place focused via a map pin / list tap
   List<BookingTodo> _bookingTodos = [];
@@ -149,6 +163,12 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
     _load();
   }
 
+  @override
+  void dispose() {
+    _scroll.dispose();
+    super.dispose();
+  }
+
   Future<void> _load({bool silent = false}) async {
     // Silent mode refreshes an already-displayed trip in place — no
     // full-screen spinner, no error page — so the refine panel (and the
@@ -172,6 +192,9 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
           _trip = trip;
           _bookingTodos = trip.bookingTodos ?? [];
           _offlineSince = null; // live data — leave offline mode if we were in it
+          // Today mode fires only from loud loads — never from a silent
+          // refresh, which shares this success path (PR #51/#53 invariants).
+          if (!silent) _maybeAutoScrollToday(trip);
         });
         // Remember this as the most recently viewed trip (home screen tile).
         ref.read(recentTripProvider.notifier).record(
@@ -202,6 +225,9 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
             _bookingTodos = cached.trip.bookingTodos ?? [];
             _offlineSince = cached.savedAt;
             _error = null;
+            // Opening a live trip while offline is Today mode's prime use
+            // case — the cached copy scrolls to today just like a live load.
+            if (!silent) _maybeAutoScrollToday(cached.trip);
           });
           return; // finally still clears _loading
         }
@@ -274,6 +300,151 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
     }();
     _refreshFuture = future;
     return future;
+  }
+
+  // ── Today mode (specs/today-mode) ─────────────────────────────────────
+
+  /// Pinned-header heights, shared by the build method and the Today scroll
+  /// math so the two can never drift apart.
+  static const double _mapHeaderHeight =
+      12 + 240 + 12; // top gap + map + bottom gap
+  // Itinerary title row (36) + gap (8) + filter chip row (48) + bottom
+  // padding (8); title-row-only when the trip has no items.
+  static const double _listHeaderHeight = 100;
+  static const double _listHeaderHeightEmpty = 48;
+
+  /// Combined height of the chrome pinned above the itinerary slivers: the
+  /// map header (shown only when a filtered item is mappable — same gate as
+  /// the build) plus the itinerary title/filter header.
+  double _pinnedChrome(Trip trip) {
+    final mapShown =
+        _filtered(trip).any((i) => i.latitude != 0 || i.longitude != 0);
+    final listH = (trip.items ?? const []).isNotEmpty
+        ? _listHeaderHeight
+        : _listHeaderHeightEmpty;
+    return (mapShown ? _mapHeaderHeight : 0) + listH;
+  }
+
+  /// Measured height of the pinned city header above [dayKey]'s section
+  /// (0 when it isn't laid out yet).
+  double _cityHeaderHeight(String dayKey) {
+    final cityKey = dayKey.substring(0, dayKey.lastIndexOf('#'));
+    final box = _cityHeaderKeys[cityKey]?.currentContext?.findRenderObject();
+    return box is RenderBox && box.hasSize ? box.size.height : 0;
+  }
+
+  /// One-shot Today trigger, called inside the setState of the loud load
+  /// paths (live success and cached-offline fallback) so the map's today
+  /// chip preselection lands in the same frame as the trip. Never called
+  /// from silent refreshes; a no-op once fired, while the refine panel is
+  /// open, or when the trip is undated/past/future or has no day tags.
+  void _maybeAutoScrollToday(Trip trip) {
+    if (_autoScrolledToday || _panelOpen) return;
+    final today = tripDayOn(trip.startDate, trip.endDate, DateTime.now());
+    if (today == null) return;
+    if (!(trip.items ?? const <ItineraryItem>[]).any((i) => i.day != null)) {
+      return;
+    }
+    _autoScrolledToday = true;
+    _selectedDay = today; // map day-chip preselect
+    // The scroll itself waits for the first build that actually shows the
+    // scroll view: this setState still renders the loading spinner (the
+    // loud path clears _loading later, in its finally), so a post-frame
+    // callback scheduled here could fire before the CustomScrollView exists.
+    _pendingTodayScroll = today;
+  }
+
+  /// Scrolls the itinerary so [day]'s header rests just below the pinned
+  /// chrome (map + title + city header). Missing headers fall back to the
+  /// nearest prior day, then the nearest following; a collapsed city/day is
+  /// expanded first. Pure view work — safe offline and with the panel open.
+  void _scrollToDay(int day) {
+    final dayKey = _resolveDayHeaderKey(day);
+    if (dayKey == null) return;
+    final cityKey = dayKey.substring(0, dayKey.lastIndexOf('#'));
+    if (_collapsedCities.contains(cityKey) ||
+        _collapsedDays.contains(dayKey)) {
+      setState(() {
+        _collapsedCities.remove(cityKey);
+        _collapsedDays.remove(dayKey);
+      });
+      // Continue once the expanded section has laid out.
+      WidgetsBinding.instance
+          .addPostFrameCallback((_) => _scrollToDayHeader(dayKey));
+      return;
+    }
+    _scrollToDayHeader(dayKey);
+  }
+
+  /// The registry key of the day header [day] should scroll to: the first
+  /// (build-order) header for that exact day, else the nearest prior day
+  /// with a header, else the nearest following. Only headers that are
+  /// currently built count, except those hidden inside a collapsed city —
+  /// still reachable because [_scrollToDay] expands them first.
+  String? _resolveDayHeaderKey(int day) {
+    String? prior;
+    String? next;
+    int? priorDay;
+    int? nextDay;
+    for (final entry in _dayHeaderKeys.entries) {
+      final key = entry.key;
+      final hashAt = key.lastIndexOf('#');
+      final d = int.tryParse(key.substring(hashAt + 1));
+      if (d == null) continue;
+      // Skip stale keys whose day no longer renders (removed items), as
+      // opposed to ones merely hidden inside a collapsed city group.
+      if (entry.value.currentContext == null &&
+          !_collapsedCities.contains(key.substring(0, hashAt))) {
+        continue;
+      }
+      if (d == day) return key;
+      if (d < day && (priorDay == null || d > priorDay)) {
+        priorDay = d;
+        prior = key;
+      }
+      if (d > day && (nextDay == null || d < nextDay)) {
+        nextDay = d;
+        next = key;
+      }
+    }
+    return prior ?? next;
+  }
+
+  /// Offset-reveal scroll to [dayKey]'s header (specs/today-mode plan.md,
+  /// D1): `ensureVisible` is unreliable under SliverPinnedHeader /
+  /// MultiSliver, so compute the reveal offset, subtract everything pinned
+  /// above the header's resting slot, animate, then run exactly one
+  /// correction pass against the header's actual on-screen position.
+  Future<void> _scrollToDayHeader(String dayKey) async {
+    final trip = _trip;
+    if (!mounted || trip == null || !_scroll.hasClients) return;
+    final target = _dayHeaderKeys[dayKey]?.currentContext?.findRenderObject();
+    if (target == null || !target.attached) return;
+    final viewport = RenderAbstractViewport.maybeOf(target);
+    if (viewport == null) return;
+    final resting = _pinnedChrome(trip) + _cityHeaderHeight(dayKey);
+    final reveal = viewport.getOffsetToReveal(target, 0).offset - resting;
+    final offset = reveal.clamp(0.0, _scroll.position.maxScrollExtent);
+    await _scroll.animateTo(offset,
+        duration: const Duration(milliseconds: 350),
+        curve: Curves.easeOutCubic);
+    if (!mounted || !_scroll.hasClients) return;
+    // One correction pass (no loops chasing layout): late-built slivers can
+    // shift the estimate, so measure where the header actually landed and
+    // jump the residual. A header pinned in its slot measures exactly at
+    // the desired dy, so this never fights the pin.
+    final box = _dayHeaderKeys[dayKey]?.currentContext?.findRenderObject();
+    if (box is! RenderBox || !box.attached) return;
+    final vp = RenderAbstractViewport.maybeOf(box);
+    if (vp == null) return;
+    // Header dy in viewport coordinates vs. its resting slot below the
+    // pinned chrome.
+    final actual = box.localToGlobal(Offset.zero, ancestor: vp).dy;
+    final delta = actual - (_pinnedChrome(trip) + _cityHeaderHeight(dayKey));
+    if (delta.abs() > 2) {
+      _scroll.jumpTo((_scroll.offset + delta)
+          .clamp(0.0, _scroll.position.maxScrollExtent));
+    }
   }
 
   /// Pushes the itinerary-derived booking checklist to the server, which upserts
@@ -1021,6 +1192,10 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
     if (!items.any((it) => it.day != null)) {
       return [_boxSliver(_buildDayTripWidgets(items, theme))];
     }
+    // Today mode: the header for today's trip day (if any) gets a visible
+    // highlight; undated/past/future trips resolve to null and render as-is.
+    final todayDay =
+        tripDayOn(_trip?.startDate, _trip?.endDate, DateTime.now());
     final slivers = <Widget>[];
     var i = 0;
     while (i < items.length) {
@@ -1057,7 +1232,9 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
                         RefineTarget.day(day,
                             city: cityKey == 'Other places' ? null : cityKey));
                   }
-                : null);
+                : null,
+            headerKey: _dayHeaderKeys.putIfAbsent(dayKey, GlobalKey.new),
+            isToday: day == todayDay);
         slivers.add(MultiSliver(
           pushPinnedChildren: true,
           children: [
@@ -1543,7 +1720,10 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
 
   /// Day section header: shows the calendar date (day N -> startDate + (N-1))
   /// when the trip start is known, otherwise falls back to "Day N". The opaque
-  /// Material keeps items from showing through while the header is pinned.
+  /// Material keeps items from showing through while the header is pinned —
+  /// today's tint is alpha-blended onto the scaffold background (never a
+  /// translucent color) for the same reason. [headerKey] gives the Today
+  /// scroller a stable handle on the header's render box.
   Widget _daySubHeader(
       int day,
       DateTime? tripStart,
@@ -1551,13 +1731,19 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
       bool collapsed,
       int travelMin,
       VoidCallback onTap,
-      VoidCallback? onRefine) {
+      VoidCallback? onRefine,
+      {Key? headerKey,
+      bool isToday = false}) {
     final label = tripStart != null
         ? _fmtDayHeader(tripStart.add(Duration(days: day - 1)))
         : 'Day $day';
     final muted = theme.colorScheme.onSurfaceVariant;
     return Material(
-      color: theme.scaffoldBackgroundColor,
+      key: headerKey,
+      color: isToday
+          ? Color.alphaBlend(theme.colorScheme.primary.withValues(alpha: 0.06),
+              theme.scaffoldBackgroundColor)
+          : theme.scaffoldBackgroundColor,
       child: InkWell(
         onTap: onTap,
         child: Padding(
@@ -1567,12 +1753,27 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
               Icon(Icons.today, size: 16, color: theme.colorScheme.primary),
               const SizedBox(width: 6),
               Expanded(
-                child: Text(
-                  label,
-                  style: theme.textTheme.labelLarge?.copyWith(
-                    color: theme.colorScheme.primary,
-                    fontWeight: FontWeight.w700,
-                  ),
+                child: Row(
+                  children: [
+                    Flexible(
+                      child: Text(
+                        label,
+                        style: theme.textTheme.labelLarge?.copyWith(
+                          color: theme.colorScheme.primary,
+                          fontWeight: FontWeight.w700,
+                        ),
+                      ),
+                    ),
+                    if (isToday) ...[
+                      const SizedBox(width: 8),
+                      StatusPill.custom(
+                        label: 'Today',
+                        background:
+                            theme.colorScheme.primary.withValues(alpha: 0.15),
+                        foreground: theme.colorScheme.primary,
+                      ),
+                    ],
+                  ],
                 ),
               ),
               if (travelMin > 0) ...[
@@ -2382,7 +2583,28 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
                       if (_selectedDay != null && _selectedDay! > mapDayCount) {
                         _selectedDay = null;
                       }
+                      // Today mode: the jump chip renders only when today
+                      // falls inside the trip's dates AND some item carries a
+                      // day tag (the same gate as the auto-scroll, so the
+                      // chip never points at nothing).
+                      final todayDay =
+                          tripDayOn(trip.startDate, trip.endDate, DateTime.now());
+                      final hasTodayTarget = todayDay != null &&
+                          (trip.items ?? const <ItineraryItem>[])
+                              .any((i) => i.day != null);
+                      // A loud load queued the one-shot auto-scroll; this is
+                      // the first frame that actually mounts the scroll view
+                      // (and registers the day-header keys), so kick it off
+                      // once this frame's layout is done.
+                      final pendingToday = _pendingTodayScroll;
+                      if (pendingToday != null) {
+                        _pendingTodayScroll = null;
+                        WidgetsBinding.instance.addPostFrameCallback((_) {
+                          if (mounted) _scrollToDay(pendingToday);
+                        });
+                      }
                       final scrollView = CustomScrollView(
+                        controller: _scroll,
                         slivers: [
                           SliverPadding(
                             padding: const EdgeInsets.fromLTRB(16, 16, 16, 0),
@@ -2403,8 +2625,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
                             SliverPersistentHeader(
                               pinned: true,
                               delegate: _PinnedHeaderDelegate(
-                                height:
-                                    12 + 240 + 12, // top gap + map + bottom gap
+                                height: _mapHeaderHeight,
                                 backgroundColor: theme.scaffoldBackgroundColor,
                                 padding:
                                     const EdgeInsets.fromLTRB(16, 12, 16, 12),
@@ -2461,11 +2682,11 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
                           SliverPersistentHeader(
                             pinned: true,
                             delegate: _PinnedHeaderDelegate(
-                              // title row (36) + gap (8) + chip row (48) + bottom
-                              // padding (8); title-row-only when there are no items.
+                              // title row + filter chip row; title-row-only
+                              // when there are no items (see the constants).
                               height: (trip.items ?? const []).isNotEmpty
-                                  ? 100
-                                  : 48,
+                                  ? _listHeaderHeight
+                                  : _listHeaderHeightEmpty,
                               backgroundColor: theme.scaffoldBackgroundColor,
                               padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
                               // Align fills the header's full extent so the child's
@@ -2487,6 +2708,30 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
                                                 style: theme
                                                     .textTheme.titleMedium),
                                           ),
+                                          if (hasTodayTarget) ...[
+                                            ActionChip(
+                                              avatar: Icon(Icons.today,
+                                                  size: 16,
+                                                  color: theme
+                                                      .colorScheme.primary),
+                                              label: const Text('Today'),
+                                              visualDensity:
+                                                  VisualDensity.compact,
+                                              materialTapTargetSize:
+                                                  MaterialTapTargetSize
+                                                      .shrinkWrap,
+                                              // Pure view work (select +
+                                              // expand + scroll): allowed
+                                              // offline and while the refine
+                                              // panel is open.
+                                              onPressed: () {
+                                                setState(() =>
+                                                    _selectedDay = todayDay);
+                                                _scrollToDay(todayDay);
+                                              },
+                                            ),
+                                            const SizedBox(width: 4),
+                                          ],
                                           TextButton.icon(
                                             onPressed:
                                                 _isOffline ? null : _addPlace,
@@ -2555,8 +2800,11 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
                                     pushPinnedChildren: true,
                                     children: [
                                       SliverPinnedHeader(
-                                          child:
-                                              _cityHeader(trip, group, theme)),
+                                          child: KeyedSubtree(
+                                              key: _cityHeaderKeys.putIfAbsent(
+                                                  group.label, GlobalKey.new),
+                                              child: _cityHeader(
+                                                  trip, group, theme))),
                                       if (!_collapsedCities
                                           .contains(group.label)) ...[
                                         // Embedded bookings render only in the

--- a/src/packages/flutter-app/test/trip_detail_today_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_today_test.dart
@@ -1,0 +1,235 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:travel_route_planner/models/trip.dart';
+import 'package:travel_route_planner/models/itinerary_item.dart';
+import 'package:travel_route_planner/services/api_client.dart';
+import 'package:travel_route_planner/services/trips_api_service.dart';
+import 'package:travel_route_planner/providers/trips_provider.dart';
+import 'package:travel_route_planner/screens/trip_detail_screen.dart';
+import 'package:travel_route_planner/widgets/map_day_chips.dart';
+import 'package:travel_route_planner/widgets/status_pill.dart';
+
+/// Today mode (specs/today-mode PR 3): one-shot auto-scroll to today's day
+/// header, the pinned "Today" jump chip, and the header highlight.
+///
+/// Dates are computed relative to DateTime.now() so "today" is always live.
+/// Items carry zero coordinates so the map sliver is skipped — the scroll
+/// math must land correctly with the map-hidden pinned-chrome height.
+class _FakeTripsApiService extends TripsApiService {
+  final Trip trip;
+  int calls = 0;
+  _FakeTripsApiService(this.trip) : super(ApiClient(baseUrl: 'http://test'));
+
+  @override
+  Future<Trip> getTrip(String id) async {
+    calls++;
+    return trip;
+  }
+}
+
+String _iso(DateTime d) =>
+    '${d.year.toString().padLeft(4, '0')}-'
+    '${d.month.toString().padLeft(2, '0')}-'
+    '${d.day.toString().padLeft(2, '0')}';
+
+ItineraryItem _item(int pos, String name, int day,
+        {double lat = 0, double lng = 0}) =>
+    ItineraryItem(
+      id: 'i$pos',
+      position: pos,
+      name: name,
+      address: '$name street, Paris',
+      latitude: lat,
+      longitude: lng,
+      category: 'attraction',
+      day: day,
+      city: 'Paris',
+    );
+
+/// A three-day Paris trip: day 1 is long enough that today's (day 2) header
+/// starts well below the fold, day 3 gives the scroll room to land day 2 at
+/// the top.
+Trip _liveTrip({required String startDate, required String endDate}) => Trip(
+      id: 't1',
+      title: 'Live Trip',
+      status: 'planned',
+      createdAt: '2026-06-01',
+      updatedAt: '2026-06-01',
+      startDate: startDate,
+      endDate: endDate,
+      items: [
+        for (var k = 0; k < 6; k++) _item(k, 'Past stop $k', 1),
+        for (var k = 0; k < 6; k++) _item(6 + k, 'Today stop $k', 2),
+        for (var k = 0; k < 4; k++) _item(12 + k, 'Next stop $k', 3),
+      ],
+    );
+
+Future<void> _pumpScreen(WidgetTester tester, TripsApiService service) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [tripsApiServiceProvider.overrideWithValue(service)],
+      child: const MaterialApp(home: TripDetailScreen(tripId: 't1')),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+ScrollPosition _position(WidgetTester tester) =>
+    tester.state<ScrollableState>(find.byType(Scrollable).first).position;
+
+/// The "Today" StatusPill inside today's day header (the jump chip is an
+/// ActionChip, so the two never collide).
+Finder _todayPill() => find.widgetWithText(StatusPill, 'Today');
+
+Finder _todayChip() => find.widgetWithText(ActionChip, 'Today');
+
+void main() {
+  final now = DateTime.now();
+  // Today is day 2 of a 3-day trip that started yesterday.
+  final start = _iso(now.subtract(const Duration(days: 1)));
+  final end = _iso(now.add(const Duration(days: 1)));
+
+  testWidgets(
+      'live trip auto-scrolls once to today: header rests just below the '
+      'pinned chrome, tinted, with a Today pill and jump chip',
+      (WidgetTester tester) async {
+    await _pumpScreen(
+        tester, _FakeTripsApiService(_liveTrip(startDate: start, endDate: end)));
+
+    // The one-shot scroll actually moved the list.
+    expect(_position(tester).pixels, greaterThan(0));
+
+    // Today's header carries the pill and the highlight tint (opaque: the
+    // primary tint alpha-blended onto the scaffold background).
+    expect(_todayPill(), findsOneWidget);
+    final theme = Theme.of(tester.element(find.text('Itinerary')));
+    final expectedTint = Color.alphaBlend(
+        theme.colorScheme.primary.withValues(alpha: 0.06),
+        theme.scaffoldBackgroundColor);
+    final headerMaterial = tester.widget<Material>(find
+        .ancestor(of: _todayPill(), matching: find.byType(Material))
+        .first);
+    expect(headerMaterial.color, expectedTint);
+
+    // The header sits just below the pinned chrome: with zero-coord items
+    // the map sliver is skipped, so the chrome is the itinerary title header
+    // (100) plus the pinned city header above the day header.
+    final viewportTop = tester.getTopLeft(find.byType(CustomScrollView)).dy;
+    final pillDy = tester.getTopLeft(_todayPill()).dy;
+    expect(pillDy, greaterThan(viewportTop + 100));
+    expect(pillDy, lessThan(viewportTop + 100 + 120));
+    // Today's items start right under it.
+    expect(find.text('Today stop 0'), findsOneWidget);
+
+    // The jump chip renders in the pinned title row.
+    expect(_todayChip(), findsOneWidget);
+  });
+
+  testWidgets('a silent refresh never re-triggers the auto-scroll (one-shot)',
+      (WidgetTester tester) async {
+    final service =
+        _FakeTripsApiService(_liveTrip(startDate: start, endDate: end));
+    await _pumpScreen(tester, service);
+    expect(_position(tester).pixels, greaterThan(0));
+
+    // Scroll back to the top, then drive a silent refresh through the fake
+    // service via pull-to-refresh.
+    _position(tester).jumpTo(0);
+    await tester.pumpAndSettle();
+    await tester.fling(
+        find.byType(CustomScrollView), const Offset(0, 400), 1000);
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1));
+    await tester.pumpAndSettle();
+
+    expect(service.calls, greaterThan(1)); // the refresh really refetched
+    expect(_position(tester).pixels, 0); // ...and did not scroll
+  });
+
+  testWidgets('the Today chip expands a collapsed today section and scrolls',
+      (WidgetTester tester) async {
+    await _pumpScreen(
+        tester, _FakeTripsApiService(_liveTrip(startDate: start, endDate: end)));
+
+    // Collapse today's day by tapping its header (the pill sits inside the
+    // header's InkWell), then park the list at the top.
+    await tester.tap(_todayPill());
+    await tester.pumpAndSettle();
+    expect(find.text('Today stop 0'), findsNothing);
+    _position(tester).jumpTo(0);
+    await tester.pumpAndSettle();
+
+    await tester.tap(_todayChip());
+    await tester.pumpAndSettle();
+
+    // Expanded and scrolled: today's items are back and the header rests
+    // below the pinned chrome again.
+    expect(_position(tester).pixels, greaterThan(0));
+    expect(find.text('Today stop 0'), findsOneWidget);
+    final viewportTop = tester.getTopLeft(find.byType(CustomScrollView)).dy;
+    final pillDy = tester.getTopLeft(_todayPill()).dy;
+    expect(pillDy, greaterThan(viewportTop + 100));
+    expect(pillDy, lessThan(viewportTop + 100 + 120));
+  });
+
+  testWidgets('a trip that ended yesterday gets no Today behavior',
+      (WidgetTester tester) async {
+    final trip = _liveTrip(
+      startDate: _iso(now.subtract(const Duration(days: 3))),
+      endDate: _iso(now.subtract(const Duration(days: 1))),
+    );
+    await _pumpScreen(tester, _FakeTripsApiService(trip));
+
+    expect(_position(tester).pixels, 0);
+    expect(_todayChip(), findsNothing);
+    expect(_todayPill(), findsNothing);
+  });
+
+  testWidgets('an undated trip gets no Today behavior',
+      (WidgetTester tester) async {
+    final undated = Trip(
+      id: 't1',
+      title: 'Undated Trip',
+      status: 'planned',
+      createdAt: '2026-06-01',
+      updatedAt: '2026-06-01',
+      items: [
+        for (var k = 0; k < 6; k++) _item(k, 'Stop $k', 1),
+        for (var k = 0; k < 6; k++) _item(6 + k, 'Later stop $k', 2),
+      ],
+    );
+    await _pumpScreen(tester, _FakeTripsApiService(undated));
+
+    expect(_position(tester).pixels, 0);
+    expect(_todayChip(), findsNothing);
+    expect(_todayPill(), findsNothing);
+    expect(find.text('Day 1'), findsOneWidget); // plain headers, no dates
+  });
+
+  testWidgets('a live trip preselects today on the map day chips',
+      (WidgetTester tester) async {
+    // Real (tight Paris-cluster) coordinates so the map sliver mounts — the
+    // auto-scroll then also exercises the map-shown pinned-chrome height.
+    final trip = Trip(
+      id: 't1',
+      title: 'Live Mapped Trip',
+      status: 'planned',
+      createdAt: '2026-06-01',
+      updatedAt: '2026-06-01',
+      startDate: start,
+      endDate: end,
+      items: [
+        _item(0, 'Louvre', 1, lat: 48.8606, lng: 2.3376),
+        _item(1, 'Orsay', 1, lat: 48.8600, lng: 2.3266),
+        _item(2, 'Pantheon', 2, lat: 48.8462, lng: 2.3464),
+      ],
+    );
+    await _pumpScreen(tester, _FakeTripsApiService(trip));
+
+    expect(
+        tester.widget<MapDayChips>(find.byType(MapDayChips)).selected, 2);
+    expect(_todayChip(), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary

Wave 11 PR 3 (final) of `specs/today-mode` — the Today behaviors on the trip detail screen, built on #96 (trip-day helpers) and #98 (map day chips):

- **One-shot auto-scroll (plan.md D1).** Opening a trip whose date range includes today scrolls the itinerary once to today's day header via offset-reveal math (`getOffsetToReveal` minus the pinned chrome: map header when shown + itinerary title header + the *measured* city header), animated 350ms `easeOutCubic`, followed by exactly one correction pass against the header's actual viewport position. Day headers get stable `GlobalKey`s keyed `'$cityKey#$day'` — the same scheme as `_collapsedDays`.
- **Trigger discipline.** Fires from the loud `_load` success path **and** the cached-offline fallback (offline mid-trip is a prime use case) — never from silent `_refresh()` (PR #51/#53 invariants), never while the refine panel is open, at most once per screen visit. It also preselects today's map day chip in the same `setState` as the load result. The scroll itself is deferred to the first build that mounts the scroll view (the load's own `setState` still shows the spinner).
- **Fallback + expansion.** No header for today → nearest prior day with a header → nearest following → no-op. A collapsed city/day containing the target expands first (one `setState`), then the scroll continues post-frame. Undated/past/future trips: nothing happens anywhere.
- **"Today" jump chip (D3).** Compact `ActionChip` in the pinned Itinerary title row, left of "Add place", rendered only when today is inside the trip dates and at least one item is day-tagged. Pure view work: selects today's map chip, expands, scrolls — works offline and with the panel open (no mutations, `_guardOffline` untouched).
- **Header highlight (D3).** Today's day header is tinted `Color.alphaBlend(primary @ 6%, scaffoldBackground)` — stays opaque, as pinned rendering requires — with a `StatusPill.custom` "Today" after the date label.
- The pinned-header heights (map `12+240+12`, title `100`/`48`) are extracted to shared constants used by both the build and the scroll math so they cannot drift.

## Tests

New `test/trip_detail_today_test.dart` (dates computed relative to `DateTime.now()`; zero-coord items so the map sliver is skipped and the map-hidden chrome path is exercised):
1. live trip → offset > 0, header rests exactly at viewportTop + 100 + measured city header (asserted via dy range), tinted Material + Today pill + Today chip;
2. silent pull-to-refresh through the fake service → offset unchanged (one-shot);
3. collapse today's day via its header, scroll to top, tap the Today chip → expands + scrolls back;
4. trip ended yesterday → offset 0, no chip, no highlight;
5. undated trip → unchanged (`Day N` headers, no Today anything);
6. live mapped trip → `MapDayChips.selected` preselects today.

`make flutter-test`: **142 passed** (sticky-headers and day-chips tests unchanged). `flutter analyze --no-fatal-infos --fatal-warnings`: exit 0, the 12 known pre-existing infos, none added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)