### PR TITLE
Import a trip from an external AI chat (API)

### DIFF
--- a/specs/import-trip-from-ai-chat/plan.md
+++ b/specs/import-trip-from-ai-chat/plan.md
@@ -1,0 +1,131 @@
+# Plan: Import a trip from an external AI chat
+
+## Technical Approach
+
+```
+paste text ──POST /trips/import──▶ importTripHandler
+                                        │
+                                        ▼
+                          importTripCore (trip_import_service.go)
+                            1. truncateForImport (head 10k + tail 50k)
+                            2. extractImportedTrip — ONE forced-tool Claude call
+                               (Sonnet 4.6, ToolChoice=import_trip, 120s)
+                            3. resolveImportedLocations — Google Places per place
+                               (≤50 lookups; verified / approximate / dropped)
+                            4. persistTrip(userID, "chat-<token>", …)
+                            5. analytics (trip_created + trip_imported)
+                                        │
+                                        ▼
+                     201 {trip_id, title, item_count, warnings[]}
+```
+
+Design decisions:
+- **Sonnet 4.6, not Haiku**: one-shot user-visible result with no chat loop to
+  repair it; the agent already emits this exact location shape on Sonnet 4.6.
+  ~$0.07 typical / ≤$0.17 worst case. Model is a file-level const for a later
+  Haiku downgrade once eval fixtures exist.
+- **Head+tail truncation** (not head-only like local ingest): destination and
+  dates live at the start of a conversation, the final itinerary at the end.
+- **Tiered coordinates**: Google hit → verified; miss but plausible model
+  coords (range-checked, not (0,0)) → kept + "approximate" warning; neither →
+  dropped + warning. Degraded (no `GOOGLE_PLACES_API_KEY`): everything rides
+  the model tier + one aggregate warning. `itinerary_items.latitude/longitude`
+  are NOT NULL, and a (0,0) pin ruins the map; but failing the whole import in
+  degraded mode would be worse. Unlike the local-content publish gate this is
+  the user's own private trip, so approximate+flagged is acceptable.
+- **chat_id yes, plan_chat_sessions row no**: `trips.chat_id` alone makes
+  refine-in-chat work (plan_handler binds by chat_id) and keeps the trip out of
+  the resumable-chats list (`NOT EXISTS trips.chat_id` filter); the first
+  refine turn upserts the session row naturally.
+- **Warnings localized server-side** via the existing `tr()` catalog
+  (`import.*` keys, en+es) since they are displayed verbatim.
+
+## Go API Changes
+
+### Routes
+- `POST /api/v1/trips/import` — `strict(authMiddleware(importTripHandler))`
+  (each request = 1 Claude call + ≤50 Places calls; deliberate rare action,
+  same tier as `/trips/{id}/refine`).
+- `bodyLimitMiddleware`: new `/api/v1/trips/import` lane at 2 MiB
+  (`importMaxRequestBodyBytes`) — long transcripts blow the 256 KiB default.
+
+### New files
+- `trip_import_service.go` — constants (`importToolName`, `importTimeout=120s`,
+  `importMaxChars=60000`, `importHeadChars=10000`, `importMaxLocations=80`,
+  `importMaxPlaceLookups=50`, `importModel`), `ImportedTrip`/`ImportedLocation`
+  structs, `truncateForImport`, `extractImportedTrip` (forced-tool call
+  mirroring `extractLocalContent`), `plausibleCoords`, `resolveImportedLocations`
+  (Places loop mirroring `ingestLocalHandler` stage 3, reusing `placeQuery`),
+  `importTripCore` (the unit Track 2's MCP `create_trip` tool will reuse).
+- `trip_import_handler.go` — decode/validate, `newAnthropicClient`, call core,
+  map typed errors to 422/502, respond 201.
+
+### Reused
+`persistTrip`, `placeQuery`, `placesService.SearchPlaces`,
+`generateSessionToken` (chat token), `itemParamsFromLocation` (inside
+persistTrip), `recordEvent`/`recordActiveTripsCapSignal`/`safeGo`,
+`newAnthropicClient` (keeps the `ANTHROPIC_BASE_URL` fake seam), `tr()`.
+
+### Tool schema (model-facing)
+Envelope: `title`*, `summary`, `start_date`/`end_date` (YYYY-MM-DD, only if
+stated), `travel_mode` (enum flight|car|train|bus|ferry|mixed);
+`locations[]`*: `name`*, `city`*, `search_hint`*, `day` (1-based int),
+`time_of_day` (morning|afternoon|evening), `category` (attraction|restaurant),
+`day_trip_from`, `latitude`/`longitude` (approximate, only if confident).
+Grounding prompt: ONLY places named in the text; call the tool exactly once;
+empty locations when no trip is present.
+
+## Flutter Changes
+
+### Models
+`lib/models/import_trip_result.dart` — `@JsonSerializable`
+(`trip_id`, `title`, `item_count`, `warnings`) → `make flutter-build-models`.
+
+### Service
+`trips_api_service.dart`: `importTrip(String text, {String? source})` →
+`ImportTripResult` (template: `duplicateSharedTrip`).
+
+### Provider
+`lib/providers/import_trip_provider.dart` — StateNotifier: idle → importing →
+success(result)/error(message); invalidates `tripsProvider` on success.
+
+### Screens
+`lib/screens/import_trip_screen.dart` — explainer + copy-prompt button +
+paste field (`maxLines: null`) + import button + staged progress + error state.
+Entry points: Trips list app-bar `IconButton` and empty-state action.
+Planning prompt text = ARB constant (en+es), asks for a final "TRIP SUMMARY"
+(Day N — City; Morning/Afternoon/Evening entries as "Place — City"; dates;
+day trips; inter-city travel mode).
+
+## Contract Parity
+
+| JSON key | Go type | Dart type | Nullable? | ✓ |
+|---|---|---|---|---|
+| trip_id | string | String | no | ✓ |
+| title | string | String | no | ✓ |
+| item_count | int | int | no | ✓ |
+| warnings | []string | List<String> | no (may be empty) | ✓ |
+| text (req) | string | String | no | ✓ |
+| source (req) | string | String? | yes | ✓ |
+
+## Cross-cutting
+
+- No new env vars; behavior with missing `ANTHROPIC_API_KEY` (503) and missing
+  `GOOGLE_PLACES_API_KEY` (degraded, warnings) documented in spec.
+- nginx: no change (`client_max_body_size` already ≥ 20 MiB).
+- Server i18n: new `import.*` keys in the `messages` catalog (i18n.go), en+es.
+
+## Verification
+
+- `trip_import_test.go` (pure): truncation head+tail behavior, coordinate
+  plausibility check.
+- `trip_import_integration_test.go` (Postgres + fake Anthropic via
+  `newFakeAnthropic(t).scriptNonStreamingTool("import_trip", …)` + fake Places
+  via `swapPlacesService` with a canned-JSON RoundTripper): happy path rows +
+  chat_id + coercion; approximate-kept warning; dropped warning; degraded
+  no-key mode; empty text 400; no-trip 422; unauth 401; trip cap 422;
+  resumable-chats unaffected; analytics rows; oversized-input truncation.
+- `make api-fmt && make api-vet && make api-test`.
+- Manual: `make docker-dev`, real keys — copy prompt → ChatGPT → paste →
+  verify map/day rendering, warnings, refine-in-chat binding, item editing,
+  second import creates a separate lineage.

--- a/specs/import-trip-from-ai-chat/spec.md
+++ b/specs/import-trip-from-ai-chat/spec.md
@@ -1,0 +1,108 @@
+# Import a trip from an external AI chat
+
+## Context
+
+Travelers increasingly plan trips in ChatGPT or Claude — long, rich conversations
+on their own subscriptions. Today none of that work can enter Golden Tempo except
+by re-planning from scratch in the in-app agent, which costs us $1–5 of Anthropic
+spend per session (docs/business-model.md). This feature lets a user paste the
+conversation (or its final summary) into Golden Tempo, where **one** cheap
+forced-tool extraction call turns it into a real, editable trip. The user's own
+AI subscription paid for the thinking; we pay cents for the structuring.
+
+This is Track 1 of the external-AI plan. Its core pipeline
+(extract → resolve coordinates → persist) is deliberately reusable by Track 2
+(the ChatGPT/claude.ai MCP connector, specs/mcp-connector, future).
+
+## User Stories
+
+- As a traveler who planned a trip in ChatGPT, I paste the conversation into
+  Golden Tempo and get a full trip — days, cities, places on the map — that I
+  can edit like any other trip.
+- As a traveler about to start planning in ChatGPT, I copy a "planning prompt"
+  from Golden Tempo first, so my ChatGPT conversation ends with a summary the
+  importer parses reliably.
+- As the same traveler, when some pasted place can't be found on the map, I see
+  which ones need attention instead of silently losing them.
+
+## Acceptance Criteria
+
+- [ ] A signed-in user can paste text at an "Import from AI chat" screen and get
+      a trip that appears in My Trips, opens in the trip detail UI, and renders
+      on the map with day/city grouping.
+- [ ] Works with both a structured "TRIP SUMMARY" (from the copy-prompt flow)
+      and a messy full transcript.
+- [ ] Every place is resolved against Google Places; unresolved places with a
+      plausible model-supplied coordinate are kept and flagged as approximate;
+      places with no usable coordinate are dropped and named in a warning.
+- [ ] The imported trip carries a fresh chat lineage (`trips.chat_id`), so
+      "refine in chat" works on it immediately and nothing appears in the
+      resumable-chats list.
+- [ ] Anonymous users cannot import (401); the entry point is only shown signed in.
+- [ ] Extraction failures return a friendly error and never a 500; the pasted
+      text is preserved client-side for retry.
+- [ ] Analytics: `trip_created` (source=import) and `trip_imported`
+      (item_count/resolved/approximate/dropped) events are recorded.
+
+## API Surface
+
+### POST /api/v1/trips/import  (auth required, strict rate tier)
+
+Purpose: turn pasted AI-chat text into a persisted trip in one call.
+
+Request: `{"text": "<pasted conversation or summary>", "source": "chatgpt|claude|gemini|other"}`
+(`source` optional, analytics only).
+
+Response `201`: `{"trip_id": "<uuid>", "title": "...", "item_count": N, "warnings": ["..."]}`
+Warnings are localized, user-displayable strings (approximate/dropped places,
+degraded place verification).
+
+Errors:
+- `400` empty/invalid body
+- `401` unauthenticated
+- `422` no trip found in the text; or per-user trip cap reached
+- `502` extraction failed (provider detail logged server-side only)
+- `413` body over 2 MiB; `429` rate limited
+
+## Data Model
+
+No schema changes. Writes `trips` + `itinerary_items` through the existing
+`persistTrip` primitive with a freshly minted `chat-<token>` chat id. No
+`plan_chat_sessions` row is written (refine-in-chat creates one on first use).
+
+## UI Behavior
+
+- Surface: "Import from AI chat" icon action on the Trips list app bar, plus a
+  button on the trips-list empty state.
+- Screen: explainer, "Copy planning prompt" button, large paste field, Import
+  button. During import: indeterminate progress with staged copy (extraction
+  takes 5–20 s). Success: navigate (replace) to the new trip's detail screen;
+  if warnings exist, show them in a dismissible notice. Failure: inline error,
+  paste text preserved, retry available.
+- All copy in en + es.
+
+## Edge Cases & Error States
+
+- Anthropic down / key missing → 502 / 503, friendly message, retry works.
+- Google Places key missing (degraded mode) → import still succeeds with
+  model-approximate coordinates + one aggregate "verification unavailable"
+  warning.
+- Pasted text > 60k chars → server keeps head (10k) + tail (50k) around a
+  truncation marker; start (destination/dates) and end (final itinerary) of a
+  conversation both survive.
+- Text with no recognizable trip (recipes, homework…) → 422, no trip created.
+- Trip cap reached → 422 with the cap message from persistTrip.
+- Duplicate import of the same text → a second, independent trip (new lineage);
+  no dedup in v1.
+
+## Out of Scope
+
+- The MCP connector / OAuth account linking (Track 2, specs/mcp-connector).
+- Extracting accommodations, transport segments, or booking info.
+- Images in pasted content; file upload; URL import.
+- Editing/preview of extracted items before the trip is created.
+
+## Open Questions
+
+None — decisions (model choice, coordinate policy, chat_id semantics) are
+recorded in plan.md.

--- a/specs/import-trip-from-ai-chat/tasks.md
+++ b/specs/import-trip-from-ai-chat/tasks.md
@@ -1,0 +1,33 @@
+# Tasks: Import a trip from an external AI chat
+
+## API (Go)
+
+- [ ] `trip_import_service.go`: constants, structs, `truncateForImport`,
+      `extractImportedTrip`, `plausibleCoords`, `resolveImportedLocations`,
+      `importTripCore`
+- [ ] `trip_import_handler.go`: `importTripHandler`
+- [ ] `main.go`: route `POST /trips/import` (strict + auth)
+- [ ] `middleware.go`: 2 MiB body lane for `/api/v1/trips/import`
+- [ ] `i18n.go`: `import.*` catalog keys (en+es)
+- [ ] [P] `trip_import_test.go`: truncation + coordinate unit tests
+- [ ] [P] `trip_import_integration_test.go`: full matrix (see plan.md)
+- [ ] `make api-fmt && make api-vet && make api-test` green
+
+## Models & codegen (Flutter)
+
+- [ ] `lib/models/import_trip_result.dart` + `make flutter-build-models`
+
+## UI (Flutter)
+
+- [ ] `trips_api_service.dart`: `importTrip`
+- [ ] `lib/providers/import_trip_provider.dart`
+- [ ] `lib/screens/import_trip_screen.dart` (copy-prompt, paste, progress,
+      warnings, error/retry)
+- [ ] Entry points: trips-list app bar action + empty-state action
+- [ ] ARB strings en+es (incl. planning prompt) + regenerate l10n
+- [ ] `flutter analyze` green
+
+## Verification
+
+- [ ] Manual e2e on docker-dev with real keys (see plan.md)
+- [ ] Check `trip_imported` analytics rows land

--- a/src/packages/api/i18n.go
+++ b/src/packages/api/i18n.go
@@ -213,6 +213,12 @@ var messages = map[string]map[string]string{
 	"ics.segmentTitle":  {"en": "%s: %s", "es": "%s: %s"},
 	"ics.stayTitle":     {"en": "Stay: %s", "es": "Alojamiento: %s"},
 
+	"import.error.no_trip":         {"en": "We couldn't find a trip in that text — paste the conversation or its final summary.", "es": "No encontramos un viaje en ese texto — pega la conversación o su resumen final."},
+	"import.error.nothing_located": {"en": "We couldn't locate any of the places in that text on the map.", "es": "No pudimos ubicar en el mapa ninguno de los lugares de ese texto."},
+	"import.warning.approximate":   {"en": "%s: location is approximate — check it on the map", "es": "%s: la ubicación es aproximada — revísala en el mapa"},
+	"import.warning.dropped":       {"en": "%s couldn't be located and was left out — add it manually", "es": "%s no se pudo ubicar y quedó fuera — agrégalo manualmente"},
+	"import.warning.unverified":    {"en": "Place verification is unavailable right now — imported locations are approximate.", "es": "La verificación de lugares no está disponible ahora — las ubicaciones importadas son aproximadas."},
+
 	"notif.aTraveler": {"en": "A traveler", "es": "Un viajero"},
 
 	"page.verify.expired.body":  {"en": "Request a new verification email from your account.", "es": "Pide un nuevo correo de verificación desde tu cuenta."},

--- a/src/packages/api/main.go
+++ b/src/packages/api/main.go
@@ -723,6 +723,9 @@ func buildRouter() *mux.Router {
 	api.Handle("/trips", authMiddleware(http.HandlerFunc(listTripsHandler))).Methods("GET")
 	api.Handle("/trips/versions", admin(listTripVersionsHandler)).Methods("GET")
 	// Literal routes must precede /trips/{id} or mux binds them as an id.
+	// Import runs one Claude call + up to 50 Places lookups per request —
+	// strict tier, same class as /trips/{id}/refine (specs/import-trip-from-ai-chat).
+	api.Handle("/trips/import", strict(authMiddleware(http.HandlerFunc(importTripHandler)))).Methods("POST")
 	api.Handle("/trips/shared-with-me", authMiddleware(http.HandlerFunc(listSharedWithMeHandler))).Methods("GET")
 	// Resumable plan conversations (specs/continue-where-you-left-off).
 	api.Handle("/chats", authMiddleware(http.HandlerFunc(listChatSessionsHandler))).Methods("GET")

--- a/src/packages/api/middleware.go
+++ b/src/packages/api/middleware.go
@@ -170,6 +170,7 @@ const (
 	maxRequestBodyBytes       = 256 << 10 // 256 KiB, all endpoints by default
 	planMaxRequestBodyBytes   = 20 << 20  // 20 MiB for the /plan chat history incl. images (see above)
 	transcribeMaxRequestBytes = 10 << 20  // 10 MiB for /transcribe audio clips (60s opus is well under)
+	importMaxRequestBodyBytes = 2 << 20   // 2 MiB for /trips/import pasted transcripts (server truncates to 60k chars)
 )
 
 // bodyLimitMiddleware caps request body size. It wraps the request body ONLY
@@ -186,6 +187,8 @@ func bodyLimitMiddleware(next http.Handler) http.Handler {
 			limit = planMaxRequestBodyBytes
 		case "/api/v1/transcribe":
 			limit = transcribeMaxRequestBytes
+		case "/api/v1/trips/import":
+			limit = importMaxRequestBodyBytes
 		}
 		if r.ContentLength > limit {
 			writeJSONError(w, http.StatusRequestEntityTooLarge, "request body too large")

--- a/src/packages/api/trip_import_handler.go
+++ b/src/packages/api/trip_import_handler.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"os"
+	"strings"
+)
+
+// trip_import_handler.go: POST /api/v1/trips/import — paste an external-AI
+// conversation (ChatGPT, Claude, …), get a persisted trip back. Auth required
+// (trips are per-user); strict rate tier (each request is one Claude call plus
+// up to importMaxPlaceLookups Places lookups); its own 2 MiB body lane in
+// bodyLimitMiddleware (a long transcript blows the 256 KiB default).
+
+type importTripRequest struct {
+	Text string `json:"text"`
+	// Which AI the text came from — analytics only, never trusted for logic.
+	Source string `json:"source"`
+}
+
+type importTripResponse struct {
+	TripID    string   `json:"trip_id"`
+	Title     string   `json:"title"`
+	ItemCount int      `json:"item_count"`
+	Warnings  []string `json:"warnings"`
+}
+
+var allowedImportSources = map[string]bool{
+	"chatgpt": true, "claude": true, "gemini": true, "other": true,
+}
+
+func importTripHandler(w http.ResponseWriter, r *http.Request) {
+	user, ok := userFromContext(r.Context())
+	if !ok {
+		writeJSONError(w, http.StatusUnauthorized, "authentication required")
+		return
+	}
+
+	var req importTripRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid JSON")
+		return
+	}
+	text := strings.TrimSpace(req.Text)
+	if text == "" {
+		writeJSONError(w, http.StatusBadRequest, "text is required")
+		return
+	}
+	source := strings.ToLower(strings.TrimSpace(req.Source))
+	if !allowedImportSources[source] {
+		source = "other"
+	}
+
+	apiKey := os.Getenv("ANTHROPIC_API_KEY")
+	if apiKey == "" {
+		writeJSONError(w, http.StatusServiceUnavailable, "ANTHROPIC_API_KEY not configured")
+		return
+	}
+
+	res, err := importTripCore(r.Context(), newAnthropicClient(apiKey), user.ID, text, source)
+	if err != nil {
+		locale := requestLocale(r.Context())
+		var phase *importPhaseError
+		switch {
+		case errors.Is(err, errImportNoTrip):
+			writeJSONError(w, http.StatusUnprocessableEntity, tr(locale, "import.error.no_trip"))
+		case errors.Is(err, errImportNothingLocated):
+			writeJSONError(w, http.StatusUnprocessableEntity, tr(locale, "import.error.nothing_located"))
+		case errors.As(err, &phase) && phase.phase == "extract":
+			// Provider/internal detail stays in the server log (tees to
+			// Sentry); the client gets a generic message.
+			ctxLog(r.Context()).Error("trip import: extraction failed", "error", err)
+			writeJSONError(w, http.StatusBadGateway, "extraction failed")
+		case strings.Contains(err.Error(), "trip limit reached"):
+			// persistTrip's per-user lineage cap; its message is user-ready.
+			writeJSONError(w, http.StatusUnprocessableEntity, err.Error())
+		default:
+			ctxLog(r.Context()).Error("trip import: persist failed", "error", err)
+			writeJSONError(w, http.StatusInternalServerError, "could not save trip")
+		}
+		return
+	}
+
+	writeJSON(w, http.StatusCreated, importTripResponse{
+		TripID:    res.TripID,
+		Title:     res.Title,
+		ItemCount: res.ItemCount,
+		Warnings:  res.Warnings,
+	})
+}

--- a/src/packages/api/trip_import_integration_test.go
+++ b/src/packages/api/trip_import_integration_test.go
@@ -1,0 +1,296 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"travel-route-planner/store"
+)
+
+// Integration tests for POST /api/v1/trips/import: fake Anthropic behind the
+// ANTHROPIC_BASE_URL seam (forced-tool non-streaming turn) + fake Google Places
+// behind a canned RoundTripper on a swapped placesService singleton.
+
+// cannedPlacesTransport answers every text search with one hit echoing the
+// query, except queries the miss predicate rejects (ZERO_RESULTS).
+type cannedPlacesTransport struct {
+	miss func(query string) bool
+}
+
+func (c cannedPlacesTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	q := req.URL.Query().Get("query")
+	body := fmt.Sprintf(
+		`{"results":[{"place_id":"pl_test","name":%q,"formatted_address":"1 Test St","geometry":{"location":{"lat":38.7223,"lng":-9.1393}}}],"status":"OK"}`, q)
+	if c.miss != nil && c.miss(q) {
+		body = `{"results":[],"status":"ZERO_RESULTS"}`
+	}
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}, nil
+}
+
+func swapCannedPlaces(t *testing.T, miss func(string) bool) {
+	t.Helper()
+	svc := NewGooglePlacesService()
+	svc.APIKey = "places-test-key"
+	svc.Client = &http.Client{Transport: cannedPlacesTransport{miss: miss}}
+	swapPlacesService(t, svc)
+}
+
+const importHappyPayload = `{
+	"title": "Lisbon Weekend",
+	"summary": "Two days in Lisbon with a Sintra day trip.",
+	"start_date": "2026-09-04",
+	"end_date": "2026-09-05",
+	"travel_mode": "flight",
+	"locations": [
+		{"name": "Belém Tower", "city": "Lisbon", "search_hint": "Belém Tower, Lisbon", "day": 1, "time_of_day": "morning", "category": "attraction"},
+		{"name": "Time Out Market", "city": "Lisbon", "search_hint": "Time Out Market, Lisbon", "day": 1, "time_of_day": "evening", "category": "restaurant"},
+		{"name": "Pena Palace", "city": "Sintra", "day_trip_from": "Lisbon", "search_hint": "Pena Palace, Sintra", "day": 2, "time_of_day": "afternoon", "category": "attraction"}
+	]
+}`
+
+func TestImportTripHappyPath(t *testing.T) {
+	resetDB(t)
+	fake := newFakeAnthropic(t)
+	fake.scriptNonStreamingTool(importToolName, importHappyPayload)
+	swapCannedPlaces(t, nil)
+	user, token := createTestUser(t, "importer@example.com")
+
+	rec := doJSON(t, http.MethodPost, "/api/v1/trips/import", token,
+		map[string]any{"text": "Day 1 Belém Tower... (pasted ChatGPT plan)", "source": "chatgpt"})
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, body %s", rec.Code, rec.Body.String())
+	}
+	body := decode(t, rec)
+	if body["title"] != "Lisbon Weekend" {
+		t.Errorf("title = %v", body["title"])
+	}
+	if int(body["item_count"].(float64)) != 3 {
+		t.Errorf("item_count = %v", body["item_count"])
+	}
+	if warns := body["warnings"].([]any); len(warns) != 0 {
+		t.Errorf("warnings = %v, want none", warns)
+	}
+
+	tripID := uuid.MustParse(body["trip_id"].(string))
+	q := store.New(dbPool)
+	trip, err := q.GetTripByIDAndOwner(context.Background(), store.GetTripByIDAndOwnerParams{ID: tripID, UserID: user.ID})
+	if err != nil {
+		t.Fatalf("trip not persisted: %v", err)
+	}
+	if trip.ChatID == nil || !strings.HasPrefix(*trip.ChatID, "chat-") {
+		t.Errorf("chat_id = %v, want chat-<token>", trip.ChatID)
+	}
+	if !trip.StartDate.Valid || trip.StartDate.Time.Format("2006-01-02") != "2026-09-04" {
+		t.Errorf("start_date = %v", trip.StartDate)
+	}
+	if trip.TravelMode == nil || *trip.TravelMode != "flight" {
+		t.Errorf("travel_mode = %v", trip.TravelMode)
+	}
+
+	items, err := q.GetItineraryItemsByTrip(context.Background(), tripID)
+	if err != nil || len(items) != 3 {
+		t.Fatalf("items = %d (%v), want 3", len(items), err)
+	}
+	var sintra *store.ItineraryItem
+	for i := range items {
+		it := items[i]
+		if it.Latitude != 38.7223 || it.Longitude != -9.1393 {
+			t.Errorf("%s: coords = (%v,%v), want Google-resolved", it.Name, it.Latitude, it.Longitude)
+		}
+		if it.PlaceID == nil || *it.PlaceID != "pl_test" {
+			t.Errorf("%s: place_id = %v", it.Name, it.PlaceID)
+		}
+		if it.Day == nil || it.TimeOfDay == nil || it.City == nil {
+			t.Errorf("%s: day/time_of_day/city not coerced (%v %v %v)", it.Name, it.Day, it.TimeOfDay, it.City)
+		}
+		if it.Name == "Pena Palace" {
+			sintra = &items[i]
+		}
+	}
+	if sintra == nil || sintra.DayTripFrom == nil || *sintra.DayTripFrom != "Lisbon" {
+		t.Errorf("day_trip_from not carried through: %+v", sintra)
+	}
+
+	// Fresh lineage, no session row: the import must not surface in
+	// resumable chats.
+	chats := doJSON(t, http.MethodGet, "/api/v1/chats", token, nil)
+	if chats.Code != http.StatusOK || strings.Contains(chats.Body.String(), *trip.ChatID) {
+		t.Errorf("imported chat_id leaked into resumable chats: %s", chats.Body.String())
+	}
+
+	waitForEventCount(t, user.ID, "trip_created", 1)
+	waitForEventCount(t, user.ID, "trip_imported", 1)
+}
+
+func TestImportTripApproximateAndDropped(t *testing.T) {
+	resetDB(t)
+	fake := newFakeAnthropic(t)
+	fake.scriptNonStreamingTool(importToolName, `{
+		"title": "Mixed Bag",
+		"locations": [
+			{"name": "Findable Cafe", "city": "Lisbon", "search_hint": "Findable Cafe, Lisbon", "day": 1},
+			{"name": "Mystery Bar", "city": "Lisbon", "search_hint": "Mystery Bar, Lisbon", "day": 1, "latitude": 38.71, "longitude": -9.14},
+			{"name": "Ghost Spot", "city": "Lisbon", "search_hint": "Ghost Spot, Lisbon", "day": 2}
+		]
+	}`)
+	swapCannedPlaces(t, func(q string) bool {
+		return strings.Contains(q, "Mystery") || strings.Contains(q, "Ghost")
+	})
+	_, token := createTestUser(t, "mixed@example.com")
+
+	rec := doJSON(t, http.MethodPost, "/api/v1/trips/import", token, map[string]any{"text": "some plan"})
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, body %s", rec.Code, rec.Body.String())
+	}
+	body := decode(t, rec)
+	if int(body["item_count"].(float64)) != 2 {
+		t.Errorf("item_count = %v, want 2 (Ghost Spot dropped)", body["item_count"])
+	}
+	warns := body["warnings"].([]any)
+	if len(warns) != 2 {
+		t.Fatalf("warnings = %v, want approximate + dropped", warns)
+	}
+	joined := fmt.Sprint(warns...)
+	if !strings.Contains(joined, "Mystery Bar") || !strings.Contains(joined, "Ghost Spot") {
+		t.Errorf("warnings must name the affected places: %v", warns)
+	}
+
+	tripID := uuid.MustParse(body["trip_id"].(string))
+	items, _ := store.New(dbPool).GetItineraryItemsByTrip(context.Background(), tripID)
+	byName := map[string]store.ItineraryItem{}
+	for _, it := range items {
+		byName[it.Name] = it
+	}
+	if it := byName["Mystery Bar"]; it.Latitude != 38.71 || it.Longitude != -9.14 {
+		t.Errorf("Mystery Bar must keep the model's approximate coords, got (%v,%v)", it.Latitude, it.Longitude)
+	}
+	if _, ok := byName["Ghost Spot"]; ok {
+		t.Error("Ghost Spot (no coords anywhere) must be dropped")
+	}
+}
+
+// Degraded mode: no GOOGLE_PLACES_API_KEY. Locations with model coordinates
+// ride the approximate tier under one aggregate warning; the rest drop.
+func TestImportTripDegradedPlaces(t *testing.T) {
+	resetDB(t)
+	fake := newFakeAnthropic(t)
+	fake.scriptNonStreamingTool(importToolName, `{
+		"title": "No Places Key",
+		"locations": [
+			{"name": "Guessed Museum", "city": "Rome", "search_hint": "Guessed Museum, Rome", "latitude": 41.9, "longitude": 12.49},
+			{"name": "Unknown Alley", "city": "Rome", "search_hint": "Unknown Alley, Rome"}
+		]
+	}`)
+	svc := NewGooglePlacesService()
+	svc.APIKey = ""
+	swapPlacesService(t, svc)
+	_, token := createTestUser(t, "degraded@example.com")
+
+	rec := doJSON(t, http.MethodPost, "/api/v1/trips/import", token, map[string]any{"text": "roma plan"})
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, body %s", rec.Code, rec.Body.String())
+	}
+	body := decode(t, rec)
+	if int(body["item_count"].(float64)) != 1 {
+		t.Errorf("item_count = %v, want 1", body["item_count"])
+	}
+	joined := fmt.Sprint(body["warnings"].([]any)...)
+	if !strings.Contains(joined, "verification is unavailable") {
+		t.Errorf("aggregate degraded warning missing: %v", joined)
+	}
+	if !strings.Contains(joined, "Unknown Alley") {
+		t.Errorf("dropped place must be named: %v", joined)
+	}
+}
+
+func TestImportTripNoTripFound(t *testing.T) {
+	resetDB(t)
+	fake := newFakeAnthropic(t)
+	fake.scriptNonStreamingTool(importToolName, `{"title": "", "locations": []}`)
+	swapCannedPlaces(t, nil)
+	_, token := createTestUser(t, "notrip@example.com")
+
+	rec := doJSON(t, http.MethodPost, "/api/v1/trips/import", token, map[string]any{"text": "a cookie recipe"})
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status = %d, want 422; body %s", rec.Code, rec.Body.String())
+	}
+	if n := countTrips(t); n != 0 {
+		t.Errorf("trips created = %d, want 0", n)
+	}
+}
+
+func TestImportTripValidation(t *testing.T) {
+	resetDB(t)
+	_, token := createTestUser(t, "valid@example.com")
+
+	if rec := doJSON(t, http.MethodPost, "/api/v1/trips/import", token, map[string]any{"text": "   "}); rec.Code != http.StatusBadRequest {
+		t.Errorf("empty text: status = %d, want 400", rec.Code)
+	}
+	if rec := doJSON(t, http.MethodPost, "/api/v1/trips/import", "", map[string]any{"text": "a plan"}); rec.Code != http.StatusUnauthorized {
+		t.Errorf("anonymous: status = %d, want 401", rec.Code)
+	}
+}
+
+func TestImportTripCapReached(t *testing.T) {
+	resetDB(t)
+	t.Setenv("MAX_TRIPS_PER_USER", "1")
+	fake := newFakeAnthropic(t)
+	fake.scriptNonStreamingTool(importToolName, importHappyPayload)
+	swapCannedPlaces(t, nil)
+	user, token := createTestUser(t, "capped@example.com")
+	createTestTrip(t, user.ID, 1)
+
+	rec := doJSON(t, http.MethodPost, "/api/v1/trips/import", token, map[string]any{"text": "another plan"})
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status = %d, want 422; body %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "trip limit reached") {
+		t.Errorf("cap message missing: %s", rec.Body.String())
+	}
+}
+
+// Oversized pastes must reach the model truncated head+tail, not rejected and
+// not head-only.
+func TestImportTripTruncatesOversizedPaste(t *testing.T) {
+	resetDB(t)
+	fake := newFakeAnthropic(t)
+	fake.scriptNonStreamingTool(importToolName, importHappyPayload)
+	swapCannedPlaces(t, nil)
+	_, token := createTestUser(t, "long@example.com")
+
+	text := "TRIP START Lisbon " + strings.Repeat("x", importMaxChars) + " TRIP END Sintra"
+	rec := doJSON(t, http.MethodPost, "/api/v1/trips/import", token, map[string]any{"text": text})
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, body %s", rec.Code, rec.Body.String())
+	}
+	bodies := fake.requestBodies()
+	if len(bodies) != 1 {
+		t.Fatalf("model calls = %d, want 1", len(bodies))
+	}
+	sent := string(bodies[0])
+	if !strings.Contains(sent, "TRIP START Lisbon") || !strings.Contains(sent, "TRIP END Sintra") {
+		t.Error("head and tail of the paste must both reach the model")
+	}
+	if !strings.Contains(sent, "truncated") {
+		t.Error("truncation marker missing from the model request")
+	}
+}
+
+func countTrips(t *testing.T) int {
+	t.Helper()
+	var n int
+	if err := dbPool.QueryRow(context.Background(), `SELECT count(*) FROM trips`).Scan(&n); err != nil {
+		t.Fatalf("countTrips: %v", err)
+	}
+	return n
+}

