### PR TITLE
fix(trip): render squeezed legs as a zero-night stop at the arrival

### DIFF
--- a/docs/friction-log.md
+++ b/docs/friction-log.md
@@ -5,6 +5,24 @@ build queue. Priority when picking work: **breakage > friction in features
 actually used > ideas that recur across ≥2 sessions**. Tag entries `[app]`
 (dogfooding the product) or `[dev]` (workflow/tooling). Newest first.
 
+## 2026-08-05 — trip-detail dogfooding (leg dates, round four — later still)
+
+- **[app] Minor error → fixed (specs/set-leg-dates v4):** "Medellín should get
+  5 nights" worked and the squeeze was narrated + offered for fixing (round
+  three machinery), but the interim inverted state rendered "Medellín →
+  Quito, Sep 14" directly above "Stay in Quito, Sep 13" — check-in before
+  the flight lands. The arrival-adjustment only let the arrival win when it
+  was EARLIER than the leg's own start, and inter-city flight rows read the
+  previous leg's RAW end, so no local patch could make the chain coherent.
+  Fix: one shared visible-ranges derivation (`_visibleGroupRanges` client /
+  `visibleLegDisplayRange` server) — a squeezed leg collapses to a
+  zero-night stop at its arrival, cascading so downstream flights and
+  headers follow; confirmed stays never collapse; the honest no-op quotes
+  the zero-night render. Lesson: **when data can be legitimately
+  inconsistent mid-conversation, the renderer needs an explicit rule for the
+  inconsistent state too — "it can't happen" states that CAN happen
+  transiently still get looked at.**
+
 ## 2026-08-05 — trip-detail dogfooding (leg dates, round three — late)
 
 - **[app] BREAKAGE → fixed (specs/set-leg-dates v3):** after the Kraków move,

--- a/specs/set-leg-dates/spec.md
+++ b/specs/set-leg-dates/spec.md
@@ -93,6 +93,14 @@ the agent to chain follow-up set_leg_dates calls.
       nights left) gets a squeeze NOTE naming that leg; the agent offers to
       shift the remaining cities and chains one set_leg_dates call per leg
       (earliest first) in the same turn — no new tool parameters.
+- [ ] While a squeeze is unresolved (an INVERTED leg — the previous leg ran
+      past its departure day), the page renders it as a zero-night stop at
+      its arrival, cascading: stay row, header chip, and both flight dates
+      agree, and consecutive squeezed legs chain onto the same arrival
+      (client `_visibleGroupRanges` ↔ server `visibleLegDisplayRange`; the
+      honest no-op quotes the zero-night render). A confirmed stay's
+      explicit dates are never collapsed; partial overlaps (arrival lands
+      mid-leg with nights remaining) keep the leg's own start.
 - [ ] Auto-suggested (draft) stays/segments are never moved or confirmed by
       the tool; migration 00053 deletes the frozen pre-#274 rows and
       `checkLodging` skips any `auto` row, so a stale draft can't mask

--- a/src/packages/api/plan_leg_dates.go
+++ b/src/packages/api/plan_leg_dates.go
@@ -190,6 +190,36 @@ func anchoredLegDisplayRange(runs []legRun, i int, stays []store.Accommodation, 
 	return s, e
 }
 
