### PR TITLE
feat(flutter): auto-submit sign-in after a password-manager autofill

### DIFF
--- a/src/packages/flutter-app/lib/screens/auth_screen.dart
+++ b/src/packages/flutter-app/lib/screens/auth_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -24,12 +26,66 @@ class _AuthScreenState extends ConsumerState<AuthScreen> {
   final _displayNameController = TextEditingController();
   late bool _isLogin = widget.initialIsLogin;
 
+  // Auto-submit after a password-manager autofill. An extension fill is
+  // distinctive: both fields jump from empty to a full value in one change
+  // event, within milliseconds of each other. Manual typing changes one
+  // character at a time and human paste-then-paste is seconds apart, so
+  // neither matches. Each auto-submit consumes the fill timestamps — a
+  // failed attempt is never retried without a fresh fill gesture (keeps us
+  // clear of the server-side login lockout).
+  static const _fillWindow = Duration(milliseconds: 500);
+  String _prevEmail = '';
+  String _prevPassword = '';
+  DateTime? _emailFillAt;
+  DateTime? _passwordFillAt;
+  Timer? _autoSubmitTimer;
+
+  @override
+  void initState() {
+    super.initState();
+    _emailController.addListener(() => _onCredentialChanged(isEmail: true));
+    _passwordController.addListener(() => _onCredentialChanged(isEmail: false));
+  }
+
   @override
   void dispose() {
+    _autoSubmitTimer?.cancel();
     _emailController.dispose();
     _passwordController.dispose();
     _displayNameController.dispose();
     super.dispose();
+  }
+
+  void _onCredentialChanged({required bool isEmail}) {
+    final value = isEmail ? _emailController.text : _passwordController.text;
+    final prev = isEmail ? _prevEmail : _prevPassword;
+    if (value == prev) return;
+    final oneShotFill = prev.isEmpty && value.length > 1;
+    final fillAt = oneShotFill ? DateTime.now() : null;
+    if (isEmail) {
+      _prevEmail = value;
+      _emailFillAt = fillAt;
+    } else {
+      _prevPassword = value;
+      _passwordFillAt = fillAt;
+    }
+    _maybeAutoSubmit();
+  }
+
+  void _maybeAutoSubmit() {
+    if (!_isLogin) return;
+    final emailAt = _emailFillAt;
+    final passwordAt = _passwordFillAt;
+    if (emailAt == null || passwordAt == null) return;
+    if (emailAt.difference(passwordAt).abs() > _fillWindow) return;
+    if (ref.read(authProvider).loading) return;
+    _autoSubmitTimer?.cancel();
+    _autoSubmitTimer = Timer(const Duration(milliseconds: 250), () {
+      if (!mounted || !_isLogin) return;
+      _emailFillAt = null;
+      _passwordFillAt = null;
+      _submit();
+    });
   }
 
   Future<void> _submit() async {

--- a/src/packages/flutter-app/test/auth_autofill_submit_test.dart
+++ b/src/packages/flutter-app/test/auth_autofill_submit_test.dart
@@ -1,0 +1,119 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:travel_route_planner/models/user.dart';
+import 'package:travel_route_planner/providers/auth_provider.dart';
+import 'package:travel_route_planner/screens/auth_screen.dart';
+import 'package:travel_route_planner/services/auth_service.dart';
+import 'package:travel_route_planner/services/auth_storage.dart';
+
+/// Records login/register calls; Google SSO reports unavailable so the
+/// button stays hidden.
+class _FakeAuthService extends AuthService {
+  final List<(String, String)> loginCalls = [];
+  final List<(String, String)> registerCalls = [];
+
+  _FakeAuthService() : super(baseUrl: 'http://unused');
+
+  static final _user = UserModel(
+    id: 'u1',
+    email: 'brian@example.com',
+    displayName: 'Brian',
+    createdAt: DateTime.utc(2026, 1, 1),
+  );
+
+  @override
+  Future<AuthResponse> login(String email, String password) async {
+    loginCalls.add((email, password));
+    return AuthResponse(user: _user, token: 'tok');
+  }
+
+  @override
+  Future<AuthResponse> register(String email, String password,
+      {String? displayName}) async {
+    registerCalls.add((email, password));
+    return AuthResponse(user: _user, token: 'tok');
+  }
+
+  @override
+  Future<bool> googleSignInAvailable() async => false;
+}
+
+class _FakeAuthStorage extends AuthStorage {
+  String? token;
+
+  @override
+  Future<String?> loadToken() async => token;
+
+  @override
+  Future<void> saveToken(String value) async => token = value;
+
+  @override
+  Future<void> clearToken() async => token = null;
+}
+
+Widget _wrap(_FakeAuthService service) {
+  return ProviderScope(
+    overrides: [
+      authServiceProvider.overrideWithValue(service),
+      authStorageProvider.overrideWithValue(_FakeAuthStorage()),
+    ],
+    child: const MaterialApp(home: AuthScreen()),
+  );
+}
+
+Finder _fieldByLabel(String label) => find.ancestor(
+      of: find.text(label),
+      matching: find.byType(TextFormField),
+    );
+
+void main() {
+  testWidgets('password-manager style double fill auto-submits sign-in',
+      (tester) async {
+    final service = _FakeAuthService();
+    await tester.pumpWidget(_wrap(service));
+    await tester.pump();
+
+    // Both fields jump from empty to a full value back-to-back, like an
+    // extension fill.
+    await tester.enterText(_fieldByLabel('Email'), 'brian@example.com');
+    await tester.enterText(_fieldByLabel('Password'), 'hunter2hunter2');
+    await tester.pump(const Duration(milliseconds: 400));
+    await tester.pumpAndSettle();
+
+    expect(service.loginCalls, [('brian@example.com', 'hunter2hunter2')]);
+  });
+
+  testWidgets('human-paced entry does not auto-submit', (tester) async {
+    final service = _FakeAuthService();
+    await tester.pumpWidget(_wrap(service));
+    await tester.pump();
+
+    await tester.enterText(_fieldByLabel('Email'), 'brian@example.com');
+    // The fill window compares wall-clock timestamps, so let real time pass
+    // (runAsync escapes the fake-async zone), well outside the 500ms window.
+    await tester.runAsync(
+        () => Future<void>.delayed(const Duration(milliseconds: 700)));
+    await tester.enterText(_fieldByLabel('Password'), 'hunter2hunter2');
+    await tester.pump(const Duration(seconds: 1));
+
+    expect(service.loginCalls, isEmpty);
+  });
+
+  testWidgets('sign-up mode never auto-submits', (tester) async {
+    final service = _FakeAuthService();
+    await tester.pumpWidget(_wrap(service));
+    await tester.pump();
+
+    await tester.ensureVisible(find.text("Don't have an account? Sign up"));
+    await tester.tap(find.text("Don't have an account? Sign up"));
+    await tester.pumpAndSettle();
+
+    await tester.enterText(_fieldByLabel('Email'), 'brian@example.com');
+    await tester.enterText(_fieldByLabel('Password'), 'hunter2hunter2');
+    await tester.pump(const Duration(seconds: 1));
+
+    expect(service.registerCalls, isEmpty);
+    expect(service.loginCalls, isEmpty);
+  });
+}


### PR DESCRIPTION
## Summary
- Completes the 1Password flow from #174/#175: after picking a login from the extension badge, the sign-in form now submits itself — no Sign-in click needed. (The one click to pick the login in 1Password remains; extensions never fill without an explicit selection.)
- Detection keys on the autofill signature: both credential fields jump from empty to a full value in one change event, within 500 ms of each other. Manual typing (per-keystroke) and human-paced paste (seconds apart) don't match.
- Guards: sign-in mode only, 250 ms debounce, and each auto-submit consumes the fill timestamps — a failed attempt is never retried without a fresh explicit fill, keeping clear of the server-side login lockout. Bonus: iOS/Android keychain autofill gets the same auto-login on mobile builds.

## Testing
- New `test/auth_autofill_submit_test.dart`: double fill auto-submits with the filled values; human-paced entry (real 700 ms gap via `runAsync`) does not; sign-up mode never does. Full suite: 362 tests pass; `flutter analyze` clean for changed files.
- Dev-stack e2e via headless CDP, simulating an extension fill on both hidden autofill inputs with no Sign-in click: bogus creds → server "invalid email or password" appears on its own (single attempt, form still usable); dev-login creds → lands on the signed-in home screen automatically.
- Post-deploy check: on goldentempotravel.com, click the email field, pick the login from 1Password → fields fill and the app signs in by itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)