### PR TITLE
feat(flutter): night counter on trip-detail city date chips

### DIFF
--- a/src/packages/flutter-app/lib/l10n/app_en.arb
+++ b/src/packages/flutter-app/lib/l10n/app_en.arb
@@ -829,6 +829,17 @@
       }
     }
   },
+  "tripLegDatesWithNights": "{range} · {count, plural, one{1 night} other{{count} nights}}",
+  "@tripLegDatesWithNights": {
+    "placeholders": {
+      "range": {
+        "type": "String"
+      },
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "tripTravelMinutes": "{minutes} min",
   "@tripTravelMinutes": {
     "placeholders": {

--- a/src/packages/flutter-app/lib/l10n/app_es.arb
+++ b/src/packages/flutter-app/lib/l10n/app_es.arb
@@ -404,6 +404,7 @@
   "tripDayTripTo": "Excursión · {town}",
   "tripDayTripFallback": "Excursión",
   "tripTonight": "Esta noche: {stays}",
+  "tripLegDatesWithNights": "{range} · {count, plural, one{1 noche} other{{count} noches}}",
   "tripTravelMinutes": "{minutes} min",
   "tripTravelHours": "{hours} h",
   "tripTravelHoursMinutes": "{hours} h {minutes} min",

--- a/src/packages/flutter-app/lib/l10n/app_localizations.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations.dart
@@ -2522,6 +2522,12 @@ abstract class AppLocalizations {
   /// **'Tonight: {stays}'**
   String tripTonight(String stays);
 
+  /// No description provided for @tripLegDatesWithNights.
+  ///
+  /// In en, this message translates to:
+  /// **'{range} · {count, plural, one{1 night} other{{count} nights}}'**
+  String tripLegDatesWithNights(String range, int count);
+
   /// No description provided for @tripTravelMinutes.
   ///
   /// In en, this message translates to:

--- a/src/packages/flutter-app/lib/l10n/app_localizations_en.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations_en.dart
@@ -1367,6 +1367,17 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String tripLegDatesWithNights(String range, int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count nights',
+      one: '1 night',
+    );
+    return '$range · $_temp0';
+  }
+
+  @override
   String tripTravelMinutes(int minutes) {
     return '$minutes min';
   }

--- a/src/packages/flutter-app/lib/l10n/app_localizations_es.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations_es.dart
@@ -1378,6 +1378,17 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
+  String tripLegDatesWithNights(String range, int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count noches',
+      one: '1 noche',
+    );
+    return '$range · $_temp0';
+  }
+
+  @override
   String tripTravelMinutes(int minutes) {
     return '$minutes min';
   }

--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -2180,10 +2180,14 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
                       Icon(Icons.event,
                           size: 14, color: theme.colorScheme.primary),
                       const SizedBox(width: 4),
-                      Text(
-                        group.dateRange!,
-                        style: theme.textTheme.labelMedium
-                            ?.copyWith(color: theme.colorScheme.primary),
+                      Flexible(
+                        child: Text(
+                          group.dateRange!,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: theme.textTheme.labelMedium
+                              ?.copyWith(color: theme.colorScheme.primary),
+                        ),
                       ),
                     ],
                     // 'Other places' has no hub the section tool can target;
@@ -3849,8 +3853,11 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
   /// visible ranges are arrival-adjusted, matching the stay todos — a leg whose
   /// items collapse onto one day reads "Sep 24 – Sep 27", not a bare "Sep 27"
   /// contradicting the stay row beneath it, and a squeezed leg collapses to a
-  /// zero-night stop at its arrival.
+  /// zero-night stop at its arrival. Multi-night legs carry a nights suffix
+  /// ("Aug 24 – Aug 27 · 3 nights") computed from the same range pair;
+  /// squeezed zero-night legs keep the bare single-date label.
   Map<int, String> _locationDates(Trip trip) {
+    final l10n = context.l10n;
     final items = trip.items ?? const <ItineraryItem>[];
     if (items.isEmpty) return const {};
     final ranges = visibleLegRanges(trip);
@@ -3861,8 +3868,11 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
       final end = ranges[gi].end;
       if (start == null || end == null) continue;
       final text = _formatRange(start, end);
+      final nights = nightsBetween(start, end);
+      final label =
+          nights > 0 ? l10n.tripLegDatesWithNights(text, nights) : text;
       for (final item in legs[gi].items) {
-        result[item.position] = text;
+        result[item.position] = label;
       }
     }
     return result;

--- a/src/packages/flutter-app/lib/utils/leg_ranges.dart
+++ b/src/packages/flutter-app/lib/utils/leg_ranges.dart
@@ -220,3 +220,13 @@ List<int> allocateDays(int totalDays, List<int> weights) {
   }
   return counts;
 }
+
+/// Whole nights between two local-midnight dates, checkout-exclusive
+/// (Aug 24 -> Aug 27 = 3; same day = 0). UTC-normalized so a DST
+/// transition inside the range can't skew the count. Client display
+/// only — NOT part of the Go-twin contract; the legs payload carries
+/// no nights field.
+int nightsBetween(DateTime a, DateTime b) =>
+    DateTime.utc(b.year, b.month, b.day)
+        .difference(DateTime.utc(a.year, a.month, a.day))
+        .inDays;

--- a/src/packages/flutter-app/test/leg_ranges_test.dart
+++ b/src/packages/flutter-app/test/leg_ranges_test.dart
@@ -280,4 +280,24 @@ void main() {
       expect(allocateDays(2, [5, 5, 5]), [1, 1, 1]);
     });
   });
