### PR TITLE
feat: Booked checkmarks for the Your bookings hub

### DIFF
--- a/src/packages/api/accommodation_handler.go
+++ b/src/packages/api/accommodation_handler.go
@@ -23,6 +23,7 @@ type AccommodationResponse struct {
 	CheckIn   *string  `json:"check_in,omitempty"`
 	CheckOut  *string  `json:"check_out,omitempty"`
 	PriceNote *string  `json:"price_note,omitempty"`
+	Booked    bool     `json:"booked"`
 	Auto      bool     `json:"auto"`
 	AutoKey   *string  `json:"auto_key,omitempty"`
 }
@@ -37,6 +38,10 @@ type AddAccommodationRequest struct {
 	CheckIn   *string  `json:"check_in"`
 	CheckOut  *string  `json:"check_out"`
 	PriceNote *string  `json:"price_note"`
+
+	// PATCH-only: the "Booked" checkbox on confirmed rows. Ignored on add —
+	// new stays start unbooked.
+	Booked *bool `json:"booked"`
 }
 
 func toAccommodationResponse(a store.Accommodation) AccommodationResponse {
@@ -51,6 +56,7 @@ func toAccommodationResponse(a store.Accommodation) AccommodationResponse {
 		CheckIn:   dateToPtr(a.CheckIn),
 		CheckOut:  dateToPtr(a.CheckOut),
 		PriceNote: a.PriceNote,
+		Booked:    a.Booked,
 		Auto:      a.Auto,
 		AutoKey:   a.AutoKey,
 	}
@@ -164,12 +170,21 @@ func updateAccommodationHandler(w http.ResponseWriter, r *http.Request) {
 		CheckIn:   checkIn,
 		CheckOut:  checkOut,
 		PriceNote: req.PriceNote,
+		Booked:    req.Booked,
 		ID:        accID,
 		TripID:    tripID,
 	})
 	if err != nil {
 		writeJSONError(w, http.StatusNotFound, "accommodation not found")
 		return
+	}
+	if req.Booked != nil && *req.Booked {
+		user, _ := userFromContext(r.Context())
+		meta := map[string]any{"kind": "stay"}
+		if acc.Provider != nil {
+			meta["provider"] = *acc.Provider
+		}
+		go recordEvent(user.ID, "saved_booking_marked_booked", &tripID, meta)
 	}
 	_ = store.New(dbPool).TouchTrip(r.Context(), touchedBy(tripID, r))
 	writeJSON(w, http.StatusOK, toAccommodationResponse(acc))

--- a/src/packages/api/bookings_booked_integration_test.go
+++ b/src/packages/api/bookings_booked_integration_test.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"net/http"
+	"testing"
+)
+
+// The "Booked" checkbox on saved bookings: PATCH {booked} round-trips through
+// the trip read, toggles back off, and is editor-only.
+func TestSavedBookingBookedToggle(t *testing.T) {
+	resetDB(t)
+	owner, ownerToken := createTestUser(t, "owner@example.com")
+	_, viewerToken := createTestUser(t, "viewer@example.com")
+	trip := createTestTrip(t, owner.ID, 2)
+	id := trip.ID.String()
+
+	rec := doJSON(t, "POST", "/api/v1/trips/"+id+"/accommodations", ownerToken, map[string]any{
+		"name": "Casa do Brian", "provider": "airbnb",
+	})
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("add stay = %d: %s", rec.Code, rec.Body.String())
+	}
+	stay := decode(t, rec)
+	if stay["booked"] != false {
+		t.Fatalf("new stay should start unbooked: %v", stay)
+	}
+	stayID := stay["id"].(string)
+
+	rec = doJSON(t, "POST", "/api/v1/trips/"+id+"/segments", ownerToken, map[string]any{
+		"mode": "train", "origin": "Lisbon", "destination": "Porto",
+	})
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("add segment = %d: %s", rec.Code, rec.Body.String())
+	}
+	segID := decode(t, rec)["id"].(string)
+
+	// Mark both booked; the flag must survive the trip read.
+	rec = doJSON(t, "PATCH", "/api/v1/trips/"+id+"/accommodations/"+stayID, ownerToken, map[string]any{"booked": true})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("book stay = %d: %s", rec.Code, rec.Body.String())
+	}
+	if got := decode(t, rec); got["booked"] != true {
+		t.Fatalf("booked stay = %v", got)
+	}
+	rec = doJSON(t, "PATCH", "/api/v1/trips/"+id+"/segments/"+segID, ownerToken, map[string]any{"booked": true})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("book segment = %d: %s", rec.Code, rec.Body.String())
+	}
+	tripView := decode(t, doJSON(t, "GET", "/api/v1/trips/"+id, ownerToken, nil))
+	if stays := listOf(t, tripView, "accommodations"); len(stays) != 1 || stays[0]["booked"] != true {
+		t.Fatalf("stays after booking = %v", stays)
+	}
+	if segs := listOf(t, tripView, "segments"); len(segs) != 1 || segs[0]["booked"] != true {
+		t.Fatalf("segments after booking = %v", segs)
+	}
+
+	// Unchecking works, and a booked-only PATCH must not clobber content.
+	rec = doJSON(t, "PATCH", "/api/v1/trips/"+id+"/accommodations/"+stayID, ownerToken, map[string]any{"booked": false})
+	if got := decode(t, rec); rec.Code != http.StatusOK || got["booked"] != false || got["name"] != "Casa do Brian" {
+		t.Fatalf("unbook stay = %d %v", rec.Code, got)
+	}
+
+	// Viewer follows are read-only: the toggle must be rejected.
+	shareToken := createShare(t, ownerToken, id, "viewer")
+	if rec := joinShare(t, viewerToken, shareToken); rec.Code >= 300 {
+		t.Fatalf("join = %d", rec.Code)
+	}
+	rec = doJSON(t, "PATCH", "/api/v1/trips/"+id+"/segments/"+segID, viewerToken, map[string]any{"booked": true})
+	if rec.Code < 400 {
+		t.Fatalf("viewer booked toggle should be rejected, got %d", rec.Code)
+	}
+}

