### PR TITLE
ux: friendly error messages instead of raw ApiException dumps

### DIFF
--- a/src/packages/flutter-app/lib/l10n/app_en.arb
+++ b/src/packages/flutter-app/lib/l10n/app_en.arb
@@ -1846,5 +1846,10 @@
   "calendarModeBus": "Bus",
   "calendarModeCar": "Car",
   "calendarModeFerry": "Ferry",
-  "calendarModeOther": "Other"
+  "calendarModeOther": "Other",
+  "errorNetwork": "Check your internet connection and try again.",
+  "errorTooManyRequests": "You're going a little too fast — wait a moment and try again.",
+  "errorSession": "Your session has expired. Please sign in again.",
+  "errorServer": "Something went wrong on our end. Please try again in a moment.",
+  "errorGeneric": "Something went wrong. Please try again."
 }

--- a/src/packages/flutter-app/lib/l10n/app_es.arb
+++ b/src/packages/flutter-app/lib/l10n/app_es.arb
@@ -780,5 +780,10 @@
   "calendarModeBus": "Autobús",
   "calendarModeCar": "Coche",
   "calendarModeFerry": "Ferri",
-  "calendarModeOther": "Otro"
+  "calendarModeOther": "Otro",
+  "errorNetwork": "Comprueba tu conexión a internet e inténtalo de nuevo.",
+  "errorTooManyRequests": "Vas un poco demasiado rápido: espera un momento e inténtalo de nuevo.",
+  "errorSession": "Tu sesión ha caducado. Vuelve a iniciar sesión.",
+  "errorServer": "Algo salió mal de nuestro lado. Inténtalo de nuevo en un momento.",
+  "errorGeneric": "Algo salió mal. Inténtalo de nuevo."
 }

--- a/src/packages/flutter-app/lib/l10n/app_localizations.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations.dart
@@ -4783,6 +4783,36 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Other'**
   String get calendarModeOther;
+
+  /// No description provided for @errorNetwork.
+  ///
+  /// In en, this message translates to:
+  /// **'Check your internet connection and try again.'**
+  String get errorNetwork;
+
+  /// No description provided for @errorTooManyRequests.
+  ///
+  /// In en, this message translates to:
+  /// **'You\'re going a little too fast — wait a moment and try again.'**
+  String get errorTooManyRequests;
+
+  /// No description provided for @errorSession.
+  ///
+  /// In en, this message translates to:
+  /// **'Your session has expired. Please sign in again.'**
+  String get errorSession;
+
+  /// No description provided for @errorServer.
+  ///
+  /// In en, this message translates to:
+  /// **'Something went wrong on our end. Please try again in a moment.'**
+  String get errorServer;
+
+  /// No description provided for @errorGeneric.
+  ///
+  /// In en, this message translates to:
+  /// **'Something went wrong. Please try again.'**
+  String get errorGeneric;
 }
 
 class _AppLocalizationsDelegate

--- a/src/packages/flutter-app/lib/l10n/app_localizations_en.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations_en.dart
@@ -2767,4 +2767,21 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get calendarModeOther => 'Other';
+
+  @override
+  String get errorNetwork => 'Check your internet connection and try again.';
+
+  @override
+  String get errorTooManyRequests =>
+      'You\'re going a little too fast — wait a moment and try again.';
+
+  @override
+  String get errorSession => 'Your session has expired. Please sign in again.';
+
+  @override
+  String get errorServer =>
+      'Something went wrong on our end. Please try again in a moment.';
+
+  @override
+  String get errorGeneric => 'Something went wrong. Please try again.';
 }

--- a/src/packages/flutter-app/lib/l10n/app_localizations_es.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations_es.dart
@@ -2785,4 +2785,22 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get calendarModeOther => 'Otro';
+
+  @override
+  String get errorNetwork =>
+      'Comprueba tu conexión a internet e inténtalo de nuevo.';
+
+  @override
+  String get errorTooManyRequests =>
+      'Vas un poco demasiado rápido: espera un momento e inténtalo de nuevo.';
+
+  @override
+  String get errorSession => 'Tu sesión ha caducado. Vuelve a iniciar sesión.';
+
+  @override
+  String get errorServer =>
+      'Algo salió mal de nuestro lado. Inténtalo de nuevo en un momento.';
+
+  @override
+  String get errorGeneric => 'Algo salió mal. Inténtalo de nuevo.';
 }

