### PR TITLE
fix: friendly titles for near-me continue cards

### DIFF
--- a/specs/continue-where-you-left-off/spec.md
+++ b/specs/continue-where-you-left-off/spec.md
@@ -33,8 +33,9 @@ agent actually saved.
       reply, so a resume shows everything both sides said.
 - [ ] The trips page shows a "Continue where you left off" section above saved
       trips, listing in-progress conversations (most recent first), each with a
-      title drawn from the opening message, a preview of the latest reply, and
-      when it was last active.
+      title drawn from the opening message (its display label when one is
+      present — seeded chips like "What's near me?" — otherwise its text), a
+      preview of the latest reply, and when it was last active.
 - [ ] Tapping an entry opens the AI planning tab with the full conversation
       restored; sending the next message continues the same conversation with
       full context.
@@ -75,9 +76,11 @@ agent actually saved.
 ## Data Model
 
 - **Plan chat session** — one per planning conversation per user: the owner,
-  the conversation's opaque id, a short title (from the opening message), a
-  preview (latest assistant reply), the transcript (ordered role/content
-  messages), the running compaction summary if any, message count, and
+  the conversation's opaque id, a short title (from the opening message's
+  display label when present, otherwise its text), a preview (latest assistant
+  reply), the transcript (ordered role/content messages, each with an optional
+  display label for seeded chips), the running compaction summary if any,
+  message count, and
   created/updated timestamps. Updated wholesale each turn. Deleted on dismiss;
   stale sessions (no activity for ~60 days) are pruned opportunistically.
 

