### PR TITLE
docs(restore): fix pg_isready race in the scratch-restore wait

### DIFF
--- a/dockerize/production/restore.md
+++ b/dockerize/production/restore.md
@@ -47,8 +47,20 @@ docker run -d --name pg-restore \
   -e POSTGRES_PASSWORD="$POSTGRES_PASSWORD" \
   postgres:16-alpine
 
-# wait for it to accept connections
-until docker exec pg-restore pg_isready -U travel -d travel_planner; do sleep 1; done
+# Wait for it to accept connections — and stay up. A single pg_isready check
+# races the image's first-boot init, which starts a TEMPORARY server, then
+# stops and restarts it: the restore then fails with "the database system is
+# shutting down" (hit for real in the 2026-07-21 drill). Require several
+# consecutive successes instead.
+ok=0
+until [ "$ok" -ge 3 ]; do
+  if docker exec pg-restore pg_isready -U travel -d travel_planner >/dev/null 2>&1; then
+    ok=$((ok+1))
+  else
+    ok=0
+  fi
+  sleep 2
+done
 
 gunzip -c "$DUMP" | docker exec -i pg-restore \
   pg_restore -U travel -d travel_planner --no-owner --exit-on-error


### PR DESCRIPTION
## Summary
- The runbook's `until pg_isready` wait races the postgres image's first-boot init (temporary server → restart), producing "the database system is shutting down" mid-restore. Replaced with a require-3-consecutive-successes loop.

## Testing
- Found and fixed during today's real restore drill on the Pi: first attempt failed exactly this way; with the steady-state wait, the full drill passed (28 tables, 6 users, 3 trips, 36 items restored and verified in scratch, then torn down).

🤖 Generated with [Claude Code](https://claude.com/claude-code)