### PR TITLE
fix(web): hide Chrome's autofill highlight + detect keystroke-burst fills

### DIFF
--- a/src/packages/flutter-app/lib/screens/auth_screen.dart
+++ b/src/packages/flutter-app/lib/screens/auth_screen.dart
@@ -28,15 +28,19 @@ class _AuthScreenState extends ConsumerState<AuthScreen> {
   late bool _isLogin = widget.initialIsLogin;
 
   // Auto-submit after a password-manager autofill. An extension fill is
-  // distinctive: both fields jump from empty to a full value in one change
-  // event, within milliseconds of each other. Manual typing changes one
-  // character at a time and human paste-then-paste is seconds apart, so
-  // neither matches. Each auto-submit consumes the fill timestamps — a
-  // failed attempt is never retried without a fresh fill gesture (keeps us
-  // clear of the server-side login lockout).
-  static const _fillWindow = Duration(milliseconds: 500);
+  // distinctive: each field goes from empty to its full value within one
+  // rapid burst (a single change event, or keystroke-simulated characters
+  // milliseconds apart), and the two fields fill within ~a second of each
+  // other. A human types one field over seconds — the burst window lapses —
+  // and can't complete both fields back-to-back. Each auto-submit consumes
+  // the fill timestamps — a failed attempt is never retried without a
+  // fresh fill gesture (keeps us clear of the server-side login lockout).
+  static const _burstWindow = Duration(milliseconds: 400);
+  static const _fillWindow = Duration(milliseconds: 1500);
   String _prevEmail = '';
   String _prevPassword = '';
+  DateTime? _emailBurstStart;
+  DateTime? _passwordBurstStart;
   DateTime? _emailFillAt;
   DateTime? _passwordFillAt;
   Timer? _autoSubmitTimer;
@@ -61,13 +65,31 @@ class _AuthScreenState extends ConsumerState<AuthScreen> {
     final value = isEmail ? _emailController.text : _passwordController.text;
     final prev = isEmail ? _prevEmail : _prevPassword;
     if (value == prev) return;
-    final oneShotFill = prev.isEmpty && value.length > 1;
-    final fillAt = oneShotFill ? DateTime.now() : null;
+    // Any new change invalidates a pending auto-submit; _maybeAutoSubmit
+    // re-arms it below only if the fill signature still holds.
+    _autoSubmitTimer?.cancel();
+    final now = DateTime.now();
+    // The burst starts when the field first becomes non-empty; it ends (and
+    // the field no longer counts as manager-filled) once changes keep
+    // arriving past the burst window — that's a human typing.
+    var burstStart = isEmail ? _emailBurstStart : _passwordBurstStart;
+    if (value.isEmpty) {
+      burstStart = null;
+    } else if (prev.isEmpty) {
+      burstStart = now;
+    }
+    final filled =
+        value.isNotEmpty &&
+        burstStart != null &&
+        now.difference(burstStart) <= _burstWindow;
+    final fillAt = filled ? now : null;
     if (isEmail) {
       _prevEmail = value;
+      _emailBurstStart = burstStart;
       _emailFillAt = fillAt;
     } else {
       _prevPassword = value;
+      _passwordBurstStart = burstStart;
       _passwordFillAt = fillAt;
     }
     _maybeAutoSubmit();
@@ -81,7 +103,9 @@ class _AuthScreenState extends ConsumerState<AuthScreen> {
     if (emailAt.difference(passwordAt).abs() > _fillWindow) return;
     if (ref.read(authProvider).loading) return;
     _autoSubmitTimer?.cancel();
-    _autoSubmitTimer = Timer(const Duration(milliseconds: 250), () {
+    // Debounced past the burst window so it fires once the fill has fully
+    // arrived, with the complete values in both controllers.
+    _autoSubmitTimer = Timer(const Duration(milliseconds: 350), () {
       if (!mounted || !_isLogin) return;
       _emailFillAt = null;
       _passwordFillAt = null;
@@ -96,8 +120,11 @@ class _AuthScreenState extends ConsumerState<AuthScreen> {
     final password = _passwordController.text;
     final ok = _isLogin
         ? await notifier.login(email, password)
-        : await notifier.register(email, password,
-            displayName: _displayNameController.text.trim());
+        : await notifier.register(
+            email,
+            password,
+            displayName: _displayNameController.text.trim(),
+          );
     // Tell the platform the autofill session succeeded so the browser /
     // password manager offers to save the credentials.
     if (ok) TextInput.finishAutofillContext();
@@ -170,9 +197,12 @@ class _AuthScreenState extends ConsumerState<AuthScreen> {
                     const BrandLogo.mark(size: 72),
                     const SizedBox(height: 16),
                     Text(
-                      _isLogin ? l10n.authWelcomeBack : l10n.authCreateAccountTitle,
-                      style: theme.textTheme.headlineSmall
-                          ?.copyWith(fontWeight: FontWeight.bold),
+                      _isLogin
+                          ? l10n.authWelcomeBack
+                          : l10n.authCreateAccountTitle,
+                      style: theme.textTheme.headlineSmall?.copyWith(
+                        fontWeight: FontWeight.bold,
+                      ),
                       textAlign: TextAlign.center,
                     ),
                     const SizedBox(height: 24),
@@ -184,8 +214,9 @@ class _AuthScreenState extends ConsumerState<AuthScreen> {
                         AutofillHints.username,
                         AutofillHints.email,
                       ],
-                      decoration:
-                          InputDecoration(labelText: l10n.authEmailLabel),
+                      decoration: InputDecoration(
+                        labelText: l10n.authEmailLabel,
+                      ),
                       validator: (v) {
                         final value = (v ?? '').trim();
                         if (value.isEmpty) return l10n.authEmailRequired;
@@ -206,8 +237,9 @@ class _AuthScreenState extends ConsumerState<AuthScreen> {
                       ],
                       textInputAction: TextInputAction.done,
                       onFieldSubmitted: (_) => _submit(),
-                      decoration:
-                          InputDecoration(labelText: l10n.authPasswordLabel),
+                      decoration: InputDecoration(
+                        labelText: l10n.authPasswordLabel,
+                      ),
                       validator: (v) {
                         if ((v ?? '').isEmpty) return l10n.authPasswordRequired;
                         if (!_isLogin && v!.length < 8) {
@@ -246,9 +278,11 @@ class _AuthScreenState extends ConsumerState<AuthScreen> {
                               width: 20,
                               child: CircularProgressIndicator(strokeWidth: 2),
                             )
-                          : Text(_isLogin
-                              ? l10n.authSignIn
-                              : l10n.authCreateAccount),
+                          : Text(
+                              _isLogin
+                                  ? l10n.authSignIn
+                                  : l10n.authCreateAccount,
+                            ),
                     ),
                     if (!_isLogin) ...[
                       const SizedBox(height: 12),
@@ -257,9 +291,11 @@ class _AuthScreenState extends ConsumerState<AuthScreen> {
                     const SizedBox(height: 12),
                     TextButton(
                       onPressed: auth.loading ? null : _toggleMode,
-                      child: Text(_isLogin
-                          ? l10n.authNoAccountPrompt
-                          : l10n.authHaveAccountPrompt),
+                      child: Text(
+                        _isLogin
+                            ? l10n.authNoAccountPrompt
+                            : l10n.authHaveAccountPrompt,
+                      ),
                     ),
                     if (_isLogin)
                       TextButton(
@@ -282,16 +318,19 @@ class _AuthScreenState extends ConsumerState<AuthScreen> {
 class _RequestResetDialog extends StatefulWidget {
   final String initialEmail;
   final Future<void> Function(String email) onRequest;
-  const _RequestResetDialog(
-      {required this.initialEmail, required this.onRequest});
+  const _RequestResetDialog({
+    required this.initialEmail,
+    required this.onRequest,
+  });
 
   @override
   State<_RequestResetDialog> createState() => _RequestResetDialogState();
 }
 
 class _RequestResetDialogState extends State<_RequestResetDialog> {
-  late final TextEditingController _email =
-      TextEditingController(text: widget.initialEmail);
+  late final TextEditingController _email = TextEditingController(
+    text: widget.initialEmail,
+  );
   bool _sending = false;
   String? _error;
 

--- a/src/packages/flutter-app/test/auth_autofill_submit_test.dart
+++ b/src/packages/flutter-app/test/auth_autofill_submit_test.dart
@@ -31,8 +31,11 @@ class _FakeAuthService extends AuthService {
   }
 
   @override
-  Future<AuthResponse> register(String email, String password,
-      {String? displayName}) async {
+  Future<AuthResponse> register(
+    String email,
+    String password, {
+    String? displayName,
+  }) async {
     registerCalls.add((email, password));
     return AuthResponse(user: _user, token: 'tok');
   }
@@ -64,14 +67,13 @@ Widget _wrap(_FakeAuthService service) {
   );
 }
 
-Finder _fieldByLabel(String label) => find.ancestor(
-      of: find.text(label),
-      matching: find.byType(TextFormField),
-    );
+Finder _fieldByLabel(String label) =>
+    find.ancestor(of: find.text(label), matching: find.byType(TextFormField));
 
 void main() {
-  testWidgets('password-manager style double fill auto-submits sign-in',
-      (tester) async {
+  testWidgets('password-manager style double fill auto-submits sign-in', (
+    tester,
+  ) async {
     final service = _FakeAuthService();
     await tester.pumpWidget(_wrap(service));
     await tester.pump();
@@ -93,9 +95,56 @@ void main() {
 
     await tester.enterText(_fieldByLabel('Email'), 'brian@example.com');
     // The fill window compares wall-clock timestamps, so let real time pass
-    // (runAsync escapes the fake-async zone), well outside the 500ms window.
+    // (runAsync escapes the fake-async zone), well outside the 1500ms
+    // cross-field window.
     await tester.runAsync(
-        () => Future<void>.delayed(const Duration(milliseconds: 700)));
+      () => Future<void>.delayed(const Duration(milliseconds: 1800)),
+    );
+    await tester.enterText(_fieldByLabel('Password'), 'hunter2hunter2');
+    await tester.pump(const Duration(seconds: 1));
+
+    expect(service.loginCalls, isEmpty);
+  });
+
+  testWidgets('keystroke-simulated burst fill auto-submits', (tester) async {
+    final service = _FakeAuthService();
+    await tester.pumpWidget(_wrap(service));
+    await tester.pump();
+
+    // Some managers fill by simulating keystrokes: many change events,
+    // milliseconds apart. Type each field character-by-character with real
+    // ~10ms gaps — well inside the 400ms per-field burst window.
+    Future<void> burstType(String label, String value) async {
+      for (var i = 1; i <= value.length; i++) {
+        await tester.enterText(_fieldByLabel(label), value.substring(0, i));
+        await tester.runAsync(
+          () => Future<void>.delayed(const Duration(milliseconds: 10)),
+        );
+      }
+    }
+
+    await burstType('Email', 'b@c.io');
+    await burstType('Password', 'hunter2');
+    await tester.pump(const Duration(milliseconds: 500));
+    await tester.pumpAndSettle();
+
+    expect(service.loginCalls, [('b@c.io', 'hunter2')]);
+  });
+
+  testWidgets('slow per-char typing does not auto-submit', (tester) async {
+    final service = _FakeAuthService();
+    await tester.pumpWidget(_wrap(service));
+    await tester.pump();
+
+    // Human typing: characters spread past the 400ms burst window kill the
+    // field's fill signature even though it started fast.
+    const email = 'b@c.io';
+    for (var i = 1; i <= email.length; i++) {
+      await tester.enterText(_fieldByLabel('Email'), email.substring(0, i));
+      await tester.runAsync(
+        () => Future<void>.delayed(const Duration(milliseconds: 150)),
+      );
+    }
     await tester.enterText(_fieldByLabel('Password'), 'hunter2hunter2');
     await tester.pump(const Duration(seconds: 1));
 

--- a/src/packages/flutter-app/web/index.html
+++ b/src/packages/flutter-app/web/index.html
@@ -158,7 +158,7 @@
     // beneath, so a user click on a sibling still focuses the right
     // Flutter field.
     (function () {
-      console.info('[autofill] shim v3 active');
+      console.info('[autofill] shim v3.1 active');
       var diagnosed = new WeakSet();
       var forwarded = new WeakSet();
       function logFillEvent(e) {
@@ -217,6 +217,18 @@
             diagnosed.add(el);
             el.addEventListener('input', logFillEvent);
             el.addEventListener('change', logFillEvent);
+          }
+          // Chrome paints an opaque pale-blue -internal-autofill-selected
+          // background (and forces text color) on autofilled inputs — a UA
+          // style that ignores background:transparent, which turned filled
+          // fields into blue bars covering the canvas text. The endless
+          // background transition is the standard way to keep it from ever
+          // appearing; text-fill-color keeps the DOM text invisible so only
+          // the canvas-rendered text shows.
+          if (!el.style.transition) {
+            el.style.transition =
+                'background-color 600000s 0s, background-image 600000s 0s';
+            el.style.webkitTextFillColor = 'transparent';
           }
           var y = rect.top + (i - focusedIdx) * (rect.height + 40);
           if (el !== focused) {


### PR DESCRIPTION
## Summary
- Follow-up to #187, which got 1Password pair-filling both fields. Brian's screenshots showed two remaining issues — and confirmed the fill itself now works (canvas-rendered text peeks out from under the bar):
  1. **The "dark bar"**: Chrome paints its opaque pale-blue `-internal-autofill-selected` background on the autofilled invisible DOM input sitting above the canvas, hiding the real text. Fixed with the standard endless `background-color`/`background-image` transition (the UA style never gets to paint) plus `-webkit-text-fill-color: transparent`. Version marker bumped to `shim v3.1`.
  2. **No auto-submit**: 1Password delivers the fill as a rapid keystroke burst, not the single change event the #177 detector required. A field now counts as manager-filled when it goes empty→non-empty within a 400 ms burst regardless of event count; the cross-field window widens to 1500 ms for sequential fills.
- Safety: any new controller change cancels a pending auto-submit before the signature is re-evaluated (no mid-typing submits with partial passwords); 350 ms debounce lets the burst finish; sign-in-mode-only and consume-on-use guards unchanged.

## Testing
- `flutter test`: 420 pass, including new widget tests — keystroke-simulated burst auto-submits with the full values; slow per-char typing (150 ms gaps) stays inert; human-paced two-field entry (1.8 s apart) stays inert; one-shot fill still auto-submits; sign-up mode never does. `flutter analyze` clean for changed files.
- CDP battery on the dev stack (v3.1 injected): both fields carry the anti-highlight styles; both pass the ported Bitwarden viewability rules; email↔password click focus switching, typing, and caret clicks intact; simulated double-fill auto-submits ("invalid email or password" with no click).
- The UA autofill highlight itself can't be triggered synthetically — Brian's real-1Password test after deploy is the final check: both values visible (no blue bar) and automatic sign-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)