### PR TITLE
feat(api): trip_render_legs module — the one server-side legs derivation + program specs

### DIFF
--- a/specs/itinerary-item-dates/spec.md
+++ b/specs/itinerary-item-dates/spec.md
@@ -1,0 +1,51 @@
+# Spec: Itinerary Items Store Calendar Dates
+
+> Stage B of [`specs/trip-dates-truth/`](../trip-dates-truth/spec.md).
+> Migration numbers reserved: **00054** (add + backfill), **00055** (drop
+> stored day, optional/deferred). Re-verify numbers at execution.
+
+## Context
+
+Item scheduling is stored as positional day integers anchored to the trip's
+start date, with departure-day semantics that exist only by convention — the
+root enabler of the leg-dates bug class (a writer can "correctly" write day
+numbers that mean the wrong dates). This feature makes the calendar date the
+stored truth on dated trips, with the day number maintained as a derived
+mirror for wire compatibility, dateless drafts, and UI grouping.
+
+## User Stories
+
+- As a **traveler**, I want calendar/print/screen dates to be the same fact
+  read three ways, not three computations that can disagree.
+- As a **developer/agent**, I want date edits to be edits of dates, with the
+  day number derived — never the reverse guessed.
+
+## Acceptance Criteria
+
+- [ ] Every dated trip's items carry a stored calendar date; backfill equals
+      start_date + day − 1; currently-inconsistent trips backfill verbatim
+      (the leg computation renders them exactly as today).
+- [ ] Dateless trips keep day-number authority (item dates uniformly absent);
+      the undated→dated transition materializes dates atomically; authority
+      is decidable from the trip row alone.
+- [ ] One conversion boundary writes BOTH fields on every write path; a
+      lone-field write is impossible by construction. Day-number inputs
+      (tool schemas, old bundles) keep working forever, converted at the
+      boundary with the existing validation.
+- [ ] Whole-trip and per-leg date tools shift/write item dates (day mirror
+      maintained); the trip-PATCH date change gains the same semantics
+      (unify with set_trip_dates: shift stays/segments and re-derive the
+      checklist) inside a proper transaction.
+- [ ] Calendar exports, print day sections, day sub-headers, and per-day
+      weather read the stored date — making sub-headers agree with squeezed
+      city headers (fixing the audited live inconsistency).
+- [ ] The leg computation flips its item-day inputs to stored dates only
+      after a prod audit query shows zero divergence (provable no-op).
+- [ ] Binary rollback is safe (day mirror stays correct); one documented
+      idempotent repair statement re-syncs dates on roll-forward.
+
+## Out of Scope
+
+- Removing day numbers from any wire format or UI grouping mechanism.
+- Monotonicity/clamp-to-span enforcement beyond today's permissiveness (the
+  leg computation absorbs disorder; trip health flags it).

--- a/specs/itinerary-item-dates/tasks.md
+++ b/specs/itinerary-item-dates/tasks.md
@@ -1,0 +1,13 @@
+# Tasks: Itinerary Items Store Calendar Dates
+
+Lane briefs are written at execution time (waves 3–6) against then-current
+code; plan.md accompanies the wave-3 brief. Migration lane rule: one
+migration lane per wave.
+
+| Wave | Lane | Branch | Contents |
+|---|---|---|---|
+| 3 | 4a | `item-date-column` | migration 00054 (add `item_date` + backfill), `itemSchedule` conversion boundary, writer sweep dual-write, POST/PATCH dual-accept |
+| 5 | 5a | `item-date-anchor-flip` | leg computation + calendar + print + review + sub-headers onto `item_date`; pre-flip prod audit query = 0 |
+| 5 | 5b | `date-tools-native` | set_trip_dates shifts item dates + materializes on undated→dated; set_leg_dates writes dates natively; trip-PATCH unification (tx + shifts + re-derive) |
+| 6 | 6a | `kill-client-fallback` | offline-cache version bump; delete `leg_ranges.dart`, parity logger, transition tests (hub lane) |
+| 6 | 6b | `drop-stored-day` | migration 00055: derive day in reads, drop the column (or defer with boundary-only writes as the acceptance bar) |

--- a/specs/server-booking-todos/spec.md
+++ b/specs/server-booking-todos/spec.md
@@ -1,0 +1,43 @@
+# Spec: Server-Derived Booking Checklist
+
+> Stage C of [`specs/trip-dates-truth/`](../trip-dates-truth/spec.md).
+> Executes after the server-leg-dates client repoint (wave 4–5).
+
+## Context
+
+The auto "Stay in X" / "A → B" checklist rows are derived on the traveler's
+device only when the trip screen loads, then synced up — so a trip edited via
+chat serves stale checklist dates to the AI (get_trip), the print packet, and
+collaborators until someone opens the page. Deriving them server-side on
+every relevant write makes the checklist a maintained view, not a cache.
+
+## User Stories
+
+- As a **traveler**, when I change dates in chat, my checklist (and its
+  printed copy) is already correct the next time anyone sees it.
+- As the **trip assistant**, I want get_trip's checklist dates to be trustworthy
+  without requiring a screen load in between.
+
+## Acceptance Criteria
+
+- [ ] Auto stay/transport/home-leg/ferry checklist rows are re-derived
+      server-side (from the shared leg computation, using the trip OWNER's
+      home airport) after every write that can change them: itinerary edits,
+      date tools, stay/segment CRUD, travel-mode and home-airport changes.
+- [ ] Manual and agent-added rows, booked flags, and dismissals survive
+      re-derivation untouched.
+- [ ] Rollout is shadow-first: a comparison window logs client-posted vs
+      server-derived rows on real trips before the flip.
+- [ ] At the flip, the legacy client sync endpoints become no-op echoes that
+      return server truth (old cached bundles then display it); the client
+      derivation code is deleted one wave later.
+- [ ] Legacy auto draft stays/segments follow the same server derivation (no
+      second client-owned derivation remains).
+- [ ] "Stay in Other places" rows are no longer produced (hubless legs get no
+      stay todo) — a flagged, deliberate improvement.
+
+## Out of Scope
+
+- Localized subtitles (server keeps writing English date-range subtitles for
+  old bundles; the updated client formats from the date fields).
+- Any change to manual todo editing or the booked/dismiss flows.

