### PR TITLE
feat(api): ops health + self-check alerts + backup monitoring (Observability PR2)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -169,6 +169,21 @@ smoke: ## Run the end-to-end smoke test (BASE_URL, SMOKE_SEED_MODE, ...)
 		SMOKE_DB_CONTAINER="$(SMOKE_DB_CONTAINER)" \
 		./scripts/smoke.sh
 
+# Postgres backup — dumps the DB (gzip), prunes old dumps, writes the freshness
+# heartbeat /admin/ops/health reads, and best-effort copies off-site via rclone.
+# Wraps dockerize/production/backup.sh; every path/name overrides via env (see
+# that script's header): BACKUP_DIR, RETENTION_DAYS, RCLONE_REMOTE,
+# BACKUP_HEARTBEAT_FILE, COMPOSE_FILE, PG_SERVICE, PG_USER, PG_DB. On prod this
+# runs via the goldentempo-backup systemd timer; this target is for manual/dry runs.
+#   make backup                                        # prod defaults
+#   make backup COMPOSE_FILE=dockerize/development/docker-compose.yml BACKUP_DIR=/tmp/bk
+backup: ## Run a Postgres backup (BACKUP_DIR, RETENTION_DAYS, RCLONE_REMOTE, ...)
+	@BACKUP_DIR="$(BACKUP_DIR)" RETENTION_DAYS="$(RETENTION_DAYS)" \
+		RCLONE_REMOTE="$(RCLONE_REMOTE)" BACKUP_HEARTBEAT_FILE="$(BACKUP_HEARTBEAT_FILE)" \
+		COMPOSE_FILE="$(COMPOSE_FILE)" COMPOSE_PROJECT="$(COMPOSE_PROJECT)" \
+		PG_SERVICE="$(PG_SERVICE)" PG_USER="$(PG_USER)" PG_DB="$(PG_DB)" \
+		./dockerize/production/backup.sh
+
 # Documentation
 docs: ## Show application URLs and documentation
 	@echo "Application (via gateway):"

--- a/dockerize/production/.env.sample
+++ b/dockerize/production/.env.sample
@@ -149,3 +149,8 @@ SENTRY_DSN=
 # BACKUP_DIR=/opt/goldentempo/backups
 # RETENTION_DAYS=14
 # RCLONE_REMOTE=r2:goldentempo-backups
+# BACKUP_HEARTBEAT_FILE writes a freshness marker on every good local dump;
+# the api's /admin/ops/health reads it (BACKUP_STALE_HOURS is read by the api).
+# Point the api at the same file if it runs where BACKUP_DIR is not the default.
+# BACKUP_HEARTBEAT_FILE=/opt/goldentempo/backups/.last_success
+# BACKUP_STALE_HOURS=36   # api marks backups stale (=> degraded) past this age

--- a/dockerize/production/backup.sh
+++ b/dockerize/production/backup.sh
@@ -24,6 +24,9 @@
 #   PG_USER / PG_DB   database credentials (default travel / travel_planner)
 #   RETENTION_DAYS    local prune horizon (default 14)
 #   RCLONE_REMOTE     rclone destination (default r2:goldentempo-backups)
+#   BACKUP_HEARTBEAT_FILE  freshness marker written on a good local dump
+#                     (default $BACKUP_DIR/.last_success); the API's
+#                     /admin/ops/health reads it to detect stale backups
 set -euo pipefail
 
 COMPOSE_FILE="${COMPOSE_FILE:-/opt/goldentempo/docker-compose.yml}"
@@ -34,6 +37,7 @@ PG_USER="${PG_USER:-travel}"
 PG_DB="${PG_DB:-travel_planner}"
 RETENTION_DAYS="${RETENTION_DAYS:-14}"
 RCLONE_REMOTE="${RCLONE_REMOTE:-r2:goldentempo-backups}"
