### PR TITLE
feat(ci): expose deployed release SHA + make the deploy job self-verify

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,6 +210,8 @@ jobs:
           tags: |
             ghcr.io/bdowe/goldentempo-gateway:latest
             ghcr.io/bdowe/goldentempo-gateway:${{ github.sha }}
+          build-args: |
+            GIT_SHA=${{ github.sha }}
           cache-from: type=gha,scope=gateway
           cache-to: type=gha,mode=max,scope=gateway
 
@@ -322,3 +324,31 @@ jobs:
             docker compose pull
             docker compose up -d --remove-orphans
             docker image prune -f"
+
+      # A green deploy should mean "this SHA is live and serving", not just
+      # "the restart script ran": poll the public site until both the api
+      # (health.release, baked from SENTRY_RELEASE) and the web build
+      # (/app/version.json, baked from GIT_SHA) report the deployed tag.
+      # No curl -f: a degraded-DB health still answers 503 WITH the release
+      # in the body, and that still proves which build is serving. The query
+      # string busts Cloudflare's edge cache for version.json. Note:
+      # rollbacks (workflow_dispatch) to images built before these markers
+      # existed will fail this step — deploy them with the pre-marker
+      # workflow revision if ever needed.
+      - name: Verify deployed release
+        if: steps.gate.outputs.configured == 'true'
+        run: |
+          for i in $(seq 1 30); do
+            api=$(curl -sS -m 10 "https://goldentempotravel.com/api/v1/health" \
+              | jq -r '.release // empty' 2>/dev/null || true)
+            web=$(curl -sS -m 10 "https://goldentempotravel.com/app/version.json?deploy=${IMAGE_TAG}" \
+              | jq -r '.release // empty' 2>/dev/null || true)
+            if [ "$api" = "$IMAGE_TAG" ] && [ "$web" = "$IMAGE_TAG" ]; then
+              echo "live: api and web both serving ${IMAGE_TAG}"
+              exit 0
+            fi
+            echo "waiting: api='${api:-?}' web='${web:-?}' want='${IMAGE_TAG}' (attempt $i/30)"
+            sleep 10
+          done
+          echo "::error::deployed release never became ${IMAGE_TAG}"
+          exit 1

--- a/dockerize/deployment/Dockerfile
+++ b/dockerize/deployment/Dockerfile
@@ -40,6 +40,16 @@ RUN flutter build web --release \
     --dart-define=API_BASE_URL=/api/v1 \
     --dart-define=APP_BASE_PATH=/app/
 
+# Release identifier for the web build, mirroring the api image's
+# SENTRY_RELEASE: CI passes the git SHA so /app/version.json answers
+# "which commit is this frontend?" (the deploy job verifies it). Flutter
+# already emits version.json (app_name/version/build_number) and nginx
+# already serves it no-cache — inject a release field into it rather than
+# clobbering, and fail the build if the injection missed.
+ARG GIT_SHA=
+RUN sed -i 's/}[[:space:]]*$/,"release":"'"${GIT_SHA}"'"}/' build/web/version.json \
+    && grep -q '"release"' build/web/version.json
+
 # Serve static files and proxy API via nginx
 FROM nginx:alpine
 

--- a/src/packages/api/main.go
+++ b/src/packages/api/main.go
@@ -29,6 +29,9 @@ type HealthResponse struct {
 	Timestamp time.Time `json:"timestamp"`
 	Service   string    `json:"service"`
 	Database  string    `json:"database"`
+	// Release is the git SHA this build was made from (SENTRY_RELEASE,
+	// baked into the image by CI) — lets "what's live?" be one curl.
+	Release string `json:"release,omitempty"`
 }
 
 // corsMiddleware adds CORS headers for origins listed in ALLOWED_ORIGINS
@@ -96,6 +99,7 @@ func healthHandler(w http.ResponseWriter, r *http.Request) {
 		Timestamp: time.Now(),
 		Service:   "travel-route-planner-api",
 		Database:  database,
+		Release:   os.Getenv("SENTRY_RELEASE"),
 	}
 
 	w.Header().Set("Content-Type", "application/json")


### PR DESCRIPTION
## Summary
- Answers "which commit is live?" directly:
  - `/api/v1/health` now reports `"release": "<git sha>"` — read from the `SENTRY_RELEASE` env the api image already bakes in at build time (`omitempty` locally).
  - The gateway build injects the same SHA as a `"release"` field into Flutter's existing `/app/version.json` (already on nginx's no-cache list; the build fails if the injection misses).
- The deploy job gains a final **Verify deployed release** step: polls the public site (up to 5 min) until both the api health and web version.json report the deployed tag. A green "Deploy to production" now means "this SHA is live and serving", not "the restart script ran". Plain curl (a degraded-DB 503 still carries the release in its body) + a cache-busting query for version.json through Cloudflare.
- Known limitation, noted inline: manual rollback (`workflow_dispatch`) to an image built *before* these markers existed would fail verification — deploy those with the pre-marker workflow revision if ever needed.

## Testing
- `go fmt` / `go vet` / `go build` / `go test ./...` all pass; workflow YAML parses.
- The sed injection verified against a real Flutter-shaped `version.json` (produces valid JSON with the release field; guarded by a grep in the Dockerfile).
- End-to-end proof is this PR's own deploy: the new verify step must pass for the run to go green, and afterwards `curl -s https://goldentempotravel.com/api/v1/health | jq .release` should equal the merge SHA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)