### PR TITLE
refactor(api): legsRenderSummary runs over computeTripLegs

### DIFF
--- a/src/packages/api/plan_leg_dates.go
+++ b/src/packages/api/plan_leg_dates.go
@@ -277,22 +277,22 @@ func legsSummary(runs []legRun, stays []store.Accommodation, tripStart time.Time
 	return strings.Join(parts, ", ")
 }
 
-// legsRenderSummary lists every dated leg with the calendar span the trip
-// page RENDERS for it (visibleLegDisplayRange: first-leg anchor, arrival
-// rule, zero-night squeeze collapse) — one "- City: X to Y" line per leg.
-// This is the model-facing render truth: it goes into get_trip and into
-// update_itinerary_section's result so a wrong day-number mental model is
-// falsifiable from the tool output instead of surviving successful writes.
-// Empty when no run is dated.
-func legsRenderSummary(items []store.ItineraryItem, stays []store.Accommodation, tripStart time.Time) string {
-	runs := legRuns(items)
+// legsRenderSummary lists every spanned leg with the calendar range the trip
+// page RENDERS for it — one "- City: X to Y" line. This is the model-facing
+// render truth: it goes into get_trip and into update_itinerary_section's
+// result so a wrong day-number mental model is falsifiable from tool output
+// instead of surviving successful writes. Since stage 1b
+// (specs/server-leg-dates) it runs over computeTripLegs — the same
+// computation the `legs` payload serializes — so what the model reads is
+// exactly what the page shows. Spanless legs are skipped; hubless legs with
+// spans print under the "Other places" label. Empty when nothing is spanned.
+func legsRenderSummary(trip store.Trip, items []store.ItineraryItem, stays []store.Accommodation) string {
 	var b strings.Builder
-	for i, r := range runs {
-		if r.minDay < 1 || r.hub == "" {
+	for _, leg := range computeTripLegs(trip, items, stays) {
+		if leg.Start == nil || leg.End == nil {
 			continue
 		}
-		s, e := visibleLegDisplayRange(runs, i, stays, tripStart)
-		fmt.Fprintf(&b, "- %s: %s\n", r.hub, legRangeText(s, e))
+		fmt.Fprintf(&b, "- %s: %s\n", leg.Label, legRangeText(*leg.Start, *leg.End))
 	}
 	return b.String()
 }

--- a/src/packages/api/plan_leg_dates_test.go
+++ b/src/packages/api/plan_leg_dates_test.go
@@ -136,20 +136,19 @@ func TestLegRunsAndMatching(t *testing.T) {
 // arrival rule, and the zero-night collapse for an inverted leg all flow
 // through, one line per dated leg.
 func TestLegsRenderSummary(t *testing.T) {
-	tripStart := civilDate("2026-08-24")
 	items := []store.ItineraryItem{
 		legItem(0, "Prague", "", 4),  // first leg, anchored to trip start
 		legItem(1, "Kraków", "", 10), // Sep 2
 		legItem(2, "Berlin", "", 9),  // Sep 1 — INVERTED, collapses to Sep 2
 	}
-	got := legsRenderSummary(items, nil, tripStart)
+	got := legsRenderSummary(rlTrip("2026-08-24", ""), items, nil)
 	want := "- Prague: 2026-08-24 to 2026-08-27\n" +
 		"- Kraków: 2026-08-27 to 2026-09-02\n" +
 		"- Berlin: 2026-09-02 to 2026-09-02\n"
 	if got != want {
 		t.Fatalf("legsRenderSummary =\n%s\nwant\n%s", got, want)
 	}
-	if legsRenderSummary(nil, nil, tripStart) != "" {
+	if legsRenderSummary(rlTrip("2026-08-24", ""), nil, nil) != "" {
 		t.Fatal("empty itinerary should yield an empty summary")
 	}
 }

--- a/src/packages/api/plan_tool_registry.go
+++ b/src/packages/api/plan_tool_registry.go
@@ -729,7 +729,7 @@ func sectionLegsRender(s *planSession) string {
 	if err != nil {
 		return ""
 	}
-	return legsRenderSummary(items, stays, trip.StartDate.Time)
+	return legsRenderSummary(trip, items, stays)
 }
 
 func runSavePreferencesTool(s *planSession, input json.RawMessage) (string, bool) {

--- a/src/packages/api/plan_tools_extra.go
+++ b/src/packages/api/plan_tools_extra.go
@@ -710,7 +710,7 @@ func runGetTripTool(ctx context.Context, authed bool, uid uuid.UUID, boundTripID
 	// city's last item day is its DEPARTURE), so without this the model
 	// cannot falsify a wrong day→date mental model from anything it reads.
 	if staysErr == nil && trip.StartDate.Valid {
-		if legs := legsRenderSummary(items, stays, trip.StartDate.Time); legs != "" {
+		if legs := legsRenderSummary(trip, items, stays); legs != "" {
 			b.WriteString("City legs as rendered on the trip page (arrival to departure):\n" + legs)
 		}
 	}


### PR DESCRIPTION
## Summary
- Stage 1b of `specs/server-leg-dates`: `legsRenderSummary` (feeding get_trip's "City legs" section and every `update_itinerary_section` result) now runs over `computeTripLegs` — the same computation PR #299 serializes into the `legs` payload. What the model reads, what the payload carries, and what the page renders are now one definition.
- Signature change `legsRenderSummary(trip, items, stays)` (the module needs the trip's end date for auto-allocation); both call sites updated.
- **Golden diff review** (the gate for this lane): dated fixtures are value-identical — `TestLegsRenderSummary` and every get_trip/section-result pin passed without edits. Two documented improvements: hubless legs with spans print under "Other places" (previously skipped), and undated legs on a date-bounded trip now show their auto-allocated span exactly as the page renders it.
- `set_leg_dates`' internal move semantics (legRuns/visibleLegDisplayRange) deliberately untouched until stage 5a per the spec.

## Testing
- Targeted suites (legsRenderSummary golden, get_trip, section results, all 15 set_leg_dates tests) green without assertion edits; full Go suite green against the lane DB (63s); gofmt/vet clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)