### PR TITLE
fix: merge Home's two "where you left off" surfaces into one section

### DIFF
--- a/src/packages/flutter-app/lib/l10n/app_en.arb
+++ b/src/packages/flutter-app/lib/l10n/app_en.arb
@@ -1162,7 +1162,6 @@
   "homeSuggestionTokyo": "Weekend in Tokyo",
   "homeStatusDraft": "Draft",
   "homeStatusPlanned": "Planned",
-  "homeRecentTripEyebrow": "PICK UP WHERE YOU LEFT OFF",
   "homeLocalGuidesTitle": "Local guides",
   "homeGuideByline": "By {name}",
   "@homeGuideByline": {

--- a/src/packages/flutter-app/lib/l10n/app_es.arb
+++ b/src/packages/flutter-app/lib/l10n/app_es.arb
@@ -519,7 +519,6 @@
   "homeSuggestionTokyo": "Fin de semana en Tokio",
   "homeStatusDraft": "Borrador",
   "homeStatusPlanned": "Planeado",
-  "homeRecentTripEyebrow": "CONTINÚA DONDE LO DEJASTE",
   "homeLocalGuidesTitle": "Guías locales",
   "homeGuideByline": "Por {name}",
   "shellNavHome": "Inicio",

--- a/src/packages/flutter-app/lib/l10n/app_localizations.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations.dart
@@ -63,7 +63,7 @@ import 'app_localizations_es.dart';
 /// property.
 abstract class AppLocalizations {
   AppLocalizations(String locale)
-      : localeName = intl.Intl.canonicalizedLocale(locale.toString());
+    : localeName = intl.Intl.canonicalizedLocale(locale.toString());
 
   final String localeName;
 
@@ -86,16 +86,16 @@ abstract class AppLocalizations {
   /// of delegates is preferred or required.
   static const List<LocalizationsDelegate<dynamic>> localizationsDelegates =
       <LocalizationsDelegate<dynamic>>[
-    delegate,
-    GlobalMaterialLocalizations.delegate,
-    GlobalCupertinoLocalizations.delegate,
-    GlobalWidgetsLocalizations.delegate,
-  ];
+        delegate,
+        GlobalMaterialLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+      ];
 
   /// A list of this localizations delegate's supported locales.
   static const List<Locale> supportedLocales = <Locale>[
     Locale('en'),
-    Locale('es')
+    Locale('es'),
   ];
 
   /// Product name. Not translated — it is a brand name.
@@ -3212,12 +3212,6 @@ abstract class AppLocalizations {
   /// **'Planned'**
   String get homeStatusPlanned;
 
-  /// No description provided for @homeRecentTripEyebrow.
-  ///
-  /// In en, this message translates to:
-  /// **'PICK UP WHERE YOU LEFT OFF'**
-  String get homeRecentTripEyebrow;
-
   /// No description provided for @homeLocalGuidesTitle.
   ///
   /// In en, this message translates to:
@@ -5280,8 +5274,9 @@ AppLocalizations lookupAppLocalizations(Locale locale) {
   }
 
   throw FlutterError(
-      'AppLocalizations.delegate failed to load unsupported locale "$locale". This is likely '
-      'an issue with the localizations generation tool. Please file an issue '
-      'on GitHub with a reproducible sample app and the gen-l10n configuration '
-      'that was used.');
+    'AppLocalizations.delegate failed to load unsupported locale "$locale". This is likely '
+    'an issue with the localizations generation tool. Please file an issue '
+    'on GitHub with a reproducible sample app and the gen-l10n configuration '
+    'that was used.',
+  );
 }

--- a/src/packages/flutter-app/lib/l10n/app_localizations.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations.dart
@@ -63,7 +63,7 @@ import 'app_localizations_es.dart';
 /// property.
 abstract class AppLocalizations {
   AppLocalizations(String locale)
-    : localeName = intl.Intl.canonicalizedLocale(locale.toString());
+      : localeName = intl.Intl.canonicalizedLocale(locale.toString());
 
   final String localeName;
 
@@ -86,16 +86,16 @@ abstract class AppLocalizations {
   /// of delegates is preferred or required.
   static const List<LocalizationsDelegate<dynamic>> localizationsDelegates =
       <LocalizationsDelegate<dynamic>>[
-        delegate,
-        GlobalMaterialLocalizations.delegate,
-        GlobalCupertinoLocalizations.delegate,
-        GlobalWidgetsLocalizations.delegate,
-      ];
+    delegate,
+    GlobalMaterialLocalizations.delegate,
+    GlobalCupertinoLocalizations.delegate,
+    GlobalWidgetsLocalizations.delegate,
+  ];
 
   /// A list of this localizations delegate's supported locales.
   static const List<Locale> supportedLocales = <Locale>[
     Locale('en'),
-    Locale('es'),
+    Locale('es')
   ];
 
   /// Product name. Not translated — it is a brand name.
@@ -5274,9 +5274,8 @@ AppLocalizations lookupAppLocalizations(Locale locale) {
   }
 
   throw FlutterError(
-    'AppLocalizations.delegate failed to load unsupported locale "$locale". This is likely '
-    'an issue with the localizations generation tool. Please file an issue '
-    'on GitHub with a reproducible sample app and the gen-l10n configuration '
-    'that was used.',
-  );
+      'AppLocalizations.delegate failed to load unsupported locale "$locale". This is likely '
+      'an issue with the localizations generation tool. Please file an issue '
+      'on GitHub with a reproducible sample app and the gen-l10n configuration '
+      'that was used.');
 }

