### PR TITLE
feat(api): deterministic trip-review rule engine + GET /trips/{id}/review

### DIFF
--- a/src/packages/api/main.go
+++ b/src/packages/api/main.go
@@ -849,6 +849,7 @@ func buildRouter() *mux.Router {
 	api.Handle("/trips/{id}/budget/expenses", authMiddleware(http.HandlerFunc(addExpenseHandler))).Methods("POST")
 	api.Handle("/trips/{id}/budget/expenses/{expenseId}", authMiddleware(http.HandlerFunc(patchExpenseHandler))).Methods("PATCH")
 	api.Handle("/trips/{id}/budget/expenses/{expenseId}", authMiddleware(http.HandlerFunc(deleteExpenseHandler))).Methods("DELETE")
+	api.Handle("/trips/{id}/review", authMiddleware(http.HandlerFunc(getTripReviewHandler))).Methods("GET")
 
 	// Local-source content — curation is admin-only (authMiddleware + adminMiddleware).
 	api.Handle("/admin/local/sources", admin(listLocalSourcesHandler)).Methods("GET")

--- a/src/packages/api/review_handler.go
+++ b/src/packages/api/review_handler.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"net/http"
+	"strconv"
+
+	"travel-route-planner/store"
+)
+
+// review_handler.go — GET /api/v1/trips/{id}/review. A read-only, deterministic
+// projection: no writes, no external calls. Authorized exactly like the budget
+// and checklist trip-scoped routes (editableTrip: owner or active editor-
+// collaborator); a missing or non-editable trip 404s.
+
+// ReviewResponse envelopes the ordered findings so the payload can grow
+// (summary counts, etc.) without breaking clients.
+type ReviewResponse struct {
+	Findings []Finding `json:"findings"`
+}
+
+func getTripReviewHandler(w http.ResponseWriter, r *http.Request) {
+	trip, ok := editableTrip(w, r)
+	if !ok {
+		return
+	}
+	data, ok := loadExportData(r.Context(), trip.ID)
+	if !ok {
+		writeJSONError(w, http.StatusNotFound, "trip not found")
+		return
+	}
+
+	// Budget lives outside exportData; load it the same way getBudgetHandler
+	// does and hand reviewTrip the derived response so checkBudget stays pure.
+	q := store.New(dbPool)
+	var budget *store.TripBudget
+	if b, err := q.GetBudgetByTrip(r.Context(), trip.ID); err == nil {
+		budget = &b
+	}
+	expenses, err := q.ListExpensesByTrip(r.Context(), trip.ID)
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "could not load budget")
+		return
+	}
+	br := buildBudgetResponse(budget, expenses)
+
+	// PR3 wires the operating-hours check behind ?check_hours=true; accepted
+	// (and tolerantly parsed) now so the surface is stable.
+	checkHours, _ := strconv.ParseBool(r.URL.Query().Get("check_hours"))
+
+	findings := reviewTrip(data, reviewOptions{CheckHours: checkHours, Budget: &br})
+	writeJSON(w, http.StatusOK, ReviewResponse{Findings: findings})
+}

