### PR TITLE
feat(api): day-by-day print travel packet

### DIFF
--- a/specs/print-travel-packet/plan.md
+++ b/specs/print-travel-packet/plan.md
@@ -1,0 +1,80 @@
+# Plan: Print Travel Packet
+
+> **HOW.** Translates `spec.md` into a file-level technical approach. Every
+> decision should trace back to an acceptance criterion. See `../../CLAUDE.md`
+> for repo conventions referenced below — don't restate them, point to them.
+
+## Technical Approach
+
+Rebuild the body of the existing token-gated print page
+(`print_view_handler.go`) as a day-by-day packet. All changes are server-side
+Go; the Flutter trigger flow (`_openPrintExport` → mint token → new tab) is
+untouched.
+
+Key decisions:
+
+- **`loadExportData` stays frozen.** It is shared with the trip-review engine
+  (`review_handler.go`) and a plan tool (`plan_tools_extra.go`); both load
+  budget themselves and neither wants weather-lookup latency. Budget and
+  weather for print load in `printViewHandler` only, best-effort — a failure
+  omits the section, never 500s a page whose headers may already be sent.
+- **Day assembly is pure functions** over `exportData`, unit-testable without
+  a DB: bucket items by `day`, attach segments by depart/arrive date, match
+  stays by `check_in ≤ night < check_out`.
+- **A `maxPrintDays = 60` clamp** guards the new 1..N day loop — the old code
+  never iterated a range, so a stray `day = 5000` was harmless; now it must be
+  clamped (over-clamp items land in Unscheduled).
+- **Weather uses the trip-review idiom** (`weatherDayKey`, forecast exact-date
+  vs historical MM-DD matching), bounded by a 6-second context and a 5-city
+  cap; the day→city mapping comes from the day's items with gap-fill from the
+  previous day.
+- **URLs print as visible text** (`host+path`, truncated) because paper isn't
+  clickable; `html/template` discipline is preserved (no Sprintf HTML).
+
+## Go API Changes
+
+`src/packages/api/` (all files are `package main`):
+
+- **Routes:** none — `GET /export/{token}/print.html` already registered.
+- **Handlers:** all work in `print_view_handler.go`:
+  - view models: `printDaySection`, `printBudget`/`printBudgetRow`; extended
+    `printItem` (+City), `printSegment` (+Provider/PriceNote/Notes/URL/
+    URLText/Booked), `printStay` (+Provider/PriceNote/URL/URLText/Booked/Note)
+  - pure builders: `printDayCount`, `resolveDayCities`, `buildPrintDays`,
+    `buildPrintBudget`, `displayURL`, `formatWeatherLine`; rewritten
+    `buildPrintView(d, budget, weatherByDay)`
+  - loaders: `loadPrintBudget` (GetBudgetByTrip/ListExpensesByTrip, nil on
+    error), `loadPrintWeather` (takes `*WeatherService` param for testability)
+  - template: day sections → Unscheduled → Other transport / Accommodations
+    fallback lists → Budget → Booking checklist → Packing checklist; print CSS
+    `break-inside: avoid` on day sections/rows, `@page { margin: 14mm }`
+- **Service:** none new — reuses `weatherService` and sqlc `store` queries.
+- **Types:** view models above, template-only (no JSON).
+
+Unchanged: `export_handler.go`, `export_token.go`, `calendar_handler.go`,
+`review_handler.go`, `plan_tools_extra.go`.
+
+## Flutter Changes
+
+**None.** The existing menu action, token mint, and URL builder work as-is.
+
+## Contract Parity  ← anti-drift gate
+
+N/A — the page is server-rendered HTML; no JSON contract changes on either
+side.
+
+## Cross-cutting
+
+- **Env vars:** none new (`EXPORT_SIGNING_SECRET` already documented).
+- **Gateway:** existing path, no proxy changes.
+
+## Verification
+
+(Mirror into `tasks.md` as the final tasks.)
+
+- `make api-fmt && make api-vet` — clean.
+- `go test ./...` in `src/packages/api` (unit); with `TEST_DATABASE_URL` for
+  the export integration tests, including untouched `TestExportCalendar_*`.
+- Manual via `make docker-dev` (API container needs `up --build`): open a trip
+  → menu → "Print / Save as PDF" → walk the acceptance criteria in `spec.md`,
+  then Cmd+P to check page breaks.

--- a/specs/print-travel-packet/spec.md
+++ b/specs/print-travel-packet/spec.md
@@ -1,0 +1,115 @@
+# Spec: Print Travel Packet
+
+> **WHAT & WHY only.** No tech choices, file names, libraries, or code. If a
+> sentence names a file or a package, it belongs in `plan.md`, not here.
+
+## Context
+
+The existing "Print / Save as PDF" export renders a flat dump: the itinerary
+grouped by city, then separate accommodation, transport, and checklist lists.
+On paper mid-trip that layout forces constant cross-referencing — "what's
+happening *today*, where am I sleeping *tonight*?" — and it omits the trip
+summary, budget, weather, and booking details entirely. This feature turns the
+printed page into a travel agent-style **day-by-day packet**: everything for a
+given day in one place, followed by compact reference sections.
+
+## User Stories
+
+- As a **traveler on the road**, I want a printed page per day showing that
+  day's activities, transport, weather, and tonight's stay so that I can follow
+  my trip without a phone.
+- As a **trip owner**, I want booking details (provider, price notes, links,
+  booked status) visible on paper so that the printout works as a booking
+  reference at check-in desks.
+- As a **budget-conscious traveler**, I want my budget and expense breakdown in
+  the printout so that the packet doubles as a spending reference.
+
+## Acceptance Criteria
+
+- [ ] The print page opens from the existing trip-menu "Print / Save as PDF"
+      action with no change to how it is triggered.
+- [ ] The page header shows the trip title and date range; the trip summary
+      paragraph appears beneath it when one exists.
+- [ ] The body renders one section per calendar day of the trip, labeled
+      "Day N · Weekday, Month D — City".
+- [ ] A day section shows, in order: a weather line (when available), transport
+      departing/arriving that day, the day's itinerary items (time-of-day,
+      address, "Recommended by" attribution), and a "Tonight" block for the
+      accommodation covering that night.
+- [ ] The first night of a stay shows a check-in note; the last night shows the
+      check-out date; a stay never appears on its check-out day.
+- [ ] Days inside the trip range with no planned items still render (with
+      weather/stay/transport and a "No plans yet" note).
+- [ ] Items without an assigned day appear in an "Unscheduled" section after
+      the day pages, grouped as before.
+- [ ] A day consisting entirely of day-trip items is labeled with the
+      destination and a "Day trip from <hub>" subline.
+- [ ] Stays and transport carry provider, price note, booked status, and the
+      booking link rendered as short visible text (readable on paper).
+- [ ] A Budget section shows the target (with currency), expenses grouped by
+      category with subtotals, total spent, and remaining — only when a budget
+      or expenses exist.
+- [ ] Weather shows real forecasts for near-term days and "Typical:" last-year
+      values for far-out days; weather being unavailable never breaks or blanks
+      the page.
+- [ ] The Booking checklist and Packing checklist sections remain at the end,
+      unchanged.
+- [ ] A trip with no dates falls back to relative "Day N" sections with flat
+      accommodation/transport reference lists (no weather).
+- [ ] Printing (Cmd+P / Save as PDF) avoids splitting a day section or a single
+      row across a page break where it fits.
+- [ ] The calendar (.ics) export continues to work exactly as before.
+
+## API Surface
+
+No new endpoints. The existing token-gated print page changes its rendered
+content only:
+
+### `GET /api/v1/export/{token}/print.html`
+- **Purpose:** printable day-by-day travel packet for the trip the signed token
+  grants access to.
+- **Request:** unchanged (signed token in path; 1-hour validity).
+- **Response:** HTML page per the layout above.
+- **Errors:** unchanged — invalid/expired token yields the existing friendly
+  404 page.
+
+## Data Model
+
+No new entities. The page now *reads* (in addition to what it already read):
+the trip summary, the trip budget and its expenses, and per-city weather
+(looked up live, never stored).
+
+## UI Behavior
+
+- **Screen / surface:** browser tab opened by the trip menu's
+  "Print / Save as PDF" action; user prints via the browser.
+- **Happy path:** open menu → Print / Save as PDF → new tab shows the packet →
+  Cmd+P.
+- **States:** expired token → friendly "link isn't available" page; trip with
+  no content → existing "nothing to export yet" message; weather/budget
+  unavailable → those lines/sections are simply absent.
+
+## Edge Cases & Error States
+
+- Item day numbers beyond the trip's date range extend the day list; absurd
+  day numbers (beyond a 60-day cap) fall into Unscheduled instead of rendering
+  thousands of sections.
+- Transport with only an arrival date attaches to the arrival day; transport
+  with no dates goes to an "Other transport" reference list.
+- Stays with no valid dates go to an "Accommodations" reference list.
+- Weather lookups are bounded (a few seconds, a handful of cities); any
+  failure or out-of-window date silently omits that day's weather line.
+- Budget lookups failing silently omit the Budget section.
+
+## Out of Scope
+
+- Changing how the export is triggered, tokenized, or shared (no Flutter work).
+- Maps, photos, or QR codes on the printout.
+- Trip Health findings, local-recommendation browsing, or events on the
+  printout.
+- Changes to the .ics calendar export content.
+
+## Open Questions
+
+None — layout and content scope were decided with the owner before
+implementation.

