### PR TITLE
polish: wave-2 foundations — shared widget i18n + tokens

### DIFF
--- a/src/packages/flutter-app/lib/screens/trips_list_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trips_list_screen.dart
@@ -46,8 +46,8 @@ class _TripsListScreenState extends ConsumerState<TripsListScreen> {
     final theme = Theme.of(context);
     final l10n = context.l10n;
     final state = ref.watch(tripsProvider);
-    final resumable =
-        ref.watch(resumableChatsProvider).valueOrNull ?? const <ChatSessionSummary>[];
+    final resumable = ref.watch(resumableChatsProvider).valueOrNull ??
+        const <ChatSessionSummary>[];
     // Watched before the guard branches: an account whose only trips are
     // shared-with-me must reach the list, not the plan-a-trip empty state.
     final sharedAsync = ref.watch(sharedWithMeProvider);
@@ -88,8 +88,8 @@ class _TripsListScreenState extends ConsumerState<TripsListScreen> {
         message: l10n.tripsListEmptyMessage,
         actions: [
           FilledButton.icon(
-            onPressed: () => ref.read(navIndexProvider.notifier).state =
-                AppTab.plan.index,
+            onPressed: () =>
+                ref.read(navIndexProvider.notifier).state = AppTab.plan.index,
             icon: const Icon(Icons.auto_awesome),
             label: Text(l10n.tripsListPlanTrip),
           ),
@@ -106,6 +106,10 @@ class _TripsListScreenState extends ConsumerState<TripsListScreen> {
         },
         child: ListView(
           padding: const EdgeInsets.all(AppSpacing.md),
+          // Pull-to-refresh must arm even when the list is shorter than the
+          // viewport (one or two trips is the common case) — clamping physics
+          // would swallow the gesture on Android/web.
+          physics: const AlwaysScrollableScrollPhysics(),
           children: [
             // Centered 700px column on wide layouts, Home's exact pattern:
             // the ListView stays full-width (wheel/scrollbar work in the
@@ -153,8 +157,7 @@ class _TripsListScreenState extends ConsumerState<TripsListScreen> {
                     Padding(
                       padding: const EdgeInsets.fromLTRB(
                           AppSpacing.xs, AppSpacing.lg, 0, AppSpacing.sm),
-                      child:
-                          SectionHeader(title: l10n.tripsListSharedWithYou),
+                      child: SectionHeader(title: l10n.tripsListSharedWithYou),
                     ),
                     for (final t in shared) _TripCard(trip: t, isAdmin: false),
                   ],
@@ -308,7 +311,8 @@ class _DateChip extends StatelessWidget {
       child: Row(
         mainAxisSize: MainAxisSize.min,
         children: [
-          Icon(Icons.event, size: 13, color: theme.colorScheme.onSurfaceVariant),
+          Icon(Icons.event,
+              size: 13, color: theme.colorScheme.onSurfaceVariant),
           const SizedBox(width: AppSpacing.xs),
           Text(
             label,
@@ -381,7 +385,8 @@ class _VersionList extends ConsumerWidget {
               ListTile(
                 dense: true,
                 leading: const Icon(Icons.history, size: 20),
-                title: Text(versions[i].title, maxLines: 2, overflow: TextOverflow.ellipsis),
+                title: Text(versions[i].title,
+                    maxLines: 2, overflow: TextOverflow.ellipsis),
                 subtitle: Text(
                   i == 0
                       ? l10n.tripsListVersionLatest(

--- a/src/packages/flutter-app/lib/theme/app_colors.dart
+++ b/src/packages/flutter-app/lib/theme/app_colors.dart
@@ -30,6 +30,17 @@ abstract final class AppColors {
         ],
       );
 
+  // Semantic status pair for positive/complete states (booked checkmarks,
+  // Planned pills, published counts) — the exact green pair screens were
+  // re-declaring inline before the polish wave.
+  static Color get successContainer => Colors.green.withValues(alpha: 0.15);
+  static Color get onSuccessContainer => Colors.green.shade800;
+
+  // Semantic status pair for attention/pending states (review counts, draft
+  // badges) — the matching amber pair.
+  static Color get warningContainer => Colors.amber.withValues(alpha: 0.20);
+  static Color get onWarningContainer => Colors.amber.shade900;
+
   /// Accent color for an itinerary place by its category. `scheme` supplies the
   /// theme-derived fallbacks so this stays in sync with the seed.
   static Color forCategory(String? category, ColorScheme scheme) {

--- a/src/packages/flutter-app/lib/theme/app_shadows.dart
+++ b/src/packages/flutter-app/lib/theme/app_shadows.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 
+import 'app_colors.dart';
+
 /// Drop shadows for custom (non-Card) raised surfaces. Downward-offset so they
 /// imply light from above, per the wiki's depth-and-shadows guidance — a flat,
 /// evenly-blurred shadow looks artificial.
@@ -11,6 +13,25 @@ abstract final class AppShadows {
           color: Colors.black.withValues(alpha: 0.10),
           blurRadius: 10,
           offset: const Offset(0, 3),
+        ),
+      ];
+
+  /// Shadow under brand-gradient cards (hero strips, recent/live trip cards) —
+  /// the brandDark pair those cards were each declaring inline.
+  static List<BoxShadow> get brandCard => [
+        BoxShadow(
+          color: AppColors.brandDark.withValues(alpha: 0.3),
+          blurRadius: 10,
+          offset: const Offset(0, 4),
+        ),
+      ];
+
+  /// Deeper variant for full-bleed heroes (landing).
+  static List<BoxShadow> get hero => [
+        BoxShadow(
+          color: AppColors.brandDark.withValues(alpha: 0.4),
+          blurRadius: 16,
+          offset: const Offset(0, 6),
         ),
       ];
 }

--- a/src/packages/flutter-app/lib/widgets/choice_chip_row.dart
+++ b/src/packages/flutter-app/lib/widgets/choice_chip_row.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 
+import '../theme/spacing.dart';
+
 /// A single-select row of [ChoiceChip]s. Tapping the selected chip again
 /// clears the selection (passes null).
 class ChoiceChipRow extends StatelessWidget {
@@ -24,7 +26,9 @@ class ChoiceChipRow extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Wrap(
-      spacing: 8,
+      spacing: AppSpacing.sm,
+      // Long localized labels (es) wrap onto extra runs; keep them breathing.
+      runSpacing: AppSpacing.xs,
       children: options.map((o) {
         return ChoiceChip(
           label: Text(labelBuilder?.call(o) ?? o),

--- a/src/packages/flutter-app/lib/widgets/gradient_app_bar.dart
+++ b/src/packages/flutter-app/lib/widgets/gradient_app_bar.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
 
-/// App bar painted with the app's teal gradient — the same
-/// `teal.shade600 -> teal.shade900` used by the home "Plan Your Trip with AI"
-/// banner. Use in place of [AppBar] so every screen shares one header look.
+import '../theme/app_colors.dart';
+
+/// App bar painted with [AppColors.brandGradient] — the same teal pair used by
+/// the home hero banner. Use in place of [AppBar] so every screen shares one
+/// header look.
 class GradientAppBar extends StatelessWidget implements PreferredSizeWidget {
   final Widget title;
   final List<Widget>? actions;
@@ -26,13 +28,7 @@ class GradientAppBar extends StatelessWidget implements PreferredSizeWidget {
       backgroundColor: Colors.transparent,
       foregroundColor: Colors.white,
       flexibleSpace: Container(
-        decoration: BoxDecoration(
-          gradient: LinearGradient(
-            begin: Alignment.topLeft,
-            end: Alignment.bottomRight,
-            colors: [Colors.teal.shade600, Colors.teal.shade900],
-          ),
-        ),
+        decoration: BoxDecoration(gradient: AppColors.brandGradient),
       ),
     );
   }

--- a/src/packages/flutter-app/lib/widgets/map_day_chips.dart
+++ b/src/packages/flutter-app/lib/widgets/map_day_chips.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 
+import '../l10n/l10n.dart';
+
 /// Day-filter chips overlaid on a trip map: `All · Day 1 · … · Day N`
 /// (specs/today-mode). [selected] is the 1-based day, null meaning All;
 /// tapping a chip reports the new value through [onSelected] (tapping the
@@ -77,15 +79,18 @@ class MapDayChips extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     if (dayCount == 0) return const SizedBox.shrink();
+    // Same keys the trip-detail filter menu uses, so the chip row and the
+    // list agree in every language (specs/i18n-spanish).
+    final l10n = context.l10n;
     return SingleChildScrollView(
       scrollDirection: Axis.horizontal,
       child: Row(
         children: [
-          _chip(label: 'All', value: null),
+          _chip(label: l10n.tripFilterAll, value: null),
           for (var d = 1; d <= dayCount; d++) ...[
             const SizedBox(width: 6),
             _chip(
-              label: 'Day $d',
+              label: l10n.tripDayN(d),
               value: d,
               muted: mappedDays != null && !mappedDays!.contains(d),
             ),

--- a/src/packages/flutter-app/lib/widgets/page_container.dart
+++ b/src/packages/flutter-app/lib/widgets/page_container.dart
@@ -3,9 +3,10 @@ import 'package:flutter/material.dart';
 /// Centers page content and caps its width on wide (web/desktop) layouts.
 ///
 /// Place it *inside* the scroll view, around the content column, so the
-/// scrollable region stays full-width while the content is constrained.
-/// Currently used by the home screen; other scrollable screens (trips list,
-/// preferences) can adopt it later.
+/// scrollable region stays full-width (mouse wheel and scrollbar keep working
+/// in the gutters) while the content is constrained. The house width tiers:
+/// 700 (default, reading/list pages), 760 (chat column), 900 (dense pages
+/// like trip detail).
 class PageContainer extends StatelessWidget {
   final Widget child;
   final double maxWidth;

--- a/src/packages/flutter-app/lib/widgets/status_pill.dart
+++ b/src/packages/flutter-app/lib/widgets/status_pill.dart
@@ -1,9 +1,12 @@
 import 'package:flutter/material.dart';
+import '../l10n/l10n.dart';
+import '../theme/app_colors.dart';
 import '../theme/spacing.dart';
 
-/// A filled tonal pill for a trip's status (Draft / Planned). Reads at a glance
-/// and stays colorblind-safe by carrying its label, not just a colored dot.
-/// Shared by the trips list and the trip-detail header.
+/// A filled tonal pill for a trip's status (draft / planned, rendered through
+/// AppLocalizations). Reads at a glance and stays colorblind-safe by carrying
+/// its label, not just a colored dot. Shared by the trips list and the
+/// trip-detail header.
 ///
 /// [StatusPill.custom] renders the same pill chrome with an explicit label and
 /// colors (no leading icon, smaller type) for non-trip states — e.g. the price
@@ -50,17 +53,22 @@ class StatusPill extends StatelessWidget {
       style = theme.textTheme.labelSmall;
     } else {
       final isPlanned = status == 'planned';
-      label = status.isEmpty
-          ? 'Draft'
-          : '${status[0].toUpperCase()}${status.substring(1)}';
+      // Canonical API statuses map to localized copy (the same mapping the
+      // trip-detail status menu uses); anything unexpected falls back to
+      // title-case rather than rendering blank.
+      label = switch (status) {
+        '' || 'draft' => context.l10n.tripStatusDraft,
+        'planned' => context.l10n.tripStatusPlanned,
+        _ => '${status[0].toUpperCase()}${status.substring(1)}',
+      };
 
       // Planned reads as a positive, completed state (green); anything else is
       // a neutral surface tone so it doesn't compete for attention.
       bg = isPlanned
-          ? Colors.green.withValues(alpha: 0.15)
+          ? AppColors.successContainer
           : theme.colorScheme.surfaceContainerHighest;
       fg = isPlanned
-          ? Colors.green.shade800
+          ? AppColors.onSuccessContainer
           : theme.colorScheme.onSurfaceVariant;
       icon = isPlanned ? Icons.check_circle : Icons.edit_note;
       style = theme.textTheme.labelMedium;

--- a/src/packages/flutter-app/test/foundations_polish_test.dart
+++ b/src/packages/flutter-app/test/foundations_polish_test.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:travel_route_planner/widgets/map_day_chips.dart';
+import 'package:travel_route_planner/widgets/status_pill.dart';
+
+import 'support/l10n_test_app.dart';
+
+/// Wave-2 foundations (polish/wave2-foundations): the shared StatusPill and
+/// MapDayChips widgets must resolve their labels through AppLocalizations —
+/// they previously shipped hardcoded English onto the trips list, the
+/// trip-detail header, and all three map surfaces.
+void main() {
+  Widget pill(String status, {Locale? locale}) => localizedTestApp(
+        home: Scaffold(body: StatusPill(status: status)),
+        locale: locale,
+      );
+
+  Widget chips({Locale? locale}) => localizedTestApp(
+        home: Scaffold(
+          body: MapDayChips(
+            dayCount: 2,
+            selected: 1,
+            onSelected: (_) {},
+          ),
+        ),
+        locale: locale,
+      );
+
+  group('StatusPill localization', () {
+    testWidgets('renders English labels under en', (tester) async {
+      await tester.pumpWidget(pill('draft'));
+      expect(find.text('Draft'), findsOneWidget);
+    });
+
+    testWidgets('renders Spanish labels under es', (tester) async {
+      await tester.pumpWidget(pill('draft', locale: const Locale('es')));
+      expect(find.text('Borrador'), findsOneWidget);
+      expect(find.text('Draft'), findsNothing);
+
+      await tester.pumpWidget(pill('planned', locale: const Locale('es')));
+      expect(find.text('Planificado'), findsOneWidget);
+    });
+
+    testWidgets('empty status falls back to draft copy', (tester) async {
+      await tester.pumpWidget(pill('', locale: const Locale('es')));
+      expect(find.text('Borrador'), findsOneWidget);
+    });
+
+    testWidgets('unknown status title-cases instead of rendering blank',
+        (tester) async {
+      await tester.pumpWidget(pill('archived'));
+      expect(find.text('Archived'), findsOneWidget);
+    });
+  });
+
+  group('MapDayChips localization', () {
+    testWidgets('renders English labels under en', (tester) async {
+      await tester.pumpWidget(chips());
+      expect(find.text('All'), findsOneWidget);
+      expect(find.text('Day 1'), findsOneWidget);
+      expect(find.text('Day 2'), findsOneWidget);
+    });
+
+    testWidgets('renders Spanish labels under es', (tester) async {
+      await tester.pumpWidget(chips(locale: const Locale('es')));
+      expect(find.text('Todos'), findsOneWidget);
+      expect(find.text('Día 1'), findsOneWidget);
+      expect(find.text('Day 1'), findsNothing);
+    });
+  });
+}

--- a/src/packages/flutter-app/test/trips_list_live_test.dart
+++ b/src/packages/flutter-app/test/trips_list_live_test.dart
@@ -53,8 +53,7 @@ class _QueuedTripsApiService extends TripsApiService {
   }
 }
 
-String _iso(DateTime d) =>
-    '${d.year.toString().padLeft(4, '0')}-'
+String _iso(DateTime d) => '${d.year.toString().padLeft(4, '0')}-'
     '${d.month.toString().padLeft(2, '0')}-'
     '${d.day.toString().padLeft(2, '0')}';
 
@@ -71,8 +70,7 @@ Trip _trip(String id, String title, {String? start, String? end}) => Trip(
     );
 
 /// Yesterday → tomorrow: today is Day 2 of 3.
-Trip _liveTrip() =>
-    _trip('live', 'Athens Trip', start: _rel(-1), end: _rel(1));
+Trip _liveTrip() => _trip('live', 'Athens Trip', start: _rel(-1), end: _rel(1));
 
 ChatSessionSummary _chat() => ChatSessionSummary(
       chatId: 'c1',
@@ -97,7 +95,8 @@ Future<void> _pumpList(
         resumableChatsProvider.overrideWith((ref) async => chats),
       ],
       child: MaterialApp(
-      localizationsDelegates: testLocalizationsDelegates,home: TripsListScreen()),
+          localizationsDelegates: testLocalizationsDelegates,
+          home: TripsListScreen()),
     ),
   );
 }
@@ -107,11 +106,13 @@ void main() {
     SharedPreferences.setMockInitialValues({});
   });
 
-  testWidgets(
-      'live card renders above the continue section and above My Trips',
+  testWidgets('live card renders above the continue section and above My Trips',
       (WidgetTester tester) async {
     final service = _QueuedTripsApiService([
-      [_trip('future', 'Lisbon Trip', start: _rel(5), end: _rel(8)), _liveTrip()]
+      [
+        _trip('future', 'Lisbon Trip', start: _rel(5), end: _rel(8)),
+        _liveTrip()
+      ]
     ]);
 
     await _pumpList(tester, service, chats: [_chat()]);
@@ -211,5 +212,24 @@ void main() {
     await tester.pumpAndSettle();
     final phoneCard = tester.getSize(find.byType(Card).first);
     expect(phoneCard.width, greaterThan(340)); // full width minus padding
+  });
+
+  testWidgets('short list keeps pull-to-refresh armed (always-scrollable)',
+      (WidgetTester tester) async {
+    final service = _QueuedTripsApiService([
+      [_trip('t1', 'Lisbon Trip', start: _rel(30), end: _rel(33))],
+    ]);
+    await _pumpList(tester, service);
+    await tester.pumpAndSettle();
+
+    // One trip card is far shorter than the viewport; with clamping physics
+    // the drag would be swallowed and onRefresh could never fire.
+    final list = tester.widget<ListView>(find.byType(ListView).first);
+    expect(list.physics, isA<AlwaysScrollableScrollPhysics>());
+
+    await tester.fling(find.byType(ListView).first, const Offset(0, 300), 1000);
+    await tester.pump();
+    expect(find.byType(RefreshProgressIndicator), findsOneWidget);
+    await tester.pumpAndSettle();
   });
 }


### PR DESCRIPTION
- StatusPill + MapDayChips resolve labels through AppLocalizations (they shipped hardcoded English onto the trips list, trip-detail header, and all three map surfaces in Spanish builds; keys already existed)
- AppColors semantic success/warning pairs + AppShadows brandCard/hero tokens (adopted opportunistically by later wave PRs)
- GradientAppBar paints from AppColors.brandGradient (byte-identical)
- ChoiceChipRow spacing tokens + runSpacing for wrapping es labels
- Trips list: AlwaysScrollableScrollPhysics — pull-to-refresh was dead on short lists
- Tests: foundations_polish_test.dart (es locale assertions), trips-list physics/fling regression
- Verified live on the dev stack in es: Borrador pill + Todos/Día chips

Part of UI polish wave 2 — a 10-PR sequence from a 223-finding audit of every screen (mobile + desktop, en + es). Merging strictly in sequence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)