### PR TITLE
refactor(flutter): extract the leg date-range derivation to utils/leg_ranges.dart

### DIFF
--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -44,6 +44,7 @@ import '../services/trip_cache.dart';
 import '../theme/app_colors.dart';
 import '../theme/spacing.dart';
 import '../utils/calendar_links.dart';
+import '../utils/leg_ranges.dart';
 import '../utils/money_format.dart';
 import '../utils/share_link.dart';
 import '../utils/tracked_launch.dart';
@@ -230,7 +231,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
 
   /// The trip's user-confirmed stays. Suggested drafts (auto=true) are working
   /// state for the bookings hub only — they must never feed the map, the
-  /// Tonight caption, or (crucially) [_locationGroupRanges]: seeded draft
+  /// Tonight caption, or (crucially) [rawLegRanges]: seeded draft
   /// dates flowing back into derivation would freeze the derived ranges.
   List<Accommodation> _confirmedStays(Trip trip) =>
       (trip.accommodations ?? const <Accommodation>[])
@@ -748,11 +749,11 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
 
   /// Builds the auto-TODO payload from the itinerary's location groups: a stay
   /// per city (with its dates) and a transport leg between consecutive cities.
-  /// Dates come from [_visibleGroupRanges], so stay check-ins, inter-city leg
+  /// Dates come from [visibleLegRanges], so stay check-ins, inter-city leg
   /// dates, and the header chips all agree — including squeezed legs, which
   /// read as a zero-night stop at their arrival.
   List<Map<String, dynamic>> _deriveTodos(Trip trip) {
-    final ranges = _visibleGroupRanges(trip);
+    final ranges = visibleLegRanges(trip);
     final todos = <Map<String, dynamic>>[];
     final legs = <String,
         ({
@@ -3619,7 +3620,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
   }
 
   /// Maps each itinerary item's position to its location's formatted date range.
-  /// Delegates to [_visibleGroupRanges] so the itinerary labels and the booking
+  /// Delegates to [visibleLegRanges] so the itinerary labels and the booking
   /// checklist derive dates the same way. The two derivations index-align by
   /// construction: both run the same [tripLegs] split over the same items. The
   /// visible ranges are arrival-adjusted, matching the stay todos — a leg whose
@@ -3629,7 +3630,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
   Map<int, String> _locationDates(Trip trip) {
     final items = trip.items ?? const <ItineraryItem>[];
     if (items.isEmpty) return const {};
-    final ranges = _visibleGroupRanges(trip);
+    final ranges = visibleLegRanges(trip);
     final legs = tripLegs(items);
     final result = <int, String>{};
     for (var gi = 0; gi < legs.length; gi++) {
@@ -3644,226 +3645,10 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
     return result;
   }
 
-  /// Per-location-group label and date range. Each location gets a contiguous
-  /// slice of the trip's start–end span, weighted by how many places it has; an
-  /// accommodation with its own dates overrides the computed slice (and sets
-  /// [stayAnchored], which exempts the leg from the visible-range collapse).
-  /// Computed over the full itinerary so the category filter doesn't shift the
-  /// allocation.
-  List<
-      ({
-        String label,
-        DateTime? start,
-        DateTime? end,
-        _Coord? coord,
-        bool stayAnchored
-      })> _locationGroupRanges(Trip trip) {
-    final items = trip.items ?? const <ItineraryItem>[];
-    if (items.isEmpty) return const [];
-    // Confirmed only: a suggested draft's dates come FROM this derivation, so
-    // letting them back in via _accDateRangeFor would freeze the ranges.
-    final stays = _confirmedStays(trip);
-
-    // Canonical locality runs over the full itinerary (shared split).
-    final legs = tripLegs(items);
-
-    // Auto-split the trip span across groups, weighted by item count.
-    final start = DateTime.tryParse(trip.startDate ?? '');
-    final end = DateTime.tryParse(trip.endDate ?? '');
-    final auto =
-        List<({DateTime start, DateTime end})?>.filled(legs.length, null);
-    if (start != null && end != null && !end.isBefore(start)) {
-      final totalDays = end.difference(start).inDays + 1;
-      final n = legs.length;
-      if (n <= totalDays) {
-        // Enough days: give each location a contiguous slice weighted by size.
-        final counts = _allocateDays(
-            totalDays, [for (final leg in legs) leg.items.length]);
-        var cursor = start;
-        for (var i = 0; i < n; i++) {
-          final rStart = cursor.isAfter(end) ? end : cursor;
-          var rEnd = rStart.add(Duration(days: counts[i] - 1));
-          if (rEnd.isAfter(end)) rEnd = end;
-          auto[i] = (start: rStart, end: rEnd);
-          cursor = rEnd.add(const Duration(days: 1));
-        }
-      } else {
-        // More locations than days: map each to a single day in order, so dates
-        // stay ascending and within the trip (some days carry several stops).
-        for (var i = 0; i < n; i++) {
-          final d = start.add(
-              Duration(days: (i * totalDays ~/ n).clamp(0, totalDays - 1)));
-          auto[i] = (start: d, end: d);
-        }
-      }
-    }
-
-    final result = <({
-      String label,
-      DateTime? start,
-      DateTime? end,
-      _Coord? coord,
-      bool stayAnchored
-    })>[];
-    for (var i = 0; i < legs.length; i++) {
-      final leg = legs[i];
-      // The raw nullable locality feeds the stay-address match — the
-      // 'Other places' placeholder label would falsely substring-match.
-      final accRange = _accDateRangeFor(leg.locality, stays);
-      final dayRange = _dayRangeFor(leg.items, start);
-      final a = auto[i];
-      var rangeStart = accRange?.start ?? dayRange?.start ?? a?.start;
-      // First-leg trip-start anchor: the traveler is in the first city from
-      // the trip's first day, so an item-derived range must not start later
-      // (a single late item would render a bare "Aug 27" on an Aug 24 trip).
-      // A confirmed stay's check-in still wins; the server mirrors this in
-      // anchoredLegDisplayRange (plan_leg_dates.go).
-      if (i == 0 &&
-          accRange == null &&
-          start != null &&
-          rangeStart != null &&
-          start.isBefore(rangeStart)) {
-        rangeStart = start;
-      }
-      result.add((
-        label: leg.label,
-        start: rangeStart,
-        end: accRange?.end ?? dayRange?.end ?? a?.end,
-        coord: leg.coord,
-        stayAnchored: accRange != null,
-      ));
-    }
-    return result;
-  }
-
-  /// The ranges the page RENDERS: [_locationGroupRanges] plus the arrival
-  /// rule, as one forward pass. A leg renders from its arrival — the previous
-  /// group's VISIBLE end — when that comes first (the old per-consumer
-  /// arrival adjustment), and COLLAPSES to a zero-night stop at the arrival
-  /// when the previous leg has run past the leg's own last day (the interim
-  /// state a set_leg_dates squeeze leaves behind, narrated as "no nights
-  /// left" in chat). Cascading: each leg clamps against the previous VISIBLE
-  /// end, so consecutive squeezed legs chain and the inter-city leg dates
-  /// (previous end) follow automatically. A confirmed stay's explicit dates
-  /// are never collapsed (same carve-out as the first-leg anchor); an arrival
-  /// strictly inside a leg's own span keeps the leg's start (partial
-  /// overlap — unchanged). Stay todos, inter-city leg dates, and header chips
-  /// consume THIS; map pins and weather/events stay on the raw ranges. The
-  /// server mirrors this in visibleLegDisplayRange (plan_leg_dates.go).
-  List<
-      ({
-        String label,
-        DateTime? start,
-        DateTime? end,
-        _Coord? coord,
-        bool stayAnchored
-      })> _visibleGroupRanges(Trip trip) {
-    final raw = _locationGroupRanges(trip);
-    final result = <({
-      String label,
-      DateTime? start,
-      DateTime? end,
-      _Coord? coord,
-      bool stayAnchored
-    })>[];
-    DateTime? prevEnd;
-    for (final r in raw) {
-      var start = r.start;
-      var end = r.end;
-      if (prevEnd != null) {
-        if (start == null || prevEnd.isBefore(start)) {
-          start = prevEnd;
-        } else if (end != null && prevEnd.isAfter(end) && !r.stayAnchored) {
-          start = prevEnd;
-          end = prevEnd;
-        }
-      }
-      result.add((
-        label: r.label,
-        start: start,
-        end: end,
-        coord: r.coord,
-        stayAnchored: r.stayAnchored,
-      ));
-      prevEnd = end;
-    }
-    return result;
-  }
-
-  /// Date range for a location group from its items' AI-assigned day numbers,
-  /// anchored to the trip start: day N -> startDate + (N-1). Null when the trip
-  /// has no start date or none of the items carry a day.
-  ({DateTime start, DateTime end})? _dayRangeFor(
-      List<ItineraryItem> items, DateTime? tripStart) {
-    if (tripStart == null) return null;
-    int? lo, hi;
-    for (final it in items) {
-      final d = it.day;
-      if (d == null || d < 1) continue;
-      if (lo == null || d < lo) lo = d;
-      if (hi == null || d > hi) hi = d;
-    }
-    if (lo == null || hi == null) return null;
-    return (
-      start: tripStart.add(Duration(days: lo - 1)),
-      end: tripStart.add(Duration(days: hi - 1)),
-    );
-  }
-
-  /// First accommodation in [locality] with both check-in/out dates, as DateTimes.
-  ({DateTime start, DateTime end})? _accDateRangeFor(
-      String? locality, List<Accommodation> stays) {
-    if (locality == null) return null;
-    final key = locality.toLowerCase();
-    for (final acc in stays) {
-      final addr = acc.address?.toLowerCase();
-      if (addr == null) continue;
-      if ((addr.contains(key) || key.contains(addr)) &&
-          acc.checkIn != null &&
-          acc.checkOut != null) {
-        final ci = DateTime.tryParse(acc.checkIn!);
-        final co = DateTime.tryParse(acc.checkOut!);
-        if (ci != null && co != null) return (start: ci, end: co);
-      }
-    }
-    return null;
-  }
-
-  /// Splits [totalDays] across groups proportional to [weights], each group at
-  /// least 1 day, summing to totalDays (largest-remainder; trims overflow from
-  /// the largest groups when the min-1 floor pushes the total over).
-  List<int> _allocateDays(int totalDays, List<int> weights) {
-    final n = weights.length;
-    if (n == 0) return const [];
-    if (totalDays <= n) {
-      return List.filled(n, 1); // ranges clamp to the trip end
-    }
-    final totalW = weights.fold<int>(0, (s, w) => s + (w <= 0 ? 1 : w));
-    final exact = [
-      for (final w in weights) totalDays * (w <= 0 ? 1 : w) / totalW
-    ];
-    final counts = [for (final e in exact) e.floor() < 1 ? 1 : e.floor()];
-    var used = counts.fold<int>(0, (s, c) => s + c);
-    // Hand out any remaining days to the largest fractional remainders.
-    final byRemainder = List<int>.generate(n, (i) => i)
-      ..sort((a, b) =>
-          (exact[b] - exact[b].floor()).compareTo(exact[a] - exact[a].floor()));
-    for (var k = 0; used < totalDays; k++) {
-      counts[byRemainder[k % n]] += 1;
-      used++;
-    }
-    // Or trim back from the largest groups if min-1 overshot.
-    final byCount = List<int>.generate(n, (i) => i)
-      ..sort((a, b) => counts[b].compareTo(counts[a]));
-    for (var k = 0; used > totalDays; k++) {
-      final j = byCount[k % n];
-      if (counts[j] > 1) {
-        counts[j]--;
-        used--;
-      }
-    }
-    return counts;
-  }
+  // The leg date-range derivation (raw + visible) lives in
+  // utils/leg_ranges.dart (specs/trip-dates-truth stage 0a) — one testable
+  // definition shared with the booking-todo derivation and, soon, the Go
+  // twin behind the server legs payload.
 
   String _formatRange(DateTime a, DateTime b) {
     final sameDay = a.year == b.year && a.month == b.month && a.day == b.day;
@@ -4288,7 +4073,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
   List<TripMapDestination> _mapDestinations(Trip trip) {
     final l10n = context.l10n;
     return [
-      for (final r in _locationGroupRanges(trip))
+      for (final r in rawLegRanges(trip))
         if (r.coord != null)
           TripMapDestination(
             label: _groupLabelText(l10n, r.label),
@@ -4405,7 +4190,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
   /// derivation the outbound/return booking todos trust — never the first/
   /// last mapped pin, which shifts under day/category filters.
   ({LatLng? first, LatLng? last}) _homeLegEndpoints(Trip trip) {
-    final ranges = _locationGroupRanges(trip);
+    final ranges = rawLegRanges(trip);
     final firstCoord = ranges.isEmpty ? null : ranges.first.coord;
     final lastCoord = ranges.isEmpty ? null : ranges.last.coord;
     return (
@@ -4595,7 +4380,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
                       // the rest fall through to the Bookings section's
                       // "Other" sub-group.
                       final grouped = _groupedBookings([
-                        for (final r in _locationGroupRanges(trip)) r.label
+                        for (final r in rawLegRanges(trip)) r.label
                       ]);
                       final filtered = _filtered(trip);
                       final groups =
@@ -4603,7 +4388,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
                       // Date window per city group, for the embedded events
                       // lookup (keyed by the same label _buildGroups uses).
                       final groupRanges = {
-                        for (final r in _locationGroupRanges(trip))
+                        for (final r in rawLegRanges(trip))
                           r.label: (start: r.start, end: r.end)
                       };
                       final tripStart = DateTime.tryParse(trip.startDate ?? '');

--- a/src/packages/flutter-app/lib/utils/leg_ranges.dart
+++ b/src/packages/flutter-app/lib/utils/leg_ranges.dart
@@ -1,0 +1,222 @@
+// The client-side leg DATE-RANGE derivation: the calendar span each city leg
+// occupies, raw ([rawLegRanges]) and as rendered ([visibleLegRanges]).
+// Extracted verbatim from trip_detail_screen.dart (specs/trip-dates-truth,
+// stage 0a) so the trip screen, its booking-todo derivation, and the upcoming
+// Go twin (trip_render_legs.go) share one testable definition.
+//
+// Pure like trip_legs.dart / trip_days.dart: no widget/l10n imports. The
+// server mirrors [visibleLegRanges] in visibleLegDisplayRange
+// (plan_leg_dates.go) today and in the trip_render_legs.go module once the
+// legs payload ships — the twin tests hand-mirror this file's fixtures.
+
+import '../models/accommodation.dart';
+import '../models/itinerary_item.dart';
+import '../models/trip.dart';
+import 'trip_legs.dart';
+
+/// One leg's date range. [stayAnchored] marks a range taken from a confirmed
+/// accommodation's explicit dates, which exempts the leg from the
+/// visible-range zero-night collapse.
+typedef LegRange = ({
+  String label,
+  DateTime? start,
+  DateTime? end,
+  ({double lat, double lng})? coord,
+  bool stayAnchored,
+});
+
+/// Per-location-group label and date range. Each location gets a contiguous
+/// slice of the trip's start–end span, weighted by how many places it has; an
+/// accommodation with its own dates overrides the computed slice (and sets
+/// [LegRange.stayAnchored]). Computed over the full itinerary so category
+/// filters don't shift the allocation.
+List<LegRange> rawLegRanges(Trip trip) {
+  final items = trip.items ?? const <ItineraryItem>[];
+  if (items.isEmpty) return const [];
+  // Confirmed only: a suggested draft's dates come FROM this derivation, so
+  // letting them back in via _accDateRangeFor would freeze the ranges. Same
+  // !auto rule as the trip screen's _confirmedStays.
+  final stays = (trip.accommodations ?? const <Accommodation>[])
+      .where((a) => !a.auto)
+      .toList();
+
+  // Canonical locality runs over the full itinerary (shared split).
+  final legs = tripLegs(items);
+
+  // Auto-split the trip span across groups, weighted by item count.
+  final start = DateTime.tryParse(trip.startDate ?? '');
+  final end = DateTime.tryParse(trip.endDate ?? '');
+  final auto = List<({DateTime start, DateTime end})?>.filled(legs.length, null);
+  if (start != null && end != null && !end.isBefore(start)) {
+    final totalDays = end.difference(start).inDays + 1;
+    final n = legs.length;
+    if (n <= totalDays) {
+      // Enough days: give each location a contiguous slice weighted by size.
+      final counts =
+          allocateDays(totalDays, [for (final leg in legs) leg.items.length]);
+      var cursor = start;
+      for (var i = 0; i < n; i++) {
+        final rStart = cursor.isAfter(end) ? end : cursor;
+        var rEnd = rStart.add(Duration(days: counts[i] - 1));
+        if (rEnd.isAfter(end)) rEnd = end;
+        auto[i] = (start: rStart, end: rEnd);
+        cursor = rEnd.add(const Duration(days: 1));
+      }
+    } else {
+      // More locations than days: map each to a single day in order, so dates
+      // stay ascending and within the trip (some days carry several stops).
+      for (var i = 0; i < n; i++) {
+        final d = start
+            .add(Duration(days: (i * totalDays ~/ n).clamp(0, totalDays - 1)));
+        auto[i] = (start: d, end: d);
+      }
+    }
+  }
+
+  final result = <LegRange>[];
+  for (var i = 0; i < legs.length; i++) {
+    final leg = legs[i];
+    // The raw nullable locality feeds the stay-address match — the
+    // 'Other places' placeholder label would falsely substring-match.
+    final accRange = _accDateRangeFor(leg.locality, stays);
+    final dayRange = _dayRangeFor(leg.items, start);
+    final a = auto[i];
+    var rangeStart = accRange?.start ?? dayRange?.start ?? a?.start;
+    // First-leg trip-start anchor: the traveler is in the first city from
+    // the trip's first day, so an item-derived range must not start later
+    // (a single late item would render a bare "Aug 27" on an Aug 24 trip).
+    // A confirmed stay's check-in still wins; the server mirrors this in
+    // anchoredLegDisplayRange (plan_leg_dates.go).
+    if (i == 0 &&
+        accRange == null &&
+        start != null &&
+        rangeStart != null &&
+        start.isBefore(rangeStart)) {
+      rangeStart = start;
+    }
+    result.add((
+      label: leg.label,
+      start: rangeStart,
+      end: accRange?.end ?? dayRange?.end ?? a?.end,
+      coord: leg.coord,
+      stayAnchored: accRange != null,
+    ));
+  }
+  return result;
+}
+
+/// The ranges the page RENDERS: [rawLegRanges] plus the arrival rule, as one
+/// forward pass. A leg renders from its arrival — the previous group's
+/// VISIBLE end — when that comes first, and COLLAPSES to a zero-night stop at
+/// the arrival when the previous leg has run past the leg's own last day (the
+/// interim state a set_leg_dates squeeze leaves behind, narrated as "no
+/// nights left" in chat). Cascading: each leg clamps against the previous
+/// VISIBLE end, so consecutive squeezed legs chain and the inter-city leg
+/// dates (previous end) follow automatically. A confirmed stay's explicit
+/// dates are never collapsed (same carve-out as the first-leg anchor); an
+/// arrival strictly inside a leg's own span keeps the leg's start (partial
+/// overlap — unchanged). Stay todos, inter-city leg dates, and header chips
+/// consume THIS; map pins and weather/events stay on the raw ranges. The
+/// server mirrors this in visibleLegDisplayRange (plan_leg_dates.go).
+List<LegRange> visibleLegRanges(Trip trip) {
+  final raw = rawLegRanges(trip);
+  final result = <LegRange>[];
+  DateTime? prevEnd;
+  for (final r in raw) {
+    var start = r.start;
+    var end = r.end;
+    if (prevEnd != null) {
+      if (start == null || prevEnd.isBefore(start)) {
+        start = prevEnd;
+      } else if (end != null && prevEnd.isAfter(end) && !r.stayAnchored) {
+        start = prevEnd;
+        end = prevEnd;
+      }
+    }
+    result.add((
+      label: r.label,
+      start: start,
+      end: end,
+      coord: r.coord,
+      stayAnchored: r.stayAnchored,
+    ));
+    prevEnd = end;
+  }
+  return result;
+}
+
+/// Date range for a location group from its items' AI-assigned day numbers,
+/// anchored to the trip start: day N -> startDate + (N-1). Null when the trip
+/// has no start date or none of the items carry a day.
+({DateTime start, DateTime end})? _dayRangeFor(
+    List<ItineraryItem> items, DateTime? tripStart) {
+  if (tripStart == null) return null;
+  int? lo, hi;
+  for (final it in items) {
+    final d = it.day;
+    if (d == null || d < 1) continue;
+    if (lo == null || d < lo) lo = d;
+    if (hi == null || d > hi) hi = d;
+  }
+  if (lo == null || hi == null) return null;
+  return (
+    start: tripStart.add(Duration(days: lo - 1)),
+    end: tripStart.add(Duration(days: hi - 1)),
+  );
+}
+
+/// First accommodation in [locality] with both check-in/out dates, as DateTimes.
+({DateTime start, DateTime end})? _accDateRangeFor(
+    String? locality, List<Accommodation> stays) {
+  if (locality == null) return null;
+  final key = locality.toLowerCase();
+  for (final acc in stays) {
+    final addr = acc.address?.toLowerCase();
+    if (addr == null) continue;
+    if ((addr.contains(key) || key.contains(addr)) &&
+        acc.checkIn != null &&
+        acc.checkOut != null) {
+      final ci = DateTime.tryParse(acc.checkIn!);
+      final co = DateTime.tryParse(acc.checkOut!);
+      if (ci != null && co != null) return (start: ci, end: co);
+    }
+  }
+  return null;
+}
+
+/// Splits [totalDays] across groups proportional to [weights], each group at
+/// least 1 day, summing to totalDays (largest-remainder; trims overflow from
+/// the largest groups when the min-1 floor pushes the total over). Public for
+/// direct unit tests; [rawLegRanges] is its only production caller.
+List<int> allocateDays(int totalDays, List<int> weights) {
+  final n = weights.length;
+  if (n == 0) return const [];
+  if (totalDays <= n) {
+    return List.filled(n, 1); // ranges clamp to the trip end
+  }
+  final totalW = weights.fold<int>(0, (s, w) => s + (w <= 0 ? 1 : w));
+  final exact = [
+    for (final w in weights) totalDays * (w <= 0 ? 1 : w) / totalW
+  ];
+  final counts = [for (final e in exact) e.floor() < 1 ? 1 : e.floor()];
+  var used = counts.fold<int>(0, (s, c) => s + c);
+  // Hand out any remaining days to the largest fractional remainders.
+  final byRemainder = List<int>.generate(n, (i) => i)
+    ..sort((a, b) =>
+        (exact[b] - exact[b].floor()).compareTo(exact[a] - exact[a].floor()));
+  for (var k = 0; used < totalDays; k++) {
+    counts[byRemainder[k % n]] += 1;
+    used++;
+  }
+  // Or trim back from the largest groups if min-1 overshot.
+  final byCount = List<int>.generate(n, (i) => i)
+    ..sort((a, b) => counts[b].compareTo(counts[a]));
+  for (var k = 0; used > totalDays; k++) {
+    final j = byCount[k % n];
+    if (counts[j] > 1) {
+      counts[j]--;
+      used--;
+    }
+  }
+  return counts;
+}

--- a/src/packages/flutter-app/test/leg_ranges_test.dart
+++ b/src/packages/flutter-app/test/leg_ranges_test.dart
@@ -1,0 +1,283 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:travel_route_planner/models/accommodation.dart';
+import 'package:travel_route_planner/models/itinerary_item.dart';
+import 'package:travel_route_planner/models/trip.dart';
+import 'package:travel_route_planner/utils/leg_ranges.dart';
+
+// CROSS-LANGUAGE CONTRACT (specs/trip-dates-truth): these fixtures and
+// expected values are hand-mirrored in the Go twin suite
+// (api/trip_render_legs_test.go, stage 0b) — same trips, same expected
+// spans, city names and all. Pinning both sides to the same literals means a
+// drift on either side fails a test instead of shipping silently (the
+// calendar-title parity convention). Divergences that are DELIBERATE are
+// marked "diverges:" below with the decision.
+
+ItineraryItem _item(int pos, String name, String? city, {int? day}) =>
+    ItineraryItem(
+      id: 'i$pos',
+      position: pos,
+      name: name,
+      address: city == null ? null : '$city address',
+      latitude: 0,
+      longitude: 0,
+      category: 'attraction',
+      day: day,
+      city: city,
+    );
+
+Trip _trip(
+  List<ItineraryItem> items, {
+  String? startDate,
+  String? endDate,
+  List<Accommodation>? stays,
+}) =>
+    Trip(
+      id: 't1',
+      title: 'Fixture',
+      status: 'planned',
+      startDate: startDate,
+      endDate: endDate,
+      createdAt: '2026-08-01',
+      updatedAt: '2026-08-01',
+      items: items,
+      accommodations: stays,
+    );
+
+DateTime _d(String iso) => DateTime.parse(iso);
+
+void main() {
+  group('rawLegRanges', () {
+    test('item-day ranges anchored to the trip start', () {
+      final ranges = rawLegRanges(_trip(
+        [
+          _item(0, 'Feskekôrka', 'Gothenburg', day: 1),
+          _item(1, 'Liseberg', 'Gothenburg', day: 3),
+          _item(2, 'Prado', 'Madrid', day: 5),
+        ],
+        startDate: '2026-08-24',
+        endDate: '2026-08-28',
+      ));
+      expect(ranges.length, 2);
+      expect(ranges[0].start, _d('2026-08-24'));
+      expect(ranges[0].end, _d('2026-08-26'));
+      // Madrid's raw range collapses to its single item day — the visible
+      // pass, not this one, pulls its start back to the arrival.
+      expect(ranges[1].start, _d('2026-08-28'));
+      expect(ranges[1].end, _d('2026-08-28'));
+      expect(ranges[1].stayAnchored, isFalse);
+    });
+
+    test('first leg anchors to the trip start when items sit late', () {
+      final ranges = rawLegRanges(_trip(
+        [
+          _item(0, 'Prague', 'Prague', day: 4),
+          _item(1, 'Kraków', 'Kraków', day: 9),
+        ],
+        startDate: '2026-08-24',
+        endDate: '2026-09-01',
+      ));
+      expect(ranges[0].start, _d('2026-08-24'));
+      expect(ranges[0].end, _d('2026-08-27'));
+    });
+
+    test('a confirmed stay overrides item days and sets stayAnchored', () {
+      final ranges = rawLegRanges(_trip(
+        [
+          _item(0, 'Museo', 'Medellín', day: 1),
+          _item(1, 'Quito', 'Quito', day: 5),
+        ],
+        startDate: '2026-09-01',
+        endDate: '2026-09-07',
+        stays: const [
+          Accommodation(
+            id: 'a1',
+            name: 'Hotel Quito',
+            address: 'Av. González Suárez, Quito, Ecuador',
+            checkIn: '2026-09-03',
+            checkOut: '2026-09-05',
+          ),
+        ],
+      ));
+      expect(ranges[1].start, _d('2026-09-03'));
+      expect(ranges[1].end, _d('2026-09-05'));
+      expect(ranges[1].stayAnchored, isTrue);
+    });
+
+    // diverges: stay matching is address-only client-side today; the Go twin
+    // also matches by NAME (agent-added stays carry no address). The unified
+    // rule after the payload cutover is address-then-name — this pin
+    // documents the pre-cutover client behavior.
+    test('an address-less stay does not anchor (client rule, pre-cutover)',
+        () {
+      final ranges = rawLegRanges(_trip(
+        [_item(0, 'Quito', 'Quito', day: 3)],
+        startDate: '2026-09-01',
+        endDate: '2026-09-05',
+        stays: const [
+          Accommodation(
+            id: 'a1',
+            name: 'Stay in Quito',
+            checkIn: '2026-09-02',
+            checkOut: '2026-09-04',
+          ),
+        ],
+      ));
+      expect(ranges[0].stayAnchored, isFalse);
+      // First-leg anchor applies instead: start = trip start.
+      expect(ranges[0].start, _d('2026-09-01'));
+      expect(ranges[0].end, _d('2026-09-03'));
+    });
+
+    test('undated legs take the weighted auto-allocation slice', () {
+      final ranges = rawLegRanges(_trip(
+        [
+          _item(0, 'Louvre', 'Paris'),
+          _item(1, 'Orsay', 'Paris'),
+          _item(2, 'Marais walk', 'Paris'),
+          _item(3, 'Colosseum', 'Rome'),
+        ],
+        startDate: '2026-06-01',
+        endDate: '2026-06-08', // 8 days: Paris (3 items) 6, Rome (1 item) 2
+      ));
+      expect(ranges[0].start, _d('2026-06-01'));
+      expect(ranges[0].end, _d('2026-06-06'));
+      expect(ranges[1].start, _d('2026-06-07'));
+      expect(ranges[1].end, _d('2026-06-08'));
+    });
+
+    test('more locations than days maps each to one ascending day', () {
+      final ranges = rawLegRanges(_trip(
+        [
+          _item(0, 'A', 'Alpha'),
+          _item(1, 'B', 'Beta'),
+          _item(2, 'C', 'Gamma'),
+        ],
+        startDate: '2026-06-01',
+        endDate: '2026-06-02', // 2 days, 3 cities
+      ));
+      expect(ranges[0].start, _d('2026-06-01'));
+      expect(ranges[1].start, _d('2026-06-01'));
+      expect(ranges[2].start, _d('2026-06-02'));
+      for (final r in ranges) {
+        expect(r.start, r.end);
+      }
+    });
+
+    test('a dateless trip yields null ranges', () {
+      final ranges = rawLegRanges(_trip(
+        [_item(0, 'Louvre', 'Paris', day: 1)],
+      ));
+      expect(ranges.single.start, isNull);
+      expect(ranges.single.end, isNull);
+    });
+  });
+
+  group('visibleLegRanges', () {
+    test('arrival pulls a late-starting leg back to the previous end', () {
+      final ranges = visibleLegRanges(_trip(
+        [
+          _item(0, 'Feskekôrka', 'Gothenburg', day: 1),
+          _item(1, 'Liseberg', 'Gothenburg', day: 3),
+          _item(2, 'Prado', 'Madrid', day: 5),
+        ],
+        startDate: '2026-08-24',
+        endDate: '2026-08-28',
+      ));
+      expect(ranges[1].start, _d('2026-08-26'));
+      expect(ranges[1].end, _d('2026-08-28'));
+    });
+
+    test('a squeezed leg collapses to a zero-night stop and cascades', () {
+      final ranges = visibleLegRanges(_trip(
+        [
+          _item(0, 'Museo', 'Medellín', day: 1),
+          _item(1, 'Comuna 13', 'Medellín', day: 6),
+          _item(2, 'Quito', 'Quito', day: 5),
+          _item(3, 'Mitad del Mundo', 'Galápagos', day: 6),
+          _item(4, 'Tortuga Bay', 'Galápagos', day: 7),
+        ],
+        startDate: '2026-09-01',
+        endDate: '2026-09-07',
+      ));
+      expect(ranges[1].start, _d('2026-09-06'));
+      expect(ranges[1].end, _d('2026-09-06'));
+      expect(ranges[2].start, _d('2026-09-06'));
+      expect(ranges[2].end, _d('2026-09-07'));
+    });
+
+    test('consecutive squeezed legs chain onto the same arrival', () {
+      final ranges = visibleLegRanges(_trip(
+        [
+          _item(0, 'Museo', 'Medellín', day: 1),
+          _item(1, 'Comuna 13', 'Medellín', day: 6),
+          _item(2, 'Quito', 'Quito', day: 4),
+          _item(3, 'Guayaquil', 'Guayaquil', day: 5),
+        ],
+        startDate: '2026-09-01',
+        endDate: '2026-09-07',
+      ));
+      expect(ranges[1].start, _d('2026-09-06'));
+      expect(ranges[1].end, _d('2026-09-06'));
+      expect(ranges[2].start, _d('2026-09-06'));
+      expect(ranges[2].end, _d('2026-09-06'));
+    });
+
+    test('a confirmed stay is never collapsed', () {
+      final ranges = visibleLegRanges(_trip(
+        [
+          _item(0, 'Museo', 'Medellín', day: 1),
+          _item(1, 'Comuna 13', 'Medellín', day: 6),
+          _item(2, 'Quito', 'Quito', day: 5),
+        ],
+        startDate: '2026-09-01',
+        endDate: '2026-09-07',
+        stays: const [
+          Accommodation(
+            id: 'a1',
+            name: 'Hotel Quito',
+            address: 'Av. González Suárez, Quito, Ecuador',
+            checkIn: '2026-09-03',
+            checkOut: '2026-09-05',
+          ),
+        ],
+      ));
+      expect(ranges[1].start, _d('2026-09-03'));
+      expect(ranges[1].end, _d('2026-09-05'));
+    });
+
+    // diverges: client-side a null-range leg still participates in the chain
+    // (prevEnd is overwritten with null, disabling adjustment downstream);
+    // the Go twin SKIPS undated legs without touching prevEnd. The unified
+    // payload rule is the Go one; this pin documents the pre-cutover client
+    // behavior so the cutover diff is deliberate.
+    test('a dateless interior leg resets the chain (client rule, pre-cutover)',
+        () {
+      final ranges = visibleLegRanges(_trip(
+        [
+          _item(0, 'A', 'Alpha', day: 1),
+          _item(1, 'mystery', null),
+          _item(2, 'C', 'Gamma', day: 5),
+        ],
+        startDate: '2026-06-01',
+        // No end date: no auto-allocation, so the hubless leg has null range.
+      ));
+      expect(ranges.length, 3);
+      expect(ranges[1].start, _d('2026-06-01')); // adopts prev end...
+      expect(ranges[1].end, isNull); // ...but its own end is null
+      // Chain reset: Gamma keeps its raw start, un-adjusted.
+      expect(ranges[2].start, _d('2026-06-05'));
+    });
+  });
+
+  group('allocateDays', () {
+    test('splits by weight with largest-remainder distribution', () {
+      expect(allocateDays(8, [3, 1]), [6, 2]);
+      expect(allocateDays(10, [1, 1, 1]), [4, 3, 3]);
+    });
+
+    test('floors at one day each and handles totalDays <= n', () {
+      expect(allocateDays(2, [5, 5, 5]), [1, 1, 1]);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Stage 0a of the trip-dates single-source-of-truth program (specs/trip-dates-truth, to land with stage 0b): verbatim extraction of the leg date-range derivation cluster (~250 lines: `_locationGroupRanges`, `_visibleGroupRanges`, `_dayRangeFor`, `_accDateRangeFor`, `_allocateDays`) from the trip-detail hub file into pure `lib/utils/leg_ranges.dart` (`rawLegRanges` / `visibleLegRanges` / `allocateDays`).
- Hub file keeps presentation only and repoints six call sites (2 visible + 4 raw consumers); net −229 lines. No behavior change by construction.
- New `test/leg_ranges_test.dart` — 14 pure unit tests whose fixture literals are the **cross-language contract** for the upcoming Go twin (`trip_render_legs.go`), per the repo's calendar-parity convention. Two deliberate pre-cutover client divergences are pinned with `diverges:` markers (address-only stay matching vs the server's address-then-name; chain reset across dateless interior legs vs the server's skip rule) so the eventual cutover diff is intentional, not accidental.

## Testing
- Full Flutter suite green: 696 tests (682 existing pass byte-identical — the pure-move proof — plus 14 new); `flutter analyze` = 3 pre-existing infos.
- Hub-file diff reviewed: deletion + import + six call-site renames + three doc-reference updates only; never dart-formatted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)