### PR TITLE
chore: move production domain to goldentempotravel.com

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -161,7 +161,7 @@ seed-local: ## Bulk-ingest local content via admin API (CONTENT_DIR=./content/lo
 # pass through: SMOKE_SEED_MODE=sql|plan|existing, SMOKE_TRIP_ID, SMOKE_TOKEN,
 # SMOKE_SIGNING_SECRET, SMOKE_DB_CONTAINER (see scripts/smoke.sh header).
 #   make smoke                                         # dev stack, sql seed
-#   make smoke BASE_URL=https://goldentempo.co SMOKE_SEED_MODE=plan   # post-deploy
+#   make smoke BASE_URL=https://goldentempotravel.com SMOKE_SEED_MODE=plan   # post-deploy
 smoke: ## Run the end-to-end smoke test (BASE_URL, SMOKE_SEED_MODE, ...)
 	@BASE_URL="$(if $(BASE_URL),$(BASE_URL),$(GATEWAY_URL))" \
 		SMOKE_SEED_MODE="$(SMOKE_SEED_MODE)" SMOKE_TRIP_ID="$(SMOKE_TRIP_ID)" \

--- a/dockerize/README.md
+++ b/dockerize/README.md
@@ -8,7 +8,7 @@ Docker orchestration lives here instead of in individual app packages. A single 
 dockerize/
 ├── development/     # Flutter dev server (hot reload) + Go API + nginx
 ├── deployment/      # Static Flutter build + Go API + nginx
-└── production/      # goldentempo.co: prebuilt GHCR images + TLS gateway behind Cloudflare (see its README)
+└── production/      # goldentempotravel.com: prebuilt GHCR images + TLS gateway behind Cloudflare (see its README)
 ```
 
 ## Quick start

--- a/dockerize/production/.env.sample
+++ b/dockerize/production/.env.sample
@@ -1,4 +1,4 @@
-# Production environment for goldentempo.co
+# Production environment for goldentempotravel.com
 # ------------------------------------------
 # Copy to /opt/goldentempo/.env (chmod 600, root-owned) next to
 # docker-compose.yml. This single file serves two purposes:
@@ -30,13 +30,13 @@ IMAGE_TAG=latest
 # ---------------------------------------------------------------------------
 
 # Leave EMPTY in production. The nginx gateway serves the UI and API
-# same-origin (goldentempo.co), so no CORS headers are needed; an allowlist
+# same-origin (goldentempotravel.com), so no CORS headers are needed; an allowlist
 # here would only widen the surface. Localhost origins are a dev-only thing.
 ALLOWED_ORIGINS=
 
 # Public URL used in transactional email links (verification, password
 # reset, price alerts). Static for this deployment.
-PUBLIC_BASE_URL=https://goldentempo.co
+PUBLIC_BASE_URL=https://goldentempotravel.com
 
 # Path prefix the Flutter app is served under (deep links in emails).
 PUBLIC_APP_PATH=/app/

--- a/dockerize/production/README.md
+++ b/dockerize/production/README.md
@@ -1,4 +1,4 @@
-# Production stack — goldentempo.co
+# Production stack — goldentempotravel.com
 
 Runs the prebuilt GHCR images on a VPS behind **Cloudflare** (proxied DNS,
 SSL mode **Full (strict)**). The gateway terminates TLS with a **Cloudflare
@@ -20,7 +20,7 @@ Cloudflare edge IPs.
 └── backups/                  # backup.sh output (gzipped pg_dump custom format)
 
 /etc/goldentempo/certs/
-├── origin.crt                # Cloudflare Origin CA certificate (goldentempo.co + *.goldentempo.co)
+├── origin.crt                # Cloudflare Origin CA certificate (goldentempotravel.com + *.goldentempotravel.com)
 └── origin.key                # its private key (chmod 600, root-owned)
 ```
 
