### PR TITLE
feat(map): destination-numbered trip overview on the All view

### DIFF
--- a/src/packages/flutter-app/lib/screens/shared_trip_screen.dart
+++ b/src/packages/flutter-app/lib/screens/shared_trip_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:latlong2/latlong.dart' show LatLng;
 import '../l10n/l10n.dart';
 import '../models/accommodation.dart';
 import '../models/itinerary_item.dart';
@@ -14,6 +15,7 @@ import '../theme/spacing.dart';
 import '../utils/errors.dart';
 import '../utils/trip_days.dart';
 import '../utils/trip_format.dart';
+import '../utils/trip_legs.dart';
 import '../widgets/empty_state.dart';
 import '../widgets/page_container.dart';
 import '../widgets/section_header.dart';
@@ -102,24 +104,20 @@ class _SharedTripBodyState extends ConsumerState<_SharedTripBody> {
 
   Trip get _trip => widget.shared.trip;
 
-  /// Groups items by hub city (day_trip_from ?? city) in itinerary order —
-  /// the same locality rule the owner's trip detail uses.
+  /// Groups items by hub city in itinerary order — the same shared [tripLegs]
+  /// rule the owner's trip detail uses (day_trip_from ?? city ?? a city
+  /// parsed from the address).
   List<({String label, List<ItineraryItem> items})> _groups(
       AppLocalizations l10n) {
-    final items = _trip.items ?? const <ItineraryItem>[];
-    final groups = <({String label, List<ItineraryItem> items})>[];
-    for (final it in items) {
-      final hub = (it.dayTripFrom?.trim().isNotEmpty ?? false)
-          ? it.dayTripFrom!.trim()
-          : (it.city?.trim().isNotEmpty ?? false)
-              ? it.city!.trim()
-              : l10n.sharedPlacesGroup;
-      if (groups.isEmpty || groups.last.label != hub) {
-        groups.add((label: hub, items: <ItineraryItem>[]));
-      }
-      groups.last.items.add(it);
-    }
-    return groups;
+    return [
+      for (final leg in tripLegs(_trip.items ?? const <ItineraryItem>[]))
+        (
+          label: leg.label == kOtherPlacesLabel
+              ? l10n.sharedPlacesGroup
+              : leg.label,
+          items: leg.items,
+        ),
+    ];
   }
 
   /// Routes through sign-in if needed; true when a session exists after.
@@ -246,6 +244,21 @@ class _SharedTripBodyState extends ConsumerState<_SharedTripBody> {
                     DateTime(tripStart.year, tripStart.month,
                         tripStart.day + _selectedDay! - 1)))
                 .toList();
