### PR TITLE
feat(api): abuse & cost caps (Hardening PR2)

### DIFF
--- a/src/packages/api/.env.sample
+++ b/src/packages/api/.env.sample
@@ -78,6 +78,15 @@ UNSUBSCRIBE_SIGNING_SECRET=
 # FREE_PLAN_SESSIONS_PER_MONTH=20  # plan_runs cap, trailing 30 days
 # FREE_ACTIVE_TRIPS=3              # active_trips cap (distinct trip lineages)
 
+# Abuse & cost caps (Hardening PR2; abuse_caps.go). All in-memory, per single
+# Pi instance, reset on restart. Read at call time; defaults shown.
+# LOGIN_MAX_FAILURES=5                # consecutive failed logins per email before lockout
+# LOGIN_LOCK_MINUTES=15              # how long a locked-out email stays locked
+# FREE_ANON_PLAN_PER_DAY=5           # anonymous /plan runs per client IP per UTC day (authed users exempt)
+# MAX_REGISTRATIONS_PER_IP_PER_DAY=10 # new accounts per client IP per UTC day
+# EMAIL_MIN_INTERVAL_SECONDS=60      # min gap between transactional emails to one address (per purpose)
+# MAX_INFLIGHT_REQUESTS=100          # global concurrent in-flight request ceiling (503 when full; /health exempt)
+
 # Optional Anthropic API base-URL override (test seam for a fake-Anthropic
 # harness). Leave unset in production.
 # ANTHROPIC_BASE_URL=