--- a/src/packages/api/migrations/00040_bookings_booked.sql
+++ b/src/packages/api/migrations/00040_bookings_booked.sql
@@ -1,0 +1,11 @@
+-- +goose Up
+-- "Booked" checkmark for the bookings hub ("Your bookings" stays + transport),
+-- mirroring booking_todos.booked. Confirmed rows only in the UI — checking a
+-- box on a Suggested draft would silently confirm it, so drafts keep their
+-- Keep/Edit/Dismiss actions instead.
+ALTER TABLE accommodations ADD COLUMN booked boolean NOT NULL DEFAULT false;
+ALTER TABLE trip_segments ADD COLUMN booked boolean NOT NULL DEFAULT false;
+
+-- +goose Down
+ALTER TABLE trip_segments DROP COLUMN IF EXISTS booked;
+ALTER TABLE accommodations DROP COLUMN IF EXISTS booked;

--- a/src/packages/api/query/accommodations.sql
+++ b/src/packages/api/query/accommodations.sql
@@ -45,6 +45,7 @@ SET name       = COALESCE(sqlc.narg('name'), name),
     check_in   = COALESCE(sqlc.narg('check_in'), check_in),
     check_out  = COALESCE(sqlc.narg('check_out'), check_out),
     price_note = COALESCE(sqlc.narg('price_note'), price_note),
+    booked     = COALESCE(sqlc.narg('booked'), booked),
     auto       = false
 WHERE id = sqlc.arg('id') AND trip_id = sqlc.arg('trip_id') AND NOT dismissed
 RETURNING *;

--- a/src/packages/api/query/segments.sql
+++ b/src/packages/api/query/segments.sql
@@ -45,6 +45,7 @@ SET mode        = COALESCE(sqlc.narg('mode'), mode),
     url         = COALESCE(sqlc.narg('url'), url),
     price_note  = COALESCE(sqlc.narg('price_note'), price_note),
     notes       = COALESCE(sqlc.narg('notes'), notes),
+    booked      = COALESCE(sqlc.narg('booked'), booked),
     auto        = false
 WHERE id = sqlc.arg('id') AND trip_id = sqlc.arg('trip_id') AND NOT dismissed
 RETURNING *;

--- a/src/packages/api/segment_handler.go
+++ b/src/packages/api/segment_handler.go
@@ -27,6 +27,7 @@ type SegmentResponse struct {
 	URL         *string `json:"url,omitempty"`
 	PriceNote   *string `json:"price_note,omitempty"`
 	Notes       *string `json:"notes,omitempty"`
+	Booked      bool    `json:"booked"`
 	Auto        bool    `json:"auto"`
 	AutoKey     *string `json:"auto_key,omitempty"`
 }
