### PR TITLE
feat(flutter): Trip Health review section

### DIFF
--- a/src/packages/flutter-app/lib/models/trip_finding.dart
+++ b/src/packages/flutter-app/lib/models/trip_finding.dart
@@ -1,0 +1,33 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'trip_finding.g.dart';
+
+/// One issue surfaced by the trip-health review (`GET /trips/{id}/review`).
+/// [severity] is info | warn | critical; [category] is one of dates |
+/// unscheduled | packing | lodging | transit | budget | bookings. [day] and
+/// [itemId] are optional deep-link anchors: when present, tapping the finding
+/// scrolls the itinerary to that day (or the day of that item).
+@JsonSerializable()
+class TripFinding {
+  final String severity;
+  final String category;
+  final String message;
+  @JsonKey(name: 'trip_id')
+  final String tripId;
+  final int? day;
+  @JsonKey(name: 'item_id')
+  final String? itemId;
+
+  const TripFinding({
+    required this.severity,
+    required this.category,
+    required this.message,
+    required this.tripId,
+    this.day,
+    this.itemId,
+  });
+
+  factory TripFinding.fromJson(Map<String, dynamic> json) =>
+      _$TripFindingFromJson(json);
+  Map<String, dynamic> toJson() => _$TripFindingToJson(this);
+}

--- a/src/packages/flutter-app/lib/models/trip_finding.g.dart
+++ b/src/packages/flutter-app/lib/models/trip_finding.g.dart
@@ -1,0 +1,26 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'trip_finding.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+TripFinding _$TripFindingFromJson(Map<String, dynamic> json) => TripFinding(
+      severity: json['severity'] as String,
+      category: json['category'] as String,
+      message: json['message'] as String,
+      tripId: json['trip_id'] as String,
+      day: (json['day'] as num?)?.toInt(),
+      itemId: json['item_id'] as String?,
+    );
+
+Map<String, dynamic> _$TripFindingToJson(TripFinding instance) =>
+    <String, dynamic>{
+      'severity': instance.severity,
+      'category': instance.category,
+      'message': instance.message,
+      'trip_id': instance.tripId,
+      'day': instance.day,
+      'item_id': instance.itemId,
+    };

--- a/src/packages/flutter-app/lib/providers/trip_review_provider.dart
+++ b/src/packages/flutter-app/lib/providers/trip_review_provider.dart
@@ -1,0 +1,37 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../models/trip_finding.dart';
+import '../services/trip_review_api_service.dart';
+import 'api_client_provider.dart';
+
+final tripReviewApiServiceProvider = Provider<TripReviewApiService>((ref) {
+  return TripReviewApiService(ref.watch(apiClientProvider));
+});
+
+/// Key for [tripReviewProvider]: a trip id plus the opt-in opening-hours flag.
+/// The flag participates in equality so flipping it fetches a distinct result
+/// (and keeps the base, hours-off review cached alongside).
+class TripReviewKey {
+  final String tripId;
+  final bool checkHours;
+
+  const TripReviewKey(this.tripId, {this.checkHours = false});
+
+  @override
+  bool operator ==(Object other) =>
+      other is TripReviewKey &&
+      other.tripId == tripId &&
+      other.checkHours == checkHours;
+
+  @override
+  int get hashCode => Object.hash(tripId, checkHours);
+}
+
+/// A trip's health review, keyed by (trip id, check-hours). Mirrors
+/// [checklistProvider]: refreshable by invalidating the family key. The
+/// hours-on variant is fetched lazily when the section flips the flag.
+final tripReviewProvider =
+    FutureProvider.family<List<TripFinding>, TripReviewKey>((ref, key) async {
+  return ref
+      .watch(tripReviewApiServiceProvider)
+      .getReview(key.tripId, checkHours: key.checkHours);
+});

--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -44,6 +44,7 @@ import '../widgets/booking_todo_card.dart';
 import '../widgets/bookings_section.dart';
 import '../widgets/budget_section.dart';
 import '../widgets/checklist_section.dart';
+import '../widgets/trip_review_section.dart';
 import '../widgets/empty_state.dart';
 import '../widgets/event_card.dart';
 import '../widgets/local_rec_card.dart';
@@ -3844,6 +3845,27 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
                                 tripId: trip.id,
                                 canEdit: !_readOnly,
                                 isOffline: _isOffline,
