### PR TITLE
MCP connector 2/6: OAuth 2.1 provider endpoints

### DIFF
--- a/specs/mcp-connector/tasks.md
+++ b/specs/mcp-connector/tasks.md
@@ -7,12 +7,12 @@
 - [x] resetDB TRUNCATE additions
 
 ## PR 2 — OAuth provider
-- [ ] Well-known documents (RFC 9728 both paths, RFC 8414, openid-configuration alias)
-- [ ] `POST /oauth/register` (DCR, redirect-URI validation)
-- [ ] `GET /oauth/authorize` (park request, 302 to /connect/; HTML error for bad client/redirect)
-- [ ] `POST /oauth/authorize/context` + `POST /oauth/authorize/decision`
-- [ ] `POST /oauth/token` (S256 verify, single-use + reuse revocation, refresh rotation)
-- [ ] Integration tests: full dance + negative matrix
+- [x] Well-known documents (RFC 9728 both paths, RFC 8414, openid-configuration alias)
+- [x] `POST /oauth/register` (DCR, redirect-URI validation)
+- [x] `GET /oauth/authorize` (park request, 302 to /connect/; HTML error for bad client/redirect)
+- [x] `POST /oauth/authorize/context` + `POST /oauth/authorize/decision`
+- [x] `POST /oauth/token` (S256 verify, single-use + reuse revocation, refresh rotation)
+- [x] Integration tests: full dance + negative matrix
 
 ## PR 3 — Flutter consent
 - [ ] `connect/<request-token>` + `trip/<id>` routes in generateRoute

