### PR TITLE
feat: per-event Add to calendar (Google + Apple) for stays, transport, and itinerary items

### DIFF
--- a/src/packages/api/calendar_event_handler.go
+++ b/src/packages/api/calendar_event_handler.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/gorilla/mux"
+)
+
+// calendar_event_handler.go — GET /api/v1/export/{token}/event/{kind}/{id}.ics,
+// one trip event as a single-VEVENT iCalendar file so it can be added to Apple
+// (or any other) calendar individually. Token-gated and PUBLIC like the
+// whole-trip calendar.ics; kind ∈ stay|segment|item. UIDs match the whole-trip
+// export so re-adding after a full-trip import dedupes in the user's calendar.
+
+// calendarEventHandler streams a single trip event's .ics attachment.
+func calendarEventHandler(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	notFound := func() {
+		// Match the whole-trip route: opaque 404, no leak — bad token, bad id,
+		// unknown kind, and undated event are all indistinguishable.
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		w.WriteHeader(http.StatusNotFound)
+		w.Write([]byte("export link not available"))
+	}
+	data, ok := resolveExport(r, vars["token"])
+	if !ok {
+		notFound()
+		return
+	}
+	id, err := uuid.Parse(vars["id"])
+	if err != nil {
+		notFound()
+		return
+	}
+	body, filename, ok := buildSingleEventICS(data, vars["kind"], id)
+	if !ok {
+		notFound()
+		return
+	}
+	w.Header().Set("Content-Type", "text/calendar; charset=utf-8")
+	w.Header().Set("Content-Disposition", `attachment; filename="`+filename+`.ics"`)
+	w.Write([]byte(body))
+}
+
+// buildSingleEventICS finds the event by kind+id in the export snapshot and
+// renders a one-VEVENT VCALENDAR. ok=false for an unknown kind, a missing id,
+// or an undated event — callers answer one opaque 404 for all of them.
+func buildSingleEventICS(d exportData, kind string, id uuid.UUID) (body, filename string, ok bool) {
+	var (
+		uid, summary, location, description string
+		start, end                          time.Time
+	)
+	switch kind {
+	case "stay":
+		for _, a := range d.Accommodations {
+			if a.ID == id {
+				start, end, summary, location, ok = stayEventFields(a)
+				uid = "acc-" + a.ID.String()
+				break
+			}
+		}
+	case "segment":
+		for _, s := range d.Segments {
+			if s.ID == id {
+				start, end, summary, description, ok = segmentEventFields(s)
+				uid = "seg-" + s.ID.String()
+				break
+			}
+		}
+	case "item":
+		for _, it := range d.Items {
+			if it.ID == id {
+				start, end, summary, location, description, ok = itemEventFields(d.Trip, it)
+				uid = "item-" + it.ID.String()
+				break
+			}
+		}
+	}
+	if !ok {
+		return "", "", false
+	}
+
+	var b icsBuilder
+	b.line("BEGIN:VCALENDAR")
+	b.line("VERSION:2.0")
+	b.line("PRODID:-//Golden Tempo Travel//Trip Export//EN")
+	b.line("CALSCALE:GREGORIAN")
+	b.line("METHOD:PUBLISH")
+	stamp := time.Now().UTC().Format("20060102T150405Z")
+	b.event(stamp, uid, start, end, summary, location, description)
+	b.line("END:VCALENDAR")
+	return b.String(), tripSlug(summary), true
+}