--- a/src/packages/flutter-app/lib/providers/flights_provider.dart
+++ b/src/packages/flutter-app/lib/providers/flights_provider.dart
@@ -22,7 +22,9 @@ class FlightsState {
   final String? bestOfferId;
   final String optimizeFor;
   final bool loading;
-  final String? error;
+  // Holds the raw caught error (an ApiException, usually) so the UI can render
+  // it via friendlyError(l10n, ...); providers have no BuildContext/l10n.
+  final Object? error;
   final bool hasSearched;
 
   const FlightsState({
@@ -48,7 +50,7 @@ class FlightsState {
           bestOfferId == _sentinel ? this.bestOfferId : bestOfferId as String?,
       optimizeFor: optimizeFor ?? this.optimizeFor,
       loading: loading ?? this.loading,
-      error: error == _sentinel ? this.error : error as String?,
+      error: error == _sentinel ? this.error : error,
       hasSearched: hasSearched ?? this.hasSearched,
     );
   }
@@ -77,7 +79,7 @@ class FlightsNotifier extends StateNotifier<FlightsState> {
         loading: false,
       );
     } catch (e) {
-      state = state.copyWith(loading: false, error: e.toString());
+      state = state.copyWith(loading: false, error: e);
     }
   }
 

--- a/src/packages/flutter-app/lib/providers/plan_provider.dart
+++ b/src/packages/flutter-app/lib/providers/plan_provider.dart
@@ -46,7 +46,10 @@ class PlanState {
   final String? eventLinksCity;
   final List<LocalRecommendation>? localRecs;
   final String? localRecsCity;
-  final String? error;
+  // Either a friendly String the /plan SSE stream sent, or a raw caught error
+  // (ApiException) from a failed connect. friendlyError() renders both: it
+  // passes a String through unchanged and classifies an ApiException.
+  final Object? error;
 
   /// Messages the user sent while a turn was streaming, waiting FIFO to be
   /// sent. Always replaced whole, never mutated in place.
@@ -162,7 +165,7 @@ class PlanState {
       eventLinksCity: eventLinksCity == _sentinel ? this.eventLinksCity : eventLinksCity as String?,
       localRecs: localRecs == _sentinel ? this.localRecs : localRecs as List<LocalRecommendation>?,
       localRecsCity: localRecsCity == _sentinel ? this.localRecsCity : localRecsCity as String?,
-      error: error == _sentinel ? this.error : error as String?,
+      error: error == _sentinel ? this.error : error,
       queuedMessages: queuedMessages ?? this.queuedMessages,
       suggestedReplies: suggestedReplies ?? this.suggestedReplies,
       profileUpdateNote:
@@ -572,7 +575,7 @@ class PlanNotifier extends StateNotifier<PlanState> {
         activeTools: [],
         isCompacting: false,
         suggestedReplies: [],
-        error: e.toString(),
+        error: e,
       );
     }
   }

--- a/src/packages/flutter-app/lib/screens/alerts_screen.dart
+++ b/src/packages/flutter-app/lib/screens/alerts_screen.dart
@@ -6,6 +6,7 @@ import '../providers/alerts_provider.dart';
 import '../providers/notifications_provider.dart';
 import '../providers/auth_provider.dart';
 import '../theme/spacing.dart';
+import '../utils/errors.dart';
 import '../utils/money_format.dart';
 import '../widgets/empty_state.dart';
 import '../widgets/offline_banner.dart' show relativeTime;
@@ -267,7 +268,7 @@ class _AlertCard extends ConsumerWidget {
         await notifier.updateTarget(alert.id, result.target!);
       }
     } catch (e) {
-      if (context.mounted) showSnack(context, '$e');
+      if (context.mounted) showSnack(context, friendlyError(l10n, e));
     }
   }
 