--- a/src/packages/api/trip_import_service.go
+++ b/src/packages/api/trip_import_service.go
@@ -1,0 +1,370 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	anthropic "github.com/anthropics/anthropic-sdk-go"
+	"github.com/google/uuid"
+
+	"travel-route-planner/store"
+)
+
+// trip_import_service.go turns a pasted external-AI conversation (ChatGPT,
+// Claude, …) into a persisted trip: one forced-tool extraction call (the
+// local_extraction_service.go pattern), a Google Places pass to resolve
+// coordinates (the ingestLocalHandler pattern), then the existing persistTrip
+// primitive. importTripCore is deliberately handler-free so the future MCP
+// connector's create_trip tool (specs/mcp-connector) can call it directly.
+
+const (
+	importToolName = "import_trip"
+	// The extraction emits up to importMaxLocations structured places, so it
+	// needs more room than local ingest's 90s / 4k tokens.
+	importTimeout      = 120 * time.Second
+	importMaxTokens    = 8192
+	importMaxChars     = 60000
+	importHeadChars    = 10000
+	importMaxLocations = 80
+	// Each unresolved place costs one Places Text Search (~$0.032). The cap
+	// bounds worst-case spend per import; places past it fall back to the
+	// model-coordinate tier below rather than being dropped outright.
+	importMaxPlaceLookups = 50
+	// Sonnet, not Haiku: a one-shot user-visible result with no chat loop to
+	// repair it, and the live /plan agent already produces this exact location
+	// shape on Sonnet 4.6 — the schema conventions are battle-tested against
+	// it. Revisit (Haiku) once eval fixtures exist.
+	importModel = anthropic.ModelClaudeSonnet4_6
+
+	importSystemPrompt = "You extract a travel itinerary from a pasted AI-chat conversation or trip summary. " +
+		"Call import_trip exactly once. " +
+		"STRICT RULES: Use ONLY places actually named in the provided text — never invent or pad with your own suggestions. " +
+		"If several itinerary drafts appear, extract the FINAL agreed version. " +
+		"`search_hint` is the best short string to find the exact place on a map (place name + city). " +
+		"`city` is the actual municipality the place is in (e.g. 'Versailles', not 'Paris'); use `day_trip_from` for the hub city when the place is a same-day trip from where the traveler stays. " +
+		"`day` starts at 1 and increases chronologically across the whole trip; all places on the same day share the number. " +
+		"Spread `time_of_day` sensibly (sights across morning-afternoon, meals at their natural times) when the text implies an order. " +
+		"`category` is 'restaurant' for places you eat or drink, otherwise 'attraction'. " +
+		"Only set start_date/end_date when actual dates are stated in the text (YYYY-MM-DD). " +
+		"Only set latitude/longitude when you are confident of the approximate coordinates; they are a fallback, never required. " +
+		"If the text contains no recognizable trip, return an empty locations array."
+)
+
+// errImportNoTrip: the model found no itinerary in the text.
+// errImportNothingLocated: an itinerary was found but no place survived
+// coordinate resolution. Both surface as 422s, with different copy.
+var (
+	errImportNoTrip         = errors.New("no trip found in text")
+	errImportNothingLocated = errors.New("no places could be located")
+)
+
+// importPhaseError tags a failure with the pipeline phase so the handler can
+// map extraction problems to 502 and persistence problems to 500/422 without
+// string-sniffing the whole chain.
+type importPhaseError struct {
+	phase string // "extract" | "persist"
+	err   error
+}
+
+func (e *importPhaseError) Error() string { return e.err.Error() }
+func (e *importPhaseError) Unwrap() error { return e.err }
+
+// ImportedLocation is one place as the model proposes it — coordinates are an
+// optional model-confidence fallback; the authoritative ones come from Google.
+type ImportedLocation struct {
+	Name        string   `json:"name"`
+	City        string   `json:"city"`
+	DayTripFrom string   `json:"day_trip_from"`
+	Category    string   `json:"category"`
+	TimeOfDay   string   `json:"time_of_day"`
+	Day         int      `json:"day"`
+	SearchHint  string   `json:"search_hint"`
+	Latitude    *float64 `json:"latitude"`
+	Longitude   *float64 `json:"longitude"`
+}
+
+type ImportedTrip struct {
+	Title      string             `json:"title"`
+	Summary    string             `json:"summary"`
+	StartDate  string             `json:"start_date"`
+	EndDate    string             `json:"end_date"`
+	TravelMode string             `json:"travel_mode"`
+	Locations  []ImportedLocation `json:"locations"`
+}
+
+// importStats feeds the trip_imported analytics event and the response warnings.
+type importStats struct {
+	Resolved    int
+	Approximate int
+	Dropped     int
+}
+
+type importResult struct {
+	TripID    string
+	Title     string
+	ItemCount int
+	Warnings  []string
+}
+
+// truncateForImport keeps the head and tail of an oversized paste. Unlike the
+// head-only truncation in local ingest, a chat transcript's two load-bearing
+// regions are its start (destination, dates) and its end (the final agreed
+// itinerary) — the middle back-and-forth is the expendable part. Rune-based so
+// we never split a UTF-8 sequence.
+func truncateForImport(s string) string {
+	r := []rune(s)
+	if len(r) <= importMaxChars {
+		return s
+	}
+	const marker = "\n[... middle of conversation truncated ...]\n"
+	tail := importMaxChars - importHeadChars
+	return string(r[:importHeadChars]) + marker + string(r[len(r)-tail:])
+}
+
+// plausibleCoords reports whether a model-supplied coordinate pair is usable
+// as a flagged fallback: both present, in range, and not the (0,0) null-island
+// filler models emit when guessing.
+func plausibleCoords(lat, lng *float64) bool {
+	if lat == nil || lng == nil {
+		return false
+	}
+	if *lat < -90 || *lat > 90 || *lng < -180 || *lng > 180 {
+		return false
+	}
+	return *lat != 0 || *lng != 0
+}
+
+// extractImportedTrip runs the single forced-tool call and returns the parsed
+// itinerary proposal.
+func extractImportedTrip(ctx context.Context, client anthropic.Client, rawText string) (ImportedTrip, error) {
+	ctx, cancel := context.WithTimeout(ctx, importTimeout)
+	defer cancel()
+
+	rawText = truncateForImport(rawText)
+
+	tool := anthropic.ToolParam{
+		Name:        importToolName,
+		Description: anthropic.String("Record the structured trip itinerary extracted from the pasted conversation or summary."),
+		InputSchema: anthropic.ToolInputSchemaParam{
+			Properties: map[string]any{
+				"title":      map[string]any{"type": "string", "description": "Short trip name, e.g. 'Lisbon & Porto'"},
+				"summary":    map[string]any{"type": "string", "description": "2-3 sentence trip summary"},
+				"start_date": map[string]any{"type": "string", "description": "YYYY-MM-DD, only if stated in the text"},
+				"end_date":   map[string]any{"type": "string", "description": "YYYY-MM-DD, only if stated in the text"},
+				"travel_mode": map[string]any{
+					"type": "string",
+					"enum": []string{"flight", "car", "train", "bus", "ferry", "mixed"},
+				},
+				"locations": map[string]any{
+					"type": "array",
+					"items": map[string]any{
+						"type": "object",
+						"properties": map[string]any{
+							"name": map[string]any{"type": "string"},
+							"city": map[string]any{
+								"type":        "string",
+								"description": "The municipality the place is physically in — 'Versailles', not 'Paris'.",
+							},
+							"day_trip_from": map[string]any{
+								"type":        "string",
+								"description": "Hub city when this place is a same-day trip from where the traveler stays.",
+							},
+							"category":    map[string]any{"type": "string", "enum": []string{"attraction", "restaurant"}},
+							"time_of_day": map[string]any{"type": "string", "enum": []string{"morning", "afternoon", "evening"}},
+							"day":         map[string]any{"type": "integer", "description": "Trip day, 1-based, chronological across the whole trip"},
+							"search_hint": map[string]any{"type": "string", "description": "Best string to locate the place on a map"},
+							"latitude":    map[string]any{"type": "number", "description": "Approximate, only if confident"},
+							"longitude":   map[string]any{"type": "number", "description": "Approximate, only if confident"},
+						},
+						"required": []string{"name", "city", "search_hint"},
+					},
+				},
+			},
+			Required: []string{"title", "locations"},
+		},
+	}
+
+	resp, err := client.Messages.New(ctx, anthropic.MessageNewParams{
+		Model:      importModel,
+		MaxTokens:  importMaxTokens,
+		System:     []anthropic.TextBlockParam{{Text: importSystemPrompt}},
+		Tools:      []anthropic.ToolUnionParam{{OfTool: &tool}},
+		ToolChoice: anthropic.ToolChoiceParamOfTool(importToolName),
+		Messages: []anthropic.MessageParam{
+			anthropic.NewUserMessage(anthropic.NewTextBlock(
+				"Pasted conversation or trip summary:\n\n" + rawText)),
+		},
+	})
+	if err != nil {
+		return ImportedTrip{}, fmt.Errorf("import model call: %w", err)
+	}
+
+	for _, block := range resp.Content {
+		if variant, ok := block.AsAny().(anthropic.ToolUseBlock); ok && variant.Name == importToolName {
+			var out ImportedTrip
+			if err := json.Unmarshal(variant.Input, &out); err != nil {
+				return ImportedTrip{}, fmt.Errorf("parse import: %w", err)
+			}
+			return out, nil
+		}
+	}
+	return ImportedTrip{}, fmt.Errorf("model did not return %s", importToolName)
+}
+
+// resolveImportedLocations verifies each extracted place against Google Places
+// and returns persistTrip-shaped location maps plus user-facing warnings.
+// Coordinate tiers: Google hit (authoritative) > plausible model coordinates
+// (kept, flagged approximate) > neither (dropped, named in a warning).
+// itinerary_items.latitude/longitude are NOT NULL and a (0,0) pin ruins the
+// map — but unlike the local-content publish gate, this is the user's own
+// private trip, so approximate-and-flagged beats failing the import.
+func resolveImportedLocations(ctx context.Context, locs []ImportedLocation) ([]map[string]any, importStats, []string) {
+	locale := requestLocale(ctx)
+	var (
+		out      []map[string]any
+		stats    importStats
+		warnings []string
+		lookups  int
+	)
+
+	// Degraded mode: no Places key means every lookup would error identically.
+	// Skip the loop's per-place noise and emit one aggregate warning instead.
+	placesAvailable := placesService.APIKey != ""
+	if !placesAvailable {
+		warnings = append(warnings, tr(locale, "import.warning.unverified"))
+	}
+
+	for _, l := range locs {
+		name := strings.TrimSpace(l.Name)
+		if name == "" {
+			continue
+		}
+		loc := map[string]any{"name": name}
+		if c := strings.TrimSpace(l.City); c != "" {
+			loc["city"] = c
+		}
+		if d := strings.TrimSpace(l.DayTripFrom); d != "" {
+			loc["day_trip_from"] = d
+		}
+		if l.Category != "" {
+			loc["category"] = l.Category
+		}
+		if l.TimeOfDay != "" {
+			loc["time_of_day"] = l.TimeOfDay
+		}
+		if l.Day >= 1 {
+			// JSON numbers decode as float64; itemParamsFromLocation expects
+			// that shape (see locationFromItem).
+			loc["day"] = float64(l.Day)
+		}
+
+		resolved := false
+		if placesAvailable && lookups < importMaxPlaceLookups {
+			lookups++
+			if hits, err := placesService.SearchPlaces(ctx, placeQuery(l.SearchHint, name, l.City)); err == nil && len(hits) > 0 {
+				hit := hits[0]
+				loc["latitude"] = hit.Latitude
+				loc["longitude"] = hit.Longitude
+				if hit.PlaceID != "" {
+					loc["place_id"] = hit.PlaceID
+				}
+				if hit.Address != "" {
+					loc["address"] = hit.Address
+				}
+				resolved = true
+				stats.Resolved++
+			}
+		}
+		if !resolved {
+			if plausibleCoords(l.Latitude, l.Longitude) {
+				loc["latitude"] = *l.Latitude
+				loc["longitude"] = *l.Longitude
+				stats.Approximate++
+				if placesAvailable {
+					warnings = append(warnings, tr(locale, "import.warning.approximate", name))
+				}
+			} else {
+				stats.Dropped++
+				warnings = append(warnings, tr(locale, "import.warning.dropped", name))
+				continue
+			}
+		}
+		out = append(out, loc)
+	}
+	return out, stats, warnings
+}
+
+// importTripCore is the reusable extract -> resolve -> persist pipeline behind
+// POST /trips/import (and, later, the MCP connector's create_trip tool).
+func importTripCore(ctx context.Context, client anthropic.Client, userID uuid.UUID, rawText, source string) (importResult, error) {
+	extracted, err := extractImportedTrip(ctx, client, rawText)
+	if err != nil {
+		return importResult{}, &importPhaseError{phase: "extract", err: err}
+	}
+	if len(extracted.Locations) == 0 {
+		return importResult{}, errImportNoTrip
+	}
+	if len(extracted.Locations) > importMaxLocations {
+		extracted.Locations = extracted.Locations[:importMaxLocations]
+	}
+
+	locations, stats, warnings := resolveImportedLocations(ctx, extracted.Locations)
+	if len(locations) == 0 {
+		return importResult{}, errImportNothingLocated
+	}
+
+	// Same walking-order optimization the in-app agent applies: reorder within
+	// each day/time-of-day block by distance, keeping the day structure intact.
+	locations = reorderItineraryByDistance(locations)
+
+	chatToken, err := generateSessionToken()
+	if err != nil {
+		return importResult{}, &importPhaseError{phase: "persist", err: err}
+	}
+	chatID := "chat-" + chatToken
+
+	tripID, newLineage, err := persistTrip(ctx, userID, chatID,
+		extracted.Title, extracted.Summary, extracted.StartDate, extracted.EndDate,
+		extracted.TravelMode, locations)
+	if err != nil {
+		return importResult{}, &importPhaseError{phase: "persist", err: err}
+	}
+
+	res := importResult{TripID: tripID, Title: strings.TrimSpace(extracted.Title), ItemCount: len(locations), Warnings: warnings}
+	if res.Warnings == nil {
+		res.Warnings = []string{}
+	}
+
+	parsed, perr := uuid.Parse(tripID)
+	if perr == nil {
+		// Report the title persistTrip actually stored (it applies fallback
+		// chains the extraction title may have skipped).
+		if trip, terr := store.New(dbPool).GetTripByIDAndOwner(ctx, store.GetTripByIDAndOwnerParams{ID: parsed, UserID: userID}); terr == nil {
+			res.Title = trip.Title
+		}
+		safeGo("recordEvent", func() {
+			recordEvent(userID, "trip_created", &parsed, map[string]any{
+				"item_count": res.ItemCount,
+				"source":     "import",
+			})
+			recordEvent(userID, "trip_imported", &parsed, map[string]any{
+				"item_count":  res.ItemCount,
+				"resolved":    stats.Resolved,
+				"approximate": stats.Approximate,
+				"dropped":     stats.Dropped,
+				"provider":    source,
+			})
+		})
+		// Free-cap active_trips crossing signal — imports always mint a fresh
+		// chat lineage, but keep the guard so a future caller reusing a lineage
+		// can't over-emit (specs/free-cap-instrumentation).
+		if newLineage {
+			safeGo("recordActiveTripsCapSignal", func() { recordActiveTripsCapSignal(userID, parsed) })
+		}
+	}
+	return res, nil
+}

