### PR TITLE
fix: single-world map fills the box width — no more background side bars

### DIFF
--- a/src/packages/flutter-app/lib/screens/local_guide_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/local_guide_detail_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:math' as math;
+
 import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -40,8 +42,10 @@ class LocalGuideDetailScreen extends ConsumerWidget {
             const Icon(Icons.menu_book, size: 20),
             const SizedBox(width: AppSpacing.sm),
             Flexible(
-              child:
-                  Text(l10n.guideDetailTitle, overflow: TextOverflow.ellipsis),
+              child: Text(
+                l10n.guideDetailTitle,
+                overflow: TextOverflow.ellipsis,
+              ),
             ),
           ],
         ),
@@ -72,8 +76,10 @@ class LocalGuideDetailScreen extends ConsumerWidget {
               ref.invalidate(localGuideDetailProvider(guide.id)),
           // Add-to-trip needs an account (guides browse stays public).
           onAddPin: ref.watch(authProvider).isSignedIn
-              ? (pin) => showAddToTripSheet(context,
-                  AddToTripPayload.fromLocalRec(pin, source: 'guide_pin'))
+              ? (pin) => showAddToTripSheet(
+                  context,
+                  AddToTripPayload.fromLocalRec(pin, source: 'guide_pin'),
+                )
               : null,
         ),
       ),
@@ -114,8 +120,9 @@ class _GuideBody extends StatelessWidget {
       _pick(guide.neighborhood, fallback.neighborhood),
       _pick(guide.city, fallback.city),
     ].where((s) => s.isNotEmpty).join(' · ');
-    final mapped =
-        pins.where((p) => p.latitude != null && p.longitude != null).toList();
+    final mapped = pins
+        .where((p) => p.latitude != null && p.longitude != null)
+        .toList();
 
     return RefreshIndicator(
       onRefresh: onRefresh,
@@ -136,15 +143,17 @@ class _GuideBody extends StatelessWidget {
                 ],
                 Text(
                   title,
-                  style: theme.textTheme.headlineSmall
-                      ?.copyWith(fontWeight: FontWeight.bold),
+                  style: theme.textTheme.headlineSmall?.copyWith(
+                    fontWeight: FontWeight.bold,
+                  ),
                 ),
                 if (placeLine.isNotEmpty) ...[
                   const SizedBox(height: AppSpacing.xs),
                   Text(
                     placeLine,
-                    style: theme.textTheme.bodyMedium
-                        ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+                    style: theme.textTheme.bodyMedium?.copyWith(
+                      color: theme.colorScheme.onSurfaceVariant,
+                    ),
                   ),
                 ],
                 // The local behind the guide — same face + name treatment as the
@@ -162,7 +171,9 @@ class _GuideBody extends StatelessWidget {
                         child: Text(
                           sourceName.characters.first.toUpperCase(),
                           style: theme.textTheme.labelSmall?.copyWith(
-                              color: accent, fontWeight: FontWeight.w700),
+                            color: accent,
+                            fontWeight: FontWeight.w700,
+                          ),
                         ),
                       ),
                       const SizedBox(width: AppSpacing.sm),
@@ -170,7 +181,9 @@ class _GuideBody extends StatelessWidget {
                         child: Text(
                           l10n.guideDetailByline(sourceName),
                           style: theme.textTheme.labelLarge?.copyWith(
-                              color: accent, fontWeight: FontWeight.w600),
+                            color: accent,
+                            fontWeight: FontWeight.w600,
+                          ),
                           maxLines: 1,
                           overflow: TextOverflow.ellipsis,
                         ),
@@ -198,13 +211,16 @@ class _GuideBody extends StatelessWidget {
                       Text(
                         l10n.guideDetailPlacesTitle,
                         style: theme.textTheme.labelLarge?.copyWith(
-                            fontWeight: FontWeight.w600, color: accent),
+                          fontWeight: FontWeight.w600,
+                          color: accent,
+                        ),
                       ),
                       const SizedBox(width: AppSpacing.sm),
                       Text(
                         '${pins.length}',
                         style: theme.textTheme.labelMedium?.copyWith(
-                            color: theme.colorScheme.onSurfaceVariant),
+                          color: theme.colorScheme.onSurfaceVariant,
+                        ),
                       ),
                     ],
                   ),
@@ -216,8 +232,9 @@ class _GuideBody extends StatelessWidget {
                   for (final pin in pins)
                     LocalRecCard(
                       rec: pin,
-                      onAddToTrip:
-                          onAddPin == null ? null : () => onAddPin!(pin),
+                      onAddToTrip: onAddPin == null
+                          ? null
+                          : () => onAddPin!(pin),
                     ),
                 ] else ...[
                   const SizedBox(height: AppSpacing.xl),
@@ -258,8 +275,11 @@ class _HeroImage extends StatelessWidget {
           errorBuilder: (context, _, __) => Container(
             decoration: BoxDecoration(gradient: AppColors.brandGradient),
             alignment: Alignment.center,
-            child: const Icon(Icons.photo_outlined,
-                size: 40, color: Colors.white70),
+            child: const Icon(
+              Icons.photo_outlined,
+              size: 40,
+              color: Colors.white70,
+            ),
           ),
         ),
       ),
