### PR TITLE
feat(flutter): Trip assistant — persistent chat FAB on trip detail

### DIFF
--- a/src/packages/api/plan_handler.go
+++ b/src/packages/api/plan_handler.go
@@ -271,7 +271,7 @@ func planHandler(w http.ResponseWriter, r *http.Request) {
 		systemPrompt += profileNotesInstruction
 	}
 	if boundTripID != nil {
-		systemPrompt += "\n\nYou are refining an existing saved trip in place. The conversation's first message describes the current itinerary and which section the traveler wants to change. Apply changes by calling update_itinerary_section with the targeted scope and the COMPLETE updated list of places for that section — include unchanged places with their existing coordinates, city, day, time_of_day and category tags so they aren't lost. Use search_places to find real coordinates for any new place before adding it. Only change the section the traveler asked about unless they broaden the request."
+		systemPrompt += "\n\nYou are refining an existing saved trip in place. The conversation's first message describes the current itinerary and which section the traveler wants to change. Apply changes by calling update_itinerary_section with the targeted scope and the COMPLETE updated list of places for that section — include unchanged places with their existing coordinates, city, day, time_of_day and category tags so they aren't lost. Use search_places to find real coordinates for any new place before adding it. Only change the section the traveler asked about unless they broaden the request. The traveler may also ask questions about the trip without wanting changes — answer those directly from the itinerary and your search tools; only call update_itinerary_section when they explicitly ask for a modification."
 	}
 
 	// prevCacheMarker tracks the conversation cache breakpoint set on the

--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -815,11 +815,33 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
     ref
         .read(tripRefineProvider(widget.tripId).notifier)
         .beginSectionRefinement(_buildSectionSeed(trip, target),
-            displayLabel: 'Refining ${target.label}');
+            displayLabel: target.assistant
+                ? 'Trip assistant'
+                : 'Refining ${target.label}');
     setState(() {
       _panelOpen = true;
       _refineTarget = target;
     });
+  }
+
+  /// FAB entry point: resumes the panel conversation if one is in progress,
+  /// otherwise starts a fresh whole-trip assistant session.
+  void _openChat(Trip trip) {
+    if (_guardOffline()) return;
+    // The FAB is hidden for viewers; belt-and-braces like _openRefine.
+    if (!trip.isOwner) return;
+    final hasConversation =
+        ref.read(tripRefineProvider(widget.tripId)).messages.isNotEmpty;
+    if (hasConversation) {
+      setState(() {
+        _panelOpen = true;
+        // Restore a header if the screen was rebuilt and lost it; keep a
+        // surviving section-refine target so its header stays accurate.
+        _refineTarget ??= const RefineTarget.assistant();
+      });
+      return;
+    }
+    _openRefine(trip, const RefineTarget.assistant());
   }
 
   /// Whether an item falls inside the refinement target (client-side mirror of
@@ -890,8 +912,12 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
         b.write("scope='trip'");
     }
     b.write(' and the COMPLETE updated list for the section, keeping unchanged '
-        'places exactly as listed above (same coordinates and tags). '
-        'Start by asking what I want to change.');
+        'places exactly as listed above (same coordinates and tags). ');
+    b.write(t.assistant
+        ? 'I may also just ask questions about the trip (flights, bookings, '
+            'timing) — answer those directly without changing anything. '
+            'Start by asking how you can help.'
+        : 'Start by asking what I want to change.');
     return b.toString();
   }
 
