### PR TITLE
feat(i18n): Spanish server output, AI language and provider locales (PR 6/7)

### DIFF
--- a/specs/i18n-spanish/tasks.md
+++ b/specs/i18n-spanish/tasks.md
@@ -109,27 +109,27 @@ Also in PR 5:
 
 ## PR 6 — Server-side Spanish + AI + providers
 
-- [ ] Catalog entries for all server-rendered strings
-- [ ] Email builders take a `locale` param: verification, reset, inline verify
+- [x] Catalog entries for all server-rendered strings
+- [x] Email builders take a `locale` param: verification, reset, inline verify
       pages, invites, trip reminders, weekly nudges, price alerts
-- [ ] Email jobs read `users.locale` (queries join the column)
-- [ ] `trip_review.go` — findings, fix labels, localized dates
-- [ ] `print_view_handler.go` + `share_preview_handler.go` — `<html lang>`,
+- [x] Email jobs read `users.locale` (queries join the column)
+- [x] `trip_review.go` — findings, fix labels, localized dates
+- [x] `print_view_handler.go` + `share_preview_handler.go` — `<html lang>`,
       labels, `?lang=` param; `calendar_handler.go` — time-of-day labels
-- [ ] **Calendar event titles must flip client- and server-side together.**
+- [x] **Calendar event titles must flip client- and server-side together.**
       `bookings_section.dart` builds Google-link titles (`Stay: {name}`, the
       transport `_segmentCalendarTitle`) that deliberately mirror the Go `.ics`
       export. PR 4 left them in English on purpose: translating only the client
       would make the Google link disagree with the downloaded `.ics`. Localize
       both in this PR, in one change.
-- [ ] `notifications_writer.go` — fallback actor string
-- [ ] `plan_handler.go` — Spanish instruction appended only when locale != en
+- [x] `notifications_writer.go` — fallback actor string
+- [x] `plan_handler.go` — Spanish instruction appended only when locale != en
       (`basePrompt` and `plan_tool_registry.go` untouched)
-- [ ] [P] Provider language params: `places_service.go`, `events_service.go`,
+- [x] [P] Provider language params: `places_service.go`, `events_service.go`,
       `weather_service.go` (un-hardcode `language=en`)
-- [ ] Tests: es email builders, Spanish trip-review integration test, and the
+- [x] Tests: es email builders, Spanish trip-review integration test, and the
       **English prompt byte-stability** test via the fake-Anthropic harness
-- [ ] `make smoke`
+- [x] `make smoke`
 
 ## Deliberately not localized
 
@@ -155,6 +155,24 @@ Also in PR 5:
 - [ ] Copy change (deliberately deferred from PR 3): the budget/pace/interest
       chips render lowercase `budget`/`mid`/`luxury`. Capitalizing them is an
       English-visible change, so it does not belong in an extraction PR.
+
+**PR 6 notes:**
+- 131 catalog keys. `TestSystemPromptEnglishUnchanged` is the load-bearing test:
+  English (and no-header, and unsupported-locale) requests must produce a prompt
+  with no language instruction, and Spanish must be exactly the English prompt
+  plus a suffix, so the cached prefix provably never moved.
+- Signup now persists the negotiated locale in `CreateUser` (email + both SSO
+  paths), so the very first verification email is already in the right language
+  instead of waiting for the client's first sync.
+- Calendar titles are a cross-language contract, pinned from BOTH sides:
+  `api/calendar_event_test.go` and `flutter-app/test/calendar_title_parity_test.dart`.
+  Unified the Spanish ferry term ("ferri") across the three mode label sets.
+- Email dates stay ISO (`2026-09-01`). Localizing them would change the ENGLISH
+  body, which the character-identical rule forbids; ISO is unambiguous in both
+  languages. A deliberate copy change, not an extraction change.
+- Still English by design: `FindingFix.PackingItem` values (they are written to
+  the packing list as data — localizing belongs to that write path), and
+  `weather_service.go`'s `summarizeWeather` string, which is agent-facing.
 
 ## PR 7 — Enablement
 

--- a/src/packages/api/apple_auth_handler.go
+++ b/src/packages/api/apple_auth_handler.go
@@ -150,8 +150,10 @@ func findOrCreateAppleUser(r *http.Request, claims appleClaims, formName string)
 		if displayName == "" {
 			displayName = defaultDisplayName(email)
 		}
