### PR TITLE
feat: co-planners can refine shared trips with the AI agent

### DIFF
--- a/specs/collaborator-refine/plan.md
+++ b/specs/collaborator-refine/plan.md
@@ -1,0 +1,82 @@
+# Plan: Collaborator AI Refine
+
+> **HOW.** Translates `spec.md` into a file-level technical approach. See
+> `../../CLAUDE.md` for repo conventions.
+
+## Technical Approach
+
+The refine panel already runs a trip-bound `/plan` session whose only write
+tool (`update_itinerary_section`) patches the bound trip row in place — it
+never calls `persistTrip`, so there is no lineage-fork risk on this path. The
+whole feature is therefore an authorization change: swap the trip-bound
+binding and the two in-session owner guards from `GetTripByIDAndOwner` to the
+existing `GetEditableTripByID` seam (owner OR active editor collaborator), and
+un-gate the Flutter refine entry points. Two supporting changes keep the
+system honest: a `FOR UPDATE` trip-row lock serializes concurrent
+whole-itinerary rewrites (pre-existing duplicate-items race under READ
+COMMITTED), and editor-facing responses null out `chat_id` so a collaborator
+can never seed a freeform `/plan` with the owner's session key and fork the
+lineage under their own account.
+
+## Go API Changes
+
+- `query/trips.sql`: new `GetTripForUpdate :one` (`SELECT … FOR UPDATE`);
+  regenerate with `make api-sqlc`.
+- `itinerary_section.go` `replaceTripSection`: lock the trip row first inside
+  the transaction.
+- `itinerary_item_handler.go` `reorderItineraryItemsHandler`: same lock at the
+  top of the reorder transaction (makes the stale-set 409 reliable).
+- `plan_handler.go` (trip binding): `GetEditableTripByID` instead of
+  `GetTripByIDAndOwner`; stash the trip's owner id on the session
+  (`boundTripOwnerID`) for analytics.
+- `plan_tools_extra.go`:
+  - `runGetTripTool` gains a `boundTripID` parameter — the bound trip resolves
+    via `GetEditableTripByID`; all other trip ids (and the list-trips branch)
+    stay caller-owned.
+  - `checkBookingTodoSession`: bound trip → editable seam; anything else stays
+    owner-scoped.
+- `trip_handler.go` `getTripHandler` + `collaborator_handler.go`
+  `listSharedWithMeHandler`: `resp.ChatID = nil` for editor access.
+- `plan_tool_registry.go`: `planSession.boundTripOwnerID` field;
+  `trip_refined` event gains `is_collaborator`.
+- Unchanged on purpose: `refineTripHandler` (owner-only, no app callers);
+  session persistence rules (trip-bound sessions never write
+  `plan_chat_sessions`); free-cap metering (per-caller).
+
+## Flutter Changes
+
+`lib/screens/trip_detail_screen.dart` only — no models/services/providers:
+- `_openRefine` / `_openChat`: drop the owner belt-and-braces guards.
+- Per-day refine icon, city-header refine icon, chat FAB: drop `isOwner` from
+  the gates (offline gate stays).
+- Header card: editors now get the co-planning banner **and** the
+  "Refine with AI" button (previously either/or).
+- Share menu and delete stay owner-only.
+
+## Contract Parity  ← anti-drift gate
+
+No new JSON fields. One behavioral row:
+
+| JSON key | Go type | Dart type | Nullable? | ✓ |
+|----------|---------|-----------|-----------|---|
+| `chat_id` | `*string` (now nil for editors) | `String?` | yes | ✓ |
+
+Flutter consumers of `chatId` are owner/admin-only surfaces (version history,
+resumable chats), each already null-guarded.
+
+## Cross-cutting
+
+- No env vars, no migrations, no gateway changes.
+
+## Verification
+
+- `make api-fmt && make api-vet`; full `go test` with `TEST_DATABASE_URL`.
+- New integration tests (`collaborator_integration_test.go`):
+  `TestCollaboratorCanRefineViaAgent` (fake-Anthropic drives
+  `update_itinerary_section`; asserts single trip row, in-place item rewrite,
+  owner read), `TestStrangerCannotRefineViaAgent`,
+  `TestCollaboratorResponsesOmitChatID`.
+- `make flutter-analyze` / `make flutter-test`.
+- Manual: two accounts via `make docker-dev`; co-planner refines a shared
+  trip; owner sees the change on reload; double-refine leaves a single clean
+  item set.

