### PR TITLE
feat(flutter): admin System Health dashboard tab (Observability PR3)

### DIFF
--- a/src/packages/flutter-app/lib/models/ops_health.dart
+++ b/src/packages/flutter-app/lib/models/ops_health.dart
@@ -1,0 +1,98 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'ops_health.g.dart';
+
+/// Dependency + build + backup health from GET /admin/ops/health — an
+/// admin-only snapshot powering the System Health dashboard tab. snake_case
+/// JSON keys via [FieldRename.snake].
+
+/// Database reachability. [status] is one of "ok" | "unreachable" |
+/// "not_configured".
+@JsonSerializable(fieldRename: FieldRename.snake)
+class HealthDb {
+  final String status;
+  final int pingMs;
+
+  const HealthDb({this.status = 'not_configured', this.pingMs = 0});
+
+  factory HealthDb.fromJson(Map<String, dynamic> json) =>
+      _$HealthDbFromJson(json);
+  Map<String, dynamic> toJson() => _$HealthDbToJson(this);
+}
+
+/// A single upstream provider and whether its credentials are configured.
+@JsonSerializable(fieldRename: FieldRename.snake)
+class ProviderStat {
+  final String name;
+  final bool configured;
+  final String note;
+
+  const ProviderStat({
+    this.name = '',
+    this.configured = false,
+    this.note = '',
+  });
+
+  factory ProviderStat.fromJson(Map<String, dynamic> json) =>
+      _$ProviderStatFromJson(json);
+  Map<String, dynamic> toJson() => _$ProviderStatToJson(this);
+}
+
+/// Build identity + process uptime.
+@JsonSerializable(fieldRename: FieldRename.snake)
+class BuildInfo {
+  final String release;
+  final String goVersion;
+  final DateTime? startedAt;
+  final int uptimeS;
+
+  const BuildInfo({
+    this.release = '',
+    this.goVersion = '',
+    this.startedAt,
+    this.uptimeS = 0,
+  });
+
+  factory BuildInfo.fromJson(Map<String, dynamic> json) =>
+      _$BuildInfoFromJson(json);
+  Map<String, dynamic> toJson() => _$BuildInfoToJson(this);
+}
+
+/// Backup freshness. [lastSuccessAt]/[ageS] are null when no backup has been
+/// recorded yet; [stale] flags an over-age backup.
+@JsonSerializable(fieldRename: FieldRename.snake)
+class BackupInfo {
+  final String? lastSuccessAt;
+  final int? ageS;
+  final bool stale;
+
+  const BackupInfo({this.lastSuccessAt, this.ageS, this.stale = false});
+
+  factory BackupInfo.fromJson(Map<String, dynamic> json) =>
+      _$BackupInfoFromJson(json);
+  Map<String, dynamic> toJson() => _$BackupInfoToJson(this);
+}
+
+/// Mirror of GET /admin/ops/health.
+@JsonSerializable(fieldRename: FieldRename.snake)
+class OpsHealth {
+  final HealthDb db;
+  final List<ProviderStat> providers;
+  final BuildInfo build;
+  final BackupInfo backups;
+  final bool degraded;
+  final List<String> reasons;
+
+  const OpsHealth({
+    this.db = const HealthDb(),
+    this.providers = const [],
+    this.build = const BuildInfo(),
+    this.backups = const BackupInfo(),
+    this.degraded = false,
+    this.reasons = const [],
+  });
+
+  factory OpsHealth.fromJson(Map<String, dynamic> json) =>
+      _$OpsHealthFromJson(json);
+  Map<String, dynamic> toJson() => _$OpsHealthToJson(this);
+}

--- a/src/packages/flutter-app/lib/models/ops_health.g.dart
+++ b/src/packages/flutter-app/lib/models/ops_health.g.dart
@@ -1,0 +1,89 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'ops_health.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+HealthDb _$HealthDbFromJson(Map<String, dynamic> json) => HealthDb(
+      status: json['status'] as String? ?? 'not_configured',
+      pingMs: (json['ping_ms'] as num?)?.toInt() ?? 0,
+    );
+
+Map<String, dynamic> _$HealthDbToJson(HealthDb instance) => <String, dynamic>{
+      'status': instance.status,
+      'ping_ms': instance.pingMs,
+    };
+
+ProviderStat _$ProviderStatFromJson(Map<String, dynamic> json) => ProviderStat(
+      name: json['name'] as String? ?? '',
+      configured: json['configured'] as bool? ?? false,
+      note: json['note'] as String? ?? '',
+    );
+
+Map<String, dynamic> _$ProviderStatToJson(ProviderStat instance) =>
+    <String, dynamic>{
+      'name': instance.name,
+      'configured': instance.configured,
+      'note': instance.note,
+    };
+
+BuildInfo _$BuildInfoFromJson(Map<String, dynamic> json) => BuildInfo(
+      release: json['release'] as String? ?? '',
+      goVersion: json['go_version'] as String? ?? '',
+      startedAt: json['started_at'] == null
+          ? null
+          : DateTime.parse(json['started_at'] as String),
+      uptimeS: (json['uptime_s'] as num?)?.toInt() ?? 0,
+    );
+
+Map<String, dynamic> _$BuildInfoToJson(BuildInfo instance) => <String, dynamic>{
+      'release': instance.release,
+      'go_version': instance.goVersion,
+      'started_at': instance.startedAt?.toIso8601String(),
+      'uptime_s': instance.uptimeS,
+    };
+
+BackupInfo _$BackupInfoFromJson(Map<String, dynamic> json) => BackupInfo(
+      lastSuccessAt: json['last_success_at'] as String?,
+      ageS: (json['age_s'] as num?)?.toInt(),
+      stale: json['stale'] as bool? ?? false,
+    );
+
+Map<String, dynamic> _$BackupInfoToJson(BackupInfo instance) =>
+    <String, dynamic>{
+      'last_success_at': instance.lastSuccessAt,
+      'age_s': instance.ageS,
+      'stale': instance.stale,
+    };
+
+OpsHealth _$OpsHealthFromJson(Map<String, dynamic> json) => OpsHealth(
+      db: json['db'] == null
+          ? const HealthDb()
+          : HealthDb.fromJson(json['db'] as Map<String, dynamic>),
+      providers: (json['providers'] as List<dynamic>?)
+              ?.map((e) => ProviderStat.fromJson(e as Map<String, dynamic>))
+              .toList() ??
+          const [],
+      build: json['build'] == null
+          ? const BuildInfo()
+          : BuildInfo.fromJson(json['build'] as Map<String, dynamic>),
+      backups: json['backups'] == null
+          ? const BackupInfo()
+          : BackupInfo.fromJson(json['backups'] as Map<String, dynamic>),
+      degraded: json['degraded'] as bool? ?? false,
+      reasons: (json['reasons'] as List<dynamic>?)
+              ?.map((e) => e as String)
+              .toList() ??
+          const [],
+    );
+
+Map<String, dynamic> _$OpsHealthToJson(OpsHealth instance) => <String, dynamic>{
+      'db': instance.db,
+      'providers': instance.providers,
+      'build': instance.build,
+      'backups': instance.backups,
+      'degraded': instance.degraded,
+      'reasons': instance.reasons,
+    };

