### PR TITLE
fix(smoke): retry rate-limited account cleanup in the exit trap

### DIFF
--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -141,9 +141,10 @@ PASSWORD=""
 ACCOUNT_DELETED=0
 cleanup() {
   if [ -n "$TOKEN" ] && [ "$ACCOUNT_DELETED" = 0 ]; then
-    curl -sS -o /dev/null --max-time "$SMOKE_TIMEOUT" -X DELETE "$API/auth/account" \
-      -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
-      -d "$(jq -n --arg p "$PASSWORD" '{password:$p}')" >/dev/null 2>&1 || true
+    # Via req so a 429 gets one Retry-After retry: a die() mid-run lands here
+    # with the strict per-IP bucket still hot, which used to strand the user.
+    req DELETE /auth/account "$(jq -n --arg p "$PASSWORD" '{password:$p}')" \
+      "Authorization: Bearer $TOKEN" >/dev/null 2>&1 || true
   fi
 }
 trap cleanup EXIT


### PR DESCRIPTION
## Summary
- The EXIT-trap `cleanup()` deleted the throwaway smoke user with a bare curl; when a run `die()`d mid-flight the strict per-IP bucket was often still hot, the DELETE got a 429, and the account was silently stranded on prod (found 3 such leftovers after tonight's transient plan-seed failures)
- Route it through the existing `req` helper, which already retries once honoring `Retry-After` (capped at 65s)

## Testing
- `bash -n scripts/smoke.sh`
- Forced-failure run against an unreachable gateway exits cleanly through the trap
- The `req` 429-retry path is already proven by the main teardown step (line 430)

🤖 Generated with [Claude Code](https://claude.com/claude-code)