### PR TITLE
docs: adopt the Zen of Python as the repo's coding principles

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,17 @@ A travel route planning platform with two packages:
 
 A single **nginx gateway** on port **3000** serves the Flutter UI and proxies `/api/v1/` to the Go API, keeping everything same-origin.
 
+## Coding Principles
+
+This repo codes by the Zen of Python — see [`docs/zen.md`](docs/zen.md) for
+the full text and the repo-specific lessons attached to it. The headline,
+paid for by the leg-dates arc: **explicit is better than implicit** — data
+semantics live in schema/types/enforced boundaries, never in conventions
+someone must remember; derived state is computed in exactly one place; a
+mutating tool's result states the post-state its consumer will observe.
+Read `docs/zen.md` before designing a data model, tool contract, or
+derivation.
+
 ## Spec-Driven Development
 
 Non-trivial features start as a spec under `specs/<feature-name>/` (copied from

--- a/docs/zen.md
+++ b/docs/zen.md
@@ -1,0 +1,71 @@
+# The Zen of Python — this repo's coding principles
+
+Adopted 2026-08-06 after the leg-dates arc (PRs #284–#295 and the
+specs/trip-dates-truth re-architecture it forced). Read this before designing
+a data model, a tool contract, or a derivation. When a principle here and a
+convenient shortcut disagree, the principle wins — or the divergence gets
+written down and justified.
+
+## The Zen of Python (Tim Peters, PEP 20)
+
+```
+Beautiful is better than ugly.
+Explicit is better than implicit.
+Simple is better than complex.
+Complex is better than complicated.
+Flat is better than nested.
+Sparse is better than dense.
+Readability counts.
+Special cases aren't special enough to break the rules.
+Although practicality beats purity.
+Errors should never pass silently.
+Unless explicitly silenced.
+In the face of ambiguity, refuse the temptation to guess.
+There should be one-- and preferably only one --obvious way to do it.
+Although that way may not be obvious at first unless you're Dutch.
+Now is better than never.
+Although never is often better than *right* now.
+If the implementation is hard to explain, it's a bad idea.
+If the implementation is easy to explain, it may be a good idea.
+Namespaces are one honking great idea -- let's do more of those!
+```
+
+## How this repo has paid for violating it
+
+These aren't hypotheticals — each was a shipped bug class here:
+
+- **Explicit is better than implicit** — the root cause of the leg-dates arc.
+  Destination dates were implicit (derived from `trips.start_date + day − 1`,
+  with "a city's last item day is its departure" existing only by convention)
+  instead of stored as their own dates. Five renderers re-derived them, tools
+  edited storage the renderer didn't read, and an AI guessed the convention
+  wrong seven "successful" writes in a row. Remediation:
+  `specs/trip-dates-truth` (explicit `item_date` storage, one explicit
+  derivation, explicit rendered ranges in every write result). Corollary
+  learned the hard way: an invariant that only holds *implicitly* — e.g. via
+  rows that can be deleted (the first-leg anchor via draft stays) — is not an
+  invariant.
+- **Errors should never pass silently** — a mutating tool whose success
+  result carried zero derived state let a wrong mental model survive
+  unlimited "successful" calls; honest no-ops and result echoes fixed it.
+- **In the face of ambiguity, refuse the temptation to guess** — day-number
+  semantics were ambiguous, so the model guessed (arrival vs departure) and
+  the guess was unfalsifiable. Contracts the model consumes must make wrong
+  guesses fail loudly.
+- **There should be one — and preferably only one — obvious way to do it** —
+  the audit found five "what is a leg" grouping rules and ~eight day→date
+  computations. One definition, N call sites.
+
+## Applying it here
+
+- New field or derived value? Ask: is the meaning explicit in the schema/type,
+  or is it a convention someone must remember? Conventions get promoted to
+  storage, types, or enforced boundaries — or documented as debt with a plan.
+- New tool/endpoint? Its result must state what changed AND the post-state the
+  consumer will observe. "Success" with no derived state is silent error-
+  passing.
+- Second implementation of anything? Stop. Either consume the first or write
+  the parity contract (twin fixtures) that keeps them honest — see
+  test/leg_ranges_test.dart ↔ trip_render_legs_test.go.
+- Practicality beats purity is allowed — but the divergence gets a comment, a
+  decision record (specs/*/plan.md), and a test pinning it.


### PR DESCRIPTION
## Summary
- New `docs/zen.md`: the full Zen of Python (PEP 20) plus the repo-specific lessons attached to the four principles the leg-dates arc violated — *explicit is better than implicit* (the root cause: destination dates derived from `start_date + day − 1` with conventions nobody wrote down, remediated by `specs/trip-dates-truth`), *errors should never pass silently* (zero-state success results), *refuse the temptation to guess* (unfalsifiable day semantics), and *one obvious way* (five grouping rules) — with concrete "applying it here" rules.
- `CLAUDE.md` gains a Coding Principles section pointing at it, so every future session reads the principles before designing a data model, tool contract, or derivation.

## Testing
- Docs-only change; CI green suffices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)