### PR TITLE
feat(flutter): "Happening now" live-trip card

### DIFF
--- a/specs/happening-now/plan.md
+++ b/specs/happening-now/plan.md
@@ -1,0 +1,103 @@
+# Plan: Happening Now
+
+> **HOW.** See `spec.md`. Flutter-only; no Go, endpoint, model-codegen, or env
+> changes (API Surface: none). Ships in two PRs: (1) the Happening now card on
+> the trips list and home screen, (2) the Tonight caption in the trip detail's
+> today section.
+
+## Technical Approach
+
+Everything derives from data the app already holds. The decisions, and why:
+
+1. **Liveness reuses `tripDayOn` (`lib/utils/trip_days.dart`).** "Live" is
+   defined as `tripDayOn(startDate, endDate, now) != null` — the exact
+   predicate today-mode uses to auto-scroll, so the card and the destination
+   screen can never disagree about whether a trip is "on". End-day inclusive
+   and open-ended (null end) semantics come for free.
+2. **Pure selector + thin provider.** `liveTripOf(List<Trip>, DateTime)` is a
+   pure function (unit-testable without Riverpod); `liveTripProvider` is a
+   plain `Provider<Trip?>` deriving from `tripsProvider` via a **narrow
+   select on its trips list** (chat-panel invariant: never watch the whole
+   state — loading flips must not rebuild the card). Latest-startDate wins;
+   list order breaks ties.
+3. **No fetch from home.** AppShell's `IndexedStack` mounts `TripsListScreen`
+   eagerly, whose `initState` `loadTrips()` populates `tripsProvider`
+   app-wide — home only watches. Offline works because `tripsProvider`
+   already falls back to `TripCache`.
+4. **Build-time "now".** Liveness is sampled when the provider (re)computes —
+   on every trips-list (re)load — matching today-mode's build-time "today".
+   No midnight timer (documented limitation in spec.md).
+5. **Card = gradient sibling of `_RecentTripCard`.** Same
+   `AppColors.brandGradient` + shadow + `InkWell` conventions
+   (home_screen.dart), with a white-tinted `StatusPill.custom` "Live" pill —
+   top-priority visual object on both surfaces.
+6. **Tonight caption (PR 2) reuses `stayCoversDate`.** Checkout-exclusive
+   (`checkIn <= today < checkOut`), the same helper the map's day filter
+   uses. Rendered as the first content row of today's day section (non-
+   pinned, scrolls with items) in `trip_detail_screen.dart`; when the day is
+   split across city groups, only the first group containing today renders
+   it; a stay with an empty name is skipped.
+
+## Go API Changes
+
+None.
+
+## Flutter Changes
+
+`src/packages/flutter-app/`:
+
+### PR 1 — Happening now card
+
+- **`lib/providers/live_trip_provider.dart`** (new): `liveTripOf(trips, now)`
+  pure function + `liveTripProvider` (`Provider<Trip?>` over
+  `tripsProvider.select((s) => s.trips)`).
+- **`lib/widgets/live_trip_card.dart`** (new):
+  `LiveTripCard({required Trip trip, required VoidCallback onTap})` —
+  eyebrow "HAPPENING NOW", title `citiesLabel(trip.cities) ?? trip.title`,
+  white "Live" `StatusPill.custom`, "Day N of M" via `tripDayOn` +
+  `dayCount` (M omitted when `dayCount` is 0, i.e. no end date; the list
+  payload has no items, so `itemDays` is empty).
+- **`lib/utils/trip_format.dart`**: `citiesLabel(List<String>?)` — moved
+  from `trips_list_screen.dart`'s private `_locationLabel` so the card and
+  the trip card share one formatter (behavior-neutral refactor).
+- **`lib/screens/trips_list_screen.dart`**: render `LiveTripCard` as the
+  first `ListView` child (above the resumable-chats section); tap →
+  existing `_openTrip`. The trip stays in "My Trips".
+- **`lib/screens/home_screen.dart`**: watch `liveTripProvider`; render the
+  card in the recent-trip slot, with `_RecentTripCard` below it only when
+  `recentTrip.tripId != liveTrip.id`. No `loadTrips()` call from home.
+
+### PR 2 — Tonight caption
+
+- **`lib/screens/trip_detail_screen.dart`**: in the day-section builder,
+  when `day == todayDay` and this is the first group containing that day,
+  prepend a caption row "Tonight: <name>" for the accommodation matching
+  `stayCoversDate(checkIn, checkOut, DateTime.now())`; skip when no match
+  or the name is empty.
+
+## Contract Parity  ← anti-drift gate
+
+No request/response pair changes — nothing to reconcile.
+
+| JSON key | Go type | Dart type | Nullable? | ✓ |
+|----------|---------|-----------|-----------|---|
+| — (no API changes) | — | — | — | ☑ |
+
+## Cross-cutting
+
+- **Env vars:** none.
+- **Gateway:** no new paths.
+
+## Verification
+
+- `make flutter-analyze` clean; `make flutter-test` green.
+- `test/live_trip_provider_test.dart`: none/one/two live, latest-startDate
+  win, list-order tiebreak, undated skipped, ends-today live,
+  ended-yesterday / starts-tomorrow not live.
+- `test/trips_list_live_test.dart`: card above the continue section and
+  "My Trips"; "Day N of M" + "Live"; tap pushes `TripDetailScreen`; absent
+  when nothing is live; still renders from the offline cache.
+- Home widget test: live card shown; recent tile hidden when it is the live
+  trip, shown when different.
+- Manual: `make docker-dev`, sign in with a trip spanning today → home and
+  trips list lead with the card; tap lands on today's section.