--- a/src/packages/flutter-app/lib/models/ops_metrics.dart
+++ b/src/packages/flutter-app/lib/models/ops_metrics.dart
@@ -1,0 +1,126 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'ops_metrics.g.dart';
+
+/// Live process + request metrics from GET /admin/ops/metrics — an admin-only,
+/// instantaneous snapshot (not windowed like /admin/metrics). Powers the
+/// System Health dashboard tab. snake_case JSON keys via [FieldRename.snake].
+
+/// Runtime stats for the API process.
+@JsonSerializable(fieldRename: FieldRename.snake)
+class ProcessStats {
+  final int uptimeS;
+  final int goroutines;
+  final int memAllocBytes;
+  final int memSysBytes;
+  final int gomaxprocs;
+  final DateTime? startedAt;
+
+  const ProcessStats({
+    this.uptimeS = 0,
+    this.goroutines = 0,
+    this.memAllocBytes = 0,
+    this.memSysBytes = 0,
+    this.gomaxprocs = 0,
+    this.startedAt,
+  });
+
+  factory ProcessStats.fromJson(Map<String, dynamic> json) =>
+      _$ProcessStatsFromJson(json);
+  Map<String, dynamic> toJson() => _$ProcessStatsToJson(this);
+}
+
+/// Per-route request counters + latency percentiles.
+@JsonSerializable(fieldRename: FieldRename.snake)
+class RouteMetric {
+  final String route;
+  final String method;
+  final int count;
+
+  /// Response-class counts keyed "2xx" / "3xx" / "4xx" / "5xx".
+  final Map<String, int> byClass;
+  final double errorRate;
+  final double p50Ms;
+  final double p95Ms;
+  final double p99Ms;
+  final double meanMs;
+  final DateTime? lastSeen;
+
+  const RouteMetric({
+    this.route = '',
+    this.method = '',
+    this.count = 0,
+    this.byClass = const {},
+    this.errorRate = 0,
+    this.p50Ms = 0,
+    this.p95Ms = 0,
+    this.p99Ms = 0,
+    this.meanMs = 0,
+    this.lastSeen,
+  });
+
+  factory RouteMetric.fromJson(Map<String, dynamic> json) =>
+      _$RouteMetricFromJson(json);
+  Map<String, dynamic> toJson() => _$RouteMetricToJson(this);
+}
+
+/// Aggregate request counters plus the per-route breakdown.
+@JsonSerializable(fieldRename: FieldRename.snake)
+class RequestMetrics {
+  final int total;
+
+  /// Response-class totals keyed "2xx" / "3xx" / "4xx" / "5xx".
+  final Map<String, int> byClass;
+  final List<RouteMetric> routes;
+
+  const RequestMetrics({
+    this.total = 0,
+    this.byClass = const {},
+    this.routes = const [],
+  });
+
+  /// 4xx + 5xx as a fraction of [total] (0 when no requests seen).
+  double get errorRate {
+    if (total == 0) return 0;
+    final errors = (byClass['4xx'] ?? 0) + (byClass['5xx'] ?? 0);
+    return errors / total;
+  }
+
+  factory RequestMetrics.fromJson(Map<String, dynamic> json) =>
+      _$RequestMetricsFromJson(json);
+  Map<String, dynamic> toJson() => _$RequestMetricsToJson(this);
+}
+
+/// Upstream provider call/cache counters (process-lifetime).
+@JsonSerializable(fieldRename: FieldRename.snake)
+class UpstreamStats {
+  final int placesUpstreamCalls;
+  final int placesCacheHits;
+
+  const UpstreamStats({
+    this.placesUpstreamCalls = 0,
+    this.placesCacheHits = 0,
+  });
+
+  factory UpstreamStats.fromJson(Map<String, dynamic> json) =>
+      _$UpstreamStatsFromJson(json);
+  Map<String, dynamic> toJson() => _$UpstreamStatsToJson(this);
+}
+
+/// Mirror of GET /admin/ops/metrics.
+@JsonSerializable(fieldRename: FieldRename.snake)
+class OpsMetrics {
+  final ProcessStats process;
+  final RequestMetrics requests;
+  final UpstreamStats upstream;
+
+  const OpsMetrics({
+    this.process = const ProcessStats(),
+    this.requests = const RequestMetrics(),
+    this.upstream = const UpstreamStats(),
+  });
+
+  factory OpsMetrics.fromJson(Map<String, dynamic> json) =>
+      _$OpsMetricsFromJson(json);
+  Map<String, dynamic> toJson() => _$OpsMetricsToJson(this);
+}

