### PR TITLE
fix(flutter): keep city date chips flush right after nights counter

### DIFF
--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -2180,7 +2180,15 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
                       Icon(Icons.event,
                           size: 14, color: theme.colorScheme.primary),
                       const SizedBox(width: 4),
-                      Flexible(
+                      // Deliberately NOT Flexible: a second flex child would
+                      // split the free space with the label's Expanded and
+                      // drag the chip+chevron cluster off the right edge.
+                      // The fixed cap bounds the cluster instead — the
+                      // longest localized chip ("27 ago – 1 sep · 5 noches")
+                      // measures ~175px, so real text never truncates; only
+                      // pathological widths ellipsize rather than overflow.
+                      ConstrainedBox(
+                        constraints: const BoxConstraints(maxWidth: 200),
                         child: Text(
                           group.dateRange!,
                           maxLines: 1,

--- a/src/packages/flutter-app/test/trip_detail_leg_nights_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_leg_nights_test.dart
@@ -132,6 +132,59 @@ void main() {
     expect(find.textContaining('5 noches'), findsOneWidget);
   });
 
+  testWidgets('date chips sit flush right with aligned chevrons',
+      (WidgetTester tester) async {
+    // Regression: wrapping the chip Text in Flexible gave the header Row two
+    // flex children, so the label's Expanded only claimed half the free
+    // space and the chip+chevron cluster drifted left by a per-row amount.
+    // The chevron must end exactly where its Row ends, on every row.
+    await _pump(tester, _pragueKrakowTrip());
+
+    double chevronRightIn(String chipText) {
+      final row = find
+          .ancestor(of: find.text(chipText), matching: find.byType(Row))
+          .first;
+      final chevron = find.descendant(
+          of: row, matching: find.byIcon(Icons.chevron_right));
+      expect(chevron, findsOneWidget);
+      expect(
+        tester.getTopRight(chevron).dx,
+        moreOrLessEquals(tester.getTopRight(row).dx, epsilon: 0.1),
+        reason: 'chevron of "$chipText" must be flush with its row end',
+      );
+      return tester.getTopRight(chevron).dx;
+    }
+
+    final prague = chevronRightIn('Aug 24 – Aug 27 · 3 nights');
+    final krakow = chevronRightIn('Aug 27 – Sep 1 · 5 nights');
+    expect(prague, moreOrLessEquals(krakow, epsilon: 0.1),
+        reason: 'chevrons must align across rows');
+  });
+
+  testWidgets('phone width: header row never overflows and stays flush right',
+      (WidgetTester tester) async {
+    // The test font renders every glyph as a full-size square, so the chip
+    // here measures far wider than any real font — the harshest squeeze the
+    // row can see. The ConstrainedBox cap must ellipsize the chip (never
+    // overflow), and the chevron must stay flush with the row end.
+    await tester.binding.setSurfaceSize(const Size(375, 667));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    await _pump(tester, _pragueKrakowTrip());
+
+    final row = find
+        .ancestor(
+            of: find.text('Aug 24 – Aug 27 · 3 nights'),
+            matching: find.byType(Row))
+        .first;
+    final chevron = find.descendant(
+        of: row, matching: find.byIcon(Icons.chevron_right));
+    expect(
+      tester.getTopRight(chevron).dx,
+      moreOrLessEquals(tester.getTopRight(row).dx, epsilon: 0.1),
+      reason: 'chevron must stay flush with the row end at phone width',
+    );
+  });
+
   // The only tests that pin the separator and order — if the format ever
   // changes, the ARB lines and these literals are the whole diff.
   test('message-level plural forms in en and es', () async {


### PR DESCRIPTION
## Summary
- Fixes the styling regression Brian spotted after #306: date chips and chevrons drifted off the right edge and stopped aligning across rows.
- Root cause: wrapping the chip `Text` in `Flexible` gave the header Row two flex children — the label's `Expanded` only claimed half the free space, and the chip's unused loose allocation became a per-row trailing gap after the chevron.
- Fix: the chip is non-flex again (structurally flush right, chevrons align by construction), bounded by a 200px `ConstrainedBox` — wider than the longest real localized chip (~175px, "27 ago – 1 sep · 5 noches"), so production text never truncates; only pathological widths ellipsize instead of overflowing the row.
- New regression tests pin chevron-flush-with-row-end and cross-row chevron alignment at desktop width, plus no-overflow flushness at phone width (375px) where the square-glyph test font inflates the chip to ~300px — the harshest squeeze the row can see.

## Testing
- Alignment test written first and confirmed RED against the shipped code (chevron 765.5 vs row end 768.0), GREEN after the fix.
- The two `trip_detail_map_expand_test.dart` phone tests that overflowed by 83px under a plain revert pass with the cap.
- Full `flutter test`: 740 tests, all passing. `flutter analyze` clean (3 pre-existing infos only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)