### PR TITLE
feat(flutter): preselect the viewed day in Add place from the map's empty state

### DIFF
--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -743,13 +743,15 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
     if (added == true) await _load();
   }
 
-  Future<void> _addPlace() async {
+  /// [day] preselects the dialog's Day dropdown (e.g. from the map's
+  /// empty-day CTA, where the user is already looking at a specific day).
+  Future<void> _addPlace({int? day}) async {
     if (_guardOffline()) return;
     final trip = _trip;
     if (trip == null) return;
     final added = await showDialog<bool>(
       context: context,
-      builder: (_) => AddItineraryItemDialog(trip: trip),
+      builder: (_) => AddItineraryItemDialog(trip: trip, initialDay: day),
     );
     if (added == true) await _load();
   }
@@ -2795,7 +2797,8 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
                                           emptyAction: _isOffline
                                               ? null
                                               : FilledButton.tonalIcon(
-                                                  onPressed: _addPlace,
+                                                  onPressed: () => _addPlace(
+                                                      day: _selectedDay),
                                                   icon: const Icon(Icons.add,
                                                       size: 18),
                                                   label:

--- a/src/packages/flutter-app/lib/widgets/add_itinerary_item_dialog.dart
+++ b/src/packages/flutter-app/lib/widgets/add_itinerary_item_dialog.dart
@@ -6,6 +6,7 @@ import '../models/itinerary_item.dart';
 import '../models/place_search_result.dart';
 import '../providers/places_api_provider.dart';
 import '../providers/trips_provider.dart';
+import '../utils/trip_days.dart';
 
 /// Manually adds one place to a trip's itinerary: Google Places search picks a
 /// real place (coordinates/address auto-filled), with a typed-name fallback
@@ -35,13 +36,16 @@ class _AddItineraryItemDialogState
   bool _saving = false;
   String? _error;
 
-  int get _maxDay {
-    var max = 0;
-    for (final it in widget.trip.items ?? const <ItineraryItem>[]) {
-      if (it.day != null && it.day! > max) max = it.day!;
-    }
-    return max;
-  }
+  /// Days offered by the Day dropdown: the same span as the map's day chips
+  /// (trip date range or highest tagged day, whichever is later), so every
+  /// real trip day is offered — including trailing days with no items yet —
+  /// and any chip-selected [AddItineraryItemDialog.initialDay] has a
+  /// matching entry.
+  int get _dayCount => dayCount(
+        widget.trip.startDate,
+        widget.trip.endDate,
+        (widget.trip.items ?? const <ItineraryItem>[]).map((i) => i.day),
+      );
 
   /// The hub city of the chosen day's existing items, so the new place joins
   /// that city group. Without this the group key falls back to the address
@@ -62,7 +66,12 @@ class _AddItineraryItemDialogState
   @override
   void initState() {
     super.initState();
-    _day = widget.initialDay;
+    // Only accept a day the dropdown actually offers; a stale out-of-range
+    // value would trip DropdownButtonFormField's items assertion.
+    final initial = widget.initialDay;
+    _day = (initial != null && initial >= 1 && initial <= _dayCount + 1)
+        ? initial
+        : null;
   }
 
   @override
@@ -189,6 +198,9 @@ class _AddItineraryItemDialogState
                   Expanded(
                     child: DropdownButtonFormField<int?>(
                       initialValue: _day,
+                      // Fill the field and ellipsize instead of overflowing
+                      // when an item label outgrows the half-width column.
+                      isExpanded: true,
                       decoration: const InputDecoration(
                         labelText: 'Day',
                         border: OutlineInputBorder(),
@@ -197,13 +209,13 @@ class _AddItineraryItemDialogState
                       items: [
                         const DropdownMenuItem(
                             value: null, child: Text('Unscheduled')),
-                        for (var d = 1; d <= _maxDay; d++)
+                        for (var d = 1; d <= _dayCount; d++)
                           DropdownMenuItem(value: d, child: Text('Day $d')),
                         DropdownMenuItem(
-                            value: _maxDay + 1,
-                            child: Text(_maxDay == 0
+                            value: _dayCount + 1,
+                            child: Text(_dayCount == 0
                                 ? 'Day 1'
-                                : 'New day (${_maxDay + 1})')),
+                                : 'New day (${_dayCount + 1})')),
                       ],
                       onChanged: (v) => setState(() => _day = v),
                     ),
@@ -212,6 +224,7 @@ class _AddItineraryItemDialogState
                   Expanded(
                     child: DropdownButtonFormField<String?>(
                       initialValue: _timeOfDay,
+                      isExpanded: true,
                       decoration: const InputDecoration(
                         labelText: 'Time of day',
                         border: OutlineInputBorder(),

--- a/src/packages/flutter-app/test/trip_detail_day_chips_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_day_chips_test.dart
@@ -167,6 +167,27 @@ void main() {
     expect(map(tester).items, hasLength(3));
   });
 
+  testWidgets('the empty-day CTA opens Add place with that day preselected',
+      (WidgetTester tester) async {
+    await pumpScreen(tester);
+    await tapChip(tester, 'Day 3');
+
+    await tester.tap(find.descendant(
+      of: find.byType(TripMap),
+      matching: find.text('Add place'),
+    ));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(AlertDialog), findsOneWidget);
+    // Day 3 has no tagged items, so it's only offered because the dropdown
+    // spans the trip's dates; the CTA preselects it. Asserted via the form
+    // field's value — the dropdown renders every item's text offstage, so a
+    // text find would pass vacuously.
+    final dayField = tester.state<FormFieldState<int?>>(
+        find.byType(DropdownButtonFormField<int?>));
+    expect(dayField.value, 3);
+  });
+
   testWidgets('chips for days with nothing mappable render muted but stay '
       'tappable', (WidgetTester tester) async {
     await pumpScreen(tester);


### PR DESCRIPTION
## Summary
- Follow-up to #117: the map's empty-day "Add place" CTA opened the dialog with the Day dropdown on "Unscheduled" even though the user was already looking at a specific day. It now preselects that day.
- `_addPlace` takes an optional `day` and threads it to `AddItineraryItemDialog`'s existing (previously unused) `initialDay`; the itinerary-header button is unchanged.
- The dialog's Day dropdown now offers the same day span as the map chips (`dayCount`: trip date range or highest tagged day) instead of tagged days only — so trailing empty days like a fly-out day are real options, and any chip-selected day always has a matching dropdown item. An out-of-range `initialDay` falls back to Unscheduled instead of tripping the dropdown's items assertion.
- Both dropdowns get `isExpanded: true`, fixing a latent RenderFlex overflow (wide item labels vs the half-width column) that the new widget test surfaced.

## Testing
- `flutter test`: all 231 pass, including a new case asserting the CTA opens the dialog with the day's form-field value preselected (asserted via `FormFieldState.value` — the dropdown renders all item texts offstage, so a text find would pass vacuously).
- `flutter analyze`: only the 12 pre-existing infos.
- Manual: drove the dev stack headlessly on the 11-day Latin America trip — Day 11 empty-state CTA opens the dialog with "Day 11" preselected; the header Add place still defaults to "Unscheduled".

🤖 Generated with [Claude Code](https://claude.com/claude-code)