### PR TITLE
fix(deploy): pin cloudflared + detach compose up so deploys can't sever their own tunnel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -330,6 +330,17 @@ jobs:
       # silently rolled the stack back to the old image (2026-08-01 incident).
       # The gate step's IMAGE_TAG charset check ([A-Za-z0-9._-]) keeps the
       # sed replacement injection-free.
+      #
+      # `compose up` runs DETACHED (setsid + nohup, all fds redirected):
+      # this SSH session arrives through the cloudflared tunnel, so if the
+      # deploy recreates the cloudflared container (e.g. a version-pin bump
+      # in docker-compose.yml), the session is severed the moment the old
+      # cloudflared stops. Inline, that killed `up` between "remove old" and
+      # "start new" and left the stack down with no way back in (2026-07-23
+      # Pi incident). Detached, the recreate finishes on the host and the
+      # tunnel returns on its own; the Verify step below is the real success
+      # gate either way. If verify then fails, the up's output is in
+      # /opt/goldentempo/deploy-up.log (fetched by the step after it).
       - name: Pull images and restart stack
         if: steps.gate.outputs.configured == 'true'
         env:
@@ -346,8 +357,10 @@ jobs:
             fi
             export IMAGE_TAG='${IMAGE_TAG}'
             docker compose pull
-            docker compose up -d --remove-orphans
-            docker image prune -f"
+            rm -f deploy-up.log
+            setsid nohup sh -c 'docker compose up -d --remove-orphans && docker image prune -f' \
+              </dev/null >deploy-up.log 2>&1 &
+            echo 'compose up dispatched (detached); see Verify step / deploy-up.log'"
 
       # A green deploy should mean "this SHA is live and serving", not just
       # "the restart script ran": poll the public site until both the api
@@ -376,3 +389,16 @@ jobs:
           done
           echo "::error::deployed release never became ${IMAGE_TAG}"
           exit 1
+
+      # When verify fails, the detached up's output on the host is the first
+      # place to look — and by this point the tunnel is usually back even if
+      # the deploy recreated cloudflared. Best-effort: if the tunnel is still
+      # down this step can't help, and the DO web console is the way in.
+      - name: Fetch deploy-up.log on failure
+        if: failure() && steps.gate.outputs.configured == 'true'
+        env:
+          TUNNEL_SERVICE_TOKEN_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
+          TUNNEL_SERVICE_TOKEN_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
+        run: |
+          ssh -o ConnectTimeout=15 deploy-target \
+            "cd /opt/goldentempo && tail -100 deploy-up.log; docker compose ps -a" || true

--- a/dockerize/production/README.md
+++ b/dockerize/production/README.md
@@ -65,6 +65,17 @@ then does normal SSH-key auth on top. The host firewall needs
 inbound 80/443 rules at all. Enable **Always Use HTTPS** at the edge —
 the origin serves plain :80 and never sees an http URL a user typed.
 
+**The `cloudflared` image is version-pinned** in `docker-compose.yml` —
+never `:latest`. Deploys ride the tunnel, and recreating the cloudflared
+container severs the deploy's own SSH session; with `:latest`, any
+upstream release turned the next routine deploy into that recreate and
+left the stack half-down with no way back in (the 2026-07-23 Pi outage).
+To upgrade cloudflared: bump the pin in its own commit and deploy
+normally — CI runs `compose up` detached on the host, so the recreate
+completes and the tunnel returns after a seconds-long blip (the deploy's
+Verify step still confirms the site came back). If a bump ever goes
+wrong, the DO web console is the tunnel-free way in.
+
 ## Environment / secrets
 
 All runtime configuration lives in one file: `/opt/goldentempo/.env`

--- a/dockerize/production/docker-compose.yml
+++ b/dockerize/production/docker-compose.yml
@@ -122,7 +122,16 @@ services:
   # the client address — see that file for why the compose subnet below is
   # the trusted range.
   cloudflared:
-    image: cloudflare/cloudflared:latest
+    # Version-PINNED, never :latest. Deploys ride this tunnel (CI SSHes in
+    # through it), and `compose up` recreates this container whenever its
+    # config or image changes — severing the deploy's own SSH session the
+    # moment the old cloudflared stops. With :latest, any upstream release
+    # turned the next routine deploy into that self-severing recreate (this
+    # is exactly what took the Pi host down on 2026-07-23). Bump this pin
+    # deliberately, on its own deploy: the CI restart step runs `up`
+    # detached on the host, so the recreate completes and the tunnel
+    # returns after a seconds-long blip even though the SSH pipe drops.
+    image: cloudflare/cloudflared:2026.7.3
     command: tunnel --no-autoupdate run --token ${TUNNEL_TOKEN:?TUNNEL_TOKEN must be set}
     depends_on:
       - gateway


### PR DESCRIPTION
## Summary
- Pin `cloudflare/cloudflared` to `2026.7.3` (the exact digest prod runs today) instead of `:latest` — with `:latest`, any upstream cloudflared release made the next routine deploy recreate the tunnel container, severing the deploy's own SSH session mid-`compose up` and leaving the stack down with no way back in. This is the confirmed root cause of the 2026-07-23 Pi outage (forensics 2026-08-06: journal shows the deploy's SSH pipe closing the same second the old cloudflared was force-killed, leaving api/gateway/cloudflared in `Created`, never started), and the DO droplet had the identical failure primed.
- Run the remote `compose up -d` **detached** on the host (`setsid nohup … </dev/null >deploy-up.log 2>&1 &`) so a deliberate pin-bump deploy survives its own SSH severance: the recreate completes server-side, the tunnel returns after a seconds-long blip, and the existing **Verify deployed release** step remains the real success gate.
- Add a `failure()` step that fetches `/opt/goldentempo/deploy-up.log` + `compose ps -a` for post-mortems (best-effort; the tunnel is usually back by then).
- Document the pin + bump procedure in `dockerize/production/README.md`.

## Testing
- `docker compose config --quiet` on the production compose file (stub `.env`) — clean.
- `ci.yml` YAML parse — clean.
- Verified `2026.7.3` is the version currently running on the DO droplet (`cloudflared --version` in the live container), so this deploy's own cloudflared recreate is config-only and the pinned image needs no pull.
- The detached-up path's real-world proof is the next deploy's Verify step (polls the public site for the new release markers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)