--- a/src/packages/api/main.go
+++ b/src/packages/api/main.go
@@ -654,6 +654,13 @@ func buildRouter() *mux.Router {
 	router.HandleFunc("/hello", helloHandler).Methods("GET")
 	router.HandleFunc("/health", healthHandler).Methods("GET", "HEAD")
 
+	// MCP connector discovery documents (specs/mcp-connector) — root-level by
+	// RFC requirement; every handler 404s until MCP_ENABLED=true.
+	router.HandleFunc("/.well-known/oauth-protected-resource", oauthProtectedResourceHandler).Methods("GET")
+	router.HandleFunc("/.well-known/oauth-protected-resource/mcp", oauthProtectedResourceHandler).Methods("GET")
+	router.HandleFunc("/.well-known/oauth-authorization-server", oauthServerMetadataHandler).Methods("GET")
+	router.HandleFunc("/.well-known/openid-configuration", oauthServerMetadataHandler).Methods("GET")
+
 	// API versioning
 	api := router.PathPrefix("/api/v1").Subrouter()
 	api.HandleFunc("/hello", helloHandler).Methods("GET")
@@ -718,6 +725,16 @@ func buildRouter() *mux.Router {
 	api.HandleFunc("/auth/apple/availability", appleAvailabilityHandler).Methods("GET")
 	api.Handle("/auth/apple", strict(http.HandlerFunc(appleStartHandler))).Methods("GET")
 	api.Handle("/auth/apple/callback", strict(http.HandlerFunc(appleCallbackHandler))).Methods("POST")
+
+	// MCP connector OAuth provider (specs/mcp-connector): ChatGPT/claude.ai
+	// register via DCR, the browser consents at the app's /connect/ screen,
+	// tokens redeem here. All handlers gate on MCP_ENABLED. Credential-bearing
+	// endpoints take the strict tier; decision additionally requires auth.
+	api.Handle("/oauth/register", strict(http.HandlerFunc(oauthRegisterHandler))).Methods("POST")
+	api.Handle("/oauth/authorize", strict(http.HandlerFunc(oauthAuthorizeHandler))).Methods("GET")
+	api.Handle("/oauth/authorize/context", strict(http.HandlerFunc(oauthAuthorizeContextHandler))).Methods("POST")
+	api.Handle("/oauth/authorize/decision", strict(authMiddleware(http.HandlerFunc(oauthAuthorizeDecisionHandler)))).Methods("POST")
+	api.Handle("/oauth/token", strict(http.HandlerFunc(oauthTokenHandler))).Methods("POST")
 	// admin composes the auth + admin gate; used for curation and version-history routes.
 	admin := func(h http.HandlerFunc) http.Handler { return authMiddleware(adminMiddleware(h)) }
 	api.Handle("/trips", authMiddleware(http.HandlerFunc(listTripsHandler))).Methods("GET")

--- a/src/packages/api/oauth_provider_handler.go
+++ b/src/packages/api/oauth_provider_handler.go
@@ -1,0 +1,510 @@
+package main
+
+import (
+	"context"
+	"crypto/subtle"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"travel-route-planner/store"
+)
+
+// oauth_provider_handler.go: the OAuth 2.1 provider endpoints behind the MCP
+// connector (specs/mcp-connector). ChatGPT/claude.ai discover us via the
+// well-known documents, register as public clients (DCR), send the user's
+// browser through the Flutter consent screen, and exchange the code for
+// hashed, rotating tokens. Everything here 404s until MCP_ENABLED=true so
+// deploying the code exposes nothing.
+//
+// Error-shape note: the register and token endpoints speak the RFC-mandated
+// {"error": "..."} JSON (RFC 7591 §3.2.2 / RFC 6749 §5.2), NOT the app's
+// writeJSONError envelope — MCP clients parse these fields.
+
+// mcpEnabled is the feature gate, read per request like the SSO *Configured()
+// helpers so tests and ops can flip it without a boot-order dependency.
+func mcpEnabled() bool {
+	return os.Getenv("MCP_ENABLED") == "true"
+}
+
+// oauthGuard applies the gate + DB check every OAuth endpoint starts with.
+func oauthGuard(w http.ResponseWriter) bool {
+	if !mcpEnabled() {
+		http.Error(w, "not found", http.StatusNotFound)
+		return false
+	}
+	if dbPool == nil {
+		writeJSONError(w, http.StatusServiceUnavailable, "database unavailable")
+		return false
+	}
+	return true
+}
+
+func mcpResourceURL() string { return publicBaseURL() + "/mcp" }
+
+// --- discovery documents -----------------------------------------------------
+
+// GET /.well-known/oauth-protected-resource[/mcp] (RFC 9728). Both path forms
+// are served because client probing order varies by release.
+func oauthProtectedResourceHandler(w http.ResponseWriter, r *http.Request) {
+	if !mcpEnabled() {
+		http.Error(w, "not found", http.StatusNotFound)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"resource":                 mcpResourceURL(),
+		"authorization_servers":    []string{publicBaseURL()},
+		"scopes_supported":         []string{oauthScopeTripsWrite, oauthScopeRecsRead},
+		"bearer_methods_supported": []string{"header"},
+	})
+}
+
+// GET /.well-known/oauth-authorization-server (RFC 8414), plus an
+// openid-configuration alias for clients that probe that first.
+func oauthServerMetadataHandler(w http.ResponseWriter, r *http.Request) {
+	if !mcpEnabled() {
+		http.Error(w, "not found", http.StatusNotFound)
+		return
+	}
+	base := publicBaseURL()
+	writeJSON(w, http.StatusOK, map[string]any{
+		"issuer":                                base,
+		"authorization_endpoint":                base + "/api/v1/oauth/authorize",
+		"token_endpoint":                        base + "/api/v1/oauth/token",
+		"registration_endpoint":                 base + "/api/v1/oauth/register",
+		"response_types_supported":              []string{"code"},
+		"grant_types_supported":                 []string{"authorization_code", "refresh_token"},
+		"code_challenge_methods_supported":      []string{"S256"},
+		"token_endpoint_auth_methods_supported": []string{"none"},
+		"scopes_supported":                      []string{oauthScopeTripsWrite, oauthScopeRecsRead},
+	})
+}
+
+// --- dynamic client registration (RFC 7591) ----------------------------------
+
+type oauthRegisterRequest struct {
+	ClientName              string   `json:"client_name"`
+	RedirectURIs            []string `json:"redirect_uris"`
+	TokenEndpointAuthMethod string   `json:"token_endpoint_auth_method"`
+}
+
+func oauthRegistrationError(w http.ResponseWriter, code, desc string) {
+	writeJSON(w, http.StatusBadRequest, map[string]string{
+		"error": code, "error_description": desc,
+	})
+}
+
+// validOAuthRedirectURI: https anywhere, or http on loopback hosts (MCP
+// Inspector and other local dev tools); never a fragment.
+func validOAuthRedirectURI(raw string) bool {
+	u, err := url.Parse(raw)
+	if err != nil || u.Fragment != "" || u.Host == "" {
+		return false
+	}
+	switch u.Scheme {
+	case "https":
+		return true
+	case "http":
+		h := u.Hostname()
+		return h == "localhost" || h == "127.0.0.1" || h == "::1"
+	}
+	return false
+}
+
+// POST /api/v1/oauth/register — open registration, public clients only.
+func oauthRegisterHandler(w http.ResponseWriter, r *http.Request) {
+	if !oauthGuard(w) {
+		return
+	}
+	var req oauthRegisterRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		oauthRegistrationError(w, "invalid_client_metadata", "invalid JSON")
+		return
+	}
+	name := strings.TrimSpace(req.ClientName)
+	if name == "" || len(name) > maxNameLen {
+		oauthRegistrationError(w, "invalid_client_metadata", "client_name is required")
+		return
+	}
+	if len(req.RedirectURIs) == 0 || len(req.RedirectURIs) > 5 {
+		oauthRegistrationError(w, "invalid_redirect_uri", "between 1 and 5 redirect_uris required")
+		return
+	}
+	for _, u := range req.RedirectURIs {
+		if len(u) > maxURLLen || !validOAuthRedirectURI(u) {
+			oauthRegistrationError(w, "invalid_redirect_uri", "redirect_uris must be https (or http://localhost) with no fragment")
+			return
+		}
+	}
+	if m := strings.TrimSpace(req.TokenEndpointAuthMethod); m != "" && m != "none" {
+		oauthRegistrationError(w, "invalid_client_metadata", "only public clients (token_endpoint_auth_method 'none') are supported")
+		return
+	}
+
+	client, err := store.New(dbPool).CreateOAuthClient(r.Context(), store.CreateOAuthClientParams{
+		ClientName: name, RedirectUris: req.RedirectURIs,
+	})
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "could not register client")
+		return
+	}
+	writeJSON(w, http.StatusCreated, map[string]any{
+		"client_id":                  client.ID.String(),
+		"client_name":                client.ClientName,
+		"redirect_uris":              client.RedirectUris,
+		"token_endpoint_auth_method": "none",
+		"grant_types":                []string{"authorization_code", "refresh_token"},
+		"response_types":             []string{"code"},
+	})
+}
+
+// --- authorize ----------------------------------------------------------------
+
+// oauthErrorPage: for failures where redirecting would be an open-redirect
+// vector (unknown client, unregistered redirect_uri) — render, never redirect.
+func oauthErrorPage(w http.ResponseWriter, locale, body string) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.WriteHeader(http.StatusBadRequest)
+	fmt.Fprintf(w, "<html lang=%q><body><h2>%s</h2><p>%s</p></body></html>",
+		locale, "Golden Tempo Travel", body)
+}
+
+// oauthRedirectError sends the RFC 6749 §4.1.2.1 error redirect for failures
+// discovered AFTER the redirect_uri itself validated.
+func oauthRedirectError(w http.ResponseWriter, r *http.Request, redirectURI, code, state string) {
+	u, err := url.Parse(redirectURI)
+	if err != nil {
+		oauthErrorPage(w, requestLocale(r.Context()), "invalid redirect")
+		return
+	}
+	q := u.Query()
+	q.Set("error", code)
+	if state != "" {
+		q.Set("state", state)
+	}
+	u.RawQuery = q.Encode()
+	http.Redirect(w, r, u.String(), http.StatusFound)
+}
+
+// GET /api/v1/oauth/authorize — validates the request, parks it, and sends
+// the browser to the Flutter consent screen at /connect/<request-token>.
+func oauthAuthorizeHandler(w http.ResponseWriter, r *http.Request) {
+	if !oauthGuard(w) {
+		return
+	}
+	locale := requestLocale(r.Context())
+	qp := r.URL.Query()
+	q := store.New(dbPool)
+
+	// Opportunistic janitor, same posture as DeleteExpiredSessions.
+	// context.Background(): the request context dies with this handler.
+	safeGo("oauthJanitor", func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		jq := store.New(dbPool)
+		_ = jq.DeleteExpiredOAuthAuthCodes(ctx)
+		_ = jq.DeleteExpiredOAuthTokens(ctx)
+	})
+
+	clientID, err := uuid.Parse(qp.Get("client_id"))
+	if err != nil {
+		oauthErrorPage(w, locale, "Unknown application (bad client_id). Start over from your AI assistant.")
+		return
+	}
+	client, err := q.GetOAuthClient(r.Context(), clientID)
+	if err != nil {
+		oauthErrorPage(w, locale, "Unknown application. Start over from your AI assistant.")
+		return
+	}
+	redirectURI := qp.Get("redirect_uri")
+	registered := false
+	for _, u := range client.RedirectUris {
+		if u == redirectURI {
+			registered = true
+			break
+		}
+	}
+	if !registered {
+		// The one place we must never redirect: an attacker-chosen URI.
+		oauthErrorPage(w, locale, "This application supplied an unregistered redirect address.")
+		return
+	}
+
+	state := qp.Get("state")
+	if qp.Get("response_type") != "code" {
+		oauthRedirectError(w, r, redirectURI, "unsupported_response_type", state)
+		return
+	}
+	if qp.Get("code_challenge") == "" || qp.Get("code_challenge_method") != "S256" {
+		oauthRedirectError(w, r, redirectURI, "invalid_request", state)
+		return
+	}
+	scope, ok := normalizeOAuthScope(qp.Get("scope"))
+	if !ok {
+		oauthRedirectError(w, r, redirectURI, "invalid_scope", state)
+		return
+	}
+	// RFC 8707 resource indicator: when present it must name our MCP server.
+	if res := qp.Get("resource"); res != "" && res != mcpResourceURL() {
+		oauthRedirectError(w, r, redirectURI, "invalid_target", state)
+		return
+	}
+
+	rawToken, tokenHash, err := newOAuthSecret(oauthRequestTokenPrefix)
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "could not start authorization")
+		return
+	}
+	if _, err := q.CreateOAuthAuthRequest(r.Context(), store.CreateOAuthAuthRequestParams{
+		ClientID:         client.ID,
+		RequestTokenHash: tokenHash,
+		RedirectUri:      redirectURI,
+		Scope:            scope,
+		State:            state,
+		CodeChallenge:    qp.Get("code_challenge"),
+		ExpiresAt:        time.Now().Add(oauthRequestTokenTTL),
+	}); err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "could not start authorization")
+		return
+	}
+	_ = q.TouchOAuthClient(r.Context(), client.ID)
+
+	http.Redirect(w, r, publicAppURL("connect/", rawToken), http.StatusSeeOther)
+}
+
+// --- consent screen backend ----------------------------------------------------
+
+type oauthContextRequest struct {
+	RequestToken string `json:"request_token"`
+}
+
+// POST /api/v1/oauth/authorize/context — unauthenticated on purpose: the
+// 256-bit single-use request token IS the credential, and the consent screen
+// must render before sign-in completes.
+func oauthAuthorizeContextHandler(w http.ResponseWriter, r *http.Request) {
+	if !oauthGuard(w) {
+		return
+	}
+	var req oauthContextRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.RequestToken == "" {
+		writeJSONError(w, http.StatusBadRequest, "request_token is required")
+		return
+	}
+	row, err := store.New(dbPool).GetOAuthAuthRequestByRequestHash(r.Context(), hashBearerToken(req.RequestToken))
+	if err != nil || row.ApprovedAt.Valid {
+		writeJSONError(w, http.StatusGone, "authorization request expired — start over from your AI assistant")
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"client_name": row.ClientName,
+		"scopes":      strings.Fields(row.Scope),
+		"expires_at":  row.ExpiresAt,
+	})
+}
+
+type oauthDecisionRequest struct {
+	RequestToken string `json:"request_token"`
+	Approve      bool   `json:"approve"`
+}
+
+// POST /api/v1/oauth/authorize/decision (authMiddleware) — binds the
+// signed-in user, upserts the consent grant, mints the code.
+func oauthAuthorizeDecisionHandler(w http.ResponseWriter, r *http.Request) {
+	if !oauthGuard(w) {
+		return
+	}
+	user, ok := userFromContext(r.Context())
+	if !ok {
+		writeJSONError(w, http.StatusUnauthorized, "authentication required")
+		return
+	}
+	var req oauthDecisionRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.RequestToken == "" {
+		writeJSONError(w, http.StatusBadRequest, "request_token is required")
+		return
+	}
+	q := store.New(dbPool)
+	requestHash := hashBearerToken(req.RequestToken)
+	row, err := q.GetOAuthAuthRequestByRequestHash(r.Context(), requestHash)
+	if err != nil || row.ApprovedAt.Valid {
+		writeJSONError(w, http.StatusGone, "authorization request expired — start over from your AI assistant")
+		return
+	}
+
+	redirect, err := url.Parse(row.RedirectUri)
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "invalid stored redirect")
+		return
+	}
+	rq := redirect.Query()
+	if row.State != "" {
+		rq.Set("state", row.State)
+	}
+
+	if !req.Approve {
+		_ = q.DeleteOAuthAuthRequest(r.Context(), requestHash)
+		rq.Set("error", "access_denied")
+		redirect.RawQuery = rq.Encode()
+		writeJSON(w, http.StatusOK, map[string]string{"redirect_url": redirect.String()})
+		return
+	}
+
+	if _, err := q.UpsertOAuthGrant(r.Context(), store.UpsertOAuthGrantParams{
+		UserID: user.ID, ClientID: row.ClientID, Scope: row.Scope,
+	}); err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "could not record consent")
+		return
+	}
+	rawCode, codeHash, err := newOAuthSecret(oauthCodePrefix)
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "could not mint code")
+		return
+	}
+	// Conditional UPDATE (approved_at IS NULL) makes the consent handle
+	// single-use even under concurrent decisions.
+	if _, err := q.ApproveOAuthAuthRequest(r.Context(), store.ApproveOAuthAuthRequestParams{
+		RequestTokenHash: requestHash,
+		UserID:           pgtype.UUID{Bytes: user.ID, Valid: true},
+		CodeHash:         &codeHash,
+		ExpiresAt:        time.Now().Add(oauthCodeTTL),
+	}); err != nil {
+		writeJSONError(w, http.StatusGone, "authorization request expired — start over from your AI assistant")
+		return
+	}
+
+	rq.Set("code", rawCode)
+	redirect.RawQuery = rq.Encode()
+	writeJSON(w, http.StatusOK, map[string]string{"redirect_url": redirect.String()})
+}
+
+// --- token endpoint -------------------------------------------------------------
+
+// oauthTokenError speaks RFC 6749 §5.2.
+func oauthTokenError(w http.ResponseWriter, status int, code string) {
+	writeJSON(w, status, map[string]string{"error": code})
+}
+
+// POST /api/v1/oauth/token — form-encoded per spec.
+func oauthTokenHandler(w http.ResponseWriter, r *http.Request) {
+	if !oauthGuard(w) {
+		return
+	}
+	if err := r.ParseForm(); err != nil {
+		oauthTokenError(w, http.StatusBadRequest, "invalid_request")
+		return
+	}
+	switch r.PostForm.Get("grant_type") {
+	case "authorization_code":
+		oauthTokenAuthorizationCode(w, r)
+	case "refresh_token":
+		oauthTokenRefresh(w, r)
+	default:
+		oauthTokenError(w, http.StatusBadRequest, "unsupported_grant_type")
+	}
+}
+
+func oauthTokenAuthorizationCode(w http.ResponseWriter, r *http.Request) {
+	q := store.New(dbPool)
+	form := r.PostForm
+
+	clientID, err := uuid.Parse(form.Get("client_id"))
+	if err != nil {
+		oauthTokenError(w, http.StatusUnauthorized, "invalid_client")
+		return
+	}
+	codeHash := hashBearerToken(form.Get("code"))
+	row, err := q.GetOAuthAuthCodeByCodeHash(r.Context(), &codeHash)
+	if err != nil {
+		oauthTokenError(w, http.StatusBadRequest, "invalid_grant")
+		return
+	}
+	if row.CodeUsedAt.Valid {
+		// Code reuse is the classic stolen-code signal: kill everything the
+		// first redemption minted (RFC 6749 §4.1.2), then refuse.
+		_ = q.RevokeOAuthTokensByAuthCode(r.Context(), pgtype.UUID{Bytes: row.ID, Valid: true})
+		oauthTokenError(w, http.StatusBadRequest, "invalid_grant")
+		return
+	}
+	if row.ClientID != clientID ||
+		row.RedirectUri != form.Get("redirect_uri") ||
+		!row.ApprovedAt.Valid || !row.UserID.Valid ||
+		time.Now().After(row.ExpiresAt) {
+		oauthTokenError(w, http.StatusBadRequest, "invalid_grant")
+		return
+	}
+	// PKCE S256, constant-time.
+	computed := pkceChallenge(form.Get("code_verifier"))
+	if subtle.ConstantTimeCompare([]byte(computed), []byte(row.CodeChallenge)) != 1 {
+		oauthTokenError(w, http.StatusBadRequest, "invalid_grant")
+		return
+	}
+
+	userID := uuid.UUID(row.UserID.Bytes)
+	grant, err := q.GetOAuthGrantByUserAndClient(r.Context(), store.GetOAuthGrantByUserAndClientParams{
+		UserID: userID, ClientID: row.ClientID,
+	})
+	if err != nil || grant.RevokedAt.Valid {
+		oauthTokenError(w, http.StatusBadRequest, "invalid_grant")
+		return
+	}
+	if err := q.MarkOAuthCodeUsed(r.Context(), row.ID); err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "could not redeem code")
+		return
+	}
+	issueOAuthTokenPair(w, r, grant.ID, grant.Scope, pgtype.UUID{Bytes: row.ID, Valid: true})
+}
+
+func oauthTokenRefresh(w http.ResponseWriter, r *http.Request) {
+	q := store.New(dbPool)
+	form := r.PostForm
+
+	row, err := q.GetOAuthTokenByRefreshHash(r.Context(), hashBearerToken(form.Get("refresh_token")))
+	if err != nil || row.GrantRevokedAt.Valid {
+		oauthTokenError(w, http.StatusBadRequest, "invalid_grant")
+		return
+	}
+	if cid := form.Get("client_id"); cid != "" && cid != row.ClientID.String() {
+		oauthTokenError(w, http.StatusBadRequest, "invalid_grant")
+		return
+	}
+	// Rotation: the presented refresh token dies with this exchange.
+	if err := q.RevokeOAuthToken(r.Context(), row.ID); err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "could not rotate token")
+		return
+	}
+	issueOAuthTokenPair(w, r, row.GrantID, row.Scope, row.AuthCodeID)
+}
+
+func issueOAuthTokenPair(w http.ResponseWriter, r *http.Request, grantID uuid.UUID, scope string, authCodeID pgtype.UUID) {
+	rawAccess, accessHash, err1 := newOAuthSecret(oauthAccessTokenPrefix)
+	rawRefresh, refreshHash, err2 := newOAuthSecret(oauthRefreshTokenPrefix)
+	if err1 != nil || err2 != nil {
+		writeJSONError(w, http.StatusInternalServerError, "could not mint tokens")
+		return
+	}
+	if _, err := store.New(dbPool).CreateOAuthTokenPair(r.Context(), store.CreateOAuthTokenPairParams{
+		GrantID:          grantID,
+		AuthCodeID:       authCodeID,
+		AccessTokenHash:  accessHash,
+		RefreshTokenHash: refreshHash,
+		AccessExpiresAt:  time.Now().Add(oauthAccessTokenTTL),
+		RefreshExpiresAt: time.Now().Add(oauthRefreshTokenTTL),
+	}); err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "could not mint tokens")
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"access_token":  rawAccess,
+		"token_type":    "Bearer",
+		"expires_in":    int(oauthAccessTokenTTL.Seconds()),
+		"refresh_token": rawRefresh,
+		"scope":         scope,
+	})
+}