+                              ),
+                            ),
+                          ),
+                          // Trip health: read-only review (own endpoint/
+                          // provider, not part of the trip payload) — a trailing
+                          // peer section. Tapping a finding deep-links to its
+                          // day via the shared _scrollToDay; item-only findings
+                          // resolve to a day through the trip's items.
+                          SliverPadding(
+                            padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+                            sliver: SliverToBoxAdapter(
+                              child: TripReviewSection(
+                                tripId: trip.id,
+                                isOffline: _isOffline,
+                                onScrollToDay: _scrollToDay,
+                                dayForItem: (itemId) {
+                                  for (final item in trip.items ?? const []) {
+                                    if (item.id == itemId) return item.day;
+                                  }
+                                  return null;
+                                },
                               ),
                             ),
                           ),

--- a/src/packages/flutter-app/lib/services/trip_review_api_service.dart
+++ b/src/packages/flutter-app/lib/services/trip_review_api_service.dart
@@ -1,0 +1,30 @@
+import 'dart:convert';
+import '../models/trip_finding.dart';
+import 'api_client.dart';
+
+/// Wraps the per-trip health review endpoint (`GET /trips/{id}/review`).
+/// Read-only; mirrors [ChecklistApiService] conventions. The optional
+/// [checkHours] flag opts into the slower opening-hours check (real Google
+/// lookups land in a later PR — a harmless no-op until then).
+class TripReviewApiService {
+  final ApiClient apiClient;
+
+  TripReviewApiService(this.apiClient);
+
+  Future<List<TripFinding>> getReview(String tripId,
+      {bool checkHours = false}) async {
+    final res = await apiClient.httpClient.get(
+      Uri.parse(
+          '${apiClient.baseUrl}/trips/$tripId/review?check_hours=$checkHours'),
+      headers: apiClient.jsonHeaders(),
+    );
+    if (res.statusCode == 200) {
+      final body = jsonDecode(res.body) as Map<String, dynamic>;
+      final list = (body['findings'] as List<dynamic>?) ?? const [];
+      return list
+          .map((e) => TripFinding.fromJson(e as Map<String, dynamic>))
+          .toList();
+    }
+    throw Exception('Failed to load trip review (${res.statusCode})');
+  }
+}