--- a/src/packages/api/calendar_event_test.go
+++ b/src/packages/api/calendar_event_test.go
@@ -1,0 +1,178 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"travel-route-planner/store"
+)
+
+// Unit tests for buildSingleEventICS — pure, no DB: the export snapshot is
+// constructed as literals.
+
+func singleEventFixture(t *testing.T) exportData {
+	t.Helper()
+	day := int32(3)
+	tod := "morning"
+	rec := "Maria"
+	return exportData{
+		Trip: store.Trip{
+			ID:        uuid.New(),
+			Title:     "Greek Islands",
+			StartDate: pgDate(t, "2026-08-01"),
+		},
+		Items: []store.ItineraryItem{{
+			ID:              uuid.New(),
+			Name:            "Acropolis, ruins",
+			Address:         strp("Athens 105 58"),
+			Day:             &day,
+			TimeOfDay:       &tod,
+			LocalSourceName: &rec,
+		}},
+		Accommodations: []store.Accommodation{{
+			ID:       uuid.New(),
+			Name:     "Hotel Grande Bretagne",
+			Address:  strp("Syntagma Square"),
+			CheckIn:  pgDate(t, "2026-08-01"),
+			CheckOut: pgDate(t, "2026-08-05"),
+		}},
+		Segments: []store.TripSegment{{
+			ID:          uuid.New(),
+			Mode:        "flight",
+			Origin:      strp("JFK"),
+			Destination: strp("ATH"),
+			DepartDate:  pgDate(t, "2026-08-01"),
+			ArriveDate:  pgDate(t, "2026-08-02"),
+		}},
+	}
+}
+
+func TestBuildSingleEventICS_Stay(t *testing.T) {
+	d := singleEventFixture(t)
+	body, filename, ok := buildSingleEventICS(d, "stay", d.Accommodations[0].ID)
+	if !ok {
+		t.Fatal("stay should render")
+	}
+	if filename != "stay-hotel-grande-bretagne" {
+		t.Fatalf("filename: %q", filename)
+	}
+	if n := strings.Count(body, "BEGIN:VEVENT"); n != 1 {
+		t.Fatalf("expected exactly 1 VEVENT, got %d\n%s", n, body)
+	}
+	for _, want := range []string{
+		"BEGIN:VCALENDAR",
+		"UID:acc-" + d.Accommodations[0].ID.String() + "@goldentempo",
+		"DTSTART;VALUE=DATE:20260801",
+		"DTEND;VALUE=DATE:20260805", // check-out day, end-exclusive
+		"SUMMARY:Stay: Hotel Grande Bretagne",
+		"LOCATION:Syntagma Square",
+		"END:VCALENDAR",
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("missing %q in:\n%s", want, body)
+		}
+	}
+}
+
+func TestBuildSingleEventICS_StayWithoutCheckoutIsOneNight(t *testing.T) {
+	d := singleEventFixture(t)
+	d.Accommodations[0].CheckOut = pgtype.Date{}
+	body, _, ok := buildSingleEventICS(d, "stay", d.Accommodations[0].ID)
+	if !ok {
+		t.Fatal("stay without checkout should still render")
+	}
+	if !strings.Contains(body, "DTEND;VALUE=DATE:20260802") {
+		t.Fatalf("expected one-night DTEND 20260802 in:\n%s", body)
+	}
+}
+
+func TestBuildSingleEventICS_Segment(t *testing.T) {
+	d := singleEventFixture(t)
+	body, filename, ok := buildSingleEventICS(d, "segment", d.Segments[0].ID)
+	if !ok {
+		t.Fatal("segment should render")
+	}
+	if filename != "flight-jfk-ath" {
+		t.Fatalf("filename: %q", filename)
+	}
+	for _, want := range []string{
+		"UID:seg-" + d.Segments[0].ID.String() + "@goldentempo",
+		"SUMMARY:Flight: JFK → ATH",
+		"DTSTART;VALUE=DATE:20260801",
+		"DTEND;VALUE=DATE:20260803", // arrival day + 1, end-exclusive
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("missing %q in:\n%s", want, body)
+		}
+	}
+}
+
+func TestBuildSingleEventICS_SegmentSameDayArrival(t *testing.T) {
+	d := singleEventFixture(t)
+	d.Segments[0].ArriveDate = d.Segments[0].DepartDate
+	body, _, ok := buildSingleEventICS(d, "segment", d.Segments[0].ID)
+	if !ok {
+		t.Fatal("same-day segment should render")
+	}
+	if !strings.Contains(body, "DTEND;VALUE=DATE:20260802") {
+		t.Fatalf("expected single-day DTEND 20260802 in:\n%s", body)
+	}
+}
+
+func TestBuildSingleEventICS_Item(t *testing.T) {
+	d := singleEventFixture(t)
+	body, _, ok := buildSingleEventICS(d, "item", d.Items[0].ID)
+	if !ok {
+		t.Fatal("item should render")
+	}
+	for _, want := range []string{
+		"UID:item-" + d.Items[0].ID.String() + "@goldentempo",
+		"DTSTART;VALUE=DATE:20260803", // trip start + (day 3 − 1)
+		"DTEND;VALUE=DATE:20260804",
+		`SUMMARY:Acropolis\, ruins`, // RFC 5545 comma escaping
+		"DESCRIPTION:Morning · Recommended by Maria",
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("missing %q in:\n%s", want, body)
+		}
+	}
+}
+
+func TestBuildSingleEventICS_NotFoundCases(t *testing.T) {
+	d := singleEventFixture(t)
+
+	undatedStay := singleEventFixture(t)
+	undatedStay.Accommodations[0].CheckIn = pgtype.Date{}
+
+	undatedSegment := singleEventFixture(t)
+	undatedSegment.Segments[0].DepartDate = pgtype.Date{}
+
+	daylessItem := singleEventFixture(t)
+	daylessItem.Items[0].Day = nil
+
+	startlessTrip := singleEventFixture(t)
+	startlessTrip.Trip.StartDate = pgtype.Date{}
+
+	cases := []struct {
+		name string
+		d    exportData
+		kind string
+		id   uuid.UUID
+	}{
+		{"unknown kind", d, "hovercraft", d.Accommodations[0].ID},
+		{"unknown id", d, "stay", uuid.New()},
+		{"wrong-kind id", d, "segment", d.Accommodations[0].ID},
+		{"undated stay", undatedStay, "stay", undatedStay.Accommodations[0].ID},
+		{"undated segment", undatedSegment, "segment", undatedSegment.Segments[0].ID},
+		{"dayless item", daylessItem, "item", daylessItem.Items[0].ID},
+		{"trip without start date", startlessTrip, "item", startlessTrip.Items[0].ID},
+	}
+	for _, tc := range cases {
+		if _, _, ok := buildSingleEventICS(tc.d, tc.kind, tc.id); ok {
+			t.Fatalf("%s: expected ok=false", tc.name)
+		}
+	}
+}

