### PR TITLE
feat(map): home-airport legs on the inline trip card + desktop expand button

### DIFF
--- a/docs/friction-log.md
+++ b/docs/friction-log.md
@@ -5,6 +5,21 @@ build queue. Priority when picking work: **breakage > friction in features
 actually used > ideas that recur across ≥2 sessions**. Tag entries `[app]`
 (dogfooding the product) or `[dev]` (workflow/tooling). Newest first.
 
+## 2026-08-04 — trip-detail dogfooding (map home legs)
+
+- **[app] Friction re-filed → fixed (shipped-but-unreachable):** "Map doesn't
+  show arrows to and from home airport" came back hours after PR #286 shipped
+  the home-airport legs — because they render only on the full-screen map,
+  whose sole entry points (tap-to-expand + fullscreen button) are phone-only
+  (`expandable` is gated on `< 800px`). At the desktop widths the app is
+  dogfooded at, the feature was structurally invisible; the item also never
+  made it into this log, so nothing flagged the gap. Fix: the inline
+  trip-detail card now draws the legs itself (same All/Day 1/last-day gating,
+  whole-journey fit) and the wide card gets a fullscreen control beside the
+  zoom column, so the big map is finally reachable on desktop. Lesson: **a
+  feature scoped to one surface must ship with a reachability check on every
+  breakpoint** — "the tap-to-expand map" didn't exist at ≥800px.
+
 ## 2026-08-04 — trip-detail dogfooding (cluster order)
 
 - **[app] Friction recurred → fixed (reorder, not relocation):** the 08-03

--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -4239,6 +4239,15 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
     Set<int> mappedDays, {
     required bool expandable,
   }) {
+    final endpoints = _homeLegEndpoints(trip);
+    final home = homeOverlayFor(
+      ref,
+      homeAirport: _homeAirport,
+      day: _selectedDay,
+      dayCount: mapDayCount,
+      firstCityPoint: endpoints.first,
+      lastCityPoint: endpoints.last,
+    );
     Widget map = TripMap(
       items: _dayFiltered(trip, _selectedDay),
       accommodations: _dayFilteredStays(trip, _selectedDay),
@@ -4248,6 +4257,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
       // across the gaps a day filter creates, and the category filter
       // already empties this map.
       segmentLabels: _segmentLabels(),
+      home: home,
       fitSignature: _selectedDay,
       // Keep fitted markers clear of the chip row overlaid below.
       topOverlayInset: mapDayCount > 0 ? MapDayChips.mapTopInset : 0,
@@ -4272,6 +4282,9 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
               final it = trip.items!.firstWhere((i) => i.position == pos);
               _showSnack(it.name);
             },
+      onExpand: expandable
+          ? null
+          : () => _openFullMap(trip, mapDayCount, mappedDays),
     );
     if (expandable) {
       map = GestureDetector(
@@ -4313,16 +4326,25 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
     );
   }
 