+// visibleLegDisplayRange is the span the trip page actually RENDERS for run
+// i: anchoredLegDisplayRange with the arrival rule folded in, as a forward
+// pass over the dated runs so consecutive squeezed legs chain. A leg renders
+// from its arrival (the previous dated leg's VISIBLE end) when that comes
+// first; when the arrival has run PAST the leg's own last day, an
+// item-derived leg collapses to a zero-night stop at the arrival (a
+// confirmed stay's explicit dates never collapse — same carve-out as the
+// first-leg anchor). An arrival strictly inside the leg's own span keeps the
+// leg's start (partial overlap, unchanged). Mirrors _visibleGroupRanges in
+// trip_detail_screen.dart.
+func visibleLegDisplayRange(runs []legRun, i int, stays []store.Accommodation, tripStart time.Time) (time.Time, time.Time) {
+	var s, e, prevEnd time.Time
+	havePrev := false
+	for j := 0; j <= i; j++ {
+		if runs[j].minDay < 1 || runs[j].hub == "" {
+			continue
+		}
+		s, e = anchoredLegDisplayRange(runs, j, stays, tripStart)
+		if havePrev {
+			if prevEnd.Before(s) {
+				s = prevEnd
+			} else if prevEnd.After(e) && matchedConfirmedStay(runs[j], stays) == nil {
+				s, e = prevEnd, prevEnd
+			}
+		}
+		prevEnd, havePrev = e, true
+	}
+	return s, e
+}
+
 // legDateChange is the pure outcome of a leg move: the resolved new span,
 // the endpoint-anchored day deltas, and the leg's new 1-based trip-day
 // indices.
@@ -541,11 +571,8 @@ func runSetLegDatesTool(s *planSession, input json.RawMessage) (string, bool) {
 		if prevRun != nil {
 			fmt.Fprintf(&b, "; the previous leg (%s) ends %s", prevRun.hub, prevEnd.Format(dateLayout))
 		}
-		visStart, visEnd := oldLegStart, oldLegEnd
-		if prevRun != nil && prevEnd.Before(visStart) {
-			visStart = prevEnd
-		}
-		fmt.Fprintf(&b, ". The trip page shows this leg as %s (a leg's visible start is the previous leg's end — or the trip's start date for the first leg — when that comes first) and was NOT refreshed.", legRangeText(visStart, visEnd))
+		visStart, visEnd := visibleLegDisplayRange(runs, matched[0], stays, tripStart)
+		fmt.Fprintf(&b, ". The trip page shows this leg as %s (a leg renders from its arrival — the previous leg's visible end, or the trip's start date for the first leg — when that comes first, and collapses to a zero-night stop at that arrival when the previous leg has run past this leg's last day) and was NOT refreshed.", legRangeText(visStart, visEnd))
 		b.WriteString(" Never tell the traveler anything changed; if this state doesn't match what they asked for, tell them the actual dates and ask how to adjust.")
 		return b.String(), false
 	}

--- a/src/packages/api/plan_leg_dates_test.go
+++ b/src/packages/api/plan_leg_dates_test.go
@@ -598,6 +598,60 @@ func TestPlanSetLegDatesSqueezeNoteNamesNextLeg(t *testing.T) {
 	}
 }
 