@@ -41,6 +42,10 @@ type AddSegmentRequest struct {
 	URL         *string `json:"url"`
 	PriceNote   *string `json:"price_note"`
 	Notes       *string `json:"notes"`
+
+	// PATCH-only: the "Booked" checkbox on confirmed rows. Ignored on add —
+	// new segments start unbooked.
+	Booked *bool `json:"booked"`
 }
 
 func toSegmentResponse(s store.TripSegment) SegmentResponse {
@@ -55,6 +60,7 @@ func toSegmentResponse(s store.TripSegment) SegmentResponse {
 		URL:         s.Url,
 		PriceNote:   s.PriceNote,
 		Notes:       s.Notes,
+		Booked:      s.Booked,
 		Auto:        s.Auto,
 		AutoKey:     s.AutoKey,
 	}
@@ -181,12 +187,21 @@ func updateSegmentHandler(w http.ResponseWriter, r *http.Request) {
 		Url:         req.URL,
 		PriceNote:   req.PriceNote,
 		Notes:       req.Notes,
+		Booked:      req.Booked,
 		ID:          segID,
 		TripID:      tripID,
 	})
 	if err != nil {
 		writeJSONError(w, http.StatusNotFound, "segment not found")
 		return
+	}
+	if req.Booked != nil && *req.Booked {
+		user, _ := userFromContext(r.Context())
+		meta := map[string]any{"kind": "transport", "mode": seg.Mode}
+		if seg.Provider != nil {
+			meta["provider"] = *seg.Provider
+		}
+		go recordEvent(user.ID, "saved_booking_marked_booked", &tripID, meta)
 	}
 	_ = store.New(dbPool).TouchTrip(r.Context(), touchedBy(tripID, r))
 	writeJSON(w, http.StatusOK, toSegmentResponse(seg))

