### PR TITLE
feat(api): owner-private trip export — print view + calendar .ics

### DIFF
--- a/src/packages/api/calendar_handler.go
+++ b/src/packages/api/calendar_handler.go
@@ -1,0 +1,221 @@
+package main
+
+import (
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/gorilla/mux"
+
+	"travel-route-planner/store"
+)
+
+// calendar_handler.go — GET /api/v1/export/{token}/calendar.ics, the trip as an
+// RFC 5545 iCalendar file. Token-gated and PUBLIC (the signed token is the
+// capability). Everything is an all-day VEVENT so it drops cleanly onto a
+// calendar's day grid. Zero external deps — the string is built by hand with
+// careful TEXT escaping and line folding.
+
+const icsDateLayout = "20060102"
+
+// calendarHandler streams the trip's .ics attachment.
+func calendarHandler(w http.ResponseWriter, r *http.Request) {
+	data, ok := resolveExport(r, mux.Vars(r)["token"])
+	if !ok {
+		// Match the print route: opaque 404, no leak.
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		w.WriteHeader(http.StatusNotFound)
+		w.Write([]byte("export link not available"))
+		return
+	}
+	body := buildICS(data)
+	w.Header().Set("Content-Type", "text/calendar; charset=utf-8")
+	w.Header().Set("Content-Disposition", `attachment; filename="`+tripSlug(data.Trip.Title)+`.ics"`)
+	w.Write([]byte(body))
+}
+
+// buildICS renders the export data as a VCALENDAR document. Undatable itinerary
+// items are skipped; if nothing at all is datable the calendar still contains a
+// single trip-span all-day event so the download is never empty.
+func buildICS(d exportData) string {
+	var b icsBuilder
+	b.line("BEGIN:VCALENDAR")
+	b.line("VERSION:2.0")
+	b.line("PRODID:-//Golden Tempo Travel//Trip Export//EN")
+	b.line("CALSCALE:GREGORIAN")
+	b.line("METHOD:PUBLISH")
+
+	stamp := time.Now().UTC().Format("20060102T150405Z")
+	events := 0
+
+	for _, it := range d.Items {
+		start, ok := itemStartDate(d.Trip, it)
+		if !ok {
+			continue // no trip start_date or no day → not datable
+		}
+		desc := icsItemDescription(it)
+		b.event(stamp, "item-"+it.ID.String(), start, start.AddDate(0, 0, 1),
+			it.Name, strPtrVal(it.Address), desc)
+		events++
+	}
+
+	for _, a := range d.Accommodations {
+		if !a.CheckIn.Valid {
+			continue
+		}
+		end := a.CheckIn.Time.AddDate(0, 0, 1)
+		if a.CheckOut.Valid && a.CheckOut.Time.After(a.CheckIn.Time) {
+			end = a.CheckOut.Time
+		}
+		b.event(stamp, "acc-"+a.ID.String(), a.CheckIn.Time, end,
+			"Stay: "+a.Name, strPtrVal(a.Address), "")
+		events++
+	}
+
+	for _, s := range d.Segments {
+		if !s.DepartDate.Valid {
+			continue
+		}
+		end := s.DepartDate.Time.AddDate(0, 0, 1)
+		if s.ArriveDate.Valid && s.ArriveDate.Time.After(s.DepartDate.Time) {
+			end = s.ArriveDate.Time.AddDate(0, 0, 1)
+		}
+		summary := capitalize(s.Mode) + ": " + segmentRoute(s)
+		b.event(stamp, "seg-"+s.ID.String(), s.DepartDate.Time, end,
+			summary, "", strPtrVal(s.Notes))
+		events++
+	}
+
+	// Fallback: a datable-but-empty export still yields one trip-span event.
+	if events == 0 && d.Trip.StartDate.Valid {
+		end := d.Trip.StartDate.Time.AddDate(0, 0, 1)
+		if d.Trip.EndDate.Valid && d.Trip.EndDate.Time.After(d.Trip.StartDate.Time) {
+			end = d.Trip.EndDate.Time.AddDate(0, 0, 1)
+		}
+		b.event(stamp, "trip-"+d.Trip.ID.String(), d.Trip.StartDate.Time, end,
+			d.Trip.Title, "", "")
+	}
+
+	b.line("END:VCALENDAR")
+	return b.String()
+}
+
+// itemStartDate resolves an item's all-day start: trip.start_date + (day-1).
+// Not datable when the trip has no start date or the item has no day.
+func itemStartDate(trip store.Trip, it store.ItineraryItem) (time.Time, bool) {
+	if !trip.StartDate.Valid || it.Day == nil || *it.Day < 1 {
+		return time.Time{}, false
+	}
+	return trip.StartDate.Time.AddDate(0, 0, int(*it.Day)-1), true
+}
+
+// icsItemDescription joins the time-of-day and local attribution into the
+// VEVENT DESCRIPTION (pre-escape; the builder escapes it).
+func icsItemDescription(it store.ItineraryItem) string {
+	var parts []string
+	if t := capitalize(strPtrVal(it.TimeOfDay)); t != "" {
+		parts = append(parts, t)
+	}
+	if rec := strings.TrimSpace(strPtrVal(it.LocalSourceName)); rec != "" {
+		parts = append(parts, "Recommended by "+rec)
+	}
+	return strings.Join(parts, " · ")
+}
+
+// icsBuilder accumulates CRLF-terminated, RFC-folded content lines.
+type icsBuilder struct {
+	sb strings.Builder
+}
+
+func (b *icsBuilder) line(s string) {
+	b.sb.WriteString(foldICSLine(s))
+	b.sb.WriteString("\r\n")
+}
+
+// event writes one all-day VEVENT. start/end are DATE values (end exclusive).
+// summary/location/description are raw text — escaped here.
+func (b *icsBuilder) event(stamp, uid string, start, end time.Time, summary, location, description string) {
+	b.line("BEGIN:VEVENT")
+	b.line("UID:" + uid + "@goldentempo")
+	b.line("DTSTAMP:" + stamp)
+	b.line("DTSTART;VALUE=DATE:" + start.Format(icsDateLayout))
+	b.line("DTEND;VALUE=DATE:" + end.Format(icsDateLayout))
+	b.line("SUMMARY:" + escapeICSText(summary))
+	if strings.TrimSpace(location) != "" {
+		b.line("LOCATION:" + escapeICSText(location))
+	}
+	if strings.TrimSpace(description) != "" {
+		b.line("DESCRIPTION:" + escapeICSText(description))
+	}
+	b.line("END:VEVENT")
+}
+
+func (b *icsBuilder) String() string { return b.sb.String() }
+
+// escapeICSText escapes a TEXT value per RFC 5545 §3.3.11: backslash, semicolon,
+// and comma are backslash-escaped, and newlines become the literal "\n".
+func escapeICSText(s string) string {
+	r := strings.NewReplacer(
+		`\`, `\\`,
+		`;`, `\;`,
+		`,`, `\,`,
+		"\r\n", `\n`,
+		"\n", `\n`,
+		"\r", `\n`,
+	)
+	return r.Replace(s)
+}
+
+// foldICSLine folds a content line to <=75 octets per RFC 5545 §3.1, using a
+// CRLF followed by a single space for each continuation. Folds on octet
+// boundaries but never mid-UTF-8-rune.
+func foldICSLine(s string) string {
+	const limit = 75
+	if len(s) <= limit {
+		return s
+	}
+	var out strings.Builder
+	line := 0
+	for i := 0; i < len(s); {
+		// Advance one rune so we never split a multi-byte sequence.
+		size := 1
+		for i+size < len(s) && s[i+size]&0xC0 == 0x80 {
+			size++
+		}
+		if line+size > limit {
+			out.WriteString("\r\n ")
+			line = 1 // the leading space counts toward the folded line
+		}
+		out.WriteString(s[i : i+size])
+		line += size
+		i += size
+	}
+	return out.String()
+}
+
+// tripSlug turns a trip title into a filesystem-friendly slug for the .ics
+// filename, falling back to "trip".
+func tripSlug(title string) string {
+	var b strings.Builder
+	prevDash := false
+	for _, r := range strings.ToLower(strings.TrimSpace(title)) {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9':
+			b.WriteRune(r)
+			prevDash = false
+		default:
+			if !prevDash {
+				b.WriteByte('-')
+				prevDash = true
+			}
+		}
+	}
+	slug := strings.Trim(b.String(), "-")
+	if slug == "" {
+		return "trip"
+	}
+	if len(slug) > 60 {
+		slug = strings.Trim(slug[:60], "-")
+	}
+	return slug
+}

--- a/src/packages/api/export_handler.go
+++ b/src/packages/api/export_handler.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/google/uuid"
+
+	"travel-route-planner/store"
+)
+
+// Owner-private trip export. The authed owner (or an editor collaborator) mints
+// a short-lived signed token via POST /trips/{id}/export-token; the two public,
+// token-gated GET routes (print.html, calendar.ics) verify it and render the
+// FULL trip — drafts, booking todos, and packing checklist included. This is
+// deliberately NOT the redacted public share view: export is for the trip's own
+// planners, printing or importing their complete plan.
+
+type ExportTokenResponse struct {
+	Token     string    `json:"token"`
+	ExpiresAt time.Time `json:"expires_at"`
+}
+
+// exportTokenHandler mints a signed export token for a trip. Gated by
+// editableTrip (owner or active editor-collaborator), matching every other
+// trip mutation. The token embeds the trip id + expiry and is self-verifying,
+// so the public export GETs need no session.
+func exportTokenHandler(w http.ResponseWriter, r *http.Request) {
+	trip, ok := editableTrip(w, r)
+	if !ok {
+		return
+	}
+	token, exp := newExportToken(trip.ID)
+	writeJSON(w, http.StatusOK, ExportTokenResponse{Token: token, ExpiresAt: exp})
+}
+
+// exportData is the full owner-view snapshot rendered by both export formats.
+type exportData struct {
+	Trip           store.Trip
+	Items          []store.ItineraryItem
+	Accommodations []store.Accommodation
+	Segments       []store.TripSegment
+	BookingTodos   []store.BookingTodo
+	Checklist      []store.TripChecklistItem
+}
+
+// loadExportData loads the full trip by id — no owner scoping, because the
+// verified export token IS the authorization. Unlike buildSharedTripResponse it
+// loads ALL accommodations/segments (drafts included) plus booking todos and
+// the packing checklist. A missing trip returns ok=false so callers 404.
+func loadExportData(ctx context.Context, tripID uuid.UUID) (exportData, bool) {
+	if dbPool == nil {
+		return exportData{}, false
+	}
+	q := store.New(dbPool)
+	// GetTripForUpdate is the only by-id-alone trip read; in autocommit its
+	// row lock is a momentary single-statement hold, harmless for this read.
+	trip, err := q.GetTripForUpdate(ctx, tripID)
+	if err != nil {
+		return exportData{}, false
+	}
+	items, err := q.GetItineraryItemsByTrip(ctx, tripID)
+	if err != nil {
+		return exportData{}, false
+	}
+	accommodations, err := q.ListAccommodationsByTrip(ctx, tripID)
+	if err != nil {
+		return exportData{}, false
+	}
+	segments, err := q.ListSegmentsByTrip(ctx, tripID)
+	if err != nil {
+		return exportData{}, false
+	}
+	todos, err := q.ListBookingTodosByTrip(ctx, tripID)
+	if err != nil {
+		return exportData{}, false
+	}
+	checklist, err := q.ListChecklistItemsByTrip(ctx, tripID)
+	if err != nil {
+		return exportData{}, false
+	}
+	return exportData{
+		Trip:           trip,
+		Items:          items,
+		Accommodations: accommodations,
+		Segments:       segments,
+		BookingTodos:   todos,
+		Checklist:      checklist,
+	}, true
+}
+
+// resolveExport turns the {token} path var into loaded export data. A bad or
+// expired token, or a vanished trip, both yield ok=false — the caller answers a
+// single opaque 404 either way so nothing about the trip leaks.
+func resolveExport(r *http.Request, token string) (exportData, bool) {
+	tripID, ok := verifyExportToken(token)
+	if !ok {
+		return exportData{}, false
+	}
+	return loadExportData(r.Context(), tripID)
+}

--- a/src/packages/api/export_integration_test.go
+++ b/src/packages/api/export_integration_test.go
@@ -1,0 +1,191 @@
+package main
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"travel-route-planner/store"
+)
+
+// exportFixtureTrip builds a dated trip with a day-tagged item, a stay, and a
+// segment so both export formats have something to render. Returns the trip.
+func exportFixtureTrip(t *testing.T, owner uuid.UUID, title string) store.Trip {
+	t.Helper()
+	ctx := context.Background()
+	q := store.New(dbPool)
+	chat := title + "-chat"
+	trip, err := q.CreateTrip(ctx, store.CreateTripParams{
+		UserID: owner, Title: title, Status: "draft", ChatID: &chat,
+	})
+	if err != nil {
+		t.Fatalf("CreateTrip: %v", err)
+	}
+	start := pgDate(t, "2026-08-01")
+	end := pgDate(t, "2026-08-05")
+	if _, err := q.UpdateTrip(ctx, store.UpdateTripParams{
+		ID: trip.ID, UserID: owner, StartDate: start, EndDate: end,
+	}); err != nil {
+		t.Fatalf("UpdateTrip dates: %v", err)
+	}
+	day := int32(2)
+	city := "Athens"
+	tod := "morning"
+	rec := "Maria"
+	if _, err := q.CreateItineraryItem(ctx, store.CreateItineraryItemParams{
+		TripID: trip.ID, Position: 0, Name: "Acropolis, & the Parthenon; ruins",
+		Latitude: 37.97, Longitude: 23.72,
+		Day: &day, City: &city, TimeOfDay: &tod, LocalSourceName: &rec,
+	}); err != nil {
+		t.Fatalf("CreateItineraryItem: %v", err)
+	}
+	if _, err := q.CreateAccommodation(ctx, store.CreateAccommodationParams{
+		TripID: trip.ID, Name: "Hotel Grande Bretagne",
+		CheckIn: pgDate(t, "2026-08-01"), CheckOut: pgDate(t, "2026-08-05"),
+	}); err != nil {
+		t.Fatalf("CreateAccommodation: %v", err)
+	}
+	if _, err := q.CreateSegment(ctx, store.CreateSegmentParams{
+		TripID: trip.ID, Mode: "flight", Origin: strp("JFK"), Destination: strp("ATH"),
+		DepartDate: pgDate(t, "2026-08-01"), ArriveDate: pgDate(t, "2026-08-01"),
+	}); err != nil {
+		t.Fatalf("CreateSegment: %v", err)
+	}
+	final, err := q.GetTripByIDAndOwner(ctx, store.GetTripByIDAndOwnerParams{ID: trip.ID, UserID: owner})
+	if err != nil {
+		t.Fatalf("reload trip: %v", err)
+	}
+	return final
+}
+
+func pgDate(t *testing.T, s string) pgtype.Date {
+	t.Helper()
+	tm, err := time.Parse("2006-01-02", s)
+	if err != nil {
+		t.Fatalf("parse date %q: %v", s, err)
+	}
+	return pgtype.Date{Time: tm, Valid: true}
+}
+
+func TestExportToken_RequiresAuthAndOwnership(t *testing.T) {
+	resetDB(t)
+	owner, ownerTok := createTestUser(t, "owner@example.com")
+	_, strangerTok := createTestUser(t, "stranger@example.com")
+	trip := createTestTrip(t, owner.ID, 1)
+
+	// Anonymous → 401.
+	if rec := doJSON(t, "POST", "/api/v1/trips/"+trip.ID.String()+"/export-token", "", nil); rec.Code != 401 {
+		t.Fatalf("anonymous export-token: got %d want 401", rec.Code)
+	}
+	// Non-owner → 404 (editableTrip hides existence).
+	if rec := doJSON(t, "POST", "/api/v1/trips/"+trip.ID.String()+"/export-token", strangerTok, nil); rec.Code != 404 {
+		t.Fatalf("non-owner export-token: got %d want 404", rec.Code)
+	}
+	// Owner → 200 with a token + expiry.
+	rec := doJSON(t, "POST", "/api/v1/trips/"+trip.ID.String()+"/export-token", ownerTok, nil)
+	if rec.Code != 200 {
+		t.Fatalf("owner export-token: got %d want 200 (%s)", rec.Code, rec.Body.String())
+	}
+	m := decode(t, rec)
+	if _, ok := m["token"].(string); !ok || m["token"] == "" {
+		t.Fatalf("missing token in %v", m)
+	}
+	if _, ok := m["expires_at"].(string); !ok {
+		t.Fatalf("missing expires_at in %v", m)
+	}
+	// The minted token must verify back to this trip.
+	if id, ok := verifyExportToken(m["token"].(string)); !ok || id != trip.ID {
+		t.Fatalf("minted token did not verify to trip")
+	}
+}
+
+func TestExportPrintView_RendersAndEscapes(t *testing.T) {
+	resetDB(t)
+	owner, _ := createTestUser(t, "printer@example.com")
+	trip := exportFixtureTrip(t, owner.ID, "<script>alert(1)</script> Trip")
+	token, _ := newExportToken(trip.ID)
+
+	rec := doJSON(t, "GET", "/api/v1/export/"+token+"/print.html", "", nil)
+	if rec.Code != 200 {
+		t.Fatalf("print.html: got %d want 200", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); !strings.HasPrefix(ct, "text/html") {
+		t.Fatalf("print.html content-type: %q", ct)
+	}
+	body := rec.Body.String()
+	// Title present but the <script> escaped, never raw.
+	if strings.Contains(body, "<script>alert(1)</script>") {
+		t.Fatal("print.html leaked an unescaped <script> title")
+	}
+	if !strings.Contains(body, "&lt;script&gt;") {
+		t.Fatal("print.html did not render the escaped title")
+	}
+	// Day header + item name.
+	if !strings.Contains(body, "Day 2") {
+		t.Fatal("print.html missing day header")
+	}
+	if !strings.Contains(body, "Acropolis") {
+		t.Fatal("print.html missing item name")
+	}
+	if !strings.Contains(body, "Recommended by Maria") {
+		t.Fatal("print.html missing local attribution")
+	}
+}
+
+func TestExportPrintView_InvalidTokenIs404(t *testing.T) {
+	resetDB(t)
+	rec := doJSON(t, "GET", "/api/v1/export/not-a-real-token/print.html", "", nil)
+	if rec.Code != 404 {
+		t.Fatalf("invalid print token: got %d want 404", rec.Code)
+	}
+}
+
+func TestExportCalendar_ICSShapeAndEscaping(t *testing.T) {
+	resetDB(t)
+	owner, _ := createTestUser(t, "ical@example.com")
+	trip := exportFixtureTrip(t, owner.ID, "Greek Islands")
+	token, _ := newExportToken(trip.ID)
+
+	rec := doJSON(t, "GET", "/api/v1/export/"+token+"/calendar.ics", "", nil)
+	if rec.Code != 200 {
+		t.Fatalf("calendar.ics: got %d want 200", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); !strings.HasPrefix(ct, "text/calendar") {
+		t.Fatalf("calendar content-type: %q", ct)
+	}
+	if cd := rec.Header().Get("Content-Disposition"); !strings.Contains(cd, `filename="greek-islands.ics"`) {
+		t.Fatalf("calendar content-disposition: %q", cd)
+	}
+	body := rec.Body.String()
+	if n := strings.Count(body, "BEGIN:VEVENT"); n != 3 {
+		t.Fatalf("expected 3 VEVENTs (item+stay+segment), got %d\n%s", n, body)
+	}
+	// Item all-day event: day 2 → 2026-08-02.
+	if !strings.Contains(body, "DTSTART;VALUE=DATE:20260802") {
+		t.Fatalf("item DTSTART wrong; body:\n%s", body)
+	}
+	// Stay check-in 2026-08-01.
+	if !strings.Contains(body, "DTSTART;VALUE=DATE:20260801") {
+		t.Fatalf("stay DTSTART wrong; body:\n%s", body)
+	}
+	// RFC escaping: "Acropolis, & the Parthenon; ruins" → comma & semicolon escaped.
+	if !strings.Contains(body, `Acropolis\, & the Parthenon\; ruins`) {
+		t.Fatalf("ICS TEXT escaping wrong; body:\n%s", body)
+	}
+	// CRLF line endings.
+	if !strings.Contains(body, "\r\n") {
+		t.Fatal("ICS not CRLF-terminated")
+	}
+}
+
+func TestExportCalendar_InvalidTokenIs404(t *testing.T) {
+	resetDB(t)
+	rec := doJSON(t, "GET", "/api/v1/export/bogus.token/calendar.ics", "", nil)
+	if rec.Code != 404 {
+		t.Fatalf("invalid calendar token: got %d want 404", rec.Code)
+	}
+}

--- a/src/packages/api/export_token.go
+++ b/src/packages/api/export_token.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Owner-private trip export tokens. The app authenticates with bearer tokens
+// only (no cookies), so a plain browser navigation to an authed export URL
+// would 401. Instead the owner mints a short-lived, HMAC-signed capability
+// token that carries the trip id and an expiry, and the public print.html /
+// calendar.ics routes verify it. The token IS the authorization — no DB row,
+// no migration. These helpers are pure (no DB) so they unit-test cleanly.
+
+// exportTokenTTL bounds how long a minted export link stays valid.
+const exportTokenTTL = time.Hour
+
+var (
+	exportSecretOnce sync.Once
+	exportSecret     []byte
+)
+
+// exportSigningSecret returns the HMAC key for export tokens. It prefers the
+// EXPORT_SIGNING_SECRET env var (mirrors how the rest of the app reads secrets
+// via os.Getenv). When unset it mints a random per-process secret so tokens
+// stay unforgeable in dev; a restart invalidates outstanding links, which is
+// fine given the 1h TTL. The very-unlikely rand failure falls back to a fixed
+// documented dev default rather than panicking.
+func exportSigningSecret() []byte {
+	exportSecretOnce.Do(func() {
+		if s := strings.TrimSpace(os.Getenv("EXPORT_SIGNING_SECRET")); s != "" {
+			exportSecret = []byte(s)
+			return
+		}
+		buf := make([]byte, 32)
+		if _, err := rand.Read(buf); err != nil {
+			exportSecret = []byte("golden-tempo-dev-export-secret-default")
+			return
+		}
+		exportSecret = buf
+	})
+	return exportSecret
+}
+
+// signExportToken builds a token for tripID that expires at exp, signed with
+// secret. Format: base64url(payload) + "." + base64url(HMAC-SHA256(payload)),
+// where payload is the raw "<tripID>|<unix-exp>" string.
+func signExportToken(secret []byte, tripID uuid.UUID, exp time.Time) string {
+	payload := tripID.String() + "|" + strconv.FormatInt(exp.Unix(), 10)
+	sig := hmacSign(secret, payload)
+	enc := base64.RawURLEncoding
+	return enc.EncodeToString([]byte(payload)) + "." + enc.EncodeToString(sig)
+}
+
+// verifyExportTokenWith validates token against secret at time now, returning
+// the trip id when the signature matches (constant-time) and the token has not
+// expired. Any structural, signature, or expiry problem returns ok=false with
+// no distinction — callers surface a single opaque 404.
+func verifyExportTokenWith(secret []byte, token string, now time.Time) (uuid.UUID, bool) {
+	parts := strings.SplitN(token, ".", 2)
+	if len(parts) != 2 {
+		return uuid.UUID{}, false
+	}
+	enc := base64.RawURLEncoding
+	payloadBytes, err := enc.DecodeString(parts[0])
+	if err != nil {
+		return uuid.UUID{}, false
+	}
+	gotSig, err := enc.DecodeString(parts[1])
+	if err != nil {
+		return uuid.UUID{}, false
+	}
+	wantSig := hmacSign(secret, string(payloadBytes))
+	// Constant-time compare — never a byte-by-byte early return.
+	if !hmac.Equal(gotSig, wantSig) {
+		return uuid.UUID{}, false
+	}
+	fields := strings.SplitN(string(payloadBytes), "|", 2)
+	if len(fields) != 2 {
+		return uuid.UUID{}, false
+	}
+	exp, err := strconv.ParseInt(fields[1], 10, 64)
+	if err != nil || now.Unix() >= exp {
+		return uuid.UUID{}, false
+	}
+	id, err := uuid.Parse(fields[0])
+	if err != nil {
+		return uuid.UUID{}, false
+	}
+	return id, true
+}
+
+// hmacSign returns HMAC-SHA256(payload) under secret.
+func hmacSign(secret []byte, payload string) []byte {
+	mac := hmac.New(sha256.New, secret)
+	mac.Write([]byte(payload))
+	return mac.Sum(nil)
+}
+
+// newExportToken mints a token for tripID valid for exportTokenTTL using the
+// process signing secret. Returns the token and its absolute expiry.
+func newExportToken(tripID uuid.UUID) (string, time.Time) {
+	exp := time.Now().Add(exportTokenTTL)
+	return signExportToken(exportSigningSecret(), tripID, exp), exp
+}
+
+// verifyExportToken validates a token minted by newExportToken.
+func verifyExportToken(token string) (uuid.UUID, bool) {
+	return verifyExportTokenWith(exportSigningSecret(), token, time.Now())
+}

--- a/src/packages/api/export_token_test.go
+++ b/src/packages/api/export_token_test.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+var testExportSecret = []byte("test-export-secret-0123456789")
+
+func TestExportToken_RoundTrip(t *testing.T) {
+	id := uuid.New()
+	tok := signExportToken(testExportSecret, id, time.Now().Add(time.Hour))
+	got, ok := verifyExportTokenWith(testExportSecret, tok, time.Now())
+	if !ok {
+		t.Fatal("valid token failed to verify")
+	}
+	if got != id {
+		t.Fatalf("trip id mismatch: got %s want %s", got, id)
+	}
+}
+
+func TestExportToken_TamperedPayloadFails(t *testing.T) {
+	id := uuid.New()
+	tok := signExportToken(testExportSecret, id, time.Now().Add(time.Hour))
+	parts := strings.SplitN(tok, ".", 2)
+	if len(parts) != 2 {
+		t.Fatalf("unexpected token shape %q", tok)
+	}
+	// Swap the payload for a different trip id but keep the original signature.
+	other := signExportToken(testExportSecret, uuid.New(), time.Now().Add(time.Hour))
+	tampered := strings.SplitN(other, ".", 2)[0] + "." + parts[1]
+	if _, ok := verifyExportTokenWith(testExportSecret, tampered, time.Now()); ok {
+		t.Fatal("tampered payload verified")
+	}
+}
+
+func TestExportToken_TamperedSignatureFails(t *testing.T) {
+	id := uuid.New()
+	tok := signExportToken(testExportSecret, id, time.Now().Add(time.Hour))
+	// Flip the last character of the signature segment.
+	flipped := tok[:len(tok)-1]
+	if tok[len(tok)-1] == 'A' {
+		flipped += "B"
+	} else {
+		flipped += "A"
+	}
+	if _, ok := verifyExportTokenWith(testExportSecret, flipped, time.Now()); ok {
+		t.Fatal("tampered signature verified")
+	}
+}
+
+func TestExportToken_ExpiredFails(t *testing.T) {
+	id := uuid.New()
+	tok := signExportToken(testExportSecret, id, time.Now().Add(-time.Minute))
+	if _, ok := verifyExportTokenWith(testExportSecret, tok, time.Now()); ok {
+		t.Fatal("expired token verified")
+	}
+}
+
+func TestExportToken_WrongSecretFails(t *testing.T) {
+	id := uuid.New()
+	tok := signExportToken(testExportSecret, id, time.Now().Add(time.Hour))
+	if _, ok := verifyExportTokenWith([]byte("a-completely-different-secret"), tok, time.Now()); ok {
+		t.Fatal("token verified under the wrong secret")
+	}
+}
+
+func TestExportToken_MalformedFails(t *testing.T) {
+	for _, bad := range []string{"", "no-dot", "a.b.c", "!!!.###", "."} {
+		if _, ok := verifyExportTokenWith(testExportSecret, bad, time.Now()); ok {
+			t.Fatalf("malformed token %q verified", bad)
+		}
+	}
+}

--- a/src/packages/api/main.go
+++ b/src/packages/api/main.go
@@ -724,6 +724,13 @@ func buildRouter() *mux.Router {
 	api.Handle("/trips/{id}/refine", strict(authMiddleware(http.HandlerFunc(refineTripHandler)))).Methods("POST")
 	api.Handle("/trips/{id}/share", authMiddleware(http.HandlerFunc(createShareHandler))).Methods("POST")
 	api.Handle("/trips/{id}/share", authMiddleware(http.HandlerFunc(revokeShareHandler))).Methods("DELETE")
+	// Owner-private export: the authed owner/editor mints a short-lived signed
+	// token, then the two PUBLIC token-gated GETs below render the full trip.
+	api.Handle("/trips/{id}/export-token", authMiddleware(http.HandlerFunc(exportTokenHandler))).Methods("POST")
+	// Public, token-gated export routes — NO authMiddleware: the signed export
+	// token IS the authorization (a bad/expired token is a clean 404).
+	api.HandleFunc("/export/{token}/print.html", printViewHandler).Methods("GET")
+	api.HandleFunc("/export/{token}/calendar.ics", calendarHandler).Methods("GET")
 	// Public share read sits behind the general per-IP limiter like everything
 	// else; it is the one endpoint deliberately open to anonymous strangers.
 	api.HandleFunc("/shared/{token}", sharedTripHandler).Methods("GET")

--- a/src/packages/api/print_view_handler.go
+++ b/src/packages/api/print_view_handler.go
@@ -1,0 +1,385 @@
+package main
+
+import (
+	"html/template"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gorilla/mux"
+
+	"travel-route-planner/store"
+)
+
+// capitalize upper-cases the first rune of a lower-case token (e.g. "morning" →
+// "Morning", "flight" → "Flight") for display. Avoids the deprecated
+// strings.Title while covering these single-word values.
+func capitalize(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ""
+	}
+	return strings.ToUpper(s[:1]) + s[1:]
+}
+
+// print_view_handler.go — GET /api/v1/export/{token}/print.html, a printable
+// full-trip page. Token-gated and PUBLIC (no authMiddleware): the signed token
+// is the capability. Rendered with html/template so every field is
+// auto-escaped; NEVER assemble this HTML with fmt.Sprintf (same rule as
+// share_preview_handler.go).
+
+type printItem struct {
+	Name          string
+	TimeOfDay     string
+	Address       string
+	RecommendedBy string // local_source_name attribution, when present
+}
+
+type printDay struct {
+	Label string // "Day 3" / "Unscheduled"
+	Date  string // "Mon, Jan 2" or "" when undatable
+	Items []printItem
+}
+
+type printGroup struct {
+	Hub  string // day_trip_from → city → "Itinerary"
+	Days []printDay
+}
+
+type printStay struct {
+	Name     string
+	Address  string
+	CheckIn  string
+	CheckOut string
+}
+
+type printSegment struct {
+	Mode   string
+	Route  string // "Origin → Destination"
+	Depart string
+	Arrive string
+}
+
+type printTodo struct {
+	Title    string
+	Subtitle string
+	Booked   bool
+}
+
+type printChecklistGroup struct {
+	Category string
+	Items    []printChecklistItem
+}
+
+type printChecklistItem struct {
+	Title   string
+	Checked bool
+}
+
+type printViewData struct {
+	Title      string
+	Dates      string
+	Groups     []printGroup
+	Stays      []printStay
+	Segments   []printSegment
+	Todos      []printTodo
+	Checklist  []printChecklistGroup
+	HasContent bool
+}
+
+// printViewTmpl uses html/template — every field is auto-escaped. Brand house
+// style (teal gradient header) cloned from dockerize/static/privacy.html.
+var printViewTmpl = template.Must(template.New("print-view").Parse(`<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>{{.Title}} — Golden Tempo Travel</title>
+  <style>
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+      color: #263238; background: #fff; line-height: 1.55;
+    }
+    header {
+      background: linear-gradient(to bottom right, #00897B, #004D40);
+      color: #fff; padding: 32px 24px 28px;
+    }
+    header .wrap { max-width: 820px; margin: 0 auto; }
+    header .brand {
+      font-size: 0.8rem; letter-spacing: 0.08em; text-transform: uppercase;
+      opacity: 0.85; margin: 0 0 6px; display: flex; align-items: center; gap: 10px;
+    }
+    header .brand img { height: 22px; width: 22px; border-radius: 5px; }
+    header h1 { margin: 0; font-size: 1.7rem; }
+    header .meta { margin: 8px 0 0; opacity: 0.9; font-size: 0.95rem; }
+    main { max-width: 820px; margin: 0 auto; padding: 28px 24px 56px; }
+    h2 {
+      color: #00695C; font-size: 1.2rem; margin: 32px 0 8px;
+      border-bottom: 2px solid #B2DFDB; padding-bottom: 6px;
+    }
+    .hub { margin: 20px 0 0; }
+    .hub-name { font-size: 1.05rem; font-weight: 600; color: #004D40; margin: 0 0 4px; }
+    .day { margin: 12px 0 0; padding: 10px 14px; background: #F5F7F7; border-radius: 8px; }
+    .day-head { font-weight: 600; color: #00695C; margin: 0 0 6px; }
+    .item { margin: 6px 0; padding-left: 14px; border-left: 3px solid #B2DFDB; }
+    .item-name { font-weight: 600; }
+    .item-meta { font-size: 0.9rem; color: #546E7A; }
+    .rec { font-size: 0.88rem; color: #00695C; font-style: italic; }
+    .row { padding: 8px 0; border-bottom: 1px solid #ECEFF1; }
+    .row:last-child { border-bottom: none; }
+    .row-title { font-weight: 600; }
+    .row-meta { font-size: 0.9rem; color: #546E7A; }
+    .cat { font-weight: 600; color: #004D40; margin: 14px 0 4px; text-transform: capitalize; }
+    ul.check { list-style: none; padding-left: 0; margin: 0; }
+    ul.check li { padding: 3px 0; }
+    .box { display: inline-block; width: 1em; }
+    .booked { color: #2E7D32; }
+    footer { margin-top: 40px; padding-top: 14px; border-top: 1px solid #CFD8DC; font-size: 0.85rem; color: #607D8B; }
+    .empty { color: #607D8B; font-style: italic; }
+    @media print {
+      header { background: #004D40 !important; -webkit-print-color-adjust: exact; print-color-adjust: exact; }
+      .day, .hub, .row { page-break-inside: avoid; }
+      h2 { page-break-after: avoid; }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="wrap">
+      <p class="brand"><img src="/app/icons/Icon-512.png" alt="">Golden Tempo Travel</p>
+      <h1>{{.Title}}</h1>
+      {{if .Dates}}<p class="meta">{{.Dates}}</p>{{end}}
+    </div>
+  </header>
+  <main>
+    {{if not .HasContent}}<p class="empty">This trip has nothing to export yet.</p>{{end}}
+
+    {{if .Groups}}
+    <h2>Itinerary</h2>
+    {{range .Groups}}
+    <div class="hub">
+      <p class="hub-name">{{.Hub}}</p>
+      {{range .Days}}
+      <div class="day">
+        <p class="day-head">{{.Label}}{{if .Date}} · {{.Date}}{{end}}</p>
+        {{range .Items}}
+        <div class="item">
+          <div class="item-name">{{.Name}}</div>
+          {{if or .TimeOfDay .Address}}<div class="item-meta">{{if .TimeOfDay}}{{.TimeOfDay}}{{end}}{{if and .TimeOfDay .Address}} · {{end}}{{.Address}}</div>{{end}}
+          {{if .RecommendedBy}}<div class="rec">Recommended by {{.RecommendedBy}}</div>{{end}}
+        </div>
+        {{end}}
+      </div>
+      {{end}}
+    </div>
+    {{end}}
+    {{end}}
+
+    {{if .Stays}}
+    <h2>Accommodations</h2>
+    {{range .Stays}}
+    <div class="row">
+      <div class="row-title">{{.Name}}</div>
+      {{if .Address}}<div class="row-meta">{{.Address}}</div>{{end}}
+      {{if or .CheckIn .CheckOut}}<div class="row-meta">{{if .CheckIn}}Check-in {{.CheckIn}}{{end}}{{if .CheckOut}} · Check-out {{.CheckOut}}{{end}}</div>{{end}}
+    </div>
+    {{end}}
+    {{end}}
+
+    {{if .Segments}}
+    <h2>Transport</h2>
+    {{range .Segments}}
+    <div class="row">
+      <div class="row-title">{{.Route}}</div>
+      <div class="row-meta">{{.Mode}}{{if .Depart}} · Departs {{.Depart}}{{end}}{{if .Arrive}} · Arrives {{.Arrive}}{{end}}</div>
+    </div>
+    {{end}}
+    {{end}}
+
+    {{if .Todos}}
+    <h2>Booking checklist</h2>
+    {{range .Todos}}
+    <div class="row">
+      <div class="row-title"><span class="box">{{if .Booked}}&#9745;{{else}}&#9744;{{end}}</span> {{.Title}}{{if .Booked}} <span class="booked">(booked)</span>{{end}}</div>
+      {{if .Subtitle}}<div class="row-meta">{{.Subtitle}}</div>{{end}}
+    </div>
+    {{end}}
+    {{end}}
+
+    {{if .Checklist}}
+    <h2>Packing checklist</h2>
+    {{range .Checklist}}
+    <p class="cat">{{.Category}}</p>
+    <ul class="check">
+      {{range .Items}}<li><span class="box">{{if .Checked}}&#9745;{{else}}&#9744;{{end}}</span> {{.Title}}</li>{{end}}
+    </ul>
+    {{end}}
+    {{end}}
+
+    <footer>Exported from Golden Tempo Travel</footer>
+  </main>
+</body>
+</html>`))
+
+// printViewHandler renders the full trip as a printable HTML page.
+func printViewHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	data, ok := resolveExport(r, mux.Vars(r)["token"])
+	if !ok {
+		w.WriteHeader(http.StatusNotFound)
+		w.Write([]byte("<!DOCTYPE html><html><body><h2>This export link isn't available</h2><p>It may have expired.</p></body></html>"))
+		return
+	}
+	view := buildPrintView(data)
+	if err := printViewTmpl.Execute(w, view); err != nil {
+		// Headers already sent; nothing sensible left to do.
+		return
+	}
+}
+
+// buildPrintView reshapes the raw export data into the template view model:
+// items grouped by hub (day_trip_from → city) then by day with resolved dates,
+// plus flat stays/segments/todos/checklist sections.
+func buildPrintView(d exportData) printViewData {
+	view := printViewData{Title: strings.TrimSpace(d.Trip.Title)}
+	if view.Title == "" {
+		view.Title = "Untitled trip"
+	}
+	if d.Trip.StartDate.Valid && d.Trip.EndDate.Valid {
+		view.Dates = d.Trip.StartDate.Time.Format("Jan 2") + " – " + d.Trip.EndDate.Time.Format("Jan 2, 2006")
+	} else if d.Trip.StartDate.Valid {
+		view.Dates = d.Trip.StartDate.Time.Format("Jan 2, 2006")
+	}
+
+	view.Groups = groupExportItems(d.Trip, d.Items)
+
+	for _, a := range d.Accommodations {
+		view.Stays = append(view.Stays, printStay{
+			Name:     a.Name,
+			Address:  strPtrVal(a.Address),
+			CheckIn:  formatExportDate(dateToPtr(a.CheckIn)),
+			CheckOut: formatExportDate(dateToPtr(a.CheckOut)),
+		})
+	}
+	for _, s := range d.Segments {
+		view.Segments = append(view.Segments, printSegment{
+			Mode:   capitalize(s.Mode),
+			Route:  segmentRoute(s),
+			Depart: formatExportDate(dateToPtr(s.DepartDate)),
+			Arrive: formatExportDate(dateToPtr(s.ArriveDate)),
+		})
+	}
+	for _, t := range d.BookingTodos {
+		view.Todos = append(view.Todos, printTodo{
+			Title:    t.Title,
+			Subtitle: strPtrVal(t.Subtitle),
+			Booked:   t.Booked,
+		})
+	}
+	view.Checklist = groupChecklist(d.Checklist)
+
+	view.HasContent = len(view.Groups) > 0 || len(view.Stays) > 0 ||
+		len(view.Segments) > 0 || len(view.Todos) > 0 || len(view.Checklist) > 0
+	return view
+}
+
+// groupExportItems walks items in position order and groups them by hub
+// (day_trip_from, falling back to city, then "Itinerary"), sub-grouping by day.
+// First-appearance order is preserved for both hubs and days. Per-item date is
+// trip.start_date + (day-1) when both are present.
+func groupExportItems(trip store.Trip, items []store.ItineraryItem) []printGroup {
+	var groups []printGroup
+	groupIdx := map[string]int{}
+	dayIdx := map[string]int{} // key: hub + "\x00" + day
+
+	for _, it := range items {
+		hub := strings.TrimSpace(strPtrVal(it.DayTripFrom))
+		if hub == "" {
+			hub = strings.TrimSpace(strPtrVal(it.City))
+		}
+		if hub == "" {
+			hub = "Itinerary"
+		}
+		gi, ok := groupIdx[hub]
+		if !ok {
+			gi = len(groups)
+			groupIdx[hub] = gi
+			groups = append(groups, printGroup{Hub: hub})
+		}
+
+		dayNum := 0
+		if it.Day != nil {
+			dayNum = int(*it.Day)
+		}
+		dayKey := hub + "\x00" + strconv.Itoa(dayNum)
+		di, ok := dayIdx[dayKey]
+		if !ok {
+			di = len(groups[gi].Days)
+			dayIdx[dayKey] = di
+			label := "Unscheduled"
+			date := ""
+			if dayNum > 0 {
+				label = "Day " + strconv.Itoa(dayNum)
+				if trip.StartDate.Valid {
+					date = trip.StartDate.Time.AddDate(0, 0, dayNum-1).Format("Mon, Jan 2")
+				}
+			}
+			groups[gi].Days = append(groups[gi].Days, printDay{Label: label, Date: date})
+		}
+
+		groups[gi].Days[di].Items = append(groups[gi].Days[di].Items, printItem{
+			Name:          it.Name,
+			TimeOfDay:     capitalize(strPtrVal(it.TimeOfDay)),
+			Address:       strPtrVal(it.Address),
+			RecommendedBy: strPtrVal(it.LocalSourceName),
+		})
+	}
+	return groups
+}
+
+// groupChecklist buckets packing items by category, preserving first-appearance
+// order (items already arrive sorted by position).
+func groupChecklist(items []store.TripChecklistItem) []printChecklistGroup {
+	var groups []printChecklistGroup
+	idx := map[string]int{}
+	for _, it := range items {
+		gi, ok := idx[it.Category]
+		if !ok {
+			gi = len(groups)
+			idx[it.Category] = gi
+			groups = append(groups, printChecklistGroup{Category: it.Category})
+		}
+		groups[gi].Items = append(groups[gi].Items, printChecklistItem{Title: it.Title, Checked: it.Checked})
+	}
+	return groups
+}
+
+// segmentRoute renders "Origin → Destination", tolerating missing endpoints.
+func segmentRoute(s store.TripSegment) string {
+	o := strings.TrimSpace(strPtrVal(s.Origin))
+	dst := strings.TrimSpace(strPtrVal(s.Destination))
+	switch {
+	case o != "" && dst != "":
+		return o + " → " + dst
+	case dst != "":
+		return dst
+	case o != "":
+		return o
+	default:
+		return capitalize(s.Mode)
+	}
+}
+
+// formatExportDate turns a *string "YYYY-MM-DD" into a friendly "Mon, Jan 2".
+func formatExportDate(s *string) string {
+	if s == nil || *s == "" {
+		return ""
+	}
+	t, err := time.Parse(dateLayout, *s)
+	if err != nil {
+		return *s
+	}
+	return t.Format("Mon, Jan 2")
+}


### PR DESCRIPTION
## What

Owner-private **full-trip export** in two formats: a printable `print.html` and a `calendar.ics`. Unlike the public share view, export includes the complete owner working set — booking drafts, booking-todo checklist, and packing checklist.

## Why token-gated (not authMiddleware)

The app authenticates with **bearer tokens only** (no cookies), so a plain browser navigation to an authed export URL would 401. Instead the owner mints a short-lived **HMAC-signed capability token** that carries the trip id + expiry; the two PUBLIC GET routes verify it. The token IS the authorization — no migration, no DB row.

## Endpoints

| Method | Path | Auth | Returns |
|--------|------|------|---------|
| POST | `/api/v1/trips/{id}/export-token` | authMiddleware + `editableTrip` (owner/editor) | `{token, expires_at}` |
| GET | `/api/v1/export/{token}/print.html` | token only (public) | `text/html` printable page |
| GET | `/api/v1/export/{token}/calendar.ics` | token only (public) | `text/calendar` attachment |

- **Token scheme:** `base64url("<tripID>|<unix-exp>") + "." + base64url(HMAC-SHA256(payload))`; constant-time compare (`hmac.Equal`); 1h TTL.
- **Secret:** `EXPORT_SIGNING_SECRET` env var; if unset, a random per-process key (restart invalidates outstanding links — fine for a 1h TTL).
- Invalid/expired/tampered token → opaque **404** on both GET routes (no leak).

## Rendering

- **print.html:** `html/template` (auto-escaped — never `fmt.Sprintf`, same rule as `share_preview_handler.go`). Items grouped by hub (`day_trip_from` → `city`) then by day, per-item date = `start_date + (day-1)`. Sections: itinerary, accommodations, transport, booking checklist, packing checklist. Brand teal header cloned from `privacy.html`, `@media print` page-break rules.
- **calendar.ics:** hand-built RFC 5545 VCALENDAR, zero deps. All-day VEVENTs for items/stays/segments with stable `UID:<kind>-<rowid>@goldentempo`, TEXT escaping (`\` `,` `;` newline) and 75-octet line folding, CRLF endings.

## Tests

- `export_token_test.go` (pure): round-trip, tampered payload/signature, expired, wrong-secret, malformed.
- `export_integration_test.go`: export-token auth (401) + ownership (non-owner 404); print render with escaped `<script>` title + day header + item name; `.ics` shape (3 VEVENTs, correct DTSTART dates, comma/semicolon escaping); invalid-token 404s.

`make api-fmt`, `make api-vet`, and `go test ./...` (incl. Postgres integration) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)