### PR TITLE
feat(flutter): consolidate trip bookings into one Bookings section

### DIFF
--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -916,7 +916,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
     }
   }
 
-  /// Persists a drag-reorder of the residual "Other bookings" cards.
+  /// Persists a drag-reorder of the Bookings section's residual "Other" cards.
   /// Optimistic: residual display order derives from _bookingTodos list order
   /// (see _groupedBookings), so move the residual entries to the tail in their
   /// new order — grouped todos are slot-matched by key, so nothing else shifts.
@@ -944,6 +944,48 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
       if (mounted) setState(() => _bookingTodos = prev);
       _showSnack('Could not reorder: $e');
     }
+  }
+
+  /// The residual booking-todo cards (the Bookings section's "Other"
+  /// sub-group): todos that didn't match a city group. City-matched todos
+  /// render embedded inside their city groups instead. Only called with a
+  /// non-empty [residual] — the section hides the sub-group otherwise.
+  Widget _residualBookingsList(List<BookingTodo> residual, ThemeData theme) {
+    return ReorderableListView.builder(
+      shrinkWrap: true,
+      physics: const NeverScrollableScrollPhysics(),
+      padding: EdgeInsets.zero,
+      buildDefaultDragHandles: false,
+      itemCount: residual.length,
+      onReorder: (oldIndex, newIndex) =>
+          _reorderResidual(residual, oldIndex, newIndex),
+      itemBuilder: (context, i) {
+        final todo = residual[i];
+        final canDrag = !_readOnly && !_isOffline && residual.length > 1;
+        return Padding(
+          key: ValueKey(todo.id),
+          padding: const EdgeInsets.symmetric(vertical: 4),
+          child: BookingTodoCard(
+            todo: todo,
+            onBookedChanged: (v) => _setBooked(todo, v),
+            onOpen: _openCallbackFor(todo),
+            openLabelOverride:
+                _flightLegs.containsKey(todo.todoKey) ? 'Find flights' : null,
+            onEdit: todo.auto ? null : () => _editTodo(todo),
+            onDelete: todo.auto ? null : () => _deleteTodo(todo),
+            dragHandle: canDrag
+                ? ReorderableDragStartListener(
+                    index: i,
+                    child: Icon(
+                      Icons.drag_indicator,
+                      color: theme.colorScheme.onSurfaceVariant,
+                    ),
+                  )
+                : null,
+          ),
+        );
+      },
+    );
   }
 
   /// Persists a drag-reorder of the saved-stays list in the bookings hub.
