### PR TITLE
feat(prod): Cloudflare Tunnel origin for the Raspberry Pi host

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,19 +216,26 @@ jobs:
     env:
       IMAGE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.image_tag || github.sha }}
     steps:
-      # The DEPLOY_* secrets arrive with Track B step 3 (server provisioning).
-      # Until then this job self-skips with a notice instead of failing, so
-      # main CI stays green. Delete this gate once the secrets exist, if you
-      # want missing config to be loud.
+      # The production host is a Raspberry Pi behind a Cloudflare Tunnel, so
+      # there is no publicly routable SSH port: every ssh/rsync below goes
+      # through `cloudflared access ssh` against the tunnel's SSH hostname
+      # (DEPLOY_HOST, e.g. ssh.goldentempotravel.com), authenticated by a
+      # Cloudflare Access service token (CF_ACCESS_*) on top of the normal
+      # SSH keypair. Until all five secrets exist this job self-skips with a
+      # notice instead of failing, so main CI stays green. Delete this gate
+      # once the secrets exist, if you want missing config to be loud.
       - name: Check deploy secrets
         id: gate
         env:
           DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
           DEPLOY_SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
           DEPLOY_KNOWN_HOSTS: ${{ secrets.DEPLOY_KNOWN_HOSTS }}
+          CF_ACCESS_CLIENT_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
+          CF_ACCESS_CLIENT_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
         run: |
-          if [ -z "$DEPLOY_HOST" ] || [ -z "$DEPLOY_SSH_KEY" ] || [ -z "$DEPLOY_KNOWN_HOSTS" ]; then
-            echo "::notice::deploy secrets not configured — skipping deploy (Track B step 3)"
+          if [ -z "$DEPLOY_HOST" ] || [ -z "$DEPLOY_SSH_KEY" ] || [ -z "$DEPLOY_KNOWN_HOSTS" ] \
+             || [ -z "$CF_ACCESS_CLIENT_ID" ] || [ -z "$CF_ACCESS_CLIENT_SECRET" ]; then
+            echo "::notice::deploy secrets not configured — skipping deploy (launch runbook step 3)"
             echo "configured=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -247,25 +254,42 @@ jobs:
         with:
           ssh-private-key: ${{ secrets.DEPLOY_SSH_KEY }}
 
-      - name: Add server to known_hosts
+      # cloudflared provides the transport: ssh can't reach the Pi directly,
+      # so a ProxyCommand pipes each connection through the tunnel's SSH
+      # hostname, authorized by the Access service token (the
+      # TUNNEL_SERVICE_TOKEN_* env vars cloudflared reads).
+      - name: Install cloudflared and configure SSH via Cloudflare Access
         if: steps.gate.outputs.configured == 'true'
         env:
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
           DEPLOY_KNOWN_HOSTS: ${{ secrets.DEPLOY_KNOWN_HOSTS }}
         run: |
+          sudo curl -fsSL \
+            https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64 \
+            -o /usr/local/bin/cloudflared
+          sudo chmod +x /usr/local/bin/cloudflared
+          cloudflared --version
           mkdir -p ~/.ssh
           chmod 700 ~/.ssh
           printf '%s\n' "$DEPLOY_KNOWN_HOSTS" >> ~/.ssh/known_hosts
           chmod 600 ~/.ssh/known_hosts
+          cat >> ~/.ssh/config <<EOF
+          Host deploy-target
+            HostName ${DEPLOY_HOST}
+            User deploy
+            ProxyCommand cloudflared access ssh --hostname %h
+          EOF
+          chmod 600 ~/.ssh/config
 
       # Everything under dockerize/production/ that's in git (compose, nginx
       # confs, README). No --delete: /opt/goldentempo/ also holds the .env,
-      # .image_tag, and backups/ that must never be touched from CI. Certs
-      # live outside the tree in /etc/goldentempo/certs.
+      # .image_tag, and backups/ that must never be touched from CI.
       - name: Sync production stack files
         if: steps.gate.outputs.configured == 'true'
         env:
-          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
-        run: rsync -rtvz dockerize/production/ "deploy@${DEPLOY_HOST}:/opt/goldentempo/"
+          TUNNEL_SERVICE_TOKEN_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
+          TUNNEL_SERVICE_TOKEN_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
+        run: rsync -rtvz dockerize/production/ "deploy-target:/opt/goldentempo/"
 
       # .image_tag records what's live so manual server-side restarts can
       # reuse it (see dockerize/production/README.md) instead of silently
@@ -273,9 +297,10 @@ jobs:
       - name: Pull images and restart stack
         if: steps.gate.outputs.configured == 'true'
         env:
-          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          TUNNEL_SERVICE_TOKEN_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
+          TUNNEL_SERVICE_TOKEN_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
         run: |
-          ssh "deploy@${DEPLOY_HOST}" "set -eu
+          ssh deploy-target "set -eu
             cd /opt/goldentempo
             printf 'IMAGE_TAG=%s\n' '${IMAGE_TAG}' > .image_tag
             export IMAGE_TAG='${IMAGE_TAG}'

--- a/dockerize/README.md
+++ b/dockerize/README.md
@@ -8,7 +8,7 @@ Docker orchestration lives here instead of in individual app packages. A single 
 dockerize/
 ├── development/     # Flutter dev server (hot reload) + Go API + nginx
 ├── deployment/      # Static Flutter build + Go API + nginx
-└── production/      # goldentempotravel.com: prebuilt GHCR images + TLS gateway behind Cloudflare (see its README)
+└── production/      # goldentempotravel.com: prebuilt GHCR images behind a Cloudflare Tunnel (see its README)
 ```
 
 ## Quick start

--- a/dockerize/production/.env.sample
+++ b/dockerize/production/.env.sample
@@ -25,6 +25,15 @@ POSTGRES_PASSWORD=
 # here is only the fallback when the shell doesn't set one.
 IMAGE_TAG=latest
 
+# REQUIRED — compose refuses to start without it. The Cloudflare Tunnel
+# connector token for this host: Zero Trust → Networks → Tunnels → your
+# tunnel → the token from the install command. The tunnel is the ONLY path
+# from the internet to this stack (no ports are published, no inbound
+# firewall openings needed); its public hostnames route
+# goldentempotravel.com → http://gateway:80 and ssh.goldentempotravel.com →
+# ssh://172.28.0.1:22 for CI deploys.
+TUNNEL_TOKEN=
+
 # ---------------------------------------------------------------------------
 # Core API config
 # ---------------------------------------------------------------------------

--- a/dockerize/production/README.md
+++ b/dockerize/production/README.md
@@ -1,28 +1,44 @@
 # Production stack — goldentempotravel.com
 
-Runs the prebuilt GHCR images on a VPS behind **Cloudflare** (proxied DNS,
-SSL mode **Full (strict)**). The gateway terminates TLS with a **Cloudflare
-Origin CA** certificate and restores the real client IP from
-`CF-Connecting-IP` so the API's per-IP rate limiter sees end users, not
-Cloudflare edge IPs.
+Runs the prebuilt GHCR images (multi-arch: amd64 + arm64) on a home
+**Raspberry Pi** reached exclusively through a **Cloudflare Tunnel**: the
+`cloudflared` service dials out to the Cloudflare edge, so the host
+publishes no ports, forwards nothing on the router, and never exposes its
+home IP. TLS terminates at the edge; nginx restores the real client IP
+from `CF-Connecting-IP` so the API's per-IP rate limiter sees end users,
+not the tunnel connector.
 
 ## Server layout
 
 ```
 /opt/goldentempo/
 ├── docker-compose.yml        # this directory's compose file
