### PR TITLE
fix: strict base64 for signed tokens; deterministic tamper test

### DIFF
--- a/src/packages/api/export_token.go
+++ b/src/packages/api/export_token.go
@@ -57,7 +57,7 @@ func exportSigningSecret() []byte {
 func signExportToken(secret []byte, tripID uuid.UUID, exp time.Time) string {
 	payload := tripID.String() + "|" + strconv.FormatInt(exp.Unix(), 10)
 	sig := hmacSign(secret, payload)
-	enc := base64.RawURLEncoding
+	enc := base64.RawURLEncoding.Strict()
 	return enc.EncodeToString([]byte(payload)) + "." + enc.EncodeToString(sig)
 }
 
@@ -70,7 +70,7 @@ func verifyExportTokenWith(secret []byte, token string, now time.Time) (uuid.UUI
 	if len(parts) != 2 {
 		return uuid.UUID{}, false
 	}
-	enc := base64.RawURLEncoding
+	enc := base64.RawURLEncoding.Strict()
 	payloadBytes, err := enc.DecodeString(parts[0])
 	if err != nil {
 		return uuid.UUID{}, false

--- a/src/packages/api/unsubscribe_token.go
+++ b/src/packages/api/unsubscribe_token.go
@@ -78,7 +78,7 @@ func unsubscribeSigningSecret() []byte {
 func signUnsubscribeToken(secret []byte, userID uuid.UUID, category string) string {
 	payload := userID.String() + "|" + category
 	sig := hmacSign(secret, payload)
-	enc := base64.RawURLEncoding
+	enc := base64.RawURLEncoding.Strict()
 	return enc.EncodeToString([]byte(payload)) + "." + enc.EncodeToString(sig)
 }
 
@@ -91,7 +91,7 @@ func verifyUnsubscribeTokenWith(secret []byte, token string) (uuid.UUID, string,
 	if len(parts) != 2 {
 		return uuid.UUID{}, "", false
 	}
-	enc := base64.RawURLEncoding
+	enc := base64.RawURLEncoding.Strict()
 	payloadBytes, err := enc.DecodeString(parts[0])
 	if err != nil {
 		return uuid.UUID{}, "", false

--- a/src/packages/api/unsubscribe_token_test.go
+++ b/src/packages/api/unsubscribe_token_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/base64"
 	"strings"
 	"testing"
 
@@ -41,12 +42,17 @@ func TestUnsubscribeToken_TamperedPayloadFails(t *testing.T) {
 func TestUnsubscribeToken_TamperedSignatureFails(t *testing.T) {
 	id := uuid.New()
 	tok := signUnsubscribeToken(testUnsubSecret, id, unsubAll)
-	flipped := tok[:len(tok)-1]
-	if tok[len(tok)-1] == 'A' {
-		flipped += "B"
-	} else {
-		flipped += "A"
+	// Tamper the signature by flipping a byte of the DECODED signature and
+	// re-encoding — flipping the last base64 char is unreliable because
+	// non-strict RawURLEncoding ignores its trailing padding bits, so the
+	// decode can round-trip to the same bytes and "verify" a tampered token.
+	parts := strings.SplitN(tok, ".", 2)
+	sig, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		t.Fatalf("decode signature: %v", err)
 	}
+	sig[0] ^= 0xFF
+	flipped := parts[0] + "." + base64.RawURLEncoding.EncodeToString(sig)
 	if _, _, ok := verifyUnsubscribeTokenWith(testUnsubSecret, flipped); ok {
 		t.Fatal("tampered signature verified")
 	}


### PR DESCRIPTION
The Wave-16 CI flake on `TestUnsubscribeToken_TamperedSignatureFails` was a deterministic-but-uuid-seeded test bug: flipping the last base64 char of a signature is a no-op on the decoded bytes when non-strict `RawURLEncoding` ignores its trailing padding bits, so a tampered token could verify.

- **Verify paths** in `unsubscribe_token.go` + `export_token.go` decode with `RawURLEncoding.Strict()` — rejects malleable tokens (non-zero padding bits); encode output unchanged.
- **Test** tampers a decoded signature byte + re-encodes; deterministic. 20× under `-race`: green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)