### PR TITLE
feat: drag-to-reorder for the Your bookings hub (stays + transport)

### DIFF
--- a/src/packages/api/booking_draft_handler.go
+++ b/src/packages/api/booking_draft_handler.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/google/uuid"
+
 	"travel-route-planner/store"
 )
 
@@ -148,4 +150,123 @@ func syncBookingDraftsHandler(w http.ResponseWriter, r *http.Request) {
 		"accommodations": accResp,
 		"segments":       segResp,
 	})
+}
+
+type ReorderBookingsRequest struct {
+	StayIDs    []string `json:"stay_ids"`
+	SegmentIDs []string `json:"segment_ids"`
+}
+
+// orderedIDSubset parses ids and checks each exists in the trip's row set with
+// no duplicates. ok=false means the client's list is stale (or malformed) and
+// the caller should 409.
+func orderedIDSubset(ids []string, existing map[uuid.UUID]bool) ([]uuid.UUID, bool) {
+	ordered := make([]uuid.UUID, 0, len(ids))
+	seen := make(map[uuid.UUID]bool, len(ids))
+	for _, raw := range ids {
+		id, err := uuid.Parse(raw)
+		if err != nil || !existing[id] || seen[id] {
+			return nil, false
+		}
+		seen[id] = true
+		ordered = append(ordered, id)
+	}
+	return ordered, true
+}
+
+// reorderBookingsHandler reassigns positions 0..n-1 per bookings-hub group
+// (stays, segments) to the submitted ids. A drag sends only the group that
+// moved; the other array stays empty. Subsets are fine: unsubmitted rows keep
+// their position (new rows default to 9999 and sort by date at the tail).
+// Draft (auto) rows are orderable too — the drafts sync upsert never touches
+// position, so the order set here survives every trip load; a drag racing a
+// concurrent prune fails the exists check below and 409s.
+func reorderBookingsHandler(w http.ResponseWriter, r *http.Request) {
+	trip, ok := editableTrip(w, r)
+	if !ok {
+		return
+	}
+	tripID := trip.ID
+	var req ReorderBookingsRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid JSON")
+		return
+	}
+	if len(req.StayIDs) == 0 && len(req.SegmentIDs) == 0 {
+		writeJSONError(w, http.StatusBadRequest, "stay_ids or segment_ids is required")
+		return
+	}
+
+	ctx := r.Context()
+	tx, err := dbPool.Begin(ctx)
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "could not reorder bookings")
+		return
+	}
+	defer tx.Rollback(ctx)
+	q := store.New(tx)
+
+	// Serialize against concurrent syncs/reorders so the stale-set 409 stays
+	// reliable between the reads below and commit.
+	if _, err := q.GetTripForUpdate(ctx, tripID); err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "could not reorder bookings")
+		return
+	}
+	if len(req.StayIDs) > 0 {
+		stays, err := q.ListAccommodationsByTrip(ctx, tripID)
+		if err != nil {
+			writeJSONError(w, http.StatusInternalServerError, "could not load bookings")
+			return
+		}
+		existing := make(map[uuid.UUID]bool, len(stays))
+		for _, a := range stays {
+			existing[a.ID] = true
+		}
+		ordered, ok := orderedIDSubset(req.StayIDs, existing)
+		if !ok {
+			writeJSONError(w, http.StatusConflict, "bookings list is out of date; reload the trip")
+			return
+		}
+		for pos, id := range ordered {
+			if err := q.SetAccommodationPosition(ctx, store.SetAccommodationPositionParams{
+				ID: id, TripID: tripID, Position: int32(pos),
+			}); err != nil {
+				writeJSONError(w, http.StatusInternalServerError, "could not reorder bookings")
+				return
+			}
+		}
+	}
+	if len(req.SegmentIDs) > 0 {
+		segments, err := q.ListSegmentsByTrip(ctx, tripID)
+		if err != nil {
+			writeJSONError(w, http.StatusInternalServerError, "could not load bookings")
+			return
+		}
+		existing := make(map[uuid.UUID]bool, len(segments))
+		for _, s := range segments {
+			existing[s.ID] = true
+		}
+		ordered, ok := orderedIDSubset(req.SegmentIDs, existing)
+		if !ok {
+			writeJSONError(w, http.StatusConflict, "bookings list is out of date; reload the trip")
+			return
+		}
+		for pos, id := range ordered {
+			if err := q.SetSegmentPosition(ctx, store.SetSegmentPositionParams{
+				ID: id, TripID: tripID, Position: int32(pos),
+			}); err != nil {
+				writeJSONError(w, http.StatusInternalServerError, "could not reorder bookings")
+				return
+			}
+		}
+	}
+	if err := q.TouchTrip(ctx, touchedBy(tripID, r)); err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "could not reorder bookings")
+		return
+	}
+	if err := tx.Commit(ctx); err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "could not reorder bookings")
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
 }