--- a/src/packages/flutter-app/lib/models/ops_metrics.g.dart
+++ b/src/packages/flutter-app/lib/models/ops_metrics.g.dart
@@ -1,0 +1,112 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'ops_metrics.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+ProcessStats _$ProcessStatsFromJson(Map<String, dynamic> json) => ProcessStats(
+      uptimeS: (json['uptime_s'] as num?)?.toInt() ?? 0,
+      goroutines: (json['goroutines'] as num?)?.toInt() ?? 0,
+      memAllocBytes: (json['mem_alloc_bytes'] as num?)?.toInt() ?? 0,
+      memSysBytes: (json['mem_sys_bytes'] as num?)?.toInt() ?? 0,
+      gomaxprocs: (json['gomaxprocs'] as num?)?.toInt() ?? 0,
+      startedAt: json['started_at'] == null
+          ? null
+          : DateTime.parse(json['started_at'] as String),
+    );
+
+Map<String, dynamic> _$ProcessStatsToJson(ProcessStats instance) =>
+    <String, dynamic>{
+      'uptime_s': instance.uptimeS,
+      'goroutines': instance.goroutines,
+      'mem_alloc_bytes': instance.memAllocBytes,
+      'mem_sys_bytes': instance.memSysBytes,
+      'gomaxprocs': instance.gomaxprocs,
+      'started_at': instance.startedAt?.toIso8601String(),
+    };
+
+RouteMetric _$RouteMetricFromJson(Map<String, dynamic> json) => RouteMetric(
+      route: json['route'] as String? ?? '',
+      method: json['method'] as String? ?? '',
+      count: (json['count'] as num?)?.toInt() ?? 0,
+      byClass: (json['by_class'] as Map<String, dynamic>?)?.map(
+            (k, e) => MapEntry(k, (e as num).toInt()),
+          ) ??
+          const {},
+      errorRate: (json['error_rate'] as num?)?.toDouble() ?? 0,
+      p50Ms: (json['p50_ms'] as num?)?.toDouble() ?? 0,
+      p95Ms: (json['p95_ms'] as num?)?.toDouble() ?? 0,
+      p99Ms: (json['p99_ms'] as num?)?.toDouble() ?? 0,
+      meanMs: (json['mean_ms'] as num?)?.toDouble() ?? 0,
+      lastSeen: json['last_seen'] == null
+          ? null
+          : DateTime.parse(json['last_seen'] as String),
+    );
+
+Map<String, dynamic> _$RouteMetricToJson(RouteMetric instance) =>
+    <String, dynamic>{
+      'route': instance.route,
+      'method': instance.method,
+      'count': instance.count,
+      'by_class': instance.byClass,
+      'error_rate': instance.errorRate,
+      'p50_ms': instance.p50Ms,
+      'p95_ms': instance.p95Ms,
+      'p99_ms': instance.p99Ms,
+      'mean_ms': instance.meanMs,
+      'last_seen': instance.lastSeen?.toIso8601String(),
+    };
+
+RequestMetrics _$RequestMetricsFromJson(Map<String, dynamic> json) =>
+    RequestMetrics(
+      total: (json['total'] as num?)?.toInt() ?? 0,
+      byClass: (json['by_class'] as Map<String, dynamic>?)?.map(
+            (k, e) => MapEntry(k, (e as num).toInt()),
+          ) ??
+          const {},
+      routes: (json['routes'] as List<dynamic>?)
+              ?.map((e) => RouteMetric.fromJson(e as Map<String, dynamic>))
+              .toList() ??
+          const [],
+    );
+
+Map<String, dynamic> _$RequestMetricsToJson(RequestMetrics instance) =>
+    <String, dynamic>{
+      'total': instance.total,
+      'by_class': instance.byClass,
+      'routes': instance.routes,
+    };
+
+UpstreamStats _$UpstreamStatsFromJson(Map<String, dynamic> json) =>
+    UpstreamStats(
+      placesUpstreamCalls:
+          (json['places_upstream_calls'] as num?)?.toInt() ?? 0,
+      placesCacheHits: (json['places_cache_hits'] as num?)?.toInt() ?? 0,
+    );
+
+Map<String, dynamic> _$UpstreamStatsToJson(UpstreamStats instance) =>
+    <String, dynamic>{
+      'places_upstream_calls': instance.placesUpstreamCalls,
+      'places_cache_hits': instance.placesCacheHits,
+    };
+
+OpsMetrics _$OpsMetricsFromJson(Map<String, dynamic> json) => OpsMetrics(
+      process: json['process'] == null
+          ? const ProcessStats()
+          : ProcessStats.fromJson(json['process'] as Map<String, dynamic>),
+      requests: json['requests'] == null
+          ? const RequestMetrics()
+          : RequestMetrics.fromJson(json['requests'] as Map<String, dynamic>),
+      upstream: json['upstream'] == null
+          ? const UpstreamStats()
+          : UpstreamStats.fromJson(json['upstream'] as Map<String, dynamic>),
+    );
+
+Map<String, dynamic> _$OpsMetricsToJson(OpsMetrics instance) =>
+    <String, dynamic>{
+      'process': instance.process,
+      'requests': instance.requests,
+      'upstream': instance.upstream,
+    };

