### PR TITLE
feat(flutter): visible language switcher — app-bar globe menu on Home, landing, sign-in

### DIFF
--- a/specs/i18n-spanish/spec.md
+++ b/specs/i18n-spanish/spec.md
@@ -38,9 +38,15 @@ language is a translation job rather than an engineering project.
 - [ ] A language control in account settings offers *System default*, *English*
       and *Español*; choosing one switches the whole app immediately, without a
       restart, and survives closing and reopening the app.
+- [ ] A globe button in the app bar — on Home, the landing page and the
+      sign-in screen — opens a menu with the same three options, with the
+      current choice checked; selecting one behaves exactly like the settings
+      picker (immediate, persisted, synced to the account when signed in).
 - [ ] The explicit choice is remembered on the account: signing in on a second
       device (with no choice made there) adopts it.
-- [ ] Signed-out surfaces (landing, sign-in, sign-up) honor the device language.
+- [ ] Signed-out surfaces (landing, sign-in, sign-up) honor the device
+      language, and the app-bar globe menu lets a visitor choose explicitly
+      before signing in.
 - [ ] With the app in Spanish, the AI planner replies in Spanish and the
       itineraries, day summaries and titles it produces are in Spanish; dates,
       airport codes and other structured values remain in their canonical
@@ -101,7 +107,9 @@ language is a translation job rather than an engineering project.
 ## UI Behavior
 
 - **Screen / surface:** a *Language / Idioma* group in account settings,
-  alongside the existing email-preferences group.
+  alongside the existing email-preferences group; plus a globe icon button in
+  the Home, landing and sign-in app bars opening a popup menu with the same
+  options.
 - **Happy path:** the user opens account settings, picks *Español*, and the app
   redraws in Spanish immediately. The choice is stored on the device and, if
   signed in, on the account.

--- a/specs/i18n-spanish/tasks.md
+++ b/specs/i18n-spanish/tasks.md
@@ -192,3 +192,13 @@ Also in PR 5:
 **Remaining follow-ups** (all recorded above, none blocking): `PackingItem`
 values, `weather_service.go`'s `summarizeWeather`, email dates staying ISO, and
 the lowercase budget/pace chip labels.
+
+## PR 8 — Visible language switcher
+
+- [x] Amend spec.md: app-bar globe menu on Home / landing / sign-in
+- [x] `l10n.dart`: shared `languageDisplayName`; retire `_LanguagePicker._nameFor`
+- [x] `widgets/language_menu_button.dart` — globe `PopupMenuButton`, checked on
+      the override, entries from `kLocaleSystem` + `kSupportedLocales`
+- [x] ARB: `languageMenuTooltip` (en + es); `flutter gen-l10n`, drift-free
+- [x] Mount in Home, landing and auth app bars (all widths — no rail gate)
+- [x] Tests: `language_menu_button_test.dart`; `flutter analyze` clean

--- a/src/packages/flutter-app/lib/l10n/app_en.arb
+++ b/src/packages/flutter-app/lib/l10n/app_en.arb
@@ -24,6 +24,10 @@
   "@languageChangeNote": {
     "description": "Explains that switching language does not retranslate existing saved content."
   },
+  "languageMenuTooltip": "Change language",
+  "@languageMenuTooltip": {
+    "description": "Tooltip of the app-bar globe button that opens the language menu."
+  },
   "commonSave": "Save",
   "commonCancel": "Cancel",
   "commonDelete": "Delete",

--- a/src/packages/flutter-app/lib/l10n/app_es.arb
+++ b/src/packages/flutter-app/lib/l10n/app_es.arb
@@ -6,6 +6,7 @@
   "languageEnglish": "English",
   "languageSpanish": "Español",
   "languageChangeNote": "Los viajes y las notas que ya guardaste se mantienen en el idioma en que se escribieron.",
+  "languageMenuTooltip": "Cambiar idioma",
   "commonSave": "Guardar",
   "commonCancel": "Cancelar",
   "commonDelete": "Eliminar",

