### PR TITLE
feat(web): persist the current page in the URL so refresh restores it

### DIFF
--- a/specs/url-page-persistence/plan.md
+++ b/specs/url-page-persistence/plan.md
@@ -1,0 +1,129 @@
+# Plan: URL Page Persistence
+
+> **HOW.** See `spec.md` for what & why. Flutter-only change; no Go, no nginx
+> (the deployment gateway already SPA-falls-back `/app/*` to the shell —
+> `dockerize/deployment/nginx/snippets/app-locations.conf`).
+
+## Technical Approach
+
+Stay on Navigator 1.0 (no go_router/Router migration — the shell's nested
+tab navigators with app-lifetime GlobalKeys make that a rewrite). Two halves:
+
+1. **Write half**: a single source-of-truth location (`UrlSyncController`)
+   fed by NavigatorObservers on the three tab navigators + `navIndexProvider`
+   changes + the plan chat id, reported to the browser with
+   `SystemNavigator.routeInformationUpdated(uri:, replace: true)` behind a
+   test-overridable `urlReporterProvider`.
+2. **Read half**: `generateRoute` parses the new paths into a `BootTarget`
+   carried through `AuthGate`; the controller consumes it once when auth
+   resolves signed-in-and-onboarded — sets the tab, then bounded-retry-pushes
+   the inner screen (the `shared_trip_screen.dart` deep-link pattern).
+
+### Flutter 3.35.4 SDK facts this design rests on (re-verify on SDK bumps)
+
+Local, CI (`.github/workflows/ci.yml`), and both Dockerfiles all pin 3.35.4.
+
+- `SystemNavigator.routeUpdated` **no longer exists**; the framework calls
+  `routeInformationUpdated`, which does **not** switch the engine's history
+  mode — in single-entry mode it *replaces* the browser entry (URL updates, no
+  history stack).
+- Single-entry mode is guaranteed: `WidgetsApp` sets
+  `reportsRouteUpdateToEngine: true` and the root Navigator's `initState`
+  calls `SystemNavigator.selectSingleEntryHistory()`.
+- The framework's own auto-report fires **only for named routes**, so the
+  unnamed `TripMapScreen` root push reports nothing. Naming it would be
+  harmful (its pop would re-report the boot route's name). The only post-boot
+  auto-reports are the five `pushNamedAndRemoveUntil('/')` reset sites.
+- Riverpod 2.6.1 forbids provider writes during build/initState → the boot
+  tab is applied from an auth-state **listener** (outside the build phase,
+  before the shell's first frame — no home-tab flash).
+- Boot-URL test seam:
+  `tester.binding.platformDispatcher.defaultRouteNameTestValue`.
+
+### Hard invariant
+
+`generateInitialRoutes` must keep producing **exactly one** route (double
+AppShell mount = blank screen; commit ff3c907, locked by
+`test/deep_link_initial_routes_test.dart`).
+
+## URL grammar (single source: `lib/navigation/app_routes.dart`)
+
+| Location | Written when | Boot restore (signed in) |
+|---|---|---|
+| `/` | home tab at root | shell, home tab |
+| `/plan` | plan tab, no chat yet / after reset | shell, plan tab |
+| `/plan/<chatId>` | plan tab once a chat exists | plan tab + transcript resume; failure → fresh plan tab |
+| `/trips` | trips tab at root | shell, trips tab |
+| `/trips/<tripId>` | any `TripDetailScreen` push | trips tab + push detail |
+| `/trip/<tripId>` | never written (MCP alias) | same; URL self-normalizes |
+| `/alerts` `/preferences` `/account` `/admin/metrics` `/admin/local` `/guides` `/notifications` | utility screens | shell, home tab + push |
+| `/import` | import screen | shell, trips tab + push |
+| `/share` `/invite` `/reset` `/verify` `/sso` `/connect` | — | UNCHANGED bare boot |
+
+`BootTarget { tab, tripId?, chatId?, utility? }` + `parseBootTarget(Uri)` +
+format helpers, used by both halves so they cannot drift. Deliberately
+unnamed (URL stays at nearest named ancestor): `TripMapScreen` (closures,
+root push), `LocalGuideDetailScreen` (full object), `FlightSearchScreen`
+(non-URL-encodable prefill), `AuthScreen`, retake-quiz.
+
+## Flutter Changes
+
+- **New `lib/navigation/app_routes.dart`** — grammar above.
+- **New `lib/navigation/url_sync.dart`** — `UrlSyncController` (per-tab stacks
+  of named `Route` references; tab-root didPush clears its tab's stack —
+  self-healing across GlobalKey remounts; `_shellAttached` gate so bare-boot
+  flows never get their URL touched; consume-once boot target; bounded
+  retry-push), `TabUrlObserver` (fresh instances per `AppShell.build` — an
+  observer can't attach to two navigators), `RootUrlObserver` (post-frame
+  re-assert after root nav events — converges over the framework's `/`
+  auto-reports), `urlReporterProvider` seam.
+- **`lib/main.dart`** — `navigatorObservers`; `generateInitialRoutes` passes
+  `isBoot: true`; `generateRoute` parses `BootTarget` → `AuthGate(bootTarget:)`
+  (only the boot route carries one — runtime `pushNamed('/')` resets can't
+  clobber a flow's chosen tab); delete the bare `/trip/<id>` + `/alerts`
+  branches (they boot in-shell now); `AuthGate` → `ConsumerStatefulWidget`
+  registering the target with the controller.
+- **`lib/screens/app_shell.dart`** — `_TabNavigator` gains `observers`.
+- **`lib/navigation/app_nav.dart`** — `locatedRoute(page, location)` +
+  `pushOnActiveTab(..., {String? location})`.
+- **Named push sites** — trips_list (detail, import), home (2× detail,
+  guides), agent (detail), import_trip (pushReplacement detail),
+  add_to_trip_sheet, shared_trip (retry-push detail), account_menu (5 utility
+  screens), alerts (notifications). **`trip_detail_screen.dart` untouched**
+  (hub file; its two pushes stay unnamed by design).
+- **Phase B (chat resume)** — `PlanState.chatId` (mirrors `savedTripId`);
+  new `lib/providers/plan_resume.dart` `resumePlanChat(...)` lifted from
+  `ContinueChatCard._resume`; `continue_chats_section.dart` refactors onto it;
+  `/plan/<chatId>` boot calls it, silent degrade to fresh `/plan` (zero new
+  l10n strings).
+
+## Go API Changes
+
+None. (The `/trips/<uuid>` re-engagement email links start working purely
+client-side.)
+
+## Contract Parity
+
+n/a — no new JSON contract; the chat-resume path reuses the existing
+`GET /api/v1/chats/{chatId}` transcript shape.
+
+## Cross-cutting
+
+- No new env vars, no gateway changes, no migrations, no ARB/l10n changes.
+- Accepted cosmetics/limitations (documented in spec): brief `/trips` →
+  `/trips/<id>` URL settle on deep-link boot; query strings dropped; SSO
+  redirect loses the deep-link target.
+
+## Verification
+
+- `make flutter-analyze` && `make flutter-test`.
+- New/extended tests: `app_routes_test` (grammar round-trip),
+  `deep_link_initial_routes_test` (one-route invariant for every new path),
+  `url_boot_restore_test` (real app boot via `defaultRouteNameTestValue`:
+  trips detail, alias normalization, in-shell alerts/import, signed-out →
+  sign-in lands on target), `url_sync_report_test` (tab/push/pop/unnamed/
+  sign-out reporting), `url_plan_chat_test` (resume, reset, boot happy path,
+  fetch-failure degrade).
+- Manual walk of every spec acceptance criterion on the lane dev stack
+  (`make docker-dev-bg`, this lane's gateway), including refresh on each
+  surface and the untouched `/share` + `/sso` flows.

--- a/specs/url-page-persistence/spec.md
+++ b/specs/url-page-persistence/spec.md
@@ -1,0 +1,96 @@
+# Spec: URL Page Persistence
+
+> **WHAT & WHY only.** Tech details live in `plan.md`.
+
+## Context
+
+On the web app, the browser URL never changes after the first page load: open a
+trip, switch to the Plan tab, or drill into Alerts, and the address bar still
+shows the app root. Refreshing the page therefore always dumps you back on
+Home, losing your place — mid-trip-review, mid-chat, mid-anything. The URL
+should reflect the page you are on, so a refresh (or a bookmarked/shared-tab
+reopen) puts you back exactly where you were. As a side effect, links into
+specific app pages (e.g. the trip links in re-engagement emails, which today
+land on Home) start working.
+
+## User Stories
+
+- As a **traveler**, I want **the page I'm on reflected in the URL** so that
+  **refreshing the browser doesn't lose my place**.
+- As a **traveler planning in the chat**, I want **a refresh to bring back my
+  conversation** so that **an accidental reload doesn't cost me my session**.
+- As a **recipient of a trip-reminder email**, I want **the trip link to open
+  that trip** so that **I don't have to hunt for it from Home**.
+
+## Acceptance Criteria
+
+- [ ] Switching top-level tabs (Home / Plan / Trips) updates the URL to `/`,
+      `/plan`, `/trips` respectively.
+- [ ] Opening a trip updates the URL to `/trips/<tripId>`; refreshing there
+      reopens that trip with the navigation shell (rail/bar) present and the
+      Trips tab selected.
+- [ ] Opening Alerts, Preferences, Account settings, Admin metrics, Local
+      admin, Import, Guides, or Notifications updates the URL to a stable path;
+      refreshing there reopens that screen inside the shell.
+- [ ] Once a plan conversation exists, the Plan tab's URL becomes
+      `/plan/<chatId>`; refreshing there restores the conversation transcript.
+      If the conversation can't be restored (expired, trip-bound, someone
+      else's), the Plan tab opens fresh — no error dialog.
+- [ ] Going back (browser back button) and popping in-app screens keeps the URL
+      in sync with what's on screen.
+- [ ] Signing out resets the URL to `/`.
+- [ ] `/trips/<tripId>` (the shape used in re-engagement emails) and
+      `/trip/<tripId>` (the shape the AI connector emits) both open the trip.
+- [ ] Refreshing on a page while signed out shows the landing page; signing in
+      with email+password then lands on the page the URL pointed at.
+- [ ] Existing deep-link flows — share links, invites, password reset, email
+      verification, SSO callback, connector consent — behave exactly as before.
+- [ ] An unrecognized path behaves like today (lands on the normal app flow).
+
+## API Surface
+
+None. This is entirely client-side; the only server interaction is the existing
+conversation-transcript fetch already used by "Continue where you left off".
+
+## Data Model
+
+None. No new persistence; the URL itself is the state.
+
+## UI Behavior
+
+- **Where:** the browser address bar, on every page of the web app.
+- **Happy path:** navigate anywhere → URL updates in place (no new history
+  entries) → refresh → the same page reappears, shell intact, correct tab
+  highlighted.
+- **States:** while a restored trip or conversation loads, the target screen's
+  own loading state shows (no new spinners); restore failures degrade silently
+  to the nearest sensible page (tab root).
+
+## Edge Cases & Error States
+
+- Deep link while signed out → landing page; the target is honored after
+  email/password sign-in (and after the onboarding quiz for new accounts).
+- A Google/Apple sign-in redirect leaves the page, so a deep-link target does
+  not survive SSO — the user lands on Home. Known limitation.
+- Restoring `/plan/<chatId>` for a conversation with no stored transcript
+  (trip-bound, anonymous, graduated, or foreign) opens a fresh Plan tab.
+- Screens that can't be reconstructed from a URL (full-screen trip map, guide
+  detail, flight search with prefill) keep the URL of the page beneath them;
+  refresh lands on that page.
+- Query strings and fragments are not preserved.
+- For a moment during a deep-link boot the URL may show the tab root (e.g.
+  `/trips`) before settling on the full path — cosmetic only.
+
+## Out of Scope
+
+- Browser back/forward **history entries** (back keeps its current behavior:
+  it pops the in-app screen). The URL is always *replaced*, never pushed.
+- Editing the URL bar mid-session as a navigation method (pre-existing
+  unsupported behavior; refresh is the supported path).
+- Restoring scroll positions, map viewports, or in-screen tab state (e.g. the
+  admin dashboard's inner tabs).
+- Preserving deep-link targets across the SSO redirect round-trip.
+
+## Open Questions
+
+None.

--- a/src/packages/flutter-app/lib/main.dart
+++ b/src/packages/flutter-app/lib/main.dart
@@ -4,10 +4,11 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_web_plugins/url_strategy.dart';
 import 'constants/app_info.dart';
 import 'l10n/l10n.dart';
+import 'navigation/app_routes.dart';
+import 'navigation/url_sync.dart';
 import 'providers/auth_provider.dart';
 import 'providers/locale_provider.dart';
 import 'theme/app_theme.dart';
-import 'screens/alerts_screen.dart';
 import 'screens/connect_app_screen.dart';
 import 'screens/landing_screen.dart';
 import 'screens/app_shell.dart';
@@ -15,7 +16,6 @@ import 'screens/onboarding_quiz_screen.dart';
 import 'screens/reset_password_screen.dart';
 import 'screens/shared_trip_screen.dart';
 import 'screens/sso_callback_screen.dart';
-import 'screens/trip_detail_screen.dart';
 import 'screens/verify_email_screen.dart';
 import 'screens/splash_screen.dart';
 
@@ -37,13 +37,17 @@ void main() {
 /// catch-all, so a signed-in session mounts two AppShells whose tab
 /// navigators share the same GlobalKeys — the tree corrupts and the body
 /// renders blank.
+///
+/// isBoot marks this the cold-boot route: the only one allowed to carry a
+/// restore target (specs/url-page-persistence) — runtime pushNamed('/')
+/// resets must never replay the boot URL's destination.
 List<Route<dynamic>> generateInitialRoutes(String initialRoute) =>
-    [generateRoute(RouteSettings(name: initialRoute))];
+    [generateRoute(RouteSettings(name: initialRoute), isBoot: true)];
 
 /// Route by URL so share links work signed-out. Everything else lands
 /// on AuthGate, preserving the existing splash -> landing/quiz/shell
 /// flow. Legacy /#/share links are rewritten by the index.html shim.
-Route<dynamic> generateRoute(RouteSettings settings) {
+Route<dynamic> generateRoute(RouteSettings settings, {bool isBoot = false}) {
   final uri = Uri.tryParse(settings.name ?? '/');
   final segments = uri?.pathSegments ?? const <String>[];
   if (segments.length == 2 && segments[0] == 'share') {
@@ -90,25 +94,16 @@ Route<dynamic> generateRoute(RouteSettings settings) {
       builder: (_) => ConnectAppScreen(requestToken: segments[1]),
     );
   }
-  // A connector's create_trip returns a /trip/<id> URL so the AI's answer can
-  // link straight into the app.
-  if (segments.length == 2 && segments[0] == 'trip') {
-    return MaterialPageRoute(
-      settings: settings,
-      builder: (_) => TripDetailScreen(tripId: segments[1]),
-    );
-  }
-  // Price-alert emails deep-link here; the screen itself handles the
-  // signed-out case with a sign-in prompt.
-  if (segments.length == 1 && segments[0] == 'alerts') {
-    return MaterialPageRoute(
-      settings: settings,
-      builder: (_) => const AlertsScreen(),
-    );
-  }
+  // URL persistence (specs/url-page-persistence): recognized app paths —
+  // tabs, /trips/<id> (and the connector's /trip/<id> alias), /alerts and the
+  // other utility screens, /plan/<chatId> — land on the normal gate carrying
+  // a parsed target that URL sync applies once the session resolves, so the
+  // page boots inside the shell. Unknown paths parse to null and behave like
+  // the plain catch-all.
+  final target = uri == null ? null : parseBootTarget(uri);
   return MaterialPageRoute(
     settings: settings,
-    builder: (_) => const AuthGate(),
+    builder: (_) => AuthGate(bootTarget: isBoot ? target : null),
   );
 }
 
@@ -135,6 +130,9 @@ class TravelRoutePlannerApp extends ConsumerWidget {
       ],
       onGenerateRoute: generateRoute,
       onGenerateInitialRoutes: generateInitialRoutes,
+      // URL persistence write half: re-asserts the synced location after
+      // root-navigator events (specs/url-page-persistence).
+      navigatorObservers: [ref.watch(rootUrlObserverProvider)],
     );
   }
 }
@@ -142,11 +140,28 @@ class TravelRoutePlannerApp extends ConsumerWidget {
 /// Shows a loading splash until the stored session is checked, then routes to
 /// the landing page (signed out), the one-time signup quiz (signed in but not
 /// yet onboarded), or the home screen.
-class AuthGate extends ConsumerWidget {
-  const AuthGate({super.key});
+class AuthGate extends ConsumerStatefulWidget {
+  /// Where the boot URL pointed (specs/url-page-persistence); null everywhere
+  /// but the cold-boot route. URL sync holds it until the session resolves
+  /// signed-in-and-onboarded, so it survives the landing page and the quiz.
+  final BootTarget? bootTarget;
+
+  const AuthGate({super.key, this.bootTarget});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<AuthGate> createState() => _AuthGateState();
+}
+
+class _AuthGateState extends ConsumerState<AuthGate> {
+  @override
+  void initState() {
+    super.initState();
+    // A plain field hand-off (no provider writes — illegal in initState).
+    ref.read(urlSyncProvider).registerBootTarget(widget.bootTarget);
+  }
+
+  @override
+  Widget build(BuildContext context) {
     final auth = ref.watch(authProvider);
     final Widget child;
     if (!auth.initialized) {

--- a/src/packages/flutter-app/lib/navigation/app_nav.dart
+++ b/src/packages/flutter-app/lib/navigation/app_nav.dart
@@ -20,12 +20,25 @@ final tabNavKeysProvider = Provider<List<GlobalKey<NavigatorState>>>(
   (ref) => List.generate(AppTab.values.length, (_) => GlobalKey<NavigatorState>()),
 );
 
+/// A [MaterialPageRoute] whose settings name is the page's location in the
+/// URL grammar (app_routes.dart), which makes it visible to URL sync: the
+/// address bar shows [location] while the route is on top, and a refresh
+/// there restores the page. Pushes without a location keep the URL of the
+/// page beneath them.
+Route<T> locatedRoute<T>(Widget page, String location) => MaterialPageRoute<T>(
+      settings: RouteSettings(name: location),
+      builder: (_) => page,
+    );
+
 /// Push [page] onto the currently-selected tab's navigator, so the content area
-/// animates while the persistent rail/bar stays put.
-void pushOnActiveTab(WidgetRef ref, Widget page) {
+/// animates while the persistent rail/bar stays put. Pass [location] when the
+/// page is restorable from a URL (see [locatedRoute]).
+void pushOnActiveTab(WidgetRef ref, Widget page, {String? location}) {
   final keys = ref.read(tabNavKeysProvider);
   final state = keys[ref.read(navIndexProvider)].currentState;
-  state?.push(MaterialPageRoute(builder: (_) => page));
+  state?.push(location == null
+      ? MaterialPageRoute(builder: (_) => page)
+      : locatedRoute(page, location));
 }
 
 /// Return to the Home tab — the logo-tap action. Mirrors the shell's

--- a/src/packages/flutter-app/lib/navigation/app_routes.dart
+++ b/src/packages/flutter-app/lib/navigation/app_routes.dart
@@ -1,0 +1,128 @@
+import 'app_nav.dart';
+
+/// The URL grammar (specs/url-page-persistence). One table shared by both
+/// halves of URL persistence — the write half formats locations with the
+/// helpers below, the read half parses them with [parseBootTarget] — so the
+/// two can never drift apart.
+///
+/// Token deep links (/share, /invite, /reset, /verify, /sso, /connect) are
+/// NOT part of this grammar: generateRoute matches them before parsing, and
+/// they boot bare (no shell), exactly as before.
+
+/// Zero-argument screens that are pushed inside the shell and can be
+/// reconstructed from their path alone.
+enum BootUtility {
+  alerts,
+  preferences,
+  account,
+  adminMetrics,
+  adminLocal,
+  importTrip,
+  guides,
+  notifications,
+}
+
+/// Where a URL lands after boot: a tab, plus at most one of an inner screen
+/// to push (trip detail via [tripId], a utility screen via [utility]) or a
+/// plan conversation to resume ([chatId]).
+class BootTarget {
+  final AppTab tab;
+  final String? tripId;
+  final String? chatId;
+  final BootUtility? utility;
+
+  const BootTarget(this.tab, {this.tripId, this.chatId, this.utility});
+
+  @override
+  bool operator ==(Object other) =>
+      other is BootTarget &&
+      other.tab == tab &&
+      other.tripId == tripId &&
+      other.chatId == chatId &&
+      other.utility == utility;
+
+  @override
+  int get hashCode => Object.hash(tab, tripId, chatId, utility);
+
+  @override
+  String toString() =>
+      'BootTarget(${tab.name}, tripId: $tripId, chatId: $chatId, utility: ${utility?.name})';
+}
+
+const kHomeLocation = '/';
+const kPlanLocation = '/plan';
+const kTripsLocation = '/trips';
+
+String tripDetailLocation(String tripId) => '$kTripsLocation/$tripId';
+String planChatLocation(String chatId) => '$kPlanLocation/$chatId';
+
+String utilityLocation(BootUtility utility) => switch (utility) {
+      BootUtility.alerts => '/alerts',
+      BootUtility.preferences => '/preferences',
+      BootUtility.account => '/account',
+      BootUtility.adminMetrics => '/admin/metrics',
+      BootUtility.adminLocal => '/admin/local',
+      BootUtility.importTrip => '/import',
+      BootUtility.guides => '/guides',
+      BootUtility.notifications => '/notifications',
+    };
+
+/// The tab a utility screen is restored onto. Import lives in the trips flow;
+/// everything else hangs off Home (the account menu is reachable from any tab,
+/// so restore needs one deterministic choice).
+AppTab utilityTab(BootUtility utility) => switch (utility) {
+      BootUtility.importTrip => AppTab.trips,
+      _ => AppTab.home,
+    };
+
+/// Parses a location into a [BootTarget], or null for paths this grammar
+/// doesn't know (the caller falls through to the plain AuthGate catch-all,
+/// leaving the URL untouched). Trailing slashes are tolerated; query strings
+/// and fragments are ignored.
+BootTarget? parseBootTarget(Uri uri) {
+  final segments =
+      uri.pathSegments.where((s) => s.isNotEmpty).toList(growable: false);
+  if (segments.isEmpty) return const BootTarget(AppTab.home);
+
+  switch (segments[0]) {
+    case 'plan':
+      if (segments.length == 1) return const BootTarget(AppTab.plan);
+      if (segments.length == 2) {
+        return BootTarget(AppTab.plan, chatId: segments[1]);
+      }
+    case 'trips':
+      if (segments.length == 1) return const BootTarget(AppTab.trips);
+      if (segments.length == 2) {
+        return BootTarget(AppTab.trips, tripId: segments[1]);
+      }
+    // Alias: the MCP connector's create_trip links /trip/<id> (singular).
+    // Never written back — the URL self-normalizes to /trips/<id>.
+    case 'trip':
+      if (segments.length == 2) {
+        return BootTarget(AppTab.trips, tripId: segments[1]);
+      }
+    case 'admin':
+      if (segments.length == 2 && segments[1] == 'metrics') {
+        return const BootTarget(AppTab.home, utility: BootUtility.adminMetrics);
+      }
+      if (segments.length == 2 && segments[1] == 'local') {
+        return const BootTarget(AppTab.home, utility: BootUtility.adminLocal);
+      }
+    default:
+      if (segments.length == 1) {
+        final utility = switch (segments[0]) {
+          'alerts' => BootUtility.alerts,
+          'preferences' => BootUtility.preferences,
+          'account' => BootUtility.account,
+          'import' => BootUtility.importTrip,
+          'guides' => BootUtility.guides,
+          'notifications' => BootUtility.notifications,
+          _ => null,
+        };
+        if (utility != null) {
+          return BootTarget(utilityTab(utility), utility: utility);
+        }
+      }
+  }
+  return null;
+}

--- a/src/packages/flutter-app/lib/navigation/url_sync.dart
+++ b/src/packages/flutter-app/lib/navigation/url_sync.dart
@@ -1,0 +1,304 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../providers/auth_provider.dart';
+import '../providers/plan_provider.dart';
+import '../providers/plan_resume.dart';
+import '../providers/resumable_chats_provider.dart';
+import '../screens/account_settings_screen.dart';
+import '../screens/admin_metrics_screen.dart';
+import '../screens/alerts_screen.dart';
+import '../screens/guides_screen.dart';
+import '../screens/import_trip_screen.dart';
+import '../screens/local_admin_screen.dart';
+import '../screens/notification_center_screen.dart';
+import '../screens/preferences_screen.dart';
+import '../screens/trip_detail_screen.dart';
+import 'app_nav.dart';
+import 'app_routes.dart';
+
+/// URL persistence (specs/url-page-persistence): keeps the browser address bar
+/// in sync with the page on screen so a refresh restores it.
+///
+/// The app stays on Navigator 1.0, so nothing reports the URL after boot by
+/// itself — [UrlSyncController] derives the current location from the active
+/// tab and that tab's topmost *named* route (observers below), and writes it
+/// via [SystemNavigator.routeInformationUpdated]. The engine is in
+/// single-entry history mode (the WidgetsApp default), where that call
+/// REPLACES the browser entry: the URL updates without growing a history
+/// stack, and the back button keeps its existing pop behavior.
+///
+/// The read half lives in main.dart's generateRoute: recognized paths parse to
+/// a [BootTarget] (lib/navigation/app_routes.dart) that AuthGate registers
+/// here; [_onAuthChanged] consumes it once the session resolves signed-in.
+
+/// Writes one location to the address bar. A provider so tests can record
+/// reports instead; also the single seam to touch if an SDK upgrade changes
+/// the engine call.
+typedef UrlReporter = void Function(String location);
+
+final urlReporterProvider = Provider<UrlReporter>((ref) => _reportToEngine);
+
+void _reportToEngine(String location) {
+  if (!kIsWeb) return;
+  SystemNavigator.routeInformationUpdated(
+      uri: Uri.parse(location), replace: true);
+}
+
+final urlSyncProvider = Provider<UrlSyncController>((ref) {
+  final controller = UrlSyncController(ref);
+  ref.listen(navIndexProvider, (_, __) => controller._report());
+  // The plan tab's root location includes the conversation id once one
+  // exists (first send / resume; cleared by Start over).
+  ref.listen(planProvider.select((s) => s.chatId),
+      (_, __) => controller._report());
+  ref.listen(authProvider, controller._onAuthChanged);
+  return controller;
+});
+
+/// Root-navigator observer, attached via MaterialApp.navigatorObservers.
+/// Created through a provider so the controller exists from the first frame.
+final rootUrlObserverProvider = Provider<RootUrlObserver>(
+    (ref) => RootUrlObserver(ref.watch(urlSyncProvider)));
+
+class UrlSyncController {
+  UrlSyncController(this._ref);
+
+  final Ref _ref;
+
+  /// Named routes above each tab's root, oldest first. Holds [Route]
+  /// references rather than name strings so a pop removes exactly its own
+  /// entry even if two routes on the stack share a name.
+  final List<List<Route<dynamic>>> _tabStacks =
+      List.generate(AppTab.values.length, (_) => <Route<dynamic>>[]);
+
+  /// False until a tab-root route mounts. Gates every report so bare-boot
+  /// flows (/share, /sso, /connect, …) never have their URL touched, and so
+  /// nothing reports while the splash/landing screens are up.
+  bool _shellAttached = false;
+
+  String? _lastReported;
+
+  BootTarget? _bootTarget;
+  bool _bootConsumed = false;
+
+  // ---- write half -------------------------------------------------------
+
+  String get _currentLocation {
+    final tab = _ref.read(navIndexProvider);
+    final stack = _tabStacks[tab];
+    if (stack.isNotEmpty) return stack.last.settings.name!;
+    return _tabRootLocation(AppTab.values[tab]);
+  }
+
+  String _tabRootLocation(AppTab tab) => switch (tab) {
+        AppTab.home => kHomeLocation,
+        // The root planProvider only — trip-bound panel chats
+        // (tripRefineProvider) never reach the URL.
+        AppTab.plan => switch (_ref.read(planProvider).chatId) {
+            null => kPlanLocation,
+            final chatId => planChatLocation(chatId),
+          },
+        AppTab.trips => kTripsLocation,
+      };
+
+  void _report() {
+    if (!_shellAttached) return;
+    final location = _currentLocation;
+    if (location == _lastReported) return;
+    _lastReported = location;
+    _ref.read(urlReporterProvider)(location);
+  }
+
+  void _didPushOnTab(int tab, Route<dynamic> route) {
+    if (route.isFirst) {
+      // A tab root mounting (first shell build, or a remount after a
+      // pushNamedAndRemoveUntil('/') reset recreated the navigator): any
+      // remembered stack belonged to the dead navigator.
+      _tabStacks[tab].clear();
+      _shellAttached = true;
+    } else if (route.settings.name != null) {
+      _tabStacks[tab].add(route);
+    }
+    _report();
+  }
+
+  void _didRemoveFromTab(int tab, Route<dynamic> route) {
+    _tabStacks[tab].remove(route);
+    _report();
+  }
+
+  void _didReplaceOnTab(
+      int tab, Route<dynamic>? newRoute, Route<dynamic>? oldRoute) {
+    if (oldRoute != null) _tabStacks[tab].remove(oldRoute);
+    if (newRoute != null && !newRoute.isFirst && newRoute.settings.name != null) {
+      _tabStacks[tab].add(newRoute);
+    }
+    _report();
+  }
+
+  /// After any ROOT-navigator event, re-assert our location a frame later.
+  /// The framework auto-reports named root routes (the five
+  /// pushNamedAndRemoveUntil('/') reset sites report `/`), which would
+  /// otherwise be the last word in the address bar even though the shell
+  /// remounts on some tab. Unconditional on purpose: it must out-shout the
+  /// framework's report, so it skips the [_lastReported] dedupe.
+  void _reassertAfterRootNavigation() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!_shellAttached) return;
+      final location = _currentLocation;
+      _lastReported = location;
+      _ref.read(urlReporterProvider)(location);
+    });
+  }
+
+  // ---- read half (boot restore) -----------------------------------------
+
+  /// Called by AuthGate. Only the boot route carries a non-null target
+  /// (generateRoute's isBoot flag), so runtime resets to '/' can never
+  /// clobber a flow's chosen tab; nulls are ignored here for the same reason.
+  void registerBootTarget(BootTarget? target) {
+    if (target == null || _bootTarget != null || _bootConsumed) return;
+    _bootTarget = target;
+    // AuthGate registers from initState (build phase, where provider writes
+    // are illegal); check outside the frame. The normal path — auth still
+    // restoring — is handled by _onAuthChanged when it resolves.
+    WidgetsBinding.instance.addPostFrameCallback(
+        (_) => _maybeConsumeBootTarget(_ref.read(authProvider)));
+  }
+
+  void _onAuthChanged(AuthState? previous, AuthState next) {
+    if ((previous?.isSignedIn ?? false) && !next.isSignedIn) {
+      // Sign-out: the shell is unmounting (no observer events fire for
+      // that), so forget its stacks and hand the address bar back to root.
+      for (final stack in _tabStacks) {
+        stack.clear();
+      }
+      _shellAttached = false;
+      if (_lastReported != kHomeLocation) {
+        _lastReported = kHomeLocation;
+        _ref.read(urlReporterProvider)(kHomeLocation);
+      }
+    }
+    _maybeConsumeBootTarget(next);
+  }
+
+  /// Applies the boot target once the session is signed in and onboarded —
+  /// which also covers "sign in later, then land where the URL pointed" and
+  /// "finish the quiz, then land". Consumed at most once per app run so a
+  /// sign-out/sign-in cycle doesn't replay a stale deep link.
+  void _maybeConsumeBootTarget(AuthState auth) {
+    final target = _bootTarget;
+    if (target == null || _bootConsumed) return;
+    if (!auth.initialized || !auth.isSignedIn) return;
+    if (auth.user!.needsOnboarding) return;
+    _bootConsumed = true;
+    _bootTarget = null;
+
+    // Listener context, never mid-build: the provider write is legal, and it
+    // lands before the frame that mounts AppShell — no wrong-tab flash.
+    _ref.read(navIndexProvider.notifier).state = target.tab.index;
+
+    final tripId = target.tripId;
+    final utility = target.utility;
+    final chatId = target.chatId;
+    if (tripId != null) {
+      _pushOnTabWhenReady(
+          target.tab,
+          () => locatedRoute(
+              TripDetailScreen(tripId: tripId), tripDetailLocation(tripId)));
+    } else if (utility != null) {
+      _pushOnTabWhenReady(target.tab,
+          () => locatedRoute(_utilityScreen(utility), utilityLocation(utility)));
+    } else if (chatId != null) {
+      // Fire-and-forget: success rehydrates planProvider (the Plan tab —
+      // already selected above — renders it, and the chatId listener restores
+      // /plan/<id> in the address bar); failure — no stored transcript, e.g.
+      // a trip-bound or foreign id — silently leaves a fresh chat at /plan.
+      resumePlanChat(
+        chats: _ref.read(chatsApiServiceProvider),
+        plan: _ref.read(planProvider.notifier),
+        chatId: chatId,
+      );
+    }
+  }
+
+  /// The shell (and the tab's nested navigator) mounts over the next frames;
+  /// retry rather than betting on one frame (the shared-trip join-landing
+  /// pattern). If every attempt misses, the user still lands on the right
+  /// tab and the URL self-corrects to the tab root.
+  void _pushOnTabWhenReady(AppTab tab, Route<dynamic> Function() buildRoute,
+      [int attempts = 10]) {
+    final nav = _ref.read(tabNavKeysProvider)[tab.index].currentState;
+    if (nav != null) {
+      nav.push(buildRoute());
+    } else if (attempts > 0) {
+      WidgetsBinding.instance.addPostFrameCallback(
+          (_) => _pushOnTabWhenReady(tab, buildRoute, attempts - 1));
+    }
+  }
+
+  Widget _utilityScreen(BootUtility utility) => switch (utility) {
+        BootUtility.alerts => const AlertsScreen(),
+        BootUtility.preferences => const PreferencesScreen(),
+        BootUtility.account => const AccountSettingsScreen(),
+        BootUtility.adminMetrics => const AdminMetricsScreen(),
+        BootUtility.adminLocal => const LocalAdminScreen(),
+        BootUtility.importTrip => const ImportTripScreen(),
+        BootUtility.guides => const GuidesScreen(),
+        BootUtility.notifications => const NotificationCenterScreen(),
+      };
+}
+
+/// Forwards one tab navigator's route events to the controller. Instances are
+/// created fresh in every AppShell build: a NavigatorObserver may only be
+/// attached to one navigator at a time, and app-lifetime instances would
+/// trip that assert when a reset remounts the shell.
+class TabUrlObserver extends NavigatorObserver {
+  TabUrlObserver(this._controller, this._tab);
+
+  final UrlSyncController _controller;
+  final int _tab;
+
+  @override
+  void didPush(Route<dynamic> route, Route<dynamic>? previousRoute) =>
+      _controller._didPushOnTab(_tab, route);
+
+  @override
+  void didPop(Route<dynamic> route, Route<dynamic>? previousRoute) =>
+      _controller._didRemoveFromTab(_tab, route);
+
+  @override
+  void didRemove(Route<dynamic> route, Route<dynamic>? previousRoute) =>
+      _controller._didRemoveFromTab(_tab, route);
+
+  @override
+  void didReplace({Route<dynamic>? newRoute, Route<dynamic>? oldRoute}) =>
+      _controller._didReplaceOnTab(_tab, newRoute, oldRoute);
+}
+
+/// Watches the ROOT navigator only to re-assert the synced location after
+/// its pushes/pops (see [UrlSyncController._reassertAfterRootNavigation]).
+class RootUrlObserver extends NavigatorObserver {
+  RootUrlObserver(this._controller);
+
+  final UrlSyncController _controller;
+
+  @override
+  void didPush(Route<dynamic> route, Route<dynamic>? previousRoute) =>
+      _controller._reassertAfterRootNavigation();
+
+  @override
+  void didPop(Route<dynamic> route, Route<dynamic>? previousRoute) =>
+      _controller._reassertAfterRootNavigation();
+
+  @override
+  void didRemove(Route<dynamic> route, Route<dynamic>? previousRoute) =>
+      _controller._reassertAfterRootNavigation();
+
+  @override
+  void didReplace({Route<dynamic>? newRoute, Route<dynamic>? oldRoute}) =>
+      _controller._reassertAfterRootNavigation();
+}

--- a/src/packages/flutter-app/lib/providers/plan_provider.dart
+++ b/src/packages/flutter-app/lib/providers/plan_provider.dart
@@ -109,6 +109,12 @@ class PlanState {
   /// transient "Summarizing earlier conversation…" chip.
   final bool isCompacting;
 
+  /// The conversation's stable chat id, mirrored from the notifier's private
+  /// one once a conversation exists (first send, or a resume) — the public
+  /// read path URL sync needs to emit /plan/<chatId>
+  /// (specs/url-page-persistence). Null until then and after Start over.
+  final String? chatId;
+
   const PlanState({
     this.messages = const [],
     this.isStreaming = false,
@@ -140,6 +146,7 @@ class PlanState {
     this.compactedSummary,
     this.compactedCount = 0,
     this.isCompacting = false,
+    this.chatId,
   });
 
   PlanState copyWith({
@@ -173,6 +180,7 @@ class PlanState {
     Object? compactedSummary = _sentinel,
     int? compactedCount,
     bool? isCompacting,
+    Object? chatId = _sentinel,
   }) {
     return PlanState(
       messages: messages ?? this.messages,
@@ -209,6 +217,7 @@ class PlanState {
           compactedSummary == _sentinel ? this.compactedSummary : compactedSummary as String?,
       compactedCount: compactedCount ?? this.compactedCount,
       isCompacting: isCompacting ?? this.isCompacting,
+      chatId: chatId == _sentinel ? this.chatId : chatId as String?,
     );
   }
 }
@@ -354,6 +363,7 @@ class PlanNotifier extends StateNotifier<PlanState> {
       messages: updatedMessages,
       isStreaming: true,
       streamingText: '',
+      chatId: _chatId,
       activeTools: [],
       flightOffers: null,
       flightRouteLabel: null,
@@ -753,6 +763,7 @@ class PlanNotifier extends StateNotifier<PlanState> {
     _chatId = chatId;
     state = state.copyWith(
       messages: messages,
+      chatId: chatId,
       compactedSummary:
           (summary == null || summary.isEmpty) ? null : summary,
     );

--- a/src/packages/flutter-app/lib/providers/plan_resume.dart
+++ b/src/packages/flutter-app/lib/providers/plan_resume.dart
@@ -1,0 +1,43 @@
+import '../models/plan_message.dart';
+import '../services/chats_api_service.dart';
+import 'plan_provider.dart';
+
+/// Fetches a persisted conversation transcript and rehydrates it into [plan]
+/// (specs/continue-where-you-left-off). Shared by the home-screen Continue
+/// card and the /plan/<chatId> URL restore (specs/url-page-persistence).
+///
+/// False on any failure — including the expected 404s for ids with no stored
+/// transcript (trip-bound, anonymous, graduated, or someone else's chat).
+/// Callers decide how loud to be; the URL restore degrades silently.
+Future<bool> resumePlanChat({
+  required ChatsApiService chats,
+  required PlanNotifier plan,
+  required String chatId,
+}) async {
+  try {
+    final detail = await chats.getChat(chatId);
+    plan.resumeConversation(
+      chatId: detail.chatId,
+      summary: detail.summary,
+      messages: [
+        for (final m in detail.messages)
+          PlanMessage(
+            role: m.role == 'user' ? MessageRole.user : MessageRole.assistant,
+            content: m.content,
+            // Restores the seed context chip (e.g. "Near my current
+            // location") instead of the raw coordinate bubble.
+            displayLabel: m.displayLabel,
+            // Pixels are stripped server-side; null bytes renders the
+            // "Image" placeholder chip and stays out of resent history.
+            attachments: [
+              for (final img in m.images)
+                PlanAttachment(bytes: null, mediaType: img.mediaType),
+            ],
+          ),
+      ],
+    );
+    return true;
+  } catch (_) {
+    return false;
+  }
+}

--- a/src/packages/flutter-app/lib/screens/agent_screen.dart
+++ b/src/packages/flutter-app/lib/screens/agent_screen.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../l10n/l10n.dart';
+import '../navigation/app_nav.dart';
+import '../navigation/app_routes.dart';
 import '../theme/app_colors.dart';
 import '../theme/spacing.dart';
 import '../widgets/account_menu.dart';
@@ -56,7 +58,8 @@ class _AgentScreenState extends ConsumerState<AgentScreen> {
 
   void _openTrip(String tripId) {
     Navigator.of(context).push(
-      MaterialPageRoute(builder: (_) => TripDetailScreen(tripId: tripId)),
+      locatedRoute(
+          TripDetailScreen(tripId: tripId), tripDetailLocation(tripId)),
     );
   }
 

--- a/src/packages/flutter-app/lib/screens/alerts_screen.dart
+++ b/src/packages/flutter-app/lib/screens/alerts_screen.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../l10n/l10n.dart';
 import '../models/price_alert.dart';
+import '../navigation/app_nav.dart';
+import '../navigation/app_routes.dart';
 import '../providers/alerts_provider.dart';
 import '../providers/notifications_provider.dart';
 import '../providers/auth_provider.dart';
@@ -113,6 +115,8 @@ class _AlertsScreenState extends ConsumerState<AlertsScreen> {
           message: l10n.alertsEmptyMessage,
           actions: [
             FilledButton.icon(
+              // Unnamed on purpose: flight search carries non-URL-encodable
+              // prefill at its other launch site; one consistent behavior.
               onPressed: () => Navigator.of(context).push(
                 MaterialPageRoute(builder: (_) => const FlightSearchScreen()),
               ),
@@ -162,7 +166,8 @@ class _NotificationBell extends ConsumerWidget {
       tooltip: context.l10n.notifTitle,
       icon: const Icon(Icons.notifications_none),
       onPressed: () => Navigator.of(context).push(
-        MaterialPageRoute(builder: (_) => const NotificationCenterScreen()),
+        locatedRoute(const NotificationCenterScreen(),
+            utilityLocation(BootUtility.notifications)),
       ),
     );
     if (count == 0) return bell;

--- a/src/packages/flutter-app/lib/screens/app_shell.dart
+++ b/src/packages/flutter-app/lib/screens/app_shell.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../l10n/l10n.dart';
 import '../navigation/app_nav.dart';
+import '../navigation/url_sync.dart';
 import '../theme/spacing.dart';
 import '../widgets/account_menu.dart';
 import '../widgets/brand_logo.dart';
@@ -32,6 +33,7 @@ class AppShell extends ConsumerWidget {
     final l10n = context.l10n;
     final index = ref.watch(navIndexProvider);
     final navKeys = ref.watch(tabNavKeysProvider);
+    final urlSync = ref.watch(urlSyncProvider);
     final isWide = MediaQuery.sizeOf(context).width >= kRailBreakpoint;
 
     void onSelect(int i) {
@@ -56,7 +58,13 @@ class AppShell extends ConsumerWidget {
         index: index,
         children: [
           for (var i = 0; i < navKeys.length; i++)
-            _TabNavigator(navKey: navKeys[i], child: _tabRoots[i]),
+            _TabNavigator(
+              navKey: navKeys[i],
+              // Fresh observer instances every build: an observer may only be
+              // attached to one navigator at a time (url_sync.dart).
+              observers: [TabUrlObserver(urlSync, i)],
+              child: _tabRoots[i],
+            ),
         ],
       ),
     );
@@ -140,14 +148,17 @@ class _RailBrand extends ConsumerWidget {
 /// within the tab stack here so they animate inside the content area only.
 class _TabNavigator extends StatelessWidget {
   final GlobalKey<NavigatorState> navKey;
+  final List<NavigatorObserver> observers;
   final Widget child;
 
-  const _TabNavigator({required this.navKey, required this.child});
+  const _TabNavigator(
+      {required this.navKey, required this.observers, required this.child});
 
   @override
   Widget build(BuildContext context) {
     return Navigator(
       key: navKey,
+      observers: observers,
       onGenerateRoute: (settings) => MaterialPageRoute(
         builder: (_) => child,
         settings: settings,

--- a/src/packages/flutter-app/lib/screens/home_screen.dart
+++ b/src/packages/flutter-app/lib/screens/home_screen.dart
@@ -11,6 +11,7 @@ import '../providers/recent_trip_provider.dart';
 import '../providers/resumable_chats_provider.dart';
 import '../providers/trips_provider.dart';
 import '../navigation/app_nav.dart';
+import '../navigation/app_routes.dart';
 import '../theme/app_colors.dart';
 import '../theme/app_shadows.dart';
 import '../theme/spacing.dart';
@@ -176,8 +177,9 @@ class HomeScreen extends ConsumerWidget {
                   LiveTripCard(
                     trip: liveTrip,
                     onTap: () => Navigator.of(context).push(
-                      MaterialPageRoute(
-                        builder: (_) => TripDetailScreen(tripId: liveTrip.id),
+                      locatedRoute(
+                        TripDetailScreen(tripId: liveTrip.id),
+                        tripDetailLocation(liveTrip.id),
                       ),
                     ),
                   ),
@@ -197,9 +199,9 @@ class HomeScreen extends ConsumerWidget {
                           dateRange: recentTrip.dateRange,
                           status: recentTrip.status,
                           onTap: () => Navigator.of(context).push(
-                            MaterialPageRoute(
-                              builder: (_) =>
-                                  TripDetailScreen(tripId: recentTrip.tripId),
+                            locatedRoute(
+                              TripDetailScreen(tripId: recentTrip.tripId),
+                              tripDetailLocation(recentTrip.tripId),
                             ),
                           ),
                         )
@@ -581,7 +583,8 @@ class _LocalGuidesRow extends ConsumerWidget {
           title: context.l10n.homeLocalGuidesTitle,
           action: TextButton(
             onPressed: () => Navigator.of(context).push(
-              MaterialPageRoute(builder: (_) => const GuidesScreen()),
+              locatedRoute(
+                  const GuidesScreen(), utilityLocation(BootUtility.guides)),
             ),
             child: Text(context.l10n.commonSeeAll),
           ),
@@ -628,6 +631,8 @@ class _GuideCard extends StatelessWidget {
       child: Material(
         color: Colors.transparent,
         child: InkWell(
+          // Unnamed on purpose: the screen takes the full guide object, so a
+          // URL couldn't reconstruct it — refresh lands on the page beneath.
           onTap: () => Navigator.of(context).push(
             MaterialPageRoute(
               builder: (_) => LocalGuideDetailScreen(guide: guide),

--- a/src/packages/flutter-app/lib/screens/import_trip_screen.dart
+++ b/src/packages/flutter-app/lib/screens/import_trip_screen.dart
@@ -5,6 +5,8 @@ import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../l10n/l10n.dart';
+import '../navigation/app_nav.dart';
+import '../navigation/app_routes.dart';
 import '../providers/import_trip_provider.dart';
 import '../theme/spacing.dart';
 import '../widgets/gradient_app_bar.dart';
@@ -77,7 +79,8 @@ class _ImportTripScreenState extends ConsumerState<ImportTripScreen> {
       if (!mounted) return;
     }
     Navigator.of(context).pushReplacement(
-      MaterialPageRoute(builder: (_) => TripDetailScreen(tripId: res.tripId)),
+      locatedRoute(
+          TripDetailScreen(tripId: res.tripId), tripDetailLocation(res.tripId)),
     );
   }
 

--- a/src/packages/flutter-app/lib/screens/shared_trip_screen.dart
+++ b/src/packages/flutter-app/lib/screens/shared_trip_screen.dart
@@ -7,6 +7,7 @@ import '../models/itinerary_item.dart';
 import '../models/shared_trip.dart';
 import '../models/trip.dart';
 import '../navigation/app_nav.dart';
+import '../navigation/app_routes.dart';
 import '../providers/auth_provider.dart';
 import '../providers/shared_trip_provider.dart';
 import '../providers/shared_with_me_provider.dart';
@@ -174,8 +175,8 @@ class _SharedTripBodyState extends ConsumerState<_SharedTripBody> {
       void openOnTripsTab([int attempts = 10]) {
         final nav = navKeys[AppTab.trips.index].currentState;
         if (nav != null) {
-          nav.push(MaterialPageRoute(
-              builder: (_) => TripDetailScreen(tripId: tripId)));
+          nav.push(locatedRoute(
+              TripDetailScreen(tripId: tripId), tripDetailLocation(tripId)));
         } else if (attempts > 0) {
           WidgetsBinding.instance
               .addPostFrameCallback((_) => openOnTripsTab(attempts - 1));

--- a/src/packages/flutter-app/lib/screens/trips_list_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trips_list_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../l10n/l10n.dart';
 import '../navigation/app_nav.dart';
+import '../navigation/app_routes.dart';
 import '../theme/spacing.dart';
 import '../utils/trip_format.dart';
 import '../widgets/account_menu.dart';
@@ -202,13 +203,14 @@ class _TripsListScreenState extends ConsumerState<TripsListScreen> {
 
 void _openTrip(BuildContext context, String tripId) {
   Navigator.of(context).push(
-    MaterialPageRoute(builder: (_) => TripDetailScreen(tripId: tripId)),
+    locatedRoute(TripDetailScreen(tripId: tripId), tripDetailLocation(tripId)),
   );
 }
 
 void _openImport(BuildContext context) {
   Navigator.of(context).push(
-    MaterialPageRoute(builder: (_) => const ImportTripScreen()),
+    locatedRoute(
+        const ImportTripScreen(), utilityLocation(BootUtility.importTrip)),
   );
 }
 

--- a/src/packages/flutter-app/lib/widgets/account_menu.dart
+++ b/src/packages/flutter-app/lib/widgets/account_menu.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../l10n/l10n.dart';
 import '../navigation/app_nav.dart';
+import '../navigation/app_routes.dart';
 import '../providers/notifications_provider.dart';
 import '../providers/auth_provider.dart';
 import '../screens/account_settings_screen.dart';
@@ -41,17 +42,23 @@ void _onSelected(BuildContext context, WidgetRef ref, String value) {
     ref.read(authProvider.notifier).logout();
   } else if (value == 'preferences') {
     // Push onto the active tab's navigator so the rail/bar stays put.
-    pushOnActiveTab(ref, const PreferencesScreen());
+    pushOnActiveTab(ref, const PreferencesScreen(),
+        location: utilityLocation(BootUtility.preferences));
   } else if (value == 'alerts') {
-    pushOnActiveTab(ref, const AlertsScreen());
+    pushOnActiveTab(ref, const AlertsScreen(),
+        location: utilityLocation(BootUtility.alerts));
   } else if (value == 'retake_quiz') {
+    // No location: a transient flow, not a page worth restoring on refresh.
     pushOnActiveTab(ref, const OnboardingQuizScreen(retake: true));
   } else if (value == 'account_settings') {
-    pushOnActiveTab(ref, const AccountSettingsScreen());
+    pushOnActiveTab(ref, const AccountSettingsScreen(),
+        location: utilityLocation(BootUtility.account));
   } else if (value == 'local_admin') {
-    pushOnActiveTab(ref, const LocalAdminScreen());
+    pushOnActiveTab(ref, const LocalAdminScreen(),
+        location: utilityLocation(BootUtility.adminLocal));
   } else if (value == 'admin_metrics') {
-    pushOnActiveTab(ref, const AdminMetricsScreen());
+    pushOnActiveTab(ref, const AdminMetricsScreen(),
+        location: utilityLocation(BootUtility.adminMetrics));
   }
 }
 

--- a/src/packages/flutter-app/lib/widgets/add_to_trip_sheet.dart
+++ b/src/packages/flutter-app/lib/widgets/add_to_trip_sheet.dart
@@ -7,6 +7,7 @@ import '../models/itinerary_item.dart';
 import '../models/local_recommendation.dart';
 import '../models/trip.dart';
 import '../navigation/app_nav.dart';
+import '../navigation/app_routes.dart';
 import '../providers/analytics_provider.dart';
 import '../providers/trips_provider.dart';
 import '../screens/trip_detail_screen.dart';
@@ -163,8 +164,9 @@ Future<Trip?> showAddToTripSheet(
           ? null
           : SnackBarAction(
               label: l10n.addToTripViewTrip,
-              onPressed: () => navigator.push(MaterialPageRoute(
-                builder: (_) => TripDetailScreen(tripId: trip.id),
+              onPressed: () => navigator.push(locatedRoute(
+                TripDetailScreen(tripId: trip.id),
+                tripDetailLocation(trip.id),
               )),
             ),
     ));

--- a/src/packages/flutter-app/lib/widgets/continue_chats_section.dart
+++ b/src/packages/flutter-app/lib/widgets/continue_chats_section.dart
@@ -2,9 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../l10n/l10n.dart';
 import '../models/chat_session.dart';
-import '../models/plan_message.dart';
 import '../navigation/app_nav.dart';
 import '../providers/plan_provider.dart';
+import '../providers/plan_resume.dart';
 import '../providers/resumable_chats_provider.dart';
 import '../theme/spacing.dart';
 import 'offline_banner.dart' show relativeTime;
@@ -61,33 +61,14 @@ class ContinueChatCard extends ConsumerWidget {
   Future<void> _resume(BuildContext context, WidgetRef ref) async {
     final messenger = ScaffoldMessenger.of(context);
     final l10n = context.l10n;
-    try {
-      final detail =
-          await ref.read(chatsApiServiceProvider).getChat(chat.chatId);
-      ref.read(planProvider.notifier).resumeConversation(
-            chatId: detail.chatId,
-            summary: detail.summary,
-            messages: [
-              for (final m in detail.messages)
-                PlanMessage(
-                  role: m.role == 'user'
-                      ? MessageRole.user
-                      : MessageRole.assistant,
-                  content: m.content,
-                  // Restores the seed context chip (e.g. "Near my current
-                  // location") instead of the raw coordinate bubble.
-                  displayLabel: m.displayLabel,
-                  // Pixels are stripped server-side; null bytes renders the
-                  // "Image" placeholder chip and stays out of resent history.
-                  attachments: [
-                    for (final img in m.images)
-                      PlanAttachment(bytes: null, mediaType: img.mediaType),
-                  ],
-                ),
-            ],
-          );
+    final ok = await resumePlanChat(
+      chats: ref.read(chatsApiServiceProvider),
+      plan: ref.read(planProvider.notifier),
+      chatId: chat.chatId,
+    );
+    if (ok) {
       ref.read(navIndexProvider.notifier).state = AppTab.plan.index;
-    } catch (_) {
+    } else {
       messenger.showSnackBar(
         SnackBar(content: Text(l10n.continueChatsReopenError)),
       );

--- a/src/packages/flutter-app/test/app_routes_test.dart
+++ b/src/packages/flutter-app/test/app_routes_test.dart
@@ -1,0 +1,59 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:travel_route_planner/navigation/app_nav.dart';
+import 'package:travel_route_planner/navigation/app_routes.dart';
+
+/// The URL grammar must round-trip: every location the write half can emit
+/// parses back to the target that reproduces the same screen (and the same
+/// location string), so the two halves of URL persistence cannot drift.
+void main() {
+  BootTarget? parse(String location) => parseBootTarget(Uri.parse(location));
+
+  test('tab roots round-trip', () {
+    expect(parse(kHomeLocation), const BootTarget(AppTab.home));
+    expect(parse(kPlanLocation), const BootTarget(AppTab.plan));
+    expect(parse(kTripsLocation), const BootTarget(AppTab.trips));
+  });
+
+  test('trip detail round-trips and /trip aliases to it', () {
+    const target = BootTarget(AppTab.trips, tripId: 'abc-123');
+    expect(parse(tripDetailLocation('abc-123')), target);
+    expect(parse('/trip/abc-123'), target);
+  });
+
+  test('plan chat round-trips', () {
+    expect(parse(planChatLocation('chat-xyz')),
+        const BootTarget(AppTab.plan, chatId: 'chat-xyz'));
+  });
+
+  test('every utility screen round-trips onto its restore tab', () {
+    for (final utility in BootUtility.values) {
+      expect(parse(utilityLocation(utility)),
+          BootTarget(utilityTab(utility), utility: utility),
+          reason: utility.name);
+    }
+  });
+
+  test('trailing slashes and query strings are tolerated', () {
+    expect(parse('/trips/'), const BootTarget(AppTab.trips));
+    expect(parse('/trips/abc/'), const BootTarget(AppTab.trips, tripId: 'abc'));
+    expect(parse('/plan?foo=1'), const BootTarget(AppTab.plan));
+  });
+
+  test('unknown and over-long paths parse to null (plain catch-all)', () {
+    for (final path in [
+      '/nope',
+      '/trips/a/b',
+      '/plan/a/b',
+      '/admin',
+      '/admin/nope',
+      '/trip',
+      // Token routes are matched before the grammar in generateRoute, but the
+      // grammar itself must not claim them either.
+      '/share/tok',
+      '/sso/code',
+    ]) {
+      expect(parse(path), isNull, reason: path);
+    }
+  });
+}

--- a/src/packages/flutter-app/test/deep_link_initial_routes_test.dart
+++ b/src/packages/flutter-app/test/deep_link_initial_routes_test.dart
@@ -16,7 +16,24 @@ void main() {
       '/reset/tok123',
       '/verify/tok123',
       '/sso/code123',
+      '/connect/tok123',
+      // URL persistence boot paths (specs/url-page-persistence) ride the same
+      // one-route invariant: each lands on a single AuthGate that restores
+      // the page inside the shell.
+      '/plan',
+      '/plan/chat-abc',
+      '/trips',
+      '/trips/t1',
+      '/trip/t1',
       '/alerts',
+      '/preferences',
+      '/account',
+      '/admin/metrics',
+      '/admin/local',
+      '/import',
+      '/guides',
+      '/notifications',
+      '/no-such-page',
     ]) {
       final routes = generateInitialRoutes(path);
       expect(routes, hasLength(1), reason: 'path $path');

--- a/src/packages/flutter-app/test/support/url_sync_fakes.dart
+++ b/src/packages/flutter-app/test/support/url_sync_fakes.dart
@@ -1,0 +1,81 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:travel_route_planner/models/trip.dart';
+import 'package:travel_route_planner/models/user.dart';
+import 'package:travel_route_planner/providers/auth_provider.dart';
+import 'package:travel_route_planner/services/api_client.dart';
+import 'package:travel_route_planner/services/trips_api_service.dart';
+
+/// Shared fakes for the URL-persistence tests (specs/url-page-persistence):
+/// they pump the real [TravelRoutePlannerApp], so the session and the trips
+/// backend both need deterministic stand-ins.
+
+/// Auth notifier whose state is fully script-controlled: starts resolved
+/// (signed in when [user] is non-null), and flips via [signIn]/[signOut] so
+/// tests can drive the auth transitions URL sync listens for.
+class FakeAuthNotifier extends StateNotifier<AuthState>
+    implements AuthNotifier {
+  FakeAuthNotifier(UserModel? user)
+      : super(AuthState(user: user, initialized: true));
+
+  void signIn(UserModel user) => state = state.copyWith(user: user);
+
+  void signOut() => state = state.copyWith(clearUser: true);
+
+  @override
+  void clearError() => state = state.copyWith(clearError: true);
+
+  @override
+  Future<bool> login(String email, String password) async => false;
+
+  @override
+  Future<bool> register(String email, String password,
+          {String? displayName}) async =>
+      false;
+
+  @override
+  Future<void> completeOnboarding() async {}
+
+  @override
+  Future<void> logout() async {}
+
+  @override
+  Future<void> signOutLocally() async {}
+
+  @override
+  void setUser(UserModel user) {}
+
+  @override
+  Future<void> adoptSession(String token, UserModel user) async {}
+}
+
+class FakeTripsApiService extends TripsApiService {
+  final Trip trip;
+
+  FakeTripsApiService(this.trip) : super(ApiClient(baseUrl: 'http://test'));
+
+  @override
+  Future<Trip> getTrip(String id) async => trip;
+
+  @override
+  Future<List<Trip>> listTrips() async => [trip];
+
+  @override
+  Future<List<Trip>> listSharedWithMe() async => const [];
+}
+
+UserModel fakeUser() => UserModel(
+      id: 'user-1',
+      email: 'test@example.com',
+      displayName: 'Brian',
+      createdAt: DateTime(2026, 1, 1),
+    );
+
+Trip fakeTrip(String id) => Trip(
+      id: id,
+      title: 'Lisbon long weekend',
+      status: 'planned',
+      createdAt: '2026-06-01',
+      updatedAt: '2026-06-01',
+      items: const [],
+    );

--- a/src/packages/flutter-app/test/url_boot_restore_test.dart
+++ b/src/packages/flutter-app/test/url_boot_restore_test.dart
@@ -1,0 +1,123 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:travel_route_planner/main.dart';
+import 'package:travel_route_planner/models/user.dart';
+import 'package:travel_route_planner/navigation/app_nav.dart';
+import 'package:travel_route_planner/navigation/url_sync.dart';
+import 'package:travel_route_planner/providers/auth_provider.dart';
+import 'package:travel_route_planner/providers/live_trip_provider.dart';
+import 'package:travel_route_planner/providers/resumable_chats_provider.dart';
+import 'package:travel_route_planner/providers/trips_provider.dart';
+import 'package:travel_route_planner/screens/alerts_screen.dart';
+import 'package:travel_route_planner/screens/app_shell.dart';
+import 'package:travel_route_planner/screens/import_trip_screen.dart';
+import 'package:travel_route_planner/screens/landing_screen.dart';
+import 'package:travel_route_planner/screens/trip_detail_screen.dart';
+
+import 'support/url_sync_fakes.dart';
+
+/// Boot restore (specs/url-page-persistence): pumping the real app with a
+/// deep-link boot URL must land inside the shell on the URL's page — the
+/// refresh-doesn't-lose-your-place half of URL persistence.
+void main() {
+  late FakeAuthNotifier auth;
+  late List<String> reports;
+
+  Future<void> pumpApp(
+    WidgetTester tester, {
+    required String initialUrl,
+    UserModel? user,
+  }) async {
+    tester.binding.platformDispatcher.defaultRouteNameTestValue = initialUrl;
+    auth = FakeAuthNotifier(user);
+    reports = <String>[];
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          authProvider.overrideWith((ref) => auth),
+          tripsApiServiceProvider
+              .overrideWithValue(FakeTripsApiService(fakeTrip('t1'))),
+          liveTripProvider.overrideWithValue(null),
+          resumableChatsProvider.overrideWith((ref) async => const []),
+          urlReporterProvider.overrideWithValue(reports.add),
+        ],
+        child: const TravelRoutePlannerApp(),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  T read<T>(WidgetTester tester, ProviderListenable<T> provider) =>
+      ProviderScope.containerOf(
+              tester.element(find.byType(TravelRoutePlannerApp)))
+          .read(provider);
+
+  setUp(() => SharedPreferences.setMockInitialValues({}));
+
+  testWidgets('booting /trips/<id> restores trip detail inside the shell',
+      (tester) async {
+    await pumpApp(tester, initialUrl: '/trips/t1', user: fakeUser());
+
+    expect(find.byType(AppShell), findsOneWidget);
+    expect(read(tester, navIndexProvider), AppTab.trips.index);
+    final detail =
+        tester.widget<TripDetailScreen>(find.byType(TripDetailScreen));
+    expect(detail.tripId, 't1');
+    expect(reports.last, '/trips/t1');
+  });
+
+  testWidgets('the /trip/<id> connector alias opens the trip and normalizes',
+      (tester) async {
+    await pumpApp(tester, initialUrl: '/trip/t1', user: fakeUser());
+
+    expect(find.byType(TripDetailScreen), findsOneWidget);
+    expect(reports.last, '/trips/t1');
+  });
+
+  testWidgets('booting /alerts restores the screen in-shell on the home tab',
+      (tester) async {
+    await pumpApp(tester, initialUrl: '/alerts', user: fakeUser());
+
+    expect(find.byType(AppShell), findsOneWidget);
+    expect(read(tester, navIndexProvider), AppTab.home.index);
+    expect(find.byType(AlertsScreen), findsOneWidget);
+    expect(reports.last, '/alerts');
+  });
+
+  testWidgets('booting /import restores onto the trips tab', (tester) async {
+    await pumpApp(tester, initialUrl: '/import', user: fakeUser());
+
+    expect(read(tester, navIndexProvider), AppTab.trips.index);
+    expect(find.byType(ImportTripScreen), findsOneWidget);
+    expect(reports.last, '/import');
+  });
+
+  testWidgets('an unknown path behaves like the plain catch-all',
+      (tester) async {
+    await pumpApp(tester, initialUrl: '/no-such-page', user: fakeUser());
+
+    expect(find.byType(AppShell), findsOneWidget);
+    expect(read(tester, navIndexProvider), AppTab.home.index);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('signed-out deep link waits on the landing page, then lands',
+      (tester) async {
+    await pumpApp(tester, initialUrl: '/trips/t1', user: null);
+
+    expect(find.byType(LandingScreen), findsOneWidget);
+    expect(find.byType(AppShell), findsNothing);
+    // The bare-boot gate: nothing may rewrite the URL while signed out.
+    expect(reports, isEmpty);
+
+    auth.signIn(fakeUser());
+    await tester.pumpAndSettle();
+
+    expect(find.byType(AppShell), findsOneWidget);
+    expect(read(tester, navIndexProvider), AppTab.trips.index);
+    expect(find.byType(TripDetailScreen), findsOneWidget);
+    expect(reports.last, '/trips/t1');
+  });
+}

--- a/src/packages/flutter-app/test/url_plan_chat_test.dart
+++ b/src/packages/flutter-app/test/url_plan_chat_test.dart
@@ -1,0 +1,123 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:travel_route_planner/main.dart';
+import 'package:travel_route_planner/models/chat_session.dart';
+import 'package:travel_route_planner/models/plan_message.dart';
+import 'package:travel_route_planner/navigation/app_nav.dart';
+import 'package:travel_route_planner/navigation/url_sync.dart';
+import 'package:travel_route_planner/providers/auth_provider.dart';
+import 'package:travel_route_planner/providers/live_trip_provider.dart';
+import 'package:travel_route_planner/providers/plan_provider.dart';
+import 'package:travel_route_planner/providers/resumable_chats_provider.dart';
+import 'package:travel_route_planner/providers/trips_provider.dart';
+import 'package:travel_route_planner/services/api_client.dart';
+import 'package:travel_route_planner/services/chats_api_service.dart';
+
+import 'support/url_sync_fakes.dart';
+
+/// /plan/<chatId> (specs/url-page-persistence): the Plan tab's URL carries
+/// the conversation id once one exists, and booting on it rehydrates the
+/// transcript — with a silent fresh-chat fallback when there is nothing to
+/// restore (trip-bound, foreign, or expired ids).
+class _FakeChatsApiService extends ChatsApiService {
+  final ChatSessionDetail? detail;
+
+  _FakeChatsApiService(this.detail) : super(ApiClient(baseUrl: 'http://test'));
+
+  @override
+  Future<ChatSessionDetail> getChat(String chatId) async {
+    final d = detail;
+    if (d == null || d.chatId != chatId) {
+      throw Exception('no stored transcript (404)');
+    }
+    return d;
+  }
+}
+
+ChatSessionDetail _detail(String chatId) => ChatSessionDetail(
+      chatId: chatId,
+      title: 'Greek islands',
+      summary: '',
+      messages: const [
+        ChatSessionMessage(role: 'user', content: 'Plan me an island hop'),
+        ChatSessionMessage(role: 'assistant', content: 'Naxos then Paros.'),
+      ],
+      updatedAt: '2026-07-02T10:00:00Z',
+    );
+
+void main() {
+  late List<String> reports;
+
+  Future<ProviderContainer> pumpApp(
+    WidgetTester tester, {
+    required String initialUrl,
+    ChatSessionDetail? storedChat,
+  }) async {
+    tester.binding.platformDispatcher.defaultRouteNameTestValue = initialUrl;
+    reports = <String>[];
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          authProvider.overrideWith((ref) => FakeAuthNotifier(fakeUser())),
+          tripsApiServiceProvider
+              .overrideWithValue(FakeTripsApiService(fakeTrip('t1'))),
+          chatsApiServiceProvider
+              .overrideWithValue(_FakeChatsApiService(storedChat)),
+          liveTripProvider.overrideWithValue(null),
+          resumableChatsProvider.overrideWith((ref) async => const []),
+          urlReporterProvider.overrideWithValue(reports.add),
+        ],
+        child: const TravelRoutePlannerApp(),
+      ),
+    );
+    await tester.pumpAndSettle();
+    return ProviderScope.containerOf(
+        tester.element(find.byType(TravelRoutePlannerApp)));
+  }
+
+  setUp(() => SharedPreferences.setMockInitialValues({}));
+
+  testWidgets('booting /plan/<chatId> rehydrates the conversation',
+      (tester) async {
+    final container = await pumpApp(tester,
+        initialUrl: '/plan/c1', storedChat: _detail('c1'));
+
+    expect(container.read(navIndexProvider), AppTab.plan.index);
+    final plan = container.read(planProvider);
+    expect(plan.chatId, 'c1');
+    expect(plan.messages, hasLength(2));
+    expect(plan.messages.first.role, MessageRole.user);
+    expect(reports.last, '/plan/c1');
+  });
+
+  testWidgets('a chat with no stored transcript degrades to a fresh Plan tab',
+      (tester) async {
+    final container =
+        await pumpApp(tester, initialUrl: '/plan/gone', storedChat: null);
+
+    expect(container.read(navIndexProvider), AppTab.plan.index);
+    final plan = container.read(planProvider);
+    expect(plan.chatId, isNull);
+    expect(plan.messages, isEmpty);
+    expect(reports.last, '/plan');
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('resume and Start over move the Plan tab URL', (tester) async {
+    final container = await pumpApp(tester, initialUrl: '/');
+
+    final notifier = container.read(planProvider.notifier);
+    notifier.resumeConversation(chatId: 'c9', messages: const [
+      PlanMessage(role: MessageRole.user, content: 'hello'),
+    ]);
+    container.read(navIndexProvider.notifier).state = AppTab.plan.index;
+    await tester.pumpAndSettle();
+    expect(reports.last, '/plan/c9');
+
+    notifier.reset();
+    await tester.pumpAndSettle();
+    expect(reports.last, '/plan');
+  });
+}

--- a/src/packages/flutter-app/test/url_sync_report_test.dart
+++ b/src/packages/flutter-app/test/url_sync_report_test.dart
@@ -1,0 +1,143 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:travel_route_planner/main.dart';
+import 'package:travel_route_planner/navigation/app_nav.dart';
+import 'package:travel_route_planner/navigation/url_sync.dart';
+import 'package:travel_route_planner/providers/auth_provider.dart';
+import 'package:travel_route_planner/providers/live_trip_provider.dart';
+import 'package:travel_route_planner/providers/resumable_chats_provider.dart';
+import 'package:travel_route_planner/providers/trips_provider.dart';
+import 'package:travel_route_planner/screens/app_shell.dart';
+import 'package:travel_route_planner/screens/trip_detail_screen.dart';
+
+import 'support/url_sync_fakes.dart';
+
+/// The write half of URL persistence (specs/url-page-persistence): every
+/// page change — tab switch, located push, pop, sign-out — must land in the
+/// address bar, and unnamed routes must leave it alone.
+void main() {
+  late FakeAuthNotifier auth;
+  late List<String> reports;
+
+  Future<ProviderContainer> pumpApp(WidgetTester tester) async {
+    tester.binding.platformDispatcher.defaultRouteNameTestValue = '/';
+    auth = FakeAuthNotifier(fakeUser());
+    reports = <String>[];
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          authProvider.overrideWith((ref) => auth),
+          tripsApiServiceProvider
+              .overrideWithValue(FakeTripsApiService(fakeTrip('t1'))),
+          liveTripProvider.overrideWithValue(null),
+          resumableChatsProvider.overrideWith((ref) async => const []),
+          urlReporterProvider.overrideWithValue(reports.add),
+        ],
+        child: const TravelRoutePlannerApp(),
+      ),
+    );
+    await tester.pumpAndSettle();
+    return ProviderScope.containerOf(
+        tester.element(find.byType(TravelRoutePlannerApp)));
+  }
+
+  setUp(() => SharedPreferences.setMockInitialValues({}));
+
+  testWidgets('tab switches report each tab root', (tester) async {
+    final container = await pumpApp(tester);
+    expect(reports.last, '/');
+
+    container.read(navIndexProvider.notifier).state = AppTab.plan.index;
+    await tester.pumpAndSettle();
+    expect(reports.last, '/plan');
+
+    container.read(navIndexProvider.notifier).state = AppTab.trips.index;
+    await tester.pumpAndSettle();
+    expect(reports.last, '/trips');
+  });
+
+  testWidgets('opening and closing a trip keeps the URL in step',
+      (tester) async {
+    final container = await pumpApp(tester);
+    container.read(navIndexProvider.notifier).state = AppTab.trips.index;
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Lisbon long weekend'));
+    await tester.pumpAndSettle();
+    expect(find.byType(TripDetailScreen), findsOneWidget);
+    expect(reports.last, '/trips/t1');
+
+    await tester.pageBack();
+    await tester.pumpAndSettle();
+    expect(reports.last, '/trips');
+  });
+
+  testWidgets('per-tab memory: switching away and back restores the page URL',
+      (tester) async {
+    final container = await pumpApp(tester);
+    container.read(navIndexProvider.notifier).state = AppTab.trips.index;
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Lisbon long weekend'));
+    await tester.pumpAndSettle();
+    expect(reports.last, '/trips/t1');
+
+    container.read(navIndexProvider.notifier).state = AppTab.home.index;
+    await tester.pumpAndSettle();
+    expect(reports.last, '/');
+
+    // IndexedStack kept the trips stack alive, so the URL must say so too.
+    container.read(navIndexProvider.notifier).state = AppTab.trips.index;
+    await tester.pumpAndSettle();
+    expect(reports.last, '/trips/t1');
+  });
+
+  testWidgets('unnamed pushes leave the URL at the page beneath',
+      (tester) async {
+    final container = await pumpApp(tester);
+    container.read(navIndexProvider.notifier).state = AppTab.trips.index;
+    await tester.pumpAndSettle();
+    expect(reports.last, '/trips');
+
+    // An in-tab unnamed push (the LocalGuideDetail/FlightSearch class of
+    // screens): no report.
+    final tabNav = container
+        .read(tabNavKeysProvider)[AppTab.trips.index]
+        .currentState!;
+    tabNav.push(MaterialPageRoute(
+        builder: (_) => const Scaffold(body: Text('unnamed page'))));
+    await tester.pumpAndSettle();
+    expect(reports.last, '/trips');
+
+    tabNav.pop();
+    await tester.pumpAndSettle();
+    expect(reports.last, '/trips');
+
+    // A root-navigator unnamed push + pop (the TripMapScreen shape): the
+    // root observer re-asserts, so the last word stays the shell's location.
+    final rootNav = Navigator.of(tester.element(find.byType(AppShell)),
+        rootNavigator: true);
+    rootNav.push(MaterialPageRoute(
+        fullscreenDialog: true,
+        builder: (_) => const Scaffold(body: Text('fullscreen dialog'))));
+    await tester.pumpAndSettle();
+    expect(reports.last, '/trips');
+
+    rootNav.pop();
+    await tester.pumpAndSettle();
+    expect(reports.last, '/trips');
+  });
+
+  testWidgets('signing out resets the URL to the root', (tester) async {
+    final container = await pumpApp(tester);
+    container.read(navIndexProvider.notifier).state = AppTab.trips.index;
+    await tester.pumpAndSettle();
+    expect(reports.last, '/trips');
+
+    auth.signOut();
+    await tester.pumpAndSettle();
+    expect(reports.last, '/');
+  });
+}


### PR DESCRIPTION
## Summary
- The browser URL now tracks the page you're on — tabs (`/`, `/plan`, `/trips`), trip detail (`/trips/<id>`), the plan conversation (`/plan/<chatId>`), and the zero-arg utility screens (`/alerts`, `/preferences`, `/account`, `/admin/*`, `/import`, `/guides`, `/notifications`) — so a refresh restores that page inside the shell instead of dumping you on Home.
- Write half: `UrlSyncController` (new `lib/navigation/url_sync.dart`) derives the location from the active tab + its topmost named route via per-tab NavigatorObservers, and *replaces* the browser entry through `SystemNavigator.routeInformationUpdated` (single-entry history — no history-stack change; browser back keeps its pop behavior) behind a test-overridable `urlReporterProvider` seam. Deliberately-unnamed pushes (trip map, guide detail, flight search, auth) keep the URL of the page beneath.
- Read half: `generateRoute` parses recognized paths into a `BootTarget` (new `lib/navigation/app_routes.dart`, one round-trippable grammar shared by both halves) carried through `AuthGate`; URL sync consumes it once the session resolves signed-in-and-onboarded — tab synchronously, inner screen via the bounded retry-push pattern. Deep links now boot inside the shell (previously `/trip/<id>` and `/alerts` booted bare), and a signed-out deep link lands on the target after email/password sign-in.
- `/trips/<id>` becomes the canonical trip URL — fixing the re-engagement email links (`/trips/<uuid>`), which previously fell through to Home — with `/trip/<id>` kept as a read-only alias for MCP-connector links.
- `/plan/<chatId>` rehydrates the persisted transcript via `resumePlanChat` (extracted from `ContinueChatCard`, now shared) and degrades silently to a fresh Plan tab when no transcript exists (trip-bound/foreign/expired ids). Sign-out resets the URL to `/`.
- Token deep-link flows (`/share`, `/invite`, `/reset`, `/verify`, `/sso`, `/connect`) are untouched and still boot bare; the one-initial-route invariant (ff3c907) holds for every new path. `trip_detail_screen.dart` deliberately not touched (hub file). No Go/API/nginx changes.

## Testing
- `flutter analyze` clean (3 pre-existing infos in `route_response.dart` only).
- `flutter test`: full suite green (651 tests), including 21 new/extended: grammar round-trip (`app_routes_test`), one-route invariant for all new paths (`deep_link_initial_routes_test`), real-app boot restores via `defaultRouteNameTestValue` — trip detail, alias normalization, in-shell alerts/import, unknown-path catch-all, signed-out→sign-in lands on target (`url_boot_restore_test`), reporting behavior — tab switch, push/pop, per-tab memory, unnamed pushes, root-navigator re-assert, sign-out reset (`url_sync_report_test`), and chat resume happy path + 404 degrade + Start-over (`url_plan_chat_test`).
- Manual pass in real headless Chrome against the lane dev stack (CDP, `location.pathname` assertions + screenshots): tab switch, trip open, **hard reload on `/trips/<id>` restores the trip in-shell**, browser back, `/trip/<id>` alias normalization, `/plan/<chatId>` transcript restore, missing-chat degrade to `/plan`, `/preferences` reload restore, sign-out reset to `/`, and the SSO handoff flow (used for the login itself) unaffected.
- SDK behavior verified against Flutter 3.35.4 sources (pinned in CI + both Dockerfiles): `routeInformationUpdated` replaces the entry in single-entry mode and does not switch history modes; framework auto-reports fire only for named routes. Findings recorded in `specs/url-page-persistence/plan.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)