### PR TITLE
legal: finalize Terms + Privacy for launch; add sign-up consent gate

### DIFF
--- a/dockerize/static/privacy.html
+++ b/dockerize/static/privacy.html
@@ -3,7 +3,6 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="robots" content="noindex">
   <title>Privacy Policy — Golden Tempo Travel</title>
   <style>
     * { box-sizing: border-box; }
@@ -14,15 +13,6 @@
       color: #263238;
       background: #fafafa;
       line-height: 1.6;
-    }
-    .draft-banner {
-      background: #fff3cd;
-      color: #664d03;
-      border-bottom: 1px solid #ffe69c;
-      text-align: center;
-      padding: 10px 16px;
-      font-weight: 600;
-      font-size: 0.95rem;
     }
     header {
       background: linear-gradient(to bottom right, #00897B, #004D40);
@@ -57,15 +47,20 @@
       border-radius: 0 8px 8px 0;
       margin: 20px 0;
     }
-    table { border-collapse: collapse; width: 100%; margin: 12px 0; }
-    th, td {
-      text-align: left;
-      padding: 8px 10px;
-      border-bottom: 1px solid #CFD8DC;
-      vertical-align: top;
+    table {
+      border-collapse: collapse;
+      width: 100%;
+      margin: 16px 0;
       font-size: 0.95rem;
     }
-    th { color: #00695C; }
+    th, td {
+      border: 1px solid #CFD8DC;
+      padding: 8px 10px;
+      text-align: left;
+      vertical-align: top;
+    }
+    th { background: #E0F2F1; color: #00695C; }
+    .table-scroll { overflow-x: auto; }
     footer {
       border-top: 1px solid #CFD8DC;
       margin-top: 48px;
@@ -77,142 +72,314 @@
   </style>
 </head>
 <body>
-  <div class="draft-banner">DRAFT — pending legal review. This document is not yet final.</div>
   <header>
     <div class="wrap">
       <p class="brand">Golden Tempo Travel</p>
       <h1>Privacy Policy</h1>
-      <p class="meta">Draft of July 6, 2026 · Golden Tempo LLC</p>
+      <p class="meta">Effective July 24, 2026 · Golden Tempo LLC</p>
     </div>
   </header>
   <main>
     <p>
       Golden Tempo Travel is operated by <strong>Golden Tempo LLC</strong>, a
-      New Jersey limited liability company ("we", "us"). This policy explains
-      what information the service collects, how it is used, and the choices
-      you have. Questions or requests:
+      New Jersey limited liability company ("we," "us"). This policy explains
+      what we collect, how we use it, who we share it with, and the choices you
+      have. It is written to match what the product actually does. Questions or
+      requests:
       <a href="mailto:goldentempollc@gmail.com">goldentempollc@gmail.com</a>.
     </p>
-
     <div class="callout">
       <strong>The short version:</strong> we store your account email, your
-      trips and travel preferences, and first-party usage events. We do not
-      sell personal data, we do not use third-party analytics or advertising
-      trackers, and you can delete your account (and the data that goes with
-      it) yourself, in the app, at any time.
+      trips, and your conversations with the AI planning assistant. Your
+      planning messages are sent to Anthropic (the AI provider) to generate
+      responses. We keep a first-party log of product events with no third-party
+      analytics or ad trackers, we do not sell personal data, and you can delete
+      your account — and everything in it — yourself, in the app, at any time.
     </div>
 
     <h2>1. Information we collect</h2>
+    <p>
+      <strong>Account information.</strong> Your email address, an optional
+      display name, your language preference, and — if you sign up with a
+      password — the password stored only as a bcrypt hash (we cannot see your
+      actual password). If you sign in with Google or Apple, we store your email
+      and the provider's account identifier so we can recognize you next time;
+      SSO-only accounts have no password at all.
+    </p>
+    <p>
+      <strong>Trips and planning content.</strong> Trips, itineraries, saved
+      places, accommodations and transport segments, booking checklists, packing
+      lists, budgets and expenses, price alerts (route, dates, and baggage
+      preference), and trip share/invite records.
+    </p>
+    <p>
+      <strong>AI conversations.</strong> When you are signed in, your
+      conversations with the planning assistant are saved so you can pick up
+      where you left off. <strong>Images you attach are not stored</strong> —
+      they are sent to the AI provider to generate a response, and only an
+      "image attached" marker is kept in the saved conversation. Conversations
+      you have while signed out are not saved at all.
+    </p>
+    <p>
+      <strong>Traveler preferences and profile notes.</strong> Preferences you
+      set (budget, pace, interests, home airport) and a short, AI-maintained set
+      of profile notes about how you like to travel (for example "travels with
+      two kids," "vegetarian"), built from your planning conversations so future
+      trips are personalized. The AI is instructed <strong>not</strong> to
+      record sensitive information (such as health, religion, or politics) unless
+      you explicitly ask it to remember something. You can view and edit these
+      preferences in the app, and they are deleted with your account.
+    </p>
+    <p>
+      <strong>Usage events.</strong> A first-party log of product events
+      (account created, trip saved, booking link clicked, AI session token
+      counts, and similar). Each event carries your internal account ID, an
+      event type, an optional trip ID, and limited technical metadata — by
+      design it contains <strong>no email address, no IP address, no browser
+      user-agent, and no free text</strong>. It lives in our own database; we
+      use no third-party analytics services. A small set of events (such as
+      landing-page clicks) can be recorded without any account attached.
+    </p>
+    <p>
+      <strong>Server logs and security data.</strong> Like nearly every web
+      service, our servers keep standard request logs — timestamp, request path,
+      response status, and <strong>your IP address</strong> — used for security,
+      debugging, and abuse prevention, and routinely rotated. We also keep
+      short-lived, in-memory counters keyed by IP address to rate-limit abuse
+      (login lockouts, daily AI-usage caps, sign-up caps); these are never
+      written to the database and disappear on restart. Our edge network
+      provider (Cloudflare) also processes your IP address and requests to route
+      traffic and block attacks.
+    </p>
+    <p>
+      <strong>Email delivery records.</strong> When we send you email
+      (verification, password reset, price alerts, trip reminders, co-planning
+      invites), your email address is processed by our transactional email
+      provider for delivery. Links in verification and reset emails use
+      single-use, expiring tokens that we store only as cryptographic hashes.
+    </p>
+
+    <h2>2. How we use information</h2>
     <ul>
-      <li><strong>Account information.</strong> Your email address, an optional
-        display name, and your password — stored only as a cryptographic hash;
-        we cannot see your actual password.</li>
-      <li><strong>Trip and planning data.</strong> Trips, itineraries, saved
-        places, booking checklists, price alerts, and the traveler preferences
-        you set (for example travel style or pace) — including messages you
-        send to the AI planning assistant.</li>
-      <li><strong>Usage events.</strong> A first-party log of product events
-        (for example: account created, trip saved, booking link clicked, AI
-        planning session token counts). These events are tied to your account
-        ID only — by design they contain <strong>no email address, no IP
-        address, no browser user-agent, and no free text</strong>. They live in
-        our own database; we use no third-party analytics services.</li>
-      <li><strong>Email delivery records.</strong> When we send you a
-        verification email, a password-reset code, or a price-alert
-        notification, your email address is processed by our transactional
-        email provider for delivery.</li>
+      <li>To provide the Service: store your trips, generate itineraries, run
+        searches, send the emails you request or subscribe to.</li>
+      <li>To personalize: apply your saved preferences and profile notes to
+        future planning conversations.</li>
+      <li>To keep the Service safe and affordable: rate limiting, abuse
+        prevention, debugging, and cost monitoring.</li>
+      <li>To understand product usage in aggregate, using our own pseudonymous
+        event log.</li>
+      <li>We do <strong>not</strong> use your data for third-party advertising,
+        and we do not sell it.</li>
     </ul>
 
-    <h2>2. Third-party services we use to answer your requests</h2>
+    <h2>3. AI processing (please read this one)</h2>
     <p>
-      When you plan a trip, parts of your request are sent to third-party
-      providers <em>transiently</em> — to look up an answer, not to build a
-      profile of you:
+      The planning assistant is powered by <strong>Anthropic's Claude
+      models</strong>, called from our servers. When you use it, we send
+      Anthropic: your conversation messages, any images you attach, your current
+      trip context, your saved traveler preferences and profile notes, and the
+      results of searches the assistant runs on your behalf. Long conversations
+      are also summarized by an AI model so they can continue past length
+      limits, and after planning sessions an AI model may distill durable travel
+      preferences from the conversation into your profile notes.
     </p>
-    <table>
-      <tr><th>Provider</th><th>What is sent</th><th>Why</th></tr>
-      <tr><td>Google Places</td><td>Place and destination search terms</td><td>Finding and verifying places</td></tr>
-      <tr><td>Duffel</td><td>Airports, dates, passenger counts</td><td>Flight search</td></tr>
-      <tr><td>Ticketmaster</td><td>City and date window</td><td>Local events lookup</td></tr>
-      <tr><td>Open-Meteo</td><td>Destination coordinates and dates</td><td>Weather forecasts</td></tr>
-      <tr><td>Anthropic</td><td>Your planning conversation and trip context</td><td>Generating AI itineraries</td></tr>
-      <tr><td>Speech services</td><td>Voice-dictation audio (only while you use the mic)</td><td>Turning your speech into text</td></tr>
-    </table>
     <p>
-      These lookups are made server-side through our API; the providers do not
-      receive your email address or account identity from us. Results you
-      choose to keep (for example a place added to an itinerary) are stored as
-      part of your trip data.
+      We use Anthropic's commercial API. Under Anthropic's commercial terms, API
+      inputs and outputs are not used to train Anthropic's models by default.
+      Anthropic's own usage policies apply to this processing: see
+      <a href="https://www.anthropic.com/legal" rel="noopener"
+        target="_blank">anthropic.com/legal</a>.
+    </p>
+    <div class="callout">
+      Practical advice: the assistant needs to know about your trip, not about
+      you. Don't paste passport numbers, payment details, or other sensitive
+      personal information into the chat.
+    </div>
+
+    <h2>4. Service providers we share data with, and why</h2>
+    <p>
+      We share data only as needed to answer your requests or run the Service —
+      never for the providers' own marketing:
+    </p>
+    <div class="table-scroll">
+      <table>
+        <thead>
+          <tr><th>Provider</th><th>What they receive</th><th>Why</th></tr>
+        </thead>
+        <tbody>
+          <tr><td>Anthropic</td><td>Planning conversations, attached images, trip context, preferences (see Section 3)</td><td>AI itinerary generation</td></tr>
+          <tr><td>Google Places</td><td>Place and destination search text</td><td>Finding and verifying places</td></tr>
+          <tr><td>Duffel</td><td>Airports, dates, passenger counts</td><td>Flight search</td></tr>
+          <tr><td>Ticketmaster</td><td>City and date window</td><td>Local events lookup</td></tr>
+          <tr><td>Open-Meteo</td><td>Destination name/coordinates and dates</td><td>Weather forecasts</td></tr>
+          <tr><td>Groq (or your browser's built-in speech service)</td><td>Voice-dictation audio, only while you use the microphone</td><td>Speech-to-text</td></tr>
+          <tr><td>Google / Apple</td><td>Standard sign-in flow data, if you choose SSO</td><td>Account sign-in</td></tr>
+          <tr><td>Resend</td><td>Your email address and message content</td><td>Delivering the emails described above</td></tr>
+          <tr><td>Cloudflare</td><td>IP address and request traffic</td><td>Edge network, TLS, and attack protection</td></tr>
+          <tr><td>Sentry</td><td>Technical error reports (error message and request metadata such as a request ID — not your account profile)</td><td>Error monitoring</td></tr>
+        </tbody>
+      </table>
+    </div>
+    <p>
+      These lookups are made server-side; search providers do not receive your
+      email address or account identity from us. Results you choose to keep
+      become part of your trip data.
     </p>
     <p>
       <strong>Voice dictation is optional.</strong> If you tap the microphone,
-      audio is transcribed either by your browser's built-in speech service
-      (for example Google in Chrome or Apple in Safari) or by our configured
-      transcription provider, then discarded — we never store your audio, and
-      nothing is sent unless you choose to send the resulting text.
+      audio is transcribed either by your browser's built-in speech service or
+      by our transcription provider, then discarded — we never store your audio.
+    </p>
+    <p>
+      Beyond these providers, we do not share personal data with third parties
+      except: with your direction (share links, invites, booking handoffs), to
+      comply with law or valid legal process, to protect the Service and its
+      users from fraud or abuse, or as part of a business transfer (in which case
+      this policy would continue to apply to your data until changed with
+      notice).
     </p>
 
-    <h2>3. Affiliate and outbound links</h2>
+    <h2>5. Affiliate and outbound links</h2>
     <p>
-      Booking handoff links (for example to Booking.com) open the provider's
-      own site and may include an affiliate identifier so the provider can
-      credit us if you book. Once you leave Golden Tempo Travel, the
+      Booking handoff links (for example Booking.com or Ferryhopper) open the
+      provider's own site and may include an affiliate identifier so the
+      provider can credit us if you book. Once you leave Golden Tempo Travel, the
       provider's own privacy policy applies. We record that a booking link was
-      clicked (see usage events above); we do not receive your payment or
-      booking details.
+      clicked (see usage events); we never receive your payment or booking
+      details.
     </p>
 
-    <h2>4. Cookies and local storage</h2>
-    <p>
-      We use browser local storage to keep your session token so you stay
-      signed in. We do not use advertising cookies, cross-site trackers, or
-      third-party analytics scripts.
-    </p>
-
-    <h2>5. We do not sell personal data</h2>
-    <p>
-      We do not sell, rent, or trade your personal data, and we do not share
-      it with third parties for their own marketing.
-    </p>
-
-    <h2>6. Data retention and deletion</h2>
+    <h2>6. Sharing, invites, and export links</h2>
     <ul>
-      <li>Account, trip, and preference data is kept for as long as your
-        account exists.</li>
-      <li>You can <strong>delete your account in the app</strong> (Account
-        settings → Delete account). Deletion permanently removes your account,
-        trips, itineraries, preferences, alerts, and sessions.</li>
-      <li>Usage events are pseudonymous by design (account ID only, no email,
-        IP, or user-agent) and are retained after account deletion as part of
-        aggregate product statistics; after deletion they no longer link to
-        any identifiable account record.</li>
-      <li>You can also request deletion or a copy of your data by emailing
-        <a href="mailto:goldentempollc@gmail.com">goldentempollc@gmail.com</a>.</li>
+      <li><strong>Share links:</strong> anyone with a share link can view the
+        latest version of that trip until you revoke the link (you can revoke it
+        in the app).</li>
+      <li><strong>Co-planner invites:</strong> sent by email with a single-use,
+        expiring invite token (stored hashed on our side). Co-planners can view
+        and edit the trip; your display name is visible to them.</li>
+      <li><strong>Export and calendar links:</strong> signed links that expire
+        after one hour; anyone with the link can access the export while it is
+        valid.</li>
     </ul>
 
-    <h2>7. Security</h2>
+    <h2>7. Cookies and local storage</h2>
     <p>
-      Passwords are stored only as salted hashes, sessions use expiring
-      tokens, and access to production data is limited. No online service can
-      promise perfect security, but we design for storing as little personal
-      data as possible in the first place.
+      We use your browser's storage for: your session token (so you stay signed
+      in), a local cache of your trips (so they stay viewable offline), and small
+      preferences like language and last-viewed trip. We set <strong>no
+      advertising cookies, no cross-site trackers, and no third-party analytics
+      scripts</strong>. Cloudflare may set strictly-necessary technical cookies
+      for security. You can clear all locally stored data by signing out and
+      clearing your browser's site data.
     </p>
 
-    <h2>8. Children</h2>
+    <h2>8. Data retention</h2>
+    <ul>
+      <li>Account, trip, preference, and conversation data: kept while your
+        account exists.</li>
+      <li>Unfinished planning conversations: automatically deleted after about
+        60 days of inactivity.</li>
+      <li>Email verification/reset/invite tokens: single-use and short-lived;
+        stored only as hashes.</li>
+      <li>Server request logs: kept short-term for security and operations, then
+        rotated.</li>
+      <li>Database backups: we keep a rolling window of recent daily backups
+        (roughly the last ten days). Deleted data leaves the backup rotation as
+        those backups age out.</li>
+      <li>Usage events: pseudonymous by design (internal account ID only). After
+        you delete your account they are retained as aggregate product
+        statistics, but no longer link to any identifiable account record — the
+        account they pointed at no longer exists.</li>
+    </ul>
+
+    <h2>9. Deleting your account</h2>
     <p>
-      The service is not directed to children under 13, and we do not
-      knowingly collect personal information from them. If you believe a child
-      has created an account, contact us and we will delete it.
+      You can delete your account yourself in the app (Account settings → Delete
+      account; password confirmation required unless you signed up via SSO).
+      Deletion immediately and permanently removes your account, trips,
+      itineraries, conversations, preferences and profile notes, alerts,
+      notifications, share links, and sessions from our live database. Copies in
+      rotating backups age out as described above. You can also email us to
+      request deletion.
     </p>
 
-    <h2>9. Changes to this policy</h2>
+    <h2>10. Security</h2>
     <p>
-      We may update this policy as the product evolves. Material changes will
-      be reflected on this page with an updated date. Continued use of the
-      service after a change means you accept the updated policy.
+      Honestly stated: passwords are stored as bcrypt hashes; email-borne tokens
+      (verification, reset, invites) are stored only as SHA-256 hashes; sessions
+      use random, expiring tokens; export links are signed and expire after an
+      hour; all traffic is encrypted in transit (TLS); production access is
+      limited to the operator. We deliberately collect little (no payment data,
+      no precise location tracking, no ad IDs) because the best protection for
+      data is not holding it. No online service can promise perfect security — if
+      we learn of a breach affecting your data, we will notify you as required by
+      law.
     </p>
 
-    <h2>10. Contact</h2>
+    <h2>11. Your rights and controls</h2>
+    <p>Built into the app, today:</p>
+    <ul>
+      <li><strong>Delete your account</strong> (and all your data) — Account
+        settings.</li>
+      <li><strong>Sign out of your other devices</strong> — Account
+        settings.</li>
+      <li><strong>Edit or delete</strong> any trip, conversation, or preference,
+        including the AI-maintained profile notes.</li>
+      <li><strong>Email controls:</strong> verification and reset emails are
+        transactional; price alerts stop when you delete the alert; trip
+        reminders and weekly digest emails have opt-outs in Account settings
+        <strong>and</strong> a one-click unsubscribe link in every such
+        email.</li>
+      <li><strong>Revoke share links</strong> and remove co-planners.</li>
+    </ul>
+    <p>
+      By email
+      (<a href="mailto:goldentempollc@gmail.com">goldentempollc@gmail.com</a>):
+      you can request a copy of your data, correction, or deletion, and we will
+      act on it within 30 days.
+    </p>
+    <p>
+      <strong>If you are in the EEA, UK, or a jurisdiction with similar
+      laws:</strong> we process your data to perform our contract with you
+      (providing the Service), for our legitimate interests (security, abuse
+      prevention, product improvement using pseudonymous events), and with your
+      consent where required (non-essential emails). You have rights of access,
+      rectification, erasure, portability, restriction, and objection, and the
+      right to complain to your local supervisory authority. We are a small US
+      company and have not appointed an EU/UK representative.
+    </p>
+    <p>
+      <strong>California residents:</strong> we do not sell or "share" personal
+      information as defined by the CCPA/CPRA, and we honor access and deletion
+      requests from anyone, regardless of where you live.
+    </p>
+
+    <h2>12. International transfers</h2>
+    <p>
+      We are US-based, and your data is processed and stored in the United States
+      (our own database servers, plus the US-based providers listed above). If
+      you use the Service from outside the US, you understand your data is
+      transferred to and processed in the US, where privacy laws may differ from
+      those in your country.
+    </p>
+
+    <h2>13. Children</h2>
+    <p>
+      The Service is not directed to children under 13, and we do not knowingly
+      collect personal information from them. If you believe a child under 13 has
+      created an account, contact us and we will delete it.
+    </p>
+
+    <h2>14. Changes to this policy</h2>
+    <p>
+      We may update this policy as the product evolves. Material changes will be
+      posted here with a new effective date, and we will make reasonable efforts
+      to notify you in the app or by email. Continued use after a change means
+      you accept the updated policy.
+    </p>
+
+    <h2>15. Contact</h2>
     <p>
       Golden Tempo LLC (New Jersey, USA)<br>
       <a href="mailto:goldentempollc@gmail.com">goldentempollc@gmail.com</a>

--- a/dockerize/static/terms.html
+++ b/dockerize/static/terms.html
@@ -3,7 +3,6 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="robots" content="noindex">
   <title>Terms of Service — Golden Tempo Travel</title>
   <style>
     * { box-sizing: border-box; }
@@ -14,15 +13,6 @@
       color: #263238;
       background: #fafafa;
       line-height: 1.6;
-    }
-    .draft-banner {
-      background: #fff3cd;
-      color: #664d03;
-      border-bottom: 1px solid #ffe69c;
-      text-align: center;
-      padding: 10px 16px;
-      font-weight: 600;
-      font-size: 0.95rem;
     }
     header {
       background: linear-gradient(to bottom right, #00897B, #004D40);
@@ -68,58 +58,81 @@
   </style>
 </head>
 <body>
-  <div class="draft-banner">DRAFT — pending legal review. This document is not yet final.</div>
   <header>
     <div class="wrap">
       <p class="brand">Golden Tempo Travel</p>
       <h1>Terms of Service</h1>
-      <p class="meta">Draft of July 6, 2026 · Golden Tempo LLC</p>
+      <p class="meta">Effective July 24, 2026 · Golden Tempo LLC</p>
     </div>
   </header>
   <main>
     <p>
-      These Terms of Service ("Terms") govern your use of Golden Tempo Travel
-      (the "Service"), operated by <strong>Golden Tempo LLC</strong>, a New
-      Jersey limited liability company. By creating an account or using the
-      Service, you agree to these Terms. If you do not agree, do not use the
-      Service. Questions:
+      These Terms of Service ("Terms") are an agreement between you and
+      <strong>Golden Tempo LLC</strong>, a New Jersey limited liability company
+      doing business as Golden Tempo Travel ("Golden Tempo," "we," "us"). They
+      govern your use of goldentempotravel.com and the Golden Tempo Travel app
+      (together, the "Service"). By creating an account or using the Service,
+      you agree to these Terms and to our <a href="/privacy">Privacy Policy</a>.
+      If you do not agree, do not use the Service. Questions:
       <a href="mailto:goldentempollc@gmail.com">goldentempollc@gmail.com</a>.
     </p>
 
     <h2>1. What the Service is (and is not)</h2>
     <p>
-      Golden Tempo Travel is a trip-planning tool: it helps you build
-      itineraries, optimize routes, and find flights, stays, events, and
-      ferries — including with AI-generated suggestions.
+      Golden Tempo Travel is a trip-planning tool. It helps you build
+      day-by-day itineraries and research flights, stays, events, ferries, and
+      local recommendations — including with an AI planning assistant that
+      generates suggestions in conversation with you.
     </p>
     <div class="callout">
-      <strong>We are not a travel agency.</strong> The Service does not sell,
-      book, or resell travel. Booking links hand you off to third-party
-      providers (for example Booking.com, airlines, or ferry operators); any
+      <strong>We are not a travel agency, tour operator, or seller of
+      travel.</strong> The Service does not sell, book, or resell travel.
+      Booking links hand you off to third-party providers (for example
+      Booking.com, airlines, Ferryhopper, or event ticketing sites); any
       purchase is a transaction between you and that provider, under that
-      provider's own terms. Some outbound links are affiliate links, meaning
-      the provider may pay us a commission if you book — at no extra cost to
-      you.
+      provider's own terms and privacy policy. We are not a party to those
+      transactions and have no responsibility for them — including
+      cancellations, refunds, schedule changes, or the quality of what you
+      booked.
     </div>
-
-    <h2>2. Accuracy of information</h2>
     <p>
-      Itineraries, place details, prices, schedules, weather, and event
-      listings come from third-party sources or are AI-generated, and can be
-      incomplete, outdated, or wrong. <strong>Verify anything that matters
-      (prices, opening hours, visas, schedules, safety guidance) with the
-      provider or an official source before you commit to it.</strong> You are
-      responsible for your own travel decisions.
+      <strong>Affiliate disclosure:</strong> some outbound booking links are
+      affiliate links, meaning the provider may pay us a commission if you book
+      through them. This costs you nothing extra and does not change which
+      results we show you.
     </p>
 
-    <h2>3. Your account</h2>
+    <h2>2. AI-generated content and accuracy</h2>
+    <p>
+      Much of what the Service shows you is AI-generated or drawn from
+      third-party data sources, and it can be incomplete, outdated, or simply
+      wrong. Itineraries are <strong>suggestions, not advice or a
+      guarantee</strong>. Prices change, places close, schedules shift, and
+      entry requirements vary by nationality.
+    </p>
+    <p>
+      <strong>Before you commit money or travel plans to anything, verify it
+      with the provider or an official source</strong> — especially prices,
+      opening hours, transport schedules, visa and entry requirements, health
+      requirements, and safety guidance. You are responsible for your own
+      travel decisions and arrangements. We are not liable for losses arising
+      from reliance on content in the Service, whether AI-generated or sourced
+      from third parties.
+    </p>
+
+    <h2>3. Your account and eligibility</h2>
     <ul>
-      <li>You must provide a valid email address and keep your password
-        secure. You are responsible for activity under your account.</li>
-      <li>You must be at least 13 years old (and old enough to consent to
-        these Terms where you live) to use the Service.</li>
-      <li>You can delete your account at any time in Account settings; see the
-        <a href="/privacy">Privacy Policy</a> for what deletion removes.</li>
+      <li>You must provide a valid email address (or sign in with Google or
+        Apple) and keep your credentials secure. You are responsible for
+        activity under your account.</li>
+      <li>You must be at least <strong>13 years old</strong> to use the
+        Service, and old enough to enter into these Terms where you live (in
+        some places that is 16 or 18).</li>
+      <li>If you sign in with Google or Apple, your use of those sign-in
+        services is also subject to their terms.</li>
+      <li>You can delete your account at any time in Account settings. The
+        <a href="/privacy">Privacy Policy</a> describes exactly what deletion
+        removes.</li>
     </ul>
 
     <h2>4. Acceptable use</h2>
@@ -128,71 +141,143 @@
       <li>use the Service for anything unlawful, or to plan unlawful
         activity;</li>
       <li>probe, disrupt, overload, or attempt to gain unauthorized access to
-        the Service or other users' data;</li>
-      <li>scrape, harvest, or bulk-extract content or data from the Service,
-        or resell the Service;</li>
-      <li>abuse the AI planning assistant (for example, attempting to use it
-        for purposes unrelated to travel planning at volume, or to generate
-        harmful content);</li>
+        the Service, other users' data, or our infrastructure;</li>
+      <li>circumvent rate limits, usage caps, or access controls;</li>
+      <li>scrape, harvest, or bulk-extract content or data from the Service, or
+        resell or white-label the Service;</li>
+      <li>abuse the AI planning assistant — for example, using it at volume for
+        purposes unrelated to travel planning, attempting to extract our
+        prompts or systems, or using it to generate harmful content;</li>
+      <li>upload content you have no right to share, or content that is
+        malicious (including malware or attempts at prompt injection against
+        other users' shared trips);</li>
       <li>impersonate others or misrepresent your affiliation with any person
         or entity.</li>
     </ul>
+    <p>
+      We enforce reasonable technical limits (request rates, message and image
+      sizes, daily AI-usage caps) to keep the Service available and affordable
+      for everyone. We may change these limits.
+    </p>
 
     <h2>5. Your content</h2>
     <p>
-      Trips, itineraries, preferences, and messages you create remain yours.
-      You grant Golden Tempo LLC a limited license to store and process them
-      solely to operate and improve the Service, as described in the
-      <a href="/privacy">Privacy Policy</a>. If you share a trip via a share
-      link, anyone with the link can view (or, for co-planner invites, edit)
-      that trip.
+      Trips, itineraries, notes, checklists, messages to the AI assistant, and
+      images you upload ("Your Content") <strong>remain yours</strong>. You
+      grant Golden Tempo LLC a limited, non-exclusive license to host, store,
+      process, transmit, and display Your Content solely to operate, secure,
+      and improve the Service — including sending relevant parts to the service
+      providers described in the <a href="/privacy">Privacy Policy</a> (for
+      example, sending your planning conversation to our AI provider to generate
+      a response). This license ends when you delete the content or your
+      account, except for the limited retention described in the Privacy Policy
+      (for example, rotating backups).
+    </p>
+    <div class="callout">
+      <strong>Sharing is under your control, and at your discretion.</strong>
+      If you create a share link, anyone who has the link can view the trip
+      until you revoke the link. If you invite a co-planner, they can view and
+      edit that trip. If you create an export or calendar link, anyone with that
+      link can access the exported content while the link is valid. Share
+      thoughtfully.
+    </div>
+
+    <h2>6. Our intellectual property</h2>
+    <p>
+      The Service itself — its software, design, branding, and content we
+      created — belongs to Golden Tempo LLC or its licensors. These Terms do not
+      grant you any right to use our name, logo, or branding. You may use the
+      Service only as permitted by these Terms.
     </p>
 
-    <h2>6. Suspension and termination</h2>
+    <h2>7. Third-party services</h2>
     <p>
-      We may suspend or terminate accounts that violate these Terms, abuse the
-      Service, or create risk for us or other users. Where reasonable, we will
-      warn you first. You may stop using the Service and delete your account
-      at any time.
+      The Service depends on third-party providers (AI models, place and flight
+      data, weather, events, email delivery, and network infrastructure —
+      listed in the <a href="/privacy">Privacy Policy</a>). We do not control
+      them, and the Service may be affected if they change, fail, or become
+      unavailable. Content from third-party sources belongs to those sources.
     </p>
 
-    <h2>7. Disclaimers</h2>
+    <h2>8. Suspension and termination</h2>
     <p>
-      THE SERVICE IS PROVIDED "AS IS" AND "AS AVAILABLE", WITHOUT WARRANTIES
-      OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING MERCHANTABILITY, FITNESS FOR
-      A PARTICULAR PURPOSE, AND NON-INFRINGEMENT. WE DO NOT WARRANT THAT THE
-      SERVICE WILL BE UNINTERRUPTED, ERROR-FREE, OR THAT ANY INFORMATION
-      (INCLUDING AI-GENERATED CONTENT) WILL BE ACCURATE OR RELIABLE.
+      We may suspend or terminate your account if you violate these Terms, abuse
+      the Service, or create risk or legal exposure for us or other users. Where
+      reasonable, we will warn you first. You may stop using the Service and
+      delete your account at any time. We may also change, limit, or discontinue
+      the Service (or parts of it) — if we discontinue it entirely, we will make
+      reasonable efforts to give notice so you can export your trips. Sections
+      5–13 survive termination to the extent they reasonably should.
     </p>
 
-    <h2>8. Limitation of liability</h2>
+    <h2>9. Disclaimers</h2>
     <p>
-      TO THE MAXIMUM EXTENT PERMITTED BY LAW, GOLDEN TEMPO LLC WILL NOT BE
+      THE SERVICE IS PROVIDED "AS IS" AND "AS AVAILABLE," WITHOUT WARRANTIES OF
+      ANY KIND, EXPRESS OR IMPLIED, INCLUDING MERCHANTABILITY, FITNESS FOR A
+      PARTICULAR PURPOSE, AND NON-INFRINGEMENT. WE DO NOT WARRANT THAT THE
+      SERVICE WILL BE UNINTERRUPTED, SECURE, OR ERROR-FREE, OR THAT ANY
+      INFORMATION IN IT (INCLUDING AI-GENERATED CONTENT AND THIRD-PARTY DATA)
+      WILL BE ACCURATE, COMPLETE, OR RELIABLE. NO ADVICE OR INFORMATION OBTAINED
+      FROM THE SERVICE CREATES ANY WARRANTY.
+    </p>
+
+    <h2>10. Limitation of liability</h2>
+    <p>
+      TO THE MAXIMUM EXTENT PERMITTED BY LAW: (A) GOLDEN TEMPO LLC WILL NOT BE
       LIABLE FOR INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL, OR PUNITIVE
-      DAMAGES, OR FOR LOST PROFITS, DATA, OR TRAVEL COSTS, ARISING FROM YOUR
-      USE OF THE SERVICE OR FROM ANY THIRD-PARTY PROVIDER YOU REACH THROUGH
-      IT. OUR TOTAL LIABILITY FOR ANY CLAIM RELATING TO THE SERVICE IS LIMITED
-      TO THE GREATER OF $100 OR THE AMOUNT YOU PAID US IN THE 12 MONTHS BEFORE
-      THE CLAIM. Some jurisdictions do not allow certain limitations, so parts
-      of this section may not apply to you.
+      DAMAGES, OR FOR LOST PROFITS, LOST DATA, OR <strong>TRAVEL COSTS, MISSED
+      CONNECTIONS, OR OTHER TRAVEL LOSSES</strong>, ARISING FROM YOUR USE OF THE
+      SERVICE OR FROM ANY THIRD-PARTY PROVIDER YOU REACH THROUGH IT; AND (B) OUR
+      TOTAL LIABILITY FOR ALL CLAIMS RELATING TO THE SERVICE IS LIMITED TO THE
+      GREATER OF <strong>$100</strong> OR THE AMOUNT YOU PAID US IN THE 12
+      MONTHS BEFORE THE CLAIM. SOME JURISDICTIONS DO NOT ALLOW CERTAIN
+      LIMITATIONS, SO PARTS OF THIS SECTION MAY NOT APPLY TO YOU. NOTHING IN
+      THESE TERMS LIMITS LIABILITY THAT CANNOT BE LIMITED BY LAW.
     </p>
 
-    <h2>9. Governing law</h2>
+    <h2>11. Indemnification</h2>
+    <p>
+      If a third party brings a claim against Golden Tempo LLC arising out of
+      Your Content, your violation of these Terms, or your violation of law or
+      the rights of others, you agree to indemnify and hold us harmless from the
+      resulting damages, liabilities, and reasonable legal costs. We will notify
+      you of any such claim and reasonably cooperate with you. (This section is
+      about you causing third-party claims — it does not shift our own
+      responsibilities under these Terms onto you.)
+    </p>
+
+    <h2>12. Governing law and disputes</h2>
     <p>
       These Terms are governed by the laws of the State of New Jersey, USA,
-      without regard to conflict-of-law rules. Disputes will be resolved in
-      the state or federal courts located in New Jersey, and you consent to
-      their jurisdiction.
+      without regard to conflict-of-law rules.
     </p>
-
-    <h2>10. Changes to these Terms</h2>
     <p>
-      We may update these Terms as the Service evolves. Material changes will
-      be reflected on this page with an updated date. Continued use of the
-      Service after a change means you accept the updated Terms.
+      <strong>Talk to us first.</strong> Before filing any claim, you agree to
+      email us at
+      <a href="mailto:goldentempollc@gmail.com">goldentempollc@gmail.com</a> and
+      give us 30 days to try to resolve the issue informally. Most problems can
+      be fixed this way.
+    </p>
+    <p>
+      Any dispute not resolved informally will be resolved by binding individual
+      arbitration administered by the American Arbitration Association under its
+      Consumer Arbitration Rules, rather than in court, except that either party
+      may bring an individual claim in small-claims court.
+      <strong>You and Golden Tempo each waive the right to a jury trial and to
+      participate in a class action.</strong> You may opt out of arbitration
+      within 30 days of accepting these Terms by emailing us.
     </p>
 
-    <h2>11. Contact</h2>
+    <h2>13. Changes to these Terms</h2>
+    <p>
+      We may update these Terms as the Service evolves. If a change is material,
+      we will post the updated Terms here with a new effective date and make
+      reasonable efforts to notify you in the app or by email before it takes
+      effect. Continued use of the Service after a change means you accept the
+      updated Terms.
+    </p>
+
+    <h2>14. Contact</h2>
     <p>
       Golden Tempo LLC (New Jersey, USA)<br>
       <a href="mailto:goldentempollc@gmail.com">goldentempollc@gmail.com</a>

--- a/src/packages/flutter-app/lib/l10n/app_en.arb
+++ b/src/packages/flutter-app/lib/l10n/app_en.arb
@@ -1416,6 +1416,7 @@
   "sharedSaveSeparateCopy": "Or save a separate copy",
   "sharedKeepInTrips": "Keep in my trips",
   "legalAgreementPrefix": "By signing up you agree to the ",
+  "legalConsentCheckboxPrefix": "I agree to the ",
   "legalTermsOfService": "Terms of Service",
   "legalAgreementConjunction": " and ",
   "legalPrivacyPolicy": "Privacy Policy",

--- a/src/packages/flutter-app/lib/l10n/app_es.arb
+++ b/src/packages/flutter-app/lib/l10n/app_es.arb
@@ -616,6 +616,7 @@
   "sharedSaveSeparateCopy": "O guardar una copia aparte",
   "sharedKeepInTrips": "Guardar en mis viajes",
   "legalAgreementPrefix": "Al registrarte aceptas los ",
+  "legalConsentCheckboxPrefix": "Acepto los ",
   "legalTermsOfService": "Términos del servicio",
   "legalAgreementConjunction": " y la ",
   "legalPrivacyPolicy": "Política de privacidad",

--- a/src/packages/flutter-app/lib/l10n/app_localizations.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations.dart
@@ -3794,6 +3794,12 @@ abstract class AppLocalizations {
   /// **'By signing up you agree to the '**
   String get legalAgreementPrefix;
 
+  /// No description provided for @legalConsentCheckboxPrefix.
+  ///
+  /// In en, this message translates to:
+  /// **'I agree to the '**
+  String get legalConsentCheckboxPrefix;
+
   /// No description provided for @legalTermsOfService.
   ///
   /// In en, this message translates to:

--- a/src/packages/flutter-app/lib/l10n/app_localizations_en.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations_en.dart
@@ -2117,6 +2117,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get legalAgreementPrefix => 'By signing up you agree to the ';
 
   @override
+  String get legalConsentCheckboxPrefix => 'I agree to the ';
+
+  @override
   String get legalTermsOfService => 'Terms of Service';
 
   @override

--- a/src/packages/flutter-app/lib/l10n/app_localizations_es.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations_es.dart
@@ -2128,6 +2128,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get legalAgreementPrefix => 'Al registrarte aceptas los ';
 
   @override
+  String get legalConsentCheckboxPrefix => 'Acepto los ';
+
+  @override
   String get legalTermsOfService => 'Términos del servicio';
 
   @override

--- a/src/packages/flutter-app/lib/screens/auth_screen.dart
+++ b/src/packages/flutter-app/lib/screens/auth_screen.dart
@@ -28,6 +28,11 @@ class _AuthScreenState extends ConsumerState<AuthScreen> {
   final _displayNameController = TextEditingController();
   late bool _isLogin = widget.initialIsLogin;
 
+  // Blocking affirmative consent for email sign-up (launch legal gate): the
+  // create-account button stays disabled until this is ticked. Login and SSO
+  // don't use it — SSO shows an informational line under its own buttons.
+  bool _agreedToTerms = false;
+
   // Auto-submit after a password-manager autofill. An extension fill is
   // distinctive: each field goes from empty to its full value within one
   // rapid burst (a single change event, or keystroke-simulated characters
@@ -115,6 +120,10 @@ class _AuthScreenState extends ConsumerState<AuthScreen> {
   }
 
   Future<void> _submit() async {
+    // Consent gate for email sign-up: also guards the Enter-key path
+    // (onFieldSubmitted), which reaches here without touching the disabled
+    // create-account button.
+    if (!_isLogin && !_agreedToTerms) return;
     if (!_formKey.currentState!.validate()) return;
     final notifier = ref.read(authProvider.notifier);
     final email = _emailController.text.trim();
@@ -268,9 +277,18 @@ class _AuthScreenState extends ConsumerState<AuthScreen> {
                         textAlign: TextAlign.center,
                       ),
                     ],
-                    const SizedBox(height: 24),
+                    const SizedBox(height: 16),
+                    if (!_isLogin) ...[
+                      LegalConsentCheckbox(
+                        value: _agreedToTerms,
+                        onChanged: (v) => setState(() => _agreedToTerms = v),
+                      ),
+                      const SizedBox(height: 8),
+                    ],
                     FilledButton(
-                      onPressed: auth.loading ? null : _submit,
+                      onPressed: auth.loading || (!_isLogin && !_agreedToTerms)
+                          ? null
+                          : _submit,
                       style: FilledButton.styleFrom(
                         padding: const EdgeInsets.symmetric(vertical: 16),
                       ),
@@ -286,10 +304,6 @@ class _AuthScreenState extends ConsumerState<AuthScreen> {
                                   : l10n.authCreateAccount,
                             ),
                     ),
-                    if (!_isLogin) ...[
-                      const SizedBox(height: 12),
-                      const LegalAgreementText(),
-                    ],
                     const SizedBox(height: 12),
                     TextButton(
                       onPressed: auth.loading ? null : _toggleMode,

--- a/src/packages/flutter-app/lib/widgets/legal_links.dart
+++ b/src/packages/flutter-app/lib/widgets/legal_links.dart
@@ -25,32 +25,80 @@ Future<void> openLegalPage(String path) async {
 Future<void> openPrivacyPolicy() => openLegalPage('/privacy');
 Future<void> openTermsOfService() => openLegalPage('/terms');
 
+/// The "…Terms of Service and Privacy Policy." tail shared by the informational
+/// line and the consent checkbox: the two tappable links joined by the
+/// localized conjunction, followed by a period. The caller supplies the leading
+/// prefix span so it can read either "By signing up you agree to the …" or
+/// "I agree to the …".
+List<Widget> _legalLinkTail(BuildContext context, TextStyle? base) {
+  final l10n = context.l10n;
+  return [
+    _InlineLink(
+        label: l10n.legalTermsOfService, style: base, onTap: openTermsOfService),
+    Text(l10n.legalAgreementConjunction, style: base),
+    _InlineLink(
+        label: l10n.legalPrivacyPolicy, style: base, onTap: openPrivacyPolicy),
+    Text('.', style: base),
+  ];
+}
+
 /// "By signing up you agree to the Terms of Service and Privacy Policy" —
-/// small print with tappable links, shown under the sign-up form.
+/// informational small print with tappable links. Used under the SSO buttons,
+/// where the provider's own click is the agreement (email sign-up uses the
+/// blocking [LegalConsentCheckbox] instead).
 class LegalAgreementText extends StatelessWidget {
   const LegalAgreementText({super.key});
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final l10n = context.l10n;
     final base = theme.textTheme.bodySmall
         ?.copyWith(color: theme.colorScheme.onSurfaceVariant);
     return Wrap(
       alignment: WrapAlignment.center,
       crossAxisAlignment: WrapCrossAlignment.center,
       children: [
-        Text(l10n.legalAgreementPrefix, style: base),
-        _InlineLink(
-            label: l10n.legalTermsOfService,
-            style: base,
-            onTap: openTermsOfService),
-        Text(l10n.legalAgreementConjunction, style: base),
-        _InlineLink(
-            label: l10n.legalPrivacyPolicy,
-            style: base,
-            onTap: openPrivacyPolicy),
-        Text('.', style: base),
+        Text(context.l10n.legalAgreementPrefix, style: base),
+        ..._legalLinkTail(context, base),
+      ],
+    );
+  }
+}
+
+/// Blocking affirmative-consent checkbox for email sign-up: the create-account
+/// button stays disabled until this is ticked. The label ("I agree to the
+/// Terms of Service and Privacy Policy") carries the same tappable links.
+class LegalConsentCheckbox extends StatelessWidget {
+  final bool value;
+  final ValueChanged<bool> onChanged;
+
+  const LegalConsentCheckbox(
+      {super.key, required this.value, required this.onChanged});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final base = theme.textTheme.bodySmall
+        ?.copyWith(color: theme.colorScheme.onSurfaceVariant);
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: [
+        Checkbox(
+          value: value,
+          onChanged: (v) => onChanged(v ?? false),
+          visualDensity: VisualDensity.compact,
+          materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+        ),
+        const SizedBox(width: 4),
+        Expanded(
+          child: Wrap(
+            crossAxisAlignment: WrapCrossAlignment.center,
+            children: [
+              Text(context.l10n.legalConsentCheckboxPrefix, style: base),
+              ..._legalLinkTail(context, base),
+            ],
+          ),
+        ),
       ],
     );
   }

--- a/src/packages/flutter-app/lib/widgets/sso_buttons.dart
+++ b/src/packages/flutter-app/lib/widgets/sso_buttons.dart
@@ -4,6 +4,7 @@ import '../l10n/l10n.dart';
 import '../providers/auth_provider.dart';
 import 'apple_sign_in_button.dart';
 import 'google_sign_in_button.dart';
+import 'legal_links.dart';
 
 /// The SSO section of the auth screen: one "or" divider above whichever
 /// provider buttons the backend has configured (Google, then Apple). Renders
@@ -36,6 +37,10 @@ class SsoButtons extends ConsumerWidget {
         if (google) const GoogleSignInButton(),
         if (google && apple) const SizedBox(height: 12),
         if (apple) const AppleSignInButton(),
+        const SizedBox(height: 12),
+        // Informational — the provider's own click is the agreement. Email
+        // sign-up uses the blocking LegalConsentCheckbox instead.
+        const LegalAgreementText(),
       ],
     );
   }

--- a/src/packages/flutter-app/test/auth_autofill_submit_test.dart
+++ b/src/packages/flutter-app/test/auth_autofill_submit_test.dart
@@ -167,4 +167,40 @@ void main() {
     expect(service.registerCalls, isEmpty);
     expect(service.loginCalls, isEmpty);
   });
+
+  testWidgets('email sign-up is blocked until the consent box is ticked', (
+    tester,
+  ) async {
+    final service = _FakeAuthService();
+    await tester.pumpWidget(_wrap(service));
+    await tester.pump();
+
+    await tester.tap(find.text("Don't have an account? Sign up"));
+    await tester.pumpAndSettle();
+
+    await tester.enterText(_fieldByLabel('Email'), 'brian@example.com');
+    await tester.enterText(_fieldByLabel('Password'), 'hunter2hunter2');
+    await tester.pump();
+
+    final createButton = find.ancestor(
+      of: find.text('Create account'),
+      matching: find.byType(FilledButton),
+    );
+
+    // Consent unticked: the button is disabled and the Enter-key path is
+    // guarded, so no registration can happen.
+    expect(tester.widget<FilledButton>(createButton).onPressed, isNull);
+    await tester.tap(createButton, warnIfMissed: false);
+    await tester.pump();
+    expect(service.registerCalls, isEmpty);
+
+    // Tick consent → the button enables and registration goes through.
+    await tester.tap(find.byType(Checkbox));
+    await tester.pump();
+    expect(tester.widget<FilledButton>(createButton).onPressed, isNotNull);
+
+    await tester.tap(createButton);
+    await tester.pumpAndSettle();
+    expect(service.registerCalls, [('brian@example.com', 'hunter2hunter2')]);
+  });
 }


### PR DESCRIPTION
## Summary
Launch-readiness: finalize the legal pages for the public announcement and add a **blocking affirmative-consent checkbox** at email sign-up. (Marketing copy-drift + the OG card ship in a separate follow-up PR to keep this one a focused legal-review artifact.)

> ⚠️ **@bdowe — legal sign-off gate.** This de-DRAFTs and publishes the Terms/Privacy pages. Please read the rendered `/terms` and `/privacy` before this deploys. The placeholders were filled with the agreed defaults; see below.

### Legal pages (`dockerize/static/{terms,privacy}.html`)
- Remove the `noindex` meta + DRAFT banner (div + CSS); effective date set to **July 24, 2026**.
- Body replaced with the launch-ready, code-verified copy. Terms adds indemnification, informal-dispute-first + **individual AAA arbitration with a class-action waiver**, a service-may-change clause, and an SSO line. Privacy honestly documents: IP addresses in request logs, Cloudflare/Sentry, the AI-maintained profile notes, stored SSO identities, persisted chat transcripts (images stripped to markers), rotating backups, share/invite/export link mechanics, and one-click unsubscribe.
- **Placeholders filled with agreed defaults:** $100 liability cap · contact `goldentempollc@gmail.com` · email provider Resend · minimum age 13.
- **Two now-inaccurate claims dropped:** "optimize routes" (standalone route optimizer retired in #221) and the Airbnb listing-page fetch (that SSRF endpoint was deleted in #224). The unconfirmed off-site-backup provider row was also dropped (retention §8 still covers backups generically).

### Sign-up consent (Flutter)
- New **blocking `LegalConsentCheckbox`**: the create-account button stays disabled until it's ticked, and `_submit()` guards the Enter-key (`onFieldSubmitted`) path so it can't bypass the gate. Login and SSO are unaffected — SSO keeps an informational "by signing up you agree…" line under its own buttons (the provider click is the agreement).
- New l10n key `legalConsentCheckboxPrefix` (en + es); localizations regenerated.

### Open item for a later step (not this PR)
CAN-SPAM requires a physical postal address in the *marketing-class* email footers (trip reminders / weekly nudges). I don't have a mailing address to insert — flagging for @bdowe to add to those email templates.

## Test plan
- [x] Legal pages swept clean of `noindex` / `DRAFT` / `PLACEHOLDER` / `TODO`; both nginx server configs already serve `/terms` and `/privacy`.
- [x] New widget test: create-account is disabled and registration is blocked until the consent box is ticked, then goes through.
- [x] `flutter gen-l10n` clean (no drift, full translation), `flutter analyze` exits 0, `flutter test` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)