### PR TITLE
fix(api): allow reverting a price alert to any-drop (clear target)

### DIFF
--- a/src/packages/api/price_alert_handler.go
+++ b/src/packages/api/price_alert_handler.go
@@ -278,9 +278,18 @@ func patchPriceAlertHandler(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		Status      *string  `json:"status"`
 		TargetPrice *float64 `json:"target_price"`
+		// ClearTarget reverts a target-mode alert back to any-drop mode
+		// (target_price = NULL). It exists because target_price is a pointer:
+		// nil is indistinguishable from "field omitted", so without an explicit
+		// signal the handler can set/change a target but never clear it.
+		ClearTarget bool `json:"clear_target"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		writeJSONError(w, http.StatusBadRequest, "invalid JSON")
+		return
+	}
+	if req.ClearTarget && req.TargetPrice != nil {
+		writeJSONError(w, http.StatusBadRequest, "cannot both clear_target and set target_price")
 		return
 	}
 
@@ -308,8 +317,14 @@ func patchPriceAlertHandler(w http.ResponseWriter, r *http.Request) {
 		}
 		status = s
 	}
+	// target_price = $4 is written directly (not COALESCE'd), so passing nil
+	// here clears the row back to any-drop mode. baseline_price is untouched by
+	// UpdatePriceAlert, so the any-drop checker path re-baselines correctly.
 	target := current.TargetPrice
-	if req.TargetPrice != nil {
+	switch {
+	case req.ClearTarget:
+		target = nil
+	case req.TargetPrice != nil:
 		if *req.TargetPrice <= 0 {
 			writeJSONError(w, http.StatusBadRequest, "target_price must be positive")
 			return

--- a/src/packages/api/price_alert_integration_test.go
+++ b/src/packages/api/price_alert_integration_test.go
@@ -83,6 +83,53 @@ func TestAlertDuplicateAndCap(t *testing.T) {
 	}
 }
 
+func TestAlertClearTargetToAnyDrop(t *testing.T) {
+	resetDB(t)
+	_, token := createTestUser(t, "watcher@example.com")
+
+	// Start in target mode.
+	create := doJSON(t, "POST", "/api/v1/alerts", token, alertBody(map[string]any{
+		"target_price": 450.0,
+	}))
+	if create.Code != http.StatusCreated {
+		t.Fatalf("create = %d: %s", create.Code, create.Body.String())
+	}
+	created := decode(t, create)
+	id := created["id"].(string)
+	if created["target_price"] != 450.0 {
+		t.Fatalf("target not set on create: %s", create.Body.String())
+	}
+
+	// clear_target:true reverts to any-drop mode (target_price = NULL).
+	clear := doJSON(t, "PATCH", "/api/v1/alerts/"+id, token, map[string]any{"clear_target": true})
+	if clear.Code != http.StatusOK {
+		t.Fatalf("clear = %d: %s", clear.Code, clear.Body.String())
+	}
+	if got := decode(t, clear)["target_price"]; got != nil {
+		t.Fatalf("target_price not cleared: got %v", got)
+	}
+
+	// A plain patch (no target fields) must keep it any-drop, not resurrect it.
+	pause := doJSON(t, "PATCH", "/api/v1/alerts/"+id, token, map[string]any{"status": "paused"})
+	if pause.Code != http.StatusOK || decode(t, pause)["target_price"] != nil {
+		t.Fatalf("target reappeared after status patch: %s", pause.Body.String())
+	}
+
+	// Setting a target again after clearing works.
+	reset := doJSON(t, "PATCH", "/api/v1/alerts/"+id, token, map[string]any{"target_price": 399.0})
+	if reset.Code != http.StatusOK || decode(t, reset)["target_price"] != 399.0 {
+		t.Fatalf("re-set target failed: %d %s", reset.Code, reset.Body.String())
+	}
+
+	// Contradictory request (clear + set) is rejected.
+	both := doJSON(t, "PATCH", "/api/v1/alerts/"+id, token, map[string]any{
+		"clear_target": true, "target_price": 500.0,
+	})
+	if both.Code != http.StatusBadRequest {
+		t.Fatalf("clear+set = %d, want 400: %s", both.Code, both.Body.String())
+	}
+}
+
 func TestAlertOwnershipAndAuth(t *testing.T) {
 	resetDB(t)
 	_, ownerToken := createTestUser(t, "owner@example.com")

--- a/src/packages/flutter-app/lib/providers/alerts_provider.dart
+++ b/src/packages/flutter-app/lib/providers/alerts_provider.dart
@@ -87,11 +87,22 @@ class AlertsNotifier extends StateNotifier<AlertsState> {
     );
   }
 
-  /// Sets the target price (the "notify at or below" threshold). The PATCH
-  /// only accepts a positive value — the backend has no clear-to-any-drop path,
-  /// so an alert with a target stays target-mode.
+  /// Sets the target price (the "notify at or below" threshold) to a positive
+  /// value. To revert a target-mode alert back to any-drop, use [clearTarget].
   Future<void> updateTarget(String id, double target) async {
     final updated = await _service.patch(id, {'target_price': target});
+    state = state.copyWith(
+      alerts: [
+        for (final a in state.alerts) a.id == id ? updated : a,
+      ],
+    );
+  }
+
+  /// Reverts a target-mode alert to any-drop mode (notify on any price drop).
+  /// `clear_target` is the explicit signal the backend needs to null the
+  /// target — a plain omitted `target_price` would just preserve it.
+  Future<void> clearTarget(String id) async {
+    final updated = await _service.patch(id, {'clear_target': true});
     state = state.copyWith(
       alerts: [
         for (final a in state.alerts) a.id == id ? updated : a,

--- a/src/packages/flutter-app/lib/screens/alerts_screen.dart
+++ b/src/packages/flutter-app/lib/screens/alerts_screen.dart
@@ -197,7 +197,8 @@ class _AlertCard extends ConsumerWidget {
     final controller = TextEditingController(
       text: alert.targetPrice?.toStringAsFixed(0) ?? '',
     );
-    final target = await showDialog<double>(
+    final hasTarget = alert.targetPrice != null;
+    final result = await showDialog<({double? target, bool clear})>(
       context: context,
       builder: (dialogCtx) {
         String? error;
@@ -224,6 +225,16 @@ class _AlertCard extends ConsumerWidget {
                     errorText: error,
                   ),
                 ),
+                // Only a target-mode alert can be reverted; an any-drop alert
+                // is already there.
+                if (hasTarget) ...[
+                  const SizedBox(height: AppSpacing.sm),
+                  TextButton(
+                    onPressed: () => Navigator.of(dialogCtx)
+                        .pop((target: null, clear: true)),
+                    child: const Text('Watch for any drop instead'),
+                  ),
+                ],
               ],
             ),
             actions: [
@@ -238,7 +249,7 @@ class _AlertCard extends ConsumerWidget {
                     setState(() => error = 'Enter a valid target price');
                     return;
                   }
-                  Navigator.of(dialogCtx).pop(v);
+                  Navigator.of(dialogCtx).pop((target: v, clear: false));
                 },
                 child: const Text('Save'),
               ),
@@ -247,9 +258,14 @@ class _AlertCard extends ConsumerWidget {
         );
       },
     );
-    if (target == null || !context.mounted) return;
+    if (result == null || !context.mounted) return;
     try {
-      await ref.read(alertsProvider.notifier).updateTarget(alert.id, target);
+      final notifier = ref.read(alertsProvider.notifier);
+      if (result.clear) {
+        await notifier.clearTarget(alert.id);
+      } else {
+        await notifier.updateTarget(alert.id, result.target!);
+      }
     } catch (e) {
       if (context.mounted) showSnack(context, '$e');
     }

--- a/src/packages/flutter-app/test/alerts_screen_test.dart
+++ b/src/packages/flutter-app/test/alerts_screen_test.dart
@@ -68,13 +68,17 @@ class _FakeAlertsApiService extends AlertsApiService {
     if (body.containsKey('target_price')) {
       patched.add('$id:target=${body['target_price']}');
     }
+    final cleared = body['clear_target'] == true;
+    if (cleared) patched.add('$id:clear');
     return PriceAlert(
       id: a.id,
       origin: a.origin,
       destination: a.destination,
       departDate: a.departDate,
       status: (body['status'] as String?) ?? a.status,
-      targetPrice: (body['target_price'] as double?) ?? a.targetPrice,
+      targetPrice: cleared
+          ? null
+          : (body['target_price'] as double?) ?? a.targetPrice,
       currency: a.currency,
     );
   }
@@ -347,6 +351,34 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(service.patched, contains('a1:target=399.0'));
+  });
+
+  testWidgets('edit-target dialog can revert a target alert to any-drop',
+      (tester) async {
+    final service = await _pump(tester, alerts: [_alert(target: 450)]);
+
+    await tester.tap(find.byTooltip('Alert actions'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Edit target price'));
+    await tester.pumpAndSettle();
+
+    // The "any drop" affordance only appears for a target-mode alert.
+    await tester.tap(find.text('Watch for any drop instead'));
+    await tester.pumpAndSettle();
+
+    expect(service.patched, contains('a1:clear'));
+  });
+
+  testWidgets('any-drop alert dialog offers no revert affordance',
+      (tester) async {
+    await _pump(tester, alerts: [_alert()]);
+
+    await tester.tap(find.byTooltip('Alert actions'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Set target price'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Watch for any drop instead'), findsNothing);
   });
 
   test('model round-trips snake_case JSON', () {


### PR DESCRIPTION
## What

On the alert-edit PATCH, `target_price` is a `*float64`, so nil is indistinguishable from "field omitted". The handler preserved the current target on every patch, meaning a target-mode alert could be set or changed but **never cleared** back to any-drop mode.

## Fix

- Add an explicit `clear_target` bool to the update request (JSON `clear_target`). When true, the handler writes `target_price = NULL`.
- Reject a request that sets both `clear_target:true` **and** a non-null `target_price` (400 — contradictory).
- **No sqlc change needed:** the existing `UpdatePriceAlert` query assigns `target_price = $4` directly (not `COALESCE`), so passing a nil param already writes NULL. `make api-sqlc` produces no drift.
- `baseline_price` is untouched by the update, so the checker's any-drop path re-baselines correctly after a clear.

## Flutter

The edit-target dialog now offers **"Watch for any drop instead"** for target-mode alerts (hidden for alerts already in any-drop mode), wired through a new `clearTarget` provider method that PATCHes `clear_target:true`.

## Tests

- `price_alert_integration_test.go`: new `TestAlertClearTargetToAnyDrop` — create a target alert → clear → target NULL and stays cleared through a status-only patch → re-set a target works → contradictory clear+set is 400.
- `alerts_screen_test.dart`: revert-to-any-drop taps `clear_target`; any-drop alert offers no revert affordance.
- Go suite + full Flutter suite (313) green; `flutter analyze` clean (12 baseline infos, none added).

🤖 Generated with [Claude Code](https://claude.com/claude-code)