### PR TITLE
feat: /wave and /lane triggers for the parallel-lane workflow

### DIFF
--- a/.claude/skills/lane/SKILL.md
+++ b/.claude/skills/lane/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: lane
+description: Bootstrap ONE parallel lane — worktree + port slot + LANE-BRIEF.md — and print the terminal one-liner to start a session in it (or spawn a background agent on request). The Mode B counterpart to /wave; rules in docs/parallel-dev.md.
+---
+
+# /lane — bootstrap a single lane
+
+Usage: `/lane NAME [the lane's brief…]`. NAME becomes the branch, worktree
+directory, and compose project (`gtt-<name>`). No NAME → ask.
+
+## Steps
+
+1. **Create the worktree**: `make wt-new NAME=<name>` (from the main
+   checkout). It branches off origin/main, assigns the next port slot, copies
+   and retargets `.env`, and prints the lane's gateway/postgres ports.
+
+2. **Write `LANE-BRIEF.md`** at the worktree root (it is gitignored — never
+   committed, never blocks ship or worktree removal), containing:
+   - The brief: from the args; if none given, ask for one or a spec to point
+     at (`specs/<feature>/` — include its `spec.md`/`plan.md`/task rows).
+   - A conflict-manifest section: every EXISTING file the lane may edit,
+     checked against the hub table (`docs/parallel-dev.md` §3); reserved
+     migration number if the lane needs one.
+   - The closing instruction verbatim: *"Run local checks, then `ship pr`.
+     Report the PR URL. Do not merge. Do not touch files outside your
+     manifest."*
+
+3. **Hand off.** Print the one-liner for a new terminal:
+
+   ```bash
+   cd .claude/worktrees/<name> && claude "read LANE-BRIEF.md and execute it"
+   ```
+
+   If the user asked for background ("bg", "spawn it"): do NOT use worktree
+   isolation — that would create a second worktree. Spawn a background Agent
+   whose prompt says to work inside this existing worktree directory and
+   execute its `LANE-BRIEF.md`; report the agent's task id.
+
+4. Remind: `make docker-dev-bg` inside the lane brings up its own stack on
+   the printed ports (only needed for hands-on testing); after the PR merges,
+   `make wt-rm NAME=<name>` from the main checkout cleans everything up.

--- a/.claude/skills/wave/SKILL.md
+++ b/.claude/skills/wave/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: wave
+description: Run plans/specs as parallel coding lanes end to end — cross-plan conflict check, lane table (pauses once for approval), fan out worktree agents, auto-/integrate when every lane reaches PR-open. `/wave status` shows lanes/agents/PRs; `/wave abort` is the kill switch. Rules live in docs/parallel-dev.md.
+---
+
+# /wave — orchestrate a parallel lane wave
+
+Args decide the mode: `status` → snapshot; `abort` → kill switch; anything else
+(spec names, plan-file paths, or free-text feature descriptions) → orchestrate.
+No args in orchestrate intent → ask what to run.
+
+## Orchestrate
+
+1. **Resolve inputs.** Accept any mix of: `specs/<name>/` directories,
+   `~/.claude/plans/*.md` files, or ad-hoc descriptions. Read every plan fully
+   before partitioning.
+
+2. **Cross-plan conflict check.** Build a per-lane conflict manifest (every
+   EXISTING file the lane will edit — new files are free) against the hub
+   table in `docs/parallel-dev.md` §3. Enforce the four constraints:
+   ≤1 lane touches `trip_detail_screen.dart`; ≤1 lane appends to
+   `plan_tool_registry.go`; ARB key prefixes unique across the wave;
+   ≤1 migration per lane with numbers reserved NOW
+   (`ls src/packages/api/migrations | tail -1` → next free, assigned in merge
+   order). 2–4 lanes total. If a constraint cannot be satisfied, propose a
+   re-split or a serialization edge and say so in the table.
+
+3. **Write the Lanes section** into each spec's `tasks.md` (template:
+   `specs/_template/tasks.md`). For plan-file or ad-hoc inputs, put the lane
+   table in a wave note instead.
+
+4. **PAUSE — the one human gate.** Present the lane table (lanes, branches,
+   manifests, reserved migration numbers, merge order) with AskUserQuestion:
+   approve / edit / cancel. State explicitly: *after approval the wave runs
+   unattended through fan-out, PR-open, serial merge, and prod deploys.*
+
+5. **Preflight.** Main CI green, no deploy in flight, `git status` clean in
+   the main checkout, `make wt-list` shows no conflicting lanes.
+
+6. **Fan out.** One background Agent per lane, `isolation: "worktree"`. The
+   lane brief must contain: the spec/plan paths; the lane's task rows and
+   conflict manifest verbatim; its reserved migration number (if any); a
+   `make wt-init` note if the lane needs a live dev stack; and the closing
+   instruction verbatim: *"Run local checks, then `ship pr`. Report the PR
+   URL. Do not merge. Do not touch files outside your manifest."*
+
+7. **Monitor.** Track lanes via TaskList/TaskOutput; steer or hand red-CI
+   failures back with SendMessage (who-fixes-what rule:
+   `docs/parallel-dev.md` §6). Collect PR URLs from completion reports.
+
+8. **Auto-integrate.** When EVERY lane has reported PR-open, run the
+   `integrate` skill with the lane table's merge order. No second approval —
+   the step-4 gate covered this.
+
+9. **Close.** `make wt-rm NAME=<lane>` per merged lane (from the main
+   checkout), then report the wave summary: PRs merged, deploys verified,
+   final prod SHA, anything handed back or left open.
+
+## /wave status
+
+One combined snapshot, no changes: `make wt-list` (lanes/slots/ports),
+TaskList (running lane agents), `gh pr list` (open lane PRs), and
+`docker compose ls` filtered to `gtt-*`/`development`. Flag anomalies
+(a lane worktree with no agent and no PR; an agent whose lane is gone).
+
+## /wave abort
+
+The kill switch. Stop every running lane agent (TaskStop). Then ASK before
+touching worktrees — `make wt-rm` destroys uncommitted lane work; default is
+to leave worktrees in place. Report per lane: agent stopped / already done /
+worktree kept or removed, and any PRs already open (they stay open for a
+later `/integrate` or manual close).

