### PR TITLE
feat(flutter): taller hero card on home and landing

### DIFF
--- a/src/packages/flutter-app/lib/screens/home_screen.dart
+++ b/src/packages/flutter-app/lib/screens/home_screen.dart
@@ -227,9 +227,10 @@ class _AgentHeroCard extends StatelessWidget {
 
   Widget _heroContent(BuildContext context) {
     return Container(
-      constraints: const BoxConstraints(minHeight: 340),
+      constraints: const BoxConstraints(minHeight: 440),
       padding: const EdgeInsets.all(28),
       child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Container(

--- a/src/packages/flutter-app/lib/screens/landing_screen.dart
+++ b/src/packages/flutter-app/lib/screens/landing_screen.dart
@@ -217,9 +217,10 @@ class _LandingHero extends StatelessWidget {
               ),
             ),
             Container(
-              constraints: const BoxConstraints(minHeight: 340),
+              constraints: const BoxConstraints(minHeight: 440),
               padding: const EdgeInsets.all(28),
               child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   const BrandBadge(


### PR DESCRIPTION
## Summary
- Grow the "Plan less. Travel more." hero card from `minHeight: 340` to `440` on both the logged-out landing page (`_LandingHero`) and the logged-in home page (`_AgentHeroCard`) — follow-up to #176, which freed up vertical space on both pages
- Center the hero content vertically (`MainAxisAlignment.center`) so the added height becomes balanced breathing room over the Santorini photo instead of empty scrim below the CTAs/chips

The two heroes intentionally mirror each other, so the change is identical in both files; `440` is a single constant per file if we want to nudge it after seeing it live.

## Testing
- `make flutter-analyze` — 12 pre-existing infos, none in touched files
- `make flutter-test` — all 362 tests pass
- minHeight only grows the card, so narrow viewports are unaffected (content can still expand beyond it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)