### PR TITLE
fix: drop the duplicate Home app-bar logo when the rail is visible

### DIFF
--- a/src/packages/flutter-app/lib/screens/home_screen.dart
+++ b/src/packages/flutter-app/lib/screens/home_screen.dart
@@ -87,39 +87,50 @@ class HomeScreen extends ConsumerWidget {
     return Scaffold(
       appBar: GradientAppBar(
         centerTitle: false,
-        // Brand mark on a light badge (so the black/gold logo reads on the teal
-        // app bar) next to the wordmark in white. LayoutBuilder inside the
-        // title's own constraints: with the globe + avatar actions a phone
-        // can't fit the full wordmark ("Golden Tempo Tra…"), so narrow widths
-        // show the mark alone rather than an ellipsized brand.
+        // Three states, keyed off window width (same measurement as the
+        // shell's rail check, NOT the title slot's constraints):
+        //  - rail visible (>= kRailBreakpoint): wordmark only — the rail brand
+        //    already shows the mark one corner over, so the badge here would
+        //    be a duplicate. Static: the rail brand is the logo-home tap.
+        //  - no rail: brand mark on a light badge (so the black/gold logo
+        //    reads on the teal app bar) next to the wordmark in white.
+        //  - compact title slot (< _wordmarkMinWidth): with the globe + avatar
+        //    actions a phone can't fit the full wordmark ("Golden Tempo
+        //    Tra…"), so the badge shows alone rather than an ellipsized brand.
         title: LayoutBuilder(
           builder: (context, constraints) {
+            final hasRail =
+                MediaQuery.sizeOf(context).width >= kRailBreakpoint;
             final compact = constraints.maxWidth < _wordmarkMinWidth;
+            const wordmark = Flexible(
+              child: Text(
+                AppInfo.name,
+                overflow: TextOverflow.ellipsis,
+                style: TextStyle(
+                  fontFamily: 'Playfair Display',
+                  fontWeight: FontWeight.w600,
+                  fontSize: 20,
+                  letterSpacing: 0.5,
+                  color: Colors.white,
+                ),
+              ),
+            );
             return Row(
               mainAxisSize: MainAxisSize.min,
               children: [
-                BrandBadge(
-                  padding: const EdgeInsets.symmetric(
-                      horizontal: AppSpacing.sm, vertical: AppSpacing.xs),
-                  // Logo-links-home: pops anything pushed on the Home stack.
-                  onTap: () => goHome(ref),
-                  child: const BrandLogo.mark(size: 28),
-                ),
-                if (!compact) ...const [
-                  SizedBox(width: AppSpacing.sm),
-                  Flexible(
-                    child: Text(
-                      AppInfo.name,
-                      overflow: TextOverflow.ellipsis,
-                      style: TextStyle(
-                        fontFamily: 'Playfair Display',
-                        fontWeight: FontWeight.w600,
-                        fontSize: 20,
-                        letterSpacing: 0.5,
-                        color: Colors.white,
-                      ),
-                    ),
+                if (!hasRail)
+                  BrandBadge(
+                    padding: const EdgeInsets.symmetric(
+                        horizontal: AppSpacing.sm, vertical: AppSpacing.xs),
+                    // Logo-links-home: pops anything pushed on the Home stack.
+                    onTap: () => goHome(ref),
+                    child: const BrandLogo.mark(size: 28),
                   ),
+                if (hasRail)
+                  wordmark
+                else if (!compact) ...const [
+                  SizedBox(width: AppSpacing.sm),
+                  wordmark,
                 ],
               ],
             );

--- a/src/packages/flutter-app/test/home_polish_test.dart
+++ b/src/packages/flutter-app/test/home_polish_test.dart
@@ -115,9 +115,18 @@ void main() {
     expect(tester.takeException(), isNull);
   });
 
-  testWidgets('wide app bar keeps the full wordmark',
-      (WidgetTester tester) async {
+  testWidgets(
+      'wide app bar shows the wordmark only — the rail carries the '
+      'mark', (WidgetTester tester) async {
     await _pumpHome(tester, surface: const Size(1200, 800));
+
+    expect(find.text(AppInfo.name), findsOneWidget);
+    expect(find.byType(BrandLogo), findsNothing);
+  });
+
+  testWidgets('mid width (no rail) keeps badge and wordmark together',
+      (WidgetTester tester) async {
+    await _pumpHome(tester, surface: const Size(700, 800));
 
     expect(find.text(AppInfo.name), findsOneWidget);
     expect(find.byType(BrandLogo), findsOneWidget);


### PR DESCRIPTION
## Summary
- On wide layouts (≥ `kRailBreakpoint`, 800px) the rail brand and the Home app-bar badge showed the same horseshoe mark stacked in one corner; the Home header now shows the "Golden Tempo Travel" wordmark alone there, with the rail carrying the single (clickable, logo-links-home) mark.
- Narrow layouts are unchanged: badge + wordmark, wordmark dropping below the 280px title-slot floor — the app bar is the only brand surface without a rail.
- The gate keys off window width via `MediaQuery.sizeOf` (same measurement as `AppShell`'s rail check), not the title slot's `LayoutBuilder` constraints.

## Testing
- `flutter analyze` clean (3 pre-existing infos in `route_response.dart` only).
- Full `flutter test` suite: 595 passed. Updated the wide-surface `home_polish_test.dart` assertion (wordmark present, `BrandLogo` absent) and added a 700×800 mid-width case locking in the no-rail badge + wordmark state.
- Manual: dev stack at localhost:3000 wide — header shows wordmark only, rail shows the single logo tile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)