### PR TITLE
feat: remove "System default" from the language picker

### DIFF
--- a/src/packages/flutter-app/lib/l10n/app_en.arb
+++ b/src/packages/flutter-app/lib/l10n/app_en.arb
@@ -8,10 +8,6 @@
   "@languageSectionTitle": {
     "description": "Header of the language group in account settings."
   },
-  "languageSystemDefault": "System default",
-  "@languageSystemDefault": {
-    "description": "Language option that follows the device/browser language."
-  },
   "languageEnglish": "English",
   "@languageEnglish": {
     "description": "Name of the English language, shown in its own language."

--- a/src/packages/flutter-app/lib/l10n/app_es.arb
+++ b/src/packages/flutter-app/lib/l10n/app_es.arb
@@ -2,7 +2,6 @@
   "@@locale": "es",
   "appTitle": "Golden Tempo Travel",
   "languageSectionTitle": "Idioma",
-  "languageSystemDefault": "Predeterminado del sistema",
   "languageEnglish": "English",
   "languageSpanish": "Español",
   "languageChangeNote": "Los viajes y las notas que ya guardaste se mantienen en el idioma en que se escribieron.",

--- a/src/packages/flutter-app/lib/l10n/app_localizations.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations.dart
@@ -63,7 +63,7 @@ import 'app_localizations_es.dart';
 /// property.
 abstract class AppLocalizations {
   AppLocalizations(String locale)
-      : localeName = intl.Intl.canonicalizedLocale(locale.toString());
+    : localeName = intl.Intl.canonicalizedLocale(locale.toString());
 
   final String localeName;
 
@@ -86,16 +86,16 @@ abstract class AppLocalizations {
   /// of delegates is preferred or required.
   static const List<LocalizationsDelegate<dynamic>> localizationsDelegates =
       <LocalizationsDelegate<dynamic>>[
-    delegate,
-    GlobalMaterialLocalizations.delegate,
-    GlobalCupertinoLocalizations.delegate,
-    GlobalWidgetsLocalizations.delegate,
-  ];
+        delegate,
+        GlobalMaterialLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+      ];
 
   /// A list of this localizations delegate's supported locales.
   static const List<Locale> supportedLocales = <Locale>[
     Locale('en'),
-    Locale('es')
+    Locale('es'),
   ];
 
   /// Product name. Not translated — it is a brand name.
@@ -109,12 +109,6 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Language'**
   String get languageSectionTitle;
-
-  /// Language option that follows the device/browser language.
-  ///
-  /// In en, this message translates to:
-  /// **'System default'**
-  String get languageSystemDefault;
 
   /// Name of the English language, shown in its own language.
   ///
@@ -5316,8 +5310,9 @@ AppLocalizations lookupAppLocalizations(Locale locale) {
   }
 
   throw FlutterError(
-      'AppLocalizations.delegate failed to load unsupported locale "$locale". This is likely '
-      'an issue with the localizations generation tool. Please file an issue '
-      'on GitHub with a reproducible sample app and the gen-l10n configuration '
-      'that was used.');
+    'AppLocalizations.delegate failed to load unsupported locale "$locale". This is likely '
+    'an issue with the localizations generation tool. Please file an issue '
+    'on GitHub with a reproducible sample app and the gen-l10n configuration '
+    'that was used.',
+  );
 }

