### PR TITLE
fix(flutter): show currency on every quoted price

### DIFF
--- a/src/packages/flutter-app/lib/screens/airbnb_parser_screen.dart
+++ b/src/packages/flutter-app/lib/screens/airbnb_parser_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../utils/money_format.dart';
 import '../widgets/gradient_app_bar.dart';
 import '../models/airbnb_listing.dart';
 import '../models/trip.dart';
@@ -173,7 +174,7 @@ class _AirbnbParserScreenState extends ConsumerState<AirbnbParserScreen> {
         },
         if (listing.pricing.hasPricing)
           'price_note':
-              '${listing.pricing.currency} ${listing.pricing.nightlyRate.toStringAsFixed(0)}/night',
+              '${formatMoney(listing.pricing.nightlyRate, listing.pricing.currency)}/night',
       });
       if (!mounted) return;
       final open = await showDialog<bool>(

--- a/src/packages/flutter-app/lib/screens/alerts_screen.dart
+++ b/src/packages/flutter-app/lib/screens/alerts_screen.dart
@@ -4,6 +4,7 @@ import '../models/price_alert.dart';
 import '../providers/alerts_provider.dart';
 import '../providers/auth_provider.dart';
 import '../theme/spacing.dart';
+import '../utils/money_format.dart';
 import '../widgets/empty_state.dart';
 import '../widgets/offline_banner.dart' show relativeTime;
 import '../widgets/page_container.dart';
@@ -151,10 +152,10 @@ class _AlertCard extends ConsumerWidget {
     final checked = alert.lastCheckedPrice;
     final parts = <String>[];
     if (checked != null) {
-      parts.add('Last seen $cur ${checked.toStringAsFixed(0)}');
+      parts.add('Last seen ${formatMoney(checked, cur)}');
     }
     if (alert.targetPrice != null) {
-      parts.add('target $cur ${alert.targetPrice!.toStringAsFixed(0)}');
+      parts.add('target ${formatMoney(alert.targetPrice!, cur)}');
     } else {
       parts.add('watching for any drop');
     }
@@ -179,8 +180,7 @@ class _AlertCard extends ConsumerWidget {
     final checked = alert.lastCheckedPrice;
     if (base == null || checked == null || checked >= base) return null;
     final cur = alert.currency ?? '';
-    final delta = (base - checked).toStringAsFixed(0);
-    return 'Down $cur $delta from when you started watching';
+    return 'Down ${formatMoney(base - checked, cur)} from when you started watching';
   }
 
   /// "Checked 2 hours ago" from the last check time, if we have one.

--- a/src/packages/flutter-app/lib/screens/notification_center_screen.dart
+++ b/src/packages/flutter-app/lib/screens/notification_center_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../models/alert_event.dart';
 import '../providers/alerts_provider.dart';
 import '../theme/spacing.dart';
+import '../utils/money_format.dart';
 import '../widgets/empty_state.dart';
 import '../widgets/offline_banner.dart' show relativeTime;
 import '../widgets/page_container.dart';
@@ -93,10 +94,9 @@ class _EventTile extends StatelessWidget {
   const _EventTile({required this.event});
 
   String _dropLine() {
-    final cur = event.currency.isEmpty ? '' : '${event.currency} ';
-    final now = '$cur${event.price.toStringAsFixed(0)}';
+    final now = formatMoney(event.price, event.currency);
     if (event.previousPrice != null) {
-      return '$now, down from $cur${event.previousPrice!.toStringAsFixed(0)}';
+      return '$now, down from ${formatMoney(event.previousPrice!, event.currency)}';
     }
     return now;
   }

--- a/src/packages/flutter-app/lib/utils/money_format.dart
+++ b/src/packages/flutter-app/lib/utils/money_format.dart
@@ -1,0 +1,46 @@
+// Shared money formatting so every quoted price is rendered with its currency
+// visible and consistent — no bare "$412" that silently mixes USD/CAD/AUD, and
+// no amount printed without the currency it's quoted in.
+//
+// This is a currency-CODE → SYMBOL map: static and universal (a currency's
+// symbol never changes), NOT a country→currency mapping. It exists purely to
+// present the `currency` field each priced object already carries.
+
+/// Symbols for the codes our providers (Duffel flights, Ferryhopper, alerts)
+/// actually return. Deliberately short: a distinct, unambiguous symbol only.
+/// Anything not listed falls back to showing the ISO code itself.
+const Map<String, String> _currencySymbols = {
+  'USD': r'$',
+  'EUR': '€',
+  'GBP': '£',
+  'JPY': '¥',
+  'CNY': '¥',
+  'AUD': r'A$',
+  'CAD': r'C$',
+  'NZD': r'NZ$',
+  'HKD': r'HK$',
+  'SGD': r'S$',
+  'MXN': r'MX$',
+  'BRL': r'R$',
+  'INR': '₹',
+  'KRW': '₩',
+  'THB': '฿',
+  'TRY': '₺',
+};
+
+/// Renders [amount] with its [currencyCode] visible: `"€412"` / `"C$412"` when
+/// the code maps to a known symbol, else `"USD 412"` (code prefix) so the
+/// amount is never shown bare. An empty/whitespace code degrades to just the
+/// number. Amounts are rounded to whole units (prices are quoted that way),
+/// and a negative amount keeps a leading minus: `"-$5"`.
+String formatMoney(num amount, String currencyCode) {
+  final code = currencyCode.trim().toUpperCase();
+  final negative = amount < 0;
+  final sign = negative ? '-' : '';
+  final rounded = amount.abs().round();
+  final symbol = _currencySymbols[code];
+  if (symbol == null) {
+    return code.isEmpty ? '$sign$rounded' : '$sign$code $rounded';
+  }
+  return '$sign$symbol$rounded';
+}

--- a/src/packages/flutter-app/lib/widgets/create_alert_sheet.dart
+++ b/src/packages/flutter-app/lib/widgets/create_alert_sheet.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../providers/alerts_provider.dart';
 import '../theme/spacing.dart';
+import '../utils/money_format.dart';
 import '../utils/snack.dart';
 
 /// Bottom sheet that turns the current flight search into a price alert
@@ -137,7 +138,7 @@ class _CreateAlertSheetState extends ConsumerState<CreateAlertSheet> {
             Padding(
               padding: const EdgeInsets.only(top: AppSpacing.xs),
               child: Text(
-                'Best price now: $cur ${widget.currentPrice!.toStringAsFixed(0)}',
+                'Best price now: ${formatMoney(widget.currentPrice!, cur)}',
                 style: theme.textTheme.bodyMedium,
               ),
             ),

--- a/src/packages/flutter-app/lib/widgets/ferry_card.dart
+++ b/src/packages/flutter-app/lib/widgets/ferry_card.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import '../models/ferry_option.dart';
 import '../theme/app_colors.dart';
 import '../theme/spacing.dart';
+import '../utils/money_format.dart';
 import '../utils/tracked_launch.dart';
 
 /// A ferry option: route, date, and (when available) operator/time/price,
@@ -26,8 +27,7 @@ class FerryCard extends StatelessWidget {
     final detail = [
       if (option.operator.isNotEmpty) option.operator,
       if (option.departTime.isNotEmpty) option.departTime,
-      if (option.price > 0)
-        '${option.currency.isEmpty ? '' : '${option.currency} '}${option.price.toStringAsFixed(0)}',
+      if (option.price > 0) formatMoney(option.price, option.currency),
     ].join(' · ');
 
     return Card(

--- a/src/packages/flutter-app/lib/widgets/flight_details_sheet.dart
+++ b/src/packages/flutter-app/lib/widgets/flight_details_sheet.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import '../models/flight_leg.dart';
 import '../models/flight_offer.dart';
+import '../utils/money_format.dart';
 import '../utils/tracked_launch.dart';
 import 'airline_logo.dart';
 import '../utils/snack.dart';
@@ -156,7 +157,7 @@ class _BaggageRow extends StatelessWidget {
     switch (offer.baggageStatus) {
       case 'paid':
         note =
-            '+${offer.currency} ${offer.bagFee.toStringAsFixed(0)} bag fee included in price';
+            '+${formatMoney(offer.bagFee, offer.currency)} bag fee included in price';
         noteColor = muted;
       case 'unknown':
         note = 'Your bag is not included — check the fee with the airline';

--- a/src/packages/flutter-app/lib/widgets/flight_offer_card.dart
+++ b/src/packages/flutter-app/lib/widgets/flight_offer_card.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import '../models/flight_leg.dart';
 import '../models/flight_offer.dart';
+import '../utils/money_format.dart';
 import '../utils/tracked_launch.dart';
 import 'airline_logo.dart';
 import 'flight_details_sheet.dart';
@@ -36,7 +37,7 @@ String? savingsLabelFor(List<FlightOffer> offers, String? bestOfferId) {
   if (nextBest == null) return null;
   final saved = nextBest - best.displayPrice;
   if (saved < 0.5) return null;
-  return 'Saves ${best.currency} ${saved.toStringAsFixed(0)} vs next option';
+  return 'Saves ${formatMoney(saved, best.currency)} vs next option';
 }
 
 /// A single ranked flight offer rendered as a card — airline(s), route, price,
@@ -59,7 +60,7 @@ class FlightOfferCard extends StatelessWidget {
   String? get _bagBadge => switch (offer.baggageStatus) {
         'included' => 'Bag included',
         'paid' =>
-          'incl. bag +${offer.currency} ${offer.bagFee.toStringAsFixed(0)}',
+          'incl. bag +${formatMoney(offer.bagFee, offer.currency)}',
         'unknown' => 'Bag fee unknown',
         _ => null,
       };
@@ -161,7 +162,7 @@ class FlightOfferCard extends StatelessWidget {
                     crossAxisAlignment: CrossAxisAlignment.end,
                     children: [
                       Text(
-                        '${offer.currency} ${offer.displayPrice.toStringAsFixed(0)}',
+                        formatMoney(offer.displayPrice, offer.currency),
                         style: theme.textTheme.titleLarge?.copyWith(
                             fontWeight: FontWeight.bold, color: accent),
                       ),

--- a/src/packages/flutter-app/test/alerts_screen_test.dart
+++ b/src/packages/flutter-app/test/alerts_screen_test.dart
@@ -230,8 +230,8 @@ void main() {
     expect(find.text('Price dropped'), findsOneWidget);
     expect(find.text('Paused'), findsOneWidget);
     expect(find.text('Expired'), findsOneWidget);
-    expect(find.textContaining('target USD 450'), findsOneWidget);
-    expect(find.textContaining('Last seen USD 498'), findsNWidgets(4));
+    expect(find.textContaining('target \$450'), findsOneWidget);
+    expect(find.textContaining('Last seen \$498'), findsNWidgets(4));
   });
 
   testWidgets('pause action patches the alert', (tester) async {
@@ -268,8 +268,8 @@ void main() {
     ]);
 
     // Drop line uses price + previous_price.
-    expect(find.textContaining('USD 412, down from USD 498'), findsOneWidget);
-    expect(find.textContaining('USD 210, down from USD 260'), findsOneWidget);
+    expect(find.textContaining('\$412, down from \$498'), findsOneWidget);
+    expect(find.textContaining('\$210, down from \$260'), findsOneWidget);
 
     // Newest first: the JFK→LAX row (newer occurred_at) sits above BOS→CDG.
     final newerY = tester.getTopLeft(find.text('JFK → LAX')).dy;
@@ -280,7 +280,7 @@ void main() {
   testWidgets('event with no previous price shows just the new price',
       (tester) async {
     await _pumpCenter(tester, events: [_event(previousPrice: null, price: 300)]);
-    expect(find.textContaining('USD 300'), findsOneWidget);
+    expect(find.textContaining('\$300'), findsOneWidget);
     expect(find.textContaining('down from'), findsNothing);
   });
 
@@ -329,7 +329,7 @@ void main() {
             .toIso8601String(),
       ),
     ]);
-    expect(find.textContaining('Down USD 86 from when you started watching'),
+    expect(find.textContaining('Down \$86 from when you started watching'),
         findsOneWidget);
     expect(find.textContaining('Checked 2 hours ago'), findsOneWidget);
   });

--- a/src/packages/flutter-app/test/flight_round_trip_test.dart
+++ b/src/packages/flutter-app/test/flight_round_trip_test.dart
@@ -598,26 +598,26 @@ void main() {
         (tester) async {
       await pumpCard(
           tester, bagOffer(status: 'paid', bagFee: 60, effective: 160));
-      expect(find.text('USD 160'), findsOneWidget);
-      expect(find.text('incl. bag +USD 60'), findsOneWidget);
+      expect(find.text('\$160'), findsOneWidget);
+      expect(find.text('incl. bag +\$60'), findsOneWidget);
     });
 
     testWidgets('included offer shows a bag-included badge', (tester) async {
       await pumpCard(tester, bagOffer(status: 'included', effective: 100));
-      expect(find.text('USD 100'), findsOneWidget);
+      expect(find.text('\$100'), findsOneWidget);
       expect(find.text('Bag included'), findsOneWidget);
     });
 
     testWidgets('unknown fee is called out instead of silently underpricing',
         (tester) async {
       await pumpCard(tester, bagOffer(status: 'unknown'));
-      expect(find.text('USD 100'), findsOneWidget);
+      expect(find.text('\$100'), findsOneWidget);
       expect(find.text('Bag fee unknown'), findsOneWidget);
     });
 
     testWidgets('personal-item searches render no badge', (tester) async {
       await pumpCard(tester, bagOffer());
-      expect(find.text('USD 100'), findsOneWidget);
+      expect(find.text('\$100'), findsOneWidget);
       expect(find.textContaining('Bag'), findsNothing);
     });
   });

--- a/src/packages/flutter-app/test/flight_savings_pill_test.dart
+++ b/src/packages/flutter-app/test/flight_savings_pill_test.dart
@@ -33,7 +33,7 @@ void main() {
         _offer('b', 180, baggageStatus: 'paid', effectivePrice: 223),
         _offer('c', 190, baggageStatus: 'paid', effectivePrice: 250),
       ];
-      expect(savingsLabelFor(offers, 'a'), 'Saves USD 23 vs next option');
+      expect(savingsLabelFor(offers, 'a'), 'Saves \$23 vs next option');
     });
 
     test('null on bare-fare searches (no baggage status)', () {
@@ -57,7 +57,7 @@ void main() {
             currency: 'EUR'),
         _offer('d', 210, baggageStatus: 'paid', effectivePrice: 260),
       ];
-      expect(savingsLabelFor(offers, 'a'), 'Saves USD 60 vs next option');
+      expect(savingsLabelFor(offers, 'a'), 'Saves \$60 vs next option');
       expect(savingsLabelFor([offers[0], offers[1]], 'a'), isNull);
     });
 
@@ -93,12 +93,12 @@ void main() {
             offer: _offer('a', 200,
                 baggageStatus: 'included', effectivePrice: 200),
             isBest: true,
-            savingsLabel: 'Saves USD 23 vs next option',
+            savingsLabel: 'Saves \$23 vs next option',
           ),
         ),
       ));
       expect(find.text('BEST MATCH'), findsOneWidget);
-      expect(find.text('Saves USD 23 vs next option'), findsOneWidget);
+      expect(find.text('Saves \$23 vs next option'), findsOneWidget);
     });
 
     testWidgets('renders no pill by default', (tester) async {

--- a/src/packages/flutter-app/test/money_format_test.dart
+++ b/src/packages/flutter-app/test/money_format_test.dart
@@ -1,0 +1,53 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:travel_route_planner/utils/money_format.dart';
+
+void main() {
+  group('formatMoney', () {
+    test('known codes render with their symbol, no space', () {
+      expect(formatMoney(412, 'USD'), r'$412');
+      expect(formatMoney(412, 'EUR'), '€412');
+      expect(formatMoney(412, 'GBP'), '£412');
+      expect(formatMoney(412, 'JPY'), '¥412');
+    });
+
+    test('disambiguating dollar variants keep their prefix', () {
+      expect(formatMoney(412, 'CAD'), r'C$412');
+      expect(formatMoney(412, 'AUD'), r'A$412');
+      expect(formatMoney(412, 'NZD'), r'NZ$412');
+    });
+
+    test('case and surrounding whitespace are normalized', () {
+      expect(formatMoney(50, ' usd '), r'$50');
+      expect(formatMoney(50, 'eur'), '€50');
+    });
+
+    test('unknown code falls back to a visible code prefix', () {
+      expect(formatMoney(412, 'CHF'), 'CHF 412');
+      expect(formatMoney(412, 'ZZZ'), 'ZZZ 412');
+    });
+
+    test('empty code degrades to the bare number', () {
+      expect(formatMoney(412, ''), '412');
+      expect(formatMoney(412, '   '), '412');
+    });
+
+    test('amounts round to whole units', () {
+      expect(formatMoney(412.4, 'USD'), r'$412');
+      expect(formatMoney(412.6, 'USD'), r'$413');
+      expect(formatMoney(412.6, 'CHF'), 'CHF 413');
+    });
+
+    test('zero renders cleanly', () {
+      expect(formatMoney(0, 'EUR'), '€0');
+      expect(formatMoney(0, 'CAD'), r'C$0');
+      expect(formatMoney(0, 'ZZZ'), 'ZZZ 0');
+    });
+
+    test('negative amounts keep a leading minus', () {
+      expect(formatMoney(-5, 'USD'), r'-$5');
+      expect(formatMoney(-5, 'EUR'), '-€5');
+      expect(formatMoney(-5, 'CHF'), '-CHF 5');
+      expect(formatMoney(-5, ''), '-5');
+    });
+  });
+}


### PR DESCRIPTION
## What

Prices across the app were rendered with weak or implicit currency indication: a bare `USD 412` code prefix, or on ferries/notifications an implicit `$412` that silently mixes USD/CAD/AUD. This routes **every** priced surface through a shared `formatMoney(num amount, String currencyCode)` helper so the currency each price is quoted in is always visible.

- Known codes render with a distinct symbol, no space: `€412`, `£412`, `C$412`, `A$412`.
- Unknown/absent codes fall back to a visible code prefix (`CHF 412`) or the bare number when the code is empty.
- Dollar variants stay distinguishable, so mixed-currency lists (e.g. USD + EUR alerts) never compare amounts silently.

## Scope

Presentation only — **no** model, provider, or API changes; **no** FX conversion and **no** country→currency mapping. The helper's map is a static currency-code→symbol table (universal, never changes).

## Helper

`lib/utils/money_format.dart` — `String formatMoney(num amount, String currencyCode)`. Short const symbol map: USD EUR GBP JPY CNY AUD CAD NZD HKD SGD MXN BRL INR KRW THB TRY. Rounds to whole units; keeps a leading minus for negatives.

## Surfaces routed

- `flight_offer_card.dart` — main price, "Saves …" savings pill, "incl. bag +…" badge
- `flight_details_sheet.dart` — bag-fee-included note
- `ferry_card.dart` — structured price detail
- `create_alert_sheet.dart` — "Best price now"
- `alerts_screen.dart` — last-seen / target / baseline-drop lines
- `notification_center_screen.dart` — drop line ("$412, down from $498")
- `airbnb_parser_screen.dart` — nightly-rate price note

## Not priced / noted

- `bookings_section.dart` and `trip_segment` `priceNote` are free-text, user-entered fields with no structured currency — left as-is.
- The `Event` model has no price field; `priceLevel` on places is Google's `$`-tier, not a currency amount — out of scope.

## Tests

- New `test/money_format_test.dart` (symbol hits, dollar-variant prefixes, case/whitespace normalization, unknown-code fallback, empty code, rounding, zero, negatives).
- Updated existing assertions in `flight_savings_pill_test`, `alerts_screen_test`, `flight_round_trip_test` from `USD NNN` to the new `$NNN`.
- `flutter test`: 303 passed. `flutter analyze --no-fatal-infos --fatal-warnings`: exit 0 (12 pre-existing infos, none in changed files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)