--- a/src/packages/flutter-app/lib/l10n/app_localizations.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations.dart
@@ -134,6 +134,12 @@ abstract class AppLocalizations {
   /// **'Trips and notes you already saved stay in the language they were written in.'**
   String get languageChangeNote;
 
+  /// Tooltip of the app-bar globe button that opens the language menu.
+  ///
+  /// In en, this message translates to:
+  /// **'Change language'**
+  String get languageMenuTooltip;
+
   /// No description provided for @commonSave.
   ///
   /// In en, this message translates to:

--- a/src/packages/flutter-app/lib/l10n/app_localizations_en.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations_en.dart
@@ -28,6 +28,9 @@ class AppLocalizationsEn extends AppLocalizations {
       'Trips and notes you already saved stay in the language they were written in.';
 
   @override
+  String get languageMenuTooltip => 'Change language';
+
+  @override
   String get commonSave => 'Save';
 
   @override

--- a/src/packages/flutter-app/lib/l10n/app_localizations_es.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations_es.dart
@@ -28,6 +28,9 @@ class AppLocalizationsEs extends AppLocalizations {
       'Los viajes y las notas que ya guardaste se mantienen en el idioma en que se escribieron.';
 
   @override
+  String get languageMenuTooltip => 'Cambiar idioma';
+
+  @override
   String get commonSave => 'Guardar';
 
   @override

--- a/src/packages/flutter-app/lib/l10n/l10n.dart
+++ b/src/packages/flutter-app/lib/l10n/l10n.dart
@@ -24,6 +24,16 @@ const List<Locale> kSupportedLocales = [
 bool isSupportedLanguage(String languageCode) =>
     kSupportedLocales.any((l) => l.languageCode == languageCode);
 
+/// The display name of a supported language, in its own language — shared by
+/// the account-settings picker and the app-bar language menu so they can
+/// never disagree.
+String languageDisplayName(AppLocalizations l10n, String code) =>
+    switch (code) {
+      'en' => l10n.languageEnglish,
+      'es' => l10n.languageSpanish,
+      _ => code,
+    };
+
 /// Shorthand for the generated lookups: `context.l10n.commonSave`.
 extension AppLocalizationsX on BuildContext {
   AppLocalizations get l10n => AppLocalizations.of(this);

--- a/src/packages/flutter-app/lib/screens/account_settings_screen.dart
+++ b/src/packages/flutter-app/lib/screens/account_settings_screen.dart
@@ -327,12 +327,6 @@ class _AccountSettingsScreenState extends ConsumerState<AccountSettingsScreen> {
 class _LanguagePicker extends ConsumerWidget {
   const _LanguagePicker();
 
-  static String _nameFor(AppLocalizations l10n, String code) => switch (code) {
-        'en' => l10n.languageEnglish,
-        'es' => l10n.languageSpanish,
-        _ => code,
-      };
-
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final l10n = context.l10n;
@@ -358,7 +352,7 @@ class _LanguagePicker extends ConsumerWidget {
               for (final locale in kSupportedLocales)
                 RadioListTile<String>(
                   contentPadding: EdgeInsets.zero,
-                  title: Text(_nameFor(l10n, locale.languageCode)),
+                  title: Text(languageDisplayName(l10n, locale.languageCode)),
                   value: locale.languageCode,
                 ),
             ],

--- a/src/packages/flutter-app/lib/screens/auth_screen.dart
+++ b/src/packages/flutter-app/lib/screens/auth_screen.dart
@@ -6,6 +6,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../l10n/l10n.dart';
 import '../providers/auth_provider.dart';
 import '../widgets/brand_logo.dart';
+import '../widgets/language_menu_button.dart';
 import '../widgets/sso_buttons.dart';
 import '../widgets/legal_links.dart';
 import '../utils/snack.dart';
@@ -178,6 +179,7 @@ class _AuthScreenState extends ConsumerState<AuthScreen> {
         backgroundColor: Colors.transparent,
         elevation: 0,
         scrolledUnderElevation: 0,
+        actions: const [LanguageMenuButton()],
       ),
       body: Center(
         child: SingleChildScrollView(

--- a/src/packages/flutter-app/lib/screens/home_screen.dart
+++ b/src/packages/flutter-app/lib/screens/home_screen.dart
@@ -18,6 +18,7 @@ import '../widgets/account_menu.dart';
 import '../widgets/brand_logo.dart';
 import '../widgets/continue_chats_section.dart';
 import '../widgets/gradient_app_bar.dart';
+import '../widgets/language_menu_button.dart';
 import '../widgets/live_trip_card.dart';
 import '../widgets/page_container.dart';
 import '../widgets/section_header.dart';
@@ -102,7 +103,7 @@ class HomeScreen extends ConsumerWidget {
             ),
           ],
         ),
-        actions: const [AccountMenu()],
+        actions: const [LanguageMenuButton(), AccountMenu()],
       ),
       body: SafeArea(
         child: SingleChildScrollView(

--- a/src/packages/flutter-app/lib/screens/landing_screen.dart
+++ b/src/packages/flutter-app/lib/screens/landing_screen.dart
@@ -6,6 +6,7 @@ import '../theme/app_colors.dart';
 import '../theme/spacing.dart';
 import '../widgets/brand_logo.dart';
 import '../widgets/gradient_app_bar.dart';
+import '../widgets/language_menu_button.dart';
 import '../widgets/legal_links.dart';
 import '../widgets/page_container.dart';
 import 'auth_screen.dart';
@@ -73,6 +74,7 @@ class _LandingScreenState extends State<LandingScreen> {
           child: BrandLogo.mark(size: 30),
         ),
         actions: [
+          const LanguageMenuButton(),
           TextButton(
             onPressed: () => _openAuth(context, isLogin: true),
             style: TextButton.styleFrom(foregroundColor: Colors.white),

--- a/src/packages/flutter-app/lib/widgets/language_menu_button.dart
+++ b/src/packages/flutter-app/lib/widgets/language_menu_button.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../l10n/l10n.dart';
+import '../providers/locale_provider.dart';
+import '../theme/spacing.dart';
+
+/// App-bar globe button offering the same choices as the account-settings
+/// language picker (specs/i18n-spanish): System default plus every entry in
+/// [kSupportedLocales]. Works signed out — the locale provider persists
+/// device-wide and only syncs to the account when a session exists.
+///
+/// Unlike `AccountMenu`, this renders at every width: the wide layout's rail
+/// has no language control to defer to.
+class LanguageMenuButton extends ConsumerWidget {
+  const LanguageMenuButton({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final theme = Theme.of(context);
+    final l10n = context.l10n;
+    // Checked state mirrors the settings picker: keyed on the explicit
+    // override, so "System default" stays checked while following the device.
+    final override = ref.watch(localeProvider.select((s) => s.override));
+    return PopupMenuButton<String>(
+      tooltip: l10n.languageMenuTooltip,
+      // Open below the bar, on an M3 surface, instead of the default
+      // overlapping panel that would inherit the app bar's white icons.
+      position: PopupMenuPosition.under,
+      color: theme.colorScheme.surface,
+      elevation: 3,
+      shape: const RoundedRectangleBorder(borderRadius: AppRadius.mdAll),
+      // No explicit color: inherits the bar's foreground (white on the
+      // gradient bars, onSurface on the auth screen's transparent bar).
+      icon: const Icon(Icons.language),
+      onSelected: (v) => ref.read(localeProvider.notifier).setOverride(v),
+      itemBuilder: (_) => [
+        CheckedPopupMenuItem<String>(
+          value: kLocaleSystem,
+          checked: override == kLocaleSystem,
+          child: Text(l10n.languageSystemDefault),
+        ),
+        for (final locale in kSupportedLocales)
+          CheckedPopupMenuItem<String>(
+            value: locale.languageCode,
+            checked: override == locale.languageCode,
+            child: Text(languageDisplayName(l10n, locale.languageCode)),
+          ),
+      ],
+    );
+  }
+}

--- a/src/packages/flutter-app/test/language_menu_button_test.dart
+++ b/src/packages/flutter-app/test/language_menu_button_test.dart
@@ -1,0 +1,236 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:travel_route_planner/l10n/l10n.dart';
+import 'package:travel_route_planner/models/user.dart';
+import 'package:travel_route_planner/navigation/app_nav.dart';
+import 'package:travel_route_planner/providers/analytics_provider.dart';
+import 'package:travel_route_planner/providers/auth_provider.dart';
+import 'package:travel_route_planner/providers/locale_provider.dart';
+import 'package:travel_route_planner/screens/auth_screen.dart';
+import 'package:travel_route_planner/screens/home_screen.dart';
+import 'package:travel_route_planner/screens/landing_screen.dart';
+import 'package:travel_route_planner/services/analytics_api_service.dart';
+import 'package:travel_route_planner/services/api_client.dart';
+import 'package:travel_route_planner/services/auth_service.dart';
+import 'package:travel_route_planner/services/auth_storage.dart';
+import 'package:travel_route_planner/widgets/gradient_app_bar.dart';
+import 'package:travel_route_planner/widgets/language_menu_button.dart';
+
+import 'support/l10n_test_app.dart';
+
+/// The app-bar globe menu (specs/i18n-spanish, visible language switcher):
+/// same three choices as the settings picker, checked on the override, and
+/// present on the surfaces a signed-out visitor actually sees — including at
+/// rail width, where AccountMenu hides itself and the globe must not.
+///
+/// The locale provider reads authProvider to decide whether to sync the
+/// choice to the account; constructing the real AuthStorage hits
+/// flutter_secure_storage, which has no implementation under `flutter test`.
+class _FakeAuthStorage extends AuthStorage {
+  String? token;
+
+  @override
+  Future<String?> loadToken() async => token;
+
+  @override
+  Future<void> saveToken(String value) async => token = value;
+
+  @override
+  Future<void> clearToken() async => token = null;
+}
+
+/// Records nothing; Google SSO reports unavailable so the button stays hidden.
+class _FakeAuthService extends AuthService {
+  _FakeAuthService() : super(baseUrl: 'http://unused');
+
+  @override
+  Future<bool> googleSignInAvailable() async => false;
+}
+
+class _NoopAnalytics implements AnalyticsApiService {
+  @override
+  ApiClient get apiClient => throw UnimplementedError();
+
+  @override
+  Future<void> recordLandingViewed() => Future.value();
+
+  @override
+  Future<void> recordBookingLinkClicked({
+    String? tripId,
+    String? todoKey,
+    String? provider,
+    String? surface,
+    String? kind,
+  }) =>
+      Future.value();
+
+  @override
+  Future<void> recordItineraryItemAdded({
+    required String tripId,
+    required String source,
+  }) =>
+      Future.value();
+}
+
+/// Auth notifier pinned to a fixed signed-in state, so the home screen can be
+/// pumped without network or storage.
+class _FakeAuthNotifier extends StateNotifier<AuthState>
+    implements AuthNotifier {
+  _FakeAuthNotifier(UserModel? user)
+      : super(AuthState(user: user, initialized: true));
+
+  @override
+  Future<bool> login(String email, String password) async => false;
+
+  @override
+  Future<bool> register(String email, String password,
+          {String? displayName}) async =>
+      false;
+
+  @override
+  Future<void> completeOnboarding() async {}
+
+  @override
+  Future<void> logout() async {}
+
+  @override
+  Future<void> signOutLocally() async {}
+
+  @override
+  void setUser(UserModel user) {}
+
+  @override
+  Future<void> adoptSession(String token, UserModel user) async {}
+}
+
+bool _checkedOf(WidgetTester tester, String label) => tester
+    .widget<CheckedPopupMenuItem<String>>(
+        find.widgetWithText(CheckedPopupMenuItem<String>, label))
+    .checked;
+
+void main() {
+  setUp(() => SharedPreferences.setMockInitialValues({}));
+
+  testWidgets('menu lists System default, English and Español with the '
+      'override checked', (tester) async {
+    await tester.pumpWidget(ProviderScope(
+      overrides: [authStorageProvider.overrideWithValue(_FakeAuthStorage())],
+      child: localizedTestApp(
+        home: Scaffold(
+          appBar: GradientAppBar(
+            title: const Text('t'),
+            actions: const [LanguageMenuButton()],
+          ),
+        ),
+      ),
+    ));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byIcon(Icons.language));
+    await tester.pumpAndSettle();
+
+    expect(find.text('System default'), findsOneWidget);
+    expect(find.text('English'), findsOneWidget);
+    expect(find.text('Español'), findsOneWidget);
+    expect(_checkedOf(tester, 'System default'), isTrue);
+    expect(_checkedOf(tester, 'English'), isFalse);
+    expect(_checkedOf(tester, 'Español'), isFalse);
+  });
+
+  testWidgets('selecting Español switches the app and checks it in the menu',
+      (tester) async {
+    late WidgetRef ref;
+    await tester.pumpWidget(ProviderScope(
+      overrides: [authStorageProvider.overrideWithValue(_FakeAuthStorage())],
+      child: Consumer(builder: (context, r, _) {
+        ref = r;
+        final locale = r.watch(localeProvider.select((s) => s.materialLocale));
+        return MaterialApp(
+          localizationsDelegates: testLocalizationsDelegates,
+          supportedLocales: kSupportedLocales,
+          locale: locale,
+          home: Scaffold(
+            appBar: AppBar(actions: const [LanguageMenuButton()]),
+            body: Builder(
+              builder: (context) => Text(context.l10n.languageSectionTitle),
+            ),
+          ),
+        );
+      }),
+    ));
+    await tester.pumpAndSettle();
+    expect(find.text('Language'), findsOneWidget);
+
+    await tester.tap(find.byIcon(Icons.language));
+    await tester.pumpAndSettle();
+    await tester
+        .tap(find.widgetWithText(CheckedPopupMenuItem<String>, 'Español'));
+    await tester.pumpAndSettle();
+
+    expect(ref.read(localeProvider).override, 'es');
+    expect(find.text('Idioma'), findsOneWidget);
+    expect(find.text('Language'), findsNothing);
+
+    // Reopened, the menu itself is now in Spanish, with Español checked.
+    await tester.tap(find.byIcon(Icons.language));
+    await tester.pumpAndSettle();
+    expect(_checkedOf(tester, 'Español'), isTrue);
+    expect(_checkedOf(tester, 'Predeterminado del sistema'), isFalse);
+  });
+
+  testWidgets('landing screen shows the globe signed out, even at rail width',
+      (tester) async {
+    LandingScreen.resetViewRecordedForTest();
+    await tester.binding.setSurfaceSize(const Size(1200, 800));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    expect(1200, greaterThanOrEqualTo(kRailBreakpoint));
+
+    await tester.pumpWidget(ProviderScope(
+      overrides: [
+        authStorageProvider.overrideWithValue(_FakeAuthStorage()),
+        analyticsApiServiceProvider.overrideWithValue(_NoopAnalytics()),
+      ],
+      child: localizedTestApp(home: const LandingScreen()),
+    ));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(LanguageMenuButton), findsOneWidget);
+    expect(find.byIcon(Icons.language), findsOneWidget);
+  });
+
+  testWidgets('home app bar shows the globe', (tester) async {
+    // The default 800x600 surface sits exactly at kRailBreakpoint, where
+    // AccountMenu renders nothing — the globe must still be there.
+    await tester.pumpWidget(ProviderScope(
+      overrides: [
+        authStorageProvider.overrideWithValue(_FakeAuthStorage()),
+        authProvider.overrideWith((ref) => _FakeAuthNotifier(UserModel(
+              id: 'user-1',
+              email: 'test@example.com',
+              displayName: 'Test',
+              createdAt: DateTime(2026, 1, 1),
+            ))),
+      ],
+      child: localizedTestApp(home: const HomeScreen()),
+    ));
+    await tester.pump();
+
+    expect(find.byType(LanguageMenuButton), findsOneWidget);
+  });
+
+  testWidgets('sign-in screen shows the globe', (tester) async {
+    await tester.pumpWidget(ProviderScope(
+      overrides: [
+        authServiceProvider.overrideWithValue(_FakeAuthService()),
+        authStorageProvider.overrideWithValue(_FakeAuthStorage()),
+      ],
+      child: localizedTestApp(home: const AuthScreen()),
+    ));
+    await tester.pump();
+
+    expect(find.byType(LanguageMenuButton), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## What

Adds a visible way to change languages — previously the only control was the radio picker buried in Account settings (avatar menu → Account settings → Language), and **signed-out visitors had no way to switch at all**.

- New `LanguageMenuButton` widget: globe icon → popup menu with **System default / English / Español**, checkmark on the current override (same semantics as the settings picker, same `localeProvider.setOverride`). Styled like the AccountMenu popup (under the bar, M3 surface, `AppRadius.mdAll`).
- Mounted on three surfaces: **Home** app bar (next to the avatar), **landing** page (next to Sign in), and the **sign-in** screen's transparent bar. Trips/Plan tabs unchanged; settings picker stays.
- Renders at **every width** — deliberately unlike `AccountMenu`'s ≥800px self-hide, since the rail has no language control to defer to.
- Entries iterate `kSupportedLocales`; a shared `languageDisplayName` helper in `l10n.dart` replaces the picker's private `_nameFor`, so the two surfaces can never disagree. Adding a future language remains a one-line + ARB change.
- One new ARB key `languageMenuTooltip` (en "Change language" / es "Cambiar idioma") — without it PopupMenuButton shows the framework's unlocalized "Show menu".
- Amends `specs/i18n-spanish` (new acceptance criteria + PR 8 checklist).

## Testing

- 5 new widget tests (`language_menu_button_test.dart`): menu contents + checked state, Español selection flips override/UI and re-checks in the (now Spanish) menu, landing shows the globe signed-out at rail width, Home and sign-in mounts.
- Full suite passes (481); `flutter analyze` clean; `flutter gen-l10n` drift-free with empty `l10n_untranslated.json`.
- Verified live on the dev stack: signed-in Home (wide) switch to Español redraws instantly and the settings radio agrees; fresh-origin signed-out landing switch works; sign-in screen shows the dark globe on the transparent bar; System default restores device language everywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)