--- a/src/packages/api/calendar_handler.go
+++ b/src/packages/api/calendar_handler.go
@@ -49,40 +49,29 @@ func buildICS(d exportData) string {
 	events := 0
 
 	for _, it := range d.Items {
-		start, ok := itemStartDate(d.Trip, it)
+		start, end, summary, location, description, ok := itemEventFields(d.Trip, it)
 		if !ok {
 			continue // no trip start_date or no day → not datable
 		}
-		desc := icsItemDescription(it)
-		b.event(stamp, "item-"+it.ID.String(), start, start.AddDate(0, 0, 1),
-			it.Name, strPtrVal(it.Address), desc)
+		b.event(stamp, "item-"+it.ID.String(), start, end, summary, location, description)
 		events++
 	}
 
 	for _, a := range d.Accommodations {
-		if !a.CheckIn.Valid {
+		start, end, summary, location, ok := stayEventFields(a)
+		if !ok {
 			continue
 		}
-		end := a.CheckIn.Time.AddDate(0, 0, 1)
-		if a.CheckOut.Valid && a.CheckOut.Time.After(a.CheckIn.Time) {
-			end = a.CheckOut.Time
-		}
-		b.event(stamp, "acc-"+a.ID.String(), a.CheckIn.Time, end,
-			"Stay: "+a.Name, strPtrVal(a.Address), "")
+		b.event(stamp, "acc-"+a.ID.String(), start, end, summary, location, "")
 		events++
 	}
 
 	for _, s := range d.Segments {
-		if !s.DepartDate.Valid {
+		start, end, summary, description, ok := segmentEventFields(s)
+		if !ok {
 			continue
 		}
-		end := s.DepartDate.Time.AddDate(0, 0, 1)
-		if s.ArriveDate.Valid && s.ArriveDate.Time.After(s.DepartDate.Time) {
-			end = s.ArriveDate.Time.AddDate(0, 0, 1)
-		}
-		summary := capitalize(s.Mode) + ": " + segmentRoute(s)
-		b.event(stamp, "seg-"+s.ID.String(), s.DepartDate.Time, end,
-			summary, "", strPtrVal(s.Notes))
+		b.event(stamp, "seg-"+s.ID.String(), start, end, summary, "", description)
 		events++
 	}
 
@@ -98,6 +87,48 @@ func buildICS(d exportData) string {
 
 	b.line("END:VCALENDAR")
 	return b.String()
+}
+
+// The three per-kind field resolvers below are shared by the whole-trip
+// calendar and the single-event endpoint (calendar_event_handler.go) so both
+// render identical all-day VEVENTs. All ends are exclusive; ok=false means the
+// event is undated and gets no VEVENT.
+
+// stayEventFields resolves an accommodation's VEVENT fields: check-in through
+// check-out (or one night when check-out is missing/not after check-in).
+func stayEventFields(a store.Accommodation) (start, end time.Time, summary, location string, ok bool) {
+	if !a.CheckIn.Valid {
+		return time.Time{}, time.Time{}, "", "", false
+	}
+	end = a.CheckIn.Time.AddDate(0, 0, 1)
+	if a.CheckOut.Valid && a.CheckOut.Time.After(a.CheckIn.Time) {
+		end = a.CheckOut.Time
+	}
+	return a.CheckIn.Time, end, "Stay: " + a.Name, strPtrVal(a.Address), true
+}
+
+// segmentEventFields resolves a transport segment's VEVENT fields: departure
+// day through arrival day inclusive (single day when arrival is missing).
+func segmentEventFields(s store.TripSegment) (start, end time.Time, summary, description string, ok bool) {
+	if !s.DepartDate.Valid {
+		return time.Time{}, time.Time{}, "", "", false
+	}
+	end = s.DepartDate.Time.AddDate(0, 0, 1)
+	if s.ArriveDate.Valid && s.ArriveDate.Time.After(s.DepartDate.Time) {
+		end = s.ArriveDate.Time.AddDate(0, 0, 1)
+	}
+	summary = capitalize(s.Mode) + ": " + segmentRoute(s)
+	return s.DepartDate.Time, end, summary, strPtrVal(s.Notes), true
+}
+
+// itemEventFields resolves an itinerary item's VEVENT fields: the single trip
+// day the item is assigned to.
+func itemEventFields(trip store.Trip, it store.ItineraryItem) (start, end time.Time, summary, location, description string, ok bool) {
+	start, ok = itemStartDate(trip, it)
+	if !ok {
+		return time.Time{}, time.Time{}, "", "", "", false
+	}
+	return start, start.AddDate(0, 0, 1), it.Name, strPtrVal(it.Address), icsItemDescription(it), true
 }
 
 // itemStartDate resolves an item's all-day start: trip.start_date + (day-1).

--- a/src/packages/api/export_integration_test.go
+++ b/src/packages/api/export_integration_test.go
@@ -355,3 +355,50 @@ func TestExportCalendar_InvalidTokenIs404(t *testing.T) {
 		t.Fatalf("invalid calendar token: got %d want 404", rec.Code)
 	}
 }
+
+func TestExportEventCalendar_SingleEventAndOpaque404s(t *testing.T) {
+	resetDB(t)
+	owner, _ := createTestUser(t, "one-event@example.com")
+	trip := exportFixtureTrip(t, owner.ID, "Greek Islands")
+	token, _ := newExportToken(trip.ID)
+
+	stays, err := store.New(dbPool).ListAccommodationsByTrip(context.Background(), trip.ID)
+	if err != nil || len(stays) != 1 {
+		t.Fatalf("fixture stays: %v (%d)", err, len(stays))
+	}
+	stayID := stays[0].ID.String()
+
+	rec := doJSON(t, "GET", "/api/v1/export/"+token+"/event/stay/"+stayID+".ics", "", nil)
+	if rec.Code != 200 {
+		t.Fatalf("event stay.ics: got %d want 200 (%s)", rec.Code, rec.Body.String())
+	}
+	if ct := rec.Header().Get("Content-Type"); !strings.HasPrefix(ct, "text/calendar") {
+		t.Fatalf("event content-type: %q", ct)
+	}
+	if cd := rec.Header().Get("Content-Disposition"); !strings.Contains(cd, `attachment; filename="stay-hotel-grande-bretagne.ics"`) {
+		t.Fatalf("event content-disposition: %q", cd)
+	}
+	body := rec.Body.String()
+	if n := strings.Count(body, "BEGIN:VEVENT"); n != 1 {
+		t.Fatalf("expected exactly 1 VEVENT, got %d\n%s", n, body)
+	}
+	if !strings.Contains(body, "UID:acc-"+stayID+"@goldentempo") {
+		t.Fatalf("event UID missing; body:\n%s", body)
+	}
+
+	// All failure shapes are one opaque 404, indistinguishable from a bad token.
+	for name, path := range map[string]string{
+		"bad token":    "/api/v1/export/bogus.token/event/stay/" + stayID + ".ics",
+		"bogus uuid":   "/api/v1/export/" + token + "/event/stay/not-a-uuid.ics",
+		"unknown id":   "/api/v1/export/" + token + "/event/stay/" + uuid.NewString() + ".ics",
+		"unknown kind": "/api/v1/export/" + token + "/event/hovercraft/" + stayID + ".ics",
+	} {
+		rec := doJSON(t, "GET", path, "", nil)
+		if rec.Code != 404 {
+			t.Fatalf("%s: got %d want 404", name, rec.Code)
+		}
+		if got := rec.Body.String(); got != "export link not available" {
+			t.Fatalf("%s: body %q not opaque", name, got)
+		}
+	}
+}

--- a/src/packages/api/main.go
+++ b/src/packages/api/main.go
@@ -812,6 +812,7 @@ func buildRouter() *mux.Router {
 	// token IS the authorization (a bad/expired token is a clean 404).
 	api.HandleFunc("/export/{token}/print.html", printViewHandler).Methods("GET")
 	api.HandleFunc("/export/{token}/calendar.ics", calendarHandler).Methods("GET")
+	api.HandleFunc("/export/{token}/event/{kind}/{id}.ics", calendarEventHandler).Methods("GET")
 	// Public share read sits behind the general per-IP limiter like everything
 	// else; it is the one endpoint deliberately open to anonymous strangers.
 	api.HandleFunc("/shared/{token}", sharedTripHandler).Methods("GET")

--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -39,6 +39,7 @@ import '../models/budget.dart';
 import '../services/trip_cache.dart';
 import '../theme/app_colors.dart';
 import '../theme/spacing.dart';
+import '../utils/calendar_links.dart';
 import '../utils/share_link.dart';
 import '../utils/tracked_launch.dart';
 import '../utils/trip_days.dart';
@@ -1663,6 +1664,62 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
     }
   }
 
+  /// Google-Calendar details line for an itinerary item, mirroring the Go
+  /// export's icsItemDescription: time-of-day + local attribution.
+  String _itemCalendarDetails(ItineraryItem item) {
+    final tod = item.timeOfDay;
+    final rec = item.localSourceName?.trim();
+    return [
+      if (tod != null && tod.isNotEmpty)
+        tod[0].toUpperCase() + tod.substring(1),
+      if (rec != null && rec.isNotEmpty) 'Recommended by $rec',
+    ].join(' · ');
+  }
+
+  /// Opens a prefilled Google Calendar event for one itinerary item — a pure
+  /// URL, so no token mint and no offline gate.
+  Future<void> _addItemToGoogleCalendar(ItineraryItem item) async {
+    final range = itemCalendarRange(_trip?.startDate, item.day);
+    if (range == null) return;
+    await trackedLaunchUrl(
+      context,
+      googleCalendarUrl(
+        title: item.name,
+        start: range.start,
+        endExclusive: range.endExclusive,
+        location: item.address,
+        details: _itemCalendarDetails(item),
+      ),
+      provider: 'google_calendar',
+      surface: 'event_calendar',
+      tripId: widget.tripId,
+      kind: 'item',
+    );
+  }
+
+  /// Mints an export token and downloads the item's one-event .ics (the Apple
+  /// Calendar path). Needs the network, like _openExport.
+  Future<void> _addItemToAppleCalendar(ItineraryItem item) async {
+    if (_isOffline) return;
+    try {
+      final service = ref.read(tripsApiServiceProvider);
+      final token = await service.mintExportToken(widget.tripId);
+      if (!mounted) return;
+      final url = exportEventIcsUrl(
+          service.apiClient.baseUrl, token, 'item', item.id);
+      await trackedLaunchUrl(
+        context,
+        url,
+        provider: 'apple_calendar',
+        surface: 'event_calendar',
+        tripId: widget.tripId,
+        kind: 'item',
+      );
+    } catch (e) {
+      _showSnack('Could not export the event: $e');
+    }
+  }
+
   Future<void> _revokeLink() async {
     try {
       await ref.read(tripsApiServiceProvider).revokeShareLink(widget.tripId);
@@ -2780,6 +2837,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
   Widget _itemMenu(ItineraryItem item) {
     final canUp = _moveNeighbor(item, -1) != null;
     final canDown = _moveNeighbor(item, 1) != null;
+    final calendarRange = itemCalendarRange(_trip?.startDate, item.day);
     return PopupMenuButton<String>(
       icon: const Icon(Icons.more_vert),
       tooltip: 'Place actions',
@@ -2793,6 +2851,10 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
             _moveItem(item, 1);
           case 'reorder':
             _reorderSection(item);
+          case 'gcal':
+            _addItemToGoogleCalendar(item);
+          case 'ics':
+            _addItemToAppleCalendar(item);
           case 'delete':
             _deleteItem(item);
         }
@@ -2833,6 +2895,25 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
               contentPadding: EdgeInsets.zero,
             ),
           ),
+        if (calendarRange != null) ...[
+          const PopupMenuItem(
+            value: 'gcal',
+            child: ListTile(
+              leading: Icon(Icons.event_outlined),
+              title: Text('Add to Google Calendar'),
+              contentPadding: EdgeInsets.zero,
+            ),
+          ),
+          PopupMenuItem(
+            value: 'ics',
+            enabled: !_isOffline,
+            child: const ListTile(
+              leading: Icon(Icons.event_available_outlined),
+              title: Text('Add to Apple Calendar (.ics)'),
+              contentPadding: EdgeInsets.zero,
+            ),
+          ),
+        ],
         const PopupMenuItem(
           value: 'delete',
           child: ListTile(
@@ -4171,6 +4252,8 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
                                             grouped.residual, theme),
                                     onAddBooking:
                                         _isOffline ? null : _addBooking,
+                                    appleCalendarEnabled:
+                                        !_readOnly && !_isOffline,
                                   ),
                                 ],
                               ),