+
+  // nightsBetween is a client-display helper only — deliberately NOT part of
+  // the hand-mirrored Go-twin contract above; the legs payload carries no
+  // nights field.
+  group('nightsBetween', () {
+    test('checkout-exclusive whole nights', () {
+      expect(nightsBetween(DateTime(2026, 8, 24), DateTime(2026, 8, 27)), 3);
+      expect(nightsBetween(DateTime(2026, 8, 27), DateTime(2026, 9, 1)), 5);
+    });
+
+    test('same day is zero nights', () {
+      expect(nightsBetween(DateTime(2026, 9, 6), DateTime(2026, 9, 6)), 0);
+    });
+
+    test('DST spring-forward does not drop a night', () {
+      // US DST starts Mar 8 2026; a raw local-midnight Duration diff reads
+      // ~1.96 days and would truncate to 1.
+      expect(nightsBetween(DateTime(2026, 3, 7), DateTime(2026, 3, 9)), 2);
+    });
+  });
 }

--- a/src/packages/flutter-app/test/trip_detail_collapsed_default_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_collapsed_default_test.dart
@@ -98,7 +98,7 @@ void main() {
     // Headers with their date ranges are the whole resting view.
     expect(find.text('Paris'), findsOneWidget);
     expect(find.text('Rome'), findsOneWidget);
-    expect(find.text('Jun 10 – Jun 11'), findsOneWidget);
+    expect(find.text('Jun 10 – Jun 11 · 1 night'), findsOneWidget);
 
     // Items and embedded booking rows are hidden until a group is opened.
     expect(find.text('Louvre'), findsNothing);

--- a/src/packages/flutter-app/test/trip_detail_grouping_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_grouping_test.dart
@@ -91,8 +91,9 @@ void main() {
     expect(find.text('Green Turtle Cay'), findsOneWidget);
     expect(find.text('Great Guana Cay'), findsOneWidget);
 
-    // The Green Turtle Cay group is labelled with the stay's date range.
-    expect(find.text('Jun 10 – Jun 12'), findsOneWidget);
+    // The Green Turtle Cay group is labelled with the stay's date range
+    // plus its night count.
+    expect(find.text('Jun 10 – Jun 12 · 2 nights'), findsOneWidget);
 
     // Groups default collapsed — open both to reach their contents.
     await expandCity(tester, 'Green Turtle Cay');
@@ -154,8 +155,8 @@ void main() {
     expect(find.text('Thu, Jun 11'), findsOneWidget);
     expect(find.text('Sat, Jun 13'), findsOneWidget);
 
-    // Paris spans days 1–2 -> Jun 10 – Jun 11 next to the city name.
-    expect(find.text('Jun 10 – Jun 11'), findsOneWidget);
+    // Paris spans days 1–2 -> Jun 10 – Jun 11 (1 night) next to the city name.
+    expect(find.text('Jun 10 – Jun 11 · 1 night'), findsOneWidget);
 
     // The Versailles day trip still nests under its day.
     expect(find.text('Day trip · Versailles'), findsOneWidget);

--- a/src/packages/flutter-app/test/trip_detail_leg_nights_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_leg_nights_test.dart
@@ -1,0 +1,146 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:travel_route_planner/l10n/l10n.dart';
+import 'package:travel_route_planner/models/trip.dart';
+import 'package:travel_route_planner/models/itinerary_item.dart';
+import 'package:travel_route_planner/models/booking_todo.dart';
+import 'package:travel_route_planner/services/api_client.dart';
+import 'package:travel_route_planner/services/booking_todos_api_service.dart';
+import 'package:travel_route_planner/services/trips_api_service.dart';
+import 'package:travel_route_planner/providers/booking_todos_provider.dart';
+import 'package:travel_route_planner/providers/trips_provider.dart';
+import 'package:travel_route_planner/screens/trip_detail_screen.dart';
+
+import 'support/l10n_test_app.dart';
+
+/// Returns a fixed trip without hitting the network, so we can exercise the
+/// real TripDetailScreen render path (and its booking-todo derivation).
+class _FakeTripsApiService extends TripsApiService {
+  final Trip trip;
+  _FakeTripsApiService(this.trip) : super(ApiClient(baseUrl: 'http://test'));
+
+  @override
+  Future<Trip> getTrip(String id) async => trip;
+}
+
+/// Swallows the derived-payload sync like the offline test env.
+class _FakeBookingTodosApiService extends BookingTodosApiService {
+  _FakeBookingTodosApiService() : super(ApiClient(baseUrl: 'http://test'));
+
+  @override
+  Future<List<BookingTodo>> syncTodos(
+          String tripId, List<Map<String, dynamic>> derived) async =>
+      throw Exception('offline test env');
+}
+
+ItineraryItem _item(int pos, String name, String city, {int? day}) =>
+    ItineraryItem(
+      id: 'i$pos',
+      position: pos,
+      name: name,
+      address: '$city address',
+      // Zero coords so the screen skips the map widget in the test env.
+      latitude: 0,
+      longitude: 0,
+      category: 'attraction',
+      day: day,
+      city: city,
+    );
+
+Future<void> _pump(WidgetTester tester, Trip trip, {Locale? locale}) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        tripsApiServiceProvider.overrideWithValue(_FakeTripsApiService(trip)),
+        bookingTodosApiServiceProvider
+            .overrideWithValue(_FakeBookingTodosApiService()),
+      ],
+      child: localizedTestApp(
+        home: TripDetailScreen(tripId: 't1'),
+        locale: locale,
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+/// Prague Aug 24 – Aug 27 (3 nights), Kraków Aug 27 – Sep 1 (5 nights) —
+/// the canonical example the feature was asked for.
+Trip _pragueKrakowTrip() => Trip(
+      id: 't1',
+      title: 'Big Summer',
+      status: 'planned',
+      startDate: '2026-08-24',
+      endDate: '2026-09-01',
+      createdAt: '2026-08-01',
+      updatedAt: '2026-08-01',
+      items: [
+        _item(0, 'Prague', 'Prague', day: 4),
+        _item(1, 'Kraków', 'Kraków', day: 9),
+      ],
+    );
+
+void main() {
+  testWidgets('city headers carry a night count next to the date range',
+      (WidgetTester tester) async {
+    await _pump(tester, _pragueKrakowTrip());
+
+    expect(find.text('Aug 24 – Aug 27 · 3 nights'), findsOneWidget);
+    expect(find.text('Aug 27 – Sep 1 · 5 nights'), findsOneWidget);
+  });
+
+  testWidgets('a squeezed zero-night leg keeps its bare single-date chip',
+      (WidgetTester tester) async {
+    // Quito is squeezed onto its Sep 6 arrival (see
+    // trip_detail_squeezed_leg_test.dart) — no "0 nights" noise on it, while
+    // the following Galápagos leg still gets its counter.
+    await _pump(
+      tester,
+      Trip(
+        id: 't1',
+        title: 'Squeeze',
+        status: 'planned',
+        startDate: '2026-09-01',
+        endDate: '2026-09-07',
+        createdAt: '2026-08-01',
+        updatedAt: '2026-08-01',
+        items: [
+          _item(0, 'Museo', 'Medellín', day: 1),
+          _item(1, 'Comuna 13', 'Medellín', day: 6),
+          _item(2, 'Quito', 'Quito', day: 5),
+          _item(3, 'Mitad del Mundo', 'Galápagos', day: 6),
+          _item(4, 'Tortuga Bay', 'Galápagos', day: 7),
+        ],
+      ),
+    );
+
+    expect(find.text('Sep 6'), findsWidgets);
+    expect(find.textContaining('0 nights'), findsNothing);
+    expect(find.text('Sep 6 – Sep 7 · 1 night'), findsWidgets);
+  });
+
+  testWidgets('night counts pluralize in Spanish',
+      (WidgetTester tester) async {
+    // Only the nights half is pinned: the date half comes from
+    // DateFormat.MMMd(), which reads Intl.defaultLocale (English in the
+    // test env) rather than the widget locale.
+    await _pump(tester, _pragueKrakowTrip(), locale: const Locale('es'));
+
+    expect(find.textContaining('3 noches'), findsOneWidget);
+    expect(find.textContaining('5 noches'), findsOneWidget);
+  });
+
+  // The only tests that pin the separator and order — if the format ever
+  // changes, the ARB lines and these literals are the whole diff.
+  test('message-level plural forms in en and es', () async {
+    final en = await AppLocalizations.delegate.load(const Locale('en'));
+    expect(en.tripLegDatesWithNights('R', 1), 'R · 1 night');
+    expect(en.tripLegDatesWithNights('R', 3), 'R · 3 nights');
+
+    final es = await AppLocalizations.delegate.load(const Locale('es'));
+    expect(es.tripLegDatesWithNights('R', 1), 'R · 1 noche');
+    expect(es.tripLegDatesWithNights('R', 5), 'R · 5 noches');
+  });
+}

--- a/src/packages/flutter-app/test/trip_detail_squeezed_leg_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_squeezed_leg_test.dart
@@ -127,10 +127,11 @@ void main() {
     expect(galStay['return_date'], '2026-09-07');
 
     // Headers: no stale bare "Sep 5" chip anywhere; the squeezed leg shows
-    // its arrival and the next leg follows from it.
+    // its bare arrival (zero nights -> no counter) and the next leg follows
+    // from it with a night count.
     expect(find.text('Sep 5'), findsNothing);
     expect(find.text('Sep 6'), findsWidgets);
-    expect(find.text('Sep 6 – Sep 7'), findsWidgets);
+    expect(find.text('Sep 6 – Sep 7 · 1 night'), findsWidgets);
   });
 
   testWidgets('consecutive squeezed legs chain onto the same arrival',
@@ -190,6 +191,6 @@ void main() {
         derived.singleWhere((t) => t['todo_key'] == 'stay:quito');
     expect(quitoStay['depart_date'], '2026-09-03');
     expect(quitoStay['return_date'], '2026-09-05');
-    expect(find.text('Sep 3 – Sep 5'), findsWidgets);
+    expect(find.text('Sep 3 – Sep 5 · 2 nights'), findsWidgets);
   });
 }

--- a/src/packages/flutter-app/test/trip_detail_stay_dates_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_stay_dates_test.dart
@@ -169,8 +169,9 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    // Header shows the anchored range, not a bare end date.
-    expect(find.text('Aug 24 – Aug 27'), findsWidgets);
+    // Header shows the anchored range with its night count, not a bare
+    // end date.
+    expect(find.text('Aug 24 – Aug 27 · 3 nights'), findsWidgets);
     expect(find.text('Aug 27'), findsNothing);
 
     // The prefs load is async and can re-trigger the derivation — assert on
@@ -232,7 +233,7 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    expect(find.text('Aug 26 – Aug 28'), findsWidgets);
+    expect(find.text('Aug 26 – Aug 28 · 2 nights'), findsWidgets);
     expect(find.text('Aug 28'), findsNothing);
   });
 }