--- a/src/packages/api/store/accommodations.sql.go
+++ b/src/packages/api/store/accommodations.sql.go
@@ -15,7 +15,7 @@ import (
 const createAccommodation = `-- name: CreateAccommodation :one
 INSERT INTO accommodations (trip_id, name, provider, url, address, latitude, longitude, check_in, check_out, price_note)
 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
-RETURNING id, trip_id, name, provider, url, address, latitude, longitude, check_in, check_out, price_note, created_at, updated_at, auto, auto_key, dismissed, position
+RETURNING id, trip_id, name, provider, url, address, latitude, longitude, check_in, check_out, price_note, created_at, updated_at, auto, auto_key, dismissed, position, booked
 `
 
 type CreateAccommodationParams struct {
@@ -63,6 +63,7 @@ func (q *Queries) CreateAccommodation(ctx context.Context, arg CreateAccommodati
 		&i.AutoKey,
 		&i.Dismissed,
 		&i.Position,
+		&i.Booked,
 	)
 	return i, err
 }
@@ -122,7 +123,7 @@ func (q *Queries) DismissDraftAccommodation(ctx context.Context, arg DismissDraf
 }
 
 const listAccommodationsByTrip = `-- name: ListAccommodationsByTrip :many
-SELECT id, trip_id, name, provider, url, address, latitude, longitude, check_in, check_out, price_note, created_at, updated_at, auto, auto_key, dismissed, position FROM accommodations WHERE trip_id = $1 AND NOT dismissed ORDER BY position ASC, check_in ASC NULLS LAST, created_at ASC
+SELECT id, trip_id, name, provider, url, address, latitude, longitude, check_in, check_out, price_note, created_at, updated_at, auto, auto_key, dismissed, position, booked FROM accommodations WHERE trip_id = $1 AND NOT dismissed ORDER BY position ASC, check_in ASC NULLS LAST, created_at ASC
 `
 
 func (q *Queries) ListAccommodationsByTrip(ctx context.Context, tripID uuid.UUID) ([]Accommodation, error) {
@@ -152,6 +153,7 @@ func (q *Queries) ListAccommodationsByTrip(ctx context.Context, tripID uuid.UUID
 			&i.AutoKey,
 			&i.Dismissed,
 			&i.Position,
+			&i.Booked,
 		); err != nil {
 			return nil, err
 		}
@@ -164,7 +166,7 @@ func (q *Queries) ListAccommodationsByTrip(ctx context.Context, tripID uuid.UUID
 }
 
 const listConfirmedAccommodationsByTrip = `-- name: ListConfirmedAccommodationsByTrip :many
-SELECT id, trip_id, name, provider, url, address, latitude, longitude, check_in, check_out, price_note, created_at, updated_at, auto, auto_key, dismissed, position FROM accommodations WHERE trip_id = $1 AND auto = false AND NOT dismissed ORDER BY position ASC, check_in ASC NULLS LAST, created_at ASC
+SELECT id, trip_id, name, provider, url, address, latitude, longitude, check_in, check_out, price_note, created_at, updated_at, auto, auto_key, dismissed, position, booked FROM accommodations WHERE trip_id = $1 AND auto = false AND NOT dismissed ORDER BY position ASC, check_in ASC NULLS LAST, created_at ASC
 `
 
 // Viewer/share/duplicate surface: drafts (auto=true) are editor-only.
@@ -195,6 +197,7 @@ func (q *Queries) ListConfirmedAccommodationsByTrip(ctx context.Context, tripID 
 			&i.AutoKey,
 			&i.Dismissed,
 			&i.Position,
+			&i.Booked,
 		); err != nil {
 			return nil, err
 		}
@@ -232,9 +235,10 @@ SET name       = COALESCE($1, name),
     check_in   = COALESCE($7, check_in),
     check_out  = COALESCE($8, check_out),
     price_note = COALESCE($9, price_note),
+    booked     = COALESCE($10, booked),
     auto       = false
-WHERE id = $10 AND trip_id = $11 AND NOT dismissed
-RETURNING id, trip_id, name, provider, url, address, latitude, longitude, check_in, check_out, price_note, created_at, updated_at, auto, auto_key, dismissed, position
+WHERE id = $11 AND trip_id = $12 AND NOT dismissed
+RETURNING id, trip_id, name, provider, url, address, latitude, longitude, check_in, check_out, price_note, created_at, updated_at, auto, auto_key, dismissed, position, booked
 `
 
 type UpdateAccommodationParams struct {
@@ -247,6 +251,7 @@ type UpdateAccommodationParams struct {
 	CheckIn   pgtype.Date `json:"check_in"`
 	CheckOut  pgtype.Date `json:"check_out"`
 	PriceNote *string     `json:"price_note"`
+	Booked    *bool       `json:"booked"`
 	ID        uuid.UUID   `json:"id"`
 	TripID    uuid.UUID   `json:"trip_id"`
 }
@@ -265,6 +270,7 @@ func (q *Queries) UpdateAccommodation(ctx context.Context, arg UpdateAccommodati
 		arg.CheckIn,
 		arg.CheckOut,
 		arg.PriceNote,
+		arg.Booked,
 		arg.ID,
 		arg.TripID,
 	)
@@ -287,6 +293,7 @@ func (q *Queries) UpdateAccommodation(ctx context.Context, arg UpdateAccommodati
 		&i.AutoKey,
 		&i.Dismissed,
 		&i.Position,
+		&i.Booked,
 	)
 	return i, err
 }

--- a/src/packages/api/store/models.go
+++ b/src/packages/api/store/models.go
@@ -29,6 +29,7 @@ type Accommodation struct {
 	AutoKey   *string     `json:"auto_key"`
 	Dismissed bool        `json:"dismissed"`
 	Position  int32       `json:"position"`
+	Booked    bool        `json:"booked"`
 }
 
 type AlertEvent struct {
@@ -279,6 +280,7 @@ type TripSegment struct {
 	AutoKey     *string     `json:"auto_key"`
 	Dismissed   bool        `json:"dismissed"`
 	Position    int32       `json:"position"`
+	Booked      bool        `json:"booked"`
 }
 
 type TripShare struct {

--- a/src/packages/api/store/segments.sql.go
+++ b/src/packages/api/store/segments.sql.go
@@ -15,7 +15,7 @@ import (
 const createSegment = `-- name: CreateSegment :one
 INSERT INTO trip_segments (trip_id, mode, origin, destination, depart_date, arrive_date, provider, url, price_note, notes)
 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
-RETURNING id, trip_id, mode, origin, destination, depart_date, arrive_date, provider, url, price_note, notes, created_at, updated_at, auto, auto_key, dismissed, position
+RETURNING id, trip_id, mode, origin, destination, depart_date, arrive_date, provider, url, price_note, notes, created_at, updated_at, auto, auto_key, dismissed, position, booked
 `
 
 type CreateSegmentParams struct {
@@ -63,6 +63,7 @@ func (q *Queries) CreateSegment(ctx context.Context, arg CreateSegmentParams) (T
 		&i.AutoKey,
 		&i.Dismissed,
 		&i.Position,
+		&i.Booked,
 	)
 	return i, err
 }
@@ -122,7 +123,7 @@ func (q *Queries) DismissDraftSegment(ctx context.Context, arg DismissDraftSegme
 }
 
 const listConfirmedSegmentsByTrip = `-- name: ListConfirmedSegmentsByTrip :many
-SELECT id, trip_id, mode, origin, destination, depart_date, arrive_date, provider, url, price_note, notes, created_at, updated_at, auto, auto_key, dismissed, position FROM trip_segments WHERE trip_id = $1 AND auto = false AND NOT dismissed ORDER BY position ASC, depart_date ASC NULLS LAST, created_at ASC
+SELECT id, trip_id, mode, origin, destination, depart_date, arrive_date, provider, url, price_note, notes, created_at, updated_at, auto, auto_key, dismissed, position, booked FROM trip_segments WHERE trip_id = $1 AND auto = false AND NOT dismissed ORDER BY position ASC, depart_date ASC NULLS LAST, created_at ASC
 `
 
 // Viewer/share/duplicate surface: drafts (auto=true) are editor-only.
@@ -153,6 +154,7 @@ func (q *Queries) ListConfirmedSegmentsByTrip(ctx context.Context, tripID uuid.U
 			&i.AutoKey,
 			&i.Dismissed,
 			&i.Position,
+			&i.Booked,
 		); err != nil {
 			return nil, err
 		}
@@ -165,7 +167,7 @@ func (q *Queries) ListConfirmedSegmentsByTrip(ctx context.Context, tripID uuid.U
 }
 
 const listSegmentsByTrip = `-- name: ListSegmentsByTrip :many
-SELECT id, trip_id, mode, origin, destination, depart_date, arrive_date, provider, url, price_note, notes, created_at, updated_at, auto, auto_key, dismissed, position FROM trip_segments WHERE trip_id = $1 AND NOT dismissed ORDER BY position ASC, depart_date ASC NULLS LAST, created_at ASC
+SELECT id, trip_id, mode, origin, destination, depart_date, arrive_date, provider, url, price_note, notes, created_at, updated_at, auto, auto_key, dismissed, position, booked FROM trip_segments WHERE trip_id = $1 AND NOT dismissed ORDER BY position ASC, depart_date ASC NULLS LAST, created_at ASC
 `
 
 func (q *Queries) ListSegmentsByTrip(ctx context.Context, tripID uuid.UUID) ([]TripSegment, error) {
@@ -195,6 +197,7 @@ func (q *Queries) ListSegmentsByTrip(ctx context.Context, tripID uuid.UUID) ([]T
 			&i.AutoKey,
 			&i.Dismissed,
 			&i.Position,
+			&i.Booked,
 		); err != nil {
 			return nil, err
 		}
@@ -232,9 +235,10 @@ SET mode        = COALESCE($1, mode),
     url         = COALESCE($7, url),
     price_note  = COALESCE($8, price_note),
     notes       = COALESCE($9, notes),
+    booked      = COALESCE($10, booked),
     auto        = false
-WHERE id = $10 AND trip_id = $11 AND NOT dismissed
-RETURNING id, trip_id, mode, origin, destination, depart_date, arrive_date, provider, url, price_note, notes, created_at, updated_at, auto, auto_key, dismissed, position
+WHERE id = $11 AND trip_id = $12 AND NOT dismissed
+RETURNING id, trip_id, mode, origin, destination, depart_date, arrive_date, provider, url, price_note, notes, created_at, updated_at, auto, auto_key, dismissed, position, booked
 `
 
 type UpdateSegmentParams struct {
@@ -247,6 +251,7 @@ type UpdateSegmentParams struct {
 	Url         *string     `json:"url"`
 	PriceNote   *string     `json:"price_note"`
 	Notes       *string     `json:"notes"`
+	Booked      *bool       `json:"booked"`
 	ID          uuid.UUID   `json:"id"`
 	TripID      uuid.UUID   `json:"trip_id"`
 }
@@ -265,6 +270,7 @@ func (q *Queries) UpdateSegment(ctx context.Context, arg UpdateSegmentParams) (T
 		arg.Url,
 		arg.PriceNote,
 		arg.Notes,
+		arg.Booked,
 		arg.ID,
 		arg.TripID,
 	)
@@ -287,6 +293,7 @@ func (q *Queries) UpdateSegment(ctx context.Context, arg UpdateSegmentParams) (T
 		&i.AutoKey,
 		&i.Dismissed,
 		&i.Position,
+		&i.Booked,
 	)
 	return i, err
 }

--- a/src/packages/flutter-app/lib/models/accommodation.dart
+++ b/src/packages/flutter-app/lib/models/accommodation.dart
@@ -18,6 +18,11 @@ class Accommodation {
   @JsonKey(name: 'price_note')
   final String? priceNote;
 
+  /// The "Booked" checkbox in the bookings hub. defaultValue guards cached
+  /// trip JSON written before the field existed.
+  @JsonKey(defaultValue: false)
+  final bool booked;
+
   /// True for itinerary-derived "Suggested" drafts owned by the booking-drafts
   /// sync; false for user-confirmed rows.
   final bool auto;
@@ -35,9 +40,26 @@ class Accommodation {
     this.checkIn,
     this.checkOut,
     this.priceNote,
+    this.booked = false,
     this.auto = false,
     this.autoKey,
   });
+
+  Accommodation copyWith({bool? booked}) => Accommodation(
+        id: id,
+        name: name,
+        provider: provider,
+        url: url,
+        address: address,
+        latitude: latitude,
+        longitude: longitude,
+        checkIn: checkIn,
+        checkOut: checkOut,
+        priceNote: priceNote,
+        booked: booked ?? this.booked,
+        auto: auto,
+        autoKey: autoKey,
+      );
 
   factory Accommodation.fromJson(Map<String, dynamic> json) =>
       _$AccommodationFromJson(json);

--- a/src/packages/flutter-app/lib/models/accommodation.g.dart
+++ b/src/packages/flutter-app/lib/models/accommodation.g.dart
@@ -18,6 +18,7 @@ Accommodation _$AccommodationFromJson(Map<String, dynamic> json) =>
       checkIn: json['check_in'] as String?,
       checkOut: json['check_out'] as String?,
       priceNote: json['price_note'] as String?,
+      booked: json['booked'] as bool? ?? false,
       auto: json['auto'] as bool? ?? false,
       autoKey: json['auto_key'] as String?,
     );
@@ -34,6 +35,7 @@ Map<String, dynamic> _$AccommodationToJson(Accommodation instance) =>
       'check_in': instance.checkIn,
       'check_out': instance.checkOut,
       'price_note': instance.priceNote,
+      'booked': instance.booked,
       'auto': instance.auto,
       'auto_key': instance.autoKey,
     };