--- a/src/packages/flutter-app/lib/providers/ops_admin_provider.dart
+++ b/src/packages/flutter-app/lib/providers/ops_admin_provider.dart
@@ -1,0 +1,21 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../models/ops_health.dart';
+import '../models/ops_metrics.dart';
+import '../services/ops_admin_api_service.dart';
+import 'api_client_provider.dart';
+
+final opsAdminApiServiceProvider = Provider<OpsAdminApiService>((ref) {
+  return OpsAdminApiService(ref.watch(apiClientProvider));
+});
+
+/// Live process + request metrics. Instantaneous — the Health pane invalidates
+/// it on a timer to auto-refresh.
+final opsMetricsProvider = FutureProvider<OpsMetrics>((ref) async {
+  return ref.watch(opsAdminApiServiceProvider).getOpsMetrics();
+});
+
+/// Dependency + build + backup health. Auto-refreshed alongside
+/// [opsMetricsProvider].
+final opsHealthProvider = FutureProvider<OpsHealth>((ref) async {
+  return ref.watch(opsAdminApiServiceProvider).getOpsHealth();
+});

--- a/src/packages/flutter-app/lib/screens/admin_metrics_screen.dart
+++ b/src/packages/flutter-app/lib/screens/admin_metrics_screen.dart
@@ -6,6 +6,7 @@ import '../providers/admin_metrics_provider.dart';
 import '../theme/spacing.dart';
 import '../widgets/daily_count_chart.dart';
 import '../widgets/empty_state.dart';
+import '../widgets/health_pane.dart';
 import '../widgets/page_container.dart';
 import '../widgets/section_header.dart';
 import '../widgets/status_pill.dart';
