### PR TITLE
feat(flutter): mute empty day chips and give the trip map a real empty state

### DIFF
--- a/src/packages/flutter-app/lib/screens/shared_trip_screen.dart
+++ b/src/packages/flutter-app/lib/screens/shared_trip_screen.dart
@@ -156,6 +156,19 @@ class _SharedTripBodyState extends ConsumerState<_SharedTripBody> {
     if (_selectedDay != null && _selectedDay! > mapDayCount) {
       _selectedDay = null; // trip shrank under a stale selection
     }
+    // Days that would plot something, so empty days get muted chips.
+    final mappedDays = daysWithMappedContent(
+      trip.startDate,
+      mapDayCount,
+      [
+        for (final i in items)
+          if (i.latitude != 0 || i.longitude != 0) i.day,
+      ],
+      [
+        for (final a in stays)
+          if (TripMap.stayHasCoords(a)) (checkIn: a.checkIn, checkOut: a.checkOut),
+      ],
+    );
     final dayItems = _selectedDay == null
         ? items
         : items.where((i) => i.day == _selectedDay).toList();
@@ -215,7 +228,7 @@ class _SharedTripBodyState extends ConsumerState<_SharedTripBody> {
                               : 0,
                           emptyLabel: _selectedDay == null
                               ? 'No mapped places'
-                              : 'No mapped places on this day',
+                              : 'No places pinned on Day $_selectedDay',
                           onPinTap: (pos) =>
                               setState(() => _selectedPosition = pos),
                         ),
@@ -229,6 +242,7 @@ class _SharedTripBodyState extends ConsumerState<_SharedTripBody> {
                         child: MapDayChips(
                           dayCount: mapDayCount,
                           selected: _selectedDay,
+                          mappedDays: mappedDays,
                           onSelected: (d) =>
                               setState(() => _selectedDay = d),
                         ),

--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -2685,6 +2685,25 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
                       if (_selectedDay != null && _selectedDay! > mapDayCount) {
                         _selectedDay = null;
                       }
+                      // Days that would plot something, so empty days (e.g.
+                      // the fly-out day, all booking todos) get muted chips.
+                      // Trip-wide like mapDayCount — the category filter never
+                      // flickers the chip treatment.
+                      final mappedDays = daysWithMappedContent(
+                        trip.startDate,
+                        mapDayCount,
+                        [
+                          for (final i
+                              in trip.items ?? const <ItineraryItem>[])
+                            if (i.latitude != 0 || i.longitude != 0) i.day,
+                        ],
+                        [
+                          for (final a in trip.accommodations ??
+                              const <Accommodation>[])
+                            if (TripMap.stayHasCoords(a))
+                              (checkIn: a.checkIn, checkOut: a.checkOut),
+                        ],
+                      );
                       // Today mode: the jump chip renders only when today
                       // falls inside the trip's dates AND some item carries a
                       // day tag (the same gate as the auto-scroll, so the
@@ -2767,7 +2786,21 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
                                               : 0,
                                           emptyLabel: _selectedDay == null
                                               ? 'No mapped places'
-                                              : 'No mapped places on this day',
+                                              : 'No places pinned on '
+                                                  'Day $_selectedDay',
+                                          emptyMessage: _isOffline
+                                              ? null
+                                              : 'Add a place to see it '
+                                                  'on the map.',
+                                          emptyAction: _isOffline
+                                              ? null
+                                              : FilledButton.tonalIcon(
+                                                  onPressed: _addPlace,
+                                                  icon: const Icon(Icons.add,
+                                                      size: 18),
+                                                  label:
+                                                      const Text('Add place'),
+                                                ),
                                           onPinTap: (pos) {
                                             setState(
                                                 () => _selectedPosition = pos);
@@ -2787,6 +2820,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
                                         child: MapDayChips(
                                           dayCount: mapDayCount,
                                           selected: _selectedDay,
+                                          mappedDays: mappedDays,
                                           onSelected: (d) => setState(
                                               () => _selectedDay = d),
                                         ),

--- a/src/packages/flutter-app/lib/utils/trip_days.dart
+++ b/src/packages/flutter-app/lib/utils/trip_days.dart
@@ -41,6 +41,38 @@ int dayCount(String? startDate, String? endDate, Iterable<int?> itemDays) {
   return max;
 }
 
+/// The set of 1-based days in `1..dayCount` that would plot something on the
+/// trip map: days carried by a coordinate-bearing itinerary item, plus days
+/// whose night is covered by a geocoded stay (checkout-exclusive, via
+/// [stayCoversDate]). Callers pre-filter to mapped entries — pass only the
+/// day tags of items with real coordinates and the date ranges of stays with
+/// real coordinates. Lets day chips mute days that would show an empty map.
+Set<int> daysWithMappedContent(
+  String? startDate,
+  int dayCount,
+  Iterable<int?> mappedItemDays,
+  Iterable<({String? checkIn, String? checkOut})> mappedStayDates,
+) {
+  final days = <int>{
+    for (final d in mappedItemDays)
+      if (d != null && d >= 1 && d <= dayCount) d,
+  };
+  final start = DateTime.tryParse(startDate ?? '');
+  if (start != null) {
+    for (var d = 1; d <= dayCount; d++) {
+      if (days.contains(d)) continue;
+      // Calendar-day arithmetic (constructor normalizes overflow) rather than
+      // Duration, which drifts a date across a DST transition.
+      final night = DateTime(start.year, start.month, start.day + d - 1);
+      if (mappedStayDates
+          .any((s) => stayCoversDate(s.checkIn, s.checkOut, night))) {
+        days.add(d);
+      }
+    }
+  }
+  return days;
+}
+
 /// Whether a stay covers the night of [date] (device-local calendar date):
 /// check-in <= date < check-out — **checkout-exclusive**, since nobody sleeps
 /// there on checkout day. False when either date is missing or unparseable.

--- a/src/packages/flutter-app/lib/widgets/empty_state.dart
+++ b/src/packages/flutter-app/lib/widgets/empty_state.dart
@@ -15,6 +15,11 @@ class EmptyState extends StatelessWidget {
   /// Tints the icon. Defaults to a muted primary.
   final Color? iconColor;
 
+  /// Tighter metrics (smaller icon and type, less padding) for short
+  /// containers — e.g. the 240px trip-map header, where the default 64px icon
+  /// plus a title and a button would overflow.
+  final bool compact;
+
   const EmptyState({
     super.key,
     required this.icon,
@@ -22,6 +27,7 @@ class EmptyState extends StatelessWidget {
     this.message,
     this.actions = const [],
     this.iconColor,
+    this.compact = false,
   });
 
   @override
@@ -29,21 +35,22 @@ class EmptyState extends StatelessWidget {
     final theme = Theme.of(context);
     return Center(
       child: Padding(
-        padding: const EdgeInsets.all(AppSpacing.xxl),
+        padding: EdgeInsets.all(compact ? AppSpacing.lg : AppSpacing.xxl),
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
             Icon(
               icon,
-              size: 64,
+              size: compact ? 32 : 64,
               color: iconColor ?? theme.colorScheme.primary.withValues(alpha: 0.5),
             ),
-            const SizedBox(height: AppSpacing.lg),
+            SizedBox(height: compact ? AppSpacing.sm : AppSpacing.lg),
             Text(
               title,
-              style: theme.textTheme.titleLarge?.copyWith(
-                fontWeight: FontWeight.bold,
-              ),
+              style: (compact
+                      ? theme.textTheme.titleMedium
+                      : theme.textTheme.titleLarge)
+                  ?.copyWith(fontWeight: FontWeight.bold),
               textAlign: TextAlign.center,
             ),
             if (message != null) ...[
@@ -51,13 +58,14 @@ class EmptyState extends StatelessWidget {
               Text(
                 message!,
                 textAlign: TextAlign.center,
-                style: theme.textTheme.bodyMedium?.copyWith(
-                  color: theme.colorScheme.onSurfaceVariant,
-                ),
+                style: (compact
+                        ? theme.textTheme.bodySmall
+                        : theme.textTheme.bodyMedium)
+                    ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
               ),
             ],
             if (actions.isNotEmpty) ...[
-              const SizedBox(height: AppSpacing.xl),
+              SizedBox(height: compact ? AppSpacing.md : AppSpacing.xl),
               Wrap(
                 spacing: AppSpacing.sm,
                 runSpacing: AppSpacing.sm,

--- a/src/packages/flutter-app/lib/widgets/map_day_chips.dart
+++ b/src/packages/flutter-app/lib/widgets/map_day_chips.dart
@@ -22,15 +22,29 @@ class MapDayChips extends StatelessWidget {
   final int? selected;
   final ValueChanged<int?> onSelected;
 
+  /// Days that have something plottable (a coordinate-bearing item tagged to
+  /// the day, or a stay covering its night — see `daysWithMappedContent`).
+  /// Chips for other days stay tappable but render muted, signalling "nothing
+  /// on the map here" before the tap. Null (the default) mutes nothing.
+  final Set<int>? mappedDays;
+
   const MapDayChips({
     super.key,
     required this.dayCount,
     required this.selected,
     required this.onSelected,
+    this.mappedDays,
   });
 
-  Widget _chip({required String label, required int? value}) {
+  Widget _chip({
+    required String label,
+    required int? value,
+    bool muted = false,
+  }) {
     final isSelected = selected == value;
+    // A selected chip keeps the full treatment even when its day is empty —
+    // the ring is what says "you are here"; the map's empty state says empty.
+    final dim = muted && !isSelected;
     return ChoiceChip(
       label: Text(label),
       selected: isSelected,
@@ -44,12 +58,16 @@ class MapDayChips extends StatelessWidget {
       // Dark translucent scrim so the text reads over satellite imagery
       // (same treatment as TripMap's segment labels); selection is a solid
       // white ring + brighter fill rather than a theme tint, which would
-      // vanish against imagery.
-      backgroundColor: Colors.black.withValues(alpha: 0.6),
+      // vanish against imagery. Muted (nothing mapped that day) fades the
+      // scrim, border, and label together.
+      backgroundColor: Colors.black.withValues(alpha: dim ? 0.35 : 0.6),
       selectedColor: Colors.black.withValues(alpha: 0.8),
-      side: BorderSide(color: isSelected ? Colors.white : Colors.white24),
+      side: BorderSide(
+          color: isSelected
+              ? Colors.white
+              : (dim ? Colors.white12 : Colors.white24)),
       labelStyle: TextStyle(
-        color: Colors.white,
+        color: dim ? Colors.white60 : Colors.white,
         fontSize: 11,
         fontWeight: isSelected ? FontWeight.w700 : FontWeight.w600,
       ),
@@ -66,7 +84,11 @@ class MapDayChips extends StatelessWidget {
           _chip(label: 'All', value: null),
           for (var d = 1; d <= dayCount; d++) ...[
             const SizedBox(width: 6),
-            _chip(label: 'Day $d', value: d),
+            _chip(
+              label: 'Day $d',
+              value: d,
+              muted: mappedDays != null && !mappedDays!.contains(d),
+            ),
           ],
         ],
       ),

--- a/src/packages/flutter-app/lib/widgets/trip_map.dart
+++ b/src/packages/flutter-app/lib/widgets/trip_map.dart
@@ -10,6 +10,7 @@ import '../models/itinerary_item.dart';
 import '../theme/app_colors.dart';
 import '../utils/trip_format.dart';
 import 'app_map.dart';
+import 'empty_state.dart';
 
 /// Plots a trip's itinerary on a satellite basemap: a numbered, category-tinted
 /// pin per place, a route line connecting them in itinerary order, auto-fit to
@@ -41,6 +42,14 @@ class TripMap extends StatefulWidget {
   /// coordinates). The default keeps existing call sites unchanged.
   final String emptyLabel;
 
+  /// Optional second line under [emptyLabel] in the empty state.
+  final String? emptyMessage;
+
+  /// Optional CTA (e.g. an "Add place" button) rendered in the empty state.
+  /// Null — the default, and what read-only screens pass — shows icon + text
+  /// only.
+  final Widget? emptyAction;
+
   /// Extra top camera-fit padding (px) for overlays floating on the map's top
   /// edge (e.g. [MapDayChips]), so fitted markers never land underneath them.
   /// The default keeps existing call sites unchanged.
@@ -55,6 +64,8 @@ class TripMap extends StatefulWidget {
     this.accommodations = const [],
     this.fitSignature,
     this.emptyLabel = 'No mapped places',
+    this.emptyMessage,
+    this.emptyAction,
     this.topOverlayInset = 0,
   });
 
@@ -221,11 +232,15 @@ class _TripMapState extends State<TripMap> {
     if (mapped.isEmpty && stays.isEmpty) {
       return Container(
         color: theme.colorScheme.surfaceContainerHighest,
-        alignment: Alignment.center,
-        child: Text(
-          widget.emptyLabel,
-          style: theme.textTheme.bodySmall
-              ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+        // Keep the centered content clear of the day-chip band overlaid on
+        // the map's top edge (same inset the camera fitting respects).
+        padding: EdgeInsets.only(top: widget.topOverlayInset),
+        child: EmptyState(
+          compact: true,
+          icon: Icons.location_off_outlined,
+          title: widget.emptyLabel,
+          message: widget.emptyMessage,
+          actions: [if (widget.emptyAction != null) widget.emptyAction!],
         ),
       );
     }

--- a/src/packages/flutter-app/test/shared_trip_day_chips_test.dart
+++ b/src/packages/flutter-app/test/shared_trip_day_chips_test.dart
@@ -116,6 +116,11 @@ void main() {
     expect(map(tester).fitSignature, isNull);
     expect(map(tester).items, hasLength(3));
     expect(map(tester).accommodations, hasLength(2));
+
+    // Both days plot something, so no chip is muted — and the read-only map
+    // carries no empty-state CTA.
+    expect(tester.widget<MapDayChips>(chips).mappedDays, {1, 2});
+    expect(map(tester).emptyAction, isNull);
   });
 
   testWidgets('day chip filters the shared map; All restores',

--- a/src/packages/flutter-app/test/trip_detail_day_chips_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_day_chips_test.dart
@@ -139,21 +139,58 @@ void main() {
     expect(map(tester).fitSignature, isNull);
   });
 
-  testWidgets('a day with nothing mappable shows the on-map empty message '
-      'while the chips stay', (WidgetTester tester) async {
+  testWidgets('a day with nothing mappable shows the on-map empty state '
+      'with an Add place CTA while the chips stay',
+      (WidgetTester tester) async {
     await pumpScreen(tester);
 
     await tapChip(tester, 'Day 3');
 
     expect(map(tester).items, isEmpty);
     expect(map(tester).accommodations, isEmpty);
-    expect(find.text('No mapped places on this day'), findsOneWidget);
+    expect(find.text('No places pinned on Day 3'), findsOneWidget);
+    // The editable screen gets the CTA on the map itself (the itinerary
+    // header has its own same-label button outside the map).
+    expect(
+      find.descendant(
+        of: find.byType(TripMap),
+        matching: find.text('Add place'),
+      ),
+      findsOneWidget,
+    );
     // The chip row survives the empty selection (the gate is keyed to the
     // unfiltered items) and can navigate back out.
     expect(find.byType(MapDayChips), findsOneWidget);
 
     await tapChip(tester, 'All');
-    expect(find.text('No mapped places on this day'), findsNothing);
+    expect(find.text('No places pinned on Day 3'), findsNothing);
     expect(map(tester).items, hasLength(3));
+  });
+
+  testWidgets('chips for days with nothing mappable render muted but stay '
+      'tappable', (WidgetTester tester) async {
+    await pumpScreen(tester);
+
+    ChoiceChip chipFor(String label) => tester.widget<ChoiceChip>(
+          find.ancestor(
+            of: find.descendant(
+              of: find.byType(MapDayChips),
+              matching: find.text(label),
+            ),
+            matching: find.byType(ChoiceChip),
+          ),
+        );
+
+    // Day 3 has no items and no covering stay; Days 1–2 plot something.
+    expect(chipFor('Day 3').labelStyle?.color, Colors.white60);
+    expect(chipFor('Day 1').labelStyle?.color, Colors.white);
+    expect(chipFor('Day 2').labelStyle?.color, Colors.white);
+    expect(chipFor('All').labelStyle?.color, Colors.white);
+
+    // Selecting the muted chip restores the full treatment (the ring says
+    // "you are here"; the map's empty state says empty).
+    await tapChip(tester, 'Day 3');
+    expect(chipFor('Day 3').labelStyle?.color, Colors.white);
+    expect(chipFor('Day 3').selected, isTrue);
   });
 }

--- a/src/packages/flutter-app/test/trip_map_test.dart
+++ b/src/packages/flutter-app/test/trip_map_test.dart
@@ -107,6 +107,24 @@ void main() {
     expect(find.text('No mapped places'), findsOneWidget);
   });
 
+  testWidgets('empty state renders the optional message and CTA',
+      (WidgetTester tester) async {
+    var tapped = false;
+    await tester.pumpWidget(_host(TripMap(
+      items: const [],
+      emptyMessage: 'Add a place to see it on the map.',
+      emptyAction: FilledButton(
+        onPressed: () => tapped = true,
+        child: const Text('Add place'),
+      ),
+    )));
+    await tester.pump();
+
+    expect(find.text('Add a place to see it on the map.'), findsOneWidget);
+    await tester.tap(find.text('Add place'));
+    expect(tapped, isTrue);
+  });
+
   testWidgets('changing fitSignature re-fits without crashing (smoke)',
       (WidgetTester tester) async {
     await tester.pumpWidget(


### PR DESCRIPTION
## Summary
- A trip day with nothing mappable (e.g. the fly-out day, whose items are coordinate-less booking todos) used to render a bare grey void reading "No mapped places on this day". The day itself is real — the chip count comes from the trip's date span — so the UI now communicates instead of hiding.
- New `daysWithMappedContent` helper in `trip_days.dart`: the set of days that would plot something (a coordinate-bearing item tagged to the day, or a geocoded stay covering that night, checkout-exclusive).
- `MapDayChips` mutes chips for unmapped days — faded scrim/border/label — while keeping them tappable; a selected chip keeps the full white-ring treatment.
- `TripMap`'s empty branch now renders the design-system `EmptyState` (new `compact` mode so it fits the 240px pinned map header, inset below the chip row) with a day-aware title ("No places pinned on Day 11") and optional message + CTA.
- Trip detail wires the CTA to the existing `_addPlace` flow (hidden while offline); the read-only shared trip view gets the same muting and empty state without the CTA.

## Testing
- `flutter test`: all 230 pass, including new/updated cases — muted-chip styling + still-selectable, empty state with CTA on trip detail, `mappedDays`/no-CTA on the shared view, `emptyMessage`/`emptyAction` render + tap on `TripMap`.
- `flutter analyze`: only the 12 pre-existing infos (identical on main).
- Manual: drove the dev stack headlessly on the seeded 11-day Latin America trip (items on days 1–10 only) — Day 11 chip renders muted up front; selecting it shows the icon/title/message/Add place empty state, the CTA opens the real Add place dialog, Day 10 and All render unchanged, and no layout-overflow exceptions in the flutter logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)