### PR TITLE
security: hash session bearer tokens at rest

### DIFF
--- a/src/packages/api/account_handler.go
+++ b/src/packages/api/account_handler.go
@@ -137,12 +137,12 @@ func changePasswordHandler(w http.ResponseWriter, r *http.Request) {
 	if err := q.DeleteSessionsByUser(r.Context(), user.ID); err != nil {
 		log.Printf("change password: could not revoke sessions for %s: %v", user.ID, err)
 	}
-	session, err := issueSession(r.Context(), q, user.ID)
+	token, err := issueSession(r.Context(), q, user.ID)
 	if err != nil {
 		writeJSONError(w, http.StatusInternalServerError, "password changed — sign in again")
 		return
 	}
-	writeJSON(w, http.StatusOK, AuthResponse{User: toUserResponse(user), Token: session.ID})
+	writeJSON(w, http.StatusOK, AuthResponse{User: toUserResponse(user), Token: token})
 }
 
 func logoutAllHandler(w http.ResponseWriter, r *http.Request) {

--- a/src/packages/api/account_integration_test.go
+++ b/src/packages/api/account_integration_test.go
@@ -65,7 +65,7 @@ func TestChangePasswordRevokesOtherSessions(t *testing.T) {
 	resetDB(t)
 	user, tokenA := createTestUser(t, "me@example.com")
 	// A second device.
-	sessionB, err := issueSession(t.Context(), store.New(dbPool), user.ID)
+	tokenB, err := issueSession(t.Context(), store.New(dbPool), user.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -93,7 +93,7 @@ func TestChangePasswordRevokesOtherSessions(t *testing.T) {
 	if r := doJSON(t, "GET", "/api/v1/auth/me", tokenA, nil); r.Code != http.StatusUnauthorized {
 		t.Fatalf("old session A alive = %d", r.Code)
 	}
-	if r := doJSON(t, "GET", "/api/v1/auth/me", sessionB.ID, nil); r.Code != http.StatusUnauthorized {
+	if r := doJSON(t, "GET", "/api/v1/auth/me", tokenB, nil); r.Code != http.StatusUnauthorized {
 		t.Fatalf("old session B alive = %d", r.Code)
 	}
 	if r := doJSON(t, "GET", "/api/v1/auth/me", fresh, nil); r.Code != http.StatusOK {
@@ -109,7 +109,7 @@ func TestChangePasswordRevokesOtherSessions(t *testing.T) {
 func TestLogoutAllDevices(t *testing.T) {
 	resetDB(t)
 	user, token := createTestUser(t, "me@example.com")
-	other, err := issueSession(t.Context(), store.New(dbPool), user.ID)
+	otherToken, err := issueSession(t.Context(), store.New(dbPool), user.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -117,7 +117,7 @@ func TestLogoutAllDevices(t *testing.T) {
 	if rec := doJSON(t, "POST", "/api/v1/auth/logout-all", token, nil); rec.Code != http.StatusNoContent {
 		t.Fatalf("logout-all = %d", rec.Code)
 	}
-	if r := doJSON(t, "GET", "/api/v1/auth/me", other.ID, nil); r.Code != http.StatusUnauthorized {
+	if r := doJSON(t, "GET", "/api/v1/auth/me", otherToken, nil); r.Code != http.StatusUnauthorized {
 		t.Fatalf("other device still signed in = %d", r.Code)
 	}
 }

--- a/src/packages/api/auth_handler.go
+++ b/src/packages/api/auth_handler.go
@@ -121,7 +121,7 @@ func userIDFromRequest(r *http.Request) (uuid.UUID, bool, error) {
 	if token == "" {
 		return uuid.UUID{}, false, nil
 	}
-	row, err := store.New(dbPool).GetSessionWithUser(r.Context(), token)
+	row, err := store.New(dbPool).GetSessionWithUser(r.Context(), hashBearerToken(token))
 	if err != nil {
 		if dbErrorStatus(err) == http.StatusServiceUnavailable {
 			ctxLog(r.Context()).Error("auth: session lookup failed (db)", "error", err)
@@ -154,7 +154,7 @@ func authMiddleware(next http.Handler) http.Handler {
 			return
 		}
 		q := store.New(dbPool)
-		row, err := q.GetSessionWithUser(r.Context(), token)
+		row, err := q.GetSessionWithUser(r.Context(), hashBearerToken(token))
 		if err != nil {
 			// A DB-connection failure (Postgres restarting, pool closed, conn
 			// refused) must NOT masquerade as an invalid session — that logs
@@ -278,7 +278,7 @@ func registerHandler(w http.ResponseWriter, r *http.Request) {
 	// Count the successful creation toward this IP's daily ceiling.
 	registrationCounter.incr(ip, time.Now())
 
-	session, err := issueSession(r.Context(), q, user.ID)
+	token, err := issueSession(r.Context(), q, user.ID)
 	if err != nil {
 		writeJSONError(w, http.StatusInternalServerError, "could not start session")
 		return
@@ -287,7 +287,7 @@ func registerHandler(w http.ResponseWriter, r *http.Request) {
 	// or fails on email delivery or analytics.
 	safeGo("sendVerificationEmail", func() { sendVerificationEmailIn(user, signupLocale) })
 	safeGo("recordEvent", func() { recordEvent(user.ID, "user_registered", nil, nil) })
-	writeJSON(w, http.StatusCreated, AuthResponse{User: toUserResponse(user), Token: session.ID})
+	writeJSON(w, http.StatusCreated, AuthResponse{User: toUserResponse(user), Token: token})
 }
 
 func loginHandler(w http.ResponseWriter, r *http.Request) {
@@ -337,17 +337,17 @@ func loginHandler(w http.ResponseWriter, r *http.Request) {
 	// Successful auth clears the failure streak.
 	loginLockouts.reset(req.Email)
 
-	session, err := issueSession(r.Context(), q, user.ID)
+	token, err := issueSession(r.Context(), q, user.ID)
 	if err != nil {
 		writeJSONError(w, http.StatusInternalServerError, "could not start session")
 		return
 	}
-	writeJSON(w, http.StatusOK, AuthResponse{User: toUserResponse(user), Token: session.ID})
+	writeJSON(w, http.StatusOK, AuthResponse{User: toUserResponse(user), Token: token})
 }
 
 func logoutHandler(w http.ResponseWriter, r *http.Request) {
 	if token := bearerToken(r); token != "" && dbPool != nil {
-		_ = store.New(dbPool).DeleteSession(r.Context(), token)
+		_ = store.New(dbPool).DeleteSession(r.Context(), hashBearerToken(token))
 	}
 	w.WriteHeader(http.StatusNoContent)
 }

--- a/src/packages/api/auth_service.go
+++ b/src/packages/api/auth_service.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/hex"
 	"net/mail"
 	"strings"
@@ -48,16 +49,31 @@ func generateSessionToken() (string, error) {
 	return hex.EncodeToString(b), nil
 }
 
-func issueSession(ctx context.Context, q *store.Queries, userID uuid.UUID) (store.Session, error) {
+// hashBearerToken returns the SHA-256 hex digest of a bearer token. Session
+// tokens are stored as this digest so a database read can't yield a usable
+// token; the raw token (held only by the client) is hashed the same way on
+// every lookup. Matches the Postgres `encode(sha256(id::bytea),'hex')` the
+// hashing migration applies to pre-existing rows, so old sessions keep working.
+func hashBearerToken(raw string) string {
+	sum := sha256.Sum256([]byte(raw))
+	return hex.EncodeToString(sum[:])
+}
+
+// issueSession mints a new session and returns the RAW token for the client.
+// The database stores only its hash — the raw is never persisted.
+func issueSession(ctx context.Context, q *store.Queries, userID uuid.UUID) (string, error) {
 	token, err := generateSessionToken()
 	if err != nil {
-		return store.Session{}, err
+		return "", err
 	}
-	return q.CreateSession(ctx, store.CreateSessionParams{
-		ID:        token,
+	if _, err := q.CreateSession(ctx, store.CreateSessionParams{
+		ID:        hashBearerToken(token),
 		UserID:    userID,
 		ExpiresAt: time.Now().Add(sessionDuration),
-	})
+	}); err != nil {
+		return "", err
+	}
+	return token, nil
 }
 
 func validateEmail(email string) bool {

--- a/src/packages/api/google_auth_handler.go
+++ b/src/packages/api/google_auth_handler.go
@@ -216,10 +216,10 @@ func ssoExchangeHandler(w http.ResponseWriter, r *http.Request) {
 		writeJSONError(w, http.StatusInternalServerError, "could not complete sign-in")
 		return
 	}
-	session, err := issueSession(r.Context(), q, user.ID)
+	token, err := issueSession(r.Context(), q, user.ID)
 	if err != nil {
 		writeJSONError(w, http.StatusInternalServerError, "could not start session")
 		return
 	}
-	writeJSON(w, http.StatusOK, AuthResponse{User: toUserResponse(user), Token: session.ID})
+	writeJSON(w, http.StatusOK, AuthResponse{User: toUserResponse(user), Token: token})
 }

--- a/src/packages/api/integration_test.go
+++ b/src/packages/api/integration_test.go
@@ -152,11 +152,11 @@ func createTestUser(t *testing.T, email string) (store.User, string) {
 	if err != nil {
 		t.Fatalf("createTestUser(%s): %v", email, err)
 	}
-	s, err := issueSession(ctx, q, u.ID)
+	token, err := issueSession(ctx, q, u.ID)
 	if err != nil {
 		t.Fatalf("issueSession(%s): %v", email, err)
 	}
-	return u, s.ID
+	return u, token
 }
 
 func makeAdmin(t *testing.T, id uuid.UUID) {

--- a/src/packages/api/migrations/00050_hash_session_tokens.sql
+++ b/src/packages/api/migrations/00050_hash_session_tokens.sql
@@ -1,0 +1,17 @@
+-- +goose Up
+-- Store session bearer tokens as SHA-256 digests instead of the raw token, so a
+-- database read (SQL injection, a leaked backup) can no longer yield a usable
+-- session. This matches how email/verify/reset/invite tokens are already stored.
+--
+-- Hashing the EXISTING rows in place keeps currently-signed-in users logged in:
+-- the client still holds the raw token, and auth_service.go's hashBearerToken()
+-- hashes it the same way on every lookup — encode(sha256(<utf8 bytes>),'hex'),
+-- lowercase — so sha256(raw) computed in Go matches the digest stored here.
+-- sessions.id is TEXT, so the 64-char hex digest fits with no type change.
+UPDATE sessions SET id = encode(sha256(id::bytea), 'hex');
+
+-- +goose Down
+-- Hashing is one-way: the raw tokens cannot be recovered. Rolling back to code
+-- that expects raw tokens would reject every stored (hashed) session, so clear
+-- them — users simply sign in again.
+DELETE FROM sessions;

--- a/src/packages/api/session_token_test.go
+++ b/src/packages/api/session_token_test.go
@@ -1,0 +1,26 @@
+package main
+
+import "testing"
+
+// TestHashBearerToken locks the exact digest hashBearerToken produces. The
+// vector must equal Postgres `encode(sha256('test'::bytea),'hex')` — the
+// hashing migration (00050) rewrites existing sessions.id with that SQL, so if
+// the Go and SQL digests ever diverged, every already-signed-in session would
+// stop validating after the migration.
+func TestHashBearerToken(t *testing.T) {
+	const wantForTest = "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"
+	if got := hashBearerToken("test"); got != wantForTest {
+		t.Fatalf("hashBearerToken(%q) = %q, want %q (must match SQL sha256)", "test", got, wantForTest)
+	}
+	// 64-char lowercase hex, deterministic, and collision-free across inputs.
+	h := hashBearerToken("some-random-session-token")
+	if len(h) != 64 {
+		t.Fatalf("digest length = %d, want 64", len(h))
+	}
+	if hashBearerToken("x") != hashBearerToken("x") {
+		t.Fatal("hashBearerToken is not deterministic")
+	}
+	if hashBearerToken("a") == hashBearerToken("b") {
+		t.Fatal("distinct tokens hashed to the same digest")
+	}
+}


### PR DESCRIPTION
## Summary
Launch-readiness (MED from the audit): session tokens were stored in `sessions.id` as the **raw** bearer token, so a database read (SQL injection, a leaked backup) would yield tokens usable for full account access. Store the SHA-256 digest instead — matching how email/verify/reset/invite tokens are already stored.

- `hashBearerToken()` = `hex(sha256(token))`. `issueSession()` now stores the digest and returns the **raw** token to the client (never persisted); its four callers (password change, register, login, Google/Apple SSO exchange) use the returned raw token.
- The three validation paths (two `GetSessionWithUser` lookups + the logout `DeleteSession`) hash the incoming bearer token before the query.
- **Migration 00050** rewrites existing `sessions.id` in place with `encode(sha256(id::bytea),'hex')`. This is byte-identical to the Go digest, so **currently-signed-in users stay logged in through the deploy — no forced re-login.** (Down clears sessions; hashing is one-way.)

## Why share tokens are NOT hashed here
`createShareHandler` is idempotent: when an active share exists it returns the **stored** token so re-opening the dialog shows the same link — a hash can't satisfy that, and rotating the token on re-share would break already-distributed links. Hashing share tokens needs a product decision (accept rotation, or change the idempotency model). Flagged for @bdowe as a follow-up rather than shipping a share-link regression in the launch PR. (Share tokens grant access to one trip and already live in shared URLs, a lower-value target than a session token.)

## Test plan
- [x] Verified the migration's SQL digest equals Go's `hashBearerToken` for the same input against a real Postgres 16 (`encode(sha256('test'::bytea),'hex')` == `sha256("test")`) — this is what makes existing sessions survive.
- [x] New `session_token_test.go` pins that exact vector so the Go and SQL hashes can't silently diverge.
- [x] Full `go test -race ./...` green against a throwaway DB (59s): session round-trip (register → raw token → authed request), `change-password`/`logout-all` killing other sessions, and the share create/join flow all pass.
- [x] `go build`/`vet`/`gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)