@@ -136,10 +136,10 @@ fresh scratch volume first, then swap it under the live stack and confirm
 ## Sanity checks after a deploy
 
 ```bash
-curl -fsS https://goldentempo.co/health              # gateway
-curl -fsS https://goldentempo.co/api/v1/health       # API through the proxy
-curl -sI  http://goldentempo.co/                     # 301 → https apex
-curl -sI  https://www.goldentempo.co/                # 301 → apex
+curl -fsS https://goldentempotravel.com/health              # gateway
+curl -fsS https://goldentempotravel.com/api/v1/health       # API through the proxy
+curl -sI  http://goldentempotravel.com/                     # 301 → https apex
+curl -sI  https://www.goldentempotravel.com/                # 301 → apex
 ```
 
 For the full end-to-end journey (register → trip → item → share/OG → export →
@@ -151,7 +151,7 @@ against production:
 # sql seed mode is local-only (needs the postgres container); against prod use
 # plan mode (the AI planner builds a real trip — costs a little Anthropic spend)
 # or existing mode with a trip you own (SMOKE_TRIP_ID + SMOKE_TOKEN=<bearer>).
-make smoke BASE_URL=https://goldentempo.co SMOKE_SEED_MODE=plan
+make smoke BASE_URL=https://goldentempotravel.com SMOKE_SEED_MODE=plan
 ```
 
 Green means the traveler journey works end to end; the run also prints a

--- a/dockerize/production/backup.sh
+++ b/dockerize/production/backup.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Nightly Postgres backup for the goldentempo.co production stack.
+# Nightly Postgres backup for the goldentempotravel.com production stack.
 #
 # Dumps the database from the running postgres container (pg_dump custom
 # format, gzipped), prunes local dumps older than RETENTION_DAYS, and — if

--- a/dockerize/production/docker-compose.yml
+++ b/dockerize/production/docker-compose.yml
@@ -1,4 +1,4 @@
-# Production stack for https://goldentempo.co — same topology as
+# Production stack for https://goldentempotravel.com — same topology as
 # dockerize/deployment/docker-compose.yml, but runs prebuilt images from
 # GHCR (no build:) and terminates TLS on the gateway (:80 + :443) behind
 # Cloudflare. All nginx config and certs are volume-mounted, never baked,
@@ -103,7 +103,7 @@ services:
     depends_on:
       - api
     healthcheck:
-      # :80 is a wholesale 301 to https://goldentempo.co, so probe :443
+      # :80 is a wholesale 301 to https://goldentempotravel.com, so probe :443
       # directly; the apex server is default_server, so "localhost" lands
       # there. --no-check-certificate: the Origin CA cert isn't in the
       # container's trust store (it's only trusted by Cloudflare).

--- a/dockerize/production/nginx/prod.conf
+++ b/dockerize/production/nginx/prod.conf
@@ -1,4 +1,4 @@
-# Production gateway for https://goldentempo.co — TLS termination behind
+# Production gateway for https://goldentempotravel.com — TLS termination behind
 # Cloudflare (proxied DNS, SSL mode "Full (strict)", Cloudflare Origin CA
 # certificate on the origin).
 #
@@ -15,8 +15,8 @@
 server {
     listen 80;
     listen [::]:80;
-    server_name goldentempo.co www.goldentempo.co;
-    return 301 https://goldentempo.co$request_uri;
+    server_name goldentempotravel.com www.goldentempotravel.com;
+    return 301 https://goldentempotravel.com$request_uri;
 }
 
 # Canonical apex. default_server so requests without a matching SNI/Host —
@@ -26,7 +26,7 @@ server {
     listen 443 ssl default_server;
     listen [::]:443 ssl default_server;
     http2 on;
-    server_name goldentempo.co;
+    server_name goldentempotravel.com;
 
     ssl_certificate     /etc/goldentempo/certs/origin.crt;
     ssl_certificate_key /etc/goldentempo/certs/origin.key;
@@ -37,17 +37,17 @@ server {
     include /etc/nginx/snippets/app-locations.conf;
 }
 
-# www → apex 301 (the Origin CA cert covers goldentempo.co and
-# *.goldentempo.co, so terminating www here is fine).
+# www → apex 301 (the Origin CA cert covers goldentempotravel.com and
+# *.goldentempotravel.com, so terminating www here is fine).
 server {
     listen 443 ssl;
     listen [::]:443 ssl;
     http2 on;
-    server_name www.goldentempo.co;
+    server_name www.goldentempotravel.com;
 
     ssl_certificate     /etc/goldentempo/certs/origin.crt;
     ssl_certificate_key /etc/goldentempo/certs/origin.key;
     ssl_protocols       TLSv1.2 TLSv1.3;
 
-    return 301 https://goldentempo.co$request_uri;
+    return 301 https://goldentempotravel.com$request_uri;
 }

--- a/dockerize/production/restore.md
+++ b/dockerize/production/restore.md
@@ -1,4 +1,4 @@
-# Restore runbook — goldentempo.co Postgres
+# Restore runbook — goldentempotravel.com Postgres
 
 Restores a `backup.sh` dump (`pg_dump -Fc | gzip`) into a **fresh volume
 first**, verifies it there, and only then swaps it under the live stack.
@@ -91,10 +91,10 @@ docker compose up -d api      # api boot re-applies any missing migrations
 ```bash
 docker compose ps                                        # postgres healthy, api healthy
 docker compose logs --tail 50 api                        # migrations applied, no errors
-curl -fsS https://goldentempo.co/api/v1/health           # "database":"ok"
+curl -fsS https://goldentempotravel.com/api/v1/health           # "database":"ok"
 ```
 
-Then a real user check: log in at <https://goldentempo.co/app/> and open a
+Then a real user check: log in at <https://goldentempotravel.com/app/> and open a
 trip.
 
 ## 6. Clean up

--- a/dockerize/static/robots.txt
+++ b/dockerize/static/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Disallow: /api/
 
-Sitemap: https://goldentempo.co/sitemap.xml
+Sitemap: https://goldentempotravel.com/sitemap.xml

--- a/dockerize/static/sitemap.xml
+++ b/dockerize/static/sitemap.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  <url><loc>https://goldentempo.co/</loc></url>
-  <url><loc>https://goldentempo.co/app/</loc></url>
-  <url><loc>https://goldentempo.co/privacy</loc></url>
-  <url><loc>https://goldentempo.co/terms</loc></url>
+  <url><loc>https://goldentempotravel.com/</loc></url>
+  <url><loc>https://goldentempotravel.com/app/</loc></url>
+  <url><loc>https://goldentempotravel.com/privacy</loc></url>
+  <url><loc>https://goldentempotravel.com/terms</loc></url>
 </urlset>

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -5,7 +5,7 @@
 # hits) and asserts each step, colored PASS/FAIL, non-zero exit on any failure.
 # Built to run TWICE against the same code: as a rehearsal against the local dev
 # stack, and as the go/no-go sanity check against production the moment DNS flips
-# to https://goldentempo.co. Pure bash + curl + jq, cloning the api_call idiom
+# to https://goldentempotravel.com. Pure bash + curl + jq, cloning the api_call idiom
 # from scripts/seed_local_content.sh.
 #
 # It registers a THROWAWAY user (unique email), exercises the traveler journey

--- a/src/packages/flutter-app/web/index.html
+++ b/src/packages/flutter-app/web/index.html
@@ -33,13 +33,13 @@
 
   <!-- SEO / social sharing (app landing; per-trip share links are prerendered
        server-side via /api/v1/share-preview and don't use these). -->
-  <link rel="canonical" href="https://goldentempo.co/app/">
+  <link rel="canonical" href="https://goldentempotravel.com/app/">
   <meta property="og:type" content="website">
   <meta property="og:site_name" content="Golden Tempo Travel">
   <meta property="og:title" content="Golden Tempo Travel">
   <meta property="og:description" content="Golden Tempo Travel - Plan trips, optimize routes, and build itineraries with AI.">
-  <meta property="og:url" content="https://goldentempo.co/app/">
-  <meta property="og:image" content="https://goldentempo.co/app/icons/Icon-512.png">
+  <meta property="og:url" content="https://goldentempotravel.com/app/">
+  <meta property="og:image" content="https://goldentempotravel.com/app/icons/Icon-512.png">
   <meta name="twitter:card" content="summary">
 
   <!-- iOS meta tags & icons -->


### PR DESCRIPTION
## Summary
- Swap every non-historical `goldentempo.co` reference to the newly registered launch domain `goldentempotravel.com`: nginx `server_name`s + 301 redirects, robots.txt/sitemap.xml, canonical + OG tags in `web/index.html`, production compose/env/backup/restore docs, and the smoke-harness default `BASE_URL`.
- Spec history (`specs/google-sso`) and the LLC playbook intentionally keep the old name.
- Legal pages under `dockerize/deployment/legal/` contain no domain references (verified).

## Testing
- `grep -rn "goldentempo\.co\b"` over the repo (excluding specs/docs history) returns nothing — no strays.
- Pure string/config change; exercised for real by the launch smoke run (`make smoke BASE_URL=https://goldentempotravel.com`) once DNS + tunnel are up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)