### PR TITLE
fix(sharing): make joined shared trips visible and un-blank the join landing

### DIFF
--- a/src/packages/flutter-app/lib/main.dart
+++ b/src/packages/flutter-app/lib/main.dart
@@ -29,6 +29,70 @@ void main() {
   );
 }
 
+/// A deep link boots on exactly its own route. The default
+/// onGenerateInitialRoutes expands `/share/x` into a stack of every path
+/// prefix (`/`, `/share`, `/share/x`); the prefixes hit the AuthGate
+/// catch-all, so a signed-in session mounts two AppShells whose tab
+/// navigators share the same GlobalKeys — the tree corrupts and the body
+/// renders blank.
+List<Route<dynamic>> generateInitialRoutes(String initialRoute) =>
+    [generateRoute(RouteSettings(name: initialRoute))];
+
+/// Route by URL so share links work signed-out. Everything else lands
+/// on AuthGate, preserving the existing splash -> landing/quiz/shell
+/// flow. Legacy /#/share links are rewritten by the index.html shim.
+Route<dynamic> generateRoute(RouteSettings settings) {
+  final uri = Uri.tryParse(settings.name ?? '/');
+  final segments = uri?.pathSegments ?? const <String>[];
+  if (segments.length == 2 && segments[0] == 'share') {
+    return MaterialPageRoute(
+      settings: settings,
+      builder: (_) => SharedTripScreen(token: segments[1]),
+    );
+  }
+  // Emailed co-planner invites (specs/invite-by-email); same screen,
+  // invite-token fetch + accept.
+  if (segments.length == 2 && segments[0] == 'invite') {
+    return MaterialPageRoute(
+      settings: settings,
+      builder: (_) => SharedTripScreen(
+          token: segments[1], linkKind: SharedLinkKind.invite),
+    );
+  }
+  if (segments.length == 2 && segments[0] == 'reset') {
+    return MaterialPageRoute(
+      settings: settings,
+      builder: (_) => ResetPasswordScreen(token: segments[1]),
+    );
+  }
+  if (segments.length == 2 && segments[0] == 'verify') {
+    return MaterialPageRoute(
+      settings: settings,
+      builder: (_) => VerifyEmailScreen(token: segments[1]),
+    );
+  }
+  // Landing spot for the Google sign-in redirect (specs/google-sso):
+  // /sso/<one-time code>, or /sso/error when the flow failed upstream.
+  if (segments.length == 2 && segments[0] == 'sso') {
+    return MaterialPageRoute(
+      settings: settings,
+      builder: (_) => SsoCallbackScreen(code: segments[1]),
+    );
+  }
+  // Price-alert emails deep-link here; the screen itself handles the
+  // signed-out case with a sign-in prompt.
+  if (segments.length == 1 && segments[0] == 'alerts') {
+    return MaterialPageRoute(
+      settings: settings,
+      builder: (_) => const AlertsScreen(),
+    );
+  }
+  return MaterialPageRoute(
+    settings: settings,
+    builder: (_) => const AuthGate(),
+  );
+}
+
 class TravelRoutePlannerApp extends ConsumerWidget {
   const TravelRoutePlannerApp({super.key});
 
@@ -51,60 +115,8 @@ class TravelRoutePlannerApp extends ConsumerWidget {
         GlobalWidgetsLocalizations.delegate,
         GlobalCupertinoLocalizations.delegate,
       ],
-      // Route by URL so share links work signed-out. Everything else lands
-      // on AuthGate, preserving the existing splash -> landing/quiz/shell
-      // flow. Legacy /#/share links are rewritten by the index.html shim.
-      onGenerateRoute: (settings) {
-        final uri = Uri.tryParse(settings.name ?? '/');
-        final segments = uri?.pathSegments ?? const <String>[];
-        if (segments.length == 2 && segments[0] == 'share') {
-          return MaterialPageRoute(
-            settings: settings,
-            builder: (_) => SharedTripScreen(token: segments[1]),
-          );
-        }
-        // Emailed co-planner invites (specs/invite-by-email); same screen,
-        // invite-token fetch + accept.
-        if (segments.length == 2 && segments[0] == 'invite') {
-          return MaterialPageRoute(
-            settings: settings,
-            builder: (_) => SharedTripScreen(
-                token: segments[1], linkKind: SharedLinkKind.invite),
-          );
-        }
-        if (segments.length == 2 && segments[0] == 'reset') {
-          return MaterialPageRoute(
-            settings: settings,
-            builder: (_) => ResetPasswordScreen(token: segments[1]),
-          );
-        }
-        if (segments.length == 2 && segments[0] == 'verify') {
-          return MaterialPageRoute(
-            settings: settings,
-            builder: (_) => VerifyEmailScreen(token: segments[1]),
-          );
-        }
-        // Landing spot for the Google sign-in redirect (specs/google-sso):
-        // /sso/<one-time code>, or /sso/error when the flow failed upstream.
-        if (segments.length == 2 && segments[0] == 'sso') {
-          return MaterialPageRoute(
-            settings: settings,
-            builder: (_) => SsoCallbackScreen(code: segments[1]),
-          );
-        }
-        // Price-alert emails deep-link here; the screen itself handles the
-        // signed-out case with a sign-in prompt.
-        if (segments.length == 1 && segments[0] == 'alerts') {
-          return MaterialPageRoute(
-            settings: settings,
-            builder: (_) => const AlertsScreen(),
-          );
-        }
-        return MaterialPageRoute(
-          settings: settings,
-          builder: (_) => const AuthGate(),
-        );
-      },
+      onGenerateRoute: generateRoute,
+      onGenerateInitialRoutes: generateInitialRoutes,
     );
   }
 }