--- a/specs/print-travel-packet/tasks.md
+++ b/specs/print-travel-packet/tasks.md
@@ -1,0 +1,44 @@
+# Tasks: Print Travel Packet
+
+> Dependency-ordered. `[P]` = can run in parallel with its siblings (no shared
+> files / no ordering dependency). Work top to bottom; verification is last.
+
+## API (Go)
+
+- [ ] Extend/add view models in `print_view_handler.go` (`printDaySection`,
+      `printBudget`, richer `printSegment`/`printStay`/`printItem`)
+- [ ] Pure builders: `printDayCount` (60-day clamp), `resolveDayCities`,
+      `buildPrintDays`, `buildPrintBudget`, `displayURL`, `formatWeatherLine`
+- [ ] Rewrite `buildPrintView` to assemble days + unscheduled + fallback lists
+- [ ] Rewrite `printViewTmpl`: summary → day sections → Unscheduled → Other
+      transport / Accommodations → Budget → checklists; print CSS page-break
+      rules
+- [ ] Handler loaders: `loadPrintBudget`, `loadPrintWeather` (best-effort,
+      6s timeout, ≤5 cities); wire into `printViewHandler`
+- [ ] Confirm zero diffs in `export_handler.go`, `calendar_handler.go`,
+      `review_handler.go`, `plan_tools_extra.go`
+
+## Models & codegen (Flutter)
+
+- N/A — no Flutter changes (server-rendered HTML, trigger flow unchanged)
+
+## Tests
+
+- [ ] [P] Unit `print_view_test.go`: `buildPrintDays` edge cases (stay-night
+      matching, check-in/out notes, arrive-only segments, undated trip,
+      day clamp, day-trip labels, empty days), `buildPrintBudget`,
+      `displayURL`, `formatWeatherLine`, template escaping,
+      `loadPrintWeather` via `weatherStub` + dead-server resilience
+- [ ] Integration `export_integration_test.go`: extend fixture (summary,
+      budget+expenses, booked segment with URL, unscheduled item, empty day),
+      swap `weatherService` stub; keep `TestExportCalendar_*` and existing
+      print assertions green
+
+## Verification
+
+- [ ] `make api-fmt && make api-vet` clean
+- [ ] `go test ./...` in `src/packages/api`; full suite with
+      `TEST_DATABASE_URL`
+- [ ] Manual end-to-end via gateway (`make docker-dev` →
+      `http://localhost:3000`): every acceptance criterion in `spec.md`
+      checked off; Cmd+P page-break check

--- a/src/packages/api/export_integration_test.go
+++ b/src/packages/api/export_integration_test.go
@@ -136,6 +136,172 @@ func TestExportPrintView_RendersAndEscapes(t *testing.T) {
 	}
 }
 
