### PR TITLE
fix: warn on unset signing secrets; document them in prod env

### DIFF
--- a/dockerize/production/.env.sample
+++ b/dockerize/production/.env.sample
@@ -100,6 +100,16 @@ SMTP_PASSWORD=
 SMTP_FROM=
 
 # ---------------------------------------------------------------------------
+# Signing secrets (HMAC keys for capability links)
+# ---------------------------------------------------------------------------
+# REQUIRED in production — a stable random value (e.g. `openssl rand -hex 32`).
+# Unset => a per-process random key that breaks all outstanding
+# unsubscribe/export links on every restart/deploy. UNSUBSCRIBE_SIGNING_SECRET
+# falls back to EXPORT_SIGNING_SECRET if unset, so setting one is enough.
+EXPORT_SIGNING_SECRET=
+UNSUBSCRIBE_SIGNING_SECRET=
+
+# ---------------------------------------------------------------------------
 # Observability
 # ---------------------------------------------------------------------------
 

--- a/src/packages/api/.env.sample
+++ b/src/packages/api/.env.sample
@@ -59,10 +59,14 @@ PUBLIC_BASE_URL=
 # Path prefix the Flutter app is served under, for app deep links in emails
 # ("/" default, "/app/" in deployment). Normalized to start+end with "/".
 PUBLIC_APP_PATH=
-# HMAC secret for one-click email unsubscribe links (RFC 8058). Set a STABLE
-# value in production so unsubscribe links printed in old emails keep working
-# across restarts; falls back to EXPORT_SIGNING_SECRET, then a random
-# per-process key in dev (breaks outstanding links on restart — dev-only).
+# HMAC signing secrets for capability links (owner-private trip export tokens
+# and one-click email unsubscribe links, RFC 8058). Set a STABLE random value
+# (e.g. `openssl rand -hex 32`) in production so links printed in old emails
+# keep working across restarts; unset => a per-process random key that breaks
+# every outstanding unsubscribe/export link on restart (fine for local dev only).
+# UNSUBSCRIBE_SIGNING_SECRET falls back to EXPORT_SIGNING_SECRET if unset, so
+# setting one secret covers both.
+EXPORT_SIGNING_SECRET=
 UNSUBSCRIBE_SIGNING_SECRET=
 
 # Price alerts checker cadence (optional; defaults shown)

--- a/src/packages/api/main.go
+++ b/src/packages/api/main.go
@@ -548,6 +548,31 @@ func initSentry() bool {
 	return true
 }
 
