### PR TITLE
feat(flutter): surface resumable plan chats on the home screen

### DIFF
--- a/src/packages/flutter-app/lib/screens/home_screen.dart
+++ b/src/packages/flutter-app/lib/screens/home_screen.dart
@@ -13,6 +13,7 @@ import '../theme/app_shadows.dart';
 import '../theme/spacing.dart';
 import '../widgets/account_menu.dart';
 import '../widgets/brand_logo.dart';
+import '../widgets/continue_chats_section.dart';
 import '../widgets/gradient_app_bar.dart';
 import '../widgets/live_trip_card.dart';
 import '../widgets/page_container.dart';
@@ -112,6 +113,12 @@ class HomeScreen extends ConsumerWidget {
                   ),
                   const SizedBox(height: 16),
                 ],
+                // In-progress AI conversations that haven't produced a trip
+                // yet (specs/continue-where-you-left-off) — same section as
+                // My Trips, slotted below the live trip like there. Collapses
+                // to nothing when empty, on error, or signed out.
+                const ContinueChatsSection(),
+
                 if (recentTrip != null &&
                     recentTrip.tripId != liveTrip?.id) ...[
                   _RecentTripCard(

--- a/src/packages/flutter-app/lib/screens/trips_list_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trips_list_screen.dart
@@ -4,13 +4,13 @@ import '../navigation/app_nav.dart';
 import '../theme/spacing.dart';
 import '../utils/trip_format.dart';
 import '../widgets/account_menu.dart';
+import '../widgets/continue_chats_section.dart';
 import '../widgets/empty_state.dart';
 import '../widgets/gradient_app_bar.dart';
 import '../widgets/live_trip_card.dart';
 import '../widgets/offline_banner.dart';
 import '../widgets/status_pill.dart';
 import '../models/chat_session.dart';
-import '../models/plan_message.dart';
 import '../models/trip.dart';
 import '../providers/auth_provider.dart';
 import '../providers/live_trip_provider.dart';
@@ -115,7 +115,7 @@ class _TripsListScreenState extends ConsumerState<TripsListScreen> {
                 child: Text('Continue where you left off',
                     style: theme.textTheme.titleMedium),
               ),
-              for (final c in resumable) _ContinueChatCard(chat: c),
+              for (final c in resumable) ContinueChatCard(chat: c),
               if (state.trips.isNotEmpty)
                 Padding(
                   padding: const EdgeInsets.fromLTRB(
@@ -162,98 +162,6 @@ class _TripsListScreenState extends ConsumerState<TripsListScreen> {
         actions: [AccountMenu()],
       ),
       body: body,
-    );
-  }
-}
-
-/// One in-progress AI conversation: tap to rehydrate it into the Plan tab,
-/// dismiss (trailing ✕) to drop it from the section.
-class _ContinueChatCard extends ConsumerWidget {
-  final ChatSessionSummary chat;
-
-  const _ContinueChatCard({required this.chat});
-
-  Future<void> _resume(BuildContext context, WidgetRef ref) async {
-    final messenger = ScaffoldMessenger.of(context);
-    try {
-      final detail =
-          await ref.read(chatsApiServiceProvider).getChat(chat.chatId);
-      ref.read(planProvider.notifier).resumeConversation(
-            chatId: detail.chatId,
-            summary: detail.summary,
-            messages: [
-              for (final m in detail.messages)
-                PlanMessage(
-                  role: m.role == 'user'
-                      ? MessageRole.user
-                      : MessageRole.assistant,
-                  content: m.content,
-                  // Pixels are stripped server-side; null bytes renders the
-                  // "Image" placeholder chip and stays out of resent history.
-                  attachments: [
-                    for (final img in m.images)
-                      PlanAttachment(bytes: null, mediaType: img.mediaType),
-                  ],
-                ),
-            ],
-          );
-      ref.read(navIndexProvider.notifier).state = AppTab.plan.index;
-    } catch (_) {
-      messenger.showSnackBar(
-        const SnackBar(content: Text('Could not reopen that conversation.')),
-      );
-    }
-  }
-
-  Future<void> _dismiss(BuildContext context, WidgetRef ref) async {
-    final messenger = ScaffoldMessenger.of(context);
-    try {
-      await ref.read(chatsApiServiceProvider).dismissChat(chat.chatId);
-    } catch (_) {
-      messenger.showSnackBar(
-        const SnackBar(content: Text('Could not dismiss that conversation.')),
-      );
-    }
-    ref.invalidate(resumableChatsProvider);
-  }
-
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final theme = Theme.of(context);
-    final updated = DateTime.tryParse(chat.updatedAt);
-    return Card(
-      child: ListTile(
-        leading: const Icon(Icons.forum_outlined),
-        title: Text(
-          chat.title,
-          maxLines: 1,
-          overflow: TextOverflow.ellipsis,
-          style: theme.textTheme.titleMedium
-              ?.copyWith(fontWeight: FontWeight.w600),
-        ),
-        subtitle: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            if (chat.preview.isNotEmpty)
-              Text(chat.preview, maxLines: 2, overflow: TextOverflow.ellipsis),
-            if (updated != null)
-              Padding(
-                padding: const EdgeInsets.only(top: AppSpacing.xs),
-                child: Text(
-                  relativeTime(updated),
-                  style: theme.textTheme.bodySmall
-                      ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
-                ),
-              ),
-          ],
-        ),
-        trailing: IconButton(
-          icon: const Icon(Icons.close, size: 20),
-          tooltip: 'Dismiss',
-          onPressed: () => _dismiss(context, ref),
-        ),
-        onTap: () => _resume(context, ref),
-      ),
     );
   }
 }

