### PR TITLE
feat(api): ship server-computed city legs in trip payloads

### DIFF
--- a/src/packages/api/share_handler.go
+++ b/src/packages/api/share_handler.go
@@ -185,6 +185,7 @@ func buildSharedTripResponse(ctx context.Context, ownerID uuid.UUID, trip store.
 		ownerName = *owner.DisplayName
 	}
 	resp := toTripResponse(trip, items, accommodations, segments, nil)
+	resp.Legs = tripLegsResponse(trip, items, accommodations)
 	resp.ChatID = nil
 	return SharedTripResponse{Trip: resp, OwnerName: ownerName, Role: role}, nil
 }

--- a/src/packages/api/trip_handler.go
+++ b/src/packages/api/trip_handler.go
@@ -72,6 +72,53 @@ type TripResponse struct {
 	// the owner's client polls /status only when set (editors always poll).
 	UpdatedByName *string `json:"updated_by_name,omitempty"`
 	Shared        bool    `json:"shared,omitempty"`
+	// Legs is the server-computed city-leg view (specs/server-leg-dates):
+	// the rendered date span per contiguous city run, from computeTripLegs —
+	// the one derivation. Attached only on the full trip views (GET
+	// /trips/{id} and the shared view), never on list/stub responses whose
+	// partial data would yield anchor-less legs. Old clients ignore it.
+	Legs []TripLegResponse `json:"legs,omitempty"`
+}
+
+// TripLegResponse is one rendered city leg. Dates are YYYY-MM-DD; absent
+// when the leg has no calendar span. See RenderLeg (trip_render_legs.go)
+// for the field semantics.
+type TripLegResponse struct {
+	Key        string   `json:"key"`
+	Label      string   `json:"label"`
+	Hub        *string  `json:"hub,omitempty"`
+	StartDate  *string  `json:"start_date,omitempty"`
+	EndDate    *string  `json:"end_date,omitempty"`
+	DateSource string   `json:"date_source,omitempty"`
+	ZeroNight  bool     `json:"zero_night,omitempty"`
+	FirstPos   int32    `json:"first_position"`
+	LastPos    int32    `json:"last_position"`
+	Lat        *float64 `json:"lat,omitempty"`
+	Lng        *float64 `json:"lng,omitempty"`
+}
+
+// tripLegsResponse computes the legs payload for a full trip view.
+func tripLegsResponse(t store.Trip, items []store.ItineraryItem, stays []store.Accommodation) []TripLegResponse {
+	legs := computeTripLegs(t, items, stays)
+	out := make([]TripLegResponse, 0, len(legs))
+	for _, l := range legs {
+		r := TripLegResponse{
+			Key: l.Key, Label: l.Label, Hub: l.Hub,
+			DateSource: l.DateSource, ZeroNight: l.ZeroNight,
+			FirstPos: l.FirstPos, LastPos: l.LastPos,
+			Lat: l.Lat, Lng: l.Lng,
+		}
+		if l.Start != nil {
+			s := l.Start.Format(dateLayout)
+			r.StartDate = &s
+		}
+		if l.End != nil {
+			e := l.End.Format(dateLayout)
+			r.EndDate = &e
+		}
+		out = append(out, r)
+	}
+	return out
 }
 
 // TripStatusResponse is the freshness-poll payload for shared trips.