+BACKUP_HEARTBEAT_FILE="${BACKUP_HEARTBEAT_FILE:-$BACKUP_DIR/.last_success}"
 
 compose() {
     if [ -n "$COMPOSE_PROJECT" ]; then
@@ -62,6 +66,13 @@ echo "[backup] wrote $(du -h "$out" | cut -f1) $out"
 find "$BACKUP_DIR" -maxdepth 1 -name "${PG_DB}-*.dump.gz" -type f \
     -mtime +"$RETENTION_DAYS" -print -delete |
     sed 's/^/[backup] pruned /'
+
+# Freshness heartbeat: a good local dump exists. Written BEFORE the best-effort
+# off-site copy so an unconfigured/failed rclone (which exits 0) never withholds
+# the "backups are current" signal — the API's /admin/ops/health only asks
+# whether a recent dump succeeded, not whether it was mirrored off-site.
+date -u +%FT%TZ >"$BACKUP_HEARTBEAT_FILE"
+echo "[backup] heartbeat $(cat "$BACKUP_HEARTBEAT_FILE") -> $BACKUP_HEARTBEAT_FILE"
 
 # Off-site copy (best-effort): requires rclone AND the remote to exist.
 remote_name="${RCLONE_REMOTE%%:*}"

--- a/dockerize/production/restore-drill.sh
+++ b/dockerize/production/restore-drill.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Restore drill for the goldentempotravel.com Postgres backups.
+#
+# Codifies the "verify a dump into a throwaway volume" half of restore.md
+# (steps 0–3) as a repeatable, non-destructive check: it NEVER touches the live
+# stack or its data volume. It restores the latest (or a named) dump into a
+# scratch postgres container, runs a sanity SELECT count(*) on a core table,
+# reports PASS/FAIL, and tears the scratch container down.
+#
+# Run it periodically (or from a systemd timer) so "we have backups" is proven,
+# not assumed. Exit status is 0 on PASS, non-zero on FAIL.
+#
+# Every knob overrides via env so it can drill any stack's dumps:
+#
+#   BACKUP_DIR      where dumps live (default /opt/goldentempo/backups)
+#   PG_DB           database name inside the dump (default travel_planner)
+#   PG_USER         role to restore as (default travel)
+#   DUMP            explicit dump path (default: newest ${PG_DB}-*.dump.gz)
+#   CORE_TABLE      table the sanity count runs against (default users)
+#   PG_IMAGE        scratch postgres image (default postgres:16-alpine)
+#   SCRATCH_NAME    scratch container name (default pg-restore-drill)
+set -euo pipefail
+
+BACKUP_DIR="${BACKUP_DIR:-/opt/goldentempo/backups}"
+PG_DB="${PG_DB:-travel_planner}"
+PG_USER="${PG_USER:-travel}"
+CORE_TABLE="${CORE_TABLE:-users}"
+PG_IMAGE="${PG_IMAGE:-postgres:16-alpine}"
+SCRATCH_NAME="${SCRATCH_NAME:-pg-restore-drill}"
+
+fail() {
+    echo "[restore-drill] FAIL: $*" >&2
+    exit 1
+}
+
+# Pick the dump: an explicit DUMP wins, else the newest matching file.
+DUMP="${DUMP:-}"
+if [ -z "$DUMP" ]; then
+    DUMP="$(find "$BACKUP_DIR" -maxdepth 1 -name "${PG_DB}-*.dump.gz" -type f \
+        | sort | tail -n 1)"
+fi
+[ -n "$DUMP" ] && [ -f "$DUMP" ] || fail "no dump found in $BACKUP_DIR (${PG_DB}-*.dump.gz)"
+
+echo "[restore-drill] $(date -u +%FT%TZ) drilling $DUMP"
+
+# gzip integrity before we spend a container on it.
+gunzip -t "$DUMP" || fail "gzip integrity check failed for $DUMP"
+
+# Always tear the scratch container down, even on failure.
+cleanup() {
+    docker rm -f "$SCRATCH_NAME" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+# Fresh scratch postgres — no volume, purely ephemeral.
+docker rm -f "$SCRATCH_NAME" >/dev/null 2>&1 || true
+docker run -d --name "$SCRATCH_NAME" \
+    -e POSTGRES_USER="$PG_USER" \
+    -e POSTGRES_DB="$PG_DB" \
+    -e POSTGRES_PASSWORD=drill \
+    "$PG_IMAGE" >/dev/null
+
+echo "[restore-drill] waiting for scratch postgres to accept connections"
+for _ in $(seq 1 30); do
+    if docker exec "$SCRATCH_NAME" pg_isready -U "$PG_USER" -d "$PG_DB" >/dev/null 2>&1; then
+        break
+    fi
+    sleep 1
+done
+docker exec "$SCRATCH_NAME" pg_isready -U "$PG_USER" -d "$PG_DB" >/dev/null 2>&1 \
+    || fail "scratch postgres never became ready"
+
+echo "[restore-drill] restoring dump"
+gunzip -c "$DUMP" | docker exec -i "$SCRATCH_NAME" \
+    pg_restore -U "$PG_USER" -d "$PG_DB" --no-owner --exit-on-error \
+    || fail "pg_restore reported errors"
+
+# Sanity: the core table exists and its row count is a non-negative integer.
+count="$(docker exec "$SCRATCH_NAME" psql -U "$PG_USER" -d "$PG_DB" -tA \
+    -c "SELECT count(*) FROM ${CORE_TABLE};" 2>/dev/null | tr -d '[:space:]')" \
+    || fail "sanity SELECT on ${CORE_TABLE} failed"
+case "$count" in
+    ''|*[!0-9]*) fail "sanity count on ${CORE_TABLE} was not a number: '${count}'" ;;
+esac
+
+echo "[restore-drill] PASS: ${CORE_TABLE} restored with ${count} rows from $DUMP"

--- a/dockerize/production/systemd/README.md
+++ b/dockerize/production/systemd/README.md
@@ -1,0 +1,53 @@
+# systemd units — Golden Tempo backups
+
+Committed units that schedule the nightly Postgres backup (`../backup.sh`).
+They assume the standard prod layout: the stack lives at `/opt/goldentempo`
+(compose project `goldentempo`, `.env` beside the compose file) and
+`backup.sh` is copied to `/opt/goldentempo/backup.sh`.
+
+## Install
+
+```bash
+# From /opt/goldentempo on the prod host (adjust paths if your layout differs):
+sudo cp dockerize/production/backup.sh            /opt/goldentempo/backup.sh
+sudo chmod +x /opt/goldentempo/backup.sh
+sudo cp dockerize/production/systemd/goldentempo-backup.service /etc/systemd/system/
+sudo cp dockerize/production/systemd/goldentempo-backup.timer   /etc/systemd/system/
+
+sudo systemctl daemon-reload
+sudo systemctl enable --now goldentempo-backup.timer
+```
+
+## Operate
+
+```bash
+systemctl list-timers goldentempo-backup.timer   # next/last run
+sudo systemctl start goldentempo-backup.service  # run one backup now
+journalctl -u goldentempo-backup.service -n 50   # last run's output
+```
+
+The service is `Type=oneshot`; the timer fires it daily ~04:10 with
+`Persistent=true` (a backup missed while the host was off runs on next boot).
+Knobs come from `EnvironmentFile=/opt/goldentempo/.env` — see the `backup.sh`
+header and the Backups block in `.env.sample` (`BACKUP_DIR`, `RETENTION_DAYS`,
+`RCLONE_REMOTE`, `BACKUP_HEARTBEAT_FILE`, `BACKUP_STALE_HOURS`).
+
+## Verify the backups actually restore
+
+A backup you can't restore isn't a backup. Periodically run the non-destructive
+drill (it touches only a throwaway container, never the live stack):
+
+```bash
+sudo /opt/goldentempo/restore-drill.sh   # restores the latest dump, PASS/FAIL
+```
+
+`../restore.md` is the full, live-stack restore runbook.
+
+## How the heartbeat feeds health
+
+`backup.sh` writes `BACKUP_HEARTBEAT_FILE` (default
+`$BACKUP_DIR/.last_success`) on every good local dump. The API's
+`GET /api/v1/admin/ops/health` reads it and flags `backups.stale` (and marks
+the whole service degraded, alerting admins) once it is older than
+`BACKUP_STALE_HOURS` (default 36) — so a silently-failing timer becomes a
+visible, alerting condition. Make the file readable by the API process/container.

--- a/dockerize/production/systemd/goldentempo-backup.service
+++ b/dockerize/production/systemd/goldentempo-backup.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Golden Tempo Postgres backup (pg_dump -> gzip -> rclone off-site)
+Documentation=file:///opt/goldentempo/restore.md
+# Only run once the Docker daemon is up — backup.sh talks to the postgres
+# container via docker compose exec.
+Requires=docker.service
+After=docker.service network-online.target
+
+[Service]
+Type=oneshot
+# EnvironmentFile carries the backup knobs (BACKUP_DIR, RETENTION_DAYS,
+# RCLONE_REMOTE, BACKUP_HEARTBEAT_FILE, ...) alongside the app config.
+EnvironmentFile=/opt/goldentempo/.env
+ExecStart=/opt/goldentempo/backup.sh
+# A backup should never run forever; fail loudly instead.
+TimeoutStartSec=1800
+Nice=10
+IOSchedulingClass=best-effort
+IOSchedulingPriority=7

--- a/dockerize/production/systemd/goldentempo-backup.timer
+++ b/dockerize/production/systemd/goldentempo-backup.timer
@@ -1,0 +1,14 @@
+[Unit]
+Description=Daily Golden Tempo Postgres backup (~04:10)
+Documentation=file:///opt/goldentempo/restore.md
+
+[Timer]
+# Daily at 04:10. RandomizedDelaySec smears the exact start a little so a fleet
+# of hosts don't all hit storage at the same instant.
+OnCalendar=*-*-* 04:10:00
+RandomizedDelaySec=300
+# Persistent=true runs a missed backup on next boot (host was off at 04:10).
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/src/packages/api/main.go
+++ b/src/packages/api/main.go
@@ -644,6 +644,10 @@ func main() {
 	// planning nudge; no-op in degraded mode.
 	startReengagementChecker(ctx)
 
+	// Background health self-check (Observability): alerts on healthy<->degraded
+	// transitions (DB reachability + backup freshness); no-op in degraded mode.
+	startHealthMonitor(ctx)
+
 	startServer(buildRouter())
 }
 
@@ -873,6 +877,10 @@ func buildRouter() *mux.Router {
 	// Live in-process request/latency/error + runtime rollup (ops_metrics.go).
 	// No dbPool guard — it must render in degraded mode; admin auth only.
 	api.Handle("/admin/ops/metrics", admin(opsMetricsHandler)).Methods("GET")
+
+	// Consolidated dependency health: DB + provider config + build + backup
+	// freshness (ops_health.go). Also renders in degraded mode; admin auth only.
+	api.Handle("/admin/ops/health", admin(opsHealthHandler)).Methods("GET")
 
 	// Public browse endpoints for published local-sourced content.
 	api.HandleFunc("/local/recommendations", localRecommendationsHandler).Methods("GET")

--- a/src/packages/api/ops_health.go
+++ b/src/packages/api/ops_health.go
@@ -1,0 +1,203 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"runtime"
+	"strings"
+	"time"
+)
+
+// Consolidated dependency-health endpoint (Observability PR2): GET
+// /api/v1/admin/ops/health rolls up the DB, every provider's "configured"
+// state, build/runtime info, and backup freshness into one DependencyHealth
+// document, plus a top-level Degraded verdict + Reasons list.
+//
+// Like opsMetricsHandler this has NO dbPool guard: the endpoint must render
+// even when the database is down — that is exactly when an operator needs it.
+// The DB section reports "unreachable"/"not_configured" instead of failing the
+// request. Admin auth is still enforced at route registration.
+//
+// The pure helpers (providerStatuses, evalBackupHealth, computeHealthState) are
+// shared verbatim with the self-check monitor (ops_monitor.go) so the endpoint
+// and the alert loop can never disagree about what "degraded" means.
+
+const (
+	defaultBackupHeartbeatFile = "/opt/goldentempo/backups/.last_success"
+	defaultBackupStaleHours    = 36
+)
+
+// DependencyHealth is the wire contract of GET /admin/ops/health. Field tags
+// are load-bearing: PR3 (Flutter ops dashboard) builds against this exact shape.
+type DependencyHealth struct {
+	DB        HealthDB       `json:"db"`
+	Providers []ProviderStat `json:"providers"`
+	Build     BuildInfo      `json:"build"`
+	Backups   BackupInfo     `json:"backups"`
+	Degraded  bool           `json:"degraded"`
+	Reasons   []string       `json:"reasons"` // non-nil (empty slice, not null)
+}
+
+// HealthDB reports database reachability. Status is one of "ok",
+// "unreachable", or "not_configured"; PingMs is the ping round-trip in ms
+// (0 when not ok).
+type HealthDB struct {
+	Status string `json:"status"`
+	PingMs int    `json:"ping_ms"`
+}
+
+// ProviderStat is one external dependency's configuration status. Configured
+// reflects whether the credential/config needed to use it is present; Note is
+// an optional human hint (e.g. "not configured").
+type ProviderStat struct {
+	Name       string `json:"name"`
+	Configured bool   `json:"configured"`
+	Note       string `json:"note"`
+}
+
+// BuildInfo is static build/runtime provenance for the running process.
+type BuildInfo struct {
+	Release   string `json:"release"`
+	GoVersion string `json:"go_version"`
+	StartedAt string `json:"started_at"` // ISO8601 (RFC3339)
+	UptimeS   int64  `json:"uptime_s"`
+}
+
+// BackupInfo is the freshness of the last successful DB backup, read from the
+// heartbeat file the backup job writes. LastSuccessAt/AgeS are nil when no
+// heartbeat exists; Stale is true then too.
+type BackupInfo struct {
+	LastSuccessAt *string `json:"last_success_at"` // ISO8601, null if none
+	AgeS          *int64  `json:"age_s"`           // null if none
+	Stale         bool    `json:"stale"`
+}
+
+// opsHealthHandler serves GET /api/v1/admin/ops/health.
+func opsHealthHandler(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, http.StatusOK, buildDependencyHealth(r.Context(), time.Now()))
+}
+
+// buildDependencyHealth assembles the full document. now is injectable so the
+// backup-freshness math is testable.
+func buildDependencyHealth(ctx context.Context, now time.Time) DependencyHealth {
+	db := probeDB(ctx)
+	backups := readBackupHealth(now)
+	state := computeHealthState(db.Status == "ok", backups.Stale)
+	return DependencyHealth{
+		DB:        db,
+		Providers: providerStatuses(),
+		Build:     buildInfo(now),
+		Backups:   backups,
+		Degraded:  state.degraded,
+		Reasons:   state.reasons,
+	}
+}
+
+// probeDB pings the database and reports status + latency. "not_configured"
+// when there is no pool, "unreachable" when a ping fails, "ok" otherwise.
+func probeDB(ctx context.Context) HealthDB {
+	if dbPool == nil {
+		return HealthDB{Status: "not_configured"}
+	}
+	start := time.Now()
+	if !pingDB(ctx) {
+		return HealthDB{Status: "unreachable"}
+	}
+	return HealthDB{Status: "ok", PingMs: int(time.Since(start).Milliseconds())}
+}
+
+// buildInfo captures static build/runtime provenance.
+func buildInfo(now time.Time) BuildInfo {
+	return BuildInfo{
+		Release:   os.Getenv("SENTRY_RELEASE"),
+		GoVersion: runtime.Version(),
+		StartedAt: processStart.UTC().Format(time.RFC3339),
+		UptimeS:   int64(now.Sub(processStart).Seconds()),
+	}
+}
+
+// providerStatuses is the consolidated external-dependency configuration list.
+// Each entry's Configured flag reuses that provider's own "configured" check so
+// this stays the single source of truth for provider readiness. Order is
+// stable for a deterministic UI.
+func providerStatuses() []ProviderStat {
+	stat := func(name string, ok bool) ProviderStat {
+		note := ""
+		if !ok {
+			note = "not configured"
+		}
+		return ProviderStat{Name: name, Configured: ok, Note: note}
+	}
+
+	duffelConfigured := duffelService != nil && duffelService.Token != ""
+	emailConfigured := emailService != nil && emailService.Configured()
+	transcriptionConfigured := transcriptionService != nil && transcriptionService.Configured()
+
+	return []ProviderStat{
+		stat("google_places", os.Getenv("GOOGLE_PLACES_API_KEY") != ""),
+		stat("anthropic", os.Getenv("ANTHROPIC_API_KEY") != ""),
+		stat("duffel", duffelConfigured),
+		stat("ticketmaster", os.Getenv("TICKETMASTER_API_KEY") != ""),
+		stat("email", emailConfigured),
+		stat("google_oauth", googleOAuthConfigured()),
+		stat("transcription", transcriptionConfigured),
+		stat("sentry", sentryEnabled),
+	}
+}
+
+// readBackupHealth reads the backup heartbeat file and evaluates its freshness
+// against BACKUP_STALE_HOURS. The file (written by backup.sh) holds a single
+// RFC3339 timestamp from `date -u +%FT%TZ`.
+func readBackupHealth(now time.Time) BackupInfo {
+	path := os.Getenv("BACKUP_HEARTBEAT_FILE")
+	if path == "" {
+		path = defaultBackupHeartbeatFile
+	}
+	contents, err := os.ReadFile(path)
+	return evalBackupHealth(now, string(contents), err, envInt("BACKUP_STALE_HOURS", defaultBackupStaleHours))
+}
+
+// evalBackupHealth is the pure freshness evaluator. A missing/unreadable/
+// unparseable heartbeat yields last_success_at=null, age_s=null, stale=true (no
+// evidence of a recent backup is itself a degraded signal). Otherwise Stale is
+// true once the heartbeat is older than staleHours.
+func evalBackupHealth(now time.Time, contents string, readErr error, staleHours int) BackupInfo {
+	if readErr != nil {
+		return BackupInfo{Stale: true}
+	}
+	ts, perr := time.Parse(time.RFC3339, strings.TrimSpace(contents))
+	if perr != nil {
+		return BackupInfo{Stale: true}
+	}
+	iso := ts.UTC().Format(time.RFC3339)
+	ageS := int64(now.Sub(ts).Seconds())
+	if ageS < 0 {
+		ageS = 0
+	}
+	stale := now.Sub(ts) > time.Duration(staleHours)*time.Hour
+	return BackupInfo{LastSuccessAt: &iso, AgeS: &ageS, Stale: stale}
+}
+
+// healthState is the deterministic degraded verdict shared by the endpoint and
+// the monitor.
+type healthState struct {
+	degraded bool
+	reasons  []string
+}
+
+// computeHealthState derives the top-level degraded verdict from the two
+// deterministic, unpriced signals: DB reachability and backup freshness. It
+// deliberately does NOT consider provider configuration (a missing optional
+// provider key is not "the service is unhealthy") and never pings paid
+// providers. reasons is always non-nil.
+func computeHealthState(dbOK, backupsStale bool) healthState {
+	reasons := []string{}
+	if !dbOK {
+		reasons = append(reasons, "database unreachable")
+	}
+	if backupsStale {
+		reasons = append(reasons, "backups stale")
+	}
+	return healthState{degraded: len(reasons) > 0, reasons: reasons}
+}