+// shouldWarnSigningSecrets reports whether the app is running in production with
+// NO stable HMAC signing secret configured. In that state both export tokens and
+// unsubscribe tokens fall back to a per-process random key (see export_token.go /
+// unsubscribe_token.go), so every restart/deploy silently invalidates all
+// outstanding one-click unsubscribe links (which RFC 8058 / CAN-SPAM require to
+// stay honorable indefinitely) and 1h export links. Since UNSUBSCRIBE_SIGNING_SECRET
+// falls back to EXPORT_SIGNING_SECRET, either one being set clears the warning.
+// Pure (no env reads) so it unit-tests cleanly.
+func shouldWarnSigningSecrets(goEnv, exportSecret, unsubSecret string) bool {
+	return goEnv == "production" &&
+		strings.TrimSpace(exportSecret) == "" &&
+		strings.TrimSpace(unsubSecret) == ""
+}
+
+// warnIfSigningSecretsUnset emits a loud startup warning (never fatal — a soft
+// launch shouldn't die on this) when running in production without a stable
+// signing secret. Reads the raw envs directly, which is non-invasive: the token
+// files resolve their secret lazily via sync.Once, so this re-read does not force
+// or perturb their initialization.
+func warnIfSigningSecretsUnset() {
+	if shouldWarnSigningSecrets(os.Getenv("GO_ENV"), os.Getenv("EXPORT_SIGNING_SECRET"), os.Getenv("UNSUBSCRIBE_SIGNING_SECRET")) {
+		slog.Warn("signing secrets unset — outstanding unsubscribe/export links will break on restart; set EXPORT_SIGNING_SECRET (openssl rand -hex 32) in production")
+	}
+}
+
 func main() {
 	// slog is the canonical logger; SetDefault also routes the stdlib log
 	// package through the same handler, so existing log.Printf call sites
@@ -605,6 +630,11 @@ func main() {
 		defer dbPool.Close()
 		log.Println("Connected to database; migrations applied")
 	}
+
+	// Loud production warning when no stable signing secret is configured: the
+	// token files fall back to a per-process random key, which breaks every
+	// outstanding unsubscribe/export link on restart. Non-fatal by design.
+	warnIfSigningSecretsUnset()
 
 	// Background price-alert checker (specs/price-alerts); no-ops in
 	// degraded mode or without a Duffel token.

--- a/src/packages/api/signing_secrets_warn_test.go
+++ b/src/packages/api/signing_secrets_warn_test.go
@@ -1,0 +1,32 @@
+package main
+
+import "testing"
+
+// TestShouldWarnSigningSecrets covers the pure decision behind the production
+// startup warning: warn only when running in production with neither signing
+// secret set. Anything else (dev, or at least one secret present) stays quiet.
+func TestShouldWarnSigningSecrets(t *testing.T) {
+	tests := []struct {
+		name         string
+		goEnv        string
+		exportSecret string
+		unsubSecret  string
+		want         bool
+	}{
+		{name: "production, both empty -> warn", goEnv: "production", want: true},
+		{name: "production, whitespace-only secrets -> warn", goEnv: "production", exportSecret: "  ", unsubSecret: "\t", want: true},
+		{name: "production, export set -> quiet", goEnv: "production", exportSecret: "abc", want: false},
+		{name: "production, unsub set -> quiet", goEnv: "production", unsubSecret: "abc", want: false},
+		{name: "production, both set -> quiet", goEnv: "production", exportSecret: "abc", unsubSecret: "def", want: false},
+		{name: "dev, both empty -> quiet", goEnv: "", want: false},
+		{name: "development env, both empty -> quiet", goEnv: "development", want: false},
+		{name: "staging, both empty -> quiet", goEnv: "staging", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := shouldWarnSigningSecrets(tt.goEnv, tt.exportSecret, tt.unsubSecret); got != tt.want {
+				t.Errorf("shouldWarnSigningSecrets(%q, %q, %q) = %v, want %v", tt.goEnv, tt.exportSecret, tt.unsubSecret, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## The bug (real launch blocker)

`EXPORT_SIGNING_SECRET` and `UNSUBSCRIBE_SIGNING_SECRET` were **absent from `dockerize/production/.env.sample`**. When neither is set, `export_token.go` and `unsubscribe_token.go` each mint a **RANDOM per-process HMAC key** via `sync.Once`.

Because every deploy restarts the API, that per-process key changes on each deploy — silently invalidating:
- **all outstanding one-click unsubscribe links** — RFC 8058 / CAN-SPAM require these to stay honorable indefinitely, so breaking them is a compliance problem, not just a UX one; and
- outstanding 1h export links.

An operator following the prod `.env.sample` would never know to set the secret, and nothing at startup flagged it.

## Fix

- **Document both secrets** in `dockerize/production/.env.sample` and `src/packages/api/.env.sample`: a stable random value (`openssl rand -hex 32`), with the note that `UNSUBSCRIBE_SIGNING_SECRET` falls back to `EXPORT_SIGNING_SECRET`, so setting one is enough.
- **Loud, non-fatal startup warning** (`slog.Warn`) when `GO_ENV=production` and neither secret is set — matching the existing SMTP / degraded-mode warnings. Deliberately **not** fail-fast: a soft launch shouldn't die on this; the visible warning is the surface.
- **Pure, unit-tested helper** `shouldWarnSigningSecrets(goEnv, export, unsub)` so the decision is testable. Token behavior is untouched — no forced init; the startup env re-read is non-invasive (the token files still resolve lazily via `sync.Once`).

## Tests

`shouldWarnSigningSecrets` table test covers production-both-empty (warn), whitespace-only (warn), either-set (quiet), and dev/staging (quiet). `make api-fmt`, `make api-vet`, and `go test ./...` all pass; existing token tests unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)