### PR TITLE
feat(flutter): savings pill on the best baggage-aware flight offer

### DIFF
--- a/src/packages/api/price_alert_checker_test.go
+++ b/src/packages/api/price_alert_checker_test.go
@@ -281,6 +281,7 @@ func TestAlertCheckerRunOnce(t *testing.T) {
 			UserID: u.ID, Origin: "BOS", Destination: "CDG",
 			DepartDate: pgtype.Date{Time: depart, Valid: true},
 			CabinClass: "economy", Adults: 1, TargetPrice: target,
+			Baggage: baggagePersonalItem,
 		})
 		if err != nil {
 			t.Fatalf("seed alert: %v", err)
@@ -347,6 +348,7 @@ func TestAlertCheckerInsertsEvents(t *testing.T) {
 		UserID: userA.ID, Origin: "BOS", Destination: "CDG",
 		DepartDate: pgtype.Date{Time: depart, Valid: true},
 		CabinClass: "economy", Adults: 1, TargetPrice: f64(450),
+		Baggage:          baggagePersonalItem,
 		LastCheckedPrice: f64(498), Currency: &usd,
 		LastCheckedAt: pgTimestamptz(time.Now().Add(-7 * time.Hour)),
 	})
@@ -357,7 +359,7 @@ func TestAlertCheckerInsertsEvents(t *testing.T) {
 	if _, err := q.CreatePriceAlert(context.Background(), store.CreatePriceAlertParams{
 		UserID: userB.ID, Origin: "BOS", Destination: "CDG",
 		DepartDate: pgtype.Date{Time: depart, Valid: true},
-		CabinClass: "economy", Adults: 1,
+		CabinClass: "economy", Adults: 1, Baggage: baggagePersonalItem,
 	}); err != nil {
 		t.Fatalf("seed alert B: %v", err)
 	}
@@ -471,6 +473,7 @@ func TestAlertCheckerFlexFanOut(t *testing.T) {
 		UserID: user.ID, Origin: "BOS", Destination: "CDG",
 		DepartDate: pgtype.Date{Time: depart, Valid: true},
 		CabinClass: "economy", Adults: 1, TargetPrice: f64(450), FlexDays: 1,
+		Baggage: baggagePersonalItem,
 	}); err != nil {
 		t.Fatalf("seed flex alert: %v", err)
 	}
@@ -534,6 +537,7 @@ func TestAlertCheckerFlexRespectsBatchLimit(t *testing.T) {
 		UserID: user.ID, Origin: "BOS", Destination: "CDG",
 		DepartDate: pgtype.Date{Time: depart, Valid: true},
 		CabinClass: "economy", Adults: 1, TargetPrice: f64(450), FlexDays: 1,
+		Baggage: baggagePersonalItem,
 	}); err != nil {
 		t.Fatalf("seed flex alert: %v", err)
 	}

--- a/src/packages/flutter-app/lib/screens/flight_search_screen.dart
+++ b/src/packages/flutter-app/lib/screens/flight_search_screen.dart
@@ -602,14 +602,17 @@ class _Results extends StatelessWidget {
       );
     }
 
+    final savingsLabel = savingsLabelFor(state.offers, state.bestOfferId);
     return ListView.builder(
       padding: const EdgeInsets.all(16),
       itemCount: state.offers.length,
       itemBuilder: (context, i) {
         final offer = state.offers[i];
+        final isBest = offer.id == state.bestOfferId;
         return FlightOfferCard(
           offer: offer,
-          isBest: offer.id == state.bestOfferId,
+          isBest: isBest,
+          savingsLabel: isBest ? savingsLabel : null,
         );
       },
     );

--- a/src/packages/flutter-app/lib/widgets/flight_offer_card.dart
+++ b/src/packages/flutter-app/lib/widgets/flight_offer_card.dart
@@ -4,7 +4,40 @@ import '../models/flight_offer.dart';
 import '../utils/tracked_launch.dart';
 import 'airline_logo.dart';
 import 'flight_details_sheet.dart';
+import 'status_pill.dart';
 import '../utils/snack.dart';