@@ -32,16 +33,18 @@ class _AdminMetricsScreenState extends ConsumerState<AdminMetricsScreen> {
   @override
   Widget build(BuildContext context) {
     return DefaultTabController(
-      length: 4,
+      length: 5,
       child: Scaffold(
         appBar: AppBar(
           title: const Text('Metrics'),
           bottom: const TabBar(
+            isScrollable: true,
             tabs: [
               Tab(text: 'Overview'),
               Tab(text: 'Trends'),
               Tab(text: 'Activity'),
               Tab(text: 'Users'),
+              Tab(text: 'Health'),
             ],
           ),
         ),
@@ -57,6 +60,7 @@ class _AdminMetricsScreenState extends ConsumerState<AdminMetricsScreen> {
             ),
             const _ActivityPane(),
             const _UsersPane(),
+            const HealthPane(),
           ],
         ),
       ),

--- a/src/packages/flutter-app/lib/services/ops_admin_api_service.dart
+++ b/src/packages/flutter-app/lib/services/ops_admin_api_service.dart
@@ -1,0 +1,30 @@
+import 'dart:convert';
+import '../models/ops_health.dart';
+import '../models/ops_metrics.dart';
+import 'api_client.dart';
+
+/// GET /admin/ops/metrics and /admin/ops/health — live process/request metrics
+/// and dependency/backup health for the System Health dashboard tab. Both
+/// require an admin bearer token (enforced server-side by adminMiddleware).
+class OpsAdminApiService {
+  final ApiClient apiClient;
+
+  OpsAdminApiService(this.apiClient);
+
+  Future<T> _get<T>(String pathAndQuery, T Function(dynamic) parse) async {
+    final res = await apiClient.httpClient.get(
+      Uri.parse('${apiClient.baseUrl}$pathAndQuery'),
+      headers: apiClient.jsonHeaders(),
+    );
+    if (res.statusCode == 200) {
+      return parse(jsonDecode(res.body));
+    }
+    throw Exception('Failed to load $pathAndQuery (${res.statusCode})');
+  }
+
+  Future<OpsMetrics> getOpsMetrics() =>
+      _get('/admin/ops/metrics', (json) => OpsMetrics.fromJson(json));
+
+  Future<OpsHealth> getOpsHealth() =>
+      _get('/admin/ops/health', (json) => OpsHealth.fromJson(json));
+}

--- a/src/packages/flutter-app/lib/widgets/health_pane.dart
+++ b/src/packages/flutter-app/lib/widgets/health_pane.dart
@@ -1,0 +1,523 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../models/ops_health.dart';
+import '../models/ops_metrics.dart';
+import '../providers/ops_admin_provider.dart';
+import '../theme/spacing.dart';
+import 'empty_state.dart';
+import 'page_container.dart';
+import 'section_header.dart';
+import 'status_pill.dart';
+
+/// The "Health" tab of the admin dashboard: a live snapshot of the API
+/// process, request mix, dependency health, and backup freshness. Auto-refreshes
+/// every 10s (paused while the app is backgrounded) and supports pull-to-refresh.
+class HealthPane extends ConsumerStatefulWidget {
+  const HealthPane({super.key});
+
+  @override
+  ConsumerState<HealthPane> createState() => _HealthPaneState();
+}
+
+class _HealthPaneState extends ConsumerState<HealthPane>
+    with AutomaticKeepAliveClientMixin, WidgetsBindingObserver {
+  static const _refreshInterval = Duration(seconds: 10);
+  Timer? _timer;
+
+  @override
+  bool get wantKeepAlive => true;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+    _startTimer();
+  }
+
+  @override
+  void dispose() {
+    _timer?.cancel();
+    _timer = null;
+    WidgetsBinding.instance.removeObserver(this);
+    super.dispose();
+  }
+
+  void _startTimer() {
+    _timer?.cancel();
+    _timer = Timer.periodic(_refreshInterval, (_) => _refresh());
+  }
+
+  void _refresh() {
+    if (!mounted) return;
+    ref.invalidate(opsMetricsProvider);
+    ref.invalidate(opsHealthProvider);
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    // Pause polling in the background; resume (and refresh once) on return.
+    if (state == AppLifecycleState.resumed) {
+      _startTimer();
+      _refresh();
+    } else {
+      _timer?.cancel();
+      _timer = null;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    super.build(context);
+    final metrics = ref.watch(opsMetricsProvider);
+    final health = ref.watch(opsHealthProvider);
+
+    return PageContainer(
+      child: RefreshIndicator(
+        onRefresh: () async {
+          ref.invalidate(opsMetricsProvider);
+          ref.invalidate(opsHealthProvider);
+          await Future.wait([
+            ref.read(opsMetricsProvider.future),
+            ref.read(opsHealthProvider.future),
+          ]);
+        },
+        child: ListView(
+          physics: const AlwaysScrollableScrollPhysics(),
+          padding: const EdgeInsets.all(AppSpacing.lg),
+          children: [
+            metrics.when(
+              loading: () => const Padding(
+                padding: EdgeInsets.all(AppSpacing.xl),
+                child: Center(child: CircularProgressIndicator()),
+              ),
+              error: (e, _) => EmptyState(
+                icon: Icons.cloud_off,
+                title: 'Could not load metrics',
+                message: '$e',
+                actions: [
+                  FilledButton(
+                    onPressed: () => ref.invalidate(opsMetricsProvider),
+                    child: const Text('Retry'),
+                  ),
+                ],
+              ),
+              data: (m) => _MetricsSection(metrics: m),
+            ),
+            const SizedBox(height: AppSpacing.xl),
+            health.when(
+              loading: () => const Padding(
+                padding: EdgeInsets.all(AppSpacing.xl),
+                child: Center(child: CircularProgressIndicator()),
+              ),
+              error: (e, _) => EmptyState(
+                icon: Icons.cloud_off,
+                title: 'Could not load health',
+                message: '$e',
+                actions: [
+                  FilledButton(
+                    onPressed: () => ref.invalidate(opsHealthProvider),
+                    child: const Text('Retry'),
+                  ),
+                ],
+              ),
+              data: (h) => _HealthSection(health: h),
+            ),
+            const SizedBox(height: AppSpacing.xxl),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// --- KPI tiles ---------------------------------------------------------------
+
+/// Uptime + request-mix headline tiles.
+class _MetricsSection extends StatelessWidget {
+  final OpsMetrics metrics;
+  const _MetricsSection({required this.metrics});
+
+  @override
+  Widget build(BuildContext context) {
+    final m = metrics;
+    final errRate = m.requests.errorRate;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const SectionHeader(title: 'Process'),
+        const SizedBox(height: AppSpacing.sm),
+        _TileGrid(tiles: [
+          _Stat('Uptime', _formatUptime(m.process.uptimeS)),
+          _Stat('Requests', _compact(m.requests.total),
+              caption: _classCaption(m.requests.byClass)),
+          _Stat('Error rate', '${(errRate * 100).toStringAsFixed(1)}%',
+              severity: _errSeverity(errRate)),
+          _Stat('Goroutines', '${m.process.goroutines}',
+              caption: 'GOMAXPROCS ${m.process.gomaxprocs}'),
+          _Stat('Memory', '${_mb(m.process.memAllocBytes)} MB',
+              caption: '${_mb(m.process.memSysBytes)} MB sys'),
+          if (m.upstream.placesUpstreamCalls > 0 ||
+              m.upstream.placesCacheHits > 0)
+            _Stat('Places calls', '${m.upstream.placesUpstreamCalls}',
+                caption: '${m.upstream.placesCacheHits} cache hits'),
+        ]),
+        if (m.requests.routes.isNotEmpty) ...[
+          const SizedBox(height: AppSpacing.xl),
+          const SectionHeader(title: 'Routes'),
+          const SizedBox(height: AppSpacing.sm),
+          _RouteTable(routes: m.requests.routes),
+        ],
+      ],
+    );
+  }
+
+  static String _classCaption(Map<String, int> byClass) {
+    final ok = byClass['2xx'] ?? 0;
+    final c4 = byClass['4xx'] ?? 0;
+    final c5 = byClass['5xx'] ?? 0;
+    return '$ok 2xx · $c4 4xx · $c5 5xx';
+  }
+
+  static String? _errSeverity(double rate) {
+    if (rate >= 0.05) return 'critical';
+    if (rate >= 0.02) return 'warn';
+    return null;
+  }
+}
+
+/// Top routes by count. Horizontally scrollable so wide rows never overflow.
+class _RouteTable extends StatelessWidget {
+  final List<RouteMetric> routes;
+  const _RouteTable({required this.routes});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final sorted = [...routes]..sort((a, b) => b.count.compareTo(a.count));
+    final top = sorted.take(12).toList();
+
+    return SingleChildScrollView(
+      scrollDirection: Axis.horizontal,
+      child: DataTable(
+        columnSpacing: AppSpacing.xl,
+        headingRowHeight: 36,
+        dataRowMinHeight: 36,
+        dataRowMaxHeight: 44,
+        columns: const [
+          DataColumn(label: Text('Route')),
+          DataColumn(label: Text('Method')),
+          DataColumn(label: Text('Count'), numeric: true),
+          DataColumn(label: Text('Error %'), numeric: true),
+          DataColumn(label: Text('p95 ms'), numeric: true),
+        ],
+        rows: [
+          for (final r in top)
+            DataRow(cells: [
+              DataCell(ConstrainedBox(
+                constraints: const BoxConstraints(maxWidth: 260),
+                child: Text(r.route, overflow: TextOverflow.ellipsis),
+              )),
+              DataCell(Text(r.method)),
+              DataCell(Text('${r.count}')),
+              DataCell(Text(
+                '${(r.errorRate * 100).toStringAsFixed(1)}%',
+                style: r.errorRate >= 0.05
+                    ? TextStyle(color: theme.colorScheme.error)
+                    : null,
+              )),
+              DataCell(Text(r.p95Ms.toStringAsFixed(0))),
+            ]),
+        ],
+      ),
+    );
+  }
+}
+
+// --- Dependencies + backups --------------------------------------------------
+
+class _HealthSection extends StatelessWidget {
+  final OpsHealth health;
+  const _HealthSection({required this.health});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final h = health;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        if (h.degraded) ...[
+          _DegradedBanner(reasons: h.reasons),
+          const SizedBox(height: AppSpacing.lg),
+        ],
+        const SectionHeader(title: 'Dependencies'),
+        const SizedBox(height: AppSpacing.sm),
+        _DependencyRow(
+          label: 'Database',
+          detail: h.db.status == 'ok' ? '${h.db.pingMs} ms ping' : null,
+          pill: _dbPill(theme, h.db),
+        ),
+        for (final p in h.providers)
+          _DependencyRow(
+            label: _humanize(p.name),
+            detail: p.note.isEmpty ? null : p.note,
+            pill: p.configured
+                ? _pill(theme, 'configured', 'ok')
+                : _pill(theme, 'not configured', 'warn'),
+          ),
+        const SizedBox(height: AppSpacing.xl),
+        const SectionHeader(title: 'Backups'),
+        const SizedBox(height: AppSpacing.sm),
+        _DependencyRow(
+          label: 'Last backup',
+          detail: h.backups.ageS != null
+              ? '${_humanizeAge(h.backups.ageS!)} ago'
+              : 'no backup recorded',
+          pill: _backupPill(theme, h.backups),
+        ),
+        if (h.build.release.isNotEmpty || h.build.goVersion.isNotEmpty) ...[
+          const SizedBox(height: AppSpacing.xl),
+          const SectionHeader(title: 'Build'),
+          const SizedBox(height: AppSpacing.sm),
+          Text(
+            [
+              if (h.build.release.isNotEmpty) 'release ${h.build.release}',
+              if (h.build.goVersion.isNotEmpty) h.build.goVersion,
+            ].join(' · '),
+            style: theme.textTheme.bodyMedium?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+          ),
+        ],
+      ],
+    );
+  }
+
+  static Widget _dbPill(ThemeData theme, HealthDb db) {
+    switch (db.status) {
+      case 'ok':
+        return _pill(theme, 'ok', 'ok');
+      case 'unreachable':
+        return _pill(theme, 'unreachable', 'critical');
+      default:
+        return _pill(theme, 'not configured', 'warn');
+    }
+  }
+
+  static Widget _backupPill(ThemeData theme, BackupInfo b) {
+    if (b.ageS == null) return _pill(theme, 'unknown', 'warn');
+    if (b.stale) return _pill(theme, 'stale', 'critical');
+    return _pill(theme, 'fresh', 'ok');
+  }
+}
+
+class _DegradedBanner extends StatelessWidget {
+  final List<String> reasons;
+  const _DegradedBanner({required this.reasons});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(AppSpacing.lg),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.errorContainer,
+        borderRadius: AppRadius.mdAll,
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Icon(Icons.warning_amber_rounded,
+                  size: 20, color: theme.colorScheme.onErrorContainer),
+              const SizedBox(width: AppSpacing.sm),
+              Text(
+                'System degraded',
+                style: theme.textTheme.titleSmall?.copyWith(
+                  color: theme.colorScheme.onErrorContainer,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+            ],
+          ),
+          if (reasons.isNotEmpty) ...[
+            const SizedBox(height: AppSpacing.xs),
+            for (final r in reasons)
+              Text(
+                '• $r',
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.onErrorContainer,
+                ),
+              ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class _DependencyRow extends StatelessWidget {
+  final String label;
+  final String? detail;
+  final Widget pill;
+  const _DependencyRow({required this.label, this.detail, required this.pill});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: AppSpacing.xs),
+      child: Row(
+        children: [
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(label, style: theme.textTheme.bodyMedium),
+                if (detail != null)
+                  Text(
+                    detail!,
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: theme.colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+              ],
+            ),
+          ),
+          const SizedBox(width: AppSpacing.sm),
+          pill,
+        ],
+      ),
+    );
+  }
+}
+
+// --- Shared helpers ----------------------------------------------------------
+
+/// Severity → pill. ok=green, warn=amber, critical=red (mirrors the Trip
+/// Health severity palette).
+StatusPill _pill(ThemeData theme, String label, String severity) {
+  final (bg, fg) = _severityColors(theme, severity);
+  return StatusPill.custom(label: label, background: bg, foreground: fg);
+}
+
+(Color, Color) _severityColors(ThemeData theme, String severity) {
+  switch (severity) {
+    case 'critical':
+      return (theme.colorScheme.errorContainer, theme.colorScheme.onErrorContainer);
+    case 'warn':
+      return (Colors.amber.withValues(alpha: 0.20), Colors.amber.shade900);
+    case 'ok':
+      return (Colors.green.withValues(alpha: 0.15), Colors.green.shade800);
+    default:
+      return (
+        theme.colorScheme.surfaceContainerHighest,
+        theme.colorScheme.onSurfaceVariant,
+      );
+  }
+}
+
+String _formatUptime(int seconds) {
+  if (seconds <= 0) return '0s';
+  final d = seconds ~/ 86400;
+  final h = (seconds % 86400) ~/ 3600;
+  final m = (seconds % 3600) ~/ 60;
+  if (d > 0) return '${d}d ${h}h';
+  if (h > 0) return '${h}h ${m}m';
+  if (m > 0) return '${m}m';
+  return '${seconds}s';
+}
+
+/// Seconds → coarse "3d" / "4h" / "5m" / "30s" for the backup age line.
+String _humanizeAge(int seconds) {
+  if (seconds >= 86400) return '${seconds ~/ 86400}d';
+  if (seconds >= 3600) return '${seconds ~/ 3600}h';
+  if (seconds >= 60) return '${seconds ~/ 60}m';
+  return '${seconds}s';
+}
+
+String _compact(int v) {
+  if (v >= 1000000) return '${(v / 1000000).toStringAsFixed(1)}M';
+  if (v >= 1000) return '${(v / 1000).toStringAsFixed(1)}k';
+  return '$v';
+}
+
+String _mb(int bytes) => (bytes / (1024 * 1024)).toStringAsFixed(1);
+
+/// "google_places" → "Google places".
+String _humanize(String name) {
+  final s = name.replaceAll('_', ' ');
+  return s.isEmpty ? s : '${s[0].toUpperCase()}${s.substring(1)}';
+}
+
+// --- Tile primitives (mirrors admin_metrics_screen's _Stat/_TileGrid) --------
+
+class _Stat {
+  final String label;
+  final String value;
+  final String? caption;
+
+  /// Optional severity that tints the value (warn=amber, critical=red).
+  final String? severity;
+  const _Stat(this.label, this.value, {this.caption, this.severity});
+}
+
+class _TileGrid extends StatelessWidget {
+  final List<_Stat> tiles;
+  const _TileGrid({required this.tiles});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Wrap(
+      spacing: AppSpacing.md,
+      runSpacing: AppSpacing.md,
+      children: [
+        for (final t in tiles)
+          Container(
+            constraints: const BoxConstraints(minWidth: 140),
+            padding: const EdgeInsets.all(AppSpacing.lg),
+            decoration: BoxDecoration(
+              color: theme.colorScheme.surfaceContainerLow,
+              borderRadius: AppRadius.mdAll,
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  t.label,
+                  style: theme.textTheme.labelMedium?.copyWith(
+                    color: theme.colorScheme.onSurfaceVariant,
+                  ),
+                ),
+                const SizedBox(height: AppSpacing.xs),
+                Text(
+                  t.value,
+                  style: theme.textTheme.headlineSmall?.copyWith(
+                    fontWeight: FontWeight.w700,
+                    color: t.severity == 'critical'
+                        ? theme.colorScheme.error
+                        : t.severity == 'warn'
+                            ? Colors.amber.shade900
+                            : null,
+                  ),
+                ),
+                if (t.caption != null)
+                  Text(
+                    t.caption!,
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: theme.colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+              ],
+            ),
+          ),
+      ],
+    );
+  }
+}

