### PR TITLE
feat: legs parity monitor — payload vs local derivation on every trip load

### DIFF
--- a/src/packages/api/analytics.go
+++ b/src/packages/api/analytics.go
@@ -28,6 +28,11 @@ var clientEventTypes = map[string]bool{
 	// A place added to a trip from a browse surface (local rec, event, guide
 	// pin) — specs/add-to-itinerary. Distinguished by metadata "source".
 	"itinerary_item_added": true,
+	// Transition telemetry (specs/server-leg-dates): the client compared the
+	// server `legs` payload against its local derivation on a trip load and
+	// they DISAGREED. Expected volume: zero — any row is a derivation-parity
+	// bug and blocks the stage-2a client repoint. Remove at stage 6a.
+	"legs_parity_mismatch": true,
 }
 
 // anonymousClientEventTypes is the tighter whitelist for UNAUTHENTICATED

--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -19,6 +19,7 @@ import '../models/location_timing.dart';
 import '../models/route_request.dart';
 import '../models/trip_segment.dart';
 import '../providers/accommodations_provider.dart';
+import '../providers/analytics_provider.dart';
 import '../providers/transport_provider.dart';
 import '../providers/trips_provider.dart';
 import '../providers/recent_trip_provider.dart';
@@ -44,6 +45,7 @@ import '../services/trip_cache.dart';
 import '../theme/app_colors.dart';
 import '../theme/spacing.dart';
 import '../utils/calendar_links.dart';
+import '../utils/leg_parity.dart';
 import '../utils/leg_ranges.dart';
 import '../utils/money_format.dart';
 import '../utils/share_link.dart';
