### PR TITLE
feat(sharing): notify the owner when someone joins via a share link

### DIFF
--- a/src/packages/api/collaborator_handler.go
+++ b/src/packages/api/collaborator_handler.go
@@ -83,20 +83,28 @@ func joinSharedTripHandler(w http.ResponseWriter, r *http.Request) {
 		// Viewer tokens create a viewer "follow"; editor tokens (and an
 		// editor redeeming any link) yield editor — the upsert never
 		// downgrades.
-		role, err := store.New(dbPool).CreateTripCollaborator(r.Context(), store.CreateTripCollaboratorParams{
+		row, err := store.New(dbPool).CreateTripCollaborator(r.Context(), store.CreateTripCollaboratorParams{
 			ChatID: share.ChatID, OwnerID: share.OwnerID, UserID: user.ID, Role: share.Role,
 		})
 		if err != nil {
 			writeJSONError(w, http.StatusInternalServerError, "could not join trip")
 			return
 		}
-		access = role
+		access = row.Role
 		safeGo("recordEvent", func() {
 			recordEvent(user.ID, "collaborator_joined", &trip.ID, map[string]any{
 				"owner_id": share.OwnerID.String(),
-				"role":     role,
+				"role":     row.Role,
 			})
 		})
+		// Tell the owner on the first join only — the idempotent upsert
+		// reports whether this call created the membership, so re-opening
+		// the link (or the client retrying) never re-notifies.
+		if row.Inserted {
+			safeGo("notifyShareJoined", func() {
+				notifyShareJoined(share.OwnerID, user, trip, row.Role)
+			})
+		}
 	}
 	writeJSON(w, http.StatusOK, JoinSharedTripResponse{TripID: trip.ID.String(), Access: access})
 }

--- a/src/packages/api/notifications_writer.go
+++ b/src/packages/api/notifications_writer.go
@@ -80,3 +80,44 @@ func notifyInviteAccepted(ownerID uuid.UUID, accepter store.User, trip store.Tri
 		log.Printf("notifications: invite_accepted for owner %s failed: %v", ownerID, err)
 	}
 }
