### PR TITLE
ci: build multi-arch (amd64+arm64) images for Raspberry Pi deploy target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,6 +151,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # QEMU runs the arm64 RUN steps (the api image's final alpine stage);
+      # the heavy build stages are pinned to $BUILDPLATFORM in their
+      # Dockerfiles and cross-compile natively.
+      - uses: docker/setup-qemu-action@v3
+
       - uses: docker/setup-buildx-action@v3
 
       - uses: docker/login-action@v3
@@ -166,6 +171,9 @@ jobs:
         with:
           context: src/packages/api
           file: src/packages/api/Dockerfile
+          # arm64 covers the Raspberry Pi production host; amd64 keeps
+          # x86 servers and local docker-compose pulls working.
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             ghcr.io/bdowe/goldentempo-api:latest
@@ -182,6 +190,7 @@ jobs:
         with:
           context: .
           file: dockerize/deployment/Dockerfile
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             ghcr.io/bdowe/goldentempo-gateway:latest

--- a/dockerize/deployment/Dockerfile
+++ b/dockerize/deployment/Dockerfile
@@ -1,5 +1,7 @@
-# Build Flutter web app
-FROM debian:stable-slim AS flutter-build
+# Build Flutter web app. The output (js/wasm/assets) is target-independent,
+# so pin this stage to the build host's platform: multi-arch builds run the
+# Flutter toolchain once, natively, instead of again under QEMU emulation.
+FROM --platform=$BUILDPLATFORM debian:stable-slim AS flutter-build
 
 RUN apt-get update && apt-get install -y \
     curl \

--- a/src/packages/api/Dockerfile
+++ b/src/packages/api/Dockerfile
@@ -1,5 +1,6 @@
-# Build stage
-FROM golang:1.26-alpine AS builder
+# Build stage — pinned to the build host's platform so multi-arch builds
+# cross-compile (fast) instead of running the Go toolchain under QEMU.
+FROM --platform=$BUILDPLATFORM golang:1.26-alpine AS builder
 
 # Set working directory
 WORKDIR /app
@@ -16,8 +17,9 @@ RUN go mod download
 # Copy source code
 COPY . .
 
-# Build the application
-RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o main .
+# Build the application for the image's target platform (amd64/arm64)
+ARG TARGETOS TARGETARCH
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -a -installsuffix cgo -o main .
 
 # Final stage
 FROM alpine:latest


### PR DESCRIPTION
## Summary
- Add `docker/setup-qemu-action` and `platforms: linux/amd64,linux/arm64` to both GHCR build-push steps in CI — the production host is moving to a Raspberry Pi (arm64) and the images were amd64-only.
- Pin the api builder stage to `$BUILDPLATFORM` with `GOARCH=$TARGETARCH` so Go cross-compiles natively instead of running under QEMU.
- Pin the gateway `flutter-build` stage to `$BUILDPLATFORM` — the Flutter web output is target-independent, so the (slow) toolchain runs once natively; only the final `nginx:alpine` copy stage is per-arch.

## Testing
- Local `docker buildx build --platform linux/arm64` of the api image: builds clean, `docker inspect` reports `linux/arm64`, and the binary boots under arm64 emulation (startup warnings printed as expected).
- Gateway Dockerfile change is stage-platform-pinning only; full multi-arch manifest will be verified on the first main build (`docker manifest inspect`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)