### PR TITLE
fix(web): relay silent password-manager value writes into the engine

### DIFF
--- a/src/packages/flutter-app/web/index.html
+++ b/src/packages/flutter-app/web/index.html
@@ -158,18 +158,55 @@
     // beneath, so a user click on a sibling still focuses the right
     // Flutter field.
     (function () {
-      console.info('[autofill] shim v3.1 active');
+      console.info('[autofill] shim v3.2 active');
       var diagnosed = new WeakSet();
       var forwarded = new WeakSet();
+      // Last value the engine is known to have ingested per input — kept in
+      // sync by the input listener below; the relay poll compares against it.
+      var lastSeen = new WeakMap();
       function logFillEvent(e) {
         // Verbose-level breadcrumbs for debugging real password-manager
         // behavior (DevTools console, "Verbose" filter, search "autofill").
+        lastSeen.set(e.target, e.target.value || '');
         console.debug('[autofill] ' + e.type +
             ' on ' + (e.target.getAttribute('autocomplete') || e.target.name) +
             ' len=' + (e.target.value || '').length +
             ' trusted=' + e.isTrusted +
             ' inputType=' + (e.inputType || '-'));
       }
+      // 1Password writes values into the inputs WITHOUT dispatching DOM
+      // events (Chrome still marks the fields autofilled, but Flutter's
+      // engine only ingests values via events, so the fill never reached
+      // Flutter state). Poll the autofill form's inputs and synthesize the
+      // input event for any value that changed with no event — the engine's
+      // own listener then ingests it. Duplicate delivery for event-ful
+      // writes is harmless: same-value updates are dropped app-side.
+      setInterval(function () {
+        var probe = document.querySelector(
+            'flt-text-editing-host form input, flt-text-editing-host form textarea');
+        if (!probe) return;
+        var fields = probe.form.querySelectorAll('input, textarea');
+        for (var i = 0; i < fields.length; i++) {
+          var el = fields[i];
+          if (el.type === 'submit') continue;
+          var value = el.value || '';
+          if (!lastSeen.has(el)) {
+            lastSeen.set(el, value);
+            continue;
+          }
+          if (lastSeen.get(el) === value) continue;
+          lastSeen.set(el, value);
+          console.debug('[autofill] relay silent write on ' +
+              (el.getAttribute('autocomplete') || el.name) +
+              ' len=' + value.length);
+          el.dispatchEvent(new InputEvent('input', {
+            bubbles: true,
+            composed: true,
+            inputType: 'insertReplacementText',
+            data: value,
+          }));
+        }
+      }, 200);
       // A pointer event landed on a non-focused autofill input. Cancel it
       // (also suppresses the compatibility mouse events) and re-dispatch a
       // clone at whatever the engine has under that point, found by


### PR DESCRIPTION
## Summary
- The final piece of the autofill saga. With the highlight suppressed (#203), the remaining fault became clear: **1Password writes values into the hidden DOM inputs without dispatching any DOM events** — Chrome marks the fields autofilled (the earlier "blue bars"), but Flutter's engine only ingests values via events, so the fill never reached Flutter state and auto-submit never triggered. The user's earlier "zero `[autofill]` console lines" observation was accurate all along.
- **Shim v3.2**: a 200 ms poll over the active autofill form compares each input's `.value` to the last value the engine is known to have seen (tracked via the existing input listener, so typing/IME/event-ful fills stay in sync and are never re-relayed) and synthesizes the `input` event for any silent write. Mechanism-independent — works for any password manager. Duplicate delivery is safe: same-value updates are dropped app-side (`value == prev` early return).
- Startup marker bumped to `shim v3.2 active`; relay dispatches log as `[autofill] relay silent write …` for future diagnosis.

## Testing
- CDP battery on the dev stack, injected v3.2: silent native-setter writes with **no events** into both inputs (the exact 1P mechanism) → exactly two relay dispatches → both values render on the canvas → the burst auto-submit fires by itself (~1.5 s, "invalid email or password" from bogus creds, zero clicks). Typing produced zero relay dispatches.
- `index.html` only; no Dart changes — the widget suite is untouched.
- Post-deploy (the #204 verify step gates the green check): console shows `shim v3.2 active`; picking a login from 1Password should now visibly fill both fields and sign in automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)