### PR TITLE
security: redact capability tokens + mask email PII in logs

### DIFF
--- a/src/packages/api/email_auth_handler.go
+++ b/src/packages/api/email_auth_handler.go
@@ -107,7 +107,7 @@ func sendVerificationEmailIn(user store.User, locale string) {
 	// throttled resend doesn't invalidate a still-valid prior token. Keyed by
 	// purpose so verify and reset don't block each other. Anti email-bombing.
 	if !emailSendThrottle.allow("verify:"+strings.ToLower(user.Email), time.Now(), emailMinInterval()) {
-		log.Printf("verification email: throttled for %s (min interval not elapsed)", user.Email)
+		log.Printf("verification email: throttled for %s (min interval not elapsed)", maskEmail(user.Email))
 		return
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
@@ -115,13 +115,13 @@ func sendVerificationEmailIn(user store.User, locale string) {
 	q := store.New(dbPool)
 	token, err := issueEmailToken(ctx, q, user, "verify", verifyTokenTTL)
 	if err != nil {
-		log.Printf("verification email: could not issue token for %s: %v", user.Email, err)
+		log.Printf("verification email: could not issue token for %s: %v", maskEmail(user.Email), err)
 		return
 	}
 	link := publicAppURL("verify/", token)
 	body := tr(locale, "email.verify.body", link)
 	if err := emailSend(user.Email, tr(locale, "email.verify.subject"), body); err != nil {
-		log.Printf("verification email: send to %s failed: %v", user.Email, err)
+		log.Printf("verification email: send to %s failed: %v", maskEmail(user.Email), err)
 	}
 }
 
@@ -233,23 +233,23 @@ func requestPasswordResetHandler(w http.ResponseWriter, r *http.Request) {
 			// still always answers 202, so the throttle is invisible to callers
 			// and can't be used to enumerate accounts. Anti email-bombing.
 			if !emailSendThrottle.allow("reset:"+u.Email, time.Now(), emailMinInterval()) {
-				log.Printf("password reset: throttled for %s (min interval not elapsed)", u.Email)
+				log.Printf("password reset: throttled for %s (min interval not elapsed)", maskEmail(u.Email))
 				return
 			}
 			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 			defer cancel()
 			token, err := issueEmailToken(ctx, store.New(dbPool), u, "reset", resetTokenTTL)
 			if err != nil {
-				log.Printf("password reset: could not issue token for %s: %v", u.Email, err)
+				log.Printf("password reset: could not issue token for %s: %v", maskEmail(u.Email), err)
 				return
 			}
 			body := tr(locale, "email.reset.body", publicAppURL("reset/", token), token)
 			if err := emailSend(u.Email, tr(locale, "email.reset.subject"), body); err != nil {
-				log.Printf("password reset: send to %s failed: %v", u.Email, err)
+				log.Printf("password reset: send to %s failed: %v", maskEmail(u.Email), err)
 			}
 		})
 	} else if !errors.Is(err, pgx.ErrNoRows) {
-		log.Printf("password reset: lookup failed for %s: %v", email, err)
+		log.Printf("password reset: lookup failed for %s: %v", maskEmail(email), err)
 	}
 	w.WriteHeader(http.StatusAccepted)
 }

