### PR TITLE
feat(flutter): shared trip page declutter — 700px column + SectionHeader

### DIFF
--- a/src/packages/flutter-app/lib/screens/shared_trip_screen.dart
+++ b/src/packages/flutter-app/lib/screens/shared_trip_screen.dart
@@ -14,6 +14,8 @@ import '../theme/spacing.dart';
 import '../utils/trip_days.dart';
 import '../utils/trip_format.dart';
 import '../widgets/empty_state.dart';
+import '../widgets/page_container.dart';
+import '../widgets/section_header.dart';
 import '../widgets/gradient_app_bar.dart';
 import '../widgets/map_day_chips.dart';
 import '../widgets/trip_map.dart';
@@ -232,6 +234,13 @@ class _SharedTripBodyState extends ConsumerState<_SharedTripBody> {
           padding: const EdgeInsets.fromLTRB(
               AppSpacing.lg, AppSpacing.lg, AppSpacing.lg, 96),
           children: [
+            // Centered 700px column on wide layouts (declutter series):
+            // the ListView stays full-width (wheel/scrollbar work in the
+            // gutters) while the content is capped, same as the trips list.
+            PageContainer(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
             Text(trip.title, style: theme.textTheme.headlineSmall),
             const SizedBox(height: AppSpacing.xs),
             Text(
@@ -335,7 +344,7 @@ class _SharedTripBodyState extends ConsumerState<_SharedTripBody> {
               ],
             if ((trip.accommodations ?? const []).isNotEmpty) ...[
               const SizedBox(height: AppSpacing.lg),
-              Text(l10n.sharedStays, style: theme.textTheme.titleMedium),
+              SectionHeader(title: l10n.sharedStays),
               for (final a in trip.accommodations!)
                 ListTile(
                   contentPadding: EdgeInsets.zero,
@@ -344,6 +353,9 @@ class _SharedTripBodyState extends ConsumerState<_SharedTripBody> {
                   subtitle: a.address != null ? Text(a.address!) : null,
                 ),
             ],
+                ],
+              ),
+            ),
           ],
         ),
         Positioned(
@@ -353,8 +365,11 @@ class _SharedTripBodyState extends ConsumerState<_SharedTripBody> {
           child: Container(
             padding: const EdgeInsets.all(AppSpacing.md),
             color: theme.scaffoldBackgroundColor,
+            // Background stays full-bleed over the scroll edge; the buttons
+            // cap to the same 700px column as the content above.
             child: SafeArea(
-              child: widget.shared.isEditorLink
+              child: PageContainer(
+                child: widget.shared.isEditorLink
                   ? Column(
                       mainAxisSize: MainAxisSize.min,
                       crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -405,6 +420,7 @@ class _SharedTripBodyState extends ConsumerState<_SharedTripBody> {
                         ),
                       ],
                     ),
+              ),
             ),
           ),
         ),

--- a/src/packages/flutter-app/test/shared_trip_width_test.dart
+++ b/src/packages/flutter-app/test/shared_trip_width_test.dart
@@ -1,0 +1,96 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:travel_route_planner/models/accommodation.dart';
+import 'package:travel_route_planner/models/itinerary_item.dart';
+import 'package:travel_route_planner/models/shared_trip.dart';
+import 'package:travel_route_planner/models/trip.dart';
+import 'package:travel_route_planner/providers/trips_provider.dart';
+import 'package:travel_route_planner/screens/shared_trip_screen.dart';
+import 'package:travel_route_planner/services/api_client.dart';
+import 'package:travel_route_planner/services/trips_api_service.dart';
+
+import 'support/l10n_test_app.dart';
+
+/// Declutter series: the public shared-trip page caps its content (and the
+/// pinned bottom action bar's buttons) at PageContainer's 700px on wide
+/// layouts, while phones keep the full-width layout.
+class _FakeTripsApiService extends TripsApiService {
+  final SharedTrip shared;
+  _FakeTripsApiService(this.shared) : super(ApiClient(baseUrl: 'http://test'));
+
+  @override
+  Future<SharedTrip> getSharedTrip(String token) async => shared;
+}
+
+Trip _trip() => Trip(
+      id: 't1',
+      title: 'Lisbon long weekend',
+      status: 'planned',
+      createdAt: '2026-06-01',
+      updatedAt: '2026-06-01',
+      items: [
+        ItineraryItem(
+          id: 'i0',
+          position: 0,
+          name: 'Castelo de São Jorge',
+          address: 'R. de Santa Cruz do Castelo, Lisboa',
+          latitude: 0,
+          longitude: 0,
+          category: 'attraction',
+          day: 1,
+          city: 'Lisboa',
+        ),
+      ],
+      accommodations: const [
+        Accommodation(id: 'a1', name: 'Alfama Guesthouse'),
+      ],
+    );
+
+Future<void> _pump(WidgetTester tester, {required Size surface}) async {
+  await tester.binding.setSurfaceSize(surface);
+  addTearDown(() => tester.binding.setSurfaceSize(null));
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        tripsApiServiceProvider.overrideWithValue(
+            _FakeTripsApiService(SharedTrip(trip: _trip(), ownerName: 'Ann'))),
+      ],
+      child: MaterialApp(
+          localizationsDelegates: testLocalizationsDelegates,
+          home: const SharedTripScreen(token: 'tok')),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  testWidgets('wide layouts cap content and bottom-bar buttons at 700px',
+      (tester) async {
+    await _pump(tester, surface: const Size(1200, 900));
+
+    final row = find.byType(ListTile).first;
+    expect(tester.getSize(row).width, lessThanOrEqualTo(700));
+    // Centered: symmetric gutters.
+    final left = tester.getTopLeft(row).dx;
+    final right = 1200 - tester.getTopRight(row).dx;
+    expect((left - right).abs(), lessThan(2));
+
+    // The pinned action bar's primary button shares the same column.
+    // (FilledButton.icon builds a private subclass — bySubtype, not byType.)
+    final button = find.bySubtype<FilledButton>().first;
+    expect(tester.getSize(button).width, lessThanOrEqualTo(700));
+    final bLeft = tester.getTopLeft(button).dx;
+    final bRight = 1200 - tester.getTopRight(button).dx;
+    expect((bLeft - bRight).abs(), lessThan(2));
+  });
+
+  testWidgets('phones keep the full-width layout', (tester) async {
+    await _pump(tester, surface: const Size(390, 844));
+    expect(tester.getSize(find.byType(ListTile).first).width,
+        greaterThan(340));
+    expect(tester.getSize(find.bySubtype<FilledButton>().first).width,
+        greaterThan(340));
+  });
+}


### PR DESCRIPTION
Declutter finale, PR 1 of 3. The public share/invite landing page was the highest-value remaining gap — it's the first thing invitees see, and it was the last outward-facing screen with no desktop width cap.

- List content wraps in `PageContainer` (700px, trips-list pattern — scrollable stays full-width).
- The pinned join/save bar keeps its full-bleed background but caps its **buttons** to the same column, so everything aligns at desktop widths.
- "Stays" title → shared `SectionHeader`; the primary-tinted city group headers deliberately stay (they mirror trip detail's locality grouping, second-level hierarchy, no trailing action).
- Zero string changes. All three link-kind bottom bars (editor / viewer / invite) render inside the single new wrap.

## Verification
`flutter analyze` clean; full suite green incl. new `shared_trip_width_test` (content + primary button ≤700px and symmetrically centered at 1200×900; full-width at 390×844); existing `stays_only_map_gate_test` + `shared_trip_day_chips_test` untouched and green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)