+		signupLocale := requestLocale(ctx)
 		user, err = q.CreateUser(ctx, store.CreateUserParams{
 			Email: email, PasswordHash: nil, DisplayName: &displayName,
+			Locale: &signupLocale,
 		})
 		if err != nil {
 			return store.User{}, err

--- a/src/packages/api/auth_handler.go
+++ b/src/packages/api/auth_handler.go
@@ -264,10 +264,12 @@ func registerHandler(w http.ResponseWriter, r *http.Request) {
 		displayName = &d
 	}
 
+	signupLocale := requestLocale(r.Context())
 	user, err := q.CreateUser(r.Context(), store.CreateUserParams{
 		Email:        req.Email,
 		PasswordHash: &hash,
 		DisplayName:  displayName,
+		Locale:       &signupLocale,
 	})
 	if err != nil {
 		writeJSONError(w, http.StatusInternalServerError, "could not create account")
@@ -283,7 +285,7 @@ func registerHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	// Fire-and-forget, like the profile distiller: registration never blocks
 	// or fails on email delivery or analytics.
-	safeGo("sendVerificationEmail", func() { sendVerificationEmail(user) })
+	safeGo("sendVerificationEmail", func() { sendVerificationEmailIn(user, signupLocale) })
 	safeGo("recordEvent", func() { recordEvent(user.ID, "user_registered", nil, nil) })
 	writeJSON(w, http.StatusCreated, AuthResponse{User: toUserResponse(user), Token: session.ID})
 }

--- a/src/packages/api/calendar_event_handler.go
+++ b/src/packages/api/calendar_event_handler.go
@@ -34,7 +34,7 @@ func calendarEventHandler(w http.ResponseWriter, r *http.Request) {
 		notFound()
 		return
 	}
-	body, filename, ok := buildSingleEventICS(data, vars["kind"], id)
+	body, filename, ok := buildSingleEventICS(requestLocale(r.Context()), data, vars["kind"], id)
 	if !ok {
 		notFound()
 		return
@@ -47,7 +47,7 @@ func calendarEventHandler(w http.ResponseWriter, r *http.Request) {
 // buildSingleEventICS finds the event by kind+id in the export snapshot and
 // renders a one-VEVENT VCALENDAR. ok=false for an unknown kind, a missing id,
 // or an undated event — callers answer one opaque 404 for all of them.
-func buildSingleEventICS(d exportData, kind string, id uuid.UUID) (body, filename string, ok bool) {
+func buildSingleEventICS(locale string, d exportData, kind string, id uuid.UUID) (body, filename string, ok bool) {
 	var (
 		uid, summary, location, description string
 		start, end                          time.Time
@@ -56,7 +56,7 @@ func buildSingleEventICS(d exportData, kind string, id uuid.UUID) (body, filenam
 	case "stay":
 		for _, a := range d.Accommodations {
 			if a.ID == id {
-				start, end, summary, location, ok = stayEventFields(a)
+				start, end, summary, location, ok = stayEventFieldsIn(locale, a)
 				uid = "acc-" + a.ID.String()
 				break
 			}
@@ -64,7 +64,7 @@ func buildSingleEventICS(d exportData, kind string, id uuid.UUID) (body, filenam
 	case "segment":
 		for _, s := range d.Segments {
 			if s.ID == id {
-				start, end, summary, description, ok = segmentEventFields(s)
+				start, end, summary, description, ok = segmentEventFieldsIn(locale, s)
 				uid = "seg-" + s.ID.String()
 				break
 			}
@@ -72,7 +72,7 @@ func buildSingleEventICS(d exportData, kind string, id uuid.UUID) (body, filenam
 	case "item":
 		for _, it := range d.Items {
 			if it.ID == id {
-				start, end, summary, location, description, ok = itemEventFields(d.Trip, it)
+				start, end, summary, location, description, ok = itemEventFieldsIn(locale, d.Trip, it)
 				uid = "item-" + it.ID.String()
 				break
 			}

--- a/src/packages/api/calendar_event_test.go
+++ b/src/packages/api/calendar_event_test.go
@@ -52,7 +52,7 @@ func singleEventFixture(t *testing.T) exportData {
 
 func TestBuildSingleEventICS_Stay(t *testing.T) {
 	d := singleEventFixture(t)
-	body, filename, ok := buildSingleEventICS(d, "stay", d.Accommodations[0].ID)
+	body, filename, ok := buildSingleEventICS("en", d, "stay", d.Accommodations[0].ID)
 	if !ok {
 		t.Fatal("stay should render")
 	}
@@ -80,7 +80,7 @@ func TestBuildSingleEventICS_Stay(t *testing.T) {
 func TestBuildSingleEventICS_StayWithoutCheckoutIsOneNight(t *testing.T) {
 	d := singleEventFixture(t)
 	d.Accommodations[0].CheckOut = pgtype.Date{}
-	body, _, ok := buildSingleEventICS(d, "stay", d.Accommodations[0].ID)
+	body, _, ok := buildSingleEventICS("en", d, "stay", d.Accommodations[0].ID)
 	if !ok {
 		t.Fatal("stay without checkout should still render")
 	}
@@ -91,7 +91,7 @@ func TestBuildSingleEventICS_StayWithoutCheckoutIsOneNight(t *testing.T) {
 
 func TestBuildSingleEventICS_Segment(t *testing.T) {
 	d := singleEventFixture(t)
-	body, filename, ok := buildSingleEventICS(d, "segment", d.Segments[0].ID)
+	body, filename, ok := buildSingleEventICS("en", d, "segment", d.Segments[0].ID)
 	if !ok {
 		t.Fatal("segment should render")
 	}
@@ -113,7 +113,7 @@ func TestBuildSingleEventICS_Segment(t *testing.T) {
 func TestBuildSingleEventICS_SegmentSameDayArrival(t *testing.T) {
 	d := singleEventFixture(t)
 	d.Segments[0].ArriveDate = d.Segments[0].DepartDate
-	body, _, ok := buildSingleEventICS(d, "segment", d.Segments[0].ID)
+	body, _, ok := buildSingleEventICS("en", d, "segment", d.Segments[0].ID)
 	if !ok {
 		t.Fatal("same-day segment should render")
 	}
@@ -124,7 +124,7 @@ func TestBuildSingleEventICS_SegmentSameDayArrival(t *testing.T) {
 
 func TestBuildSingleEventICS_Item(t *testing.T) {
 	d := singleEventFixture(t)
-	body, _, ok := buildSingleEventICS(d, "item", d.Items[0].ID)
+	body, _, ok := buildSingleEventICS("en", d, "item", d.Items[0].ID)
 	if !ok {
 		t.Fatal("item should render")
 	}
@@ -171,8 +171,35 @@ func TestBuildSingleEventICS_NotFoundCases(t *testing.T) {
 		{"trip without start date", startlessTrip, "item", startlessTrip.Items[0].ID},
 	}
 	for _, tc := range cases {
-		if _, _, ok := buildSingleEventICS(tc.d, tc.kind, tc.id); ok {
+		if _, _, ok := buildSingleEventICS("en", tc.d, tc.kind, tc.id); ok {
 			t.Fatalf("%s: expected ok=false", tc.name)
 		}
+	}
+}
+
+// Calendar titles are a cross-language contract: the Flutter client builds
+// Google Calendar links for the SAME events, so the two must agree in every
+// locale. These expectations are mirrored in the Flutter suite
+// (flutter-app/test/calendar_title_parity_test.dart) — a drift on either side
+// fails a test instead of shipping two differently-named entries for one trip.
+func TestSingleEventICSSpanishTitles(t *testing.T) {
+	d := singleEventFixture(t)
+
+	body, _, ok := buildSingleEventICS("es", d, "stay", d.Accommodations[0].ID)
+	if !ok {
+		t.Fatal("stay should render")
+	}
+	if want := "SUMMARY:Alojamiento: Hotel Grande Bretagne"; !strings.Contains(body, want) {
+		t.Errorf("es stay summary missing %q\n%s", want, body)
+	}
+
+	body, _, ok = buildSingleEventICS("es", d, "segment", d.Segments[0].ID)
+	if !ok {
+		t.Fatal("segment should render")
+	}
+	// The route itself is traveler data and stays as-is; only the mode word
+	// translates.
+	if want := "SUMMARY:Vuelo: JFK → ATH"; !strings.Contains(body, want) {
+		t.Errorf("es segment summary missing %q\n%s", want, body)
 	}
 }

--- a/src/packages/api/calendar_handler.go
+++ b/src/packages/api/calendar_handler.go
@@ -28,7 +28,10 @@ func calendarHandler(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte("export link not available"))
 		return
 	}
-	body := buildICS(data)
+	// localeMiddleware has already resolved ?lang= / Accept-Language. Calendar
+	// apps fetch this URL themselves, so an explicit ?lang= on the share link is
+	// the reliable signal; the header is the fallback.
+	body := buildICS(requestLocale(r.Context()), data)
 	w.Header().Set("Content-Type", "text/calendar; charset=utf-8")
 	w.Header().Set("Content-Disposition", `attachment; filename="`+tripSlug(data.Trip.Title)+`.ics"`)
 	w.Write([]byte(body))
@@ -37,7 +40,7 @@ func calendarHandler(w http.ResponseWriter, r *http.Request) {
 // buildICS renders the export data as a VCALENDAR document. Undatable itinerary
 // items are skipped; if nothing at all is datable the calendar still contains a
 // single trip-span all-day event so the download is never empty.
-func buildICS(d exportData) string {
+func buildICS(locale string, d exportData) string {
 	var b icsBuilder
 	b.line("BEGIN:VCALENDAR")
 	b.line("VERSION:2.0")
@@ -49,7 +52,7 @@ func buildICS(d exportData) string {
 	events := 0
 
 	for _, it := range d.Items {
-		start, end, summary, location, description, ok := itemEventFields(d.Trip, it)
+		start, end, summary, location, description, ok := itemEventFieldsIn(locale, d.Trip, it)
 		if !ok {
 			continue // no trip start_date or no day → not datable
 		}
@@ -58,7 +61,7 @@ func buildICS(d exportData) string {
 	}
 
 	for _, a := range d.Accommodations {
-		start, end, summary, location, ok := stayEventFields(a)
+		start, end, summary, location, ok := stayEventFieldsIn(locale, a)
 		if !ok {
 			continue
 		}
@@ -67,7 +70,7 @@ func buildICS(d exportData) string {
 	}
 
 	for _, s := range d.Segments {
-		start, end, summary, description, ok := segmentEventFields(s)
+		start, end, summary, description, ok := segmentEventFieldsIn(locale, s)
 		if !ok {
 			continue
 		}
@@ -94,9 +97,16 @@ func buildICS(d exportData) string {
 // render identical all-day VEVENTs. All ends are exclusive; ok=false means the
 // event is undated and gets no VEVENT.
 
-// stayEventFields resolves an accommodation's VEVENT fields: check-in through
-// check-out (or one night when check-out is missing/not after check-in).
-func stayEventFields(a store.Accommodation) (start, end time.Time, summary, location string, ok bool) {
+// The three unsuffixed forms below are English-locale shims kept so
+// calendar_event_handler.go (the per-event .ics) compiles unchanged; it does
+// not thread a request locale yet. Follow-up: pass requestLocale there and
+// delete these.
+
+// stayEventFieldsIn resolves an accommodation's VEVENT fields: check-in through
+// check-out (or one night when check-out is missing/not after check-in). The
+// SUMMARY is mirrored byte-for-byte by the Flutter client's Google Calendar
+// link (bookings_section.dart) — change both together.
+func stayEventFieldsIn(locale string, a store.Accommodation) (start, end time.Time, summary, location string, ok bool) {
 	if !a.CheckIn.Valid {
 		return time.Time{}, time.Time{}, "", "", false
 	}
@@ -104,12 +114,13 @@ func stayEventFields(a store.Accommodation) (start, end time.Time, summary, loca
 	if a.CheckOut.Valid && a.CheckOut.Time.After(a.CheckIn.Time) {
 		end = a.CheckOut.Time
 	}
-	return a.CheckIn.Time, end, "Stay: " + a.Name, strPtrVal(a.Address), true
+	return a.CheckIn.Time, end, tr(locale, "ics.stayTitle", a.Name), strPtrVal(a.Address), true
 }
 
-// segmentEventFields resolves a transport segment's VEVENT fields: departure
-// day through arrival day inclusive (single day when arrival is missing).
-func segmentEventFields(s store.TripSegment) (start, end time.Time, summary, description string, ok bool) {
+// segmentEventFieldsIn resolves a transport segment's VEVENT fields: departure
+// day through arrival day inclusive (single day when arrival is missing). The
+// SUMMARY is mirrored by the Flutter client — see stayEventFieldsIn.
+func segmentEventFieldsIn(locale string, s store.TripSegment) (start, end time.Time, summary, description string, ok bool) {
 	if !s.DepartDate.Valid {
 		return time.Time{}, time.Time{}, "", "", false
 	}
@@ -117,18 +128,19 @@ func segmentEventFields(s store.TripSegment) (start, end time.Time, summary, des
 	if s.ArriveDate.Valid && s.ArriveDate.Time.After(s.DepartDate.Time) {
 		end = s.ArriveDate.Time.AddDate(0, 0, 1)
 	}
-	summary = capitalize(s.Mode) + ": " + segmentRoute(s)
+	summary = tr(locale, "ics.segmentTitle", localizedMode(locale, s.Mode), segmentRouteIn(locale, s))
 	return s.DepartDate.Time, end, summary, strPtrVal(s.Notes), true
 }
 
-// itemEventFields resolves an itinerary item's VEVENT fields: the single trip
-// day the item is assigned to.
-func itemEventFields(trip store.Trip, it store.ItineraryItem) (start, end time.Time, summary, location, description string, ok bool) {
+// itemEventFieldsIn resolves an itinerary item's VEVENT fields: the single trip
+// day the item is assigned to. The SUMMARY is the item's own name — traveler
+// data, never translated.
+func itemEventFieldsIn(locale string, trip store.Trip, it store.ItineraryItem) (start, end time.Time, summary, location, description string, ok bool) {
 	start, ok = itemStartDate(trip, it)
 	if !ok {
 		return time.Time{}, time.Time{}, "", "", "", false
 	}
-	return start, start.AddDate(0, 0, 1), it.Name, strPtrVal(it.Address), icsItemDescription(it), true
+	return start, start.AddDate(0, 0, 1), it.Name, strPtrVal(it.Address), icsItemDescription(locale, it), true
 }
 
 // itemStartDate resolves an item's all-day start: trip.start_date + (day-1).
@@ -142,13 +154,13 @@ func itemStartDate(trip store.Trip, it store.ItineraryItem) (time.Time, bool) {
 
 // icsItemDescription joins the time-of-day and local attribution into the
 // VEVENT DESCRIPTION (pre-escape; the builder escapes it).
-func icsItemDescription(it store.ItineraryItem) string {
+func icsItemDescription(locale string, it store.ItineraryItem) string {
 	var parts []string
-	if t := capitalize(strPtrVal(it.TimeOfDay)); t != "" {
+	if t := localizedTimeOfDay(locale, strPtrVal(it.TimeOfDay)); t != "" {
 		parts = append(parts, t)
 	}
 	if rec := strings.TrimSpace(strPtrVal(it.LocalSourceName)); rec != "" {
-		parts = append(parts, "Recommended by "+rec)
+		parts = append(parts, tr(locale, "ics.recommendedBy", rec))
 	}
 	return strings.Join(parts, " · ")
 }

--- a/src/packages/api/email_auth_handler.go
+++ b/src/packages/api/email_auth_handler.go
@@ -93,8 +93,16 @@ func publicAppURL(parts ...string) string {
 }
 
 // sendVerificationEmail is called fire-and-forget after registration (same
-// pattern as the profile distiller kickoff) and from the resend endpoint.
+// pattern as the profile distiller kickoff). Registration has no locale to hand
+// down that the account doesn't already carry, so the language comes from the
+// stored users.locale (NULL => English); callers inside a request that know the
+// negotiated locale use sendVerificationEmailIn instead.
 func sendVerificationEmail(user store.User) {
+	sendVerificationEmailIn(user, localeOrDefault(user.Locale))
+}
+
+// sendVerificationEmailIn is sendVerificationEmail with an explicit locale.
+func sendVerificationEmailIn(user store.User, locale string) {
 	// Per-address throttle (abuse_caps.go): checked before issuing a token so a
 	// throttled resend doesn't invalidate a still-valid prior token. Keyed by
 	// purpose so verify and reset don't block each other. Anti email-bombing.
@@ -111,10 +119,8 @@ func sendVerificationEmail(user store.User) {
 		return
 	}
 	link := publicAppURL("verify/", token)
-	body := "Welcome to Golden Tempo Travel!\n\n" +
-		"Confirm your email address by opening this link:\n\n" + link + "\n\n" +
-		"The link expires in 24 hours. If you didn't create an account, you can ignore this email."
-	if err := emailSend(user.Email, "Confirm your email — Golden Tempo Travel", body); err != nil {
+	body := tr(locale, "email.verify.body", link)
+	if err := emailSend(user.Email, tr(locale, "email.verify.subject"), body); err != nil {
 		log.Printf("verification email: send to %s failed: %v", user.Email, err)
 	}
 }
@@ -126,7 +132,10 @@ func requestVerificationHandler(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusOK, map[string]string{"status": "already verified"})
 		return
 	}
-	safeGo("sendVerificationEmail", func() { sendVerificationEmail(user) })
+	// Request-driven: the client states its language on the request, which is
+	// fresher than whatever the account last synced.
+	locale := requestLocale(r.Context())
+	safeGo("sendVerificationEmail", func() { sendVerificationEmailIn(user, locale) })
 	w.WriteHeader(http.StatusAccepted)
 }
 
@@ -157,6 +166,7 @@ func verifyEmailHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	locale := requestLocale(r.Context())
 	q := store.New(dbPool)
 	et, err := q.GetValidEmailToken(r.Context(), store.GetValidEmailTokenParams{
 		TokenHash: hashEmailToken(token), Purpose: "verify",
@@ -165,7 +175,8 @@ func verifyEmailHandler(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodGet {
 			w.Header().Set("Content-Type", "text/html; charset=utf-8")
 			w.WriteHeader(http.StatusNotFound)
-			fmt.Fprint(w, "<html><body><h2>Link expired or already used</h2><p>Request a new verification email from your account.</p></body></html>")
+			fmt.Fprintf(w, "<html lang=%q><body><h2>%s</h2><p>%s</p></body></html>",
+				locale, tr(locale, "page.verify.expired.title"), tr(locale, "page.verify.expired.body"))
 			return
 		}
 		writeJSONError(w, http.StatusNotFound, "invalid or expired token")
@@ -181,7 +192,11 @@ func verifyEmailHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	if r.Method == http.MethodGet {
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
-		fmt.Fprintf(w, "<html><body><h2>Email verified ✓</h2><p>You're all set — head back to <a href=%q>Golden Tempo Travel</a>.</p></body></html>", publicBaseURL())
+		// The brand link is substituted as markup so the sentence around it can
+		// reorder per language without splitting the anchor.
+		homeLink := fmt.Sprintf("<a href=%q>Golden Tempo Travel</a>", publicBaseURL())
+		fmt.Fprintf(w, "<html lang=%q><body><h2>%s</h2><p>%s</p></body></html>",
+			locale, tr(locale, "page.verify.ok.title"), tr(locale, "page.verify.ok.body", homeLink))
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]string{"status": "verified"})
@@ -207,6 +222,7 @@ func requestPasswordResetHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	locale := requestLocale(r.Context())
 	q := store.New(dbPool)
 	user, err := q.GetUserByEmail(r.Context(), email)
 	if err == nil {
@@ -227,12 +243,8 @@ func requestPasswordResetHandler(w http.ResponseWriter, r *http.Request) {
 				log.Printf("password reset: could not issue token for %s: %v", u.Email, err)
 				return
 			}
-			body := "Someone (hopefully you) asked to reset your Golden Tempo Travel password.\n\n" +
-				"Reset your password: " + publicAppURL("reset/", token) + "\n\n" +
-				"If the link doesn't open, use this reset code instead:\n\n    " + token + "\n\n" +
-				"In the app, choose \"Forgot password?\", paste the code, and pick a new password. " +
-				"The link and code are valid for 1 hour and work once. If this wasn't you, ignore this email — your password is unchanged."
-			if err := emailSend(u.Email, "Reset your password — Golden Tempo Travel", body); err != nil {
+			body := tr(locale, "email.reset.body", publicAppURL("reset/", token), token)
+			if err := emailSend(u.Email, tr(locale, "email.reset.subject"), body); err != nil {
 				log.Printf("password reset: send to %s failed: %v", u.Email, err)
 			}
 		})

--- a/src/packages/api/events_service.go
+++ b/src/packages/api/events_service.go
@@ -120,6 +120,10 @@ func (s *EventsService) SearchEvents(ctx context.Context, city, startDate, endDa
 	params.Set("startDateTime", startDT)
 	params.Set("endDateTime", endDT)
 	params.Set("sort", "date,asc")
+	// Ticketmaster returns localized names/descriptions where it has them; it
+	// falls back to the source language on its own, so a thin Spanish catalog
+	// degrades rather than emptying results (specs/i18n-spanish).
+	params.Set("locale", requestLocale(ctx)+",*")
 	// Over-fetch: Ticketmaster's date filter is loose and surfaces ongoing/flex
 	// runs whose start date predates the window, so we fetch a wider page and
 	// post-filter to the trip window below before capping at maxEvents.

--- a/src/packages/api/google_auth_handler.go
+++ b/src/packages/api/google_auth_handler.go
@@ -159,8 +159,10 @@ func findOrCreateGoogleUser(r *http.Request, claims googleClaims) (store.User, e
 		if displayName == "" {
 			displayName = defaultDisplayName(email)
 		}
+		signupLocale := requestLocale(ctx)
 		user, err = q.CreateUser(ctx, store.CreateUserParams{
 			Email: email, PasswordHash: nil, DisplayName: &displayName,
+			Locale: &signupLocale,
 		})
 		if err != nil {
 			return store.User{}, err

--- a/src/packages/api/i18n.go
+++ b/src/packages/api/i18n.go
@@ -161,11 +161,146 @@ func localeOrDefault(stored *string) string {
 // format strings; argument order must match across locales, which is why
 // multi-argument entries keep their placeholders in the same sequence.
 var messages = map[string]map[string]string{
-	"timeofday.morning":   {"en": "Morning", "es": "Mañana"},
+	"common.day":         {"en": "Day %d", "es": "Día %d"},
+	"common.unscheduled": {"en": "Unscheduled", "es": "Sin programar"},
+
+	"email.alert.bag_carry_on":     {"en": "Price includes a carry-on bag per traveler", "es": "El precio incluye un equipaje de mano por viajero"},
+	"email.alert.bag_checked":      {"en": "Price includes a checked bag per traveler", "es": "El precio incluye una maleta facturada por viajero"},
+	"email.alert.best_price":       {"en": "Best price now: %s", "es": "Mejor precio ahora: %s"},
+	"email.alert.book":             {"en": "Search it again and book: %s", "es": "Búscala de nuevo y reserva: %s"},
+	"email.alert.cabin":            {"en": "Cabin: %s · Adults: %d", "es": "Cabina: %s · Adultos: %d"},
+	"email.alert.departing":        {"en": "Departing: %s", "es": "Salida: %s"},
+	"email.alert.departing_flex":   {"en": "Departing: %s (cheapest in your ±%dd window)", "es": "Salida: %s (la más barata en tu ventana de ±%d días)"},
+	"email.alert.footer":           {"en": "Prices change frequently and this fare may not last. Manage or mute this alert under Price alerts in the app.", "es": "Los precios cambian con frecuencia y esta tarifa puede no durar. Gestiona o silencia esta alerta en Alertas de precio, dentro de la app."},
+	"email.alert.lead":             {"en": "Good news — the fare you're watching dropped.", "es": "Buenas noticias: la tarifa que sigues ha bajado."},
+	"email.alert.on_airlines":      {"en": "on %s", "es": "en %s"},
+	"email.alert.previously":       {"en": "Previously: %s %.0f", "es": "Antes: %s %.0f"},
+	"email.alert.returning":        {"en": "Returning: %s", "es": "Regreso: %s"},
+	"email.alert.route":            {"en": "Route: %s", "es": "Ruta: %s"},
+	"email.alert.subject_drop":     {"en": "Price drop: %s now %s", "es": "Bajada de precio: %s ahora %s"},
+	"email.alert.subject_target":   {"en": "Target price hit: %s now %s", "es": "Precio objetivo alcanzado: %s ahora %s"},
+	"email.alert.your_target":      {"en": "Your target: %s %.0f", "es": "Tu objetivo: %s %.0f"},
+	"email.invite.body":            {"en": "%s invited you to co-plan \"%s\" on Golden Tempo Travel.\n\nOpen this link to see the trip and join as a co-planner:\n\n%s\n\nThe link works once and expires in 7 days. If you weren't expecting this, you can ignore this email.", "es": "%s te ha invitado a planificar «%s» juntos en Golden Tempo Travel.\n\nAbre este enlace para ver el viaje y unirte como coplanificador:\n\n%s\n\nEl enlace funciona una sola vez y caduca en 7 días. Si no esperabas este correo, puedes ignorarlo."},
+	"email.invite.default_sender":  {"en": "A traveler", "es": "Alguien"},
+	"email.invite.subject":         {"en": "%s invited you to co-plan \"%s\"", "es": "%s te ha invitado a planificar «%s» juntos"},
+	"email.nudge.body":             {"en": "You started planning a trip but haven't been back in a while — your work is saved right where you left it.", "es": "Empezaste a planificar un viaje, pero hace tiempo que no vuelves: tu trabajo sigue guardado justo donde lo dejaste."},
+	"email.nudge.greeting":         {"en": "Hi %s,", "es": "Hola, %s:"},
+	"email.nudge.greeting_generic": {"en": "Hi there,", "es": "¡Hola!"},
+	"email.nudge.resume":           {"en": "Jump back in: %s", "es": "Vuelve a entrar aquí: %s"},
+	"email.nudge.subject":          {"en": "Pick up where you left off", "es": "Retoma donde lo dejaste"},
+	"email.nudge.unsubscribe":      {"en": "Not planning anything right now? Unsubscribe from these nudges: %s", "es": "¿No estás planificando nada ahora mismo? Cancela la suscripción a estos recordatorios: %s"},
+	"email.reminder.departure":     {"en": "Departure: %s", "es": "Salida: %s"},
+	"email.reminder.lead_soon":     {"en": "Your trip \"%s\" is coming up in %d days.", "es": "Tu viaje «%s» comienza dentro de %d días."},
+	"email.reminder.lead_today":    {"en": "Today's the day — \"%s\" begins.", "es": "Hoy es el día: «%s» comienza."},
+	"email.reminder.open":          {"en": "Open your itinerary: %s", "es": "Abre tu itinerario: %s"},
+	"email.reminder.signoff":       {"en": "Safe travels!", "es": "¡Buen viaje!"},
+	"email.reminder.subject_soon":  {"en": "Your trip \"%s\" starts in %d days", "es": "Tu viaje «%s» empieza dentro de %d días"},
+	"email.reminder.subject_today": {"en": "Your trip \"%s\" starts today", "es": "Tu viaje «%s» empieza hoy"},
+	"email.reminder.unsubscribe":   {"en": "To stop trip reminders, unsubscribe here: %s", "es": "Para dejar de recibir recordatorios de viaje, cancela la suscripción aquí: %s"},
+	"email.reset.body":             {"en": "Someone (hopefully you) asked to reset your Golden Tempo Travel password.\n\nReset your password: %s\n\nIf the link doesn't open, use this reset code instead:\n\n    %s\n\nIn the app, choose \"Forgot password?\", paste the code, and pick a new password. The link and code are valid for 1 hour and work once. If this wasn't you, ignore this email — your password is unchanged.", "es": "Alguien (esperamos que tú) pidió restablecer tu contraseña de Golden Tempo Travel.\n\nRestablece tu contraseña: %s\n\nSi el enlace no se abre, usa este código de restablecimiento:\n\n    %s\n\nEn la app, elige «¿Olvidaste tu contraseña?», pega el código y elige una contraseña nueva. El enlace y el código son válidos durante 1 hora y funcionan una sola vez. Si no fuiste tú, ignora este correo: tu contraseña no ha cambiado."},
+	"email.reset.subject":          {"en": "Reset your password — Golden Tempo Travel", "es": "Restablece tu contraseña — Golden Tempo Travel"},
+	"email.verify.body":            {"en": "Welcome to Golden Tempo Travel!\n\nConfirm your email address by opening this link:\n\n%s\n\nThe link expires in 24 hours. If you didn't create an account, you can ignore this email.", "es": "¡Te damos la bienvenida a Golden Tempo Travel!\n\nConfirma tu dirección de correo abriendo este enlace:\n\n%s\n\nEl enlace caduca en 24 horas. Si no creaste una cuenta, puedes ignorar este correo."},
+	"email.verify.subject":         {"en": "Confirm your email — Golden Tempo Travel", "es": "Confirma tu correo — Golden Tempo Travel"},
+
+	"ics.mode.bus":      {"en": "Bus", "es": "Autobús"},
+	"ics.mode.car":      {"en": "Car", "es": "Coche"},
+	"ics.mode.ferry":    {"en": "Ferry", "es": "Ferri"},
+	"ics.mode.flight":   {"en": "Flight", "es": "Vuelo"},
+	"ics.mode.other":    {"en": "Other", "es": "Otro"},
+	"ics.mode.train":    {"en": "Train", "es": "Tren"},
+	"ics.recommendedBy": {"en": "Recommended by %s", "es": "Recomendado por %s"},
+	"ics.segmentTitle":  {"en": "%s: %s", "es": "%s: %s"},
+	"ics.stayTitle":     {"en": "Stay: %s", "es": "Alojamiento: %s"},
+
+	"notif.aTraveler": {"en": "A traveler", "es": "Un viajero"},
+
+	"page.verify.expired.body":  {"en": "Request a new verification email from your account.", "es": "Pide un nuevo correo de verificación desde tu cuenta."},
+	"page.verify.expired.title": {"en": "Link expired or already used", "es": "El enlace caducó o ya se usó"},
+	"page.verify.ok.body":       {"en": "You're all set — head back to %s.", "es": "Todo listo: vuelve a %s."},
+	"page.verify.ok.title":      {"en": "Email verified ✓", "es": "Correo verificado ✓"},
+
+	"print.accommodations":       {"en": "Accommodations", "es": "Alojamientos"},
+	"print.arrives":              {"en": "Arrives %s", "es": "Llega el %s"},
+	"print.booked":               {"en": "(booked)", "es": "(reservado)"},
+	"print.bookingChecklist":     {"en": "Booking checklist", "es": "Lista de reservas"},
+	"print.budget":               {"en": "Budget", "es": "Presupuesto"},
+	"print.checkIn":              {"en": "Check-in %s", "es": "Entrada %s"},
+	"print.checkInToday":         {"en": "Check in today", "es": "Entrada hoy"},
+	"print.checkOut":             {"en": "Check-out %s", "es": "Salida %s"},
+	"print.checkOutOn":           {"en": "Check out %s", "es": "Salida el %s"},
+	"print.dateWithYear":         {"en": "%s, %d", "es": "%s de %d"},
+	"print.dayTripFrom":          {"en": "Day trip from %s", "es": "Excursión de un día desde %s"},
+	"print.departs":              {"en": "Departs %s", "es": "Sale el %s"},
+	"print.emptyExport":          {"en": "This trip has nothing to export yet.", "es": "Este viaje aún no tiene nada que exportar."},
+	"print.footer":               {"en": "Exported from Golden Tempo Travel", "es": "Exportado desde Golden Tempo Travel"},
+	"print.itinerary":            {"en": "Itinerary", "es": "Itinerario"},
+	"print.linkUnavailableBody":  {"en": "It may have expired.", "es": "Puede que haya caducado."},
+	"print.linkUnavailableTitle": {"en": "This export link isn't available", "es": "Este enlace de exportación no está disponible"},
+	"print.noPlans":              {"en": "No plans yet for this day.", "es": "Aún no hay planes para este día."},
+	"print.otherTransport":       {"en": "Other transport", "es": "Otros transportes"},
+	"print.packingChecklist":     {"en": "Packing checklist", "es": "Lista de equipaje"},
+	"print.recommendedBy":        {"en": "Recommended by", "es": "Recomendado por"},
+	"print.remaining":            {"en": "Remaining:", "es": "Restante:"},
+	"print.target":               {"en": "Target:", "es": "Objetivo:"},
+	"print.tonight":              {"en": "Tonight:", "es": "Esta noche:"},
+	"print.totalSpent":           {"en": "Total spent:", "es": "Total gastado:"},
+	"print.untitledTrip":         {"en": "Untitled trip", "es": "Viaje sin título"},
+	"print.weather":              {"en": "Weather", "es": "Tiempo"},
+	"print.weatherRainChance":    {"en": ", %d%% chance of rain", "es": ", %d%% de probabilidad de lluvia"},
+	"print.weatherRainMm":        {"en": ", %.0fmm rain", "es": ", %.0f mm de lluvia"},
+	"print.weatherTypical":       {"en": "Typical: %s", "es": "Típico: %s"},
+
+	"review.confirmBooking":       {"en": "Confirm your booking for %s.", "es": "Confirma tu reserva de %s."},
+	"review.emptyDay":             {"en": "Day %d has nothing planned.", "es": "El día %d no tiene nada planificado."},
+	"review.fix.addBus":           {"en": "Add bus", "es": "Añadir autobús"},
+	"review.fix.addDrive":         {"en": "Add drive", "es": "Añadir trayecto en coche"},
+	"review.fix.addFerry":         {"en": "Add ferry", "es": "Añadir ferri"},
+	"review.fix.addStay":          {"en": "Add a stay", "es": "Añadir alojamiento"},
+	"review.fix.addSunProtection": {"en": "+ sun protection", "es": "+ protección solar"},
+	"review.fix.addTrain":         {"en": "Add train", "es": "Añadir tren"},
+	"review.fix.addTransport":     {"en": "Add transport", "es": "Añadir transporte"},
+	"review.fix.addUmbrella":      {"en": "+ umbrella", "es": "+ paraguas"},
+	"review.fix.addWarmLayers":    {"en": "+ warm layers", "es": "+ ropa de abrigo"},
+	"review.fix.adjustBudget":     {"en": "Adjust budget", "es": "Ajustar el presupuesto"},
+	"review.fix.markBooked":       {"en": "Mark booked", "es": "Marcar como reservado"},
+	"review.fix.moveToDay":        {"en": "Move to Day %d", "es": "Mover al día %d"},
+	"review.fix.reschedule":       {"en": "Reschedule", "es": "Reprogramar"},
+	"review.fix.setDates":         {"en": "Set dates", "es": "Añadir fechas"},
+	"review.itemBeyondSpan":       {"en": "%q is on day %d, past the trip's %d-day span.", "es": "%q está en el día %d, más allá de la duración de %d días del viaje."},
+	"review.mayBeClosed":          {"en": "%s may be closed on %s (Day %d).", "es": "%s puede estar cerrado el %s (día %d)."},
+	"review.noDates":              {"en": "Add trip dates to unlock day-by-day checks.", "es": "Añade las fechas del viaje para desbloquear las comprobaciones día a día."},
+	"review.noLodging":            {"en": "No lodging booked for the night of %s.", "es": "No hay alojamiento reservado para la noche del %s."},
+	"review.noTransport":          {"en": "No transport booked from %s to %s.", "es": "No hay transporte reservado de %s a %s."},
+	"review.overBudget":           {"en": "Over budget by %.2f %s.", "es": "Te has pasado del presupuesto por %.2f %s."},
+	"review.packedDay":            {"en": "Day %d has %d items planned — that may be too packed.", "es": "El día %d tiene %d actividades planificadas — puede que sea demasiado."},
+	"review.rainLikely":           {"en": "Rain likely on Day %d (%s) — pack an umbrella.", "es": "Es probable que llueva el día %d (%s) — lleva paraguas."},
+	"review.timeOfDayCollision":   {"en": "Day %d has %d things scheduled for the %s.", "es": "El día %d tiene %d cosas programadas para %s."},
+	"review.tod.afternoon":        {"en": "afternoon", "es": "la tarde"},
+	"review.tod.evening":          {"en": "evening", "es": "la noche"},
+	"review.tod.morning":          {"en": "morning", "es": "la mañana"},
+	"review.unscheduledMany":      {"en": "%d items have no day assigned — schedule them to see them on the day plan.", "es": "%d actividades no tienen día asignado — prográmalas para verlas en el plan diario."},
+	"review.unscheduledOne":       {"en": "1 item has no day assigned — schedule it to see it on the day plan.", "es": "1 actividad no tiene día asignado — prográmala para verla en el plan diario."},
+	"review.veryCold":             {"en": "Day %d (%s) could be very cold (%.0f°C) — pack warm layers.", "es": "El día %d (%s) puede hacer mucho frío (%.0f °C) — lleva ropa de abrigo."},
+	"review.veryHot":              {"en": "Day %d (%s) could be very hot (%.0f°C) — plan for the heat.", "es": "El día %d (%s) puede hacer mucho calor (%.0f °C) — prepárate para el calor."},
+
+	"share.aTraveler":              {"en": "a traveler", "es": "un viajero"},
+	"share.dateWithYear":           {"en": "%s, %d", "es": "%s de %d"},
+	"share.plannedBy":              {"en": "Planned by %s", "es": "Planificado por %s"},
+	"share.temporarilyUnavailable": {"en": "Temporarily unavailable", "es": "No disponible temporalmente"},
+	"share.unavailableBody":        {"en": "The link may have been turned off.", "es": "Puede que el enlace se haya desactivado."},
+	"share.unavailableTitle":       {"en": "This trip isn't available", "es": "Este viaje no está disponible"},
+
 	"timeofday.afternoon": {"en": "Afternoon", "es": "Tarde"},
 	"timeofday.evening":   {"en": "Evening", "es": "Noche"},
-	"common.day":          {"en": "Day %d", "es": "Día %d"},
-	"common.unscheduled":  {"en": "Unscheduled", "es": "Sin programar"},
+	"timeofday.morning":   {"en": "Morning", "es": "Mañana"},
+
+	"weekday.friday":    {"en": "Friday", "es": "viernes"},
+	"weekday.monday":    {"en": "Monday", "es": "lunes"},
+	"weekday.saturday":  {"en": "Saturday", "es": "sábado"},
+	"weekday.sunday":    {"en": "Sunday", "es": "domingo"},
+	"weekday.thursday":  {"en": "Thursday", "es": "jueves"},
+	"weekday.tuesday":   {"en": "Tuesday", "es": "martes"},
+	"weekday.wednesday": {"en": "Wednesday", "es": "miércoles"},
 }
 
 // tr renders a catalog entry in the given locale, falling back to English and
@@ -212,6 +347,25 @@ var esMonthsLong = [...]string{
 
 // Indexed by time.Weekday (Sunday = 0).
 var esWeekdaysShort = [...]string{"dom", "lun", "mar", "mié", "jue", "vie", "sáb"}
+
+// weekdayKeys maps a time.Weekday to its catalog key. time.Weekday.String() is
+// hardcoded English, the same reason localizedDate exists — anything that names
+// a day of the week to a user goes through the catalog.
+// Indexed by time.Weekday (Sunday = 0).
+var weekdayKeys = [...]string{
+	"weekday.sunday",
+	"weekday.monday",
+	"weekday.tuesday",
+	"weekday.wednesday",
+	"weekday.thursday",
+	"weekday.friday",
+	"weekday.saturday",
+}
+
+// localizedWeekday names a day of the week in the given locale.
+func localizedWeekday(locale string, w time.Weekday) string {
+	return tr(locale, weekdayKeys[w])
+}
 
 // localizedDate renders t in the given style and locale. Spanish uses
 // day-before-month ordering, which is why this switches on locale rather than

--- a/src/packages/api/invite_handler.go
+++ b/src/packages/api/invite_handler.go
@@ -120,24 +120,32 @@ func createTripInviteHandler(w http.ResponseWriter, r *http.Request) {
 		writeJSONError(w, http.StatusInternalServerError, "could not create invite")
 		return
 	}
+	// The invite is read by the RECIPIENT, so their stored language wins when
+	// they already have an account. Strangers have no stored locale, so the
+	// inviter's request locale is the only signal there is. Resolved here (in
+	// the request) rather than in the goroutine, which has no context; the
+	// lookup can't leak account existence because the response is unchanged.
+	inviteLocale := requestLocale(r.Context())
+	if recipient, err := q.GetUserByEmail(r.Context(), email); err == nil {
+		inviteLocale = localeOrDefault(recipient.Locale)
+	}
 	// Fire-and-forget like sendVerificationEmail; degraded SMTP logs the
 	// body, and a send failure never fails the request.
-	safeGo("sendInviteEmail", func() { sendInviteEmail(user, invite.Email, token, trip.Title) })
+	safeGo("sendInviteEmail", func() { sendInviteEmail(user, invite.Email, token, trip.Title, inviteLocale) })
 	safeGo("recordEvent", func() { recordEvent(user.ID, "invite_sent", &trip.ID, nil) })
 	writeJSON(w, http.StatusCreated, toInviteResponse(invite))
 }
 
-// sendInviteEmail composes and sends the invite link.
-func sendInviteEmail(owner store.User, to, token, tripTitle string) {
-	ownerName := "A traveler"
+// sendInviteEmail composes and sends the invite link, in the recipient's
+// language.
+func sendInviteEmail(owner store.User, to, token, tripTitle, locale string) {
+	ownerName := tr(locale, "email.invite.default_sender")
 	if owner.DisplayName != nil && *owner.DisplayName != "" {
 		ownerName = *owner.DisplayName
 	}
 	link := publicAppURL("invite/", token)
-	body := ownerName + " invited you to co-plan \"" + tripTitle + "\" on Golden Tempo Travel.\n\n" +
-		"Open this link to see the trip and join as a co-planner:\n\n" + link + "\n\n" +
-		"The link works once and expires in 7 days. If you weren't expecting this, you can ignore this email."
-	if err := emailService.Send(to, ownerName+" invited you to co-plan \""+tripTitle+"\"", body); err != nil {
+	body := tr(locale, "email.invite.body", ownerName, tripTitle, link)
+	if err := emailService.Send(to, tr(locale, "email.invite.subject", ownerName, tripTitle), body); err != nil {
 		log.Printf("invite email: send to %s failed: %v", to, err)
 	}
 }

--- a/src/packages/api/notifications_writer.go
+++ b/src/packages/api/notifications_writer.go
@@ -48,7 +48,19 @@ func notifyInviteAccepted(ownerID uuid.UUID, accepter store.User, trip store.Tri
 	if dbPool == nil {
 		return
 	}
-	name := "A traveler"
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// There is no request here, and the row is read by the OWNER — so the
+	// fallback label is written in the owner's stored locale, not the
+	// accepter's. Only this one value is display text; "accepter_name" and
+	// "trip_title" are payload keys the client renders around, and trip.Title
+	// is traveler data.
+	locale := defaultLocale
+	if owner, err := store.New(dbPool).GetUserByID(ctx, ownerID); err == nil {
+		locale = localeOrDefault(owner.Locale)
+	}
+	name := tr(locale, "notif.aTraveler")
 	if accepter.DisplayName != nil && *accepter.DisplayName != "" {
 		name = *accepter.DisplayName
 	}
@@ -59,8 +71,6 @@ func notifyInviteAccepted(ownerID uuid.UUID, accepter store.User, trip store.Tri
 	if err != nil {
 		return
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
 	if _, err := store.New(dbPool).InsertNotification(ctx, store.InsertNotificationParams{
 		UserID:  ownerID,
 		Type:    "invite_accepted",

--- a/src/packages/api/places_service.go
+++ b/src/packages/api/places_service.go
@@ -185,6 +185,10 @@ func (gps *GooglePlacesService) SearchPlaces(ctx context.Context, query string) 
 	params := url.Values{}
 	params.Add("query", query)
 	params.Add("key", gps.APIKey)
+	// Ask the provider for the traveler's language so place names and addresses
+	// come back localized (specs/i18n-spanish). Falls back to "en" outside a
+	// request, which is what background callers want anyway.
+	params.Add("language", requestLocale(ctx))
 
 	gps.searchCalls.upstream.Add(1)
 	resp, err := gps.doGet(ctx, placesTextSearchURL+"?"+params.Encode())
@@ -257,6 +261,10 @@ func (gps *GooglePlacesService) GetPlaceAutocomplete(ctx context.Context, input 
 	params := url.Values{}
 	params.Add("input", input)
 	params.Add("key", gps.APIKey)
+	// Ask the provider for the traveler's language so place names and addresses
+	// come back localized (specs/i18n-spanish). Falls back to "en" outside a
+	// request, which is what background callers want anyway.
+	params.Add("language", requestLocale(ctx))
 
 	gps.autocompleteCalls.upstream.Add(1)
 	resp, err := gps.doGet(ctx, placesAutocompleteURL+"?"+params.Encode())
@@ -315,6 +323,10 @@ func (gps *GooglePlacesService) GetPlaceDetails(ctx context.Context, placeID str
 	params.Add("place_id", placeID)
 	params.Add("fields", "place_id,name,formatted_address,geometry,types,rating,price_level,opening_hours,website,formatted_phone_number")
 	params.Add("key", gps.APIKey)
+	// Ask the provider for the traveler's language so place names and addresses
+	// come back localized (specs/i18n-spanish). Falls back to "en" outside a
+	// request, which is what background callers want anyway.
+	params.Add("language", requestLocale(ctx))
 
 	gps.detailsCalls.upstream.Add(1)
 	resp, err := gps.doGet(ctx, placesDetailsURL+"?"+params.Encode())

--- a/src/packages/api/plan_handler.go
+++ b/src/packages/api/plan_handler.go
@@ -397,6 +397,16 @@ func planHandler(w http.ResponseWriter, r *http.Request) {
 			systemPrompt += "\n\nThis trip's travel mode is " + *boundTripTravelMode + "; keep new transport suggestions in that mode."
 		}
 	}
+	// Response language (specs/i18n-spanish). Appended ONLY for non-English
+	// locales, so an English request's prompt is byte-for-byte what it was
+	// before this feature existed — see TestSystemPromptEnglishUnchanged.
+	//
+	// This is deliberately NOT a save_preferences field: plan_tool_registry.go
+	// is part of the prompt-cache prefix and must stay byte-stable, and the
+	// agent must not be able to overwrite the traveler's language. Spanish
+	// conversations simply get their own cache line, which caches normally
+	// across turns because the locale is constant within a conversation.
+	systemPrompt += responseLanguageInstruction(requestLocale(ctx))
 
 	// prevCacheMarker tracks the conversation cache breakpoint set on the
 	// newest tool-results message; it must be cleared before setting the next
@@ -614,6 +624,19 @@ func summarizeEvents(city string, events []Event) string {
 // profileNotesInstruction is the standing profile-keeping rule appended to every
 // authenticated session's system prompt, whether or not notes exist yet.
 const profileNotesInstruction = "\n\nWhen you learn something durable about this traveler — travel companions, dietary needs, accommodation style, accessibility needs, likes or dislikes — call save_preferences with profile_notes set to the COMPLETE updated profile: your current notes merged with the new fact, de-duplicated, as short bullet lines (max ~15). Never send only the new fact. Don't store one-off trip details or sensitive information (health, religion, politics) unless the traveler explicitly asks you to remember it."
+
+// responseLanguageInstruction tells the agent which language to write in.
+// Returns "" for English so the English prompt is unchanged; structured tool
+// arguments are pinned to their canonical formats because the tool schemas and
+// the database expect them regardless of the traveler's language. The trailing
+// clause keeps the agent following a traveler who writes in a third language
+// rather than fighting them.
+func responseLanguageInstruction(locale string) string {
+	if locale == defaultLocale {
+		return ""
+	}
+	return "\n\nRespond in " + languageName(locale) + ": all prose, trip titles, day summaries and place descriptions. Keep structured tool arguments in their required formats — dates as YYYY-MM-DD, IATA airport codes, and enum values (time_of_day, category, budget, pace, mode) exactly as the tool schemas specify. If the traveler writes in another language, follow their language instead."
+}
 
 // personalizedSystemPrompt appends the traveler's saved preferences and
 // AI-maintained profile notes to the base prompt, omitting any fields that are

--- a/src/packages/api/plan_language_integration_test.go
+++ b/src/packages/api/plan_language_integration_test.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// The response-language instruction (specs/i18n-spanish) is the one change in
+// this feature that touches the model's input, so it gets the strictest test in
+// the suite: English requests must produce a byte-for-byte unchanged system
+// prompt, and Spanish must add the instruction and nothing else.
+
+// systemPromptFrom pulls the single system block out of a captured
+// /v1/messages request body.
+func systemPromptFrom(t *testing.T, body []byte) string {
+	t.Helper()
+	var req struct {
+		System []struct {
+			Text string `json:"text"`
+		} `json:"system"`
+	}
+	if err := json.Unmarshal(body, &req); err != nil {
+		t.Fatalf("decode request body: %v", err)
+	}
+	if len(req.System) != 1 {
+		t.Fatalf("system blocks = %d, want 1", len(req.System))
+	}
+	return req.System[0].Text
+}
+
+// planWithLocale drives /plan with an explicit Accept-Language and returns the
+// system prompt the model received.
+func planWithLocale(t *testing.T, acceptLanguage string) string {
+	t.Helper()
+	fa := newFakeAnthropic(t, textTurn("ok"))
+
+	body, err := json.Marshal(PlanRequest{
+		ChatID:   "chat-lang",
+		Messages: []PlanChatMessage{{Role: "user", Content: "hola"}},
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	req := httptest.NewRequest("POST", "/api/v1/plan", strings.NewReader(string(body)))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Forwarded-For", nextTestIP())
+	if acceptLanguage != "" {
+		req.Header.Set("Accept-Language", acceptLanguage)
+	}
+	rec := httptest.NewRecorder()
+	testRouter.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("/plan = %d: %s", rec.Code, rec.Body.String())
+	}
+	bodies := fa.requestBodies()
+	if len(bodies) == 0 {
+		t.Fatal("fake anthropic received no requests")
+	}
+	return systemPromptFrom(t, bodies[0])
+}
+
+// The load-bearing regression test: English behavior must be untouched by the
+// whole i18n feature. If this fails, English users' prompt-cache prefix and
+// model behavior have changed.
+func TestSystemPromptEnglishUnchanged(t *testing.T) {
+	resetDB(t)
+	for _, header := range []string{"", "en", "en-US,en;q=0.9", "fr"} {
+		prompt := planWithLocale(t, header)
+		if strings.Contains(prompt, "Respond in") {
+			t.Errorf("Accept-Language %q: English prompt gained a language instruction:\n%s",
+				header, prompt)
+		}
+		// These requests are anonymous and not trip-bound, so the prompt is
+		// exactly basePrompt — it must still end on basePrompt's final
+		// sentence, proving nothing was appended.
+		if !strings.HasSuffix(prompt, "no headings or tables.") {
+			t.Errorf("Accept-Language %q: prompt does not end with basePrompt's "+
+				"final sentence — something was appended:\n...%s", header,
+				prompt[max(0, len(prompt)-160):])
+		}
+	}
+}
+
+// Spanish adds the instruction, and adds it to the END so the cached prefix
+// (tools + basePrompt) is otherwise identical.
+func TestSystemPromptSpanishAddsLanguageInstruction(t *testing.T) {
+	resetDB(t)
+	english := planWithLocale(t, "en")
+	spanish := planWithLocale(t, "es-MX,es;q=0.9")
+
+	if !strings.HasPrefix(spanish, english) {
+		t.Fatal("Spanish prompt is not the English prompt plus a suffix; the shared prefix changed")
+	}
+	added := strings.TrimPrefix(spanish, english)
+	for _, want := range []string{
+		"Respond in Spanish (español)",
+		"YYYY-MM-DD",
+		"If the traveler writes in another language",
+	} {
+		if !strings.Contains(added, want) {
+			t.Errorf("Spanish instruction missing %q; got:\n%s", want, added)
+		}
+	}
+}
+
+// The instruction is a pure function of the locale, so its English no-op and
+// its per-locale wording are worth pinning without a DB or a fake server.
+func TestResponseLanguageInstruction(t *testing.T) {
+	if got := responseLanguageInstruction("en"); got != "" {
+		t.Errorf("English instruction = %q, want empty", got)
+	}
+	es := responseLanguageInstruction("es")
+	if !strings.Contains(es, "Spanish (español)") {
+		t.Errorf("Spanish instruction = %q", es)
+	}
+	// Unsupported locales must not silently instruct the model in a language
+	// the app cannot render.
+	if got := responseLanguageInstruction("zz"); !strings.Contains(got, "English") {
+		t.Errorf("unknown locale instruction = %q, want the English name", got)
+	}
+}

--- a/src/packages/api/plan_tools_extra.go
+++ b/src/packages/api/plan_tools_extra.go
@@ -303,7 +303,10 @@ func runReviewTripTool(s *planSession, input json.RawMessage) (string, bool) {
 		br = &resp
 	}
 
-	findings := reviewTrip(s.ctx, data,
+	// The agent narrates these findings back to the traveler, so they are
+	// generated in the traveler's language — the same locale that drives the
+	// response-language instruction (specs/i18n-spanish).
+	findings := reviewTrip(s.ctx, requestLocale(s.ctx), data,
 		reviewOptions{CheckHours: false, Budget: br},
 		reviewDeps{Weather: weatherService})
 	return formatReviewFindings(findings), false

--- a/src/packages/api/price_alert_checker.go
+++ b/src/packages/api/price_alert_checker.go
@@ -326,7 +326,10 @@ func (c *alertChecker) settle(ctx context.Context, q *store.Queries, row store.L
 	}); err != nil {
 		log.Printf("price alerts: insert notification %s: %v", a.ID, err)
 	}
-	safeGo("sendAlertEmail", func() { sendAlertEmail(row.OwnerEmail, a, lowest, matchedParam) })
+	// Background tick, no request to negotiate from: the owner's stored language
+	// rides along on the due-alert row.
+	locale := localeOrDefault(row.OwnerLocale)
+	safeGo("sendAlertEmail", func() { sendAlertEmail(locale, row.OwnerEmail, a, lowest, matchedParam) })
 	tripID := tripIDPtr(a)
 	safeGo("recordEvent", func() {
 		recordEvent(a.UserID, "alert_triggered", tripID, map[string]any{
@@ -409,54 +412,54 @@ func lowestOffer(offers []FlightOffer) (FlightOffer, bool) {
 	return best, found
 }
 
-// buildAlertEmail renders the notification. Pure — unit-tested.
-func buildAlertEmail(a store.PriceAlert, lowest FlightOffer, matched pgtype.Date) (subject, body string) {
+// buildAlertEmail renders the notification in the recipient's language.
+// Pure — unit-tested.
+func buildAlertEmail(locale string, a store.PriceAlert, lowest FlightOffer, matched pgtype.Date) (subject, body string) {
 	route := fmt.Sprintf("%s → %s", a.Origin, a.Destination)
 	price := fmt.Sprintf("%s %.0f", lowest.Currency, scoringPrice(lowest))
 	if a.TargetPrice != nil {
-		subject = fmt.Sprintf("Target price hit: %s now %s", route, price)
+		subject = tr(locale, "email.alert.subject_target", route, price)
 	} else {
-		subject = fmt.Sprintf("Price drop: %s now %s", route, price)
+		subject = tr(locale, "email.alert.subject_drop", route, price)
 	}
 
 	var b strings.Builder
-	fmt.Fprintf(&b, "Good news — the fare you're watching dropped.\n\n")
-	fmt.Fprintf(&b, "Route: %s\n", route)
+	fmt.Fprintf(&b, "%s\n\n", tr(locale, "email.alert.lead"))
+	fmt.Fprintf(&b, "%s\n", tr(locale, "email.alert.route", route))
 	// For a flexible watch the cheapest date in the window may differ from the
 	// nominal departure; name it so the traveler books the right day.
 	if a.FlexDays > 0 && matched.Valid {
-		fmt.Fprintf(&b, "Departing: %s (cheapest in your ±%dd window)\n", dateString(matched), a.FlexDays)
+		fmt.Fprintf(&b, "%s\n", tr(locale, "email.alert.departing_flex", dateString(matched), a.FlexDays))
 	} else {
-		fmt.Fprintf(&b, "Departing: %s\n", dateString(a.DepartDate))
+		fmt.Fprintf(&b, "%s\n", tr(locale, "email.alert.departing", dateString(a.DepartDate)))
 	}
 	if ret := dateString(a.ReturnDate); ret != "" {
-		fmt.Fprintf(&b, "Returning: %s\n", ret)
+		fmt.Fprintf(&b, "%s\n", tr(locale, "email.alert.returning", ret))
 	}
-	fmt.Fprintf(&b, "Cabin: %s · Adults: %d\n", a.CabinClass, a.Adults)
+	fmt.Fprintf(&b, "%s\n", tr(locale, "email.alert.cabin", a.CabinClass, a.Adults))
 	switch a.Baggage {
 	case baggageCarryOn:
-		fmt.Fprintf(&b, "Price includes a carry-on bag per traveler\n")
+		fmt.Fprintf(&b, "%s\n", tr(locale, "email.alert.bag_carry_on"))
 	case baggageChecked:
-		fmt.Fprintf(&b, "Price includes a checked bag per traveler\n")
+		fmt.Fprintf(&b, "%s\n", tr(locale, "email.alert.bag_checked"))
 	}
-	fmt.Fprintf(&b, "\nBest price now: %s", price)
+	fmt.Fprintf(&b, "\n%s", tr(locale, "email.alert.best_price", price))
 	if len(lowest.Airlines) > 0 {
-		fmt.Fprintf(&b, " on %s", strings.Join(lowest.Airlines, "/"))
+		fmt.Fprintf(&b, " %s", tr(locale, "email.alert.on_airlines", strings.Join(lowest.Airlines, "/")))
 	}
 	b.WriteString("\n")
 	if a.TargetPrice != nil {
-		fmt.Fprintf(&b, "Your target: %s %.0f\n", lowest.Currency, *a.TargetPrice)
+		fmt.Fprintf(&b, "%s\n", tr(locale, "email.alert.your_target", lowest.Currency, *a.TargetPrice))
 	} else if a.LastCheckedPrice != nil {
-		fmt.Fprintf(&b, "Previously: %s %.0f\n", lowest.Currency, *a.LastCheckedPrice)
+		fmt.Fprintf(&b, "%s\n", tr(locale, "email.alert.previously", lowest.Currency, *a.LastCheckedPrice))
 	}
-	fmt.Fprintf(&b, "\nSearch it again and book: %s\n", publicAppURL("alerts"))
-	b.WriteString("\nPrices change frequently and this fare may not last. ")
-	b.WriteString("Manage or mute this alert under Price alerts in the app.\n")
+	fmt.Fprintf(&b, "\n%s\n", tr(locale, "email.alert.book", publicAppURL("alerts")))
+	fmt.Fprintf(&b, "\n%s\n", tr(locale, "email.alert.footer"))
 	return subject, b.String()
 }
 
-func sendAlertEmail(to string, a store.PriceAlert, lowest FlightOffer, matched pgtype.Date) {
-	subject, body := buildAlertEmail(a, lowest, matched)
+func sendAlertEmail(locale, to string, a store.PriceAlert, lowest FlightOffer, matched pgtype.Date) {
+	subject, body := buildAlertEmail(locale, a, lowest, matched)
 	if err := emailService.Send(to, subject, body); err != nil {
 		log.Printf("price alerts: email to %s failed: %v", to, err)
 	}

--- a/src/packages/api/price_alert_checker_test.go
+++ b/src/packages/api/price_alert_checker_test.go
@@ -188,7 +188,7 @@ func TestLowestOffer(t *testing.T) {
 func TestBuildAlertEmail(t *testing.T) {
 	t.Setenv("PUBLIC_BASE_URL", "https://app.example.com")
 	a := alertFixture(func(a *store.PriceAlert) { a.TargetPrice = f64(450) })
-	subject, body := buildAlertEmail(a, FlightOffer{Price: 412, Currency: "USD", Airlines: []string{"Air France"}}, pgtype.Date{})
+	subject, body := buildAlertEmail("en", a, FlightOffer{Price: 412, Currency: "USD", Airlines: []string{"Air France"}}, pgtype.Date{})
 
 	if !strings.Contains(subject, "Target price hit") || !strings.Contains(subject, "BOS → CDG") {
 		t.Fatalf("subject = %q", subject)

--- a/src/packages/api/print_view_handler.go
+++ b/src/packages/api/print_view_handler.go
@@ -27,6 +27,44 @@ func capitalize(s string) string {
 	return strings.ToUpper(s[:1]) + s[1:]
 }
 
+// segmentModeKeys maps the stored transport-mode enum to its catalog key. The
+// labels live under ics.* because the .ics event titles are their canonical
+// home (the Flutter client mirrors them byte-for-byte); the print packet reuses
+// the same strings so a segment reads identically on paper and in a calendar.
+var segmentModeKeys = map[string]string{
+	"flight": "ics.mode.flight",
+	"train":  "ics.mode.train",
+	"bus":    "ics.mode.bus",
+	"car":    "ics.mode.car",
+	"ferry":  "ics.mode.ferry",
+	"other":  "ics.mode.other",
+}
+
+// localizedMode renders a transport mode for display. Anything outside the
+// enum falls back to capitalize(), which is exactly what the English output
+// did before localization.
+func localizedMode(locale, mode string) string {
+	if key, ok := segmentModeKeys[strings.ToLower(strings.TrimSpace(mode))]; ok {
+		return tr(locale, key)
+	}
+	return capitalize(mode)
+}
+
+var timeOfDayKeys = map[string]string{
+	"morning":   "timeofday.morning",
+	"afternoon": "timeofday.afternoon",
+	"evening":   "timeofday.evening",
+}
+
+// localizedTimeOfDay renders an itinerary item's time_of_day, falling back to
+// capitalize() for unexpected values.
+func localizedTimeOfDay(locale, tod string) string {
+	if key, ok := timeOfDayKeys[strings.ToLower(strings.TrimSpace(tod))]; ok {
+		return tr(locale, key)
+	}
+	return capitalize(tod)
+}
+
 // print_view_handler.go — GET /api/v1/export/{token}/print.html, a printable
 // full-trip page. Token-gated and PUBLIC (no authMiddleware): the signed token
 // is the capability. Rendered with html/template so every field is
@@ -127,7 +165,53 @@ type printChecklistItem struct {
 	Checked bool
 }
 
+// printLabels holds the page's static chrome in the reader's locale. The
+// template can't call Sprintf, so every label is resolved up front and
+// referenced as {{$.T.X}}; anything with an interpolated value stays a
+// catalog template resolved in Go.
+type printLabels struct {
+	Weather          string
+	Booked           string
+	RecommendedBy    string
+	NoPlans          string
+	Tonight          string
+	EmptyExport      string
+	Unscheduled      string
+	Accommodations   string
+	OtherTransport   string
+	Budget           string
+	Target           string
+	TotalSpent       string
+	Remaining        string
+	BookingChecklist string
+	PackingChecklist string
+	Footer           string
+}
+
+func newPrintLabels(locale string) printLabels {
+	return printLabels{
+		Weather:          tr(locale, "print.weather"),
+		Booked:           tr(locale, "print.booked"),
+		RecommendedBy:    tr(locale, "print.recommendedBy"),
+		NoPlans:          tr(locale, "print.noPlans"),
+		Tonight:          tr(locale, "print.tonight"),
+		EmptyExport:      tr(locale, "print.emptyExport"),
+		Unscheduled:      tr(locale, "common.unscheduled"),
+		Accommodations:   tr(locale, "print.accommodations"),
+		OtherTransport:   tr(locale, "print.otherTransport"),
+		Budget:           tr(locale, "print.budget"),
+		Target:           tr(locale, "print.target"),
+		TotalSpent:       tr(locale, "print.totalSpent"),
+		Remaining:        tr(locale, "print.remaining"),
+		BookingChecklist: tr(locale, "print.bookingChecklist"),
+		PackingChecklist: tr(locale, "print.packingChecklist"),
+		Footer:           tr(locale, "print.footer"),
+	}
+}
+
 type printViewData struct {
+	Lang          string
+	T             printLabels
 	Title         string
 	Dates         string
 	Summary       string
@@ -144,7 +228,7 @@ type printViewData struct {
 // printViewTmpl uses html/template — every field is auto-escaped. Brand house
 // style (teal gradient header) cloned from dockerize/static/privacy.html.
 var printViewTmpl = template.Must(template.New("print-view").Parse(`<!DOCTYPE html>
-<html lang="en">
+<html lang="{{.Lang}}">
 <head>
   <meta charset="utf-8">
   <title>{{.Title}} — Golden Tempo Travel</title>
@@ -221,7 +305,7 @@ var printViewTmpl = template.Must(template.New("print-view").Parse(`<!DOCTYPE ht
     </div>
   </header>
   <main>
-    {{if not .HasContent}}<p class="empty">This trip has nothing to export yet.</p>{{end}}
+    {{if not .HasContent}}<p class="empty">{{$.T.EmptyExport}}</p>{{end}}
 
     {{if .Summary}}<p class="summary">{{.Summary}}</p>{{end}}
 
@@ -229,10 +313,10 @@ var printViewTmpl = template.Must(template.New("print-view").Parse(`<!DOCTYPE ht
     <section class="day-sec">
       <h2>{{.Label}}{{if .Date}} · {{.Date}}{{end}}{{if .Hub}} — {{.Hub}}{{end}}</h2>
       {{if .DayTrip}}<p class="daytrip">{{.DayTrip}}</p>{{end}}
-      {{if .Weather}}<p class="wx">Weather: {{.Weather}}</p>{{end}}
+      {{if .Weather}}<p class="wx">{{$.T.Weather}}: {{.Weather}}</p>{{end}}
       {{range .Segments}}
       <div class="row">
-        <div class="row-title">{{.Mode}} · {{.Route}}{{if .Booked}} <span class="booked">(booked)</span>{{end}}</div>
+        <div class="row-title">{{.Mode}} · {{.Route}}{{if .Booked}} <span class="booked">{{$.T.Booked}}</span>{{end}}</div>
         {{if .Meta}}<div class="row-meta">{{.Meta}}</div>{{end}}
         {{if .Notes}}<div class="row-meta">{{.Notes}}</div>{{end}}
         {{if .URLText}}<div class="url"><a href="{{.URL}}">{{.URLText}}</a></div>{{end}}
@@ -242,13 +326,13 @@ var printViewTmpl = template.Must(template.New("print-view").Parse(`<!DOCTYPE ht
       <div class="item">
         <div class="item-name">{{.Name}}</div>
         {{if or .TimeOfDay .City .Address}}<div class="item-meta">{{if .TimeOfDay}}{{.TimeOfDay}}{{end}}{{if and .TimeOfDay .City}} · {{end}}{{.City}}{{if and (or .TimeOfDay .City) .Address}} · {{end}}{{.Address}}</div>{{end}}
-        {{if .RecommendedBy}}<div class="rec">Recommended by {{.RecommendedBy}}</div>{{end}}
+        {{if .RecommendedBy}}<div class="rec">{{$.T.RecommendedBy}} {{.RecommendedBy}}</div>{{end}}
       </div>
       {{end}}
-      {{if not .Items}}<p class="empty">No plans yet for this day.</p>{{end}}
+      {{if not .Items}}<p class="empty">{{$.T.NoPlans}}</p>{{end}}
       {{range .Stays}}
       <div class="stay">
-        <div class="row-title">Tonight: {{.Name}}{{if .Booked}} <span class="booked">(booked)</span>{{end}}</div>
+        <div class="row-title">{{$.T.Tonight}} {{.Name}}{{if .Booked}} <span class="booked">{{$.T.Booked}}</span>{{end}}</div>
         {{if .Address}}<div class="row-meta">{{.Address}}</div>{{end}}
         {{if .Meta}}<div class="row-meta">{{.Meta}}</div>{{end}}
         {{if .URLText}}<div class="url"><a href="{{.URL}}">{{.URLText}}</a></div>{{end}}
@@ -258,7 +342,7 @@ var printViewTmpl = template.Must(template.New("print-view").Parse(`<!DOCTYPE ht
     {{end}}
 
     {{if .Unscheduled}}
-    <h2>Unscheduled</h2>
+    <h2>{{$.T.Unscheduled}}</h2>
     {{range .Unscheduled}}
     <div class="hub">
       <p class="hub-name">{{.Hub}}</p>
@@ -269,7 +353,7 @@ var printViewTmpl = template.Must(template.New("print-view").Parse(`<!DOCTYPE ht
         <div class="item">
           <div class="item-name">{{.Name}}</div>
           {{if or .TimeOfDay .Address}}<div class="item-meta">{{if .TimeOfDay}}{{.TimeOfDay}}{{end}}{{if and .TimeOfDay .Address}} · {{end}}{{.Address}}</div>{{end}}
-          {{if .RecommendedBy}}<div class="rec">Recommended by {{.RecommendedBy}}</div>{{end}}
+          {{if .RecommendedBy}}<div class="rec">{{$.T.RecommendedBy}} {{.RecommendedBy}}</div>{{end}}
         </div>
         {{end}}
       </div>
@@ -279,10 +363,10 @@ var printViewTmpl = template.Must(template.New("print-view").Parse(`<!DOCTYPE ht
     {{end}}
 
     {{if .OtherStays}}
-    <h2>Accommodations</h2>
+    <h2>{{$.T.Accommodations}}</h2>
     {{range .OtherStays}}
     <div class="row">
-      <div class="row-title">{{.Name}}{{if .Booked}} <span class="booked">(booked)</span>{{end}}</div>
+      <div class="row-title">{{.Name}}{{if .Booked}} <span class="booked">{{$.T.Booked}}</span>{{end}}</div>
       {{if .Address}}<div class="row-meta">{{.Address}}</div>{{end}}
       {{if .Meta}}<div class="row-meta">{{.Meta}}</div>{{end}}
       {{if .URLText}}<div class="url"><a href="{{.URL}}">{{.URLText}}</a></div>{{end}}
@@ -291,10 +375,10 @@ var printViewTmpl = template.Must(template.New("print-view").Parse(`<!DOCTYPE ht
     {{end}}
 
     {{if .OtherSegments}}
-    <h2>Other transport</h2>
+    <h2>{{$.T.OtherTransport}}</h2>
     {{range .OtherSegments}}
     <div class="row">
-      <div class="row-title">{{.Mode}} · {{.Route}}{{if .Booked}} <span class="booked">(booked)</span>{{end}}</div>
+      <div class="row-title">{{.Mode}} · {{.Route}}{{if .Booked}} <span class="booked">{{$.T.Booked}}</span>{{end}}</div>
       {{if .Meta}}<div class="row-meta">{{.Meta}}</div>{{end}}
       {{if .Notes}}<div class="row-meta">{{.Notes}}</div>{{end}}
       {{if .URLText}}<div class="url"><a href="{{.URL}}">{{.URLText}}</a></div>{{end}}
@@ -303,8 +387,8 @@ var printViewTmpl = template.Must(template.New("print-view").Parse(`<!DOCTYPE ht
     {{end}}
 
     {{with .Budget}}
-    <h2>Budget ({{.Currency}})</h2>
-    {{if .Target}}<p class="budget-line">Target: {{.Target}}</p>{{end}}
+    <h2>{{$.T.Budget}} ({{.Currency}})</h2>
+    {{if .Target}}<p class="budget-line">{{$.T.Target}} {{.Target}}</p>{{end}}
     {{if .Rows}}
     <table class="budget">
       {{range .Rows}}
@@ -312,21 +396,21 @@ var printViewTmpl = template.Must(template.New("print-view").Parse(`<!DOCTYPE ht
       {{end}}
     </table>
     {{end}}
-    <p class="budget-line">Total spent: {{.Spent}}{{if .Remaining}} · Remaining: {{.Remaining}}{{end}}</p>
+    <p class="budget-line">{{$.T.TotalSpent}} {{.Spent}}{{if .Remaining}} · {{$.T.Remaining}} {{.Remaining}}{{end}}</p>
     {{end}}
 
     {{if .Todos}}
-    <h2>Booking checklist</h2>
+    <h2>{{$.T.BookingChecklist}}</h2>
     {{range .Todos}}
     <div class="row">
-      <div class="row-title"><span class="box">{{if .Booked}}&#9745;{{else}}&#9744;{{end}}</span> {{.Title}}{{if .Booked}} <span class="booked">(booked)</span>{{end}}</div>
+      <div class="row-title"><span class="box">{{if .Booked}}&#9745;{{else}}&#9744;{{end}}</span> {{.Title}}{{if .Booked}} <span class="booked">{{$.T.Booked}}</span>{{end}}</div>
       {{if .Subtitle}}<div class="row-meta">{{.Subtitle}}</div>{{end}}
     </div>
     {{end}}
     {{end}}
 
     {{if .Checklist}}
-    <h2>Packing checklist</h2>
+    <h2>{{$.T.PackingChecklist}}</h2>
     {{range .Checklist}}
     <p class="cat">{{.Category}}</p>
     <ul class="check">
@@ -335,7 +419,7 @@ var printViewTmpl = template.Must(template.New("print-view").Parse(`<!DOCTYPE ht
     {{end}}
     {{end}}
 
-    <footer>Exported from Golden Tempo Travel</footer>
+    <footer>{{$.T.Footer}}</footer>
   </main>
 </body>
 </html>`))
@@ -343,10 +427,15 @@ var printViewTmpl = template.Must(template.New("print-view").Parse(`<!DOCTYPE ht
 // printViewHandler renders the full trip as a printable HTML page.
 func printViewHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	// localeMiddleware has already resolved ?lang= / Accept-Language; this route
+	// is token-gated and public, so the request is the only locale signal.
+	locale := requestLocale(r.Context())
 	data, ok := resolveExport(r, mux.Vars(r)["token"])
 	if !ok {
 		w.WriteHeader(http.StatusNotFound)
-		w.Write([]byte("<!DOCTYPE html><html><body><h2>This export link isn't available</h2><p>It may have expired.</p></body></html>"))
+		w.Write([]byte("<!DOCTYPE html><html lang=\"" + locale + "\"><body><h2>" +
+			template.HTMLEscapeString(tr(locale, "print.linkUnavailableTitle")) + "</h2><p>" +
+			template.HTMLEscapeString(tr(locale, "print.linkUnavailableBody")) + "</p></body></html>"))
 		return
 	}
 	budget := loadPrintBudget(r.Context(), data.Trip.ID)
@@ -354,7 +443,7 @@ func printViewHandler(w http.ResponseWriter, r *http.Request) {
 	if n, dated := printDayCount(data); dated {
 		weather = loadPrintWeather(r.Context(), weatherService, data, n)
 	}
-	view := buildPrintView(data, budget, weather)
+	view := buildPrintView(locale, data, budget, weather)
 	if err := printViewTmpl.Execute(w, view); err != nil {
 		// Headers already sent; nothing sensible left to do.
 		return
@@ -388,6 +477,7 @@ func loadPrintWeather(ctx context.Context, ws *WeatherService, d exportData, n i
 	if ws == nil || !d.Trip.StartDate.Valid || n <= 0 {
 		return nil
 	}
+	locale := requestLocale(ctx)
 	ctx, cancel := context.WithTimeout(ctx, 6*time.Second)
 	defer cancel()
 
@@ -438,7 +528,7 @@ func loadPrintWeather(ctx context.Context, ws *WeatherService, d exportData, n i
 				key = start.AddDate(0, 0, i).Format("01-02")
 			}
 			if wd, ok := byKey[key]; ok {
-				out[i] = formatWeatherLine(wd, historical)
+				out[i] = formatWeatherLine(locale, wd, historical)
 			}
 		}
 	}
@@ -447,15 +537,15 @@ func loadPrintWeather(ctx context.Context, ws *WeatherService, d exportData, n i
 
 // formatWeatherLine mirrors summarizeWeather's per-day rendering; "Typical:"
 // flags archive data (last year's observations, not a forecast).
-func formatWeatherLine(wd WeatherDay, historical bool) string {
+func formatWeatherLine(locale string, wd WeatherDay, historical bool) string {
 	line := fmt.Sprintf("%.0f–%.0f°C", wd.TempMinC, wd.TempMaxC)
 	if wd.PrecipPct != nil {
-		line += fmt.Sprintf(", %d%% chance of rain", *wd.PrecipPct)
+		line += tr(locale, "print.weatherRainChance", *wd.PrecipPct)
 	} else if wd.PrecipMM >= 1 {
-		line += fmt.Sprintf(", %.0fmm rain", wd.PrecipMM)
+		line += tr(locale, "print.weatherRainMm", wd.PrecipMM)
 	}
 	if historical {
-		return "Typical: " + line
+		return tr(locale, "print.weatherTypical", line)
 	}
 	return line
 }
@@ -463,15 +553,15 @@ func formatWeatherLine(wd WeatherDay, historical bool) string {
 // buildPrintView reshapes the raw export data into the template view model:
 // day-by-day packet sections plus unscheduled/reference/budget/checklist
 // sections. budget and weatherByDay are optional (nil ⇒ section/lines omitted).
-func buildPrintView(d exportData, budget *printBudget, weatherByDay []string) printViewData {
-	view := printViewData{Title: strings.TrimSpace(d.Trip.Title)}
+func buildPrintView(locale string, d exportData, budget *printBudget, weatherByDay []string) printViewData {
+	view := printViewData{Lang: locale, T: newPrintLabels(locale), Title: strings.TrimSpace(d.Trip.Title)}
 	if view.Title == "" {
-		view.Title = "Untitled trip"
+		view.Title = tr(locale, "print.untitledTrip")
 	}
 	if d.Trip.StartDate.Valid && d.Trip.EndDate.Valid {
-		view.Dates = d.Trip.StartDate.Time.Format("Jan 2") + " – " + d.Trip.EndDate.Time.Format("Jan 2, 2006")
+		view.Dates = localizedDate(locale, d.Trip.StartDate.Time, dateStyleMonthDay) + " – " + printDateWithYear(locale, d.Trip.EndDate.Time)
 	} else if d.Trip.StartDate.Valid {
-		view.Dates = d.Trip.StartDate.Time.Format("Jan 2, 2006")
+		view.Dates = printDateWithYear(locale, d.Trip.StartDate.Time)
 	}
 	view.Summary = strings.TrimSpace(strPtrVal(d.Trip.Summary))
 
@@ -482,9 +572,9 @@ func buildPrintView(d exportData, budget *printBudget, weatherByDay []string) pr
 		return view
 	}
 
-	days, unscheduled, otherStays, otherSegs := buildPrintDays(d, weatherByDay)
+	days, unscheduled, otherStays, otherSegs := buildPrintDays(locale, d, weatherByDay)
 	view.Days = days
-	view.Unscheduled = groupExportItems(d.Trip, unscheduled)
+	view.Unscheduled = groupExportItemsIn(locale, d.Trip, unscheduled)
 	view.OtherStays = otherStays
 	view.OtherSegments = otherSegs
 	view.Budget = budget
@@ -570,7 +660,7 @@ func resolveDayCities(d exportData, n int) []string {
 // segments attached by depart (falling back to arrive) date, stays matched to
 // the nights they cover (check_in ≤ night < check_out). Whatever can't be
 // placed on a day is returned for the trailing reference sections.
-func buildPrintDays(d exportData, weatherByDay []string) ([]printDaySection, []store.ItineraryItem, []printStay, []printSegment) {
+func buildPrintDays(locale string, d exportData, weatherByDay []string) ([]printDaySection, []store.ItineraryItem, []printStay, []printSegment) {
 	n, dated := printDayCount(d)
 	var unscheduled []store.ItineraryItem
 	var otherStays []printStay
@@ -578,10 +668,10 @@ func buildPrintDays(d exportData, weatherByDay []string) ([]printDaySection, []s
 
 	if n == 0 {
 		for _, a := range d.Accommodations {
-			otherStays = append(otherStays, toPrintStay(a, stayDatesNote(a)))
+			otherStays = append(otherStays, toPrintStay(a, stayDatesNote(locale, a)))
 		}
 		for _, s := range d.Segments {
-			otherSegs = append(otherSegs, toPrintSegment(s))
+			otherSegs = append(otherSegs, toPrintSegment(locale, s))
 		}
 		return nil, d.Items, otherStays, otherSegs
 	}
@@ -590,10 +680,10 @@ func buildPrintDays(d exportData, weatherByDay []string) ([]printDaySection, []s
 	cities := resolveDayCities(d, n)
 	days := make([]printDaySection, n)
 	for i := range days {
-		days[i].Label = "Day " + strconv.Itoa(i+1)
+		days[i].Label = tr(locale, "common.day", i+1)
 		days[i].Hub = cities[i]
 		if dated {
-			days[i].Date = start.AddDate(0, 0, i).Format("Mon, Jan 2")
+			days[i].Date = localizedDate(locale, start.AddDate(0, 0, i), dateStyleWeekdayMonthDay)
 		}
 		if i < len(weatherByDay) {
 			days[i].Weather = weatherByDay[i]
@@ -616,7 +706,7 @@ func buildPrintDays(d exportData, weatherByDay []string) ([]printDaySection, []s
 		}
 		item := printItem{
 			Name:          it.Name,
-			TimeOfDay:     capitalize(strPtrVal(it.TimeOfDay)),
+			TimeOfDay:     localizedTimeOfDay(locale, strPtrVal(it.TimeOfDay)),
 			Address:       strPtrVal(it.Address),
 			RecommendedBy: strPtrVal(it.LocalSourceName),
 		}
@@ -637,7 +727,7 @@ func buildPrintDays(d exportData, weatherByDay []string) ([]printDaySection, []s
 	}
 	for i, hub := range dayTripHub {
 		if hub != "" && hub != mixedDayTrip {
-			days[i].DayTrip = "Day trip from " + hub
+			days[i].DayTrip = tr(locale, "print.dayTripFrom", hub)
 		}
 	}
 
@@ -661,10 +751,10 @@ func buildPrintDays(d exportData, weatherByDay []string) ([]printDaySection, []s
 			di = dayIndexOf(s.ArriveDate.Time)
 		}
 		if di < 0 {
-			otherSegs = append(otherSegs, toPrintSegment(s))
+			otherSegs = append(otherSegs, toPrintSegment(locale, s))
 			continue
 		}
-		days[di].Segments = append(days[di].Segments, toPrintSegment(s))
+		days[di].Segments = append(days[di].Segments, toPrintSegment(locale, s))
 	}
 
 	for _, a := range d.Accommodations {
@@ -682,17 +772,18 @@ func buildPrintDays(d exportData, weatherByDay []string) ([]printDaySection, []s
 				}
 				var notes []string
 				if night.Equal(checkIn) {
-					notes = append(notes, "Check in today")
+					notes = append(notes, tr(locale, "print.checkInToday"))
 				}
 				if a.CheckOut.Valid && night.Equal(checkOut.AddDate(0, 0, -1)) {
-					notes = append(notes, "Check out "+checkOut.Format("Mon, Jan 2"))
+					notes = append(notes, tr(locale, "print.checkOutOn",
+						localizedDate(locale, checkOut, dateStyleWeekdayMonthDay)))
 				}
 				days[i].Stays = append(days[i].Stays, toPrintStay(a, strings.Join(notes, " · ")))
 				attached = true
 			}
 		}
 		if !attached {
-			otherStays = append(otherStays, toPrintStay(a, stayDatesNote(a)))
+			otherStays = append(otherStays, toPrintStay(a, stayDatesNote(locale, a)))
 		}
 	}
 
@@ -765,13 +856,13 @@ func formatMoneyAmount(v float64) string {
 	return strconv.FormatFloat(v, 'f', 2, 64)
 }
 
-func toPrintSegment(s store.TripSegment) printSegment {
+func toPrintSegment(locale string, s store.TripSegment) printSegment {
 	var meta []string
-	if dep := formatExportDate(dateToPtr(s.DepartDate)); dep != "" {
-		meta = append(meta, "Departs "+dep)
+	if dep := formatExportDate(locale, dateToPtr(s.DepartDate)); dep != "" {
+		meta = append(meta, tr(locale, "print.departs", dep))
 	}
-	if arr := formatExportDate(dateToPtr(s.ArriveDate)); arr != "" {
-		meta = append(meta, "Arrives "+arr)
+	if arr := formatExportDate(locale, dateToPtr(s.ArriveDate)); arr != "" {
+		meta = append(meta, tr(locale, "print.arrives", arr))
 	}
 	if p := strings.TrimSpace(strPtrVal(s.Provider)); p != "" {
 		meta = append(meta, p)
@@ -781,8 +872,8 @@ func toPrintSegment(s store.TripSegment) printSegment {
 	}
 	rawURL := strings.TrimSpace(strPtrVal(s.Url))
 	return printSegment{
-		Route:   segmentRoute(s),
-		Mode:    capitalize(s.Mode),
+		Route:   segmentRouteIn(locale, s),
+		Mode:    localizedMode(locale, s.Mode),
 		Meta:    strings.Join(meta, " · "),
 		Notes:   strings.TrimSpace(strPtrVal(s.Notes)),
 		URL:     rawURL,
@@ -816,13 +907,13 @@ func toPrintStay(a store.Accommodation, note string) printStay {
 }
 
 // stayDatesNote renders the reference-list date range for a stay.
-func stayDatesNote(a store.Accommodation) string {
+func stayDatesNote(locale string, a store.Accommodation) string {
 	var parts []string
-	if ci := formatExportDate(dateToPtr(a.CheckIn)); ci != "" {
-		parts = append(parts, "Check-in "+ci)
+	if ci := formatExportDate(locale, dateToPtr(a.CheckIn)); ci != "" {
+		parts = append(parts, tr(locale, "print.checkIn", ci))
 	}
-	if co := formatExportDate(dateToPtr(a.CheckOut)); co != "" {
-		parts = append(parts, "Check-out "+co)
+	if co := formatExportDate(locale, dateToPtr(a.CheckOut)); co != "" {
+		parts = append(parts, tr(locale, "print.checkOut", co))
 	}
 	return strings.Join(parts, " · ")
 }
@@ -847,12 +938,18 @@ func displayURL(raw string) string {
 	return display
 }
 
-// groupExportItems walks items in position order and groups them by hub
+// groupExportItems is the English-locale entry point, kept for trip_review.go,
+// which reads only the hub grouping and has no locale to thread through.
+func groupExportItems(trip store.Trip, items []store.ItineraryItem) []printGroup {
+	return groupExportItemsIn(defaultLocale, trip, items)
+}
+
+// groupExportItemsIn walks items in position order and groups them by hub
 // (day_trip_from, falling back to city, then "Itinerary"), sub-grouping by day.
 // First-appearance order is preserved for both hubs and days. Per-item date is
 // trip.start_date + (day-1) when both are present. Used for the Unscheduled
 // section (and exercised by the .ics fixture tests).
-func groupExportItems(trip store.Trip, items []store.ItineraryItem) []printGroup {
+func groupExportItemsIn(locale string, trip store.Trip, items []store.ItineraryItem) []printGroup {
 	var groups []printGroup
 	groupIdx := map[string]int{}
 	dayIdx := map[string]int{} // key: hub + "\x00" + day
@@ -863,7 +960,7 @@ func groupExportItems(trip store.Trip, items []store.ItineraryItem) []printGroup
 			hub = strings.TrimSpace(strPtrVal(it.City))
 		}
 		if hub == "" {
-			hub = "Itinerary"
+			hub = tr(locale, "print.itinerary")
 		}
 		gi, ok := groupIdx[hub]
 		if !ok {
@@ -881,12 +978,12 @@ func groupExportItems(trip store.Trip, items []store.ItineraryItem) []printGroup
 		if !ok {
 			di = len(groups[gi].Days)
 			dayIdx[dayKey] = di
-			label := "Unscheduled"
+			label := tr(locale, "common.unscheduled")
 			date := ""
 			if dayNum > 0 {
-				label = "Day " + strconv.Itoa(dayNum)
+				label = tr(locale, "common.day", dayNum)
 				if trip.StartDate.Valid {
-					date = trip.StartDate.Time.AddDate(0, 0, dayNum-1).Format("Mon, Jan 2")
+					date = localizedDate(locale, trip.StartDate.Time.AddDate(0, 0, dayNum-1), dateStyleWeekdayMonthDay)
 				}
 			}
 			groups[gi].Days = append(groups[gi].Days, printDay{Label: label, Date: date})
@@ -894,7 +991,7 @@ func groupExportItems(trip store.Trip, items []store.ItineraryItem) []printGroup
 
 		groups[gi].Days[di].Items = append(groups[gi].Days[di].Items, printItem{
 			Name:          it.Name,
-			TimeOfDay:     capitalize(strPtrVal(it.TimeOfDay)),
+			TimeOfDay:     localizedTimeOfDay(locale, strPtrVal(it.TimeOfDay)),
 			Address:       strPtrVal(it.Address),
 			RecommendedBy: strPtrVal(it.LocalSourceName),
 		})
@@ -919,8 +1016,15 @@ func groupChecklist(items []store.TripChecklistItem) []printChecklistGroup {
 	return groups
 }
 
-// segmentRoute renders "Origin → Destination", tolerating missing endpoints.
+// segmentRoute is the English-locale entry point, kept for trip_review.go.
 func segmentRoute(s store.TripSegment) string {
+	return segmentRouteIn(defaultLocale, s)
+}
+
+// segmentRouteIn renders "Origin → Destination", tolerating missing endpoints.
+// Only the both-endpoints-missing fallback (the mode name) is localizable; the
+// endpoints themselves are traveler-supplied place names.
+func segmentRouteIn(locale string, s store.TripSegment) string {
 	o := strings.TrimSpace(strPtrVal(s.Origin))
 	dst := strings.TrimSpace(strPtrVal(s.Destination))
 	switch {
@@ -931,12 +1035,13 @@ func segmentRoute(s store.TripSegment) string {
 	case o != "":
 		return o
 	default:
-		return capitalize(s.Mode)
+		return localizedMode(locale, s.Mode)
 	}
 }
 
-// formatExportDate turns a *string "YYYY-MM-DD" into a friendly "Mon, Jan 2".
-func formatExportDate(s *string) string {
+// formatExportDate turns a *string "YYYY-MM-DD" into a friendly "Mon, Jan 2"
+// ("lun, 2 ene" in Spanish), leaving an unparseable value untouched.
+func formatExportDate(locale string, s *string) string {
 	if s == nil || *s == "" {
 		return ""
 	}
@@ -944,5 +1049,12 @@ func formatExportDate(s *string) string {
 	if err != nil {
 		return *s
 	}
-	return t.Format("Mon, Jan 2")
+	return localizedDate(locale, t, dateStyleWeekdayMonthDay)
+}
+
+// printDateWithYear renders a year-qualified short date: "Aug 5, 2026" /
+// "5 ago de 2026". localizedDate has no year-bearing short style, so the year
+// is joined through the catalog to keep Spanish's "de" in the right place.
+func printDateWithYear(locale string, t time.Time) string {
+	return tr(locale, "print.dateWithYear", localizedDate(locale, t, dateStyleMonthDay), t.Year())
 }

--- a/src/packages/api/print_view_test.go
+++ b/src/packages/api/print_view_test.go
@@ -81,7 +81,7 @@ func TestBuildPrintDays_StayNights(t *testing.T) {
 			CheckIn: dateVal(t, "2026-08-01"), CheckOut: dateVal(t, "2026-08-05"),
 		}},
 	}
-	days, _, otherStays, _ := buildPrintDays(d, nil)
+	days, _, otherStays, _ := buildPrintDays("en", d, nil)
 	if len(days) != 5 {
 		t.Fatalf("expected 5 day sections, got %d", len(days))
 	}
@@ -115,7 +115,7 @@ func TestBuildPrintDays_StayEdgeCases(t *testing.T) {
 	d := exportData{Trip: trip, Accommodations: []store.Accommodation{{
 		Name: "One Night Inn", CheckIn: dateVal(t, "2026-08-02"), CheckOut: dateVal(t, "2026-08-03"),
 	}}}
-	days, _, _, _ := buildPrintDays(d, nil)
+	days, _, _, _ := buildPrintDays("en", d, nil)
 	if len(days[1].Stays) != 1 || len(days[0].Stays) != 0 || len(days[2].Stays) != 0 {
 		t.Fatalf("single-night stay placement wrong: %+v", days)
 	}
@@ -128,7 +128,7 @@ func TestBuildPrintDays_StayEdgeCases(t *testing.T) {
 	d = exportData{Trip: trip, Accommodations: []store.Accommodation{{
 		Name: "Open Ended", CheckIn: dateVal(t, "2026-08-03"),
 	}}}
-	days, _, otherStays, _ := buildPrintDays(d, nil)
+	days, _, otherStays, _ := buildPrintDays("en", d, nil)
 	if len(days[2].Stays) != 1 || len(otherStays) != 0 {
 		t.Fatalf("check-in-only stay should land on its night: days=%+v other=%+v", days, otherStays)
 	}
@@ -137,7 +137,7 @@ func TestBuildPrintDays_StayEdgeCases(t *testing.T) {
 	d = exportData{Trip: trip, Accommodations: []store.Accommodation{{
 		Name: "Elsewhere", CheckIn: dateVal(t, "2026-09-01"), CheckOut: dateVal(t, "2026-09-03"),
 	}}}
-	days, _, otherStays, _ = buildPrintDays(d, nil)
+	days, _, otherStays, _ = buildPrintDays("en", d, nil)
 	for i, day := range days {
 		if len(day.Stays) != 0 {
 			t.Fatalf("out-of-range stay leaked onto day %d", i+1)
@@ -149,7 +149,7 @@ func TestBuildPrintDays_StayEdgeCases(t *testing.T) {
 
 	// No dates at all ⇒ reference list.
 	d = exportData{Trip: trip, Accommodations: []store.Accommodation{{Name: "Dateless"}}}
-	_, _, otherStays, _ = buildPrintDays(d, nil)
+	_, _, otherStays, _ = buildPrintDays("en", d, nil)
 	if len(otherStays) != 1 {
 		t.Fatalf("dateless stay should be a reference entry, got %+v", otherStays)
 	}
@@ -173,7 +173,7 @@ func TestBuildPrintDays_Segments(t *testing.T) {
 				DepartDate: dateVal(t, "2026-07-31"), ArriveDate: dateVal(t, "2026-08-01")},
 		},
 	}
-	days, _, _, otherSegs := buildPrintDays(d, nil)
+	days, _, _, otherSegs := buildPrintDays("en", d, nil)
 
 	if len(days[1].Segments) != 1 {
 		t.Fatalf("train should attach to day 2, got %+v", days[1].Segments)
@@ -211,7 +211,7 @@ func TestBuildPrintDays_ItemsAndDayTrips(t *testing.T) {
 			{Name: "Runaway", City: strp("Athens"), Day: i32p(5000)},
 		},
 	}
-	days, unscheduled, _, _ := buildPrintDays(d, nil)
+	days, unscheduled, _, _ := buildPrintDays("en", d, nil)
 
 	if len(days) != 5 {
 		t.Fatalf("expected 5 days, got %d", len(days))
@@ -266,7 +266,7 @@ func TestBuildPrintDays_UndatedTrip(t *testing.T) {
 		Accommodations: []store.Accommodation{{Name: "Hôtel", CheckIn: dateVal(t, "2026-08-01")}},
 		Segments:       []store.TripSegment{{Mode: "train", DepartDate: dateVal(t, "2026-08-01")}},
 	}
-	days, unscheduled, otherStays, otherSegs := buildPrintDays(d, nil)
+	days, unscheduled, otherStays, otherSegs := buildPrintDays("en", d, nil)
 
 	// Item-less relative days are dropped; the rest have no calendar date.
 	if len(days) != 2 || days[0].Label != "Day 1" || days[1].Label != "Day 3" {
@@ -355,13 +355,13 @@ func TestDisplayURL(t *testing.T) {
 
 func TestFormatWeatherLine(t *testing.T) {
 	pct := 20
-	if got := formatWeatherLine(WeatherDay{TempMinC: 15.4, TempMaxC: 24.6, PrecipPct: &pct}, false); got != "15–25°C, 20% chance of rain" {
+	if got := formatWeatherLine("en", WeatherDay{TempMinC: 15.4, TempMaxC: 24.6, PrecipPct: &pct}, false); got != "15–25°C, 20% chance of rain" {
 		t.Fatalf("forecast line = %q", got)
 	}
-	if got := formatWeatherLine(WeatherDay{TempMinC: 18, TempMaxC: 27, PrecipMM: 6}, true); got != "Typical: 18–27°C, 6mm rain" {
+	if got := formatWeatherLine("en", WeatherDay{TempMinC: 18, TempMaxC: 27, PrecipMM: 6}, true); got != "Typical: 18–27°C, 6mm rain" {
 		t.Fatalf("historical line = %q", got)
 	}
-	if got := formatWeatherLine(WeatherDay{TempMinC: 18, TempMaxC: 27, PrecipMM: 0.2}, false); got != "18–27°C" {
+	if got := formatWeatherLine("en", WeatherDay{TempMinC: 18, TempMaxC: 27, PrecipMM: 0.2}, false); got != "18–27°C" {
 		t.Fatalf("dry line = %q", got)
 	}
 }
@@ -429,13 +429,13 @@ func TestLoadPrintWeather_Resilient(t *testing.T) {
 
 func TestBuildPrintView_HasContent(t *testing.T) {
 	// A dated but empty trip renders the empty state, not 5 hollow days.
-	view := buildPrintView(exportData{Trip: printFixtureTrip(t)}, nil, nil)
+	view := buildPrintView("en", exportData{Trip: printFixtureTrip(t)}, nil, nil)
 	if view.HasContent || len(view.Days) != 0 {
 		t.Fatalf("empty trip should have no content, got %+v", view)
 	}
 	// A budget alone counts as content.
 	target := 100.0
-	view = buildPrintView(exportData{Trip: printFixtureTrip(t)},
+	view = buildPrintView("en", exportData{Trip: printFixtureTrip(t)},
 		buildPrintBudget(&store.TripBudget{TargetAmount: &target, Currency: "USD"}, nil), nil)
 	if !view.HasContent || view.Budget == nil {
 		t.Fatalf("budget-only trip should have content, got %+v", view)
@@ -445,6 +445,7 @@ func TestBuildPrintView_HasContent(t *testing.T) {
 func TestPrintViewTemplate_Escapes(t *testing.T) {
 	evil := `<script>alert(1)</script>`
 	view := printViewData{
+		T:       newPrintLabels("en"),
 		Title:   evil,
 		Summary: evil,
 		Days: []printDaySection{{
@@ -475,6 +476,9 @@ func TestPrintViewTemplate_Escapes(t *testing.T) {
 
 func TestPrintViewTemplate_DaySections(t *testing.T) {
 	view := printViewData{
+		// The template renders its static chrome from T (specs/i18n-spanish),
+		// so a literal built in a test needs the English label set.
+		T:     newPrintLabels("en"),
 		Title: "Greece",
 		Days: []printDaySection{
 			{Label: "Day 1", Date: "Sat, Aug 1", Hub: "Athens", Weather: "18–27°C",

--- a/src/packages/api/query/price_alerts.sql
+++ b/src/packages/api/query/price_alerts.sql
@@ -34,7 +34,9 @@ WHERE id = $1 AND user_id = $2;
 -- name: ListDuePriceAlerts :many
 -- Active alerts not yet checked in this cycle, oldest-checked first. The
 -- caller passes the freshness cutoff (now - check interval) and batch size.
-SELECT sqlc.embed(price_alerts), users.email AS owner_email
+-- owner_locale rides along because the checker emails with no request context
+-- to negotiate a language from (NULL => English).
+SELECT sqlc.embed(price_alerts), users.email AS owner_email, users.locale AS owner_locale
 FROM price_alerts
 JOIN users ON users.id = price_alerts.user_id
 WHERE price_alerts.status = 'active'

--- a/src/packages/api/query/reengagement.sql
+++ b/src/packages/api/query/reengagement.sql
@@ -13,7 +13,10 @@ SELECT t.id,
        COALESCE(t.chat_id, t.id::text)::text AS lineage_key,
        u.email,
        u.display_name,
-       u.reminders_opt_out
+       u.reminders_opt_out,
+       -- The email is rendered with no request context, so the recipient's
+       -- stored language rides along with the row (NULL => English).
+       u.locale
 FROM trips t
 JOIN users u ON u.id = t.user_id
 WHERE t.status = 'planned'
@@ -57,7 +60,10 @@ ON CONFLICT (user_id, trip_lineage_key, kind) DO NOTHING;
 SELECT u.id,
        u.email,
        u.display_name,
-       u.nudges_opt_out
+       u.nudges_opt_out,
+       -- Same as ListTripsForReminder: request-less job, so the language comes
+       -- from the row (NULL => English).
+       u.locale
 FROM users u
 WHERE (u.last_weekly_nudge_at IS NULL OR u.last_weekly_nudge_at < sqlc.arg('cutoff'))
   AND (

--- a/src/packages/api/query/users.sql
+++ b/src/packages/api/query/users.sql
@@ -1,6 +1,9 @@
 -- name: CreateUser :one
-INSERT INTO users (email, password_hash, display_name)
-VALUES ($1, $2, $3)
+-- locale is the language negotiated on the signup request, so the very first
+-- email (verification) is already in the traveler's language rather than
+-- waiting for the client's first sync (specs/i18n-spanish).
+INSERT INTO users (email, password_hash, display_name, locale)
+VALUES ($1, $2, $3, $4)
 RETURNING *;
 
 -- name: GetUserByEmail :one

--- a/src/packages/api/reengagement_checker.go
+++ b/src/packages/api/reengagement_checker.go
@@ -225,46 +225,49 @@ func weeklyNudgePayload() []byte {
 
 // --- email builders (pure, unit-tested) ---
 
-// buildTripReminderEmail renders the trip-reminder email. Pure — unit-tested.
-func buildTripReminderEmail(kind, tripTitle, startDate, tripURL, unsubscribeURL string) (subject, body string) {
+// buildTripReminderEmail renders the trip-reminder email in the recipient's
+// language. Pure — unit-tested.
+func buildTripReminderEmail(locale, kind, tripTitle, startDate, tripURL, unsubscribeURL string) (subject, body string) {
 	var b strings.Builder
 	if kind == reminderKindToday {
-		subject = fmt.Sprintf("Your trip \"%s\" starts today", tripTitle)
-		fmt.Fprintf(&b, "Today's the day — \"%s\" begins.\n\n", tripTitle)
+		subject = tr(locale, "email.reminder.subject_today", tripTitle)
+		fmt.Fprintf(&b, "%s\n\n", tr(locale, "email.reminder.lead_today", tripTitle))
 	} else {
-		subject = fmt.Sprintf("Your trip \"%s\" starts in %d days", tripTitle, reminderDaysSoon)
-		fmt.Fprintf(&b, "Your trip \"%s\" is coming up in %d days.\n\n", tripTitle, reminderDaysSoon)
+		subject = tr(locale, "email.reminder.subject_soon", tripTitle, reminderDaysSoon)
+		fmt.Fprintf(&b, "%s\n\n", tr(locale, "email.reminder.lead_soon", tripTitle, reminderDaysSoon))
 	}
 	if startDate != "" {
-		fmt.Fprintf(&b, "Departure: %s\n", startDate)
+		fmt.Fprintf(&b, "%s\n", tr(locale, "email.reminder.departure", startDate))
 	}
-	fmt.Fprintf(&b, "\nOpen your itinerary: %s\n", tripURL)
-	b.WriteString("\nSafe travels!\n")
-	fmt.Fprintf(&b, "\nTo stop trip reminders, unsubscribe here: %s\n", unsubscribeURL)
+	fmt.Fprintf(&b, "\n%s\n", tr(locale, "email.reminder.open", tripURL))
+	fmt.Fprintf(&b, "\n%s\n", tr(locale, "email.reminder.signoff"))
+	fmt.Fprintf(&b, "\n%s\n", tr(locale, "email.reminder.unsubscribe", unsubscribeURL))
 	return subject, b.String()
 }
 
-// buildWeeklyNudgeEmail renders the weekly planning nudge. Pure — unit-tested.
-// name is the recipient's display name ("" => a generic greeting).
-func buildWeeklyNudgeEmail(name, appURL, unsubscribeURL string) (subject, body string) {
-	subject = "Pick up where you left off"
+// buildWeeklyNudgeEmail renders the weekly planning nudge in the recipient's
+// language. Pure — unit-tested. name is the recipient's display name
+// ("" => a generic greeting).
+func buildWeeklyNudgeEmail(locale, name, appURL, unsubscribeURL string) (subject, body string) {
+	subject = tr(locale, "email.nudge.subject")
 	var b strings.Builder
 	if strings.TrimSpace(name) != "" {
-		fmt.Fprintf(&b, "Hi %s,\n\n", name)
+		fmt.Fprintf(&b, "%s\n\n", tr(locale, "email.nudge.greeting", name))
 	} else {
-		b.WriteString("Hi there,\n\n")
+		fmt.Fprintf(&b, "%s\n\n", tr(locale, "email.nudge.greeting_generic"))
 	}
-	b.WriteString("You started planning a trip but haven't been back in a while — ")
-	b.WriteString("your work is saved right where you left it.\n\n")
-	fmt.Fprintf(&b, "Jump back in: %s\n", appURL)
-	fmt.Fprintf(&b, "\nNot planning anything right now? Unsubscribe from these nudges: %s\n", unsubscribeURL)
+	fmt.Fprintf(&b, "%s\n\n", tr(locale, "email.nudge.body"))
+	fmt.Fprintf(&b, "%s\n", tr(locale, "email.nudge.resume", appURL))
+	fmt.Fprintf(&b, "\n%s\n", tr(locale, "email.nudge.unsubscribe", unsubscribeURL))
 	return subject, b.String()
 }
 
 func sendReminderEmail(row store.ListTripsForReminderRow, kind string) {
 	tripURL := publicAppURL("trips/", row.ID.String())
 	unsub := unsubscribeURL(row.UserID, unsubReminders)
-	subject, body := buildTripReminderEmail(kind, row.Title, dateString(row.StartDate), tripURL, unsub)
+	// No request context in a background tick: the language is the one the
+	// account synced (ListTripsForReminder carries it on the row).
+	subject, body := buildTripReminderEmail(localeOrDefault(row.Locale), kind, row.Title, dateString(row.StartDate), tripURL, unsub)
 	if err := emailService.SendMarketing(row.Email, subject, body, unsub); err != nil {
 		log.Printf("re-engagement: reminder email to %s failed: %v", row.Email, err)
 	}
@@ -277,7 +280,7 @@ func sendNudgeEmail(row store.ListUsersForWeeklyNudgeRow) {
 	if row.DisplayName != nil {
 		name = *row.DisplayName
 	}
-	subject, body := buildWeeklyNudgeEmail(name, appURL, unsub)
+	subject, body := buildWeeklyNudgeEmail(localeOrDefault(row.Locale), name, appURL, unsub)
 	if err := emailService.SendMarketing(row.Email, subject, body, unsub); err != nil {
 		log.Printf("re-engagement: nudge email to %s failed: %v", row.Email, err)
 	}

--- a/src/packages/api/reengagement_checker_test.go
+++ b/src/packages/api/reengagement_checker_test.go
@@ -20,7 +20,7 @@ func TestBuildTripReminderEmail(t *testing.T) {
 	unsub := "https://app.example.com/api/v1/unsubscribe/tok"
 
 	// 3-days-out variant.
-	subject, body := buildTripReminderEmail(reminderKindSoon, "Athens Hop", "2026-09-01", tripURL, unsub)
+	subject, body := buildTripReminderEmail("en", reminderKindSoon, "Athens Hop", "2026-09-01", tripURL, unsub)
 	if !strings.Contains(subject, "Athens Hop") || !strings.Contains(subject, "3 days") {
 		t.Fatalf("soon subject = %q", subject)
 	}
@@ -31,7 +31,7 @@ func TestBuildTripReminderEmail(t *testing.T) {
 	}
 
 	// Day-of variant.
-	subject, body = buildTripReminderEmail(reminderKindToday, "Athens Hop", "2026-09-01", tripURL, unsub)
+	subject, body = buildTripReminderEmail("en", reminderKindToday, "Athens Hop", "2026-09-01", tripURL, unsub)
 	if !strings.Contains(subject, "starts today") {
 		t.Fatalf("today subject = %q", subject)
 	}
@@ -44,7 +44,7 @@ func TestBuildWeeklyNudgeEmail(t *testing.T) {
 	appURL := "https://app.example.com/"
 	unsub := "https://app.example.com/api/v1/unsubscribe/tok"
 
-	subject, body := buildWeeklyNudgeEmail("Brian", appURL, unsub)
+	subject, body := buildWeeklyNudgeEmail("en", "Brian", appURL, unsub)
 	if !strings.Contains(subject, "left off") {
 		t.Fatalf("subject = %q", subject)
 	}
@@ -55,7 +55,7 @@ func TestBuildWeeklyNudgeEmail(t *testing.T) {
 	}
 
 	// Empty name falls back to a generic greeting.
-	_, body = buildWeeklyNudgeEmail("", appURL, unsub)
+	_, body = buildWeeklyNudgeEmail("en", "", appURL, unsub)
 	if !strings.Contains(body, "Hi there") {
 		t.Fatalf("generic greeting missing:\n%s", body)
 	}

--- a/src/packages/api/review_handler.go
+++ b/src/packages/api/review_handler.go
@@ -47,7 +47,7 @@ func getTripReviewHandler(w http.ResponseWriter, r *http.Request) {
 	// check; weather enrichment always runs (keyless + cached).
 	checkHours, _ := strconv.ParseBool(r.URL.Query().Get("check_hours"))
 
-	findings := reviewTrip(r.Context(), data,
+	findings := reviewTrip(r.Context(), requestLocale(r.Context()), data,
 		reviewOptions{CheckHours: checkHours, Budget: &br},
 		reviewDeps{Weather: weatherService, Places: placesService})
 	writeJSON(w, http.StatusOK, ReviewResponse{Findings: findings})

--- a/src/packages/api/share_preview_handler.go
+++ b/src/packages/api/share_preview_handler.go
@@ -17,7 +17,7 @@ import (
 // sharePreviewTmpl uses html/template — all fields are auto-escaped; never
 // build this page with fmt.Sprintf.
 var sharePreviewTmpl = template.Must(template.New("share-preview").Parse(`<!DOCTYPE html>
-<html lang="en">
+<html lang="{{.Lang}}">
 <head>
   <meta charset="utf-8">
   <title>{{.Title}} — Golden Tempo Travel</title>
@@ -38,6 +38,7 @@ var sharePreviewTmpl = template.Must(template.New("share-preview").Parse(`<!DOCT
 </html>`))
 
 type sharePreviewData struct {
+	Lang        string
 	Title       string
 	Description string
 	URL         string
@@ -69,19 +70,25 @@ func truncatePreview(s string, max int) string {
 // posture as sharedTripHandler; no new queries.
 func sharePreviewHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	// Crawlers rarely send a useful Accept-Language, but localeMiddleware also
+	// honors the ?lang= a localized share link carries.
+	locale := requestLocale(r.Context())
 	if dbPool == nil {
 		w.WriteHeader(http.StatusServiceUnavailable)
-		w.Write([]byte("<html><body><h2>Temporarily unavailable</h2></body></html>"))
+		w.Write([]byte("<html lang=\"" + locale + "\"><body><h2>" +
+			template.HTMLEscapeString(tr(locale, "share.temporarilyUnavailable")) + "</h2></body></html>"))
 		return
 	}
 	share, trip, ok := resolveShare(r)
 	if !ok {
 		w.WriteHeader(http.StatusNotFound)
-		w.Write([]byte("<html><body><h2>This trip isn't available</h2><p>The link may have been turned off.</p></body></html>"))
+		w.Write([]byte("<html lang=\"" + locale + "\"><body><h2>" +
+			template.HTMLEscapeString(tr(locale, "share.unavailableTitle")) + "</h2><p>" +
+			template.HTMLEscapeString(tr(locale, "share.unavailableBody")) + "</p></body></html>"))
 		return
 	}
 
-	ownerName := "a traveler"
+	ownerName := tr(locale, "share.aTraveler")
 	if owner, err := store.New(dbPool).GetUserByID(r.Context(), share.OwnerID); err == nil &&
 		owner.DisplayName != nil && *owner.DisplayName != "" {
 		ownerName = *owner.DisplayName
@@ -90,9 +97,11 @@ func sharePreviewHandler(w http.ResponseWriter, r *http.Request) {
 	var descParts []string
 	if trip.StartDate.Valid && trip.EndDate.Valid {
 		descParts = append(descParts,
-			trip.StartDate.Time.Format("Jan 2")+" – "+trip.EndDate.Time.Format("Jan 2, 2006"))
+			localizedDate(locale, trip.StartDate.Time, dateStyleMonthDay)+" – "+
+				tr(locale, "share.dateWithYear",
+					localizedDate(locale, trip.EndDate.Time, dateStyleMonthDay), trip.EndDate.Time.Year()))
 	}
-	descParts = append(descParts, "Planned by "+ownerName)
+	descParts = append(descParts, tr(locale, "share.plannedBy", ownerName))
 	if trip.Summary != nil {
 		if first := strings.TrimSpace(strings.SplitN(*trip.Summary, "\n", 2)[0]); first != "" {
 			descParts = append(descParts, first)
@@ -101,6 +110,7 @@ func sharePreviewHandler(w http.ResponseWriter, r *http.Request) {
 
 	base := previewBaseURL(r)
 	data := sharePreviewData{
+		Lang:        locale,
 		Title:       truncatePreview(trip.Title, 70),
 		Description: truncatePreview(strings.Join(descParts, " · "), 200),
 		URL:         base + "/app/share/" + share.Token,

--- a/src/packages/api/store/price_alerts.sql.go
+++ b/src/packages/api/store/price_alerts.sql.go
@@ -166,7 +166,7 @@ func (q *Queries) GetPriceAlertForUser(ctx context.Context, arg GetPriceAlertFor
 }
 
 const listDuePriceAlerts = `-- name: ListDuePriceAlerts :many
-SELECT price_alerts.id, price_alerts.user_id, price_alerts.trip_id, price_alerts.origin, price_alerts.destination, price_alerts.depart_date, price_alerts.return_date, price_alerts.cabin_class, price_alerts.adults, price_alerts.target_price, price_alerts.currency, price_alerts.last_checked_price, price_alerts.last_checked_at, price_alerts.last_notified_price, price_alerts.last_notified_at, price_alerts.status, price_alerts.created_at, price_alerts.updated_at, price_alerts.baseline_price, price_alerts.flex_days, price_alerts.baggage, users.email AS owner_email
+SELECT price_alerts.id, price_alerts.user_id, price_alerts.trip_id, price_alerts.origin, price_alerts.destination, price_alerts.depart_date, price_alerts.return_date, price_alerts.cabin_class, price_alerts.adults, price_alerts.target_price, price_alerts.currency, price_alerts.last_checked_price, price_alerts.last_checked_at, price_alerts.last_notified_price, price_alerts.last_notified_at, price_alerts.status, price_alerts.created_at, price_alerts.updated_at, price_alerts.baseline_price, price_alerts.flex_days, price_alerts.baggage, users.email AS owner_email, users.locale AS owner_locale
 FROM price_alerts
 JOIN users ON users.id = price_alerts.user_id
 WHERE price_alerts.status = 'active'
@@ -182,12 +182,15 @@ type ListDuePriceAlertsParams struct {
 }
 
 type ListDuePriceAlertsRow struct {
-	PriceAlert PriceAlert `json:"price_alert"`
-	OwnerEmail string     `json:"owner_email"`
+	PriceAlert  PriceAlert `json:"price_alert"`
+	OwnerEmail  string     `json:"owner_email"`
+	OwnerLocale *string    `json:"owner_locale"`
 }
 
 // Active alerts not yet checked in this cycle, oldest-checked first. The
 // caller passes the freshness cutoff (now - check interval) and batch size.
+// owner_locale rides along because the checker emails with no request context
+// to negotiate a language from (NULL => English).
 func (q *Queries) ListDuePriceAlerts(ctx context.Context, arg ListDuePriceAlertsParams) ([]ListDuePriceAlertsRow, error) {
 	rows, err := q.db.Query(ctx, listDuePriceAlerts, arg.LastCheckedAt, arg.Limit)
 	if err != nil {
@@ -220,6 +223,7 @@ func (q *Queries) ListDuePriceAlerts(ctx context.Context, arg ListDuePriceAlerts
 			&i.PriceAlert.FlexDays,
 			&i.PriceAlert.Baggage,
 			&i.OwnerEmail,
+			&i.OwnerLocale,
 		); err != nil {
 			return nil, err
 		}

--- a/src/packages/api/store/reengagement.sql.go
+++ b/src/packages/api/store/reengagement.sql.go
@@ -20,7 +20,10 @@ SELECT t.id,
        COALESCE(t.chat_id, t.id::text)::text AS lineage_key,
        u.email,
        u.display_name,
-       u.reminders_opt_out
+       u.reminders_opt_out,
+       -- The email is rendered with no request context, so the recipient's
+       -- stored language rides along with the row (NULL => English).
+       u.locale
 FROM trips t
 JOIN users u ON u.id = t.user_id
 WHERE t.status = 'planned'
@@ -59,6 +62,7 @@ type ListTripsForReminderRow struct {
 	Email           string      `json:"email"`
 	DisplayName     *string     `json:"display_name"`
 	RemindersOptOut bool        `json:"reminders_opt_out"`
+	Locale          *string     `json:"locale"`
 }
 
 // Latest trip per lineage that is planned and departs on the target date
@@ -86,6 +90,7 @@ func (q *Queries) ListTripsForReminder(ctx context.Context, arg ListTripsForRemi
 			&i.Email,
 			&i.DisplayName,
 			&i.RemindersOptOut,
+			&i.Locale,
 		); err != nil {
 			return nil, err
 		}
@@ -101,7 +106,10 @@ const listUsersForWeeklyNudge = `-- name: ListUsersForWeeklyNudge :many
 SELECT u.id,
        u.email,
        u.display_name,
-       u.nudges_opt_out
+       u.nudges_opt_out,
+       -- Same as ListTripsForReminder: request-less job, so the language comes
+       -- from the row (NULL => English).
+       u.locale
 FROM users u
 WHERE (u.last_weekly_nudge_at IS NULL OR u.last_weekly_nudge_at < $1)
   AND (
@@ -130,6 +138,7 @@ type ListUsersForWeeklyNudgeRow struct {
 	Email        string    `json:"email"`
 	DisplayName  *string   `json:"display_name"`
 	NudgesOptOut bool      `json:"nudges_opt_out"`
+	Locale       *string   `json:"locale"`
 }
 
 // Users who started planning but went quiet: their most recent activity (max
@@ -154,6 +163,7 @@ func (q *Queries) ListUsersForWeeklyNudge(ctx context.Context, arg ListUsersForW
 			&i.Email,
 			&i.DisplayName,
 			&i.NudgesOptOut,
+			&i.Locale,
 		); err != nil {
 			return nil, err
 		}

--- a/src/packages/api/store/users.sql.go
+++ b/src/packages/api/store/users.sql.go
@@ -12,8 +12,8 @@ import (
 )
 
 const createUser = `-- name: CreateUser :one
-INSERT INTO users (email, password_hash, display_name)
-VALUES ($1, $2, $3)
+INSERT INTO users (email, password_hash, display_name, locale)
+VALUES ($1, $2, $3, $4)
 RETURNING id, created_at, updated_at, email, password_hash, display_name, is_admin, onboarded_at, email_verified_at, reminders_opt_out, nudges_opt_out, last_weekly_nudge_at, locale
 `
 
@@ -21,10 +21,19 @@ type CreateUserParams struct {
 	Email        string  `json:"email"`
 	PasswordHash *string `json:"password_hash"`
 	DisplayName  *string `json:"display_name"`
+	Locale       *string `json:"locale"`
 }
 
+// locale is the language negotiated on the signup request, so the very first
+// email (verification) is already in the traveler's language rather than
+// waiting for the client's first sync (specs/i18n-spanish).
 func (q *Queries) CreateUser(ctx context.Context, arg CreateUserParams) (User, error) {
-	row := q.db.QueryRow(ctx, createUser, arg.Email, arg.PasswordHash, arg.DisplayName)
+	row := q.db.QueryRow(ctx, createUser,
+		arg.Email,
+		arg.PasswordHash,
+		arg.DisplayName,
+		arg.Locale,
+	)
 	var i User
 	err := row.Scan(
 		&i.ID,

--- a/src/packages/api/trip_review.go
+++ b/src/packages/api/trip_review.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"sort"
 	"strings"
 	"time"
@@ -85,18 +84,21 @@ type reviewDeps struct {
 // category) so the output is reproducible for a given trip snapshot. The
 // weather/place-hours checks are best-effort live lookups threaded through
 // deps; any provider error skips silently so the review never fails.
-func reviewTrip(ctx context.Context, data exportData, opts reviewOptions, deps reviewDeps) []Finding {
+// The locale is threaded in explicitly rather than read off ctx: reviewTrip is
+// also driven by the agent tool and by tests that have no request context, and
+// an explicit parameter keeps the finding copy a pure function of its inputs.
+func reviewTrip(ctx context.Context, locale string, data exportData, opts reviewOptions, deps reviewDeps) []Finding {
 	findings := make([]Finding, 0)
-	findings = append(findings, checkDates(data)...)
-	findings = append(findings, checkUnscheduled(data)...)
-	findings = append(findings, checkDensity(data)...)
-	findings = append(findings, checkLodging(data)...)
-	findings = append(findings, checkTransit(data)...)
-	findings = append(findings, checkBudget(data, opts.Budget)...)
-	findings = append(findings, checkBookings(data)...)
-	findings = append(findings, checkWeather(ctx, data, deps.Weather)...)
+	findings = append(findings, checkDates(locale, data)...)
+	findings = append(findings, checkUnscheduled(locale, data)...)
+	findings = append(findings, checkDensity(locale, data)...)
+	findings = append(findings, checkLodging(locale, data)...)
+	findings = append(findings, checkTransit(locale, data)...)
+	findings = append(findings, checkBudget(locale, data, opts.Budget)...)
+	findings = append(findings, checkBookings(locale, data)...)
+	findings = append(findings, checkWeather(ctx, locale, data, deps.Weather)...)
 	if opts.CheckHours {
-		findings = append(findings, checkHours(ctx, data, deps.Places)...)
+		findings = append(findings, checkHours(ctx, locale, data, deps.Places)...)
 	}
 
 	severityRank := map[string]int{"critical": 0, "warn": 1, "info": 2}
@@ -142,14 +144,14 @@ func nightsBetween(start, end time.Time) int {
 
 // checkDates flags a trip with no dates (blocks every day-bound check) and any
 // item tagged to a day past the trip's span.
-func checkDates(d exportData) []Finding {
+func checkDates(locale string, d exportData) []Finding {
 	tripID := d.Trip.ID.String()
 	var out []Finding
 	if !d.Trip.StartDate.Valid || !d.Trip.EndDate.Valid {
 		out = append(out, Finding{
 			Severity: "info", Category: "dates", TripID: tripID,
-			Message: "Add trip dates to unlock day-by-day checks.",
-			Fix:     &FindingFix{Action: "set_dates", Label: "Set dates"},
+			Message: tr(locale, "review.noDates"),
+			Fix:     &FindingFix{Action: "set_dates", Label: tr(locale, "review.fix.setDates")},
 		})
 		return out // no span → the beyond-span check below is meaningless
 	}
@@ -161,9 +163,9 @@ func checkDates(d exportData) []Finding {
 			lastValidDay := dc
 			out = append(out, Finding{
 				Severity: "warn", Category: "dates", TripID: tripID, Day: &day, ItemID: &id,
-				Message: fmt.Sprintf("%q is on day %d, past the trip's %d-day span.", it.Name, day, dc),
+				Message: tr(locale, "review.itemBeyondSpan", it.Name, day, dc),
 				Fix: &FindingFix{
-					Action: "move_item", Label: fmt.Sprintf("Move to Day %d", lastValidDay),
+					Action: "move_item", Label: tr(locale, "review.fix.moveToDay", lastValidDay),
 					ItemID: &id, TargetDay: &lastValidDay,
 				},
 			})
@@ -174,7 +176,7 @@ func checkDates(d exportData) []Finding {
 
 // checkUnscheduled emits one grouped finding for all items with no day (cleaner
 // than one-per-item when many are unscheduled).
-func checkUnscheduled(d exportData) []Finding {
+func checkUnscheduled(locale string, d exportData) []Finding {
 	var count int
 	for _, it := range d.Items {
 		if it.Day == nil {
@@ -184,9 +186,9 @@ func checkUnscheduled(d exportData) []Finding {
 	if count == 0 {
 		return nil
 	}
-	msg := "1 item has no day assigned — schedule it to see it on the day plan."
+	msg := tr(locale, "review.unscheduledOne")
 	if count > 1 {
-		msg = fmt.Sprintf("%d items have no day assigned — schedule them to see them on the day plan.", count)
+		msg = tr(locale, "review.unscheduledMany", count)
 	}
 	return []Finding{{
 		Severity: "info", Category: "unscheduled", TripID: d.Trip.ID.String(), Message: msg,
@@ -196,7 +198,7 @@ func checkUnscheduled(d exportData) []Finding {
 // checkDensity flags empty days between the first and last scheduled day, and
 // over-packed days (more than 6 items, or two+ items sharing a time_of_day).
 // Buckets by absolute day so a day split across hubs still counts once.
-func checkDensity(d exportData) []Finding {
+func checkDensity(locale string, d exportData) []Finding {
 	tripID := d.Trip.ID.String()
 	buckets := map[int][]store.ItineraryItem{}
 	minDay, maxDay := 0, 0
@@ -222,7 +224,7 @@ func checkDensity(d exportData) []Finding {
 			dd := day
 			out = append(out, Finding{
 				Severity: "info", Category: "packing", TripID: tripID, Day: &dd,
-				Message: fmt.Sprintf("Day %d has nothing planned.", day),
+				Message: tr(locale, "review.emptyDay", day),
 			})
 		}
 	}
@@ -235,7 +237,7 @@ func checkDensity(d exportData) []Finding {
 		if len(items) > 6 {
 			f := Finding{
 				Severity: "warn", Category: "packing", TripID: tripID, Day: &dd,
-				Message: fmt.Sprintf("Day %d has %d items planned — that may be too packed.", day, len(items)),
+				Message: tr(locale, "review.packedDay", day, len(items)),
 			}
 			// Offer a one-tap move of the last item in the crowded day to the
 			// nearest meaningfully-lighter day — only when both a movable item
@@ -243,7 +245,7 @@ func checkDensity(d exportData) []Finding {
 			if target := lighterDay(d, day); target != nil {
 				id := items[len(items)-1].ID.String()
 				f.Fix = &FindingFix{
-					Action: "move_item", Label: fmt.Sprintf("Move to Day %d", *target),
+					Action: "move_item", Label: tr(locale, "review.fix.moveToDay", *target),
 					ItemID: &id, TargetDay: target,
 				}
 			}
@@ -260,13 +262,13 @@ func checkDensity(d exportData) []Finding {
 			if todCount[tod] > 1 {
 				f := Finding{
 					Severity: "warn", Category: "packing", TripID: tripID, Day: &dd,
-					Message: fmt.Sprintf("Day %d has %d things scheduled for the %s.", day, todCount[tod], tod),
+					Message: tr(locale, "review.timeOfDayCollision", day, todCount[tod], tr(locale, "review.tod."+tod)),
 				}
 				if target := lighterDay(d, day); target != nil {
 					// The last item in that colliding slot is the one to move.
 					if id, ok := lastItemInSlot(items, tod); ok {
 						f.Fix = &FindingFix{
-							Action: "move_item", Label: fmt.Sprintf("Move to Day %d", *target),
+							Action: "move_item", Label: tr(locale, "review.fix.moveToDay", *target),
 							ItemID: &id, TargetDay: target,
 						}
 					}
@@ -329,7 +331,7 @@ func lastItemInSlot(items []store.ItineraryItem, tod string) (string, bool) {
 // exclusive) and flags any night no accommodation covers. Gated so an empty
 // draft isn't nagged: only runs when the trip is `planned` OR already has at
 // least one accommodation.
-func checkLodging(d exportData) []Finding {
+func checkLodging(locale string, d exportData) []Finding {
 	if !d.Trip.StartDate.Valid || !d.Trip.EndDate.Valid {
 		return nil
 	}
@@ -355,9 +357,9 @@ func checkLodging(d exportData) []Finding {
 			checkOut := night.AddDate(0, 0, 1).Format(dateLayout)
 			out = append(out, Finding{
 				Severity: "warn", Category: "lodging", TripID: tripID, Day: &day,
-				Message: fmt.Sprintf("No lodging booked for the night of %s.", night.Format("Mon, Jan 2")),
+				Message: tr(locale, "review.noLodging", localizedDate(locale, night, dateStyleWeekdayMonthDay)),
 				Fix: &FindingFix{
-					Action: "add_lodging", Label: "Add a stay",
+					Action: "add_lodging", Label: tr(locale, "review.fix.addStay"),
 					City:     cityForDay(d.Items, day),
 					CheckIn:  &checkIn,
 					CheckOut: &checkOut,
@@ -428,7 +430,7 @@ func hubFirstDate(trip store.Trip, items []store.ItineraryItem, hub string) (tim
 // segment plausibly connects the two, it flags a missing leg. Conservative on
 // purpose — a same-city move or a fuzzy origin/destination match suppresses the
 // warning to avoid false positives.
-func checkTransit(d exportData) []Finding {
+func checkTransit(locale string, d exportData) []Finding {
 	groups := groupExportItems(d.Trip, d.Items)
 	if len(groups) < 2 {
 		return nil
@@ -448,24 +450,24 @@ func checkTransit(d exportData) []Finding {
 		}
 		origin, dest := from, to
 		greek := isGreekLocation(origin) || isGreekLocation(dest)
-		label, mode := "Add transport", "flight"
+		label, mode := tr(locale, "review.fix.addTransport"), "flight"
 		if greek {
 			// Island legs stay ferry regardless of the trip's travel mode —
 			// you can't drive between islands.
-			label, mode = "Add ferry", "ferry"
+			label, mode = tr(locale, "review.fix.addFerry"), "ferry"
 		} else if tm := d.Trip.TravelMode; tm != nil && allowedSegmentModes[*tm] {
 			// 'mixed' fails the allowedSegmentModes check and keeps the
 			// flight default — intended.
 			mode = *tm
 			switch *tm {
 			case "car":
-				label = "Add drive"
+				label = tr(locale, "review.fix.addDrive")
 			case "train":
-				label = "Add train"
+				label = tr(locale, "review.fix.addTrain")
 			case "bus":
-				label = "Add bus"
+				label = tr(locale, "review.fix.addBus")
 			case "ferry":
-				label = "Add ferry"
+				label = tr(locale, "review.fix.addFerry")
 			}
 		}
 		fix := &FindingFix{
@@ -478,7 +480,7 @@ func checkTransit(d exportData) []Finding {
 		}
 		out = append(out, Finding{
 			Severity: "warn", Category: "transit", TripID: tripID,
-			Message: fmt.Sprintf("No transport booked from %s to %s.", from, to),
+			Message: tr(locale, "review.noTransport", from, to),
 			Fix:     fix,
 		})
 	}
@@ -512,15 +514,15 @@ func fuzzyMatch(a, b string) bool {
 }
 
 // checkBudget flags a trip whose spending exceeds its target.
-func checkBudget(d exportData, budget *BudgetResponse) []Finding {
+func checkBudget(locale string, d exportData, budget *BudgetResponse) []Finding {
 	if budget == nil || budget.Remaining == nil || *budget.Remaining >= 0 {
 		return nil
 	}
 	over := -*budget.Remaining
 	return []Finding{{
 		Severity: "warn", Category: "budget", TripID: d.Trip.ID.String(),
-		Message: fmt.Sprintf("Over budget by %.2f %s.", over, budget.Currency),
-		Fix:     &FindingFix{Action: "raise_budget", Label: "Adjust budget"},
+		Message: tr(locale, "review.overBudget", over, budget.Currency),
+		Fix:     &FindingFix{Action: "raise_budget", Label: tr(locale, "review.fix.adjustBudget")},
 	}}
 }
 
@@ -529,7 +531,7 @@ func checkBudget(d exportData, budget *BudgetResponse) []Finding {
 // generated "Suggested" drafts that track the itinerary, not commitments the
 // traveler made, so they're skipped: nagging "confirm your booking" for a
 // suggestion the traveler never chose is noise.
-func checkBookings(d exportData) []Finding {
+func checkBookings(locale string, d exportData) []Finding {
 	tripID := d.Trip.ID.String()
 	var out []Finding
 	for _, a := range d.Accommodations {
@@ -540,9 +542,9 @@ func checkBookings(d exportData) []Finding {
 		et := "accommodation"
 		out = append(out, Finding{
 			Severity: "info", Category: "bookings", TripID: tripID, ItemID: &id,
-			Message: fmt.Sprintf("Confirm your booking for %s.", a.Name),
+			Message: tr(locale, "review.confirmBooking", a.Name),
 			Fix: &FindingFix{
-				Action: "mark_booked", Label: "Mark booked", ItemID: &id, EntityType: &et,
+				Action: "mark_booked", Label: tr(locale, "review.fix.markBooked"), ItemID: &id, EntityType: &et,
 			},
 		})
 	}
@@ -554,9 +556,9 @@ func checkBookings(d exportData) []Finding {
 		et := "segment"
 		out = append(out, Finding{
 			Severity: "info", Category: "bookings", TripID: tripID, ItemID: &id,
-			Message: fmt.Sprintf("Confirm your booking for %s.", segmentRoute(s)),
+			Message: tr(locale, "review.confirmBooking", segmentRoute(s)),
 			Fix: &FindingFix{
-				Action: "mark_booked", Label: "Mark booked", ItemID: &id, EntityType: &et,
+				Action: "mark_booked", Label: tr(locale, "review.fix.markBooked"), ItemID: &id, EntityType: &et,
 			},
 		})
 	}
@@ -581,7 +583,7 @@ const (
 // days, one GetTripWeather lookup per distinct city (keyless, TTL-cached).
 // Best-effort: a nil service, an undated trip, or any provider error/empty
 // result skips silently — weather never fails or blocks a review.
-func checkWeather(ctx context.Context, d exportData, weather *WeatherService) []Finding {
+func checkWeather(ctx context.Context, locale string, d exportData, weather *WeatherService) []Finding {
 	if weather == nil || !d.Trip.StartDate.Valid {
 		return nil
 	}
@@ -660,9 +662,9 @@ func checkWeather(ctx context.Context, d exportData, weather *WeatherService) []
 			if di.outdoor && weatherDayRainy(wd) {
 				out = append(out, Finding{
 					Severity: "info", Category: "weather", TripID: tripID, Day: &dd,
-					Message: fmt.Sprintf("Rain likely on Day %d (%s) — pack an umbrella.", day, city),
+					Message: tr(locale, "review.rainLikely", day, city),
 					Fix: &FindingFix{
-						Action: "add_packing", Label: "+ umbrella",
+						Action: "add_packing", Label: tr(locale, "review.fix.addUmbrella"),
 						PackingItem: ptrTo("Umbrella"), PackingCategory: ptrTo("general"),
 					},
 				})
@@ -671,18 +673,18 @@ func checkWeather(ctx context.Context, d exportData, weather *WeatherService) []
 			case wd.TempMaxC >= hotThresholdC:
 				out = append(out, Finding{
 					Severity: "info", Category: "weather", TripID: tripID, Day: &dd,
-					Message: fmt.Sprintf("Day %d (%s) could be very hot (%.0f°C) — plan for the heat.", day, city, wd.TempMaxC),
+					Message: tr(locale, "review.veryHot", day, city, wd.TempMaxC),
 					Fix: &FindingFix{
-						Action: "add_packing", Label: "+ sun protection",
+						Action: "add_packing", Label: tr(locale, "review.fix.addSunProtection"),
 						PackingItem: ptrTo("Sunscreen"), PackingCategory: ptrTo("health"),
 					},
 				})
 			case wd.TempMinC <= coldThresholdC:
 				out = append(out, Finding{
 					Severity: "info", Category: "weather", TripID: tripID, Day: &dd,
-					Message: fmt.Sprintf("Day %d (%s) could be very cold (%.0f°C) — pack warm layers.", day, city, wd.TempMinC),
+					Message: tr(locale, "review.veryCold", day, city, wd.TempMinC),
 					Fix: &FindingFix{
-						Action: "add_packing", Label: "+ warm layers",
+						Action: "add_packing", Label: tr(locale, "review.fix.addWarmLayers"),
 						PackingItem: ptrTo("Warm layers"), PackingCategory: ptrTo("clothing"),
 					},
 				})
@@ -734,7 +736,7 @@ func isOutdoorItem(it store.ItineraryItem) bool {
 // details, converts the opening hours, and warns when the place is closed that
 // weekday. Bounded to maxHoursLookups upstream fetches per review. Best-effort:
 // a nil service, a Places error, or unresolvable hours skips that item.
-func checkHours(ctx context.Context, d exportData, places *GooglePlacesService) []Finding {
+func checkHours(ctx context.Context, locale string, d exportData, places *GooglePlacesService) []Finding {
 	if places == nil {
 		return nil
 	}
@@ -781,10 +783,10 @@ func checkHours(ctx context.Context, d exportData, places *GooglePlacesService) 
 		id := it.ID.String()
 		out = append(out, Finding{
 			Severity: "warn", Category: "hours", TripID: tripID, Day: &day, ItemID: &id,
-			Message: fmt.Sprintf("%s may be closed on %s (Day %d).", it.Name, weekday.String(), day),
+			Message: tr(locale, "review.mayBeClosed", it.Name, localizedWeekday(locale, weekday), day),
 			// No cheap "open on day N" signal here (we only fetched this item's
 			// hours), so the client opens an editor — TargetDay stays nil.
-			Fix: &FindingFix{Action: "move_item", Label: "Reschedule", ItemID: &id},
+			Fix: &FindingFix{Action: "move_item", Label: tr(locale, "review.fix.reschedule"), ItemID: &id},
 		})
 	}
 	return out

--- a/src/packages/api/trip_review_test.go
+++ b/src/packages/api/trip_review_test.go
@@ -32,7 +32,7 @@ func i32p(v int32) *int32 { return &v }
 
 func TestCheckDates_Undated(t *testing.T) {
 	d := exportData{Trip: store.Trip{ID: uuid.New(), Status: "draft"}}
-	fs := checkDates(d)
+	fs := checkDates("en", d)
 	if len(fs) != 1 || fs[0].Category != "dates" || fs[0].Severity != "info" {
 		t.Fatalf("undated trip = %+v", fs)
 	}
@@ -45,7 +45,7 @@ func TestCheckDates_ItemPastSpan(t *testing.T) {
 		{ID: uuid.New(), Name: "Louvre", Day: i32p(2)},
 		{ID: uuid.New(), Name: "Way Out", Day: i32p(9)},
 	}
-	fs := checkDates(exportData{Trip: trip, Items: items})
+	fs := checkDates("en", exportData{Trip: trip, Items: items})
 	if len(fs) != 1 || fs[0].Severity != "warn" || fs[0].Day == nil || *fs[0].Day != 9 {
 		t.Fatalf("past-span = %+v", fs)
 	}
@@ -57,7 +57,7 @@ func TestCheckUnscheduled_Grouped(t *testing.T) {
 		{ID: uuid.New(), Name: "B"}, // day nil
 		{ID: uuid.New(), Name: "C", Day: i32p(1)},
 	}}
-	fs := checkUnscheduled(d)
+	fs := checkUnscheduled("en", d)
 	if len(fs) != 1 || fs[0].Category != "unscheduled" {
 		t.Fatalf("unscheduled = %+v", fs)
 	}
@@ -71,7 +71,7 @@ func TestCheckDensity_EmptyAndPacked(t *testing.T) {
 		// day 2 empty
 		{ID: uuid.New(), Name: "C", Day: i32p(3)},
 	}
-	fs := checkDensity(exportData{Trip: store.Trip{ID: uuid.New()}, Items: items})
+	fs := checkDensity("en", exportData{Trip: store.Trip{ID: uuid.New()}, Items: items})
 	cats := map[string][]Finding{}
 	for _, f := range fs {
 		cats[f.Severity] = append(cats[f.Severity], f)
@@ -89,7 +89,7 @@ func TestCheckLodging_GateAndCoverage(t *testing.T) {
 		StartDate: dateVal(t, "2026-08-01"), EndDate: dateVal(t, "2026-08-04")} // 3 nights: 1,2,3
 
 	// No accommodations, planned → all 3 nights flagged.
-	fs := checkLodging(exportData{Trip: trip})
+	fs := checkLodging("en", exportData{Trip: trip})
 	if len(fs) != 3 {
 		t.Fatalf("planned no-lodging = %d findings, want 3: %+v", len(fs), fs)
 	}
@@ -97,7 +97,7 @@ func TestCheckLodging_GateAndCoverage(t *testing.T) {
 	// One stay covering nights 1-2 (checkout 08-03, exclusive) → only night 3 flagged.
 	acc := []store.Accommodation{{ID: uuid.New(), Name: "Hotel",
 		CheckIn: dateVal(t, "2026-08-01"), CheckOut: dateVal(t, "2026-08-03")}}
-	fs = checkLodging(exportData{Trip: trip, Accommodations: acc})
+	fs = checkLodging("en", exportData{Trip: trip, Accommodations: acc})
 	if len(fs) != 1 || fs[0].Day == nil || *fs[0].Day != 3 {
 		t.Fatalf("partial lodging = %+v", fs)
 	}
@@ -105,7 +105,7 @@ func TestCheckLodging_GateAndCoverage(t *testing.T) {
 	// Empty draft (draft status, no accommodations) is not nagged.
 	draft := trip
 	draft.Status = "draft"
-	if fs := checkLodging(exportData{Trip: draft}); len(fs) != 0 {
+	if fs := checkLodging("en", exportData{Trip: draft}); len(fs) != 0 {
 		t.Fatalf("empty draft should be silent, got %+v", fs)
 	}
 }
@@ -117,14 +117,14 @@ func TestCheckTransit_MissingLeg(t *testing.T) {
 		{ID: uuid.New(), Name: "Duomo", City: strp("Florence"), Day: i32p(2)},
 	}
 	// No segments → missing Rome→Florence leg.
-	fs := checkTransit(exportData{Trip: trip, Items: items})
+	fs := checkTransit("en", exportData{Trip: trip, Items: items})
 	if len(fs) != 1 || fs[0].Category != "transit" {
 		t.Fatalf("missing leg = %+v", fs)
 	}
 	// A connecting segment suppresses it.
 	segs := []store.TripSegment{{ID: uuid.New(), Mode: "train",
 		Origin: strp("Rome"), Destination: strp("Florence")}}
-	if fs := checkTransit(exportData{Trip: trip, Items: items, Segments: segs}); len(fs) != 0 {
+	if fs := checkTransit("en", exportData{Trip: trip, Items: items, Segments: segs}); len(fs) != 0 {
 		t.Fatalf("connected legs should be silent, got %+v", fs)
 	}
 }
@@ -132,15 +132,15 @@ func TestCheckTransit_MissingLeg(t *testing.T) {
 func TestCheckBudget_OverBudget(t *testing.T) {
 	over := -50.0
 	br := &BudgetResponse{Currency: "USD", Spent: 150, Remaining: &over}
-	fs := checkBudget(exportData{Trip: store.Trip{ID: uuid.New()}}, br)
+	fs := checkBudget("en", exportData{Trip: store.Trip{ID: uuid.New()}}, br)
 	if len(fs) != 1 || fs[0].Category != "budget" || fs[0].Severity != "warn" {
 		t.Fatalf("over budget = %+v", fs)
 	}
 	within := 10.0
-	if fs := checkBudget(exportData{Trip: store.Trip{ID: uuid.New()}}, &BudgetResponse{Remaining: &within}); len(fs) != 0 {
+	if fs := checkBudget("en", exportData{Trip: store.Trip{ID: uuid.New()}}, &BudgetResponse{Remaining: &within}); len(fs) != 0 {
 		t.Fatalf("within budget should be silent, got %+v", fs)
 	}
-	if fs := checkBudget(exportData{Trip: store.Trip{ID: uuid.New()}}, nil); len(fs) != 0 {
+	if fs := checkBudget("en", exportData{Trip: store.Trip{ID: uuid.New()}}, nil); len(fs) != 0 {
 		t.Fatalf("no budget should be silent, got %+v", fs)
 	}
 }
@@ -160,7 +160,7 @@ func TestCheckBookings_Unbooked(t *testing.T) {
 			{ID: uuid.New(), Mode: "train", Origin: strp("Rome"), Destination: strp("Florence"), Booked: false, Auto: true},
 		},
 	}
-	fs := checkBookings(d)
+	fs := checkBookings("en", d)
 	if len(fs) != 2 {
 		t.Fatalf("expected 2 unbooked findings (auto drafts skipped), got %+v", fs)
 	}
@@ -233,7 +233,7 @@ func TestCheckWeather_RainyOutdoorDay(t *testing.T) {
 	d := exportData{Trip: trip, Items: items}
 
 	weather := weatherStub(t, true, 22, 14) // rainy, mild
-	fs := checkWeather(context.Background(), d, weather)
+	fs := checkWeather(context.Background(), "en", d, weather)
 	var gotRain bool
 	for _, f := range fs {
 		if f.Category != "weather" || f.Severity != "info" {
@@ -251,14 +251,14 @@ func TestCheckWeather_RainyOutdoorDay(t *testing.T) {
 	indoor := exportData{Trip: trip, Items: []store.ItineraryItem{
 		{ID: uuid.New(), Name: "Louvre", City: strp("Paris"), Category: strp("museum"), Day: i32p(1)},
 	}}
-	for _, f := range checkWeather(context.Background(), indoor, weather) {
+	for _, f := range checkWeather(context.Background(), "en", indoor, weather) {
 		if strings.Contains(f.Message, "umbrella") {
 			t.Fatalf("indoor day should not get an umbrella finding: %+v", f)
 		}
 	}
 
 	// Nil service is a silent no-op.
-	if fs := checkWeather(context.Background(), d, nil); len(fs) != 0 {
+	if fs := checkWeather(context.Background(), "en", d, nil); len(fs) != 0 {
 		t.Fatalf("nil weather service should yield no findings, got %+v", fs)
 	}
 }
@@ -273,7 +273,7 @@ func TestCheckWeather_HotDay(t *testing.T) {
 	}}
 	weather := weatherStub(t, false, 37, 26) // hot, dry
 	var gotHot bool
-	for _, f := range checkWeather(context.Background(), d, weather) {
+	for _, f := range checkWeather(context.Background(), "en", d, weather) {
 		if strings.Contains(f.Message, "very hot") {
 			gotHot = true
 		}
@@ -313,7 +313,7 @@ func TestCheckHours_ClosedOnScheduledWeekday(t *testing.T) {
 	d := exportData{Trip: trip, Items: items}
 
 	svc, rt := placesDouble(t, closedMondayDetailsJSON)
-	fs := checkHours(context.Background(), d, svc)
+	fs := checkHours(context.Background(), "en", d, svc)
 	if len(fs) != 1 || fs[0].Category != "hours" || fs[0].Severity != "warn" {
 		t.Fatalf("expected one closed-weekday warn, got %+v", fs)
 	}
@@ -325,7 +325,7 @@ func TestCheckHours_ClosedOnScheduledWeekday(t *testing.T) {
 	}
 
 	// Nil service is a silent no-op.
-	if fs := checkHours(context.Background(), d, nil); len(fs) != 0 {
+	if fs := checkHours(context.Background(), "en", d, nil); len(fs) != 0 {
 		t.Fatalf("nil places service should yield no findings, got %+v", fs)
 	}
 }
@@ -341,7 +341,7 @@ func TestReviewTrip_CheckHoursGate(t *testing.T) {
 	deps := reviewDeps{Places: svc}
 
 	// CheckHours=false → the hours check never runs (no Google call, no hours finding).
-	for _, f := range reviewTrip(context.Background(), d, reviewOptions{CheckHours: false}, deps) {
+	for _, f := range reviewTrip(context.Background(), "en", d, reviewOptions{CheckHours: false}, deps) {
 		if f.Category == "hours" {
 			t.Fatalf("hours finding leaked with CheckHours=false: %+v", f)
 		}
@@ -352,7 +352,7 @@ func TestReviewTrip_CheckHoursGate(t *testing.T) {
 
 	// CheckHours=true → the finding appears.
 	var gotHours bool
-	for _, f := range reviewTrip(context.Background(), d, reviewOptions{CheckHours: true}, deps) {
+	for _, f := range reviewTrip(context.Background(), "en", d, reviewOptions{CheckHours: true}, deps) {
 		if f.Category == "hours" {
 			gotHours = true
 		}
@@ -373,7 +373,7 @@ func TestFix_Lodging(t *testing.T) {
 	items := []store.ItineraryItem{
 		{ID: uuid.New(), Name: "Beach", City: strp("Nice"), Day: i32p(3)},
 	}
-	fs := checkLodging(exportData{Trip: trip, Accommodations: acc, Items: items})
+	fs := checkLodging("en", exportData{Trip: trip, Accommodations: acc, Items: items})
 	if len(fs) != 1 || fs[0].Fix == nil {
 		t.Fatalf("expected one lodging finding with a fix, got %+v", fs)
 	}
@@ -402,7 +402,7 @@ func TestFix_TransitGreekFerry(t *testing.T) {
 		{ID: uuid.New(), Name: "Acropolis", City: strp("Athens"), Day: i32p(1)},
 		{ID: uuid.New(), Name: "Portara", City: strp("Naxos"), Day: i32p(2)},
 	}
-	fs := checkTransit(exportData{Trip: trip, Items: items})
+	fs := checkTransit("en", exportData{Trip: trip, Items: items})
 	if len(fs) != 1 || fs[0].Fix == nil {
 		t.Fatalf("expected one transit finding with a fix, got %+v", fs)
 	}
@@ -426,7 +426,7 @@ func TestFix_TransitGreekFerry(t *testing.T) {
 		{ID: uuid.New(), Name: "Colosseum", City: strp("Rome"), Day: i32p(1)},
 		{ID: uuid.New(), Name: "Duomo", City: strp("Florence"), Day: i32p(2)},
 	}
-	gf := checkTransit(exportData{Trip: trip, Items: nonGreek})
+	gf := checkTransit("en", exportData{Trip: trip, Items: nonGreek})
 	if len(gf) != 1 || gf[0].Fix == nil || gf[0].Fix.Label != "Add transport" ||
 		gf[0].Fix.Mode == nil || *gf[0].Fix.Mode != "flight" {
 		t.Fatalf("non-greek transit fix = %+v", gf)
@@ -446,14 +446,14 @@ func TestFix_TransitRespectsTravelMode(t *testing.T) {
 			TravelMode: mode}
 	}
 
-	fs := checkTransit(exportData{Trip: tripWith(strp("car")), Items: items})
+	fs := checkTransit("en", exportData{Trip: tripWith(strp("car")), Items: items})
 	if len(fs) != 1 || fs[0].Fix == nil || fs[0].Fix.Label != "Add drive" ||
 		fs[0].Fix.Mode == nil || *fs[0].Fix.Mode != "car" {
 		t.Fatalf("car-trip transit fix = %+v", fs)
 	}
 
 	// mixed is not a segment mode → keeps the flight default.
-	fs = checkTransit(exportData{Trip: tripWith(strp("mixed")), Items: items})
+	fs = checkTransit("en", exportData{Trip: tripWith(strp("mixed")), Items: items})
 	if len(fs) != 1 || fs[0].Fix == nil || *fs[0].Fix.Mode != "flight" {
 		t.Fatalf("mixed-trip transit fix = %+v", fs)
 	}
@@ -463,7 +463,7 @@ func TestFix_TransitRespectsTravelMode(t *testing.T) {
 		{ID: uuid.New(), Name: "Acropolis", City: strp("Athens"), Day: i32p(1)},
 		{ID: uuid.New(), Name: "Portara", City: strp("Naxos"), Day: i32p(2)},
 	}
-	fs = checkTransit(exportData{Trip: tripWith(strp("car")), Items: greek})
+	fs = checkTransit("en", exportData{Trip: tripWith(strp("car")), Items: greek})
 	if len(fs) != 1 || fs[0].Fix == nil || *fs[0].Fix.Mode != "ferry" {
 		t.Fatalf("greek car-trip transit fix = %+v", fs)
 	}
@@ -479,7 +479,7 @@ func TestFix_BookingsEntityType(t *testing.T) {
 			{ID: uuid.New(), Mode: "flight", Origin: strp("JFK"), Destination: strp("CDG"), Booked: false},
 		},
 	}
-	fs := checkBookings(d)
+	fs := checkBookings("en", d)
 	if len(fs) != 2 {
 		t.Fatalf("expected 2 booking findings, got %+v", fs)
 	}
@@ -503,7 +503,7 @@ func TestFix_DatesBeyondSpan(t *testing.T) {
 		StartDate: dateVal(t, "2026-08-01"), EndDate: dateVal(t, "2026-08-03")} // 3-day span
 	id := uuid.New()
 	items := []store.ItineraryItem{{ID: id, Name: "Way Out", Day: i32p(9)}}
-	fs := checkDates(exportData{Trip: trip, Items: items})
+	fs := checkDates("en", exportData{Trip: trip, Items: items})
 	if len(fs) != 1 || fs[0].Fix == nil {
 		t.Fatalf("expected one beyond-span finding with a fix, got %+v", fs)
 	}
@@ -528,7 +528,7 @@ func TestFix_OverPacked_LighterDayAndNone(t *testing.T) {
 		items = append(items, store.ItineraryItem{ID: id, Name: fmt.Sprintf("A%d", i), Day: i32p(1)})
 	}
 	items = append(items, store.ItineraryItem{ID: uuid.New(), Name: "B", Day: i32p(2)})
-	fs := checkDensity(exportData{Trip: store.Trip{ID: tripID}, Items: items})
+	fs := checkDensity("en", exportData{Trip: store.Trip{ID: tripID}, Items: items})
 	var packed *Finding
 	for i := range fs {
 		if fs[i].Severity == "warn" && strings.Contains(fs[i].Message, "too packed") {
@@ -550,7 +550,7 @@ func TestFix_OverPacked_LighterDayAndNone(t *testing.T) {
 	for i := 0; i < 7; i++ {
 		solo = append(solo, store.ItineraryItem{ID: uuid.New(), Name: fmt.Sprintf("C%d", i), Day: i32p(1)})
 	}
-	sf := checkDensity(exportData{Trip: store.Trip{ID: tripID}, Items: solo})
+	sf := checkDensity("en", exportData{Trip: store.Trip{ID: tripID}, Items: solo})
 	for _, f := range sf {
 		if strings.Contains(f.Message, "too packed") && f.Fix != nil {
 			t.Fatalf("no lighter day exists — over-packed fix should be nil, got %+v", f.Fix)
@@ -568,7 +568,7 @@ func TestFix_WeatherRainAddPacking(t *testing.T) {
 	}}
 	weather := weatherStub(t, true, 22, 14)
 	var gotFix bool
-	for _, f := range checkWeather(context.Background(), d, weather) {
+	for _, f := range checkWeather(context.Background(), "en", d, weather) {
 		if strings.Contains(f.Message, "umbrella") {
 			if f.Fix == nil || f.Fix.Action != "add_packing" ||
 				f.Fix.PackingItem == nil || *f.Fix.PackingItem != "Umbrella" {
@@ -595,7 +595,7 @@ func TestReviewTrip_CleanTripNoFindings(t *testing.T) {
 		Accommodations: []store.Accommodation{{ID: uuid.New(), Name: "Hotel", Booked: true,
 			CheckIn: dateVal(t, "2026-08-01"), CheckOut: dateVal(t, "2026-08-02")}},
 	}
-	fs := reviewTrip(context.Background(), d, reviewOptions{}, reviewDeps{})
+	fs := reviewTrip(context.Background(), "en", d, reviewOptions{}, reviewDeps{})
 	if len(fs) != 0 {
 		t.Fatalf("clean trip should have no findings, got %+v", fs)
 	}
@@ -610,8 +610,8 @@ func TestReviewTrip_DeterministicOrder(t *testing.T) {
 	d := exportData{Trip: trip, Items: []store.ItineraryItem{
 		{ID: uuid.New(), Name: "A"}, // unscheduled
 	}}
-	ja, _ := json.Marshal(reviewTrip(context.Background(), d, reviewOptions{}, reviewDeps{}))
-	jb, _ := json.Marshal(reviewTrip(context.Background(), d, reviewOptions{}, reviewDeps{}))
+	ja, _ := json.Marshal(reviewTrip(context.Background(), "en", d, reviewOptions{}, reviewDeps{}))
+	jb, _ := json.Marshal(reviewTrip(context.Background(), "en", d, reviewOptions{}, reviewDeps{}))
 	if string(ja) != string(jb) {
 		t.Fatalf("nondeterministic order:\n%s\n%s", ja, jb)
 	}

--- a/src/packages/api/weather_service.go
+++ b/src/packages/api/weather_service.go
@@ -98,8 +98,10 @@ func (s *WeatherService) geocode(ctx context.Context, city string) (geoResult, e
 			Longitude float64 `json:"longitude"`
 		} `json:"results"`
 	}
-	u := fmt.Sprintf("%s/v1/search?name=%s&count=1&language=en&format=json",
-		s.GeocodeBaseURL, url.QueryEscape(city))
+	// Geocoding language was hardcoded to English before i18n; the traveler's
+	// locale now decides how the matched place is named (specs/i18n-spanish).
+	u := fmt.Sprintf("%s/v1/search?name=%s&count=1&language=%s&format=json",
+		s.GeocodeBaseURL, url.QueryEscape(city), requestLocale(ctx))
 	if err := s.getJSON(ctx, u, &out); err != nil {
 		return geoResult{}, err
 	}

--- a/src/packages/flutter-app/lib/l10n/app_en.arb
+++ b/src/packages/flutter-app/lib/l10n/app_en.arb
@@ -1803,5 +1803,32 @@
         "type": "String"
       }
     }
-  }
+  },
+  "calendarStayTitle": "Stay: {name}",
+  "@calendarStayTitle": {
+    "description": "Calendar event title for a stay. MUST stay byte-identical to the Go .ics export's ics.stayTitle — the Google link and the downloaded .ics are the same event.",
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
+  "calendarSegmentTitle": "{mode}: {route}",
+  "@calendarSegmentTitle": {
+    "description": "Calendar event title for a transport segment. Mirrors the Go .ics export's ics.segmentTitle.",
+    "placeholders": {
+      "mode": {
+        "type": "String"
+      },
+      "route": {
+        "type": "String"
+      }
+    }
+  },
+  "calendarModeFlight": "Flight",
+  "calendarModeTrain": "Train",
+  "calendarModeBus": "Bus",
+  "calendarModeCar": "Car",
+  "calendarModeFerry": "Ferry",
+  "calendarModeOther": "Other"
 }

--- a/src/packages/flutter-app/lib/l10n/app_es.arb
+++ b/src/packages/flutter-app/lib/l10n/app_es.arb
@@ -280,7 +280,7 @@
   "tripTravelModeTooltip": "Modo de viaje",
   "tripModeTrain": "Tren",
   "tripModeBus": "Autobús",
-  "tripModeFerry": "Ferry",
+  "tripModeFerry": "Ferri",
   "tripUpdateFailed": "Error al actualizar: {error}",
   "tripDeleteFailed": "Error al eliminar: {error}",
   "tripReorderFailed": "No se pudo reordenar: {error}",
@@ -785,5 +785,13 @@
   "appMapCredits": "Créditos del mapa",
   "flightStops": "{count, plural, =0{Sin escalas} =1{1 escala} other{{count} escalas}}",
   "flightStopsEachWay": "{stops} por trayecto",
-  "flightStopsSplit": "{outbound} / {inbound}"
+  "flightStopsSplit": "{outbound} / {inbound}",
+  "calendarStayTitle": "Alojamiento: {name}",
+  "calendarSegmentTitle": "{mode}: {route}",
+  "calendarModeFlight": "Vuelo",
+  "calendarModeTrain": "Tren",
+  "calendarModeBus": "Autobús",
+  "calendarModeCar": "Coche",
+  "calendarModeFerry": "Ferri",
+  "calendarModeOther": "Otro"
 }

--- a/src/packages/flutter-app/lib/l10n/app_localizations.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations.dart
@@ -4813,6 +4813,54 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'{outbound} / {inbound}'**
   String flightStopsSplit(String outbound, String inbound);
+
+  /// Calendar event title for a stay. MUST stay byte-identical to the Go .ics export's ics.stayTitle — the Google link and the downloaded .ics are the same event.
+  ///
+  /// In en, this message translates to:
+  /// **'Stay: {name}'**
+  String calendarStayTitle(String name);
+
+  /// Calendar event title for a transport segment. Mirrors the Go .ics export's ics.segmentTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'{mode}: {route}'**
+  String calendarSegmentTitle(String mode, String route);
+
+  /// No description provided for @calendarModeFlight.
+  ///
+  /// In en, this message translates to:
+  /// **'Flight'**
+  String get calendarModeFlight;
+
+  /// No description provided for @calendarModeTrain.
+  ///
+  /// In en, this message translates to:
+  /// **'Train'**
+  String get calendarModeTrain;
+
+  /// No description provided for @calendarModeBus.
+  ///
+  /// In en, this message translates to:
+  /// **'Bus'**
+  String get calendarModeBus;
+
+  /// No description provided for @calendarModeCar.
+  ///
+  /// In en, this message translates to:
+  /// **'Car'**
+  String get calendarModeCar;
+
+  /// No description provided for @calendarModeFerry.
+  ///
+  /// In en, this message translates to:
+  /// **'Ferry'**
+  String get calendarModeFerry;
+
+  /// No description provided for @calendarModeOther.
+  ///
+  /// In en, this message translates to:
+  /// **'Other'**
+  String get calendarModeOther;
 }
 
 class _AppLocalizationsDelegate

--- a/src/packages/flutter-app/lib/l10n/app_localizations_en.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations_en.dart
@@ -2763,4 +2763,32 @@ class AppLocalizationsEn extends AppLocalizations {
   String flightStopsSplit(String outbound, String inbound) {
     return '$outbound / $inbound';
   }
+
+  @override
+  String calendarStayTitle(String name) {
+    return 'Stay: $name';
+  }
+
+  @override
+  String calendarSegmentTitle(String mode, String route) {
+    return '$mode: $route';
+  }
+
+  @override
+  String get calendarModeFlight => 'Flight';
+
+  @override
+  String get calendarModeTrain => 'Train';
+
+  @override
+  String get calendarModeBus => 'Bus';
+
+  @override
+  String get calendarModeCar => 'Car';
+
+  @override
+  String get calendarModeFerry => 'Ferry';
+
+  @override
+  String get calendarModeOther => 'Other';
 }

--- a/src/packages/flutter-app/lib/l10n/app_localizations_es.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations_es.dart
@@ -900,7 +900,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get tripModeBus => 'Autobús';
 
   @override
-  String get tripModeFerry => 'Ferry';
+  String get tripModeFerry => 'Ferri';
 
   @override
   String tripUpdateFailed(String error) {
@@ -2782,4 +2782,32 @@ class AppLocalizationsEs extends AppLocalizations {
   String flightStopsSplit(String outbound, String inbound) {
     return '$outbound / $inbound';
   }
+
+  @override
+  String calendarStayTitle(String name) {
+    return 'Alojamiento: $name';
+  }
+
+  @override
+  String calendarSegmentTitle(String mode, String route) {
+    return '$mode: $route';
+  }
+
+  @override
+  String get calendarModeFlight => 'Vuelo';
+
+  @override
+  String get calendarModeTrain => 'Tren';
+
+  @override
+  String get calendarModeBus => 'Autobús';
+
+  @override
+  String get calendarModeCar => 'Coche';
+
+  @override
+  String get calendarModeFerry => 'Ferri';
+
+  @override
+  String get calendarModeOther => 'Otro';
 }

--- a/src/packages/flutter-app/lib/widgets/bookings_section.dart
+++ b/src/packages/flutter-app/lib/widgets/bookings_section.dart
@@ -107,14 +107,34 @@ class BookingsSection extends StatelessWidget {
 
   /// Calendar-event title for a segment, mirroring the Go export's
   /// `capitalize(mode) + ": " + segmentRoute(s)`.
-  static String _segmentCalendarTitle(TripSegment s) {
-    final mode = s.mode.isEmpty
-        ? 'Trip'
-        : s.mode[0].toUpperCase() + s.mode.substring(1);
+  /// Calendar event title for a transport segment.
+  ///
+  /// This MUST stay byte-identical to the Go `.ics` export
+  /// (calendar_handler.go `segmentEventFieldsIn`): the traveler picks between
+  /// a Google Calendar link built here and an `.ics` file built there for the
+  /// SAME event, so any divergence shows up as two differently-named entries.
+  /// That is why the empty-route case falls back to the mode label rather than
+  /// returning the mode alone, matching Go's `segmentRouteIn`.
+  static String _segmentCalendarTitle(AppLocalizations l10n, TripSegment s) {
+    final mode = _calendarModeLabel(l10n, s.mode);
     final route =
         [s.origin, s.destination].whereType<String>().join(' → ');
-    return route.isEmpty ? mode : '$mode: $route';
+    return l10n.calendarSegmentTitle(mode, route.isEmpty ? mode : route);
   }
+
+  /// Mirrors Go's `localizedMode`: known modes translate, anything else keeps
+  /// its raw value capitalized.
+  static String _calendarModeLabel(AppLocalizations l10n, String mode) =>
+      switch (mode.trim().toLowerCase()) {
+        'flight' => l10n.calendarModeFlight,
+        'train' => l10n.calendarModeTrain,
+        'bus' => l10n.calendarModeBus,
+        'car' => l10n.calendarModeCar,
+        'ferry' => l10n.calendarModeFerry,
+        'other' => l10n.calendarModeOther,
+        '' => '',
+        _ => mode[0].toUpperCase() + mode.substring(1),
+      };
 
   static IconData _modeIcon(String mode) => switch (mode) {
         'flight' => Icons.flight_takeoff,
@@ -329,7 +349,7 @@ class BookingsSection extends StatelessWidget {
                                 kind: 'stay',
                                 eventId: a.id,
                                 analyticsKind: 'stay',
-                                title: 'Stay: ${a.name}',
+                                title: l10n.calendarStayTitle(a.name),
                                 start: range.start,
                                 endExclusive: range.endExclusive,
                                 location: a.address,
@@ -429,7 +449,7 @@ class BookingsSection extends StatelessWidget {
                                 kind: 'segment',
                                 eventId: s.id,
                                 analyticsKind: 'transport',
-                                title: _segmentCalendarTitle(s),
+                                title: _segmentCalendarTitle(l10n, s),
                                 start: range.start,
                                 endExclusive: range.endExclusive,
                                 details: s.notes,

--- a/src/packages/flutter-app/test/calendar_title_parity_test.dart
+++ b/src/packages/flutter-app/test/calendar_title_parity_test.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:travel_route_planner/l10n/l10n.dart';
+
+/// Calendar event titles are a CROSS-LANGUAGE CONTRACT.
+///
+/// The traveler chooses between a Google Calendar link built by the Flutter
+/// client and an `.ics` file built by the Go API — for the same event. If the
+/// two disagree, the same trip shows up under two different names depending on
+/// which button was pressed.
+///
+/// These expectations are duplicated in the Go suite
+/// (api/calendar_event_test.go). Pinning both sides to the same literals means
+/// a drift on either side fails a test rather than shipping silently.
+void main() {
+  Future<AppLocalizations> load(String code) =>
+      AppLocalizations.delegate.load(Locale(code));
+
+  test('stay titles match the Go .ics export (ics.stayTitle)', () async {
+    final en = await load('en');
+    final es = await load('es');
+    expect(en.calendarStayTitle('Hotel Grande Bretagne'),
+        'Stay: Hotel Grande Bretagne');
+    expect(es.calendarStayTitle('Hotel Grande Bretagne'),
+        'Alojamiento: Hotel Grande Bretagne');
+  });
+
+  test('segment titles match the Go .ics export (ics.segmentTitle)', () async {
+    final en = await load('en');
+    final es = await load('es');
+    expect(en.calendarSegmentTitle('Flight', 'JFK → ATH'), 'Flight: JFK → ATH');
+    expect(es.calendarSegmentTitle('Vuelo', 'JFK → ATH'), 'Vuelo: JFK → ATH');
+  });
+
+  test('mode labels match the Go .ics export (ics.mode.*)', () async {
+    final en = await load('en');
+    final es = await load('es');
+    expect(
+      [
+        en.calendarModeFlight,
+        en.calendarModeTrain,
+        en.calendarModeBus,
+        en.calendarModeCar,
+        en.calendarModeFerry,
+        en.calendarModeOther,
+      ],
+      ['Flight', 'Train', 'Bus', 'Car', 'Ferry', 'Other'],
+    );
+    expect(
+      [
+        es.calendarModeFlight,
+        es.calendarModeTrain,
+        es.calendarModeBus,
+        es.calendarModeCar,
+        es.calendarModeFerry,
+        es.calendarModeOther,
+      ],
+      ['Vuelo', 'Tren', 'Autobús', 'Coche', 'Ferri', 'Otro'],
+    );
+  });
+
+  // The app had shipped both "ferri" (lowercase, inline) and "Ferry"
+  // (capitalized, standalone) as the Spanish for the same mode. They should be
+  // the same word in either casing.
+  test('the Spanish ferry term is consistent across mode label sets', () async {
+    final es = await load('es');
+    expect(es.bookingsModeFerry.toLowerCase(), 'ferri');
+    expect(es.tripModeFerry.toLowerCase(), 'ferri');
+    expect(es.calendarModeFerry.toLowerCase(), 'ferri');
+  });
+}


### PR DESCRIPTION
Sixth PR of `specs/i18n-spanish`. **131 catalog keys** covering the text the API itself renders — verification/reset/invite/reminder/nudge/alert emails and the inline verify pages, trip-health findings, the print packet, share preview and `.ics` exports, and the notification fallback. **Ships dark**: `es` is still absent from the Flutter `kSupportedLocales`.

## The load-bearing change

The AI response-language instruction is **deliberately additive**: appended to the *end* of the assembled system prompt, and only when the locale is non-English. So an English request's prompt is byte-for-byte what it was before this feature existed.

- `TestSystemPromptEnglishUnchanged` asserts that for English, no-header, *and* unsupported-locale requests.
- `TestSystemPromptSpanishAddsLanguageInstruction` asserts the Spanish prompt is exactly the English prompt **plus a suffix** — proving the cached prefix never moved.

`plan_tool_registry.go` is untouched. It's part of the prompt-cache prefix, and I deliberately did **not** add a `language` field to `save_preferences` — the agent must not be able to overwrite the traveler's language choice. The instruction also pins structured tool arguments (YYYY-MM-DD, IATA codes, enum values) to their canonical formats, since the schemas and DB expect those regardless of prose language.

## Gap closed

A Spanish user's **signup verification email would still have been English** — `users.locale` is NULL at account creation and the client hasn't synced yet. `CreateUser` now persists the negotiated locale across all three signup paths (email, Google, Apple). Background jobs read `users.locale` by widening queries they already run, with no extra round trips.

## Calendar titles: a cross-language contract

This is why PR 4 deliberately left the client side English. The traveler picks between a Google Calendar link built in Flutter and an `.ics` built in Go **for the same event** — divergence means one trip showing up under two names depending on which button was pressed. Both sides flip here, pinned from both ends by `calendar_event_test.go` and a new `calendar_title_parity_test.dart`. That also surfaced and fixed a pre-existing inconsistency: the Spanish ferry term shipped as both "ferri" and "Ferry" across three mode label sets, now unified.

## Also

- **Providers take the request locale**: Google Places (3 call sites), Ticketmaster (`locale=es,*` — the wildcard makes a thin Spanish catalog degrade rather than return nothing), and weather geocoding, which had `language=en` hardcoded.
- `localizedWeekday` moved to `i18n.go` beside `localizedDate` — `time.Weekday.String()` is hardcoded English for the same reason `time.Format` is.
- The per-event `.ics` is localized too. An agent had left English shims to keep an unowned file compiling; threading the locale through let them go.

## Deliberately left English

**Email dates stay ISO** (`2026-09-01`). Localizing them would change the *English* body, which the character-identical rule forbids, and ISO is unambiguous in both languages — a copy change, not an extraction change. Also `FindingFix.PackingItem` values, which are written to the packing list as data (localizing belongs to that write path, not the review engine).

## Testing

Full Go suite passes (including the catalog-completeness gate across all 131 keys) and **402 Flutter tests**. `make api-vet`, `flutter analyze` and l10n coverage are clean.

## Next

PR 7: add `es` to `kSupportedLocales`, the settings picker, and a full Spanish walkthrough.

🤖 Generated with [Claude Code](https://claude.com/claude-code)