### PR TITLE
feat: paste-from-clipboard image attachments (web)

### DIFF
--- a/specs/chat-image-attachments/spec.md
+++ b/specs/chat-image-attachments/spec.md
@@ -47,6 +47,9 @@ ChatGPT.
       message; nothing is sent.
 - [ ] The same attachment experience works in both the main planning chat and
       the trip-refine chat panel.
+- [ ] On the web app, pasting an image from the clipboard (e.g. a screenshot)
+      while the message field is focused attaches it like a drop; pasting
+      plain text still pastes text normally.
 - [ ] Resuming a saved conversation shows an "image" placeholder where images
       were attached; the conversation can continue normally.
 
@@ -110,7 +113,8 @@ No new endpoints. The existing plan-streaming request is extended:
 
 ## Out of Scope
 
-- Camera capture and paste-from-clipboard (paste is a candidate follow-up).
+- Camera capture; paste-from-clipboard on native desktop/mobile (web paste
+  shipped as a follow-up — native needs a clipboard plugin dependency).
 - Image pixels surviving chat resume (placeholder only; no object storage).
 - Images on trip itineraries, bookings, or anywhere outside the chat.
 - Image generation or editing by the agent.

--- a/src/packages/flutter-app/lib/utils/clipboard_images_stub.dart
+++ b/src/packages/flutter-app/lib/utils/clipboard_images_stub.dart
@@ -1,0 +1,15 @@
+import 'dart:typed_data';
+
+/// Non-web stub for paste-from-clipboard image capture: native desktop/mobile
+/// clipboards need a plugin (super_clipboard-class dependency) that isn't
+/// worth the weight while web is the primary target — pasting there is a
+/// no-op and the paperclip/drag-drop paths cover image intake.
+///
+/// Returns a cancel function; see clipboard_images_web.dart for the real
+/// implementation and the contract.
+void Function() listenForPastedImages(
+  bool Function() isActive,
+  void Function(List<(Uint8List, String)> files) onImages,
+) {
+  return () {};
+}

--- a/src/packages/flutter-app/lib/utils/clipboard_images_web.dart
+++ b/src/packages/flutter-app/lib/utils/clipboard_images_web.dart
@@ -1,0 +1,47 @@
+import 'dart:async';
+import 'dart:js_interop';
+import 'dart:typed_data';
+
+import 'package:web/web.dart' as web;
+
+/// Web implementation of paste-from-clipboard image capture
+/// (specs/chat-image-attachments): a document-level `paste` listener that
+/// extracts image files (screenshot paste, copied image) and hands their
+/// (bytes, mimeType) pairs to [onImages].
+///
+/// [isActive] gates handling — the caller passes a composer-has-focus check,
+/// so a paste lands in exactly one chat panel even when several are mounted
+/// (Agent tab behind the Trips tab's refine panel), and pasting into other
+/// text fields elsewhere in the app is never intercepted.
+///
+/// Text-only pastes are left alone entirely: preventDefault fires only when
+/// image files are present, so normal paste into the message field works
+/// unchanged.
+///
+/// Returns a cancel function that removes the listener (call from dispose).
+void Function() listenForPastedImages(
+  bool Function() isActive,
+  void Function(List<(Uint8List, String)> files) onImages,
+) {
+  final handler = ((web.Event e) {
+    if (!isActive()) return;
+    final data = (e as web.ClipboardEvent).clipboardData;
+    if (data == null) return;
+    final files = <web.File>[];
+    for (var i = 0; i < data.items.length; i++) {
+      final item = data.items[i];
+      if (item.kind == 'file' && item.type.startsWith('image/')) {
+        final file = item.getAsFile();
+        if (file != null) files.add(file);
+      }
+    }
+    if (files.isEmpty) return;
+    e.preventDefault(); // keep the file from also pasting as text/filename
+    Future.wait(files.map((f) async {
+      final buffer = await f.arrayBuffer().toDart;
+      return (buffer.toDart.asUint8List(), f.type);
+    })).then(onImages);
+  }).toJS;
+  web.document.addEventListener('paste', handler);
+  return () => web.document.removeEventListener('paste', handler);
+}

--- a/src/packages/flutter-app/lib/widgets/chat_panel.dart
+++ b/src/packages/flutter-app/lib/widgets/chat_panel.dart
@@ -12,6 +12,8 @@ import '../providers/plan_provider.dart';
 import '../services/dictation_controller.dart';
 import '../services/image_attachment_pipeline.dart';
 import '../theme/app_colors.dart';
+import '../utils/clipboard_images_stub.dart'
+    if (dart.library.js_interop) '../utils/clipboard_images_web.dart';
 import '../utils/tracked_launch.dart';
 import 'result_summary_chip.dart';
 