--- a/src/packages/flutter-app/lib/utils/calendar_links.dart
+++ b/src/packages/flutter-app/lib/utils/calendar_links.dart
@@ -1,0 +1,77 @@
+import '../models/accommodation.dart';
+import '../models/trip_segment.dart';
+
+/// Builders for the per-event "Add to calendar" affordance.
+///
+/// Google Calendar takes a prefilled calendar.google.com link built entirely
+/// client-side (no server round-trip, no OAuth); Apple Calendar goes through
+/// the token-gated per-event .ics endpoint instead (see exportEventIcsUrl in
+/// share_link.dart). The date-range resolvers mirror the Go export semantics
+/// (calendar_handler.go): everything is all-day with an EXCLUSIVE end, and a
+/// null range means "undated — hide the affordance".
+
+/// Prefilled Google Calendar event link (all-day; [endExclusive] follows the
+/// same end-exclusive convention as the .ics export).
+String googleCalendarUrl({
+  required String title,
+  required DateTime start,
+  required DateTime endExclusive,
+  String? location,
+  String? details,
+}) {
+  return Uri.https('calendar.google.com', '/calendar/render', {
+    'action': 'TEMPLATE',
+    'text': title,
+    'dates': '${_ymd(start)}/${_ymd(endExclusive)}',
+    if (location != null && location.trim().isNotEmpty) 'location': location,
+    if (details != null && details.trim().isNotEmpty) 'details': details,
+  }).toString();
+}
+
+String _ymd(DateTime d) => '${d.year.toString().padLeft(4, '0')}'
+    '${d.month.toString().padLeft(2, '0')}'
+    '${d.day.toString().padLeft(2, '0')}';
+
+/// A stay spans check-in through check-out (one night when check-out is
+/// missing or not after check-in). Null when check-in is missing/unparseable.
+({DateTime start, DateTime endExclusive})? stayCalendarRange(Accommodation a) {
+  final start = _parseDate(a.checkIn);
+  if (start == null) return null;
+  final checkOut = _parseDate(a.checkOut);
+  final end = (checkOut != null && checkOut.isAfter(start))
+      ? checkOut
+      : start.add(const Duration(days: 1));
+  return (start: start, endExclusive: end);
+}
+
+/// A segment spans departure day through arrival day inclusive (a single day
+/// when arrival is missing). Null when the departure date is missing.
+({DateTime start, DateTime endExclusive})? segmentCalendarRange(TripSegment s) {
+  final start = _parseDate(s.departDate);
+  if (start == null) return null;
+  final arrive = _parseDate(s.arriveDate);
+  final end = (arrive != null && arrive.isAfter(start))
+      ? arrive.add(const Duration(days: 1))
+      : start.add(const Duration(days: 1));
+  return (start: start, endExclusive: end);
+}
+
+/// An itinerary item occupies the single trip day it's assigned to:
+/// trip.start_date + (day - 1). Null without a trip start date or a day.
+({DateTime start, DateTime endExclusive})? itemCalendarRange(
+    String? tripStartDate, int? day) {
+  final tripStart = _parseDate(tripStartDate);
+  if (tripStart == null || day == null || day < 1) return null;
+  final start = tripStart.add(Duration(days: day - 1));
+  return (start: start, endExclusive: start.add(const Duration(days: 1)));
+}
+
+/// Parses a YYYY-MM-DD date to UTC midnight. UTC keeps the day arithmetic
+/// above exact — adding Duration(days: 1) to a LOCAL DateTime shifts by an
+/// hour across DST boundaries (see the Today-mode calendar-math lesson).
+DateTime? _parseDate(String? s) {
+  if (s == null || s.isEmpty) return null;
+  final t = DateTime.tryParse(s);
+  if (t == null) return null;
+  return DateTime.utc(t.year, t.month, t.day);
+}

