### PR TITLE
polish: declutter-wave regressions — bubble width, bottom pad, dedup, home mobile

### DIFF
--- a/src/packages/flutter-app/lib/l10n/app_en.arb
+++ b/src/packages/flutter-app/lib/l10n/app_en.arb
@@ -1487,6 +1487,7 @@
   },
   "chatInputHint": "Describe your trip...",
   "chatFollowUpHint": "Ask a follow-up…",
+  "chatSend": "Send",
   "chatAttachImages": "Attach images",
   "chatStopDictating": "Stop dictating",
   "chatDictate": "Dictate",

--- a/src/packages/flutter-app/lib/l10n/app_es.arb
+++ b/src/packages/flutter-app/lib/l10n/app_es.arb
@@ -640,6 +640,7 @@
   "offlineBannerMessage": "Sin conexión: mostrando la copia guardada {when}",
   "chatInputHint": "Describe tu viaje...",
   "chatFollowUpHint": "Haz una pregunta de seguimiento…",
+  "chatSend": "Enviar",
   "chatAttachImages": "Adjuntar imágenes",
   "chatStopDictating": "Dejar de dictar",
   "chatDictate": "Dictar",

--- a/src/packages/flutter-app/lib/l10n/app_localizations.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations.dart
@@ -3938,6 +3938,12 @@ abstract class AppLocalizations {
   /// **'Ask a follow-up…'**
   String get chatFollowUpHint;
 
+  /// No description provided for @chatSend.
+  ///
+  /// In en, this message translates to:
+  /// **'Send'**
+  String get chatSend;
+
   /// No description provided for @chatAttachImages.
   ///
   /// In en, this message translates to:

--- a/src/packages/flutter-app/lib/l10n/app_localizations_en.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations_en.dart
@@ -2229,6 +2229,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get chatFollowUpHint => 'Ask a follow-up…';
 
   @override
+  String get chatSend => 'Send';
+
+  @override
   String get chatAttachImages => 'Attach images';
 
   @override

--- a/src/packages/flutter-app/lib/l10n/app_localizations_es.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations_es.dart
@@ -2242,6 +2242,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get chatFollowUpHint => 'Haz una pregunta de seguimiento…';
 
   @override
+  String get chatSend => 'Enviar';
+
+  @override
   String get chatAttachImages => 'Adjuntar imágenes';
 
   @override

--- a/src/packages/flutter-app/lib/screens/home_screen.dart
+++ b/src/packages/flutter-app/lib/screens/home_screen.dart
@@ -46,6 +46,11 @@ String greetingText(AppLocalizations l10n, Greeting greeting) =>
       Greeting.evening => l10n.homeGreetingEvening,
     };
 
+/// Below this app-bar-title width the wordmark would ellipsize next to the
+/// badge (Playfair 20px "Golden Tempo Travel" ≈ 210px + badge + gap), so the
+/// header drops to the brand mark alone.
+const double _wordmarkMinWidth = 280;
+
 class HomeScreen extends ConsumerWidget {
   const HomeScreen({super.key});
 
@@ -78,45 +83,55 @@ class HomeScreen extends ConsumerWidget {
       appBar: GradientAppBar(
         centerTitle: false,
         // Brand mark on a light badge (so the black/gold logo reads on the teal
-        // app bar) next to the wordmark in white.
-        title: Row(
-          mainAxisSize: MainAxisSize.min,
-          children: const [
-            BrandBadge(
-              padding: EdgeInsets.symmetric(
-                  horizontal: AppSpacing.sm, vertical: AppSpacing.xs),
-              child: BrandLogo.mark(size: 28),
-            ),
-            SizedBox(width: AppSpacing.sm),
-            Flexible(
-              child: Text(
-                AppInfo.name,
-                overflow: TextOverflow.ellipsis,
-                style: TextStyle(
-                  fontFamily: 'Playfair Display',
-                  fontWeight: FontWeight.w600,
-                  fontSize: 20,
-                  letterSpacing: 0.5,
-                  color: Colors.white,
+        // app bar) next to the wordmark in white. LayoutBuilder inside the
+        // title's own constraints: with the globe + avatar actions a phone
+        // can't fit the full wordmark ("Golden Tempo Tra…"), so narrow widths
+        // show the mark alone rather than an ellipsized brand.
+        title: LayoutBuilder(
+          builder: (context, constraints) {
+            final compact = constraints.maxWidth < _wordmarkMinWidth;
+            return Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                const BrandBadge(
+                  padding: EdgeInsets.symmetric(
+                      horizontal: AppSpacing.sm, vertical: AppSpacing.xs),
+                  child: BrandLogo.mark(size: 28),
                 ),
-              ),
-            ),
-          ],
+                if (!compact) ...const [
+                  SizedBox(width: AppSpacing.sm),
+                  Flexible(
+                    child: Text(
+                      AppInfo.name,
+                      overflow: TextOverflow.ellipsis,
+                      style: TextStyle(
+                        fontFamily: 'Playfair Display',
+                        fontWeight: FontWeight.w600,
+                        fontSize: 20,
+                        letterSpacing: 0.5,
+                        color: Colors.white,
+                      ),
+                    ),
+                  ),
+                ],
+              ],
+            );
+          },
         ),
         actions: const [LanguageMenuButton(), AccountMenu()],
       ),
       body: SafeArea(
         child: SingleChildScrollView(
-          padding: const EdgeInsets.all(16),
+          padding: const EdgeInsets.all(AppSpacing.lg),
           child: PageContainer(
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.stretch,
               children: [
-                const SizedBox(height: 8),
+                const SizedBox(height: AppSpacing.sm),
 
                 _GreetingHeader(displayName: user?.displayName),
 
-                const SizedBox(height: 16),
+                const SizedBox(height: AppSpacing.lg),
 
                 // AI Travel Agent entry: the full photo hero sells the
                 // product to a brand-new account; returning users get a slim
@@ -126,7 +141,7 @@ class HomeScreen extends ConsumerWidget {
                 else
                   _AgentHeroCard(onStart: startPlanning),
 
-                SizedBox(height: returning ? AppSpacing.lg : 28),
+                SizedBox(height: returning ? AppSpacing.lg : AppSpacing.xl),
 
                 // The trip happening today (specs/happening-now), then the
                 // most recently viewed trip — the latter hidden when it *is*
@@ -140,7 +155,7 @@ class HomeScreen extends ConsumerWidget {
                       ),
                     ),
                   ),
-                  const SizedBox(height: 16),
+                  const SizedBox(height: AppSpacing.lg),
                 ],
                 // In-progress AI conversations that haven't produced a trip
                 // yet (specs/continue-where-you-left-off) — same section as
@@ -161,7 +176,7 @@ class HomeScreen extends ConsumerWidget {
                       ),
                     ),
                   ),
-                  const SizedBox(height: 16),
+                  const SizedBox(height: AppSpacing.lg),
                 ],
 
                 // Local guides discover row — published narrative guides
@@ -170,7 +185,7 @@ class HomeScreen extends ConsumerWidget {
                 // included) only appears when there is something to show.
                 const _LocalGuidesRow(),
 
-                const SizedBox(height: 16),
+                const SizedBox(height: AppSpacing.lg),
               ],
             ),
           ),
