### PR TITLE
feat(flutter): autofill support for credential forms (1Password / browser password managers)

### DIFF
--- a/src/packages/flutter-app/lib/screens/account_settings_screen.dart
+++ b/src/packages/flutter-app/lib/screens/account_settings_screen.dart
@@ -76,9 +76,7 @@ class _AccountSettingsScreenState extends ConsumerState<AccountSettingsScreen> {
               _currentPwController.text,
               _newPwController.text,
             );
-        await ref
-            .read(authProvider.notifier)
-            .adoptSession(res.token, res.user);
+        await ref.read(authProvider.notifier).adoptSession(res.token, res.user);
         _currentPwController.clear();
         _newPwController.clear();
         _snack('Password changed — other devices were signed out');
@@ -122,6 +120,7 @@ class _AccountSettingsScreenState extends ConsumerState<AccountSettingsScreen> {
             TextField(
               controller: pwController,
               obscureText: true,
+              autofillHints: const [AutofillHints.password],
               decoration: const InputDecoration(
                 labelText: 'Confirm your password',
                 border: OutlineInputBorder(),
@@ -193,21 +192,29 @@ class _AccountSettingsScreenState extends ConsumerState<AccountSettingsScreen> {
             const SizedBox(height: AppSpacing.xl),
             const SectionHeader(title: 'Password'),
             const SizedBox(height: AppSpacing.md),
-            TextField(
-              controller: _currentPwController,
-              obscureText: true,
-              decoration: const InputDecoration(
-                labelText: 'Current password',
-                border: OutlineInputBorder(),
-              ),
-            ),
-            const SizedBox(height: AppSpacing.md),
-            TextField(
-              controller: _newPwController,
-              obscureText: true,
-              decoration: const InputDecoration(
-                labelText: 'New password (8+ characters)',
-                border: OutlineInputBorder(),
+            AutofillGroup(
+              child: Column(
+                children: [
+                  TextField(
+                    controller: _currentPwController,
+                    obscureText: true,
+                    autofillHints: const [AutofillHints.password],
+                    decoration: const InputDecoration(
+                      labelText: 'Current password',
+                      border: OutlineInputBorder(),
+                    ),
+                  ),
+                  const SizedBox(height: AppSpacing.md),
+                  TextField(
+                    controller: _newPwController,
+                    obscureText: true,
+                    autofillHints: const [AutofillHints.newPassword],
+                    decoration: const InputDecoration(
+                      labelText: 'New password (8+ characters)',
+                      border: OutlineInputBorder(),
+                    ),
+                  ),
+                ],
               ),
             ),
             const SizedBox(height: AppSpacing.sm),
@@ -281,8 +288,8 @@ class _AccountSettingsScreenState extends ConsumerState<AccountSettingsScreen> {
             Align(
               alignment: Alignment.centerLeft,
               child: OutlinedButton.icon(
-                icon: Icon(Icons.delete_forever,
-                    color: theme.colorScheme.error),
+                icon:
+                    Icon(Icons.delete_forever, color: theme.colorScheme.error),
                 label: Text('Delete account',
                     style: TextStyle(color: theme.colorScheme.error)),
                 style: OutlinedButton.styleFrom(

--- a/src/packages/flutter-app/lib/screens/auth_screen.dart
+++ b/src/packages/flutter-app/lib/screens/auth_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../providers/auth_provider.dart';
 import '../widgets/brand_logo.dart';
@@ -40,6 +41,9 @@ class _AuthScreenState extends ConsumerState<AuthScreen> {
         ? await notifier.login(email, password)
         : await notifier.register(email, password,
             displayName: _displayNameController.text.trim());
+    // Tell the platform the autofill session succeeded so the browser /
+    // password manager offers to save the credentials.
+    if (ok) TextInput.finishAutofillContext();
     // On success the AuthGate swaps the root from the landing page to the app.
     // When this screen was pushed on top of the landing page, pop it so the
     // app (now the root) is revealed instead of this form staying on top.
@@ -90,95 +94,112 @@ class _AuthScreenState extends ConsumerState<AuthScreen> {
             constraints: const BoxConstraints(maxWidth: 420),
             child: Form(
               key: _formKey,
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                children: [
-                  const BrandLogo.mark(size: 72),
-                  const SizedBox(height: 16),
-                  Text(
-                    _isLogin ? 'Welcome back' : 'Create your account',
-                    style: theme.textTheme.headlineSmall
-                        ?.copyWith(fontWeight: FontWeight.bold),
-                    textAlign: TextAlign.center,
-                  ),
-                  const SizedBox(height: 24),
-                  TextFormField(
-                    controller: _emailController,
-                    keyboardType: TextInputType.emailAddress,
-                    autocorrect: false,
-                    decoration: const InputDecoration(labelText: 'Email'),
-                    validator: (v) {
-                      final value = (v ?? '').trim();
-                      if (value.isEmpty) return 'Email is required';
-                      if (!value.contains('@') || !value.contains('.')) {
-                        return 'Enter a valid email';
-                      }
-                      return null;
-                    },
-                  ),
-                  const SizedBox(height: 12),
-                  TextFormField(
-                    controller: _passwordController,
-                    obscureText: true,
-                    decoration: const InputDecoration(labelText: 'Password'),
-                    validator: (v) {
-                      if ((v ?? '').isEmpty) return 'Password is required';
-                      if (!_isLogin && v!.length < 8) {
-                        return 'Password must be at least 8 characters';
-                      }
-                      return null;
-                    },
-                  ),
-                  if (!_isLogin) ...[
-                    const SizedBox(height: 12),
-                    TextFormField(
-                      controller: _displayNameController,
-                      decoration: const InputDecoration(
-                        labelText: 'Display name (optional)',
-                      ),
-                    ),
-                  ],
-                  if (auth.error != null) ...[
+              // AutofillGroup makes Flutter web expose the fields as a DOM
+              // <form> with autocomplete attributes, which is what browser
+              // password managers (1Password etc.) hook into.
+              child: AutofillGroup(
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    const BrandLogo.mark(size: 72),
                     const SizedBox(height: 16),
                     Text(
-                      auth.error!,
-                      style: TextStyle(color: theme.colorScheme.error),
+                      _isLogin ? 'Welcome back' : 'Create your account',
+                      style: theme.textTheme.headlineSmall
+                          ?.copyWith(fontWeight: FontWeight.bold),
                       textAlign: TextAlign.center,
                     ),
-                  ],
-                  const SizedBox(height: 24),
-                  FilledButton(
-                    onPressed: auth.loading ? null : _submit,
-                    style: FilledButton.styleFrom(
-                      padding: const EdgeInsets.symmetric(vertical: 16),
+                    const SizedBox(height: 24),
+                    TextFormField(
+                      controller: _emailController,
+                      keyboardType: TextInputType.emailAddress,
+                      autocorrect: false,
+                      autofillHints: const [
+                        AutofillHints.username,
+                        AutofillHints.email,
+                      ],
+                      decoration: const InputDecoration(labelText: 'Email'),
+                      validator: (v) {
+                        final value = (v ?? '').trim();
+                        if (value.isEmpty) return 'Email is required';
+                        if (!value.contains('@') || !value.contains('.')) {
+                          return 'Enter a valid email';
+                        }
+                        return null;
+                      },
                     ),
-                    child: auth.loading
-                        ? const SizedBox(
-                            height: 20,
-                            width: 20,
-                            child: CircularProgressIndicator(strokeWidth: 2),
-                          )
-                        : Text(_isLogin ? 'Sign in' : 'Create account'),
-                  ),
-                  if (!_isLogin) ...[
                     const SizedBox(height: 12),
-                    const LegalAgreementText(),
-                  ],
-                  const SizedBox(height: 12),
-                  TextButton(
-                    onPressed: auth.loading ? null : _toggleMode,
-                    child: Text(_isLogin
-                        ? "Don't have an account? Sign up"
-                        : 'Already have an account? Sign in'),
-                  ),
-                  if (_isLogin)
-                    TextButton(
-                      onPressed: auth.loading ? null : _forgotPassword,
-                      child: const Text('Forgot password?'),
+                    TextFormField(
+                      controller: _passwordController,
+                      obscureText: true,
+                      autofillHints: [
+                        _isLogin
+                            ? AutofillHints.password
+                            : AutofillHints.newPassword,
+                      ],
+                      textInputAction: TextInputAction.done,
+                      onFieldSubmitted: (_) => _submit(),
+                      decoration: const InputDecoration(labelText: 'Password'),
+                      validator: (v) {
+                        if ((v ?? '').isEmpty) return 'Password is required';
+                        if (!_isLogin && v!.length < 8) {
+                          return 'Password must be at least 8 characters';
+                        }
+                        return null;
+                      },
                     ),
-                  const GoogleSignInButton(),
-                ],
+                    if (!_isLogin) ...[
+                      const SizedBox(height: 12),
+                      TextFormField(
+                        controller: _displayNameController,
+                        autofillHints: const [AutofillHints.name],
+                        decoration: const InputDecoration(
+                          labelText: 'Display name (optional)',
+                        ),
+                      ),
+                    ],
+                    if (auth.error != null) ...[
+                      const SizedBox(height: 16),
+                      Text(
+                        auth.error!,
+                        style: TextStyle(color: theme.colorScheme.error),
+                        textAlign: TextAlign.center,
+                      ),
+                    ],
+                    const SizedBox(height: 24),
+                    FilledButton(
+                      onPressed: auth.loading ? null : _submit,
+                      style: FilledButton.styleFrom(
+                        padding: const EdgeInsets.symmetric(vertical: 16),
+                      ),
+                      child: auth.loading
+                          ? const SizedBox(
+                              height: 20,
+                              width: 20,
+                              child: CircularProgressIndicator(strokeWidth: 2),
+                            )
+                          : Text(_isLogin ? 'Sign in' : 'Create account'),
+                    ),
+                    if (!_isLogin) ...[
+                      const SizedBox(height: 12),
+                      const LegalAgreementText(),
+                    ],
+                    const SizedBox(height: 12),
+                    TextButton(
+                      onPressed: auth.loading ? null : _toggleMode,
+                      child: Text(_isLogin
+                          ? "Don't have an account? Sign up"
+                          : 'Already have an account? Sign in'),
+                    ),
+                    if (_isLogin)
+                      TextButton(
+                        onPressed: auth.loading ? null : _forgotPassword,
+                        child: const Text('Forgot password?'),
+                      ),
+                    const GoogleSignInButton(),
+                  ],
+                ),
               ),
             ),
           ),
@@ -248,6 +269,7 @@ class _RequestResetDialogState extends State<_RequestResetDialog> {
             controller: _email,
             keyboardType: TextInputType.emailAddress,
             autocorrect: false,
+            autofillHints: const [AutofillHints.email],
             decoration: InputDecoration(
               labelText: 'Email',
               errorText: _error,
@@ -321,26 +343,30 @@ class _EnterResetCodeDialogState extends State<_EnterResetCodeDialog> {
   Widget build(BuildContext context) {
     return AlertDialog(
       title: const Text('Enter your reset code'),
-      content: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          const Text('Check your inbox for the code we just sent.'),
-          const SizedBox(height: 12),
-          TextField(
-            controller: _code,
-            autocorrect: false,
-            decoration: const InputDecoration(labelText: 'Reset code'),
-          ),
-          const SizedBox(height: 12),
-          TextField(
-            controller: _password,
-            obscureText: true,
-            decoration: InputDecoration(
-              labelText: 'New password',
-              errorText: _error,
+      content: AutofillGroup(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Text('Check your inbox for the code we just sent.'),
+            const SizedBox(height: 12),
+            TextField(
+              controller: _code,
+              autocorrect: false,
+              autofillHints: const [AutofillHints.oneTimeCode],
+              decoration: const InputDecoration(labelText: 'Reset code'),
             ),
-          ),
-        ],
+            const SizedBox(height: 12),
+            TextField(
+              controller: _password,
+              obscureText: true,
+              autofillHints: const [AutofillHints.newPassword],
+              decoration: InputDecoration(
+                labelText: 'New password',
+                errorText: _error,
+              ),
+            ),
+          ],
+        ),
       ),
       actions: [
         TextButton(

--- a/src/packages/flutter-app/lib/screens/reset_password_screen.dart
+++ b/src/packages/flutter-app/lib/screens/reset_password_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../providers/auth_provider.dart';
 import '../widgets/gradient_app_bar.dart';
@@ -40,6 +41,8 @@ class _ResetPasswordScreenState extends ConsumerState<ResetPasswordScreen> {
       await ref
           .read(authServiceProvider)
           .resetPassword(widget.token, _passwordController.text);
+      // Let the browser / password manager offer to update the saved login.
+      TextInput.finishAutofillContext();
       if (mounted) setState(() => _done = true);
     } catch (e) {
       if (mounted) {
@@ -106,66 +109,70 @@ class _ResetPasswordScreenState extends ConsumerState<ResetPasswordScreen> {
   Widget _buildForm(ThemeData theme) {
     return Form(
       key: _formKey,
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: [
-          Text(
-            'Choose a new password',
-            style: theme.textTheme.headlineSmall
-                ?.copyWith(fontWeight: FontWeight.bold),
-            textAlign: TextAlign.center,
-          ),
-          const SizedBox(height: 24),
-          TextFormField(
-            controller: _passwordController,
-            obscureText: true,
-            decoration: const InputDecoration(labelText: 'New password'),
-            validator: (v) {
-              if ((v ?? '').isEmpty) return 'Password is required';
-              if (v!.length < 8) {
-                return 'Password must be at least 8 characters';
-              }
-              return null;
-            },
-          ),
-          const SizedBox(height: 12),
-          TextFormField(
-            controller: _confirmController,
-            obscureText: true,
-            decoration:
-                const InputDecoration(labelText: 'Confirm new password'),
-            validator: (v) {
-              if ((v ?? '').isEmpty) return 'Confirm your new password';
-              if (v != _passwordController.text) {
-                return 'Passwords don\'t match';
-              }
-              return null;
-            },
-          ),
-          if (_error != null) ...[
-            const SizedBox(height: 16),
+      child: AutofillGroup(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
             Text(
-              _error!,
-              style: TextStyle(color: theme.colorScheme.error),
+              'Choose a new password',
+              style: theme.textTheme.headlineSmall
+                  ?.copyWith(fontWeight: FontWeight.bold),
               textAlign: TextAlign.center,
             ),
-          ],
-          const SizedBox(height: 24),
-          FilledButton(
-            onPressed: _saving ? null : _submit,
-            style: FilledButton.styleFrom(
-              padding: const EdgeInsets.symmetric(vertical: 16),
+            const SizedBox(height: 24),
+            TextFormField(
+              controller: _passwordController,
+              obscureText: true,
+              autofillHints: const [AutofillHints.newPassword],
+              decoration: const InputDecoration(labelText: 'New password'),
+              validator: (v) {
+                if ((v ?? '').isEmpty) return 'Password is required';
+                if (v!.length < 8) {
+                  return 'Password must be at least 8 characters';
+                }
+                return null;
+              },
             ),
-            child: _saving
-                ? const SizedBox(
-                    height: 20,
-                    width: 20,
-                    child: CircularProgressIndicator(strokeWidth: 2),
-                  )
-                : const Text('Set new password'),
-          ),
-        ],
+            const SizedBox(height: 12),
+            TextFormField(
+              controller: _confirmController,
+              obscureText: true,
+              autofillHints: const [AutofillHints.newPassword],
+              decoration:
+                  const InputDecoration(labelText: 'Confirm new password'),
+              validator: (v) {
+                if ((v ?? '').isEmpty) return 'Confirm your new password';
+                if (v != _passwordController.text) {
+                  return 'Passwords don\'t match';
+                }
+                return null;
+              },
+            ),
+            if (_error != null) ...[
+              const SizedBox(height: 16),
+              Text(
+                _error!,
+                style: TextStyle(color: theme.colorScheme.error),
+                textAlign: TextAlign.center,
+              ),
+            ],
+            const SizedBox(height: 24),
+            FilledButton(
+              onPressed: _saving ? null : _submit,
+              style: FilledButton.styleFrom(
+                padding: const EdgeInsets.symmetric(vertical: 16),
+              ),
+              child: _saving
+                  ? const SizedBox(
+                      height: 20,
+                      width: 20,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : const Text('Set new password'),
+            ),
+          ],
+        ),
       ),
     );
   }


### PR DESCRIPTION
## Summary
- 1Password (and browser password managers) couldn't fill the sign-in form: Flutter web renders text fields to canvas, and no field in the app had autofill wiring, so no DOM inputs existed for extensions to detect.
- Wrap every credential form in an `AutofillGroup` with `autofillHints` — Flutter web then emits a real DOM `<form>` with `autocomplete="username"` / `current-password` / `new-password` / `one-time-code` attributes that password managers hook into. Native mobile builds get platform keychain autofill from the same hints for free.
- Sign-in/sign-up form: email → username+email, password → `password` in sign-in mode / `newPassword` in sign-up mode (enables generated-password offers), display name → `name`; `TextInput.finishAutofillContext()` on success triggers the browser's save-credentials prompt; Enter in the password field submits.
- Also covered: forgot-password dialogs (email / one-time code / new password), the deep-link reset screen (+ update-saved-login prompt on success), and account settings (change password, delete-account confirm).

## Testing
- `flutter analyze` — no issues in the edited files (only pre-existing infos elsewhere).
- `flutter test` — all 359 tests pass.
- Headless CDP verification on the dev stack: after focusing the email field on the sign-in screen, the DOM contains `<form>` with `<input autocomplete="username">` and `<input type="password" autocomplete="current-password">`; screen renders normally.
- Real-extension check post-deploy: click the email field on goldentempotravel.com and confirm the 1Password badge fills both fields, and that saving is offered after sign-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)