### PR TITLE
feat: native share sheet + viewer 'Keep in my trips' follows

### DIFF
--- a/specs/share-ux-viewer-follow/plan.md
+++ b/specs/share-ux-viewer-follow/plan.md
@@ -1,0 +1,77 @@
+# Plan: Native Share Sheet & Viewer Follow
+
+> **HOW.** See `../../CLAUDE.md` for repo conventions.
+
+## Technical Approach
+
+Viewer follow is a role, not a new mechanism: `trip_collaborators.role`
+already exists, so the join upsert learns roles (upgrade-never-downgrade via
+`ON CONFLICT ... DO UPDATE ... CASE`) and reads move from the editor-only
+seam to a new `GetViewableTripByID` that returns the caller's effective
+access. Every mutation handler keeps `editableTrip` untouched, so viewers
+are read-only for free. The share sheet is a thin utility: share_plus on
+mobile (with the iPad-mandatory `sharePositionOrigin`), clipboard elsewhere.
+
+## Go API Changes
+
+- `query/collaborators.sql`: role-aware `CreateTripCollaborator :one`
+  (upsert + RETURNING role); `GetViewableTripByID` (owner or any active
+  member + access column); `role` added to `ListCollaboratorsByOwnerAndChat`
+  and `ListLatestCollaboratedTripsForUser`. `make api-sqlc`.
+- `collaborator_handler.go`: join drops the viewer 403 and passes the
+  share's role; `viewableTrip` helper; shared-with-me `Access` from the row;
+  `CollaboratorResponse.Role`; `removeCollaboratorHandler` special-cases
+  `userId == "me"` (self-leave via `GetViewableTripByID` + revoke,
+  `collaborator_left` event). `collaborator_joined` gains role metadata.
+- `trip_handler.go` `getTripHandler`: `viewableTrip`; booking todos skipped
+  for viewers; `Access` from the query; chat_id null for all non-owners.
+- `invite_handler.go`: accept passes `Role: "editor"` explicitly.
+- `analytics.go` trip-id validation gate → `GetViewableTripByID` (viewers'
+  client events still attribute).
+- Freshness endpoints already role-agnostic (any active collaborator).
+
+## Flutter Changes
+
+- `pubspec.yaml`: `share_plus: ^12.0.2` (13.x doesn't resolve with the
+  current SDK constraint; the `SharePlus.instance.share(ShareParams)` API is
+  present since v11).
+- New `lib/utils/share_link.dart`: `appBasePath`, `shareUrl(token)`,
+  `shareUsesNativeSheet` (kIsWeb/defaultTargetPlatform — no dart:io), and
+  `shareOrCopyLink(...)` with `sharePositionOrigin`.
+- `trip_detail_screen.dart`: `_shareLink`/`_inviteCoPlanner` use the helper
+  (anchor rect from a GlobalKey on the share menu); platform-aware menu
+  labels; "Manage access" sheet title + per-row role labels; viewer gating
+  via `_readOnly` (`Trip.canEdit`): rename/dates/status, item menus, Add
+  place (list + map empty state), Add booking, `BookingsSection.readOnly`;
+  three-way banner (owner button / editor co-planning / viewer
+  "view only"); app-bar "Remove from my trips" → `leaveTrip` + confirm;
+  polling condition widened to all non-owners.
+- `bookings_section.dart`: `readOnly` flag hides add buttons + delete icons.
+- `trips_api_service.dart`: `leaveTrip`; `listCollaborators` gains `role`.
+- `shared_trip_screen.dart`: viewer links get primary "Keep in my trips"
+  (same join flow — server decides the role) + secondary save-a-copy.
+- `trips_list_screen.dart`: viewer cards (eye icon, "Shared by {owner}").
+
+## Contract Parity  ← anti-drift gate
+
+| JSON key | Go type | Dart type | Nullable? | ✓ |
+|----------|---------|-----------|-----------|---|
+| trip `access` (now incl. 'viewer') | `string,omitempty` | `String?` (`canEdit` helper) | yes | ✓ |
+| collaborator `role` | `string` | `String` (record field) | no | ✓ |
+| join `access` | `string` | (unused by client) | no | ✓ |
+
+## Cross-cutting
+
+- No env vars, no migration, no gateway changes. share_plus needs no
+  platform config for text shares.
+
+## Verification
+
+- Integration tests (`collaborator_integration_test.go`): viewer join →
+  read-only follow (200 read without todos/chat_id; item/patch/todo
+  mutations 404; shared-with-me + collaborators list roles; status poll OK);
+  role transitions (viewer→editor upgrade, no downgrade); self-leave (+
+  owner self-leave 404). Full Go suite green.
+- `flutter analyze` clean; all Flutter tests pass.
+- Manual: mobile share sheet on a device/simulator (iPad popover anchor!);
+  viewer follow end-to-end in two browser sessions.