--- a/src/packages/api/ops_health_test.go
+++ b/src/packages/api/ops_health_test.go
@@ -1,0 +1,231 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// --- providerStatuses across env combinations ---
+
+func TestProviderStatuses(t *testing.T) {
+	// The three token-emptiness providers we can toggle via env (the others
+	// read singletons/globals fixed at package init). Setting them proves the
+	// consolidated list reflects configuration; clearing proves the inverse.
+	t.Setenv("GOOGLE_PLACES_API_KEY", "pk")
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	t.Setenv("TICKETMASTER_API_KEY", "tm")
+
+	byName := map[string]ProviderStat{}
+	for _, p := range providerStatuses() {
+		byName[p.Name] = p
+	}
+
+	// All eight expected providers are present.
+	for _, name := range []string{
+		"google_places", "anthropic", "duffel", "ticketmaster",
+		"email", "google_oauth", "transcription", "sentry",
+	} {
+		if _, ok := byName[name]; !ok {
+			t.Fatalf("provider %q missing from statuses", name)
+		}
+	}
+
+	if !byName["google_places"].Configured {
+		t.Errorf("google_places should be configured (env set)")
+	}
+	if byName["anthropic"].Configured {
+		t.Errorf("anthropic should be unconfigured (env empty)")
+	}
+	if !byName["ticketmaster"].Configured {
+		t.Errorf("ticketmaster should be configured (env set)")
+	}
+
+	// Note is consistent with Configured for every entry.
+	for _, p := range providerStatuses() {
+		if p.Configured && p.Note != "" {
+			t.Errorf("%s configured but has note %q", p.Name, p.Note)
+		}
+		if !p.Configured && p.Note != "not configured" {
+			t.Errorf("%s unconfigured but note = %q", p.Name, p.Note)
+		}
+	}
+}
+
+func TestProviderStatusesUnsetClears(t *testing.T) {
+	t.Setenv("GOOGLE_PLACES_API_KEY", "")
+	t.Setenv("TICKETMASTER_API_KEY", "")
+	byName := map[string]ProviderStat{}
+	for _, p := range providerStatuses() {
+		byName[p.Name] = p
+	}
+	if byName["google_places"].Configured || byName["ticketmaster"].Configured {
+		t.Fatalf("cleared providers still report configured")
+	}
+}
+
+// --- evalBackupHealth: fresh / stale / missing ---
+
+func TestEvalBackupHealth(t *testing.T) {
+	now := time.Date(2026, 7, 19, 12, 0, 0, 0, time.UTC)
+
+	// Fresh: 1 hour old, 36h threshold => not stale, fields populated.
+	fresh := now.Add(-1 * time.Hour).Format(time.RFC3339)
+	b := evalBackupHealth(now, fresh+"\n", nil, 36)
+	if b.Stale {
+		t.Errorf("fresh backup marked stale")
+	}
+	if b.LastSuccessAt == nil || b.AgeS == nil {
+		t.Fatalf("fresh backup missing fields: %+v", b)
+	}
+	if *b.AgeS != 3600 {
+		t.Errorf("age_s = %d, want 3600", *b.AgeS)
+	}
+
+	// Stale: 40 hours old, 36h threshold => stale.
+	old := now.Add(-40 * time.Hour).Format(time.RFC3339)
+	b = evalBackupHealth(now, old, nil, 36)
+	if !b.Stale {
+		t.Errorf("40h-old backup not marked stale")
+	}
+	if b.LastSuccessAt == nil {
+		t.Errorf("stale-but-present backup should still expose timestamp")
+	}
+
+	// Missing file (read error): stale, no fields.
+	b = evalBackupHealth(now, "", errors.New("no such file"), 36)
+	if !b.Stale || b.LastSuccessAt != nil || b.AgeS != nil {
+		t.Errorf("missing heartbeat should be stale/null: %+v", b)
+	}
+
+	// Unparseable contents: treated like missing.
+	b = evalBackupHealth(now, "garbage", nil, 36)
+	if !b.Stale || b.LastSuccessAt != nil {
+		t.Errorf("unparseable heartbeat should be stale/null: %+v", b)
+	}
+}
+
+// --- computeHealthState transition matrix ---
+
+func TestComputeHealthState(t *testing.T) {
+	cases := []struct {
+		dbOK, backupsStale bool
+		wantDegraded       bool
+		wantReasons        []string
+	}{
+		{true, false, false, []string{}},
+		{false, false, true, []string{"database unreachable"}},
+		{true, true, true, []string{"backups stale"}},
+		{false, true, true, []string{"database unreachable", "backups stale"}},
+	}
+	for _, c := range cases {
+		got := computeHealthState(c.dbOK, c.backupsStale)
+		if got.degraded != c.wantDegraded {
+			t.Errorf("dbOK=%v stale=%v: degraded=%v want %v", c.dbOK, c.backupsStale, got.degraded, c.wantDegraded)
+		}
+		if got.reasons == nil {
+			t.Errorf("reasons must be non-nil")
+		}
+		if strings.Join(got.reasons, "|") != strings.Join(c.wantReasons, "|") {
+			t.Errorf("dbOK=%v stale=%v: reasons=%v want %v", c.dbOK, c.backupsStale, got.reasons, c.wantReasons)
+		}
+	}
+}
+
+// --- buildOpsAlertEmail content ---
+
+func TestBuildOpsAlertEmail(t *testing.T) {
+	appURL := "https://app.example.com/"
+
+	subject, body := buildOpsAlertEmail(true, []string{"database unreachable", "backups stale"}, appURL)
+	if !strings.Contains(subject, "degraded") {
+		t.Errorf("degrade subject = %q", subject)
+	}
+	for _, want := range []string{"database unreachable", "backups stale", appURL} {
+		if !strings.Contains(body, want) {
+			t.Errorf("degrade body missing %q:\n%s", want, body)
+		}
+	}
+
+	subject, body = buildOpsAlertEmail(false, nil, appURL)
+	if !strings.Contains(subject, "recovered") {
+		t.Errorf("recover subject = %q", subject)
+	}
+	if !strings.Contains(body, "recovered") || !strings.Contains(body, appURL) {
+		t.Errorf("recover body:\n%s", body)
+	}
+}
+
+// --- opsHealthHandler shape ---
+
+// writeFreshHeartbeat points BACKUP_HEARTBEAT_FILE at a temp file holding a
+// just-now timestamp so backups are not stale (isolating the DB signal).
+func writeFreshHeartbeat(t *testing.T, now time.Time) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), ".last_success")
+	if err := os.WriteFile(path, []byte(now.Format(time.RFC3339)+"\n"), 0o600); err != nil {
+		t.Fatalf("write heartbeat: %v", err)
+	}
+	t.Setenv("BACKUP_HEARTBEAT_FILE", path)
+}
+
+func TestOpsHealthHandlerNoDB(t *testing.T) {
+	saved := dbPool
+	dbPool = nil
+	defer func() { dbPool = saved }()
+
+	req := httptest.NewRequest("GET", "/api/v1/admin/ops/health", nil)
+	rec := httptest.NewRecorder()
+	opsHealthHandler(rec, req)
+
+	if rec.Code != 200 {
+		t.Fatalf("status = %d, want 200 (renders even with no DB)", rec.Code)
+	}
+	var got DependencyHealth
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("bad JSON: %v", err)
+	}
+	if got.DB.Status != "not_configured" {
+		t.Errorf("db.status = %q, want not_configured", got.DB.Status)
+	}
+	if !got.Degraded {
+		t.Errorf("no DB should be degraded")
+	}
+	if got.Reasons == nil {
+		t.Errorf("reasons must be non-nil (empty slice, not null)")
+	}
+	if len(got.Providers) != 8 {
+		t.Errorf("providers len = %d, want 8", len(got.Providers))
+	}
+	if got.Build.GoVersion == "" || got.Build.StartedAt == "" {
+		t.Errorf("build info incomplete: %+v", got.Build)
+	}
+}
+
+func TestOpsHealthHandlerDBUp(t *testing.T) {
+	requireDB(t)
+	writeFreshHeartbeat(t, time.Now())
+
+	req := httptest.NewRequest("GET", "/api/v1/admin/ops/health", nil)
+	rec := httptest.NewRecorder()
+	opsHealthHandler(rec, req)
+
+	var got DependencyHealth
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("bad JSON: %v", err)
+	}
+	if got.DB.Status != "ok" {
+		t.Fatalf("db.status = %q, want ok", got.DB.Status)
+	}
+	if got.Degraded {
+		t.Errorf("DB up + fresh backup should not be degraded: reasons=%v", got.Reasons)
+	}
+	if got.Reasons == nil || len(got.Reasons) != 0 {
+		t.Errorf("healthy reasons should be empty non-nil, got %v", got.Reasons)
+	}
+}

