### PR TITLE
feat(flutter): one-tap fix actions in Trip Health (Wave 19 PR2)

### DIFF
--- a/src/packages/flutter-app/lib/models/trip_finding.dart
+++ b/src/packages/flutter-app/lib/models/trip_finding.dart
@@ -18,6 +18,11 @@ class TripFinding {
   @JsonKey(name: 'item_id')
   final String? itemId;
 
+  /// Optional one-tap fix descriptor (added in the review's PR1). Null/omitted
+  /// when a finding has no actionable fix.
+  @JsonKey(name: 'fix')
+  final FindingFix? fix;
+
   const TripFinding({
     required this.severity,
     required this.category,
@@ -25,9 +30,78 @@ class TripFinding {
     required this.tripId,
     this.day,
     this.itemId,
+    this.fix,
   });
 
   factory TripFinding.fromJson(Map<String, dynamic> json) =>
       _$TripFindingFromJson(json);
   Map<String, dynamic> toJson() => _$TripFindingToJson(this);
+}
+
+/// A structured "fix" for a [TripFinding]: what one-tap action resolves it plus
+/// any prefill hints. [action] is one of add_lodging | add_transport |
+/// move_item | mark_booked | add_packing | set_dates | raise_budget; [label] is
+/// the human button text. Every other field is optional and only present for
+/// the action(s) that use it.
+@JsonSerializable()
+class FindingFix {
+  final String action;
+  final String label;
+
+  @JsonKey(name: 'item_id')
+  final String? itemId;
+
+  /// For mark_booked: accommodation | segment.
+  @JsonKey(name: 'entity_type')
+  final String? entityType;
+
+  /// For move_item: the day to move the item to.
+  @JsonKey(name: 'target_day')
+  final int? targetDay;
+
+  /// For add_lodging: the city the stay is for.
+  final String? city;
+
+  /// For add_transport: leg endpoints.
+  final String? origin;
+  final String? destination;
+
+  /// For add_lodging: YYYY-MM-DD check-in / check-out.
+  @JsonKey(name: 'check_in')
+  final String? checkIn;
+  @JsonKey(name: 'check_out')
+  final String? checkOut;
+
+  /// For add_transport: YYYY-MM-DD departure date.
+  final String? date;
+
+  /// For add_transport: e.g. ferry, flight, train.
+  final String? mode;
+
+  /// For add_packing: the item + its category.
+  @JsonKey(name: 'packing_item')
+  final String? packingItem;
+  @JsonKey(name: 'packing_category')
+  final String? packingCategory;
+
+  const FindingFix({
+    required this.action,
+    required this.label,
+    this.itemId,
+    this.entityType,
+    this.targetDay,
+    this.city,
+    this.origin,
+    this.destination,
+    this.checkIn,
+    this.checkOut,
+    this.date,
+    this.mode,
+    this.packingItem,
+    this.packingCategory,
+  });
+
+  factory FindingFix.fromJson(Map<String, dynamic> json) =>
+      _$FindingFixFromJson(json);
+  Map<String, dynamic> toJson() => _$FindingFixToJson(this);
 }

--- a/src/packages/flutter-app/lib/models/trip_finding.g.dart
+++ b/src/packages/flutter-app/lib/models/trip_finding.g.dart
@@ -13,6 +13,9 @@ TripFinding _$TripFindingFromJson(Map<String, dynamic> json) => TripFinding(
       tripId: json['trip_id'] as String,
       day: (json['day'] as num?)?.toInt(),
       itemId: json['item_id'] as String?,
+      fix: json['fix'] == null
+          ? null
+          : FindingFix.fromJson(json['fix'] as Map<String, dynamic>),
     );
 
 Map<String, dynamic> _$TripFindingToJson(TripFinding instance) =>
@@ -23,4 +26,40 @@ Map<String, dynamic> _$TripFindingToJson(TripFinding instance) =>
       'trip_id': instance.tripId,
       'day': instance.day,
       'item_id': instance.itemId,
+      'fix': instance.fix,
+    };
+
+FindingFix _$FindingFixFromJson(Map<String, dynamic> json) => FindingFix(
+      action: json['action'] as String,
+      label: json['label'] as String,
+      itemId: json['item_id'] as String?,
+      entityType: json['entity_type'] as String?,
+      targetDay: (json['target_day'] as num?)?.toInt(),
+      city: json['city'] as String?,
+      origin: json['origin'] as String?,
+      destination: json['destination'] as String?,
+      checkIn: json['check_in'] as String?,
+      checkOut: json['check_out'] as String?,
+      date: json['date'] as String?,
+      mode: json['mode'] as String?,
+      packingItem: json['packing_item'] as String?,
+      packingCategory: json['packing_category'] as String?,
+    );
+
+Map<String, dynamic> _$FindingFixToJson(FindingFix instance) =>
+    <String, dynamic>{
+      'action': instance.action,
+      'label': instance.label,
+      'item_id': instance.itemId,
+      'entity_type': instance.entityType,
+      'target_day': instance.targetDay,
+      'city': instance.city,
+      'origin': instance.origin,
+      'destination': instance.destination,
+      'check_in': instance.checkIn,
+      'check_out': instance.checkOut,
+      'date': instance.date,
+      'mode': instance.mode,
+      'packing_item': instance.packingItem,
+      'packing_category': instance.packingCategory,
     };

