### PR TITLE
docs(legal): mark EIN obtained (2026-07-21)

### DIFF
--- a/docs/legal/llc-formation-playbook.md
+++ b/docs/legal/llc-formation-playbook.md
@@ -33,7 +33,7 @@ alternate name (DBA, $50).
 - [x] Gov2Go annual-report reminders + CorpWatch alerts
 - [x] Business email created (+ forwarding to personal)
 - [x] goldentempo.co registered (Cloudflare, auto-renew on)
-- [ ] **EIN** — irs.gov online, free, ~10 min, weekdays ~7am–10pm ET only
+- [x] **EIN** — obtained 2026-07-21 (irs.gov online; digital CP 575 downloaded, not mailed — number & letter live in the password manager, not this repo)
 - [ ] **NJ-REG** tax registration — free, same portal, **due 2026-09-03** (60 days from formation); do EIN first
 - [ ] Verify Gov2Go's "annual report due 2026-07-31" event — believed to be a quirk (first report should be due July 2027); confirm via the annual-report portal with the Entity ID, or DORES 609-292-9292; if genuinely due, just file ($75)
 - [ ] Sign & date the operating agreement; keep with records


### PR DESCRIPTION
Checks the **EIN** box in the LLC formation playbook.

Obtained 2026-07-21 via the IRS online application. The digital CP 575
option was chosen, which means the letter is **not** mailed — the
downloaded PDF is the only copy. The EIN itself and the letter live in
the password manager; neither is recorded in this repo.

Next gate on the checklist: **NJ-REG, due 2026-09-03**.

Docs only — no code, no migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)