### PR TITLE
fix(flutter): add back button to sign-in screen

### DIFF
--- a/src/packages/flutter-app/lib/screens/auth_screen.dart
+++ b/src/packages/flutter-app/lib/screens/auth_screen.dart
@@ -143,6 +143,13 @@ class _AuthScreenState extends ConsumerState<AuthScreen> {
     final auth = ref.watch(authProvider);
 
     return Scaffold(
+      // Transparent AppBar so the implied back arrow gives a way back to the
+      // landing page underneath (this screen is always pushed on top of it).
+      appBar: AppBar(
+        backgroundColor: Colors.transparent,
+        elevation: 0,
+        scrolledUnderElevation: 0,
+      ),
       body: Center(
         child: SingleChildScrollView(
           padding: const EdgeInsets.all(24),


### PR DESCRIPTION
## Summary
- The sign-in screen (`AuthScreen`) is always pushed on top of the landing page but had no AppBar or back affordance, so visitors had no visible way back without signing in.
- Added a transparent, zero-elevation AppBar to its Scaffold; Flutter's default `automaticallyImplyLeading` renders the back arrow since the route can pop, returning to the landing page. Layout and the success-path pop are untouched.

## Testing
- `flutter analyze` — no new issues (12 pre-existing `withOpacity` deprecation infos elsewhere).
- `flutter test` — all tests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)