### PR TITLE
fix(flutter): key city sections by visit, not by city name

### DIFF
--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -1918,13 +1918,32 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
   /// Groups items into consecutive runs sharing the same locality, labelling
   /// each run with the date range precomputed for that location (keyed by the
   /// first item's position).
-  List<({String label, String? dateRange, List<ItineraryItem> items})>
-      _buildGroups(
+  ///
+  /// [label] is the display city and stays shared across runs (it feeds the
+  /// per-city weather/events/local-intel lookups). [key] identifies the *run*:
+  /// a trip that revisits a city (Athens → Fira → Oia → Fira) yields two runs
+  /// with the same label, and everything keyed per-header — the header
+  /// [GlobalKey]s, the collapse sets, the `key#day` day keys — must tell them
+  /// apart or two live widgets share one GlobalKey and the itinerary fails to
+  /// build. Repeats get a `#2`, `#3`, … suffix; the scroll helpers parse day
+  /// keys with `lastIndexOf('#')`, so a suffixed key round-trips fine.
+  List<
+      ({
+        String key,
+        String label,
+        String? dateRange,
+        List<ItineraryItem> items
+      })> _buildGroups(
     List<ItineraryItem> items,
     Map<int, String> locationDates,
   ) {
-    final groups =
-        <({String label, String? dateRange, List<ItineraryItem> items})>[];
+    final groups = <({
+      String key,
+      String label,
+      String? dateRange,
+      List<ItineraryItem> items
+    })>[];
+    final seen = <String, int>{};
     String? currentKey;
     List<ItineraryItem>? current;
     for (final item in items) {
@@ -1932,8 +1951,12 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
       if (current == null || locality != currentKey) {
         current = [];
         currentKey = locality;
+        final label = locality ?? _kOtherPlaces;
+        final n = (seen[label] ?? 0) + 1;
+        seen[label] = n;
         groups.add((
-          label: locality ?? _kOtherPlaces,
+          key: n == 1 ? label : '$label#$n',
+          label: label,
           dateRange: locationDates[item.position],
           items: current,
         ));
@@ -1948,8 +1971,12 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
   /// Each day is a [MultiSliver] whose header pins below the city header while
   /// the day's items scroll past, then is pushed off by the next day. Legacy
   /// items with no day fall back to flat day-trip batching with no day headers.
-  List<Widget> _buildGroupItemSlivers(String cityKey, List<ItineraryItem> items,
-      ThemeData theme, DateTime? tripStart,
+  ///
+  /// [cityKey] is the display city (weather lookup, refine target); [groupKey]
+  /// identifies this run of it and prefixes the day keys, so a revisited city's
+  /// two runs never share a day header (see [_buildGroups]).
+  List<Widget> _buildGroupItemSlivers(String cityKey, String groupKey,
+      List<ItineraryItem> items, ThemeData theme, DateTime? tripStart,
       {required bool showTonight, ({DateTime? start, DateTime? end})? range}) {
     if (!items.any((it) => it.day != null)) {
       return _dayTripSectionSlivers(items, theme);
@@ -1985,7 +2012,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
         i++;
       }
       if (day != null) {
-        final dayKey = '$cityKey#$day';
+        final dayKey = '$groupKey#$day';
         final collapsed = _collapsedDays.contains(dayKey);
         final header = _daySubHeader(
             day, tripStart, theme, collapsed, _runTravelMin(run), () {
@@ -2064,18 +2091,23 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
   /// Material keeps items from showing through while pinned.
   Widget _cityHeader(
       Trip trip,
-      ({String label, String? dateRange, List<ItineraryItem> items}) group,
+      ({
+        String key,
+        String label,
+        String? dateRange,
+        List<ItineraryItem> items
+      }) group,
       ThemeData theme) {
     final l10n = context.l10n;
-    final cityCollapsed = _collapsedCities.contains(group.label);
+    final cityCollapsed = _collapsedCities.contains(group.key);
     return Material(
       color: theme.scaffoldBackgroundColor,
       child: InkWell(
         onTap: () => setState(() {
           if (cityCollapsed) {
-            _collapsedCities.remove(group.label);
+            _collapsedCities.remove(group.key);
           } else {
-            _collapsedCities.add(group.label);
+            _collapsedCities.add(group.key);
           }
         }),
         child: Padding(
@@ -3987,14 +4019,16 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
                           (trip.items ?? const <ItineraryItem>[])
                               .any((i) => i.day != null);
                       // Tonight caption (specs/happening-now): day numbers
-                      // repeat across city groups (keys are '$cityKey#$day'),
+                      // repeat across city groups (keys are '$groupKey#$day'),
                       // so resolve the FIRST group containing today's day
                       // once, here — exactly one caption can ever render.
-                      String? firstTodayGroupLabel;
+                      // Matched on the run key, not the label: a revisited
+                      // city has two runs sharing a label.
+                      String? firstTodayGroupKey;
                       if (todayDay != null) {
                         for (final group in groups) {
                           if (group.items.any((it) => it.day == todayDay)) {
-                            firstTodayGroupLabel = group.label;
+                            firstTodayGroupKey = group.key;
                             break;
                           }
                         }
@@ -4226,12 +4260,16 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
                                     children: [
                                       SliverPinnedHeader(
                                           child: KeyedSubtree(
+                                              // Keyed by the run, not the city:
+                                              // a revisited city renders two
+                                              // headers at once and a shared
+                                              // GlobalKey would break the build.
                                               key: _cityHeaderKeys.putIfAbsent(
-                                                  group.label, GlobalKey.new),
+                                                  group.key, GlobalKey.new),
                                               child: _cityHeader(
                                                   trip, group, theme))),
                                       if (!_collapsedCities
-                                          .contains(group.label)) ...[
+                                          .contains(group.key)) ...[
                                         // Embedded bookings render only in the
                                         // unfiltered view: a category filter can
                                         // merge adjacent same-label runs, which
@@ -4243,11 +4281,12 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
                                               departureOnly: false)),
                                         ..._buildGroupItemSlivers(
                                             group.label,
+                                            group.key,
                                             group.items,
                                             theme,
                                             tripStart,
-                                            showTonight: group.label ==
-                                                firstTodayGroupLabel,
+                                            showTonight: group.key ==
+                                                firstTodayGroupKey,
                                             range: groupRanges[group.label]),
                                         // Curated local recommendations for this
                                         // city — the "legit info you can't

--- a/src/packages/flutter-app/test/trip_detail_revisited_city_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_revisited_city_test.dart
@@ -1,0 +1,123 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:travel_route_planner/models/trip.dart';
+import 'package:travel_route_planner/models/itinerary_item.dart';
+import 'package:travel_route_planner/services/api_client.dart';
+import 'package:travel_route_planner/services/trips_api_service.dart';
+import 'package:travel_route_planner/providers/trips_provider.dart';
+import 'package:travel_route_planner/screens/trip_detail_screen.dart';
+
+import 'support/l10n_test_app.dart';
+
+class _FakeTripsApiService extends TripsApiService {
+  final Trip trip;
+  _FakeTripsApiService(this.trip) : super(ApiClient(baseUrl: 'http://test'));
+
+  @override
+  Future<Trip> getTrip(String id) async => trip;
+}
+
+ItineraryItem _item(int pos, String name, String city, int day) =>
+    ItineraryItem(
+      id: 'i$pos',
+      position: pos,
+      name: name,
+      address: '$name street, $city-land',
+      // Zero coords so the screen skips the map widget in the test env.
+      latitude: 0,
+      longitude: 0,
+      category: 'attraction',
+      day: day,
+      city: city,
+    );
+
+void main() {
+  // Regression: an itinerary that returns to a city (Athens → Fira → Oia →
+  // Fira → Oia) builds two city groups with the same label. Keying the pinned
+  // city headers by label handed one GlobalKey to two live widgets, which threw
+  // "Multiple widgets used the same GlobalKey" and left the whole trip body
+  // blank. Each run must get its own key.
+  testWidgets('a trip that revisits a city renders both visits',
+      (WidgetTester tester) async {
+    final trip = Trip(
+      id: 't1',
+      title: 'Athens & Santorini',
+      status: 'planned',
+      createdAt: '2026-09-10',
+      updatedAt: '2026-09-10',
+      items: [
+        _item(0, 'Acropolis', 'Athens', 1),
+        _item(1, 'Ancient Agora', 'Athens', 2),
+        _item(2, 'Fira town', 'Fira', 3),
+        _item(3, 'Four Winds', 'Oia', 3),
+        _item(4, 'Akrotiri', 'Fira', 4),
+        _item(5, 'Oia sunset', 'Oia', 5),
+      ],
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          tripsApiServiceProvider.overrideWithValue(_FakeTripsApiService(trip)),
+        ],
+        child: MaterialApp(
+          localizationsDelegates: testLocalizationsDelegates,
+          home: TripDetailScreen(tripId: 't1'),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // The body built at all (the GlobalKey clash used to blank it out)...
+    expect(tester.takeException(), isNull);
+    expect(find.text('Acropolis'), findsOneWidget);
+    // ...and each city that is visited twice has two pinned headers, one per
+    // run, rather than one collapsed/duplicated header.
+    expect(find.text('Fira'), findsNWidgets(2));
+    expect(find.text('Oia'), findsNWidgets(2));
+    expect(find.text('Athens'), findsOneWidget);
+  });
+
+  testWidgets('collapsing one visit leaves the other visit expanded',
+      (WidgetTester tester) async {
+    final trip = Trip(
+      id: 't2',
+      title: 'Athens & Santorini',
+      status: 'planned',
+      createdAt: '2026-09-10',
+      updatedAt: '2026-09-10',
+      items: [
+        _item(0, 'Fira first stop', 'Fira', 1),
+        _item(1, 'Oia detour', 'Oia', 2),
+        _item(2, 'Fira second stop', 'Fira', 3),
+      ],
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          tripsApiServiceProvider.overrideWithValue(_FakeTripsApiService(trip)),
+        ],
+        child: MaterialApp(
+          localizationsDelegates: testLocalizationsDelegates,
+          home: TripDetailScreen(tripId: 't2'),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Fira first stop'), findsOneWidget);
+
+    // Tap the first Fira header: that run's items go away, the second Fira
+    // header stays (a label-keyed collapse set would have hidden both), and
+    // the freed space reveals the next group's item.
+    await tester.tap(find.text('Fira').first);
+    await tester.pumpAndSettle();
+
+    expect(find.text('Fira first stop'), findsNothing);
+    expect(find.text('Fira'), findsNWidgets(2));
+    expect(find.text('Oia detour'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Problem

The **"Athens & Santorini September"** trip rendered a **completely blank body**, with the console spamming `Multiple widgets used the same GlobalKey`.

`_buildGroups` splits an itinerary into *consecutive runs* of the same city. That trip goes Athens → Fira → Oia → Fira → Oia, so "Fira" and "Oia" each produce **two groups with the same label** — and the pinned city header looked its `GlobalKey` up by `group.label`:

```dart
key: _cityHeaderKeys.putIfAbsent(group.label, GlobalKey.new)
```

Two live widgets sharing one `GlobalKey` throws during build, so the whole itinerary subtree failed rather than merely glitching. Any revisit-a-city trip hits this — a common shape for island hopping and out-and-back trips.

## Fix

Each run now carries its own `key` (`Fira`, `Fira#2`, …) next to the display `label`. Switched to the run key:

- the city-header `GlobalKey`s,
- `_collapsedCities` (so collapsing one visit no longer collapses the other),
- the `key#day` day keys feeding `_dayHeaderKeys` / `_collapsedDays` / the Today scroll helpers,
- the Tonight caption match — on `label` it would have rendered twice for a revisited city.

`label` keeps its old meaning everywhere the *city* is what matters: weather, events, local intel, refine targets, `groupRanges`. The day-key parsers already use `lastIndexOf('#')`, so a `#2`-suffixed key round-trips unchanged.

## Verification

- New `test/trip_detail_revisited_city_test.dart`: the screen builds for a revisited city (both Fira and Oia headers present, no exception), and collapsing one visit leaves the other expanded. **Both fail on the unpatched screen** (verified by stashing the fix).
- `flutter analyze` clean (12 pre-existing infos), `flutter test` 418 passed.
- Browser check against the real trip on a dev stack: renders end to end — Athens, both Fira runs and both Oia runs each with their own pinned header, ferry row, weather and events — and **zero** GlobalKey messages in the console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)