### PR TITLE
feat: timed itinerary events and booking detail in the calendar export

### DIFF
--- a/specs/calendar-export-timed-events/plan.md
+++ b/specs/calendar-export-timed-events/plan.md
@@ -1,0 +1,85 @@
+# Plan: Calendar Export — Timed Items & Booking Detail
+
+> **HOW.** Translates `spec.md` into a file-level technical approach.
+
+## Technical Approach
+
+Two surfaces render calendar events and they must agree: the Go `.ics` builders
+(whole-trip and per-event) and the **client-built Google Calendar link** in Dart.
+Both were widened together.
+
+Key decisions:
+
+- **One `icsEvent` struct** returned by the three shared resolvers
+  (`stayEventFieldsIn`, `segmentEventFieldsIn`, `itemEventFieldsIn` in
+  `calendar_handler.go`), consumed by both `buildICS` and `buildSingleEventICS`.
+  The UID prefixes moved *into* the resolvers so the dedupe scheme — which lets
+  a single-event add collapse into a later whole-trip import — has exactly one
+  definition.
+- **Floating date-times** for timed items (`20260803T090000`, no `Z`, no
+  `TZID`). A zone would shift the event when the traveler lands; floating is the
+  correct semantic for a trip itinerary. The Dart side must match exactly, which
+  is why `googleCalendarUrl` emits the same digits with no `Z`.
+- **Windows are derived, not stored**: `itemTimeWindow` maps the validated
+  `time_of_day` enum onto 09–12 / 13–17 / 19–22, mirrored by `_itemTimeWindow`
+  in `calendar_links.dart`. No schema change. Unknown/empty ⇒ all-day.
+- **`URL` is a URI value, not TEXT** (RFC 5545 §3.8.4.6) — emitted unescaped so
+  query strings survive, while the same string inside `DESCRIPTION` is escaped.
+- **`X-WR-CALNAME` on the whole-trip file only**; on a single-event file some
+  clients offer to create a whole calendar named after that one event.
+  `X-WR-TIMEZONE` is deliberately absent — it would pin the floating times.
+
+## Go API Changes
+
+`src/packages/api/`:
+
+- `calendar_handler.go` — `icsEvent`, `icsDateTimeLayout`, `icsNow` (DTSTAMP
+  test seam), builder `event(stamp, icsEvent)` with the DATE/DATE-TIME branch
+  and the `URL` line, the three resolvers, `itemTimeWindow`,
+  `icsStayDescription` / `icsSegmentDescription` / `icsDetailParts` /
+  `icsBookedLabel`, `X-WR-CALNAME`.
+- `calendar_event_handler.go` — `buildSingleEventICS` collapses its four-variable
+  switch to one `icsEvent`; no local UID assembly.
+- `i18n.go` — new `ics.booked` key (en/es).
+- Reused as-is: `displayURL` (`print_view_handler.go`), `tr`, `localizedMode`,
+  `localizedTimeOfDay`, `segmentRouteIn`.
+
+## Flutter Changes
+
+`src/packages/flutter-app/lib/`:
+
+- `utils/calendar_links.dart` — range resolvers now return `allDay`;
+  `itemCalendarRange` takes `timeOfDay`; `googleCalendarUrl` takes `allDay`;
+  new localized `stayCalendarDetails` / `segmentCalendarDetails` /
+  `itemCalendarDetails` (the last moved out of `trip_detail_screen.dart`) and a
+  `displayUrl` mirror of the Go helper.
+- `widgets/add_to_calendar_button.dart` — new `allDay` field forwarded to the
+  Google link.
+- `widgets/bookings_section.dart`, `screens/trip_detail_screen.dart` — pass
+  `allDay`, `timeOfDay`, and the richer detail builders.
+
+**Wall-clock carriers:** the Dart `DateTime`s stay UTC-constructed so day
+arithmetic is DST-exact, but they are never instants — no `.toLocal()`/`.toUtc()`
+anywhere, because the digits are emitted without a zone. A DST test guards this.
+
+## Contract Parity
+
+N/A for JSON. The cross-language contract here is the *event content*: titles,
+detail strings, and time windows are asserted with matching expectations in
+`calendar_test.go` / `calendar_event_test.go` (Go) and `calendar_links_test.dart`
+(Dart), so drift fails a test on one side.
+
+## Cross-cutting
+
+- **Env vars:** none new.
+- **i18n:** `ics.booked` added to both locales; the catalog completeness test
+  enforces coverage.
+
+## Verification
+
+- `make api-fmt && make api-vet`; `go test ./...`, and with `TEST_DATABASE_URL`
+  for the export integration tests (incl. the updated timed assertions).
+- `make flutter-analyze && make flutter-test`.
+- Manual: open a trip, add an item to Google and to Apple Calendar from the same
+  row, confirm identical times; import the whole-trip `.ics` and confirm the
+  calendar name, item time slots, and stay booking detail.

--- a/specs/calendar-export-timed-events/spec.md
+++ b/specs/calendar-export-timed-events/spec.md
@@ -1,0 +1,91 @@
+# Spec: Calendar Export — Timed Items & Booking Detail
+
+> **WHAT & WHY only.** No tech choices, file names, libraries, or code. If a
+> sentence names a file or a package, it belongs in `plan.md`, not here.
+
+## Context
+
+The calendar export lagged behind the rest of the product. Every event was
+all-day, so a day with four activities imported as four identical banners
+stacked at the top of the day — useless as a schedule. Stays and transport
+carried no provider, price, booked status, or booking link, so the calendar was
+strictly less useful than both the app and the printed packet. This feature
+turns itinerary items into real time-slotted events and brings booking detail
+onto every calendar entry.
+
+## User Stories
+
+- As a **traveler**, I want my activities to occupy time slots in my calendar so
+  that a day reads as a schedule instead of a pile of all-day banners.
+- As a **traveler at a check-in desk**, I want the calendar entry for my stay or
+  flight to show the provider, price note, booked status, and booking link so
+  that I don't have to open the app.
+- As a **traveler importing a whole trip**, I want the import to be labeled with
+  my trip's name so it's identifiable among my other calendars.
+
+## Acceptance Criteria
+
+- [ ] An itinerary item tagged morning appears 09:00–12:00, afternoon
+      13:00–17:00, and evening 19:00–22:00 on its trip day.
+- [ ] Item times are floating: the event shows at those wall-clock hours in
+      whatever timezone the traveler's device is set to, with no shifting.
+- [ ] An item with no time-of-day remains an all-day event.
+- [ ] Stays and transport remain all-day events (no clock data exists for them).
+- [ ] A stay's calendar entry shows provider, price note, "Booked" when booked,
+      and a readable short form of the booking link; the full link is attached
+      as the event's URL.
+- [ ] A transport entry shows the same, plus the traveler's own notes.
+- [ ] An event with none of those fields shows no empty description or link.
+- [ ] Importing the whole trip produces a calendar labeled with the trip title.
+- [ ] Adding a single event and then importing the whole trip does not create a
+      duplicate of that event.
+- [ ] The Google Calendar button and the Apple (.ics) button on the same row
+      produce the same event — same times, same title, same details.
+- [ ] All text follows the traveler's language, matching the rest of the app.
+
+## API Surface
+
+No new endpoints; the two existing calendar downloads change their content only.
+
+### `GET /api/v1/export/{token}/calendar.ics` and `.../event/{kind}/{id}.ics`
+- **Purpose:** the trip (or one event) as a calendar file.
+- **Request:** unchanged — signed token, plus the existing language selection.
+- **Response:** calendar file per the rules above.
+- **Errors:** unchanged opaque 404 for a bad/expired token or unknown event.
+
+## Data Model
+
+No new entities and no schema change. Item times are **derived from the existing
+time-of-day bucket** — they are a product-level convention, not traveler-entered
+clock data. Storing real start/end times per item remains the eventual upgrade;
+until then the windows above are the promise.
+
+## UI Behavior
+
+- **Screen / surface:** unchanged — the per-event "Add to calendar" menu on
+  stays, transport, and itinerary items, plus the trip menu's calendar export.
+- **Happy path:** pick Google or Apple; the event lands with its time slot and
+  booking detail.
+- **States:** undated events still hide the affordance entirely.
+
+## Edge Cases & Error States
+
+- Unrecognized or legacy time-of-day values fall back to all-day rather than
+  guessing a window.
+- Booking links containing commas or semicolons must survive intact in the
+  attached link.
+- Long descriptions must remain valid calendar files (line-length limits).
+- Multi-byte characters (accents, emoji) must never be corrupted by that
+  line-length handling.
+
+## Out of Scope
+
+- Real per-item start/end time columns and any UI for editing them.
+- Timed stays (check-in time) or transport (departure time).
+- Booking todos and the packing checklist — deliberately not in the calendar.
+- Changes to how the export is triggered, tokenized, or shared.
+
+## Open Questions
+
+None — the windows and the todo/checklist exclusion were decided with the owner
+before implementation.