-├── .env                      # secrets — copy .env.sample and fill in (chmod 600)
+├── .env                      # secrets incl. TUNNEL_TOKEN — copy .env.sample, fill in (chmod 600)
 ├── .image_tag                # IMAGE_TAG=<sha> of the live deploy (written by CI)
 ├── backup.sh                 # nightly pg_dump + prune + optional rclone off-site copy
 ├── nginx/
-│   ├── prod.conf             # TLS server blocks (mounted over conf.d/default.conf)
-│   └── cloudflare-realip.conf# CF ranges + real_ip_header (mounted into conf.d/)
+│   ├── prod.conf             # :80 server blocks (mounted over conf.d/default.conf)
+│   └── cloudflare-realip.conf# compose-subnet trust + real_ip_header (mounted into conf.d/)
 └── backups/                  # backup.sh output (gzipped pg_dump custom format)
-
-/etc/goldentempo/certs/
-├── origin.crt                # Cloudflare Origin CA certificate (goldentempotravel.com + *.goldentempotravel.com)
-└── origin.key                # its private key (chmod 600, root-owned)
 ```
+
+## Cloudflare Tunnel
+
+One tunnel (Zero Trust → Networks → Tunnels), token in `.env` as
+`TUNNEL_TOKEN`, with three public hostnames:
+
+| Hostname | Service | Purpose |
+|----------|---------|---------|
+| `goldentempotravel.com` | `http://gateway:80` | the site |
+| `www.goldentempotravel.com` | `http://gateway:80` | nginx 301s it to the apex |
+| `ssh.goldentempotravel.com` | `ssh://172.28.0.1:22` | CI deploys (host sshd via the pinned bridge gateway IP) |
+
+The SSH hostname sits behind a Cloudflare **Access** application with a
+**service token**; CI authenticates with it (`CF_ACCESS_*` secrets) and
+then does normal SSH-key auth on top. The host firewall needs
+`ufw allow from 172.28.0.0/16 to any port 22` (tunnel→sshd) and no
+inbound 80/443 rules at all. Enable **Always Use HTTPS** at the edge —
+the origin serves plain :80 and never sees an http URL a user typed.
 
 ## Environment / secrets
 
@@ -47,17 +63,16 @@ host; it exists only on the private compose network.
 
 - `/etc/nginx/snippets/app-locations.conf` — the shared location set
   (API proxy, SPA, share-preview rewrite, static caching, legal pages),