@@ -285,7 +286,7 @@ class _AlertCard extends ConsumerWidget {
       try {
         await action();
       } catch (e) {
-        if (context.mounted) showSnack(context, '$e');
+        if (context.mounted) showSnack(context, friendlyError(l10n, e));
       }
     }
 

--- a/src/packages/flutter-app/lib/screens/flight_search_screen.dart
+++ b/src/packages/flutter-app/lib/screens/flight_search_screen.dart
@@ -6,6 +6,7 @@ import '../models/flight_search_request.dart';
 import '../providers/auth_provider.dart';
 import '../providers/flights_provider.dart';
 import '../providers/preferences_provider.dart';
+import '../utils/errors.dart';
 import '../widgets/airport_field.dart';
 import '../widgets/page_container.dart';
 import '../widgets/create_alert_sheet.dart';
@@ -595,7 +596,7 @@ class _Results extends StatelessWidget {
                   style: theme.textTheme.titleMedium),
               const SizedBox(height: 4),
               Text(
-                state.error!,
+                friendlyError(l10n, state.error),
                 textAlign: TextAlign.center,
                 style: theme.textTheme.bodySmall
                     ?.copyWith(color: theme.colorScheme.onSurfaceVariant),

--- a/src/packages/flutter-app/lib/screens/shared_trip_screen.dart
+++ b/src/packages/flutter-app/lib/screens/shared_trip_screen.dart
@@ -11,6 +11,7 @@ import '../providers/shared_trip_provider.dart';
 import '../providers/shared_with_me_provider.dart';
 import '../providers/trips_provider.dart';
 import '../theme/spacing.dart';
+import '../utils/errors.dart';
 import '../utils/trip_days.dart';
 import '../utils/trip_format.dart';
 import '../widgets/empty_state.dart';
@@ -128,7 +129,7 @@ class _SharedTripBodyState extends ConsumerState<_SharedTripBody> {
       Navigator.of(context)
           .pushNamedAndRemoveUntil('/', (route) => false);
     } catch (e) {
-      if (mounted) showSnack(context, l10n.sharedSaveCopyError('$e'));
+      if (mounted) showSnack(context, l10n.sharedSaveCopyError(friendlyError(l10n, e)));
     } finally {
       if (mounted) setState(() => _saving = false);
     }
@@ -170,7 +171,7 @@ class _SharedTripBodyState extends ConsumerState<_SharedTripBody> {
 
       WidgetsBinding.instance.addPostFrameCallback((_) => openOnTripsTab());
     } catch (e) {
-      if (mounted) showSnack(context, l10n.sharedJoinError('$e'));
+      if (mounted) showSnack(context, l10n.sharedJoinError(friendlyError(l10n, e)));
     } finally {
       if (mounted) setState(() => _saving = false);
     }

--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -22,6 +22,7 @@ import '../providers/transport_provider.dart';
 import '../providers/trips_provider.dart';
 import '../providers/recent_trip_provider.dart';
 import '../providers/booking_drafts_provider.dart';
+import '../utils/errors.dart';
 import '../providers/booking_todos_provider.dart';
 import '../providers/preferences_provider.dart';
 import '../providers/api_client_provider.dart';
@@ -1072,7 +1073,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
           .setBooked(widget.tripId, todo.id, booked);
     } catch (e) {
       if (mounted) setState(() => _bookingTodos = prev);
-      _showSnack(l10n.tripUpdateFailed('$e'));
+      _showSnack(l10n.tripUpdateFailed(friendlyError(l10n, e)));
     }
   }
 
@@ -1103,7 +1104,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
           .reorderTodos(widget.tripId, [for (final t in newOrder) t.id]);
     } catch (e) {
       if (mounted) setState(() => _bookingTodos = prev);
-      _showSnack(l10n.tripReorderFailed('$e'));
+      _showSnack(l10n.tripReorderFailed(friendlyError(l10n, e)));
     }
   }
 
@@ -1178,7 +1179,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
           stayIds: [for (final a in newOrder) a.id]);
     } catch (e) {
       if (mounted) setState(() => _stays = prev);
-      _showSnack(l10n.tripReorderFailed('$e'));
+      _showSnack(l10n.tripReorderFailed(friendlyError(l10n, e)));
     }
   }
 