--- a/src/packages/api/abuse_caps.go
+++ b/src/packages/api/abuse_caps.go
@@ -1,0 +1,336 @@
+package main
+
+import (
+	"net/http"
+	"sync"
+	"time"
+)
+
+// Abuse & cost caps (Hardening PR2). These guard a single-instance API taking
+// real users on a home Raspberry Pi against credential stuffing, runaway
+// anonymous AI spend, email-bombing, mass signups, and being swamped.
+//
+// Like ipRateLimiter (ratelimit.go), all state here is deliberately in-memory:
+// the API runs as one instance behind the nginx gateway, so process-local
+// counters are correct and reset-on-restart is acceptable (a restart is a rare,
+// operator-driven event that also clears any in-progress attack). A
+// multi-instance deployment would move this behind a shared store (e.g. Redis)
+// at the same seams. Every map evicts idle keys via a janitor so churn can't
+// grow it unbounded, mirroring ipRateLimiter's structure.
+
+// --- tunables (env-overridable via envInt; read at call time like the ALERT_*
+// and FREE_* knobs so ops/tests can adjust without a boot-order dependency) ---
+
+const (
+	// Login lockout: consecutive failed logins to one email before a temporary
+	// lock, and how long that lock lasts.
+	defaultLoginMaxFailures = 5
+	defaultLoginLockMinutes = 15
+
+	// Anonymous /plan requests allowed per client IP per UTC day. The key money
+	// fix: authenticated callers are exempt (see anonPlanAllowed).
+	defaultAnonPlanPerDay = 5
+
+	// New accounts allowed per client IP per UTC day.
+	defaultRegistrationsPerIPPerDay = 10
+
+	// Minimum seconds between transactional emails (verify / reset) to the same
+	// address, per purpose.
+	defaultEmailMinIntervalSeconds = 60
+
+	// Max simultaneously in-flight HTTP requests across the whole server.
+	defaultMaxInflightRequests = 100
+)
+
+func loginMaxFailures() int { return envInt("LOGIN_MAX_FAILURES", defaultLoginMaxFailures) }
+func loginLockWindow() time.Duration {
+	return time.Duration(envInt("LOGIN_LOCK_MINUTES", defaultLoginLockMinutes)) * time.Minute
+}
+func anonPlanPerDay() int { return envInt("FREE_ANON_PLAN_PER_DAY", defaultAnonPlanPerDay) }
+func registrationsPerIPPerDay() int {
+	return envInt("MAX_REGISTRATIONS_PER_IP_PER_DAY", defaultRegistrationsPerIPPerDay)
+}
+func emailMinInterval() time.Duration {
+	return time.Duration(envInt("EMAIL_MIN_INTERVAL_SECONDS", defaultEmailMinIntervalSeconds)) * time.Second
+}
+func maxInflightRequests() int { return envInt("MAX_INFLIGHT_REQUESTS", defaultMaxInflightRequests) }
+
+// utcDay is the integer UTC day number (days since the Unix epoch). It rolls
+// over exactly at UTC midnight, giving daily counters a cheap, monotone bucket
+// key without storing calendar dates.
+func utcDay(now time.Time) int64 { return now.UTC().Unix() / 86400 }
+
+// --- process-wide singletons ---
+//
+// Constructed at package init (each spawns its janitor goroutine, same as
+// newIPRateLimiter). Tests reset them in place via resetAll rather than
+// reconstructing, to avoid leaking janitors.
+var (
+	loginLockouts       = newLockoutTracker(loginMaxFailures, loginLockWindow)
+	anonPlanCounter     = newDailyCounter()
+	registrationCounter = newDailyCounter()
+	emailSendThrottle   = newIntervalThrottle()
+)
+
+// =============================================================================
+// Login lockout — per-email consecutive-failure tracker with a timed lock.
+// =============================================================================
+
+type lockoutEntry struct {
+	failures    int
+	lockedUntil time.Time
+	lastSeen    time.Time
+}
+
+type lockoutTracker struct {
+	mu      sync.Mutex
+	entries map[string]*lockoutEntry
+	maxFail func() int
+	window  func() time.Duration
+}
+
+func newLockoutTracker(maxFail func() int, window func() time.Duration) *lockoutTracker {
+	l := &lockoutTracker{
+		entries: make(map[string]*lockoutEntry),
+		maxFail: maxFail,
+		window:  window,
+	}
+	go l.janitor()
+	return l
+}
+
+// locked reports whether key is currently within an active lock window.
+func (l *lockoutTracker) locked(key string, now time.Time) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	e := l.entries[key]
+	return e != nil && now.Before(e.lockedUntil)
+}
+
+// recordFailure counts one failed attempt for key and, on reaching the
+// threshold, locks it for the window. An expired prior lock resets the counter
+// so a returning-but-fresh attacker starts over. Returns whether key is now
+// locked.
+func (l *lockoutTracker) recordFailure(key string, now time.Time) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	e := l.entries[key]
+	if e == nil {
+		e = &lockoutEntry{}
+		l.entries[key] = e
+	}
+	e.lastSeen = now
+	if !e.lockedUntil.IsZero() && !now.Before(e.lockedUntil) {
+		// The last lock has elapsed; start a fresh failure streak.
+		e.failures = 0
+		e.lockedUntil = time.Time{}
+	}
+	e.failures++
+	if e.failures >= l.maxFail() {
+		e.lockedUntil = now.Add(l.window())
+		return true
+	}
+	return false
+}
+
+// reset clears all failure state for key (a successful login).
+func (l *lockoutTracker) reset(key string) {
+	l.mu.Lock()
+	delete(l.entries, key)
+	l.mu.Unlock()
+}
+
+func (l *lockoutTracker) resetAll() {
+	l.mu.Lock()
+	l.entries = make(map[string]*lockoutEntry)
+	l.mu.Unlock()
+}
+
+func (l *lockoutTracker) janitor() {
+	for range time.Tick(5 * time.Minute) {
+		// Evict entries idle beyond the lock window plus a margin: once a lock
+		// has long expired and nothing has touched the key, it can't affect any
+		// decision, so it's safe to drop.
+		cutoff := time.Now().Add(-l.window() - 10*time.Minute)
+		l.mu.Lock()
+		for k, e := range l.entries {
+			if e.lastSeen.Before(cutoff) {
+				delete(l.entries, k)
+			}
+		}
+		l.mu.Unlock()
+	}
+}
+
+// =============================================================================
+// Daily counter — per-key count within the current UTC day, rolling at
+// midnight. Shared by the anonymous /plan cap and the registration ceiling.
+// =============================================================================
+
+type dailyEntry struct {
+	day      int64
+	count    int
+	lastSeen time.Time
+}
+
+type dailyCounter struct {
+	mu      sync.Mutex
+	entries map[string]*dailyEntry
+}
+
+func newDailyCounter() *dailyCounter {
+	c := &dailyCounter{entries: make(map[string]*dailyEntry)}
+	go c.janitor()
+	return c
+}
+
+// incr bumps key's counter for now's UTC day (resetting first if the stored
+// day is stale) and returns the post-increment count for today.
+func (c *dailyCounter) incr(key string, now time.Time) int {
+	day := utcDay(now)
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	e := c.entries[key]
+	if e == nil || e.day != day {
+		e = &dailyEntry{day: day}
+		c.entries[key] = e
+	}
+	e.count++
+	e.lastSeen = now
+	return e.count
+}
+
+// count returns key's count for now's UTC day without incrementing (a stale
+// day reads as zero).
+func (c *dailyCounter) count(key string, now time.Time) int {
+	day := utcDay(now)
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	e := c.entries[key]
+	if e == nil || e.day != day {
+		return 0
+	}
+	return e.count
+}
+
+func (c *dailyCounter) resetAll() {
+	c.mu.Lock()
+	c.entries = make(map[string]*dailyEntry)
+	c.mu.Unlock()
+}
+
+func (c *dailyCounter) janitor() {
+	for range time.Tick(1 * time.Hour) {
+		cutoff := time.Now().Add(-26 * time.Hour) // one full day + margin
+		c.mu.Lock()
+		for k, e := range c.entries {
+			if e.lastSeen.Before(cutoff) {
+				delete(c.entries, k)
+			}
+		}
+		c.mu.Unlock()
+	}
+}
+
+// =============================================================================
+// Interval throttle — enforces a minimum gap between events for a key. Used to
+// rate-limit transactional email sends per address (anti email-bombing).
+// =============================================================================
+
+type intervalThrottle struct {
+	mu   sync.Mutex
+	last map[string]time.Time
+}
+
+func newIntervalThrottle() *intervalThrottle {
+	t := &intervalThrottle{last: make(map[string]time.Time)}
+	go t.janitor()
+	return t
+}
+
+// allow reports whether at least minInterval has elapsed since the last allowed
+// event for key. When it returns true it records now as the new last-allowed
+// time; when false it changes nothing.
+func (t *intervalThrottle) allow(key string, now time.Time, minInterval time.Duration) bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if last, ok := t.last[key]; ok && now.Sub(last) < minInterval {
+		return false
+	}
+	t.last[key] = now
+	return true
+}
+
+func (t *intervalThrottle) resetAll() {
+	t.mu.Lock()
+	t.last = make(map[string]time.Time)
+	t.mu.Unlock()
+}
+
+func (t *intervalThrottle) janitor() {
+	for range time.Tick(10 * time.Minute) {
+		cutoff := time.Now().Add(-1 * time.Hour)
+		t.mu.Lock()
+		for k, ts := range t.last {
+			if ts.Before(cutoff) {
+				delete(t.last, k)
+			}
+		}
+		t.mu.Unlock()
+	}
+}
+
+// =============================================================================
+// Anonymous /plan cap decision.
+// =============================================================================
+
+// anonPlanAllowed reports whether a /plan request may proceed under the
+// anonymous per-IP daily cap. Authenticated callers (authed=true) always pass
+// AND are never counted — the cap is a cost guard against unauthenticated abuse
+// only, leaving the measure-only free-cap behavior (free_cap.go) for signed-in
+// users exactly as-is. For anonymous callers it increments the per-IP UTC-day
+// counter and allows up to anonPlanPerDay() per day; requests beyond that are
+// rejected (over-by-one and far-over are not distinguished).
+func anonPlanAllowed(authed bool, ip string, now time.Time) bool {
+	if authed {
+		return true
+	}
+	return anonPlanCounter.incr(ip, now) <= anonPlanPerDay()
+}
+
+// =============================================================================
+// Global concurrency limiter — a buffered-channel semaphore capping the number
+// of simultaneously in-flight requests. Non-blocking acquire: a full server
+// sheds new load with 503 + Retry-After rather than queueing unboundedly (the
+// server runs with WriteTimeout:0 for SSE, so there is no other backstop).
+// =============================================================================
+
+type concurrencyLimiter struct {
+	sem chan struct{}
+}
+
+func newConcurrencyLimiter(max int) *concurrencyLimiter {
+	if max < 1 {
+		max = 1
+	}
+	return &concurrencyLimiter{sem: make(chan struct{}, max)}
+}
+
+func (cl *concurrencyLimiter) middleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Health probes are never shed: a saturated server still must be able to
+		// report its liveness/readiness to the container/orchestrator.
+		if r.URL.Path == "/health" || r.URL.Path == "/api/v1/health" {
+			next.ServeHTTP(w, r)
+			return
+		}
+		select {
+		case cl.sem <- struct{}{}:
+			defer func() { <-cl.sem }()
+			next.ServeHTTP(w, r)
+		default:
+			w.Header().Set("Retry-After", "5")
+			writeJSONError(w, http.StatusServiceUnavailable, "server busy; please retry shortly")
+		}
+	})
+}

