### PR TITLE
feat(api): exclude-admins filter + created_at index for admin activity

### DIFF
--- a/src/packages/api/admin_integration_test.go
+++ b/src/packages/api/admin_integration_test.go
@@ -438,6 +438,44 @@ func TestAdminActivity(t *testing.T) {
 	}
 }
 
+// TestAdminActivityExcludeAdmins asserts exclude_admins=true drops rows from
+// admin users (the operator's own clicks) while keeping normal-user and
+// anonymous rows, and that the default omits the filter (backward compatible).
+func TestAdminActivityExcludeAdmins(t *testing.T) {
+	resetDB(t)
+	admin, adminToken := createTestUser(t, "excl-admin@example.com")
+	makeAdmin(t, admin.ID)
+	user, _ := createTestUser(t, "excl-user@example.com")
+
+	now := time.Now()
+	insertEvent(t, user.ID, "user_registered", now.Add(-3*time.Minute), "")
+	insertAnonymousEvent(t, "booking_link_clicked", now.Add(-2*time.Minute), "")
+	insertEvent(t, admin.ID, "trip_created", now.Add(-1*time.Minute), "")
+
+	// Default (exclude_admins absent) returns all three, admin's included.
+	body := decode(t, doJSON(t, "GET", "/api/v1/admin/metrics/activity?limit=50", adminToken, nil))
+	events, _ := body["events"].([]any)
+	if len(events) != 3 {
+		t.Fatalf("default events = %d, want 3 (admin row included)", len(events))
+	}
+
+	// exclude_admins=true drops only the admin's row; user + anonymous survive.
+	body = decode(t, doJSON(t, "GET", "/api/v1/admin/metrics/activity?limit=50&exclude_admins=true", adminToken, nil))
+	events, _ = body["events"].([]any)
+	if len(events) != 2 {
+		t.Fatalf("exclude_admins events = %d, want 2 (admin row omitted)", len(events))
+	}
+	for _, e := range events {
+		ev := e.(map[string]any)
+		if ev["user_is_admin"] == true {
+			t.Errorf("exclude_admins returned an admin row: %v", ev["event_type"])
+		}
+		if ev["event_type"] == "trip_created" {
+			t.Errorf("admin's trip_created row leaked into exclude_admins result")
+		}
+	}
+}
+
 // TestAdminUsers asserts the per-user aggregates (lineage-deduped trips, token
 // sums with the plan_session_completed filter, cost estimate), the
 // last_event_at DESC NULLS LAST ordering, and offset paging.

--- a/src/packages/api/admin_metrics_handler.go
+++ b/src/packages/api/admin_metrics_handler.go
@@ -6,7 +6,7 @@ package main
 //
 //	GET /admin/metrics/timeseries?days=   — daily buckets for the Trends tab
 //	GET /admin/metrics/totals             — all-time domain-table counts
-//	GET /admin/metrics/activity?limit=&before= — event tail, keyset-paginated
+//	GET /admin/metrics/activity?limit=&before=&exclude_admins= — event tail, keyset-paginated
 //	GET /admin/metrics/users?limit=&offset=    — per-user activity aggregates
 //
 // Deliberately NOT folded into MetricsResponse: totals is not window-scoped,
@@ -144,7 +144,7 @@ type activityResponse struct {
 	NextBefore string `json:"next_before,omitempty"`
 }
 