--- a/specs/happening-now/spec.md
+++ b/specs/happening-now/spec.md
@@ -1,0 +1,133 @@
+# Spec: Happening Now
+
+## Context
+
+Today-mode (specs/today-mode) made the *trip detail screen* live-trip aware —
+but the user still has to find and open the trip themselves. Mid-trip, the app
+should meet them at the front door: the home screen and the trips list should
+surface "the trip you are on right now" as the single most prominent object,
+one tap from today's plan. And once inside, the day being lived deserves one
+more piece of glanceable context: where you're sleeping tonight. This spec
+covers both: the **Happening now card** (PR 1) and the **Tonight caption**
+inside today's day section (PR 2).
+
+## User Stories
+
+- As a **traveler mid-trip**, I want the app's home screen and trips list to
+  lead with the trip I'm on so that today's plan is one tap away, not a search.
+- As a **traveler mid-trip**, I want that card to tell me where I am in the
+  trip ("Day 3 of 7") so that I get my bearings at a glance.
+- As a **traveler mid-trip**, I want today's section of the itinerary to name
+  tonight's accommodation so that "where am I sleeping?" never needs scrolling
+  to a different section.
+
+## Acceptance Criteria
+
+### Liveness (shared by both PRs)
+
+- [ ] A trip is **live** when the device's local calendar date falls inside
+      its date range — start day and end day inclusive (same rule that drives
+      today-mode's auto-scroll: today's trip-day exists). A trip with a start
+      date but no end date is live from its start day onward.
+- [ ] Undated trips and trips with unparseable dates are never live.
+- [ ] Trip status (draft/planned) plays no part — a draft you're on is live.
+- [ ] When several owned trips are live at once, the one with the **latest
+      start date** wins; trips sharing a start date tie-break by their order
+      in the trips list. Exactly one card is ever shown.
+- [ ] Only **owned** trips are considered; trips shared *with* the user never
+      produce a card.
+
+### Happening now card (PR 1)
+
+- [ ] **Trips list:** when a live trip exists, a promoted card renders at the
+      very top of the list — above "Continue where you left off" and above
+      "My Trips". The live trip still appears in "My Trips" below (the card
+      is a shortcut, not a filter).
+- [ ] **Home screen:** the same card renders in the recent-trip slot. When
+      the most-recently-viewed trip *is* the live trip, only the live card
+      shows; when they differ, the recent-trip tile renders below it.
+- [ ] The card reads: a "HAPPENING NOW" eyebrow, the trip's destination
+      summary (its cities, falling back to the title), a "Live" pill, and
+      "Day N of M" ("Day N" alone when the trip has no end date). It carries
+      the brand-gradient emphasis treatment so it reads as the top-priority
+      object on both surfaces.
+- [ ] Tapping the card opens the trip detail screen, which (per today-mode)
+      auto-scrolls to today's day section.
+- [ ] With no live trip, both surfaces render exactly as before.
+- [ ] The trips-list card still appears when the list is served from the
+      offline cache.
+
+### Tonight caption (PR 2)
+
+- [ ] Inside a live trip's detail screen, today's day section shows a
+      **"Tonight: <stay name>"** caption as the **first content row** of the
+      section — under the day header, above today's first item. It scrolls
+      with the content (never pinned).
+- [ ] Tonight's stay is the accommodation covering **tonight** checkout-
+      exclusively: check-in ≤ today < check-out. A stay never claims its own
+      checkout night.
+- [ ] When today's day is rendered in more than one city group, the caption
+      appears only in the **first** group containing it — never duplicated.
+- [ ] A covering stay with an empty name is skipped (no "Tonight:" with
+      nothing after it); with no covering stay, no caption renders at all.
+- [ ] Non-live trips, shared read-only views, and days other than today never
+      show the caption.
+
+## API Surface
+
+None. Everything derives client-side from data the app already receives. The
+trips-*list* payload intentionally carries no itinerary items or
+accommodations, which is why the card shows trip-level facts only.
+
+## Data Model
+
+No persisted entities change. Client-side derived concepts:
+
+- **Live trip** — the single owned trip whose date range contains the device's
+  local date today, chosen by latest start date (then list order) among
+  candidates.
+- **Trip progress** — "Day N of M": N is today's 1-based trip day, M the date
+  span in days; M is unknown (omitted) for open-ended trips.
+- **Tonight's stay** — the accommodation whose check-in/check-out window
+  covers tonight, checkout-exclusively (same rule as today-mode's map stays).
+
+## UI Behavior
+
+- **Surfaces:** trips list (top of list), home screen (recent-trip slot), and
+  — for PR 2 — the trip detail itinerary's today section.
+- **Happy path:** traveler opens the app mid-trip → home leads with
+  "HAPPENING NOW · Paris & Lyon · Live · Day 3 of 7" → tap → trip detail
+  auto-scrolls to Day 3, whose first row reads "Tonight: Hôtel du Petit
+  Moulin" → the whole question "what am I doing today and where am I
+  sleeping?" is answered without a single scroll.
+- **States:** no live trip → surfaces unchanged; offline → card still derived
+  from the cached trips list; open-ended trip → "Day N" without a total.
+
+## Edge Cases & Error States
+
+- **Midnight rollover:** liveness and "Day N" are computed when the surfaces
+  build (list load/refresh), consistent with today-mode's build-time "today".
+  A trip that goes live at midnight appears on the next refresh — the app
+  does not spontaneously re-render at 00:00.
+- **Timezones:** "today" is the device's local calendar date; trip dates are
+  date-only strings read as local dates. Same convention as today-mode.
+- Trip ends today → still live (end-day inclusive); ended yesterday or
+  starting tomorrow → not live.
+- Trip with cities data shows the cities summary; legacy trips without it
+  fall back to the title.
+- Back-to-back stays tonight (A checks out today, B checks in today) →
+  checkout-exclusivity means only B covers tonight.
+
+## Out of Scope
+
+- Any Go API or payload change (including adding items/accommodations to the
+  trips-list response).
+- Per-trip city-of-the-day or stay details **on the card** — the list payload
+  has no items/accommodations, and the card stays trip-level by design.
+- Trips shared with the user (sharedWithMe) as live-card candidates.
+- Live re-rendering at midnight (timer-driven recompute).
+- Notifications/reminders about the live trip.
+
+## Open Questions
+
+None.

--- a/src/packages/flutter-app/lib/providers/live_trip_provider.dart
+++ b/src/packages/flutter-app/lib/providers/live_trip_provider.dart
@@ -1,0 +1,39 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../models/trip.dart';
+import '../utils/trip_days.dart';
+import 'trips_provider.dart';
+
+/// The trip from [trips] that is happening on [now]'s device-local calendar
+/// date, or null when none is. Liveness reuses [tripDayOn] (specs/today-mode):
+/// dated, start <= today <= end (end-day inclusive; a missing end date means
+/// the trip never ends once started). No status filter — a draft you're on is
+/// still the trip you're on.
+///
+/// When several trips are live at once, the one that started most recently
+/// wins (it's the leg you're actually living); trips with the same start date
+/// tie-break by list order.
+Trip? liveTripOf(List<Trip> trips, DateTime now) {
+  Trip? best;
+  DateTime? bestStart;
+  for (final t in trips) {
+    if (tripDayOn(t.startDate, t.endDate, now) == null) continue;
+    // tripDayOn != null guarantees startDate parses.
+    final start = DateTime.parse(t.startDate!);
+    if (bestStart == null || start.isAfter(bestStart)) {
+      best = t;
+      bestStart = start;
+    }
+  }
+  return best;
+}
+
+/// The user's currently-live trip for the "Happening now" card
+/// (specs/happening-now), derived from the owned-trips list. Owned trips only:
+/// tripsProvider never includes shared-with-me trips. Recomputed whenever the
+/// trips list is (re)loaded — like today-mode, "now" is sampled at build time,
+/// so a trip going live at midnight shows up on the next list refresh, not
+/// spontaneously.
+final liveTripProvider = Provider<Trip?>((ref) {
+  final trips = ref.watch(tripsProvider.select((s) => s.trips));
+  return liveTripOf(trips, DateTime.now());
+});

--- a/src/packages/flutter-app/lib/screens/home_screen.dart
+++ b/src/packages/flutter-app/lib/screens/home_screen.dart
@@ -4,6 +4,7 @@ import 'package:material_design_icons_flutter/material_design_icons_flutter.dart
 import '../constants/app_info.dart';
 import '../models/local_guide.dart';
 import '../providers/auth_provider.dart';
+import '../providers/live_trip_provider.dart';
 import '../providers/local_provider.dart';
 import '../providers/plan_provider.dart';
 import '../providers/recent_trip_provider.dart';
@@ -14,6 +15,7 @@ import '../theme/spacing.dart';
 import '../widgets/account_menu.dart';
 import '../widgets/brand_logo.dart';
 import '../widgets/gradient_app_bar.dart';
+import '../widgets/live_trip_card.dart';
 import '../widgets/page_container.dart';
 import '../widgets/section_header.dart';
 import 'route_optimizer_screen.dart';
@@ -39,6 +41,9 @@ class HomeScreen extends ConsumerWidget {
     final theme = Theme.of(context);
     final user = ref.watch(authProvider).user;
     final recentTrip = ref.watch(recentTripProvider);
+    // Populated app-wide: AppShell's IndexedStack keeps TripsListScreen
+    // mounted, and its loadTrips() feeds tripsProvider — no fetch from here.
+    final liveTrip = ref.watch(liveTripProvider);
 
     // The chat is a persistent tab, so "Let's go" / a suggestion switches to it
     // (and seeds the message) rather than pushing a one-off screen.
@@ -98,8 +103,22 @@ class HomeScreen extends ConsumerWidget {
 
                 const SizedBox(height: 28),
 
-                // Most recently viewed trip — hidden until one has been opened.
-                if (recentTrip != null) ...[
+                // The trip happening today (specs/happening-now), then the
+                // most recently viewed trip — the latter hidden when it *is*
+                // the live trip, so the same trip never stacks twice.
+                if (liveTrip != null) ...[
+                  LiveTripCard(
+                    trip: liveTrip,
+                    onTap: () => Navigator.of(context).push(
+                      MaterialPageRoute(
+                        builder: (_) => TripDetailScreen(tripId: liveTrip.id),
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: 16),
+                ],
+                if (recentTrip != null &&
+                    recentTrip.tripId != liveTrip?.id) ...[
                   _RecentTripCard(
                     title: recentTrip.title,
                     dateRange: recentTrip.dateRange,

--- a/src/packages/flutter-app/lib/screens/trips_list_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trips_list_screen.dart
@@ -6,12 +6,14 @@ import '../utils/trip_format.dart';
 import '../widgets/account_menu.dart';
 import '../widgets/empty_state.dart';
 import '../widgets/gradient_app_bar.dart';
+import '../widgets/live_trip_card.dart';
 import '../widgets/offline_banner.dart';
 import '../widgets/status_pill.dart';
 import '../models/chat_session.dart';
 import '../models/plan_message.dart';
 import '../models/trip.dart';
 import '../providers/auth_provider.dart';
+import '../providers/live_trip_provider.dart';
 import '../providers/plan_provider.dart';
 import '../providers/resumable_chats_provider.dart';
 import '../providers/shared_with_me_provider.dart';
@@ -82,6 +84,7 @@ class _TripsListScreenState extends ConsumerState<TripsListScreen> {
       final isAdmin = ref.watch(authProvider).user?.isAdmin ?? false;
       final shared =
           ref.watch(sharedWithMeProvider).valueOrNull ?? const <Trip>[];
+      final liveTrip = ref.watch(liveTripProvider);
       body = RefreshIndicator(
         onRefresh: () async {
           ref.invalidate(sharedWithMeProvider);
@@ -91,6 +94,17 @@ class _TripsListScreenState extends ConsumerState<TripsListScreen> {
         child: ListView(
           padding: const EdgeInsets.all(AppSpacing.md),
           children: [
+            // The trip happening today, promoted to the very top as a
+            // one-tap shortcut (specs/happening-now). It also stays in
+            // "My Trips" below — this is a spotlight, not a filter.
+            if (liveTrip != null)
+              Padding(
+                padding: const EdgeInsets.only(bottom: AppSpacing.lg),
+                child: LiveTripCard(
+                  trip: liveTrip,
+                  onTap: () => _openTrip(context, liveTrip.id),
+                ),
+              ),
             // In-progress AI conversations that haven't produced a trip yet
             // (specs/continue-where-you-left-off) — the discussion phase,
             // above the trips they may become.
@@ -238,17 +252,6 @@ class _ContinueChatCard extends ConsumerWidget {
   }
 }
 
-/// A short destination summary from the trip's hub cities: "Paris",
-/// "Mexico City & Puerto Vallarta", or "Tokyo & Kyoto +2 more". Null when the
-/// trip has no city data (legacy trips), so the caller falls back to the title.
-String? _locationLabel(Trip t) {
-  final cities = t.cities ?? const <String>[];
-  if (cities.isEmpty) return null;
-  if (cities.length == 1) return cities.first;
-  if (cities.length == 2) return '${cities[0]} & ${cities[1]}';
-  return '${cities[0]} & ${cities[1]} +${cities.length - 2} more';
-}
-
 void _openTrip(BuildContext context, String tripId) {
   Navigator.of(context).push(
     MaterialPageRoute(builder: (_) => TripDetailScreen(tripId: tripId)),
@@ -270,7 +273,7 @@ class _TripCard extends ConsumerWidget {
     final range = tripDateRange(trip.startDate, trip.endDate);
 
     final title = Text(
-      _locationLabel(trip) ?? trip.title,
+      citiesLabel(trip.cities) ?? trip.title,
       maxLines: 1,
       overflow: TextOverflow.ellipsis,
       style: Theme.of(context)

--- a/src/packages/flutter-app/lib/utils/trip_format.dart
+++ b/src/packages/flutter-app/lib/utils/trip_format.dart
@@ -18,6 +18,17 @@ String? tripDateRange(String? startIso, String? endIso) {
   return sameDay ? _fmt(a) : '${_fmt(a)} – ${_fmt(b)}';
 }
 
+/// A short destination summary from a trip's hub cities: "Paris",
+/// "Mexico City & Puerto Vallarta", or "Tokyo & Kyoto +2 more". Null when
+/// there is no city data (legacy trips), so callers fall back to the title.
+String? citiesLabel(List<String>? cities) {
+  final c = cities ?? const <String>[];
+  if (c.isEmpty) return null;
+  if (c.length == 1) return c.first;
+  if (c.length == 2) return '${c[0]} & ${c[1]}';
+  return '${c[0]} & ${c[1]} +${c.length - 2} more';
+}
+
 /// "YYYY-MM-DD" from an ISO timestamp, falling back to the raw value.
 String shortDate(String iso) {
   final d = DateTime.tryParse(iso);

--- a/src/packages/flutter-app/lib/widgets/live_trip_card.dart
+++ b/src/packages/flutter-app/lib/widgets/live_trip_card.dart
@@ -1,0 +1,124 @@
+import 'package:flutter/material.dart';
+import '../models/trip.dart';
+import '../theme/app_colors.dart';
+import '../theme/spacing.dart';
+import '../utils/trip_days.dart';
+import '../utils/trip_format.dart';
+import 'status_pill.dart';
+
+/// Promoted shortcut into the trip that is happening right now
+/// (specs/happening-now). Same brand-gradient treatment as the home screen's
+/// recent-trip tile, so it reads as the top-priority object wherever it sits;
+/// shown above everything else on the trips list and in the recent-trip slot
+/// on home. Tap goes straight to the trip detail, which auto-scrolls to today.
+class LiveTripCard extends StatelessWidget {
+  final Trip trip;
+  final VoidCallback onTap;
+
+  const LiveTripCard({super.key, required this.trip, required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    // Where the trip stands today: "Day N of M", or just "Day N" for an
+    // open-ended trip (no end date => day count 0). The trips-list payload
+    // carries no items, so the count comes from the date span alone.
+    final day = tripDayOn(trip.startDate, trip.endDate, DateTime.now());
+    final total = dayCount(trip.startDate, trip.endDate, const <int?>[]);
+    final progress =
+        day == null ? null : (total > 0 ? 'Day $day of $total' : 'Day $day');
+
+    return Container(
+      decoration: BoxDecoration(
+        borderRadius: AppRadius.mdAll,
+        gradient: AppColors.brandGradient,
+        boxShadow: [
+          BoxShadow(
+            color: AppColors.brandDark.withValues(alpha: 0.3),
+            blurRadius: 10,
+            offset: const Offset(0, 4),
+          ),
+        ],
+      ),
+      child: Material(
+        color: Colors.transparent,
+        child: InkWell(
+          onTap: onTap,
+          borderRadius: AppRadius.mdAll,
+          child: Padding(
+            padding: const EdgeInsets.all(AppSpacing.lg),
+            child: Row(
+              children: [
+                Container(
+                  padding: const EdgeInsets.all(AppSpacing.sm + 2),
+                  decoration: BoxDecoration(
+                    color: Colors.white.withValues(alpha: 0.15),
+                    shape: BoxShape.circle,
+                  ),
+                  child:
+                      const Icon(Icons.near_me, color: Colors.white, size: 26),
+                ),
+                const SizedBox(width: AppSpacing.lg),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        'HAPPENING NOW',
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: theme.textTheme.labelSmall?.copyWith(
+                          color: Colors.white70,
+                          letterSpacing: 1.2,
+                        ),
+                      ),
+                      const SizedBox(height: 2),
+                      Text(
+                        citiesLabel(trip.cities) ?? trip.title,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: theme.textTheme.titleMedium?.copyWith(
+                          fontWeight: FontWeight.bold,
+                          color: Colors.white,
+                        ),
+                      ),
+                      const SizedBox(height: AppSpacing.xs),
+                      Row(
+                        children: [
+                          // White-tinted pill so it sits on the gradient like
+                          // the rest of the card, not like the light-surface
+                          // StatusPill used on the trips list.
+                          StatusPill.custom(
+                            label: 'Live',
+                            background: Colors.white.withValues(alpha: 0.22),
+                            foreground: Colors.white,
+                          ),
+                          if (progress != null) ...[
+                            const SizedBox(width: AppSpacing.sm),
+                            Flexible(
+                              child: Text(
+                                progress,
+                                maxLines: 1,
+                                overflow: TextOverflow.ellipsis,
+                                style: theme.textTheme.bodySmall?.copyWith(
+                                  color: Colors.white.withValues(alpha: 0.85),
+                                ),
+                              ),
+                            ),
+                          ],
+                        ],
+                      ),
+                    ],
+                  ),
+                ),
+                const Icon(Icons.arrow_forward_ios,
+                    size: 16, color: Colors.white70),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/src/packages/flutter-app/test/home_live_trip_test.dart
+++ b/src/packages/flutter-app/test/home_live_trip_test.dart
@@ -1,0 +1,141 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:travel_route_planner/models/trip.dart';
+import 'package:travel_route_planner/models/user.dart';
+import 'package:travel_route_planner/providers/auth_provider.dart';
+import 'package:travel_route_planner/providers/live_trip_provider.dart';
+import 'package:travel_route_planner/screens/home_screen.dart';
+import 'package:travel_route_planner/widgets/live_trip_card.dart';
+
+/// Home-screen slotting of the "Happening now" card (specs/happening-now):
+/// the live card takes the recent-trip slot, and the recent-trip tile only
+/// renders below it when it points at a *different* trip.
+class _FakeAuthNotifier extends StateNotifier<AuthState>
+    implements AuthNotifier {
+  _FakeAuthNotifier(UserModel? user)
+      : super(AuthState(user: user, initialized: true));
+
+  @override
+  Future<bool> login(String email, String password) async => false;
+
+  @override
+  Future<bool> register(String email, String password,
+          {String? displayName}) async =>
+      false;
+
+  @override
+  Future<void> completeOnboarding() async {}
+
+  @override
+  Future<void> logout() async {}
+
+  @override
+  Future<void> signOutLocally() async {}
+
+  @override
+  void setUser(UserModel user) {}
+
+  @override
+  Future<void> adoptSession(String token, UserModel user) async {}
+}
+
+UserModel _user() => UserModel(
+      id: 'user-1',
+      email: 'test@example.com',
+      displayName: 'Brian',
+      createdAt: DateTime(2026, 1, 1),
+    );
+
+String _iso(DateTime d) =>
+    '${d.year.toString().padLeft(4, '0')}-'
+    '${d.month.toString().padLeft(2, '0')}-'
+    '${d.day.toString().padLeft(2, '0')}';
+
+Trip _liveTrip(String id) => Trip(
+      id: id,
+      title: 'Athens Trip',
+      status: 'planned',
+      startDate: _iso(DateTime.now().subtract(const Duration(days: 1))),
+      endDate: _iso(DateTime.now().add(const Duration(days: 1))),
+      createdAt: '2026-06-01',
+      updatedAt: '2026-06-01',
+    );
+
+/// Seeds the persisted recent-trip snapshot the way the detail screen would
+/// have recorded it (recent_trip_provider storage format, keyed by user).
+void _seedRecentTrip(String tripId, String title) {
+  SharedPreferences.setMockInitialValues({
+    'recent_trip.user-1': jsonEncode({
+      'id': tripId,
+      'title': title,
+      'status': 'planned',
+    }),
+  });
+}
+
+Future<void> _pumpHome(WidgetTester tester, Trip? liveTrip) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        authProvider.overrideWith((ref) => _FakeAuthNotifier(_user())),
+        liveTripProvider.overrideWithValue(liveTrip),
+      ],
+      child: const MaterialApp(home: HomeScreen()),
+    ),
+  );
+  // Extra pumps flush the SharedPreferences read behind recentTripProvider.
+  await tester.pump();
+  await tester.pump();
+}
+
+void main() {
+  testWidgets('live card shows in the recent-trip slot',
+      (WidgetTester tester) async {
+    SharedPreferences.setMockInitialValues({});
+    await _pumpHome(tester, _liveTrip('t1'));
+
+    expect(find.byType(LiveTripCard), findsOneWidget);
+    expect(find.text('HAPPENING NOW'), findsOneWidget);
+    expect(find.text('Day 2 of 3'), findsOneWidget);
+  });
+
+  testWidgets('recent-trip tile hides when it is the live trip',
+      (WidgetTester tester) async {
+    _seedRecentTrip('t1', 'Athens Trip');
+    await _pumpHome(tester, _liveTrip('t1'));
+
+    expect(find.byType(LiveTripCard), findsOneWidget);
+    expect(find.text('PICK UP WHERE YOU LEFT OFF'), findsNothing);
+  });
+
+  testWidgets('both cards show when the recent trip is a different trip',
+      (WidgetTester tester) async {
+    _seedRecentTrip('t2', 'Lisbon Trip');
+    await _pumpHome(tester, _liveTrip('t1'));
+
+    expect(find.byType(LiveTripCard), findsOneWidget);
+    expect(find.text('PICK UP WHERE YOU LEFT OFF'), findsOneWidget);
+    expect(find.text('Lisbon Trip'), findsOneWidget);
+
+    // The live card leads the slot; the recent tile sits below it.
+    expect(
+      tester.getTopLeft(find.byType(LiveTripCard)).dy,
+      lessThan(
+          tester.getTopLeft(find.text('PICK UP WHERE YOU LEFT OFF')).dy),
+    );
+  });
+
+  testWidgets('no live trip leaves the recent-trip tile alone',
+      (WidgetTester tester) async {
+    _seedRecentTrip('t2', 'Lisbon Trip');
+    await _pumpHome(tester, null);
+
+    expect(find.byType(LiveTripCard), findsNothing);
+    expect(find.text('PICK UP WHERE YOU LEFT OFF'), findsOneWidget);
+  });
+}

--- a/src/packages/flutter-app/test/live_trip_provider_test.dart
+++ b/src/packages/flutter-app/test/live_trip_provider_test.dart
@@ -1,0 +1,81 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:travel_route_planner/models/trip.dart';
+import 'package:travel_route_planner/providers/live_trip_provider.dart';
+
+/// Pure tests for liveTripOf (specs/happening-now): liveness is
+/// tripDayOn != null (device-local, end-day inclusive); among several live
+/// trips the latest start date wins, ties broken by list order.
+Trip _trip(String id, {String? start, String? end}) => Trip(
+      id: id,
+      title: 'Trip $id',
+      status: 'planned',
+      startDate: start,
+      endDate: end,
+      createdAt: '2026-06-01',
+      updatedAt: '2026-06-01',
+    );
+
+String _iso(DateTime d) =>
+    '${d.year.toString().padLeft(4, '0')}-'
+    '${d.month.toString().padLeft(2, '0')}-'
+    '${d.day.toString().padLeft(2, '0')}';
+
+void main() {
+  final now = DateTime(2026, 7, 16, 14, 30);
+  String rel(int days) => _iso(now.add(Duration(days: days)));
+
+  test('no live trip returns null', () {
+    final trips = [
+      _trip('past', start: rel(-10), end: rel(-3)),
+      _trip('future', start: rel(3), end: rel(10)),
+    ];
+    expect(liveTripOf(trips, now), isNull);
+    expect(liveTripOf(const [], now), isNull);
+  });
+
+  test('a single live trip is picked', () {
+    final trips = [
+      _trip('past', start: rel(-10), end: rel(-3)),
+      _trip('live', start: rel(-1), end: rel(1)),
+      _trip('future', start: rel(3), end: rel(10)),
+    ];
+    expect(liveTripOf(trips, now)?.id, 'live');
+  });
+
+  test('two live trips: the latest start date wins regardless of order', () {
+    final older = _trip('older', start: rel(-5), end: rel(2));
+    final newer = _trip('newer', start: rel(-1), end: rel(4));
+    expect(liveTripOf([older, newer], now)?.id, 'newer');
+    expect(liveTripOf([newer, older], now)?.id, 'newer');
+  });
+
+  test('same start date ties break by list order', () {
+    final a = _trip('a', start: rel(-1), end: rel(2));
+    final b = _trip('b', start: rel(-1), end: rel(3));
+    expect(liveTripOf([a, b], now)?.id, 'a');
+    expect(liveTripOf([b, a], now)?.id, 'b');
+  });
+
+  test('undated trips are skipped', () {
+    final trips = [
+      _trip('undated'),
+      _trip('endless', start: rel(-2)),
+    ];
+    // The undated trip is never live; the open-ended dated one is.
+    expect(liveTripOf(trips, now)?.id, 'endless');
+    expect(liveTripOf([_trip('undated')], now), isNull);
+  });
+
+  test('a trip ending today is still live (end-day inclusive)', () {
+    final trips = [_trip('lastday', start: rel(-4), end: rel(0))];
+    expect(liveTripOf(trips, now)?.id, 'lastday');
+  });
+
+  test('ended yesterday or starting tomorrow is not live', () {
+    expect(
+        liveTripOf([_trip('done', start: rel(-4), end: rel(-1))], now), isNull);
+    expect(
+        liveTripOf([_trip('soon', start: rel(1), end: rel(4))], now), isNull);
+  });
+}

--- a/src/packages/flutter-app/test/trips_list_live_test.dart
+++ b/src/packages/flutter-app/test/trips_list_live_test.dart
@@ -1,0 +1,188 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:travel_route_planner/models/chat_session.dart';
+import 'package:travel_route_planner/models/trip.dart';
+import 'package:travel_route_planner/providers/resumable_chats_provider.dart';
+import 'package:travel_route_planner/providers/trip_cache_provider.dart';
+import 'package:travel_route_planner/providers/trips_provider.dart';
+import 'package:travel_route_planner/screens/trip_detail_screen.dart';
+import 'package:travel_route_planner/screens/trips_list_screen.dart';
+import 'package:travel_route_planner/services/api_client.dart';
+import 'package:travel_route_planner/services/trip_cache.dart';
+import 'package:travel_route_planner/services/trips_api_service.dart';
+import 'package:travel_route_planner/widgets/live_trip_card.dart';
+
+/// The "Happening now" card on the trips list (specs/happening-now): promoted
+/// above the continue section and My Trips, live trip left in place below,
+/// tap-through to the trip detail, and offline-cache parity.
+///
+/// Dates are relative to DateTime.now() so "today" is always live.
+class _QueuedTripsApiService extends TripsApiService {
+  final List<Object> responses;
+  int calls = 0;
+
+  _QueuedTripsApiService(this.responses)
+      : super(ApiClient(baseUrl: 'http://test'));
+
+  @override
+  Future<List<Trip>> listTrips() {
+    final next =
+        responses[calls < responses.length ? calls : responses.length - 1];
+    calls++;
+    if (next is List<Trip>) return Future.value(next);
+    return Future.error(next);
+  }
+
+  /// Serves the tapped trip to the pushed detail screen without a network.
+  @override
+  Future<Trip> getTrip(String id) async {
+    for (final r in responses) {
+      if (r is List<Trip>) {
+        for (final t in r) {
+          if (t.id == id) return t;
+        }
+      }
+    }
+    throw StateError('no queued trip $id');
+  }
+}
+
+String _iso(DateTime d) =>
+    '${d.year.toString().padLeft(4, '0')}-'
+    '${d.month.toString().padLeft(2, '0')}-'
+    '${d.day.toString().padLeft(2, '0')}';
+
+String _rel(int days) => _iso(DateTime.now().add(Duration(days: days)));
+
+Trip _trip(String id, String title, {String? start, String? end}) => Trip(
+      id: id,
+      title: title,
+      status: 'planned',
+      startDate: start,
+      endDate: end,
+      createdAt: '2026-06-01',
+      updatedAt: '2026-06-01',
+    );
+
+/// Yesterday → tomorrow: today is Day 2 of 3.
+Trip _liveTrip() =>
+    _trip('live', 'Athens Trip', start: _rel(-1), end: _rel(1));
+
+ChatSessionSummary _chat() => ChatSessionSummary(
+      chatId: 'c1',
+      title: 'Weekend in Rome',
+      preview: 'Thinking about museums…',
+      messageCount: 3,
+      createdAt: '2026-06-01T10:00:00Z',
+      updatedAt: '2026-06-01T10:00:00Z',
+    );
+
+Future<void> _pumpList(
+  WidgetTester tester,
+  _QueuedTripsApiService service, {
+  TripCache? cache,
+  List<ChatSessionSummary> chats = const [],
+}) {
+  return tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        tripsApiServiceProvider.overrideWithValue(service),
+        tripCacheProvider.overrideWithValue(cache ?? TripCache('u1')),
+        resumableChatsProvider.overrideWith((ref) async => chats),
+      ],
+      child: const MaterialApp(home: TripsListScreen()),
+    ),
+  );
+}
+
+void main() {
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  testWidgets(
+      'live card renders above the continue section and above My Trips',
+      (WidgetTester tester) async {
+    final service = _QueuedTripsApiService([
+      [_trip('future', 'Lisbon Trip', start: _rel(5), end: _rel(8)), _liveTrip()]
+    ]);
+
+    await _pumpList(tester, service, chats: [_chat()]);
+    await tester.pumpAndSettle();
+
+    expect(find.byType(LiveTripCard), findsOneWidget);
+    final cardY = tester.getTopLeft(find.byType(LiveTripCard)).dy;
+    final continueY =
+        tester.getTopLeft(find.text('Continue where you left off')).dy;
+    final tripCardY = tester.getTopLeft(find.text('Lisbon Trip')).dy;
+    expect(cardY, lessThan(continueY));
+    expect(continueY, lessThan(tripCardY));
+
+    // Promoted shortcut, not a filter: the live trip stays in My Trips, so
+    // its title shows twice — once on the card, once on its list card.
+    expect(find.text('Athens Trip'), findsNWidgets(2));
+  });
+
+  testWidgets('live card shows trip progress and the Live pill',
+      (WidgetTester tester) async {
+    final service = _QueuedTripsApiService([
+      [_liveTrip()]
+    ]);
+
+    await _pumpList(tester, service);
+    await tester.pumpAndSettle();
+
+    expect(find.text('HAPPENING NOW'), findsOneWidget);
+    expect(find.text('Day 2 of 3'), findsOneWidget);
+    expect(find.text('Live'), findsOneWidget);
+  });
+
+  testWidgets('tapping the live card opens the trip detail screen',
+      (WidgetTester tester) async {
+    final service = _QueuedTripsApiService([
+      [_liveTrip()]
+    ]);
+
+    await _pumpList(tester, service);
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byType(LiveTripCard));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(TripDetailScreen), findsOneWidget);
+  });
+
+  testWidgets('no live trip means no card', (WidgetTester tester) async {
+    final service = _QueuedTripsApiService([
+      [
+        _trip('past', 'Old Trip', start: _rel(-9), end: _rel(-2)),
+        _trip('future', 'Lisbon Trip', start: _rel(5), end: _rel(8)),
+      ]
+    ]);
+
+    await _pumpList(tester, service);
+    await tester.pumpAndSettle();
+
+    expect(find.byType(LiveTripCard), findsNothing);
+    expect(find.text('HAPPENING NOW'), findsNothing);
+  });
+
+  testWidgets('live card still renders from the offline cache',
+      (WidgetTester tester) async {
+    final cache = TripCache('u1');
+    await cache.writeList([_liveTrip()]);
+    final service = _QueuedTripsApiService([http.ClientException('down')]);
+
+    await _pumpList(tester, service, cache: cache);
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('Offline — showing saved copy from'),
+        findsOneWidget);
+    expect(find.byType(LiveTripCard), findsOneWidget);
+    expect(find.text('Day 2 of 3'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary

Wave 12 PR 1 (specs/happening-now, PR 1 of 2). When a trip is happening *today*, the trips list and home screen lead with a promoted brand-gradient card — "HAPPENING NOW · <cities> · Live · Day N of M" — one tap from today's plan (the trip detail then auto-scrolls to today per specs/today-mode).

## Changes

- **`lib/providers/live_trip_provider.dart`** (new): pure `liveTripOf(List<Trip>, DateTime)` — a trip is live when `tripDayOn(start, end, now) != null` (device-local calendar date, end-day inclusive, open-ended trips live from start; no status filter). Multiple live trips → latest `startDate` wins, ties by list order. `liveTripProvider` derives from `tripsProvider` via a narrow select on its trips list, so loading/error flips never rebuild the card.
- **`lib/widgets/live_trip_card.dart`** (new): gradient/elevation conventions matched to the home recent-trip tile so it reads as the top-priority object; white-tinted `StatusPill.custom` "Live" pill; title `citiesLabel(trip.cities) ?? trip.title`; "Day N of M" via `tripDayOn`/`dayCount` ("Day N" alone when there's no end date).
- **`lib/utils/trip_format.dart`**: `citiesLabel()` extracted from `trips_list_screen.dart`'s private `_locationLabel` (behavior-neutral refactor; `_TripCard` now calls it).
- **`trips_list_screen.dart`**: card at the very top of the ListView, above "Continue where you left off" and "My Trips"; tap → existing `_openTrip`. The live trip **stays** in My Trips — promoted shortcut, not a filter. Works from the offline cache.
- **`home_screen.dart`**: card in the recent-trip slot; the recent tile renders below it only when `recentTrip.tripId != liveTrip.id`. No `loadTrips()` from home — AppShell's IndexedStack mounts TripsListScreen eagerly, which populates `tripsProvider` app-wide.
- **`specs/happening-now/`**: spec + plan covering this PR **and** the follow-up Tonight caption (PR 2): non-pinned first content row of today's day section, checkout-exclusive tonight stay, first-group dedupe, empty-name skip; non-goals: no API changes, no per-trip city/stay detail on the card (list payload carries no items), no shared-with-me trips, build-time "now" (midnight-rollover limitation, consistent with today-mode).

## Tests

- `test/live_trip_provider_test.dart` (pure): none/one/two live, latest-startDate win, list-order tiebreak, undated skipped, ends-today live, ended-yesterday / starts-tomorrow not live.
- `test/trips_list_live_test.dart`: card above the continue section and My Trips (with a fake resumable chat), trip still listed below, "Day 2 of 3" + "Live", tap pushes `TripDetailScreen`, absent when nothing live, renders from offline cache (queued network error + seeded TripCache).
- `test/home_live_trip_test.dart`: live card in the slot; recent tile hidden when it *is* the live trip, both shown (live first) when different; untouched when no live trip.

`flutter test`: **214/214 pass**. `flutter analyze --no-fatal-infos --fatal-warnings`: exit 0, 12 pre-existing infos (baseline unchanged, none in new files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)