### PR TITLE
fix(prod): relative redirects behind the tunnel

### DIFF
--- a/dockerize/production/nginx/prod.conf
+++ b/dockerize/production/nginx/prod.conf
@@ -23,6 +23,12 @@ server {
     listen [::]:80 default_server;
     server_name goldentempotravel.com;
 
+    # The origin speaks plain http behind the tunnel, so nginx's default
+    # absolute redirects (e.g. the snippet's `return 301 /app/;`) would be
+    # expanded to http:// URLs and briefly downgrade users off TLS. Relative
+    # Location headers keep the browser on the scheme it arrived with.
+    absolute_redirect off;
+
     include /etc/nginx/snippets/app-locations.conf;
 }
 


### PR DESCRIPTION
## Summary
- Add `absolute_redirect off;` to the apex server in `prod.conf`: behind the tunnel the origin sees plain http, so nginx expanded the shared snippet's `return 301 /app/;` into `Location: http://goldentempotravel.com/app/`, downgrading users off TLS for one hop.

## Testing
- Hot-applied on the live Pi (`docker compose up -d --force-recreate gateway` — note: a plain `nginx -s reload` does NOT pick up a replaced single-file bind mount, the container keeps the old inode) and verified live: `curl -I https://goldentempotravel.com/` now returns relative `Location: /app/`.
- Merging this exercises the first tunnel-based CI deploy end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)