### PR TITLE
fix(web): size non-focused autofill inputs so 1Password fills both fields

### DIFF
--- a/src/packages/flutter-app/web/index.html
+++ b/src/packages/flutter-app/web/index.html
@@ -144,6 +144,61 @@
     });
   </script>
 
+  <script>
+    // Password-manager autofill shim. Flutter web only gives the *focused*
+    // text field a real DOM rect; its AutofillGroup siblings are left at
+    // 0x0 (upstream flutter/flutter#61301, #127694), and 1Password/Bitwarden
+    // refuse to fill zero-size inputs (anti-phishing visibility check) — so
+    // picking a login filled only the focused field. Give the siblings a
+    // plausible on-screen rect stacked around the focused field; they stay
+    // visually transparent and click-through, and values the extension
+    // writes into them reach Flutter through the engine's own listeners.
+    // Only elements currently at 0x0 are touched, so the engine's own
+    // styling of the focused element always wins and the MutationObserver
+    // settles instead of looping.
+    (function () {
+      var scheduled = false;
+      function sizeAutofillSiblings() {
+        scheduled = false;
+        var focused = document.querySelector(
+            'form input.flt-text-editing, form textarea.flt-text-editing');
+        if (!focused || !focused.form) return;
+        var rect = focused.getBoundingClientRect();
+        if (!rect.width || !rect.height) return;
+        var fields = Array.prototype.filter.call(
+            focused.form.querySelectorAll('input, textarea'),
+            function (el) { return el.type !== 'submit'; });
+        var focusedIdx = fields.indexOf(focused);
+        fields.forEach(function (el, i) {
+          if (el === focused || el.offsetWidth > 0 || el.offsetHeight > 0) {
+            return;
+          }
+          var y = rect.top + (i - focusedIdx) * (rect.height + 40);
+          el.style.position = 'absolute';
+          el.style.top = '0px';
+          el.style.left = '0px';
+          el.style.transform =
+              'translate(' + rect.left + 'px, ' + y + 'px)';
+          el.style.width = rect.width + 'px';
+          el.style.height = rect.height + 'px';
+          el.style.pointerEvents = 'none';
+        });
+      }
+      function schedule() {
+        if (scheduled) return;
+        scheduled = true;
+        requestAnimationFrame(sizeAutofillSiblings);
+      }
+      new MutationObserver(schedule).observe(document.body, {
+        childList: true,
+        subtree: true,
+        attributes: true,
+        attributeFilter: ['style', 'class'],
+      });
+      document.addEventListener('focusin', schedule, true);
+    })();
+  </script>
+
   <!-- Flutter initialization: build-generated bootstrap (inlines the loader,
        the build config, and the injected service-worker version — verified in
        build/web/flutter_bootstrap.js). Replaces the deprecated


### PR DESCRIPTION
## Summary
- Follow-up to #174: 1Password filled the password but not the email. Root cause (found by inspecting the live DOM): Flutter web positions/sizes only the *focused* text-editing element; the AutofillGroup sibling inputs stay at 0×0 (upstream flutter/flutter#61301 / #127694), and 1Password skips zero-size fields as an anti-phishing visibility check.
- Adds a shim to `web/index.html`: a MutationObserver that, when a credential field is focused, gives any 0×0 sibling in the autofill `<form>` a real rect stacked around the focused field (transparent, `pointer-events: none`). Only elements currently at 0×0 are touched, so the engine's own styling of the focused element always wins and the observer settles instead of looping.
- Values the extension writes into those siblings propagate to Flutter through the engine's existing input listeners — no Dart changes needed.

## Testing
- Headless CDP against the dev stack: with password focused, the username input now measures 388×24 at the email field's visual position (was 0×0); with email focused, the password sibling is likewise sized. `pointer-events: none` confirmed on siblings; clicking through a shimmed sibling still focuses the underlying Flutter field.
- End-to-end: simulated an extension-style fill (native value setter + InputEvent) on both inputs while email was focused, clicked Sign in — server responded "invalid email or password", proving both values reached Flutter state and were submitted (previously the email would have been empty and the client validator would have blocked).
- Real-extension check post-deploy: on goldentempotravel.com, pick a login from the 1Password badge — both email and password should fill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)