@@ -3610,7 +3652,8 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
                   ? const SizedBox.shrink()
                   : LayoutBuilder(builder: (context, constraints) {
                       // City-matched bookings render inside their city group;
-                      // the rest fall through to the "Other bookings" section.
+                      // the rest fall through to the Bookings section's
+                      // "Other" sub-group.
                       final grouped = _groupedBookings([
                         for (final r in _locationGroupRanges(trip)) r.label
                       ]);
@@ -3992,86 +4035,20 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
                                     onReorderSegments: (_readOnly || _isOffline)
                                         ? null
                                         : _reorderSegments,
+                                    // Residual booking-todos only: city-matched
+                                    // todos render embedded in their city
+                                    // groups above, so the Other sub-group
+                                    // appears only when something didn't match
+                                    // a city (custom or stale todos). Viewers
+                                    // get no checklist at all (the server
+                                    // withholds todos from them).
+                                    otherBookings: grouped.residual.isEmpty
+                                        ? null
+                                        : _residualBookingsList(
+                                            grouped.residual, theme),
+                                    onAddBooking:
+                                        _isOffline ? null : _addBooking,
                                   ),
-                                  // Bookings live embedded in their city groups;
-                                  // this section appears only when something
-                                  // didn't match a city (custom or stale todos).
-                                  // Viewers get no checklist at all (the server
-                                  // withholds todos from them).
-                                  if (grouped.residual.isEmpty && !_readOnly)
-                                    Align(
-                                      alignment: Alignment.centerRight,
-                                      child: TextButton.icon(
-                                        onPressed: _isOffline ? null : _addBooking,
-                                        icon: const Icon(Icons.add, size: 18),
-                                        label: const Text('Add booking'),
-                                      ),
-                                    )
-                                  else ...[
-                                    const Divider(height: 32),
-                                    Row(
-                                      children: [
-                                        Expanded(
-                                            child: Text('Other bookings',
-                                                style: theme
-                                                    .textTheme.titleMedium)),
-                                        TextButton.icon(
-                                          onPressed: _isOffline ? null : _addBooking,
-                                          icon: const Icon(Icons.add, size: 18),
-                                          label: const Text('Add'),
-                                        ),
-                                      ],
-                                    ),
-                                    const SizedBox(height: 8),
-                                    ReorderableListView.builder(
-                                      shrinkWrap: true,
-                                      physics:
-                                          const NeverScrollableScrollPhysics(),
-                                      padding: EdgeInsets.zero,
-                                      buildDefaultDragHandles: false,
-                                      itemCount: grouped.residual.length,
-                                      onReorder: (oldIndex, newIndex) =>
-                                          _reorderResidual(grouped.residual,
-                                              oldIndex, newIndex),
-                                      itemBuilder: (context, i) {
-                                        final todo = grouped.residual[i];
-                                        final canDrag = !_readOnly &&
-                                            !_isOffline &&
-                                            grouped.residual.length > 1;
-                                        return Padding(
-                                          key: ValueKey(todo.id),
-                                          padding: const EdgeInsets.symmetric(
-                                              vertical: 4),
-                                          child: BookingTodoCard(
-                                            todo: todo,
-                                            onBookedChanged: (v) =>
-                                                _setBooked(todo, v),
-                                            onOpen: _openCallbackFor(todo),
-                                            openLabelOverride: _flightLegs
-                                                    .containsKey(todo.todoKey)
-                                                ? 'Find flights'
-                                                : null,
-                                            onEdit: todo.auto
-                                                ? null
-                                                : () => _editTodo(todo),
-                                            onDelete: todo.auto
-                                                ? null
-                                                : () => _deleteTodo(todo),
-                                            dragHandle: canDrag
-                                                ? ReorderableDragStartListener(
-                                                    index: i,
-                                                    child: Icon(
-                                                      Icons.drag_indicator,
-                                                      color: theme.colorScheme
-                                                          .onSurfaceVariant,
-                                                    ),
-                                                  )
-                                                : null,
-                                          ),
-                                        );
-                                      },
-                                    ),
-                                  ],
                                 ],
                               ),
                             ),

--- a/src/packages/flutter-app/lib/services/booking_todos_api_service.dart
+++ b/src/packages/flutter-app/lib/services/booking_todos_api_service.dart
@@ -68,7 +68,8 @@ class BookingTodosApiService {
     throw Exception('Failed to update booking todo (${res.statusCode})');
   }
 
