### PR TITLE
security: add edge security headers (HSTS, XFO, CSP-Report-Only)

### DIFF
--- a/dockerize/deployment/nginx/snippets/app-locations.conf
+++ b/dockerize/deployment/nginx/snippets/app-locations.conf
@@ -9,6 +9,12 @@
 root /usr/share/nginx/html;
 index index.html;
 
+# Server-scope security headers. Locations WITHOUT their own add_header (/api/,
+# the legal pages, robots/sitemap, the `/` redirect) inherit these; the app
+# blocks below that define their own add_header re-include the snippet, since
+# nginx stops inheriting add_header once a level sets any of its own.
+include /etc/nginx/snippets/security-headers.conf;
+
 location /api/ {
     proxy_pass http://api:8080;
     proxy_http_version 1.1;
@@ -47,6 +53,7 @@ location ~ ^/app/share/ {
 
     add_header Cross-Origin-Embedder-Policy require-corp;
     add_header Cross-Origin-Opener-Policy same-origin;
+    include /etc/nginx/snippets/security-headers.conf;
 }
 
 location /app/ {
@@ -54,6 +61,7 @@ location /app/ {
 
     add_header Cross-Origin-Embedder-Policy require-corp;
     add_header Cross-Origin-Opener-Policy same-origin;
+    include /etc/nginx/snippets/security-headers.conf;
 }
 
 # App-shell files that change IN PLACE on every deploy — flutter build does
@@ -67,6 +75,7 @@ location ~ ^/app/(?:index\.html|flutter_service_worker\.js|flutter_bootstrap\.js
     add_header Cache-Control "no-cache";
     add_header Cross-Origin-Embedder-Policy require-corp;
     add_header Cross-Origin-Opener-Policy same-origin;
+    include /etc/nginx/snippets/security-headers.conf;
 }
 
 # Long-lived caching ONLY for the service-worker-managed resource trees
@@ -80,6 +89,7 @@ location ~ ^/app/(?:assets|canvaskit|icons)/ {
     add_header Cache-Control "public, max-age=31536000, immutable";
     add_header Cross-Origin-Embedder-Policy require-corp;
     add_header Cross-Origin-Opener-Policy same-origin;
+    include /etc/nginx/snippets/security-headers.conf;
 }
 
 # Legal pages — static HTML, shared source of truth in dockerize/static/

--- a/dockerize/deployment/nginx/snippets/security-headers.conf
+++ b/dockerize/deployment/nginx/snippets/security-headers.conf
@@ -1,0 +1,36 @@
+# Shared security response headers. Included at *server* scope by
+# app-locations.conf AND re-included inside every location that sets its own
+# add_header — nginx does NOT inherit add_header once a level defines any of
+# its own, so each such block must re-include this file to keep the headers.
+#
+# The Content-Security-Policy ships Report-Only first: it emits console
+# violations for tuning but blocks nothing, so a too-tight source list can't
+# take the live app down. Once the browser console is clean, rename
+# Content-Security-Policy-Report-Only -> Content-Security-Policy to enforce.
+#
+# `always` so the headers are sent on error/redirect responses too. HSTS is
+# harmless on the plain-:80 deployment/dev gateway (browsers honor it only over
+# HTTPS) and takes effect for real once Cloudflare serves the origin over TLS.
+
+add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
+add_header X-Content-Type-Options "nosniff" always;
+add_header X-Frame-Options "DENY" always;
+add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+# microphone=(self): voice dictation (speech_to_text). No geolocation/camera/
+# payment/usb packages exist in the app, so those are denied outright.
+add_header Permissions-Policy "camera=(), geolocation=(), microphone=(self), payment=(), usb=()" always;
+
+# CSP source rationale:
+#   script-src  'unsafe-inline' — web/index.html carries inline bootstrap,
+#               splash-fade, and autofill-shim scripts; 'wasm-unsafe-eval' —
+#               the CanvasKit renderer compiles WebAssembly.
+#   style-src   'unsafe-inline' — inline splash <style> + Flutter's runtime
+#               injected styles.
+#   img-src     https: + data:/blob: — arbitrary local-guide photo hosts and
+#               the two map-tile CDNs, plus generated/inline images.
+#   connect-src https: — under the CanvasKit renderer, network images (guide
+#               photos, map tiles) and the fallback fonts are fetched via XHR,
+#               so they land in connect-src, not img-src/font-src. 'self' also
+#               covers same-origin /api over plain http on the dev gateway.
+#   worker-src  blob: — CanvasKit spawns web workers from blob: URLs.
+add_header Content-Security-Policy-Report-Only "default-src 'self'; script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data: https://fonts.gstatic.com; connect-src 'self' https:; worker-src 'self' blob:; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; manifest-src 'self'" always;


### PR DESCRIPTION
## Summary
Launch-readiness P0 (HIGH-2 from the security audit): the gateway sent **no** security response headers. Add a shared `snippets/security-headers.conf` and wire it into the gateway.

Headers added:
- `Strict-Transport-Security` (2y, includeSubDomains)
- `X-Content-Type-Options: nosniff`
- `X-Frame-Options: DENY`
- `Referrer-Policy: strict-origin-when-cross-origin`
- `Permissions-Policy: camera=(), geolocation=(), microphone=(self), payment=(), usb=()` — only microphone is allowed (voice dictation via `speech_to_text`); the app has no camera/geolocation/payment/usb packages, verified by grep.
- `Content-Security-Policy-Report-Only` — **Report-Only first** so a too-tight source list can't take the live app down; flip to enforcing once the browser console is clean.

## CSP tuning (CanvasKit Flutter build)
- `script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval'` — `web/index.html` carries inline bootstrap/splash/autofill scripts; CanvasKit compiles WASM.
- `style-src 'self' 'unsafe-inline'` — inline splash `<style>` + Flutter runtime styles.
- `img-src 'self' data: blob: https:` and `connect-src 'self' https:` — arbitrary local-guide photo hosts + the two map-tile CDNs (`server.arcgisonline.com`, `basemaps.cartocdn.com`); CanvasKit fetches network images via XHR, so they land in `connect-src`.
- `worker-src 'self' blob:` — CanvasKit workers.

## Wiring
`include`d at **server scope** (covers `/api`, legal pages, robots/sitemap, the `/` redirect) and re-included inside each of the four app blocks that define their own `add_header` — nginx stops inheriting `add_header` once a level sets any of its own. The snippet is baked into the gateway image (`snippets/` is COPYed wholesale), so both the deployment `:80` and production TLS servers pick it up. Does not touch the pre-existing COEP/COOP headers.

## Test plan
- [x] `nginx -t` passes for both the deployment and production server configs (validated in a throwaway `nginx:alpine`).
- [x] Runtime `curl -I`: the app document (`/app/`) and legal pages (`/privacy`) carry all six headers alongside the existing COEP/COOP; the internal `/health` correctly stays bare.
- [ ] Post-deploy: watch the browser console for CSP-Report-Only violations, then flip to enforcing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)