### PR TITLE
feat(i18n): server locale foundation for Spanish support (PR 1/7)

### DIFF
--- a/specs/i18n-spanish/plan.md
+++ b/specs/i18n-spanish/plan.md
@@ -1,0 +1,163 @@
+# Plan: Spanish Localization (i18n)
+
+> See `../../CLAUDE.md` for repo conventions referenced below.
+
+## Technical Approach
+
+Both packages are greenfield for i18n — there is no localization layer to
+migrate around, and no locale is carried anywhere today. The shape of the
+solution is therefore: **resolve the locale exactly once, on the client, and
+carry it everywhere.**
+
+Four decisions drive the rest:
+
+1. **The client owns resolution.** Flutter computes an *effective locale*
+   (explicit override, else device locale, else English) and sends it on every
+   request as `Accept-Language`. The server never re-derives it and never reads
+   the DB to find it. One resolution point means the override cannot disagree
+   with the header.
+2. **The stored locale lives on `users`, not `traveler_preferences`.** Locale
+   is app configuration, not travel taste. The background email jobs
+   (`reengagement_checker.go`, `price_alert_checker.go`) run with no request and
+   already read the users row, so a column there is free to join; a
+   `traveler_preferences` column would add a LEFT JOIN to every one of them
+   *and* would put locale inside the AI's `save_preferences` tool, which must
+   not be able to change it. This mirrors `00044_email_prefs.sql`.
+   The stored value is used **only** where there is no request: background
+   email, and token-gated exports.
+3. **Localize what users read, not what developers read.** Emails, trip-review
+   findings, export pages and `.ics` labels go through a catalog. The ~hundreds
+   of `writeJSONError` strings do not (see spec → Out of Scope).
+4. **The English path stays byte-identical.** Every server-side change is gated
+   on `locale != "en"`, and the AI system prompt in particular is only appended
+   to for non-English requests — so English prompt-cache behavior and English
+   output are provably unchanged. This is the single most important invariant
+   in the feature and has a dedicated regression test.
+
+Sequencing: the Flutter string extraction is ~800 literals, so `es` is **not**
+added to `supportedLocales` until the very last PR. Every extraction PR is
+therefore behavior-neutral and independently shippable, and the risky enablement
+is one small, revertable change.
+
+## Go API Changes
+
+`src/packages/api/` (all `package main`):
+
+- **`i18n.go`** (new) — the whole locale layer:
+  - `supportedLocales` / `languageNames` — the source of truth; adding a locale
+    is an append here plus catalog entries.
+  - `normalizeLocale` — base-subtag folding (`es-MX` → `es`), used by both
+    negotiation and the PATCH validator.
+  - `matchLocale` — `Accept-Language` parsing, q-value ordered.
+  - `localeMiddleware` + `requestLocale(ctx)` — stamps and reads the negotiated
+    locale; `requestLocale` returns `en` outside a request, so every call site
+    is safe by default.
+  - `tr(locale, key, args...)` — catalog lookup with `locale → en → key`
+    fallback and `Sprintf` templating.
+  - `localizedDate(locale, t, style)` — Go's `time.Format` emits English month
+    and weekday names unconditionally, so localized dates need their own tables.
+- **Middleware registration:** `router.Use(localeMiddleware)` in `main.go`,
+  after `corsMiddleware` (it must run for every route, including the public
+  export routes).
+- **Migration** `migrations/00049_user_locale.sql` — `users.locale TEXT` (NULL =
+  never resolved). Down drops it.
+- **Queries** `query/users.sql` — `UpdateUserProfile` replaces the
+  display-name-only setter with the partial-update `COALESCE(sqlc.narg(...))`
+  pattern already used by `SetUserEmailOptOut`, so one query updates display
+  name and/or locale. Regenerate with `make api-sqlc`; never hand-edit `store/`.
+- **Handlers:** `patchAccountHandler` (`account_handler.go`) accepts an optional
+  validated `locale`; `UserResponse`/`toUserResponse` (`auth_handler.go`) expose
+  it, so `/auth/me` and every auth response carry it.
+
+Later PRs (see below) thread `requestLocale(ctx)` into `trip_review.go`, the
+email builders, `print_view_handler.go`, `share_preview_handler.go`,
+`calendar_handler.go`, `plan_handler.go`, and the provider query strings in
+`places_service.go`, `events_service.go` and `weather_service.go`.
+
+### Prompt-cache constraint (CLAUDE.md → Key Constraints)
+
+`plan_tool_registry.go` is **not touched**: no `language` field is added to
+`save_preferences`, so the registry stays byte-stable. `basePrompt` is not
+touched either. The Spanish instruction is appended to the assembled
+`systemPrompt` in `plan_handler.go` only when the locale is non-English. The
+cache breakpoint covers the whole system block and the prompt already varies per
+user and per day, so a per-locale cache line is free; English is unchanged.
+
+## Flutter Changes
+
+`src/packages/flutter-app/lib/`:
+
+- **Localization**: `flutter_localizations` + `intl` in `pubspec.yaml` with
+  `generate: true`; `l10n.yaml`; `lib/l10n/app_en.arb` + `app_es.arb`;
+  `lib/l10n/l10n.dart` exposing a `context.l10n` extension so call sites stay
+  short. `untranslated-messages-file` makes missing Spanish a build artifact
+  that CI can assert on.
+- **Provider** `providers/locale_provider.dart` — persists the override in
+  `shared_preferences` (pattern: `providers/recent_trip_provider.dart`), exposes
+  the effective locale, and on change sets `Intl.defaultLocale`, updates the
+  API client's language tag, and fire-and-forgets the account sync (pattern:
+  `providers/preferences_provider.dart`).
+- **Client** `services/api_client.dart` — `Accept-Language` in `jsonHeaders()`,
+  next to the existing bearer-token injection.
+- **App shell** `main.dart` — `localizationsDelegates`, `supportedLocales`,
+  `locale`. `GlobalMaterialLocalizations.delegate` also initializes `intl` date
+  symbols, so no manual `initializeDateFormatting` is needed.
+- **Models** — the auth user model gains `locale`; run
+  `make flutter-build-models`.
+- **Formatting** `utils/trip_format.dart` and `utils/money_format.dart` — the
+  hand-rolled English month table becomes `DateFormat`, and money digits get
+  `NumberFormat` grouping. Both keep their current signatures, so their ~10 call
+  sites are untouched. Currency *symbol* selection stays currency-driven (it is
+  not a locale concern).
+- **Screens/widgets** — literals become `context.l10n.*` across
+  `screens/` and `widgets/`.
+- **Settings** `screens/account_settings_screen.dart` — a *Language / Idioma*
+  section using the existing `SectionHeader` pattern.
+
+## Contract Parity
+
+| JSON key | Go type (`auth_handler.go`) | Dart type (`models/`) | Nullable? | ✓ |
+|----------|-----------------------------|-----------------------|-----------|---|
+| `locale` | `*string` (`omitempty`) | `String?` | yes | ☐ |
+
+`users.locale` is nullable (never-resolved accounts), so the Go field is a
+pointer and the Dart field is nullable.
+
+## Cross-cutting
+
+- **Env vars:** none. Locale is per-user data, not configuration.
+- **Gateway:** no new paths; `Accept-Language` is a standard header and passes
+  through the nginx proxy untouched.
+- **Migrations:** `00049` follows `00048_apple_sso.sql`.
+
+## PR sequence
+
+| PR | Content |
+|----|---------|
+| 1 | This spec + server locale foundation: migration, `i18n.go`, account PATCH/`/auth/me`, middleware |
+| 2 | Flutter i18n infrastructure (invisible: `supportedLocales` is `[en]` only) + `locale_provider` + `Accept-Language` + intl date/money |
+| 3 | String extraction A — auth, landing, settings, preferences, account |
+| 4 | String extraction B — trips, itinerary, today mode, budget, checklist |
+| 5 | String extraction C — chat/plan, alerts, share/export, remaining widgets and non-`Text` strings |
+| 6 | Server-side Spanish (emails, trip review, exports, `.ics`) + AI language instruction + provider language params — all ships dark |
+| 7 | Enablement: `es` in `supportedLocales`, the settings picker, end-to-end pass |
+
+## Verification
+
+- `make api-fmt && make api-vet` clean.
+- `make api-test`; Go unit tests for `matchLocale` (q-values, regional variants,
+  unsupported), `tr` fallback, `localizedDate`, and a catalog-completeness test
+  that fails if any key lacks a translation.
+- Integration tests (`TEST_DATABASE_URL`, `travel_planner_test`): account locale
+  round-trips through PATCH and `/auth/me`; an invalid locale is rejected; a
+  Spanish `Accept-Language` produces Spanish trip-review findings (PR 6).
+- **English byte-stability regression test** (PR 6) via the fake-Anthropic
+  harness (`ANTHROPIC_BASE_URL`): the system prompt received for an English
+  request is unchanged, and the Spanish instruction appears only under `es`.
+- `make flutter-build-models`, `make flutter-analyze`, `make flutter-test`;
+  a widget test pumping the app under `es`; per-extraction-PR layout spot-check
+  with a temporary Spanish override (text expansion).
+- Manual end-to-end via `make docker-dev` at `http://localhost:3000`: switch to
+  Español and walk every acceptance criterion — chat, trip health, print packet,
+  `.ics`, and a triggered verification email.
+- `make smoke` after PRs 6 and 7.

