### PR TITLE
feat(map): home-airport legs on the full-screen trip map

### DIFF
--- a/src/packages/api/duffel_service.go
+++ b/src/packages/api/duffel_service.go
@@ -36,6 +36,10 @@ type Airport struct {
 	City     string `json:"city,omitempty"`
 	Country  string `json:"country,omitempty"`
 	SubType  string `json:"sub_type,omitempty"` // airport | city
+	// Pointers + omitempty: entries Duffel returns without coordinates (some
+	// city-type places) keep their JSON shape byte-identical to before.
+	Latitude  *float64 `json:"latitude,omitempty"`
+	Longitude *float64 `json:"longitude,omitempty"`
 }
 
 // FlightLeg is a single flown segment within an offer.
@@ -255,11 +259,13 @@ func (d *DuffelService) placeSuggestions(ctx context.Context, params url.Values)
 
 	var result struct {
 		Data []struct {
-			Type            string `json:"type"`
-			Name            string `json:"name"`
-			IataCode        string `json:"iata_code"`
-			CityName        string `json:"city_name"`
-			IataCountryCode string `json:"iata_country_code"`
+			Type            string   `json:"type"`
+			Name            string   `json:"name"`
+			IataCode        string   `json:"iata_code"`
+			CityName        string   `json:"city_name"`
+			IataCountryCode string   `json:"iata_country_code"`
+			Latitude        *float64 `json:"latitude"`
+			Longitude       *float64 `json:"longitude"`
 		} `json:"data"`
 	}
 	if err := json.Unmarshal(body, &result); err != nil {
@@ -272,11 +278,13 @@ func (d *DuffelService) placeSuggestions(ctx context.Context, params url.Values)
 			continue
 		}
 		airports = append(airports, Airport{
-			IataCode: p.IataCode,
-			Name:     p.Name,
-			City:     p.CityName,
-			Country:  p.IataCountryCode,
-			SubType:  p.Type,
+			IataCode:  p.IataCode,
+			Name:      p.Name,
+			City:      p.CityName,
+			Country:   p.IataCountryCode,
+			SubType:   p.Type,
+			Latitude:  p.Latitude,
+			Longitude: p.Longitude,
 		})
 	}
 	d.placesCache.set(cacheKey, airports)

--- a/src/packages/api/duffel_service_test.go
+++ b/src/packages/api/duffel_service_test.go
@@ -229,3 +229,53 @@ func TestSearchFlightOffersDefaultsToEconomy(t *testing.T) {
 		t.Fatalf("passengers = %d, want 1", got)
 	}
 }