--- a/src/packages/flutter-app/lib/models/trip_segment.dart
+++ b/src/packages/flutter-app/lib/models/trip_segment.dart
@@ -18,6 +18,11 @@ class TripSegment {
   final String? priceNote;
   final String? notes;
 
+  /// The "Booked" checkbox in the bookings hub. defaultValue guards cached
+  /// trip JSON written before the field existed.
+  @JsonKey(defaultValue: false)
+  final bool booked;
+
   /// True for itinerary-derived "Suggested" drafts owned by the booking-drafts
   /// sync; false for user-confirmed rows.
   final bool auto;
@@ -35,9 +40,26 @@ class TripSegment {
     this.url,
     this.priceNote,
     this.notes,
+    this.booked = false,
     this.auto = false,
     this.autoKey,
   });
+
+  TripSegment copyWith({bool? booked}) => TripSegment(
+        id: id,
+        mode: mode,
+        origin: origin,
+        destination: destination,
+        departDate: departDate,
+        arriveDate: arriveDate,
+        provider: provider,
+        url: url,
+        priceNote: priceNote,
+        notes: notes,
+        booked: booked ?? this.booked,
+        auto: auto,
+        autoKey: autoKey,
+      );
 
   factory TripSegment.fromJson(Map<String, dynamic> json) =>
       _$TripSegmentFromJson(json);

