### PR TITLE
feat(flutter): trip detail trailing cluster leads with Trip health

### DIFF
--- a/docs/friction-log.md
+++ b/docs/friction-log.md
@@ -5,6 +5,21 @@ build queue. Priority when picking work: **breakage > friction in features
 actually used > ideas that recur across ≥2 sessions**. Tag entries `[app]`
 (dogfooding the product) or `[dev]` (workflow/tooling). Newest first.
 
+## 2026-08-04 — trip-detail dogfooding (cluster order)
+
+- **[app] Friction recurred → fixed (reorder, not relocation):** the 08-03
+  "keep Packing & prep / Budget inline" resolution flagged reachability as
+  the residual risk, and it recurred the very next day — on a long trip,
+  two empty rows ("No items yet" / "Not tracked yet") sat ABOVE an amber
+  11-to-review Trip health row. Fixed per that entry's own remedy: the
+  trailing cluster now leads with Trip health, so actionable review state
+  is met right after the itinerary and the empty rows trail at the true
+  page bottom (one-line reorder + an order-contract widget test). Menus
+  were re-considered and re-rejected for the same reasons as 08-03:
+  glanceable state, the screen deliberately has no overflow menu, the
+  share menu's gating (owner-only, hidden offline) can't host
+  viewer-visible sections, and there is still zero usage telemetry.
+
 ## 2026-08-04 — trip-detail dogfooding (late night)
 
 - **[app] BREAKAGE → fixed (specs/set-leg-dates):** asked the refine chat to

--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -3883,8 +3883,9 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
   String _fmtDayHeader(DateTime d) => DateFormat.MMMEd().format(d);
 
   // ── Trailing collapsed sections ─────────────────────────────────────────
-  // Bookings / Packing / Budget / Trip health end the page as one-line
-  // summary rows, closed by default. Summary data comes from watches HERE in
+  // Trip health / Packing / Budget end the page as one-line summary rows,
+  // closed by default — health first so its actionable review pill is met
+  // before the empty-state rows. Summary data comes from watches HERE in
   // the parent — the section widgets are only mounted while expanded, so a
   // child-side watch could never feed a collapsed row's counts.
 
@@ -4961,9 +4962,13 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
                                 gutter, AppSpacing.sm, gutter, 96),
                             sliver: SliverToBoxAdapter(
                               child: _sectionCluster([
+                                  // Health first: it carries actionable state
+                                  // (the review pill), so it's met right after
+                                  // the itinerary; empty Packing/Budget rows
+                                  // trail at the true page bottom.
+                                  _healthSectionRow(trip, theme),
                                   _packingSectionRow(trip, theme),
                                   _budgetSectionRow(trip, theme),
-                                  _healthSectionRow(trip, theme),
                                 ]),
                             ),
                           ),

--- a/src/packages/flutter-app/lib/widgets/collapsible_section.dart
+++ b/src/packages/flutter-app/lib/widgets/collapsible_section.dart
@@ -4,8 +4,8 @@ import '../theme/spacing.dart';
 
 /// A one-line section row (icon · title · summary · pill · chevron) that
 /// expands in place. The trip detail page renders its trailing sections
-/// (Bookings, Packing, Budget, Trip health) behind these rows, closed by
-/// default, so the page ends in a quiet index instead of four full sections.
+/// (Trip health, Packing, Budget) behind these rows, closed by default, so
+/// the page ends in a quiet index instead of three full sections.
 ///
 /// The parent owns [expanded]: trip detail keeps the set of open sections in
 /// screen state (like its city/day collapse sets), so expansion survives

--- a/src/packages/flutter-app/test/trip_detail_fix_actions_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_fix_actions_test.dart
@@ -14,11 +14,15 @@ import 'package:travel_route_planner/services/accommodations_api_service.dart';
 import 'package:travel_route_planner/services/transport_api_service.dart';
 import 'package:travel_route_planner/services/checklist_api_service.dart';
 import 'package:travel_route_planner/models/checklist_item.dart';
+import 'package:travel_route_planner/services/budget_api_service.dart';
+import 'package:travel_route_planner/models/budget.dart';
+import 'package:travel_route_planner/models/expense.dart';
 import 'package:travel_route_planner/providers/trips_provider.dart';
 import 'package:travel_route_planner/providers/trip_review_provider.dart';
 import 'package:travel_route_planner/providers/accommodations_provider.dart';
 import 'package:travel_route_planner/providers/transport_provider.dart';
 import 'package:travel_route_planner/providers/checklist_provider.dart';