--- a/specs/calendar-export-timed-events/tasks.md
+++ b/specs/calendar-export-timed-events/tasks.md
@@ -1,0 +1,40 @@
+# Tasks: Calendar Export — Timed Items & Booking Detail
+
+> Dependency-ordered. `[P]` = can run in parallel with its siblings.
+
+## API (Go)
+
+- [x] `icsEvent` struct + `icsDateTimeLayout` + `icsNow` seam
+- [x] Builder `event(stamp, icsEvent)`: DATE vs floating DATE-TIME, `URL` line
+      emitted unescaped (URI value type)
+- [x] Resolvers return `(icsEvent, bool)` carrying UID/AllDay/URL/Description
+- [x] `itemTimeWindow` (09–12 / 13–17 / 19–22; unknown ⇒ all-day)
+- [x] `icsStayDescription` / `icsSegmentDescription` reusing `displayURL`
+- [x] `X-WR-CALNAME` on the whole-trip calendar only
+- [x] `ics.booked` catalog key (en/es)
+- [x] `buildSingleEventICS` consumes the shared `icsEvent`
+
+## UI (Flutter)
+
+- [x] `calendar_links.dart`: `allDay` on all range resolvers, `timeOfDay` on
+      `itemCalendarRange`, `allDay` on `googleCalendarUrl` (no `Z`)
+- [x] Localized detail builders + `displayUrl` mirror
+- [x] `AddToCalendarButton.allDay`; wire bookings rows and the item menu
+
+## Tests
+
+- [x] [P] Go `calendar_test.go`: time windows, descriptions, timed-vs-all-day,
+      URL-not-escaped, **first real `foldICSLine` tests** (300-char ASCII,
+      2-byte and 4-byte runes), pinned-DTSTAMP whole document
+- [x] [P] Go `calendar_event_test.go`: timed item, all-day fallback, stay and
+      segment booking detail, bare event emits neither DESCRIPTION nor URL
+- [x] `export_integration_test.go`: timed item assertions + `X-WR-CALNAME`
+- [x] Dart `calendar_links_test.dart`: floating timed link, per-bucket hours,
+      all-day fallbacks, **DST guard**, detail builders, `displayUrl`
+
+## Verification
+
+- [x] `gofmt`/`go vet` clean; full Go suite green with `TEST_DATABASE_URL`
+- [x] `flutter analyze` clean (no new issues); 416 Flutter tests green
+- [ ] Manual end-to-end via gateway: same-row Google vs Apple parity, whole-trip
+      import shows calendar name + time slots + booking detail

--- a/src/packages/api/calendar_event_handler.go
+++ b/src/packages/api/calendar_event_handler.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"net/http"
-	"time"
 
 	"github.com/google/uuid"
 	"github.com/gorilla/mux"
@@ -48,32 +47,28 @@ func calendarEventHandler(w http.ResponseWriter, r *http.Request) {
 // renders a one-VEVENT VCALENDAR. ok=false for an unknown kind, a missing id,
 // or an undated event — callers answer one opaque 404 for all of them.
 func buildSingleEventICS(locale string, d exportData, kind string, id uuid.UUID) (body, filename string, ok bool) {
-	var (
-		uid, summary, location, description string
-		start, end                          time.Time
-	)
+	// The UID comes from the resolver, so the dedupe scheme has exactly one
+	// definition shared with the whole-trip export.
+	var ev icsEvent
 	switch kind {
 	case "stay":
 		for _, a := range d.Accommodations {
 			if a.ID == id {
-				start, end, summary, location, ok = stayEventFieldsIn(locale, a)
-				uid = "acc-" + a.ID.String()
+				ev, ok = stayEventFieldsIn(locale, a)
 				break
 			}
 		}
 	case "segment":
 		for _, s := range d.Segments {
 			if s.ID == id {
-				start, end, summary, description, ok = segmentEventFieldsIn(locale, s)
-				uid = "seg-" + s.ID.String()
+				ev, ok = segmentEventFieldsIn(locale, s)
 				break
 			}
 		}
 	case "item":
 		for _, it := range d.Items {
 			if it.ID == id {
-				start, end, summary, location, description, ok = itemEventFieldsIn(locale, d.Trip, it)
-				uid = "item-" + it.ID.String()
+				ev, ok = itemEventFieldsIn(locale, d.Trip, it)
 				break
 			}
 		}
@@ -88,8 +83,10 @@ func buildSingleEventICS(locale string, d exportData, kind string, id uuid.UUID)
 	b.line("PRODID:-//Golden Tempo Travel//Trip Export//EN")
 	b.line("CALSCALE:GREGORIAN")
 	b.line("METHOD:PUBLISH")
-	stamp := time.Now().UTC().Format("20060102T150405Z")
-	b.event(stamp, uid, start, end, summary, location, description)
+	// No X-WR-CALNAME here: on a single-event file some clients offer to create
+	// a whole new calendar named after that one event.
+	stamp := icsNow().UTC().Format("20060102T150405Z")
+	b.event(stamp, ev)
 	b.line("END:VCALENDAR")
-	return b.String(), tripSlug(summary), true
+	return b.String(), tripSlug(ev.Summary), true
 }

--- a/src/packages/api/calendar_event_test.go
+++ b/src/packages/api/calendar_event_test.go
@@ -130,14 +130,95 @@ func TestBuildSingleEventICS_Item(t *testing.T) {
 	}
 	for _, want := range []string{
 		"UID:item-" + d.Items[0].ID.String() + "@goldentempo",
-		"DTSTART;VALUE=DATE:20260803", // trip start + (day 3 − 1)
-		"DTEND;VALUE=DATE:20260804",
+		// Timed: trip start + (day 3 − 1), morning window 09:00–12:00.
+		"DTSTART:20260803T090000",
+		"DTEND:20260803T120000",
 		`SUMMARY:Acropolis\, ruins`, // RFC 5545 comma escaping
 		"DESCRIPTION:Morning · Recommended by Maria",
 	} {
 		if !strings.Contains(body, want) {
 			t.Fatalf("missing %q in:\n%s", want, body)
 		}
+	}
+	// Timed items must be FLOATING: a Z suffix or a TZID would pin them to one
+	// zone and shift the event when the traveler lands.
+	if strings.Contains(body, "20260803T090000Z") || strings.Contains(body, "TZID=") {
+		t.Fatalf("item time must be floating, got:\n%s", body)
+	}
+	if strings.Contains(body, "VALUE=DATE") {
+		t.Fatalf("timed item must not emit a DATE value:\n%s", body)
+	}
+}
+
+func TestBuildSingleEventICS_ItemWithoutTimeOfDayIsAllDay(t *testing.T) {
+	d := singleEventFixture(t)
+	d.Items[0].TimeOfDay = nil
+	body, _, ok := buildSingleEventICS("en", d, "item", d.Items[0].ID)
+	if !ok {
+		t.Fatal("item without time_of_day should still render")
+	}
+	for _, want := range []string{
+		"DTSTART;VALUE=DATE:20260803",
+		"DTEND;VALUE=DATE:20260804",
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("missing %q in:\n%s", want, body)
+		}
+	}
+}
+
+func TestBuildSingleEventICS_StayCarriesBookingDetails(t *testing.T) {
+	d := singleEventFixture(t)
+	a := &d.Accommodations[0]
+	a.Provider = strp("Booking.com")
+	a.PriceNote = strp("€180/night")
+	a.Url = strp("https://www.booking.com/hotel/gr/grande.html?aid=42,7")
+	a.Booked = true
+
+	body, _, ok := buildSingleEventICS("en", d, "stay", a.ID)
+	if !ok {
+		t.Fatal("stay should render")
+	}
+	// Description carries the readable link; the raw href rides URL. Unfold
+	// first — these values are long enough to trigger RFC 5545 folding.
+	if want := "DESCRIPTION:Booking.com · €180/night · Booked · booking.com/hotel/gr/grande.html"; !strings.Contains(unfoldICS(body), want) {
+		t.Fatalf("missing %q in:\n%s", want, body)
+	}
+	// URL is a URI value: the comma in the query string must NOT be escaped,
+	// while the same comma inside DESCRIPTION text would be.
+	if want := "URL:https://www.booking.com/hotel/gr/grande.html?aid=42,7"; !strings.Contains(unfoldICS(body), want) {
+		t.Fatalf("missing unescaped %q in:\n%s", want, body)
+	}
+}
+
+func TestBuildSingleEventICS_SegmentCarriesBookingDetails(t *testing.T) {
+	d := singleEventFixture(t)
+	s := &d.Segments[0]
+	s.Provider = strp("Delta")
+	s.PriceNote = strp("$780")
+	s.Notes = strp("Departs 6:30 PM")
+	s.Url = strp("https://www.delta.com/booking/xyz")
+	s.Booked = true
+
+	body, _, ok := buildSingleEventICS("en", d, "segment", s.ID)
+	if !ok {
+		t.Fatal("segment should render")
+	}
+	if want := "DESCRIPTION:Delta · $780 · Booked · Departs 6:30 PM · delta.com/booking/xyz"; !strings.Contains(unfoldICS(body), want) {
+		t.Fatalf("missing %q in:\n%s", want, body)
+	}
+}
+
+func TestBuildSingleEventICS_NoBookingDetailsOmitsLines(t *testing.T) {
+	// The bare fixture has no provider/price/url and is unbooked: no
+	// DESCRIPTION and no URL line at all, rather than empty ones.
+	d := singleEventFixture(t)
+	body, _, ok := buildSingleEventICS("en", d, "stay", d.Accommodations[0].ID)
+	if !ok {
+		t.Fatal("stay should render")
+	}
+	if strings.Contains(body, "DESCRIPTION:") || strings.Contains(body, "URL:") {
+		t.Fatalf("bare stay should emit neither DESCRIPTION nor URL:\n%s", body)
 	}
 }
 