+
+// notifyShareJoined tells a trip owner that someone redeemed a share link.
+// Fired only on the join that actually created the membership (the upsert
+// reports inserted), so re-opening the link never re-notifies. The role rides
+// in the payload: viewer joins read as "is now following", editor joins as
+// "joined".
+func notifyShareJoined(ownerID uuid.UUID, joiner store.User, trip store.Trip, role string) {
+	if dbPool == nil {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// As in notifyInviteAccepted: the fallback label is read by the OWNER, so
+	// it renders in the owner's stored locale; the other values are payload
+	// keys and traveler data.
+	locale := defaultLocale
+	if owner, err := store.New(dbPool).GetUserByID(ctx, ownerID); err == nil {
+		locale = localeOrDefault(owner.Locale)
+	}
+	name := tr(locale, "notif.aTraveler")
+	if joiner.DisplayName != nil && *joiner.DisplayName != "" {
+		name = *joiner.DisplayName
+	}
+	payload, err := json.Marshal(map[string]string{
+		"joiner_name": name,
+		"trip_title":  trip.Title,
+		"role":        role,
+	})
+	if err != nil {
+		return
+	}
+	if _, err := store.New(dbPool).InsertNotification(ctx, store.InsertNotificationParams{
+		UserID:  ownerID,
+		Type:    "share_joined",
+		Payload: payload,
+		TripID:  pgtype.UUID{Bytes: trip.ID, Valid: true},
+	}); err != nil {
+		log.Printf("notifications: share_joined for owner %s failed: %v", ownerID, err)
+	}
+}

--- a/src/packages/api/notifications_writer_integration_test.go
+++ b/src/packages/api/notifications_writer_integration_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"testing"
 	"time"
@@ -171,5 +172,55 @@ func TestInviteAcceptNotifiesOwner(t *testing.T) {
 	// The accepter (friend) should not be notified.
 	if n := countNotificationsOfType(t, friend.ID, "invite_accepted"); n != 0 {
 		t.Fatalf("accepter invite_accepted = %d, want 0", n)
+	}
+}
+
+func TestShareJoinNotifiesOwnerOnce(t *testing.T) {
+	resetDB(t)
+	owner, ownerToken := createTestUser(t, "owner@example.com")
+	viewer, viewerToken := createTestUser(t, "viewer@example.com")
+	trip := createTestTrip(t, owner.ID, 1)
+	shareToken := createShare(t, ownerToken, trip.ID.String(), "viewer")
+
+	if rec := joinShare(t, viewerToken, shareToken); rec.Code != http.StatusOK {
+		t.Fatalf("join = %d: %s", rec.Code, rec.Body.String())
+	}
+	time.Sleep(300 * time.Millisecond)
+
+	notes := notificationsOfType(t, owner.ID, "share_joined")
+	if len(notes) != 1 {
+		t.Fatalf("owner share_joined = %d, want 1", len(notes))
+	}
+	if !notes[0].TripID.Valid || uuid.UUID(notes[0].TripID.Bytes) != trip.ID {
+		t.Fatalf("share_joined trip_id mismatch")
+	}
+	var payload map[string]string
+	if err := json.Unmarshal(notes[0].Payload, &payload); err != nil {
+		t.Fatalf("share_joined payload: %v", err)
+	}
+	if payload["role"] != "viewer" {
+		t.Fatalf("share_joined role = %q, want viewer", payload["role"])
+	}
+	// The joiner is not notified.
+	if n := countNotificationsOfType(t, viewer.ID, "share_joined"); n != 0 {
+		t.Fatalf("joiner share_joined = %d, want 0", n)
+	}
+
+	// Re-redeeming the link is idempotent and must NOT re-notify.
+	if rec := joinShare(t, viewerToken, shareToken); rec.Code != http.StatusOK {
+		t.Fatalf("re-join = %d: %s", rec.Code, rec.Body.String())
+	}
+	time.Sleep(300 * time.Millisecond)
+	if n := countNotificationsOfType(t, owner.ID, "share_joined"); n != 1 {
+		t.Fatalf("owner share_joined after re-join = %d, want 1 (unchanged)", n)
+	}
+
+	// An owner opening their own link never notifies.
+	if rec := joinShare(t, ownerToken, shareToken); rec.Code != http.StatusOK {
+		t.Fatalf("owner self-join = %d: %s", rec.Code, rec.Body.String())
+	}
+	time.Sleep(300 * time.Millisecond)
+	if n := countNotificationsOfType(t, owner.ID, "share_joined"); n != 1 {
+		t.Fatalf("owner share_joined after self-join = %d, want 1 (unchanged)", n)
 	}
 }

--- a/src/packages/api/query/collaborators.sql
+++ b/src/packages/api/query/collaborators.sql
@@ -1,13 +1,15 @@
 -- name: CreateTripCollaborator :one
 -- Idempotent join, upgrade-never-downgrade: redeeming an editor link (or
 -- invite) upgrades an existing viewer membership; redeeming a viewer link as
--- an editor keeps editor. Returns the resulting role.
+-- an editor keeps editor. Returns the resulting role plus whether this call
+-- created the membership (xmax = 0 only on a fresh insert), so callers can
+-- fire first-join-only side effects without re-notifying on every re-redeem.
 INSERT INTO trip_collaborators (chat_id, owner_id, user_id, role)
 VALUES ($1, $2, $3, $4)
 ON CONFLICT (owner_id, chat_id, user_id) WHERE revoked_at IS NULL
 DO UPDATE SET role = CASE WHEN EXCLUDED.role = 'editor' THEN 'editor'
                           ELSE trip_collaborators.role END
-RETURNING role;
+RETURNING role, (xmax = 0)::boolean AS inserted;
 
 -- name: ListCollaboratorsByOwnerAndChat :many
 SELECT c.user_id, c.created_at, c.role, u.email,

--- a/src/packages/api/store/collaborators.sql.go
+++ b/src/packages/api/store/collaborators.sql.go
@@ -19,7 +19,7 @@ VALUES ($1, $2, $3, $4)
 ON CONFLICT (owner_id, chat_id, user_id) WHERE revoked_at IS NULL
 DO UPDATE SET role = CASE WHEN EXCLUDED.role = 'editor' THEN 'editor'
                           ELSE trip_collaborators.role END
-RETURNING role
+RETURNING role, (xmax = 0)::boolean AS inserted
 `
 
 type CreateTripCollaboratorParams struct {
@@ -29,19 +29,26 @@ type CreateTripCollaboratorParams struct {
 	Role    string    `json:"role"`
 }
 
+type CreateTripCollaboratorRow struct {
+	Role     string `json:"role"`
+	Inserted bool   `json:"inserted"`
+}
+
 // Idempotent join, upgrade-never-downgrade: redeeming an editor link (or
 // invite) upgrades an existing viewer membership; redeeming a viewer link as
-// an editor keeps editor. Returns the resulting role.
-func (q *Queries) CreateTripCollaborator(ctx context.Context, arg CreateTripCollaboratorParams) (string, error) {
+// an editor keeps editor. Returns the resulting role plus whether this call
+// created the membership (xmax = 0 only on a fresh insert), so callers can
+// fire first-join-only side effects without re-notifying on every re-redeem.
+func (q *Queries) CreateTripCollaborator(ctx context.Context, arg CreateTripCollaboratorParams) (CreateTripCollaboratorRow, error) {
 	row := q.db.QueryRow(ctx, createTripCollaborator,
 		arg.ChatID,
 		arg.OwnerID,
 		arg.UserID,
 		arg.Role,
 	)
-	var role string
-	err := row.Scan(&role)
-	return role, err
+	var i CreateTripCollaboratorRow
+	err := row.Scan(&i.Role, &i.Inserted)
+	return i, err
 }
 
 const getEditableTripByID = `-- name: GetEditableTripByID :one

--- a/src/packages/flutter-app/lib/l10n/app_en.arb
+++ b/src/packages/flutter-app/lib/l10n/app_en.arb
@@ -1307,6 +1307,17 @@
       }
     }
   },