@@ -426,6 +473,7 @@ func getTripHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	resp := toTripResponse(trip, items, accommodations, segments, bookingTodos)
+	resp.Legs = tripLegsResponse(trip, items, accommodations)
 	resp.Access = row.Access
 	if row.Access != "owner" {
 		// The chat_id keys the OWNER's plan sessions; a collaborator seeding a

--- a/src/packages/api/trip_legs_payload_test.go
+++ b/src/packages/api/trip_legs_payload_test.go
@@ -1,0 +1,78 @@
+package main
+
+// The `legs` payload (specs/server-leg-dates stage 1a): full trip views carry
+// the server-computed city legs; list responses don't. Values here must agree
+// with the trip_render_legs_test.go twin fixtures — the payload is just
+// computeTripLegs serialized.
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestTripResponseCarriesLegs(t *testing.T) {
+	resetDB(t)
+	owner, token := createTestUser(t, "legspayload@example.com")
+	trip := createTestTrip(t, owner.ID, 0)
+	seedMultiCityTrip(t, trip, owner.ID)
+
+	rec := doJSON(t, "GET", "/api/v1/trips/"+trip.ID.String(), token, nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET trip = %d", rec.Code)
+	}
+	body := rec.Body.String()
+	for _, want := range []string{
+		`"legs":[`,
+		`"key":"Panama City"`,
+		`"key":"Los Angeles"`,
+		// PC: stay-anchored (Hotel Casco Viejo, address match).
+		`"start_date":"2026-09-15"`,
+		`"end_date":"2026-09-20"`,
+		// LA: stay-anchored by NAME ("Stay in Los Angeles").
+		`"start_date":"2026-09-20"`,
+		`"end_date":"2026-09-24"`,
+		`"date_source":"stay"`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("trip response missing %q:\n%s", want, body)
+		}
+	}
+
+	// The LIST response never carries legs (partial data would yield
+	// anchor-less values).
+	list := doJSON(t, "GET", "/api/v1/trips", token, nil)
+	if list.Code != http.StatusOK {
+		t.Fatalf("GET trips = %d", list.Code)
+	}
+	if strings.Contains(list.Body.String(), `"legs"`) {
+		t.Fatalf("list response leaked legs:\n%s", list.Body.String())
+	}
+}
+
+func TestSharedTripCarriesLegs(t *testing.T) {
+	resetDB(t)
+	owner, token := createTestUser(t, "legsshare@example.com")
+	trip := createTestTrip(t, owner.ID, 0)
+	seedMultiCityTrip(t, trip, owner.ID)
+
+	shareRec := doJSON(t, "POST", "/api/v1/trips/"+trip.ID.String()+"/share", token, map[string]any{})
+	if shareRec.Code != http.StatusCreated && shareRec.Code != http.StatusOK {
+		t.Fatalf("create share = %d: %s", shareRec.Code, shareRec.Body.String())
+	}
+	tok := decode(t, shareRec)["token"]
+	if tok == nil {
+		t.Fatalf("no share token in %s", shareRec.Body.String())
+	}
+
+	view := doJSON(t, "GET", "/api/v1/shared/"+tok.(string), "", nil)
+	if view.Code != http.StatusOK {
+		t.Fatalf("shared view = %d: %s", view.Code, view.Body.String())
+	}
+	body := view.Body.String()
+	for _, want := range []string{`"legs":[`, `"key":"Panama City"`, `"date_source":"stay"`} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("shared view missing %q:\n%s", want, body)
+		}
+	}
+}

--- a/src/packages/flutter-app/lib/models/trip.dart
+++ b/src/packages/flutter-app/lib/models/trip.dart
@@ -3,6 +3,7 @@ import 'itinerary_item.dart';
 import 'accommodation.dart';
 import 'trip_segment.dart';
 import 'booking_todo.dart';
+import 'trip_leg_dto.dart';
 
 part 'trip.g.dart';
 