--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -31,6 +31,11 @@ import '../providers/ferries_provider.dart';
 import '../providers/local_provider.dart';
 import '../providers/shared_with_me_provider.dart';
 import '../providers/trip_cache_provider.dart';
+import '../providers/trip_review_provider.dart';
+import '../providers/checklist_provider.dart';
+import '../providers/budget_provider.dart';
+import '../models/trip_finding.dart';
+import '../models/budget.dart';
 import '../services/trip_cache.dart';
 import '../theme/app_colors.dart';
 import '../theme/spacing.dart';
@@ -2865,6 +2870,256 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
     }
   }
 
+  // ---- Trip Health one-tap fixes ------------------------------------------
+
+  /// Applies a Trip Health finding's structured [FindingFix]. Safe mutations
+  /// (move/mark-booked/add-packing) apply instantly with a snackbar + Undo;
+  /// adds open the existing sheet PREFILLED; set-dates / raise-budget open the
+  /// existing editors. After any success the trip reloads and the review
+  /// re-reads (see [_afterFix]) so the resolved finding drops off.
+  Future<void> _applyFix(TripFinding finding) async {
+    if (_guardOffline()) return;
+    final fix = finding.fix;
+    if (fix == null) return;
+    final tripId = widget.tripId;
+    switch (fix.action) {
+      case 'add_lodging':
+        final body = await showModalBottomSheet<Map<String, dynamic>>(
+          context: context,
+          isScrollControlled: true,
+          builder: (_) => AddStaySheet(
+            initialName: fix.city == null ? null : 'Stay in ${fix.city}',
+            initialCheckIn: fix.checkIn,
+            initialCheckOut: fix.checkOut,
+          ),
+        );
+        if (body == null) return;
+        try {
+          await ref
+              .read(accommodationsApiServiceProvider)
+              .add(tripId, body);
+          await _afterFix();
+        } catch (e) {
+          _showSnack('Could not add stay: $e');
+        }
+        break;
+      case 'add_transport':
+        final body = await showModalBottomSheet<Map<String, dynamic>>(
+          context: context,
+          isScrollControlled: true,
+          builder: (_) => AddSegmentSheet(
+            initialOrigin: fix.origin,
+            initialDestination: fix.destination,
+            initialMode: fix.mode,
+            initialDepartDate: fix.date,
+          ),
+        );
+        if (body == null) return;
+        try {
+          await ref
+              .read(transportApiServiceProvider)
+              .addSegment(tripId, body);
+          await _afterFix();
+        } catch (e) {
+          _showSnack('Could not add transport: $e');
+        }
+        break;
+      case 'move_item':
+        final itemId = fix.itemId;
+        final targetDay = fix.targetDay;
+        if (itemId == null || targetDay == null) return;
+        final oldDay = _dayOfItem(itemId);
+        try {
+          await ref
+              .read(tripsApiServiceProvider)
+              .updateItineraryItem(tripId, itemId, {'day': targetDay});
+          await _afterFix();
+          if (!mounted) return;
+          ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+            content: Text('Moved to Day $targetDay'),
+            action: oldDay == null
+                ? null
+                : SnackBarAction(
+                    label: 'Undo',
+                    onPressed: () => _moveItemToDay(itemId, oldDay),
+                  ),
+          ));
+        } catch (e) {
+          _showSnack('Could not move item: $e');
+        }
+        break;
+      case 'mark_booked':
+        final itemId = fix.itemId;
+        if (itemId == null) return;
+        final isAccommodation = fix.entityType == 'accommodation';
+        try {
+          await _setEntityBooked(isAccommodation, itemId, true);
+          await _afterFix();
+          if (!mounted) return;
+          ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+            content: const Text('Marked as booked'),
+            action: SnackBarAction(
+              label: 'Undo',
+              onPressed: () async {
+                await _setEntityBooked(isAccommodation, itemId, false);
+                await _afterFix();
+              },
+            ),
+          ));
+        } catch (e) {
+          _showSnack('Could not update booking: $e');
+        }
+        break;
+      case 'add_packing':
+        final title = fix.packingItem;
+        if (title == null) return;
+        final category = fix.packingCategory ?? 'general';
+        try {
+          final added = await ref
+              .read(checklistApiServiceProvider)
+              .add(tripId, title, category);
+          ref.invalidate(checklistProvider(tripId));
+          await _afterFix();
+          if (!mounted) return;
+          ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+            content: Text('Added "$title" to packing'),
+            action: SnackBarAction(
+              label: 'Undo',
+              onPressed: () async {
+                try {
+                  await ref
+                      .read(checklistApiServiceProvider)
+                      .delete(tripId, added.id);
+                  ref.invalidate(checklistProvider(tripId));
+                  _invalidateReview();
+                } catch (e) {
+                  _showSnack('Could not undo: $e');
+                }
+              },
+            ),
+          ));
+        } catch (e) {
+          _showSnack('Could not add packing item: $e');
+        }
+        break;
+      case 'set_dates':
+        await _editDates();
+        _invalidateReview();
+        break;
+      case 'raise_budget':
+        await _editBudgetTarget();
+        break;
+    }
+  }
+
+  /// Reloads the trip payload and re-reads the health review so a resolved
+  /// finding disappears on the next fetch.
+  Future<void> _afterFix() async {
+    await _load();
+    _invalidateReview();
+  }
+
+  /// Invalidates both review variants (hours-off and hours-on) so whichever the
+  /// section is showing re-fetches.
+  void _invalidateReview() {
+    ref.invalidate(
+        tripReviewProvider(TripReviewKey(widget.tripId, checkHours: false)));
+    ref.invalidate(
+        tripReviewProvider(TripReviewKey(widget.tripId, checkHours: true)));
+  }
+
+  int? _dayOfItem(String itemId) {
+    for (final item in _trip?.items ?? const <ItineraryItem>[]) {
+      if (item.id == itemId) return item.day;
+    }
+    return null;
+  }
+
+  Future<void> _moveItemToDay(String itemId, int day) async {
+    try {
+      await ref
+          .read(tripsApiServiceProvider)
+          .updateItineraryItem(widget.tripId, itemId, {'day': day});
+      await _afterFix();
+    } catch (e) {
+      _showSnack('Could not move item: $e');
+    }
+  }
+
+  Future<void> _setEntityBooked(
+      bool isAccommodation, String id, bool booked) async {
+    if (isAccommodation) {
+      await ref
+          .read(accommodationsApiServiceProvider)
+          .update(widget.tripId, id, {'booked': booked});
+    } else {
+      await ref
+          .read(transportApiServiceProvider)
+          .updateSegment(widget.tripId, id, {'booked': booked});
+    }
+  }
+
+  /// Screen-level budget-target editor for the raise_budget fix. Reuses the
+  /// budget provider/service; keeps the trip's existing currency.
+  Future<void> _editBudgetTarget() async {
+    if (_guardOffline()) return;
+    final Budget budget;
+    try {
+      budget = await ref.read(budgetProvider(widget.tripId).future);
+    } catch (e) {
+      _showSnack('Could not load budget: $e');
+      return;
+    }
+    if (!mounted) return;
+    final currency = budget.currency;
+    final controller = TextEditingController(
+      text: budget.targetAmount == null
+          ? ''
+          : budget.targetAmount!.toStringAsFixed(0),
+    );
+    final result = await showDialog<Map<String, double?>>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Set budget target'),
+        content: TextField(
+          controller: controller,
+          autofocus: true,
+          keyboardType: const TextInputType.numberWithOptions(decimal: true),
+          decoration: InputDecoration(
+            labelText: 'Target ($currency)',
+            hintText: 'Leave blank to just track spending',
+          ),
+        ),
+        actions: [
+          TextButton(
+              onPressed: () => Navigator.of(ctx).pop(),
+              child: const Text('Cancel')),
+          FilledButton(
+            onPressed: () {
+              final raw = controller.text.trim();
+              final amount = raw.isEmpty ? null : double.tryParse(raw);
+              if (raw.isNotEmpty && (amount == null || amount < 0)) return;
+              Navigator.of(ctx).pop(<String, double?>{'amount': amount});
+            },
+            child: const Text('Save'),
+          ),
+        ],
+      ),
+    );
+    if (result == null) return; // cancelled
+    try {
+      await ref.read(budgetApiServiceProvider).upsertBudget(
+            widget.tripId,
+            targetAmount: result['amount'],
+            currency: currency,
+          );
+      ref.invalidate(budgetProvider(widget.tripId));
+      await _afterFix();
+    } catch (e) {
+      _showSnack('Could not update budget: $e');
+    }
+  }
+
   /// Google Maps deep link for a place: prefer place_id, then coordinates, then a
   /// name/address text search.
   String _mapsUrl(ItineraryItem it) {
@@ -3866,6 +4121,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
                                   }
                                   return null;
                                 },