--- a/src/packages/api/abuse_caps_integration_test.go
+++ b/src/packages/api/abuse_caps_integration_test.go
@@ -1,0 +1,165 @@
+package main
+
+import (
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// Credential stuffing across many IPs must be stopped by the per-account
+// lockout even though each request comes from a fresh IP (so the strict
+// per-IP limiter never fires). After the threshold, even the CORRECT password
+// is rejected with 429 — and identically for a non-existent account, preserving
+// no-enumeration.
+func TestLoginLockoutStopsCrossIPStuffing(t *testing.T) {
+	resetDB(t)
+	loginLockouts.resetAll()
+	createTestUser(t, "locktarget@example.com") // password is "password123"
+
+	// LOGIN_MAX_FAILURES defaults to 5. Each attempt uses a fresh unique IP.
+	for i := 0; i < 5; i++ {
+		rec := doJSON(t, "POST", "/api/v1/auth/login", "", map[string]any{
+			"email": "locktarget@example.com", "password": "wrong-password",
+		})
+		if rec.Code != http.StatusUnauthorized {
+			t.Fatalf("bad login %d = %d, want 401", i+1, rec.Code)
+		}
+	}
+	// The correct password is now refused with 429 within the lock window.
+	rec := doJSON(t, "POST", "/api/v1/auth/login", "", map[string]any{
+		"email": "locktarget@example.com", "password": "password123",
+	})
+	if rec.Code != http.StatusTooManyRequests {
+		t.Fatalf("locked login with correct password = %d, want 429", rec.Code)
+	}
+	if rec.Header().Get("Retry-After") == "" {
+		t.Fatal("lockout 429 should carry Retry-After")
+	}
+
+	// A non-existent account locks the same way (enumeration-safe): the 429
+	// reveals nothing about existence.
+	loginLockouts.resetAll()
+	for i := 0; i < 5; i++ {
+		doJSON(t, "POST", "/api/v1/auth/login", "", map[string]any{
+			"email": "ghost@example.com", "password": "wrong-password",
+		})
+	}
+	ghost := doJSON(t, "POST", "/api/v1/auth/login", "", map[string]any{
+		"email": "ghost@example.com", "password": "whatever",
+	})
+	if ghost.Code != http.StatusTooManyRequests {
+		t.Fatalf("locked non-existent account = %d, want 429 (enumeration-safe)", ghost.Code)
+	}
+}
+
+// A successful login before the threshold clears the failure streak.
+func TestLoginLockoutResetsOnSuccess(t *testing.T) {
+	resetDB(t)
+	loginLockouts.resetAll()
+	createTestUser(t, "resetstreak@example.com")
+
+	for i := 0; i < 4; i++ { // one short of the default threshold (5)
+		doJSON(t, "POST", "/api/v1/auth/login", "", map[string]any{
+			"email": "resetstreak@example.com", "password": "wrong-password",
+		})
+	}
+	// Correct login succeeds and resets the streak.
+	ok := doJSON(t, "POST", "/api/v1/auth/login", "", map[string]any{
+		"email": "resetstreak@example.com", "password": "password123",
+	})
+	if ok.Code != http.StatusOK {
+		t.Fatalf("login before lockout = %d, want 200", ok.Code)
+	}
+	// Four more failures still don't lock (streak restarted at 0).
+	for i := 0; i < 4; i++ {
+		doJSON(t, "POST", "/api/v1/auth/login", "", map[string]any{
+			"email": "resetstreak@example.com", "password": "wrong-password",
+		})
+	}
+	again := doJSON(t, "POST", "/api/v1/auth/login", "", map[string]any{
+		"email": "resetstreak@example.com", "password": "password123",
+	})
+	if again.Code != http.StatusOK {
+		t.Fatalf("login after reset + <threshold failures = %d, want 200", again.Code)
+	}
+}
+
+// Past the per-IP daily ceiling, registration is refused with a 429 that names
+// the network cause (distinguishing it from the strict rate limiter).
+func TestRegistrationCeilingPerIP(t *testing.T) {
+	resetDB(t)
+	registrationCounter.resetAll()
+	t.Setenv("MAX_REGISTRATIONS_PER_IP_PER_DAY", "2")
+
+	ip := nextTestIP() // one IP for all three; stays within the strict burst (3)
+	codes := make([]int, 0, 3)
+	for i := 0; i < 3; i++ {
+		rec := doJSONFromIP(t, "POST", "/api/v1/auth/register", "", ip, map[string]any{
+			"email": "reg" + nextTestIP() + "@example.com", "password": "hunter2hunter2",
+		})
+		codes = append(codes, rec.Code)
+		if i == 2 {
+			if rec.Code != http.StatusTooManyRequests {
+				t.Fatalf("3rd register past ceiling = %d, want 429", rec.Code)
+			}
+			if !strings.Contains(rec.Body.String(), "too many accounts created from this network") {
+				t.Fatalf("ceiling 429 body = %q, want the network-ceiling message", rec.Body.String())
+			}
+		}
+	}
+	if codes[0] != http.StatusCreated || codes[1] != http.StatusCreated {
+		t.Fatalf("first two registers = %v, want 201/201", codes[:2])
+	}
+}
+
+// Two rapid password-reset requests for the same address deliver only one
+// email (the per-address throttle skips the second send) while the user-facing
+// response stays 202 both times, so the throttle can't be used to enumerate.
+func TestPasswordResetEmailThrottled(t *testing.T) {
+	resetDB(t)
+	emailSendThrottle.resetAll()
+	createTestUser(t, "bomb@example.com")
+
+	var mu sync.Mutex
+	sends := 0
+	orig := emailSend
+	emailSend = func(to, subject, body string) error {
+		mu.Lock()
+		sends++
+		mu.Unlock()
+		return nil
+	}
+	defer func() { emailSend = orig }()
+
+	for i := 0; i < 2; i++ {
+		rec := doJSON(t, "POST", "/api/v1/auth/request-password-reset", "", map[string]any{
+			"email": "bomb@example.com",
+		})
+		if rec.Code != http.StatusAccepted {
+			t.Fatalf("reset request %d = %d, want 202 (unchanged)", i+1, rec.Code)
+		}
+	}
+
+	// Sends run in fire-and-forget goroutines; wait for the first, then give a
+	// (wrongly) un-throttled second a chance to land. The throttle guarantees
+	// at most one regardless of scheduling.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		mu.Lock()
+		n := sends
+		mu.Unlock()
+		if n >= 1 {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	time.Sleep(150 * time.Millisecond)
+	mu.Lock()
+	n := sends
+	mu.Unlock()
+	if n != 1 {
+		t.Fatalf("reset email sends = %d, want exactly 1 (second throttled)", n)
+	}
+}

--- a/src/packages/api/abuse_caps_test.go
+++ b/src/packages/api/abuse_caps_test.go
@@ -1,0 +1,232 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// --- login lockout (fake clock, no DB) ---
+
+func TestLockoutTrackerLocksAfterThreshold(t *testing.T) {
+	window := 15 * time.Minute
+	l := newLockoutTracker(func() int { return 5 }, func() time.Duration { return window })
+	now := time.Unix(1_700_000_000, 0)
+
+	for i := 0; i < 4; i++ {
+		if l.recordFailure("victim@example.com", now) {
+			t.Fatalf("failure %d should not lock yet", i+1)
+		}
+		if l.locked("victim@example.com", now) {
+			t.Fatalf("account should not be locked after %d failures", i+1)
+		}
+	}
+	// 5th failure trips the lock.
+	if !l.recordFailure("victim@example.com", now) {
+		t.Fatal("5th failure should lock the account")
+	}
+	if !l.locked("victim@example.com", now) {
+		t.Fatal("account should be locked at the threshold")
+	}
+	// Still locked just before the window closes; unlocked after it.
+	if !l.locked("victim@example.com", now.Add(window-time.Second)) {
+		t.Fatal("account should remain locked within the window")
+	}
+	if l.locked("victim@example.com", now.Add(window+time.Second)) {
+		t.Fatal("account should unlock after the window elapses")
+	}
+}
+
+func TestLockoutTrackerResetClearsStreak(t *testing.T) {
+	l := newLockoutTracker(func() int { return 5 }, func() time.Duration { return 15 * time.Minute })
+	now := time.Unix(1_700_000_000, 0)
+
+	for i := 0; i < 4; i++ {
+		l.recordFailure("user@example.com", now)
+	}
+	// A success before lockout wipes the counter.
+	l.reset("user@example.com")
+	// It now takes a full fresh streak to lock again.
+	for i := 0; i < 4; i++ {
+		if l.recordFailure("user@example.com", now) {
+			t.Fatalf("post-reset failure %d should not lock (streak restarted)", i+1)
+		}
+	}
+	if l.locked("user@example.com", now) {
+		t.Fatal("account should not be locked after reset + <threshold failures")
+	}
+}
+
+func TestLockoutTrackerKeysAreIndependent(t *testing.T) {
+	l := newLockoutTracker(func() int { return 3 }, func() time.Duration { return time.Minute })
+	now := time.Unix(1_700_000_000, 0)
+	for i := 0; i < 3; i++ {
+		l.recordFailure("a@example.com", now)
+	}
+	if !l.locked("a@example.com", now) {
+		t.Fatal("a should be locked")
+	}
+	if l.locked("b@example.com", now) {
+		t.Fatal("b must not share a's lock")
+	}
+}
+
+// --- anonymous /plan daily cap (fake clock, no DB) ---
+
+func TestAnonPlanAllowedCapsAnonymousPerIP(t *testing.T) {
+	anonPlanCounter.resetAll()
+	t.Setenv("FREE_ANON_PLAN_PER_DAY", "3")
+	now := time.Unix(1_700_000_000, 0).UTC()
+	ip := "203.0.113.9"
+
+	for i := 0; i < 3; i++ {
+		if !anonPlanAllowed(false, ip, now) {
+			t.Fatalf("anonymous request %d within cap should be allowed", i+1)
+		}
+	}
+	if anonPlanAllowed(false, ip, now) {
+		t.Fatal("anonymous request past the daily cap should be rejected")
+	}
+	// A different IP has its own budget.
+	if !anonPlanAllowed(false, "198.51.100.7", now) {
+		t.Fatal("a different IP must not share the exhausted budget")
+	}
+}
+
+func TestAnonPlanAuthedExemptAndUncounted(t *testing.T) {
+	anonPlanCounter.resetAll()
+	t.Setenv("FREE_ANON_PLAN_PER_DAY", "2")
+	now := time.Unix(1_700_000_000, 0).UTC()
+	ip := "203.0.113.20"
+
+	// Authenticated callers always pass, even far past the anon cap...
+	for i := 0; i < 10; i++ {
+		if !anonPlanAllowed(true, ip, now) {
+			t.Fatal("authenticated caller must never be capped")
+		}
+	}
+	// ...and must not consume any of the anonymous budget for that IP.
+	if got := anonPlanCounter.count(ip, now); got != 0 {
+		t.Fatalf("authed traffic consumed anon budget: count = %d, want 0", got)
+	}
+	if !anonPlanAllowed(false, ip, now) {
+		t.Fatal("anon budget should be untouched by authed traffic")
+	}
+}
+
+func TestAnonPlanCapResetsAtUTCMidnight(t *testing.T) {
+	anonPlanCounter.resetAll()
+	t.Setenv("FREE_ANON_PLAN_PER_DAY", "1")
+	ip := "203.0.113.30"
+	day1 := time.Date(2026, 1, 1, 23, 59, 0, 0, time.UTC)
+	day2 := time.Date(2026, 1, 2, 0, 1, 0, 0, time.UTC)
+
+	if !anonPlanAllowed(false, ip, day1) {
+		t.Fatal("first request of the day should be allowed")
+	}
+	if anonPlanAllowed(false, ip, day1) {
+		t.Fatal("second request same day should be capped")
+	}
+	if !anonPlanAllowed(false, ip, day2) {
+		t.Fatal("counter should roll over at UTC midnight")
+	}
+}
+
+// planHandler emits a friendly SSE error (not a 500) when the anon cap trips.
+// No DB needed: with dbPool nil, userIDFromRequest resolves anonymous.
+func TestPlanHandlerAnonCapEmitsFriendlySSE(t *testing.T) {
+	anonPlanCounter.resetAll()
+	t.Setenv("FREE_ANON_PLAN_PER_DAY", "1")
+	// Ensure the first (allowed) request short-circuits at the API-key check
+	// instead of attempting a real Anthropic call on a dev box that exports one.
+	t.Setenv("ANTHROPIC_API_KEY", "")
+
+	body := `{"messages":[{"role":"user","content":"hi"}]}`
+	call := func() *httptest.ResponseRecorder {
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/plan", strings.NewReader(body))
+		req.Header.Set("X-Forwarded-For", "203.0.113.40")
+		rec := httptest.NewRecorder()
+		planHandler(rec, req)
+		return rec
+	}
+
+	// First anonymous request passes the cap (whatever it does next).
+	call()
+	// Second trips the cap: 200 (SSE always) with the friendly cap message.
+	rec := call()
+	if rec.Code != http.StatusOK {
+		t.Fatalf("capped /plan status = %d, want 200 (SSE error, never 500)", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "free planning limit") {
+		t.Fatalf("capped /plan body = %q, want the friendly cap message", rec.Body.String())
+	}
+	if strings.Contains(rec.Body.String(), "\"type\":\"error\"") == false {
+		t.Fatalf("capped /plan should emit an SSE error event, got %q", rec.Body.String())
+	}
+}
+
+// --- email interval throttle ---
+
+func TestIntervalThrottleEnforcesMinGap(t *testing.T) {
+	tr := newIntervalThrottle()
+	now := time.Unix(1_700_000_000, 0)
+	gap := time.Minute
+
+	if !tr.allow("reset:v@example.com", now, gap) {
+		t.Fatal("first send should be allowed")
+	}
+	if tr.allow("reset:v@example.com", now.Add(30*time.Second), gap) {
+		t.Fatal("second send within the min interval should be throttled")
+	}
+	if !tr.allow("reset:v@example.com", now.Add(61*time.Second), gap) {
+		t.Fatal("send after the interval should be allowed")
+	}
+	// Distinct key (different purpose / address) is independent.
+	if !tr.allow("verify:v@example.com", now.Add(30*time.Second), gap) {
+		t.Fatal("a different throttle key must not be blocked")
+	}
+}
+
+// --- concurrency limiter ---
+
+func TestConcurrencyLimiterShedsWhenFullButExemptsHealth(t *testing.T) {
+	cl := newConcurrencyLimiter(1)
+	release := make(chan struct{})
+	entered := make(chan struct{})
+	h := cl.middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/health" {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		entered <- struct{}{}
+		<-release
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	// Occupy the single slot with a request parked inside the handler.
+	go func() {
+		h.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/api/v1/plan", nil))
+	}()
+	<-entered
+
+	// A second request finds the semaphore full and is shed immediately.
+	shed := httptest.NewRecorder()
+	h.ServeHTTP(shed, httptest.NewRequest(http.MethodGet, "/api/v1/anything", nil))
+	if shed.Code != http.StatusServiceUnavailable {
+		t.Fatalf("shed request status = %d, want 503", shed.Code)
+	}
+	if shed.Header().Get("Retry-After") == "" {
+		t.Fatal("503 should carry Retry-After")
+	}
+
+	// /health is exempt and answers 200 even while saturated.
+	hrec := httptest.NewRecorder()
+	h.ServeHTTP(hrec, httptest.NewRequest(http.MethodGet, "/health", nil))
+	if hrec.Code != http.StatusOK {
+		t.Fatalf("/health under saturation = %d, want 200", hrec.Code)
+	}
+
+	close(release)
+}

--- a/src/packages/api/auth_handler.go
+++ b/src/packages/api/auth_handler.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -218,6 +219,16 @@ func registerHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Per-IP daily account-creation ceiling (abuse_caps.go): stops one network
+	// from minting accounts en masse. Counts only successful creations (bumped
+	// below), so failed/duplicate attempts don't burn the budget. Generic 429.
+	ip := clientIP(r)
+	if registrationCounter.count(ip, time.Now()) >= registrationsPerIPPerDay() {
+		w.Header().Set("Retry-After", "3600")
+		writeJSONError(w, http.StatusTooManyRequests, "too many accounts created from this network today; please try again later")
+		return
+	}
+
 	q := store.New(dbPool)
 	if _, err := q.GetUserByEmail(r.Context(), req.Email); err == nil {
 		writeJSONError(w, http.StatusConflict, "an account with this email already exists")
@@ -248,6 +259,8 @@ func registerHandler(w http.ResponseWriter, r *http.Request) {
 		writeJSONError(w, http.StatusInternalServerError, "could not create account")
 		return
 	}
+	// Count the successful creation toward this IP's daily ceiling.
+	registrationCounter.incr(ip, time.Now())
 
 	session, err := issueSession(r.Context(), q, user.ID)
 	if err != nil {
@@ -277,10 +290,26 @@ func loginHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Per-account login lockout (abuse_caps.go): the strict 5/min/IP limiter
+	// alone doesn't stop credential stuffing spread across many IPs, so track
+	// consecutive failures keyed by email and temporarily lock after too many.
+	// The lock fires identically whether or not the email exists — an attacker
+	// probing one address can never tell existence from the 429, preserving the
+	// no-user-enumeration guarantee below.
+	now := time.Now()
+	if loginLockouts.locked(req.Email, now) {
+		w.Header().Set("Retry-After", strconv.Itoa(int(loginLockWindow().Seconds())))
+		writeJSONError(w, http.StatusTooManyRequests, "too many failed login attempts; please wait a few minutes and try again")
+		return
+	}
+
 	q := store.New(dbPool)
 	user, err := q.GetUserByEmail(r.Context(), req.Email)
 	if errors.Is(err, pgx.ErrNoRows) || (err == nil && !checkUserPassword(user, req.Password)) {
-		// Generic message — never reveal whether the email or the password was wrong.
+		// Generic message — never reveal whether the email or the password was
+		// wrong. Both misses count toward the lockout so the counter accrues the
+		// same way for real and non-existent accounts.
+		loginLockouts.recordFailure(req.Email, now)
 		writeJSONError(w, http.StatusUnauthorized, "invalid email or password")
 		return
 	}
@@ -288,6 +317,9 @@ func loginHandler(w http.ResponseWriter, r *http.Request) {
 		writeJSONError(w, http.StatusInternalServerError, "could not look up account")
 		return
 	}
+
+	// Successful auth clears the failure streak.
+	loginLockouts.reset(req.Email)
 
 	session, err := issueSession(r.Context(), q, user.ID)
 	if err != nil {

--- a/src/packages/api/email_auth_handler.go
+++ b/src/packages/api/email_auth_handler.go
@@ -25,6 +25,13 @@ const (
 	verifyTokenTTL = 24 * time.Hour
 )
 
+// emailSend is the delivery seam used by the throttled transactional flows
+// (verification + password reset). Production routes straight to emailService;
+// tests swap it to observe delivery without an SMTP server.
+var emailSend = func(to, subject, body string) error {
+	return emailService.Send(to, subject, body)
+}
+
 func hashEmailToken(token string) string {
 	sum := sha256.Sum256([]byte(token))
 	return hex.EncodeToString(sum[:])
@@ -88,6 +95,13 @@ func publicAppURL(parts ...string) string {
 // sendVerificationEmail is called fire-and-forget after registration (same
 // pattern as the profile distiller kickoff) and from the resend endpoint.
 func sendVerificationEmail(user store.User) {
+	// Per-address throttle (abuse_caps.go): checked before issuing a token so a
+	// throttled resend doesn't invalidate a still-valid prior token. Keyed by
+	// purpose so verify and reset don't block each other. Anti email-bombing.
+	if !emailSendThrottle.allow("verify:"+strings.ToLower(user.Email), time.Now(), emailMinInterval()) {
+		log.Printf("verification email: throttled for %s (min interval not elapsed)", user.Email)
+		return
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 	q := store.New(dbPool)
@@ -100,7 +114,7 @@ func sendVerificationEmail(user store.User) {
 	body := "Welcome to Golden Tempo Travel!\n\n" +
 		"Confirm your email address by opening this link:\n\n" + link + "\n\n" +
 		"The link expires in 24 hours. If you didn't create an account, you can ignore this email."
-	if err := emailService.Send(user.Email, "Confirm your email — Golden Tempo Travel", body); err != nil {
+	if err := emailSend(user.Email, "Confirm your email — Golden Tempo Travel", body); err != nil {
 		log.Printf("verification email: send to %s failed: %v", user.Email, err)
 	}
 }
@@ -198,6 +212,14 @@ func requestPasswordResetHandler(w http.ResponseWriter, r *http.Request) {
 	if err == nil {
 		u := user
 		safeGo("sendPasswordResetEmail", func() {
+			// Per-address throttle (abuse_caps.go): a rapid second request for
+			// the same address skips the send (and token issue). The handler
+			// still always answers 202, so the throttle is invisible to callers
+			// and can't be used to enumerate accounts. Anti email-bombing.
+			if !emailSendThrottle.allow("reset:"+u.Email, time.Now(), emailMinInterval()) {
+				log.Printf("password reset: throttled for %s (min interval not elapsed)", u.Email)
+				return
+			}
 			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 			defer cancel()
 			token, err := issueEmailToken(ctx, store.New(dbPool), u, "reset", resetTokenTTL)
@@ -210,7 +232,7 @@ func requestPasswordResetHandler(w http.ResponseWriter, r *http.Request) {
 				"If the link doesn't open, use this reset code instead:\n\n    " + token + "\n\n" +
 				"In the app, choose \"Forgot password?\", paste the code, and pick a new password. " +
 				"The link and code are valid for 1 hour and work once. If this wasn't you, ignore this email — your password is unchanged."
-			if err := emailService.Send(u.Email, "Reset your password — Golden Tempo Travel", body); err != nil {
+			if err := emailSend(u.Email, "Reset your password — Golden Tempo Travel", body); err != nil {
 				log.Printf("password reset: send to %s failed: %v", u.Email, err)
 			}
 		})

--- a/src/packages/api/main.go
+++ b/src/packages/api/main.go
@@ -688,6 +688,12 @@ func buildRouter() *mux.Router {
 	anonEvents := rateLimitMiddleware(anonEventsLimiter)
 	router.Use(requestIDMiddleware)
 	router.Use(recoveryMiddleware)
+	// Global concurrency ceiling (abuse_caps.go): a single Pi instance with
+	// WriteTimeout:0 (needed for SSE) has no cap on concurrent in-flight
+	// requests, so a burst could swamp it. Shed excess load early — right after
+	// recovery/requestID — with a non-blocking 503 + Retry-After (/health is
+	// exempt so probes still answer under saturation).
+	router.Use(newConcurrencyLimiter(maxInflightRequests()).middleware)
 	// metricsMiddleware sits right after recovery so it times the full handler
 	// (recovered panics count as the 500 they return) and folds each request
 	// into the in-process opsMetrics registry (ops_metrics.go).

--- a/src/packages/api/plan_handler.go
+++ b/src/packages/api/plan_handler.go
@@ -30,6 +30,15 @@ const planMaxIterations = 15
 // deadline; exceeding it surfaces as a friendly SSE error, not a hang.
 const planModelCallTimeout = 120 * time.Second
 
+// planMaxDuration is the overall wall-clock ceiling for a single /plan request.
+// The server runs with WriteTimeout:0 so SSE can stream unbounded, and
+// planModelCallTimeout only bounds one model call — so without this a stuck
+// stream (client gone, agent loop wedged) could pin its goroutine and its
+// concurrency slot indefinitely. Deriving the handler context from this closes
+// the request after the ceiling and frees the slot. Generous: a rich multi-tool
+// session with compaction stays well under it.
+const planMaxDuration = 10 * time.Minute
+
 // planMaxMessages / planMaxMessageChars bound the resent conversation history.
 // Every agent-loop iteration (up to planMaxIterations) re-pays input tokens on
 // the full history, so these bounds are a hard cost lever. The working limit
@@ -110,6 +119,12 @@ func planHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Overall wall-clock ceiling on the whole request (see planMaxDuration): a
+	// stuck stream eventually closes and frees its goroutine + concurrency slot.
+	ctx, cancel := context.WithTimeout(r.Context(), planMaxDuration)
+	defer cancel()
+	r = r.WithContext(ctx)
+
 	var req PlanRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		sendSSE(w, "error", map[string]string{"message": "invalid request body"})
@@ -159,14 +174,6 @@ func planHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	apiKey := os.Getenv("ANTHROPIC_API_KEY")
-	if apiKey == "" {
-		sendSSE(w, "error", map[string]string{"message": "ANTHROPIC_API_KEY not configured"})
-		return
-	}
-
-	client := newAnthropicClient(apiKey)
-
 	// Resolve the caller once: anonymous sessions get no personalization and no
 	// preference-writing tool; signed-in sessions get both.
 	uid, authed, uerr := userIDFromRequest(r)
@@ -177,7 +184,26 @@ func planHandler(w http.ResponseWriter, r *http.Request) {
 		sendSSE(w, "error", map[string]string{"message": "The service is temporarily unavailable. Please try again in a moment."})
 		return
 	}
-	ctx := r.Context()
+
+	// Anonymous /plan daily cap (abuse_caps.go): the money fix. Signed-in
+	// callers are exempt and uncounted (their measure-only free cap in
+	// free_cap.go is unchanged); anonymous callers get anonPlanPerDay() free AI
+	// planning runs per IP per UTC day, then a friendly SSE error — never a 500.
+	if !anonPlanAllowed(authed, clientIP(r), time.Now()) {
+		safeGo("recordAnonPlanCap", func() {
+			recordEventOpt(nil, "anon_plan_cap_hit", nil, map[string]any{"per_day": anonPlanPerDay()})
+		})
+		sendSSE(w, "error", map[string]string{"message": "You've reached today's free planning limit. Sign in to keep planning, or check back tomorrow."})
+		return
+	}
+
+	apiKey := os.Getenv("ANTHROPIC_API_KEY")
+	if apiKey == "" {
+		sendSSE(w, "error", map[string]string{"message": "ANTHROPIC_API_KEY not configured"})
+		return
+	}
+
+	client := newAnthropicClient(apiKey)
 
 	// Snapshot the wire history as the client sent it, BEFORE the compaction
 	// block below rewrites req.Messages (or prepends the summary-as-message).


### PR DESCRIPTION
Pre-launch hardening PR2 — "don't get brute-forced, don't lose money, don't get swamped." Abuse & cost caps for the Go API taking real users on a home Raspberry Pi.

## Caps added (all in-memory, no migration)

State is process-local by design — the API runs as one instance behind the nginx gateway, matching the existing `ipRateLimiter`. Reset-on-restart is acceptable. New `abuse_caps.go` generalizes the `ipRateLimiter` evicting-map + janitor pattern into three reusable limiters plus a concurrency semaphore.

1. **Per-account login lockout** (`loginHandler`) — after `LOGIN_MAX_FAILURES` (5) consecutive failures keyed by lowercased email, lock the account for `LOGIN_LOCK_MINUTES` (15) and return **429**. Wrong-password and unknown-email count identically, so the lock never reveals account existence (no enumeration). Success resets the streak. Closes the credential-stuffing hole the strict 5/min/**IP** limiter can't (attack spread across IPs).

2. **Anonymous `/plan` daily cap — the money fix** — `FREE_ANON_PLAN_PER_DAY` (5) per client IP per UTC day, applied **only to anonymous callers**. Authenticated callers are exempt **and uncounted** — the measure-only `free_cap.go` behavior for logged-in users is unchanged. Over-cap emits a **friendly SSE `error` event** (never a 500) and records an `anon_plan_cap_hit` analytics event (visible in the admin dashboard). Rolls over at UTC midnight.

3. **Per-address email throttle** — `EMAIL_MIN_INTERVAL_SECONDS` (60) minimum gap between transactional sends (password-reset + verification), keyed by purpose+email, checked before token issue. User-facing responses are **unchanged** (reset stays always-202, verify 202/200), so the throttle is invisible and enumeration-safe. Anti email-bombing.

4. **Per-IP registration ceiling** (`registerHandler`) — `MAX_REGISTRATIONS_PER_IP_PER_DAY` (10) **successful** creations per client IP per UTC day, else **429**.

5. **Global concurrency cap + `/plan` wall-clock bound** — a `MAX_INFLIGHT_REQUESTS` (100) buffered-channel semaphore middleware wired early in `buildRouter`; non-blocking acquire sheds excess load with **503 + Retry-After** (`/health` exempt). Plus a `planMaxDuration` (10m) context on the whole `/plan` request so a stuck stream eventually frees its goroutine + concurrency slot (complements PR1's per-Anthropic-call 120s timeout).

## Notes
- All thresholds are env-tunable via the existing `envInt` helper and documented in `.env.sample`.
- The anonymous `/plan` cap does **not** affect authenticated requests: `anonPlanAllowed(authed=true, ...)` returns true without touching the counter (unit-tested).
- Only `src/packages/api/` touched; no `store/` changes, no migration.

## Tests
Fake-clock unit tests for each limiter + the concurrency middleware + the `/plan` cap SSE shape, plus DB-backed integration tests through the shared router (login lockout cross-IP + reset-on-success, registration ceiling, email throttle single-send). `cd src/packages/api && gofmt -w . && go vet ./... && go test ./... -race` all pass (including the known-flaky `TestStrictRateLimiterOnRegister`, unaffected by the ceiling default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)