+
+/// "Saves USD 23 vs next option" for the best-ranked offer on a baggage-aware
+/// search, comparing effective totals (fare + bag fee). Null when there is
+/// nothing honest to claim: bare-fare searches, an unpriceable bag on the best
+/// offer, no comparable alternative (unknown fees and other currencies are
+/// skipped — their totals understate or don't compare), or a saving that would
+/// round to zero.
+String? savingsLabelFor(List<FlightOffer> offers, String? bestOfferId) {
+  FlightOffer? best;
+  for (final o in offers) {
+    if (o.id == bestOfferId) {
+      best = o;
+      break;
+    }
+  }
+  if (best == null || best.baggageStatus == null || best.bagFeeUnknown) {
+    return null;
+  }
+  double? nextBest;
+  for (final o in offers) {
+    if (o.id == best.id || o.bagFeeUnknown || o.currency != best.currency) {
+      continue;
+    }
+    if (nextBest == null || o.displayPrice < nextBest) {
+      nextBest = o.displayPrice;
+    }
+  }
+  if (nextBest == null) return null;
+  final saved = nextBest - best.displayPrice;
+  if (saved < 0.5) return null;
+  return 'Saves ${best.currency} ${saved.toStringAsFixed(0)} vs next option';
+}
 
 /// A single ranked flight offer rendered as a card — airline(s), route, price,
 /// score, duration/stops, and a Book deep-link. Shared by the standalone
