### PR TITLE
feat(api): in-process request metrics + admin ops-metrics endpoint (Observability PR1)

### DIFF
--- a/src/packages/api/main.go
+++ b/src/packages/api/main.go
@@ -678,6 +678,10 @@ func buildRouter() *mux.Router {
 	anonEvents := rateLimitMiddleware(anonEventsLimiter)
 	router.Use(requestIDMiddleware)
 	router.Use(recoveryMiddleware)
+	// metricsMiddleware sits right after recovery so it times the full handler
+	// (recovered panics count as the 500 they return) and folds each request
+	// into the in-process opsMetrics registry (ops_metrics.go).
+	router.Use(metricsMiddleware)
 	router.Use(corsMiddleware)
 	router.Use(bodyLimitMiddleware)
 	router.Use(func(next http.Handler) http.Handler {
@@ -866,6 +870,9 @@ func buildRouter() *mux.Router {
 	api.Handle("/admin/metrics/totals", admin(adminTotalsHandler)).Methods("GET")
 	api.Handle("/admin/metrics/activity", admin(adminActivityHandler)).Methods("GET")
 	api.Handle("/admin/metrics/users", admin(adminUsersHandler)).Methods("GET")
+	// Live in-process request/latency/error + runtime rollup (ops_metrics.go).
+	// No dbPool guard — it must render in degraded mode; admin auth only.
+	api.Handle("/admin/ops/metrics", admin(opsMetricsHandler)).Methods("GET")
 
 	// Public browse endpoints for published local-sourced content.
 	api.HandleFunc("/local/recommendations", localRecommendationsHandler).Methods("GET")

--- a/src/packages/api/ops_handler.go
+++ b/src/packages/api/ops_handler.go
@@ -1,0 +1,15 @@
+package main
+
+import "net/http"
+
+// opsMetricsHandler is GET /api/v1/admin/ops/metrics: the live in-process
+// request/latency/error rollup plus runtime process stats (ops_metrics.go).
+//
+// Unlike the /admin/metrics family, this endpoint has NO dbPool guard: process
+// and request stats live entirely in memory, so they must render even in
+// degraded mode (dbPool == nil) — that is precisely when operators need
+// visibility. Admin auth is still enforced at route registration (authMiddleware
+// does require the DB, which is the right trade: no session store, no admin).
+func opsMetricsHandler(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, http.StatusOK, opsMetrics.snapshot())
+}

--- a/src/packages/api/ops_metrics.go
+++ b/src/packages/api/ops_metrics.go
@@ -1,0 +1,326 @@
+package main
+
+import (
+	"math"
+	"net/http"
+	"runtime"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/gorilla/mux"
+)
+
+// In-process request-metrics registry. Per-request latency/status are already
+// LOGGED (the slog "request" line in requestIDMiddleware) but never aggregated;
+// this layer keeps a concurrent-safe rollup in memory so the admin ops endpoint
+// can render live latency/error/throughput without a DB round trip.
+//
+// PROCESS-LIFETIME, like the upstreamCallCounters in places_service.go: every
+// counter starts at zero on boot and resets on restart/deploy. Nothing here is
+// persisted and there is no migration — this is operational telemetry, not
+// audited analytics. The registry is read-only for the DB layer: the ops
+// endpoint must render even in degraded mode (dbPool == nil), which is exactly
+// when process visibility matters most.
+
+// processStart is captured once at package init so the ops endpoint can report
+// uptime. The server has no other single start-time var to reuse.
+var processStart = time.Now()
+
+// opsBucketBoundsMs are the fixed upper edges (inclusive) of the latency
+// histogram, in milliseconds. A request of X ms lands in the first bucket whose
+// bound is >= X; anything over the last bound lands in the implicit +Inf
+// overflow bucket. Fixed buckets keep record() allocation-free and make
+// percentiles a cheap cumulative walk. Keep this in sync with opsBucketCount.
+var opsBucketBoundsMs = [...]float64{5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000}
+
+// opsBucketCount is len(opsBucketBoundsMs)+1 — the finite buckets plus the
+// +Inf overflow bucket. A const so routeStat can hold a fixed array.
+const opsBucketCount = len(opsBucketBoundsMs) + 1
+
+// bucketIndex returns the histogram bucket for a latency in ms: 0..len-1 for
+// the finite buckets, len (the overflow +Inf bucket) for anything larger.
+func bucketIndex(ms float64) int {
+	for i, b := range opsBucketBoundsMs {
+		if ms <= b {
+			return i
+		}
+	}
+	return len(opsBucketBoundsMs)
+}
+
+// routeStat is the rollup for one (method, route-template) pair. A single small
+// mutex guards the whole struct; the critical section is a handful of adds, so
+// contention is negligible even under load and the read side gets a consistent
+// snapshot.
+type routeStat struct {
+	mu       sync.Mutex
+	method   string
+	template string
+	count    uint64
+	// byClass is indexed by HTTP status class (status/100): [1]=1xx .. [5]=5xx.
+	// Index 0 is unused. 4xx/5xx are what error_rate keys off.
+	byClass  [6]uint64
+	sumMs    float64 // sum of latencies for the mean
+	buckets  [opsBucketCount]uint64
+	lastSeen int64 // unix millis of the most recent request
+}
+
+func (s *routeStat) record(status int, dur time.Duration) {
+	ms := float64(dur.Nanoseconds()) / 1e6
+	class := status / 100
+	if class < 1 {
+		class = 1
+	}
+	if class > 5 {
+		class = 5
+	}
+	s.mu.Lock()
+	s.count++
+	s.byClass[class]++
+	s.sumMs += ms
+	s.buckets[bucketIndex(ms)]++
+	s.lastSeen = time.Now().UnixMilli()
+	s.mu.Unlock()
+}
+
+// opsRegistry is the package-global registry keyed by "METHOD template".
+type opsRegistry struct {
+	mu     sync.RWMutex
+	routes map[string]*routeStat
+}
+
+// opsMetrics is the process-global request-metrics registry.
+var opsMetrics = &opsRegistry{routes: make(map[string]*routeStat)}
+
+// record folds one completed request into the registry. The common case (route
+// already seen) takes only the read lock plus the per-route lock; the write
+// lock is held just long enough to create a new route's stat once.
+func (o *opsRegistry) record(method, template string, status int, dur time.Duration) {
+	key := method + " " + template
+	o.mu.RLock()
+	s := o.routes[key]
+	o.mu.RUnlock()
+	if s == nil {
+		o.mu.Lock()
+		if s = o.routes[key]; s == nil {
+			s = &routeStat{method: method, template: template}
+			o.routes[key] = s
+		}
+		o.mu.Unlock()
+	}
+	s.record(status, dur)
+}
+
+// classLabel maps a status class (1..5) to its "Nxx" label.
+func classLabel(class int) string {
+	switch class {
+	case 1:
+		return "1xx"
+	case 2:
+		return "2xx"
+	case 3:
+		return "3xx"
+	case 4:
+		return "4xx"
+	case 5:
+		return "5xx"
+	}
+	return "other"
+}
+
+// percentileMs returns the pth-percentile latency (0<p<=1) from a histogram
+// bucket snapshot, as the upper edge of the bucket the pth observation falls
+// in. Overflow (+Inf) observations report the largest finite bound. Precision
+// is bucket-granular by design.
+func percentileMs(buckets *[opsBucketCount]uint64, count uint64, p float64) float64 {
+	if count == 0 {
+		return 0
+	}
+	target := uint64(math.Ceil(p * float64(count)))
+	if target == 0 {
+		target = 1
+	}
+	var cum uint64
+	for i, c := range buckets {
+		cum += c
+		if cum >= target {
+			if i < len(opsBucketBoundsMs) {
+				return opsBucketBoundsMs[i]
+			}
+			return opsBucketBoundsMs[len(opsBucketBoundsMs)-1]
+		}
+	}
+	return opsBucketBoundsMs[len(opsBucketBoundsMs)-1]
+}
+
+// ---- JSON view types (tags are the wire contract) ----
+
+// OpsMetricsResponse is the body of GET /admin/ops/metrics.
+type OpsMetricsResponse struct {
+	Process  ProcessStats     `json:"process"`
+	Requests RequestMetrics   `json:"requests"`
+	Upstream map[string]int64 `json:"upstream"`
+}
+
+// ProcessStats is the live runtime snapshot (goroutines, heap, GOMAXPROCS,
+// uptime). Reset on restart like everything else here.
+type ProcessStats struct {
+	UptimeS       int64  `json:"uptime_s"`
+	Goroutines    int    `json:"goroutines"`
+	MemAllocBytes uint64 `json:"mem_alloc_bytes"`
+	MemSysBytes   uint64 `json:"mem_sys_bytes"`
+	GOMAXPROCS    int    `json:"gomaxprocs"`
+	StartedAt     string `json:"started_at"`
+}
+
+// RequestMetrics is the aggregate + per-route request rollup.
+type RequestMetrics struct {
+	Total   uint64            `json:"total"`
+	ByClass map[string]uint64 `json:"by_class"`
+	Routes  []RouteMetric     `json:"routes"`
+}
+
+// RouteMetric is one (method, route-template) row.
+type RouteMetric struct {
+	Route     string            `json:"route"`
+	Method    string            `json:"method"`
+	Count     uint64            `json:"count"`
+	ByClass   map[string]uint64 `json:"by_class"`
+	ErrorRate float64           `json:"error_rate"`
+	P50Ms     float64           `json:"p50_ms"`
+	P95Ms     float64           `json:"p95_ms"`
+	P99Ms     float64           `json:"p99_ms"`
+	MeanMs    float64           `json:"mean_ms"`
+	LastSeen  string            `json:"last_seen"`
+}
+
+// snapshot builds the JSON view. It copies each route's state under that
+// route's lock so the walk never races with live record() calls, then computes
+// derived fields (percentiles, error rate, mean) outside the locks.
+func (o *opsRegistry) snapshot() OpsMetricsResponse {
+	o.mu.RLock()
+	stats := make([]*routeStat, 0, len(o.routes))
+	for _, s := range o.routes {
+		stats = append(stats, s)
+	}
+	o.mu.RUnlock()
+
+	routes := make([]RouteMetric, 0, len(stats))
+	var total uint64
+	overall := map[string]uint64{}
+	for _, s := range stats {
+		s.mu.Lock()
+		count := s.count
+		byClass := s.byClass
+		sumMs := s.sumMs
+		buckets := s.buckets
+		lastSeen := s.lastSeen
+		method := s.method
+		template := s.template
+		s.mu.Unlock()
+
+		if count == 0 {
+			continue
+		}
+		rm := RouteMetric{
+			Route:   template,
+			Method:  method,
+			Count:   count,
+			ByClass: map[string]uint64{},
+			P50Ms:   percentileMs(&buckets, count, 0.50),
+			P95Ms:   percentileMs(&buckets, count, 0.95),
+			P99Ms:   percentileMs(&buckets, count, 0.99),
+			MeanMs:  sumMs / float64(count),
+		}
+		for class := 1; class <= 5; class++ {
+			if n := byClass[class]; n > 0 {
+				label := classLabel(class)
+				rm.ByClass[label] = n
+				overall[label] += n
+			}
+		}
+		rm.ErrorRate = float64(byClass[4]+byClass[5]) / float64(count)
+		if lastSeen > 0 {
+			rm.LastSeen = time.UnixMilli(lastSeen).UTC().Format(time.RFC3339)
+		}
+		total += count
+		routes = append(routes, rm)
+	}
+
+	// Stable output: most-trafficked routes first, ties broken by name.
+	sort.Slice(routes, func(i, j int) bool {
+		if routes[i].Count != routes[j].Count {
+			return routes[i].Count > routes[j].Count
+		}
+		if routes[i].Method != routes[j].Method {
+			return routes[i].Method < routes[j].Method
+		}
+		return routes[i].Route < routes[j].Route
+	})
+
+	var mem runtime.MemStats
+	runtime.ReadMemStats(&mem)
+	return OpsMetricsResponse{
+		Process: ProcessStats{
+			UptimeS:       int64(time.Since(processStart).Seconds()),
+			Goroutines:    runtime.NumGoroutine(),
+			MemAllocBytes: mem.Alloc,
+			MemSysBytes:   mem.Sys,
+			GOMAXPROCS:    runtime.GOMAXPROCS(0),
+			StartedAt:     processStart.UTC().Format(time.RFC3339),
+		},
+		Requests: RequestMetrics{
+			Total:   total,
+			ByClass: overall,
+			Routes:  routes,
+		},
+		Upstream: upstreamCountsSnapshot(),
+	}
+}
+
+// upstreamCountsSnapshot flattens the existing process-lifetime provider
+// counters (places_service.go / events_service.go) into a flat map for the ops
+// view. Read-only: it never mutates the counters, which stay owned by their
+// services and are also surfaced (priced) by adminMetricsHandler.
+func upstreamCountsSnapshot() map[string]int64 {
+	m := map[string]int64{}
+	if placesService != nil {
+		for name, c := range map[string]*upstreamCallCounters{
+			"places_search":       &placesService.searchCalls,
+			"places_autocomplete": &placesService.autocompleteCalls,
+			"places_details":      &placesService.detailsCalls,
+		} {
+			m[name+"_upstream"] = c.upstream.Load()
+			m[name+"_cache_hits"] = c.cacheHits.Load()
+		}
+	}
+	if eventsService != nil {
+		m["events_upstream"] = eventsService.calls.upstream.Load()
+		m["events_cache_hits"] = eventsService.calls.cacheHits.Load()
+	}
+	return m
+}
+
+// metricsMiddleware times each request and folds its (method, route-template,
+// status, latency) into opsMetrics. It reuses statusRecorder (middleware.go) so
+// the status code is captured and http.Flusher is preserved for SSE. The route
+// template — not the concrete path — is the key, so per-id routes like
+// /trips/{id} collapse to one row instead of exploding cardinality; an
+// unmatched route (no template) is grouped under "other".
+func metricsMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rec := &statusRecorder{ResponseWriter: w, status: http.StatusOK}
+		start := time.Now()
+		next.ServeHTTP(rec, r)
+		dur := time.Since(start)
+
+		template := "other"
+		if route := mux.CurrentRoute(r); route != nil {
+			if t, err := route.GetPathTemplate(); err == nil && t != "" {
+				template = t
+			}
+		}
+		opsMetrics.record(r.Method, template, rec.status, dur)
+	})
+}