+                                onApplyFix: _readOnly ? null : _applyFix,
                               ),
                             ),
                           ),

--- a/src/packages/flutter-app/lib/widgets/bookings_section.dart
+++ b/src/packages/flutter-app/lib/widgets/bookings_section.dart
@@ -386,7 +386,20 @@ class BookingsSection extends StatelessWidget {
 /// to editing.
 class AddStaySheet extends StatefulWidget {
   final Accommodation? initial;
-  const AddStaySheet({super.key, this.initial});
+
+  /// Optional prefills for a fresh (non-edit) sheet, used by the Trip Health
+  /// "Add a stay" fix. Ignored when [initial] is set. Dates are YYYY-MM-DD.
+  final String? initialName;
+  final String? initialCheckIn;
+  final String? initialCheckOut;
+
+  const AddStaySheet({
+    super.key,
+    this.initial,
+    this.initialName,
+    this.initialCheckIn,
+    this.initialCheckOut,
+  });
 
   @override
   State<AddStaySheet> createState() => _AddStaySheetState();
@@ -413,6 +426,14 @@ class _AddStaySheetState extends State<AddStaySheet> {
       _priceNote.text = a.priceNote ?? '';
       _checkIn = a.checkIn == null ? null : DateTime.tryParse(a.checkIn!);
       _checkOut = a.checkOut == null ? null : DateTime.tryParse(a.checkOut!);
+    } else {
+      if (widget.initialName != null) _name.text = widget.initialName!;
+      _checkIn = widget.initialCheckIn == null
+          ? null
+          : DateTime.tryParse(widget.initialCheckIn!);
+      _checkOut = widget.initialCheckOut == null
+          ? null
+          : DateTime.tryParse(widget.initialCheckOut!);
     }
   }
 
@@ -558,7 +579,22 @@ class _AddStaySheetState extends State<AddStaySheet> {
 /// labels flip to editing.
 class AddSegmentSheet extends StatefulWidget {
   final TripSegment? initial;
-  const AddSegmentSheet({super.key, this.initial});
+
+  /// Optional prefills for a fresh (non-edit) sheet, used by the Trip Health
+  /// "Add transport" fix. Ignored when [initial] is set. Date is YYYY-MM-DD.
+  final String? initialOrigin;
+  final String? initialDestination;
+  final String? initialMode;
+  final String? initialDepartDate;
+
+  const AddSegmentSheet({
+    super.key,
+    this.initial,
+    this.initialOrigin,
+    this.initialDestination,
+    this.initialMode,
+    this.initialDepartDate,
+  });
 
   @override
   State<AddSegmentSheet> createState() => _AddSegmentSheetState();
@@ -586,6 +622,15 @@ class _AddSegmentSheetState extends State<AddSegmentSheet> {
       _mode = s.mode;
       _departDate =
           s.departDate == null ? null : DateTime.tryParse(s.departDate!);
+    } else {
+      if (widget.initialOrigin != null) _origin.text = widget.initialOrigin!;
+      if (widget.initialDestination != null) {
+        _destination.text = widget.initialDestination!;
+      }
+      if (widget.initialMode != null) _mode = widget.initialMode!;
+      _departDate = widget.initialDepartDate == null
+          ? null
+          : DateTime.tryParse(widget.initialDepartDate!);
     }
   }
 

--- a/src/packages/flutter-app/lib/widgets/trip_review_section.dart
+++ b/src/packages/flutter-app/lib/widgets/trip_review_section.dart
@@ -27,12 +27,17 @@ class TripReviewSection extends ConsumerStatefulWidget {
   /// item id but no day. Returns null when the item isn't placed on a day.
   final int? Function(String itemId)? dayForItem;
 
+  /// Applies a finding's one-tap fix. The screen owns the sheets, services and
+  /// refresh, so it supplies this; when null the fix button is hidden.
+  final Future<void> Function(TripFinding finding)? onApplyFix;
+
   const TripReviewSection({
     super.key,
     required this.tripId,
     required this.isOffline,
     this.onScrollToDay,
     this.dayForItem,
+    this.onApplyFix,
   });
 
   @override
@@ -186,7 +191,11 @@ class _TripReviewSectionState extends ConsumerState<TripReviewSection> {
                   ?.copyWith(color: theme.colorScheme.onSurface),
             ),
           ),
-          if (tappable)
+          // A fix, when present, takes the trailing slot from the chevron: its
+          // own button so its tap never reaches the row's scroll InkWell.
+          if (finding.fix != null && widget.onApplyFix != null)
+            _buildFixButton(finding)
+          else if (tappable)
             Icon(Icons.chevron_right,
                 size: 18, color: theme.colorScheme.onSurfaceVariant),
         ],
@@ -198,6 +207,27 @@ class _TripReviewSectionState extends ConsumerState<TripReviewSection> {
       onTap: () => _onTapFinding(finding),
       borderRadius: AppRadius.smAll,
       child: row,
+    );
+  }
+
+  // Compact trailing "fix" affordance. Sits inside the row's InkWell when the
+  // finding is also tap-to-scroll; because it's a button it wins the gesture
+  // arena, so applying a fix never scrolls the itinerary.
+  Widget _buildFixButton(TripFinding finding) {
+    return Padding(
+      padding: const EdgeInsets.only(left: AppSpacing.xs),
+      child: FilledButton.tonal(
+        key: ValueKey('fix-${finding.fix!.action}-${finding.message}'),
+        onPressed: () => widget.onApplyFix!(finding),
+        style: FilledButton.styleFrom(
+          visualDensity: VisualDensity.compact,
+          padding: const EdgeInsets.symmetric(
+              horizontal: AppSpacing.sm, vertical: 0),
+          minimumSize: const Size(0, 32),
+          tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+        ),
+        child: Text(finding.fix!.label),
+      ),
     );
   }
 