-  used verbatim by both the deployment `:80` server and the production
-  `:443` server;
+  used verbatim by both the deployment and production `:80` servers;
 - `/etc/nginx/conf.d/share-prerender-map.conf` — the `$share_prerender`
   bot-UA `map` (must live at `http` scope);
 - `/etc/nginx/conf.d/default.conf` — the local `:80` server shell.
 
 The production compose then **mounts** `nginx/prod.conf` *over*
 `conf.d/default.conf` (replacing the `:80 localhost` shell with the
-`:80→301` + `:443 ssl` servers), mounts `nginx/cloudflare-realip.conf` into
-`conf.d/`, and mounts `/etc/goldentempo/certs` read-only. Editing a conf on
-the host therefore needs only a gateway restart, not an image rebuild:
+apex + www→apex servers) and mounts `nginx/cloudflare-realip.conf` into
+`conf.d/`. Editing a conf on the host therefore needs only a gateway
+restart, not an image rebuild:
 
 ```bash
 docker compose exec gateway nginx -t && docker compose exec gateway nginx -s reload
@@ -65,19 +80,19 @@ docker compose exec gateway nginx -t && docker compose exec gateway nginx -s rel
 
 ## Client-IP chain (rate limiting correctness)
 
-1. Cloudflare edge connects to nginx `:443` and sets `CF-Connecting-IP`.
-2. `cloudflare-realip.conf`: the peer IP is in Cloudflare's published
-   ranges, so the realip module rewrites `$remote_addr` to the header's
-   value (the end user). Non-Cloudflare peers keep their socket IP and the
-   header is ignored — unspoofable.
+1. The Cloudflare edge terminates TLS and hands the request to this host's
+   `cloudflared` connector, which proxies it to nginx `:80` with
+   `CF-Connecting-IP` set to the end user's IP.
+2. `cloudflare-realip.conf`: the peer is the cloudflared container on the
+   pinned compose subnet (`172.28.0.0/16`), so the realip module rewrites
+   `$remote_addr` to the header's value. Unspoofable because the gateway
+   publishes no host ports — that subnet is the only possible traffic
+   source, and everything on it is ours.
 3. The shared `/api/` proxy block sends
    `X-Forwarded-For: $remote_addr` — **replace, not append** — a single
    trusted value.
 4. The Go rate limiter (`src/packages/api/ratelimit.go` `clientIP()`) takes
    the rightmost `X-Forwarded-For` entry → the real user IP.
-
-When Cloudflare publishes new ranges, refresh `cloudflare-realip.conf`
-from <https://www.cloudflare.com/ips/> and reload the gateway.
 
 ## Deploy / rollback
 
@@ -86,9 +101,14 @@ both images to GHCR (`:latest` and `:<sha>`) and the CI `deploy` job
 rsyncs this directory to `/opt/goldentempo/` and restarts the stack with
 `IMAGE_TAG=<sha>`. It also writes the live tag to
 `/opt/goldentempo/.image_tag` so manual restarts don't fall back to
-`:latest`. (Until the `DEPLOY_HOST` / `DEPLOY_SSH_KEY` /
-`DEPLOY_KNOWN_HOSTS` secrets exist, the deploy job self-skips with a
-notice.)
+`:latest`. CI reaches the Pi through the tunnel's SSH hostname via
+`cloudflared access ssh` + an Access service token. (Until the
+`DEPLOY_HOST` / `DEPLOY_SSH_KEY` / `DEPLOY_KNOWN_HOSTS` /
+`CF_ACCESS_CLIENT_ID` / `CF_ACCESS_CLIENT_SECRET` secrets exist, the
+deploy job self-skips with a notice. `DEPLOY_HOST` is the SSH hostname —
+`ssh.goldentempotravel.com` — and `DEPLOY_KNOWN_HOSTS` entries must use
+that same name: on the Pi,
+`for f in /etc/ssh/ssh_host_*_key.pub; do awk '{print "ssh.goldentempotravel.com", $1, $2}' "$f"; done`.)
 
 **Rollback** = re-deploy an older image: GitHub → Actions → CI →
 *Run workflow* on `main` with `image_tag` set to the git SHA of a previous

--- a/dockerize/production/docker-compose.yml
+++ b/dockerize/production/docker-compose.yml
@@ -1,14 +1,19 @@
 # Production stack for https://goldentempotravel.com — same topology as
 # dockerize/deployment/docker-compose.yml, but runs prebuilt images from
-# GHCR (no build:) and terminates TLS on the gateway (:80 + :443) behind
-# Cloudflare. All nginx config and certs are volume-mounted, never baked,
-# so a config change is `docker compose up -d --force-recreate gateway`,
-# not an image rebuild.
+# GHCR (no build:) and reaches the internet exclusively through a
+# Cloudflare Tunnel (the cloudflared service below dials OUT to Cloudflare;
+# nothing here publishes a host port, and the host needs no inbound
+# firewall openings at all). TLS terminates at the Cloudflare edge; the
+# tunnel leg is encrypted by cloudflared itself, so the gateway serves
+# plain :80 on the private compose network only. All nginx config is
+# volume-mounted, never baked, so a config change is
+# `docker compose up -d --force-recreate gateway`, not an image rebuild.
 #
-# Runs from /opt/goldentempo/ on the VPS with a .env file next to it
-# (copy .env.sample in this directory and fill it in). Compose reads that
-# same .env automatically for ${...} interpolation, so POSTGRES_PASSWORD /
-# IMAGE_TAG below and the api's env_file all come from one file.
+# Runs from /opt/goldentempo/ on the production host with a .env file next
+# to it (copy .env.sample in this directory and fill it in). Compose reads
+# that same .env automatically for ${...} interpolation, so
+# POSTGRES_PASSWORD / IMAGE_TAG / TUNNEL_TOKEN below and the api's
+# env_file all come from one file.
 services:
   chrome:
     image: chromedp/headless-shell:latest
@@ -90,28 +95,41 @@ services:
 
   gateway:
     image: ghcr.io/bdowe/goldentempo-gateway:${IMAGE_TAG:-latest}
-    ports:
-      - "80:80"
-      - "443:443"
+    # No ports: on purpose — the only way in is the cloudflared service on
+    # the private compose network. Publishing 80/443 here would bypass the
+    # tunnel AND the real-IP trust model in nginx/cloudflare-realip.conf.
     volumes:
       # prod.conf replaces the baked-in :80 localhost server; the shared
       # location snippet + $share_prerender map stay from the image.
       - ./nginx/prod.conf:/etc/nginx/conf.d/default.conf:ro
       - ./nginx/cloudflare-realip.conf:/etc/nginx/conf.d/cloudflare-realip.conf:ro
-      # Cloudflare Origin CA cert + key (origin.crt / origin.key).
-      - /etc/goldentempo/certs:/etc/goldentempo/certs:ro
     depends_on:
       - api
     healthcheck:
-      # :80 is a wholesale 301 to https://goldentempotravel.com, so probe :443
-      # directly; the apex server is default_server, so "localhost" lands
-      # there. --no-check-certificate: the Origin CA cert isn't in the
-      # container's trust store (it's only trusted by Cloudflare).
-      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "--no-check-certificate", "https://localhost/health"]
+      # The apex server is default_server on :80, so "localhost" lands there.
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost/health"]
       interval: 30s
       timeout: 10s
       retries: 3
       start_period: 10s
+    restart: unless-stopped
+    networks:
+      - travel-planner-network
+
+  # Outbound-only connector to the Cloudflare edge. The tunnel's public
+  # hostnames (configured in the Zero Trust dashboard) route
+  # goldentempotravel.com → http://gateway:80 and ssh.goldentempotravel.com →
+  # ssh://172.28.0.1:22 (the host, via the pinned bridge gateway address;
+  # ufw must allow 22 from 172.28.0.0/16) for CI deploys. cloudflared sets
+  # CF-Connecting-IP
+  # on every proxied request, which nginx/cloudflare-realip.conf restores as
+  # the client address — see that file for why the compose subnet below is
+  # the trusted range.
+  cloudflared:
+    image: cloudflare/cloudflared:latest
+    command: tunnel --no-autoupdate run --token ${TUNNEL_TOKEN:?TUNNEL_TOKEN must be set}
+    depends_on:
+      - gateway
     restart: unless-stopped
     networks:
       - travel-planner-network
@@ -122,3 +140,9 @@ volumes:
 networks:
   travel-planner-network:
     driver: bridge
+    # Pinned so nginx/cloudflare-realip.conf can trust exactly this range
+    # (the cloudflared container is the only possible client of gateway:80).
+    # Change the subnet there if you change it here.
+    ipam:
+      config:
+        - subnet: 172.28.0.0/16

--- a/dockerize/production/nginx/cloudflare-realip.conf
+++ b/dockerize/production/nginx/cloudflare-realip.conf
@@ -1,41 +1,24 @@
-# Restore the real client IP behind Cloudflare (http scope; mounted into
-# /etc/nginx/conf.d/ by dockerize/production/docker-compose.yml).
+# Restore the real client IP behind the Cloudflare Tunnel (http scope;
+# mounted into /etc/nginx/conf.d/ by dockerize/production/docker-compose.yml).
 #
-# For connections whose peer address is inside one of the trusted ranges
-# below, nginx rewrites $remote_addr to the value of CF-Connecting-IP (the
-# header Cloudflare sets to the end user's IP). Connections from anywhere
-# else keep their socket peer address and the header is ignored — so a
-# direct (non-Cloudflare) client cannot spoof its identity by sending
-# CF-Connecting-IP itself.
+# With a tunnel origin, requests do NOT arrive from Cloudflare's public
+# ranges — they arrive from the cloudflared container on the private
+# compose network (pinned to the subnet below in docker-compose.yml).
+# cloudflared forwards the edge's CF-Connecting-IP header (the end user's
+# IP), which the realip module rewrites into $remote_addr for peers inside
+# the trusted range.
+#
+# This stays unspoofable because the gateway publishes no host ports: the
+# compose subnet is the ONLY possible source of traffic, and everything on
+# it (cloudflared, api, postgres, chrome) is ours. The in-container health
+# check connects from localhost — outside the range — so it keeps its
+# socket address and sends no CF-Connecting-IP anyway.
 #
 # The shared /api/ proxy block (snippets/app-locations.conf) then forwards
 # X-Forwarded-For: $remote_addr — a single trusted value — which is exactly
 # what the Go rate limiter's clientIP() reads (rightmost XFF entry).
-
-# Cloudflare IPv4 ranges — refresh from https://www.cloudflare.com/ips/
-set_real_ip_from 173.245.48.0/20;
-set_real_ip_from 103.21.244.0/22;
-set_real_ip_from 103.22.200.0/22;
-set_real_ip_from 103.31.4.0/22;
-set_real_ip_from 141.101.64.0/18;
-set_real_ip_from 108.162.192.0/18;
-set_real_ip_from 190.93.240.0/20;
-set_real_ip_from 188.114.96.0/20;
-set_real_ip_from 197.234.240.0/22;
-set_real_ip_from 198.41.128.0/17;
-set_real_ip_from 162.158.0.0/15;
-set_real_ip_from 104.16.0.0/13;
-set_real_ip_from 104.24.0.0/14;
-set_real_ip_from 172.64.0.0/13;
-set_real_ip_from 131.0.72.0/22;
-
-# Cloudflare IPv6 ranges — refresh from https://www.cloudflare.com/ips/
-set_real_ip_from 2400:cb00::/32;
-set_real_ip_from 2606:4700::/32;
-set_real_ip_from 2803:f800::/32;
-set_real_ip_from 2405:b500::/32;
-set_real_ip_from 2405:8100::/32;
-set_real_ip_from 2a06:98c0::/29;
-set_real_ip_from 2c0f:f248::/32;
+#
+# Must match networks.travel-planner-network.ipam in docker-compose.yml.
+set_real_ip_from 172.28.0.0/16;
 
 real_ip_header CF-Connecting-IP;

--- a/dockerize/production/nginx/prod.conf
+++ b/dockerize/production/nginx/prod.conf
@@ -1,6 +1,7 @@
-# Production gateway for https://goldentempotravel.com — TLS termination behind
-# Cloudflare (proxied DNS, SSL mode "Full (strict)", Cloudflare Origin CA
-# certificate on the origin).
+# Production gateway for https://goldentempotravel.com — Cloudflare Tunnel
+# origin. TLS terminates at the Cloudflare edge; the only client of this
+# server is the cloudflared container on the private compose network (the
+# gateway publishes no host ports), so it listens on plain :80.
 #
 # This file is volume-mounted over /etc/nginx/conf.d/default.conf by
 # dockerize/production/docker-compose.yml (config is mounted, never baked).
@@ -9,45 +10,28 @@
 # gateway image by dockerize/deployment/Dockerfile and remain in place;
 # cloudflare-realip.conf is mounted alongside this file to restore the real
 # client IP from CF-Connecting-IP before any of this runs.
+#
+# http→https is enforced at the edge (Cloudflare "Always Use HTTPS"), so no
+# :80 redirect server is needed here — by the time a request reaches this
+# origin it was already served over TLS to the user.
 
-# Plain HTTP → canonical HTTPS. Cloudflare in Full (strict) mode always dials
-# the origin on :443; this catches direct hits and misconfigured edges.
-server {
-    listen 80;
-    listen [::]:80;
-    server_name goldentempotravel.com www.goldentempotravel.com;
-    return 301 https://goldentempotravel.com$request_uri;
-}
-
-# Canonical apex. default_server so requests without a matching SNI/Host —
-# notably the in-container health check against https://localhost/health —
+# Canonical apex. default_server so requests without a matching Host —
+# notably the in-container health check against http://localhost/health —
 # land here instead of falling into the www redirect below.
 server {
-    listen 443 ssl default_server;
-    listen [::]:443 ssl default_server;
-    http2 on;
+    listen 80 default_server;
+    listen [::]:80 default_server;
     server_name goldentempotravel.com;
-
-    ssl_certificate     /etc/goldentempo/certs/origin.crt;
-    ssl_certificate_key /etc/goldentempo/certs/origin.key;
-    ssl_protocols       TLSv1.2 TLSv1.3;
-    ssl_session_cache   shared:SSL:10m;
-    ssl_session_timeout 1d;
 
     include /etc/nginx/snippets/app-locations.conf;
 }
 
-# www → apex 301 (the Origin CA cert covers goldentempotravel.com and
-# *.goldentempotravel.com, so terminating www here is fine).
+# www → apex 301 (the tunnel routes both hostnames here; the edge cert
+# covers www, so redirecting at the origin is fine).
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
-    http2 on;
+    listen 80;
+    listen [::]:80;
     server_name www.goldentempotravel.com;
-
-    ssl_certificate     /etc/goldentempo/certs/origin.crt;
-    ssl_certificate_key /etc/goldentempo/certs/origin.key;
-    ssl_protocols       TLSv1.2 TLSv1.3;
 
     return 301 https://goldentempotravel.com$request_uri;
 }


### PR DESCRIPTION
## Summary
- Add a `cloudflared` service to the production compose — the stack's only path to the internet is an outbound tunnel connection (no published ports, no port forwarding, home IP never exposed).
- Gateway drops `ports:` and the origin-cert mounts; `prod.conf` becomes plain `:80` apex + www→apex servers (TLS terminates at the Cloudflare edge, http→https via Always Use HTTPS).
- **Real-IP correctness:** `cloudflare-realip.conf` now trusts the pinned compose subnet (`172.28.0.0/16`) instead of Cloudflare's public ranges — tunnel traffic arrives from the local cloudflared container, and with no published ports that subnet is the only possible peer, so `CF-Connecting-IP` stays unspoofable and the Go rate limiter keeps seeing end-user IPs.
- Deploy job SSHes through the tunnel: `cloudflared access ssh` ProxyCommand + Cloudflare Access service token; the self-skip gate now also requires `CF_ACCESS_CLIENT_ID`/`CF_ACCESS_CLIENT_SECRET`. rsync + SHA-pinned `.image_tag` + workflow_dispatch rollback unchanged.
- Production README rewritten for the tunnel topology (public hostnames table, ufw note, known_hosts recipe); `.env.sample` documents `TUNNEL_TOKEN`.

## Testing
- `docker compose config` validates with a scratch `.env` (fail-fast on missing `TUNNEL_TOKEN` confirmed by the `:?` interpolation).
- `nginx -t` green inside `nginx:alpine` with the new prod.conf + realip conf and the baked-in snippets/map mounted (api aliased to loopback).
- Workflow YAML parses; the heredoc-generated `~/.ssh/config` renders correctly (verified by dumping the step script).
- End-to-end exercise happens at first deploy: tunnel-driven CI deploy + `make smoke BASE_URL=https://goldentempotravel.com`, plus the two-network 429 check to prove real-IP restoration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)