--- a/src/packages/flutter-app/lib/utils/share_link.dart
+++ b/src/packages/flutter-app/lib/utils/share_link.dart
@@ -38,6 +38,13 @@ String exportPrintUrl(String apiBaseUrl, String token) =>
 String exportIcsUrl(String apiBaseUrl, String token) =>
     _exportUrl(apiBaseUrl, token, 'calendar.ics');
 
+/// Absolute URL for ONE trip event's token-gated .ics ([kind] is the server's
+/// path segment: stay | segment | item). See [exportPrintUrl] for how the
+/// same-origin URL is built.
+String exportEventIcsUrl(
+        String apiBaseUrl, String token, String kind, String id) =>
+    _exportUrl(apiBaseUrl, token, 'event/$kind/$id.ics');
+
 String _exportUrl(String apiBaseUrl, String token, String file) {
   final path = '$apiBaseUrl/export/$token/$file';
   // An absolute API base (bare `flutter run`) is already launch-ready.

--- a/src/packages/flutter-app/lib/widgets/add_to_calendar_button.dart
+++ b/src/packages/flutter-app/lib/widgets/add_to_calendar_button.dart
@@ -1,0 +1,115 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../providers/trips_provider.dart';
+import '../utils/calendar_links.dart';
+import '../utils/share_link.dart';
+import '../utils/snack.dart';
+import '../utils/tracked_launch.dart';
+
+/// Per-event "Add to calendar" menu: Google Calendar via a prefilled
+/// calendar.google.com link (pure URL — works offline-queued and for
+/// read-only viewers), Apple Calendar via the token-gated per-event .ics
+/// (needs an export token mint, so [appleEnabled] is false for viewers and
+/// offline). Only rendered for dated events — call sites gate on the
+/// calendar range resolvers.
+class AddToCalendarButton extends ConsumerWidget {
+  final String tripId;
+
+  /// Server path segment for the .ics endpoint: stay | segment | item.
+  final String kind;
+  final String eventId;
+
+  /// Analytics kind, matching the bookings naming: stay | transport | item.
+  final String analyticsKind;
+  final String title;
+  final DateTime start;
+  final DateTime endExclusive;
+  final String? location;
+  final String? details;
+  final bool appleEnabled;
+
+  const AddToCalendarButton({
+    super.key,
+    required this.tripId,
+    required this.kind,
+    required this.eventId,
+    required this.analyticsKind,
+    required this.title,
+    required this.start,
+    required this.endExclusive,
+    this.location,
+    this.details,
+    this.appleEnabled = false,
+  });
+
+  Future<void> _openGoogle(BuildContext context) async {
+    await trackedLaunchUrl(
+      context,
+      googleCalendarUrl(
+        title: title,
+        start: start,
+        endExclusive: endExclusive,
+        location: location,
+        details: details,
+      ),
+      provider: 'google_calendar',
+      surface: 'event_calendar',
+      tripId: tripId,
+      kind: analyticsKind,
+    );
+  }
+
+  Future<void> _openApple(BuildContext context, WidgetRef ref) async {
+    try {
+      final service = ref.read(tripsApiServiceProvider);
+      final token = await service.mintExportToken(tripId);
+      final url =
+          exportEventIcsUrl(service.apiClient.baseUrl, token, kind, eventId);
+      if (!context.mounted) return;
+      await trackedLaunchUrl(
+        context,
+        url,
+        provider: 'apple_calendar',
+        surface: 'event_calendar',
+        tripId: tripId,
+        kind: analyticsKind,
+      );
+    } catch (e) {
+      if (context.mounted) {
+        showSnack(context, 'Could not export the event: $e');
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return PopupMenuButton<String>(
+      icon: const Icon(Icons.event_outlined, size: 18),
+      tooltip: 'Add to calendar',
+      onSelected: (choice) => switch (choice) {
+        'google' => _openGoogle(context),
+        _ => _openApple(context, ref),
+      },
+      itemBuilder: (context) => [
+        const PopupMenuItem(
+          value: 'google',
+          child: ListTile(
+            leading: Icon(Icons.event_outlined),
+            title: Text('Google Calendar'),
+            contentPadding: EdgeInsets.zero,
+          ),
+        ),
+        PopupMenuItem(
+          value: 'apple',
+          enabled: appleEnabled,
+          child: const ListTile(
+            leading: Icon(Icons.event_available_outlined),
+            title: Text('Apple Calendar (.ics)'),
+            contentPadding: EdgeInsets.zero,
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/src/packages/flutter-app/lib/widgets/bookings_section.dart
+++ b/src/packages/flutter-app/lib/widgets/bookings_section.dart
@@ -3,7 +3,9 @@ import '../models/accommodation.dart';
 import '../models/trip.dart';
 import '../models/trip_segment.dart';
 import '../theme/spacing.dart';
+import '../utils/calendar_links.dart';
 import '../utils/tracked_launch.dart';
+import 'add_to_calendar_button.dart';
 import 'section_header.dart';
 import 'status_pill.dart';
 
@@ -61,6 +63,11 @@ class BookingsSection extends StatelessWidget {
   /// (offline), mirroring the reorder callbacks.
   final VoidCallback? onAddBooking;
 
+  /// Whether the "Apple Calendar (.ics)" entry of the per-row Add-to-calendar
+  /// menu is enabled. False for viewers (they can't mint export tokens) and
+  /// offline; the Google entry is a pure URL and stays available regardless.
+  final bool appleCalendarEnabled;
+
   const BookingsSection({
     super.key,
     required this.trip,
@@ -81,7 +88,19 @@ class BookingsSection extends StatelessWidget {
     this.readOnly = false,
     this.otherBookings,
     this.onAddBooking,
+    this.appleCalendarEnabled = false,
   });
+
+  /// Calendar-event title for a segment, mirroring the Go export's
+  /// `capitalize(mode) + ": " + segmentRoute(s)`.
+  static String _segmentCalendarTitle(TripSegment s) {
+    final mode = s.mode.isEmpty
+        ? 'Trip'
+        : s.mode[0].toUpperCase() + s.mode.substring(1);
+    final route =
+        [s.origin, s.destination].whereType<String>().join(' → ');
+    return route.isEmpty ? mode : '$mode: $route';
+  }
 
   static IconData _modeIcon(String mode) => switch (mode) {
         'flight' => Icons.flight_takeoff,
@@ -288,6 +307,19 @@ class BookingsSection extends StatelessWidget {
                       : Row(
                           mainAxisSize: MainAxisSize.min,
                           children: [
+                            if (stayCalendarRange(a) case final range?)
+                              AddToCalendarButton(
+                                tripId: trip.id,
+                                kind: 'stay',
+                                eventId: a.id,
+                                analyticsKind: 'stay',
+                                title: 'Stay: ${a.name}',
+                                start: range.start,
+                                endExclusive: range.endExclusive,
+                                location: a.address,
+                                details: a.provider,
+                                appleEnabled: appleCalendarEnabled,
+                              ),
                             if (a.url != null && a.url!.isNotEmpty)
                               IconButton(
                                 icon: const Icon(Icons.open_in_new, size: 18),
@@ -374,6 +406,18 @@ class BookingsSection extends StatelessWidget {
                       : Row(
                           mainAxisSize: MainAxisSize.min,
                           children: [
+                            if (segmentCalendarRange(s) case final range?)
+                              AddToCalendarButton(
+                                tripId: trip.id,
+                                kind: 'segment',
+                                eventId: s.id,
+                                analyticsKind: 'transport',
+                                title: _segmentCalendarTitle(s),
+                                start: range.start,
+                                endExclusive: range.endExclusive,
+                                details: s.notes,
+                                appleEnabled: appleCalendarEnabled,
+                              ),
                             if (s.url != null && s.url!.isNotEmpty)
                               IconButton(
                                 icon: const Icon(Icons.open_in_new, size: 18),

--- a/src/packages/flutter-app/test/bookings_calendar_menu_test.dart
+++ b/src/packages/flutter-app/test/bookings_calendar_menu_test.dart
@@ -1,0 +1,212 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:url_launcher_platform_interface/link.dart' show LinkDelegate;
+import 'package:url_launcher_platform_interface/url_launcher_platform_interface.dart';
+
+import 'package:travel_route_planner/models/accommodation.dart';
+import 'package:travel_route_planner/models/trip.dart';
+import 'package:travel_route_planner/models/trip_segment.dart';
+import 'package:travel_route_planner/providers/analytics_provider.dart';
+import 'package:travel_route_planner/providers/trips_provider.dart';
+import 'package:travel_route_planner/services/analytics_api_service.dart';
+import 'package:travel_route_planner/services/api_client.dart';
+import 'package:travel_route_planner/services/trips_api_service.dart';
+import 'package:travel_route_planner/widgets/bookings_section.dart';
+
+/// Records mint calls and returns a fixed token so the built per-event .ics
+/// URL is deterministic.
+class _FakeTripsApiService extends TripsApiService {
+  int mintCalls = 0;
+
+  _FakeTripsApiService() : super(ApiClient(baseUrl: 'http://test/api/v1'));
+
+  @override
+  Future<String> mintExportToken(String tripId) {
+    mintCalls++;
+    return Future.value('tok-123');
+  }
+}
+
+class _FakeUrlLauncher extends UrlLauncherPlatform {
+  final launched = <String>[];
+
+  @override
+  LinkDelegate? get linkDelegate => null;
+
+  @override
+  Future<bool> canLaunch(String url) async => true;
+
+  @override
+  Future<bool> launchUrl(String url, LaunchOptions options) async {
+    launched.add(url);
+    return true;
+  }
+}
+
+class _NoopAnalytics extends AnalyticsApiService {
+  _NoopAnalytics() : super(ApiClient(baseUrl: 'http://test/api/v1'));
+
+  @override
+  Future<void> recordBookingLinkClicked({
+    String? tripId,
+    String? todoKey,
+    String? provider,
+    String? surface,
+    String? kind,
+  }) =>
+      Future.value();
+}
+
+Trip _trip() => Trip(
+      id: 't1',
+      title: 'Portugal',
+      status: 'planned',
+      createdAt: '2026-06-01',
+      updatedAt: '2026-06-01',
+    );
+
+const _datedStay = Accommodation(
+  id: 'a1',
+  name: 'Casa do Brian',
+  provider: 'Airbnb',
+  address: 'Lisbon',
+  checkIn: '2026-09-04',
+  checkOut: '2026-09-06',
+);
+
+const _undatedStay = Accommodation(id: 'a2', name: 'Somewhere in Porto');
+
+const _draftStay = Accommodation(
+  id: 'a3',
+  name: 'Stay in Faro',
+  checkIn: '2026-09-06',
+  checkOut: '2026-09-08',
+  auto: true,
+  autoKey: 'stay:faro',
+);
+
+const _datedLeg = TripSegment(
+  id: 's1',
+  mode: 'flight',
+  origin: 'LIS',
+  destination: 'OPO',
+  departDate: '2026-09-04',
+  arriveDate: '2026-09-05',
+);
+
+Future<(_FakeTripsApiService, _FakeUrlLauncher)> _pump(
+  WidgetTester tester, {
+  required List<Accommodation> stays,
+  List<TripSegment> segments = const [],
+  bool appleCalendarEnabled = true,
+}) async {
+  final service = _FakeTripsApiService();
+  final launcher = _FakeUrlLauncher();
+  UrlLauncherPlatform.instance = launcher;
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        tripsApiServiceProvider.overrideWithValue(service),
+        analyticsApiServiceProvider.overrideWithValue(_NoopAnalytics()),
+      ],
+      child: MaterialApp(
+        home: Scaffold(
+          body: SingleChildScrollView(
+            child: BookingsSection(
+              trip: _trip(),
+              stays: stays,
+              segments: segments,
+              onAddStay: () {},
+              onDeleteStay: (_) {},
+              onEditStay: (_) {},
+              onConfirmStay: (_) {},
+              onAddSegment: () {},
+              onDeleteSegment: (_) {},
+              onEditSegment: (_) {},
+              onConfirmSegment: (_) {},
+              appleCalendarEnabled: appleCalendarEnabled,
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+  return (service, launcher);
+}
+
+Finder _calendarButton() => find.byTooltip('Add to calendar');
+
+void main() {
+  testWidgets('dated stay shows the menu; undated and draft stays do not',
+      (tester) async {
+    await _pump(tester, stays: [_datedStay, _undatedStay, _draftStay]);
+    expect(_calendarButton(), findsOneWidget);
+  });
+
+  testWidgets('Google entry launches a prefilled calendar.google.com link',
+      (tester) async {
+    final (service, launcher) = await _pump(tester, stays: [_datedStay]);
+
+    await tester.tap(_calendarButton());
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Google Calendar'));
+    await tester.pumpAndSettle();
+
+    expect(launcher.launched, hasLength(1));
+    final uri = Uri.parse(launcher.launched.single);
+    expect(uri.host, 'calendar.google.com');
+    expect(uri.queryParameters['action'], 'TEMPLATE');
+    expect(uri.queryParameters['text'], 'Stay: Casa do Brian');
+    expect(uri.queryParameters['dates'], '20260904/20260906');
+    expect(service.mintCalls, 0, reason: 'Google path needs no token');
+  });
+
+  testWidgets('Apple entry mints once and launches the per-event .ics',
+      (tester) async {
+    final (service, launcher) = await _pump(tester, stays: [_datedStay]);
+
+    await tester.tap(_calendarButton());
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Apple Calendar (.ics)'));
+    await tester.pumpAndSettle();
+
+    expect(service.mintCalls, 1);
+    expect(launcher.launched.single,
+        'http://test/api/v1/export/tok-123/event/stay/a1.ics');
+  });
+
+  testWidgets('segment row builds the mode-and-route title', (tester) async {
+    final (_, launcher) =
+        await _pump(tester, stays: const [], segments: [_datedLeg]);
+
+    await tester.tap(_calendarButton());
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Google Calendar'));
+    await tester.pumpAndSettle();
+
+    final uri = Uri.parse(launcher.launched.single);
+    expect(uri.queryParameters['text'], 'Flight: LIS → OPO');
+    expect(uri.queryParameters['dates'], '20260904/20260906');
+  });
+
+  testWidgets('appleCalendarEnabled: false renders the Apple entry disabled',
+      (tester) async {
+    final (service, launcher) =
+        await _pump(tester, stays: [_datedStay], appleCalendarEnabled: false);
+
+    await tester.tap(_calendarButton());
+    await tester.pumpAndSettle();
+    final item = tester.widget<PopupMenuItem<String>>(find.ancestor(
+      of: find.text('Apple Calendar (.ics)'),
+      matching: find.byWidgetPredicate((w) => w is PopupMenuItem<String>),
+    ));
+    expect(item.enabled, isFalse);
+
+    await tester.tap(find.text('Apple Calendar (.ics)'), warnIfMissed: false);
+    await tester.pumpAndSettle();
+    expect(service.mintCalls, 0);
+    expect(launcher.launched, isEmpty);
+  });
+}

--- a/src/packages/flutter-app/test/calendar_links_test.dart
+++ b/src/packages/flutter-app/test/calendar_links_test.dart
@@ -1,0 +1,105 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:travel_route_planner/models/accommodation.dart';
+import 'package:travel_route_planner/models/trip_segment.dart';
+import 'package:travel_route_planner/utils/calendar_links.dart';
+
+void main() {
+  group('googleCalendarUrl', () {
+    test('builds a prefilled all-day TEMPLATE link', () {
+      final url = googleCalendarUrl(
+        title: 'Stay: Casa do Brian',
+        start: DateTime.utc(2026, 9, 4),
+        endExclusive: DateTime.utc(2026, 9, 6),
+        location: 'Lisbon',
+        details: 'Airbnb',
+      );
+      final uri = Uri.parse(url);
+      expect(uri.host, 'calendar.google.com');
+      expect(uri.path, '/calendar/render');
+      expect(uri.queryParameters['action'], 'TEMPLATE');
+      expect(uri.queryParameters['text'], 'Stay: Casa do Brian');
+      expect(uri.queryParameters['dates'], '20260904/20260906');
+      expect(uri.queryParameters['location'], 'Lisbon');
+      expect(uri.queryParameters['details'], 'Airbnb');
+    });
+
+    test('encodes reserved characters and omits empty optionals', () {
+      final url = googleCalendarUrl(
+        title: 'Fish & chips, maybe?',
+        start: DateTime.utc(2026, 9, 4),
+        endExclusive: DateTime.utc(2026, 9, 5),
+        location: '  ',
+      );
+      final uri = Uri.parse(url);
+      expect(uri.queryParameters['text'], 'Fish & chips, maybe?');
+      expect(uri.queryParameters.containsKey('location'), isFalse);
+      expect(uri.queryParameters.containsKey('details'), isFalse);
+    });
+  });
+
+  group('stayCalendarRange', () {
+    test('spans check-in to check-out (end-exclusive)', () {
+      const a = Accommodation(
+          id: 'a', name: 'Casa', checkIn: '2026-09-04', checkOut: '2026-09-06');
+      final r = stayCalendarRange(a)!;
+      expect(r.start, DateTime.utc(2026, 9, 4));
+      expect(r.endExclusive, DateTime.utc(2026, 9, 6));
+    });
+
+    test('missing or non-later check-out falls back to one night', () {
+      const noOut = Accommodation(id: 'a', name: 'Casa', checkIn: '2026-09-04');
+      expect(stayCalendarRange(noOut)!.endExclusive, DateTime.utc(2026, 9, 5));
+      const sameDay = Accommodation(
+          id: 'a', name: 'Casa', checkIn: '2026-09-04', checkOut: '2026-09-04');
+      expect(
+          stayCalendarRange(sameDay)!.endExclusive, DateTime.utc(2026, 9, 5));
+    });
+
+    test('null for missing or unparseable check-in', () {
+      expect(stayCalendarRange(const Accommodation(id: 'a', name: 'Casa')),
+          isNull);
+      expect(
+          stayCalendarRange(const Accommodation(
+              id: 'a', name: 'Casa', checkIn: 'not-a-date')),
+          isNull);
+    });
+  });
+
+  group('segmentCalendarRange', () {
+    test('spans departure through arrival day inclusive', () {
+      const s = TripSegment(
+          id: 's',
+          mode: 'flight',
+          departDate: '2026-09-04',
+          arriveDate: '2026-09-05');
+      final r = segmentCalendarRange(s)!;
+      expect(r.start, DateTime.utc(2026, 9, 4));
+      expect(r.endExclusive, DateTime.utc(2026, 9, 6));
+    });
+
+    test('missing arrival is a single day; missing departure is null', () {
+      const noArrive =
+          TripSegment(id: 's', mode: 'flight', departDate: '2026-09-04');
+      expect(segmentCalendarRange(noArrive)!.endExclusive,
+          DateTime.utc(2026, 9, 5));
+      expect(segmentCalendarRange(const TripSegment(id: 's', mode: 'flight')),
+          isNull);
+    });
+  });
+
+  group('itemCalendarRange', () {
+    test('resolves trip start + (day - 1) as a single day', () {
+      final r = itemCalendarRange('2026-08-01', 3)!;
+      expect(r.start, DateTime.utc(2026, 8, 3));
+      expect(r.endExclusive, DateTime.utc(2026, 8, 4));
+    });
+
+    test('null without a trip start, a day, or a valid day', () {
+      expect(itemCalendarRange(null, 3), isNull);
+      expect(itemCalendarRange('2026-08-01', null), isNull);
+      expect(itemCalendarRange('2026-08-01', 0), isNull);
+      expect(itemCalendarRange('nope', 3), isNull);
+    });
+  });
+}


### PR DESCRIPTION
## What

Adds a per-event "Add to calendar" action so a single trip event — a stay, a transport segment (flight/train/…), or a dated itinerary item — can be put on the user's Google or Apple calendar. Previously only the whole-trip .ics export existed.

## Server (Go)

- `calendar_handler.go`: behavior-preserving extraction of the three `buildICS` loops into shared `stayEventFields` / `segmentEventFields` / `itemEventFields` resolvers (existing ICS integration assertions guard the refactor).
- New `calendar_event_handler.go`: `GET /api/v1/export/{token}/event/{kind}/{id}.ics` (kind ∈ `stay|segment|item`) — token-gated, PUBLIC like the whole-trip route; renders one all-day VEVENT via the shared helpers with the **same UID scheme** (`acc-`/`seg-`/`item-`) so re-adding after a whole-trip import dedupes. Bad token / bad uuid / unknown kind / unknown id / undated event → one opaque 404.

## Flutter

- `utils/calendar_links.dart`: client-side `googleCalendarUrl` (prefilled `calendar.google.com/calendar/render?action=TEMPLATE` all-day link, no OAuth, no server call) + stay/segment/item date-range resolvers mirroring the Go end-exclusive semantics; date math at UTC midnight (DST lesson from Today mode).
- `widgets/add_to_calendar_button.dart`: compact popup (Google Calendar / Apple Calendar (.ics)); the Apple entry mints an export token → `exportEventIcsUrl` → download; analytics via `trackedLaunchUrl` (`google_calendar`/`apple_calendar`, surface `event_calendar`).
- Bookings hub: button on dated, non-draft stay/segment rows; `appleCalendarEnabled = !readOnly && !offline` (Google stays available to viewers/offline — it's a pure URL).
- Itinerary item menu: "Add to Google Calendar" / "Add to Apple Calendar (.ics)" entries for day-assigned items (Apple disabled offline).
- Undated events show no affordance anywhere; the server 404s them opaquely regardless.

## Tests

- Go unit (`calendar_event_test.go`): per-kind DTSTART/DTEND incl. end-exclusive maths + missing-end fallbacks, single-VEVENT shape, UID prefixes, RFC 5545 escaping, all ok=false cases.
- Go integration: 200 + headers for a real stay; opaque-404 sweep (bad token, bogus uuid, unknown id, unknown kind).
- Flutter: `calendar_links_test.dart` (URL params/encoding, resolver null/edge cases) + `bookings_calendar_menu_test.dart` (affordance gating incl. drafts/undated, Google launch URL, Apple mint-once + .ics URL, disabled Apple entry).

`go test ./...` (unit + integration against a fresh test DB), `go vet`, `flutter analyze` (no new issues), `flutter test` (378 passed) all green. No migrations, no model/.g.dart changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)