### PR TITLE
feat: shared-trip freshness polling + 'Updated by X' attribution

### DIFF
--- a/specs/shared-trip-freshness/plan.md
+++ b/specs/shared-trip-freshness/plan.md
@@ -1,0 +1,67 @@
+# Plan: Shared-Trip Freshness & Edit Attribution
+
+> **HOW.** See `../../CLAUDE.md` for repo conventions.
+
+## Technical Approach
+
+One nullable column (`trips.updated_by`), stamped through the existing
+`TouchTrip` choke point, plus a cheap authorized status endpoint the client
+polls on a guarded 25s timer. No new tables: the UI only needs "who edited
+last", and the choke point is where a future `trip_activity` log/notification
+outbox would hook in. Passive load paths (booking-todo sync) explicitly never
+stamp — otherwise every reader looks like an editor and polling clients chase
+each other's refreshes.
+
+## Go API Changes
+
+- Migration `migrations/00035_trip_updated_by.sql`: `ALTER TABLE trips ADD
+  COLUMN updated_by uuid REFERENCES users(id) ON DELETE SET NULL`.
+- `query/trips.sql`: `TouchTrip` gains `updated_by = $2` (invariant comment:
+  real edits only); new `GetTripStatusByID` (owner-or-collaborator WHERE) and
+  `HasActiveCollaborators`; `CreateTrip` stamps the creator. `make api-sqlc`.
+- `trip_handler.go`: `touchedBy(tripID, r)` param helper;
+  `tripStatusHandler` (`GET /trips/{id}/status`, default limiter — it's
+  polled); `TripResponse` gains `updated_by_name` (omitted for self-edits) +
+  `shared` (owner-side EXISTS); patchTrip stamps post-update.
+- Stamp sites added: accommodation add/delete, segment add/delete,
+  booking-todo add/patch/delete (`_ = TouchTrip(...)` best-effort after
+  commit), agent booking-todo tools (`touchTripAs`), `replaceTripSection`
+  (actor param threaded from the plan session, also covers collaborator
+  refines). **Excluded**: `syncBookingTodosHandler`.
+- Route in `main.go` next to the trip detail routes.
+
+## Flutter Changes
+
+- `models/trip.dart`: `updatedByName`, `shared` (+ codegen).
+- `services/trips_api_service.dart`: `getTripStatus(id)` returning a record.
+- `screens/trip_detail_screen.dart`: `WidgetsBindingObserver` mixin;
+  `Timer.periodic(25s)` started/stopped by `_syncStatusPolling()` after every
+  load and on lifecycle changes; `_statusTick()` skips offline / panel-open /
+  refresh-in-flight and calls the existing `_refresh()` when the server
+  timestamp is newer; "Updated by X · 2m ago" line in the header card
+  (`_relativeTime` helper).
+
+## Contract Parity  ← anti-drift gate
+
+| JSON key | Go type | Dart type | Nullable? | ✓ |
+|----------|---------|-----------|-----------|---|
+| `updated_by_name` | `*string` | `String?` | yes | ✓ |
+| `shared` | `bool,omitempty` | `bool?` | yes | ✓ |
+| status `updated_at` | `time.Time` | `DateTime` (parsed) | no | ✓ |
+| status `updated_by` | `*string` | `String?` | yes | ✓ |
+| status `updated_by_name` | `*string` | `String?` | yes | ✓ |
+
+## Cross-cutting
+
+- No env vars; no gateway changes; migration runs on boot as usual.
+
+## Verification
+
+- Integration tests (`trip_status_integration_test.go`): status authz
+  (owner/editor 200, stranger 404, anon 401); collaborator edit → owner sees
+  attribution, editor's own view omits it, status carries the editor id;
+  passive booking-todo sync stamps nothing.
+- `make api-fmt && make api-vet`; full `go test`; `make flutter-build-models`;
+  `flutter analyze` + `flutter test`.
+- Manual: two browser sessions on one shared trip; edit on one side appears
+  on the other within ~30s with the attribution line.