--- a/src/packages/flutter-app/lib/screens/shared_trip_screen.dart
+++ b/src/packages/flutter-app/lib/screens/shared_trip_screen.dart
@@ -8,6 +8,7 @@ import '../models/trip.dart';
 import '../navigation/app_nav.dart';
 import '../providers/auth_provider.dart';
 import '../providers/shared_trip_provider.dart';
+import '../providers/shared_with_me_provider.dart';
 import '../providers/trips_provider.dart';
 import '../theme/spacing.dart';
 import '../utils/trip_days.dart';
@@ -144,14 +145,28 @@ class _SharedTripBodyState extends ConsumerState<_SharedTripBody> {
           ? await service.acceptInvite(widget.token)
           : await service.joinSharedTrip(widget.token);
       if (!mounted) return;
+      ref.invalidate(sharedWithMeProvider);
       ref.read(navIndexProvider.notifier).state = AppTab.trips.index;
-      Navigator.of(context).pushNamedAndRemoveUntil('/', (route) => false);
-      // Give the shell a frame to mount, then open the trip on the Trips tab.
+      // Read before navigating: pushNamedAndRemoveUntil disposes this state,
+      // so the callbacks below must not touch ref.
       final navKeys = ref.read(tabNavKeysProvider);
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        navKeys[AppTab.trips.index].currentState?.push(MaterialPageRoute(
-            builder: (_) => TripDetailScreen(tripId: tripId)));
-      });
+      Navigator.of(context).pushNamedAndRemoveUntil('/', (route) => false);
+      // The shell (and the Trips tab's nested navigator) remounts over the
+      // next frames; retry until it's attached rather than betting on one
+      // frame and silently dropping the push. If every attempt misses, the
+      // user still lands on the Trips tab where the joined trip now shows.
+      void openOnTripsTab([int attempts = 10]) {
+        final nav = navKeys[AppTab.trips.index].currentState;
+        if (nav != null) {
+          nav.push(MaterialPageRoute(
+              builder: (_) => TripDetailScreen(tripId: tripId)));
+        } else if (attempts > 0) {
+          WidgetsBinding.instance
+              .addPostFrameCallback((_) => openOnTripsTab(attempts - 1));
+        }
+      }
+
+      WidgetsBinding.instance.addPostFrameCallback((_) => openOnTripsTab());
     } catch (e) {
       if (mounted) showSnack(context, l10n.sharedJoinError('$e'));
     } finally {

--- a/src/packages/flutter-app/lib/screens/trips_list_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trips_list_screen.dart
@@ -35,6 +35,7 @@ class _TripsListScreenState extends ConsumerState<TripsListScreen> {
     WidgetsBinding.instance.addPostFrameCallback((_) {
       ref.read(tripsProvider.notifier).loadTrips();
       ref.invalidate(resumableChatsProvider);
+      ref.invalidate(sharedWithMeProvider);
     });
   }
 
@@ -45,6 +46,10 @@ class _TripsListScreenState extends ConsumerState<TripsListScreen> {
     final state = ref.watch(tripsProvider);
     final resumable =
         ref.watch(resumableChatsProvider).valueOrNull ?? const <ChatSessionSummary>[];
+    // Watched before the guard branches: an account whose only trips are
+    // shared-with-me must reach the list, not the plan-a-trip empty state.
+    final sharedAsync = ref.watch(sharedWithMeProvider);
+    final shared = sharedAsync.valueOrNull ?? const <Trip>[];
 
     // A conversation that just produced a saved trip graduates out of the
     // continue section — refetch when the agent reports a saved trip.
@@ -53,9 +58,15 @@ class _TripsListScreenState extends ConsumerState<TripsListScreen> {
     });
 
     Widget body;
-    if (state.loading && state.trips.isEmpty && resumable.isEmpty) {
+    if ((state.loading || sharedAsync.isLoading) &&
+        state.trips.isEmpty &&
+        resumable.isEmpty &&
+        shared.isEmpty) {
       body = const Center(child: CircularProgressIndicator());
-    } else if (state.error != null && state.trips.isEmpty && resumable.isEmpty) {
+    } else if (state.error != null &&
+        state.trips.isEmpty &&
+        resumable.isEmpty &&
+        shared.isEmpty) {
       body = EmptyState(
         icon: Icons.cloud_off,
         title: l10n.tripsListErrorTitle,
@@ -68,7 +79,7 @@ class _TripsListScreenState extends ConsumerState<TripsListScreen> {
           ),
         ],
       );
-    } else if (state.trips.isEmpty && resumable.isEmpty) {
+    } else if (state.trips.isEmpty && resumable.isEmpty && shared.isEmpty) {
       body = EmptyState(
         icon: Icons.luggage,
         title: l10n.tripsListEmptyTitle,
@@ -84,8 +95,6 @@ class _TripsListScreenState extends ConsumerState<TripsListScreen> {
       );
     } else {
       final isAdmin = ref.watch(authProvider).user?.isAdmin ?? false;
-      final shared =
-          ref.watch(sharedWithMeProvider).valueOrNull ?? const <Trip>[];
       final liveTrip = ref.watch(liveTripProvider);
       body = RefreshIndicator(
         onRefresh: () async {

--- a/src/packages/flutter-app/test/deep_link_initial_routes_test.dart
+++ b/src/packages/flutter-app/test/deep_link_initial_routes_test.dart
@@ -1,0 +1,26 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:travel_route_planner/main.dart';
+
+/// A deep link must boot on exactly one route. The framework default expands
+/// `/share/x` into a stack of every path prefix; the prefixes hit the
+/// AuthGate catch-all and a signed-in session then mounts two AppShells whose
+/// tab navigators collide on the same GlobalKeys (blank-screen tree
+/// corruption). Regression test for generateInitialRoutes.
+void main() {
+  test('deep links generate a single initial route', () {
+    for (final path in [
+      '/',
+      '/share/tok123',
+      '/invite/tok123',
+      '/reset/tok123',
+      '/verify/tok123',
+      '/sso/code123',
+      '/alerts',
+    ]) {
+      final routes = generateInitialRoutes(path);
+      expect(routes, hasLength(1), reason: 'path $path');
+      expect(routes.single.settings.name, path);
+    }
+  });
+}

--- a/src/packages/flutter-app/test/trips_list_shared_only_test.dart
+++ b/src/packages/flutter-app/test/trips_list_shared_only_test.dart
@@ -1,0 +1,77 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:travel_route_planner/models/trip.dart';
+import 'package:travel_route_planner/providers/resumable_chats_provider.dart';
+import 'package:travel_route_planner/providers/shared_with_me_provider.dart';
+import 'package:travel_route_planner/providers/trip_cache_provider.dart';
+import 'package:travel_route_planner/providers/trips_provider.dart';
+import 'package:travel_route_planner/screens/trips_list_screen.dart';
+import 'package:travel_route_planner/services/api_client.dart';
+import 'package:travel_route_planner/services/trip_cache.dart';
+import 'package:travel_route_planner/services/trips_api_service.dart';
+
+import 'support/l10n_test_app.dart';
+
+/// A recipient whose only trip is one shared with them must see the
+/// "Shared with you" section — not the plan-a-trip empty state. Regression
+/// test for the guard branches short-circuiting before the shared fetch.
+class _EmptyTripsApiService extends TripsApiService {
+  _EmptyTripsApiService() : super(ApiClient(baseUrl: 'http://test'));
+
+  @override
+  Future<List<Trip>> listTrips() async => const <Trip>[];
+}
+
+Trip _sharedTrip() => Trip(
+      id: 'shared-1',
+      title: 'Athens Together',
+      status: 'planned',
+      startDate: '2026-08-01',
+      endDate: '2026-08-05',
+      createdAt: '2026-06-01',
+      updatedAt: '2026-06-01',
+    );
+
+Future<void> _pumpList(WidgetTester tester, {required List<Trip> shared}) {
+  return tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        tripsApiServiceProvider.overrideWithValue(_EmptyTripsApiService()),
+        tripCacheProvider.overrideWithValue(TripCache('u1')),
+        resumableChatsProvider.overrideWith((ref) async => const []),
+        sharedWithMeProvider.overrideWith((ref) async => shared),
+      ],
+      child: MaterialApp(
+          localizationsDelegates: testLocalizationsDelegates,
+          home: TripsListScreen()),
+    ),
+  );
+}
+
+void main() {
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  testWidgets('shared-only account renders the Shared with you section',
+      (WidgetTester tester) async {
+    await _pumpList(tester, shared: [_sharedTrip()]);
+    await tester.pumpAndSettle();
+
+    expect(find.text('Shared with you'), findsOneWidget);
+    expect(find.text('Athens Together'), findsOneWidget);
+    expect(find.text('No trips yet'), findsNothing);
+  });
+
+  testWidgets('truly empty account still gets the plan-a-trip empty state',
+      (WidgetTester tester) async {
+    await _pumpList(tester, shared: const []);
+    await tester.pumpAndSettle();
+
+    expect(find.text('No trips yet'), findsOneWidget);
+    expect(find.text('Shared with you'), findsNothing);
+  });
+}


### PR DESCRIPTION
## Summary
- Deep links (`/share`, `/invite`, `/reset`, `/verify`, `/sso`) now boot on a **single** initial route: the framework default expanded `/share/x` into a stack of every path prefix, and the prefixes hit the AuthGate catch-all — a signed-in session mounted two AppShells whose tab navigators collided on the same GlobalKeys, corrupting the tree into a blank body (the reported "blank trips screen" after joining a shared trip).
- The trips list no longer short-circuits to the plan-a-trip empty state before watching `sharedWithMeProvider`: a recipient whose only trip is shared with them now sees the "Shared with you" section; the provider also refetches on screen mount.
- The post-join push of the trip detail retried-across-frames instead of betting on a single frame after the navigator teardown and silently no-opping; worst case it now degrades to the trips list, which shows the joined trip.

## Testing
- `flutter analyze` — clean (only the 12 pre-existing info lints).
- `flutter test` — all 423 pass, including 3 new regression tests (`deep_link_initial_routes_test.dart`, `trips_list_shared_only_test.dart`).
- Manual end-to-end on the dev stack (headless Chrome + CDP): fresh signed-out account opens a viewer share link → "Keep in my trips" → signs in → lands on the trip detail with zero console exceptions (previously: `Multiple widgets used the same GlobalKey` spam + blank body); backing out shows "Shared with you"; the owner's Manage access lists the viewer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)