--- a/src/packages/flutter-app/lib/models/trip_segment.g.dart
+++ b/src/packages/flutter-app/lib/models/trip_segment.g.dart
@@ -17,6 +17,7 @@ TripSegment _$TripSegmentFromJson(Map<String, dynamic> json) => TripSegment(
       url: json['url'] as String?,
       priceNote: json['price_note'] as String?,
       notes: json['notes'] as String?,
+      booked: json['booked'] as bool? ?? false,
       auto: json['auto'] as bool? ?? false,
       autoKey: json['auto_key'] as String?,
     );
@@ -33,6 +34,7 @@ Map<String, dynamic> _$TripSegmentToJson(TripSegment instance) =>
       'url': instance.url,
       'price_note': instance.priceNote,
       'notes': instance.notes,
+      'booked': instance.booked,
       'auto': instance.auto,
       'auto_key': instance.autoKey,
     };

--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -1324,6 +1324,27 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
     }
   }
 
+  /// "Booked" checkbox on a confirmed stay. Optimistic like the checklist's
+  /// _setBooked: swap the row in _stays, PATCH {booked}, roll back on error.
+  Future<void> _setStayBooked(Accommodation a, bool booked) async {
+    if (_guardOffline()) return;
+    final prev = _stays;
+    setState(() {
+      _stays = [
+        for (final s in _stays)
+          if (s.id == a.id) s.copyWith(booked: booked) else s,
+      ];
+    });
+    try {
+      await ref
+          .read(accommodationsApiServiceProvider)
+          .update(widget.tripId, a.id, {'booked': booked});
+    } catch (e) {
+      if (mounted) setState(() => _stays = prev);
+      _showSnack('Update failed: $e');
+    }
+  }
+
   /// "Keep" on a Suggested draft: an empty PATCH confirms it as-is.
   Future<void> _confirmStay(Accommodation a) async {
     if (_guardOffline()) return;
@@ -1384,6 +1405,26 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
       await _load();
     } catch (e) {
       _showSnack('Could not update transport: $e');
+    }
+  }
+
+  /// Mirror of [_setStayBooked] for the transport-segments list.
+  Future<void> _setSegmentBooked(TripSegment seg, bool booked) async {
+    if (_guardOffline()) return;
+    final prev = _segments;
+    setState(() {
+      _segments = [
+        for (final s in _segments)
+          if (s.id == seg.id) s.copyWith(booked: booked) else s,
+      ];
+    });
+    try {
+      await ref
+          .read(transportApiServiceProvider)
+          .updateSegment(widget.tripId, seg.id, {'booked': booked});
+    } catch (e) {
+      if (mounted) setState(() => _segments = prev);
+      _showSnack('Update failed: $e');
     }
   }
 