--- a/src/packages/flutter-app/lib/widgets/trip_review_section.dart
+++ b/src/packages/flutter-app/lib/widgets/trip_review_section.dart
@@ -1,0 +1,223 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../models/trip_finding.dart';
+import '../providers/trip_review_provider.dart';
+import '../theme/spacing.dart';
+import 'empty_state.dart';
+import 'section_header.dart';
+import 'status_pill.dart';
+
+/// The trip-detail "Trip health" section: surfaces the read-only review from
+/// `GET /trips/{id}/review` as an ordered list of findings, worst-severity
+/// first. Self-contained — it owns its data via [tripReviewProvider], keyed on
+/// (tripId, checkHours). Mirrors [ChecklistSection]/[BudgetSection] structure.
+///
+/// Tapping a finding with a resolvable day deep-links the itinerary to that day
+/// via [onScrollToDay]; [dayForItem] resolves an item id → day when a finding
+/// carries only an item id. Both are optional (no-op when absent/unresolvable).
+class TripReviewSection extends ConsumerStatefulWidget {
+  final String tripId;
+  final bool isOffline;
+
+  /// Scrolls the itinerary to [day]. Wired to the screen's `_scrollToDay`.
+  final void Function(int day)? onScrollToDay;
+
+  /// Resolves an itinerary item id to its day, for findings that carry an
+  /// item id but no day. Returns null when the item isn't placed on a day.
+  final int? Function(String itemId)? dayForItem;
+
+  const TripReviewSection({
+    super.key,
+    required this.tripId,
+    required this.isOffline,
+    this.onScrollToDay,
+    this.dayForItem,
+  });
+
+  @override
+  ConsumerState<TripReviewSection> createState() => _TripReviewSectionState();
+}
+
+// Severity display order (worst first) and rank for sorting.
+const Map<String, int> _severityRank = {
+  'critical': 0,
+  'warn': 1,
+  'info': 2,
+};
+
+const Map<String, String> _severityLabels = {
+  'critical': 'Critical',
+  'warn': 'Warning',
+  'info': 'Info',
+};
+
+const Map<String, IconData> _categoryIcons = {
+  'dates': Icons.event_outlined,
+  'unscheduled': Icons.schedule_outlined,
+  'packing': Icons.luggage_outlined,
+  'lodging': Icons.hotel_outlined,
+  'transit': Icons.directions_transit_outlined,
+  'budget': Icons.account_balance_wallet_outlined,
+  'bookings': Icons.confirmation_number_outlined,
+};
+
+int _rankOf(String severity) => _severityRank[severity] ?? 3;
+
+class _TripReviewSectionState extends ConsumerState<TripReviewSection> {
+  // Opt-in opening-hours check: flips the provider key to the slower variant.
+  bool _checkHours = false;
+
+  TripReviewKey get _key =>
+      TripReviewKey(widget.tripId, checkHours: _checkHours);
+
+  // Severity → chip colors. Critical reads loud (red), warn amber, info neutral.
+  ({Color bg, Color fg}) _severityColors(ThemeData theme, String severity) {
+    switch (severity) {
+      case 'critical':
+        return (
+          bg: theme.colorScheme.errorContainer,
+          fg: theme.colorScheme.onErrorContainer,
+        );
+      case 'warn':
+        return (
+          bg: Colors.amber.withValues(alpha: 0.20),
+          fg: Colors.amber.shade900,
+        );
+      default:
+        return (
+          bg: theme.colorScheme.surfaceContainerHighest,
+          fg: theme.colorScheme.onSurfaceVariant,
+        );
+    }
+  }
+
+  void _onTapFinding(TripFinding finding) {
+    final onScrollToDay = widget.onScrollToDay;
+    if (onScrollToDay == null) return;
+    int? day = finding.day;
+    if (day == null && finding.itemId != null) {
+      day = widget.dayForItem?.call(finding.itemId!);
+    }
+    if (day != null) onScrollToDay(day);
+  }
+
+  void _toggleCheckHours() {
+    if (widget.isOffline) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+            content: Text("You're offline — reconnect to run more checks.")),
+      );
+      return;
+    }
+    setState(() => _checkHours = !_checkHours);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final async = ref.watch(tripReviewProvider(_key));
+    // Best-effort: on error or first load with no data, render nothing rather
+    // than an error state — a utility section shouldn't shout. (Offline still
+    // shows the last-loaded findings — the read GET is cached by the family.)
+    final findings = async.valueOrNull;
+    if (findings == null) return const SizedBox.shrink();
+
+    final theme = Theme.of(context);
+    final sorted = [...findings]
+      ..sort((a, b) => _rankOf(a.severity).compareTo(_rankOf(b.severity)));
+    final worst = sorted.isEmpty ? null : sorted.first.severity;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        const Divider(height: 32),
+        SectionHeader(
+          title: 'Trip health',
+          action: findings.isEmpty
+              ? null
+              : StatusPill.custom(
+                  label: '${findings.length} to review',
+                  background: _severityColors(theme, worst!).bg,
+                  foreground: _severityColors(theme, worst).fg,
+                ),
+        ),
+        const SizedBox(height: AppSpacing.sm),
+        if (findings.isEmpty)
+          const EmptyState(
+            compact: true,
+            icon: Icons.check_circle_outline,
+            iconColor: Colors.green,
+            title: 'Looks good',
+            message: 'No issues found — your trip is in good shape.',
+          )
+        else
+          for (final f in sorted) _buildRow(theme, f),
+        const SizedBox(height: AppSpacing.sm),
+        _buildCheckHoursAction(theme, async.isLoading),
+      ],
+    );
+  }
+
+  Widget _buildRow(ThemeData theme, TripFinding finding) {
+    final colors = _severityColors(theme, finding.severity);
+    final icon = _categoryIcons[finding.category] ?? Icons.info_outline;
+    // A finding is tappable when we can resolve it to a day to scroll to.
+    final tappable = widget.onScrollToDay != null &&
+        (finding.day != null ||
+            (finding.itemId != null &&
+                widget.dayForItem?.call(finding.itemId!) != null));
+    final row = Padding(
+      padding: const EdgeInsets.symmetric(vertical: AppSpacing.xs),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          StatusPill.custom(
+            label: _severityLabels[finding.severity] ?? finding.severity,
+            background: colors.bg,
+            foreground: colors.fg,
+          ),
+          const SizedBox(width: AppSpacing.sm),
+          Icon(icon, size: 16, color: theme.colorScheme.onSurfaceVariant),
+          const SizedBox(width: AppSpacing.xs),
+          Expanded(
+            child: Text(
+              finding.message,
+              style: theme.textTheme.bodyMedium
+                  ?.copyWith(color: theme.colorScheme.onSurface),
+            ),
+          ),
+          if (tappable)
+            Icon(Icons.chevron_right,
+                size: 18, color: theme.colorScheme.onSurfaceVariant),
+        ],
+      ),
+    );
+    if (!tappable) return row;
+    return InkWell(
+      key: ValueKey('finding-${finding.category}-${finding.message}'),
+      onTap: () => _onTapFinding(finding),
+      borderRadius: AppRadius.smAll,
+      child: row,
+    );
+  }
+
+  Widget _buildCheckHoursAction(ThemeData theme, bool loading) {
+    return Align(
+      alignment: Alignment.centerLeft,
+      child: TextButton.icon(
+        icon: loading
+            ? const SizedBox(
+                width: 14,
+                height: 14,
+                child: CircularProgressIndicator(strokeWidth: 2),
+              )
+            : Icon(_checkHours ? Icons.check : Icons.access_time),
+        label: Text(_checkHours
+            ? 'Opening hours checked'
+            : 'Also check opening hours'),
+        onPressed:
+            (widget.isOffline || _checkHours) ? null : _toggleCheckHours,
+      ),
+    );
+  }
+}