@@ -13,7 +46,12 @@ import '../utils/snack.dart';
 class FlightOfferCard extends StatelessWidget {
   final FlightOffer offer;
   final bool isBest;
-  const FlightOfferCard({super.key, required this.offer, this.isBest = false});
+
+  /// Green savings pill next to the BEST MATCH badge; the results list
+  /// computes it via [savingsLabelFor] so the card stays presentational.
+  final String? savingsLabel;
+  const FlightOfferCard(
+      {super.key, required this.offer, this.isBest = false, this.savingsLabel});
 
   /// Baggage badge under the price on baggage-aware searches; null otherwise.
   /// "paid" prices already fold the fee into [FlightOffer.displayPrice] — the
@@ -53,21 +91,35 @@ class FlightOfferCard extends StatelessWidget {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              if (isBest)
+              if (isBest || savingsLabel != null)
                 Padding(
                   padding: const EdgeInsets.only(bottom: 8),
-                  child: Container(
-                    padding:
-                        const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
-                    decoration: BoxDecoration(
-                      color: accent,
-                      borderRadius: BorderRadius.circular(8),
-                    ),
-                    child: const Text('BEST MATCH',
-                        style: TextStyle(
-                            color: Colors.white,
-                            fontSize: 11,
-                            fontWeight: FontWeight.bold)),
+                  child: Wrap(
+                    spacing: 6,
+                    runSpacing: 4,
+                    crossAxisAlignment: WrapCrossAlignment.center,
+                    children: [
+                      if (isBest)
+                        Container(
+                          padding: const EdgeInsets.symmetric(
+                              horizontal: 8, vertical: 3),
+                          decoration: BoxDecoration(
+                            color: accent,
+                            borderRadius: BorderRadius.circular(8),
+                          ),
+                          child: const Text('BEST MATCH',
+                              style: TextStyle(
+                                  color: Colors.white,
+                                  fontSize: 11,
+                                  fontWeight: FontWeight.bold)),
+                        ),
+                      if (savingsLabel case final label?)
+                        StatusPill.custom(
+                          label: label,
+                          background: Colors.green.withValues(alpha: 0.15),
+                          foreground: Colors.green.shade800,
+                        ),
+                    ],
                   ),
                 ),
               Row(

--- a/src/packages/flutter-app/test/flight_savings_pill_test.dart
+++ b/src/packages/flutter-app/test/flight_savings_pill_test.dart
@@ -1,0 +1,118 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:travel_route_planner/models/flight_offer.dart';
+import 'package:travel_route_planner/widgets/flight_offer_card.dart';
+
+FlightOffer _offer(
+  String id,
+  double price, {
+  String? baggageStatus,
+  double? effectivePrice,
+  String currency = 'USD',
+}) =>
+    FlightOffer(
+      id: id,
+      price: price,
+      currency: currency,
+      stops: 0,
+      durationMinutes: 420,
+      airlines: const ['TestAir'],
+      departTime: '2026-09-01T18:00:00',
+      arriveTime: '2026-09-02T07:00:00',
+      segments: const [],
+      baggageStatus: baggageStatus,
+      effectivePrice: effectivePrice,
+    );
+
+void main() {
+  group('savingsLabelFor', () {
+    test('labels the saving between the best and next effective total', () {
+      final offers = [
+        _offer('a', 200, baggageStatus: 'included', effectivePrice: 200),
+        _offer('b', 180, baggageStatus: 'paid', effectivePrice: 223),
+        _offer('c', 190, baggageStatus: 'paid', effectivePrice: 250),
+      ];
+      expect(savingsLabelFor(offers, 'a'), 'Saves USD 23 vs next option');
+    });
+
+    test('null on bare-fare searches (no baggage status)', () {
+      final offers = [_offer('a', 200), _offer('b', 230)];
+      expect(savingsLabelFor(offers, 'a'), isNull);
+    });
+
+    test('null when the best offer\'s bag fee is unknown', () {
+      final offers = [
+        _offer('a', 180, baggageStatus: 'unknown'),
+        _offer('b', 200, baggageStatus: 'included', effectivePrice: 200),
+      ];
+      expect(savingsLabelFor(offers, 'a'), isNull);
+    });
+
+    test('skips unknown-fee and foreign-currency alternatives', () {
+      final offers = [
+        _offer('a', 200, baggageStatus: 'included', effectivePrice: 200),
+        _offer('b', 150, baggageStatus: 'unknown'),
+        _offer('c', 100, baggageStatus: 'paid', effectivePrice: 140,
+            currency: 'EUR'),
+        _offer('d', 210, baggageStatus: 'paid', effectivePrice: 260),
+      ];
+      expect(savingsLabelFor(offers, 'a'), 'Saves USD 60 vs next option');
+      expect(savingsLabelFor([offers[0], offers[1]], 'a'), isNull);
+    });
+
+    test('null when the best match is not the cheapest or saving rounds to 0',
+        () {
+      final dearerBest = [
+        _offer('a', 260, baggageStatus: 'included', effectivePrice: 260),
+        _offer('b', 180, baggageStatus: 'paid', effectivePrice: 223),
+      ];
+      expect(savingsLabelFor(dearerBest, 'a'), isNull);
+      final nearTie = [
+        _offer('a', 200, baggageStatus: 'included', effectivePrice: 200),
+        _offer('b', 180, baggageStatus: 'paid', effectivePrice: 200.3),
+      ];
+      expect(savingsLabelFor(nearTie, 'a'), isNull);
+    });
+
+    test('null when the best offer id is absent', () {
+      final offers = [
+        _offer('a', 200, baggageStatus: 'included', effectivePrice: 200),
+      ];
+      expect(savingsLabelFor(offers, null), isNull);
+      expect(savingsLabelFor(offers, 'zzz'), isNull);
+    });
+  });
+
+  group('FlightOfferCard savings pill', () {
+    testWidgets('renders the pill next to BEST MATCH when a label is passed',
+        (tester) async {
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: FlightOfferCard(
+            offer: _offer('a', 200,
+                baggageStatus: 'included', effectivePrice: 200),
+            isBest: true,
+            savingsLabel: 'Saves USD 23 vs next option',
+          ),
+        ),
+      ));
+      expect(find.text('BEST MATCH'), findsOneWidget);
+      expect(find.text('Saves USD 23 vs next option'), findsOneWidget);
+    });
+
+    testWidgets('renders no pill by default', (tester) async {
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: FlightOfferCard(
+            offer: _offer('a', 200,
+                baggageStatus: 'included', effectivePrice: 200),
+            isBest: true,
+          ),
+        ),
+      ));
+      expect(find.text('BEST MATCH'), findsOneWidget);
+      expect(find.textContaining('vs next option'), findsNothing);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Best-match flight card now shows a green "Saves USD X vs next option" pill on baggage-aware searches, quantifying how much the top pick's effective total (fare + bag fee) beats the next-cheapest comparable alternative — the follow-up left open by #126.
- The comparison lives in a testable `savingsLabelFor(offers, bestOfferId)` helper; the card stays presentational via a new optional `savingsLabel` param rendered as `StatusPill.custom` beside the BEST MATCH badge.
- The pill never overclaims: no label on bare-fare searches, when the best offer's bag fee is unknown, when the best match isn't the cheapest (e.g. optimize-for-time), or when the saving rounds to zero; unknown-fee and foreign-currency offers are excluded from the "next option" pool.

## Testing
- `flutter test` — full suite passes, including 8 new tests in `test/flight_savings_pill_test.dart` (helper edge cases + pill render/absence).
- `flutter analyze` — only the 12 pre-existing infos in unrelated files.
- Data inputs (`displayPrice`, `baggageStatus`) were e2e-verified against the Duffel test token when #126 shipped; this change is widget-level on top of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)