### PR TITLE
polish: admin — functional fixes only (overflow, states, guards, refresh)

### DIFF
--- a/src/packages/flutter-app/lib/screens/admin_metrics_screen.dart
+++ b/src/packages/flutter-app/lib/screens/admin_metrics_screen.dart
@@ -22,8 +22,7 @@ class AdminMetricsScreen extends ConsumerStatefulWidget {
   const AdminMetricsScreen({super.key});
 
   @override
-  ConsumerState<AdminMetricsScreen> createState() =>
-      _AdminMetricsScreenState();
+  ConsumerState<AdminMetricsScreen> createState() => _AdminMetricsScreenState();
 }
 
 class _AdminMetricsScreenState extends ConsumerState<AdminMetricsScreen> {
@@ -113,13 +112,21 @@ class _OverviewPane extends ConsumerWidget {
                 message: '$e',
                 actions: [
                   FilledButton(
-                    onPressed: () =>
-                        ref.invalidate(adminMetricsProvider(days)),
+                    onPressed: () => ref.invalidate(adminMetricsProvider(days)),
                     child: const Text('Retry'),
                   ),
                 ],
               ),
-              data: (m) => _MetricsBody(metrics: m, header: _TotalsSection()),
+              // Pull-to-refresh re-polls both async sources this pane shows,
+              // matching the Activity/Users panes' affordance.
+              data: (m) => RefreshIndicator(
+                onRefresh: () async {
+                  ref.invalidate(adminTotalsProvider);
+                  ref.invalidate(adminMetricsProvider(days));
+                  await ref.read(adminMetricsProvider(days).future);
+                },
+                child: _MetricsBody(metrics: m, header: _TotalsSection()),
+              ),
             ),
           ),
         ],
@@ -166,8 +173,7 @@ class _TotalsSection extends ConsumerWidget {
             _Stat('Users', '${t.users}',
                 caption:
                     '${t.verifiedUsers} verified · ${t.onboardedUsers} onboarded'),
-            _Stat('Trips', '${t.trips}',
-                caption: '${t.tripLineages} lineages'),
+            _Stat('Trips', '${t.trips}', caption: '${t.tripLineages} lineages'),
             _Stat('Itinerary items', '${t.itineraryItems}'),
             _Stat('Booking todos', '${t.bookingTodos}'),
             _Stat('Active price alerts', '${t.activePriceAlerts}'),
@@ -226,15 +232,23 @@ class _TrendsPane extends ConsumerWidget {
                   ),
                 ],
               ),
-              data: (t) => ListView(
-                padding: const EdgeInsets.all(AppSpacing.lg),
-                children: [
-                  for (final (key, title) in _series) ...[
-                    DailyCountChart(title: title, data: t.denseSeries(key)),
+              // Pull-to-refresh, matching the Activity/Users panes.
+              data: (t) => RefreshIndicator(
+                onRefresh: () async {
+                  ref.invalidate(adminTimeseriesProvider(days));
+                  await ref.read(adminTimeseriesProvider(days).future);
+                },
+                child: ListView(
+                  physics: const AlwaysScrollableScrollPhysics(),
+                  padding: const EdgeInsets.all(AppSpacing.lg),
+                  children: [
+                    for (final (key, title) in _series) ...[
+                      DailyCountChart(title: title, data: t.denseSeries(key)),
+                      const SizedBox(height: AppSpacing.xl),
+                    ],
                     const SizedBox(height: AppSpacing.xl),
                   ],
-                  const SizedBox(height: AppSpacing.xl),
-                ],
+                ),
               ),
             ),
           ),
