### PR TITLE
feat(flutter): trips list declutter — 700px column + SectionHeader titles

### DIFF
--- a/src/packages/flutter-app/lib/screens/trips_list_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trips_list_screen.dart
@@ -10,6 +10,8 @@ import '../widgets/empty_state.dart';
 import '../widgets/gradient_app_bar.dart';
 import '../widgets/live_trip_card.dart';
 import '../widgets/offline_banner.dart';
+import '../widgets/page_container.dart';
+import '../widgets/section_header.dart';
 import '../widgets/status_pill.dart';
 import '../models/chat_session.dart';
 import '../models/trip.dart';
@@ -105,49 +107,60 @@ class _TripsListScreenState extends ConsumerState<TripsListScreen> {
         child: ListView(
           padding: const EdgeInsets.all(AppSpacing.md),
           children: [
-            // The trip happening today, promoted to the very top as a
-            // one-tap shortcut (specs/happening-now). It also stays in
-            // "My Trips" below — this is a spotlight, not a filter.
-            if (liveTrip != null)
-              Padding(
-                padding: const EdgeInsets.only(bottom: AppSpacing.lg),
-                child: LiveTripCard(
-                  trip: liveTrip,
-                  onTap: () => _openTrip(context, liveTrip.id),
-                ),
+            // Centered 700px column on wide layouts, Home's exact pattern:
+            // the ListView stays full-width (wheel/scrollbar work in the
+            // gutters) while the content is capped. Non-lazy is fine at
+            // trips-list sizes, same trade Home makes.
+            PageContainer(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  // The trip happening today, promoted to the very top as a
+                  // one-tap shortcut (specs/happening-now). It also stays in
+                  // "My Trips" below — this is a spotlight, not a filter.
+                  if (liveTrip != null)
+                    Padding(
+                      padding: const EdgeInsets.only(bottom: AppSpacing.lg),
+                      child: LiveTripCard(
+                        trip: liveTrip,
+                        onTap: () => _openTrip(context, liveTrip.id),
+                      ),
+                    ),
+                  // In-progress AI conversations that haven't produced a
+                  // trip yet (specs/continue-where-you-left-off) — the
+                  // discussion phase, above the trips they may become.
+                  if (resumable.isNotEmpty) ...[
+                    Padding(
+                      padding: const EdgeInsets.fromLTRB(
+                          AppSpacing.xs, 0, 0, AppSpacing.sm),
+                      child: SectionHeader(title: l10n.continueChatsTitle),
+                    ),
+                    for (final c in resumable) ContinueChatCard(chat: c),
+                    if (state.trips.isNotEmpty)
+                      Padding(
+                        padding: const EdgeInsets.fromLTRB(
+                            AppSpacing.xs, AppSpacing.lg, 0, AppSpacing.sm),
+                        child: SectionHeader(title: l10n.tripsListTitle),
+                      ),
+                  ],
+                  for (final t in state.trips)
+                    _TripCard(trip: t, isAdmin: isAdmin),
+                  // Trips others invited this user to co-plan. Kept as a
+                  // separate section: "mine" vs "shared with me" is the
+                  // mental model, and the card shows the owner instead of
+                  // admin version chrome.
+                  if (shared.isNotEmpty) ...[
+                    Padding(
+                      padding: const EdgeInsets.fromLTRB(
+                          AppSpacing.xs, AppSpacing.lg, 0, AppSpacing.sm),
+                      child:
+                          SectionHeader(title: l10n.tripsListSharedWithYou),
+                    ),
+                    for (final t in shared) _TripCard(trip: t, isAdmin: false),
+                  ],
+                ],
               ),
-            // In-progress AI conversations that haven't produced a trip yet
-            // (specs/continue-where-you-left-off) — the discussion phase,
-            // above the trips they may become.
-            if (resumable.isNotEmpty) ...[
-              Padding(
-                padding: const EdgeInsets.fromLTRB(
-                    AppSpacing.xs, 0, 0, AppSpacing.sm),
-                child: Text(l10n.continueChatsTitle,
-                    style: theme.textTheme.titleMedium),
-              ),
-              for (final c in resumable) ContinueChatCard(chat: c),
-              if (state.trips.isNotEmpty)
-                Padding(
-                  padding: const EdgeInsets.fromLTRB(
-                      AppSpacing.xs, AppSpacing.lg, 0, AppSpacing.sm),
-                  child: Text(l10n.tripsListTitle,
-                      style: theme.textTheme.titleMedium),
-                ),
-            ],
-            for (final t in state.trips) _TripCard(trip: t, isAdmin: isAdmin),
-            // Trips others invited this user to co-plan. Kept as a separate
-            // section: "mine" vs "shared with me" is the mental model, and
-            // the card shows the owner instead of admin version chrome.
-            if (shared.isNotEmpty) ...[
-              Padding(
-                padding: const EdgeInsets.fromLTRB(
-                    AppSpacing.xs, AppSpacing.lg, 0, AppSpacing.sm),
-                child: Text(l10n.tripsListSharedWithYou,
-                    style: theme.textTheme.titleMedium),
-              ),
-              for (final t in shared) _TripCard(trip: t, isAdmin: false),
-            ],
+            ),
           ],
         ),
       );

