### PR TITLE
feat(flutter): "Tonight: <stay>" caption on today's section

### DIFF
--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -144,9 +144,17 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
   /// A trip without a parseable start date can't map Day N to a calendar
   /// date, so no stay matches (they all still show under All).
   List<Accommodation> _dayFilteredStays(Trip trip) {
-    final all = trip.accommodations ?? const <Accommodation>[];
     final day = _selectedDay;
-    if (day == null) return all;
+    if (day == null) return trip.accommodations ?? const <Accommodation>[];
+    return _staysOnNight(trip, day);
+  }
+
+  /// Stays covering the night of trip day [day], checkout-exclusively — the
+  /// single home of the day→night math shared by the map's day filter and the
+  /// Tonight caption. A trip without a parseable start date can't map Day N
+  /// to a calendar date, so no stay matches.
+  List<Accommodation> _staysOnNight(Trip trip, int day) {
+    final all = trip.accommodations ?? const <Accommodation>[];
     final start = DateTime.tryParse(trip.startDate ?? '');
     if (start == null) return const [];
     // Calendar-day arithmetic (constructor normalizes overflow) rather than
@@ -1224,7 +1232,8 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
   /// the day's items scroll past, then is pushed off by the next day. Legacy
   /// items with no day fall back to flat day-trip batching with no day headers.
   List<Widget> _buildGroupItemSlivers(String cityKey, List<ItineraryItem> items,
-      ThemeData theme, DateTime? tripStart) {
+      ThemeData theme, DateTime? tripStart,
+      {required bool showTonight}) {
     if (!items.any((it) => it.day != null)) {
       return [_boxSliver(_buildDayTripWidgets(items, theme))];
     }
@@ -1271,11 +1280,23 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
                 : null,
             headerKey: _dayHeaderKeys.putIfAbsent(dayKey, GlobalKey.new),
             isToday: day == todayDay);
+        // Tonight caption (specs/happening-now): a non-pinned content row —
+        // it scrolls and collapses with the section, never joining the
+        // pinned chrome. [showTonight] is true for at most one group, so
+        // repeated day numbers across city groups can't duplicate it.
+        final trip = _trip;
+        final tonight = (showTonight && day == todayDay && trip != null)
+            ? _tonightCaption(theme, _staysOnNight(trip, day))
+            : null;
         slivers.add(MultiSliver(
           pushPinnedChildren: true,
           children: [
             SliverPinnedHeader(child: header),
-            if (!collapsed) _boxSliver(_buildDayTripWidgets(run, theme)),
+            if (!collapsed)
+              _boxSliver([
+                if (tonight != null) tonight,
+                ..._buildDayTripWidgets(run, theme),
+              ]),
           ],
         ));
       } else {
@@ -1837,6 +1858,37 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
             ],
           ),
         ),
+      ),
+    );
+  }
+
+  /// "Tonight: <stay>" caption for today's day section (specs/happening-now
+  /// PR 2): where the traveler sleeps tonight, checkout-exclusively. Returns
+  /// null when no covering stay has a non-empty name — no filler row.
+  Widget? _tonightCaption(ThemeData theme, List<Accommodation> stays) {
+    final names = stays
+        .map((a) => a.name.trim())
+        .where((n) => n.isNotEmpty)
+        .toList();
+    if (names.isEmpty) return null;
+    return Padding(
+      // Matches the _dayTripSubHeader indent (20 left) so the caption reads
+      // as a sub-row of the day, tucked tight under the header (6 top).
+      padding: const EdgeInsets.fromLTRB(20, 6, 16, 0),
+      child: Row(
+        children: [
+          Icon(Icons.hotel, size: 14, color: theme.colorScheme.primary),
+          const SizedBox(width: 6),
+          Expanded(
+            child: Text(
+              'Tonight: ${names.join(', ')}',
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: theme.textTheme.bodySmall
+                  ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+            ),
+          ),
+        ],
       ),
     );
   }
@@ -2642,6 +2694,19 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
                       final hasTodayTarget = todayDay != null &&
                           (trip.items ?? const <ItineraryItem>[])
                               .any((i) => i.day != null);