--- a/src/packages/flutter-app/lib/l10n/app_localizations.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations.dart
@@ -63,7 +63,7 @@ import 'app_localizations_es.dart';
 /// property.
 abstract class AppLocalizations {
   AppLocalizations(String locale)
-    : localeName = intl.Intl.canonicalizedLocale(locale.toString());
+      : localeName = intl.Intl.canonicalizedLocale(locale.toString());
 
   final String localeName;
 
@@ -86,16 +86,16 @@ abstract class AppLocalizations {
   /// of delegates is preferred or required.
   static const List<LocalizationsDelegate<dynamic>> localizationsDelegates =
       <LocalizationsDelegate<dynamic>>[
-        delegate,
-        GlobalMaterialLocalizations.delegate,
-        GlobalCupertinoLocalizations.delegate,
-        GlobalWidgetsLocalizations.delegate,
-      ];
+    delegate,
+    GlobalMaterialLocalizations.delegate,
+    GlobalCupertinoLocalizations.delegate,
+    GlobalWidgetsLocalizations.delegate,
+  ];
 
   /// A list of this localizations delegate's supported locales.
   static const List<Locale> supportedLocales = <Locale>[
     Locale('en'),
-    Locale('es'),
+    Locale('es')
   ];
 
   /// Product name. Not translated — it is a brand name.
@@ -5310,9 +5310,8 @@ AppLocalizations lookupAppLocalizations(Locale locale) {
   }
 
   throw FlutterError(
-    'AppLocalizations.delegate failed to load unsupported locale "$locale". This is likely '
-    'an issue with the localizations generation tool. Please file an issue '
-    'on GitHub with a reproducible sample app and the gen-l10n configuration '
-    'that was used.',
-  );
+      'AppLocalizations.delegate failed to load unsupported locale "$locale". This is likely '
+      'an issue with the localizations generation tool. Please file an issue '
+      'on GitHub with a reproducible sample app and the gen-l10n configuration '
+      'that was used.');
 }