--- a/src/packages/flutter-app/test/trip_detail_fix_actions_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_fix_actions_test.dart
@@ -1,0 +1,327 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:travel_route_planner/models/trip.dart';
+import 'package:travel_route_planner/models/itinerary_item.dart';
+import 'package:travel_route_planner/models/trip_finding.dart';
+import 'package:travel_route_planner/models/accommodation.dart';
+import 'package:travel_route_planner/models/trip_segment.dart';
+import 'package:travel_route_planner/services/api_client.dart';
+import 'package:travel_route_planner/services/trips_api_service.dart';
+import 'package:travel_route_planner/services/trip_review_api_service.dart';
+import 'package:travel_route_planner/services/accommodations_api_service.dart';
+import 'package:travel_route_planner/services/transport_api_service.dart';
+import 'package:travel_route_planner/services/checklist_api_service.dart';
+import 'package:travel_route_planner/models/checklist_item.dart';
+import 'package:travel_route_planner/providers/trips_provider.dart';
+import 'package:travel_route_planner/providers/trip_review_provider.dart';
+import 'package:travel_route_planner/providers/accommodations_provider.dart';
+import 'package:travel_route_planner/providers/transport_provider.dart';
+import 'package:travel_route_planner/providers/checklist_provider.dart';
+import 'package:travel_route_planner/screens/trip_detail_screen.dart';
+import 'package:travel_route_planner/widgets/bookings_section.dart';
+
+/// Serves a fixed trip and records itinerary-item PATCHes for the move_item fix.
+class _FakeTripsApiService extends TripsApiService {
+  final Trip trip;
+  final List<Map<String, dynamic>> itemPatches = [];
+  _FakeTripsApiService(this.trip) : super(ApiClient(baseUrl: 'http://test'));
+
+  @override
+  Future<Trip> getTrip(String id) async => trip;
+
+  @override
+  Future<ItineraryItem> updateItineraryItem(
+      String tripId, String itemId, Map<String, dynamic> body) async {
+    itemPatches.add({'id': itemId, ...body});
+    return _item(0, 'x', 'y', 'attraction', day: body['day'] as int?);
+  }
+}
+
+/// Stateful review fake: returns [findings] until a fix resolves them, then
+/// empty on the next fetch — so a successful fix both re-fetches (call count
+/// grows) and drops the finding from the list.
+class _FakeReviewApiService extends TripReviewApiService {
+  final List<TripFinding> findings;
+  int calls = 0;
+  bool resolved = false;
+
+  _FakeReviewApiService(this.findings)
+      : super(ApiClient(baseUrl: 'http://test'));
+
+  @override
+  Future<List<TripFinding>> getReview(String tripId,
+      {bool checkHours = false}) async {
+    calls++;
+    return resolved ? const [] : List.of(findings);
+  }
+}
+
+class _FakeAccommodationsApiService extends AccommodationsApiService {
+  final List<Map<String, dynamic>> patches = [];
+  _FakeAccommodationsApiService() : super(ApiClient(baseUrl: 'http://test'));
+
+  @override
+  Future<Accommodation> update(
+      String tripId, String accId, Map<String, dynamic> body) async {
+    patches.add({'id': accId, ...body});
+    return Accommodation(id: accId, name: 'Stay');
+  }
+}
+
+class _FakeTransportApiService extends TransportApiService {
+  final List<Map<String, dynamic>> patches = [];
+  final List<Map<String, dynamic>> added = [];
+  _FakeTransportApiService() : super(ApiClient(baseUrl: 'http://test'));
+
+  @override
+  Future<TripSegment> updateSegment(
+      String tripId, String segmentId, Map<String, dynamic> body) async {
+    patches.add({'id': segmentId, ...body});
+    return TripSegment(id: segmentId, mode: 'ferry');
+  }
+
+  @override
+  Future<TripSegment> addSegment(
+      String tripId, Map<String, dynamic> body) async {
+    added.add(body);
+    return TripSegment(id: 'seg-new', mode: body['mode'] as String? ?? 'other');
+  }
+}
+
+class _FakeChecklistApiService extends ChecklistApiService {
+  int addCount = 0;
+  String? lastTitle;
+  String? lastCategory;
+  _FakeChecklistApiService() : super(ApiClient(baseUrl: 'http://test'));
+
+  @override
+  Future<List<ChecklistItem>> list(String tripId) async => const [];
+
+  @override
+  Future<ChecklistItem> add(
+      String tripId, String title, String category) async {
+    addCount++;
+    lastTitle = title;
+    lastCategory = category;
+    return ChecklistItem(id: 'c1', category: category, title: title);
+  }
+}
+
+ItineraryItem _item(int pos, String name, String address, String category,
+        {int? day}) =>
+    ItineraryItem(
+      id: 'i$pos',
+      position: pos,
+      name: name,
+      address: address,
+      latitude: 0,
+      longitude: 0,
+      category: category,
+      day: day,
+    );
+
+Trip _trip({List<ItineraryItem>? items}) => Trip(
+      id: 't1',
+      title: 'Greece',
+      status: 'planned',
+      startDate: '2026-08-01',
+      endDate: '2026-08-05',
+      createdAt: '2026-07-01',
+      updatedAt: '2026-07-01',
+      items: items ??
+          [_item(0, 'Acropolis', 'Athens, Greece', 'attraction', day: 1)],
+    );
+
+void _useTallViewport(WidgetTester tester) {
+  tester.view.physicalSize = const Size(800, 3000);
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.reset);
+}
+
+Future<void> _pumpScreen(
+  WidgetTester tester, {
+  required Trip trip,
+  required _FakeReviewApiService review,
+  _FakeTripsApiService? trips,
+  _FakeAccommodationsApiService? accommodations,
+  _FakeTransportApiService? transport,
+  _FakeChecklistApiService? checklist,
+}) async {
+  _useTallViewport(tester);
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        tripsApiServiceProvider
+            .overrideWithValue(trips ?? _FakeTripsApiService(trip)),
+        tripReviewApiServiceProvider.overrideWithValue(review),
+        if (accommodations != null)
+          accommodationsApiServiceProvider.overrideWithValue(accommodations),
+        if (transport != null)
+          transportApiServiceProvider.overrideWithValue(transport),
+        if (checklist != null)
+          checklistApiServiceProvider.overrideWithValue(checklist),
+      ],
+      child: MaterialApp(home: TripDetailScreen(tripId: 't1')),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+TripFinding _finding(String category, String message, FindingFix fix) =>
+    TripFinding(
+      severity: 'warn',
+      category: category,
+      message: message,
+      tripId: 't1',
+      fix: fix,
+    );
+
+void main() {
+  testWidgets('mark_booked (accommodation) PATCHes booked + re-reads review',
+      (tester) async {
+    final review = _FakeReviewApiService([
+      _finding('bookings', 'Stay not booked',
+          const FindingFix(
+              action: 'mark_booked',
+              label: 'Mark booked',
+              itemId: 'acc-1',
+              entityType: 'accommodation')),
+    ]);
+    final accommodations = _FakeAccommodationsApiService();
+    await _pumpScreen(tester,
+        trip: _trip(), review: review, accommodations: accommodations);
+
+    final callsBefore = review.calls;
+    review.resolved = true; // server now considers it booked
+    await tester.tap(find.widgetWithText(FilledButton, 'Mark booked'));
+    await tester.pumpAndSettle();
+
+    expect(accommodations.patches, hasLength(1));
+    expect(accommodations.patches.single['id'], 'acc-1');
+    expect(accommodations.patches.single['booked'], true);
+    // Review re-read (invalidated) — and the resolved finding is gone.
+    expect(review.calls, greaterThan(callsBefore));
+    expect(find.widgetWithText(FilledButton, 'Mark booked'), findsNothing);
+  });
+
+  testWidgets('mark_booked (segment) PATCHes the transport segment',
+      (tester) async {
+    final review = _FakeReviewApiService([
+      _finding('transit', 'Ferry not booked',
+          const FindingFix(
+              action: 'mark_booked',
+              label: 'Mark booked',
+              itemId: 'seg-1',
+              entityType: 'segment')),
+    ]);
+    final transport = _FakeTransportApiService();
+    await _pumpScreen(tester,
+        trip: _trip(), review: review, transport: transport);
+
+    await tester.tap(find.widgetWithText(FilledButton, 'Mark booked'));
+    await tester.pumpAndSettle();
+
+    expect(transport.patches, hasLength(1));
+    expect(transport.patches.single['id'], 'seg-1');
+    expect(transport.patches.single['booked'], true);
+  });
+
+  testWidgets('move_item PATCHes the item day + re-reads review',
+      (tester) async {
+    final trips = _FakeTripsApiService(_trip());
+    final review = _FakeReviewApiService([
+      _finding('unscheduled', 'Item stranded on the wrong day',
+          const FindingFix(
+              action: 'move_item',
+              label: 'Move to Day 2',
+              itemId: 'i0',
+              targetDay: 2)),
+    ]);
+    await _pumpScreen(tester, trip: trips.trip, review: review, trips: trips);
+
+    final callsBefore = review.calls;
+    review.resolved = true;
+    await tester.tap(find.widgetWithText(FilledButton, 'Move to Day 2'));
+    await tester.pumpAndSettle();
+
+    expect(trips.itemPatches, hasLength(1));
+    expect(trips.itemPatches.single['id'], 'i0');
+    expect(trips.itemPatches.single['day'], 2);
+    expect(review.calls, greaterThan(callsBefore));
+  });
+
+  testWidgets('add_packing adds a checklist item + re-reads review',
+      (tester) async {
+    final review = _FakeReviewApiService([
+      _finding('packing', 'No umbrella for rainy Athens',
+          const FindingFix(
+              action: 'add_packing',
+              label: 'Add to list',
+              packingItem: 'Umbrella',
+              packingCategory: 'general')),
+    ]);
+    final checklist = _FakeChecklistApiService();
+    await _pumpScreen(tester,
+        trip: _trip(), review: review, checklist: checklist);
+
+    final callsBefore = review.calls;
+    review.resolved = true;
+    await tester.tap(find.widgetWithText(FilledButton, 'Add to list'));
+    await tester.pumpAndSettle();
+
+    expect(checklist.addCount, 1);
+    expect(checklist.lastTitle, 'Umbrella');
+    expect(checklist.lastCategory, 'general');
+    expect(review.calls, greaterThan(callsBefore));
+  });
+
+  testWidgets('add_lodging opens the stay sheet prefilled with dates',
+      (tester) async {
+    final review = _FakeReviewApiService([
+      _finding('lodging', 'No stay in Naxos',
+          const FindingFix(
+              action: 'add_lodging',
+              label: 'Add a stay',
+              city: 'Naxos',
+              checkIn: '2026-08-03',
+              checkOut: '2026-08-04')),
+    ]);
+    await _pumpScreen(tester, trip: _trip(), review: review);
+
+    await tester.tap(find.widgetWithText(FilledButton, 'Add a stay'));
+    await tester.pumpAndSettle();
+
+    // The stay sheet is open, prefilled with a city name hint and the dates.
+    expect(find.byType(AddStaySheet), findsOneWidget);
+    expect(find.text('Stay in Naxos'), findsOneWidget);
+    expect(find.text('2026-08-03 → 2026-08-04'), findsOneWidget);
+  });
+
+  testWidgets('add_transport opens the transport sheet prefilled',
+      (tester) async {
+    final review = _FakeReviewApiService([
+      _finding('transit', 'No transport Athens → Naxos',
+          const FindingFix(
+              action: 'add_transport',
+              label: 'Add transport',
+              origin: 'Athens',
+              destination: 'Naxos',
+              mode: 'ferry',
+              date: '2026-08-03')),
+    ]);
+    await _pumpScreen(tester, trip: _trip(), review: review);
+
+    await tester.tap(find.widgetWithText(FilledButton, 'Add transport'));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(AddSegmentSheet), findsOneWidget);
+    Finder inSheet(String text) => find.descendant(
+        of: find.byType(AddSegmentSheet), matching: find.text(text));
+    expect(inSheet('Athens'), findsOneWidget);
+    expect(inSheet('Naxos'), findsOneWidget);
+    // Prefilled departure date shows on the date button.
+    expect(inSheet('2026-08-03'), findsOneWidget);
+  });
+}

