### PR TITLE
feat(flutter): per-trip budget & expense section

### DIFF
--- a/src/packages/flutter-app/lib/models/budget.dart
+++ b/src/packages/flutter-app/lib/models/budget.dart
@@ -1,0 +1,27 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'budget.g.dart';
+
+/// The single per-trip budget: one [targetAmount] target in one [currency]
+/// (default USD — there is no trip-level currency to inherit) plus server-derived
+/// [spent] (sum of every expense) and [remaining] (target − spent, null when no
+/// target is set). All expenses are assumed to be in [currency] — there is no
+/// cross-currency summing or FX.
+@JsonSerializable()
+class Budget {
+  @JsonKey(name: 'target_amount')
+  final double? targetAmount;
+  final String currency;
+  final double spent;
+  final double? remaining;
+
+  const Budget({
+    this.targetAmount,
+    this.currency = 'USD',
+    this.spent = 0,
+    this.remaining,
+  });
+
+  factory Budget.fromJson(Map<String, dynamic> json) => _$BudgetFromJson(json);
+  Map<String, dynamic> toJson() => _$BudgetToJson(this);
+}

--- a/src/packages/flutter-app/lib/models/budget.g.dart
+++ b/src/packages/flutter-app/lib/models/budget.g.dart
@@ -1,0 +1,21 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'budget.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+Budget _$BudgetFromJson(Map<String, dynamic> json) => Budget(
+      targetAmount: (json['target_amount'] as num?)?.toDouble(),
+      currency: json['currency'] as String? ?? 'USD',
+      spent: (json['spent'] as num?)?.toDouble() ?? 0,
+      remaining: (json['remaining'] as num?)?.toDouble(),
+    );
+
+Map<String, dynamic> _$BudgetToJson(Budget instance) => <String, dynamic>{
+      'target_amount': instance.targetAmount,
+      'currency': instance.currency,
+      'spent': instance.spent,
+      'remaining': instance.remaining,
+    };

--- a/src/packages/flutter-app/lib/models/expense.dart
+++ b/src/packages/flutter-app/lib/models/expense.dart
@@ -1,0 +1,40 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'expense.g.dart';
+
+/// One manual expense line-item on a trip's budget. [category] is a tag from the
+/// backend's bounded set (flights | lodging | food | activities | transport |
+/// shopping | general), used only for client-side subtotals — there are no
+/// per-category targets. [amount] is assumed to be in the budget's currency.
+/// [auto] marks a row as AI-seeded (parallels [ChecklistItem.auto]).
+@JsonSerializable()
+class Expense {
+  final String id;
+  final String category;
+  final String label;
+  final double amount;
+  final int position;
+  final bool auto;
+
+  const Expense({
+    required this.id,
+    required this.category,
+    required this.label,
+    required this.amount,
+    this.position = 0,
+    this.auto = false,
+  });
+
+  Expense copyWith({String? category, String? label, double? amount}) => Expense(
+        id: id,
+        category: category ?? this.category,
+        label: label ?? this.label,
+        amount: amount ?? this.amount,
+        position: position,
+        auto: auto,
+      );
+
+  factory Expense.fromJson(Map<String, dynamic> json) =>
+      _$ExpenseFromJson(json);
+  Map<String, dynamic> toJson() => _$ExpenseToJson(this);
+}

--- a/src/packages/flutter-app/lib/models/expense.g.dart
+++ b/src/packages/flutter-app/lib/models/expense.g.dart
@@ -1,0 +1,25 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'expense.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+Expense _$ExpenseFromJson(Map<String, dynamic> json) => Expense(
+      id: json['id'] as String,
+      category: json['category'] as String,
+      label: json['label'] as String,
+      amount: (json['amount'] as num).toDouble(),
+      position: (json['position'] as num?)?.toInt() ?? 0,
+      auto: json['auto'] as bool? ?? false,
+    );
+
+Map<String, dynamic> _$ExpenseToJson(Expense instance) => <String, dynamic>{
+      'id': instance.id,
+      'category': instance.category,
+      'label': instance.label,
+      'amount': instance.amount,
+      'position': instance.position,
+      'auto': instance.auto,
+    };

--- a/src/packages/flutter-app/lib/providers/budget_provider.dart
+++ b/src/packages/flutter-app/lib/providers/budget_provider.dart
@@ -1,0 +1,24 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../models/budget.dart';
+import '../models/expense.dart';
+import '../services/budget_api_service.dart';
+import 'api_client_provider.dart';
+
+final budgetApiServiceProvider = Provider<BudgetApiService>((ref) {
+  return BudgetApiService(ref.watch(apiClientProvider));
+});
+
+/// A trip's budget (target + currency + derived spent/remaining), keyed by trip
+/// id. Mutations invalidate this provider to refetch. `.when(skipLoadingOnReload)`
+/// (the default) keeps the current values on screen during the refresh.
+final budgetProvider =
+    FutureProvider.family<Budget, String>((ref, tripId) async {
+  return ref.watch(budgetApiServiceProvider).getBudget(tripId);
+});
+
+/// A trip's expense line-items, keyed by trip id. Invalidated alongside
+/// [budgetProvider] on every mutation.
+final expensesProvider =
+    FutureProvider.family<List<Expense>, String>((ref, tripId) async {
+  return ref.watch(budgetApiServiceProvider).listExpenses(tripId);
+});