@@ -266,6 +280,9 @@ class _MetricsBody extends StatelessWidget {
   Widget build(BuildContext context) {
     final m = metrics;
     return ListView(
+      // Always scrollable so Overview's pull-to-refresh works even when the
+      // tiles fit the viewport.
+      physics: const AlwaysScrollableScrollPhysics(),
       padding: const EdgeInsets.all(AppSpacing.lg),
       children: [
         if (header != null) header!,
@@ -331,8 +348,8 @@ class _MetricsBody extends StatelessWidget {
           _Stat('Would hit plan cap', '${m.freeCapWouldHits['plan_runs'] ?? 0}',
               caption:
                   '${m.freeCapUsersAffected['plan_runs'] ?? 0} users affected'),
-          _Stat(
-              'Would hit trip cap', '${m.freeCapWouldHits['active_trips'] ?? 0}',
+          _Stat('Would hit trip cap',
+              '${m.freeCapWouldHits['active_trips'] ?? 0}',
               caption:
                   '${m.freeCapUsersAffected['active_trips'] ?? 0} users affected'),
           _Stat('Tokens in', _tokens(m.planInputTokens),
@@ -700,8 +717,9 @@ class _UsersPaneState extends ConsumerState<_UsersPane>
   Future<void> _loadMore(int offset) async {
     setState(() => _loadingMore = true);
     try {
-      final page =
-          await ref.read(adminMetricsApiServiceProvider).fetchUsers(offset: offset);
+      final page = await ref
+          .read(adminMetricsApiServiceProvider)
+          .fetchUsers(offset: offset);
       if (!mounted) return;
       setState(() => _more.addAll(page.users));
     } catch (_) {
@@ -815,7 +833,10 @@ class _UserTile extends StatelessWidget {
         ),
       ),
       childrenPadding: const EdgeInsets.fromLTRB(
-        AppSpacing.lg, 0, AppSpacing.lg, AppSpacing.lg,
+        AppSpacing.lg,
+        0,
+        AppSpacing.lg,
+        AppSpacing.lg,
       ),
       expandedCrossAxisAlignment: CrossAxisAlignment.start,
       children: [

--- a/src/packages/flutter-app/lib/screens/local_admin_screen.dart
+++ b/src/packages/flutter-app/lib/screens/local_admin_screen.dart
@@ -77,6 +77,11 @@ class _IngestPaneState extends ConsumerState<_IngestPane> {
   String? _result;
   String? _error;
 
+  /// Separate from [_error] (ingest/validation failures shown under the
+  /// submit button): a sources-load failure renders inline where the source
+  /// dropdown would be, so it is visible on phones without scrolling.
+  String? _sourcesError;
+
   @override
   void initState() {
     super.initState();
@@ -91,17 +96,21 @@ class _IngestPaneState extends ConsumerState<_IngestPane> {
   }
 
   Future<void> _loadSources() async {
-    setState(() => _loadingSources = true);
+    setState(() {
+      _loadingSources = true;
+      _sourcesError = null;
+    });
     try {
       final s = await ref.read(localApiServiceProvider).listSources();
+      if (!mounted) return;
       setState(() {
         _sources = s;
         _sourceId ??= s.isNotEmpty ? s.first['id'] as String : null;
       });
     } catch (e) {
-      setState(() => _error = '$e');
+      if (mounted) setState(() => _sourcesError = '$e');
     } finally {
-      setState(() => _loadingSources = false);
+      if (mounted) setState(() => _loadingSources = false);
     }
   }
 
@@ -156,6 +165,7 @@ class _IngestPaneState extends ConsumerState<_IngestPane> {
           'photo_url': photo.text.trim(),
           'consent_ref': consent.text.trim(),
         });
+        if (!mounted) return;
         setState(() => _sourceId = row['id'] as String);
         await _loadSources();
       } catch (e) {
@@ -186,6 +196,7 @@ class _IngestPaneState extends ConsumerState<_IngestPane> {
       final recs = (res['recommendations'] as List?)?.length ?? 0;
       final verified = res['verified'] ?? 0;
       final unverified = res['unverified'] ?? 0;
+      if (!mounted) return;
       setState(() {
         _result =
             'Drafted $recs recommendation(s): $verified verified, $unverified need coordinates.'
@@ -193,11 +204,11 @@ class _IngestPaneState extends ConsumerState<_IngestPane> {
         _raw.clear();
       });
     } on ApiException catch (e) {
-      setState(() => _error = e.message);
+      if (mounted) setState(() => _error = e.message);
     } catch (e) {
-      setState(() => _error = '$e');
+      if (mounted) setState(() => _error = '$e');
     } finally {
-      setState(() => _busy = false);
+      if (mounted) setState(() => _busy = false);
     }
   }
 
@@ -220,12 +231,34 @@ class _IngestPaneState extends ConsumerState<_IngestPane> {
         const SizedBox(height: AppSpacing.lg),
         if (_loadingSources)
           const LinearProgressIndicator()
+        else if (_sourcesError != null)
+          // Inline where the dropdown would be — a load failure used to hide
+          // at the bottom of this ListView, off-screen on phones.
+          Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              _Banner(
+                icon: Icons.error_outline,
+                color: theme.colorScheme.error,
+                text: 'Could not load sources: $_sourcesError',
+              ),
+              const SizedBox(height: AppSpacing.sm),
+              OutlinedButton.icon(
+                onPressed: _loadSources,
+                icon: const Icon(Icons.refresh, size: 18),
+                label: const Text('Retry'),
+              ),
+            ],
+          )
         else
           Row(
             children: [
               Expanded(
                 child: DropdownButtonFormField<String>(
                   initialValue: _sourceId,
+                  // Constrain to the row: an unexpanded dropdown sizes to its
+                  // widest item, so a long source name overflows narrow phones.
+                  isExpanded: true,
                   decoration: const InputDecoration(
                       labelText: 'Local source', border: OutlineInputBorder()),
                   items: _sources
@@ -259,6 +292,7 @@ class _IngestPaneState extends ConsumerState<_IngestPane> {
             Expanded(
               child: DropdownButtonFormField<String>(
                 initialValue: _kind,
+                isExpanded: true,
                 decoration: const InputDecoration(
                     labelText: 'Kind', border: OutlineInputBorder()),
                 items: const [
@@ -296,7 +330,8 @@ class _IngestPaneState extends ConsumerState<_IngestPane> {
         ),
         if (_result != null) ...[
           const SizedBox(height: AppSpacing.md),
-          _Banner(icon: Icons.check_circle, color: Colors.green, text: _result!),
+          _Banner(
+              icon: Icons.check_circle, color: Colors.green, text: _result!),
         ],
         if (_error != null) ...[
           const SizedBox(height: AppSpacing.md),
@@ -336,11 +371,11 @@ class _ReviewPaneState extends ConsumerState<_ReviewPane> {
     });
     try {
       final d = await ref.read(localApiServiceProvider).listByStatus('draft');
-      setState(() => _drafts = d);
+      if (mounted) setState(() => _drafts = d);
     } catch (e) {
-      setState(() => _error = '$e');
+      if (mounted) setState(() => _error = '$e');
     } finally {
-      setState(() => _loading = false);
+      if (mounted) setState(() => _loading = false);
     }
   }
 
@@ -359,25 +394,32 @@ class _ReviewPaneState extends ConsumerState<_ReviewPane> {
     final theme = Theme.of(context);
     if (_loading) return const Center(child: CircularProgressIndicator());
     if (_error != null) {
-      return EmptyState(
-        icon: Icons.error_outline,
-        title: 'Could not load drafts',
-        message: _error!,
-        actions: [
-          FilledButton(onPressed: _load, child: const Text('Retry')),
-        ],
+      return _RefreshableState(
+        onRefresh: _load,
+        child: EmptyState(
+          icon: Icons.error_outline,
+          title: 'Could not load drafts',
+          message: _error!,
+          actions: [
+            FilledButton(onPressed: _load, child: const Text('Retry')),
+          ],
+        ),
       );
     }
     if (_drafts.isEmpty) {
-      return const EmptyState(
-        icon: Icons.inbox,
-        title: 'No drafts to review',
-        message: 'Ingest raw material to generate draft recommendations.',
+      return _RefreshableState(
+        onRefresh: _load,
+        child: const EmptyState(
+          icon: Icons.inbox,
+          title: 'No drafts to review',
+          message: 'Ingest raw material to generate draft recommendations.',
+        ),
       );
     }
     return RefreshIndicator(
       onRefresh: _load,
       child: ListView.builder(
+        physics: const AlwaysScrollableScrollPhysics(),
         padding: const EdgeInsets.all(AppSpacing.md),
         itemCount: _drafts.length,
         itemBuilder: (_, i) {
@@ -423,13 +465,19 @@ class _ReviewPaneState extends ConsumerState<_ReviewPane> {
                   ],
                   const SizedBox(height: AppSpacing.sm),
                   Row(
-                    mainAxisAlignment: MainAxisAlignment.end,
                     children: [
+                      // Flexible so the hint ellipsizes instead of pushing
+                      // the Publish button off a narrow card.
                       if (!hasCoords)
-                        Text('Needs coordinates to publish',
-                            style: theme.textTheme.labelSmall
-                                ?.copyWith(color: theme.colorScheme.error)),
-                      const Spacer(),
+                        Expanded(
+                          child: Text('Needs coordinates to publish',
+                              overflow: TextOverflow.ellipsis,
+                              style: theme.textTheme.labelSmall
+                                  ?.copyWith(color: theme.colorScheme.error)),
+                        )
+                      else
+                        const Spacer(),
+                      const SizedBox(width: AppSpacing.sm),
                       FilledButton.tonalIcon(
                         onPressed: hasCoords
                             ? () => _publish(d['id'] as String)
@@ -475,11 +523,11 @@ class _CoveragePaneState extends ConsumerState<_CoveragePane> {
     });
     try {
       final r = await ref.read(localApiServiceProvider).coverage();
-      setState(() => _rows = r);
+      if (mounted) setState(() => _rows = r);
     } catch (e) {
-      setState(() => _error = '$e');
+      if (mounted) setState(() => _error = '$e');
     } finally {
-      setState(() => _loading = false);
+      if (mounted) setState(() => _loading = false);
     }
   }
 
@@ -487,38 +535,54 @@ class _CoveragePaneState extends ConsumerState<_CoveragePane> {
   Widget build(BuildContext context) {
     if (_loading) return const Center(child: CircularProgressIndicator());
     if (_error != null) {
-      return EmptyState(
-        icon: Icons.error_outline,
-        title: 'Could not load coverage',
-        message: _error!,
-        actions: [FilledButton(onPressed: _load, child: const Text('Retry'))],
+      return _RefreshableState(
+        onRefresh: _load,
+        child: EmptyState(
+          icon: Icons.error_outline,
+          title: 'Could not load coverage',
+          message: _error!,
+          actions: [FilledButton(onPressed: _load, child: const Text('Retry'))],
+        ),
       );
     }
     if (_rows.isEmpty) {
-      return const EmptyState(
-        icon: Icons.map_outlined,
-        title: 'No coverage yet',
-        message: 'Publish recommendations to build city coverage.',
+      return _RefreshableState(
+        onRefresh: _load,
+        child: const EmptyState(
+          icon: Icons.map_outlined,
+          title: 'No coverage yet',
+          message: 'Publish recommendations to build city coverage.',
+        ),
       );
     }
     return RefreshIndicator(
       onRefresh: _load,
       child: ListView(
+        physics: const AlwaysScrollableScrollPhysics(),
         padding: const EdgeInsets.all(AppSpacing.md),
         children: [
-          DataTable(
-            columns: const [
-              DataColumn(label: Text('City')),
-              DataColumn(label: Text('Published'), numeric: true),
-              DataColumn(label: Text('Draft'), numeric: true),
-            ],
-            rows: _rows
-                .map((r) => DataRow(cells: [
-                      DataCell(Text(r['city'] as String? ?? '—')),
-                      DataCell(Text('${r['published'] ?? 0}')),
-                      DataCell(Text('${r['draft'] ?? 0}')),
-                    ]))
-                .toList(),
+          // Horizontally scrollable so long city names never overflow narrow
+          // widths — the same pattern as health_pane.dart's _RouteTable.
+          SingleChildScrollView(
+            scrollDirection: Axis.horizontal,
+            child: DataTable(
+              columnSpacing: AppSpacing.xl,
+              headingRowHeight: 36,
+              dataRowMinHeight: 36,
+              dataRowMaxHeight: 44,
+              columns: const [
+                DataColumn(label: Text('City')),
+                DataColumn(label: Text('Published'), numeric: true),
+                DataColumn(label: Text('Draft'), numeric: true),
+              ],
+              rows: _rows
+                  .map((r) => DataRow(cells: [
+                        DataCell(Text(r['city'] as String? ?? '—')),
+                        DataCell(Text('${r['published'] ?? 0}')),
+                        DataCell(Text('${r['draft'] ?? 0}')),
+                      ]))
+                  .toList(),
+            ),
           ),
         ],
       ),
@@ -527,6 +591,30 @@ class _CoveragePaneState extends ConsumerState<_CoveragePane> {
 }
 
 // --- shared ------------------------------------------------------------------
+
+/// Wraps a non-list state (error / empty) in a viewport-filling scrollable
+/// inside a RefreshIndicator, so pull-to-refresh still works when there are
+/// no rows to scroll — the exact case an admin hits right after ingesting.
+class _RefreshableState extends StatelessWidget {
+  final Future<void> Function() onRefresh;
+  final Widget child;
+  const _RefreshableState({required this.onRefresh, required this.child});
+
+  @override
+  Widget build(BuildContext context) {
+    return RefreshIndicator(
+      onRefresh: onRefresh,
+      child: LayoutBuilder(
+        builder: (context, constraints) => ListView(
+          physics: const AlwaysScrollableScrollPhysics(),
+          children: [
+            SizedBox(height: constraints.maxHeight, child: child),
+          ],
+        ),
+      ),
+    );
+  }
+}
 
 class _Banner extends StatelessWidget {
   final IconData icon;

--- a/src/packages/flutter-app/test/admin_metrics_screen_test.dart
+++ b/src/packages/flutter-app/test/admin_metrics_screen_test.dart
@@ -234,8 +234,8 @@ void main() {
     await tester.pumpWidget(
       ProviderScope(
         overrides: [
-          adminMetricsProvider(30).overrideWith((ref) async =>
-              const AdminMetrics(days: 30)),
+          adminMetricsProvider(30)
+              .overrideWith((ref) async => const AdminMetrics(days: 30)),
           adminTotalsProvider.overrideWith((ref) async => _totals),
           // The pane inherits Overview's 30-day default window.
           adminTimeseriesProvider(30).overrideWith((ref) async => ts),
@@ -262,6 +262,37 @@ void main() {
     }
     // Signups window total = 2 + 5.
     expect(find.text('7'), findsWidgets);
+  });
+
+  testWidgets('Overview and Trends panes expose pull-to-refresh',
+      (tester) async {
+    tester.view.physicalSize = const Size(800, 1600);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          adminMetricsProvider(30)
+              .overrideWith((ref) async => const AdminMetrics(days: 30)),
+          adminTotalsProvider.overrideWith((ref) async => _totals),
+          adminTimeseriesProvider(30).overrideWith((ref) async =>
+              AdminTimeseries(
+                  days: 30,
+                  startDay: DateTime.utc(2026, 7, 1),
+                  series: const {})),
+        ],
+        child: const MaterialApp(home: AdminMetricsScreen()),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // Overview (the default tab) is refreshable like Activity/Users.
+    expect(find.byType(RefreshIndicator), findsOneWidget);
+
+    await tester.tap(find.text('Trends'));
+    await tester.pumpAndSettle();
+    expect(find.byType(RefreshIndicator), findsOneWidget);
   });
 
   testWidgets('Activity tab lists events with anonymous handling and paging',
@@ -292,8 +323,8 @@ void main() {
     await tester.pumpWidget(
       ProviderScope(
         overrides: [
-          adminMetricsProvider(30).overrideWith((ref) async =>
-              const AdminMetrics(days: 30)),
+          adminMetricsProvider(30)
+              .overrideWith((ref) async => const AdminMetrics(days: 30)),
           adminTotalsProvider.overrideWith((ref) async => _totals),
           adminActivityProvider.overrideWith((ref) async => feed),
         ],
@@ -351,8 +382,8 @@ void main() {
     await tester.pumpWidget(
       ProviderScope(
         overrides: [
-          adminMetricsProvider(30).overrideWith((ref) async =>
-              const AdminMetrics(days: 30)),
+          adminMetricsProvider(30)
+              .overrideWith((ref) async => const AdminMetrics(days: 30)),
           adminTotalsProvider.overrideWith((ref) async => _totals),
           adminUsersProvider(0).overrideWith((ref) async => list),
         ],
@@ -362,8 +393,8 @@ void main() {
     await tester.pumpAndSettle();
 
     // 'Users' is also a totals tile label — target the tab specifically.
-    await tester.tap(find.descendant(
-        of: find.byType(TabBar), matching: find.text('Users')));
+    await tester.tap(
+        find.descendant(of: find.byType(TabBar), matching: find.text('Users')));
     await tester.pumpAndSettle();
 
     expect(find.text('2 users'), findsOneWidget);

--- a/src/packages/flutter-app/test/local_admin_screen_test.dart
+++ b/src/packages/flutter-app/test/local_admin_screen_test.dart
@@ -1,0 +1,201 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:travel_route_planner/models/local_guide.dart';
+import 'package:travel_route_planner/models/local_recommendation.dart';
+import 'package:travel_route_planner/providers/local_provider.dart';
+import 'package:travel_route_planner/screens/local_admin_screen.dart';
+import 'package:travel_route_planner/services/api_client.dart';
+import 'package:travel_route_planner/services/local_api_service.dart';
+
+/// Serves canned admin payloads instead of hitting the network. [failSources]
+/// is mutable so a test can fail the first sources load, then flip it and
+/// exercise the retry affordance.
+class _FakeLocalApi implements LocalApiService {
+  final List<Map<String, dynamic>> sources;
+  final List<Map<String, dynamic>> drafts;
+  final List<Map<String, dynamic>> coverageRows;
+  bool failSources;
+
+  _FakeLocalApi({
+    this.sources = const [],
+    this.drafts = const [],
+    this.coverageRows = const [],
+    this.failSources = false,
+  });
+
+  @override
+  ApiClient get apiClient => throw UnimplementedError();
+
+  @override
+  Future<List<Map<String, dynamic>>> listSources() async {
+    if (failSources) throw Exception('boom');
+    return sources;
+  }
+
+  @override
+  Future<List<Map<String, dynamic>>> listByStatus(String status) async =>
+      drafts;
+
+  @override
+  Future<List<Map<String, dynamic>>> coverage() async => coverageRows;
+
+  @override
+  Future<Map<String, dynamic>> createSource(Map<String, dynamic> fields) =>
+      throw UnimplementedError();
+
+  @override
+  Future<Map<String, dynamic>> ingest({
+    required String sourceId,
+    required String city,
+    required String kind,
+    required String rawText,
+  }) =>
+      throw UnimplementedError();
+
+  @override
+  Future<void> publish(String id) async {}
+
+  @override
+  Future<List<LocalRecommendation>> searchRecommendations(
+    String city, {
+    String? category,
+  }) async =>
+      [];
+
+  @override
+  Future<List<LocalGuide>> guides([String? city]) async => [];
+
+  @override
+  Future<({LocalGuide guide, List<LocalRecommendation> recommendations})>
+      guideById(String id) => throw UnimplementedError();
+}
+
+Future<void> _pump(
+  WidgetTester tester,
+  _FakeLocalApi api, {
+  Size surface = const Size(360, 690),
+}) async {
+  await tester.binding.setSurfaceSize(surface);
+  addTearDown(() => tester.binding.setSurfaceSize(null));
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [localApiServiceProvider.overrideWithValue(api)],
+      child: const MaterialApp(home: LocalAdminScreen()),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  testWidgets(
+      'overflow floor: coverage table with long city names at 360px '
+      'renders without errors', (tester) async {
+    final api = _FakeLocalApi(
+      sources: [
+        {'id': 's1', 'name': 'Yiannis the fisherman'},
+      ],
+      coverageRows: [
+        {
+          'city': 'Santa Cruz de Tenerife y su área metropolitana entera',
+          'published': 12,
+          'draft': 345,
+        },
+        {
+          'city': 'Thessaloniki and the greater Chalkidiki peninsula',
+          'published': 3,
+          'draft': 1,
+        },
+      ],
+    );
+    await _pump(tester, api);
+
+    await tester.tap(find.text('Coverage'));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(DataTable), findsOneWidget);
+    // The table sits in a horizontal scroller, so long cities scroll instead
+    // of striping the pane with a RenderFlex overflow.
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets(
+      'overflow floor: review card missing coordinates at 320px '
+      'keeps the hint and Publish button without errors', (tester) async {
+    final api = _FakeLocalApi(
+      sources: [
+        {'id': 's1', 'name': 'Yiannis'},
+      ],
+      drafts: [
+        {
+          'id': 'd1',
+          'name': 'A taverna with an extremely long name that must ellipsize',
+          'city': 'Chania',
+          'neighborhood': 'Old Venetian Harbour',
+          'category': 'restaurant',
+          'source_name': 'Yiannis the fisherman',
+          'tip': 'Go at sunset and ask for the catch of the day.',
+          'place_verified': false,
+          // No latitude/longitude → the "needs coordinates" hint renders.
+        },
+      ],
+    );
+    await _pump(tester, api, surface: const Size(320, 690));
+
+    await tester.tap(find.text('Review'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Needs coordinates to publish'), findsOneWidget);
+    expect(find.text('Publish'), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('empty review queue still supports pull-to-refresh',
+      (tester) async {
+    final api = _FakeLocalApi(
+      sources: [
+        {'id': 's1', 'name': 'Yiannis'},
+      ],
+    );
+    await _pump(tester, api);
+
+    await tester.tap(find.text('Review'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('No drafts to review'), findsOneWidget);
+    expect(find.byType(RefreshIndicator), findsOneWidget);
+
+    // The pull gesture works from the empty state (the branch used to sit
+    // outside any scrollable, so pull-to-refresh was dead exactly here).
+    await tester.fling(
+        find.text('No drafts to review'), const Offset(0, 300), 1000);
+    await tester.pumpAndSettle();
+    expect(find.text('No drafts to review'), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('sources load failure surfaces a visible inline retry',
+      (tester) async {
+    final api = _FakeLocalApi(
+      sources: [
+        {'id': 's1', 'name': 'Yiannis'},
+      ],
+      failSources: true,
+    );
+    await _pump(tester, api);
+
+    // The failure renders where the dropdown would be — top of the form,
+    // not buried at the bottom of the ListView.
+    expect(find.textContaining('Could not load sources'), findsOneWidget);
+    expect(find.text('Retry'), findsOneWidget);
+    expect(find.text('Local source'), findsNothing);
+
+    api.failSources = false;
+    await tester.tap(find.text('Retry'));
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('Could not load sources'), findsNothing);
+    expect(find.text('Local source'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
- Coverage DataTable scrolls horizontally (health_pane pattern); pull-to-refresh works from empty/error branches; mounted guards on all post-await setState loaders; Review action row overflow fixed; sources-load failure surfaces inline with Retry; isExpanded dropdowns
- Admin metrics: Overview + Trends get RefreshIndicator parity
- Deliberately no cosmetics/i18n/width-caps (admin is functional-fixes-only per scope decision)
- Tests: local_admin_screen_test.dart (4) + 2 metrics refresh tests

Part of UI polish wave 2 — a 10-PR sequence from a 223-finding audit of every screen (mobile + desktop, en + es). Merging strictly in sequence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)