--- a/src/packages/api/trip_import_test.go
+++ b/src/packages/api/trip_import_test.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestTruncateForImportPassthrough(t *testing.T) {
+	s := strings.Repeat("a", importMaxChars)
+	if got := truncateForImport(s); got != s {
+		t.Fatal("text at the limit must pass through unchanged")
+	}
+}
+
+func TestTruncateForImportKeepsHeadAndTail(t *testing.T) {
+	head := strings.Repeat("H", importHeadChars)
+	middle := strings.Repeat("M", importMaxChars) // guarantees over-limit
+	tail := strings.Repeat("T", importMaxChars-importHeadChars)
+	got := truncateForImport(head + middle + tail)
+
+	if !strings.HasPrefix(got, head) {
+		t.Error("head of the paste must survive truncation")
+	}
+	if !strings.HasSuffix(got, tail) {
+		t.Error("tail of the paste must survive truncation")
+	}
+	if !strings.Contains(got, "truncated") {
+		t.Error("truncation marker missing")
+	}
+	if strings.Contains(got, "M") {
+		t.Error("middle must be cut")
+	}
+}
+
+// Multi-byte runes at the cut boundaries must never be split — the result has
+// to stay valid UTF-8 for the JSON request body.
+func TestTruncateForImportRuneSafe(t *testing.T) {
+	s := strings.Repeat("é", importMaxChars+1000)
+	got := truncateForImport(s)
+	if strings.ContainsRune(got, '�') {
+		t.Fatal("truncation split a multi-byte rune")
+	}
+	r := []rune(got)
+	if len(r) > importMaxChars+100 { // marker allowance
+		t.Fatalf("truncated length = %d runes, want <= %d", len(r), importMaxChars+100)
+	}
+}
+
+func TestPlausibleCoords(t *testing.T) {
+	f := func(v float64) *float64 { return &v }
+	cases := []struct {
+		name     string
+		lat, lng *float64
+		want     bool
+	}{
+		{"both nil", nil, nil, false},
+		{"lat only", f(38.7), nil, false},
+		{"lat out of range", f(91), f(0.5), false},
+		{"lng out of range", f(38.7), f(181), false},
+		{"null island filler", f(0), f(0), false},
+		{"valid", f(38.7223), f(-9.1393), true},
+		{"valid on equator", f(0), f(-9.1), true},
+	}
+	for _, c := range cases {
+		if got := plausibleCoords(c.lat, c.lng); got != c.want {
+			t.Errorf("%s: plausibleCoords = %v, want %v", c.name, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
Track 1 (PR 1 of 2) of the external-AI plan: let users do trip-planning chat in their own ChatGPT/Claude (their subscription pays for inference) and paste the result into Golden Tempo as a real trip.

## What

- **`POST /api/v1/trips/import`** (auth, strict tier): pasted text → one forced-tool **Sonnet 4.6** extraction (`import_trip`, ~$0.07/typical vs $1–5 for an agent-loop session) → Google Places coordinate resolution → `persistTrip` under a fresh `chat-<token>` lineage.
- **Tiered coordinates**: Google hit → verified; miss with plausible model coords → kept + localized "approximate" warning; neither → dropped + named in a warning. Degraded mode (no Places key) keeps the import alive with one aggregate warning.
- **Head+tail truncation** (10k + 50k chars): a transcript's destination/dates live at the start, the final itinerary at the end — head-only truncation would cut the part that matters.
- `trips.chat_id` set, **no** `plan_chat_sessions` row: refine-in-chat binds via chat_id, resumable-chats list stays clean, first refine creates the session row naturally.
- New 2 MiB body lane in `bodyLimitMiddleware`; `import.*` keys in the server i18n catalog (en+es); `trip_created{source:import}` + new `trip_imported` analytics; free-cap signal on new lineage.
- `importTripCore` is handler-free so Track 2's MCP-connector `create_trip` tool reuses the same pipeline.

## Spec

`specs/import-trip-from-ai-chat/` (spec.md / plan.md / tasks.md). Flutter UI (paste screen, copy-planning-prompt, entry points) lands in PR 2 of 2.

## Tests

- Unit: head+tail truncation (incl. rune safety), coordinate plausibility.
- Integration (fake Anthropic via `ANTHROPIC_BASE_URL`, fake Places via `swapPlacesService` + canned RoundTripper): happy path (rows, chat_id, coercion, day-trip carry-through), approximate/dropped warnings, degraded no-key mode, no-trip 422, empty-text 400, anonymous 401, trip-cap 422, oversized-paste truncation reaching the model, resumable-chats unaffected, analytics rows.
- Full `go test` suite green locally against Postgres.

🤖 Generated with [Claude Code](https://claude.com/claude-code)