### PR TITLE
feat(flutter): home declutter — compact plan strip for returning users

### DIFF
--- a/src/packages/flutter-app/lib/screens/home_screen.dart
+++ b/src/packages/flutter-app/lib/screens/home_screen.dart
@@ -8,6 +8,8 @@ import '../providers/live_trip_provider.dart';
 import '../providers/local_provider.dart';
 import '../providers/plan_provider.dart';
 import '../providers/recent_trip_provider.dart';
+import '../providers/resumable_chats_provider.dart';
+import '../providers/trips_provider.dart';
 import '../navigation/app_nav.dart';
 import '../theme/app_colors.dart';
 import '../theme/app_shadows.dart';
@@ -53,6 +55,14 @@ class HomeScreen extends ConsumerWidget {
     // Populated app-wide: AppShell's IndexedStack keeps TripsListScreen
     // mounted, and its loadTrips() feeds tripsProvider — no fetch from here.
     final liveTrip = ref.watch(liveTripProvider);
+    // Returning users (anything to come back to) get the compact plan strip
+    // instead of the 440px photo hero, so their trips sit above the fold.
+    // While providers are still loading this reads false and the full hero
+    // shows briefly — same async-appearance behavior as LiveTripCard.
+    final returning = liveTrip != null ||
+        recentTrip != null ||
+        ref.watch(tripsProvider).trips.isNotEmpty ||
+        (ref.watch(resumableChatsProvider).valueOrNull?.isNotEmpty ?? false);
 
     // The chat is a persistent tab, so "Let's go" / a suggestion switches to it
     // (and seeds the message) rather than pushing a one-off screen.
@@ -107,10 +117,15 @@ class HomeScreen extends ConsumerWidget {
 
                 const SizedBox(height: 16),
 
-                // AI Travel Agent hero card
-                _AgentHeroCard(onStart: startPlanning),
+                // AI Travel Agent entry: the full photo hero sells the
+                // product to a brand-new account; returning users get a slim
+                // strip with the same CTA so their trips stay above the fold.
+                if (returning)
+                  _PlanStrip(onStart: startPlanning)
+                else
+                  _AgentHeroCard(onStart: startPlanning),
 
-                const SizedBox(height: 28),
+                SizedBox(height: returning ? AppSpacing.lg : 28),
 
                 // The trip happening today (specs/happening-now), then the
                 // most recently viewed trip — the latter hidden when it *is*
@@ -155,6 +170,83 @@ class HomeScreen extends ConsumerWidget {
                 const _LocalGuidesRow(),
 
                 const SizedBox(height: 16),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Compact sibling of [_AgentHeroCard] for returning users: one gradient
+/// row — icon, headline, CTA — in the same card language as
+/// [_RecentTripCard]/[LiveTripCard]. No photo, no suggestion chips; the Plan
+/// tab has free input.
+class _PlanStrip extends StatelessWidget {
+  final void Function({String? initialMessage}) onStart;
+
+  const _PlanStrip({required this.onStart});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final l10n = context.l10n;
+    return Container(
+      decoration: BoxDecoration(
+        borderRadius: AppRadius.mdAll,
+        gradient: AppColors.brandGradient,
+        boxShadow: [
+          BoxShadow(
+            color: AppColors.brandDark.withValues(alpha: 0.3),
+            blurRadius: 10,
+            offset: const Offset(0, 4),
+          ),
+        ],
+      ),
+      child: Material(
+        color: Colors.transparent,
+        child: InkWell(
+          onTap: () => onStart(),
+          borderRadius: AppRadius.mdAll,
+          child: Padding(
+            padding: const EdgeInsets.all(AppSpacing.lg),
+            child: Row(
+              children: [
+                Container(
+                  padding: const EdgeInsets.all(AppSpacing.sm + 2),
+                  decoration: BoxDecoration(
+                    color: Colors.white.withValues(alpha: 0.15),
+                    shape: BoxShape.circle,
+                  ),
+                  child: const Icon(Icons.flight_takeoff,
+                      color: Colors.white, size: 26),
+                ),
+                const SizedBox(width: AppSpacing.lg),
+                Expanded(
+                  child: Text(
+                    l10n.homeHeroTitle,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: theme.textTheme.titleMedium?.copyWith(
+                      fontWeight: FontWeight.bold,
+                      color: Colors.white,
+                    ),
+                  ),
+                ),
+                const SizedBox(width: AppSpacing.md),
+                FilledButton(
+                  onPressed: () => onStart(),
+                  style: FilledButton.styleFrom(
+                    backgroundColor: Colors.white,
+                    foregroundColor: AppColors.brandDark,
+                    visualDensity: VisualDensity.compact,
+                  ),
+                  child: Text(
+                    l10n.homeHeroCta,
+                    style: const TextStyle(fontWeight: FontWeight.bold),
+                  ),
+                ),
               ],
             ),
           ),

--- a/src/packages/flutter-app/test/home_plan_strip_test.dart
+++ b/src/packages/flutter-app/test/home_plan_strip_test.dart
@@ -1,0 +1,137 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:travel_route_planner/models/trip.dart';
+import 'package:travel_route_planner/models/user.dart';
+import 'package:travel_route_planner/navigation/app_nav.dart';
+import 'package:travel_route_planner/providers/auth_provider.dart';
+import 'package:travel_route_planner/providers/live_trip_provider.dart';
+import 'package:travel_route_planner/providers/resumable_chats_provider.dart';
+import 'package:travel_route_planner/screens/home_screen.dart';
+
+import 'support/l10n_test_app.dart';
+
+/// Home hero split (home declutter): brand-new accounts get the full photo
+/// hero with suggestion chips; returning users (any trip or in-progress
+/// chat) get the compact one-row plan strip so trips sit above the fold.
+class _FakeAuthNotifier extends StateNotifier<AuthState>
+    implements AuthNotifier {
+  _FakeAuthNotifier(UserModel? user)
+      : super(AuthState(user: user, initialized: true));
+
+  @override
+  Future<bool> login(String email, String password) async => false;
+
+  @override
+  Future<bool> register(String email, String password,
+          {String? displayName}) async =>
+      false;
+
+  @override
+  Future<void> completeOnboarding() async {}
+
+  @override
+  Future<void> logout() async {}
+
+  @override
+  Future<void> signOutLocally() async {}
+
+  @override
+  void setUser(UserModel user) {}
+
+  @override
+  Future<void> adoptSession(String token, UserModel user) async {}
+}
+
+UserModel _user() => UserModel(
+      id: 'user-1',
+      email: 'test@example.com',
+      displayName: 'Brian',
+      createdAt: DateTime(2026, 1, 1),
+    );
+
+String _iso(DateTime d) =>
+    '${d.year.toString().padLeft(4, '0')}-'
+    '${d.month.toString().padLeft(2, '0')}-'
+    '${d.day.toString().padLeft(2, '0')}';
+
+Trip _liveTrip() => Trip(
+      id: 't1',
+      title: 'Athens Trip',
+      status: 'planned',
+      startDate: _iso(DateTime.now().subtract(const Duration(days: 1))),
+      endDate: _iso(DateTime.now().add(const Duration(days: 1))),
+      createdAt: '2026-06-01',
+      updatedAt: '2026-06-01',
+    );
+
+Future<void> _pumpHome(WidgetTester tester, {Trip? liveTrip}) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        authProvider.overrideWith((ref) => _FakeAuthNotifier(_user())),
+        liveTripProvider.overrideWithValue(liveTrip),
+        resumableChatsProvider.overrideWith((ref) async => const []),
+      ],
+      child: MaterialApp(
+          localizationsDelegates: testLocalizationsDelegates,
+          home: const HomeScreen()),
+    ),
+  );
+  // Extra pumps flush the SharedPreferences read behind recentTripProvider.
+  await tester.pump();
+  await tester.pump();
+}
+
+void main() {
+  testWidgets('empty account keeps the full photo hero',
+      (WidgetTester tester) async {
+    SharedPreferences.setMockInitialValues({});
+    await _pumpHome(tester);
+
+    expect(find.text('Plan less. Travel more.'), findsOneWidget);
+    expect(find.text('2 days in Paris'), findsOneWidget); // suggestion chips
+    expect(find.byType(Image), findsWidgets); // photo hero present
+  });
+
+  testWidgets('live trip swaps the hero for the compact plan strip',
+      (WidgetTester tester) async {
+    SharedPreferences.setMockInitialValues({});
+    await _pumpHome(tester, liveTrip: _liveTrip());
+
+    // Same headline + CTA, no photo, no suggestion chips.
+    expect(find.text('Plan less. Travel more.'), findsOneWidget);
+    expect(find.text("Let's go"), findsOneWidget);
+    expect(find.text('2 days in Paris'), findsNothing);
+    expect(find.byIcon(Icons.flight_takeoff), findsOneWidget);
+  });
+
+  testWidgets('strip CTA still switches to the Plan tab',
+      (WidgetTester tester) async {
+    SharedPreferences.setMockInitialValues({});
+    late final ProviderContainer container;
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          authProvider.overrideWith((ref) => _FakeAuthNotifier(_user())),
+          liveTripProvider.overrideWithValue(_liveTrip()),
+          resumableChatsProvider.overrideWith((ref) async => const []),
+        ],
+        child: Builder(builder: (context) {
+          container = ProviderScope.containerOf(context);
+          return MaterialApp(
+              localizationsDelegates: testLocalizationsDelegates,
+              home: const HomeScreen());
+        }),
+      ),
+    );
+    await tester.pump();
+    await tester.pump();
+
+    await tester.tap(find.text("Let's go"));
+    await tester.pump();
+    expect(container.read(navIndexProvider), AppTab.plan.index);
+  });
+}


