### PR TITLE
fix(prod): mount backups dir into api so the freshness self-check can see it

### DIFF
--- a/dockerize/production/docker-compose.yml
+++ b/dockerize/production/docker-compose.yml
@@ -78,6 +78,13 @@ services:
       # same private compose bridge network. TLS would only encrypt
       # loopback-equivalent traffic between two containers on one machine.
       - DATABASE_URL=postgres://travel:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set}@postgres:5432/travel_planner?sslmode=disable
+    volumes:
+      # The backup-freshness self-check (ops_health.go) reads the heartbeat
+      # backup.sh writes at /opt/goldentempo/backups/.last_success — a HOST
+      # path. Without this read-only mount the containerized api sees no
+      # heartbeat at all and reports "backups stale" forever, however fresh
+      # the dumps are.
+      - ./backups:/opt/goldentempo/backups:ro
     depends_on:
       chrome:
         condition: service_started


### PR DESCRIPTION
## Summary
- The backup-freshness self-check (`ops_health.go`, default `/opt/goldentempo/backups/.last_success`) reads a **host** path, but the production api runs in a container with no such mount — so prod permanently reported `backups stale` (nightly degradation emails + a Sentry event on every api restart), regardless of actual backup health.
- Add a read-only `./backups:/opt/goldentempo/backups:ro` mount to the api service. Dev was never affected (`make api-run` runs on the host).

## Testing
- Hot-applied on the Pi: api recreated with the mount, no `ops health degraded` lines since (previously fired on every self-check tick); `/api/v1/health` 200s.
- The Sentry `ops health degraded` issue (goldentempo-api-2) should stop receiving events; backups were verified genuinely fresh today (local + R2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)