### PR TITLE
feat(api): trip-review weather + place-hours findings + review_trip agent tool

### DIFF
--- a/src/packages/api/plan_tool_registry.go
+++ b/src/packages/api/plan_tool_registry.go
@@ -98,6 +98,8 @@ var planToolRegistry = []planTool{
 	{def: updateBookingTodoTool, enabled: authedOnly, run: runUpdateBookingTodoTool},
 	{def: removeBookingTodoTool, enabled: authedOnly, run: runRemoveBookingTodoTool},
 	{def: addPackingItemTool, enabled: authedOnly, run: runAddPackingItemTool},
+	{def: reviewTripTool, enabled: func(s *planSession) bool { return s.authed && s.boundTripID != nil },
+		run: runReviewTripTool},
 }
 
 // planToolByName dispatches tool_use blocks; derived from the registry so the

--- a/src/packages/api/plan_tool_registry_test.go
+++ b/src/packages/api/plan_tool_registry_test.go
@@ -29,7 +29,7 @@ func TestPlanSessionToolsOrderStable(t *testing.T) {
 				"add_booking_todo", "update_booking_todo", "remove_booking_todo", "add_packing_item")},
 		{"authed trip-bound", &planSession{authed: true, boundTripID: &tid},
 			append(append([]string{}, base...), "update_itinerary_section", "save_preferences", "get_trip",
-				"add_booking_todo", "update_booking_todo", "remove_booking_todo", "add_packing_item")},
+				"add_booking_todo", "update_booking_todo", "remove_booking_todo", "add_packing_item", "review_trip")},
 	}
 	for _, tc := range cases {
 		tools := planSessionTools(tc.session)

--- a/src/packages/api/plan_tools_extra.go
+++ b/src/packages/api/plan_tools_extra.go
@@ -162,6 +162,82 @@ var addPackingItemTool = anthropic.ToolParam{
 	},
 }
 
