### PR TITLE
feat(api): resilience hardening — timeouts, panic guards, DB-blip 503 (Hardening PR1)

### DIFF
--- a/src/packages/api/accommodation_handler.go
+++ b/src/packages/api/accommodation_handler.go
@@ -184,7 +184,7 @@ func updateAccommodationHandler(w http.ResponseWriter, r *http.Request) {
 		if acc.Provider != nil {
 			meta["provider"] = *acc.Provider
 		}
-		go recordEvent(user.ID, "saved_booking_marked_booked", &tripID, meta)
+		safeGo("recordEvent", func() { recordEvent(user.ID, "saved_booking_marked_booked", &tripID, meta) })
 	}
 	_ = store.New(dbPool).TouchTrip(r.Context(), touchedBy(tripID, r))
 	writeJSON(w, http.StatusOK, toAccommodationResponse(acc))

--- a/src/packages/api/analytics.go
+++ b/src/packages/api/analytics.go
@@ -179,7 +179,7 @@ func recordClientEventHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	meta := sanitizeClientEventMetadata(req.Metadata)
-	go func() {
+	safeGo("recordClientEvent", func() {
 		// Best-effort trip validation off the response path: attach-rate
 		// counts DISTINCT trip_id, so a fabricated/foreign UUID must not be
 		// stored. A trip_id survives only when the trip exists and the caller
@@ -199,7 +199,7 @@ func recordClientEventHandler(w http.ResponseWriter, r *http.Request) {
 			cancel()
 		}
 		recordEvent(user.ID, req.EventType, tripID, meta)
-	}()
+	})
 	w.WriteHeader(http.StatusAccepted)
 }
 
@@ -228,7 +228,7 @@ func recordAnonymousClientEventHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	meta := sanitizeClientEventMetadata(req.Metadata)
-	go recordEventOpt(nil, req.EventType, nil, meta)
+	safeGo("recordEventOpt", func() { recordEventOpt(nil, req.EventType, nil, meta) })
 	w.WriteHeader(http.StatusAccepted)
 }
 

--- a/src/packages/api/auth_handler.go
+++ b/src/packages/api/auth_handler.go
@@ -97,22 +97,41 @@ func userFromContext(ctx context.Context) (store.User, bool) {
 }
 
 // userIDFromRequest resolves the bearer token to a user ID without failing the