--- a/src/packages/flutter-app/test/trip_review_section_test.dart
+++ b/src/packages/flutter-app/test/trip_review_section_test.dart
@@ -1,0 +1,179 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:travel_route_planner/models/trip_finding.dart';
+import 'package:travel_route_planner/services/api_client.dart';
+import 'package:travel_route_planner/services/trip_review_api_service.dart';
+import 'package:travel_route_planner/providers/trip_review_provider.dart';
+import 'package:travel_route_planner/widgets/trip_review_section.dart';
+import 'package:travel_route_planner/widgets/empty_state.dart';
+
+/// A fake that returns a fixed list and records the checkHours values it was
+/// asked for, so tests can assert the opt-in extra check re-fetches.
+class _FakeTripReviewApiService extends TripReviewApiService {
+  final List<TripFinding> findings;
+  final List<bool> checkHoursCalls = [];
+
+  _FakeTripReviewApiService(this.findings)
+      : super(ApiClient(baseUrl: 'http://test'));
+
+  @override
+  Future<List<TripFinding>> getReview(String tripId,
+      {bool checkHours = false}) async {
+    checkHoursCalls.add(checkHours);
+    return List.of(findings);
+  }
+}
+
+TripFinding _f(String severity, String category, String message,
+        {int? day, String? itemId}) =>
+    TripFinding(
+      severity: severity,
+      category: category,
+      message: message,
+      tripId: 't1',
+      day: day,
+      itemId: itemId,
+    );
+
+Future<_FakeTripReviewApiService> _pump(
+  WidgetTester tester,
+  List<TripFinding> findings, {
+  bool isOffline = false,
+  void Function(int day)? onScrollToDay,
+  int? Function(String itemId)? dayForItem,
+}) async {
+  final fake = _FakeTripReviewApiService(findings);
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        tripReviewApiServiceProvider.overrideWithValue(fake),
+      ],
+      child: MaterialApp(
+        home: Scaffold(
+          body: SingleChildScrollView(
+            child: TripReviewSection(
+              tripId: 't1',
+              isOffline: isOffline,
+              onScrollToDay: onScrollToDay,
+              dayForItem: dayForItem,
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+  return fake;
+}
+
+void main() {
+  testWidgets(
+      'renders findings ordered worst-first with severity chips + count pill',
+      (tester) async {
+    await _pump(tester, [
+      _f('info', 'packing', 'Consider a rain jacket'),
+      _f('critical', 'dates', 'Trip has no dates set'),
+      _f('warn', 'lodging', 'No lodging on day 2'),
+    ]);
+
+    expect(find.text('Trip health'), findsOneWidget);
+    // Count pill.
+    expect(find.text('3 to review'), findsOneWidget);
+    // Severity chips.
+    expect(find.text('Critical'), findsOneWidget);
+    expect(find.text('Warning'), findsOneWidget);
+    expect(find.text('Info'), findsOneWidget);
+    // Messages present.
+    expect(find.text('Trip has no dates set'), findsOneWidget);
+
+    // Worst-first ordering: critical message sits above the info message.
+    final critical = tester.getTopLeft(find.text('Trip has no dates set')).dy;
+    final info = tester.getTopLeft(find.text('Consider a rain jacket')).dy;
+    expect(critical, lessThan(info));
+  });
+
+  testWidgets('empty findings shows the positive "Looks good" empty state',
+      (tester) async {
+    await _pump(tester, []);
+
+    expect(find.byType(EmptyState), findsOneWidget);
+    expect(find.text('Looks good'), findsOneWidget);
+    expect(find.text('3 to review'), findsNothing);
+  });
+
+  testWidgets('tapping a finding with a day invokes the scroll callback',
+      (tester) async {
+    int? scrolledTo;
+    await _pump(
+      tester,
+      [_f('warn', 'unscheduled', 'Nothing planned on day 3', day: 3)],
+      onScrollToDay: (day) => scrolledTo = day,
+    );
+
+    await tester.tap(find.text('Nothing planned on day 3'));
+    await tester.pumpAndSettle();
+
+    expect(scrolledTo, 3);
+  });
+
+  testWidgets('tapping an item-only finding resolves its day via dayForItem',
+      (tester) async {
+    int? scrolledTo;
+    await _pump(
+      tester,
+      [_f('warn', 'transit', 'Long gap before this stop', itemId: 'item-x')],
+      onScrollToDay: (day) => scrolledTo = day,
+      dayForItem: (id) => id == 'item-x' ? 5 : null,
+    );
+
+    await tester.tap(find.text('Long gap before this stop'));
+    await tester.pumpAndSettle();
+
+    expect(scrolledTo, 5);
+  });
+
+  testWidgets('a finding with no anchor does not crash on tap', (tester) async {
+    var scrollCount = 0;
+    await _pump(
+      tester,
+      [_f('info', 'budget', 'Budget looks tight')],
+      onScrollToDay: (_) => scrollCount++,
+    );
+
+    // Not tappable (no day/item) — the message renders and nothing scrolls.
+    await tester.tap(find.text('Budget looks tight'));
+    await tester.pumpAndSettle();
+    expect(scrollCount, 0);
+  });
+
+  testWidgets('check-hours button triggers a checkHours=true refetch',
+      (tester) async {
+    final fake = await _pump(tester, [_f('info', 'packing', 'Bring sunscreen')]);
+
+    // Initial load is hours-off.
+    expect(fake.checkHoursCalls, contains(false));
+    expect(fake.checkHoursCalls, isNot(contains(true)));
+
+    await tester.tap(find.text('Also check opening hours'));
+    await tester.pumpAndSettle();
+
+    // Flipping the flag re-fetches with checkHours=true.
+    expect(fake.checkHoursCalls, contains(true));
+  });
+
+  testWidgets('offline disables the check-hours action', (tester) async {
+    final fake = await _pump(
+      tester,
+      [_f('info', 'packing', 'Bring sunscreen')],
+      isOffline: true,
+    );
+
+    await tester.tap(find.text('Also check opening hours'));
+    await tester.pumpAndSettle();
+
+    // Button is disabled offline — no extra fetch.
+    expect(fake.checkHoursCalls, isNot(contains(true)));
+  });
+}


### PR DESCRIPTION
Surfaces the trip-health review from `GET /trips/{id}/review` (#155) as a self-contained trailing trip-detail section, mirroring `ChecklistSection`/`BudgetSection`.

## What

- **Model** `lib/models/trip_finding.dart` — `TripFinding{severity, category, message, tripId, day?, itemId?}` (`@JsonSerializable`, snake_case `trip_id`/`item_id`); `.g.dart` generated.
- **Service** `lib/services/trip_review_api_service.dart` — `getReview(tripId, {checkHours=false})` → `GET /trips/{id}/review?check_hours=…`, parses `.findings`.
- **Provider** `lib/providers/trip_review_provider.dart` — `tripReviewProvider` family keyed on `(tripId, checkHours)`; refreshable by invalidation, hours-off variant cached alongside.
- **Widget** `lib/widgets/trip_review_section.dart`:
  - `SectionHeader` "Trip health" + a count pill (`N to review`, colored by worst severity: critical→red, warn→amber, else neutral).
  - Empty → positive "Looks good" `EmptyState` (green check).
  - Per-finding rows ordered critical-first: leading severity `StatusPill` + category icon + message.
  - **Deep-link**: tapping a finding scrolls the itinerary to its day via the shared `_scrollToDay`; item-only findings resolve their day through the trip's items.
  - **"Also check opening hours"** opt-in action: flips the provider key to `checkHours=true` (slower lookup lands in PR3; harmless no-op until then), with a subtle loading spinner; gated offline.
- **Mount**: trailing sliver peer beside Budget in `trip_detail_screen.dart` (same `SliverPadding`→`SliverToBoxAdapter` wrapper). Diff is confined to the import + mount block — pinned-header/scroll-math regions untouched.

## Tests

- New `test/trip_review_section_test.dart` (7 cases, fake service): ordering + severity chips + count pill, "Looks good" empty state, day deep-link tap, item→day resolution, no-anchor no-crash, `checkHours=true` refetch, offline-disabled action.
- `flutter test`: 342 passed. `flutter analyze --no-fatal-infos --fatal-warnings`: 12 baseline infos, none new. Regression `trip_detail_sticky_headers_test.dart` + `trip_detail_today_test.dart` pass unmodified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)