--- a/src/packages/api/ops_monitor.go
+++ b/src/packages/api/ops_monitor.go
@@ -1,0 +1,197 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"log/slog"
+	"math/rand"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"travel-route-planner/store"
+)
+
+// Health self-check monitor (Observability PR2): a background ticker that
+// re-evaluates the same deterministic health signals the /admin/ops/health
+// endpoint reports (DB reachability + backup freshness) and alerts on
+// TRANSITIONS only — healthy->degraded and degraded->healthy. It mirrors the
+// price-alert / re-engagement checker shape exactly (own goroutine, env-cadence
+// ticker, jittered first tick, dbPool-nil guard, injectable clock in runOnce).
+//
+// Alerting on transitions (not on every degraded tick) is the dedup: a five-
+// minute tick over a multi-hour outage fires ONE alert, and one recovery. State
+// lives in memory on the checker, so a restart while still degraded re-alerts
+// once — acceptable (Brian) and not worth a table.
+//
+// Three channels fire on a transition:
+//   - slog.Error on degrade (teed to Sentry via sentry_slog.go); slog.Info on
+//     recovery.
+//   - an in-app notification per admin user (ops_alert / ops_recovered).
+//   - an email per admin, but ONLY when SMTP is configured.
+//
+// This monitor never pings paid providers — computeHealthState is DB + backups
+// only, so the loop costs one cheap DB ping and one file stat per tick.
+
+const (
+	defaultHealthTickMinutes = 5
+
+	notificationTypeOpsAlert     = "ops_alert"
+	notificationTypeOpsRecovered = "ops_recovered"
+)
+
+type healthMonitor struct {
+	interval     time.Duration
+	lastDegraded bool // in-memory transition state; starts healthy (false)
+
+	// Injectable seams for tests. Defaulted in startHealthMonitor to the real
+	// store/email singletons.
+	listAdmins   func(context.Context) ([]store.ListAdminUsersRow, error)
+	insertNotify func(context.Context, store.InsertNotificationParams) error
+	sendEmail    func(to, subject, body string) error
+	emailEnabled func() bool
+	pingDBFn     func(context.Context) bool
+}
+
+// startHealthMonitor launches the background loop. No-ops (with a log line)
+// when persistence is unavailable — with no DB there is no admin list to alert
+// and pingDB is always false; the monitor resumes on next boot once a database
+// is configured, exactly like startAlertChecker.
+func startHealthMonitor(ctx context.Context) {
+	if dbPool == nil {
+		log.Printf("ops health: monitor disabled (no database)")
+		return
+	}
+	m := &healthMonitor{
+		interval: time.Duration(envInt("HEALTH_TICK_MINUTES", defaultHealthTickMinutes)) * time.Minute,
+		listAdmins: func(ctx context.Context) ([]store.ListAdminUsersRow, error) {
+			return store.New(dbPool).ListAdminUsers(ctx)
+		},
+		insertNotify: func(ctx context.Context, p store.InsertNotificationParams) error {
+			_, err := store.New(dbPool).InsertNotification(ctx, p)
+			return err
+		},
+		sendEmail:    func(to, subject, body string) error { return emailService.Send(to, subject, body) },
+		emailEnabled: func() bool { return emailService.Configured() },
+		pingDBFn:     pingDB,
+	}
+	go m.run(ctx)
+	log.Printf("ops health: monitor started (tick %s)", m.interval)
+}
+
+func (m *healthMonitor) run(ctx context.Context) {
+	// Jitter the first tick so restarts don't synchronize a burst of alerts.
+	select {
+	case <-ctx.Done():
+		return
+	case <-time.After(time.Duration(rand.Int63n(int64(m.interval)))):
+	}
+	ticker := time.NewTicker(m.interval)
+	defer ticker.Stop()
+	for {
+		m.runOnce(ctx, time.Now())
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+	}
+}
+
+// runOnce evaluates health once and alerts on a transition. now is the testable
+// clock (drives backup-freshness). On no transition it does nothing — that is
+// the dedup that keeps a long outage to a single alert.
+func (m *healthMonitor) runOnce(ctx context.Context, now time.Time) {
+	dbOK := m.pingDBFn(ctx)
+	backups := readBackupHealth(now)
+	state := computeHealthState(dbOK, backups.Stale)
+
+	if state.degraded == m.lastDegraded {
+		return // no transition — the dedup
+	}
+	m.lastDegraded = state.degraded
+	m.alertTransition(ctx, state)
+}
+
+// alertTransition fires all three channels for one healthy<->degraded flip.
+func (m *healthMonitor) alertTransition(ctx context.Context, state healthState) {
+	if state.degraded {
+		// LevelError is teed to Sentry (sentry_slog.go).
+		slog.Error("ops health degraded", "reasons", strings.Join(state.reasons, ", "))
+	} else {
+		slog.Info("ops health recovered")
+	}
+
+	admins, err := m.listAdmins(ctx)
+	if err != nil {
+		log.Printf("ops health: list admins failed: %v", err)
+		return
+	}
+
+	notifType := notificationTypeOpsRecovered
+	if state.degraded {
+		notifType = notificationTypeOpsAlert
+	}
+	payload := opsAlertPayload(state)
+
+	for _, a := range admins {
+		if err := m.insertNotify(ctx, store.InsertNotificationParams{
+			UserID:  a.ID,
+			Type:    notifType,
+			Payload: payload,
+			TripID:  pgtype.UUID{}, // no trip association
+		}); err != nil {
+			log.Printf("ops health: insert %s notification for %s failed: %v", notifType, a.ID, err)
+		}
+	}
+
+	// Email is the only gated channel: skip entirely when SMTP is unconfigured.
+	if !m.emailEnabled() {
+		return
+	}
+	subject, body := buildOpsAlertEmail(state.degraded, state.reasons, publicAppURL())
+	for _, a := range admins {
+		if err := m.sendEmail(a.Email, subject, body); err != nil {
+			log.Printf("ops health: alert email to %s failed: %v", a.Email, err)
+		}
+	}
+}
+
+// opsAlertPayload is the self-describing render bag for the in-app ops
+// notification, the same convention as the other notification payloads.
+func opsAlertPayload(state healthState) []byte {
+	b, err := json.Marshal(map[string]any{
+		"degraded": state.degraded,
+		"reasons":  state.reasons,
+	})
+	if err != nil {
+		return []byte(`{}`)
+	}
+	return b
+}
+
+// buildOpsAlertEmail renders the operator alert email. Pure — unit-tested. On
+// degrade it lists the reasons; on recovery it confirms all-clear. appURL links
+// back to the app (the ops dashboard lives behind it).
+func buildOpsAlertEmail(degraded bool, reasons []string, appURL string) (subject, body string) {
+	var b strings.Builder
+	if degraded {
+		subject = "[ops] Golden Tempo API degraded"
+		b.WriteString("The Golden Tempo API self-check detected a degradation.\n\n")
+		b.WriteString("Reasons:\n")
+		if len(reasons) == 0 {
+			b.WriteString("  - (unspecified)\n")
+		}
+		for _, r := range reasons {
+			fmt.Fprintf(&b, "  - %s\n", r)
+		}
+	} else {
+		subject = "[ops] Golden Tempo API recovered"
+		b.WriteString("The Golden Tempo API self-check reports all clear — health has recovered.\n")
+	}
+	fmt.Fprintf(&b, "\nOps dashboard: %s\n", appURL)
+	return subject, b.String()
+}