+                      // Tonight caption (specs/happening-now): day numbers
+                      // repeat across city groups (keys are '$cityKey#$day'),
+                      // so resolve the FIRST group containing today's day
+                      // once, here — exactly one caption can ever render.
+                      String? firstTodayGroupLabel;
+                      if (todayDay != null) {
+                        for (final group in groups) {
+                          if (group.items.any((it) => it.day == todayDay)) {
+                            firstTodayGroupLabel = group.label;
+                            break;
+                          }
+                        }
+                      }
                       // A loud load queued the one-shot auto-scroll; this is
                       // the first frame that actually mounts the scroll view
                       // (and registers the day-header keys), so kick it off
@@ -2870,8 +2935,13 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
                                           _boxSliver(_bookingRowWidgets(
                                               grouped.slots[gi],
                                               departureOnly: false)),
-                                        ..._buildGroupItemSlivers(group.label,
-                                            group.items, theme, tripStart),
+                                        ..._buildGroupItemSlivers(
+                                            group.label,
+                                            group.items,
+                                            theme,
+                                            tripStart,
+                                            showTonight: group.label ==
+                                                firstTodayGroupLabel),
                                         // Curated local recommendations for this
                                         // city — the "legit info you can't
                                         // google" surface. Leads the events

--- a/src/packages/flutter-app/test/trip_detail_today_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_today_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:travel_route_planner/models/trip.dart';
 import 'package:travel_route_planner/models/itinerary_item.dart';
+import 'package:travel_route_planner/models/accommodation.dart';
 import 'package:travel_route_planner/services/api_client.dart';
 import 'package:travel_route_planner/services/trips_api_service.dart';
 import 'package:travel_route_planner/providers/trips_provider.dart';