@@ -1200,7 +1201,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
           segmentIds: [for (final s in newOrder) s.id]);
     } catch (e) {
       if (mounted) setState(() => _segments = prev);
-      _showSnack(l10n.tripReorderFailed('$e'));
+      _showSnack(l10n.tripReorderFailed(friendlyError(l10n, e)));
     }
   }
 
@@ -1232,7 +1233,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
             .add(widget.tripId, body);
         await _load();
       } catch (e) {
-        _showSnack(l10n.tripAddStayFailed('$e'));
+        _showSnack(l10n.tripAddStayFailed(friendlyError(l10n, e)));
       }
       return;
     }
@@ -1262,7 +1263,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
           .addSegment(widget.tripId, body);
       await _load();
     } catch (e) {
-      _showSnack(l10n.tripAddTransportFailed('$e'));
+      _showSnack(l10n.tripAddTransportFailed(friendlyError(l10n, e)));
     }
   }
 
@@ -1278,7 +1279,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
             _bookingTodos.where((t) => t.id != todo.id).toList());
       }
     } catch (e) {
-      _showSnack(l10n.tripDeleteFailed('$e'));
+      _showSnack(l10n.tripDeleteFailed(friendlyError(l10n, e)));
     }
   }
 
@@ -1343,7 +1344,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
         await _syncBookingDrafts(updated);
       }
     } catch (e) {
-      _showSnack(l10n.tripUpdateFailed('$e'));
+      _showSnack(l10n.tripUpdateFailed(friendlyError(l10n, e)));
     }
   }
 
@@ -1543,7 +1544,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
             .clearIfMatches(widget.tripId);
         if (mounted) Navigator.of(context).pop();
       } catch (e) {
-        _showSnack(l10n.tripDeleteFailed('$e'));
+        _showSnack(l10n.tripDeleteFailed(friendlyError(l10n, e)));
       }
     }
   }
@@ -1578,7 +1579,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
       ref.invalidate(sharedWithMeProvider);
       if (mounted) Navigator.of(context).pop();
     } catch (e) {
-      _showSnack(l10n.tripLeaveFailed('$e'));
+      _showSnack(l10n.tripLeaveFailed(friendlyError(l10n, e)));
     }
   }
 
@@ -1597,7 +1598,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
           .add(widget.tripId, body);
       await _load();
     } catch (e) {
-      _showSnack(l10n.tripAddStayFailed('$e'));
+      _showSnack(l10n.tripAddStayFailed(friendlyError(l10n, e)));
     }
   }
 
@@ -1610,7 +1611,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
           .delete(widget.tripId, a.id);
       await _load();
     } catch (e) {
-      _showSnack(l10n.tripRemoveStayFailed('$e'));
+      _showSnack(l10n.tripRemoveStayFailed(friendlyError(l10n, e)));
     }
   }
 
@@ -1631,7 +1632,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
           .update(widget.tripId, a.id, body);
       await _load();
     } catch (e) {
-      _showSnack(l10n.tripUpdateStayFailed('$e'));
+      _showSnack(l10n.tripUpdateStayFailed(friendlyError(l10n, e)));
     }
   }
 
@@ -1653,7 +1654,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
           .update(widget.tripId, a.id, {'booked': booked});
     } catch (e) {
       if (mounted) setState(() => _stays = prev);
-      _showSnack(l10n.tripUpdateFailed('$e'));
+      _showSnack(l10n.tripUpdateFailed(friendlyError(l10n, e)));
     }
   }
 
@@ -1674,7 +1675,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
           .addSegment(widget.tripId, body);
       await _load();
     } catch (e) {
-      _showSnack(l10n.tripAddTransportFailed('$e'));
+      _showSnack(l10n.tripAddTransportFailed(friendlyError(l10n, e)));
     }
   }
 
@@ -1687,7 +1688,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
           .deleteSegment(widget.tripId, s.id);
       await _load();
     } catch (e) {
-      _showSnack(l10n.tripRemoveTransportFailed('$e'));
+      _showSnack(l10n.tripRemoveTransportFailed(friendlyError(l10n, e)));
     }
   }
 
