### PR TITLE
fix(flutter): show the map for stays-only trips; render anonymous provider clicks

### DIFF
--- a/src/packages/flutter-app/lib/screens/admin_metrics_screen.dart
+++ b/src/packages/flutter-app/lib/screens/admin_metrics_screen.dart
@@ -303,6 +303,16 @@ class _MetricsBody extends StatelessWidget {
           const SizedBox(height: AppSpacing.lg),
           _ProviderClicks(clicks: m.clicksByProvider),
         ],
+        // Anonymous slice of the provider split (signed-out clicks — same
+        // discountable caveat as the caption above). Hidden when null (API
+        // predates the split) or empty, so old backends render unchanged.
+        if (m.clicksByProviderAnonymous?.isNotEmpty ?? false) ...[
+          const SizedBox(height: AppSpacing.lg),
+          _ProviderClicks(
+            clicks: m.clicksByProviderAnonymous!,
+            title: 'Anonymous clicks by provider',
+          ),
+        ],
         const SizedBox(height: AppSpacing.xl),
         const SectionHeader(title: 'AI planning'),
         const SizedBox(height: AppSpacing.sm),
@@ -446,7 +456,9 @@ class _TileGrid extends StatelessWidget {
 /// identity, so no categorical palette is needed.
 class _ProviderClicks extends StatelessWidget {
   final Map<String, int> clicks;
-  const _ProviderClicks({required this.clicks});
+  final String title;
+  const _ProviderClicks(
+      {required this.clicks, this.title = 'Clicks by provider'});
 
   @override
   Widget build(BuildContext context) {
@@ -458,7 +470,7 @@ class _ProviderClicks extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Text('Clicks by provider', style: theme.textTheme.labelLarge),
+        Text(title, style: theme.textTheme.labelLarge),
         const SizedBox(height: AppSpacing.sm),
         for (final e in entries)
           Padding(

--- a/src/packages/flutter-app/lib/screens/shared_trip_screen.dart
+++ b/src/packages/flutter-app/lib/screens/shared_trip_screen.dart
@@ -144,9 +144,13 @@ class _SharedTripBodyState extends ConsumerState<_SharedTripBody> {
     final trip = _trip;
     final items = trip.items ?? const <ItineraryItem>[];
     final dates = tripDateRange(trip.startDate, trip.endDate);
-    // The map-visibility gate stays keyed to the unfiltered items so the
-    // chip row never disappears when the selected day has nothing mappable.
-    final hasCoords = items.any((i) => i.latitude != 0 || i.longitude != 0);
+    final stays = trip.accommodations ?? const <Accommodation>[];
+    // The map-visibility gate stays keyed to the unfiltered items/stays so the
+    // chip row never disappears when the selected day has nothing mappable. A
+    // geocoded stay counts on its own: TripMap renders stay pins, so a
+    // stays-only trip still has a map worth showing.
+    final hasCoords = items.any((i) => i.latitude != 0 || i.longitude != 0) ||
+        stays.any(TripMap.stayHasCoords);
     final mapDayCount =
         dayCount(trip.startDate, trip.endDate, items.map((i) => i.day));
     if (_selectedDay != null && _selectedDay! > mapDayCount) {
@@ -155,7 +159,6 @@ class _SharedTripBodyState extends ConsumerState<_SharedTripBody> {
     final dayItems = _selectedDay == null
         ? items
         : items.where((i) => i.day == _selectedDay).toList();
-    final stays = trip.accommodations ?? const <Accommodation>[];
     // Under Day N, only the stay(s) covering that night (checkout-exclusive);
     // without a parseable start date no stay can match a day.
     final tripStart = DateTime.tryParse(trip.startDate ?? '');

--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -157,6 +157,17 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
         .toList();
   }
 
+  /// Map-visibility gate: a filtered item with coordinates OR a geocoded stay
+  /// (TripMap renders stay pins on its own, so a stays-only trip still has a
+  /// map worth showing). Keyed to the unfiltered stay list — like the items,
+  /// day filtering only narrows what's plotted, never whether the map shows.
+  /// Shared by the build and the pinned-chrome scroll math so the two can
+  /// never drift apart.
+  bool _mapShown(Trip trip) =>
+      _filtered(trip).any((i) => i.latitude != 0 || i.longitude != 0) ||
+      (trip.accommodations ?? const <Accommodation>[])
+          .any(TripMap.stayHasCoords);
+
   @override
   void initState() {
     super.initState();
@@ -314,11 +325,10 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
   static const double _listHeaderHeightEmpty = 48;
 
   /// Combined height of the chrome pinned above the itinerary slivers: the
-  /// map header (shown only when a filtered item is mappable — same gate as
-  /// the build) plus the itinerary title/filter header.
+  /// map header (shown when a filtered item or a stay is mappable — same
+  /// [_mapShown] gate as the build) plus the itinerary title/filter header.
   double _pinnedChrome(Trip trip) {
-    final mapShown =
-        _filtered(trip).any((i) => i.latitude != 0 || i.longitude != 0);
+    final mapShown = _mapShown(trip);
     final listH = (trip.items ?? const []).isNotEmpty
         ? _listHeaderHeight
         : _listHeaderHeightEmpty;
@@ -2660,8 +2670,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
                           ),
                           // The map scrolls with the page until it reaches the top,
                           // then stays pinned while the itinerary scrolls beneath it.
-                          if (_filtered(trip)
-                              .any((i) => i.latitude != 0 || i.longitude != 0))
+                          if (_mapShown(trip))
                             SliverPersistentHeader(
                               pinned: true,
                               delegate: _PinnedHeaderDelegate(

--- a/src/packages/flutter-app/lib/widgets/trip_map.dart
+++ b/src/packages/flutter-app/lib/widgets/trip_map.dart
@@ -58,6 +58,15 @@ class TripMap extends StatefulWidget {
     this.topOverlayInset = 0,
   });
 
+  /// Whether [a] would render as a stay pin: geocoded (null means "not
+  /// geocoded") and not the (0,0) junk sentinel. Public so screens can key
+  /// their map-visibility gates to the exact filter the renderer applies.
+  static bool stayHasCoords(Accommodation a) {
+    final lat = a.latitude;
+    final lng = a.longitude;
+    return lat != null && lng != null && (lat != 0 || lng != 0);
+  }
+
   @override
   State<TripMap> createState() => _TripMapState();
 }
@@ -137,10 +146,8 @@ class _TripMapState extends State<TripMap> {
         if (_hasCoords(it)) LatLng(it.latitude, it.longitude),
     ];
     for (final a in accommodations) {
-      final lat = a.latitude;
-      final lng = a.longitude;
-      if (lat != null && lng != null && (lat != 0 || lng != 0)) {
-        points.add(LatLng(lat, lng));
+      if (TripMap.stayHasCoords(a)) {
+        points.add(LatLng(a.latitude!, a.longitude!));
       }
     }
     return points;
@@ -206,10 +213,8 @@ class _TripMapState extends State<TripMap> {
     // Stays with real coordinates (null means "not geocoded"; 0,0 is junk).
     final stays = <({Accommodation stay, LatLng point})>[];
     for (final a in widget.accommodations) {
-      final lat = a.latitude;
-      final lng = a.longitude;
-      if (lat != null && lng != null && (lat != 0 || lng != 0)) {
-        stays.add((stay: a, point: LatLng(lat, lng)));
+      if (TripMap.stayHasCoords(a)) {
+        stays.add((stay: a, point: LatLng(a.latitude!, a.longitude!)));
       }
     }
 

--- a/src/packages/flutter-app/test/admin_metrics_screen_test.dart
+++ b/src/packages/flutter-app/test/admin_metrics_screen_test.dart
@@ -113,7 +113,10 @@ void main() {
     expect(
         find.text('1 users affected'), findsOneWidget); // active_trips cohort
     expect(find.text('Clicks by provider'), findsOneWidget);
-    expect(find.text('booking'), findsOneWidget);
+    // The anonymous provider split renders as its own bar list under the
+    // authenticated one, so 'booking' labels a row in each.
+    expect(find.text('Anonymous clicks by provider'), findsOneWidget);
+    expect(find.text('booking'), findsNWidgets(2));
     expect(find.text('Price alerts'), findsOneWidget);
 
     // Provider-call counters: honestly labeled as since-restart, with the
@@ -159,7 +162,39 @@ void main() {
     expect(find.text('Provider APIs (since restart)'), findsNothing);
     expect(find.text('Landing views'), findsNothing);
     expect(find.textContaining('anonymous, rate-limit bounded'), findsNothing);
+    expect(find.text('Anonymous clicks by provider'), findsNothing);
     expect(find.text('Price alerts'), findsOneWidget);
+  });
+
+  testWidgets('omits the anonymous provider split when the map is empty',
+      (tester) async {
+    tester.view.physicalSize = const Size(800, 3600);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+
+    // Present-but-empty (no anonymous clicks in the window) renders nothing —
+    // same as an API that predates the field.
+    const metrics = AdminMetrics(
+      days: 30,
+      signups: 1,
+      clicksByProvider: {'booking': 8},
+      clicksByProviderAnonymous: {},
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          adminMetricsProvider(30).overrideWith((ref) async => metrics),
+          adminTotalsProvider.overrideWith((ref) async => _totals),
+        ],
+        child: const MaterialApp(home: AdminMetricsScreen()),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Clicks by provider'), findsOneWidget);
+    expect(find.text('booking'), findsOneWidget);
+    expect(find.text('Anonymous clicks by provider'), findsNothing);
   });
 
   testWidgets('error state offers retry', (tester) async {

--- a/src/packages/flutter-app/test/stays_only_map_gate_test.dart
+++ b/src/packages/flutter-app/test/stays_only_map_gate_test.dart
@@ -1,0 +1,126 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:travel_route_planner/models/accommodation.dart';
+import 'package:travel_route_planner/models/itinerary_item.dart';
+import 'package:travel_route_planner/models/shared_trip.dart';
+import 'package:travel_route_planner/models/trip.dart';
+import 'package:travel_route_planner/providers/trips_provider.dart';
+import 'package:travel_route_planner/screens/shared_trip_screen.dart';
+import 'package:travel_route_planner/screens/trip_detail_screen.dart';
+import 'package:travel_route_planner/services/api_client.dart';
+import 'package:travel_route_planner/services/trips_api_service.dart';
+import 'package:travel_route_planner/widgets/trip_map.dart';
+
+// The map-visibility gate must count geocoded stays, not just items: a trip
+// whose only mapped things are its accommodations (hotels booked, no located
+// activities yet) still has a map worth showing — TripMap renders and
+// camera-fits stay pins on its own.
+
+class _FakeTripsApiService extends TripsApiService {
+  final Trip? trip;
+  final SharedTrip? shared;
+  _FakeTripsApiService({this.trip, this.shared})
+      : super(ApiClient(baseUrl: 'http://test'));
+
+  @override
+  Future<Trip> getTrip(String id) async => trip!;
+
+  @override
+  Future<SharedTrip> getSharedTrip(String token) async => shared!;
+}
+
+Trip _trip({List<ItineraryItem>? items, List<Accommodation>? stays}) => Trip(
+      id: 't1',
+      title: 'Lisbon long weekend',
+      status: 'planned',
+      createdAt: '2026-06-01',
+      updatedAt: '2026-06-01',
+      items: items ?? const [],
+      accommodations: stays,
+    );
+
+const _geocodedStay = Accommodation(
+  id: 'a1',
+  name: 'Alfama Guesthouse',
+  latitude: 38.7139,
+  longitude: -9.1334,
+);
+
+// null coordinates = "not geocoded"; must not count toward the gate.
+const _ungeocodedStay = Accommodation(id: 'a2', name: 'Mystery Hotel');
+
+// (0,0) is the "no location" sentinel for items.
+ItineraryItem _unmappedItem(int pos) => ItineraryItem(
+      id: 'i$pos',
+      position: pos,
+      name: 'Stop $pos',
+      latitude: 0,
+      longitude: 0,
+      category: 'attraction',
+    );
+
+Future<void> _pumpTripDetail(WidgetTester tester, Trip trip) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        tripsApiServiceProvider
+            .overrideWithValue(_FakeTripsApiService(trip: trip)),
+      ],
+      child: const MaterialApp(home: TripDetailScreen(tripId: 't1')),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+Future<void> _pumpSharedTrip(WidgetTester tester, Trip trip) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        tripsApiServiceProvider.overrideWithValue(_FakeTripsApiService(
+            shared: SharedTrip(trip: trip, ownerName: 'Ann'))),
+      ],
+      child: const MaterialApp(home: SharedTripScreen(token: 'tok')),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  testWidgets('trip detail shows the map for a stays-only trip',
+      (tester) async {
+    await _pumpTripDetail(tester, _trip(stays: const [_geocodedStay]));
+    expect(find.byType(TripMap), findsOneWidget);
+  });
+
+  testWidgets('trip detail hides the map when nothing has coordinates',
+      (tester) async {
+    await _pumpTripDetail(
+      tester,
+      _trip(
+        items: [_unmappedItem(0), _unmappedItem(1)],
+        stays: const [_ungeocodedStay],
+      ),
+    );
+    expect(find.byType(TripMap), findsNothing);
+  });
+
+  testWidgets('shared trip shows the map for a stays-only trip',
+      (tester) async {
+    await _pumpSharedTrip(tester, _trip(stays: const [_geocodedStay]));
+    expect(find.byType(TripMap), findsOneWidget);
+  });
+
+  testWidgets('shared trip hides the map when nothing has coordinates',
+      (tester) async {
+    await _pumpSharedTrip(
+      tester,
+      _trip(
+        items: [_unmappedItem(0), _unmappedItem(1)],
+        stays: const [_ungeocodedStay],
+      ),
+    );
+    expect(find.byType(TripMap), findsNothing);
+  });
+}


### PR DESCRIPTION
## Summary

Two small verified gaps in the Flutter app (Wave 12 PR 3):

### 1. Stays-only map visibility gate

Both trip screens showed the trip map only when itinerary **items** had coordinates, so a trip whose only mapped things are its accommodations (hotels booked, no located activities yet) hid a map that already renders and camera-fits stay pins (TripMap handles them since #91).

- `lib/widgets/trip_map.dart` — TripMap's stay filter (`lat != null && lng != null && !(0,0)`) is now a public `TripMap.stayHasCoords`, used by both internal sites (fit-points assembly and marker loop), so gates and renderer share the exact same predicate.
- `lib/screens/trip_detail_screen.dart` — new `_mapShown(Trip)` helper (filtered items with coords **OR** any geocoded stay) replaces the duplicated gate in the build's `SliverPersistentHeader` condition and `_pinnedChrome`'s scroll math, so the two can never drift.
- `lib/screens/shared_trip_screen.dart` — `hasCoords` now ORs `stays.any(TripMap.stayHasCoords)`; keyed to the unfiltered stay list (like the items) so the day-chip row never disappears when a selected day has nothing mappable.

Note: the task brief listed a 4th gate site at trip_detail_screen.dart:470, but on reading it that is `_computeTravelTimes`' "≥2 routed items" gate — accommodations are never sent to the route optimizer, so it was deliberately left unchanged.

### 2. Render `clicks_by_provider_anonymous`

Modeled in `admin_metrics.dart` and emitted by the API since #92, but never rendered. The Overview tab now shows a second `_ProviderClicks` bar list titled "Anonymous clicks by provider" beneath the authenticated one, hidden when the field is null (old API — #79 nullable pattern) **or** empty.

## Tests

- New `test/stays_only_map_gate_test.dart`: a stays-only trip (no located items, one geocoded accommodation) renders TripMap on **both** trip detail and shared trip; a trip with (0,0) items and an ungeocoded stay still hides the map on both.
- Extended `test/admin_metrics_screen_test.dart`: anonymous provider split renders under the caption when populated (and `booking` now labels a row in each list); absent when the field is null (old-API test) or present-but-empty (new test).

## Verification

- `flutter test` — 203/203 pass
- `flutter analyze --no-fatal-infos --fatal-warnings` — exit 0 (12 pre-existing infos, none in touched files, none added)

🤖 Generated with [Claude Code](https://claude.com/claude-code)