### PR TITLE
feat: email preferences + one-click unsubscribe

### DIFF
--- a/src/packages/api/.env.sample
+++ b/src/packages/api/.env.sample
@@ -59,6 +59,11 @@ PUBLIC_BASE_URL=
 # Path prefix the Flutter app is served under, for app deep links in emails
 # ("/" default, "/app/" in deployment). Normalized to start+end with "/".
 PUBLIC_APP_PATH=
+# HMAC secret for one-click email unsubscribe links (RFC 8058). Set a STABLE
+# value in production so unsubscribe links printed in old emails keep working
+# across restarts; falls back to EXPORT_SIGNING_SECRET, then a random
+# per-process key in dev (breaks outstanding links on restart — dev-only).
+UNSUBSCRIBE_SIGNING_SECRET=
 
 # Price alerts checker cadence (optional; defaults shown)
 # ALERT_TICK_MINUTES=5    # how often the checker wakes up

--- a/src/packages/api/account_handler.go
+++ b/src/packages/api/account_handler.go
@@ -47,6 +47,41 @@ func patchAccountHandler(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, toUserResponse(updated))
 }
 
+// patchEmailPreferencesHandler updates the signed-in user's email opt-outs. The
+// client speaks opt-IN ("enabled"): switch ON = receiving = opt_out false. Both
+// fields are optional pointers so the UI can toggle one stream at a time; a body
+// touching neither is a no-op that still returns the current user.
+func patchEmailPreferencesHandler(w http.ResponseWriter, r *http.Request) {
+	if dbPool == nil {
+		writeJSONError(w, http.StatusServiceUnavailable, "database unavailable")
+		return
+	}
+	user, _ := userFromContext(r.Context())
+	var req struct {
+		RemindersEnabled *bool `json:"reminders_enabled"`
+		NudgesEnabled    *bool `json:"nudges_enabled"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid JSON")
+		return
+	}
+	params := store.SetUserEmailOptOutParams{ID: user.ID}
+	if req.RemindersEnabled != nil {
+		optOut := !*req.RemindersEnabled
+		params.RemindersOptOut = &optOut
+	}
+	if req.NudgesEnabled != nil {
+		optOut := !*req.NudgesEnabled
+		params.NudgesOptOut = &optOut
+	}
+	updated, err := store.New(dbPool).SetUserEmailOptOut(r.Context(), params)
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "could not update email preferences")
+		return
+	}
+	writeJSON(w, http.StatusOK, toUserResponse(updated))
+}
+
 func changePasswordHandler(w http.ResponseWriter, r *http.Request) {
 	if dbPool == nil {
 		writeJSONError(w, http.StatusServiceUnavailable, "database unavailable")

--- a/src/packages/api/auth_handler.go
+++ b/src/packages/api/auth_handler.go
@@ -34,6 +34,11 @@ type UserResponse struct {
 	IsAdmin         bool      `json:"is_admin"`
 	NeedsOnboarding bool      `json:"needs_onboarding"`
 	CreatedAt       time.Time `json:"created_at"`
+	// Email preferences are expressed to the client as opt-INs (receiving = on)
+	// so the account-settings switches read naturally; they invert the stored
+	// opt-out columns.
+	RemindersEnabled bool `json:"reminders_enabled"`
+	NudgesEnabled    bool `json:"nudges_enabled"`
 }
 
 type AuthResponse struct {
@@ -53,6 +58,9 @@ func toUserResponse(u store.User) UserResponse {
 		IsAdmin:         u.IsAdmin,
 		NeedsOnboarding: !u.OnboardedAt.Valid,
 		CreatedAt:       u.CreatedAt,
+		// Opt-out false => still receiving => enabled true.
+		RemindersEnabled: !u.RemindersOptOut,
+		NudgesEnabled:    !u.NudgesOptOut,
 	}
 }
 

--- a/src/packages/api/email_service.go
+++ b/src/packages/api/email_service.go
@@ -45,27 +45,66 @@ func (s *EmailService) Configured() bool {
 	return s.Host != "" && s.From != ""
 }
 
-// Send delivers a plain-text email. In degraded mode it logs the message
-// (minus nothing — these are our own transactional bodies) and reports
-// success so callers never surface delivery as a user-facing error.
+// Send delivers a plain-text transactional email (verify/reset). Left untouched
+// by the marketing plumbing — transactional mail is never unsubscribable.
 func (s *EmailService) Send(to, subject, body string) error {
-	if !s.Configured() {
-		log.Printf("email (not sent, SMTP unconfigured) to=%s subject=%q body=%q", to, subject, body)
+	return s.SendWithHeaders(to, subject, body, nil)
+}
+
+// SendMarketing delivers a plain-text marketing email (reminders, weekly nudge)
+// carrying the RFC 8058 one-click unsubscribe headers built from unsubscribeURL.
+// The URL must be the public /api/v1/unsubscribe/<token> capability link. The
+// List-Unsubscribe-Post header opts the message into one-click: a supporting
+// mail client can POST that URL directly, no page visit, honoring the opt-out.
+func (s *EmailService) SendMarketing(to, subject, body, unsubscribeURL string) error {
+	return s.SendWithHeaders(to, subject, body, listUnsubscribeHeaders(unsubscribeURL))
+}
+
+// listUnsubscribeHeaders returns the ordered List-Unsubscribe + -Post header
+// lines for a one-click unsubscribe URL, or nil when the URL is empty. Pure and
+// deterministic (ordered slice, not a map) so header construction unit-tests
+// cleanly. RFC 8058 requires both headers together for one-click to be honored.
+func listUnsubscribeHeaders(unsubscribeURL string) []string {
+	if strings.TrimSpace(unsubscribeURL) == "" {
 		return nil
 	}
-	msg := strings.Join([]string{
-		"From: " + s.From,
-		"To: " + to,
-		"Subject: " + subject,
-		"MIME-Version: 1.0",
-		"Content-Type: text/plain; charset=utf-8",
-		"",
-		body,
-	}, "\r\n")
+	return []string{
+		"List-Unsubscribe: <" + unsubscribeURL + ">",
+		"List-Unsubscribe-Post: List-Unsubscribe=One-Click",
+	}
+}
+
+// SendWithHeaders delivers a plain-text email with optional extra header lines
+// (each "Key: value", CRLF is added by the framer). In degraded mode it logs the
+// message and reports success so callers never surface delivery as a
+// user-facing error.
+func (s *EmailService) SendWithHeaders(to, subject, body string, extraHeaders []string) error {
+	if !s.Configured() {
+		log.Printf("email (not sent, SMTP unconfigured) to=%s subject=%q headers=%v body=%q", to, subject, extraHeaders, body)
+		return nil
+	}
+	msg := buildEmailMessage(s.From, to, subject, body, extraHeaders)
 
 	var auth smtp.Auth
 	if s.Username != "" {
 		auth = smtp.PlainAuth("", s.Username, s.Password, s.Host)
 	}
 	return smtp.SendMail(s.Host+":"+s.Port, auth, s.From, []string{to}, []byte(msg))
+}
+
+// buildEmailMessage frames the RFC 5322 message (CRLF-delimited). Pure so the
+// header block — including any List-Unsubscribe lines — is unit-testable without
+// an SMTP server. extraHeaders sit after the fixed headers, before the blank
+// line that separates headers from the body.
+func buildEmailMessage(from, to, subject, body string, extraHeaders []string) string {
+	lines := []string{
+		"From: " + from,
+		"To: " + to,
+		"Subject: " + subject,
+		"MIME-Version: 1.0",
+		"Content-Type: text/plain; charset=utf-8",
+	}
+	lines = append(lines, extraHeaders...)
+	lines = append(lines, "", body)
+	return strings.Join(lines, "\r\n")
 }

--- a/src/packages/api/main.go
+++ b/src/packages/api/main.go
@@ -701,6 +701,11 @@ func buildRouter() *mux.Router {
 	api.Handle("/auth/account", strict(authMiddleware(http.HandlerFunc(deleteAccountHandler)))).Methods("DELETE")
 	api.Handle("/auth/change-password", strict(authMiddleware(http.HandlerFunc(changePasswordHandler)))).Methods("POST")
 	api.Handle("/auth/logout-all", authMiddleware(http.HandlerFunc(logoutAllHandler))).Methods("POST")
+	api.Handle("/auth/email-preferences", authMiddleware(http.HandlerFunc(patchEmailPreferencesHandler))).Methods("PATCH")
+	// Public, token-gated one-click unsubscribe — NO authMiddleware: the signed
+	// token IS the capability. GET = human clicks the footer link; POST = RFC
+	// 8058 List-Unsubscribe-Post one-click flow fired by the mail client.
+	api.HandleFunc("/unsubscribe/{token}", unsubscribeHandler).Methods("GET", "POST")
 	// Sign in with Google (specs/google-sso). Browser redirect flow + one-time
 	// code exchange; unauthenticated, so the credential routes take the strict tier.
 	api.HandleFunc("/auth/google/availability", googleAvailabilityHandler).Methods("GET")

--- a/src/packages/api/migrations/00044_email_prefs.sql
+++ b/src/packages/api/migrations/00044_email_prefs.sql
@@ -1,0 +1,13 @@
+-- +goose Up
+-- Per-category email opt-out flags. Both marketing-ish streams default to
+-- opted-IN (false = still receiving), each independently unsubscribable via a
+-- signed one-click link (RFC 8058 List-Unsubscribe). A weekly nudge legally
+-- needs opt-out; transactional mail (verify/reset) is not gated by these.
+ALTER TABLE users
+    ADD COLUMN reminders_opt_out BOOLEAN NOT NULL DEFAULT false,
+    ADD COLUMN nudges_opt_out    BOOLEAN NOT NULL DEFAULT false;
+
+-- +goose Down
+ALTER TABLE users
+    DROP COLUMN reminders_opt_out,
+    DROP COLUMN nudges_opt_out;

--- a/src/packages/api/query/users.sql
+++ b/src/packages/api/query/users.sql
@@ -25,5 +25,15 @@ WHERE id = $1;
 UPDATE users SET display_name = $2 WHERE id = $1
 RETURNING *;
 
+-- name: SetUserEmailOptOut :one
+-- Category-partial opt-out setter: a NULL arg leaves that flag untouched, so a
+-- single query handles reminders-only, nudges-only, or all-at-once. Used by
+-- both the one-click unsubscribe link and the account-settings PATCH.
+UPDATE users SET
+    reminders_opt_out = COALESCE(sqlc.narg('reminders_opt_out'), reminders_opt_out),
+    nudges_opt_out    = COALESCE(sqlc.narg('nudges_opt_out'), nudges_opt_out)
+WHERE id = sqlc.arg('id')
+RETURNING *;
+
 -- name: DeleteUser :execrows
 DELETE FROM users WHERE id = $1;

--- a/src/packages/api/store/models.go
+++ b/src/packages/api/store/models.go
@@ -336,4 +336,6 @@ type User struct {
 	IsAdmin         bool               `json:"is_admin"`
 	OnboardedAt     pgtype.Timestamptz `json:"onboarded_at"`
 	EmailVerifiedAt pgtype.Timestamptz `json:"email_verified_at"`
+	RemindersOptOut bool               `json:"reminders_opt_out"`
+	NudgesOptOut    bool               `json:"nudges_opt_out"`
 }

--- a/src/packages/api/store/sessions.sql.go
+++ b/src/packages/api/store/sessions.sql.go
@@ -67,7 +67,7 @@ func (q *Queries) DeleteSessionsByUser(ctx context.Context, userID uuid.UUID) er
 const getSessionWithUser = `-- name: GetSessionWithUser :one
 SELECT
     sessions.id, sessions.user_id, sessions.expires_at, sessions.created_at,
-    users.id, users.created_at, users.updated_at, users.email, users.password_hash, users.display_name, users.is_admin, users.onboarded_at, users.email_verified_at
+    users.id, users.created_at, users.updated_at, users.email, users.password_hash, users.display_name, users.is_admin, users.onboarded_at, users.email_verified_at, users.reminders_opt_out, users.nudges_opt_out
 FROM sessions
 JOIN users ON users.id = sessions.user_id
 WHERE sessions.id = $1
@@ -95,6 +95,8 @@ func (q *Queries) GetSessionWithUser(ctx context.Context, id string) (GetSession
 		&i.User.IsAdmin,
 		&i.User.OnboardedAt,
 		&i.User.EmailVerifiedAt,
+		&i.User.RemindersOptOut,
+		&i.User.NudgesOptOut,
 	)
 	return i, err
 }

--- a/src/packages/api/store/users.sql.go
+++ b/src/packages/api/store/users.sql.go
@@ -14,7 +14,7 @@ import (
 const createUser = `-- name: CreateUser :one
 INSERT INTO users (email, password_hash, display_name)
 VALUES ($1, $2, $3)
-RETURNING id, created_at, updated_at, email, password_hash, display_name, is_admin, onboarded_at, email_verified_at
+RETURNING id, created_at, updated_at, email, password_hash, display_name, is_admin, onboarded_at, email_verified_at, reminders_opt_out, nudges_opt_out
 `
 
 type CreateUserParams struct {
@@ -36,6 +36,8 @@ func (q *Queries) CreateUser(ctx context.Context, arg CreateUserParams) (User, e
 		&i.IsAdmin,
 		&i.OnboardedAt,
 		&i.EmailVerifiedAt,
+		&i.RemindersOptOut,
+		&i.NudgesOptOut,
 	)
 	return i, err
 }
@@ -53,7 +55,7 @@ func (q *Queries) DeleteUser(ctx context.Context, id uuid.UUID) (int64, error) {
 }
 
 const getUserByEmail = `-- name: GetUserByEmail :one
-SELECT id, created_at, updated_at, email, password_hash, display_name, is_admin, onboarded_at, email_verified_at FROM users WHERE email = $1
+SELECT id, created_at, updated_at, email, password_hash, display_name, is_admin, onboarded_at, email_verified_at, reminders_opt_out, nudges_opt_out FROM users WHERE email = $1
 `
 
 func (q *Queries) GetUserByEmail(ctx context.Context, email string) (User, error) {
@@ -69,12 +71,14 @@ func (q *Queries) GetUserByEmail(ctx context.Context, email string) (User, error
 		&i.IsAdmin,
 		&i.OnboardedAt,
 		&i.EmailVerifiedAt,
+		&i.RemindersOptOut,
+		&i.NudgesOptOut,
 	)
 	return i, err
 }
 
 const getUserByID = `-- name: GetUserByID :one
-SELECT id, created_at, updated_at, email, password_hash, display_name, is_admin, onboarded_at, email_verified_at FROM users WHERE id = $1
+SELECT id, created_at, updated_at, email, password_hash, display_name, is_admin, onboarded_at, email_verified_at, reminders_opt_out, nudges_opt_out FROM users WHERE id = $1
 `
 
 func (q *Queries) GetUserByID(ctx context.Context, id uuid.UUID) (User, error) {
@@ -90,6 +94,8 @@ func (q *Queries) GetUserByID(ctx context.Context, id uuid.UUID) (User, error) {
 		&i.IsAdmin,
 		&i.OnboardedAt,
 		&i.EmailVerifiedAt,
+		&i.RemindersOptOut,
+		&i.NudgesOptOut,
 	)
 	return i, err
 }
@@ -107,7 +113,7 @@ func (q *Queries) MarkUserEmailVerified(ctx context.Context, id uuid.UUID) error
 const markUserOnboarded = `-- name: MarkUserOnboarded :one
 UPDATE users SET onboarded_at = COALESCE(onboarded_at, now())
 WHERE id = $1
-RETURNING id, created_at, updated_at, email, password_hash, display_name, is_admin, onboarded_at, email_verified_at
+RETURNING id, created_at, updated_at, email, password_hash, display_name, is_admin, onboarded_at, email_verified_at, reminders_opt_out, nudges_opt_out
 `
 
 func (q *Queries) MarkUserOnboarded(ctx context.Context, id uuid.UUID) (User, error) {
@@ -123,13 +129,51 @@ func (q *Queries) MarkUserOnboarded(ctx context.Context, id uuid.UUID) (User, er
 		&i.IsAdmin,
 		&i.OnboardedAt,
 		&i.EmailVerifiedAt,
+		&i.RemindersOptOut,
+		&i.NudgesOptOut,
+	)
+	return i, err
+}
+
+const setUserEmailOptOut = `-- name: SetUserEmailOptOut :one
+UPDATE users SET
+    reminders_opt_out = COALESCE($1, reminders_opt_out),
+    nudges_opt_out    = COALESCE($2, nudges_opt_out)
+WHERE id = $3
+RETURNING id, created_at, updated_at, email, password_hash, display_name, is_admin, onboarded_at, email_verified_at, reminders_opt_out, nudges_opt_out
+`
+
+type SetUserEmailOptOutParams struct {
+	RemindersOptOut *bool     `json:"reminders_opt_out"`
+	NudgesOptOut    *bool     `json:"nudges_opt_out"`
+	ID              uuid.UUID `json:"id"`
+}
+
+// Category-partial opt-out setter: a NULL arg leaves that flag untouched, so a
+// single query handles reminders-only, nudges-only, or all-at-once. Used by
+// both the one-click unsubscribe link and the account-settings PATCH.
+func (q *Queries) SetUserEmailOptOut(ctx context.Context, arg SetUserEmailOptOutParams) (User, error) {
+	row := q.db.QueryRow(ctx, setUserEmailOptOut, arg.RemindersOptOut, arg.NudgesOptOut, arg.ID)
+	var i User
+	err := row.Scan(
+		&i.ID,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.Email,
+		&i.PasswordHash,
+		&i.DisplayName,
+		&i.IsAdmin,
+		&i.OnboardedAt,
+		&i.EmailVerifiedAt,
+		&i.RemindersOptOut,
+		&i.NudgesOptOut,
 	)
 	return i, err
 }
 
 const updateUserDisplayName = `-- name: UpdateUserDisplayName :one
 UPDATE users SET display_name = $2 WHERE id = $1
-RETURNING id, created_at, updated_at, email, password_hash, display_name, is_admin, onboarded_at, email_verified_at
+RETURNING id, created_at, updated_at, email, password_hash, display_name, is_admin, onboarded_at, email_verified_at, reminders_opt_out, nudges_opt_out
 `
 
 type UpdateUserDisplayNameParams struct {
@@ -150,6 +194,8 @@ func (q *Queries) UpdateUserDisplayName(ctx context.Context, arg UpdateUserDispl
 		&i.IsAdmin,
 		&i.OnboardedAt,
 		&i.EmailVerifiedAt,
+		&i.RemindersOptOut,
+		&i.NudgesOptOut,
 	)
 	return i, err
 }

--- a/src/packages/api/unsubscribe_handler.go
+++ b/src/packages/api/unsubscribe_handler.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"context"
+	"html/template"
+	"net/http"
+
+	"github.com/google/uuid"
+	"github.com/gorilla/mux"
+
+	"travel-route-planner/store"
+)
+
+// One-click email unsubscribe. PUBLIC (no authMiddleware): the signed token in
+// the path IS the capability. Both verbs do the same thing — GET is the plain
+// link a human clicks in the footer (answered with a friendly HTML page), POST
+// is the RFC 8058 List-Unsubscribe-Post "One-Click" flow a mail client fires
+// automatically (answered 200, body ignored). Idempotent: unsubscribing an
+// already-unsubscribed user still succeeds.
+
+// ptrTrue is a reusable *bool for the SetUserEmailOptOut narg params (a nil arg
+// leaves that category's flag untouched).
+var ptrTrue = func() *bool { b := true; return &b }()
+
+// applyUnsubscribe flips the opt-out flag(s) for the category. Returns false if
+// the user no longer exists (deleted account) — treated as a clean 404 rather
+// than leaking existence.
+func applyUnsubscribe(ctx context.Context, userID uuid.UUID, category string) bool {
+	q := store.New(dbPool)
+	params := store.SetUserEmailOptOutParams{ID: userID}
+	switch category {
+	case unsubReminders:
+		params.RemindersOptOut = ptrTrue
+	case unsubNudges:
+		params.NudgesOptOut = ptrTrue
+	case unsubAll:
+		params.RemindersOptOut = ptrTrue
+		params.NudgesOptOut = ptrTrue
+	default:
+		return false
+	}
+	if _, err := q.SetUserEmailOptOut(ctx, params); err != nil {
+		return false
+	}
+	return true
+}
+
+// unsubscribeCategoryLabel is the human phrase shown on the confirmation page.
+func unsubscribeCategoryLabel(category string) string {
+	switch category {
+	case unsubReminders:
+		return "trip reminders"
+	case unsubNudges:
+		return "weekly planning ideas"
+	case unsubAll:
+		return "all marketing emails"
+	default:
+		return "these emails"
+	}
+}
+
+var unsubscribePage = template.Must(template.New("unsub").Parse(`<!doctype html>
+<html lang="en"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Unsubscribed — Golden Tempo Travel</title>
+<style>
+  body{font-family:system-ui,-apple-system,Segoe UI,Roboto,sans-serif;background:#f6f7f9;color:#1a1a1a;margin:0;padding:2rem;display:flex;justify-content:center}
+  .card{background:#fff;max-width:32rem;width:100%;border-radius:16px;padding:2rem 2.25rem;box-shadow:0 1px 3px rgba(0,0,0,.08);margin-top:3rem}
+  h1{font-size:1.35rem;margin:0 0 .75rem}
+  p{line-height:1.55;color:#41474d}
+  a{color:#0b6e4f;font-weight:600;text-decoration:none}
+  a:hover{text-decoration:underline}
+</style></head>
+<body><div class="card">
+  <h1>You've been unsubscribed ✓</h1>
+  <p>You'll no longer receive <strong>{{.Label}}</strong> from Golden Tempo Travel.</p>
+  <p>Changed your mind, or want to fine-tune which emails you get? Manage your
+     preferences any time in <a href="{{.AppURL}}">your account settings</a>.</p>
+</div></body></html>`))
+
+func unsubscribeHandler(w http.ResponseWriter, r *http.Request) {
+	if dbPool == nil {
+		// Nothing we can persist; still answer human-friendly, not a 500 loop.
+		writeUnsubResult(w, r, "", http.StatusServiceUnavailable)
+		return
+	}
+	token := mux.Vars(r)["token"]
+	userID, category, ok := verifyUnsubscribeToken(token)
+	if !ok {
+		writeUnsubResult(w, r, "", http.StatusNotFound)
+		return
+	}
+	if !applyUnsubscribe(r.Context(), userID, category) {
+		// User gone (deleted account) — opaque 404, same as a bad token.
+		writeUnsubResult(w, r, "", http.StatusNotFound)
+		return
+	}
+	writeUnsubResult(w, r, category, http.StatusOK)
+}
+
+// writeUnsubResult renders the outcome: POST (one-click) callers get a terse
+// text/plain body (mail clients ignore it); GET callers get the HTML page on
+// success or a small HTML notice on failure.
+func writeUnsubResult(w http.ResponseWriter, r *http.Request, category string, status int) {
+	if r.Method == http.MethodPost {
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		w.WriteHeader(status)
+		if status == http.StatusOK {
+			w.Write([]byte("unsubscribed"))
+		} else {
+			w.Write([]byte("could not unsubscribe"))
+		}
+		return
+	}
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	if status != http.StatusOK {
+		w.WriteHeader(status)
+		w.Write([]byte("<!doctype html><html><body style=\"font-family:system-ui;padding:2rem\">" +
+			"<h2>This unsubscribe link is invalid or expired</h2>" +
+			"<p>Manage your email preferences in your account settings instead.</p></body></html>"))
+		return
+	}
+	// 200 is implicit on first write; render the friendly page.
+	unsubscribePage.Execute(w, struct {
+		Label  string
+		AppURL string
+	}{
+		Label:  unsubscribeCategoryLabel(category),
+		AppURL: publicAppURL(),
+	})
+}

--- a/src/packages/api/unsubscribe_integration_test.go
+++ b/src/packages/api/unsubscribe_integration_test.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"travel-route-planner/store"
+)
+
+// optOutFlags reads the two email opt-out columns straight from the DB.
+func optOutFlags(t *testing.T, userID interface{ String() string }) (reminders, nudges bool) {
+	t.Helper()
+	if err := dbPool.QueryRow(t.Context(),
+		`SELECT reminders_opt_out, nudges_opt_out FROM users WHERE id = $1`,
+		userID).Scan(&reminders, &nudges); err != nil {
+		t.Fatalf("read opt-out flags: %v", err)
+	}
+	return
+}
+
+// doUnsub drives the public unsubscribe route (no auth).
+func doUnsub(t *testing.T, method, token string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(method, "/api/v1/unsubscribe/"+token, nil)
+	req.Header.Set("X-Forwarded-For", nextTestIP())
+	rec := httptest.NewRecorder()
+	testRouter.ServeHTTP(rec, req)
+	return rec
+}
+
+func TestUnsubscribe_FlipsFlagPerCategory(t *testing.T) {
+	resetDB(t)
+	user, _ := createTestUser(t, "unsub@example.com")
+
+	// Default: both opted-in (opt_out false).
+	if r, n := optOutFlags(t, user.ID); r || n {
+		t.Fatalf("new user should be opted-in, got reminders_opt_out=%v nudges_opt_out=%v", r, n)
+	}
+
+	// Nudges link flips only nudges.
+	tok := newUnsubscribeToken(user.ID, unsubNudges)
+	if rec := doUnsub(t, "GET", tok); rec.Code != http.StatusOK {
+		t.Fatalf("unsubscribe nudges = %d: %s", rec.Code, rec.Body.String())
+	}
+	if r, n := optOutFlags(t, user.ID); r || !n {
+		t.Fatalf("after nudges unsub: reminders_opt_out=%v nudges_opt_out=%v, want false/true", r, n)
+	}
+
+	// Idempotent: clicking again still 200, still opted-out.
+	if rec := doUnsub(t, "GET", tok); rec.Code != http.StatusOK {
+		t.Fatalf("idempotent unsubscribe = %d", rec.Code)
+	}
+	if _, n := optOutFlags(t, user.ID); !n {
+		t.Fatal("second unsubscribe should keep nudges opted-out")
+	}
+
+	// "all" flips both.
+	allTok := newUnsubscribeToken(user.ID, unsubAll)
+	if rec := doUnsub(t, "POST", allTok); rec.Code != http.StatusOK {
+		t.Fatalf("unsubscribe all (POST) = %d: %s", rec.Code, rec.Body.String())
+	}
+	if r, n := optOutFlags(t, user.ID); !r || !n {
+		t.Fatalf("after all unsub: reminders_opt_out=%v nudges_opt_out=%v, want true/true", r, n)
+	}
+}
+
+func TestUnsubscribe_InvalidToken(t *testing.T) {
+	resetDB(t)
+	for _, bad := range []string{"garbage", "a.b", "not-a-token"} {
+		if rec := doUnsub(t, "GET", bad); rec.Code != http.StatusNotFound {
+			t.Fatalf("bad token %q = %d, want 404", bad, rec.Code)
+		}
+	}
+}
+
+func TestUnsubscribe_WrongUserGone(t *testing.T) {
+	resetDB(t)
+	user, _ := createTestUser(t, "gone-soon@example.com")
+	tok := newUnsubscribeToken(user.ID, unsubReminders)
+	// Delete the user, then the token points at nobody.
+	if _, err := store.New(dbPool).DeleteUser(t.Context(), user.ID); err != nil {
+		t.Fatal(err)
+	}
+	if rec := doUnsub(t, "GET", tok); rec.Code != http.StatusNotFound {
+		t.Fatalf("deleted-user token = %d, want 404", rec.Code)
+	}
+}
+
+func TestEmailPreferences_PatchAndMe(t *testing.T) {
+	resetDB(t)
+	_, token := createTestUser(t, "prefs@example.com")
+
+	// /auth/me reflects defaults: both enabled.
+	me := decode(t, doJSON(t, "GET", "/api/v1/auth/me", token, nil))
+	if me["reminders_enabled"] != true || me["nudges_enabled"] != true {
+		t.Fatalf("default prefs: %v", me)
+	}
+
+	// Toggle nudges off via PATCH.
+	rec := doJSON(t, "PATCH", "/api/v1/auth/email-preferences", token, map[string]any{
+		"nudges_enabled": false,
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("patch prefs = %d: %s", rec.Code, rec.Body.String())
+	}
+	body := decode(t, rec)
+	if body["nudges_enabled"] != false || body["reminders_enabled"] != true {
+		t.Fatalf("after patch: %v", body)
+	}
+
+	// Persisted on next /auth/me.
+	me2 := decode(t, doJSON(t, "GET", "/api/v1/auth/me", token, nil))
+	if me2["nudges_enabled"] != false {
+		t.Fatalf("nudges pref not persisted: %v", me2)
+	}
+}

--- a/src/packages/api/unsubscribe_token.go
+++ b/src/packages/api/unsubscribe_token.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"crypto/hmac"
+	"crypto/rand"
+	"encoding/base64"
+	"os"
+	"strings"
+	"sync"
+
+	"github.com/google/uuid"
+)
+
+// One-click email unsubscribe capability tokens. Like the export tokens, the
+// token IS the authorization — a public GET/POST to /api/v1/unsubscribe/{token}
+// verifies the HMAC signature and flips the opt-out flag, no session and no DB
+// row. Unlike export tokens these carry NO expiry: an unsubscribe link printed
+// in an email months ago must still work (CAN-SPAM/RFC 8058 expect indefinitely
+// honorable opt-out). The signature is the only thing standing between a
+// stranger and a user's preferences, so the signing secret must be stable in
+// production (a per-process random dev fallback means old links break on
+// restart, which is fine for local dev but never for prod). These helpers are
+// pure (no DB) so they unit-test cleanly.
+
+// Unsubscribe categories. "all" flips every opt-out flag at once (the footer
+// "unsubscribe from all email" link); the per-stream links use the specific
+// category so a user can silence the weekly nudge but keep trip reminders.
+const (
+	unsubReminders = "reminders"
+	unsubNudges    = "nudges"
+	unsubAll       = "all"
+)
+
+func validUnsubCategory(c string) bool {
+	switch c {
+	case unsubReminders, unsubNudges, unsubAll:
+		return true
+	}
+	return false
+}
+
+var (
+	unsubSecretOnce sync.Once
+	unsubSecret     []byte
+)
+
+// unsubscribeSigningSecret returns the HMAC key for unsubscribe tokens. It
+// prefers UNSUBSCRIBE_SIGNING_SECRET, then falls back to the shared
+// EXPORT_SIGNING_SECRET (so a single "app signing secret" env satisfies both),
+// and only if neither is set mints a random per-process secret. Random fallback
+// keeps dev tokens unforgeable but invalidates outstanding links on restart —
+// acceptable for local dev, never for prod (set the env there). The very
+// unlikely rand failure falls back to a fixed documented dev default rather
+// than panicking.
+func unsubscribeSigningSecret() []byte {
+	unsubSecretOnce.Do(func() {
+		if s := strings.TrimSpace(os.Getenv("UNSUBSCRIBE_SIGNING_SECRET")); s != "" {
+			unsubSecret = []byte(s)
+			return
+		}
+		if s := strings.TrimSpace(os.Getenv("EXPORT_SIGNING_SECRET")); s != "" {
+			unsubSecret = []byte(s)
+			return
+		}
+		buf := make([]byte, 32)
+		if _, err := rand.Read(buf); err != nil {
+			unsubSecret = []byte("golden-tempo-dev-unsubscribe-secret-default")
+			return
+		}
+		unsubSecret = buf
+	})
+	return unsubSecret
+}
+
+// signUnsubscribeToken builds a token for (userID, category) signed with secret.
+// Format mirrors export tokens: base64url(payload) + "." + base64url(HMAC),
+// where payload is the raw "<userID>|<category>" string. No expiry field.
+func signUnsubscribeToken(secret []byte, userID uuid.UUID, category string) string {
+	payload := userID.String() + "|" + category
+	sig := hmacSign(secret, payload)
+	enc := base64.RawURLEncoding
+	return enc.EncodeToString([]byte(payload)) + "." + enc.EncodeToString(sig)
+}
+
+// verifyUnsubscribeTokenWith validates token against secret, returning the user
+// id and category when the signature matches (constant-time) and the category
+// is one we recognize. Any structural, signature, or category problem returns
+// ok=false with no distinction — callers surface a single opaque 404.
+func verifyUnsubscribeTokenWith(secret []byte, token string) (uuid.UUID, string, bool) {
+	parts := strings.SplitN(token, ".", 2)
+	if len(parts) != 2 {
+		return uuid.UUID{}, "", false
+	}
+	enc := base64.RawURLEncoding
+	payloadBytes, err := enc.DecodeString(parts[0])
+	if err != nil {
+		return uuid.UUID{}, "", false
+	}
+	gotSig, err := enc.DecodeString(parts[1])
+	if err != nil {
+		return uuid.UUID{}, "", false
+	}
+	wantSig := hmacSign(secret, string(payloadBytes))
+	// Constant-time compare — never a byte-by-byte early return.
+	if !hmac.Equal(gotSig, wantSig) {
+		return uuid.UUID{}, "", false
+	}
+	fields := strings.SplitN(string(payloadBytes), "|", 2)
+	if len(fields) != 2 {
+		return uuid.UUID{}, "", false
+	}
+	category := fields[1]
+	if !validUnsubCategory(category) {
+		return uuid.UUID{}, "", false
+	}
+	id, err := uuid.Parse(fields[0])
+	if err != nil {
+		return uuid.UUID{}, "", false
+	}
+	return id, category, true
+}
+
+// newUnsubscribeToken mints a token for (userID, category) using the process
+// signing secret.
+func newUnsubscribeToken(userID uuid.UUID, category string) string {
+	return signUnsubscribeToken(unsubscribeSigningSecret(), userID, category)
+}
+
+// verifyUnsubscribeToken validates a token minted by newUnsubscribeToken.
+func verifyUnsubscribeToken(token string) (uuid.UUID, string, bool) {
+	return verifyUnsubscribeTokenWith(unsubscribeSigningSecret(), token)
+}
+
+// unsubscribeURL builds the absolute public one-click link for (userID,
+// category). The endpoint lives under the API prefix (/api/v1/unsubscribe/...),
+// NOT under the Flutter app path — publicAppPath is "/app/" in deployment and
+// would 404 the API route, the same gotcha as the export URLs.
+func unsubscribeURL(userID uuid.UUID, category string) string {
+	return publicBaseURL() + "/api/v1/unsubscribe/" + newUnsubscribeToken(userID, category)
+}