--- a/specs/share-ux-viewer-follow/spec.md
+++ b/specs/share-ux-viewer-follow/spec.md
@@ -1,0 +1,100 @@
+# Spec: Native Share Sheet & Viewer Follow
+
+## Context
+
+Two rough edges remain in sharing. First, sharing is clipboard-only: on a
+phone, "Copy share link" then switching apps to paste is clunky when every
+other app opens the OS share sheet. Second, a read-only share link is
+stateless — a friend who wants to keep watching the trip has either a buried
+browser link or a frozen copy. This feature adds the native share sheet on
+mobile, and lets a viewer-link recipient "Keep in my trips": a read-only
+membership that shows the live trip in their own app as the owner plans.
+
+## User Stories
+
+- As a **trip owner on my phone**, I want **the OS share sheet** so that
+  **sending the link to a friend is one tap into Messages/WhatsApp**.
+- As a **friend with a view link**, I want **the trip pinned in my own app,
+  staying current** so that **I don't need to re-find the link or settle for
+  a stale copy**.
+- As a **trip owner**, I want **viewers clearly read-only and manageable**
+  so that **sharing widely never risks stray edits**.
+
+## Acceptance Criteria
+
+- [ ] On iOS/Android, "Share link…" and "Share co-planner invite…" open the
+      OS share sheet with a "{title} · {dates}" message + URL (anchored
+      correctly on iPad); on web/desktop the actions copy to the clipboard
+      with the existing snackbar.
+- [ ] Opening a viewer link offers "Keep in my trips"; after joining, the
+      trip appears under "Shared with you" marked "Shared by {owner}", and
+      opening it shows the live trip read-only.
+- [ ] Viewers see no edit affordances (no rename/dates/status editing, no
+      add/edit/delete on places, stays, transport), no AI refine or chat, and
+      no booking checklist; their reads stay fresh via the same silent
+      polling co-planners get.
+- [ ] Viewer mutations are rejected server-side with the same not-found
+      posture as strangers.
+- [ ] An editor link upgrades a viewer to co-planner; a viewer link never
+      downgrades an editor.
+- [ ] Members can remove a shared trip from their own list (viewer or
+      editor); the owner can remove individual viewers from Manage access,
+      which now labels each person "Can edit" or "Viewer".
+
+## API Surface
+
+### `POST /api/v1/shared/{token}/join` (behavior change)
+- Viewer tokens no longer 403: they create a viewer-role membership.
+  Response `access` reflects the resulting role (upgrade-never-downgrade).
+
+### `GET /api/v1/trips/{id}` (behavior change)
+- Now readable by viewer members; `access` may be `viewer`; booking todos are
+  omitted for viewers (same boundary as the public share view); `chat_id`
+  stays null for all non-owners.
+
+### `GET /api/v1/trips/shared-with-me`, `GET /trips/{id}/collaborators`
+- Rows carry the member's actual `role`/`access` instead of assuming editor.
+
+### `DELETE /api/v1/trips/{id}/collaborators/me`
+- The caller leaves a trip shared with them (editor or viewer). Owners get
+  404 (they aren't members).
+
+## Data Model
+
+No migration. The existing membership row's `role` column now takes the
+value `viewer`; the join upsert upgrades roles but never downgrades.
+
+## UI Behavior
+
+- **Share menu (mobile):** items read "Share link…" / "Share co-planner
+  invite…" and open the share sheet; desktop/web keep the copy labels.
+- **Shared-trip screen (viewer link):** primary "Keep in my trips", secondary
+  "Or save a separate copy". Editor links unchanged.
+- **Trip detail (viewer):** banner "Shared by {owner} — view only" with an
+  eye icon; static status pill; no edit pencils, item menus, add buttons,
+  refine surfaces, or booking checklist; an app-bar "Remove from my trips"
+  action (confirm dialog) for any non-owner member.
+- **Trips list:** viewer cards get an eye icon + "Shared by {owner}"; editor
+  cards keep the group icon + "Planned with {owner}".
+- **Manage access sheet:** rows labeled "Can edit" / "Viewer"; removal works
+  for both.
+
+## Edge Cases & Error States
+
+- Viewer opens a cached copy offline: the existing offline read-only mode
+  already hides edit affordances.
+- Owner revokes links: existing followers keep access (same semantics as
+  co-planners); the revoke snackbar says so.
+- iPad share popover requires an anchor rect — derived from the share menu
+  button; sharing is skipped gracefully if the anchor is gone.
+
+## Out of Scope
+
+- Viewer-role email invites.
+- Public OG-preview changes (viewer follow reuses existing share links).
+- Live sync beyond the freshness polling that already exists.
+
+## Open Questions
+
+None — resolved during planning: viewers never see booking todos; CTA copy
+"Keep in my trips"; clipboard remains the web/desktop behavior.

--- a/specs/share-ux-viewer-follow/tasks.md
+++ b/specs/share-ux-viewer-follow/tasks.md
@@ -1,0 +1,26 @@
+# Tasks: Native Share Sheet & Viewer Follow
+
+> Dependency-ordered. Work top to bottom; verification is last.
+
+## API (Go)
+
+- [x] Role-aware collaborator upsert + `GetViewableTripByID` + role in list
+      queries; `make api-sqlc`
+- [x] Join accepts viewer tokens; shared-with-me/collaborators carry roles;
+      self-leave (`collaborators/me`); `viewableTrip` in `getTripHandler`
+      (no todos for viewers); analytics gate → viewable
+
+## UI (Flutter)
+
+- [x] `share_plus` + `lib/utils/share_link.dart` (`shareOrCopyLink`,
+      iPad anchor rect); share menu labels per platform
+- [x] Viewer read-only gating in trip detail + `BookingsSection.readOnly`;
+      three-way banner; "Remove from my trips"
+- [x] "Keep in my trips" on viewer links; trips-list viewer cards;
+      "Manage access" sheet roles; `leaveTrip` service
+
+## Verification
+
+- [x] Full Go suite (3 new/replaced integration tests)
+- [x] `flutter analyze` clean; all Flutter tests pass
+- [ ] Manual: mobile share sheet; two-session viewer follow via gateway

--- a/src/packages/api/analytics.go
+++ b/src/packages/api/analytics.go
@@ -189,7 +189,9 @@ func recordClientEventHandler(w http.ResponseWriter, r *http.Request) {
 		// Skipped in degraded mode (recordEvent drops the event then anyway).
 		if tripID != nil && dbPool != nil {
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-			if _, err := store.New(dbPool).GetEditableTripByID(ctx, store.GetEditableTripByIDParams{
+			// Viewable (not editable): viewer follows may attribute client
+			// events (e.g. booking link clicks) to the trip they can read.
+			if _, err := store.New(dbPool).GetViewableTripByID(ctx, store.GetViewableTripByIDParams{
 				ID: *tripID, UserID: user.ID,
 			}); err != nil {
 				tripID = nil

--- a/src/packages/api/collaborator_handler.go
+++ b/src/packages/api/collaborator_handler.go
@@ -25,6 +25,7 @@ type CollaboratorResponse struct {
 	UserID      string    `json:"user_id"`
 	DisplayName string    `json:"display_name"`
 	Email       string    `json:"email"`
+	Role        string    `json:"role"`
 	JoinedAt    time.Time `json:"joined_at"`
 }
 
@@ -48,6 +49,26 @@ func editableTrip(w http.ResponseWriter, r *http.Request) (store.Trip, bool) {
 	return trip, true
 }
 
+// viewableTrip is editableTrip's read-only sibling: owner or ANY active
+// collaborator (viewer follows included). Returns the row plus the caller's
+// effective access ("owner"/"editor"/"viewer"). Mutation handlers must keep
+// using editableTrip.
+func viewableTrip(w http.ResponseWriter, r *http.Request) (store.GetViewableTripByIDRow, bool) {
+	user, _ := userFromContext(r.Context())
+	tripID, ok := tripIDFromPath(r)
+	if !ok {
+		writeJSONError(w, http.StatusNotFound, "trip not found")
+		return store.GetViewableTripByIDRow{}, false
+	}
+	row, err := store.New(dbPool).GetViewableTripByID(r.Context(),
+		store.GetViewableTripByIDParams{ID: tripID, UserID: user.ID})
+	if err != nil {
+		writeJSONError(w, http.StatusNotFound, "trip not found")
+		return store.GetViewableTripByIDRow{}, false
+	}
+	return row, true
+}
+
 // joinSharedTripHandler redeems an editor-role token for membership.
 // Idempotent; the owner joining their own trip is a no-op success.
 func joinSharedTripHandler(w http.ResponseWriter, r *http.Request) {
@@ -57,24 +78,23 @@ func joinSharedTripHandler(w http.ResponseWriter, r *http.Request) {
 		writeJSONError(w, http.StatusNotFound, "shared trip not found")
 		return
 	}
-	if share.Role != "editor" {
-		writeJSONError(w, http.StatusForbidden, "this link doesn't allow editing")
-		return
-	}
+	access := "owner"
 	if trip.UserID != user.ID {
-		if err := store.New(dbPool).CreateTripCollaborator(r.Context(), store.CreateTripCollaboratorParams{
-			ChatID: share.ChatID, OwnerID: share.OwnerID, UserID: user.ID,
-		}); err != nil {
+		// Viewer tokens create a viewer "follow"; editor tokens (and an
+		// editor redeeming any link) yield editor — the upsert never
+		// downgrades.
+		role, err := store.New(dbPool).CreateTripCollaborator(r.Context(), store.CreateTripCollaboratorParams{
+			ChatID: share.ChatID, OwnerID: share.OwnerID, UserID: user.ID, Role: share.Role,
+		})
+		if err != nil {
 			writeJSONError(w, http.StatusInternalServerError, "could not join trip")
 			return
 		}
+		access = role
 		go recordEvent(user.ID, "collaborator_joined", &trip.ID, map[string]any{
 			"owner_id": share.OwnerID.String(),
+			"role":     role,
 		})
-	}
-	access := "editor"
-	if trip.UserID == user.ID {
-		access = "owner"
 	}
 	writeJSON(w, http.StatusOK, JoinSharedTripResponse{TripID: trip.ID.String(), Access: access})
 }
@@ -107,6 +127,7 @@ func listCollaboratorsHandler(w http.ResponseWriter, r *http.Request) {
 				UserID:      c.UserID.String(),
 				DisplayName: c.DisplayName,
 				Email:       c.Email,
+				Role:        c.Role,
 				JoinedAt:    c.CreatedAt,
 			})
 		}
@@ -120,6 +141,26 @@ func removeCollaboratorHandler(w http.ResponseWriter, r *http.Request) {
 	id, ok := tripIDFromPath(r)
 	if !ok {
 		writeJSONError(w, http.StatusNotFound, "trip not found")
+		return
+	}
+	// "me" = leaving a trip that was shared with you — the one non-owner
+	// case; works for editors and viewer follows alike.
+	if mux.Vars(r)["userId"] == "me" {
+		row, err := store.New(dbPool).GetViewableTripByID(r.Context(),
+			store.GetViewableTripByIDParams{ID: id, UserID: user.ID})
+		if err != nil || row.ChatID == nil || row.UserID == user.ID {
+			writeJSONError(w, http.StatusNotFound, "trip not found")
+			return
+		}
+		n, err := store.New(dbPool).RevokeTripCollaborator(r.Context(), store.RevokeTripCollaboratorParams{
+			OwnerID: row.UserID, ChatID: *row.ChatID, UserID: user.ID,
+		})
+		if err != nil || n == 0 {
+			writeJSONError(w, http.StatusNotFound, "trip not found")
+			return
+		}
+		go recordEvent(user.ID, "collaborator_left", &row.ID, nil)
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 	collabID, err := uuid.Parse(mux.Vars(r)["userId"])
@@ -172,7 +213,7 @@ func listSharedWithMeHandler(w http.ResponseWriter, r *http.Request) {
 		}, nil, nil, nil, nil)
 		resp.VersionCount = int(t.VersionCount)
 		resp.Cities = t.Cities
-		resp.Access = "editor"
+		resp.Access = t.Role
 		// Owner's plan-session key — same fork hazard as getTripHandler.
 		resp.ChatID = nil
 		if t.OwnerName != "" {

--- a/src/packages/api/collaborator_integration_test.go
+++ b/src/packages/api/collaborator_integration_test.go
@@ -33,15 +33,125 @@ func TestEditorJoinAndEdit(t *testing.T) {
 	}
 }
 
-func TestViewerTokenCannotJoin(t *testing.T) {
+// Redeeming a viewer token creates a read-only "follow": the trip shows up
+// in Shared with you, reads work (without booking todos), mutations 404.
+func TestViewerTokenCreatesReadOnlyFollow(t *testing.T) {
+	resetDB(t)
+	owner, ownerToken := createTestUser(t, "owner@example.com")
+	viewer, viewerToken := createTestUser(t, "viewer@example.com")
+	trip := createTestTrip(t, owner.ID, 2)
+	shareToken := createShare(t, ownerToken, trip.ID.String(), "viewer")
+
+	join := joinShare(t, viewerToken, shareToken)
+	if join.Code != http.StatusOK {
+		t.Fatalf("viewer join = %d: %s", join.Code, join.Body.String())
+	}
+	if body := decode(t, join); body["access"] != "viewer" {
+		t.Fatalf("join access = %v, want viewer", body["access"])
+	}
+
+	// Read works, without booking todos or chat_id.
+	get := doJSON(t, "GET", "/api/v1/trips/"+trip.ID.String(), viewerToken, nil)
+	if get.Code != http.StatusOK {
+		t.Fatalf("viewer GET = %d", get.Code)
+	}
+	body := decode(t, get)
+	if body["access"] != "viewer" {
+		t.Fatalf("GET access = %v, want viewer", body["access"])
+	}
+	if body["booking_todos"] != nil {
+		t.Fatalf("viewer sees booking todos: %v", body["booking_todos"])
+	}
+	if body["chat_id"] != nil {
+		t.Fatalf("viewer sees chat_id")
+	}
+
+	// Every mutation surface stays editor/owner-only (404 posture).
+	if rec := doJSON(t, "POST", "/api/v1/trips/"+trip.ID.String()+"/items", viewerToken, map[string]any{
+		"name": "Nope", "latitude": 1.0, "longitude": 1.0,
+	}); rec.Code != http.StatusNotFound {
+		t.Fatalf("viewer add item = %d, want 404", rec.Code)
+	}
+	if rec := doJSON(t, "PATCH", "/api/v1/trips/"+trip.ID.String(), viewerToken, map[string]any{
+		"title": "Hijacked",
+	}); rec.Code != http.StatusNotFound {
+		t.Fatalf("viewer patch trip = %d, want 404", rec.Code)
+	}
+	if rec := doJSON(t, "POST", "/api/v1/trips/"+trip.ID.String()+"/booking-todos", viewerToken, map[string]any{
+		"kind": "other", "title": "Nope",
+	}); rec.Code != http.StatusNotFound {
+		t.Fatalf("viewer add todo = %d, want 404", rec.Code)
+	}
+
+	// Shared-with-me lists the follow with the viewer role.
+	shared := doJSON(t, "GET", "/api/v1/trips/shared-with-me", viewerToken, nil)
+	var rows []map[string]any
+	_ = json.Unmarshal(shared.Body.Bytes(), &rows)
+	if len(rows) != 1 || rows[0]["access"] != "viewer" {
+		t.Fatalf("shared-with-me = %v, want one viewer row", rows)
+	}
+
+	// The status poll works for viewers (freshness), and the owner's manage
+	// list shows the role.
+	if rec := doJSON(t, "GET", "/api/v1/trips/"+trip.ID.String()+"/status", viewerToken, nil); rec.Code != http.StatusOK {
+		t.Fatalf("viewer status = %d", rec.Code)
+	}
+	collabs := doJSON(t, "GET", "/api/v1/trips/"+trip.ID.String()+"/collaborators", ownerToken, nil)
+	var crows []map[string]any
+	_ = json.Unmarshal(collabs.Body.Bytes(), &crows)
+	if len(crows) != 1 || crows[0]["role"] != "viewer" || crows[0]["user_id"] != viewer.ID.String() {
+		t.Fatalf("collaborators = %v, want the viewer with role", crows)
+	}
+}
+
+// Role transitions: editor link upgrades a viewer; a viewer link never
+// downgrades an editor.
+func TestViewerEditorRoleTransitions(t *testing.T) {
+	resetDB(t)
+	owner, ownerToken := createTestUser(t, "owner@example.com")
+	_, friendToken := createTestUser(t, "friend@example.com")
+	trip := createTestTrip(t, owner.ID, 1)
+	viewerLink := createShare(t, ownerToken, trip.ID.String(), "viewer")
+	editorLink := createShare(t, ownerToken, trip.ID.String(), "editor")
+
+	if rec := joinShare(t, friendToken, viewerLink); decode(t, rec)["access"] != "viewer" {
+		t.Fatalf("first join should be viewer")
+	}
+	if rec := joinShare(t, friendToken, editorLink); decode(t, rec)["access"] != "editor" {
+		t.Fatalf("editor link should upgrade the follow")
+	}
+	// Now an editor; the viewer link must not downgrade.
+	if rec := joinShare(t, friendToken, viewerLink); decode(t, rec)["access"] != "editor" {
+		t.Fatalf("viewer link downgraded an editor")
+	}
+	add := doJSON(t, "POST", "/api/v1/trips/"+trip.ID.String()+"/items", friendToken, map[string]any{
+		"name": "Upgraded Edit", "latitude": 1.0, "longitude": 1.0,
+	})
+	if add.Code != http.StatusCreated && add.Code != http.StatusOK {
+		t.Fatalf("upgraded editor add = %d", add.Code)
+	}
+}
+
+// Members can leave via DELETE .../collaborators/me; owners can't "leave".
+func TestCollaboratorSelfLeave(t *testing.T) {
 	resetDB(t)
 	owner, ownerToken := createTestUser(t, "owner@example.com")
 	_, viewerToken := createTestUser(t, "viewer@example.com")
 	trip := createTestTrip(t, owner.ID, 1)
 	shareToken := createShare(t, ownerToken, trip.ID.String(), "viewer")
+	if rec := joinShare(t, viewerToken, shareToken); rec.Code != http.StatusOK {
+		t.Fatalf("join = %d", rec.Code)
+	}
 
-	if rec := joinShare(t, viewerToken, shareToken); rec.Code != http.StatusForbidden {
-		t.Fatalf("viewer join = %d, want 403", rec.Code)
+	if rec := doJSON(t, "DELETE", "/api/v1/trips/"+trip.ID.String()+"/collaborators/me", viewerToken, nil); rec.Code != http.StatusNoContent {
+		t.Fatalf("self-leave = %d, want 204", rec.Code)
+	}
+	if rec := doJSON(t, "GET", "/api/v1/trips/"+trip.ID.String(), viewerToken, nil); rec.Code != http.StatusNotFound {
+		t.Fatalf("read after leave = %d, want 404", rec.Code)
+	}
+	// Owner "leaving" their own trip is a 404 (they aren't a member).
+	if rec := doJSON(t, "DELETE", "/api/v1/trips/"+trip.ID.String()+"/collaborators/me", ownerToken, nil); rec.Code != http.StatusNotFound {
+		t.Fatalf("owner self-leave = %d, want 404", rec.Code)
 	}
 }
 

--- a/src/packages/api/invite_handler.go
+++ b/src/packages/api/invite_handler.go
@@ -288,8 +288,8 @@ func acceptInviteHandler(w http.ResponseWriter, r *http.Request) {
 		writeJSONError(w, http.StatusNotFound, "invite not found")
 		return
 	}
-	if err := qtx.CreateTripCollaborator(ctx, store.CreateTripCollaboratorParams{
-		ChatID: invite.ChatID, OwnerID: invite.OwnerID, UserID: user.ID,
+	if _, err := qtx.CreateTripCollaborator(ctx, store.CreateTripCollaboratorParams{
+		ChatID: invite.ChatID, OwnerID: invite.OwnerID, UserID: user.ID, Role: "editor",
 	}); err != nil {
 		writeJSONError(w, http.StatusInternalServerError, "could not join trip")
 		return

--- a/src/packages/api/query/collaborators.sql
+++ b/src/packages/api/query/collaborators.sql
@@ -1,11 +1,16 @@
--- name: CreateTripCollaborator :exec
--- Idempotent join: the partial unique index makes a second redeem a no-op.
+-- name: CreateTripCollaborator :one
+-- Idempotent join, upgrade-never-downgrade: redeeming an editor link (or
+-- invite) upgrades an existing viewer membership; redeeming a viewer link as
+-- an editor keeps editor. Returns the resulting role.
 INSERT INTO trip_collaborators (chat_id, owner_id, user_id, role)
-VALUES ($1, $2, $3, 'editor')
-ON CONFLICT (owner_id, chat_id, user_id) WHERE revoked_at IS NULL DO NOTHING;
+VALUES ($1, $2, $3, $4)
+ON CONFLICT (owner_id, chat_id, user_id) WHERE revoked_at IS NULL
+DO UPDATE SET role = CASE WHEN EXCLUDED.role = 'editor' THEN 'editor'
+                          ELSE trip_collaborators.role END
+RETURNING role;
 
 -- name: ListCollaboratorsByOwnerAndChat :many
-SELECT c.user_id, c.created_at, u.email,
+SELECT c.user_id, c.created_at, c.role, u.email,
        COALESCE(u.display_name, '')::text AS display_name
 FROM trip_collaborators c
 JOIN users u ON u.id = c.user_id
@@ -27,18 +32,29 @@ WHERE t.id = $1
         WHERE c.user_id = $2 AND c.role = 'editor' AND c.revoked_at IS NULL
           AND c.owner_id = t.user_id AND c.chat_id = t.chat_id));
 
+-- name: GetViewableTripByID :one
+-- Read access: owner or ANY active collaborator (viewer follows included).
+-- Returns the effective access so callers don't need a second lookup. The
+-- partial unique index guarantees at most one active membership per person,
+-- so the LEFT JOIN can't fan out.
+SELECT t.*, CASE WHEN t.user_id = $2 THEN 'owner' ELSE c.role END::text AS access
+FROM trips t
+LEFT JOIN trip_collaborators c ON c.owner_id = t.user_id AND c.chat_id = t.chat_id
+     AND c.user_id = $2 AND c.revoked_at IS NULL
+WHERE t.id = $1 AND (t.user_id = $2 OR c.id IS NOT NULL);
+
 -- name: ListLatestCollaboratedTripsForUser :many
 -- "Shared with you": one row per collaborated lineage (latest version), same
 -- shape as ListLatestTripsByOwner plus the owner's display name.
 SELECT latest.id, latest.user_id, latest.created_at, latest.updated_at,
        latest.title, latest.start_date, latest.end_date, latest.status,
-       latest.chat_id, latest.version_count,
+       latest.chat_id, latest.role, latest.version_count,
        COALESCE(c2.cities, ARRAY[]::text[])::text[] AS cities,
        COALESCE(u.display_name, '')::text AS owner_name
 FROM (
   SELECT DISTINCT ON (t.chat_id)
          t.id, t.user_id, t.created_at, t.updated_at, t.title, t.start_date,
-         t.end_date, t.status, t.chat_id,
+         t.end_date, t.status, t.chat_id, c.role,
          count(*) OVER (PARTITION BY t.chat_id) AS version_count
   FROM trips t
   JOIN trip_collaborators c ON c.owner_id = t.user_id AND c.chat_id = t.chat_id

--- a/src/packages/api/store/collaborators.sql.go
+++ b/src/packages/api/store/collaborators.sql.go
@@ -13,22 +13,35 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
-const createTripCollaborator = `-- name: CreateTripCollaborator :exec
+const createTripCollaborator = `-- name: CreateTripCollaborator :one
 INSERT INTO trip_collaborators (chat_id, owner_id, user_id, role)
-VALUES ($1, $2, $3, 'editor')
-ON CONFLICT (owner_id, chat_id, user_id) WHERE revoked_at IS NULL DO NOTHING
+VALUES ($1, $2, $3, $4)
+ON CONFLICT (owner_id, chat_id, user_id) WHERE revoked_at IS NULL
+DO UPDATE SET role = CASE WHEN EXCLUDED.role = 'editor' THEN 'editor'
+                          ELSE trip_collaborators.role END
+RETURNING role
 `
 
 type CreateTripCollaboratorParams struct {
 	ChatID  string    `json:"chat_id"`
 	OwnerID uuid.UUID `json:"owner_id"`
 	UserID  uuid.UUID `json:"user_id"`
+	Role    string    `json:"role"`
 }
 
-// Idempotent join: the partial unique index makes a second redeem a no-op.
-func (q *Queries) CreateTripCollaborator(ctx context.Context, arg CreateTripCollaboratorParams) error {
-	_, err := q.db.Exec(ctx, createTripCollaborator, arg.ChatID, arg.OwnerID, arg.UserID)
-	return err
+// Idempotent join, upgrade-never-downgrade: redeeming an editor link (or
+// invite) upgrades an existing viewer membership; redeeming a viewer link as
+// an editor keeps editor. Returns the resulting role.
+func (q *Queries) CreateTripCollaborator(ctx context.Context, arg CreateTripCollaboratorParams) (string, error) {
+	row := q.db.QueryRow(ctx, createTripCollaborator,
+		arg.ChatID,
+		arg.OwnerID,
+		arg.UserID,
+		arg.Role,
+	)
+	var role string
+	err := row.Scan(&role)
+	return role, err
 }
 
 const getEditableTripByID = `-- name: GetEditableTripByID :one
@@ -67,8 +80,60 @@ func (q *Queries) GetEditableTripByID(ctx context.Context, arg GetEditableTripBy
 	return i, err
 }
 
+const getViewableTripByID = `-- name: GetViewableTripByID :one
+SELECT t.id, t.user_id, t.created_at, t.updated_at, t.title, t.start_date, t.end_date, t.status, t.chat_id, t.summary, t.updated_by, CASE WHEN t.user_id = $2 THEN 'owner' ELSE c.role END::text AS access
+FROM trips t
+LEFT JOIN trip_collaborators c ON c.owner_id = t.user_id AND c.chat_id = t.chat_id
+     AND c.user_id = $2 AND c.revoked_at IS NULL
+WHERE t.id = $1 AND (t.user_id = $2 OR c.id IS NOT NULL)
+`
+
+type GetViewableTripByIDParams struct {
+	ID     uuid.UUID `json:"id"`
+	UserID uuid.UUID `json:"user_id"`
+}
+
+type GetViewableTripByIDRow struct {
+	ID        uuid.UUID   `json:"id"`
+	UserID    uuid.UUID   `json:"user_id"`
+	CreatedAt time.Time   `json:"created_at"`
+	UpdatedAt time.Time   `json:"updated_at"`
+	Title     string      `json:"title"`
+	StartDate pgtype.Date `json:"start_date"`
+	EndDate   pgtype.Date `json:"end_date"`
+	Status    string      `json:"status"`
+	ChatID    *string     `json:"chat_id"`
+	Summary   *string     `json:"summary"`
+	UpdatedBy pgtype.UUID `json:"updated_by"`
+	Access    string      `json:"access"`
+}
+
+// Read access: owner or ANY active collaborator (viewer follows included).
+// Returns the effective access so callers don't need a second lookup. The
+// partial unique index guarantees at most one active membership per person,
+// so the LEFT JOIN can't fan out.
+func (q *Queries) GetViewableTripByID(ctx context.Context, arg GetViewableTripByIDParams) (GetViewableTripByIDRow, error) {
+	row := q.db.QueryRow(ctx, getViewableTripByID, arg.ID, arg.UserID)
+	var i GetViewableTripByIDRow
+	err := row.Scan(
+		&i.ID,
+		&i.UserID,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.Title,
+		&i.StartDate,
+		&i.EndDate,
+		&i.Status,
+		&i.ChatID,
+		&i.Summary,
+		&i.UpdatedBy,
+		&i.Access,
+	)
+	return i, err
+}
+
 const listCollaboratorsByOwnerAndChat = `-- name: ListCollaboratorsByOwnerAndChat :many
-SELECT c.user_id, c.created_at, u.email,
+SELECT c.user_id, c.created_at, c.role, u.email,
        COALESCE(u.display_name, '')::text AS display_name
 FROM trip_collaborators c
 JOIN users u ON u.id = c.user_id
@@ -84,6 +149,7 @@ type ListCollaboratorsByOwnerAndChatParams struct {
 type ListCollaboratorsByOwnerAndChatRow struct {
 	UserID      uuid.UUID `json:"user_id"`
 	CreatedAt   time.Time `json:"created_at"`
+	Role        string    `json:"role"`
 	Email       string    `json:"email"`
 	DisplayName string    `json:"display_name"`
 }
@@ -100,6 +166,7 @@ func (q *Queries) ListCollaboratorsByOwnerAndChat(ctx context.Context, arg ListC
 		if err := rows.Scan(
 			&i.UserID,
 			&i.CreatedAt,
+			&i.Role,
 			&i.Email,
 			&i.DisplayName,
 		); err != nil {
@@ -116,13 +183,13 @@ func (q *Queries) ListCollaboratorsByOwnerAndChat(ctx context.Context, arg ListC
 const listLatestCollaboratedTripsForUser = `-- name: ListLatestCollaboratedTripsForUser :many
 SELECT latest.id, latest.user_id, latest.created_at, latest.updated_at,
        latest.title, latest.start_date, latest.end_date, latest.status,
-       latest.chat_id, latest.version_count,
+       latest.chat_id, latest.role, latest.version_count,
        COALESCE(c2.cities, ARRAY[]::text[])::text[] AS cities,
        COALESCE(u.display_name, '')::text AS owner_name
 FROM (
   SELECT DISTINCT ON (t.chat_id)
          t.id, t.user_id, t.created_at, t.updated_at, t.title, t.start_date,
-         t.end_date, t.status, t.chat_id,
+         t.end_date, t.status, t.chat_id, c.role,
          count(*) OVER (PARTITION BY t.chat_id) AS version_count
   FROM trips t
   JOIN trip_collaborators c ON c.owner_id = t.user_id AND c.chat_id = t.chat_id
@@ -154,6 +221,7 @@ type ListLatestCollaboratedTripsForUserRow struct {
 	EndDate      pgtype.Date `json:"end_date"`
 	Status       string      `json:"status"`
 	ChatID       *string     `json:"chat_id"`
+	Role         string      `json:"role"`
 	VersionCount int64       `json:"version_count"`
 	Cities       []string    `json:"cities"`
 	OwnerName    string      `json:"owner_name"`
@@ -180,6 +248,7 @@ func (q *Queries) ListLatestCollaboratedTripsForUser(ctx context.Context, userID
 			&i.EndDate,
 			&i.Status,
 			&i.ChatID,
+			&i.Role,
 			&i.VersionCount,
 			&i.Cities,
 			&i.OwnerName,

--- a/src/packages/api/trip_handler.go
+++ b/src/packages/api/trip_handler.go
@@ -337,11 +337,17 @@ func listTripVersionsHandler(w http.ResponseWriter, r *http.Request) {
 
 func getTripHandler(w http.ResponseWriter, r *http.Request) {
 	user, _ := userFromContext(r.Context())
-	// Owner or editor-collaborator may read; v1 has no viewer membership, so
-	// editable == viewable.
-	trip, ok := editableTrip(w, r)
+	// Owner, editor co-planner, or viewer follow may read; mutations stay
+	// behind editableTrip.
+	row, ok := viewableTrip(w, r)
 	if !ok {
 		return
+	}
+	trip := store.Trip{
+		ID: row.ID, UserID: row.UserID, CreatedAt: row.CreatedAt,
+		UpdatedAt: row.UpdatedAt, Title: row.Title, StartDate: row.StartDate,
+		EndDate: row.EndDate, Status: row.Status, ChatID: row.ChatID,
+		Summary: row.Summary, UpdatedBy: row.UpdatedBy,
 	}
 	q := store.New(dbPool)
 	items, err := q.GetItineraryItemsByTrip(r.Context(), trip.ID)
@@ -359,19 +365,22 @@ func getTripHandler(w http.ResponseWriter, r *http.Request) {
 		writeJSONError(w, http.StatusInternalServerError, "could not load segments")
 		return
 	}
-	bookingTodos, err := q.ListBookingTodosByTrip(r.Context(), trip.ID)
-	if err != nil {
-		writeJSONError(w, http.StatusInternalServerError, "could not load booking todos")
-		return
+	// Booking todos encode the owner's booking state and prices — viewer
+	// follows don't get them, matching the public share view's boundary.
+	var bookingTodos []store.BookingTodo
+	if row.Access != "viewer" {
+		bookingTodos, err = q.ListBookingTodosByTrip(r.Context(), trip.ID)
+		if err != nil {
+			writeJSONError(w, http.StatusInternalServerError, "could not load booking todos")
+			return
+		}
 	}
 	resp := toTripResponse(trip, items, accommodations, segments, bookingTodos)
-	if trip.UserID == user.ID {
-		resp.Access = "owner"
-	} else {
-		resp.Access = "editor"
+	resp.Access = row.Access
+	if row.Access != "owner" {
 		// The chat_id keys the OWNER's plan sessions; a collaborator seeding a
 		// freeform /plan chat with it would fork the lineage under their own
-		// account. Refine binds by trip_id, so editors never need it.
+		// account. Refine binds by trip_id, so members never need it.
 		resp.ChatID = nil
 		if owner, err := q.GetUserByID(r.Context(), trip.UserID); err == nil &&
 			owner.DisplayName != nil && *owner.DisplayName != "" {

--- a/src/packages/flutter-app/lib/screens/shared_trip_screen.dart
+++ b/src/packages/flutter-app/lib/screens/shared_trip_screen.dart
@@ -127,8 +127,9 @@ class _SharedTripBodyState extends ConsumerState<_SharedTripBody> {
     }
   }
 
-  /// Editor links: redeem membership, then land in the shared trip itself
-  /// (Trips tab underneath so back lands somewhere sensible).
+  /// Redeems membership — editor links join as co-planner, viewer links as a
+  /// read-only follow — then lands in the shared trip itself (Trips tab
+  /// underneath so back lands somewhere sensible).
   Future<void> _joinAsCoPlanner() async {
     if (!await _ensureSignedIn()) return;
     setState(() => _saving = true);
@@ -358,16 +359,30 @@ class _SharedTripBodyState extends ConsumerState<_SharedTripBody> {
                           ),
                       ],
                     )
-                  : FilledButton.icon(
-                      onPressed: _saving ? null : _saveCopy,
-                      icon: _saving
-                          ? const SizedBox(
-                              width: 16,
-                              height: 16,
-                              child: CircularProgressIndicator(strokeWidth: 2),
-                            )
-                          : const Icon(Icons.library_add_outlined),
-                      label: const Text('Save a copy to my trips'),
+                  : Column(
+                      mainAxisSize: MainAxisSize.min,
+                      crossAxisAlignment: CrossAxisAlignment.stretch,
+                      children: [
+                        // Viewer follow (specs/share-ux-viewer-follow): the
+                        // trip appears read-only in "Shared with you" and
+                        // stays current as the owner plans.
+                        FilledButton.icon(
+                          onPressed: _saving ? null : _joinAsCoPlanner,
+                          icon: _saving
+                              ? const SizedBox(
+                                  width: 16,
+                                  height: 16,
+                                  child:
+                                      CircularProgressIndicator(strokeWidth: 2),
+                                )
+                              : const Icon(Icons.bookmark_add_outlined),
+                          label: const Text('Keep in my trips'),
+                        ),
+                        TextButton(
+                          onPressed: _saving ? null : _saveCopy,
+                          child: const Text('Or save a separate copy'),
+                        ),
+                      ],
                     ),
             ),
           ),

--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart' show RenderAbstractViewport;
-import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:sliver_tools/sliver_tools.dart';
 import 'package:url_launcher/url_launcher.dart';
@@ -27,10 +26,12 @@ import '../providers/plan_provider.dart';
 import '../providers/events_provider.dart';
 import '../providers/ferries_provider.dart';
 import '../providers/local_provider.dart';
+import '../providers/shared_with_me_provider.dart';
 import '../providers/trip_cache_provider.dart';
 import '../services/trip_cache.dart';
 import '../theme/app_colors.dart';
 import '../theme/spacing.dart';
+import '../utils/share_link.dart';
 import '../utils/tracked_launch.dart';
 import '../utils/trip_days.dart';
 import '../utils/trip_format.dart';
@@ -212,12 +213,13 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
   }
 
   /// (Re)starts or stops the poll timer to match the loaded trip. Owners
-  /// poll when the trip has co-planners (`shared`), editors always.
+  /// poll when the trip has co-planners (`shared`); editors and viewer
+  /// follows always.
   void _syncStatusPolling() {
     final trip = _trip;
     final want = trip != null &&
         !_isOffline &&
-        (trip.access == 'editor' || (trip.shared ?? false));
+        (!trip.isOwner || (trip.shared ?? false));
     if (want) {
       _statusPoll ??=
           Timer.periodic(_statusPollInterval, (_) => _statusTick());
@@ -344,6 +346,10 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
   }
 
   bool get _isOffline => _offlineSince != null;
+
+  /// Viewer follows (access == 'viewer') see the trip without any edit
+  /// affordances — the server 404s their mutations anyway.
+  bool get _readOnly => !(_trip?.canEdit ?? true);
 
   /// Belt-and-braces offline gate at the top of every mutation method. The
   /// primary affordances are also visually disabled/hidden while offline;
@@ -1036,6 +1042,37 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
     if (mounted) showSnack(context, msg);
   }
 
+  /// Drops this shared trip from the member's own list (the owner's trip is
+  /// untouched). Editors and viewer follows alike.
+  Future<void> _leaveTrip() async {
+    final confirm = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Remove from my trips?'),
+        content: const Text(
+            "You'll lose access until you're invited again. The trip itself "
+            'is not deleted.'),
+        actions: [
+          TextButton(
+              onPressed: () => Navigator.pop(context, false),
+              child: const Text('Cancel')),
+          FilledButton(
+            onPressed: () => Navigator.pop(context, true),
+            child: const Text('Remove'),
+          ),
+        ],
+      ),
+    );
+    if (confirm != true) return;
+    try {
+      await ref.read(tripsApiServiceProvider).leaveTrip(widget.tripId);
+      ref.invalidate(sharedWithMeProvider);
+      if (mounted) Navigator.of(context).pop();
+    } catch (e) {
+      _showSnack('Could not remove trip: $e');
+    }
+  }
+
   Future<void> _addStay() async {
     if (_guardOffline()) return;
     final body = await showModalBottomSheet<Map<String, dynamic>>(
@@ -1097,27 +1134,42 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
   }
 
   /// Where the app is mounted on its host: '/' in dev, '/app/' in the
-  /// deployment build (set via --dart-define, like API_BASE_URL). Dart can't
-  /// portably read the base href, so the build injects it.
-  static const _appBasePath =
-      String.fromEnvironment('APP_BASE_PATH', defaultValue: '/');
+  /// Anchors the app-bar share menu so the iPad share popover has a rect to
+  /// point at (share_plus requires sharePositionOrigin there).
+  final GlobalKey _shareMenuKey = GlobalKey();
 
-  /// Mints (or reuses) the trip's share link and copies it to the clipboard.
-  /// Path-style form: origin + basePath + share/<token>.
+  Rect? _shareAnchorRect() {
+    final box =
+        _shareMenuKey.currentContext?.findRenderObject() as RenderBox?;
+    if (box == null || !box.hasSize) return null;
+    return box.localToGlobal(Offset.zero) & box.size;
+  }
+
+  /// "Title · dates" line that accompanies a shared link.
+  String _shareMessage(Trip trip) {
+    final dates = tripDateRange(trip.startDate, trip.endDate);
+    return dates == null
+        ? _displayTitle(trip)
+        : '${_displayTitle(trip)} · $dates';
+  }
+
+  /// Mints (or reuses) the trip's share link, then hands it to the OS share
+  /// sheet (mobile) or the clipboard (web/desktop).
   Future<void> _shareLink() async {
+    final trip = _trip;
+    if (trip == null) return;
     try {
       final token = await ref
           .read(tripsApiServiceProvider)
           .createShareLink(widget.tripId);
-      String origin;
-      try {
-        origin = Uri.base.origin;
-      } catch (_) {
-        origin = ''; // non-http platform; copy a relative link
-      }
-      final url = '$origin${_appBasePath}share/$token';
-      await Clipboard.setData(ClipboardData(text: url));
-      _showSnack('Share link copied to clipboard');
+      if (!mounted) return;
+      await shareOrCopyLink(
+        context,
+        url: shareUrl(token),
+        message: _shareMessage(trip),
+        snackOnCopy: 'Share link copied to clipboard',
+        sharePositionOrigin: _shareAnchorRect(),
+      );
     } catch (e) {
       _showSnack('Could not create share link: $e');
     }
@@ -1127,28 +1179,29 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
     try {
       await ref.read(tripsApiServiceProvider).revokeShareLink(widget.tripId);
       _showSnack(
-          'Sharing turned off — links no longer work (existing co-planners keep access)');
+          'Sharing turned off — links no longer work (existing co-planners and followers keep access)');
     } catch (e) {
       _showSnack('Could not turn off sharing: $e');
     }
   }
 
-  /// Mints an editor link and copies it — the recipient can join as a
+  /// Mints an editor link and shares/copies it — the recipient can join as a
   /// co-planner and edit this trip.
   Future<void> _inviteCoPlanner() async {
+    final trip = _trip;
+    if (trip == null) return;
     try {
       final token = await ref
           .read(tripsApiServiceProvider)
           .createShareLink(widget.tripId, role: 'editor');
-      String origin;
-      try {
-        origin = Uri.base.origin;
-      } catch (_) {
-        origin = '';
-      }
-      final url = '$origin${_appBasePath}share/$token';
-      await Clipboard.setData(ClipboardData(text: url));
-      _showSnack('Co-planner invite copied — anyone with it can edit');
+      if (!mounted) return;
+      await shareOrCopyLink(
+        context,
+        url: shareUrl(token),
+        message: 'Co-plan with me: ${_shareMessage(trip)}',
+        snackOnCopy: 'Co-planner invite copied — anyone with it can edit',
+        sharePositionOrigin: _shareAnchorRect(),
+      );
     } catch (e) {
       _showSnack('Could not create invite: $e');
     }
@@ -2042,7 +2095,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
                 tooltip: 'Open in Google Maps',
                 onPressed: () => _launch(_mapsUrl(item)),
               ),
-              _itemMenu(item),
+              if (!_readOnly) _itemMenu(item),
             ],
           ),
           selected: _selectedPosition == item.position,
@@ -2553,11 +2606,12 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
                     overflow: TextOverflow.ellipsis,
                   ),
                 ),
-                IconButton(
-                  icon: const Icon(Icons.edit, size: 20),
-                  tooltip: 'Rename',
-                  onPressed: _isOffline ? null : _editTitle,
-                ),
+                if (trip.canEdit)
+                  IconButton(
+                    icon: const Icon(Icons.edit, size: 20),
+                    tooltip: 'Rename',
+                    onPressed: _isOffline ? null : _editTitle,
+                  ),
               ],
             ),
             const SizedBox(height: 8),
@@ -2571,35 +2625,47 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
                   label: Text(hasDates
                       ? '${trip.startDate} → ${trip.endDate}'
                       : 'Add dates'),
-                  onPressed: _isOffline ? null : _editDates,
+                  onPressed:
+                      (_isOffline || !trip.canEdit) ? null : _editDates,
                 ),
-                PopupMenuButton<String>(
-                  tooltip: 'Change status',
-                  enabled: !_isOffline,
-                  onSelected: (v) => _patch(status: v),
-                  itemBuilder: (_) => const [
-                    PopupMenuItem(value: 'draft', child: Text('Draft')),
-                    PopupMenuItem(value: 'planned', child: Text('Planned')),
-                  ],
-                  child: StatusPill(
-                    status: trip.status,
-                    trailing: const Icon(Icons.arrow_drop_down),
-                  ),
-                ),
+                if (trip.canEdit)
+                  PopupMenuButton<String>(
+                    tooltip: 'Change status',
+                    enabled: !_isOffline,
+                    onSelected: (v) => _patch(status: v),
+                    itemBuilder: (_) => const [
+                      PopupMenuItem(value: 'draft', child: Text('Draft')),
+                      PopupMenuItem(value: 'planned', child: Text('Planned')),
+                    ],
+                    child: StatusPill(
+                      status: trip.status,
+                      trailing: const Icon(Icons.arrow_drop_down),
+                    ),
+                  )
+                else
+                  StatusPill(status: trip.status),
               ],
             ),
             const SizedBox(height: 12),
             if (!trip.isOwner) ...[
               Row(
                 children: [
-                  Icon(Icons.group_outlined,
-                      size: 16, color: theme.colorScheme.onSurfaceVariant),
+                  Icon(
+                      trip.canEdit
+                          ? Icons.group_outlined
+                          : Icons.visibility_outlined,
+                      size: 16,
+                      color: theme.colorScheme.onSurfaceVariant),
                   const SizedBox(width: 6),
                   Expanded(
                     child: Text(
-                      trip.ownerName != null
-                          ? 'Co-planning with ${trip.ownerName} — your changes save for everyone.'
-                          : 'Co-planning a shared trip — your changes save for everyone.',
+                      trip.canEdit
+                          ? (trip.ownerName != null
+                              ? 'Co-planning with ${trip.ownerName} — your changes save for everyone.'
+                              : 'Co-planning a shared trip — your changes save for everyone.')
+                          : (trip.ownerName != null
+                              ? 'Shared by ${trip.ownerName} — view only.'
+                              : 'Shared trip — view only.'),
                       style: theme.textTheme.bodySmall?.copyWith(
                           color: theme.colorScheme.onSurfaceVariant),
                     ),
@@ -2695,6 +2761,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
           // neither. Both mutate, so they're hidden while offline-serving.
           if (trip != null && trip.isOwner && !_isOffline)
             PopupMenuButton<String>(
+              key: _shareMenuKey,
               icon: const Icon(Icons.share_outlined),
               tooltip: 'Share trip',
               onSelected: (v) => switch (v) {
@@ -2703,13 +2770,21 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
                 'manage' => _manageCoPlanners(),
                 _ => _revokeLink(),
               },
-              itemBuilder: (context) => const [
-                PopupMenuItem(value: 'copy', child: Text('Copy share link')),
+              itemBuilder: (context) => [
                 PopupMenuItem(
-                    value: 'invite', child: Text('Copy invite link (can edit)')),
+                    value: 'copy',
+                    child: Text(shareUsesNativeSheet
+                        ? 'Share link…'
+                        : 'Copy share link')),
                 PopupMenuItem(
-                    value: 'manage', child: Text('Manage co-planners')),
-                PopupMenuItem(value: 'revoke', child: Text('Turn off sharing')),
+                    value: 'invite',
+                    child: Text(shareUsesNativeSheet
+                        ? 'Share co-planner invite…'
+                        : 'Copy invite link (can edit)')),
+                const PopupMenuItem(
+                    value: 'manage', child: Text('Manage access')),
+                const PopupMenuItem(
+                    value: 'revoke', child: Text('Turn off sharing')),
               ],
             ),
           if (trip != null && trip.isOwner && !_isOffline)
@@ -2717,6 +2792,14 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
               icon: const Icon(Icons.delete_outline),
               tooltip: 'Delete trip',
               onPressed: _delete,
+            ),
+          // Members (editors and viewer follows) can drop the trip from
+          // their own list; the owner's trip is untouched.
+          if (trip != null && !trip.isOwner && !_isOffline)
+            IconButton(
+              icon: const Icon(Icons.bookmark_remove_outlined),
+              tooltip: 'Remove from my trips',
+              onPressed: _leaveTrip,
             ),
         ],
       ),
@@ -2875,7 +2958,8 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
                                               ? null
                                               : 'Add a place to see it '
                                                   'on the map.',
-                                          emptyAction: _isOffline
+                                          emptyAction: (_isOffline ||
+                                                  _readOnly)
                                               ? null
                                               : FilledButton.tonalIcon(
                                                   onPressed: () => _addPlace(
@@ -2969,17 +3053,19 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
                                             ),
                                             const SizedBox(width: 4),
                                           ],
-                                          TextButton.icon(
-                                            onPressed:
-                                                _isOffline ? null : _addPlace,
-                                            style: TextButton.styleFrom(
-                                              visualDensity:
-                                                  VisualDensity.compact,
+                                          if (!_readOnly)
+                                            TextButton.icon(
+                                              onPressed: _isOffline
+                                                  ? null
+                                                  : _addPlace,
+                                              style: TextButton.styleFrom(
+                                                visualDensity:
+                                                    VisualDensity.compact,
+                                              ),
+                                              icon: const Icon(Icons.add,
+                                                  size: 18),
+                                              label: const Text('Add place'),
                                             ),
-                                            icon:
-                                                const Icon(Icons.add, size: 18),
-                                            label: const Text('Add place'),
-                                          ),
                                         ],
                                       ),
                                     ),
@@ -3097,6 +3183,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
                                   // checklist above.
                                   BookingsSection(
                                     trip: trip,
+                                    readOnly: _readOnly,
                                     onAddStay: _addStay,
                                     onDeleteStay: _deleteStay,
                                     onAddSegment: _addSegment,
@@ -3105,7 +3192,9 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
                                   // Bookings live embedded in their city groups;
                                   // this section appears only when something
                                   // didn't match a city (custom or stale todos).
-                                  if (grouped.residual.isEmpty)
+                                  // Viewers get no checklist at all (the server
+                                  // withholds todos from them).
+                                  if (grouped.residual.isEmpty && !_readOnly)
                                     Align(
                                       alignment: Alignment.centerRight,
                                       child: TextButton.icon(
@@ -3772,7 +3861,8 @@ class _CoPlannersSheet extends ConsumerStatefulWidget {
 }
 
 class _CoPlannersSheetState extends ConsumerState<_CoPlannersSheet> {
-  List<({String userId, String displayName, String email})>? _collaborators;
+  List<({String userId, String displayName, String email, String role})>?
+      _collaborators;
   List<({String id, String email, DateTime expiresAt})>? _invites;
   final _emailController = TextEditingController();
   bool _sending = false;
@@ -3799,8 +3889,8 @@ class _CoPlannersSheetState extends ConsumerState<_CoPlannersSheet> {
       ]);
       if (mounted) {
         setState(() {
-          _collaborators =
-              results[0] as List<({String userId, String displayName, String email})>;
+          _collaborators = results[0]
+              as List<({String userId, String displayName, String email, String role})>;
           _invites =
               results[1] as List<({String id, String email, DateTime expiresAt})>;
         });
@@ -3878,7 +3968,7 @@ class _CoPlannersSheetState extends ConsumerState<_CoPlannersSheet> {
           mainAxisSize: MainAxisSize.min,
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Text('Co-planners', style: theme.textTheme.titleMedium),
+            Text('Manage access', style: theme.textTheme.titleMedium),
             const SizedBox(height: AppSpacing.sm),
             // Invite by email (specs/invite-by-email): the friend gets a
             // single-use link; they appear below once they accept.
@@ -3925,11 +4015,18 @@ class _CoPlannersSheetState extends ConsumerState<_CoPlannersSheet> {
               for (final c in collaborators)
                 ListTile(
                   contentPadding: EdgeInsets.zero,
-                  leading:
-                      const CircleAvatar(child: Icon(Icons.person, size: 18)),
+                  leading: CircleAvatar(
+                      child: Icon(
+                          c.role == 'viewer'
+                              ? Icons.visibility_outlined
+                              : Icons.person,
+                          size: 18)),
                   title: Text(
                       c.displayName.isNotEmpty ? c.displayName : c.email),
-                  subtitle: c.displayName.isNotEmpty ? Text(c.email) : null,
+                  subtitle: Text([
+                    if (c.displayName.isNotEmpty) c.email,
+                    c.role == 'viewer' ? 'Viewer' : 'Can edit',
+                  ].join(' · ')),
                   trailing: IconButton(
                     icon: const Icon(Icons.person_remove_outlined),
                     tooltip: 'Remove access',

--- a/src/packages/flutter-app/lib/screens/trips_list_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trips_list_screen.dart
@@ -296,7 +296,9 @@ class _TripCard extends ConsumerWidget {
           StatusPill(status: trip.status),
           if (!trip.isOwner && (trip.ownerName ?? '').isNotEmpty)
             Text(
-              'Planned with ${trip.ownerName}',
+              trip.canEdit
+                  ? 'Planned with ${trip.ownerName}'
+                  : 'Shared by ${trip.ownerName}',
               style: Theme.of(context).textTheme.bodySmall?.copyWith(
                   color: Theme.of(context).colorScheme.onSurfaceVariant),
             ),
@@ -307,7 +309,11 @@ class _TripCard extends ConsumerWidget {
     if (!hasHistory) {
       return Card(
         child: ListTile(
-          leading: Icon(trip.isOwner ? Icons.map_outlined : Icons.group_outlined),
+          leading: Icon(trip.isOwner
+              ? Icons.map_outlined
+              : trip.canEdit
+                  ? Icons.group_outlined
+                  : Icons.visibility_outlined),
           title: title,
           subtitle: subtitle,
           trailing: const Icon(Icons.chevron_right),

--- a/src/packages/flutter-app/lib/services/trips_api_service.dart
+++ b/src/packages/flutter-app/lib/services/trips_api_service.dart
@@ -152,8 +152,8 @@ class TripsApiService {
     throw Exception('Failed to load shared trips (${res.statusCode})');
   }
 
-  /// Owner-only: active co-planners on a trip.
-  Future<List<({String userId, String displayName, String email})>>
+  /// Owner-only: active co-planners and viewer follows on a trip.
+  Future<List<({String userId, String displayName, String email, String role})>>
       listCollaborators(String tripId) async {
     final res = await apiClient.httpClient.get(
       Uri.parse('${apiClient.baseUrl}/trips/$tripId/collaborators'),
@@ -166,10 +166,22 @@ class TripsApiService {
                 userId: e['user_id'] as String,
                 displayName: (e['display_name'] as String?) ?? '',
                 email: (e['email'] as String?) ?? '',
+                role: (e['role'] as String?) ?? 'editor',
               ))
           .toList();
     }
     throw Exception('Failed to load co-planners (${res.statusCode})');
+  }
+
+  /// Leaves a trip that was shared with the caller (editor or viewer).
+  Future<void> leaveTrip(String tripId) async {
+    final res = await apiClient.httpClient.delete(
+      Uri.parse('${apiClient.baseUrl}/trips/$tripId/collaborators/me'),
+      headers: apiClient.jsonHeaders(),
+    );
+    if (res.statusCode != 204) {
+      throw Exception('Failed to leave trip (${res.statusCode})');
+    }
   }
 
   /// Owner-only: removes a co-planner's access.

--- a/src/packages/flutter-app/lib/utils/share_link.dart
+++ b/src/packages/flutter-app/lib/utils/share_link.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/foundation.dart'
+    show defaultTargetPlatform, kIsWeb, TargetPlatform;
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:share_plus/share_plus.dart';
+import 'snack.dart';
+
+/// Base path the Flutter app is served under, injected by the deployment
+/// build via --dart-define (like API_BASE_URL). Dart can't portably read the
+/// base href.
+const appBasePath =
+    String.fromEnvironment('APP_BASE_PATH', defaultValue: '/');
+
+/// Public URL for a share token: origin + basePath + share/<token>.
+String shareUrl(String token) {
+  String origin;
+  try {
+    origin = Uri.base.origin;
+  } catch (_) {
+    origin = ''; // non-http platform; a relative link still works in-app
+  }
+  return '$origin${appBasePath}share/$token';
+}
+
+/// Whether share actions present the OS share sheet (mobile) instead of a
+/// clipboard copy (web/desktop, where navigator.share support is patchy and
+/// the clipboard is the dependable UX). Drives menu labels too.
+bool get shareUsesNativeSheet =>
+    !kIsWeb &&
+    (defaultTargetPlatform == TargetPlatform.iOS ||
+        defaultTargetPlatform == TargetPlatform.android);
+
+/// Shares [url] via the OS share sheet on mobile, or copies it to the
+/// clipboard elsewhere (with [snackOnCopy] feedback). [sharePositionOrigin]
+/// is the tapped control's global rect — REQUIRED on iPad, where the share
+/// popover anchors to it and share_plus crashes without one.
+Future<void> shareOrCopyLink(
+  BuildContext context, {
+  required String url,
+  required String message,
+  required String snackOnCopy,
+  Rect? sharePositionOrigin,
+}) async {
+  if (shareUsesNativeSheet) {
+    await SharePlus.instance.share(ShareParams(
+      text: '$message\n$url',
+      subject: message,
+      sharePositionOrigin: sharePositionOrigin,
+    ));
+  } else {
+    await Clipboard.setData(ClipboardData(text: url));
+    if (context.mounted) showSnack(context, snackOnCopy);
+  }
+}

--- a/src/packages/flutter-app/lib/widgets/bookings_section.dart
+++ b/src/packages/flutter-app/lib/widgets/bookings_section.dart
@@ -16,6 +16,10 @@ class BookingsSection extends StatelessWidget {
   final VoidCallback onAddSegment;
   final void Function(TripSegment) onDeleteSegment;
 
+  /// Read-only mode (viewer follows): stays and transport render without the
+  /// add buttons and delete icons.
+  final bool readOnly;
+
   const BookingsSection({
     super.key,
     required this.trip,
@@ -23,6 +27,7 @@ class BookingsSection extends StatelessWidget {
     required this.onDeleteStay,
     required this.onAddSegment,
     required this.onDeleteSegment,
+    this.readOnly = false,
   });
 
   static IconData _modeIcon(String mode) => switch (mode) {
@@ -64,16 +69,18 @@ class BookingsSection extends StatelessWidget {
             Expanded(
               child: Text('Your bookings', style: theme.textTheme.titleMedium),
             ),
-            TextButton.icon(
-              onPressed: onAddStay,
-              icon: const Icon(Icons.hotel_outlined, size: 18),
-              label: const Text('Add stay'),
-            ),
-            TextButton.icon(
-              onPressed: onAddSegment,
-              icon: const Icon(Icons.route_outlined, size: 18),
-              label: const Text('Add transport'),
-            ),
+            if (!readOnly) ...[
+              TextButton.icon(
+                onPressed: onAddStay,
+                icon: const Icon(Icons.hotel_outlined, size: 18),
+                label: const Text('Add stay'),
+              ),
+              TextButton.icon(
+                onPressed: onAddSegment,
+                icon: const Icon(Icons.route_outlined, size: 18),
+                label: const Text('Add transport'),
+              ),
+            ],
           ],
         ),
         if (stays.isEmpty && segments.isEmpty)
@@ -110,11 +117,12 @@ class BookingsSection extends StatelessWidget {
                       onPressed: () => _open(context, a.url!,
                           provider: a.provider, kind: 'stay'),
                     ),
-                  IconButton(
-                    icon: const Icon(Icons.delete_outline, size: 18),
-                    tooltip: 'Remove stay',
-                    onPressed: () => onDeleteStay(a),
-                  ),
+                  if (!readOnly)
+                    IconButton(
+                      icon: const Icon(Icons.delete_outline, size: 18),
+                      tooltip: 'Remove stay',
+                      onPressed: () => onDeleteStay(a),
+                    ),
                 ],
               ),
             ),
@@ -145,11 +153,12 @@ class BookingsSection extends StatelessWidget {
                       onPressed: () => _open(context, s.url!,
                           provider: s.provider, kind: 'transport'),
                     ),
-                  IconButton(
-                    icon: const Icon(Icons.delete_outline, size: 18),
-                    tooltip: 'Remove transport',
-                    onPressed: () => onDeleteSegment(s),
-                  ),
+                  if (!readOnly)
+                    IconButton(
+                      icon: const Icon(Icons.delete_outline, size: 18),
+                      tooltip: 'Remove transport',
+                      onPressed: () => onDeleteSegment(s),
+                    ),
                 ],
               ),
             ),

--- a/src/packages/flutter-app/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/src/packages/flutter-app/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -8,6 +8,7 @@ import Foundation
 import flutter_secure_storage_macos
 import path_provider_foundation
 import record_macos
+import share_plus
 import shared_preferences_foundation
 import speech_to_text
 import url_launcher_macos
@@ -16,6 +17,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FlutterSecureStoragePlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStoragePlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   RecordMacOsPlugin.register(with: registry.registrar(forPlugin: "RecordMacOsPlugin"))
+  SharePlusMacosPlugin.register(with: registry.registrar(forPlugin: "SharePlusMacosPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
   SpeechToTextPlugin.register(with: registry.registrar(forPlugin: "SpeechToTextPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))

--- a/src/packages/flutter-app/pubspec.lock
+++ b/src/packages/flutter-app/pubspec.lock
@@ -177,6 +177,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.2"
+  cross_file:
+    dependency: transitive
+    description:
+      name: cross_file
+      sha256: "28bb3ae56f117b5aec029d702a90f57d285cd975c3c5c281eaca38dbc47c5937"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.5+2"
   crypto:
     dependency: transitive
     description:
@@ -824,6 +832,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.6.1"
+  share_plus:
+    dependency: "direct main"
+    description:
+      name: share_plus
+      sha256: "223873d106614442ea6f20db5a038685cc5b32a2fba81cdecaefbbae0523f7fa"
+      url: "https://pub.dev"
+    source: hosted
+    version: "12.0.2"
+  share_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: share_plus_platform_interface
+      sha256: "88023e53a13429bd65d8e85e11a9b484f49d4c190abbd96c7932b74d6927cc9a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.1.0"
   shared_preferences:
     dependency: "direct main"
     description:

--- a/src/packages/flutter-app/pubspec.yaml
+++ b/src/packages/flutter-app/pubspec.yaml
@@ -59,6 +59,9 @@ dependencies:
   # Open external Airbnb/Booking links
   url_launcher: ^6.3.0
 
+  # Native OS share sheet for trip links (mobile; web/desktop copy instead)
+  share_plus: ^12.0.2
+
   # Render airline logos (Duffel serves them as SVG)
   flutter_svg: ^2.0.10
 

--- a/src/packages/flutter-app/windows/flutter/generated_plugin_registrant.cc
+++ b/src/packages/flutter-app/windows/flutter/generated_plugin_registrant.cc
@@ -8,6 +8,7 @@
 
 #include <flutter_secure_storage_windows/flutter_secure_storage_windows_plugin.h>
 #include <record_windows/record_windows_plugin_c_api.h>
+#include <share_plus/share_plus_windows_plugin_c_api.h>
 #include <speech_to_text_windows/speech_to_text_windows.h>
 #include <url_launcher_windows/url_launcher_windows.h>
 
@@ -16,6 +17,8 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("FlutterSecureStorageWindowsPlugin"));
   RecordWindowsPluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("RecordWindowsPluginCApi"));
+  SharePlusWindowsPluginCApiRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("SharePlusWindowsPluginCApi"));
   SpeechToTextWindowsRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("SpeechToTextWindows"));
   UrlLauncherWindowsRegisterWithRegistrar(

--- a/src/packages/flutter-app/windows/flutter/generated_plugins.cmake
+++ b/src/packages/flutter-app/windows/flutter/generated_plugins.cmake
@@ -5,6 +5,7 @@
 list(APPEND FLUTTER_PLUGIN_LIST
   flutter_secure_storage_windows
   record_windows
+  share_plus
   speech_to_text_windows
   url_launcher_windows
 )


### PR DESCRIPTION
## Summary

Sharing v2, PR 4 of 4 (specs/share-ux-viewer-follow). Stacked on #124.

**Viewer follow** (no migration — `trip_collaborators.role` already existed):
- `POST /shared/{token}/join` accepts viewer tokens → viewer-role membership. The upsert is role-aware with upgrade-never-downgrade (`CASE` in `ON CONFLICT DO UPDATE`, RETURNING the resulting role) — an editor link upgrades a follower; a viewer link never downgrades an editor.
- New `GetViewableTripByID` seam (owner or any active member, returns effective access) used by `getTripHandler` and the analytics trip-validation gate; **all mutation handlers keep `GetEditableTripByID`**, so viewers are read-only for free (mutations 404). Viewers' trip reads omit booking todos (same boundary as the public share view) and `chat_id`.
- `shared-with-me` + collaborators list carry real roles; `DELETE /trips/{id}/collaborators/me` lets any member (editor or viewer) leave.
- Flutter: viewer links get a primary **"Keep in my trips"**; trip detail renders a full read-only mode for `access == 'viewer'` (view-only banner, static status pill, no edit/add/refine surfaces, no checklist) with an app-bar "Remove from my trips"; trips-list viewer cards show an eye icon + "Shared by {owner}"; the manage sheet is now "Manage access" with per-row roles; freshness polling extends to viewers.

**Native share sheet**:
- `share_plus ^12.0.2` + new `lib/utils/share_link.dart` — OS share sheet on iOS/Android with "{title} · {dates}" + URL and the iPad-mandatory `sharePositionOrigin` (anchored to the share menu); web/desktop keep clipboard copy; menu labels adapt ("Share link…" vs "Copy share link").

## Testing

- Integration tests: `TestViewerTokenCreatesReadOnlyFollow` (read without todos/chat_id, mutations 404, roles in both lists, status poll), `TestViewerEditorRoleTransitions`, `TestCollaboratorSelfLeave` (replaces the obsolete viewer-403 test). Full Go suite green.
- `flutter analyze` clean; all Flutter tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)