--- a/src/packages/api/ops_metrics_test.go
+++ b/src/packages/api/ops_metrics_test.go
@@ -1,0 +1,274 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gorilla/mux"
+)
+
+// newOpsRegistry builds an isolated registry so tests never race on the
+// package-global opsMetrics (which the shared testRouter mutates on every
+// request). record/snapshot are methods on *opsRegistry, so a fresh one gets
+// the same behavior without cross-test contamination.
+func newOpsRegistry() *opsRegistry {
+	return &opsRegistry{routes: make(map[string]*routeStat)}
+}
+
+// TestOpsRegistryConcurrentRecord hammers record from many goroutines and
+// asserts the total count is exact. Run under -race, this proves the registry
+// is data-race free and loses no increments.
+func TestOpsRegistryConcurrentRecord(t *testing.T) {
+	reg := newOpsRegistry()
+	const goroutines = 50
+	const perG = 200
+
+	var wg sync.WaitGroup
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+			for i := 0; i < perG; i++ {
+				// Two templates so we also exercise concurrent creation of a
+				// route's stat under the write lock.
+				tmpl := "/api/v1/a"
+				if i%2 == 0 {
+					tmpl = "/api/v1/b"
+				}
+				reg.record("GET", tmpl, 200, time.Millisecond)
+			}
+		}(g)
+	}
+	wg.Wait()
+
+	snap := reg.snapshot()
+	want := uint64(goroutines * perG)
+	if snap.Requests.Total != want {
+		t.Fatalf("total = %d, want %d", snap.Requests.Total, want)
+	}
+	if snap.Requests.ByClass["2xx"] != want {
+		t.Fatalf("2xx = %d, want %d", snap.Requests.ByClass["2xx"], want)
+	}
+	var routeSum uint64
+	for _, r := range snap.Requests.Routes {
+		routeSum += r.Count
+	}
+	if routeSum != want {
+		t.Fatalf("route count sum = %d, want %d", routeSum, want)
+	}
+}
+
+// TestOpsPercentiles feeds a known latency distribution and asserts p50/p95/p99
+// land in the right histogram buckets (bucket-granular, so we assert the
+// reported upper edge). 100 requests: 90 fast (~1ms → bucket 5), 9 mid (~120ms
+// → bucket 250), 1 slow (~3000ms → bucket 5000).
+func TestOpsPercentiles(t *testing.T) {
+	reg := newOpsRegistry()
+	for i := 0; i < 90; i++ {
+		reg.record("GET", "/x", 200, 1*time.Millisecond)
+	}
+	for i := 0; i < 9; i++ {
+		reg.record("GET", "/x", 200, 120*time.Millisecond)
+	}
+	reg.record("GET", "/x", 200, 3000*time.Millisecond)
+
+	snap := reg.snapshot()
+	if len(snap.Requests.Routes) != 1 {
+		t.Fatalf("routes = %d, want 1", len(snap.Requests.Routes))
+	}
+	r := snap.Requests.Routes[0]
+	// p50 sits among the 90 fast requests → 5ms bucket.
+	if r.P50Ms != 5 {
+		t.Errorf("p50 = %v, want 5 (fast bucket)", r.P50Ms)
+	}
+	// p95 is the 95th observation: past the 90 fast into the mid group → 250ms.
+	if r.P95Ms != 250 {
+		t.Errorf("p95 = %v, want 250 (mid bucket)", r.P95Ms)
+	}
+	// p99 is the 99th observation: still the last mid request → 250ms.
+	if r.P99Ms != 250 {
+		t.Errorf("p99 = %v, want 250 (mid bucket)", r.P99Ms)
+	}
+	// Mean is dominated by the single 3s outlier: (90*1 + 9*120 + 3000)/100.
+	wantMean := float64(90*1+9*120+3000) / 100.0
+	if r.MeanMs < wantMean-0.5 || r.MeanMs > wantMean+0.5 {
+		t.Errorf("mean = %v, want ~%v", r.MeanMs, wantMean)
+	}
+}
+
+// TestOpsTemplateGrouping asserts two requests to the SAME template but
+// different concrete ids collapse into one route row with count 2.
+func TestOpsTemplateGrouping(t *testing.T) {
+	reg := newOpsRegistry()
+	reg.record("GET", "/api/v1/trips/{id}", 200, time.Millisecond)
+	reg.record("GET", "/api/v1/trips/{id}", 200, time.Millisecond)
+
+	snap := reg.snapshot()
+	if len(snap.Requests.Routes) != 1 {
+		t.Fatalf("routes = %d, want 1 (templates must collapse)", len(snap.Requests.Routes))
+	}
+	r := snap.Requests.Routes[0]
+	if r.Route != "/api/v1/trips/{id}" || r.Count != 2 {
+		t.Fatalf("route = %q count = %d, want /api/v1/trips/{id} count 2", r.Route, r.Count)
+	}
+}
+
+// TestOpsErrorRate feeds a mix of 2xx and 5xx and asserts the class buckets and
+// error_rate. 4xx and 5xx both count toward errors.
+func TestOpsErrorRate(t *testing.T) {
+	reg := newOpsRegistry()
+	for i := 0; i < 7; i++ {
+		reg.record("GET", "/y", 200, time.Millisecond)
+	}
+	reg.record("GET", "/y", 404, time.Millisecond)
+	reg.record("GET", "/y", 500, time.Millisecond)
+	reg.record("GET", "/y", 503, time.Millisecond)
+
+	snap := reg.snapshot()
+	r := snap.Requests.Routes[0]
+	if r.ByClass["2xx"] != 7 || r.ByClass["4xx"] != 1 || r.ByClass["5xx"] != 2 {
+		t.Fatalf("by_class = %v, want 2xx:7 4xx:1 5xx:2", r.ByClass)
+	}
+	// (1 + 2) / 10 = 0.3
+	if r.ErrorRate < 0.29 || r.ErrorRate > 0.31 {
+		t.Errorf("error_rate = %v, want ~0.3", r.ErrorRate)
+	}
+}
+
+// TestMetricsMiddlewareRecords drives the middleware over a tiny mux with a
+// handler that 500s, and asserts the 5xx class + error_rate land in the shared
+// opsMetrics registry under the matched route template.
+func TestMetricsMiddlewareRecords(t *testing.T) {
+	// Isolate from other tests by swapping the package global for the duration.
+	saved := opsMetrics
+	opsMetrics = newOpsRegistry()
+	defer func() { opsMetrics = saved }()
+
+	router := mux.NewRouter()
+	router.Use(metricsMiddleware)
+	router.HandleFunc("/things/{id}", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}).Methods("GET")
+
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, httptest.NewRequest("GET", "/things/42", nil))
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500", rec.Code)
+	}
+
+	snap := opsMetrics.snapshot()
+	if snap.Requests.Total != 1 {
+		t.Fatalf("total = %d, want 1", snap.Requests.Total)
+	}
+	r := snap.Requests.Routes[0]
+	if r.Route != "/things/{id}" {
+		t.Errorf("route = %q, want /things/{id} (template, not concrete id)", r.Route)
+	}
+	if r.ByClass["5xx"] != 1 {
+		t.Errorf("5xx = %d, want 1", r.ByClass["5xx"])
+	}
+	if r.ErrorRate != 1 {
+		t.Errorf("error_rate = %v, want 1", r.ErrorRate)
+	}
+}
+
+// TestMetricsMiddlewareNoRouteGroupsAsOther asserts a request the router never
+// matched (no mux route on the context) records under "other".
+func TestMetricsMiddlewareNoRouteGroupsAsOther(t *testing.T) {
+	saved := opsMetrics
+	opsMetrics = newOpsRegistry()
+	defer func() { opsMetrics = saved }()
+
+	// Wrap the middleware directly (not via a mux) so CurrentRoute(r) is nil.
+	h := metricsMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest("GET", "/whatever", nil))
+
+	snap := opsMetrics.snapshot()
+	if len(snap.Requests.Routes) != 1 || snap.Requests.Routes[0].Route != "other" {
+		t.Fatalf("routes = %v, want a single 'other' row", snap.Requests.Routes)
+	}
+	if snap.Requests.Routes[0].ByClass["4xx"] != 1 {
+		t.Errorf("4xx = %d, want 1", snap.Requests.Routes[0].ByClass["4xx"])
+	}
+}
+
+// TestOpsProcessStats asserts the process section is populated (uptime,
+// goroutines, GOMAXPROCS, started_at) — the part that must render even without
+// a DB.
+func TestOpsProcessStats(t *testing.T) {
+	snap := newOpsRegistry().snapshot()
+	if snap.Process.Goroutines < 1 {
+		t.Errorf("goroutines = %d, want >= 1", snap.Process.Goroutines)
+	}
+	if snap.Process.GOMAXPROCS < 1 {
+		t.Errorf("gomaxprocs = %d, want >= 1", snap.Process.GOMAXPROCS)
+	}
+	if snap.Process.StartedAt == "" {
+		t.Errorf("started_at empty, want a timestamp")
+	}
+	if snap.Process.UptimeS < 0 {
+		t.Errorf("uptime = %d, want >= 0", snap.Process.UptimeS)
+	}
+	if snap.Upstream == nil {
+		t.Errorf("upstream map is nil, want present (possibly empty)")
+	}
+}
+
+// TestOpsMetricsEndpoint is the DB-backed admin auth path: an admin token gets
+// 200 + the expected shape; a non-admin gets 403.
+func TestOpsMetricsEndpoint(t *testing.T) {
+	resetDB(t)
+	admin, adminToken := createTestUser(t, "ops-admin@example.com")
+	makeAdmin(t, admin.ID)
+	_, userToken := createTestUser(t, "ops-user@example.com")
+
+	// Non-admin is forbidden.
+	if rec := doJSON(t, "GET", "/api/v1/admin/ops/metrics", userToken, nil); rec.Code != http.StatusForbidden {
+		t.Fatalf("non-admin = %d, want 403", rec.Code)
+	}
+	// Anonymous is unauthorized.
+	if rec := doJSON(t, "GET", "/api/v1/admin/ops/metrics", "", nil); rec.Code != http.StatusUnauthorized {
+		t.Fatalf("anonymous = %d, want 401", rec.Code)
+	}
+
+	rec := doJSON(t, "GET", "/api/v1/admin/ops/metrics", adminToken, nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("admin = %d: %s", rec.Code, rec.Body.String())
+	}
+	body := decode(t, rec)
+	proc, ok := body["process"].(map[string]any)
+	if !ok {
+		t.Fatalf("process missing: %v", body["process"])
+	}
+	if _, ok := proc["goroutines"].(float64); !ok {
+		t.Errorf("process.goroutines missing/not a number: %v", proc["goroutines"])
+	}
+	if _, ok := proc["started_at"].(string); !ok {
+		t.Errorf("process.started_at missing: %v", proc["started_at"])
+	}
+	reqs, ok := body["requests"].(map[string]any)
+	if !ok {
+		t.Fatalf("requests missing: %v", body["requests"])
+	}
+	// This very request flows through metricsMiddleware, so the endpoint's own
+	// route template must already be counted.
+	routes, _ := reqs["routes"].([]any)
+	foundSelf := false
+	for _, ri := range routes {
+		if r, ok := ri.(map[string]any); ok && r["route"] == "/api/v1/admin/ops/metrics" {
+			foundSelf = true
+		}
+	}
+	if !foundSelf {
+		t.Errorf("routes does not include the ops endpoint's own template; got %v", routes)
+	}
+	if _, ok := body["upstream"].(map[string]any); !ok {
+		t.Errorf("upstream missing: %v", body["upstream"])
+	}
+}