+  /// Home-leg endpoints are the trip's first/last location groups — the same
+  /// derivation the outbound/return booking todos trust — never the first/
+  /// last mapped pin, which shifts under day/category filters.
+  ({LatLng? first, LatLng? last}) _homeLegEndpoints(Trip trip) {
+    final ranges = _locationGroupRanges(trip);
+    final firstCoord = ranges.isEmpty ? null : ranges.first.coord;
+    final lastCoord = ranges.isEmpty ? null : ranges.last.coord;
+    return (
+      first:
+          firstCoord == null ? null : LatLng(firstCoord.lat, firstCoord.lng),
+      last: lastCoord == null ? null : LatLng(lastCoord.lat, lastCoord.lng),
+    );
+  }
+
   /// Pushes the full-screen interactive map. Root navigator so the map
   /// covers the bottom navigation bar; the closures read the live [_trip] so
   /// a silent refresh propagates on the next chip tap.
   void _openFullMap(Trip trip, int mapDayCount, Set<int> mappedDays) {
-    // Home-leg endpoints are the trip's first/last location groups — the same
-    // derivation the outbound/return booking todos trust — never the first/
-    // last mapped pin, which shifts under day/category filters.
-    final ranges = _locationGroupRanges(trip);
-    final firstCoord = ranges.isEmpty ? null : ranges.first.coord;
-    final lastCoord = ranges.isEmpty ? null : ranges.last.coord;
+    final endpoints = _homeLegEndpoints(trip);
     Navigator.of(context, rootNavigator: true).push(
       MaterialPageRoute(
         fullscreenDialog: true,
@@ -4330,10 +4352,8 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
           title: _displayTitle(trip),
           destinations: _mapDestinations(trip),
           homeAirport: _homeAirport,
-          firstCityPoint:
-              firstCoord == null ? null : LatLng(firstCoord.lat, firstCoord.lng),
-          lastCityPoint:
-              lastCoord == null ? null : LatLng(lastCoord.lat, lastCoord.lng),
+          firstCityPoint: endpoints.first,
+          lastCityPoint: endpoints.last,
           itemsForDay: (d) {
             final t = _trip;
             return t == null ? const <ItineraryItem>[] : _dayFiltered(t, d);

--- a/src/packages/flutter-app/lib/screens/trip_map_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_map_screen.dart
@@ -12,6 +12,35 @@ import '../widgets/gradient_app_bar.dart';
 import '../widgets/map_day_chips.dart';
 import '../widgets/trip_map.dart';
 
+/// Builds the home-airport overlay for a trip-map surface, or null while the
+/// IATA → coordinate lookup is pending / failed (the map simply omits the
+/// legs; the provider watch rebuilds when it resolves). The outbound leg
+/// belongs to day 1 and the return leg to the last day, so mid-trip day
+/// chips show no orphan home pin. Shared by the full-screen map and the
+/// inline trip-detail card so both surfaces gate identically.
+TripMapHome? homeOverlayFor(
+  WidgetRef ref, {
+  required String? homeAirport,
+  required int? day, // null = All
+  required int dayCount, // the surface's mapDayCount
+  required LatLng? firstCityPoint,
+  required LatLng? lastCityPoint,
+}) {
+  final code = homeAirport;
+  if (code == null || code.isEmpty) return null;
+  final point = ref.watch(homeAirportPointProvider(code)).valueOrNull;
+  if (point == null) return null;
+  final outboundTo = (day == null || day == 1) ? firstCityPoint : null;
+  final returnFrom = (day == null || day == dayCount) ? lastCityPoint : null;
+  if (outboundTo == null && returnFrom == null) return null;
+  return TripMapHome(
+    point: LatLng(point.lat, point.lng),
+    label: code,
+    outboundTo: outboundTo,
+    returnFrom: returnFrom,
+  );
+}
+
 /// Full-screen interactive trip map, pushed from the trip detail screen on
 /// phones (where the inline map is a static tap-to-expand preview). Pushed as
 /// a `fullscreenDialog` route so the framework provides the localized close
@@ -83,28 +112,14 @@ class _TripMapScreenState extends ConsumerState<TripMapScreen> {
   late int? _day = widget.initialDay;
   int? _selectedPosition;
 
-  /// The home overlay for the current day selection, or null while the IATA →
-  /// coordinate lookup is pending / failed (the map simply omits the legs;
-  /// the provider watch rebuilds when it resolves). The outbound leg belongs
-  /// to day 1 and the return leg to the last day, so mid-trip day chips show
-  /// no orphan home pin.
-  TripMapHome? _homeOverlay() {
-    final code = widget.homeAirport;
-    if (code == null || code.isEmpty) return null;
-    final point = ref.watch(homeAirportPointProvider(code)).valueOrNull;
-    if (point == null) return null;
-    final outboundTo =
-        (_day == null || _day == 1) ? widget.firstCityPoint : null;
-    final returnFrom =
-        (_day == null || _day == widget.dayCount) ? widget.lastCityPoint : null;
-    if (outboundTo == null && returnFrom == null) return null;
-    return TripMapHome(
-      point: LatLng(point.lat, point.lng),
-      label: code,
-      outboundTo: outboundTo,
-      returnFrom: returnFrom,
-    );
-  }
+  TripMapHome? _homeOverlay() => homeOverlayFor(
+        ref,
+        homeAirport: widget.homeAirport,
+        day: _day,
+        dayCount: widget.dayCount,
+        firstCityPoint: widget.firstCityPoint,
+        lastCityPoint: widget.lastCityPoint,
+      );
 
   @override
   Widget build(BuildContext context) {

--- a/src/packages/flutter-app/lib/widgets/trip_map.dart
+++ b/src/packages/flutter-app/lib/widgets/trip_map.dart
@@ -134,8 +134,8 @@ class TripMap extends StatefulWidget {
   final bool interactive;
 
   /// Home-airport overlay: dashed outbound/return legs, a home pin, and the
-  /// home point joining the camera fit. Null — the default, and what the
-  /// inline map card and shared views pass — renders exactly as before.
+  /// home point joining the camera fit. Null — the default, and what shared
+  /// views pass — renders exactly as before.
   final TripMapHome? home;
 
   /// Trip-overview destination pins (see [TripMapDestination]). With ≥2
@@ -144,6 +144,11 @@ class TripMap extends StatefulWidget {
   /// single-city trips — keeps per-item pins, so existing call sites are
   /// unchanged.
   final List<TripMapDestination>? destinations;
+
+  /// Opens the full-screen map. Non-null renders a fullscreen button beside
+  /// the zoom/reset column when [interactive]; null — the default — keeps
+  /// the control stack exactly as before.
+  final VoidCallback? onExpand;
 
   const TripMap({
     super.key,
@@ -160,6 +165,7 @@ class TripMap extends StatefulWidget {
     this.interactive = true,
     this.home,
     this.destinations,
+    this.onExpand,
   });
 
   /// Whether [a] would render as a stay pin: geocoded (null means "not
@@ -723,25 +729,42 @@ class _TripMapState extends State<TripMap> {
               Positioned(
                 right: 8,
                 bottom: 8,
-                child: Column(
+                // The expand button sits beside the zoom column, not above
+                // it: stacked, the strip would reach into the day-chip band
+                // on the 240px inline card.
+                child: Row(
                   mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.end,
                   children: [
-                    MapControlButton(
-                      icon: Icons.add,
-                      tooltip: l10n.mapZoomIn,
-                      onTap: () => _zoomBy(1),
-                    ),
-                    const SizedBox(height: 8),
-                    MapControlButton(
-                      icon: Icons.remove,
-                      tooltip: l10n.mapZoomOut,
-                      onTap: () => _zoomBy(-1),
-                    ),
-                    const SizedBox(height: 8),
-                    MapControlButton(
-                      icon: Icons.zoom_in_map,
-                      tooltip: l10n.mapResetMap,
-                      onTap: () => _fitToTrip(fitPoints),
+                    if (widget.onExpand != null) ...[
+                      MapControlButton(
+                        icon: Icons.fullscreen,
+                        tooltip: l10n.tripExpandMap,
+                        onTap: widget.onExpand!,
+                      ),
+                      const SizedBox(width: 8),
+                    ],
+                    Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        MapControlButton(
+                          icon: Icons.add,
+                          tooltip: l10n.mapZoomIn,
+                          onTap: () => _zoomBy(1),
+                        ),
+                        const SizedBox(height: 8),
+                        MapControlButton(
+                          icon: Icons.remove,
+                          tooltip: l10n.mapZoomOut,
+                          onTap: () => _zoomBy(-1),
+                        ),
+                        const SizedBox(height: 8),
+                        MapControlButton(
+                          icon: Icons.zoom_in_map,
+                          tooltip: l10n.mapResetMap,
+                          onTap: () => _fitToTrip(fitPoints),
+                        ),
+                      ],
                     ),
                   ],
                 ),

--- a/src/packages/flutter-app/test/shared_trip_day_chips_test.dart
+++ b/src/packages/flutter-app/test/shared_trip_day_chips_test.dart
@@ -124,6 +124,9 @@ void main() {
     // carries no empty-state CTA.
     expect(tester.widget<MapDayChips>(chips).mappedDays, {1, 2});
     expect(map(tester).emptyAction, isNull);
+
+    // Shared views are viewer-agnostic: never a home-airport overlay.
+    expect(map(tester).home, isNull);
   });
 
   testWidgets('day chip filters the shared map; All restores',

--- a/src/packages/flutter-app/test/trip_detail_home_legs_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_home_legs_test.dart
@@ -1,0 +1,181 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:latlong2/latlong.dart';
+
+import 'package:travel_route_planner/models/accommodation.dart';
+import 'package:travel_route_planner/models/trip.dart';
+import 'package:travel_route_planner/models/itinerary_item.dart';
+import 'package:travel_route_planner/models/traveler_preferences.dart';
+import 'package:travel_route_planner/providers/flights_provider.dart';
+import 'package:travel_route_planner/providers/preferences_provider.dart';
+import 'package:travel_route_planner/providers/trips_provider.dart';
+import 'package:travel_route_planner/screens/trip_detail_screen.dart';
+import 'package:travel_route_planner/services/api_client.dart';
+import 'package:travel_route_planner/services/preferences_api_service.dart';
+import 'package:travel_route_planner/services/trips_api_service.dart';
+import 'package:travel_route_planner/widgets/map_day_chips.dart';
+import 'package:travel_route_planner/widgets/trip_map.dart';
+
+import 'support/l10n_test_app.dart';
+
+/// Home-airport legs on the INLINE trip-detail map card: the overlay follows
+/// the same day gating as the full-screen map (outbound on All/Day 1, return
+/// on All/last day, nothing mid-trip), keyed off the viewer's saved home
+/// airport. The default test surface (800x600) takes the wide pinned-card
+/// path, the surface the legs were invisible on before this feature.
+
+class _FakeTripsApiService extends TripsApiService {
+  final Trip trip;
+  _FakeTripsApiService(this.trip) : super(ApiClient(baseUrl: 'http://test'));
+
+  @override
+  Future<Trip> getTrip(String id) async => trip;
+}
+
+class _FakePrefsApi implements PreferencesApiService {
+  @override
+  ApiClient get apiClient => throw UnsupportedError('unused in tests');
+
+  @override
+  Future<TravelerPreferences> getPreferences() async =>
+      const TravelerPreferences(homeAirport: 'EWR');
+
+  @override
+  Future<TravelerPreferences> savePreferences({
+    String? budget,
+    String? pace,
+    required List<String> interests,
+    String? homeAirport,
+    String? profileNotes,
+  }) async =>
+      const TravelerPreferences(homeAirport: 'EWR');
+}
+
+/// Real (tight Paris-cluster) coordinates so the trip detail screen mounts a
+/// live TripMap instead of skipping it.
+ItineraryItem _item(int pos, String name, double lat, double lng, int day) =>
+    ItineraryItem(
+      id: 'i$pos',
+      position: pos,
+      name: name,
+      latitude: lat,
+      longitude: lng,
+      category: 'attraction',
+      day: day,
+      city: 'Paris',
+    );
+
+void main() {
+  // Newark; far from the Paris fixtures, same point the full-screen tests use.
+  const homePoint = (lat: 40.6895, lng: -74.1745);
+
+  // Sept 1–3 => Day 1..3 chips; Day 3 deliberately has nothing mappable, so
+  // the return-leg assertion also covers the on-map empty state (TripMap's
+  // home is a constructor argument, present whether or not tiles render).
+  final trip = Trip(
+    id: 't1',
+    title: 'Paris',
+    status: 'planned',
+    createdAt: '2026-06-01',
+    updatedAt: '2026-06-01',
+    startDate: '2026-09-01',
+    endDate: '2026-09-03',
+    items: [
+      _item(0, 'Louvre', 48.8606, 2.3376, 1),
+      _item(1, 'Orsay', 48.8600, 2.3266, 1),
+      _item(2, 'Pantheon', 48.8462, 2.3464, 2),
+    ],
+    accommodations: const [
+      Accommodation(
+        id: 'a1',
+        name: 'Night One Hotel',
+        latitude: 48.8630,
+        longitude: 2.3364,
+        checkIn: '2026-09-01',
+        checkOut: '2026-09-02',
+      ),
+    ],
+  );
+
+  Future<void> pumpScreen(WidgetTester tester, {bool withHome = true}) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          tripsApiServiceProvider.overrideWithValue(_FakeTripsApiService(trip)),
+          if (withHome) ...[
+            // Populates _homeAirport via the screen's prefs load...
+            preferencesApiServiceProvider.overrideWithValue(_FakePrefsApi()),
+            // ...and resolves the IATA to coordinates without the network.
+            homeAirportPointProvider('EWR')
+                .overrideWith((ref) async => homePoint),
+          ],
+        ],
+        child: MaterialApp(
+          localizationsDelegates: testLocalizationsDelegates,
+          home: const TripDetailScreen(tripId: 't1'),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  /// Scoped to MapDayChips: the itinerary list renders its own "Day N"
+  /// headers and an "All" category chip.
+  Future<void> tapChip(WidgetTester tester, String label) async {
+    await tester.tap(find.descendant(
+      of: find.byType(MapDayChips),
+      matching: find.text(label),
+    ));
+    await tester.pump();
+    await tester.pump(); // post-frame camera re-fit
+  }
+
+  TripMap map(WidgetTester tester) =>
+      tester.widget<TripMap>(find.byType(TripMap));
+
+  testWidgets('All draws both legs, the home pin, and the EWR label',
+      (WidgetTester tester) async {
+    await pumpScreen(tester);
+
+    final home = map(tester).home;
+    expect(home, isNotNull);
+    expect(home!.label, 'EWR');
+    expect(home.point, LatLng(homePoint.lat, homePoint.lng));
+    expect(home.outboundTo, isNotNull);
+    expect(home.returnFrom, isNotNull);
+    expect(find.byIcon(Icons.flight_takeoff), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('endpoint days keep their leg; mid-trip days get no overlay',
+      (WidgetTester tester) async {
+    await pumpScreen(tester);
+
+    await tapChip(tester, 'Day 1');
+    var home = map(tester).home;
+    expect(home!.outboundTo, isNotNull);
+    expect(home.returnFrom, isNull);
+
+    await tapChip(tester, 'Day 2');
+    expect(map(tester).home, isNull);
+    expect(find.byIcon(Icons.flight_takeoff), findsNothing);
+
+    await tapChip(tester, 'Day 3');
+    home = map(tester).home;
+    expect(home!.outboundTo, isNull);
+    expect(home.returnFrom, isNotNull);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('no saved home airport never touches the provider',
+      (WidgetTester tester) async {
+    // No homeAirportPointProvider override registered: a provider read would
+    // throw in this scope if the lookup path were exercised.
+    await pumpScreen(tester, withHome: false);
+
+    expect(map(tester).home, isNull);
+    expect(find.byIcon(Icons.flight_takeoff), findsNothing);
+    expect(tester.takeException(), isNull);
+  });
+}

--- a/src/packages/flutter-app/test/trip_detail_map_expand_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_map_expand_test.dart
@@ -145,13 +145,42 @@ void main() {
       (WidgetTester tester) async {
     await pumpScreen(tester, surface: const Size(1200, 800));
 
-    // Interactive inline: zoom controls present, no expand affordance.
+    // Interactive inline: zoom controls present, plus the fullscreen control
+    // in the map's own strip (the full-screen map used to be unreachable at
+    // wide widths).
     expect(inMap(find.byIcon(Icons.add)), findsOneWidget);
-    expect(find.byIcon(Icons.fullscreen), findsNothing);
+    expect(inMap(find.byIcon(Icons.fullscreen)), findsOneWidget);
 
     // Pinned: scrolling the page leaves the map in the viewport.
     await tester.drag(find.byType(CustomScrollView), const Offset(0, -400));
     await tester.pump();
     expect(find.byType(TripMap), findsOneWidget);
+  });
+
+  testWidgets(
+      'wide: the fullscreen control opens the full-screen map; a day picked '
+      'there survives closing', (WidgetTester tester) async {
+    await pumpScreen(tester, surface: const Size(1200, 800));
+
+    await tester.tap(inMap(find.byIcon(Icons.fullscreen)));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(TripMapScreen), findsOneWidget);
+
+    final chips = find.byType(MapDayChips);
+    await tester.tap(find.descendant(of: chips, matching: find.text('Day 2')));
+    await tester.pump();
+    await tester.pump(); // post-frame camera re-fit
+
+    final fullMap = tester.widget<TripMap>(find.byType(TripMap));
+    expect(fullMap.items.map((i) => i.name), ['Pantheon']);
+
+    await tester.tap(find.byType(CloseButton));
+    await tester.pumpAndSettle();
+
+    // Back on the trip screen, the inline chips kept the selection.
+    expect(find.byType(TripMapScreen), findsNothing);
+    final inlineChips = tester.widget<MapDayChips>(find.byType(MapDayChips));
+    expect(inlineChips.selected, 2);
   });
 }


### PR DESCRIPTION
## Summary
- Friction re-filed 2026-08-04: "Map doesn't show arrows to and from home airport" — PR #286's home legs render only on the full-screen map, and that map's only entry points (`tap-to-expand` + fullscreen button) are gated on the `< 800px` phone branch, so the feature was **structurally unreachable at desktop widths**. Approved direction: legs on the inline card AND a wide expand affordance.
- **Inline trip-detail card draws the home overlay itself**: `TripMapScreen._homeOverlay` is extracted to a shared top-level `homeOverlayFor(ref, …)` so both surfaces gate identically — outbound leg on All/Day 1, return on All/last day, nothing mid-trip; the home point joins the auto-fit only on those endpoint days, so daily (mid-trip) framing stays tight. Endpoint derivation is hoisted into `_homeLegEndpoints` (first/last location groups, same values `_openFullMap` already passed).
- **`TripMap` grows an optional `onExpand`**: when set (and `interactive`), a fullscreen `MapControlButton` renders beside the zoom/reset column — beside, not stacked, because a 4-button stack would reach into the 64px day-chip band on the 240px card. Null (`TripMapScreen`, shared views, phone preview) keeps the control stack byte-identical. The wide card passes it; the phone preview keeps its existing external overlay button.
- Shared views still pass no `home` (now asserted). Friction-log entry added with the shipped-but-unreachable root cause.

## Testing
- `flutter analyze` — clean (3 pre-existing `route_response.dart` infos on main too).
- `make flutter-test` — full suite green (636 passed), including new `test/trip_detail_home_legs_test.dart` (All/Day 1/mid/last-day gating on the wide pinned card, EWR label + pin render, and the no-saved-pref case proving the coordinate provider is never touched), the flipped + new wide tests in `trip_detail_map_expand_test.dart` (fullscreen control present at 1200px, opens `TripMapScreen`, day picked there survives closing), and the shared-view `home == null` assertion. `trip_map_test.dart` / `trip_map_screen_test.dart` pass unchanged.
- Manual eyeball items for the dogfood pass (not run headless): control-strip spacing at exactly 800px wide, and how zoomed-out the 180px phone preview reads on All/endpoint days now that the fit includes home.

🤖 Generated with [Claude Code](https://claude.com/claude-code)