### PR TITLE
fix(web): size the autofill form itself so 1Password fills both fields

### DIFF
--- a/src/packages/flutter-app/web/index.html
+++ b/src/packages/flutter-app/web/index.html
@@ -157,9 +157,17 @@
     // styling of the focused element always wins and the MutationObserver
     // settles instead of looping.
     (function () {
-      var scheduled = false;
-      function sizeAutofillSiblings() {
-        scheduled = false;
+      var diagnosed = new WeakSet();
+      function logFillEvent(e) {
+        // Verbose-level breadcrumbs for debugging real password-manager
+        // behavior (DevTools console, "Verbose" filter, search "autofill").
+        console.debug('[autofill] ' + e.type +
+            ' on ' + (e.target.getAttribute('autocomplete') || e.target.name) +
+            ' len=' + (e.target.value || '').length +
+            ' trusted=' + e.isTrusted +
+            ' inputType=' + (e.inputType || '-'));
+      }
+      function sizeAutofillForm() {
         var focused = document.querySelector(
             'form input.flt-text-editing, form textarea.flt-text-editing');
         if (!focused || !focused.form) return;
@@ -169,33 +177,60 @@
             focused.form.querySelectorAll('input, textarea'),
             function (el) { return el.type !== 'submit'; });
         var focusedIdx = fields.indexOf(focused);
+        var minY = rect.top;
+        var maxY = rect.top + rect.height;
         fields.forEach(function (el, i) {
-          if (el === focused || el.offsetWidth > 0 || el.offsetHeight > 0) {
-            return;
+          if (!diagnosed.has(el)) {
+            diagnosed.add(el);
+            el.addEventListener('input', logFillEvent);
+            el.addEventListener('change', logFillEvent);
           }
           var y = rect.top + (i - focusedIdx) * (rect.height + 40);
-          el.style.position = 'absolute';
-          el.style.top = '0px';
-          el.style.left = '0px';
-          el.style.transform =
-              'translate(' + rect.left + 'px, ' + y + 'px)';
-          el.style.width = rect.width + 'px';
-          el.style.height = rect.height + 'px';
-          el.style.pointerEvents = 'none';
+          if (el !== focused) {
+            if (el.offsetWidth <= 0 && el.offsetHeight <= 0) {
+              el.style.position = 'absolute';
+              el.style.top = '0px';
+              el.style.left = '0px';
+              el.style.transform =
+                  'translate(' + rect.left + 'px, ' + y + 'px)';
+              el.style.width = rect.width + 'px';
+              el.style.height = rect.height + 'px';
+              el.style.pointerEvents = 'none';
+            } else {
+              y = el.getBoundingClientRect().top;
+            }
+          }
+          minY = Math.min(minY, y);
+          maxY = Math.max(maxY, y + rect.height);
         });
+        // Extensions treat 0x0 forms as hidden/honeypot forms and skip
+        // their fields — give the form itself a real size. It must stay
+        // static AND unmargined at its natural spot: positioning it would
+        // make it the containing block for the engine's absolutely-placed
+        // inputs, and empirically even margins break the engine's
+        // focus-switch between fields. pointer-events:none keeps the sized
+        // box click-transparent; the focused input wins pe back explicitly.
+        var form = focused.form;
+        if (form.offsetWidth <= 0 || form.offsetHeight <= 0) {
+          form.style.width = rect.width + 'px';
+          form.style.height = (maxY - minY) + 'px';
+          form.style.pointerEvents = 'none';
+        }
+        if (getComputedStyle(focused).pointerEvents === 'none') {
+          focused.style.pointerEvents = 'auto';
+        }
       }
-      function schedule() {
-        if (scheduled) return;
-        scheduled = true;
-        requestAnimationFrame(sizeAutofillSiblings);
-      }
-      new MutationObserver(schedule).observe(document.body, {
+      // Run synchronously inside the observer callback: our observer is
+      // registered before extension content scripts, so the fields are
+      // already sized when the extension's own observer sees the same
+      // mutation batch and analyzes the form.
+      new MutationObserver(sizeAutofillForm).observe(document.body, {
         childList: true,
         subtree: true,
         attributes: true,
         attributeFilter: ['style', 'class'],
       });
-      document.addEventListener('focusin', schedule, true);
+      document.addEventListener('focusin', sizeAutofillForm, true);
     })();
   </script>
 


### PR DESCRIPTION
## Summary
- Real-world follow-up to #175/#177: 1Password was still filling only the focused field per pick. Root cause hypothesis (strongest candidate after eliminating field size, pointer-events, and event delivery): the autofill `<form>` element itself was 0×0, and password managers skip zero-size forms as hidden/honeypot forms — so no pair-fill.
- Shim v2: the form gets a real size at its natural static position. Positioning it over the fields — even via margins only — empirically breaks the engine's field-to-field focus switch (bisected live on the dev stack), so the box stays at its natural spot with `pointer-events: none` and the focused input explicitly wins pointer-events back.
- Siblings are now sized synchronously inside the MutationObserver callback (registered before extension content scripts), so the form is fully formed when the extension's observer processes the same mutation batch.
- Adds `console.debug('[autofill] …')` breadcrumbs (field, value length, `isTrusted`, `inputType`) on the credential inputs — if 1Password still misbehaves, DevTools verbose console shows exactly what it did.

## Testing
- Headless CDP on the dev stack: form measures 388×88 (was 0×0); both inputs sized at their widget positions; **email→password click moves focus correctly** (regression introduced by the margin variant and fixed); typing lands in the newly-focused field; simulated extension double-fill still triggers the #177 auto-submit ("invalid email or password" appears with no Sign-in click).
- `flutter analyze` / `flutter test` unaffected (index.html only).
- Post-deploy check: pick a login from the 1Password badge on goldentempotravel.com — both fields should fill and the app should sign in automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)