--- a/specs/shared-trip-freshness/spec.md
+++ b/specs/shared-trip-freshness/spec.md
@@ -1,0 +1,91 @@
+# Spec: Shared-Trip Freshness & Edit Attribution
+
+## Context
+
+Co-planners on a shared trip only see each other's changes after a manual
+pull-to-refresh, and nothing says who changed what — two people planning
+together are effectively working blind between reloads. This feature makes an
+open shared trip feel current without heavy machinery: the screen quietly
+checks for remote edits and refreshes itself, and a subtle "Updated by Maria ·
+2m ago" line credits the last editor. It deliberately stops short of realtime
+sync, presence, or notifications.
+
+## User Stories
+
+- As a **co-planner**, I want **the trip screen to pick up my friend's changes
+  on its own** so that **we can plan together without constantly refreshing**.
+- As a **trip owner**, I want **to see who last changed the trip and when** so
+  that **a surprise edit has a name attached**.
+- As a **traveler**, I want **my own edits left unlabeled** so that **the
+  attribution line only appears when it carries news**.
+
+## Acceptance Criteria
+
+- [ ] With a shared trip open on two devices, an edit on one appears on the
+      other within ~30 seconds, with no user action.
+- [ ] The trip header shows "Updated by {name} · {relative time}" when the
+      last content edit was made by someone other than the viewer; it never
+      shows for the viewer's own edits.
+- [ ] Every content edit is attributed: items, stays, transport segments,
+      booking-checklist changes, title/date/status changes, and AI
+      refinements — whether made in the UI or by the agent.
+- [ ] Merely opening or reloading a trip never marks it as edited (the
+      passive booking-checklist sync does not stamp attribution).
+- [ ] Polling only happens while a shared trip is open, in the foreground,
+      and online; unshared trips never poll.
+- [ ] Strangers cannot read a trip's freshness status (same not-found posture
+      as the trip itself).
+
+## API Surface
+
+### `GET /api/v1/trips/{id}/status`
+- **Purpose:** cheap freshness poll for an open shared trip.
+- **Request:** authenticated; no body.
+- **Response:** `updated_at`, plus `updated_by` (user id) and
+  `updated_by_name` when the last editor is known.
+- **Errors:** 404 for non-members and unknown ids (no existence leak); 401
+  unauthenticated.
+
+### `GET /api/v1/trips/{id}` (response additions)
+- `updated_by_name`: display name of the last editor, omitted when unknown or
+  when the caller made the edit.
+- `shared`: true on an owner's trip that has active co-planners — the signal
+  that polling is worthwhile (editors poll based on their access alone).
+
+## Data Model
+
+- **Trip** gains a *last edited by* reference (nullable; unknown for
+  pre-feature rows, cleared if the editor's account is deleted). All content
+  writes record it through the single existing "touch the trip" choke point —
+  the same place a future activity log or notification outbox would hook in.
+
+## UI Behavior
+
+- **Trip detail:** while a shared trip is open, the screen checks freshness
+  every ~25s; when the server's `updated_at` is newer than the loaded copy,
+  the existing silent refresh runs (no spinner, no scroll jump). The
+  attribution line renders under the header controls in muted body-small
+  type.
+- **Lifecycle:** polling stops when the app backgrounds and restarts (with an
+  immediate catch-up check) on resume; it never runs offline, while the
+  refine panel is streaming, or while another refresh is in flight.
+- **States:** poll failures are swallowed — no error UI, no offline flip.
+
+## Edge Cases & Error States
+
+- Editor's account deleted: attribution reverts to unknown; no broken name.
+- Two clients polling simultaneously: reads are cheap single-row lookups;
+  refreshes coalesce through the existing silent-refresh queue.
+- Clock skew is irrelevant: the client compares the server's own timestamps.
+
+## Out of Scope
+
+- WebSockets/SSE between users, presence, typing indicators.
+- Push or in-app notifications; unread badges.
+- Per-item "edited by" chips or an activity-feed screen.
+- Polling on the trips list.
+
+## Open Questions
+
+None — resolved during planning: 25s interval, self-attribution hidden,
+activity log deferred (the touch choke point is the future hook).

--- a/specs/shared-trip-freshness/tasks.md
+++ b/specs/shared-trip-freshness/tasks.md
@@ -1,0 +1,31 @@
+# Tasks: Shared-Trip Freshness & Edit Attribution
+
+> Dependency-ordered. Work top to bottom; verification is last.
+
+## API (Go)
+
+- [x] Migration 00035 `trips.updated_by`
+- [x] `TouchTrip(id, updated_by)` + `GetTripStatusByID` +
+      `HasActiveCollaborators` + `CreateTrip` creator stamp; `make api-sqlc`
+- [x] `touchedBy` helper; stamps in item/accommodation/segment/booking-todo
+      handlers, agent todo tools, `replaceTripSection` (actor param),
+      patchTrip; sync handler explicitly excluded
+- [x] `tripStatusHandler` + route; `TripResponse.updated_by_name`/`shared`
+
+## Models & codegen (Flutter)
+
+- [x] `Trip.updatedByName` / `Trip.shared`; `make flutter-build-models`
+- [x] Contract Parity table complete
+
+## UI (Flutter)
+
+- [x] `getTripStatus` service method
+- [x] Lifecycle-aware 25s poll in trip detail (`_syncStatusPolling` /
+      `_statusTick`), guarded against offline/panel/in-flight refresh
+- [x] "Updated by X · 2m ago" header line
+
+## Verification
+
+- [x] `go vet` + full `go test` pass (3 new integration tests)
+- [x] `flutter analyze` clean; all Flutter tests pass
+- [ ] Manual two-session check via gateway (`make docker-dev`)

--- a/src/packages/api/accommodation_handler.go
+++ b/src/packages/api/accommodation_handler.go
@@ -116,6 +116,8 @@ func addAccommodationHandler(w http.ResponseWriter, r *http.Request) {
 		writeJSONError(w, http.StatusInternalServerError, "could not save accommodation")
 		return
 	}
+	// Best-effort attribution/freshness bump — the stay itself committed.
+	_ = store.New(dbPool).TouchTrip(r.Context(), touchedBy(tripID, r))
 	writeJSON(w, http.StatusCreated, toAccommodationResponse(acc))
 }
 
@@ -140,5 +142,6 @@ func deleteAccommodationHandler(w http.ResponseWriter, r *http.Request) {
 		writeJSONError(w, http.StatusNotFound, "accommodation not found")
 		return
 	}
+	_ = store.New(dbPool).TouchTrip(r.Context(), touchedBy(tripID, r))
 	w.WriteHeader(http.StatusNoContent)
 }

--- a/src/packages/api/booking_todo_handler.go
+++ b/src/packages/api/booking_todo_handler.go
@@ -271,6 +271,9 @@ func addBookingTodoHandler(w http.ResponseWriter, r *http.Request) {
 		writeJSONError(w, http.StatusInternalServerError, "could not save booking todo")
 		return
 	}
+	// Best-effort attribution/freshness bump — the todo itself committed.
+	// (syncBookingTodosHandler must NEVER stamp: it runs on every trip load.)
+	_ = store.New(dbPool).TouchTrip(r.Context(), touchedBy(tripID, r))
 	writeJSON(w, http.StatusCreated, toBookingTodoResponse(todo))
 }
 
@@ -315,6 +318,7 @@ func patchBookingTodoHandler(w http.ResponseWriter, r *http.Request) {
 		}
 		go recordEvent(user.ID, "booking_marked_booked", &tripID, meta)
 	}
+	_ = store.New(dbPool).TouchTrip(r.Context(), touchedBy(tripID, r))
 	writeJSON(w, http.StatusOK, toBookingTodoResponse(todo))
 }
 
@@ -339,6 +343,7 @@ func deleteBookingTodoHandler(w http.ResponseWriter, r *http.Request) {
 		writeJSONError(w, http.StatusNotFound, "booking todo not found")
 		return
 	}
+	_ = store.New(dbPool).TouchTrip(r.Context(), touchedBy(tripID, r))
 	w.WriteHeader(http.StatusNoContent)
 }
 

--- a/src/packages/api/itinerary_item_handler.go
+++ b/src/packages/api/itinerary_item_handler.go
@@ -165,7 +165,7 @@ func addItineraryItemHandler(w http.ResponseWriter, r *http.Request) {
 		writeJSONError(w, http.StatusInternalServerError, "could not save place")
 		return
 	}