--- a/src/packages/api/calendar_handler.go
+++ b/src/packages/api/calendar_handler.go
@@ -12,11 +12,38 @@ import (
 
 // calendar_handler.go — GET /api/v1/export/{token}/calendar.ics, the trip as an
 // RFC 5545 iCalendar file. Token-gated and PUBLIC (the signed token is the
-// capability). Everything is an all-day VEVENT so it drops cleanly onto a
-// calendar's day grid. Zero external deps — the string is built by hand with
-// careful TEXT escaping and line folding.
+// capability). Stays and transport are all-day VEVENTs (the data model has no
+// clock times for them); itinerary items become timed events derived from their
+// time_of_day bucket (specs/calendar-export-timed-events). Zero external deps —
+// the string is built by hand with careful TEXT escaping and line folding.
 
-const icsDateLayout = "20060102"
+const (
+	icsDateLayout = "20060102"
+	// icsDateTimeLayout is a FLOATING local date-time: no trailing Z and no
+	// TZID, so the event renders at the same wall clock in whatever timezone
+	// the traveler's device is in. That is the right semantic for a trip — 9am
+	// in Athens should stay 9am when you land.
+	icsDateTimeLayout = "20060102T150405"
+)
+
+// icsEvent is one resolved VEVENT, shared by the whole-trip calendar and the
+// per-event endpoint (calendar_event_handler.go) so both render identically.
+type icsEvent struct {
+	// UID is the pre-suffix identity ("item-<uuid>"); the builder appends
+	// "@goldentempo". The scheme is byte-stable BY CONTRACT: adding a single
+	// event after a whole-trip import dedupes on it. Never change a prefix.
+	UID string
+
+	// Start/End are exclusive-end. All-day events format as DATE values;
+	// timed events as floating DATE-TIMEs (see icsDateTimeLayout).
+	Start, End time.Time
+	AllDay     bool
+
+	Summary     string
+	Location    string
+	Description string
+	URL         string
+}
 
 // calendarHandler streams the trip's .ics attachment.
 func calendarHandler(w http.ResponseWriter, r *http.Request) {
@@ -48,34 +75,37 @@ func buildICS(locale string, d exportData) string {
 	b.line("CALSCALE:GREGORIAN")
 	b.line("METHOD:PUBLISH")
 
-	stamp := time.Now().UTC().Format("20060102T150405Z")
+	// X-WR-CALNAME labels the import in Google/Apple Calendar ("Greek Islands"
+	// instead of an unnamed pile of events). Non-standard but widely honored.
+	// Deliberately NOT set on the single-event file (some clients offer to
+	// create a whole calendar named after that one event), and X-WR-TIMEZONE is
+	// deliberately absent — it would pin the floating item times to one zone.
+	if name := strings.TrimSpace(d.Trip.Title); name != "" {
+		b.line("X-WR-CALNAME:" + escapeICSText(name))
+	}
+
+	stamp := icsNow().UTC().Format("20060102T150405Z")
 	events := 0
 
 	for _, it := range d.Items {
-		start, end, summary, location, description, ok := itemEventFieldsIn(locale, d.Trip, it)
-		if !ok {
-			continue // no trip start_date or no day → not datable
+		if ev, ok := itemEventFieldsIn(locale, d.Trip, it); ok {
+			b.event(stamp, ev) // no trip start_date or no day → not datable
+			events++
 		}
-		b.event(stamp, "item-"+it.ID.String(), start, end, summary, location, description)
-		events++
 	}
 
 	for _, a := range d.Accommodations {
-		start, end, summary, location, ok := stayEventFieldsIn(locale, a)
-		if !ok {
-			continue
+		if ev, ok := stayEventFieldsIn(locale, a); ok {
+			b.event(stamp, ev)
+			events++
 		}
-		b.event(stamp, "acc-"+a.ID.String(), start, end, summary, location, "")
-		events++
 	}
 
 	for _, s := range d.Segments {
-		start, end, summary, description, ok := segmentEventFieldsIn(locale, s)
-		if !ok {
-			continue
+		if ev, ok := segmentEventFieldsIn(locale, s); ok {
+			b.event(stamp, ev)
+			events++
 		}
-		b.event(stamp, "seg-"+s.ID.String(), start, end, summary, "", description)
-		events++
 	}
 
 	// Fallback: a datable-but-empty export still yields one trip-span event.
@@ -84,8 +114,13 @@ func buildICS(locale string, d exportData) string {
 		if d.Trip.EndDate.Valid && d.Trip.EndDate.Time.After(d.Trip.StartDate.Time) {
 			end = d.Trip.EndDate.Time.AddDate(0, 0, 1)
 		}
-		b.event(stamp, "trip-"+d.Trip.ID.String(), d.Trip.StartDate.Time, end,
-			d.Trip.Title, "", "")
+		b.event(stamp, icsEvent{
+			UID:     "trip-" + d.Trip.ID.String(),
+			Start:   d.Trip.StartDate.Time,
+			End:     end,
+			AllDay:  true,
+			Summary: d.Trip.Title,
+		})
 	}
 
 	b.line("END:VCALENDAR")
@@ -94,53 +129,148 @@ func buildICS(locale string, d exportData) string {
 
 // The three per-kind field resolvers below are shared by the whole-trip
 // calendar and the single-event endpoint (calendar_event_handler.go) so both
-// render identical all-day VEVENTs. All ends are exclusive; ok=false means the
-// event is undated and gets no VEVENT.
+// render identical VEVENTs. All ends are exclusive; ok=false means the event is
+// undated and gets no VEVENT.
 
-// The three unsuffixed forms below are English-locale shims kept so
-// calendar_event_handler.go (the per-event .ics) compiles unchanged; it does
-// not thread a request locale yet. Follow-up: pass requestLocale there and
-// delete these.
-
-// stayEventFieldsIn resolves an accommodation's VEVENT fields: check-in through
-// check-out (or one night when check-out is missing/not after check-in). The
-// SUMMARY is mirrored byte-for-byte by the Flutter client's Google Calendar
-// link (bookings_section.dart) — change both together.
-func stayEventFieldsIn(locale string, a store.Accommodation) (start, end time.Time, summary, location string, ok bool) {
+// stayEventFieldsIn resolves an accommodation's VEVENT: check-in through
+// check-out (or one night when check-out is missing/not after check-in),
+// all-day. The SUMMARY is mirrored byte-for-byte by the Flutter client's Google
+// Calendar link (bookings_section.dart) — change both together.
+func stayEventFieldsIn(locale string, a store.Accommodation) (icsEvent, bool) {
 	if !a.CheckIn.Valid {
-		return time.Time{}, time.Time{}, "", "", false
+		return icsEvent{}, false
 	}
-	end = a.CheckIn.Time.AddDate(0, 0, 1)
+	end := a.CheckIn.Time.AddDate(0, 0, 1)
 	if a.CheckOut.Valid && a.CheckOut.Time.After(a.CheckIn.Time) {
 		end = a.CheckOut.Time
 	}
-	return a.CheckIn.Time, end, tr(locale, "ics.stayTitle", a.Name), strPtrVal(a.Address), true
+	return icsEvent{
+		UID:         "acc-" + a.ID.String(),
+		Start:       a.CheckIn.Time,
+		End:         end,
+		AllDay:      true,
+		Summary:     tr(locale, "ics.stayTitle", a.Name),
+		Location:    strPtrVal(a.Address),
+		Description: icsStayDescription(locale, a),
+		URL:         strings.TrimSpace(strPtrVal(a.Url)),
+	}, true
 }
 
-// segmentEventFieldsIn resolves a transport segment's VEVENT fields: departure
-// day through arrival day inclusive (single day when arrival is missing). The
-// SUMMARY is mirrored by the Flutter client — see stayEventFieldsIn.
-func segmentEventFieldsIn(locale string, s store.TripSegment) (start, end time.Time, summary, description string, ok bool) {
+// segmentEventFieldsIn resolves a transport segment's VEVENT: departure day
+// through arrival day inclusive (single day when arrival is missing), all-day —
+// the model carries dates only, no clock times. The SUMMARY is mirrored by the
+// Flutter client — see stayEventFieldsIn.
+func segmentEventFieldsIn(locale string, s store.TripSegment) (icsEvent, bool) {
 	if !s.DepartDate.Valid {
-		return time.Time{}, time.Time{}, "", "", false
+		return icsEvent{}, false
 	}
-	end = s.DepartDate.Time.AddDate(0, 0, 1)
+	end := s.DepartDate.Time.AddDate(0, 0, 1)
 	if s.ArriveDate.Valid && s.ArriveDate.Time.After(s.DepartDate.Time) {
 		end = s.ArriveDate.Time.AddDate(0, 0, 1)
 	}
-	summary = tr(locale, "ics.segmentTitle", localizedMode(locale, s.Mode), segmentRouteIn(locale, s))
-	return s.DepartDate.Time, end, summary, strPtrVal(s.Notes), true
+	return icsEvent{
+		UID:         "seg-" + s.ID.String(),
+		Start:       s.DepartDate.Time,
+		End:         end,
+		AllDay:      true,
+		Summary:     tr(locale, "ics.segmentTitle", localizedMode(locale, s.Mode), segmentRouteIn(locale, s)),
+		Description: icsSegmentDescription(locale, s),
+		URL:         strings.TrimSpace(strPtrVal(s.Url)),
+	}, true
 }
 
-// itemEventFieldsIn resolves an itinerary item's VEVENT fields: the single trip
-// day the item is assigned to. The SUMMARY is the item's own name — traveler
-// data, never translated.
-func itemEventFieldsIn(locale string, trip store.Trip, it store.ItineraryItem) (start, end time.Time, summary, location, description string, ok bool) {
-	start, ok = itemStartDate(trip, it)
+// itemEventFieldsIn resolves an itinerary item's VEVENT on the single trip day
+// it is assigned to: a timed event when time_of_day gives a window, otherwise
+// all-day. The SUMMARY is the item's own name — traveler data, never translated.
+func itemEventFieldsIn(locale string, trip store.Trip, it store.ItineraryItem) (icsEvent, bool) {
+	day, ok := itemStartDate(trip, it)
 	if !ok {
-		return time.Time{}, time.Time{}, "", "", "", false
+		return icsEvent{}, false
 	}
-	return start, start.AddDate(0, 0, 1), it.Name, strPtrVal(it.Address), icsItemDescription(locale, it), true
+	ev := icsEvent{
+		UID:         "item-" + it.ID.String(),
+		Summary:     it.Name,
+		Location:    strPtrVal(it.Address),
+		Description: icsItemDescription(locale, it),
+	}
+	if start, end, timed := itemTimeWindow(day, strPtrVal(it.TimeOfDay)); timed {
+		ev.Start, ev.End, ev.AllDay = start, end, false
+	} else {
+		ev.Start, ev.End, ev.AllDay = day, day.AddDate(0, 0, 1), true
+	}
+	return ev, true
+}
+
+// itemTimeWindow maps a time_of_day bucket onto clock times on the item's day:
+// morning 09:00–12:00, afternoon 13:00–17:00, evening 19:00–22:00. ok=false for
+// an empty or unrecognized bucket, which keeps the item all-day.
+//
+// These windows are a product-level GUESS, not traveler data — the model stores
+// only the bucket. Real start_time/end_time columns are the eventual upgrade;
+// mirrored in Dart by _itemTimeWindow (calendar_links.dart), change both
+// together. The returned times use time.UTC purely as a container: they are
+// formatted with icsDateTimeLayout, which emits no zone, so they are floating.
+// Building them from day.Date() components (never Add) keeps DST out of it.
+func itemTimeWindow(day time.Time, timeOfDay string) (start, end time.Time, ok bool) {
+	var startHour, endHour int
+	switch strings.ToLower(strings.TrimSpace(timeOfDay)) {
+	case "morning":
+		startHour, endHour = 9, 12
+	case "afternoon":
+		startHour, endHour = 13, 17
+	case "evening":
+		startHour, endHour = 19, 22
+	default:
+		return time.Time{}, time.Time{}, false
+	}
+	y, m, d := day.Date()
+	return time.Date(y, m, d, startHour, 0, 0, 0, time.UTC),
+		time.Date(y, m, d, endHour, 0, 0, 0, time.UTC), true
+}
+
+// icsStayDescription mirrors the print packet's stay meta line (toPrintStay):
+// provider, price note, booked flag, and the readable form of the booking link
+// — the raw href rides the URL property instead.
+func icsStayDescription(locale string, a store.Accommodation) string {
+	parts := icsDetailParts(
+		strPtrVal(a.Provider),
+		strPtrVal(a.PriceNote),
+		icsBookedLabel(locale, a.Booked),
+		displayURL(strPtrVal(a.Url)),
+	)
+	return strings.Join(parts, " · ")
+}
+
+// icsSegmentDescription mirrors toPrintSegment: provider, price note, booked
+// flag, the traveler's own notes, then the readable link.
+func icsSegmentDescription(locale string, s store.TripSegment) string {
+	parts := icsDetailParts(
+		strPtrVal(s.Provider),
+		strPtrVal(s.PriceNote),
+		icsBookedLabel(locale, s.Booked),
+		strPtrVal(s.Notes),
+		displayURL(strPtrVal(s.Url)),
+	)
+	return strings.Join(parts, " · ")
+}
+
+// icsDetailParts trims and drops empties so a missing field never leaves a
+// dangling " ·  · " in the description.
+func icsDetailParts(vals ...string) []string {
+	parts := make([]string, 0, len(vals))
+	for _, v := range vals {
+		if v = strings.TrimSpace(v); v != "" {
+			parts = append(parts, v)
+		}
+	}
+	return parts
+}
+
+func icsBookedLabel(locale string, booked bool) string {
+	if !booked {
+		return ""
+	}
+	return tr(locale, "ics.booked")
 }
 
 // itemStartDate resolves an item's all-day start: trip.start_date + (day-1).
@@ -165,6 +295,9 @@ func icsItemDescription(locale string, it store.ItineraryItem) string {
 	return strings.Join(parts, " · ")
 }
 
+// icsNow is the DTSTAMP clock, swappable so tests can pin a whole document.
+var icsNow = time.Now
+
 // icsBuilder accumulates CRLF-terminated, RFC-folded content lines.
 type icsBuilder struct {
 	sb strings.Builder
@@ -175,20 +308,31 @@ func (b *icsBuilder) line(s string) {
 	b.sb.WriteString("\r\n")
 }
 
-// event writes one all-day VEVENT. start/end are DATE values (end exclusive).
-// summary/location/description are raw text — escaped here.
-func (b *icsBuilder) event(stamp, uid string, start, end time.Time, summary, location, description string) {
+// event writes one VEVENT — a DATE pair when ev.AllDay, otherwise a floating
+// DATE-TIME pair. Text properties are escaped here; ev's fields are raw.
+func (b *icsBuilder) event(stamp string, ev icsEvent) {
 	b.line("BEGIN:VEVENT")
-	b.line("UID:" + uid + "@goldentempo")
+	b.line("UID:" + ev.UID + "@goldentempo")
 	b.line("DTSTAMP:" + stamp)
-	b.line("DTSTART;VALUE=DATE:" + start.Format(icsDateLayout))
-	b.line("DTEND;VALUE=DATE:" + end.Format(icsDateLayout))
-	b.line("SUMMARY:" + escapeICSText(summary))
-	if strings.TrimSpace(location) != "" {
-		b.line("LOCATION:" + escapeICSText(location))
+	if ev.AllDay {
+		b.line("DTSTART;VALUE=DATE:" + ev.Start.Format(icsDateLayout))
+		b.line("DTEND;VALUE=DATE:" + ev.End.Format(icsDateLayout))
+	} else {
+		b.line("DTSTART:" + ev.Start.Format(icsDateTimeLayout))
+		b.line("DTEND:" + ev.End.Format(icsDateTimeLayout))
 	}
-	if strings.TrimSpace(description) != "" {
-		b.line("DESCRIPTION:" + escapeICSText(description))
+	b.line("SUMMARY:" + escapeICSText(ev.Summary))
+	if strings.TrimSpace(ev.Location) != "" {
+		b.line("LOCATION:" + escapeICSText(ev.Location))
+	}
+	if strings.TrimSpace(ev.Description) != "" {
+		b.line("DESCRIPTION:" + escapeICSText(ev.Description))
+	}
+	if u := strings.TrimSpace(ev.URL); u != "" {
+		// URL is typed URI, not TEXT (RFC 5545 §3.8.4.6) — escaping it would
+		// corrupt commas and semicolons inside query strings. Folding still
+		// applies via line().
+		b.line("URL:" + u)
 	}
 	b.line("END:VEVENT")
 }

--- a/src/packages/api/calendar_test.go
+++ b/src/packages/api/calendar_test.go
@@ -1,0 +1,248 @@
+package main
+
+// calendar_test.go — pure unit tests for the .ics builders (no DB):
+// time-of-day windows, description assembly, timed-vs-all-day formatting, and
+// RFC 5545 line folding. See specs/calendar-export-timed-events.
+
+import (
+	"strings"
+	"testing"
+	"time"
+	"unicode/utf8"
+
+	"github.com/google/uuid"
+
+	"travel-route-planner/store"
+)
+
+// unfoldICS reverses RFC 5545 folding so a test can assert on logical lines.
+func unfoldICS(s string) string { return strings.ReplaceAll(s, "\r\n ", "") }
+
+func TestItemTimeWindow(t *testing.T) {
+	day := time.Date(2026, 8, 3, 0, 0, 0, 0, time.UTC)
+
+	cases := []struct {
+		timeOfDay          string
+		wantOK             bool
+		startHour, endHour int
+	}{
+		{"morning", true, 9, 12},
+		{"afternoon", true, 13, 17},
+		{"evening", true, 19, 22},
+		{"  Morning  ", true, 9, 12}, // normalized like the rest of the codebase
+		{"", false, 0, 0},
+		{"night", false, 0, 0}, // not in the server-validated enum
+	}
+	for _, c := range cases {
+		start, end, ok := itemTimeWindow(day, c.timeOfDay)
+		if ok != c.wantOK {
+			t.Fatalf("%q: ok = %v, want %v", c.timeOfDay, ok, c.wantOK)
+		}
+		if !ok {
+			if !start.IsZero() || !end.IsZero() {
+				t.Fatalf("%q: expected zero times when ok=false", c.timeOfDay)
+			}
+			continue
+		}
+		if start.Hour() != c.startHour || end.Hour() != c.endHour {
+			t.Fatalf("%q: got %d–%d, want %d–%d", c.timeOfDay, start.Hour(), end.Hour(), c.startHour, c.endHour)
+		}
+		if start.Year() != 2026 || start.Month() != time.August || start.Day() != 3 {
+			t.Fatalf("%q: window moved off the item's day: %v", c.timeOfDay, start)
+		}
+	}
+}
+
+func TestICSStayDescription(t *testing.T) {
+	full := store.Accommodation{
+		Provider:  strp("Booking.com"),
+		PriceNote: strp("€180/night"),
+		Url:       strp("https://www.booking.com/hotel/gr/grande.html?aid=42"),
+		Booked:    true,
+	}
+	if got, want := icsStayDescription("en", full),
+		"Booking.com · €180/night · Booked · booking.com/hotel/gr/grande.html"; got != want {
+		t.Fatalf("full stay description = %q, want %q", got, want)
+	}
+
+	// Unbooked drops the label rather than saying "Not booked".
+	unbooked := full
+	unbooked.Booked = false
+	if got := icsStayDescription("en", unbooked); strings.Contains(got, "Booked") {
+		t.Fatalf("unbooked stay should omit the flag, got %q", got)
+	}
+
+	// Missing fields must not leave dangling separators.
+	sparse := store.Accommodation{PriceNote: strp("€180/night")}
+	if got, want := icsStayDescription("en", sparse), "€180/night"; got != want {
+		t.Fatalf("sparse stay description = %q, want %q", got, want)
+	}
+	if got := icsStayDescription("en", store.Accommodation{}); got != "" {
+		t.Fatalf("empty stay description = %q, want empty", got)
+	}
+
+	if got := icsStayDescription("es", full); !strings.Contains(got, "Reservado") {
+		t.Fatalf("es stay description should localize the booked flag, got %q", got)
+	}
+}
+
+func TestICSSegmentDescription(t *testing.T) {
+	full := store.TripSegment{
+		Provider:  strp("Delta"),
+		PriceNote: strp("$780"),
+		Notes:     strp("Departs 6:30 PM"),
+		Url:       strp("https://www.delta.com/booking/xyz"),
+		Booked:    true,
+	}
+	if got, want := icsSegmentDescription("en", full),
+		"Delta · $780 · Booked · Departs 6:30 PM · delta.com/booking/xyz"; got != want {
+		t.Fatalf("full segment description = %q, want %q", got, want)
+	}
+	// Notes alone is the pre-existing behavior and must survive.
+	if got, want := icsSegmentDescription("en", store.TripSegment{Notes: strp("Seat 14A")}), "Seat 14A"; got != want {
+		t.Fatalf("notes-only description = %q, want %q", got, want)
+	}
+	if got := icsSegmentDescription("en", store.TripSegment{}); got != "" {
+		t.Fatalf("empty segment description = %q, want empty", got)
+	}
+}
+
+func TestICSBuilderEventTimedVsAllDay(t *testing.T) {
+	var timed icsBuilder
+	timed.event("20260101T000000Z", icsEvent{
+		UID:     "item-x",
+		Start:   time.Date(2026, 8, 3, 9, 0, 0, 0, time.UTC),
+		End:     time.Date(2026, 8, 3, 12, 0, 0, 0, time.UTC),
+		Summary: "Acropolis",
+	})
+	got := timed.String()
+	if !strings.Contains(got, "DTSTART:20260803T090000\r\n") || !strings.Contains(got, "DTEND:20260803T120000\r\n") {
+		t.Fatalf("timed DTSTART/DTEND wrong:\n%s", got)
+	}
+	// Floating: the DT lines carry no Z and no TZID (DTSTAMP is legitimately
+	// UTC and keeps its Z).
+	if strings.Contains(got, "DTSTART:20260803T090000Z") || strings.Contains(got, "DTEND:20260803T120000Z") ||
+		strings.Contains(got, "TZID=") || strings.Contains(got, "VALUE=DATE") {
+		t.Fatalf("timed event must be floating and not a DATE value:\n%s", got)
+	}
+
+	var allDay icsBuilder
+	allDay.event("20260101T000000Z", icsEvent{
+		UID:     "acc-x",
+		Start:   time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC),
+		End:     time.Date(2026, 8, 5, 0, 0, 0, 0, time.UTC),
+		AllDay:  true,
+		Summary: "Stay: Hotel",
+	})
+	if got := allDay.String(); !strings.Contains(got, "DTSTART;VALUE=DATE:20260801") ||
+		!strings.Contains(got, "DTEND;VALUE=DATE:20260805") {
+		t.Fatalf("all-day DTSTART/DTEND wrong:\n%s", got)
+	}
+}
+
+func TestICSBuilderURLIsNotTextEscaped(t *testing.T) {
+	raw := "https://example.com/book?a=1,2;b=3"
+	var b icsBuilder
+	b.event("20260101T000000Z", icsEvent{
+		UID: "seg-x", AllDay: true,
+		Start: time.Now(), End: time.Now(),
+		Summary:     "Flight",
+		Description: raw, // same string as TEXT — must be escaped here
+		URL:         raw, // …but verbatim as a URI value
+	})
+	got := unfoldICS(b.String())
+	if !strings.Contains(got, "URL:"+raw) {
+		t.Fatalf("URL should be verbatim (URI value type):\n%s", got)
+	}
+	if !strings.Contains(got, `DESCRIPTION:https://example.com/book?a=1\,2\;b=3`) {
+		t.Fatalf("DESCRIPTION should be TEXT-escaped:\n%s", got)
+	}
+}
+
+// TestFoldICSLine covers RFC 5545 §3.1 folding, which enriched descriptions now
+// routinely trigger — before this feature every value was short enough that
+// folding never ran in practice.
+func TestFoldICSLine(t *testing.T) {
+	assertFolded := func(t *testing.T, in string) {
+		t.Helper()
+		out := foldICSLine(in)
+		for i, seg := range strings.Split(out, "\r\n") {
+			if i > 0 && !strings.HasPrefix(seg, " ") {
+				t.Fatalf("continuation %d must start with one space: %q", i, seg)
+			}
+			if len(seg) > 75 {
+				t.Fatalf("segment %d is %d octets (>75): %q", i, len(seg), seg)
+			}
+			if !utf8.ValidString(seg) {
+				t.Fatalf("segment %d split a rune: %q", i, seg)
+			}
+		}
+		if got := unfoldICS(out); got != in {
+			t.Fatalf("unfold round-trip failed:\ngot  %q\nwant %q", got, in)
+		}
+	}
+
+	short := "SUMMARY:Acropolis"
+	if got := foldICSLine(short); got != short {
+		t.Fatalf("short line should pass through, got %q", got)
+	}
+	assertFolded(t, "DESCRIPTION:"+strings.Repeat("a", 300))
+	// Multi-byte: 2-byte runes, and a 4-byte rune placed to straddle the
+	// 75-octet boundary.
+	assertFolded(t, "DESCRIPTION:"+strings.Repeat("é", 60))
+	assertFolded(t, "DESCRIPTION:"+strings.Repeat("a", 72)+"𝄞"+strings.Repeat("b", 40))
+}
+
+// TestBuildICSDocument pins a whole document (DTSTAMP included, via the icsNow
+// seam) so the calendar's overall shape is covered, not just its fragments.
+func TestBuildICSDocument(t *testing.T) {
+	prev := icsNow
+	icsNow = func() time.Time { return time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC) }
+	t.Cleanup(func() { icsNow = prev })
+
+	day := int32(1)
+	tod := "evening"
+	d := exportData{
+		Trip: store.Trip{
+			ID:        uuid.New(),
+			Title:     "Greek Islands",
+			StartDate: pgDate(t, "2026-08-01"),
+			EndDate:   pgDate(t, "2026-08-05"),
+		},
+		Items: []store.ItineraryItem{{
+			ID: uuid.New(), Name: "Sunset dinner", Day: &day, TimeOfDay: &tod,
+		}},
+	}
+	body := buildICS("en", d)
+
+	for _, want := range []string{
+		"BEGIN:VCALENDAR\r\n",
+		"X-WR-CALNAME:Greek Islands\r\n",
+		"DTSTAMP:20260720T120000Z\r\n",
+		"DTSTART:20260801T190000\r\n", // evening window on day 1
+		"DTEND:20260801T220000\r\n",
+		"END:VCALENDAR\r\n",
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("missing %q in:\n%s", want, body)
+		}
+	}
+	// One real event ⇒ no trip-span fallback event.
+	if n := strings.Count(body, "BEGIN:VEVENT"); n != 1 {
+		t.Fatalf("expected 1 VEVENT, got %d:\n%s", n, body)
+	}
+}
+
+func TestBuildICSEmptyTripStillYieldsSpanEvent(t *testing.T) {
+	d := exportData{Trip: store.Trip{
+		ID: uuid.New(), Title: "Empty", StartDate: pgDate(t, "2026-08-01"), EndDate: pgDate(t, "2026-08-03"),
+	}}
+	body := buildICS("en", d)
+	if n := strings.Count(body, "BEGIN:VEVENT"); n != 1 {
+		t.Fatalf("expected the trip-span fallback event, got %d:\n%s", n, body)
+	}
+	if !strings.Contains(body, "DTSTART;VALUE=DATE:20260801") ||
+		!strings.Contains(body, "DTEND;VALUE=DATE:20260804") {
+		t.Fatalf("trip-span event dates wrong:\n%s", body)
+	}
+}

--- a/src/packages/api/export_integration_test.go
+++ b/src/packages/api/export_integration_test.go
@@ -330,11 +330,18 @@ func TestExportCalendar_ICSShapeAndEscaping(t *testing.T) {
 	if n := strings.Count(body, "BEGIN:VEVENT"); n != 3 {
 		t.Fatalf("expected 3 VEVENTs (item+stay+segment), got %d\n%s", n, body)
 	}
-	// Item all-day event: day 2 → 2026-08-02.
-	if !strings.Contains(body, "DTSTART;VALUE=DATE:20260802") {
-		t.Fatalf("item DTSTART wrong; body:\n%s", body)
+	// The whole-trip import is labeled in the user's calendar.
+	if !strings.Contains(body, "X-WR-CALNAME:Greek Islands") {
+		t.Fatalf("missing calendar name; body:\n%s", body)
 	}
-	// Stay check-in 2026-08-01.
+	// Item is a TIMED floating event: day 2 → 2026-08-02, "morning" → 09:00–12:00.
+	if !strings.Contains(body, "DTSTART:20260802T090000") || !strings.Contains(body, "DTEND:20260802T120000") {
+		t.Fatalf("item timed DTSTART/DTEND wrong; body:\n%s", body)
+	}
+	if strings.Contains(body, "DTSTART:20260802T090000Z") {
+		t.Fatalf("timed events must be floating (no Z); body:\n%s", body)
+	}
+	// Stay check-in 2026-08-01 stays all-day alongside the timed item.
 	if !strings.Contains(body, "DTSTART;VALUE=DATE:20260801") {
 		t.Fatalf("stay DTSTART wrong; body:\n%s", body)
 	}

--- a/src/packages/api/i18n.go
+++ b/src/packages/api/i18n.go
@@ -202,6 +202,7 @@ var messages = map[string]map[string]string{
 	"email.verify.body":            {"en": "Welcome to Golden Tempo Travel!\n\nConfirm your email address by opening this link:\n\n%s\n\nThe link expires in 24 hours. If you didn't create an account, you can ignore this email.", "es": "¡Te damos la bienvenida a Golden Tempo Travel!\n\nConfirma tu dirección de correo abriendo este enlace:\n\n%s\n\nEl enlace caduca en 24 horas. Si no creaste una cuenta, puedes ignorar este correo."},
 	"email.verify.subject":         {"en": "Confirm your email — Golden Tempo Travel", "es": "Confirma tu correo — Golden Tempo Travel"},
 
+	"ics.booked":        {"en": "Booked", "es": "Reservado"},
 	"ics.mode.bus":      {"en": "Bus", "es": "Autobús"},
 	"ics.mode.car":      {"en": "Car", "es": "Coche"},
 	"ics.mode.ferry":    {"en": "Ferry", "es": "Ferri"},

--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -1725,22 +1725,12 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
     }
   }
 
-  /// Google-Calendar details line for an itinerary item, mirroring the Go
-  /// export's icsItemDescription: time-of-day + local attribution.
-  String _itemCalendarDetails(ItineraryItem item) {
-    final tod = item.timeOfDay;
-    final rec = item.localSourceName?.trim();
-    return [
-      if (tod != null && tod.isNotEmpty)
-        tod[0].toUpperCase() + tod.substring(1),
-      if (rec != null && rec.isNotEmpty) context.l10n.tripRecommendedBy(rec),
-    ].join(' · ');
-  }
-
   /// Opens a prefilled Google Calendar event for one itinerary item — a pure
-  /// URL, so no token mint and no offline gate.
+  /// URL, so no token mint and no offline gate. Timed when the item carries a
+  /// time_of_day, matching the .ics.
   Future<void> _addItemToGoogleCalendar(ItineraryItem item) async {
-    final range = itemCalendarRange(_trip?.startDate, item.day);
+    final range = itemCalendarRange(_trip?.startDate, item.day,
+        timeOfDay: item.timeOfDay);
     if (range == null) return;
     await trackedLaunchUrl(
       context,
@@ -1748,8 +1738,9 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
         title: item.name,
         start: range.start,
         endExclusive: range.endExclusive,
+        allDay: range.allDay,
         location: item.address,
-        details: _itemCalendarDetails(item),
+        details: itemCalendarDetails(context.l10n, item),
       ),
       provider: 'google_calendar',
       surface: 'event_calendar',

--- a/src/packages/flutter-app/lib/utils/calendar_links.dart
+++ b/src/packages/flutter-app/lib/utils/calendar_links.dart
@@ -1,4 +1,6 @@
+import '../l10n/app_localizations.dart';
 import '../models/accommodation.dart';
+import '../models/itinerary_item.dart';
 import '../models/trip_segment.dart';
 
 /// Builders for the per-event "Add to calendar" affordance.
@@ -6,23 +8,29 @@ import '../models/trip_segment.dart';
 /// Google Calendar takes a prefilled calendar.google.com link built entirely
 /// client-side (no server round-trip, no OAuth); Apple Calendar goes through
 /// the token-gated per-event .ics endpoint instead (see exportEventIcsUrl in
-/// share_link.dart). The date-range resolvers mirror the Go export semantics
-/// (calendar_handler.go): everything is all-day with an EXCLUSIVE end, and a
-/// null range means "undated — hide the affordance".
+/// share_link.dart). Both buttons sit on the same rows, so these resolvers
+/// mirror the Go export semantics (calendar_handler.go) field for field —
+/// ends are EXCLUSIVE, a null range means "undated, hide the affordance",
+/// stays and transport are all-day, and itinerary items become TIMED events
+/// from their time_of_day bucket. Change either side and you must change both.
 
-/// Prefilled Google Calendar event link (all-day; [endExclusive] follows the
-/// same end-exclusive convention as the .ics export).
+/// Prefilled Google Calendar event link. All-day by default; [allDay] false
+/// emits floating local date-times so the event lands at the same wall clock
+/// as the .ics.
 String googleCalendarUrl({
   required String title,
   required DateTime start,
   required DateTime endExclusive,
+  bool allDay = true,
   String? location,
   String? details,
 }) {
   return Uri.https('calendar.google.com', '/calendar/render', {
     'action': 'TEMPLATE',
     'text': title,
-    'dates': '${_ymd(start)}/${_ymd(endExclusive)}',
+    'dates': allDay
+        ? '${_ymd(start)}/${_ymd(endExclusive)}'
+        : '${_ymdhms(start)}/${_ymdhms(endExclusive)}',
     if (location != null && location.trim().isNotEmpty) 'location': location,
     if (details != null && details.trim().isNotEmpty) 'details': details,
   }).toString();
@@ -32,43 +40,148 @@ String _ymd(DateTime d) => '${d.year.toString().padLeft(4, '0')}'
     '${d.month.toString().padLeft(2, '0')}'
     '${d.day.toString().padLeft(2, '0')}';
 
+/// Floating local date-time. Deliberately NO trailing "Z": a Z would make
+/// Google read the pair as UTC and shift the event by the viewer's offset,
+/// breaking parity with the floating .ics (icsDateTimeLayout in Go).
+String _ymdhms(DateTime d) => '${_ymd(d)}T'
+    '${d.hour.toString().padLeft(2, '0')}'
+    '${d.minute.toString().padLeft(2, '0')}'
+    '${d.second.toString().padLeft(2, '0')}';
+
 /// A stay spans check-in through check-out (one night when check-out is
 /// missing or not after check-in). Null when check-in is missing/unparseable.
-({DateTime start, DateTime endExclusive})? stayCalendarRange(Accommodation a) {
+({DateTime start, DateTime endExclusive, bool allDay})? stayCalendarRange(
+    Accommodation a) {
   final start = _parseDate(a.checkIn);
   if (start == null) return null;
   final checkOut = _parseDate(a.checkOut);
   final end = (checkOut != null && checkOut.isAfter(start))
       ? checkOut
       : start.add(const Duration(days: 1));
-  return (start: start, endExclusive: end);
+  return (start: start, endExclusive: end, allDay: true);
 }
 
 /// A segment spans departure day through arrival day inclusive (a single day
 /// when arrival is missing). Null when the departure date is missing.
-({DateTime start, DateTime endExclusive})? segmentCalendarRange(TripSegment s) {
+({DateTime start, DateTime endExclusive, bool allDay})? segmentCalendarRange(
+    TripSegment s) {
   final start = _parseDate(s.departDate);
   if (start == null) return null;
   final arrive = _parseDate(s.arriveDate);
   final end = (arrive != null && arrive.isAfter(start))
       ? arrive.add(const Duration(days: 1))
       : start.add(const Duration(days: 1));
-  return (start: start, endExclusive: end);
+  return (start: start, endExclusive: end, allDay: true);
 }
 
 /// An itinerary item occupies the single trip day it's assigned to:
-/// trip.start_date + (day - 1). Null without a trip start date or a day.
-({DateTime start, DateTime endExclusive})? itemCalendarRange(
-    String? tripStartDate, int? day) {
+/// trip.start_date + (day - 1). With a [timeOfDay] bucket it becomes a timed
+/// event; without one it stays all-day. Null without a trip start date or day.
+({DateTime start, DateTime endExclusive, bool allDay})? itemCalendarRange(
+  String? tripStartDate,
+  int? day, {
+  String? timeOfDay,
+}) {
   final tripStart = _parseDate(tripStartDate);
   if (tripStart == null || day == null || day < 1) return null;
-  final start = tripStart.add(Duration(days: day - 1));
-  return (start: start, endExclusive: start.add(const Duration(days: 1)));
+  // Day arithmetic stays on UTC midnights — see _parseDate.
+  final dayStart = tripStart.add(Duration(days: day - 1));
+
+  final window = _itemTimeWindow(timeOfDay);
+  if (window == null) {
+    return (
+      start: dayStart,
+      endExclusive: dayStart.add(const Duration(days: 1)),
+      allDay: true,
+    );
+  }
+  // Rebuild with the hour rather than adding a Duration: these values are
+  // wall-clock carriers, not instants (see _parseDate).
+  return (
+    start: DateTime.utc(
+        dayStart.year, dayStart.month, dayStart.day, window.startHour),
+    endExclusive:
+        DateTime.utc(dayStart.year, dayStart.month, dayStart.day, window.endHour),
+    allDay: false,
+  );
+}
+
+/// morning 09–12, afternoon 13–17, evening 19–22; null for an empty or
+/// unrecognized bucket (the item stays all-day). Mirrors itemTimeWindow in
+/// calendar_handler.go — the two MUST move together.
+({int startHour, int endHour})? _itemTimeWindow(String? timeOfDay) =>
+    switch (timeOfDay?.trim().toLowerCase()) {
+      'morning' => (startHour: 9, endHour: 12),
+      'afternoon' => (startHour: 13, endHour: 17),
+      'evening' => (startHour: 19, endHour: 22),
+      _ => null,
+    };
+
+/// Calendar details for a stay, mirroring icsStayDescription: provider, price
+/// note, booked flag, and the readable booking link.
+String stayCalendarDetails(AppLocalizations l10n, Accommodation a) =>
+    _detailParts([
+      a.provider,
+      a.priceNote,
+      if (a.booked) l10n.bookingCardBooked,
+      displayUrl(a.url),
+    ]);
+
+/// Calendar details for a transport segment, mirroring icsSegmentDescription.
+String segmentCalendarDetails(AppLocalizations l10n, TripSegment s) =>
+    _detailParts([
+      s.provider,
+      s.priceNote,
+      if (s.booked) l10n.bookingCardBooked,
+      s.notes,
+      displayUrl(s.url),
+    ]);
+
+/// Calendar details for an itinerary item, mirroring icsItemDescription:
+/// time-of-day + local attribution.
+String itemCalendarDetails(AppLocalizations l10n, ItineraryItem item) {
+  final tod = item.timeOfDay;
+  final rec = item.localSourceName?.trim();
+  return _detailParts([
+    if (tod != null && tod.isNotEmpty) tod[0].toUpperCase() + tod.substring(1),
+    if (rec != null && rec.isNotEmpty) l10n.tripRecommendedBy(rec),
+  ]);
+}
+
+/// Joins the non-empty parts so a missing field never leaves a dangling
+/// separator (mirrors icsDetailParts in Go).
+String _detailParts(List<String?> vals) => vals
+    .map((v) => v?.trim() ?? '')
+    .where((v) => v.isNotEmpty)
+    .join(' · ');
+
+/// Readable form of a booking link for calendar text: host + path, no scheme,
+/// "www.", query, or fragment, truncated. Mirrors displayURL in
+/// print_view_handler.go.
+String displayUrl(String? raw) {
+  final trimmed = raw?.trim() ?? '';
+  if (trimmed.isEmpty) return '';
+  var display = trimmed;
+  final uri = Uri.tryParse(trimmed);
+  if (uri != null && uri.host.isNotEmpty) {
+    final host = uri.host.startsWith('www.') ? uri.host.substring(4) : uri.host;
+    var path = uri.path;
+    if (path.endsWith('/')) path = path.substring(0, path.length - 1);
+    display = '$host$path';
+  }
+  const maxRunes = 48;
+  final runes = display.runes.toList();
+  if (runes.length > maxRunes) {
+    return '${String.fromCharCodes(runes.take(maxRunes - 1))}…';
+  }
+  return display;
 }
 
 /// Parses a YYYY-MM-DD date to UTC midnight. UTC keeps the day arithmetic
 /// above exact — adding Duration(days: 1) to a LOCAL DateTime shifts by an
 /// hour across DST boundaries (see the Today-mode calendar-math lesson).
+/// These DateTimes are never instants: they are wall-clock carriers, emitted
+/// without a zone, so they stay floating like the .ics.
 DateTime? _parseDate(String? s) {
   if (s == null || s.isEmpty) return null;
   final t = DateTime.tryParse(s);

--- a/src/packages/flutter-app/lib/widgets/add_to_calendar_button.dart
+++ b/src/packages/flutter-app/lib/widgets/add_to_calendar_button.dart
@@ -28,6 +28,10 @@ class AddToCalendarButton extends ConsumerWidget {
   final DateTime endExclusive;
   final String? location;
   final String? details;
+
+  /// All-day (the default) vs a timed event — mirror of the .ics semantics;
+  /// pass the range resolver's `allDay`.
+  final bool allDay;
   final bool appleEnabled;
 
   const AddToCalendarButton({
@@ -41,6 +45,7 @@ class AddToCalendarButton extends ConsumerWidget {
     required this.endExclusive,
     this.location,
     this.details,
+    this.allDay = true,
     this.appleEnabled = false,
   });
 
@@ -51,6 +56,7 @@ class AddToCalendarButton extends ConsumerWidget {
         title: title,
         start: start,
         endExclusive: endExclusive,
+        allDay: allDay,
         location: location,
         details: details,
       ),

--- a/src/packages/flutter-app/lib/widgets/bookings_section.dart
+++ b/src/packages/flutter-app/lib/widgets/bookings_section.dart
@@ -352,8 +352,9 @@ class BookingsSection extends StatelessWidget {
                                 title: l10n.calendarStayTitle(a.name),
                                 start: range.start,
                                 endExclusive: range.endExclusive,
+                                allDay: range.allDay,
                                 location: a.address,
-                                details: a.provider,
+                                details: stayCalendarDetails(l10n, a),
                                 appleEnabled: appleCalendarEnabled,
                               ),
                             if (a.url != null && a.url!.isNotEmpty)
@@ -452,7 +453,8 @@ class BookingsSection extends StatelessWidget {
                                 title: _segmentCalendarTitle(l10n, s),
                                 start: range.start,
                                 endExclusive: range.endExclusive,
-                                details: s.notes,
+                                allDay: range.allDay,
+                                details: segmentCalendarDetails(l10n, s),
                                 appleEnabled: appleCalendarEnabled,
                               ),
                             if (s.url != null && s.url!.isNotEmpty)

--- a/src/packages/flutter-app/test/calendar_links_test.dart
+++ b/src/packages/flutter-app/test/calendar_links_test.dart
@@ -1,6 +1,9 @@
+import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import 'package:travel_route_planner/l10n/app_localizations.dart';
 import 'package:travel_route_planner/models/accommodation.dart';
+import 'package:travel_route_planner/models/itinerary_item.dart';
 import 'package:travel_route_planner/models/trip_segment.dart';
 import 'package:travel_route_planner/utils/calendar_links.dart';
 
@@ -35,6 +38,20 @@ void main() {
       expect(uri.queryParameters['text'], 'Fish & chips, maybe?');
       expect(uri.queryParameters.containsKey('location'), isFalse);
       expect(uri.queryParameters.containsKey('details'), isFalse);
+    });
+
+    test('builds a floating timed link with no Z suffix', () {
+      final url = googleCalendarUrl(
+        title: 'Acropolis',
+        start: DateTime.utc(2026, 8, 3, 9),
+        endExclusive: DateTime.utc(2026, 8, 3, 12),
+        allDay: false,
+      );
+      final dates = Uri.parse(url).queryParameters['dates'];
+      expect(dates, '20260803T090000/20260803T120000');
+      // A Z would make Google read the pair as UTC and shift the event,
+      // breaking parity with the floating .ics.
+      expect(dates, isNot(contains('Z')));
     });
   });
 
@@ -89,10 +106,11 @@ void main() {
   });
 
   group('itemCalendarRange', () {
-    test('resolves trip start + (day - 1) as a single day', () {
+    test('resolves trip start + (day - 1) as a single all-day', () {
       final r = itemCalendarRange('2026-08-01', 3)!;
       expect(r.start, DateTime.utc(2026, 8, 3));
       expect(r.endExclusive, DateTime.utc(2026, 8, 4));
+      expect(r.allDay, isTrue);
     });
 
     test('null without a trip start, a day, or a valid day', () {
@@ -100,6 +118,128 @@ void main() {
       expect(itemCalendarRange('2026-08-01', null), isNull);
       expect(itemCalendarRange('2026-08-01', 0), isNull);
       expect(itemCalendarRange('nope', 3), isNull);
+    });
+
+    // These windows mirror itemTimeWindow in calendar_handler.go — the Go
+    // table test asserts the same hours. Drift shows up as a diff here.
+    test('time_of_day buckets become timed windows', () {
+      const cases = {
+        'morning': (9, 12),
+        'afternoon': (13, 17),
+        'evening': (19, 22),
+      };
+      cases.forEach((tod, hours) {
+        final r = itemCalendarRange('2026-08-01', 3, timeOfDay: tod)!;
+        expect(r.allDay, isFalse, reason: tod);
+        expect(r.start, DateTime.utc(2026, 8, 3, hours.$1), reason: tod);
+        expect(r.endExclusive, DateTime.utc(2026, 8, 3, hours.$2), reason: tod);
+      });
+    });
+
+    test('empty or unknown time_of_day stays all-day', () {
+      for (final tod in [null, '', 'night', 'whenever']) {
+        final r = itemCalendarRange('2026-08-01', 3, timeOfDay: tod)!;
+        expect(r.allDay, isTrue, reason: '$tod');
+        expect(r.start, DateTime.utc(2026, 8, 3), reason: '$tod');
+        expect(r.endExclusive, DateTime.utc(2026, 8, 4), reason: '$tod');
+      }
+    });
+
+    test('timed windows survive a DST boundary', () {
+      // 2026-10-25 is the EU DST change. Day 3 of a trip starting Oct 24 is
+      // Oct 26 at 09:00 — this fails if anyone "fixes" the UTC wall-clock
+      // carrier into local time.
+      final r = itemCalendarRange('2026-10-24', 3, timeOfDay: 'morning')!;
+      expect(r.start, DateTime.utc(2026, 10, 26, 9));
+      expect(r.endExclusive, DateTime.utc(2026, 10, 26, 12));
+    });
+  });
+
+  group('displayUrl', () {
+    test('strips scheme, www, query, and trailing slash', () {
+      expect(
+          displayUrl('https://www.booking.com/hotel/gr/grande.html?aid=42&x=1'),
+          'booking.com/hotel/gr/grande.html');
+      expect(displayUrl('http://example.com/'), 'example.com');
+      expect(displayUrl(null), '');
+      expect(displayUrl('  '), '');
+      expect(displayUrl('not a url'), 'not a url');
+    });
+
+    test('truncates long links with an ellipsis', () {
+      final long = 'https://example.com/${'very-long-path/' * 10}';
+      final got = displayUrl(long);
+      expect(got.runes.length, lessThanOrEqualTo(48));
+      expect(got, endsWith('…'));
+    });
+  });
+
+  group('calendar details', () {
+    late AppLocalizations l10n;
+
+    setUpAll(() async {
+      l10n = await AppLocalizations.delegate.load(const Locale('en'));
+    });
+
+    // Expected strings mirror icsStayDescription / icsSegmentDescription /
+    // icsItemDescription in the Go suite (calendar_test.go).
+    test('stay details join provider, price, booked, and link', () {
+      const a = Accommodation(
+        id: 'a',
+        name: 'Casa',
+        provider: 'Booking.com',
+        priceNote: '€180/night',
+        url: 'https://www.booking.com/hotel/gr/grande.html?aid=42',
+        booked: true,
+      );
+      expect(stayCalendarDetails(l10n, a),
+          'Booking.com · €180/night · Booked · booking.com/hotel/gr/grande.html');
+    });
+
+    test('unbooked stay omits the flag and empties leave no separators', () {
+      const a = Accommodation(
+          id: 'a', name: 'Casa', priceNote: '€180/night', booked: false);
+      expect(stayCalendarDetails(l10n, a), '€180/night');
+      expect(
+          stayCalendarDetails(l10n, const Accommodation(id: 'a', name: 'Casa')),
+          '');
+    });
+
+    test('segment details include notes between booked and the link', () {
+      const s = TripSegment(
+        id: 's',
+        mode: 'flight',
+        provider: 'Delta',
+        priceNote: r'$780',
+        notes: 'Departs 6:30 PM',
+        url: 'https://www.delta.com/booking/xyz',
+        booked: true,
+      );
+      expect(segmentCalendarDetails(l10n, s),
+          r'Delta · $780 · Booked · Departs 6:30 PM · delta.com/booking/xyz');
+    });
+
+    test('item details capitalize time-of-day and credit the local', () {
+      const item = ItineraryItem(
+        id: 'i',
+        position: 0,
+        name: 'Acropolis',
+        latitude: 37.97,
+        longitude: 23.72,
+        timeOfDay: 'morning',
+        localSourceName: 'Maria',
+      );
+      expect(itemCalendarDetails(l10n, item), 'Morning · Recommended by Maria');
+      expect(
+          itemCalendarDetails(
+              l10n,
+              const ItineraryItem(
+                  id: 'i',
+                  position: 0,
+                  name: 'X',
+                  latitude: 0,
+                  longitude: 0)),
+          '');
     });
   });
 }


### PR DESCRIPTION
## Summary
- **Itinerary items are now timed calendar events**, derived from their existing `time_of_day` bucket: morning 09:00–12:00, afternoon 13:00–17:00, evening 19:00–22:00. A day with four activities reads as a schedule instead of four identical all-day banners. Items with no bucket stay all-day, as do stays and transport (the model has no clock times for those).
- Times are **floating** (no `Z`, no `TZID`) so they hold their wall clock in whatever timezone the traveler's device is in.
- **Stays and transport carry booking detail**: provider, price note, booked flag, and a readable short link in `DESCRIPTION`, with the raw href on a `URL` property — emitted unescaped, since `URL` is a URI value type and escaping would corrupt query strings.
- The whole-trip file gains `X-WR-CALNAME` so the import is labeled with the trip title; the single-event file deliberately omits it (some clients would offer to create a whole calendar named after one event).
- The three shared resolvers now return one `icsEvent`, so the whole-trip and per-event endpoints render identically and the UID dedupe scheme has a single definition.
- **Flutter parity**: the client-built Google Calendar links mirror the same windows, detail strings, and floating format — the Google and Apple buttons on the same row must produce the same event. Detail builders are localized (new `ics.booked` key, en/es).
- No schema change. The windows are a documented product convention; real per-item time columns remain the eventual upgrade, recorded in the spec.

## Testing
- New `calendar_test.go`: time-window table, description assembly (no dangling separators, booked-only-when-true, localized), timed-vs-all-day formatting, `URL`-not-escaped-while-`DESCRIPTION`-is, and a pinned-DTSTAMP whole document via a new `icsNow` seam.
- **First real `foldICSLine` coverage** — folding was previously untested and never exercised in practice, but enriched descriptions routinely exceed 75 octets. Covers 300-char ASCII, 2-byte runes, and a 4-byte rune straddling the boundary, asserting per-segment UTF-8 validity and byte-exact unfold round-trips.
- `calendar_event_test.go`: timed item, all-day fallback without `time_of_day`, stay/segment booking detail, and a bare event emitting neither `DESCRIPTION` nor `URL`.
- `export_integration_test.go`: updated to the timed assertions (the old `DTSTART;VALUE=DATE:20260802` assertion correctly broke) plus `X-WR-CALNAME`; the stay stays all-day alongside, proving both paths coexist.
- Dart `calendar_links_test.dart`: floating timed link asserting no `Z`, per-bucket hours mirroring the Go table, all-day fallbacks, detail builders, `displayUrl`, and a **DST guard** (trip start Oct 24, day 3 across the EU change) that fails if anyone converts the UTC wall-clock carriers to local time.
- Full Go suite green with `TEST_DATABASE_URL`; `flutter analyze` clean (no new issues); all 416 Flutter tests pass.
- **Verified against a real iCalendar parser** (Python `icalendar`), not just my own assertions: floating times confirmed tz-naive, folded descriptions unfold correctly, and the comma inside a booking URL survives intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)