--- a/src/packages/api/unsubscribe_token_test.go
+++ b/src/packages/api/unsubscribe_token_test.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+var testUnsubSecret = []byte("test-unsubscribe-secret-0123456789")
+
+func TestUnsubscribeToken_RoundTrip(t *testing.T) {
+	for _, cat := range []string{unsubReminders, unsubNudges, unsubAll} {
+		id := uuid.New()
+		tok := signUnsubscribeToken(testUnsubSecret, id, cat)
+		gotID, gotCat, ok := verifyUnsubscribeTokenWith(testUnsubSecret, tok)
+		if !ok {
+			t.Fatalf("category %q: valid token failed to verify", cat)
+		}
+		if gotID != id {
+			t.Fatalf("category %q: user id mismatch: got %s want %s", cat, gotID, id)
+		}
+		if gotCat != cat {
+			t.Fatalf("category mismatch: got %q want %q", gotCat, cat)
+		}
+	}
+}
+
+func TestUnsubscribeToken_TamperedPayloadFails(t *testing.T) {
+	id := uuid.New()
+	tok := signUnsubscribeToken(testUnsubSecret, id, unsubNudges)
+	parts := strings.SplitN(tok, ".", 2)
+	// Keep the original signature but swap in a different user's payload.
+	other := signUnsubscribeToken(testUnsubSecret, uuid.New(), unsubNudges)
+	tampered := strings.SplitN(other, ".", 2)[0] + "." + parts[1]
+	if _, _, ok := verifyUnsubscribeTokenWith(testUnsubSecret, tampered); ok {
+		t.Fatal("tampered payload verified")
+	}
+}
+
+func TestUnsubscribeToken_TamperedSignatureFails(t *testing.T) {
+	id := uuid.New()
+	tok := signUnsubscribeToken(testUnsubSecret, id, unsubAll)
+	flipped := tok[:len(tok)-1]
+	if tok[len(tok)-1] == 'A' {
+		flipped += "B"
+	} else {
+		flipped += "A"
+	}
+	if _, _, ok := verifyUnsubscribeTokenWith(testUnsubSecret, flipped); ok {
+		t.Fatal("tampered signature verified")
+	}
+}
+
+func TestUnsubscribeToken_WrongSecretFails(t *testing.T) {
+	id := uuid.New()
+	tok := signUnsubscribeToken(testUnsubSecret, id, unsubReminders)
+	if _, _, ok := verifyUnsubscribeTokenWith([]byte("a-completely-different-secret"), tok); ok {
+		t.Fatal("token verified under the wrong secret")
+	}
+}
+
+func TestUnsubscribeToken_UnknownCategoryFails(t *testing.T) {
+	// A validly-signed token whose category isn't one we recognize must fail —
+	// guards against a widened category set on one side of a deploy.
+	id := uuid.New()
+	tok := signUnsubscribeToken(testUnsubSecret, id, "promotions")
+	if _, _, ok := verifyUnsubscribeTokenWith(testUnsubSecret, tok); ok {
+		t.Fatal("unknown category verified")
+	}
+}
+
+func TestUnsubscribeToken_MalformedFails(t *testing.T) {
+	for _, bad := range []string{"", "no-dot", "a.b.c", "!!!.###", "."} {
+		if _, _, ok := verifyUnsubscribeTokenWith(testUnsubSecret, bad); ok {
+			t.Fatalf("malformed token %q verified", bad)
+		}
+	}
+}
+
+func TestListUnsubscribeHeaders(t *testing.T) {
+	// Empty URL => no headers (a marketing send without a link stays plain).
+	if got := listUnsubscribeHeaders("  "); got != nil {
+		t.Fatalf("empty url should yield nil headers, got %v", got)
+	}
+	url := "https://app.example.com/api/v1/unsubscribe/tok.sig"
+	got := listUnsubscribeHeaders(url)
+	want := []string{
+		"List-Unsubscribe: <" + url + ">",
+		"List-Unsubscribe-Post: List-Unsubscribe=One-Click",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("header count = %d, want %d: %v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("header[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+
+	// The full message must carry both headers, in order, above the body.
+	msg := buildEmailMessage("from@x.com", "to@y.com", "Weekly ideas", "hello", got)
+	if !strings.Contains(msg, "\r\nList-Unsubscribe: <"+url+">\r\n") {
+		t.Fatalf("message missing List-Unsubscribe header:\n%s", msg)
+	}
+	if !strings.Contains(msg, "\r\nList-Unsubscribe-Post: List-Unsubscribe=One-Click\r\n\r\nhello") {
+		t.Fatalf("message missing List-Unsubscribe-Post header before body:\n%s", msg)
+	}
+}

--- a/src/packages/flutter-app/lib/models/user.dart
+++ b/src/packages/flutter-app/lib/models/user.dart
@@ -15,6 +15,13 @@ class UserModel {
   @JsonKey(name: 'created_at')
   final DateTime createdAt;
 
+  /// Email preferences, expressed as opt-INs (true = receiving). Default true
+  /// so older payloads without the fields read as opted-in.
+  @JsonKey(name: 'reminders_enabled')
+  final bool remindersEnabled;
+  @JsonKey(name: 'nudges_enabled')
+  final bool nudgesEnabled;
+
   const UserModel({
     required this.id,
     required this.email,
@@ -22,6 +29,8 @@ class UserModel {
     this.isAdmin = false,
     this.needsOnboarding = false,
     required this.createdAt,
+    this.remindersEnabled = true,
+    this.nudgesEnabled = true,
   });
 
   factory UserModel.fromJson(Map<String, dynamic> json) =>

--- a/src/packages/flutter-app/lib/models/user.g.dart
+++ b/src/packages/flutter-app/lib/models/user.g.dart
@@ -13,6 +13,8 @@ UserModel _$UserModelFromJson(Map<String, dynamic> json) => UserModel(
       isAdmin: json['is_admin'] as bool? ?? false,
       needsOnboarding: json['needs_onboarding'] as bool? ?? false,
       createdAt: DateTime.parse(json['created_at'] as String),
+      remindersEnabled: json['reminders_enabled'] as bool? ?? true,
+      nudgesEnabled: json['nudges_enabled'] as bool? ?? true,
     );
 
 Map<String, dynamic> _$UserModelToJson(UserModel instance) => <String, dynamic>{
@@ -22,6 +24,8 @@ Map<String, dynamic> _$UserModelToJson(UserModel instance) => <String, dynamic>{
       'is_admin': instance.isAdmin,
       'needs_onboarding': instance.needsOnboarding,
       'created_at': instance.createdAt.toIso8601String(),
+      'reminders_enabled': instance.remindersEnabled,
+      'nudges_enabled': instance.nudgesEnabled,
     };
 
 AuthResponse _$AuthResponseFromJson(Map<String, dynamic> json) => AuthResponse(

--- a/src/packages/flutter-app/lib/screens/account_settings_screen.dart
+++ b/src/packages/flutter-app/lib/screens/account_settings_screen.dart
@@ -84,6 +84,20 @@ class _AccountSettingsScreenState extends ConsumerState<AccountSettingsScreen> {
         _snack('Password changed — other devices were signed out');
       });
 
+  Future<void> _setReminders(bool enabled) => _run(() async {
+        final user = await ref
+            .read(accountApiServiceProvider)
+            .updateEmailPreferences(remindersEnabled: enabled);
+        ref.read(authProvider.notifier).setUser(user);
+      });
+
+  Future<void> _setNudges(bool enabled) => _run(() async {
+        final user = await ref
+            .read(accountApiServiceProvider)
+            .updateEmailPreferences(nudgesEnabled: enabled);
+        ref.read(authProvider.notifier).setUser(user);
+      });
+
   Future<void> _logoutAll() => _run(() async {
         await ref.read(accountApiServiceProvider).logoutAll();
         // Our own session died too; sign out locally and let AuthGate route.
@@ -220,6 +234,25 @@ class _AccountSettingsScreenState extends ConsumerState<AccountSettingsScreen> {
                 label: const Text('Sign out everywhere'),
                 onPressed: _busy ? null : _logoutAll,
               ),
+            ),
+            const SizedBox(height: AppSpacing.xl),
+            const SectionHeader(title: 'Email preferences'),
+            const SizedBox(height: AppSpacing.sm),
+            SwitchListTile(
+              contentPadding: EdgeInsets.zero,
+              title: const Text('Trip reminders'),
+              subtitle: const Text(
+                  'Nudges about upcoming trips and things left to book.'),
+              value: user?.remindersEnabled ?? true,
+              onChanged: _busy ? null : (v) => _setReminders(v),
+            ),
+            SwitchListTile(
+              contentPadding: EdgeInsets.zero,
+              title: const Text('Weekly planning ideas'),
+              subtitle: const Text(
+                  'A weekly email with destination ideas and inspiration.'),
+              value: user?.nudgesEnabled ?? true,
+              onChanged: _busy ? null : (v) => _setNudges(v),
             ),
             const SizedBox(height: AppSpacing.xl),
             const SectionHeader(title: 'Legal'),

--- a/src/packages/flutter-app/lib/services/account_api_service.dart
+++ b/src/packages/flutter-app/lib/services/account_api_service.dart
@@ -53,6 +53,26 @@ class AccountApiService {
     throw Exception(_message(res.body, res.statusCode));
   }
 
+  /// Updates email preferences (opt-INs: true = receiving). Pass only the
+  /// stream(s) you're changing; returns the refreshed user.
+  Future<UserModel> updateEmailPreferences({
+    bool? remindersEnabled,
+    bool? nudgesEnabled,
+  }) async {
+    final body = <String, dynamic>{};
+    if (remindersEnabled != null) body['reminders_enabled'] = remindersEnabled;
+    if (nudgesEnabled != null) body['nudges_enabled'] = nudgesEnabled;
+    final res = await apiClient.httpClient.patch(
+      Uri.parse('${apiClient.baseUrl}/auth/email-preferences'),
+      headers: apiClient.jsonHeaders(json: true),
+      body: jsonEncode(body),
+    );
+    if (res.statusCode == 200) {
+      return UserModel.fromJson(jsonDecode(res.body));
+    }
+    throw Exception(_message(res.body, res.statusCode));
+  }
+
   Future<void> logoutAll() async {
     final res = await apiClient.httpClient.post(
       Uri.parse('${apiClient.baseUrl}/auth/logout-all'),


### PR DESCRIPTION
## Wave 16 PR 1 — email preferences + one-click unsubscribe

Foundation for the re-engagement wave. No email-preference concept existed; a weekly marketing nudge legally needs opt-out. Both streams (trip reminders + weekly nudge) **default ON (opt-out)**, each independently unsubscribable.

### Backend
- **Migration `00044_email_prefs.sql`**: adds `users.reminders_opt_out` / `nudges_opt_out` (`NOT NULL DEFAULT false` = opted-IN); Down drops them. `SetUserEmailOptOut` sqlc query is category-partial (NULL narg leaves a flag untouched).
- **`unsubscribe_token.go`**: HMAC-SHA256 signed capability token encoding `user_id` + `category` (`reminders`|`nudges`|`all`), **no expiry** (unsubscribe links must work indefinitely), constant-time verify. Reuses the export-token `hmacSign` helper. Secret from `UNSUBSCRIBE_SIGNING_SECRET`, falling back to `EXPORT_SIGNING_SECRET`, then a random per-process dev key.
- **`GET`/`POST /api/v1/unsubscribe/{token}`** (public, no auth — the token is the capability): verifies, flips the opt-out flag(s), idempotent. `GET` renders a friendly HTML confirmation page (`html/template`) linking back to account settings; `POST` is the RFC 8058 `List-Unsubscribe-Post` one-click flow.
- **`EmailService.SendMarketing` / `SendWithHeaders`**: add `List-Unsubscribe` + `List-Unsubscribe-Post: List-Unsubscribe=One-Click` headers via a pure, unit-tested `buildEmailMessage`. Transactional `Send` is untouched. Unsubscribe URL built as `publicBaseURL()+"/api/v1/unsubscribe/"+token` (API prefix, **not** the `/app/` app path).
- **`PATCH /api/v1/auth/email-preferences`** + `reminders_enabled`/`nudges_enabled` (opt-IN) on the user response (so `/auth/me` is the "get prefs" read).

### Flutter
- "Email preferences" section in `account_settings_screen.dart` with two opt-IN switches (ON = receiving), backed by `updateEmailPreferences` on the account API service and the two new `UserModel` fields.

### Tests
- Pure: unsubscribe token round-trip (all categories), tampered payload/signature, wrong secret, unknown category, malformed; `List-Unsubscribe` header construction.
- Integration (own DB): valid token flips the right flag per category, idempotent, invalid → 404, deleted-user token → 404; PATCH prefs + `/auth/me` persistence.
- `go test ./...` (incl. integration), `go vet`, `flutter test` (329 pass), `flutter analyze` (12 baseline infos, 0 added).

🤖 Generated with [Claude Code](https://claude.com/claude-code)