+
+func TestPlaceSuggestionsCarriesCoordinates(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"data":[
+			{"type":"airport","name":"Boston Logan International Airport","iata_code":"BOS","city_name":"Boston","iata_country_code":"US","latitude":42.365613,"longitude":-71.009537},
+			{"type":"city","name":"Boston","iata_code":"BOS","iata_country_code":"US"}
+		]}`))
+	}))
+	t.Cleanup(srv.Close)
+	d := &DuffelService{
+		Token:   "test-token",
+		BaseURL: srv.URL,
+		Version: "v2",
+		Client:  &http.Client{Timeout: 5 * time.Second},
+		// placeSuggestions dereferences the cache unconditionally; the
+		// direct-literal stub skips NewDuffelService.
+		placesCache: newTTLCache[[]Airport](time.Minute, 10),
+	}
+
+	got, err := d.SearchAirports(context.Background(), "BOS")
+	if err != nil {
+		t.Fatalf("SearchAirports: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("results = %d, want 2", len(got))
+	}
+
+	airport := got[0]
+	if airport.Latitude == nil || airport.Longitude == nil {
+		t.Fatal("airport entry must carry Duffel's coordinates")
+	}
+	if *airport.Latitude != 42.365613 || *airport.Longitude != -71.009537 {
+		t.Fatalf("airport coords = %v,%v, want 42.365613,-71.009537", *airport.Latitude, *airport.Longitude)
+	}
+
+	city := got[1]
+	if city.Latitude != nil || city.Longitude != nil {
+		t.Fatal("entry without coords must keep nil pointers, not 0,0")
+	}
+	// Coordless entries must marshal byte-identically to the pre-coordinate
+	// shape (omitempty on the pointers).
+	out, err := json.Marshal(city)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(out), "latitude") || strings.Contains(string(out), "longitude") {
+		t.Fatalf("coordless Airport JSON must omit coordinate keys, got %s", out)
+	}
+}

--- a/src/packages/flutter-app/lib/l10n/app_en.arb
+++ b/src/packages/flutter-app/lib/l10n/app_en.arb
@@ -1284,6 +1284,14 @@
   "mapZoomIn": "Zoom in",
   "mapZoomOut": "Zoom out",
   "mapResetMap": "Reset map",
+  "mapHomeAirport": "Home airport ({code})",
+  "@mapHomeAirport": {
+    "placeholders": {
+      "code": {
+        "type": "String"
+      }
+    }
+  },
   "accountMenuTooltip": "Account",
   "accountMenuTravelProfile": "Travel profile",
   "accountMenuPriceAlerts": "Price alerts",

--- a/src/packages/flutter-app/lib/l10n/app_es.arb
+++ b/src/packages/flutter-app/lib/l10n/app_es.arb
@@ -582,6 +582,7 @@
   "mapZoomIn": "Acercar",
   "mapZoomOut": "Alejar",
   "mapResetMap": "Restablecer mapa",
+  "mapHomeAirport": "Aeropuerto de origen ({code})",
   "accountMenuTooltip": "Cuenta",
   "accountMenuTravelProfile": "Perfil de viaje",
   "accountMenuPriceAlerts": "Alertas de precio",

--- a/src/packages/flutter-app/lib/l10n/app_localizations.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations.dart
@@ -3590,6 +3590,12 @@ abstract class AppLocalizations {
   /// **'Reset map'**
   String get mapResetMap;
 
+  /// No description provided for @mapHomeAirport.
+  ///
+  /// In en, this message translates to:
+  /// **'Home airport ({code})'**
+  String mapHomeAirport(String code);
+
   /// No description provided for @accountMenuTooltip.
   ///
   /// In en, this message translates to:

--- a/src/packages/flutter-app/lib/l10n/app_localizations_en.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations_en.dart
@@ -1991,6 +1991,11 @@ class AppLocalizationsEn extends AppLocalizations {
   String get mapResetMap => 'Reset map';
 
   @override
+  String mapHomeAirport(String code) {
+    return 'Home airport ($code)';
+  }
+
+  @override
   String get accountMenuTooltip => 'Account';
 
   @override

--- a/src/packages/flutter-app/lib/l10n/app_localizations_es.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations_es.dart
@@ -2006,6 +2006,11 @@ class AppLocalizationsEs extends AppLocalizations {
   String get mapResetMap => 'Restablecer mapa';
 
   @override
+  String mapHomeAirport(String code) {
+    return 'Aeropuerto de origen ($code)';
+  }
+
+  @override
   String get accountMenuTooltip => 'Cuenta';
 
   @override

--- a/src/packages/flutter-app/lib/models/airport.dart
+++ b/src/packages/flutter-app/lib/models/airport.dart
@@ -12,12 +12,19 @@ class Airport {
   @JsonKey(name: 'sub_type')
   final String subType;
 
+  /// Null when Duffel returned no coordinates for this place (some city-type
+  /// entries) or for placeholder instances built from a bare IATA code.
+  final double? latitude;
+  final double? longitude;
+
   const Airport({
     required this.iataCode,
     required this.name,
     this.city = '',
     this.country = '',
     this.subType = '',
+    this.latitude,
+    this.longitude,
   });
 
   /// "Paris (CDG)" style label for autocomplete rows and field display. Falls

--- a/src/packages/flutter-app/lib/models/airport.g.dart
+++ b/src/packages/flutter-app/lib/models/airport.g.dart
@@ -12,6 +12,8 @@ Airport _$AirportFromJson(Map<String, dynamic> json) => Airport(
       city: json['city'] as String? ?? '',
       country: json['country'] as String? ?? '',
       subType: json['sub_type'] as String? ?? '',
+      latitude: (json['latitude'] as num?)?.toDouble(),
+      longitude: (json['longitude'] as num?)?.toDouble(),
     );
 
 Map<String, dynamic> _$AirportToJson(Airport instance) => <String, dynamic>{
@@ -20,4 +22,6 @@ Map<String, dynamic> _$AirportToJson(Airport instance) => <String, dynamic>{
       'city': instance.city,
       'country': instance.country,
       'sub_type': instance.subType,
+      'latitude': instance.latitude,
+      'longitude': instance.longitude,
     };

--- a/src/packages/flutter-app/lib/providers/flights_provider.dart
+++ b/src/packages/flutter-app/lib/providers/flights_provider.dart
@@ -17,6 +17,35 @@ final airportSearchProvider =
   return service.searchAirports(query.trim());
 });
 
+/// Resolves a saved home-airport IATA code to map coordinates (a record, not
+/// LatLng, so the providers layer stays free of map imports). Errors resolve
+/// to null rather than surfacing: the one contract callers rely on is
+/// "no coordinates → no home legs on the map", and a session-cached errored
+/// family provider would otherwise pin the failure until restart.
+final homeAirportPointProvider =
+    FutureProvider.family<({double lat, double lng})?, String>(
+        (ref, iata) async {
+  final code = iata.trim().toUpperCase();
+  if (code.isEmpty) return null;
+  final List<Airport> results;
+  try {
+    results = await ref.watch(flightsApiServiceProvider).searchAirports(code);
+  } catch (_) {
+    return null;
+  }
+  Airport? match;
+  for (final a in results) {
+    if (a.iataCode.toUpperCase() != code) continue;
+    if (a.latitude == null || a.longitude == null) continue;
+    if (a.subType == 'airport') {
+      match = a;
+      break;
+    }
+    match ??= a; // city-type fallback when it happens to carry coords
+  }
+  return match == null ? null : (lat: match.latitude!, lng: match.longitude!);
+});
+
 class FlightsState {
   final List<FlightOffer> offers;
   final String? bestOfferId;

--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart' show RenderAbstractViewport;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
+import 'package:latlong2/latlong.dart' show LatLng;
 import 'package:sliver_tools/sliver_tools.dart';
 import 'package:url_launcher/url_launcher.dart';
 import '../widgets/gradient_app_bar.dart';
@@ -4359,11 +4360,22 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
   /// covers the bottom navigation bar; the closures read the live [_trip] so
   /// a silent refresh propagates on the next chip tap.
   void _openFullMap(Trip trip, int mapDayCount, Set<int> mappedDays) {
+    // Home-leg endpoints are the trip's first/last location groups — the same
+    // derivation the outbound/return booking todos trust — never the first/
+    // last mapped pin, which shifts under day/category filters.
+    final ranges = _locationGroupRanges(trip);
+    final firstCoord = ranges.isEmpty ? null : ranges.first.coord;
+    final lastCoord = ranges.isEmpty ? null : ranges.last.coord;
     Navigator.of(context, rootNavigator: true).push(
       MaterialPageRoute(
         fullscreenDialog: true,
         builder: (_) => TripMapScreen(
           title: _displayTitle(trip),
+          homeAirport: _homeAirport,
+          firstCityPoint:
+              firstCoord == null ? null : LatLng(firstCoord.lat, firstCoord.lng),
+          lastCityPoint:
+              lastCoord == null ? null : LatLng(lastCoord.lat, lastCoord.lng),
           itemsForDay: (d) {
             final t = _trip;
             return t == null ? const <ItineraryItem>[] : _dayFiltered(t, d);

--- a/src/packages/flutter-app/lib/screens/trip_map_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_map_screen.dart
@@ -1,8 +1,11 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:latlong2/latlong.dart';
 
 import '../l10n/l10n.dart';
 import '../models/accommodation.dart';
 import '../models/itinerary_item.dart';
+import '../providers/flights_provider.dart';
 import '../utils/snack.dart';
 import '../widgets/app_map.dart';
 import '../widgets/gradient_app_bar.dart';
@@ -19,7 +22,7 @@ import '../widgets/trip_map.dart';
 /// the parent's live trip field, but a silent refresh while this screen is
 /// open only shows up after the next chip tap rebuilds it — acceptable
 /// staleness for a modal map.
-class TripMapScreen extends StatefulWidget {
+class TripMapScreen extends ConsumerStatefulWidget {
   final String title;
 
   /// Items/stays to plot for a day-chip selection (null = All), supplied by
@@ -42,6 +45,13 @@ class TripMapScreen extends StatefulWidget {
   /// read-only) hides the empty state's CTA and hint.
   final void Function(int? day)? onAddPlace;
 
+  /// The viewer's saved home-airport IATA code; with the trip's first/last
+  /// city coordinates it draws the journey's home legs (owner surfaces only —
+  /// shared views pass nothing). Null = no home overlay.
+  final String? homeAirport;
+  final LatLng? firstCityPoint;
+  final LatLng? lastCityPoint;
+
   const TripMapScreen({
     super.key,
     required this.title,
@@ -53,15 +63,41 @@ class TripMapScreen extends StatefulWidget {
     this.mappedDays,
     this.initialDay,
     this.onAddPlace,
+    this.homeAirport,
+    this.firstCityPoint,
+    this.lastCityPoint,
   });
 
   @override
-  State<TripMapScreen> createState() => _TripMapScreenState();
+  ConsumerState<TripMapScreen> createState() => _TripMapScreenState();
 }
 
-class _TripMapScreenState extends State<TripMapScreen> {
+class _TripMapScreenState extends ConsumerState<TripMapScreen> {
   late int? _day = widget.initialDay;
   int? _selectedPosition;
+
+  /// The home overlay for the current day selection, or null while the IATA →
+  /// coordinate lookup is pending / failed (the map simply omits the legs;
+  /// the provider watch rebuilds when it resolves). The outbound leg belongs
+  /// to day 1 and the return leg to the last day, so mid-trip day chips show
+  /// no orphan home pin.
+  TripMapHome? _homeOverlay() {
+    final code = widget.homeAirport;
+    if (code == null || code.isEmpty) return null;
+    final point = ref.watch(homeAirportPointProvider(code)).valueOrNull;
+    if (point == null) return null;
+    final outboundTo =
+        (_day == null || _day == 1) ? widget.firstCityPoint : null;
+    final returnFrom =
+        (_day == null || _day == widget.dayCount) ? widget.lastCityPoint : null;
+    if (outboundTo == null && returnFrom == null) return null;
+    return TripMapHome(
+      point: LatLng(point.lat, point.lng),
+      label: code,
+      outboundTo: outboundTo,
+      returnFrom: returnFrom,
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -102,6 +138,7 @@ class _TripMapScreenState extends State<TripMapScreen> {
                 accommodations: widget.staysForDay(_day),
                 selectedPosition: _selectedPosition,
                 segmentLabels: widget.segmentLabels,
+                home: _homeOverlay(),
                 fitSignature: _day,
                 // Keep fitted markers clear of the chip row overlaid below.
                 topOverlayInset:

--- a/src/packages/flutter-app/lib/widgets/trip_map.dart
+++ b/src/packages/flutter-app/lib/widgets/trip_map.dart
@@ -27,6 +27,36 @@ const double _pinHitBox = 44;
 /// less than [TripMap.topOverlayInset]'s usual value.
 const double _emptyStateTopInset = 44;
 
+/// Home-airport overlay for the full-screen trip map: the home point plus
+/// which travel legs to draw. A null endpoint hides that leg (e.g. a mid-trip
+/// day-chip selection); with both endpoints null callers should pass
+/// `home: null` instead so no orphan pin renders.
+///
+/// Limitation: a leg spanning more than 180° of longitude is dropped — the
+/// map is a single non-wrapping world ([AppMapCrs]), so such a leg would draw
+/// the long way around. When every leg drops, the whole overlay (pin and
+/// camera-fit inclusion) is suppressed.
+class TripMapHome {
+  /// The home airport's coordinates.
+  final LatLng point;
+
+  /// First-city coordinate; non-null draws the outbound leg home → city.
+  final LatLng? outboundTo;
+
+  /// Last-city coordinate; non-null draws the return leg city → home.
+  final LatLng? returnFrom;
+
+  /// Bare IATA code (e.g. "EWR") for the pin's tooltip.
+  final String label;
+
+  const TripMapHome({
+    required this.point,
+    required this.label,
+    this.outboundTo,
+    this.returnFrom,
+  });
+}
+
 /// Plots a trip's itinerary on a satellite basemap: a numbered, category-tinted
 /// pin per place, a route line connecting them in itinerary order, auto-fit to
 /// the trip's extent. Tapping a pin calls [onPinTap] with that item's position.
@@ -75,6 +105,11 @@ class TripMap extends StatefulWidget {
   /// Callers overlay their own tap handler (e.g. tap-to-expand on phones).
   final bool interactive;
 
+  /// Home-airport overlay: dashed outbound/return legs, a home pin, and the
+  /// home point joining the camera fit. Null — the default, and what the
+  /// inline map card and shared views pass — renders exactly as before.
+  final TripMapHome? home;
+
   const TripMap({
     super.key,
     required this.items,
@@ -88,6 +123,7 @@ class TripMap extends StatefulWidget {
     this.emptyAction,
     this.topOverlayInset = 0,
     this.interactive = true,
+    this.home,
   });
 
   /// Whether [a] would render as a stay pin: geocoded (null means "not
@@ -117,6 +153,30 @@ class _TripMapState extends State<TripMap> {
 
   static bool _hasCoords(ItineraryItem i) =>
       i.latitude != 0 || i.longitude != 0;
+
+  /// [TripMapHome] after the antimeridian guard documented on the class:
+  /// legs spanning more than 180° of longitude (or with equal endpoints) are
+  /// dropped, and when no drawable leg remains the whole overlay is
+  /// suppressed — null here means "render no home pin and fit no home point".
+  static TripMapHome? _effectiveHome(TripMapHome? home) {
+    if (home == null) return null;
+    bool drawable(LatLng? other) =>
+        other != null &&
+        other != home.point &&
+        (other.longitude - home.point.longitude).abs() <= 180;
+    final outboundTo = drawable(home.outboundTo) ? home.outboundTo : null;
+    final returnFrom = drawable(home.returnFrom) ? home.returnFrom : null;
+    if (outboundTo == null && returnFrom == null) return null;
+    if (outboundTo == home.outboundTo && returnFrom == home.returnFrom) {
+      return home;
+    }
+    return TripMapHome(
+      point: home.point,
+      label: home.label,
+      outboundTo: outboundTo,
+      returnFrom: returnFrom,
+    );
+  }
 
   /// Clockwise angle (radians) from screen-up to the segment a->b as rendered
   /// on the Web Mercator map, so a rotated up-arrow lies along the polyline.
@@ -171,11 +231,14 @@ class _TripMapState extends State<TripMap> {
   }
 
   /// Every coordinate the camera should frame: mapped items plus geocoded
-  /// stays. Mirrors the fitPoints assembled in [build]. Static so it can run
-  /// against an oldWidget's lists in [didUpdateWidget].
+  /// stays, plus the home airport when its overlay has a visible leg (the
+  /// camera must never stretch to a point nothing connects to). Mirrors the
+  /// fitPoints assembled in [build]. Static so it can run against an
+  /// oldWidget's lists in [didUpdateWidget].
   static List<LatLng> _fitPointsOf(
     List<ItineraryItem> items,
     List<Accommodation> accommodations,
+    LatLng? homePoint,
   ) {
     final points = <LatLng>[
       for (final it in items)
@@ -186,11 +249,15 @@ class _TripMapState extends State<TripMap> {
         points.add(LatLng(a.latitude!, a.longitude!));
       }
     }
+    if (homePoint != null) points.add(homePoint);
     return points;
   }
 
-  List<LatLng> _fitPoints() =>
-      _fitPointsOf(widget.items, widget.accommodations);
+  List<LatLng> _fitPoints() => _fitPointsOf(
+        widget.items,
+        widget.accommodations,
+        _effectiveHome(widget.home)?.point,
+      );
 
   @override
   void didUpdateWidget(covariant TripMap oldWidget) {
@@ -205,7 +272,14 @@ class _TripMapState extends State<TripMap> {
     // already frames the new content.
     bool contentChanged() {
       if (widget.selectedPosition != null) return false;
-      final oldPoints = _fitPointsOf(oldWidget.items, oldWidget.accommodations);
+      // The home comparison also covers the async case: the home overlay
+      // flipping null → resolved (the IATA lookup completing after mount)
+      // changes the fit-point set, so the camera refits to include home.
+      final oldPoints = _fitPointsOf(
+        oldWidget.items,
+        oldWidget.accommodations,
+        _effectiveHome(oldWidget.home)?.point,
+      );
       if (oldPoints.isEmpty) return false;
       return !setEquals(_fitPoints().toSet(), oldPoints.toSet());
     }
@@ -279,9 +353,26 @@ class _TripMapState extends State<TripMap> {
     }
 
     final points = mapped.map((m) => m.point).toList();
-    // Camera framing covers stays too; the route polyline sticks to [points].
-    final fitPoints = [...points, for (final s in stays) s.point];
+    final home = _effectiveHome(widget.home);
+    // Camera framing covers stays and the home airport too; the route
+    // polyline sticks to [points].
+    final fitPoints = [
+      ...points,
+      for (final s in stays) s.point,
+      if (home != null) home.point,
+    ];
     final selected = _selectedPoint();
+
+    // Home-airport legs (outbound home → first city, return last city →
+    // home). Kept out of [mapped]/[points]: appending there would silently
+    // reindex the numbered pins and break segment-label adjacency, so the
+    // legs get their own dashed polylines and arrow markers below.
+    final homeSegments = <({LatLng a, LatLng b})>[
+      if (home != null && home.outboundTo != null)
+        (a: home.point, b: home.outboundTo!),
+      if (home != null && home.returnFrom != null)
+        (a: home.returnFrom!, b: home.point),
+    ];
 
     // Travel-time labels at the midpoint of each within-city leg (only between
     // truly adjacent itinerary stops that are both mapped). Kept as endpoint
@@ -320,6 +411,21 @@ class _TripMapState extends State<TripMap> {
           width: 18,
           height: 18,
           child: _SegmentArrow(angle: _bearing(a.point, b.point)),
+        ),
+      );
+    }
+    // Home legs carry no travel-time labels, so their arrow always sits at
+    // the midpoint.
+    for (final s in homeSegments) {
+      arrowMarkers.add(
+        Marker(
+          point: LatLng(
+            (s.a.latitude + s.b.latitude) / 2,
+            (s.a.longitude + s.b.longitude) / 2,
+          ),
+          width: 18,
+          height: 18,
+          child: _SegmentArrow(angle: _bearing(s.a, s.b)),
         ),
       );
     }
@@ -405,9 +511,53 @@ class _TripMapState extends State<TripMap> {
                       ),
                     ],
                   ),
+                if (homeSegments.isNotEmpty)
+                  PolylineLayer(
+                    polylines: [
+                      for (final s in homeSegments) ...[
+                        // Same two-pass glow as the route line, but dashed:
+                        // these legs are travel to/from the trip, not part of
+                        // the itinerary walk.
+                        Polyline(
+                          points: [s.a, s.b],
+                          strokeWidth: 6,
+                          color: Colors.white.withValues(alpha: 0.25),
+                          pattern: StrokePattern.dashed(
+                            segments: const [8, 6],
+                          ),
+                        ),
+                        Polyline(
+                          points: [s.a, s.b],
+                          strokeWidth: 2,
+                          color: Colors.white.withValues(alpha: 0.95),
+                          pattern: StrokePattern.dashed(
+                            segments: const [8, 6],
+                          ),
+                        ),
+                      ],
+                    ],
+                  ),
                 if (arrowMarkers.isNotEmpty) MarkerLayer(markers: arrowMarkers),
                 if (labelSegments.isNotEmpty)
                   _SegmentLabelLayer(segments: labelSegments),
+                // The home airport, like stays, sits outside the clusterer
+                // and beneath the numbered pins: it is a fixed journey
+                // endpoint, not an itinerary stop.
+                if (home != null)
+                  MarkerLayer(
+                    markers: [
+                      Marker(
+                        point: home.point,
+                        // Transparent 44px halo around the 26px body; the box
+                        // stays centered on the coordinate (see _pinHitBox).
+                        width: _pinHitBox,
+                        height: _pinHitBox,
+                        child: _HomePin(
+                          message: l10n.mapHomeAirport(home.label),
+                        ),
+                      ),
+                    ],
+                  ),
                 // Stays live in their own layer, outside the clusterer: a trip has
                 // few of them and "where am I sleeping" should never collapse into
                 // an anonymous count bubble with sightseeing pins. Drawn beneath
@@ -681,6 +831,51 @@ class _Pin extends StatelessWidget {
           color: Colors.white,
           fontSize: 11,
           fontWeight: FontWeight.bold,
+        ),
+      ),
+    );
+  }
+}
+
+/// The home-airport marker: a rounded square with a takeoff glyph in the
+/// flights accent color — same family treatment as [_StayPin] (white ring,
+/// shadow, square-not-round), distinct from both stays and itinerary dots.
+/// Tap shows a self-contained tooltip ("Home airport (EWR)").
+class _HomePin extends StatelessWidget {
+  /// Pre-localized tooltip text.
+  final String message;
+
+  const _HomePin({required this.message});
+
+  @override
+  Widget build(BuildContext context) {
+    // The tooltip's tap detector fills the marker's [_pinHitBox] box, so the
+    // whole transparent halo around the 26px square triggers it.
+    return Tooltip(
+      message: message,
+      triggerMode: TooltipTriggerMode.tap,
+      child: Center(
+        child: Container(
+          width: 26,
+          height: 26,
+          decoration: BoxDecoration(
+            color: AppColors.toolFlights,
+            borderRadius: BorderRadius.circular(7),
+            border: Border.all(color: Colors.white, width: 2),
+            boxShadow: [
+              BoxShadow(
+                color: Colors.black.withValues(alpha: 0.35),
+                blurRadius: 4,
+                offset: const Offset(0, 1),
+              ),
+            ],
+          ),
+          alignment: Alignment.center,
+          child: const Icon(
+            Icons.flight_takeoff,
+            size: 14,
+            color: Colors.white,
+          ),
         ),
       ),
     );

--- a/src/packages/flutter-app/test/trip_map_screen_test.dart
+++ b/src/packages/flutter-app/test/trip_map_screen_test.dart
@@ -1,8 +1,11 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:latlong2/latlong.dart';
 
 import 'package:travel_route_planner/models/accommodation.dart';
 import 'package:travel_route_planner/models/itinerary_item.dart';
+import 'package:travel_route_planner/providers/flights_provider.dart';
 import 'package:travel_route_planner/screens/trip_map_screen.dart';
 import 'package:travel_route_planner/widgets/map_day_chips.dart';
 
@@ -29,23 +32,33 @@ Widget _app({
   EdgeInsets viewPadding = EdgeInsets.zero,
   void Function(int? day)? onAddPlace,
   String title = 'Paris getaway',
+  String? homeAirport,
+  LatLng? firstCityPoint,
+  LatLng? lastCityPoint,
+  List<Override> overrides = const [],
 }) {
-  return MaterialApp(
-    localizationsDelegates: testLocalizationsDelegates,
-    builder: (context, child) => MediaQuery(
-      data: MediaQuery.of(
-        context,
-      ).copyWith(padding: viewPadding, viewPadding: viewPadding),
-      child: child!,
-    ),
-    home: TripMapScreen(
-      title: title,
-      itemsForDay: (_) => _items,
-      staysForDay: (_) => const <Accommodation>[],
-      segmentLabels: const {},
-      dayCount: 3,
-      onDaySelected: (_) {},
-      onAddPlace: onAddPlace,
+  return ProviderScope(
+    overrides: overrides,
+    child: MaterialApp(
+      localizationsDelegates: testLocalizationsDelegates,
+      builder: (context, child) => MediaQuery(
+        data: MediaQuery.of(
+          context,
+        ).copyWith(padding: viewPadding, viewPadding: viewPadding),
+        child: child!,
+      ),
+      home: TripMapScreen(
+        title: title,
+        itemsForDay: (_) => _items,
+        staysForDay: (_) => const <Accommodation>[],
+        segmentLabels: const {},
+        dayCount: 3,
+        onDaySelected: (_) {},
+        onAddPlace: onAddPlace,
+        homeAirport: homeAirport,
+        firstCityPoint: firstCityPoint,
+        lastCityPoint: lastCityPoint,
+      ),
     ),
   );
 }
@@ -113,6 +126,87 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.byIcon(Icons.add_location_alt_outlined), findsNothing);
+  });
+
+  group('home-airport legs', () {
+    // Newark, far enough from the Paris fixtures that the fit visibly widens.
+    const homePoint = (lat: 40.6895, lng: -74.1745);
+    final firstCity = LatLng(_items.first.latitude, _items.first.longitude);
+    final lastCity = LatLng(_items.last.latitude, _items.last.longitude);
+
+    Widget appWithHome() => _app(
+          homeAirport: 'EWR',
+          firstCityPoint: firstCity,
+          lastCityPoint: lastCity,
+          overrides: [
+            homeAirportPointProvider('EWR')
+                .overrideWith((ref) async => homePoint),
+          ],
+        );
+
+    Future<void> tapDay(WidgetTester tester, String label) async {
+      await tester.tap(
+        find.descendant(
+          of: find.byType(MapDayChips),
+          matching: find.text(label),
+        ),
+      );
+      await tester.pumpAndSettle();
+    }
+
+    testWidgets(
+      'home pin shows on All and the endpoint days, hides mid-trip',
+      (tester) async {
+        await tester.pumpWidget(appWithHome());
+        await tester.pumpAndSettle();
+
+        // "All": both legs → home pin present.
+        expect(find.byIcon(Icons.flight_takeoff), findsOneWidget);
+
+        // Mid-trip day: neither leg belongs to it → no orphan pin.
+        await tapDay(tester, 'Day 2');
+        expect(find.byIcon(Icons.flight_takeoff), findsNothing);
+
+        // Day 1 carries the outbound leg, the last day the return leg.
+        await tapDay(tester, 'Day 1');
+        expect(find.byIcon(Icons.flight_takeoff), findsOneWidget);
+        await tapDay(tester, 'Day 3');
+        expect(find.byIcon(Icons.flight_takeoff), findsOneWidget);
+        expect(tester.takeException(), isNull);
+      },
+    );
+
+    testWidgets('unresolved home airport renders the map as before', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _app(
+          homeAirport: 'EWR',
+          firstCityPoint: firstCity,
+          lastCityPoint: lastCity,
+          overrides: [
+            // Lookup failed / no coordinates → provider contract yields null.
+            homeAirportPointProvider('EWR').overrideWith((ref) async => null),
+          ],
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(Icons.flight_takeoff), findsNothing);
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('no saved home airport never touches the provider', (
+      tester,
+    ) async {
+      // No override registered: a provider read would throw in this scope if
+      // the network path were exercised.
+      await tester.pumpWidget(_app());
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(Icons.flight_takeoff), findsNothing);
+      expect(tester.takeException(), isNull);
+    });
   });
 
   testWidgets('long titles ellipsize instead of overflowing at 360px', (

--- a/src/packages/flutter-app/test/trip_map_test.dart
+++ b/src/packages/flutter-app/test/trip_map_test.dart
@@ -372,6 +372,104 @@ void main() {
     expect(find.text('7'), findsNothing);
   });
 
+  group('home-airport overlay', () {
+    // Newark — a transatlantic hop from the Paris fixtures, so its inclusion
+    // in the camera fit is unambiguous.
+    const homePoint = LatLng(40.6895, -74.1745);
+    final home = TripMapHome(
+      point: homePoint,
+      label: 'EWR',
+      outboundTo: LatLng(items.first.latitude, items.first.longitude),
+      returnFrom: LatLng(items.last.latitude, items.last.longitude),
+    );
+
+    testWidgets('default home: null renders no pin and no extra arrows', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(_host(TripMap(items: items)));
+      await tester.pump();
+
+      expect(find.byIcon(Icons.flight_takeoff), findsNothing);
+      // Exactly the one itinerary-leg arrow between the two fixtures.
+      expect(find.byIcon(Icons.navigation), findsOneWidget);
+    });
+
+    testWidgets('overlay adds the pin and two leg arrows, numbering intact', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(_host(TripMap(items: items, home: home)));
+      await tester.pump();
+      await tester.pump();
+
+      expect(find.byIcon(Icons.flight_takeoff), findsOneWidget);
+      // Itinerary arrow + outbound + return.
+      expect(find.byIcon(Icons.navigation), findsNWidgets(3));
+      // At the whole-journey zoom the two Paris pins collapse into a cluster
+      // bubble; its count proves the home point never joined [mapped] (a "3"
+      // here would mean the overlay leaked into the numbered pins).
+      expect(find.text('2'), findsOneWidget);
+      expect(find.text('3'), findsNothing);
+
+      // Whole-journey framing: the initial fit includes home and the trip.
+      final bounds = _camera(tester).visibleBounds;
+      expect(bounds.contains(homePoint), isTrue);
+      for (final it in items) {
+        expect(bounds.contains(LatLng(it.latitude, it.longitude)), isTrue);
+      }
+    });
+
+    testWidgets('overlay arriving after mount refits to include home', (
+      WidgetTester tester,
+    ) async {
+      // Mount without home (the IATA lookup is still pending)...
+      await tester.pumpWidget(_host(TripMap(items: items)));
+      await tester.pump();
+      expect(_camera(tester).visibleBounds.contains(homePoint), isFalse);
+
+      // ...then it resolves: didUpdateWidget's fit-set comparison must refit.
+      await tester.pumpWidget(_host(TripMap(items: items, home: home)));
+      await tester.pump(); // frame scheduling the post-frame re-fit
+      await tester.pump(); // camera moved
+
+      expect(_camera(tester).visibleBounds.contains(homePoint), isTrue);
+    });
+
+    testWidgets('legs crossing the antimeridian drop the whole overlay', (
+      WidgetTester tester,
+    ) async {
+      final fijiItems = [
+        _item(0, 'Suva', -18.1416, -178.4419),
+        _item(1, 'Nadi', -17.7765, -177.4356),
+      ];
+      final crossingHome = TripMapHome(
+        point: const LatLng(35.5494, 139.7798), // Tokyo, >180° of lng away
+        label: 'HND',
+        outboundTo: LatLng(fijiItems.first.latitude, fijiItems.first.longitude),
+        returnFrom: LatLng(fijiItems.last.latitude, fijiItems.last.longitude),
+      );
+
+      await tester.pumpWidget(
+        _host(TripMap(items: fijiItems, home: crossingHome)),
+      );
+      await tester.pump();
+
+      // No pin, and only the itinerary arrow — a long-way-around line on the
+      // single-world map would be worse than omitting the legs.
+      expect(find.byIcon(Icons.flight_takeoff), findsNothing);
+      expect(find.byIcon(Icons.navigation), findsOneWidget);
+    });
+
+    testWidgets('home alone must not summon a map (empty-state guard)', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(_host(TripMap(items: const [], home: home)));
+      await tester.pump();
+
+      expect(find.text('No mapped places'), findsOneWidget);
+      expect(find.byIcon(Icons.flight_takeoff), findsNothing);
+    });
+  });
+
   testWidgets('interactive: false hides the zoom/reset controls', (
     WidgetTester tester,
   ) async {


### PR DESCRIPTION
## Summary
- Friction-log item: "Map doesn't show arrows to and from home airport." The full-screen trip map now draws dashed, arrowed legs from the home airport to the trip's first city and from the last city back home, plus a distinct home pin (flight-takeoff glyph, IATA tooltip) — and auto-fits the whole journey.
- Inline map card and shared trip views are behaviorally unchanged (`home: null` default) so day-to-day framing stays tight; per product decision the whole-journey view lives on the tap-to-expand map only, for all travel modes.
- Duffel `/places/suggestions` parse now carries `latitude`/`longitude` onto `Airport` (`*float64` + `omitempty`, so coordless entries stay byte-identical); new `homeAirportPointProvider` resolves the saved home-airport IATA to coordinates (session-cached, errors → null → no legs).
- Home legs render as separate map layers: pin numbering, segment-label adjacency, and marker clustering are untouched. Legs spanning >180° of longitude are dropped (the single-world `AppMapCrs` has no longitude wrap; documented on `TripMapHome`).
- Day-chip semantics: outbound leg on All/Day 1, return leg on All/last day; mid-trip days show no orphan home pin. Endpoints come from `_locationGroupRanges` (same derivation the booking todos trust), not the filter-sensitive first/last mapped pin.

## Testing
- `go build ./... && go test ./...` green, incl. new `TestPlaceSuggestionsCarriesCoordinates` (coords parse + omitempty byte-stability).
- `flutter analyze` clean (3 pre-existing infos in untouched `route_response.dart`); full `flutter test` green (631 tests).
- New widget tests: TripMap home overlay (pin + 2 arrows, cluster count proves no numbering leak, async null→value refit, antimeridian drop, empty-state guard) and TripMapScreen day-chip visibility / graceful-degradation / provider-untouched cases.
- Live Duffel verification: `places/suggestions?query=BOS` returns lat/lng on `airport`-type entries (city-type omits them — handled).

🤖 Generated with [Claude Code](https://claude.com/claude-code)