--- a/specs/collaborator-refine/spec.md
+++ b/specs/collaborator-refine/spec.md
@@ -1,0 +1,100 @@
+# Spec: Collaborator AI Refine
+
+## Context
+
+Co-planners (editor collaborators, specs/collaborative-editing) can hand-edit a
+shared trip but cannot use the AI refine agent — refine is owner-only. That
+splits the planning experience: the owner gets the product's best tool, invited
+friends get manual editing. This feature lets editor collaborators refine the
+shared trip with the AI exactly as the owner does, while keeping the trip's
+version lineage single and owner-owned. It also fixes a latent concurrency bug
+where two simultaneous whole-itinerary rewrites could merge into a duplicated
+itinerary.
+
+## User Stories
+
+- As a **co-planner**, I want **to use "Refine with AI" on a trip shared with
+  me** so that **I can contribute ideas without asking the owner to run them**.
+- As a **trip owner**, I want **a friend's AI refinements to land on my trip in
+  place** so that **the trip never forks or duplicates under their account**.
+- As a **trip owner**, I want **strangers kept out of the AI agent for my
+  trips** so that **sharing never widens write access beyond members**.
+
+## Acceptance Criteria
+
+- [ ] An editor collaborator sees the "Refine with AI" button, per-day and
+      per-city refine icons, and the trip-assistant chat button on a shared
+      trip, and can run a refinement end-to-end.
+- [ ] A collaborator's refinement rewrites the owner's trip in place: no new
+      trip version, no new trip under the collaborator's account; the owner
+      sees the change on next load.
+- [ ] A non-member requesting a trip-bound agent session is refused before
+      anything streams, with no existence leak.
+- [ ] Collaborators never receive the trip's planning-conversation key from
+      shared-trip responses.
+- [ ] Two simultaneous whole-itinerary writes (refine vs. refine, refine vs.
+      reorder) serialize — last write wins cleanly, never a merged/duplicated
+      item set.
+- [ ] A collaborator's refine session is ephemeral: it does not appear in
+      anyone's resumable chats.
+- [ ] Refine usage is metered against the person pressing the button (their
+      own free-tier session count, not the owner's).
+
+## API Surface
+
+No new endpoints. Behavior changes:
+
+### `POST /api/v1/plan` (trip-bound sessions)
+- **Purpose:** a session bound to a trip is now authorized for the trip's
+  owner **or an active editor collaborator** (previously owner-only).
+- **Errors:** unchanged shape — non-members get the same "trip not found"
+  stream error as an unknown trip id.
+- Inside the session, the agent's trip-read and booking-checklist tools accept
+  the bound trip for collaborators; every other trip reference remains
+  strictly caller-owned (a collaborator can never list or touch the owner's
+  other trips).
+
+### `GET /api/v1/trips/{id}` and `GET /api/v1/trips/shared-with-me`
+- **Response:** `chat_id` is null when the caller's access is `editor`
+  (still present for owners).
+
+## Data Model
+
+No schema changes. Refinement rewrites the bound trip's itinerary items in
+place; whole-itinerary rewrites now hold a trip-level write lock for the
+duration of the rewrite so concurrent writers serialize.
+
+## UI Behavior
+
+- **Trip detail (shared, editor access):** the header shows the co-planning
+  banner *and* the "Refine with AI" button (previously banner only). Per-day
+  and per-city refine icons and the trip-assistant chat button appear as they
+  do for owners. All refine entry points stay hidden offline.
+- **Happy path:** co-planner opens the shared trip → taps Refine → the refine
+  panel streams the agent → the section updates in place → the banner's
+  "your changes save for everyone" promise holds for AI edits too.
+- **States:** unchanged from the owner refine flow (streaming, error snack,
+  offline guard).
+
+## Edge Cases & Error States
+
+- Collaborator removed mid-session: the next tool write fails authorization
+  and surfaces the agent's normal error path.
+- Owner and collaborator refine simultaneously: writes serialize; the later
+  transaction wins wholesale (documented last-write-wins model).
+- Signed-out or non-member callers binding a trip id: refused before
+  streaming.
+
+## Out of Scope
+
+- Viewer-role membership (separate feature: share-ux-viewer-follow).
+- Freshness/notifications when a collaborator refines (separate feature:
+  shared-trip-freshness).
+- Collaborator access to the owner's planning chat history or resumable chats.
+- The legacy owner-only refine-session endpoint (unused by the app) keeps its
+  behavior.
+
+## Open Questions
+
+None — resolved during planning: refine cost meters to the caller; chat_id is
+withheld from editors; the unused legacy refine endpoint stays owner-only.

--- a/specs/collaborator-refine/tasks.md
+++ b/specs/collaborator-refine/tasks.md
@@ -1,0 +1,30 @@
+# Tasks: Collaborator AI Refine
+
+> Dependency-ordered. Work top to bottom; verification is last.
+
+## API (Go)
+
+- [x] `GetTripForUpdate` query + `make api-sqlc`
+- [x] Row lock in `replaceTripSection` and the reorder transaction
+- [x] Trip-bound `/plan` binding → `GetEditableTripByID`; stash
+      `boundTripOwnerID` on the session
+- [x] `runGetTripTool` + `checkBookingTodoSession` accept the bound trip via
+      the editable seam
+- [x] Null `chat_id` in editor responses (`getTripHandler`,
+      `listSharedWithMeHandler`)
+- [x] `is_collaborator` on the `trip_refined` event
+
+## UI (Flutter)
+
+- [x] Drop owner gates from `_openRefine`, `_openChat`, per-day/city refine
+      icons, chat FAB
+- [x] Header shows co-planning banner + Refine button for editors
+
+## Verification
+
+- [x] `go vet` + full `go test` (with `TEST_DATABASE_URL`) pass
+- [x] New integration tests: collaborator refine end-to-end, stranger refusal,
+      chat_id omission
+- [x] `flutter analyze` clean
+- [ ] Manual end-to-end via gateway (`make docker-dev`): co-planner refines,
+      owner sees the in-place update

--- a/src/packages/api/collaborator_handler.go
+++ b/src/packages/api/collaborator_handler.go
@@ -173,6 +173,8 @@ func listSharedWithMeHandler(w http.ResponseWriter, r *http.Request) {
 		resp.VersionCount = int(t.VersionCount)
 		resp.Cities = t.Cities
 		resp.Access = "editor"
+		// Owner's plan-session key — same fork hazard as getTripHandler.
+		resp.ChatID = nil
 		if t.OwnerName != "" {
 			name := t.OwnerName
 			resp.OwnerName = &name

--- a/src/packages/api/collaborator_integration_test.go
+++ b/src/packages/api/collaborator_integration_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -110,5 +112,129 @@ func TestCollaboratorListAndRemoval(t *testing.T) {
 	})
 	if add.Code != http.StatusNotFound {
 		t.Fatalf("removed editor add item = %d, want 404", add.Code)
+	}
+}
+
+// A joined editor can run the trip-bound refine agent: the section rewrite
+// lands on the owner's same trip row — no fork, no new version, and the owner
+// still reads the result.
+func TestCollaboratorCanRefineViaAgent(t *testing.T) {
+	resetDB(t)
+	newFakeAnthropic(t,
+		toolTurn("update_itinerary_section", `{"scope":"trip","items":[{"name":"Editor Cafe","latitude":37.98,"longitude":23.74,"day":1}]}`),
+		textTurn("Swapped the plan for the cafe."))
+
+	owner, ownerToken := createTestUser(t, "owner@example.com")
+	_, editorToken := createTestUser(t, "editor@example.com")
+	trip := createTestTrip(t, owner.ID, 2)
+	shareToken := createShare(t, ownerToken, trip.ID.String(), "editor")
+	if rec := joinShare(t, editorToken, shareToken); rec.Code >= 300 {
+		t.Fatalf("join = %d", rec.Code)
+	}
+
+	rec := doJSON(t, "POST", "/api/v1/plan", editorToken, PlanRequest{
+		TripID:   trip.ID.String(),
+		Messages: []PlanChatMessage{{Role: "user", Content: "replace everything with one cafe"}},
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("/plan = %d, want 200", rec.Code)
+	}
+	events := planEvents(t, rec.Body.String())
+	if updated := eventsOfType(events, "trip_updated"); len(updated) != 1 {
+		t.Fatalf("trip_updated events = %v, want exactly one", updated)
+	}
+	if errs := eventsOfType(events, "error"); len(errs) != 0 {
+		t.Fatalf("unexpected error events: %v", errs)
+	}
+	// A bound session must never create a new trip version — least of all one
+	// forked under the collaborator's account.
+	var tripCount int
+	if err := dbPool.QueryRow(context.Background(),
+		`SELECT count(*) FROM trips`).Scan(&tripCount); err != nil {
+		t.Fatalf("trips query: %v", err)
+	}
+	if tripCount != 1 {
+		t.Fatalf("trips after collaborator refine = %d, want 1", tripCount)
+	}
+	var count int
+	var name string
+	if err := dbPool.QueryRow(context.Background(),
+		`SELECT count(*), min(name) FROM itinerary_items WHERE trip_id = $1`,
+		trip.ID).Scan(&count, &name); err != nil {
+		t.Fatalf("items query: %v", err)
+	}
+	if count != 1 || name != "Editor Cafe" {
+		t.Fatalf("items after refine = %d/%q, want 1/\"Editor Cafe\"", count, name)
+	}
+	// The owner still owns and reads the refined trip.
+	get := doJSON(t, "GET", "/api/v1/trips/"+trip.ID.String(), ownerToken, nil)
+	if get.Code != http.StatusOK {
+		t.Fatalf("owner GET after collaborator refine = %d", get.Code)
+	}
+}
+
+// A non-member is refused the trip-bound agent before anything streams.
+func TestStrangerCannotRefineViaAgent(t *testing.T) {
+	resetDB(t)
+	newFakeAnthropic(t, textTurn("should never be reached"))
+
+	owner, _ := createTestUser(t, "owner@example.com")
+	_, strangerToken := createTestUser(t, "stranger@example.com")
+	trip := createTestTrip(t, owner.ID, 1)
+
+	rec := doJSON(t, "POST", "/api/v1/plan", strangerToken, PlanRequest{
+		TripID:   trip.ID.String(),
+		Messages: []PlanChatMessage{{Role: "user", Content: "rewrite this trip"}},
+	})
+	events := planEvents(t, rec.Body.String())
+	if errs := eventsOfType(events, "error"); len(errs) != 1 {
+		t.Fatalf("error events = %v, want exactly one", errs)
+	}
+	if updated := eventsOfType(events, "trip_updated"); len(updated) != 0 {
+		t.Fatalf("stranger produced trip_updated: %v", updated)
+	}
+}
+
+// The collaborator's editor chat_id exposure: shared trips must not leak the
+// owner's plan-session key (a collaborator seeding /plan with it would fork
+// the lineage under their own account).
+func TestCollaboratorResponsesOmitChatID(t *testing.T) {
+	resetDB(t)
+	owner, ownerToken := createTestUser(t, "owner@example.com")
+	_, editorToken := createTestUser(t, "editor@example.com")
+	trip := createTestTrip(t, owner.ID, 1)
+	shareToken := createShare(t, ownerToken, trip.ID.String(), "editor")
+	if rec := joinShare(t, editorToken, shareToken); rec.Code >= 300 {
+		t.Fatalf("join = %d", rec.Code)
+	}
+
+	get := doJSON(t, "GET", "/api/v1/trips/"+trip.ID.String(), editorToken, nil)
+	if get.Code != http.StatusOK {
+		t.Fatalf("editor GET = %d", get.Code)
+	}
+	if body := decode(t, get); body["chat_id"] != nil {
+		t.Fatalf("editor GET leaks chat_id: %v", body["chat_id"])
+	}
+	// Owner keeps seeing it (their own plan-session key).
+	ownerGet := doJSON(t, "GET", "/api/v1/trips/"+trip.ID.String(), ownerToken, nil)
+	if body := decode(t, ownerGet); body["chat_id"] == nil {
+		t.Fatalf("owner GET lost chat_id")
+	}
+
+	shared := doJSON(t, "GET", "/api/v1/trips/shared-with-me", editorToken, nil)
+	if shared.Code != http.StatusOK {
+		t.Fatalf("shared-with-me = %d", shared.Code)
+	}
+	var rows []map[string]any
+	if err := json.Unmarshal(shared.Body.Bytes(), &rows); err != nil {
+		t.Fatalf("shared-with-me decode: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("shared-with-me rows = %d, want 1", len(rows))
+	}
+	for _, row := range rows {
+		if row["chat_id"] != nil {
+			t.Fatalf("shared-with-me leaks chat_id: %v", row["chat_id"])
+		}
 	}
 }

--- a/src/packages/api/itinerary_item_handler.go
+++ b/src/packages/api/itinerary_item_handler.go
@@ -379,6 +379,13 @@ func reorderItineraryItemsHandler(w http.ResponseWriter, r *http.Request) {
 	defer tx.Rollback(ctx)
 	q := store.New(tx)
 
+	// Serialize against concurrent whole-itinerary rewrites (refine agent) —
+	// the stale-set 409 below is only reliable if the item set can't change
+	// between this read and commit.
+	if _, err := q.GetTripForUpdate(ctx, tripID); err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "could not reorder itinerary")
+		return
+	}
 	items, err := q.GetItineraryItemsByTrip(ctx, tripID)
 	if err != nil {
 		writeJSONError(w, http.StatusInternalServerError, "could not load itinerary")

--- a/src/packages/api/itinerary_section.go
+++ b/src/packages/api/itinerary_section.go
@@ -283,6 +283,11 @@ func replaceTripSection(ctx context.Context, tripID uuid.UUID, sel sectionSelect
 	defer tx.Rollback(ctx)
 	q := store.New(tx)
 
+	// Serialize whole-itinerary rewrites: a concurrent rewrite's delete would
+	// miss rows inserted after our snapshot, leaving both item sets merged.
+	if _, err := q.GetTripForUpdate(ctx, tripID); err != nil {
+		return err
+	}
 	existing, err := q.GetItineraryItemsByTrip(ctx, tripID)
 	if err != nil {
 		return err

--- a/src/packages/api/plan_handler.go
+++ b/src/packages/api/plan_handler.go
@@ -186,9 +186,11 @@ func planHandler(w http.ResponseWriter, r *http.Request) {
 		})
 	}()
 
-	// A trip-bound session must verifiably own the trip before anything streams;
-	// failing closed here guarantees a refine panel can never fall back to the
-	// version-creating create_itinerary flow.
+	// A trip-bound session must verifiably be editable by the caller (owner or
+	// editor collaborator) before anything streams; failing closed here
+	// guarantees a refine panel can never fall back to the version-creating
+	// create_itinerary flow. Collaborator refines patch the owner's trip row
+	// in place — the lineage never forks.
 	var boundTripID *uuid.UUID
 	if strings.TrimSpace(req.TripID) != "" {
 		tid, err := uuid.Parse(req.TripID)
@@ -196,11 +198,13 @@ func planHandler(w http.ResponseWriter, r *http.Request) {
 			sendSSE(w, "error", map[string]string{"message": "sign in to refine this trip"})
 			return
 		}
-		if _, err := store.New(dbPool).GetTripByIDAndOwner(r.Context(), store.GetTripByIDAndOwnerParams{ID: tid, UserID: uid}); err != nil {
+		boundTrip, err := store.New(dbPool).GetEditableTripByID(r.Context(), store.GetEditableTripByIDParams{ID: tid, UserID: uid})
+		if err != nil {
 			sendSSE(w, "error", map[string]string{"message": "trip not found"})
 			return
 		}
 		boundTripID = &tid
+		session.boundTripOwnerID = boundTrip.UserID
 	}
 	session.boundTripID = boundTripID
 

--- a/src/packages/api/plan_tool_registry.go
+++ b/src/packages/api/plan_tool_registry.go
@@ -38,6 +38,9 @@ type planSession struct {
 	authed      bool
 	uid         uuid.UUID
 	boundTripID *uuid.UUID
+	// boundTripOwnerID is the lineage owner of the bound trip (zero when
+	// unbound); differs from uid when an editor collaborator is refining.
+	boundTripOwnerID uuid.UUID
 
 	// tripID is the trip this session persisted or refined (nil if none);
 	// the handler's completion instrumentation reads it.
@@ -89,7 +92,7 @@ var planToolRegistry = []planTool{
 		run: runCreateItineraryTool, noResultEvent: true},
 	{def: savePrefsTool, enabled: authedOnly, run: runSavePreferencesTool},
 	{def: getTripTool, enabled: authedOnly, run: func(s *planSession, input json.RawMessage) (string, bool) {
-		return runGetTripTool(s.ctx, s.authed, s.uid, input)
+		return runGetTripTool(s.ctx, s.authed, s.uid, s.boundTripID, input)
 	}},
 	{def: addBookingTodoTool, enabled: authedOnly, run: runAddBookingTodoTool},
 	{def: updateBookingTodoTool, enabled: authedOnly, run: runUpdateBookingTodoTool},
@@ -406,7 +409,8 @@ func runUpdateItinerarySectionTool(s *planSession, input json.RawMessage) (strin
 	sendSSE(s.w, "trip_updated", map[string]string{"trip_id": s.boundTripID.String()})
 	s.tripID = s.boundTripID
 	go recordEvent(s.uid, "trip_refined", s.boundTripID, map[string]any{
-		"scope": in.Scope,
+		"scope":           in.Scope,
+		"is_collaborator": s.uid != s.boundTripOwnerID,
 	})
 	return "Section updated — the traveler's trip page has refreshed.", false
 }

--- a/src/packages/api/plan_tools_extra.go
+++ b/src/packages/api/plan_tools_extra.go
@@ -152,7 +152,7 @@ func runGetWeatherTool(ctx context.Context, input json.RawMessage) (string, bool
 	return summarizeWeather(report), false
 }
 
-func runGetTripTool(ctx context.Context, authed bool, uid uuid.UUID, input json.RawMessage) (string, bool) {
+func runGetTripTool(ctx context.Context, authed bool, uid uuid.UUID, boundTripID *uuid.UUID, input json.RawMessage) (string, bool) {
 	if !authed {
 		return "The traveler is not signed in, so there are no saved trips to read. Continue planning in this conversation.", true
 	}
@@ -193,7 +193,15 @@ func runGetTripTool(ctx context.Context, authed bool, uid uuid.UUID, input json.
 	if err != nil {
 		return "That trip_id is not valid; call get_trip without arguments to list trips.", true
 	}
-	trip, err := q.GetTripByIDAndOwner(ctx, store.GetTripByIDAndOwnerParams{ID: tid, UserID: uid})
+	// The bound trip of a refine session may be one the caller co-plans rather
+	// than owns; everything else stays strictly caller-owned (a collaborator
+	// must never browse the owner's other trips).
+	var trip store.Trip
+	if boundTripID != nil && tid == *boundTripID {
+		trip, err = q.GetEditableTripByID(ctx, store.GetEditableTripByIDParams{ID: tid, UserID: uid})
+	} else {
+		trip, err = q.GetTripByIDAndOwner(ctx, store.GetTripByIDAndOwnerParams{ID: tid, UserID: uid})
+	}
 	if err != nil {
 		return "No such trip for this traveler; call get_trip without arguments to list trips.", true
 	}
@@ -266,8 +274,13 @@ func checkBookingTodoSession(s *planSession, tripID string) (uuid.UUID, string, 
 	if err != nil {
 		return uuid.Nil, "That trip_id is not valid; call get_trip to find the right one.", true
 	}
-	// Ownership: the agent may only write to the caller's own trips.
-	if _, err := store.New(dbPool).GetTripByIDAndOwner(s.ctx, store.GetTripByIDAndOwnerParams{ID: tid, UserID: s.uid}); err != nil {
+	// The agent may write to the caller's own trips, or to the bound trip of
+	// a refine session the caller can edit (owner or collaborator).
+	if s.boundTripID != nil && tid == *s.boundTripID {
+		if _, err := store.New(dbPool).GetEditableTripByID(s.ctx, store.GetEditableTripByIDParams{ID: tid, UserID: s.uid}); err != nil {
+			return uuid.Nil, "No such trip for this traveler; call get_trip to find the right one.", true
+		}
+	} else if _, err := store.New(dbPool).GetTripByIDAndOwner(s.ctx, store.GetTripByIDAndOwnerParams{ID: tid, UserID: s.uid}); err != nil {
 		return uuid.Nil, "No such trip for this traveler; call get_trip to find the right one.", true
 	}
 	return tid, "", false

--- a/src/packages/api/plan_tools_extra_test.go
+++ b/src/packages/api/plan_tools_extra_test.go
@@ -132,7 +132,7 @@ func TestGetTripWeatherCaches(t *testing.T) {
 }
 
 func TestGetTripToolAnonymous(t *testing.T) {
-	msg, isErr := runGetTripTool(context.Background(), false, uuid.Nil, json.RawMessage(`{}`))
+	msg, isErr := runGetTripTool(context.Background(), false, uuid.Nil, nil, json.RawMessage(`{}`))
 	if !isErr || !strings.Contains(msg, "not signed in") {
 		t.Fatalf("anonymous get_trip = %q (err=%v)", msg, isErr)
 	}
@@ -166,19 +166,19 @@ func TestGetTripToolListsAndReads(t *testing.T) {
 	trip := createTestTrip(t, owner.ID, 2)
 	createTestTrip(t, other.ID, 1) // must never appear for owner
 
-	list, isErr := runGetTripTool(context.Background(), true, owner.ID, json.RawMessage(`{}`))
+	list, isErr := runGetTripTool(context.Background(), true, owner.ID, nil, json.RawMessage(`{}`))
 	if isErr || !strings.Contains(list, trip.ID.String()) || !strings.Contains(list, "saved trips (1)") {
 		t.Fatalf("list = %q (err=%v)", list, isErr)
 	}
 
-	detail, isErr := runGetTripTool(context.Background(), true, owner.ID,
+	detail, isErr := runGetTripTool(context.Background(), true, owner.ID, nil,
 		json.RawMessage(`{"trip_id":"`+trip.ID.String()+`"}`))
 	if isErr || !strings.Contains(detail, "Place 1") || !strings.Contains(detail, "2 places") {
 		t.Fatalf("detail = %q (err=%v)", detail, isErr)
 	}
 
 	// Cross-user read must fail closed.
-	_, isErr = runGetTripTool(context.Background(), true, other.ID,
+	_, isErr = runGetTripTool(context.Background(), true, other.ID, nil,
 		json.RawMessage(`{"trip_id":"`+trip.ID.String()+`"}`))
 	if !isErr {
 		t.Fatal("cross-user get_trip did not error")
@@ -362,7 +362,7 @@ func TestGetTripToolShowsBookingChecklist(t *testing.T) {
 	todoID := seedAgentTodo(t, s, trip.ID, "Book flights EWR to CUR")
 	seedAutoTodo(t, trip.ID)
 
-	detail, isErr := runGetTripTool(context.Background(), true, owner.ID,
+	detail, isErr := runGetTripTool(context.Background(), true, owner.ID, nil,
 		json.RawMessage(`{"trip_id":"`+trip.ID.String()+`"}`))
 	if isErr {
 		t.Fatalf("detail errored: %q", detail)

--- a/src/packages/api/query/trips.sql
+++ b/src/packages/api/query/trips.sql
@@ -109,6 +109,13 @@ UPDATE itinerary_items SET position = $3 WHERE id = $1 AND trip_id = $2;
 -- Itinerary-item writes don't touch the trips row, so bump updated_at by hand.
 UPDATE trips SET updated_at = now() WHERE id = $1;
 
+-- name: GetTripForUpdate :one
+-- Row-locks the trip for the duration of the transaction. Full-itinerary
+-- rewrites (replaceTripSection) and reorders read-then-write the whole item
+-- set; without this lock two concurrent writers interleave under READ
+-- COMMITTED and both item sets survive the delete/reinsert.
+SELECT * FROM trips WHERE id = $1 FOR UPDATE;
+
 -- name: UpdateTrip :one
 UPDATE trips
 SET title      = COALESCE(sqlc.narg('title'), title),

--- a/src/packages/api/store/trips.sql.go
+++ b/src/packages/api/store/trips.sql.go
@@ -266,6 +266,32 @@ func (q *Queries) GetTripByIDAndOwner(ctx context.Context, arg GetTripByIDAndOwn
 	return i, err
 }
 
+const getTripForUpdate = `-- name: GetTripForUpdate :one
+SELECT id, user_id, created_at, updated_at, title, start_date, end_date, status, chat_id, summary FROM trips WHERE id = $1 FOR UPDATE
+`
+
+// Row-locks the trip for the duration of the transaction. Full-itinerary
+// rewrites (replaceTripSection) and reorders read-then-write the whole item
+// set; without this lock two concurrent writers interleave under READ
+// COMMITTED and both item sets survive the delete/reinsert.
+func (q *Queries) GetTripForUpdate(ctx context.Context, id uuid.UUID) (Trip, error) {
+	row := q.db.QueryRow(ctx, getTripForUpdate, id)
+	var i Trip
+	err := row.Scan(
+		&i.ID,
+		&i.UserID,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.Title,
+		&i.StartDate,
+		&i.EndDate,
+		&i.Status,
+		&i.ChatID,
+		&i.Summary,
+	)
+	return i, err
+}
+
 const listLatestTripsByOwner = `-- name: ListLatestTripsByOwner :many
 SELECT latest.id, latest.user_id, latest.created_at, latest.updated_at,
        latest.title, latest.start_date, latest.end_date, latest.status,

--- a/src/packages/api/trip_handler.go
+++ b/src/packages/api/trip_handler.go
@@ -349,6 +349,10 @@ func getTripHandler(w http.ResponseWriter, r *http.Request) {
 		resp.Access = "owner"
 	} else {
 		resp.Access = "editor"
+		// The chat_id keys the OWNER's plan sessions; a collaborator seeding a
+		// freeform /plan chat with it would fork the lineage under their own
+		// account. Refine binds by trip_id, so editors never need it.
+		resp.ChatID = nil
 		if owner, err := q.GetUserByID(r.Context(), trip.UserID); err == nil &&
 			owner.DisplayName != nil && *owner.DisplayName != "" {
 			resp.OwnerName = owner.DisplayName

--- a/src/packages/flutter-app/lib/models/trip.dart
+++ b/src/packages/flutter-app/lib/models/trip.dart
@@ -58,6 +58,10 @@ class Trip {
     this.ownerName,
   });
 
+  /// True when the current user may edit this trip: owner or editor
+  /// co-planner. Viewer-role members (future) are read-only.
+  bool get canEdit => access == null || access == 'owner' || access == 'editor';
+
   /// True when the current user owns this trip (missing access ⇒ owner,
   /// for responses that predate collaboration).
   bool get isOwner => access == null || access == 'owner';

--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -821,12 +821,9 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
     // Chat/refine needs the network; also keeps the refine panel from ever
     // observing a cached (read-only) trip.
     if (_guardOffline()) return;
-    // AI refine is owner-only (keeps the version lineage single-writer);
-    // the buttons are hidden for editors, this is the belt-and-braces guard.
-    if (!trip.isOwner) {
-      _showSnack('Only the trip owner can refine with AI.');
-      return;
-    }
+    // Owners and editor co-planners refine; viewer-role members are
+    // read-only. Buttons are hidden, this is the belt-and-braces guard.
+    if (!trip.canEdit) return;
     final items = trip.items ?? [];
     if (items.isEmpty) {
       _showSnack('Add some places before refining with AI.');
@@ -848,8 +845,9 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
   /// otherwise starts a fresh whole-trip assistant session.
   void _openChat(Trip trip) {
     if (_guardOffline()) return;
-    // The FAB is hidden for viewers; belt-and-braces like _openRefine.
-    if (!trip.isOwner) return;
+    // The FAB is hidden for read-only viewers; belt-and-braces like
+    // _openRefine.
+    if (!trip.canEdit) return;
     final hasConversation =
         ref.read(tripRefineProvider(widget.tripId)).messages.isNotEmpty;
     if (hasConversation) {
@@ -1265,9 +1263,9 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
             }
           });
         },
-            // Refine is owner-only (and online-only); editors and offline
-            // viewers get no per-day refine icon.
-            (!_isOffline && (_trip?.isOwner ?? true))
+            // Refine needs the network; owners and editor co-planners both
+            // get the per-day refine icon (viewers don't).
+            (!_isOffline && (_trip?.canEdit ?? true))
                 ? () {
                     final trip = _trip;
                     if (trip == null) return;
@@ -1364,7 +1362,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
                   // 'Other places' has no hub the section tool can target;
                   // refine also needs the network.
                   if (group.label != 'Other places' &&
-                      trip.isOwner &&
+                      trip.canEdit &&
                       !_isOffline)
                     IconButton(
                       icon: const Icon(Icons.auto_awesome, size: 16),
@@ -2519,7 +2517,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
               ],
             ),
             const SizedBox(height: 12),
-            if (!trip.isOwner)
+            if (!trip.isOwner) ...[
               Row(
                 children: [
                   Icon(Icons.group_outlined,
@@ -2535,8 +2533,10 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
                     ),
                   ),
                 ],
-              )
-            else
+              ),
+              const SizedBox(height: 12),
+            ],
+            if (trip.canEdit)
               SizedBox(
                 width: double.infinity,
                 child: FilledButton.tonalIcon(
@@ -2597,7 +2597,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
       // the panel is docked (redundant), on narrow it would overlap the sheet.
       floatingActionButton: (trip != null &&
               !_panelOpen &&
-              trip.isOwner &&
+              trip.canEdit &&
               !_isOffline &&
               (trip.items?.isNotEmpty ?? false))
           ? FloatingActionButton(

--- a/src/packages/flutter-app/test/trip_detail_chat_fab_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_chat_fab_test.dart
@@ -117,6 +117,14 @@ void main() {
     expect(find.byType(FloatingActionButton), findsNothing);
   });
 
+  testWidgets('FAB shows for editor co-planners (specs/collaborator-refine)',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(_app(_trip(access: 'editor')));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(FloatingActionButton), findsOneWidget);
+  });
+
   testWidgets('reopening via the FAB resumes the conversation, not a reset',
       (WidgetTester tester) async {
     await tester.pumpWidget(_app(_trip()));


### PR DESCRIPTION
## Summary

Sharing v2, PR 1 of 4 (specs/collaborator-refine). Editor collaborators can now use the AI refine agent on trips shared with them:

- **Refine surface for editors**: header "Refine with AI" button, per-day/per-city refine icons, and the trip-assistant FAB now show for editor co-planners, gated on a new `Trip.canEdit` so future viewer-role members stay read-only.
- **Authz**: the trip-bound `/plan` binding and the in-session `get_trip`/booking-todo guards accept the bound trip via `GetEditableTripByID`; every other trip reference stays strictly caller-owned. Rewrites land on the owner's trip row in place — no fork, no new version, metered against the caller's own plan-session caps.
- **Lineage-fork guard**: editor responses (`GET /trips/{id}`, `GET /trips/shared-with-me`) null out `chat_id` — the owner's plan-session key would otherwise let a collaborator fork the lineage via a freeform plan chat.
- **Concurrency fix (pre-existing race)**: `replaceTripSection` and the reorder transaction now take a `FOR UPDATE` trip-row lock; previously two concurrent whole-itinerary rewrites could interleave under READ COMMITTED and merge into a duplicated item set.

## Testing

- New integration tests: `TestCollaboratorCanRefineViaAgent` (fake-Anthropic harness drives `update_itinerary_section`; asserts single trip row, in-place rewrite, owner read), `TestStrangerCannotRefineViaAgent`, `TestCollaboratorResponsesOmitChatID`.
- Full Go suite passes with `TEST_DATABASE_URL`; `flutter analyze` clean; all 240 Flutter tests pass (FAB test extended: hidden for viewers, shown for editors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)