### PR TITLE
fix(api): accept HEAD on health endpoints

### DIFF
--- a/src/packages/api/main.go
+++ b/src/packages/api/main.go
@@ -739,12 +739,12 @@ func buildRouter() *mux.Router {
 	// Define routes
 	router.HandleFunc("/", helloHandler).Methods("GET")
 	router.HandleFunc("/hello", helloHandler).Methods("GET")
-	router.HandleFunc("/health", healthHandler).Methods("GET")
+	router.HandleFunc("/health", healthHandler).Methods("GET", "HEAD")
 
 	// API versioning
 	api := router.PathPrefix("/api/v1").Subrouter()
 	api.HandleFunc("/hello", helloHandler).Methods("GET")
-	api.HandleFunc("/health", healthHandler).Methods("GET")
+	api.HandleFunc("/health", healthHandler).Methods("GET", "HEAD")
 	api.HandleFunc("/optimize-route", optimizeRouteHandler).Methods("POST")
 	api.HandleFunc("/places/search", placesSearchHandler).Methods("GET")
 	api.HandleFunc("/places/autocomplete", placesAutocompleteHandler).Methods("GET")


### PR DESCRIPTION
## Summary
- `/health` and `/api/v1/health` now accept HEAD in addition to GET. UptimeRobot's free tier probes with HEAD (method choice is paywalled), so the API health monitor reported DOWN via 405 against a healthy site. HEAD-on-health is standard HTTP behavior; net/http suppresses response bodies for HEAD automatically.

## Testing
- `go build` + `go vet` green.
- Post-deploy: `curl -I https://goldentempotravel.com/api/v1/health` should return 200 (was 405), and the UptimeRobot monitor should flip to Up on its next 5-minute check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)