### PR TITLE
fix: baggage-dedup keeps cheaper effective fare; weather leap-day chip

### DIFF
--- a/src/packages/api/flight_baggage.go
+++ b/src/packages/api/flight_baggage.go
@@ -59,8 +59,11 @@ func searchFlightsWithBaggage(ctx context.Context, d *DuffelService, req FlightS
 	// Preliminary rank to decide which offers earn a fee lookup: the K best
 	// candidates that still lack the bag. Unknown-fee offers score on the
 	// bare fare here, which is exactly the "looks cheapest" list the traveler
-	// would otherwise be misled by.
-	offers = RankFlightOffers(offers, req.OptimizeFor)
+	// would otherwise be misled by. collapseUnknown=false keeps every
+	// bag-exclusive fare of a schedule distinct so the effective-cheaper one
+	// isn't dropped by bare-fare dedup before it can be fee-priced; the final
+	// RankFlightOffers below collapses the priced results on effective price.
+	offers = rankFlightOffers(offers, req.OptimizeFor, false)
 	lookup := make([]int, 0, bagFeeTopK)
 	for i := range offers {
 		if len(lookup) >= bagFeeTopK {

--- a/src/packages/api/flight_baggage_test.go
+++ b/src/packages/api/flight_baggage_test.go
@@ -301,6 +301,75 @@ func TestSearchWithBaggageEffectivePriceRanking(t *testing.T) {
 	}
 }
 
+func TestSearchWithBaggageKeepsEffectiveCheaperOnSharedSchedule(t *testing.T) {
+	// Two bag-exclusive fares on ONE schedule with inverted effective totals:
+	//   P: fare 100 + 80 checked-bag fee = 180 effective
+	//   Q: fare 130 + 20 checked-bag fee = 150 effective
+	// The old preliminary dedup collapsed both to a single "|bag:0" key and kept
+	// P (cheaper BARE fare), so Q never earned a fee lookup and the search
+	// reported 180 when 150 existed. Both must now survive to fee pricing and the
+	// effective-cheaper Q must be the schedule's survivor.
+	depart := "2026-09-01T08:00:00"
+	bs := &baggageStub{
+		searchBody: searchBody(
+			bagSearchOffer("off_p", "100.00", depart, ""),
+			bagSearchOffer("off_q", "130.00", depart, ""),
+		),
+		serviceBody: map[string]string{
+			"off_p": servicesBody(checkedBagService("s1", "80.00", "USD", 3, []string{"seg_1"}, []string{"pas_1"})),
+			"off_q": servicesBody(checkedBagService("s1", "20.00", "USD", 3, []string{"seg_1"}, []string{"pas_1"})),
+		},
+	}
+	d := newBaggageStubService(t, bs)
+
+	offers, err := searchFlightsWithBaggage(context.Background(), d, FlightSearchRequest{
+		Origin: "AAA", Destination: "BBB", DepartDate: "2026-09-01", Adults: 1,
+		Baggage: baggageChecked, OptimizeFor: "cost",
+	})
+	if err != nil {
+		t.Fatalf("searchFlightsWithBaggage: %v", err)
+	}
+	// Both bag-exclusive fares must be fee-priced (neither dropped pre-lookup).
+	if bs.getCount() != 2 {
+		t.Fatalf("offer GETs = %v, want both off_p and off_q priced", bs.gets)
+	}
+	// The shared schedule collapses to exactly one survivor: the cheaper effective.
+	if len(offers) != 1 {
+		t.Fatalf("offers = %d, want 1 (shared schedule collapsed on effective price)", len(offers))
+	}
+	if offers[0].ID != "off_q" || offers[0].EffectivePrice != 150 {
+		t.Fatalf("survivor = %s @ %v, want off_q @ 150 (not off_p @ 180)", offers[0].ID, offers[0].EffectivePrice)
+	}
+	best, ok := lowestOffer(offers)
+	if !ok || best.EffectivePrice != 150 {
+		t.Fatalf("lowestOffer = %+v ok=%v, want effective 150 not 180", best, ok)
+	}
+}
+
+func TestSearchNoBaggageSharedScheduleStillCollapses(t *testing.T) {
+	// Regression: with no baggage tier requested, same-schedule offers still
+	// collapse to the cheapest bare fare and no fee lookups happen at all.
+	depart := "2026-09-01T08:00:00"
+	bs := &baggageStub{searchBody: searchBody(
+		bagSearchOffer("cheap", "100.00", depart, ""),
+		bagSearchOffer("dear", "130.00", depart, ""),
+	)}
+	d := newBaggageStubService(t, bs)
+
+	offers, err := searchFlightsWithBaggage(context.Background(), d, FlightSearchRequest{
+		Origin: "AAA", Destination: "BBB", DepartDate: "2026-09-01", Adults: 1,
+	})
+	if err != nil {
+		t.Fatalf("searchFlightsWithBaggage: %v", err)
+	}
+	if bs.getCount() != 0 {
+		t.Fatalf("no-baggage search made %d fee lookups, want 0", bs.getCount())
+	}
+	if len(offers) != 1 || offers[0].ID != "cheap" {
+		t.Fatalf("no-baggage dedup changed: %+v", offers)
+	}
+}
+
 func TestSearchWithBaggageUnknownDegradesAndSinks(t *testing.T) {
 	bs := &baggageStub{
 		searchBody: searchBody(

--- a/src/packages/api/flight_optimizer.go
+++ b/src/packages/api/flight_optimizer.go
@@ -3,6 +3,7 @@ package main
 import (
 	"math"
 	"sort"
+	"strconv"
 	"strings"
 )
 
@@ -125,21 +126,48 @@ func scheduleSignature(o FlightOffer) string {
 	return strings.Join(parts, "|")
 }
 
+// preferOffer reports whether candidate should replace current as the survivor
+// when two offers collapse onto the same schedule key. A priced offer (included
+// or fee-priced) always beats an unknown-fee one regardless of bare fare: an
+// unknown fare is unpriceable, so it must never hide a schedule's real price.
+// Among offers of the same known-ness, the lower scoring (effective) price wins.
+func preferOffer(cand, cur FlightOffer) bool {
+	cu := cand.BaggageStatus == baggageStatusUnknown
+	ru := cur.BaggageStatus == baggageStatusUnknown
+	if cu != ru {
+		return ru // replace only when the incumbent is the unknown one
+	}
+	return scoringPrice(cand) < scoringPrice(cur)
+}
+
 // dedupBySchedule collapses offers that share an identical schedule, keeping the
-// lowest-priced offer for each. Order of first appearance is preserved so the
-// result is stable before ranking. Offers without segments fall back to a
-// signature of their top-level depart/arrive times so they are never dropped.
-func dedupBySchedule(offers []FlightOffer) []FlightOffer {
+// preferred offer for each (see preferOffer). Order of first appearance is
+// preserved so the result is stable before ranking. Offers without segments
+// fall back to a signature of their top-level depart/arrive times so they are
+// never dropped.
+//
+// collapseUnknown governs bag-exclusive (unknown-fee) offers. On the FINAL rank
+// it is true: leftover unknown variants of a schedule collapse to one (and lose
+// to any priced offer on that schedule). On the PRELIMINARY baggage rank it is
+// false: two same-schedule bag-exclusive fares can have inverted effective
+// (fare+bag) totals, so collapsing by bare fare would drop the effective-cheaper
+// one before it ever earns a fee lookup. Keeping each unknown offer under its
+// own key lets them all survive to fee pricing; the final rank then collapses
+// the priced results on true effective price.
+func dedupBySchedule(offers []FlightOffer, collapseUnknown bool) []FlightOffer {
 	best := make(map[string]int, len(offers)) // signature -> index in result
 	result := make([]FlightOffer, 0, len(offers))
-	for _, o := range offers {
+	for i, o := range offers {
 		sig := scheduleSignature(o)
 		if sig == "" {
 			sig = o.DepartTime + "-" + o.ArriveTime
 		}
 		sig += bagKey(o)
+		if !collapseUnknown && o.BaggageStatus == baggageStatusUnknown {
+			sig += "|u:" + strconv.Itoa(i) // each unknown fare stays distinct
+		}
 		if idx, ok := best[sig]; ok {
-			if scoringPrice(o) < scoringPrice(result[idx]) {
+			if preferOffer(o, result[idx]) {
 				result[idx] = o
 			}
 			continue
@@ -159,11 +187,19 @@ func dedupBySchedule(offers []FlightOffer) []FlightOffer {
 // per-slice fields are unchanged; see scoringDuration/scoringStops.
 // The *_score and Score fields on each offer are populated in place.
 func RankFlightOffers(offers []FlightOffer, optimizeFor string) []FlightOffer {
+	return rankFlightOffers(offers, optimizeFor, true)
+}
+
+// rankFlightOffers is RankFlightOffers with an explicit collapseUnknown flag.
+// The exported wrapper collapses unknowns (the final/default behavior); the
+// preliminary baggage rank passes false so all bag-exclusive variants of a
+// schedule survive to earn a fee lookup (see dedupBySchedule).
+func rankFlightOffers(offers []FlightOffer, optimizeFor string, collapseUnknown bool) []FlightOffer {
 	if len(offers) == 0 {
 		return offers
 	}
 
-	offers = dedupBySchedule(offers)
+	offers = dedupBySchedule(offers, collapseUnknown)
 
 	w := flightPresets[normalizeOptimizeFor(optimizeFor)]
 

--- a/src/packages/api/flight_optimizer_test.go
+++ b/src/packages/api/flight_optimizer_test.go
@@ -72,7 +72,7 @@ func TestDedupCollapsesSameRouteDifferentLayoverTiming(t *testing.T) {
 		twoStop("b", 390, "OPO", "LIS", "2026-07-16T18:00:00", "2026-07-16T19:05:00"),
 		twoStop("c", 390, "OPO", "LIS", "2026-07-16T16:00:00", "2026-07-16T17:00:00"),
 	}
-	got := dedupBySchedule(in)
+	got := dedupBySchedule(in, true)
 	if len(got) != 1 {
 		t.Fatalf("expected same-route/different-layover offers to collapse to 1, got %d", len(got))
 	}
@@ -85,7 +85,7 @@ func TestDedupKeepsDifferentConnectingAirports(t *testing.T) {
 		twoStop("via-opo", 390, "OPO", "LIS", "2026-07-16T12:35:00", "2026-07-16T13:25:00"),
 		twoStop("via-mad", 390, "MAD", "LIS", "2026-07-16T12:35:00", "2026-07-16T13:25:00"),
 	}
-	got := dedupBySchedule(in)
+	got := dedupBySchedule(in, true)
 	if len(got) != 2 {
 		t.Fatalf("expected different-hub itineraries to stay separate, got %d", len(got))
 	}
@@ -97,7 +97,7 @@ func TestDedupBySchedulePreservesOrderAndKeepsCheapest(t *testing.T) {
 		offer("b-other", 300, "JFK", "ORY", "T3", "T4", 500, 1),
 		offer("a-cheap", 250, "JFK", "CDG", "T1", "T2", 480, 0),
 	}
-	got := dedupBySchedule(in)
+	got := dedupBySchedule(in, true)
 	if len(got) != 2 {
 		t.Fatalf("expected 2 schedules, got %d", len(got))
 	}
@@ -134,7 +134,7 @@ func TestDedupKeepsSameOutboundDifferentReturns(t *testing.T) {
 	a := roundTrip("fast-return", 600, "JFK", "CDG", "T1", "T2", 420, 0, 480, 1)
 	b := roundTrip("slow-return", 550, "JFK", "CDG", "T1", "T2", 420, 0, 1200, 2)
 
-	got := dedupBySchedule([]FlightOffer{a, b})
+	got := dedupBySchedule([]FlightOffer{a, b}, true)
 	if len(got) != 2 {
 		t.Fatalf("dedup collapsed distinct return slices: kept %d offers, want 2", len(got))
 	}

--- a/src/packages/flutter-app/lib/models/weather.dart
+++ b/src/packages/flutter-app/lib/models/weather.dart
@@ -57,11 +57,39 @@ class WeatherReport {
 
   /// The day matching [monthDay] ("MM-DD"), or null when the report has no
   /// entry for that date (undated day, out of the fetched window).
+  ///
+  /// Leap-day fallback: a historical report is keyed off last year's dates, and
+  /// a Feb 29 trip day rolls to the prior (non-leap) year's Mar 1 server-side,
+  /// so the archive holds no "02-29" and an exact match would leave that one day
+  /// with no chip. When the exact key is absent we borrow the nearest adjacent
+  /// calendar day's typical weather (02-29 -> 02-28, then 03-01). The fallback
+  /// only fires when there's no exact entry, so ordinary days are unaffected.
   WeatherDay? dayFor(String monthDay) {
     for (final d in days) {
       if (d.monthDayKey == monthDay) return d;
     }
+    for (final adjacent in _adjacentMonthDays(monthDay)) {
+      for (final d in days) {
+        if (d.monthDayKey == adjacent) return d;
+      }
+    }
     return null;
+  }
+
+  /// Previous- then next-calendar-day "MM-DD" keys for [monthDay], parsed in a
+  /// leap year so "02-29" is valid. Empty when [monthDay] isn't a valid MM-DD.
+  static List<String> _adjacentMonthDays(String monthDay) {
+    if (monthDay.length != 5) return const [];
+    final month = int.tryParse(monthDay.substring(0, 2));
+    final day = int.tryParse(monthDay.substring(3, 5));
+    if (month == null || day == null) return const [];
+    final base = DateTime(2024, month, day); // leap year: 02-29 is valid
+    String key(DateTime d) => '${d.month.toString().padLeft(2, '0')}-'
+        '${d.day.toString().padLeft(2, '0')}';
+    return [
+      key(base.subtract(const Duration(days: 1))),
+      key(base.add(const Duration(days: 1))),
+    ];
   }
 
   factory WeatherReport.fromJson(Map<String, dynamic> json) =>

--- a/src/packages/flutter-app/test/trip_detail_weather_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_weather_test.dart
@@ -133,6 +133,39 @@ void main() {
     expect(find.textContaining('% rain'), findsNothing);
   });
 
+  test('dayFor falls back to the nearest adjacent day for a missing 02-29',
+      () {
+    // A historical archive keyed off last year has no 02-29 (the leap day rolls
+    // to the prior non-leap year's Mar 1 server-side). dayFor should borrow the
+    // adjacent 02-28 entry so Feb 29 still renders a chip.
+    final report = WeatherReport(
+      kind: 'historical',
+      days: [
+        WeatherDay(date: '2025-02-28', tempMinC: 3, tempMaxC: 9),
+        WeatherDay(date: '2025-03-01', tempMinC: 4, tempMaxC: 10),
+      ],
+    );
+    final resolved = report.dayFor('02-29');
+    expect(resolved, isNotNull);
+    expect(resolved!.date, '2025-02-28'); // previous day preferred over 03-01
+  });
+
+  test('dayFor uses the next day when the previous is also absent', () {
+    final report = WeatherReport(
+      kind: 'historical',
+      days: [WeatherDay(date: '2025-03-01', tempMinC: 4, tempMaxC: 10)],
+    );
+    expect(report.dayFor('02-29')?.date, '2025-03-01');
+  });
+
+  test('dayFor still returns null when no adjacent day exists either', () {
+    final report = WeatherReport(
+      kind: 'historical',
+      days: [WeatherDay(date: '2025-07-04', tempMinC: 18, tempMaxC: 28)],
+    );
+    expect(report.dayFor('02-29'), isNull);
+  });
+
   testWidgets('an undated trip renders no weather chip', (tester) async {
     final undated = Trip(
       id: 't1',


### PR DESCRIPTION
Two findings from the Wave-15 adversarial review, both adversarially verified as REAL (not refuted).

## 1. Baggage dedup discarded the cheaper EFFECTIVE fare (minor, money)

On a baggage-aware search, the **preliminary** `RankFlightOffers` (`flight_baggage.go`) runs *before* bag fees are fetched. Unknown-fee offers have `EffectivePrice=0`, so `scoringPrice` returns the **bare** fare and `bagKey` maps every bag-exclusive fare to `|bag:0`. Two same-schedule bag-exclusive fares therefore shared a dedup key and the one with the lower **bare** fare was kept — even if it had a higher **effective** (fare + bag) price. The dropped fare never earned a `GetOfferBagFee` lookup, so `lowestOffer` / `/flights/search` / the agent could report a pricier "lowest" than truly available.

Concrete: schedule S has P (fare 100, checked fee 80 -> effective 180) and Q (fare 130, fee 20 -> effective 150). Old dedup kept P (cheaper bare), dropped Q, and reported **180** when **150** existed.

**Fix (approach a):** the preliminary rank now dedups with `collapseUnknown=false`, keeping every bag-exclusive variant of a schedule distinct so each survives to be fee-priced. The **final** `RankFlightOffers` then collapses the priced results on true effective price. Additionally, dedup collapse now prefers a priced offer over an unknown-fee one, so a leftover un-priced unknown can never hide a schedule's real price.

**Top-K bound stays intact:** the `bagFeeTopK`=10 cap still applies to the post-dedup set — the lookup loop picks at most K bag-exclusive offers regardless of how many variants survive, so the fee-fetch fan-out is unchanged. (`TestSearchWithBaggageTopKBudget` still passes.)

## 2. Feb 29 lost its weather chip on historical trips (minor, ui)

The archive is keyed off last year's dates; a leap-day trip's Feb 29 rolls to the prior (non-leap) year's Mar 1 server-side, so `WeatherReport.dayFor('02-29')` (MM-DD match) found nothing and that day rendered with no chip. `dayFor` now falls back to the **nearest adjacent** calendar day when the exact MM-DD is absent (02-29 -> 02-28, then 03-01). The fallback fires only when there's no exact entry, so ordinary days are untouched. Client-side only — no API change.

## Tests
- `TestSearchWithBaggageKeepsEffectiveCheaperOnSharedSchedule`: the P/Q scenario end-to-end — both fares get fee-priced, the effective-cheaper Q@150 is the surviving offer, `lowestOffer` reports 150 not 180.
- `TestSearchNoBaggageSharedScheduleStillCollapses`: one-way no-baggage regression — same-schedule offers still collapse to cheapest bare, zero fee lookups.
- `weather.dart` `dayFor` unit tests: 02-29 resolves to the 02-28 entry (previous preferred), falls through to 03-01 when 02-28 is absent, and returns null when neither adjacent day exists.
- Existing flight-baggage + weather suites unchanged and green; `flutter analyze` exit 0 (12 baseline infos, none added).

Provenance: Wave-15 adversarial review, confirmed findings A-fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)