@@ -283,6 +303,10 @@ class _GuideMap extends StatefulWidget {
 class _GuideMapState extends State<_GuideMap> {
   final MapController _controller = MapController();
 
+  /// Width from the previous layout, to catch resizes (see the
+  /// LayoutBuilder in [build]).
+  double? _lastMapWidth;
+
   void _zoomBy(double delta) {
     try {
       _controller.move(
@@ -301,66 +325,95 @@ class _GuideMapState extends State<_GuideMap> {
     const interaction = InteractionOptions(
       flags: InteractiveFlag.all & ~InteractiveFlag.scrollWheelZoom,
     );
-    final options = points.length == 1
-        ? appMapOptions(
-            initialCenter: points.first,
-            initialZoom: 13,
-            interactionOptions: interaction,
-          )
-        : appMapOptions(
-            initialCameraFit: CameraFit.bounds(
-              bounds: LatLngBounds.fromPoints(points),
-              padding: const EdgeInsets.all(32),
-            ),
-            interactionOptions: interaction,
-          );
 
     return ClipRRect(
       borderRadius: AppRadius.lgAll,
       child: SizedBox(
         height: 240,
-        child: Stack(
-          children: [
-            FlutterMap(
-              mapController: _controller,
-              options: options,
+        child: LayoutBuilder(
+          builder: (context, constraints) {
+            // Zoom floor so the zoom-out button can't shrink the single world
+            // narrower than the map box (background bars); see appMapMinZoomFor.
+            final minZoom = appMapMinZoomFor(constraints.maxWidth);
+
+            // flutter_map adopts a changed minZoom but never re-clamps the live
+            // zoom, so after a resize nudge the camera back over the floor
+            // (moveRaw re-applies the camera constraint too; no-op otherwise).
+            if (_lastMapWidth != null &&
+                _lastMapWidth != constraints.maxWidth) {
+              WidgetsBinding.instance.addPostFrameCallback((_) {
+                if (!mounted) return;
+                try {
+                  final camera = _controller.camera;
+                  _controller.move(
+                    camera.center,
+                    math.max(camera.zoom, minZoom),
+                  );
+                } catch (_) {}
+              });
+            }
+            _lastMapWidth = constraints.maxWidth;
+
+            final options = points.length == 1
+                ? appMapOptions(
+                    initialCenter: points.first,
+                    initialZoom: 13,
+                    minZoom: minZoom,
+                    interactionOptions: interaction,
+                  )
+                : appMapOptions(
+                    initialCameraFit: CameraFit.bounds(
+                      bounds: LatLngBounds.fromPoints(points),
+                      padding: const EdgeInsets.all(32),
+                    ),
+                    minZoom: minZoom,
+                    interactionOptions: interaction,
+                  );
+
+            return Stack(
               children: [
-                ...appMapTileLayers(context),
-                MarkerLayer(
-                  markers: [
-                    for (var i = 0; i < points.length; i++)
-                      Marker(
-                        point: points[i],
-                        width: 24,
-                        height: 24,
-                        child: _GuidePin(label: '${i + 1}'),
-                      ),
+                FlutterMap(
+                  mapController: _controller,
+                  options: options,
+                  children: [
+                    ...appMapTileLayers(context),
+                    MarkerLayer(
+                      markers: [
+                        for (var i = 0; i < points.length; i++)
+                          Marker(
+                            point: points[i],
+                            width: 24,
+                            height: 24,
+                            child: _GuidePin(label: '${i + 1}'),
+                          ),
+                      ],
+                    ),
+                    appMapAttribution(),
                   ],
                 ),
-                appMapAttribution(),
+                Positioned(
+                  right: 8,
+                  bottom: 8,
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      MapControlButton(
+                        icon: Icons.add,
+                        tooltip: context.l10n.mapZoomIn,
+                        onTap: () => _zoomBy(1),
+                      ),
+                      const SizedBox(height: AppSpacing.sm),
+                      MapControlButton(
+                        icon: Icons.remove,
+                        tooltip: context.l10n.mapZoomOut,
+                        onTap: () => _zoomBy(-1),
+                      ),
+                    ],
+                  ),
+                ),
               ],
-            ),
-            Positioned(
-              right: 8,
-              bottom: 8,
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  MapControlButton(
-                    icon: Icons.add,
-                    tooltip: context.l10n.mapZoomIn,
-                    onTap: () => _zoomBy(1),
-                  ),
-                  const SizedBox(height: AppSpacing.sm),
-                  MapControlButton(
-                    icon: Icons.remove,
-                    tooltip: context.l10n.mapZoomOut,
-                    onTap: () => _zoomBy(-1),
-                  ),
-                ],
-              ),
-            ),
-          ],
+            );
+          },
         ),
       ),
     );

--- a/src/packages/flutter-app/lib/widgets/app_map.dart
+++ b/src/packages/flutter-app/lib/widgets/app_map.dart
@@ -1,3 +1,5 @@
+import 'dart:math' as math;
+
 import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:latlong2/latlong.dart';
@@ -9,6 +11,24 @@ import '../theme/app_colors.dart';
 /// "not lit yet" instead of a broken grey hole. Pass as
 /// `MapOptions.backgroundColor` wherever [appMapTileLayers] is used.
 const Color appMapBackground = Color(0xFF0A0F1A);
+
+/// Nudges the computed zoom floor up so floating-point rounding can never
+/// leave a sub-pixel sliver of background at the world's edges (the world
+/// ends up ~0.7% wider than the viewport).
+const double _minZoomEpsilon = 0.01;
+
+/// Lowest zoom at which the single world (256·2^z px wide) still fills a
+/// viewport of [viewportWidth] px horizontally; never below the legacy floor
+/// of 1. Pass as `minZoom` to [appMapOptions] so neither an auto-fit nor a
+/// user zoom-out can shrink the world narrower than the map box, which would
+/// expose [appMapBackground] as bars down both sides.
+double appMapMinZoomFor(double viewportWidth) {
+  // At or below 512px (all phone bands) z1's 512px world already fills the
+  // box — power-of-two exact, no epsilon needed — keeping the floor
+  // identical to the pre-dynamic behavior there.
+  if (!viewportWidth.isFinite || viewportWidth <= 512) return 1;
+  return math.log(viewportWidth / 256) / math.ln2 + _minZoomEpsilon;
+}
 
 /// Web Mercator that draws exactly **one** world.
 ///
@@ -69,29 +89,98 @@ MapOptions appMapOptions({
   LatLng? initialCenter,
   double? initialZoom,
   CameraFit? initialCameraFit,
+  double minZoom = 1,
   required InteractionOptions interactionOptions,
 }) {
   return MapOptions(
     crs: const AppMapCrs(),
     backgroundColor: appMapBackground,
-    // Keeps the camera *center* on the world, so a pan can't drift off into
-    // empty background. Deliberately not CameraConstraint.contain: that one
+    // Keeps the world edges outside the viewport horizontally (no background
+    // bars from a pan or an off-meridian fit) and the camera center on the
+    // planet vertically. Deliberately not CameraConstraint.contain: that one
     // rejects any camera it cannot fit inside the bounds (returning null),
     // which would freeze a map taller than the world is wide.
-    cameraConstraint: CameraConstraint.containCenter(
-      bounds: LatLngBounds(const LatLng(-85, -180), const LatLng(85, 180)),
-    ),
+    cameraConstraint: const AppMapCameraConstraint(),
     // Without a floor, zooming out shrinks the single world to a postage
     // stamp and then past the smallest tile level into empty background.
-    // z1 = a 512px world, which still fills our 240px map bands vertically
-    // and is far below any real trip's auto-fit zoom (that would need ~130°
-    // of latitude in one trip), so the fit is never clamped by this.
-    minZoom: 1,
+    // Callers with a known width pass [appMapMinZoomFor] so the world always
+    // fills the viewport horizontally — the camera fit clamps up to it, which
+    // trades vertical fit in our short map bands (an extreme-latitude trip
+    // may need a pan to reach its outermost pins) for never showing bars.
+    minZoom: minZoom,
     initialCenter: initialCenter ?? const LatLng(0, 0),
     initialZoom: initialZoom ?? 13,
     initialCameraFit: initialCameraFit,
     interactionOptions: interactionOptions,
   );
+}
+
+/// Camera constraint for the single-world [AppMapCrs]: contains the world
+/// *edges* horizontally (a pan or off-center fit can never drag ±180° inside
+/// the viewport and expose [appMapBackground] as side bars) while only
+/// containing the camera *center* vertically at ±85° (edge-containing
+/// latitude would freeze any map taller than the world, per the note on
+/// [appMapOptions]).
+///
+/// Horizontal containment is only possible when the world is at least as
+/// wide as the viewport — [appMapMinZoomFor] guarantees that; below the
+/// floor (transient states only) the camera is returned unchanged rather
+/// than `null`, which would freeze the map.
+@immutable
+class AppMapCameraConstraint extends CameraConstraint {
+  /// Create the app's single-world camera constraint.
+  const AppMapCameraConstraint();
+
+  static const double _maxLatitude = 85;
+
+  @override
+  MapCamera constrain(MapCamera camera) {
+    // The controller applies its options (and debug-asserts constraint
+    // compliance) once before the first layout, while the camera still has
+    // the sentinel "impossible" size — nothing sensible to contain yet.
+    final size = camera.nonRotatedSize;
+    if (size == MapCamera.kImpossibleSize ||
+        !size.width.isFinite ||
+        size.width <= 0) {
+      return camera;
+    }
+
+    final zoom = camera.zoom;
+    final center = LatLng(
+      camera.center.latitude.clamp(-_maxLatitude, _maxLatitude),
+      camera.center.longitude,
+    );
+
+    // Mirror ContainCamera's x-axis math against the whole world.
+    final westPix = camera.projectAtZoom(const LatLng(0, -180), zoom);
+    final eastPix = camera.projectAtZoom(const LatLng(0, 180), zoom);
+    final halfWidth = camera.size.width / 2;
+    final leftOkCenter = math.min(westPix.dx, eastPix.dx) + halfWidth;
+    final rightOkCenter = math.max(westPix.dx, eastPix.dx) - halfWidth;
+
+    // World narrower than the viewport: no horizontal containment exists
+    // (transiently possible below the [appMapMinZoomFor] floor).
+    if (leftOkCenter > rightOkCenter) {
+      if (center == camera.center) return camera;
+      return camera.withPosition(center: center);
+    }
+
+    final centerPix = camera.projectAtZoom(center, zoom);
+    final newX = centerPix.dx.clamp(leftOkCenter, rightOkCenter);
+    if (newX == centerPix.dx) {
+      if (center == camera.center) return camera;
+      return camera.withPosition(center: center);
+    }
+    return camera.withPosition(
+      center: camera.unprojectAtZoom(Offset(newX, centerPix.dy), zoom),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) => other is AppMapCameraConstraint;
+
+  @override
+  int get hashCode => (AppMapCameraConstraint).hashCode;
 }
 
 /// Shared basemap for every map in the app: Esri World Imagery satellite

--- a/src/packages/flutter-app/lib/widgets/trip_map.dart
+++ b/src/packages/flutter-app/lib/widgets/trip_map.dart
@@ -106,6 +106,10 @@ class TripMap extends StatefulWidget {
 class _TripMapState extends State<TripMap> {
   final MapController _controller = MapController();
 
+  /// Width from the previous layout, to catch resizes in [build]'s
+  /// LayoutBuilder (they never reach [didUpdateWidget]).
+  double? _lastMapWidth;
+
   /// Fit padding shared by the initial fit and every re-fit; asymmetric so a
   /// top overlay (day chips) never covers the topmost fitted marker.
   EdgeInsets get _fitPadding =>
@@ -303,7 +307,8 @@ class _TripMapState extends State<TripMap> {
       final a = mapped[k];
       final b = mapped[k + 1];
       if (a.point == b.point) continue;
-      final hasLabel = b.item.position == a.item.position + 1 &&
+      final hasLabel =
+          b.item.position == a.item.position + 1 &&
           widget.segmentLabels[a.item.position] != null;
       final t = hasLabel ? 0.7 : 0.5;
       arrowMarkers.add(
@@ -327,19 +332,44 @@ class _TripMapState extends State<TripMap> {
           )
         : const InteractionOptions(flags: InteractiveFlag.none);
 
-    // Center on the selected place when one is set (e.g. the map was just
-    // (re)built after a list tap); otherwise fit the whole trip.
-    final MapOptions options = selected != null
-        ? appMapOptions(
-            initialCenter: selected,
-            initialZoom: 15,
-            interactionOptions: interaction,
-          )
-        : fitPoints.length == 1
+    // The zoom floor that keeps the single world filling the box depends on
+    // the width the map is given, so the options are assembled in a
+    // LayoutBuilder.
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final minZoom = appMapMinZoomFor(constraints.maxWidth);
+
+        // flutter_map adopts a changed minZoom into the camera's options but
+        // never re-clamps the live zoom, so after a resize nudge the camera
+        // back over the (possibly risen) floor. One move covers both resize
+        // failure modes: moveRaw re-applies clampZoom *and* the camera
+        // constraint, and no-ops when nothing is out of bounds.
+        if (_lastMapWidth != null && _lastMapWidth != constraints.maxWidth) {
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            if (!mounted) return;
+            try {
+              final camera = _controller.camera;
+              _controller.move(camera.center, math.max(camera.zoom, minZoom));
+            } catch (_) {}
+          });
+        }
+        _lastMapWidth = constraints.maxWidth;
+
+        // Center on the selected place when one is set (e.g. the map was just
+        // (re)built after a list tap); otherwise fit the whole trip.
+        final MapOptions options = selected != null
+            ? appMapOptions(
+                initialCenter: selected,
+                initialZoom: 15,
+                minZoom: minZoom,
+                interactionOptions: interaction,
+              )
+            : fitPoints.length == 1
             // Single point: bounds collapse, so center with a sensible zoom.
             ? appMapOptions(
                 initialCenter: fitPoints.first,
                 initialZoom: 13,
+                minZoom: minZoom,
                 interactionOptions: interaction,
               )
             : appMapOptions(
@@ -347,133 +377,140 @@ class _TripMapState extends State<TripMap> {
                   bounds: LatLngBounds.fromPoints(fitPoints),
                   padding: _fitPadding,
                 ),
+                minZoom: minZoom,
                 interactionOptions: interaction,
               );
 
-    return Stack(
-      children: [
-        FlutterMap(
-          mapController: _controller,
-          options: options,
+        return Stack(
           children: [
-            ...appMapTileLayers(context),
-            if (points.length >= 2)
-              PolylineLayer(
-                polylines: [
-                  // Two passes make a thin line with a soft glow that stays
-                  // legible over satellite imagery.
-                  Polyline(
-                    points: points,
-                    strokeWidth: 6,
-                    color: Colors.white.withValues(alpha: 0.25),
-                  ),
-                  Polyline(
-                    points: points,
-                    strokeWidth: 2,
-                    color: Colors.white.withValues(alpha: 0.95),
-                  ),
-                ],
-              ),
-            if (arrowMarkers.isNotEmpty) MarkerLayer(markers: arrowMarkers),
-            if (labelSegments.isNotEmpty)
-              _SegmentLabelLayer(segments: labelSegments),
-            // Stays live in their own layer, outside the clusterer: a trip has
-            // few of them and "where am I sleeping" should never collapse into
-            // an anonymous count bubble with sightseeing pins. Drawn beneath
-            // the numbered pins so the primary interaction stays on top.
-            if (stays.isNotEmpty)
-              MarkerLayer(
-                markers: [
-                  for (final s in stays)
-                    Marker(
-                      point: s.point,
-                      // Transparent 44px halo around the 26px square; the
-                      // box stays centered on the coordinate (see
-                      // _pinHitBox).
-                      width: _pinHitBox,
-                      height: _pinHitBox,
-                      child: _StayPin(
-                        name: s.stay.name,
-                        dates: tripDateRange(s.stay.checkIn, s.stay.checkOut),
+            FlutterMap(
+              mapController: _controller,
+              options: options,
+              children: [
+                ...appMapTileLayers(context),
+                if (points.length >= 2)
+                  PolylineLayer(
+                    polylines: [
+                      // Two passes make a thin line with a soft glow that stays
+                      // legible over satellite imagery.
+                      Polyline(
+                        points: points,
+                        strokeWidth: 6,
+                        color: Colors.white.withValues(alpha: 0.25),
                       ),
-                    ),
-                ],
-              ),
-            MarkerClusterLayerWidget(
-              options: MarkerClusterLayerOptions(
-                maxClusterRadius: 45,
-                size: const Size(32, 32),
-                padding: const EdgeInsets.all(40),
-                markers: [
-                  // Labels count 1..N over what this map view shows (the whole
-                  // trip on All, one day on Day N) — not the item's trip-wide
-                  // position, which reads as arbitrary once the view filters
-                  // or skips ungeocoded items.
-                  for (final (k, m) in mapped.indexed)
-                    Marker(
-                      point: m.point,
-                      // Transparent 44px halo around the 24/28px dot, tap
-                      // handling on the whole box; centered so the dot stays
-                      // anchored on its coordinate (see _pinHitBox).
-                      width: _pinHitBox,
-                      height: _pinHitBox,
-                      child: GestureDetector(
-                        behavior: HitTestBehavior.opaque,
-                        onTap: widget.onPinTap == null
-                            ? null
-                            : () => widget.onPinTap!(m.item.position),
-                        child: Center(
-                          child: SizedBox.square(
-                            dimension:
-                                widget.selectedPosition == m.item.position
-                                    ? 28
-                                    : 24,
-                            child: _Pin(
-                              label: '${k + 1}',
-                              category: m.item.category,
-                              selected:
-                                  widget.selectedPosition == m.item.position,
+                      Polyline(
+                        points: points,
+                        strokeWidth: 2,
+                        color: Colors.white.withValues(alpha: 0.95),
+                      ),
+                    ],
+                  ),
+                if (arrowMarkers.isNotEmpty) MarkerLayer(markers: arrowMarkers),
+                if (labelSegments.isNotEmpty)
+                  _SegmentLabelLayer(segments: labelSegments),
+                // Stays live in their own layer, outside the clusterer: a trip has
+                // few of them and "where am I sleeping" should never collapse into
+                // an anonymous count bubble with sightseeing pins. Drawn beneath
+                // the numbered pins so the primary interaction stays on top.
+                if (stays.isNotEmpty)
+                  MarkerLayer(
+                    markers: [
+                      for (final s in stays)
+                        Marker(
+                          point: s.point,
+                          // Transparent 44px halo around the 26px square; the
+                          // box stays centered on the coordinate (see
+                          // _pinHitBox).
+                          width: _pinHitBox,
+                          height: _pinHitBox,
+                          child: _StayPin(
+                            name: s.stay.name,
+                            dates: tripDateRange(
+                              s.stay.checkIn,
+                              s.stay.checkOut,
                             ),
                           ),
                         ),
-                      ),
-                    ),
-                ],
-                builder: (context, clusterMarkers) =>
-                    _ClusterBubble(count: clusterMarkers.length),
-              ),
-            ),
-            appMapAttribution(),
-          ],
-        ),
-        if (widget.interactive)
-          Positioned(
-            right: 8,
-            bottom: 8,
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                MapControlButton(
-                  icon: Icons.add,
-                  tooltip: l10n.mapZoomIn,
-                  onTap: () => _zoomBy(1),
+                    ],
+                  ),
+                MarkerClusterLayerWidget(
+                  options: MarkerClusterLayerOptions(
+                    maxClusterRadius: 45,
+                    size: const Size(32, 32),
+                    padding: const EdgeInsets.all(40),
+                    markers: [
+                      // Labels count 1..N over what this map view shows (the whole
+                      // trip on All, one day on Day N) — not the item's trip-wide
+                      // position, which reads as arbitrary once the view filters
+                      // or skips ungeocoded items.
+                      for (final (k, m) in mapped.indexed)
+                        Marker(
+                          point: m.point,
+                          // Transparent 44px halo around the 24/28px dot, tap
+                          // handling on the whole box; centered so the dot stays
+                          // anchored on its coordinate (see _pinHitBox).
+                          width: _pinHitBox,
+                          height: _pinHitBox,
+                          child: GestureDetector(
+                            behavior: HitTestBehavior.opaque,
+                            onTap: widget.onPinTap == null
+                                ? null
+                                : () => widget.onPinTap!(m.item.position),
+                            child: Center(
+                              child: SizedBox.square(
+                                dimension:
+                                    widget.selectedPosition == m.item.position
+                                    ? 28
+                                    : 24,
+                                child: _Pin(
+                                  label: '${k + 1}',
+                                  category: m.item.category,
+                                  selected:
+                                      widget.selectedPosition ==
+                                      m.item.position,
+                                ),
+                              ),
+                            ),
+                          ),
+                        ),
+                    ],
+                    builder: (context, clusterMarkers) =>
+                        _ClusterBubble(count: clusterMarkers.length),
+                  ),
                 ),
-                const SizedBox(height: 8),
-                MapControlButton(
-                  icon: Icons.remove,
-                  tooltip: l10n.mapZoomOut,
-                  onTap: () => _zoomBy(-1),
-                ),
-                const SizedBox(height: 8),
-                MapControlButton(
-                  icon: Icons.center_focus_strong,
-                  tooltip: l10n.mapResetMap,
-                  onTap: () => _fitToTrip(fitPoints),
-                ),
+                appMapAttribution(),
               ],
             ),
-          ),
-      ],
+            if (widget.interactive)
+              Positioned(
+                right: 8,
+                bottom: 8,
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    MapControlButton(
+                      icon: Icons.add,
+                      tooltip: l10n.mapZoomIn,
+                      onTap: () => _zoomBy(1),
+                    ),
+                    const SizedBox(height: 8),
+                    MapControlButton(
+                      icon: Icons.remove,
+                      tooltip: l10n.mapZoomOut,
+                      onTap: () => _zoomBy(-1),
+                    ),
+                    const SizedBox(height: 8),
+                    MapControlButton(
+                      icon: Icons.center_focus_strong,
+                      tooltip: l10n.mapResetMap,
+                      onTap: () => _fitToTrip(fitPoints),
+                    ),
+                  ],
+                ),
+              ),
+          ],
+        );
+      },
     );
   }
 }

--- a/src/packages/flutter-app/test/app_map_min_zoom_test.dart
+++ b/src/packages/flutter-app/test/app_map_min_zoom_test.dart
@@ -1,0 +1,113 @@
+import 'dart:math' as math;
+import 'dart:ui';
+
+import 'package:flutter_map/flutter_map.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:latlong2/latlong.dart';
+
+import 'package:travel_route_planner/widgets/app_map.dart';
+
+/// World pixel width at [zoom] under Web Mercator (256px tiles).
+double _worldWidth(double zoom) => 256 * math.pow(2, zoom).toDouble();
+
+MapCamera _camera({
+  required double zoom,
+  LatLng center = const LatLng(0, 0),
+  Size size = const Size(900, 240),
+}) =>
+    MapCamera(
+      crs: const AppMapCrs(),
+      center: center,
+      zoom: zoom,
+      rotation: 0,
+      nonRotatedSize: size,
+    );
+
+void main() {
+  group('appMapMinZoomFor', () {
+    test('never drops below the legacy floor of 1', () {
+      // At or below a 512px viewport, z1's 512px world already fills it.
+      for (final w in [1.0, 360.0, 400.0, 512.0]) {
+        expect(appMapMinZoomFor(w), 1, reason: 'width $w');
+      }
+    });
+
+    test('guards return the legacy floor for degenerate widths', () {
+      expect(appMapMinZoomFor(0), 1);
+      expect(appMapMinZoomFor(-100), 1);
+      expect(appMapMinZoomFor(double.infinity), 1);
+      expect(appMapMinZoomFor(double.nan), 1);
+    });
+
+    test('world at the floor always fills the viewport width', () {
+      for (final w in [513.0, 640.0, 868.0, 900.0, 1024.0, 1440.0, 2560.0]) {
+        final world = _worldWidth(appMapMinZoomFor(w));
+        expect(world, greaterThanOrEqualTo(w), reason: 'width $w');
+        // ...but only barely: the epsilon must not over-zoom the fit.
+        expect(world, lessThan(w * 1.02), reason: 'width $w');
+      }
+    });
+  });
+
+  group('AppMapCameraConstraint', () {
+    const constraint = AppMapCameraConstraint();
+
+    test('is identity on the pre-layout camera (impossible size)', () {
+      final camera =
+          _camera(zoom: 2).withNonRotatedSize(MapCamera.kImpossibleSize);
+      expect(identical(constraint.constrain(camera), camera), isTrue);
+    });
+
+    test(
+        'is identity (not null / frozen) when the world is narrower than '
+        'the viewport', () {
+      // z1 = 512px world inside a 900px viewport — below the minZoom floor,
+      // reachable only transiently. ContainCamera-style math would bail with
+      // null here, which freezes the map; we must hand the camera back.
+      final camera = _camera(zoom: 1);
+      expect(identical(constraint.constrain(camera), camera), isTrue);
+    });
+
+    test('clamps center latitude to ±85 like the old containCenter', () {
+      final constrained =
+          constraint.constrain(_camera(zoom: 5, center: const LatLng(89, 10)));
+      expect(constrained.center.latitude, 85);
+      expect(constrained.center.longitude, 10);
+    });
+
+    test('keeps the world edges outside the viewport at the zoom floor', () {
+      final zoom = appMapMinZoomFor(900);
+      final constrained = constraint
+          .constrain(_camera(zoom: zoom, center: const LatLng(0, 157)));
+      // Projection is linear in longitude, so the limit is exact: the center
+      // may sit at most half a viewport short of either world edge.
+      final maxLng = 180 * (1 - 900 / _worldWidth(zoom));
+      expect(constrained.center.longitude, closeTo(maxLng, 1e-9));
+
+      // And the visible edges confirm no background is exposed.
+      expect(
+        constrained.latLngToScreenOffset(const LatLng(0, -180)).dx,
+        lessThanOrEqualTo(0.5),
+      );
+      expect(
+        constrained.latLngToScreenOffset(const LatLng(0, 180)).dx,
+        greaterThanOrEqualTo(899.5),
+      );
+    });
+
+    test('allows wider centers once zoomed past the floor', () {
+      final zoom = appMapMinZoomFor(900) + 1;
+      final constrained = constraint
+          .constrain(_camera(zoom: zoom, center: const LatLng(0, 157)));
+      final maxLng = 180 * (1 - 900 / _worldWidth(zoom));
+      expect(maxLng, greaterThan(45)); // sanity: room to roam at z+1
+      expect(constrained.center.longitude, closeTo(maxLng, 1e-9));
+    });
+
+    test('is identity for an already-compliant camera', () {
+      final zoom = appMapMinZoomFor(900) + 1;
+      final camera = _camera(zoom: zoom, center: const LatLng(20, 30));
+      expect(identical(constraint.constrain(camera), camera), isTrue);
+    });
+  });
+}

--- a/src/packages/flutter-app/test/trip_map_test.dart
+++ b/src/packages/flutter-app/test/trip_map_test.dart
@@ -21,10 +21,16 @@ ItineraryItem _item(int pos, String name, double lat, double lng) =>
     );
 
 /// Hosts the map at a fixed size (FlutterMap needs bounded constraints).
-Widget _host(Widget child) => MaterialApp(
+Widget _host(Widget child) => _hostSized(child, const Size(400, 300));
+
+/// [_host] at an arbitrary size, for tests that need the wide map bands
+/// where the single world is narrower than the box at low zooms.
+Widget _hostSized(Widget child, Size size) => MaterialApp(
       localizationsDelegates: testLocalizationsDelegates,
       home: Scaffold(
-        body: Center(child: SizedBox(width: 400, height: 300, child: child)),
+        body: Center(
+          child: SizedBox(width: size.width, height: size.height, child: child),
+        ),
       ),
     );
 
@@ -483,5 +489,84 @@ void main() {
 
     expect(find.text('No mapped places'), findsNothing);
     expect(find.byIcon(Icons.hotel), findsOneWidget);
+  });
+
+  group('single world fills a wide map band (no background side bars)', () {
+    // Tokyo + Auckland: the auto-fit for this pair in a 900×240 band is
+    // height-limited to a zoom *below* the width floor, and its bounds center
+    // (~157°E) sits close enough to the antimeridian that even a
+    // floor-clamped camera would show background on the right without the
+    // longitude-containing constraint. Exercises both halves of the fix.
+    final wideItems = [
+      _item(0, 'Tokyo Tower', 35.6586, 139.7454),
+      _item(1, 'Sky Tower', -36.8485, 174.7622),
+    ];
+    const band = Size(900, 240);
+
+    /// No pixel of background may show beside the world: the west edge must
+    /// project at/left of x=0 and the east edge at/right of x=band.width.
+    void expectNoSideBars(WidgetTester tester) {
+      final camera = _camera(tester);
+      expect(
+        camera.latLngToScreenOffset(const LatLng(0, -180)).dx,
+        lessThanOrEqualTo(0.5),
+      );
+      expect(
+        camera.latLngToScreenOffset(const LatLng(0, 180)).dx,
+        greaterThanOrEqualTo(band.width - 0.5),
+      );
+    }
+
+    Future<void> pumpWideTrip(WidgetTester tester) async {
+      tester.view.physicalSize = const Size(1000, 800);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+      await tester.pumpWidget(
+        _hostSized(TripMap(items: wideItems), band),
+      );
+      await tester.pump();
+    }
+
+    testWidgets('auto-fit clamps to the width-aware zoom floor', (
+      WidgetTester tester,
+    ) async {
+      await pumpWideTrip(tester);
+
+      final camera = _camera(tester);
+      expect(camera.minZoom, appMapMinZoomFor(band.width));
+      expect(camera.zoom, greaterThanOrEqualTo(camera.minZoom!));
+      expectNoSideBars(tester);
+    });
+
+    testWidgets('zooming out cannot shrink the world below the box width', (
+      WidgetTester tester,
+    ) async {
+      await pumpWideTrip(tester);
+
+      await tester.tap(find.byIcon(Icons.remove));
+      await tester.pump();
+      await tester.tap(find.byIcon(Icons.remove));
+      await tester.pump();
+
+      expect(
+        _camera(tester).zoom,
+        greaterThanOrEqualTo(appMapMinZoomFor(band.width)),
+      );
+      expectNoSideBars(tester);
+    });
+
+    testWidgets('reset re-fits without reintroducing bars', (
+      WidgetTester tester,
+    ) async {
+      await pumpWideTrip(tester);
+
+      await tester.tap(find.byIcon(Icons.center_focus_strong));
+      await tester.pump();
+
+      final camera = _camera(tester);
+      expect(camera.zoom, greaterThanOrEqualTo(appMapMinZoomFor(band.width)));
+      expectNoSideBars(tester);
+    });
   });
 }


### PR DESCRIPTION
## Summary
- **Bug**: wide trips (e.g. Americas + Europe) showed black bars on both sides of the trip map — the single-world CRS (#196) paints the space-dark background past ±180°, and the static `minZoom: 1` floor (a 512px world) couldn't fill the ~870px map card once the height-limited camera fit clamped to it.
- `appMapMinZoomFor(width)`: width-aware zoom floor (`log2(width/256) + ε`) wired per-surface via `LayoutBuilder`, flooring the auto-fit, day-chip refits, reset, pinch, and zoom buttons. Widths ≤ 512 (all phone bands) keep the exact legacy behavior.
- `AppMapCameraConstraint` replaces `containCenter`: contains the world *edges* horizontally (fixes one-sided bars on off-meridian trips, e.g. Pacific-centered Tokyo+Auckland, and stops pans from dragging an edge into view) while still only center-clamping latitude at ±85 so short bands never freeze. Returns the camera unchanged (never null) below the floor.
- flutter_map adopts a changed `minZoom` but never re-clamps the live zoom, so `TripMap` and the guide map nudge the camera back over the floor post-frame on width changes.
- Known trade-off: at the floor in the 180/240px bands an extreme-latitude trip may need a pan to reach its outermost pins — beats black bars.

## Testing
- `flutter analyze` clean (3 pre-existing infos in `route_response.dart`).
- Full `flutter test` suite: 602 passing, including new `test/app_map_min_zoom_test.dart` (floor math + constraint unit tests against hand-built `MapCamera`s) and a new `trip_map_test.dart` group asserting, in a 900×240 band with Tokyo+Auckland pins: fit clamps to the floor, world edges project outside the viewport, zoom-out can't go below the floor, reset stays bar-free.
- Manual on the lane dev stack: seeded a Panama→Berlin trip; the map card fills edge-to-edge, zoom-out fully is pinned to card width, hard pans stop exactly at the world edges, reset re-fits cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)