### PR TITLE
feat(chat): stop button to cancel the in-flight assistant reply

### DIFF
--- a/src/packages/api/ai_health_integration_test.go
+++ b/src/packages/api/ai_health_integration_test.go
@@ -1,7 +1,10 @@
 package main
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
@@ -102,5 +105,47 @@ func TestPlanTransientFailureDoesNotDegrade(t *testing.T) {
 	s := aiHealth.state()
 	if s.Failing || s.FatalTotal != 0 || s.TransientTotal == 0 {
 		t.Fatalf("tracker after transient = %+v", s)
+	}
+}
+
+// A client abort mid-stream (the stop button, a closed tab) is a deliberate
+// teardown, not an AI failure: no health record, no error SSE. Without the
+// canceled-guard in the stream-error path every user stop would bump
+// ai_transient_total and tee an ERROR to Sentry.
+func TestPlanClientAbortRecordsNoAIFailure(t *testing.T) {
+	resetAIHealth(t)
+	stalled := make(chan struct{})
+	newFakeAnthropic(t, stallTurn("Half an answer that gets cut", stalled))
+
+	body, err := json.Marshal(PlanRequest{Messages: []PlanChatMessage{
+		{Role: "user", Content: "plan me a weekend in Athens"},
+	}})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/v1/plan", bytes.NewReader(body)).WithContext(ctx)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		planHandler(rec, req)
+	}()
+
+	// The fake is mid-stream with deltas on the wire — abort like a client.
+	<-stalled
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("planHandler did not return after client abort")
+	}
+
+	if out := rec.Body.String(); strings.Contains(out, `"type":"error"`) {
+		t.Fatalf("stream = %q, want no error event on client abort", out)
+	}
+	if s := aiHealth.state(); s.Failing || s.FatalTotal != 0 || s.TransientTotal != 0 {
+		t.Fatalf("tracker after client abort = %+v, want untouched", s)
 	}
 }

--- a/src/packages/api/fake_anthropic_test.go
+++ b/src/packages/api/fake_anthropic_test.go
@@ -44,13 +44,14 @@ import (
 
 // fakeTurn is one scripted assistant turn for a streaming call.
 type fakeTurn struct {
-	kind       string // "text" | "tool" | "textThenTool" | "error" | "httpError"
+	kind       string // "text" | "tool" | "textThenTool" | "error" | "httpError" | "stall"
 	httpStatus int    // httpError only
 	errType    string // httpError only, e.g. "invalid_request_error"
 	text       string
 	toolName   string
 	toolInput  string // raw JSON object
 	errMsg     string
+	stalled    chan struct{} // stall only: closed once the deltas are on the wire
 }
 
 // textTurn streams the given text (split across multiple text_delta frames)
@@ -74,6 +75,14 @@ func textThenToolTurn(text, name, inputJSON string) fakeTurn {
 // an SSE `error` event (the shape a real overloaded_error takes on the wire),
 // so stream.Err() fires client-side.
 func errorTurn(message string) fakeTurn { return fakeTurn{kind: "error", errMsg: message} }
+
+// stallTurn streams the leading text, closes [stalled], then parks until the
+// caller's request context dies — the wire shape of a user abort (stop
+// button / closed tab) landing mid-generation. The SDK surfaces the teardown
+// as context.Canceled from stream.Err().
+func stallTurn(text string, stalled chan struct{}) fakeTurn {
+	return fakeTurn{kind: "stall", text: text, stalled: stalled}
+}
 
 // httpErrorTurn answers the streaming call with a non-2xx status and an
 // Anthropic error JSON body before any SSE frames — the shape the real
@@ -206,7 +215,7 @@ func (f *fakeAnthropic) handle(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "unscripted turn", http.StatusInternalServerError)
 		return
 	}
-	f.streamTurn(w, idx, turns[idx])
+	f.streamTurn(w, r, idx, turns[idx])
 }
 
 // contentHasToolResult reports whether a message's content array carries a
@@ -236,7 +245,7 @@ func (f *fakeAnthropic) sseFrame(w http.ResponseWriter, event string, data any) 
 	io.WriteString(w, "event: "+event+"\ndata: "+string(b)+"\n\n")
 }
 
