### PR TITLE
feat: edit custom bookings + date pickers in the Add-a-booking dialog

### DIFF
--- a/src/packages/api/booking_todo_edit_integration_test.go
+++ b/src/packages/api/booking_todo_edit_integration_test.go
@@ -1,0 +1,182 @@
+package main
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// syncAutoTodo upserts one itinerary-derived (auto=true) todo and returns its id.
+func syncAutoTodo(t *testing.T, token, tripID string) string {
+	t.Helper()
+	rec := doJSON(t, "PUT", "/api/v1/trips/"+tripID+"/booking-todos", token, []map[string]any{
+		{"kind": "stay", "todo_key": "stay:paris", "title": "Stay in Paris", "destination": "Paris"},
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("sync auto todo = %d: %s", rec.Code, rec.Body.String())
+	}
+	list := decodeTodoList(t, rec)
+	if len(list) == 0 {
+		t.Fatal("sync returned no todos")
+	}
+	return list[0]["id"].(string)
+}
+
+func TestPatchBookingTodoContentEdit(t *testing.T) {
+	resetDB(t)
+	owner, token := createTestUser(t, "owner@example.com")
+	trip := createTestTrip(t, owner.ID, 0)
+	tripID := trip.ID.String()
+
+	rec := doJSON(t, "POST", "/api/v1/trips/"+tripID+"/booking-todos", token, map[string]any{
+		"kind": "stay", "title": "Hotel in Athens", "destination": "Athens",
+		"depart_date": "2026-08-01", "return_date": "2026-08-05",
+		"provider": "airbnb", "guests": 1,
+	})
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("add = %d: %s", rec.Code, rec.Body.String())
+	}
+	created := decode(t, rec)
+	todoID := created["id"].(string)
+	origURL, _ := created["search_url"].(string)
+	if origURL == "" {
+		t.Fatal("expected a built search_url on create")
+	}
+
+	// A plain content edit updates fields and leaves the link/provider alone.
+	rec = doJSON(t, "PATCH", "/api/v1/trips/"+tripID+"/booking-todos/"+todoID, token, map[string]any{
+		"kind": "stay", "title": "Aparthotel in Athens",
+		"depart_date": "2026-08-02", "return_date": "2026-08-06",
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("patch = %d: %s", rec.Code, rec.Body.String())
+	}
+	got := decode(t, rec)
+	if got["title"] != "Aparthotel in Athens" || got["depart_date"] != "2026-08-02" || got["return_date"] != "2026-08-06" {
+		t.Fatalf("patched fields = %v", got)
+	}
+	if got["search_url"] != origURL || got["provider"] != "airbnb" {
+		t.Fatalf("link/provider changed without a destination: %v / %v", got["search_url"], got["provider"])
+	}
+	if got["booked"] != false {
+		t.Fatalf("booked flipped by content edit: %v", got["booked"])
+	}
+
+	// Re-entering a destination rebuilds the search link with the new dates.
+	rec = doJSON(t, "PATCH", "/api/v1/trips/"+tripID+"/booking-todos/"+todoID, token, map[string]any{
+		"kind": "stay", "destination": "Thessaloniki", "depart_date": "2026-09-01",
+		"provider": "airbnb", "guests": 2,
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("rebuild patch = %d: %s", rec.Code, rec.Body.String())
+	}
+	got = decode(t, rec)
+	newURL, _ := got["search_url"].(string)
+	if newURL == "" || newURL == origURL || !strings.Contains(newURL, "Thessaloniki") {
+		t.Fatalf("search_url not rebuilt: %q", newURL)
+	}
+
+	// An explicit link wins over the destination-built one.
+	rec = doJSON(t, "PATCH", "/api/v1/trips/"+tripID+"/booking-todos/"+todoID, token, map[string]any{
+		"search_url": "https://example.com/booked",
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("url patch = %d: %s", rec.Code, rec.Body.String())
+	}
+	if got = decode(t, rec); got["search_url"] != "https://example.com/booked" {
+		t.Fatalf("explicit search_url not stored: %v", got["search_url"])
+	}
+}
+
+func TestPatchBookingTodoBookedPathsAndAutoRows(t *testing.T) {
+	resetDB(t)
+	owner, token := createTestUser(t, "owner@example.com")
+	trip := createTestTrip(t, owner.ID, 0)
+	tripID := trip.ID.String()
+
+	autoID := syncAutoTodo(t, token, tripID)
+	customID := addCustomTodo(t, token, tripID, "Museum tickets")
+
+	// The original booked-only contract must keep working on auto rows — that
+	// path stays on SetBookingTodoBooked, which has no auto=false guard.
+	rec := doJSON(t, "PATCH", "/api/v1/trips/"+tripID+"/booking-todos/"+autoID, token, map[string]any{
+		"booked": true,
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("booked-only on auto row = %d: %s", rec.Code, rec.Body.String())
+	}
+	if got := decode(t, rec); got["booked"] != true {
+		t.Fatalf("auto row booked = %v, want true", got["booked"])
+	}
+
+	// Booked-only on a custom row: unchanged behavior.
+	rec = doJSON(t, "PATCH", "/api/v1/trips/"+tripID+"/booking-todos/"+customID, token, map[string]any{
+		"booked": true,
+	})
+	if rec.Code != http.StatusOK || decode(t, rec)["booked"] != true {
+		t.Fatalf("booked-only on custom row = %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// Content edits are custom-only: an auto row answers 404.
+	rec = doJSON(t, "PATCH", "/api/v1/trips/"+tripID+"/booking-todos/"+autoID, token, map[string]any{
+		"title": "Renamed",
+	})
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("content edit on auto row = %d, want 404", rec.Code)
+	}
+
+	// A combined edit+booked on a custom row applies both.
+	rec = doJSON(t, "PATCH", "/api/v1/trips/"+tripID+"/booking-todos/"+customID, token, map[string]any{
+		"title": "Museum + audio guide", "booked": false,
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("combined patch = %d: %s", rec.Code, rec.Body.String())
+	}
+	if got := decode(t, rec); got["title"] != "Museum + audio guide" || got["booked"] != false {
+		t.Fatalf("combined patch result = %v", got)
+	}
+}
+
+func TestPatchBookingTodoValidationAndAccess(t *testing.T) {
+	resetDB(t)
+	owner, token := createTestUser(t, "owner@example.com")
+	trip := createTestTrip(t, owner.ID, 0)
+	tripID := trip.ID.String()
+	todoID := addCustomTodo(t, token, tripID, "Ferry tickets")
+
+	cases := []struct {
+		name string
+		body map[string]any
+		want int
+	}{
+		{"empty body still needs booked", map[string]any{}, http.StatusBadRequest},
+		{"bad kind", map[string]any{"kind": "cruise"}, http.StatusBadRequest},
+		{"blank title", map[string]any{"title": "  "}, http.StatusBadRequest},
+		{"bad depart date", map[string]any{"depart_date": "next tuesday"}, http.StatusBadRequest},
+		{"bad return date", map[string]any{"return_date": "2026/09/01"}, http.StatusBadRequest},
+		{"destination without kind", map[string]any{"destination": "Athens"}, http.StatusBadRequest},
+	}
+	for _, tc := range cases {
+		rec := doJSON(t, "PATCH", "/api/v1/trips/"+tripID+"/booking-todos/"+todoID, token, tc.body)
+		if rec.Code != tc.want {
+			t.Fatalf("%s = %d, want %d: %s", tc.name, rec.Code, tc.want, rec.Body.String())
+		}
+	}
+
+	// Viewers keep the mutation 404 posture; anonymous is 401.
+	_, viewerToken := createTestUser(t, "viewer@example.com")
+	shareToken := createShare(t, token, tripID, "viewer")
+	if rec := joinShare(t, viewerToken, shareToken); rec.Code != http.StatusOK {
+		t.Fatalf("viewer join = %d: %s", rec.Code, rec.Body.String())
+	}
+	if rec := doJSON(t, "PATCH", "/api/v1/trips/"+tripID+"/booking-todos/"+todoID, viewerToken, map[string]any{
+		"title": "Hijacked",
+	}); rec.Code != http.StatusNotFound {
+		t.Fatalf("viewer content patch = %d, want 404", rec.Code)
+	}
+	if rec := doJSON(t, "PATCH", "/api/v1/trips/"+tripID+"/booking-todos/"+todoID, "", map[string]any{
+		"title": "Anon",
+	}); rec.Code != http.StatusUnauthorized {
+		t.Fatalf("anonymous patch = %d, want 401", rec.Code)
+	}
+}

--- a/src/packages/api/booking_todo_handler.go
+++ b/src/packages/api/booking_todo_handler.go
@@ -277,8 +277,30 @@ func addBookingTodoHandler(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusCreated, toBookingTodoResponse(todo))
 }
 
+// PatchBookingTodoRequest is a partial update. Booked-only requests (the
+// original contract) work on any row, including auto ones; content fields
+// apply to custom (auto = false) rows only. destination/origin are never
+// persisted — when a destination is present and no explicit search_url, the
+// search link + provider are rebuilt via bookingSearchURL, like the add path.
 type PatchBookingTodoRequest struct {
-	Booked *bool `json:"booked"`
+	Booked      *bool   `json:"booked"`
+	Kind        *string `json:"kind"`
+	Title       *string `json:"title"`
+	Subtitle    *string `json:"subtitle"`
+	Destination *string `json:"destination"`
+	Origin      *string `json:"origin"`
+	DepartDate  *string `json:"depart_date"`
+	ReturnDate  *string `json:"return_date"`
+	SearchURL   *string `json:"search_url"`
+	Provider    *string `json:"provider"`
+	Guests      int     `json:"guests"`
+	Passengers  int     `json:"passengers"`
+}
+
+func (req *PatchBookingTodoRequest) hasContentEdit() bool {
+	return req.Kind != nil || req.Title != nil || req.Subtitle != nil ||
+		req.Destination != nil || req.DepartDate != nil || req.ReturnDate != nil ||
+		req.SearchURL != nil
 }
 
 func patchBookingTodoHandler(w http.ResponseWriter, r *http.Request) {
@@ -297,20 +319,79 @@ func patchBookingTodoHandler(w http.ResponseWriter, r *http.Request) {
 		writeJSONError(w, http.StatusBadRequest, "invalid JSON")
 		return
 	}
-	if req.Booked == nil {
-		writeJSONError(w, http.StatusBadRequest, "booked is required")
-		return
+
+	var todo store.BookingTodo
+	if !req.hasContentEdit() {
+		// Booked-only: must stay on SetBookingTodoBooked — UpdateBookingTodo
+		// excludes auto rows, but the checkbox works on itinerary-derived
+		// todos too.
+		if req.Booked == nil {
+			writeJSONError(w, http.StatusBadRequest, "booked is required")
+			return
+		}
+		todo, err = store.New(dbPool).SetBookingTodoBooked(r.Context(), store.SetBookingTodoBookedParams{
+			ID:     todoID,
+			TripID: tripID,
+			Booked: *req.Booked,
+		})
+	} else {
+		var kind, title *string
+		if req.Kind != nil {
+			k := strings.TrimSpace(*req.Kind)
+			if !allowedBookingKinds[k] {
+				writeJSONError(w, http.StatusBadRequest, "kind must be one of: stay, transport, other")
+				return
+			}
+			kind = &k
+		}
+		if req.Title != nil {
+			t := strings.TrimSpace(*req.Title)
+			if t == "" {
+				writeJSONError(w, http.StatusBadRequest, "title cannot be empty")
+				return
+			}
+			title = &t
+		}
+		depart, derr := parseDateParam(req.DepartDate)
+		if derr != nil {
+			writeJSONError(w, http.StatusBadRequest, "depart_date must be YYYY-MM-DD")
+			return
+		}
+		ret, rerr := parseDateParam(req.ReturnDate)
+		if rerr != nil {
+			writeJSONError(w, http.StatusBadRequest, "return_date must be YYYY-MM-DD")
+			return
+		}
+
+		url := strPtrVal(req.SearchURL)
+		provider := strPtrVal(req.Provider)
+		if strings.TrimSpace(url) == "" && req.Destination != nil {
+			if kind == nil {
+				writeJSONError(w, http.StatusBadRequest, "kind is required when destination is set")
+				return
+			}
+			url, provider = bookingSearchURL(*kind, strPtrVal(req.Destination), req.Origin, req.DepartDate, req.ReturnDate, req.Guests, req.Passengers, req.Provider)
+		}
+
+		todo, err = store.New(dbPool).UpdateBookingTodo(r.Context(), store.UpdateBookingTodoParams{
+			ID:         todoID,
+			TripID:     tripID,
+			Kind:       kind,
+			Title:      title,
+			Subtitle:   req.Subtitle,
+			DepartDate: depart,
+			ReturnDate: ret,
+			SearchUrl:  strPtrOrNil(url),
+			Provider:   strPtrOrNil(provider),
+			Booked:     req.Booked,
+		})
 	}
-	todo, err := store.New(dbPool).SetBookingTodoBooked(r.Context(), store.SetBookingTodoBookedParams{
-		ID:     todoID,
-		TripID: tripID,
-		Booked: *req.Booked,
-	})
 	if err != nil {
+		// Wrong id, wrong trip, or a content edit on an auto row.
 		writeJSONError(w, http.StatusNotFound, "booking todo not found")
 		return
 	}
-	if *req.Booked {
+	if req.Booked != nil && *req.Booked {
 		user, _ := userFromContext(r.Context())
 		meta := map[string]any{"kind": todo.Kind, "todo_key": todo.TodoKey}
 		if todo.Provider != nil {

--- a/src/packages/api/query/booking_todos.sql
+++ b/src/packages/api/query/booking_todos.sql
@@ -30,13 +30,16 @@ UPDATE booking_todos SET booked = $3 WHERE id = $1 AND trip_id = $2 RETURNING *;
 -- name: UpdateBookingTodo :one
 -- Partial update (COALESCE sqlc.narg idiom, see query/trips.sql UpdateTrip).
 -- auto = false only: auto rows are owned by the client's itinerary sync and
--- would be overwritten on the next sync. COALESCE means subtitle/depart_date
--- can be overwritten but not cleared back to NULL.
+-- would be overwritten on the next sync. COALESCE means fields can be
+-- overwritten but not cleared back to NULL.
 UPDATE booking_todos
 SET kind        = COALESCE(sqlc.narg('kind'), kind),
     title       = COALESCE(sqlc.narg('title'), title),
     subtitle    = COALESCE(sqlc.narg('subtitle'), subtitle),
     depart_date = COALESCE(sqlc.narg('depart_date'), depart_date),
+    return_date = COALESCE(sqlc.narg('return_date'), return_date),
+    search_url  = COALESCE(sqlc.narg('search_url'), search_url),
+    provider    = COALESCE(sqlc.narg('provider'), provider),
     booked      = COALESCE(sqlc.narg('booked'), booked)
 WHERE id = sqlc.arg('id') AND trip_id = sqlc.arg('trip_id') AND auto = false
 RETURNING *;

--- a/src/packages/api/store/booking_todos.sql.go
+++ b/src/packages/api/store/booking_todos.sql.go
@@ -211,8 +211,11 @@ SET kind        = COALESCE($1, kind),
     title       = COALESCE($2, title),
     subtitle    = COALESCE($3, subtitle),
     depart_date = COALESCE($4, depart_date),
-    booked      = COALESCE($5, booked)
-WHERE id = $6 AND trip_id = $7 AND auto = false
+    return_date = COALESCE($5, return_date),
+    search_url  = COALESCE($6, search_url),
+    provider    = COALESCE($7, provider),
+    booked      = COALESCE($8, booked)
+WHERE id = $9 AND trip_id = $10 AND auto = false
 RETURNING id, trip_id, kind, todo_key, title, subtitle, provider, search_url, depart_date, return_date, booked, auto, position, created_at, updated_at
 `
 
@@ -221,6 +224,9 @@ type UpdateBookingTodoParams struct {
 	Title      *string     `json:"title"`
 	Subtitle   *string     `json:"subtitle"`
 	DepartDate pgtype.Date `json:"depart_date"`
+	ReturnDate pgtype.Date `json:"return_date"`
+	SearchUrl  *string     `json:"search_url"`
+	Provider   *string     `json:"provider"`
 	Booked     *bool       `json:"booked"`
 	ID         uuid.UUID   `json:"id"`
 	TripID     uuid.UUID   `json:"trip_id"`
@@ -228,14 +234,17 @@ type UpdateBookingTodoParams struct {
 
 // Partial update (COALESCE sqlc.narg idiom, see query/trips.sql UpdateTrip).
 // auto = false only: auto rows are owned by the client's itinerary sync and
-// would be overwritten on the next sync. COALESCE means subtitle/depart_date
-// can be overwritten but not cleared back to NULL.
+// would be overwritten on the next sync. COALESCE means fields can be
+// overwritten but not cleared back to NULL.
 func (q *Queries) UpdateBookingTodo(ctx context.Context, arg UpdateBookingTodoParams) (BookingTodo, error) {
 	row := q.db.QueryRow(ctx, updateBookingTodo,
 		arg.Kind,
 		arg.Title,
 		arg.Subtitle,
 		arg.DepartDate,
+		arg.ReturnDate,
+		arg.SearchUrl,
+		arg.Provider,
 		arg.Booked,
 		arg.ID,
 		arg.TripID,

--- a/src/packages/flutter-app/lib/screens/local_admin_screen.dart
+++ b/src/packages/flutter-app/lib/screens/local_admin_screen.dart
@@ -121,13 +121,16 @@ class _IngestPaneState extends ConsumerState<_IngestPane> {
               TextField(
                   controller: name,
                   decoration: const InputDecoration(labelText: 'Name *')),
+              const SizedBox(height: AppSpacing.md),
               TextField(
                   controller: credibility,
                   decoration: const InputDecoration(
                       labelText: 'Credibility (chef, 20yr resident…)')),
+              const SizedBox(height: AppSpacing.md),
               TextField(
                   controller: photo,
                   decoration: const InputDecoration(labelText: 'Photo URL')),
+              const SizedBox(height: AppSpacing.md),
               TextField(
                   controller: consent,
                   decoration: const InputDecoration(

--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -960,6 +960,16 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
     if (added == true) await _load();
   }
 
+  Future<void> _editTodo(BookingTodo todo) async {
+    if (_guardOffline()) return;
+    final changed = await showDialog<bool>(
+      context: context,
+      builder: (_) =>
+          _AddBookingTodoDialog(tripId: widget.tripId, existing: todo),
+    );
+    if (changed == true) await _load();
+  }
+
   /// [day] preselects the dialog's Day dropdown (e.g. from the map's
   /// empty-day CTA, where the user is already looking at a specific day).
   Future<void> _addPlace({int? day}) async {
@@ -3472,6 +3482,9 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
                                                     .containsKey(todo.todoKey)
                                                 ? 'Find flights'
                                                 : null,
+                                            onEdit: todo.auto
+                                                ? null
+                                                : () => _editTodo(todo),
                                             onDelete: todo.auto
                                                 ? null
                                                 : () => _deleteTodo(todo),
@@ -3684,11 +3697,18 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
   }
 }
 
-/// Adds a custom booking TODO. A destination (and optional dates) lets the
-/// server build the search link; a pasted link overrides it.
+/// Adds or edits a custom booking TODO. A destination (and optional dates)
+/// lets the server build the search link; a pasted link overrides it.
 class _AddBookingTodoDialog extends ConsumerStatefulWidget {
   final String tripId;
-  const _AddBookingTodoDialog({required this.tripId});
+
+  /// When set, the dialog edits this todo (PATCH) instead of adding one.
+  /// Destination/origin aren't persisted server-side, so they open blank:
+  /// re-entering a destination makes the server rebuild the search link,
+  /// otherwise the existing link is kept.
+  final BookingTodo? existing;
+
+  const _AddBookingTodoDialog({required this.tripId, this.existing});
 
   @override
   ConsumerState<_AddBookingTodoDialog> createState() =>
@@ -3700,19 +3720,30 @@ class _AddBookingTodoDialogState extends ConsumerState<_AddBookingTodoDialog> {
   final _title = TextEditingController();
   final _destination = TextEditingController();
   final _origin = TextEditingController();
-  final _departDate = TextEditingController();
-  final _returnDate = TextEditingController();
+  DateTime? _departDate;
+  DateTime? _returnDate;
   final _url = TextEditingController();
   bool _saving = false;
   String? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    final e = widget.existing;
+    if (e != null) {
+      _kind = e.kind;
+      _title.text = e.title;
+      _url.text = e.searchUrl ?? '';
+      _departDate = DateTime.tryParse(e.departDate ?? '');
+      _returnDate = DateTime.tryParse(e.returnDate ?? '');
+    }
+  }
 
   @override
   void dispose() {
     _title.dispose();
     _destination.dispose();
     _origin.dispose();
-    _departDate.dispose();
-    _returnDate.dispose();
     _url.dispose();
     super.dispose();
   }
@@ -3720,6 +3751,27 @@ class _AddBookingTodoDialogState extends ConsumerState<_AddBookingTodoDialog> {
   String? _nn(String s) {
     final t = s.trim();
     return t.isEmpty ? null : t;
+  }
+
+  String _fmt(DateTime d) =>
+      '${d.year}-${d.month.toString().padLeft(2, '0')}-${d.day.toString().padLeft(2, '0')}';
+
+  Future<void> _pickDate(bool isDepart) async {
+    final now = DateTime.now();
+    final first = now.subtract(const Duration(days: 365));
+    final last = now.add(const Duration(days: 365 * 2));
+    var initial = (isDepart ? _departDate : _returnDate) ?? now;
+    if (initial.isBefore(first)) initial = first;
+    if (initial.isAfter(last)) initial = last;
+    final picked = await showDatePicker(
+      context: context,
+      initialDate: initial,
+      firstDate: first,
+      lastDate: last,
+    );
+    if (picked != null) {
+      setState(() => isDepart ? _departDate = picked : _returnDate = picked);
+    }
   }
 
   Future<void> _save() async {
@@ -3733,22 +3785,43 @@ class _AddBookingTodoDialogState extends ConsumerState<_AddBookingTodoDialog> {
     });
     try {
       final isTransport = _kind == 'transport';
-      await ref.read(bookingTodosApiServiceProvider).addTodo(widget.tripId, {
+      final isEdit = widget.existing != null;
+      // Note: PATCH is a COALESCE partial update, so an omitted date can't
+      // clear a previously saved one — it just keeps the old value.
+      final body = <String, dynamic>{
         'kind': _kind,
         'title': _title.text.trim(),
         if (_nn(_destination.text) != null)
           'destination': _nn(_destination.text),
         if (isTransport && _nn(_origin.text) != null)
           'origin': _nn(_origin.text),
-        if (_nn(_departDate.text) != null) 'depart_date': _nn(_departDate.text),
-        if (!isTransport && _nn(_returnDate.text) != null)
-          'return_date': _nn(_returnDate.text),
-        if (_nn(_url.text) != null) 'search_url': _nn(_url.text),
-        if (_kind == 'stay') 'provider': 'airbnb',
-        if (isTransport) 'provider': 'google_flights',
+        if (_departDate != null) 'depart_date': _fmt(_departDate!),
+        if (!isTransport && _returnDate != null)
+          'return_date': _fmt(_returnDate!),
+        // On edit the field is prefilled with the stored link; sending it
+        // back unchanged would override a destination-driven rebuild (an
+        // explicit search_url wins server-side), so omit it unless the user
+        // actually changed it — COALESCE keeps the stored one.
+        if (_nn(_url.text) != null &&
+            (!isEdit || _nn(_url.text) != widget.existing!.searchUrl))
+          'search_url': _nn(_url.text),
+        // The provider is only a preference for the server's link builder; on
+        // edit, sending it without a destination would overwrite the stored
+        // provider while the old link stays — so only send it when a link is
+        // (re)built from a destination.
+        if (!isEdit || _nn(_destination.text) != null) ...{
+          if (_kind == 'stay') 'provider': 'airbnb',
+          if (isTransport) 'provider': 'google_flights',
+        },
         'guests': 1,
         'passengers': 1,
-      });
+      };
+      final svc = ref.read(bookingTodosApiServiceProvider);
+      if (isEdit) {
+        await svc.update(widget.tripId, widget.existing!.id, body);
+      } else {
+        await svc.addTodo(widget.tripId, body);
+      }
       if (mounted) Navigator.pop(context, true);
     } catch (e) {
       setState(() {
@@ -3758,11 +3831,38 @@ class _AddBookingTodoDialogState extends ConsumerState<_AddBookingTodoDialog> {
     }
   }
 
+  /// A picker-backed date row: tap to pick, with a clear button when set
+  /// (both dates are optional).
+  Widget _dateField(String label, bool isDepart) {
+    final value = isDepart ? _departDate : _returnDate;
+    return Row(
+      children: [
+        Expanded(
+          child: OutlinedButton.icon(
+            icon: const Icon(Icons.event, size: 18),
+            label: Align(
+              alignment: Alignment.centerLeft,
+              child: Text(value == null ? label : '$label: ${_fmt(value)}'),
+            ),
+            onPressed: () => _pickDate(isDepart),
+          ),
+        ),
+        if (value != null)
+          IconButton(
+            icon: const Icon(Icons.clear, size: 18),
+            tooltip: 'Clear date',
+            onPressed: () => setState(() =>
+                isDepart ? _departDate = null : _returnDate = null),
+          ),
+      ],
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final isTransport = _kind == 'transport';
     return AlertDialog(
-      title: const Text('Add a booking'),
+      title: Text(widget.existing == null ? 'Add a booking' : 'Edit booking'),
       content: SingleChildScrollView(
         child: Column(
           mainAxisSize: MainAxisSize.min,
@@ -3777,29 +3877,31 @@ class _AddBookingTodoDialogState extends ConsumerState<_AddBookingTodoDialog> {
               ],
               onChanged: (v) => setState(() => _kind = v ?? 'stay'),
             ),
+            const SizedBox(height: AppSpacing.md),
             TextField(
                 controller: _title,
                 decoration: const InputDecoration(labelText: 'Title')),
-            if (isTransport)
+            const SizedBox(height: AppSpacing.md),
+            if (isTransport) ...[
               TextField(
                   controller: _origin,
                   decoration:
                       const InputDecoration(labelText: 'Origin (optional)')),
+              const SizedBox(height: AppSpacing.md),
+            ],
             TextField(
                 controller: _destination,
                 decoration:
                     const InputDecoration(labelText: 'Destination (optional)')),
-            TextField(
-                controller: _departDate,
-                decoration: InputDecoration(
-                    labelText: isTransport
-                        ? 'Depart date (YYYY-MM-DD)'
-                        : 'Check-in (YYYY-MM-DD)')),
-            if (!isTransport)
-              TextField(
-                  controller: _returnDate,
-                  decoration: const InputDecoration(
-                      labelText: 'Check-out (YYYY-MM-DD)')),
+            const SizedBox(height: AppSpacing.md),
+            _dateField(
+                isTransport ? 'Depart date (optional)' : 'Check-in (optional)',
+                true),
+            if (!isTransport) ...[
+              const SizedBox(height: AppSpacing.sm),
+              _dateField('Check-out (optional)', false),
+            ],
+            const SizedBox(height: AppSpacing.md),
             TextField(
                 controller: _url,
                 decoration: const InputDecoration(

--- a/src/packages/flutter-app/lib/services/booking_todos_api_service.dart
+++ b/src/packages/flutter-app/lib/services/booking_todos_api_service.dart
@@ -52,6 +52,22 @@ class BookingTodosApiService {
     throw Exception('Failed to update booking todo (${res.statusCode})');
   }
 
+  /// Partial content update of a custom (non-auto) todo. Same body shape as
+  /// [addTodo]; a destination with no explicit search_url makes the server
+  /// rebuild the search link.
+  Future<BookingTodo> update(
+      String tripId, String todoId, Map<String, dynamic> body) async {
+    final res = await apiClient.httpClient.patch(
+      Uri.parse('${apiClient.baseUrl}/trips/$tripId/booking-todos/$todoId'),
+      headers: apiClient.jsonHeaders(json: true),
+      body: jsonEncode(body),
+    );
+    if (res.statusCode == 200) {
+      return BookingTodo.fromJson(jsonDecode(res.body));
+    }
+    throw Exception('Failed to update booking todo (${res.statusCode})');
+  }
+
   /// Persists the user's drag order for the residual "Other bookings" list.
   /// Sends only that subset; the server renumbers those rows 0..n-1.
   Future<void> reorderTodos(String tripId, List<String> todoIds) async {

--- a/src/packages/flutter-app/lib/widgets/booking_todo_card.dart
+++ b/src/packages/flutter-app/lib/widgets/booking_todo_card.dart
@@ -38,6 +38,7 @@ class BookingTodoCard extends StatelessWidget {
   final BookingTodo todo;
   final ValueChanged<bool> onBookedChanged;
   final VoidCallback? onOpen;
+  final VoidCallback? onEdit;
   final VoidCallback? onDelete;
 
   /// Overrides the open-button text (e.g. 'Find flights' when the action opens
@@ -54,6 +55,7 @@ class BookingTodoCard extends StatelessWidget {
     required this.todo,
     required this.onBookedChanged,
     this.onOpen,
+    this.onEdit,
     this.onDelete,
     this.openLabelOverride,
     this.dragHandle,
@@ -92,6 +94,12 @@ class BookingTodoCard extends StatelessWidget {
                     ],
                   ),
                 ),
+                if (onEdit != null)
+                  IconButton(
+                    icon: const Icon(Icons.edit_outlined),
+                    tooltip: 'Edit',
+                    onPressed: onEdit,
+                  ),
                 if (onDelete != null)
                   IconButton(
                     icon: const Icon(Icons.delete_outline),


### PR DESCRIPTION
## Summary
- **Edit a booking**: custom "Other bookings" cards get a pencil button that reopens the Add-a-booking dialog prefilled ("Edit booking"); saves go through `PATCH /trips/{id}/booking-todos/{todoId}`, which now accepts content fields alongside the original booked-only contract. Booked-only requests stay on `SetBookingTodoBooked` (so the checkbox keeps working on auto rows); content edits use `UpdateBookingTodo` (custom rows only — auto rows 404). Re-entering a destination rebuilds the search link via the same builder as the add path; the prefilled link is only resent if the user changed it, so a destination rebuild isn't silently overridden.
- **Date pickers**: the check-in/check-out (or depart date) text fields are now `showDatePicker` buttons with a clear-× affordance, matching the AddStaySheet/AddSegmentSheet pattern — no more manual YYYY-MM-DD typing.
- **Label-overlap fix**: the dialog's fields were stacked with zero gaps, so a focused field's floating label rendered over the field above; fields now get `AppSpacing.md` gaps. The admin "New local source" dialog had the identical bug and gets the same fix.
- `UpdateBookingTodo` SQL gains `return_date`/`search_url`/`provider` COALESCE columns (sqlc regenerated; the agent plan-tool call site uses named fields and is unaffected).

Known limitation (commented in code): the PATCH is a COALESCE partial update, so an omitted field keeps its old value — a previously saved date can't be cleared back to empty from the edit dialog.

## Testing
- New `booking_todo_edit_integration_test.go`: content edits round-trip, destination link rebuild, explicit-URL override, booked-only on auto rows still 200 (path-split regression guard), content edit on auto rows 404, validation 400s, viewer 404 / anonymous 401.
- Full Go suite green against a local test DB; `flutter analyze` (no new findings) and `flutter test` (265 passing).
- Verified end-to-end in the dev stack via headless browser: add with picker → Airbnb link built with picked date; edit (retitle + new date + re-entered destination) → DB shows rebuilt Porto link; label overlap gone when focusing Destination; auto-row Booked checkbox still toggles; blank-title save shows inline error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)