### PR TITLE
feat: weather in the trip itinerary

### DIFF
--- a/src/packages/api/main.go
+++ b/src/packages/api/main.go
@@ -672,6 +672,7 @@ func buildRouter() *mux.Router {
 	api.HandleFunc("/flights/search", flightsSearchHandler).Methods("POST")
 	api.HandleFunc("/flights/airports", airportsSearchHandler).Methods("GET")
 	api.HandleFunc("/events/search", eventsSearchHandler).Methods("GET")
+	api.HandleFunc("/weather", weatherSearchHandler).Methods("GET")
 	api.HandleFunc("/ferries/search", ferriesSearchHandler).Methods("GET")
 	api.HandleFunc("/events/greece-links", greeceEventsLinksHandler).Methods("GET")
 	api.Handle("/plan", strict(http.HandlerFunc(planHandler))).Methods("POST")

--- a/src/packages/api/weather_handler_test.go
+++ b/src/packages/api/weather_handler_test.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// A fake Open-Meteo: /v1/search geocodes (optionally empty), /v1/forecast and
+// /v1/archive return a two-day daily series. Lets the handler test drive the
+// real WeatherService end to end without hitting the network.
+func newTestWeatherServer(t *testing.T, geocodeHit bool) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.Contains(r.URL.Path, "/search"):
+			if !geocodeHit {
+				w.Write([]byte(`{"results":[]}`))
+				return
+			}
+			w.Write([]byte(`{"results":[{"name":"Paris","country":"France","latitude":48.85,"longitude":2.35}]}`))
+		default: // forecast or archive
+			w.Write([]byte(`{"daily":{"time":["2099-08-01","2099-08-02"],"temperature_2m_max":[26,28],"temperature_2m_min":[17,18],"precipitation_sum":[0,3],"precipitation_probability_mean":[10,60]}}`))
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func withTestWeatherService(t *testing.T, geocodeHit bool) {
+	t.Helper()
+	srv := newTestWeatherServer(t, geocodeHit)
+	prev := weatherService
+	t.Cleanup(func() { weatherService = prev })
+	weatherService = &WeatherService{
+		GeocodeBaseURL:  srv.URL,
+		ForecastBaseURL: srv.URL,
+		ArchiveBaseURL:  srv.URL,
+		Client:          srv.Client(),
+		geoCache:        newTTLCache[geoResult](time.Hour, 10),
+		summaryCache:    newTTLCache[WeatherReport](time.Hour, 10),
+	}
+}
+
+func TestWeatherHandlerMissingParams(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/weather?start_date=2099-08-01", nil)
+	rec := httptest.NewRecorder()
+	weatherSearchHandler(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for missing city, got %d", rec.Code)
+	}
+}
+
+func TestWeatherHandlerReturnsReport(t *testing.T) {
+	withTestWeatherService(t, true)
+	// A far-future range so the archive ("historical") branch runs deterministically.
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/weather?city=Paris&start_date=2099-08-01&end_date=2099-08-02", nil)
+	rec := httptest.NewRecorder()
+	weatherSearchHandler(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var report WeatherReport
+	if err := json.Unmarshal(rec.Body.Bytes(), &report); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(report.Days) != 2 {
+		t.Fatalf("expected 2 days, got %d", len(report.Days))
+	}
+	if report.Location == "" {
+		t.Fatalf("expected a resolved location label")
+	}
+}
+
+func TestWeatherHandlerGeocodeMissIsEmptyNot500(t *testing.T) {
+	withTestWeatherService(t, false)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/weather?city=Nowheresville&start_date=2099-08-01", nil)
+	rec := httptest.NewRecorder()
+	weatherSearchHandler(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected best-effort 200 on geocode miss, got %d", rec.Code)
+	}
+	var report WeatherReport
+	if err := json.Unmarshal(rec.Body.Bytes(), &report); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(report.Days) != 0 {
+		t.Fatalf("expected empty report, got %d days", len(report.Days))
+	}
+}

--- a/src/packages/api/weather_service.go
+++ b/src/packages/api/weather_service.go
@@ -215,6 +215,38 @@ func (s *WeatherService) fetchDaily(ctx context.Context, geo geoResult, start, e
 	return report, nil
 }
 
+// weatherSearchHandler serves GET /api/v1/weather?city=&start_date=&end_date=,
+// returning the WeatherReport as JSON. Public and keyless, matching the events
+// lookup. Weather is best-effort trip decoration: a geocode miss or a provider
+// hiccup yields a clean empty report (200) rather than a 500 — the client just
+// shows no chip. Only a missing required param is a hard 400.
+func weatherSearchHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	q := r.URL.Query()
+	city := strings.TrimSpace(q.Get("city"))
+	startDate := strings.TrimSpace(q.Get("start_date"))
+	endDate := strings.TrimSpace(q.Get("end_date"))
+	if city == "" || startDate == "" {
+		http.Error(w, "Missing required query parameters 'city' and 'start_date'", http.StatusBadRequest)
+		return
+	}
+	if endDate == "" {
+		endDate = startDate
+	}
+
+	report, err := weatherService.GetTripWeather(r.Context(), city, startDate, endDate)
+	if err != nil {
+		// Best-effort: log the detail server-side, hand the client an empty
+		// report so weather never blocks the itinerary or leaks provider
+		// error strings.
+		ctxLog(r.Context()).Info("weather lookup returned no data", "error", err)
+		json.NewEncoder(w).Encode(WeatherReport{Days: []WeatherDay{}})
+		return
+	}
+	json.NewEncoder(w).Encode(report)
+}
+
 // summarizeWeather renders a report as compact text for the model.
 func summarizeWeather(r WeatherReport) string {
 	var b strings.Builder

--- a/src/packages/flutter-app/lib/models/weather.dart
+++ b/src/packages/flutter-app/lib/models/weather.dart
@@ -1,0 +1,70 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'weather.g.dart';
+
+/// One day of the trip weather, matching the Go API's WeatherDay. For a
+/// forecast, [precipProbability] carries the chance of rain (%); the archive
+/// ("historical") branch leaves it null and only reports observed rainfall.
+@JsonSerializable()
+class WeatherDay {
+  final String date; // YYYY-MM-DD
+  @JsonKey(name: 'temp_min_c', defaultValue: 0)
+  final double tempMinC;
+  @JsonKey(name: 'temp_max_c', defaultValue: 0)
+  final double tempMaxC;
+  @JsonKey(name: 'precip_mm', defaultValue: 0)
+  final double precipMm;
+  @JsonKey(name: 'precip_probability')
+  final int? precipProbability;
+
+  const WeatherDay({
+    required this.date,
+    this.tempMinC = 0,
+    this.tempMaxC = 0,
+    this.precipMm = 0,
+    this.precipProbability,
+  });
+
+  /// Month-day key ("MM-DD") for matching a trip day to its weather. The
+  /// historical branch returns last year's dates for the same month-day, so we
+  /// match on month-day rather than the full date.
+  String get monthDayKey => date.length >= 10 ? date.substring(5, 10) : date;
+
+  factory WeatherDay.fromJson(Map<String, dynamic> json) =>
+      _$WeatherDayFromJson(json);
+  Map<String, dynamic> toJson() => _$WeatherDayToJson(this);
+}
+
+/// Trip weather report from /weather, matching the Go API's WeatherReport.
+/// [kind] is "forecast" within the 16-day horizon, else "historical" (last
+/// year's observations, surfaced as "typical").
+@JsonSerializable()
+class WeatherReport {
+  @JsonKey(defaultValue: '')
+  final String location;
+  @JsonKey(defaultValue: '')
+  final String kind;
+  @JsonKey(defaultValue: <WeatherDay>[])
+  final List<WeatherDay> days;
+
+  const WeatherReport({
+    this.location = '',
+    this.kind = '',
+    this.days = const [],
+  });
+
+  bool get isHistorical => kind == 'historical';
+
+  /// The day matching [monthDay] ("MM-DD"), or null when the report has no
+  /// entry for that date (undated day, out of the fetched window).
+  WeatherDay? dayFor(String monthDay) {
+    for (final d in days) {
+      if (d.monthDayKey == monthDay) return d;
+    }
+    return null;
+  }
+
+  factory WeatherReport.fromJson(Map<String, dynamic> json) =>
+      _$WeatherReportFromJson(json);
+  Map<String, dynamic> toJson() => _$WeatherReportToJson(this);
+}

--- a/src/packages/flutter-app/lib/models/weather.g.dart
+++ b/src/packages/flutter-app/lib/models/weather.g.dart
@@ -1,0 +1,41 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'weather.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+WeatherDay _$WeatherDayFromJson(Map<String, dynamic> json) => WeatherDay(
+      date: json['date'] as String,
+      tempMinC: (json['temp_min_c'] as num?)?.toDouble() ?? 0,
+      tempMaxC: (json['temp_max_c'] as num?)?.toDouble() ?? 0,
+      precipMm: (json['precip_mm'] as num?)?.toDouble() ?? 0,
+      precipProbability: (json['precip_probability'] as num?)?.toInt(),
+    );
+
+Map<String, dynamic> _$WeatherDayToJson(WeatherDay instance) =>
+    <String, dynamic>{
+      'date': instance.date,
+      'temp_min_c': instance.tempMinC,
+      'temp_max_c': instance.tempMaxC,
+      'precip_mm': instance.precipMm,
+      'precip_probability': instance.precipProbability,
+    };
+
+WeatherReport _$WeatherReportFromJson(Map<String, dynamic> json) =>
+    WeatherReport(
+      location: json['location'] as String? ?? '',
+      kind: json['kind'] as String? ?? '',
+      days: (json['days'] as List<dynamic>?)
+              ?.map((e) => WeatherDay.fromJson(e as Map<String, dynamic>))
+              .toList() ??
+          [],
+    );
+
+Map<String, dynamic> _$WeatherReportToJson(WeatherReport instance) =>
+    <String, dynamic>{
+      'location': instance.location,
+      'kind': instance.kind,
+      'days': instance.days,
+    };

--- a/src/packages/flutter-app/lib/providers/weather_provider.dart
+++ b/src/packages/flutter-app/lib/providers/weather_provider.dart
@@ -1,0 +1,53 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../models/weather.dart';
+import '../services/weather_api_service.dart';
+import 'api_client_provider.dart';
+
+final weatherApiServiceProvider = Provider<WeatherApiService>((ref) {
+  return WeatherApiService(ref.watch(apiClientProvider));
+});
+
+/// Identifies one weather lookup: a city and its date window. Used as the
+/// family key so each city group in a trip caches its own report — one API
+/// call per city per trip view.
+class WeatherQuery {
+  final String city;
+  final String startDate; // YYYY-MM-DD
+  final String endDate; // YYYY-MM-DD
+
+  const WeatherQuery({
+    required this.city,
+    required this.startDate,
+    required this.endDate,
+  });
+
+  @override
+  bool operator ==(Object other) =>
+      other is WeatherQuery &&
+      other.city == city &&
+      other.startDate == startDate &&
+      other.endDate == endDate;
+
+  @override
+  int get hashCode => Object.hash(city, startDate, endDate);
+}
+
+/// Trip weather for a city + date window. Best-effort: any failure resolves to
+/// an empty report so weather never surfaces an error state that could block or
+/// clutter the itinerary — the UI simply renders no chip.
+final weatherByCityProvider =
+    FutureProvider.family<WeatherReport, WeatherQuery>((ref, query) async {
+  if (query.city.trim().isEmpty || query.startDate.isEmpty) {
+    return const WeatherReport();
+  }
+  final service = ref.watch(weatherApiServiceProvider);
+  try {
+    return await service.getTripWeather(
+      query.city.trim(),
+      query.startDate,
+      endDate: query.endDate,
+    );
+  } catch (_) {
+    return const WeatherReport();
+  }
+});

--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -25,6 +25,8 @@ import '../providers/preferences_provider.dart';
 import '../providers/api_client_provider.dart';
 import '../providers/plan_provider.dart';
 import '../providers/events_provider.dart';
+import '../providers/weather_provider.dart';
+import '../models/weather.dart';
 import '../providers/ferries_provider.dart';
 import '../providers/local_provider.dart';
 import '../providers/shared_with_me_provider.dart';
@@ -1655,9 +1657,26 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
   /// items with no day fall back to flat day-trip batching with no day headers.
   List<Widget> _buildGroupItemSlivers(String cityKey, List<ItineraryItem> items,
       ThemeData theme, DateTime? tripStart,
-      {required bool showTonight}) {
+      {required bool showTonight, ({DateTime? start, DateTime? end})? range}) {
     if (!items.any((it) => it.day != null)) {
       return _dayTripSectionSlivers(items, theme);
+    }
+    // Per-day weather (specs/weather-in-itinerary): one report per city group
+    // for its date window — one API call per city per trip view, cached by the
+    // family provider. Best-effort: valueOrNull stays null until it resolves
+    // (and forever on failure), so nothing renders and the pinned-scroll math
+    // is untouched. 'Other places' has no real city to geocode.
+    WeatherReport? weatherReport;
+    if (cityKey != 'Other places' &&
+        range?.start != null &&
+        range?.end != null) {
+      weatherReport = ref
+          .watch(weatherByCityProvider(WeatherQuery(
+            city: cityKey,
+            startDate: _fmt(range!.start!),
+            endDate: _fmt(range.end!),
+          )))
+          .valueOrNull;
     }
     // Today mode: the header for today's trip day (if any) gets a visible
     // highlight; undated/past/future trips resolve to null and render as-is.
@@ -1710,11 +1729,23 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
         final tonight = (showTonight && day == todayDay && trip != null)
             ? _tonightCaption(theme, _staysOnNight(trip, day))
             : null;
+        // Weather chip for this day, if the report covers its date. Historical
+        // reports carry last year's month-day, so we match on month-day.
+        Widget? weatherChip;
+        if (weatherReport != null && tripStart != null) {
+          final md = _fmt(tripStart.add(Duration(days: day - 1))).substring(5);
+          final wd = weatherReport.dayFor(md);
+          if (wd != null) {
+            weatherChip =
+                _weatherChip(theme, wd, weatherReport.isHistorical);
+          }
+        }
         slivers.add(MultiSliver(
           pushPinnedChildren: true,
           children: [
             SliverPinnedHeader(child: header),
             if (!collapsed) ...[
+              if (weatherChip != null) _boxSliver([weatherChip]),
               if (tonight != null) _boxSliver([tonight]),
               ..._dayTripSectionSlivers(run, theme),
             ],
@@ -2363,6 +2394,73 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
         ),
       ),
     );
+  }
+
+  /// Per-day weather chip (specs/weather-in-itinerary): hi/lo temp + a
+  /// condition glyph derived from rain, rendered as a non-pinned content row
+  /// under the day header (same indent/typography as [_tonightCaption]).
+  /// Forecast days append the rain chance; historical reports (trip beyond the
+  /// 16-day horizon) are labeled "typical", never "forecast".
+  Widget _weatherChip(ThemeData theme, WeatherDay day, bool historical) {
+    final muted = theme.colorScheme.onSurfaceVariant;
+    final (icon, iconColor) = _weatherGlyph(theme, day);
+    final hi = day.tempMaxC.round();
+    final lo = day.tempMinC.round();
+    final parts = <String>['$hi° / $lo°'];
+    if (!historical &&
+        day.precipProbability != null &&
+        day.precipProbability! >= 20) {
+      parts.add('${day.precipProbability}% rain');
+    }
+    return Padding(
+      // Matches the Tonight caption indent (20 left, 6 top) so the chip reads
+      // as a sub-row of the day header.
+      padding: const EdgeInsets.fromLTRB(20, 6, 16, 0),
+      child: Row(
+        children: [
+          Icon(icon, size: 15, color: iconColor),
+          const SizedBox(width: 6),
+          Flexible(
+            child: Text(
+              parts.join('  ·  '),
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: theme.textTheme.bodySmall?.copyWith(color: muted),
+            ),
+          ),
+          if (historical) ...[
+            const SizedBox(width: 8),
+            Flexible(
+              child: Text(
+                'typical for these dates',
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: muted,
+                  fontStyle: FontStyle.italic,
+                ),
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
+  /// Condition glyph + color from precipitation. Forecast days key off the rain
+  /// probability (%), historical days off observed rainfall (mm): sunny below
+  /// the light threshold, cloud in between, umbrella above the wet threshold.
+  (IconData, Color) _weatherGlyph(ThemeData theme, WeatherDay day) {
+    final scheme = theme.colorScheme;
+    final pct = day.precipProbability;
+    if (pct != null) {
+      if (pct >= 60) return (Icons.umbrella, scheme.primary);
+      if (pct >= 30) return (Icons.cloud, scheme.onSurfaceVariant);
+      return (Icons.wb_sunny, Colors.amber.shade700);
+    }
+    if (day.precipMm >= 5) return (Icons.umbrella, scheme.primary);
+    if (day.precipMm >= 1) return (Icons.cloud, scheme.onSurfaceVariant);
+    return (Icons.wb_sunny, Colors.amber.shade700);
   }
 
   /// "Tonight: <stay>" caption for today's day section (specs/happening-now
@@ -3537,7 +3635,8 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
                                             theme,
                                             tripStart,
                                             showTonight: group.label ==
-                                                firstTodayGroupLabel),
+                                                firstTodayGroupLabel,
+                                            range: groupRanges[group.label]),
                                         // Curated local recommendations for this
                                         // city — the "legit info you can't
                                         // google" surface. Leads the events

--- a/src/packages/flutter-app/lib/services/weather_api_service.dart
+++ b/src/packages/flutter-app/lib/services/weather_api_service.dart
@@ -1,0 +1,40 @@
+import 'dart:convert';
+import '../models/weather.dart';
+import 'api_client.dart';
+
+/// Wraps the /weather endpoint (Open-Meteo-backed, keyless). Like events, the
+/// endpoint is public, but we still send the bearer token when present to match
+/// the other services.
+class WeatherApiService {
+  final ApiClient apiClient;
+
+  WeatherApiService(this.apiClient);
+
+  /// Trip weather for [city] between [startDate] and [endDate] (YYYY-MM-DD;
+  /// [endDate] defaults to [startDate] server-side when empty). The endpoint is
+  /// best-effort and returns an empty report on a geocode miss, so a normal
+  /// "no weather" answer is a 200 with no days.
+  Future<WeatherReport> getTripWeather(
+    String city,
+    String startDate, {
+    String? endDate,
+  }) async {
+    final uri = Uri.parse('${apiClient.baseUrl}/weather').replace(
+      queryParameters: {
+        'city': city,
+        'start_date': startDate,
+        if (endDate != null && endDate.isNotEmpty) 'end_date': endDate,
+      },
+    );
+    final res =
+        await apiClient.httpClient.get(uri, headers: apiClient.jsonHeaders());
+    if (res.statusCode == 200) {
+      return WeatherReport.fromJson(jsonDecode(res.body) as Map<String, dynamic>);
+    }
+    throw ApiException(
+      statusCode: res.statusCode,
+      message: 'Failed to fetch weather: ${res.body}',
+      endpoint: 'weather',
+    );
+  }
+}

--- a/src/packages/flutter-app/test/trip_detail_weather_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_weather_test.dart
@@ -1,0 +1,161 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:travel_route_planner/models/trip.dart';
+import 'package:travel_route_planner/models/itinerary_item.dart';
+import 'package:travel_route_planner/models/weather.dart';
+import 'package:travel_route_planner/services/api_client.dart';
+import 'package:travel_route_planner/services/trips_api_service.dart';
+import 'package:travel_route_planner/services/weather_api_service.dart';
+import 'package:travel_route_planner/providers/trips_provider.dart';
+import 'package:travel_route_planner/providers/weather_provider.dart';
+import 'package:travel_route_planner/screens/trip_detail_screen.dart';
+
+/// Weather in the itinerary (specs/weather-in-itinerary): a dated day renders a
+/// per-day weather chip under its day header; historical reports read "typical";
+/// an undated trip renders none. Dates are relative to now so the day headers
+/// carry real dates the fake weather report can match on month-day.
+
+class _FakeTripsApiService extends TripsApiService {
+  final Trip trip;
+  _FakeTripsApiService(this.trip) : super(ApiClient(baseUrl: 'http://test'));
+
+  @override
+  Future<Trip> getTrip(String id) async => trip;
+}
+
+/// Returns a fixed report for every lookup, so the day chips are deterministic.
+class _FakeWeatherApiService extends WeatherApiService {
+  final WeatherReport report;
+  _FakeWeatherApiService(this.report)
+      : super(ApiClient(baseUrl: 'http://test'));
+
+  @override
+  Future<WeatherReport> getTripWeather(String city, String startDate,
+          {String? endDate}) async =>
+      report;
+}
+
+String _iso(DateTime d) =>
+    '${d.year.toString().padLeft(4, '0')}-'
+    '${d.month.toString().padLeft(2, '0')}-'
+    '${d.day.toString().padLeft(2, '0')}';
+
+ItineraryItem _item(int pos, String name, int day) => ItineraryItem(
+      id: 'i$pos',
+      position: pos,
+      name: name,
+      address: '$name street, Paris',
+      latitude: 0,
+      longitude: 0,
+      category: 'attraction',
+      day: day,
+      city: 'Paris',
+    );
+
+Trip _twoDayTrip(DateTime start) => Trip(
+      id: 't1',
+      title: 'Weather Trip',
+      status: 'planned',
+      createdAt: '2026-06-01',
+      updatedAt: '2026-06-01',
+      startDate: _iso(start),
+      endDate: _iso(start.add(const Duration(days: 1))),
+      items: [
+        _item(0, 'Louvre', 1),
+        _item(1, 'Orsay', 2),
+      ],
+    );
+
+Future<void> _pump(
+    WidgetTester tester, Trip trip, WeatherReport report) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        tripsApiServiceProvider
+            .overrideWithValue(_FakeTripsApiService(trip)),
+        weatherApiServiceProvider
+            .overrideWithValue(_FakeWeatherApiService(report)),
+      ],
+      child: const MaterialApp(home: TripDetailScreen(tripId: 't1')),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  final start = DateTime.now();
+  // Month-day keys the two trip days map to.
+  final md1 = _iso(start).substring(5);
+  final md2 = _iso(start.add(const Duration(days: 1))).substring(5);
+
+  testWidgets('a dated day renders a forecast weather chip under the header',
+      (tester) async {
+    final report = WeatherReport(
+      location: 'Paris, France',
+      kind: 'forecast',
+      days: [
+        WeatherDay(
+            date: '2000-$md1', tempMinC: 16, tempMaxC: 24, precipProbability: 70),
+        WeatherDay(
+            date: '2000-$md2', tempMinC: 15, tempMaxC: 22, precipProbability: 10),
+      ],
+    );
+    await _pump(tester, _twoDayTrip(start), report);
+
+    // Hi/lo temps rendered (rounded) for both days. Day 1 folds the rain
+    // chance into the same Text, so match on substring.
+    expect(find.textContaining('24° / 16°'), findsOneWidget);
+    expect(find.text('22° / 15°'), findsOneWidget);
+    // The rainy day surfaces its chance; the umbrella glyph appears.
+    expect(find.textContaining('70% rain'), findsOneWidget);
+    expect(find.byIcon(Icons.umbrella), findsWidgets);
+    // Forecast, so no "typical" affordance.
+    expect(find.textContaining('typical'), findsNothing);
+  });
+
+  testWidgets('a historical report labels the chip "typical", not a forecast',
+      (tester) async {
+    final report = WeatherReport(
+      location: 'Paris, France',
+      kind: 'historical',
+      days: [
+        WeatherDay(date: '2000-$md1', tempMinC: 18, tempMaxC: 27, precipMm: 0),
+        WeatherDay(date: '2000-$md2', tempMinC: 17, tempMaxC: 26, precipMm: 0),
+      ],
+    );
+    await _pump(tester, _twoDayTrip(start), report);
+
+    expect(find.text('27° / 18°'), findsOneWidget);
+    expect(find.textContaining('typical for these dates'), findsWidgets);
+    // Historical never shows a rain-chance percentage.
+    expect(find.textContaining('% rain'), findsNothing);
+  });
+
+  testWidgets('an undated trip renders no weather chip', (tester) async {
+    final undated = Trip(
+      id: 't1',
+      title: 'Undated',
+      status: 'planned',
+      createdAt: '2026-06-01',
+      updatedAt: '2026-06-01',
+      items: [
+        _item(0, 'Louvre', 1),
+        _item(1, 'Orsay', 2),
+      ],
+    );
+    final report = WeatherReport(
+      location: 'Paris, France',
+      kind: 'forecast',
+      days: [
+        WeatherDay(
+            date: '2000-$md1', tempMinC: 16, tempMaxC: 24, precipProbability: 10),
+      ],
+    );
+    await _pump(tester, undated, report);
+
+    expect(find.textContaining('° / '), findsNothing);
+    expect(find.text('Day 1'), findsOneWidget); // plain header, no dates
+  });
+}


### PR DESCRIPTION
## Weather in the itinerary (Wave 14 PR 1)

Surfaces per-day weather on the trip detail screen, reusing the existing keyless Open-Meteo `WeatherService` (no rebuild).

### Backend
- `GET /api/v1/weather?city=&start_date=&end_date=` → the `WeatherReport` as JSON. Public/keyless, registered next to `/events/search` (matching that peer's auth choice — weather is cheap + keyless).
- Validates `city` + `start_date` (400 if missing); `end_date` defaults to `start_date`. A geocode miss or provider hiccup returns a clean empty report (200), never a 500 — weather is best-effort trip decoration.
- Handler test covers the 400, a populated report, and the geocode-miss→empty-200 path.

### Flutter
- `models/weather.dart` (`WeatherReport` / `WeatherDay`, `@JsonSerializable`) + generated `.g.dart`.
- `services/weather_api_service.dart` — follows the events/places service pattern.
- `providers/weather_provider.dart` — a `family` FutureProvider keyed on `(city, startDate, endDate)`, one call per city per trip view, cached; swallows failures to an empty report so weather never blocks the itinerary.
- Trip detail: a per-day chip (hi/lo temp + rain-derived condition glyph, rain-chance on forecasts, "typical for these dates" on historical) rendered as a **non-pinned content row** under the day header — same pattern as the Tonight caption, so the #107 pinned-scroll math is untouched.

### Tests
- New widget test: forecast chip renders, historical shows "typical", undated trip shows none.
- `trip_detail_sticky_headers_test` + `trip_detail_today_test` pass **unmodified** (pinned-height math untouched).
- Full Go + Flutter suites green; `flutter analyze` clean (12 pre-existing infos, none added).

🤖 Generated with [Claude Code](https://claude.com/claude-code)