### PR TITLE
polish: map surfaces — touch targets, SafeArea, chip ergonomics

### DIFF
--- a/src/packages/flutter-app/lib/screens/trip_map_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_map_screen.dart
@@ -4,6 +4,7 @@ import '../l10n/l10n.dart';
 import '../models/accommodation.dart';
 import '../models/itinerary_item.dart';
 import '../utils/snack.dart';
+import '../widgets/app_map.dart';
 import '../widgets/gradient_app_bar.dart';
 import '../widgets/map_day_chips.dart';
 import '../widgets/trip_map.dart';
@@ -68,59 +69,84 @@ class _TripMapScreenState extends State<TripMapScreen> {
     final items = widget.itemsForDay(_day);
     final onAddPlace = widget.onAddPlace;
     return Scaffold(
-      appBar: GradientAppBar(title: Text(widget.title)),
-      body: Stack(
-        children: [
-          Positioned.fill(
-            child: TripMap(
-              items: items,
-              accommodations: widget.staysForDay(_day),
-              selectedPosition: _selectedPosition,
-              segmentLabels: widget.segmentLabels,
-              fitSignature: _day,
-              // Keep fitted markers clear of the chip row overlaid below.
-              topOverlayInset:
-                  widget.dayCount > 0 ? MapDayChips.mapTopInset : 0,
-              emptyLabel: _day == null
-                  ? l10n.tripNoMappedPlaces
-                  : l10n.tripNoPlacesOnDay(_day!),
-              emptyMessage:
-                  onAddPlace == null ? null : l10n.tripAddPlaceMapHint,
-              emptyAction: onAddPlace == null
-                  ? null
-                  : FilledButton.tonalIcon(
-                      onPressed: () => onAddPlace(_day),
-                      icon: const Icon(Icons.add, size: 18),
-                      label: Text(l10n.tripAddPlace),
-                    ),
-              onPinTap: (pos) {
-                setState(() => _selectedPosition = pos);
-                for (final it in items) {
-                  if (it.position == pos) {
-                    showSnack(context, it.name);
-                    break;
-                  }
-                }
-              },
+      // The strip the bottom SafeArea leaves below the map reads as part of
+      // the space-dark map canvas instead of a bare scaffold gap.
+      backgroundColor: appMapBackground,
+      appBar: GradientAppBar(
+        // Multi-city titles ("Barcelona, Madrid & 3 more") must ellipsize —
+        // the fullscreenDialog close button already eats leading width.
+        title: Text(widget.title, maxLines: 1, overflow: TextOverflow.ellipsis),
+        actions: [
+          // Persistent add affordance: the on-map CTA only exists in the
+          // empty state, so once a day has a single pin the full-screen map
+          // would otherwise force a round-trip back to trip detail to add
+          // the next place. Null onAddPlace (offline / read-only) hides it.
+          if (onAddPlace != null)
+            IconButton(
+              tooltip: l10n.tripAddPlace,
+              onPressed: () => onAddPlace(_day),
+              icon: const Icon(Icons.add_location_alt_outlined),
             ),
-          ),
-          // Above the map's gesture layer, so chip taps and row scrolls never
-          // pan the map.
-          Positioned(
-            top: 8,
-            left: 8,
-            right: 8,
-            child: MapDayChips(
-              dayCount: widget.dayCount,
-              selected: _day,
-              mappedDays: widget.mappedDays,
-              onSelected: (d) {
-                setState(() => _day = d);
-                widget.onDaySelected(d);
-              },
-            ),
-          ),
         ],
+      ),
+      // Root-navigator fullscreenDialog: without a bottom SafeArea the
+      // zoom/reset column and the attribution button sit under the iOS home
+      // indicator. Top stays with the app bar.
+      body: SafeArea(
+        top: false,
+        child: Stack(
+          children: [
+            Positioned.fill(
+              child: TripMap(
+                items: items,
+                accommodations: widget.staysForDay(_day),
+                selectedPosition: _selectedPosition,
+                segmentLabels: widget.segmentLabels,
+                fitSignature: _day,
+                // Keep fitted markers clear of the chip row overlaid below.
+                topOverlayInset:
+                    widget.dayCount > 0 ? MapDayChips.mapTopInset : 0,
+                emptyLabel: _day == null
+                    ? l10n.tripNoMappedPlaces
+                    : l10n.tripNoPlacesOnDay(_day!),
+                emptyMessage:
+                    onAddPlace == null ? null : l10n.tripAddPlaceMapHint,
+                emptyAction: onAddPlace == null
+                    ? null
+                    : FilledButton.tonalIcon(
+                        onPressed: () => onAddPlace(_day),
+                        icon: const Icon(Icons.add, size: 18),
+                        label: Text(l10n.tripAddPlace),
+                      ),
+                onPinTap: (pos) {
+                  setState(() => _selectedPosition = pos);
+                  for (final it in items) {
+                    if (it.position == pos) {
+                      showSnack(context, it.name);
+                      break;
+                    }
+                  }
+                },
+              ),
+            ),
+            // Above the map's gesture layer, so chip taps and row scrolls never
+            // pan the map.
+            Positioned(
+              top: 8,
+              left: 8,
+              right: 8,
+              child: MapDayChips(
+                dayCount: widget.dayCount,
+                selected: _day,
+                mappedDays: widget.mappedDays,
+                onSelected: (d) {
+                  setState(() => _day = d);
+                  widget.onDaySelected(d);
+                },
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/src/packages/flutter-app/lib/theme/app_colors.dart
+++ b/src/packages/flutter-app/lib/theme/app_colors.dart
@@ -30,6 +30,12 @@ abstract final class AppColors {
         ],
       );
 
+  /// Translucent dark scrim behind text and controls overlaid on satellite
+  /// imagery — the map day chips, TripMap's segment labels, and the map
+  /// control buttons all share this one value so the over-map family can't
+  /// drift apart again.
+  static final Color mapScrim = Colors.black.withValues(alpha: 0.6);
+
   // Semantic status pair for positive/complete states (booked checkmarks,
   // Planned pills, published counts) — the exact green pair screens were
   // re-declaring inline before the polish wave.

--- a/src/packages/flutter-app/lib/widgets/app_map.dart
+++ b/src/packages/flutter-app/lib/widgets/app_map.dart
@@ -3,6 +3,7 @@ import 'package:flutter_map/flutter_map.dart';
 import 'package:latlong2/latlong.dart';
 
 import '../l10n/l10n.dart';
+import '../theme/app_colors.dart';
 
 /// Space-dark canvas behind the tiles: unloaded/failed satellite tiles read as
 /// "not lit yet" instead of a broken grey hole. Pass as
@@ -148,9 +149,16 @@ Widget appMapAttribution() {
   );
 }
 
-/// A small circular control overlaid on the map (zoom in/out, reset). Dark
-/// and translucent so it reads as a frosted chip over satellite imagery.
+/// A small circular control overlaid on the map (zoom in/out, reset, expand).
+/// Dark and translucent so it reads as a frosted chip over satellite imagery.
+///
+/// The painted circle stays [_visualSize]; a transparent halo pads the hit
+/// box to [_hitTarget] (the 44px mobile touch minimum — every placement of
+/// these controls is touch-first).
 class MapControlButton extends StatelessWidget {
+  static const double _hitTarget = 44;
+  static const double _visualSize = 36;
+
   final IconData icon;
   final String? tooltip;
   final VoidCallback onTap;
@@ -164,16 +172,29 @@ class MapControlButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final button = Material(
-      color: Colors.black.withValues(alpha: 0.55),
-      shape: const CircleBorder(side: BorderSide(color: Colors.white24)),
-      child: InkWell(
-        customBorder: const CircleBorder(),
-        onTap: onTap,
-        child: SizedBox(
-          width: 36,
-          height: 36,
-          child: Icon(icon, size: 20, color: Colors.white),
+    final button = SizedBox(
+      width: _hitTarget,
+      height: _hitTarget,
+      child: Material(
+        color: Colors.transparent,
+        child: InkWell(
+          customBorder: const CircleBorder(),
+          onTap: onTap,
+          child: Center(
+            // Ink (not Container) so the tap ripple still paints over the
+            // frosted chip instead of underneath it.
+            child: Ink(
+              width: _visualSize,
+              height: _visualSize,
+              decoration: ShapeDecoration(
+                color: AppColors.mapScrim,
+                shape: const CircleBorder(
+                  side: BorderSide(color: Colors.white24),
+                ),
+              ),
+              child: Icon(icon, size: 20, color: Colors.white),
+            ),
+          ),
         ),
       ),
     );

--- a/src/packages/flutter-app/lib/widgets/map_day_chips.dart
+++ b/src/packages/flutter-app/lib/widgets/map_day_chips.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 
 import '../l10n/l10n.dart';
+import '../theme/app_colors.dart';
+import '../theme/spacing.dart';
 
 /// Day-filter chips overlaid on a trip map: `All · Day 1 · … · Day N`
 /// (specs/today-mode). [selected] is the 1-based day, null meaning All;
@@ -12,13 +14,18 @@ import '../l10n/l10n.dart';
 /// no "Unscheduled" chip.
 ///
 /// The chips sit over satellite imagery, so they use the same translucent
-/// dark scrim treatment as the map's segment labels and control buttons.
-class MapDayChips extends StatelessWidget {
+/// dark scrim treatment ([AppColors.mapScrim]) as the map's segment labels
+/// and control buttons. The strip keeps the selected chip in view: the
+/// full-screen map can open with a late day preselected (inherited from the
+/// inline card), which would otherwise rest off-screen with no cue that the
+/// row scrolls.
+class MapDayChips extends StatefulWidget {
   /// Vertical band (px) the chip row occupies over the map's top edge when
-  /// overlaid at `top: 8`, including breathing room. Callers pass this as
+  /// overlaid at `top: 8`, including breathing room: 8 offset + the 48px
+  /// chip hit box (padded tap target) + 8 clearance. Callers pass this as
   /// TripMap's `topOverlayInset` so camera fitting keeps markers out from
   /// under the chips.
-  static const double mapTopInset = 48;
+  static const double mapTopInset = 64;
 
   final int dayCount;
   final int? selected;
@@ -38,61 +45,124 @@ class MapDayChips extends StatelessWidget {
     this.mappedDays,
   });
 
+  @override
+  State<MapDayChips> createState() => _MapDayChipsState();
+}
+
+class _MapDayChipsState extends State<MapDayChips> {
+  final ScrollController _controller = ScrollController();
+
+  /// Rides whichever chip is currently selected so [_revealSelected] can
+  /// measure it (SingleChildScrollView lays out off-viewport children, so the
+  /// context exists even when the chip is scrolled out of sight).
+  final GlobalKey _selectedKey = GlobalKey();
+
+  @override
+  void initState() {
+    super.initState();
+    // First layout: land the strip on the selected chip.
+    WidgetsBinding.instance.addPostFrameCallback((_) => _revealSelected());
+  }
+
+  @override
+  void didUpdateWidget(covariant MapDayChips oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.selected != oldWidget.selected) {
+      WidgetsBinding.instance.addPostFrameCallback(
+        (_) => _revealSelected(animate: true),
+      );
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  /// Centers the selected chip in the strip (clamped to its extent). Goes
+  /// through this strip's own [ScrollPosition] — never `Scrollable.ensureVisible`,
+  /// which walks every ancestor scrollable and would also yank the page
+  /// scroll hosting the inline map card on trip detail.
+  void _revealSelected({bool animate = false}) {
+    if (!mounted || !_controller.hasClients) return;
+    final target = _selectedKey.currentContext?.findRenderObject();
+    if (target == null) return;
+    _controller.position.ensureVisible(
+      target,
+      alignment: 0.5,
+      duration: animate ? const Duration(milliseconds: 200) : Duration.zero,
+      curve: Curves.easeOutCubic,
+    );
+  }
+
   Widget _chip({
     required String label,
     required int? value,
     bool muted = false,
   }) {
-    final isSelected = selected == value;
+    final isSelected = widget.selected == value;
     // A selected chip keeps the full treatment even when its day is empty —
     // the ring is what says "you are here"; the map's empty state says empty.
     final dim = muted && !isSelected;
-    return ChoiceChip(
+    final chip = ChoiceChip(
       label: Text(label),
       selected: isSelected,
-      onSelected: (_) => onSelected(value),
-      // Compact: the row floats over the map and must not eat into it.
-      visualDensity: VisualDensity.compact,
-      materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+      onSelected: (_) => widget.onSelected(value),
+      // Compact visual (tight padding, small label) so the row doesn't eat
+      // into the map, but a full 48px hit box: the padded tap target's extra
+      // area is transparent, and density must stay standard — compact would
+      // shave the hit box to 40px, under the 44px touch minimum.
+      visualDensity: VisualDensity.standard,
+      materialTapTargetSize: MaterialTapTargetSize.padded,
       padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
       labelPadding: EdgeInsets.zero,
       showCheckmark: false,
       // Dark translucent scrim so the text reads over satellite imagery
-      // (same treatment as TripMap's segment labels); selection is a solid
-      // white ring + brighter fill rather than a theme tint, which would
-      // vanish against imagery. Muted (nothing mapped that day) fades the
-      // scrim, border, and label together.
-      backgroundColor: Colors.black.withValues(alpha: dim ? 0.35 : 0.6),
+      // (AppColors.mapScrim — shared with TripMap's segment labels and the
+      // map control buttons); selection is a solid white ring + brighter
+      // fill rather than a theme tint, which would vanish against imagery.
+      // Muted (nothing mapped that day) fades the scrim, border, and label
+      // together.
+      backgroundColor:
+          dim ? Colors.black.withValues(alpha: 0.35) : AppColors.mapScrim,
       selectedColor: Colors.black.withValues(alpha: 0.8),
       side: BorderSide(
-          color: isSelected
-              ? Colors.white
-              : (dim ? Colors.white12 : Colors.white24)),
+        color:
+            isSelected ? Colors.white : (dim ? Colors.white12 : Colors.white24),
+      ),
       labelStyle: TextStyle(
         color: dim ? Colors.white60 : Colors.white,
         fontSize: 11,
         fontWeight: isSelected ? FontWeight.w700 : FontWeight.w600,
       ),
     );
+    return isSelected ? KeyedSubtree(key: _selectedKey, child: chip) : chip;
   }
 
   @override
   Widget build(BuildContext context) {
-    if (dayCount == 0) return const SizedBox.shrink();
+    if (widget.dayCount == 0) return const SizedBox.shrink();
     // Same keys the trip-detail filter menu uses, so the chip row and the
     // list agree in every language (specs/i18n-spanish).
     final l10n = context.l10n;
     return SingleChildScrollView(
+      controller: _controller,
       scrollDirection: Axis.horizontal,
+      // Draggable even when the chips fit, and end padding so the first/last
+      // chip never sits flush against the map edge.
+      physics: const AlwaysScrollableScrollPhysics(),
+      padding: const EdgeInsets.symmetric(horizontal: AppSpacing.xs),
       child: Row(
         children: [
           _chip(label: l10n.tripFilterAll, value: null),
-          for (var d = 1; d <= dayCount; d++) ...[
+          for (var d = 1; d <= widget.dayCount; d++) ...[
             const SizedBox(width: 6),
             _chip(
               label: l10n.tripDayN(d),
               value: d,
-              muted: mappedDays != null && !mappedDays!.contains(d),
+              muted:
+                  widget.mappedDays != null && !widget.mappedDays!.contains(d),
             ),
           ],
         ],

--- a/src/packages/flutter-app/lib/widgets/trip_map.dart
+++ b/src/packages/flutter-app/lib/widgets/trip_map.dart
@@ -13,6 +13,20 @@ import '../utils/trip_format.dart';
 import 'app_map.dart';
 import 'empty_state.dart';
 
+/// Tap box (px) for interactive map pins. The painted dot stays small; the
+/// surrounding transparent halo brings the target up to the mobile touch
+/// minimum. Markers anchor by their box center (flutter_map's default
+/// alignment), so the enlargement must stay symmetric with the visual
+/// centered inside — anything else drifts pins off their coordinates on all
+/// three map surfaces.
+const double _pinHitBox = 44;
+
+/// Clearance (px) for the day-chip band's visible pills when the empty state
+/// is centered under it: 8px overlay offset + the ~32px pill + breathing
+/// room. See the empty-state branch in [_TripMapState.build] for why this is
+/// less than [TripMap.topOverlayInset]'s usual value.
+const double _emptyStateTopInset = 44;
+
 /// Plots a trip's itinerary on a satellite basemap: a numbered, category-tinted
 /// pin per place, a route line connecting them in itinerary order, auto-fit to
 /// the trip's extent. Tapping a pin calls [onPinTap] with that item's position.
@@ -241,9 +255,15 @@ class _TripMapState extends State<TripMap> {
     if (mapped.isEmpty && stays.isEmpty) {
       return Container(
         color: theme.colorScheme.surfaceContainerHighest,
-        // Keep the centered content clear of the day-chip band overlaid on
-        // the map's top edge (same inset the camera fitting respects).
-        padding: EdgeInsets.only(top: widget.topOverlayInset),
+        // Keep the centered content clear of the day-chip band's *visible*
+        // pills. Deliberately capped below the full camera-fit inset: that
+        // one also covers the band's transparent hit halo, which static
+        // empty-state text can safely sit under — and the fixed-height
+        // inline map cards don't have the room (EmptyState would overflow
+        // at 240px).
+        padding: EdgeInsets.only(
+          top: math.min(widget.topOverlayInset, _emptyStateTopInset),
+        ),
         child: EmptyState(
           compact: true,
           icon: Icons.location_off_outlined,
@@ -367,8 +387,11 @@ class _TripMapState extends State<TripMap> {
                   for (final s in stays)
                     Marker(
                       point: s.point,
-                      width: 26,
-                      height: 26,
+                      // Transparent 44px halo around the 26px square; the
+                      // box stays centered on the coordinate (see
+                      // _pinHitBox).
+                      width: _pinHitBox,
+                      height: _pinHitBox,
                       child: _StayPin(
                         name: s.stay.name,
                         dates: tripDateRange(s.stay.checkIn, s.stay.checkOut),
@@ -389,17 +412,30 @@ class _TripMapState extends State<TripMap> {
                   for (final (k, m) in mapped.indexed)
                     Marker(
                       point: m.point,
-                      width:
-                          widget.selectedPosition == m.item.position ? 28 : 24,
-                      height:
-                          widget.selectedPosition == m.item.position ? 28 : 24,
-                      child: _Pin(
-                        label: '${k + 1}',
-                        category: m.item.category,
-                        selected: widget.selectedPosition == m.item.position,
+                      // Transparent 44px halo around the 24/28px dot, tap
+                      // handling on the whole box; centered so the dot stays
+                      // anchored on its coordinate (see _pinHitBox).
+                      width: _pinHitBox,
+                      height: _pinHitBox,
+                      child: GestureDetector(
+                        behavior: HitTestBehavior.opaque,
                         onTap: widget.onPinTap == null
                             ? null
                             : () => widget.onPinTap!(m.item.position),
+                        child: Center(
+                          child: SizedBox.square(
+                            dimension:
+                                widget.selectedPosition == m.item.position
+                                    ? 28
+                                    : 24,
+                            child: _Pin(
+                              label: '${k + 1}',
+                              category: m.item.category,
+                              selected:
+                                  widget.selectedPosition == m.item.position,
+                            ),
+                          ),
+                        ),
                       ),
                     ),
                 ],
@@ -513,9 +549,10 @@ class _SegmentLabel extends StatelessWidget {
       child: Container(
         padding: const EdgeInsets.symmetric(horizontal: 7, vertical: 3),
         decoration: BoxDecoration(
-          // Dark translucent chip so the time reads cleanly over satellite
-          // imagery and the route line beneath it.
-          color: Colors.black.withValues(alpha: 0.6),
+          // Shared over-map scrim so the time reads cleanly over satellite
+          // imagery and the route line beneath it (same treatment as the day
+          // chips and control buttons).
+          color: AppColors.mapScrim,
           borderRadius: BorderRadius.circular(10),
           border: Border.all(color: Colors.white24),
         ),
@@ -566,17 +603,17 @@ class _ClusterBubble extends StatelessWidget {
   }
 }
 
+/// The painted itinerary dot. Purely visual: tap handling lives on the
+/// marker-level GestureDetector so the whole [_pinHitBox] halo is tappable.
 class _Pin extends StatelessWidget {
   final String label;
   final String? category;
   final bool selected;
-  final VoidCallback? onTap;
 
   const _Pin({
     required this.label,
     required this.category,
     required this.selected,
-    this.onTap,
   });
 
   Color _color(ColorScheme scheme) => AppColors.forCategory(category, scheme);
@@ -585,31 +622,28 @@ class _Pin extends StatelessWidget {
   Widget build(BuildContext context) {
     final scheme = Theme.of(context).colorScheme;
     final color = _color(scheme);
-    return GestureDetector(
-      onTap: onTap,
-      child: Container(
-        // A permanent white ring keeps the small dots crisp over satellite
-        // imagery; selection thickens the ring (and the marker itself grows).
-        decoration: BoxDecoration(
-          color: color,
-          shape: BoxShape.circle,
-          border: Border.all(color: Colors.white, width: selected ? 3 : 2),
-          boxShadow: [
-            BoxShadow(
-              color: Colors.black.withValues(alpha: selected ? 0.5 : 0.35),
-              blurRadius: selected ? 6 : 4,
-              offset: const Offset(0, 1),
-            ),
-          ],
-        ),
-        alignment: Alignment.center,
-        child: Text(
-          label,
-          style: const TextStyle(
-            color: Colors.white,
-            fontSize: 11,
-            fontWeight: FontWeight.bold,
+    return Container(
+      // A permanent white ring keeps the small dots crisp over satellite
+      // imagery; selection thickens the ring (and the dot itself grows).
+      decoration: BoxDecoration(
+        color: color,
+        shape: BoxShape.circle,
+        border: Border.all(color: Colors.white, width: selected ? 3 : 2),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withValues(alpha: selected ? 0.5 : 0.35),
+            blurRadius: selected ? 6 : 4,
+            offset: const Offset(0, 1),
           ),
+        ],
+      ),
+      alignment: Alignment.center,
+      child: Text(
+        label,
+        style: const TextStyle(
+          color: Colors.white,
+          fontSize: 11,
+          fontWeight: FontWeight.bold,
         ),
       ),
     );
@@ -630,26 +664,32 @@ class _StayPin extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    // The tooltip's tap detector fills the marker's [_pinHitBox] box, so the
+    // whole transparent halo around the 26px square triggers it.
     return Tooltip(
       message: dates == null ? name : '$name\n$dates',
       triggerMode: TooltipTriggerMode.tap,
-      child: Container(
-        // Same white ring + shadow treatment as _Pin so it reads as part of
-        // the family, but square where itinerary pins are round.
-        decoration: BoxDecoration(
-          color: AppColors.toolAirbnb,
-          borderRadius: BorderRadius.circular(7),
-          border: Border.all(color: Colors.white, width: 2),
-          boxShadow: [
-            BoxShadow(
-              color: Colors.black.withValues(alpha: 0.35),
-              blurRadius: 4,
-              offset: const Offset(0, 1),
-            ),
-          ],
+      child: Center(
+        child: Container(
+          width: 26,
+          height: 26,
+          // Same white ring + shadow treatment as _Pin so it reads as part
+          // of the family, but square where itinerary pins are round.
+          decoration: BoxDecoration(
+            color: AppColors.toolAirbnb,
+            borderRadius: BorderRadius.circular(7),
+            border: Border.all(color: Colors.white, width: 2),
+            boxShadow: [
+              BoxShadow(
+                color: Colors.black.withValues(alpha: 0.35),
+                blurRadius: 4,
+                offset: const Offset(0, 1),
+              ),
+            ],
+          ),
+          alignment: Alignment.center,
+          child: const Icon(Icons.hotel, size: 14, color: Colors.white),
         ),
-        alignment: Alignment.center,
-        child: const Icon(Icons.hotel, size: 14, color: Colors.white),
       ),
     );
   }

--- a/src/packages/flutter-app/test/map_day_chips_test.dart
+++ b/src/packages/flutter-app/test/map_day_chips_test.dart
@@ -1,0 +1,112 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:travel_route_planner/widgets/map_day_chips.dart';
+
+import 'support/l10n_test_app.dart';
+
+/// Hosts the strip at a fixed width, mirroring its real placement as a
+/// Positioned row floating over a map.
+Widget _host({
+  required int dayCount,
+  required int? selected,
+  double width = 320,
+  ValueChanged<int?>? onSelected,
+}) {
+  return localizedTestApp(
+    home: Scaffold(
+      body: Center(
+        child: SizedBox(
+          width: width,
+          child: MapDayChips(
+            dayCount: dayCount,
+            selected: selected,
+            onSelected: onSelected ?? (_) {},
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+Rect _stripViewport(WidgetTester tester) => tester.getRect(
+      find.descendant(
+        of: find.byType(MapDayChips),
+        matching: find.byType(SingleChildScrollView),
+      ),
+    );
+
+Rect _chipRect(WidgetTester tester, String label) => tester.getRect(
+      find.ancestor(of: find.text(label), matching: find.byType(ChoiceChip)),
+    );
+
+void main() {
+  testWidgets('every chip carries a >=44px hit box', (tester) async {
+    await tester.pumpWidget(_host(dayCount: 2, selected: null, width: 600));
+    await tester.pumpAndSettle();
+
+    final chips = find.byType(ChoiceChip);
+    expect(chips, findsNWidgets(3)); // All + Day 1 + Day 2
+    for (var i = 0; i < 3; i++) {
+      expect(
+        tester.getSize(chips.at(i)).height,
+        greaterThanOrEqualTo(44),
+        reason: 'chip $i must meet the 44px touch minimum',
+      );
+    }
+  });
+
+  testWidgets('a tap outside the visual pill but inside the hit box selects', (
+    tester,
+  ) async {
+    int? received = -1;
+    await tester.pumpWidget(
+      _host(
+        dayCount: 2,
+        selected: null,
+        width: 600,
+        onSelected: (v) => received = v,
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // 20px above center: within the 48px hit box, well above the compact
+    // pill — exactly the kind of tap that used to pan the map instead.
+    await tester.tapAt(
+      tester.getCenter(find.text('Day 2')) + const Offset(0, -20),
+    );
+    expect(received, 2);
+  });
+
+  testWidgets('opening with a late day selected scrolls the strip to it', (
+    tester,
+  ) async {
+    // Step 0 repro: a long trip opens the full-screen map on a late day and
+    // the strip used to rest at Day 1 with the selection off-screen.
+    await tester.pumpWidget(_host(dayCount: 10, selected: 9, width: 300));
+    await tester.pumpAndSettle();
+
+    final viewport = _stripViewport(tester);
+    final chip = _chipRect(tester, 'Day 9');
+    expect(chip.left, greaterThanOrEqualTo(viewport.left));
+    expect(chip.right, lessThanOrEqualTo(viewport.right));
+  });
+
+  testWidgets('selection change scrolls the newly selected chip into view', (
+    tester,
+  ) async {
+    await tester.pumpWidget(_host(dayCount: 10, selected: null, width: 300));
+    await tester.pumpAndSettle();
+
+    final viewport = _stripViewport(tester);
+    // Sanity: Day 10 starts off-screen to the right.
+    expect(_chipRect(tester, 'Day 10').right, greaterThan(viewport.right));
+
+    await tester.pumpWidget(_host(dayCount: 10, selected: 10, width: 300));
+    await tester.pumpAndSettle();
+
+    final chip = _chipRect(tester, 'Day 10');
+    expect(chip.left, greaterThanOrEqualTo(viewport.left));
+    expect(chip.right, lessThanOrEqualTo(viewport.right));
+  });
+}

--- a/src/packages/flutter-app/test/trip_map_screen_test.dart
+++ b/src/packages/flutter-app/test/trip_map_screen_test.dart
@@ -1,0 +1,133 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:travel_route_planner/models/accommodation.dart';
+import 'package:travel_route_planner/models/itinerary_item.dart';
+import 'package:travel_route_planner/screens/trip_map_screen.dart';
+import 'package:travel_route_planner/widgets/map_day_chips.dart';
+
+import 'support/l10n_test_app.dart';
+
+ItineraryItem _item(int pos, String name, double lat, double lng) =>
+    ItineraryItem(
+      id: 'i$pos',
+      position: pos,
+      name: name,
+      latitude: lat,
+      longitude: lng,
+      category: 'attraction',
+    );
+
+final _items = [
+  _item(0, 'Louvre', 48.8606, 2.3376),
+  _item(1, 'Café de Flore', 48.8540, 2.3326),
+];
+
+/// [viewPadding] simulates device chrome (e.g. the 34px iOS home-indicator
+/// band) — the test binding's own MediaQuery always reports zero.
+Widget _app({
+  EdgeInsets viewPadding = EdgeInsets.zero,
+  void Function(int? day)? onAddPlace,
+  String title = 'Paris getaway',
+}) {
+  return MaterialApp(
+    localizationsDelegates: testLocalizationsDelegates,
+    builder: (context, child) => MediaQuery(
+      data: MediaQuery.of(
+        context,
+      ).copyWith(padding: viewPadding, viewPadding: viewPadding),
+      child: child!,
+    ),
+    home: TripMapScreen(
+      title: title,
+      itemsForDay: (_) => _items,
+      staysForDay: (_) => const <Accommodation>[],
+      segmentLabels: const {},
+      dayCount: 3,
+      onDaySelected: (_) {},
+      onAddPlace: onAddPlace,
+    ),
+  );
+}
+
+void main() {
+  testWidgets('bottom map controls clear a simulated home indicator', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(360, 690));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    await tester.pumpWidget(
+      _app(viewPadding: const EdgeInsets.only(bottom: 34)),
+    );
+    await tester.pumpAndSettle();
+
+    // The body honors the bottom inset (SafeArea), so the reset button —
+    // the lowest control in the zoom column — can't sit under the 34px
+    // home-indicator band.
+    final reset = find.byIcon(Icons.center_focus_strong);
+    expect(reset, findsOneWidget);
+    expect(tester.getBottomLeft(reset).dy, lessThanOrEqualTo(690 - 34));
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets(
+    'app bar carries a persistent add-place action wired to the current day',
+    (tester) async {
+      var called = false;
+      int? receivedDay = -1;
+      await tester.pumpWidget(
+        _app(
+          onAddPlace: (d) {
+            called = true;
+            receivedDay = d;
+          },
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final action = find.byIcon(Icons.add_location_alt_outlined);
+      expect(action, findsOneWidget);
+
+      await tester.tap(action);
+      expect(called, isTrue);
+      expect(receivedDay, isNull); // opened on All
+
+      // Selecting a day must carry through to the action.
+      await tester.tap(
+        find.descendant(
+          of: find.byType(MapDayChips),
+          matching: find.text('Day 2'),
+        ),
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(action);
+      expect(receivedDay, 2);
+    },
+  );
+
+  testWidgets('read-only map (no onAddPlace) hides the add action', (
+    tester,
+  ) async {
+    await tester.pumpWidget(_app(onAddPlace: null));
+    await tester.pumpAndSettle();
+
+    expect(find.byIcon(Icons.add_location_alt_outlined), findsNothing);
+  });
+
+  testWidgets('long titles ellipsize instead of overflowing at 360px', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(360, 690));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    const title = 'Barcelona, Madrid, Sevilla, Granada & 5 more';
+    await tester.pumpWidget(_app(title: title));
+    await tester.pumpAndSettle();
+
+    final text = tester.widget<Text>(find.text(title));
+    expect(text.maxLines, 1);
+    expect(text.overflow, TextOverflow.ellipsis);
+    expect(tester.takeException(), isNull);
+  });
+}

--- a/src/packages/flutter-app/test/trip_map_test.dart
+++ b/src/packages/flutter-app/test/trip_map_test.dart
@@ -5,6 +5,7 @@ import 'package:latlong2/latlong.dart';
 
 import 'package:travel_route_planner/models/accommodation.dart';
 import 'package:travel_route_planner/models/itinerary_item.dart';
+import 'package:travel_route_planner/widgets/app_map.dart';
 import 'package:travel_route_planner/widgets/trip_map.dart';
 
 import 'support/l10n_test_app.dart';
@@ -23,9 +24,7 @@ ItineraryItem _item(int pos, String name, double lat, double lng) =>
 Widget _host(Widget child) => MaterialApp(
       localizationsDelegates: testLocalizationsDelegates,
       home: Scaffold(
-        body: Center(
-          child: SizedBox(width: 400, height: 300, child: child),
-        ),
+        body: Center(child: SizedBox(width: 400, height: 300, child: child)),
       ),
     );
 
@@ -42,8 +41,9 @@ void main() {
     _item(1, 'Café de Flore', 48.8540, 2.3326),
   ];
 
-  testWidgets('builds without accommodations (default keeps old call sites)',
-      (WidgetTester tester) async {
+  testWidgets('builds without accommodations (default keeps old call sites)', (
+    WidgetTester tester,
+  ) async {
     await tester.pumpWidget(_host(TripMap(items: items)));
     await tester.pump();
 
@@ -51,8 +51,9 @@ void main() {
     expect(find.byIcon(Icons.hotel), findsNothing);
   });
 
-  testWidgets('renders one stay marker per stay with coordinates',
-      (WidgetTester tester) async {
+  testWidgets('renders one stay marker per stay with coordinates', (
+    WidgetTester tester,
+  ) async {
     const stays = [
       Accommodation(
         id: 'a1',
@@ -81,18 +82,21 @@ void main() {
 
     // Tapping a stay is a tooltip affair (name + dates), not selection sync.
     final tooltips = tester
-        .widgetList<Tooltip>(find.ancestor(
-          of: find.byIcon(Icons.hotel),
-          matching: find.byType(Tooltip),
-        ))
+        .widgetList<Tooltip>(
+          find.ancestor(
+            of: find.byIcon(Icons.hotel),
+            matching: find.byType(Tooltip),
+          ),
+        )
         .map((t) => t.message)
         .toList();
     expect(tooltips, contains('Hôtel du Louvre\nJun 10 – Jun 12'));
     expect(tooltips, contains('Left Bank Flat')); // no dates -> name only
   });
 
-  testWidgets('custom emptyLabel renders when nothing is mappable',
-      (WidgetTester tester) async {
+  testWidgets('custom emptyLabel renders when nothing is mappable', (
+    WidgetTester tester,
+  ) async {
     await tester.pumpWidget(
       _host(const TripMap(items: [], emptyLabel: 'No mapped places on Day 3')),
     );
@@ -102,25 +106,31 @@ void main() {
     expect(find.text('No mapped places'), findsNothing);
   });
 
-  testWidgets('default emptyLabel keeps the existing message',
-      (WidgetTester tester) async {
+  testWidgets('default emptyLabel keeps the existing message', (
+    WidgetTester tester,
+  ) async {
     await tester.pumpWidget(_host(const TripMap(items: [])));
     await tester.pump();
 
     expect(find.text('No mapped places'), findsOneWidget);
   });
 
-  testWidgets('empty state renders the optional message and CTA',
-      (WidgetTester tester) async {
+  testWidgets('empty state renders the optional message and CTA', (
+    WidgetTester tester,
+  ) async {
     var tapped = false;
-    await tester.pumpWidget(_host(TripMap(
-      items: const [],
-      emptyMessage: 'Add a place to see it on the map.',
-      emptyAction: FilledButton(
-        onPressed: () => tapped = true,
-        child: const Text('Add place'),
+    await tester.pumpWidget(
+      _host(
+        TripMap(
+          items: const [],
+          emptyMessage: 'Add a place to see it on the map.',
+          emptyAction: FilledButton(
+            onPressed: () => tapped = true,
+            child: const Text('Add place'),
+          ),
+        ),
       ),
-    )));
+    );
     await tester.pump();
 
     expect(find.text('Add a place to see it on the map.'), findsOneWidget);
@@ -128,11 +138,10 @@ void main() {
     expect(tapped, isTrue);
   });
 
-  testWidgets('changing fitSignature re-fits without crashing (smoke)',
-      (WidgetTester tester) async {
-    await tester.pumpWidget(
-      _host(TripMap(items: items, fitSignature: 'all')),
-    );
+  testWidgets('changing fitSignature re-fits without crashing (smoke)', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(_host(TripMap(items: items, fitSignature: 'all')));
     await tester.pump();
 
     // Filtered down to one item under a new signature: the post-frame re-fit
@@ -157,57 +166,78 @@ void main() {
   });
 
   testWidgets(
-      'adding a far-away item with unchanged fitSignature re-fits the camera '
-      'to contain all points', (WidgetTester tester) async {
-    await tester.pumpWidget(_host(TripMap(items: items, fitSignature: 'all')));
-    await tester.pump();
+    'adding a far-away item with unchanged fitSignature re-fits the camera '
+    'to contain all points',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(
+        _host(TripMap(items: items, fitSignature: 'all')),
+      );
+      await tester.pump();
 
-    // Marseille: well outside the Paris-fit viewport, so the final assertions
-    // below are exactly what the pre-fix code violates.
-    const far = LatLng(43.2965, 5.3698);
-    expect(_camera(tester).visibleBounds.contains(far), isFalse);
+      // Marseille: well outside the Paris-fit viewport, so the final assertions
+      // below are exactly what the pre-fix code violates.
+      const far = LatLng(43.2965, 5.3698);
+      expect(_camera(tester).visibleBounds.contains(far), isFalse);
 
-    await tester.pumpWidget(_host(TripMap(
-      items: [...items, _item(2, 'Vieux-Port', far.latitude, far.longitude)],
-      fitSignature: 'all', // unchanged — the bug condition
-    )));
-    await tester.pump(); // frame rendering the new pin schedules the re-fit
-    await tester.pump(); // post-frame callback has run; camera updated
+      await tester.pumpWidget(
+        _host(
+          TripMap(
+            items: [
+              ...items,
+              _item(2, 'Vieux-Port', far.latitude, far.longitude),
+            ],
+            fitSignature: 'all', // unchanged — the bug condition
+          ),
+        ),
+      );
+      await tester.pump(); // frame rendering the new pin schedules the re-fit
+      await tester.pump(); // post-frame callback has run; camera updated
 
-    final bounds = _camera(tester).visibleBounds;
-    expect(bounds.contains(far), isTrue);
-    for (final it in items) {
-      expect(bounds.contains(LatLng(it.latitude, it.longitude)), isTrue);
-    }
-  });
+      final bounds = _camera(tester).visibleBounds;
+      expect(bounds.contains(far), isTrue);
+      for (final it in items) {
+        expect(bounds.contains(LatLng(it.latitude, it.longitude)), isTrue);
+      }
+    },
+  );
 
-  testWidgets('content change while a pin is selected does not yank the camera',
-      (WidgetTester tester) async {
-    await tester.pumpWidget(
-      _host(TripMap(items: items, selectedPosition: 0, fitSignature: 'all')),
-    );
-    await tester.pump();
+  testWidgets(
+    'content change while a pin is selected does not yank the camera',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(
+        _host(TripMap(items: items, selectedPosition: 0, fitSignature: 'all')),
+      );
+      await tester.pump();
 
-    // Initial mount centers on the selected item at zoom 15.
-    expect(_camera(tester).zoom, 15);
+      // Initial mount centers on the selected item at zoom 15.
+      expect(_camera(tester).zoom, 15);
 
-    const far = LatLng(43.2965, 5.3698);
-    await tester.pumpWidget(_host(TripMap(
-      items: [...items, _item(2, 'Vieux-Port', far.latitude, far.longitude)],
-      selectedPosition: 0,
-      fitSignature: 'all',
-    )));
-    await tester.pump();
-    await tester.pump();
+      const far = LatLng(43.2965, 5.3698);
+      await tester.pumpWidget(
+        _host(
+          TripMap(
+            items: [
+              ...items,
+              _item(2, 'Vieux-Port', far.latitude, far.longitude),
+            ],
+            selectedPosition: 0,
+            fitSignature: 'all',
+          ),
+        ),
+      );
+      await tester.pump();
+      await tester.pump();
 
-    final camera = _camera(tester);
-    expect(camera.zoom, 15);
-    expect(camera.center.latitude, closeTo(48.8606, 1e-4)); // still on Louvre
-    expect(camera.visibleBounds.contains(far), isFalse);
-  });
+      final camera = _camera(tester);
+      expect(camera.zoom, 15);
+      expect(camera.center.latitude, closeTo(48.8606, 1e-4)); // still on Louvre
+      expect(camera.visibleBounds.contains(far), isFalse);
+    },
+  );
 
-  testWidgets('empty state to mapped content frames all points',
-      (WidgetTester tester) async {
+  testWidgets('empty state to mapped content frames all points', (
+    WidgetTester tester,
+  ) async {
     await tester.pumpWidget(_host(const TripMap(items: [])));
     await tester.pump();
     expect(find.text('No mapped places'), findsOneWidget);
@@ -222,15 +252,14 @@ void main() {
     }
   });
 
-  testWidgets('reordering items does not move the camera',
-      (WidgetTester tester) async {
+  testWidgets('reordering items does not move the camera', (
+    WidgetTester tester,
+  ) async {
     await tester.pumpWidget(_host(TripMap(items: items)));
     await tester.pump();
 
     final before = _camera(tester);
-    await tester.pumpWidget(
-      _host(TripMap(items: items.reversed.toList())),
-    );
+    await tester.pumpWidget(_host(TripMap(items: items.reversed.toList())));
     await tester.pump();
     await tester.pump();
 
@@ -239,8 +268,9 @@ void main() {
     expect(after.center, before.center);
   });
 
-  testWidgets('segment label shows when the leg is long enough on screen',
-      (WidgetTester tester) async {
+  testWidgets('segment label shows when the leg is long enough on screen', (
+    WidgetTester tester,
+  ) async {
     // The Paris pair alone fits at a high zoom, so the ~0.8km leg spans far
     // more than the visibility threshold.
     await tester.pumpWidget(
@@ -251,67 +281,83 @@ void main() {
     expect(find.text('12 min'), findsOneWidget);
   });
 
-  testWidgets('segment label hides when the leg converges at fit zoom',
-      (WidgetTester tester) async {
+  testWidgets('segment label hides when the leg converges at fit zoom', (
+    WidgetTester tester,
+  ) async {
     // Adding Marseille zooms the fit out to country scale, where the Paris
     // leg collapses to a few pixels — the pill would just sit behind the
     // numbered pins, so it must not render.
-    await tester.pumpWidget(_host(TripMap(
-      items: [...items, _item(2, 'Vieux-Port', 43.2965, 5.3698)],
-      segmentLabels: const {0: '12 min'},
-    )));
+    await tester.pumpWidget(
+      _host(
+        TripMap(
+          items: [...items, _item(2, 'Vieux-Port', 43.2965, 5.3698)],
+          segmentLabels: const {0: '12 min'},
+        ),
+      ),
+    );
     await tester.pump();
 
     expect(find.text('12 min'), findsNothing);
     expect(find.byType(TripMap), findsOneWidget);
   });
 
-  testWidgets('camera change re-evaluates segment label visibility',
-      (WidgetTester tester) async {
+  testWidgets('camera change re-evaluates segment label visibility', (
+    WidgetTester tester,
+  ) async {
     final threeItems = [...items, _item(2, 'Vieux-Port', 43.2965, 5.3698)];
-    await tester.pumpWidget(_host(TripMap(
-      items: threeItems,
-      segmentLabels: const {0: '12 min'},
-    )));
+    await tester.pumpWidget(
+      _host(TripMap(items: threeItems, segmentLabels: const {0: '12 min'})),
+    );
     await tester.pump();
     expect(find.text('12 min'), findsNothing);
 
     // Selecting a pin moves the camera to zoom 15, where the Paris leg is
     // hundreds of px long — the label must (re)appear without a rebuild of
     // the segment data.
-    await tester.pumpWidget(_host(TripMap(
-      items: threeItems,
-      segmentLabels: const {0: '12 min'},
-      selectedPosition: 0,
-    )));
+    await tester.pumpWidget(
+      _host(
+        TripMap(
+          items: threeItems,
+          segmentLabels: const {0: '12 min'},
+          selectedPosition: 0,
+        ),
+      ),
+    );
     await tester.pump(); // frame scheduling the post-frame camera move
     await tester.pump(); // camera moved; label layer rebuilt
 
     expect(find.text('12 min'), findsOneWidget);
   });
 
-  testWidgets('topOverlayInset keeps fitted markers below the overlay band',
-      (WidgetTester tester) async {
-    await tester.pumpWidget(
-      _host(TripMap(items: items, topOverlayInset: 48)),
-    );
+  testWidgets('topOverlayInset keeps fitted markers below the overlay band', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(_host(TripMap(items: items, topOverlayInset: 48)));
     await tester.pump();
 
     // Topmost point (Louvre) must clear the 48px chip band at the fit.
-    final dy =
-        _camera(tester).latLngToScreenOffset(const LatLng(48.8606, 2.3376)).dy;
+    final dy = _camera(
+      tester,
+    ).latLngToScreenOffset(const LatLng(48.8606, 2.3376)).dy;
     expect(dy, greaterThanOrEqualTo(48));
   });
 
-  testWidgets('pins number 1..N over the shown items, not trip-wide position',
-      (WidgetTester tester) async {
+  testWidgets('pins number 1..N over the shown items, not trip-wide position', (
+    WidgetTester tester,
+  ) async {
     // A day-filtered (or partially geocoded) view hands the map items whose
     // positions start mid-trip; the labels must still read 1, 2 in route
     // order rather than exposing positions 5, 6 as "6", "7".
-    await tester.pumpWidget(_host(TripMap(items: [
-      _item(5, 'Louvre', 48.8606, 2.3376),
-      _item(6, 'Café de Flore', 48.8540, 2.3326),
-    ])));
+    await tester.pumpWidget(
+      _host(
+        TripMap(
+          items: [
+            _item(5, 'Louvre', 48.8606, 2.3376),
+            _item(6, 'Café de Flore', 48.8540, 2.3326),
+          ],
+        ),
+      ),
+    );
     await tester.pump();
 
     expect(find.text('1'), findsOneWidget);
@@ -320,8 +366,9 @@ void main() {
     expect(find.text('7'), findsNothing);
   });
 
-  testWidgets('interactive: false hides the zoom/reset controls',
-      (WidgetTester tester) async {
+  testWidgets('interactive: false hides the zoom/reset controls', (
+    WidgetTester tester,
+  ) async {
     await tester.pumpWidget(_host(TripMap(items: items, interactive: false)));
     await tester.pump();
 
@@ -330,8 +377,9 @@ void main() {
     expect(find.byIcon(Icons.center_focus_strong), findsNothing);
   });
 
-  testWidgets('default (interactive) keeps the zoom/reset controls',
-      (WidgetTester tester) async {
+  testWidgets('default (interactive) keeps the zoom/reset controls', (
+    WidgetTester tester,
+  ) async {
     await tester.pumpWidget(_host(TripMap(items: items)));
     await tester.pump();
 
@@ -340,8 +388,85 @@ void main() {
     expect(find.byIcon(Icons.center_focus_strong), findsOneWidget);
   });
 
-  testWidgets('stays alone (no mapped items) still render a map',
-      (WidgetTester tester) async {
+  testWidgets('pin dot stays anchored on its coordinate inside the 44px box', (
+    WidgetTester tester,
+  ) async {
+    // The widened tap halo must not drift the painted dot: the marker box is
+    // center-anchored, so the dot's on-screen center has to sit exactly on
+    // the projected coordinate.
+    await tester.pumpWidget(_host(TripMap(items: [items.first])));
+    await tester.pump();
+
+    final mapTopLeft = tester.getTopLeft(find.byType(FlutterMap));
+    final projected = _camera(
+      tester,
+    ).latLngToScreenOffset(const LatLng(48.8606, 2.3376));
+    final pinCenter = tester.getCenter(find.text('1'));
+    expect((pinCenter - (mapTopLeft + projected)).distance, lessThan(1.0));
+  });
+
+  testWidgets('taps in the widened pin halo still select the pin', (
+    WidgetTester tester,
+  ) async {
+    int? tappedPos;
+    await tester.pumpWidget(
+      _host(TripMap(items: [items.first], onPinTap: (p) => tappedPos = p)),
+    );
+    await tester.pump();
+
+    // 18px below the dot center: outside the 24px dot, inside the 44px box.
+    await tester.tapAt(tester.getCenter(find.text('1')) + const Offset(0, 18));
+    expect(tappedPos, 0);
+  });
+
+  testWidgets('stay pin tooltip triggers from the widened halo', (
+    WidgetTester tester,
+  ) async {
+    const stays = [
+      Accommodation(
+        id: 'a1',
+        name: 'Hôtel du Louvre',
+        latitude: 48.8630,
+        longitude: 2.3364,
+      ),
+    ];
+    await tester.pumpWidget(
+      _host(const TripMap(items: [], accommodations: stays)),
+    );
+    await tester.pump();
+
+    await tester.tapAt(
+      tester.getCenter(find.byIcon(Icons.hotel)) + const Offset(0, 18),
+    );
+    await tester.pump(const Duration(milliseconds: 200));
+
+    // The tooltip overlay carries the message (name only — no dates given).
+    expect(find.text('Hôtel du Louvre'), findsOneWidget);
+
+    // Let the tap-triggered tooltip's show timer elapse and fade out so the
+    // test ends without pending timers.
+    await tester.pump(const Duration(seconds: 3));
+    await tester.pumpAndSettle();
+  });
+
+  testWidgets('map control buttons meet the 44px touch target', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(_host(TripMap(items: items)));
+    await tester.pump();
+
+    final buttons = find.byType(MapControlButton);
+    expect(buttons, findsNWidgets(3)); // zoom in / zoom out / reset
+    for (var i = 0; i < 3; i++) {
+      final size = tester.getSize(buttons.at(i));
+      expect(size.width, greaterThanOrEqualTo(44));
+      expect(size.height, greaterThanOrEqualTo(44));
+    }
+  });
+
+  testWidgets('stays alone (no mapped items) still render a map', (
+    WidgetTester tester,
+  ) async {
     const stays = [
       Accommodation(
         id: 'a1',


### PR DESCRIPTION
Day chips get real 48px hit boxes (visual pill unchanged) and the strip now scrolls to the selected day (it opened on Day 7 with the strip resting at Day 1); the full-screen map gains SafeArea for its bottom controls, a title ellipsis, and a persistent add-place action; map controls and pins get 44px hit areas with pin anchors locked by a <1px regression test; three drifted over-map scrims consolidate into AppColors.mapScrim.

Tests: new map_day_chips_test + trip_map_screen_test, trip_map_test extensions; full suite 540 green post-rebase.

Part of UI polish wave 2. 🤖 Generated with [Claude Code](https://claude.com/claude-code)