### PR TITLE
fix(flutter): number trip-map pins 1..N per view, not by trip-wide position

### DIFF
--- a/src/packages/flutter-app/lib/widgets/trip_map.dart
+++ b/src/packages/flutter-app/lib/widgets/trip_map.dart
@@ -355,7 +355,11 @@ class _TripMapState extends State<TripMap> {
                 size: const Size(32, 32),
                 padding: const EdgeInsets.all(40),
                 markers: [
-                  for (final m in mapped)
+                  // Labels count 1..N over what this map view shows (the whole
+                  // trip on All, one day on Day N) — not the item's trip-wide
+                  // position, which reads as arbitrary once the view filters
+                  // or skips ungeocoded items.
+                  for (final (k, m) in mapped.indexed)
                     Marker(
                       point: m.point,
                       width: widget.selectedPosition == m.item.position
@@ -365,7 +369,7 @@ class _TripMapState extends State<TripMap> {
                           ? 28
                           : 24,
                       child: _Pin(
-                        label: '${m.item.position + 1}',
+                        label: '${k + 1}',
                         category: m.item.category,
                         selected: widget.selectedPosition == m.item.position,
                         onTap: widget.onPinTap == null

--- a/src/packages/flutter-app/test/trip_map_test.dart
+++ b/src/packages/flutter-app/test/trip_map_test.dart
@@ -283,6 +283,23 @@ void main() {
     expect(dy, greaterThanOrEqualTo(48));
   });
 
+  testWidgets('pins number 1..N over the shown items, not trip-wide position',
+      (WidgetTester tester) async {
+    // A day-filtered (or partially geocoded) view hands the map items whose
+    // positions start mid-trip; the labels must still read 1, 2 in route
+    // order rather than exposing positions 5, 6 as "6", "7".
+    await tester.pumpWidget(_host(TripMap(items: [
+      _item(5, 'Louvre', 48.8606, 2.3376),
+      _item(6, 'Café de Flore', 48.8540, 2.3326),
+    ])));
+    await tester.pump();
+
+    expect(find.text('1'), findsOneWidget);
+    expect(find.text('2'), findsOneWidget);
+    expect(find.text('6'), findsNothing);
+    expect(find.text('7'), findsNothing);
+  });
+
   testWidgets('stays alone (no mapped items) still render a map',
       (WidgetTester tester) async {
     const stays = [


### PR DESCRIPTION
## Problem

On the trip map, the zoomed-out **All** view showed pins numbered **6, 7, 8, 9** for a four-stop route. Pin labels were hard-coded to `ItineraryItem.position + 1` (the item's absolute position in the full itinerary), so a trip whose geocoded stops sit mid-itinerary rendered arbitrary-looking numbers, and ungeocoded items left gaps in the sequence.

## Fix

Label each pin by its index within the set the map is currently showing (`mapped.indexed`), so numbers always read 1..N in route order and match the drawn polyline:

- **All view**: 1, 2, 3, 4 across the whole trip
- **Day view**: restarts at 1 ("stop 1 of the day")

Selection sizing, `onPinTap`, and segment-label lookups still key off `position` — only the displayed label changed. `shared_trip_screen` gets the fix for free since it feeds `TripMap` the same way.

## Tests

- New regression test: items at positions 5 and 6 must render pins "1" and "2", never "6"/"7".
- Full `flutter test` suite passes (199); `flutter analyze` clean apart from pre-existing deprecation infos in an unrelated file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)