### PR TITLE
feat(flutter): print & calendar export in the trip share menu

### DIFF
--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -1486,6 +1486,38 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
     }
   }
 
+  /// Mints an owner-private export token and opens the printable view (which
+  /// the browser's print dialog turns into a PDF). Export needs the network,
+  /// so it's gated on !_isOffline like the rest of the share menu.
+  Future<void> _openPrintExport() => _openExport(print: true);
+
+  /// Mints an export token and opens the calendar (.ics) download — the trip's
+  /// days as calendar events.
+  Future<void> _openCalendarExport() => _openExport(print: false);
+
+  Future<void> _openExport({required bool print}) async {
+    if (_trip == null || _isOffline) return;
+    try {
+      final service = ref.read(tripsApiServiceProvider);
+      final token = await service.mintExportToken(widget.tripId);
+      if (!mounted) return;
+      final base = service.apiClient.baseUrl;
+      final url =
+          print ? exportPrintUrl(base, token) : exportIcsUrl(base, token);
+      await trackedLaunchUrl(
+        context,
+        url,
+        provider: 'export',
+        surface: print ? 'print' : 'calendar',
+        tripId: widget.tripId,
+      );
+    } catch (e) {
+      _showSnack(print
+          ? 'Could not open the printable view: $e'
+          : 'Could not export the calendar: $e');
+    }
+  }
+
   Future<void> _revokeLink() async {
     try {
       await ref.read(tripsApiServiceProvider).revokeShareLink(widget.tripId);
@@ -3260,6 +3292,8 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
                 'copy' => _shareLink(),
                 'invite' => _inviteCoPlanner(),
                 'manage' => _manageCoPlanners(),
+                'print' => _openPrintExport(),
+                'calendar' => _openCalendarExport(),
                 _ => _revokeLink(),
               },
               itemBuilder: (context) => [
@@ -3275,6 +3309,12 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
                         : 'Copy invite link (can edit)')),
                 const PopupMenuItem(
                     value: 'manage', child: Text('Manage access')),
+                const PopupMenuDivider(),
+                const PopupMenuItem(
+                    value: 'print', child: Text('Print / Save as PDF')),
+                const PopupMenuItem(
+                    value: 'calendar', child: Text('Add to calendar')),
+                const PopupMenuDivider(),
                 const PopupMenuItem(
                     value: 'revoke', child: Text('Turn off sharing')),
               ],

--- a/src/packages/flutter-app/lib/services/trips_api_service.dart
+++ b/src/packages/flutter-app/lib/services/trips_api_service.dart
@@ -126,6 +126,21 @@ class TripsApiService {
     throw Exception('Failed to create share link (${res.statusCode})');
   }
 