--- a/src/packages/flutter-app/test/trip_review_section_test.dart
+++ b/src/packages/flutter-app/test/trip_review_section_test.dart
@@ -27,7 +27,7 @@ class _FakeTripReviewApiService extends TripReviewApiService {
 }
 
 TripFinding _f(String severity, String category, String message,
-        {int? day, String? itemId}) =>
+        {int? day, String? itemId, FindingFix? fix}) =>
     TripFinding(
       severity: severity,
       category: category,
@@ -35,6 +35,7 @@ TripFinding _f(String severity, String category, String message,
       tripId: 't1',
       day: day,
       itemId: itemId,
+      fix: fix,
     );
 
 Future<_FakeTripReviewApiService> _pump(
@@ -43,6 +44,7 @@ Future<_FakeTripReviewApiService> _pump(
   bool isOffline = false,
   void Function(int day)? onScrollToDay,
   int? Function(String itemId)? dayForItem,
+  Future<void> Function(TripFinding finding)? onApplyFix,
 }) async {
   final fake = _FakeTripReviewApiService(findings);
   await tester.pumpWidget(
@@ -58,6 +60,7 @@ Future<_FakeTripReviewApiService> _pump(
               isOffline: isOffline,
               onScrollToDay: onScrollToDay,
               dayForItem: dayForItem,
+              onApplyFix: onApplyFix,
             ),
           ),
         ),
@@ -161,6 +164,97 @@ void main() {
 
     // Flipping the flag re-fetches with checkHours=true.
     expect(fake.checkHoursCalls, contains(true));
+  });
+
+  testWidgets('a finding with a fix renders a button with the fix label',
+      (tester) async {
+    await _pump(
+      tester,
+      [
+        _f('warn', 'lodging', 'No lodging in Naxos',
+            fix: const FindingFix(action: 'add_lodging', label: 'Add a stay')),
+      ],
+      onApplyFix: (_) async {},
+    );
+
+    expect(find.widgetWithText(FilledButton, 'Add a stay'), findsOneWidget);
+    // The fix took the trailing slot from the chevron.
+    expect(find.byIcon(Icons.chevron_right), findsNothing);
+  });
+
+  testWidgets('every fix action renders its labelled button', (tester) async {
+    await _pump(
+      tester,
+      [
+        _f('warn', 'lodging', 'a',
+            fix: const FindingFix(action: 'add_lodging', label: 'Add a stay')),
+        _f('warn', 'transit', 'b',
+            fix: const FindingFix(
+                action: 'add_transport', label: 'Add transport')),
+        _f('warn', 'unscheduled', 'c',
+            fix: const FindingFix(action: 'move_item', label: 'Move to Day 2')),
+        _f('warn', 'bookings', 'd',
+            fix: const FindingFix(action: 'mark_booked', label: 'Mark booked')),
+        _f('info', 'packing', 'e',
+            fix: const FindingFix(action: 'add_packing', label: 'Add to list')),
+        _f('critical', 'dates', 'f',
+            fix: const FindingFix(action: 'set_dates', label: 'Set dates')),
+        _f('info', 'budget', 'g',
+            fix:
+                const FindingFix(action: 'raise_budget', label: 'Raise budget')),
+      ],
+      onApplyFix: (_) async {},
+    );
+
+    for (final label in const [
+      'Add a stay',
+      'Add transport',
+      'Move to Day 2',
+      'Mark booked',
+      'Add to list',
+      'Set dates',
+      'Raise budget',
+    ]) {
+      expect(find.widgetWithText(FilledButton, label), findsOneWidget);
+    }
+  });
+
+  testWidgets('tapping the fix button calls onApplyFix, not the row scroll',
+      (tester) async {
+    TripFinding? applied;
+    var scrollCount = 0;
+    // Finding carries a day, so the row is also tap-to-scroll — the button must
+    // win the gesture and never scroll.
+    await _pump(
+      tester,
+      [
+        _f('warn', 'unscheduled', 'Nothing on day 2', day: 2,
+            fix: const FindingFix(
+                action: 'move_item', label: 'Move here', targetDay: 2)),
+      ],
+      onScrollToDay: (_) => scrollCount++,
+      onApplyFix: (f) async => applied = f,
+    );
+
+    await tester.tap(find.widgetWithText(FilledButton, 'Move here'));
+    await tester.pumpAndSettle();
+
+    expect(applied, isNotNull);
+    expect(applied!.fix!.action, 'move_item');
+    expect(scrollCount, 0);
+  });
+
+  testWidgets('no fix button when onApplyFix is null', (tester) async {
+    await _pump(
+      tester,
+      [
+        _f('warn', 'lodging', 'No lodging',
+            fix: const FindingFix(action: 'add_lodging', label: 'Add a stay')),
+      ],
+      // onApplyFix omitted (null) — the button is hidden.
+    );
+
+    expect(find.widgetWithText(FilledButton, 'Add a stay'), findsNothing);
   });
 
   testWidgets('offline disables the check-hours action', (tester) async {


### PR DESCRIPTION
## What

Wave 19 PR2. Builds on the review PR1 (#158), which added a structured `fix` descriptor to each Trip Health finding. Each finding row is now **actionable**: when a finding carries a `fix`, a compact trailing button (label from `fix.label`) takes the chevron slot.

**Affordance = apply-with-undo.** Safe fixes mutate instantly with a snackbar + Undo; adds that need input open the existing sheet **prefilled**.

## Per-action wiring (`_applyFix` in `trip_detail_screen.dart`)

| action | behavior |
|--------|----------|
| `add_lodging` | opens `AddStaySheet` prefilled with `check_in`/`check_out` + a "Stay in {city}" name hint |
| `add_transport` | opens `AddSegmentSheet` prefilled with `origin`/`destination`/`mode`/`date` |
| `move_item` | instant `PATCH items/{id} {day}` → snackbar "Moved to Day N · Undo" (Undo re-PATCHes the captured old day) |
| `mark_booked` | instant `{booked:true}` on the accommodation (`entity_type=accommodation`) or segment → snackbar + Undo (`{booked:false}`) |
| `add_packing` | instant checklist add `{category, title}` → snackbar + Undo (deletes the added item) |
| `set_dates` | opens the existing trip date-range editor |
| `raise_budget` | opens a budget-target dialog (keeps the trip's currency) |

The sheets gained optional initial-value params (default `null` → existing behavior unchanged). The fix button is a `FilledButton.tonal` nested in the row's scroll `InkWell`, so it wins the gesture arena and applying a fix never scrolls the itinerary. The button is hidden for read-only (viewer) roles.

## Post-fix refresh

After **any** successful fix, `_afterFix()` both reloads the trip payload and invalidates **both** review keys (`checkHours` false *and* true), so the resolved finding drops off on the re-fetch.

## Model

`FindingFix` (`@JsonSerializable`) mirrors the API JSON; `TripFinding` gains a nullable `fix`. `.g.dart` regenerated via build_runner (never hand-edited).

## Tests

- `trip_review_section_test.dart`: each action renders its labelled button; the fix button fires `onApplyFix` and does **not** trigger the row scroll; no button when `onApplyFix` is null.
- `trip_detail_fix_actions_test.dart` (new, screen-level): `mark_booked` (accommodation + segment), `move_item`, `add_packing` invoke the expected service method **and** re-read the review (resolved finding disappears); `add_lodging`/`add_transport` open the prefilled sheet.
- Regression suites (`trip_detail_sticky_headers_test.dart`, `trip_detail_today_test.dart`) unchanged.

`flutter test` — all pass. `flutter analyze --no-fatal-infos --fatal-warnings` — no new warnings/infos (same 12 pre-existing baseline infos in unrelated files).

Only touches `src/packages/flutter-app/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)