### PR TITLE
fix(review): collapse per-day trip-health findings into date ranges

### DIFF
--- a/src/packages/api/i18n.go
+++ b/src/packages/api/i18n.go
@@ -266,6 +266,7 @@ var messages = map[string]map[string]string{
 
 	"review.confirmBooking":       {"en": "Confirm your booking for %s.", "es": "Confirma tu reserva de %s."},
 	"review.emptyDay":             {"en": "Day %d has nothing planned.", "es": "El día %d no tiene nada planificado."},
+	"review.emptyDayRange":        {"en": "Days %d–%d have nothing planned.", "es": "Los días %d–%d no tienen nada planificado."},
 	"review.fix.addBus":           {"en": "Add bus", "es": "Añadir autobús"},
 	"review.fix.addDrive":         {"en": "Add drive", "es": "Añadir trayecto en coche"},
 	"review.fix.addFerry":         {"en": "Add ferry", "es": "Añadir ferri"},
@@ -284,6 +285,7 @@ var messages = map[string]map[string]string{
 	"review.mayBeClosed":          {"en": "%s may be closed on %s (Day %d).", "es": "%s puede estar cerrado el %s (día %d)."},
 	"review.noDates":              {"en": "Add trip dates to unlock day-by-day checks.", "es": "Añade las fechas del viaje para desbloquear las comprobaciones día a día."},
 	"review.noLodging":            {"en": "No lodging booked for the night of %s.", "es": "No hay alojamiento reservado para la noche del %s."},
+	"review.noLodgingRange":       {"en": "No lodging booked for the nights of %s – %s (%d nights).", "es": "No hay alojamiento reservado para las noches del %s al %s (%d noches)."},
 	"review.noTransport":          {"en": "No transport booked from %s to %s.", "es": "No hay transporte reservado de %s a %s."},
 	"review.overBudget":           {"en": "Over budget by %.2f %s.", "es": "Te has pasado del presupuesto por %.2f %s."},
 	"review.packedDay":            {"en": "Day %d has %d items planned — that may be too packed.", "es": "El día %d tiene %d actividades planificadas — puede que sea demasiado."},

--- a/src/packages/api/trip_review.go
+++ b/src/packages/api/trip_review.go
@@ -220,13 +220,24 @@ func checkDensity(locale string, d exportData) []Finding {
 	}
 	var out []Finding
 	for day := minDay; day <= maxDay; day++ {
-		if len(buckets[day]) == 0 {
-			dd := day
-			out = append(out, Finding{
-				Severity: "info", Category: "packing", TripID: tripID, Day: &dd,
-				Message: tr(locale, "review.emptyDay", day),
-			})
+		if len(buckets[day]) != 0 {
+			continue
 		}
+		// Collapse a run of consecutive empty days into one finding anchored
+		// on the run's first day (that's where tap-to-scroll lands).
+		first := day
+		for day < maxDay && len(buckets[day+1]) == 0 {
+			day++
+		}
+		msg := tr(locale, "review.emptyDay", first)
+		if day > first {
+			msg = tr(locale, "review.emptyDayRange", first, day)
+		}
+		dd := first
+		out = append(out, Finding{
+			Severity: "info", Category: "packing", TripID: tripID, Day: &dd,
+			Message: msg,
+		})
 	}
 	for day := minDay; day <= maxDay; day++ {
 		items := buckets[day]
@@ -328,9 +339,12 @@ func lastItemInSlot(items []store.ItineraryItem, tod string) (string, bool) {
 }
 
 // checkLodging walks each night of a dated trip (start .. end-1, checkout-
-// exclusive) and flags any night no accommodation covers. Gated so an empty
-// draft isn't nagged: only runs when the trip is `planned` OR already has at
-// least one accommodation.
+// exclusive) and flags each run of consecutive uncovered nights as ONE
+// finding whose fix prefills the whole range. Runs split when the hub city
+// changes so every "add a stay" spans a single place; a night with no known
+// city never forces a split (the run adopts the first known city it sees).
+// Gated so an empty draft isn't nagged: only runs when the trip is `planned`
+// OR already has at least one accommodation.
 func checkLodging(locale string, d exportData) []Finding {
 	if !d.Trip.StartDate.Valid || !d.Trip.EndDate.Valid {
 		return nil
@@ -341,7 +355,12 @@ func checkLodging(locale string, d exportData) []Finding {
 	tripID := d.Trip.ID.String()
 	start := d.Trip.StartDate.Time
 	nights := nightsBetween(start, d.Trip.EndDate.Time)
-	var out []Finding
+	type nightRun struct {
+		firstN, lastN int // 0-based night indexes
+		city          *string
+	}
+	var runs []nightRun
+	var cur *nightRun
 	for n := 0; n < nights; n++ {
 		night := start.AddDate(0, 0, n)
 		covered := false
@@ -351,21 +370,49 @@ func checkLodging(locale string, d exportData) []Finding {
 				break
 			}
 		}
-		if !covered {
-			day := n + 1
-			checkIn := night.Format(dateLayout)
-			checkOut := night.AddDate(0, 0, 1).Format(dateLayout)
-			out = append(out, Finding{
-				Severity: "warn", Category: "lodging", TripID: tripID, Day: &day,
-				Message: tr(locale, "review.noLodging", localizedDate(locale, night, dateStyleWeekdayMonthDay)),
-				Fix: &FindingFix{
-					Action: "add_lodging", Label: tr(locale, "review.fix.addStay"),
-					City:     cityForDay(d.Items, day),
-					CheckIn:  &checkIn,
-					CheckOut: &checkOut,
-				},
-			})
+		if covered {
+			cur = nil
+			continue
 		}
+		city := cityForDay(d.Items, n+1)
+		switch {
+		case cur == nil:
+			runs = append(runs, nightRun{n, n, city})
+			cur = &runs[len(runs)-1]
+		case city == nil || cur.city == nil || strings.EqualFold(*city, *cur.city):
+			cur.lastN = n
+			if cur.city == nil {
+				cur.city = city
+			}
+		default: // a different known city starts a new per-place run
+			runs = append(runs, nightRun{n, n, city})
+			cur = &runs[len(runs)-1]
+		}
+	}
+	var out []Finding
+	for _, r := range runs {
+		day := r.firstN + 1
+		firstNight := start.AddDate(0, 0, r.firstN)
+		lastNight := start.AddDate(0, 0, r.lastN)
+		checkIn := firstNight.Format(dateLayout)
+		checkOut := lastNight.AddDate(0, 0, 1).Format(dateLayout)
+		msg := tr(locale, "review.noLodging", localizedDate(locale, firstNight, dateStyleWeekdayMonthDay))
+		if r.lastN > r.firstN {
+			msg = tr(locale, "review.noLodgingRange",
+				localizedDate(locale, firstNight, dateStyleWeekdayMonthDay),
+				localizedDate(locale, lastNight, dateStyleWeekdayMonthDay),
+				r.lastN-r.firstN+1)
+		}
+		out = append(out, Finding{
+			Severity: "warn", Category: "lodging", TripID: tripID, Day: &day,
+			Message: msg,
+			Fix: &FindingFix{
+				Action: "add_lodging", Label: tr(locale, "review.fix.addStay"),
+				City:     r.city,
+				CheckIn:  &checkIn,
+				CheckOut: &checkOut,
+			},
+		})
 	}
 	return out
 }

--- a/src/packages/api/trip_review_test.go
+++ b/src/packages/api/trip_review_test.go
@@ -79,8 +79,31 @@ func TestCheckDensity_EmptyAndPacked(t *testing.T) {
 	if len(cats["info"]) != 1 { // day 2 empty
 		t.Fatalf("expected one empty-day info, got %+v", fs)
 	}
+	if got := cats["info"][0].Message; got != "Day 2 has nothing planned." {
+		t.Fatalf("single empty day should keep the singular message, got %q", got)
+	}
 	if len(cats["warn"]) != 1 { // two mornings day 1
 		t.Fatalf("expected one over-packed warn, got %+v", fs)
+	}
+}
+
+func TestCheckDensity_EmptyDayRuns(t *testing.T) {
+	items := []store.ItineraryItem{
+		{ID: uuid.New(), Name: "A", Day: i32p(1)},
+		// days 2-4 empty
+		{ID: uuid.New(), Name: "B", Day: i32p(5)},
+		// day 6 empty
+		{ID: uuid.New(), Name: "C", Day: i32p(7)},
+	}
+	fs := checkDensity("en", exportData{Trip: store.Trip{ID: uuid.New()}, Items: items})
+	if len(fs) != 2 {
+		t.Fatalf("expected two empty-day findings (one per run), got %+v", fs)
+	}
+	if fs[0].Day == nil || *fs[0].Day != 2 || fs[0].Message != "Days 2–4 have nothing planned." {
+		t.Fatalf("multi-day run = %+v", fs[0])
+	}
+	if fs[1].Day == nil || *fs[1].Day != 6 || fs[1].Message != "Day 6 has nothing planned." {
+		t.Fatalf("single-day run = %+v", fs[1])
 	}
 }
 
@@ -88,10 +111,19 @@ func TestCheckLodging_GateAndCoverage(t *testing.T) {
 	trip := store.Trip{ID: uuid.New(), Status: "planned",
 		StartDate: dateVal(t, "2026-08-01"), EndDate: dateVal(t, "2026-08-04")} // 3 nights: 1,2,3
 
-	// No accommodations, planned → all 3 nights flagged.
+	// No accommodations, planned → one finding covering the whole 3-night run.
 	fs := checkLodging("en", exportData{Trip: trip})
-	if len(fs) != 3 {
-		t.Fatalf("planned no-lodging = %d findings, want 3: %+v", len(fs), fs)
+	if len(fs) != 1 {
+		t.Fatalf("planned no-lodging = %d findings, want 1 grouped run: %+v", len(fs), fs)
+	}
+	if fs[0].Day == nil || *fs[0].Day != 1 {
+		t.Fatalf("grouped run should anchor on Day 1, got %+v", fs[0])
+	}
+	if !strings.Contains(fs[0].Message, "Sat, Aug 1 – Mon, Aug 3 (3 nights)") {
+		t.Fatalf("grouped message = %q", fs[0].Message)
+	}
+	if fix := fs[0].Fix; fix == nil || *fix.CheckIn != "2026-08-01" || *fix.CheckOut != "2026-08-04" {
+		t.Fatalf("grouped fix should span the run, got %+v", fs[0].Fix)
 	}
 
 	// One stay covering nights 1-2 (checkout 08-03, exclusive) → only night 3 flagged.
@@ -101,12 +133,75 @@ func TestCheckLodging_GateAndCoverage(t *testing.T) {
 	if len(fs) != 1 || fs[0].Day == nil || *fs[0].Day != 3 {
 		t.Fatalf("partial lodging = %+v", fs)
 	}
+	if !strings.Contains(fs[0].Message, "the night of") {
+		t.Fatalf("single-night run should keep the singular message, got %q", fs[0].Message)
+	}
 
 	// Empty draft (draft status, no accommodations) is not nagged.
 	draft := trip
 	draft.Status = "draft"
 	if fs := checkLodging("en", exportData{Trip: draft}); len(fs) != 0 {
 		t.Fatalf("empty draft should be silent, got %+v", fs)
+	}
+}
+
+func TestCheckLodging_GroupsRuns(t *testing.T) {
+	// gap–covered–gap: 5 nights, a stay covers only night 3 → two range runs.
+	trip := store.Trip{ID: uuid.New(), Status: "planned",
+		StartDate: dateVal(t, "2026-08-01"), EndDate: dateVal(t, "2026-08-06")} // nights 1-5
+	acc := []store.Accommodation{{ID: uuid.New(), Name: "Hotel",
+		CheckIn: dateVal(t, "2026-08-03"), CheckOut: dateVal(t, "2026-08-04")}} // covers night 3
+	fs := checkLodging("en", exportData{Trip: trip, Accommodations: acc})
+	if len(fs) != 2 {
+		t.Fatalf("gap-covered-gap = %d findings, want 2: %+v", len(fs), fs)
+	}
+	if *fs[0].Day != 1 || *fs[0].Fix.CheckIn != "2026-08-01" || *fs[0].Fix.CheckOut != "2026-08-03" {
+		t.Fatalf("first run = day %d fix %+v", *fs[0].Day, fs[0].Fix)
+	}
+	if *fs[1].Day != 4 || *fs[1].Fix.CheckIn != "2026-08-04" || *fs[1].Fix.CheckOut != "2026-08-06" {
+		t.Fatalf("second run = day %d fix %+v", *fs[1].Day, fs[1].Fix)
+	}
+
+	// A city change splits the run so each fix prefills a single place.
+	twoCity := store.Trip{ID: uuid.New(), Status: "planned",
+		StartDate: dateVal(t, "2026-08-01"), EndDate: dateVal(t, "2026-08-05")} // nights 1-4
+	items := []store.ItineraryItem{
+		{ID: uuid.New(), Name: "Colosseum", City: strp("Rome"), Day: i32p(1)},
+		{ID: uuid.New(), Name: "Forum", City: strp("Rome"), Day: i32p(2)},
+		{ID: uuid.New(), Name: "Duomo", City: strp("Florence"), Day: i32p(3)},
+		{ID: uuid.New(), Name: "Uffizi", City: strp("Florence"), Day: i32p(4)},
+	}
+	fs = checkLodging("en", exportData{Trip: twoCity, Items: items})
+	if len(fs) != 2 {
+		t.Fatalf("city split = %d findings, want 2: %+v", len(fs), fs)
+	}
+	if *fs[0].Fix.City != "Rome" || *fs[0].Fix.CheckIn != "2026-08-01" || *fs[0].Fix.CheckOut != "2026-08-03" {
+		t.Fatalf("Rome run fix = %+v", fs[0].Fix)
+	}
+	if *fs[1].Fix.City != "Florence" || *fs[1].Fix.CheckIn != "2026-08-03" || *fs[1].Fix.CheckOut != "2026-08-05" {
+		t.Fatalf("Florence run fix = %+v", fs[1].Fix)
+	}
+
+	// Unknown-city nights never split a run; the run adopts the first known city.
+	adopt := store.Trip{ID: uuid.New(), Status: "planned",
+		StartDate: dateVal(t, "2026-08-01"), EndDate: dateVal(t, "2026-08-04")} // nights 1-3
+	fs = checkLodging("en", exportData{Trip: adopt, Items: []store.ItineraryItem{
+		{ID: uuid.New(), Name: "Vatican", City: strp("Rome"), Day: i32p(2)}, // days 1 and 3 have no items
+	}})
+	if len(fs) != 1 || fs[0].Fix.City == nil || *fs[0].Fix.City != "Rome" {
+		t.Fatalf("nil-city adoption = %+v", fs)
+	}
+}
+
+func TestCheckLodging_RangeSpanish(t *testing.T) {
+	trip := store.Trip{ID: uuid.New(), Status: "planned",
+		StartDate: dateVal(t, "2026-08-01"), EndDate: dateVal(t, "2026-08-04")} // 3 nights
+	fs := checkLodging("es", exportData{Trip: trip})
+	if len(fs) != 1 {
+		t.Fatalf("es grouped run = %+v", fs)
+	}
+	if !strings.Contains(fs[0].Message, " al ") || !strings.Contains(fs[0].Message, "(3 noches)") {
+		t.Fatalf("es range message = %q", fs[0].Message)
 	}
 }
 
@@ -392,6 +487,22 @@ func TestFix_Lodging(t *testing.T) {
 	}
 	if fix.City == nil || *fix.City != "Nice" {
 		t.Fatalf("expected city Nice from the night's items, got %v", fix.City)
+	}
+}
+
+func TestFix_LodgingRange(t *testing.T) {
+	trip := store.Trip{ID: uuid.New(), Status: "planned",
+		StartDate: dateVal(t, "2026-08-01"), EndDate: dateVal(t, "2026-08-05")} // nights 1-4
+	fs := checkLodging("en", exportData{Trip: trip})
+	if len(fs) != 1 || fs[0].Fix == nil {
+		t.Fatalf("expected one grouped lodging finding with a fix, got %+v", fs)
+	}
+	fix := fs[0].Fix
+	// The fix spans the whole run: check_out = check_in + (nights × 24h).
+	ci, _ := time.Parse(dateLayout, *fix.CheckIn)
+	co, _ := time.Parse(dateLayout, *fix.CheckOut)
+	if co.Sub(ci) != 4*24*time.Hour {
+		t.Fatalf("fix span = %v, want 4 nights", co.Sub(ci))
 	}
 }
 


### PR DESCRIPTION
## Summary
- **Lodging gaps**: `checkLodging` now groups consecutive uncovered nights into one warning per run — "No lodging booked for the nights of Tue, Sep 15 – Sun, Sep 20 (6 nights)." — instead of one row per night. Runs split when the hub city changes so each "Add a stay" prefills a single-city check-in/check-out spanning the whole gap; unknown-city nights never force a split (the run adopts the first known city).
- **Empty days**: `checkDensity` collapses consecutive "Day N has nothing planned." infos into "Days X–Y have nothing planned.", anchored on the run's first day so tap-to-scroll lands at the range start.
- Single-night/-day runs keep the existing singular messages; two new i18n keys (`review.noLodgingRange`, `review.emptyDayRange`, en+es) cover the ranges.
- Server-side only: Flutter renders `finding.message` verbatim and the wider `check_in`/`check_out` flow through the existing `AddStaySheet` prefill and the agent's `[fix:]` tail unchanged.

## Testing
- `make api-fmt` / `make api-vet` clean; full `go test ./...` green.
- Updated `TestCheckLodging_GateAndCoverage` (3-night gap → 1 grouped finding with range message + spanning fix); new `TestCheckLodging_GroupsRuns` (gap–covered–gap, city split with abutting check-in/out, nil-city adoption), `TestFix_LodgingRange` (fix spans nights × 24h), `TestCheckLodging_RangeSpanish`, `TestCheckDensity_EmptyDayRuns`.
- Flutter untouched; `flutter test test/trip_review_section_test.dart test/trip_detail_fix_actions_test.dart` → 17/17 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)