--- a/src/packages/flutter-app/lib/l10n/app_localizations_en.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations_en.dart
@@ -15,9 +15,6 @@ class AppLocalizationsEn extends AppLocalizations {
   String get languageSectionTitle => 'Language';
 
   @override
-  String get languageSystemDefault => 'System default';
-
-  @override
   String get languageEnglish => 'English';
 
   @override

--- a/src/packages/flutter-app/lib/l10n/app_localizations_es.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations_es.dart
@@ -15,9 +15,6 @@ class AppLocalizationsEs extends AppLocalizations {
   String get languageSectionTitle => 'Idioma';
 
   @override
-  String get languageSystemDefault => 'Predeterminado del sistema';
-
-  @override
   String get languageEnglish => 'English';
 
   @override

--- a/src/packages/flutter-app/lib/main.dart
+++ b/src/packages/flutter-app/lib/main.dart
@@ -117,15 +117,14 @@ class TravelRoutePlannerApp extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    // Watching only the locale the widget layer needs: a change to the stored
-    // override alone (same effective language) must not rebuild the app.
+    // Watching only the locale the widget layer needs, not the whole state.
     final locale = ref.watch(localeProvider.select((s) => s.materialLocale));
     return MaterialApp(
       title: AppInfo.name,
       debugShowCheckedModeBanner: false,
       theme: AppTheme.light,
-      // specs/i18n-spanish. `locale` is null while following the device, which
-      // lets Flutter resolve against supportedLocales itself.
+      // specs/i18n-spanish. Always concrete: the locale provider resolves the
+      // device language itself and stores it at first launch.
       locale: locale,
       supportedLocales: kSupportedLocales,
       localizationsDelegates: const [

--- a/src/packages/flutter-app/lib/providers/locale_provider.dart
+++ b/src/packages/flutter-app/lib/providers/locale_provider.dart
@@ -12,49 +12,37 @@ import 'auth_provider.dart';
 
 /// The app's language, and the single place it is decided (specs/i18n-spanish).
 ///
-/// The client owns locale resolution: it picks the effective language once and
-/// states it on every request via `Accept-Language`. The server never
-/// re-derives it, which is what keeps an explicit override from disagreeing
-/// with what the backend thinks the user reads.
+/// The client owns locale resolution: it picks the language once and states it
+/// on every request via `Accept-Language`. The server never re-derives it,
+/// which is what keeps the picker from disagreeing with what the backend
+/// thinks the user reads.
 ///
-/// Resolution order: explicit override, else the device language (when the app
-/// ships translations for it), else English.
+/// There is no "follow the system" mode: a device that has never chosen
+/// resolves its language once at startup — the device language when this build
+/// ships translations for it, else English — and stores that as the choice, so
+/// the picker always shows a concrete language.
 
-/// Storage key for the explicit choice. Device-wide rather than per-user: the
-/// sign-in screen needs a language before anyone is signed in.
+/// Storage key for the choice. Device-wide rather than per-user: the sign-in
+/// screen needs a language before anyone is signed in. (The historic name
+/// predates the removal of the "system default" picker option.)
 const String _overrideKey = 'locale_override';
-
-/// Sentinel stored (and shown in the picker) for "follow the device".
-const String kLocaleSystem = 'system';
 
 @immutable
 class LocaleState {
-  /// The user's explicit choice: [kLocaleSystem], or a language code.
-  final String override;
+  /// The language in use. Always a supported language code.
+  final String language;
 
-  /// The language actually in use, after resolving [override] against the
-  /// device language and what this build supports. Never empty.
-  final String effective;
-
-  /// False until the stored override has been read; the app renders with the
+  /// False until the stored choice has been read; the app renders with the
   /// device-derived default in the meantime.
   final bool loaded;
 
-  const LocaleState({
-    this.override = kLocaleSystem,
-    this.effective = 'en',
-    this.loaded = false,
-  });
+  const LocaleState({this.language = 'en', this.loaded = false});
 
-  /// What to hand [MaterialApp.locale]: null when following the system, so
-  /// Flutter does its own resolution against `supportedLocales`.
-  Locale? get materialLocale =>
-      override == kLocaleSystem ? null : Locale(effective);
+  /// What to hand [MaterialApp.locale].
+  Locale get materialLocale => Locale(language);
 
-  LocaleState copyWith({String? override, String? effective, bool? loaded}) =>
-      LocaleState(
-        override: override ?? this.override,
-        effective: effective ?? this.effective,
+  LocaleState copyWith({String? language, bool? loaded}) => LocaleState(
+        language: language ?? this.language,
         loaded: loaded ?? this.loaded,
       );
 }
@@ -68,86 +56,72 @@ String? deviceLanguage() {
   return null;
 }
 
-/// Resolves an override against the device language and this build's
-/// translations. Unsupported values (a stale override from a build that
-/// shipped a language this one doesn't) fall back rather than sticking.
-String resolveEffectiveLocale(String override) {
-  if (override != kLocaleSystem && isSupportedLanguage(override)) {
-    return override;
-  }
+/// Folds a stored choice (null when nothing is stored) to a language this
+/// build can render. Unsupported values — a stale choice from a build that
+/// shipped a language this one doesn't, or the retired "system" sentinel —
+/// fall back to the device language rather than sticking.
+String resolveEffectiveLocale(String? stored) {
+  if (stored != null && isSupportedLanguage(stored)) return stored;
   return deviceLanguage() ?? 'en';
 }
 
 class LocaleNotifier extends StateNotifier<LocaleState> {
   final Ref _ref;
 
-  LocaleNotifier(this._ref) : super(const LocaleState()) {
-    // Render immediately with the device-derived language; the stored override
-    // arrives a frame or two later and only redraws if it differs.
-    _apply(resolveEffectiveLocale(kLocaleSystem));
+  // Render immediately with the device-derived language; the stored choice
+  // arrives a frame or two later and only redraws if it differs.
+  LocaleNotifier(this._ref)
+      : super(LocaleState(language: resolveEffectiveLocale(null))) {
+    _apply(state.language);
   }
 
-  /// Reads the stored override. Called once at startup.
+  /// Reads the stored choice. Called once at startup. A device that has never
+  /// chosen resolves the device language and stores it, so the picker always
+  /// has a concrete selection from then on.
   Future<void> load() async {
-    String override = kLocaleSystem;
+    SharedPreferences? prefs;
+    String? stored;
     try {
-      final prefs = await SharedPreferences.getInstance();
-      override = prefs.getString(_overrideKey) ?? kLocaleSystem;
+      prefs = await SharedPreferences.getInstance();
+      stored = prefs.getString(_overrideKey);
     } catch (_) {
-      // Storage unavailable (private browsing, first run) — follow the device.
+      // Storage unavailable (private browsing, first run) — the resolved
+      // language still applies for this session.
     }
-    final effective = resolveEffectiveLocale(override);
-    state = state.copyWith(
-      override: override,
-      effective: effective,
-      loaded: true,
-    );
-    _apply(effective);
+    final language = resolveEffectiveLocale(stored);
+    state = state.copyWith(language: language, loaded: true);
+    _apply(language);
+    if (stored != language) {
+      try {
+        await prefs?.setString(_overrideKey, language);
+      } catch (_) {
+        // Same session-only fallback as above.
+      }
+    }
   }
 
-  /// Records an explicit choice ([kLocaleSystem] to go back to following the
-  /// device) and syncs it to the account.
-  Future<void> setOverride(String override) async {
-    final effective = resolveEffectiveLocale(override);
-    state = state.copyWith(override: override, effective: effective);
-    _apply(effective);
+  /// Records an explicit choice and syncs it to the account.
+  Future<void> setLanguage(String language) async {
+    final resolved = resolveEffectiveLocale(language);
+    state = state.copyWith(language: resolved);
+    _apply(resolved);
     try {
       final prefs = await SharedPreferences.getInstance();
-      if (override == kLocaleSystem) {
-        await prefs.remove(_overrideKey);
-      } else {
-        await prefs.setString(_overrideKey, override);
-      }
+      await prefs.setString(_overrideKey, resolved);
     } catch (_) {
       // The choice still applies for this session.
     }
     await syncToAccount();
   }
 
-  /// Adopts the account's stored language on a device that has never made its
-  /// own choice, so a second device follows the first. A local override always
-  /// wins on the device where it was set — and if there is no local choice, the
-  /// device's resolved language is pushed up instead, so the background email
-  /// jobs (which have no request to negotiate from) always have a value.
-  Future<void> reconcileWithAccount(String? accountLocale) async {
-    if (state.override == kLocaleSystem &&
-        accountLocale != null &&
-        isSupportedLanguage(accountLocale) &&
-        accountLocale != state.effective) {
-      await setOverride(accountLocale);
-      return;
-    }
-    if (accountLocale != state.effective) await syncToAccount();
-  }
-
-  /// Best-effort push of the effective language to the account. Never throws
+  /// Best-effort push of the chosen language to the account. Never throws
   /// and never blocks the UI: a failed sync only costs a wrong-language email
   /// until the next successful one.
   Future<void> syncToAccount() async {
     if (!_ref.read(authProvider).isSignedIn) return;
     try {
       final api = _ref.read(apiClientProvider);
-      final user = await AccountApiService(api).updateLocale(state.effective);
+      final user = await AccountApiService(api).updateLocale(state.language);
       _ref.read(authProvider.notifier).setUser(user);
     } catch (_) {
       // Offline or transient — retried on the next locale change or sign-in.

--- a/src/packages/flutter-app/lib/screens/account_settings_screen.dart
+++ b/src/packages/flutter-app/lib/screens/account_settings_screen.dart
@@ -418,10 +418,10 @@ class _DeleteAccountDialogState extends State<_DeleteAccountDialog> {
 
 /// Language selection (specs/i18n-spanish).
 ///
-/// "System default" is the initial state and keeps following the device, so a
-/// traveler who changes their phone's language is followed rather than pinned.
-/// An explicit choice wins on this device and syncs to the account, which is
-/// what makes it carry to a second device and to the emails the server sends.
+/// The device language (or English) is resolved and stored at first launch,
+/// so a concrete language is always selected here. A choice made on this
+/// device syncs to the account, which is what makes it carry to a second
+/// device and to the emails the server sends.
 ///
 /// Options are built from [kSupportedLocales] rather than hardcoded, so
 /// enabling a language stays a one-line change.
@@ -438,18 +438,13 @@ class _LanguagePicker extends ConsumerWidget {
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
         RadioGroup<String>(
-          groupValue: state.override,
+          groupValue: state.language,
           onChanged: (v) {
-            if (v != null) ref.read(localeProvider.notifier).setOverride(v);
+            if (v != null) ref.read(localeProvider.notifier).setLanguage(v);
           },
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
-              RadioListTile<String>(
-                contentPadding: EdgeInsets.zero,
-                title: Text(l10n.languageSystemDefault),
-                value: kLocaleSystem,
-              ),
               for (final locale in kSupportedLocales)
                 RadioListTile<String>(
                   contentPadding: EdgeInsets.zero,

--- a/src/packages/flutter-app/lib/widgets/language_menu_button.dart
+++ b/src/packages/flutter-app/lib/widgets/language_menu_button.dart
@@ -6,9 +6,9 @@ import '../providers/locale_provider.dart';
 import '../theme/spacing.dart';
 
 /// App-bar globe button offering the same choices as the account-settings
-/// language picker (specs/i18n-spanish): System default plus every entry in
-/// [kSupportedLocales]. Works signed out — the locale provider persists
-/// device-wide and only syncs to the account when a session exists.
+/// language picker (specs/i18n-spanish): every entry in [kSupportedLocales].
+/// Works signed out — the locale provider persists device-wide and only syncs
+/// to the account when a session exists.
 ///
 /// Unlike `AccountMenu`, this renders at every width: the wide layout's rail
 /// has no language control to defer to.
@@ -19,9 +19,8 @@ class LanguageMenuButton extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final theme = Theme.of(context);
     final l10n = context.l10n;
-    // Checked state mirrors the settings picker: keyed on the explicit
-    // override, so "System default" stays checked while following the device.
-    final override = ref.watch(localeProvider.select((s) => s.override));
+    // Checked state mirrors the settings picker.
+    final language = ref.watch(localeProvider.select((s) => s.language));
     return PopupMenuButton<String>(
       tooltip: l10n.languageMenuTooltip,
       // Open below the bar, on an M3 surface, instead of the default
@@ -33,17 +32,12 @@ class LanguageMenuButton extends ConsumerWidget {
       // No explicit color: inherits the bar's foreground (white on the
       // gradient bars, onSurface on the auth screen's transparent bar).
       icon: const Icon(Icons.language),
-      onSelected: (v) => ref.read(localeProvider.notifier).setOverride(v),
+      onSelected: (v) => ref.read(localeProvider.notifier).setLanguage(v),
       itemBuilder: (_) => [
-        CheckedPopupMenuItem<String>(
-          value: kLocaleSystem,
-          checked: override == kLocaleSystem,
-          child: Text(l10n.languageSystemDefault),
-        ),
         for (final locale in kSupportedLocales)
           CheckedPopupMenuItem<String>(
             value: locale.languageCode,
-            checked: override == locale.languageCode,
+            checked: language == locale.languageCode,
             child: Text(languageDisplayName(l10n, locale.languageCode)),
           ),
       ],

--- a/src/packages/flutter-app/test/language_menu_button_test.dart
+++ b/src/packages/flutter-app/test/language_menu_button_test.dart
@@ -22,7 +22,7 @@ import 'package:travel_route_planner/widgets/language_menu_button.dart';
 import 'support/l10n_test_app.dart';
 
 /// The app-bar globe menu (specs/i18n-spanish, visible language switcher):
-/// same three choices as the settings picker, checked on the override, and
+/// same choices as the settings picker, checked on the active language, and
 /// present on the surfaces a signed-out visitor actually sees — including at
 /// rail width, where AccountMenu hides itself and the globe must not.
 ///
@@ -117,8 +117,8 @@ bool _checkedOf(WidgetTester tester, String label) => tester
 void main() {
   setUp(() => SharedPreferences.setMockInitialValues({}));
 
-  testWidgets('menu lists System default, English and Español with the '
-      'override checked', (tester) async {
+  testWidgets('menu lists only English and Español with the active language '
+      'checked', (tester) async {
     await tester.pumpWidget(ProviderScope(
       overrides: [authStorageProvider.overrideWithValue(_FakeAuthStorage())],
       child: localizedTestApp(
@@ -135,11 +135,12 @@ void main() {
     await tester.tap(find.byIcon(Icons.language));
     await tester.pumpAndSettle();
 
-    expect(find.text('System default'), findsOneWidget);
+    // No "System default" entry: a device that never chose shows its resolved
+    // language (English under `flutter test`) checked instead.
+    expect(find.text('System default'), findsNothing);
     expect(find.text('English'), findsOneWidget);
     expect(find.text('Español'), findsOneWidget);
-    expect(_checkedOf(tester, 'System default'), isTrue);
-    expect(_checkedOf(tester, 'English'), isFalse);
+    expect(_checkedOf(tester, 'English'), isTrue);
     expect(_checkedOf(tester, 'Español'), isFalse);
   });
 
@@ -173,7 +174,7 @@ void main() {
         .tap(find.widgetWithText(CheckedPopupMenuItem<String>, 'Español'));
     await tester.pumpAndSettle();
 
-    expect(ref.read(localeProvider).override, 'es');
+    expect(ref.read(localeProvider).language, 'es');
     expect(find.text('Idioma'), findsOneWidget);
     expect(find.text('Language'), findsNothing);
 
@@ -181,7 +182,7 @@ void main() {
     await tester.tap(find.byIcon(Icons.language));
     await tester.pumpAndSettle();
     expect(_checkedOf(tester, 'Español'), isTrue);
-    expect(_checkedOf(tester, 'Predeterminado del sistema'), isFalse);
+    expect(_checkedOf(tester, 'English'), isFalse);
   });
 
   testWidgets('landing screen shows the globe signed out, even at rail width',

--- a/src/packages/flutter-app/test/language_picker_test.dart
+++ b/src/packages/flutter-app/test/language_picker_test.dart
@@ -64,7 +64,7 @@ void main() {
 
     expect(find.text('Language'), findsOneWidget);
 
-    await ref.read(localeProvider.notifier).setOverride('es');
+    await ref.read(localeProvider.notifier).setLanguage('es');
     await tester.pumpAndSettle();
 
     expect(find.text('Idioma'), findsOneWidget);
@@ -73,32 +73,33 @@ void main() {
 
   test('an explicit choice is persisted and restored on next launch', () async {
     final container = _container();
-    await container.read(localeProvider.notifier).setOverride('es');
-    expect(container.read(localeProvider).effective, 'es');
+    await container.read(localeProvider.notifier).setLanguage('es');
+    expect(container.read(localeProvider).language, 'es');
 
-    // A fresh container stands in for a relaunch: the override must come back
+    // A fresh container stands in for a relaunch: the choice must come back
     // from device storage rather than resetting to the device language.
     final relaunched = _container();
     await relaunched.read(localeProvider.notifier).load();
-    expect(relaunched.read(localeProvider).override, 'es');
-    expect(relaunched.read(localeProvider).effective, 'es');
+    expect(relaunched.read(localeProvider).language, 'es');
   });
 
-  test('returning to System default clears the stored override', () async {
+  test('first launch resolves the device language and stores it', () async {
+    // A device that has never chosen ("system default" users from before the
+    // option was removed, and fresh installs) gets its resolved language
+    // persisted, so the picker always shows a concrete selection.
     final container = _container();
-    await container.read(localeProvider.notifier).setOverride('es');
-    await container.read(localeProvider.notifier).setOverride(kLocaleSystem);
+    await container.read(localeProvider.notifier).load();
+    expect(container.read(localeProvider).language, 'en');
 
-    final relaunched = _container();
-    await relaunched.read(localeProvider.notifier).load();
-    expect(relaunched.read(localeProvider).override, kLocaleSystem);
+    final prefs = await SharedPreferences.getInstance();
+    expect(prefs.getString('locale_override'), 'en');
   });
 
   test('the API client language header follows the choice', () async {
     final container = _container();
-    await container.read(localeProvider.notifier).setOverride('es');
+    await container.read(localeProvider.notifier).setLanguage('es');
     // The server renders emails, trip-health findings and exports from this
     // header, so it must track the picker and not just the widget tree.
-    expect(container.read(localeProvider).effective, 'es');
+    expect(container.read(localeProvider).language, 'es');
   });
 }

--- a/src/packages/flutter-app/test/locale_provider_test.dart
+++ b/src/packages/flutter-app/test/locale_provider_test.dart
@@ -24,36 +24,33 @@ void main() {
   });
 
   group('resolveEffectiveLocale', () {
-    test('system follows the device, falling back to English', () {
-      expect(resolveEffectiveLocale(kLocaleSystem), 'en');
+    test('nothing stored follows the device, falling back to English', () {
+      expect(resolveEffectiveLocale(null), 'en');
     });
 
-    test('an override for a language this build cannot render is ignored', () {
-      // A stale override left by a build that shipped more languages must not
-      // pin the app to a language it has no translations for.
+    test('a stored choice this build cannot render is ignored', () {
+      // A stale choice left by a build that shipped more languages — or the
+      // retired "system" sentinel — must not pin the app to a language it has
+      // no translations for.
       expect(resolveEffectiveLocale('klingon'), 'en');
       expect(resolveEffectiveLocale('fr'), 'en');
+      expect(resolveEffectiveLocale('system'), 'en');
     });
 
-    test('an override for a supported language wins', () {
+    test('a stored supported language wins', () {
       expect(resolveEffectiveLocale('en'), 'en');
       expect(resolveEffectiveLocale('es'), 'es');
     });
   });
 
   group('LocaleState', () {
-    test('following the system hands MaterialApp a null locale', () {
-      // Null lets Flutter resolve against supportedLocales itself, which is
-      // what keeps the app tracking a device language change.
-      const state = LocaleState(override: kLocaleSystem, effective: 'en');
-      expect(state.materialLocale, isNull);
-    });
-
-    test('an explicit choice pins MaterialApp to that locale', () {
-      const state = LocaleState(override: 'en', effective: 'en');
-      expect(state.materialLocale?.languageCode, 'en');
-      const spanish = LocaleState(override: 'es', effective: 'es');
-      expect(spanish.materialLocale?.languageCode, 'es');
+    test('the chosen language pins MaterialApp to that locale', () {
+      // Always concrete: there is no "follow the system" mode, so MaterialApp
+      // never gets a null locale to resolve itself.
+      const state = LocaleState(language: 'en');
+      expect(state.materialLocale.languageCode, 'en');
+      const spanish = LocaleState(language: 'es');
+      expect(spanish.materialLocale.languageCode, 'es');
     });
   });
 


### PR DESCRIPTION
## Summary
- The app-bar globe menu and the Account-settings language picker now list only the languages (English, Español) — the "System default" entry is gone.
- The "follow the system" mode is removed end to end: `kLocaleSystem` sentinel deleted, `LocaleState` collapsed to a single always-concrete `language` field, `MaterialApp.locale` is never null anymore.
- Migration for devices that never chose (including everyone previously on "System default", which was stored as *no* pref key): first `load()` resolves the device language (supported → that language, else English), persists it, and the picker shows it checked. Prior explicit choices survive under the same storage key.
- Dropped the dead `reconcileWithAccount` and the now-unused `languageSystemDefault` l10n key (both ARBs + regenerated `app_localizations*.dart` via `flutter gen-l10n`).
- No server changes: the API never accepted `"system"` and `users.locale` NULL already falls back to English.

## Testing
- `flutter analyze` — no new issues (3 pre-existing infos in `route_response.dart`, exist on main; CI runs `--no-fatal-infos`).
- `make flutter-test` — all 589 tests pass, including updated coverage: menu lists only the two languages with the active one checked, first launch persists the resolved device language, explicit choice survives relaunch, stale/`system` stored values fold to the device language.

🤖 Generated with [Claude Code](https://claude.com/claude-code)