### PR TITLE
fix: remove duplicate Get started CTA on the landing page

### DIFF
--- a/src/packages/flutter-app/lib/screens/landing_screen.dart
+++ b/src/packages/flutter-app/lib/screens/landing_screen.dart
@@ -103,22 +103,6 @@ class _LandingScreenState extends State<LandingScreen> {
                   title: l10n.landingFeatureAgentTitle,
                   description: l10n.landingFeatureAgentDescription,
                 ),
-                const SizedBox(height: AppSpacing.xl),
-                SizedBox(
-                  width: double.infinity,
-                  child: FilledButton(
-                    onPressed: () => _openAuth(context, isLogin: false),
-                    style: FilledButton.styleFrom(
-                      padding:
-                          const EdgeInsets.symmetric(vertical: AppSpacing.lg),
-                    ),
-                    child: Text(
-                      l10n.landingGetStarted,
-                      style: const TextStyle(
-                          fontWeight: FontWeight.bold, fontSize: 16),
-                    ),
-                  ),
-                ),
                 const SizedBox(height: AppSpacing.lg),
                 const _LandingFooter(),
                 const SizedBox(height: AppSpacing.lg),

--- a/src/packages/flutter-app/test/landing_polish_test.dart
+++ b/src/packages/flutter-app/test/landing_polish_test.dart
@@ -59,9 +59,9 @@ void main() {
     await _pump(tester, surface: const Size(320, 568));
     expect(tester.takeException(), isNull);
 
-    // Hero CTA (the first 'Get started' in tree order) is fully visible
-    // without scrolling — the acquisition-surface guarantee.
-    final primary = find.widgetWithText(FilledButton, 'Get started').first;
+    // Hero CTA is fully visible without scrolling — the acquisition-surface
+    // guarantee.
+    final primary = find.widgetWithText(FilledButton, 'Get started');
     expect(tester.getBottomLeft(primary).dy, lessThanOrEqualTo(568));
     final secondary =
         find.widgetWithText(TextButton, 'I already have an account');
@@ -74,8 +74,8 @@ void main() {
         surface: const Size(360, 690), locale: const Locale('es'));
     expect(tester.takeException(), isNull);
 
-    expect(find.text('Empezar'), findsWidgets);
-    final primary = find.widgetWithText(FilledButton, 'Empezar').first;
+    expect(find.text('Empezar'), findsOneWidget);
+    final primary = find.widgetWithText(FilledButton, 'Empezar');
     expect(tester.getBottomLeft(primary).dy, lessThanOrEqualTo(690));
   });
 
@@ -84,7 +84,7 @@ void main() {
     await _pump(tester, surface: const Size(1200, 900));
     expect(tester.takeException(), isNull);
 
-    // Every CTA (hero + trailing) stays within the 700px content column.
+    // The hero CTA stays within the 700px content column.
     for (final button in find.byType(FilledButton).evaluate()) {
       expect(tester.getSize(find.byWidget(button.widget)).width,
           lessThanOrEqualTo(700));


### PR DESCRIPTION
## Summary
- The landing page rendered two identical "Get started" buttons: the hero CTA and a trailing full-width CTA left over from when three feature cards separated them. After the features section shrank to one card (5723138), the whole page fits on one screen and the twin buttons sat ~250px apart.
- Removes the trailing CTA (and its spacer) from `landing_screen.dart`; the hero "Get started" and "I already have an account" remain, and the feature card now flows into the footer.
- Tidies `landing_polish_test.dart`: drops the `.first` finders and stale two-button comments, tightens the Spanish check to `findsOneWidget`.

## Testing
- `flutter test test/landing_polish_test.dart` — 3/3 pass
- Full `flutter test` — 590/590 pass
- `make flutter-analyze` — only the 3 pre-existing `unnecessary_brace_in_string_interps` infos in `lib/models/route_response.dart` (untouched by this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)