@@ -68,6 +70,10 @@ class ChatPanel extends ConsumerStatefulWidget {
 class _ChatPanelState extends ConsumerState<ChatPanel> {
   final _controller = TextEditingController();
   final _scrollController = ScrollController();
+  final _inputFocus = FocusNode();
+
+  /// Removes the web paste listener (no-op off web).
+  late final void Function() _cancelPasteListener;
 
   /// Voice dictation for this composer (specs/voice-dictation): writes
   /// transcripts into [_controller]; the user reviews and sends normally.
@@ -99,6 +105,14 @@ class _ChatPanelState extends ConsumerState<ChatPanel> {
     super.initState();
     _dictation = ref.read(dictationControllerFactoryProvider)(_controller);
     _dictation.addListener(_onDictationChanged);
+    // Paste-from-clipboard (web only): focus-gated so exactly one mounted
+    // panel handles a paste, and pastes outside the composer are untouched.
+    _cancelPasteListener = listenForPastedImages(
+      () => mounted && _inputFocus.hasFocus,
+      (files) {
+        if (mounted) _addFiles(files);
+      },
+    );
   }
 
   void _onDictationChanged() {
@@ -112,10 +126,12 @@ class _ChatPanelState extends ConsumerState<ChatPanel> {
 
   @override
   void dispose() {
+    _cancelPasteListener();
     _dictation.removeListener(_onDictationChanged);
     _dictation.dispose();
     _controller.dispose();
     _scrollController.dispose();
+    _inputFocus.dispose();
     super.dispose();
   }
 
@@ -297,6 +313,7 @@ class _ChatPanelState extends ConsumerState<ChatPanel> {
           ),
         _InputBar(
           controller: _controller,
+          focusNode: _inputFocus,
           isStreaming: isStreaming,
           hint: widget.inputHint,
           onSend: _send,
@@ -1105,6 +1122,7 @@ class _StreamingCursorState extends State<_StreamingCursor>
 
 class _InputBar extends StatelessWidget {
   final TextEditingController controller;
+  final FocusNode focusNode;
   final bool isStreaming;
   final String hint;
   final VoidCallback onSend;
@@ -1113,6 +1131,7 @@ class _InputBar extends StatelessWidget {
 
   const _InputBar({
     required this.controller,
+    required this.focusNode,
     required this.isStreaming,
     required this.hint,
     required this.onSend,
@@ -1145,6 +1164,7 @@ class _InputBar extends StatelessWidget {
           Expanded(
             child: TextField(
               controller: controller,
+              focusNode: focusNode,
               maxLines: null,
               textInputAction: TextInputAction.send,
               onSubmitted: (_) => onSend(),

--- a/src/packages/flutter-app/pubspec.lock
+++ b/src/packages/flutter-app/pubspec.lock
@@ -1238,7 +1238,7 @@ packages:
     source: hosted
     version: "1.1.3"
   web:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: web
       sha256: "868d88a33d8a87b18ffc05f9f030ba328ffefba92d6c127917a2ba740f9cfe4a"

--- a/src/packages/flutter-app/pubspec.yaml
+++ b/src/packages/flutter-app/pubspec.yaml
@@ -82,6 +82,7 @@ dependencies:
   desktop_drop: ^0.6.1 # drag-drop target (web + desktop; no-op on mobile)
   file_picker: ^10.3.3 # paperclip button; uniform bytes on web/desktop/gallery
   image: ^4.3.0 # pure-Dart ENCODING of already-downscaled pixels only
+  web: ^1.1.1 # paste-from-clipboard listener (clipboard_images_web.dart)
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- Pasting an image from the clipboard (screenshot, copied image) into the chat composer attaches it exactly like a drop — same `_addFiles` intake, so the 4-image cap, downscale pipeline, chips, and send path from #134 apply unchanged.
- Web-only via the codebase's first conditional import: `lib/utils/clipboard_images_web.dart` (package:web document paste listener) with a no-op stub for native platforms; native desktop/mobile paste deliberately out of scope.
- Focus-gated: only the panel whose message field has focus handles a paste, so the Agent tab and a trip-refine panel can coexist without double-attaching, and pastes into other text fields are never intercepted.
- `preventDefault` fires only when image files are present — plain text paste behaves exactly as before.
- Spec updated (`specs/chat-image-attachments/spec.md`): paste moved from out-of-scope to an acceptance criterion.

## Testing
- `flutter analyze` clean (12 pre-existing infos); full Flutter suite passes.
- Manual on the dev stack via headless CDP: paste with composer unfocused is ignored; focused paste attaches a chip alongside typed text; sending the pasted 1800×1200 image, the agent answered "Blue" — full paste → downscale → image-block loop confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)