@@ -3546,6 +3587,8 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
                                     onDeleteSegment: _deleteSegment,
                                     onEditSegment: _editSegment,
                                     onConfirmSegment: _confirmSegment,
+                                    onStayBookedChanged: _setStayBooked,
+                                    onSegmentBookedChanged: _setSegmentBooked,
                                     onReorderStays: (_readOnly || _isOffline)
                                         ? null
                                         : _reorderStays,

--- a/src/packages/flutter-app/lib/widgets/bookings_section.dart
+++ b/src/packages/flutter-app/lib/widgets/bookings_section.dart
@@ -28,6 +28,13 @@ class BookingsSection extends StatelessWidget {
   final void Function(TripSegment) onEditSegment;
   final void Function(TripSegment) onConfirmSegment;
 
+  /// "Booked" checkbox toggles on confirmed rows (drafts keep their
+  /// keep/edit/dismiss actions instead — checking a suggestion would silently
+  /// confirm it). Null disables the checkboxes (offline), like the reorder
+  /// callbacks; in read-only mode they render disabled but still show state.
+  final void Function(Accommodation, bool)? onStayBookedChanged;
+  final void Function(TripSegment, bool)? onSegmentBookedChanged;
+
   /// Drag-reorder callbacks, `ReorderableListView.onReorder`-shaped. Null
   /// disables reordering for that group (viewer follows, offline). Indexes
   /// refer to [stays]/[segments] directly — when reordering is enabled the
@@ -53,6 +60,8 @@ class BookingsSection extends StatelessWidget {
     required this.onDeleteSegment,
     required this.onEditSegment,
     required this.onConfirmSegment,
+    this.onStayBookedChanged,
+    this.onSegmentBookedChanged,
     this.onReorderStays,
     this.onReorderSegments,
     this.readOnly = false,
@@ -121,6 +130,26 @@ class BookingsSection extends StatelessWidget {
       ],
     );
   }
+
+  /// Compact "Booked" checkbox for confirmed rows, shrunk to sit in the
+  /// trailing icon row (same treatment as BookingTodoRow's). A null
+  /// [onChanged] renders it disabled but still showing state.
+  Widget _bookedCheckbox(
+          {required bool value, required void Function(bool)? onChanged}) =>
+      Checkbox(
+        value: value,
+        onChanged: onChanged == null ? null : (v) => onChanged(v ?? false),
+        visualDensity: VisualDensity.compact,
+        materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+      );
+
+  /// Muted + struck-through once booked, mirroring the checklist rows.
+  TextStyle? _bookedTitleStyle(ThemeData theme, bool booked) => booked
+      ? TextStyle(
+          color: theme.colorScheme.onSurfaceVariant,
+          decoration: TextDecoration.lineThrough,
+        )
+      : null;
 
   Widget _dragHandle(ThemeData theme, int index) =>
       ReorderableDragStartListener(
@@ -202,7 +231,10 @@ class BookingsSection extends StatelessWidget {
                   leading: const Icon(Icons.hotel_outlined),
                   title: Row(
                     children: [
-                      Flexible(child: Text(a.name)),
+                      Flexible(
+                        child: Text(a.name,
+                            style: _bookedTitleStyle(theme, a.booked)),
+                      ),
                       if (a.auto) _suggestedPill(theme),
                     ],
                   ),
@@ -246,6 +278,13 @@ class BookingsSection extends StatelessWidget {
                                 onPressed: () => onDeleteStay(a),
                               ),
                             ],
+                            _bookedCheckbox(
+                              value: a.booked,
+                              onChanged:
+                                  (readOnly || onStayBookedChanged == null)
+                                      ? null
+                                      : (v) => onStayBookedChanged!(a, v),
+                            ),
                             if (canDragStays) _dragHandle(theme, i),
                           ],
                         ),
@@ -277,6 +316,7 @@ class BookingsSection extends StatelessWidget {
                           [s.origin, s.destination]
                               .whereType<String>()
                               .join(' → '),
+                          style: _bookedTitleStyle(theme, s.booked),
                         ),
                       ),
                       if (s.auto) _suggestedPill(theme),
@@ -322,6 +362,13 @@ class BookingsSection extends StatelessWidget {
                                 onPressed: () => onDeleteSegment(s),
                               ),
                             ],