--- a/src/packages/flutter-app/test/trips_list_live_test.dart
+++ b/src/packages/flutter-app/test/trips_list_live_test.dart
@@ -188,4 +188,28 @@ void main() {
     expect(find.byType(LiveTripCard), findsOneWidget);
     expect(find.text('Day 2 of 3'), findsOneWidget);
   });
+
+  testWidgets('wide layouts cap the list content at 700px, phones fill',
+      (WidgetTester tester) async {
+    final service = _QueuedTripsApiService([
+      [_trip('t1', 'Lisbon Trip', start: _rel(30), end: _rel(33))],
+    ]);
+
+    await tester.binding.setSurfaceSize(const Size(1200, 900));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    await _pumpList(tester, service);
+    await tester.pumpAndSettle();
+
+    final wideCard = tester.getSize(find.byType(Card).first);
+    expect(wideCard.width, lessThanOrEqualTo(700));
+    // Centered: symmetric gutters.
+    final left = tester.getTopLeft(find.byType(Card).first).dx;
+    final right = 1200 - tester.getTopRight(find.byType(Card).first).dx;
+    expect((left - right).abs(), lessThan(2));
+
+    await tester.binding.setSurfaceSize(const Size(390, 844));
+    await tester.pumpAndSettle();
+    final phoneCard = tester.getSize(find.byType(Card).first);
+    expect(phoneCard.width, greaterThan(340)); // full width minus padding
+  });
 }


### PR DESCRIPTION
Third declutter pass (after trip-detail desktop #212/#213 and mobile #216). Smallest of the three by design — this page was already structurally lean.

- **Desktop width cap**: the trips list was the last main screen stretching edge-to-edge. Its ListView content now sits in `PageContainer` (Home's exact pattern; the widget's doc comment already named trips list as an intended adopter) — centered 700px column, scrollable stays full-width so wheel/scrollbar work in the gutters.
- **Section titles** ("Continue where you left off" / "My Trips" / "Shared with you") switch from plain `Text(titleMedium)` to the shared `SectionHeader`, matching every other screen.
- Everything else untouched per Brian's call to keep the elevated-card language: LiveTripCard, ContinueChatCard, trip cards (incl. admin version expansion), StatusPill/date chips, empty/error/offline states.

## Verification
- `flutter analyze` clean; **468/468 tests** (new width-guard case: content ≤700px and symmetrically centered at 1200×900, full-width at 390).
- Dev-stack browser pass: 1440 shows the centered column (Live card + trip cards capped together); 390 identical to before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)