--- a/specs/server-booking-todos/tasks.md
+++ b/specs/server-booking-todos/tasks.md
@@ -1,0 +1,20 @@
+# Tasks: Server-Derived Booking Checklist
+
+Lane briefs are written at wave-4 execution time against then-current code.
+
+## Wave 4 (one lane, two PRs — deploy + dogfood soak between them)
+
+| Lane | Branch | Contents |
+|---|---|---|
+| 3a-shadow | `server-todos-shadow` | Go `rederiveBookingTodos` port over computeTripLegs (owner home airport, ferry/ground rules); on client sync, log client-vs-server diff; no behavior change |
+| 3a-flip | same lane, PR 2 | derive-on-write triggers everywhere + sync endpoints become no-op echoes (SAME deploy); replaces set_trip_dates' todo SQL-shift with full re-derive |
+
+## Wave 5 (hub lane)
+
+| Lane | Branch | Contents |
+|---|---|---|
+| 3b | `delete-client-todos` | delete `_deriveTodos`/`_syncBookingTodos`/home-ferry-ground builders; flight/ferry prefill rebuilt from todo rows |
+
+Hard rule: 3b merges no earlier than one full wave after 3a-flip deploys
+(rollback asymmetry — reverting the flip after 3b would freeze todos).
+plan.md for this spec is written with the wave-4 lane briefs.