@@ -53,6 +54,11 @@ class Trip {
   /// polls for freshness. Editors poll based on [access] alone.
   final bool? shared;
 
+  /// Server-computed city legs (specs/server-leg-dates) — present on full
+  /// trip views; absent on list responses, offline caches, and old
+  /// snapshots, where clients fall back to the local derivation.
+  final List<TripLegDto>? legs;
+
   const Trip({
     required this.id,
     required this.title,
@@ -74,6 +80,7 @@ class Trip {
     this.ownerName,
     this.updatedByName,
     this.shared,
+    this.legs,
   });
 
   /// True when the current user may edit this trip: owner or editor

--- a/src/packages/flutter-app/lib/models/trip.g.dart
+++ b/src/packages/flutter-app/lib/models/trip.g.dart
@@ -36,6 +36,9 @@ Trip _$TripFromJson(Map<String, dynamic> json) => Trip(
       ownerName: json['owner_name'] as String?,
       updatedByName: json['updated_by_name'] as String?,
       shared: json['shared'] as bool?,
+      legs: (json['legs'] as List<dynamic>?)
+          ?.map((e) => TripLegDto.fromJson(e as Map<String, dynamic>))
+          .toList(),
     );
 
 Map<String, dynamic> _$TripToJson(Trip instance) => <String, dynamic>{
@@ -60,4 +63,5 @@ Map<String, dynamic> _$TripToJson(Trip instance) => <String, dynamic>{
       'owner_name': instance.ownerName,
       'updated_by_name': instance.updatedByName,
       'shared': instance.shared,
+      'legs': instance.legs?.map((e) => e.toJson()).toList(),
     };

--- a/src/packages/flutter-app/lib/models/trip_leg_dto.dart
+++ b/src/packages/flutter-app/lib/models/trip_leg_dto.dart
@@ -1,0 +1,67 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'trip_leg_dto.g.dart';
+
+/// One server-computed city leg (specs/server-leg-dates): the rendered date
+/// span per contiguous city run, from the API's one derivation
+/// (computeTripLegs, trip_render_legs.go). Present on full trip views only;
+/// clients render these when available and fall back to the local
+/// utils/leg_ranges.dart derivation when absent (offline caches, old
+/// snapshots, rollback).
+@JsonSerializable(explicitToJson: true)
+class TripLegDto {
+  /// Per-run key — revisited cities get "City#2", "City#3", … suffixes,
+  /// matching the client tripLegs convention for collapse/header registries.
+  final String key;
+
+  /// Display label; 'Other places' sentinel for hubless runs (localized at
+  /// render time, never here).
+  final String label;
+
+  /// Raw hub locality; null for hubless runs.
+  final String? hub;
+
+  /// Rendered span, YYYY-MM-DD, arrival → departure (checkout-day
+  /// semantics). Null when the leg has no calendar span.
+  @JsonKey(name: 'start_date')
+  final String? startDate;
+  @JsonKey(name: 'end_date')
+  final String? endDate;
+
+  /// Which rule produced the span: 'stay' | 'items' | 'auto' | null.
+  @JsonKey(name: 'date_source')
+  final String? dateSource;
+
+  /// True when a squeeze collapsed the leg to a zero-night stop at its
+  /// arrival (the interim state chat narrates as "no nights left").
+  @JsonKey(name: 'zero_night')
+  final bool? zeroNight;
+
+  /// The leg's contiguous item-position bounds within the itinerary.
+  @JsonKey(name: 'first_position')
+  final int firstPosition;
+  @JsonKey(name: 'last_position')
+  final int lastPosition;
+
+  /// Representative coordinate (first geocoded item); null when ungeocoded.
+  final double? lat;
+  final double? lng;
+
+  const TripLegDto({
+    required this.key,
+    required this.label,
+    this.hub,
+    this.startDate,
+    this.endDate,
+    this.dateSource,
+    this.zeroNight,
+    required this.firstPosition,
+    required this.lastPosition,
+    this.lat,
+    this.lng,
+  });
+
+  factory TripLegDto.fromJson(Map<String, dynamic> json) =>
+      _$TripLegDtoFromJson(json);
+  Map<String, dynamic> toJson() => _$TripLegDtoToJson(this);
+}

--- a/src/packages/flutter-app/lib/models/trip_leg_dto.g.dart
+++ b/src/packages/flutter-app/lib/models/trip_leg_dto.g.dart
@@ -1,0 +1,36 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'trip_leg_dto.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+TripLegDto _$TripLegDtoFromJson(Map<String, dynamic> json) => TripLegDto(
+      key: json['key'] as String,
+      label: json['label'] as String,
+      hub: json['hub'] as String?,
+      startDate: json['start_date'] as String?,
+      endDate: json['end_date'] as String?,
+      dateSource: json['date_source'] as String?,
+      zeroNight: json['zero_night'] as bool?,
+      firstPosition: (json['first_position'] as num).toInt(),
+      lastPosition: (json['last_position'] as num).toInt(),
+      lat: (json['lat'] as num?)?.toDouble(),
+      lng: (json['lng'] as num?)?.toDouble(),
+    );
+
+Map<String, dynamic> _$TripLegDtoToJson(TripLegDto instance) =>
+    <String, dynamic>{
+      'key': instance.key,
+      'label': instance.label,
+      'hub': instance.hub,
+      'start_date': instance.startDate,
+      'end_date': instance.endDate,
+      'date_source': instance.dateSource,
+      'zero_night': instance.zeroNight,
+      'first_position': instance.firstPosition,
+      'last_position': instance.lastPosition,
+      'lat': instance.lat,
+      'lng': instance.lng,
+    };

--- a/src/packages/flutter-app/test/trip_leg_dto_test.dart
+++ b/src/packages/flutter-app/test/trip_leg_dto_test.dart
@@ -1,0 +1,76 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:travel_route_planner/models/trip.dart';
+import 'package:travel_route_planner/models/trip_leg_dto.dart';
+
+void main() {
+  test('TripLegDto parses the server legs payload shape', () {
+    final trip = Trip.fromJson({
+      'id': 't1',
+      'title': 'Fixture',
+      'status': 'planned',
+      'created_at': '2026-08-01',
+      'updated_at': '2026-08-01',
+      'legs': [
+        {
+          'key': 'Panama City',
+          'label': 'Panama City',
+          'hub': 'Panama City',
+          'start_date': '2026-09-15',
+          'end_date': '2026-09-20',
+          'date_source': 'stay',
+          'first_position': 0,
+          'last_position': 5,
+          'lat': 8.98,
+          'lng': -79.52,
+        },
+        {
+          'key': 'Other places',
+          'label': 'Other places',
+          'first_position': 6,
+          'last_position': 6,
+        },
+      ],
+    });
+
+    final legs = trip.legs!;
+    expect(legs, hasLength(2));
+    expect(legs[0].key, 'Panama City');
+    expect(legs[0].startDate, '2026-09-15');
+    expect(legs[0].endDate, '2026-09-20');
+    expect(legs[0].dateSource, 'stay');
+    expect(legs[0].zeroNight, isNull);
+    expect(legs[1].hub, isNull);
+    expect(legs[1].startDate, isNull);
+    expect(legs[1].firstPosition, 6);
+  });
+
+  test('a payload without legs parses to null (fallback path)', () {
+    final trip = Trip.fromJson({
+      'id': 't1',
+      'title': 'Fixture',
+      'status': 'planned',
+      'created_at': '2026-08-01',
+      'updated_at': '2026-08-01',
+    });
+    expect(trip.legs, isNull);
+  });
+
+  test('TripLegDto round-trips through toJson', () {
+    const leg = TripLegDto(
+      key: 'Athens#2',
+      label: 'Athens',
+      hub: 'Athens',
+      startDate: '2026-06-05',
+      endDate: '2026-06-06',
+      dateSource: 'items',
+      zeroNight: true,
+      firstPosition: 4,
+      lastPosition: 6,
+    );
+    final back = TripLegDto.fromJson(leg.toJson());
+    expect(back.key, 'Athens#2');
+    expect(back.zeroNight, isTrue);
+    expect(back.lat, isNull);
+  });
+}


### PR DESCRIPTION
## Summary
- Stage 1a of `specs/server-leg-dates`: full trip views (GET `/trips/{id}` + the shared view) now carry a `legs` array serialized from `computeTripLegs` — the one derivation landed in #298. List/stub responses deliberately never carry it (partial data would yield anchor-less legs, and the client falls back cleanly when the field is absent). Purely additive; old clients ignore it; **nothing consumes it yet** (stage 2a repoints the client after the parity soak).
- `TripLegResponse`: `key` (revisits `City#2`), `label`/`hub`, YYYY-MM-DD rendered span, `date_source` (stay/items/auto), `zero_night`, item-position bounds, representative coordinate.
- Dart: new `TripLegDto` model + `Trip.legs` (build_runner regen — only `trip.g.dart` + the new `.g.dart` changed, no drift).

## Testing
- Go: new integration tests pin the payload on the twin-fixture trip — Panama City stay-anchored by address, LA stay-anchored by NAME (the reconciled fallback rule), and the list-response exclusion; shared-view coverage included. Full suite green against the lane DB (39.9s).
- Flutter: new model tests (payload parse shape, null-legs fallback, round-trip); full suite green; analyze = 3 pre-existing infos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)