### PR TITLE
feat: inline drag-to-reorder for itinerary items

### DIFF
--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -1616,7 +1616,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
       ThemeData theme, DateTime? tripStart,
       {required bool showTonight}) {
     if (!items.any((it) => it.day != null)) {
-      return [_boxSliver(_buildDayTripWidgets(items, theme))];
+      return _dayTripSectionSlivers(items, theme);
     }
     // Today mode: the header for today's trip day (if any) gets a visible
     // highlight; undated/past/future trips resolve to null and render as-is.
@@ -1673,15 +1673,14 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
           pushPinnedChildren: true,
           children: [
             SliverPinnedHeader(child: header),
-            if (!collapsed)
-              _boxSliver([
-                if (tonight != null) tonight,
-                ..._buildDayTripWidgets(run, theme),
-              ]),
+            if (!collapsed) ...[
+              if (tonight != null) _boxSliver([tonight]),
+              ..._dayTripSectionSlivers(run, theme),
+            ],
           ],
         ));
       } else {
-        slivers.add(_boxSliver(_buildDayTripWidgets(run, theme)));
+        slivers.addAll(_dayTripSectionSlivers(run, theme));
       }
     }
     return slivers;
@@ -2017,46 +2016,128 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
 
   /// Batches consecutive day-trip places (by town) under an indented
   /// "Day trip · <town>" sub-header so nearby towns read as excursions from the