--- a/specs/server-leg-dates/plan.md
+++ b/specs/server-leg-dates/plan.md
@@ -1,0 +1,46 @@
+# Plan: Server-Computed City-Leg Dates
+
+## Key decisions (reconciled from the audited divergences)
+
+| Rule | Decision | Why |
+|---|---|---|
+| Run split | Dart rule: null/empty hub is its own run, groups with hubless neighbors; revisits keyed `City#2` | Payload must reproduce what the screen shows; client collapse keys survive |
+| Hub of an item | `day_trip_from ?? city`, trimmed; NO address parsing | Server never second-guesses tags; client's `cityFromAddress` fallback retires at the client repoint (address-only items become "Other places") |
+| Stay→leg match | Go rule: fuzzy address, then NAME fallback; non-auto, both dates | Agent-added address-less stays must anchor their leg |
+| Span precedence | stay > item days > weighted auto-allocation (ported `_allocateDays`) > none | Existing client semantics, now one implementation |
+| First-leg anchor | First leg WITH a span, when item-derived, starts at the trip start | Generalizes the Go `firstDatedRunIdx` rule; avoids anchor/auto overlap pathologies |
+| Arrival chain | Go rule: spanless legs are skipped and never reset the chain; zero-night collapse spares stay-anchored legs | The Dart null-reset was the bug-shaped variant |
+
+## Modules
+
+- `src/packages/api/trip_render_legs.go` — `computeTripLegs(trip, items,
+  stays) []RenderLeg` + `allocateLegDays` (stage 0b, landed with this spec).
+  Twin tests in `trip_render_legs_test.go` hand-mirror
+  `flutter-app/test/leg_ranges_test.dart` fixtures (calendar-parity
+  convention); the two `diverges:` cases carry the server-side expected
+  values. Note the raw-vs-visible lens: the Go module emits only the
+  chained/visible output, so three Dart RAW fixtures appear here with their
+  visible-lens values (arrival pull-backs).
+- `flutter-app/lib/utils/leg_ranges.dart` — the extracted client derivation
+  (stage 0a, PR #297): `rawLegRanges` / `visibleLegRanges` / `allocateDays`.
+
+## Remaining lanes (wave 2–3; see tasks.md)
+
+- 1a payload: `legs` field on the trip + shared responses (`RenderLeg` JSON),
+  Dart `TripLeg` model on `Trip` (`make flutter-build-models`).
+- 1b Go consumers: `legsRenderSummary`/get_trip/section results +
+  `print_view_handler.go` stay-matching onto `computeTripLegs`; golden diffs
+  reviewed line-by-line against documented divergences only.
+- 1c parity logger: `kDebugMode` comparison payload-vs-`visibleLegRanges` in
+  the trip provider, mismatches → instrumentation events. Soak gate: ≥1 week
+  zero mismatches on real trips.
+- 2a client repoint (hub lane): consumers → `trip.legs ?? visibleLegRanges`
+  fallback (raw consumers get raw-equivalents from the payload or keep
+  `rawLegRanges` until 6a — decide per consumer in the lane brief).
+- 2b optional: shared view shows leg dates.
+
+## Verification
+
+Twin unit suites both sides; payload integration test; parity soak via daily
+dogfooding; widget tests duplicated to pin fallback AND payload paths before
+the repoint merges.

--- a/specs/server-leg-dates/spec.md
+++ b/specs/server-leg-dates/spec.md
@@ -1,0 +1,42 @@
+# Spec: Server-Computed City-Leg Dates
+
+> Stage A of [`specs/trip-dates-truth/`](../trip-dates-truth/spec.md).
+
+## Context
+
+Every surface that shows "Paris — Sep 20 – Sep 24" derives that range itself,
+in two hand-mirrored implementations (client + server) plus several one-off
+computations, with documented and undocumented divergences between them. This
+feature makes the server compute the legs ONCE and ship them in the trip
+payload; the client renders what it's told, keeping a temporary local fallback
+only for legless payloads (offline caches, rollback).
+
+## User Stories
+
+- As a **traveler**, I want every view of my trip — headers, stay rows,
+  flights, map pins, chat answers, print — to show the SAME dates for a city.
+- As the **trip assistant**, I want to read the exact ranges the traveler
+  sees, so I never narrate dates the page contradicts.
+
+## Acceptance Criteria
+
+- [ ] The trip detail and shared-trip payloads carry a `legs` array: one entry
+      per contiguous city run (revisits distinct, hubless runs labeled), with
+      the rendered start/end dates, the date source (stay / items / auto /
+      none), a zero-night flag, item-position bounds, and a representative
+      coordinate. Old clients ignore it.
+- [ ] The trip screen's city headers, stay/flight checklist inputs, map pins,
+      and weather/events windows render the payload legs when present, and
+      fall back to the local derivation only when absent.
+- [ ] get_trip and section-rewrite tool results echo the same computation.
+- [ ] A debug-mode parity monitor compares payload legs to the local
+      derivation on every trip load and reports mismatches; one week of daily
+      dogfooding with zero mismatches gates the client repoint.
+- [ ] Reconciled-rule behavior deltas are enumerated, decided, and pinned by
+      tests (address-then-name stay matching; chain skip over spanless legs;
+      first-spanned-leg anchor; no address-parse grouping).
+
+## Out of Scope
+
+- Schema changes (stage B) and server-derived todos (stage C).
+- The trips LIST endpoint (its `cities` summary is not a date consumer).

--- a/specs/server-leg-dates/tasks.md
+++ b/specs/server-leg-dates/tasks.md
@@ -1,0 +1,27 @@
+# Tasks: Server-Computed City-Leg Dates
+
+## Landed
+
+- [x] 0a `extract-leg-ranges` — Dart cluster → `utils/leg_ranges.dart` (PR #297)
+- [x] 0b `trip-render-legs` — Go module + twin tests + program specs (this PR)
+
+## Wave 2 (three lanes, no hub file, no migrations)
+
+| Lane | Branch | Contents | Depends on |
+|---|---|---|---|
+| 1a | `legs-payload` | `legs` on trip+shared responses; Dart `TripLeg` model + build_runner | 0b |
+| 1b | `legs-go-consumers` | legsRenderSummary/get_trip/section results/print stay-matching → computeTripLegs; golden diff review | 0b |
+| 1c | `legs-parity-logger` | kDebugMode payload-vs-local comparison → instrumentation events | 1a |
+
+Gate into wave 3: ≥1 week dogfooding, zero parity-mismatch events.
+
+## Wave 3 (2a is THE hub lane of its wave)
+
+| Lane | Branch | Contents | Depends on |
+|---|---|---|---|
+| 2a | `legs-client-repoint` | consumers → `trip.legs ?? visibleLegRanges`; duplicated payload-path widget tests | 1a deployed + 1c soak |
+| 2b | `shared-leg-dates` (optional) | shared view leg date chips | 1a |
+
+Constraints: at most one in-flight lane touches `trip_detail_screen.dart`;
+no `plan_tool_registry.go` definition-byte changes anywhere in this feature
+(result strings only).

--- a/specs/trip-dates-truth/spec.md
+++ b/specs/trip-dates-truth/spec.md
@@ -1,0 +1,64 @@
+# Spec: Trip Dates — Single Source of Truth (umbrella)
+
+> Umbrella for a staged re-architecture. The three feature specs execute it:
+> [`specs/server-leg-dates/`](../server-leg-dates/spec.md) (waves 1–3),
+> [`specs/server-booking-todos/`](../server-booking-todos/spec.md) (waves 4–5),
+> [`specs/itinerary-item-dates/`](../itinerary-item-dates/spec.md) (waves 3–6).
+
+## Context
+
+The August 2026 leg-dates arc (PRs #284–#295, five dogfooding rounds on one
+trip) kept producing the same bug shape: a date edit "succeeds" while the page
+shows something else. An audit found why: the dates a trip displays are a
+DERIVED view — per-city legs computed from positional item day numbers whose
+semantics (a city's last item day is its departure) exist only by convention —
+and that derivation exists in **five grouping rules and ~eight independent
+day→date computations** across two languages, with a third copy of the dates
+in the booking checklist that goes stale between screen loads, and write paths
+that never see what the reader will render. Each round patched one mismatch;
+this program removes the category: **one derivation, computed server-side,
+consumed everywhere; real calendar dates as storage truth; derived rows
+maintained by the writer, not the viewer.**
+
+## End state
+
+1. One Go function computes every city leg's rendered date span; the trip
+   payload carries it; client, chat tools, print, calendar, health checks and
+   the shared view all consume it. The client computes no dates.
+2. `itinerary_items` stores a real calendar date; the day number remains as a
+   derived mirror (wire format, dateless drafts, UI grouping). Authority is a
+   pure function of whether the trip has a start date.
+3. Auto booking-todos (and legacy auto drafts) are derived server-side on
+   every relevant write. A trip edited only via chat renders correctly with a
+   fresh checklist on first open.
+
+## Rollout (A → C → B, six waves; see feature specs for lane tables)
+
+Parity-prove the server derivation against the frozen client semantics first
+(retained client fallback + a ≥1-week live parity soak gate), close the
+checklist staleness channel second, flip storage last when it is a provable
+no-op (dual-write + backfill + pre-flip audit query). Compat: old cached
+bundles keep working forever (day-number inputs converted at the boundary;
+todo syncs become no-op echoes that return server truth).
+
+## The category is dead when
+
+- [ ] Exactly one function computes leg date ranges; trip payload, shared
+      payload, get_trip, section-rewrite results, print, and calendar spans
+      all consume it (one definition, N call sites).
+- [ ] Zero client-side date derivation code remains (grep list in tasks).
+- [ ] Every dated item carries a stored calendar date; the stored day number
+      is written only by the conversion boundary (or dropped); date-change
+      tools move dates.
+- [ ] A trip edited ONLY via chat renders correct leg dates and a fresh
+      checklist on first screen load.
+- [ ] An old cached bundle can still read the trip, edit items by day number,
+      and call the legacy sync endpoints without corrupting server truth.
+- [ ] All transition scaffolding (parity logger, twin fixtures, client
+      fallback) is deleted.
+
+## Out of Scope
+
+- Day chips / Today mode / day-grouping mechanics (stay day-number-based).
+- Print/shared visual redesigns beyond consuming the shared computation.
+- Section-rewrite stay-coherence (backlog; visible via rendered-leg echoes).

--- a/src/packages/api/trip_render_legs.go
+++ b/src/packages/api/trip_render_legs.go
@@ -1,0 +1,338 @@
+package main
+
+// The ONE trip-legs derivation (specs/trip-dates-truth, stage 0b): the city
+// legs a trip renders, with the calendar span each occupies. This module is
+// the server-canonical twin of the client's utils/leg_ranges.dart +
+// utils/trip_legs.dart pair, built to back the `legs` payload
+// (specs/server-leg-dates) and, later, server-derived booking todos and the
+// item_date storage flip. Its fixtures are hand-mirrored 1:1 with
+// test/leg_ranges_test.dart (the calendar-parity convention) — change either
+// side and you must change both.
+//
+// Reconciled rules (each was a documented divergence between the old Dart
+// and Go derivations; decisions recorded in specs/server-leg-dates/plan.md):
+//   - grouping: DART rule — a null/empty hub is its own run and groups with
+//     adjacent hubless items; revisited cities stay separate runs keyed
+//     "City", "City#2", …; NO address parsing (day_trip_from ?? city only —
+//     the client's cityFromAddress fallback retires at cutover).
+//   - stay matching: GO rule — fuzzy address, then NAME fallback, so
+//     agent-added address-less stays ("Stay in Los Angeles") anchor their
+//     leg.
+//   - span precedence: confirmed stay > item days > weighted auto-allocation
+//     (the Dart-only _allocateDays fallback, ported) > none.
+//   - first-leg anchor: the first leg WITH a span, when that span is
+//     item-derived, pulls its start back to the trip start.
+//   - arrival chain + zero-night collapse: GO rule — legs without a span are
+//     skipped and never reset the chain.
+//
+// Not yet wired to any consumer — stage 1a/1b repoint the payload and the
+// existing plan_leg_dates.go summaries onto this module.
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"travel-route-planner/store"
+)
+
+// otherPlacesLabel is the canonical key/label for legs whose locality can't
+// be resolved — the client's kOtherPlacesLabel. It keys collapse/header
+// registries and is NEVER localized server-side; screens map it to a display
+// label at render time.
+const otherPlacesLabel = "Other places"
+
+// RenderLeg is one city leg as the trip page renders it. Start/End are civil
+// dates (UTC midnights); nil when the leg has no calendar span. DateSource
+// says which rule produced the span: "stay", "items", "auto", or "" (none).
+type RenderLeg struct {
+	Key         string     `json:"key"`
+	Label       string     `json:"label"`
+	Hub         *string    `json:"hub"`
+	Start       *time.Time `json:"start_date"`
+	End         *time.Time `json:"end_date"`
+	DateSource  string     `json:"date_source"`
+	ZeroNight   bool       `json:"zero_night"`
+	FirstPos    int32      `json:"first_position"`
+	LastPos     int32      `json:"last_position"`
+	Lat         *float64   `json:"lat"`
+	Lng         *float64   `json:"lng"`
+	itemDays    []int32    // dated items' day numbers, derivation-internal
+	stayMatched bool       // span came from a confirmed stay
+}
+
+// renderHubOf resolves the locality an item groups under: its day-trip hub
+// when set, else its own city. No address parsing — the server never
+// second-guesses missing tags (decision: specs/server-leg-dates).
+func renderHubOf(it store.ItineraryItem) string {
+	if h := strings.TrimSpace(strPtrVal(it.DayTripFrom)); h != "" {
+		return h
+	}
+	return strings.TrimSpace(strPtrVal(it.City))
+}
+
+// computeTripLegs derives the trip's rendered city legs. Items must be in
+// position order (GetItineraryItemsByTrip's order).
+func computeTripLegs(trip store.Trip, items []store.ItineraryItem, stays []store.Accommodation) []RenderLeg {
+	if len(items) == 0 {
+		return nil
+	}
+
+	// 1. Group into runs: split when the hub changes (Dart tripLegs rule —
+	// hubless items form their own runs with hubless neighbors).
+	type run struct {
+		hub      string
+		items    []store.ItineraryItem
+		firstPos int32
+		lastPos  int32
+	}
+	var runs []run
+	for _, it := range items {
+		hub := renderHubOf(it)
+		if len(runs) == 0 || !strings.EqualFold(runs[len(runs)-1].hub, hub) {
+			runs = append(runs, run{hub: hub, firstPos: it.Position})
+		}
+		cur := &runs[len(runs)-1]
+		cur.items = append(cur.items, it)
+		cur.lastPos = it.Position
+	}
+
+	// Run keys: revisited labels get #2, #3, … suffixes (client convention —
+	// collapse-state and header keys are per-run).
+	seen := map[string]int{}
+	legs := make([]RenderLeg, 0, len(runs))
+	for _, r := range runs {
+		label := r.hub
+		if label == "" {
+			label = otherPlacesLabel
+		}
+		seen[strings.ToLower(label)]++
+		key := label
+		if n := seen[strings.ToLower(label)]; n > 1 {
+			key = fmt.Sprintf("%s#%d", label, n)
+		}
+		leg := RenderLeg{Key: key, Label: label, FirstPos: r.firstPos, LastPos: r.lastPos}
+		if r.hub != "" {
+			hub := r.hub
+			leg.Hub = &hub
+		}
+		for _, it := range r.items {
+			if it.Day != nil && *it.Day >= 1 {
+				leg.itemDays = append(leg.itemDays, *it.Day)
+			}
+			// Representative coordinate: the first item with real coords —
+			// (0,0) is the "no location" sentinel for manually-added places.
+			if leg.Lat == nil && (it.Latitude != 0 || it.Longitude != 0) {
+				lat, lng := it.Latitude, it.Longitude
+				leg.Lat, leg.Lng = &lat, &lng
+			}
+		}
+		legs = append(legs, leg)
+	}
+
+	// 2. Auto-allocation lattice: a weighted contiguous slice of the whole
+	// trip span per leg, used only as the per-leg third fallback below.
+	var autoStart, autoEnd []time.Time
+	haveAuto := false
+	if trip.StartDate.Valid && trip.EndDate.Valid && !trip.EndDate.Time.Before(trip.StartDate.Time) {
+		start, end := trip.StartDate.Time, trip.EndDate.Time
+		totalDays := int(end.Sub(start).Hours()/24) + 1
+		n := len(legs)
+		autoStart = make([]time.Time, n)
+		autoEnd = make([]time.Time, n)
+		haveAuto = true
+		if n <= totalDays {
+			weights := make([]int, n)
+			for i, r := range runs {
+				weights[i] = len(r.items)
+			}
+			counts := allocateLegDays(totalDays, weights)
+			cursor := start
+			for i := 0; i < n; i++ {
+				rStart := cursor
+				if rStart.After(end) {
+					rStart = end
+				}
+				rEnd := rStart.AddDate(0, 0, counts[i]-1)
+				if rEnd.After(end) {
+					rEnd = end
+				}
+				autoStart[i], autoEnd[i] = rStart, rEnd
+				cursor = rEnd.AddDate(0, 0, 1)
+			}
+		} else {
+			// More locations than days: one ascending day each.
+			for i := 0; i < n; i++ {
+				off := i * totalDays / n
+				if off > totalDays-1 {
+					off = totalDays - 1
+				}
+				d := start.AddDate(0, 0, off)
+				autoStart[i], autoEnd[i] = d, d
+			}
+		}
+	}
+
+	// 3. Per-leg own span: stay > item days > auto slice > none.
+	tripStart := trip.StartDate.Time
+	for i := range legs {
+		leg := &legs[i]
+		hubLower := strings.ToLower(strPtrVal(leg.Hub))
+		if hubLower != "" {
+			if a := firstConfirmedStayForHub(stays, hubLower); a != nil {
+				s, e := a.CheckIn.Time, a.CheckOut.Time
+				leg.Start, leg.End = &s, &e
+				leg.DateSource = "stay"
+				leg.stayMatched = true
+				continue
+			}
+		}
+		if len(leg.itemDays) > 0 && trip.StartDate.Valid {
+			lo, hi := leg.itemDays[0], leg.itemDays[0]
+			for _, d := range leg.itemDays[1:] {
+				if d < lo {
+					lo = d
+				}
+				if d > hi {
+					hi = d
+				}
+			}
+			s := tripStart.AddDate(0, 0, int(lo)-1)
+			e := tripStart.AddDate(0, 0, int(hi)-1)
+			leg.Start, leg.End = &s, &e
+			leg.DateSource = "items"
+			continue
+		}
+		if haveAuto {
+			s, e := autoStart[i], autoEnd[i]
+			leg.Start, leg.End = &s, &e
+			leg.DateSource = "auto"
+		}
+	}
+
+	// 4. First-leg anchor: the first leg WITH a span, when item-derived,
+	// starts at the trip start — the traveler is in the first city from the
+	// trip's first day; a single late item must not read as a late arrival.
+	if trip.StartDate.Valid {
+		for i := range legs {
+			if legs[i].Start == nil {
+				continue
+			}
+			if legs[i].DateSource == "items" && tripStart.Before(*legs[i].Start) {
+				s := tripStart
+				legs[i].Start = &s
+			}
+			break
+		}
+	}
+
+	// 5. Arrival chain + zero-night collapse: a leg renders from its arrival
+	// (the previous spanned leg's VISIBLE end) when that comes first, and
+	// collapses to a zero-night stop at the arrival when the previous leg has
+	// run past its own last day. Spanless legs are skipped and never reset
+	// the chain; confirmed stays never collapse.
+	var prevEnd *time.Time
+	for i := range legs {
+		leg := &legs[i]
+		if leg.Start == nil || leg.End == nil {
+			continue
+		}
+		if prevEnd != nil {
+			if prevEnd.Before(*leg.Start) {
+				s := *prevEnd
+				leg.Start = &s
+			} else if prevEnd.After(*leg.End) && !leg.stayMatched {
+				s := *prevEnd
+				leg.Start, leg.End = &s, &s
+				leg.ZeroNight = true
+			}
+		}
+		prevEnd = leg.End
+	}
+
+	return legs
+}
+
+// firstConfirmedStayForHub finds the confirmed (non-auto) stay that anchors a
+// leg's span: fuzzy address match, then NAME fallback for agent-added stays
+// with no address; both dates required. Same predicate as stayMatchesHub
+// (plan_leg_dates.go) — kept separate so this module stays free of legRun.
+func firstConfirmedStayForHub(stays []store.Accommodation, hubLower string) *store.Accommodation {
+	for i, a := range stays {
+		if a.Auto || !a.CheckIn.Valid || !a.CheckOut.Valid {
+			continue
+		}
+		if stayMatchesHub(a, hubLower) {
+			return &stays[i]
+		}
+	}
+	return nil
+}
+
+// allocateLegDays splits totalDays across legs proportional to weights, each
+// leg at least 1 day, summing to totalDays (largest-remainder; trims from
+// the largest legs when the min-1 floor overshoots). Twin of allocateDays in
+// utils/leg_ranges.dart.
+func allocateLegDays(totalDays int, weights []int) []int {
+	n := len(weights)
+	if n == 0 {
+		return nil
+	}
+	counts := make([]int, n)
+	if totalDays <= n {
+		for i := range counts {
+			counts[i] = 1 // spans clamp to the trip end
+		}
+		return counts
+	}
+	totalW := 0
+	norm := make([]int, n)
+	for i, w := range weights {
+		if w <= 0 {
+			w = 1
+		}
+		norm[i] = w
+		totalW += w
+	}
+	exact := make([]float64, n)
+	used := 0
+	for i, w := range norm {
+		exact[i] = float64(totalDays) * float64(w) / float64(totalW)
+		counts[i] = int(exact[i])
+		if counts[i] < 1 {
+			counts[i] = 1
+		}
+		used += counts[i]
+	}
+	frac := func(i int) float64 { return exact[i] - float64(int(exact[i])) }
+	// Hand out remaining days to the largest fractional remainders.
+	byRemainder := make([]int, n)
+	for i := range byRemainder {
+		byRemainder[i] = i
+	}
+	sort.SliceStable(byRemainder, func(a, b int) bool {
+		return frac(byRemainder[a]) > frac(byRemainder[b])
+	})
+	for k := 0; used < totalDays; k++ {
+		counts[byRemainder[k%n]]++
+		used++
+	}
+	// Or trim back from the largest legs if the min-1 floor overshot. The
+	// count snapshot is taken once, like the Dart twin's byCount sort.
+	byCount := make([]int, n)
+	for i := range byCount {
+		byCount[i] = i
+	}
+	sort.SliceStable(byCount, func(a, b int) bool {
+		return counts[byCount[a]] > counts[byCount[b]]
+	})
+	for k := 0; used > totalDays; k++ {
+		j := byCount[k%n]
+		if counts[j] > 1 {
+			counts[j]--
+			used--
+		}
+	}
+	return counts
+}

--- a/src/packages/api/trip_render_legs_test.go
+++ b/src/packages/api/trip_render_legs_test.go
@@ -1,0 +1,256 @@
+package main
+
+// CROSS-LANGUAGE CONTRACT (specs/trip-dates-truth): these fixtures and
+// expected values hand-mirror test/leg_ranges_test.dart in the Flutter suite
+// (the calendar-parity convention) — same trips, same expected spans, city
+// names and all. Change either side and you must change both. The two cases
+// the Dart suite pins with "diverges:" markers appear here with the SERVER
+// expected values (the reconciled post-cutover rules): an address-less
+// confirmed stay DOES anchor (name fallback), and a spanless interior leg
+// does NOT reset the arrival chain.
+
+import (
+	"testing"
+	"time"
+
+	"travel-route-planner/store"
+)
+
+func rlItem(pos int, name string, city *string, day int) store.ItineraryItem {
+	it := store.ItineraryItem{Position: int32(pos), Name: name, City: city,
+		Latitude: 1, Longitude: 1}
+	if day > 0 {
+		d := int32(day)
+		it.Day = &d
+	}
+	return it
+}
+
+func rlCity(c string) *string { return &c }
+
+func rlTrip(start, end string) store.Trip {
+	t := store.Trip{}
+	if start != "" {
+		t.StartDate = validDate(start)
+	}
+	if end != "" {
+		t.EndDate = validDate(end)
+	}
+	return t
+}
+
+func rlStay(name, address, checkIn, checkOut string) store.Accommodation {
+	a := store.Accommodation{Name: name,
+		CheckIn: validDate(checkIn), CheckOut: validDate(checkOut)}
+	if address != "" {
+		a.Address = &address
+	}
+	return a
+}
+
+func rlDate(iso string) time.Time { return civilDate(iso) }
+
+func assertSpan(t *testing.T, leg RenderLeg, start, end string) {
+	t.Helper()
+	if leg.Start == nil || leg.End == nil {
+		t.Fatalf("%s: span = %v/%v, want %s/%s", leg.Key, leg.Start, leg.End, start, end)
+	}
+	if !leg.Start.Equal(rlDate(start)) || !leg.End.Equal(rlDate(end)) {
+		t.Fatalf("%s: span = %s/%s, want %s/%s", leg.Key,
+			leg.Start.Format(dateLayout), leg.End.Format(dateLayout), start, end)
+	}
+}
+
+func TestComputeTripLegsItemDayRanges(t *testing.T) {
+	legs := computeTripLegs(rlTrip("2026-08-24", "2026-08-28"), []store.ItineraryItem{
+		rlItem(0, "Feskekôrka", rlCity("Gothenburg"), 1),
+		rlItem(1, "Liseberg", rlCity("Gothenburg"), 3),
+		rlItem(2, "Prado", rlCity("Madrid"), 5),
+	}, nil)
+	if len(legs) != 2 {
+		t.Fatalf("legs = %d, want 2", len(legs))
+	}
+	assertSpan(t, legs[0], "2026-08-24", "2026-08-26")
+	// Madrid's own range collapses to its item day; the chain pulls its
+	// visible start back to the arrival (Gothenburg's end).
+	assertSpan(t, legs[1], "2026-08-26", "2026-08-28")
+	if legs[0].Key != "Gothenburg" || legs[1].Key != "Madrid" {
+		t.Fatalf("keys = %s/%s", legs[0].Key, legs[1].Key)
+	}
+	if legs[0].DateSource != "items" || legs[1].DateSource != "items" {
+		t.Fatalf("date sources = %s/%s, want items/items", legs[0].DateSource, legs[1].DateSource)
+	}
+	if legs[0].FirstPos != 0 || legs[0].LastPos != 1 || legs[1].FirstPos != 2 {
+		t.Fatalf("positions = %d-%d / %d-%d", legs[0].FirstPos, legs[0].LastPos, legs[1].FirstPos, legs[1].LastPos)
+	}
+}
+
+func TestComputeTripLegsFirstLegAnchor(t *testing.T) {
+	legs := computeTripLegs(rlTrip("2026-08-24", "2026-09-01"), []store.ItineraryItem{
+		rlItem(0, "Prague", rlCity("Prague"), 4),
+		rlItem(1, "Kraków", rlCity("Kraków"), 9),
+	}, nil)
+	assertSpan(t, legs[0], "2026-08-24", "2026-08-27")
+	assertSpan(t, legs[1], "2026-08-27", "2026-09-01")
+}
+
+func TestComputeTripLegsConfirmedStayAnchors(t *testing.T) {
+	legs := computeTripLegs(rlTrip("2026-09-01", "2026-09-07"), []store.ItineraryItem{
+		rlItem(0, "Museo", rlCity("Medellín"), 1),
+		rlItem(1, "Quito", rlCity("Quito"), 5),
+	}, []store.Accommodation{
+		rlStay("Hotel Quito", "Av. González Suárez, Quito, Ecuador", "2026-09-03", "2026-09-05"),
+	})
+	// The stay's dates are the leg's OWN span (source "stay", end Sep 5),
+	// but the arrival rule still pulls the visible start back to Medellín's
+	// end (Sep 1) — the Dart raw-pass fixture sees Sep 3; this module is the
+	// visible/chained output, matching the client's rendered value.
+	assertSpan(t, legs[1], "2026-09-01", "2026-09-05")
+	if legs[1].DateSource != "stay" {
+		t.Fatalf("date source = %s, want stay", legs[1].DateSource)
+	}
+}
+
+// diverges (Dart pins the opposite pre-cutover): an address-LESS confirmed
+// stay anchors via the NAME fallback — the reconciled server rule, so
+// agent-added "Stay in Quito" rows anchor their leg.
+func TestComputeTripLegsAddressLessStayAnchorsByName(t *testing.T) {
+	legs := computeTripLegs(rlTrip("2026-09-01", "2026-09-05"), []store.ItineraryItem{
+		rlItem(0, "Quito", rlCity("Quito"), 3),
+	}, []store.Accommodation{
+		rlStay("Stay in Quito", "", "2026-09-02", "2026-09-04"),
+	})
+	assertSpan(t, legs[0], "2026-09-02", "2026-09-04")
+	if legs[0].DateSource != "stay" {
+		t.Fatalf("date source = %s, want stay (name fallback)", legs[0].DateSource)
+	}
+}
+
+func TestComputeTripLegsAutoAllocation(t *testing.T) {
+	legs := computeTripLegs(rlTrip("2026-06-01", "2026-06-08"), []store.ItineraryItem{
+		rlItem(0, "Louvre", rlCity("Paris"), 0),
+		rlItem(1, "Orsay", rlCity("Paris"), 0),
+		rlItem(2, "Marais walk", rlCity("Paris"), 0),
+		rlItem(3, "Colosseum", rlCity("Rome"), 0),
+	}, nil)
+	assertSpan(t, legs[0], "2026-06-01", "2026-06-06")
+	// Raw auto slices are [Jun 7, Jun 8]; the arrival rule renders Rome from
+	// Paris's departure day (checkout-day semantics, like every other leg).
+	assertSpan(t, legs[1], "2026-06-06", "2026-06-08")
+	if legs[0].DateSource != "auto" || legs[1].DateSource != "auto" {
+		t.Fatalf("date sources = %s/%s, want auto/auto", legs[0].DateSource, legs[1].DateSource)
+	}
+}
+
+func TestComputeTripLegsMoreLocationsThanDays(t *testing.T) {
+	legs := computeTripLegs(rlTrip("2026-06-01", "2026-06-02"), []store.ItineraryItem{
+		rlItem(0, "A", rlCity("Alpha"), 0),
+		rlItem(1, "B", rlCity("Beta"), 0),
+		rlItem(2, "C", rlCity("Gamma"), 0),
+	}, nil)
+	assertSpan(t, legs[0], "2026-06-01", "2026-06-01")
+	assertSpan(t, legs[1], "2026-06-01", "2026-06-01")
+	// Raw slice is a bare Jun 2; the arrival rule renders it from Beta's end.
+	assertSpan(t, legs[2], "2026-06-01", "2026-06-02")
+}
+
+func TestComputeTripLegsDatelessTrip(t *testing.T) {
+	legs := computeTripLegs(rlTrip("", ""), []store.ItineraryItem{
+		rlItem(0, "Louvre", rlCity("Paris"), 1),
+	}, nil)
+	if legs[0].Start != nil || legs[0].End != nil || legs[0].DateSource != "" {
+		t.Fatalf("dateless legs = %+v, want nil span", legs[0])
+	}
+}
+
+func TestComputeTripLegsZeroNightCollapseCascades(t *testing.T) {
+	legs := computeTripLegs(rlTrip("2026-09-01", "2026-09-07"), []store.ItineraryItem{
+		rlItem(0, "Museo", rlCity("Medellín"), 1),
+		rlItem(1, "Comuna 13", rlCity("Medellín"), 6),
+		rlItem(2, "Quito", rlCity("Quito"), 5),
+		rlItem(3, "Mitad del Mundo", rlCity("Galápagos"), 6),
+		rlItem(4, "Tortuga Bay", rlCity("Galápagos"), 7),
+	}, nil)
+	assertSpan(t, legs[1], "2026-09-06", "2026-09-06")
+	if !legs[1].ZeroNight {
+		t.Fatal("squeezed leg not marked zero_night")
+	}
+	assertSpan(t, legs[2], "2026-09-06", "2026-09-07")
+	if legs[2].ZeroNight {
+		t.Fatal("downstream leg wrongly marked zero_night")
+	}
+}
+
+func TestComputeTripLegsConsecutiveSqueezesChain(t *testing.T) {
+	legs := computeTripLegs(rlTrip("2026-09-01", "2026-09-07"), []store.ItineraryItem{
+		rlItem(0, "Museo", rlCity("Medellín"), 1),
+		rlItem(1, "Comuna 13", rlCity("Medellín"), 6),
+		rlItem(2, "Quito", rlCity("Quito"), 4),
+		rlItem(3, "Guayaquil", rlCity("Guayaquil"), 5),
+	}, nil)
+	assertSpan(t, legs[1], "2026-09-06", "2026-09-06")
+	assertSpan(t, legs[2], "2026-09-06", "2026-09-06")
+	if !legs[1].ZeroNight || !legs[2].ZeroNight {
+		t.Fatal("chained squeezes not both zero_night")
+	}
+}
+
+func TestComputeTripLegsStayNeverCollapses(t *testing.T) {
+	legs := computeTripLegs(rlTrip("2026-09-01", "2026-09-07"), []store.ItineraryItem{
+		rlItem(0, "Museo", rlCity("Medellín"), 1),
+		rlItem(1, "Comuna 13", rlCity("Medellín"), 6),
+		rlItem(2, "Quito", rlCity("Quito"), 5),
+	}, []store.Accommodation{
+		rlStay("Hotel Quito", "Av. González Suárez, Quito, Ecuador", "2026-09-03", "2026-09-05"),
+	})
+	assertSpan(t, legs[1], "2026-09-03", "2026-09-05")
+	if legs[1].ZeroNight {
+		t.Fatal("stay-anchored leg wrongly collapsed")
+	}
+}
+
+// diverges (Dart pins the opposite pre-cutover): a spanless interior leg is
+// SKIPPED by the arrival chain and never resets it — the reconciled server
+// rule. Note the auto lattice needs no trip end here, so the hubless leg has
+// no span at all.
+func TestComputeTripLegsSpanlessLegDoesNotResetChain(t *testing.T) {
+	legs := computeTripLegs(rlTrip("2026-06-01", ""), []store.ItineraryItem{
+		rlItem(0, "A", rlCity("Alpha"), 1),
+		rlItem(1, "mystery", nil, 0),
+		rlItem(2, "C", rlCity("Gamma"), 5),
+	}, nil)
+	if len(legs) != 3 {
+		t.Fatalf("legs = %d, want 3", len(legs))
+	}
+	if legs[1].Start != nil || legs[1].Label != otherPlacesLabel || legs[1].Hub != nil {
+		t.Fatalf("hubless leg = %+v, want spanless Other places", legs[1])
+	}
+	// Gamma still chains off Alpha's end across the spanless leg.
+	assertSpan(t, legs[2], "2026-06-01", "2026-06-05")
+}
+
+func TestComputeTripLegsRevisitKeysAndHubs(t *testing.T) {
+	legs := computeTripLegs(rlTrip("2026-06-01", "2026-06-06"), []store.ItineraryItem{
+		rlItem(0, "Acropolis", rlCity("Athens"), 1),
+		rlItem(1, "Oia", rlCity("Santorini"), 3),
+		rlItem(2, "Plaka dinner", rlCity("Athens"), 5),
+	}, nil)
+	if legs[0].Key != "Athens" || legs[1].Key != "Santorini" || legs[2].Key != "Athens#2" {
+		t.Fatalf("keys = %s/%s/%s, want Athens/Santorini/Athens#2", legs[0].Key, legs[1].Key, legs[2].Key)
+	}
+	if legs[2].Label != "Athens" {
+		t.Fatalf("revisit label = %s, want Athens", legs[2].Label)
+	}
+}
+
+func TestAllocateLegDays(t *testing.T) {
+	if got := allocateLegDays(8, []int{3, 1}); got[0] != 6 || got[1] != 2 {
+		t.Fatalf("allocateLegDays(8, [3 1]) = %v, want [6 2]", got)
+	}
+	if got := allocateLegDays(10, []int{1, 1, 1}); got[0] != 4 || got[1] != 3 || got[2] != 3 {
+		t.Fatalf("allocateLegDays(10, [1 1 1]) = %v, want [4 3 3]", got)
+	}
+	if got := allocateLegDays(2, []int{5, 5, 5}); got[0] != 1 || got[1] != 1 || got[2] != 1 {
+		t.Fatalf("allocateLegDays(2, [5 5 5]) = %v, want [1 1 1]", got)
+	}
+}


### PR DESCRIPTION
## Summary
- Stage 0b of the trip-dates single-source-of-truth program (pairs with #297/stage 0a): new `trip_render_legs.go` with `computeTripLegs(trip, items, stays) []RenderLeg` — the ONE derivation that will back the `legs` payload (stage 1a), server-derived booking todos (stage C), and the `item_date` storage flip (stage B). Deliberately unwired; its value is the tested module.
- **Reconciled rules** (each was a documented Dart↔Go divergence; decision table in `specs/server-leg-dates/plan.md`): Dart run-split (hubless runs stand alone; revisits keyed `City#2`), no address-parse grouping, Go stay-matching (address then NAME — agent-added stays anchor their leg), span precedence stay > item days > ported weighted auto-allocation (`allocateLegDays`, twin of Dart `allocateDays`), first-spanned-leg trip-start anchor, Go arrival chain (spanless legs skipped, never reset) + zero-night collapse with the stay carve-out.
- **Twin tests**: `trip_render_legs_test.go` hand-mirrors `test/leg_ranges_test.dart` fixtures 1:1 per the repo's calendar-parity convention. The Dart suite's two `diverges:` pins appear here with the reconciled server values; three Dart raw-pass fixtures carry visible-lens values (this module emits only the chained output), each with an explaining comment.
- **Program specs landed**: `specs/trip-dates-truth/` umbrella (end state, A→C→B rollout, category-is-dead checklist), `specs/server-leg-dates/` (spec + decision-table plan + wave-2/3 lane tables with the ≥1-week parity-soak gate), `specs/server-booking-todos/` and `specs/itinerary-item-dates/` (spec + lane tables; plan.md written at their execution waves). Migrations 00054/00055 reserved.

## Testing
- 13 new unit tests green (grouping/keys/positions, spans by all four sources, both anchors, squeeze + chained squeeze + stay carve-out, dateless, revisits, allocation table); full Go suite green against the lane DB (43.7s); gofmt/vet clean. No registry, payload, schema, or behavior changes — pure additive module + docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)