--- a/src/packages/api/trip_review.go
+++ b/src/packages/api/trip_review.go
@@ -1,0 +1,348 @@
+package main
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"travel-route-planner/store"
+)
+
+// trip_review.go — a DETERMINISTIC, read-only trip review. It flags real
+// problems in a saved trip (unscheduled items, uncovered nights, missing
+// transport, over budget, unconfirmed bookings, …) by walking the already-
+// loaded exportData. NO AI, NO external calls, NO migration: every finding
+// traces to persisted data, so nothing here can hallucinate. reviewTrip is a
+// pure function over its inputs — each check is a small, individually-testable
+// helper so PR3 can add checkWeather/checkHours alongside without reshaping it.
+
+// Finding is one flagged issue. Day/ItemID follow ItineraryItemResponse's
+// nullable-pointer + omitempty convention: absent when the finding isn't tied
+// to a specific day or entity. Severity is info|warn|critical; Category is one
+// of dates|unscheduled|packing|lodging|transit|budget|bookings.
+type Finding struct {
+	Severity string  `json:"severity"`
+	Category string  `json:"category"`
+	Message  string  `json:"message"`
+	TripID   string  `json:"trip_id"`
+	Day      *int    `json:"day,omitempty"`
+	ItemID   *string `json:"item_id,omitempty"`
+}
+
+// reviewOptions carries inputs that don't live on exportData. Budget is the
+// pre-computed BudgetResponse (nil when there's no budget row) so checkBudget
+// stays a pure reader. CheckHours is accepted now but unused in PR1 — PR3
+// wires the operating-hours check behind it.
+type reviewOptions struct {
+	CheckHours bool
+	Budget     *BudgetResponse
+}
+
+// reviewTrip runs every deterministic check over the loaded trip data and
+// returns the findings in a stable order (by day, then severity, then
+// category) so the output is reproducible for a given trip snapshot.
+func reviewTrip(data exportData, opts reviewOptions) []Finding {
+	findings := make([]Finding, 0)
+	findings = append(findings, checkDates(data)...)
+	findings = append(findings, checkUnscheduled(data)...)
+	findings = append(findings, checkDensity(data)...)
+	findings = append(findings, checkLodging(data)...)
+	findings = append(findings, checkTransit(data)...)
+	findings = append(findings, checkBudget(data, opts.Budget)...)
+	findings = append(findings, checkBookings(data)...)
+
+	severityRank := map[string]int{"critical": 0, "warn": 1, "info": 2}
+	sort.SliceStable(findings, func(i, j int) bool {
+		di, dj := findingDayKey(findings[i]), findingDayKey(findings[j])
+		if di != dj {
+			return di < dj
+		}
+		if si, sj := severityRank[findings[i].Severity], severityRank[findings[j].Severity]; si != sj {
+			return si < sj
+		}
+		return findings[i].Category < findings[j].Category
+	})
+	return findings
+}
+
+// findingDayKey sorts undated findings (Day == nil) after all day-bound ones.
+func findingDayKey(f Finding) int {
+	if f.Day == nil {
+		return 1 << 30
+	}
+	return *f.Day
+}
+
+// tripDayCount is the number of days the trip's DATES cover (start..end,
+// inclusive) — the date-span branch of trip_days.dart's dayCount. Unlike the
+// Dart helper it deliberately does NOT fold in tagged item days: this is the
+// yardstick the beyond-span check measures items against, so an item tagged
+// past the span must not extend the yardstick to hide itself. 0 when undated.
+func tripDayCount(trip store.Trip) int {
+	if !trip.StartDate.Valid || !trip.EndDate.Valid {
+		return 0
+	}
+	return nightsBetween(trip.StartDate.Time, trip.EndDate.Time) + 1
+}
+
+// nightsBetween counts whole calendar days from start to end. pgtype dates are
+// UTC midnights, so the subtraction is exact; the +0.5 guards against any FP
+// drift.
+func nightsBetween(start, end time.Time) int {
+	return int(end.Sub(start).Hours()/24 + 0.5)
+}
+
+// checkDates flags a trip with no dates (blocks every day-bound check) and any
+// item tagged to a day past the trip's span.
+func checkDates(d exportData) []Finding {
+	tripID := d.Trip.ID.String()
+	var out []Finding
+	if !d.Trip.StartDate.Valid || !d.Trip.EndDate.Valid {
+		out = append(out, Finding{
+			Severity: "info", Category: "dates", TripID: tripID,
+			Message: "Add trip dates to unlock day-by-day checks.",
+		})
+		return out // no span → the beyond-span check below is meaningless
+	}
+	dc := tripDayCount(d.Trip)
+	for _, it := range d.Items {
+		if it.Day != nil && int(*it.Day) > dc {
+			day := int(*it.Day)
+			id := it.ID.String()
+			out = append(out, Finding{
+				Severity: "warn", Category: "dates", TripID: tripID, Day: &day, ItemID: &id,
+				Message: fmt.Sprintf("%q is on day %d, past the trip's %d-day span.", it.Name, day, dc),
+			})
+		}
+	}
+	return out
+}
+
+// checkUnscheduled emits one grouped finding for all items with no day (cleaner
+// than one-per-item when many are unscheduled).
+func checkUnscheduled(d exportData) []Finding {
+	var count int
+	for _, it := range d.Items {
+		if it.Day == nil {
+			count++
+		}
+	}
+	if count == 0 {
+		return nil
+	}
+	msg := "1 item has no day assigned — schedule it to see it on the day plan."
+	if count > 1 {
+		msg = fmt.Sprintf("%d items have no day assigned — schedule them to see them on the day plan.", count)
+	}
+	return []Finding{{
+		Severity: "info", Category: "unscheduled", TripID: d.Trip.ID.String(), Message: msg,
+	}}
+}
+
+// checkDensity flags empty days between the first and last scheduled day, and
+// over-packed days (more than 6 items, or two+ items sharing a time_of_day).
+// Buckets by absolute day so a day split across hubs still counts once.
+func checkDensity(d exportData) []Finding {
+	tripID := d.Trip.ID.String()
+	buckets := map[int][]store.ItineraryItem{}
+	minDay, maxDay := 0, 0
+	for _, it := range d.Items {
+		if it.Day == nil {
+			continue
+		}
+		day := int(*it.Day)
+		buckets[day] = append(buckets[day], it)
+		if minDay == 0 || day < minDay {
+			minDay = day
+		}
+		if day > maxDay {
+			maxDay = day
+		}
+	}
+	if len(buckets) == 0 {
+		return nil
+	}
+	var out []Finding
+	for day := minDay; day <= maxDay; day++ {
+		if len(buckets[day]) == 0 {
+			dd := day
+			out = append(out, Finding{
+				Severity: "info", Category: "packing", TripID: tripID, Day: &dd,
+				Message: fmt.Sprintf("Day %d has nothing planned.", day),
+			})
+		}
+	}
+	for day := minDay; day <= maxDay; day++ {
+		items := buckets[day]
+		if len(items) == 0 {
+			continue
+		}
+		dd := day
+		if len(items) > 6 {
+			out = append(out, Finding{
+				Severity: "warn", Category: "packing", TripID: tripID, Day: &dd,
+				Message: fmt.Sprintf("Day %d has %d items planned — that may be too packed.", day, len(items)),
+			})
+		}
+		todCount := map[string]int{}
+		for _, it := range items {
+			if t := strings.TrimSpace(strPtrVal(it.TimeOfDay)); t != "" {
+				todCount[t]++
+			}
+		}
+		// Fixed order keeps the output deterministic.
+		for _, tod := range []string{"morning", "afternoon", "evening"} {
+			if todCount[tod] > 1 {
+				out = append(out, Finding{
+					Severity: "warn", Category: "packing", TripID: tripID, Day: &dd,
+					Message: fmt.Sprintf("Day %d has %d things scheduled for the %s.", day, todCount[tod], tod),
+				})
+			}
+		}
+	}
+	return out
+}
+
+// checkLodging walks each night of a dated trip (start .. end-1, checkout-
+// exclusive) and flags any night no accommodation covers. Gated so an empty
+// draft isn't nagged: only runs when the trip is `planned` OR already has at
+// least one accommodation.
+func checkLodging(d exportData) []Finding {
+	if !d.Trip.StartDate.Valid || !d.Trip.EndDate.Valid {
+		return nil
+	}
+	if d.Trip.Status != "planned" && len(d.Accommodations) == 0 {
+		return nil
+	}
+	tripID := d.Trip.ID.String()
+	start := d.Trip.StartDate.Time
+	nights := nightsBetween(start, d.Trip.EndDate.Time)
+	var out []Finding
+	for n := 0; n < nights; n++ {
+		night := start.AddDate(0, 0, n)
+		covered := false
+		for _, a := range d.Accommodations {
+			if stayCoversNight(a.CheckIn, a.CheckOut, night) {
+				covered = true
+				break
+			}
+		}
+		if !covered {
+			day := n + 1
+			out = append(out, Finding{
+				Severity: "warn", Category: "lodging", TripID: tripID, Day: &day,
+				Message: fmt.Sprintf("No lodging booked for the night of %s.", night.Format("Mon, Jan 2")),
+			})
+		}
+	}
+	return out
+}
+
+// stayCoversNight is the server twin of trip_days.dart's stayCoversDate:
+// check-in <= night < check-out (checkout-exclusive). All values are UTC
+// midnights, so the comparison is a plain date compare.
+func stayCoversNight(checkIn, checkOut pgtype.Date, night time.Time) bool {
+	if !checkIn.Valid || !checkOut.Valid {
+		return false
+	}
+	return !night.Before(checkIn.Time) && night.Before(checkOut.Time)
+}
+
+// checkTransit walks consecutive hub groups; when the hub city changes and no
+// segment plausibly connects the two, it flags a missing leg. Conservative on
+// purpose — a same-city move or a fuzzy origin/destination match suppresses the
+// warning to avoid false positives.
+func checkTransit(d exportData) []Finding {
+	groups := groupExportItems(d.Trip, d.Items)
+	if len(groups) < 2 {
+		return nil
+	}
+	tripID := d.Trip.ID.String()
+	var out []Finding
+	for i := 1; i < len(groups); i++ {
+		from, to := groups[i-1].Hub, groups[i].Hub
+		if from == "" || to == "" || from == "Itinerary" || to == "Itinerary" {
+			continue
+		}
+		if strings.EqualFold(from, to) {
+			continue
+		}
+		if segmentConnects(d.Segments, from, to) {
+			continue
+		}
+		out = append(out, Finding{
+			Severity: "warn", Category: "transit", TripID: tripID,
+			Message: fmt.Sprintf("No transport booked from %s to %s.", from, to),
+		})
+	}
+	return out
+}
+
+// segmentConnects reports whether any segment plausibly links from→to (either
+// direction), via case-insensitive substring matching of the hub cities
+// against the segment's origin/destination.
+func segmentConnects(segs []store.TripSegment, from, to string) bool {
+	from, to = strings.ToLower(from), strings.ToLower(to)
+	for _, s := range segs {
+		o := strings.ToLower(strings.TrimSpace(strPtrVal(s.Origin)))
+		dst := strings.ToLower(strings.TrimSpace(strPtrVal(s.Destination)))
+		if fuzzyMatch(o, from) && fuzzyMatch(dst, to) {
+			return true
+		}
+		if fuzzyMatch(o, to) && fuzzyMatch(dst, from) {
+			return true
+		}
+	}
+	return false
+}
+
+// fuzzyMatch is a lenient, non-empty substring match in either direction.
+func fuzzyMatch(a, b string) bool {
+	if a == "" || b == "" {
+		return false
+	}
+	return strings.Contains(a, b) || strings.Contains(b, a)
+}
+
+// checkBudget flags a trip whose spending exceeds its target.
+func checkBudget(d exportData, budget *BudgetResponse) []Finding {
+	if budget == nil || budget.Remaining == nil || *budget.Remaining >= 0 {
+		return nil
+	}
+	over := -*budget.Remaining
+	return []Finding{{
+		Severity: "warn", Category: "budget", TripID: d.Trip.ID.String(),
+		Message: fmt.Sprintf("Over budget by %.2f %s.", over, budget.Currency),
+	}}
+}
+
+// checkBookings flags each unbooked accommodation and segment at info level —
+// a gentle "don't forget to confirm", never critical.
+func checkBookings(d exportData) []Finding {
+	tripID := d.Trip.ID.String()
+	var out []Finding
+	for _, a := range d.Accommodations {
+		if a.Booked {
+			continue
+		}
+		id := a.ID.String()
+		out = append(out, Finding{
+			Severity: "info", Category: "bookings", TripID: tripID, ItemID: &id,
+			Message: fmt.Sprintf("Confirm your booking for %s.", a.Name),
+		})
+	}
+	for _, s := range d.Segments {
+		if s.Booked {
+			continue
+		}
+		id := s.ID.String()
+		out = append(out, Finding{
+			Severity: "info", Category: "bookings", TripID: tripID, ItemID: &id,
+			Message: fmt.Sprintf("Confirm your booking for %s.", segmentRoute(s)),
+		})
+	}
+	return out
+}

