### PR TITLE
fix(flutter): collapsed trip-detail headers scroll as rows, never pin

### DIFF
--- a/docs/friction-log.md
+++ b/docs/friction-log.md
@@ -29,6 +29,21 @@ actually used > ideas that recur across ≥2 sessions**. Tag entries `[app]`
   specs/server-leg-dates lane-1a follow-up), and lens/collapse usage still
   has zero telemetry (`clientEventTypes` whitelist makes that a Go change).
 
+- **[app] BREAKAGE same-day → fixed (collapsed headers squished on
+  scroll):** first dogfood of the collapsed default found every header
+  squishing to a sliver, then a blank still-scrollable area, as the page
+  scrolled. Root cause (verified against sliver_tools source): a collapsed
+  group was a `MultiSliver(pushPinnedChildren)` whose ONLY child was its
+  `SliverPinnedHeader`; the pinned child reports `paintOrigin = overlap`,
+  and with no body sliver contributing `paintOrigin: 0`, the pinned
+  chrome's overlap gets subtracted from the group's paint AND layout
+  extents while scrollExtent stays full. Fix: pin a header only while its
+  section is expanded — collapsed cities AND collapsed days (the same
+  zero-body shape, latent since before the collapse default) render as
+  plain scrolling rows. Lesson: **a pinned sliver only earns its pin while
+  it has content to preside over — a zero-body pinned group is a geometry
+  hazard, not a no-op.**
+
 ## 2026-08-06 — trip-detail dogfooding (leg dates, round five)
 
 - **[app] BREAKAGE → fixed (specs/set-leg-dates round five):** the agent

--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -2098,17 +2098,25 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
                 _weatherChip(theme, wd, weatherReport.isHistorical);
           }
         }
-        slivers.add(MultiSliver(
-          pushPinnedChildren: true,
-          children: [
-            SliverPinnedHeader(child: header),
-            if (!collapsed) ...[
+        // A collapsed day pins nothing: pinning exists so a header stays
+        // visible while its content scrolls beneath it, and a zero-body
+        // pinned group's paintOrigin (= viewport overlap) poisons
+        // MultiSliver's minPaintOrigin — the header squishes, then
+        // vanishes, as the pinned chrome scrolls in. Same hazard as the
+        // collapsed city groups in build.
+        if (collapsed) {
+          slivers.add(SliverToBoxAdapter(child: header));
+        } else {
+          slivers.add(MultiSliver(
+            pushPinnedChildren: true,
+            children: [
+              SliverPinnedHeader(child: header),
               if (weatherChip != null) _boxSliver([weatherChip]),
               if (tonight != null) _boxSliver([tonight]),
               ..._dayTripSectionSlivers(run, theme),
             ],
-          ],
-        ));
+          ));
+        }
       } else {
         slivers.addAll(_dayTripSectionSlivers(run, theme));
       }
@@ -5036,21 +5044,40 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
                                   EdgeInsets.fromLTRB(gutter, 4, gutter, 0),
                               sliver: MultiSliver(children: [
                                 for (final (gi, group) in groups.indexed)
-                                  MultiSliver(
-                                    pushPinnedChildren: true,
-                                    children: [
-                                      SliverPinnedHeader(
-                                          child: KeyedSubtree(
-                                              // Keyed by the run, not the city:
-                                              // a revisited city renders two
-                                              // headers at once and a shared
-                                              // GlobalKey would break the build.
-                                              key: _cityHeaderKeys.putIfAbsent(
-                                                  group.key, GlobalKey.new),
-                                              child: _cityHeader(
-                                                  trip, group, theme))),
-                                      if (_expandedCities
-                                          .contains(group.key)) ...[
+                                  // A collapsed group is a plain scrolling
+                                  // row, NOT a pinned header: pinning exists
+                                  // so a header stays visible while its
+                                  // content scrolls beneath it, and a
+                                  // zero-body pinned group's paintOrigin
+                                  // (= viewport overlap) poisons
+                                  // MultiSliver's minPaintOrigin — every
+                                  // collapsed header squishes, then
+                                  // vanishes, as the pinned chrome scrolls
+                                  // in. (pushPinnedChildren: false is no
+                                  // fix either — the header would pin
+                                  // forever and overlay the next group.)
+                                  if (!_expandedCities.contains(group.key))
+                                    SliverToBoxAdapter(
+                                        child: KeyedSubtree(
+                                            // Keyed by the run, not the city:
+                                            // a revisited city renders two
+                                            // headers at once and a shared
+                                            // GlobalKey would break the build.
+                                            key: _cityHeaderKeys.putIfAbsent(
+                                                group.key, GlobalKey.new),
+                                            child: _cityHeader(
+                                                trip, group, theme)))
+                                  else
+                                    MultiSliver(
+                                      pushPinnedChildren: true,
+                                      children: [
+                                        SliverPinnedHeader(
+                                            child: KeyedSubtree(
+                                                key: _cityHeaderKeys
+                                                    .putIfAbsent(group.key,
+                                                        GlobalKey.new),
+                                                child: _cityHeader(
+                                                    trip, group, theme))),
                                         // Embedded bookings render only in the
                                         // unfiltered view: a category filter can
                                         // merge adjacent same-label runs, which
@@ -5090,8 +5117,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
                                               grouped.slots[gi],
                                               departureOnly: true)),
                                       ],
-                                    ],
-                                  ),
+                                    ),
                               ]),
                             ),
                           // Residual bookings + add actions, at the tail of