--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -42,6 +42,7 @@ import '../widgets/add_itinerary_item_dialog.dart';
 import '../widgets/add_to_trip_sheet.dart';
 import '../widgets/booking_todo_card.dart';
 import '../widgets/bookings_section.dart';
+import '../widgets/budget_section.dart';
 import '../widgets/checklist_section.dart';
 import '../widgets/empty_state.dart';
 import '../widgets/event_card.dart';
@@ -3827,6 +3828,19 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
                             padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
                             sliver: SliverToBoxAdapter(
                               child: ChecklistSection(
+                                tripId: trip.id,
+                                canEdit: !_readOnly,
+                                isOffline: _isOffline,
+                              ),
+                            ),
+                          ),
+                          // Budget & expenses: a self-contained per-trip budget
+                          // tracker (own endpoint/provider, not part of the trip
+                          // payload) — a trailing peer section beside Packing.
+                          SliverPadding(
+                            padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+                            sliver: SliverToBoxAdapter(
+                              child: BudgetSection(
                                 tripId: trip.id,
                                 canEdit: !_readOnly,
                                 isOffline: _isOffline,

--- a/src/packages/flutter-app/lib/services/budget_api_service.dart
+++ b/src/packages/flutter-app/lib/services/budget_api_service.dart
@@ -1,0 +1,94 @@
+import 'dart:convert';
+import '../models/budget.dart';
+import '../models/expense.dart';
+import 'api_client.dart';
+
+/// Wraps the per-trip budget & expense endpoints (`/trips/{id}/budget` and
+/// `/trips/{id}/budget/expenses`). Mirrors [ChecklistApiService] conventions.
+class BudgetApiService {
+  final ApiClient apiClient;
+
+  BudgetApiService(this.apiClient);
+
+  List<Expense> _parseList(String body) {
+    final list = jsonDecode(body) as List<dynamic>;
+    return list
+        .map((e) => Expense.fromJson(e as Map<String, dynamic>))
+        .toList();
+  }
+
+  Future<Budget> getBudget(String tripId) async {
+    final res = await apiClient.httpClient.get(
+      Uri.parse('${apiClient.baseUrl}/trips/$tripId/budget'),
+      headers: apiClient.jsonHeaders(),
+    );
+    if (res.statusCode == 200) return Budget.fromJson(jsonDecode(res.body));
+    throw Exception('Failed to load budget (${res.statusCode})');
+  }
+
+  /// Upsert the single per-trip target + currency (PUT). A null [targetAmount]
+  /// clears the target (tracking spend only); [currency] defaults to USD.
+  Future<Budget> upsertBudget(String tripId,
+      {double? targetAmount, String currency = 'USD'}) async {
+    final res = await apiClient.httpClient.put(
+      Uri.parse('${apiClient.baseUrl}/trips/$tripId/budget'),
+      headers: apiClient.jsonHeaders(json: true),
+      body: jsonEncode({'target_amount': targetAmount, 'currency': currency}),
+    );
+    if (res.statusCode == 200) return Budget.fromJson(jsonDecode(res.body));
+    throw Exception('Failed to save budget (${res.statusCode})');
+  }
+
+  Future<List<Expense>> listExpenses(String tripId) async {
+    final res = await apiClient.httpClient.get(
+      Uri.parse('${apiClient.baseUrl}/trips/$tripId/budget/expenses'),
+      headers: apiClient.jsonHeaders(),
+    );
+    if (res.statusCode == 200) return _parseList(res.body);
+    throw Exception('Failed to load expenses (${res.statusCode})');
+  }
+
+  Future<Expense> addExpense(String tripId,
+      {required String category,
+      required String label,
+      required double amount}) async {
+    final res = await apiClient.httpClient.post(
+      Uri.parse('${apiClient.baseUrl}/trips/$tripId/budget/expenses'),
+      headers: apiClient.jsonHeaders(json: true),
+      body: jsonEncode({
+        'category': category,
+        'label': label,
+        'amount': amount,
+      }),
+    );
+    if (res.statusCode == 201) {
+      return Expense.fromJson(jsonDecode(res.body));
+    }
+    throw Exception('Failed to add expense (${res.statusCode})');
+  }
+
+  /// Partial update — pass only the fields to change (category / label / amount
+  /// / position).
+  Future<Expense> updateExpense(
+      String tripId, String expenseId, Map<String, dynamic> body) async {
+    final res = await apiClient.httpClient.patch(
+      Uri.parse('${apiClient.baseUrl}/trips/$tripId/budget/expenses/$expenseId'),
+      headers: apiClient.jsonHeaders(json: true),
+      body: jsonEncode(body),
+    );
+    if (res.statusCode == 200) {
+      return Expense.fromJson(jsonDecode(res.body));
+    }
+    throw Exception('Failed to update expense (${res.statusCode})');
+  }
+
+  Future<void> deleteExpense(String tripId, String expenseId) async {
+    final res = await apiClient.httpClient.delete(
+      Uri.parse('${apiClient.baseUrl}/trips/$tripId/budget/expenses/$expenseId'),
+      headers: apiClient.jsonHeaders(),
+    );
+    if (res.statusCode != 204) {
+      throw Exception('Failed to delete expense (${res.statusCode})');
+    }
+  }
+}

--- a/src/packages/flutter-app/lib/widgets/budget_section.dart
+++ b/src/packages/flutter-app/lib/widgets/budget_section.dart
@@ -1,0 +1,584 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../models/budget.dart';
+import '../models/expense.dart';
+import '../providers/budget_provider.dart';
+import '../theme/spacing.dart';
+import '../utils/money_format.dart';
+import 'empty_state.dart';
+import 'section_header.dart';
+import 'status_pill.dart';
+
+/// The trip-detail "Budget" section: a single per-trip budget (one target in one
+/// currency) plus a flat list of manual expense line-items grouped by category
+/// with per-category subtotals, a running total, and a remaining footer.
+/// Self-contained — it owns its data via [budgetProvider] + [expensesProvider]
+/// and reconciles mutations by invalidating both family keys. Mirrors
+/// [ChecklistSection] structure.
+class BudgetSection extends ConsumerStatefulWidget {
+  final String tripId;
+  final bool canEdit;
+  final bool isOffline;
+
+  const BudgetSection({
+    super.key,
+    required this.tripId,
+    required this.canEdit,
+    required this.isOffline,
+  });
+
+  @override
+  ConsumerState<BudgetSection> createState() => _BudgetSectionState();
+}
+
+// Display order + labels for the category groups. The server bounds category to
+// this exact set (default "general"); anything unexpected falls under "General".
+const List<String> _categoryOrder = [
+  'flights',
+  'lodging',
+  'food',
+  'activities',
+  'transport',
+  'shopping',
+  'general',
+];
+
+const Map<String, String> _categoryLabels = {
+  'flights': 'Flights',
+  'lodging': 'Lodging',
+  'food': 'Food',
+  'activities': 'Activities',
+  'transport': 'Transport',
+  'shopping': 'Shopping',
+  'general': 'General',
+};
+
+const Map<String, IconData> _categoryIcons = {
+  'flights': Icons.flight_outlined,
+  'lodging': Icons.hotel_outlined,
+  'food': Icons.restaurant_outlined,
+  'activities': Icons.local_activity_outlined,
+  'transport': Icons.directions_bus_outlined,
+  'shopping': Icons.shopping_bag_outlined,
+  'general': Icons.receipt_long_outlined,
+};
+
+// The currency codes formatMoney knows a symbol for — offered in the target
+// dialog's dropdown. USD is the default.
+const List<String> _currencyCodes = [
+  'USD',
+  'EUR',
+  'GBP',
+  'JPY',
+  'CNY',
+  'AUD',
+  'CAD',
+  'NZD',
+  'HKD',
+  'SGD',
+  'MXN',
+  'BRL',
+  'INR',
+  'KRW',
+  'THB',
+  'TRY',
+];
+
+String _normalizeCategory(String raw) {
+  final c = raw.trim().toLowerCase();
+  return _categoryLabels.containsKey(c) ? c : 'general';
+}
+
+class _BudgetSectionState extends ConsumerState<BudgetSection> {
+  final TextEditingController _labelController = TextEditingController();
+  final TextEditingController _amountController = TextEditingController();
+  String _addCategory = 'general';
+  bool _busy = false;
+
+  @override
+  void dispose() {
+    _labelController.dispose();
+    _amountController.dispose();
+    super.dispose();
+  }
+
+  bool _guard() {
+    if (widget.isOffline) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+            content: Text("You're offline — reconnect to make changes.")),
+      );
+      return true;
+    }
+    return false;
+  }
+
+  Future<void> _run(Future<void> Function() op) async {
+    if (_guard() || _busy) return;
+    setState(() => _busy = true);
+    try {
+      await op();
+      ref.invalidate(budgetProvider(widget.tripId));
+      ref.invalidate(expensesProvider(widget.tripId));
+    } catch (_) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Something went wrong. Try again.')),
+        );
+      }
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+
+  void _delete(Expense expense) => _run(() => ref
+      .read(budgetApiServiceProvider)
+      .deleteExpense(widget.tripId, expense.id));
+
+  void _add() {
+    final label = _labelController.text.trim();
+    final amount = double.tryParse(_amountController.text.trim());
+    if (label.isEmpty || amount == null || amount < 0) return;
+    _run(() async {
+      await ref.read(budgetApiServiceProvider).addExpense(
+            widget.tripId,
+            category: _addCategory,
+            label: label,
+            amount: amount,
+          );
+      _labelController.clear();
+      _amountController.clear();
+    });
+  }
+
+  Future<void> _editExpense(Expense expense) async {
+    if (_guard()) return;
+    final labelController = TextEditingController(text: expense.label);
+    final amountController =
+        TextEditingController(text: _trimAmount(expense.amount));
+    var category = _normalizeCategory(expense.category);
+    final result = await showDialog<Map<String, dynamic>>(
+      context: context,
+      builder: (ctx) => StatefulBuilder(
+        builder: (ctx, setLocal) => AlertDialog(
+          title: const Text('Edit expense'),
+          content: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              DropdownButtonFormField<String>(
+                initialValue: category,
+                decoration: const InputDecoration(labelText: 'Category'),
+                onChanged: (v) => setLocal(() => category = v ?? 'general'),
+                items: [
+                  for (final cat in _categoryOrder)
+                    DropdownMenuItem(
+                        value: cat, child: Text(_categoryLabels[cat]!)),
+                ],
+              ),
+              TextField(
+                controller: labelController,
+                autofocus: true,
+                decoration: const InputDecoration(labelText: 'Label'),
+              ),
+              TextField(
+                controller: amountController,
+                keyboardType:
+                    const TextInputType.numberWithOptions(decimal: true),
+                inputFormatters: [
+                  FilteringTextInputFormatter.allow(RegExp(r'[0-9.]')),
+                ],
+                decoration: const InputDecoration(labelText: 'Amount'),
+              ),
+            ],
+          ),
+          actions: [
+            TextButton(
+                onPressed: () => Navigator.of(ctx).pop(),
+                child: const Text('Cancel')),
+            FilledButton(
+              onPressed: () {
+                final label = labelController.text.trim();
+                final amount = double.tryParse(amountController.text.trim());
+                if (label.isEmpty || amount == null || amount < 0) return;
+                Navigator.of(ctx).pop({
+                  'category': category,
+                  'label': label,
+                  'amount': amount,
+                });
+              },
+              child: const Text('Save'),
+            ),
+          ],
+        ),
+      ),
+    );
+    if (result != null) {
+      _run(() => ref
+          .read(budgetApiServiceProvider)
+          .updateExpense(widget.tripId, expense.id, result));
+    }
+  }
+
+  Future<void> _editTarget(Budget budget) async {
+    if (_guard()) return;
+    final amountController = TextEditingController(
+        text: budget.targetAmount == null
+            ? ''
+            : _trimAmount(budget.targetAmount!));
+    var currency = _currencyCodes.contains(budget.currency)
+        ? budget.currency
+        : 'USD';
+    final result = await showDialog<Map<String, dynamic>>(
+      context: context,
+      builder: (ctx) => StatefulBuilder(
+        builder: (ctx, setLocal) => AlertDialog(
+          title: const Text('Set budget target'),
+          content: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Row(
+                children: [
+                  SizedBox(
+                    width: 96,
+                    child: DropdownButtonFormField<String>(
+                      initialValue: currency,
+                      decoration: const InputDecoration(labelText: 'Currency'),
+                      onChanged: (v) => setLocal(() => currency = v ?? 'USD'),
+                      items: [
+                        for (final code in _currencyCodes)
+                          DropdownMenuItem(value: code, child: Text(code)),
+                      ],
+                    ),
+                  ),
+                  const SizedBox(width: AppSpacing.sm),
+                  Expanded(
+                    child: TextField(
+                      controller: amountController,
+                      autofocus: true,
+                      keyboardType:
+                          const TextInputType.numberWithOptions(decimal: true),
+                      inputFormatters: [
+                        FilteringTextInputFormatter.allow(RegExp(r'[0-9.]')),
+                      ],
+                      decoration: const InputDecoration(
+                        labelText: 'Target',
+                        hintText: 'Leave blank for none',
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: AppSpacing.sm),
+              Text(
+                'Leave the target blank to just track spending.',
+                style: Theme.of(context).textTheme.bodySmall,
+              ),
+            ],
+          ),
+          actions: [
+            TextButton(
+                onPressed: () => Navigator.of(ctx).pop(),
+                child: const Text('Cancel')),
+            FilledButton(
+              onPressed: () {
+                final raw = amountController.text.trim();
+                final amount = raw.isEmpty ? null : double.tryParse(raw);
+                if (raw.isNotEmpty && (amount == null || amount < 0)) return;
+                Navigator.of(ctx).pop({
+                  'target_amount': amount,
+                  'currency': currency,
+                });
+              },
+              child: const Text('Save'),
+            ),
+          ],
+        ),
+      ),
+    );
+    if (result != null) {
+      _run(() => ref.read(budgetApiServiceProvider).upsertBudget(
+            widget.tripId,
+            targetAmount: result['target_amount'] as double?,
+            currency: result['currency'] as String,
+          ));
+    }
+  }
+
+  // Whole units for editing (prices are quoted that way); drop a trailing ".0".
+  String _trimAmount(double v) =>
+      v == v.roundToDouble() ? v.round().toString() : v.toString();
+
+  @override
+  Widget build(BuildContext context) {
+    final budgetAsync = ref.watch(budgetProvider(widget.tripId));
+    final expensesAsync = ref.watch(expensesProvider(widget.tripId));
+    // Best-effort: render nothing until both loads have data — a utility
+    // section shouldn't shout an error or flash a spinner.
+    final budget = budgetAsync.valueOrNull;
+    final expenses = expensesAsync.valueOrNull;
+    if (budget == null || expenses == null) return const SizedBox.shrink();
+
+    final hasTarget = budget.targetAmount != null;
+    // Viewers with nothing to show (no expenses and no target) get no section.
+    if (expenses.isEmpty && !hasTarget && !widget.canEdit) {
+      return const SizedBox.shrink();
+    }
+
+    final theme = Theme.of(context);
+    final currency = budget.currency;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        const Divider(height: 32),
+        SectionHeader(
+          title: 'Budget',
+          action: StatusPill.custom(
+            label: hasTarget
+                ? '${formatMoney(budget.spent, currency)} / ${formatMoney(budget.targetAmount!, currency)}'
+                : formatMoney(budget.spent, currency),
+            background: theme.colorScheme.surfaceContainerHighest,
+            foreground: theme.colorScheme.onSurfaceVariant,
+          ),
+        ),
+        const SizedBox(height: AppSpacing.sm),
+        if (widget.canEdit) _buildTargetControl(theme, budget),
+        if (expenses.isEmpty && !hasTarget)
+          const EmptyState(
+            compact: true,
+            icon: Icons.account_balance_wallet_outlined,
+            title: 'No budget yet',
+            message:
+                'Set a target above, or add expenses below to track your spending.',
+          )
+        else ...[
+          ..._buildGroups(theme, expenses, currency),
+          _buildTotals(theme, budget, expenses),
+        ],
+        if (widget.canEdit) ...[
+          const SizedBox(height: AppSpacing.sm),
+          _buildAddRow(theme),
+        ],
+      ],
+    );
+  }
+
+  Widget _buildTargetControl(ThemeData theme, Budget budget) {
+    final hasTarget = budget.targetAmount != null;
+    return Padding(
+      padding: const EdgeInsets.only(bottom: AppSpacing.xs),
+      child: InkWell(
+        onTap: () => _editTarget(budget),
+        borderRadius: AppRadius.smAll,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(
+              vertical: AppSpacing.xs, horizontal: AppSpacing.xs),
+          child: Row(
+            children: [
+              Icon(Icons.flag_outlined,
+                  size: 16, color: theme.colorScheme.onSurfaceVariant),
+              const SizedBox(width: AppSpacing.xs),
+              Expanded(
+                child: Text(
+                  hasTarget
+                      ? 'Target: ${formatMoney(budget.targetAmount!, budget.currency)} (${budget.currency})'
+                      : 'No target set — tracking spend only',
+                  style: theme.textTheme.bodyMedium
+                      ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+                ),
+              ),
+              Icon(Icons.edit_outlined,
+                  size: 16, color: theme.colorScheme.onSurfaceVariant),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  List<Widget> _buildGroups(
+      ThemeData theme, List<Expense> expenses, String currency) {
+    final byCategory = <String, List<Expense>>{};
+    for (final e in expenses) {
+      byCategory.putIfAbsent(_normalizeCategory(e.category), () => []).add(e);
+    }
+    final widgets = <Widget>[];
+    for (final cat in _categoryOrder) {
+      final group = byCategory[cat];
+      if (group == null || group.isEmpty) continue;
+      final subtotal = group.fold<double>(0, (sum, e) => sum + e.amount);
+      widgets.add(Padding(
+        padding:
+            const EdgeInsets.only(top: AppSpacing.sm, bottom: AppSpacing.xs),
+        child: Row(
+          children: [
+            Icon(_categoryIcons[cat],
+                size: 16, color: theme.colorScheme.onSurfaceVariant),
+            const SizedBox(width: AppSpacing.xs),
+            Expanded(
+              child: Text(
+                _categoryLabels[cat]!,
+                style: theme.textTheme.labelLarge
+                    ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+              ),
+            ),
+            Text(
+              formatMoney(subtotal, currency),
+              style: theme.textTheme.labelLarge
+                  ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+            ),
+          ],
+        ),
+      ));
+      for (final e in group) {
+        widgets.add(_buildRow(theme, e, currency));
+      }
+    }
+    return widgets;
+  }
+
+  Widget _buildRow(ThemeData theme, Expense expense, String currency) {
+    return Padding(
+      key: ValueKey(expense.id),
+      padding: const EdgeInsets.symmetric(vertical: 2),
+      child: Row(
+        children: [
+          const SizedBox(width: AppSpacing.lg),
+          Expanded(
+            child: Text(
+              expense.label,
+              style: theme.textTheme.bodyMedium
+                  ?.copyWith(color: theme.colorScheme.onSurface),
+            ),
+          ),
+          Text(
+            formatMoney(expense.amount, currency),
+            style: theme.textTheme.bodyMedium,
+          ),
+          if (widget.canEdit)
+            PopupMenuButton<String>(
+              icon: Icon(Icons.more_vert,
+                  size: 18, color: theme.colorScheme.onSurfaceVariant),
+              tooltip: 'Expense options',
+              onSelected: (v) {
+                if (v == 'edit') _editExpense(expense);
+                if (v == 'delete') _delete(expense);
+              },
+              itemBuilder: (_) => const [
+                PopupMenuItem(value: 'edit', child: Text('Edit')),
+                PopupMenuItem(value: 'delete', child: Text('Delete')),
+              ],
+            )
+          else
+            const SizedBox(width: AppSpacing.sm),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildTotals(ThemeData theme, Budget budget, List<Expense> expenses) {
+    final currency = budget.currency;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        const Padding(
+          padding: EdgeInsets.symmetric(vertical: AppSpacing.xs),
+          child: Divider(height: 1),
+        ),
+        Row(
+          children: [
+            Expanded(
+              child: Text('Total spent',
+                  style: theme.textTheme.titleSmall
+                      ?.copyWith(fontWeight: FontWeight.bold)),
+            ),
+            Text(
+              formatMoney(budget.spent, currency),
+              style: theme.textTheme.titleSmall
+                  ?.copyWith(fontWeight: FontWeight.bold),
+            ),
+          ],
+        ),
+        if (budget.remaining != null) ...[
+          const SizedBox(height: 2),
+          Row(
+            children: [
+              Expanded(
+                child: Text('Remaining',
+                    style: theme.textTheme.bodyMedium
+                        ?.copyWith(color: theme.colorScheme.onSurfaceVariant)),
+              ),
+              Text(
+                formatMoney(budget.remaining!, currency),
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  color: budget.remaining! < 0
+                      ? theme.colorScheme.error
+                      : theme.colorScheme.onSurfaceVariant,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ],
+          ),
+        ],
+      ],
+    );
+  }
+
+  Widget _buildAddRow(ThemeData theme) {
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: [
+        DropdownButton<String>(
+          value: _addCategory,
+          underline: const SizedBox.shrink(),
+          onChanged: widget.isOffline
+              ? null
+              : (v) => setState(() => _addCategory = v ?? 'general'),
+          items: [
+            for (final cat in _categoryOrder)
+              DropdownMenuItem(
+                value: cat,
+                child: Icon(_categoryIcons[cat],
+                    size: 18, color: theme.colorScheme.onSurfaceVariant),
+              ),
+          ],
+        ),
+        const SizedBox(width: AppSpacing.sm),
+        Expanded(
+          child: TextField(
+            controller: _labelController,
+            textInputAction: TextInputAction.next,
+            decoration: const InputDecoration(
+              isDense: true,
+              hintText: 'Add an expense…',
+            ),
+          ),
+        ),
+        const SizedBox(width: AppSpacing.sm),
+        SizedBox(
+          width: 88,
+          child: TextField(
+            controller: _amountController,
+            textInputAction: TextInputAction.done,
+            keyboardType: const TextInputType.numberWithOptions(decimal: true),
+            inputFormatters: [
+              FilteringTextInputFormatter.allow(RegExp(r'[0-9.]')),
+            ],
+            decoration: const InputDecoration(
+              isDense: true,
+              hintText: 'Amount',
+            ),
+            onSubmitted: (_) => _add(),
+          ),
+        ),
+        IconButton(
+          icon: const Icon(Icons.add),
+          tooltip: 'Add expense',
+          onPressed: widget.isOffline ? null : _add,
+        ),
+      ],
+    );
+  }
+}

--- a/src/packages/flutter-app/test/budget_section_test.dart
+++ b/src/packages/flutter-app/test/budget_section_test.dart
@@ -1,0 +1,240 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:travel_route_planner/models/budget.dart';
+import 'package:travel_route_planner/models/expense.dart';
+import 'package:travel_route_planner/services/api_client.dart';
+import 'package:travel_route_planner/services/budget_api_service.dart';
+import 'package:travel_route_planner/providers/budget_provider.dart';
+import 'package:travel_route_planner/utils/money_format.dart';
+import 'package:travel_route_planner/widgets/budget_section.dart';
+
+/// A stateful fake: it holds the target/currency + the expense list so
+/// invalidate-after-mutate reflects the change, derives spent/remaining exactly
+/// like the server, and records which network methods were called.
+class _FakeBudgetApiService extends BudgetApiService {
+  final List<Expense> expenses;
+  double? targetAmount;
+  String currency;
+
+  final List<Map<String, dynamic>> patches = [];
+  final List<Map<String, dynamic>> puts = [];
+  int addCount = 0;
+  int deleteCount = 0;
+
+  _FakeBudgetApiService(this.expenses, {this.targetAmount, this.currency = 'USD'})
+      : super(ApiClient(baseUrl: 'http://test'));
+
+  double get _spent => expenses.fold<double>(0, (s, e) => s + e.amount);
+
+  @override
+  Future<Budget> getBudget(String tripId) async => Budget(
+        targetAmount: targetAmount,
+        currency: currency,
+        spent: _spent,
+        remaining: targetAmount == null ? null : targetAmount! - _spent,
+      );
+
+  @override
+  Future<List<Expense>> listExpenses(String tripId) async =>
+      List.of(expenses); // snapshot
+
+  @override
+  Future<Budget> upsertBudget(String tripId,
+      {double? targetAmount, String currency = 'USD'}) async {
+    puts.add({'target_amount': targetAmount, 'currency': currency});
+    this.targetAmount = targetAmount;
+    this.currency = currency;
+    return getBudget(tripId);
+  }
+
+  @override
+  Future<Expense> addExpense(String tripId,
+      {required String category,
+      required String label,
+      required double amount}) async {
+    addCount++;
+    final e = Expense(
+        id: 'new-$addCount',
+        category: category,
+        label: label,
+        amount: amount);
+    expenses.add(e);
+    return e;
+  }
+
+  @override
+  Future<Expense> updateExpense(
+      String tripId, String expenseId, Map<String, dynamic> body) async {
+    patches.add({'id': expenseId, ...body});
+    final idx = expenses.indexWhere((e) => e.id == expenseId);
+    if (idx >= 0) {
+      expenses[idx] = expenses[idx].copyWith(
+        category: body['category'] as String?,
+        label: body['label'] as String?,
+        amount: (body['amount'] as num?)?.toDouble(),
+      );
+      return expenses[idx];
+    }
+    throw Exception('not found');
+  }
+
+  @override
+  Future<void> deleteExpense(String tripId, String expenseId) async {
+    deleteCount++;
+    expenses.removeWhere((e) => e.id == expenseId);
+  }
+}
+
+Expense _exp(String id, String category, String label, double amount) =>
+    Expense(id: id, category: category, label: label, amount: amount);
+
+Future<_FakeBudgetApiService> _pump(
+  WidgetTester tester,
+  List<Expense> expenses, {
+  double? targetAmount,
+  String currency = 'USD',
+  bool canEdit = true,
+  bool isOffline = false,
+}) async {
+  final fake = _FakeBudgetApiService(expenses,
+      targetAmount: targetAmount, currency: currency);
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        budgetApiServiceProvider.overrideWithValue(fake),
+      ],
+      child: MaterialApp(
+        home: Scaffold(
+          body: SingleChildScrollView(
+            child: BudgetSection(
+                tripId: 't1', canEdit: canEdit, isOffline: isOffline),
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+  return fake;
+}
+
+void main() {
+  testWidgets(
+      'renders expenses grouped with subtotals, a running total, and remaining',
+      (tester) async {
+    await _pump(
+      tester,
+      [
+        _exp('a', 'flights', 'JFK→CDG', 400),
+        _exp('b', 'food', 'Dinner', 60),
+        _exp('c', 'food', 'Lunch', 40),
+      ],
+      targetAmount: 1000,
+      currency: 'EUR',
+    );
+
+    expect(find.text('Budget'), findsOneWidget);
+    // Category group headers.
+    expect(find.text('Flights'), findsOneWidget);
+    expect(find.text('Food'), findsOneWidget);
+    // Flights subtotal = 400, Food subtotal = 100 (both in EUR).
+    expect(find.text(formatMoney(400, 'EUR')), findsWidgets);
+    expect(find.text(formatMoney(100, 'EUR')), findsOneWidget);
+    // Running total = 500 spent.
+    expect(find.text('Total spent'), findsOneWidget);
+    expect(find.text(formatMoney(500, 'EUR')), findsWidgets);
+    // Remaining = 1000 - 500 = 500.
+    expect(find.text('Remaining'), findsOneWidget);
+    // Pill shows spent / target.
+    expect(
+        find.text('${formatMoney(500, 'EUR')} / ${formatMoney(1000, 'EUR')}'),
+        findsOneWidget);
+  });
+
+  testWidgets('adding an expense posts to the service', (tester) async {
+    final fake = await _pump(tester, [_exp('a', 'food', 'Lunch', 20)]);
+
+    await tester.enterText(find.byType(TextField).first, 'Taxi');
+    await tester.enterText(find.byType(TextField).last, '15');
+    await tester.tap(find.byTooltip('Add expense'));
+    await tester.pumpAndSettle();
+
+    expect(fake.addCount, 1);
+    expect(find.text('Taxi'), findsOneWidget);
+  });
+
+  testWidgets('editing an expense calls PATCH', (tester) async {
+    final fake = await _pump(tester, [_exp('a', 'food', 'Lunch', 20)]);
+
+    await tester.tap(find.byTooltip('Expense options'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Edit'));
+    await tester.pumpAndSettle();
+
+    await tester.enterText(
+        find.widgetWithText(TextField, 'Lunch'), 'Brunch');
+    await tester.tap(find.text('Save'));
+    await tester.pumpAndSettle();
+
+    expect(fake.patches, isNotEmpty);
+    expect(fake.patches.first['id'], 'a');
+    expect(fake.patches.first['label'], 'Brunch');
+  });
+
+  testWidgets('setting a target calls PUT', (tester) async {
+    final fake = await _pump(tester, [_exp('a', 'food', 'Lunch', 20)]);
+
+    // Tap the target control (shows the "no target" hint text).
+    await tester.tap(find.text('No target set — tracking spend only'));
+    await tester.pumpAndSettle();
+
+    await tester.enterText(
+        find.widgetWithText(TextField, 'Leave blank for none'), '800');
+    await tester.tap(find.text('Save'));
+    await tester.pumpAndSettle();
+
+    expect(fake.puts, isNotEmpty);
+    expect(fake.puts.first['target_amount'], 800);
+    expect(fake.puts.first['currency'], 'USD');
+  });
+
+  testWidgets('empty state shows the hint and an add field', (tester) async {
+    await _pump(tester, []);
+
+    expect(find.text('No budget yet'), findsOneWidget);
+    expect(find.textContaining('track your spending'), findsOneWidget);
+    // The add affordance is still available for the editor.
+    expect(find.byTooltip('Add expense'), findsOneWidget);
+  });
+
+  testWidgets('viewer with no expenses and no target renders nothing',
+      (tester) async {
+    await _pump(tester, [], canEdit: false);
+
+    expect(find.text('Budget'), findsNothing);
+    expect(find.byTooltip('Add expense'), findsNothing);
+  });
+
+  testWidgets('viewer sees amounts but no mutation affordances',
+      (tester) async {
+    await _pump(tester, [_exp('a', 'food', 'Lunch', 20)],
+        targetAmount: 100, canEdit: false);
+
+    // The section renders with its data...
+    expect(find.text('Budget'), findsOneWidget);
+    expect(find.text('Lunch'), findsOneWidget);
+    // ...but no add row, per-expense menu, or target control.
+    expect(find.byTooltip('Add expense'), findsNothing);
+    expect(find.byTooltip('Expense options'), findsNothing);
+    expect(find.text('No target set — tracking spend only'), findsNothing);
+  });
+
+  testWidgets('offline disables the add affordance', (tester) async {
+    await _pump(tester, [_exp('a', 'food', 'Lunch', 20)], isOffline: true);
+
+    final addButton =
+        tester.widget<IconButton>(find.widgetWithIcon(IconButton, Icons.add));
+    expect(addButton.onPressed, isNull);
+  });
+}


### PR DESCRIPTION
## What

Adds a self-contained **Budget** section to the trip-detail screen, mirroring `ChecklistSection` exactly. Backend (#141) is done; this is the Flutter surface.

- **Models** — `Budget{targetAmount?, currency, spent, remaining?}` and `Expense{id, category, label, amount, position, auto}` (`@JsonSerializable` + generated `.g.dart`).
- **Service** — `BudgetApiService`: `getBudget` / `upsertBudget` (PUT) / `listExpenses` / `addExpense` / `updateExpense` (PATCH) / `deleteExpense`.
- **Provider** — `budgetProvider` + `expensesProvider` families keyed by tripId; both invalidated on every mutation. Backing `budgetApiServiceProvider`.
- **Widget** — `BudgetSection` (`ConsumerStatefulWidget` with the `_run`/`_guard` offline pattern):
  - `SectionHeader` "Budget" + `StatusPill` showing `spent / target` (or just spent when no target).
  - Tap-to-edit target/currency dialog (currency dropdown of the codes `formatMoney` knows, default USD). Empty target = "tracking spend only".
  - Expenses grouped by the backend's bounded category set with **per-category subtotals**, a **Total spent** line, and a **Remaining** footer (red when negative).
  - Add-expense row (category + label + amount), per-expense edit/delete popup menu, `EmptyState` when no expenses and no target.
  - Every amount via `formatMoney` in the single budget currency — **no cross-currency summing** (honest v1: one currency per budget, no FX).
- **Mount** — a trailing peer `SliverPadding`/`SliverToBoxAdapter` beside `ChecklistSection` in `trip_detail_screen.dart`, passing `tripId`, `canEdit: !_readOnly`, `isOffline: _isOffline`. The share/export menu (#144) is untouched.

## Tests

`test/budget_section_test.dart` (mirrors `checklist_section_test.dart`): grouped rendering with subtotals + running total + remaining, add POSTs, edit calls PATCH, set-target calls PUT, empty state, viewer (`canEdit=false`) hides mutation affordances, offline disables them — all asserting `formatMoney`'d strings.

- `flutter test` — **329 passed** (incl. new file's 8; regression `trip_detail_sticky_headers_test` + `trip_detail_today_test` unmodified & green).
- `flutter analyze --no-fatal-infos --fatal-warnings` — exit 0 (12 baseline infos, none added).

🤖 Generated with [Claude Code](https://claude.com/claude-code)