--- a/src/packages/api/email_service.go
+++ b/src/packages/api/email_service.go
@@ -80,7 +80,15 @@ func listUnsubscribeHeaders(unsubscribeURL string) []string {
 // user-facing error.
 func (s *EmailService) SendWithHeaders(to, subject, body string, extraHeaders []string) error {
 	if !s.Configured() {
-		log.Printf("email (not sent, SMTP unconfigured) to=%s subject=%q headers=%v body=%q", to, subject, extraHeaders, body)
+		// The full body carries verify/reset tokens and one-click unsubscribe
+		// links — invaluable for grabbing a token in local dev, but a secret
+		// leak if SMTP is ever unset in production. Log it only outside
+		// production; production gets a masked, body-free line.
+		if os.Getenv("GO_ENV") == "production" {
+			log.Printf("email (not sent, SMTP unconfigured) to=%s subject=%q", maskEmail(to), subject)
+		} else {
+			log.Printf("email (not sent, SMTP unconfigured) to=%s subject=%q headers=%v body=%q", to, subject, extraHeaders, body)
+		}
 		return nil
 	}
 	msg := buildEmailMessage(s.From, to, subject, body, extraHeaders)
@@ -107,4 +115,21 @@ func buildEmailMessage(from, to, subject, body string, extraHeaders []string) st
 	lines = append(lines, extraHeaders...)
 	lines = append(lines, "", body)
 	return strings.Join(lines, "\r\n")
+}
+
+// maskEmail reduces an address to a low-PII form for logs: it keeps the first
+// (and, when the local part is long enough, last) character of the local part
+// and the full domain, so a line stays useful for delivery debugging without
+// recording who the recipient is — e.g. "brian@gmail.com" -> "b***n@gmail.com".
+// A value without a usable local part is dropped entirely.
+func maskEmail(email string) string {
+	at := strings.LastIndexByte(email, '@')
+	if at <= 0 || at == len(email)-1 {
+		return "[redacted-email]"
+	}
+	local, domain := email[:at], email[at+1:]
+	if len(local) <= 2 {
+		return local[:1] + "***@" + domain
+	}
+	return local[:1] + "***" + local[len(local)-1:] + "@" + domain
 }

--- a/src/packages/api/invite_handler.go
+++ b/src/packages/api/invite_handler.go
@@ -146,7 +146,7 @@ func sendInviteEmail(owner store.User, to, token, tripTitle, locale string) {
 	link := publicAppURL("invite/", token)
 	body := tr(locale, "email.invite.body", ownerName, tripTitle, link)
 	if err := emailService.Send(to, tr(locale, "email.invite.subject", ownerName, tripTitle), body); err != nil {
-		log.Printf("invite email: send to %s failed: %v", to, err)
+		log.Printf("invite email: send to %s failed: %v", maskEmail(to), err)
 	}
 }
 

--- a/src/packages/api/log_hygiene_test.go
+++ b/src/packages/api/log_hygiene_test.go
@@ -1,0 +1,66 @@
+package main
+
+import "testing"
+
+func TestRedactPath(t *testing.T) {
+	cases := []struct{ in, want string }{
+		// Token segment scrubbed, trailing path kept.
+		{"/api/v1/export/abc123secret/print.html", "/api/v1/export/[redacted]/print.html"},
+		{"/api/v1/export/abc123secret/event/stay/42.ics", "/api/v1/export/[redacted]/event/stay/42.ics"},
+		{"/api/v1/shared/tok/join", "/api/v1/shared/[redacted]/join"},
+		// Terminal token (no trailing path).
+		{"/api/v1/shared/tok", "/api/v1/shared/[redacted]"},
+		{"/api/v1/invites/tok", "/api/v1/invites/[redacted]"},
+		{"/api/v1/unsubscribe/tok", "/api/v1/unsubscribe/[redacted]"},
+		{"/api/v1/share-preview/tok", "/api/v1/share-preview/[redacted]"},
+		// Prefix present but no segment after it — left alone.
+		{"/api/v1/export/", "/api/v1/export/"},
+		// Non-token paths pass through untouched.
+		{"/api/v1/trips/123", "/api/v1/trips/123"},
+		{"/api/v1/health", "/api/v1/health"},
+		{"/api/v1/exported/xyz", "/api/v1/exported/xyz"}, // not a prefix match
+	}
+	for _, c := range cases {
+		if got := redactPath(c.in); got != c.want {
+			t.Errorf("redactPath(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestRedactQuery(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"token=abc", "token=[redacted]"},
+		{"code=xyz&state=csrf", "code=[redacted]&state=[redacted]"},
+		// Non-sensitive keys preserved verbatim, order intact.
+		{"q=paris&page=2", "q=paris&page=2"},
+		// Mixed: only sensitive value scrubbed, others kept in place.
+		{"foo=1&token=secret&bar=2", "foo=1&token=[redacted]&bar=2"},
+		// Case-insensitive key match.
+		{"Token=secret", "Token=[redacted]"},
+		// Bare sensitive key with no value.
+		{"token", "token=[redacted]"},
+		{"", ""},
+	}
+	for _, c := range cases {
+		if got := redactQuery(c.in); got != c.want {
+			t.Errorf("redactQuery(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestMaskEmail(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"brian@gmail.com", "b***n@gmail.com"},
+		{"bo@example.com", "b***@example.com"}, // 2-char local
+		{"a@x.io", "a***@x.io"},                // 1-char local
+		{"first.last@sub.domain.co", "f***t@sub.domain.co"},
+		{"nolocal", "[redacted-email]"},   // no @
+		{"trailing@", "[redacted-email]"}, // @ at end, empty domain
+		{"@nodomain", "[redacted-email]"}, // empty local
+	}
+	for _, c := range cases {
+		if got := maskEmail(c.in); got != c.want {
+			t.Errorf("maskEmail(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}

--- a/src/packages/api/main.go
+++ b/src/packages/api/main.go
@@ -482,14 +482,15 @@ func shouldWarnSigningSecrets(goEnv, exportSecret, unsubSecret string) bool {
 		strings.TrimSpace(unsubSecret) == ""
 }
 
-// warnIfSigningSecretsUnset emits a loud startup warning (never fatal — a soft
-// launch shouldn't die on this) when running in production without a stable
-// signing secret. Reads the raw envs directly, which is non-invasive: the token
-// files resolve their secret lazily via sync.Once, so this re-read does not force
-// or perturb their initialization.
+// warnIfSigningSecretsUnset logs at error level (never fatal — a soft launch
+// shouldn't die on this, but error level routes it to Sentry so a misconfigured
+// production deploy pages instead of scrolling past) when running in production
+// without a stable signing secret. Reads the raw envs directly, which is
+// non-invasive: the token files resolve their secret lazily via sync.Once, so
+// this re-read does not force or perturb their initialization.
 func warnIfSigningSecretsUnset() {
 	if shouldWarnSigningSecrets(os.Getenv("GO_ENV"), os.Getenv("EXPORT_SIGNING_SECRET"), os.Getenv("UNSUBSCRIBE_SIGNING_SECRET")) {
-		slog.Warn("signing secrets unset — outstanding unsubscribe/export links will break on restart; set EXPORT_SIGNING_SECRET (openssl rand -hex 32) in production")
+		slog.Error("signing secrets unset — outstanding unsubscribe/export links will break on restart; set EXPORT_SIGNING_SECRET (openssl rand -hex 32) in production")
 	}
 }
 

--- a/src/packages/api/middleware.go
+++ b/src/packages/api/middleware.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"runtime/debug"
+	"strings"
 	"time"
 
 	"github.com/getsentry/sentry-go"
@@ -49,6 +51,77 @@ func (s *statusRecorder) Flush() {
 	}
 }
 
+// tokenPathPrefixes are URL path prefixes whose NEXT segment is a secret — a
+// signed export token, a share/invite/unsubscribe token, or a share-preview
+// token. redactPath scrubs that segment so capability tokens never reach the
+// request log (from where they could be replayed).
+var tokenPathPrefixes = []string{
+	"/api/v1/export/",
+	"/api/v1/shared/",
+	"/api/v1/invites/",
+	"/api/v1/unsubscribe/",
+	"/api/v1/share-preview/",
+}
+
+// redactPath replaces the secret segment following a known token-bearing
+// prefix with "[redacted]", keeping the rest of the path for debugging
+// (e.g. /api/v1/export/[redacted]/print.html). Paths without such a prefix
+// pass through unchanged.
+func redactPath(p string) string {
+	for _, prefix := range tokenPathPrefixes {
+		if !strings.HasPrefix(p, prefix) {
+			continue
+		}
+		rest := p[len(prefix):]
+		if rest == "" {
+			return p
+		}
+		if i := strings.IndexByte(rest, '/'); i >= 0 {
+			return prefix + "[redacted]" + rest[i:]
+		}
+		return prefix + "[redacted]"
+	}
+	return p
+}
+
+// sensitiveQueryKeys are query parameters whose values are secrets or
+// single-use capability codes (email-verify token, OAuth code/state, and the
+// OAuth token echoes some providers append).
+var sensitiveQueryKeys = map[string]bool{
+	"token":        true,
+	"code":         true,
+	"state":        true,
+	"access_token": true,
+	"id_token":     true,
+}
+
+// redactQuery replaces the values of sensitive query keys with "[redacted]",
+// leaving every other parameter — and the original order — intact. Splitting on
+// the raw "&" is safe because a literal "&" inside a value is always
+// percent-encoded. A query with no sensitive keys is returned verbatim.
+func redactQuery(raw string) string {
+	parts := strings.Split(raw, "&")
+	changed := false
+	for i, p := range parts {
+		key := p
+		if eq := strings.IndexByte(p, '='); eq >= 0 {
+			key = p[:eq]
+		}
+		decoded := key
+		if u, err := url.QueryUnescape(key); err == nil {
+			decoded = u
+		}
+		if sensitiveQueryKeys[strings.ToLower(decoded)] {
+			parts[i] = key + "=[redacted]"
+			changed = true
+		}
+	}
+	if !changed {
+		return raw
+	}
+	return strings.Join(parts, "&")
+}
+
 // requestIDMiddleware assigns each request an ID (honoring an inbound
 // X-Request-ID from the gateway), echoes it on the response, and emits the
 // structured request log line.
@@ -67,13 +140,13 @@ func requestIDMiddleware(next http.Handler) http.Handler {
 		attrs := []any{
 			"request_id", id,
 			"method", r.Method,
-			"path", r.URL.Path,
+			"path", redactPath(r.URL.Path),
 			"status", rec.status,
 			"duration_ms", time.Since(start).Milliseconds(),
 			"remote", clientIP(r),
 		}
 		if q := r.URL.RawQuery; q != "" {
-			attrs = append(attrs, "query", q)
+			attrs = append(attrs, "query", redactQuery(q))
 		}
 		slog.Info("request", attrs...)
 	})

--- a/src/packages/api/ops_monitor.go
+++ b/src/packages/api/ops_monitor.go
@@ -157,7 +157,7 @@ func (m *healthMonitor) alertTransition(ctx context.Context, state healthState) 
 	subject, body := buildOpsAlertEmail(state.degraded, state.reasons, publicAppURL())
 	for _, a := range admins {
 		if err := m.sendEmail(a.Email, subject, body); err != nil {
-			log.Printf("ops health: alert email to %s failed: %v", a.Email, err)
+			log.Printf("ops health: alert email to %s failed: %v", maskEmail(a.Email), err)
 		}
 	}
 }

--- a/src/packages/api/price_alert_checker.go
+++ b/src/packages/api/price_alert_checker.go
@@ -461,7 +461,7 @@ func buildAlertEmail(locale string, a store.PriceAlert, lowest FlightOffer, matc
 func sendAlertEmail(locale, to string, a store.PriceAlert, lowest FlightOffer, matched pgtype.Date) {
 	subject, body := buildAlertEmail(locale, a, lowest, matched)
 	if err := emailService.Send(to, subject, body); err != nil {
-		log.Printf("price alerts: email to %s failed: %v", to, err)
+		log.Printf("price alerts: email to %s failed: %v", maskEmail(to), err)
 	}
 }
 

--- a/src/packages/api/reengagement_checker.go
+++ b/src/packages/api/reengagement_checker.go
@@ -269,7 +269,7 @@ func sendReminderEmail(row store.ListTripsForReminderRow, kind string) {
 	// account synced (ListTripsForReminder carries it on the row).
 	subject, body := buildTripReminderEmail(localeOrDefault(row.Locale), kind, row.Title, dateString(row.StartDate), tripURL, unsub)
 	if err := emailService.SendMarketing(row.Email, subject, body, unsub); err != nil {
-		log.Printf("re-engagement: reminder email to %s failed: %v", row.Email, err)
+		log.Printf("re-engagement: reminder email to %s failed: %v", maskEmail(row.Email), err)
 	}
 }
 
@@ -282,6 +282,6 @@ func sendNudgeEmail(row store.ListUsersForWeeklyNudgeRow) {
 	}
 	subject, body := buildWeeklyNudgeEmail(localeOrDefault(row.Locale), name, appURL, unsub)
 	if err := emailService.SendMarketing(row.Email, subject, body, unsub); err != nil {
-		log.Printf("re-engagement: nudge email to %s failed: %v", row.Email, err)
+		log.Printf("re-engagement: nudge email to %s failed: %v", maskEmail(row.Email), err)
 	}
 }


### PR DESCRIPTION
## Summary
Three log-hygiene fixes from the launch audit (MED severity):

**1. Capability tokens no longer land in the request log.** `requestIDMiddleware` logged `r.URL.Path` and `RawQuery` verbatim, so signed export tokens, share/invite/unsubscribe tokens, and OAuth `code`/`state` were written to logs (replayable).
- `redactPath()` scrubs the secret segment after `/export/`, `/shared/`, `/invites/`, `/unsubscribe/`, `/share-preview/` (keeps the rest: `/api/v1/export/[redacted]/print.html`).
- `redactQuery()` scrubs `token`/`code`/`state`/`access_token`/`id_token` values; other params and their order are preserved verbatim.

**2. Email PII masked.** ~13 send-path log sites logged recipient emails in cleartext. `maskEmail()` reduces `brian@gmail.com` → `b***n@gmail.com` (keeps the domain for delivery debugging). Applied across verify/reset, invite, ops-alert, price-alert, and re-engagement paths. The SMTP-unconfigured fallback still logs the full body (for grabbing a token) in dev, but drops the body and masks the recipient in production.

**3. Signing-secret misconfig now pages.** `warnIfSigningSecretsUnset` logs at **error** level (routes to Sentry) so a production deploy missing `EXPORT_SIGNING_SECRET` alerts instead of scrolling past a warning.

## Test plan
- [x] New `log_hygiene_test.go` unit-tests `redactPath`, `redactQuery`, `maskEmail` (table-driven, edge cases included).
- [x] `gofmt`, `go build`, `go vet`, `go test ./... -short` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)