@@ -1708,7 +1709,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
           .updateSegment(widget.tripId, s.id, body);
       await _load();
     } catch (e) {
-      _showSnack(l10n.tripUpdateTransportFailed('$e'));
+      _showSnack(l10n.tripUpdateTransportFailed(friendlyError(l10n, e)));
     }
   }
 
@@ -1729,7 +1730,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
           .updateSegment(widget.tripId, seg.id, {'booked': booked});
     } catch (e) {
       if (mounted) setState(() => _segments = prev);
-      _showSnack(l10n.tripUpdateFailed('$e'));
+      _showSnack(l10n.tripUpdateFailed(friendlyError(l10n, e)));
     }
   }
 
@@ -1772,7 +1773,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
         sharePositionOrigin: _shareAnchorRect(),
       );
     } catch (e) {
-      _showSnack(l10n.tripShareLinkFailed('$e'));
+      _showSnack(l10n.tripShareLinkFailed(friendlyError(l10n, e)));
     }
   }
 
@@ -1804,8 +1805,8 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
       );
     } catch (e) {
       _showSnack(print
-          ? l10n.tripPrintExportFailed('$e')
-          : l10n.tripCalendarExportFailed('$e'));
+          ? l10n.tripPrintExportFailed(friendlyError(l10n, e))
+          : l10n.tripCalendarExportFailed(friendlyError(l10n, e)));
     }
   }
 
@@ -1853,7 +1854,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
         kind: 'item',
       );
     } catch (e) {
-      _showSnack(l10n.tripEventExportFailed('$e'));
+      _showSnack(l10n.tripEventExportFailed(friendlyError(l10n, e)));
     }
   }
 
@@ -1863,7 +1864,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
       await ref.read(tripsApiServiceProvider).revokeShareLink(widget.tripId);
       _showSnack(l10n.tripSharingTurnedOff);
     } catch (e) {
-      _showSnack(l10n.tripSharingOffFailed('$e'));
+      _showSnack(l10n.tripSharingOffFailed(friendlyError(l10n, e)));
     }
   }
 
@@ -1886,7 +1887,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
         sharePositionOrigin: _shareAnchorRect(),
       );
     } catch (e) {
-      _showSnack(l10n.tripInviteFailed('$e'));
+      _showSnack(l10n.tripInviteFailed(friendlyError(l10n, e)));
     }
   }
 
@@ -2645,7 +2646,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
           .reorderItineraryItems(trip.id, [for (final it in newItems) it.id]);
       await _load(silent: true);
     } catch (e) {
-      _showSnack(l10n.tripReorderFailed('$e'));
+      _showSnack(l10n.tripReorderFailed(friendlyError(l10n, e)));
       await _load(silent: true);
     }
   }
@@ -3254,7 +3255,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
           .reorderItineraryItems(trip.id, ids);
       await _load();
     } catch (e) {
-      _showSnack(l10n.tripReorderFailed('$e'));
+      _showSnack(l10n.tripReorderFailed(friendlyError(l10n, e)));
       await _load();
     }
   }
@@ -3278,7 +3279,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
           .reorderItineraryItems(trip.id, ids);
       await _load();
     } catch (e) {
-      _showSnack(l10n.tripReorderFailed('$e'));
+      _showSnack(l10n.tripReorderFailed(friendlyError(l10n, e)));
       await _load();
     }
   }
@@ -3293,7 +3294,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
           .read(tripsApiServiceProvider)
           .deleteItineraryItem(trip.id, item.id);
     } catch (e) {
-      _showSnack(l10n.tripRemoveItemFailed(item.name, '$e'));
+      _showSnack(l10n.tripRemoveItemFailed(item.name, friendlyError(l10n, e)));
       return;
     }
     await _load();
@@ -3331,7 +3332,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
       await ref.read(tripsApiServiceProvider).addItineraryItem(tripId, body);
       await _load();
     } catch (e) {
-      _showSnack(l10n.tripRestoreItemFailed(item.name, '$e'));
+      _showSnack(l10n.tripRestoreItemFailed(item.name, friendlyError(l10n, e)));
     }
   }
 
