### PR TITLE
feat: Sign in with Apple (server-side flow, ships dark)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,11 +94,15 @@ TRANSCRIPTION_BASE_URL=...      # Default https://api.groq.com/openai/v1
 TRANSCRIPTION_MODEL=...         # Default whisper-large-v3-turbo
 GOOGLE_OAUTH_CLIENT_ID=...      # Sign in with Google (server-side OAuth), with...
 GOOGLE_OAUTH_CLIENT_SECRET=...  # ...this; register <PUBLIC_BASE_URL>/api/v1/auth/google/callback as redirect URI
+APPLE_TEAM_ID=...               # Sign in with Apple (specs/apple-sso): Team ID, plus...
+APPLE_CLIENT_ID=...             # ...the Services ID, ...
+APPLE_KEY_ID=...                # ...the .p8 key id, and...
+APPLE_PRIVATE_KEY=...           # ...the .p8 PEM base64-encoded onto one line
 SENTRY_DSN=...                  # Optional error alerting; empty => Sentry fully inert
 DATABASE_URL=...                # Postgres connection; absent/unreachable => degraded mode (no persistence)
 ```
 
-Without `GOOGLE_PLACES_API_KEY`, place search endpoints return errors. The `/plan` handler also calls `search_places` internally, which will fail without the key. Without `DUFFEL_ACCESS_TOKEN`, the `/flights/*` endpoints return a configured-error; the rest of the API is unaffected. Without `TICKETMASTER_API_KEY`, the `/events/search` endpoint (and the `/plan` agent's `search_events` tool) returns a configured-error; the rest of the API is unaffected. Without `TRANSCRIPTION_API_KEY`, the dictation fallback is disabled (`/transcribe/availability` reports it) and the mic only appears in browsers with built-in speech recognition. Without the `GOOGLE_OAUTH_*` pair, the Google button is hidden and `/auth/google` answers 503; email+password auth is unaffected. `FERRYHOPPER_AFFILIATE_ID` is optional — ferry links work without it (just unattributed). `.env.sample` documents further optional vars: `SMTP_*` (verification/reset email; empty => tokens are logged instead), `PUBLIC_BASE_URL`/`PUBLIC_APP_PATH`, `ALLOWED_ORIGINS` (CORS, dev-only), `BOOKING_AFFILIATE_ID`, `PORT`, price-alert cadence (`ALERT_*`), free-cap tuning (`FREE_*`), `ANTHROPIC_BASE_URL` (test seam), and `SENTRY_RELEASE`.
+Without `GOOGLE_PLACES_API_KEY`, place search endpoints return errors. The `/plan` handler also calls `search_places` internally, which will fail without the key. Without `DUFFEL_ACCESS_TOKEN`, the `/flights/*` endpoints return a configured-error; the rest of the API is unaffected. Without `TICKETMASTER_API_KEY`, the `/events/search` endpoint (and the `/plan` agent's `search_events` tool) returns a configured-error; the rest of the API is unaffected. Without `TRANSCRIPTION_API_KEY`, the dictation fallback is disabled (`/transcribe/availability` reports it) and the mic only appears in browsers with built-in speech recognition. Without the `GOOGLE_OAUTH_*` pair, the Google button is hidden and `/auth/google` answers 503; likewise the four `APPLE_*` vars gate the Apple button and `/auth/apple`; email+password auth is unaffected either way. `FERRYHOPPER_AFFILIATE_ID` is optional — ferry links work without it (just unattributed). `.env.sample` documents further optional vars: `SMTP_*` (verification/reset email; empty => tokens are logged instead), `PUBLIC_BASE_URL`/`PUBLIC_APP_PATH`, `ALLOWED_ORIGINS` (CORS, dev-only), `BOOKING_AFFILIATE_ID`, `PORT`, price-alert cadence (`ALERT_*`), free-cap tuning (`FREE_*`), `ANTHROPIC_BASE_URL` (test seam), and `SENTRY_RELEASE`.
 
 ## API Endpoints
 
@@ -120,7 +124,8 @@ Without `GOOGLE_PLACES_API_KEY`, place search endpoints return errors. The `/pla
 | GET | `/api/v1/admin/local/coverage` | **Admin.** Per-city published/draft counts |
 | GET | `/api/v1/admin/metrics` | **Admin.** Phase-1 funnel metrics; siblings `/admin/metrics/{timeseries,totals,activity,users}` power the tabbed analytics dashboard |
 | POST | `/api/v1/transcribe` | Voice-dictation fallback: audio clip → text via OpenAI-compatible transcription (Groq default); `GET /api/v1/transcribe/availability` gates the mic UI |
-| GET | `/api/v1/auth/google` | Sign in with Google: server-side OAuth redirect flow (specs/google-sso); callback lands on `/sso/<one-time code>`, exchanged via `POST /auth/google/exchange`; `GET /auth/google/availability` gates the button |
+| GET | `/api/v1/auth/google` | Sign in with Google: server-side OAuth redirect flow (specs/google-sso); callback lands on `/sso/<one-time code>`, exchanged via `POST /auth/sso/exchange` (`/auth/google/exchange` is a legacy alias); `GET /auth/google/availability` gates the button |
+| GET | `/api/v1/auth/apple` | Sign in with Apple (specs/apple-sso): same flow with a **POST** form_post callback, ES256 client-secret JWT, no PKCE; `GET /auth/apple/availability` gates the button |
 | GET | `/api/v1/chats` | Resumable (in-progress) plan conversations; excludes chats that produced a trip |
 | GET/DELETE | `/api/v1/chats/{chatId}` | Full transcript for resume / dismiss a conversation |
 | POST | `/api/v1/plan` | SSE stream; Claude claude-sonnet-4-6 agent loop over a 16-tool registry (see `plan_tool_registry.go`) — notably `search_places`, `search_local_recommendations`, `search_flights`, `search_events`, `create_itinerary` / `update_itinerary_section` (mutually exclusive by session), `save_preferences`, and booking-todo tools |

--- a/dockerize/production/.env.sample
+++ b/dockerize/production/.env.sample
@@ -75,6 +75,17 @@ ANTHROPIC_API_KEY=
 GOOGLE_OAUTH_CLIENT_ID=
 GOOGLE_OAUTH_CLIENT_SECRET=
 
+# Sign in with Apple (specs/apple-sso). Needs Apple Developer Program
+# enrollment — console steps in specs/apple-sso/plan.md. APPLE_CLIENT_ID is
+# the Services ID (com.goldentempotravel.web); the return URL to register is
+# <PUBLIC_BASE_URL>/api/v1/auth/apple/callback. APPLE_PRIVATE_KEY is the .p8
+# base64-encoded onto one line (base64 -i AuthKey_<KEY_ID>.p8 | tr -d '\n').
+# Any absent => the Apple button is hidden (degraded, not fatal).
+APPLE_TEAM_ID=
+APPLE_CLIENT_ID=
+APPLE_KEY_ID=
+APPLE_PRIVATE_KEY=
+
 # Flight search (Duffel). Use a LIVE token (duffel_live_...) in production;
 # a test token returns sandbox data. Missing => /flights/* return a
 # configured-error, rest of the API unaffected (degraded, not fatal).

--- a/specs/apple-sso/plan.md
+++ b/specs/apple-sso/plan.md
@@ -1,0 +1,77 @@
+# Plan: Sign in with Apple
+
+Sibling of specs/google-sso — same server-side redirect flow, `/sso/<code>`
+handoff, and linking rules, implemented in `apple_oauth.go` +
+`apple_auth_handler.go` with zero new dependencies. Ships dark until Apple
+Developer Program enrollment (see Ops runbook below).
+
+## Deltas vs Google
+
+1. **ES256 client-secret JWT** (`appleClientSecret` in apple_oauth.go): Apple
+   has no static secret; we sign `{iss: TEAM_ID, sub: SERVICES_ID, aud:
+   appleid.apple.com, iat, exp: +5min}` with the `.p8` P-256 key using
+   stdlib `crypto/ecdsa`. The signature is **raw r||s, each half left-padded
+   to 32 bytes — not ASN.1 DER** (`ecdsa.SignASN1` would be wrong). The fake
+   token endpoint verifies the JWT with `ecdsa.Verify`, so a regression
+   fails tests.
+2. **form_post callback**: requesting `scope=name email` requires
+   `response_mode=form_post`, so `/auth/apple/callback` is a **POST** and the
+   state cookie (`apple_oauth_state`) is **SameSite=None; Secure** — Lax
+   cookies don't ride cross-site POSTs. Secure is unconditional: Apple
+   rejects http/localhost return URLs, so a local browser flow is impossible
+   regardless; integration tests attach the cookie to httptest requests.
+3. **No PKCE** — Apple doesn't support it; the fake rejects `code_verifier`
+   at the wire. CSRF = state cookie + one-time code + client-secret JWT.
+4. **Name arrives once**: first authorization only, via the `user` form
+   field (`parseAppleUserField`); fallback `defaultDisplayName(email)`.
+5. **flexBool**: `email_verified` / `is_private_email` arrive as bool or
+   string. Relay addresses get no special casing — they're verified, real,
+   deliverable-via-relay addresses that simply never match existing accounts.
+6. **No id_token signature verification** — same server-to-server TLS trust
+   decision as `parseGoogleIDToken`, same unsigned-JWT test fake.
+7. **Exchange generalized**: `googleExchangeHandler` → `ssoExchangeHandler`
+   at `/auth/sso/exchange` (Flutter now calls this); `/auth/google/exchange`
+   kept as an alias for handoff codes in-flight across the deploy.
+
+## Key files
+
+- API: `apple_oauth.go`, `apple_auth_handler.go`,
+  `migrations/00048_apple_sso.sql` (provider CHECK → `('google','apple')`;
+  down deletes only stranded Apple-only accounts), routes in `main.go`.
+- Tests: `fake_apple_test.go` (in-test P-256 key; verifies the client-secret
+  JWT cryptographically), `apple_auth_integration_test.go` (13 cases).
+- Flutter: `widgets/sso_buttons.dart` (shared divider + both buttons),
+  `widgets/apple_sign_in_button.dart` (HIG black button, `Icons.apple` glyph
+  — no asset needed), `appleSsoAvailableProvider`, `appleSignInAvailable` +
+  `exchangeSsoCode`→`/auth/sso/exchange` in `services/auth_service.dart`.
+
+## Configuration
+
+`APPLE_TEAM_ID`, `APPLE_CLIENT_ID` (the Services ID), `APPLE_KEY_ID`,
+`APPLE_PRIVATE_KEY` (.p8 base64-encoded to one line). Any missing ⇒ degraded
+mode. Test seams: `APPLE_AUTH_URL` / `APPLE_TOKEN_URL`.
+
+## Ops runbook (post-enrollment)
+
+1. Enroll in the Apple Developer Program (developer.apple.com, $99/yr; the
+   Golden Tempo LLC route needs a D-U-N-S number — allow days to weeks).
+2. Certificates, Identifiers & Profiles → Identifiers → create an **App ID**
+   (primary), then a **Services ID** `com.goldentempotravel.web` with
+   "Sign In with Apple" enabled → this is `APPLE_CLIENT_ID`.
+3. Configure the Services ID: register domain `goldentempotravel.com` and
+   Return URL exactly `https://goldentempotravel.com/api/v1/auth/apple/callback`.
+4. Keys → create a key with "Sign In with Apple" → download
+   `AuthKey_<KEY_ID>.p8` (**one-time download** — store it in the password
+   manager), note the Key ID and the Team ID (console top-right).
+5. On the Pi: `base64 -i AuthKey_<KEY_ID>.p8 | tr -d '\n'` → set the four
+   `APPLE_*` vars in `/opt/goldentempo/.env`, recreate the api container,
+   confirm `curl https://goldentempotravel.com/api/v1/auth/apple/availability`
+   → `{"available":true}` and the button appears.
+6. **Email relay**: Certificates → Services → "Sign In with Apple for Email
+   Communication" → register the transactional-email sending domain/address
+   (SPF/DKIM must pass) so password-reset mail reaches
+   `@privaterelay.appleid.com` users.
+7. Smoke: full prod sign-in; name capture (to re-trigger the first-auth
+   consent, revoke the grant at appleid.apple.com → Sign-In & Security →
+   Sign in with Apple); a Hide-My-Email signup; auto-link with an existing
+   email+password account.

--- a/specs/apple-sso/spec.md
+++ b/specs/apple-sso/spec.md
@@ -1,0 +1,80 @@
+# Spec: Sign in with Apple
+
+> **WHAT & WHY only.** Implementation details live in `plan.md`.
+
+## Context
+
+Google sign-in removed the password ceremony for most travelers; Apple users
+— especially anyone arriving on an iPhone or iPad — expect the same one-tap
+option, and Apple's Hide-My-Email appeals to privacy-conscious users. The
+identity machinery built for Google (external identities, one-time handoff
+codes, SSO-only accounts) is provider-agnostic, so Apple is a small delta.
+**This feature ships dark**: it requires Apple Developer Program enrollment
+(not yet done), so until credentials are configured the button is hidden and
+nothing changes for any user.
+
+## User Stories
+
+- As an **Apple-ecosystem visitor**, I want to create an account with my
+  Apple ID so that I don't need another password.
+- As a **privacy-conscious user**, I want to sign up with Hide My Email and
+  still get a working account.
+- As an **existing user**, I want signing in with Apple (same address) to
+  land me in my existing account, not a duplicate.
+
+## Acceptance Criteria
+
+- [ ] The sign-in screen shows "Continue with Apple" only when the server has
+      Apple credentials configured; with Google also configured, both buttons
+      share a single "or" divider.
+- [ ] Clicking it walks through Apple's consent sheet and lands the user in
+      the app signed in, without a password.
+- [ ] A first-time Apple user gets a new account using the name they shared
+      on the consent sheet (Apple sends it only that once), email
+      pre-verified, and sees the onboarding quiz.
+- [ ] Repeat Apple sign-ins land in the same account and keep that name.
+- [ ] A Hide-My-Email (private relay) signup creates a working account under
+      the relay address.
+- [ ] An Apple sign-in whose verified email matches an existing account signs
+      into and links that account — no duplicate; the original password keeps
+      working.
+- [ ] An unverified or missing Apple email is refused (takeover guard).
+- [ ] Cancelling the consent sheet, tampering with the redirect, or reusing
+      an expired handoff link shows the friendly error screen.
+- [ ] SSO-only accounts behave exactly as Google's: generic 401 on password
+      login, guided message on change-password, session-only deletion.
+- [ ] With no Apple credentials configured, the button is absent and all
+      existing auth (email+password, Google) is completely unaffected.
+
+## API Surface
+
+### `GET /api/v1/auth/apple/availability`
+- **Response:** `{available: bool}` — true only with full Apple credentials
+  and a database.
+
+### `GET /api/v1/auth/apple`
+- **Purpose:** starts the redirect flow. 503 when unconfigured.
+
+### `POST /api/v1/auth/apple/callback`
+- **Purpose:** Apple posts the result here (a cross-site form POST — unlike
+  Google's GET callback). Redirects to `/sso/<one-time code>` on success or
+  `/sso/error` on any failure.
+
+### `POST /api/v1/auth/sso/exchange`
+- **Purpose:** provider-neutral swap of the one-time code for a session
+  (`{user, token}`, identical to login). `/auth/google/exchange` remains as
+  an alias. 404 for invalid/expired/used codes.
+
+## Data Model
+
+- **Auth identity** — the existing table now accepts provider `apple`.
+- Everything else (handoff codes, SSO-only users) is reused unchanged.
+
+## Non-Goals
+
+- Native iOS/macOS Sign in with Apple (the ASAuthorization plugin flow).
+- ID-token signature verification against Apple's JWKS (same server-to-server
+  trust decision as Google; revisit if tokens ever arrive via a browser).
+- A "connected accounts" management UI / unlinking.
+- Registering the outbound-email domain with Apple's private relay is an ops
+  task (documented in plan.md), not part of this change.

--- a/specs/apple-sso/tasks.md
+++ b/specs/apple-sso/tasks.md
@@ -1,0 +1,56 @@
+# Tasks: Sign in with Apple
+
+> Dependency-ordered; built in one pass on branch apple-sso.
+
+## Persistence
+
+- [x] Migration `00048_apple_sso.sql`: provider CHECK → `('google','apple')`;
+      down deletes only stranded Apple-only accounts
+- [x] No sqlc changes (queries already provider-parameterized); `resetDB`
+      already truncates `auth_identities`
+
+## API (Go)
+
+- [x] `apple_oauth.go` — env getters, URL seams, ES256 client-secret JWT
+      (raw r||s), `flexBool`, `exchangeAppleCode` (no PKCE),
+      `parseAppleIDToken`, `parseAppleUserField`
+- [x] `apple_auth_handler.go` — availability / start (SameSite=None Secure
+      state cookie, form_post redirect) / POST callback /
+      `findOrCreateAppleUser` (name-once capture, relay-email friendly)
+- [x] `googleExchangeHandler` → `ssoExchangeHandler`; `/auth/sso/exchange` +
+      `/auth/google/exchange` alias; Apple routes registered (strict tier) +
+      startup log line
+- [x] Env samples: `src/packages/api/.env.sample`,
+      `dockerize/production/.env.sample` (four `APPLE_*` vars)
+
+## Tests (Go)
+
+- [x] `fake_apple_test.go` — in-test P-256 key; token endpoint verifies the
+      client-secret JWT with `ecdsa.Verify` and rejects `code_verifier`
+- [x] `apple_auth_integration_test.go` — 13 cases: availability, 503,
+      redirect contents (form_post, no PKCE, None+Secure cookie), state
+      mismatch, declined, happy path + name capture, repeat without `user`
+      field, auto-link, unverified/missing email refusal, string bools,
+      private relay, exchange single-use + alias, client-secret unit test
+
+## UI (Flutter)
+
+- [x] `appleSignInAvailable` + `exchangeSsoCode` → `/auth/sso/exchange`
+- [x] `appleSsoAvailableProvider`
+- [x] `sso_buttons.dart` (shared divider), slimmed
+      `google_sign_in_button.dart`, new `apple_sign_in_button.dart`
+      (`Icons.apple`, HIG black) — wired into `auth_screen.dart`
+- [x] `sso_callback_screen.dart` wording made provider-neutral
+
+## Tests (Flutter)
+
+- [x] `sso_buttons_test.dart` (4 availability combinations, single divider)
+- [x] `apple_sign_in_button_test.dart`, updated google/sso-callback tests
+
+## Verification
+
+- [x] Full Go suite green (Postgres test DB); Google suite unaffected by the
+      exchange rename
+- [x] `flutter analyze` clean + full widget suite green
+- [ ] Post-enrollment prod smoke (plan.md runbook step 7) — blocked on Apple
+      Developer Program enrollment

--- a/specs/google-sso/tasks.md
+++ b/specs/google-sso/tasks.md
@@ -49,5 +49,5 @@
 
 - [x] Full Go suite green against a Postgres test DB
 - [x] `flutter analyze` clean (no new issues) + widget tests green
-- [ ] Manual click-through with real Google credentials (needs a Web OAuth
-      client registered for http://localhost:3000/api/v1/auth/google/callback)
+- [x] Manual click-through with real Google credentials — verified on
+      production (goldentempotravel.com) 2026-07-20; consent screen published

--- a/src/packages/api/.env.sample
+++ b/src/packages/api/.env.sample
@@ -28,6 +28,18 @@ TRANSCRIPTION_MODEL=whisper-large-v3-turbo
 # auth is unaffected.
 GOOGLE_OAUTH_CLIENT_ID=
 GOOGLE_OAUTH_CLIENT_SECRET=
+# Sign in with Apple (specs/apple-sso). Requires Apple Developer Program
+# enrollment; see specs/apple-sso/plan.md for the console steps (Services ID,
+# domain + return URL registration, .p8 key). APPLE_CLIENT_ID is the Services
+# ID; APPLE_PRIVATE_KEY is the .p8 file base64-encoded to stay on one line:
+#   base64 -i AuthKey_<KEY_ID>.p8 | tr -d '\n'
+# Any of the four absent => the Apple button is hidden and /auth/apple
+# answers 503; everything else unaffected. Note: Apple rejects http/localhost
+# return URLs, so the browser flow only works against the prod domain.
+APPLE_TEAM_ID=
+APPLE_CLIENT_ID=
+APPLE_KEY_ID=
+APPLE_PRIVATE_KEY=
 CHROME_WS_URL=ws://chrome:9222/   # Set when running in Docker; leave empty to launch Chrome locally
 # Postgres connection. For local `make api-run`, point at localhost. In Docker the
 # compose stacks override this to use the `postgres` service host.

--- a/src/packages/api/apple_auth_handler.go
+++ b/src/packages/api/apple_auth_handler.go
@@ -1,0 +1,174 @@
+package main
+
+import (
+	"errors"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/jackc/pgx/v5"
+
+	"travel-route-planner/store"
+)
+
+// Sign in with Apple (specs/apple-sso), the sibling of google_auth_handler.go.
+// Same browser flow and /sso/<code> handoff, with three Apple deltas:
+//
+//   - the callback is a cross-site POST (`response_mode=form_post` is required
+//     when requesting the name/email scopes), so the state cookie must be
+//     SameSite=None; Secure — Lax cookies don't ride cross-site POSTs. Secure
+//     is unconditional: Apple rejects http/localhost return URLs, so a local
+//     browser flow is impossible either way (tests drive the router directly).
+//   - no PKCE (Apple doesn't support it); CSRF protection is the state cookie
+//     plus the one-time code plus the ES256 client secret.
+//   - the user's name arrives once, on the first authorization, as a `user`
+//     form field — never in the id_token.
+
+const appleStateCookie = "apple_oauth_state"
+
+func appleAvailabilityHandler(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, http.StatusOK, map[string]bool{
+		"available": appleOAuthConfigured() && dbPool != nil,
+	})
+}
+
+func appleStartHandler(w http.ResponseWriter, r *http.Request) {
+	if !appleOAuthConfigured() || dbPool == nil {
+		writeJSONError(w, http.StatusServiceUnavailable, "Apple sign-in is not configured")
+		return
+	}
+	state, err := randomURLToken()
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "could not start sign-in")
+		return
+	}
+	http.SetCookie(w, &http.Cookie{
+		Name:     appleStateCookie,
+		Value:    state,
+		Path:     "/api/v1/auth/apple",
+		MaxAge:   600,
+		HttpOnly: true,
+		Secure:   true,
+		SameSite: http.SameSiteNoneMode,
+	})
+	params := url.Values{
+		"client_id":     {appleClientID()},
+		"redirect_uri":  {appleRedirectURI()},
+		"response_type": {"code"},
+		"scope":         {"name email"},
+		"response_mode": {"form_post"},
+		"state":         {state},
+	}
+	http.Redirect(w, r, appleAuthURL()+"?"+params.Encode(), http.StatusFound)
+}
+
+// appleCallbackHandler receives Apple's form_post. It is still a top-level
+// browser navigation, so every failure redirects to the app's /sso/error
+// route (303 converts the POST to a GET).
+func appleCallbackHandler(w http.ResponseWriter, r *http.Request) {
+	redirectErr := func() {
+		http.Redirect(w, r, publicAppURL("sso/", "error"), http.StatusSeeOther)
+	}
+
+	cookie, cookieErr := r.Cookie(appleStateCookie)
+	http.SetCookie(w, &http.Cookie{
+		Name: appleStateCookie, Value: "", Path: "/api/v1/auth/apple",
+		MaxAge: -1, HttpOnly: true, Secure: true, SameSite: http.SameSiteNoneMode,
+	})
+
+	if !appleOAuthConfigured() || dbPool == nil {
+		redirectErr()
+		return
+	}
+	if err := r.ParseForm(); err != nil {
+		redirectErr()
+		return
+	}
+	if r.FormValue("error") != "" { // user cancelled the Apple sheet
+		redirectErr()
+		return
+	}
+	code := r.FormValue("code")
+	state := r.FormValue("state")
+	if code == "" || state == "" || cookieErr != nil || cookie.Value != state {
+		redirectErr()
+		return
+	}
+
+	claims, err := exchangeAppleCode(r.Context(), code)
+	if err != nil {
+		ctxLog(r.Context()).Error("apple oauth: code exchange failed", "error", err)
+		redirectErr()
+		return
+	}
+
+	user, err := findOrCreateAppleUser(r, claims, parseAppleUserField(r.FormValue("user")))
+	if err != nil {
+		ctxLog(r.Context()).Error("apple oauth: find-or-create failed", "error", err)
+		redirectErr()
+		return
+	}
+
+	handoff, err := issueEmailToken(r.Context(), store.New(dbPool), user, "sso", ssoHandoffTTL)
+	if err != nil {
+		ctxLog(r.Context()).Error("apple oauth: could not issue handoff code", "error", err)
+		redirectErr()
+		return
+	}
+	http.Redirect(w, r, publicAppURL("sso/", handoff), http.StatusSeeOther)
+}
+
+var errUnverifiedAppleEmail = errors.New("apple account email is missing or not verified")
+
+// findOrCreateAppleUser applies the same linking rules as Google's: known sub
+// signs in; a verified matching email auto-links; otherwise a new account is
+// created. Hide-My-Email relay addresses are verified, deliverable-via-relay
+// addresses — no special casing; they simply never match an existing account.
+// formName is the once-only name from the `user` form field.
+func findOrCreateAppleUser(r *http.Request, claims appleClaims, formName string) (store.User, error) {
+	ctx := r.Context()
+	q := store.New(dbPool)
+
+	ident, err := q.GetAuthIdentity(ctx, store.GetAuthIdentityParams{
+		Provider: "apple", ProviderUserID: claims.Sub,
+	})
+	if err == nil {
+		return q.GetUserByID(ctx, ident.UserID)
+	}
+	if !errors.Is(err, pgx.ErrNoRows) {
+		return store.User{}, err
+	}
+
+	email := strings.ToLower(strings.TrimSpace(claims.Email))
+	if email == "" || !bool(claims.EmailVerified) {
+		return store.User{}, errUnverifiedAppleEmail
+	}
+
+	user, err := q.GetUserByEmail(ctx, email)
+	if errors.Is(err, pgx.ErrNoRows) {
+		displayName := formName
+		if displayName == "" {
+			displayName = defaultDisplayName(email)
+		}
+		user, err = q.CreateUser(ctx, store.CreateUserParams{
+			Email: email, PasswordHash: nil, DisplayName: &displayName,
+		})
+		if err != nil {
+			return store.User{}, err
+		}
+		go recordEvent(user.ID, "user_registered", nil, map[string]any{"method": "apple"})
+	} else if err != nil {
+		return store.User{}, err
+	}
+
+	if _, err := q.CreateAuthIdentity(ctx, store.CreateAuthIdentityParams{
+		UserID: user.ID, Provider: "apple", ProviderUserID: claims.Sub, Email: &email,
+	}); err != nil {
+		return store.User{}, err
+	}
+	// Apple vouched for the address — no verification email needed.
+	if err := q.MarkUserEmailVerified(ctx, user.ID); err != nil {
+		return store.User{}, err
+	}
+	return q.GetUserByID(ctx, user.ID)
+}

--- a/src/packages/api/apple_auth_integration_test.go
+++ b/src/packages/api/apple_auth_integration_test.go
@@ -1,0 +1,369 @@
+package main
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"travel-route-planner/store"
+)
+
+// End-to-end tests for Sign in with Apple (specs/apple-sso), driven against
+// the fake token endpoint from fake_apple_test.go. Apple's consent sheet never
+// happens: tests capture state+cookie from /auth/apple and replay them to the
+// callback as the form_post POST a browser would deliver.
+
+func startApple(t *testing.T) (state string, cookie *http.Cookie) {
+	t.Helper()
+	req := httptest.NewRequest("GET", "/api/v1/auth/apple", nil)
+	req.Header.Set("X-Forwarded-For", nextTestIP())
+	rec := httptest.NewRecorder()
+	testRouter.ServeHTTP(rec, req)
+	if rec.Code != http.StatusFound {
+		t.Fatalf("/auth/apple = %d: %s", rec.Code, rec.Body.String())
+	}
+	loc, err := url.Parse(rec.Header().Get("Location"))
+	if err != nil {
+		t.Fatalf("parse redirect: %v", err)
+	}
+	state = loc.Query().Get("state")
+	for _, c := range rec.Result().Cookies() {
+		if c.Name == appleStateCookie {
+			cookie = c
+		}
+	}
+	if state == "" || cookie == nil {
+		t.Fatalf("start flow missing state (%q) or cookie", state)
+	}
+	return state, cookie
+}
+
+// appleCallback delivers Apple's cross-site form_post to the callback.
+func appleCallback(t *testing.T, form url.Values, cookie *http.Cookie) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest("POST", "/api/v1/auth/apple/callback", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("X-Forwarded-For", nextTestIP())
+	if cookie != nil {
+		req.AddCookie(cookie)
+	}
+	rec := httptest.NewRecorder()
+	testRouter.ServeHTTP(rec, req)
+	return rec
+}
+
+// appleSignIn runs the whole dance and returns the exchange response.
+// userField mimics the once-only `user` form field ("" to omit).
+func appleSignIn(t *testing.T, userField string) map[string]any {
+	t.Helper()
+	state, cookie := startApple(t)
+	form := url.Values{"code": {"fake-auth-code"}, "state": {state}}
+	if userField != "" {
+		form.Set("user", userField)
+	}
+	rec := appleCallback(t, form, cookie)
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("callback = %d: %s", rec.Code, rec.Body.String())
+	}
+	loc := rec.Header().Get("Location")
+	code := loc[strings.LastIndex(loc, "/")+1:]
+	if code == "error" || code == "" {
+		t.Fatalf("callback redirected to %q, want /sso/<code>", loc)
+	}
+	ex := doJSON(t, "POST", "/api/v1/auth/sso/exchange", "", map[string]any{"code": code})
+	if ex.Code != http.StatusOK {
+		t.Fatalf("exchange = %d: %s", ex.Code, ex.Body.String())
+	}
+	return decode(t, ex)
+}
+
+func TestAppleAvailability(t *testing.T) {
+	requireDB(t)
+	rec := doJSON(t, "GET", "/api/v1/auth/apple/availability", "", nil)
+	if rec.Code != http.StatusOK || decode(t, rec)["available"] != false {
+		t.Fatalf("unconfigured availability = %d %s, want available:false", rec.Code, rec.Body.String())
+	}
+
+	setupFakeApple(t, testAppleClaims("any@example.com"))
+	rec = doJSON(t, "GET", "/api/v1/auth/apple/availability", "", nil)
+	if rec.Code != http.StatusOK || decode(t, rec)["available"] != true {
+		t.Fatalf("configured availability = %d %s, want available:true", rec.Code, rec.Body.String())
+	}
+}
+
+func TestAppleStartUnconfigured(t *testing.T) {
+	requireDB(t)
+	req := httptest.NewRequest("GET", "/api/v1/auth/apple", nil)
+	req.Header.Set("X-Forwarded-For", nextTestIP())
+	rec := httptest.NewRecorder()
+	testRouter.ServeHTTP(rec, req)
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("/auth/apple unconfigured = %d, want 503", rec.Code)
+	}
+}
+
+func TestAppleStartRedirect(t *testing.T) {
+	requireDB(t)
+	setupFakeApple(t, testAppleClaims("any@example.com"))
+
+	req := httptest.NewRequest("GET", "/api/v1/auth/apple", nil)
+	req.Header.Set("X-Forwarded-For", nextTestIP())
+	rec := httptest.NewRecorder()
+	testRouter.ServeHTTP(rec, req)
+	if rec.Code != http.StatusFound {
+		t.Fatalf("/auth/apple = %d", rec.Code)
+	}
+	loc, err := url.Parse(rec.Header().Get("Location"))
+	if err != nil {
+		t.Fatalf("parse redirect: %v", err)
+	}
+	if loc.Host != "appleid.apple.com" {
+		t.Fatalf("redirect host = %q", loc.Host)
+	}
+	q := loc.Query()
+	if q.Get("client_id") != testAppleClientID ||
+		q.Get("response_type") != "code" ||
+		q.Get("response_mode") != "form_post" ||
+		q.Get("scope") != "name email" ||
+		q.Get("state") == "" {
+		t.Fatalf("redirect query incomplete: %s", loc.RawQuery)
+	}
+	if q.Get("code_challenge") != "" {
+		t.Fatal("Apple flow must not send PKCE code_challenge")
+	}
+	if q.Get("redirect_uri") != "http://localhost:3000/api/v1/auth/apple/callback" {
+		t.Fatalf("redirect_uri = %q", q.Get("redirect_uri"))
+	}
+	var cookie *http.Cookie
+	for _, c := range rec.Result().Cookies() {
+		if c.Name == appleStateCookie {
+			cookie = c
+		}
+	}
+	if cookie == nil || !cookie.HttpOnly || !cookie.Secure || cookie.SameSite != http.SameSiteNoneMode {
+		t.Fatalf("state cookie must be HttpOnly+Secure+SameSite=None: %+v", cookie)
+	}
+	// Cookie carries the bare state (no PKCE verifier appended).
+	if cookie.Value != q.Get("state") {
+		t.Fatalf("cookie value %q != redirect state %q", cookie.Value, q.Get("state"))
+	}
+}
+
+func TestAppleCallbackStateMismatch(t *testing.T) {
+	resetDB(t)
+	setupFakeApple(t, testAppleClaims("victim@example.com"))
+
+	_, cookie := startApple(t)
+	rec := appleCallback(t, url.Values{"code": {"fake-auth-code"}, "state": {"tampered"}}, cookie)
+	if rec.Code != http.StatusSeeOther || !strings.HasSuffix(rec.Header().Get("Location"), "/sso/error") {
+		t.Fatalf("tampered state → %d %q, want 303 /sso/error", rec.Code, rec.Header().Get("Location"))
+	}
+	if countRows(t, "users") != 0 {
+		t.Fatal("tampered callback must not create a user")
+	}
+}
+
+func TestAppleCallbackDeclined(t *testing.T) {
+	resetDB(t)
+	setupFakeApple(t, testAppleClaims("nope@example.com"))
+
+	state, cookie := startApple(t)
+	rec := appleCallback(t, url.Values{"error": {"user_cancelled"}, "state": {state}}, cookie)
+	if rec.Code != http.StatusSeeOther || !strings.HasSuffix(rec.Header().Get("Location"), "/sso/error") {
+		t.Fatalf("declined → %d %q, want 303 /sso/error", rec.Code, rec.Header().Get("Location"))
+	}
+}
+
+func TestAppleSignInHappyPathWithNameCapture(t *testing.T) {
+	resetDB(t)
+	setupFakeApple(t, testAppleClaims("newbie@apple-example.com"))
+
+	resp := appleSignIn(t, `{"name":{"firstName":"Ada","lastName":"Lovelace"},"email":"newbie@apple-example.com"}`)
+	token, _ := resp["token"].(string)
+	user, _ := resp["user"].(map[string]any)
+	if token == "" || user == nil {
+		t.Fatalf("exchange response malformed: %v", resp)
+	}
+	if user["email"] != "newbie@apple-example.com" || user["display_name"] != "Ada Lovelace" {
+		t.Fatalf("user payload wrong (name should come from the user form field): %v", user)
+	}
+	if user["needs_onboarding"] != true {
+		t.Fatal("fresh Apple user should owe the onboarding quiz")
+	}
+
+	me := doJSON(t, "GET", "/api/v1/auth/me", token, nil)
+	if me.Code != http.StatusOK {
+		t.Fatalf("/auth/me with SSO session = %d", me.Code)
+	}
+
+	dbUser, err := store.New(dbPool).GetUserByEmail(context.Background(), "newbie@apple-example.com")
+	if err != nil {
+		t.Fatalf("user not in DB: %v", err)
+	}
+	if !dbUser.EmailVerifiedAt.Valid || dbUser.PasswordHash != nil {
+		t.Fatal("Apple-created user should be email-verified with no password hash")
+	}
+	if countRows(t, "auth_identities") != 1 {
+		t.Fatal("expected one auth_identities row")
+	}
+}
+
+// The `user` field arrives only on the first authorization; repeats must
+// still resolve to the same account without it.
+func TestAppleRepeatSignInWithoutUserField(t *testing.T) {
+	resetDB(t)
+	setupFakeApple(t, testAppleClaims("repeat@apple-example.com"))
+
+	first := appleSignIn(t, `{"name":{"firstName":"Only","lastName":"Once"}}`)
+	second := appleSignIn(t, "")
+	u1, _ := first["user"].(map[string]any)
+	u2, _ := second["user"].(map[string]any)
+	if u1["id"] != u2["id"] {
+		t.Fatalf("same Apple sub produced two users: %v / %v", u1["id"], u2["id"])
+	}
+	if u2["display_name"] != "Only Once" {
+		t.Fatalf("display name should persist from first auth, got %v", u2["display_name"])
+	}
+	if countRows(t, "users") != 1 || countRows(t, "auth_identities") != 1 {
+		t.Fatal("repeat sign-in must not duplicate user or identity")
+	}
+}
+
+func TestAppleAutoLinkExistingEmail(t *testing.T) {
+	resetDB(t)
+	existing, _ := createTestUser(t, "linked@apple-example.com")
+	setupFakeApple(t, testAppleClaims("linked@apple-example.com"))
+
+	resp := appleSignIn(t, "")
+	user, _ := resp["user"].(map[string]any)
+	if user["id"] != existing.ID.String() {
+		t.Fatalf("verified Apple email should link to existing user %s, got %v", existing.ID, user["id"])
+	}
+	if countRows(t, "users") != 1 {
+		t.Fatal("auto-link must not create a second account")
+	}
+
+	login := doJSON(t, "POST", "/api/v1/auth/login", "", map[string]any{
+		"email": "linked@apple-example.com", "password": "password123",
+	})
+	if login.Code != http.StatusOK {
+		t.Fatalf("password login after link = %d", login.Code)
+	}
+}
+
+func TestAppleUnverifiedOrMissingEmailRefused(t *testing.T) {
+	resetDB(t)
+	createTestUser(t, "target@apple-example.com")
+
+	cases := map[string]map[string]any{
+		"bool false":    testAppleClaims("target@apple-example.com"),
+		"string false":  testAppleClaims("target@apple-example.com"),
+		"missing email": testAppleClaims("target@apple-example.com"),
+	}
+	cases["bool false"]["email_verified"] = false
+	cases["string false"]["email_verified"] = "false"
+	delete(cases["missing email"], "email")
+
+	for name, claims := range cases {
+		setupFakeApple(t, claims)
+		state, cookie := startApple(t)
+		rec := appleCallback(t, url.Values{"code": {"fake-auth-code"}, "state": {state}}, cookie)
+		if rec.Code != http.StatusSeeOther || !strings.HasSuffix(rec.Header().Get("Location"), "/sso/error") {
+			t.Fatalf("%s → %d %q, want 303 /sso/error", name, rec.Code, rec.Header().Get("Location"))
+		}
+	}
+	if countRows(t, "auth_identities") != 0 {
+		t.Fatal("unverified/missing Apple email must never link (takeover guard)")
+	}
+}
+
+// Apple sends booleans as strings sometimes; "true" must work end to end.
+func TestAppleEmailVerifiedAsString(t *testing.T) {
+	resetDB(t)
+	claims := testAppleClaims("stringy@apple-example.com")
+	claims["email_verified"] = "true"
+	setupFakeApple(t, claims)
+
+	resp := appleSignIn(t, "")
+	if user, _ := resp["user"].(map[string]any); user["email"] != "stringy@apple-example.com" {
+		t.Fatalf("string email_verified should sign in: %v", resp)
+	}
+}
+
+// Hide-My-Email relay addresses are verified real addresses; they create a
+// fresh account (they'll never match an existing email).
+func TestApplePrivateRelayEmail(t *testing.T) {
+	resetDB(t)
+	claims := testAppleClaims("abc123xyz@privaterelay.appleid.com")
+	claims["is_private_email"] = "true"
+	setupFakeApple(t, claims)
+
+	resp := appleSignIn(t, "")
+	user, _ := resp["user"].(map[string]any)
+	if user["email"] != "abc123xyz@privaterelay.appleid.com" {
+		t.Fatalf("relay email should create an account: %v", resp)
+	}
+	if countRows(t, "users") != 1 {
+		t.Fatal("expected exactly one account for the relay address")
+	}
+}
+
+func TestAppleExchangeCodeSingleUseAndAlias(t *testing.T) {
+	resetDB(t)
+	setupFakeApple(t, testAppleClaims("onceonly@apple-example.com"))
+
+	state, cookie := startApple(t)
+	rec := appleCallback(t, url.Values{"code": {"fake-auth-code"}, "state": {state}}, cookie)
+	loc := rec.Header().Get("Location")
+	code := loc[strings.LastIndex(loc, "/")+1:]
+
+	if ex := doJSON(t, "POST", "/api/v1/auth/sso/exchange", "", map[string]any{"code": code}); ex.Code != http.StatusOK {
+		t.Fatalf("first exchange = %d", ex.Code)
+	}
+	if ex := doJSON(t, "POST", "/api/v1/auth/sso/exchange", "", map[string]any{"code": code}); ex.Code != http.StatusNotFound {
+		t.Fatalf("replayed exchange = %d, want 404", ex.Code)
+	}
+
+	// The legacy /auth/google/exchange alias serves Apple handoff codes too
+	// (the 'sso' token carries no provider tag).
+	state2, cookie2 := startApple(t)
+	rec2 := appleCallback(t, url.Values{"code": {"fake-auth-code"}, "state": {state2}}, cookie2)
+	loc2 := rec2.Header().Get("Location")
+	code2 := loc2[strings.LastIndex(loc2, "/")+1:]
+	if ex := doJSON(t, "POST", "/api/v1/auth/google/exchange", "", map[string]any{"code": code2}); ex.Code != http.StatusOK {
+		t.Fatalf("google-alias exchange of apple code = %d, want 200", ex.Code)
+	}
+}
+
+func TestAppleClientSecretJWT(t *testing.T) {
+	// Unit test: valid ES256 JWT with raw r||s signature and 5-minute expiry.
+	// setupFakeApple's token server also verifies this on every exchange; this
+	// pins the details deterministically.
+	setupFakeApple(t, testAppleClaims("unit@apple-example.com")) // provides key env
+	now := time.Unix(1_770_000_000, 0)
+	secret, err := appleClientSecret(now)
+	if err != nil {
+		t.Fatalf("appleClientSecret: %v", err)
+	}
+	parts := strings.Split(secret, ".")
+	if len(parts) != 3 {
+		t.Fatalf("not a JWT: %q", secret)
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		t.Fatalf("decode payload: %v", err)
+	}
+	var claims struct{ Iat, Exp int64 }
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		t.Fatalf("claims: %v", err)
+	}
+	if claims.Exp-claims.Iat != 300 {
+		t.Fatalf("exp-iat = %d, want 300", claims.Exp-claims.Iat)
+	}
+}

--- a/src/packages/api/apple_oauth.go
+++ b/src/packages/api/apple_oauth.go
@@ -1,0 +1,225 @@
+package main
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Server-side Sign in with Apple client (specs/apple-sso), the sibling of
+// google_oauth.go. Same hand-rolled style and lazy-env/test-seam conventions.
+// Apple differences: the client_secret is an ES256-signed JWT built from a
+// .p8 key (not a static string), PKCE is not supported, and the callback is a
+// form_post POST (see apple_auth_handler.go).
+
+var appleOAuthHTTPClient = &http.Client{Timeout: 15 * time.Second}
+
+func appleTeamID() string   { return os.Getenv("APPLE_TEAM_ID") }
+func appleClientID() string { return os.Getenv("APPLE_CLIENT_ID") } // the Services ID
+func appleKeyID() string    { return os.Getenv("APPLE_KEY_ID") }
+
+// applePrivateKeyB64 is the .p8 file base64-encoded to survive env_file's
+// single-line rule: base64 -i AuthKey_<KEY_ID>.p8 | tr -d '\n'
+func applePrivateKeyB64() string { return os.Getenv("APPLE_PRIVATE_KEY") }
+
+func appleOAuthConfigured() bool {
+	return appleTeamID() != "" && appleClientID() != "" &&
+		appleKeyID() != "" && applePrivateKeyB64() != ""
+}
+
+func appleAuthURL() string {
+	if u := os.Getenv("APPLE_AUTH_URL"); u != "" {
+		return u
+	}
+	return "https://appleid.apple.com/auth/authorize"
+}
+
+func appleTokenURL() string {
+	if u := os.Getenv("APPLE_TOKEN_URL"); u != "" {
+		return u
+	}
+	return "https://appleid.apple.com/auth/token"
+}
+
+// appleRedirectURI must exactly match a Return URL registered on the Apple
+// Services ID.
+func appleRedirectURI() string {
+	return publicBaseURL() + "/api/v1/auth/apple/callback"
+}
+
+// appleClientSecret builds the ES256-signed JWT Apple requires as the
+// client_secret. Generated fresh per request with a short exp — Apple allows
+// up to 6 months but caching buys nothing at our volume.
+func appleClientSecret(now time.Time) (string, error) {
+	pemBytes, err := base64.StdEncoding.DecodeString(applePrivateKeyB64())
+	if err != nil {
+		return "", fmt.Errorf("APPLE_PRIVATE_KEY is not base64: %w", err)
+	}
+	block, _ := pem.Decode(pemBytes)
+	if block == nil {
+		return "", errors.New("APPLE_PRIVATE_KEY does not decode to PEM")
+	}
+	keyAny, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		return "", fmt.Errorf("APPLE_PRIVATE_KEY: %w", err)
+	}
+	key, ok := keyAny.(*ecdsa.PrivateKey)
+	if !ok {
+		return "", errors.New("APPLE_PRIVATE_KEY is not an ECDSA key")
+	}
+
+	header, err := json.Marshal(map[string]string{"alg": "ES256", "kid": appleKeyID()})
+	if err != nil {
+		return "", err
+	}
+	payload, err := json.Marshal(map[string]any{
+		"iss": appleTeamID(),
+		"sub": appleClientID(),
+		"aud": "https://appleid.apple.com",
+		"iat": now.Unix(),
+		"exp": now.Add(5 * time.Minute).Unix(),
+	})
+	if err != nil {
+		return "", err
+	}
+	signingInput := base64.RawURLEncoding.EncodeToString(header) + "." +
+		base64.RawURLEncoding.EncodeToString(payload)
+	sum := sha256.Sum256([]byte(signingInput))
+	r, s, err := ecdsa.Sign(rand.Reader, key, sum[:])
+	if err != nil {
+		return "", err
+	}
+	// JWT ES256 signatures are raw r||s with each half left-padded to 32
+	// bytes — not the ASN.1 DER that ecdsa.SignASN1 produces.
+	sig := make([]byte, 64)
+	r.FillBytes(sig[:32])
+	s.FillBytes(sig[32:])
+	return signingInput + "." + base64.RawURLEncoding.EncodeToString(sig), nil
+}
+
+// flexBool tolerates Apple sending booleans as JSON bools or as the strings
+// "true"/"false" (both occur in the wild for email_verified/is_private_email).
+type flexBool bool
+
+func (b *flexBool) UnmarshalJSON(data []byte) error {
+	v, err := strconv.ParseBool(strings.Trim(string(data), `"`))
+	if err != nil {
+		return fmt.Errorf("not a boolean: %s", data)
+	}
+	*b = flexBool(v)
+	return nil
+}
+
+type appleClaims struct {
+	Iss            string   `json:"iss"`
+	Aud            string   `json:"aud"`
+	Sub            string   `json:"sub"`
+	Email          string   `json:"email"`
+	EmailVerified  flexBool `json:"email_verified"`
+	IsPrivateEmail flexBool `json:"is_private_email"`
+	Exp            int64    `json:"exp"`
+}
+
+// exchangeAppleCode swaps the authorization code for tokens and returns the
+// validated ID-token claims. No PKCE verifier — Apple doesn't support it; the
+// ES256 client secret authenticates us instead. Signature verification is
+// skipped for the same reason as Google's: the token arrives directly from
+// Apple's token endpoint over TLS.
+func exchangeAppleCode(ctx context.Context, code string) (appleClaims, error) {
+	secret, err := appleClientSecret(time.Now())
+	if err != nil {
+		return appleClaims{}, err
+	}
+	form := url.Values{
+		"code":          {code},
+		"client_id":     {appleClientID()},
+		"client_secret": {secret},
+		"redirect_uri":  {appleRedirectURI()},
+		"grant_type":    {"authorization_code"},
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, appleTokenURL(), strings.NewReader(form.Encode()))
+	if err != nil {
+		return appleClaims{}, err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	resp, err := appleOAuthHTTPClient.Do(req)
+	if err != nil {
+		return appleClaims{}, err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return appleClaims{}, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return appleClaims{}, fmt.Errorf("token endpoint returned %d: %s", resp.StatusCode, body)
+	}
+	var tok struct {
+		IDToken string `json:"id_token"`
+	}
+	if err := json.Unmarshal(body, &tok); err != nil {
+		return appleClaims{}, err
+	}
+	return parseAppleIDToken(tok.IDToken)
+}
+
+func parseAppleIDToken(idToken string) (appleClaims, error) {
+	parts := strings.Split(idToken, ".")
+	if len(parts) != 3 {
+		return appleClaims{}, errors.New("id_token is not a JWT")
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return appleClaims{}, fmt.Errorf("id_token payload: %w", err)
+	}
+	var claims appleClaims
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return appleClaims{}, fmt.Errorf("id_token claims: %w", err)
+	}
+	if claims.Iss != "https://appleid.apple.com" {
+		return appleClaims{}, fmt.Errorf("unexpected issuer %q", claims.Iss)
+	}
+	if claims.Aud != appleClientID() {
+		return appleClaims{}, errors.New("id_token audience mismatch")
+	}
+	if claims.Exp <= time.Now().Unix() {
+		return appleClaims{}, errors.New("id_token expired")
+	}
+	if claims.Sub == "" {
+		return appleClaims{}, errors.New("id_token missing sub")
+	}
+	return claims, nil
+}
+
+// parseAppleUserField extracts a display name from the `user` form field
+// Apple posts on the FIRST authorization only (never in the id_token).
+// Best-effort: any parse failure just yields "".
+func parseAppleUserField(raw string) string {
+	if raw == "" {
+		return ""
+	}
+	var u struct {
+		Name struct {
+			FirstName string `json:"firstName"`
+			LastName  string `json:"lastName"`
+		} `json:"name"`
+	}
+	if err := json.Unmarshal([]byte(raw), &u); err != nil {
+		return ""
+	}
+	return strings.TrimSpace(strings.TrimSpace(u.Name.FirstName) + " " + strings.TrimSpace(u.Name.LastName))
+}

--- a/src/packages/api/fake_apple_test.go
+++ b/src/packages/api/fake_apple_test.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Fake Apple token endpoint (sibling of fake_google_test.go), pointed at via
+// the APPLE_TOKEN_URL env seam. Unlike the Google fake it VERIFIES the ES256
+// client-secret JWT against a real in-test P-256 key — so a DER-vs-raw
+// signature mistake in appleClientSecret fails loudly — and it rejects any
+// request carrying code_verifier (Apple has no PKCE).
+
+const (
+	testAppleClientID = "com.goldentempotravel.web"
+	testAppleTeamID   = "TESTTEAM01"
+	testAppleKeyID    = "TESTKEY123"
+)
+
+// fakeAppleIDToken takes claims as a map so tests can mimic Apple's habit of
+// sending booleans as the strings "true"/"false".
+func fakeAppleIDToken(t *testing.T, claims map[string]any) string {
+	t.Helper()
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"RS256","typ":"JWT"}`))
+	payload, err := json.Marshal(claims)
+	if err != nil {
+		t.Fatalf("marshal claims: %v", err)
+	}
+	return header + "." + base64.RawURLEncoding.EncodeToString(payload) + ".x"
+}
+
+func testAppleClaims(email string) map[string]any {
+	return map[string]any{
+		"iss":            "https://appleid.apple.com",
+		"aud":            testAppleClientID,
+		"sub":            "apple-sub-" + email,
+		"email":          email,
+		"email_verified": true,
+		"exp":            time.Now().Add(time.Hour).Unix(),
+	}
+}
+
+// verifyAppleClientSecret checks the JWT the server sent as client_secret:
+// ES256 header with our kid, iss/sub/aud claims, and a raw 64-byte r||s
+// signature that verifies against pub.
+func verifyAppleClientSecret(t *testing.T, secret string, pub *ecdsa.PublicKey) bool {
+	t.Helper()
+	parts := strings.Split(secret, ".")
+	if len(parts) != 3 {
+		return false
+	}
+	headerJSON, err := base64.RawURLEncoding.DecodeString(parts[0])
+	if err != nil {
+		return false
+	}
+	var header struct{ Alg, Kid string }
+	if json.Unmarshal(headerJSON, &header) != nil || header.Alg != "ES256" || header.Kid != testAppleKeyID {
+		return false
+	}
+	claimsJSON, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return false
+	}
+	var claims struct {
+		Iss, Sub, Aud string
+		Iat, Exp      int64
+	}
+	if json.Unmarshal(claimsJSON, &claims) != nil ||
+		claims.Iss != testAppleTeamID || claims.Sub != testAppleClientID ||
+		claims.Aud != "https://appleid.apple.com" || claims.Exp <= claims.Iat {
+		return false
+	}
+	sig, err := base64.RawURLEncoding.DecodeString(parts[2])
+	if err != nil || len(sig) != 64 {
+		return false
+	}
+	sum := sha256.Sum256([]byte(parts[0] + "." + parts[1]))
+	r := new(big.Int).SetBytes(sig[:32])
+	s := new(big.Int).SetBytes(sig[32:])
+	return ecdsa.Verify(pub, sum[:], r, s)
+}
+
+// setupFakeApple configures the Apple OAuth env with a freshly generated
+// P-256 key and serves a token endpoint answering with the given claims.
+func setupFakeApple(t *testing.T, claims map[string]any) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	der, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		t.Fatalf("marshal key: %v", err)
+	}
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der})
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		if r.FormValue("code_verifier") != "" { // Apple has no PKCE
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		if r.FormValue("code") == "" || r.FormValue("client_id") != testAppleClientID ||
+			!verifyAppleClientSecret(t, r.FormValue("client_secret"), &key.PublicKey) {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		json.NewEncoder(w).Encode(map[string]string{"id_token": fakeAppleIDToken(t, claims)})
+	}))
+	t.Cleanup(srv.Close)
+
+	t.Setenv("APPLE_TEAM_ID", testAppleTeamID)
+	t.Setenv("APPLE_CLIENT_ID", testAppleClientID)
+	t.Setenv("APPLE_KEY_ID", testAppleKeyID)
+	t.Setenv("APPLE_PRIVATE_KEY", base64.StdEncoding.EncodeToString(pemBytes))
+	t.Setenv("APPLE_TOKEN_URL", srv.URL)
+}

--- a/src/packages/api/google_auth_handler.go
+++ b/src/packages/api/google_auth_handler.go
@@ -182,9 +182,10 @@ func findOrCreateGoogleUser(r *http.Request, claims googleClaims) (store.User, e
 	return q.GetUserByID(ctx, user.ID)
 }
 
-// googleExchangeHandler swaps the one-time handoff code for a real session.
-// Response shape matches login so the app can adopt it directly.
-func googleExchangeHandler(w http.ResponseWriter, r *http.Request) {
+// ssoExchangeHandler swaps the one-time handoff code for a real session.
+// Response shape matches login so the app can adopt it directly. Provider-
+// agnostic: the 'sso' tokens Google and Apple callbacks issue are identical.
+func ssoExchangeHandler(w http.ResponseWriter, r *http.Request) {
 	if dbPool == nil {
 		writeJSONError(w, http.StatusServiceUnavailable, "database unavailable")
 		return

--- a/src/packages/api/main.go
+++ b/src/packages/api/main.go
@@ -787,7 +787,15 @@ func buildRouter() *mux.Router {
 	api.HandleFunc("/auth/google/availability", googleAvailabilityHandler).Methods("GET")
 	api.Handle("/auth/google", strict(http.HandlerFunc(googleStartHandler))).Methods("GET")
 	api.Handle("/auth/google/callback", strict(http.HandlerFunc(googleCallbackHandler))).Methods("GET")
-	api.Handle("/auth/google/exchange", strict(http.HandlerFunc(googleExchangeHandler))).Methods("POST")
+	// The exchange is provider-agnostic; /auth/google/exchange stays as an
+	// alias for handoff codes in-flight across a deploy.
+	api.Handle("/auth/sso/exchange", strict(http.HandlerFunc(ssoExchangeHandler))).Methods("POST")
+	api.Handle("/auth/google/exchange", strict(http.HandlerFunc(ssoExchangeHandler))).Methods("POST")
+	// Sign in with Apple (specs/apple-sso). Same flow, three deltas: POST
+	// form_post callback, no PKCE, ES256 client-secret JWT.
+	api.HandleFunc("/auth/apple/availability", appleAvailabilityHandler).Methods("GET")
+	api.Handle("/auth/apple", strict(http.HandlerFunc(appleStartHandler))).Methods("GET")
+	api.Handle("/auth/apple/callback", strict(http.HandlerFunc(appleCallbackHandler))).Methods("POST")
 	// admin composes the auth + admin gate; used for curation and version-history routes.
 	admin := func(h http.HandlerFunc) http.Handler { return authMiddleware(adminMiddleware(h)) }
 	api.Handle("/trips", authMiddleware(http.HandlerFunc(listTripsHandler))).Methods("GET")
@@ -957,6 +965,7 @@ func startServer(router *mux.Router) {
 	log.Printf("  POST /api/v1/auth/register      - Register")
 	log.Printf("  POST /api/v1/auth/login         - Login")
 	log.Printf("  GET  /api/v1/auth/google        - Sign in with Google (redirect flow)")
+	log.Printf("  GET  /api/v1/auth/apple         - Sign in with Apple (redirect flow)")
 	log.Printf("  POST /api/v1/auth/logout        - Logout (auth)")
 	log.Printf("  GET  /api/v1/auth/me            - Current user (auth)")
 	log.Printf("  POST /api/v1/auth/onboarding-complete - Mark onboarding done (auth)")

--- a/src/packages/api/migrations/00048_apple_sso.sql
+++ b/src/packages/api/migrations/00048_apple_sso.sql
@@ -1,0 +1,17 @@
+-- +goose Up
+-- Sign in with Apple (specs/apple-sso): second identity provider.
+ALTER TABLE auth_identities DROP CONSTRAINT auth_identities_provider_check;
+ALTER TABLE auth_identities ADD CONSTRAINT auth_identities_provider_check
+    CHECK (provider IN ('google', 'apple'));
+
+-- +goose Down
+DELETE FROM auth_identities WHERE provider = 'apple';
+-- Accounts whose ONLY sign-in method was Apple are unreachable afterwards
+-- (no password, no remaining identity) — remove them, like 00032's down does
+-- for SSO-only users. Apple-linked password/Google accounts survive.
+DELETE FROM users u
+ WHERE u.password_hash IS NULL
+   AND NOT EXISTS (SELECT 1 FROM auth_identities ai WHERE ai.user_id = u.id);
+ALTER TABLE auth_identities DROP CONSTRAINT auth_identities_provider_check;
+ALTER TABLE auth_identities ADD CONSTRAINT auth_identities_provider_check
+    CHECK (provider IN ('google'));

--- a/src/packages/flutter-app/lib/providers/auth_provider.dart
+++ b/src/packages/flutter-app/lib/providers/auth_provider.dart
@@ -22,6 +22,11 @@ final googleSsoAvailableProvider = FutureProvider<bool>((ref) {
   return ref.watch(authServiceProvider).googleSignInAvailable();
 });
 
+/// Whether the backend has Apple sign-in configured (specs/apple-sso).
+final appleSsoAvailableProvider = FutureProvider<bool>((ref) {
+  return ref.watch(authServiceProvider).appleSignInAvailable();
+});
+
 class AuthState {
   final UserModel? user;
   final bool initialized; // false until the stored token has been checked

--- a/src/packages/flutter-app/lib/screens/auth_screen.dart
+++ b/src/packages/flutter-app/lib/screens/auth_screen.dart
@@ -5,7 +5,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../providers/auth_provider.dart';
 import '../widgets/brand_logo.dart';
-import '../widgets/google_sign_in_button.dart';
+import '../widgets/sso_buttons.dart';
 import '../widgets/legal_links.dart';
 import '../utils/snack.dart';
 
@@ -260,7 +260,7 @@ class _AuthScreenState extends ConsumerState<AuthScreen> {
                         onPressed: auth.loading ? null : _forgotPassword,
                         child: const Text('Forgot password?'),
                       ),
-                    const GoogleSignInButton(),
+                    const SsoButtons(),
                   ],
                 ),
               ),

--- a/src/packages/flutter-app/lib/screens/sso_callback_screen.dart
+++ b/src/packages/flutter-app/lib/screens/sso_callback_screen.dart
@@ -3,10 +3,11 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../providers/auth_provider.dart';
 import '../widgets/gradient_app_bar.dart';
 
-/// Landing spot for the Google sign-in redirect, reachable at /sso/<code>
-/// (specs/google-sso). Swaps the one-time code for a session on load and
-/// hands it to the auth provider; /sso/error means the OAuth flow itself
-/// failed (declined consent, expired state, unverified Google email).
+/// Landing spot for the SSO redirect (Google or Apple), reachable at
+/// /sso/<code> (specs/google-sso, specs/apple-sso). Swaps the one-time code
+/// for a session on load and hands it to the auth provider; /sso/error means
+/// the OAuth flow itself failed (declined consent, expired state, unverified
+/// provider email).
 class SsoCallbackScreen extends ConsumerStatefulWidget {
   final String code;
   const SsoCallbackScreen({super.key, required this.code});
@@ -29,7 +30,7 @@ class _SsoCallbackScreenState extends ConsumerState<SsoCallbackScreen> {
     if (widget.code == 'error') {
       setState(() {
         _loading = false;
-        _error = 'Google sign-in was cancelled or failed. Please try again.';
+        _error = 'Sign-in was cancelled or failed. Please try again.';
       });
       return;
     }

--- a/src/packages/flutter-app/lib/services/auth_service.dart
+++ b/src/packages/flutter-app/lib/services/auth_service.dart
@@ -122,11 +122,27 @@ class AuthService {
     }
   }
 
+  /// Whether the server has Apple sign-in configured. False on any error so
+  /// the button simply stays hidden when the backend is unreachable.
+  Future<bool> appleSignInAvailable() async {
+    try {
+      final res = await httpClient.get(
+        Uri.parse('$baseUrl/auth/apple/availability'),
+      );
+      if (res.statusCode != 200) return false;
+      final body = jsonDecode(res.body);
+      return body is Map && body['available'] == true;
+    } catch (_) {
+      return false;
+    }
+  }
+
   /// Swaps the one-time code from the /sso/<code> redirect for a real
-  /// session. Codes are single-use and expire after a minute.
+  /// session. Codes are single-use, provider-agnostic (Google or Apple),
+  /// and expire after a minute.
   Future<AuthResponse> exchangeSsoCode(String code) async {
     final res = await httpClient.post(
-      Uri.parse('$baseUrl/auth/google/exchange'),
+      Uri.parse('$baseUrl/auth/sso/exchange'),
       headers: const {'Content-Type': 'application/json'},
       body: jsonEncode({'code': code}),
     );

--- a/src/packages/flutter-app/lib/widgets/apple_sign_in_button.dart
+++ b/src/packages/flutter-app/lib/widgets/apple_sign_in_button.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:url_launcher/url_launcher.dart';
+import '../providers/api_client_provider.dart';
+import '../providers/auth_provider.dart';
+
+/// "Continue with Apple" (specs/apple-sso). Same server-side redirect flow as
+/// the Google button — the whole tab navigates to /auth/apple and comes back
+/// to /sso/<code> — styled per Apple's HIG (black fill, white logo + text).
+/// Renders nothing when the backend has no Apple credentials configured.
+class AppleSignInButton extends ConsumerWidget {
+  const AppleSignInButton({super.key});
+
+  void _start(WidgetRef ref) {
+    final base = ref.read(apiClientProvider).baseUrl;
+    // In Docker the base URL is the relative /api/v1; resolve it against the
+    // page origin because launchUrl needs an absolute URL.
+    final url = base.startsWith('http')
+        ? '$base/auth/apple'
+        : Uri.base.resolve('$base/auth/apple').toString();
+    launchUrl(Uri.parse(url), webOnlyWindowName: '_self');
+  }
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final available = ref.watch(appleSsoAvailableProvider);
+    if (available.valueOrNull != true) return const SizedBox.shrink();
+    return FilledButton.icon(
+      onPressed: () => _start(ref),
+      // Material Icons ships an Apple glyph — no bundled asset needed
+      // (unlike the Google "G", which has no font equivalent).
+      icon: const Icon(Icons.apple, size: 22),
+      label: const Text('Continue with Apple'),
+      style: FilledButton.styleFrom(
+        backgroundColor: Colors.black,
+        foregroundColor: Colors.white,
+        padding: const EdgeInsets.symmetric(vertical: 16),
+      ),
+    );
+  }
+}

--- a/src/packages/flutter-app/lib/widgets/google_sign_in_button.dart
+++ b/src/packages/flutter-app/lib/widgets/google_sign_in_button.dart
@@ -4,9 +4,9 @@ import 'package:url_launcher/url_launcher.dart';
 import '../providers/api_client_provider.dart';
 import '../providers/auth_provider.dart';
 
-/// "Continue with Google" (specs/google-sso), including the OR divider above
-/// it. Renders nothing while availability is unknown or when the backend has
-/// no OAuth client configured, so the auth form is unchanged in that case.
+/// "Continue with Google" (specs/google-sso). Renders nothing while
+/// availability is unknown or when the backend has no OAuth client
+/// configured. The shared "or" divider lives in SsoButtons.
 ///
 /// Not a plugin flow: the whole tab navigates to the API's /auth/google
 /// endpoint and comes back to /sso/<code> after the Google redirect dance,
@@ -29,35 +29,17 @@ class GoogleSignInButton extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final available = ref.watch(googleSsoAvailableProvider);
     if (available.valueOrNull != true) return const SizedBox.shrink();
-    final theme = Theme.of(context);
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      children: [
-        const SizedBox(height: 20),
-        Row(
-          children: [
-            const Expanded(child: Divider()),
-            Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 12),
-              child: Text('or', style: theme.textTheme.bodySmall),
-            ),
-            const Expanded(child: Divider()),
-          ],
-        ),
-        const SizedBox(height: 20),
-        OutlinedButton.icon(
-          onPressed: () => _start(ref),
-          icon: Image.asset(
-            'assets/images/google_g_logo.png',
-            height: 20,
-            width: 20,
-          ),
-          label: const Text('Continue with Google'),
-          style: OutlinedButton.styleFrom(
-            padding: const EdgeInsets.symmetric(vertical: 16),
-          ),
-        ),
-      ],
+    return OutlinedButton.icon(
+      onPressed: () => _start(ref),
+      icon: Image.asset(
+        'assets/images/google_g_logo.png',
+        height: 20,
+        width: 20,
+      ),
+      label: const Text('Continue with Google'),
+      style: OutlinedButton.styleFrom(
+        padding: const EdgeInsets.symmetric(vertical: 16),
+      ),
     );
   }
 }

--- a/src/packages/flutter-app/lib/widgets/sso_buttons.dart
+++ b/src/packages/flutter-app/lib/widgets/sso_buttons.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../providers/auth_provider.dart';
+import 'apple_sign_in_button.dart';
+import 'google_sign_in_button.dart';
+
+/// The SSO section of the auth screen: one "or" divider above whichever
+/// provider buttons the backend has configured (Google, then Apple). Renders
+/// nothing when no provider is available, leaving the form unchanged.
+class SsoButtons extends ConsumerWidget {
+  const SsoButtons({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final google = ref.watch(googleSsoAvailableProvider).valueOrNull == true;
+    final apple = ref.watch(appleSsoAvailableProvider).valueOrNull == true;
+    if (!google && !apple) return const SizedBox.shrink();
+    final theme = Theme.of(context);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        const SizedBox(height: 20),
+        Row(
+          children: [
+            const Expanded(child: Divider()),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 12),
+              child: Text('or', style: theme.textTheme.bodySmall),
+            ),
+            const Expanded(child: Divider()),
+          ],
+        ),
+        const SizedBox(height: 20),
+        if (google) const GoogleSignInButton(),
+        if (google && apple) const SizedBox(height: 12),
+        if (apple) const AppleSignInButton(),
+      ],
+    );
+  }
+}

--- a/src/packages/flutter-app/test/apple_sign_in_button_test.dart
+++ b/src/packages/flutter-app/test/apple_sign_in_button_test.dart
@@ -4,18 +4,17 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:travel_route_planner/providers/auth_provider.dart';
 import 'package:travel_route_planner/services/auth_service.dart';
 import 'package:travel_route_planner/services/auth_storage.dart';
-import 'package:travel_route_planner/widgets/google_sign_in_button.dart';
+import 'package:travel_route_planner/widgets/apple_sign_in_button.dart';
 
-/// AuthService with a scripted availability answer.
+/// AuthService with a scripted Apple availability answer.
 class _FakeAuthService extends AuthService {
   final bool available;
   _FakeAuthService({required this.available}) : super(baseUrl: 'http://unused');
 
   @override
-  Future<bool> googleSignInAvailable() async => available;
+  Future<bool> appleSignInAvailable() async => available;
 }
 
-/// In-memory AuthStorage so the auth provider never touches secure storage.
 class _FakeAuthStorage extends AuthStorage {
   @override
   Future<String?> loadToken() async => null;
@@ -30,29 +29,31 @@ class _FakeAuthStorage extends AuthStorage {
 Widget _wrap({required bool available}) {
   return ProviderScope(
     overrides: [
-      authServiceProvider.overrideWithValue(_FakeAuthService(available: available)),
+      authServiceProvider
+          .overrideWithValue(_FakeAuthService(available: available)),
       authStorageProvider.overrideWithValue(_FakeAuthStorage()),
     ],
     child: const MaterialApp(
-      home: Scaffold(body: GoogleSignInButton()),
+      home: Scaffold(body: AppleSignInButton()),
     ),
   );
 }
 
 void main() {
-  testWidgets('renders nothing when the backend has no Google OAuth client',
+  testWidgets('renders nothing when the backend has no Apple credentials',
       (tester) async {
     await tester.pumpWidget(_wrap(available: false));
     await tester.pumpAndSettle();
 
-    expect(find.text('Continue with Google'), findsNothing);
+    expect(find.text('Continue with Apple'), findsNothing);
   });
 
-  testWidgets('shows the button when Google sign-in is available',
+  testWidgets('shows the black HIG button when Apple sign-in is available',
       (tester) async {
     await tester.pumpWidget(_wrap(available: true));
     await tester.pumpAndSettle();
 
-    expect(find.text('Continue with Google'), findsOneWidget);
+    expect(find.text('Continue with Apple'), findsOneWidget);
+    expect(find.byIcon(Icons.apple), findsOneWidget);
   });
 }

--- a/src/packages/flutter-app/test/sso_buttons_test.dart
+++ b/src/packages/flutter-app/test/sso_buttons_test.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:travel_route_planner/providers/auth_provider.dart';
+import 'package:travel_route_planner/services/auth_service.dart';
+import 'package:travel_route_planner/services/auth_storage.dart';
+import 'package:travel_route_planner/widgets/sso_buttons.dart';
+
+/// AuthService with scripted availability per provider.
+class _FakeAuthService extends AuthService {
+  final bool google;
+  final bool apple;
+  _FakeAuthService({required this.google, required this.apple})
+      : super(baseUrl: 'http://unused');
+
+  @override
+  Future<bool> googleSignInAvailable() async => google;
+
+  @override
+  Future<bool> appleSignInAvailable() async => apple;
+}
+
+class _FakeAuthStorage extends AuthStorage {
+  @override
+  Future<String?> loadToken() async => null;
+
+  @override
+  Future<void> saveToken(String value) async {}
+
+  @override
+  Future<void> clearToken() async {}
+}
+
+Widget _wrap({required bool google, required bool apple}) {
+  return ProviderScope(
+    overrides: [
+      authServiceProvider
+          .overrideWithValue(_FakeAuthService(google: google, apple: apple)),
+      authStorageProvider.overrideWithValue(_FakeAuthStorage()),
+    ],
+    child: const MaterialApp(
+      home: Scaffold(body: SsoButtons()),
+    ),
+  );
+}
+
+void main() {
+  testWidgets('renders nothing when no provider is configured',
+      (tester) async {
+    await tester.pumpWidget(_wrap(google: false, apple: false));
+    await tester.pumpAndSettle();
+
+    expect(find.text('or'), findsNothing);
+    expect(find.text('Continue with Google'), findsNothing);
+    expect(find.text('Continue with Apple'), findsNothing);
+  });
+
+  testWidgets('one divider and one button when only Google is available',
+      (tester) async {
+    await tester.pumpWidget(_wrap(google: true, apple: false));
+    await tester.pumpAndSettle();
+
+    expect(find.text('or'), findsOneWidget);
+    expect(find.text('Continue with Google'), findsOneWidget);
+    expect(find.text('Continue with Apple'), findsNothing);
+  });
+
+  testWidgets('one divider and one button when only Apple is available',
+      (tester) async {
+    await tester.pumpWidget(_wrap(google: false, apple: true));
+    await tester.pumpAndSettle();
+
+    expect(find.text('or'), findsOneWidget);
+    expect(find.text('Continue with Apple'), findsOneWidget);
+    expect(find.text('Continue with Google'), findsNothing);
+  });
+
+  testWidgets('both buttons under a single divider when both are available',
+      (tester) async {
+    await tester.pumpWidget(_wrap(google: true, apple: true));
+    await tester.pumpAndSettle();
+
+    expect(find.text('or'), findsOneWidget);
+    expect(find.text('Continue with Google'), findsOneWidget);
+    expect(find.text('Continue with Apple'), findsOneWidget);
+  });
+}

--- a/src/packages/flutter-app/test/sso_callback_screen_test.dart
+++ b/src/packages/flutter-app/test/sso_callback_screen_test.dart
@@ -92,7 +92,7 @@ void main() {
 
     expect(service.exchangedCode, isNull);
     expect(
-      find.text('Google sign-in was cancelled or failed. Please try again.'),
+      find.text('Sign-in was cancelled or failed. Please try again.'),
       findsOneWidget,
     );
     expect(find.text('Back to sign in'), findsOneWidget);


### PR DESCRIPTION
## Summary
- **Sign in with Apple** (specs/apple-sso): second SSO provider on the provider-agnostic machinery from #110 — `auth_identities` (CHECK widened by migration 00048), the 60s `'sso'` handoff codes, and the `/sso/<code>` route are all reused.
- Apple-specific handling: **ES256 client-secret JWT** signed with the `.p8` key via stdlib crypto (raw `r||s` signature — the test fake verifies it with `ecdsa.Verify`); **cross-site `form_post` callback** (POST route + `SameSite=None; Secure` state cookie); **no PKCE** (fake rejects `code_verifier` at the wire); once-only name capture from the `user` form field; `flexBool` for Apple's string-typed boolean claims; Hide-My-Email relay addresses treated as normal verified emails.
- Exchange endpoint generalized to **`/auth/sso/exchange`** (`/auth/google/exchange` kept as an alias for in-flight codes).
- Flutter: new `SsoButtons` wrapper owns the shared "or" divider; HIG-styled black Apple button using the built-in `Icons.apple` glyph (no asset); provider-neutral callback wording.
- **Ships dark**: all four `APPLE_*` env vars unset ⇒ button hidden, `/auth/apple` answers 503, nothing else changes. Enrollment runbook (Services ID, return URL, `.p8` key, email-relay registration) in `specs/apple-sso/plan.md`.

## Testing
- 13 new Go integration cases (`apple_auth_integration_test.go` + `fake_apple_test.go` with an in-test P-256 key): redirect contents (form_post/no-PKCE/None+Secure cookie), state tampering, declined sheet, happy path with name capture, repeat-sub without the `user` field, email auto-link, unverified/missing-email refusal (bool and string forms), private-relay signup, exchange single-use + google alias, client-secret JWT unit test. Full Go suite green against Postgres (Google suite unaffected by the exchange rename).
- Flutter: new `sso_buttons_test.dart` (4 availability combinations) + `apple_sign_in_button_test.dart`; full suite green (384 tests), `flutter analyze` at baseline.
- Not manually testable pre-enrollment (Apple rejects http/localhost return URLs); post-enrollment smoke steps documented in the spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)