+var reviewTripTool = anthropic.ToolParam{
+	Name:        "review_trip",
+	Description: anthropic.String("Run an automated health check on the trip currently open in this conversation. It flags real problems in the saved plan — unscheduled items, nights with no lodging, missing transport between cities, over-budget spend, unconfirmed bookings, likely rain on outdoor days, and temperature extremes — all derived from the saved trip plus a live weather lookup (nothing invented). Use it when the traveler asks whether their trip is ready or what they're missing, or proactively before wrapping up. After reviewing, offer to fix issues with update_itinerary_section, add_booking_todo, or add_packing_item. No arguments — it reviews the open trip."),
+	InputSchema: anthropic.ToolInputSchemaParam{
+		Properties: map[string]any{},
+	},
+}
+
+// runReviewTripTool reviews the session's bound trip and narrates the findings.
+// It defaults CheckHours off: the operating-hours check spends real Google
+// money, and a conversational review shouldn't silently bill — the traveler can
+// still run the hours-aware review from the trip page (?check_hours=true).
+func runReviewTripTool(s *planSession, input json.RawMessage) (string, bool) {
+	if !s.authed {
+		return "The traveler isn't signed in, so there's no saved trip to review. Keep planning here in the conversation.", true
+	}
+	if s.boundTripID == nil {
+		return "No trip is open in this conversation to review. Ask the traveler to open one of their saved trips, then try again.", true
+	}
+	if dbPool == nil {
+		return "Trip review is unavailable right now (persistence offline).", true
+	}
+	data, ok := loadExportData(s.ctx, *s.boundTripID)
+	if !ok {
+		return "Could not load that trip to review it.", true
+	}
+
+	// Budget lives outside exportData; load it exactly like the review handler
+	// so checkBudget sees the same numbers.
+	q := store.New(dbPool)
+	var budget *store.TripBudget
+	if b, err := q.GetBudgetByTrip(s.ctx, *s.boundTripID); err == nil {
+		budget = &b
+	}
+	var br *BudgetResponse
+	if expenses, err := q.ListExpensesByTrip(s.ctx, *s.boundTripID); err == nil {
+		resp := buildBudgetResponse(budget, expenses)
+		br = &resp
+	}
+
+	findings := reviewTrip(s.ctx, data,
+		reviewOptions{CheckHours: false, Budget: br},
+		reviewDeps{Weather: weatherService})
+	return formatReviewFindings(findings), false
+}
+
+// formatReviewFindings renders findings for the model to narrate: grouped by
+// severity, each line already carrying its day number where relevant.
+func formatReviewFindings(findings []Finding) string {
+	if len(findings) == 0 {
+		return "Trip review found no issues — the saved plan looks complete: every day has something, nights are covered, and transport and bookings are in order. Reassure the traveler briefly."
+	}
+	bySev := map[string][]Finding{}
+	for _, f := range findings {
+		bySev[f.Severity] = append(bySev[f.Severity], f)
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "Trip review found %d thing(s) worth flagging:\n", len(findings))
+	for _, grp := range []struct{ key, header string }{
+		{"critical", "Critical"},
+		{"warn", "Needs attention"},
+		{"info", "Heads-up"},
+	} {
+		fs := bySev[grp.key]
+		if len(fs) == 0 {
+			continue
+		}
+		fmt.Fprintf(&b, "%s:\n", grp.header)
+		for _, f := range fs {
+			b.WriteString("- " + f.Message + "\n")
+		}
+	}
+	b.WriteString("Summarize these for the traveler in plain language and offer to fix them — you can update the itinerary, add booking to-dos, or add packing items.")
+	return b.String()
+}
+
 func runAddPackingItemTool(s *planSession, input json.RawMessage) (string, bool) {
 	var in struct {
 		TripID   string `json:"trip_id"`

--- a/src/packages/api/review_handler.go
+++ b/src/packages/api/review_handler.go
@@ -43,10 +43,12 @@ func getTripReviewHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	br := buildBudgetResponse(budget, expenses)
 
-	// PR3 wires the operating-hours check behind ?check_hours=true; accepted
-	// (and tolerantly parsed) now so the surface is stable.
+	// ?check_hours=true opts into the billable, live-Google operating-hours
+	// check; weather enrichment always runs (keyless + cached).
 	checkHours, _ := strconv.ParseBool(r.URL.Query().Get("check_hours"))
 
-	findings := reviewTrip(data, reviewOptions{CheckHours: checkHours, Budget: &br})
+	findings := reviewTrip(r.Context(), data,
+		reviewOptions{CheckHours: checkHours, Budget: &br},
+		reviewDeps{Weather: weatherService, Places: placesService})
 	writeJSON(w, http.StatusOK, ReviewResponse{Findings: findings})
 }

--- a/src/packages/api/trip_review.go
+++ b/src/packages/api/trip_review.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"strings"
@@ -22,7 +23,7 @@ import (
 // Finding is one flagged issue. Day/ItemID follow ItineraryItemResponse's
 // nullable-pointer + omitempty convention: absent when the finding isn't tied
 // to a specific day or entity. Severity is info|warn|critical; Category is one
-// of dates|unscheduled|packing|lodging|transit|budget|bookings.
+// of dates|unscheduled|packing|lodging|transit|budget|bookings|weather|hours.
 type Finding struct {
 	Severity string  `json:"severity"`
 	Category string  `json:"category"`
@@ -34,17 +35,28 @@ type Finding struct {
 
 // reviewOptions carries inputs that don't live on exportData. Budget is the
 // pre-computed BudgetResponse (nil when there's no budget row) so checkBudget
-// stays a pure reader. CheckHours is accepted now but unused in PR1 — PR3
-// wires the operating-hours check behind it.
+// stays a pure reader. CheckHours opts the trip into the (billable, live
+// Google) operating-hours check — off by default so a plain review never
+// spends.
 type reviewOptions struct {
 	CheckHours bool
 	Budget     *BudgetResponse
 }
 
+// reviewDeps carries the live-lookup services the enrichment checks need. Both
+// are nil-safe: a nil service makes its check a silent no-op (that's how the
+// pure unit tests and the deterministic-order test run without a network).
+type reviewDeps struct {
+	Weather *WeatherService
+	Places  *GooglePlacesService
+}
+
 // reviewTrip runs every deterministic check over the loaded trip data and
 // returns the findings in a stable order (by day, then severity, then
-// category) so the output is reproducible for a given trip snapshot.
-func reviewTrip(data exportData, opts reviewOptions) []Finding {
+// category) so the output is reproducible for a given trip snapshot. The
+// weather/place-hours checks are best-effort live lookups threaded through
+// deps; any provider error skips silently so the review never fails.
+func reviewTrip(ctx context.Context, data exportData, opts reviewOptions, deps reviewDeps) []Finding {
 	findings := make([]Finding, 0)
 	findings = append(findings, checkDates(data)...)
 	findings = append(findings, checkUnscheduled(data)...)
@@ -53,6 +65,10 @@ func reviewTrip(data exportData, opts reviewOptions) []Finding {
 	findings = append(findings, checkTransit(data)...)
 	findings = append(findings, checkBudget(data, opts.Budget)...)
 	findings = append(findings, checkBookings(data)...)
+	findings = append(findings, checkWeather(ctx, data, deps.Weather)...)
+	if opts.CheckHours {
+		findings = append(findings, checkHours(ctx, data, deps.Places)...)
+	}
 
 	severityRank := map[string]int{"critical": 0, "warn": 1, "info": 2}
 	sort.SliceStable(findings, func(i, j int) bool {
@@ -320,12 +336,15 @@ func checkBudget(d exportData, budget *BudgetResponse) []Finding {
 }
 
 // checkBookings flags each unbooked accommodation and segment at info level —
-// a gentle "don't forget to confirm", never critical.
+// a gentle "don't forget to confirm", never critical. Auto rows are system-
+// generated "Suggested" drafts that track the itinerary, not commitments the
+// traveler made, so they're skipped: nagging "confirm your booking" for a
+// suggestion the traveler never chose is noise.
 func checkBookings(d exportData) []Finding {
 	tripID := d.Trip.ID.String()
 	var out []Finding
 	for _, a := range d.Accommodations {
-		if a.Booked {
+		if a.Booked || a.Auto {
 			continue
 		}
 		id := a.ID.String()
@@ -335,13 +354,225 @@ func checkBookings(d exportData) []Finding {
 		})
 	}
 	for _, s := range d.Segments {
-		if s.Booked {
+		if s.Booked || s.Auto {
 			continue
 		}
 		id := s.ID.String()
 		out = append(out, Finding{
 			Severity: "info", Category: "bookings", TripID: tripID, ItemID: &id,
 			Message: fmt.Sprintf("Confirm your booking for %s.", segmentRoute(s)),
+		})
+	}
+	return out
+}
+
+// --- live-lookup enrichment checks (PR3) --------------------------------------
+
+// Weather advisory thresholds. Rain is split by report kind: a forecast carries
+// a precipitation probability (flag at ≥60%), while last year's archive gives
+// only a mm total (flag at ≥5mm, a solidly wet day). Temperature extremes flag
+// off the day's high/low. All weather findings are info-level advice.
+const (
+	rainProbPct     = 60
+	rainHistoricMM  = 5.0
+	hotThresholdC   = 34.0
+	coldThresholdC  = 0.0
+	maxHoursLookups = 30 // cap billable Google detail calls per review
+)
+
+// checkWeather adds advisory findings for rainy or temperature-extreme trip
+// days, one GetTripWeather lookup per distinct city (keyless, TTL-cached).
+// Best-effort: a nil service, an undated trip, or any provider error/empty
+// result skips silently — weather never fails or blocks a review.
+func checkWeather(ctx context.Context, d exportData, weather *WeatherService) []Finding {
+	if weather == nil || !d.Trip.StartDate.Valid {
+		return nil
+	}
+	tripID := d.Trip.ID.String()
+
+	// Per city, the distinct trip days present (with their calendar dates) and
+	// whether each has an outdoor plan the rain would actually spoil.
+	type dayInfo struct {
+		date    time.Time
+		outdoor bool
+	}
+	cityDays := map[string]map[int]*dayInfo{}
+	var order []string // deterministic city iteration
+	for _, it := range d.Items {
+		city := strings.TrimSpace(strPtrVal(it.City))
+		if city == "" || it.Day == nil {
+			continue
+		}
+		date, ok := itemStartDate(d.Trip, it)
+		if !ok {
+			continue
+		}
+		days, seen := cityDays[city]
+		if !seen {
+			days = map[int]*dayInfo{}
+			cityDays[city] = days
+			order = append(order, city)
+		}
+		day := int(*it.Day)
+		di := days[day]
+		if di == nil {
+			di = &dayInfo{date: date}
+			days[day] = di
+		}
+		if isOutdoorItem(it) {
+			di.outdoor = true
+		}
+	}
+
+	var out []Finding
+	for _, city := range order {
+		days := cityDays[city]
+		var first, last time.Time
+		for _, di := range days {
+			if first.IsZero() || di.date.Before(first) {
+				first = di.date
+			}
+			if di.date.After(last) {
+				last = di.date
+			}
+		}
+		report, err := weather.GetTripWeather(ctx, city, first.Format(dateLayout), last.Format(dateLayout))
+		if err != nil || len(report.Days) == 0 {
+			continue // best-effort
+		}
+		// Index the report by day. A forecast carries real (this-year) dates —
+		// match exact. The archive fallback carries LAST year's dates for the
+		// same days, so match on month-day only (MM-DD suffix).
+		historical := report.Kind == "historical"
+		byKey := make(map[string]WeatherDay, len(report.Days))
+		for _, wd := range report.Days {
+			byKey[weatherDayKey(wd.Date, historical)] = wd
+		}
+		for day, di := range days {
+			var lookup string
+			if historical {
+				lookup = di.date.Format("01-02")
+			} else {
+				lookup = di.date.Format(dateLayout)
+			}
+			wd, ok := byKey[lookup]
+			if !ok {
+				continue
+			}
+			dd := day
+			if di.outdoor && weatherDayRainy(wd) {
+				out = append(out, Finding{
+					Severity: "info", Category: "weather", TripID: tripID, Day: &dd,
+					Message: fmt.Sprintf("Rain likely on Day %d (%s) — pack an umbrella.", day, city),
+				})
+			}
+			switch {
+			case wd.TempMaxC >= hotThresholdC:
+				out = append(out, Finding{
+					Severity: "info", Category: "weather", TripID: tripID, Day: &dd,
+					Message: fmt.Sprintf("Day %d (%s) could be very hot (%.0f°C) — plan for the heat.", day, city, wd.TempMaxC),
+				})
+			case wd.TempMinC <= coldThresholdC:
+				out = append(out, Finding{
+					Severity: "info", Category: "weather", TripID: tripID, Day: &dd,
+					Message: fmt.Sprintf("Day %d (%s) could be very cold (%.0f°C) — pack warm layers.", day, city, wd.TempMinC),
+				})
+			}
+		}
+	}
+	return out
+}
+
+// weatherDayKey normalizes a report day's date to the map key used to align it
+// with a trip day: the full YYYY-MM-DD for a forecast, or the MM-DD suffix for
+// the archive (whose dates are last year's for the same calendar days).
+func weatherDayKey(date string, historical bool) string {
+	if historical && len(date) >= 10 {
+		return date[5:]
+	}
+	return date
+}
+
+// weatherDayRainy reports a meaningfully wet day: a high forecast probability,
+// or (archive, no probability) a solid rainfall total.
+func weatherDayRainy(wd WeatherDay) bool {
+	if wd.PrecipPct != nil {
+		return *wd.PrecipPct >= rainProbPct
+	}
+	return wd.PrecipMM >= rainHistoricMM
+}
+
+// indoorCategories are the item categories rain doesn't disrupt; everything
+// else (attractions, parks, tours, or an untagged item) counts as outdoor for
+// the umbrella advisory.
+var indoorCategories = map[string]bool{
+	"restaurant":  true,
+	"coffee_shop": true,
+	"cafe":        true,
+	"museum":      true,
+	"shopping":    true,
+	"bar":         true,
+}
+
+func isOutdoorItem(it store.ItineraryItem) bool {
+	cat := strings.ToLower(strings.TrimSpace(strPtrVal(it.Category)))
+	return !indoorCategories[cat]
+}
+
+// checkHours flags saved places that may be closed on the trip day they're
+// scheduled. Opt-in (billable Google detail calls): for each item with a
+// place_id and a resolvable trip-day weekday, it fetches 24h-cached place
+// details, converts the opening hours, and warns when the place is closed that
+// weekday. Bounded to maxHoursLookups upstream fetches per review. Best-effort:
+// a nil service, a Places error, or unresolvable hours skips that item.
+func checkHours(ctx context.Context, d exportData, places *GooglePlacesService) []Finding {
+	if places == nil {
+		return nil
+	}
+	tripID := d.Trip.ID.String()
+	th := &TimeHelper{}
+	var out []Finding
+	lookups := 0
+	for _, it := range d.Items {
+		placeID := strings.TrimSpace(strPtrVal(it.PlaceID))
+		if placeID == "" {
+			continue
+		}
+		date, ok := itemStartDate(d.Trip, it)
+		if !ok {
+			continue // no trip-day weekday to check against
+		}
+		if lookups >= maxHoursLookups {
+			ctxLog(ctx).Info("trip review hours check hit lookup cap",
+				"trip_id", tripID, "cap", maxHoursLookups)
+			break
+		}
+		lookups++
+		details, err := places.GetPlaceDetails(placeID)
+		if err != nil || details == nil || details.OpeningHours == nil {
+			continue // best-effort
+		}
+		hours := ConvertGoogleHoursToOperatingHours(details.OpeningHours)
+		if hours == nil {
+			continue
+		}
+		weekday := date.Weekday()
+		hoursStr := strings.TrimSpace(th.getHoursForDay(hours, weekday))
+		if hoursStr == "" {
+			continue // no hours known for that weekday → don't guess
+		}
+		// Only flag a weekday Google explicitly marks "closed" — the reliable
+		// all-day-closed signal. We deliberately don't probe a clock time:
+		// ConvertGoogleHoursToOperatingHours is lossy on AM/PM, so an
+		// evening-only venue must not read as "closed".
+		if _, _, _, _, isClosed, perr := th.parseOperatingHours(hoursStr); perr != nil || !isClosed {
+			continue
+		}
+		day := int(*it.Day)
+		id := it.ID.String()
+		out = append(out, Finding{
+			Severity: "warn", Category: "hours", TripID: tripID, Day: &day, ItemID: &id,
+			Message: fmt.Sprintf("%s may be closed on %s (Day %d).", it.Name, weekday.String(), day),
 		})
 	}
 	return out

--- a/src/packages/api/trip_review_integration_test.go
+++ b/src/packages/api/trip_review_integration_test.go
@@ -1,8 +1,12 @@
 package main
 
 import (
+	"context"
 	"net/http"
 	"testing"
+	"time"
+
+	"travel-route-planner/store"
 )
 
 // Postgres-backed tests for GET /trips/{id}/review. A deliberately-broken trip
@@ -123,5 +127,101 @@ func TestTripReview_NonOwner404(t *testing.T) {
 	rec := doJSON(t, "GET", "/api/v1/trips/"+id+"/review", strangerToken, nil)
 	if rec.Code != http.StatusNotFound {
 		t.Fatalf("non-owner review = %d, want 404: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestTripReview_HoursFindings drives the ?check_hours=true path against a fake
+// Google Places double: a place scheduled to a weekday it's closed on surfaces
+// an "hours" finding, and the check does not run without the query flag.
+func TestTripReview_HoursFindings(t *testing.T) {
+	resetDB(t)
+	owner, ownerToken := createTestUser(t, "owner@example.com")
+	trip := createTestTrip(t, owner.ID, 0)
+	id := trip.ID.String()
+
+	// 2026-08-03 is a Monday; the place is "Closed" on Mondays in the double.
+	rec := doJSON(t, "PATCH", "/api/v1/trips/"+id, ownerToken, map[string]any{
+		"start_date": "2026-08-03", "end_date": "2026-08-05", "status": "planned",
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("patch trip = %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// An item with a place_id, scheduled to Day 1 (the Monday).
+	pid := "p1"
+	day := int32(1)
+	if _, err := store.New(dbPool).CreateItineraryItem(context.Background(), store.CreateItineraryItemParams{
+		TripID: trip.ID, Position: 0, Name: "Musée Rodin", PlaceID: &pid,
+		Latitude: 48.85, Longitude: 2.31, Day: &day,
+	}); err != nil {
+		t.Fatalf("insert item: %v", err)
+	}
+
+	// Point the shared Places singleton at the closed-Monday double.
+	svc, _ := placesDouble(t, closedMondayDetailsJSON)
+	prev := placesService
+	placesService = svc
+	t.Cleanup(func() { placesService = prev })
+
+	// Without the flag: no hours check.
+	if got := reviewCategories(t, id, ownerToken); got["hours"] {
+		t.Fatalf("hours finding present without ?check_hours: %v", got)
+	}
+
+	// With the flag: the closed-weekday warning appears.
+	rec = doJSON(t, "GET", "/api/v1/trips/"+id+"/review?check_hours=true", ownerToken, nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET review = %d: %s", rec.Code, rec.Body.String())
+	}
+	var gotHours bool
+	for _, f := range listOf(t, decode(t, rec), "findings") {
+		if f["category"] == "hours" {
+			gotHours = true
+		}
+	}
+	if !gotHours {
+		t.Fatalf("expected an hours finding with ?check_hours=true: %s", rec.Body.String())
+	}
+}
+
+// TestTripReview_WeatherFindings exercises the always-on weather check against a
+// rainy forecast double: an outdoor item on a rainy trip day yields a weather
+// finding.
+func TestTripReview_WeatherFindings(t *testing.T) {
+	resetDB(t)
+	owner, ownerToken := createTestUser(t, "owner@example.com")
+	trip := createTestTrip(t, owner.ID, 0)
+	id := trip.ID.String()
+
+	// Near-future dates so the forecast (not archive) path runs and its dates
+	// line up exactly with the trip days.
+	start := time.Now().AddDate(0, 0, 3)
+	rec := doJSON(t, "PATCH", "/api/v1/trips/"+id, ownerToken, map[string]any{
+		"start_date": start.Format(dateLayout),
+		"end_date":   start.AddDate(0, 0, 1).Format(dateLayout),
+		"status":     "planned",
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("patch trip = %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// An outdoor attraction in Paris on Day 1.
+	city := "Paris"
+	category := "attraction"
+	day := int32(1)
+	if _, err := store.New(dbPool).CreateItineraryItem(context.Background(), store.CreateItineraryItemParams{
+		TripID: trip.ID, Position: 0, Name: "Eiffel Tower", City: &city, Category: &category,
+		Latitude: 48.85, Longitude: 2.35, Day: &day,
+	}); err != nil {
+		t.Fatalf("insert item: %v", err)
+	}
+
+	// Point the shared weather singleton at a rainy, mild forecast double.
+	prev := weatherService
+	weatherService = weatherStub(t, true, 22, 14)
+	t.Cleanup(func() { weatherService = prev })
+
+	if got := reviewCategories(t, id, ownerToken); !got["weather"] {
+		t.Fatalf("expected a weather finding for a rainy outdoor day, got %v", got)
 	}
 }

--- a/src/packages/api/trip_review_test.go
+++ b/src/packages/api/trip_review_test.go
@@ -1,7 +1,12 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -146,19 +151,214 @@ func TestCheckBookings_Unbooked(t *testing.T) {
 		Accommodations: []store.Accommodation{
 			{ID: uuid.New(), Name: "Hotel", Booked: false},
 			{ID: uuid.New(), Name: "Booked Inn", Booked: true},
+			// Auto "Suggested" draft — a system suggestion, not a user booking.
+			{ID: uuid.New(), Name: "Suggested Stay", Booked: false, Auto: true},
 		},
 		Segments: []store.TripSegment{
 			{ID: uuid.New(), Mode: "flight", Origin: strp("JFK"), Destination: strp("CDG"), Booked: false},
+			// Auto suggested segment — also skipped.
+			{ID: uuid.New(), Mode: "train", Origin: strp("Rome"), Destination: strp("Florence"), Booked: false, Auto: true},
 		},
 	}
 	fs := checkBookings(d)
 	if len(fs) != 2 {
-		t.Fatalf("expected 2 unbooked findings, got %+v", fs)
+		t.Fatalf("expected 2 unbooked findings (auto drafts skipped), got %+v", fs)
 	}
 	for _, f := range fs {
 		if f.Severity != "info" || f.Category != "bookings" || f.ItemID == nil {
 			t.Fatalf("booking finding shape = %+v", f)
 		}
+		if strings.Contains(f.Message, "Suggested") {
+			t.Fatalf("auto suggestion should not be flagged: %+v", f)
+		}
+	}
+}
+
+// weatherStub serves geocode + forecast/archive from one httptest server,
+// echoing the requested date range with caller-chosen conditions.
+func weatherStub(t *testing.T, rainy bool, tempMax, tempMin float64) *WeatherService {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.HasPrefix(r.URL.Path, "/v1/search"):
+			fmt.Fprint(w, `{"results":[{"name":"Paris","country":"France","latitude":48.85,"longitude":2.35}]}`)
+		case strings.HasPrefix(r.URL.Path, "/v1/forecast"), strings.HasPrefix(r.URL.Path, "/v1/archive"):
+			q := r.URL.Query()
+			start, _ := time.Parse(dateLayout, q.Get("start_date"))
+			end, _ := time.Parse(dateLayout, q.Get("end_date"))
+			forecast := strings.HasPrefix(r.URL.Path, "/v1/forecast")
+			prob := 5
+			psum := 0.0
+			if rainy {
+				prob, psum = 85, 9.0
+			}
+			var times, tmax, tmin, sum, pr []string
+			for dt := start; !dt.After(end); dt = dt.AddDate(0, 0, 1) {
+				times = append(times, `"`+dt.Format(dateLayout)+`"`)
+				tmax = append(tmax, fmt.Sprintf("%f", tempMax))
+				tmin = append(tmin, fmt.Sprintf("%f", tempMin))
+				sum = append(sum, fmt.Sprintf("%f", psum))
+				pr = append(pr, fmt.Sprintf("%d", prob))
+			}
+			out := fmt.Sprintf(`{"daily":{"time":[%s],"temperature_2m_max":[%s],"temperature_2m_min":[%s],"precipitation_sum":[%s]`,
+				strings.Join(times, ","), strings.Join(tmax, ","), strings.Join(tmin, ","), strings.Join(sum, ","))
+			if forecast {
+				out += fmt.Sprintf(`,"precipitation_probability_mean":[%s]`, strings.Join(pr, ","))
+			}
+			out += "}}"
+			fmt.Fprint(w, out)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	s := NewWeatherService()
+	s.GeocodeBaseURL = srv.URL
+	s.ForecastBaseURL = srv.URL
+	s.ArchiveBaseURL = srv.URL
+	return s
+}
+
+func TestCheckWeather_RainyOutdoorDay(t *testing.T) {
+	// A dated future trip so the forecast path is used; day 1 has an outdoor
+	// attraction in Paris.
+	start := time.Now().AddDate(0, 0, 3)
+	trip := store.Trip{ID: uuid.New(), Status: "planned",
+		StartDate: pgtype.Date{Time: start.Truncate(24 * time.Hour), Valid: true},
+		EndDate:   pgtype.Date{Time: start.AddDate(0, 0, 1).Truncate(24 * time.Hour), Valid: true}}
+	items := []store.ItineraryItem{
+		{ID: uuid.New(), Name: "Eiffel Tower", City: strp("Paris"), Category: strp("attraction"), Day: i32p(1)},
+	}
+	d := exportData{Trip: trip, Items: items}
+
+	weather := weatherStub(t, true, 22, 14) // rainy, mild
+	fs := checkWeather(context.Background(), d, weather)
+	var gotRain bool
+	for _, f := range fs {
+		if f.Category != "weather" || f.Severity != "info" {
+			t.Fatalf("weather finding shape = %+v", f)
+		}
+		if strings.Contains(f.Message, "umbrella") && f.Day != nil && *f.Day == 1 {
+			gotRain = true
+		}
+	}
+	if !gotRain {
+		t.Fatalf("expected a Day 1 umbrella finding, got %+v", fs)
+	}
+
+	// Indoor-only day: same rain, but a museum → no umbrella nag.
+	indoor := exportData{Trip: trip, Items: []store.ItineraryItem{
+		{ID: uuid.New(), Name: "Louvre", City: strp("Paris"), Category: strp("museum"), Day: i32p(1)},
+	}}
+	for _, f := range checkWeather(context.Background(), indoor, weather) {
+		if strings.Contains(f.Message, "umbrella") {
+			t.Fatalf("indoor day should not get an umbrella finding: %+v", f)
+		}
+	}
+
+	// Nil service is a silent no-op.
+	if fs := checkWeather(context.Background(), d, nil); len(fs) != 0 {
+		t.Fatalf("nil weather service should yield no findings, got %+v", fs)
+	}
+}
+
+func TestCheckWeather_HotDay(t *testing.T) {
+	start := time.Now().AddDate(0, 0, 3)
+	trip := store.Trip{ID: uuid.New(), Status: "planned",
+		StartDate: pgtype.Date{Time: start.Truncate(24 * time.Hour), Valid: true},
+		EndDate:   pgtype.Date{Time: start.Truncate(24 * time.Hour), Valid: true}}
+	d := exportData{Trip: trip, Items: []store.ItineraryItem{
+		{ID: uuid.New(), Name: "Louvre", City: strp("Paris"), Category: strp("museum"), Day: i32p(1)},
+	}}
+	weather := weatherStub(t, false, 37, 26) // hot, dry
+	var gotHot bool
+	for _, f := range checkWeather(context.Background(), d, weather) {
+		if strings.Contains(f.Message, "very hot") {
+			gotHot = true
+		}
+	}
+	if !gotHot {
+		t.Fatal("expected a 'very hot' weather finding")
+	}
+}
+
+// placesDouble builds a GooglePlacesService whose HTTP client answers every
+// request from one canned body (via the shared countingTransport), counting
+// billable calls so checkHours can be exercised without real Google.
+func placesDouble(t *testing.T, body string) (*GooglePlacesService, *countingTransport) {
+	t.Helper()
+	rt := &countingTransport{body: body}
+	svc := NewGooglePlacesService()
+	svc.APIKey = "test-key"
+	svc.Client = &http.Client{Transport: rt}
+	return svc, rt
+}
+
+// closedMondayDetailsJSON: place open Tue–Sun, closed Monday.
+const closedMondayDetailsJSON = `{"status":"OK","result":{"place_id":"p1","name":"Musée Rodin","formatted_address":"Paris","geometry":{"location":{"lat":48.85,"lng":2.31}},"types":["museum"],"opening_hours":{"open_now":false,"weekday_text":["Monday: Closed","Tuesday: 10:00 AM – 6:30 PM","Wednesday: 10:00 AM – 6:30 PM","Thursday: 10:00 AM – 6:30 PM","Friday: 10:00 AM – 6:30 PM","Saturday: 10:00 AM – 6:30 PM","Sunday: 10:00 AM – 6:30 PM"]}}}`
+
+func TestCheckHours_ClosedOnScheduledWeekday(t *testing.T) {
+	// 2026-08-03 is a Monday; the item scheduled to Day 1 lands on it.
+	monday := dateVal(t, "2026-08-03")
+	if monday.Time.Weekday() != time.Monday {
+		t.Fatalf("fixture date is %s, expected Monday", monday.Time.Weekday())
+	}
+	trip := store.Trip{ID: uuid.New(), Status: "planned",
+		StartDate: monday, EndDate: dateVal(t, "2026-08-04")}
+	items := []store.ItineraryItem{
+		{ID: uuid.New(), Name: "Musée Rodin", PlaceID: strp("p1"), Day: i32p(1)},
+		{ID: uuid.New(), Name: "No PlaceID", Day: i32p(1)}, // skipped (no place_id)
+	}
+	d := exportData{Trip: trip, Items: items}
+
+	svc, rt := placesDouble(t, closedMondayDetailsJSON)
+	fs := checkHours(context.Background(), d, svc)
+	if len(fs) != 1 || fs[0].Category != "hours" || fs[0].Severity != "warn" {
+		t.Fatalf("expected one closed-weekday warn, got %+v", fs)
+	}
+	if !strings.Contains(fs[0].Message, "closed on Monday") {
+		t.Fatalf("message = %q", fs[0].Message)
+	}
+	if rt.calls != 1 {
+		t.Fatalf("expected exactly 1 place-details call (item without place_id skipped), got %d", rt.calls)
+	}
+
+	// Nil service is a silent no-op.
+	if fs := checkHours(context.Background(), d, nil); len(fs) != 0 {
+		t.Fatalf("nil places service should yield no findings, got %+v", fs)
+	}
+}
+
+func TestReviewTrip_CheckHoursGate(t *testing.T) {
+	monday := dateVal(t, "2026-08-03")
+	trip := store.Trip{ID: uuid.New(), Status: "planned",
+		StartDate: monday, EndDate: dateVal(t, "2026-08-04")}
+	d := exportData{Trip: trip, Items: []store.ItineraryItem{
+		{ID: uuid.New(), Name: "Musée Rodin", PlaceID: strp("p1"), Day: i32p(1)},
+	}}
+	svc, rt := placesDouble(t, closedMondayDetailsJSON)
+	deps := reviewDeps{Places: svc}
+
+	// CheckHours=false → the hours check never runs (no Google call, no hours finding).
+	for _, f := range reviewTrip(context.Background(), d, reviewOptions{CheckHours: false}, deps) {
+		if f.Category == "hours" {
+			t.Fatalf("hours finding leaked with CheckHours=false: %+v", f)
+		}
+	}
+	if rt.calls != 0 {
+		t.Fatalf("CheckHours=false must not call Google, got %d calls", rt.calls)
+	}
+
+	// CheckHours=true → the finding appears.
+	var gotHours bool
+	for _, f := range reviewTrip(context.Background(), d, reviewOptions{CheckHours: true}, deps) {
+		if f.Category == "hours" {
+			gotHours = true
+		}
+	}
+	if !gotHours {
+		t.Fatal("expected an hours finding with CheckHours=true")
 	}
 }
 
@@ -168,8 +368,8 @@ func TestReviewTrip_DeterministicOrder(t *testing.T) {
 	d := exportData{Trip: trip, Items: []store.ItineraryItem{
 		{ID: uuid.New(), Name: "A"}, // unscheduled
 	}}
-	ja, _ := json.Marshal(reviewTrip(d, reviewOptions{}))
-	jb, _ := json.Marshal(reviewTrip(d, reviewOptions{}))
+	ja, _ := json.Marshal(reviewTrip(context.Background(), d, reviewOptions{}, reviewDeps{}))
+	jb, _ := json.Marshal(reviewTrip(context.Background(), d, reviewOptions{}, reviewDeps{}))
 	if string(ja) != string(jb) {
 		t.Fatalf("nondeterministic order:\n%s\n%s", ja, jb)
 	}


### PR DESCRIPTION
Extends the #155 deterministic trip-review engine with two best-effort **live-lookup** checks and exposes the full review to the `/plan` agent.

## What changed
- **`reviewTrip` signature** → `reviewTrip(ctx, data, opts, deps)`. `deps` (`reviewDeps{Weather, Places}`) carries the live services; both are **nil-safe** so the pure unit tests and the deterministic-order test run offline. The `{findings: [...]}` response envelope is unchanged (Flutter-compatible).
- **`checkWeather`** (always on, keyless + TTL-cached): one `GetTripWeather` lookup per distinct city, results mapped back to trip days (exact date for forecasts; month-day for the archive's last-year dates). Flags **rain on outdoor days** (≥60% forecast probability, or ≥5mm for historical) → *"Rain likely on Day N (city) — pack an umbrella"*, and **temperature extremes** (≥34°C hot / ≤0°C cold). All info-level. Any provider error/empty skips silently.
- **`checkHours`** (opt-in `?check_hours=true`): per item with a `place_id` and a resolvable trip-day weekday, 24h-cached `GetPlaceDetails` → `ConvertGoogleHoursToOperatingHours` → warns when Google marks that weekday **closed**. Uses the explicit `closed` marker (not a clock probe) since the AM/PM conversion is lossy, so evening-only venues aren't misflagged. Bounded to **30** upstream lookups/review (logged if capped).
- **`checkBookings`** now skips `auto=true` "Suggested" drafts (PR1 follow-up) — system suggestions, not user commitments.
- **`review_trip` agent tool**: appended at the **tail** of `planToolRegistry` (cache-prefix invariant preserved — no existing entries reordered), enabled when `authed && boundTripID != nil`. Reviews the session's open trip (loads export data + budget like the HTTP handler), **`check_hours` defaults off** to avoid surprise Google spend in chat, and returns findings grouped by severity for the model to narrate. The agent can then fix issues via `update_itinerary_section` / `add_booking_todo` / `add_packing_item`.

## Tests
- Unit: `checkWeather` (rainy outdoor → umbrella, hot day, indoor-day skip, nil-safe), `checkHours` (closed-weekday via the Google double, `place_id`-less skip, single billable call, nil-safe), `reviewTrip` CheckHours gate (false → no Google call/finding; true → finding), `checkBookings` auto-skip.
- Registry-order test updated: `review_trip` at the tail of the authed-trip-bound case only.
- Integration: `?check_hours=true` yields an hours finding against the fake Places (and none without the flag); weather findings appear for a dated trip with a rainy forecast double.
- `go test ./...` green (full suite incl. Postgres integration); `go vet` + `gofmt` clean. `make api-sqlc` is a no-op here (no `query/*.sql` or schema change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)