-// request when absent/invalid. Used by endpoints that are open to anonymous
-// callers but persist data only when signed in (e.g. /plan).
-func userIDFromRequest(r *http.Request) (uuid.UUID, bool) {
+// request when the token is absent/invalid. Used by endpoints that are open to
+// anonymous callers but persist data only when signed in (e.g. /plan).
+//
+// The third return value is a DB-availability error: when a token WAS presented
+// but the session lookup failed because the database is unreachable, it returns
+// (zero, false, errDBUnavailable) so the caller can answer "temporarily
+// unavailable" instead of silently downgrading an authenticated user to
+// anonymous (which would drop their personalization and persistence on a blip).
+// Genuinely-absent/expired sessions still return (zero, false, nil) — anonymous.
+func userIDFromRequest(r *http.Request) (uuid.UUID, bool, error) {
 	if dbPool == nil {
-		return uuid.UUID{}, false
+		return uuid.UUID{}, false, nil
 	}
 	token := bearerToken(r)
 	if token == "" {
-		return uuid.UUID{}, false
+		return uuid.UUID{}, false, nil
 	}
 	row, err := store.New(dbPool).GetSessionWithUser(r.Context(), token)
-	if err != nil || row.Session.ExpiresAt.Before(time.Now()) {
-		return uuid.UUID{}, false
+	if err != nil {
+		if dbErrorStatus(err) == http.StatusServiceUnavailable {
+			ctxLog(r.Context()).Error("auth: session lookup failed (db)", "error", err)
+			return uuid.UUID{}, false, errDBUnavailable
+		}
+		return uuid.UUID{}, false, nil // absent/expired session -> anonymous
 	}
-	return row.User.ID, true
+	if row.Session.ExpiresAt.Before(time.Now()) {
+		return uuid.UUID{}, false, nil
+	}
+	return row.User.ID, true, nil
 }
+
+// errDBUnavailable signals that a request could not be resolved because the
+// database was temporarily unreachable — the caller should return 503, not
+// treat the request as anonymous or unauthenticated.
+var errDBUnavailable = errors.New("database temporarily unavailable")
 
 // authMiddleware resolves the bearer token to a user and rejects unauthenticated
 // requests with 401. Wrap only the routes that require authentication.
@@ -129,7 +148,27 @@ func authMiddleware(next http.Handler) http.Handler {
 		}
 		q := store.New(dbPool)
 		row, err := q.GetSessionWithUser(r.Context(), token)
-		if err != nil || row.Session.ExpiresAt.Before(time.Now()) {
+		if err != nil {
+			// A DB-connection failure (Postgres restarting, pool closed, conn
+			// refused) must NOT masquerade as an invalid session — that logs
+			// every user out on a transient blip. Answer 503 (retryable) and
+			// keep 401 strictly for a genuinely absent/expired session.
+			if dbErrorStatus(err) == http.StatusServiceUnavailable {
+				ctxLog(r.Context()).Error("auth: session lookup failed (db)", "error", err)
+				writeJSONError(w, http.StatusServiceUnavailable, "service temporarily unavailable")
+				return
+			}
+			if errors.Is(err, pgx.ErrNoRows) {
+				writeJSONError(w, http.StatusUnauthorized, "invalid or expired session")
+				return
+			}
+			// Unexpected non-connection error: log and 500 rather than silently
+			// rejecting a possibly-valid session as unauthorized.
+			ctxLog(r.Context()).Error("auth: unexpected session lookup error", "error", err)
+			writeJSONError(w, http.StatusInternalServerError, "internal error")
+			return
+		}
+		if row.Session.ExpiresAt.Before(time.Now()) {
 			writeJSONError(w, http.StatusUnauthorized, "invalid or expired session")
 			return
 		}
@@ -217,8 +256,8 @@ func registerHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	// Fire-and-forget, like the profile distiller: registration never blocks
 	// or fails on email delivery or analytics.
-	go sendVerificationEmail(user)
-	go recordEvent(user.ID, "user_registered", nil, nil)
+	safeGo("sendVerificationEmail", func() { sendVerificationEmail(user) })
+	safeGo("recordEvent", func() { recordEvent(user.ID, "user_registered", nil, nil) })
 	writeJSON(w, http.StatusCreated, AuthResponse{User: toUserResponse(user), Token: session.ID})
 }
 
@@ -287,6 +326,6 @@ func completeOnboardingHandler(w http.ResponseWriter, r *http.Request) {
 		writeJSONError(w, http.StatusInternalServerError, "could not complete onboarding")
 		return
 	}
-	go recordEvent(user.ID, "onboarding_completed", nil, nil)
+	safeGo("recordEvent", func() { recordEvent(user.ID, "onboarding_completed", nil, nil) })
 	writeJSON(w, http.StatusOK, toUserResponse(updated))
 }

--- a/src/packages/api/booking_todo_handler.go
+++ b/src/packages/api/booking_todo_handler.go
@@ -397,7 +397,7 @@ func patchBookingTodoHandler(w http.ResponseWriter, r *http.Request) {
 		if todo.Provider != nil {
 			meta["provider"] = *todo.Provider
 		}
-		go recordEvent(user.ID, "booking_marked_booked", &tripID, meta)
+		safeGo("recordEvent", func() { recordEvent(user.ID, "booking_marked_booked", &tripID, meta) })
 	}
 	_ = store.New(dbPool).TouchTrip(r.Context(), touchedBy(tripID, r))
 	writeJSON(w, http.StatusOK, toBookingTodoResponse(todo))

--- a/src/packages/api/collaborator_handler.go
+++ b/src/packages/api/collaborator_handler.go
@@ -91,9 +91,11 @@ func joinSharedTripHandler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		access = role
-		go recordEvent(user.ID, "collaborator_joined", &trip.ID, map[string]any{
-			"owner_id": share.OwnerID.String(),
-			"role":     role,
+		safeGo("recordEvent", func() {
+			recordEvent(user.ID, "collaborator_joined", &trip.ID, map[string]any{
+				"owner_id": share.OwnerID.String(),
+				"role":     role,
+			})
 		})
 	}
 	writeJSON(w, http.StatusOK, JoinSharedTripResponse{TripID: trip.ID.String(), Access: access})
@@ -159,7 +161,7 @@ func removeCollaboratorHandler(w http.ResponseWriter, r *http.Request) {
 			writeJSONError(w, http.StatusNotFound, "trip not found")
 			return
 		}
-		go recordEvent(user.ID, "collaborator_left", &row.ID, nil)
+		safeGo("recordEvent", func() { recordEvent(user.ID, "collaborator_left", &row.ID, nil) })
 		w.WriteHeader(http.StatusNoContent)
 		return
 	}
@@ -189,8 +191,10 @@ func removeCollaboratorHandler(w http.ResponseWriter, r *http.Request) {
 		writeJSONError(w, http.StatusNotFound, "co-planner not found")
 		return
 	}
-	go recordEvent(user.ID, "collaborator_removed", &trip.ID, map[string]any{
-		"collaborator_id": collabID.String(),
+	safeGo("recordEvent", func() {
+		recordEvent(user.ID, "collaborator_removed", &trip.ID, map[string]any{
+			"collaborator_id": collabID.String(),
+		})
 	})
 	w.WriteHeader(http.StatusNoContent)
 }

--- a/src/packages/api/db.go
+++ b/src/packages/api/db.go
@@ -4,11 +4,17 @@ import (
 	"context"
 	"database/sql"
 	"embed"
+	"errors"
 	"fmt"
+	"net"
+	"net/http"
 	"time"
 
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 	_ "github.com/jackc/pgx/v5/stdlib" // registers the "pgx" database/sql driver for goose
+	"github.com/jackc/puddle/v2"
 	"github.com/pressly/goose/v3"
 )
 
@@ -26,8 +32,26 @@ func initDB(ctx context.Context, databaseURL string) (*pgxpool.Pool, error) {
 	if err != nil {
 		return nil, fmt.Errorf("parse DATABASE_URL: %w", err)
 	}
+	// Pool sizing/liveness tuned for a small single-host (Raspberry Pi)
+	// deployment: keep the pool modest, recycle connections so a Postgres
+	// restart doesn't leave the pool holding dead sockets, and reap idle
+	// connections. HealthCheckPeriod actively pings idle conns so a mid-idle
+	// server restart is noticed and the conn replaced before a request grabs it.
 	cfg.MaxConns = 10
+	cfg.MinConns = 0
 	cfg.ConnConfig.ConnectTimeout = 5 * time.Second
+	cfg.HealthCheckPeriod = 30 * time.Second
+	cfg.MaxConnLifetime = 1 * time.Hour
+	cfg.MaxConnIdleTime = 5 * time.Minute
+
+	// Server-side statement timeout: cap any single query at 15s so a runaway
+	// or lock-blocked statement can't pin a connection (and the caller's
+	// request) indefinitely. Applied per-connection via a Postgres session
+	// GUC, so it covers every query including sqlc-generated ones.
+	if cfg.ConnConfig.RuntimeParams == nil {
+		cfg.ConnConfig.RuntimeParams = map[string]string{}
+	}
+	cfg.ConnConfig.RuntimeParams["statement_timeout"] = "15000" // milliseconds
 
 	pool, err := pgxpool.NewWithConfig(ctx, cfg)
 	if err != nil {
@@ -71,4 +95,51 @@ func pingDB(ctx context.Context) bool {
 	pingCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
 	defer cancel()
 	return dbPool.Ping(pingCtx) == nil
+}
+
+// dbErrorStatus classifies a database error into the HTTP status a handler
+// should surface. It exists so a transient DB outage (Postgres restarting, the
+// pool being closed, a connection refused/reset) is treated as a RETRYABLE
+// 503 — "service temporarily unavailable" — instead of leaking out as a 401
+// (logging every user out on a blip) or a bare 500.
+//
+//   - 503: connection-level failure. The query never reached a live server.
+//     Detected via pgconn.SafeToRetry (true only when the error occurred
+//     before any bytes were sent), a closed pool, or any net error in the
+//     chain. These are the "come back in a moment" cases.
+//   - 0:   pgx.ErrNoRows — not an outage at all, just an absent row. The
+//     caller decides what a missing row means (401/404/etc).
+//   - 500: everything else, including a *pgconn.PgError (the server DID
+//     respond, with an error code — the connection is alive, so this is a
+//     server-side/logic error, not a transient blip). Also covers nil, which
+//     no caller should pass but which maps to "not a DB problem".
+func dbErrorStatus(err error) int {
+	if err == nil {
+		return 0
+	}
+	if errors.Is(err, pgx.ErrNoRows) {
+		return 0
+	}
+	// A PgError means Postgres received the statement and answered with an
+	// SQLSTATE — the connection is healthy, so this is not a blip.
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) {
+		return http.StatusInternalServerError
+	}
+	// Connection never delivered the query: refused/reset/dead-on-acquire.
+	if pgconn.SafeToRetry(err) {
+		return http.StatusServiceUnavailable
+	}
+	if errors.Is(err, puddle.ErrClosedPool) || errors.Is(err, puddle.ErrNotAvailable) {
+		return http.StatusServiceUnavailable
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		return http.StatusServiceUnavailable
+	}
+	var opErr *net.OpError
+	if errors.As(err, &opErr) {
+		return http.StatusServiceUnavailable
+	}
+	return http.StatusInternalServerError
 }

--- a/src/packages/api/email_auth_handler.go
+++ b/src/packages/api/email_auth_handler.go
@@ -112,7 +112,7 @@ func requestVerificationHandler(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusOK, map[string]string{"status": "already verified"})
 		return
 	}
-	go sendVerificationEmail(user)
+	safeGo("sendVerificationEmail", func() { sendVerificationEmail(user) })
 	w.WriteHeader(http.StatusAccepted)
 }
 
@@ -196,7 +196,8 @@ func requestPasswordResetHandler(w http.ResponseWriter, r *http.Request) {
 	q := store.New(dbPool)
 	user, err := q.GetUserByEmail(r.Context(), email)
 	if err == nil {
-		go func(u store.User) {
+		u := user
+		safeGo("sendPasswordResetEmail", func() {
 			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 			defer cancel()
 			token, err := issueEmailToken(ctx, store.New(dbPool), u, "reset", resetTokenTTL)
@@ -212,7 +213,7 @@ func requestPasswordResetHandler(w http.ResponseWriter, r *http.Request) {
 			if err := emailService.Send(u.Email, "Reset your password — Golden Tempo Travel", body); err != nil {
 				log.Printf("password reset: send to %s failed: %v", u.Email, err)
 			}
-		}(user)
+		})
 	} else if !errors.Is(err, pgx.ErrNoRows) {
 		log.Printf("password reset: lookup failed for %s: %v", email, err)
 	}

--- a/src/packages/api/flight_baggage.go
+++ b/src/packages/api/flight_baggage.go
@@ -91,7 +91,8 @@ func fetchBagFees(ctx context.Context, d *DuffelService, offers []FlightOffer, i
 	sem := make(chan struct{}, bagFeeConcurrency)
 	for _, i := range indexes {
 		wg.Add(1)
-		go func(o *FlightOffer) {
+		o := &offers[i]
+		safeGo("flight bag fee lookup", func() {
 			defer wg.Done()
 			select {
 			case sem <- struct{}{}:
@@ -112,7 +113,7 @@ func fetchBagFees(ctx context.Context, d *DuffelService, offers []FlightOffer, i
 			o.BaggageStatus = baggageStatusPaid
 			o.BagFee = fee
 			o.EffectivePrice = o.Price + fee
-		}(&offers[i])
+		})
 	}
 	wg.Wait()
 }

--- a/src/packages/api/go.mod
+++ b/src/packages/api/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/mux v1.8.0
 	github.com/jackc/pgx/v5 v5.9.2
+	github.com/jackc/puddle/v2 v2.2.2
 	github.com/pressly/goose/v3 v3.27.1
 	golang.org/x/crypto v0.50.0
 	golang.org/x/time v0.15.0
@@ -28,7 +29,6 @@ require (
 	github.com/invopop/jsonschema v0.13.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
-	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mfridman/interpolate v0.0.2 // indirect

--- a/src/packages/api/google_auth_handler.go
+++ b/src/packages/api/google_auth_handler.go
@@ -165,7 +165,7 @@ func findOrCreateGoogleUser(r *http.Request, claims googleClaims) (store.User, e
 		if err != nil {
 			return store.User{}, err
 		}
-		go recordEvent(user.ID, "user_registered", nil, map[string]any{"method": "google"})
+		safeGo("recordEvent", func() { recordEvent(user.ID, "user_registered", nil, map[string]any{"method": "google"}) })
 	} else if err != nil {
 		return store.User{}, err
 	}

--- a/src/packages/api/invite_handler.go
+++ b/src/packages/api/invite_handler.go
@@ -122,8 +122,8 @@ func createTripInviteHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	// Fire-and-forget like sendVerificationEmail; degraded SMTP logs the
 	// body, and a send failure never fails the request.
-	go sendInviteEmail(user, invite.Email, token, trip.Title)
-	go recordEvent(user.ID, "invite_sent", &trip.ID, nil)
+	safeGo("sendInviteEmail", func() { sendInviteEmail(user, invite.Email, token, trip.Title) })
+	safeGo("recordEvent", func() { recordEvent(user.ID, "invite_sent", &trip.ID, nil) })
 	writeJSON(w, http.StatusCreated, toInviteResponse(invite))
 }
 
@@ -192,7 +192,7 @@ func revokeTripInviteHandler(w http.ResponseWriter, r *http.Request) {
 		writeJSONError(w, http.StatusNotFound, "invite not found")
 		return
 	}
-	go recordEvent(user.ID, "invite_revoked", nil, nil)
+	safeGo("recordEvent", func() { recordEvent(user.ID, "invite_revoked", nil, nil) })
 	w.WriteHeader(http.StatusNoContent)
 }
 
@@ -298,11 +298,13 @@ func acceptInviteHandler(w http.ResponseWriter, r *http.Request) {
 		writeJSONError(w, http.StatusInternalServerError, "could not join trip")
 		return
 	}
-	go recordEvent(user.ID, "invite_accepted", &trip.ID, map[string]any{
-		"owner_id": invite.OwnerID.String(),
+	safeGo("recordEvent", func() {
+		recordEvent(user.ID, "invite_accepted", &trip.ID, map[string]any{
+			"owner_id": invite.OwnerID.String(),
+		})
 	})
 	// Tell the owner their invite was redeemed (in-app only; one-time event, no
 	// throttle). Best-effort, like the analytics write above.
-	go notifyInviteAccepted(invite.OwnerID, user, trip)
+	safeGo("notifyInviteAccepted", func() { notifyInviteAccepted(invite.OwnerID, user, trip) })
 	writeJSON(w, http.StatusOK, JoinSharedTripResponse{TripID: trip.ID.String(), Access: "editor"})
 }

--- a/src/packages/api/local_ingest_handler.go
+++ b/src/packages/api/local_ingest_handler.go
@@ -144,7 +144,10 @@ func ingestLocalHandler(w http.ResponseWriter, r *http.Request) {
 	client := newAnthropicClient(apiKey)
 	content, err := extractLocalContent(r.Context(), client, city, req.RawText)
 	if err != nil {
-		writeJSONError(w, http.StatusBadGateway, "extraction failed: "+err.Error())
+		// Provider/internal detail stays in the server log (tees to Sentry);
+		// the client gets a generic message.
+		ctxLog(r.Context()).Error("local ingest: extraction failed", "error", err, "city", city)
+		writeJSONError(w, http.StatusBadGateway, "extraction failed")
 		return
 	}
 
@@ -171,7 +174,7 @@ func ingestLocalHandler(w http.ResponseWriter, r *http.Request) {
 		}
 		// Anti-hallucination: resolve the place on Google. Unmatched pins are kept
 		// as unverified drafts (curator can fix the name) — never silently dropped.
-		if hits, perr := places.SearchPlaces(placeQuery(rec.SearchHint, name, city)); perr == nil && len(hits) > 0 {
+		if hits, perr := places.SearchPlaces(r.Context(), placeQuery(rec.SearchHint, name, city)); perr == nil && len(hits) > 0 {
 			hit := hits[0]
 			params.PlaceID = strPtrOrNil(hit.PlaceID)
 			params.Address = strPtrOrNil(hit.Address)

--- a/src/packages/api/main.go
+++ b/src/packages/api/main.go
@@ -107,10 +107,12 @@ func optimizeRouteHandler(w http.ResponseWriter, r *http.Request) {
 
 	// Parse JSON request body
 	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+		// Parse detail (which can echo raw request bytes) goes to the log only.
+		ctxLog(r.Context()).Error("invalid JSON request body", "error", err)
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusBadRequest)
 		json.NewEncoder(w).Encode(Response{
-			Message: fmt.Sprintf("Invalid JSON: %v", err),
+			Message: "Invalid JSON in request body",
 			Status:  "error",
 		})
 		return
@@ -184,7 +186,7 @@ func optimizeRouteHandler(w http.ResponseWriter, r *http.Request) {
 
 	// Create optimizer and process request
 	optimizer := NewRouteOptimizer(request.Locations)
-	result := optimizer.OptimizeRoute(request)
+	result := optimizer.OptimizeRoute(r.Context(), request)
 
 	// Return result
 	w.Header().Set("Content-Type", "application/json")
@@ -202,7 +204,7 @@ func placesSearchHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	results, err := placesService.SearchPlaces(query)
+	results, err := placesService.SearchPlaces(r.Context(), query)
 	if err != nil {
 		// Detail goes to the server log only: provider/internal error strings
 		// must never reach an unauthenticated caller.
@@ -227,7 +229,7 @@ func placesAutocompleteHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	results, err := placesService.GetPlaceAutocomplete(input)
+	results, err := placesService.GetPlaceAutocomplete(r.Context(), input)
 	if err != nil {
 		ctxLog(r.Context()).Error("places autocomplete failed", "error", err)
 		http.Error(w, "Failed to get autocomplete", http.StatusInternalServerError)
@@ -250,7 +252,7 @@ func placesDetailsHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	result, err := placesService.GetPlaceDetails(placeID)
+	result, err := placesService.GetPlaceDetails(r.Context(), placeID)
 	if err != nil {
 		ctxLog(r.Context()).Error("place details failed", "error", err)
 		http.Error(w, "Failed to get place details", http.StatusInternalServerError)
@@ -325,10 +327,12 @@ func flightsSearchHandler(w http.ResponseWriter, r *http.Request) {
 	var request FlightSearchRequest
 
 	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+		// Parse detail (which can echo raw request bytes) goes to the log only.
+		ctxLog(r.Context()).Error("invalid JSON request body", "error", err)
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusBadRequest)
 		json.NewEncoder(w).Encode(Response{
-			Message: fmt.Sprintf("Invalid JSON: %v", err),
+			Message: "Invalid JSON in request body",
 			Status:  "error",
 		})
 		return
@@ -422,8 +426,9 @@ func airbnbParseHandler(w http.ResponseWriter, r *http.Request) {
 	var req AirbnbParseRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		w.Header().Set("Content-Type", "application/json")
+		ctxLog(r.Context()).Error("invalid JSON request body", "error", err)
 		w.WriteHeader(http.StatusBadRequest)
-		json.NewEncoder(w).Encode(Response{Message: fmt.Sprintf("Invalid JSON: %v", err), Status: "error"})
+		json.NewEncoder(w).Encode(Response{Message: "Invalid JSON in request body", Status: "error"})
 		return
 	}
 	if req.URL == "" {
@@ -452,8 +457,9 @@ func airbnbDebugHandler(w http.ResponseWriter, r *http.Request) {
 	var req AirbnbParseRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		w.Header().Set("Content-Type", "application/json")
+		ctxLog(r.Context()).Error("invalid JSON request body", "error", err)
 		w.WriteHeader(http.StatusBadRequest)
-		json.NewEncoder(w).Encode(Response{Message: fmt.Sprintf("Invalid JSON: %v", err), Status: "error"})
+		json.NewEncoder(w).Encode(Response{Message: "Invalid JSON in request body", Status: "error"})
 		return
 	}
 	if req.URL == "" {

--- a/src/packages/api/ops_monitor.go
+++ b/src/packages/api/ops_monitor.go
@@ -92,7 +92,9 @@ func (m *healthMonitor) run(ctx context.Context) {
 	ticker := time.NewTicker(m.interval)
 	defer ticker.Stop()
 	for {
-		m.runOnce(ctx, time.Now())
+		// Guard each tick: a panic in one cycle must not kill the ticker (and
+		// with it the whole process). Log-and-continue to the next tick.
+		safeRun("health monitor tick", func() { m.runOnce(ctx, time.Now()) })
 		select {
 		case <-ctx.Done():
 			return

--- a/src/packages/api/places_service.go
+++ b/src/packages/api/places_service.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -11,6 +12,14 @@ import (
 	"strings"
 	"sync/atomic"
 	"time"
+)
+
+// Google Places API base URLs. Package vars (not consts) so tests can point the
+// client at an httptest server — matching the seam other provider services use.
+var (
+	placesTextSearchURL   = "https://maps.googleapis.com/maps/api/place/textsearch/json"
+	placesAutocompleteURL = "https://maps.googleapis.com/maps/api/place/autocomplete/json"
+	placesDetailsURL      = "https://maps.googleapis.com/maps/api/place/details/json"
 )
 
 // upstreamCallCounters tracks billable upstream calls vs cache hits for one
@@ -125,12 +134,28 @@ func NewGooglePlacesService() *GooglePlacesService {
 	}
 
 	return &GooglePlacesService{
-		APIKey:            apiKey,
-		Client:            &http.Client{},
+		APIKey: apiKey,
+		// An explicit timeout is essential: SearchPlaces/GetPlaceDetails run
+		// synchronously inside the /plan agent loop, so a hung Google socket
+		// with a zero-value (no-timeout) client would stall the whole SSE
+		// stream forever. This is a hard backstop on top of the per-call
+		// context deadline threaded through each method.
+		Client:            &http.Client{Timeout: 15 * time.Second},
 		searchCache:       newTTLCache[[]PlaceSearchResult](1*time.Hour, 2000),
 		autocompleteCache: newTTLCache[[]PlaceAutocompleteResult](24*time.Hour, 5000),
 		detailsCache:      newTTLCache[*PlaceDetailsResult](24*time.Hour, 5000),
 	}
+}
+
+// doGet issues a context-aware GET so the caller's deadline/cancellation aborts
+// a slow Google call. Paired with the client's Timeout, this guarantees a
+// Places lookup can never block the synchronous /plan agent loop indefinitely.
+func (gps *GooglePlacesService) doGet(ctx context.Context, fullURL string) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fullURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	return gps.Client.Do(req)
 }
 
 // placesService is a process-wide singleton reused across requests, matching
@@ -141,8 +166,11 @@ func NewGooglePlacesService() *GooglePlacesService {
 // so degraded mode keeps working.
 var placesService = NewGooglePlacesService()
 
-// SearchPlaces searches for places by text query
-func (gps *GooglePlacesService) SearchPlaces(query string) ([]PlaceSearchResult, error) {
+// SearchPlaces searches for places by text query. The context bounds the
+// upstream HTTP call so a caller cancelling (or a request deadline) aborts a
+// slow Google lookup instead of blocking — critical on the synchronous /plan
+// agent path.
+func (gps *GooglePlacesService) SearchPlaces(ctx context.Context, query string) ([]PlaceSearchResult, error) {
 	if gps.APIKey == "" {
 		return nil, fmt.Errorf("Google Places API key not configured")
 	}
@@ -154,13 +182,12 @@ func (gps *GooglePlacesService) SearchPlaces(query string) ([]PlaceSearchResult,
 	}
 
 	// Use Text Search API
-	baseURL := "https://maps.googleapis.com/maps/api/place/textsearch/json"
 	params := url.Values{}
 	params.Add("query", query)
 	params.Add("key", gps.APIKey)
 
 	gps.searchCalls.upstream.Add(1)
-	resp, err := gps.Client.Get(baseURL + "?" + params.Encode())
+	resp, err := gps.doGet(ctx, placesTextSearchURL+"?"+params.Encode())
 	if err != nil {
 		return nil, fmt.Errorf("failed to search places: %w", redactTransportError(err))
 	}
@@ -216,7 +243,7 @@ func (gps *GooglePlacesService) SearchPlaces(query string) ([]PlaceSearchResult,
 }
 
 // GetPlaceAutocomplete gets autocomplete suggestions for a query
-func (gps *GooglePlacesService) GetPlaceAutocomplete(input string) ([]PlaceAutocompleteResult, error) {
+func (gps *GooglePlacesService) GetPlaceAutocomplete(ctx context.Context, input string) ([]PlaceAutocompleteResult, error) {
 	if gps.APIKey == "" {
 		return nil, fmt.Errorf("Google Places API key not configured")
 	}
@@ -227,13 +254,12 @@ func (gps *GooglePlacesService) GetPlaceAutocomplete(input string) ([]PlaceAutoc
 		return cached, nil
 	}
 
-	baseURL := "https://maps.googleapis.com/maps/api/place/autocomplete/json"
 	params := url.Values{}
 	params.Add("input", input)
 	params.Add("key", gps.APIKey)
 
 	gps.autocompleteCalls.upstream.Add(1)
-	resp, err := gps.Client.Get(baseURL + "?" + params.Encode())
+	resp, err := gps.doGet(ctx, placesAutocompleteURL+"?"+params.Encode())
 	if err != nil {
 		return nil, fmt.Errorf("failed to get autocomplete: %w", redactTransportError(err))
 	}
@@ -275,7 +301,7 @@ func (gps *GooglePlacesService) GetPlaceAutocomplete(input string) ([]PlaceAutoc
 }
 
 // GetPlaceDetails gets detailed information about a place by Place ID
-func (gps *GooglePlacesService) GetPlaceDetails(placeID string) (*PlaceDetailsResult, error) {
+func (gps *GooglePlacesService) GetPlaceDetails(ctx context.Context, placeID string) (*PlaceDetailsResult, error) {
 	if gps.APIKey == "" {
 		return nil, fmt.Errorf("Google Places API key not configured")
 	}
@@ -285,14 +311,13 @@ func (gps *GooglePlacesService) GetPlaceDetails(placeID string) (*PlaceDetailsRe
 		return cached, nil
 	}
 
-	baseURL := "https://maps.googleapis.com/maps/api/place/details/json"
 	params := url.Values{}
 	params.Add("place_id", placeID)
 	params.Add("fields", "place_id,name,formatted_address,geometry,types,rating,price_level,opening_hours,website,formatted_phone_number")
 	params.Add("key", gps.APIKey)
 
 	gps.detailsCalls.upstream.Add(1)
-	resp, err := gps.Client.Get(baseURL + "?" + params.Encode())
+	resp, err := gps.doGet(ctx, placesDetailsURL+"?"+params.Encode())
 	if err != nil {
 		return nil, fmt.Errorf("failed to get place details: %w", redactTransportError(err))
 	}

--- a/src/packages/api/places_service_test.go
+++ b/src/packages/api/places_service_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -36,12 +37,12 @@ func TestSearchPlacesServedFromCache(t *testing.T) {
 	svc.APIKey = "test-key"
 	svc.Client = &http.Client{Transport: rt}
 
-	first, err := svc.SearchPlaces("Louvre Museum Paris")
+	first, err := svc.SearchPlaces(context.Background(), "Louvre Museum Paris")
 	if err != nil {
 		t.Fatalf("first search failed: %v", err)
 	}
 	// Same query modulo case/whitespace must hit the cache, not Google.
-	second, err := svc.SearchPlaces("  louvre museum paris ")
+	second, err := svc.SearchPlaces(context.Background(), "  louvre museum paris ")
 	if err != nil {
 		t.Fatalf("second search failed: %v", err)
 	}
@@ -69,10 +70,10 @@ func TestGetPlaceDetailsServedFromCache(t *testing.T) {
 	svc.APIKey = "test-key"
 	svc.Client = &http.Client{Transport: rt}
 
-	if _, err := svc.GetPlaceDetails("p1"); err != nil {
+	if _, err := svc.GetPlaceDetails(context.Background(), "p1"); err != nil {
 		t.Fatalf("first details call failed: %v", err)
 	}
-	got, err := svc.GetPlaceDetails("p1")
+	got, err := svc.GetPlaceDetails(context.Background(), "p1")
 	if err != nil {
 		t.Fatalf("second details call failed: %v", err)
 	}
@@ -95,10 +96,10 @@ func TestAutocompleteCountersTrackMissAndHit(t *testing.T) {
 	svc.APIKey = "test-key"
 	svc.Client = &http.Client{Transport: rt}
 
-	if _, err := svc.GetPlaceAutocomplete("louvre"); err != nil {
+	if _, err := svc.GetPlaceAutocomplete(context.Background(), "louvre"); err != nil {
 		t.Fatalf("first autocomplete failed: %v", err)
 	}
-	if _, err := svc.GetPlaceAutocomplete(" LOUVRE "); err != nil {
+	if _, err := svc.GetPlaceAutocomplete(context.Background(), " LOUVRE "); err != nil {
 		t.Fatalf("second autocomplete failed: %v", err)
 	}
 	if rt.calls != 1 {
@@ -138,13 +139,13 @@ func TestPlacesServiceSingletonSafeWithoutKey(t *testing.T) {
 
 	svc := NewGooglePlacesService()
 	svc.APIKey = ""
-	if _, err := svc.SearchPlaces("anything"); err == nil || !strings.Contains(err.Error(), "not configured") {
+	if _, err := svc.SearchPlaces(context.Background(), "anything"); err == nil || !strings.Contains(err.Error(), "not configured") {
 		t.Fatalf("SearchPlaces without key: err = %v, want not-configured error", err)
 	}
-	if _, err := svc.GetPlaceAutocomplete("any"); err == nil {
+	if _, err := svc.GetPlaceAutocomplete(context.Background(), "any"); err == nil {
 		t.Fatal("GetPlaceAutocomplete without key must error")
 	}
-	if _, err := svc.GetPlaceDetails("p1"); err == nil {
+	if _, err := svc.GetPlaceDetails(context.Background(), "p1"); err == nil {
 		t.Fatal("GetPlaceDetails without key must error")
 	}
 }
@@ -174,9 +175,9 @@ func TestPlacesTransportErrorsOmitAPIKey(t *testing.T) {
 		name string
 		call func() error
 	}{
-		{"SearchPlaces", func() error { _, err := svc.SearchPlaces("louvre"); return err }},
-		{"GetPlaceAutocomplete", func() error { _, err := svc.GetPlaceAutocomplete("lou"); return err }},
-		{"GetPlaceDetails", func() error { _, err := svc.GetPlaceDetails("p1"); return err }},
+		{"SearchPlaces", func() error { _, err := svc.SearchPlaces(context.Background(), "louvre"); return err }},
+		{"GetPlaceAutocomplete", func() error { _, err := svc.GetPlaceAutocomplete(context.Background(), "lou"); return err }},
+		{"GetPlaceDetails", func() error { _, err := svc.GetPlaceDetails(context.Background(), "p1"); return err }},
 	}
 	for _, c := range calls {
 		err := c.call()

--- a/src/packages/api/plan_connectivity.go
+++ b/src/packages/api/plan_connectivity.go
@@ -224,7 +224,8 @@ func fetchConnectivity(ctx context.Context, legs []connLeg) map[connLeg]connLegR
 			continue
 		}
 		wg.Add(1)
-		go func(leg connLeg) {
+		leg := leg
+		safeGo("connectivity leg lookup", func() {
 			defer wg.Done()
 			select {
 			case sem <- struct{}{}:
@@ -253,7 +254,7 @@ func fetchConnectivity(ctx context.Context, legs []connLeg) map[connLeg]connLegR
 			mu.Lock()
 			results[leg] = res
 			mu.Unlock()
-		}(leg)
+		})
 	}
 	wg.Wait()
 	return results

--- a/src/packages/api/plan_handler.go
+++ b/src/packages/api/plan_handler.go
@@ -23,6 +23,13 @@ import (
 // ends the stream gracefully instead of letting a pathological loop burn cost.
 const planMaxIterations = 15
 
+// planModelCallTimeout bounds a single streaming model call. The handler's own
+// context is r.Context() (no server WriteTimeout, since SSE needs unlimited),
+// so without this a hung/slow upstream Anthropic socket would stall the agent
+// loop — and the client's SSE stream — indefinitely. Each call gets its own
+// deadline; exceeding it surfaces as a friendly SSE error, not a hang.
+const planModelCallTimeout = 120 * time.Second
+
 // planMaxMessages / planMaxMessageChars bound the resent conversation history.
 // Every agent-loop iteration (up to planMaxIterations) re-pays input tokens on
 // the full history, so these bounds are a hard cost lever. The working limit
@@ -162,7 +169,14 @@ func planHandler(w http.ResponseWriter, r *http.Request) {
 
 	// Resolve the caller once: anonymous sessions get no personalization and no
 	// preference-writing tool; signed-in sessions get both.
-	uid, authed := userIDFromRequest(r)
+	uid, authed, uerr := userIDFromRequest(r)
+	if uerr != nil {
+		// A token was presented but the DB was unreachable — don't silently
+		// downgrade to anonymous (losing personalization + persistence). Ask
+		// the client to retry rather than proceeding half-authenticated.
+		sendSSE(w, "error", map[string]string{"message": "The service is temporarily unavailable. Please try again in a moment."})
+		return
+	}
 	ctx := r.Context()
 
 	// Snapshot the wire history as the client sent it, BEFORE the compaction
@@ -227,7 +241,7 @@ func planHandler(w http.ResponseWriter, r *http.Request) {
 	// Also runs the free-cap plan_runs crossing check (free_cap.go) — one
 	// count query, entirely off the SSE hot path, skipped when unauthed or
 	// degraded.
-	go recordPlanSessionStart(planUID, authed)
+	safeGo("recordPlanSessionStart", func() { recordPlanSessionStart(planUID, authed) })
 	defer func() {
 		recordEventOpt(planUID, "plan_session_completed", session.tripID, map[string]any{
 			"authenticated":         authed,
@@ -379,7 +393,8 @@ func planHandler(w http.ResponseWriter, r *http.Request) {
 			Messages: messages,
 		}
 
-		stream := client.Messages.NewStreaming(ctx, params)
+		callCtx, cancelCall := context.WithTimeout(ctx, planModelCallTimeout)
+		stream := client.Messages.NewStreaming(callCtx, params)
 		resp := anthropic.Message{}
 
 		for stream.Next() {
@@ -393,8 +408,14 @@ func planHandler(w http.ResponseWriter, r *http.Request) {
 				}
 			}
 		}
-		if err := stream.Err(); err != nil {
-			sendSSE(w, "error", map[string]string{"message": err.Error()})
+		streamErr := stream.Err()
+		cancelCall() // the deadline only needs to cover the streaming call above
+		if streamErr != nil {
+			// Redact: the raw Anthropic/transport error can carry internal
+			// detail and is unhelpful to the user. Log it server-side (tees to
+			// Sentry via slog) and send a generic, friendly message.
+			ctxLog(ctx).Error("plan: anthropic stream error", "error", streamErr)
+			sendSSE(w, "error", map[string]string{"message": "The planner hit a problem reaching the AI service. Please try again in a moment."})
 			return
 		}
 		planTokensIn += resp.Usage.InputTokens

--- a/src/packages/api/plan_tool_registry.go
+++ b/src/packages/api/plan_tool_registry.go
@@ -342,7 +342,7 @@ func runSearchPlacesTool(s *planSession, input json.RawMessage) (string, bool) {
 	}
 	json.Unmarshal(input, &in)
 
-	results, err := placesService.SearchPlaces(in.Query)
+	results, err := placesService.SearchPlaces(s.ctx, in.Query)
 	if err != nil {
 		return fmt.Sprintf("Error searching places: %v", err), true
 	}
@@ -374,8 +374,10 @@ func runCreateItineraryTool(s *planSession, input json.RawMessage) (string, bool
 			donePayload["trip_id"] = tripID
 			if parsed, err := uuid.Parse(tripID); err == nil {
 				s.tripID = &parsed
-				go recordEvent(s.uid, "trip_created", &parsed, map[string]any{
-					"item_count": len(in.Locations),
+				safeGo("recordEvent", func() {
+					recordEvent(s.uid, "trip_created", &parsed, map[string]any{
+						"item_count": len(in.Locations),
+					})
 				})
 				// Free-cap active_trips crossing signal — only a
 				// brand-new lineage can move the lineage count; a
@@ -383,7 +385,7 @@ func runCreateItineraryTool(s *planSession, input json.RawMessage) (string, bool
 				// it unchanged and must never emit
 				// (specs/free-cap-instrumentation).
 				if newLineage {
-					go recordActiveTripsCapSignal(s.uid, parsed)
+					safeGo("recordActiveTripsCapSignal", func() { recordActiveTripsCapSignal(s.uid, parsed) })
 				}
 			}
 			// Distill what this conversation revealed about the traveler
@@ -391,7 +393,9 @@ func runCreateItineraryTool(s *planSession, input json.RawMessage) (string, bool
 			// context.Background(): the request ctx dies with the handler.
 			if !s.distilled {
 				s.distilled = true
-				go distillTravelerProfile(context.Background(), s.client, s.uid, s.req.Messages)
+				safeGo("distillTravelerProfile", func() {
+					distillTravelerProfile(context.Background(), s.client, s.uid, s.req.Messages)
+				})
 			}
 		}
 	}
@@ -418,15 +422,17 @@ func runUpdateItinerarySectionTool(s *planSession, input json.RawMessage) (strin
 	}
 	sendSSE(s.w, "trip_updated", map[string]string{"trip_id": s.boundTripID.String()})
 	s.tripID = s.boundTripID
-	go recordEvent(s.uid, "trip_refined", s.boundTripID, map[string]any{
-		"scope":           in.Scope,
-		"is_collaborator": s.uid != s.boundTripOwnerID,
+	safeGo("recordEvent", func() {
+		recordEvent(s.uid, "trip_refined", s.boundTripID, map[string]any{
+			"scope":           in.Scope,
+			"is_collaborator": s.uid != s.boundTripOwnerID,
+		})
 	})
 	// A collaborator refining the owner's trip in place is the canonical
 	// agent collaborator-edit path. replaceTripSection's TouchTrip doesn't run
 	// through touchedBy, so notify here; the SQL self-gates for owner refines.
 	if s.uid != s.boundTripOwnerID {
-		go notifyCollabEdit(*s.boundTripID, s.uid)
+		safeGo("notifyCollabEdit", func() { notifyCollabEdit(*s.boundTripID, s.uid) })
 	}
 	return "Section updated — the traveler's trip page has refreshed.", false
 }

--- a/src/packages/api/plan_tools_extra.go
+++ b/src/packages/api/plan_tools_extra.go
@@ -371,7 +371,9 @@ func runAddPackingItemTool(s *planSession, input json.RawMessage) (string, bool)
 	}
 	touchTripAs(s.ctx, tid, s.uid)
 	sendSSE(s.w, "trip_updated", map[string]string{"trip_id": tid.String()})
-	go recordEvent(s.uid, "agent_packing_item_added", &tid, map[string]any{"category": item.Category})
+	safeGo("recordEvent", func() {
+		recordEvent(s.uid, "agent_packing_item_added", &tid, map[string]any{"category": item.Category})
+	})
 	return fmt.Sprintf("Added %q to the trip's packing & prep checklist. Keep going for the other items; the traveler will see the list on the trip page.", item.Title), false
 }
 
@@ -440,7 +442,7 @@ func runAddAccommodationTool(s *planSession, input json.RawMessage) (string, boo
 	}
 	touchTripAs(s.ctx, tid, s.uid)
 	sendSSE(s.w, "trip_updated", map[string]string{"trip_id": tid.String()})
-	go recordEvent(s.uid, "agent_accommodation_added", &tid, nil)
+	safeGo("recordEvent", func() { recordEvent(s.uid, "agent_accommodation_added", &tid, nil) })
 	return fmt.Sprintf("Added the stay %q to the trip. It starts unbooked — the traveler can confirm it on the trip page. Mention it briefly.", acc.Name), false
 }
 
@@ -482,7 +484,7 @@ func runAddTransportSegmentTool(s *planSession, input json.RawMessage) (string, 
 	}
 	touchTripAs(s.ctx, tid, s.uid)
 	sendSSE(s.w, "trip_updated", map[string]string{"trip_id": tid.String()})
-	go recordEvent(s.uid, "agent_segment_added", &tid, map[string]any{"mode": seg.Mode})
+	safeGo("recordEvent", func() { recordEvent(s.uid, "agent_segment_added", &tid, map[string]any{"mode": seg.Mode}) })
 	leg := seg.Mode
 	if seg.Origin != nil && seg.Destination != nil {
 		leg = fmt.Sprintf("%s %s → %s", seg.Mode, *seg.Origin, *seg.Destination)
@@ -528,7 +530,7 @@ func runMoveItineraryItemTool(s *planSession, input json.RawMessage) (string, bo
 	}
 	touchTripAs(s.ctx, tid, s.uid)
 	sendSSE(s.w, "trip_updated", map[string]string{"trip_id": tid.String()})
-	go recordEvent(s.uid, "agent_item_moved", &tid, nil)
+	safeGo("recordEvent", func() { recordEvent(s.uid, "agent_item_moved", &tid, nil) })
 	where := fmt.Sprintf("Day %d", *in.Day)
 	if item.TimeOfDay != nil && *item.TimeOfDay != "" {
 		where += " (" + *item.TimeOfDay + ")"
@@ -724,7 +726,7 @@ func runAddBookingTodoTool(s *planSession, input json.RawMessage) (string, bool)
 	}
 	touchTripAs(s.ctx, tid, s.uid)
 	sendSSE(s.w, "trip_updated", map[string]string{"trip_id": tid.String()})
-	go recordEvent(s.uid, "agent_booking_todo_added", &tid, map[string]any{"kind": todo.Kind})
+	safeGo("recordEvent", func() { recordEvent(s.uid, "agent_booking_todo_added", &tid, map[string]any{"kind": todo.Kind}) })
 	return fmt.Sprintf("Added %q to the trip's booking checklist. Mention it briefly; the traveler will see it on the trip page.", todo.Title), false
 }
 
@@ -738,7 +740,7 @@ func touchTripAs(ctx context.Context, tripID, actor uuid.UUID) {
 	// Same "collaborator edited a shared trip" signal as the HTTP paths, for
 	// agent tool edits (booking to-do add/update/remove). Self-gated in SQL, so
 	// owner-actor edits no-op.
-	go notifyCollabEdit(tripID, actor)
+	safeGo("notifyCollabEdit", func() { notifyCollabEdit(tripID, actor) })
 }
 
 // bookingTodoMissingMsg covers both "wrong id" and "auto row" — the queries
@@ -797,7 +799,7 @@ func runUpdateBookingTodoTool(s *planSession, input json.RawMessage) (string, bo
 	}
 	touchTripAs(s.ctx, tid, s.uid)
 	sendSSE(s.w, "trip_updated", map[string]string{"trip_id": tid.String()})
-	go recordEvent(s.uid, "agent_booking_todo_updated", &tid, map[string]any{"kind": todo.Kind})
+	safeGo("recordEvent", func() { recordEvent(s.uid, "agent_booking_todo_updated", &tid, map[string]any{"kind": todo.Kind}) })
 	return fmt.Sprintf("Updated %q on the trip's booking checklist — the traveler's trip page has refreshed.", todo.Title), false
 }
 
@@ -823,6 +825,6 @@ func runRemoveBookingTodoTool(s *planSession, input json.RawMessage) (string, bo
 	}
 	touchTripAs(s.ctx, tid, s.uid)
 	sendSSE(s.w, "trip_updated", map[string]string{"trip_id": tid.String()})
-	go recordEvent(s.uid, "agent_booking_todo_removed", &tid, nil)
+	safeGo("recordEvent", func() { recordEvent(s.uid, "agent_booking_todo_removed", &tid, nil) })
 	return "Removed the item from the trip's booking checklist — the traveler's trip page has refreshed.", false
 }

--- a/src/packages/api/price_alert_checker.go
+++ b/src/packages/api/price_alert_checker.go
@@ -86,7 +86,9 @@ func (c *alertChecker) run(ctx context.Context) {
 	ticker := time.NewTicker(c.interval)
 	defer ticker.Stop()
 	for {
-		c.runOnce(ctx)
+		// Guard each tick: a panic in one cycle must not kill the ticker (and
+		// with it the whole process). Log-and-continue to the next tick.
+		safeRun("price alert checker tick", func() { c.runOnce(ctx) })
 		select {
 		case <-ctx.Done():
 			return
@@ -324,12 +326,14 @@ func (c *alertChecker) settle(ctx context.Context, q *store.Queries, row store.L
 	}); err != nil {
 		log.Printf("price alerts: insert notification %s: %v", a.ID, err)
 	}
-	go sendAlertEmail(row.OwnerEmail, a, lowest, matchedParam)
+	safeGo("sendAlertEmail", func() { sendAlertEmail(row.OwnerEmail, a, lowest, matchedParam) })
 	tripID := tripIDPtr(a)
-	go recordEvent(a.UserID, "alert_triggered", tripID, map[string]any{
-		"origin": a.Origin, "destination": a.Destination,
-		"price": effective, "currency": lowest.Currency,
-		"target_price": a.TargetPrice,
+	safeGo("recordEvent", func() {
+		recordEvent(a.UserID, "alert_triggered", tripID, map[string]any{
+			"origin": a.Origin, "destination": a.Destination,
+			"price": effective, "currency": lowest.Currency,
+			"target_price": a.TargetPrice,
+		})
 	})
 }
 

--- a/src/packages/api/price_alert_handler.go
+++ b/src/packages/api/price_alert_handler.go
@@ -239,8 +239,10 @@ func createPriceAlertHandler(w http.ResponseWriter, r *http.Request) {
 	if alert.TargetPrice != nil {
 		mode = "target"
 	}
-	go recordEvent(user.ID, "alert_created", tripIDPtr(alert), map[string]any{
-		"origin": alert.Origin, "destination": alert.Destination, "mode": mode,
+	safeGo("recordEvent", func() {
+		recordEvent(user.ID, "alert_created", tripIDPtr(alert), map[string]any{
+			"origin": alert.Origin, "destination": alert.Destination, "mode": mode,
+		})
 	})
 	writeJSON(w, http.StatusCreated, toPriceAlertResponse(alert))
 }

--- a/src/packages/api/reengagement_checker.go
+++ b/src/packages/api/reengagement_checker.go
@@ -77,7 +77,9 @@ func (c *reengagementChecker) run(ctx context.Context) {
 	ticker := time.NewTicker(c.interval)
 	defer ticker.Stop()
 	for {
-		c.runOnce(ctx, time.Now())
+		// Guard each tick: a panic in one cycle must not kill the ticker (and
+		// with it the whole process). Log-and-continue to the next tick.
+		safeRun("re-engagement checker tick", func() { c.runOnce(ctx, time.Now()) })
 		select {
 		case <-ctx.Done():
 			return
@@ -151,7 +153,7 @@ func (c *reengagementChecker) sendTripReminder(ctx context.Context, q *store.Que
 		log.Printf("re-engagement: insert %s notification for %s failed: %v", kind, row.UserID, err)
 	}
 	if !row.RemindersOptOut {
-		go sendReminderEmail(row, kind)
+		safeGo("sendReminderEmail", func() { sendReminderEmail(row, kind) })
 	}
 }
 
@@ -191,7 +193,7 @@ func (c *reengagementChecker) sendWeeklyNudge(ctx context.Context, q *store.Quer
 		log.Printf("re-engagement: insert weekly nudge for %s failed: %v", row.ID, err)
 	}
 	if !row.NudgesOptOut {
-		go sendNudgeEmail(row)
+		safeGo("sendNudgeEmail", func() { sendNudgeEmail(row) })
 	}
 }
 

--- a/src/packages/api/resilience_test.go
+++ b/src/packages/api/resilience_test.go
@@ -1,0 +1,238 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/jackc/puddle/v2"
+)
+
+// A hung Google socket must abort on the caller's context deadline rather than
+// block the synchronous /plan agent loop forever. With a slow httptest server
+// and a short-deadline context, the call must return promptly with a
+// deadline-exceeded error — not hang until the client's 15s Timeout.
+func TestSearchPlacesHonorsContextDeadline(t *testing.T) {
+	slow := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-r.Context().Done(): // client hung up (deadline) — stop
+		case <-time.After(3 * time.Second):
+			w.Write([]byte(fakeTextSearchJSON))
+		}
+	}))
+	defer slow.Close()
+
+	orig := placesTextSearchURL
+	placesTextSearchURL = slow.URL
+	defer func() { placesTextSearchURL = orig }()
+
+	svc := NewGooglePlacesService()
+	svc.APIKey = "test-key"
+	// A real client (not the fake transport) so the request actually reaches
+	// the slow server; the context deadline — not the client Timeout — is what
+	// we're asserting here.
+	svc.Client = &http.Client{}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	_, err := svc.SearchPlaces(ctx, "somewhere")
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected a deadline error, got nil (call did not honor the context)")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected context.DeadlineExceeded in the chain, got: %v", err)
+	}
+	if elapsed > 2*time.Second {
+		t.Fatalf("call took %s — it hung instead of cancelling on the deadline", elapsed)
+	}
+}
+
+// safeGo must actually run fn.
+func TestSafeGoRunsFn(t *testing.T) {
+	done := make(chan struct{})
+	safeGo("test-run", func() { close(done) })
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("safeGo never ran fn")
+	}
+}
+
+// A panic inside a safeGo goroutine must be recovered — it must NOT crash the
+// process — and subsequent safeGo calls must keep working.
+func TestSafeGoRecoversPanic(t *testing.T) {
+	panicked := make(chan struct{})
+	safeGo("test-panic", func() {
+		defer close(panicked) // runs during unwind, before safeGo's recover
+		panic("boom")
+	})
+	<-panicked
+
+	// If the panic had crashed the process, we'd never reach here. Prove the
+	// worker pool is still usable.
+	done := make(chan struct{})
+	safeGo("test-after-panic", func() { close(done) })
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("process/goroutine machinery broken after a recovered panic")
+	}
+}
+
+// safeRun is the synchronous guard used inside ticker loops: it must recover a
+// panicking tick and return so the loop (and the process) survives.
+func TestSafeRunRecoversAndContinues(t *testing.T) {
+	safeRun("tick-1", func() { panic("bad tick") }) // must return, not crash
+
+	ran := false
+	safeRun("tick-2", func() { ran = true })
+	if !ran {
+		t.Fatal("safeRun did not run the next tick after a recovered panic")
+	}
+}
+
+// dbErrorStatus is the classifier behind DB-blip -> 503. A connection-level
+// failure is retryable (503); an absent row is not an outage (0, caller
+// decides); a server-answered error keeps the connection alive (500).
+func TestDBErrorStatusMapping(t *testing.T) {
+	connRefused := &net.OpError{Op: "dial", Net: "tcp", Err: errors.New("connection refused")}
+
+	cases := []struct {
+		name string
+		err  error
+		want int
+	}{
+		{"nil", nil, 0},
+		{"no rows -> caller decides", pgx.ErrNoRows, 0},
+		{"wrapped no rows", errors.New("lookup: " + pgx.ErrNoRows.Error()), http.StatusInternalServerError}, // not the sentinel
+		{"server-side PgError -> 500", &pgconn.PgError{Code: "23505", Message: "dup"}, http.StatusInternalServerError},
+		{"connection refused -> 503", connRefused, http.StatusServiceUnavailable},
+		{"closed pool -> 503", puddle.ErrClosedPool, http.StatusServiceUnavailable},
+		{"resource unavailable -> 503", puddle.ErrNotAvailable, http.StatusServiceUnavailable},
+	}
+	for _, c := range cases {
+		if got := dbErrorStatus(c.err); got != c.want {
+			t.Errorf("%s: dbErrorStatus = %d, want %d", c.name, got, c.want)
+		}
+	}
+
+	// The real sentinel wrapped in a chain must still classify as no-rows.
+	wrapped := errWrap("session lookup", pgx.ErrNoRows)
+	if got := dbErrorStatus(wrapped); got != 0 {
+		t.Errorf("wrapped pgx.ErrNoRows: dbErrorStatus = %d, want 0", got)
+	}
+}
+
+func errWrap(msg string, err error) error { return &wrappedErr{msg, err} }
+
+type wrappedErr struct {
+	msg string
+	err error
+}
+
+func (w *wrappedErr) Error() string { return w.msg + ": " + w.err.Error() }
+func (w *wrappedErr) Unwrap() error { return w.err }
+
+// A DB-connection failure inside authMiddleware must surface as a retryable 503
+// — NOT a 401 that logs the user out on a transient Postgres blip. We point the
+// pool at a dead address so the session lookup fails at connect time.
+func TestAuthMiddlewareDBBlipReturns503(t *testing.T) {
+	orig := dbPool
+	defer func() { dbPool = orig }()
+
+	cfg, err := pgxpool.ParseConfig("postgres://u:p@127.0.0.1:1/db?sslmode=disable")
+	if err != nil {
+		t.Fatalf("parse config: %v", err)
+	}
+	cfg.ConnConfig.ConnectTimeout = 500 * time.Millisecond
+	cfg.MinConns = 0
+	pool, err := pgxpool.NewWithConfig(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("new pool: %v", err)
+	}
+	defer pool.Close()
+	dbPool = pool
+
+	h := authMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	req := httptest.NewRequest(http.MethodGet, "/protected", nil)
+	req.Header.Set("Authorization", "Bearer some-token")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("auth on a DB blip returned %d, want 503 (must not log the user out)", rec.Code)
+	}
+}
+
+// authMiddleware with no token is still a plain 401 — the DB-blip handling must
+// not change the missing-credentials path.
+func TestAuthMiddlewareMissingTokenStill401(t *testing.T) {
+	orig := dbPool
+	defer func() { dbPool = orig }()
+
+	cfg, err := pgxpool.ParseConfig("postgres://u:p@127.0.0.1:1/db?sslmode=disable")
+	if err != nil {
+		t.Fatalf("parse config: %v", err)
+	}
+	pool, err := pgxpool.NewWithConfig(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("new pool: %v", err)
+	}
+	defer pool.Close()
+	dbPool = pool
+
+	h := authMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	req := httptest.NewRequest(http.MethodGet, "/protected", nil) // no Authorization
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("auth with no token returned %d, want 401", rec.Code)
+	}
+}
+
+// userIDFromRequest must not silently downgrade an authenticated request to
+// anonymous when the DB is unreachable — it surfaces errDBUnavailable so the
+// caller can 503.
+func TestUserIDFromRequestSurfacesDBBlip(t *testing.T) {
+	orig := dbPool
+	defer func() { dbPool = orig }()
+
+	cfg, err := pgxpool.ParseConfig("postgres://u:p@127.0.0.1:1/db?sslmode=disable")
+	if err != nil {
+		t.Fatalf("parse config: %v", err)
+	}
+	cfg.ConnConfig.ConnectTimeout = 500 * time.Millisecond
+	cfg.MinConns = 0
+	pool, err := pgxpool.NewWithConfig(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("new pool: %v", err)
+	}
+	defer pool.Close()
+	dbPool = pool
+
+	req := httptest.NewRequest(http.MethodGet, "/plan", nil)
+	req.Header.Set("Authorization", "Bearer some-token")
+	_, authed, uerr := userIDFromRequest(req)
+	if authed {
+		t.Fatal("must not report authed on a DB blip")
+	}
+	if !errors.Is(uerr, errDBUnavailable) {
+		t.Fatalf("expected errDBUnavailable, got %v", uerr)
+	}
+}

--- a/src/packages/api/route_optimizer.go
+++ b/src/packages/api/route_optimizer.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"strconv"
@@ -463,7 +464,7 @@ func (ro *RouteOptimizer) findLocationIndex(locationID string) int {
 
 // OptimizeRoute is the main function to optimize a route
 // resolveLocation resolves a location's coordinates and details from Google Places API
-func (ro *RouteOptimizer) resolveLocation(location *Location, placesService *GooglePlacesService) error {
+func (ro *RouteOptimizer) resolveLocation(ctx context.Context, location *Location, placesService *GooglePlacesService) error {
 	// If we already have coordinates, no need to resolve
 	if location.Latitude != nil && location.Longitude != nil {
 		return nil
@@ -474,13 +475,13 @@ func (ro *RouteOptimizer) resolveLocation(location *Location, placesService *Goo
 
 	// Try to get details by Place ID first
 	if location.PlaceID != "" {
-		placeDetails, err = placesService.GetPlaceDetails(location.PlaceID)
+		placeDetails, err = placesService.GetPlaceDetails(ctx, location.PlaceID)
 		if err != nil {
 			return fmt.Errorf("failed to get place details for place_id %s: %w", location.PlaceID, err)
 		}
 	} else if location.Name != "" {
 		// Search by name if no Place ID
-		searchResults, err := placesService.SearchPlaces(location.Name)
+		searchResults, err := placesService.SearchPlaces(ctx, location.Name)
 		if err != nil {
 			return fmt.Errorf("failed to search for place '%s': %w", location.Name, err)
 		}
@@ -490,7 +491,7 @@ func (ro *RouteOptimizer) resolveLocation(location *Location, placesService *Goo
 
 		// Use the first result and get detailed info
 		firstResult := searchResults[0]
-		placeDetails, err = placesService.GetPlaceDetails(firstResult.PlaceID)
+		placeDetails, err = placesService.GetPlaceDetails(ctx, firstResult.PlaceID)
 		if err != nil {
 			return fmt.Errorf("failed to get place details for '%s': %w", location.Name, err)
 		}
@@ -521,7 +522,7 @@ func (ro *RouteOptimizer) resolveLocation(location *Location, placesService *Goo
 	return nil
 }
 
-func (ro *RouteOptimizer) OptimizeRoute(request RouteRequest) RouteResponse {
+func (ro *RouteOptimizer) OptimizeRoute(ctx context.Context, request RouteRequest) RouteResponse {
 	if len(request.Locations) == 0 {
 		return RouteResponse{
 			Status: "error: no locations provided",
@@ -531,7 +532,7 @@ func (ro *RouteOptimizer) OptimizeRoute(request RouteRequest) RouteResponse {
 	// Resolve locations that don't have coordinates (via the shared
 	// placesService singleton so lookups hit its TTL caches)
 	for i := range request.Locations {
-		if err := ro.resolveLocation(&request.Locations[i], placesService); err != nil {
+		if err := ro.resolveLocation(ctx, &request.Locations[i], placesService); err != nil {
 			return RouteResponse{
 				Status: fmt.Sprintf("error resolving location '%s': %v", request.Locations[i].Name, err),
 			}

--- a/src/packages/api/route_optimizer_test.go
+++ b/src/packages/api/route_optimizer_test.go
@@ -1,6 +1,9 @@
 package main
 
-import "testing"
+import (
+	"context"
+	"testing"
+)
 
 func f64(v float64) *float64 { return &v }
 
@@ -21,7 +24,7 @@ func TestOptimizeRoutePreserveOrder(t *testing.T) {
 		},
 	}
 
-	resp := ro.OptimizeRoute(req)
+	resp := ro.OptimizeRoute(context.Background(), req)
 
 	if resp.Status != "success" {
 		t.Fatalf("expected success, got %q", resp.Status)

--- a/src/packages/api/segment_handler.go
+++ b/src/packages/api/segment_handler.go
@@ -201,7 +201,7 @@ func updateSegmentHandler(w http.ResponseWriter, r *http.Request) {
 		if seg.Provider != nil {
 			meta["provider"] = *seg.Provider
 		}
-		go recordEvent(user.ID, "saved_booking_marked_booked", &tripID, meta)
+		safeGo("recordEvent", func() { recordEvent(user.ID, "saved_booking_marked_booked", &tripID, meta) })
 	}
 	_ = store.New(dbPool).TouchTrip(r.Context(), touchedBy(tripID, r))
 	writeJSON(w, http.StatusOK, toSegmentResponse(seg))

--- a/src/packages/api/share_handler.go
+++ b/src/packages/api/share_handler.go
@@ -108,7 +108,7 @@ func createShareHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if role == "editor" {
-		go recordEvent(user.ID, "editor_share_created", &trip.ID, nil)
+		safeGo("recordEvent", func() { recordEvent(user.ID, "editor_share_created", &trip.ID, nil) })
 	}
 	writeJSON(w, http.StatusCreated, ShareResponse{Token: share.Token, Role: share.Role, CreatedAt: share.CreatedAt})
 }

--- a/src/packages/api/trip_handler.go
+++ b/src/packages/api/trip_handler.go
@@ -148,7 +148,7 @@ func toItineraryItemResponse(it store.ItineraryItem) ItineraryItemResponse {
 // notify, which is acceptable for an in-app signal.
 func touchedBy(tripID uuid.UUID, r *http.Request) store.TouchTripParams {
 	user, _ := userFromContext(r.Context())
-	go notifyCollabEdit(tripID, user.ID)
+	safeGo("notifyCollabEdit", func() { notifyCollabEdit(tripID, user.ID) })
 	return store.TouchTripParams{ID: tripID, UpdatedBy: pgtype.UUID{Bytes: user.ID, Valid: true}}
 }
 

--- a/src/packages/api/trip_review.go
+++ b/src/packages/api/trip_review.go
@@ -741,7 +741,7 @@ func checkHours(ctx context.Context, d exportData, places *GooglePlacesService) 
 			break
 		}
 		lookups++
-		details, err := places.GetPlaceDetails(placeID)
+		details, err := places.GetPlaceDetails(ctx, placeID)
 		if err != nil || details == nil || details.OpeningHours == nil {
 			continue // best-effort
 		}

--- a/src/packages/api/util_safego.go
+++ b/src/packages/api/util_safego.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"log/slog"
+	"runtime/debug"
+)
+
+// safeGo runs fn in a new goroutine wrapped in a panic recover. A panic in a
+// bare `go fn()` crashes the ENTIRE process (Go has no per-goroutine recovery),
+// which for a single-host deployment means every in-flight request dies. Every
+// fire-and-forget goroutine (analytics, emails, notifications, fan-out workers)
+// must go through here so one bad payload can't take the server down.
+//
+// On panic it logs at Error level with the stack; because slog.Default() is
+// wired to the Sentry handler in main.go, that log also raises a Sentry event.
+// name identifies the call site in the log/alert.
+func safeGo(name string, fn func()) {
+	go func() {
+		defer func() {
+			if rec := recover(); rec != nil {
+				slog.Error("panic in "+name, "err", rec, "stack", string(debug.Stack()))
+			}
+		}()
+		fn()
+	}()
+}
+
+// safeRun runs fn synchronously with the same panic recovery as safeGo. Used to
+// guard the per-tick body of a long-lived background ticker loop so one bad tick
+// logs and continues instead of killing the ticker (and the process) forever.
+func safeRun(name string, fn func()) {
+	defer func() {
+		if rec := recover(); rec != nil {
+			slog.Error("panic in "+name, "err", rec, "stack", string(debug.Stack()))
+		}
+	}()
+	fn()
+}


### PR DESCRIPTION
## Hardening PR1 — resilience & crash-safety

First of the pre-launch hardening wave (survive day 1 on the Pi). **No migration.**

### Fixes
- **Google Places timeout + context** — the one client with neither; a Google stall could hang the whole `/plan` SSE stream. Now `http.Client{Timeout:15s}` + `NewRequestWithContext`, with `ctx` threaded through `SearchPlaces`/`GetPlaceAutocomplete`/`GetPlaceDetails` and every caller (handlers, plan tool, route optimizer, trip review, local ingest). Added base-URL test seam.
- **Anthropic loop deadline + redaction** — per-call `context.WithTimeout(120s)` on the streaming call; the raw stream error is now logged server-side and a generic message goes over SSE (no upstream-text leak).
- **`safeGo`/`safeRun` panic guards** (`util_safego.go`) — applied to the three background checker tickers (price-alert, re-engagement, **ops health-monitor**), the connectivity + baggage fan-out workers, and ~30 fire-and-forget goroutines. A panic in any of them no longer crashes the process (recovered → `slog.Error` → Sentry).
- **DB blip → retryable 503, not logout** — `dbErrorStatus(err)` classifies pgx/pgconn connection failures (primary signal `pgconn.SafeToRetry`, plus `net.Error`/`puddle.ErrClosedPool`). `authMiddleware` returns **503** on a blip (401 only for a truly absent/expired session), `userIDFromRequest` surfaces DB-unavailable instead of silently anonymizing `/plan`, and the pool gains `statement_timeout=15s` + `HealthCheckPeriod`/`MaxConnLifetime`/`MaxConnIdleTime`.
- **Redactions** — local-ingest extraction error + the four optimize-route "Invalid JSON" sites now log detail, return generic. (Left the static, user-actionable preferences/alert validation messages as-is per the brief.)

### Tests
`resilience_test.go`: Places context-deadline (httptest slow server), `safeGo`/`safeRun` panic recovery, `dbErrorStatus` mapping table, `authMiddleware` 503-on-blip + still-401-without-token, `userIDFromRequest` sentinel. `gofmt`/`go vet` clean; **`go test ./... -race` passes**.

PR2 (abuse & cost caps) and PR3 (input validation) follow, sequenced (shared files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)