### PR TITLE
fix(flutter): make chat transcript text selectable for copy/paste

### DIFF
--- a/src/packages/flutter-app/lib/theme/app_theme.dart
+++ b/src/packages/flutter-app/lib/theme/app_theme.dart
@@ -34,6 +34,12 @@ abstract final class AppTheme {
 
     return base.copyWith(
       textTheme: textTheme,
+      // Chat transcripts sit inside a SelectionArea; gpt_markdown's
+      // SelectableAdapter force-unwraps DefaultSelectionStyle.selectionColor,
+      // so keep this explicitly set rather than relying on Material's default.
+      textSelectionTheme: TextSelectionThemeData(
+        selectionColor: colorScheme.primary.withValues(alpha: 0.3),
+      ),
       appBarTheme: const AppBarTheme(
         centerTitle: true,
         elevation: 2,

--- a/src/packages/flutter-app/lib/widgets/chat_panel.dart
+++ b/src/packages/flutter-app/lib/widgets/chat_panel.dart
@@ -308,41 +308,46 @@ class _ChatPanelState extends ConsumerState<ChatPanel> {
           Expanded(
             child: isEmpty
                 ? (widget.emptyState ?? const SizedBox.shrink())
-                : NotificationListener<ScrollNotification>(
-                    onNotification: _onScrollNotification,
-                    child: ListView.builder(
-                      controller: _scrollController,
-                      padding: const EdgeInsets.symmetric(
-                          horizontal: AppSpacing.lg, vertical: AppSpacing.md),
-                      itemCount: messages.length + 1,
-                      itemBuilder: (context, i) {
-                        if (i < messages.length) {
-                          final msg = messages[i];
-                          // Labeled messages (e.g. the machine-built refine
-                          // seed) collapse to a context chip; the full content
-                          // still went to the server history.
-                          if (msg.displayLabel != null) {
-                            return _SeedContextChip(
+                // SelectionArea wraps only the message list: the composer's
+                // TextField below has native selection and must keep its own
+                // gesture handling.
+                : SelectionArea(
+                    child: NotificationListener<ScrollNotification>(
+                      onNotification: _onScrollNotification,
+                      child: ListView.builder(
+                        controller: _scrollController,
+                        padding: const EdgeInsets.symmetric(
+                            horizontal: AppSpacing.lg, vertical: AppSpacing.md),
+                        itemCount: messages.length + 1,
+                        itemBuilder: (context, i) {
+                          if (i < messages.length) {
+                            final msg = messages[i];
+                            // Labeled messages (e.g. the machine-built refine
+                            // seed) collapse to a context chip; the full content
+                            // still went to the server history.
+                            if (msg.displayLabel != null) {
+                              return _SeedContextChip(
+                                key: ValueKey('msg-$i'),
+                                label: msg.displayLabel!,
+                              );
+                            }
+                            // Append-only list, so index keys are stable.
+                            return ChatMessageBubble(
                               key: ValueKey('msg-$i'),
-                              label: msg.displayLabel!,
+                              message: msg,
+                              maxWidth: bubbleMaxWidth,
                             );
                           }
-                          // Append-only list, so index keys are stable.
-                          return ChatMessageBubble(
-                            key: ValueKey('msg-$i'),
-                            message: msg,
-                            maxWidth: bubbleMaxWidth,
+                          return _ChatTail(
+                            key: const ValueKey('chat-tail'),
+                            state: widget.state,
+                            notifier: widget.notifier,
+                            footerBuilder: widget.footerBuilder,
+                            onViewTrip: widget.onViewTrip,
+                            bubbleMaxWidth: bubbleMaxWidth,
                           );
-                        }
-                        return _ChatTail(
-                          key: const ValueKey('chat-tail'),
-                          state: widget.state,
-                          notifier: widget.notifier,
-                          footerBuilder: widget.footerBuilder,
-                          onViewTrip: widget.onViewTrip,
-                          bubbleMaxWidth: bubbleMaxWidth,
-                        );
-                      },
+                        },
+                      ),
                     ),
                   ),
           ),

--- a/src/packages/flutter-app/test/chat_panel_selection_test.dart
+++ b/src/packages/flutter-app/test/chat_panel_selection_test.dart
@@ -1,0 +1,174 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:gpt_markdown/gpt_markdown.dart';
+
+import 'package:travel_route_planner/models/agent_place.dart';
+import 'package:travel_route_planner/models/plan_message.dart';
+import 'package:travel_route_planner/providers/plan_provider.dart';
+import 'package:travel_route_planner/services/api_client.dart';
+import 'package:travel_route_planner/services/plan_service.dart';
+import 'package:travel_route_planner/widgets/chat_panel.dart';
+import 'package:travel_route_planner/widgets/place_photo_card.dart';
+
+import 'support/l10n_test_app.dart';
+
+/// Chat transcripts are wrapped in a SelectionArea so text can be highlighted
+/// and copied (friction-log item: nothing in a conversation was copyable).
+/// The composer's TextField stays OUTSIDE the wrap — it has native selection
+/// and nesting it would double-handle gestures.
+
+class _SeededPlanNotifier extends PlanNotifier {
+  _SeededPlanNotifier(PlanState seeded)
+      : super(PlanService('http://unused'), ApiClient()) {
+    state = seeded;
+  }
+}
+
+Future<void> _pumpSeededChat(WidgetTester tester, PlanState seeded) async {
+  tester.view.physicalSize = const Size(1200, 900);
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.resetPhysicalSize);
+  addTearDown(tester.view.resetDevicePixelRatio);
+
+  final provider = StateNotifierProvider<PlanNotifier, PlanState>(
+      (ref) => _SeededPlanNotifier(seeded));
+  await tester.pumpWidget(
+    ProviderScope(
+      child: localizedTestApp(
+        home: Scaffold(
+          body: ChatPanel(state: provider, notifier: provider.notifier),
+        ),
+      ),
+    ),
+  );
+}
+
+void main() {
+  testWidgets('message bubbles sit inside a SelectionArea',
+      (WidgetTester tester) async {
+    await _pumpSeededChat(
+      tester,
+      PlanState(messages: [
+        PlanMessage(role: MessageRole.user, content: 'hello'),
+        PlanMessage(role: MessageRole.assistant, content: 'world'),
+      ]),
+    );
+
+    expect(
+      find.ancestor(
+        of: find.byType(ChatMessageBubble),
+        matching: find.byType(SelectionArea),
+      ),
+      findsNWidgets(2),
+    );
+  });
+
+  testWidgets('the composer TextField stays outside the SelectionArea',
+      (WidgetTester tester) async {
+    await _pumpSeededChat(
+      tester,
+      PlanState(messages: [
+        PlanMessage(role: MessageRole.assistant, content: 'world'),
+      ]),
+    );
+
+    expect(
+      find.ancestor(
+        of: find.byType(TextField),
+        matching: find.byType(SelectionArea),
+      ),
+      findsNothing,
+    );
+  });
+
+  testWidgets('drag-selecting an assistant reply and pressing Ctrl+C copies it',
+      (WidgetTester tester) async {
+    String? copied;
+    tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+      SystemChannels.platform,
+      (MethodCall call) async {
+        if (call.method == 'Clipboard.setData') {
+          copied = (call.arguments as Map)['text'] as String;
+        }
+        return null;
+      },
+    );
+    addTearDown(() => tester.binding.defaultBinaryMessenger
+        .setMockMethodCallHandler(SystemChannels.platform, null));
+
+    await _pumpSeededChat(
+      tester,
+      PlanState(messages: [
+        PlanMessage(
+            role: MessageRole.assistant,
+            content: 'Lisbon is lovely in October.'),
+      ]),
+    );
+
+    // Mouse drag across the rendered markdown, like a user highlighting it.
+    final markdown = find.byType(GptMarkdown);
+    final gesture = await tester.startGesture(
+      tester.getTopLeft(markdown) + const Offset(2, 8),
+      kind: PointerDeviceKind.mouse,
+    );
+    await tester.pump();
+    await gesture.moveTo(tester.getBottomRight(markdown) - const Offset(2, 8));
+    await tester.pump();
+    await gesture.up();
+    await tester.pump();
+
+    await tester.sendKeyDownEvent(LogicalKeyboardKey.controlLeft);
+    await tester.sendKeyDownEvent(LogicalKeyboardKey.keyC);
+    await tester.sendKeyUpEvent(LogicalKeyboardKey.keyC);
+    await tester.sendKeyUpEvent(LogicalKeyboardKey.controlLeft);
+    await tester.pump();
+
+    expect(copied, contains('Lisbon'));
+  });
+
+  testWidgets('photo rails still drag-scroll with a mouse inside the wrap',
+      (WidgetTester tester) async {
+    const place = AgentPlace(
+      name: 'Bar El Comercio',
+      placeId: 'p1',
+      address: 'Calle Lineros 9',
+      lat: 37.39,
+      lng: -5.99,
+      rating: 4.5,
+      priceLevel: 2,
+      category: 'restaurant',
+    );
+    await _pumpSeededChat(
+      tester,
+      PlanState(
+        messages: [
+          PlanMessage(role: MessageRole.user, content: 'where should I eat?'),
+        ],
+        places: const [
+          place, place, place, place, place, place, place, place, //
+        ],
+        placesQuery: 'tapas in seville',
+      ),
+    );
+    await tester.pump();
+
+    final rail = find.descendant(
+      of: find.byType(PlacePhotoStrip),
+      matching: find.byType(Scrollable),
+    );
+    expect(rail, findsOneWidget);
+    final position = tester.state<ScrollableState>(rail).position;
+    expect(position.pixels, 0);
+
+    // A horizontal mouse drag over the rail must win the gesture arena
+    // against the SelectionArea's selection drag.
+    await tester.drag(rail, const Offset(-150, 0),
+        kind: PointerDeviceKind.mouse);
+    await tester.pump();
+
+    expect(position.pixels, greaterThan(0));
+  });
+}


### PR DESCRIPTION
## Summary
Friction-log item: chat text couldn't be highlighted with the cursor to copy/paste. Flutter web renders text to canvas, and nothing in the app enabled selection.

- Wrap the `ChatPanel` message list (only the list — the composer `TextField` keeps its native selection) in a `SelectionArea`. This covers both hosts: the Plan tab and the trip-detail refine dock/sheet.
- `gpt_markdown` renders prose via `Text.rich`, so assistant markdown participates in the selection automatically.
- Set `textSelectionTheme.selectionColor` (teal @ 30%) explicitly — `gpt_markdown`'s `SelectableAdapter` force-unwraps `DefaultSelectionStyle.selectionColor`.

Known, accepted limits: an in-progress selection inside the *streaming* bubble collapses as tokens arrive (committed messages are fine), and selection doesn't extend into unbuilt off-screen list items.

## Testing
- New `chat_panel_selection_test.dart`: wrap structure (bubbles inside / composer outside), mouse drag-select + Ctrl+C lands the bubble text on the clipboard, and the horizontal photo rail still wins the gesture arena for mouse drags.
- Full `flutter test` suite green (608), `flutter analyze --no-fatal-infos --fatal-warnings` clean.
- Verified in a real browser against the dev stack: drag-selecting an assistant reply shows the teal highlight across the whole markdown bubble; composer still types/sends normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)