### PR TITLE
fix(flutter): trip-map overlaps — day chips over markers, pins over travel-time pills

### DIFF
--- a/src/packages/flutter-app/lib/screens/shared_trip_screen.dart
+++ b/src/packages/flutter-app/lib/screens/shared_trip_screen.dart
@@ -205,6 +205,11 @@ class _SharedTripBodyState extends ConsumerState<_SharedTripBody> {
                           accommodations: dayStays,
                           selectedPosition: _selectedPosition,
                           fitSignature: _selectedDay,
+                          // Keep fitted markers clear of the chip row
+                          // overlaid below.
+                          topOverlayInset: mapDayCount > 0
+                              ? MapDayChips.mapTopInset
+                              : 0,
                           emptyLabel: _selectedDay == null
                               ? 'No mapped places'
                               : 'No mapped places on this day',

--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -2646,6 +2646,11 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
                                           // filter already empties this map.
                                           segmentLabels: _segmentLabels(),
                                           fitSignature: _selectedDay,
+                                          // Keep fitted markers clear of the
+                                          // chip row overlaid below.
+                                          topOverlayInset: mapDayCount > 0
+                                              ? MapDayChips.mapTopInset
+                                              : 0,
                                           emptyLabel: _selectedDay == null
                                               ? 'No mapped places'
                                               : 'No mapped places on this day',

--- a/src/packages/flutter-app/lib/widgets/map_day_chips.dart
+++ b/src/packages/flutter-app/lib/widgets/map_day_chips.dart
@@ -12,6 +12,12 @@ import 'package:flutter/material.dart';
 /// The chips sit over satellite imagery, so they use the same translucent
 /// dark scrim treatment as the map's segment labels and control buttons.
 class MapDayChips extends StatelessWidget {
+  /// Vertical band (px) the chip row occupies over the map's top edge when
+  /// overlaid at `top: 8`, including breathing room. Callers pass this as
+  /// TripMap's `topOverlayInset` so camera fitting keeps markers out from
+  /// under the chips.
+  static const double mapTopInset = 48;
+
   final int dayCount;
   final int? selected;
   final ValueChanged<int?> onSelected;

--- a/src/packages/flutter-app/lib/widgets/trip_map.dart
+++ b/src/packages/flutter-app/lib/widgets/trip_map.dart
@@ -41,6 +41,11 @@ class TripMap extends StatefulWidget {
   /// coordinates). The default keeps existing call sites unchanged.
   final String emptyLabel;
 
+  /// Extra top camera-fit padding (px) for overlays floating on the map's top
+  /// edge (e.g. [MapDayChips]), so fitted markers never land underneath them.
+  /// The default keeps existing call sites unchanged.
+  final double topOverlayInset;
+
   const TripMap({
     super.key,
     required this.items,
@@ -50,6 +55,7 @@ class TripMap extends StatefulWidget {
     this.accommodations = const [],
     this.fitSignature,
     this.emptyLabel = 'No mapped places',
+    this.topOverlayInset = 0,
   });
 
   @override
@@ -58,6 +64,11 @@ class TripMap extends StatefulWidget {
 
 class _TripMapState extends State<TripMap> {
   final MapController _controller = MapController();
+
+  /// Fit padding shared by the initial fit and every re-fit; asymmetric so a
+  /// top overlay (day chips) never covers the topmost fitted marker.
+  EdgeInsets get _fitPadding =>
+      EdgeInsets.fromLTRB(32, 32 + widget.topOverlayInset, 32, 32);
 
   static bool _hasCoords(ItineraryItem i) =>
       i.latitude != 0 || i.longitude != 0;
@@ -98,7 +109,7 @@ class _TripMapState extends State<TripMap> {
         _controller.fitCamera(
           CameraFit.bounds(
             bounds: LatLngBounds.fromPoints(points),
-            padding: const EdgeInsets.all(32),
+            padding: _fitPadding,
           ),
         );
       }
@@ -220,30 +231,24 @@ class _TripMapState extends State<TripMap> {
     final selected = _selectedPoint();
 
     // Travel-time labels at the midpoint of each within-city leg (only between
-    // truly adjacent itinerary stops that are both mapped).
-    final labelMarkers = <Marker>[];
+    // truly adjacent itinerary stops that are both mapped). Kept as endpoint
+    // records — _SegmentLabelLayer decides per camera frame which are visible.
+    final labelSegments = <({LatLng a, LatLng b, String text})>[];
     for (var k = 0; k < mapped.length - 1; k++) {
       final a = mapped[k];
       final b = mapped[k + 1];
       if (b.item.position != a.item.position + 1) continue;
       final label = widget.segmentLabels[a.item.position];
       if (label == null) continue;
-      labelMarkers.add(
-        Marker(
-          point: LatLng(
-            (a.point.latitude + b.point.latitude) / 2,
-            (a.point.longitude + b.point.longitude) / 2,
-          ),
-          width: 84,
-          height: 26,
-          child: _SegmentLabel(text: label),
-        ),
-      );
+      labelSegments.add((a: a.point, b: b.point, text: label));
     }
 
     // Direction arrows on every drawn segment (each consecutive pair of mapped
     // points, matching the polyline). Placed at the midpoint, or further along
-    // when a travel-time label already occupies the midpoint.
+    // when a travel-time label already occupies the midpoint. Placement stays
+    // static even though labels hide dynamically on short legs: on such a leg
+    // (< _SegmentLabelLayer.minLegPx on screen) t=0.7 vs 0.5 differs by a few
+    // px and the arrow tucks behind the pins anyway.
     final arrowMarkers = <Marker>[];
     for (var k = 0; k < mapped.length - 1; k++) {
       final a = mapped[k];
@@ -291,7 +296,7 @@ class _TripMapState extends State<TripMap> {
             : MapOptions(
                 initialCameraFit: CameraFit.bounds(
                   bounds: LatLngBounds.fromPoints(fitPoints),
-                  padding: const EdgeInsets.all(32),
+                  padding: _fitPadding,
                 ),
                 interactionOptions: interaction,
                 backgroundColor: appMapBackground,
@@ -322,7 +327,8 @@ class _TripMapState extends State<TripMap> {
                 ],
               ),
             if (arrowMarkers.isNotEmpty) MarkerLayer(markers: arrowMarkers),
-            if (labelMarkers.isNotEmpty) MarkerLayer(markers: labelMarkers),
+            if (labelSegments.isNotEmpty)
+              _SegmentLabelLayer(segments: labelSegments),
             // Stays live in their own layer, outside the clusterer: a trip has
             // few of them and "where am I sleeping" should never collapse into
             // an anonymous count bubble with sightseeing pins. Drawn beneath
@@ -427,6 +433,42 @@ class _SegmentArrow extends StatelessWidget {
         ],
       ),
     );
+  }
+}
+
+/// Renders travel-time pills only for legs long enough on screen to have room
+/// for one — zoomed out, same-city stops converge and the midpoint pill would
+/// just sit behind the numbered pins. Rebuilds on every camera move/zoom
+/// because MapCamera.of registers an InheritedModel dependency.
+class _SegmentLabelLayer extends StatelessWidget {
+  /// Minimum on-screen leg length (px) before its pill is drawn: pin radius
+  /// (12-14) + half a typical pill (~23×11) + breathing room, per side.
+  static const double minLegPx = 70;
+
+  final List<({LatLng a, LatLng b, String text})> segments;
+  const _SegmentLabelLayer({required this.segments});
+
+  @override
+  Widget build(BuildContext context) {
+    final camera = MapCamera.of(context);
+    final markers = <Marker>[
+      for (final s in segments)
+        if ((camera.latLngToScreenOffset(s.a) -
+                    camera.latLngToScreenOffset(s.b))
+                .distance >=
+            minLegPx)
+          Marker(
+            point: LatLng(
+              (s.a.latitude + s.b.latitude) / 2,
+              (s.a.longitude + s.b.longitude) / 2,
+            ),
+            width: 84,
+            height: 26,
+            child: _SegmentLabel(text: s.text),
+          ),
+    ];
+    if (markers.isEmpty) return const SizedBox.shrink();
+    return MarkerLayer(markers: markers);
   }
 }
 

--- a/src/packages/flutter-app/test/trip_map_test.dart
+++ b/src/packages/flutter-app/test/trip_map_test.dart
@@ -218,6 +218,71 @@ void main() {
     expect(after.center, before.center);
   });
 
+  testWidgets('segment label shows when the leg is long enough on screen',
+      (WidgetTester tester) async {
+    // The Paris pair alone fits at a high zoom, so the ~0.8km leg spans far
+    // more than the visibility threshold.
+    await tester.pumpWidget(
+      _host(TripMap(items: items, segmentLabels: const {0: '12 min'})),
+    );
+    await tester.pump();
+
+    expect(find.text('12 min'), findsOneWidget);
+  });
+
+  testWidgets('segment label hides when the leg converges at fit zoom',
+      (WidgetTester tester) async {
+    // Adding Marseille zooms the fit out to country scale, where the Paris
+    // leg collapses to a few pixels — the pill would just sit behind the
+    // numbered pins, so it must not render.
+    await tester.pumpWidget(_host(TripMap(
+      items: [...items, _item(2, 'Vieux-Port', 43.2965, 5.3698)],
+      segmentLabels: const {0: '12 min'},
+    )));
+    await tester.pump();
+
+    expect(find.text('12 min'), findsNothing);
+    expect(find.byType(TripMap), findsOneWidget);
+  });
+
+  testWidgets('camera change re-evaluates segment label visibility',
+      (WidgetTester tester) async {
+    final threeItems = [...items, _item(2, 'Vieux-Port', 43.2965, 5.3698)];
+    await tester.pumpWidget(_host(TripMap(
+      items: threeItems,
+      segmentLabels: const {0: '12 min'},
+    )));
+    await tester.pump();
+    expect(find.text('12 min'), findsNothing);
+
+    // Selecting a pin moves the camera to zoom 15, where the Paris leg is
+    // hundreds of px long — the label must (re)appear without a rebuild of
+    // the segment data.
+    await tester.pumpWidget(_host(TripMap(
+      items: threeItems,
+      segmentLabels: const {0: '12 min'},
+      selectedPosition: 0,
+    )));
+    await tester.pump(); // frame scheduling the post-frame camera move
+    await tester.pump(); // camera moved; label layer rebuilt
+
+    expect(find.text('12 min'), findsOneWidget);
+  });
+
+  testWidgets('topOverlayInset keeps fitted markers below the overlay band',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(
+      _host(TripMap(items: items, topOverlayInset: 48)),
+    );
+    await tester.pump();
+
+    // Topmost point (Louvre) must clear the 48px chip band at the fit.
+    final dy = _camera(tester)
+        .latLngToScreenOffset(const LatLng(48.8606, 2.3376))
+        .dy;
+    expect(dy, greaterThanOrEqualTo(48));
+  });
+
   testWidgets('stays alone (no mapped items) still render a map',
       (WidgetTester tester) async {
     const stays = [


### PR DESCRIPTION
## Problem

Two overlaps on the trip map (seen on "Latin America 4-Country Adventure"):

1. **Day-chip row covers markers.** The chips are a `Positioned(top: 8)` overlay on the map, but every camera fit used uniform 32px padding, so the topmost fitted marker could land directly under the chip row.
2. **Numbered pins cover their travel-time pills.** Pills render at each leg's geographic midpoint. Zoomed out to country scale, two same-city stops converge to the same screen point, so the 84×26 pill sat right behind the 24px pin (pins intentionally draw on top so numbers stay tappable) — leaving "min" fragments peeking out behind the circles.

## Fix

- **`TripMap.topOverlayInset`** (default 0): extra top camera-fit padding applied to every fit — initial, day-chip refit (`fitSignature`), content-change refit, and the reset button — via a shared `_fitPadding` getter. Both `trip_detail_screen` and `shared_trip_screen` pass the new `MapDayChips.mapTopInset` (48px) whenever chips render.
- **`_SegmentLabelLayer`**: travel-time pills are now built from endpoint records and drawn only when the leg spans ≥ 70px on screen. `MapCamera.of(context)` registers an InheritedModel dependency, so visibility re-evaluates on every pan/zoom — pills vanish at country zoom and reappear when zooming into a city. Direction arrows are deliberately unchanged (on a hidden-label leg the whole segment is < 70px, so their placement difference is a few px behind the pins).

## Testing

- 4 new widget tests: pill shows on a long leg, hides at converged fit zoom, reappears after a camera change, and `topOverlayInset` keeps the topmost fitted marker below the overlay band.
- Full suite: 189/189 passing; `flutter analyze` clean apart from the 12 pre-existing infos in untouched files.
- Verified live in headless Chrome against a clone of the reported trip: markers clear of the chip row at the "All" fit; no pill fragments behind pins zoomed out; "8 min" / "3 min" pills render cleanly after selecting Day 1 (Guadalajara).

🤖 Generated with [Claude Code](https://claude.com/claude-code)