@@ -361,6 +363,15 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
       final trip =
           await ref.read(tripsApiServiceProvider).getTrip(widget.tripId);
       if (mounted) {
+        // Transition telemetry (specs/server-leg-dates): daily dogfooding is
+        // the parity monitor for the server legs payload vs the local
+        // derivation this screen still renders. Zero expected volume;
+        // fire-and-forget; deleted with the fallback at stage 6a.
+        final parityDiffs = legParityMismatches(trip);
+        if (parityDiffs.isNotEmpty) {
+          unawaited(ref.read(analyticsApiServiceProvider).recordLegsParityMismatch(
+              tripId: trip.id, details: parityDiffs));
+        }
         // Write-through for offline viewing; fire-and-forget (never throws)
         // so the online path is unaffected.
         unawaited(ref.read(tripCacheProvider).writeTrip(trip));

--- a/src/packages/flutter-app/lib/services/analytics_api_service.dart
+++ b/src/packages/flutter-app/lib/services/analytics_api_service.dart
@@ -60,6 +60,25 @@ class AnalyticsApiService {
   /// Call sites guard this to once per app session.
   Future<void> recordLandingViewed() => _record('landing_viewed');
 
+  /// Transition telemetry (specs/server-leg-dates): the server `legs`
+  /// payload and the local derivation disagreed on a trip load. Expected
+  /// volume: zero — any event is a parity bug that blocks the client
+  /// repoint. Removed at stage 6a. [details] is truncated defensively;
+  /// authed-only like every trip-scoped event.
+  Future<void> recordLegsParityMismatch({
+    required String tripId,
+    required List<String> details,
+  }) {
+    final joined = details.join('; ');
+    return _record(
+      'legs_parity_mismatch',
+      tripId: tripId,
+      metadata: {
+        'details': joined.length > 400 ? joined.substring(0, 400) : joined,
+      },
+    );
+  }
+
   Future<void> _record(
     String eventType, {
     String? tripId,

--- a/src/packages/flutter-app/lib/utils/leg_parity.dart
+++ b/src/packages/flutter-app/lib/utils/leg_parity.dart
@@ -1,0 +1,44 @@
+// Transition telemetry for specs/server-leg-dates: compares the server
+// `legs` payload against the local derivation the screen still renders, so
+// Brian's daily prod dogfooding IS the parity monitor gating the stage-2a
+// client repoint. Deleted with the fallback at stage 6a.
+//
+// Pure: no widgets, no providers. Callers emit the analytics event.
+
+import 'package:intl/intl.dart';
+
+import '../models/trip.dart';
+import 'leg_ranges.dart';
+
+/// Human-readable payload-vs-local differences for [trip]; empty = parity.
+/// Empty when the payload carries no legs (nothing to compare). Compares
+/// label and rendered span only — coordinates and positions are not part of
+/// the dates contract.
+List<String> legParityMismatches(Trip trip) {
+  final payload = trip.legs;
+  if (payload == null) return const [];
+  final local = visibleLegRanges(trip);
+
+  String? fmt(DateTime? d) =>
+      d == null ? null : DateFormat('yyyy-MM-dd').format(d);
+
+  final out = <String>[];
+  if (payload.length != local.length) {
+    out.add('leg count: payload ${payload.length} vs local ${local.length}');
+  }
+  final n = payload.length < local.length ? payload.length : local.length;
+  for (var i = 0; i < n; i++) {
+    final p = payload[i];
+    final l = local[i];
+    if (p.label != l.label) {
+      out.add('[$i] label: ${p.label} vs ${l.label}');
+    }
+    if (p.startDate != fmt(l.start)) {
+      out.add('[$i] ${p.label} start: ${p.startDate} vs ${fmt(l.start)}');
+    }
+    if (p.endDate != fmt(l.end)) {
+      out.add('[$i] ${p.label} end: ${p.endDate} vs ${fmt(l.end)}');
+    }
+  }
+  return out;
+}

--- a/src/packages/flutter-app/test/landing_polish_test.dart
+++ b/src/packages/flutter-app/test/landing_polish_test.dart
@@ -12,6 +12,11 @@ import 'support/l10n_test_app.dart';
 
 class _NoopAnalytics implements AnalyticsApiService {
   @override
+  Future<void> recordLegsParityMismatch(
+          {required String tripId, required List<String> details}) =>
+      Future.value();
+
+  @override
   ApiClient get apiClient => throw UnimplementedError();
 
   @override

--- a/src/packages/flutter-app/test/landing_screen_analytics_test.dart
+++ b/src/packages/flutter-app/test/landing_screen_analytics_test.dart
@@ -11,6 +11,11 @@ import 'support/l10n_test_app.dart';
 
 /// Counts landing-view records instead of hitting the network.
 class _CountingAnalytics implements AnalyticsApiService {
+  @override
+  Future<void> recordLegsParityMismatch(
+          {required String tripId, required List<String> details}) =>
+      Future.value();
+
   int landingViews = 0;
 
   @override
@@ -79,6 +84,11 @@ void main() {
 }
 
 class _ThrowingAnalytics implements AnalyticsApiService {
+  @override
+  Future<void> recordLegsParityMismatch(
+          {required String tripId, required List<String> details}) =>
+      Future.value();
+
   @override
   ApiClient get apiClient => throw UnimplementedError();
 

--- a/src/packages/flutter-app/test/language_menu_button_test.dart
+++ b/src/packages/flutter-app/test/language_menu_button_test.dart
@@ -52,6 +52,11 @@ class _FakeAuthService extends AuthService {
 
 class _NoopAnalytics implements AnalyticsApiService {
   @override
+  Future<void> recordLegsParityMismatch(
+          {required String tripId, required List<String> details}) =>
+      Future.value();
+
+  @override
   ApiClient get apiClient => throw UnimplementedError();
 
   @override

--- a/src/packages/flutter-app/test/leg_parity_test.dart
+++ b/src/packages/flutter-app/test/leg_parity_test.dart
@@ -1,0 +1,111 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:travel_route_planner/models/itinerary_item.dart';
+import 'package:travel_route_planner/models/trip.dart';
+import 'package:travel_route_planner/models/trip_leg_dto.dart';
+import 'package:travel_route_planner/utils/leg_parity.dart';
+
+ItineraryItem _item(int pos, String name, String city, {int? day}) =>
+    ItineraryItem(
+      id: 'i$pos',
+      position: pos,
+      name: name,
+      address: '$city address',
+      latitude: 0,
+      longitude: 0,
+      category: 'attraction',
+      day: day,
+      city: city,
+    );
+
+Trip _trip(List<ItineraryItem> items, List<TripLegDto>? legs) => Trip(
+      id: 't1',
+      title: 'Parity',
+      status: 'planned',
+      startDate: '2026-08-24',
+      endDate: '2026-08-28',
+      createdAt: '2026-08-01',
+      updatedAt: '2026-08-01',
+      items: items,
+      legs: legs,
+    );
+
+void main() {
+  final gothenburgMadrid = [
+    _item(0, 'Feskekôrka', 'Gothenburg', day: 1),
+    _item(1, 'Liseberg', 'Gothenburg', day: 3),
+    _item(2, 'Prado', 'Madrid', day: 5),
+  ];
+
+  test('a matching payload yields no mismatches', () {
+    // Values mirror the leg_ranges_test.dart visible expectations.
+    final trip = _trip(gothenburgMadrid, const [
+      TripLegDto(
+        key: 'Gothenburg',
+        label: 'Gothenburg',
+        hub: 'Gothenburg',
+        startDate: '2026-08-24',
+        endDate: '2026-08-26',
+        dateSource: 'items',
+        firstPosition: 0,
+        lastPosition: 1,
+      ),
+      TripLegDto(
+        key: 'Madrid',
+        label: 'Madrid',
+        hub: 'Madrid',
+        startDate: '2026-08-26',
+        endDate: '2026-08-28',
+        dateSource: 'items',
+        firstPosition: 2,
+        lastPosition: 2,
+      ),
+    ]);
+    expect(legParityMismatches(trip), isEmpty);
+  });
+
+  test('a divergent payload reports labeled differences', () {
+    final trip = _trip(gothenburgMadrid, const [
+      TripLegDto(
+        key: 'Gothenburg',
+        label: 'Gothenburg',
+        startDate: '2026-08-24',
+        endDate: '2026-08-25', // local says 08-26
+        firstPosition: 0,
+        lastPosition: 1,
+      ),
+      TripLegDto(
+        key: 'Madrid',
+        label: 'Madrid',
+        startDate: '2026-08-26',
+        endDate: '2026-08-28',
+        firstPosition: 2,
+        lastPosition: 2,
+      ),
+    ]);
+    final diffs = legParityMismatches(trip);
+    // Madrid's payload start (08-26) still equals the LOCAL arrival — the
+    // local derivation is self-consistent — so only the end diff reports.
+    expect(diffs, hasLength(1));
+    expect(diffs[0], contains('Gothenburg end: 2026-08-25 vs 2026-08-26'));
+  });
+
+  test('leg-count differences are reported once', () {
+    final trip = _trip(gothenburgMadrid, const [
+      TripLegDto(
+        key: 'Gothenburg',
+        label: 'Gothenburg',
+        startDate: '2026-08-24',
+        endDate: '2026-08-26',
+        firstPosition: 0,
+        lastPosition: 1,
+      ),
+    ]);
+    final diffs = legParityMismatches(trip);
+    expect(diffs.first, contains('leg count: payload 1 vs local 2'));
+  });
+
+  test('a payload without legs compares nothing', () {
+    expect(legParityMismatches(_trip(gothenburgMadrid, null)), isEmpty);
+  });
+}

--- a/src/packages/flutter-app/test/tracked_launch_test.dart
+++ b/src/packages/flutter-app/test/tracked_launch_test.dart
@@ -30,6 +30,11 @@ class _FakeUrlLauncher extends UrlLauncherPlatform {
 /// Captures booking-click records; can be told to blow up to prove that
 /// analytics failure never blocks the launch.
 class _RecordingAnalytics implements AnalyticsApiService {
+  @override
+  Future<void> recordLegsParityMismatch(
+          {required String tripId, required List<String> details}) =>
+      Future.value();
+
   final calls = <Map<String, String?>>[];
   final bool throwOnRecord;
 


### PR DESCRIPTION
## Summary
- Stage 1c of `specs/server-leg-dates` — the last wave-2 lane. On every trip-detail load, the client compares the server `legs` payload (#299) against the local `visibleLegRanges` derivation it still renders, and files a `legs_parity_mismatch` analytics event (trip_id + labeled diffs, truncated) on any disagreement. **Expected volume: zero** — any row is a derivation-parity bug that blocks the stage-2a client repoint. This makes Brian's daily dogfooding the parity monitor gating wave 3.
- Runs in **release** builds deliberately: prod is where the dogfooding happens, so a `kDebugMode` gate would have made the soak vacuous. The comparison is a cheap pure function; a network call fires only on mismatch. All of it is deleted with the fallback at stage 6a.
- Pieces: pure `utils/leg_parity.dart` (labels + rendered spans only — coords/positions aren't part of the dates contract), `AnalyticsApiService.recordLegsParityMismatch`, the server `clientEventTypes` whitelist entry (authed-only), a guarded fire-and-forget hook in the trip load path, and no-op overrides for the four analytics test fakes.

## Testing
- New `leg_parity_test.dart`: parity → empty; divergent payload → labeled diff (with the self-consistency subtlety documented — a wrong upstream end doesn't double-report the next leg's arrival); leg-count diff; null-legs no-op.
- Full Flutter suite green (703 tests; one unrelated parked-web-autofill test flaked under multi-stack load and passes in isolation and on rerun); analyze = 3 pre-existing infos. Full Go suite green against the lane DB (45s).

Soak query for the gate: `SELECT count(*) FROM analytics_events WHERE event_type='legs_parity_mismatch'` — must stay 0 for a week of dogfooding before wave 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)