-	if err := q.TouchTrip(ctx, tripID); err != nil {
+	if err := q.TouchTrip(ctx, touchedBy(tripID, r)); err != nil {
 		writeJSONError(w, http.StatusInternalServerError, "could not save place")
 		return
 	}
@@ -284,7 +284,7 @@ func patchItineraryItemHandler(w http.ResponseWriter, r *http.Request) {
 		writeJSONError(w, http.StatusNotFound, "item not found")
 		return
 	}
-	if err := store.New(dbPool).TouchTrip(ctx, tripID); err != nil {
+	if err := store.New(dbPool).TouchTrip(ctx, touchedBy(tripID, r)); err != nil {
 		writeJSONError(w, http.StatusInternalServerError, "could not save place")
 		return
 	}
@@ -339,7 +339,7 @@ func deleteItineraryItemHandler(w http.ResponseWriter, r *http.Request) {
 		writeJSONError(w, http.StatusInternalServerError, "could not delete place")
 		return
 	}
-	if err := q.TouchTrip(ctx, tripID); err != nil {
+	if err := q.TouchTrip(ctx, touchedBy(tripID, r)); err != nil {
 		writeJSONError(w, http.StatusInternalServerError, "could not delete place")
 		return
 	}
@@ -418,7 +418,7 @@ func reorderItineraryItemsHandler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-	if err := q.TouchTrip(ctx, tripID); err != nil {
+	if err := q.TouchTrip(ctx, touchedBy(tripID, r)); err != nil {
 		writeJSONError(w, http.StatusInternalServerError, "could not reorder itinerary")
 		return
 	}

--- a/src/packages/api/itinerary_section.go
+++ b/src/packages/api/itinerary_section.go
@@ -275,7 +275,7 @@ func itemParamsFromLocation(tripID uuid.UUID, position int32, loc map[string]any
 // current items, splice the targeted section, then reinsert everything with a
 // dense 0-based position sequence. Item ids are not stable across a rewrite;
 // nothing external references them.
-func replaceTripSection(ctx context.Context, tripID uuid.UUID, sel sectionSelector, newLocs []map[string]any) error {
+func replaceTripSection(ctx context.Context, tripID, actorID uuid.UUID, sel sectionSelector, newLocs []map[string]any) error {
 	tx, err := dbPool.Begin(ctx)
 	if err != nil {
 		return err
@@ -304,7 +304,9 @@ func replaceTripSection(ctx context.Context, tripID uuid.UUID, sel sectionSelect
 			return err
 		}
 	}
-	if err := q.TouchTrip(ctx, tripID); err != nil {
+	if err := q.TouchTrip(ctx, store.TouchTripParams{
+		ID: tripID, UpdatedBy: pgtype.UUID{Bytes: actorID, Valid: true},
+	}); err != nil {
 		return err
 	}
 	return tx.Commit(ctx)

--- a/src/packages/api/main.go
+++ b/src/packages/api/main.go
@@ -715,6 +715,7 @@ func buildRouter() *mux.Router {
 	api.Handle("/trips/{id}", authMiddleware(http.HandlerFunc(getTripHandler))).Methods("GET")
 	api.Handle("/trips/{id}", authMiddleware(http.HandlerFunc(patchTripHandler))).Methods("PATCH")
 	api.Handle("/trips/{id}", authMiddleware(http.HandlerFunc(deleteTripHandler))).Methods("DELETE")
+	api.Handle("/trips/{id}/status", authMiddleware(http.HandlerFunc(tripStatusHandler))).Methods("GET")
 	api.Handle("/trips/{id}/refine", strict(authMiddleware(http.HandlerFunc(refineTripHandler)))).Methods("POST")
 	api.Handle("/trips/{id}/share", authMiddleware(http.HandlerFunc(createShareHandler))).Methods("POST")
 	api.Handle("/trips/{id}/share", authMiddleware(http.HandlerFunc(revokeShareHandler))).Methods("DELETE")

--- a/src/packages/api/migrations/00035_trip_updated_by.sql
+++ b/src/packages/api/migrations/00035_trip_updated_by.sql
@@ -1,0 +1,11 @@
+-- +goose Up
+-- Who last touched the trip's content — the "Updated by Maria · 2m ago"
+-- attribution for shared trips (specs/shared-trip-freshness). NULL means
+-- unknown (pre-feature rows). updated_at itself is trigger-maintained.
+-- All content writes stamp this via the TouchTrip choke point; a future
+-- trip_activity log / notification outbox would hang off that same choke
+-- point rather than adding columns here.
+ALTER TABLE trips ADD COLUMN updated_by uuid REFERENCES users(id) ON DELETE SET NULL;
+
+-- +goose Down
+ALTER TABLE trips DROP COLUMN updated_by;

--- a/src/packages/api/plan_tool_registry.go
+++ b/src/packages/api/plan_tool_registry.go
@@ -403,7 +403,7 @@ func runUpdateItinerarySectionTool(s *planSession, input json.RawMessage) (strin
 	}
 	// Same in-block walking-distance cleanup create_itinerary gets.
 	in.Items = reorderItineraryByDistance(in.Items)
-	if err := replaceTripSection(s.ctx, *s.boundTripID, sectionSelector{Scope: in.Scope, Day: in.Day, City: in.City}, in.Items); err != nil {
+	if err := replaceTripSection(s.ctx, *s.boundTripID, s.uid, sectionSelector{Scope: in.Scope, Day: in.Day, City: in.City}, in.Items); err != nil {
 		return fmt.Sprintf("Could not update the section: %v", err), true
 	}
 	sendSSE(s.w, "trip_updated", map[string]string{"trip_id": s.boundTripID.String()})

--- a/src/packages/api/plan_tools_extra.go
+++ b/src/packages/api/plan_tools_extra.go
@@ -8,6 +8,7 @@ import (
 
 	anthropic "github.com/anthropics/anthropic-sdk-go"
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
 
 	"travel-route-planner/store"
 )
@@ -324,9 +325,19 @@ func runAddBookingTodoTool(s *planSession, input json.RawMessage) (string, bool)
 	if err != nil {
 		return "Could not save the booking to-do.", true
 	}
+	touchTripAs(s.ctx, tid, s.uid)
 	sendSSE(s.w, "trip_updated", map[string]string{"trip_id": tid.String()})
 	go recordEvent(s.uid, "agent_booking_todo_added", &tid, map[string]any{"kind": todo.Kind})
 	return fmt.Sprintf("Added %q to the trip's booking checklist. Mention it briefly; the traveler will see it on the trip page.", todo.Title), false
+}
+
+// touchTripAs stamps a content edit made through an agent tool (best-effort;
+// the write itself already committed). Same invariant as TouchTrip: real
+// edits only, never passive loads.
+func touchTripAs(ctx context.Context, tripID, actor uuid.UUID) {
+	_ = store.New(dbPool).TouchTrip(ctx, store.TouchTripParams{
+		ID: tripID, UpdatedBy: pgtype.UUID{Bytes: actor, Valid: true},
+	})
 }
 
 // bookingTodoMissingMsg covers both "wrong id" and "auto row" — the queries
@@ -383,6 +394,7 @@ func runUpdateBookingTodoTool(s *planSession, input json.RawMessage) (string, bo
 	if err != nil {
 		return bookingTodoMissingMsg, true
 	}
+	touchTripAs(s.ctx, tid, s.uid)
 	sendSSE(s.w, "trip_updated", map[string]string{"trip_id": tid.String()})
 	go recordEvent(s.uid, "agent_booking_todo_updated", &tid, map[string]any{"kind": todo.Kind})
 	return fmt.Sprintf("Updated %q on the trip's booking checklist — the traveler's trip page has refreshed.", todo.Title), false
@@ -408,6 +420,7 @@ func runRemoveBookingTodoTool(s *planSession, input json.RawMessage) (string, bo
 	if err != nil || rows == 0 {
 		return bookingTodoMissingMsg, true
 	}
+	touchTripAs(s.ctx, tid, s.uid)
 	sendSSE(s.w, "trip_updated", map[string]string{"trip_id": tid.String()})
 	go recordEvent(s.uid, "agent_booking_todo_removed", &tid, nil)
 	return "Removed the item from the trip's booking checklist — the traveler's trip page has refreshed.", false

--- a/src/packages/api/query/trips.sql
+++ b/src/packages/api/query/trips.sql
@@ -1,6 +1,6 @@
 -- name: CreateTrip :one
-INSERT INTO trips (user_id, title, status, chat_id, summary)
-VALUES ($1, $2, $3, $4, $5)
+INSERT INTO trips (user_id, title, status, chat_id, summary, updated_by)
+VALUES ($1, $2, $3, $4, $5, $1)
 RETURNING *;
 
 -- name: CreateItineraryItem :one
@@ -106,8 +106,33 @@ WHERE trip_id = $1 AND position > $2;
 UPDATE itinerary_items SET position = $3 WHERE id = $1 AND trip_id = $2;
 
 -- name: TouchTrip :exec
--- Itinerary-item writes don't touch the trips row, so bump updated_at by hand.
-UPDATE trips SET updated_at = now() WHERE id = $1;
+-- Content writes don't touch the trips row, so bump updated_at by hand and
+-- record who made the edit (the "Updated by X" attribution on shared trips).
+-- INVARIANT: only call from real user edits — never from passive load paths
+-- like syncBookingTodos, or every reader looks like an editor and polling
+-- clients chase each other's refreshes.
+UPDATE trips SET updated_at = now(), updated_by = $2 WHERE id = $1;
+
+-- name: GetTripStatusByID :one
+-- Freshness poll for shared-trip clients: one cheap row, authorized for the
+-- owner or any active collaborator on the row's lineage.
+SELECT t.updated_at, t.updated_by,
+       COALESCE(u.display_name, '')::text AS updated_by_name
+FROM trips t
+LEFT JOIN users u ON u.id = t.updated_by
+WHERE t.id = $1
+  AND (t.user_id = $2 OR EXISTS (
+        SELECT 1 FROM trip_collaborators c
+        WHERE c.user_id = $2 AND c.revoked_at IS NULL
+          AND c.owner_id = t.user_id AND c.chat_id = t.chat_id));
+
+-- name: HasActiveCollaborators :one
+-- Whether anyone collaborates on this lineage — tells the owner's client the
+-- trip is shared (worth polling for freshness).
+SELECT EXISTS (
+  SELECT 1 FROM trip_collaborators
+  WHERE owner_id = $1 AND chat_id = $2 AND revoked_at IS NULL
+)::bool;
 
 -- name: GetTripForUpdate :one
 -- Row-locks the trip for the duration of the transaction. Full-itinerary

--- a/src/packages/api/segment_handler.go
+++ b/src/packages/api/segment_handler.go
@@ -124,6 +124,8 @@ func addSegmentHandler(w http.ResponseWriter, r *http.Request) {
 		writeJSONError(w, http.StatusInternalServerError, "could not save segment")
 		return
 	}
+	// Best-effort attribution/freshness bump — the segment itself committed.
+	_ = store.New(dbPool).TouchTrip(r.Context(), touchedBy(tripID, r))
 	writeJSON(w, http.StatusCreated, toSegmentResponse(seg))
 }
 
@@ -148,5 +150,6 @@ func deleteSegmentHandler(w http.ResponseWriter, r *http.Request) {
 		writeJSONError(w, http.StatusNotFound, "segment not found")
 		return
 	}
+	_ = store.New(dbPool).TouchTrip(r.Context(), touchedBy(tripID, r))
 	w.WriteHeader(http.StatusNoContent)
 }

--- a/src/packages/api/store/collaborators.sql.go
+++ b/src/packages/api/store/collaborators.sql.go
@@ -32,7 +32,7 @@ func (q *Queries) CreateTripCollaborator(ctx context.Context, arg CreateTripColl
 }
 
 const getEditableTripByID = `-- name: GetEditableTripByID :one
-SELECT t.id, t.user_id, t.created_at, t.updated_at, t.title, t.start_date, t.end_date, t.status, t.chat_id, t.summary FROM trips t
+SELECT t.id, t.user_id, t.created_at, t.updated_at, t.title, t.start_date, t.end_date, t.status, t.chat_id, t.summary, t.updated_by FROM trips t
 WHERE t.id = $1
   AND (t.user_id = $2 OR EXISTS (
         SELECT 1 FROM trip_collaborators c
@@ -62,6 +62,7 @@ func (q *Queries) GetEditableTripByID(ctx context.Context, arg GetEditableTripBy
 		&i.Status,
 		&i.ChatID,
 		&i.Summary,
+		&i.UpdatedBy,
 	)
 	return i, err
 }

--- a/src/packages/api/store/models.go
+++ b/src/packages/api/store/models.go
@@ -229,6 +229,7 @@ type Trip struct {
 	Status    string      `json:"status"`
 	ChatID    *string     `json:"chat_id"`
 	Summary   *string     `json:"summary"`
+	UpdatedBy pgtype.UUID `json:"updated_by"`
 }
 
 type TripCollaborator struct {

--- a/src/packages/api/store/shares.sql.go
+++ b/src/packages/api/store/shares.sql.go
@@ -95,7 +95,7 @@ func (q *Queries) GetActiveShareByToken(ctx context.Context, token string) (Trip
 }
 
 const getLatestTripByOwnerAndChat = `-- name: GetLatestTripByOwnerAndChat :one
-SELECT id, user_id, created_at, updated_at, title, start_date, end_date, status, chat_id, summary FROM trips
+SELECT id, user_id, created_at, updated_at, title, start_date, end_date, status, chat_id, summary, updated_by FROM trips
 WHERE user_id = $1 AND chat_id = $2
 ORDER BY created_at DESC
 LIMIT 1
@@ -121,6 +121,7 @@ func (q *Queries) GetLatestTripByOwnerAndChat(ctx context.Context, arg GetLatest
 		&i.Status,
 		&i.ChatID,
 		&i.Summary,
+		&i.UpdatedBy,
 	)
 	return i, err
 }

--- a/src/packages/api/store/trips.sql.go
+++ b/src/packages/api/store/trips.sql.go
@@ -108,9 +108,9 @@ func (q *Queries) CreateItineraryItem(ctx context.Context, arg CreateItineraryIt
 }
 
 const createTrip = `-- name: CreateTrip :one
-INSERT INTO trips (user_id, title, status, chat_id, summary)
-VALUES ($1, $2, $3, $4, $5)
-RETURNING id, user_id, created_at, updated_at, title, start_date, end_date, status, chat_id, summary
+INSERT INTO trips (user_id, title, status, chat_id, summary, updated_by)
+VALUES ($1, $2, $3, $4, $5, $1)
+RETURNING id, user_id, created_at, updated_at, title, start_date, end_date, status, chat_id, summary, updated_by
 `
 
 type CreateTripParams struct {
@@ -141,6 +141,7 @@ func (q *Queries) CreateTrip(ctx context.Context, arg CreateTripParams) (Trip, e
 		&i.Status,
 		&i.ChatID,
 		&i.Summary,
+		&i.UpdatedBy,
 	)
 	return i, err
 }
@@ -240,7 +241,7 @@ func (q *Queries) GetItineraryItemsByTrip(ctx context.Context, tripID uuid.UUID)
 }
 
 const getTripByIDAndOwner = `-- name: GetTripByIDAndOwner :one
-SELECT id, user_id, created_at, updated_at, title, start_date, end_date, status, chat_id, summary FROM trips WHERE id = $1 AND user_id = $2
+SELECT id, user_id, created_at, updated_at, title, start_date, end_date, status, chat_id, summary, updated_by FROM trips WHERE id = $1 AND user_id = $2
 `
 
 type GetTripByIDAndOwnerParams struct {
@@ -262,12 +263,13 @@ func (q *Queries) GetTripByIDAndOwner(ctx context.Context, arg GetTripByIDAndOwn
 		&i.Status,
 		&i.ChatID,
 		&i.Summary,
+		&i.UpdatedBy,
 	)
 	return i, err
 }
 
 const getTripForUpdate = `-- name: GetTripForUpdate :one
-SELECT id, user_id, created_at, updated_at, title, start_date, end_date, status, chat_id, summary FROM trips WHERE id = $1 FOR UPDATE
+SELECT id, user_id, created_at, updated_at, title, start_date, end_date, status, chat_id, summary, updated_by FROM trips WHERE id = $1 FOR UPDATE
 `
 
 // Row-locks the trip for the duration of the transaction. Full-itinerary
@@ -288,8 +290,62 @@ func (q *Queries) GetTripForUpdate(ctx context.Context, id uuid.UUID) (Trip, err
 		&i.Status,
 		&i.ChatID,
 		&i.Summary,
+		&i.UpdatedBy,
 	)
 	return i, err
+}
+
+const getTripStatusByID = `-- name: GetTripStatusByID :one
+SELECT t.updated_at, t.updated_by,
+       COALESCE(u.display_name, '')::text AS updated_by_name
+FROM trips t
+LEFT JOIN users u ON u.id = t.updated_by
+WHERE t.id = $1
+  AND (t.user_id = $2 OR EXISTS (
+        SELECT 1 FROM trip_collaborators c
+        WHERE c.user_id = $2 AND c.revoked_at IS NULL
+          AND c.owner_id = t.user_id AND c.chat_id = t.chat_id))
+`
+
+type GetTripStatusByIDParams struct {
+	ID     uuid.UUID `json:"id"`
+	UserID uuid.UUID `json:"user_id"`
+}
+
+type GetTripStatusByIDRow struct {
+	UpdatedAt     time.Time   `json:"updated_at"`
+	UpdatedBy     pgtype.UUID `json:"updated_by"`
+	UpdatedByName string      `json:"updated_by_name"`
+}
+
+// Freshness poll for shared-trip clients: one cheap row, authorized for the
+// owner or any active collaborator on the row's lineage.
+func (q *Queries) GetTripStatusByID(ctx context.Context, arg GetTripStatusByIDParams) (GetTripStatusByIDRow, error) {
+	row := q.db.QueryRow(ctx, getTripStatusByID, arg.ID, arg.UserID)
+	var i GetTripStatusByIDRow
+	err := row.Scan(&i.UpdatedAt, &i.UpdatedBy, &i.UpdatedByName)
+	return i, err
+}
+
+const hasActiveCollaborators = `-- name: HasActiveCollaborators :one
+SELECT EXISTS (
+  SELECT 1 FROM trip_collaborators
+  WHERE owner_id = $1 AND chat_id = $2 AND revoked_at IS NULL
+)::bool
+`
+
+type HasActiveCollaboratorsParams struct {
+	OwnerID uuid.UUID `json:"owner_id"`
+	ChatID  string    `json:"chat_id"`
+}
+
+// Whether anyone collaborates on this lineage — tells the owner's client the
+// trip is shared (worth polling for freshness).
+func (q *Queries) HasActiveCollaborators(ctx context.Context, arg HasActiveCollaboratorsParams) (bool, error) {
+	row := q.db.QueryRow(ctx, hasActiveCollaborators, arg.OwnerID, arg.ChatID)
+	var column_1 bool
+	err := row.Scan(&column_1)
+	return column_1, err
 }
 
 const listLatestTripsByOwner = `-- name: ListLatestTripsByOwner :many
@@ -368,7 +424,7 @@ func (q *Queries) ListLatestTripsByOwner(ctx context.Context, userID uuid.UUID) 
 }
 
 const listTripVersionsByChat = `-- name: ListTripVersionsByChat :many
-SELECT id, user_id, created_at, updated_at, title, start_date, end_date, status, chat_id, summary FROM trips WHERE user_id = $1 AND chat_id = $2 ORDER BY created_at DESC
+SELECT id, user_id, created_at, updated_at, title, start_date, end_date, status, chat_id, summary, updated_by FROM trips WHERE user_id = $1 AND chat_id = $2 ORDER BY created_at DESC
 `
 
 type ListTripVersionsByChatParams struct {
@@ -396,6 +452,7 @@ func (q *Queries) ListTripVersionsByChat(ctx context.Context, arg ListTripVersio
 			&i.Status,
 			&i.ChatID,
 			&i.Summary,
+			&i.UpdatedBy,
 		); err != nil {
 			return nil, err
 		}
@@ -408,7 +465,7 @@ func (q *Queries) ListTripVersionsByChat(ctx context.Context, arg ListTripVersio
 }
 
 const listTripsByOwner = `-- name: ListTripsByOwner :many
-SELECT id, user_id, created_at, updated_at, title, start_date, end_date, status, chat_id, summary FROM trips WHERE user_id = $1 ORDER BY created_at DESC
+SELECT id, user_id, created_at, updated_at, title, start_date, end_date, status, chat_id, summary, updated_by FROM trips WHERE user_id = $1 ORDER BY created_at DESC
 `
 
 func (q *Queries) ListTripsByOwner(ctx context.Context, userID uuid.UUID) ([]Trip, error) {
@@ -431,6 +488,7 @@ func (q *Queries) ListTripsByOwner(ctx context.Context, userID uuid.UUID) ([]Tri
 			&i.Status,
 			&i.ChatID,
 			&i.Summary,
+			&i.UpdatedBy,
 		); err != nil {
 			return nil, err
 		}
@@ -475,12 +533,21 @@ func (q *Queries) ShiftItineraryItemPositions(ctx context.Context, arg ShiftItin
 }
 
 const touchTrip = `-- name: TouchTrip :exec
-UPDATE trips SET updated_at = now() WHERE id = $1
+UPDATE trips SET updated_at = now(), updated_by = $2 WHERE id = $1
 `
 
-// Itinerary-item writes don't touch the trips row, so bump updated_at by hand.
-func (q *Queries) TouchTrip(ctx context.Context, id uuid.UUID) error {
-	_, err := q.db.Exec(ctx, touchTrip, id)
+type TouchTripParams struct {
+	ID        uuid.UUID   `json:"id"`
+	UpdatedBy pgtype.UUID `json:"updated_by"`
+}
+
+// Content writes don't touch the trips row, so bump updated_at by hand and
+// record who made the edit (the "Updated by X" attribution on shared trips).
+// INVARIANT: only call from real user edits — never from passive load paths
+// like syncBookingTodos, or every reader looks like an editor and polling
+// clients chase each other's refreshes.
+func (q *Queries) TouchTrip(ctx context.Context, arg TouchTripParams) error {
+	_, err := q.db.Exec(ctx, touchTrip, arg.ID, arg.UpdatedBy)
 	return err
 }
 
@@ -587,7 +654,7 @@ SET title      = COALESCE($1, title),
     status     = COALESCE($4, status),
     chat_id    = COALESCE($5, chat_id)
 WHERE id = $6 AND user_id = $7
-RETURNING id, user_id, created_at, updated_at, title, start_date, end_date, status, chat_id, summary
+RETURNING id, user_id, created_at, updated_at, title, start_date, end_date, status, chat_id, summary, updated_by
 `
 
 type UpdateTripParams struct {
@@ -622,6 +689,7 @@ func (q *Queries) UpdateTrip(ctx context.Context, arg UpdateTripParams) (Trip, e
 		&i.Status,
 		&i.ChatID,
 		&i.Summary,
+		&i.UpdatedBy,
 	)
 	return i, err
 }

--- a/src/packages/api/trip_handler.go
+++ b/src/packages/api/trip_handler.go
@@ -65,6 +65,18 @@ type TripResponse struct {
 	// that predate collaboration; clients treat missing as owner.
 	Access    string  `json:"access,omitempty"`
 	OwnerName *string `json:"owner_name,omitempty"` // set when access == "editor"
+	// UpdatedByName attributes the last content edit ("Updated by Maria");
+	// empty when unknown. Shared marks a trip that has active collaborators —
+	// the owner's client polls /status only when set (editors always poll).
+	UpdatedByName *string `json:"updated_by_name,omitempty"`
+	Shared        bool    `json:"shared,omitempty"`
+}
+
+// TripStatusResponse is the freshness-poll payload for shared trips.
+type TripStatusResponse struct {
+	UpdatedAt     time.Time `json:"updated_at"`
+	UpdatedBy     *string   `json:"updated_by,omitempty"`
+	UpdatedByName *string   `json:"updated_by_name,omitempty"`
 }
 
 type PatchTripRequest struct {
@@ -119,6 +131,14 @@ func toItineraryItemResponse(it store.ItineraryItem) ItineraryItemResponse {
 		LocalSourceName:       it.LocalSourceName,
 		LocalRecommendationID: pgUUIDToStringPtr(it.LocalRecommendationID),
 	}
+}
+
+// touchedBy builds TouchTrip params attributing a content edit to the
+// request's signed-in user (the "Updated by X" line on shared trips). Only
+// use on real user edits — see the TouchTrip query invariant.
+func touchedBy(tripID uuid.UUID, r *http.Request) store.TouchTripParams {
+	user, _ := userFromContext(r.Context())
+	return store.TouchTripParams{ID: tripID, UpdatedBy: pgtype.UUID{Bytes: user.ID, Valid: true}}
 }
 
 func toTripResponse(t store.Trip, items []store.ItineraryItem, accommodations []store.Accommodation, segments []store.TripSegment, bookingTodos []store.BookingTodo) TripResponse {
@@ -358,6 +378,50 @@ func getTripHandler(w http.ResponseWriter, r *http.Request) {
 			resp.OwnerName = owner.DisplayName
 		}
 	}
+	// "Updated by X" attribution — omitted for the caller's own edits.
+	if trip.UpdatedBy.Valid && trip.UpdatedBy.Bytes != user.ID {
+		if editor, err := q.GetUserByID(r.Context(), trip.UpdatedBy.Bytes); err == nil &&
+			editor.DisplayName != nil && *editor.DisplayName != "" {
+			resp.UpdatedByName = editor.DisplayName
+		}
+	}
+	// Tell the owner's client this trip has co-planners (worth polling for
+	// freshness). Editors know to poll from access alone.
+	if trip.UserID == user.ID && trip.ChatID != nil {
+		if shared, err := q.HasActiveCollaborators(r.Context(), store.HasActiveCollaboratorsParams{
+			OwnerID: trip.UserID, ChatID: *trip.ChatID,
+		}); err == nil {
+			resp.Shared = shared
+		}
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// tripStatusHandler is the cheap freshness poll for shared trips: one row,
+// owner or any active collaborator. Registered on the default rate-limit
+// tier on purpose — clients hit it every ~25s.
+func tripStatusHandler(w http.ResponseWriter, r *http.Request) {
+	user, _ := userFromContext(r.Context())
+	tripID, ok := tripIDFromPath(r)
+	if !ok {
+		writeJSONError(w, http.StatusNotFound, "trip not found")
+		return
+	}
+	row, err := store.New(dbPool).GetTripStatusByID(r.Context(),
+		store.GetTripStatusByIDParams{ID: tripID, UserID: user.ID})
+	if err != nil {
+		writeJSONError(w, http.StatusNotFound, "trip not found")
+		return
+	}
+	resp := TripStatusResponse{UpdatedAt: row.UpdatedAt}
+	if row.UpdatedBy.Valid {
+		id := uuid.UUID(row.UpdatedBy.Bytes).String()
+		resp.UpdatedBy = &id
+		if row.UpdatedByName != "" {
+			name := row.UpdatedByName
+			resp.UpdatedByName = &name
+		}
+	}
 	writeJSON(w, http.StatusOK, resp)
 }
 
@@ -450,6 +514,8 @@ func patchTripHandler(w http.ResponseWriter, r *http.Request) {
 		writeJSONError(w, http.StatusInternalServerError, "could not update trip")
 		return
 	}
+	// Best-effort attribution: the patch itself already committed.
+	_ = q.TouchTrip(r.Context(), touchedBy(trip.ID, r))
 	items, err := q.GetItineraryItemsByTrip(r.Context(), trip.ID)
 	if err != nil {
 		writeJSONError(w, http.StatusInternalServerError, "could not load itinerary")

--- a/src/packages/api/trip_status_integration_test.go
+++ b/src/packages/api/trip_status_integration_test.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"net/http"
+	"testing"
+)
+
+// The freshness poll: owner and collaborators read it, strangers get the
+// usual 404, and the payload attributes the last content edit.
+func TestTripStatusAuthorization(t *testing.T) {
+	resetDB(t)
+	owner, ownerToken := createTestUser(t, "owner@example.com")
+	_, editorToken := createTestUser(t, "editor@example.com")
+	_, strangerToken := createTestUser(t, "stranger@example.com")
+	trip := createTestTrip(t, owner.ID, 1)
+	shareToken := createShare(t, ownerToken, trip.ID.String(), "editor")
+	if rec := joinShare(t, editorToken, shareToken); rec.Code >= 300 {
+		t.Fatalf("join = %d", rec.Code)
+	}
+
+	for name, tok := range map[string]string{"owner": ownerToken, "editor": editorToken} {
+		rec := doJSON(t, "GET", "/api/v1/trips/"+trip.ID.String()+"/status", tok, nil)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("%s status = %d, want 200", name, rec.Code)
+		}
+		if body := decode(t, rec); body["updated_at"] == nil {
+			t.Fatalf("%s status missing updated_at: %v", name, body)
+		}
+	}
+	if rec := doJSON(t, "GET", "/api/v1/trips/"+trip.ID.String()+"/status", strangerToken, nil); rec.Code != http.StatusNotFound {
+		t.Fatalf("stranger status = %d, want 404", rec.Code)
+	}
+	if rec := doJSON(t, "GET", "/api/v1/trips/"+trip.ID.String()+"/status", "", nil); rec.Code != http.StatusUnauthorized {
+		t.Fatalf("anonymous status = %d, want 401", rec.Code)
+	}
+}
+
+// A collaborator's edit stamps updated_by; the owner sees "Updated by X" on
+// the trip response and the status poll, while the editor's own view omits
+// self-attribution.
+func TestTripStatusAttributionAfterCollaboratorEdit(t *testing.T) {
+	resetDB(t)
+	owner, ownerToken := createTestUser(t, "owner@example.com")
+	editor, editorToken := createTestUser(t, "editor@example.com")
+	trip := createTestTrip(t, owner.ID, 1)
+	shareToken := createShare(t, ownerToken, trip.ID.String(), "editor")
+	if rec := joinShare(t, editorToken, shareToken); rec.Code >= 300 {
+		t.Fatalf("join = %d", rec.Code)
+	}
+
+	// Before any collaborator edit: the owner created the trip, so their own
+	// view carries no attribution line.
+	before := decode(t, doJSON(t, "GET", "/api/v1/trips/"+trip.ID.String(), ownerToken, nil))
+	if before["updated_by_name"] != nil {
+		t.Fatalf("owner sees self-attribution before edits: %v", before["updated_by_name"])
+	}
+	if before["shared"] != true {
+		t.Fatalf("owner trip shared = %v, want true after join", before["shared"])
+	}
+
+	add := doJSON(t, "POST", "/api/v1/trips/"+trip.ID.String()+"/items", editorToken, map[string]any{
+		"name": "Editor's Pick", "latitude": 37.98, "longitude": 23.73,
+	})
+	if add.Code != http.StatusCreated && add.Code != http.StatusOK {
+		t.Fatalf("editor add item = %d", add.Code)
+	}
+
+	after := decode(t, doJSON(t, "GET", "/api/v1/trips/"+trip.ID.String(), ownerToken, nil))
+	if after["updated_by_name"] != "Test User" {
+		t.Fatalf("owner updated_by_name = %v, want editor's display name", after["updated_by_name"])
+	}
+	// The editor's own view hides self-attribution.
+	editorView := decode(t, doJSON(t, "GET", "/api/v1/trips/"+trip.ID.String(), editorToken, nil))
+	if editorView["updated_by_name"] != nil {
+		t.Fatalf("editor sees self-attribution: %v", editorView["updated_by_name"])
+	}
+
+	status := decode(t, doJSON(t, "GET", "/api/v1/trips/"+trip.ID.String()+"/status", ownerToken, nil))
+	if status["updated_by"] != editor.ID.String() {
+		t.Fatalf("status updated_by = %v, want editor id", status["updated_by"])
+	}
+	if status["updated_by_name"] != "Test User" {
+		t.Fatalf("status updated_by_name = %v", status["updated_by_name"])
+	}
+}
+
+// The booking-todo sync endpoint runs on every trip load and must never
+// stamp attribution — a reader is not an editor.
+func TestPassiveSyncDoesNotStampAttribution(t *testing.T) {
+	resetDB(t)
+	owner, ownerToken := createTestUser(t, "owner@example.com")
+	_, editorToken := createTestUser(t, "editor@example.com")
+	trip := createTestTrip(t, owner.ID, 2)
+	shareToken := createShare(t, ownerToken, trip.ID.String(), "editor")
+	if rec := joinShare(t, editorToken, shareToken); rec.Code >= 300 {
+		t.Fatalf("join = %d", rec.Code)
+	}
+
+	// The editor "loads" the trip: sync runs, no content edit.
+	if rec := doJSON(t, "PUT", "/api/v1/trips/"+trip.ID.String()+"/booking-todos", editorToken, map[string]any{}); rec.Code >= 500 {
+		t.Fatalf("sync = %d: %s", rec.Code, rec.Body.String())
+	}
+
+	ownerView := decode(t, doJSON(t, "GET", "/api/v1/trips/"+trip.ID.String(), ownerToken, nil))
+	if ownerView["updated_by_name"] != nil {
+		t.Fatalf("passive sync stamped attribution: %v", ownerView["updated_by_name"])
+	}
+}

--- a/src/packages/flutter-app/lib/models/trip.dart
+++ b/src/packages/flutter-app/lib/models/trip.dart
@@ -38,6 +38,15 @@ class Trip {
   @JsonKey(name: 'owner_name')
   final String? ownerName;
 
+  /// Who last edited the trip's content — omitted for the caller's own edits
+  /// (specs/shared-trip-freshness).
+  @JsonKey(name: 'updated_by_name')
+  final String? updatedByName;
+
+  /// True on an owner's trip that has active co-planners: the detail screen
+  /// polls for freshness. Editors poll based on [access] alone.
+  final bool? shared;
+
   const Trip({
     required this.id,
     required this.title,
@@ -56,6 +65,8 @@ class Trip {
     this.bookingTodos,
     this.access,
     this.ownerName,
+    this.updatedByName,
+    this.shared,
   });
 
   /// True when the current user may edit this trip: owner or editor

--- a/src/packages/flutter-app/lib/models/trip.g.dart
+++ b/src/packages/flutter-app/lib/models/trip.g.dart
@@ -33,6 +33,8 @@ Trip _$TripFromJson(Map<String, dynamic> json) => Trip(
           .toList(),
       access: json['access'] as String?,
       ownerName: json['owner_name'] as String?,
+      updatedByName: json['updated_by_name'] as String?,
+      shared: json['shared'] as bool?,
     );
 
 Map<String, dynamic> _$TripToJson(Trip instance) => <String, dynamic>{
@@ -54,4 +56,6 @@ Map<String, dynamic> _$TripToJson(Trip instance) => <String, dynamic>{
       'booking_todos': instance.bookingTodos?.map((e) => e.toJson()).toList(),
       'access': instance.access,
       'owner_name': instance.ownerName,
+      'updated_by_name': instance.updatedByName,
+      'shared': instance.shared,
     };

--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -63,7 +63,8 @@ class TripDetailScreen extends ConsumerStatefulWidget {
   ConsumerState<TripDetailScreen> createState() => _TripDetailScreenState();
 }
 
-class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
+class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
+    with WidgetsBindingObserver {
   Trip? _trip;
   bool _loading = true;
   String? _error;
@@ -179,13 +180,71 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
   @override
   void initState() {
     super.initState();
+    WidgetsBinding.instance.addObserver(this);
     _load();
   }
 
   @override
   void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    _statusPoll?.cancel();
     _scroll.dispose();
     super.dispose();
+  }
+
+  // ── Freshness polling (specs/shared-trip-freshness) ───────────────────
+  // Shared trips poll the cheap /status endpoint and silently refresh when
+  // someone else edited. Only runs foregrounded, online, on shared trips.
+
+  Timer? _statusPoll;
+  static const _statusPollInterval = Duration(seconds: 25);
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state == AppLifecycleState.resumed) {
+      _syncStatusPolling();
+      _statusTick(); // catch up on edits made while backgrounded
+    } else if (state == AppLifecycleState.paused ||
+        state == AppLifecycleState.inactive) {
+      _statusPoll?.cancel();
+      _statusPoll = null;
+    }
+  }
+
+  /// (Re)starts or stops the poll timer to match the loaded trip. Owners
+  /// poll when the trip has co-planners (`shared`), editors always.
+  void _syncStatusPolling() {
+    final trip = _trip;
+    final want = trip != null &&
+        !_isOffline &&
+        (trip.access == 'editor' || (trip.shared ?? false));
+    if (want) {
+      _statusPoll ??=
+          Timer.periodic(_statusPollInterval, (_) => _statusTick());
+    } else {
+      _statusPoll?.cancel();
+      _statusPoll = null;
+    }
+  }
+
+  Future<void> _statusTick() async {
+    final trip = _trip;
+    // Skip while the refine panel streams (its trip_updated events already
+    // drive _refresh) or a refresh is in flight.
+    if (trip == null || _isOffline || _panelOpen || _refreshFuture != null) {
+      return;
+    }
+    try {
+      final status =
+          await ref.read(tripsApiServiceProvider).getTripStatus(trip.id);
+      if (!mounted) return;
+      final loaded = DateTime.tryParse(trip.updatedAt);
+      if (loaded != null && status.updatedAt.isAfter(loaded)) {
+        await _refresh();
+      }
+    } catch (_) {
+      // Background poll: never surface errors or flip offline mode.
+    }
   }
 
   Future<void> _load({bool silent = false}) async {
@@ -280,6 +339,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
       if (mounted && !quiet) setState(() => _error = e.toString());
     } finally {
       if (mounted && !quiet) setState(() => _loading = false);
+      if (mounted) _syncStatusPolling();
     }
   }
 
@@ -2428,6 +2488,17 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
 
   String _fmtShortDt(DateTime d) => '${_months[d.month - 1]} ${d.day}';
 
+  /// Coarse relative timestamp for the "Updated by X" line.
+  String _relativeTime(String iso) {
+    final t = DateTime.tryParse(iso);
+    if (t == null) return 'recently';
+    final d = DateTime.now().difference(t.toLocal());
+    if (d.inMinutes < 1) return 'just now';
+    if (d.inMinutes < 60) return '${d.inMinutes}m ago';
+    if (d.inHours < 24) return '${d.inHours}h ago';
+    return '${d.inDays}d ago';
+  }
+
   /// Day-header date, e.g. "Tue, Jul 15" (weekday + month + day).
   String _fmtDayHeader(DateTime d) =>
       '${_weekdays[d.weekday - 1]}, ${_months[d.month - 1]} ${d.day}';
@@ -2548,6 +2619,16 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen> {
                   label: const Text('Refine with AI'),
                 ),
               ),
+            // "Updated by Maria · 2m ago" — only present when someone ELSE
+            // made the last edit (the server omits self-attribution).
+            if (trip.updatedByName != null) ...[
+              const SizedBox(height: 8),
+              Text(
+                'Updated by ${trip.updatedByName} · ${_relativeTime(trip.updatedAt)}',
+                style: theme.textTheme.bodySmall
+                    ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+              ),
+            ],
             if (overview != null) ...[
               const SizedBox(height: 16),
               Text(

--- a/src/packages/flutter-app/lib/services/trips_api_service.dart
+++ b/src/packages/flutter-app/lib/services/trips_api_service.dart
@@ -46,6 +46,24 @@ class TripsApiService {
     throw Exception('Failed to load trip versions (${res.statusCode})');
   }
 
+  /// Cheap freshness poll for shared trips (specs/shared-trip-freshness).
+  /// Returns the trip's updated_at plus who last edited (null for unknown).
+  Future<({DateTime updatedAt, String? updatedBy, String? updatedByName})>
+      getTripStatus(String id) async {
+    final res = await apiClient.httpClient.get(
+        Uri.parse('${apiClient.baseUrl}/trips/$id/status'),
+        headers: apiClient.jsonHeaders());
+    if (res.statusCode == 200) {
+      final body = jsonDecode(res.body) as Map<String, dynamic>;
+      return (
+        updatedAt: DateTime.parse(body['updated_at'] as String),
+        updatedBy: body['updated_by'] as String?,
+        updatedByName: body['updated_by_name'] as String?,
+      );
+    }
+    throw Exception('Failed to load trip status (${res.statusCode})');
+  }
+
   Future<Trip> getTrip(String id) async {
     final res = await apiClient.httpClient
         .get(Uri.parse('${apiClient.baseUrl}/trips/$id'), headers: apiClient.jsonHeaders());


### PR DESCRIPTION
## Summary

Sharing v2, PR 2 of 4 (specs/shared-trip-freshness). Stacked on #122 — merge that first; this diff includes only the freshness commits once #122 lands.

- **Attribution**: `trips.updated_by` (migration 00035), stamped via the single `TouchTrip` choke point on every content edit — item/stay/segment/booking-todo handlers, agent booking-todo tools, `replaceTripSection` (actor threaded from the plan session, so collaborator AI refines attribute too), trip patches, and trip creation. The passive `syncBookingTodosHandler` explicitly never stamps (documented invariant) — otherwise every reader looks like an editor and polling clients chase each other.
- **Freshness poll**: `GET /trips/{id}/status` — one cheap row, owner-or-collaborator authz, default rate tier (it's polled). `TripResponse` gains `updated_by_name` (omitted for the caller's own edits) and `shared` (owner has active co-planners).
- **Flutter**: trip detail polls every 25s while a shared trip is open — lifecycle-aware (stops on background, catch-up tick on resume), skipped while offline/refine-panel-streaming/refresh-in-flight; a newer server timestamp triggers the existing coalescing silent `_refresh()`. Header renders "Updated by {name} · {relative}" only for other people's edits.

## Testing

- New `trip_status_integration_test.go`: status authz (owner/editor 200, stranger 404, anon 401); collaborator edit → owner sees attribution + editor's own view omits it + status carries editor id; passive sync stamps nothing.
- Full Go suite green; `flutter analyze` clean; all 240 Flutter tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)