+  /// Mints a short-lived, owner-private export token for a trip. The printable
+  /// and calendar (.ics) views are then reachable at the token-gated public
+  /// export routes (build the URLs with exportPrintUrl/exportIcsUrl). Owner-
+  /// only on the server: non-owners get a 404.
+  Future<String> mintExportToken(String tripId) async {
+    final res = await apiClient.httpClient.post(
+      Uri.parse('${apiClient.baseUrl}/trips/$tripId/export-token'),
+      headers: apiClient.jsonHeaders(json: true),
+    );
+    if (res.statusCode == 200 || res.statusCode == 201) {
+      return (jsonDecode(res.body) as Map<String, dynamic>)['token'] as String;
+    }
+    throw Exception('Failed to create export link (${res.statusCode})');
+  }
+
   /// Redeems an editor-role share token; returns the trip id to open.
   Future<String> joinSharedTrip(String token) async {
     final res = await apiClient.httpClient.post(

--- a/src/packages/flutter-app/lib/utils/share_link.dart
+++ b/src/packages/flutter-app/lib/utils/share_link.dart
@@ -22,6 +22,37 @@ String shareUrl(String token) {
   return '$origin${appBasePath}share/$token';
 }
 
+/// Absolute URL for a trip's token-gated print view (owner-private export).
+/// The API is same-origin behind the nginx gateway, so [apiBaseUrl] is the
+/// app's configured API base ('/api/v1' in Docker/dev-gateway, an absolute
+/// localhost URL under a bare `flutter run`). We resolve it to the current
+/// origin the same way [shareUrl] does, so the link lands on the `/api/`
+/// proxy in dev (:3000) and prod alike. NB: the API sits at `<origin>/api/v1`
+/// even when the app itself is served under [appBasePath] (`/app/` in prod),
+/// so this deliberately keys off the API base, not the app base path.
+String exportPrintUrl(String apiBaseUrl, String token) =>
+    _exportUrl(apiBaseUrl, token, 'print.html');
+
+/// Absolute URL for a trip's token-gated calendar (.ics) export. See
+/// [exportPrintUrl] for how the same-origin URL is built.
+String exportIcsUrl(String apiBaseUrl, String token) =>
+    _exportUrl(apiBaseUrl, token, 'calendar.ics');
+
+String _exportUrl(String apiBaseUrl, String token, String file) {
+  final path = '$apiBaseUrl/export/$token/$file';
+  // An absolute API base (bare `flutter run`) is already launch-ready.
+  if (path.startsWith('http://') || path.startsWith('https://')) return path;
+  // Relative base ('/api/v1', the Docker/gateway case): pin it to the origin
+  // so url_launcher receives an absolute URL.
+  String origin;
+  try {
+    origin = Uri.base.origin;
+  } catch (_) {
+    origin = '';
+  }
+  return '$origin$path';
+}
+
 /// Whether share actions present the OS share sheet (mobile) instead of a
 /// clipboard copy (web/desktop, where navigator.share support is patchy and
 /// the clipboard is the dependable UX). Drives menu labels too.

--- a/src/packages/flutter-app/test/trip_detail_export_menu_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_export_menu_test.dart
@@ -1,0 +1,185 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:url_launcher_platform_interface/link.dart' show LinkDelegate;
+import 'package:url_launcher_platform_interface/url_launcher_platform_interface.dart';
+
+import 'package:travel_route_planner/models/itinerary_item.dart';
+import 'package:travel_route_planner/models/trip.dart';
+import 'package:travel_route_planner/providers/analytics_provider.dart';
+import 'package:travel_route_planner/providers/trip_cache_provider.dart';
+import 'package:travel_route_planner/providers/trips_provider.dart';
+import 'package:travel_route_planner/screens/trip_detail_screen.dart';
+import 'package:travel_route_planner/services/analytics_api_service.dart';
+import 'package:travel_route_planner/services/api_client.dart';
+import 'package:travel_route_planner/services/trip_cache.dart';
+import 'package:travel_route_planner/services/trips_api_service.dart';
+
+/// A trips service whose getTrip returns [trip] (or throws when null), and
+/// whose mintExportToken records the call and hands back a fixed token. Its
+/// ApiClient carries a known base so the built export URL is deterministic.
+class _FakeTripsApiService extends TripsApiService {
+  final Trip? trip;
+  final Object? getError;
+  int mintCalls = 0;
+
+  _FakeTripsApiService({this.trip, this.getError})
+      : super(ApiClient(baseUrl: 'http://test/api/v1'));
+
+  @override
+  Future<Trip> getTrip(String id) =>
+      trip != null ? Future.value(trip) : Future.error(getError!);
+
+  @override
+  Future<String> mintExportToken(String tripId) {
+    mintCalls++;
+    return Future.value('tok-123');
+  }
+}
+
+/// Captures launched URLs instead of hitting a platform.
+class _FakeUrlLauncher extends UrlLauncherPlatform {
+  final launched = <String>[];
+
+  @override
+  LinkDelegate? get linkDelegate => null;
+
+  @override
+  Future<bool> canLaunch(String url) async => true;
+
+  @override
+  Future<bool> launchUrl(String url, LaunchOptions options) async {
+    launched.add(url);
+    return true;
+  }
+}
+
+/// No-op analytics so tracked_launch's fire-and-forget record never touches
+/// the network in the test env.
+class _NoopAnalytics extends AnalyticsApiService {
+  _NoopAnalytics() : super(ApiClient(baseUrl: 'http://test/api/v1'));
+
+  @override
+  Future<void> recordBookingLinkClicked({
+    String? tripId,
+    String? todoKey,
+    String? provider,
+    String? surface,
+    String? kind,
+  }) =>
+      Future.value();
+}
+
+Trip _trip({String? access}) => Trip(
+      id: 't1',
+      title: 'Athens Trip',
+      status: 'planned',
+      access: access,
+      createdAt: '2026-06-01',
+      updatedAt: '2026-06-01',
+      items: [
+        ItineraryItem(
+          id: 'i0',
+          position: 0,
+          name: 'Acropolis',
+          address: 'Athens, Greece',
+          latitude: 0,
+          longitude: 0,
+          category: 'attraction',
+        ),
+      ],
+    );
+
+Future<void> _pump(
+  WidgetTester tester,
+  _FakeTripsApiService service, {
+  TripCache? cache,
+  _FakeUrlLauncher? launcher,
+}) async {
+  if (launcher != null) UrlLauncherPlatform.instance = launcher;
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        tripsApiServiceProvider.overrideWithValue(service),
+        tripCacheProvider.overrideWithValue(cache ?? TripCache('u1')),
+        analyticsApiServiceProvider.overrideWithValue(_NoopAnalytics()),
+      ],
+      child: const MaterialApp(home: TripDetailScreen(tripId: 't1')),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  setUp(() => SharedPreferences.setMockInitialValues({}));
+
+  testWidgets('owner sees Print and Add-to-calendar in the share menu',
+      (tester) async {
+    await _pump(tester, _FakeTripsApiService(trip: _trip()));
+
+    await tester.tap(find.byTooltip('Share trip'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Print / Save as PDF'), findsOneWidget);
+    expect(find.text('Add to calendar'), findsOneWidget);
+  });
+
+  testWidgets('tapping Print mints a token then launches the print URL',
+      (tester) async {
+    final service = _FakeTripsApiService(trip: _trip());
+    final launcher = _FakeUrlLauncher();
+    await _pump(tester, service, launcher: launcher);
+
+    await tester.tap(find.byTooltip('Share trip'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Print / Save as PDF'));
+    await tester.pumpAndSettle();
+
+    expect(service.mintCalls, 1);
+    expect(launcher.launched,
+        ['http://test/api/v1/export/tok-123/print.html']);
+  });
+
+  testWidgets('tapping Add-to-calendar launches the .ics URL',
+      (tester) async {
+    final service = _FakeTripsApiService(trip: _trip());
+    final launcher = _FakeUrlLauncher();
+    await _pump(tester, service, launcher: launcher);
+
+    await tester.tap(find.byTooltip('Share trip'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Add to calendar'));
+    await tester.pumpAndSettle();
+
+    expect(service.mintCalls, 1);
+    expect(launcher.launched,
+        ['http://test/api/v1/export/tok-123/calendar.ics']);
+  });
+
+  testWidgets('a non-owner (viewer) never sees the share menu or exports',
+      (tester) async {
+    await _pump(tester, _FakeTripsApiService(trip: _trip(access: 'viewer')));
+
+    expect(find.byTooltip('Share trip'), findsNothing);
+    expect(find.text('Print / Save as PDF'), findsNothing);
+    expect(find.text('Add to calendar'), findsNothing);
+  });
+
+  testWidgets('offline hides the share menu (export needs the network)',
+      (tester) async {
+    final cache = TripCache('u1');
+    await cache.writeTrip(_trip());
+    // getTrip fails with a cached copy present => offline read-only mode.
+    await _pump(
+      tester,
+      _FakeTripsApiService(getError: http.ClientException('offline')),
+      cache: cache,
+    );
+
+    expect(find.text('Acropolis'), findsOneWidget); // cached copy renders
+    expect(find.byTooltip('Share trip'), findsNothing);
+    expect(find.text('Print / Save as PDF'), findsNothing);
+  });
+}


### PR DESCRIPTION
## What

Wires the #142 export backend into the trip UI. Adds two items to the existing owner-only share menu on `TripDetailScreen`:

- **Print / Save as PDF** → opens the token-gated `print.html` (the browser's print dialog turns it into a PDF)
- **Add to calendar** → opens the token-gated `calendar.ics`

On tap each mints a short-lived, owner-private export token (`POST /trips/{id}/export-token`) then launches the URL via `trackedLaunchUrl` so the click is instrumented (`provider: export`, `surface: print`/`calendar`). Mint/offline failures surface a friendly snackbar. The whole share menu is already gated on `trip.isOwner && !_isOffline`, so the exports inherit owner-only + online gating for free.

## URL building (dev + prod)

`mintExportToken` returns the token; `exportPrintUrl` / `exportIcsUrl` (in `share_link.dart`) build the absolute URL from the app's configured **API base**, resolved against the current origin exactly like `shareUrl`:

- **prod**: API base `/api/v1` → `<origin>/api/v1/export/<token>/print.html`
- **dev gateway (:3000)**: API base `/api/v1` → `<origin>/api/v1/...` (nginx `/api/` proxy)
- **bare `flutter run`**: API base `http://localhost:8080/api/v1` (already absolute) → used as-is

Note: this deliberately keys off the **API base**, not `appBasePath`. In prod the app is served under `/app/` but the API stays at `<origin>/api/v1` (nginx `location /api/`), so `<origin><basePath>api/v1/...` would have been wrong.

## Files

- `lib/utils/share_link.dart` — `exportPrintUrl` / `exportIcsUrl` (+ private `_exportUrl`) helpers
- `lib/services/trips_api_service.dart` — `mintExportToken(tripId)`
- `lib/screens/trip_detail_screen.dart` — `_openPrintExport` / `_openCalendarExport` handlers + two `PopupMenuItem`s (with dividers) in the share menu
- `test/trip_detail_export_menu_test.dart` — new widget test

## Tests

- New widget test (5 cases): owner sees both items; tapping Print mints then launches the print URL; tapping Add-to-calendar launches the .ics URL; non-owner never sees the menu; offline hides the menu.
- Full suite: **318 passed**. Regressions `trip_detail_sticky_headers_test.dart` + `trip_detail_today_test.dart` pass unmodified.
- `flutter analyze --no-fatal-infos --fatal-warnings`: exit 0 (12 baseline infos, none added).

🤖 Generated with [Claude Code](https://claude.com/claude-code)