@@ -3352,7 +3353,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
           .updateItineraryItem(trip.id, item.id, changes);
       await _load();
     } catch (e) {
-      _showSnack(l10n.tripUpdateItemFailed(item.name, '$e'));
+      _showSnack(l10n.tripUpdateItemFailed(item.name, friendlyError(l10n, e)));
     }
   }
 
@@ -3387,7 +3388,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
               .add(tripId, body);
           await _afterFix();
         } catch (e) {
-          _showSnack(l10n.tripAddStayFailed('$e'));
+          _showSnack(l10n.tripAddStayFailed(friendlyError(l10n, e)));
         }
         break;
       case 'add_transport':
@@ -3408,7 +3409,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
               .addSegment(tripId, body);
           await _afterFix();
         } catch (e) {
-          _showSnack(l10n.tripAddTransportFailed('$e'));
+          _showSnack(l10n.tripAddTransportFailed(friendlyError(l10n, e)));
         }
         break;
       case 'move_item':
@@ -3432,7 +3433,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
                   ),
           ));
         } catch (e) {
-          _showSnack(l10n.tripMoveItemFailed('$e'));
+          _showSnack(l10n.tripMoveItemFailed(friendlyError(l10n, e)));
         }
         break;
       case 'mark_booked':
@@ -3454,7 +3455,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
             ),
           ));
         } catch (e) {
-          _showSnack(l10n.tripUpdateBookingFailed('$e'));
+          _showSnack(l10n.tripUpdateBookingFailed(friendlyError(l10n, e)));
         }
         break;
       case 'add_packing':
@@ -3480,13 +3481,13 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
                   ref.invalidate(checklistProvider(tripId));
                   _invalidateReview();
                 } catch (e) {
-                  _showSnack(l10n.tripUndoFailed('$e'));
+                  _showSnack(l10n.tripUndoFailed(friendlyError(l10n, e)));
                 }
               },
             ),
           ));
         } catch (e) {
-          _showSnack(l10n.tripAddPackingFailed('$e'));
+          _showSnack(l10n.tripAddPackingFailed(friendlyError(l10n, e)));
         }
         break;
       case 'set_dates':
@@ -3530,7 +3531,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
           .updateItineraryItem(widget.tripId, itemId, {'day': day});
       await _afterFix();
     } catch (e) {
-      _showSnack(l10n.tripMoveItemFailed('$e'));
+      _showSnack(l10n.tripMoveItemFailed(friendlyError(l10n, e)));
     }
   }
 
@@ -3556,7 +3557,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
     try {
       budget = await ref.read(budgetProvider(widget.tripId).future);
     } catch (e) {
-      _showSnack(l10n.tripLoadBudgetFailed('$e'));
+      _showSnack(l10n.tripLoadBudgetFailed(friendlyError(l10n, e)));
       return;
     }
     if (!mounted) return;
@@ -3605,7 +3606,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
       ref.invalidate(budgetProvider(widget.tripId));
       await _afterFix();
     } catch (e) {
-      _showSnack(l10n.tripUpdateBudgetFailed('$e'));
+      _showSnack(l10n.tripUpdateBudgetFailed(friendlyError(l10n, e)));
     }
   }
 
@@ -5171,7 +5172,7 @@ class _AddBookingTodoDialogState extends ConsumerState<_AddBookingTodoDialog> {
     } catch (e) {
       setState(() {
         _saving = false;
-        _error = l10n.tripSaveFailed('$e');
+        _error = l10n.tripSaveFailed(friendlyError(l10n, e));
       });
     }
   }