--- a/src/packages/api/trip_review_integration_test.go
+++ b/src/packages/api/trip_review_integration_test.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"net/http"
+	"testing"
+)
+
+// Postgres-backed tests for GET /trips/{id}/review. A deliberately-broken trip
+// must surface the expected finding categories; a clean trip returns none; and
+// a non-owner is 404'd (owner-or-editor scoping via editableTrip).
+
+// reviewCategories drives the review endpoint and returns the set of categories
+// present in the findings.
+func reviewCategories(t *testing.T, id, token string) map[string]bool {
+	t.Helper()
+	rec := doJSON(t, "GET", "/api/v1/trips/"+id+"/review", token, nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET review = %d: %s", rec.Code, rec.Body.String())
+	}
+	body := decode(t, rec)
+	found := map[string]bool{}
+	for _, f := range listOf(t, body, "findings") {
+		if c, ok := f["category"].(string); ok {
+			found[c] = true
+		}
+	}
+	return found
+}
+
+func TestTripReview_BrokenTrip(t *testing.T) {
+	resetDB(t)
+	owner, ownerToken := createTestUser(t, "owner@example.com")
+	// Two items, both day=nil (unscheduled), draft status.
+	trip := createTestTrip(t, owner.ID, 2)
+	id := trip.ID.String()
+
+	// Make it a planned, dated trip (unlocks lodging night-walk).
+	rec := doJSON(t, "PATCH", "/api/v1/trips/"+id, ownerToken, map[string]any{
+		"start_date": "2026-08-01", "end_date": "2026-08-04", "status": "planned",
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("patch trip = %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// An unbooked flight segment.
+	rec = doJSON(t, "POST", "/api/v1/trips/"+id+"/segments", ownerToken, map[string]any{
+		"mode": "flight", "origin": "JFK", "destination": "CDG",
+	})
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("add segment = %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// Budget target 100 with a single 150 expense → over budget.
+	rec = doJSON(t, "PUT", "/api/v1/trips/"+id+"/budget", ownerToken, map[string]any{"target_amount": 100})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("put budget = %d: %s", rec.Code, rec.Body.String())
+	}
+	rec = doJSON(t, "POST", "/api/v1/trips/"+id+"/budget/expenses", ownerToken, map[string]any{
+		"label": "Hotel", "amount": 150, "category": "lodging",
+	})
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("add expense = %d: %s", rec.Code, rec.Body.String())
+	}
+
+	got := reviewCategories(t, id, ownerToken)
+	for _, want := range []string{"unscheduled", "lodging", "bookings", "budget"} {
+		if !got[want] {
+			t.Errorf("expected a %q finding, got categories %v", want, got)
+		}
+	}
+}
+
+func TestTripReview_CleanTrip(t *testing.T) {
+	resetDB(t)
+	owner, ownerToken := createTestUser(t, "owner@example.com")
+	// No itinerary items → nothing unscheduled, no density/transit gaps.
+	trip := createTestTrip(t, owner.ID, 0)
+	id := trip.ID.String()
+
+	rec := doJSON(t, "PATCH", "/api/v1/trips/"+id, ownerToken, map[string]any{
+		"start_date": "2026-08-01", "end_date": "2026-08-04", "status": "planned",
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("patch trip = %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// A stay covering every night (08-01..08-03, checkout 08-04 exclusive).
+	rec = doJSON(t, "POST", "/api/v1/trips/"+id+"/accommodations", ownerToken, map[string]any{
+		"name": "Grand Hotel", "check_in": "2026-08-01", "check_out": "2026-08-04",
+	})
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("add stay = %d: %s", rec.Code, rec.Body.String())
+	}
+	stayID := decode(t, rec)["id"].(string)
+	// Mark it booked so no bookings finding.
+	rec = doJSON(t, "PATCH", "/api/v1/trips/"+id+"/accommodations/"+stayID, ownerToken, map[string]any{"booked": true})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("book stay = %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// A comfortable budget (no expenses) → within budget.
+	rec = doJSON(t, "PUT", "/api/v1/trips/"+id+"/budget", ownerToken, map[string]any{"target_amount": 1000})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("put budget = %d: %s", rec.Code, rec.Body.String())
+	}
+
+	rec = doJSON(t, "GET", "/api/v1/trips/"+id+"/review", ownerToken, nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET review = %d: %s", rec.Code, rec.Body.String())
+	}
+	if fs := listOf(t, decode(t, rec), "findings"); len(fs) != 0 {
+		t.Fatalf("clean trip should have no findings, got %v", fs)
+	}
+}
+
+func TestTripReview_NonOwner404(t *testing.T) {
+	resetDB(t)
+	owner, _ := createTestUser(t, "owner@example.com")
+	_, strangerToken := createTestUser(t, "stranger@example.com")
+	trip := createTestTrip(t, owner.ID, 1)
+	id := trip.ID.String()
+
+	rec := doJSON(t, "GET", "/api/v1/trips/"+id+"/review", strangerToken, nil)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("non-owner review = %d, want 404: %s", rec.Code, rec.Body.String())
+	}
+}

--- a/src/packages/api/trip_review_test.go
+++ b/src/packages/api/trip_review_test.go
@@ -1,0 +1,176 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"travel-route-planner/store"
+)
+
+// Pure unit tests for the individual review checks — hand-built exportData, no
+// DB. These exercise the deterministic rules in isolation.
+
+func dateVal(t *testing.T, s string) pgtype.Date {
+	t.Helper()
+	tm, err := time.Parse("2006-01-02", s)
+	if err != nil {
+		t.Fatalf("parse date %q: %v", s, err)
+	}
+	return pgtype.Date{Time: tm, Valid: true}
+}
+
+func i32p(v int32) *int32 { return &v }
+
+func TestCheckDates_Undated(t *testing.T) {
+	d := exportData{Trip: store.Trip{ID: uuid.New(), Status: "draft"}}
+	fs := checkDates(d)
+	if len(fs) != 1 || fs[0].Category != "dates" || fs[0].Severity != "info" {
+		t.Fatalf("undated trip = %+v", fs)
+	}
+}
+
+func TestCheckDates_ItemPastSpan(t *testing.T) {
+	trip := store.Trip{ID: uuid.New(), Status: "planned",
+		StartDate: dateVal(t, "2026-08-01"), EndDate: dateVal(t, "2026-08-03")} // 3-day span
+	items := []store.ItineraryItem{
+		{ID: uuid.New(), Name: "Louvre", Day: i32p(2)},
+		{ID: uuid.New(), Name: "Way Out", Day: i32p(9)},
+	}
+	fs := checkDates(exportData{Trip: trip, Items: items})
+	if len(fs) != 1 || fs[0].Severity != "warn" || fs[0].Day == nil || *fs[0].Day != 9 {
+		t.Fatalf("past-span = %+v", fs)
+	}
+}
+
+func TestCheckUnscheduled_Grouped(t *testing.T) {
+	d := exportData{Trip: store.Trip{ID: uuid.New()}, Items: []store.ItineraryItem{
+		{ID: uuid.New(), Name: "A"}, // day nil
+		{ID: uuid.New(), Name: "B"}, // day nil
+		{ID: uuid.New(), Name: "C", Day: i32p(1)},
+	}}
+	fs := checkUnscheduled(d)
+	if len(fs) != 1 || fs[0].Category != "unscheduled" {
+		t.Fatalf("unscheduled = %+v", fs)
+	}
+}
+
+func TestCheckDensity_EmptyAndPacked(t *testing.T) {
+	morning := strp("morning")
+	items := []store.ItineraryItem{
+		{ID: uuid.New(), Name: "A", Day: i32p(1), TimeOfDay: morning},
+		{ID: uuid.New(), Name: "B", Day: i32p(1), TimeOfDay: morning}, // two mornings on day 1
+		// day 2 empty
+		{ID: uuid.New(), Name: "C", Day: i32p(3)},
+	}
+	fs := checkDensity(exportData{Trip: store.Trip{ID: uuid.New()}, Items: items})
+	cats := map[string][]Finding{}
+	for _, f := range fs {
+		cats[f.Severity] = append(cats[f.Severity], f)
+	}
+	if len(cats["info"]) != 1 { // day 2 empty
+		t.Fatalf("expected one empty-day info, got %+v", fs)
+	}
+	if len(cats["warn"]) != 1 { // two mornings day 1
+		t.Fatalf("expected one over-packed warn, got %+v", fs)
+	}
+}
+
+func TestCheckLodging_GateAndCoverage(t *testing.T) {
+	trip := store.Trip{ID: uuid.New(), Status: "planned",
+		StartDate: dateVal(t, "2026-08-01"), EndDate: dateVal(t, "2026-08-04")} // 3 nights: 1,2,3
+
+	// No accommodations, planned → all 3 nights flagged.
+	fs := checkLodging(exportData{Trip: trip})
+	if len(fs) != 3 {
+		t.Fatalf("planned no-lodging = %d findings, want 3: %+v", len(fs), fs)
+	}
+
+	// One stay covering nights 1-2 (checkout 08-03, exclusive) → only night 3 flagged.
+	acc := []store.Accommodation{{ID: uuid.New(), Name: "Hotel",
+		CheckIn: dateVal(t, "2026-08-01"), CheckOut: dateVal(t, "2026-08-03")}}
+	fs = checkLodging(exportData{Trip: trip, Accommodations: acc})
+	if len(fs) != 1 || fs[0].Day == nil || *fs[0].Day != 3 {
+		t.Fatalf("partial lodging = %+v", fs)
+	}
+
+	// Empty draft (draft status, no accommodations) is not nagged.
+	draft := trip
+	draft.Status = "draft"
+	if fs := checkLodging(exportData{Trip: draft}); len(fs) != 0 {
+		t.Fatalf("empty draft should be silent, got %+v", fs)
+	}
+}
+
+func TestCheckTransit_MissingLeg(t *testing.T) {
+	trip := store.Trip{ID: uuid.New()}
+	items := []store.ItineraryItem{
+		{ID: uuid.New(), Name: "Colosseum", City: strp("Rome"), Day: i32p(1)},
+		{ID: uuid.New(), Name: "Duomo", City: strp("Florence"), Day: i32p(2)},
+	}
+	// No segments → missing Rome→Florence leg.
+	fs := checkTransit(exportData{Trip: trip, Items: items})
+	if len(fs) != 1 || fs[0].Category != "transit" {
+		t.Fatalf("missing leg = %+v", fs)
+	}
+	// A connecting segment suppresses it.
+	segs := []store.TripSegment{{ID: uuid.New(), Mode: "train",
+		Origin: strp("Rome"), Destination: strp("Florence")}}
+	if fs := checkTransit(exportData{Trip: trip, Items: items, Segments: segs}); len(fs) != 0 {
+		t.Fatalf("connected legs should be silent, got %+v", fs)
+	}
+}
+
+func TestCheckBudget_OverBudget(t *testing.T) {
+	over := -50.0
+	br := &BudgetResponse{Currency: "USD", Spent: 150, Remaining: &over}
+	fs := checkBudget(exportData{Trip: store.Trip{ID: uuid.New()}}, br)
+	if len(fs) != 1 || fs[0].Category != "budget" || fs[0].Severity != "warn" {
+		t.Fatalf("over budget = %+v", fs)
+	}
+	within := 10.0
+	if fs := checkBudget(exportData{Trip: store.Trip{ID: uuid.New()}}, &BudgetResponse{Remaining: &within}); len(fs) != 0 {
+		t.Fatalf("within budget should be silent, got %+v", fs)
+	}
+	if fs := checkBudget(exportData{Trip: store.Trip{ID: uuid.New()}}, nil); len(fs) != 0 {
+		t.Fatalf("no budget should be silent, got %+v", fs)
+	}
+}
+
+func TestCheckBookings_Unbooked(t *testing.T) {
+	d := exportData{
+		Trip: store.Trip{ID: uuid.New()},
+		Accommodations: []store.Accommodation{
+			{ID: uuid.New(), Name: "Hotel", Booked: false},
+			{ID: uuid.New(), Name: "Booked Inn", Booked: true},
+		},
+		Segments: []store.TripSegment{
+			{ID: uuid.New(), Mode: "flight", Origin: strp("JFK"), Destination: strp("CDG"), Booked: false},
+		},
+	}
+	fs := checkBookings(d)
+	if len(fs) != 2 {
+		t.Fatalf("expected 2 unbooked findings, got %+v", fs)
+	}
+	for _, f := range fs {
+		if f.Severity != "info" || f.Category != "bookings" || f.ItemID == nil {
+			t.Fatalf("booking finding shape = %+v", f)
+		}
+	}
+}
+
+func TestReviewTrip_DeterministicOrder(t *testing.T) {
+	trip := store.Trip{ID: uuid.New(), Status: "planned",
+		StartDate: dateVal(t, "2026-08-01"), EndDate: dateVal(t, "2026-08-03")}
+	d := exportData{Trip: trip, Items: []store.ItineraryItem{
+		{ID: uuid.New(), Name: "A"}, // unscheduled
+	}}
+	ja, _ := json.Marshal(reviewTrip(d, reviewOptions{}))
+	jb, _ := json.Marshal(reviewTrip(d, reviewOptions{}))
+	if string(ja) != string(jb) {
+		t.Fatalf("nondeterministic order:\n%s\n%s", ja, jb)
+	}
+}


### PR DESCRIPTION
## What

A read-only, **deterministic** trip review that flags real problems in a saved trip — no AI, no external calls, no migration. Every finding traces to persisted data (loaded once via `loadExportData`), so nothing here can hallucinate.

### `trip_review.go`
`reviewTrip(data exportData, opts reviewOptions) []Finding` is a pure function over the loaded data, running small individually-testable checks with stable ordering (by day → severity → category):

- **dates** — undated trip → info; item tagged past the date span → warn.
- **unscheduled** — one grouped info finding for all `day == nil` items.
- **packing** — empty day between first/last scheduled day → info; over-packed day (>6 items, or 2+ sharing a `time_of_day`) → warn.
- **lodging** — walks each night `start..end-1` (checkout-exclusive, the server twin of `trip_days.dart` `stayCoversDate`); flags uncovered nights. **Gated**: only runs when the trip is `planned` OR already has ≥1 accommodation (empty drafts aren't nagged).
- **transit** — walks consecutive hub groups (`groupExportItems`); flags a hub-city change with no connecting segment. Conservative fuzzy origin/destination match to avoid false positives.
- **budget** — `buildBudgetResponse` remaining < 0 → warn.
- **bookings** — each unbooked accommodation/segment → info.

`reviewOptions.CheckHours` is accepted now (unused) for PR3 to wire.

### `review_handler.go`
`GET /api/v1/trips/{id}/review` behind `authMiddleware` + `editableTrip` (owner-or-editor, 404 otherwise), mirroring the budget/checklist routes. Returns `{"findings": [...]}`. Parses `?check_hours=` (bool).

## Tests
- Unit tests per check with hand-built `exportData` (no DB).
- Integration test: deliberately-broken trip (unscheduled + lodging + bookings + budget), clean trip (no findings), non-owner → 404.
- `make api-fmt`, `go vet`, full `go test ./...` (incl. integration on a dedicated DB) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)