-func (f *fakeAnthropic) streamTurn(w http.ResponseWriter, idx int, turn fakeTurn) {
+func (f *fakeAnthropic) streamTurn(w http.ResponseWriter, r *http.Request, idx int, turn fakeTurn) {
 	// A pre-stream HTTP failure never opens the SSE stream: status + error
 	// body only, exactly like the real credit-balance 400.
 	if turn.kind == "httpError" {
@@ -313,6 +322,23 @@ func (f *fakeAnthropic) streamTurn(w http.ResponseWriter, idx int, turn fakeTurn
 			blockDelta(1, map[string]any{"type": "input_json_delta", "partial_json": chunk})
 		}
 		lastBlock = 1
+
+	case "stall":
+		f.sseFrame(w, "content_block_start", map[string]any{
+			"type": "content_block_start", "index": 0,
+			"content_block": map[string]any{"type": "text", "text": ""},
+		})
+		for _, chunk := range splitForStreaming(turn.text) {
+			blockDelta(0, map[string]any{"type": "text_delta", "text": chunk})
+		}
+		if fl, ok := w.(http.Flusher); ok {
+			fl.Flush()
+		}
+		if turn.stalled != nil {
+			close(turn.stalled)
+		}
+		<-r.Context().Done()
+		return
 
 	case "error":
 		// Start a real answer, then die mid-turn: the client sees the leading

--- a/src/packages/api/plan_compactor.go
+++ b/src/packages/api/plan_compactor.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -95,8 +96,11 @@ func summarizePlanConversation(ctx context.Context, client anthropic.Client, pre
 		},
 	})
 	// Health record at the SDK call only — later shape/parse problems are our
-	// bugs, not provider health (ai_health.go).
-	recordAIResult(err)
+	// bugs, not provider health (ai_health.go). Skip when the caller canceled
+	// (stop button mid-compaction): a deliberate teardown is not an AI result.
+	if !errors.Is(ctx.Err(), context.Canceled) {
+		recordAIResult(err)
+	}
 	if err != nil {
 		return "", err
 	}

--- a/src/packages/api/plan_handler.go
+++ b/src/packages/api/plan_handler.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
@@ -481,6 +482,14 @@ func planHandler(w http.ResponseWriter, r *http.Request) {
 		}
 		streamErr := stream.Err()
 		cancelCall() // the deadline only needs to cover the streaming call above
+		// Client went away (stop button / closed tab): the model call was torn
+		// down on purpose — not an AI failure. No health record, no ERROR log
+		// (Sentry tee), no SSE to a dead socket. Canceled-only, on the request
+		// ctx: planModelCallTimeout and planMaxDuration expiries surface as
+		// DeadlineExceeded (here or on callCtx) and keep recording as before.
+		if errors.Is(ctx.Err(), context.Canceled) {
+			return
+		}
 		// Exactly one health record per model call (ai_health.go); nil records
 		// a success, so the first good call after an outage flips recovery.
 		aiClass, aiReason := recordAIResult(streamErr)

--- a/src/packages/flutter-app/lib/l10n/app_en.arb
+++ b/src/packages/flutter-app/lib/l10n/app_en.arb
@@ -1537,6 +1537,7 @@
   "chatInputHint": "Describe your trip...",
   "chatFollowUpHint": "Ask a follow-up…",
   "chatSend": "Send",
+  "chatStopGenerating": "Stop generating",
   "chatAttachImages": "Attach images",
   "chatStopDictating": "Stop dictating",
   "chatDictate": "Dictate",

--- a/src/packages/flutter-app/lib/l10n/app_es.arb
+++ b/src/packages/flutter-app/lib/l10n/app_es.arb
@@ -672,6 +672,7 @@
   "chatInputHint": "Describe tu viaje...",
   "chatFollowUpHint": "Haz una pregunta de seguimiento…",
   "chatSend": "Enviar",
+  "chatStopGenerating": "Detener la generación",
   "chatAttachImages": "Adjuntar imágenes",
   "chatStopDictating": "Dejar de dictar",
   "chatDictate": "Dictar",

--- a/src/packages/flutter-app/lib/l10n/app_localizations.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations.dart
@@ -4130,6 +4130,12 @@ abstract class AppLocalizations {
   /// **'Send'**
   String get chatSend;
 
+  /// No description provided for @chatStopGenerating.
+  ///
+  /// In en, this message translates to:
+  /// **'Stop generating'**
+  String get chatStopGenerating;
+
   /// No description provided for @chatAttachImages.
   ///
   /// In en, this message translates to:

--- a/src/packages/flutter-app/lib/l10n/app_localizations_en.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations_en.dart
@@ -2335,6 +2335,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get chatSend => 'Send';
 
   @override
+  String get chatStopGenerating => 'Stop generating';
+
+  @override
   String get chatAttachImages => 'Attach images';
 
   @override

--- a/src/packages/flutter-app/lib/l10n/app_localizations_es.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations_es.dart
@@ -2350,6 +2350,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get chatSend => 'Enviar';
 
   @override
+  String get chatStopGenerating => 'Detener la generación';
+
+  @override
   String get chatAttachImages => 'Adjuntar imágenes';
 
   @override

--- a/src/packages/flutter-app/lib/providers/plan_provider.dart
+++ b/src/packages/flutter-app/lib/providers/plan_provider.dart
@@ -246,6 +246,19 @@ class PlanNotifier extends StateNotifier<PlanState> {
   Timer? _streamFlushTimer;
   StringBuffer? _streamBuffer;
 
+  // Completes when the in-flight turn is deliberately torn down (stop button,
+  // Start over, dispose). PlanService feeds it to AbortableRequest, which
+  // aborts the transport immediately — even while the socket is idle during a
+  // server-side tool call — so the server's request context cancels and
+  // generation stops instead of streaming to a dead client.
+  Completer<void>? _abortCurrent;
+
+  void _abortInFlight() {
+    final abort = _abortCurrent;
+    _abortCurrent = null;
+    if (abort != null && !abort.isCompleted) abort.complete();
+  }
+
   void _scheduleStreamFlush() {
     _streamFlushTimer ??= Timer(_streamFlushInterval, _flushStreamText);
   }
@@ -269,6 +282,7 @@ class PlanNotifier extends StateNotifier<PlanState> {
   @override
   void dispose() {
     // Refine-panel family instances can be disposed mid-stream.
+    _abortInFlight();
     _endStreamBuffer();
     super.dispose();
   }
@@ -325,6 +339,8 @@ class PlanNotifier extends StateNotifier<PlanState> {
   Future<void> _sendNow(String text,
       {String? displayLabel, List<PlanAttachment> attachments = const []}) async {
     final turn = ++_turn;
+    final abort = Completer<void>();
+    _abortCurrent = abort;
     _chatId ??= _newChatId();
 
     final userMessage = PlanMessage(
@@ -399,7 +415,8 @@ class PlanNotifier extends StateNotifier<PlanState> {
           bearerToken: _apiClient.authToken,
           chatId: _chatId,
           tripId: tripId,
-          summary: state.compactedSummary)) {
+          summary: state.compactedSummary,
+          abortTrigger: abort.future)) {
         // Superseded by reset()/Start over: stop consuming and touch nothing
         // — the successor turn owns the state and the stream buffer now.
         if (turn != _turn) return;
@@ -683,9 +700,42 @@ class PlanNotifier extends StateNotifier<PlanState> {
         displayLabel: failed.displayLabel, attachments: failed.attachments);
   }
 
+  /// Stops the in-flight turn: commits whatever the model already streamed as
+  /// a normal assistant message (matching what the server persists — its
+  /// deferred transcript upsert survives the abort) and aborts the transport.
+  void stopStreaming() {
+    if (!state.isStreaming) return; // idle / double-tap: no-op
+    // Supersede FIRST: the abort surfaces in _sendNow as a stream teardown,
+    // and the turn guards must make it a no-op — never a second commit or an
+    // error banner.
+    _turn++;
+    // Read before _endStreamBuffer nulls the buffer; using the buffer (not
+    // state.streamingText) captures the un-flushed 48ms coalescing tail,
+    // exactly like the error-path commit.
+    final partial = _streamBuffer?.toString() ?? '';
+    _endStreamBuffer();
+    state = state.copyWith(
+      isStreaming: false,
+      streamingText: null,
+      activeTools: [],
+      isCompacting: false,
+      suggestedReplies: [],
+      messages: partial.isEmpty
+          ? state.messages
+          : [
+              ...state.messages,
+              PlanMessage(role: MessageRole.assistant, content: partial),
+            ],
+    );
+    // Queue stays put (same as post-error): stopping is not "success", and
+    // auto-draining would immediately start a turn the user just killed.
+    _abortInFlight();
+  }
+
   void reset() {
     _turn++; // any in-flight stream loop self-terminates without touching state
     _chatId = null;
+    _abortInFlight(); // kill the socket too, or the server keeps generating
     _endStreamBuffer();
     state = const PlanState();
   }

--- a/src/packages/flutter-app/lib/services/plan_service.dart
+++ b/src/packages/flutter-app/lib/services/plan_service.dart
@@ -26,8 +26,14 @@ class PlanService {
     String? chatId,
     String? tripId,
     String? summary,
+    Future<void>? abortTrigger,
   }) async* {
-    final request = http.Request('POST', Uri.parse('$baseUrl/plan'));
+    // AbortableRequest tears down the transport the moment [abortTrigger]
+    // completes — even while the socket is idle mid-tool-call. Cancelling the
+    // consumer's subscription alone would only take effect at the next SSE
+    // frame, leaving the server generating for a dead client.
+    final request = http.AbortableRequest('POST', Uri.parse('$baseUrl/plan'),
+        abortTrigger: abortTrigger);
     request.headers['Content-Type'] = 'application/json';
     if (bearerToken != null) {
       request.headers['Authorization'] = 'Bearer $bearerToken';
@@ -87,6 +93,11 @@ class PlanService {
           }
         }
       }
+    } on http.RequestAbortedException {
+      // Deliberate teardown (stop button, reset, dispose) — end the stream
+      // with no synthetic error event; the provider superseded this turn
+      // before firing the trigger, so nothing downstream is listening.
+      return;
     } finally {
       client.close();
     }

--- a/src/packages/flutter-app/lib/widgets/chat_panel.dart
+++ b/src/packages/flutter-app/lib/widgets/chat_panel.dart
@@ -363,6 +363,8 @@ class _ChatPanelState extends ConsumerState<ChatPanel> {
             isStreaming: isStreaming,
             hint: widget.inputHint ?? context.l10n.chatInputHint,
             onSend: _send,
+            onStop: () => ref.read(widget.notifier).stopStreaming(),
+            hasDraftAttachments: _pending.isNotEmpty || _processingCount > 0,
             onAttach: _pickImages,
             dictation: _dictation,
             floating: widget.floatingComposer,
@@ -1526,6 +1528,8 @@ class _InputBar extends StatelessWidget {
   final bool isStreaming;
   final String hint;
   final VoidCallback onSend;
+  final VoidCallback onStop;
+  final bool hasDraftAttachments;
   final VoidCallback onAttach;
   final DictationController dictation;
   final bool floating;
@@ -1536,6 +1540,8 @@ class _InputBar extends StatelessWidget {
     required this.isStreaming,
     required this.hint,
     required this.onSend,
+    required this.onStop,
+    required this.hasDraftAttachments,
     required this.onAttach,
     required this.dictation,
     this.floating = false,
@@ -1603,10 +1609,28 @@ class _InputBar extends StatelessWidget {
           ),
           _MicButton(dictation: dictation),
           const SizedBox(width: AppSpacing.sm),
-          IconButton.filled(
-            tooltip: context.l10n.chatSend,
-            onPressed: onSend,
-            icon: const Icon(Icons.send),
+          // Contextual swap: while streaming with nothing drafted the send
+          // button becomes a stop button; any draft (text or attachment)
+          // flips it back to send so queue-ahead keeps working.
+          ValueListenableBuilder<TextEditingValue>(
+            valueListenable: controller,
+            builder: (context, value, _) {
+              final showStop = isStreaming &&
+                  value.text.trim().isEmpty &&
+                  !hasDraftAttachments;
+              if (showStop) {
+                return IconButton.filled(
+                  tooltip: context.l10n.chatStopGenerating,
+                  onPressed: onStop,
+                  icon: const Icon(Icons.stop),
+                );
+              }
+              return IconButton.filled(
+                tooltip: context.l10n.chatSend,
+                onPressed: onSend,
+                icon: const Icon(Icons.send),
+              );
+            },
           ),
         ],
       ),

--- a/src/packages/flutter-app/test/chat_panel_attachments_test.dart
+++ b/src/packages/flutter-app/test/chat_panel_attachments_test.dart
@@ -66,6 +66,7 @@ class _RecordingPlanService extends PlanService {
     String? chatId,
     String? tripId,
     String? summary,
+    Future<void>? abortTrigger,
   }) async* {
     histories.add(List.of(messages));
     yield PlanEvent(type: 'text_delta', data: {'text': 'ok'});

--- a/src/packages/flutter-app/test/chat_panel_dictation_test.dart
+++ b/src/packages/flutter-app/test/chat_panel_dictation_test.dart
@@ -57,6 +57,7 @@ class _FakePlanService extends PlanService {
     String? chatId,
     String? tripId,
     String? summary,
+    Future<void>? abortTrigger,
   }) async* {
     sent.add(messages.last['content'] ?? '');
     yield PlanEvent(type: 'text_delta', data: {'text': 'ok'});

--- a/src/packages/flutter-app/test/chat_panel_parking_strip_test.dart
+++ b/src/packages/flutter-app/test/chat_panel_parking_strip_test.dart
@@ -31,6 +31,7 @@ class _StubPlanService extends PlanService {
     String? chatId,
     String? tripId,
     String? summary,
+    Future<void>? abortTrigger,
   }) async* {}
 }
 

--- a/src/packages/flutter-app/test/chat_panel_place_strip_test.dart
+++ b/src/packages/flutter-app/test/chat_panel_place_strip_test.dart
@@ -35,6 +35,7 @@ class _StubPlanService extends PlanService {
     String? chatId,
     String? tripId,
     String? summary,
+    Future<void>? abortTrigger,
   }) async* {}
 }
 

--- a/src/packages/flutter-app/test/chat_panel_queue_test.dart
+++ b/src/packages/flutter-app/test/chat_panel_queue_test.dart
@@ -28,6 +28,7 @@ class _GatedPlanService extends PlanService {
     String? chatId,
     String? tripId,
     String? summary,
+    Future<void>? abortTrigger,
   }) async* {
     final call = calls++;
     yield PlanEvent(type: 'text_delta', data: {'text': 'reply $call'});
@@ -75,6 +76,9 @@ void main() {
     expect(field.decoration?.hintText, 'Ask a follow-up…');
 
     await tester.enterText(find.byType(TextField), 'also add delphi');
+    // Mid-stream the empty-composer button is Stop; typing flips it back to
+    // send on the next frame (contextual send/stop swap).
+    await tester.pump();
     await tester.tap(find.byIcon(Icons.send));
     await tester.pump();
 
@@ -105,6 +109,8 @@ void main() {
     await tester.pump();
 
     await tester.enterText(find.byType(TextField), 'also add delphi');
+    // Contextual swap: a frame must render for Stop to flip back to send.
+    await tester.pump();
     await tester.tap(find.byIcon(Icons.send));
     await tester.pump();
     expect(find.text('Queued'), findsOneWidget);

--- a/src/packages/flutter-app/test/chat_panel_quick_replies_test.dart
+++ b/src/packages/flutter-app/test/chat_panel_quick_replies_test.dart
@@ -34,6 +34,7 @@ class _ScriptedPlanService extends PlanService {
     String? chatId,
     String? tripId,
     String? summary,
+    Future<void>? abortTrigger,
   }) async* {
     lastHistory = messages;
     for (final e in events) {
@@ -57,6 +58,7 @@ class _ParkablePlanService extends PlanService {
     String? chatId,
     String? tripId,
     String? summary,
+    Future<void>? abortTrigger,
   }) async* {
     for (final step in script) {
       if (step is Completer<void>) {

--- a/src/packages/flutter-app/test/chat_panel_seed_chip_test.dart
+++ b/src/packages/flutter-app/test/chat_panel_seed_chip_test.dart
@@ -22,6 +22,7 @@ class _ScriptedPlanService extends PlanService {
     String? chatId,
     String? tripId,
     String? summary,
+    Future<void>? abortTrigger,
   }) async* {
     for (final e in events) {
       yield e;

--- a/src/packages/flutter-app/test/chat_panel_stop_button_test.dart
+++ b/src/packages/flutter-app/test/chat_panel_stop_button_test.dart
@@ -1,0 +1,144 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:travel_route_planner/providers/plan_provider.dart';
+import 'package:travel_route_planner/services/api_client.dart';
+import 'package:travel_route_planner/services/plan_service.dart';
+import 'package:travel_route_planner/widgets/chat_panel.dart';
+
+import 'support/l10n_test_app.dart';
+
+/// Contextual send/stop swap: while a turn streams with nothing drafted the
+/// send button becomes a stop button; typing a follow-up flips it back to
+/// send so queue-ahead keeps working; tapping stop commits the partial reply
+/// as a normal bubble and reverts the button.
+
+/// Plays [script] in order: [PlanEvent]s are yielded, [Completer]s are
+/// awaited — so a test can park the stream mid-turn and observe the UI.
+class _StagedPlanService extends PlanService {
+  final List<Object> script;
+
+  _StagedPlanService(this.script) : super('http://unused');
+
+  @override
+  Stream<PlanEvent> streamPlan(
+    List<Map<String, dynamic>> messages, {
+    String? bearerToken,
+    String? chatId,
+    String? tripId,
+    String? summary,
+    Future<void>? abortTrigger,
+  }) async* {
+    for (final step in script) {
+      if (step is Completer<void>) {
+        await step.future;
+      } else {
+        yield step as PlanEvent;
+      }
+    }
+  }
+}
+
+Future<void> _pumpPanel(WidgetTester tester, _StagedPlanService service) async {
+  final notifier = PlanNotifier(service, ApiClient());
+  final provider =
+      StateNotifierProvider<PlanNotifier, PlanState>((ref) => notifier);
+  await tester.pumpWidget(
+    ProviderScope(
+      child: MaterialApp(
+        localizationsDelegates: testLocalizationsDelegates,
+        home: Scaffold(
+          body: ChatPanel(state: provider, notifier: provider.notifier),
+        ),
+      ),
+    ),
+  );
+}
+
+Future<void> _send(WidgetTester tester) async {
+  await tester.enterText(find.byType(TextField), 'hi');
+  await tester.pump();
+  await tester.tap(find.byIcon(Icons.send));
+  await tester.pump();
+}
+
+void main() {
+  testWidgets('idle shows send; streaming with an empty composer shows stop',
+      (WidgetTester tester) async {
+    final gate = Completer<void>();
+    final service = _StagedPlanService([
+      const PlanEvent(type: 'text_delta', data: {'text': 'Hello there'}),
+      gate,
+    ]);
+    await _pumpPanel(tester, service);
+
+    expect(find.byIcon(Icons.send), findsOneWidget);
+    expect(find.byIcon(Icons.stop), findsNothing);
+
+    // _send clears the composer, so the swap lands the instant a turn starts.
+    await _send(tester);
+    expect(find.byIcon(Icons.stop), findsOneWidget);
+    expect(find.byIcon(Icons.send), findsNothing);
+
+    gate.complete();
+    await tester.pumpAndSettle();
+    expect(find.byIcon(Icons.send), findsOneWidget);
+    expect(find.byIcon(Icons.stop), findsNothing);
+  });
+
+  testWidgets('typing a follow-up mid-stream flips stop back to send',
+      (WidgetTester tester) async {
+    final gate = Completer<void>();
+    final service = _StagedPlanService([
+      const PlanEvent(type: 'text_delta', data: {'text': 'Hello there'}),
+      gate,
+    ]);
+    await _pumpPanel(tester, service);
+
+    await _send(tester);
+    expect(find.byIcon(Icons.stop), findsOneWidget);
+
+    await tester.enterText(find.byType(TextField), 'queue this too');
+    await tester.pump();
+    expect(find.byIcon(Icons.send), findsOneWidget);
+    expect(find.byIcon(Icons.stop), findsNothing);
+
+    // Whitespace is not a draft.
+    await tester.enterText(find.byType(TextField), '  ');
+    await tester.pump();
+    expect(find.byIcon(Icons.stop), findsOneWidget);
+
+    gate.complete();
+    await tester.pumpAndSettle();
+  });
+
+  testWidgets('tapping stop commits the partial bubble and reverts the button',
+      (WidgetTester tester) async {
+    final gate = Completer<void>();
+    final service = _StagedPlanService([
+      const PlanEvent(type: 'text_delta', data: {'text': 'Hello there'}),
+      gate,
+    ]);
+    await _pumpPanel(tester, service);
+
+    await _send(tester);
+    // Let the 48ms flush render the live streaming bubble first.
+    await tester.pump(const Duration(milliseconds: 60));
+    expect(find.text('Hello there'), findsOneWidget);
+
+    await tester.tap(find.byIcon(Icons.stop));
+    await tester.pump();
+
+    // The partial survives as a committed assistant bubble — no error banner,
+    // no ghost streaming bubble later.
+    expect(find.text('Hello there'), findsOneWidget);
+    expect(find.byIcon(Icons.send), findsOneWidget);
+    expect(find.byIcon(Icons.stop), findsNothing);
+    await tester.pump(const Duration(milliseconds: 80));
+    expect(find.text('Hello there'), findsOneWidget);
+    await tester.pumpAndSettle();
+  });
+}

--- a/src/packages/flutter-app/test/chat_panel_typing_indicator_test.dart
+++ b/src/packages/flutter-app/test/chat_panel_typing_indicator_test.dart
@@ -33,6 +33,7 @@ class _StagedPlanService extends PlanService {
     String? chatId,
     String? tripId,
     String? summary,
+    Future<void>? abortTrigger,
   }) async* {
     for (final step in script) {
       if (step is Completer<void>) {

--- a/src/packages/flutter-app/test/plan_provider_attachments_test.dart
+++ b/src/packages/flutter-app/test/plan_provider_attachments_test.dart
@@ -26,6 +26,7 @@ class _RecordingPlanService extends PlanService {
     String? chatId,
     String? tripId,
     String? summary,
+    Future<void>? abortTrigger,
   }) async* {
     final call = histories.length;
     histories.add(List.of(messages));

--- a/src/packages/flutter-app/test/plan_provider_compaction_test.dart
+++ b/src/packages/flutter-app/test/plan_provider_compaction_test.dart
@@ -25,6 +25,7 @@ class _CompactionPlanService extends PlanService {
     String? chatId,
     String? tripId,
     String? summary,
+    Future<void>? abortTrigger,
   }) async* {
     final call = histories.length;
     histories.add(List.of(messages));

--- a/src/packages/flutter-app/test/plan_provider_places_test.dart
+++ b/src/packages/flutter-app/test/plan_provider_places_test.dart
@@ -18,6 +18,7 @@ class _ScriptedPlanService extends PlanService {
     String? chatId,
     String? tripId,
     String? summary,
+    Future<void>? abortTrigger,
   }) async* {
     for (final e in events) {
       yield e;

--- a/src/packages/flutter-app/test/plan_provider_queue_test.dart
+++ b/src/packages/flutter-app/test/plan_provider_queue_test.dart
@@ -27,6 +27,7 @@ class _GatedPlanService extends PlanService {
     String? chatId,
     String? tripId,
     String? summary,
+    Future<void>? abortTrigger,
   }) async* {
     final call = histories.length;
     histories.add(List.of(messages));

--- a/src/packages/flutter-app/test/plan_provider_separator_test.dart
+++ b/src/packages/flutter-app/test/plan_provider_separator_test.dart
@@ -25,6 +25,7 @@ class _ScriptedPlanService extends PlanService {
     String? chatId,
     String? tripId,
     String? summary,
+    Future<void>? abortTrigger,
   }) async* {
     for (final e in events) {
       if (delay != null) await Future<void>.delayed(delay!);

--- a/src/packages/flutter-app/test/plan_provider_stop_test.dart
+++ b/src/packages/flutter-app/test/plan_provider_stop_test.dart
@@ -1,0 +1,179 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:travel_route_planner/models/plan_message.dart';
+import 'package:travel_route_planner/providers/plan_provider.dart';
+import 'package:travel_route_planner/services/api_client.dart';
+import 'package:travel_route_planner/services/plan_service.dart';
+
+/// stopStreaming(): commits whatever streamed so far as a normal assistant
+/// message, fires the transport abort trigger, and supersedes the turn so any
+/// tail from the dying stream (late events, teardown) touches nothing.
+
+/// Plays [script] in order — [PlanEvent]s yield, [Completer]s park the stream
+/// — and records the abort trigger each turn hands to the transport.
+class _StagedPlanService extends PlanService {
+  List<Object> script;
+  bool aborted = false;
+
+  _StagedPlanService(this.script) : super('http://unused');
+
+  @override
+  Stream<PlanEvent> streamPlan(
+    List<Map<String, dynamic>> messages, {
+    String? bearerToken,
+    String? chatId,
+    String? tripId,
+    String? summary,
+    Future<void>? abortTrigger,
+  }) async* {
+    abortTrigger?.whenComplete(() => aborted = true);
+    for (final step in script) {
+      if (step is Completer<void>) {
+        await step.future;
+      } else {
+        yield step as PlanEvent;
+      }
+    }
+  }
+}
+
+void main() {
+  test('stop mid-stream commits the partial, aborts, and ignores the tail',
+      () async {
+    final gate = Completer<void>();
+    final service = _StagedPlanService([
+      const PlanEvent(type: 'text_delta', data: {'text': 'Half an ans'}),
+      gate,
+      const PlanEvent(type: 'text_delta', data: {'text': 'wer, never seen'}),
+      const PlanEvent(type: 'suggest_replies', data: {
+        'replies': ['Ghost chip']
+      }),
+    ]);
+    final notifier = PlanNotifier(service, ApiClient());
+
+    final send = notifier.sendMessage('plan athens');
+    await Future<void>.delayed(const Duration(milliseconds: 5));
+    expect(notifier.state.isStreaming, isTrue);
+
+    notifier.stopStreaming();
+
+    // The un-flushed buffer (not state.streamingText) is what commits — the
+    // 48ms coalescing tail must not be lost.
+    expect(notifier.state.isStreaming, isFalse);
+    expect(notifier.state.streamingText, isNull);
+    expect(notifier.state.error, isNull);
+    expect(notifier.state.messages.last.role, MessageRole.assistant);
+    expect(notifier.state.messages.last.content, 'Half an ans');
+    await Future<void>.delayed(Duration.zero);
+    expect(service.aborted, isTrue);
+
+    // Release the parked stream: the superseded turn must change nothing.
+    gate.complete();
+    await send;
+    expect(notifier.state.messages.length, 2);
+    expect(notifier.state.messages.last.content, 'Half an ans');
+    expect(notifier.state.suggestedReplies, isEmpty);
+    expect(notifier.state.isStreaming, isFalse);
+
+    // A late flush timer must not resurrect a ghost streaming bubble.
+    await Future<void>.delayed(const Duration(milliseconds: 80));
+    expect(notifier.state.streamingText, isNull);
+  });
+
+  test('stop before any text commits nothing (typing-indicator phase)',
+      () async {
+    final gate = Completer<void>();
+    final service = _StagedPlanService([gate]);
+    final notifier = PlanNotifier(service, ApiClient());
+
+    unawaited(notifier.sendMessage('plan athens'));
+    await Future<void>.delayed(const Duration(milliseconds: 5));
+    expect(notifier.state.isStreaming, isTrue);
+
+    notifier.stopStreaming();
+
+    expect(notifier.state.isStreaming, isFalse);
+    // Only the user message — no empty assistant bubble.
+    expect(notifier.state.messages.map((m) => m.role).toList(),
+        [MessageRole.user]);
+    await Future<void>.delayed(Duration.zero);
+    expect(service.aborted, isTrue);
+  });
+
+  test('stop while idle is a no-op (covers double-tap)', () async {
+    final service = _StagedPlanService([
+      const PlanEvent(type: 'text_delta', data: {'text': 'Done.'}),
+    ]);
+    final notifier = PlanNotifier(service, ApiClient());
+
+    // Never started: nothing happens.
+    notifier.stopStreaming();
+    expect(notifier.state.messages, isEmpty);
+
+    await notifier.sendMessage('hi');
+    final committed = notifier.state.messages.length;
+
+    // Turn already ended naturally: the second "tap" changes nothing.
+    notifier.stopStreaming();
+    expect(notifier.state.messages.length, committed);
+    expect(notifier.state.isStreaming, isFalse);
+  });
+
+  test('stop keeps the queue; the next explicit send drains it FIFO',
+      () async {
+    final gate = Completer<void>();
+    final service = _StagedPlanService([
+      const PlanEvent(type: 'text_delta', data: {'text': 'First reply cut'}),
+      gate,
+    ]);
+    final notifier = PlanNotifier(service, ApiClient());
+
+    unawaited(notifier.sendMessage('one'));
+    await Future<void>.delayed(const Duration(milliseconds: 5));
+    await notifier.sendMessage('two'); // queued behind the live turn
+
+    notifier.stopStreaming();
+
+    // Stopping is not "success": no auto-drain of a turn the user just killed.
+    expect(notifier.state.queuedMessages.map((m) => m.text).toList(), ['two']);
+    expect(notifier.state.isStreaming, isFalse);
+
+    // A fresh explicit send drains the backlog FIFO ahead of itself.
+    service.script = [
+      const PlanEvent(type: 'text_delta', data: {'text': 'ok'}),
+    ];
+    await notifier.sendMessage('three');
+    expect(notifier.state.queuedMessages, isEmpty);
+    expect(
+      notifier.state.messages
+          .where((m) => m.role == MessageRole.user)
+          .map((m) => m.content)
+          .toList(),
+      ['one', 'two', 'three'],
+    );
+    expect(notifier.state.isStreaming, isFalse);
+  });
+
+  test('stop then immediate send starts a clean fresh turn', () async {
+    final gate = Completer<void>();
+    final service = _StagedPlanService([
+      const PlanEvent(type: 'text_delta', data: {'text': 'Stale half'}),
+      gate,
+    ]);
+    final notifier = PlanNotifier(service, ApiClient());
+
+    unawaited(notifier.sendMessage('plan athens'));
+    await Future<void>.delayed(const Duration(milliseconds: 5));
+    notifier.stopStreaming();
+
+    service.script = [
+      const PlanEvent(type: 'text_delta', data: {'text': 'Fresh answer.'}),
+    ];
+    await notifier.sendMessage('actually, kyoto');
+
+    expect(notifier.state.messages.last.content, 'Fresh answer.');
+    expect(notifier.state.isStreaming, isFalse);
+    expect(notifier.state.error, isNull);
+  });
+}

--- a/src/packages/flutter-app/test/plan_provider_stream_test.dart
+++ b/src/packages/flutter-app/test/plan_provider_stream_test.dart
@@ -18,6 +18,7 @@ class _FakePlanService extends PlanService {
     String? chatId,
     String? tripId,
     String? summary,
+    Future<void>? abortTrigger,
   }) async* {
     for (var i = 0; i < deltaCount; i++) {
       await Future<void>.delayed(const Duration(milliseconds: 2));
@@ -41,6 +42,7 @@ class _ScriptedPlanService extends PlanService {
     String? chatId,
     String? tripId,
     String? summary,
+    Future<void>? abortTrigger,
   }) async* {
     lastHistory = messages;
     for (final e in events) {

--- a/src/packages/flutter-app/test/plan_service_abort_test.dart
+++ b/src/packages/flutter-app/test/plan_service_abort_test.dart
@@ -1,0 +1,83 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:travel_route_planner/services/plan_service.dart';
+
+/// streamPlan hands its abortTrigger to an AbortableRequest so the transport
+/// dies the moment the trigger fires — even mid-tool-call with an idle socket
+/// — and the resulting RequestAbortedException ends the stream cleanly with
+/// no synthetic error event.
+///
+/// MockClient does not honor abortTrigger, so this fake transport implements
+/// the contract by hand: stream one SSE frame, then inject the abort error
+/// when the trigger completes (what BrowserClient/IOClient do for real).
+class _AbortAwareClient extends http.BaseClient {
+  Future<void>? seenTrigger;
+  bool closed = false;
+
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) async {
+    seenTrigger = (request as http.AbortableRequest).abortTrigger;
+    final controller = StreamController<List<int>>();
+    controller.add(
+        utf8.encode('data: {"type":"text_delta","data":{"text":"one"}}\n\n'));
+    if (seenTrigger == null) {
+      // No trigger: behave like a normal completed response.
+      unawaited(controller.close());
+    } else {
+      seenTrigger!.whenComplete(() {
+        controller.addError(http.RequestAbortedException(request.url));
+        controller.close();
+      });
+    }
+    return http.StreamedResponse(controller.stream, 200);
+  }
+
+  @override
+  void close() {
+    closed = true;
+    super.close();
+  }
+}
+
+void main() {
+  const history = [
+    {'role': 'user', 'content': 'plan athens'}
+  ];
+
+  test('abort mid-stream ends cleanly: pre-abort events only, no error event',
+      () async {
+    final client = _AbortAwareClient();
+    final service =
+        PlanService('http://test/api/v1', clientFactory: () => client);
+    final abort = Completer<void>();
+
+    final eventsFuture =
+        service.streamPlan(history, abortTrigger: abort.future).toList();
+    await Future<void>.delayed(const Duration(milliseconds: 5));
+
+    // The trigger reached the transport as this request's abortTrigger.
+    expect(identical(client.seenTrigger, abort.future), isTrue);
+
+    abort.complete();
+    final events = await eventsFuture;
+
+    expect(events.map((e) => e.type).toList(), ['text_delta']);
+    expect(events.single.data['text'], 'one');
+    expect(client.closed, isTrue);
+  });
+
+  test('no abortTrigger: the stream parses and completes unchanged', () async {
+    final client = _AbortAwareClient();
+    final service =
+        PlanService('http://test/api/v1', clientFactory: () => client);
+
+    final events = await service.streamPlan(history).toList();
+
+    expect(client.seenTrigger, isNull);
+    expect(events.map((e) => e.type).toList(), ['text_delta']);
+    expect(client.closed, isTrue);
+  });
+}

--- a/src/packages/flutter-app/test/resume_conversation_test.dart
+++ b/src/packages/flutter-app/test/resume_conversation_test.dart
@@ -21,6 +21,7 @@ class _RecordingPlanService extends PlanService {
     String? chatId,
     String? tripId,
     String? summary,
+    Future<void>? abortTrigger,
   }) async* {
     histories.add(List.of(messages));
     chatIds.add(chatId);

--- a/src/packages/flutter-app/test/trip_detail_chat_fab_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_chat_fab_test.dart
@@ -36,6 +36,7 @@ class _ScriptedPlanService extends PlanService {
     String? chatId,
     String? tripId,
     String? summary,
+    Future<void>? abortTrigger,
   }) async* {
     for (final e in events) {
       yield e;


### PR DESCRIPTION
## Summary
- **Stop button in the chat composer** (ChatGPT/Claude-style): while a reply streams and nothing is drafted, the send button becomes a stop button; typing a follow-up flips it back to send so queue-ahead keeps working (`_InputBar` ValueListenableBuilder swap in `chat_panel.dart`).
- **Stopping commits the partial reply** as a normal assistant bubble (no marker, per Brian's call) — reading the un-flushed 48ms stream buffer, exactly like the mid-turn error path — and leaves the message queue intact (`PlanNotifier.stopStreaming()`).
- **The abort is a real transport abort**: `PlanService.streamPlan` gains an `abortTrigger` fed to `http.AbortableRequest` (http 1.5.0, already locked), so the socket dies even while idle mid-tool-call — server generation and Anthropic token spend stop at the next iteration boundary. The same seam is wired into `reset()`/`dispose()`, fixing the pre-existing lingering-socket gap on "Start over" and refine-panel disposal.
- **Server: client aborts are no longer misclassified as AI failures.** `plan_handler.go` returns quietly when the request ctx is Canceled (deadline expiries still record + report as before); `plan_compactor.go` skips `recordAIResult` on caller cancellation. Previously every stop would bump `ai_transient_total` and tee an ERROR to Sentry. The deferred background-ctx transcript upsert already persists the partial, so server and client transcripts match.
- New l10n key `chatStopGenerating` (en/es, localizations regenerated).
- Known v1 limitation: stopping mid-`create_itinerary` can fail the trip persist with `context.Canceled` (tools share the request ctx).

## Testing
- `make flutter-analyze` (clean apart from 3 pre-existing infos on main) and `make flutter-test` — all 614 pass, including new suites: `plan_provider_stop_test.dart` (partial commit, abort fired, superseded-turn tail ignored, no-text/idle/double-tap no-ops, queue preserved + FIFO drain, stop-then-send), `chat_panel_stop_button_test.dart` (icon swap states, tap-stop commits), `plan_service_abort_test.dart` (hand-rolled abort-aware BaseClient; clean end, no synthetic error). Two `chat_panel_queue_test.dart` tests gained a pump between typing and tapping send (the swap rebuilds on the next frame).
- `make api-fmt`, `make api-vet`, `make api-test-go` — green incl. new `TestPlanClientAbortRecordsNoAIFailure` (new fake-Anthropic `stallTurn` parks mid-stream; cancel produces no error SSE and an untouched health tracker).
- Manual on the lane stack (:3007), real Anthropic: curl abort mid-tool-phase and a full headless-Chrome web run (BrowserClient/fetch abort path) — stop button appears on send, tap froze the reply mid-word, committed bubble + send arrow restored, API log shows the request ending at the click with **no** `plan: anthropic stream error`, and `plan_chat_sessions` holds the identical partial text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)