### PR TITLE
feat(prod): force https at the origin via X-Forwarded-Proto redirect

### DIFF
--- a/dockerize/production/nginx/prod.conf
+++ b/dockerize/production/nginx/prod.conf
@@ -29,6 +29,15 @@ server {
     # Location headers keep the browser on the scheme it arrived with.
     absolute_redirect off;
 
+    # Never serve content to a visitor who arrived over plain http: the edge
+    # forwards the original scheme in X-Forwarded-Proto, so bounce those to
+    # https here regardless of whether Cloudflare's "Always Use HTTPS" edge
+    # toggle is on. The in-container health check sends no such header and
+    # is unaffected.
+    if ($http_x_forwarded_proto = "http") {
+        return 301 https://$host$request_uri;
+    }
+
     include /etc/nginx/snippets/app-locations.conf;
 }
 


### PR DESCRIPTION
## Summary
- Plain-http visitors were served content through the tunnel (the edge Always Use HTTPS toggle was never enabled). The apex server now 301s any request whose `X-Forwarded-Proto` says it arrived over http, so the origin never serves http regardless of edge configuration.
- In-container health checks send no `X-Forwarded-Proto` and are unaffected.

## Testing
- Hot-applied on the Pi (force-recreate) and verified live: `curl -I http://goldentempotravel.com/?cb=…` → `301` `location: https://goldentempotravel.com/?cb=…`; `https://…/health` still 200.
- Flipping the Cloudflare "Always Use HTTPS" edge toggle remains recommended (saves a round-trip) but is no longer load-bearing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)