### PR TITLE
feat: drag-to-reorder for Other bookings cards on trip detail

### DIFF
--- a/src/packages/api/booking_todo_handler.go
+++ b/src/packages/api/booking_todo_handler.go
@@ -322,6 +322,87 @@ func patchBookingTodoHandler(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, toBookingTodoResponse(todo))
 }
 
+type ReorderBookingTodosRequest struct {
+	TodoIDs []string `json:"todo_ids"`
+}
+
+// reorderBookingTodosHandler reassigns positions 0..n-1 to the submitted todo
+// ids — a subset of the trip's todos, not a full permutation. The client only
+// sends its draggable residual ("Other bookings") list: city-grouped todos
+// render slot-matched by todo_key regardless of position, and their positions
+// are re-upserted from the derived payload on every sync anyway. Residual rows
+// are durably custom (auto = false), which sync never rewrites, so the order
+// set here sticks.
+func reorderBookingTodosHandler(w http.ResponseWriter, r *http.Request) {
+	trip, ok := editableTrip(w, r)
+	if !ok {
+		return
+	}
+	tripID := trip.ID
+	var req ReorderBookingTodosRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid JSON")
+		return
+	}
+	if len(req.TodoIDs) == 0 {
+		writeJSONError(w, http.StatusBadRequest, "todo_ids is required")
+		return
+	}
+
+	ctx := r.Context()
+	tx, err := dbPool.Begin(ctx)
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "could not reorder booking todos")
+		return
+	}
+	defer tx.Rollback(ctx)
+	q := store.New(tx)
+
+	// Serialize against concurrent syncs/reorders so the stale-set 409 below
+	// stays reliable between this read and commit.
+	if _, err := q.GetTripForUpdate(ctx, tripID); err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "could not reorder booking todos")
+		return
+	}
+	todos, err := q.ListBookingTodosByTrip(ctx, tripID)
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "could not load booking todos")
+		return
+	}
+	existing := make(map[uuid.UUID]bool, len(todos))
+	for _, t := range todos {
+		existing[t.ID] = true
+	}
+	ordered := make([]uuid.UUID, 0, len(req.TodoIDs))
+	seen := make(map[uuid.UUID]bool, len(req.TodoIDs))
+	for _, raw := range req.TodoIDs {
+		id, err := uuid.Parse(raw)
+		if err != nil || !existing[id] || seen[id] {
+			writeJSONError(w, http.StatusConflict, "booking list is out of date; reload the trip")
+			return
+		}
+		seen[id] = true
+		ordered = append(ordered, id)
+	}
+	for pos, id := range ordered {
+		if err := q.SetBookingTodoPosition(ctx, store.SetBookingTodoPositionParams{
+			ID: id, TripID: tripID, Position: int32(pos),
+		}); err != nil {
+			writeJSONError(w, http.StatusInternalServerError, "could not reorder booking todos")
+			return
+		}
+	}
+	if err := q.TouchTrip(ctx, touchedBy(tripID, r)); err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "could not reorder booking todos")
+		return
+	}
+	if err := tx.Commit(ctx); err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "could not reorder booking todos")
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
 func deleteBookingTodoHandler(w http.ResponseWriter, r *http.Request) {
 	trip, ok := editableTrip(w, r)
 	if !ok {

--- a/src/packages/api/booking_todo_reorder_integration_test.go
+++ b/src/packages/api/booking_todo_reorder_integration_test.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+func addCustomTodo(t *testing.T, token, tripID, title string) string {
+	t.Helper()
+	rec := doJSON(t, "POST", "/api/v1/trips/"+tripID+"/booking-todos", token, map[string]any{
+		"kind": "other", "title": title,
+	})
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("add todo %q = %d: %s", title, rec.Code, rec.Body.String())
+	}
+	return decode(t, rec)["id"].(string)
+}
+
+// listTodosViaSync exercises the same read path the app uses on trip load: an
+// empty derived payload upserts nothing but returns the full ordered list.
+func listTodosViaSync(t *testing.T, token, tripID string) []map[string]any {
+	t.Helper()
+	rec := doJSON(t, "PUT", "/api/v1/trips/"+tripID+"/booking-todos", token, []map[string]any{})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("sync todos = %d: %s", rec.Code, rec.Body.String())
+	}
+	return decodeTodoList(t, rec)
+}
+
+func decodeTodoList(t *testing.T, rec *httptest.ResponseRecorder) []map[string]any {
+	t.Helper()
+	var list []map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &list); err != nil {
+		t.Fatalf("decode list %q: %v", rec.Body.String(), err)
+	}
+	return list
+}
+
+func TestReorderBookingTodos(t *testing.T) {
+	resetDB(t)
+	owner, token := createTestUser(t, "owner@example.com")
+	trip := createTestTrip(t, owner.ID, 0)
+	tripID := trip.ID.String()
+
+	a := addCustomTodo(t, token, tripID, "Museum tickets")
+	b := addCustomTodo(t, token, tripID, "Train passes")
+	c := addCustomTodo(t, token, tripID, "Dinner reservation")
+
+	rec := doJSON(t, "PUT", "/api/v1/trips/"+tripID+"/booking-todos/order", token, map[string]any{
+		"todo_ids": []string{c, a, b},
+	})
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("reorder = %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// The order must come back through the app's own load path (sync), which
+	// also proves a sync doesn't clobber user-assigned positions.
+	todos := listTodosViaSync(t, token, tripID)
+	if len(todos) != 3 {
+		t.Fatalf("todos = %d, want 3", len(todos))
+	}
+	wantOrder := []string{c, a, b}
+	for i, todo := range todos {
+		if todo["id"] != wantOrder[i] {
+			t.Fatalf("todos[%d] = %v, want %s", i, todo["id"], wantOrder[i])
+		}
+		if pos := todo["position"].(float64); int(pos) != i {
+			t.Fatalf("todos[%d] position = %v, want %d", i, pos, i)
+		}
+	}
+}
+
+func TestReorderBookingTodosValidation(t *testing.T) {
+	resetDB(t)
+	owner, token := createTestUser(t, "owner@example.com")
+	trip := createTestTrip(t, owner.ID, 0)
+	tripID := trip.ID.String()
+	a := addCustomTodo(t, token, tripID, "Museum tickets")
+
+	cases := []struct {
+		name string
+		body map[string]any
+		want int
+	}{
+		{"empty list", map[string]any{"todo_ids": []string{}}, http.StatusBadRequest},
+		{"unknown id", map[string]any{"todo_ids": []string{uuid.NewString()}}, http.StatusConflict},
+		{"malformed id", map[string]any{"todo_ids": []string{"not-a-uuid"}}, http.StatusConflict},
+		{"duplicate id", map[string]any{"todo_ids": []string{a, a}}, http.StatusConflict},
+	}
+	for _, tc := range cases {
+		rec := doJSON(t, "PUT", "/api/v1/trips/"+tripID+"/booking-todos/order", token, tc.body)
+		if rec.Code != tc.want {
+			t.Fatalf("%s = %d, want %d: %s", tc.name, rec.Code, tc.want, rec.Body.String())
+		}
+	}
+
+	// A subset that omits some todos is valid: only the submitted rows are
+	// renumbered (the client sends its residual list, not the full set).
+	addCustomTodo(t, token, tripID, "Train passes")
+	rec := doJSON(t, "PUT", "/api/v1/trips/"+tripID+"/booking-todos/order", token, map[string]any{
+		"todo_ids": []string{a},
+	})
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("subset reorder = %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// Strangers get the usual 404; anonymous gets 401.
+	_, strangerToken := createTestUser(t, "stranger@example.com")
+	if rec := doJSON(t, "PUT", "/api/v1/trips/"+tripID+"/booking-todos/order", strangerToken, map[string]any{
+		"todo_ids": []string{a},
+	}); rec.Code != http.StatusNotFound {
+		t.Fatalf("stranger reorder = %d, want 404", rec.Code)
+	}
+	if rec := doJSON(t, "PUT", "/api/v1/trips/"+tripID+"/booking-todos/order", "", map[string]any{
+		"todo_ids": []string{a},
+	}); rec.Code != http.StatusUnauthorized {
+		t.Fatalf("anonymous reorder = %d, want 401", rec.Code)
+	}
+}

--- a/src/packages/api/main.go
+++ b/src/packages/api/main.go
@@ -782,6 +782,7 @@ func buildRouter() *mux.Router {
 	api.Handle("/trips/{id}/booking-drafts", authMiddleware(http.HandlerFunc(syncBookingDraftsHandler))).Methods("PUT")
 	api.Handle("/trips/{id}/booking-todos", authMiddleware(http.HandlerFunc(syncBookingTodosHandler))).Methods("PUT")
 	api.Handle("/trips/{id}/booking-todos", authMiddleware(http.HandlerFunc(addBookingTodoHandler))).Methods("POST")
+	api.Handle("/trips/{id}/booking-todos/order", authMiddleware(http.HandlerFunc(reorderBookingTodosHandler))).Methods("PUT")
 	api.Handle("/trips/{id}/booking-todos/{todoId}", authMiddleware(http.HandlerFunc(patchBookingTodoHandler))).Methods("PATCH")
 	api.Handle("/trips/{id}/booking-todos/{todoId}", authMiddleware(http.HandlerFunc(deleteBookingTodoHandler))).Methods("DELETE")
 

--- a/src/packages/api/query/booking_todos.sql
+++ b/src/packages/api/query/booking_todos.sql
@@ -41,6 +41,9 @@ SET kind        = COALESCE(sqlc.narg('kind'), kind),
 WHERE id = sqlc.arg('id') AND trip_id = sqlc.arg('trip_id') AND auto = false
 RETURNING *;
 
+-- name: SetBookingTodoPosition :exec
+UPDATE booking_todos SET position = $3 WHERE id = $1 AND trip_id = $2;
+
 -- name: DeleteBookingTodoNonAuto :execrows
 DELETE FROM booking_todos WHERE id = $1 AND trip_id = $2 AND auto = false;
 

--- a/src/packages/api/store/booking_todos.sql.go
+++ b/src/packages/api/store/booking_todos.sql.go
@@ -190,6 +190,21 @@ func (q *Queries) SetBookingTodoBooked(ctx context.Context, arg SetBookingTodoBo
 	return i, err
 }
 
+const setBookingTodoPosition = `-- name: SetBookingTodoPosition :exec
+UPDATE booking_todos SET position = $3 WHERE id = $1 AND trip_id = $2
+`
+
+type SetBookingTodoPositionParams struct {
+	ID       uuid.UUID `json:"id"`
+	TripID   uuid.UUID `json:"trip_id"`
+	Position int32     `json:"position"`
+}
+
+func (q *Queries) SetBookingTodoPosition(ctx context.Context, arg SetBookingTodoPositionParams) error {
+	_, err := q.db.Exec(ctx, setBookingTodoPosition, arg.ID, arg.TripID, arg.Position)
+	return err
+}
+
 const updateBookingTodo = `-- name: UpdateBookingTodo :one
 UPDATE booking_todos
 SET kind        = COALESCE($1, kind),

--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -906,6 +906,36 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
     }
   }
 
+  /// Persists a drag-reorder of the residual "Other bookings" cards.
+  /// Optimistic: residual display order derives from _bookingTodos list order
+  /// (see _groupedBookings), so move the residual entries to the tail in their
+  /// new order — grouped todos are slot-matched by key, so nothing else shifts.
+  Future<void> _reorderResidual(
+      List<BookingTodo> residual, int oldIndex, int newIndex) async {
+    if (_guardOffline()) return;
+    if (newIndex > oldIndex) newIndex--;
+    if (newIndex == oldIndex) return;
+    final newOrder = List.of(residual);
+    newOrder.insert(newIndex, newOrder.removeAt(oldIndex));
+    final residualIds = {for (final t in residual) t.id};
+    final prev = _bookingTodos;
+    setState(() {
+      _bookingTodos = [
+        for (final t in _bookingTodos)
+          if (!residualIds.contains(t.id)) t,
+        ...newOrder,
+      ];
+    });
+    try {
+      await ref
+          .read(bookingTodosApiServiceProvider)
+          .reorderTodos(widget.tripId, [for (final t in newOrder) t.id]);
+    } catch (e) {
+      if (mounted) setState(() => _bookingTodos = prev);
+      _showSnack('Could not reorder: $e');
+    }
+  }
+
   Future<void> _deleteTodo(BookingTodo todo) async {
     if (_guardOffline()) return;
     try {
@@ -3414,24 +3444,51 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
                                       ],
                                     ),
                                     const SizedBox(height: 8),
-                                    for (final todo in grouped.residual)
-                                      Padding(
-                                        padding: const EdgeInsets.symmetric(
-                                            vertical: 4),
-                                        child: BookingTodoCard(
-                                          todo: todo,
-                                          onBookedChanged: (v) =>
-                                              _setBooked(todo, v),
-                                          onOpen: _openCallbackFor(todo),
-                                          openLabelOverride: _flightLegs
-                                                  .containsKey(todo.todoKey)
-                                              ? 'Find flights'
-                                              : null,
-                                          onDelete: todo.auto
-                                              ? null
-                                              : () => _deleteTodo(todo),
-                                        ),
-                                      ),
+                                    ReorderableListView.builder(
+                                      shrinkWrap: true,
+                                      physics:
+                                          const NeverScrollableScrollPhysics(),
+                                      padding: EdgeInsets.zero,
+                                      buildDefaultDragHandles: false,
+                                      itemCount: grouped.residual.length,
+                                      onReorder: (oldIndex, newIndex) =>
+                                          _reorderResidual(grouped.residual,
+                                              oldIndex, newIndex),
+                                      itemBuilder: (context, i) {
+                                        final todo = grouped.residual[i];
+                                        final canDrag = !_readOnly &&
+                                            !_isOffline &&
+                                            grouped.residual.length > 1;
+                                        return Padding(
+                                          key: ValueKey(todo.id),
+                                          padding: const EdgeInsets.symmetric(
+                                              vertical: 4),
+                                          child: BookingTodoCard(
+                                            todo: todo,
+                                            onBookedChanged: (v) =>
+                                                _setBooked(todo, v),
+                                            onOpen: _openCallbackFor(todo),
+                                            openLabelOverride: _flightLegs
+                                                    .containsKey(todo.todoKey)
+                                                ? 'Find flights'
+                                                : null,
+                                            onDelete: todo.auto
+                                                ? null
+                                                : () => _deleteTodo(todo),
+                                            dragHandle: canDrag
+                                                ? ReorderableDragStartListener(
+                                                    index: i,
+                                                    child: Icon(
+                                                      Icons.drag_indicator,
+                                                      color: theme.colorScheme
+                                                          .onSurfaceVariant,
+                                                    ),
+                                                  )
+                                                : null,
+                                          ),
+                                        );
+                                      },
+                                    ),
                                   ],
                                 ],
                               ),

--- a/src/packages/flutter-app/lib/services/booking_todos_api_service.dart
+++ b/src/packages/flutter-app/lib/services/booking_todos_api_service.dart
@@ -52,6 +52,19 @@ class BookingTodosApiService {
     throw Exception('Failed to update booking todo (${res.statusCode})');
   }
 
+  /// Persists the user's drag order for the residual "Other bookings" list.
+  /// Sends only that subset; the server renumbers those rows 0..n-1.
+  Future<void> reorderTodos(String tripId, List<String> todoIds) async {
+    final res = await apiClient.httpClient.put(
+      Uri.parse('${apiClient.baseUrl}/trips/$tripId/booking-todos/order'),
+      headers: apiClient.jsonHeaders(json: true),
+      body: jsonEncode({'todo_ids': todoIds}),
+    );
+    if (res.statusCode != 204) {
+      throw Exception('Failed to reorder booking todos (${res.statusCode})');
+    }
+  }
+
   Future<void> delete(String tripId, String todoId) async {
     final res = await apiClient.httpClient.delete(
       Uri.parse('${apiClient.baseUrl}/trips/$tripId/booking-todos/$todoId'),

--- a/src/packages/flutter-app/lib/widgets/booking_todo_card.dart
+++ b/src/packages/flutter-app/lib/widgets/booking_todo_card.dart
@@ -44,6 +44,11 @@ class BookingTodoCard extends StatelessWidget {
   /// the in-app flight search instead of an external provider link).
   final String? openLabelOverride;
 
+  /// Optional drag affordance (e.g. a ReorderableDragStartListener-wrapped
+  /// drag_indicator) rendered at the end of the title row. The card stays
+  /// index-agnostic — the list that owns the ordering builds the listener.
+  final Widget? dragHandle;
+
   const BookingTodoCard({
     super.key,
     required this.todo,
@@ -51,6 +56,7 @@ class BookingTodoCard extends StatelessWidget {
     this.onOpen,
     this.onDelete,
     this.openLabelOverride,
+    this.dragHandle,
   });
 
   IconData get _icon => _kindIcon(todo);
@@ -92,6 +98,7 @@ class BookingTodoCard extends StatelessWidget {
                     tooltip: 'Remove',
                     onPressed: onDelete,
                   ),
+                if (dragHandle != null) dragHandle!,
               ],
             ),
             Row(

--- a/src/packages/flutter-app/test/trip_detail_booking_reorder_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_booking_reorder_test.dart
@@ -1,0 +1,173 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:travel_route_planner/models/trip.dart';
+import 'package:travel_route_planner/models/booking_todo.dart';
+import 'package:travel_route_planner/services/api_client.dart';
+import 'package:travel_route_planner/services/booking_todos_api_service.dart';
+import 'package:travel_route_planner/services/trips_api_service.dart';
+import 'package:travel_route_planner/providers/booking_todos_provider.dart';
+import 'package:travel_route_planner/providers/trips_provider.dart';
+import 'package:travel_route_planner/screens/trip_detail_screen.dart';
+import 'package:travel_route_planner/widgets/booking_todo_card.dart';
+
+/// Returns a fixed trip without hitting the network, so we can exercise the
+/// real TripDetailScreen render path.
+class _FakeTripsApiService extends TripsApiService {
+  final Trip trip;
+  _FakeTripsApiService(this.trip) : super(ApiClient(baseUrl: 'http://test'));
+
+  @override
+  Future<Trip> getTrip(String id) async => trip;
+}
+
+/// Sync fails (so the todos seeded on the trip survive, mirroring the screen's
+/// swallow-on-error behavior); reorder calls are recorded and optionally fail.
+class _FakeBookingTodosApiService extends BookingTodosApiService {
+  final List<List<String>> reorderCalls = [];
+  final bool failReorder;
+  _FakeBookingTodosApiService({this.failReorder = false})
+      : super(ApiClient(baseUrl: 'http://test'));
+
+  @override
+  Future<List<BookingTodo>> syncTodos(
+          String tripId, List<Map<String, dynamic>> derived) async =>
+      throw Exception('offline test env');
+
+  @override
+  Future<void> reorderTodos(String tripId, List<String> todoIds) async {
+    reorderCalls.add(todoIds);
+    if (failReorder) throw Exception('server said no');
+  }
+}
+
+BookingTodo _customTodo(String id, String title) => BookingTodo(
+    id: id, kind: 'other', todoKey: 'custom:$id', title: title, auto: false);
+
+Trip _tripWith(List<BookingTodo> todos) => Trip(
+      id: 't1',
+      title: 'Errands',
+      status: 'planned',
+      startDate: '2026-06-10',
+      endDate: '2026-06-13',
+      createdAt: '2026-06-01',
+      updatedAt: '2026-06-01',
+      items: [],
+      bookingTodos: todos,
+    );
+
+/// The itinerary renders lazily (slivers), so widgets below the default
+/// 800x600 test viewport never get built. A tall viewport keeps the whole
+/// page — including the trailing bookings section — built and findable.
+void _useTallViewport(WidgetTester tester) {
+  tester.view.physicalSize = const Size(800, 2400);
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.reset);
+}
+
+Future<_FakeBookingTodosApiService> _pumpTrip(WidgetTester tester, Trip trip,
+    {bool failReorder = false}) async {
+  final fake = _FakeBookingTodosApiService(failReorder: failReorder);
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        tripsApiServiceProvider.overrideWithValue(_FakeTripsApiService(trip)),
+        bookingTodosApiServiceProvider.overrideWithValue(fake),
+      ],
+      child: MaterialApp(home: TripDetailScreen(tripId: 't1')),
+    ),
+  );
+  await tester.pumpAndSettle();
+  return fake;
+}
+
+/// Drags [title]'s handle vertically by [dy] within the residual list.
+Future<void> _dragCard(WidgetTester tester, String title, double dy) async {
+  final card = find.widgetWithText(BookingTodoCard, title);
+  final handle = find.descendant(
+      of: card, matching: find.byIcon(Icons.drag_indicator));
+  final gesture = await tester.startGesture(tester.getCenter(handle));
+  await tester.pump(const Duration(milliseconds: 100));
+  // Move in steps so the reorderable list registers the drag progression.
+  for (var i = 0; i < 5; i++) {
+    await gesture.moveBy(Offset(0, dy / 5));
+    await tester.pump(const Duration(milliseconds: 50));
+  }
+  await gesture.up();
+  await tester.pumpAndSettle();
+}
+
+double _cardTop(WidgetTester tester, String title) =>
+    tester.getTopLeft(find.widgetWithText(BookingTodoCard, title)).dy;
+
+void main() {
+  testWidgets('residual cards show a drag handle and reorder persists',
+      (WidgetTester tester) async {
+    _useTallViewport(tester);
+    final fake = await _pumpTrip(
+      tester,
+      _tripWith([
+        _customTodo('a', 'Museum tickets'),
+        _customTodo('b', 'Train passes'),
+        _customTodo('c', 'Dinner reservation'),
+      ]),
+    );
+
+    expect(find.byType(BookingTodoCard), findsNWidgets(3));
+    expect(find.byIcon(Icons.drag_indicator), findsNWidgets(3));
+    expect(_cardTop(tester, 'Museum tickets'),
+        lessThan(_cardTop(tester, 'Train passes')));
+
+    // Drag the first card down past the second.
+    final cardHeight = tester
+        .getSize(find.widgetWithText(BookingTodoCard, 'Museum tickets'))
+        .height;
+    await _dragCard(tester, 'Museum tickets', cardHeight + 20);
+
+    // The server got the full residual subset in its new order...
+    expect(fake.reorderCalls, [
+      ['b', 'a', 'c']
+    ]);
+    // ...and the optimistic UI reflects it.
+    expect(_cardTop(tester, 'Train passes'),
+        lessThan(_cardTop(tester, 'Museum tickets')));
+    expect(_cardTop(tester, 'Museum tickets'),
+        lessThan(_cardTop(tester, 'Dinner reservation')));
+  });
+
+  testWidgets('failed reorder reverts the order and shows a snackbar',
+      (WidgetTester tester) async {
+    _useTallViewport(tester);
+    final fake = await _pumpTrip(
+      tester,
+      _tripWith([
+        _customTodo('a', 'Museum tickets'),
+        _customTodo('b', 'Train passes'),
+      ]),
+      failReorder: true,
+    );
+
+    final cardHeight = tester
+        .getSize(find.widgetWithText(BookingTodoCard, 'Museum tickets'))
+        .height;
+    await _dragCard(tester, 'Museum tickets', cardHeight + 20);
+
+    expect(fake.reorderCalls, [
+      ['b', 'a']
+    ]);
+    // Rolled back to the original order, with an error surfaced.
+    expect(_cardTop(tester, 'Museum tickets'),
+        lessThan(_cardTop(tester, 'Train passes')));
+    expect(find.textContaining('Could not reorder'), findsOneWidget);
+  });
+
+  testWidgets('a single residual card gets no drag handle',
+      (WidgetTester tester) async {
+    _useTallViewport(tester);
+    await _pumpTrip(tester, _tripWith([_customTodo('a', 'Museum tickets')]));
+
+    expect(find.byType(BookingTodoCard), findsOneWidget);
+    expect(find.byIcon(Icons.drag_indicator), findsNothing);
+  });
+}


### PR DESCRIPTION
## Summary
- Makes the "Other bookings" residual cards on the trip detail page draggable to reorder, via an explicit drag handle (`ReorderableListView`, matching the reorder-sheet convention; handle hidden when read-only/offline or with a single card).
- New `PUT /trips/{id}/booking-todos/order` endpoint + `SetBookingTodoPosition` sqlc query renumber the submitted ids 0..n-1 in a transaction (trip lock, 409 on stale/duplicate ids, TouchTrip). No migration — the `position` column has existed since migration 00010.
- Subset semantics by design: the client sends only its residual list. City-grouped todos render slot-matched by `todo_key` and get positions re-upserted every sync, while residual rows are durably custom (`auto=false`) which sync never rewrites — so user order survives sync with zero changes to the sync path.
- Client reorder is optimistic with rollback + snackbar on failure, mirroring `_setBooked`; `BookingTodoCard` gains an optional `dragHandle` slot.

## Testing
- Go: full suite green against an isolated test DB; new integration tests cover reorder + order surviving a sync, 409 (unknown/duplicate id), 400 (empty), 404/401 (stranger/anonymous).
- Flutter: `flutter analyze` clean (only pre-existing infos); all 265 tests pass incl. 3 new widget tests (real drag gesture + persistence call, failure rollback + snackbar, no handle for a single card).
- Manual on the dev stack (headless browser): added custom bookings, dragged by handle (lift animation works, taps unaffected), confirmed positions 0/1 in Postgres, order survived a hard reload + fresh sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)