### PR TITLE
feat: drag-and-drop image attachments in the AI chat

### DIFF
--- a/dockerize/deployment/nginx/snippets/app-locations.conf
+++ b/dockerize/deployment/nginx/snippets/app-locations.conf
@@ -12,9 +12,10 @@ index index.html;
 location /api/ {
     proxy_pass http://api:8080;
     proxy_http_version 1.1;
-    # Above nginx's 1 MiB default for /transcribe audio clips; the Go
-    # bodyLimitMiddleware enforces the real per-endpoint caps.
-    client_max_body_size 10m;
+    # Above nginx's 1 MiB default for /transcribe audio clips and /plan
+    # image attachments; the Go bodyLimitMiddleware enforces the real
+    # per-endpoint caps (widest lane: 20 MiB for /plan).
+    client_max_body_size 20m;
     proxy_read_timeout 180s;
     proxy_send_timeout 180s;
     proxy_set_header Host $host;

--- a/dockerize/development/nginx/default.conf
+++ b/dockerize/development/nginx/default.conf
@@ -10,9 +10,10 @@ server {
     location /api/ {
         proxy_pass http://api:8080;
         proxy_http_version 1.1;
-        # Above nginx's 1 MiB default for /transcribe audio clips; the Go
-        # bodyLimitMiddleware enforces the real per-endpoint caps.
-        client_max_body_size 10m;
+        # Above nginx's 1 MiB default for /transcribe audio clips and /plan
+        # image attachments; the Go bodyLimitMiddleware enforces the real
+        # per-endpoint caps (widest lane: 20 MiB for /plan).
+        client_max_body_size 20m;
         proxy_read_timeout 180s;
         proxy_send_timeout 180s;
         proxy_set_header Host $host;

--- a/specs/chat-image-attachments/plan.md
+++ b/specs/chat-image-attachments/plan.md
@@ -1,0 +1,103 @@
+# Plan: Chat Image Attachments
+
+> **HOW.** Translates `spec.md` into a file-level technical approach. See
+> `../../CLAUDE.md` for repo conventions.
+
+## Technical Approach
+
+Inline base64 images in the existing `/plan` JSON request — no upload endpoint,
+no object store. Each `PlanChatMessage` gains an optional `images` array
+(`{media_type, data}`); the handler emits Anthropic image content blocks ahead
+of the text block for user messages. The client downscales images before send
+(longest side ≤1568px — Anthropic's effective max — re-encoded JPEG ~q80) so a
+photo lands at ~100–300 KB; that keeps the resend-whole-history-every-turn
+pattern and the twice-per-turn JSONB transcript upserts tolerable. Persisted
+transcripts strip pixel data but keep `media_type` as a placeholder marker, so
+resumed chats render an "image" chip and resend a valid (empty-data, skipped)
+history.
+
+Key decisions:
+- **Inline base64 over upload-by-reference:** one request, no storage infra,
+  matches degraded-mode statelessness; bounded by caps + client downscaling.
+- **Separate `images` field, never in `content`:** keeps the existing
+  `planMaxMessageChars` rune cap and the compactor's text-only distillation
+  untouched.
+- **Engine-native decode + pure-Dart encode** on the client: browser codecs do
+  the heavy decode/resize (no main-thread jank); the `image` package only
+  encodes the already-small result.
+
+## Go API Changes
+
+`src/packages/api/`:
+
+- **`plan_handler.go`** — `PlanImage{MediaType, Data}` type; `Images
+  []PlanImage` on `PlanChatMessage`; constants `planMaxImagesPerMessage=4`,
+  `planMaxImagesPerRequest=12`, `planMaxImageBase64Len=6_800_000` (≈5 MB
+  decoded); validation in the existing guard block (media-type allowlist
+  jpeg/png/gif/webp, counts, size, user-role-only) as friendly SSE `error`
+  events; conversion builds `NewUserMessage(imageBlocks..., textBlock)` via
+  `anthropic.NewImageBlockBase64`, skipping empty-`Data` placeholders and
+  never emitting an empty text block (image-only messages).
+- **`plan_compactor.go`** — comment only: folded images intentionally drop
+  from summaries (`buildDistillationTranscript` reads `.Content`).
+- **`chat_session_handler.go`** — `savePlanChatSession` blanks `Data` on every
+  persisted image (keeps `MediaType`) before `json.Marshal`.
+- **`middleware.go`** — `planMaxRequestBodyBytes` 4 MiB → 20 MiB; comment
+  notes the body cap is the effective aggregate image bound.
+- **nginx** — `client_max_body_size` 10m → 20m in
+  `dockerize/development/nginx/default.conf` and
+  `dockerize/deployment/nginx/snippets/app-locations.conf`.
+
+## Flutter Changes
+
+`src/packages/flutter-app/lib/`:
+
+- **Models** — `models/plan_message.dart`: `PlanAttachment{Uint8List? bytes,
+  String mediaType}` with memoized `base64Data` (history re-serializes every
+  turn); `PlanMessage.attachments` (default `const []`). Hand-rolled, no
+  `.g.dart`.
+- **Service** — `services/plan_service.dart`: `streamPlan` takes
+  `List<Map<String, dynamic>>`; new `services/image_attachment_pipeline.dart`
+  (validate → dimensions via `ui.ImageDescriptor` → pass-through if ≤1568px &
+  ≤500 KB → engine downscale + JPEG q80 encode, alpha flattened to white).
+- **Provider** — `providers/plan_provider.dart`: `sendMessage(...,
+  attachments)` threaded through `QueuedMessage`/`_drainQueue`/`_sendNow`/
+  `retryLastSend`; history maps `images` for byte-bearing attachments only;
+  empty-text sends allowed with attachments.
+- **Widgets** — `widgets/chat_panel.dart`: `DropTarget` (desktop_drop) around
+  the panel with a drop overlay; paperclip button (file_picker,
+  `FileType.image`, `withData`, multiple) in `_InputBar`; pending-chips row
+  (thumbnails + ✕) above the input; bubbles render `Image.memory` thumbnails
+  or an icon placeholder for `bytes == null` (resume).
+- **Screens** — `screens/trips_list_screen.dart`: resume mapping parses
+  `images` into null-byte placeholder attachments.
+- **pubspec** — add `desktop_drop`, `file_picker`, `image`.
+
+## Contract Parity  ← anti-drift gate
+
+| JSON key | Go type (`plan_handler.go`) | Dart type | Nullable? | ✓ |
+|----------|-----------------------------------|----------------------|-----------|---|
+| `images` | `[]PlanImage` `omitempty` | `List<Map>` entry omitted when absent | yes | ☐ |
+| `images[].media_type` | `string` | `String mediaType` | no | ☐ |
+| `images[].data` | `string` (base64, "" when stripped) | `String` from memoized `base64Data` | no | ☐ |
+
+## Cross-cutting
+
+- **Env vars:** none.
+- **Gateway:** existing `/api/v1/plan` path; only the `client_max_body_size`
+  bump above.
+- **Cost:** each ~1568px image ≈1,100–1,600 input tokens, re-sent per
+  agent-loop iteration (mitigated by prompt caching, the 4/12 caps, and
+  compaction folding old images away).
+
+## Verification
+
+- `make api-fmt && make api-vet`; `go test ./...` in `src/packages/api`.
+- `make flutter-analyze && make flutter-test` (no codegen — models are
+  hand-rolled).
+- Manual via gateway (`make docker-dev`, API `up --build`, gateway recreate
+  for nginx): walk every acceptance criterion in `spec.md` — drag-drop with
+  overlay, paperclip, 4-cap, remove chip, image-only send, agent answers
+  about the image, follow-up turn retains context, trip-refine panel,
+  resume placeholder, oversized/unsupported rejection (client + `curl` a
+  hand-built bad payload).

--- a/specs/chat-image-attachments/spec.md
+++ b/specs/chat-image-attachments/spec.md
@@ -1,0 +1,122 @@
+# Spec: Chat Image Attachments
+
+> **WHAT & WHY only.** No tech choices, file names, libraries, or code. If a
+> sentence names a file or a package, it belongs in `plan.md`, not here.
+
+## Context
+
+The AI planning chat is text-only, but trip planning is a visual activity:
+travelers hold screenshots of hotel listings, maps, event posters, and photos
+of hand-written itineraries. Today they must transcribe those into words. This
+feature lets users attach images to a chat message — by dragging them onto the
+chat or via an attach button — so the planning agent can see and reason about
+them directly, matching the experience users already know from Claude and
+ChatGPT.
+
+## User Stories
+
+- As a **traveler**, I want to **drop a screenshot of a hotel listing into the
+  chat and ask "is this a good area to stay?"** so that I don't have to
+  re-type the listing's details.
+- As a **traveler**, I want to **attach a photo of a map or written itinerary**
+  so that the agent can fold it into my plan.
+- As a **traveler on a phone or tablet**, I want an **attach button that opens
+  my gallery** so that I can add images without drag-and-drop.
+- As a **returning user**, I want a resumed conversation to **show where
+  images were attached** so that the transcript still reads coherently.
+
+## Acceptance Criteria
+
+- [ ] Dragging one or more image files over the chat shows a clear "drop to
+      attach" affordance; dropping them attaches the images.
+- [ ] An attach button in the composer opens a file/gallery picker filtered to
+      images and supports selecting multiple.
+- [ ] Attached images appear as thumbnail chips above the input field, each
+      removable before sending.
+- [ ] Up to 4 images can be attached to one message; attempting more shows a
+      friendly notice.
+- [ ] A message may be sent with images and no text.
+- [ ] Sent messages display their images as thumbnails in the chat transcript.
+- [ ] The agent's reply demonstrably reflects the image content (e.g. names
+      the city in a dropped photo).
+- [ ] Images attached earlier in the conversation remain visible to the agent
+      on follow-up turns within the same session.
+- [ ] Large photos are downscaled before upload; a multi-megabyte photo sends
+      in a few hundred kilobytes without visible quality loss at chat size.
+- [ ] Unsupported file types and oversized files are rejected with a friendly
+      message; nothing is sent.
+- [ ] The same attachment experience works in both the main planning chat and
+      the trip-refine chat panel.
+- [ ] Resuming a saved conversation shows an "image" placeholder where images
+      were attached; the conversation can continue normally.
+
+## API Surface
+
+No new endpoints. The existing plan-streaming request is extended:
+
+### `POST /api/v1/plan` (extended)
+- **Purpose:** each chat message may now carry attached images alongside its
+  text.
+- **Request:** a message optionally includes a list of images, each with a
+  media type (JPEG, PNG, GIF, or WebP) and the encoded image data. Images are
+  only valid on user messages. An image with empty data is a placeholder from
+  a resumed conversation and is ignored.
+- **Response:** unchanged (SSE stream).
+- **Errors:** friendly streamed errors (not server faults) when: a message has
+  more than 4 images; the request as a whole has more than 12; an image
+  exceeds the per-image size cap (~5 MB decoded); the media type is not in the
+  allowlist; images appear on an assistant message. Requests over the overall
+  body size cap are rejected outright.
+
+### `GET /api/v1/chats/{chatId}` (behavior change)
+- Saved transcripts retain each image's media type but not its pixel data, so
+  resumed conversations can render placeholders without storing megabytes.
+
+## Data Model
+
+- **Chat message image** — an attachment on a user chat message: a media type
+  plus encoded image data. In persisted transcripts the data is stripped and
+  only the media type remains (a placeholder marker). No new tables.
+
+## UI Behavior
+
+- **Surface:** the shared chat composer, in the Agent tab and the trip-refine
+  panel.
+- **Happy path:** user drags an image over the chat → overlay invites the
+  drop → thumbnail chip appears above the input (brief processing spinner for
+  large photos) → user types a question (optional) → send → the sent bubble
+  shows the thumbnail(s) → the agent replies about the image.
+- **States:**
+  - *Processing:* a spinner chip while an image is being read/downscaled;
+    sending is deferred until processing completes.
+  - *Attached:* thumbnail chips with a remove (✕) control.
+  - *Error:* snackbar for unreadable/oversized/unsupported files and for the
+    5th image.
+  - *Resumed:* placeholder chip (icon + "Image") where pixels are gone.
+
+## Edge Cases & Error States
+
+- Unsupported type (e.g. PDF, HEIC) → rejected client-side with a notice; the
+  server independently rejects non-allowlisted types.
+- Oversized source file (>10 MB) → rejected client-side before processing.
+- Animated GIF larger than the pass-through threshold → downscaled to a still
+  image (animation lost).
+- Transparent PNG re-encoded to JPEG → transparency flattened to white.
+- Send fails mid-stream → retry re-sends the message including its images.
+- Message queued while the agent is streaming → its images are preserved and
+  sent when the queue drains.
+- Conversation compaction folds old messages into a text summary → their
+  images leave the model's context (the newest messages keep theirs).
+
+## Out of Scope
+
+- Camera capture and paste-from-clipboard (paste is a candidate follow-up).
+- Image pixels surviving chat resume (placeholder only; no object storage).
+- Images on trip itineraries, bookings, or anywhere outside the chat.
+- Image generation or editing by the agent.
+- Non-image attachments (PDF, documents).
+
+## Open Questions
+
+None — capture scope (drag-drop + attach button) and resume behavior
+(placeholder, pixels dropped) were decided at planning time.

--- a/specs/chat-image-attachments/tasks.md
+++ b/specs/chat-image-attachments/tasks.md
@@ -1,0 +1,35 @@
+# Tasks: Chat Image Attachments
+
+> Dependency-ordered. `[P]` = can run in parallel with its siblings.
+
+## API (Go)
+
+- [ ] `PlanImage` type + `Images` field on `PlanChatMessage`; caps constants
+- [ ] Guard-block validation (allowlist, counts, size, user-role-only) as SSE errors
+- [ ] Anthropic conversion: image blocks before text, empty-`Data` skip, no empty text block
+- [ ] `savePlanChatSession` strips image data (keeps media type)
+- [ ] `planMaxRequestBodyBytes` → 20 MiB; nginx `client_max_body_size` → 20m (both configs)
+- [ ] Compactor comment (images intentionally drop from summaries)
+- [ ] Tests: `plan_images_test.go` (block order, image-only, validation, placeholder skip), persistence stripping, middleware lane
+
+## Models & wire (Flutter)
+
+- [ ] `PlanAttachment` (memoized base64) + `PlanMessage.attachments`
+- [ ] Provider threading: sendMessage/queue/drain/retry + history `images` mapping; image-only sends
+- [ ] `streamPlan` signature → `List<Map<String, dynamic>>`
+- [ ] Resume mapping → placeholder attachments
+- [ ] Contract Parity table in `plan.md` (every row ✓)
+
+## UI (Flutter)
+
+- [ ] pubspec: `desktop_drop`, `file_picker`, `image`
+- [ ] [P] `image_attachment_pipeline.dart` (validate, pass-through, downscale+encode)
+- [ ] [P] `DropTarget` + overlay on `ChatPanel`
+- [ ] Paperclip button + pending-chips row + `_send` changes
+- [ ] Bubble thumbnails + resume placeholders (incl. queued bubbles)
+
+## Verification
+
+- [ ] `make api-fmt && make api-vet` clean; `go test ./...` passes
+- [ ] `make flutter-analyze` clean; `make flutter-test` passes
+- [ ] Manual end-to-end via gateway: every acceptance criterion in `spec.md`

--- a/src/packages/api/chat_session_handler.go
+++ b/src/packages/api/chat_session_handler.go
@@ -59,7 +59,23 @@ func savePlanChatSession(ctx context.Context, uid uuid.UUID, chatID, summary str
 	if dbPool == nil || len(msgs) == 0 {
 		return
 	}
-	payload, err := json.Marshal(msgs)
+	// Persist images as markers only: the transcript is upserted wholesale
+	// twice per turn, so inlined base64 would rewrite megabytes to the JSONB
+	// column every message. MediaType survives so a resumed client can render
+	// an "image attached" placeholder; the empty Data round-trips as the
+	// placeholder shape plan_handler.go skips at conversion time.
+	persistable := append([]PlanChatMessage(nil), msgs...)
+	for i, m := range persistable {
+		if len(m.Images) == 0 {
+			continue
+		}
+		stripped := make([]PlanImage, len(m.Images))
+		for j, img := range m.Images {
+			stripped[j] = PlanImage{MediaType: img.MediaType}
+		}
+		persistable[i].Images = stripped
+	}
+	payload, err := json.Marshal(persistable)
 	if err != nil {
 		log.Printf("failed to marshal chat session %s: %v", chatID, err)
 		return

--- a/src/packages/api/middleware.go
+++ b/src/packages/api/middleware.go
@@ -85,13 +85,17 @@ func requestIDMiddleware(next http.Handler) http.Handler {
 //
 // The /plan lane must comfortably cover everything plan_handler.go's own
 // rune caps admit: planMaxMessages (40) x planMaxMessageChars (20,000 runes)
-// of 4-byte UTF-8 is ~3.2 MiB of content plus JSON framing, so 4 MiB keeps
-// the byte lane strictly wider than the rune lane. That way conversations the
-// handler would accept (or reject with a friendly SSE error event) never die
-// here first with a bare 413, which an SSE client surfaces poorly.
+// of 4-byte UTF-8 is ~3.2 MiB of content plus JSON framing. Image attachments
+// widen the lane: the client downscales to ~100-300 KB base64 per image, but
+// the per-image cap admits up to ~6.8 MB, so this body cap — not the
+// planMaxImagesPerRequest count — is the effective aggregate byte bound for
+// image-heavy histories. A 413 here still beats dying at the model API, but
+// conversations within plan_handler.go's own caps should normally clear this
+// lane and get friendly SSE error events instead. nginx's client_max_body_size
+// (dockerize/*/nginx) must stay >= this value or the gateway 413s first.
 const (
 	maxRequestBodyBytes       = 256 << 10 // 256 KiB, all endpoints by default
-	planMaxRequestBodyBytes   = 4 << 20   // 4 MiB for the /plan chat history (see above)
+	planMaxRequestBodyBytes   = 20 << 20  // 20 MiB for the /plan chat history incl. images (see above)
 	transcribeMaxRequestBytes = 10 << 20  // 10 MiB for /transcribe audio clips (60s opus is well under)
 )
 

--- a/src/packages/api/middleware_test.go
+++ b/src/packages/api/middleware_test.go
@@ -215,15 +215,15 @@ func TestBodyLimitAllowsNormalBody(t *testing.T) {
 	}
 }
 
-// /plan resends the whole chat history, so it gets the wider 4 MiB lane
-// (sized to exceed what the handler's own rune caps admit): a body over the
-// general cap but under the plan cap must pass through.
+// /plan resends the whole chat history — now with inline base64 image
+// attachments — so it gets the widest 20 MiB lane: a body over the general
+// cap, and one over the pre-images 4 MiB lane, must both pass through.
 func TestBodyLimitPlanGetsWiderLane(t *testing.T) {
 	handlerRan := false
 	h := bodyLimitMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		handlerRan = true
 		if _, err := io.Copy(io.Discard, r.Body); err != nil {
-			t.Fatalf("reading a 512KiB /plan body failed: %v", err)
+			t.Fatalf("reading an under-cap /plan body failed: %v", err)
 		}
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -232,6 +232,13 @@ func TestBodyLimitPlanGetsWiderLane(t *testing.T) {
 	h.ServeHTTP(rec, httptest.NewRequest("POST", "/api/v1/plan", bytes.NewReader(make([]byte, 512<<10))))
 	if !handlerRan || rec.Code != http.StatusOK {
 		t.Fatalf("handlerRan = %v, status = %d; want 512KiB /plan body to pass", handlerRan, rec.Code)
+	}
+
+	// An image-bearing history over the old 4 MiB text lane must fit now.
+	rec = httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest("POST", "/api/v1/plan", bytes.NewReader(make([]byte, 5<<20))))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want a 5 MiB /plan body to pass the image-widened lane", rec.Code)
 	}
 
 	rec = httptest.NewRecorder()

--- a/src/packages/api/plan_compactor.go
+++ b/src/packages/api/plan_compactor.go
@@ -59,6 +59,9 @@ func summaryAsMessage(summary string) PlanChatMessage {
 // summary) into a new state summary with one non-streamed forced-tool Haiku
 // call.
 func summarizePlanConversation(ctx context.Context, client anthropic.Client, prevSummary string, older []PlanChatMessage) (string, error) {
+	// The distillation transcript is text-only (.Content): attached images on
+	// folded messages intentionally leave the model's context here — only the
+	// planCompactKeep newest messages keep their images verbatim.
 	text := buildDistillationTranscript(older, len(older), compactMaxInputChars)
 	if text == "" {
 		return "", fmt.Errorf("empty transcript")

--- a/src/packages/api/plan_handler.go
+++ b/src/packages/api/plan_handler.go
@@ -38,6 +38,26 @@ const (
 	planMaxMessageChars = 20000
 )
 
+// Image attachment caps. Per-image tracks Anthropic's 5 MB decoded limit
+// (base64 is ~4/3 of that); the per-message/per-request counts bound token
+// cost — like message text, every attached image is resent with the history
+// on each agent-loop iteration. The 20 MiB /plan body lane (middleware.go) is
+// the effective aggregate byte bound; these caps exist to fail single-message
+// abuse and Anthropic-side rejections early with a friendly SSE error.
+const (
+	planMaxImagesPerMessage = 4
+	planMaxImagesPerRequest = 12
+	planMaxImageBase64Len   = 6_800_000
+)
+
+// planImageMediaTypes is the allowlist Anthropic accepts for image blocks.
+var planImageMediaTypes = map[string]bool{
+	"image/jpeg": true,
+	"image/png":  true,
+	"image/gif":  true,
+	"image/webp": true,
+}
+
 type PlanRequest struct {
 	Messages []PlanChatMessage `json:"messages"`
 	// Summary is the compacted context from earlier turns, previously handed to
@@ -52,8 +72,19 @@ type PlanRequest struct {
 }
 
 type PlanChatMessage struct {
-	Role    string `json:"role"`
-	Content string `json:"content"`
+	Role    string      `json:"role"`
+	Content string      `json:"content"`
+	Images  []PlanImage `json:"images,omitempty"`
+}
+
+// PlanImage is one image attached to a user message. Persisted transcripts
+// keep MediaType but blank Data (savePlanChatSession), so a resumed client can
+// render an "image attached" placeholder without megabytes of base64 living in
+// the JSONB transcript; empty-Data images are skipped when building the model
+// request.
+type PlanImage struct {
+	MediaType string `json:"media_type"`
+	Data      string `json:"data"` // base64, no data: URI prefix
 }
 
 func sendSSE(w http.ResponseWriter, eventType string, data any) {
@@ -84,10 +115,36 @@ func planHandler(w http.ResponseWriter, r *http.Request) {
 		sendSSE(w, "error", map[string]string{"message": "This conversation is too long to continue. Please start a new chat to keep planning."})
 		return
 	}
+	totalImages := 0
 	for _, m := range req.Messages {
 		if utf8.RuneCountInString(m.Content) > planMaxMessageChars {
 			sendSSE(w, "error", map[string]string{"message": "One of the messages is too long for the planner. Please shorten it and try again."})
 			return
+		}
+		if len(m.Images) > 0 && m.Role != "user" {
+			sendSSE(w, "error", map[string]string{"message": "Images can only be attached to your own messages."})
+			return
+		}
+		if len(m.Images) > planMaxImagesPerMessage {
+			sendSSE(w, "error", map[string]string{"message": "A message can include at most 4 images. Please remove some and try again."})
+			return
+		}
+		totalImages += len(m.Images)
+		if totalImages > planMaxImagesPerRequest {
+			sendSSE(w, "error", map[string]string{"message": "This conversation has too many images to continue. Please start a new chat to keep planning."})
+			return
+		}
+		for _, img := range m.Images {
+			// Empty Data is the stripped placeholder shape from a resumed
+			// transcript — valid on the wire, skipped at conversion time.
+			if img.Data != "" && !planImageMediaTypes[img.MediaType] {
+				sendSSE(w, "error", map[string]string{"message": "That image format isn't supported. Please use a JPEG, PNG, GIF, or WebP image."})
+				return
+			}
+			if len(img.Data) > planMaxImageBase64Len {
+				sendSSE(w, "error", map[string]string{"message": "One of the images is too large. Please attach images under 5 MB."})
+				return
+			}
 		}
 	}
 	if utf8.RuneCountInString(req.Summary) > planMaxMessageChars {
@@ -255,7 +312,25 @@ func planHandler(w http.ResponseWriter, r *http.Request) {
 	var messages []anthropic.MessageParam
 	for _, m := range req.Messages {
 		if m.Role == "user" {
-			messages = append(messages, anthropic.NewUserMessage(anthropic.NewTextBlock(m.Content)))
+			var blocks []anthropic.ContentBlockParamUnion
+			for _, img := range m.Images {
+				if img.Data == "" {
+					continue // stripped placeholder from a resumed transcript
+				}
+				blocks = append(blocks, anthropic.NewImageBlockBase64(img.MediaType, img.Data))
+			}
+			// Image-only messages carry no text block. A resumed image-only
+			// message whose pixels were stripped would otherwise be empty —
+			// the API rejects both empty content arrays and empty text
+			// blocks — so it gets a marker keeping the transcript coherent.
+			text := m.Content
+			if strings.TrimSpace(text) == "" && len(blocks) == 0 {
+				text = "[attached an image that is no longer available]"
+			}
+			if strings.TrimSpace(text) != "" {
+				blocks = append(blocks, anthropic.NewTextBlock(text))
+			}
+			messages = append(messages, anthropic.NewUserMessage(blocks...))
 		} else {
 			messages = append(messages, anthropic.NewAssistantMessage(anthropic.NewTextBlock(m.Content)))
 		}

--- a/src/packages/api/plan_images_test.go
+++ b/src/packages/api/plan_images_test.go
@@ -1,0 +1,268 @@
+package main
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// Image attachments on /plan (specs/chat-image-attachments): request
+// validation, conversion to Anthropic image content blocks (asserted on the
+// fake's request bodies), and base64 stripping in the persisted transcript.
+
+// tinyPNGBase64 is a valid-enough stand-in for image data; the handler never
+// decodes it, so content is irrelevant — only shape and size are.
+var tinyPNGBase64 = base64.StdEncoding.EncodeToString([]byte("png-bytes"))
+
+func planImage() PlanImage {
+	return PlanImage{MediaType: "image/png", Data: tinyPNGBase64}
+}
+
+// anthropicMessages parses the messages array of a captured /v1/messages
+// request body into role + raw content-block list.
+func anthropicMessages(t *testing.T, body []byte) []struct {
+	Role    string            `json:"role"`
+	Content []json.RawMessage `json:"content"`
+} {
+	t.Helper()
+	var req struct {
+		Messages []struct {
+			Role    string            `json:"role"`
+			Content []json.RawMessage `json:"content"`
+		} `json:"messages"`
+	}
+	if err := json.Unmarshal(body, &req); err != nil {
+		t.Fatalf("unparseable fake-anthropic request body: %v", err)
+	}
+	return req.Messages
+}
+
+func blockType(t *testing.T, raw json.RawMessage) string {
+	t.Helper()
+	var b struct {
+		Type string `json:"type"`
+	}
+	if err := json.Unmarshal(raw, &b); err != nil {
+		t.Fatalf("unparseable content block %s: %v", raw, err)
+	}
+	return b.Type
+}
+
+// (a) A user message with an image sends the image block BEFORE the text
+// block, base64 source intact.
+func TestPlanImageBlockPrecedesText(t *testing.T) {
+	fa := newFakeAnthropic(t, textTurn("That looks like Lisbon."))
+
+	rec := runPlanHandler(t, PlanRequest{Messages: []PlanChatMessage{
+		{Role: "user", Content: "where is this?", Images: []PlanImage{planImage()}},
+	}})
+	if errs := eventsOfType(planEvents(t, rec.Body.String()), "error"); len(errs) != 0 {
+		t.Fatalf("unexpected error events: %v", errs)
+	}
+
+	bodies := fa.requestBodies()
+	if len(bodies) != 1 {
+		t.Fatalf("anthropic calls = %d, want 1", len(bodies))
+	}
+	msgs := anthropicMessages(t, bodies[0])
+	if len(msgs) != 1 || msgs[0].Role != "user" {
+		t.Fatalf("messages = %+v, want one user message", msgs)
+	}
+	if len(msgs[0].Content) != 2 {
+		t.Fatalf("content blocks = %d, want image + text", len(msgs[0].Content))
+	}
+	if got := blockType(t, msgs[0].Content[0]); got != "image" {
+		t.Fatalf("first block type = %q, want image (images precede text)", got)
+	}
+	if got := blockType(t, msgs[0].Content[1]); got != "text" {
+		t.Fatalf("second block type = %q, want text", got)
+	}
+	var img struct {
+		Source struct {
+			Type      string `json:"type"`
+			MediaType string `json:"media_type"`
+			Data      string `json:"data"`
+		} `json:"source"`
+	}
+	if err := json.Unmarshal(msgs[0].Content[0], &img); err != nil {
+		t.Fatalf("unparseable image block: %v", err)
+	}
+	if img.Source.Type != "base64" || img.Source.MediaType != "image/png" || img.Source.Data != tinyPNGBase64 {
+		t.Fatalf("image source = %+v, want base64 image/png with the sent data", img.Source)
+	}
+}
+
+// (b) An image-only message (no text) sends a single image block and no empty
+// text block — the API rejects empty text.
+func TestPlanImageOnlyMessageOmitsTextBlock(t *testing.T) {
+	fa := newFakeAnthropic(t, textTurn("A lovely beach."))
+
+	rec := runPlanHandler(t, PlanRequest{Messages: []PlanChatMessage{
+		{Role: "user", Content: "", Images: []PlanImage{planImage()}},
+	}})
+	if errs := eventsOfType(planEvents(t, rec.Body.String()), "error"); len(errs) != 0 {
+		t.Fatalf("unexpected error events: %v", errs)
+	}
+
+	msgs := anthropicMessages(t, fa.requestBodies()[0])
+	if len(msgs[0].Content) != 1 {
+		t.Fatalf("content blocks = %d, want just the image", len(msgs[0].Content))
+	}
+	if got := blockType(t, msgs[0].Content[0]); got != "image" {
+		t.Fatalf("block type = %q, want image", got)
+	}
+}
+
+// (c) Stripped resume placeholders (empty Data) are skipped — no image block,
+// no media-type validation, the turn proceeds.
+func TestPlanStrippedPlaceholderImageSkipped(t *testing.T) {
+	fa := newFakeAnthropic(t, textTurn("Continuing where we left off."))
+
+	rec := runPlanHandler(t, PlanRequest{Messages: []PlanChatMessage{
+		{Role: "user", Content: "look at this", Images: []PlanImage{{MediaType: "image/png"}}},
+		{Role: "assistant", Content: "Nice photo!"},
+		{Role: "user", Content: "so where should I stay?"},
+	}})
+	if errs := eventsOfType(planEvents(t, rec.Body.String()), "error"); len(errs) != 0 {
+		t.Fatalf("unexpected error events: %v", errs)
+	}
+
+	msgs := anthropicMessages(t, fa.requestBodies()[0])
+	if len(msgs) != 3 {
+		t.Fatalf("messages = %d, want 3", len(msgs))
+	}
+	if len(msgs[0].Content) != 1 || blockType(t, msgs[0].Content[0]) != "text" {
+		t.Fatalf("first message blocks = %v, want a single text block (placeholder image skipped)", msgs[0].Content)
+	}
+}
+
+// (d) A resumed image-only message whose pixels were stripped would be empty —
+// it gets the marker text instead, keeping the transcript API-valid.
+func TestPlanStrippedImageOnlyMessageGetsMarker(t *testing.T) {
+	fa := newFakeAnthropic(t, textTurn("Got it."))
+
+	rec := runPlanHandler(t, PlanRequest{Messages: []PlanChatMessage{
+		{Role: "user", Content: "", Images: []PlanImage{{MediaType: "image/jpeg"}}},
+		{Role: "assistant", Content: "What a view!"},
+		{Role: "user", Content: "plan me two days there"},
+	}})
+	if errs := eventsOfType(planEvents(t, rec.Body.String()), "error"); len(errs) != 0 {
+		t.Fatalf("unexpected error events: %v", errs)
+	}
+
+	msgs := anthropicMessages(t, fa.requestBodies()[0])
+	if len(msgs[0].Content) != 1 || blockType(t, msgs[0].Content[0]) != "text" {
+		t.Fatalf("first message blocks = %v, want a single marker text block", msgs[0].Content)
+	}
+	var txt struct {
+		Text string `json:"text"`
+	}
+	if err := json.Unmarshal(msgs[0].Content[0], &txt); err != nil {
+		t.Fatalf("unparseable text block: %v", err)
+	}
+	if !strings.Contains(txt.Text, "no longer available") {
+		t.Fatalf("marker text = %q, want the image-unavailable marker", txt.Text)
+	}
+}
+
+// assertSingleFriendlyError asserts the handler wrote exactly one SSE error
+// event containing want, and stopped there (no model call happened — the fake
+// would fail the test on an unscripted turn).
+func assertSingleFriendlyError(t *testing.T, rec interface{ String() string }, want string) {
+	t.Helper()
+	out := rec.String()
+	if !strings.Contains(out, `"type":"error"`) || !strings.Contains(out, want) {
+		t.Fatalf("stream = %q, want an SSE error containing %q", out, want)
+	}
+	if strings.Count(out, "data: ") != 1 {
+		t.Fatalf("stream = %q, want exactly one event (handler must stop after rejecting)", out)
+	}
+}
+
+func TestPlanRejectsImagesOnAssistantMessage(t *testing.T) {
+	newFakeAnthropic(t) // no scripted turns: any model call fails the test
+	rec := runPlanHandler(t, PlanRequest{Messages: []PlanChatMessage{
+		{Role: "user", Content: "hi"},
+		{Role: "assistant", Content: "hello", Images: []PlanImage{planImage()}},
+	}})
+	assertSingleFriendlyError(t, rec.Body, "your own messages")
+}
+
+func TestPlanRejectsTooManyImagesPerMessage(t *testing.T) {
+	newFakeAnthropic(t)
+	imgs := make([]PlanImage, planMaxImagesPerMessage+1)
+	for i := range imgs {
+		imgs[i] = planImage()
+	}
+	rec := runPlanHandler(t, PlanRequest{Messages: []PlanChatMessage{
+		{Role: "user", Content: "hi", Images: imgs},
+	}})
+	assertSingleFriendlyError(t, rec.Body, "at most 4 images")
+}
+
+func TestPlanRejectsTooManyImagesPerRequest(t *testing.T) {
+	newFakeAnthropic(t)
+	var msgs []PlanChatMessage
+	for images := 0; images <= planMaxImagesPerRequest; images += planMaxImagesPerMessage {
+		msgs = append(msgs,
+			PlanChatMessage{Role: "user", Content: "hi", Images: []PlanImage{
+				planImage(), planImage(), planImage(), planImage(),
+			}},
+			PlanChatMessage{Role: "assistant", Content: "ok"})
+	}
+	rec := runPlanHandler(t, PlanRequest{Messages: msgs})
+	assertSingleFriendlyError(t, rec.Body, "too many images")
+}
+
+func TestPlanRejectsUnsupportedImageMediaType(t *testing.T) {
+	newFakeAnthropic(t)
+	rec := runPlanHandler(t, PlanRequest{Messages: []PlanChatMessage{
+		{Role: "user", Content: "hi", Images: []PlanImage{{MediaType: "image/bmp", Data: tinyPNGBase64}}},
+	}})
+	assertSingleFriendlyError(t, rec.Body, "isn't supported")
+}
+
+func TestPlanRejectsOversizedImage(t *testing.T) {
+	newFakeAnthropic(t)
+	rec := runPlanHandler(t, PlanRequest{Messages: []PlanChatMessage{
+		{Role: "user", Content: "hi", Images: []PlanImage{
+			{MediaType: "image/png", Data: strings.Repeat("A", planMaxImageBase64Len+1)},
+		}},
+	}})
+	assertSingleFriendlyError(t, rec.Body, "too large")
+}
+
+// (e) Persisted transcripts keep each image's media type but never its data —
+// the JSONB row must stay small under twice-per-turn wholesale upserts.
+func TestChatSessionStripsImageData(t *testing.T) {
+	resetDB(t)
+	newFakeAnthropic(t, textTurn("Beautiful — that's the Algarve."))
+	user, token := createTestUser(t, "image-chat@example.com")
+
+	rec := doJSON(t, "POST", "/api/v1/plan", token, PlanRequest{
+		ChatID: "chat-with-image",
+		Messages: []PlanChatMessage{
+			{Role: "user", Content: "where is this beach?", Images: []PlanImage{planImage()}},
+		},
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("/plan = %d, want 200", rec.Code)
+	}
+
+	msgs, _, _, found := chatSessionRow(t, user.ID, "chat-with-image")
+	if !found {
+		t.Fatal("no chat session persisted")
+	}
+	if len(msgs) != 2 || len(msgs[0].Images) != 1 {
+		t.Fatalf("persisted messages = %+v, want user message with one image marker", msgs)
+	}
+	img := msgs[0].Images[0]
+	if img.Data != "" {
+		t.Fatalf("persisted image data = %d bytes, want stripped to empty", len(img.Data))
+	}
+	if img.MediaType != "image/png" {
+		t.Fatalf("persisted media type = %q, want image/png retained", img.MediaType)
+	}
+}

--- a/src/packages/flutter-app/lib/models/chat_session.dart
+++ b/src/packages/flutter-app/lib/models/chat_session.dart
@@ -31,12 +31,33 @@ class ChatSessionSummary {
   Map<String, dynamic> toJson() => _$ChatSessionSummaryToJson(this);
 }
 
+/// Marker for an image that was attached to a persisted message. The server
+/// strips pixel data before storing transcripts, so only the media type
+/// survives — enough to render an "Image" placeholder chip on resume.
 @JsonSerializable()
+class ChatSessionImage {
+  @JsonKey(name: 'media_type')
+  final String mediaType;
+
+  const ChatSessionImage({required this.mediaType});
+
+  factory ChatSessionImage.fromJson(Map<String, dynamic> json) =>
+      _$ChatSessionImageFromJson(json);
+  Map<String, dynamic> toJson() => _$ChatSessionImageToJson(this);
+}
+
+@JsonSerializable(explicitToJson: true)
 class ChatSessionMessage {
   final String role;
   final String content;
+  @JsonKey(defaultValue: <ChatSessionImage>[])
+  final List<ChatSessionImage> images;
 
-  const ChatSessionMessage({required this.role, required this.content});
+  const ChatSessionMessage({
+    required this.role,
+    required this.content,
+    this.images = const [],
+  });
 
   factory ChatSessionMessage.fromJson(Map<String, dynamic> json) =>
       _$ChatSessionMessageFromJson(json);

--- a/src/packages/flutter-app/lib/models/chat_session.g.dart
+++ b/src/packages/flutter-app/lib/models/chat_session.g.dart
@@ -26,16 +26,31 @@ Map<String, dynamic> _$ChatSessionSummaryToJson(ChatSessionSummary instance) =>
       'updated_at': instance.updatedAt,
     };
 
+ChatSessionImage _$ChatSessionImageFromJson(Map<String, dynamic> json) =>
+    ChatSessionImage(
+      mediaType: json['media_type'] as String,
+    );
+
+Map<String, dynamic> _$ChatSessionImageToJson(ChatSessionImage instance) =>
+    <String, dynamic>{
+      'media_type': instance.mediaType,
+    };
+
 ChatSessionMessage _$ChatSessionMessageFromJson(Map<String, dynamic> json) =>
     ChatSessionMessage(
       role: json['role'] as String,
       content: json['content'] as String,
+      images: (json['images'] as List<dynamic>?)
+              ?.map((e) => ChatSessionImage.fromJson(e as Map<String, dynamic>))
+              .toList() ??
+          [],
     );
 
 Map<String, dynamic> _$ChatSessionMessageToJson(ChatSessionMessage instance) =>
     <String, dynamic>{
       'role': instance.role,
       'content': instance.content,
+      'images': instance.images.map((e) => e.toJson()).toList(),
     };
 
 ChatSessionDetail _$ChatSessionDetailFromJson(Map<String, dynamic> json) =>

--- a/src/packages/flutter-app/lib/models/plan_message.dart
+++ b/src/packages/flutter-app/lib/models/plan_message.dart
@@ -1,4 +1,29 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
 enum MessageRole { user, assistant }
+
+/// One image attached to a user chat message.
+class PlanAttachment {
+  /// Processed image bytes, ready for upload/thumbnail. Null for a
+  /// resumed-transcript placeholder: the server strips pixels from persisted
+  /// chats and keeps only [mediaType], so the bubble renders an "Image" chip
+  /// and the attachment is excluded from resent history.
+  final Uint8List? bytes;
+  final String mediaType;
+
+  PlanAttachment({required this.bytes, required this.mediaType});
+
+  String? _base64;
+
+  /// Base64 of [bytes], memoized — the whole history is re-serialized into
+  /// every /plan request, so encoding per send would be O(turns) per image.
+  String? get base64Data {
+    final b = bytes;
+    if (b == null) return null;
+    return _base64 ??= base64Encode(b);
+  }
+}
 
 class PlanMessage {
   final MessageRole role;
@@ -9,9 +34,13 @@ class PlanMessage {
   /// full refine seed) still goes to the server history untouched.
   final String? displayLabel;
 
+  /// Images attached to this (user) message.
+  final List<PlanAttachment> attachments;
+
   const PlanMessage({
     required this.role,
     required this.content,
     this.displayLabel,
+    this.attachments = const [],
   });
 }

--- a/src/packages/flutter-app/lib/providers/plan_provider.dart
+++ b/src/packages/flutter-app/lib/providers/plan_provider.dart
@@ -19,8 +19,14 @@ class QueuedMessage {
   final int id;
   final String text;
   final String? displayLabel;
+  final List<PlanAttachment> attachments;
 
-  const QueuedMessage({required this.id, required this.text, this.displayLabel});
+  const QueuedMessage({
+    required this.id,
+    required this.text,
+    this.displayLabel,
+    this.attachments = const [],
+  });
 }
 
 class PlanState {
@@ -245,11 +251,16 @@ class PlanNotifier extends StateNotifier<PlanState> {
   /// Sends [text], or queues it if a turn is already streaming (or a backlog
   /// exists post-error). Queued messages drain FIFO as each turn completes
   /// successfully; the returned future completes once the whole chain settles.
-  Future<void> sendMessage(String text, {String? displayLabel}) {
+  Future<void> sendMessage(String text,
+      {String? displayLabel, List<PlanAttachment> attachments = const []}) {
     if (state.isStreaming || state.queuedMessages.isNotEmpty) {
       state = state.copyWith(queuedMessages: [
         ...state.queuedMessages,
-        QueuedMessage(id: _nextQueuedId++, text: text, displayLabel: displayLabel),
+        QueuedMessage(
+            id: _nextQueuedId++,
+            text: text,
+            displayLabel: displayLabel,
+            attachments: attachments),
       ]);
       // Idle with a backlog (post-error state): an explicit send is fresh user
       // intent — start draining now. FIFO holds because the new message went
@@ -257,7 +268,7 @@ class PlanNotifier extends StateNotifier<PlanState> {
       if (!state.isStreaming) return _drainQueue();
       return Future.value();
     }
-    return _sendNow(text, displayLabel: displayLabel);
+    return _sendNow(text, displayLabel: displayLabel, attachments: attachments);
   }
 
   /// Removes a not-yet-sent queued message by its [QueuedMessage.id].
@@ -276,14 +287,19 @@ class PlanNotifier extends StateNotifier<PlanState> {
     if (state.isStreaming || state.queuedMessages.isEmpty) return;
     final next = state.queuedMessages.first;
     state = state.copyWith(queuedMessages: state.queuedMessages.sublist(1));
-    await _sendNow(next.text, displayLabel: next.displayLabel);
+    await _sendNow(next.text,
+        displayLabel: next.displayLabel, attachments: next.attachments);
   }
 
-  Future<void> _sendNow(String text, {String? displayLabel}) async {
+  Future<void> _sendNow(String text,
+      {String? displayLabel, List<PlanAttachment> attachments = const []}) async {
     _chatId ??= _newChatId();
 
     final userMessage = PlanMessage(
-        role: MessageRole.user, content: text, displayLabel: displayLabel);
+        role: MessageRole.user,
+        content: text,
+        displayLabel: displayLabel,
+        attachments: attachments);
     final updatedMessages = [...state.messages, userMessage];
 
     state = state.copyWith(
@@ -308,9 +324,20 @@ class PlanNotifier extends StateNotifier<PlanState> {
 
     // Messages covered by the compacted summary stay visible but leave the
     // wire history — the summary stands in for them server-side.
+    // Resume placeholders (null bytes) stay out of the wire history — the
+    // server persists images as data-less markers and skips them anyway.
     final history = updatedMessages
         .sublist(state.compactedCount.clamp(0, updatedMessages.length))
-        .map((m) => {'role': m.role == MessageRole.user ? 'user' : 'assistant', 'content': m.content})
+        .map((m) => <String, dynamic>{
+              'role': m.role == MessageRole.user ? 'user' : 'assistant',
+              'content': m.content,
+              if (m.attachments.any((a) => a.bytes != null))
+                'images': [
+                  for (final a in m.attachments)
+                    if (a.bytes != null)
+                      {'media_type': a.mediaType, 'data': a.base64Data},
+                ],
+            })
         .toList();
 
     final textBuffer = StringBuffer();
@@ -522,7 +549,8 @@ class PlanNotifier extends StateNotifier<PlanState> {
     // _sendNow, not sendMessage: with a post-error backlog the gatekeeper
     // would enqueue the retried turn at the BACK. The retried turn must run
     // first; on success its tail drains the queue.
-    await _sendNow(failed.content, displayLabel: failed.displayLabel);
+    await _sendNow(failed.content,
+        displayLabel: failed.displayLabel, attachments: failed.attachments);
   }
 
   void reset() {

--- a/src/packages/flutter-app/lib/screens/trips_list_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trips_list_screen.dart
@@ -188,6 +188,12 @@ class _ContinueChatCard extends ConsumerWidget {
                       ? MessageRole.user
                       : MessageRole.assistant,
                   content: m.content,
+                  // Pixels are stripped server-side; null bytes renders the
+                  // "Image" placeholder chip and stays out of resent history.
+                  attachments: [
+                    for (final img in m.images)
+                      PlanAttachment(bytes: null, mediaType: img.mediaType),
+                  ],
                 ),
             ],
           );

--- a/src/packages/flutter-app/lib/services/image_attachment_pipeline.dart
+++ b/src/packages/flutter-app/lib/services/image_attachment_pipeline.dart
@@ -1,0 +1,106 @@
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:flutter/foundation.dart' show debugPrint;
+import 'package:image/image.dart' as img;
+
+import '../models/plan_message.dart';
+
+/// Prepares a picked/dropped image for the chat: validates, downscales large
+/// photos to Claude's effective resolution, and re-encodes.
+///
+/// Decoding uses the engine codec (`ui.instantiateImageCodec` — the browser's
+/// native decoder on web, so a 12 MP photo never runs through a pure-Dart
+/// decoder on the main thread), and scaling happens on a `PictureRecorder`
+/// canvas from the already-decoded frame. NOTE: `ui.ImageDescriptor.width` /
+/// `.height` throw `UnsupportedError` on web, so dimensions must come from
+/// the decoded frame, not a descriptor probe. Only the *encoding* of the
+/// small result uses `package:image`.
+class ImageAttachmentPipeline {
+  /// Longest-side target. Anthropic downsizes anything beyond ~1568px anyway,
+  /// so pixels above this are pure upload/token waste.
+  static const maxDimension = 1568;
+
+  /// Sources above this are rejected outright rather than processed.
+  static const maxSourceBytes = 10 * 1024 * 1024;
+
+  /// Already-small images (dimension AND byte size) pass through untouched:
+  /// screenshots keep PNG crispness, small GIFs keep their animation, and the
+  /// common case re-encodes nothing.
+  static const passThroughBytes = 500 * 1024;
+
+  static const allowedMediaTypes = {
+    'image/jpeg',
+    'image/png',
+    'image/gif',
+    'image/webp',
+  };
+
+  const ImageAttachmentPipeline();
+
+  /// Returns the processed attachment, or null when [bytes] is not a usable
+  /// image (unsupported type, oversized source, undecodable data). Callers
+  /// surface null as a "couldn't read that image" notice.
+  Future<PlanAttachment?> process(Uint8List bytes, String mediaType) async {
+    final normalized = mediaType.toLowerCase().split(';').first.trim();
+    if (!allowedMediaTypes.contains(normalized)) return null;
+    if (bytes.isEmpty || bytes.length > maxSourceBytes) return null;
+
+    try {
+      final codec = await ui.instantiateImageCodec(bytes);
+      final frame = await codec.getNextFrame();
+      codec.dispose();
+      final image = frame.image;
+      final width = image.width;
+      final height = image.height;
+      final longest = width > height ? width : height;
+
+      if (longest <= maxDimension && bytes.length <= passThroughBytes) {
+        image.dispose();
+        return PlanAttachment(bytes: bytes, mediaType: normalized);
+      }
+
+      final scale = longest > maxDimension ? maxDimension / longest : 1.0;
+      final targetW = (width * scale).round().clamp(1, width);
+      final targetH = (height * scale).round().clamp(1, height);
+
+      final recorder = ui.PictureRecorder();
+      ui.Canvas(recorder).drawImageRect(
+        image,
+        ui.Rect.fromLTWH(0, 0, width.toDouble(), height.toDouble()),
+        ui.Rect.fromLTWH(0, 0, targetW.toDouble(), targetH.toDouble()),
+        ui.Paint()..filterQuality = ui.FilterQuality.medium,
+      );
+      final picture = recorder.endRecording();
+      final scaled = await picture.toImage(targetW, targetH);
+      picture.dispose();
+      image.dispose();
+
+      final raw = await scaled.toByteData(format: ui.ImageByteFormat.rawRgba);
+      scaled.dispose();
+      if (raw == null) return null;
+
+      // JPEG has no alpha channel: flatten transparency onto white before
+      // encoding, or transparent PNG regions would come out garbage. JPEG
+      // sources are opaque already — skip the extra composite pass.
+      var decoded = img.Image.fromBytes(
+        width: targetW,
+        height: targetH,
+        bytes: raw.buffer,
+        numChannels: 4,
+      );
+      if (normalized != 'image/jpeg') {
+        final canvas = img.Image(width: targetW, height: targetH);
+        img.fill(canvas, color: img.ColorRgb8(255, 255, 255));
+        img.compositeImage(canvas, decoded);
+        decoded = canvas;
+      }
+      final encoded = img.encodeJpg(decoded, quality: 80);
+      return PlanAttachment(
+          bytes: Uint8List.fromList(encoded), mediaType: 'image/jpeg');
+    } catch (e) {
+      debugPrint('image_attachment_pipeline: $normalized rejected: $e');
+      return null;
+    }
+  }
+}

--- a/src/packages/flutter-app/lib/services/plan_service.dart
+++ b/src/packages/flutter-app/lib/services/plan_service.dart
@@ -21,7 +21,7 @@ class PlanService {
       : _newClient = clientFactory ?? http.Client.new;
 
   Stream<PlanEvent> streamPlan(
-    List<Map<String, String>> messages, {
+    List<Map<String, dynamic>> messages, {
     String? bearerToken,
     String? chatId,
     String? tripId,

--- a/src/packages/flutter-app/lib/widgets/chat_panel.dart
+++ b/src/packages/flutter-app/lib/widgets/chat_panel.dart
@@ -1,3 +1,7 @@
+import 'dart:typed_data';
+
+import 'package:desktop_drop/desktop_drop.dart';
+import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart' show ScrollDirection;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -6,6 +10,7 @@ import '../models/plan_message.dart';
 import '../providers/dictation_provider.dart';
 import '../providers/plan_provider.dart';
 import '../services/dictation_controller.dart';
+import '../services/image_attachment_pipeline.dart';
 import '../theme/app_colors.dart';
 import '../utils/tracked_launch.dart';
 import 'result_summary_chip.dart';
@@ -37,6 +42,13 @@ class ChatPanel extends ConsumerStatefulWidget {
   /// panel leaves this null — the trip is already on screen.
   final void Function(String tripId)? onViewTrip;
 
+  /// Downscale/validate stage for attached images. Injectable for tests.
+  final ImageAttachmentPipeline attachmentPipeline;
+
+  /// Source for the paperclip button, returning (bytes, mimeType) pairs.
+  /// Defaults to the platform file picker; injectable for tests.
+  final Future<List<(Uint8List, String)>> Function()? pickImages;
+
   const ChatPanel({
     super.key,
     required this.state,
@@ -45,6 +57,8 @@ class ChatPanel extends ConsumerStatefulWidget {
     this.emptyState,
     this.footerBuilder,
     this.onViewTrip,
+    this.attachmentPipeline = const ImageAttachmentPipeline(),
+    this.pickImages,
   });
 
   @override
@@ -66,6 +80,19 @@ class _ChatPanelState extends ConsumerState<ChatPanel> {
   /// At most one bottom-jump pending per frame, no matter how many state
   /// changes request one.
   bool _scrollScheduled = false;
+
+  /// Images attached but not yet sent (specs/chat-image-attachments), shown as
+  /// removable chips above the input bar.
+  final List<PlanAttachment> _pending = [];
+
+  /// Images currently going through the downscale pipeline (spinner chips);
+  /// sending is deferred until this reaches zero.
+  int _processingCount = 0;
+
+  /// Whether a drag hovers over the panel — drives the drop overlay.
+  bool _dragging = false;
+
+  static const _maxAttachments = 4;
 
   @override
   void initState() {
@@ -120,11 +147,92 @@ class _ChatPanelState extends ConsumerState<ChatPanel> {
 
   void _send() {
     final text = _controller.text.trim();
-    if (text.isEmpty) return;
+    if (text.isEmpty && _pending.isEmpty) return;
+    if (_processingCount > 0) {
+      _notify('Still preparing an image — one moment.');
+      return;
+    }
+    final attachments = List<PlanAttachment>.of(_pending);
     _controller.clear();
-    ref.read(widget.notifier).sendMessage(text);
+    setState(_pending.clear);
+    ref.read(widget.notifier).sendMessage(text, attachments: attachments);
     _stickToBottom = true;
     _scrollToBottom();
+  }
+
+  void _notify(String message) {
+    if (!mounted) return;
+    ScaffoldMessenger.of(context)
+      ..hideCurrentSnackBar()
+      ..showSnackBar(SnackBar(content: Text(message)));
+  }
+
+  /// Single intake seam: drag-drop, the paperclip picker, and any future
+  /// paste path all feed (bytes, mimeType) pairs through here.
+  Future<void> _addFiles(Iterable<(Uint8List, String)> files) async {
+    for (final (bytes, mime) in files) {
+      if (_pending.length + _processingCount >= _maxAttachments) {
+        _notify('You can attach up to $_maxAttachments images.');
+        return;
+      }
+      setState(() => _processingCount++);
+      final attachment = await widget.attachmentPipeline.process(bytes, mime);
+      if (!mounted) return;
+      setState(() {
+        _processingCount--;
+        if (attachment != null) _pending.add(attachment);
+      });
+      if (attachment == null) {
+        _notify("Couldn't read that image — try a JPEG, PNG, GIF, or WebP under 10 MB.");
+      }
+    }
+  }
+
+  Future<void> _pickImages() async {
+    final pick = widget.pickImages ?? _pickImagesFromPlatform;
+    final files = await pick();
+    if (files.isNotEmpty) await _addFiles(files);
+  }
+
+  static Future<List<(Uint8List, String)>> _pickImagesFromPlatform() async {
+    final result = await FilePicker.platform.pickFiles(
+      type: FileType.image,
+      withData: true,
+      allowMultiple: true,
+    );
+    if (result == null) return const [];
+    return [
+      for (final f in result.files)
+        if (f.bytes != null) (f.bytes!, _mimeFromName(f.name)),
+    ];
+  }
+
+  Future<void> _onDragDone(DropDoneDetails detail) async {
+    final files = <(Uint8List, String)>[];
+    for (final item in detail.files) {
+      final mime = (item.mimeType?.isNotEmpty ?? false)
+          ? item.mimeType!
+          : _mimeFromName(item.name);
+      if (!mime.startsWith('image/')) continue;
+      files.add((await item.readAsBytes(), mime));
+    }
+    if (!mounted) return;
+    if (files.isEmpty) {
+      _notify('Only image files can be attached.');
+      return;
+    }
+    await _addFiles(files);
+  }
+
+  static String _mimeFromName(String name) {
+    final ext = name.contains('.') ? name.split('.').last.toLowerCase() : '';
+    return switch (ext) {
+      'jpg' || 'jpeg' => 'image/jpeg',
+      'png' => 'image/png',
+      'gif' => 'image/gif',
+      'webp' => 'image/webp',
+      _ => 'application/octet-stream',
+    };
   }
 
   @override
@@ -141,7 +249,7 @@ class _ChatPanelState extends ConsumerState<ChatPanel> {
     ref.listen(widget.state.select((s) => s.queuedMessages.length),
         (_, __) => _scrollToBottom());
 
-    return Column(
+    final panel = Column(
       children: [
         Expanded(
           child: isEmpty
@@ -181,14 +289,168 @@ class _ChatPanelState extends ConsumerState<ChatPanel> {
                   ),
                 ),
         ),
+        if (_pending.isNotEmpty || _processingCount > 0)
+          _PendingAttachmentsRow(
+            pending: _pending,
+            processingCount: _processingCount,
+            onRemove: (i) => setState(() => _pending.removeAt(i)),
+          ),
         _InputBar(
           controller: _controller,
           isStreaming: isStreaming,
           hint: widget.inputHint,
           onSend: _send,
+          onAttach: _pickImages,
           dictation: _dictation,
         ),
       ],
+    );
+
+    // DropTarget is a no-op on platforms without drag-drop (mobile), so the
+    // wrap is unconditional. The overlay invites the drop while a drag hovers.
+    return DropTarget(
+      onDragEntered: (_) => setState(() => _dragging = true),
+      onDragExited: (_) => setState(() => _dragging = false),
+      onDragDone: (detail) {
+        setState(() => _dragging = false);
+        _onDragDone(detail);
+      },
+      child: Stack(
+        fit: StackFit.expand,
+        children: [
+          panel,
+          if (_dragging) const _DropOverlay(),
+        ],
+      ),
+    );
+  }
+}
+
+/// Full-panel affordance shown while image files hover over the chat.
+class _DropOverlay extends StatelessWidget {
+  const _DropOverlay();
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return IgnorePointer(
+      child: Container(
+        color: theme.colorScheme.surface.withValues(alpha: 0.85),
+        child: Center(
+          child: Container(
+            padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 20),
+            decoration: BoxDecoration(
+              border: Border.all(color: theme.colorScheme.primary, width: 2),
+              borderRadius: BorderRadius.circular(16),
+            ),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Icon(Icons.add_photo_alternate_outlined,
+                    size: 40, color: theme.colorScheme.primary),
+                const SizedBox(height: 8),
+                Text(
+                  'Drop images to attach',
+                  style: theme.textTheme.titleMedium
+                      ?.copyWith(color: theme.colorScheme.primary),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Not-yet-sent attachment chips above the input bar: thumbnails with a
+/// remove ✕, plus spinner chips while the pipeline processes new drops.
+class _PendingAttachmentsRow extends StatelessWidget {
+  final List<PlanAttachment> pending;
+  final int processingCount;
+  final void Function(int index) onRemove;
+
+  const _PendingAttachmentsRow({
+    required this.pending,
+    required this.processingCount,
+    required this.onRemove,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      color: theme.colorScheme.surface,
+      padding: const EdgeInsets.fromLTRB(16, 8, 16, 0),
+      child: SizedBox(
+        height: 64,
+        child: ListView(
+          scrollDirection: Axis.horizontal,
+          children: [
+            for (var i = 0; i < pending.length; i++)
+              Padding(
+                padding: const EdgeInsets.only(right: 8),
+                child: Stack(
+                  children: [
+                    Padding(
+                      padding: const EdgeInsets.only(top: 6, right: 6),
+                      child: ClipRRect(
+                        borderRadius: BorderRadius.circular(8),
+                        child: Image.memory(
+                          pending[i].bytes!,
+                          width: 56,
+                          height: 56,
+                          fit: BoxFit.cover,
+                          gaplessPlayback: true,
+                        ),
+                      ),
+                    ),
+                    Positioned(
+                      top: 0,
+                      right: 0,
+                      child: Semantics(
+                        button: true,
+                        label: 'Remove image',
+                        child: InkWell(
+                          onTap: () => onRemove(i),
+                          child: Container(
+                            decoration: BoxDecoration(
+                              color: theme.colorScheme.inverseSurface,
+                              shape: BoxShape.circle,
+                            ),
+                            padding: const EdgeInsets.all(2),
+                            child: Icon(Icons.close,
+                                size: 12,
+                                color: theme.colorScheme.onInverseSurface),
+                          ),
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            for (var i = 0; i < processingCount; i++)
+              Padding(
+                padding: const EdgeInsets.only(top: 6, right: 14),
+                child: Container(
+                  width: 56,
+                  height: 56,
+                  decoration: BoxDecoration(
+                    color: theme.colorScheme.surfaceContainerHighest,
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                  child: const Center(
+                    child: SizedBox(
+                      width: 18,
+                      height: 18,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    ),
+                  ),
+                ),
+              ),
+          ],
+        ),
+      ),
     );
   }
 }
@@ -631,10 +893,15 @@ class _QueuedBubble extends StatelessWidget {
                 crossAxisAlignment: CrossAxisAlignment.end,
                 mainAxisSize: MainAxisSize.min,
                 children: [
-                  Text(
-                    message.displayLabel ?? message.text,
-                    style: TextStyle(color: theme.colorScheme.onPrimary),
-                  ),
+                  if (message.attachments.isNotEmpty) ...[
+                    _BubbleAttachments(attachments: message.attachments),
+                    const SizedBox(height: 4),
+                  ],
+                  if (message.text.isNotEmpty || message.displayLabel != null)
+                    Text(
+                      message.displayLabel ?? message.text,
+                      style: TextStyle(color: theme.colorScheme.onPrimary),
+                    ),
                   Text(
                     'Queued',
                     style: theme.textTheme.labelSmall?.copyWith(
@@ -711,9 +978,22 @@ class ChatMessageBubble extends StatelessWidget {
           children: [
             Flexible(
               child: isUser
-                  ? Text(
-                      message.content,
-                      style: TextStyle(color: theme.colorScheme.onPrimary),
+                  ? Column(
+                      crossAxisAlignment: CrossAxisAlignment.end,
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        if (message.attachments.isNotEmpty) ...[
+                          _BubbleAttachments(attachments: message.attachments),
+                          if (message.content.isNotEmpty)
+                            const SizedBox(height: 6),
+                        ],
+                        if (message.content.isNotEmpty)
+                          Text(
+                            message.content,
+                            style:
+                                TextStyle(color: theme.colorScheme.onPrimary),
+                          ),
+                      ],
                     )
                   : GptMarkdown(
                       message.content,
@@ -728,6 +1008,57 @@ class ChatMessageBubble extends StatelessWidget {
           ],
         ),
       ),
+    );
+  }
+}
+
+/// Image thumbnails inside a sent user bubble. Placeholders (null bytes —
+/// resumed transcripts, where the server keeps only the media type) render as
+/// an icon chip instead.
+class _BubbleAttachments extends StatelessWidget {
+  final List<PlanAttachment> attachments;
+
+  const _BubbleAttachments({required this.attachments});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Wrap(
+      spacing: 6,
+      runSpacing: 6,
+      alignment: WrapAlignment.end,
+      children: [
+        for (final a in attachments)
+          if (a.bytes != null)
+            ClipRRect(
+              borderRadius: BorderRadius.circular(10),
+              child: Image.memory(
+                a.bytes!,
+                width: 160,
+                fit: BoxFit.cover,
+                gaplessPlayback: true,
+              ),
+            )
+          else
+            Container(
+              padding:
+                  const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
+              decoration: BoxDecoration(
+                color: theme.colorScheme.onPrimary.withValues(alpha: 0.15),
+                borderRadius: BorderRadius.circular(10),
+              ),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Icon(Icons.image_outlined,
+                      size: 18, color: theme.colorScheme.onPrimary),
+                  const SizedBox(width: 6),
+                  Text('Image',
+                      style: TextStyle(color: theme.colorScheme.onPrimary)),
+                ],
+              ),
+            ),
+      ],
     );
   }
 }
@@ -777,6 +1108,7 @@ class _InputBar extends StatelessWidget {
   final bool isStreaming;
   final String hint;
   final VoidCallback onSend;
+  final VoidCallback onAttach;
   final DictationController dictation;
 
   const _InputBar({
@@ -784,6 +1116,7 @@ class _InputBar extends StatelessWidget {
     required this.isStreaming,
     required this.hint,
     required this.onSend,
+    required this.onAttach,
     required this.dictation,
   });
 
@@ -801,9 +1134,14 @@ class _InputBar extends StatelessWidget {
           ),
         ],
       ),
-      padding: const EdgeInsets.fromLTRB(16, 8, 8, 16),
+      padding: const EdgeInsets.fromLTRB(8, 8, 8, 16),
       child: Row(
         children: [
+          IconButton(
+            tooltip: 'Attach images',
+            onPressed: onAttach,
+            icon: const Icon(Icons.attach_file),
+          ),
           Expanded(
             child: TextField(
               controller: controller,

--- a/src/packages/flutter-app/linux/flutter/generated_plugin_registrant.cc
+++ b/src/packages/flutter-app/linux/flutter/generated_plugin_registrant.cc
@@ -6,11 +6,15 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <desktop_drop/desktop_drop_plugin.h>
 #include <flutter_secure_storage_linux/flutter_secure_storage_linux_plugin.h>
 #include <record_linux/record_linux_plugin.h>
 #include <url_launcher_linux/url_launcher_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
+  g_autoptr(FlPluginRegistrar) desktop_drop_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "DesktopDropPlugin");
+  desktop_drop_plugin_register_with_registrar(desktop_drop_registrar);
   g_autoptr(FlPluginRegistrar) flutter_secure_storage_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "FlutterSecureStorageLinuxPlugin");
   flutter_secure_storage_linux_plugin_register_with_registrar(flutter_secure_storage_linux_registrar);

--- a/src/packages/flutter-app/linux/flutter/generated_plugins.cmake
+++ b/src/packages/flutter-app/linux/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  desktop_drop
   flutter_secure_storage_linux
   record_linux
   url_launcher_linux

--- a/src/packages/flutter-app/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/src/packages/flutter-app/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,6 +5,8 @@
 import FlutterMacOS
 import Foundation
 
+import desktop_drop
+import file_picker
 import flutter_secure_storage_macos
 import path_provider_foundation
 import record_macos
@@ -14,6 +16,8 @@ import speech_to_text
 import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  DesktopDropPlugin.register(with: registry.registrar(forPlugin: "DesktopDropPlugin"))
+  FilePickerPlugin.register(with: registry.registrar(forPlugin: "FilePickerPlugin"))
   FlutterSecureStoragePlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStoragePlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   RecordMacOsPlugin.register(with: registry.registrar(forPlugin: "RecordMacOsPlugin"))

--- a/src/packages/flutter-app/pubspec.lock
+++ b/src/packages/flutter-app/pubspec.lock
@@ -233,6 +233,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.6"
+  dbus:
+    dependency: transitive
+    description:
+      name: dbus
+      sha256: "0ce9b0a839e6dee59a37a623d2fc26a35bbbe6404213e419b0d6411023d62645"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.14"
+  desktop_drop:
+    dependency: "direct main"
+    description:
+      name: desktop_drop
+      sha256: "927511f590ce01ee90d0d80f79bc71b9c919d8522d01e495e89a00c6f4a4fb5b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.6.1"
   fake_async:
     dependency: transitive
     description:
@@ -257,6 +273,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.1"
+  file_picker:
+    dependency: "direct main"
+    description:
+      name: file_picker
+      sha256: "57d9a1dd5063f85fa3107fb42d1faffda52fdc948cefd5fe5ea85267a5fc7343"
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.3.10"
   fixnum:
     dependency: transitive
     description:
@@ -318,6 +342,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.4.7"
+  flutter_plugin_android_lifecycle:
+    dependency: transitive
+    description:
+      name: flutter_plugin_android_lifecycle
+      sha256: "38d1c268de9097ff59cf0e844ac38759fc78f76836d37edad06fa21e182055a0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.34"
   flutter_riverpod:
     dependency: "direct main"
     description:
@@ -457,7 +489,7 @@ packages:
     source: hosted
     version: "4.0.2"
   image:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: image
       sha256: f9881ff4998044947ec38d098bc7c8316ae1186fa786eddffdb867b9bc94dfce
@@ -1077,6 +1109,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.1"
+  universal_platform:
+    dependency: transitive
+    description:
+      name: universal_platform
+      sha256: "64e16458a0ea9b99260ceb5467a214c1f298d647c659af1bff6d3bf82536b1ec"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
   url_launcher:
     dependency: "direct main"
     description:

--- a/src/packages/flutter-app/pubspec.yaml
+++ b/src/packages/flutter-app/pubspec.yaml
@@ -78,6 +78,11 @@ dependencies:
   speech_to_text: ^7.4.0
   record: ^6.2.1
 
+  # Chat image attachments (specs/chat-image-attachments)
+  desktop_drop: ^0.6.1 # drag-drop target (web + desktop; no-op on mobile)
+  file_picker: ^10.3.3 # paperclip button; uniform bytes on web/desktop/gallery
+  image: ^4.3.0 # pure-Dart ENCODING of already-downscaled pixels only
+
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/src/packages/flutter-app/test/chat_panel_attachments_test.dart
+++ b/src/packages/flutter-app/test/chat_panel_attachments_test.dart
@@ -1,0 +1,224 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:travel_route_planner/models/plan_message.dart';
+import 'package:travel_route_planner/providers/dictation_provider.dart';
+import 'package:travel_route_planner/providers/plan_provider.dart';
+import 'package:travel_route_planner/services/api_client.dart';
+import 'package:travel_route_planner/services/dictation_controller.dart';
+import 'package:travel_route_planner/services/dictation_engine.dart';
+import 'package:travel_route_planner/services/image_attachment_pipeline.dart';
+import 'package:travel_route_planner/services/plan_service.dart';
+import 'package:travel_route_planner/widgets/chat_panel.dart';
+
+/// Composer image attachments (specs/chat-image-attachments): chips appear
+/// and are removable, sends carry/clear them, image-only sends work, the
+/// 4-image cap and unreadable files surface as SnackBars. Files enter through
+/// the injected [ChatPanel.pickImages] seam — the same `_addFiles` intake
+/// drag-drop uses, whose HTML drop events widget tests can't synthesize.
+
+/// A 1×1 PNG — real bytes for Image.memory to render in chips and bubbles.
+final tinyPng = base64Decode(
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==');
+
+/// Stands in for the real pipeline: engine image decoding can't complete
+/// inside a widget test's fake-async zone (see
+/// image_attachment_pipeline_test.dart for the real pipeline's coverage).
+/// Echoes bytes through unchanged; "images" shorter than 8 bytes reject.
+class _EchoPipeline extends ImageAttachmentPipeline {
+  const _EchoPipeline();
+
+  @override
+  Future<PlanAttachment?> process(Uint8List bytes, String mediaType) async {
+    if (bytes.length < 8) return null;
+    return PlanAttachment(bytes: bytes, mediaType: mediaType);
+  }
+}
+
+class _NoDictationEngine implements DictationEngine {
+  @override
+  Future<bool> initialize() async => false;
+  @override
+  Stream<DictationEvent> start() => const Stream.empty();
+  @override
+  Future<void> stop() async {}
+  @override
+  Future<void> cancel() async {}
+}
+
+/// Replies instantly with one delta; records every history payload.
+class _RecordingPlanService extends PlanService {
+  final List<List<Map<String, dynamic>>> histories = [];
+
+  _RecordingPlanService() : super('http://unused');
+
+  @override
+  Stream<PlanEvent> streamPlan(
+    List<Map<String, dynamic>> messages, {
+    String? bearerToken,
+    String? chatId,
+    String? tripId,
+    String? summary,
+  }) async* {
+    histories.add(List.of(messages));
+    yield PlanEvent(type: 'text_delta', data: {'text': 'ok'});
+  }
+}
+
+class _Harness {
+  final _RecordingPlanService service;
+  final PlanNotifier notifier;
+
+  /// Consumed by the next paperclip tap.
+  List<(Uint8List, String)> nextPick = [];
+
+  _Harness._(this.service, this.notifier);
+
+  static Future<_Harness> build(WidgetTester tester) async {
+    final service = _RecordingPlanService();
+    final notifier = PlanNotifier(service, ApiClient());
+    final provider =
+        StateNotifierProvider<PlanNotifier, PlanState>((ref) => notifier);
+    final harness = _Harness._(service, notifier);
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          dictationControllerFactoryProvider.overrideWithValue(
+            (textController) => DictationController(
+              textController: textController,
+              primary: _NoDictationEngine(),
+              fallback: null,
+              fallbackAvailable: () async => false,
+            ),
+          ),
+        ],
+        child: MaterialApp(
+          home: Scaffold(
+            body: ChatPanel(
+              state: provider,
+              notifier: provider.notifier,
+              attachmentPipeline: const _EchoPipeline(),
+              pickImages: () async => harness.nextPick,
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+    return harness;
+  }
+}
+
+Future<void> _attach(
+    WidgetTester tester, _Harness harness, List<(Uint8List, String)> files) async {
+  harness.nextPick = files;
+  await tester.tap(find.byIcon(Icons.attach_file));
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  testWidgets('attach shows a chip; send carries the image and clears chips',
+      (tester) async {
+    final harness = await _Harness.build(tester);
+
+    await _attach(tester, harness, [(tinyPng, 'image/png')]);
+    expect(find.byType(Image), findsOneWidget, reason: 'pending chip');
+
+    await tester.enterText(find.byType(TextField), 'where is this?');
+    await tester.tap(find.byIcon(Icons.send));
+    await tester.pumpAndSettle();
+
+    final sent = harness.service.histories.single.single;
+    expect(sent['content'], 'where is this?');
+    expect((sent['images'] as List).single['media_type'], 'image/png');
+    expect((sent['images'] as List).single['data'], base64Encode(tinyPng));
+
+    // Chips row is gone; the sent bubble now shows the thumbnail.
+    expect(
+        harness.notifier.state.messages.first.attachments, hasLength(1));
+    expect(find.byType(Image), findsOneWidget, reason: 'bubble thumbnail');
+  });
+
+  testWidgets('the ✕ removes a pending image before send', (tester) async {
+    final harness = await _Harness.build(tester);
+
+    await _attach(tester, harness, [(tinyPng, 'image/png')]);
+    await tester.tap(find.byIcon(Icons.close));
+    await tester.pump();
+    expect(find.byType(Image), findsNothing);
+
+    await tester.enterText(find.byType(TextField), 'no image after all');
+    await tester.tap(find.byIcon(Icons.send));
+    await tester.pumpAndSettle();
+
+    expect(harness.service.histories.single.single,
+        isNot(contains('images')));
+  });
+
+  testWidgets('an image-only send is allowed', (tester) async {
+    final harness = await _Harness.build(tester);
+
+    // Send with nothing at all: no-op.
+    await tester.tap(find.byIcon(Icons.send));
+    await tester.pump();
+    expect(harness.service.histories, isEmpty);
+
+    await _attach(tester, harness, [(tinyPng, 'image/png')]);
+    await tester.tap(find.byIcon(Icons.send));
+    await tester.pumpAndSettle();
+
+    final sent = harness.service.histories.single.single;
+    expect(sent['content'], '');
+    expect(sent['images'], hasLength(1));
+  });
+
+  testWidgets('a fifth image is rejected with a notice', (tester) async {
+    final harness = await _Harness.build(tester);
+
+    await _attach(tester, harness,
+        List.filled(5, (tinyPng, 'image/png')));
+
+    expect(find.byType(Image), findsNWidgets(4));
+    expect(find.byType(SnackBar), findsOneWidget);
+    expect(find.textContaining('up to 4 images'), findsOneWidget);
+  });
+
+  testWidgets('an unreadable file surfaces a notice, not a chip',
+      (tester) async {
+    final harness = await _Harness.build(tester);
+
+    await _attach(tester, harness, [
+      (Uint8List.fromList([1, 2, 3]), 'image/png'),
+    ]);
+
+    expect(find.byType(Image), findsNothing);
+    expect(find.textContaining("Couldn't read that image"), findsOneWidget);
+  });
+
+  testWidgets('resumed placeholder attachments render an Image chip',
+      (tester) async {
+    final harness = await _Harness.build(tester);
+
+    harness.notifier.resumeConversation(
+      chatId: 'chat-resumed',
+      messages: [
+        PlanMessage(
+          role: MessageRole.user,
+          content: 'where is this beach?',
+          attachments: [PlanAttachment(bytes: null, mediaType: 'image/jpeg')],
+        ),
+        const PlanMessage(role: MessageRole.assistant, content: 'The Algarve.'),
+      ],
+    );
+    await tester.pump();
+
+    expect(find.text('Image'), findsOneWidget, reason: 'placeholder chip');
+    expect(find.byIcon(Icons.image_outlined), findsOneWidget);
+    expect(find.byType(Image), findsNothing, reason: 'no pixels to render');
+  });
+}

--- a/src/packages/flutter-app/test/chat_panel_dictation_test.dart
+++ b/src/packages/flutter-app/test/chat_panel_dictation_test.dart
@@ -50,7 +50,7 @@ class _FakePlanService extends PlanService {
 
   @override
   Stream<PlanEvent> streamPlan(
-    List<Map<String, String>> messages, {
+    List<Map<String, dynamic>> messages, {
     String? bearerToken,
     String? chatId,
     String? tripId,

--- a/src/packages/flutter-app/test/chat_panel_queue_test.dart
+++ b/src/packages/flutter-app/test/chat_panel_queue_test.dart
@@ -21,7 +21,7 @@ class _GatedPlanService extends PlanService {
 
   @override
   Stream<PlanEvent> streamPlan(
-    List<Map<String, String>> messages, {
+    List<Map<String, dynamic>> messages, {
     String? bearerToken,
     String? chatId,
     String? tripId,

--- a/src/packages/flutter-app/test/chat_panel_seed_chip_test.dart
+++ b/src/packages/flutter-app/test/chat_panel_seed_chip_test.dart
@@ -15,7 +15,7 @@ class _ScriptedPlanService extends PlanService {
 
   @override
   Stream<PlanEvent> streamPlan(
-    List<Map<String, String>> messages, {
+    List<Map<String, dynamic>> messages, {
     String? bearerToken,
     String? chatId,
     String? tripId,

--- a/src/packages/flutter-app/test/image_attachment_pipeline_test.dart
+++ b/src/packages/flutter-app/test/image_attachment_pipeline_test.dart
@@ -1,0 +1,65 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:image/image.dart' as img;
+import 'package:travel_route_planner/services/image_attachment_pipeline.dart';
+
+/// The downscale pipeline (specs/chat-image-attachments). Also runnable with
+/// `--platform chrome`, which matters: dart:ui image APIs differ on web
+/// (ImageDescriptor dimension getters throw there — the reason the pipeline
+/// reads dimensions from the decoded frame instead).
+void main() {
+  const pipeline = ImageAttachmentPipeline();
+
+  Uint8List makePng(int w, int h) {
+    final src = img.Image(width: w, height: h);
+    img.fill(src, color: img.ColorRgb8(212, 0, 0));
+    return Uint8List.fromList(img.encodePng(src));
+  }
+
+  test('oversized dimensions downscale to <=1568 and re-encode as JPEG',
+      () async {
+    final out = await pipeline.process(makePng(2000, 1500), 'image/png');
+    expect(out, isNotNull);
+    expect(out!.mediaType, 'image/jpeg');
+    final decoded = img.decodeJpg(out.bytes!)!;
+    expect(decoded.width, ImageAttachmentPipeline.maxDimension);
+    expect(decoded.height, 1176); // aspect preserved (1500 * 1568/2000)
+    // Solid red must survive the resize + alpha-flatten + JPEG round-trip.
+    final px = decoded.getPixel(100, 100);
+    expect(px.r, greaterThan(180));
+    expect(px.g, lessThan(40));
+  });
+
+  test('small images pass through untouched (bytes and media type)', () async {
+    final tinyPng = base64Decode(
+        'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==');
+    final out = await pipeline.process(tinyPng, 'image/png');
+    expect(out, isNotNull);
+    expect(out!.mediaType, 'image/png');
+    expect(out.bytes, tinyPng);
+  });
+
+  test('mediaType parameters are normalized for the allowlist', () async {
+    final tinyPng = makePng(2, 2);
+    final out = await pipeline.process(tinyPng, 'Image/PNG; charset=binary');
+    expect(out, isNotNull);
+    expect(out!.mediaType, 'image/png');
+  });
+
+  test('unsupported types, empty and undecodable bytes reject to null',
+      () async {
+    expect(await pipeline.process(makePng(2, 2), 'application/pdf'), isNull);
+    expect(await pipeline.process(Uint8List(0), 'image/png'), isNull);
+    expect(
+        await pipeline.process(
+            Uint8List.fromList([1, 2, 3, 4]), 'image/png'),
+        isNull);
+  });
+
+  test('sources over 10MB reject without decoding', () async {
+    final huge = Uint8List(ImageAttachmentPipeline.maxSourceBytes + 1);
+    expect(await pipeline.process(huge, 'image/png'), isNull);
+  });
+}

--- a/src/packages/flutter-app/test/plan_provider_attachments_test.dart
+++ b/src/packages/flutter-app/test/plan_provider_attachments_test.dart
@@ -1,0 +1,160 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:travel_route_planner/models/plan_message.dart';
+import 'package:travel_route_planner/providers/plan_provider.dart';
+import 'package:travel_route_planner/services/api_client.dart';
+import 'package:travel_route_planner/services/plan_service.dart';
+
+/// Image attachments through the provider (specs/chat-image-attachments):
+/// the wire history carries base64 `images` for byte-bearing attachments —
+/// on the sending turn AND on later turns' history resend — through the
+/// queue and retry paths; resume placeholders (null bytes) never serialize.
+class _RecordingPlanService extends PlanService {
+  final List<List<Map<String, dynamic>>> histories = [];
+  Completer<void>? gate;
+  bool failNext = false;
+
+  _RecordingPlanService() : super('http://unused');
+
+  @override
+  Stream<PlanEvent> streamPlan(
+    List<Map<String, dynamic>> messages, {
+    String? bearerToken,
+    String? chatId,
+    String? tripId,
+    String? summary,
+  }) async* {
+    final call = histories.length;
+    histories.add(List.of(messages));
+    yield PlanEvent(type: 'text_delta', data: {'text': 'reply $call'});
+    final parked = gate;
+    gate = null;
+    if (parked != null) await parked.future;
+    if (failNext) {
+      failNext = false;
+      yield const PlanEvent(type: 'error', data: {'message': 'boom'});
+    }
+  }
+}
+
+void main() {
+  final bytes = Uint8List.fromList([1, 2, 3, 4]);
+  final attachment = PlanAttachment(bytes: bytes, mediaType: 'image/png');
+  final expectedImage = {
+    'media_type': 'image/png',
+    'data': base64Encode(bytes),
+  };
+
+  test('attachments serialize as images on the turn and on history resend',
+      () async {
+    final service = _RecordingPlanService();
+    final notifier = PlanNotifier(service, ApiClient());
+
+    await notifier.sendMessage('where is this?', attachments: [attachment]);
+    await notifier.sendMessage('and how do I get there?');
+
+    final firstTurn = service.histories[0];
+    expect(firstTurn.single['images'], [expectedImage]);
+
+    // Second turn resends the whole history: the image rides along again.
+    final secondTurn = service.histories[1];
+    expect(secondTurn[0]['images'], [expectedImage]);
+    expect(secondTurn[1], isNot(contains('images'))); // assistant reply
+    expect(secondTurn[2], isNot(contains('images'))); // new text-only message
+  });
+
+  test('image-only send (empty text) carries the attachment', () async {
+    final service = _RecordingPlanService();
+    final notifier = PlanNotifier(service, ApiClient());
+
+    await notifier.sendMessage('', attachments: [attachment]);
+
+    expect(service.histories.single.single['content'], '');
+    expect(service.histories.single.single['images'], [expectedImage]);
+    expect(notifier.state.messages.first.attachments, hasLength(1));
+  });
+
+  test('queued-while-streaming messages keep their attachments', () async {
+    final service = _RecordingPlanService();
+    final notifier = PlanNotifier(service, ApiClient());
+
+    final gate = Completer<void>();
+    service.gate = gate;
+    final first = notifier.sendMessage('a');
+    await notifier.sendMessage('look at this', attachments: [attachment]);
+    expect(notifier.state.queuedMessages.single.attachments, hasLength(1));
+
+    gate.complete();
+    await first;
+
+    expect(service.histories, hasLength(2));
+    final drained = service.histories[1];
+    expect(drained.last['content'], 'look at this');
+    expect(drained.last['images'], [expectedImage]);
+  });
+
+  test('retryLastSend re-sends the failed message with its attachments',
+      () async {
+    final service = _RecordingPlanService();
+    final notifier = PlanNotifier(service, ApiClient());
+
+    service.failNext = true;
+    await notifier.sendMessage('what city?', attachments: [attachment]);
+    expect(notifier.state.error, 'boom');
+
+    await notifier.retryLastSend();
+
+    expect(notifier.state.error, isNull);
+    final retried = service.histories[1];
+    final userTurns =
+        retried.where((m) => m['role'] == 'user').toList();
+    expect(userTurns, hasLength(1));
+    expect(userTurns.single['images'], [expectedImage]);
+    // The transcript keeps exactly one copy of the message, with attachments.
+    expect(
+        notifier.state.messages
+            .where((m) => m.role == MessageRole.user)
+            .single
+            .attachments,
+        hasLength(1));
+  });
+
+  test('resume placeholders (null bytes) never serialize into the history',
+      () async {
+    final service = _RecordingPlanService();
+    final notifier = PlanNotifier(service, ApiClient());
+
+    notifier.resumeConversation(
+      chatId: 'chat-resumed',
+      messages: [
+        PlanMessage(
+          role: MessageRole.user,
+          content: 'where is this beach?',
+          attachments: [PlanAttachment(bytes: null, mediaType: 'image/jpeg')],
+        ),
+        const PlanMessage(role: MessageRole.assistant, content: 'The Algarve!'),
+      ],
+    );
+    await notifier.sendMessage('plan two days there');
+
+    final history = service.histories.single;
+    expect(history, hasLength(3));
+    expect(history[0], isNot(contains('images')));
+  });
+
+  test('a message mixing real and placeholder attachments sends only the real one',
+      () async {
+    final service = _RecordingPlanService();
+    final notifier = PlanNotifier(service, ApiClient());
+
+    await notifier.sendMessage('both kinds', attachments: [
+      PlanAttachment(bytes: null, mediaType: 'image/jpeg'),
+      attachment,
+    ]);
+
+    expect(service.histories.single.single['images'], [expectedImage]);
+  });
+}

--- a/src/packages/flutter-app/test/plan_provider_compaction_test.dart
+++ b/src/packages/flutter-app/test/plan_provider_compaction_test.dart
@@ -10,7 +10,7 @@ import 'package:travel_route_planner/services/plan_service.dart';
 class _CompactionPlanService extends PlanService {
   /// Script consumed one list per call; the last list repeats when exhausted.
   final List<List<PlanEvent>> scripts;
-  final List<List<Map<String, String>>> histories = [];
+  final List<List<Map<String, dynamic>>> histories = [];
   final List<String?> summaries = [];
 
   /// Consumed by the next call: the stream parks on it after its first event.
@@ -20,7 +20,7 @@ class _CompactionPlanService extends PlanService {
 
   @override
   Stream<PlanEvent> streamPlan(
-    List<Map<String, String>> messages, {
+    List<Map<String, dynamic>> messages, {
     String? bearerToken,
     String? chatId,
     String? tripId,

--- a/src/packages/flutter-app/test/plan_provider_queue_test.dart
+++ b/src/packages/flutter-app/test/plan_provider_queue_test.dart
@@ -10,7 +10,7 @@ import 'package:travel_route_planner/services/plan_service.dart';
 /// after the delta so tests can enqueue mid-stream, and optionally ending the
 /// turn with an SSE error. Records the history payload of every call.
 class _GatedPlanService extends PlanService {
-  final List<List<Map<String, String>>> histories = [];
+  final List<List<Map<String, dynamic>>> histories = [];
 
   /// Consumed by the next call: the stream parks on it after its first delta.
   Completer<void>? gate;
@@ -22,7 +22,7 @@ class _GatedPlanService extends PlanService {
 
   @override
   Stream<PlanEvent> streamPlan(
-    List<Map<String, String>> messages, {
+    List<Map<String, dynamic>> messages, {
     String? bearerToken,
     String? chatId,
     String? tripId,

--- a/src/packages/flutter-app/test/plan_provider_stream_test.dart
+++ b/src/packages/flutter-app/test/plan_provider_stream_test.dart
@@ -13,7 +13,7 @@ class _FakePlanService extends PlanService {
 
   @override
   Stream<PlanEvent> streamPlan(
-    List<Map<String, String>> messages, {
+    List<Map<String, dynamic>> messages, {
     String? bearerToken,
     String? chatId,
     String? tripId,
@@ -30,13 +30,13 @@ class _FakePlanService extends PlanService {
 /// assert what the server would receive and how events mutate state.
 class _ScriptedPlanService extends PlanService {
   final List<PlanEvent> events;
-  List<Map<String, String>>? lastHistory;
+  List<Map<String, dynamic>>? lastHistory;
 
   _ScriptedPlanService(this.events) : super('http://unused');
 
   @override
   Stream<PlanEvent> streamPlan(
-    List<Map<String, String>> messages, {
+    List<Map<String, dynamic>> messages, {
     String? bearerToken,
     String? chatId,
     String? tripId,

--- a/src/packages/flutter-app/test/plan_service_body_test.dart
+++ b/src/packages/flutter-app/test/plan_service_body_test.dart
@@ -37,4 +37,32 @@ void main() {
     expect(await capturedBody(), isNot(contains('summary')));
     expect(await capturedBody(summary: ''), isNot(contains('summary')));
   });
+
+  test('message images pass through the body untouched', () async {
+    late Map<String, dynamic> body;
+    final service = PlanService(
+      'http://test/api/v1',
+      clientFactory: () => MockClient.streaming((request, bodyStream) async {
+        body = jsonDecode(await utf8.decodeStream(bodyStream))
+            as Map<String, dynamic>;
+        return http.StreamedResponse(Stream.value(utf8.encode(sse)), 200);
+      }),
+    );
+    await service.streamPlan([
+      {
+        'role': 'user',
+        'content': 'where is this?',
+        'images': [
+          {'media_type': 'image/png', 'data': 'aGVsbG8='},
+        ],
+      },
+      {'role': 'assistant', 'content': 'Lisbon.'},
+    ]).toList();
+
+    final messages = body['messages'] as List<dynamic>;
+    expect((messages[0] as Map<String, dynamic>)['images'], [
+      {'media_type': 'image/png', 'data': 'aGVsbG8='},
+    ]);
+    expect(messages[1], isNot(contains('images')));
+  });
 }

--- a/src/packages/flutter-app/test/resume_conversation_test.dart
+++ b/src/packages/flutter-app/test/resume_conversation_test.dart
@@ -8,7 +8,7 @@ import 'package:travel_route_planner/services/plan_service.dart';
 /// Records every streamPlan call (history, chatId, summary) and replies with
 /// one text delta — the seam for asserting what a resumed session sends.
 class _RecordingPlanService extends PlanService {
-  final List<List<Map<String, String>>> histories = [];
+  final List<List<Map<String, dynamic>>> histories = [];
   final List<String?> chatIds = [];
   final List<String?> summaries = [];
 
@@ -16,7 +16,7 @@ class _RecordingPlanService extends PlanService {
 
   @override
   Stream<PlanEvent> streamPlan(
-    List<Map<String, String>> messages, {
+    List<Map<String, dynamic>> messages, {
     String? bearerToken,
     String? chatId,
     String? tripId,

--- a/src/packages/flutter-app/test/trip_detail_chat_fab_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_chat_fab_test.dart
@@ -29,7 +29,7 @@ class _ScriptedPlanService extends PlanService {
 
   @override
   Stream<PlanEvent> streamPlan(
-    List<Map<String, String>> messages, {
+    List<Map<String, dynamic>> messages, {
     String? bearerToken,
     String? chatId,
     String? tripId,

--- a/src/packages/flutter-app/windows/flutter/generated_plugin_registrant.cc
+++ b/src/packages/flutter-app/windows/flutter/generated_plugin_registrant.cc
@@ -6,6 +6,7 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <desktop_drop/desktop_drop_plugin.h>
 #include <flutter_secure_storage_windows/flutter_secure_storage_windows_plugin.h>
 #include <record_windows/record_windows_plugin_c_api.h>
 #include <share_plus/share_plus_windows_plugin_c_api.h>
@@ -13,6 +14,8 @@
 #include <url_launcher_windows/url_launcher_windows.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
+  DesktopDropPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("DesktopDropPlugin"));
   FlutterSecureStorageWindowsPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FlutterSecureStorageWindowsPlugin"));
   RecordWindowsPluginCApiRegisterWithRegistrar(

--- a/src/packages/flutter-app/windows/flutter/generated_plugins.cmake
+++ b/src/packages/flutter-app/windows/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  desktop_drop
   flutter_secure_storage_windows
   record_windows
   share_plus


### PR DESCRIPTION
## Summary
- Drag-and-drop images onto the chat (drop overlay affordance) or attach via a new paperclip button; removable thumbnail chips above the composer, thumbnails in sent bubbles. Works in both the Agent tab and the trip-refine panel (shared `ChatPanel`).
- Images flow as inline base64 on a new per-message `images` field of the `/plan` request and become Anthropic image content blocks (image blocks before text; image-only messages supported). No upload endpoint or object store.
- Client-side downscale pipeline (`image_attachment_pipeline.dart`): engine decode + `PictureRecorder` scale to ≤1568px, JPEG q80 (~50–300 KB per photo). Note: `ui.ImageDescriptor` dimension getters throw on web, hence the codec/canvas approach.
- Server caps as friendly SSE errors: 4 images/message, 12/request, ~5 MB decoded each, jpeg/png/gif/webp allowlist, user messages only. `/plan` body lane 4→20 MiB (`middleware.go`) with matching nginx `client_max_body_size` bumps in dev + deployment configs.
- Persisted transcripts strip pixel data but keep a `media_type` marker (`savePlanChatSession`); resumed chats render an "Image" placeholder chip and the server skips empty-data images (image-only stripped messages get a marker text block, since the API rejects empty content).
- Spec at `specs/chat-image-attachments/`; compaction intentionally drops folded images (text-only distillation, commented).

## Testing
- Go: `go vet` clean; full suite incl. integration tests against `travel_planner_test` (new `plan_images_test.go`: block ordering, image-only, validation rejections, placeholder skip, persistence stripping; middleware lane test).
- Flutter: `flutter analyze` clean (12 pre-existing infos); 299 tests pass incl. new provider/widget/pipeline tests; pipeline test also verified with `--platform chrome`.
- Manual on the dev stack via headless CDP: native drop → overlay → chip → send "What color is this image?" → agent answered "Red"; follow-up turn confirmed history resend keeps the image; persisted row verified stripped (426 bytes); resume shows placeholder and next turn succeeds; oversized/unsupported payloads rejected via curl.

🤖 Generated with [Claude Code](https://claude.com/claude-code)