### PR TITLE
ci: refresh the IMAGE_TAG pin in prod .env on every deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -322,9 +322,14 @@ jobs:
           TUNNEL_SERVICE_TOKEN_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
         run: rsync -rtvz dockerize/production/ "deploy-target:/opt/goldentempo/"
 
-      # .image_tag records what's live so manual server-side restarts can
-      # reuse it (see dockerize/production/README.md) instead of silently
-      # falling back to :latest.
+      # Record what's live in BOTH places manual operations read: .image_tag
+      # (the runbook's explicit source) and the IMAGE_TAG pin in .env, which
+      # compose interpolation reads automatically. Refreshing the .env pin is
+      # what makes a bare `docker compose up -d` on the host safe — before
+      # this, the pin went stale on every deploy and a manual recreate
+      # silently rolled the stack back to the old image (2026-08-01 incident).
+      # The gate step's IMAGE_TAG charset check ([A-Za-z0-9._-]) keeps the
+      # sed replacement injection-free.
       - name: Pull images and restart stack
         if: steps.gate.outputs.configured == 'true'
         env:
@@ -334,6 +339,11 @@ jobs:
           ssh deploy-target "set -eu
             cd /opt/goldentempo
             printf 'IMAGE_TAG=%s\n' '${IMAGE_TAG}' > .image_tag
+            if grep -q '^IMAGE_TAG=' .env; then
+              sed -i 's/^IMAGE_TAG=.*/IMAGE_TAG=${IMAGE_TAG}/' .env
+            else
+              printf 'IMAGE_TAG=%s\n' '${IMAGE_TAG}' >> .env
+            fi
             export IMAGE_TAG='${IMAGE_TAG}'
             docker compose pull
             docker compose up -d --remove-orphans

--- a/dockerize/production/.env.sample
+++ b/dockerize/production/.env.sample
@@ -20,9 +20,11 @@
 # would break the DSN.
 POSTGRES_PASSWORD=
 
-# Image tag to run (CI publishes :latest and :<git-sha>). Deploys usually
-# override this per-command (IMAGE_TAG=<sha> docker compose up -d); the value
-# here is only the fallback when the shell doesn't set one.
+# Image tag to run (CI publishes :latest and :<git-sha>). The CI deploy job
+# REWRITES this line to the deployed SHA on every deploy, so manual
+# `docker compose up -d` runs whatever is actually live. Only edit it by
+# hand for a deliberate manual rollback (or set IMAGE_TAG=<sha> per-command,
+# which overrides this file).
 IMAGE_TAG=latest
 
 # REQUIRED — compose refuses to start without it. The Cloudflare Tunnel

--- a/dockerize/production/README.md
+++ b/dockerize/production/README.md
@@ -125,8 +125,10 @@ docker compose exec gateway nginx -t && docker compose exec gateway nginx -s rel
 both images to GHCR (`:latest` and `:<sha>`) and the CI `deploy` job
 rsyncs this directory to `/opt/goldentempo/` and restarts the stack with
 `IMAGE_TAG=<sha>`. It also writes the live tag to
-`/opt/goldentempo/.image_tag` so manual restarts don't fall back to
-`:latest`. CI reaches the host through the tunnel's SSH hostname via
+`/opt/goldentempo/.image_tag` AND refreshes the `IMAGE_TAG=` pin inside
+`/opt/goldentempo/.env`, so a bare `docker compose up -d` on the host
+always runs the currently-deployed image — a stale `.env` pin once made a
+manual recreate silently roll the stack back to an old image. CI reaches the host through the tunnel's SSH hostname via
 `cloudflared access ssh` + an Access service token. (Until the
 `DEPLOY_HOST` / `DEPLOY_SSH_KEY` / `DEPLOY_KNOWN_HOSTS` /
 `CF_ACCESS_CLIENT_ID` / `CF_ACCESS_CLIENT_SECRET` secrets exist, the
@@ -142,8 +144,9 @@ green main build. Manual fallback on the server:
 ```bash
 cd /opt/goldentempo
 
-# Restart whatever is currently deployed (reads .image_tag written by CI)
-set -a; . ./.image_tag; set +a
+# Restart whatever is currently deployed. CI refreshes the IMAGE_TAG pin in
+# .env on every deploy, so bare compose commands are safe; sourcing
+# .image_tag first is equivalent belt-and-braces.
 docker compose pull && docker compose up -d
 
 # Deploy/rollback a specific build by hand


### PR DESCRIPTION
## Why

During the SerpApi flight-swap prod flip (2026-08-01), a manual `docker compose up -d --force-recreate api` on the droplet silently rolled the api back to a 17-hour-old image. Root cause: the deploy job overrides `IMAGE_TAG` as a shell variable for its own compose run and records it in `.image_tag`, but compose interpolation reads the `IMAGE_TAG=` line in `.env` — which nothing ever refreshed, so it went staler with every deploy.

## What

- The deploy job now rewrites (or appends) the `IMAGE_TAG=` pin in `/opt/goldentempo/.env` alongside `.image_tag`, so a bare `docker compose up -d` on the host always runs the currently-deployed image. The existing gate-step charset check (`[A-Za-z0-9._-]`) keeps the sed replacement injection-free.
- `dockerize/production/README.md`: manual-restart runbook updated (bare compose is now safe; sourcing `.image_tag` stays as belt-and-braces).
- `dockerize/production/.env.sample`: documents that CI owns the pin; hand-edit only for deliberate manual rollback.

## Verification

- Shell-expansion simulation of the ssh script (both grep-hit sed path and append path) against a scratch `.env`: pin replaced/appended exactly once, other lines (secrets) untouched.
- YAML parses. The first main deploy after merge exercises the new step live; the deploy self-verify step already proves the served SHA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)