### PR TITLE
docs: prod host is now DigitalOcean

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,7 +181,7 @@ jobs:
         with:
           context: src/packages/api
           file: src/packages/api/Dockerfile
-          # Production is an amd64 VPS (Vultr); re-add linux/arm64 (plus the
+          # Production is an amd64 VPS (DigitalOcean); re-add linux/arm64 (plus the
           # setup-qemu-action step) if an ARM host ever returns.
           platforms: linux/amd64
           push: true
@@ -228,7 +228,7 @@ jobs:
     env:
       IMAGE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.image_tag || github.sha }}
     steps:
-      # The production host is a Raspberry Pi behind a Cloudflare Tunnel, so
+      # The production host is a cloud VPS behind a Cloudflare Tunnel, so
       # there is no publicly routable SSH port: every ssh/rsync below goes
       # through `cloudflared access ssh` against the tunnel's SSH hostname
       # (DEPLOY_HOST, e.g. ssh.goldentempotravel.com), authenticated by a

--- a/dockerize/production/README.md
+++ b/dockerize/production/README.md
@@ -1,7 +1,7 @@
 # Production stack — goldentempotravel.com
 
-Runs the prebuilt GHCR images (amd64) on a cloud VPS (**Vultr**,
-Ubuntu LTS — previously a home Raspberry Pi) reached exclusively through
+Runs the prebuilt GHCR images (amd64) on a cloud VPS (**DigitalOcean**,
+Ubuntu LTS — previously Vultr, originally a home Raspberry Pi) reached exclusively through
 a **Cloudflare Tunnel**: the `cloudflared` service dials out to the
 Cloudflare edge, so the host publishes no ports and exposes nothing
 directly — even with a public IP, ingress stays tunnel-only. TLS


### PR DESCRIPTION
Vultr suspended the account on 07-31; prod was re-homed to a DigitalOcean droplet on 08-01 (same tunnel, DNS, compose stack — token rotated, DB restored from the 07-31 R2 dump). Updates the three stale provider references: production README header, ci.yml build-platform comment, ci.yml deploy-job comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)