--- a/src/packages/flutter-app/lib/l10n/app_localizations_en.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations_en.dart
@@ -1782,9 +1782,6 @@ class AppLocalizationsEn extends AppLocalizations {
   String get homeStatusPlanned => 'Planned';
 
   @override
-  String get homeRecentTripEyebrow => 'PICK UP WHERE YOU LEFT OFF';
-
-  @override
   String get homeLocalGuidesTitle => 'Local guides';
 
   @override

--- a/src/packages/flutter-app/lib/l10n/app_localizations_es.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations_es.dart
@@ -1797,9 +1797,6 @@ class AppLocalizationsEs extends AppLocalizations {
   String get homeStatusPlanned => 'Planeado';
 
   @override
-  String get homeRecentTripEyebrow => 'CONTINÚA DONDE LO DEJASTE';
-
-  @override
   String get homeLocalGuidesTitle => 'Guías locales';
 
   @override

--- a/src/packages/flutter-app/lib/screens/home_screen.dart
+++ b/src/packages/flutter-app/lib/screens/home_screen.dart
@@ -171,9 +171,7 @@ class HomeScreen extends ConsumerWidget {
 
                 SizedBox(height: returning ? AppSpacing.lg : AppSpacing.xl),
 
-                // The trip happening today (specs/happening-now), then the
-                // most recently viewed trip — the latter hidden when it *is*
-                // the live trip, so the same trip never stacks twice.
+                // The trip happening today (specs/happening-now).
                 if (liveTrip != null) ...[
                   LiveTripCard(
                     trip: liveTrip,
@@ -185,27 +183,28 @@ class HomeScreen extends ConsumerWidget {
                   ),
                   const SizedBox(height: AppSpacing.lg),
                 ],
-                // In-progress AI conversations that haven't produced a trip
-                // yet (specs/continue-where-you-left-off) — same section as
-                // My Trips, slotted below the live trip like there. Collapses
-                // to nothing when empty, on error, or signed out.
-                const ContinueChatsSection(),
-
-                if (recentTrip != null &&
-                    recentTrip.tripId != liveTrip?.id) ...[
-                  _RecentTripCard(
-                    title: recentTrip.title,
-                    dateRange: recentTrip.dateRange,
-                    status: recentTrip.status,
-                    onTap: () => Navigator.of(context).push(
-                      MaterialPageRoute(
-                        builder: (_) =>
-                            TripDetailScreen(tripId: recentTrip.tripId),
-                      ),
-                    ),
-                  ),
-                  const SizedBox(height: AppSpacing.lg),
-                ],
+                // One "Continue where you left off" section: the most
+                // recently viewed trip (hidden when it *is* the live trip,
+                // so the same trip never stacks twice), then in-progress AI
+                // conversations that haven't produced a trip yet
+                // (specs/continue-where-you-left-off). Collapses to nothing
+                // when there is nothing to resume.
+                ContinueChatsSection(
+                  leading: recentTrip != null &&
+                          recentTrip.tripId != liveTrip?.id
+                      ? _RecentTripCard(
+                          title: recentTrip.title,
+                          dateRange: recentTrip.dateRange,
+                          status: recentTrip.status,
+                          onTap: () => Navigator.of(context).push(
+                            MaterialPageRoute(
+                              builder: (_) =>
+                                  TripDetailScreen(tripId: recentTrip.tripId),
+                            ),
+                          ),
+                        )
+                      : null,
+                ),
 
                 // Local guides discover row — published narrative guides
                 // across all cities. Renders nothing while loading, on
@@ -474,6 +473,8 @@ String _statusLabel(AppLocalizations l10n, String status) => switch (status) {
 
 /// One-tap way back into the most recently viewed trip, styled as a lighter
 /// sibling of the hero card (same teal family as the app bar gradient).
+/// Rendered inside the "Continue where you left off" section, which supplies
+/// the header — the card itself carries no eyebrow.
 class _RecentTripCard extends StatelessWidget {
   final String title;
   final String? dateRange;
@@ -527,16 +528,6 @@ class _RecentTripCard extends StatelessWidget {
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
-                      Text(
-                        l10n.homeRecentTripEyebrow,
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
-                        style: theme.textTheme.labelSmall?.copyWith(
-                          color: Colors.white70,
-                          letterSpacing: 1.2,
-                        ),
-                      ),
-                      const SizedBox(height: 2),
                       Text(
                         title,
                         maxLines: 1,

--- a/src/packages/flutter-app/lib/widgets/continue_chats_section.dart
+++ b/src/packages/flutter-app/lib/widgets/continue_chats_section.dart
@@ -14,8 +14,14 @@ import 'section_header.dart';
 /// (specs/continue-where-you-left-off), as a self-contained home-screen
 /// section. Collapses to nothing while loading, on error, when signed out,
 /// or when there is nothing to resume.
+///
+/// [leading] hosts the recently-viewed-trip card on Home under the same
+/// header — one "Continue where you left off" surface instead of two
+/// adjacent sections saying the same thing.
 class ContinueChatsSection extends ConsumerWidget {
-  const ContinueChatsSection({super.key});
+  final Widget? leading;
+
+  const ContinueChatsSection({super.key, this.leading});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -27,13 +33,17 @@ class ContinueChatsSection extends ConsumerWidget {
 
     final resumable = ref.watch(resumableChatsProvider).valueOrNull ??
         const <ChatSessionSummary>[];
-    if (resumable.isEmpty) return const SizedBox.shrink();
+    if (resumable.isEmpty && leading == null) return const SizedBox.shrink();
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
         SectionHeader(title: context.l10n.continueChatsTitle),
         const SizedBox(height: AppSpacing.sm),
+        if (leading != null) ...[
+          leading!,
+          const SizedBox(height: AppSpacing.sm),
+        ],
         for (final c in resumable) ContinueChatCard(chat: c),
         const SizedBox(height: AppSpacing.lg),
       ],

--- a/src/packages/flutter-app/test/home_continue_chats_test.dart
+++ b/src/packages/flutter-app/test/home_continue_chats_test.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -14,8 +16,9 @@ import 'package:travel_route_planner/widgets/continue_chats_section.dart';
 import 'support/l10n_test_app.dart';
 
 /// Home-screen slotting of the "Continue where you left off" section
-/// (specs/continue-where-you-left-off): in-progress plan chats surface on
-/// Home too, and the section collapses to nothing when there are none.
+/// (specs/continue-where-you-left-off): one merged surface holding the
+/// recently viewed trip card and in-progress plan chats under a single
+/// header; the section collapses to nothing when there is nothing to resume.
 class _FakeAuthNotifier extends StateNotifier<AuthState>
     implements AuthNotifier {
   _FakeAuthNotifier(UserModel? user)
@@ -64,6 +67,18 @@ ChatSessionSummary _chat(String id, String title) => ChatSessionSummary(
       updatedAt: '2026-07-02T10:00:00Z',
     );
 
+/// Seeds the persisted recent-trip snapshot the way the detail screen would
+/// have recorded it (recent_trip_provider storage format, keyed by user).
+void _seedRecentTrip(String tripId, String title) {
+  SharedPreferences.setMockInitialValues({
+    'recent_trip.user-1': jsonEncode({
+      'id': tripId,
+      'title': title,
+      'status': 'planned',
+    }),
+  });
+}
+
 Future<void> _pumpHome(
   WidgetTester tester, {
   List<ChatSessionSummary> chats = const [],
@@ -102,5 +117,28 @@ void main() {
 
     expect(find.text('Continue where you left off'), findsNothing);
     expect(find.byType(ContinueChatCard), findsNothing);
+  });
+
+  testWidgets('recent trip alone still renders the section',
+      (WidgetTester tester) async {
+    _seedRecentTrip('t1', 'Lisbon Trip');
+    await _pumpHome(tester);
+
+    expect(find.text('Continue where you left off'), findsOneWidget);
+    expect(find.text('Lisbon Trip'), findsOneWidget);
+    expect(find.byType(ContinueChatCard), findsNothing);
+  });
+
+  testWidgets('recent trip and chats share one header, trip card first',
+      (WidgetTester tester) async {
+    _seedRecentTrip('t1', 'Lisbon Trip');
+    await _pumpHome(tester, chats: [_chat('c1', 'Greek islands in September')]);
+
+    expect(find.text('Continue where you left off'), findsOneWidget);
+    expect(find.byType(ContinueChatCard), findsOneWidget);
+    expect(
+      tester.getTopLeft(find.text('Lisbon Trip')).dy,
+      lessThan(tester.getTopLeft(find.byType(ContinueChatCard)).dy),
+    );
   });
 }

--- a/src/packages/flutter-app/test/home_live_trip_test.dart
+++ b/src/packages/flutter-app/test/home_live_trip_test.dart
@@ -17,7 +17,8 @@ import 'support/l10n_test_app.dart';
 
 /// Home-screen slotting of the "Happening now" card (specs/happening-now):
 /// the live card takes the recent-trip slot, and the recent-trip tile only
-/// renders below it when it points at a *different* trip.
+/// renders below it — inside the "Continue where you left off" section —
+/// when it points at a *different* trip.
 class _FakeAuthNotifier extends StateNotifier<AuthState>
     implements AuthNotifier {
   _FakeAuthNotifier(UserModel? user)
@@ -120,7 +121,9 @@ void main() {
     await _pumpHome(tester, _liveTrip('t1'));
 
     expect(find.byType(LiveTripCard), findsOneWidget);
-    expect(find.text('PICK UP WHERE YOU LEFT OFF'), findsNothing);
+    // No chats and the recent trip is the live trip, so the whole
+    // "Continue where you left off" section collapses.
+    expect(find.text('Continue where you left off'), findsNothing);
   });
 
   testWidgets('both cards show when the recent trip is a different trip',
@@ -129,14 +132,14 @@ void main() {
     await _pumpHome(tester, _liveTrip('t1'));
 
     expect(find.byType(LiveTripCard), findsOneWidget);
-    expect(find.text('PICK UP WHERE YOU LEFT OFF'), findsOneWidget);
+    expect(find.text('Continue where you left off'), findsOneWidget);
     expect(find.text('Lisbon Trip'), findsOneWidget);
 
-    // The live card leads the slot; the recent tile sits below it.
+    // The live card leads the slot; the recent tile sits below it under the
+    // continue header.
     expect(
       tester.getTopLeft(find.byType(LiveTripCard)).dy,
-      lessThan(
-          tester.getTopLeft(find.text('PICK UP WHERE YOU LEFT OFF')).dy),
+      lessThan(tester.getTopLeft(find.text('Lisbon Trip')).dy),
     );
   });
 
@@ -146,6 +149,7 @@ void main() {
     await _pumpHome(tester, null);
 
     expect(find.byType(LiveTripCard), findsNothing);
-    expect(find.text('PICK UP WHERE YOU LEFT OFF'), findsOneWidget);
+    expect(find.text('Continue where you left off'), findsOneWidget);
+    expect(find.text('Lisbon Trip'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- Home showed two adjacent resume surfaces — the "Continue where you left off" chat section and a "PICK UP WHERE YOU LEFT OFF" recent-trip card — that say the same thing (identical phrase in Spanish). They are now one section.
- `ContinueChatsSection` gains an optional `leading` slot; the section renders whenever there are chats **or** a leading widget. The trips-list mount (no leading) is behavior-identical.
- Home mounts the recent-trip card in that slot under the single existing header; the card keeps its dark brand-gradient style but drops the eyebrow. `homeRecentTripEyebrow` removed from both `.arb` files (l10n regenerated).

## Testing
- `flutter analyze` — clean (3 pre-existing infos in `route_response.dart`, untouched).
- `flutter test` — 600/600 pass, including updated `home_live_trip_test.dart` (eyebrow finders → section header; section collapses when the recent trip is the live trip) and two new cases in `home_continue_chats_test.dart` (trip-only renders the section; trip + chats share one header with the trip card first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)