--- a/src/packages/api/oauth_provider_integration_test.go
+++ b/src/packages/api/oauth_provider_integration_test.go
@@ -1,0 +1,361 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"travel-route-planner/store"
+)
+
+// OAuth provider integration tests (specs/mcp-connector): the full
+// register → authorize → consent → token dance with a locally computed PKCE
+// pair, plus the negative matrix (never-redirect guard, PKCE mismatch,
+// single-use codes with reuse revocation, refresh rotation, feature gate).
+
+func mcpTestEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("MCP_ENABLED", "true")
+	t.Setenv("PUBLIC_BASE_URL", "http://gt.test")
+}
+
+// doForm drives the router with a form-encoded POST (the token endpoint's
+// required content type; doJSON sends JSON).
+func doForm(t *testing.T, path, token string, form url.Values) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, path, strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("X-Forwarded-For", nextTestIP())
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	rec := httptest.NewRecorder()
+	testRouter.ServeHTTP(rec, req)
+	return rec
+}
+
+// registerTestClient runs DCR and returns the client_id.
+func registerTestClient(t *testing.T, redirectURI string) string {
+	t.Helper()
+	rec := doJSON(t, http.MethodPost, "/api/v1/oauth/register", "", map[string]any{
+		"client_name": "Test AI", "redirect_uris": []string{redirectURI},
+	})
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("register: status = %d, body %s", rec.Code, rec.Body.String())
+	}
+	return decode(t, rec)["client_id"].(string)
+}
+
+// authorizeAndConsent walks authorize → context → decision and returns the
+// authorization code from the decision's redirect URL.
+func authorizeAndConsent(t *testing.T, clientID, redirectURI, challenge, sessionToken string) string {
+	t.Helper()
+	authURL := "/api/v1/oauth/authorize?" + url.Values{
+		"client_id":             {clientID},
+		"redirect_uri":          {redirectURI},
+		"response_type":         {"code"},
+		"code_challenge":        {challenge},
+		"code_challenge_method": {"S256"},
+		"scope":                 {"trips:write recs:read"},
+		"state":                 {"xyz"},
+	}.Encode()
+	rec := doJSON(t, http.MethodGet, authURL, "", nil)
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("authorize: status = %d, body %s", rec.Code, rec.Body.String())
+	}
+	loc := rec.Header().Get("Location")
+	if !strings.HasPrefix(loc, "http://gt.test/connect/") {
+		t.Fatalf("authorize redirect = %q, want consent screen", loc)
+	}
+	requestToken := strings.TrimPrefix(loc, "http://gt.test/connect/")
+
+	ctxRec := doJSON(t, http.MethodPost, "/api/v1/oauth/authorize/context", "", map[string]any{"request_token": requestToken})
+	if ctxRec.Code != http.StatusOK {
+		t.Fatalf("context: status = %d, body %s", ctxRec.Code, ctxRec.Body.String())
+	}
+	if name := decode(t, ctxRec)["client_name"]; name != "Test AI" {
+		t.Fatalf("context client_name = %v", name)
+	}
+
+	decRec := doJSON(t, http.MethodPost, "/api/v1/oauth/authorize/decision", sessionToken,
+		map[string]any{"request_token": requestToken, "approve": true})
+	if decRec.Code != http.StatusOK {
+		t.Fatalf("decision: status = %d, body %s", decRec.Code, decRec.Body.String())
+	}
+	redirectURL, err := url.Parse(decode(t, decRec)["redirect_url"].(string))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if redirectURL.Query().Get("state") != "xyz" {
+		t.Fatalf("state not round-tripped: %s", redirectURL)
+	}
+	code := redirectURL.Query().Get("code")
+	if !strings.HasPrefix(code, "gt_ac_") {
+		t.Fatalf("code = %q, want gt_ac_ prefix", code)
+	}
+	return code
+}
+
+func redeemCode(t *testing.T, clientID, redirectURI, code, verifier string) *httptest.ResponseRecorder {
+	t.Helper()
+	return doForm(t, "/api/v1/oauth/token", "", url.Values{
+		"grant_type":    {"authorization_code"},
+		"code":          {code},
+		"code_verifier": {verifier},
+		"client_id":     {clientID},
+		"redirect_uri":  {redirectURI},
+	})
+}
+
+func TestOAuthFullDance(t *testing.T) {
+	resetDB(t)
+	mcpTestEnv(t)
+	const redirectURI = "https://ai.example/callback"
+	user, sessionToken := createTestUser(t, "oauth@example.com")
+
+	clientID := registerTestClient(t, redirectURI)
+	verifier, err := randomURLToken()
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := authorizeAndConsent(t, clientID, redirectURI, pkceChallenge(verifier), sessionToken)
+
+	rec := redeemCode(t, clientID, redirectURI, code, verifier)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("token: status = %d, body %s", rec.Code, rec.Body.String())
+	}
+	body := decode(t, rec)
+	access := body["access_token"].(string)
+	refresh := body["refresh_token"].(string)
+	if !strings.HasPrefix(access, "gt_at_") || !strings.HasPrefix(refresh, "gt_rt_") {
+		t.Fatalf("token prefixes wrong: %q %q", access, refresh)
+	}
+	if body["token_type"] != "Bearer" || body["scope"] != "trips:write recs:read" {
+		t.Errorf("token metadata: %v", body)
+	}
+
+	// The access token must resolve to the consenting user.
+	row, err := store.New(dbPool).GetOAuthTokenWithUserByAccessHash(context.Background(), hashBearerToken(access))
+	if err != nil {
+		t.Fatalf("access token lookup: %v", err)
+	}
+	if row.User.ID != user.ID {
+		t.Errorf("token user = %s, want %s", row.User.ID, user.ID)
+	}
+	if row.Scope != "trips:write recs:read" {
+		t.Errorf("grant scope = %q", row.Scope)
+	}
+
+	// Refresh rotates: new pair works, old refresh and old access die.
+	refRec := doForm(t, "/api/v1/oauth/token", "", url.Values{
+		"grant_type":    {"refresh_token"},
+		"refresh_token": {refresh},
+		"client_id":     {clientID},
+	})
+	if refRec.Code != http.StatusOK {
+		t.Fatalf("refresh: status = %d, body %s", refRec.Code, refRec.Body.String())
+	}
+	newAccess := decode(t, refRec)["access_token"].(string)
+	if _, err := store.New(dbPool).GetOAuthTokenWithUserByAccessHash(context.Background(), hashBearerToken(newAccess)); err != nil {
+		t.Errorf("rotated access token must resolve: %v", err)
+	}
+	if _, err := store.New(dbPool).GetOAuthTokenWithUserByAccessHash(context.Background(), hashBearerToken(access)); err == nil {
+		t.Error("pre-rotation access token must be revoked")
+	}
+	if again := doForm(t, "/api/v1/oauth/token", "", url.Values{
+		"grant_type": {"refresh_token"}, "refresh_token": {refresh}, "client_id": {clientID},
+	}); again.Code != http.StatusBadRequest {
+		t.Errorf("rotated-away refresh token: status = %d, want 400", again.Code)
+	}
+}
+
+func TestOAuthCodeReuseRevokesTokens(t *testing.T) {
+	resetDB(t)
+	mcpTestEnv(t)
+	const redirectURI = "https://ai.example/callback"
+	_, sessionToken := createTestUser(t, "reuse@example.com")
+	clientID := registerTestClient(t, redirectURI)
+	verifier, _ := randomURLToken()
+	code := authorizeAndConsent(t, clientID, redirectURI, pkceChallenge(verifier), sessionToken)
+
+	first := redeemCode(t, clientID, redirectURI, code, verifier)
+	if first.Code != http.StatusOK {
+		t.Fatalf("first redemption: %d", first.Code)
+	}
+	access := decode(t, first)["access_token"].(string)
+
+	second := redeemCode(t, clientID, redirectURI, code, verifier)
+	if second.Code != http.StatusBadRequest || !strings.Contains(second.Body.String(), "invalid_grant") {
+		t.Fatalf("code reuse: status = %d, body %s", second.Code, second.Body.String())
+	}
+	// Reuse is the stolen-code signal: the first redemption's tokens die.
+	if _, err := store.New(dbPool).GetOAuthTokenWithUserByAccessHash(context.Background(), hashBearerToken(access)); err == nil {
+		t.Error("tokens minted by a reused code must be revoked")
+	}
+}
+
+func TestOAuthPKCEMismatch(t *testing.T) {
+	resetDB(t)
+	mcpTestEnv(t)
+	const redirectURI = "https://ai.example/callback"
+	_, sessionToken := createTestUser(t, "pkce@example.com")
+	clientID := registerTestClient(t, redirectURI)
+	verifier, _ := randomURLToken()
+	code := authorizeAndConsent(t, clientID, redirectURI, pkceChallenge(verifier), sessionToken)
+
+	wrong, _ := randomURLToken()
+	rec := redeemCode(t, clientID, redirectURI, code, wrong)
+	if rec.Code != http.StatusBadRequest || !strings.Contains(rec.Body.String(), "invalid_grant") {
+		t.Fatalf("wrong verifier: status = %d, body %s", rec.Code, rec.Body.String())
+	}
+	// A failed PKCE attempt does not consume the code; the honest client wins.
+	if ok := redeemCode(t, clientID, redirectURI, code, verifier); ok.Code != http.StatusOK {
+		t.Errorf("legit redemption after failed attempt: status = %d", ok.Code)
+	}
+}
+
+func TestOAuthAuthorizeNeverRedirectsBadClients(t *testing.T) {
+	resetDB(t)
+	mcpTestEnv(t)
+	clientID := registerTestClient(t, "https://ai.example/callback")
+
+	// Unregistered redirect_uri: HTML error page, no Location header.
+	rec := doJSON(t, http.MethodGet, "/api/v1/oauth/authorize?"+url.Values{
+		"client_id":             {clientID},
+		"redirect_uri":          {"https://evil.example/steal"},
+		"response_type":         {"code"},
+		"code_challenge":        {"x"},
+		"code_challenge_method": {"S256"},
+	}.Encode(), "", nil)
+	if rec.Code != http.StatusBadRequest || rec.Header().Get("Location") != "" {
+		t.Fatalf("unregistered redirect: status = %d, location %q", rec.Code, rec.Header().Get("Location"))
+	}
+	if ct := rec.Header().Get("Content-Type"); !strings.Contains(ct, "text/html") {
+		t.Errorf("expected HTML error page, got %q", ct)
+	}
+
+	// Registered redirect + bad scope: error goes BACK via redirect.
+	rec = doJSON(t, http.MethodGet, "/api/v1/oauth/authorize?"+url.Values{
+		"client_id":             {clientID},
+		"redirect_uri":          {"https://ai.example/callback"},
+		"response_type":         {"code"},
+		"code_challenge":        {"x"},
+		"code_challenge_method": {"S256"},
+		"scope":                 {"admin:everything"},
+		"state":                 {"s1"},
+	}.Encode(), "", nil)
+	if rec.Code != http.StatusFound {
+		t.Fatalf("bad scope: status = %d", rec.Code)
+	}
+	loc, _ := url.Parse(rec.Header().Get("Location"))
+	if loc.Query().Get("error") != "invalid_scope" || loc.Query().Get("state") != "s1" {
+		t.Errorf("bad-scope redirect = %s", rec.Header().Get("Location"))
+	}
+}
+
+func TestOAuthDenyAndSingleUseConsent(t *testing.T) {
+	resetDB(t)
+	mcpTestEnv(t)
+	const redirectURI = "https://ai.example/callback"
+	_, sessionToken := createTestUser(t, "deny@example.com")
+	clientID := registerTestClient(t, redirectURI)
+
+	authURL := "/api/v1/oauth/authorize?" + url.Values{
+		"client_id": {clientID}, "redirect_uri": {redirectURI}, "response_type": {"code"},
+		"code_challenge": {pkceChallenge("v")}, "code_challenge_method": {"S256"}, "state": {"d1"},
+	}.Encode()
+	rec := doJSON(t, http.MethodGet, authURL, "", nil)
+	requestToken := strings.TrimPrefix(rec.Header().Get("Location"), "http://gt.test/connect/")
+
+	dec := doJSON(t, http.MethodPost, "/api/v1/oauth/authorize/decision", sessionToken,
+		map[string]any{"request_token": requestToken, "approve": false})
+	if dec.Code != http.StatusOK {
+		t.Fatalf("deny: status = %d", dec.Code)
+	}
+	redirectURL, _ := url.Parse(decode(t, dec)["redirect_url"].(string))
+	if redirectURL.Query().Get("error") != "access_denied" || redirectURL.Query().Get("state") != "d1" {
+		t.Errorf("deny redirect = %s", redirectURL)
+	}
+
+	// The consent handle is single-use: a second decision (or context) is gone.
+	if again := doJSON(t, http.MethodPost, "/api/v1/oauth/authorize/decision", sessionToken,
+		map[string]any{"request_token": requestToken, "approve": true}); again.Code != http.StatusGone {
+		t.Errorf("re-used consent handle: status = %d, want 410", again.Code)
+	}
+	if ctx := doJSON(t, http.MethodPost, "/api/v1/oauth/authorize/context", "",
+		map[string]any{"request_token": requestToken}); ctx.Code != http.StatusGone {
+		t.Errorf("context after deny: status = %d, want 410", ctx.Code)
+	}
+}
+
+func TestOAuthRegisterValidation(t *testing.T) {
+	resetDB(t)
+	mcpTestEnv(t)
+	cases := []map[string]any{
+		{"client_name": "X", "redirect_uris": []string{"https://a.example/cb#frag"}},
+		{"client_name": "X", "redirect_uris": []string{"http://not-localhost.example/cb"}},
+		{"client_name": "X", "redirect_uris": []string{}},
+		{"client_name": "", "redirect_uris": []string{"https://a.example/cb"}},
+	}
+	for i, body := range cases {
+		if rec := doJSON(t, http.MethodPost, "/api/v1/oauth/register", "", body); rec.Code != http.StatusBadRequest {
+			t.Errorf("case %d: status = %d, want 400 (body %s)", i, rec.Code, rec.Body.String())
+		}
+	}
+	// http://localhost is fine (MCP Inspector).
+	if rec := doJSON(t, http.MethodPost, "/api/v1/oauth/register", "", map[string]any{
+		"client_name": "Inspector", "redirect_uris": []string{"http://localhost:6274/callback"},
+	}); rec.Code != http.StatusCreated {
+		t.Errorf("localhost redirect: status = %d", rec.Code)
+	}
+}
+
+func TestOAuthDisabledEverything404s(t *testing.T) {
+	resetDB(t)
+	// MCP_ENABLED deliberately unset.
+	paths := []struct {
+		method, path string
+	}{
+		{http.MethodGet, "/.well-known/oauth-protected-resource"},
+		{http.MethodGet, "/.well-known/oauth-protected-resource/mcp"},
+		{http.MethodGet, "/.well-known/oauth-authorization-server"},
+		{http.MethodGet, "/.well-known/openid-configuration"},
+		{http.MethodPost, "/api/v1/oauth/register"},
+		{http.MethodGet, "/api/v1/oauth/authorize"},
+		{http.MethodPost, "/api/v1/oauth/authorize/context"},
+		{http.MethodPost, "/api/v1/oauth/token"},
+	}
+	for _, p := range paths {
+		if rec := doJSON(t, p.method, p.path, "", nil); rec.Code != http.StatusNotFound {
+			t.Errorf("%s %s: status = %d, want 404 while disabled", p.method, p.path, rec.Code)
+		}
+	}
+}
+
+func TestOAuthDiscoveryDocuments(t *testing.T) {
+	resetDB(t)
+	mcpTestEnv(t)
+
+	rec := doJSON(t, http.MethodGet, "/.well-known/oauth-protected-resource/mcp", "", nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("protected-resource: %d", rec.Code)
+	}
+	pr := decode(t, rec)
+	if pr["resource"] != "http://gt.test/mcp" {
+		t.Errorf("resource = %v", pr["resource"])
+	}
+
+	rec = doJSON(t, http.MethodGet, "/.well-known/oauth-authorization-server", "", nil)
+	meta := decode(t, rec)
+	if meta["issuer"] != "http://gt.test" ||
+		meta["token_endpoint"] != "http://gt.test/api/v1/oauth/token" {
+		t.Errorf("metadata = %v", meta)
+	}
+	methods := meta["code_challenge_methods_supported"].([]any)
+	if len(methods) != 1 || methods[0] != "S256" {
+		t.Errorf("code_challenge_methods = %v", methods)
+	}
+}