+  "notifFollowedTrip": "{who} is now following \"{trip}\"",
+  "@notifFollowedTrip": {
+    "placeholders": {
+      "who": {
+        "type": "String"
+      },
+      "trip": {
+        "type": "String"
+      }
+    }
+  },
   "notifEditedTrip": "{who} edited \"{trip}\"",
   "@notifEditedTrip": {
     "placeholders": {

--- a/src/packages/flutter-app/lib/l10n/app_es.arb
+++ b/src/packages/flutter-app/lib/l10n/app_es.arb
@@ -588,6 +588,7 @@
   "notifSomeone": "Alguien",
   "notifACollaborator": "Un colaborador",
   "notifJoinedTrip": "{who} se unió a «{trip}»",
+  "notifFollowedTrip": "{who} ahora sigue «{trip}»",
   "notifEditedTrip": "{who} editó «{trip}»",
   "sharedTitle": "Viaje compartido",
   "sharedUnavailableTitle": "Este enlace no está disponible",

--- a/src/packages/flutter-app/lib/l10n/app_localizations.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations.dart
@@ -3626,6 +3626,12 @@ abstract class AppLocalizations {
   /// **'{who} joined \"{trip}\"'**
   String notifJoinedTrip(String who, String trip);
 
+  /// No description provided for @notifFollowedTrip.
+  ///
+  /// In en, this message translates to:
+  /// **'{who} is now following \"{trip}\"'**
+  String notifFollowedTrip(String who, String trip);
+
   /// No description provided for @notifEditedTrip.
   ///
   /// In en, this message translates to:

--- a/src/packages/flutter-app/lib/l10n/app_localizations_en.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations_en.dart
@@ -2001,6 +2001,11 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String notifFollowedTrip(String who, String trip) {
+    return '$who is now following \"$trip\"';
+  }
+
+  @override
   String notifEditedTrip(String who, String trip) {
     return '$who edited \"$trip\"';
   }

--- a/src/packages/flutter-app/lib/l10n/app_localizations_es.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations_es.dart
@@ -2012,6 +2012,11 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
+  String notifFollowedTrip(String who, String trip) {
+    return '$who ahora sigue «$trip»';
+  }
+
+  @override
   String notifEditedTrip(String who, String trip) {
     return '$who editó «$trip»';
   }

--- a/src/packages/flutter-app/lib/screens/notification_center_screen.dart
+++ b/src/packages/flutter-app/lib/screens/notification_center_screen.dart
@@ -108,7 +108,7 @@ class _NotificationTile extends StatelessWidget {
     final content = switch (notification.type) {
       'price_drop' =>
         _PriceDropBody(payload: notification.payload, unread: unread),
-      'collab_edit' || 'invite_accepted' => _TripSignalBody(
+      'collab_edit' || 'invite_accepted' || 'share_joined' => _TripSignalBody(
           type: notification.type,
           payload: notification.payload,
           unread: unread,
@@ -306,9 +306,10 @@ class _GenericBody extends StatelessWidget {
 }
 
 /// Trip collaboration signals: a co-planner edited a shared trip
-/// (`collab_edit`) or someone accepted an invite (`invite_accepted`). Both read
-/// as "<who> <did what> <trip>" with a leading icon, built from the payload's
-/// actor/trip fields.
+/// (`collab_edit`), someone accepted an invite (`invite_accepted`), or someone
+/// redeemed a share link (`share_joined` — viewer joins read as "following").
+/// All read as "<who> <did what> <trip>" with a leading icon, built from the
+/// payload's actor/trip fields.
 class _TripSignalBody extends StatelessWidget {
   final String type;
   final Map<String, dynamic> payload;
@@ -334,6 +335,14 @@ class _TripSignalBody extends StatelessWidget {
           : l10n.notifSomeone;
       icon = Icons.group_add_outlined;
       headline = l10n.notifJoinedTrip(who, tripTitle);
+    } else if (type == 'share_joined') {
+      final who = payload['joiner_name'] is String
+          ? payload['joiner_name'] as String
+          : l10n.notifSomeone;
+      icon = Icons.group_add_outlined;
+      headline = payload['role'] == 'viewer'
+          ? l10n.notifFollowedTrip(who, tripTitle)
+          : l10n.notifJoinedTrip(who, tripTitle);
     } else {
       final who = payload['actor_name'] is String
           ? payload['actor_name'] as String

--- a/src/packages/flutter-app/test/notification_center_test.dart
+++ b/src/packages/flutter-app/test/notification_center_test.dart
@@ -185,6 +185,40 @@ void main() {
     expect(find.text('Bob joined "Lisbon"'), findsOneWidget);
   });
 
+  testWidgets('share_joined viewer renders "<who> is now following <trip>"',
+      (tester) async {
+    await _pump(tester, [
+      const AppNotification(
+        id: 's1',
+        type: 'share_joined',
+        payload: {
+          'joiner_name': 'Cara',
+          'trip_title': 'Naxos',
+          'role': 'viewer',
+        },
+        createdAt: '2026-07-16T12:00:00Z',
+      ),
+    ]);
+    expect(find.text('Cara is now following "Naxos"'), findsOneWidget);
+  });
+
+  testWidgets('share_joined editor renders "<who> joined <trip>"',
+      (tester) async {
+    await _pump(tester, [
+      const AppNotification(
+        id: 's2',
+        type: 'share_joined',
+        payload: {
+          'joiner_name': 'Dan',
+          'trip_title': 'Naxos',
+          'role': 'editor',
+        },
+        createdAt: '2026-07-16T12:00:00Z',
+      ),
+    ]);
+    expect(find.text('Dan joined "Naxos"'), findsOneWidget);
+  });
+
   testWidgets('unknown type with no title humanizes the type name',
       (tester) async {
     await _pump(tester, [


### PR DESCRIPTION
## Summary
- Follow-up to #206: share-link joins now write a `share_joined` notification for the trip owner (emailed invites already had `invite_accepted`; link joins only recorded analytics).
- `CreateTripCollaborator` additionally returns whether the upsert actually inserted (`xmax = 0`), and the handler notifies **only on the first join** — re-redeeming the link, client retries, and owner self-joins never notify.
- The notification center renders the new type through the existing trip-signal tile: viewer joins as `<who> is now following "<trip>"`, editor joins reuse the joined copy; English + Spanish, translation coverage stays complete (`l10n_untranslated.json` still `{}`).

## Testing
- `go vet` + full `go test ./...` against the local integration DB — pass, including new `TestShareJoinNotifiesOwnerOnce` (notify-once, joiner-not-notified, no re-notify on re-join, no notify on owner self-join).
- `flutter analyze` — clean (only the 12 pre-existing info lints); full `flutter test` — all pass, including two new widget tests for the viewer/editor renderings.
- `make api-sqlc` regenerated `store/` with no drift beyond the changed query.

🤖 Generated with [Claude Code](https://claude.com/claude-code)