### PR TITLE
feat: make the logo a home button (rail brand + home app bar)

### DIFF
--- a/src/packages/flutter-app/lib/navigation/app_nav.dart
+++ b/src/packages/flutter-app/lib/navigation/app_nav.dart
@@ -28,6 +28,18 @@ void pushOnActiveTab(WidgetRef ref, Widget page) {
   state?.push(MaterialPageRoute(builder: (_) => page));
 }
 
+/// Return to the Home tab — the logo-tap action. Mirrors the shell's
+/// tab-select behavior: already on Home pops its stack to the root, otherwise
+/// the tab switches (keeping the other tab's stack intact for its next visit).
+void goHome(WidgetRef ref) {
+  if (ref.read(navIndexProvider) == AppTab.home.index) {
+    final keys = ref.read(tabNavKeysProvider);
+    keys[AppTab.home.index].currentState?.popUntil((r) => r.isFirst);
+  } else {
+    ref.read(navIndexProvider.notifier).state = AppTab.home.index;
+  }
+}
+
 /// One nav destination's icons. Shared so the shell's rail and bar render the
 /// exact same set, in lockstep. Labels are NOT here: they are localized and
 /// resolved from [AppTab] in the shell (specs/i18n-spanish), so there is one

--- a/src/packages/flutter-app/lib/screens/app_shell.dart
+++ b/src/packages/flutter-app/lib/screens/app_shell.dart
@@ -118,17 +118,19 @@ const List<Widget> _tabRoots = [
 
 /// The Golden Tempo Travel brand mark for the top of the rail — the persistent
 /// Site ID (Krug). The horseshoe mark on a light badge so it fits the narrow
-/// rail and the black/gold artwork reads on the surface.
-class _RailBrand extends StatelessWidget {
+/// rail and the black/gold artwork reads on the surface. Tapping it goes Home,
+/// per the universal logo-links-home convention.
+class _RailBrand extends ConsumerWidget {
   const _RailBrand();
 
   @override
-  Widget build(BuildContext context) {
-    return const Padding(
-      padding: EdgeInsets.only(top: AppSpacing.lg, bottom: AppSpacing.sm),
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Padding(
+      padding: const EdgeInsets.only(top: AppSpacing.lg, bottom: AppSpacing.sm),
       child: BrandBadge(
-        padding: EdgeInsets.all(AppSpacing.sm),
-        child: BrandLogo.mark(size: 36),
+        padding: const EdgeInsets.all(AppSpacing.sm),
+        onTap: () => goHome(ref),
+        child: const BrandLogo.mark(size: 36),
       ),
     );
   }

--- a/src/packages/flutter-app/lib/screens/home_screen.dart
+++ b/src/packages/flutter-app/lib/screens/home_screen.dart
@@ -98,10 +98,12 @@ class HomeScreen extends ConsumerWidget {
             return Row(
               mainAxisSize: MainAxisSize.min,
               children: [
-                const BrandBadge(
-                  padding: EdgeInsets.symmetric(
+                BrandBadge(
+                  padding: const EdgeInsets.symmetric(
                       horizontal: AppSpacing.sm, vertical: AppSpacing.xs),
-                  child: BrandLogo.mark(size: 28),
+                  // Logo-links-home: pops anything pushed on the Home stack.
+                  onTap: () => goHome(ref),
+                  child: const BrandLogo.mark(size: 28),
                 ),
                 if (!compact) ...const [
                   SizedBox(width: AppSpacing.sm),

--- a/src/packages/flutter-app/lib/widgets/brand_logo.dart
+++ b/src/packages/flutter-app/lib/widgets/brand_logo.dart
@@ -83,6 +83,7 @@ class BrandBadge extends StatelessWidget {
   final EdgeInsetsGeometry padding;
   final BorderRadius borderRadius;
   final bool circle;
+  final VoidCallback? onTap;
 
   const BrandBadge({
     super.key,
@@ -91,11 +92,12 @@ class BrandBadge extends StatelessWidget {
         horizontal: AppSpacing.md, vertical: AppSpacing.sm),
     this.borderRadius = AppRadius.mdAll,
     this.circle = false,
+    this.onTap,
   });
 
   @override
   Widget build(BuildContext context) {
-    return Container(
+    final badge = Container(
       padding: padding,
       decoration: BoxDecoration(
         color: Colors.white.withValues(alpha: 0.92),
@@ -103,6 +105,22 @@ class BrandBadge extends StatelessWidget {
         borderRadius: circle ? null : borderRadius,
       ),
       child: child,
+    );
+    if (onTap == null) return badge;
+    // The badge surface is opaque, so the ripple mostly hides behind it —
+    // the InkWell is here for the tap target, web pointer cursor, and focus
+    // handling rather than the splash.
+    return Semantics(
+      button: true,
+      child: Material(
+        type: MaterialType.transparency,
+        child: InkWell(
+          onTap: onTap,
+          customBorder: circle ? const CircleBorder() : null,
+          borderRadius: circle ? null : borderRadius,
+          child: badge,
+        ),
+      ),
     );
   }
 }

--- a/src/packages/flutter-app/test/logo_home_nav_test.dart
+++ b/src/packages/flutter-app/test/logo_home_nav_test.dart
@@ -1,0 +1,106 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:travel_route_planner/navigation/app_nav.dart';
+import 'package:travel_route_planner/widgets/brand_logo.dart';
+
+/// Logo-links-home: the brand badge is tappable when given onTap (rail brand
+/// and Home app bar), and goHome mirrors the shell's tab-select behavior —
+/// switch to Home from another tab, pop Home's stack to root when already
+/// there.
+void main() {
+  testWidgets('BrandBadge with onTap fires the callback',
+      (WidgetTester tester) async {
+    var taps = 0;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: BrandBadge(
+            onTap: () => taps++,
+            child: const SizedBox(width: 24, height: 24),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.byType(BrandBadge));
+    expect(taps, 1);
+  });
+
+  testWidgets('BrandBadge without onTap stays a plain surface',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: BrandBadge(child: SizedBox(width: 24, height: 24)),
+        ),
+      ),
+    );
+
+    expect(
+      find.descendant(
+          of: find.byType(BrandBadge), matching: find.byType(InkWell)),
+      findsNothing,
+    );
+  });
+
+  testWidgets('goHome switches back to the Home tab from another tab',
+      (WidgetTester tester) async {
+    late WidgetRef capturedRef;
+    await tester.pumpWidget(
+      ProviderScope(
+        child: MaterialApp(
+          home: Consumer(builder: (context, ref, _) {
+            capturedRef = ref;
+            return const SizedBox();
+          }),
+        ),
+      ),
+    );
+    final container =
+        ProviderScope.containerOf(tester.element(find.byType(Consumer)));
+    container.read(navIndexProvider.notifier).state = AppTab.trips.index;
+
+    goHome(capturedRef);
+
+    expect(container.read(navIndexProvider), AppTab.home.index);
+  });
+
+  testWidgets('goHome pops the Home stack to its root when already on Home',
+      (WidgetTester tester) async {
+    late WidgetRef capturedRef;
+    await tester.pumpWidget(
+      ProviderScope(
+        child: Consumer(builder: (context, ref, _) {
+          capturedRef = ref;
+          final keys = ref.watch(tabNavKeysProvider);
+          return MaterialApp(
+            home: Navigator(
+              key: keys[AppTab.home.index],
+              onGenerateRoute: (settings) => MaterialPageRoute(
+                builder: (_) => const Text('home root'),
+                settings: settings,
+              ),
+            ),
+          );
+        }),
+      ),
+    );
+    final container =
+        ProviderScope.containerOf(tester.element(find.byType(Consumer)));
+    container
+        .read(tabNavKeysProvider)[AppTab.home.index]
+        .currentState!
+        .push(MaterialPageRoute(builder: (_) => const Text('pushed page')));
+    await tester.pumpAndSettle();
+    expect(find.text('pushed page'), findsOneWidget);
+
+    goHome(capturedRef);
+    await tester.pumpAndSettle();
+
+    expect(find.text('pushed page'), findsNothing);
+    expect(find.text('home root'), findsOneWidget);
+    expect(container.read(navIndexProvider), AppTab.home.index);
+  });
+}


### PR DESCRIPTION
## Summary
- The brand logo now navigates home, per the universal logo-links-home convention.
- `BrandBadge` gains an optional `onTap` (transparent `Material` + `InkWell` for the tap target, web pointer cursor, and focus handling; `Semantics(button: true)`). Without `onTap` it renders exactly as before.
- New shared `goHome(ref)` helper in `app_nav.dart` mirrors the shell's tab-select behavior: from another tab it switches to Home; already on Home it pops the Home stack to its root.
- Wired to the nav-rail brand (`_RailBrand`, wide layout — visible on every tab) and the Home app-bar badge. Signed-out screens (landing/auth/splash) stay static since the landing page already is home.

## Testing
- New `test/logo_home_nav_test.dart` (4 tests): badge tap fires, no-`onTap` badge has no InkWell, `goHome` switches tabs, `goHome` pops the Home stack to root.
- Full `flutter test` suite: 594 passing. `flutter analyze`: only the 3 pre-existing info lints in `route_response.dart` (CI runs `--no-fatal-infos`).
- Manual in the dev stack at desktop width: from the Trips tab, clicking the rail logo lands on Home.

🤖 Generated with [Claude Code](https://claude.com/claude-code)