--- a/src/packages/flutter-app/test/health_pane_test.dart
+++ b/src/packages/flutter-app/test/health_pane_test.dart
@@ -1,0 +1,179 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:travel_route_planner/models/ops_health.dart';
+import 'package:travel_route_planner/models/ops_metrics.dart';
+import 'package:travel_route_planner/providers/ops_admin_provider.dart';
+import 'package:travel_route_planner/widgets/health_pane.dart';
+
+const _metrics = OpsMetrics(
+  process: ProcessStats(
+    uptimeS: 273600, // 3d 4h
+    goroutines: 42,
+    memAllocBytes: 12 * 1024 * 1024, // 12.0 MB
+    memSysBytes: 30 * 1024 * 1024,
+    gomaxprocs: 4,
+  ),
+  requests: RequestMetrics(
+    total: 1000,
+    byClass: {'2xx': 900, '3xx': 10, '4xx': 80, '5xx': 10},
+    routes: [
+      RouteMetric(
+        route: '/api/v1/trips/{id}',
+        method: 'GET',
+        count: 120,
+        byClass: {'2xx': 110, '4xx': 10},
+        errorRate: 0.083,
+        p50Ms: 12,
+        p95Ms: 85,
+        p99Ms: 210,
+        meanMs: 22.5,
+      ),
+    ],
+  ),
+  upstream: UpstreamStats(placesUpstreamCalls: 12, placesCacheHits: 40),
+);
+
+const _health = OpsHealth(
+  db: HealthDb(status: 'ok', pingMs: 3),
+  providers: [
+    ProviderStat(name: 'google_places', configured: true),
+    ProviderStat(name: 'email', configured: false, note: 'not configured'),
+  ],
+  build: BuildInfo(release: 'abc123', goVersion: 'go1.23'),
+  backups: BackupInfo(lastSuccessAt: '2026-07-19T04:10:00Z', ageS: 53400),
+  degraded: false,
+);
+
+Widget _wrap(List<Override> overrides) => ProviderScope(
+      overrides: overrides,
+      child: const MaterialApp(home: Scaffold(body: HealthPane())),
+    );
+
+/// Pump the pane through its initial async loads without pumpAndSettle (the
+/// pane holds a periodic refresh timer, so pumpAndSettle would never settle),
+/// then unmount to cancel that timer before the test ends.
+Future<void> _pumpHealth(WidgetTester tester, Widget w) async {
+  await tester.pumpWidget(w);
+  await tester.pump(); // resolve overridden futures
+  await tester.pump();
+}
+
+Future<void> _teardown(WidgetTester tester) async {
+  await tester.pumpWidget(const SizedBox()); // dispose → cancels the timer
+  await tester.pump();
+}
+
+void main() {
+  testWidgets('renders KPI tiles, dependency pills, backup, and a route row',
+      (tester) async {
+    tester.view.physicalSize = const Size(900, 2400);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+
+    await _pumpHealth(
+      tester,
+      _wrap([
+        opsMetricsProvider.overrideWith((ref) async => _metrics),
+        opsHealthProvider.overrideWith((ref) async => _health),
+      ]),
+    );
+
+    // KPI tiles.
+    expect(find.text('Uptime'), findsOneWidget);
+    expect(find.text('3d 4h'), findsOneWidget);
+    expect(find.text('Requests'), findsOneWidget);
+    expect(find.text('Error rate'), findsOneWidget);
+    expect(find.text('9.0%'), findsOneWidget); // (80 + 10) / 1000
+    expect(find.text('Goroutines'), findsOneWidget);
+    expect(find.text('42'), findsOneWidget);
+    expect(find.text('12.0 MB'), findsOneWidget); // mem alloc
+
+    // Dependencies: DB ok pill + provider configured / not-configured pills.
+    expect(find.text('Database'), findsOneWidget);
+    expect(find.text('3 ms ping'), findsOneWidget);
+    expect(find.text('ok'), findsOneWidget);
+    expect(find.text('Google places'), findsOneWidget);
+    expect(find.text('configured'), findsOneWidget);
+    expect(find.text('Email'), findsOneWidget);
+    expect(find.text('not configured'), findsWidgets); // pill + note
+
+    // Backups.
+    expect(find.text('Last backup'), findsOneWidget);
+    expect(find.text('fresh'), findsOneWidget);
+    expect(find.textContaining('ago'), findsOneWidget);
+
+    // Route table row.
+    expect(find.text('/api/v1/trips/{id}'), findsOneWidget);
+    expect(find.text('120'), findsOneWidget);
+    expect(find.text('85'), findsOneWidget); // p95
+
+    // No degraded banner when healthy.
+    expect(find.text('System degraded'), findsNothing);
+
+    await _teardown(tester);
+  });
+
+  testWidgets('degraded + stale backup + unreachable DB render red',
+      (tester) async {
+    tester.view.physicalSize = const Size(900, 2400);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+
+    const health = OpsHealth(
+      db: HealthDb(status: 'unreachable'),
+      providers: [],
+      backups: BackupInfo(stale: true, ageS: 900000),
+      degraded: true,
+      reasons: ['database unreachable', 'backup is stale'],
+    );
+
+    await _pumpHealth(
+      tester,
+      _wrap([
+        opsMetricsProvider.overrideWith((ref) async => _metrics),
+        opsHealthProvider.overrideWith((ref) async => health),
+      ]),
+    );
+
+    expect(find.text('System degraded'), findsOneWidget);
+    expect(find.textContaining('database unreachable'), findsOneWidget);
+    expect(find.text('unreachable'), findsOneWidget);
+    expect(find.text('stale'), findsOneWidget);
+
+    await _teardown(tester);
+  });
+
+  testWidgets('loading state shows a spinner', (tester) async {
+    final never = Completer<OpsMetrics>();
+    final neverH = Completer<OpsHealth>();
+    await tester.pumpWidget(_wrap([
+      opsMetricsProvider.overrideWith((ref) => never.future),
+      opsHealthProvider.overrideWith((ref) => neverH.future),
+    ]));
+    await tester.pump();
+
+    expect(find.byType(CircularProgressIndicator), findsWidgets);
+
+    await _teardown(tester);
+  });
+
+  testWidgets('error state offers retry', (tester) async {
+    await _pumpHealth(
+      tester,
+      _wrap([
+        opsMetricsProvider
+            .overrideWith((ref) async => throw Exception('403')),
+        opsHealthProvider.overrideWith((ref) async => _health),
+      ]),
+    );
+
+    expect(find.text('Could not load metrics'), findsOneWidget);
+    expect(find.text('Retry'), findsOneWidget);
+
+    await _teardown(tester);
+  });
+}