--- a/src/packages/flutter-app/lib/widgets/continue_chats_section.dart
+++ b/src/packages/flutter-app/lib/widgets/continue_chats_section.dart
@@ -1,0 +1,133 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../models/chat_session.dart';
+import '../models/plan_message.dart';
+import '../navigation/app_nav.dart';
+import '../providers/plan_provider.dart';
+import '../providers/resumable_chats_provider.dart';
+import '../theme/spacing.dart';
+import 'offline_banner.dart' show relativeTime;
+import 'section_header.dart';
+
+/// In-progress AI conversations that haven't produced a trip yet
+/// (specs/continue-where-you-left-off), as a self-contained home-screen
+/// section. Collapses to nothing while loading, on error, when signed out,
+/// or when there is nothing to resume.
+class ContinueChatsSection extends ConsumerWidget {
+  const ContinueChatsSection({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    // A conversation that just produced a saved trip graduates out of the
+    // continue section — refetch when the agent reports a saved trip.
+    ref.listen(planProvider.select((s) => s.savedTripId), (prev, next) {
+      if (next != null && next != prev) ref.invalidate(resumableChatsProvider);
+    });
+
+    final resumable = ref.watch(resumableChatsProvider).valueOrNull ??
+        const <ChatSessionSummary>[];
+    if (resumable.isEmpty) return const SizedBox.shrink();
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        const SectionHeader(title: 'Continue where you left off'),
+        const SizedBox(height: AppSpacing.sm),
+        for (final c in resumable) ContinueChatCard(chat: c),
+        const SizedBox(height: AppSpacing.lg),
+      ],
+    );
+  }
+}
+
+/// One in-progress AI conversation: tap to rehydrate it into the Plan tab,
+/// dismiss (trailing ✕) to drop it from the section.
+class ContinueChatCard extends ConsumerWidget {
+  final ChatSessionSummary chat;
+
+  const ContinueChatCard({super.key, required this.chat});
+
+  Future<void> _resume(BuildContext context, WidgetRef ref) async {
+    final messenger = ScaffoldMessenger.of(context);
+    try {
+      final detail =
+          await ref.read(chatsApiServiceProvider).getChat(chat.chatId);
+      ref.read(planProvider.notifier).resumeConversation(
+            chatId: detail.chatId,
+            summary: detail.summary,
+            messages: [
+              for (final m in detail.messages)
+                PlanMessage(
+                  role: m.role == 'user'
+                      ? MessageRole.user
+                      : MessageRole.assistant,
+                  content: m.content,
+                  // Pixels are stripped server-side; null bytes renders the
+                  // "Image" placeholder chip and stays out of resent history.
+                  attachments: [
+                    for (final img in m.images)
+                      PlanAttachment(bytes: null, mediaType: img.mediaType),
+                  ],
+                ),
+            ],
+          );
+      ref.read(navIndexProvider.notifier).state = AppTab.plan.index;
+    } catch (_) {
+      messenger.showSnackBar(
+        const SnackBar(content: Text('Could not reopen that conversation.')),
+      );
+    }
+  }
+
+  Future<void> _dismiss(BuildContext context, WidgetRef ref) async {
+    final messenger = ScaffoldMessenger.of(context);
+    try {
+      await ref.read(chatsApiServiceProvider).dismissChat(chat.chatId);
+    } catch (_) {
+      messenger.showSnackBar(
+        const SnackBar(content: Text('Could not dismiss that conversation.')),
+      );
+    }
+    ref.invalidate(resumableChatsProvider);
+  }
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final theme = Theme.of(context);
+    final updated = DateTime.tryParse(chat.updatedAt);
+    return Card(
+      child: ListTile(
+        leading: const Icon(Icons.forum_outlined),
+        title: Text(
+          chat.title,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+          style: theme.textTheme.titleMedium
+              ?.copyWith(fontWeight: FontWeight.w600),
+        ),
+        subtitle: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            if (chat.preview.isNotEmpty)
+              Text(chat.preview, maxLines: 2, overflow: TextOverflow.ellipsis),
+            if (updated != null)
+              Padding(
+                padding: const EdgeInsets.only(top: AppSpacing.xs),
+                child: Text(
+                  relativeTime(updated),
+                  style: theme.textTheme.bodySmall
+                      ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+                ),
+              ),
+          ],
+        ),
+        trailing: IconButton(
+          icon: const Icon(Icons.close, size: 20),
+          tooltip: 'Dismiss',
+          onPressed: () => _dismiss(context, ref),
+        ),
+        onTap: () => _resume(context, ref),
+      ),
+    );
+  }
+}