--- a/src/packages/api/ops_monitor_test.go
+++ b/src/packages/api/ops_monitor_test.go
@@ -1,0 +1,164 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"travel-route-planner/store"
+)
+
+// fakeMailbox records ops-alert emails the monitor would send.
+type fakeMailbox struct {
+	mu   sync.Mutex
+	sent []struct{ to, subject, body string }
+}
+
+func (m *fakeMailbox) send(to, subject, body string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.sent = append(m.sent, struct{ to, subject, body string }{to, subject, body})
+	return nil
+}
+
+func (m *fakeMailbox) count() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.sent)
+}
+
+// newTestMonitor wires a monitor to the real store (test DB) with a controllable
+// DB-ping and a fake mailbox.
+func newTestMonitor(mailbox *fakeMailbox, emailOn bool, ping *bool) *healthMonitor {
+	return &healthMonitor{
+		interval: time.Minute,
+		listAdmins: func(ctx context.Context) ([]store.ListAdminUsersRow, error) {
+			return store.New(dbPool).ListAdminUsers(ctx)
+		},
+		insertNotify: func(ctx context.Context, p store.InsertNotificationParams) error {
+			_, err := store.New(dbPool).InsertNotification(ctx, p)
+			return err
+		},
+		sendEmail:    mailbox.send,
+		emailEnabled: func() bool { return emailOn },
+		pingDBFn:     func(context.Context) bool { return *ping },
+	}
+}
+
+func opsNotifCount(t *testing.T, u uuid.UUID, typ string) int {
+	t.Helper()
+	rows, err := store.New(dbPool).ListNotificationsByUser(context.Background(),
+		store.ListNotificationsByUserParams{UserID: u, Limit: 50})
+	if err != nil {
+		t.Fatalf("list notifications: %v", err)
+	}
+	n := 0
+	for _, r := range rows {
+		if r.Type == typ {
+			n++
+		}
+	}
+	return n
+}
+
+// A healthy->degraded->healthy sequence fires exactly one alert per transition
+// (in-app notification per admin + one email per admin), and a repeat degraded
+// tick fires nothing. Only admins are notified.
+func TestHealthMonitorTransitions(t *testing.T) {
+	requireDB(t)
+	resetDB(t)
+	writeFreshHeartbeat(t, time.Now()) // isolate the DB signal from backups
+
+	admin1, _ := createTestUser(t, "opsadmin1@example.com")
+	admin2, _ := createTestUser(t, "opsadmin2@example.com")
+	makeAdmin(t, admin1.ID)
+	makeAdmin(t, admin2.ID)
+	nonAdmin, _ := createTestUser(t, "regular@example.com")
+
+	mailbox := &fakeMailbox{}
+	dbUp := true
+	m := newTestMonitor(mailbox, true, &dbUp)
+	ctx := context.Background()
+	now := time.Now()
+
+	// Tick 1: healthy, starting state healthy => no transition, no alerts.
+	m.runOnce(ctx, now)
+	if c := opsNotifCount(t, admin1.ID, notificationTypeOpsAlert); c != 0 {
+		t.Fatalf("healthy tick alerted admin1: %d", c)
+	}
+	if mailbox.count() != 0 {
+		t.Fatalf("healthy tick emailed: %d", mailbox.count())
+	}
+
+	// Tick 2: DB goes down => degraded transition => one alert per admin + email.
+	dbUp = false
+	m.runOnce(ctx, now)
+	for _, a := range []uuid.UUID{admin1.ID, admin2.ID} {
+		if c := opsNotifCount(t, a, notificationTypeOpsAlert); c != 1 {
+			t.Fatalf("admin %s ops_alert count = %d, want 1", a, c)
+		}
+	}
+	if c := opsNotifCount(t, nonAdmin.ID, notificationTypeOpsAlert); c != 0 {
+		t.Fatalf("non-admin received ops_alert: %d", c)
+	}
+	if mailbox.count() != 2 {
+		t.Fatalf("degrade emails = %d, want 2 (one per admin)", mailbox.count())
+	}
+	// Payload carries degraded + reasons.
+	rows, _ := store.New(dbPool).ListNotificationsByUser(ctx,
+		store.ListNotificationsByUserParams{UserID: admin1.ID, Limit: 50})
+	var p map[string]any
+	_ = json.Unmarshal(rows[0].Payload, &p)
+	if p["degraded"] != true {
+		t.Fatalf("payload degraded = %v, want true", p["degraded"])
+	}
+
+	// Tick 3: still degraded => no transition => no new alerts/emails (dedup).
+	m.runOnce(ctx, now)
+	if c := opsNotifCount(t, admin1.ID, notificationTypeOpsAlert); c != 1 {
+		t.Fatalf("repeat degraded tick re-alerted: count = %d, want 1", c)
+	}
+	if mailbox.count() != 2 {
+		t.Fatalf("repeat degraded tick re-emailed: %d, want 2", mailbox.count())
+	}
+
+	// Tick 4: DB recovers => recovery transition => ops_recovered per admin + email.
+	dbUp = true
+	m.runOnce(ctx, now)
+	for _, a := range []uuid.UUID{admin1.ID, admin2.ID} {
+		if c := opsNotifCount(t, a, notificationTypeOpsRecovered); c != 1 {
+			t.Fatalf("admin %s ops_recovered count = %d, want 1", a, c)
+		}
+	}
+	if mailbox.count() != 4 {
+		t.Fatalf("recovery emails total = %d, want 4", mailbox.count())
+	}
+}
+
+// With SMTP unconfigured, a transition still writes in-app notifications but
+// sends no email (email is the only gated channel).
+func TestHealthMonitorNoEmailWhenUnconfigured(t *testing.T) {
+	requireDB(t)
+	resetDB(t)
+	writeFreshHeartbeat(t, time.Now())
+
+	admin, _ := createTestUser(t, "opsadmin@example.com")
+	makeAdmin(t, admin.ID)
+
+	mailbox := &fakeMailbox{}
+	dbUp := false // start degraded on first tick
+	m := newTestMonitor(mailbox, false /* email off */, &dbUp)
+
+	m.runOnce(context.Background(), time.Now())
+
+	if c := opsNotifCount(t, admin.ID, notificationTypeOpsAlert); c != 1 {
+		t.Fatalf("in-app ops_alert count = %d, want 1", c)
+	}
+	if mailbox.count() != 0 {
+		t.Fatalf("email sent while SMTP unconfigured: %d", mailbox.count())
+	}
+}