### PR DESCRIPTION
## Observability PR3 — admin System Health tab

Adds a 5th **Health** tab to the existing admin metrics dashboard (`AdminMetricsScreen`), giving a live operational snapshot of the API. Built against the `GET /api/v1/admin/ops/metrics` and `GET /api/v1/admin/ops/health` JSON contracts (PR1 merged; PR2 in parallel — no runtime dependency on PR2). Entry is the existing admin-gated **Metrics** menu item — no new routing.

### What's in the tab
- **KPI tiles** (reuse the dashboard's tile/stat pattern): Uptime (seconds → "3d 4h"), Requests total (+ 2xx/4xx/5xx caption), Error rate % (4xx+5xx / total, tinted **amber ≥2%** / **red ≥5%**), Goroutines (+ GOMAXPROCS), Memory alloc MB (+ sys), and Places upstream calls / cache hits.
- **Dependencies** section: DB status pill (ok=green / unreachable=red / not_configured=amber) with ping ms; each provider as a configured/not-configured pill row; a red **System degraded** banner listing `reasons` when degraded.
- **Backups** row: humanized "{age} ago" + a fresh (green) / stale (red) / unknown (amber) pill.
- **Per-route table**: top routes by count (route, method, count, error %, p95 ms), horizontally scrollable per the wide-content rule.
- **Live refresh**: `Timer.periodic` every 10s invalidating both providers, `AutomaticKeepAliveClientMixin` (survives tab switches), paused while the app is backgrounded via `WidgetsBindingObserver`, cancelled in `dispose`; plus a `RefreshIndicator` for manual pull-to-refresh.
- Loading / error via `.when(...)` with `EmptyState` + Retry (`ref.invalidate`).

### Files
- `lib/models/ops_metrics.dart`, `lib/models/ops_health.dart` (+ generated `.g.dart`) — `@JsonSerializable`, snake_case keys
- `lib/services/ops_admin_api_service.dart` — `getOpsMetrics()` / `getOpsHealth()`
- `lib/providers/ops_admin_provider.dart` — service + `opsMetricsProvider` / `opsHealthProvider`
- `lib/widgets/health_pane.dart` — the pane
- `lib/screens/admin_metrics_screen.dart` — tab length 4→5, "Health" tab + `HealthPane`
- `test/health_pane_test.dart` — KPI/pill/backup/route render, degraded/loading/error states

### Verification
- `flutter test` — all pass (full suite green)
- `flutter analyze --no-fatal-infos --fatal-warnings` — clean (12 pre-existing baseline infos, none in new files)

Scope: `src/packages/flutter-app/` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)