--- a/src/packages/flutter-app/test/home_continue_chats_test.dart
+++ b/src/packages/flutter-app/test/home_continue_chats_test.dart
@@ -1,0 +1,100 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:travel_route_planner/models/chat_session.dart';
+import 'package:travel_route_planner/models/user.dart';
+import 'package:travel_route_planner/providers/auth_provider.dart';
+import 'package:travel_route_planner/providers/live_trip_provider.dart';
+import 'package:travel_route_planner/providers/resumable_chats_provider.dart';
+import 'package:travel_route_planner/screens/home_screen.dart';
+import 'package:travel_route_planner/widgets/continue_chats_section.dart';
+
+/// Home-screen slotting of the "Continue where you left off" section
+/// (specs/continue-where-you-left-off): in-progress plan chats surface on
+/// Home too, and the section collapses to nothing when there are none.
+class _FakeAuthNotifier extends StateNotifier<AuthState>
+    implements AuthNotifier {
+  _FakeAuthNotifier(UserModel? user)
+      : super(AuthState(user: user, initialized: true));
+
+  @override
+  Future<bool> login(String email, String password) async => false;
+
+  @override
+  Future<bool> register(String email, String password,
+          {String? displayName}) async =>
+      false;
+
+  @override
+  Future<void> completeOnboarding() async {}
+
+  @override
+  Future<void> logout() async {}
+
+  @override
+  Future<void> signOutLocally() async {}
+
+  @override
+  void setUser(UserModel user) {}
+
+  @override
+  Future<void> adoptSession(String token, UserModel user) async {}
+}
+
+UserModel _user() => UserModel(
+      id: 'user-1',
+      email: 'test@example.com',
+      displayName: 'Brian',
+      createdAt: DateTime(2026, 1, 1),
+    );
+
+ChatSessionSummary _chat(String id, String title) => ChatSessionSummary(
+      chatId: id,
+      title: title,
+      preview: 'Thinking about a week of island hopping.',
+      messageCount: 4,
+      createdAt: '2026-07-01T10:00:00Z',
+      updatedAt: '2026-07-02T10:00:00Z',
+    );
+
+Future<void> _pumpHome(
+  WidgetTester tester, {
+  List<ChatSessionSummary> chats = const [],
+}) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        authProvider.overrideWith((ref) => _FakeAuthNotifier(_user())),
+        liveTripProvider.overrideWithValue(null),
+        resumableChatsProvider.overrideWith((ref) async => chats),
+      ],
+      child: const MaterialApp(home: HomeScreen()),
+    ),
+  );
+  // Extra pumps flush the SharedPreferences read behind recentTripProvider
+  // and the resumable-chats future.
+  await tester.pump();
+  await tester.pump();
+}
+
+void main() {
+  setUp(() => SharedPreferences.setMockInitialValues({}));
+
+  testWidgets('in-progress chats surface on home', (WidgetTester tester) async {
+    await _pumpHome(tester, chats: [_chat('c1', 'Greek islands in September')]);
+
+    expect(find.text('Continue where you left off'), findsOneWidget);
+    expect(find.byType(ContinueChatCard), findsOneWidget);
+    expect(find.text('Greek islands in September'), findsOneWidget);
+  });
+
+  testWidgets('section collapses when there is nothing to resume',
+      (WidgetTester tester) async {
+    await _pumpHome(tester);
+
+    expect(find.text('Continue where you left off'), findsNothing);
+    expect(find.byType(ContinueChatCard), findsNothing);
+  });
+}

