### PR TITLE
Fix: connector OAuth endpoints need their own rate bucket

### DIFF
--- a/specs/mcp-connector/plan.md
+++ b/specs/mcp-connector/plan.md
@@ -67,7 +67,10 @@ other failures → `error=` redirect; success → park + 302 to
 mint code; deny → access_denied; expired/used → 410); `POST /oauth/token`
 (form-encoded; constant-time S256 compare via `pkceChallenge`; code reuse →
 `RevokeOAuthTokensByAuthCode`; refresh rotation). Metadata on the general
-limiter tier, the rest strict. Integration tests drive the full dance with a
+limiter tier; the OAuth endpoints get their **own** bucket (30/min burst 15),
+NOT the strict 5/min tier — linking is five calls in seconds and connector
+vendors egress from shared IPs, so strict would make one user's link throttle
+the next user's and could starve login/reset behind the same address. Integration tests drive the full dance with a
 locally computed PKCE pair.
 
 ### PR 4 — MCP server (`mcp_server.go`, `mcp_tools.go`)

--- a/src/packages/api/main.go
+++ b/src/packages/api/main.go
@@ -736,13 +736,23 @@ func buildRouter() *mux.Router {
 
 	// MCP connector OAuth provider (specs/mcp-connector): ChatGPT/claude.ai
 	// register via DCR, the browser consents at the app's /connect/ screen,
-	// tokens redeem here. All handlers gate on MCP_ENABLED. Credential-bearing
-	// endpoints take the strict tier; decision additionally requires auth.
-	api.Handle("/oauth/register", strict(http.HandlerFunc(oauthRegisterHandler))).Methods("POST")
-	api.Handle("/oauth/authorize", strict(http.HandlerFunc(oauthAuthorizeHandler))).Methods("GET")
-	api.Handle("/oauth/authorize/context", strict(http.HandlerFunc(oauthAuthorizeContextHandler))).Methods("POST")
-	api.Handle("/oauth/authorize/decision", strict(authMiddleware(http.HandlerFunc(oauthAuthorizeDecisionHandler)))).Methods("POST")
-	api.Handle("/oauth/token", strict(http.HandlerFunc(oauthTokenHandler))).Methods("POST")
+	// tokens redeem here. All handlers gate on MCP_ENABLED.
+	//
+	// Its OWN bucket, not the strict (5/min) tier: linking an account is five
+	// calls in a few seconds (register, authorize, context, decision, token),
+	// and connector vendors egress from shared IPs — on the strict tier one
+	// user's link would rate-limit the next user's, and could starve
+	// login/reset for anyone behind the same address. 30/min burst 15 fits
+	// several concurrent links while still bounding abuse; every endpoint
+	// underneath is independently protected (PKCE, single-use codes, and
+	// authMiddleware on the decision step).
+	oauthLimiter := newIPRateLimiter(30, 15)
+	oauthTier := rateLimitMiddleware(oauthLimiter)
+	api.Handle("/oauth/register", oauthTier(http.HandlerFunc(oauthRegisterHandler))).Methods("POST")
+	api.Handle("/oauth/authorize", oauthTier(http.HandlerFunc(oauthAuthorizeHandler))).Methods("GET")
+	api.Handle("/oauth/authorize/context", oauthTier(http.HandlerFunc(oauthAuthorizeContextHandler))).Methods("POST")
+	api.Handle("/oauth/authorize/decision", oauthTier(authMiddleware(http.HandlerFunc(oauthAuthorizeDecisionHandler)))).Methods("POST")
+	api.Handle("/oauth/token", oauthTier(http.HandlerFunc(oauthTokenHandler))).Methods("POST")
 	api.HandleFunc("/mcp/availability", mcpAvailabilityHandler).Methods("GET")
 	// Connected apps: always reachable (even with MCP_ENABLED off) so a user
 	// can always see and revoke a connection granted while it was on.

--- a/src/packages/api/oauth_provider_integration_test.go
+++ b/src/packages/api/oauth_provider_integration_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -357,5 +358,66 @@ func TestOAuthDiscoveryDocuments(t *testing.T) {
 	methods := meta["code_challenge_methods_supported"].([]any)
 	if len(methods) != 1 || methods[0] != "S256" {
 		t.Errorf("code_challenge_methods = %v", methods)
+	}
+}
+
+// A connector links an account in five rapid calls (register, authorize,
+// context, decision, token) and vendors egress from shared IPs — the OAuth
+// endpoints must not sit on the strict 5/min tier, where one user's link
+// would throttle the next user's (found end-to-end against the dev stack).
+func TestOAuthDanceSurvivesFromOneIP(t *testing.T) {
+	resetDB(t)
+	mcpTestEnv(t)
+	const redirectURI = "https://ai.example/callback"
+	ip := nextTestIP()
+
+	// Three consecutive full links from the SAME address, as three users
+	// behind one connector egress IP would produce.
+	for i := 0; i < 3; i++ {
+		user, sessionToken := createTestUser(t, fmt.Sprintf("shared%d@example.com", i))
+		_ = user
+
+		rec := doJSONFromIP(t, http.MethodPost, "/api/v1/oauth/register", "", ip, map[string]any{
+			"client_name": "Shared AI", "redirect_uris": []string{redirectURI},
+		})
+		if rec.Code != http.StatusCreated {
+			t.Fatalf("link %d register: status = %d, body %s", i, rec.Code, rec.Body.String())
+		}
+		clientID := decode(t, rec)["client_id"].(string)
+
+		verifier, _ := randomURLToken()
+		authURL := "/api/v1/oauth/authorize?" + url.Values{
+			"client_id": {clientID}, "redirect_uri": {redirectURI}, "response_type": {"code"},
+			"code_challenge": {pkceChallenge(verifier)}, "code_challenge_method": {"S256"},
+		}.Encode()
+		rec = doJSONFromIP(t, http.MethodGet, authURL, "", ip, nil)
+		if rec.Code != http.StatusSeeOther {
+			t.Fatalf("link %d authorize: status = %d", i, rec.Code)
+		}
+		requestToken := strings.TrimPrefix(rec.Header().Get("Location"), "http://gt.test/connect/")
+
+		if rec = doJSONFromIP(t, http.MethodPost, "/api/v1/oauth/authorize/context", "", ip,
+			map[string]any{"request_token": requestToken}); rec.Code != http.StatusOK {
+			t.Fatalf("link %d context: status = %d", i, rec.Code)
+		}
+		rec = doJSONFromIP(t, http.MethodPost, "/api/v1/oauth/authorize/decision", sessionToken, ip,
+			map[string]any{"request_token": requestToken, "approve": true})
+		if rec.Code != http.StatusOK {
+			t.Fatalf("link %d decision: status = %d, body %s", i, rec.Code, rec.Body.String())
+		}
+		redirectURL, _ := url.Parse(decode(t, rec)["redirect_url"].(string))
+		code := redirectURL.Query().Get("code")
+
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/oauth/token", strings.NewReader(url.Values{
+			"grant_type": {"authorization_code"}, "code": {code}, "code_verifier": {verifier},
+			"client_id": {clientID}, "redirect_uri": {redirectURI},
+		}.Encode()))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		req.Header.Set("X-Forwarded-For", ip)
+		tokRec := httptest.NewRecorder()
+		testRouter.ServeHTTP(tokRec, req)
+		if tokRec.Code != http.StatusOK {
+			t.Fatalf("link %d token: status = %d, body %s", i, tokRec.Code, tokRec.Body.String())
+		}
 	}
 }