+// An INVERTED leg (previous leg ran past its departure day) renders as a
+// zero-night stop at the arrival — the no-op report must quote THAT range,
+// not the stale item dates the page no longer shows; and the natural fix ask
+// (move the leg to the arrival day) must be a real move, not a no-op.
+func TestPlanSetLegDatesInvertedLegNoOpShowsZeroNightStop(t *testing.T) {
+	resetDB(t)
+	user, _ := createTestUser(t, "inverted@example.com")
+	trip := createTestTrip(t, user.ID, 0)
+	// Kraków day 10 (Sep 2) ends AFTER Berlin's day 9 (Sep 1): strict inversion.
+	seedPragueKrakowBerlinTrip(t, trip, user.ID, 10)
+
+	s1, rec1 := testPlanSession(true, user.ID)
+	s1.boundTripID = &trip.ID
+	msg, isErr := runSetLegDatesTool(s1, []byte(`{"city":"Berlin","start_date":"2026-09-01","end_date":"2026-09-01"}`))
+	if isErr {
+		t.Fatalf("inverted no-op errored: %s", msg)
+	}
+	for _, want := range []string{
+		"No saved rows changed",
+		"itinerary items sit on 2026-09-01 to 2026-09-01 (trip days 9-9)",
+		"the previous leg (Kraków) ends 2026-09-02",
+		"shows this leg as 2026-09-02 to 2026-09-02",
+		"zero-night stop",
+		"was NOT refreshed",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("no-op result missing %q: %s", want, msg)
+		}
+	}
+	if strings.Contains(rec1.Body.String(), "trip_updated") {
+		t.Fatal("inverted no-op emitted trip_updated")
+	}
+	if got := legDays(t, trip.ID, "Berlin"); !daysEqual(got, 9) {
+		t.Fatalf("Berlin day = %v, want [9] unchanged", got)
+	}
+
+	// The fix: move Berlin to the arrival day — a real move.
+	s2, rec2 := testPlanSession(true, user.ID)
+	s2.boundTripID = &trip.ID
+	msg, isErr = runSetLegDatesTool(s2, []byte(`{"city":"Berlin","start_date":"2026-09-02","end_date":"2026-09-02"}`))
+	if isErr {
+		t.Fatalf("fix move errored: %s", msg)
+	}
+	if !strings.Contains(msg, "Berlin is now 2026-09-02 to 2026-09-02") {
+		t.Fatalf("fix result missing new range: %s", msg)
+	}
+	if !strings.Contains(rec2.Body.String(), "trip_updated") {
+		t.Fatal("fix move did not emit trip_updated")
+	}
+	if got := legDays(t, trip.ID, "Berlin"); !daysEqual(got, 10) {
+		t.Fatalf("Berlin day = %v, want [10] (Sep 2)", got)
+	}
+}
+
 // Shrinking a leg folds trailing items onto its new last day and says so.
 func TestPlanSetLegDatesShrinkClampsItems(t *testing.T) {
 	resetDB(t)

--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -748,8 +748,11 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
 
   /// Builds the auto-TODO payload from the itinerary's location groups: a stay
   /// per city (with its dates) and a transport leg between consecutive cities.
+  /// Dates come from [_visibleGroupRanges], so stay check-ins, inter-city leg
+  /// dates, and the header chips all agree — including squeezed legs, which
+  /// read as a zero-night stop at their arrival.
   List<Map<String, dynamic>> _deriveTodos(Trip trip) {
-    final ranges = _locationGroupRanges(trip);
+    final ranges = _visibleGroupRanges(trip);
     final todos = <Map<String, dynamic>>[];
     final legs = <String,
         ({
@@ -867,7 +870,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
     for (var i = 0; i < ranges.length; i++) {
       final r = ranges[i];
       final label = r.label;
-      final start = _stayStartFor(ranges, i);
+      final start = r.start;
       final checkIn = start == null ? null : _fmt(start);
       final checkOut = r.end == null ? null : _fmt(r.end!);
       todos.add({
@@ -3616,20 +3619,21 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
   }
 
   /// Maps each itinerary item's position to its location's formatted date range.
-  /// Delegates to [_locationGroupRanges] so the itinerary labels and the booking
+  /// Delegates to [_visibleGroupRanges] so the itinerary labels and the booking
   /// checklist derive dates the same way. The two derivations index-align by
   /// construction: both run the same [tripLegs] split over the same items. The
-  /// range start is arrival-adjusted via [_stayStartFor], matching the stay
-  /// todos — a leg whose items collapse onto one day reads "Sep 24 – Sep 27",
-  /// not a bare "Sep 27" contradicting the stay row beneath it.
+  /// visible ranges are arrival-adjusted, matching the stay todos — a leg whose
+  /// items collapse onto one day reads "Sep 24 – Sep 27", not a bare "Sep 27"
+  /// contradicting the stay row beneath it, and a squeezed leg collapses to a
+  /// zero-night stop at its arrival.
   Map<int, String> _locationDates(Trip trip) {
     final items = trip.items ?? const <ItineraryItem>[];
     if (items.isEmpty) return const {};
-    final ranges = _locationGroupRanges(trip);
+    final ranges = _visibleGroupRanges(trip);
     final legs = tripLegs(items);
     final result = <int, String>{};
     for (var gi = 0; gi < legs.length; gi++) {
-      final start = _stayStartFor(ranges, gi);
+      final start = ranges[gi].start;
       final end = ranges[gi].end;
       if (start == null || end == null) continue;
       final text = _formatRange(start, end);
@@ -3642,10 +3646,18 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
 
   /// Per-location-group label and date range. Each location gets a contiguous
   /// slice of the trip's start–end span, weighted by how many places it has; an
-  /// accommodation with its own dates overrides the computed slice. Computed over
-  /// the full itinerary so the category filter doesn't shift the allocation.
-  List<({String label, DateTime? start, DateTime? end, _Coord? coord})>
-      _locationGroupRanges(Trip trip) {
+  /// accommodation with its own dates overrides the computed slice (and sets
+  /// [stayAnchored], which exempts the leg from the visible-range collapse).
+  /// Computed over the full itinerary so the category filter doesn't shift the
+  /// allocation.
+  List<
+      ({
+        String label,
+        DateTime? start,
+        DateTime? end,
+        _Coord? coord,
+        bool stayAnchored
+      })> _locationGroupRanges(Trip trip) {
     final items = trip.items ?? const <ItineraryItem>[];
     if (items.isEmpty) return const [];
     // Confirmed only: a suggested draft's dates come FROM this derivation, so
@@ -3686,8 +3698,13 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
       }
     }
 
-    final result =
-        <({String label, DateTime? start, DateTime? end, _Coord? coord})>[];
+    final result = <({
+      String label,
+      DateTime? start,
+      DateTime? end,
+      _Coord? coord,
+      bool stayAnchored
+    })>[];
     for (var i = 0; i < legs.length; i++) {
       final leg = legs[i];
       // The raw nullable locality feeds the stay-address match — the
@@ -3713,25 +3730,64 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
         start: rangeStart,
         end: accRange?.end ?? dayRange?.end ?? a?.end,
         coord: leg.coord,
+        stayAnchored: accRange != null,
       ));
     }
     return result;
   }
 
-  /// Effective check-in for the stay in city group [i]: the arrival date into
-  /// the city. The inbound leg is dated with the previous group's end, so when
-  /// that precedes the group's own start (e.g. a city whose items all sit on
-  /// one late day collapses its range to that single day), the stay would
-  /// otherwise show a start after the traveler has already arrived.
-  DateTime? _stayStartFor(
-      List<({String label, DateTime? start, DateTime? end, _Coord? coord})>
-          ranges,
-      int i) {
-    final own = ranges[i].start;
-    final arrival = i > 0 ? ranges[i - 1].end : null;
-    if (arrival == null) return own;
-    if (own == null || arrival.isBefore(own)) return arrival;
-    return own;
+  /// The ranges the page RENDERS: [_locationGroupRanges] plus the arrival
+  /// rule, as one forward pass. A leg renders from its arrival — the previous
+  /// group's VISIBLE end — when that comes first (the old per-consumer
+  /// arrival adjustment), and COLLAPSES to a zero-night stop at the arrival
+  /// when the previous leg has run past the leg's own last day (the interim
+  /// state a set_leg_dates squeeze leaves behind, narrated as "no nights
+  /// left" in chat). Cascading: each leg clamps against the previous VISIBLE
+  /// end, so consecutive squeezed legs chain and the inter-city leg dates
+  /// (previous end) follow automatically. A confirmed stay's explicit dates
+  /// are never collapsed (same carve-out as the first-leg anchor); an arrival
+  /// strictly inside a leg's own span keeps the leg's start (partial
+  /// overlap — unchanged). Stay todos, inter-city leg dates, and header chips
+  /// consume THIS; map pins and weather/events stay on the raw ranges. The
+  /// server mirrors this in visibleLegDisplayRange (plan_leg_dates.go).
+  List<
+      ({
+        String label,
+        DateTime? start,
+        DateTime? end,
+        _Coord? coord,
+        bool stayAnchored
+      })> _visibleGroupRanges(Trip trip) {
+    final raw = _locationGroupRanges(trip);
+    final result = <({
+      String label,
+      DateTime? start,
+      DateTime? end,
+      _Coord? coord,
+      bool stayAnchored
+    })>[];
+    DateTime? prevEnd;
+    for (final r in raw) {
+      var start = r.start;
+      var end = r.end;
+      if (prevEnd != null) {
+        if (start == null || prevEnd.isBefore(start)) {
+          start = prevEnd;
+        } else if (end != null && prevEnd.isAfter(end) && !r.stayAnchored) {
+          start = prevEnd;
+          end = prevEnd;
+        }
+      }
+      result.add((
+        label: r.label,
+        start: start,
+        end: end,
+        coord: r.coord,
+        stayAnchored: r.stayAnchored,
+      ));
+      prevEnd = end;
+    }
+    return result;
   }
 
   /// Date range for a location group from its items' AI-assigned day numbers,

--- a/src/packages/flutter-app/test/trip_detail_squeezed_leg_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_squeezed_leg_test.dart
@@ -1,0 +1,195 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:travel_route_planner/models/trip.dart';
+import 'package:travel_route_planner/models/accommodation.dart';
+import 'package:travel_route_planner/models/itinerary_item.dart';
+import 'package:travel_route_planner/models/booking_todo.dart';
+import 'package:travel_route_planner/services/api_client.dart';
+import 'package:travel_route_planner/services/booking_todos_api_service.dart';
+import 'package:travel_route_planner/services/trips_api_service.dart';
+import 'package:travel_route_planner/providers/booking_todos_provider.dart';
+import 'package:travel_route_planner/providers/trips_provider.dart';
+import 'package:travel_route_planner/screens/trip_detail_screen.dart';
+
+import 'support/l10n_test_app.dart';
+
+/// Returns a fixed trip without hitting the network, so we can exercise the
+/// real TripDetailScreen render path (and its booking-todo derivation).
+class _FakeTripsApiService extends TripsApiService {
+  final Trip trip;
+  _FakeTripsApiService(this.trip) : super(ApiClient(baseUrl: 'http://test'));
+
+  @override
+  Future<Trip> getTrip(String id) async => trip;
+}
+
+/// Records the derived payload the screen tries to sync, then fails like the
+/// offline test env (the screen swallows the error).
+class _CapturingBookingTodosApiService extends BookingTodosApiService {
+  final List<List<Map<String, dynamic>>> syncedPayloads = [];
+  _CapturingBookingTodosApiService()
+      : super(ApiClient(baseUrl: 'http://test'));
+
+  @override
+  Future<List<BookingTodo>> syncTodos(
+      String tripId, List<Map<String, dynamic>> derived) async {
+    syncedPayloads.add(derived);
+    throw Exception('offline test env');
+  }
+}
+
+ItineraryItem _item(int pos, String name, String city, {int? day}) =>
+    ItineraryItem(
+      id: 'i$pos',
+      position: pos,
+      name: name,
+      address: '$city address',
+      // Zero coords so the screen skips the map widget in the test env.
+      latitude: 0,
+      longitude: 0,
+      category: 'attraction',
+      day: day,
+      city: city,
+    );
+
+Trip _trip(List<ItineraryItem> items, {List<Accommodation>? stays}) => Trip(
+      id: 't1',
+      title: 'Squeeze',
+      status: 'planned',
+      startDate: '2026-09-01',
+      endDate: '2026-09-07',
+      createdAt: '2026-08-01',
+      updatedAt: '2026-08-01',
+      items: items,
+      accommodations: stays,
+    );
+
+Future<List<Map<String, dynamic>>> _pumpAndCapture(
+    WidgetTester tester, Trip trip) async {
+  final fake = _CapturingBookingTodosApiService();
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        tripsApiServiceProvider.overrideWithValue(_FakeTripsApiService(trip)),
+        bookingTodosApiServiceProvider.overrideWithValue(fake),
+      ],
+      child: MaterialApp(
+          localizationsDelegates: testLocalizationsDelegates,
+          home: TripDetailScreen(tripId: 't1')),
+    ),
+  );
+  await tester.pumpAndSettle();
+  expect(fake.syncedPayloads, isNotEmpty);
+  return fake.syncedPayloads.last;
+}
+
+void main() {
+  testWidgets(
+      'a squeezed leg renders as a zero-night stop at its arrival, '
+      'and downstream flight dates cascade', (WidgetTester tester) async {
+    // Medellín ran through Sep 6 but Quito's single item still departs Sep 5
+    // — the inverted interim state a set_leg_dates squeeze leaves behind.
+    // Quito must read as a zero-night stop at the arrival (Sep 6), never a
+    // check-in before the inbound flight lands.
+    final derived = await _pumpAndCapture(
+      tester,
+      _trip([
+        _item(0, 'Museo', 'Medellín', day: 1),
+        _item(1, 'Comuna 13', 'Medellín', day: 6),
+        _item(2, 'Quito', 'Quito', day: 5),
+        _item(3, 'Mitad del Mundo', 'Galápagos', day: 6),
+        _item(4, 'Tortuga Bay', 'Galápagos', day: 7),
+      ]),
+    );
+
+    final quitoStay =
+        derived.singleWhere((t) => t['todo_key'] == 'stay:quito');
+    expect(quitoStay['depart_date'], '2026-09-06');
+    expect(quitoStay['return_date'], '2026-09-06');
+    expect(quitoStay['subtitle'], 'Sep 6');
+
+    expect(
+        derived.singleWhere(
+            (t) => t['todo_key'] == 'transport:medellín>>quito')['depart_date'],
+        '2026-09-06');
+    // The cascade: the onward flight rides Quito's VISIBLE end, not its
+    // stale raw departure day (Sep 5).
+    expect(
+        derived.singleWhere((t) =>
+            t['todo_key'] == 'transport:quito>>galápagos')['depart_date'],
+        '2026-09-06');
+
+    final galStay =
+        derived.singleWhere((t) => t['todo_key'] == 'stay:galápagos');
+    expect(galStay['depart_date'], '2026-09-06');
+    expect(galStay['return_date'], '2026-09-07');
+
+    // Headers: no stale bare "Sep 5" chip anywhere; the squeezed leg shows
+    // its arrival and the next leg follows from it.
+    expect(find.text('Sep 5'), findsNothing);
+    expect(find.text('Sep 6'), findsWidgets);
+    expect(find.text('Sep 6 – Sep 7'), findsWidgets);
+  });
+
+  testWidgets('consecutive squeezed legs chain onto the same arrival',
+      (WidgetTester tester) async {
+    final derived = await _pumpAndCapture(
+      tester,
+      _trip([
+        _item(0, 'Museo', 'Medellín', day: 1),
+        _item(1, 'Comuna 13', 'Medellín', day: 6),
+        _item(2, 'Quito', 'Quito', day: 4),
+        _item(3, 'Guayaquil', 'Guayaquil', day: 5),
+      ]),
+    );
+
+    for (final key in ['stay:quito', 'stay:guayaquil']) {
+      final stay = derived.singleWhere((t) => t['todo_key'] == key);
+      expect(stay['depart_date'], '2026-09-06', reason: key);
+      expect(stay['return_date'], '2026-09-06', reason: key);
+    }
+    expect(
+        derived.singleWhere(
+            (t) => t['todo_key'] == 'transport:medellín>>quito')['depart_date'],
+        '2026-09-06');
+    expect(
+        derived.singleWhere((t) =>
+            t['todo_key'] == 'transport:quito>>guayaquil')['depart_date'],
+        '2026-09-06');
+    expect(find.text('Sep 4'), findsNothing);
+    expect(find.text('Sep 5'), findsNothing);
+  });
+
+  testWidgets('a confirmed stay is never collapsed by the squeeze clamp',
+      (WidgetTester tester) async {
+    // Quito carries an explicit confirmed stay (Sep 3–5); even with Medellín
+    // running through Sep 6, the traveler's own dates win.
+    final derived = await _pumpAndCapture(
+      tester,
+      _trip(
+        [
+          _item(0, 'Museo', 'Medellín', day: 1),
+          _item(1, 'Comuna 13', 'Medellín', day: 6),
+          _item(2, 'Quito', 'Quito', day: 5),
+        ],
+        stays: const [
+          Accommodation(
+            id: 'a1',
+            name: 'Hotel Quito',
+            address: 'Av. González Suárez, Quito, Ecuador',
+            checkIn: '2026-09-03',
+            checkOut: '2026-09-05',
+          ),
+        ],
+      ),
+    );
+
+    final quitoStay =
+        derived.singleWhere((t) => t['todo_key'] == 'stay:quito');
+    expect(quitoStay['depart_date'], '2026-09-03');
+    expect(quitoStay['return_date'], '2026-09-05');
+    expect(find.text('Sep 3 – Sep 5'), findsWidgets);
+  });
+}


### PR DESCRIPTION
## Summary
- **The Quito "starts Sep 13 instead of Sep 14" wart**: a `set_leg_dates` squeeze leaves a legitimately inconsistent interim state (previous leg runs past the next leg's departure day) while the agent negotiates the fix — and the page rendered it incoherently: "Medellín → Quito, Sep 14" directly above "Stay in Quito, Sep 13". The arrival-adjustment only let the arrival win when it was *earlier* than the leg's own start, and inter-city flight rows read the previous leg's RAW end, so no local patch could make the chain coherent.
- **One shared visible-ranges derivation** (`_visibleGroupRanges`) replaces the per-consumer `_stayStartFor` adjustment: a forward pass where the arrival (previous leg's VISIBLE end) wins when earlier, and a fully consumed item-derived leg **collapses to a zero-night stop at the arrival** — matching the agent's "no nights left" narration. Confirmed stays never collapse (same carve-out as the first-leg anchor); consecutive squeezed legs chain; partial overlaps unchanged. Stay todos, inter-city + home flight dates, and header chips all read it; map pins and weather/events stay on raw ranges (pre-existing accepted divergence).
- **Server mirror** `visibleLegDisplayRange` feeds the honest no-op, so re-asking an inverted leg's saved range now reports the zero-night render the page actually shows ("shows this leg as 2026-09-02 to 2026-09-02 … zero-night stop") instead of stale item dates.
- Provably a no-op for every non-inverted trip (the arrival rule only ever pulls starts back), so all pinned derivation behavior is byte-identical. No prompts, registry bytes, or migrations touched.

## Testing
- Flutter: new `trip_detail_squeezed_leg_test.dart` (zero-night render + cascaded flight dates on the Medellín/Quito/Galápagos shape; consecutive-squeeze chain; confirmed-stay carve-out); full suite green (682 tests), analyze = 3 pre-existing infos.
- Go: new `TestPlanSetLegDatesInvertedLegNoOpShowsZeroNightStop` (inverted no-op quotes the zero-night render with no `trip_updated`; the fix ask is a real move); all 14 leg-dates tests + full suite green against the lane DB (37s); gofmt clean.
- Dev stack with the real model (lane :3001): seeded the exact inverted shape, asked "Give Quito 2 nights" — agent moved Quito, and the reply relayed **both** boundary problems ("Medellín overlaps Quito by 1 night", "Galápagos has no nights left") and proposed the full chain fix with a clarifying question.
- Post-deploy: interim squeeze states render coherently (stay/flight/header agree) while the chat negotiates the fix; stored todos self-heal on next trip open (re-derived + re-PUT every load).

🤖 Generated with [Claude Code](https://claude.com/claude-code)