@@ -51,7 +52,11 @@ ItineraryItem _item(int pos, String name, int day,
 /// A three-day Paris trip: day 1 is long enough that today's (day 2) header
 /// starts well below the fold, day 3 gives the scroll room to land day 2 at
 /// the top.
-Trip _liveTrip({required String startDate, required String endDate}) => Trip(
+Trip _liveTrip(
+        {required String startDate,
+        required String endDate,
+        List<Accommodation>? accommodations}) =>
+    Trip(
       id: 't1',
       title: 'Live Trip',
       status: 'planned',
@@ -59,6 +64,7 @@ Trip _liveTrip({required String startDate, required String endDate}) => Trip(
       updatedAt: '2026-06-01',
       startDate: startDate,
       endDate: endDate,
+      accommodations: accommodations,
       items: [
         for (var k = 0; k < 6; k++) _item(k, 'Past stop $k', 1),
         for (var k = 0; k < 6; k++) _item(6 + k, 'Today stop $k', 2),
@@ -231,5 +237,172 @@ void main() {
     expect(
         tester.widget<MapDayChips>(find.byType(MapDayChips)).selected, 2);
     expect(_todayChip(), findsOneWidget);
+  });
+
+  group('Tonight caption (specs/happening-now PR 2)', () {
+    // Coordinate-free stays: TripMap.stayHasCoords stays false, so the map
+    // sliver never mounts and the scroll geometry the tests above pin down
+    // is unchanged.
+    Accommodation stay(String id, String name,
+            {required int checkInOffset, required int checkOutOffset}) =>
+        Accommodation(
+          id: id,
+          name: name,
+          checkIn: _iso(now.add(Duration(days: checkInOffset))),
+          checkOut: _iso(now.add(Duration(days: checkOutOffset))),
+        );
+
+    Finder tonight() => find.textContaining('Tonight: ');
+
+    testWidgets('a stay covering tonight renders exactly one caption in '
+        "today's section", (WidgetTester tester) async {
+      final trip = _liveTrip(startDate: start, endDate: end, accommodations: [
+        stay('a1', 'Hôtel du Nord', checkInOffset: -1, checkOutOffset: 2),
+      ]);
+      await _pumpScreen(tester, _FakeTripsApiService(trip));
+
+      // The auto-scroll parked today's header at the top; the caption is the
+      // section's first content row, directly under it.
+      expect(tonight(), findsOneWidget);
+      expect(find.text('Tonight: Hôtel du Nord'), findsOneWidget);
+      final pillDy = tester.getTopLeft(_todayPill()).dy;
+      final captionDy = tester.getTopLeft(tonight()).dy;
+      expect(captionDy, greaterThan(pillDy));
+      expect(captionDy,
+          lessThan(tester.getTopLeft(find.text('Today stop 0')).dy));
+    });
+
+    testWidgets('a stay checking out today never claims tonight '
+        '(checkout-exclusive)', (WidgetTester tester) async {
+      final trip = _liveTrip(startDate: start, endDate: end, accommodations: [
+        stay('a1', 'Hôtel du Nord', checkInOffset: -1, checkOutOffset: 0),
+      ]);
+      await _pumpScreen(tester, _FakeTripsApiService(trip));
+
+      expect(tonight(), findsNothing);
+    });
+
+    testWidgets('a trip that ended yesterday shows no caption',
+        (WidgetTester tester) async {
+      final trip = _liveTrip(
+        startDate: _iso(now.subtract(const Duration(days: 3))),
+        endDate: _iso(now.subtract(const Duration(days: 1))),
+        accommodations: [
+          stay('a1', 'Hôtel du Nord', checkInOffset: -1, checkOutOffset: 2),
+        ],
+      );
+      await _pumpScreen(tester, _FakeTripsApiService(trip));
+
+      expect(tonight(), findsNothing);
+    });
+
+    testWidgets('an undated trip shows no caption',
+        (WidgetTester tester) async {
+      final undated = Trip(
+        id: 't1',
+        title: 'Undated Trip',
+        status: 'planned',
+        createdAt: '2026-06-01',
+        updatedAt: '2026-06-01',
+        accommodations: [
+          stay('a1', 'Hôtel du Nord', checkInOffset: -1, checkOutOffset: 2),
+        ],
+        items: [
+          for (var k = 0; k < 3; k++) _item(k, 'Stop $k', 1),
+          for (var k = 0; k < 3; k++) _item(3 + k, 'Later stop $k', 2),
+        ],
+      );
+      await _pumpScreen(tester, _FakeTripsApiService(undated));
+
+      expect(tonight(), findsNothing);
+    });
+
+    testWidgets('two stays covering tonight are comma-joined',
+        (WidgetTester tester) async {
+      final trip = _liveTrip(startDate: start, endDate: end, accommodations: [
+        stay('a1', 'Hôtel A', checkInOffset: -1, checkOutOffset: 2),
+        stay('a2', 'Hôtel B', checkInOffset: 0, checkOutOffset: 1),
+      ]);
+      await _pumpScreen(tester, _FakeTripsApiService(trip));
+
+      expect(find.text('Tonight: Hôtel A, Hôtel B'), findsOneWidget);
+    });
+
+    testWidgets('an empty-name stay is skipped in the joined names',
+        (WidgetTester tester) async {
+      final trip = _liveTrip(startDate: start, endDate: end, accommodations: [
+        stay('a1', '  ', checkInOffset: -1, checkOutOffset: 2),
+        stay('a2', 'Hôtel B', checkInOffset: -1, checkOutOffset: 2),
+      ]);
+      await _pumpScreen(tester, _FakeTripsApiService(trip));
+
+      expect(find.text('Tonight: Hôtel B'), findsOneWidget);
+    });
+
+    testWidgets('only empty-name stays render no caption at all',
+        (WidgetTester tester) async {
+      final trip = _liveTrip(startDate: start, endDate: end, accommodations: [
+        stay('a1', '  ', checkInOffset: -1, checkOutOffset: 2),
+      ]);
+      await _pumpScreen(tester, _FakeTripsApiService(trip));
+
+      expect(tonight(), findsNothing);
+    });
+
+    testWidgets("collapsing today's day hides the caption with the section",
+        (WidgetTester tester) async {
+      final trip = _liveTrip(startDate: start, endDate: end, accommodations: [
+        stay('a1', 'Hôtel du Nord', checkInOffset: -1, checkOutOffset: 2),
+      ]);
+      await _pumpScreen(tester, _FakeTripsApiService(trip));
+      expect(tonight(), findsOneWidget);
+
+      await tester.tap(_todayPill());
+      await tester.pumpAndSettle();
+
+      expect(find.text('Today stop 0'), findsNothing); // really collapsed
+      expect(tonight(), findsNothing);
+    });
+
+    testWidgets('two city groups containing today render exactly one caption',
+        (WidgetTester tester) async {
+      ItineraryItem cityItem(int pos, String name, int day, String city) =>
+          ItineraryItem(
+            id: 'i$pos',
+            position: pos,
+            name: name,
+            address: '$name street, $city',
+            latitude: 0,
+            longitude: 0,
+            category: 'attraction',
+            day: day,
+            city: city,
+          );
+      // Day 2 (today) spans the Paris→Lyon handover, so BOTH city groups
+      // render a "Day 2" section; the caption may appear only in the first.
+      final trip = Trip(
+        id: 't1',
+        title: 'Two Cities',
+        status: 'planned',
+        createdAt: '2026-06-01',
+        updatedAt: '2026-06-01',
+        startDate: start,
+        endDate: end,
+        accommodations: [
+          stay('a1', 'Hôtel du Nord', checkInOffset: -1, checkOutOffset: 2),
+        ],
+        items: [
+          cityItem(0, 'Louvre', 1, 'Paris'),
+          cityItem(1, 'Marais walk', 2, 'Paris'),
+          cityItem(2, 'Confluence', 2, 'Lyon'),
+          cityItem(3, 'Fourvière', 3, 'Lyon'),
+        ],
+      );
+      await _pumpScreen(tester, _FakeTripsApiService(trip));
+
+      expect(find.text('Paris'), findsWidgets);
+      expect(find.text('Lyon'), findsWidgets);
+      expect(tonight(), findsOneWidget);
+    });
   });
 }


### PR DESCRIPTION
specs/happening-now **PR 2 (final)**: inside a live trip, today's day section opens with a **"Tonight: <stay>"** caption — where the traveler sleeps tonight, one glance under the Today header.

## What

- **`_staysOnNight(Trip, int day)`** extracted from `_dayFilteredStays` (the DST-safe `DateTime(y, m, d + day - 1)` + checkout-exclusive `stayCoversDate` logic from #98) — the day→night math now exists exactly once; the map day filter delegates to it.
- **`_buildGroupItemSlivers`** gains `required bool showTonight`; when the day run is today's (`day == todayDay`), the section is expanded, and `showTonight` is true, `_tonightCaption(...)` is **prepended to the day's `_boxSliver` column** — a NON-pinned content row that scrolls and collapses with the section.
- Day numbers repeat across city groups (keys are `'$cityKey#$day'`), so the sliver-assembly call site resolves the **first** group containing `todayDay` once and passes `showTonight: group.label == firstTodayGroupLabel` — exactly one caption can ever render.
- Caption row: `Icons.hotel` 14 in `colorScheme.primary`, `'Tonight: '` + trimmed stay names comma-joined in `bodySmall`/`onSurfaceVariant`, maxLines 1 + ellipsis, `EdgeInsets.fromLTRB(20, 6, 16, 0)` (matches the `_dayTripSubHeader` 20px indent). Empty names are skipped; when none remain, nothing renders — no filler.

## Pinned-height proof

Zero pinned chrome touched: no diff lines mention `_pinnedChrome`, `_mapHeaderHeight`, `_listHeaderHeight*`, `_daySubHeader`, `_load`, or the auto-scroll. `trip_detail_sticky_headers_test.dart` and the existing `trip_detail_today_test.dart` scroll cases pass **unmodified** (the only fixture change is an optional, default-null `accommodations` parameter on `_liveTrip`).

## Tests

New cases in `trip_detail_today_test.dart` (same fake service + relative-date fixture):
- covering stay (check-in yesterday, check-out +2d) → exactly one `Tonight:` caption, positioned between the Today header and today's first item
- stay checking out **today** → absent (checkout-exclusive)
- ended / undated trips → absent
- two covering stays → comma-joined
- empty-name stay skipped; all-empty → no caption at all
- today's day collapsed → caption hidden with the section
- two city groups both containing todayDay → exactly one caption

`flutter test`: **228 passed, 0 failed.** `flutter analyze --no-fatal-infos --fatal-warnings`: exit 0 (the 12 known pre-existing infos; none added).

🤖 Generated with [Claude Code](https://claude.com/claude-code)