### PR DESCRIPTION
## Observability PR1 — live request metrics

Foundation for the **Observability wave** (see & protect the live Pi). Per-request latency/status were already logged but never aggregated — this adds a concurrent-safe in-process metrics registry and an admin endpoint to read it. **In-process only — resets on restart, no DB dependency, no migration.**

### What landed
- **`ops_metrics.go`** — `opsMetrics` registry (`RWMutex` over `map[method+template]*routeStat`). Per route: count, status-class breakdown (2xx/3xx/4xx/5xx), a fixed-bucket latency histogram → p50/p95/p99, mean, last-seen. Keyed on `mux.CurrentRoute(r).GetPathTemplate()` so `/trips/{id}` doesn't explode by id (no match → `"other"`). Process stats: uptime, goroutines, `MemStats` alloc/sys, GOMAXPROCS. Folds in the existing upstream provider counters (read-only).
- **`metricsMiddleware`** — reuses the existing `statusRecorder`; wired into the global chain right after `recoveryMiddleware`.
- **`ops_handler.go`** — `GET /api/v1/admin/ops/metrics` (admin-gated; **no dbPool guard** so it renders in degraded mode by design).
- **`ops_metrics_test.go`** — 8 tests: concurrency under `-race`, percentile bucketing, template grouping, 5xx/error-rate, no-route→`other`, process stats, admin gate (200/403/401).

`gofmt`/`go vet` clean; `go test ./... -race` passes.

PR2 extends `ops_handler.go` with the dependency-health endpoint; PR3 adds the Flutter dashboard tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)