-// adminActivityHandler is GET /admin/metrics/activity?limit=&before=.
+// adminActivityHandler is GET /admin/metrics/activity?limit=&before=&exclude_admins=.
 func adminActivityHandler(w http.ResponseWriter, r *http.Request) {
 	if dbPool == nil {
 		writeJSONError(w, http.StatusServiceUnavailable, "database unavailable")
@@ -161,9 +161,14 @@ func adminActivityHandler(w http.ResponseWriter, r *http.Request) {
 		before = t
 	}
 
+	// exclude_admins=true drops the operator's own activity so the funnel/feed
+	// reflects real users; default false keeps the existing behavior.
+	excludeAdmins := r.URL.Query().Get("exclude_admins") == "true"
+
 	rows, err := store.New(dbPool).RecentAnalyticsEvents(r.Context(), store.RecentAnalyticsEventsParams{
-		Before:    before,
-		PageLimit: int32(limit),
+		Before:        before,
+		ExcludeAdmins: excludeAdmins,
+		PageLimit:     int32(limit),
 	})
 	if err != nil {
 		log.Printf("admin activity: %v", err)

--- a/src/packages/api/migrations/00043_analytics_events_created_at_idx.sql
+++ b/src/packages/api/migrations/00043_analytics_events_created_at_idx.sql
@@ -1,0 +1,10 @@
+-- +goose Up
+-- Bare created_at index for the admin activity tail (RecentAnalyticsEvents in
+-- query/admin.sql): ORDER BY created_at DESC LIMIT N was a top-N heap scan —
+-- the composite indexes from 00026 (event_type/user_id + created_at) don't
+-- serve an unfiltered time-ordered scan. DESC to match the query's ordering.
+CREATE INDEX IF NOT EXISTS analytics_events_created_at_idx
+    ON analytics_events (created_at DESC);
+
+-- +goose Down
+DROP INDEX IF EXISTS analytics_events_created_at_idx;

--- a/src/packages/api/query/admin.sql
+++ b/src/packages/api/query/admin.sql
@@ -41,9 +41,11 @@ SELECT
 -- Activity-feed tail, keyset-paginated: the client passes the last row's
 -- created_at back as $1 for the next page. COALESCE keeps sqlc's LEFT-JOIN
 -- nullability simple; the handler decides "anonymous" from user_id being
--- NULL, never from an empty email. ORDER BY created_at DESC has no bare
--- created_at index (only the composite ones from 00026) — a top-N heap scan,
--- fine at sole-admin scale.
+-- NULL, never from an empty email. When exclude_admins is true, rows from
+-- admin users are dropped so the operator's own clicks don't pollute the
+-- funnel/activity feed (anonymous rows survive — NULL is_admin COALESCEs to
+-- false). ORDER BY created_at DESC is served by the bare created_at index
+-- added in 00043.
 SELECT e.id, e.event_type, e.user_id,
        COALESCE(u.email, '')::text AS user_email,
        COALESCE(u.is_admin, false)::boolean AS user_is_admin,
@@ -51,6 +53,7 @@ SELECT e.id, e.event_type, e.user_id,
 FROM analytics_events e
 LEFT JOIN users u ON u.id = e.user_id
 WHERE e.created_at < sqlc.arg(before)
+  AND (NOT sqlc.arg(exclude_admins)::bool OR NOT COALESCE(u.is_admin, false))
 ORDER BY e.created_at DESC
 LIMIT sqlc.arg(page_limit);
 

--- a/src/packages/api/store/admin.sql.go
+++ b/src/packages/api/store/admin.sql.go
@@ -246,13 +246,15 @@ SELECT e.id, e.event_type, e.user_id,
 FROM analytics_events e
 LEFT JOIN users u ON u.id = e.user_id
 WHERE e.created_at < $1
+  AND (NOT $2::bool OR NOT COALESCE(u.is_admin, false))
 ORDER BY e.created_at DESC
-LIMIT $2
+LIMIT $3
 `
 
 type RecentAnalyticsEventsParams struct {
-	Before    time.Time `json:"before"`
-	PageLimit int32     `json:"page_limit"`
+	Before        time.Time `json:"before"`
+	ExcludeAdmins bool      `json:"exclude_admins"`
+	PageLimit     int32     `json:"page_limit"`
 }
 
 type RecentAnalyticsEventsRow struct {
@@ -269,11 +271,13 @@ type RecentAnalyticsEventsRow struct {
 // Activity-feed tail, keyset-paginated: the client passes the last row's
 // created_at back as $1 for the next page. COALESCE keeps sqlc's LEFT-JOIN
 // nullability simple; the handler decides "anonymous" from user_id being
-// NULL, never from an empty email. ORDER BY created_at DESC has no bare
-// created_at index (only the composite ones from 00026) — a top-N heap scan,
-// fine at sole-admin scale.
+// NULL, never from an empty email. When exclude_admins is true, rows from
+// admin users are dropped so the operator's own clicks don't pollute the
+// funnel/activity feed (anonymous rows survive — NULL is_admin COALESCEs to
+// false). ORDER BY created_at DESC is served by the bare created_at index
+// added in 00043.
 func (q *Queries) RecentAnalyticsEvents(ctx context.Context, arg RecentAnalyticsEventsParams) ([]RecentAnalyticsEventsRow, error) {
-	rows, err := q.db.Query(ctx, recentAnalyticsEvents, arg.Before, arg.PageLimit)
+	rows, err := q.db.Query(ctx, recentAnalyticsEvents, arg.Before, arg.ExcludeAdmins, arg.PageLimit)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Two coupled follow-ups on the admin analytics activity endpoint (#104).

## 1. `exclude_admins` filter
`RecentAnalyticsEvents` (`query/admin.sql`) returned `user_is_admin` as a column but never filtered on it — the operator's own clicks polluted the funnel and activity feed. Added an `exclude_admins` bool param:

```sql
WHERE e.created_at < sqlc.arg(before)
  AND (NOT sqlc.arg(exclude_admins)::bool OR NOT COALESCE(u.is_admin, false))
```

Threaded through sqlc (`make api-sqlc`) and the handler as `GET /admin/metrics/activity?exclude_admins=true`. Default `false` = current behavior (backward compatible); anonymous rows survive because a NULL `is_admin` COALESCEs to `false`.

## 2. `created_at` index (migration 00043)
The query's `ORDER BY created_at DESC LIMIT N` was a top-N heap scan — the composite indexes from 00026 (`event_type`/`user_id` + `created_at`) don't serve an unfiltered time-ordered scan. Migration `00043` adds a bare `analytics_events (created_at DESC)` index (idempotent, with a goose Down dropping it).

## Testing
- `make api-sqlc` clean, `make api-fmt`, `go vet ./...` clean.
- `go test ./...` passes against a fresh DB (goose-up from zero applies 00043).
- New `TestAdminActivityExcludeAdmins`: seeds admin + normal + anonymous events; asserts default returns all 3 (admin included) and `exclude_admins=true` returns 2 (admin's row omitted, `user_is_admin` never true).

🤖 Generated with [Claude Code](https://claude.com/claude-code)