--- a/src/packages/flutter-app/lib/utils/errors.dart
+++ b/src/packages/flutter-app/lib/utils/errors.dart
@@ -1,0 +1,30 @@
+import '../l10n/l10n.dart';
+import '../services/api_client.dart';
+
+/// Maps a caught error to a short, localized, user-facing message so raw
+/// [ApiException] dumps never reach a snackbar or error banner.
+///
+/// - An [ApiException] is classified by HTTP status: network (statusCode 0),
+///   an expired/forbidden session (401/403), rate limiting (429), a server
+///   fault (5xx), or a generic fallback for everything else.
+/// - A plain [String] is assumed to already be user-facing — e.g. a friendly
+///   error the `/plan` SSE stream sent — and is returned unchanged.
+/// - Anything else falls back to the generic message; the raw object is never
+///   surfaced to the user.
+String friendlyError(AppLocalizations l10n, Object? error) {
+  if (error is String) return error;
+  if (error is ApiException) {
+    switch (error.statusCode) {
+      case 0:
+        return l10n.errorNetwork;
+      case 401:
+      case 403:
+        return l10n.errorSession;
+      case 429:
+        return l10n.errorTooManyRequests;
+    }
+    if (error.statusCode >= 500) return l10n.errorServer;
+    return l10n.errorGeneric;
+  }
+  return l10n.errorGeneric;
+}

--- a/src/packages/flutter-app/lib/widgets/add_itinerary_item_dialog.dart
+++ b/src/packages/flutter-app/lib/widgets/add_itinerary_item_dialog.dart
@@ -7,6 +7,7 @@ import '../models/itinerary_item.dart';
 import '../models/place_search_result.dart';
 import '../providers/places_api_provider.dart';
 import '../providers/trips_provider.dart';
+import '../utils/errors.dart';
 import '../utils/trip_days.dart';
 
 /// Category chips send canonical API values ('attraction', 'restaurant'), which
@@ -130,7 +131,7 @@ class _AddItineraryItemDialogState
       if (mounted) {
         setState(() {
           _saving = false;
-          _error = l10n.itemDialogErrorAddFailed('$e');
+          _error = l10n.itemDialogErrorAddFailed(friendlyError(l10n, e));
         });
       }
     }

--- a/src/packages/flutter-app/lib/widgets/add_to_calendar_button.dart
+++ b/src/packages/flutter-app/lib/widgets/add_to_calendar_button.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../l10n/l10n.dart';
 import '../providers/trips_provider.dart';
 import '../utils/calendar_links.dart';
+import '../utils/errors.dart';
 import '../utils/share_link.dart';
 import '../utils/snack.dart';
 import '../utils/tracked_launch.dart';
@@ -84,7 +85,8 @@ class AddToCalendarButton extends ConsumerWidget {
       );
     } catch (e) {
       if (context.mounted) {
-        showSnack(context, context.l10n.calendarExportFailed('$e'));
+        showSnack(context,
+            context.l10n.calendarExportFailed(friendlyError(context.l10n, e)));
       }
     }
   }

--- a/src/packages/flutter-app/lib/widgets/chat_panel.dart
+++ b/src/packages/flutter-app/lib/widgets/chat_panel.dart
@@ -15,6 +15,7 @@ import '../services/dictation_controller.dart';
 import '../services/image_attachment_pipeline.dart';
 import '../theme/app_colors.dart';
 import '../theme/spacing.dart';
+import '../utils/errors.dart';
 import '../utils/clipboard_images_stub.dart'
     if (dart.library.js_interop) '../utils/clipboard_images_web.dart';
 import '../utils/tracked_launch.dart';