+                            _bookedCheckbox(
+                              value: s.booked,
+                              onChanged:
+                                  (readOnly || onSegmentBookedChanged == null)
+                                      ? null
+                                      : (v) => onSegmentBookedChanged!(s, v),
+                            ),
                             if (canDragSegments) _dragHandle(theme, i),
                           ],
                         ),

--- a/src/packages/flutter-app/test/bookings_section_drafts_test.dart
+++ b/src/packages/flutter-app/test/bookings_section_drafts_test.dart
@@ -55,6 +55,7 @@ BookingsSection _section({
   void Function(Accommodation)? onEditStay,
   void Function(Accommodation)? onDeleteStay,
   void Function(int, int)? onReorderStays,
+  void Function(Accommodation, bool)? onStayBookedChanged,
 }) =>
     BookingsSection(
       trip: _trip(),
@@ -70,6 +71,7 @@ BookingsSection _section({
       onEditSegment: (_) {},
       onConfirmSegment: (_) {},
       onReorderStays: onReorderStays,
+      onStayBookedChanged: onStayBookedChanged,
     );
 
 void main() {
@@ -140,6 +142,51 @@ void main() {
     expect(find.text('Save'), findsOneWidget);
     expect(find.text('Stay in Lisbon'), findsOneWidget);
     expect(find.text('2026-09-01 → 2026-09-04'), findsOneWidget);
+  });
+
+  testWidgets('Booked checkbox: confirmed rows only, toggles, strikes title',
+      (tester) async {
+    Accommodation? toggled;
+    bool? toggledTo;
+    await tester.pumpWidget(_wrap(_section(
+      stays: const [_draftStay, _confirmedStay],
+      segments: const [],
+      onStayBookedChanged: (a, v) {
+        toggled = a;
+        toggledTo = v;
+      },
+    )));
+
+    // Only the confirmed stay has a checkbox — drafts keep keep/edit/dismiss.
+    expect(find.byType(Checkbox), findsOneWidget);
+    await tester.tap(find.byType(Checkbox));
+    expect(toggled?.id, 'a2');
+    expect(toggledTo, isTrue);
+
+    // A booked row renders muted + struck through.
+    await tester.pumpWidget(_wrap(_section(
+      stays: [_confirmedStay.copyWith(booked: true)],
+      segments: const [],
+    )));
+    final title = tester.widget<Text>(find.text('Casa do Brian'));
+    expect(title.style?.decoration, TextDecoration.lineThrough);
+    expect(
+      tester.widget<Checkbox>(find.byType(Checkbox)).value,
+      isTrue,
+    );
+  });
+
+  testWidgets('read-only mode shows booked state but disables the checkbox',
+      (tester) async {
+    await tester.pumpWidget(_wrap(_section(
+      stays: [_confirmedStay.copyWith(booked: true)],
+      segments: const [],
+      readOnly: true,
+      onStayBookedChanged: (_, __) => fail('read-only checkbox toggled'),
+    )));
+    final box = tester.widget<Checkbox>(find.byType(Checkbox));
+    expect(box.value, isTrue);
+    expect(box.onChanged, isNull);
   });
 
   testWidgets('drag handles render for editors but never in read-only mode',


### PR DESCRIPTION
## Summary
- Adds a "Booked" checkbox to confirmed stays and transport segments in the trip-detail "Your bookings" hub, matching the derived booking checklist's affordance.
- Migration 00040 adds `booked boolean NOT NULL DEFAULT false` to `accommodations` and `trip_segments`; the flag rides the existing partial-update PATCH handlers (`booked = COALESCE(sqlc.narg(...))`) — no new endpoints.
- `booked` flows into all read surfaces automatically (trip GET, viewer follows, public shares, duplicates); duplicated trips start unbooked.
- Confirmed rows only: Suggested drafts keep their keep/edit/dismiss actions, since any PATCH confirms a draft. Viewer follows see a disabled checkbox with state.
- Booked rows render muted + struck through, mirroring the checklist rows; toggles are optimistic with rollback, mirroring `_setBooked`.
- On `booked=true` the API fires a `saved_booking_marked_booked` analytics event (distinct from `booking_marked_booked` to keep that funnel's `todo_key` meta clean).

## Testing
- `go build`/`go vet` clean; full Go suite (incl. new `TestSavedBookingBookedToggle`: create → book → trip-read round-trip → unbook preserves content → viewer PATCH rejected) passes against a test DB.
- `flutter analyze` (only the 12 pre-existing infos) and all 277 tests pass, including two new widget tests (drafts get no checkbox; read-only disables but shows state).
- Verified end-to-end in the dev stack via headless browser: checkboxes toggle with strikethrough, persist across full page reload, uncheck round-trips to `booked=f` in postgres with `auto` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)