--- a/src/packages/flutter-app/test/home_live_trip_test.dart
+++ b/src/packages/flutter-app/test/home_live_trip_test.dart
@@ -9,6 +9,7 @@ import 'package:travel_route_planner/models/trip.dart';
 import 'package:travel_route_planner/models/user.dart';
 import 'package:travel_route_planner/providers/auth_provider.dart';
 import 'package:travel_route_planner/providers/live_trip_provider.dart';
+import 'package:travel_route_planner/providers/resumable_chats_provider.dart';
 import 'package:travel_route_planner/screens/home_screen.dart';
 import 'package:travel_route_planner/widgets/live_trip_card.dart';
 
@@ -84,6 +85,9 @@ Future<void> _pumpHome(WidgetTester tester, Trip? liveTrip) async {
       overrides: [
         authProvider.overrideWith((ref) => _FakeAuthNotifier(_user())),
         liveTripProvider.overrideWithValue(liveTrip),
+        // Signed-in fake auth would otherwise trigger a real chats fetch
+        // behind the home ContinueChatsSection.
+        resumableChatsProvider.overrideWith((ref) async => const []),
       ],
       child: const MaterialApp(home: HomeScreen()),
     ),


### PR DESCRIPTION
## Summary
- Extract the "Continue where you left off" chat card from `trips_list_screen.dart` into a shared `lib/widgets/continue_chats_section.dart` (`ContinueChatCard` + self-collapsing `ContinueChatsSection`)
- Home renders `ContinueChatsSection` below the live-trip card and above the recent-trip tile, mirroring the My Trips ordering; it collapses to nothing when empty, on error, or signed out (auth gating lives in `resumableChatsProvider`)
- The section carries its own saved-trip graduation listener so a chat that produces a trip drops off Home immediately; My Trips keeps its interleaved layout using the shared card

## Testing
- `flutter analyze` — only the pre-existing baseline infos, nothing new
- `make flutter-test` — all 364 tests pass, including new `test/home_continue_chats_test.dart` (section renders with chats, collapses without) and `test/home_live_trip_test.dart` updated to override `resumableChatsProvider`

🤖 Generated with [Claude Code](https://claude.com/claude-code)