### PR TITLE
fix(api): retry initial DB connect at boot instead of degrading forever

### DIFF
--- a/src/packages/api/db.go
+++ b/src/packages/api/db.go
@@ -25,6 +25,12 @@ var embeddedMigrations embed.FS
 // mode (no DATABASE_URL, or the database was unreachable at startup).
 var dbPool *pgxpool.Pool
 
+// dbConfigured records whether a DATABASE_URL was provided at startup, so the
+// health endpoint can distinguish "no database configured" from "configured
+// but unreachable" when dbPool is nil. Set once in main before the server
+// starts; read-only afterwards.
+var dbConfigured bool
+
 // initDB creates and verifies a connection pool. A non-nil error means the
 // database is unreachable; callers treat that as degraded mode, not a crash.
 func initDB(ctx context.Context, databaseURL string) (*pgxpool.Pool, error) {

--- a/src/packages/api/main.go
+++ b/src/packages/api/main.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/getsentry/sentry-go"
 	"github.com/gorilla/mux"
+	"github.com/jackc/pgx/v5/pgxpool"
 )
 
 // Response represents a standard API response
@@ -82,9 +83,10 @@ func healthHandler(w http.ResponseWriter, r *http.Request) {
 	if !pingDB(r.Context()) {
 		status = "degraded"
 		httpStatus = http.StatusServiceUnavailable
-		if dbPool == nil {
+		switch {
+		case dbPool == nil && !dbConfigured:
 			database = "not configured"
-		} else {
+		default:
 			database = "unreachable"
 		}
 	}
@@ -619,11 +621,31 @@ func main() {
 	// Connect to the database. Missing/unreachable DB -> degraded mode (the API
 	// still serves stateless endpoints). A migration failure on a reachable DB is
 	// a real error -> exit non-zero.
+	//
+	// The initial connect RETRIES for a bounded window rather than giving up on
+	// the first failure: after a host power cycle Docker's restart policy starts
+	// this container and Postgres concurrently (depends_on ordering only applies
+	// to `compose up`), so the first attempts routinely lose the race. Without
+	// the retry the API would sit in degraded mode forever on a box that heals
+	// itself seconds later — on the self-hosted Pi that means every power blip
+	// silently killed persistence until someone restarted the container.
 	switch {
 	case dbURL == "":
 		log.Println("WARNING: DATABASE_URL not set - starting without a database; persistence features unavailable")
 	default:
-		pool, err := initDB(ctx, dbURL)
+		dbConfigured = true
+		const dbBootRetryWindow = 90 * time.Second
+		deadline := time.Now().Add(dbBootRetryWindow)
+		var pool *pgxpool.Pool
+		var err error
+		for {
+			pool, err = initDB(ctx, dbURL)
+			if err == nil || time.Now().After(deadline) {
+				break
+			}
+			log.Printf("database not ready (%v) - retrying for up to %s", err, time.Until(deadline).Round(time.Second))
+			time.Sleep(5 * time.Second)
+		}
 		if err != nil {
 			log.Printf("WARNING: database unreachable (%v) - starting in degraded mode; persistence features unavailable", err)
 			break


### PR DESCRIPTION
## Summary
- At host boot, Docker restart policies start api + postgres concurrently (`depends_on` ordering only applies to `compose up`), so the api's single connect attempt routinely lost the race and left it in degraded mode permanently — hit for real on the Pi's first power cycle tonight (`database: "not configured"` until a manual container restart).
- `main.go`: retry the initial connect every 5s for up to 90s before conceding to degraded mode; migrations and everything downstream unchanged.
- Health honesty: nil pool now reports `not configured` only when `DATABASE_URL` was truly absent; otherwise `unreachable` (new `dbConfigured` flag, set once before the server starts).

## Testing
- `go build`, `go vet`, `go test ./...` green locally.
- Real-world validation on merge: this deploys to the Pi via CI; the next power cycle should come back healthy with no manual restart (the retry log lines will show in `docker compose logs api`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)