### PR DESCRIPTION
Fourth declutter pass (trip detail #212/#213, mobile #216, trips list #217). Home was already width-capped and SectionHeader-consistent — its one heavy element was the 440px photo hero, which pushed a returning user's live trip / continue-chats / recent trip below the fold (greeting + hero filled an entire phone viewport).

- **Returning users** (any live/recent trip, saved trips, or in-progress chats — read from providers AppShell already populates) get a slim one-row gradient **plan strip**: icon + "Plan less. Travel more." + **Let's go**, in the same card language as LiveTripCard/RecentTripCard. No photo, no suggestion chips.
- **New/empty accounts keep the full photo hero unchanged** — it's the first-run pitch and stays exactly as designed.
- Reuses `homeHeroTitle`/`homeHeroCta` — zero new ARB strings. While providers load, the full hero shows briefly and swaps when content arrives (same async-appearance behavior as LiveTripCard today).

## Verification
- `flutter analyze` clean; **471/471 tests** (new `home_plan_strip_test`: empty → hero + chips; live trip → strip without chips/photo, CTA still switches to the Plan tab; all existing home tests untouched).
- Dev-stack browser pass: seeded account at 1440 and 390 → greeting + strip + Happening-Now card all above the fold; fresh account through onboarding-skip → full Santorini hero identical to today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)