### PR DESCRIPTION
specs/mcp-connector PR 2 of 6 (stacked on #246, now merged). Golden Tempo can act as the **authorization server** an MCP client needs to link a user's account.

## Endpoints

| Route | Notes |
|---|---|
| `GET /.well-known/oauth-protected-resource[/mcp]` | RFC 9728; both path forms — client probing order varies by release |
| `GET /.well-known/oauth-authorization-server` (+ `openid-configuration` alias) | RFC 8414; advertises S256 + `none` auth |
| `POST /api/v1/oauth/register` | RFC 7591 DCR: public clients only, 1–5 redirect URIs, https (or http on loopback for MCP Inspector), no fragments |
| `GET /api/v1/oauth/authorize` | Validates client/redirect/PKCE/scope/`resource`, parks the request, 302 → app `/connect/<request-token>` |
| `POST /api/v1/oauth/authorize/context` | Consent-screen data; the request token *is* the credential (screen must render pre-sign-in) |
| `POST /api/v1/oauth/authorize/decision` | Authed; approve upserts the grant + mints the code, deny returns `access_denied` |
| `POST /api/v1/oauth/token` | Form-encoded; `authorization_code` + `refresh_token` |

## Security properties

- **Never-redirect guard**: an unknown client or unregistered `redirect_uri` renders an HTML error — the one place redirecting would be an open-redirect vector. Post-validation failures use the RFC error redirect with `state` preserved.
- **PKCE S256 verified constant-time**; a failed verifier does *not* consume the code (the honest client still wins).
- **Single-use codes; reuse revokes** every token that code minted (RFC 6749 §4.1.2 stolen-code response).
- **Refresh rotation** — the presented refresh token dies with the exchange; the pre-rotation access token stops resolving.
- **Single-use consent handle** via a conditional `UPDATE ... WHERE approved_at IS NULL` (safe under concurrent decisions).
- RFC-shaped `{"error": ...}` bodies on register/token (MCP clients parse them), not the app envelope.
- Everything **404s unless `MCP_ENABLED=true`** — merging this exposes nothing.

## Tests

8 integration tests: full dance (register → authorize → context → decision → token → refresh, asserting the token resolves to the consenting user), code reuse revocation, PKCE mismatch, never-redirect guard + invalid_scope redirect, deny + single-use consent handle, DCR validation matrix, feature-gate 404s, discovery document contents. Full Go suite green.

Next: PR 3 adds the Flutter `/connect/` consent screen this flow redirects to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)