--- a/specs/i18n-spanish/spec.md
+++ b/specs/i18n-spanish/spec.md
@@ -1,0 +1,160 @@
+# Spec: Spanish Localization (i18n)
+
+## Context
+
+The product is English-only, in every surface: the app UI, the AI planning
+chat, the emails we send, and the printable/calendar exports. That excludes
+Spanish-speaking travelers entirely — the largest single non-English audience
+for the destinations we already cover well (Spain, Mexico, Latin America), and
+one we can reach without any new provider integrations. This feature makes the
+product speak Spanish end to end, and does it through infrastructure (a locale
+that is resolved once and carried everywhere) so that the *second* additional
+language is a translation job rather than an engineering project.
+
+## User Stories
+
+- As a **Spanish-speaking traveler**, I want the app to open in Spanish when my
+  phone or browser is set to Spanish, so that I don't have to hunt for a
+  setting before I can use it.
+- As a **bilingual traveler**, I want to pick my language explicitly, so that I
+  can use the app in Spanish even though my device is in English (or vice
+  versa).
+- As a **Spanish-speaking traveler**, I want the AI planner to answer me in
+  Spanish and write my itinerary in Spanish, so that the trip it produces is
+  actually readable to me.
+- As a **Spanish-speaking traveler**, I want the emails I receive (verification,
+  trip reminders, price alerts, collaboration invites) in Spanish, so that the
+  product doesn't switch languages the moment it leaves the app.
+- As a **Spanish-speaking traveler**, I want my printed trip packet and calendar
+  entries in Spanish, so that what I carry on the trip matches what I planned.
+- As a **traveler on two devices**, I want my language choice to follow my
+  account, so I set it once.
+
+## Acceptance Criteria
+
+- [ ] With the device/browser set to Spanish and no explicit choice made, the
+      app opens fully in Spanish — navigation, buttons, form labels, empty
+      states, error messages, dates and currency amounts.
+- [ ] A language control in account settings offers *System default*, *English*
+      and *Español*; choosing one switches the whole app immediately, without a
+      restart, and survives closing and reopening the app.
+- [ ] The explicit choice is remembered on the account: signing in on a second
+      device (with no choice made there) adopts it.
+- [ ] Signed-out surfaces (landing, sign-in, sign-up) honor the device language.
+- [ ] With the app in Spanish, the AI planner replies in Spanish and the
+      itineraries, day summaries and titles it produces are in Spanish; dates,
+      airport codes and other structured values remain in their canonical
+      formats.
+- [ ] With the app in English, AI planning behaves exactly as it does today.
+- [ ] Trip health / review findings appear in Spanish.
+- [ ] Verification, password-reset, invite, trip-reminder and price-alert emails
+      arrive in Spanish for a user whose language is Spanish, and in English for
+      everyone else.
+- [ ] The printable trip packet and downloaded calendar entries use Spanish
+      labels when the trip is exported from a Spanish session.
+- [ ] Place search results and weather locations come back in Spanish where the
+      upstream provider offers Spanish.
+- [ ] Nothing in the English experience changes: text, layout and AI behavior
+      are identical to before this feature.
+
+## API Surface
+
+### Language negotiation (all endpoints)
+- **Purpose:** let every request state which language its response should be in.
+- **Request:** a standard language header. Values may be regional (`es-MX`);
+  they resolve to the closest supported base language. Absent or unsupported
+  values resolve to English.
+- **Response:** unchanged in shape; any human-readable text it contains is in
+  the negotiated language.
+
+### `PATCH /api/v1/auth/account`
+- **Purpose:** additionally persist the signed-in user's language.
+- **Request:** gains an optional language field alongside the existing display
+  name; both are optional, and a request touching neither is rejected as
+  before. An unsupported language value is rejected.
+- **Response:** the current user, now including their language.
+- **Errors:** unsupported language → unprocessable entity.
+
+### `GET /api/v1/auth/me`
+- **Response:** gains the user's stored language (absent when never set).
+
+### Public export routes (print packet, calendar files, share preview)
+- **Purpose:** these are opened by token from a browser or calendar app, with no
+  signed-in session, so they cannot read the app's language.
+- **Request:** an optional language query parameter, which the app appends when
+  it builds the link. When absent, the trip owner's stored language is used,
+  falling back to English.
+
+## Data Model
+
+- **User** — gains a **preferred language**: the language this account's
+  server-generated content (emails above all) should be written in. Optional:
+  accounts that predate this feature, and clients that have not synced, have
+  none, and are treated as English. It is deliberately part of the account, not
+  of the traveler's *travel preferences*, because it is app configuration
+  rather than travel taste — and because the AI must not be able to change it.
+
+- **Message catalog** — the set of server-rendered strings, each identified by a
+  stable key and available in every supported language. Not user data; it ships
+  with the server.
+
+## UI Behavior
+
+- **Screen / surface:** a *Language / Idioma* group in account settings,
+  alongside the existing email-preferences group.
+- **Happy path:** the user opens account settings, picks *Español*, and the app
+  redraws in Spanish immediately. The choice is stored on the device and, if
+  signed in, on the account.
+- **States:**
+  - *System default* (the initial state): the app follows the device language,
+    and changes with it.
+  - *Explicit choice*: wins over the device language on that device, and is
+    adopted on other devices that have not made their own choice.
+  - *Unsupported device language* (e.g. French): the app falls back to English,
+    and the picker shows *System default*.
+  - *Offline / signed out*: the choice still applies locally; the account sync
+    happens on the next successful signed-in request and is never blocking.
+
+## Edge Cases & Error States
+
+- **Regional variants** (`es-MX`, `es-419`, `es-ES`) all resolve to Spanish;
+  there is one Spanish translation, not per-region variants.
+- **Mixed-language conversations:** if the traveler writes to the AI in a
+  language other than their app language, the AI follows the traveler's
+  language rather than fighting it.
+- **Content created in another language:** itinerary titles, day summaries,
+  checklist items and profile notes are stored in whatever language they were
+  created in. Switching languages later does not retranslate existing trips —
+  the app chrome changes, saved content does not. This is intentional
+  (retranslating would rewrite the user's own edits) and should be visible in
+  the settings copy.
+- **Upstream providers:** place search and event search may return fewer or
+  lower-quality results in Spanish than in English. Results are still shown; the
+  language request is per-provider and independently reversible.
+- **Missing translation:** any string without a Spanish translation falls back
+  to English rather than showing a blank or a key. Translation coverage is
+  enforced at build/test time so this should never reach users.
+- **Text expansion:** Spanish runs roughly 25% longer than English; layouts must
+  tolerate it without clipping or overflow.
+
+## Out of Scope
+
+- **Screen-reader and other accessibility work.** This feature is localization
+  only.
+- **Localizing API error strings.** The several hundred internal JSON error
+  messages stay English: they are developer- and edge-case-facing, the app shows
+  its own localized copy for the failures users actually hit, and the correct
+  fix is machine-readable error codes mapped client-side — a separate feature.
+- **Retranslating existing user or AI-authored trip content.**
+- **Right-to-left languages**, and per-region Spanish variants.
+- **Localizing flight data** (Duffel): the payload is IATA codes and structured
+  values, not prose.
+- **Translated marketing/legal pages** and the public landing site outside the
+  app.
+- **Currency conversion.** Amounts stay in their trip currency; only number
+  formatting is localized.
+
+## Open Questions
+
+None outstanding — scope, surfaces and the language-selection model were
+settled before implementation.

--- a/specs/i18n-spanish/tasks.md
+++ b/specs/i18n-spanish/tasks.md
@@ -1,0 +1,74 @@
+# Tasks: Spanish Localization (i18n)
+
+> Dependency-ordered by PR. `[P]` = parallelizable with its siblings.
+> Spanish stays invisible to users until PR 7, so PRs 1-6 ship independently.
+
+## PR 1 — Server locale foundation
+
+- [x] Write `spec.md` + `plan.md`
+- [x] Migration `00049_user_locale.sql` (`users.locale TEXT`, nullable)
+- [x] `query/users.sql`: `UpdateUserProfile` partial-update query; `make api-sqlc`
+- [x] `i18n.go`: `supportedLocales`, `normalizeLocale`, `matchLocale`,
+      `localeMiddleware`, `requestLocale`, `tr`, `localizedDate`, `languageName`
+- [x] Register `localeMiddleware` in `main.go`
+- [x] `patchAccountHandler` accepts + validates `locale`
+- [x] `UserResponse`/`toUserResponse` expose `locale`
+- [x] Unit tests: locale matching, catalog fallback + completeness, dates
+- [x] Integration test: locale round-trips PATCH → `/auth/me`; invalid rejected
+- [x] `make api-fmt && make api-vet` clean
+
+## PR 2 — Flutter i18n infrastructure
+
+- [ ] `pubspec.yaml`: `flutter_localizations`, `intl`, `generate: true`
+- [ ] `l10n.yaml` + `lib/l10n/app_en.arb` + `lib/l10n/app_es.arb` (shell strings)
+- [ ] `lib/l10n/l10n.dart` — `context.l10n` extension
+- [ ] `lib/providers/locale_provider.dart` — override persistence, effective
+      locale, `Intl.defaultLocale`, account sync
+- [ ] `main.dart` — delegates, `supportedLocales: [en]` (es deferred to PR 7)
+- [ ] `services/api_client.dart` — `Accept-Language` in `jsonHeaders()`
+- [ ] Auth user model gains `locale`; `make flutter-build-models`
+- [ ] [P] `utils/trip_format.dart` → `DateFormat` (signatures unchanged)
+- [ ] [P] `utils/money_format.dart` → `NumberFormat` digit grouping
+- [ ] Tests: locale resolution, `Accept-Language` header; `make flutter-analyze`
+
+## PRs 3-5 — String extraction (mechanical)
+
+Per batch (A: auth/landing/settings/preferences/account · B: trips/itinerary/
+today/budget/checklist · C: chat/alerts/share/export/remaining):
+
+- [ ] Replace literals with `context.l10n.*`
+- [ ] Add character-identical English entries to `app_en.arb`
+- [ ] Add reviewed Spanish entries to `app_es.arb`
+- [ ] Refactor strings built outside widget context (provider/service SnackBar
+      messages) to keys rendered at the widget layer
+- [ ] Layout spot-check under a temporary Spanish override (~25% expansion)
+- [ ] `make flutter-analyze && make flutter-test` clean
+
+- [ ] After PR 5: `untranslated-messages` output is empty
+
+## PR 6 — Server-side Spanish + AI + providers
+
+- [ ] Catalog entries for all server-rendered strings
+- [ ] Email builders take a `locale` param: verification, reset, inline verify
+      pages, invites, trip reminders, weekly nudges, price alerts
+- [ ] Email jobs read `users.locale` (queries join the column)
+- [ ] `trip_review.go` — findings, fix labels, localized dates
+- [ ] `print_view_handler.go` + `share_preview_handler.go` — `<html lang>`,
+      labels, `?lang=` param; `calendar_handler.go` — time-of-day labels
+- [ ] `notifications_writer.go` — fallback actor string
+- [ ] `plan_handler.go` — Spanish instruction appended only when locale != en
+      (`basePrompt` and `plan_tool_registry.go` untouched)
+- [ ] [P] Provider language params: `places_service.go`, `events_service.go`,
+      `weather_service.go` (un-hardcode `language=en`)
+- [ ] Tests: es email builders, Spanish trip-review integration test, and the
+      **English prompt byte-stability** test via the fake-Anthropic harness
+- [ ] `make smoke`
+
+## PR 7 — Enablement
+
+- [ ] `es` added to `supportedLocales` in `main.dart`
+- [ ] Language picker in `account_settings_screen.dart`
+      (System default / English / Español)
+- [ ] Full Spanish walkthrough of every `spec.md` acceptance criterion via
+      `make docker-dev`
+- [ ] `make smoke`

--- a/src/packages/api/account_handler.go
+++ b/src/packages/api/account_handler.go
@@ -23,23 +23,37 @@ func patchAccountHandler(w http.ResponseWriter, r *http.Request) {
 	user, _ := userFromContext(r.Context())
 	var req struct {
 		DisplayName *string `json:"display_name"`
+		Locale      *string `json:"locale"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		writeJSONError(w, http.StatusBadRequest, "invalid JSON")
 		return
 	}
-	if req.DisplayName == nil {
+	if req.DisplayName == nil && req.Locale == nil {
 		writeJSONError(w, http.StatusBadRequest, "nothing to update")
 		return
 	}
-	name := strings.TrimSpace(*req.DisplayName)
-	if name == "" || utf8.RuneCountInString(name) > 60 {
-		writeJSONError(w, http.StatusUnprocessableEntity, "display_name must be 1-60 characters")
-		return
+	params := store.UpdateUserProfileParams{ID: user.ID}
+	if req.DisplayName != nil {
+		name := strings.TrimSpace(*req.DisplayName)
+		if name == "" || utf8.RuneCountInString(name) > 60 {
+			writeJSONError(w, http.StatusUnprocessableEntity, "display_name must be 1-60 characters")
+			return
+		}
+		params.DisplayName = &name
 	}
-	updated, err := store.New(dbPool).UpdateUserDisplayName(r.Context(), store.UpdateUserDisplayNameParams{
-		ID: user.ID, DisplayName: &name,
-	})
+	// The client syncs its already-resolved effective locale here (specs/
+	// i18n-spanish), so background email has a language to write in. Regional
+	// tags fold to their base language; anything unsupported is a client bug.
+	if req.Locale != nil {
+		locale, ok := normalizeLocale(*req.Locale)
+		if !ok {
+			writeJSONError(w, http.StatusUnprocessableEntity, "unsupported locale")
+			return
+		}
+		params.Locale = &locale
+	}
+	updated, err := store.New(dbPool).UpdateUserProfile(r.Context(), params)
 	if err != nil {
 		writeJSONError(w, http.StatusInternalServerError, "could not update account")
 		return

--- a/src/packages/api/account_integration_test.go
+++ b/src/packages/api/account_integration_test.go
@@ -25,6 +25,42 @@ func TestAccountDisplayNameUpdate(t *testing.T) {
 	}
 }
 
+// The client syncs its resolved locale here so background email (which has no
+// request to negotiate from) knows what language to write in.
+func TestAccountLocaleRoundTrip(t *testing.T) {
+	resetDB(t)
+	_, token := createTestUser(t, "me@example.com")
+
+	// Never-set locale is absent rather than an empty string.
+	if _, present := decode(t, doJSON(t, "GET", "/api/v1/auth/me", token, nil))["locale"]; present {
+		t.Fatal("locale should be omitted before it is ever set")
+	}
+
+	// Regional tags fold to the base language.
+	rec := doJSON(t, "PATCH", "/api/v1/auth/account", token, map[string]any{"locale": "es-MX"})
+	if rec.Code != http.StatusOK || decode(t, rec)["locale"] != "es" {
+		t.Fatalf("patch locale = %d: %s", rec.Code, rec.Body.String())
+	}
+	if got := decode(t, doJSON(t, "GET", "/api/v1/auth/me", token, nil))["locale"]; got != "es" {
+		t.Fatalf("/auth/me locale = %v, want es", got)
+	}
+
+	// A locale-only patch must not disturb the display name, and vice versa.
+	rec = doJSON(t, "PATCH", "/api/v1/auth/account", token, map[string]any{"display_name": "Brian D"})
+	if body := decode(t, rec); body["display_name"] != "Brian D" || body["locale"] != "es" {
+		t.Fatalf("display-name patch clobbered locale: %s", rec.Body.String())
+	}
+
+	if rec := doJSON(t, "PATCH", "/api/v1/auth/account", token, map[string]any{
+		"locale": "klingon",
+	}); rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("unsupported locale = %d, want 422", rec.Code)
+	}
+	if rec := doJSON(t, "PATCH", "/api/v1/auth/account", token, map[string]any{}); rec.Code != http.StatusBadRequest {
+		t.Fatalf("empty patch = %d, want 400", rec.Code)
+	}
+}
+
 func TestChangePasswordRevokesOtherSessions(t *testing.T) {
 	resetDB(t)
 	user, tokenA := createTestUser(t, "me@example.com")

--- a/src/packages/api/auth_handler.go
+++ b/src/packages/api/auth_handler.go
@@ -40,6 +40,11 @@ type UserResponse struct {
 	// opt-out columns.
 	RemindersEnabled bool `json:"reminders_enabled"`
 	NudgesEnabled    bool `json:"nudges_enabled"`
+	// Preferred language ('en' | 'es'), omitted when the account has never
+	// resolved one. The client owns resolution and syncs it here; the server
+	// reads it only where there is no request to negotiate from — background
+	// email and token-gated exports (specs/i18n-spanish).
+	Locale *string `json:"locale,omitempty"`
 }
 
 type AuthResponse struct {
@@ -62,6 +67,7 @@ func toUserResponse(u store.User) UserResponse {
 		// Opt-out false => still receiving => enabled true.
 		RemindersEnabled: !u.RemindersOptOut,
 		NudgesEnabled:    !u.NudgesOptOut,
+		Locale:           u.Locale,
 	}
 }
 

--- a/src/packages/api/i18n.go
+++ b/src/packages/api/i18n.go
@@ -1,0 +1,239 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Server-side localization (specs/i18n-spanish).
+//
+// The client resolves the locale (explicit override, else device language) and
+// states it on every request via Accept-Language; the server never re-derives
+// it. users.locale is consulted only where there is no request at all —
+// background email jobs and token-gated exports.
+//
+// Scope is the text the API itself renders: emails, trip-review findings, the
+// print/share export pages and .ics labels. The writeJSONError strings are
+// deliberately NOT localized — they are developer- and edge-case-facing, and
+// the right fix there is machine-readable error codes mapped client-side.
+//
+// The catalog is a plain map rather than golang.org/x/text/message: the
+// server-side surface is a few dozen strings across a handful of locales, so a
+// literal map stays greppable, dependency-free, and testable. TestCatalogIsComplete
+// fails if any key is missing a translation, which is what keeps the fallback
+// path from silently becoming the normal path.
+
+const defaultLocale = "en"
+
+const localeContextKey contextKey = "locale"
+
+// supportedLocales is the source of truth for both negotiation and validation,
+// most-preferred first. Adding a locale means: append here, add a languageNames
+// entry, and fill in the catalog (the completeness test enforces the last one).
+var supportedLocales = []string{"en", "es"}
+
+// languageNames are English names for each locale, used to build the AI
+// response-language instruction.
+var languageNames = map[string]string{
+	"en": "English",
+	"es": "Spanish (español)",
+}
+
+// normalizeLocale folds a user- or header-supplied tag to a supported base
+// language: "es-MX", "ES", "es-419" all become "es". Returns ok=false for
+// anything unsupported, so callers can reject rather than silently defaulting.
+func normalizeLocale(tag string) (string, bool) {
+	base := strings.ToLower(strings.TrimSpace(tag))
+	if i := strings.IndexAny(base, "-_"); i >= 0 {
+		base = base[:i]
+	}
+	for _, l := range supportedLocales {
+		if l == base {
+			return l, true
+		}
+	}
+	return "", false
+}
+
+// languageName returns the English name of a locale, for prompt text.
+func languageName(locale string) string {
+	if name, ok := languageNames[locale]; ok {
+		return name
+	}
+	return languageNames[defaultLocale]
+}
+
+// matchLocale picks the best supported locale from an Accept-Language header,
+// honoring q-values ("fr,es;q=0.9,en;q=0.8" => es, even though fr comes first).
+// Unparseable, empty, and all-unsupported headers yield the default locale.
+func matchLocale(header string) string {
+	type candidate struct {
+		tag string
+		q   float64
+		pos int
+	}
+	var candidates []candidate
+	for i, part := range strings.Split(header, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		tag, q := part, 1.0
+		if semi := strings.Index(part, ";"); semi >= 0 {
+			tag = strings.TrimSpace(part[:semi])
+			for _, param := range strings.Split(part[semi+1:], ";") {
+				k, v, found := strings.Cut(param, "=")
+				if !found || strings.ToLower(strings.TrimSpace(k)) != "q" {
+					continue
+				}
+				if parsed, err := strconv.ParseFloat(strings.TrimSpace(v), 64); err == nil {
+					q = parsed
+				}
+			}
+		}
+		// q=0 means "explicitly not acceptable".
+		if q <= 0 {
+			continue
+		}
+		if locale, ok := normalizeLocale(tag); ok {
+			candidates = append(candidates, candidate{tag: locale, q: q, pos: i})
+		}
+	}
+	if len(candidates) == 0 {
+		return defaultLocale
+	}
+	// Highest q wins; ties break on header order, which is where browsers put
+	// their real preference.
+	sort.SliceStable(candidates, func(i, j int) bool {
+		if candidates[i].q != candidates[j].q {
+			return candidates[i].q > candidates[j].q
+		}
+		return candidates[i].pos < candidates[j].pos
+	})
+	return candidates[0].tag
+}
+
+// localeMiddleware stamps the negotiated locale onto the request context. It
+// runs for every route — including the public token-gated export routes, which
+// have no session to read a stored locale from.
+func localeMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		locale := matchLocale(r.Header.Get("Accept-Language"))
+		// An explicit ?lang= wins: export links are opened by a browser or a
+		// calendar app whose own language says nothing about the traveler's.
+		if q := r.URL.Query().Get("lang"); q != "" {
+			if override, ok := normalizeLocale(q); ok {
+				locale = override
+			}
+		}
+		ctx := context.WithValue(r.Context(), localeContextKey, locale)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+// requestLocale returns the locale negotiated for this request, or the default
+// outside one. Never returns "", so every call site is safe without a guard.
+func requestLocale(ctx context.Context) string {
+	if locale, ok := ctx.Value(localeContextKey).(string); ok && locale != "" {
+		return locale
+	}
+	return defaultLocale
+}
+
+// localeOrDefault resolves a stored (nullable) users.locale for the
+// request-less callers: background email jobs and export fallbacks.
+func localeOrDefault(stored *string) string {
+	if stored == nil {
+		return defaultLocale
+	}
+	if locale, ok := normalizeLocale(*stored); ok {
+		return locale
+	}
+	return defaultLocale
+}
+
+// messages maps a stable key to its per-locale template. Templates are Sprintf
+// format strings; argument order must match across locales, which is why
+// multi-argument entries keep their placeholders in the same sequence.
+var messages = map[string]map[string]string{
+	"timeofday.morning":   {"en": "Morning", "es": "Mañana"},
+	"timeofday.afternoon": {"en": "Afternoon", "es": "Tarde"},
+	"timeofday.evening":   {"en": "Evening", "es": "Noche"},
+	"common.day":          {"en": "Day %d", "es": "Día %d"},
+	"common.unscheduled":  {"en": "Unscheduled", "es": "Sin programar"},
+}
+
+// tr renders a catalog entry in the given locale, falling back to English and
+// then to the key itself, so a missing translation degrades to readable text
+// rather than a blank. Args are applied with Sprintf when present.
+func tr(locale, key string, args ...any) string {
+	template, ok := lookupMessage(locale, key)
+	if !ok {
+		return key
+	}
+	if len(args) == 0 {
+		return template
+	}
+	return fmt.Sprintf(template, args...)
+}
+
+func lookupMessage(locale, key string) (string, bool) {
+	entry, ok := messages[key]
+	if !ok {
+		return "", false
+	}
+	if template, ok := entry[locale]; ok && template != "" {
+		return template, true
+	}
+	template, ok := entry[defaultLocale]
+	return template, ok
+}
+
+// Date formatting. Go's time.Format hardcodes English month and weekday names,
+// so localized dates need their own tables rather than a layout string.
+
+const (
+	dateStyleMonthDay        = "monthDay"        // Jan 2      / 2 ene
+	dateStyleWeekdayMonthDay = "weekdayMonthDay" // Mon, Jan 2 / lun, 2 ene
+	dateStyleLong            = "long"            // January 2, 2026 / 2 de enero de 2026
+)
+
+var esMonthsShort = [...]string{"ene", "feb", "mar", "abr", "may", "jun", "jul", "ago", "sep", "oct", "nov", "dic"}
+
+var esMonthsLong = [...]string{
+	"enero", "febrero", "marzo", "abril", "mayo", "junio",
+	"julio", "agosto", "septiembre", "octubre", "noviembre", "diciembre",
+}
+
+// Indexed by time.Weekday (Sunday = 0).
+var esWeekdaysShort = [...]string{"dom", "lun", "mar", "mié", "jue", "vie", "sáb"}
+
+// localizedDate renders t in the given style and locale. Spanish uses
+// day-before-month ordering, which is why this switches on locale rather than
+// swapping a layout string.
+func localizedDate(locale string, t time.Time, style string) string {
+	if locale != "es" {
+		switch style {
+		case dateStyleWeekdayMonthDay:
+			return t.Format("Mon, Jan 2")
+		case dateStyleLong:
+			return t.Format("January 2, 2006")
+		default:
+			return t.Format("Jan 2")
+		}
+	}
+	month := int(t.Month()) - 1
+	switch style {
+	case dateStyleWeekdayMonthDay:
+		return fmt.Sprintf("%s, %d %s", esWeekdaysShort[t.Weekday()], t.Day(), esMonthsShort[month])
+	case dateStyleLong:
+		return fmt.Sprintf("%d de %s de %d", t.Day(), esMonthsLong[month], t.Year())
+	default:
+		return fmt.Sprintf("%d %s", t.Day(), esMonthsShort[month])
+	}
+}

--- a/src/packages/api/i18n_test.go
+++ b/src/packages/api/i18n_test.go
@@ -1,0 +1,184 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestNormalizeLocale(t *testing.T) {
+	cases := []struct {
+		in     string
+		want   string
+		wantOK bool
+	}{
+		{"en", "en", true},
+		{"es", "es", true},
+		{"ES", "es", true},
+		{"  es  ", "es", true},
+		{"es-MX", "es", true},
+		{"es-419", "es", true},
+		{"es_ES", "es", true},
+		{"en-GB", "en", true},
+		{"fr", "", false},
+		{"", "", false},
+		{"esperanto", "", false}, // must not prefix-match "es"
+	}
+	for _, c := range cases {
+		got, ok := normalizeLocale(c.in)
+		if got != c.want || ok != c.wantOK {
+			t.Errorf("normalizeLocale(%q) = (%q, %v), want (%q, %v)", c.in, got, ok, c.want, c.wantOK)
+		}
+	}
+}
+
+func TestMatchLocale(t *testing.T) {
+	cases := []struct {
+		header string
+		want   string
+	}{
+		{"", "en"},
+		{"es", "es"},
+		{"es-MX", "es"},
+		{"es-MX,es;q=0.9,en;q=0.8", "es"},
+		{"en-US,en;q=0.9", "en"},
+		// Highest q wins even when it is not first in the header.
+		{"fr,es;q=0.9,en;q=0.8", "es"},
+		{"fr-CA,de;q=0.7", "en"}, // nothing supported => default
+		{"*", "en"},
+		{"es;q=0", "en"},              // explicitly not acceptable
+		{"es;q=bogus,en;q=0.1", "es"}, // unparseable q falls back to 1.0
+		{"  ,  , es ", "es"},
+		// Equal q ties break on header order.
+		{"en;q=0.9,es;q=0.9", "en"},
+		{"es;q=0.9,en;q=0.9", "es"},
+	}
+	for _, c := range cases {
+		if got := matchLocale(c.header); got != c.want {
+			t.Errorf("matchLocale(%q) = %q, want %q", c.header, got, c.want)
+		}
+	}
+}
+
+func TestLocaleMiddlewareStampsContext(t *testing.T) {
+	cases := []struct {
+		name   string
+		header string
+		path   string
+		want   string
+	}{
+		{"no header defaults to english", "", "/x", "en"},
+		{"header negotiated", "es-MX,es;q=0.9", "/x", "es"},
+		{"lang query overrides header", "en-US", "/x?lang=es", "es"},
+		{"unsupported lang query ignored", "es", "/x?lang=fr", "es"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			var got string
+			h := localeMiddleware(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+				got = requestLocale(r.Context())
+			}))
+			req := httptest.NewRequest("GET", c.path, nil)
+			if c.header != "" {
+				req.Header.Set("Accept-Language", c.header)
+			}
+			h.ServeHTTP(httptest.NewRecorder(), req)
+			if got != c.want {
+				t.Errorf("requestLocale = %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
+// requestLocale must be safe to call from background jobs and tests that never
+// went through the middleware.
+func TestRequestLocaleOutsideRequest(t *testing.T) {
+	if got := requestLocale(context.Background()); got != "en" {
+		t.Errorf("requestLocale(bare ctx) = %q, want en", got)
+	}
+}
+
+func TestLocaleOrDefault(t *testing.T) {
+	es, bogus := "es-MX", "klingon"
+	cases := []struct {
+		in   *string
+		want string
+	}{
+		{nil, "en"},
+		{&es, "es"},
+		{&bogus, "en"},
+	}
+	for _, c := range cases {
+		if got := localeOrDefault(c.in); got != c.want {
+			t.Errorf("localeOrDefault(%v) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestTrFallsBackToEnglishThenKey(t *testing.T) {
+	if got := tr("es", "timeofday.morning"); got != "Mañana" {
+		t.Errorf("es translation = %q, want Mañana", got)
+	}
+	// An unknown locale must not blank the string — English is the floor.
+	if got := tr("fr", "timeofday.morning"); got != "Morning" {
+		t.Errorf("unknown-locale fallback = %q, want Morning", got)
+	}
+	// An unknown key degrades to the key itself, which is readable in a log or
+	// a page rather than an empty gap.
+	if got := tr("es", "nope.not.a.key"); got != "nope.not.a.key" {
+		t.Errorf("unknown-key fallback = %q, want the key", got)
+	}
+	if got := tr("es", "common.day", 3); got != "Día 3" {
+		t.Errorf("templated = %q, want Día 3", got)
+	}
+}
+
+// The catalog's fallback path exists for safety, not for daily use: every key
+// must carry every supported locale, or Spanish users silently read English.
+func TestCatalogIsComplete(t *testing.T) {
+	for key, entry := range messages {
+		for _, locale := range supportedLocales {
+			if entry[locale] == "" {
+				t.Errorf("message %q is missing a %q translation", key, locale)
+			}
+		}
+	}
+	for _, locale := range supportedLocales {
+		if languageNames[locale] == "" {
+			t.Errorf("locale %q has no languageNames entry", locale)
+		}
+	}
+}
+
+func TestLocalizedDate(t *testing.T) {
+	// A Monday, to exercise the weekday table.
+	d := time.Date(2026, time.January, 5, 12, 0, 0, 0, time.UTC)
+	cases := []struct {
+		locale, style, want string
+	}{
+		{"en", dateStyleMonthDay, "Jan 5"},
+		{"en", dateStyleWeekdayMonthDay, "Mon, Jan 5"},
+		{"en", dateStyleLong, "January 5, 2026"},
+		{"es", dateStyleMonthDay, "5 ene"},
+		{"es", dateStyleWeekdayMonthDay, "lun, 5 ene"},
+		{"es", dateStyleLong, "5 de enero de 2026"},
+		// Unknown locales take the English path rather than panicking.
+		{"fr", dateStyleLong, "January 5, 2026"},
+	}
+	for _, c := range cases {
+		if got := localizedDate(c.locale, d, c.style); got != c.want {
+			t.Errorf("localizedDate(%q, %q) = %q, want %q", c.locale, c.style, got, c.want)
+		}
+	}
+}
+
+func TestLanguageName(t *testing.T) {
+	if got := languageName("es"); got != "Spanish (español)" {
+		t.Errorf("languageName(es) = %q", got)
+	}
+	if got := languageName("zz"); got != "English" {
+		t.Errorf("languageName(unknown) = %q, want English", got)
+	}
+}

--- a/src/packages/api/main.go
+++ b/src/packages/api/main.go
@@ -721,6 +721,10 @@ func buildRouter() *mux.Router {
 	// into the in-process opsMetrics registry (ops_metrics.go).
 	router.Use(metricsMiddleware)
 	router.Use(corsMiddleware)
+	// Negotiates the response language for every route, including the public
+	// token-gated exports that have no session to read a stored locale from
+	// (specs/i18n-spanish).
+	router.Use(localeMiddleware)
 	router.Use(bodyLimitMiddleware)
 	router.Use(func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/src/packages/api/migrations/00049_user_locale.sql
+++ b/src/packages/api/migrations/00049_user_locale.sql
@@ -1,0 +1,16 @@
+-- +goose Up
+-- Preferred UI/content language for this account, as a base language subtag
+-- ('en' | 'es'). NULL = never resolved: accounts that predate i18n, or a client
+-- that has not synced yet. Every reader falls back to 'en', so NULL is safe.
+--
+-- This lives on users rather than traveler_preferences on purpose. Locale is
+-- app configuration, not travel taste: the background email jobs
+-- (reengagement_checker.go, price_alert_checker.go) run with no request context
+-- and already read the users row, so joining it costs nothing here and a LEFT
+-- JOIN there — and, critically, the /plan agent's save_preferences tool writes
+-- traveler_preferences, which would let the model overwrite the user's language.
+-- Same shape as 00044_email_prefs.sql.
+ALTER TABLE users ADD COLUMN locale TEXT;
+
+-- +goose Down
+ALTER TABLE users DROP COLUMN locale;

--- a/src/packages/api/query/users.sql
+++ b/src/packages/api/query/users.sql
@@ -21,8 +21,15 @@ UPDATE users SET password_hash = $2 WHERE id = $1;
 UPDATE users SET email_verified_at = COALESCE(email_verified_at, now())
 WHERE id = $1;
 
--- name: UpdateUserDisplayName :one
-UPDATE users SET display_name = $2 WHERE id = $1
+-- name: UpdateUserProfile :one
+-- Partial account update: a NULL arg leaves that column untouched, so one query
+-- serves a display-name edit, a locale sync, or both. Same shape as
+-- SetUserEmailOptOut below. Locale is never cleared back to NULL — the client
+-- always resolves "System default" to a concrete language before syncing.
+UPDATE users SET
+    display_name = COALESCE(sqlc.narg('display_name'), display_name),
+    locale       = COALESCE(sqlc.narg('locale'), locale)
+WHERE id = sqlc.arg('id')
 RETURNING *;
 
 -- name: SetUserEmailOptOut :one

--- a/src/packages/api/store/models.go
+++ b/src/packages/api/store/models.go
@@ -358,4 +358,5 @@ type User struct {
 	RemindersOptOut   bool               `json:"reminders_opt_out"`
 	NudgesOptOut      bool               `json:"nudges_opt_out"`
 	LastWeeklyNudgeAt pgtype.Timestamptz `json:"last_weekly_nudge_at"`
+	Locale            *string            `json:"locale"`
 }

--- a/src/packages/api/store/sessions.sql.go
+++ b/src/packages/api/store/sessions.sql.go
@@ -67,7 +67,7 @@ func (q *Queries) DeleteSessionsByUser(ctx context.Context, userID uuid.UUID) er
 const getSessionWithUser = `-- name: GetSessionWithUser :one
 SELECT
     sessions.id, sessions.user_id, sessions.expires_at, sessions.created_at,
-    users.id, users.created_at, users.updated_at, users.email, users.password_hash, users.display_name, users.is_admin, users.onboarded_at, users.email_verified_at, users.reminders_opt_out, users.nudges_opt_out, users.last_weekly_nudge_at
+    users.id, users.created_at, users.updated_at, users.email, users.password_hash, users.display_name, users.is_admin, users.onboarded_at, users.email_verified_at, users.reminders_opt_out, users.nudges_opt_out, users.last_weekly_nudge_at, users.locale
 FROM sessions
 JOIN users ON users.id = sessions.user_id
 WHERE sessions.id = $1
@@ -98,6 +98,7 @@ func (q *Queries) GetSessionWithUser(ctx context.Context, id string) (GetSession
 		&i.User.RemindersOptOut,
 		&i.User.NudgesOptOut,
 		&i.User.LastWeeklyNudgeAt,
+		&i.User.Locale,
 	)
 	return i, err
 }

--- a/src/packages/api/store/users.sql.go
+++ b/src/packages/api/store/users.sql.go
@@ -14,7 +14,7 @@ import (
 const createUser = `-- name: CreateUser :one
 INSERT INTO users (email, password_hash, display_name)
 VALUES ($1, $2, $3)
-RETURNING id, created_at, updated_at, email, password_hash, display_name, is_admin, onboarded_at, email_verified_at, reminders_opt_out, nudges_opt_out, last_weekly_nudge_at
+RETURNING id, created_at, updated_at, email, password_hash, display_name, is_admin, onboarded_at, email_verified_at, reminders_opt_out, nudges_opt_out, last_weekly_nudge_at, locale
 `
 
 type CreateUserParams struct {
@@ -39,6 +39,7 @@ func (q *Queries) CreateUser(ctx context.Context, arg CreateUserParams) (User, e
 		&i.RemindersOptOut,
 		&i.NudgesOptOut,
 		&i.LastWeeklyNudgeAt,
+		&i.Locale,
 	)
 	return i, err
 }
@@ -56,7 +57,7 @@ func (q *Queries) DeleteUser(ctx context.Context, id uuid.UUID) (int64, error) {
 }
 
 const getUserByEmail = `-- name: GetUserByEmail :one
-SELECT id, created_at, updated_at, email, password_hash, display_name, is_admin, onboarded_at, email_verified_at, reminders_opt_out, nudges_opt_out, last_weekly_nudge_at FROM users WHERE email = $1
+SELECT id, created_at, updated_at, email, password_hash, display_name, is_admin, onboarded_at, email_verified_at, reminders_opt_out, nudges_opt_out, last_weekly_nudge_at, locale FROM users WHERE email = $1
 `
 
 func (q *Queries) GetUserByEmail(ctx context.Context, email string) (User, error) {
@@ -75,12 +76,13 @@ func (q *Queries) GetUserByEmail(ctx context.Context, email string) (User, error
 		&i.RemindersOptOut,
 		&i.NudgesOptOut,
 		&i.LastWeeklyNudgeAt,
+		&i.Locale,
 	)
 	return i, err
 }
 
 const getUserByID = `-- name: GetUserByID :one
-SELECT id, created_at, updated_at, email, password_hash, display_name, is_admin, onboarded_at, email_verified_at, reminders_opt_out, nudges_opt_out, last_weekly_nudge_at FROM users WHERE id = $1
+SELECT id, created_at, updated_at, email, password_hash, display_name, is_admin, onboarded_at, email_verified_at, reminders_opt_out, nudges_opt_out, last_weekly_nudge_at, locale FROM users WHERE id = $1
 `
 
 func (q *Queries) GetUserByID(ctx context.Context, id uuid.UUID) (User, error) {
@@ -99,6 +101,7 @@ func (q *Queries) GetUserByID(ctx context.Context, id uuid.UUID) (User, error) {
 		&i.RemindersOptOut,
 		&i.NudgesOptOut,
 		&i.LastWeeklyNudgeAt,
+		&i.Locale,
 	)
 	return i, err
 }
@@ -153,7 +156,7 @@ func (q *Queries) MarkUserEmailVerified(ctx context.Context, id uuid.UUID) error
 const markUserOnboarded = `-- name: MarkUserOnboarded :one
 UPDATE users SET onboarded_at = COALESCE(onboarded_at, now())
 WHERE id = $1
-RETURNING id, created_at, updated_at, email, password_hash, display_name, is_admin, onboarded_at, email_verified_at, reminders_opt_out, nudges_opt_out, last_weekly_nudge_at
+RETURNING id, created_at, updated_at, email, password_hash, display_name, is_admin, onboarded_at, email_verified_at, reminders_opt_out, nudges_opt_out, last_weekly_nudge_at, locale
 `
 
 func (q *Queries) MarkUserOnboarded(ctx context.Context, id uuid.UUID) (User, error) {
@@ -172,6 +175,7 @@ func (q *Queries) MarkUserOnboarded(ctx context.Context, id uuid.UUID) (User, er
 		&i.RemindersOptOut,
 		&i.NudgesOptOut,
 		&i.LastWeeklyNudgeAt,
+		&i.Locale,
 	)
 	return i, err
 }
@@ -181,7 +185,7 @@ UPDATE users SET
     reminders_opt_out = COALESCE($1, reminders_opt_out),
     nudges_opt_out    = COALESCE($2, nudges_opt_out)
 WHERE id = $3
-RETURNING id, created_at, updated_at, email, password_hash, display_name, is_admin, onboarded_at, email_verified_at, reminders_opt_out, nudges_opt_out, last_weekly_nudge_at
+RETURNING id, created_at, updated_at, email, password_hash, display_name, is_admin, onboarded_at, email_verified_at, reminders_opt_out, nudges_opt_out, last_weekly_nudge_at, locale
 `
 
 type SetUserEmailOptOutParams struct {
@@ -209,36 +213,7 @@ func (q *Queries) SetUserEmailOptOut(ctx context.Context, arg SetUserEmailOptOut
 		&i.RemindersOptOut,
 		&i.NudgesOptOut,
 		&i.LastWeeklyNudgeAt,
-	)
-	return i, err
-}
-
-const updateUserDisplayName = `-- name: UpdateUserDisplayName :one
-UPDATE users SET display_name = $2 WHERE id = $1
-RETURNING id, created_at, updated_at, email, password_hash, display_name, is_admin, onboarded_at, email_verified_at, reminders_opt_out, nudges_opt_out, last_weekly_nudge_at
-`
-
-type UpdateUserDisplayNameParams struct {
-	ID          uuid.UUID `json:"id"`
-	DisplayName *string   `json:"display_name"`
-}
-
-func (q *Queries) UpdateUserDisplayName(ctx context.Context, arg UpdateUserDisplayNameParams) (User, error) {
-	row := q.db.QueryRow(ctx, updateUserDisplayName, arg.ID, arg.DisplayName)
-	var i User
-	err := row.Scan(
-		&i.ID,
-		&i.CreatedAt,
-		&i.UpdatedAt,
-		&i.Email,
-		&i.PasswordHash,
-		&i.DisplayName,
-		&i.IsAdmin,
-		&i.OnboardedAt,
-		&i.EmailVerifiedAt,
-		&i.RemindersOptOut,
-		&i.NudgesOptOut,
-		&i.LastWeeklyNudgeAt,
+		&i.Locale,
 	)
 	return i, err
 }
@@ -255,4 +230,43 @@ type UpdateUserPasswordParams struct {
 func (q *Queries) UpdateUserPassword(ctx context.Context, arg UpdateUserPasswordParams) error {
 	_, err := q.db.Exec(ctx, updateUserPassword, arg.ID, arg.PasswordHash)
 	return err
+}
+
+const updateUserProfile = `-- name: UpdateUserProfile :one
+UPDATE users SET
+    display_name = COALESCE($1, display_name),
+    locale       = COALESCE($2, locale)
+WHERE id = $3
+RETURNING id, created_at, updated_at, email, password_hash, display_name, is_admin, onboarded_at, email_verified_at, reminders_opt_out, nudges_opt_out, last_weekly_nudge_at, locale
+`
+
+type UpdateUserProfileParams struct {
+	DisplayName *string   `json:"display_name"`
+	Locale      *string   `json:"locale"`
+	ID          uuid.UUID `json:"id"`
+}
+
+// Partial account update: a NULL arg leaves that column untouched, so one query
+// serves a display-name edit, a locale sync, or both. Same shape as
+// SetUserEmailOptOut below. Locale is never cleared back to NULL — the client
+// always resolves "System default" to a concrete language before syncing.
+func (q *Queries) UpdateUserProfile(ctx context.Context, arg UpdateUserProfileParams) (User, error) {
+	row := q.db.QueryRow(ctx, updateUserProfile, arg.DisplayName, arg.Locale, arg.ID)
+	var i User
+	err := row.Scan(
+		&i.ID,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.Email,
+		&i.PasswordHash,
+		&i.DisplayName,
+		&i.IsAdmin,
+		&i.OnboardedAt,
+		&i.EmailVerifiedAt,
+		&i.RemindersOptOut,
+		&i.NudgesOptOut,
+		&i.LastWeeklyNudgeAt,
+		&i.Locale,
+	)
+	return i, err
 }


### PR DESCRIPTION
First PR of `specs/i18n-spanish` — the locale layer everything else builds on. **Nothing user-visible changes yet**; Spanish is not selectable until PR 7.

## Approach

The client resolves the locale (explicit override, else device language) and states it via `Accept-Language` on every request. The server never re-derives it. `users.locale` is consulted only where there is no request at all — background email jobs and token-gated exports.

## What's here

- **`migrations/00049_user_locale.sql`** — `users.locale` (nullable; NULL and unsupported values both fall back to English). On `users` rather than `traveler_preferences` because locale is app configuration, not travel taste: the email checkers already read the users row and run with no request context, and `traveler_preferences` is writable by the agent's `save_preferences` tool, which must not own the user's language. Same shape as `00044_email_prefs.sql`.
- **`i18n.go`** — `Accept-Language` negotiation (q-value ordered, so `fr,es;q=0.9` picks Spanish; regional tags like `es-MX`/`es-419` fold to `es`), a `?lang=` override for export links opened outside the app, a map-based message catalog with `locale → en → key` fallback, and localized date rendering (Go's `time.Format` emits English month/weekday names unconditionally).
- **`PATCH /auth/account`** accepts a validated `locale`; `/auth/me` returns it.
- **`query/users.sql`** — `UpdateUserDisplayName` becomes the partial-update `UpdateUserProfile`, following the `COALESCE`/`sqlc.narg` shape already used by `SetUserEmailOptOut`, so one query serves a name edit, a locale sync, or both.

The catalog is a plain map rather than `golang.org/x/text/message`: the server-side surface is a few dozen strings across a handful of locales, so a literal map stays greppable and dependency-free. A completeness test fails if any key lacks a translation, which keeps the English fallback a safety net rather than the normal path.

`plan_tool_registry.go` and `basePrompt` are deliberately untouched — the prompt-cache prefix stays byte-stable. The AI language instruction lands in PR 6, gated on `locale != "en"`.

## Testing

- 9 new unit tests: locale normalization (including that `esperanto` does not prefix-match `es`), header negotiation with q-values, middleware stamping, catalog fallback + completeness, date rendering in both locales.
- New integration test: locale round-trips `PATCH` → `/auth/me`, regional tags fold, a locale-only patch doesn't clobber the display name (and vice versa), unsupported locale → 422.
- Full API suite green against `travel_planner_test`; `make api-fmt` / `make api-vet` clean.

## Remaining sequence

PR 2 Flutter i18n infra · PRs 3-5 string extraction (~800 literals, batched) · PR 6 server-side Spanish + AI instruction + provider language params · PR 7 enablement + settings picker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)