--- a/src/packages/flutter-app/test/trip_detail_collapsed_default_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_collapsed_default_test.dart
@@ -166,6 +166,87 @@ void main() {
     expect(find.text('Hidden gem'), findsOneWidget);
   });
 
+  testWidgets('collapsed headers scroll as full-height rows (no squish)',
+      (WidgetTester tester) async {
+    // Eight collapsed groups in the default 600px viewport: scrolling pins
+    // the chrome, which used to subtract its overlap from every zero-body
+    // pinned group — headers squished to slivers, then vanished, leaving
+    // phantom scroll extent.
+    final trip = Trip(
+      id: 't1',
+      title: 'Grand Tour',
+      status: 'planned',
+      startDate: '2026-06-10',
+      endDate: '2026-06-18',
+      createdAt: '2026-06-01',
+      updatedAt: '2026-06-01',
+      items: [
+        for (var k = 1; k <= 8; k++) _item(k, 'Place $k', 'Stop$k', k),
+      ],
+    );
+    await _pump(tester, trip);
+
+    final position = _position(tester);
+    position.jumpTo(position.maxScrollExtent);
+    await tester.pumpAndSettle();
+
+    // The tail headers render at full row spacing, on screen — not
+    // squished, not blank.
+    final dy7 = tester.getTopLeft(find.text('Stop7')).dy;
+    final dy8 = tester.getTopLeft(find.text('Stop8')).dy;
+    expect(dy8 - dy7, greaterThan(40));
+    expect(dy8, lessThan(600));
+  });
+
+  testWidgets(
+      'a collapsed day header scrolls at full height inside an expanded group',
+      (WidgetTester tester) async {
+    // Same zero-body pinned hazard one level down (pre-dates the collapsed
+    // city default): a collapsed day's header used to vanish once the
+    // chrome plus the pinned city header exceeded its height.
+    final trip = Trip(
+      id: 't1',
+      title: 'Getaway',
+      status: 'planned',
+      startDate: '2026-06-10',
+      endDate: '2026-06-12',
+      createdAt: '2026-06-01',
+      updatedAt: '2026-06-01',
+      items: [
+        for (var d = 1; d <= 4; d++)
+          for (var k = 0; k < 3; k++)
+            _item((d - 1) * 3 + k, 'D$d stop $k', 'Paris', d),
+      ],
+    );
+    await _pump(tester, trip);
+
+    // Sole group is seeded open; collapse every day — four consecutive
+    // zero-body day sections, the same stacked shape as collapsed cities.
+    for (final label in const [
+      'Wed, Jun 10',
+      'Thu, Jun 11',
+      'Fri, Jun 12',
+      'Sat, Jun 13'
+    ]) {
+      await tester.tap(find.text(label));
+      await tester.pumpAndSettle();
+    }
+    expect(find.text('D1 stop 0'), findsNothing);
+
+    // Deep enough that the pinned chrome and city header have scrolled in —
+    // the overlap that used to compress the zero-body day sections.
+    final position = _position(tester);
+    position.jumpTo(position.maxScrollExtent);
+    await tester.pumpAndSettle();
+
+    // Consecutive collapsed day headers keep their full row spacing.
+    final dy2 = tester.getTopLeft(find.text('Thu, Jun 11')).dy;
+    final dy3 = tester.getTopLeft(find.text('Fri, Jun 12')).dy;
+    final dy4 = tester.getTopLeft(find.text('Sat, Jun 13')).dy;
+    expect(dy3 - dy2, greaterThan(30));
+    expect(dy4 - dy3, greaterThan(30));
+  });
+
   testWidgets('expansion survives a silent refresh; the seed stays one-shot',
       (WidgetTester tester) async {
     final service = await _pump(tester, twoCityTrip());


### PR DESCRIPTION
## Summary
- Fixes the scroll bug Brian hit on the first dogfood of collapsed-by-default groups (#304): all collapsed headers squished to slivers, then a blank still-scrollable area, as the page scrolled.
- Root cause (verified against sliver_tools 0.2.12 source): a collapsed group was a `MultiSliver(pushPinnedChildren)` whose ONLY child was its `SliverPinnedHeader`. The pinned child reports `paintOrigin = overlap`; with no body sliver contributing `paintOrigin: 0`, the pinned chrome's overlap is subtracted from the group's paint and layout extents while `scrollExtent` stays full — every collapsed header compresses simultaneously as the chrome pins (48px phone chrome, 308px with the pinned map), then vanishes leaving phantom scroll.
- Fix: pin a header only while its section is expanded. Collapsed city groups AND collapsed days (the identical zero-body shape one level down, latent since before #304 — a manually collapsed day's header could vanish on scroll) render as plain `SliverToBoxAdapter` rows. Expanded paths are byte-identical; the consumer audit (today-mode scroll math, sticky headers, GlobalKeys) confirmed nothing depends on a *collapsed* header pinning.
- Friction-log entry updated with the root cause and the lesson: a pinned sliver only earns its pin while it has content to preside over.

## Testing
- `flutter analyze` — zero new issues; `flutter test` — full suite, 731 passing.
- New city-level regression test **fails on the un-fixed code** (verified by stashing the fix): at max scroll, collapsed headers compressed below full row spacing. New day-level test pins the fixed stacked-collapsed-days behavior (the pre-existing day-level vanish is paint-level and not observable via layout asserts in the harness).
- Existing sticky-headers test (expanded groups pin while scrolling) passes unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)