### PR TITLE
docs: auto-lane-on-execute rule in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,12 @@ planning reserves goose migration numbers; at most one in-flight lane may touch
 runbooks: [`docs/parallel-dev.md`](docs/parallel-dev.md). Triggers: `/wave`
 (orchestrate a wave; also `status`/`abort`) and `/lane` (bootstrap one lane).
 
+**Auto-lane on execute**: when executing an approved plan (or starting any
+multi-file feature work) from the **main checkout**, first create a lane —
+`make wt-new NAME=<feature-slug>` — and do all the work inside that worktree;
+`ship` then stops at PR-open automatically and the integrator merges.
+Single-file fixes and doc touch-ups may stay on a main-checkout branch.
+
 ## Common Commands
 
 ```bash


### PR DESCRIPTION
## Summary
- Adds the **auto-lane-on-execute** rule to CLAUDE.md's Parallel Development section: any session executing an approved plan (or starting multi-file feature work) from the main checkout first creates its own lane (`make wt-new NAME=<slug>`) and works inside that worktree — so N plan windows lane themselves instead of colliding in one working tree. Single-file fixes and doc touch-ups stay on a plain main-checkout branch.

## Testing
- Docs-only, one CLAUDE.md hunk; CI gates run on unchanged code.
- Real verification: the next plan-window execute should self-lane without being told (every session loads CLAUDE.md).

Built in its own lane (`auto-lane-rule`) — stopping at PR-open per the workflow; the integrator merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)