--- a/src/packages/api/query/users.sql
+++ b/src/packages/api/query/users.sql
@@ -37,3 +37,13 @@ RETURNING *;
 
 -- name: DeleteUser :execrows
 DELETE FROM users WHERE id = $1;
+
+-- name: ListAdminUsers :many
+-- All admin accounts (is_admin = true), for operational fan-out such as the
+-- ops-health degradation alert. Returns just what an alert needs: id + email +
+-- display name. Stable ordering by creation so the recipient list is
+-- deterministic.
+SELECT id, email, display_name
+FROM users
+WHERE is_admin = true
+ORDER BY created_at ASC;

--- a/src/packages/api/store/users.sql.go
+++ b/src/packages/api/store/users.sql.go
@@ -103,6 +103,43 @@ func (q *Queries) GetUserByID(ctx context.Context, id uuid.UUID) (User, error) {
 	return i, err
 }
 
+const listAdminUsers = `-- name: ListAdminUsers :many
+SELECT id, email, display_name
+FROM users
+WHERE is_admin = true
+ORDER BY created_at ASC
+`
+
+type ListAdminUsersRow struct {
+	ID          uuid.UUID `json:"id"`
+	Email       string    `json:"email"`
+	DisplayName *string   `json:"display_name"`
+}
+
+// All admin accounts (is_admin = true), for operational fan-out such as the
+// ops-health degradation alert. Returns just what an alert needs: id + email +
+// display name. Stable ordering by creation so the recipient list is
+// deterministic.
+func (q *Queries) ListAdminUsers(ctx context.Context) ([]ListAdminUsersRow, error) {
+	rows, err := q.db.Query(ctx, listAdminUsers)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListAdminUsersRow
+	for rows.Next() {
+		var i ListAdminUsersRow
+		if err := rows.Scan(&i.ID, &i.Email, &i.DisplayName); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const markUserEmailVerified = `-- name: MarkUserEmailVerified :exec
 UPDATE users SET email_verified_at = COALESCE(email_verified_at, now())
 WHERE id = $1


### PR DESCRIPTION
PR2 of the Observability wave: the health / alerting / backup side (PR1 added the ops metrics endpoint).

## Endpoint — `GET /api/v1/admin/ops/health`
Admin-gated, **no dbPool guard** (renders even when the DB is down — that is when operators need it). Returns a single `DependencyHealth` document:
- `db` — `{status: "ok"|"unreachable"|"not_configured", ping_ms}`
- `providers[]` — consolidated configured-state for google_places, anthropic, duffel, ticketmaster, email, google_oauth, transcription, sentry (each reuses that provider's own "configured" check)
- `build` — `{release, go_version, started_at, uptime_s}` (reuses PR1's `processStart`)
- `backups` — `{last_success_at, age_s, stale}` from the backup heartbeat file
- `degraded` + `reasons[]` (non-nil `[]`) — DB unreachable OR backups stale

Pure helpers (`providerStatuses`, `evalBackupHealth`, `computeHealthState`) are shared verbatim with the monitor so the endpoint and the alert loop can never disagree.

## Self-check monitor (`ops_monitor.go`)
Background ticker on the `startXChecker` template (`HEALTH_TICK_MINUTES`, default 5). Alerts on **healthy↔degraded transitions only** (in-memory dedup — a multi-hour outage fires one alert + one recovery). Each transition:
- `slog.Error` on degrade (→ Sentry via the slog tee) / `slog.Info` on recover
- an in-app notification per admin — `ops_alert` / `ops_recovered` — reusing the existing `notifications` table (**no migration**)
- an email per admin, **only when SMTP is configured**

`computeHealthState` is deterministic DB + backups only — it never pings paid providers. New `ListAdminUsers` sqlc query (regenerated, not hand-edited).

## Backups (`dockerize/production/`)
- `backup.sh` writes a `BACKUP_HEARTBEAT_FILE` freshness marker on every good local dump (before the best-effort off-site copy)
- committed systemd `goldentempo-backup.service` + `.timer` (daily ~04:10, `Persistent=true`) with an install README
- `restore-drill.sh` — non-destructive restore verification into a throwaway postgres (PASS/FAIL), `bash -n`-clean
- `make backup` target; `BACKUP_HEARTBEAT_FILE` + `BACKUP_STALE_HOURS` documented in `.env.sample`

## Tests
`providerStatuses`, `evalBackupHealth` (fresh/stale/missing), `computeHealthState` matrix, `buildOpsAlertEmail`, `opsHealthHandler` (DB-up + no-DB shape), and `runOnce` transition matrix (fires exactly once per transition, not on repeat ticks; email gated on SMTP; only admins notified). `go test ./...` passes (full suite green against a local test DB).

**No migration.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)