### PR TITLE
feat(flutter): trips list orders by travel date, past trips collapse

### DIFF
--- a/src/packages/flutter-app/lib/l10n/app_en.arb
+++ b/src/packages/flutter-app/lib/l10n/app_en.arb
@@ -1037,6 +1037,15 @@
   "tripsListEmptyMessage": "Chat with the AI agent to create your first trip.",
   "tripsListPlanTrip": "Plan a trip",
   "tripsListSharedWithYou": "Shared with you",
+  "tripsListPastTrips": "Past trips",
+  "tripsListPastTripsCount": "{count, plural, one{1 trip} other{{count} trips}}",
+  "@tripsListPastTripsCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "tripsListCreated": "Created {date}",
   "@tripsListCreated": {
     "placeholders": {

--- a/src/packages/flutter-app/lib/l10n/app_es.arb
+++ b/src/packages/flutter-app/lib/l10n/app_es.arb
@@ -470,6 +470,8 @@
   "tripsListEmptyMessage": "Habla con el agente de IA para crear tu primer viaje.",
   "tripsListPlanTrip": "Planear un viaje",
   "tripsListSharedWithYou": "Compartidos contigo",
+  "tripsListPastTrips": "Viajes pasados",
+  "tripsListPastTripsCount": "{count, plural, one{1 viaje} other{{count} viajes}}",
   "tripsListCreated": "Creado el {date}",
   "tripsListPlannedWith": "Planeado con {name}",
   "tripsListSharedBy": "Compartido por {name}",

--- a/src/packages/flutter-app/lib/l10n/app_localizations.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations.dart
@@ -2918,6 +2918,18 @@ abstract class AppLocalizations {
   /// **'Shared with you'**
   String get tripsListSharedWithYou;
 
+  /// No description provided for @tripsListPastTrips.
+  ///
+  /// In en, this message translates to:
+  /// **'Past trips'**
+  String get tripsListPastTrips;
+
+  /// No description provided for @tripsListPastTripsCount.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, one{1 trip} other{{count} trips}}'**
+  String tripsListPastTripsCount(int count);
+
   /// No description provided for @tripsListCreated.
   ///
   /// In en, this message translates to:

--- a/src/packages/flutter-app/lib/l10n/app_localizations_en.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations_en.dart
@@ -1605,6 +1605,20 @@ class AppLocalizationsEn extends AppLocalizations {
   String get tripsListSharedWithYou => 'Shared with you';
 
   @override
+  String get tripsListPastTrips => 'Past trips';
+
+  @override
+  String tripsListPastTripsCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count trips',
+      one: '1 trip',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String tripsListCreated(String date) {
     return 'Created $date';
   }

--- a/src/packages/flutter-app/lib/l10n/app_localizations_es.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations_es.dart
@@ -1618,6 +1618,20 @@ class AppLocalizationsEs extends AppLocalizations {
   String get tripsListSharedWithYou => 'Compartidos contigo';
 
   @override
+  String get tripsListPastTrips => 'Viajes pasados';
+
+  @override
+  String tripsListPastTripsCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count viajes',
+      one: '1 viaje',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String tripsListCreated(String date) {
     return 'Creado el $date';
   }

--- a/src/packages/flutter-app/lib/screens/trips_list_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trips_list_screen.dart
@@ -5,7 +5,9 @@ import '../navigation/app_nav.dart';
 import '../navigation/app_routes.dart';
 import '../theme/spacing.dart';
 import '../utils/trip_format.dart';
+import '../utils/trip_list_order.dart';
 import '../widgets/account_menu.dart';
+import '../widgets/collapsible_section.dart';
 import '../widgets/continue_chats_section.dart';
 import '../widgets/empty_state.dart';
 import '../widgets/gradient_app_bar.dart';
@@ -32,6 +34,11 @@ class TripsListScreen extends ConsumerStatefulWidget {
 }
 
 class _TripsListScreenState extends ConsumerState<TripsListScreen> {
+  /// "Past trips" starts collapsed; kept in screen state (the
+  /// [CollapsibleSection] contract) so it survives silent refreshes and the
+  /// offline-banner reparent.
+  bool _pastExpanded = false;
+
   @override
   void initState() {
     super.initState();
@@ -102,6 +109,18 @@ class _TripsListScreenState extends ConsumerState<TripsListScreen> {
     } else {
       final isAdmin = ref.watch(authProvider).user?.isAdmin ?? false;
       final liveTrip = ref.watch(liveTripProvider);
+      // Server order is newest-created-first; the list shows travel-date
+      // order instead — next trip on top, finished trips tucked into a
+      // collapsed group (utils/trip_list_order.dart). The live trip is
+      // exempt from the past group so its Live pill never hides in there.
+      final now = DateTime.now();
+      final groups =
+          partitionTripsForList(state.trips, now, liveTripId: liveTrip?.id);
+      // Same ordering for shared-with-me, but no collapse: the section is
+      // short, and a header-inside-a-header would read as clutter. Past
+      // shared trips simply sort last.
+      final sharedGroups = partitionTripsForList(shared, now);
+      final sharedOrdered = [...sharedGroups.upcoming, ...sharedGroups.past];
       body = RefreshIndicator(
         onRefresh: () async {
           ref.invalidate(sharedWithMeProvider);
@@ -147,19 +166,45 @@ class _TripsListScreenState extends ConsumerState<TripsListScreen> {
                           AppSpacing.xs, 0, 0, AppSpacing.sm),
                       child: SectionHeader(title: l10n.tripsListTitle),
                     ),
-                  for (final t in state.trips)
+                  for (final t in groups.upcoming)
                     _TripCard(trip: t, isAdmin: isAdmin),
+                  if (groups.past.isNotEmpty)
+                    Padding(
+                      padding: const EdgeInsets.only(top: AppSpacing.sm),
+                      child: CollapsibleSection(
+                        title: l10n.tripsListPastTrips,
+                        icon: Icons.history,
+                        pill: StatusPill.custom(
+                          label: l10n
+                              .tripsListPastTripsCount(groups.past.length),
+                          background:
+                              theme.colorScheme.surfaceContainerHighest,
+                          foreground: theme.colorScheme.onSurfaceVariant,
+                        ),
+                        expanded: _pastExpanded,
+                        onToggle: () =>
+                            setState(() => _pastExpanded = !_pastExpanded),
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.stretch,
+                          children: [
+                            for (final t in groups.past)
+                              _TripCard(trip: t, isAdmin: isAdmin),
+                          ],
+                        ),
+                      ),
+                    ),
                   // Trips others invited this user to co-plan. Kept as a
                   // separate section: "mine" vs "shared with me" is the
                   // mental model, and the card shows the owner instead of
                   // admin version chrome.
-                  if (shared.isNotEmpty) ...[
+                  if (sharedOrdered.isNotEmpty) ...[
                     Padding(
                       padding: const EdgeInsets.fromLTRB(
                           AppSpacing.xs, AppSpacing.lg, 0, AppSpacing.sm),
                       child: SectionHeader(title: l10n.tripsListSharedWithYou),
                     ),
-                    for (final t in shared) _TripCard(trip: t, isAdmin: false),
+                    for (final t in sharedOrdered)
+                      _TripCard(trip: t, isAdmin: false),
                   ],
                 ],
               ),

--- a/src/packages/flutter-app/lib/utils/trip_days.dart
+++ b/src/packages/flutter-app/lib/utils/trip_days.dart
@@ -23,6 +23,25 @@ int? tripDayOn(String? startDate, String? endDate, DateTime when) {
   return day;
 }
 
+/// Whether the trip is entirely behind [today]'s device-local calendar date:
+/// its last day — [endDate], falling back to [startDate] for end-less trips —
+/// is strictly before today. A trip ending today is not past; trips with no
+/// parseable date at all are never past.
+///
+/// Deliberately diverges from [tripDayOn]'s "no end date means the trip never
+/// ends once started" rule (which serves the live-trip spotlight): for list
+/// grouping, a start-only trip whose start has gone by counts as past —
+/// otherwise stale drafts would sit among upcoming trips forever. Callers that
+/// also surface a live trip should exempt it rather than let the two rules
+/// disagree about the same card.
+bool tripIsPast(String? startDate, String? endDate, DateTime today) {
+  final last =
+      DateTime.tryParse(endDate ?? '') ?? DateTime.tryParse(startDate ?? '');
+  if (last == null) return false;
+  return DateTime(last.year, last.month, last.day)
+      .isBefore(DateTime(today.year, today.month, today.day));
+}
+
 /// How many days a trip spans for day chips / pickers: the later of the
 /// highest tagged day in [itemDays] and the [startDate]–[endDate] span (so an
 /// empty dated trip still offers its real days, and an item tagged beyond the

--- a/src/packages/flutter-app/lib/utils/trip_list_order.dart
+++ b/src/packages/flutter-app/lib/utils/trip_list_order.dart
@@ -1,0 +1,63 @@
+// Presentation order for the trips list. The server returns trips
+// newest-created-first (its one job is "latest version per chat lineage");
+// ordering by travel dates and tucking finished trips away is a display
+// concern, so it lives client-side — no SQL change, and the offline cache
+// keeps round-tripping the server order verbatim.
+
+import '../models/trip.dart';
+import 'trip_days.dart';
+
+/// Splits [trips] into the main list and the "Past trips" group, each ordered
+/// for display:
+///
+/// - `upcoming`: dated, not-past trips soonest first (the next trip you'll
+///   actually take on top), then undated trips newest-created first — dated
+///   plans are actionable, undated drafts wait below them.
+/// - `past`: most recently finished first.
+///
+/// The trip identified by [liveTripId] (the Happening-Now spotlight) always
+/// stays in the main list, so a Live-pill card can never end up filed under
+/// past — [tripIsPast] and the live-trip rules disagree about end-less trips.
+({List<Trip> upcoming, List<Trip> past}) partitionTripsForList(
+  List<Trip> trips,
+  DateTime today, {
+  String? liveTripId,
+}) {
+  final dated = <Trip>[];
+  final undated = <Trip>[];
+  final past = <Trip>[];
+  for (final t in trips) {
+    if (t.id != liveTripId && tripIsPast(t.startDate, t.endDate, today)) {
+      past.add(t);
+    } else if (_firstDay(t) != null) {
+      dated.add(t);
+    } else {
+      undated.add(t);
+    }
+  }
+  // List.sort is unstable, so every comparator ends in the createdAt
+  // tie-break to keep equal-date trips in a deterministic newest-first order.
+  // createdAt is an ISO-8601 string off the wire; lexicographic order is
+  // chronological order for it.
+  dated.sort((a, b) {
+    final c = _firstDay(a)!.compareTo(_firstDay(b)!);
+    return c != 0 ? c : b.createdAt.compareTo(a.createdAt);
+  });
+  undated.sort((a, b) => b.createdAt.compareTo(a.createdAt));
+  past.sort((a, b) {
+    final c = _lastDay(b)!.compareTo(_lastDay(a)!);
+    return c != 0 ? c : b.createdAt.compareTo(a.createdAt);
+  });
+  return (upcoming: [...dated, ...undated], past: past);
+}
+
+/// Sort key for upcoming trips; null means the trip is undated. Falls back to
+/// [Trip.endDate] so an end-only trip still sorts by date instead of dropping
+/// into the drafts bucket.
+DateTime? _firstDay(Trip t) =>
+    DateTime.tryParse(t.startDate ?? '') ?? DateTime.tryParse(t.endDate ?? '');
+
+/// Sort key for past trips: the last day, mirroring [tripIsPast]. Non-null for
+/// every trip [tripIsPast] classified as past.
+DateTime? _lastDay(Trip t) =>
+    DateTime.tryParse(t.endDate ?? '') ?? DateTime.tryParse(t.startDate ?? '');

--- a/src/packages/flutter-app/test/trip_list_order_test.dart
+++ b/src/packages/flutter-app/test/trip_list_order_test.dart
@@ -1,0 +1,127 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:travel_route_planner/models/trip.dart';
+import 'package:travel_route_planner/utils/trip_days.dart';
+import 'package:travel_route_planner/utils/trip_list_order.dart';
+
+/// Trips-list display order (utils/trip_list_order.dart): upcoming soonest
+/// first, undated drafts below dated plans, past trips grouped separately and
+/// most recently finished first.
+
+Trip _trip(
+  String id, {
+  String? start,
+  String? end,
+  String created = '2026-06-01T00:00:00Z',
+}) =>
+    Trip(
+      id: id,
+      title: id,
+      status: 'draft',
+      startDate: start,
+      endDate: end,
+      createdAt: created,
+      updatedAt: created,
+    );
+
+// A fixed "today" keeps every case deterministic.
+final _today = DateTime(2026, 8, 6);
+
+void main() {
+  group('tripIsPast', () {
+    test('ended yesterday is past; ending today is not', () {
+      expect(tripIsPast('2026-08-01', '2026-08-05', _today), isTrue);
+      expect(tripIsPast('2026-08-01', '2026-08-06', _today), isFalse);
+    });
+
+    test('start-only trips fall back to the start date', () {
+      expect(tripIsPast('2026-08-05', null, _today), isTrue);
+      expect(tripIsPast('2026-08-06', null, _today), isFalse);
+    });
+
+    test('undated or unparseable trips are never past', () {
+      expect(tripIsPast(null, null, _today), isFalse);
+      expect(tripIsPast('not-a-date', 'also-no', _today), isFalse);
+    });
+  });
+
+  group('partitionTripsForList', () {
+    test('upcoming sorts soonest first regardless of server order', () {
+      final r = partitionTripsForList(
+        [
+          _trip('far', start: '2026-12-01', end: '2026-12-10'),
+          _trip('soon', start: '2026-08-24', end: '2026-09-27'),
+          _trip('next', start: '2026-08-10', end: '2026-08-12'),
+        ],
+        _today,
+      );
+      expect(r.upcoming.map((t) => t.id), ['next', 'soon', 'far']);
+      expect(r.past, isEmpty);
+    });
+
+    test('undated trips sit below dated ones, newest-created first', () {
+      final r = partitionTripsForList(
+        [
+          _trip('draft-old', created: '2026-05-01T00:00:00Z'),
+          _trip('dated', start: '2026-12-01', end: '2026-12-05'),
+          _trip('draft-new', created: '2026-07-01T00:00:00Z'),
+        ],
+        _today,
+      );
+      expect(r.upcoming.map((t) => t.id), ['dated', 'draft-new', 'draft-old']);
+    });
+
+    test('past trips split off, most recently finished first', () {
+      final r = partitionTripsForList(
+        [
+          _trip('long-ago', start: '2026-01-01', end: '2026-01-05'),
+          _trip('upcoming', start: '2026-09-01', end: '2026-09-05'),
+          _trip('just-ended', start: '2026-07-21', end: '2026-07-22'),
+        ],
+        _today,
+      );
+      expect(r.upcoming.map((t) => t.id), ['upcoming']);
+      expect(r.past.map((t) => t.id), ['just-ended', 'long-ago']);
+    });
+
+    test('the live trip is exempt from the past group', () {
+      // Started yesterday, no end date: tripIsPast files it under past, but
+      // the Happening-Now spotlight considers it live — live wins.
+      final r = partitionTripsForList(
+        [_trip('live', start: '2026-08-05')],
+        _today,
+        liveTripId: 'live',
+      );
+      expect(r.upcoming.map((t) => t.id), ['live']);
+      expect(r.past, isEmpty);
+    });
+
+    test('an end-only trip still sorts by date instead of joining drafts', () {
+      final r = partitionTripsForList(
+        [
+          _trip('undated'),
+          _trip('end-only', end: '2026-08-20'),
+        ],
+        _today,
+      );
+      expect(r.upcoming.map((t) => t.id), ['end-only', 'undated']);
+    });
+
+    test('equal dates tie-break newest-created first, deterministically', () {
+      final r = partitionTripsForList(
+        [
+          _trip('older',
+              start: '2026-09-01',
+              end: '2026-09-05',
+              created: '2026-05-01T00:00:00Z'),
+          _trip('newer',
+              start: '2026-09-01',
+              end: '2026-09-05',
+              created: '2026-07-01T00:00:00Z'),
+        ],
+        _today,
+      );
+      expect(r.upcoming.map((t) => t.id), ['newer', 'older']);
+    });
+  });
+}

--- a/src/packages/flutter-app/test/trips_list_past_section_test.dart
+++ b/src/packages/flutter-app/test/trips_list_past_section_test.dart
@@ -1,0 +1,127 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:travel_route_planner/models/trip.dart';
+import 'package:travel_route_planner/providers/resumable_chats_provider.dart';
+import 'package:travel_route_planner/providers/trip_cache_provider.dart';
+import 'package:travel_route_planner/providers/trips_provider.dart';
+import 'package:travel_route_planner/screens/trips_list_screen.dart';
+import 'package:travel_route_planner/services/api_client.dart';
+import 'package:travel_route_planner/services/trip_cache.dart';
+import 'package:travel_route_planner/services/trips_api_service.dart';
+import 'package:travel_route_planner/widgets/collapsible_section.dart';
+
+import 'support/l10n_test_app.dart';
+
+/// The trips list orders by travel date and folds finished trips into a
+/// collapsed "Past trips" row (utils/trip_list_order.dart): upcoming cards on
+/// top soonest-first, past cards hidden until the row is expanded.
+class _FixedTripsApiService extends TripsApiService {
+  final List<Trip> trips;
+  _FixedTripsApiService(this.trips)
+      : super(ApiClient(baseUrl: 'http://test'));
+
+  @override
+  Future<List<Trip>> listTrips() => Future.value(trips);
+}
+
+String _iso(DateTime d) => '${d.year.toString().padLeft(4, '0')}-'
+    '${d.month.toString().padLeft(2, '0')}-'
+    '${d.day.toString().padLeft(2, '0')}';
+
+String _rel(int days) => _iso(DateTime.now().add(Duration(days: days)));
+
+Trip _trip(String id, String title, {String? start, String? end}) => Trip(
+      id: id,
+      title: title,
+      status: 'planned',
+      startDate: start,
+      endDate: end,
+      createdAt: '2026-06-01',
+      updatedAt: '2026-06-01',
+    );
+
+Future<void> _pumpList(WidgetTester tester, List<Trip> trips) {
+  return tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        tripsApiServiceProvider.overrideWithValue(_FixedTripsApiService(trips)),
+        tripCacheProvider.overrideWithValue(TripCache('u1')),
+        resumableChatsProvider.overrideWith((ref) async => const []),
+      ],
+      child: MaterialApp(
+          localizationsDelegates: testLocalizationsDelegates,
+          home: const TripsListScreen()),
+    ),
+  );
+}
+
+void main() {
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  testWidgets('past trip hides behind a collapsed row and expands on tap',
+      (WidgetTester tester) async {
+    await _pumpList(tester, [
+      // Server order: newest-created first, i.e. the past trip on top.
+      _trip('past', 'Guadalajara', start: _rel(-16), end: _rel(-15)),
+      _trip('future', 'Prague Trip', start: _rel(18), end: _rel(52)),
+    ]);
+    await tester.pumpAndSettle();
+
+    // Collapsed: the row and its count pill show, the past card doesn't.
+    expect(find.text('Past trips'), findsOneWidget);
+    expect(find.text('1 trip'), findsOneWidget);
+    expect(find.text('Prague Trip'), findsOneWidget);
+    expect(find.text('Guadalajara'), findsNothing);
+
+    // The upcoming card renders above the collapsed row.
+    expect(
+      tester.getTopLeft(find.text('Prague Trip')).dy,
+      lessThan(tester.getTopLeft(find.text('Past trips')).dy),
+    );
+
+    await tester.tap(find.text('Past trips'));
+    await tester.pumpAndSettle();
+    expect(find.text('Guadalajara'), findsOneWidget);
+
+    // Toggling closed hides it again.
+    await tester.tap(find.text('Past trips'));
+    await tester.pumpAndSettle();
+    expect(find.text('Guadalajara'), findsNothing);
+  });
+
+  testWidgets('upcoming trips reorder soonest-first, ignoring server order',
+      (WidgetTester tester) async {
+    await _pumpList(tester, [
+      _trip('far', 'December Trip', start: _rel(120), end: _rel(125)),
+      _trip('near', 'Next Week Trip', start: _rel(7), end: _rel(9)),
+    ]);
+    await tester.pumpAndSettle();
+
+    expect(
+      tester.getTopLeft(find.text('Next Week Trip')).dy,
+      lessThan(tester.getTopLeft(find.text('December Trip')).dy),
+    );
+    // Nothing is past, so no collapsed row appears.
+    expect(find.byType(CollapsibleSection), findsNothing);
+  });
+
+  testWidgets('all-past account still reaches its trips', (tester) async {
+    await _pumpList(tester, [
+      _trip('past', 'Old Trip', start: _rel(-9), end: _rel(-2)),
+    ]);
+    await tester.pumpAndSettle();
+
+    // Not the empty state: the collapsed row is the whole list.
+    expect(find.text('No trips yet'), findsNothing);
+    expect(find.text('Past trips'), findsOneWidget);
+
+    await tester.tap(find.text('Past trips'));
+    await tester.pumpAndSettle();
+    expect(find.text('Old Trip'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- My Trips previously rendered the server's `created_at DESC` order, so a recently created past trip (Guadalajara, Jul 21–22) sat above an upcoming one (Prague & Kraków, Aug 24–Sep 27). Ordering is now travel-date aware, done client-side — no SQL/sqlc change, shared-with-me query untouched.
- **Upcoming trips sort soonest-first** (the next trip you'll take is on top); **undated drafts** follow below them, newest-created first.
- **Past trips fold into a collapsed "Past trips (N)" row** (`CollapsibleSection`, the trip-detail cluster widget) at the bottom, most recently finished first, with a count pill.
- New `tripIsPast` helper in `utils/trip_days.dart` (past ⇔ `endDate ?? startDate` strictly before today; ends-today is not past) and a pure `partitionTripsForList` in new `utils/trip_list_order.dart`. The Happening-Now trip is exempt from the past group so a Live-pill card can never hide in there.
- "Shared with you" gets the same comparator (past last) without the collapse.
- New l10n keys `tripsListPastTrips` / `tripsListPastTripsCount` (en + es), localizations regenerated.

## Testing
- `flutter analyze` clean (3 pre-existing infos in `route_response.dart` only).
- Full `flutter test`: 708 tests pass, including new `test/trip_list_order_test.dart` (9 cases: soonest-first, undated placement, past classification boundaries, live-trip exemption, deterministic tie-breaks) and `test/trips_list_past_section_test.dart` (collapse/expand/count-pill, reorder, all-past account).
- Manual verification on the lane dev stack (`:3002`) with seeded data: upcoming order Prague → Lisbon, undated "Someday Japan" below with Created fallback, "Past trips (2 trips)" collapsed by default, expanding shows Guadalajara above Old Athens Trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)