### PR DESCRIPTION
## Summary
- Each city group header on the trip detail itinerary now shows a night count next to its date range — "Aug 24 – Aug 27 · 3 nights" (Prague), "Aug 27 – Sep 1 · 5 nights" (Kraków) — per Brian's request from the dogfood pass.
- The count is computed in `_locationDates` from the **same** `visibleLegRanges` pair that formats the range (one derivation site — count and dates can never disagree), via a new DST-safe `nightsBetween` helper in `leg_ranges.dart`. Client-display only: the Go legs payload is untouched and carries no nights field; the map destination cards are unchanged.
- Squeezed zero-night legs (same-day stops) keep their bare single-date chip — no "0 nights" noise (Brian's pick).
- Format lives in one ICU message `tripLegDatesWithNights` (en + es: "1 noche"/"N noches"), so reordering or reseparating later is an ARB-only diff; `flutter gen-l10n` output committed, `l10n_untranslated.json` stays `{}`.
- Chip `Text` hardened with `Flexible` + ellipsis so the longer label can never overflow the header row on narrow widths.

## Testing
- `flutter analyze` — clean (3 pre-existing infos on main only).
- Full `make flutter-test` — 738 tests, all passing.
- New: `nightsBetween` unit group in `leg_ranges_test.dart` (checkout-exclusive, same-day zero, DST spring-forward) + `trip_detail_leg_nights_test.dart` (canonical Prague/Kraków chips, squeezed-leg suppression, Spanish plurals in-widget, en/es message-level format pins).
- Updated the seven existing chip-text assertions across grouping / collapsed-default / squeezed-leg / stay-dates tests; `trip_map_test.dart` untouched and green (map cards deliberately unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)