@@ -197,13 +212,7 @@ class _PlanStrip extends StatelessWidget {
       decoration: BoxDecoration(
         borderRadius: AppRadius.mdAll,
         gradient: AppColors.brandGradient,
-        boxShadow: [
-          BoxShadow(
-            color: AppColors.brandDark.withValues(alpha: 0.3),
-            blurRadius: 10,
-            offset: const Offset(0, 4),
-          ),
-        ],
+        boxShadow: AppShadows.brandCard,
       ),
       child: Material(
         color: Colors.transparent,
@@ -227,7 +236,10 @@ class _PlanStrip extends StatelessWidget {
                 Expanded(
                   child: Text(
                     l10n.homeHeroTitle,
-                    maxLines: 1,
+                    // Two lines before ellipsis: at phone widths the CTA
+                    // starves the row and one line truncates the tagline
+                    // ("Plan less. Trav…").
+                    maxLines: 2,
                     overflow: TextOverflow.ellipsis,
                     style: theme.textTheme.titleMedium?.copyWith(
                       fontWeight: FontWeight.bold,
@@ -309,13 +321,7 @@ class _AgentHeroCard extends StatelessWidget {
     return Container(
       decoration: BoxDecoration(
         borderRadius: AppRadius.lgAll,
-        boxShadow: [
-          BoxShadow(
-            color: AppColors.brandDark.withValues(alpha: 0.4),
-            blurRadius: 16,
-            offset: const Offset(0, 6),
-          ),
-        ],
+        boxShadow: AppShadows.hero,
       ),
       child: ClipRRect(
         borderRadius: AppRadius.lgAll,
@@ -342,16 +348,17 @@ class _AgentHeroCard extends StatelessWidget {
   }
 
   Widget _heroContent(BuildContext context) {
+    final theme = Theme.of(context);
     final l10n = context.l10n;
     return Container(
       constraints: const BoxConstraints(minHeight: 440),
-      padding: const EdgeInsets.all(28),
+      padding: const EdgeInsets.all(AppSpacing.xl),
       child: Column(
         mainAxisAlignment: MainAxisAlignment.center,
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Container(
-            padding: const EdgeInsets.all(12),
+            padding: const EdgeInsets.all(AppSpacing.md),
             decoration: BoxDecoration(
               color: Colors.white.withValues(alpha: 0.15),
               shape: BoxShape.circle,
@@ -359,22 +366,22 @@ class _AgentHeroCard extends StatelessWidget {
             child:
                 const Icon(Icons.flight_takeoff, size: 44, color: Colors.white),
           ),
-          const SizedBox(height: 16),
+          const SizedBox(height: AppSpacing.lg),
           Text(
             l10n.homeHeroTitle,
-            style: Theme.of(context).textTheme.headlineSmall?.copyWith(
-                  color: Colors.white,
-                  fontWeight: FontWeight.bold,
-                ),
+            style: theme.textTheme.headlineSmall?.copyWith(
+              color: Colors.white,
+              fontWeight: FontWeight.bold,
+            ),
           ),
-          const SizedBox(height: 8),
+          const SizedBox(height: AppSpacing.sm),
           Text(
             l10n.homeHeroSubtitle,
-            style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                  color: Colors.white.withValues(alpha: 0.85),
-                ),
+            style: theme.textTheme.bodyLarge?.copyWith(
+              color: Colors.white.withValues(alpha: 0.85),
+            ),
           ),
-          const SizedBox(height: 24),
+          const SizedBox(height: AppSpacing.xl),
           SizedBox(
             width: double.infinity,
             child: FilledButton(
@@ -389,21 +396,24 @@ class _AgentHeroCard extends StatelessWidget {
               ),
               child: Text(
                 l10n.homeHeroCta,
-                style: const TextStyle(
-                    fontWeight: FontWeight.bold, fontSize: 16),
+                // titleMedium keeps the deliberate 16px hero-CTA size while
+                // deriving from the type scale instead of a raw fontSize.
+                style: theme.textTheme.titleMedium?.copyWith(
+                  color: AppColors.brandDark,
+                  fontWeight: FontWeight.bold,
+                ),
               ),
             ),
           ),
-          const SizedBox(height: 16),
+          const SizedBox(height: AppSpacing.lg),
           Wrap(
-            spacing: 8,
-            runSpacing: 8,
+            spacing: AppSpacing.sm,
+            runSpacing: AppSpacing.sm,
             children: _suggestions(l10n)
                 .map((s) => ActionChip(
                       label: Text(s,
-                          style: TextStyle(
+                          style: theme.textTheme.labelMedium?.copyWith(
                               color: AppColors.brandDark,
-                              fontSize: 12,
                               fontWeight: FontWeight.w500)),
                       backgroundColor: Colors.white,
                       side: BorderSide.none,
@@ -456,13 +466,7 @@ class _RecentTripCard extends StatelessWidget {
       decoration: BoxDecoration(
         borderRadius: AppRadius.mdAll,
         gradient: AppColors.brandGradient,
-        boxShadow: [
-          BoxShadow(
-            color: AppColors.brandDark.withValues(alpha: 0.3),
-            blurRadius: 10,
-            offset: const Offset(0, 4),
-          ),
-        ],
+        boxShadow: AppShadows.brandCard,
       ),
       child: Material(
         color: Colors.transparent,
@@ -564,8 +568,7 @@ class _LocalGuidesRow extends ConsumerWidget {
             // the horizontal viewport.
             padding: const EdgeInsets.only(bottom: AppSpacing.sm),
             itemCount: guides.length,
-            separatorBuilder: (_, __) =>
-                const SizedBox(width: AppSpacing.md),
+            separatorBuilder: (_, __) => const SizedBox(width: AppSpacing.md),
             itemBuilder: (context, i) => _GuideCard(guide: guides[i]),
           ),
         ),

--- a/src/packages/flutter-app/lib/screens/shared_trip_screen.dart
+++ b/src/packages/flutter-app/lib/screens/shared_trip_screen.dart
@@ -58,6 +58,16 @@ class SharedTripScreen extends ConsumerWidget {
           message: linkKind == SharedLinkKind.invite
               ? l10n.sharedInviteUnavailableMessage
               : l10n.sharedLinkUnavailableMessage,
+          actions: [
+            // A transient network blip shouldn't read as a dead link — let
+            // the viewer refetch before giving up.
+            FilledButton(
+              onPressed: () => ref.invalidate(linkKind == SharedLinkKind.invite
+                  ? invitedTripProvider(token)
+                  : sharedTripProvider(token)),
+              child: Text(l10n.commonRetry),
+            ),
+          ],
         ),
         data: (s) =>
             _SharedTripBody(shared: s, token: token, linkKind: linkKind),
@@ -65,6 +75,12 @@ class SharedTripScreen extends ConsumerWidget {
     );
   }
 }
+
+/// Scroll clearance for the pinned bottom action bar (excluding the SafeArea
+/// inset, added at the call site): the bar measures ~104px at its tallest —
+/// 2 x AppSpacing.md container padding + two stacked ~40px buttons — so this
+/// keeps the last row fully revealable with breathing room to spare.
+const double _actionBarClearance = 128;
 
 class _SharedTripBody extends ConsumerStatefulWidget {
   final SharedTrip shared;
@@ -120,16 +136,15 @@ class _SharedTripBodyState extends ConsumerState<_SharedTripBody> {
     if (!await _ensureSignedIn()) return;
     setState(() => _saving = true);
     try {
-      await ref
-          .read(tripsApiServiceProvider)
-          .duplicateSharedTrip(widget.token);
+      await ref.read(tripsApiServiceProvider).duplicateSharedTrip(widget.token);
       if (!mounted) return;
       // Land the viewer on their Trips tab, where the copy now lives.
       ref.read(navIndexProvider.notifier).state = AppTab.trips.index;
-      Navigator.of(context)
-          .pushNamedAndRemoveUntil('/', (route) => false);
+      Navigator.of(context).pushNamedAndRemoveUntil('/', (route) => false);
     } catch (e) {
-      if (mounted) showSnack(context, l10n.sharedSaveCopyError(friendlyError(l10n, e)));
+      if (mounted) {
+        showSnack(context, l10n.sharedSaveCopyError(friendlyError(l10n, e)));
+      }
     } finally {
       if (mounted) setState(() => _saving = false);
     }
@@ -171,7 +186,9 @@ class _SharedTripBodyState extends ConsumerState<_SharedTripBody> {
 
       WidgetsBinding.instance.addPostFrameCallback((_) => openOnTripsTab());
     } catch (e) {
-      if (mounted) showSnack(context, l10n.sharedJoinError(friendlyError(l10n, e)));
+      if (mounted) {
+        showSnack(context, l10n.sharedJoinError(friendlyError(l10n, e)));
+      }
     } finally {
       if (mounted) setState(() => _saving = false);
     }
@@ -206,7 +223,8 @@ class _SharedTripBodyState extends ConsumerState<_SharedTripBody> {
       ],
       [
         for (final a in stays)
-          if (TripMap.stayHasCoords(a)) (checkIn: a.checkIn, checkOut: a.checkOut),
+          if (TripMap.stayHasCoords(a))
+            (checkIn: a.checkIn, checkOut: a.checkOut),
       ],
     );
     final dayItems = _selectedDay == null
@@ -232,8 +250,15 @@ class _SharedTripBodyState extends ConsumerState<_SharedTripBody> {
     return Stack(
       children: [
         ListView(
-          padding: const EdgeInsets.fromLTRB(
-              AppSpacing.lg, AppSpacing.lg, AppSpacing.lg, 96),
+          // Bottom pad must clear the pinned action bar: 12+12 container
+          // padding + two stacked ~40px buttons ≈ 104px, plus the SafeArea
+          // bottom inset the bar consumes on gesture-bar phones — otherwise
+          // the last row hides behind the opaque bar even fully scrolled.
+          padding: EdgeInsets.fromLTRB(
+              AppSpacing.lg,
+              AppSpacing.lg,
+              AppSpacing.lg,
+              _actionBarClearance + MediaQuery.paddingOf(context).bottom),
           children: [
             // Centered 700px column on wide layouts (declutter series):
             // the ListView stays full-width (wheel/scrollbar work in the
@@ -242,118 +267,118 @@ class _SharedTripBodyState extends ConsumerState<_SharedTripBody> {
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.stretch,
                 children: [
-            Text(trip.title, style: theme.textTheme.headlineSmall),
-            const SizedBox(height: AppSpacing.xs),
-            Text(
-              '${l10n.sharedBy(widget.shared.ownerName)}'
-              '${dates != null ? ' · $dates' : ''}',
-              style: theme.textTheme.bodyMedium
-                  ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
-            ),
-            if (trip.summary != null && trip.summary!.trim().isNotEmpty) ...[
-              const SizedBox(height: AppSpacing.md),
-              Text(trip.summary!, style: theme.textTheme.bodyMedium),
-            ],
-            if (hasCoords) ...[
-              const SizedBox(height: AppSpacing.lg),
-              ClipRRect(
-                borderRadius: AppRadius.lgAll,
-                child: SizedBox(
-                  height: 240,
-                  child: Stack(
-                    children: [
-                      Positioned.fill(
-                        child: TripMap(
-                          items: dayItems,
-                          accommodations: dayStays,
-                          selectedPosition: _selectedPosition,
-                          fitSignature: _selectedDay,
-                          // Keep fitted markers clear of the chip row
-                          // overlaid below.
-                          topOverlayInset: mapDayCount > 0
-                              ? MapDayChips.mapTopInset
-                              : 0,
-                          emptyLabel: _selectedDay == null
-                              ? l10n.sharedNoMappedPlaces
-                              : l10n.sharedNoPlacesOnDay(_selectedDay!),
-                          onPinTap: (pos) =>
-                              setState(() => _selectedPosition = pos),
-                        ),
-                      ),
-                      // Above the map's gesture layer, so chip taps and row
-                      // scrolls never pan the map.
-                      Positioned(
-                        top: 8,
-                        left: 8,
-                        right: 8,
-                        child: MapDayChips(
-                          dayCount: mapDayCount,
-                          selected: _selectedDay,
-                          mappedDays: mappedDays,
-                          onSelected: (d) =>
-                              setState(() => _selectedDay = d),
-                        ),
-                      ),
-                    ],
+                  Text(trip.title, style: theme.textTheme.headlineSmall),
+                  const SizedBox(height: AppSpacing.xs),
+                  Text(
+                    '${l10n.sharedBy(widget.shared.ownerName)}'
+                    '${dates != null ? ' · $dates' : ''}',
+                    style: theme.textTheme.bodyMedium
+                        ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
                   ),
-                ),
-              ),
-            ],
-            const SizedBox(height: AppSpacing.lg),
-            if (items.isEmpty)
-              EmptyState(
-                icon: Icons.place_outlined,
-                title: l10n.sharedEmptyTitle,
-                message: l10n.sharedEmptyMessage,
-              )
-            else
-              for (final group in _groups(l10n)) ...[
-                Padding(
-                  padding: const EdgeInsets.only(
-                      top: AppSpacing.md, bottom: AppSpacing.xs),
-                  child: Text(
-                    group.label,
-                    style: theme.textTheme.titleMedium
-                        ?.copyWith(color: theme.colorScheme.primary),
-                  ),
-                ),
-                for (final it in group.items)
-                  ListTile(
-                    contentPadding: EdgeInsets.zero,
-                    leading: CircleAvatar(
-                      radius: 14,
-                      backgroundColor:
-                          theme.colorScheme.primary.withValues(alpha: 0.12),
-                      child: Text(
-                        '${it.position + 1}',
-                        style: theme.textTheme.labelSmall
-                            ?.copyWith(color: theme.colorScheme.primary),
+                  if (trip.summary != null &&
+                      trip.summary!.trim().isNotEmpty) ...[
+                    const SizedBox(height: AppSpacing.md),
+                    Text(trip.summary!, style: theme.textTheme.bodyMedium),
+                  ],
+                  if (hasCoords) ...[
+                    const SizedBox(height: AppSpacing.lg),
+                    ClipRRect(
+                      borderRadius: AppRadius.lgAll,
+                      child: SizedBox(
+                        height: 240,
+                        child: Stack(
+                          children: [
+                            Positioned.fill(
+                              child: TripMap(
+                                items: dayItems,
+                                accommodations: dayStays,
+                                selectedPosition: _selectedPosition,
+                                fitSignature: _selectedDay,
+                                // Keep fitted markers clear of the chip row
+                                // overlaid below.
+                                topOverlayInset: mapDayCount > 0
+                                    ? MapDayChips.mapTopInset
+                                    : 0,
+                                emptyLabel: _selectedDay == null
+                                    ? l10n.sharedNoMappedPlaces
+                                    : l10n.sharedNoPlacesOnDay(_selectedDay!),
+                                onPinTap: (pos) =>
+                                    setState(() => _selectedPosition = pos),
+                              ),
+                            ),
+                            // Above the map's gesture layer, so chip taps and row
+                            // scrolls never pan the map.
+                            Positioned(
+                              top: 8,
+                              left: 8,
+                              right: 8,
+                              child: MapDayChips(
+                                dayCount: mapDayCount,
+                                selected: _selectedDay,
+                                mappedDays: mappedDays,
+                                onSelected: (d) =>
+                                    setState(() => _selectedDay = d),
+                              ),
+                            ),
+                          ],
+                        ),
                       ),
                     ),
-                    title: Text(it.name),
-                    subtitle: it.address != null ? Text(it.address!) : null,
-                    trailing: it.day != null
-                        ? Chip(
-                            label: Text(l10n.sharedDayN(it.day!)),
-                            visualDensity: VisualDensity.compact,
-                          )
-                        : null,
-                    selected: _selectedPosition == it.position,
-                    onTap: () =>
-                        setState(() => _selectedPosition = it.position),
-                  ),
-              ],
-            if ((trip.accommodations ?? const []).isNotEmpty) ...[
-              const SizedBox(height: AppSpacing.lg),
-              SectionHeader(title: l10n.sharedStays),
-              for (final a in trip.accommodations!)
-                ListTile(
-                  contentPadding: EdgeInsets.zero,
-                  leading: const Icon(Icons.hotel_outlined),
-                  title: Text(a.name),
-                  subtitle: a.address != null ? Text(a.address!) : null,
-                ),
-            ],
+                  ],
+                  const SizedBox(height: AppSpacing.lg),
+                  if (items.isEmpty)
+                    EmptyState(
+                      icon: Icons.place_outlined,
+                      title: l10n.sharedEmptyTitle,
+                      message: l10n.sharedEmptyMessage,
+                    )
+                  else
+                    for (final group in _groups(l10n)) ...[
+                      Padding(
+                        padding: const EdgeInsets.only(
+                            top: AppSpacing.md, bottom: AppSpacing.xs),
+                        // Same header treatment as the Stays section below — one
+                        // type system per screen.
+                        child: SectionHeader(title: group.label),
+                      ),
+                      for (final it in group.items)
+                        ListTile(
+                          contentPadding: EdgeInsets.zero,
+                          leading: CircleAvatar(
+                            radius: 14,
+                            backgroundColor: theme.colorScheme.primary
+                                .withValues(alpha: 0.12),
+                            child: Text(
+                              '${it.position + 1}',
+                              style: theme.textTheme.labelSmall
+                                  ?.copyWith(color: theme.colorScheme.primary),
+                            ),
+                          ),
+                          title: Text(it.name),
+                          subtitle:
+                              it.address != null ? Text(it.address!) : null,
+                          trailing: it.day != null
+                              ? Chip(
+                                  label: Text(l10n.sharedDayN(it.day!)),
+                                  visualDensity: VisualDensity.compact,
+                                )
+                              : null,
+                          selected: _selectedPosition == it.position,
+                          onTap: () =>
+                              setState(() => _selectedPosition = it.position),
+                        ),
+                    ],
+                  if ((trip.accommodations ?? const []).isNotEmpty) ...[
+                    const SizedBox(height: AppSpacing.lg),
+                    SectionHeader(title: l10n.sharedStays),
+                    for (final a in trip.accommodations!)
+                      ListTile(
+                        contentPadding: EdgeInsets.zero,
+                        leading: const Icon(Icons.hotel_outlined),
+                        title: Text(a.name),
+                        subtitle: a.address != null ? Text(a.address!) : null,
+                      ),
+                  ],
                 ],
               ),
             ),
@@ -371,56 +396,56 @@ class _SharedTripBodyState extends ConsumerState<_SharedTripBody> {
             child: SafeArea(
               child: PageContainer(
                 child: widget.shared.isEditorLink
-                  ? Column(
-                      mainAxisSize: MainAxisSize.min,
-                      crossAxisAlignment: CrossAxisAlignment.stretch,
-                      children: [
-                        FilledButton.icon(
-                          onPressed: _saving ? null : _joinAsCoPlanner,
-                          icon: _saving
-                              ? const SizedBox(
-                                  width: 16,
-                                  height: 16,
-                                  child:
-                                      CircularProgressIndicator(strokeWidth: 2),
-                                )
-                              : const Icon(Icons.group_add_outlined),
-                          label: Text(l10n.sharedJoinCoPlanner),
-                        ),
-                        // Invite tokens have no duplicate endpoint — they're
-                        // single-use join capabilities, not browse links.
-                        if (widget.linkKind == SharedLinkKind.share)
+                    ? Column(
+                        mainAxisSize: MainAxisSize.min,
+                        crossAxisAlignment: CrossAxisAlignment.stretch,
+                        children: [
+                          FilledButton.icon(
+                            onPressed: _saving ? null : _joinAsCoPlanner,
+                            icon: _saving
+                                ? const SizedBox(
+                                    width: 16,
+                                    height: 16,
+                                    child: CircularProgressIndicator(
+                                        strokeWidth: 2),
+                                  )
+                                : const Icon(Icons.group_add_outlined),
+                            label: Text(l10n.sharedJoinCoPlanner),
+                          ),
+                          // Invite tokens have no duplicate endpoint — they're
+                          // single-use join capabilities, not browse links.
+                          if (widget.linkKind == SharedLinkKind.share)
+                            TextButton(
+                              onPressed: _saving ? null : _saveCopy,
+                              child: Text(l10n.sharedSaveSeparateCopy),
+                            ),
+                        ],
+                      )
+                    : Column(
+                        mainAxisSize: MainAxisSize.min,
+                        crossAxisAlignment: CrossAxisAlignment.stretch,
+                        children: [
+                          // Viewer follow (specs/share-ux-viewer-follow): the
+                          // trip appears read-only in "Shared with you" and
+                          // stays current as the owner plans.
+                          FilledButton.icon(
+                            onPressed: _saving ? null : _joinAsCoPlanner,
+                            icon: _saving
+                                ? const SizedBox(
+                                    width: 16,
+                                    height: 16,
+                                    child: CircularProgressIndicator(
+                                        strokeWidth: 2),
+                                  )
+                                : const Icon(Icons.bookmark_add_outlined),
+                            label: Text(l10n.sharedKeepInTrips),
+                          ),
                           TextButton(
                             onPressed: _saving ? null : _saveCopy,
                             child: Text(l10n.sharedSaveSeparateCopy),
                           ),
-                      ],
-                    )
-                  : Column(
-                      mainAxisSize: MainAxisSize.min,
-                      crossAxisAlignment: CrossAxisAlignment.stretch,
-                      children: [
-                        // Viewer follow (specs/share-ux-viewer-follow): the
-                        // trip appears read-only in "Shared with you" and
-                        // stays current as the owner plans.
-                        FilledButton.icon(
-                          onPressed: _saving ? null : _joinAsCoPlanner,
-                          icon: _saving
-                              ? const SizedBox(
-                                  width: 16,
-                                  height: 16,
-                                  child:
-                                      CircularProgressIndicator(strokeWidth: 2),
-                                )
-                              : const Icon(Icons.bookmark_add_outlined),
-                          label: Text(l10n.sharedKeepInTrips),
-                        ),
-                        TextButton(
-                          onPressed: _saving ? null : _saveCopy,
-                          child: Text(l10n.sharedSaveSeparateCopy),
-                        ),
-                      ],
-                    ),
+                        ],
+                      ),
               ),
             ),
           ),

--- a/src/packages/flutter-app/lib/screens/trips_list_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trips_list_screen.dart
@@ -17,7 +17,6 @@ import '../models/chat_session.dart';
 import '../models/trip.dart';
 import '../providers/auth_provider.dart';
 import '../providers/live_trip_provider.dart';
-import '../providers/plan_provider.dart';
 import '../providers/resumable_chats_provider.dart';
 import '../providers/shared_with_me_provider.dart';
 import '../providers/trips_provider.dart';
@@ -50,14 +49,10 @@ class _TripsListScreenState extends ConsumerState<TripsListScreen> {
         const <ChatSessionSummary>[];
     // Watched before the guard branches: an account whose only trips are
     // shared-with-me must reach the list, not the plan-a-trip empty state.
+    // (The saved-trip graduation listen lives inside ContinueChatsSection —
+    // no duplicate listener here.)
     final sharedAsync = ref.watch(sharedWithMeProvider);
     final shared = sharedAsync.valueOrNull ?? const <Trip>[];
-
-    // A conversation that just produced a saved trip graduates out of the
-    // continue section — refetch when the agent reports a saved trip.
-    ref.listen(planProvider.select((s) => s.savedTripId), (prev, next) {
-      if (next != null && next != prev) ref.invalidate(resumableChatsProvider);
-    });
 
     Widget body;
     if ((state.loading || sharedAsync.isLoading) &&
@@ -132,21 +127,17 @@ class _TripsListScreenState extends ConsumerState<TripsListScreen> {
                     ),
                   // In-progress AI conversations that haven't produced a
                   // trip yet (specs/continue-where-you-left-off) — the
-                  // discussion phase, above the trips they may become.
-                  if (resumable.isNotEmpty) ...[
+                  // discussion phase, above the trips they may become. Same
+                  // shared section as Home; it collapses to nothing when
+                  // empty and already ends in an AppSpacing.lg gap, so the
+                  // My Trips header below needs no top padding of its own.
+                  const ContinueChatsSection(),
+                  if (resumable.isNotEmpty && state.trips.isNotEmpty)
                     Padding(
                       padding: const EdgeInsets.fromLTRB(
                           AppSpacing.xs, 0, 0, AppSpacing.sm),
-                      child: SectionHeader(title: l10n.continueChatsTitle),
+                      child: SectionHeader(title: l10n.tripsListTitle),
                     ),
-                    for (final c in resumable) ContinueChatCard(chat: c),
-                    if (state.trips.isNotEmpty)
-                      Padding(
-                        padding: const EdgeInsets.fromLTRB(
-                            AppSpacing.xs, AppSpacing.lg, 0, AppSpacing.sm),
-                        child: SectionHeader(title: l10n.tripsListTitle),
-                      ),
-                  ],
                   for (final t in state.trips)
                     _TripCard(trip: t, isAdmin: isAdmin),
                   // Trips others invited this user to co-plan. Kept as a

--- a/src/packages/flutter-app/lib/widgets/chat_panel.dart
+++ b/src/packages/flutter-app/lib/widgets/chat_panel.dart
@@ -274,7 +274,9 @@ class _ChatPanelState extends ConsumerState<ChatPanel> {
     final messages = ref.watch(widget.state.select((s) => s.messages));
     final isStreaming = ref.watch(widget.state.select((s) => s.isStreaming));
     final isEmpty = ref.watch(widget.state.select((s) =>
-        s.messages.isEmpty && s.streamingText == null && s.queuedMessages.isEmpty));
+        s.messages.isEmpty &&
+        s.streamingText == null &&
+        s.queuedMessages.isEmpty));
 
     ref.listen(widget.state.select((s) => s.streamingText),
         (_, __) => _scrollToBottom());
@@ -283,82 +285,92 @@ class _ChatPanelState extends ConsumerState<ChatPanel> {
     ref.listen(widget.state.select((s) => s.queuedMessages.length),
         (_, __) => _scrollToBottom());
 
-    final panel = Column(
-      children: [
-        Expanded(
-          child: isEmpty
-              ? (widget.emptyState ?? const SizedBox.shrink())
-              : NotificationListener<ScrollNotification>(
-                  onNotification: _onScrollNotification,
-                  child: ListView.builder(
-                    controller: _scrollController,
-                    padding: const EdgeInsets.symmetric(
-                        horizontal: AppSpacing.lg, vertical: AppSpacing.md),
-                    itemCount: messages.length + 1,
-                    itemBuilder: (context, i) {
-                      if (i < messages.length) {
-                        final msg = messages[i];
-                        // Labeled messages (e.g. the machine-built refine
-                        // seed) collapse to a context chip; the full content
-                        // still went to the server history.
-                        if (msg.displayLabel != null) {
-                          return _SeedContextChip(
+    // LayoutBuilder (house rule: widths computed from the panel's own
+    // constraints): the bubble cap must track the surface the panel actually
+    // occupies — the 400px refine dock and the 760px agent column — not the
+    // window, or dock bubbles run the full dock width on desktop.
+    return LayoutBuilder(builder: (context, constraints) {
+      final bubbleMaxWidth = _bubbleMaxWidthFor(constraints.maxWidth);
+      final panel = Column(
+        children: [
+          Expanded(
+            child: isEmpty
+                ? (widget.emptyState ?? const SizedBox.shrink())
+                : NotificationListener<ScrollNotification>(
+                    onNotification: _onScrollNotification,
+                    child: ListView.builder(
+                      controller: _scrollController,
+                      padding: const EdgeInsets.symmetric(
+                          horizontal: AppSpacing.lg, vertical: AppSpacing.md),
+                      itemCount: messages.length + 1,
+                      itemBuilder: (context, i) {
+                        if (i < messages.length) {
+                          final msg = messages[i];
+                          // Labeled messages (e.g. the machine-built refine
+                          // seed) collapse to a context chip; the full content
+                          // still went to the server history.
+                          if (msg.displayLabel != null) {
+                            return _SeedContextChip(
+                              key: ValueKey('msg-$i'),
+                              label: msg.displayLabel!,
+                            );
+                          }
+                          // Append-only list, so index keys are stable.
+                          return ChatMessageBubble(
                             key: ValueKey('msg-$i'),
-                            label: msg.displayLabel!,
+                            message: msg,
+                            maxWidth: bubbleMaxWidth,
                           );
                         }
-                        // Append-only list, so index keys are stable.
-                        return ChatMessageBubble(
-                          key: ValueKey('msg-$i'),
-                          message: msg,
+                        return _ChatTail(
+                          key: const ValueKey('chat-tail'),
+                          state: widget.state,
+                          notifier: widget.notifier,
+                          footerBuilder: widget.footerBuilder,
+                          onViewTrip: widget.onViewTrip,
+                          bubbleMaxWidth: bubbleMaxWidth,
                         );
-                      }
-                      return _ChatTail(
-                        key: const ValueKey('chat-tail'),
-                        state: widget.state,
-                        notifier: widget.notifier,
-                        footerBuilder: widget.footerBuilder,
-                        onViewTrip: widget.onViewTrip,
-                      );
-                    },
+                      },
+                    ),
                   ),
-                ),
-        ),
-        if (_pending.isNotEmpty || _processingCount > 0)
-          _PendingAttachmentsRow(
-            pending: _pending,
-            processingCount: _processingCount,
-            onRemove: (i) => setState(() => _pending.removeAt(i)),
           ),
-        _InputBar(
-          controller: _controller,
-          focusNode: _inputFocus,
-          isStreaming: isStreaming,
-          hint: widget.inputHint ?? context.l10n.chatInputHint,
-          onSend: _send,
-          onAttach: _pickImages,
-          dictation: _dictation,
-        ),
-      ],
-    );
-
-    // DropTarget is a no-op on platforms without drag-drop (mobile), so the
-    // wrap is unconditional. The overlay invites the drop while a drag hovers.
-    return DropTarget(
-      onDragEntered: (_) => setState(() => _dragging = true),
-      onDragExited: (_) => setState(() => _dragging = false),
-      onDragDone: (detail) {
-        setState(() => _dragging = false);
-        _onDragDone(detail);
-      },
-      child: Stack(
-        fit: StackFit.expand,
-        children: [
-          panel,
-          if (_dragging) const _DropOverlay(),
+          if (_pending.isNotEmpty || _processingCount > 0)
+            _PendingAttachmentsRow(
+              pending: _pending,
+              processingCount: _processingCount,
+              onRemove: (i) => setState(() => _pending.removeAt(i)),
+            ),
+          _InputBar(
+            controller: _controller,
+            focusNode: _inputFocus,
+            isStreaming: isStreaming,
+            hint: widget.inputHint ?? context.l10n.chatInputHint,
+            onSend: _send,
+            onAttach: _pickImages,
+            dictation: _dictation,
+          ),
         ],
-      ),
-    );
+      );
+
+      // DropTarget is a no-op on platforms without drag-drop (mobile), so the
+      // wrap is unconditional. The overlay invites the drop while a drag
+      // hovers.
+      return DropTarget(
+        onDragEntered: (_) => setState(() => _dragging = true),
+        onDragExited: (_) => setState(() => _dragging = false),
+        onDragDone: (detail) {
+          setState(() => _dragging = false);
+          _onDragDone(detail);
+        },
+        child: Stack(
+          fit: StackFit.expand,
+          children: [
+            panel,
+            if (_dragging) const _DropOverlay(),
+          ],
+        ),
+      );
+    });
   }
 }
 
@@ -443,23 +455,34 @@ class _PendingAttachmentsRow extends StatelessWidget {
                         ),
                       ),
                     ),
+                    // ≥ kMinTouchTarget hit box; the visible badge stays
+                    // small and pinned to the thumbnail corner via the
+                    // topRight alignment.
                     Positioned(
                       top: 0,
                       right: 0,
                       child: Semantics(
                         button: true,
                         label: context.l10n.chatRemoveImage,
-                        child: InkWell(
-                          onTap: () => onRemove(i),
-                          child: Container(
-                            decoration: BoxDecoration(
-                              color: theme.colorScheme.inverseSurface,
-                              shape: BoxShape.circle,
+                        child: SizedBox(
+                          width: kMinTouchTarget,
+                          height: kMinTouchTarget,
+                          child: InkWell(
+                            onTap: () => onRemove(i),
+                            customBorder: const CircleBorder(),
+                            child: Align(
+                              alignment: Alignment.topRight,
+                              child: Container(
+                                decoration: BoxDecoration(
+                                  color: theme.colorScheme.inverseSurface,
+                                  shape: BoxShape.circle,
+                                ),
+                                padding: const EdgeInsets.all(2),
+                                child: Icon(Icons.close,
+                                    size: 12,
+                                    color: theme.colorScheme.onInverseSurface),
+                              ),
                             ),
-                            padding: const EdgeInsets.all(2),
-                            child: Icon(Icons.close,
-                                size: 12,
-                                color: theme.colorScheme.onInverseSurface),
                           ),
                         ),
                       ),
@@ -501,6 +524,7 @@ class _ChatTail extends StatelessWidget {
   final ProviderListenable<PlanNotifier> notifier;
   final Widget Function(BuildContext context, PlanState state)? footerBuilder;
   final void Function(String tripId)? onViewTrip;
+  final double bubbleMaxWidth;
 
   const _ChatTail({
     super.key,
@@ -508,6 +532,7 @@ class _ChatTail extends StatelessWidget {
     required this.notifier,
     required this.footerBuilder,
     required this.onViewTrip,
+    required this.bubbleMaxWidth,
   });
 
   @override
@@ -518,7 +543,7 @@ class _ChatTail extends StatelessWidget {
         // Compaction runs before the model call, so its chip leads the tail.
         _CompactingChip(state: state),
         _TypingIndicatorBubble(state: state),
-        _StreamingBubble(state: state),
+        _StreamingBubble(state: state, maxWidth: bubbleMaxWidth),
         _ActiveToolChips(state: state),
         _ProfileNoteChip(state: state),
         _ItineraryUpdatedChip(state: state),
@@ -529,7 +554,11 @@ class _ChatTail extends StatelessWidget {
         _ErrorBanner(state: state, notifier: notifier),
         // Last: queued messages read as "up next", below the current turn and
         // any error it produced.
-        _QueuedMessages(state: state, notifier: notifier),
+        _QueuedMessages(
+          state: state,
+          notifier: notifier,
+          bubbleMaxWidth: bubbleMaxWidth,
+        ),
       ],
     );
   }
@@ -537,8 +566,9 @@ class _ChatTail extends StatelessWidget {
 
 class _StreamingBubble extends ConsumerWidget {
   final ProviderListenable<PlanState> state;
+  final double maxWidth;
 
-  const _StreamingBubble({required this.state});
+  const _StreamingBubble({required this.state, required this.maxWidth});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -547,6 +577,7 @@ class _StreamingBubble extends ConsumerWidget {
     return ChatMessageBubble(
       message: PlanMessage(role: MessageRole.assistant, content: text),
       isStreaming: true,
+      maxWidth: maxWidth,
     );
   }
 }
@@ -607,8 +638,8 @@ class _TypingDotsBubbleState extends State<_TypingDotsBubble>
       alignment: Alignment.centerLeft,
       child: Container(
         margin: const EdgeInsets.symmetric(vertical: AppSpacing.xs),
-        padding: const EdgeInsets.symmetric(
-            horizontal: 14, vertical: AppSpacing.md),
+        padding:
+            const EdgeInsets.symmetric(horizontal: 14, vertical: AppSpacing.md),
         decoration: BoxDecoration(
           color: theme.colorScheme.surfaceContainerHighest,
           borderRadius: const BorderRadius.only(
@@ -909,8 +940,8 @@ class _ResultChips extends ConsumerWidget {
         ResultSummaryChip(
           icon: Icons.directions_boat,
           accent: AppColors.toolFerries,
-          label: label(
-              l10n.chatChipFerryOptions(r.ferries!.length), r.ferryRoute),
+          label:
+              label(l10n.chatChipFerryOptions(r.ferries!.length), r.ferryRoute),
           onTap: onTap,
         ),
       if (r.eventLinks != null && r.eventLinks!.isNotEmpty)
@@ -926,7 +957,8 @@ class _ResultChips extends ConsumerWidget {
     if (chips.isEmpty) return const SizedBox.shrink();
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: AppSpacing.xs),
-      child: Column(crossAxisAlignment: CrossAxisAlignment.start, children: chips),
+      child:
+          Column(crossAxisAlignment: CrossAxisAlignment.start, children: chips),
     );
   }
 }
@@ -1002,8 +1034,8 @@ class _ErrorBanner extends ConsumerWidget {
     if (error == null) return const SizedBox.shrink();
     // Narrow derived select: retry only makes sense once a user turn exists
     // for [PlanNotifier.retryLastSend] to re-run.
-    final canRetry = ref.watch(state
-        .select((s) => s.messages.any((m) => m.role == MessageRole.user)));
+    final canRetry = ref.watch(
+        state.select((s) => s.messages.any((m) => m.role == MessageRole.user)));
     final theme = Theme.of(context);
     return Container(
       margin: const EdgeInsets.symmetric(vertical: AppSpacing.sm),
@@ -1043,8 +1075,13 @@ class _ErrorBanner extends ConsumerWidget {
 class _QueuedMessages extends ConsumerWidget {
   final ProviderListenable<PlanState> state;
   final ProviderListenable<PlanNotifier> notifier;
+  final double bubbleMaxWidth;
 
-  const _QueuedMessages({required this.state, required this.notifier});
+  const _QueuedMessages({
+    required this.state,
+    required this.notifier,
+    required this.bubbleMaxWidth,
+  });
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -1058,6 +1095,7 @@ class _QueuedMessages extends ConsumerWidget {
           _QueuedBubble(
             key: ValueKey('queued-${m.id}'),
             message: m,
+            maxWidth: bubbleMaxWidth,
             onRemove: () => ref.read(notifier).removeQueued(m.id),
           ),
       ],
@@ -1067,9 +1105,15 @@ class _QueuedMessages extends ConsumerWidget {
 
 class _QueuedBubble extends StatelessWidget {
   final QueuedMessage message;
+  final double maxWidth;
   final VoidCallback onRemove;
 
-  const _QueuedBubble({super.key, required this.message, required this.onRemove});
+  const _QueuedBubble({
+    super.key,
+    required this.message,
+    required this.maxWidth,
+    required this.onRemove,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -1079,7 +1123,7 @@ class _QueuedBubble extends StatelessWidget {
       child: Container(
         margin: const EdgeInsets.symmetric(vertical: AppSpacing.xs),
         padding: const EdgeInsets.fromLTRB(14, 6, 6, 6),
-        constraints: BoxConstraints(maxWidth: _bubbleMaxWidth(context)),
+        constraints: BoxConstraints(maxWidth: maxWidth),
         decoration: BoxDecoration(
           color: theme.colorScheme.primary.withValues(alpha: 0.45),
           borderRadius: const BorderRadius.only(
@@ -1133,18 +1177,28 @@ class _QueuedBubble extends StatelessWidget {
   }
 }
 
-/// Bubbles span 78% of the window on phones but cap at a readable measure on
-/// wide desktop windows.
+/// Bubbles span 78% of the hosting panel's width but cap at a readable
+/// measure on wide panels. Derived from the panel's own LayoutBuilder
+/// constraints — never the window — so the 400px refine dock and the 760px
+/// agent column both keep the ragged 78% edge.
 const double _kBubbleMaxWidth = 720;
 
-double _bubbleMaxWidth(BuildContext context) =>
-    min(MediaQuery.of(context).size.width * 0.78, _kBubbleMaxWidth);
+double _bubbleMaxWidthFor(double panelWidth) =>
+    min(panelWidth * 0.78, _kBubbleMaxWidth);
 
 class ChatMessageBubble extends StatelessWidget {
   final PlanMessage message;
   final bool isStreaming;
 
-  const ChatMessageBubble({super.key, required this.message, this.isStreaming = false});
+  /// Cap for the bubble, computed by the hosting panel from its own width.
+  final double maxWidth;
+
+  const ChatMessageBubble({
+    super.key,
+    required this.message,
+    required this.maxWidth,
+    this.isStreaming = false,
+  });
 
   Future<void> _openLink(BuildContext context, String url) async {
     final uri = Uri.tryParse(url);
@@ -1169,7 +1223,7 @@ class ChatMessageBubble extends StatelessWidget {
       child: Container(
         margin: const EdgeInsets.symmetric(vertical: AppSpacing.xs),
         padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
-        constraints: BoxConstraints(maxWidth: _bubbleMaxWidth(context)),
+        constraints: BoxConstraints(maxWidth: maxWidth),
         decoration: BoxDecoration(
           color: isUser
               ? theme.colorScheme.primary
@@ -1250,8 +1304,7 @@ class _BubbleAttachments extends StatelessWidget {
             )
           else
             Container(
-              padding:
-                  const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
+              padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
               decoration: BoxDecoration(
                 color: theme.colorScheme.onPrimary.withValues(alpha: 0.15),
                 borderRadius: BorderRadius.circular(10),
@@ -1377,6 +1430,7 @@ class _InputBar extends StatelessWidget {
           _MicButton(dictation: dictation),
           const SizedBox(width: AppSpacing.sm),
           IconButton.filled(
+            tooltip: context.l10n.chatSend,
             onPressed: onSend,
             icon: const Icon(Icons.send),
           ),

--- a/src/packages/flutter-app/test/chat_panel_bubble_width_test.dart
+++ b/src/packages/flutter-app/test/chat_panel_bubble_width_test.dart
@@ -11,9 +11,10 @@ import 'package:travel_route_planner/widgets/result_summary_chip.dart';
 
 import 'support/l10n_test_app.dart';
 
-/// Chat bubbles span 78% of the window on phones but cap at 720px on wide
-/// desktop windows, keeping line lengths readable. Plus the es spot-check for
-/// the result chip's newly localized "View in trip" label.
+/// Chat bubbles span 78% of the hosting panel's own width — not the window —
+/// capping at 720px on wide panels, keeping line lengths readable. Covers the
+/// full-width phone/desktop hosts plus the 400px refine-dock host. Plus the
+/// es spot-check for the result chip's newly localized "View in trip" label.
 
 class _SeededPlanNotifier extends PlanNotifier {
   _SeededPlanNotifier(PlanState seeded)
@@ -22,7 +23,11 @@ class _SeededPlanNotifier extends PlanNotifier {
   }
 }
 
-Future<void> _pumpLongMessageAt(WidgetTester tester, Size logicalSize) async {
+Future<void> _pumpLongMessageAt(
+  WidgetTester tester,
+  Size logicalSize, {
+  double? hostWidth,
+}) async {
   tester.view.physicalSize = logicalSize;
   tester.view.devicePixelRatio = 1.0;
   addTearDown(tester.view.resetPhysicalSize);
@@ -33,12 +38,19 @@ Future<void> _pumpLongMessageAt(WidgetTester tester, Size logicalSize) async {
   ]);
   final provider = StateNotifierProvider<PlanNotifier, PlanState>(
       (ref) => _SeededPlanNotifier(seeded));
+  Widget panel = ChatPanel(state: provider, notifier: provider.notifier);
+  if (hostWidth != null) {
+    // Mimics the trip-detail refine dock: a fixed-width panel pinned to the
+    // right edge of a much wider window.
+    panel = Align(
+      alignment: Alignment.centerRight,
+      child: SizedBox(width: hostWidth, child: panel),
+    );
+  }
   await tester.pumpWidget(
     ProviderScope(
       child: localizedTestApp(
-        home: Scaffold(
-          body: ChatPanel(state: provider, notifier: provider.notifier),
-        ),
+        home: Scaffold(body: panel),
       ),
     ),
   );
@@ -66,6 +78,15 @@ void main() {
   testWidgets('bubbles keep the 78% constraint on narrow screens',
       (WidgetTester tester) async {
     await _pumpLongMessageAt(tester, const Size(400, 800));
+    expect(_bubbleMaxWidth(tester), closeTo(312, 0.01));
+  });
+
+  testWidgets('bubbles size to the hosting panel, not the window (400px dock)',
+      (WidgetTester tester) async {
+    await _pumpLongMessageAt(tester, const Size(1200, 900), hostWidth: 400);
+    // 0.78 × the dock's own 400px — were the cap still window-derived,
+    // 0.78 × 1200 would blow past the dock and clamp bubbles to its full
+    // width (the pre-fix regression).
     expect(_bubbleMaxWidth(tester), closeTo(312, 0.01));
   });
 

--- a/src/packages/flutter-app/test/home_polish_test.dart
+++ b/src/packages/flutter-app/test/home_polish_test.dart
@@ -1,0 +1,146 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:travel_route_planner/constants/app_info.dart';
+import 'package:travel_route_planner/models/trip.dart';
+import 'package:travel_route_planner/models/user.dart';
+import 'package:travel_route_planner/providers/auth_provider.dart';
+import 'package:travel_route_planner/providers/live_trip_provider.dart';
+import 'package:travel_route_planner/providers/resumable_chats_provider.dart';
+import 'package:travel_route_planner/screens/home_screen.dart';
+import 'package:travel_route_planner/widgets/brand_logo.dart';
+
+import 'support/l10n_test_app.dart';
+
+/// Home polish regressions (UI polish wave 2, PR 9):
+/// - the app bar drops the wordmark for the brand mark alone on narrow
+///   phones instead of ellipsizing the brand ("Golden Tempo Tra…");
+/// - the compact plan strip's tagline wraps to two lines instead of
+///   truncating ("Plan less. Trav…").
+class _FakeAuthNotifier extends StateNotifier<AuthState>
+    implements AuthNotifier {
+  _FakeAuthNotifier(UserModel? user)
+      : super(AuthState(user: user, initialized: true));
+
+  @override
+  void clearError() => state = state.copyWith(clearError: true);
+
+  @override
+  Future<bool> login(String email, String password) async => false;
+
+  @override
+  Future<bool> register(String email, String password,
+          {String? displayName}) async =>
+      false;
+
+  @override
+  Future<void> completeOnboarding() async {}
+
+  @override
+  Future<void> logout() async {}
+
+  @override
+  Future<void> signOutLocally() async {}
+
+  @override
+  void setUser(UserModel user) {}
+
+  @override
+  Future<void> adoptSession(String token, UserModel user) async {}
+}
+
+UserModel _user() => UserModel(
+      id: 'user-1',
+      email: 'test@example.com',
+      displayName: 'Brian',
+      createdAt: DateTime(2026, 1, 1),
+    );
+
+String _iso(DateTime d) => '${d.year.toString().padLeft(4, '0')}-'
+    '${d.month.toString().padLeft(2, '0')}-'
+    '${d.day.toString().padLeft(2, '0')}';
+
+Trip _liveTrip() => Trip(
+      id: 't1',
+      title: 'Athens Trip',
+      status: 'planned',
+      startDate: _iso(DateTime.now().subtract(const Duration(days: 1))),
+      endDate: _iso(DateTime.now().add(const Duration(days: 1))),
+      createdAt: '2026-06-01',
+      updatedAt: '2026-06-01',
+    );
+
+Future<void> _pumpHome(
+  WidgetTester tester, {
+  Trip? liveTrip,
+  Size? surface,
+  Locale? locale,
+}) async {
+  if (surface != null) {
+    // physicalSize (not setSurfaceSize): the app bar's AccountMenu gates on
+    // MediaQuery width, which setSurfaceSize does not update.
+    tester.view.physicalSize = surface;
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+  }
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        authProvider.overrideWith((ref) => _FakeAuthNotifier(_user())),
+        liveTripProvider.overrideWithValue(liveTrip),
+        resumableChatsProvider.overrideWith((ref) async => const []),
+      ],
+      child: localizedTestApp(locale: locale, home: const HomeScreen()),
+    ),
+  );
+  // Extra pumps flush the SharedPreferences read behind recentTripProvider
+  // and the resumable-chats future.
+  await tester.pump();
+  await tester.pump();
+}
+
+void main() {
+  setUp(() => SharedPreferences.setMockInitialValues({}));
+
+  testWidgets(
+      'narrow app bar shows the brand mark only — no ellipsized '
+      'wordmark', (WidgetTester tester) async {
+    await _pumpHome(tester, surface: const Size(360, 690));
+
+    expect(find.text(AppInfo.name), findsNothing);
+    expect(find.byType(BrandLogo), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('wide app bar keeps the full wordmark',
+      (WidgetTester tester) async {
+    await _pumpHome(tester, surface: const Size(1200, 800));
+
+    expect(find.text(AppInfo.name), findsOneWidget);
+    expect(find.byType(BrandLogo), findsOneWidget);
+  });
+
+  testWidgets(
+      'plan-strip tagline may wrap to two lines instead of '
+      'truncating', (WidgetTester tester) async {
+    await _pumpHome(tester,
+        liveTrip: _liveTrip(), surface: const Size(360, 690));
+
+    final tagline = tester.widget<Text>(find.text('Plan less. Travel more.'));
+    expect(tagline.maxLines, 2);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('overflow floor: home with the plan strip at 360x690 in es',
+      (WidgetTester tester) async {
+    await _pumpHome(tester,
+        liveTrip: _liveTrip(),
+        surface: const Size(360, 690),
+        locale: const Locale('es'));
+
+    expect(tester.takeException(), isNull);
+  });
+}

--- a/src/packages/flutter-app/test/shared_trip_action_bar_test.dart
+++ b/src/packages/flutter-app/test/shared_trip_action_bar_test.dart
@@ -1,0 +1,83 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:travel_route_planner/models/accommodation.dart';
+import 'package:travel_route_planner/models/itinerary_item.dart';
+import 'package:travel_route_planner/models/shared_trip.dart';
+import 'package:travel_route_planner/models/trip.dart';
+import 'package:travel_route_planner/providers/trips_provider.dart';
+import 'package:travel_route_planner/screens/shared_trip_screen.dart';
+import 'package:travel_route_planner/services/api_client.dart';
+import 'package:travel_route_planner/services/trips_api_service.dart';
+
+import 'support/l10n_test_app.dart';
+
+/// The shared-trip list must reserve enough bottom padding for the pinned
+/// action bar (which is opaque): scrolled to the end, the last row has to sit
+/// fully above the bar, not hidden behind it.
+class _FakeTripsApiService extends TripsApiService {
+  final SharedTrip shared;
+  _FakeTripsApiService(this.shared) : super(ApiClient(baseUrl: 'http://test'));
+
+  @override
+  Future<SharedTrip> getSharedTrip(String token) async => shared;
+}
+
+Trip _trip() => Trip(
+      id: 't1',
+      title: 'Lisbon long weekend',
+      status: 'planned',
+      createdAt: '2026-06-01',
+      updatedAt: '2026-06-01',
+      items: [
+        for (var i = 0; i < 12; i++)
+          ItineraryItem(
+            id: 'i$i',
+            position: i,
+            name: 'Stop number $i',
+            address: 'Address $i, Lisboa',
+            latitude: 0,
+            longitude: 0,
+            category: 'attraction',
+            day: 1 + i ~/ 4,
+            city: 'Lisboa',
+          ),
+      ],
+      accommodations: const [
+        Accommodation(id: 'a1', name: 'Alfama Guesthouse'),
+      ],
+    );
+
+void main() {
+  testWidgets('last row scrolls fully above the pinned action bar on a phone',
+      (tester) async {
+    await tester.binding.setSurfaceSize(const Size(390, 844));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          tripsApiServiceProvider.overrideWithValue(_FakeTripsApiService(
+              SharedTrip(trip: _trip(), ownerName: 'Ann'))),
+        ],
+        child: MaterialApp(
+            localizationsDelegates: testLocalizationsDelegates,
+            home: const SharedTripScreen(token: 'tok')),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // Scroll to the very end (clamping physics stop at maxScrollExtent).
+    await tester.drag(find.byType(ListView), const Offset(0, -4000));
+    await tester.pumpAndSettle();
+
+    // The bar's top edge: its primary button minus the container padding
+    // above it (AppSpacing.md = 12).
+    final barTop =
+        tester.getTopLeft(find.bySubtype<FilledButton>().first).dy - 12;
+    final lastRow = find.widgetWithText(ListTile, 'Alfama Guesthouse');
+    expect(lastRow, findsOneWidget);
+    expect(tester.getBottomLeft(lastRow).dy, lessThanOrEqualTo(barTop));
+    expect(tester.takeException(), isNull);
+  });
+}


### PR DESCRIPTION
Chat bubbles now cap from the panel's own width (the 400px refine dock rendered window-sized bubbles); shared trip's last row can scroll clear of the pinned action bar; the trips list's hand-rolled continue-chats section is replaced by the shared widget (removing a duplicated provider listen); Home's narrow app bar shows the brand mark instead of a truncated wordmark and the plan-strip tagline wraps instead of ellipsizing; home adopts the wave's shadow/spacing tokens.

Tests: 400px-dock bubble case, narrow-brand + tagline-wrap, shared-trip clearance; full suite 534 green post-rebase.

Part of UI polish wave 2. 🤖 Generated with [Claude Code](https://claude.com/claude-code)