### PR TITLE
docs: finalize legal pages for launch (HELD for legal sign-off)

### DIFF
--- a/dockerize/static/privacy.html
+++ b/dockerize/static/privacy.html
@@ -3,7 +3,6 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="robots" content="noindex">
   <title>Privacy Policy — Golden Tempo Travel</title>
   <style>
     * { box-sizing: border-box; }
@@ -14,15 +13,6 @@
       color: #263238;
       background: #fafafa;
       line-height: 1.6;
-    }
-    .draft-banner {
-      background: #fff3cd;
-      color: #664d03;
-      border-bottom: 1px solid #ffe69c;
-      text-align: center;
-      padding: 10px 16px;
-      font-weight: 600;
-      font-size: 0.95rem;
     }
     header {
       background: linear-gradient(to bottom right, #00897B, #004D40);
@@ -77,12 +67,11 @@
   </style>
 </head>
 <body>
-  <div class="draft-banner">DRAFT — pending legal review. This document is not yet final.</div>
   <header>
     <div class="wrap">
       <p class="brand">Golden Tempo Travel</p>
       <h1>Privacy Policy</h1>
-      <p class="meta">Draft of July 6, 2026 · Golden Tempo LLC</p>
+      <p class="meta">Effective <!-- TODO: set launch date --> · Golden Tempo LLC</p>
     </div>
   </header>
   <main>

--- a/dockerize/static/terms.html
+++ b/dockerize/static/terms.html
@@ -3,7 +3,6 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="robots" content="noindex">
   <title>Terms of Service — Golden Tempo Travel</title>
   <style>
     * { box-sizing: border-box; }
@@ -14,15 +13,6 @@
       color: #263238;
       background: #fafafa;
       line-height: 1.6;
-    }
-    .draft-banner {
-      background: #fff3cd;
-      color: #664d03;
-      border-bottom: 1px solid #ffe69c;
-      text-align: center;
-      padding: 10px 16px;
-      font-weight: 600;
-      font-size: 0.95rem;
     }
     header {
       background: linear-gradient(to bottom right, #00897B, #004D40);
@@ -68,12 +58,11 @@
   </style>
 </head>
 <body>
-  <div class="draft-banner">DRAFT — pending legal review. This document is not yet final.</div>
   <header>
     <div class="wrap">
       <p class="brand">Golden Tempo Travel</p>
       <h1>Terms of Service</h1>
-      <p class="meta">Draft of July 6, 2026 · Golden Tempo LLC</p>
+      <p class="meta">Effective <!-- TODO: set launch date --> · Golden Tempo LLC</p>
     </div>
   </header>
   <main>


### PR DESCRIPTION
⚠️ DO NOT MERGE until Brian confirms the legal review is complete. Removes the DRAFT banners + noindex, sets Effective-date TODO. Confirm the goldentempollc@gmail.com published contact.

## What changed

Banner / meta / date hygiene on `dockerize/static/privacy.html` and `dockerize/static/terms.html` — no legal body text was touched. Identical edits to both files:

1. **DRAFT banner removed** — deleted `<div class="draft-banner">DRAFT — pending legal review. This document is not yet final.</div>` and its `.draft-banner` CSS rule in the `<style>` block (no orphaned CSS left; grep confirms zero remaining references).
2. **Effective-date placeholder** — `<p class="meta">Draft of July 6, 2026 · Golden Tempo LLC</p>` → `<p class="meta">Effective <!-- TODO: set launch date --> · Golden Tempo LLC</p>`. The `TODO` comment stays so Brian sets the real launch date when he flips DNS.
3. **noindex removed** — deleted `<meta name="robots" content="noindex">`. These pages are already listed in `dockerize/static/sitemap.xml` (`https://goldentempo.co/privacy`, `https://goldentempo.co/terms`), so noindex contradicts the sitemap at launch.

`git diff --stat`: 2 files, +2 / −24. Nothing else changed.

## Needs Brian's confirmation

- **Legal review**: removing the DRAFT banner asserts the review happened. That's your call — this PR is HELD for your sign-off before merge.
- **Published contact address**: the pages publish `goldentempollc@gmail.com` (in the intro + the closing "Contact" block, as `Golden Tempo LLC (New Jersey, USA)`). Left unchanged per task scope — please confirm the gmail is the intended public-facing contact vs. a custom domain address (e.g. hello@goldentempo.co) before go-live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)