### PR DESCRIPTION
Found by running the connector flow end-to-end against the dev stack (not by any test — the unit/integration tests each used a fresh IP).

## The bug

Linking an account is **five calls in a few seconds**: `register` → `authorize` → `context` → `decision` → `token`. They were all on the `strict` tier (5/min, burst 3), so a single link 429s partway through — the e2e run died at step 4 with `rate limited; retry shortly`.

Production would be worse than the test: **connector vendors egress from shared IPs**, so one user's link would throttle the next user's, and — because `strict` is shared with `/auth/login`, `/auth/register` and password reset — a busy connector could starve sign-in for everyone behind the same address. This is the same reasoning that put `/mcp` on a per-grant limiter; the OAuth endpoints were the gap.

## The fix

Their own bucket at 30/min burst 15 (the `/transcribe` and `/trips/import` precedent). Abuse protection is unchanged in substance: PKCE, single-use codes, and `authMiddleware` on the decision step all still apply, and the bucket still bounds volume.

## Verification

- New regression test drives **three consecutive full links from one IP** (what three users behind one connector egress looks like).
- After the fix, the complete flow passes **through the real nginx gateway** on the dev stack: discovery → DCR → authorize → consent → token → MCP `initialize` → `tools/list` → `create_trip` (which created a real trip and returned its URL) → `list_trips` → unauthenticated `/mcp` correctly answering 401 with the `WWW-Authenticate` challenge.