+import 'package:travel_route_planner/providers/budget_provider.dart';
 import 'package:travel_route_planner/screens/trip_detail_screen.dart';
 import 'package:travel_route_planner/widgets/booking_sheets.dart';
 
@@ -111,6 +115,18 @@ class _FakeChecklistApiService extends ChecklistApiService {
   }
 }
 
+/// Loaded-but-empty budget: enough for the collapsed Budget row to render
+/// ("Not tracked yet") without a target or expenses.
+class _FakeBudgetApiService extends BudgetApiService {
+  _FakeBudgetApiService() : super(ApiClient(baseUrl: 'http://test'));
+
+  @override
+  Future<Budget> getBudget(String tripId) async => const Budget();
+
+  @override
+  Future<List<Expense>> listExpenses(String tripId) async => const [];
+}
+
 ItineraryItem _item(int pos, String name, String address, String category,
         {int? day}) =>
     ItineraryItem(
@@ -150,6 +166,7 @@ Future<void> _pumpScreen(
   _FakeAccommodationsApiService? accommodations,
   _FakeTransportApiService? transport,
   _FakeChecklistApiService? checklist,
+  _FakeBudgetApiService? budget,
 }) async {
   _useTallViewport(tester);
   await tester.pumpWidget(
@@ -164,6 +181,8 @@ Future<void> _pumpScreen(
           transportApiServiceProvider.overrideWithValue(transport),
         if (checklist != null)
           checklistApiServiceProvider.overrideWithValue(checklist),
+        if (budget != null)
+          budgetApiServiceProvider.overrideWithValue(budget),
       ],
       child: MaterialApp(
       localizationsDelegates: testLocalizationsDelegates,home: TripDetailScreen(tripId: 't1')),
@@ -331,5 +350,32 @@ void main() {
     expect(inSheet('Naxos'), findsOneWidget);
     // Prefilled departure date shows on the date button.
     expect(inSheet('2026-08-03'), findsOneWidget);
+  });
+
+  testWidgets('trailing cluster leads with Trip health, empty rows trail',
+      (tester) async {
+    // Layout contract (friction-log 2026-08-04): the cluster is ordered
+    // Trip health → Packing & prep → Budget, so actionable review state is
+    // met before the empty-state rows.
+    final review = _FakeReviewApiService([
+      _finding('packing', 'No umbrella for rainy Athens',
+          const FindingFix(
+              action: 'add_packing',
+              label: 'Add to list',
+              packingItem: 'Umbrella',
+              packingCategory: 'general')),
+    ]);
+    await _pumpScreen(tester,
+        trip: _trip(),
+        review: review,
+        checklist: _FakeChecklistApiService(),
+        budget: _FakeBudgetApiService());
+
+    // The tall test viewport lays out the whole cluster in one frame.
+    final healthY = tester.getTopLeft(find.text('Trip health')).dy;
+    final packingY = tester.getTopLeft(find.text('Packing & prep')).dy;
+    final budgetY = tester.getTopLeft(find.text('Budget')).dy;
+    expect(healthY, lessThan(packingY));
+    expect(packingY, lessThan(budgetY));
   });
 }


### PR DESCRIPTION
## Summary
- Reorders the trip-detail trailing cluster to **Trip health → Packing & prep → Budget** so the actionable review pill is met right after the itinerary and the empty-state rows ("No items yet" / "Not tracked yet") trail at the true page bottom.
- Keeps Packing & prep and Budget **inline** — re-affirms the 2026-08-03 friction-log resolution (menus would hide glanceable state; the screen deliberately has no overflow menu; the share menu's owner-only+online gating can't host viewer-visible sections). This is the "reachability, not relocation" remedy that entry prescribed, after the flagged friction recurred during dogfooding.
- Updates the stale doc comments (banner comment still mentioned the retired Bookings section; `CollapsibleSection` class doc likewise) and appends the friction-log entry.
- Adds an order-contract widget test (`trip_detail_fix_actions_test.dart`), including a loaded-but-empty budget fake so all three collapsed rows render through the real screen.

## Testing
- `flutter analyze`: only the 3 pre-existing info lints in `route_response.dart` (present on main; CI runs `--no-fatal-infos`).
- `flutter test`: full suite **632/632 passed**, including the new order-contract test and the 360×690 overflow-floor contract.
- Manual dev-stack eyeball skipped deliberately: the new test drives the real `TripDetailScreen` and asserts the exact vertical order with real localized titles; no divider/spacing logic changed (`_sectionCluster` untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)