--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ logs/
 # Per-worktree dev-stack config (scripts/worktree.sh writes it) and the
 # lane worktrees themselves (also in .git/info/exclude on harness machines)
 .wt.env
+LANE-BRIEF.md
 .claude/worktrees/
 
 # Docker volumes and data

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,8 @@ agents STOP at PR-open (`ship pr` — never merge); one integrator session
 hand-merged — regen LAST), merges serially, and watches each deploy. Wave
 planning reserves goose migration numbers; at most one in-flight lane may touch
 `trip_detail_screen.dart` or append to `plan_tool_registry.go`. Full rules and
-runbooks: [`docs/parallel-dev.md`](docs/parallel-dev.md).
+runbooks: [`docs/parallel-dev.md`](docs/parallel-dev.md). Triggers: `/wave`
+(orchestrate a wave; also `status`/`abort`) and `/lane` (bootstrap one lane).
 
 ## Common Commands
 

--- a/docs/parallel-dev.md
+++ b/docs/parallel-dev.md
@@ -142,6 +142,11 @@ failure reproduces on the lane branch *before* the rebase, it's the lane's.
 
 ## 7. Wave runbook
 
+> Shortcuts: `/wave <plans…>` automates Mode A end to end (steps 1–6 with one
+> approval pause at the lane table, then auto-`/integrate`); `/lane NAME`
+> bootstraps a Mode B worktree with a `LANE-BRIEF.md`. The steps below remain
+> the underlying reference.
+
 1. **Plan** — planning agents (read-only, parallel — this part already works)
    draft the Lanes section of `specs/<feature>/tasks.md`: per-lane branch,
    tasks, conflict manifest, reserved migration numbers, dependency edges.


### PR DESCRIPTION
## Summary
- **`/wave <plans|specs>`** (new skill): the whole Mode A loop as one word — resolve inputs (specs, `~/.claude/plans` files, or free text) → cross-plan conflict check against the hub table (four constraints, migration numbers reserved in merge order) → Lanes section written into `tasks.md` → **one approval pause at the lane table** (after which the wave runs unattended) → worktree fan-out with the standard lane brief → monitoring/hand-back → **auto-`/integrate`** when every lane reaches PR-open → close-out summary. Also `/wave status` (lanes + agents + PRs + stacks snapshot) and `/wave abort` (stop agents; worktrees kept unless explicitly confirmed).
- **`/lane NAME [brief]`** (new skill): Mode B bootstrap — `make wt-new`, a gitignored `LANE-BRIEF.md` in the worktree (brief + conflict manifest + the stop-at-PR-open closing instruction), and the terminal one-liner `cd .claude/worktrees/<name> && claude "read LANE-BRIEF.md and execute it"`; background-spawn variant on request.
- `.gitignore` += `LANE-BRIEF.md`; one-sentence trigger pointer in CLAUDE.md's Parallel Development section; shortcut note atop the `docs/parallel-dev.md` §7 runbook.

## Testing
- Docs/skills-only PR (no code paths); CI gates run on unchanged code.
- Skill registration is automatic on merge (observed live for `integrate` earlier tonight); `LANE-BRIEF.md` ignore verified by pattern (same mechanism as `.wt.env`, proven in the lane this PR was built in).
- Live-fire verification is the first real `/wave` over the two ready-to-execute plans (already the agreed next step).

Built in its own lane (worktree `wave-triggers`, slot 3) while two other lanes were active — stopping at PR-open per `docs/parallel-dev.md`; the integrator merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)