--- a/src/packages/api/chat_session_handler.go
+++ b/src/packages/api/chat_session_handler.go
@@ -83,7 +83,13 @@ func savePlanChatSession(ctx context.Context, uid uuid.UUID, chatID, summary str
 	var title, preview string
 	for _, m := range msgs {
 		if m.Role == "user" {
-			title = truncateRunes(m.Content, chatTitleMaxRunes)
+			// Machine-built seed messages (near-me coordinates) carry a
+			// human-friendly display label — title from that, never the raw text.
+			src := m.Content
+			if strings.TrimSpace(m.DisplayLabel) != "" {
+				src = m.DisplayLabel
+			}
+			title = truncateRunes(src, chatTitleMaxRunes)
 			break
 		}
 	}

--- a/src/packages/api/chat_session_integration_test.go
+++ b/src/packages/api/chat_session_integration_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"net/http"
@@ -220,6 +221,58 @@ func TestChatSessionsListGetDeleteAndGraduation(t *testing.T) {
 
 	// Settle async trip_created analytics before the next test truncates.
 	waitForEventCount(t, user.ID, "trip_created", 1)
+}
+
+// (d2) Seed display labels: a machine-built opening message (near-me chip)
+// carries a display_label that titles the session and round-trips through the
+// transcript for chip re-rendering on resume — but never reaches the model.
+func TestChatSessionTitleUsesDisplayLabel(t *testing.T) {
+	resetDB(t)
+	fa := newFakeAnthropic(t, textTurn("You're in Lower East Side, NYC."))
+	user, token := createTestUser(t, "nearme@example.com")
+
+	const seedText = "My current location is latitude 40.7234, longitude -73.9938 (accuracy about 12 m). What's good to see, do, or eat near me right now?"
+	const seedLabel = "Near my current location"
+	rec := doJSON(t, "POST", "/api/v1/plan", token, PlanRequest{
+		ChatID: "chat-near-me",
+		Messages: []PlanChatMessage{{
+			Role: "user", Content: seedText, DisplayLabel: seedLabel,
+		}},
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("/plan = %d, want 200", rec.Code)
+	}
+
+	msgs, title, _, found := chatSessionRow(t, user.ID, "chat-near-me")
+	if !found {
+		t.Fatal("no chat session persisted")
+	}
+	if title != seedLabel {
+		t.Fatalf("title = %q, want the display label %q", title, seedLabel)
+	}
+	if len(msgs) == 0 || msgs[0].DisplayLabel != seedLabel || msgs[0].Content != seedText {
+		t.Fatalf("stored first message = %+v, want label and content round-tripped", msgs[0])
+	}
+
+	// The resume surface returns the label so the client re-renders the chip.
+	rec = doJSON(t, "GET", "/api/v1/chats/chat-near-me", token, nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /chats/{id} = %d: %s", rec.Code, rec.Body.String())
+	}
+	var detail ChatSessionDetailResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &detail); err != nil {
+		t.Fatalf("decode detail: %v", err)
+	}
+	if len(detail.Messages) == 0 || detail.Messages[0].DisplayLabel != seedLabel {
+		t.Fatalf("detail first message = %+v, want display_label present", detail.Messages[0])
+	}
+
+	// Metadata only: the label must never appear in any model-bound request.
+	for i, body := range fa.requestBodies() {
+		if bytes.Contains(body, []byte("display_label")) || bytes.Contains(body, []byte(seedLabel)) {
+			t.Fatalf("model request %d leaked the display label: %s", i, body)
+		}
+	}
 }
 
 // (e) Compaction-aware persistence: when compaction runs, the stored session

--- a/src/packages/api/migrations/00052_near_me_chat_titles.sql
+++ b/src/packages/api/migrations/00052_near_me_chat_titles.sql
@@ -1,0 +1,20 @@
+-- +goose Up
+-- Backfill: chat-session titles are written once and never overwritten
+-- (UpsertPlanChatSession omits title from DO UPDATE), so sessions started via
+-- the near-me chip before display labels existed are frozen showing raw
+-- coordinates. Rewrite them to the chip's seed label. The server normally
+-- never writes localized strings (client owns locale), but each template
+-- prefix identifies the locale the client used, so the replacement is the
+-- exact ARB seed-label value for that same locale.
+UPDATE plan_chat_sessions
+SET title = 'Near my current location'
+WHERE title LIKE 'My current location is latitude %';
+
+UPDATE plan_chat_sessions
+SET title = 'Cerca de mi ubicación actual'
+WHERE title LIKE 'Mi ubicación actual es latitud %';
+
+-- +goose Down
+-- Irreversible data cleanup (original coordinate titles are not retained);
+-- intentionally a no-op.
+SELECT 1;

--- a/src/packages/api/plan_handler.go
+++ b/src/packages/api/plan_handler.go
@@ -52,6 +52,11 @@ const planMaxDuration = 10 * time.Minute
 const (
 	planMaxMessages     = 60
 	planMaxMessageChars = 20000
+	// planMaxDisplayLabelRunes bounds the display-label metadata persisted in
+	// transcripts. Labels are chip-sized UI strings; anything longer is
+	// truncated (not rejected — best-effort metadata) to keep a hostile client
+	// from bloating the JSONB column.
+	planMaxDisplayLabelRunes = 200
 )
 
 // Image attachment caps. Per-image tracks Anthropic's 5 MB decoded limit
@@ -91,6 +96,11 @@ type PlanChatMessage struct {
 	Role    string      `json:"role"`
 	Content string      `json:"content"`
 	Images  []PlanImage `json:"images,omitempty"`
+	// DisplayLabel is the client's compact stand-in for machine-built seed
+	// messages (e.g. the near-me chip's coordinate text). Metadata only: it
+	// titles the persisted chat session and round-trips through transcripts so
+	// resumed chats re-render the chip, but it is never sent to the model.
+	DisplayLabel string `json:"display_label,omitempty"`
 }
 
 // PlanImage is one image attached to a user message. Persisted transcripts
@@ -138,10 +148,13 @@ func planHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	totalImages := 0
-	for _, m := range req.Messages {
+	for i, m := range req.Messages {
 		if utf8.RuneCountInString(m.Content) > planMaxMessageChars {
 			sendSSE(w, "error", map[string]string{"message": "One of the messages is too long for the planner. Please shorten it and try again."})
 			return
+		}
+		if utf8.RuneCountInString(m.DisplayLabel) > planMaxDisplayLabelRunes {
+			req.Messages[i].DisplayLabel = truncateRunes(m.DisplayLabel, planMaxDisplayLabelRunes)
 		}
 		if len(m.Images) > 0 && m.Role != "user" {
 			sendSSE(w, "error", map[string]string{"message": "Images can only be attached to your own messages."})

--- a/src/packages/flutter-app/lib/models/chat_session.dart
+++ b/src/packages/flutter-app/lib/models/chat_session.dart
@@ -53,10 +53,17 @@ class ChatSessionMessage {
   @JsonKey(defaultValue: <ChatSessionImage>[])
   final List<ChatSessionImage> images;
 
+  /// Compact chip label for machine-built seed messages (near-me coordinates).
+  /// Round-tripped through the persisted transcript so a resumed chat renders
+  /// the seed chip instead of the raw message bubble.
+  @JsonKey(name: 'display_label')
+  final String? displayLabel;
+
   const ChatSessionMessage({
     required this.role,
     required this.content,
     this.images = const [],
+    this.displayLabel,
   });
 
   factory ChatSessionMessage.fromJson(Map<String, dynamic> json) =>

--- a/src/packages/flutter-app/lib/models/chat_session.g.dart
+++ b/src/packages/flutter-app/lib/models/chat_session.g.dart
@@ -44,6 +44,7 @@ ChatSessionMessage _$ChatSessionMessageFromJson(Map<String, dynamic> json) =>
               ?.map((e) => ChatSessionImage.fromJson(e as Map<String, dynamic>))
               .toList() ??
           [],
+      displayLabel: json['display_label'] as String?,
     );
 
 Map<String, dynamic> _$ChatSessionMessageToJson(ChatSessionMessage instance) =>
@@ -51,6 +52,7 @@ Map<String, dynamic> _$ChatSessionMessageToJson(ChatSessionMessage instance) =>
       'role': instance.role,
       'content': instance.content,
       'images': instance.images.map((e) => e.toJson()).toList(),
+      'display_label': instance.displayLabel,
     };
 
 ChatSessionDetail _$ChatSessionDetailFromJson(Map<String, dynamic> json) =>

--- a/src/packages/flutter-app/lib/providers/plan_provider.dart
+++ b/src/packages/flutter-app/lib/providers/plan_provider.dart
@@ -368,6 +368,10 @@ class PlanNotifier extends StateNotifier<PlanState> {
         .map((m) => <String, dynamic>{
               'role': m.role == MessageRole.user ? 'user' : 'assistant',
               'content': m.content,
+              // Seed-chip metadata: titles the persisted session server-side
+              // and must be resent every turn — the transcript is upserted
+              // wholesale, so omitting it would erase the label.
+              if (m.displayLabel != null) 'display_label': m.displayLabel,
               if (m.attachments.any((a) => a.bytes != null))
                 'images': [
                   for (final a in m.attachments)

--- a/src/packages/flutter-app/lib/widgets/continue_chats_section.dart
+++ b/src/packages/flutter-app/lib/widgets/continue_chats_section.dart
@@ -64,6 +64,9 @@ class ContinueChatCard extends ConsumerWidget {
                       ? MessageRole.user
                       : MessageRole.assistant,
                   content: m.content,
+                  // Restores the seed context chip (e.g. "Near my current
+                  // location") instead of the raw coordinate bubble.
+                  displayLabel: m.displayLabel,
                   // Pixels are stripped server-side; null bytes renders the
                   // "Image" placeholder chip and stays out of resent history.
                   attachments: [

--- a/src/packages/flutter-app/test/continue_chats_resume_test.dart
+++ b/src/packages/flutter-app/test/continue_chats_resume_test.dart
@@ -1,0 +1,81 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:travel_route_planner/models/chat_session.dart';
+import 'package:travel_route_planner/providers/plan_provider.dart';
+import 'package:travel_route_planner/providers/resumable_chats_provider.dart';
+import 'package:travel_route_planner/services/api_client.dart';
+import 'package:travel_route_planner/services/chats_api_service.dart';
+import 'package:travel_route_planner/widgets/continue_chats_section.dart';
+
+import 'support/l10n_test_app.dart';
+
+/// Resuming from a continue card rebuilds PlanMessages with their persisted
+/// display labels, so a near-me chat re-renders the seed context chip instead
+/// of the raw coordinate bubble (specs/continue-where-you-left-off).
+class _FakeChatsApiService extends ChatsApiService {
+  final ChatSessionDetail detail;
+
+  _FakeChatsApiService(this.detail) : super(ApiClient());
+
+  @override
+  Future<ChatSessionDetail> getChat(String chatId) async => detail;
+}
+
+void main() {
+  testWidgets('resume restores display labels onto the plan conversation',
+      (WidgetTester tester) async {
+    const rawSeed = 'My current location is latitude 40.7234, longitude '
+        '-73.9938 (accuracy about 12 m). What is good near me?';
+    final detail = ChatSessionDetail(
+      chatId: 'chat-near-me',
+      title: 'Near my current location',
+      summary: '',
+      messages: const [
+        ChatSessionMessage(
+          role: 'user',
+          content: rawSeed,
+          displayLabel: 'Near my current location',
+        ),
+        ChatSessionMessage(role: 'assistant', content: 'You are in NoLita.'),
+      ],
+      updatedAt: '2026-08-02T10:00:00Z',
+    );
+
+    final container = ProviderContainer(overrides: [
+      chatsApiServiceProvider.overrideWithValue(_FakeChatsApiService(detail)),
+    ]);
+    addTearDown(container.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: MaterialApp(
+          localizationsDelegates: testLocalizationsDelegates,
+          home: Scaffold(
+            body: ContinueChatCard(
+              chat: const ChatSessionSummary(
+                chatId: 'chat-near-me',
+                title: 'Near my current location',
+                preview: 'You are in NoLita.',
+                messageCount: 2,
+                createdAt: '2026-08-01T10:00:00Z',
+                updatedAt: '2026-08-02T10:00:00Z',
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.byType(ContinueChatCard));
+    await tester.pumpAndSettle();
+
+    final messages = container.read(planProvider).messages;
+    expect(messages, hasLength(2));
+    expect(messages.first.content, rawSeed);
+    expect(messages.first.displayLabel, 'Near my current location');
+    expect(messages.last.displayLabel, isNull);
+  });
+}

--- a/src/packages/flutter-app/test/plan_provider_stream_test.dart
+++ b/src/packages/flutter-app/test/plan_provider_stream_test.dart
@@ -155,5 +155,16 @@ void main() {
     expect(notifier.state.messages.first.displayLabel, 'Refining Day 1 — Athens');
     expect(notifier.state.messages.first.content, seed);
     expect(service.lastHistory!.first['content'], seed);
+    // The label rides along as metadata (titles the persisted session and
+    // survives the wholesale transcript upsert on later turns).
+    expect(service.lastHistory!.first['display_label'], 'Refining Day 1 — Athens');
+
+    // A plain message carries no display_label key at all.
+    service.events
+      ..clear()
+      ..add(const PlanEvent(type: 'text_delta', data: {'text': 'Sure.'}));
+    await notifier.sendMessage('make day 2 chiller');
+    expect(service.lastHistory!.last['role'], 'user');
+    expect(service.lastHistory!.last.containsKey('display_label'), isFalse);
   });
 }

--- a/src/packages/flutter-app/test/resume_conversation_test.dart
+++ b/src/packages/flutter-app/test/resume_conversation_test.dart
@@ -87,6 +87,31 @@ void main() {
       expect(service.summaries, ['- travelers: 3']);
     });
 
+    test('resumed display label survives into the next wire history', () async {
+      final service = _RecordingPlanService();
+      final notifier = PlanNotifier(service, ApiClient());
+
+      notifier.resumeConversation(
+        chatId: 'chat-near-me',
+        messages: const [
+          PlanMessage(
+            role: MessageRole.user,
+            content: 'My current location is latitude 40.7234, longitude '
+                '-73.9938 (accuracy about 12 m). What is good near me?',
+            displayLabel: 'Near my current location',
+          ),
+          PlanMessage(role: MessageRole.assistant, content: 'You are in NoLita.'),
+        ],
+      );
+      await notifier.sendMessage('anything with live music?');
+
+      // The transcript is upserted wholesale server-side each turn, so the
+      // label must ride every resend or the persisted copy loses it.
+      final history = service.histories.single;
+      expect(history.first['display_label'], 'Near my current location');
+      expect(history.last.containsKey('display_label'), isFalse);
+    });
+
     test('empty summary is not restored as compaction state', () {
       final notifier = PlanNotifier(_RecordingPlanService(), ApiClient());
       notifier.resumeConversation(
@@ -131,6 +156,21 @@ void main() {
       expect(detail.messages.map((m) => m.role).toList(),
           ['user', 'assistant']);
       expect(detail.messages.last.content, 'a1');
+    });
+
+    test('message display_label parses when present and defaults to null', () {
+      final labeled = ChatSessionMessage.fromJson({
+        'role': 'user',
+        'content': 'My current location is latitude 40.7, longitude -73.9',
+        'display_label': 'Near my current location',
+      });
+      expect(labeled.displayLabel, 'Near my current location');
+
+      final plain = ChatSessionMessage.fromJson({
+        'role': 'user',
+        'content': 'plain question',
+      });
+      expect(plain.displayLabel, isNull);
     });
   });
 }


### PR DESCRIPTION
## Summary
- Continue-where-you-left-off cards for chats started via the "What's near me?" chip showed the raw geolocation seed as the title ("My current location is latitude 40.7234, longitude -73.9938 (accuracy…"). The Flutter client already had a friendly localized label (`PlanMessage.displayLabel`, "Near my current location") but dropped it from the wire payload.
- Threads `display_label` through the stack as model-invisible metadata: the client serializes it into the /plan history (resent every turn — the transcript is upserted wholesale, so omitting it would erase the label), the server prefers it over raw content when titling the persisted session, round-trips it through the JSONB transcript and `GET /chats/{chatId}`, and the resume path rebuilds `PlanMessage`s with it — so a resumed near-me chat renders the seed context chip again instead of the raw coordinate bubble.
- The label never reaches the model: the Anthropic-bound request is built field-by-field from `Content`/`Images` only, and a new integration test asserts no model-bound request contains it. Incoming labels are truncated to 200 runes (bloat guard).
- Migration 00052 backfills existing frozen coordinate titles (en + es templates) to their seed labels — titles are written once and never overwritten, so old rows would never self-heal.
- Spec amended (`specs/continue-where-you-left-off/spec.md`): title comes from the opening message's display label when present.

## Testing
- `make api-fmt`, `make api-vet`, `go test ./...` — full suite green against the lane test DB, including new `TestChatSessionTitleUsesDisplayLabel` (title from label, transcript round-trip, GET surface, never-sent-to-model).
- `make flutter-analyze` — clean (3 pre-existing infos in untouched `route_response.dart`).
- `make flutter-test` — all 596 tests pass, including new coverage: wire history carries `display_label` (and omits it for plain messages), resumed labels survive into the next send, `ChatSessionMessage.fromJson` null/present parsing, and a widget test that tapping a continue card restores `displayLabel` onto the plan conversation.
- `chat_session.g.dart` regenerated via build_runner (not hand-edited).

🤖 Generated with [Claude Code](https://claude.com/claude-code)