-  /// Persists the user's drag order for the residual "Other bookings" list.
+  /// Persists the user's drag order for the Bookings section's residual
+  /// "Other" list.
   /// Sends only that subset; the server renumbers those rows 0..n-1.
   Future<void> reorderTodos(String tripId, List<String> todoIds) async {
     final res = await apiClient.httpClient.put(

--- a/src/packages/flutter-app/lib/widgets/bookings_section.dart
+++ b/src/packages/flutter-app/lib/widgets/bookings_section.dart
@@ -4,12 +4,14 @@ import '../models/trip.dart';
 import '../models/trip_segment.dart';
 import '../theme/spacing.dart';
 import '../utils/tracked_launch.dart';
+import 'section_header.dart';
 import 'status_pill.dart';
 
-/// "Your bookings" hub in trip detail: the stays and transport segments the
-/// user has actually saved (distinct from the auto-derived booking checklist),
-/// plus itinerary-seeded Suggested drafts (auto=true) the user can keep, edit,
-/// or dismiss. Callbacks land in the screen, which persists via the
+/// The unified "Bookings" hub in trip detail: the stays and transport segments
+/// the user has actually saved, plus itinerary-seeded Suggested drafts
+/// (auto=true) the user can keep, edit, or dismiss — and, via the
+/// [otherBookings] slot, the residual booking-todos that didn't match a city
+/// group. Callbacks land in the screen, which persists via the
 /// accommodations/segments endpoints and reloads the trip.
 class BookingsSection extends StatelessWidget {
   final Trip trip;
@@ -47,6 +49,18 @@ class BookingsSection extends StatelessWidget {
   /// entirely (the server already withholds them from viewers).
   final bool readOnly;
 
+  /// Residual booking-todos rendered as the "Other" sub-group. Built by the
+  /// screen — its callbacks (open-link factory, flight-leg labels, todo
+  /// dialogs) are screen-coupled. Null hides the sub-group and its header;
+  /// pass null rather than an empty list widget (see the empty-scroll-view
+  /// note in [build]).
+  final Widget? otherBookings;
+
+  /// Opens the add-booking-todo dialog; rendered as the section's trailing
+  /// "Add booking" footer when not read-only. Null renders it disabled
+  /// (offline), mirroring the reorder callbacks.
+  final VoidCallback? onAddBooking;
+
   const BookingsSection({
     super.key,
     required this.trip,
@@ -65,6 +79,8 @@ class BookingsSection extends StatelessWidget {
     this.onReorderStays,
     this.onReorderSegments,
     this.readOnly = false,
+    this.otherBookings,
+    this.onAddBooking,
   });
 
   static IconData _modeIcon(String mode) => switch (mode) {
@@ -161,6 +177,16 @@ class BookingsSection extends StatelessWidget {
         ),
       );
 
+  Widget _subHeader(ThemeData theme, String label) => Padding(
+        padding:
+            const EdgeInsets.only(top: AppSpacing.sm, bottom: AppSpacing.xs),
+        child: Text(
+          label,
+          style: theme.textTheme.titleSmall
+              ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+        ),
+      );
+
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
@@ -180,31 +206,34 @@ class BookingsSection extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
-        Row(
-          children: [
-            Expanded(
-              child: Text('Your bookings', style: theme.textTheme.titleMedium),
-            ),
-            if (!readOnly) ...[
-              TextButton.icon(
-                onPressed: onAddStay,
-                icon: const Icon(Icons.hotel_outlined, size: 18),
-                label: const Text('Add stay'),
-              ),
-              TextButton.icon(
-                onPressed: onAddSegment,
-                icon: const Icon(Icons.route_outlined, size: 18),
-                label: const Text('Add transport'),
-              ),
-            ],
-          ],
+        SectionHeader(
+          title: 'Bookings',
+          action: readOnly
+              ? null
+              : Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    TextButton.icon(
+                      onPressed: onAddStay,
+                      icon: const Icon(Icons.hotel_outlined, size: 18),
+                      label: const Text('Add stay'),
+                    ),
+                    TextButton.icon(
+                      onPressed: onAddSegment,
+                      icon: const Icon(Icons.route_outlined, size: 18),
+                      label: const Text('Add transport'),
+                    ),
+                  ],
+                ),
         ),
-        if (visibleStays.isEmpty && visibleSegments.isEmpty)
+        if (visibleStays.isEmpty &&
+            visibleSegments.isEmpty &&
+            otherBookings == null)
           Padding(
             padding: const EdgeInsets.symmetric(vertical: AppSpacing.sm),
             child: Text(
-              'Nothing saved yet — add the stay or transport you booked so '
-              'the whole trip lives in one place.',
+              'Nothing saved yet — add the stays, transport, and other '
+              'bookings for your trip so it all lives in one place.',
               style: theme.textTheme.bodySmall
                   ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
             ),
@@ -212,7 +241,8 @@ class BookingsSection extends StatelessWidget {
         // Only built when non-empty: ReorderableListView is itself a scroll
         // view, and a pair of always-present empty ones would pollute the
         // page's scrollable tree (and every find.byType(CustomScrollView)).
-        if (visibleStays.isNotEmpty)
+        if (visibleStays.isNotEmpty) ...[
+          _subHeader(theme, 'Stays'),
           ReorderableListView.builder(
             shrinkWrap: true,
             physics: const NeverScrollableScrollPhysics(),
@@ -292,7 +322,9 @@ class BookingsSection extends StatelessWidget {
               );
             },
           ),
-        if (visibleSegments.isNotEmpty)
+        ],
+        if (visibleSegments.isNotEmpty) ...[
+          _subHeader(theme, 'Transport'),
           ReorderableListView.builder(
             shrinkWrap: true,
             physics: const NeverScrollableScrollPhysics(),
@@ -375,6 +407,20 @@ class BookingsSection extends StatelessWidget {
                 ),
               );
             },
+          ),
+        ],
+        if (otherBookings != null) ...[
+          _subHeader(theme, 'Other'),
+          otherBookings!,
+        ],
+        if (!readOnly)
+          Align(
+            alignment: Alignment.centerRight,
+            child: TextButton.icon(
+              onPressed: onAddBooking,
+              icon: const Icon(Icons.add, size: 18),
+              label: const Text('Add booking'),
+            ),
           ),
       ],
     );

--- a/src/packages/flutter-app/test/bookings_section_drafts_test.dart
+++ b/src/packages/flutter-app/test/bookings_section_drafts_test.dart
@@ -56,6 +56,8 @@ BookingsSection _section({
   void Function(Accommodation)? onDeleteStay,
   void Function(int, int)? onReorderStays,
   void Function(Accommodation, bool)? onStayBookedChanged,
+  Widget? otherBookings,
+  VoidCallback? onAddBooking,
 }) =>
     BookingsSection(
       trip: _trip(),
@@ -72,6 +74,8 @@ BookingsSection _section({
       onConfirmSegment: (_) {},
       onReorderStays: onReorderStays,
       onStayBookedChanged: onStayBookedChanged,
+      otherBookings: otherBookings,
+      onAddBooking: onAddBooking,
     );
 
 void main() {
@@ -205,5 +209,75 @@ void main() {
       onReorderStays: (_, __) {},
     )));
     expect(find.byIcon(Icons.drag_indicator), findsNothing);
+  });
+
+  testWidgets('sub-headers render only for non-empty groups', (tester) async {
+    await tester.pumpWidget(_wrap(_section(
+      stays: const [_confirmedStay],
+      segments: const [],
+    )));
+    expect(find.text('Bookings'), findsOneWidget);
+    expect(find.text('Stays'), findsOneWidget);
+    expect(find.text('Transport'), findsNothing);
+    expect(find.text('Other'), findsNothing);
+
+    await tester.pumpWidget(_wrap(_section(
+      stays: const [],
+      segments: const [_draftLeg],
+    )));
+    expect(find.text('Stays'), findsNothing);
+    expect(find.text('Transport'), findsOneWidget);
+  });
+
+  testWidgets('otherBookings slot renders under an Other sub-header',
+      (tester) async {
+    const slotKey = Key('other-slot');
+    await tester.pumpWidget(_wrap(_section(
+      stays: const [],
+      segments: const [],
+      otherBookings: const SizedBox(key: slotKey, height: 40),
+    )));
+    expect(find.text('Other'), findsOneWidget);
+    expect(find.byKey(slotKey), findsOneWidget);
+    // A non-null slot counts as content, so no empty hint.
+    expect(find.textContaining('Nothing saved yet'), findsNothing);
+
+    await tester.pumpWidget(_wrap(_section(
+      stays: const [],
+      segments: const [],
+    )));
+    expect(find.text('Other'), findsNothing);
+    expect(find.textContaining('Nothing saved yet'), findsOneWidget);
+  });
+
+  testWidgets('Add booking footer: enabled, disabled offline, hidden read-only',
+      (tester) async {
+    var added = false;
+    await tester.pumpWidget(_wrap(_section(
+      stays: const [],
+      segments: const [],
+      onAddBooking: () => added = true,
+    )));
+    await tester.tap(find.text('Add booking'));
+    expect(added, isTrue);
+
+    // Null callback (offline) renders the footer disabled.
+    await tester.pumpWidget(_wrap(_section(
+      stays: const [],
+      segments: const [],
+    )));
+    final button = tester.widget<TextButton>(
+      find.ancestor(
+          of: find.text('Add booking'), matching: find.bySubtype<TextButton>()),
+    );
+    expect(button.onPressed, isNull);
+
+    await tester.pumpWidget(_wrap(_section(
+      stays: const [],
+      segments: const [],
+      readOnly: true,
+      onAddBooking: () {},
+    )));
+    expect(find.text('Add booking'), findsNothing);
   });
 }