+// TestExportPrintView_DayPacket exercises the day-by-day packet layout
+// (specs/print-travel-packet): summary, per-day sections with weather and
+// tonight's stay, unscheduled items, booking details, and the budget table.
+func TestExportPrintView_DayPacket(t *testing.T) {
+	resetDB(t)
+	owner, _ := createTestUser(t, "packet@example.com")
+	ctx := context.Background()
+	q := store.New(dbPool)
+
+	summary := "A slow loop through Athens with a Delphi day trip."
+	chat := "packet-chat"
+	trip, err := q.CreateTrip(ctx, store.CreateTripParams{
+		UserID: owner.ID, Title: "Packet Trip", Status: "draft", ChatID: &chat, Summary: &summary,
+	})
+	if err != nil {
+		t.Fatalf("CreateTrip: %v", err)
+	}
+	if _, err := q.UpdateTrip(ctx, store.UpdateTripParams{
+		ID: trip.ID, UserID: owner.ID,
+		StartDate: pgDate(t, "2026-08-01"), EndDate: pgDate(t, "2026-08-05"),
+	}); err != nil {
+		t.Fatalf("UpdateTrip dates: %v", err)
+	}
+
+	day := int32(2)
+	city := "Athens"
+	rec := "Maria"
+	if _, err := q.CreateItineraryItem(ctx, store.CreateItineraryItemParams{
+		TripID: trip.ID, Position: 0, Name: "Acropolis", Latitude: 37.97, Longitude: 23.72,
+		Day: &day, City: &city, LocalSourceName: &rec,
+	}); err != nil {
+		t.Fatalf("create day item: %v", err)
+	}
+	// No day ⇒ Unscheduled section.
+	if _, err := q.CreateItineraryItem(ctx, store.CreateItineraryItemParams{
+		TripID: trip.ID, Position: 1, Name: "Someday Taverna", Latitude: 37.97, Longitude: 23.73,
+		City: &city,
+	}); err != nil {
+		t.Fatalf("create unscheduled item: %v", err)
+	}
+
+	stayURL := "https://www.booking.com/hotel/gr/grande.html?aid=42"
+	stayPrice := "€180/night"
+	if _, err := q.CreateAccommodation(ctx, store.CreateAccommodationParams{
+		TripID: trip.ID, Name: "Hotel Grande Bretagne",
+		Url: &stayURL, PriceNote: &stayPrice,
+		CheckIn: pgDate(t, "2026-08-01"), CheckOut: pgDate(t, "2026-08-05"),
+	}); err != nil {
+		t.Fatalf("create stay: %v", err)
+	}
+
+	provider := "Hellenic Train"
+	segPrice := "€25"
+	seg, err := q.CreateSegment(ctx, store.CreateSegmentParams{
+		TripID: trip.ID, Mode: "train", Origin: strp("Athens"), Destination: strp("Kalambaka"),
+		DepartDate: pgDate(t, "2026-08-02"), ArriveDate: pgDate(t, "2026-08-02"),
+		Provider: &provider, PriceNote: &segPrice,
+	})
+	if err != nil {
+		t.Fatalf("create segment: %v", err)
+	}
+	booked := true
+	if _, err := q.UpdateSegment(ctx, store.UpdateSegmentParams{
+		ID: seg.ID, TripID: trip.ID, Booked: &booked,
+	}); err != nil {
+		t.Fatalf("book segment: %v", err)
+	}
+
+	target := 2000.0
+	if _, err := q.UpsertBudget(ctx, store.UpsertBudgetParams{
+		TripID: trip.ID, TargetAmount: &target, Currency: "EUR",
+	}); err != nil {
+		t.Fatalf("upsert budget: %v", err)
+	}
+	for i, e := range []struct {
+		cat, label string
+		amount     float64
+	}{
+		{"lodging", "Hotel Grande Bretagne", 600},
+		{"food", "Tavernas", 150},
+	} {
+		if _, err := q.CreateExpense(ctx, store.CreateExpenseParams{
+			TripID: trip.ID, Category: e.cat, Label: e.label, Amount: e.amount, Position: int32(i),
+		}); err != nil {
+			t.Fatalf("create expense: %v", err)
+		}
+	}
+
+	// Point the shared weather singleton at a stub double (idiom from
+	// trip_review_integration_test.go); it serves both forecast and archive
+	// paths, so the assertion is date-independent.
+	prevWeather := weatherService
+	weatherService = weatherStub(t, false, 30, 21)
+	t.Cleanup(func() { weatherService = prevWeather })
+
+	token, _ := newExportToken(trip.ID)
+	res := doJSON(t, "GET", "/api/v1/export/"+token+"/print.html", "", nil)
+	if res.Code != 200 {
+		t.Fatalf("print.html: got %d want 200", res.Code)
+	}
+	body := res.Body.String()
+
+	for _, want := range []string{
+		summary,
+		"Day 1 · Sat, Aug 1",
+		"Day 2 · Sun, Aug 2 — Athens",
+		"Day 5 · Wed, Aug 5",
+		"Weather:", "°C",
+		"Train · Athens → Kalambaka",
+		"(booked)",
+		"Hellenic Train", "€25",
+		"Acropolis", "Recommended by Maria",
+		"No plans yet for this day.",
+		"Tonight: Hotel Grande Bretagne",
+		"Check in today",
+		"Check out Wed, Aug 5",
+		"€180/night",
+		"booking.com/hotel/gr/grande.html",
+		"Unscheduled", "Someday Taverna",
+		"Budget (EUR)", "Target: 2000.00",
+		"Total spent: 750.00", "Remaining: 1250.00",
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("print packet missing %q\n%s", want, body)
+		}
+	}
+
+	// The stay covers nights 1–4 only; no "Tonight" block on the check-out day.
+	if n := strings.Count(body, "Tonight: Hotel Grande Bretagne"); n != 4 {
+		t.Fatalf("stay should appear on 4 nights, got %d", n)
+	}
+	// The raw booking URL query string must not leak into the visible text.
+	if strings.Contains(body, "aid=42</a>") {
+		t.Fatal("URL text should strip the query string")
+	}
+}
+
+// TestExportPrintView_WeatherFailureIsSilent proves a dead weather upstream
+// degrades to a page without weather lines, never an error.
+func TestExportPrintView_WeatherFailureIsSilent(t *testing.T) {
+	resetDB(t)
+	owner, _ := createTestUser(t, "noweather@example.com")
+	trip := exportFixtureTrip(t, owner.ID, "Stormy Trip")
+
+	dead := NewWeatherService()
+	dead.GeocodeBaseURL = "http://127.0.0.1:1"
+	dead.ForecastBaseURL = "http://127.0.0.1:1"
+	dead.ArchiveBaseURL = "http://127.0.0.1:1"
+	prevWeather := weatherService
+	weatherService = dead
+	t.Cleanup(func() { weatherService = prevWeather })
+
+	token, _ := newExportToken(trip.ID)
+	res := doJSON(t, "GET", "/api/v1/export/"+token+"/print.html", "", nil)
+	if res.Code != 200 {
+		t.Fatalf("print.html with dead weather: got %d want 200", res.Code)
+	}
+	body := res.Body.String()
+	if strings.Contains(body, "Weather:") {
+		t.Fatal("weather line should be absent when the upstream is down")
+	}
+	if !strings.Contains(body, "Acropolis") || !strings.Contains(body, "Day 2") {
+		t.Fatal("packet content should survive a weather outage")
+	}
+}
+
 func TestExportPrintView_InvalidTokenIs404(t *testing.T) {
 	resetDB(t)
 	rec := doJSON(t, "GET", "/api/v1/export/not-a-real-token/print.html", "", nil)

--- a/src/packages/api/print_view_handler.go
+++ b/src/packages/api/print_view_handler.go
@@ -1,12 +1,16 @@
 package main
 
 import (
+	"context"
+	"fmt"
 	"html/template"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/gorilla/mux"
 
 	"travel-route-planner/store"
@@ -28,10 +32,26 @@ func capitalize(s string) string {
 // is the capability. Rendered with html/template so every field is
 // auto-escaped; NEVER assemble this HTML with fmt.Sprintf (same rule as
 // share_preview_handler.go).
+//
+// Layout is a day-by-day travel packet (specs/print-travel-packet): one
+// section per calendar day (weather, transport, activities, tonight's stay),
+// then Unscheduled items, reference lists for undatable stays/transport,
+// Budget, and the booking/packing checklists. Budget and weather load here
+// only, best-effort — loadExportData stays shared with the review engine and
+// plan tools and must not grow those costs.
+
+// maxPrintDays caps the rendered day range. The day loop iterates 1..N, so a
+// stray item day (e.g. 5000) must not render thousands of sections; items
+// beyond the cap fall into Unscheduled.
+const maxPrintDays = 60
+
+// maxPrintWeatherCities caps outbound weather lookups per page render.
+const maxPrintWeatherCities = 5
 
 type printItem struct {
 	Name          string
 	TimeOfDay     string
+	City          string // set only when it differs from the day's hub (day trips)
 	Address       string
 	RecommendedBy string // local_source_name attribution, when present
 }
@@ -48,17 +68,47 @@ type printGroup struct {
 }
 
 type printStay struct {
-	Name     string
-	Address  string
-	CheckIn  string
-	CheckOut string
+	Name    string
+	Address string
+	Meta    string // provider · price note · check-in/out or tonight note
+	URL     string
+	URLText string // short visible link text (paper isn't clickable)
+	Booked  bool
 }
 
 type printSegment struct {
-	Mode   string
-	Route  string // "Origin → Destination"
-	Depart string
-	Arrive string
+	Route   string // "Origin → Destination"
+	Mode    string
+	Meta    string // depart/arrive · provider · price note
+	Notes   string
+	URL     string
+	URLText string
+	Booked  bool
+}
+
+type printDaySection struct {
+	Label    string // "Day 3"
+	Date     string // "Mon, Jan 2" or "" for undated trips
+	Hub      string // where you are that day
+	DayTrip  string // "Day trip from Athens" when the whole day is one day trip
+	Weather  string // formatted line; "" = omit
+	Segments []printSegment
+	Items    []printItem
+	Stays    []printStay // tonight's stay(s)
+}
+
+type printBudgetRow struct {
+	Label    string
+	Amount   string
+	Subtotal bool // category subtotal row (rendered bold)
+}
+
+type printBudget struct {
+	Currency  string
+	Target    string // "" when no target set
+	Spent     string
+	Remaining string // "" when no target set
+	Rows      []printBudgetRow
 }
 
 type printTodo struct {
@@ -78,14 +128,17 @@ type printChecklistItem struct {
 }
 
 type printViewData struct {
-	Title      string
-	Dates      string
-	Groups     []printGroup
-	Stays      []printStay
-	Segments   []printSegment
-	Todos      []printTodo
-	Checklist  []printChecklistGroup
-	HasContent bool
+	Title         string
+	Dates         string
+	Summary       string
+	Days          []printDaySection
+	Unscheduled   []printGroup
+	OtherStays    []printStay
+	OtherSegments []printSegment
+	Budget        *printBudget
+	Todos         []printTodo
+	Checklist     []printChecklistGroup
+	HasContent    bool
 }
 
 // printViewTmpl uses html/template — every field is auto-escaped. Brand house
@@ -119,6 +172,10 @@ var printViewTmpl = template.Must(template.New("print-view").Parse(`<!DOCTYPE ht
       color: #00695C; font-size: 1.2rem; margin: 32px 0 8px;
       border-bottom: 2px solid #B2DFDB; padding-bottom: 6px;
     }
+    .summary { font-size: 1.02rem; color: #455A64; margin: 0 0 8px; }
+    .day-sec { margin: 0 0 8px; }
+    .daytrip { margin: -4px 0 8px; font-size: 0.92rem; color: #00695C; font-style: italic; }
+    .wx { margin: 0 0 8px; font-size: 0.9rem; color: #546E7A; }
     .hub { margin: 20px 0 0; }
     .hub-name { font-size: 1.05rem; font-weight: 600; color: #004D40; margin: 0 0 4px; }
     .day { margin: 12px 0 0; padding: 10px 14px; background: #F5F7F7; border-radius: 8px; }
@@ -131,17 +188,27 @@ var printViewTmpl = template.Must(template.New("print-view").Parse(`<!DOCTYPE ht
     .row:last-child { border-bottom: none; }
     .row-title { font-weight: 600; }
     .row-meta { font-size: 0.9rem; color: #546E7A; }
+    .stay { margin: 10px 0 0; padding: 8px 12px; background: #F5F7F7; border-radius: 8px; }
+    .url { font-size: 0.85rem; color: #546E7A; word-break: break-all; }
+    a { color: inherit; text-decoration: none; }
     .cat { font-weight: 600; color: #004D40; margin: 14px 0 4px; text-transform: capitalize; }
     ul.check { list-style: none; padding-left: 0; margin: 0; }
     ul.check li { padding: 3px 0; }
     .box { display: inline-block; width: 1em; }
     .booked { color: #2E7D32; }
+    table.budget { border-collapse: collapse; width: 100%; max-width: 420px; }
+    table.budget td { padding: 3px 0; font-size: 0.95rem; }
+    table.budget td.amt { text-align: right; }
+    table.budget tr.subtotal td { font-weight: 600; color: #004D40; padding-top: 8px; }
+    table.budget td.exp { padding-left: 14px; color: #546E7A; }
+    .budget-line { margin: 10px 0 0; font-weight: 600; }
     footer { margin-top: 40px; padding-top: 14px; border-top: 1px solid #CFD8DC; font-size: 0.85rem; color: #607D8B; }
     .empty { color: #607D8B; font-style: italic; }
+    @page { margin: 14mm; }
     @media print {
       header { background: #004D40 !important; -webkit-print-color-adjust: exact; print-color-adjust: exact; }
-      .day, .hub, .row { page-break-inside: avoid; }
-      h2 { page-break-after: avoid; }
+      .day-sec, .day, .hub, .row, .stay, .item, table.budget tr { break-inside: avoid; page-break-inside: avoid; }
+      h2 { break-after: avoid; page-break-after: avoid; }
     }
   </style>
 </head>
@@ -156,9 +223,43 @@ var printViewTmpl = template.Must(template.New("print-view").Parse(`<!DOCTYPE ht
   <main>
     {{if not .HasContent}}<p class="empty">This trip has nothing to export yet.</p>{{end}}
 
-    {{if .Groups}}
-    <h2>Itinerary</h2>
-    {{range .Groups}}
+    {{if .Summary}}<p class="summary">{{.Summary}}</p>{{end}}
+
+    {{range .Days}}
+    <section class="day-sec">
+      <h2>{{.Label}}{{if .Date}} · {{.Date}}{{end}}{{if .Hub}} — {{.Hub}}{{end}}</h2>
+      {{if .DayTrip}}<p class="daytrip">{{.DayTrip}}</p>{{end}}
+      {{if .Weather}}<p class="wx">Weather: {{.Weather}}</p>{{end}}
+      {{range .Segments}}
+      <div class="row">
+        <div class="row-title">{{.Mode}} · {{.Route}}{{if .Booked}} <span class="booked">(booked)</span>{{end}}</div>
+        {{if .Meta}}<div class="row-meta">{{.Meta}}</div>{{end}}
+        {{if .Notes}}<div class="row-meta">{{.Notes}}</div>{{end}}
+        {{if .URLText}}<div class="url"><a href="{{.URL}}">{{.URLText}}</a></div>{{end}}
+      </div>
+      {{end}}
+      {{range .Items}}
+      <div class="item">
+        <div class="item-name">{{.Name}}</div>
+        {{if or .TimeOfDay .City .Address}}<div class="item-meta">{{if .TimeOfDay}}{{.TimeOfDay}}{{end}}{{if and .TimeOfDay .City}} · {{end}}{{.City}}{{if and (or .TimeOfDay .City) .Address}} · {{end}}{{.Address}}</div>{{end}}
+        {{if .RecommendedBy}}<div class="rec">Recommended by {{.RecommendedBy}}</div>{{end}}
+      </div>
+      {{end}}
+      {{if not .Items}}<p class="empty">No plans yet for this day.</p>{{end}}
+      {{range .Stays}}
+      <div class="stay">
+        <div class="row-title">Tonight: {{.Name}}{{if .Booked}} <span class="booked">(booked)</span>{{end}}</div>
+        {{if .Address}}<div class="row-meta">{{.Address}}</div>{{end}}
+        {{if .Meta}}<div class="row-meta">{{.Meta}}</div>{{end}}
+        {{if .URLText}}<div class="url"><a href="{{.URL}}">{{.URLText}}</a></div>{{end}}
+      </div>
+      {{end}}
+    </section>
+    {{end}}
+
+    {{if .Unscheduled}}
+    <h2>Unscheduled</h2>
+    {{range .Unscheduled}}
     <div class="hub">
       <p class="hub-name">{{.Hub}}</p>
       {{range .Days}}
@@ -177,25 +278,41 @@ var printViewTmpl = template.Must(template.New("print-view").Parse(`<!DOCTYPE ht
     {{end}}
     {{end}}
 
-    {{if .Stays}}
+    {{if .OtherStays}}
     <h2>Accommodations</h2>
-    {{range .Stays}}
+    {{range .OtherStays}}
     <div class="row">
-      <div class="row-title">{{.Name}}</div>
+      <div class="row-title">{{.Name}}{{if .Booked}} <span class="booked">(booked)</span>{{end}}</div>
       {{if .Address}}<div class="row-meta">{{.Address}}</div>{{end}}
-      {{if or .CheckIn .CheckOut}}<div class="row-meta">{{if .CheckIn}}Check-in {{.CheckIn}}{{end}}{{if .CheckOut}} · Check-out {{.CheckOut}}{{end}}</div>{{end}}
+      {{if .Meta}}<div class="row-meta">{{.Meta}}</div>{{end}}
+      {{if .URLText}}<div class="url"><a href="{{.URL}}">{{.URLText}}</a></div>{{end}}
     </div>
     {{end}}
     {{end}}
 
-    {{if .Segments}}
-    <h2>Transport</h2>
-    {{range .Segments}}
+    {{if .OtherSegments}}
+    <h2>Other transport</h2>
+    {{range .OtherSegments}}
     <div class="row">
-      <div class="row-title">{{.Route}}</div>
-      <div class="row-meta">{{.Mode}}{{if .Depart}} · Departs {{.Depart}}{{end}}{{if .Arrive}} · Arrives {{.Arrive}}{{end}}</div>
+      <div class="row-title">{{.Mode}} · {{.Route}}{{if .Booked}} <span class="booked">(booked)</span>{{end}}</div>
+      {{if .Meta}}<div class="row-meta">{{.Meta}}</div>{{end}}
+      {{if .Notes}}<div class="row-meta">{{.Notes}}</div>{{end}}
+      {{if .URLText}}<div class="url"><a href="{{.URL}}">{{.URLText}}</a></div>{{end}}
     </div>
     {{end}}
+    {{end}}
+
+    {{with .Budget}}
+    <h2>Budget ({{.Currency}})</h2>
+    {{if .Target}}<p class="budget-line">Target: {{.Target}}</p>{{end}}
+    {{if .Rows}}
+    <table class="budget">
+      {{range .Rows}}
+      <tr{{if .Subtotal}} class="subtotal"{{end}}><td{{if not .Subtotal}} class="exp"{{end}}>{{.Label}}</td><td class="amt">{{.Amount}}</td></tr>
+      {{end}}
+    </table>
+    {{end}}
+    <p class="budget-line">Total spent: {{.Spent}}{{if .Remaining}} · Remaining: {{.Remaining}}{{end}}</p>
     {{end}}
 
     {{if .Todos}}
@@ -232,17 +349,121 @@ func printViewHandler(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte("<!DOCTYPE html><html><body><h2>This export link isn't available</h2><p>It may have expired.</p></body></html>"))
 		return
 	}
-	view := buildPrintView(data)
+	budget := loadPrintBudget(r.Context(), data.Trip.ID)
+	var weather []string
+	if n, dated := printDayCount(data); dated {
+		weather = loadPrintWeather(r.Context(), weatherService, data, n)
+	}
+	view := buildPrintView(data, budget, weather)
 	if err := printViewTmpl.Execute(w, view); err != nil {
 		// Headers already sent; nothing sensible left to do.
 		return
 	}
 }
 
+// loadPrintBudget loads the trip's budget + expenses for display. Best-effort:
+// any failure returns nil and the Budget section is simply omitted — the print
+// page must render without it.
+func loadPrintBudget(ctx context.Context, tripID uuid.UUID) *printBudget {
+	if dbPool == nil {
+		return nil
+	}
+	q := store.New(dbPool)
+	var b *store.TripBudget
+	if row, err := q.GetBudgetByTrip(ctx, tripID); err == nil {
+		b = &row
+	}
+	expenses, err := q.ListExpensesByTrip(ctx, tripID)
+	if err != nil {
+		return nil
+	}
+	return buildPrintBudget(b, expenses)
+}
+
+// loadPrintWeather returns one formatted weather line per trip day (index 0 =
+// Day 1), "" where unavailable. Best-effort: never returns an error — weather
+// must not break or slow the page beyond its own timeout. Takes the service as
+// a parameter so tests don't need to swap the package-level singleton.
+func loadPrintWeather(ctx context.Context, ws *WeatherService, d exportData, n int) []string {
+	if ws == nil || !d.Trip.StartDate.Valid || n <= 0 {
+		return nil
+	}
+	ctx, cancel := context.WithTimeout(ctx, 6*time.Second)
+	defer cancel()
+
+	start := d.Trip.StartDate.Time
+	cities := resolveDayCities(d, n)
+	out := make([]string, n)
+
+	// One lookup per contiguous same-city run, capped at a handful of distinct
+	// cities per render (the service's TTL cache absorbs repeats).
+	type cityRun struct {
+		city     string
+		from, to int
+	}
+	var runs []cityRun
+	for i := 0; i < n; i++ {
+		c := cities[i]
+		if c == "" {
+			continue
+		}
+		if len(runs) > 0 && runs[len(runs)-1].city == c && runs[len(runs)-1].to == i-1 {
+			runs[len(runs)-1].to = i
+			continue
+		}
+		runs = append(runs, cityRun{city: c, from: i, to: i})
+	}
+	distinct := map[string]bool{}
+	for _, run := range runs {
+		if !distinct[run.city] {
+			if len(distinct) >= maxPrintWeatherCities {
+				continue
+			}
+			distinct[run.city] = true
+		}
+		report, err := ws.GetTripWeather(ctx, run.city,
+			start.AddDate(0, 0, run.from).Format(dateLayout),
+			start.AddDate(0, 0, run.to).Format(dateLayout))
+		if err != nil || len(report.Days) == 0 {
+			continue // weather is decoration; skip silently
+		}
+		historical := report.Kind == "historical"
+		byKey := map[string]WeatherDay{}
+		for _, wd := range report.Days {
+			byKey[weatherDayKey(wd.Date, historical)] = wd
+		}
+		for i := run.from; i <= run.to; i++ {
+			key := start.AddDate(0, 0, i).Format(dateLayout)
+			if historical {
+				key = start.AddDate(0, 0, i).Format("01-02")
+			}
+			if wd, ok := byKey[key]; ok {
+				out[i] = formatWeatherLine(wd, historical)
+			}
+		}
+	}
+	return out
+}
+
+// formatWeatherLine mirrors summarizeWeather's per-day rendering; "Typical:"
+// flags archive data (last year's observations, not a forecast).
+func formatWeatherLine(wd WeatherDay, historical bool) string {
+	line := fmt.Sprintf("%.0f–%.0f°C", wd.TempMinC, wd.TempMaxC)
+	if wd.PrecipPct != nil {
+		line += fmt.Sprintf(", %d%% chance of rain", *wd.PrecipPct)
+	} else if wd.PrecipMM >= 1 {
+		line += fmt.Sprintf(", %.0fmm rain", wd.PrecipMM)
+	}
+	if historical {
+		return "Typical: " + line
+	}
+	return line
+}
+
 // buildPrintView reshapes the raw export data into the template view model:
-// items grouped by hub (day_trip_from → city) then by day with resolved dates,
-// plus flat stays/segments/todos/checklist sections.
-func buildPrintView(d exportData) printViewData {
+// day-by-day packet sections plus unscheduled/reference/budget/checklist
+// sections. budget and weatherByDay are optional (nil ⇒ section/lines omitted).
+func buildPrintView(d exportData, budget *printBudget, weatherByDay []string) printViewData {
 	view := printViewData{Title: strings.TrimSpace(d.Trip.Title)}
 	if view.Title == "" {
 		view.Title = "Untitled trip"
@@ -252,25 +473,22 @@ func buildPrintView(d exportData) printViewData {
 	} else if d.Trip.StartDate.Valid {
 		view.Dates = d.Trip.StartDate.Time.Format("Jan 2, 2006")
 	}
+	view.Summary = strings.TrimSpace(strPtrVal(d.Trip.Summary))
 
-	view.Groups = groupExportItems(d.Trip, d.Items)
+	view.HasContent = len(d.Items) > 0 || len(d.Accommodations) > 0 ||
+		len(d.Segments) > 0 || len(d.BookingTodos) > 0 || len(d.Checklist) > 0 ||
+		budget != nil
+	if !view.HasContent {
+		return view
+	}
 
-	for _, a := range d.Accommodations {
-		view.Stays = append(view.Stays, printStay{
-			Name:     a.Name,
-			Address:  strPtrVal(a.Address),
-			CheckIn:  formatExportDate(dateToPtr(a.CheckIn)),
-			CheckOut: formatExportDate(dateToPtr(a.CheckOut)),
-		})
-	}
-	for _, s := range d.Segments {
-		view.Segments = append(view.Segments, printSegment{
-			Mode:   capitalize(s.Mode),
-			Route:  segmentRoute(s),
-			Depart: formatExportDate(dateToPtr(s.DepartDate)),
-			Arrive: formatExportDate(dateToPtr(s.ArriveDate)),
-		})
-	}
+	days, unscheduled, otherStays, otherSegs := buildPrintDays(d, weatherByDay)
+	view.Days = days
+	view.Unscheduled = groupExportItems(d.Trip, unscheduled)
+	view.OtherStays = otherStays
+	view.OtherSegments = otherSegs
+	view.Budget = budget
+
 	for _, t := range d.BookingTodos {
 		view.Todos = append(view.Todos, printTodo{
 			Title:    t.Title,
@@ -279,16 +497,361 @@ func buildPrintView(d exportData) printViewData {
 		})
 	}
 	view.Checklist = groupChecklist(d.Checklist)
-
-	view.HasContent = len(view.Groups) > 0 || len(view.Stays) > 0 ||
-		len(view.Segments) > 0 || len(view.Todos) > 0 || len(view.Checklist) > 0
 	return view
+}
+
+// printDayCount returns how many day sections to render and whether the trip
+// has real dates. The count comes from the trip's date range, extended by item
+// day numbers (so a Day 7 item on a 5-day trip still shows), and clamped to
+// maxPrintDays. Undated trips get relative day sections from item days alone.
+func printDayCount(d exportData) (int, bool) {
+	dated := d.Trip.StartDate.Valid
+	n := 0
+	if dated {
+		n = 1
+		if d.Trip.EndDate.Valid {
+			if span := int(d.Trip.EndDate.Time.Sub(d.Trip.StartDate.Time).Hours()/24) + 1; span > 1 {
+				n = span
+			}
+		}
+	}
+	// Item days extend the range, but a runaway day number (beyond the clamp)
+	// must not drag dozens of hollow sections with it — that item just lands
+	// in Unscheduled instead.
+	for _, it := range d.Items {
+		if it.Day != nil && int(*it.Day) > n && int(*it.Day) <= maxPrintDays {
+			n = int(*it.Day)
+		}
+	}
+	if n > maxPrintDays {
+		n = maxPrintDays
+	}
+	return n, dated
+}
+
+// resolveDayCities maps each day (index 0 = Day 1) to a city: the first item
+// that day with a city, gaps inheriting the previous day's city and leading
+// gaps backfilling from the first known one. Drives the day header label and
+// weather lookups — deliberately prefers City over DayTripFrom (weather should
+// be where you are, not the hub you left from).
+func resolveDayCities(d exportData, n int) []string {
+	cities := make([]string, n)
+	for _, it := range d.Items {
+		if it.Day == nil {
+			continue
+		}
+		di := int(*it.Day) - 1
+		if di < 0 || di >= n || cities[di] != "" {
+			continue
+		}
+		if city := strings.TrimSpace(strPtrVal(it.City)); city != "" {
+			cities[di] = city
+		}
+	}
+	first := ""
+	for _, c := range cities {
+		if c != "" {
+			first = c
+			break
+		}
+	}
+	prev := first
+	for i := range cities {
+		if cities[i] == "" {
+			cities[i] = prev
+		} else {
+			prev = cities[i]
+		}
+	}
+	return cities
+}
+
+// buildPrintDays assembles the day-by-day sections: items bucketed by day,
+// segments attached by depart (falling back to arrive) date, stays matched to
+// the nights they cover (check_in ≤ night < check_out). Whatever can't be
+// placed on a day is returned for the trailing reference sections.
+func buildPrintDays(d exportData, weatherByDay []string) ([]printDaySection, []store.ItineraryItem, []printStay, []printSegment) {
+	n, dated := printDayCount(d)
+	var unscheduled []store.ItineraryItem
+	var otherStays []printStay
+	var otherSegs []printSegment
+
+	if n == 0 {
+		for _, a := range d.Accommodations {
+			otherStays = append(otherStays, toPrintStay(a, stayDatesNote(a)))
+		}
+		for _, s := range d.Segments {
+			otherSegs = append(otherSegs, toPrintSegment(s))
+		}
+		return nil, d.Items, otherStays, otherSegs
+	}
+
+	start := d.Trip.StartDate.Time
+	cities := resolveDayCities(d, n)
+	days := make([]printDaySection, n)
+	for i := range days {
+		days[i].Label = "Day " + strconv.Itoa(i+1)
+		days[i].Hub = cities[i]
+		if dated {
+			days[i].Date = start.AddDate(0, 0, i).Format("Mon, Jan 2")
+		}
+		if i < len(weatherByDay) {
+			days[i].Weather = weatherByDay[i]
+		}
+	}
+
+	// Items, in position order. A day whose items all share one non-empty
+	// DayTripFrom gets a "Day trip from <hub>" subline; the sentinel marks a
+	// day disqualified by a mixed or missing hub.
+	const mixedDayTrip = "\x00"
+	dayTripHub := make([]string, n)
+	for _, it := range d.Items {
+		di := -1
+		if it.Day != nil {
+			di = int(*it.Day) - 1
+		}
+		if di < 0 || di >= n {
+			unscheduled = append(unscheduled, it)
+			continue
+		}
+		item := printItem{
+			Name:          it.Name,
+			TimeOfDay:     capitalize(strPtrVal(it.TimeOfDay)),
+			Address:       strPtrVal(it.Address),
+			RecommendedBy: strPtrVal(it.LocalSourceName),
+		}
+		if city := strings.TrimSpace(strPtrVal(it.City)); city != "" && !strings.EqualFold(city, cities[di]) {
+			item.City = city
+		}
+		days[di].Items = append(days[di].Items, item)
+
+		dtf := strings.TrimSpace(strPtrVal(it.DayTripFrom))
+		switch {
+		case dtf == "":
+			dayTripHub[di] = mixedDayTrip
+		case dayTripHub[di] == "":
+			dayTripHub[di] = dtf
+		case !strings.EqualFold(dayTripHub[di], dtf):
+			dayTripHub[di] = mixedDayTrip
+		}
+	}
+	for i, hub := range dayTripHub {
+		if hub != "" && hub != mixedDayTrip {
+			days[i].DayTrip = "Day trip from " + hub
+		}
+	}
+
+	dayIndexOf := func(t time.Time) int {
+		if !dated {
+			return -1
+		}
+		di := int(t.Sub(start).Hours() / 24)
+		if di < 0 || di >= n {
+			return -1
+		}
+		return di
+	}
+
+	for _, s := range d.Segments {
+		di := -1
+		if s.DepartDate.Valid {
+			di = dayIndexOf(s.DepartDate.Time)
+		}
+		if di < 0 && s.ArriveDate.Valid {
+			di = dayIndexOf(s.ArriveDate.Time)
+		}
+		if di < 0 {
+			otherSegs = append(otherSegs, toPrintSegment(s))
+			continue
+		}
+		days[di].Segments = append(days[di].Segments, toPrintSegment(s))
+	}
+
+	for _, a := range d.Accommodations {
+		attached := false
+		if dated && a.CheckIn.Valid {
+			checkIn := a.CheckIn.Time
+			checkOut := checkIn.AddDate(0, 0, 1) // no/invalid check-out ⇒ single night
+			if a.CheckOut.Valid && a.CheckOut.Time.After(checkIn) {
+				checkOut = a.CheckOut.Time
+			}
+			for i := 0; i < n; i++ {
+				night := start.AddDate(0, 0, i)
+				if night.Before(checkIn) || !night.Before(checkOut) {
+					continue
+				}
+				var notes []string
+				if night.Equal(checkIn) {
+					notes = append(notes, "Check in today")
+				}
+				if a.CheckOut.Valid && night.Equal(checkOut.AddDate(0, 0, -1)) {
+					notes = append(notes, "Check out "+checkOut.Format("Mon, Jan 2"))
+				}
+				days[i].Stays = append(days[i].Stays, toPrintStay(a, strings.Join(notes, " · ")))
+				attached = true
+			}
+		}
+		if !attached {
+			otherStays = append(otherStays, toPrintStay(a, stayDatesNote(a)))
+		}
+	}
+
+	// Undated trips can't attach weather, stays, or transport to a day, so an
+	// item-less "Day N" section would be an empty shell — drop those. Dated
+	// trips keep them (real calendar days worth showing even when unplanned).
+	if !dated {
+		filtered := days[:0]
+		for _, day := range days {
+			if len(day.Items) > 0 {
+				filtered = append(filtered, day)
+			}
+		}
+		days = filtered
+	}
+
+	return days, unscheduled, otherStays, otherSegs
+}
+
+// buildPrintBudget shapes the budget section: expenses grouped by category in
+// first-appearance order, each group led by a bold subtotal row. Returns nil
+// when there is nothing worth printing.
+func buildPrintBudget(b *store.TripBudget, expenses []store.TripExpense) *printBudget {
+	if len(expenses) == 0 && (b == nil || b.TargetAmount == nil) {
+		return nil
+	}
+	pb := &printBudget{Currency: "USD"}
+	if b != nil {
+		if c := strings.TrimSpace(b.Currency); c != "" {
+			pb.Currency = c
+		}
+		if b.TargetAmount != nil {
+			pb.Target = formatMoneyAmount(*b.TargetAmount)
+		}
+	}
+
+	type catGroup struct {
+		name     string
+		expenses []store.TripExpense
+		total    float64
+	}
+	var groups []*catGroup
+	idx := map[string]*catGroup{}
+	spent := 0.0
+	for _, e := range expenses {
+		g, ok := idx[e.Category]
+		if !ok {
+			g = &catGroup{name: e.Category}
+			idx[e.Category] = g
+			groups = append(groups, g)
+		}
+		g.expenses = append(g.expenses, e)
+		g.total += e.Amount
+		spent += e.Amount
+	}
+	for _, g := range groups {
+		pb.Rows = append(pb.Rows, printBudgetRow{Label: capitalize(g.name), Amount: formatMoneyAmount(g.total), Subtotal: true})
+		for _, e := range g.expenses {
+			pb.Rows = append(pb.Rows, printBudgetRow{Label: e.Label, Amount: formatMoneyAmount(e.Amount)})
+		}
+	}
+	pb.Spent = formatMoneyAmount(spent)
+	if b != nil && b.TargetAmount != nil {
+		pb.Remaining = formatMoneyAmount(*b.TargetAmount - spent)
+	}
+	return pb
+}
+
+func formatMoneyAmount(v float64) string {
+	return strconv.FormatFloat(v, 'f', 2, 64)
+}
+
+func toPrintSegment(s store.TripSegment) printSegment {
+	var meta []string
+	if dep := formatExportDate(dateToPtr(s.DepartDate)); dep != "" {
+		meta = append(meta, "Departs "+dep)
+	}
+	if arr := formatExportDate(dateToPtr(s.ArriveDate)); arr != "" {
+		meta = append(meta, "Arrives "+arr)
+	}
+	if p := strings.TrimSpace(strPtrVal(s.Provider)); p != "" {
+		meta = append(meta, p)
+	}
+	if pn := strings.TrimSpace(strPtrVal(s.PriceNote)); pn != "" {
+		meta = append(meta, pn)
+	}
+	rawURL := strings.TrimSpace(strPtrVal(s.Url))
+	return printSegment{
+		Route:   segmentRoute(s),
+		Mode:    capitalize(s.Mode),
+		Meta:    strings.Join(meta, " · "),
+		Notes:   strings.TrimSpace(strPtrVal(s.Notes)),
+		URL:     rawURL,
+		URLText: displayURL(rawURL),
+		Booked:  s.Booked,
+	}
+}
+
+// toPrintStay converts an accommodation; note is context-dependent (a tonight
+// note on day sections, the check-in/out range on reference lists).
+func toPrintStay(a store.Accommodation, note string) printStay {
+	var meta []string
+	if p := strings.TrimSpace(strPtrVal(a.Provider)); p != "" {
+		meta = append(meta, p)
+	}
+	if pn := strings.TrimSpace(strPtrVal(a.PriceNote)); pn != "" {
+		meta = append(meta, pn)
+	}
+	if note != "" {
+		meta = append(meta, note)
+	}
+	rawURL := strings.TrimSpace(strPtrVal(a.Url))
+	return printStay{
+		Name:    a.Name,
+		Address: strPtrVal(a.Address),
+		Meta:    strings.Join(meta, " · "),
+		URL:     rawURL,
+		URLText: displayURL(rawURL),
+		Booked:  a.Booked,
+	}
+}
+
+// stayDatesNote renders the reference-list date range for a stay.
+func stayDatesNote(a store.Accommodation) string {
+	var parts []string
+	if ci := formatExportDate(dateToPtr(a.CheckIn)); ci != "" {
+		parts = append(parts, "Check-in "+ci)
+	}
+	if co := formatExportDate(dateToPtr(a.CheckOut)); co != "" {
+		parts = append(parts, "Check-out "+co)
+	}
+	return strings.Join(parts, " · ")
+}
+
+// displayURL builds the short visible text for a booking link — paper isn't
+// clickable, so the reader needs something typable: host + path, no scheme,
+// "www." or query noise, truncated.
+func displayURL(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+	display := raw
+	if u, err := url.Parse(raw); err == nil && u.Host != "" {
+		display = strings.TrimPrefix(u.Host, "www.") + strings.TrimSuffix(u.Path, "/")
+	}
+	const maxRunes = 48
+	runes := []rune(display)
+	if len(runes) > maxRunes {
+		return string(runes[:maxRunes-1]) + "…"
+	}
+	return display
 }
 
 // groupExportItems walks items in position order and groups them by hub
 // (day_trip_from, falling back to city, then "Itinerary"), sub-grouping by day.
 // First-appearance order is preserved for both hubs and days. Per-item date is
-// trip.start_date + (day-1) when both are present.
+// trip.start_date + (day-1) when both are present. Used for the Unscheduled
+// section (and exercised by the .ics fixture tests).
 func groupExportItems(trip store.Trip, items []store.ItineraryItem) []printGroup {
 	var groups []printGroup
 	groupIdx := map[string]int{}

--- a/src/packages/api/print_view_test.go
+++ b/src/packages/api/print_view_test.go
@@ -1,0 +1,503 @@
+package main
+
+// print_view_test.go — DB-free unit tests for the day-by-day print packet
+// builders (specs/print-travel-packet). Template escaping follows the
+// share_preview_test.go pattern; weather uses the weatherStub seam from
+// trip_review_test.go.
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"travel-route-planner/store"
+)
+
+func printFixtureTrip(t *testing.T) store.Trip {
+	t.Helper()
+	return store.Trip{
+		ID:        uuid.New(),
+		Title:     "Greece",
+		StartDate: dateVal(t, "2026-08-01"),
+		EndDate:   dateVal(t, "2026-08-05"),
+	}
+}
+
+func TestPrintDayCount(t *testing.T) {
+	trip := printFixtureTrip(t)
+
+	n, dated := printDayCount(exportData{Trip: trip})
+	if n != 5 || !dated {
+		t.Fatalf("5-day trip: got n=%d dated=%v", n, dated)
+	}
+
+	// An item day beyond the range extends the count.
+	n, _ = printDayCount(exportData{Trip: trip, Items: []store.ItineraryItem{{Day: i32p(7)}}})
+	if n != 7 {
+		t.Fatalf("day-7 item should extend to 7, got %d", n)
+	}
+
+	// A runaway day number must not drag hollow sections with it — the range
+	// stays at the trip's own length (the item lands in Unscheduled).
+	n, _ = printDayCount(exportData{Trip: trip, Items: []store.ItineraryItem{{Day: i32p(5000)}}})
+	if n != 5 {
+		t.Fatalf("runaway day should not extend the range, got %d", n)
+	}
+
+	// An absurd trip date range still clamps.
+	longTrip := store.Trip{StartDate: dateVal(t, "2026-08-01"), EndDate: dateVal(t, "2027-08-01")}
+	n, _ = printDayCount(exportData{Trip: longTrip})
+	if n != maxPrintDays {
+		t.Fatalf("expected clamp to %d, got %d", maxPrintDays, n)
+	}
+
+	// Start date only ⇒ a single day.
+	n, dated = printDayCount(exportData{Trip: store.Trip{StartDate: dateVal(t, "2026-08-01")}})
+	if n != 1 || !dated {
+		t.Fatalf("start-only trip: got n=%d dated=%v", n, dated)
+	}
+
+	// Undated: day count comes from item days alone.
+	n, dated = printDayCount(exportData{Trip: store.Trip{}})
+	if n != 0 || dated {
+		t.Fatalf("undated empty trip: got n=%d dated=%v", n, dated)
+	}
+	n, dated = printDayCount(exportData{Trip: store.Trip{}, Items: []store.ItineraryItem{{Day: i32p(3)}}})
+	if n != 3 || dated {
+		t.Fatalf("undated with day-3 item: got n=%d dated=%v", n, dated)
+	}
+}
+
+func TestBuildPrintDays_StayNights(t *testing.T) {
+	d := exportData{
+		Trip: printFixtureTrip(t),
+		Accommodations: []store.Accommodation{{
+			Name:    "Hotel Grande",
+			CheckIn: dateVal(t, "2026-08-01"), CheckOut: dateVal(t, "2026-08-05"),
+		}},
+	}
+	days, _, otherStays, _ := buildPrintDays(d, nil)
+	if len(days) != 5 {
+		t.Fatalf("expected 5 day sections, got %d", len(days))
+	}
+	if len(otherStays) != 0 {
+		t.Fatalf("stay should attach to days, got otherStays=%+v", otherStays)
+	}
+	for i := 0; i < 4; i++ {
+		if len(days[i].Stays) != 1 {
+			t.Fatalf("day %d should have the stay, got %+v", i+1, days[i].Stays)
+		}
+	}
+	if len(days[4].Stays) != 0 {
+		t.Fatalf("stay must not appear on its check-out day, got %+v", days[4].Stays)
+	}
+	if !strings.Contains(days[0].Stays[0].Meta, "Check in today") {
+		t.Fatalf("first night should note check-in, got %q", days[0].Stays[0].Meta)
+	}
+	wantCheckout := "Check out " + time.Date(2026, 8, 5, 0, 0, 0, 0, time.UTC).Format("Mon, Jan 2")
+	if !strings.Contains(days[3].Stays[0].Meta, wantCheckout) {
+		t.Fatalf("last night should note %q, got %q", wantCheckout, days[3].Stays[0].Meta)
+	}
+	if strings.Contains(days[1].Stays[0].Meta, "Check") {
+		t.Fatalf("middle night should have no check note, got %q", days[1].Stays[0].Meta)
+	}
+}
+
+func TestBuildPrintDays_StayEdgeCases(t *testing.T) {
+	trip := printFixtureTrip(t)
+
+	// Single-night stay: both notes on the one night.
+	d := exportData{Trip: trip, Accommodations: []store.Accommodation{{
+		Name: "One Night Inn", CheckIn: dateVal(t, "2026-08-02"), CheckOut: dateVal(t, "2026-08-03"),
+	}}}
+	days, _, _, _ := buildPrintDays(d, nil)
+	if len(days[1].Stays) != 1 || len(days[0].Stays) != 0 || len(days[2].Stays) != 0 {
+		t.Fatalf("single-night stay placement wrong: %+v", days)
+	}
+	meta := days[1].Stays[0].Meta
+	if !strings.Contains(meta, "Check in today") || !strings.Contains(meta, "Check out") {
+		t.Fatalf("single-night stay should carry both notes, got %q", meta)
+	}
+
+	// Check-in only ⇒ that night only.
+	d = exportData{Trip: trip, Accommodations: []store.Accommodation{{
+		Name: "Open Ended", CheckIn: dateVal(t, "2026-08-03"),
+	}}}
+	days, _, otherStays, _ := buildPrintDays(d, nil)
+	if len(days[2].Stays) != 1 || len(otherStays) != 0 {
+		t.Fatalf("check-in-only stay should land on its night: days=%+v other=%+v", days, otherStays)
+	}
+
+	// Entirely outside the trip range ⇒ reference list, with its date range.
+	d = exportData{Trip: trip, Accommodations: []store.Accommodation{{
+		Name: "Elsewhere", CheckIn: dateVal(t, "2026-09-01"), CheckOut: dateVal(t, "2026-09-03"),
+	}}}
+	days, _, otherStays, _ = buildPrintDays(d, nil)
+	for i, day := range days {
+		if len(day.Stays) != 0 {
+			t.Fatalf("out-of-range stay leaked onto day %d", i+1)
+		}
+	}
+	if len(otherStays) != 1 || !strings.Contains(otherStays[0].Meta, "Check-in") {
+		t.Fatalf("out-of-range stay should be a reference entry, got %+v", otherStays)
+	}
+
+	// No dates at all ⇒ reference list.
+	d = exportData{Trip: trip, Accommodations: []store.Accommodation{{Name: "Dateless"}}}
+	_, _, otherStays, _ = buildPrintDays(d, nil)
+	if len(otherStays) != 1 {
+		t.Fatalf("dateless stay should be a reference entry, got %+v", otherStays)
+	}
+}
+
+func TestBuildPrintDays_Segments(t *testing.T) {
+	d := exportData{
+		Trip: printFixtureTrip(t),
+		Segments: []store.TripSegment{
+			// Departs day 2, arrives day 3 ⇒ single entry on day 2.
+			{Mode: "train", Origin: strp("Athens"), Destination: strp("Nafplio"),
+				DepartDate: dateVal(t, "2026-08-02"), ArriveDate: dateVal(t, "2026-08-03"),
+				Provider: strp("Hellenic Train"), PriceNote: strp("€25"), Booked: true},
+			// Arrive-only ⇒ attaches to the arrival day.
+			{Mode: "flight", Origin: strp("JFK"), Destination: strp("ATH"),
+				ArriveDate: dateVal(t, "2026-08-01")},
+			// No dates ⇒ reference list.
+			{Mode: "ferry", Origin: strp("Piraeus"), Destination: strp("Hydra")},
+			// Departs before the trip, arrives day 1 ⇒ arrival-day fallback.
+			{Mode: "bus", Origin: strp("Sofia"), Destination: strp("Athens"),
+				DepartDate: dateVal(t, "2026-07-31"), ArriveDate: dateVal(t, "2026-08-01")},
+		},
+	}
+	days, _, _, otherSegs := buildPrintDays(d, nil)
+
+	if len(days[1].Segments) != 1 {
+		t.Fatalf("train should attach to day 2, got %+v", days[1].Segments)
+	}
+	seg := days[1].Segments[0]
+	if !seg.Booked || !strings.Contains(seg.Meta, "Arrives") ||
+		!strings.Contains(seg.Meta, "Hellenic Train") || !strings.Contains(seg.Meta, "€25") {
+		t.Fatalf("train meta incomplete: %+v", seg)
+	}
+	if len(days[2].Segments) != 0 {
+		t.Fatalf("train must not duplicate onto its arrival day")
+	}
+	if len(days[0].Segments) != 2 {
+		t.Fatalf("day 1 should have the arrive-only flight and the fallback bus, got %+v", days[0].Segments)
+	}
+	if len(otherSegs) != 1 || otherSegs[0].Mode != "Ferry" {
+		t.Fatalf("dateless ferry should be a reference entry, got %+v", otherSegs)
+	}
+}
+
+func TestBuildPrintDays_ItemsAndDayTrips(t *testing.T) {
+	d := exportData{
+		Trip: printFixtureTrip(t),
+		Items: []store.ItineraryItem{
+			{Name: "Acropolis", City: strp("Athens"), Day: i32p(1), TimeOfDay: strp("morning")},
+			// Day 2 is entirely a day trip: Delphi from Athens.
+			{Name: "Temple of Apollo", City: strp("Delphi"), DayTripFrom: strp("Athens"), Day: i32p(2)},
+			{Name: "Delphi Museum", City: strp("Delphi"), DayTripFrom: strp("Athens"), Day: i32p(2)},
+			// Day 4 mixes a day-trip item with a local one ⇒ no day-trip label.
+			{Name: "Cape Sounion", City: strp("Sounion"), DayTripFrom: strp("Athens"), Day: i32p(4)},
+			{Name: "Plaka dinner", City: strp("Athens"), Day: i32p(4)},
+			// No day ⇒ Unscheduled.
+			{Name: "Someday Taverna", City: strp("Athens")},
+			// Beyond the clamp ⇒ Unscheduled.
+			{Name: "Runaway", City: strp("Athens"), Day: i32p(5000)},
+		},
+	}
+	days, unscheduled, _, _ := buildPrintDays(d, nil)
+
+	if len(days) != 5 {
+		t.Fatalf("expected 5 days, got %d", len(days))
+	}
+	if days[0].Hub != "Athens" || days[0].DayTrip != "" {
+		t.Fatalf("day 1 header wrong: %+v", days[0])
+	}
+	if days[1].Hub != "Delphi" || days[1].DayTrip != "Day trip from Athens" {
+		t.Fatalf("day-trip day header wrong: hub=%q daytrip=%q", days[1].Hub, days[1].DayTrip)
+	}
+	// Items on a day-trip day share the hub, so no per-item city repeats.
+	if days[1].Items[0].City != "" {
+		t.Fatalf("day-trip item should not repeat the hub city, got %q", days[1].Items[0].City)
+	}
+	if days[3].DayTrip != "" {
+		t.Fatalf("mixed day must not get a day-trip label, got %q", days[3].DayTrip)
+	}
+	// Mixed day: hub comes from the first item's city; the item in a
+	// different city carries its own city label.
+	if days[3].Hub != "Sounion" {
+		t.Fatalf("mixed-day hub should come from the first item, got %q", days[3].Hub)
+	}
+	var plaka *printItem
+	for i := range days[3].Items {
+		if days[3].Items[i].Name == "Plaka dinner" {
+			plaka = &days[3].Items[i]
+		}
+	}
+	if plaka == nil || plaka.City != "Athens" {
+		t.Fatalf("off-hub item should carry its city, got %+v", plaka)
+	}
+	// Day 3 has no items but still renders (weather/stay/transport slot).
+	if len(days[2].Items) != 0 {
+		t.Fatalf("day 3 should be empty, got %+v", days[2].Items)
+	}
+	// Gap day inherits the previous day's city.
+	if days[2].Hub != "Delphi" && days[2].Hub != "Athens" {
+		t.Fatalf("gap day should inherit a known city, got %q", days[2].Hub)
+	}
+	if len(unscheduled) != 2 {
+		t.Fatalf("expected 2 unscheduled items (no-day + clamped), got %+v", unscheduled)
+	}
+}
+
+func TestBuildPrintDays_UndatedTrip(t *testing.T) {
+	d := exportData{
+		Trip: store.Trip{Title: "Sometime"},
+		Items: []store.ItineraryItem{
+			{Name: "Louvre", City: strp("Paris"), Day: i32p(1)},
+			{Name: "Orsay", City: strp("Paris"), Day: i32p(3)},
+		},
+		Accommodations: []store.Accommodation{{Name: "Hôtel", CheckIn: dateVal(t, "2026-08-01")}},
+		Segments:       []store.TripSegment{{Mode: "train", DepartDate: dateVal(t, "2026-08-01")}},
+	}
+	days, unscheduled, otherStays, otherSegs := buildPrintDays(d, nil)
+
+	// Item-less relative days are dropped; the rest have no calendar date.
+	if len(days) != 2 || days[0].Label != "Day 1" || days[1].Label != "Day 3" {
+		t.Fatalf("undated days wrong: %+v", days)
+	}
+	for _, day := range days {
+		if day.Date != "" || len(day.Stays) != 0 || len(day.Segments) != 0 {
+			t.Fatalf("undated day must have no date/stays/segments: %+v", day)
+		}
+	}
+	if len(unscheduled) != 0 {
+		t.Fatalf("unexpected unscheduled items: %+v", unscheduled)
+	}
+	// Stays and transport fall back to the flat reference lists.
+	if len(otherStays) != 1 || len(otherSegs) != 1 {
+		t.Fatalf("undated trip should list stays/segments flat, got %+v / %+v", otherStays, otherSegs)
+	}
+}
+
+func TestBuildPrintBudget(t *testing.T) {
+	if pb := buildPrintBudget(nil, nil); pb != nil {
+		t.Fatalf("no budget, no expenses ⇒ nil, got %+v", pb)
+	}
+	// A budget row without a target and no expenses is nothing worth printing.
+	if pb := buildPrintBudget(&store.TripBudget{Currency: "EUR"}, nil); pb != nil {
+		t.Fatalf("target-less budget with no expenses ⇒ nil, got %+v", pb)
+	}
+
+	target := 2000.0
+	b := &store.TripBudget{TargetAmount: &target, Currency: "EUR"}
+	expenses := []store.TripExpense{
+		{Category: "lodging", Label: "Hotel Grande", Amount: 600},
+		{Category: "food", Label: "Tavernas", Amount: 250.5},
+		{Category: "lodging", Label: "Airbnb Delphi", Amount: 150},
+	}
+	pb := buildPrintBudget(b, expenses)
+	if pb == nil {
+		t.Fatal("expected a budget")
+	}
+	if pb.Currency != "EUR" || pb.Target != "2000.00" || pb.Spent != "1000.50" || pb.Remaining != "999.50" {
+		t.Fatalf("budget math wrong: %+v", pb)
+	}
+	// Rows: lodging subtotal, its 2 expenses, food subtotal, its expense —
+	// grouped in first-appearance order.
+	wantRows := []printBudgetRow{
+		{Label: "Lodging", Amount: "750.00", Subtotal: true},
+		{Label: "Hotel Grande", Amount: "600.00"},
+		{Label: "Airbnb Delphi", Amount: "150.00"},
+		{Label: "Food", Amount: "250.50", Subtotal: true},
+		{Label: "Tavernas", Amount: "250.50"},
+	}
+	if len(pb.Rows) != len(wantRows) {
+		t.Fatalf("rows = %+v", pb.Rows)
+	}
+	for i, want := range wantRows {
+		if pb.Rows[i] != want {
+			t.Fatalf("row %d = %+v, want %+v", i, pb.Rows[i], want)
+		}
+	}
+
+	// Expenses without a budget row: USD default, no target/remaining.
+	pb = buildPrintBudget(nil, expenses[:1])
+	if pb == nil || pb.Currency != "USD" || pb.Target != "" || pb.Remaining != "" || pb.Spent != "600.00" {
+		t.Fatalf("expenses-only budget wrong: %+v", pb)
+	}
+}
+
+func TestDisplayURL(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"", ""},
+		{"https://www.booking.com/hotel/gr/grande.html?aid=123&label=x", "booking.com/hotel/gr/grande.html"},
+		{"http://example.com/", "example.com"},
+		{"not a url", "not a url"},
+	}
+	for _, c := range cases {
+		if got := displayURL(c.in); got != c.want {
+			t.Fatalf("displayURL(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+	long := "https://example.com/" + strings.Repeat("very-long-path/", 10)
+	got := displayURL(long)
+	if len([]rune(got)) > 48 || !strings.HasSuffix(got, "…") {
+		t.Fatalf("long URL should truncate with ellipsis, got %q (%d runes)", got, len([]rune(got)))
+	}
+}
+
+func TestFormatWeatherLine(t *testing.T) {
+	pct := 20
+	if got := formatWeatherLine(WeatherDay{TempMinC: 15.4, TempMaxC: 24.6, PrecipPct: &pct}, false); got != "15–25°C, 20% chance of rain" {
+		t.Fatalf("forecast line = %q", got)
+	}
+	if got := formatWeatherLine(WeatherDay{TempMinC: 18, TempMaxC: 27, PrecipMM: 6}, true); got != "Typical: 18–27°C, 6mm rain" {
+		t.Fatalf("historical line = %q", got)
+	}
+	if got := formatWeatherLine(WeatherDay{TempMinC: 18, TempMaxC: 27, PrecipMM: 0.2}, false); got != "18–27°C" {
+		t.Fatalf("dry line = %q", got)
+	}
+}
+
+func TestLoadPrintWeather_ForecastAndHistorical(t *testing.T) {
+	ws := weatherStub(t, true, 22, 14)
+
+	// Near-future trip ⇒ forecast path with rain probability.
+	start := time.Now().UTC().AddDate(0, 0, 3).Truncate(24 * time.Hour)
+	trip := store.Trip{
+		StartDate: pgtype.Date{Time: start, Valid: true},
+		EndDate:   pgtype.Date{Time: start.AddDate(0, 0, 1), Valid: true},
+	}
+	d := exportData{Trip: trip, Items: []store.ItineraryItem{{Name: "Eiffel", City: strp("Paris"), Day: i32p(1)}}}
+	lines := loadPrintWeather(context.Background(), ws, d, 2)
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 lines, got %+v", lines)
+	}
+	for i, line := range lines {
+		if !strings.Contains(line, "°C") || !strings.Contains(line, "chance of rain") {
+			t.Fatalf("forecast line %d = %q", i, line)
+		}
+	}
+
+	// Far-future trip ⇒ archive path, "Typical:" prefix (stub echoes last
+	// year's dates; MM-DD matching aligns them with the trip days).
+	farStart := time.Now().UTC().AddDate(0, 0, 60).Truncate(24 * time.Hour)
+	d.Trip.StartDate = pgtype.Date{Time: farStart, Valid: true}
+	d.Trip.EndDate = pgtype.Date{Time: farStart.AddDate(0, 0, 1), Valid: true}
+	lines = loadPrintWeather(context.Background(), ws, d, 2)
+	if len(lines) != 2 || !strings.HasPrefix(lines[0], "Typical: ") {
+		t.Fatalf("historical lines = %+v", lines)
+	}
+}
+
+func TestLoadPrintWeather_Resilient(t *testing.T) {
+	// Dead upstream ⇒ empty lines, no error, no panic.
+	ws := NewWeatherService()
+	ws.GeocodeBaseURL = "http://127.0.0.1:1"
+	ws.ForecastBaseURL = "http://127.0.0.1:1"
+	ws.ArchiveBaseURL = "http://127.0.0.1:1"
+
+	d := exportData{
+		Trip:  printFixtureTrip(t),
+		Items: []store.ItineraryItem{{Name: "Acropolis", City: strp("Athens"), Day: i32p(1)}},
+	}
+	lines := loadPrintWeather(context.Background(), ws, d, 5)
+	if len(lines) != 5 {
+		t.Fatalf("expected 5 slots, got %+v", lines)
+	}
+	for i, line := range lines {
+		if line != "" {
+			t.Fatalf("line %d should be empty on failure, got %q", i, line)
+		}
+	}
+
+	// Undated / nil-service guards.
+	if got := loadPrintWeather(context.Background(), nil, d, 5); got != nil {
+		t.Fatalf("nil service should return nil, got %+v", got)
+	}
+	if got := loadPrintWeather(context.Background(), ws, exportData{Trip: store.Trip{}}, 5); got != nil {
+		t.Fatalf("undated trip should return nil, got %+v", got)
+	}
+}
+
+func TestBuildPrintView_HasContent(t *testing.T) {
+	// A dated but empty trip renders the empty state, not 5 hollow days.
+	view := buildPrintView(exportData{Trip: printFixtureTrip(t)}, nil, nil)
+	if view.HasContent || len(view.Days) != 0 {
+		t.Fatalf("empty trip should have no content, got %+v", view)
+	}
+	// A budget alone counts as content.
+	target := 100.0
+	view = buildPrintView(exportData{Trip: printFixtureTrip(t)},
+		buildPrintBudget(&store.TripBudget{TargetAmount: &target, Currency: "USD"}, nil), nil)
+	if !view.HasContent || view.Budget == nil {
+		t.Fatalf("budget-only trip should have content, got %+v", view)
+	}
+}
+
+func TestPrintViewTemplate_Escapes(t *testing.T) {
+	evil := `<script>alert(1)</script>`
+	view := printViewData{
+		Title:   evil,
+		Summary: evil,
+		Days: []printDaySection{{
+			Label: "Day 1", Hub: evil, Weather: evil,
+			Items:    []printItem{{Name: evil, Address: evil, RecommendedBy: evil}},
+			Stays:    []printStay{{Name: evil, Meta: evil, URL: "javascript:alert(1)", URLText: evil}},
+			Segments: []printSegment{{Route: evil, Mode: evil, Meta: evil, Notes: evil}},
+		}},
+		Budget:     &printBudget{Currency: evil, Spent: evil, Rows: []printBudgetRow{{Label: evil, Amount: evil}}},
+		HasContent: true,
+	}
+	var buf bytes.Buffer
+	if err := printViewTmpl.Execute(&buf, view); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	html := buf.String()
+	if strings.Contains(html, "<script>alert") {
+		t.Fatal("unescaped script tag leaked into print view")
+	}
+	if !strings.Contains(html, "&lt;script&gt;") {
+		t.Fatal("expected escaped script tag in output")
+	}
+	// html/template neutralizes unsafe URL schemes in href.
+	if strings.Contains(html, `href="javascript:`) {
+		t.Fatal("unsafe URL scheme survived in href")
+	}
+}
+
+func TestPrintViewTemplate_DaySections(t *testing.T) {
+	view := printViewData{
+		Title: "Greece",
+		Days: []printDaySection{
+			{Label: "Day 1", Date: "Sat, Aug 1", Hub: "Athens", Weather: "18–27°C",
+				Items: []printItem{{Name: "Acropolis", TimeOfDay: "Morning"}},
+				Stays: []printStay{{Name: "Hotel Grande", Meta: "Check in today"}}},
+			{Label: "Day 2", Date: "Sun, Aug 2", Hub: "Delphi", DayTrip: "Day trip from Athens"},
+		},
+		HasContent: true,
+	}
+	var buf bytes.Buffer
+	if err := printViewTmpl.Execute(&buf, view); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	html := buf.String()
+	for _, want := range []string{
+		"Day 1 · Sat, Aug 1 — Athens",
+		"Weather: 18–27°C",
+		"Tonight: Hotel Grande",
+		"Day trip from Athens",
+		"No plans yet for this day.",
+	} {
+		if !strings.Contains(html, want) {
+			t.Fatalf("print view missing %q", want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Rebuilds the token-gated print export (`GET /export/{token}/print.html`) as a day-by-day travel packet (specs/print-travel-packet): one section per calendar day with weather line, transport, activities, and a "Tonight" stay block with check-in/check-out notes, plus a "Day trip from <hub>" subline for day-trip days.
- Adds the previously missing content: trip summary lead paragraph, Budget section (target, per-category subtotals, total spent, remaining), and booking details on stays/transport — provider, price note, booked badge, and a short visible URL text (host+path, readable on paper).
- Unscheduled items keep the old hub grouping in an "Unscheduled" section; dateless stays/transport fall back to reference lists (also the whole-page fallback for undated trips).
- Budget and weather load best-effort in the print handler only (6s budget, ≤5 cities, silent omission on failure); `loadExportData`, the `.ics` export, the review engine, and plan tools are byte-untouched.
- A 60-day clamp guards the new 1..N day loop against runaway item day numbers; print CSS gains `break-inside: avoid` on day sections/rows and `@page` margins.
- No Flutter changes — the existing "Print / Save as PDF" menu flow opens the same URL.

## Testing
- `gofmt` / `go vet` clean.
- New unit tests (`print_view_test.go`): day-count clamp, stay-night matching incl. never-on-checkout-day, arrive-only/out-of-range/dateless segment placement, day-trip labeling, undated-trip fallback, budget math, URL shortening, weather formatting, template escaping (incl. `javascript:` href neutralization), dead-weather-server resilience.
- New integration tests: full packet render (summary, all day headers, weather, booked segment with URL text, Tonight on exactly 4 of 5 nights, "No plans yet", Unscheduled, budget totals) and a weather-outage test proving the page still renders.
- Full suite green against the local test DB, including untouched `TestExportCalendar_*` (proves the shared exportData contract held).
- Manual: rendered the packet HTML and screenshotted via headless Chrome to verify the layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)