--- a/src/packages/api/bookings_order_integration_test.go
+++ b/src/packages/api/bookings_order_integration_test.go
@@ -1,0 +1,187 @@
+package main
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+func addStay(t *testing.T, token, tripID, name string) string {
+	t.Helper()
+	rec := doJSON(t, "POST", "/api/v1/trips/"+tripID+"/accommodations", token, map[string]any{
+		"name": name,
+	})
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("add stay %q = %d: %s", name, rec.Code, rec.Body.String())
+	}
+	return decode(t, rec)["id"].(string)
+}
+
+func addSegment(t *testing.T, token, tripID, origin, destination string) string {
+	t.Helper()
+	rec := doJSON(t, "POST", "/api/v1/trips/"+tripID+"/segments", token, map[string]any{
+		"mode": "flight", "origin": origin, "destination": destination,
+	})
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("add segment %s->%s = %d: %s", origin, destination, rec.Code, rec.Body.String())
+	}
+	return decode(t, rec)["id"].(string)
+}
+
+func idsOf(rows []map[string]any) []string {
+	out := make([]string, 0, len(rows))
+	for _, r := range rows {
+		out = append(out, r["id"].(string))
+	}
+	return out
+}
+
+func assertIDOrder(t *testing.T, rows []map[string]any, want []string, label string) {
+	t.Helper()
+	got := idsOf(rows)
+	if len(got) != len(want) {
+		t.Fatalf("%s: %d rows, want %d", label, len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("%s[%d] = %s, want %s (full: %v)", label, i, got[i], want[i], got)
+		}
+	}
+}
+
+// Reordering one bookings-hub group persists and leaves the other alone; the
+// public share view reflects the editor's manual order.
+func TestReorderBookings(t *testing.T) {
+	resetDB(t)
+	owner, token := createTestUser(t, "owner@example.com")
+	trip := createTestTrip(t, owner.ID, 0)
+	tripID := trip.ID.String()
+
+	s1 := addStay(t, token, tripID, "Hotel Alpha")
+	s2 := addStay(t, token, tripID, "Hotel Beta")
+	s3 := addStay(t, token, tripID, "Hotel Gamma")
+	g1 := addSegment(t, token, tripID, "JFK", "LIS")
+	g2 := addSegment(t, token, tripID, "LIS", "JFK")
+
+	rec := doJSON(t, "PUT", "/api/v1/trips/"+tripID+"/bookings/order", token, map[string]any{
+		"stay_ids": []string{s3, s1, s2},
+	})
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("reorder stays = %d: %s", rec.Code, rec.Body.String())
+	}
+
+	body := decode(t, doJSON(t, "GET", "/api/v1/trips/"+tripID, token, nil))
+	assertIDOrder(t, listOf(t, body, "accommodations"), []string{s3, s1, s2}, "stays")
+	assertIDOrder(t, listOf(t, body, "segments"), []string{g1, g2}, "segments untouched")
+
+	rec = doJSON(t, "PUT", "/api/v1/trips/"+tripID+"/bookings/order", token, map[string]any{
+		"segment_ids": []string{g2, g1},
+	})
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("reorder segments = %d: %s", rec.Code, rec.Body.String())
+	}
+	body = decode(t, doJSON(t, "GET", "/api/v1/trips/"+tripID, token, nil))
+	assertIDOrder(t, listOf(t, body, "accommodations"), []string{s3, s1, s2}, "stays kept")
+	assertIDOrder(t, listOf(t, body, "segments"), []string{g2, g1}, "segments")
+
+	// The read-only share surface renders the same manual order.
+	shareToken := createShare(t, token, tripID, "viewer")
+	shared := decode(t, doJSON(t, "GET", "/api/v1/shared/"+shareToken, "", nil))
+	sharedTrip, ok := shared["trip"].(map[string]any)
+	if !ok {
+		t.Fatalf("shared response missing trip: %v", shared)
+	}
+	assertIDOrder(t, listOf(t, sharedTrip, "accommodations"), []string{s3, s1, s2}, "shared stays")
+	assertIDOrder(t, listOf(t, sharedTrip, "segments"), []string{g2, g1}, "shared segments")
+}
+
+// Draft (auto) rows are orderable and their user-assigned order survives the
+// per-load drafts sync; newly seeded drafts take the 9999 default and land
+// last; confirming a draft keeps the order.
+func TestReorderBookingsDraftsKeepOrder(t *testing.T) {
+	resetDB(t)
+	owner, token := createTestUser(t, "owner@example.com")
+	trip := createTestTrip(t, owner.ID, 0)
+	tripID := trip.ID.String()
+
+	confirmed := addStay(t, token, tripID, "Hotel Confirmed")
+	body := syncDrafts(t, token, tripID, []map[string]any{lisbonStay()}, nil)
+	draft := findByKey(listOf(t, body, "accommodations"), "stay:lisbon")
+	if draft == nil {
+		t.Fatalf("draft not seeded: %v", body)
+	}
+	draftID := draft["id"].(string)
+
+	// Put the draft ahead of the confirmed stay.
+	rec := doJSON(t, "PUT", "/api/v1/trips/"+tripID+"/bookings/order", token, map[string]any{
+		"stay_ids": []string{draftID, confirmed},
+	})
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("reorder = %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// The same sync that seeded the draft re-upserts it — order must hold.
+	body = syncDrafts(t, token, tripID, []map[string]any{lisbonStay()}, nil)
+	assertIDOrder(t, listOf(t, body, "accommodations"), []string{draftID, confirmed}, "after re-sync")
+
+	// A newly seeded draft (9999 default) sinks below the ordered rows.
+	porto := map[string]any{"auto_key": "stay:porto", "name": "Stay in Porto"}
+	body = syncDrafts(t, token, tripID, []map[string]any{lisbonStay(), porto}, nil)
+	stays := listOf(t, body, "accommodations")
+	newDraft := findByKey(stays, "stay:porto")
+	if newDraft == nil {
+		t.Fatalf("new draft not seeded: %v", stays)
+	}
+	assertIDOrder(t, stays, []string{draftID, confirmed, newDraft["id"].(string)}, "new draft last")
+
+	// Confirming the reordered draft (empty PATCH) keeps its position.
+	if rec := doJSON(t, "PATCH", "/api/v1/trips/"+tripID+"/accommodations/"+draftID, token, map[string]any{}); rec.Code != http.StatusOK {
+		t.Fatalf("confirm draft = %d: %s", rec.Code, rec.Body.String())
+	}
+	body = decode(t, doJSON(t, "GET", "/api/v1/trips/"+tripID, token, nil))
+	assertIDOrder(t, listOf(t, body, "accommodations"),
+		[]string{draftID, confirmed, newDraft["id"].(string)}, "after confirm")
+}
+
+func TestReorderBookingsValidation(t *testing.T) {
+	resetDB(t)
+	owner, token := createTestUser(t, "owner@example.com")
+	trip := createTestTrip(t, owner.ID, 0)
+	tripID := trip.ID.String()
+	s1 := addStay(t, token, tripID, "Hotel Alpha")
+	addStay(t, token, tripID, "Hotel Beta")
+	g1 := addSegment(t, token, tripID, "JFK", "LIS")
+
+	cases := []struct {
+		name string
+		body map[string]any
+		want int
+	}{
+		{"both empty", map[string]any{}, http.StatusBadRequest},
+		{"unknown id", map[string]any{"stay_ids": []string{uuid.NewString()}}, http.StatusConflict},
+		{"malformed id", map[string]any{"stay_ids": []string{"not-a-uuid"}}, http.StatusConflict},
+		{"duplicate id", map[string]any{"stay_ids": []string{s1, s1}}, http.StatusConflict},
+		{"segment id in stay_ids", map[string]any{"stay_ids": []string{g1}}, http.StatusConflict},
+		{"stay id in segment_ids", map[string]any{"segment_ids": []string{s1}}, http.StatusConflict},
+		{"subset ok", map[string]any{"stay_ids": []string{s1}}, http.StatusNoContent},
+	}
+	for _, tc := range cases {
+		rec := doJSON(t, "PUT", "/api/v1/trips/"+tripID+"/bookings/order", token, tc.body)
+		if rec.Code != tc.want {
+			t.Fatalf("%s = %d, want %d: %s", tc.name, rec.Code, tc.want, rec.Body.String())
+		}
+	}
+
+	_, strangerToken := createTestUser(t, "stranger@example.com")
+	if rec := doJSON(t, "PUT", "/api/v1/trips/"+tripID+"/bookings/order", strangerToken, map[string]any{
+		"stay_ids": []string{s1},
+	}); rec.Code != http.StatusNotFound {
+		t.Fatalf("stranger reorder = %d, want 404", rec.Code)
+	}
+	if rec := doJSON(t, "PUT", "/api/v1/trips/"+tripID+"/bookings/order", "", map[string]any{
+		"stay_ids": []string{s1},
+	}); rec.Code != http.StatusUnauthorized {
+		t.Fatalf("anonymous reorder = %d, want 401", rec.Code)
+	}
+}

--- a/src/packages/api/main.go
+++ b/src/packages/api/main.go
@@ -780,6 +780,7 @@ func buildRouter() *mux.Router {
 	api.Handle("/trips/{id}/segments/{segmentId}", authMiddleware(http.HandlerFunc(updateSegmentHandler))).Methods("PATCH")
 	api.Handle("/trips/{id}/segments/{segmentId}", authMiddleware(http.HandlerFunc(deleteSegmentHandler))).Methods("DELETE")
 	api.Handle("/trips/{id}/booking-drafts", authMiddleware(http.HandlerFunc(syncBookingDraftsHandler))).Methods("PUT")
+	api.Handle("/trips/{id}/bookings/order", authMiddleware(http.HandlerFunc(reorderBookingsHandler))).Methods("PUT")
 	api.Handle("/trips/{id}/booking-todos", authMiddleware(http.HandlerFunc(syncBookingTodosHandler))).Methods("PUT")
 	api.Handle("/trips/{id}/booking-todos", authMiddleware(http.HandlerFunc(addBookingTodoHandler))).Methods("POST")
 	api.Handle("/trips/{id}/booking-todos/order", authMiddleware(http.HandlerFunc(reorderBookingTodosHandler))).Methods("PUT")

--- a/src/packages/api/migrations/00039_bookings_position.sql
+++ b/src/packages/api/migrations/00039_bookings_position.sql
@@ -1,0 +1,14 @@
+-- +goose Up
+-- Manual drag order for the bookings hub ("Your bookings" stays + transport).
+-- Default 9999 (not 0) so every pre-existing row and every future insert
+-- (manual adds, seeded drafts, trip copies) ties at 9999 and falls through to
+-- the date/created_at tiebreak — today's order is preserved exactly until the
+-- user first drags, which renumbers that group 0..n-1; rows added afterwards
+-- sink to the bottom. Same convention as custom booking_todos, but via the DB
+-- default: no insert path enumerates position explicitly.
+ALTER TABLE accommodations ADD COLUMN position int NOT NULL DEFAULT 9999;
+ALTER TABLE trip_segments ADD COLUMN position int NOT NULL DEFAULT 9999;
+
+-- +goose Down
+ALTER TABLE trip_segments DROP COLUMN IF EXISTS position;
+ALTER TABLE accommodations DROP COLUMN IF EXISTS position;

--- a/src/packages/api/query/accommodations.sql
+++ b/src/packages/api/query/accommodations.sql
@@ -4,11 +4,11 @@ VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
 RETURNING *;
 
 -- name: ListAccommodationsByTrip :many
-SELECT * FROM accommodations WHERE trip_id = $1 AND NOT dismissed ORDER BY check_in ASC NULLS LAST, created_at ASC;
+SELECT * FROM accommodations WHERE trip_id = $1 AND NOT dismissed ORDER BY position ASC, check_in ASC NULLS LAST, created_at ASC;
 
 -- name: ListConfirmedAccommodationsByTrip :many
 -- Viewer/share/duplicate surface: drafts (auto=true) are editor-only.
-SELECT * FROM accommodations WHERE trip_id = $1 AND auto = false AND NOT dismissed ORDER BY check_in ASC NULLS LAST, created_at ASC;
+SELECT * FROM accommodations WHERE trip_id = $1 AND auto = false AND NOT dismissed ORDER BY position ASC, check_in ASC NULLS LAST, created_at ASC;
 
 -- name: UpsertDraftAccommodation :execrows
 -- The WHERE guard leaves confirmed (auto=false) and dismissed rows untouched,
@@ -48,6 +48,9 @@ SET name       = COALESCE(sqlc.narg('name'), name),
     auto       = false
 WHERE id = sqlc.arg('id') AND trip_id = sqlc.arg('trip_id') AND NOT dismissed
 RETURNING *;
+
+-- name: SetAccommodationPosition :exec
+UPDATE accommodations SET position = $3 WHERE id = $1 AND trip_id = $2;
 
 -- name: DeleteAccommodation :execrows
 DELETE FROM accommodations WHERE id = $1 AND trip_id = $2;

--- a/src/packages/api/query/segments.sql
+++ b/src/packages/api/query/segments.sql
@@ -4,11 +4,11 @@ VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
 RETURNING *;
 
 -- name: ListSegmentsByTrip :many
-SELECT * FROM trip_segments WHERE trip_id = $1 AND NOT dismissed ORDER BY depart_date ASC NULLS LAST, created_at ASC;
+SELECT * FROM trip_segments WHERE trip_id = $1 AND NOT dismissed ORDER BY position ASC, depart_date ASC NULLS LAST, created_at ASC;
 
 -- name: ListConfirmedSegmentsByTrip :many
 -- Viewer/share/duplicate surface: drafts (auto=true) are editor-only.
-SELECT * FROM trip_segments WHERE trip_id = $1 AND auto = false AND NOT dismissed ORDER BY depart_date ASC NULLS LAST, created_at ASC;
+SELECT * FROM trip_segments WHERE trip_id = $1 AND auto = false AND NOT dismissed ORDER BY position ASC, depart_date ASC NULLS LAST, created_at ASC;
 
 -- name: UpsertDraftSegment :execrows
 -- The WHERE guard leaves confirmed (auto=false) and dismissed rows untouched,
@@ -48,6 +48,9 @@ SET mode        = COALESCE(sqlc.narg('mode'), mode),
     auto        = false
 WHERE id = sqlc.arg('id') AND trip_id = sqlc.arg('trip_id') AND NOT dismissed
 RETURNING *;
+
+-- name: SetSegmentPosition :exec
+UPDATE trip_segments SET position = $3 WHERE id = $1 AND trip_id = $2;
 
 -- name: DeleteSegment :execrows
 DELETE FROM trip_segments WHERE id = $1 AND trip_id = $2;

--- a/src/packages/api/share_handler.go
+++ b/src/packages/api/share_handler.go
@@ -295,20 +295,36 @@ func duplicateSharedTripHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	for _, a := range accommodations {
-		if _, err := qtx.CreateAccommodation(ctx, store.CreateAccommodationParams{
+		copied, err := qtx.CreateAccommodation(ctx, store.CreateAccommodationParams{
 			TripID: copyTrip.ID, Name: a.Name, Provider: a.Provider, Url: a.Url,
 			Address: a.Address, Latitude: a.Latitude, Longitude: a.Longitude,
 			CheckIn: a.CheckIn, CheckOut: a.CheckOut, PriceNote: a.PriceNote,
+		})
+		if err != nil {
+			writeJSONError(w, http.StatusInternalServerError, "could not copy trip")
+			return
+		}
+		// Create doesn't take position (inserts default to the 9999 tail) —
+		// carry the source's manual bookings-hub order onto the copy.
+		if err := qtx.SetAccommodationPosition(ctx, store.SetAccommodationPositionParams{
+			ID: copied.ID, TripID: copyTrip.ID, Position: a.Position,
 		}); err != nil {
 			writeJSONError(w, http.StatusInternalServerError, "could not copy trip")
 			return
 		}
 	}
 	for _, s := range segments {
-		if _, err := qtx.CreateSegment(ctx, store.CreateSegmentParams{
+		copied, err := qtx.CreateSegment(ctx, store.CreateSegmentParams{
 			TripID: copyTrip.ID, Mode: s.Mode, Origin: s.Origin, Destination: s.Destination,
 			DepartDate: s.DepartDate, ArriveDate: s.ArriveDate, Provider: s.Provider,
 			Url: s.Url, PriceNote: s.PriceNote, Notes: s.Notes,
+		})
+		if err != nil {
+			writeJSONError(w, http.StatusInternalServerError, "could not copy trip")
+			return
+		}
+		if err := qtx.SetSegmentPosition(ctx, store.SetSegmentPositionParams{
+			ID: copied.ID, TripID: copyTrip.ID, Position: s.Position,
 		}); err != nil {
 			writeJSONError(w, http.StatusInternalServerError, "could not copy trip")
 			return

--- a/src/packages/api/store/accommodations.sql.go
+++ b/src/packages/api/store/accommodations.sql.go
@@ -15,7 +15,7 @@ import (
 const createAccommodation = `-- name: CreateAccommodation :one
 INSERT INTO accommodations (trip_id, name, provider, url, address, latitude, longitude, check_in, check_out, price_note)
 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
-RETURNING id, trip_id, name, provider, url, address, latitude, longitude, check_in, check_out, price_note, created_at, updated_at, auto, auto_key, dismissed
+RETURNING id, trip_id, name, provider, url, address, latitude, longitude, check_in, check_out, price_note, created_at, updated_at, auto, auto_key, dismissed, position
 `
 
 type CreateAccommodationParams struct {
@@ -62,6 +62,7 @@ func (q *Queries) CreateAccommodation(ctx context.Context, arg CreateAccommodati
 		&i.Auto,
 		&i.AutoKey,
 		&i.Dismissed,
+		&i.Position,
 	)
 	return i, err
 }
@@ -121,7 +122,7 @@ func (q *Queries) DismissDraftAccommodation(ctx context.Context, arg DismissDraf
 }
 
 const listAccommodationsByTrip = `-- name: ListAccommodationsByTrip :many
-SELECT id, trip_id, name, provider, url, address, latitude, longitude, check_in, check_out, price_note, created_at, updated_at, auto, auto_key, dismissed FROM accommodations WHERE trip_id = $1 AND NOT dismissed ORDER BY check_in ASC NULLS LAST, created_at ASC
+SELECT id, trip_id, name, provider, url, address, latitude, longitude, check_in, check_out, price_note, created_at, updated_at, auto, auto_key, dismissed, position FROM accommodations WHERE trip_id = $1 AND NOT dismissed ORDER BY position ASC, check_in ASC NULLS LAST, created_at ASC
 `
 
 func (q *Queries) ListAccommodationsByTrip(ctx context.Context, tripID uuid.UUID) ([]Accommodation, error) {
@@ -150,6 +151,7 @@ func (q *Queries) ListAccommodationsByTrip(ctx context.Context, tripID uuid.UUID
 			&i.Auto,
 			&i.AutoKey,
 			&i.Dismissed,
+			&i.Position,
 		); err != nil {
 			return nil, err
 		}
@@ -162,7 +164,7 @@ func (q *Queries) ListAccommodationsByTrip(ctx context.Context, tripID uuid.UUID
 }
 
 const listConfirmedAccommodationsByTrip = `-- name: ListConfirmedAccommodationsByTrip :many
-SELECT id, trip_id, name, provider, url, address, latitude, longitude, check_in, check_out, price_note, created_at, updated_at, auto, auto_key, dismissed FROM accommodations WHERE trip_id = $1 AND auto = false AND NOT dismissed ORDER BY check_in ASC NULLS LAST, created_at ASC
+SELECT id, trip_id, name, provider, url, address, latitude, longitude, check_in, check_out, price_note, created_at, updated_at, auto, auto_key, dismissed, position FROM accommodations WHERE trip_id = $1 AND auto = false AND NOT dismissed ORDER BY position ASC, check_in ASC NULLS LAST, created_at ASC
 `
 
 // Viewer/share/duplicate surface: drafts (auto=true) are editor-only.
@@ -192,6 +194,7 @@ func (q *Queries) ListConfirmedAccommodationsByTrip(ctx context.Context, tripID 
 			&i.Auto,
 			&i.AutoKey,
 			&i.Dismissed,
+			&i.Position,
 		); err != nil {
 			return nil, err
 		}
@@ -201,6 +204,21 @@ func (q *Queries) ListConfirmedAccommodationsByTrip(ctx context.Context, tripID 
 		return nil, err
 	}
 	return items, nil
+}
+
+const setAccommodationPosition = `-- name: SetAccommodationPosition :exec
+UPDATE accommodations SET position = $3 WHERE id = $1 AND trip_id = $2
+`
+
+type SetAccommodationPositionParams struct {
+	ID       uuid.UUID `json:"id"`
+	TripID   uuid.UUID `json:"trip_id"`
+	Position int32     `json:"position"`
+}
+
+func (q *Queries) SetAccommodationPosition(ctx context.Context, arg SetAccommodationPositionParams) error {
+	_, err := q.db.Exec(ctx, setAccommodationPosition, arg.ID, arg.TripID, arg.Position)
+	return err
 }
 
 const updateAccommodation = `-- name: UpdateAccommodation :one
@@ -216,7 +234,7 @@ SET name       = COALESCE($1, name),
     price_note = COALESCE($9, price_note),
     auto       = false
 WHERE id = $10 AND trip_id = $11 AND NOT dismissed
-RETURNING id, trip_id, name, provider, url, address, latitude, longitude, check_in, check_out, price_note, created_at, updated_at, auto, auto_key, dismissed
+RETURNING id, trip_id, name, provider, url, address, latitude, longitude, check_in, check_out, price_note, created_at, updated_at, auto, auto_key, dismissed, position
 `
 
 type UpdateAccommodationParams struct {
@@ -268,6 +286,7 @@ func (q *Queries) UpdateAccommodation(ctx context.Context, arg UpdateAccommodati
 		&i.Auto,
 		&i.AutoKey,
 		&i.Dismissed,
+		&i.Position,
 	)
 	return i, err
 }

--- a/src/packages/api/store/models.go
+++ b/src/packages/api/store/models.go
@@ -28,6 +28,7 @@ type Accommodation struct {
 	Auto      bool        `json:"auto"`
 	AutoKey   *string     `json:"auto_key"`
 	Dismissed bool        `json:"dismissed"`
+	Position  int32       `json:"position"`
 }
 
 type AlertEvent struct {
@@ -277,6 +278,7 @@ type TripSegment struct {
 	Auto        bool        `json:"auto"`
 	AutoKey     *string     `json:"auto_key"`
 	Dismissed   bool        `json:"dismissed"`
+	Position    int32       `json:"position"`
 }
 
 type TripShare struct {

--- a/src/packages/api/store/segments.sql.go
+++ b/src/packages/api/store/segments.sql.go
@@ -15,7 +15,7 @@ import (
 const createSegment = `-- name: CreateSegment :one
 INSERT INTO trip_segments (trip_id, mode, origin, destination, depart_date, arrive_date, provider, url, price_note, notes)
 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
-RETURNING id, trip_id, mode, origin, destination, depart_date, arrive_date, provider, url, price_note, notes, created_at, updated_at, auto, auto_key, dismissed
+RETURNING id, trip_id, mode, origin, destination, depart_date, arrive_date, provider, url, price_note, notes, created_at, updated_at, auto, auto_key, dismissed, position
 `
 
 type CreateSegmentParams struct {
@@ -62,6 +62,7 @@ func (q *Queries) CreateSegment(ctx context.Context, arg CreateSegmentParams) (T
 		&i.Auto,
 		&i.AutoKey,
 		&i.Dismissed,
+		&i.Position,
 	)
 	return i, err
 }
@@ -121,7 +122,7 @@ func (q *Queries) DismissDraftSegment(ctx context.Context, arg DismissDraftSegme
 }
 
 const listConfirmedSegmentsByTrip = `-- name: ListConfirmedSegmentsByTrip :many
-SELECT id, trip_id, mode, origin, destination, depart_date, arrive_date, provider, url, price_note, notes, created_at, updated_at, auto, auto_key, dismissed FROM trip_segments WHERE trip_id = $1 AND auto = false AND NOT dismissed ORDER BY depart_date ASC NULLS LAST, created_at ASC
+SELECT id, trip_id, mode, origin, destination, depart_date, arrive_date, provider, url, price_note, notes, created_at, updated_at, auto, auto_key, dismissed, position FROM trip_segments WHERE trip_id = $1 AND auto = false AND NOT dismissed ORDER BY position ASC, depart_date ASC NULLS LAST, created_at ASC
 `
 
 // Viewer/share/duplicate surface: drafts (auto=true) are editor-only.
@@ -151,6 +152,7 @@ func (q *Queries) ListConfirmedSegmentsByTrip(ctx context.Context, tripID uuid.U
 			&i.Auto,
 			&i.AutoKey,
 			&i.Dismissed,
+			&i.Position,
 		); err != nil {
 			return nil, err
 		}
@@ -163,7 +165,7 @@ func (q *Queries) ListConfirmedSegmentsByTrip(ctx context.Context, tripID uuid.U
 }
 
 const listSegmentsByTrip = `-- name: ListSegmentsByTrip :many
-SELECT id, trip_id, mode, origin, destination, depart_date, arrive_date, provider, url, price_note, notes, created_at, updated_at, auto, auto_key, dismissed FROM trip_segments WHERE trip_id = $1 AND NOT dismissed ORDER BY depart_date ASC NULLS LAST, created_at ASC
+SELECT id, trip_id, mode, origin, destination, depart_date, arrive_date, provider, url, price_note, notes, created_at, updated_at, auto, auto_key, dismissed, position FROM trip_segments WHERE trip_id = $1 AND NOT dismissed ORDER BY position ASC, depart_date ASC NULLS LAST, created_at ASC
 `
 
 func (q *Queries) ListSegmentsByTrip(ctx context.Context, tripID uuid.UUID) ([]TripSegment, error) {
@@ -192,6 +194,7 @@ func (q *Queries) ListSegmentsByTrip(ctx context.Context, tripID uuid.UUID) ([]T
 			&i.Auto,
 			&i.AutoKey,
 			&i.Dismissed,
+			&i.Position,
 		); err != nil {
 			return nil, err
 		}
@@ -201,6 +204,21 @@ func (q *Queries) ListSegmentsByTrip(ctx context.Context, tripID uuid.UUID) ([]T
 		return nil, err
 	}
 	return items, nil
+}
+
+const setSegmentPosition = `-- name: SetSegmentPosition :exec
+UPDATE trip_segments SET position = $3 WHERE id = $1 AND trip_id = $2
+`
+
+type SetSegmentPositionParams struct {
+	ID       uuid.UUID `json:"id"`
+	TripID   uuid.UUID `json:"trip_id"`
+	Position int32     `json:"position"`
+}
+
+func (q *Queries) SetSegmentPosition(ctx context.Context, arg SetSegmentPositionParams) error {
+	_, err := q.db.Exec(ctx, setSegmentPosition, arg.ID, arg.TripID, arg.Position)
+	return err
 }
 
 const updateSegment = `-- name: UpdateSegment :one
@@ -216,7 +234,7 @@ SET mode        = COALESCE($1, mode),
     notes       = COALESCE($9, notes),
     auto        = false
 WHERE id = $10 AND trip_id = $11 AND NOT dismissed
-RETURNING id, trip_id, mode, origin, destination, depart_date, arrive_date, provider, url, price_note, notes, created_at, updated_at, auto, auto_key, dismissed
+RETURNING id, trip_id, mode, origin, destination, depart_date, arrive_date, provider, url, price_note, notes, created_at, updated_at, auto, auto_key, dismissed, position
 `
 
 type UpdateSegmentParams struct {
@@ -268,6 +286,7 @@ func (q *Queries) UpdateSegment(ctx context.Context, arg UpdateSegmentParams) (T
 		&i.Auto,
 		&i.AutoKey,
 		&i.Dismissed,
+		&i.Position,
 	)
 	return i, err
 }

--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -936,6 +936,46 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
     }
   }
 
+  /// Persists a drag-reorder of the saved-stays list in the bookings hub.
+  /// Optimistic: display order is _stays list order; the drafts sync never
+  /// rewrites positions, so the order set here sticks across reloads.
+  Future<void> _reorderStays(int oldIndex, int newIndex) async {
+    if (_guardOffline()) return;
+    if (newIndex > oldIndex) newIndex--;
+    if (newIndex == oldIndex) return;
+    final prev = _stays;
+    final newOrder = List.of(_stays);
+    newOrder.insert(newIndex, newOrder.removeAt(oldIndex));
+    setState(() => _stays = newOrder);
+    try {
+      await ref.read(bookingDraftsApiServiceProvider).reorderBookings(
+          widget.tripId,
+          stayIds: [for (final a in newOrder) a.id]);
+    } catch (e) {
+      if (mounted) setState(() => _stays = prev);
+      _showSnack('Could not reorder: $e');
+    }
+  }
+
+  /// Mirror of [_reorderStays] for the transport-segments list.
+  Future<void> _reorderSegments(int oldIndex, int newIndex) async {
+    if (_guardOffline()) return;
+    if (newIndex > oldIndex) newIndex--;
+    if (newIndex == oldIndex) return;
+    final prev = _segments;
+    final newOrder = List.of(_segments);
+    newOrder.insert(newIndex, newOrder.removeAt(oldIndex));
+    setState(() => _segments = newOrder);
+    try {
+      await ref.read(bookingDraftsApiServiceProvider).reorderBookings(
+          widget.tripId,
+          segmentIds: [for (final s in newOrder) s.id]);
+    } catch (e) {
+      if (mounted) setState(() => _segments = prev);
+      _showSnack('Could not reorder: $e');
+    }
+  }
+
   Future<void> _deleteTodo(BookingTodo todo) async {
     if (_guardOffline()) return;
     try {
@@ -3423,6 +3463,12 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
                                     onDeleteSegment: _deleteSegment,
                                     onEditSegment: _editSegment,
                                     onConfirmSegment: _confirmSegment,
+                                    onReorderStays: (_readOnly || _isOffline)
+                                        ? null
+                                        : _reorderStays,
+                                    onReorderSegments: (_readOnly || _isOffline)
+                                        ? null
+                                        : _reorderSegments,
                                   ),
                                   // Bookings live embedded in their city groups;
                                   // this section appears only when something

--- a/src/packages/flutter-app/lib/services/booking_drafts_api_service.dart
+++ b/src/packages/flutter-app/lib/services/booking_drafts_api_service.dart
@@ -36,4 +36,22 @@ class BookingDraftsApiService {
     }
     throw Exception('Failed to sync booking drafts (${res.statusCode})');
   }
+
+  /// Persists the user's drag order for one bookings-hub group. Sends only
+  /// the group that moved; the server renumbers those rows 0..n-1 and leaves
+  /// the other group alone.
+  Future<void> reorderBookings(String tripId,
+      {List<String>? stayIds, List<String>? segmentIds}) async {
+    final res = await apiClient.httpClient.put(
+      Uri.parse('${apiClient.baseUrl}/trips/$tripId/bookings/order'),
+      headers: apiClient.jsonHeaders(json: true),
+      body: jsonEncode({
+        if (stayIds != null) 'stay_ids': stayIds,
+        if (segmentIds != null) 'segment_ids': segmentIds,
+      }),
+    );
+    if (res.statusCode != 204) {
+      throw Exception('Failed to reorder bookings (${res.statusCode})');
+    }
+  }
 }

--- a/src/packages/flutter-app/lib/widgets/bookings_section.dart
+++ b/src/packages/flutter-app/lib/widgets/bookings_section.dart
@@ -28,6 +28,13 @@ class BookingsSection extends StatelessWidget {
   final void Function(TripSegment) onEditSegment;
   final void Function(TripSegment) onConfirmSegment;
 
+  /// Drag-reorder callbacks, `ReorderableListView.onReorder`-shaped. Null
+  /// disables reordering for that group (viewer follows, offline). Indexes
+  /// refer to [stays]/[segments] directly — when reordering is enabled the
+  /// widget is not read-only, so the visible list IS the passed-in list.
+  final void Function(int oldIndex, int newIndex)? onReorderStays;
+  final void Function(int oldIndex, int newIndex)? onReorderSegments;
+
   /// Read-only mode (viewer follows): stays and transport render without the
   /// add buttons and edit/delete icons, and Suggested drafts are hidden
   /// entirely (the server already withholds them from viewers).
@@ -46,6 +53,8 @@ class BookingsSection extends StatelessWidget {
     required this.onDeleteSegment,
     required this.onEditSegment,
     required this.onConfirmSegment,
+    this.onReorderStays,
+    this.onReorderSegments,
     this.readOnly = false,
   });
 
@@ -88,7 +97,8 @@ class BookingsSection extends StatelessWidget {
   Widget _draftActions(
       {required VoidCallback onKeep,
       required VoidCallback onEdit,
-      required VoidCallback onDismiss}) {
+      required VoidCallback onDismiss,
+      Widget? dragHandle}) {
     return Row(
       mainAxisSize: MainAxisSize.min,
       children: [
@@ -107,18 +117,36 @@ class BookingsSection extends StatelessWidget {
           tooltip: 'Dismiss suggestion',
           onPressed: onDismiss,
         ),
+        if (dragHandle != null) dragHandle,
       ],
     );
   }
+
+  Widget _dragHandle(ThemeData theme, int index) =>
+      ReorderableDragStartListener(
+        index: index,
+        child: Padding(
+          padding: const EdgeInsets.only(left: AppSpacing.sm),
+          child: Icon(Icons.drag_indicator,
+              color: theme.colorScheme.onSurfaceVariant),
+        ),
+      );
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     // Belt and braces: the server withholds drafts from viewers, but a stale
     // cached copy could still carry them.
-    final visibleStays = readOnly ? stays.where((a) => !a.auto) : stays;
-    final visibleSegments = readOnly ? segments.where((s) => !s.auto) : segments;
+    final visibleStays = (readOnly ? stays.where((a) => !a.auto) : stays)
+        .toList(growable: false);
+    final visibleSegments =
+        (readOnly ? segments.where((s) => !s.auto) : segments)
+            .toList(growable: false);
     final draftCardColor = theme.colorScheme.surfaceContainerLow;
+    final canDragStays =
+        onReorderStays != null && !readOnly && visibleStays.length > 1;
+    final canDragSegments =
+        onReorderSegments != null && !readOnly && visibleSegments.length > 1;
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -152,115 +180,154 @@ class BookingsSection extends StatelessWidget {
                   ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
             ),
           ),
-        for (final a in visibleStays)
-          Card(
-            margin: const EdgeInsets.only(bottom: AppSpacing.sm),
-            color: a.auto ? draftCardColor : null,
-            child: ListTile(
-              leading: const Icon(Icons.hotel_outlined),
-              title: Row(
-                children: [
-                  Flexible(child: Text(a.name)),
-                  if (a.auto) _suggestedPill(theme),
-                ],
-              ),
-              subtitle: Text(
-                [
-                  if (a.provider != null && a.provider!.isNotEmpty) a.provider,
-                  if (a.checkIn != null && a.checkOut != null)
-                    '${a.checkIn} → ${a.checkOut}',
-                  if (a.address != null && a.address!.isNotEmpty) a.address,
-                ].whereType<String>().join(' · '),
-              ),
-              trailing: a.auto && !readOnly
-                  ? _draftActions(
-                      onKeep: () => onConfirmStay(a),
-                      onEdit: () => onEditStay(a),
-                      onDismiss: () => onDeleteStay(a),
-                    )
-                  : Row(
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        if (a.url != null && a.url!.isNotEmpty)
-                          IconButton(
-                            icon: const Icon(Icons.open_in_new, size: 18),
-                            tooltip: 'Open listing',
-                            onPressed: () => _open(context, a.url!,
-                                provider: a.provider, kind: 'stay'),
-                          ),
-                        if (!readOnly) ...[
-                          IconButton(
-                            icon: const Icon(Icons.edit_outlined, size: 18),
-                            tooltip: 'Edit stay',
-                            onPressed: () => onEditStay(a),
-                          ),
-                          IconButton(
-                            icon: const Icon(Icons.delete_outline, size: 18),
-                            tooltip: 'Remove stay',
-                            onPressed: () => onDeleteStay(a),
-                          ),
-                        ],
-                      ],
-                    ),
-            ),
-          ),
-        for (final s in visibleSegments)
-          Card(
-            margin: const EdgeInsets.only(bottom: AppSpacing.sm),
-            color: s.auto ? draftCardColor : null,
-            child: ListTile(
-              leading: Icon(_modeIcon(s.mode)),
-              title: Row(
-                children: [
-                  Flexible(
-                    child: Text(
-                      [s.origin, s.destination]
-                          .whereType<String>()
-                          .join(' → '),
-                    ),
+        // Only built when non-empty: ReorderableListView is itself a scroll
+        // view, and a pair of always-present empty ones would pollute the
+        // page's scrollable tree (and every find.byType(CustomScrollView)).
+        if (visibleStays.isNotEmpty)
+          ReorderableListView.builder(
+            shrinkWrap: true,
+            physics: const NeverScrollableScrollPhysics(),
+            padding: EdgeInsets.zero,
+            buildDefaultDragHandles: false,
+            itemCount: visibleStays.length,
+            onReorder: (oldIndex, newIndex) =>
+                onReorderStays?.call(oldIndex, newIndex),
+            itemBuilder: (context, i) {
+              final a = visibleStays[i];
+              return Card(
+                key: ValueKey(a.id),
+                margin: const EdgeInsets.only(bottom: AppSpacing.sm),
+                color: a.auto ? draftCardColor : null,
+                child: ListTile(
+                  leading: const Icon(Icons.hotel_outlined),
+                  title: Row(
+                    children: [
+                      Flexible(child: Text(a.name)),
+                      if (a.auto) _suggestedPill(theme),
+                    ],
                   ),
-                  if (s.auto) _suggestedPill(theme),
-                ],
-              ),
-              subtitle: Text(
-                [
-                  s.mode,
-                  if (s.departDate != null) s.departDate,
-                  if (s.provider != null && s.provider!.isNotEmpty) s.provider,
-                  if (s.notes != null && s.notes!.isNotEmpty) s.notes,
-                ].whereType<String>().join(' · '),
-              ),
-              trailing: s.auto && !readOnly
-                  ? _draftActions(
-                      onKeep: () => onConfirmSegment(s),
-                      onEdit: () => onEditSegment(s),
-                      onDismiss: () => onDeleteSegment(s),
-                    )
-                  : Row(
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        if (s.url != null && s.url!.isNotEmpty)
-                          IconButton(
-                            icon: const Icon(Icons.open_in_new, size: 18),
-                            tooltip: 'Open booking',
-                            onPressed: () => _open(context, s.url!,
-                                provider: s.provider, kind: 'transport'),
-                          ),
-                        if (!readOnly) ...[
-                          IconButton(
-                            icon: const Icon(Icons.edit_outlined, size: 18),
-                            tooltip: 'Edit transport',
-                            onPressed: () => onEditSegment(s),
-                          ),
-                          IconButton(
-                            icon: const Icon(Icons.delete_outline, size: 18),
-                            tooltip: 'Remove transport',
-                            onPressed: () => onDeleteSegment(s),
-                          ),
-                        ],
-                      ],
-                    ),
-            ),
+                  subtitle: Text(
+                    [
+                      if (a.provider != null && a.provider!.isNotEmpty)
+                        a.provider,
+                      if (a.checkIn != null && a.checkOut != null)
+                        '${a.checkIn} → ${a.checkOut}',
+                      if (a.address != null && a.address!.isNotEmpty) a.address,
+                    ].whereType<String>().join(' · '),
+                  ),
+                  trailing: a.auto && !readOnly
+                      ? _draftActions(
+                          onKeep: () => onConfirmStay(a),
+                          onEdit: () => onEditStay(a),
+                          onDismiss: () => onDeleteStay(a),
+                          dragHandle:
+                              canDragStays ? _dragHandle(theme, i) : null,
+                        )
+                      : Row(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            if (a.url != null && a.url!.isNotEmpty)
+                              IconButton(
+                                icon: const Icon(Icons.open_in_new, size: 18),
+                                tooltip: 'Open listing',
+                                onPressed: () => _open(context, a.url!,
+                                    provider: a.provider, kind: 'stay'),
+                              ),
+                            if (!readOnly) ...[
+                              IconButton(
+                                icon: const Icon(Icons.edit_outlined, size: 18),
+                                tooltip: 'Edit stay',
+                                onPressed: () => onEditStay(a),
+                              ),
+                              IconButton(
+                                icon:
+                                    const Icon(Icons.delete_outline, size: 18),
+                                tooltip: 'Remove stay',
+                                onPressed: () => onDeleteStay(a),
+                              ),
+                            ],
+                            if (canDragStays) _dragHandle(theme, i),
+                          ],
+                        ),
+                ),
+              );
+            },
+          ),
+        if (visibleSegments.isNotEmpty)
+          ReorderableListView.builder(
+            shrinkWrap: true,
+            physics: const NeverScrollableScrollPhysics(),
+            padding: EdgeInsets.zero,
+            buildDefaultDragHandles: false,
+            itemCount: visibleSegments.length,
+            onReorder: (oldIndex, newIndex) =>
+                onReorderSegments?.call(oldIndex, newIndex),
+            itemBuilder: (context, i) {
+              final s = visibleSegments[i];
+              return Card(
+                key: ValueKey(s.id),
+                margin: const EdgeInsets.only(bottom: AppSpacing.sm),
+                color: s.auto ? draftCardColor : null,
+                child: ListTile(
+                  leading: Icon(_modeIcon(s.mode)),
+                  title: Row(
+                    children: [
+                      Flexible(
+                        child: Text(
+                          [s.origin, s.destination]
+                              .whereType<String>()
+                              .join(' → '),
+                        ),
+                      ),
+                      if (s.auto) _suggestedPill(theme),
+                    ],
+                  ),
+                  subtitle: Text(
+                    [
+                      s.mode,
+                      if (s.departDate != null) s.departDate,
+                      if (s.provider != null && s.provider!.isNotEmpty)
+                        s.provider,
+                      if (s.notes != null && s.notes!.isNotEmpty) s.notes,
+                    ].whereType<String>().join(' · '),
+                  ),
+                  trailing: s.auto && !readOnly
+                      ? _draftActions(
+                          onKeep: () => onConfirmSegment(s),
+                          onEdit: () => onEditSegment(s),
+                          onDismiss: () => onDeleteSegment(s),
+                          dragHandle:
+                              canDragSegments ? _dragHandle(theme, i) : null,
+                        )
+                      : Row(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            if (s.url != null && s.url!.isNotEmpty)
+                              IconButton(
+                                icon: const Icon(Icons.open_in_new, size: 18),
+                                tooltip: 'Open booking',
+                                onPressed: () => _open(context, s.url!,
+                                    provider: s.provider, kind: 'transport'),
+                              ),
+                            if (!readOnly) ...[
+                              IconButton(
+                                icon: const Icon(Icons.edit_outlined, size: 18),
+                                tooltip: 'Edit transport',
+                                onPressed: () => onEditSegment(s),
+                              ),
+                              IconButton(
+                                icon:
+                                    const Icon(Icons.delete_outline, size: 18),
+                                tooltip: 'Remove transport',
+                                onPressed: () => onDeleteSegment(s),
+                              ),
+                            ],
+                            if (canDragSegments) _dragHandle(theme, i),
+                          ],
+                        ),
+                ),
+              );
+            },
           ),
       ],
     );

--- a/src/packages/flutter-app/test/bookings_section_drafts_test.dart
+++ b/src/packages/flutter-app/test/bookings_section_drafts_test.dart
@@ -54,6 +54,7 @@ BookingsSection _section({
   void Function(Accommodation)? onConfirmStay,
   void Function(Accommodation)? onEditStay,
   void Function(Accommodation)? onDeleteStay,
+  void Function(int, int)? onReorderStays,
 }) =>
     BookingsSection(
       trip: _trip(),
@@ -68,6 +69,7 @@ BookingsSection _section({
       onDeleteSegment: (_) {},
       onEditSegment: (_) {},
       onConfirmSegment: (_) {},
+      onReorderStays: onReorderStays,
     );
 
 void main() {
@@ -138,5 +140,23 @@ void main() {
     expect(find.text('Save'), findsOneWidget);
     expect(find.text('Stay in Lisbon'), findsOneWidget);
     expect(find.text('2026-09-01 → 2026-09-04'), findsOneWidget);
+  });
+
+  testWidgets('drag handles render for editors but never in read-only mode',
+      (tester) async {
+    await tester.pumpWidget(_wrap(_section(
+      stays: const [_draftStay, _confirmedStay],
+      segments: const [],
+      onReorderStays: (_, __) {},
+    )));
+    expect(find.byIcon(Icons.drag_indicator), findsNWidgets(2));
+
+    await tester.pumpWidget(_wrap(_section(
+      stays: const [_draftStay, _confirmedStay],
+      segments: const [],
+      readOnly: true,
+      onReorderStays: (_, __) {},
+    )));
+    expect(find.byIcon(Icons.drag_indicator), findsNothing);
   });
 }

--- a/src/packages/flutter-app/test/trip_detail_bookings_reorder_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_bookings_reorder_test.dart
@@ -1,0 +1,205 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:travel_route_planner/models/accommodation.dart';
+import 'package:travel_route_planner/models/trip.dart';
+import 'package:travel_route_planner/models/trip_segment.dart';
+import 'package:travel_route_planner/services/api_client.dart';
+import 'package:travel_route_planner/services/booking_drafts_api_service.dart';
+import 'package:travel_route_planner/services/trips_api_service.dart';
+import 'package:travel_route_planner/providers/booking_drafts_provider.dart';
+import 'package:travel_route_planner/providers/trips_provider.dart';
+import 'package:travel_route_planner/screens/trip_detail_screen.dart';
+
+/// Returns a fixed trip without hitting the network, so we can exercise the
+/// real TripDetailScreen render path.
+class _FakeTripsApiService extends TripsApiService {
+  final Trip trip;
+  _FakeTripsApiService(this.trip) : super(ApiClient(baseUrl: 'http://test'));
+
+  @override
+  Future<Trip> getTrip(String id) async => trip;
+}
+
+/// syncDrafts fails (the screen swallows it, so the stays/segments seeded on
+/// the trip survive); reorder calls are recorded and optionally fail.
+class _FakeBookingDraftsApiService extends BookingDraftsApiService {
+  final List<({List<String>? stayIds, List<String>? segmentIds})>
+      reorderCalls = [];
+  final bool failReorder;
+  _FakeBookingDraftsApiService({this.failReorder = false})
+      : super(ApiClient(baseUrl: 'http://test'));
+
+  @override
+  Future<BookingDraftsResult> syncDrafts(
+          String tripId, Map<String, dynamic> payload) async =>
+      throw Exception('offline test env');
+
+  @override
+  Future<void> reorderBookings(String tripId,
+      {List<String>? stayIds, List<String>? segmentIds}) async {
+    reorderCalls.add((stayIds: stayIds, segmentIds: segmentIds));
+    if (failReorder) throw Exception('server said no');
+  }
+}
+
+Accommodation _stay(String id, String name, {bool auto = false}) =>
+    Accommodation(
+        id: id, name: name, auto: auto, autoKey: auto ? 'stay:$id' : null);
+
+TripSegment _segment(String id, String origin, String destination) =>
+    TripSegment(id: id, mode: 'flight', origin: origin, destination: destination);
+
+Trip _trip(List<Accommodation> stays, List<TripSegment> segments) => Trip(
+      id: 't1',
+      title: 'Lisbon hop',
+      status: 'planned',
+      startDate: '2026-09-01',
+      endDate: '2026-09-06',
+      createdAt: '2026-08-01',
+      updatedAt: '2026-08-01',
+      items: [],
+      accommodations: stays,
+      segments: segments,
+    );
+
+/// The itinerary renders lazily (slivers), so widgets below the default
+/// 800x600 test viewport never get built. A tall viewport keeps the whole
+/// page — including the trailing bookings section — built and findable.
+void _useTallViewport(WidgetTester tester) {
+  tester.view.physicalSize = const Size(800, 2400);
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.reset);
+}
+
+Future<_FakeBookingDraftsApiService> _pumpTrip(WidgetTester tester, Trip trip,
+    {bool failReorder = false}) async {
+  final fake = _FakeBookingDraftsApiService(failReorder: failReorder);
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        tripsApiServiceProvider.overrideWithValue(_FakeTripsApiService(trip)),
+        bookingDraftsApiServiceProvider.overrideWithValue(fake),
+      ],
+      child: MaterialApp(home: TripDetailScreen(tripId: 't1')),
+    ),
+  );
+  await tester.pumpAndSettle();
+  return fake;
+}
+
+/// Drags the handle inside the ListTile containing [title] vertically by [dy].
+Future<void> _dragRow(WidgetTester tester, String title, double dy) async {
+  final row = find.ancestor(
+      of: find.text(title), matching: find.byType(ListTile));
+  final handle = find.descendant(
+      of: row, matching: find.byIcon(Icons.drag_indicator));
+  final gesture = await tester.startGesture(tester.getCenter(handle));
+  await tester.pump(const Duration(milliseconds: 100));
+  for (var i = 0; i < 5; i++) {
+    await gesture.moveBy(Offset(0, dy / 5));
+    await tester.pump(const Duration(milliseconds: 50));
+  }
+  await gesture.up();
+  await tester.pumpAndSettle();
+}
+
+double _rowTop(WidgetTester tester, String title) => tester
+    .getTopLeft(
+        find.ancestor(of: find.text(title), matching: find.byType(ListTile)))
+    .dy;
+
+void main() {
+  testWidgets('stay drag reorders stays only and persists via the service',
+      (WidgetTester tester) async {
+    _useTallViewport(tester);
+    final fake = await _pumpTrip(
+      tester,
+      _trip(
+        [
+          _stay('a', 'Hotel Alpha'),
+          _stay('b', 'Hotel Beta'),
+          _stay('d', 'Suggested Stay', auto: true),
+        ],
+        [_segment('g1', 'JFK', 'LIS'), _segment('g2', 'LIS', 'JFK')],
+      ),
+    );
+
+    // A handle on every stay row (incl. the Suggested draft) and segment row.
+    expect(find.byIcon(Icons.drag_indicator), findsNWidgets(5));
+
+    final rowHeight =
+        _rowTop(tester, 'Hotel Beta') - _rowTop(tester, 'Hotel Alpha');
+    await _dragRow(tester, 'Hotel Alpha', rowHeight + 20);
+
+    expect(fake.reorderCalls.length, 1);
+    expect(fake.reorderCalls.single.stayIds, ['b', 'a', 'd']);
+    expect(fake.reorderCalls.single.segmentIds, isNull);
+    // Optimistic order is visible.
+    expect(_rowTop(tester, 'Hotel Beta'),
+        lessThan(_rowTop(tester, 'Hotel Alpha')));
+    expect(_rowTop(tester, 'Hotel Alpha'),
+        lessThan(_rowTop(tester, 'Suggested Stay')));
+  });
+
+  testWidgets('segment drag sends segment_ids only',
+      (WidgetTester tester) async {
+    _useTallViewport(tester);
+    final fake = await _pumpTrip(
+      tester,
+      _trip(
+        [_stay('a', 'Hotel Alpha'), _stay('b', 'Hotel Beta')],
+        [_segment('g1', 'JFK', 'LIS'), _segment('g2', 'LIS', 'JFK')],
+      ),
+    );
+
+    final rowHeight = _rowTop(tester, 'LIS → JFK') - _rowTop(tester, 'JFK → LIS');
+    await _dragRow(tester, 'JFK → LIS', rowHeight + 20);
+
+    expect(fake.reorderCalls.length, 1);
+    expect(fake.reorderCalls.single.segmentIds, ['g2', 'g1']);
+    expect(fake.reorderCalls.single.stayIds, isNull);
+    expect(_rowTop(tester, 'LIS → JFK'), lessThan(_rowTop(tester, 'JFK → LIS')));
+  });
+
+  testWidgets('failed reorder reverts the order and shows a snackbar',
+      (WidgetTester tester) async {
+    _useTallViewport(tester);
+    final fake = await _pumpTrip(
+      tester,
+      _trip([_stay('a', 'Hotel Alpha'), _stay('b', 'Hotel Beta')], []),
+      failReorder: true,
+    );
+
+    final rowHeight =
+        _rowTop(tester, 'Hotel Beta') - _rowTop(tester, 'Hotel Alpha');
+    await _dragRow(tester, 'Hotel Alpha', rowHeight + 20);
+
+    expect(fake.reorderCalls.length, 1);
+    expect(_rowTop(tester, 'Hotel Alpha'),
+        lessThan(_rowTop(tester, 'Hotel Beta')));
+    expect(find.textContaining('Could not reorder'), findsOneWidget);
+  });
+
+  testWidgets('a single-row group gets no drag handle',
+      (WidgetTester tester) async {
+    _useTallViewport(tester);
+    await _pumpTrip(
+      tester,
+      _trip(
+        [_stay('a', 'Hotel Alpha'), _stay('b', 'Hotel Beta')],
+        [_segment('g1', 'JFK', 'LIS')],
+      ),
+    );
+
+    // Two stay handles, zero segment handles.
+    expect(find.byIcon(Icons.drag_indicator), findsNWidgets(2));
+    final segmentRow = find.ancestor(
+        of: find.text('JFK → LIS'), matching: find.byType(ListTile));
+    expect(
+        find.descendant(
+            of: segmentRow, matching: find.byIcon(Icons.drag_indicator)),
+        findsNothing);
+  });
+}


### PR DESCRIPTION
## Summary
- Makes the "Your bookings" cards draggable to reorder, within each group (stays among stays, segments among segments), via per-row drag handles — including on Suggested draft rows. Handles hide when read-only, offline, or the group has a single row.
- Migration 00039 adds `position int NOT NULL DEFAULT 9999` to `accommodations` and `trip_segments`; list queries order by `position` first with the old date sort as tiebreak. The 9999 default means nothing changes until a group is first dragged (renumbered 0..n-1); rows added afterwards sink to the tail — same convention as custom booking todos. No insert path changes; the DB default does the work.
- New `PUT /trips/{id}/bookings/order` (`{stay_ids, segment_ids}`, both optional, subset semantics, 409 on stale/duplicate/cross-group ids) in `booking_draft_handler.go`, following the PR #129 reorder pattern (tx + trip lock + TouchTrip).
- Drafts-sync upserts untouched — they never write `position`, so user order survives every trip load. Viewer/share surfaces intentionally inherit the editor's manual order, and trip duplication now carries source positions instead of resetting to date order.
- Client reorder is optimistic with rollback + snackbar; the group lists only build when non-empty (`ReorderableListView` is itself a scroll view — always-present empty ones would pollute the page's scrollable tree).

## Testing
- Go: full suite green against an isolated test DB. New integration tests: group reorder + share-view order; draft order surviving re-sync, newly seeded draft landing last, confirm-via-PATCH keeping position; validation table (both-empty 400, unknown/malformed/duplicate/cross-group 409, subset 204, stranger 404, anon 401).
- Flutter: `flutter analyze` clean (pre-existing infos only); all 270 tests pass incl. 5 new widget tests (stay drag → stay_ids only, segment drag → segment_ids only, failure rollback + snackbar, single-row no-handle, read-only no-handle).
- Manual on the dev stack (headless browser, migration 39 applied on rebuild): dragged a Suggested draft segment past another, confirmed positions 0/1 in Postgres, order held through a hard reload + drafts re-sync; single-stay group showed no handle; Keep/Edit/Dismiss taps unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)