+    // Trip-overview destination pins (All chip only): one numbered pin per
+    // city leg, from the unfiltered itinerary. Label-only tooltips — the
+    // owner-side date allocation doesn't exist on this read-only view.
+    final destinations = _selectedDay != null
+        ? null
+        : <TripMapDestination>[
+            for (final leg in tripLegs(items))
+              if (leg.coord != null)
+                TripMapDestination(
+                  label: leg.label == kOtherPlacesLabel
+                      ? l10n.sharedPlacesGroup
+                      : leg.label,
+                  point: LatLng(leg.coord!.lat, leg.coord!.lng),
+                ),
+          ];
 
     return Stack(
       children: [
@@ -292,6 +305,7 @@ class _SharedTripBodyState extends ConsumerState<_SharedTripBody> {
                               child: TripMap(
                                 items: dayItems,
                                 accommodations: dayStays,
+                                destinations: destinations,
                                 selectedPosition: _selectedPosition,
                                 fitSignature: _selectedDay,
                                 // Keep fitted markers clear of the chip row

--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -49,6 +49,7 @@ import '../utils/share_link.dart';
 import '../utils/tracked_launch.dart';
 import '../utils/trip_days.dart';
 import '../utils/trip_format.dart';
+import '../utils/trip_legs.dart';
 import '../widgets/add_itinerary_item_dialog.dart';
 import '../widgets/add_to_trip_sheet.dart';
 import '../widgets/app_map.dart';
@@ -80,8 +81,9 @@ typedef _Coord = ({double lat, double lng});
 
 /// Canonical group key for items whose locality can't be resolved. It keys the
 /// collapse/header registries and gates refine/events/local sections, so it is
-/// NEVER translated — only its display label is (specs/i18n-spanish).
-const _kOtherPlaces = 'Other places';
+/// NEVER translated — only its display label is (specs/i18n-spanish). Now
+/// canonically defined next to the shared leg split (utils/trip_legs.dart).
+const _kOtherPlaces = kOtherPlacesLabel;
 
 /// Display text for a city-group label: the canonical [_kOtherPlaces] key gets
 /// a translated label, every real city keeps the name as-is.
@@ -1873,20 +1875,13 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
   }
 
   /// The group an item belongs to: its day-trip hub city when set, else its own
-  /// city. Day trips (e.g. Versailles) thus fold under the hub (e.g. Paris).
-  String? _hubOf(ItineraryItem item) {
-    final h = item.dayTripFrom?.trim();
-    if (h != null && h.isNotEmpty) return h;
-    return _cityOf(item);
-  }
+  /// city (the shared rule in utils/trip_legs.dart).
+  String? _hubOf(ItineraryItem item) => hubOf(item);
 
   /// The city an item belongs to: the AI-assigned [ItineraryItem.city] when set,
-  /// otherwise a best-effort parse of the formatted address.
-  String? _cityOf(ItineraryItem item) {
-    final c = item.city?.trim();
-    if (c != null && c.isNotEmpty) return c;
-    return _cityFromAddress(item.address);
-  }
+  /// otherwise a best-effort parse of the formatted address (shared rule in
+  /// utils/trip_legs.dart).
+  String? _cityOf(ItineraryItem item) => cityOf(item);
 
   /// True for the AI's "city filler" placeholder — an item whose name is just
   /// the city it renders under (e.g. name 'Prague', city 'Prague'), emitted for
@@ -1899,31 +1894,9 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
     return eq(_cityOf(item)) || eq(item.dayTripFrom);
   }
 
-  /// Fallback city from a formatted address. Drops the country (last segment)
-  /// and strips postal-code tokens from the segment before it, e.g.
-  /// "Av. ..., 1400-206 Lisboa, Portugal" -> "Lisboa"; a bare "Paris" stays as is.
-  String? _cityFromAddress(String? address) {
-    if (address == null) return null;
-    final parts = address
-        .split(',')
-        .map((s) => s.trim())
-        .where((s) => s.isNotEmpty)
-        .toList();
-    if (parts.isEmpty) return null;
-    if (parts.length == 1) return parts.first;
-    final candidate = parts[parts.length - 2]; // segment before the country
-    final tokens = candidate
-        .split(RegExp(r'\s+'))
-        .where((t) =>
-            !RegExp(r'^[0-9][0-9\-]*$').hasMatch(t)) // drop postal tokens
-        .toList();
-    final city = tokens.join(' ').trim();
-    return city.isEmpty ? candidate : city;
-  }
-
-  /// Groups items into consecutive runs sharing the same locality, labelling
-  /// each run with the date range precomputed for that location (keyed by the
-  /// first item's position).
+  /// Groups items into consecutive runs sharing the same locality (the shared
+  /// [tripLegs] split), labelling each run with the date range precomputed for
+  /// that location (keyed by the first item's position).
   ///
   /// [label] is the display city and stays shared across runs (it feeds the
   /// per-city weather/events/local-intel lookups). [key] identifies the *run*:
@@ -1943,33 +1916,15 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
     List<ItineraryItem> items,
     Map<int, String> locationDates,
   ) {
-    final groups = <({
-      String key,
-      String label,
-      String? dateRange,
-      List<ItineraryItem> items
-    })>[];
-    final seen = <String, int>{};
-    String? currentKey;
-    List<ItineraryItem>? current;
-    for (final item in items) {
-      final locality = _hubOf(item);
-      if (current == null || locality != currentKey) {
-        current = [];
-        currentKey = locality;
-        final label = locality ?? _kOtherPlaces;
-        final n = (seen[label] ?? 0) + 1;
-        seen[label] = n;
-        groups.add((
-          key: n == 1 ? label : '$label#$n',
-          label: label,
-          dateRange: locationDates[item.position],
-          items: current,
-        ));
-      }
-      current.add(item);
-    }
-    return groups;
+    return [
+      for (final leg in tripLegs(items))
+        (
+          key: leg.key,
+          label: leg.label,
+          dateRange: locationDates[leg.items.first.position],
+          items: leg.items,
+        ),
+    ];
   }
 
   /// Renders a hub group's items as slivers, split into "Day N" sub-sections
@@ -3660,23 +3615,20 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
 
   /// Maps each itinerary item's position to its location's formatted date range.
   /// Delegates to [_locationGroupRanges] so the itinerary labels and the booking
-  /// checklist derive dates the same way.
+  /// checklist derive dates the same way. The two derivations index-align by
+  /// construction: both run the same [tripLegs] split over the same items.
   Map<int, String> _locationDates(Trip trip) {
     final items = trip.items ?? const <ItineraryItem>[];
     if (items.isEmpty) return const {};
     final ranges = _locationGroupRanges(trip);
+    final legs = tripLegs(items);
     final result = <int, String>{};
-    var gi = -1;
-    String? currentKey;
-    for (final item in items) {
-      final locality = _hubOf(item);
-      if (gi < 0 || locality != currentKey) {
-        gi++;
-        currentKey = locality;
-      }
+    for (var gi = 0; gi < legs.length; gi++) {
       final r = ranges[gi];
-      if (r.start != null && r.end != null) {
-        result[item.position] = _formatRange(r.start!, r.end!);
+      if (r.start == null || r.end == null) continue;
+      final text = _formatRange(r.start!, r.end!);
+      for (final item in legs[gi].items) {
+        result[item.position] = text;
       }
     }
     return result;
@@ -3694,30 +3646,21 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
     // letting them back in via _accDateRangeFor would freeze the ranges.
     final stays = _confirmedStays(trip);
 
-    // Canonical locality runs over the full itinerary.
-    final groups = <List<ItineraryItem>>[];
-    String? currentKey;
-    for (final item in items) {
-      final locality = _hubOf(item);
-      if (groups.isEmpty || locality != currentKey) {
-        groups.add([]);
-        currentKey = locality;
-      }
-      groups.last.add(item);
-    }
+    // Canonical locality runs over the full itinerary (shared split).
+    final legs = tripLegs(items);
 
     // Auto-split the trip span across groups, weighted by item count.
     final start = DateTime.tryParse(trip.startDate ?? '');
     final end = DateTime.tryParse(trip.endDate ?? '');
     final auto =
-        List<({DateTime start, DateTime end})?>.filled(groups.length, null);
+        List<({DateTime start, DateTime end})?>.filled(legs.length, null);
     if (start != null && end != null && !end.isBefore(start)) {
       final totalDays = end.difference(start).inDays + 1;
-      final n = groups.length;
+      final n = legs.length;
       if (n <= totalDays) {
         // Enough days: give each location a contiguous slice weighted by size.
-        final counts =
-            _allocateDays(totalDays, [for (final g in groups) g.length]);
+        final counts = _allocateDays(
+            totalDays, [for (final leg in legs) leg.items.length]);
         var cursor = start;
         for (var i = 0; i < n; i++) {
           final rStart = cursor.isAfter(end) ? end : cursor;
@@ -3739,17 +3682,18 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
 
     final result =
         <({String label, DateTime? start, DateTime? end, _Coord? coord})>[];
-    for (var i = 0; i < groups.length; i++) {
-      final g = groups[i];
-      final locality = _hubOf(g.first);
-      final accRange = _accDateRangeFor(locality, stays);
-      final dayRange = _dayRangeFor(g, start);
+    for (var i = 0; i < legs.length; i++) {
+      final leg = legs[i];
+      // The raw nullable locality feeds the stay-address match — the
+      // 'Other places' placeholder label would falsely substring-match.
+      final accRange = _accDateRangeFor(leg.locality, stays);
+      final dayRange = _dayRangeFor(leg.items, start);
       final a = auto[i];
       result.add((
-        label: locality ?? _kOtherPlaces,
+        label: leg.label,
         start: accRange?.start ?? dayRange?.start ?? a?.start,
         end: accRange?.end ?? dayRange?.end ?? a?.end,
-        coord: _groupCoord(g),
+        coord: leg.coord,
       ));
     }
     return result;
@@ -3769,17 +3713,6 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
     if (arrival == null) return own;
     if (own == null || arrival.isBefore(own)) return arrival;
     return own;
-  }
-
-  /// A representative coordinate for a location group: the first item with real
-  /// coordinates. (0,0) is the "no location" sentinel for manually-added places.
-  _Coord? _groupCoord(List<ItineraryItem> group) {
-    for (final it in group) {
-      if (it.latitude != 0 || it.longitude != 0) {
-        return (lat: it.latitude, lng: it.longitude);
-      }
-    }
-    return null;
   }
 
   /// Date range for a location group from its items' AI-assigned day numbers,
@@ -4270,6 +4203,28 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
     );
   }
 
+  /// Destination pins for the trip-overview map (the All chip): one per
+  /// location group with a real coordinate, in visit order, derived from the
+  /// FULL itinerary — never the day/category-filtered view, which would shift
+  /// the numbering (the home-leg doctrine in [_openFullMap]). Ungeocoded
+  /// groups are skipped so the visible numbering stays contiguous; TripMap
+  /// falls back to per-item pins below two entries, keeping single-city trips
+  /// on place-level detail.
+  List<TripMapDestination> _mapDestinations(Trip trip) {
+    final l10n = context.l10n;
+    return [
+      for (final r in _locationGroupRanges(trip))
+        if (r.coord != null)
+          TripMapDestination(
+            label: _groupLabelText(l10n, r.label),
+            point: LatLng(r.coord!.lat, r.coord!.lng),
+            dates: r.start != null && r.end != null
+                ? _formatRange(r.start!, r.end!)
+                : null,
+          ),
+    ];
+  }
+
   /// The rounded map card shared by the wide (pinned header) and phone
   /// (scroll-away) layouts. When [expandable], the map is a static preview:
   /// an [AbsorbPointer] swallows the pin/stay gesture detectors so the whole
@@ -4287,6 +4242,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
     Widget map = TripMap(
       items: _dayFiltered(trip, _selectedDay),
       accommodations: _dayFilteredStays(trip, _selectedDay),
+      destinations: _selectedDay == null ? _mapDestinations(trip) : null,
       selectedPosition: _selectedPosition,
       // Unfiltered by day: TripMap's position+1 adjacency guard drops labels
       // across the gaps a day filter creates, and the category filter
@@ -4372,6 +4328,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
         fullscreenDialog: true,
         builder: (_) => TripMapScreen(
           title: _displayTitle(trip),
+          destinations: _mapDestinations(trip),
           homeAirport: _homeAirport,
           firstCityPoint:
               firstCoord == null ? null : LatLng(firstCoord.lat, firstCoord.lng),

--- a/src/packages/flutter-app/lib/screens/trip_map_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_map_screen.dart
@@ -52,6 +52,12 @@ class TripMapScreen extends ConsumerStatefulWidget {
   final LatLng? firstCityPoint;
   final LatLng? lastCityPoint;
 
+  /// Trip-overview destination pins, derived by the parent from the full
+  /// itinerary. Shown only under the All chip (day chips flip back to
+  /// per-item pins). Frozen at push time like the home-leg endpoints — a
+  /// silent refresh shows up on the next open.
+  final List<TripMapDestination>? destinations;
+
   const TripMapScreen({
     super.key,
     required this.title,
@@ -66,6 +72,7 @@ class TripMapScreen extends ConsumerStatefulWidget {
     this.homeAirport,
     this.firstCityPoint,
     this.lastCityPoint,
+    this.destinations,
   });
 
   @override
@@ -136,6 +143,7 @@ class _TripMapScreenState extends ConsumerState<TripMapScreen> {
               child: TripMap(
                 items: items,
                 accommodations: widget.staysForDay(_day),
+                destinations: _day == null ? widget.destinations : null,
                 selectedPosition: _selectedPosition,
                 segmentLabels: widget.segmentLabels,
                 home: _homeOverlay(),

--- a/src/packages/flutter-app/lib/utils/trip_legs.dart
+++ b/src/packages/flutter-app/lib/utils/trip_legs.dart
@@ -1,0 +1,116 @@
+// The client-side "city legs" derivation: consecutive runs of itinerary items
+// sharing a hub locality, in visit (itinerary) order. Shared by the trip
+// detail screen (grouping, location date ranges, map destinations), the
+// shared trip view, and the trip map so they can never drift apart.
+//
+// Pure like trip_days.dart: no widget/l10n imports, just the item model.
+// The server has a twin of the run split (legRuns in plan_leg_dates.go) whose
+// empty-hub rule differs on purpose — see [tripLegs].
+
+import '../models/itinerary_item.dart';
+
+/// Canonical group key/label for items whose locality can't be resolved. It
+/// keys the collapse/header registries and gates refine/events/local sections,
+/// so it is NEVER translated — screens map it to a localized display label at
+/// render time (specs/i18n-spanish).
+const String kOtherPlacesLabel = 'Other places';
+
+/// One consecutive run of same-locality itinerary items — a city leg.
+///
+/// [key] identifies the *run*: a trip that revisits a city (Athens → Fira →
+/// Oia → Fira) yields two runs with the same [label], and everything keyed
+/// per-run (header GlobalKeys, collapse sets, `key#day` day keys) must tell
+/// them apart — repeats get a `#2`, `#3`, … suffix. [locality] is the raw
+/// nullable hub for lookups that must not see the [kOtherPlacesLabel]
+/// placeholder (e.g. stay-address matching); [label] is `locality` with that
+/// placeholder applied. [coord] is a representative coordinate: the first
+/// item with real coordinates, null when the whole run is ungeocoded ((0,0)
+/// is the "no location" sentinel for manually-added places).
+typedef TripLeg = ({
+  String key,
+  String label,
+  String? locality,
+  List<ItineraryItem> items,
+  ({double lat, double lng})? coord,
+});
+
+/// The locality an item groups under: its day-trip hub city when set, else its
+/// own city. Day trips (e.g. Versailles) thus fold under the hub (e.g. Paris).
+String? hubOf(ItineraryItem item) {
+  final h = item.dayTripFrom?.trim();
+  if (h != null && h.isNotEmpty) return h;
+  return cityOf(item);
+}
+
+/// The city an item belongs to: the AI-assigned [ItineraryItem.city] when set,
+/// otherwise a best-effort parse of the formatted address.
+String? cityOf(ItineraryItem item) {
+  final c = item.city?.trim();
+  if (c != null && c.isNotEmpty) return c;
+  return cityFromAddress(item.address);
+}
+
+/// Fallback city from a formatted address. Drops the country (last segment)
+/// and strips postal-code tokens from the segment before it, e.g.
+/// "Av. ..., 1400-206 Lisboa, Portugal" -> "Lisboa"; a bare "Paris" stays as is.
+String? cityFromAddress(String? address) {
+  if (address == null) return null;
+  final parts = address
+      .split(',')
+      .map((s) => s.trim())
+      .where((s) => s.isNotEmpty)
+      .toList();
+  if (parts.isEmpty) return null;
+  if (parts.length == 1) return parts.first;
+  final candidate = parts[parts.length - 2]; // segment before the country
+  final tokens = candidate
+      .split(RegExp(r'\s+'))
+      .where(
+          (t) => !RegExp(r'^[0-9][0-9\-]*$').hasMatch(t)) // drop postal tokens
+      .toList();
+  final city = tokens.join(' ').trim();
+  return city.isEmpty ? candidate : city;
+}
+
+/// Splits [items] into consecutive same-locality runs — the trip's city legs
+/// in visit order. A null locality starts its own run and groups with adjacent
+/// null-locality items (null == null); this is deliberately the client rule,
+/// NOT the server's empty-hub-adopts-the-current-run rule (plan_leg_dates.go).
+List<TripLeg> tripLegs(List<ItineraryItem> items) {
+  final runs = <({String? locality, List<ItineraryItem> items})>[];
+  String? currentKey;
+  for (final item in items) {
+    final locality = hubOf(item);
+    if (runs.isEmpty || locality != currentKey) {
+      runs.add((locality: locality, items: <ItineraryItem>[]));
+      currentKey = locality;
+    }
+    runs.last.items.add(item);
+  }
+
+  final seen = <String, int>{};
+  final legs = <TripLeg>[];
+  for (final run in runs) {
+    final label = run.locality ?? kOtherPlacesLabel;
+    final n = (seen[label] ?? 0) + 1;
+    seen[label] = n;
+    legs.add((
+      key: n == 1 ? label : '$label#$n',
+      label: label,
+      locality: run.locality,
+      items: run.items,
+      coord: _legCoord(run.items),
+    ));
+  }
+  return legs;
+}
+
+/// The first item with real coordinates, as a leg's representative point.
+({double lat, double lng})? _legCoord(List<ItineraryItem> items) {
+  for (final it in items) {
+    if (it.latitude != 0 || it.longitude != 0) {
+      return (lat: it.latitude, lng: it.longitude);
+    }
+  }
+  return null;
+}

--- a/src/packages/flutter-app/lib/widgets/trip_map.dart
+++ b/src/packages/flutter-app/lib/widgets/trip_map.dart
@@ -57,12 +57,40 @@ class TripMapHome {
   });
 }
 
+/// A destination (city leg) pin for the trip-overview map. With at least two
+/// of these, [TripMap] renders one numbered pin per entry — 1..N in list
+/// (visit) order — instead of per-item pins, and walks the route line through
+/// their coordinates. Callers derive the list from the FULL itinerary (never
+/// a day/category-filtered view, which would shift the numbering) and pass
+/// null on day views to restore per-item stop pins.
+class TripMapDestination {
+  /// Display label for the tooltip, already localized by the caller.
+  final String label;
+
+  /// The destination's representative coordinate.
+  final LatLng point;
+
+  /// Pre-formatted date range for the tooltip; null shows the label alone.
+  final String? dates;
+
+  const TripMapDestination({
+    required this.label,
+    required this.point,
+    this.dates,
+  });
+}
+
 /// Plots a trip's itinerary on a satellite basemap: a numbered, category-tinted
 /// pin per place, a route line connecting them in itinerary order, auto-fit to
 /// the trip's extent. Tapping a pin calls [onPinTap] with that item's position.
 /// When [selectedPosition] changes the camera recenters on that place.
 /// [accommodations] render as distinct stay markers (see [_StayPin]) that join
 /// the auto-fit bounds but stay out of the route line and numbering.
+///
+/// With ≥2 [destinations] the map renders the trip-overview mode instead: one
+/// numbered pin per destination (1..N in visit order) with the route line
+/// walking the destinations — per-item pins, clustering, and travel-time
+/// labels don't render there.
 class TripMap extends StatefulWidget {
   final List<ItineraryItem> items;
   final int? selectedPosition;
@@ -110,6 +138,13 @@ class TripMap extends StatefulWidget {
   /// inline map card and shared views pass — renders exactly as before.
   final TripMapHome? home;
 
+  /// Trip-overview destination pins (see [TripMapDestination]). With ≥2
+  /// entries the map renders one numbered pin per destination instead of
+  /// per-item pins. Null or a shorter list — the default, day views, and
+  /// single-city trips — keeps per-item pins, so existing call sites are
+  /// unchanged.
+  final List<TripMapDestination>? destinations;
+
   const TripMap({
     super.key,
     required this.items,
@@ -124,6 +159,7 @@ class TripMap extends StatefulWidget {
     this.topOverlayInset = 0,
     this.interactive = true,
     this.home,
+    this.destinations,
   });
 
   /// Whether [a] would render as a stay pin: geocoded (null means "not
@@ -153,6 +189,14 @@ class _TripMapState extends State<TripMap> {
 
   static bool _hasCoords(ItineraryItem i) =>
       i.latitude != 0 || i.longitude != 0;
+
+  /// Destination (trip-overview) mode: at least two pinnable destinations
+  /// supplied. 0/1 entries — a single-city trip, or every destination
+  /// ungeocoded — falls back to per-item pins so city trips keep place-level
+  /// detail. The one home of the ≥2 rule, shared by [build] and the static
+  /// fit-point mirror.
+  static bool _destinationMode(List<TripMapDestination>? destinations) =>
+      destinations != null && destinations.length >= 2;
 
   /// [TripMapHome] after the antimeridian guard documented on the class:
   /// legs spanning more than 180° of longitude (or with equal endpoints) are
@@ -230,19 +274,23 @@ class _TripMapState extends State<TripMap> {
     } catch (_) {}
   }
 
-  /// Every coordinate the camera should frame: mapped items plus geocoded
-  /// stays, plus the home airport when its overlay has a visible leg (the
-  /// camera must never stretch to a point nothing connects to). Mirrors the
-  /// fitPoints assembled in [build]. Static so it can run against an
-  /// oldWidget's lists in [didUpdateWidget].
+  /// Every coordinate the camera should frame: destination pins (overview
+  /// mode) or mapped items, plus geocoded stays, plus the home airport when
+  /// its overlay has a visible leg (the camera must never stretch to a point
+  /// nothing connects to). Mirrors the fitPoints assembled in [build]. Static
+  /// so it can run against an oldWidget's lists in [didUpdateWidget].
   static List<LatLng> _fitPointsOf(
+    List<TripMapDestination>? destinations,
     List<ItineraryItem> items,
     List<Accommodation> accommodations,
     LatLng? homePoint,
   ) {
     final points = <LatLng>[
-      for (final it in items)
-        if (_hasCoords(it)) LatLng(it.latitude, it.longitude),
+      if (_destinationMode(destinations))
+        for (final d in destinations!) d.point
+      else
+        for (final it in items)
+          if (_hasCoords(it)) LatLng(it.latitude, it.longitude),
     ];
     for (final a in accommodations) {
       if (TripMap.stayHasCoords(a)) {
@@ -254,6 +302,7 @@ class _TripMapState extends State<TripMap> {
   }
 
   List<LatLng> _fitPoints() => _fitPointsOf(
+        widget.destinations,
         widget.items,
         widget.accommodations,
         _effectiveHome(widget.home)?.point,
@@ -276,6 +325,7 @@ class _TripMapState extends State<TripMap> {
       // flipping null → resolved (the IATA lookup completing after mount)
       // changes the fit-point set, so the camera refits to include home.
       final oldPoints = _fitPointsOf(
+        oldWidget.destinations,
         oldWidget.items,
         oldWidget.accommodations,
         _effectiveHome(oldWidget.home)?.point,
@@ -330,7 +380,11 @@ class _TripMapState extends State<TripMap> {
       }
     }
 
-    if (mapped.isEmpty && stays.isEmpty) {
+    final destMode = _destinationMode(widget.destinations);
+
+    // Destination mode always has ≥2 route points to show, even when a
+    // category lens empties the day-filtered items.
+    if (mapped.isEmpty && stays.isEmpty && !destMode) {
       return Container(
         color: theme.colorScheme.surfaceContainerHighest,
         // Keep the centered content clear of the day-chip band's *visible*
@@ -352,21 +406,25 @@ class _TripMapState extends State<TripMap> {
       );
     }
 
-    final points = mapped.map((m) => m.point).toList();
+    // The route walks the destinations (city legs) in overview mode,
+    // per-item points otherwise; pins, polyline, and arrows all follow it.
+    final routePoints = destMode
+        ? [for (final d in widget.destinations!) d.point]
+        : mapped.map((m) => m.point).toList();
     final home = _effectiveHome(widget.home);
     // Camera framing covers stays and the home airport too; the route
-    // polyline sticks to [points].
+    // polyline sticks to [routePoints].
     final fitPoints = [
-      ...points,
+      ...routePoints,
       for (final s in stays) s.point,
       if (home != null) home.point,
     ];
     final selected = _selectedPoint();
 
     // Home-airport legs (outbound home → first city, return last city →
-    // home). Kept out of [mapped]/[points]: appending there would silently
-    // reindex the numbered pins and break segment-label adjacency, so the
-    // legs get their own dashed polylines and arrow markers below.
+    // home). Kept out of [mapped]/[routePoints]: appending there would
+    // silently reindex the numbered pins and break segment-label adjacency,
+    // so the legs get their own dashed polylines and arrow markers below.
     final homeSegments = <({LatLng a, LatLng b})>[
       if (home != null && home.outboundTo != null)
         (a: home.point, b: home.outboundTo!),
@@ -377,40 +435,46 @@ class _TripMapState extends State<TripMap> {
     // Travel-time labels at the midpoint of each within-city leg (only between
     // truly adjacent itinerary stops that are both mapped). Kept as endpoint
     // records — _SegmentLabelLayer decides per camera frame which are visible.
+    // Destination mode has none: segmentLabels hold within-city legs by
+    // construction, and the overview draws only city→city legs.
     final labelSegments = <({LatLng a, LatLng b, String text})>[];
-    for (var k = 0; k < mapped.length - 1; k++) {
-      final a = mapped[k];
-      final b = mapped[k + 1];
-      if (b.item.position != a.item.position + 1) continue;
-      final label = widget.segmentLabels[a.item.position];
-      if (label == null) continue;
-      labelSegments.add((a: a.point, b: b.point, text: label));
+    if (!destMode) {
+      for (var k = 0; k < mapped.length - 1; k++) {
+        final a = mapped[k];
+        final b = mapped[k + 1];
+        if (b.item.position != a.item.position + 1) continue;
+        final label = widget.segmentLabels[a.item.position];
+        if (label == null) continue;
+        labelSegments.add((a: a.point, b: b.point, text: label));
+      }
     }
 
-    // Direction arrows on every drawn segment (each consecutive pair of mapped
+    // Direction arrows on every drawn segment (each consecutive pair of route
     // points, matching the polyline). Placed at the midpoint, or further along
     // when a travel-time label already occupies the midpoint. Placement stays
     // static even though labels hide dynamically on short legs: on such a leg
     // (< _SegmentLabelLayer.minLegPx on screen) t=0.7 vs 0.5 differs by a few
-    // px and the arrow tucks behind the pins anyway.
+    // px and the arrow tucks behind the pins anyway. In destination mode
+    // [routePoints] and [mapped] no longer align, so the label lookup (an
+    // item-mode concept) must not touch [mapped] there.
     final arrowMarkers = <Marker>[];
-    for (var k = 0; k < mapped.length - 1; k++) {
-      final a = mapped[k];
-      final b = mapped[k + 1];
-      if (a.point == b.point) continue;
-      final hasLabel =
-          b.item.position == a.item.position + 1 &&
-          widget.segmentLabels[a.item.position] != null;
+    for (var k = 0; k < routePoints.length - 1; k++) {
+      final a = routePoints[k];
+      final b = routePoints[k + 1];
+      if (a == b) continue;
+      final hasLabel = !destMode &&
+          mapped[k + 1].item.position == mapped[k].item.position + 1 &&
+          widget.segmentLabels[mapped[k].item.position] != null;
       final t = hasLabel ? 0.7 : 0.5;
       arrowMarkers.add(
         Marker(
           point: LatLng(
-            a.point.latitude + (b.point.latitude - a.point.latitude) * t,
-            a.point.longitude + (b.point.longitude - a.point.longitude) * t,
+            a.latitude + (b.latitude - a.latitude) * t,
+            a.longitude + (b.longitude - a.longitude) * t,
           ),
           width: 18,
           height: 18,
-          child: _SegmentArrow(angle: _bearing(a.point, b.point)),
+          child: _SegmentArrow(angle: _bearing(a, b)),
         ),
       );
     }
@@ -471,21 +535,21 @@ class _TripMapState extends State<TripMap> {
                 interactionOptions: interaction,
               )
             : fitPoints.length == 1
-            // Single point: bounds collapse, so center with a sensible zoom.
-            ? appMapOptions(
-                initialCenter: fitPoints.first,
-                initialZoom: 13,
-                minZoom: minZoom,
-                interactionOptions: interaction,
-              )
-            : appMapOptions(
-                initialCameraFit: CameraFit.bounds(
-                  bounds: LatLngBounds.fromPoints(fitPoints),
-                  padding: _fitPadding,
-                ),
-                minZoom: minZoom,
-                interactionOptions: interaction,
-              );
+                // Single point: bounds collapse, so center with a sensible zoom.
+                ? appMapOptions(
+                    initialCenter: fitPoints.first,
+                    initialZoom: 13,
+                    minZoom: minZoom,
+                    interactionOptions: interaction,
+                  )
+                : appMapOptions(
+                    initialCameraFit: CameraFit.bounds(
+                      bounds: LatLngBounds.fromPoints(fitPoints),
+                      padding: _fitPadding,
+                    ),
+                    minZoom: minZoom,
+                    interactionOptions: interaction,
+                  );
 
         return Stack(
           children: [
@@ -494,18 +558,18 @@ class _TripMapState extends State<TripMap> {
               options: options,
               children: [
                 ...appMapTileLayers(context),
-                if (points.length >= 2)
+                if (routePoints.length >= 2)
                   PolylineLayer(
                     polylines: [
                       // Two passes make a thin line with a soft glow that stays
                       // legible over satellite imagery.
                       Polyline(
-                        points: points,
+                        points: routePoints,
                         strokeWidth: 6,
                         color: Colors.white.withValues(alpha: 0.25),
                       ),
                       Polyline(
-                        points: points,
+                        points: routePoints,
                         strokeWidth: 2,
                         color: Colors.white.withValues(alpha: 0.95),
                       ),
@@ -583,51 +647,75 @@ class _TripMapState extends State<TripMap> {
                         ),
                     ],
                   ),
-                MarkerClusterLayerWidget(
-                  options: MarkerClusterLayerOptions(
-                    maxClusterRadius: 45,
-                    size: const Size(32, 32),
-                    padding: const EdgeInsets.all(40),
+                if (destMode)
+                  // Trip overview: one numbered pin per destination (city
+                  // leg), 1..N in visit order — a plain layer, never
+                  // clustered: a count bubble here reads as a bogus route
+                  // number at world zoom.
+                  MarkerLayer(
                     markers: [
-                      // Labels count 1..N over what this map view shows (the whole
-                      // trip on All, one day on Day N) — not the item's trip-wide
-                      // position, which reads as arbitrary once the view filters
-                      // or skips ungeocoded items.
-                      for (final (k, m) in mapped.indexed)
+                      for (final (k, d) in widget.destinations!.indexed)
                         Marker(
-                          point: m.point,
-                          // Transparent 44px halo around the 24/28px dot, tap
-                          // handling on the whole box; centered so the dot stays
-                          // anchored on its coordinate (see _pinHitBox).
+                          point: d.point,
+                          // Transparent 44px halo around the 24px dot; the
+                          // box stays centered on the coordinate (see
+                          // _pinHitBox).
                           width: _pinHitBox,
                           height: _pinHitBox,
-                          child: GestureDetector(
-                            behavior: HitTestBehavior.opaque,
-                            onTap: widget.onPinTap == null
-                                ? null
-                                : () => widget.onPinTap!(m.item.position),
-                            child: Center(
-                              child: SizedBox.square(
-                                dimension:
-                                    widget.selectedPosition == m.item.position
-                                    ? 28
-                                    : 24,
-                                child: _Pin(
-                                  label: '${k + 1}',
-                                  category: m.item.category,
-                                  selected:
-                                      widget.selectedPosition ==
-                                      m.item.position,
+                          child: _DestinationPin(
+                            label: '${k + 1}',
+                            name: d.label,
+                            dates: d.dates,
+                          ),
+                        ),
+                    ],
+                  )
+                else
+                  MarkerClusterLayerWidget(
+                    options: MarkerClusterLayerOptions(
+                      maxClusterRadius: 45,
+                      size: const Size(32, 32),
+                      padding: const EdgeInsets.all(40),
+                      markers: [
+                        // Labels count 1..N over what this map view shows (the
+                        // whole trip on All, one day on Day N) — not the item's
+                        // trip-wide position, which reads as arbitrary once the
+                        // view filters or skips ungeocoded items.
+                        for (final (k, m) in mapped.indexed)
+                          Marker(
+                            point: m.point,
+                            // Transparent 44px halo around the 24/28px dot, tap
+                            // handling on the whole box; centered so the dot
+                            // stays anchored on its coordinate (see
+                            // _pinHitBox).
+                            width: _pinHitBox,
+                            height: _pinHitBox,
+                            child: GestureDetector(
+                              behavior: HitTestBehavior.opaque,
+                              onTap: widget.onPinTap == null
+                                  ? null
+                                  : () => widget.onPinTap!(m.item.position),
+                              child: Center(
+                                child: SizedBox.square(
+                                  dimension:
+                                      widget.selectedPosition == m.item.position
+                                          ? 28
+                                          : 24,
+                                  child: _Pin(
+                                    label: '${k + 1}',
+                                    category: m.item.category,
+                                    selected: widget.selectedPosition ==
+                                        m.item.position,
+                                  ),
                                 ),
                               ),
                             ),
                           ),
-                        ),
-                    ],
-                    builder: (context, clusterMarkers) =>
-                        _ClusterBubble(count: clusterMarkers.length),
+                      ],
+                      builder: (context, clusterMarkers) =>
+                          _ClusterBubble(count: clusterMarkers.length),
+                    ),
                   ),
-                ),
                 appMapAttribution(),
               ],
             ),
@@ -797,13 +885,18 @@ class _Pin extends StatelessWidget {
   final String? category;
   final bool selected;
 
+  /// Overrides the category tint ([_DestinationPin]: one consistent color).
+  final Color? color;
+
   const _Pin({
     required this.label,
     required this.category,
     required this.selected,
+    this.color,
   });
 
-  Color _color(ColorScheme scheme) => AppColors.forCategory(category, scheme);
+  Color _color(ColorScheme scheme) =>
+      color ?? AppColors.forCategory(category, scheme);
 
   @override
   Widget build(BuildContext context) {
@@ -831,6 +924,49 @@ class _Pin extends StatelessWidget {
           color: Colors.white,
           fontSize: 11,
           fontWeight: FontWeight.bold,
+        ),
+      ),
+    );
+  }
+}
+
+/// A destination (city-leg) pin for the trip-overview mode: the same round
+/// numbered dot as itinerary pins, in one consistent color (category tinting
+/// is meaningless for a whole city). Destinations sit outside the
+/// position-based selection sync, so a tap shows a self-contained tooltip
+/// (city + dates) like [_StayPin] instead of driving [TripMap.onPinTap].
+class _DestinationPin extends StatelessWidget {
+  /// The 1..N visit-order ordinal shown in the dot.
+  final String label;
+
+  /// Display city for the tooltip, already localized by the caller.
+  final String name;
+
+  /// Pre-formatted date range; null shows the name alone.
+  final String? dates;
+
+  const _DestinationPin({
+    required this.label,
+    required this.name,
+    this.dates,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    // The tooltip's tap detector fills the marker's [_pinHitBox] box, so the
+    // whole transparent halo around the 24px dot triggers it.
+    return Tooltip(
+      message: dates == null ? name : '$name\n$dates',
+      triggerMode: TooltipTriggerMode.tap,
+      child: Center(
+        child: SizedBox.square(
+          dimension: 24,
+          child: _Pin(
+            label: label,
+            category: null,
+            selected: false,
+            color: Theme.of(context).colorScheme.primary,
+          ),
         ),
       ),
     );

--- a/src/packages/flutter-app/test/shared_trip_destination_pins_test.dart
+++ b/src/packages/flutter-app/test/shared_trip_destination_pins_test.dart
@@ -1,0 +1,164 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:flutter_map_marker_cluster/flutter_map_marker_cluster.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:travel_route_planner/models/itinerary_item.dart';
+import 'package:travel_route_planner/models/shared_trip.dart';
+import 'package:travel_route_planner/models/trip.dart';
+import 'package:travel_route_planner/providers/trips_provider.dart';
+import 'package:travel_route_planner/screens/shared_trip_screen.dart';
+import 'package:travel_route_planner/services/api_client.dart';
+import 'package:travel_route_planner/services/trips_api_service.dart';
+import 'package:travel_route_planner/widgets/map_day_chips.dart';
+import 'package:travel_route_planner/widgets/section_header.dart';
+
+import 'support/l10n_test_app.dart';
+
+class _FakeTripsApiService extends TripsApiService {
+  final SharedTrip shared;
+  _FakeTripsApiService(this.shared) : super(ApiClient(baseUrl: 'http://test'));
+
+  @override
+  Future<SharedTrip> getSharedTrip(String token) async => shared;
+}
+
+ItineraryItem _item(
+  int pos,
+  String name, {
+  String? city,
+  String? address,
+  double lat = 0,
+  double lng = 0,
+  int? day,
+}) =>
+    ItineraryItem(
+      id: 'i$pos',
+      position: pos,
+      name: name,
+      latitude: lat,
+      longitude: lng,
+      category: 'attraction',
+      city: city,
+      address: address,
+      day: day,
+    );
+
+SharedTrip _shared(List<ItineraryItem> items) => SharedTrip(
+      ownerName: 'Ann',
+      trip: Trip(
+        id: 't1',
+        title: 'Grand tour',
+        status: 'planned',
+        createdAt: '2026-06-01',
+        updatedAt: '2026-06-01',
+        startDate: '2026-09-01',
+        endDate: '2026-09-03',
+        items: items,
+      ),
+    );
+
+void main() {
+  Future<void> pumpScreen(WidgetTester tester, SharedTrip shared) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          tripsApiServiceProvider
+              .overrideWithValue(_FakeTripsApiService(shared)),
+        ],
+        child: MaterialApp(
+          localizationsDelegates: testLocalizationsDelegates,
+          home: SharedTripScreen(token: 'tok'),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  /// Pin labels scoped to the map — the shared list numbers its own tiles.
+  Finder inMap(String text) =>
+      find.descendant(of: find.byType(FlutterMap), matching: find.text(text));
+
+  testWidgets(
+      'All shows destination pins with ungeocoded legs skipped (numbering '
+      'stays contiguous); a day chip flips to item pins',
+      (WidgetTester tester) async {
+    await pumpScreen(
+      tester,
+      _shared([
+        _item(0, 'Louvre', city: 'Paris', lat: 48.8606, lng: 2.3376, day: 1),
+        // Whole leg ungeocoded: pinless, and it must not consume a number.
+        _item(1, 'Traboules', city: 'Lyon', day: 2),
+        _item(2, 'Colosseum', city: 'Rome', lat: 41.8902, lng: 12.4922, day: 3),
+      ]),
+    );
+
+    expect(find.byType(MarkerClusterLayerWidget), findsNothing);
+    expect(inMap('1'), findsOneWidget);
+    expect(inMap('2'), findsOneWidget);
+    expect(inMap('3'), findsNothing);
+
+    // Pin 2 skips pinless Lyon and lands on Rome, label-only (the shared
+    // view has no owner-side date allocation).
+    final tooltip = tester.widget<Tooltip>(
+      find.ancestor(of: inMap('2'), matching: find.byType(Tooltip)),
+    );
+    expect(tooltip.message, 'Rome');
+
+    // Day 1: per-item pins return.
+    await tester.tap(find.descendant(
+      of: find.byType(MapDayChips),
+      matching: find.text('Day 1'),
+    ));
+    await tester.pump();
+    await tester.pump();
+    expect(find.byType(MarkerClusterLayerWidget), findsOneWidget);
+    expect(inMap('1'), findsOneWidget);
+  });
+
+  testWidgets(
+      'a null-city item with a parseable address groups under the parsed city '
+      '(owner-view parity)', (WidgetTester tester) async {
+    await pumpScreen(
+      tester,
+      _shared([
+        _item(0, 'Louvre', city: 'Paris', lat: 48.8606, lng: 2.3376),
+        _item(1, 'Bouchon Daniel', address: 'Rue X, 69001 Lyon, France'),
+      ]),
+    );
+
+    // Before the shared tripLegs delegation this fell into the localized
+    // "Places" bucket; now it groups under the address-parsed city, exactly
+    // like the owner's trip detail.
+    expect(
+      find.descendant(
+        of: find.byType(SectionHeader),
+        matching: find.text('Lyon'),
+      ),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('a revisited city renders two separate groups',
+      (WidgetTester tester) async {
+    await pumpScreen(
+      tester,
+      _shared([
+        _item(0, 'Louvre', city: 'Paris', lat: 48.8606, lng: 2.3376),
+        _item(1, 'Colosseum', city: 'Rome', lat: 41.8902, lng: 12.4922),
+        _item(2, 'Orsay', city: 'Paris', lat: 48.8600, lng: 2.3266),
+      ]),
+    );
+
+    expect(
+      find.descendant(
+        of: find.byType(SectionHeader),
+        matching: find.text('Paris'),
+      ),
+      findsNWidgets(2),
+    );
+    // And on the map: three destination pins, the revisit numbered last.
+    expect(inMap('3'), findsOneWidget);
+  });
+}

--- a/src/packages/flutter-app/test/trip_detail_destination_map_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_destination_map_test.dart
@@ -1,0 +1,120 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:flutter_map_marker_cluster/flutter_map_marker_cluster.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:travel_route_planner/models/itinerary_item.dart';
+import 'package:travel_route_planner/models/trip.dart';
+import 'package:travel_route_planner/providers/trips_provider.dart';
+import 'package:travel_route_planner/screens/trip_detail_screen.dart';
+import 'package:travel_route_planner/services/api_client.dart';
+import 'package:travel_route_planner/services/trips_api_service.dart';
+import 'package:travel_route_planner/widgets/map_day_chips.dart';
+
+import 'support/l10n_test_app.dart';
+
+class _FakeTripsApiService extends TripsApiService {
+  final Trip trip;
+  _FakeTripsApiService(this.trip) : super(ApiClient(baseUrl: 'http://test'));
+
+  @override
+  Future<Trip> getTrip(String id) async => trip;
+}
+
+ItineraryItem _item(
+  int pos,
+  String name,
+  String city,
+  double lat,
+  double lng,
+  int day,
+) =>
+    ItineraryItem(
+      id: 'i$pos',
+      position: pos,
+      name: name,
+      latitude: lat,
+      longitude: lng,
+      category: 'attraction',
+      city: city,
+      day: day,
+    );
+
+void main() {
+  // Two cities so the All view crosses TripMap's ≥2-destination gate; the
+  // single-city fixtures in the other trip-detail tests deliberately never do.
+  final trip = Trip(
+    id: 't1',
+    title: 'Paris & Rome',
+    status: 'planned',
+    createdAt: '2026-06-01',
+    updatedAt: '2026-06-01',
+    startDate: '2026-09-01',
+    endDate: '2026-09-02',
+    items: [
+      _item(0, 'Louvre', 'Paris', 48.8606, 2.3376, 1),
+      _item(1, 'Orsay', 'Paris', 48.8600, 2.3266, 1),
+      _item(2, 'Colosseum', 'Rome', 41.8902, 12.4922, 2),
+    ],
+  );
+
+  Future<void> pumpScreen(WidgetTester tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          tripsApiServiceProvider.overrideWithValue(_FakeTripsApiService(trip)),
+        ],
+        child: MaterialApp(
+          localizationsDelegates: testLocalizationsDelegates,
+          home: TripDetailScreen(tripId: 't1'),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  Future<void> tapChip(WidgetTester tester, String label) async {
+    await tester.tap(find.descendant(
+      of: find.byType(MapDayChips),
+      matching: find.text(label),
+    ));
+    await tester.pump();
+    await tester.pump(); // post-frame camera re-fit
+  }
+
+  /// Pin labels scoped to the map — the itinerary list renders its own text.
+  Finder inMap(String text) =>
+      find.descendant(of: find.byType(FlutterMap), matching: find.text(text));
+
+  testWidgets(
+      'All numbers destinations 1..N in visit order; day chips flip to '
+      'per-stop pins and back', (WidgetTester tester) async {
+    await pumpScreen(tester);
+
+    // All: one pin per city, no clusterer — three items, two pins.
+    expect(find.byType(MarkerClusterLayerWidget), findsNothing);
+    expect(inMap('1'), findsOneWidget);
+    expect(inMap('2'), findsOneWidget);
+    expect(inMap('3'), findsNothing);
+
+    // Pin 2 is the second *destination* (Rome), not the second item.
+    final tooltip = tester.widget<Tooltip>(
+      find.ancestor(of: inMap('2'), matching: find.byType(Tooltip)),
+    );
+    expect(tooltip.message, startsWith('Rome'));
+
+    // Day 1: per-item stop pins return, inside the clusterer.
+    await tapChip(tester, 'Day 1');
+    expect(find.byType(MarkerClusterLayerWidget), findsOneWidget);
+    expect(inMap('1'), findsOneWidget);
+    expect(inMap('2'), findsOneWidget);
+
+    // All restores the overview.
+    await tapChip(tester, 'All');
+    expect(find.byType(MarkerClusterLayerWidget), findsNothing);
+    expect(inMap('1'), findsOneWidget);
+    expect(inMap('2'), findsOneWidget);
+    expect(inMap('3'), findsNothing);
+  });
+}

--- a/src/packages/flutter-app/test/trip_legs_test.dart
+++ b/src/packages/flutter-app/test/trip_legs_test.dart
@@ -1,0 +1,123 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:travel_route_planner/models/itinerary_item.dart';
+import 'package:travel_route_planner/utils/trip_legs.dart';
+
+ItineraryItem _item(
+  int pos, {
+  String name = 'Stop',
+  String? city,
+  String? dayTripFrom,
+  String? address,
+  double lat = 0,
+  double lng = 0,
+}) =>
+    ItineraryItem(
+      id: 'i$pos',
+      position: pos,
+      name: name,
+      latitude: lat,
+      longitude: lng,
+      city: city,
+      dayTripFrom: dayTripFrom,
+      address: address,
+    );
+
+void main() {
+  group('tripLegs', () {
+    test('splits consecutive same-locality runs in itinerary order', () {
+      final legs = tripLegs([
+        _item(0, city: 'Paris', lat: 48.86, lng: 2.34),
+        _item(1, city: 'Paris', lat: 48.85, lng: 2.33),
+        _item(2, city: 'Rome', lat: 41.9, lng: 12.5),
+      ]);
+
+      expect(legs.map((l) => l.label), ['Paris', 'Rome']);
+      expect(legs.map((l) => l.key), ['Paris', 'Rome']);
+      expect(legs.first.items.map((i) => i.position), [0, 1]);
+      expect(legs.last.items.map((i) => i.position), [2]);
+    });
+
+    test('day trips fold under their hub city', () {
+      final legs = tripLegs([
+        _item(0, city: 'Paris'),
+        _item(1, city: 'Versailles', dayTripFrom: 'Paris'),
+        _item(2, city: 'Paris'),
+      ]);
+
+      expect(legs, hasLength(1));
+      expect(legs.single.label, 'Paris');
+      expect(legs.single.items, hasLength(3));
+    });
+
+    test('null localities group together but never adopt neighbors', () {
+      final legs = tripLegs([
+        _item(0, city: 'Paris'),
+        _item(1), // no city, no address
+        _item(2),
+        _item(3, city: 'Paris'),
+      ]);
+
+      expect(legs.map((l) => l.label), ['Paris', kOtherPlacesLabel, 'Paris']);
+      expect(legs[1].locality, isNull);
+      expect(legs[1].items, hasLength(2));
+      // Run identity survives the revisit around the unresolved run.
+      expect(legs.map((l) => l.key), ['Paris', kOtherPlacesLabel, 'Paris#2']);
+    });
+
+    test('revisited cities get #2/#3 keys with a shared label', () {
+      final legs = tripLegs([
+        _item(0, city: 'Athens'),
+        _item(1, city: 'Fira'),
+        _item(2, city: 'Oia'),
+        _item(3, city: 'Fira'),
+      ]);
+
+      expect(legs.map((l) => l.label), ['Athens', 'Fira', 'Oia', 'Fira']);
+      expect(legs.map((l) => l.key), ['Athens', 'Fira', 'Oia', 'Fira#2']);
+    });
+
+    test('coord is the first geocoded item; all-(0,0) runs have none', () {
+      final legs = tripLegs([
+        _item(0, city: 'Paris'), // manually added, ungeocoded
+        _item(1, city: 'Paris', lat: 48.86, lng: 2.34),
+        _item(2, city: 'Rome'),
+      ]);
+
+      expect(legs.first.coord, (lat: 48.86, lng: 2.34));
+      expect(legs.last.coord, isNull);
+    });
+
+    test('empty input yields no legs', () {
+      expect(tripLegs(const []), isEmpty);
+    });
+  });
+
+  group('hub rule', () {
+    test('hubOf prefers a non-blank dayTripFrom over the city', () {
+      expect(
+        hubOf(_item(0, city: 'Versailles', dayTripFrom: 'Paris')),
+        'Paris',
+      );
+      expect(
+        hubOf(_item(0, city: 'Versailles', dayTripFrom: '  ')),
+        'Versailles',
+      );
+    });
+
+    test('cityOf trims and falls back through blank cities', () {
+      expect(cityOf(_item(0, city: '  ', address: 'Paris')), 'Paris');
+      expect(cityOf(_item(0)), isNull);
+    });
+
+    test('cityFromAddress strips postal tokens and the country', () {
+      expect(
+        cityFromAddress('Av. da Índia 1, 1400-206 Lisboa, Portugal'),
+        'Lisboa',
+      );
+      expect(cityFromAddress('Paris'), 'Paris');
+      expect(cityFromAddress(null), isNull);
+      expect(cityFromAddress(' , '), isNull);
+    });
+  });
+}

--- a/src/packages/flutter-app/test/trip_map_screen_test.dart
+++ b/src/packages/flutter-app/test/trip_map_screen_test.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:flutter_map_marker_cluster/flutter_map_marker_cluster.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:latlong2/latlong.dart';
@@ -8,6 +10,7 @@ import 'package:travel_route_planner/models/itinerary_item.dart';
 import 'package:travel_route_planner/providers/flights_provider.dart';
 import 'package:travel_route_planner/screens/trip_map_screen.dart';
 import 'package:travel_route_planner/widgets/map_day_chips.dart';
+import 'package:travel_route_planner/widgets/trip_map.dart';
 
 import 'support/l10n_test_app.dart';
 
@@ -35,6 +38,7 @@ Widget _app({
   String? homeAirport,
   LatLng? firstCityPoint,
   LatLng? lastCityPoint,
+  List<TripMapDestination>? destinations,
   List<Override> overrides = const [],
 }) {
   return ProviderScope(
@@ -58,6 +62,7 @@ Widget _app({
         homeAirport: homeAirport,
         firstCityPoint: firstCityPoint,
         lastCityPoint: lastCityPoint,
+        destinations: destinations,
       ),
     ),
   );
@@ -205,6 +210,48 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.byIcon(Icons.flight_takeoff), findsNothing);
+      expect(tester.takeException(), isNull);
+    });
+  });
+
+  group('destination pins (trip overview)', () {
+    const dests = [
+      TripMapDestination(label: 'Paris', point: LatLng(48.8566, 2.3522)),
+      TripMapDestination(label: 'Rome', point: LatLng(41.9028, 12.4964)),
+    ];
+
+    Finder inMap(String text) =>
+        find.descendant(of: find.byType(FlutterMap), matching: find.text(text));
+
+    Future<void> tapDay(WidgetTester tester, String label) async {
+      await tester.tap(
+        find.descendant(
+          of: find.byType(MapDayChips),
+          matching: find.text(label),
+        ),
+      );
+      await tester.pumpAndSettle();
+    }
+
+    testWidgets(
+        'All shows destination pins; day chips flip to item pins '
+        'and back', (tester) async {
+      await tester.pumpWidget(_app(destinations: dests));
+      await tester.pumpAndSettle();
+
+      // All: the overview — numbered destinations, no clusterer.
+      expect(find.byType(MarkerClusterLayerWidget), findsNothing);
+      expect(inMap('1'), findsOneWidget);
+      expect(inMap('2'), findsOneWidget);
+
+      // A day selection restores per-item pins (the fixture's two items).
+      await tapDay(tester, 'Day 1');
+      expect(find.byType(MarkerClusterLayerWidget), findsOneWidget);
+
+      await tapDay(tester, 'All');
+      expect(find.byType(MarkerClusterLayerWidget), findsNothing);
+      expect(inMap('1'), findsOneWidget);
+      expect(inMap('2'), findsOneWidget);
       expect(tester.takeException(), isNull);
     });
   });

--- a/src/packages/flutter-app/test/trip_map_test.dart
+++ b/src/packages/flutter-app/test/trip_map_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
+import 'package:flutter_map_marker_cluster/flutter_map_marker_cluster.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:latlong2/latlong.dart';
 
@@ -587,6 +588,182 @@ void main() {
 
     expect(find.text('No mapped places'), findsNothing);
     expect(find.byIcon(Icons.hotel), findsOneWidget);
+  });
+
+  group('destination mode (trip overview)', () {
+    const dests = [
+      TripMapDestination(
+        label: 'Paris',
+        point: LatLng(48.8566, 2.3522),
+        dates: 'Jun 10 – Jun 12',
+      ),
+      TripMapDestination(
+        label: 'Rome',
+        point: LatLng(41.9028, 12.4964),
+        dates: 'Jun 12 – Jun 14',
+      ),
+      TripMapDestination(label: 'Athens', point: LatLng(37.9838, 23.7275)),
+    ];
+
+    /// Pin labels scoped to the map: the trip surfaces around it render
+    /// their own numbers.
+    Finder inMap(String text) =>
+        find.descendant(of: find.byType(FlutterMap), matching: find.text(text));
+
+    testWidgets('one numbered pin per destination in visit order, unclustered',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        _host(TripMap(items: items, destinations: dests)),
+      );
+      await tester.pump();
+
+      // 1..N over the destinations — the items (which would render two pins
+      // of their own) stay off the overview entirely.
+      expect(inMap('1'), findsOneWidget);
+      expect(inMap('2'), findsOneWidget);
+      expect(inMap('3'), findsOneWidget);
+      expect(inMap('4'), findsNothing);
+      expect(find.byType(MarkerClusterLayerWidget), findsNothing);
+
+      // Order lock: pin "2" sits on the 2nd destination's coordinate.
+      final mapTopLeft = tester.getTopLeft(find.byType(FlutterMap));
+      final projected = _camera(tester).latLngToScreenOffset(dests[1].point);
+      final pinCenter = tester.getCenter(inMap('2'));
+      expect((pinCenter - (mapTopLeft + projected)).distance, lessThan(1.0));
+    });
+
+    testWidgets('a single destination falls back to per-item pins', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        _host(TripMap(items: items, destinations: [dests.first])),
+      );
+      await tester.pump();
+
+      expect(find.byType(MarkerClusterLayerWidget), findsOneWidget);
+      expect(inMap('1'), findsOneWidget);
+      expect(inMap('2'), findsOneWidget);
+    });
+
+    testWidgets('destination mode renders with no mappable items (lens-proof)',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        _host(const TripMap(items: [], destinations: dests)),
+      );
+      await tester.pump();
+
+      expect(find.text('No mapped places'), findsNothing);
+      expect(inMap('1'), findsOneWidget);
+      expect(inMap('3'), findsOneWidget);
+      // The route walks the destinations: one arrow per city→city leg.
+      expect(find.byIcon(Icons.navigation), findsNWidgets(2));
+    });
+
+    testWidgets(
+        'tap shows a city tooltip — dates when known, label alone '
+        'otherwise', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        _host(const TripMap(items: [], destinations: dests)),
+      );
+      await tester.pump();
+
+      // The overlay flow on the mid-map pin (the SE-most pin sits under the
+      // zoom/reset column, where a tap would hit the buttons instead).
+      await tester.tap(inMap('2'));
+      await tester.pump(const Duration(milliseconds: 200));
+      expect(find.text('Rome\nJun 12 – Jun 14'), findsOneWidget);
+      await tester.pump(const Duration(seconds: 3));
+      await tester.pumpAndSettle();
+
+      // Dates-less destination: label-only message, asserted on the widget.
+      final athens = tester.widget<Tooltip>(
+        find.ancestor(of: inMap('3'), matching: find.byType(Tooltip)),
+      );
+      expect(athens.message, 'Athens');
+    });
+
+    testWidgets('travel-time labels never render on the overview', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        _host(
+          TripMap(
+            items: items,
+            segmentLabels: const {0: '12 min'},
+            destinations: dests,
+          ),
+        ),
+      );
+      await tester.pump();
+
+      expect(find.text('12 min'), findsNothing);
+    });
+
+    testWidgets(
+        'stays and home legs still render; the fit frames every '
+        'destination plus home', (WidgetTester tester) async {
+      const homePoint = LatLng(40.6895, -74.1745); // Newark
+      final home = TripMapHome(
+        point: homePoint,
+        label: 'EWR',
+        outboundTo: dests.first.point,
+        returnFrom: dests.last.point,
+      );
+      const stays = [
+        Accommodation(
+          id: 'a1',
+          name: 'Hotel Roma',
+          latitude: 41.9,
+          longitude: 12.5,
+        ),
+      ];
+
+      await tester.pumpWidget(
+        _host(
+          TripMap(
+            items: items,
+            accommodations: stays,
+            home: home,
+            destinations: dests,
+          ),
+        ),
+      );
+      await tester.pump();
+      await tester.pump();
+
+      expect(find.byIcon(Icons.flight_takeoff), findsOneWidget);
+      expect(find.byIcon(Icons.hotel), findsOneWidget);
+      // Two destination legs + outbound + return home legs.
+      expect(find.byIcon(Icons.navigation), findsNWidgets(4));
+
+      final bounds = _camera(tester).visibleBounds;
+      for (final d in dests) {
+        expect(bounds.contains(d.point), isTrue);
+      }
+      expect(bounds.contains(homePoint), isTrue);
+    });
+
+    testWidgets('dropping the destinations (day view) refits to the items', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        _host(TripMap(items: items, destinations: dests)),
+      );
+      await tester.pump();
+      expect(_camera(tester).visibleBounds.contains(dests.last.point), isTrue);
+
+      // Same fitSignature — the content comparison alone must notice the
+      // destination points leaving the fit set and reframe on the items.
+      await tester.pumpWidget(_host(TripMap(items: items)));
+      await tester.pump();
+      await tester.pump();
+
+      expect(
+        _camera(tester).visibleBounds.contains(dests.last.point),
+        isFalse,
+      );
+      expect(find.byType(MarkerClusterLayerWidget), findsOneWidget);
+    });
   });
 
   group('single world fills a wide map band (no background side bars)', () {


### PR DESCRIPTION
## Summary
- **Fixes the "weird map numbers"**: the All view was mixing marker-cluster **count** bubbles (black, "4 places here") with flat per-item route numbers that survived clustering (5, 8, 10) — a gapped, meaningless sequence at world zoom.
- **All view, ≥2 destinations**: one pin per city leg, numbered **1..N in visit order**, single `scheme.primary` color, no clustering; the route line + arrows walk the destinations; tapping a pin shows a tooltip (city + dates), same mechanism as stay pins. Destinations derive from the **full unfiltered itinerary** (home-leg doctrine), so day chips and lenses can't shift the numbering.
- **Unchanged**: Day-chip views (per-stop pins 1..N), single-city trips (place-level pins), stay pins, dashed home-airport legs (they anchor to the same first/last leg coords, so they meet pins 1 and N exactly). All three surfaces get the fix: embedded card, full-screen map, shared view.
- **Refactor**: the city-leg split (hub rule `day_trip_from ?? city ?? address-parse`, consecutive-run split, `#2` revisit keys, representative coord) moves to `lib/utils/trip_legs.dart`; `_locationGroupRanges`, `_buildGroups`, `_locationDates` (previously an index-coupled re-walk), and the shared screen's inline copy all delegate to it.
- **Small intentional behavior change (shared view)**: null-city items with a parseable address now group under the parsed city instead of the "Places" bucket — convergence with the owner view (covered by a test).

## Testing
- `flutter analyze` — clean (the 3 pre-existing `route_response.dart` infos are on `main` too).
- `flutter test` — **652 passed**, including 13 new: `trip_legs_test.dart` (hub rule, run split, revisit keys, null-locality, coord sentinel), `trip_map_test.dart` destination-mode group (1..N order lock via projected-coordinate anchoring, no clusterer, single-destination fallback, empty-items lens-proofing, tooltip flow, no travel labels, stays+home fit, mode-flip refit), plus screen tests for trip detail, shared view (ungeocoded-leg skip = contiguous numbering, address-fallback grouping, revisited-city double group), and the full-screen map (All ↔ Day mode flips).
- Existing parity locks untouched and green: day-view numbering, home-overlay cluster test, grouping/revisit/stay-date/travel-time/filler-suppression suites.

## Notes for the integrator
- Touches hub file `trip_detail_screen.dart` (~65 lines, grouping helpers + map card region). **PR #288 is also open against this file** (trailing-section cluster) — different regions, expect a clean rebase; merge in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)