@@ -1015,7 +1016,7 @@ class _ErrorBanner extends ConsumerWidget {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Text(
-            error,
+            friendlyError(context.l10n, error),
             style: TextStyle(color: theme.colorScheme.onErrorContainer),
           ),
           if (canRetry)

--- a/src/packages/flutter-app/test/friendly_error_test.dart
+++ b/src/packages/flutter-app/test/friendly_error_test.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:travel_route_planner/l10n/l10n.dart';
+import 'package:travel_route_planner/services/api_client.dart';
+import 'package:travel_route_planner/utils/errors.dart';
+
+import 'support/l10n_test_app.dart';
+
+/// friendlyError turns caught errors into localized, user-facing copy so raw
+/// ApiException dumps never reach a snackbar or banner.
+ApiException _api(int status) =>
+    ApiException(statusCode: status, message: 'raw internal detail', endpoint: '/x');
+
+void main() {
+  Future<AppLocalizations> pumpL10n(WidgetTester tester, {Locale? locale}) async {
+    late AppLocalizations l10n;
+    await tester.pumpWidget(localizedTestApp(
+      locale: locale,
+      home: Builder(builder: (context) {
+        l10n = context.l10n;
+        return const SizedBox.shrink();
+      }),
+    ));
+    return l10n;
+  }
+
+  testWidgets('maps ApiException status codes to distinct localized messages',
+      (tester) async {
+    final l10n = await pumpL10n(tester);
+
+    expect(friendlyError(l10n, _api(0)), l10n.errorNetwork);
+    expect(friendlyError(l10n, _api(401)), l10n.errorSession);
+    expect(friendlyError(l10n, _api(403)), l10n.errorSession);
+    expect(friendlyError(l10n, _api(429)), l10n.errorTooManyRequests);
+    expect(friendlyError(l10n, _api(500)), l10n.errorServer);
+    expect(friendlyError(l10n, _api(503)), l10n.errorServer);
+    // 4xx that isn't 401/403/429 falls back to generic.
+    expect(friendlyError(l10n, _api(400)), l10n.errorGeneric);
+    expect(friendlyError(l10n, _api(404)), l10n.errorGeneric);
+
+    // The raw internal message is never surfaced.
+    expect(friendlyError(l10n, _api(500)), isNot(contains('raw internal detail')));
+  });
+
+  testWidgets('passes an already-friendly String (e.g. a /plan SSE error) through',
+      (tester) async {
+    final l10n = await pumpL10n(tester);
+    const serverMessage = 'That destination is not supported yet.';
+    expect(friendlyError(l10n, serverMessage), serverMessage);
+  });
+
+  testWidgets('an unclassifiable error falls back to the generic message',
+      (tester) async {
+    final l10n = await pumpL10n(tester);
+    expect(friendlyError(l10n, Exception('boom')), l10n.errorGeneric);
+    expect(friendlyError(l10n, null), l10n.errorGeneric);
+  });
+
+  testWidgets('resolves Spanish copy under an es locale', (tester) async {
+    final l10n = await pumpL10n(tester, locale: const Locale('es'));
+    expect(friendlyError(l10n, _api(0)), l10n.errorNetwork);
+    expect(l10n.errorNetwork, contains('conexión'));
+  });
+}


### PR DESCRIPTION
## Summary
Launch-readiness G1 (biggest UX gap from the audit): `ApiException.userFriendlyMessage` existed but was **called zero times**, so ~50 snackbars and error banners showed users raw `ApiException(statusCode: 500, message: ...)` strings.

New `lib/utils/errors.dart` `friendlyError(l10n, error)`:
- Classifies an `ApiException` by HTTP status → network / expired-session (401/403) / rate-limit (429) / server (5xx) / generic.
- Passes an already-friendly `String` (e.g. a `/plan` SSE error the server sent) through unchanged.
- Never surfaces a raw object.

Routed **all ~50 user-facing sites**: the ~40 `l10n.tripXxxFailed('$e')` toasts in `trip_detail_screen`, plus `alerts_screen`, `shared_trip_screen`, `flight_search_screen`, the chat `_ErrorBanner`, and the add-item / add-to-calendar dialogs.

`flights_provider` and `plan_provider` now hold the error as `Object?` so the widget layer (which has `l10n`) can render it. `preferences_provider` is deliberately left alone — its error is never displayed. Admin-only `local_admin_screen` keeps raw errors for debugging.

## l10n
Adds `errorNetwork` / `errorTooManyRequests` / `errorSession` / `errorServer` / `errorGeneric` to both `app_en.arb` and `app_es.arb`, with regenerated localizations (no drift, full translation coverage).

## Test plan
- [x] New `test/friendly_error_test.dart`: status→message mapping, the String passthrough invariant, generic fallback, and Spanish resolution.
- [x] `flutter gen-l10n` clean (no drift, `l10n_untranslated.json` == `{}`), `flutter analyze --no-fatal-infos --fatal-warnings` exits 0, `flutter test` all 485 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)