@@ -2502,6 +2528,20 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
     final trip = _trip;
 
     return Scaffold(
+      // Always-reachable chat entry, mirroring the _openRefine guards so it's
+      // never a dead button. Hidden while the panel is open: on wide layouts
+      // the panel is docked (redundant), on narrow it would overlap the sheet.
+      floatingActionButton: (trip != null &&
+              !_panelOpen &&
+              trip.isOwner &&
+              !_isOffline &&
+              (trip.items?.isNotEmpty ?? false))
+          ? FloatingActionButton(
+              tooltip: 'Ask AI about this trip',
+              onPressed: () => _openChat(trip),
+              child: const Icon(Icons.chat_bubble_outline),
+            )
+          : null,
       appBar: GradientAppBar(
         title: Text(trip != null ? _displayTitle(trip) : 'Trip'),
         actions: [

--- a/src/packages/flutter-app/lib/widgets/trip_refine_panel.dart
+++ b/src/packages/flutter-app/lib/widgets/trip_refine_panel.dart
@@ -12,8 +12,14 @@ class RefineTarget {
   final int? day;
   final String? city;
 
-  const RefineTarget._(this.scope, this.day, this.city);
+  /// General-purpose "Trip assistant" flavor: same whole-trip scope, but the
+  /// framing invites questions rather than assuming every message is an edit.
+  final bool assistant;
+
+  const RefineTarget._(this.scope, this.day, this.city,
+      {this.assistant = false});
   const RefineTarget.trip() : this._('trip', null, null);
+  const RefineTarget.assistant() : this._('trip', null, null, assistant: true);
   const RefineTarget.day(int day, {String? city}) : this._('day', day, city);
   const RefineTarget.city(String city) : this._('city', null, city);
 
@@ -61,11 +67,19 @@ class TripRefinePanel extends ConsumerWidget {
           padding: const EdgeInsets.fromLTRB(16, 12, 8, 8),
           child: Row(
             children: [
-              Icon(Icons.auto_awesome, size: 18, color: theme.colorScheme.primary),
+              Icon(
+                target.assistant
+                    ? Icons.chat_bubble_outline
+                    : Icons.auto_awesome,
+                size: 18,
+                color: theme.colorScheme.primary,
+              ),
               const SizedBox(width: 8),
               Expanded(
                 child: Text(
-                  'Refining · ${target.label}',
+                  target.assistant
+                      ? 'Trip assistant'
+                      : 'Refining · ${target.label}',
                   style: theme.textTheme.titleSmall
                       ?.copyWith(fontWeight: FontWeight.bold),
                   overflow: TextOverflow.ellipsis,
@@ -84,7 +98,9 @@ class TripRefinePanel extends ConsumerWidget {
           child: ChatPanel(
             state: tripRefineProvider(tripId),
             notifier: tripRefineProvider(tripId).notifier,
-            inputHint: 'Ask for changes...',
+            inputHint: target.assistant
+                ? 'Ask anything about this trip…'
+                : 'Ask for changes...',
           ),
         ),
       ],

--- a/src/packages/flutter-app/test/trip_detail_chat_fab_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_chat_fab_test.dart
@@ -1,0 +1,141 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:travel_route_planner/models/trip.dart';
+import 'package:travel_route_planner/models/itinerary_item.dart';
+import 'package:travel_route_planner/providers/plan_provider.dart';
+import 'package:travel_route_planner/providers/trips_provider.dart';
+import 'package:travel_route_planner/services/api_client.dart';
+import 'package:travel_route_planner/services/plan_service.dart';
+import 'package:travel_route_planner/services/trips_api_service.dart';
+import 'package:travel_route_planner/screens/trip_detail_screen.dart';
+
+/// Returns a fixed trip without hitting the network, so we can exercise the
+/// real TripDetailScreen render path.
+class _FakeTripsApiService extends TripsApiService {
+  final Trip trip;
+  _FakeTripsApiService(this.trip) : super(ApiClient(baseUrl: 'http://test'));
+
+  @override
+  Future<Trip> getTrip(String id) async => trip;
+}
+
+/// Replays a canned event list; no network.
+class _ScriptedPlanService extends PlanService {
+  final List<PlanEvent> events;
+
+  _ScriptedPlanService(this.events) : super('http://unused');
+
+  @override
+  Stream<PlanEvent> streamPlan(
+    List<Map<String, String>> messages, {
+    String? bearerToken,
+    String? chatId,
+    String? tripId,
+    String? summary,
+  }) async* {
+    for (final e in events) {
+      yield e;
+    }
+  }
+}
+
+ItineraryItem _item(int pos, String name, {int? day, String? city}) =>
+    ItineraryItem(
+      id: 'i$pos',
+      position: pos,
+      name: name,
+      address: '$city, Colombia',
+      // Zero coords so the screen skips the map widget in the test env.
+      latitude: 0,
+      longitude: 0,
+      category: 'attraction',
+      day: day,
+      city: city,
+    );
+
+Trip _trip({String? access}) => Trip(
+      id: 't1',
+      title: 'Colombia Hop',
+      status: 'planned',
+      startDate: '2026-08-01',
+      endDate: '2026-08-05',
+      createdAt: '2026-07-01',
+      updatedAt: '2026-07-01',
+      access: access,
+      items: [
+        _item(0, 'Johnny Cay', day: 1, city: 'San Andrés'),
+        _item(1, 'Comuna 13', day: 3, city: 'Medellín'),
+      ],
+    );
+
+Widget _app(Trip trip) => ProviderScope(
+      overrides: [
+        tripsApiServiceProvider.overrideWithValue(_FakeTripsApiService(trip)),
+        tripRefineProvider.overrideWith((ref, tripId) => PlanNotifier(
+            _ScriptedPlanService(const []), ApiClient(),
+            tripId: tripId)),
+      ],
+      child: MaterialApp(home: TripDetailScreen(tripId: 't1')),
+    );
+
+PlanState _refineState(WidgetTester tester) =>
+    ProviderScope.containerOf(tester.element(find.byType(TripDetailScreen)))
+        .read(tripRefineProvider('t1'));
+
+void main() {
+  testWidgets('chat FAB opens the Trip assistant with a whole-trip seed',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(_app(_trip()));
+    await tester.pumpAndSettle();
+
+    final fab = find.byType(FloatingActionButton);
+    expect(fab, findsOneWidget);
+
+    await tester.tap(fab);
+    await tester.pumpAndSettle();
+
+    // Panel is open under the assistant framing; the FAB yields to it.
+    expect(find.text('Trip assistant'), findsWidgets);
+    expect(find.byType(FloatingActionButton), findsNothing);
+
+    // The seed is a single user message carrying the full itinerary and the
+    // question-friendly closing, bound for the trip-scoped session.
+    final messages = _refineState(tester).messages;
+    expect(messages, hasLength(1));
+    expect(messages.single.content, contains('Colombia Hop'));
+    expect(messages.single.content, contains('Johnny Cay'));
+    expect(messages.single.content, contains('Comuna 13'));
+    expect(messages.single.content, contains('also just ask questions'));
+  });
+
+  testWidgets('FAB is hidden for viewers', (WidgetTester tester) async {
+    await tester.pumpWidget(_app(_trip(access: 'viewer')));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(FloatingActionButton), findsNothing);
+  });
+
+  testWidgets('reopening via the FAB resumes the conversation, not a reset',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(_app(_trip()));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byType(FloatingActionButton));
+    await tester.pumpAndSettle();
+    final seeded = _refineState(tester).messages.length;
+    expect(seeded, greaterThan(0));
+
+    // Close the panel; the conversation lives on in the keepAlive provider.
+    await tester.tap(find.byTooltip('Close'));
+    await tester.pumpAndSettle();
+    expect(find.byType(FloatingActionButton), findsOneWidget);
+
+    // Reopen: same conversation, no fresh seed.
+    await tester.tap(find.byType(FloatingActionButton));
+    await tester.pumpAndSettle();
+    expect(find.text('Trip assistant'), findsWidgets);
+    expect(_refineState(tester).messages.length, seeded);
+  });
+}


### PR DESCRIPTION
## Summary
- Adds a chat FAB to the trip detail screen, visible wherever you've scrolled, so the AI is always one tap away (e.g. follow-up questions about flights from the booking checklist).
- The FAB opens the existing refine panel as a **Trip assistant**: whole-trip seed, question-friendly framing (`RefineTarget.assistant()`), same trip-bound session so it can still edit the itinerary or booking checklist on request.
- Reopening via the FAB **resumes** the in-progress conversation (the keepAlive `tripRefineProvider` already held it); section "Refine with AI" buttons keep their fresh-seed behavior.
- One-sentence addition to the trip-bound system prompt in `plan_handler.go` so the agent answers questions directly and only calls `update_itinerary_section` on an explicit edit request.
- FAB visibility mirrors the `_openRefine` guards (owner, online, non-empty trip) and hides while the panel is open.

## Testing
- `flutter analyze --no-fatal-infos --fatal-warnings` clean; full `flutter test` suite green (197 tests, 3 new in `trip_detail_chat_fab_test.dart`: FAB opens assistant with whole-trip seed, hidden for viewers, reopen resumes without reset).
- `go fmt` / `go vet` clean.
- Manual end-to-end in the dev stack via headless Chrome: FAB stays pinned while scrolled into the booking rows; asked a Medellín→San Andrés flight question → detailed answer with no trip edit; closed and reopened → conversation intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)