### PR TITLE
feat(api): input validation + data caps + QA sweep (Hardening PR3)

### DIFF
--- a/src/packages/api/accommodation_handler.go
+++ b/src/packages/api/accommodation_handler.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
@@ -11,6 +12,28 @@ import (
 
 	"travel-route-planner/store"
 )
+
+// validateAccommodationInput bounds the free-text/coordinate fields shared by
+// the add + patch paths. Length ceilings are generous — this blocks megabyte
+// sinks, not normal input.
+func validateAccommodationInput(req *AddAccommodationRequest) error {
+	if _, err := boundedString("name", req.Name, maxNameLen); err != nil {
+		return err
+	}
+	if err := boundedOptional("provider", req.Provider, maxProviderLen); err != nil {
+		return err
+	}
+	if err := boundedOptional("url", req.URL, maxURLLen); err != nil {
+		return err
+	}
+	if err := boundedOptional("address", req.Address, maxAddressLen); err != nil {
+		return err
+	}
+	if err := boundedOptional("price_note", req.PriceNote, maxNoteLen); err != nil {
+		return err
+	}
+	return validateCoords(req.Latitude, req.Longitude)
+}
 
 type AccommodationResponse struct {
 	ID        string   `json:"id"`
@@ -99,6 +122,10 @@ func addAccommodationHandler(w http.ResponseWriter, r *http.Request) {
 		writeJSONError(w, http.StatusBadRequest, "name is required")
 		return
 	}
+	if err := validateAccommodationInput(&req); err != nil {
+		writeJSONError(w, http.StatusBadRequest, err.Error())
+		return
+	}
 	checkIn, err := parseDateParam(req.CheckIn)
 	if err != nil {
 		writeJSONError(w, http.StatusBadRequest, "check_in must be YYYY-MM-DD")
@@ -107,6 +134,12 @@ func addAccommodationHandler(w http.ResponseWriter, r *http.Request) {
 	checkOut, err := parseDateParam(req.CheckOut)
 	if err != nil {
 		writeJSONError(w, http.StatusBadRequest, "check_out must be YYYY-MM-DD")
+		return
+	}
+	if existing, err := store.New(dbPool).ListAccommodationsByTrip(r.Context(), tripID); err == nil &&
+		len(existing) >= maxAccommodationsPerTrip() {
+		writeJSONError(w, http.StatusUnprocessableEntity,
+			fmt.Sprintf("accommodation limit reached (max %d) — remove one first", maxAccommodationsPerTrip()))
 		return
 	}
 
@@ -148,6 +181,10 @@ func updateAccommodationHandler(w http.ResponseWriter, r *http.Request) {
 	var req AddAccommodationRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		writeJSONError(w, http.StatusBadRequest, "invalid JSON")
+		return
+	}
+	if err := validateAccommodationInput(&req); err != nil {
+		writeJSONError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 	checkIn, err := parseDateParam(req.CheckIn)

--- a/src/packages/api/auth_handler.go
+++ b/src/packages/api/auth_handler.go
@@ -218,6 +218,14 @@ func registerHandler(w http.ResponseWriter, r *http.Request) {
 		writeJSONError(w, http.StatusUnprocessableEntity, "password must be at least 8 characters")
 		return
 	}
+	// Cap the optional display name, mirroring the account-update path's 60-rune
+	// limit (account_handler.go). Empty/absent falls back to a default below.
+	if req.DisplayName != nil {
+		if _, err := boundedString("display_name", *req.DisplayName, maxDisplayNameLen); err != nil {
+			writeJSONError(w, http.StatusUnprocessableEntity, err.Error())
+			return
+		}
+	}
 
 	// Per-IP daily account-creation ceiling (abuse_caps.go): stops one network
 	// from minting accounts en masse. Counts only successful creations (bumped

--- a/src/packages/api/booking_todo_handler.go
+++ b/src/packages/api/booking_todo_handler.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"strings"
 
@@ -238,6 +239,22 @@ func addBookingTodoHandler(w http.ResponseWriter, r *http.Request) {
 		writeJSONError(w, http.StatusBadRequest, "title is required")
 		return
 	}
+	if _, err := boundedString("title", req.Title, maxNameLen); err != nil {
+		writeJSONError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if err := boundedOptional("subtitle", req.Subtitle, maxNameLen); err != nil {
+		writeJSONError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if err := boundedOptional("provider", req.Provider, maxProviderLen); err != nil {
+		writeJSONError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if err := boundedOptional("search_url", req.SearchURL, maxURLLen); err != nil {
+		writeJSONError(w, http.StatusBadRequest, err.Error())
+		return
+	}
 	depart, err := parseDateParam(req.DepartDate)
 	if err != nil {
 		writeJSONError(w, http.StatusBadRequest, "depart_date must be YYYY-MM-DD")
@@ -246,6 +263,12 @@ func addBookingTodoHandler(w http.ResponseWriter, r *http.Request) {
 	ret, err := parseDateParam(req.ReturnDate)
 	if err != nil {
 		writeJSONError(w, http.StatusBadRequest, "return_date must be YYYY-MM-DD")
+		return
+	}
+	if existing, err := store.New(dbPool).ListBookingTodosByTrip(r.Context(), tripID); err == nil &&
+		len(existing) >= maxBookingTodosPerTrip() {
+		writeJSONError(w, http.StatusUnprocessableEntity,
+			fmt.Sprintf("booking todo limit reached (max %d) — remove one first", maxBookingTodosPerTrip()))
 		return
 	}
 
@@ -350,7 +373,19 @@ func patchBookingTodoHandler(w http.ResponseWriter, r *http.Request) {
 				writeJSONError(w, http.StatusBadRequest, "title cannot be empty")
 				return
 			}
+			if _, err := boundedString("title", t, maxNameLen); err != nil {
+				writeJSONError(w, http.StatusBadRequest, err.Error())
+				return
+			}
 			title = &t
+		}
+		if err := boundedOptional("subtitle", req.Subtitle, maxNameLen); err != nil {
+			writeJSONError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		if err := boundedOptional("search_url", req.SearchURL, maxURLLen); err != nil {
+			writeJSONError(w, http.StatusBadRequest, err.Error())
+			return
 		}
 		depart, derr := parseDateParam(req.DepartDate)
 		if derr != nil {

--- a/src/packages/api/budget_handler.go
+++ b/src/packages/api/budget_handler.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"strings"
 
@@ -204,6 +205,10 @@ func addExpenseHandler(w http.ResponseWriter, r *http.Request) {
 		writeJSONError(w, http.StatusBadRequest, "label is required")
 		return
 	}
+	if _, err := boundedString("label", label, maxNameLen); err != nil {
+		writeJSONError(w, http.StatusBadRequest, err.Error())
+		return
+	}
 	if req.Amount < 0 {
 		writeJSONError(w, http.StatusBadRequest, "amount cannot be negative")
 		return
@@ -215,6 +220,12 @@ func addExpenseHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	q := store.New(dbPool)
+	if existing, err := q.ListExpensesByTrip(r.Context(), trip.ID); err == nil &&
+		len(existing) >= maxExpensesPerTrip() {
+		writeJSONError(w, http.StatusUnprocessableEntity,
+			fmt.Sprintf("expense limit reached (max %d) — remove one first", maxExpensesPerTrip()))
+		return
+	}
 	expense, err := q.CreateExpense(r.Context(), store.CreateExpenseParams{
 		TripID:   trip.ID,
 		Category: category,
@@ -272,6 +283,10 @@ func patchExpenseHandler(w http.ResponseWriter, r *http.Request) {
 		l := strings.TrimSpace(*req.Label)
 		if l == "" {
 			writeJSONError(w, http.StatusBadRequest, "label cannot be empty")
+			return
+		}
+		if _, err := boundedString("label", l, maxNameLen); err != nil {
+			writeJSONError(w, http.StatusBadRequest, err.Error())
 			return
 		}
 		params.Label = &l

--- a/src/packages/api/checklist_handler.go
+++ b/src/packages/api/checklist_handler.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"strings"
 
@@ -89,9 +90,19 @@ func addChecklistItemHandler(w http.ResponseWriter, r *http.Request) {
 		writeJSONError(w, http.StatusBadRequest, "title is required")
 		return
 	}
+	if _, err := boundedString("title", title, maxNameLen); err != nil {
+		writeJSONError(w, http.StatusBadRequest, err.Error())
+		return
+	}
 	category, valid := normalizeChecklistCategory(req.Category)
 	if !valid {
 		writeJSONError(w, http.StatusBadRequest, "category must be one of: clothing, documents, electronics, health, general")
+		return
+	}
+	if n, err := store.New(dbPool).CountChecklistItemsByTrip(r.Context(), trip.ID); err == nil &&
+		int(n) >= maxChecklistItemsPerTrip() {
+		writeJSONError(w, http.StatusUnprocessableEntity,
+			fmt.Sprintf("checklist is full (max %d items) — remove one first", maxChecklistItemsPerTrip()))
 		return
 	}
 
@@ -153,6 +164,10 @@ func patchChecklistItemHandler(w http.ResponseWriter, r *http.Request) {
 		t := strings.TrimSpace(*req.Title)
 		if t == "" {
 			writeJSONError(w, http.StatusBadRequest, "title cannot be empty")
+			return
+		}
+		if _, err := boundedString("title", t, maxNameLen); err != nil {
+			writeJSONError(w, http.StatusBadRequest, err.Error())
 			return
 		}
 		params.Title = &t

--- a/src/packages/api/itinerary_item_handler.go
+++ b/src/packages/api/itinerary_item_handler.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"strings"
 
@@ -64,6 +65,30 @@ func addItineraryItemHandler(w http.ResponseWriter, r *http.Request) {
 		writeJSONError(w, http.StatusBadRequest, "name is required")
 		return
 	}
+	if _, err := boundedString("name", name, maxNameLen); err != nil {
+		writeJSONError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if err := validateCoords(req.Latitude, req.Longitude); err != nil {
+		writeJSONError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if err := boundedOptional("address", req.Address, maxAddressLen); err != nil {
+		writeJSONError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if err := boundedOptional("city", req.City, maxNameLen); err != nil {
+		writeJSONError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if err := boundedOptional("day_trip_from", req.DayTripFrom, maxNameLen); err != nil {
+		writeJSONError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if err := boundedOptional("local_source_name", req.LocalSourceName, maxNameLen); err != nil {
+		writeJSONError(w, http.StatusBadRequest, err.Error())
+		return
+	}
 	var category *string
 	if req.Category != nil {
 		c := strings.ToLower(strings.TrimSpace(*req.Category))
@@ -84,8 +109,8 @@ func addItineraryItemHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	var day *int32
 	if req.Day != nil {
-		if *req.Day < 1 {
-			writeJSONError(w, http.StatusBadRequest, "day must be >= 1")
+		if *req.Day < 1 || *req.Day > maxItineraryDay {
+			writeJSONError(w, http.StatusBadRequest, fmt.Sprintf("day must be between 1 and %d", maxItineraryDay))
 			return
 		}
 		d := int32(*req.Day)
@@ -137,6 +162,11 @@ func addItineraryItemHandler(w http.ResponseWriter, r *http.Request) {
 	items, err := q.GetItineraryItemsByTrip(ctx, tripID)
 	if err != nil {
 		writeJSONError(w, http.StatusInternalServerError, "could not load itinerary")
+		return
+	}
+	if len(items) >= maxItemsPerTrip() {
+		writeJSONError(w, http.StatusUnprocessableEntity,
+			fmt.Sprintf("itinerary is full (max %d items) — remove one first", maxItemsPerTrip()))
 		return
 	}
 	pos := insertPositionForDay(items, req.Day)
@@ -230,11 +260,31 @@ func patchItineraryItemHandler(w http.ResponseWriter, r *http.Request) {
 		writeJSONError(w, http.StatusBadRequest, "invalid JSON")
 		return
 	}
+	if err := validateCoords(req.Latitude, req.Longitude); err != nil {
+		writeJSONError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if err := boundedOptional("address", req.Address, maxAddressLen); err != nil {
+		writeJSONError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if err := boundedOptional("city", req.City, maxNameLen); err != nil {
+		writeJSONError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if err := boundedOptional("day_trip_from", req.DayTripFrom, maxNameLen); err != nil {
+		writeJSONError(w, http.StatusBadRequest, err.Error())
+		return
+	}
 	params := store.UpdateItineraryItemParams{ID: itemID, TripID: tripID}
 	if req.Name != nil {
 		n := strings.TrimSpace(*req.Name)
 		if n == "" {
 			writeJSONError(w, http.StatusBadRequest, "name cannot be empty")
+			return
+		}
+		if _, err := boundedString("name", n, maxNameLen); err != nil {
+			writeJSONError(w, http.StatusBadRequest, err.Error())
 			return
 		}
 		params.Name = &n
@@ -256,8 +306,8 @@ func patchItineraryItemHandler(w http.ResponseWriter, r *http.Request) {
 		params.TimeOfDay = &t
 	}
 	if req.Day != nil {
-		if *req.Day < 1 {
-			writeJSONError(w, http.StatusBadRequest, "day must be >= 1")
+		if *req.Day < 1 || *req.Day > maxItineraryDay {
+			writeJSONError(w, http.StatusBadRequest, fmt.Sprintf("day must be between 1 and %d", maxItineraryDay))
 			return
 		}
 		d := int32(*req.Day)

--- a/src/packages/api/segment_handler.go
+++ b/src/packages/api/segment_handler.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
@@ -14,6 +15,27 @@ import (
 
 var allowedSegmentModes = map[string]bool{
 	"flight": true, "train": true, "bus": true, "car": true, "ferry": true, "other": true,
+}
+
+// validateSegmentInput bounds the free-text fields shared by the add + patch
+// paths. `notes` is the biggest megabyte sink, so it gets the note ceiling.
+func validateSegmentInput(req *AddSegmentRequest) error {
+	if err := boundedOptional("origin", req.Origin, maxNameLen); err != nil {
+		return err
+	}
+	if err := boundedOptional("destination", req.Destination, maxNameLen); err != nil {
+		return err
+	}
+	if err := boundedOptional("provider", req.Provider, maxProviderLen); err != nil {
+		return err
+	}
+	if err := boundedOptional("url", req.URL, maxURLLen); err != nil {
+		return err
+	}
+	if err := boundedOptional("price_note", req.PriceNote, maxNoteLen); err != nil {
+		return err
+	}
+	return boundedOptional("notes", req.Notes, maxNoteLen)
 }
 
 type SegmentResponse struct {
@@ -103,6 +125,10 @@ func addSegmentHandler(w http.ResponseWriter, r *http.Request) {
 		writeJSONError(w, http.StatusBadRequest, "mode must be one of: flight, train, bus, car, ferry, other")
 		return
 	}
+	if err := validateSegmentInput(&req); err != nil {
+		writeJSONError(w, http.StatusBadRequest, err.Error())
+		return
+	}
 	depart, err := parseDateParam(req.DepartDate)
 	if err != nil {
 		writeJSONError(w, http.StatusBadRequest, "depart_date must be YYYY-MM-DD")
@@ -115,6 +141,12 @@ func addSegmentHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	if depart.Valid && arrive.Valid && arrive.Time.Before(depart.Time) {
 		writeJSONError(w, http.StatusBadRequest, "arrive_date must not be before depart_date")
+		return
+	}
+	if existing, err := store.New(dbPool).ListSegmentsByTrip(r.Context(), tripID); err == nil &&
+		len(existing) >= maxSegmentsPerTrip() {
+		writeJSONError(w, http.StatusUnprocessableEntity,
+			fmt.Sprintf("segment limit reached (max %d) — remove one first", maxSegmentsPerTrip()))
 		return
 	}
 
@@ -161,6 +193,10 @@ func updateSegmentHandler(w http.ResponseWriter, r *http.Request) {
 	mode := strings.ToLower(strings.TrimSpace(req.Mode))
 	if mode != "" && !allowedSegmentModes[mode] {
 		writeJSONError(w, http.StatusBadRequest, "mode must be one of: flight, train, bus, car, ferry, other")
+		return
+	}
+	if err := validateSegmentInput(&req); err != nil {
+		writeJSONError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 	depart, err := parseDateParam(req.DepartDate)

--- a/src/packages/api/segment_integration_test.go
+++ b/src/packages/api/segment_integration_test.go
@@ -1,0 +1,156 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"travel-route-planner/store"
+)
+
+// Segment CRUD + input-validation coverage. Mirrors the accommodation/booking
+// integration tests: create trip → add → patch → list → delete, plus the
+// negative-input rejections added in the hardening sweep.
+
+func TestSegmentOwnerCRUD(t *testing.T) {
+	resetDB(t)
+	owner, token := createTestUser(t, "owner@example.com")
+	trip := createTestTrip(t, owner.ID, 0)
+	base := "/api/v1/trips/" + trip.ID.String()
+
+	// Add a valid segment.
+	add := doJSON(t, "POST", base+"/segments", token, map[string]any{
+		"mode": "train", "origin": "Athens", "destination": "Thessaloniki",
+		"depart_date": "2026-08-01", "provider": "Hellenic Train",
+		"price_note": "~40 EUR", "notes": "book aisle seat",
+	})
+	if add.Code != http.StatusCreated {
+		t.Fatalf("add = %d: %s", add.Code, add.Body.String())
+	}
+	created := decode(t, add)
+	segID := created["id"].(string)
+	if created["mode"] != "train" || created["origin"] != "Athens" {
+		t.Fatalf("created segment = %v", created)
+	}
+
+	// Patch it (edit confirms the row; content updates apply).
+	patch := doJSON(t, "PATCH", base+"/segments/"+segID, token, map[string]any{
+		"mode": "bus", "destination": "Meteora", "notes": "day trip",
+	})
+	if patch.Code != http.StatusOK {
+		t.Fatalf("patch = %d: %s", patch.Code, patch.Body.String())
+	}
+	if got := decode(t, patch); got["mode"] != "bus" || got["destination"] != "Meteora" {
+		t.Fatalf("patched segment = %v", got)
+	}
+
+	// List (via the trip GET) shows the segment.
+	segs, err := store.New(dbPool).ListSegmentsByTrip(context.Background(), trip.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(segs) != 1 {
+		t.Fatalf("want 1 segment, got %d", len(segs))
+	}
+
+	// Delete.
+	del := doJSON(t, "DELETE", base+"/segments/"+segID, token, nil)
+	if del.Code != http.StatusNoContent {
+		t.Fatalf("delete = %d: %s", del.Code, del.Body.String())
+	}
+	segs, err = store.New(dbPool).ListSegmentsByTrip(context.Background(), trip.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(segs) != 0 {
+		t.Fatalf("segment survived delete: %d", len(segs))
+	}
+}
+
+func TestSegmentCrossUserIsolation(t *testing.T) {
+	resetDB(t)
+	owner, ownerToken := createTestUser(t, "owner@example.com")
+	_, intruderToken := createTestUser(t, "intruder@example.com")
+	trip := createTestTrip(t, owner.ID, 0)
+	base := "/api/v1/trips/" + trip.ID.String()
+
+	add := doJSON(t, "POST", base+"/segments", ownerToken, map[string]any{
+		"mode": "flight", "origin": "JFK", "destination": "CDG",
+	})
+	if add.Code != http.StatusCreated {
+		t.Fatalf("owner add = %d: %s", add.Code, add.Body.String())
+	}
+	segID := decode(t, add)["id"].(string)
+
+	cases := []struct {
+		method, path string
+		body         any
+	}{
+		{"POST", base + "/segments", map[string]any{"mode": "train", "origin": "A", "destination": "B"}},
+		{"PATCH", base + "/segments/" + segID, map[string]any{"mode": "bus"}},
+		{"DELETE", base + "/segments/" + segID, nil},
+	}
+	for _, tc := range cases {
+		if rec := doJSON(t, tc.method, tc.path, intruderToken, tc.body); rec.Code != http.StatusNotFound {
+			t.Fatalf("intruder %s %s = %d, want 404", tc.method, tc.path, rec.Code)
+		}
+	}
+}
+
+func TestSegmentValidation(t *testing.T) {
+	resetDB(t)
+	owner, token := createTestUser(t, "owner@example.com")
+	trip := createTestTrip(t, owner.ID, 0)
+	base := "/api/v1/trips/" + trip.ID.String()
+
+	// Bad mode → 400.
+	if rec := doJSON(t, "POST", base+"/segments", token, map[string]any{
+		"mode": "teleport", "origin": "A", "destination": "B",
+	}); rec.Code != http.StatusBadRequest {
+		t.Fatalf("bad mode = %d, want 400", rec.Code)
+	}
+
+	// Oversized notes (5 MB) → rejected, nothing persisted. notes is the biggest
+	// sink. A body this large is stopped by the 256 KiB body-limit middleware
+	// (413) before reaching the handler; a smaller-but-still-over-cap notes
+	// (below) exercises the handler's own boundedOptional check (400).
+	huge := make([]byte, 5<<20)
+	for i := range huge {
+		huge[i] = 'x'
+	}
+	if rec := doJSON(t, "POST", base+"/segments", token, map[string]any{
+		"mode": "train", "origin": "A", "destination": "B", "notes": string(huge),
+	}); rec.Code != http.StatusRequestEntityTooLarge && rec.Code != http.StatusBadRequest {
+		t.Fatalf("oversized notes = %d, want 413 or 400: %s", rec.Code, rec.Body.String())
+	}
+
+	// Over-cap notes that fits under the body limit → the handler's own 400.
+	overCap := make([]byte, maxNoteLen+1)
+	for i := range overCap {
+		overCap[i] = 'x'
+	}
+	if rec := doJSON(t, "POST", base+"/segments", token, map[string]any{
+		"mode": "train", "origin": "A", "destination": "B", "notes": string(overCap),
+	}); rec.Code != http.StatusBadRequest {
+		t.Fatalf("over-cap notes = %d, want 400: %s", rec.Code, rec.Body.String())
+	}
+
+	// Over-length origin → 400.
+	longOrigin := make([]byte, maxNameLen+1)
+	for i := range longOrigin {
+		longOrigin[i] = 'a'
+	}
+	if rec := doJSON(t, "POST", base+"/segments", token, map[string]any{
+		"mode": "train", "origin": string(longOrigin), "destination": "B",
+	}); rec.Code != http.StatusBadRequest {
+		t.Fatalf("over-length origin = %d, want 400", rec.Code)
+	}
+
+	segs, err := store.New(dbPool).ListSegmentsByTrip(context.Background(), trip.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(segs) != 0 {
+		t.Fatalf("rejected segments persisted: %d", len(segs))
+	}
+}

--- a/src/packages/api/trip_handler.go
+++ b/src/packages/api/trip_handler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log"
 	"net/http"
 	"strings"
@@ -235,6 +236,15 @@ func persistTrip(ctx context.Context, userID uuid.UUID, chatID, title, summary, 
 			newLineage = false
 		case exists:
 			newLineage = false
+		}
+	}
+
+	// Runaway guard: a brand-new lineage counts against the per-user trip cap.
+	// Version saves of an existing lineage are exempt (they don't grow the
+	// lineage count). Generous by default — a normal user never hits it.
+	if newLineage {
+		if n, cerr := q.CountActiveTripLineagesByOwner(ctx, userID); cerr == nil && int(n) >= maxTripsPerUser() {
+			return "", false, fmt.Errorf("trip limit reached (%d trips) — delete an old trip first", maxTripsPerUser())
 		}
 	}
 
@@ -512,6 +522,18 @@ func patchTripHandler(w http.ResponseWriter, r *http.Request) {
 	if req.Status != nil && !allowedStatuses[*req.Status] {
 		writeJSONError(w, http.StatusBadRequest, "status must be 'draft' or 'planned'")
 		return
+	}
+	if req.Title != nil {
+		t := strings.TrimSpace(*req.Title)
+		if t == "" {
+			writeJSONError(w, http.StatusBadRequest, "title cannot be empty")
+			return
+		}
+		if _, err := boundedString("title", t, maxNameLen); err != nil {
+			writeJSONError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		req.Title = &t
 	}
 
 	start, err := parseDateParam(req.StartDate)

--- a/src/packages/api/validation.go
+++ b/src/packages/api/validation.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+	"unicode/utf8"
+)
+
+// validation.go — shared input validators and per-user/per-trip data-volume
+// caps (Hardening PR3). The goal is narrow: reject obviously bad input
+// (out-of-range coordinates, megabyte string sinks) and bound how much a single
+// user or trip can store, so one client can't fill the disk or wedge the
+// single-instance API. The length ceilings are deliberately generous — these
+// are abuse/runaway guards, not product rules — and the data-volume caps are
+// env-tunable via envInt (like the ALERT_* / FREE_* knobs), read at call time.
+
+// --- field length ceilings (rune counts). Generous by design. ---
+
+const (
+	maxNameLen        = 200  // titles, place names, cities, origins/destinations
+	maxProviderLen    = 200  // provider labels
+	maxAddressLen     = 500  // postal addresses
+	maxURLLen         = 2000 // search/booking links
+	maxNoteLen        = 5000 // price_note / free-text notes — the biggest sinks
+	maxDisplayNameLen = 60   // mirror the account-update cap (account_handler.go)
+
+	// maxItineraryDay bounds a manually-set day number. A floor of >= 1 already
+	// exists in the item handlers; this is the missing ceiling. 366 covers a
+	// year-plus trip with slack.
+	maxItineraryDay = 366
+)
+
+// validateCoords enforces valid WGS84 ranges when coordinates are provided.
+// Nil is allowed — coordinates are optional in several models (name-only
+// resolution). Mirrors the bounds the /optimize-route and /plan paths use.
+func validateCoords(lat, lng *float64) error {
+	if lat != nil && (*lat < -90 || *lat > 90) {
+		return fmt.Errorf("latitude must be between -90 and 90")
+	}
+	if lng != nil && (*lng < -180 || *lng > 180) {
+		return fmt.Errorf("longitude must be between -180 and 180")
+	}
+	return nil
+}
+
+// boundedString trims val and enforces a max rune length, returning the trimmed
+// value. It is for required fields the caller already trims + non-empty-checks;
+// an over-length value yields a clear "field too long" 400.
+func boundedString(field, val string, max int) (string, error) {
+	v := strings.TrimSpace(val)
+	if utf8.RuneCountInString(v) > max {
+		return "", fmt.Errorf("%s too long (max %d characters)", field, max)
+	}
+	return v, nil
+}
+
+// boundedOptional length-checks an optional (pointer) string field without
+// mutating it, so the handlers' existing nil-vs-empty semantics are untouched.
+// Nil passes. It only rejects megabyte sinks.
+func boundedOptional(field string, val *string, max int) error {
+	if val == nil {
+		return nil
+	}
+	if utf8.RuneCountInString(*val) > max {
+		return fmt.Errorf("%s too long (max %d characters)", field, max)
+	}
+	return nil
+}
+
+// --- per-user / per-trip data-volume caps (runaway guards). Count-before-
+// insert, generous defaults, env-tunable. Mirror maxActiveAlertsPerUser
+// (price_alert_handler.go): count first, reject with a clear 422 when over. ---
+
+const (
+	defaultMaxTripsPerUser          = 200
+	defaultMaxItemsPerTrip          = 500
+	defaultMaxExpensesPerTrip       = 200
+	defaultMaxSegmentsPerTrip       = 200
+	defaultMaxAccommodationsPerTrip = 200
+	defaultMaxChecklistItemsPerTrip = 200
+	defaultMaxBookingTodosPerTrip   = 200
+)
+
+func maxTripsPerUser() int { return envInt("MAX_TRIPS_PER_USER", defaultMaxTripsPerUser) }
+func maxItemsPerTrip() int { return envInt("MAX_ITEMS_PER_TRIP", defaultMaxItemsPerTrip) }
+func maxExpensesPerTrip() int {
+	return envInt("MAX_EXPENSES_PER_TRIP", defaultMaxExpensesPerTrip)
+}
+func maxSegmentsPerTrip() int {
+	return envInt("MAX_SEGMENTS_PER_TRIP", defaultMaxSegmentsPerTrip)
+}
+func maxAccommodationsPerTrip() int {
+	return envInt("MAX_ACCOMMODATIONS_PER_TRIP", defaultMaxAccommodationsPerTrip)
+}
+func maxChecklistItemsPerTrip() int {
+	return envInt("MAX_CHECKLIST_ITEMS_PER_TRIP", defaultMaxChecklistItemsPerTrip)
+}
+func maxBookingTodosPerTrip() int {
+	return envInt("MAX_BOOKING_TODOS_PER_TRIP", defaultMaxBookingTodosPerTrip)
+}

--- a/src/packages/api/validation_integration_test.go
+++ b/src/packages/api/validation_integration_test.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"net/http"
+	"testing"
+)
+
+// Negative-input QA sweep (Hardening PR3). Proves the shared validators and the
+// per-trip data-volume caps reject bad input across the CRUD write handlers.
+// Uses the requireDB/resetDB/doJSON harness in integration_test.go.
+
+func TestValidationRejectsBadCoords(t *testing.T) {
+	resetDB(t)
+	owner, token := createTestUser(t, "owner@example.com")
+	trip := createTestTrip(t, owner.ID, 0)
+	base := "/api/v1/trips/" + trip.ID.String()
+
+	// Itinerary item with an out-of-range latitude → 400.
+	if rec := doJSON(t, "POST", base+"/items", token, map[string]any{
+		"name": "Bad Coords", "latitude": 9999.0, "longitude": 12.0,
+	}); rec.Code != http.StatusBadRequest {
+		t.Fatalf("item lat=9999 = %d, want 400: %s", rec.Code, rec.Body.String())
+	}
+
+	// Accommodation with an out-of-range longitude → 400.
+	if rec := doJSON(t, "POST", base+"/accommodations", token, map[string]any{
+		"name": "Bad Hotel", "latitude": 12.0, "longitude": 9999.0,
+	}); rec.Code != http.StatusBadRequest {
+		t.Fatalf("accommodation lng=9999 = %d, want 400: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestValidationRejectsEmptyTripTitle(t *testing.T) {
+	resetDB(t)
+	owner, token := createTestUser(t, "owner@example.com")
+	trip := createTestTrip(t, owner.ID, 0)
+
+	if rec := doJSON(t, "PATCH", "/api/v1/trips/"+trip.ID.String(), token, map[string]any{
+		"title": "   ",
+	}); rec.Code != http.StatusBadRequest {
+		t.Fatalf("empty trip title = %d, want 400: %s", rec.Code, rec.Body.String())
+	}
+
+	// Over-length title → 400.
+	long := make([]byte, maxNameLen+1)
+	for i := range long {
+		long[i] = 'a'
+	}
+	if rec := doJSON(t, "PATCH", "/api/v1/trips/"+trip.ID.String(), token, map[string]any{
+		"title": string(long),
+	}); rec.Code != http.StatusBadRequest {
+		t.Fatalf("over-length trip title = %d, want 400", rec.Code)
+	}
+}
+
+func TestValidationRejectsHugeDay(t *testing.T) {
+	resetDB(t)
+	owner, token := createTestUser(t, "owner@example.com")
+	trip := createTestTrip(t, owner.ID, 0)
+	base := "/api/v1/trips/" + trip.ID.String()
+
+	if rec := doJSON(t, "POST", base+"/items", token, map[string]any{
+		"name": "Far Future", "latitude": 1.0, "longitude": 2.0, "day": 1000000000,
+	}); rec.Code != http.StatusBadRequest {
+		t.Fatalf("day=1e9 = %d, want 400: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestValidationRejectsOversizedLabel(t *testing.T) {
+	resetDB(t)
+	owner, token := createTestUser(t, "owner@example.com")
+	trip := createTestTrip(t, owner.ID, 0)
+	base := "/api/v1/trips/" + trip.ID.String()
+
+	long := make([]byte, maxNameLen+1)
+	for i := range long {
+		long[i] = 'x'
+	}
+	if rec := doJSON(t, "POST", base+"/budget/expenses", token, map[string]any{
+		"category": "food", "label": string(long), "amount": 10.0,
+	}); rec.Code != http.StatusBadRequest {
+		t.Fatalf("over-length expense label = %d, want 400: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestItemVolumeCap(t *testing.T) {
+	resetDB(t)
+	t.Setenv("MAX_ITEMS_PER_TRIP", "2")
+	owner, token := createTestUser(t, "owner@example.com")
+	trip := createTestTrip(t, owner.ID, 2) // already at the cap
+	base := "/api/v1/trips/" + trip.ID.String()
+
+	if rec := doJSON(t, "POST", base+"/items", token, map[string]any{
+		"name": "One Too Many", "latitude": 1.0, "longitude": 2.0,
+	}); rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("item over cap = %d, want 422: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestExpenseVolumeCap(t *testing.T) {
+	resetDB(t)
+	t.Setenv("MAX_EXPENSES_PER_TRIP", "1")
+	owner, token := createTestUser(t, "owner@example.com")
+	trip := createTestTrip(t, owner.ID, 0)
+	base := "/api/v1/trips/" + trip.ID.String()
+
+	// First expense fits.
+	if rec := doJSON(t, "POST", base+"/budget/expenses", token, map[string]any{
+		"category": "food", "label": "Lunch", "amount": 12.0,
+	}); rec.Code != http.StatusCreated {
+		t.Fatalf("first expense = %d, want 201: %s", rec.Code, rec.Body.String())
+	}
+	// Second is over the cap.
+	if rec := doJSON(t, "POST", base+"/budget/expenses", token, map[string]any{
+		"category": "food", "label": "Dinner", "amount": 30.0,
+	}); rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("expense over cap = %d, want 422: %s", rec.Code, rec.Body.String())
+	}
+}


### PR DESCRIPTION
Final PR of the pre-launch hardening wave: reject bad input, bound stored data, test the negatives. Based on `origin/main` (includes PR1+PR2). **No migration; `store/` untouched.**

## Shared validators (`validation.go`)
- `validateCoords(lat, lng *float64)` — enforces lat ∈ [-90,90], lng ∈ [-180,180] when non-nil (mirrors the `/optimize-route` + `/plan` bounds); nil allowed (coords optional).
- `boundedString` / `boundedOptional` — rune-length ceilings (names/cities 200, address 500, url 2000, notes/price_note 5000, provider 200, display_name 60). Generous by design — blocks megabyte sinks, not normal input.

## Validation applied to the CRUD write handlers
- **Itinerary items** (add + patch): coords, `name`/`city`/`address`/`day_trip_from`/`local_source_name`, and a `day` **upper bound** (1..366; the ≥1 floor already existed).
- **Accommodations** (add + patch): coords + `name`/`provider`/`url`/`address`/`price_note` (shared helper).
- **Segments** (add + patch): `origin`/`destination`/`provider`/`url`/`price_note`/**`notes`** — notes is the biggest sink (shared helper).
- **Trip** (`patchTripHandler`): `title` non-empty-after-trim and capped.
- **Budget expense** (add + patch): `label` capped.
- **Booking todo** (add + patch): `title`/`subtitle`/`provider`/`search_url` capped.
- **Register**: `display_name` capped (mirrors the 60-rune account-update cap).

All return a clean **400** via the existing `writeJSONError` envelope.

## Per-user / per-trip data-volume caps (runaway guards)
Count-before-insert, generous env-tunable defaults (`envInt`, like `maxActiveAlertsPerUser`); over-cap returns **422**:
- trips per user (200, `persistTrip`, new lineages only — version saves exempt)
- itinerary items (500), expenses / segments / accommodations / checklist items / booking-todos per trip (200 each)

Reuses existing `CountActiveTripLineagesByOwner` / `CountChecklistItemsByTrip` and list-then-len for the rest — **no new sqlc query, `store/` unchanged.**

## QA sweep — negative-input tests
- `validation_integration_test.go`: bad coords (lat/lng 9999 → 400), empty + over-length trip title → 400, `day`=1e9 → 400, oversized expense label → 400, item cap + expense cap → 422.
- `segment_integration_test.go` (new — none existed): create → add → patch → list → delete + cross-user isolation + validation rejections (bad mode, 5 MB notes rejected upstream by the 256 KiB body limit, over-cap notes → handler 400, over-length origin → 400).

## Verification
`gofmt -w . && go vet ./... && go test ./... -race` — all pass (full suite green against a local `travel_planner_test` Postgres, incl. the known-flaky rate-limiter test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)