--- a/src/packages/flutter-app/test/trip_detail_bookings_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_bookings_test.dart
@@ -108,8 +108,10 @@ void main() {
     expect(tester.getTopLeft(find.text('Rome → JFK')).dy,
         greaterThan(tester.getTopLeft(find.text('Trastevere')).dy));
 
-    // Only the unmatched custom todo remains in "Other bookings", as a card.
-    expect(find.text('Other bookings'), findsOneWidget);
+    // Only the unmatched custom todo remains in the Bookings section's
+    // "Other" sub-group, as a card.
+    expect(find.text('Bookings'), findsOneWidget);
+    expect(find.text('Other'), findsOneWidget);
     expect(find.byType(BookingTodoCard), findsOneWidget);
     expect(
         find.widgetWithText(BookingTodoCard, 'Museum tickets'), findsOneWidget);
@@ -148,9 +150,9 @@ void main() {
 
     expect(find.byType(BookingTodoRow), findsNWidgets(2));
 
-    // No unmatched bookings -> no "Other bookings" section, just the inline
-    // add affordance.
-    expect(find.text('Other bookings'), findsNothing);
+    // No unmatched bookings -> no "Other" sub-group, just the section's
+    // "Add booking" footer.
+    expect(find.text('Other'), findsNothing);
     expect(find.text('Add booking'), findsOneWidget);
 
     await tester.tap(find.text('Paris'));


### PR DESCRIPTION
## Summary
- Merges the trip detail page's sibling "Your bookings" and "Other bookings" sections into a single **Bookings** section with **Stays / Transport / Other** sub-headers (each shown only when non-empty).
- `BookingsSection` now owns the unified header (shared `SectionHeader`), the sub-headers, a combined empty hint, and a persistent right-aligned **"Add booking"** footer for editors (disabled offline). Two new optional params: an `otherBookings` widget slot and `onAddBooking`.
- The residual booking-todo list (todos that didn't match a city group) moves out of the screen's sliver column into `_residualBookingsList()` and is passed into the slot only when non-empty — preserving the no-empty-`ReorderableListView` invariant.
- UI-only: models, endpoints, and all three reorder persistence paths (stays, segments, residual todos) are unchanged; drags still can't cross sub-lists.
- Side fix: read-only viewers with no residual todos no longer see a phantom "Other bookings" header with an enabled Add button and an empty list.

## Testing
- `flutter analyze` — clean (12 pre-existing deprecation infos only).
- Full `flutter test` — 355/355 passing.
- Updated title assertions in `test/trip_detail_bookings_test.dart`; added cases to `test/bookings_section_drafts_test.dart` covering sub-header visibility, the `otherBookings` slot contract (incl. empty-hint suppression), and the footer's enabled/disabled/hidden states.
- `grep` confirms no remaining "Your bookings"/"Other bookings" UI strings in lib or test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)