### PR TITLE
fix(flutter): draw one world on the trip map instead of repeating it

### DIFF
--- a/src/packages/flutter-app/lib/screens/local_guide_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/local_guide_detail_screen.dart
@@ -276,19 +276,17 @@ class _GuideMapState extends State<_GuideMap> {
       flags: InteractiveFlag.all & ~InteractiveFlag.scrollWheelZoom,
     );
     final options = points.length == 1
-        ? MapOptions(
+        ? appMapOptions(
             initialCenter: points.first,
             initialZoom: 13,
             interactionOptions: interaction,
-            backgroundColor: appMapBackground,
           )
-        : MapOptions(
+        : appMapOptions(
             initialCameraFit: CameraFit.bounds(
               bounds: LatLngBounds.fromPoints(points),
               padding: const EdgeInsets.all(32),
             ),
             interactionOptions: interaction,
-            backgroundColor: appMapBackground,
           );
 
     return ClipRRect(

--- a/src/packages/flutter-app/lib/widgets/app_map.dart
+++ b/src/packages/flutter-app/lib/widgets/app_map.dart
@@ -1,10 +1,95 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
+import 'package:latlong2/latlong.dart';
 
 /// Space-dark canvas behind the tiles: unloaded/failed satellite tiles read as
 /// "not lit yet" instead of a broken grey hole. Pass as
 /// `MapOptions.backgroundColor` wherever [appMapTileLayers] is used.
 const Color appMapBackground = Color(0xFF0A0F1A);
+
+/// Web Mercator that draws exactly **one** world.
+///
+/// flutter_map's stock [Epsg3857] replicates longitude, so tiles, pins and
+/// route lines repeat sideways whenever the world is narrower than the
+/// viewport. Our maps are short, fixed-height bands (240px) that auto-fit a
+/// trip's full extent: on a wide window a tall trip forces a zoom low enough
+/// that two or three copies of the planet sit side by side — visually a bug.
+/// Drawing a single world shows [appMapBackground] past the edges instead.
+///
+/// This wraps rather than extends [Epsg3857] because the two knobs that drive
+/// repetition live in different places: `replicatesWorldLongitude` is a
+/// virtual getter (markers, polylines, camera), while `wrapLng` is a
+/// `@nonVirtual` field on [Crs] that the tile layer reads to pick a wrapping
+/// [TileBounds]. Only a CRS constructed with `wrapLng: null` stops the tiles
+/// repeating; all the projection math is delegated to a real [Epsg3857].
+class AppMapCrs extends Crs {
+  /// Create the app's single-world Web Mercator CRS.
+  const AppMapCrs() : super(code: 'EPSG:3857', infinite: false);
+
+  static const Epsg3857 _mercator = Epsg3857();
+
+  @override
+  Projection get projection => _mercator.projection;
+
+  @override
+  bool get replicatesWorldLongitude => false;
+
+  @override
+  (double, double) transform(double x, double y, double scale) =>
+      _mercator.transform(x, y, scale);
+
+  @override
+  (double, double) untransform(double x, double y, double scale) =>
+      _mercator.untransform(x, y, scale);
+
+  @override
+  (double, double) latLngToXY(LatLng latlng, double scale) =>
+      _mercator.latLngToXY(latlng, scale);
+
+  @override
+  Offset latLngToOffset(LatLng latlng, double zoom) =>
+      _mercator.latLngToOffset(latlng, zoom);
+
+  @override
+  LatLng offsetToLatLng(Offset point, double zoom) =>
+      _mercator.offsetToLatLng(point, zoom);
+
+  @override
+  Rect? getProjectedBounds(double zoom) => _mercator.getProjectedBounds(zoom);
+}
+
+/// Shared [MapOptions] for every [FlutterMap] in the app: single-world
+/// rendering, the space-dark backdrop, and a camera that can't wander off the
+/// planet. Callers pass whichever framing they have — a center+zoom or a
+/// [CameraFit] — plus their interaction flags.
+MapOptions appMapOptions({
+  LatLng? initialCenter,
+  double? initialZoom,
+  CameraFit? initialCameraFit,
+  required InteractionOptions interactionOptions,
+}) {
+  return MapOptions(
+    crs: const AppMapCrs(),
+    backgroundColor: appMapBackground,
+    // Keeps the camera *center* on the world, so a pan can't drift off into
+    // empty background. Deliberately not CameraConstraint.contain: that one
+    // rejects any camera it cannot fit inside the bounds (returning null),
+    // which would freeze a map taller than the world is wide.
+    cameraConstraint: CameraConstraint.containCenter(
+      bounds: LatLngBounds(const LatLng(-85, -180), const LatLng(85, 180)),
+    ),
+    // Without a floor, zooming out shrinks the single world to a postage
+    // stamp and then past the smallest tile level into empty background.
+    // z1 = a 512px world, which still fills our 240px map bands vertically
+    // and is far below any real trip's auto-fit zoom (that would need ~130°
+    // of latitude in one trip), so the fit is never clamped by this.
+    minZoom: 1,
+    initialCenter: initialCenter ?? const LatLng(0, 0),
+    initialZoom: initialZoom ?? 13,
+    initialCameraFit: initialCameraFit,
+    interactionOptions: interactionOptions,
+  );
+}
 
 /// Shared basemap for every map in the app: Esri World Imagery satellite
 /// tiles with a labels-only overlay designed for dark imagery, so maps get a

--- a/src/packages/flutter-app/lib/widgets/trip_map.dart
+++ b/src/packages/flutter-app/lib/widgets/trip_map.dart
@@ -299,27 +299,24 @@ class _TripMapState extends State<TripMap> {
     // Center on the selected place when one is set (e.g. the map was just
     // (re)built after a list tap); otherwise fit the whole trip.
     final MapOptions options = selected != null
-        ? MapOptions(
+        ? appMapOptions(
             initialCenter: selected,
             initialZoom: 15,
             interactionOptions: interaction,
-            backgroundColor: appMapBackground,
           )
         : fitPoints.length == 1
             // Single point: bounds collapse, so center with a sensible zoom.
-            ? MapOptions(
+            ? appMapOptions(
                 initialCenter: fitPoints.first,
                 initialZoom: 13,
                 interactionOptions: interaction,
-                backgroundColor: appMapBackground,
               )
-            : MapOptions(
+            : appMapOptions(
                 initialCameraFit: CameraFit.bounds(
                   bounds: LatLngBounds.fromPoints(fitPoints),
                   padding: _fitPadding,
                 ),
                 interactionOptions: interaction,
-                backgroundColor: appMapBackground,
               );
 
     return Stack(


### PR DESCRIPTION
## Problem

On a wide window the trip map showed **two or three copies of the planet side by side**, with the route polyline drawn across each copy.

The map is a short, fixed-height band (240px) that auto-fits the whole trip. `CameraFit.bounds` fits both axes, so a trip with a big latitude span (Galápagos → Berlin) is constrained by *latitude* and settles around zoom ≈ 2, where the whole world is narrower than a ~1800px viewport — and flutter_map's stock `Epsg3857` replicates longitude to fill the rest.

## Fix

`AppMapCrs` (in `lib/widgets/app_map.dart`) is a Web Mercator CRS that draws exactly one world. It delegates all projection math to a real `Epsg3857`, but:

- reports `replicatesWorldLongitude == false` (stops markers, polylines and camera wrap), and
- is constructed with `wrapLng: null`, which is what makes the tile layer choose a non-wrapping `TileBounds`.

Those two knobs live in different places — `replicatesWorldLongitude` is virtual, `wrapLng` is a `@nonVirtual` field on `Crs` — so extending `Epsg3857` fixes the pins and the route line but leaves the *tiles* repeating. Hence delegation rather than subclassing.

Both map call sites (`trip_map.dart`, `local_guide_detail_screen.dart`) now build their `MapOptions` through the shared `appMapOptions()`, which also:

- keeps the camera centre on the world (`CameraConstraint.containCenter`, which can never reject a camera the way `contain` does), and
- floors zoom at **z1** so zooming out can't shrink the single world to a speck and then past the smallest tile level into empty background. z1 is far below any real trip's auto-fit zoom, so the fit is never clamped.

Past the map's edges you now see the existing space-dark `appMapBackground`. Nothing in the trip is cropped.

## Known / accepted

- Horizontal panning is no longer infinite — past ±180° you see background.
- An antimeridian-crossing trip (LA→Tokyo) draws its route the long way across the single world. That is already today's behaviour: `LatLngBounds.fromPoints` takes plain min/max longitude and never wraps.

## Verification

- `flutter analyze` — no new issues; `flutter test` — 384 passed.
- Browser at 1900×900 against a Galápagos→Panama→Kraków→Berlin fixture trip: single world on the auto-fit, on day-chip refits (single-day framing still zooms to the city), after zoom in/out, after a hard pan, and after **Reset map**. A regional trip (Guadalajara/Latin America, Today mode) renders unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)