-  /// hub city rather than separate stops. Inserts a within-city travel-time
-  /// connector between adjacent tiles of the same indent run.
-  List<Widget> _buildDayTripWidgets(
+  /// hub city rather than separate stops. Each contiguous batch (hub run or
+  /// day-trip batch) renders as its own [SliverReorderableList] so items can
+  /// be dragged inline within it; the within-city travel connector between
+  /// adjacent tiles is folded into the row below it and travels with it.
+  List<Widget> _dayTripSectionSlivers(
       List<ItineraryItem> items, ThemeData theme) {
-    final widgets = <Widget>[];
-    ItineraryItem? prev;
-    void addTile(ItineraryItem it, double indent) {
-      if (prev != null) {
-        final connector = _travelConnector(prev!, it, indent, theme);
-        if (connector != null) widgets.add(connector);
-      }
-      widgets.add(_itemTile(it, indent, theme));
-      prev = it;
-    }
-
+    final slivers = <Widget>[];
     var i = 0;
     while (i < items.length) {
       final dt = items[i].dayTripFrom?.trim();
       if (dt != null && dt.isNotEmpty) {
         final town = _cityOf(items[i]) ?? 'Day trip';
-        widgets
-            .add(_dayTripSubHeader(town, theme, _dayTripTravelLabel(items[i])));
-        prev = null; // don't draw a connector across the sub-header
+        slivers.add(_boxSliver([
+          _dayTripSubHeader(town, theme, _dayTripTravelLabel(items[i])),
+        ]));
+        final batch = <ItineraryItem>[];
         while (i < items.length) {
           final it = items[i];
           final d = it.dayTripFrom?.trim();
           if (d != null && d.isNotEmpty && _cityOf(it) == town) {
-            addTile(it, 32);
+            batch.add(it);
             i++;
           } else {
             break;
           }
         }
-        prev = null; // leaving the day-trip batch
+        slivers.add(_batchReorderableSliver(batch, 32, theme));
       } else {
-        addTile(items[i], 12);
-        i++;
+        final batch = <ItineraryItem>[];
+        while (i < items.length &&
+            (items[i].dayTripFrom?.trim() ?? '').isEmpty) {
+          batch.add(items[i]);
+          i++;
+        }
+        slivers.add(_batchReorderableSliver(batch, 12, theme));
       }
     }
-    return widgets;
+    return slivers;
+  }
+
+  /// One contiguous batch of item tiles as an inline-draggable sliver. Drag is
+  /// confined to the batch, a subset of _sectionOf's boundary (items rendered
+  /// apart can't be dragged past each other — the menu's "Reorder section"
+  /// sheet still covers the full section). Handles hide under a category
+  /// filter: the rendered rows are then a non-contiguous subset, so batch
+  /// indexes no longer map onto the trip's item order.
+  Widget _batchReorderableSliver(
+      List<ItineraryItem> batch, double indent, ThemeData theme) {
+    final canDrag = !_readOnly &&
+        !_isOffline &&
+        _itemFilter == 'all' &&
+        batch.length > 1;
+    return SliverReorderableList(
+      itemCount: batch.length,
+      // Unlike ReorderableListView, the sliver variant doesn't wrap the
+      // dragged proxy in a Material — without one the lifted ListTile throws.
+      proxyDecorator: (child, index, animation) => Material(
+        elevation: 4,
+        borderRadius: BorderRadius.circular(8),
+        child: child,
+      ),
+      onReorder: (oldIndex, newIndex) =>
+          _reorderBatchInline(batch, oldIndex, newIndex),
+      itemBuilder: (context, i) {
+        final item = batch[i];
+        final connector = i > 0
+            ? _travelConnector(batch[i - 1], item, indent, theme)
+            : null;
+        return Column(
+          key: ValueKey(item.id),
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            if (connector != null) connector,
+            _itemTile(
+              item,
+              indent,
+              theme,
+              dragHandle: canDrag
+                  ? ReorderableDragStartListener(
+                      index: i,
+                      child: Icon(Icons.drag_indicator,
+                          color: theme.colorScheme.onSurfaceVariant),
+                    )
+                  : null,
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  /// Persists an inline drag within one rendered batch. Optimistic: the new
+  /// order is spliced into the trip's item list in place so the drop doesn't
+  /// snap back while the request is in flight; the silent reload then
+  /// refreshes positions and travel connectors (or restores the server order
+  /// after a failure).
+  Future<void> _reorderBatchInline(
+      List<ItineraryItem> batch, int oldIndex, int newIndex) async {
+    if (_guardOffline()) return;
+    final trip = _trip;
+    final items = trip?.items;
+    if (trip == null || items == null) return;
+    if (newIndex > oldIndex) newIndex--;
+    if (newIndex == oldIndex) return;
+    final newOrder = List.of(batch);
+    newOrder.insert(newIndex, newOrder.removeAt(oldIndex));
+    final batchIds = {for (final it in batch) it.id};
+    var next = 0;
+    final newItems = <ItineraryItem>[
+      for (final it in items)
+        if (batchIds.contains(it.id)) newOrder[next++] else it,
+    ];
+    setState(() => items.setAll(0, newItems));
+    try {
+      await ref
+          .read(tripsApiServiceProvider)
+          .reorderItineraryItems(trip.id, [for (final it in newItems) it.id]);
+      await _load(silent: true);
+    } catch (e) {
+      _showSnack('Could not reorder: $e');
+      await _load(silent: true);
+    }
   }
 
   /// A small "↓ 12 min · 4.3 km" row shown between two consecutive itinerary
@@ -2316,7 +2397,8 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
     if (added != null && added.id == widget.tripId) _refresh();
   }
 
-  Widget _itemTile(ItineraryItem item, double indentLeft, ThemeData theme) =>
+  Widget _itemTile(ItineraryItem item, double indentLeft, ThemeData theme,
+          {Widget? dragHandle}) =>
       Padding(
         padding: EdgeInsets.only(left: indentLeft),
         child: ListTile(
@@ -2363,6 +2445,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
                 onPressed: () => _launch(_mapsUrl(item)),
               ),
               if (!_readOnly) _itemMenu(item),
+              if (dragHandle != null) dragHandle,
             ],
           ),
           selected: _selectedPosition == item.position,

--- a/src/packages/flutter-app/test/trip_detail_grouping_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_grouping_test.dart
@@ -36,9 +36,19 @@ ItineraryItem _item(int pos, String name, String address, String category,
       dayTripFrom: dayTripFrom,
     );
 
+/// Item rows now render inside lazy SliverReorderableLists, so rows below the
+/// default 800x600 viewport (plus cache extent) are never built. A tall
+/// viewport keeps the whole itinerary built and findable.
+void _useTallViewport(WidgetTester tester) {
+  tester.view.physicalSize = const Size(800, 2400);
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.reset);
+}
+
 void main() {
   testWidgets('itinerary groups by locality with dates derived from a stay',
       (WidgetTester tester) async {
+    _useTallViewport(tester);
     final trip = Trip(
       id: 't1',
       title: 'Bahamas',
@@ -90,6 +100,7 @@ void main() {
 
   testWidgets('items with day numbers render Day sub-sections and city dates',
       (WidgetTester tester) async {
+    _useTallViewport(tester);
     final trip = Trip(
       id: 't2',
       title: 'Europe',

--- a/src/packages/flutter-app/test/trip_detail_itinerary_reorder_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_itinerary_reorder_test.dart
@@ -1,0 +1,228 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:travel_route_planner/models/trip.dart';
+import 'package:travel_route_planner/models/itinerary_item.dart';
+import 'package:travel_route_planner/services/api_client.dart';
+import 'package:travel_route_planner/services/trips_api_service.dart';
+import 'package:travel_route_planner/providers/trips_provider.dart';
+import 'package:travel_route_planner/screens/trip_detail_screen.dart';
+
+ItineraryItem _item(int pos, String name, String category,
+        {int? day, String? city, String? dayTripFrom}) =>
+    ItineraryItem(
+      id: 'i-$name',
+      position: pos,
+      name: name,
+      address: '$name address',
+      // Zero coords so the screen skips the map widget in the test env.
+      latitude: 0,
+      longitude: 0,
+      category: category,
+      day: day,
+      city: city,
+      dayTripFrom: dayTripFrom,
+    );
+
+Trip _tripWith(List<ItineraryItem> items) => Trip(
+      id: 't1',
+      title: 'Paris',
+      status: 'planned',
+      startDate: '2026-09-01',
+      endDate: '2026-09-03',
+      createdAt: '2026-08-01',
+      updatedAt: '2026-08-01',
+      items: items,
+    );
+
+/// Serves the seeded trip and mirrors the server's reorder: a successful
+/// PUT /items/order call re-sorts the served items, so the screen's silent
+/// reload after a drag sees the new order (a failing call leaves it stale,
+/// so the reload restores the original order — the revert path).
+class _FakeTripsApiService extends TripsApiService {
+  List<ItineraryItem> items;
+  final List<List<String>> reorderCalls = [];
+  final bool failReorder;
+  _FakeTripsApiService(Trip trip, {this.failReorder = false})
+      : items = trip.items!,
+        super(ApiClient(baseUrl: 'http://test'));
+
+  // A fresh list per fetch, like a real JSON parse — the screen's optimistic
+  // in-place reorder must never alias the "server's" copy.
+  @override
+  Future<Trip> getTrip(String id) async => _tripWith(List.of(items));
+
+  @override
+  Future<void> reorderItineraryItems(String tripId, List<String> itemIds) async {
+    reorderCalls.add(itemIds);
+    if (failReorder) throw Exception('server said no');
+    final byId = {for (final it in items) it.id: it};
+    items = [for (final id in itemIds) byId[id]!];
+  }
+}
+
+/// Item rows render inside lazy SliverReorderableLists; a tall viewport keeps
+/// the whole itinerary built and findable.
+void _useTallViewport(WidgetTester tester) {
+  tester.view.physicalSize = const Size(800, 2400);
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.reset);
+}
+
+Future<_FakeTripsApiService> _pump(WidgetTester tester, Trip trip,
+    {bool failReorder = false}) async {
+  final fake = _FakeTripsApiService(trip, failReorder: failReorder);
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [tripsApiServiceProvider.overrideWithValue(fake)],
+      child: MaterialApp(home: TripDetailScreen(tripId: 't1')),
+    ),
+  );
+  await tester.pumpAndSettle();
+  return fake;
+}
+
+/// Drags the handle inside [name]'s ListTile vertically by [dy].
+Future<void> _dragItem(WidgetTester tester, String name, double dy) async {
+  final row =
+      find.ancestor(of: find.text(name), matching: find.byType(ListTile));
+  final handle =
+      find.descendant(of: row, matching: find.byIcon(Icons.drag_indicator));
+  final gesture = await tester.startGesture(tester.getCenter(handle));
+  await tester.pump(const Duration(milliseconds: 100));
+  for (var i = 0; i < 5; i++) {
+    await gesture.moveBy(Offset(0, dy / 5));
+    await tester.pump(const Duration(milliseconds: 50));
+  }
+  await gesture.up();
+  await tester.pumpAndSettle();
+}
+
+double _rowTop(WidgetTester tester, String name) => tester
+    .getTopLeft(find.ancestor(of: find.text(name), matching: find.byType(ListTile)))
+    .dy;
+
+void main() {
+  testWidgets('inline drag reorders within a day and sends the full permutation',
+      (WidgetTester tester) async {
+    _useTallViewport(tester);
+    final fake = await _pump(
+      tester,
+      _tripWith([
+        _item(0, 'Louvre', 'attraction', day: 1, city: 'Paris'),
+        _item(1, 'Orsay', 'attraction', day: 1, city: 'Paris'),
+        _item(2, 'Le Comptoir', 'restaurant', day: 1, city: 'Paris'),
+        _item(3, 'Pantheon', 'attraction', day: 2, city: 'Paris'),
+        _item(4, 'Sorbonne', 'attraction', day: 2, city: 'Paris'),
+      ]),
+    );
+
+    // A handle on every row: 3 in day 1's batch + 2 in day 2's.
+    expect(find.byIcon(Icons.drag_indicator), findsNWidgets(5));
+
+    final rowHeight = _rowTop(tester, 'Orsay') - _rowTop(tester, 'Louvre');
+    await _dragItem(tester, 'Louvre', rowHeight + 20);
+
+    expect(fake.reorderCalls, [
+      ['i-Orsay', 'i-Louvre', 'i-Le Comptoir', 'i-Pantheon', 'i-Sorbonne']
+    ]);
+    expect(_rowTop(tester, 'Orsay'), lessThan(_rowTop(tester, 'Louvre')));
+    expect(_rowTop(tester, 'Louvre'), lessThan(_rowTop(tester, 'Le Comptoir')));
+    // Day 2 untouched.
+    expect(_rowTop(tester, 'Pantheon'), lessThan(_rowTop(tester, 'Sorbonne')));
+  });
+
+  testWidgets('day-trip batches drag independently of the hub batch',
+      (WidgetTester tester) async {
+    _useTallViewport(tester);
+    final fake = await _pump(
+      tester,
+      _tripWith([
+        _item(0, 'Louvre', 'attraction', day: 1, city: 'Paris'),
+        _item(1, 'Orsay', 'attraction', day: 1, city: 'Paris'),
+        _item(2, 'Chateau', 'attraction',
+            day: 1, city: 'Versailles', dayTripFrom: 'Paris'),
+        _item(3, 'Gardens', 'attraction',
+            day: 1, city: 'Versailles', dayTripFrom: 'Paris'),
+      ]),
+    );
+
+    expect(find.text('Day trip · Versailles'), findsOneWidget);
+
+    final rowHeight = _rowTop(tester, 'Gardens') - _rowTop(tester, 'Chateau');
+    await _dragItem(tester, 'Chateau', rowHeight + 20);
+
+    // The day-trip drag permutes only the batch's slots.
+    expect(fake.reorderCalls, [
+      ['i-Louvre', 'i-Orsay', 'i-Gardens', 'i-Chateau']
+    ]);
+    expect(_rowTop(tester, 'Gardens'), lessThan(_rowTop(tester, 'Chateau')));
+    // Hub order untouched.
+    expect(_rowTop(tester, 'Louvre'), lessThan(_rowTop(tester, 'Orsay')));
+  });
+
+  testWidgets('failed reorder reverts the order and shows a snackbar',
+      (WidgetTester tester) async {
+    _useTallViewport(tester);
+    final fake = await _pump(
+      tester,
+      _tripWith([
+        _item(0, 'Louvre', 'attraction', day: 1, city: 'Paris'),
+        _item(1, 'Orsay', 'attraction', day: 1, city: 'Paris'),
+      ]),
+      failReorder: true,
+    );
+
+    final rowHeight = _rowTop(tester, 'Orsay') - _rowTop(tester, 'Louvre');
+    await _dragItem(tester, 'Louvre', rowHeight + 20);
+
+    expect(fake.reorderCalls.length, 1);
+    // The silent reload restored the server's (unchanged) order.
+    expect(_rowTop(tester, 'Louvre'), lessThan(_rowTop(tester, 'Orsay')));
+    expect(find.textContaining('Could not reorder'), findsOneWidget);
+  });
+
+  testWidgets('category filter hides the drag handles',
+      (WidgetTester tester) async {
+    _useTallViewport(tester);
+    await _pump(
+      tester,
+      _tripWith([
+        _item(0, 'Louvre', 'attraction', day: 1, city: 'Paris'),
+        _item(1, 'Orsay', 'attraction', day: 1, city: 'Paris'),
+        _item(2, 'Le Comptoir', 'restaurant', day: 1, city: 'Paris'),
+      ]),
+    );
+    expect(find.byIcon(Icons.drag_indicator), findsNWidgets(3));
+
+    await tester.tap(find.text('Attractions'));
+    await tester.pumpAndSettle();
+
+    // Filtered rows are a non-contiguous subset — no inline drag.
+    expect(find.text('Louvre'), findsOneWidget);
+    expect(find.byIcon(Icons.drag_indicator), findsNothing);
+  });
+
+  testWidgets('a single-item batch gets no drag handle',
+      (WidgetTester tester) async {
+    _useTallViewport(tester);
+    await _pump(
+      tester,
+      _tripWith([
+        _item(0, 'Louvre', 'attraction', day: 1, city: 'Paris'),
+        _item(1, 'Orsay', 'attraction', day: 1, city: 'Paris'),
+        _item(2, 'Pantheon', 'attraction', day: 2, city: 'Paris'),
+      ]),
+    );
+
+    // Two handles in day 1, none for day 2's single item.
+    expect(find.byIcon(Icons.drag_indicator), findsNWidgets(2));
+    final day2Row = find.ancestor(
+        of: find.text('Pantheon'), matching: find.byType(ListTile));
+    expect(
+        find.descendant(
+            of: day2Row, matching: find.byIcon(Icons.drag_indicator)),
+        findsNothing);
+  });
+}


### PR DESCRIPTION
## Summary
- Itinerary item tiles are now draggable inline via a per-row drag handle — each contiguous batch (a day's hub run or a "Day trip · town" batch) renders as a `SliverReorderableList`. Flutter-only: reuses the existing full-permutation `PUT /trips/{id}/items/order` endpoint through the same section-splice logic as the modal sheet.
- Drag is confined to the rendered batch, a subset of the `_sectionOf` (day + hub + day-trip) boundary — an item can never be dragged across a section line. The "Reorder section" sheet and Move up/down menu actions remain.
- Chose the sliver variant over a nested `ReorderableListView`: single scrollable tree (doesn't re-break `find.byType(CustomScrollView)` tests), drag-to-edge autoscroll against the page scroll, and lazy item rows (a perf win for long itineraries). A `proxyDecorator` supplies the `Material` + lift elevation the sliver variant doesn't add on its own.
- Reorder is optimistic (no snap-back), then a silent reload refreshes positions, travel connectors, and the map route; failure shows a snackbar and the reload restores the server order. Handles hide when read-only, offline, under a category filter (filtered rows aren't contiguous, so indexes wouldn't map), or in single-item batches. Travel connectors are folded into the row below them.

## Testing
- `flutter analyze` clean (pre-existing infos only); all 275 tests pass incl. 5 new (full-permutation payload with other days untouched, day-trip batch independence, failure revert + snackbar, filter hides handles, single-item batch no-handle).
- Two existing grouping tests gained the repo's tall-viewport helper — item rows are now lazily built, so deep rows need a viewport that reaches them.
- Manual on the dev stack (headless browser): dragged Musée d'Orsay below Joséphine with the elevated lift animation, confirmed full renumbering in Postgres (Day 1 untouched), order held through a hard reload, then dragged back to restore — connectors and map route recomputed after each drop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)