### PR TITLE
feat(flutter): secondary width sweep — preferences, flight search, guide reader

### DIFF
--- a/src/packages/flutter-app/lib/screens/flight_search_screen.dart
+++ b/src/packages/flutter-app/lib/screens/flight_search_screen.dart
@@ -7,6 +7,7 @@ import '../providers/auth_provider.dart';
 import '../providers/flights_provider.dart';
 import '../providers/preferences_provider.dart';
 import '../widgets/airport_field.dart';
+import '../widgets/page_container.dart';
 import '../widgets/create_alert_sheet.dart';
 import '../widgets/flight_offer_card.dart';
 import '../widgets/gradient_app_bar.dart';
@@ -136,9 +137,10 @@ class _FlightSearchScreenState extends ConsumerState<FlightSearchScreen> {
 
     // Resolve origin and destination concurrently so a slow/failed lookup on one
     // side doesn't delay or blank the other. Each result is applied on its own.
-    final originFuture = (w.prefillOrigin != null && w.prefillOrigin!.isNotEmpty)
-        ? _resolve(w.prefillOrigin!, coord: w.prefillOriginCoord)
-        : _homeAirportSeed();
+    final originFuture =
+        (w.prefillOrigin != null && w.prefillOrigin!.isNotEmpty)
+            ? _resolve(w.prefillOrigin!, coord: w.prefillOriginCoord)
+            : _homeAirportSeed();
     final destFuture =
         (w.prefillDestination != null && w.prefillDestination!.isNotEmpty)
             ? _resolve(w.prefillDestination!, coord: w.prefillDestinationCoord)
@@ -175,10 +177,12 @@ class _FlightSearchScreenState extends ConsumerState<FlightSearchScreen> {
   /// it retries once with a cleaned query, then — if [coord] is given — falls
   /// back to the nearest airport by coordinate (e.g. a village -> its island
   /// airport). Mirrors the backend's resolveIATA.
-  Future<Airport?> _resolve(String query, {({double lat, double lng})? coord}) async {
+  Future<Airport?> _resolve(String query,
+      {({double lat, double lng})? coord}) async {
     final q = query.trim();
     final isCode = q.length == 3 && RegExp(r'^[A-Za-z]{3}$').hasMatch(q);
-    if (isCode) return Airport(iataCode: q.toUpperCase(), name: q.toUpperCase());
+    if (isCode)
+      return Airport(iataCode: q.toUpperCase(), name: q.toUpperCase());
 
     final cleaned = _cleanLabel(q);
     final attempts = <String>[q, if (cleaned != q) cleaned];
@@ -328,182 +332,185 @@ class _FlightSearchScreenState extends ConsumerState<FlightSearchScreen> {
       appBar: GradientAppBar(title: Text(l10n.flightSearchTitle)),
       body: Column(
         children: [
-          // Search form
+          // Search form: the surface color stays full-bleed; the fields
+          // cap to the shared 700px column (declutter series).
           Container(
             color: theme.colorScheme.surface,
             padding: const EdgeInsets.all(16),
-            child: Column(
-              children: [
-                AirportField(
-                  label: l10n.flightSearchFrom,
-                  icon: Icons.flight_takeoff,
-                  selected: _origin,
-                  onSelected: (a) => setState(() => _origin = a),
-                ),
-                const SizedBox(height: 12),
-                AirportField(
-                  label: l10n.flightSearchTo,
-                  icon: Icons.flight_land,
-                  selected: _destination,
-                  onSelected: (a) => setState(() => _destination = a),
-                ),
-                const SizedBox(height: 12),
-                Row(
-                  children: [
-                    Expanded(
-                      child: OutlinedButton.icon(
-                        onPressed: _pickDate,
-                        icon: const Icon(Icons.calendar_today, size: 18),
-                        label: Text(_departDate == null
-                            ? l10n.flightSearchDepartDate
-                            : _fmtDate(_departDate!)),
-                        style: OutlinedButton.styleFrom(
-                          padding: const EdgeInsets.symmetric(vertical: 14),
+            child: PageContainer(
+              child: Column(
+                children: [
+                  AirportField(
+                    label: l10n.flightSearchFrom,
+                    icon: Icons.flight_takeoff,
+                    selected: _origin,
+                    onSelected: (a) => setState(() => _origin = a),
+                  ),
+                  const SizedBox(height: 12),
+                  AirportField(
+                    label: l10n.flightSearchTo,
+                    icon: Icons.flight_land,
+                    selected: _destination,
+                    onSelected: (a) => setState(() => _destination = a),
+                  ),
+                  const SizedBox(height: 12),
+                  Row(
+                    children: [
+                      Expanded(
+                        child: OutlinedButton.icon(
+                          onPressed: _pickDate,
+                          icon: const Icon(Icons.calendar_today, size: 18),
+                          label: Text(_departDate == null
+                              ? l10n.flightSearchDepartDate
+                              : _fmtDate(_departDate!)),
+                          style: OutlinedButton.styleFrom(
+                            padding: const EdgeInsets.symmetric(vertical: 14),
+                          ),
                         ),
                       ),
-                    ),
-                    const SizedBox(width: 12),
-                    Expanded(
-                      child: OutlinedButton.icon(
-                        onPressed: _pickReturnDate,
-                        icon: const Icon(Icons.calendar_today, size: 18),
-                        label: Text(_returnDate == null
-                            ? l10n.flightSearchReturnOptional
-                            : _fmtDate(_returnDate!)),
-                        style: OutlinedButton.styleFrom(
-                          padding: const EdgeInsets.symmetric(vertical: 14),
+                      const SizedBox(width: 12),
+                      Expanded(
+                        child: OutlinedButton.icon(
+                          onPressed: _pickReturnDate,
+                          icon: const Icon(Icons.calendar_today, size: 18),
+                          label: Text(_returnDate == null
+                              ? l10n.flightSearchReturnOptional
+                              : _fmtDate(_returnDate!)),
+                          style: OutlinedButton.styleFrom(
+                            padding: const EdgeInsets.symmetric(vertical: 14),
+                          ),
                         ),
                       ),
-                    ),
-                    if (_returnDate != null)
-                      IconButton(
-                        tooltip: l10n.flightSearchClearReturnTooltip,
-                        visualDensity: VisualDensity.compact,
-                        icon: const Icon(Icons.close, size: 18),
-                        onPressed: () => setState(() => _returnDate = null),
+                      if (_returnDate != null)
+                        IconButton(
+                          tooltip: l10n.flightSearchClearReturnTooltip,
+                          visualDensity: VisualDensity.compact,
+                          icon: const Icon(Icons.close, size: 18),
+                          onPressed: () => setState(() => _returnDate = null),
+                        ),
+                    ],
+                  ),
+                  const SizedBox(height: 12),
+                  Row(
+                    children: [
+                      _PassengerStepper(
+                        icon: Icons.person_outline,
+                        count: _adults,
+                        min: 1,
+                        onChanged: (v) => setState(() => _adults = v),
                       ),
-                  ],
-                ),
-                const SizedBox(height: 12),
-                Row(
-                  children: [
-                    _PassengerStepper(
-                      icon: Icons.person_outline,
-                      count: _adults,
-                      min: 1,
-                      onChanged: (v) => setState(() => _adults = v),
+                      const SizedBox(width: 8),
+                      _PassengerStepper(
+                        icon: Icons.child_care_outlined,
+                        count: _childAges.length,
+                        min: 0,
+                        onChanged: (v) => setState(() {
+                          while (_childAges.length < v) {
+                            _childAges.add(_defaultChildAge);
+                          }
+                          while (_childAges.length > v) {
+                            _childAges.removeLast();
+                          }
+                        }),
+                      ),
+                    ],
+                  ),
+                  if (_childAges.isNotEmpty) ...[
+                    const SizedBox(height: 12),
+                    Align(
+                      alignment: Alignment.centerLeft,
+                      child: Wrap(
+                        spacing: 12,
+                        runSpacing: 8,
+                        crossAxisAlignment: WrapCrossAlignment.center,
+                        children: [
+                          Text(l10n.flightSearchChildAges,
+                              style: theme.textTheme.bodySmall?.copyWith(
+                                  color: theme.colorScheme.onSurfaceVariant)),
+                          for (var i = 0; i < _childAges.length; i++)
+                            DropdownButton<int>(
+                              value: _childAges[i],
+                              isDense: true,
+                              items: [
+                                for (var age = 0; age <= 17; age++)
+                                  DropdownMenuItem(
+                                    value: age,
+                                    child: Text('$age'),
+                                  ),
+                              ],
+                              onChanged: (age) {
+                                if (age != null) {
+                                  setState(() => _childAges[i] = age);
+                                }
+                              },
+                            ),
+                        ],
+                      ),
                     ),
-                    const SizedBox(width: 8),
-                    _PassengerStepper(
-                      icon: Icons.child_care_outlined,
-                      count: _childAges.length,
-                      min: 0,
-                      onChanged: (v) => setState(() {
-                        while (_childAges.length < v) {
-                          _childAges.add(_defaultChildAge);
-                        }
-                        while (_childAges.length > v) {
-                          _childAges.removeLast();
-                        }
-                      }),
-                    ),
                   ],
-                ),
-                if (_childAges.isNotEmpty) ...[
                   const SizedBox(height: 12),
                   Align(
                     alignment: Alignment.centerLeft,
                     child: Wrap(
-                      spacing: 12,
-                      runSpacing: 8,
-                      crossAxisAlignment: WrapCrossAlignment.center,
+                      spacing: 8,
                       children: [
-                        Text(l10n.flightSearchChildAges,
-                            style: theme.textTheme.bodySmall?.copyWith(
-                                color: theme.colorScheme.onSurfaceVariant)),
-                        for (var i = 0; i < _childAges.length; i++)
-                          DropdownButton<int>(
-                            value: _childAges[i],
-                            isDense: true,
-                            items: [
-                              for (var age = 0; age <= 17; age++)
-                                DropdownMenuItem(
-                                  value: age,
-                                  child: Text('$age'),
-                                ),
-                            ],
-                            onChanged: (age) {
-                              if (age != null) {
-                                setState(() => _childAges[i] = age);
-                              }
-                            },
+                        for (final value in _cabinClasses)
+                          ChoiceChip(
+                            label: Text(_cabinLabel(l10n, value)),
+                            selected: _cabinClass == value,
+                            onSelected: (_) =>
+                                setState(() => _cabinClass = value),
                           ),
                       ],
                     ),
                   ),
-                ],
-                const SizedBox(height: 12),
-                Align(
-                  alignment: Alignment.centerLeft,
-                  child: Wrap(
-                    spacing: 8,
-                    children: [
-                      for (final value in _cabinClasses)
-                        ChoiceChip(
-                          label: Text(_cabinLabel(l10n, value)),
-                          selected: _cabinClass == value,
-                          onSelected: (_) =>
-                              setState(() => _cabinClass = value),
-                        ),
-                    ],
+                  const SizedBox(height: 12),
+                  SegmentedButton<String>(
+                    segments: _baggageValues
+                        .map((value) => ButtonSegment(
+                              value: value,
+                              label: Text(_baggageLabel(l10n, value)),
+                            ))
+                        .toList(),
+                    selected: {_baggage},
+                    onSelectionChanged: (s) =>
+                        setState(() => _baggage = s.first),
                   ),
-                ),
-                const SizedBox(height: 12),
-                SegmentedButton<String>(
-                  segments: _baggageValues
-                      .map((value) => ButtonSegment(
-                            value: value,
-                            label: Text(_baggageLabel(l10n, value)),
-                          ))
-                      .toList(),
-                  selected: {_baggage},
-                  onSelectionChanged: (s) => setState(() => _baggage = s.first),
-                ),
-                const SizedBox(height: 12),
-                SegmentedButton<String>(
-                  segments: _presets
-                      .map((value) => ButtonSegment(
-                            value: value,
-                            label: Text(_presetLabel(l10n, value)),
-                          ))
-                      .toList(),
-                  selected: {_optimizeFor},
-                  onSelectionChanged: (s) =>
-                      setState(() => _optimizeFor = s.first),
-                ),
-                const SizedBox(height: 12),
-                SizedBox(
-                  width: double.infinity,
-                  child: FilledButton.icon(
-                    onPressed:
-                        _canSearch && !state.loading ? _search : null,
-                    icon: state.loading
-                        ? const SizedBox(
-                            width: 18,
-                            height: 18,
-                            child: CircularProgressIndicator(
-                                strokeWidth: 2, color: Colors.white),
-                          )
-                        : const Icon(Icons.search),
-                    label: Text(state.loading
-                        ? l10n.flightSearchSearching
-                        : l10n.flightSearchSubmit),
-                    style: FilledButton.styleFrom(
-                      padding: const EdgeInsets.symmetric(vertical: 14),
+                  const SizedBox(height: 12),
+                  SegmentedButton<String>(
+                    segments: _presets
+                        .map((value) => ButtonSegment(
+                              value: value,
+                              label: Text(_presetLabel(l10n, value)),
+                            ))
+                        .toList(),
+                    selected: {_optimizeFor},
+                    onSelectionChanged: (s) =>
+                        setState(() => _optimizeFor = s.first),
+                  ),
+                  const SizedBox(height: 12),
+                  SizedBox(
+                    width: double.infinity,
+                    child: FilledButton.icon(
+                      onPressed: _canSearch && !state.loading ? _search : null,
+                      icon: state.loading
+                          ? const SizedBox(
+                              width: 18,
+                              height: 18,
+                              child: CircularProgressIndicator(
+                                  strokeWidth: 2, color: Colors.white),
+                            )
+                          : const Icon(Icons.search),
+                      label: Text(state.loading
+                          ? l10n.flightSearchSearching
+                          : l10n.flightSearchSubmit),
+                      style: FilledButton.styleFrom(
+                        padding: const EdgeInsets.symmetric(vertical: 14),
+                      ),
                     ),
                   ),
-                ),
-              ],
+                ],
+              ),
             ),
           ),
           const Divider(height: 1),
@@ -517,47 +524,48 @@ class _FlightSearchScreenState extends ConsumerState<FlightSearchScreen> {
               state.offers.isNotEmpty &&
               _watched != null &&
               ref.watch(authProvider.select((s) => s.isSignedIn)))
-            Align(
-              alignment: Alignment.centerLeft,
-              child: Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 8),
-                child: TextButton.icon(
-                  icon: const Icon(Icons.notifications_none, size: 18),
-                  label: Text(l10n.flightSearchWatchRoute),
-                  onPressed: () {
-                    final w = _watched!;
-                    // Seed the baseline from the cheapest EFFECTIVE price —
-                    // the checker tracks fare + bag fee on baggage-aware
-                    // watches, so a bare-fare baseline would read as a drop.
-                    // Unknown-fee offers can't seed a comparable baseline.
-                    final priced = state.offers
-                        .where((o) => !o.bagFeeUnknown)
-                        .toList();
-                    final cheapest = priced.isEmpty
-                        ? null
-                        : priced.reduce((a, b) =>
-                            a.displayPrice <= b.displayPrice ? a : b);
-                    final seedPrice = w.hasChildren ? null : cheapest;
-                    CreateAlertSheet.show(
-                      context,
-                      CreateAlertSheet(
-                        origin: w.origin,
-                        destination: w.destination,
-                        departDate: w.departDate,
-                        returnDate: w.returnDate,
-                        adults: w.adults,
-                        cabinClass: w.cabinClass,
-                        baggage: w.baggage,
-                        currentPrice: seedPrice?.displayPrice,
-                        currency: seedPrice?.currency,
-                      ),
-                    );
-                  },
+            PageContainer(
+              child: Align(
+                alignment: Alignment.centerLeft,
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 8),
+                  child: TextButton.icon(
+                    icon: const Icon(Icons.notifications_none, size: 18),
+                    label: Text(l10n.flightSearchWatchRoute),
+                    onPressed: () {
+                      final w = _watched!;
+                      // Seed the baseline from the cheapest EFFECTIVE price —
+                      // the checker tracks fare + bag fee on baggage-aware
+                      // watches, so a bare-fare baseline would read as a drop.
+                      // Unknown-fee offers can't seed a comparable baseline.
+                      final priced =
+                          state.offers.where((o) => !o.bagFeeUnknown).toList();
+                      final cheapest = priced.isEmpty
+                          ? null
+                          : priced.reduce((a, b) =>
+                              a.displayPrice <= b.displayPrice ? a : b);
+                      final seedPrice = w.hasChildren ? null : cheapest;
+                      CreateAlertSheet.show(
+                        context,
+                        CreateAlertSheet(
+                          origin: w.origin,
+                          destination: w.destination,
+                          departDate: w.departDate,
+                          returnDate: w.returnDate,
+                          adults: w.adults,
+                          cabinClass: w.cabinClass,
+                          baggage: w.baggage,
+                          currentPrice: seedPrice?.displayPrice,
+                          currency: seedPrice?.currency,
+                        ),
+                      );
+                    },
+                  ),
                 ),
               ),
             ),
-          // Results
-          Expanded(child: _Results(state: state)),
+          // Results (whole-scrollable cap, alerts/guides pattern)
+          Expanded(child: PageContainer(child: _Results(state: state))),
         ],
       ),
     );
@@ -616,8 +624,7 @@ class _Results extends StatelessWidget {
       );
     }
 
-    final savingsLabel =
-        savingsLabelFor(l10n, state.offers, state.bestOfferId);
+    final savingsLabel = savingsLabelFor(l10n, state.offers, state.bestOfferId);
     return ListView.builder(
       padding: const EdgeInsets.all(16),
       itemCount: state.offers.length,
@@ -650,7 +657,8 @@ class _Hint extends StatelessWidget {
           children: [
             Icon(icon, size: 56, color: color),
             const SizedBox(height: 12),
-            Text(text, textAlign: TextAlign.center,
+            Text(text,
+                textAlign: TextAlign.center,
                 style: Theme.of(context)
                     .textTheme
                     .bodyMedium
@@ -693,8 +701,7 @@ class _PassengerStepper extends StatelessWidget {
             onPressed: count > min ? () => onChanged(count - 1) : null,
             visualDensity: VisualDensity.compact,
           ),
-          Text('$count',
-              style: const TextStyle(fontWeight: FontWeight.bold)),
+          Text('$count', style: const TextStyle(fontWeight: FontWeight.bold)),
           IconButton(
             icon: const Icon(Icons.add, size: 18),
             onPressed: count < 8 ? () => onChanged(count + 1) : null,
@@ -705,4 +712,3 @@ class _PassengerStepper extends StatelessWidget {
     );
   }
 }
-

--- a/src/packages/flutter-app/lib/screens/local_guide_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/local_guide_detail_screen.dart
@@ -10,6 +10,7 @@ import '../providers/local_provider.dart';
 import '../theme/app_colors.dart';
 import '../theme/spacing.dart';
 import '../widgets/add_to_trip_sheet.dart';
+import '../widgets/page_container.dart';
 import '../widgets/app_map.dart';
 import '../widgets/empty_state.dart';
 import '../widgets/gradient_app_bar.dart';
@@ -53,7 +54,8 @@ class LocalGuideDetailScreen extends ConsumerWidget {
           message: l10n.guideDetailErrorMessage,
           actions: [
             FilledButton.icon(
-              onPressed: () => ref.invalidate(localGuideDetailProvider(guide.id)),
+              onPressed: () =>
+                  ref.invalidate(localGuideDetailProvider(guide.id)),
               icon: const Icon(Icons.refresh),
               label: Text(l10n.commonRetry),
             ),
@@ -68,8 +70,8 @@ class LocalGuideDetailScreen extends ConsumerWidget {
           theme: theme,
           // Add-to-trip needs an account (guides browse stays public).
           onAddPin: ref.watch(authProvider).isSignedIn
-              ? (pin) => showAddToTripSheet(
-                  context, AddToTripPayload.fromLocalRec(pin, source: 'guide_pin'))
+              ? (pin) => showAddToTripSheet(context,
+                  AddToTripPayload.fromLocalRec(pin, source: 'guide_pin'))
               : null,
         ),
       ),
@@ -108,109 +110,116 @@ class _GuideBody extends StatelessWidget {
       _pick(guide.neighborhood, fallback.neighborhood),
       _pick(guide.city, fallback.city),
     ].where((s) => s.isNotEmpty).join(' · ');
-    final mapped = pins
-        .where((p) => p.latitude != null && p.longitude != null)
-        .toList();
+    final mapped =
+        pins.where((p) => p.latitude != null && p.longitude != null).toList();
 
     return ListView(
       padding: const EdgeInsets.all(AppSpacing.lg),
       children: [
-        if (heroUrl.isNotEmpty) ...[
-          _HeroImage(url: heroUrl),
-          const SizedBox(height: AppSpacing.lg),
-        ],
-        Text(
-          title,
-          style: theme.textTheme.headlineSmall
-              ?.copyWith(fontWeight: FontWeight.bold),
+        // Centered 700px reading column on wide layouts (declutter series);
+        // the ListView stays full-width so wheel/scrollbar work in gutters.
+        PageContainer(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              if (heroUrl.isNotEmpty) ...[
+                _HeroImage(url: heroUrl),
+                const SizedBox(height: AppSpacing.lg),
+              ],
+              Text(
+                title,
+                style: theme.textTheme.headlineSmall
+                    ?.copyWith(fontWeight: FontWeight.bold),
+              ),
+              if (placeLine.isNotEmpty) ...[
+                const SizedBox(height: AppSpacing.xs),
+                Text(
+                  placeLine,
+                  style: theme.textTheme.bodyMedium
+                      ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+                ),
+              ],
+              // The local behind the guide — same face + name treatment as the
+              // recommendation cards, so attribution reads consistently.
+              if (sourceName.isNotEmpty) ...[
+                const SizedBox(height: AppSpacing.md),
+                Row(
+                  children: [
+                    CircleAvatar(
+                      radius: 16,
+                      backgroundColor: accent.withValues(alpha: 0.15),
+                      foregroundImage: sourcePhotoUrl.isNotEmpty
+                          ? NetworkImage(sourcePhotoUrl)
+                          : null,
+                      child: Text(
+                        sourceName.characters.first.toUpperCase(),
+                        style: theme.textTheme.labelSmall?.copyWith(
+                            color: accent, fontWeight: FontWeight.w700),
+                      ),
+                    ),
+                    const SizedBox(width: AppSpacing.sm),
+                    Expanded(
+                      child: Text(
+                        l10n.guideDetailByline(sourceName),
+                        style: theme.textTheme.labelLarge?.copyWith(
+                            color: accent, fontWeight: FontWeight.w600),
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ),
+                    Icon(Icons.verified, size: 18, color: accent),
+                  ],
+                ),
+              ],
+              if (body.isNotEmpty) ...[
+                const SizedBox(height: AppSpacing.lg),
+                Text(
+                  body,
+                  style: theme.textTheme.bodyMedium?.copyWith(height: 1.6),
+                ),
+              ],
+              if (pins.isNotEmpty) ...[
+                const SizedBox(height: AppSpacing.xl),
+                Row(
+                  children: [
+                    Icon(Icons.place, size: 18, color: accent),
+                    const SizedBox(width: 6),
+                    Text(
+                      l10n.guideDetailPlacesTitle,
+                      style: theme.textTheme.titleSmall?.copyWith(
+                          fontWeight: FontWeight.w700, color: accent),
+                    ),
+                    const SizedBox(width: AppSpacing.sm),
+                    Text(
+                      '${pins.length}',
+                      style: theme.textTheme.labelMedium
+                          ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: AppSpacing.xs),
+                if (mapped.isNotEmpty) ...[
+                  _GuideMap(pins: mapped),
+                  const SizedBox(height: AppSpacing.sm),
+                ],
+                for (final pin in pins)
+                  LocalRecCard(
+                    rec: pin,
+                    onAddToTrip: onAddPin == null ? null : () => onAddPin!(pin),
+                  ),
+              ] else ...[
+                const SizedBox(height: AppSpacing.xl),
+                EmptyState(
+                  icon: Icons.place,
+                  title: l10n.guideDetailNoPinsTitle,
+                  message: l10n.guideDetailNoPinsMessage,
+                  iconColor: accent.withValues(alpha: 0.5),
+                ),
+              ],
+              const SizedBox(height: AppSpacing.xl),
+            ],
+          ),
         ),
-        if (placeLine.isNotEmpty) ...[
-          const SizedBox(height: AppSpacing.xs),
-          Text(
-            placeLine,
-            style: theme.textTheme.bodyMedium
-                ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
-          ),
-        ],
-        // The local behind the guide — same face + name treatment as the
-        // recommendation cards, so attribution reads consistently.
-        if (sourceName.isNotEmpty) ...[
-          const SizedBox(height: AppSpacing.md),
-          Row(
-            children: [
-              CircleAvatar(
-                radius: 16,
-                backgroundColor: accent.withValues(alpha: 0.15),
-                foregroundImage: sourcePhotoUrl.isNotEmpty
-                    ? NetworkImage(sourcePhotoUrl)
-                    : null,
-                child: Text(
-                  sourceName.characters.first.toUpperCase(),
-                  style: theme.textTheme.labelSmall
-                      ?.copyWith(color: accent, fontWeight: FontWeight.w700),
-                ),
-              ),
-              const SizedBox(width: AppSpacing.sm),
-              Expanded(
-                child: Text(
-                  l10n.guideDetailByline(sourceName),
-                  style: theme.textTheme.labelLarge?.copyWith(
-                      color: accent, fontWeight: FontWeight.w600),
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                ),
-              ),
-              Icon(Icons.verified, size: 18, color: accent),
-            ],
-          ),
-        ],
-        if (body.isNotEmpty) ...[
-          const SizedBox(height: AppSpacing.lg),
-          Text(
-            body,
-            style: theme.textTheme.bodyMedium?.copyWith(height: 1.6),
-          ),
-        ],
-        if (pins.isNotEmpty) ...[
-          const SizedBox(height: AppSpacing.xl),
-          Row(
-            children: [
-              Icon(Icons.place, size: 18, color: accent),
-              const SizedBox(width: 6),
-              Text(
-                l10n.guideDetailPlacesTitle,
-                style: theme.textTheme.titleSmall?.copyWith(
-                    fontWeight: FontWeight.w700, color: accent),
-              ),
-              const SizedBox(width: AppSpacing.sm),
-              Text(
-                '${pins.length}',
-                style: theme.textTheme.labelMedium
-                    ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
-              ),
-            ],
-          ),
-          const SizedBox(height: AppSpacing.xs),
-          if (mapped.isNotEmpty) ...[
-            _GuideMap(pins: mapped),
-            const SizedBox(height: AppSpacing.sm),
-          ],
-          for (final pin in pins)
-            LocalRecCard(
-              rec: pin,
-              onAddToTrip:
-                  onAddPin == null ? null : () => onAddPin!(pin),
-            ),
-        ] else ...[
-          const SizedBox(height: AppSpacing.xl),
-          EmptyState(
-            icon: Icons.place,
-            title: l10n.guideDetailNoPinsTitle,
-            message: l10n.guideDetailNoPinsMessage,
-            iconColor: accent.withValues(alpha: 0.5),
-          ),
-        ],
-        const SizedBox(height: AppSpacing.xl),
       ],
     );
   }

--- a/src/packages/flutter-app/lib/screens/preferences_screen.dart
+++ b/src/packages/flutter-app/lib/screens/preferences_screen.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../models/airport.dart';
 import '../widgets/airport_field.dart';
+import '../widgets/page_container.dart';
+import '../widgets/section_header.dart';
 import '../widgets/choice_chip_row.dart';
 import '../widgets/gradient_app_bar.dart';
 import '../l10n/l10n.dart';
@@ -14,7 +16,16 @@ import '../utils/snack.dart';
 const _budgets = ['budget', 'mid', 'luxury'];
 const _paces = ['relaxed', 'balanced', 'packed'];
 const _suggestedInterests = [
-  'museums', 'food', 'nightlife', 'nature', 'history', 'art', 'shopping', 'outdoors', 'beaches', 'architecture',
+  'museums',
+  'food',
+  'nightlife',
+  'nature',
+  'history',
+  'art',
+  'shopping',
+  'outdoors',
+  'beaches',
+  'architecture',
 ];
 
 String _budgetLabel(AppLocalizations l10n, String value) => switch (value) {
@@ -112,8 +123,8 @@ class _PreferencesScreenState extends ConsumerState<PreferencesScreen> {
           profileNotes: _notesController.text.trim(),
         );
     if (!mounted) return;
-    showSnack(context,
-        ok ? context.l10n.prefsSaved : context.l10n.prefsSaveFailed);
+    showSnack(
+        context, ok ? context.l10n.prefsSaved : context.l10n.prefsSaveFailed);
   }
 
   @override
@@ -134,101 +145,117 @@ class _PreferencesScreenState extends ConsumerState<PreferencesScreen> {
           : ListView(
               padding: const EdgeInsets.all(16),
               children: [
-                Text(l10n.prefsBudget, style: theme.textTheme.titleMedium),
-                const SizedBox(height: 8),
-                ChoiceChipRow(
-                  options: _budgets,
-                  selected: _budget,
-                  onSelected: (v) => setState(() => _budget = v),
-                  labelBuilder: (v) => _budgetLabel(l10n, v),
-                ),
-                const SizedBox(height: 24),
-                Text(l10n.prefsPace, style: theme.textTheme.titleMedium),
-                const SizedBox(height: 8),
-                ChoiceChipRow(
-                  options: _paces,
-                  selected: _pace,
-                  onSelected: (v) => setState(() => _pace = v),
-                  labelBuilder: (v) => _paceLabel(l10n, v),
-                ),
-                const SizedBox(height: 24),
-                Text(l10n.prefsInterests, style: theme.textTheme.titleMedium),
-                const SizedBox(height: 8),
-                Wrap(
-                  spacing: 8,
-                  runSpacing: 4,
-                  children: chipLabels.map((label) {
-                    final selected = _interests.contains(label);
-                    return FilterChip(
-                      label: Text(_interestLabel(l10n, label)),
-                      selected: selected,
-                      onSelected: (sel) => setState(() {
-                        if (sel) {
-                          _interests.add(label);
-                        } else {
-                          _interests.remove(label);
-                        }
-                      }),
-                    );
-                  }).toList(),
-                ),
-                const SizedBox(height: 8),
-                Row(
-                  children: [
-                    Expanded(
-                      child: TextField(
-                        controller: _interestController,
-                        decoration:
-                            InputDecoration(hintText: l10n.prefsAddInterest),
-                        onSubmitted: (_) => _addInterest(),
+                // Centered 700px column on wide layouts (declutter series);
+                // the ListView stays full-width so wheel/scrollbar work in
+                // the gutters.
+                PageContainer(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [
+                      SectionHeader(title: l10n.prefsBudget),
+                      const SizedBox(height: 8),
+                      ChoiceChipRow(
+                        options: _budgets,
+                        selected: _budget,
+                        onSelected: (v) => setState(() => _budget = v),
+                        labelBuilder: (v) => _budgetLabel(l10n, v),
                       ),
-                    ),
-                    IconButton(icon: const Icon(Icons.add), onPressed: _addInterest),
-                  ],
-                ),
-                const SizedBox(height: 24),
-                Text(l10n.prefsHomeAirport, style: theme.textTheme.titleMedium),
-                const SizedBox(height: 4),
-                Text(
-                  l10n.prefsHomeAirportHelp,
-                  style: theme.textTheme.bodySmall?.copyWith(
-                    color: theme.colorScheme.onSurfaceVariant,
+                      const SizedBox(height: 24),
+                      SectionHeader(title: l10n.prefsPace),
+                      const SizedBox(height: 8),
+                      ChoiceChipRow(
+                        options: _paces,
+                        selected: _pace,
+                        onSelected: (v) => setState(() => _pace = v),
+                        labelBuilder: (v) => _paceLabel(l10n, v),
+                      ),
+                      const SizedBox(height: 24),
+                      SectionHeader(title: l10n.prefsInterests),
+                      const SizedBox(height: 8),
+                      Wrap(
+                        spacing: 8,
+                        runSpacing: 4,
+                        children: chipLabels.map((label) {
+                          final selected = _interests.contains(label);
+                          return FilterChip(
+                            label: Text(_interestLabel(l10n, label)),
+                            selected: selected,
+                            onSelected: (sel) => setState(() {
+                              if (sel) {
+                                _interests.add(label);
+                              } else {
+                                _interests.remove(label);
+                              }
+                            }),
+                          );
+                        }).toList(),
+                      ),
+                      const SizedBox(height: 8),
+                      Row(
+                        children: [
+                          Expanded(
+                            child: TextField(
+                              controller: _interestController,
+                              decoration: InputDecoration(
+                                  hintText: l10n.prefsAddInterest),
+                              onSubmitted: (_) => _addInterest(),
+                            ),
+                          ),
+                          IconButton(
+                              icon: const Icon(Icons.add),
+                              onPressed: _addInterest),
+                        ],
+                      ),
+                      const SizedBox(height: 24),
+                      SectionHeader(title: l10n.prefsHomeAirport),
+                      const SizedBox(height: 4),
+                      Text(
+                        l10n.prefsHomeAirportHelp,
+                        style: theme.textTheme.bodySmall?.copyWith(
+                          color: theme.colorScheme.onSurfaceVariant,
+                        ),
+                      ),
+                      const SizedBox(height: 8),
+                      AirportField(
+                        label: l10n.prefsHomeAirport,
+                        icon: Icons.home,
+                        selected: _homeAirport,
+                        onSelected: (a) => setState(() => _homeAirport = a),
+                      ),
+                      const SizedBox(height: 24),
+                      SectionHeader(title: l10n.prefsProfileNotes),
+                      const SizedBox(height: 4),
+                      Text(
+                        l10n.prefsProfileNotesHelp,
+                        style: theme.textTheme.bodySmall?.copyWith(
+                          color: theme.colorScheme.onSurfaceVariant,
+                        ),
+                      ),
+                      const SizedBox(height: 8),
+                      TextField(
+                        controller: _notesController,
+                        maxLines: 6,
+                        maxLength: 2000,
+                        decoration: InputDecoration(
+                          hintText: l10n.prefsProfileNotesHint,
+                          border: const OutlineInputBorder(),
+                        ),
+                      ),
+                      const SizedBox(height: 32),
+                      FilledButton(
+                        onPressed: state.saving ? null : _save,
+                        style: FilledButton.styleFrom(
+                            padding: const EdgeInsets.symmetric(vertical: 16)),
+                        child: state.saving
+                            ? const SizedBox(
+                                height: 20,
+                                width: 20,
+                                child:
+                                    CircularProgressIndicator(strokeWidth: 2))
+                            : Text(l10n.commonSave),
+                      ),
+                    ],
                   ),
-                ),
-                const SizedBox(height: 8),
-                AirportField(
-                  label: l10n.prefsHomeAirport,
-                  icon: Icons.home,
-                  selected: _homeAirport,
-                  onSelected: (a) => setState(() => _homeAirport = a),
-                ),
-                const SizedBox(height: 24),
-                Text(l10n.prefsProfileNotes,
-                    style: theme.textTheme.titleMedium),
-                const SizedBox(height: 4),
-                Text(
-                  l10n.prefsProfileNotesHelp,
-                  style: theme.textTheme.bodySmall?.copyWith(
-                    color: theme.colorScheme.onSurfaceVariant,
-                  ),
-                ),
-                const SizedBox(height: 8),
-                TextField(
-                  controller: _notesController,
-                  maxLines: 6,
-                  maxLength: 2000,
-                  decoration: InputDecoration(
-                    hintText: l10n.prefsProfileNotesHint,
-                    border: const OutlineInputBorder(),
-                  ),
-                ),
-                const SizedBox(height: 32),
-                FilledButton(
-                  onPressed: state.saving ? null : _save,
-                  style: FilledButton.styleFrom(padding: const EdgeInsets.symmetric(vertical: 16)),
-                  child: state.saving
-                      ? const SizedBox(height: 20, width: 20, child: CircularProgressIndicator(strokeWidth: 2))
-                      : Text(l10n.commonSave),
                 ),
               ],
             ),

--- a/src/packages/flutter-app/test/secondary_width_sweep_test.dart
+++ b/src/packages/flutter-app/test/secondary_width_sweep_test.dart
@@ -1,0 +1,94 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:travel_route_planner/models/local_guide.dart';
+import 'package:travel_route_planner/models/local_recommendation.dart';
+import 'package:travel_route_planner/providers/local_provider.dart';
+import 'package:travel_route_planner/screens/flight_search_screen.dart';
+import 'package:travel_route_planner/screens/local_guide_detail_screen.dart';
+import 'package:travel_route_planner/screens/preferences_screen.dart';
+import 'package:travel_route_planner/widgets/airport_field.dart';
+import 'package:travel_route_planner/widgets/choice_chip_row.dart';
+import 'package:travel_route_planner/widgets/local_rec_card.dart';
+
+import 'support/l10n_test_app.dart';
+
+/// Declutter sweep: preferences, flight search, and the guide reader cap
+/// their content at PageContainer's 700px on wide layouts.
+const _wide = Size(1200, 900);
+
+Future<void> _setSurface(WidgetTester tester, Size s) async {
+  await tester.binding.setSurfaceSize(s);
+  addTearDown(() => tester.binding.setSurfaceSize(null));
+}
+
+void _expectCapped(WidgetTester tester, Finder f) {
+  expect(tester.getSize(f).width, lessThanOrEqualTo(700));
+  final left = tester.getTopLeft(f).dx;
+  final right = _wide.width - tester.getTopRight(f).dx;
+  expect((left - right).abs(), lessThan(2));
+}
+
+const _guide = LocalGuide(
+  id: 'g1',
+  title: 'Alfama on foot',
+  city: 'Lisboa',
+  body: 'A slow morning through the oldest streets in the city…',
+  sourceName: 'Rui',
+);
+
+void main() {
+  testWidgets('preferences content caps at 700 on wide layouts',
+      (tester) async {
+    await _setSurface(tester, _wide);
+    await tester.pumpWidget(
+      ProviderScope(
+        child: MaterialApp(
+            localizationsDelegates: testLocalizationsDelegates,
+            home: const PreferencesScreen()),
+      ),
+    );
+    await tester.pump();
+    await tester.pump();
+    _expectCapped(tester, find.byType(ChoiceChipRow).first);
+  });
+
+  testWidgets('flight search form caps at 700 on wide layouts',
+      (tester) async {
+    await _setSurface(tester, _wide);
+    await tester.pumpWidget(
+      ProviderScope(
+        child: MaterialApp(
+            localizationsDelegates: testLocalizationsDelegates,
+            home: const FlightSearchScreen()),
+      ),
+    );
+    await tester.pump();
+    _expectCapped(tester, find.byType(AirportField).first);
+  });
+
+  testWidgets('guide reader caps at 700 on wide, fills phones',
+      (tester) async {
+    await _setSurface(tester, _wide);
+    Widget app() => ProviderScope(
+          overrides: [
+            localGuideDetailProvider('g1').overrideWith(
+                (ref) async =>
+                    (guide: _guide, recommendations: <LocalRecommendation>[])),
+          ],
+          child: MaterialApp(
+              localizationsDelegates: testLocalizationsDelegates,
+              home: const LocalGuideDetailScreen(guide: _guide)),
+        );
+    await tester.pumpWidget(app());
+    await tester.pumpAndSettle();
+    _expectCapped(tester, find.text('Alfama on foot'));
+    expect(find.byType(LocalRecCard), findsNothing);
+
+    await tester.binding.setSurfaceSize(const Size(390, 844));
+    await tester.pumpAndSettle();
+    expect(tester.getSize(find.text('Alfama on foot')).width,
+        greaterThan(340));
+  });
+}


### PR DESCRIPTION
Declutter finale, PR 2 of 3. The last three uncapped user-facing screens get the 700px column treatment:

- **Preferences**: content-wrap `PageContainer` + five `SectionHeader` titles (Budget / Pace / Interests / Home airport / Profile notes). Inputs deliberately stay — it's an editor page.
- **Flight search**: form fields cap while the surface band stays full-bleed; Watch-this-route row and the results list cap too (whole-scrollable wrap, same as alerts/guides).
- **Local guide reader**: content-wrap for a sane reading measure at desktop; hero image, pins map, and rec cards cap with the text.

Zero string changes.

## Verification
`flutter analyze` clean; **474/474** tests including new `secondary_width_sweep_test` (≤700px + symmetric centering at 1200×900 for all three screens, phone case for the reader) and the full `flight_round_trip_test` suite untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)