### PR TITLE
feat(flutter): what-to-wear recommendations merge into the packing section

### DIFF
--- a/specs/what-to-wear/plan.md
+++ b/specs/what-to-wear/plan.md
@@ -1,0 +1,152 @@
+# Plan: What to wear & pack
+
+> **HOW.** Translates `spec.md` into a file-level technical approach. Every
+> decision should trace back to an acceptance criterion. See `../../CLAUDE.md`
+> for repo conventions referenced below — don't restate them, point to them.
+
+## Technical Approach
+
+Client-only. The screen already fetches a `WeatherReport` per city per leg
+window (`weatherByCityProvider`, keyed `WeatherQuery{city,start,end}` with
+value equality); a new pure util derives a typed clothing recommendation from
+each report, and `_packingSectionRow` composes the recommendations above the
+existing `ChecklistSection` inside the same `CollapsibleSection`. Key
+decisions:
+
+- **Derivation lives in ONE new pure util** (`lib/utils/clothing_recs.dart`,
+  no widget/l10n imports — the `leg_ranges.dart` pattern). The screen's
+  `_weatherGlyph` is refactored onto the util's `rainLevel()` in the same
+  change so the client has exactly one rain-threshold definition (zen: one
+  derivation, N call sites). The Go review constants
+  (`trip_review.go:627-633`) are a *different job* (advisory findings) — not
+  twinned; the util's header cross-references them, and its extreme-condition
+  edges (34°C / 0°C / 60% / 5mm) are deliberately equal so the two surfaces
+  can never contradict (spec criterion 8).
+- **Range source is `rawLegRanges(trip)` iterated as a list** — the
+  doc-pinned weather range source (`leg_ranges.dart:119`). NOT the
+  `groupRanges` label map (last-wins for revisited cities) and NOT the
+  pending `trip.legs` payload repoint (that lane's plan already treats
+  raw-range consumers explicitly; this feature stays in that bucket).
+  **Displayed dates are the index-aligned `visibleLegRanges` pair** (1:1 with
+  raw by construction) so a row can never disagree with the city-header
+  chips — the same raw-vs-visible twin the nights counter rides; only the
+  WeatherQuery stays on raw.
+- **Fetch sharing, honestly stated**: a single-visit city's WeatherQuery is
+  byte-identical to its city-group watch, so the provider family dedups (one
+  fetch shared with the chips). A revisited city's earlier visits query
+  per-visit windows the chips never build — one extra cached /weather call
+  each, the accepted cost of one-row-per-visit.
+- **No server phrasing**: the /plan agent already reads raw weather via
+  `get_weather` and phrases advice itself; print/export render raw weather
+  lines. Nothing server-side wants the band table.
+- **Degradation is structural**: `weatherByCityProvider` resolves failures to
+  an empty report, so "no recs" is indistinguishable from loading and the
+  gate reduces bit-identically to today's behavior offline.
+
+## Go API Changes
+
+**None.** No routes, handlers, services, types, env vars, or migrations.
+
+## Flutter Changes
+
+`src/packages/flutter-app/`:
+
+- **`lib/utils/clothing_recs.dart` (NEW)** — pure derivation:
+  - `enum RainLevel { none, some, likely }`;
+    `RainLevel rainLevel(WeatherDay d)` — forecast (`precipProbability !=
+    null`): ≥60 likely / ≥30 some; historical: `precipMm` ≥5 likely / ≥1
+    some. Exactly the current `_weatherGlyph` thresholds.
+  - `enum TempBand { freezing, cold, cool, mild, warm, hot }` from the
+    **median** of daily highs (one freak day can't flip the band):
+    freezing ≤0 · cold 1–7 · cool 8–15 · mild 16–22 · warm 23–29 · hot ≥30.
+  - `class ClothingRec { band, rainLikely, bigSwing, extremeHeat,
+    freezingNights, historical, loC, hiC }` — flags are any-day rules:
+    rainLikely = any `rainLevel == likely`; bigSwing = any `(max-min) ≥ 12`;
+    extremeHeat = any `max ≥ 34`; freezingNights = any `min ≤ 0`;
+    `loC`/`hiC` = envelope min(min)/max(max), rounded.
+  - `ClothingRec? clothingRec(WeatherReport)` (null on empty days);
+    `({int loC, int hiC, bool rainLikely}) clothingSummary(List<ClothingRec>)`
+    — cross-region envelope for the collapsed line.
+- **`lib/widgets/wear_recs.dart` (NEW)** — `WearRecsList`, stateless,
+  display-only. Input: precomputed `(label, start, end, rec)` records. Per
+  region: muted `Lisbon · Sep 15–20` line (`DateFormat.MMMd`), then the
+  phrase: band phrase + flag phrases joined ` · `, italic
+  `tripTypicalForDates` appended when historical (the `_weatherChip`
+  convention). Suppression: freezingNights hidden when band ∈ {freezing,
+  cold}; bigSwing hidden when band ∈ {freezing, cold, cool}; extremeHeat
+  hidden when band == hot.
+- **`lib/screens/trip_detail_screen.dart`** (hub file, this lane only):
+  - New `_legClothingRecs(Trip)` helper: iterate `rawLegRanges(trip)`, skip
+    `_kOtherPlaces` and null start/end, watch
+    `weatherByCityProvider(WeatherQuery(city: r.label, startDate:
+    _fmt(r.start!), endDate: _fmt(r.end!)))` (byte-identical keys to the
+    city-group watch → family dedup, one fetch shared with the chips),
+    `valueOrNull` → `clothingRec(...)`, collect non-null.
+  - `_packingSectionRow` gate becomes:
+    `showChecklist = items != null && !(items.isEmpty && _readOnly);`
+    `if (!showChecklist && recs.isEmpty) return null;`
+  - `CollapsibleSection`: title → `l10n.wearSectionTitle`; summary → recs
+    present ? `'${lo}°–${hi}°'` (+ ` · ` + `wearSummaryRain` when rainy,
+    kind-neutral, no "typical") : existing `checklistSummary`; checked-count
+    moves to `pill: StatusPill.custom('$checked/$total')` when items
+    non-empty; child = `Column([if (recs.isNotEmpty) WearRecsList(...),
+    ChecklistSection(showHeader: false, ...)])`.
+  - `_weatherGlyph` refactored to switch on `rainLevel(day)`.
+- **l10n** (`lib/l10n/app_en.arb` + `app_es.arb`, prefix `wear`):
+  `wearSectionTitle` "What to wear & pack", `wearBandFreezing`,
+  `wearBandCold`, `wearBandCool`, `wearBandMild`, `wearBandWarm`,
+  `wearBandHot`, `wearRainLikely`, `wearBigSwing`, `wearExtremeHeat`,
+  `wearFreezingNights`, `wearSummaryRain` "rain likely". Temps code-built
+  (precedent: the chip's `'$hi° / $lo°'`). Run `flutter gen-l10n`; generated
+  files committed, never hand-edited; `l10n_untranslated.json` stays empty.
+
+No models, services, or providers change (no new JSON crosses the wire).
+
+## Contract Parity  ← anti-drift gate
+
+**Empty by design.** No JSON key is added or changed on either side; the
+feature is a client display-only derivation from the existing `/weather`
+response (precedent: `nightsBetween` — "Client display only — NOT part of the
+Go-twin contract", `leg_ranges.dart:227`).
+
+| JSON key | Go type | Dart type | Nullable? | ✓ |
+|----------|---------|-----------|-----------|---|
+| *(none — no wire changes)* | — | — | — | ✓ |
+
+## Cross-cutting
+
+- **Env vars:** none.
+- **Gateway:** no new paths.
+- **Behavior change (accepted):** the parent now fetches weather for every
+  dated leg at page open (previously only expanded city groups) — required
+  for the collapsed summary; cheap (keyless Open-Meteo, server 3h summary /
+  24h geo caches, provider-family dedup with the chips).
+- **Known gap flagged:** temps are °C-only app-wide; bands are defined in °C
+  constants so a future units preference only touches display.
+
+## Verification
+
+(Mirrored into `tasks.md`.)
+
+- `make flutter-analyze` clean; `make flutter-test` full suite (dated-trip
+  tests newly instantiate weather providers — the flutter_test 400-stub is
+  caught → empty report → old behavior; confirm nothing timing-strict broke).
+- New `test/clothing_recs_test.dart`: band edges both sides (0/1, 7/8, 15/16,
+  22/23, 29/30 median high), median-vs-outlier, rain edges (59/60 %,
+  4.9/5.0 mm), any-day flag rules, swing 11/12, envelope + rounding,
+  empty → null, historical passthrough, `rainLevel` pins of the old glyph
+  thresholds, `clothingSummary` merge.
+- New `test/trip_detail_wear_section_test.dart` (fakes from
+  `trip_detail_weather_test.dart` + `trip_detail_fix_actions_test.dart`):
+  collapsed title/summary, expanded rows + checklist + add field, historical
+  qualifier, read-only + empty checklist + weather → recs only,
+  weather empty → hidden as today.
+- Update `test/trip_detail_fix_actions_test.dart:376` title expectation
+  (`Packing & prep` → `What to wear & pack`) — the only breaking reference;
+  `checklist_section_test.dart` pins the untouched `checklistTitle`, and the
+  print packet title is server-side Go i18n.
+- Manual via `make docker-dev` (this lane: http://localhost:3001): walk each
+  acceptance criterion in `spec.md` (near trip = forecast summary consistent
+  with chip umbrella days; far trip = "typical" per row; read-only viewer;
+  agent `add_packing_item` + Trip-health one-tap fix land in the merged
+  section; print packet unchanged; Spanish spot-check).

--- a/specs/what-to-wear/spec.md
+++ b/specs/what-to-wear/spec.md
@@ -1,0 +1,103 @@
+# Spec: What to wear & pack
+
+## Context
+
+The trip-detail "Packing & prep" section is an empty checklist until someone
+fills it, while the screen already knows the weather for every region of the
+trip (the per-day chips). Packing decisions start from "what will it be like
+there, then?" — so the section should lead with that answer. This feature
+merges weather-derived clothing recommendations into the packing section:
+per-region guidance on top, the editable checklist below, and a glanceable
+one-line summary while collapsed. Direction settled with Brian (2026-08-07):
+merge into ONE section (nothing about the checklist retires), render in the
+trailing cluster (no inline per-city chrome), deterministic rules — no AI.
+
+## User Stories
+
+- As a **traveler planning a trip**, I want **to see what kind of clothes suit
+  each region during my dates** so that **I can pack right without researching
+  climate myself**.
+- As a **traveler planning months ahead**, I want **seasonal guidance clearly
+  framed as "typical", not a forecast**, so that **I trust it appropriately**.
+- As a **read-only collaborator on a shared trip**, I want **the same clothing
+  guidance even when the owner's checklist is empty**, so that **I can pack
+  too**.
+
+## Acceptance Criteria
+
+- [ ] The trailing-cluster row is titled "What to wear & pack" and, when
+      weather is available, its collapsed summary shows the cross-region
+      temperature envelope and rain signal (e.g. "21°–31° · rain likely").
+- [ ] Expanded, the section lists one row per leg visit (a revisited city gets
+      one row per visit, disambiguated by date range): region label, date
+      range, per-region temperature envelope, and a deterministic phrase built
+      from the temperature band plus condition flags (rain, day–night swing,
+      extreme heat, freezing nights). The dates shown are the same visible
+      ranges the city headers display, so the two never disagree.
+- [ ] Legs beyond the forecast horizon show the existing italic "typical for
+      these dates" qualifier on their row; the collapsed summary stays
+      kind-neutral (no qualifier).
+- [ ] The editable packing checklist renders below the recommendations, fully
+      intact: add/edit/check/delete, AI-seeded items, Trip-health one-tap
+      fixes, export and print packet are all unchanged.
+- [ ] The checked-count stays glanceable while collapsed (pill on the row).
+- [ ] A read-only viewer with an empty checklist sees the section when weather
+      resolves (recommendations only, no add affordance).
+- [ ] When no weather resolves (offline, undated trip, provider failure), the
+      section gates exactly as today: nothing until the checklist loads,
+      hidden for viewers with an empty checklist.
+- [ ] Recommendations never contradict Trip-health weather findings shown on
+      the same screen (shared edges: extreme heat, freezing, rain-likely).
+
+## API Surface
+
+None. The feature consumes the existing weather lookups the trip screen
+already performs per region and date window. No new endpoints, no server
+changes.
+
+## Data Model
+
+Nothing stored. Recommendations are a display-only derivation from the weather
+report already fetched per region (established precedent: the nights counter
+is client display only and not part of any server contract).
+
+## UI Behavior
+
+- **Screen / surface:** trip detail, trailing cluster, the existing packing
+  slot. Cluster order Trip health → What to wear & pack → Budget is unchanged.
+- **Happy path:** opening the trip fetches weather for each dated region
+  (shared with the day chips, so no duplicate lookups); as reports resolve,
+  the collapsed summary swaps from the checklist count to the temperature
+  envelope, with the checked-count moving to a pill. Expanding shows the
+  per-region guidance followed by the checklist.
+- **States:** loading = today's behavior (no recommendations yet); success =
+  summary + per-region rows; error/offline = weather resolves empty, so
+  recommendations are simply absent and behavior is identical to today. The
+  section never blocks and never shows an error.
+
+## Edge Cases & Error States
+
+- Undated trip / no dated regions → no weather lookups, checklist-only.
+- "Other places" (items with no real city) → skipped; nothing to geocode.
+- A region stayed in longer than two weeks → guidance covers the served
+  window silently (same accepted limitation as the day chips).
+- Mixed near/far regions in one trip (forecast + typical) → per-row
+  qualifiers carry the nuance; the collapsed summary makes no forecast claim.
+- Revisited city → one row per visit with its own dates.
+- Weather provider outage → empty reports by server contract; recommendations
+  absent, no error surfaced.
+
+## Out of Scope
+
+- Wind, UV, snow, humidity, or condition icons (daily min/max/precip only).
+- Per-day recommendations (per-region granularity only).
+- Auto-adding checklist items from recommendations.
+- Temperature units preference (°C-only today app-wide; noted as a separate
+  follow-up this feature makes more visible).
+- Any server-side clothing phrasing (the chat agent already reads raw weather
+  and phrases advice itself).
+
+## Open Questions
+
+None — direction settled 2026-08-07. Band edges are product taste pinned by
+unit tests; tunable on Brian's visual pass.

--- a/specs/what-to-wear/tasks.md
+++ b/specs/what-to-wear/tasks.md
@@ -1,0 +1,37 @@
+# Tasks: What to wear & pack
+
+> Dependency-ordered. `[P]` = can run in parallel with its siblings (no shared
+> files / no ordering dependency). Work top to bottom; verification is last.
+
+## Derivation (Flutter util)
+
+- [x] `lib/utils/clothing_recs.dart`: `RainLevel`/`rainLevel()`, `TempBand`,
+      `ClothingRec`, `clothingRec()`, `clothingSummary()` (constants + header
+      cross-reference to `trip_review.go:627-633`)
+- [x] `test/clothing_recs_test.dart`: band/rain/swing edges, median-outlier,
+      any-day rules, envelope, empty → null, historical, glyph-threshold pins
+
+## l10n
+
+- [x] [P] 12 `wear*` keys in `app_en.arb` + `app_es.arb`
+- [x] Run `flutter gen-l10n` (generated files committed; untranslated file
+      stays empty)
+
+## UI (Flutter)
+
+- [x] [P] `lib/widgets/wear_recs.dart` (`WearRecsList` + phrase-suppression
+      rules)
+- [x] `trip_detail_screen.dart`: `_legClothingRecs()` helper; rewire
+      `_packingSectionRow` (gate, title, summary, pill, merged child);
+      refactor `_weatherGlyph` onto `rainLevel()`
+- [x] `test/trip_detail_wear_section_test.dart` (6 cases incl. read-only +
+      historical + weather-empty)
+- [x] Update `test/trip_detail_fix_actions_test.dart` title expectation
+
+## Verification
+
+- [x] `make flutter-analyze` clean
+- [x] `make flutter-test` — full suite (762 passing), not just new tests
+- [ ] Manual end-to-end via this lane's gateway (`make docker-dev` →
+      http://localhost:3001): every acceptance criterion in `spec.md`
+- [ ] `ship pr` (lane stops at PR-open; integrator merges)

--- a/src/packages/flutter-app/lib/l10n/app_en.arb
+++ b/src/packages/flutter-app/lib/l10n/app_en.arb
@@ -2055,5 +2055,17 @@
   "nearMeDialogTitle": "Where are you?",
   "nearMeDialogMessage": "We couldn't get your location. Type a city or neighborhood instead, or enable location access and try again.",
   "nearMeDialogHint": "e.g. Athens, Plaka",
-  "nearMeDialogCta": "Ask"
+  "nearMeDialogCta": "Ask",
+  "wearSectionTitle": "What to wear & pack",
+  "wearBandFreezing": "Freezing — thermals and an insulated coat",
+  "wearBandCold": "Cold — warm coat, hat, and gloves",
+  "wearBandCool": "Cool — a jacket and layers",
+  "wearBandMild": "Mild — light layers",
+  "wearBandWarm": "Warm — summer clothes, a light evening layer",
+  "wearBandHot": "Hot — light fabrics and sun protection",
+  "wearRainLikely": "rain likely, pack an umbrella",
+  "wearBigSwing": "big day–night range, bring layers",
+  "wearExtremeHeat": "very hot days, extra sun protection",
+  "wearFreezingNights": "freezing nights, warm layers",
+  "wearSummaryRain": "rain likely"
 }

--- a/src/packages/flutter-app/lib/l10n/app_es.arb
+++ b/src/packages/flutter-app/lib/l10n/app_es.arb
@@ -891,5 +891,17 @@
   "nearMeDialogTitle": "¿Dónde estás?",
   "nearMeDialogMessage": "No pudimos obtener tu ubicación. Escribe una ciudad o un barrio, o activa el acceso a la ubicación e inténtalo de nuevo.",
   "nearMeDialogHint": "p. ej. Atenas, Plaka",
-  "nearMeDialogCta": "Preguntar"
+  "nearMeDialogCta": "Preguntar",
+  "wearSectionTitle": "Qué ponerte y qué llevar",
+  "wearBandFreezing": "Bajo cero — ropa térmica y abrigo aislante",
+  "wearBandCold": "Frío — abrigo, gorro y guantes",
+  "wearBandCool": "Fresco — chaqueta y varias capas",
+  "wearBandMild": "Templado — capas ligeras",
+  "wearBandWarm": "Cálido — ropa de verano y una capa ligera para la noche",
+  "wearBandHot": "Calor — ropa ligera y protección solar",
+  "wearRainLikely": "lluvia probable, lleva paraguas",
+  "wearBigSwing": "gran variación día-noche, lleva capas",
+  "wearExtremeHeat": "días muy calurosos, protección solar extra",
+  "wearFreezingNights": "noches bajo cero, capas de abrigo",
+  "wearSummaryRain": "lluvia probable"
 }

--- a/src/packages/flutter-app/lib/l10n/app_localizations.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations.dart
@@ -5329,6 +5329,78 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Ask'**
   String get nearMeDialogCta;
+
+  /// No description provided for @wearSectionTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'What to wear & pack'**
+  String get wearSectionTitle;
+
+  /// No description provided for @wearBandFreezing.
+  ///
+  /// In en, this message translates to:
+  /// **'Freezing — thermals and an insulated coat'**
+  String get wearBandFreezing;
+
+  /// No description provided for @wearBandCold.
+  ///
+  /// In en, this message translates to:
+  /// **'Cold — warm coat, hat, and gloves'**
+  String get wearBandCold;
+
+  /// No description provided for @wearBandCool.
+  ///
+  /// In en, this message translates to:
+  /// **'Cool — a jacket and layers'**
+  String get wearBandCool;
+
+  /// No description provided for @wearBandMild.
+  ///
+  /// In en, this message translates to:
+  /// **'Mild — light layers'**
+  String get wearBandMild;
+
+  /// No description provided for @wearBandWarm.
+  ///
+  /// In en, this message translates to:
+  /// **'Warm — summer clothes, a light evening layer'**
+  String get wearBandWarm;
+
+  /// No description provided for @wearBandHot.
+  ///
+  /// In en, this message translates to:
+  /// **'Hot — light fabrics and sun protection'**
+  String get wearBandHot;
+
+  /// No description provided for @wearRainLikely.
+  ///
+  /// In en, this message translates to:
+  /// **'rain likely, pack an umbrella'**
+  String get wearRainLikely;
+
+  /// No description provided for @wearBigSwing.
+  ///
+  /// In en, this message translates to:
+  /// **'big day–night range, bring layers'**
+  String get wearBigSwing;
+
+  /// No description provided for @wearExtremeHeat.
+  ///
+  /// In en, this message translates to:
+  /// **'very hot days, extra sun protection'**
+  String get wearExtremeHeat;
+
+  /// No description provided for @wearFreezingNights.
+  ///
+  /// In en, this message translates to:
+  /// **'freezing nights, warm layers'**
+  String get wearFreezingNights;
+
+  /// No description provided for @wearSummaryRain.
+  ///
+  /// In en, this message translates to:
+  /// **'rain likely'**
+  String get wearSummaryRain;
 }
 
 class _AppLocalizationsDelegate

--- a/src/packages/flutter-app/lib/l10n/app_localizations_en.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations_en.dart
@@ -3125,4 +3125,40 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get nearMeDialogCta => 'Ask';
+
+  @override
+  String get wearSectionTitle => 'What to wear & pack';
+
+  @override
+  String get wearBandFreezing => 'Freezing — thermals and an insulated coat';
+
+  @override
+  String get wearBandCold => 'Cold — warm coat, hat, and gloves';
+
+  @override
+  String get wearBandCool => 'Cool — a jacket and layers';
+
+  @override
+  String get wearBandMild => 'Mild — light layers';
+
+  @override
+  String get wearBandWarm => 'Warm — summer clothes, a light evening layer';
+
+  @override
+  String get wearBandHot => 'Hot — light fabrics and sun protection';
+
+  @override
+  String get wearRainLikely => 'rain likely, pack an umbrella';
+
+  @override
+  String get wearBigSwing => 'big day–night range, bring layers';
+
+  @override
+  String get wearExtremeHeat => 'very hot days, extra sun protection';
+
+  @override
+  String get wearFreezingNights => 'freezing nights, warm layers';
+
+  @override
+  String get wearSummaryRain => 'rain likely';
 }

--- a/src/packages/flutter-app/lib/l10n/app_localizations_es.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations_es.dart
@@ -3149,4 +3149,41 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get nearMeDialogCta => 'Preguntar';
+
+  @override
+  String get wearSectionTitle => 'Qué ponerte y qué llevar';
+
+  @override
+  String get wearBandFreezing => 'Bajo cero — ropa térmica y abrigo aislante';
+
+  @override
+  String get wearBandCold => 'Frío — abrigo, gorro y guantes';
+
+  @override
+  String get wearBandCool => 'Fresco — chaqueta y varias capas';
+
+  @override
+  String get wearBandMild => 'Templado — capas ligeras';
+
+  @override
+  String get wearBandWarm =>
+      'Cálido — ropa de verano y una capa ligera para la noche';
+
+  @override
+  String get wearBandHot => 'Calor — ropa ligera y protección solar';
+
+  @override
+  String get wearRainLikely => 'lluvia probable, lleva paraguas';
+
+  @override
+  String get wearBigSwing => 'gran variación día-noche, lleva capas';
+
+  @override
+  String get wearExtremeHeat => 'días muy calurosos, protección solar extra';
+
+  @override
+  String get wearFreezingNights => 'noches bajo cero, capas de abrigo';
+
+  @override
+  String get wearSummaryRain => 'lluvia probable';
 }

--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -45,6 +45,7 @@ import '../services/trip_cache.dart';
 import '../theme/app_colors.dart';
 import '../theme/spacing.dart';
 import '../utils/calendar_links.dart';
+import '../utils/clothing_recs.dart';
 import '../utils/leg_parity.dart';
 import '../utils/leg_ranges.dart';
 import '../utils/money_format.dart';
@@ -74,6 +75,7 @@ import '../widgets/source_links_card.dart';
 import '../widgets/status_pill.dart';
 import '../widgets/trip_map.dart';
 import '../widgets/trip_refine_panel.dart';
+import '../widgets/wear_recs.dart';
 import 'flight_search_screen.dart';
 import 'local_guide_detail_screen.dart';
 import 'trip_map_screen.dart';
@@ -3097,7 +3099,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
     final parts = <String>['$hi° / $lo°'];
     if (!historical &&
         day.precipProbability != null &&
-        day.precipProbability! >= 20) {
+        day.precipProbability! >= rainChanceCaptionPct) {
       parts.add(context.l10n.tripRainChance(day.precipProbability!));
     }
     return Padding(
@@ -3135,20 +3137,16 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
     );
   }
 
-  /// Condition glyph + color from precipitation. Forecast days key off the rain
-  /// probability (%), historical days off observed rainfall (mm): sunny below
-  /// the light threshold, cloud in between, umbrella above the wet threshold.
+  /// Condition glyph + color from precipitation: sunny / cloud / umbrella by
+  /// [rainLevel] — the client's one rain-threshold definition, shared with
+  /// the what-to-wear recommendations (utils/clothing_recs.dart).
   (IconData, Color) _weatherGlyph(ThemeData theme, WeatherDay day) {
     final scheme = theme.colorScheme;
-    final pct = day.precipProbability;
-    if (pct != null) {
-      if (pct >= 60) return (Icons.umbrella, scheme.primary);
-      if (pct >= 30) return (Icons.cloud, scheme.onSurfaceVariant);
-      return (Icons.wb_sunny, Colors.amber.shade700);
-    }
-    if (day.precipMm >= 5) return (Icons.umbrella, scheme.primary);
-    if (day.precipMm >= 1) return (Icons.cloud, scheme.onSurfaceVariant);
-    return (Icons.wb_sunny, Colors.amber.shade700);
+    return switch (rainLevel(day)) {
+      RainLevel.likely => (Icons.umbrella, scheme.primary),
+      RainLevel.some => (Icons.cloud, scheme.onSurfaceVariant),
+      RainLevel.none => (Icons.wb_sunny, Colors.amber.shade700),
+    };
   }
 
   /// "Tonight: <stay>" caption for today's day section (specs/happening-now
@@ -4011,24 +4009,102 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
     );
   }
 
+  /// Per-leg what-to-wear derivations for the merged section
+  /// (specs/what-to-wear). Weather queries stay on rawLegRanges — the
+  /// doc-pinned range source shared with the day chips (leg_ranges.dart) —
+  /// while the DISPLAYED dates come from the index-aligned visibleLegRanges
+  /// pair, so a row's dates can never disagree with the city-header chips
+  /// above it (the same raw-vs-visible twin the nights counter rides).
+  /// Iterates the leg LIST — not groupRanges, whose label keying is
+  /// last-wins for revisited cities — so a revisited city gets one row per
+  /// visit. Fetch sharing: a single-visit city's WeatherQuery is
+  /// byte-identical to its city-group watch, so the provider family dedups;
+  /// a revisited city's earlier visits query per-visit windows the chips
+  /// never build — one extra cached /weather call each, the accepted cost of
+  /// per-visit rows. Loading or failed reports derive null and drop out;
+  /// offline this is simply empty.
+  List<WearRegionRec> _legClothingRecs(Trip trip) {
+    final raw = rawLegRanges(trip);
+    final visible = visibleLegRanges(trip); // 1:1 by index with raw
+    final recs = <WearRegionRec>[];
+    for (var i = 0; i < raw.length; i++) {
+      final r = raw[i];
+      final start = r.start, end = r.end;
+      if (r.label == _kOtherPlaces || start == null || end == null) continue;
+      final report = ref
+          .watch(weatherByCityProvider(WeatherQuery(
+            city: r.label,
+            startDate: _fmt(start),
+            endDate: _fmt(end),
+          )))
+          .valueOrNull;
+      if (report == null) continue;
+      final rec = clothingRec(report);
+      if (rec == null) continue;
+      final v = visible[i];
+      recs.add((
+        label: r.label,
+        start: v.start ?? start,
+        end: v.end ?? end,
+        rec: rec,
+      ));
+    }
+    return recs;
+  }
+
+  /// Collapsed one-liner for the merged row: the cross-region temperature
+  /// envelope plus the rain signal. Kind-neutral by design — the "typical"
+  /// qualifier stays on the expanded per-region rows.
+  String _wearSummary(List<WearRegionRec> recs) {
+    final s = clothingSummary([for (final r in recs) r.rec]);
+    // Spaced dash like the date ranges ("Sep 15 – Sep 20"), so a negative low
+    // never collides with it ("-6° – 2°").
+    final range = '${s.loC}° – ${s.hiC}°';
+    return s.rainLikely ? '$range · ${context.l10n.wearSummaryRain}' : range;
+  }
+
   Widget? _packingSectionRow(Trip trip, ThemeData theme) {
-    // Mirrors ChecklistSection's own gates (nothing until loaded; viewers
-    // with an empty list get no section) so the collapsed row hides exactly
-    // when the expanded section would.
+    // Merged "What to wear & pack" (specs/what-to-wear): weather-derived
+    // recommendations on top, the editable checklist below. Recommendations
+    // alone can show the row (read-only viewers get guidance even with an
+    // empty checklist); without weather the gate reduces exactly to the old
+    // checklist-only rule, which mirrors ChecklistSection's own gates
+    // (nothing until loaded; viewers with an empty list get no checklist).
     final items = ref.watch(checklistProvider(trip.id)).valueOrNull;
-    if (items == null || (items.isEmpty && _readOnly)) return null;
-    final checked = items.where((i) => i.checked).length;
+    final recs = _legClothingRecs(trip);
+    final showChecklist = items != null && !(items.isEmpty && _readOnly);
+    if (!showChecklist && recs.isEmpty) return null;
+    final checked = items?.where((i) => i.checked).length ?? 0;
+    // With recs in the summary slot, the checked-count stays glanceable via
+    // the pill (same chrome as ChecklistSection's standalone header).
+    final summary = recs.isNotEmpty
+        ? _wearSummary(recs)
+        : context.l10n.checklistSummary(checked, items!.length);
     return CollapsibleSection(
-      title: context.l10n.checklistTitle,
+      title: context.l10n.wearSectionTitle,
       icon: Icons.luggage_outlined,
-      summary: context.l10n.checklistSummary(checked, items.length),
+      summary: summary,
+      pill: (recs.isEmpty || items == null || items.isEmpty)
+          ? null
+          : StatusPill.custom(
+              label: '$checked/${items.length}',
+              background: theme.colorScheme.surfaceContainerHighest,
+              foreground: theme.colorScheme.onSurfaceVariant,
+            ),
       expanded: _sectionExpanded('packing'),
       onToggle: () => _toggleSection('packing'),
-      child: ChecklistSection(
-        tripId: trip.id,
-        canEdit: !_readOnly,
-        isOffline: _isOffline,
-        showHeader: false,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          if (recs.isNotEmpty) WearRecsList(regions: recs),
+          if (recs.isNotEmpty && showChecklist) const Divider(height: 24),
+          ChecklistSection(
+            tripId: trip.id,
+            canEdit: !_readOnly,
+            isOffline: _isOffline,
+            showHeader: false,
+          ),
+        ],
       ),
     );
   }

--- a/src/packages/flutter-app/lib/utils/clothing_recs.dart
+++ b/src/packages/flutter-app/lib/utils/clothing_recs.dart
@@ -1,0 +1,159 @@
+// What-to-wear derivation (specs/what-to-wear): deterministic clothing
+// guidance from a leg's WeatherReport. Pure data — no widgets, no l10n;
+// phrase text lives in the ARB and is mapped in the widget layer.
+//
+// This file is the client's ONE definition of weather thresholds: the
+// trip-detail condition glyph consumes [rainLevel] and the recommendation
+// bands live here, so the chip and the recs can never disagree. The Go trip
+// review keeps its own advisory constants (trip_review.go: rainProbPct,
+// rainHistoricMM, hotThresholdC, coldThresholdC) for a different job —
+// exception findings, not banded phrasing. They are deliberately NOT twinned,
+// but [extremeHeatC]/[freezingNightC]/the rain-likely edges below equal them,
+// so a Trip-health finding and a recommendation shown on the same screen
+// always agree. Change an edge in one place → check the other.
+//
+// The report covers only days inside the leg's window (the server truncates
+// to 14 days and starts mid-trip forecasts at today; historical reports carry
+// last year's dates), and the derivation aggregates whatever days come back —
+// no month-day matching, which is why the leap-day fallback in
+// WeatherReport.dayFor is irrelevant here.
+
+import '../models/weather.dart';
+
+/// Rain banding shared by the day-chip glyph and the recommendations.
+/// Forecast days key off the rain probability (%), historical days off
+/// observed rainfall (mm).
+enum RainLevel { none, some, likely }
+
+const int rainLikelyPct = 60;
+const int rainSomePct = 30;
+const double rainLikelyMm = 5.0;
+const double rainSomeMm = 1.0;
+
+/// Chip-caption gate, not a band edge: the day chip prints "N% rain" from
+/// this cutoff (below it the number is noise, not signal). Lives here so the
+/// header's one-definition claim stays true.
+const int rainChanceCaptionPct = 20;
+
+/// Any-day condition edges. Kept equal to the Go review's advisory constants
+/// (see header) so the two surfaces never contradict.
+const double extremeHeatC = 34.0;
+const double freezingNightC = 0.0;
+
+/// Day–night spread that earns "bring layers".
+const double bigSwingC = 12.0;
+
+RainLevel rainLevel(WeatherDay day) {
+  final pct = day.precipProbability;
+  if (pct != null) {
+    if (pct >= rainLikelyPct) return RainLevel.likely;
+    if (pct >= rainSomePct) return RainLevel.some;
+    return RainLevel.none;
+  }
+  if (day.precipMm >= rainLikelyMm) return RainLevel.likely;
+  if (day.precipMm >= rainSomeMm) return RainLevel.some;
+  return RainLevel.none;
+}
+
+/// Headline temperature band, from the MEDIAN of rounded daily highs so one
+/// freak day can't flip the phrase (the envelope still exposes it in the
+/// numbers). Edges in °C on the median daily high:
+/// freezing ≤0 · cold 1–7 · cool 8–15 · mild 16–22 · warm 23–29 · hot ≥30.
+enum TempBand { freezing, cold, cool, mild, warm, hot }
+
+TempBand _bandOf(int medianHighC) {
+  if (medianHighC <= 0) return TempBand.freezing;
+  if (medianHighC <= 7) return TempBand.cold;
+  if (medianHighC <= 15) return TempBand.cool;
+  if (medianHighC <= 22) return TempBand.mild;
+  if (medianHighC <= 29) return TempBand.warm;
+  return TempBand.hot;
+}
+
+/// One leg's clothing guidance. Flags are any-day rules: packing is an
+/// envelope decision — you carry the umbrella if any day needs it.
+class ClothingRec {
+  final TempBand band;
+
+  /// Any day with [RainLevel.likely].
+  final bool rainLikely;
+
+  /// Any day whose high–low spread is ≥ [bigSwingC].
+  final bool bigSwing;
+
+  /// Any day at or above [extremeHeatC] / at or below [freezingNightC].
+  final bool extremeHeat;
+  final bool freezingNights;
+
+  /// True for archive ("typical") reports beyond the forecast horizon.
+  final bool historical;
+
+  /// Temperature envelope over the leg: min of lows / max of highs, rounded.
+  final int loC;
+  final int hiC;
+
+  const ClothingRec({
+    required this.band,
+    required this.rainLikely,
+    required this.bigSwing,
+    required this.extremeHeat,
+    required this.freezingNights,
+    required this.historical,
+    required this.loC,
+    required this.hiC,
+  });
+}
+
+/// Derives the guidance for one leg's report; null when the report is empty
+/// (loading, provider failure, undated leg — all render as "no recs").
+ClothingRec? clothingRec(WeatherReport report) {
+  final days = report.days;
+  if (days.isEmpty) return null;
+
+  final highs = days.map((d) => d.tempMaxC.round()).toList()..sort();
+  // Even count takes the upper-middle element (pinned by test): for a packing
+  // decision the warmer of the two middles is the safer headline.
+  final medianHigh = highs[highs.length ~/ 2];
+
+  var lo = days.first.tempMinC;
+  var hi = days.first.tempMaxC;
+  var rainy = false;
+  var swing = false;
+  var heat = false;
+  var freeze = false;
+  for (final d in days) {
+    if (d.tempMinC < lo) lo = d.tempMinC;
+    if (d.tempMaxC > hi) hi = d.tempMaxC;
+    if (rainLevel(d) == RainLevel.likely) rainy = true;
+    if (d.tempMaxC - d.tempMinC >= bigSwingC) swing = true;
+    if (d.tempMaxC >= extremeHeatC) heat = true;
+    if (d.tempMinC <= freezingNightC) freeze = true;
+  }
+
+  return ClothingRec(
+    band: _bandOf(medianHigh),
+    rainLikely: rainy,
+    bigSwing: swing,
+    extremeHeat: heat,
+    freezingNights: freeze,
+    historical: report.isHistorical,
+    loC: lo.round(),
+    hiC: hi.round(),
+  );
+}
+
+/// Cross-region envelope for the collapsed one-liner ("21°–31° · rain
+/// likely"). Kind-neutral by design: the numbers make no forecast claim, so
+/// the "typical" qualifier stays on the expanded per-leg rows.
+({int loC, int hiC, bool rainLikely}) clothingSummary(List<ClothingRec> recs) {
+  assert(recs.isNotEmpty, 'clothingSummary needs at least one rec');
+  var lo = recs.first.loC;
+  var hi = recs.first.hiC;
+  var rainy = false;
+  for (final r in recs) {
+    if (r.loC < lo) lo = r.loC;
+    if (r.hiC > hi) hi = r.hiC;
+    if (r.rainLikely) rainy = true;
+  }
+  return (loC: lo, hiC: hi, rainLikely: rainy);
+}

--- a/src/packages/flutter-app/lib/widgets/checklist_section.dart
+++ b/src/packages/flutter-app/lib/widgets/checklist_section.dart
@@ -9,10 +9,13 @@ import 'empty_state.dart';
 import 'section_header.dart';
 import 'status_pill.dart';
 
-/// The trip-detail "Packing & prep" section: a lightweight per-trip checklist
-/// the AI assistant seeds (add_packing_item) and the traveler edits freely.
-/// Self-contained — it owns its data via [checklistProvider] and reconciles
-/// mutations by invalidating that family key.
+/// The per-trip packing checklist: a lightweight list the AI assistant seeds
+/// (add_packing_item) and the traveler edits freely. On trip detail it renders
+/// body-only (showHeader: false) inside the merged "What to wear & pack" row
+/// (specs/what-to-wear), below the weather-derived recommendations; standalone
+/// it keeps its own "Packing & prep" header. Self-contained — it owns its data
+/// via [checklistProvider] and reconciles mutations by invalidating that
+/// family key.
 class ChecklistSection extends ConsumerStatefulWidget {
   final String tripId;
   final bool canEdit;

--- a/src/packages/flutter-app/lib/widgets/wear_recs.dart
+++ b/src/packages/flutter-app/lib/widgets/wear_recs.dart
@@ -1,0 +1,112 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+import '../l10n/l10n.dart';
+import '../theme/spacing.dart';
+import '../utils/clothing_recs.dart';
+
+/// One region's precomputed guidance: the leg label, its date window, and the
+/// derived [ClothingRec]. The trip screen builds these from its own weather
+/// watches (collapsed-row summaries must be fed by the parent), so this
+/// widget stays display-only.
+typedef WearRegionRec = ({
+  String label,
+  DateTime start,
+  DateTime end,
+  ClothingRec rec,
+});
+
+/// The what-to-wear block at the top of the merged "What to wear & pack"
+/// section (specs/what-to-wear): per region, a muted "Lisbon · Sep 15 – Sep 20
+/// · 17°–28°" line followed by the deterministic clothing phrase. Historical
+/// reports get the same italic "typical for these dates" qualifier as the
+/// day chips — never presented as a forecast.
+class WearRecsList extends StatelessWidget {
+  final List<WearRegionRec> regions;
+
+  const WearRecsList({super.key, required this.regions});
+
+  /// Flag phrases that would restate the band's own advice are dropped:
+  /// freezing/cold bands already say coat (so no "freezing nights"), cool and
+  /// below already say layers (no "big day–night range"), and the hot band
+  /// already says sun protection (no "very hot days").
+  List<String> _phrases(AppLocalizations l10n, ClothingRec rec) {
+    final band = switch (rec.band) {
+      TempBand.freezing => l10n.wearBandFreezing,
+      TempBand.cold => l10n.wearBandCold,
+      TempBand.cool => l10n.wearBandCool,
+      TempBand.mild => l10n.wearBandMild,
+      TempBand.warm => l10n.wearBandWarm,
+      TempBand.hot => l10n.wearBandHot,
+    };
+    final coldish = rec.band == TempBand.freezing || rec.band == TempBand.cold;
+    return [
+      band,
+      if (rec.rainLikely) l10n.wearRainLikely,
+      if (rec.extremeHeat && rec.band != TempBand.hot) l10n.wearExtremeHeat,
+      if (rec.freezingNights && !coldish) l10n.wearFreezingNights,
+      if (rec.bigSwing && !coldish && rec.band != TempBand.cool)
+        l10n.wearBigSwing,
+    ];
+  }
+
+  String _dateRange(DateTime start, DateTime end) {
+    // DateFormat reads Intl.defaultLocale, set by the locale provider — same
+    // convention as trip_format.dart.
+    final fmt = DateFormat.MMMd();
+    final sameDay = start.year == end.year &&
+        start.month == end.month &&
+        start.day == end.day;
+    return sameDay ? fmt.format(start) : '${fmt.format(start)} – ${fmt.format(end)}';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final l10n = context.l10n;
+    final muted = theme.colorScheme.onSurfaceVariant;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        for (final region in regions)
+          Padding(
+            padding: const EdgeInsets.only(bottom: AppSpacing.sm),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  // Spaced temp dash like the date range beside it, so a
+                  // negative low never collides with the dash ("-6° – 2°").
+                  '${region.label} · ${_dateRange(region.start, region.end)}'
+                  ' · ${region.rec.loC}° – ${region.rec.hiC}°',
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: theme.textTheme.labelLarge?.copyWith(color: muted),
+                ),
+                const SizedBox(height: 2),
+                Text.rich(
+                  TextSpan(
+                    children: [
+                      // '  ·  ' joins throughout, and the qualifier keeps the
+                      // line's own size with italic+muted only — both the
+                      // _weatherChip treatment.
+                      TextSpan(text: _phrases(l10n, region.rec).join('  ·  ')),
+                      if (region.rec.historical)
+                        TextSpan(
+                          text: '  ·  ${l10n.tripTypicalForDates}',
+                          style: theme.textTheme.bodyMedium?.copyWith(
+                            color: muted,
+                            fontStyle: FontStyle.italic,
+                          ),
+                        ),
+                    ],
+                  ),
+                  style: theme.textTheme.bodyMedium,
+                ),
+              ],
+            ),
+          ),
+      ],
+    );
+  }
+}

--- a/src/packages/flutter-app/test/clothing_recs_test.dart
+++ b/src/packages/flutter-app/test/clothing_recs_test.dart
@@ -1,0 +1,170 @@
+// Pins the what-to-wear derivation (specs/what-to-wear): band edges, the
+// median-not-mean headline rule, any-day condition flags, the temperature
+// envelope, and the rain thresholds the day-chip glyph shares via rainLevel.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:travel_route_planner/models/weather.dart';
+import 'package:travel_route_planner/utils/clothing_recs.dart';
+
+WeatherDay day({
+  double lo = 10,
+  double hi = 20,
+  double mm = 0,
+  int? pct,
+}) =>
+    WeatherDay(
+      date: '2026-09-15',
+      tempMinC: lo,
+      tempMaxC: hi,
+      precipMm: mm,
+      precipProbability: pct,
+    );
+
+WeatherReport forecast(List<WeatherDay> days) =>
+    WeatherReport(location: 'Testville', kind: 'forecast', days: days);
+
+WeatherReport historical(List<WeatherDay> days) =>
+    WeatherReport(location: 'Testville', kind: 'historical', days: days);
+
+void main() {
+  group('rainLevel (shared with the day-chip glyph)', () {
+    test('forecast bands on probability: 60 likely, 30 some, below none', () {
+      expect(rainLevel(day(pct: 60)), RainLevel.likely);
+      expect(rainLevel(day(pct: 59)), RainLevel.some);
+      expect(rainLevel(day(pct: 30)), RainLevel.some);
+      expect(rainLevel(day(pct: 29)), RainLevel.none);
+      expect(rainLevel(day(pct: 0)), RainLevel.none);
+    });
+
+    test('historical bands on observed mm: 5 likely, 1 some, below none', () {
+      expect(rainLevel(day(mm: 5.0)), RainLevel.likely);
+      expect(rainLevel(day(mm: 4.9)), RainLevel.some);
+      expect(rainLevel(day(mm: 1.0)), RainLevel.some);
+      expect(rainLevel(day(mm: 0.9)), RainLevel.none);
+    });
+
+    test('probability wins over mm when both are present (forecast day)', () {
+      expect(rainLevel(day(pct: 10, mm: 9.0)), RainLevel.none);
+    });
+  });
+
+  group('temperature band from median daily high', () {
+    TempBand bandFor(List<double> highs) =>
+        clothingRec(forecast([for (final h in highs) day(hi: h, lo: h - 5)]))!
+            .band;
+
+    test('edges both sides', () {
+      expect(bandFor([0]), TempBand.freezing);
+      expect(bandFor([1]), TempBand.cold);
+      expect(bandFor([7]), TempBand.cold);
+      expect(bandFor([8]), TempBand.cool);
+      expect(bandFor([15]), TempBand.cool);
+      expect(bandFor([16]), TempBand.mild);
+      expect(bandFor([22]), TempBand.mild);
+      expect(bandFor([23]), TempBand.warm);
+      expect(bandFor([29]), TempBand.warm);
+      expect(bandFor([30]), TempBand.hot);
+    });
+
+    test('median, not mean: one freak hot day cannot flip a mild week', () {
+      final rec = clothingRec(forecast([
+        for (var i = 0; i < 6; i++) day(hi: 20, lo: 12),
+        day(hi: 35, lo: 22),
+      ]))!;
+      expect(rec.band, TempBand.mild);
+      // ...but the envelope and the any-day flag still expose it.
+      expect(rec.hiC, 35);
+      expect(rec.extremeHeat, isTrue);
+    });
+
+    test('even count takes the upper-middle element', () {
+      // highs sorted [10, 20] -> index 1 -> 20 -> mild (not cool).
+      final rec = clothingRec(forecast([day(hi: 10), day(hi: 20)]))!;
+      expect(rec.band, TempBand.mild);
+    });
+
+    test('band uses rounded highs', () {
+      expect(bandFor([29.4]), TempBand.warm);
+      expect(bandFor([29.6]), TempBand.hot);
+    });
+  });
+
+  group('any-day condition flags', () {
+    test('one likely-rain day among dry days sets rainLikely', () {
+      final rec = clothingRec(forecast([
+        day(pct: 0),
+        day(pct: 65),
+        day(pct: 10),
+      ]))!;
+      expect(rec.rainLikely, isTrue);
+    });
+
+    test('some-level rain alone does not set rainLikely', () {
+      final rec = clothingRec(forecast([day(pct: 45), day(pct: 30)]))!;
+      expect(rec.rainLikely, isFalse);
+    });
+
+    test('bigSwing at spread 12, not 11', () {
+      expect(clothingRec(forecast([day(hi: 21, lo: 10)]))!.bigSwing, isFalse);
+      expect(clothingRec(forecast([day(hi: 22, lo: 10)]))!.bigSwing, isTrue);
+    });
+
+    test('extremeHeat at 34 / freezingNights at 0 (any day)', () {
+      final rec = clothingRec(forecast([
+        day(hi: 25, lo: 15),
+        day(hi: 34, lo: 18),
+      ]))!;
+      expect(rec.extremeHeat, isTrue);
+      expect(rec.freezingNights, isFalse);
+
+      final cold = clothingRec(forecast([
+        day(hi: 8, lo: 2),
+        day(hi: 6, lo: 0),
+      ]))!;
+      expect(cold.extremeHeat, isFalse);
+      expect(cold.freezingNights, isTrue);
+
+      expect(clothingRec(forecast([day(hi: 33.9, lo: 0.1)]))!.extremeHeat,
+          isFalse);
+      expect(clothingRec(forecast([day(hi: 33.9, lo: 0.1)]))!.freezingNights,
+          isFalse);
+    });
+  });
+
+  group('envelope and report handling', () {
+    test('loC/hiC are the rounded min-of-lows / max-of-highs', () {
+      final rec = clothingRec(forecast([
+        day(hi: 21.4, lo: 9.6),
+        day(hi: 24.6, lo: 12.2),
+      ]))!;
+      expect(rec.loC, 10);
+      expect(rec.hiC, 25);
+    });
+
+    test('empty report derives nothing', () {
+      expect(clothingRec(const WeatherReport()), isNull);
+      expect(clothingRec(forecast(const [])), isNull);
+    });
+
+    test('historical passthrough', () {
+      expect(clothingRec(historical([day()]))!.historical, isTrue);
+      expect(clothingRec(forecast([day()]))!.historical, isFalse);
+    });
+  });
+
+  group('clothingSummary', () {
+    test('merges the cross-region envelope and any-region rain', () {
+      final lisbon = clothingRec(forecast([day(hi: 28, lo: 17)]))!;
+      final porto = clothingRec(forecast([day(hi: 21, lo: 12, pct: 70)]))!;
+      final s = clothingSummary([lisbon, porto]);
+      expect(s.loC, 12);
+      expect(s.hiC, 28);
+      expect(s.rainLikely, isTrue);
+    });
+
+    test('no rain anywhere stays dry', () {
+      final s = clothingSummary([clothingRec(forecast([day()]))!]);
+      expect(s.rainLikely, isFalse);
+    });
+  });
+}

--- a/src/packages/flutter-app/test/trip_detail_fix_actions_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_fix_actions_test.dart
@@ -355,8 +355,9 @@ void main() {
   testWidgets('trailing cluster leads with Trip health, empty rows trail',
       (tester) async {
     // Layout contract (friction-log 2026-08-04): the cluster is ordered
-    // Trip health → Packing & prep → Budget, so actionable review state is
-    // met before the empty-state rows.
+    // Trip health → What to wear & pack → Budget, so actionable review state
+    // is met before the empty-state rows. (The packing slot was retitled by
+    // the merged what-to-wear section, specs/what-to-wear.)
     final review = _FakeReviewApiService([
       _finding('packing', 'No umbrella for rainy Athens',
           const FindingFix(
@@ -373,7 +374,7 @@ void main() {
 
     // The tall test viewport lays out the whole cluster in one frame.
     final healthY = tester.getTopLeft(find.text('Trip health')).dy;
-    final packingY = tester.getTopLeft(find.text('Packing & prep')).dy;
+    final packingY = tester.getTopLeft(find.text('What to wear & pack')).dy;
     final budgetY = tester.getTopLeft(find.text('Budget')).dy;
     expect(healthY, lessThan(packingY));
     expect(packingY, lessThan(budgetY));

--- a/src/packages/flutter-app/test/trip_detail_wear_section_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_wear_section_test.dart
@@ -1,0 +1,388 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:intl/intl.dart';
+import 'package:intl/date_symbol_data_local.dart';
+
+import 'package:travel_route_planner/models/checklist_item.dart';
+import 'package:travel_route_planner/models/itinerary_item.dart';
+import 'package:travel_route_planner/models/trip.dart';
+import 'package:travel_route_planner/models/weather.dart';
+import 'package:travel_route_planner/services/api_client.dart';
+import 'package:travel_route_planner/services/checklist_api_service.dart';
+import 'package:travel_route_planner/services/trips_api_service.dart';
+import 'package:travel_route_planner/services/weather_api_service.dart';
+import 'package:travel_route_planner/providers/checklist_provider.dart';
+import 'package:travel_route_planner/providers/trips_provider.dart';
+import 'package:travel_route_planner/providers/weather_provider.dart';
+import 'package:travel_route_planner/screens/trip_detail_screen.dart';
+import 'package:travel_route_planner/widgets/collapsible_section.dart';
+import 'package:travel_route_planner/widgets/wear_recs.dart';
+
+import 'support/l10n_test_app.dart';
+
+/// The merged "What to wear & pack" section (specs/what-to-wear): collapsed
+/// summary = cross-region temperature envelope + rain signal; expanded =
+/// per-region deterministic phrases above the intact checklist; historical
+/// reports carry the "typical" qualifier ON THE WEAR ROW; a revisited city
+/// gets one row per visit with per-visit weather queries; a leg whose report
+/// is empty drops out without hiding the section; recommendations alone show
+/// the row for read-only viewers; without weather the old checklist gating
+/// holds.
+
+class _FakeTripsApiService extends TripsApiService {
+  final Trip trip;
+  _FakeTripsApiService(this.trip) : super(ApiClient(baseUrl: 'http://test'));
+
+  @override
+  Future<Trip> getTrip(String id) async => trip;
+}
+
+/// One fixed report for every lookup — enough when every leg should resolve
+/// the same way.
+class _FakeWeatherApiService extends WeatherApiService {
+  final WeatherReport report;
+  _FakeWeatherApiService(this.report)
+      : super(ApiClient(baseUrl: 'http://test'));
+
+  @override
+  Future<WeatherReport> getTripWeather(String city, String startDate,
+          {String? endDate}) async =>
+      report;
+}
+
+/// Per-window reports keyed '<city>|<startDate>', recording every query — for
+/// pinning per-visit windows and the empty-report drop-out. Unknown keys get
+/// an empty report (the server's own failure contract).
+class _MapWeatherApiService extends WeatherApiService {
+  final Map<String, WeatherReport> byKey;
+  final List<String> calls = [];
+  _MapWeatherApiService(this.byKey) : super(ApiClient(baseUrl: 'http://test'));
+
+  @override
+  Future<WeatherReport> getTripWeather(String city, String startDate,
+      {String? endDate}) async {
+    final key = '$city|$startDate';
+    calls.add(key);
+    return byKey[key] ?? const WeatherReport();
+  }
+}
+
+class _FakeChecklistApiService extends ChecklistApiService {
+  final List<ChecklistItem> items;
+  _FakeChecklistApiService(this.items)
+      : super(ApiClient(baseUrl: 'http://test'));
+
+  @override
+  Future<List<ChecklistItem>> list(String tripId) async => items;
+}
+
+ItineraryItem _item(int pos, String name, int day, {String city = 'Paris'}) =>
+    ItineraryItem(
+      id: 'i$pos',
+      position: pos,
+      name: name,
+      address: '$name street, $city',
+      latitude: 0,
+      longitude: 0,
+      category: 'attraction',
+      day: day,
+      city: city,
+    );
+
+Trip _trip({String? access, List<ItineraryItem>? items, String? endDate}) =>
+    Trip(
+      id: 't1',
+      title: 'Paris',
+      status: 'planned',
+      createdAt: '2026-06-01',
+      updatedAt: '2026-06-01',
+      startDate: '2026-09-15',
+      endDate: endDate ?? '2026-09-16',
+      access: access,
+      items: items ??
+          [
+            _item(0, 'Louvre', 1),
+            _item(1, 'Orsay', 2),
+          ],
+    );
+
+/// Warm + rainy forecast: envelope 15° – 24°, median high 24 → warm band,
+/// day 1 at 70% → rain likely; spreads under 12 → no swing flag.
+final _warmRainyForecast = WeatherReport(
+  location: 'Paris, France',
+  kind: 'forecast',
+  days: const [
+    WeatherDay(
+        date: '2026-09-15', tempMinC: 16, tempMaxC: 24, precipProbability: 70),
+    WeatherDay(
+        date: '2026-09-16', tempMinC: 15, tempMaxC: 22, precipProbability: 10),
+  ],
+);
+
+final _dryHistorical = WeatherReport(
+  location: 'Paris, France',
+  kind: 'historical',
+  days: const [
+    WeatherDay(date: '2025-09-15', tempMinC: 18, tempMaxC: 27),
+    WeatherDay(date: '2025-09-16', tempMinC: 17, tempMaxC: 26),
+  ],
+);
+
+Future<void> _pump(
+  WidgetTester tester, {
+  required Trip trip,
+  WeatherReport? report,
+  WeatherApiService? weather,
+  List<ChecklistItem> checklist = const [],
+  Locale? locale,
+}) async {
+  // Tall viewport so the trailing cluster lays out without scrolling.
+  tester.view.physicalSize = const Size(800, 3000);
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.reset);
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        tripsApiServiceProvider.overrideWithValue(_FakeTripsApiService(trip)),
+        weatherApiServiceProvider
+            .overrideWithValue(weather ?? _FakeWeatherApiService(report!)),
+        checklistApiServiceProvider
+            .overrideWithValue(_FakeChecklistApiService(checklist)),
+      ],
+      child: localizedTestApp(
+          home: TripDetailScreen(tripId: 't1'), locale: locale),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+Future<void> _expand(WidgetTester tester,
+    {String title = 'What to wear & pack'}) async {
+  await tester.ensureVisible(find.text(title));
+  await tester.tap(find.text(title));
+  await tester.pumpAndSettle();
+}
+
+/// Finder scoped to the wear block, so day-chip text (which shares strings
+/// like the "typical" qualifier) can never satisfy a wear-row assertion.
+Finder _inRecs(String text) => find.descendant(
+    of: find.byType(WearRecsList), matching: find.textContaining(text));
+
+Finder _wearSectionDividers() => find.descendant(
+    of: find.widgetWithText(CollapsibleSection, 'What to wear & pack'),
+    matching: find.byType(Divider));
+
+void main() {
+  testWidgets('collapsed row shows the envelope summary and the checked pill',
+      (tester) async {
+    await _pump(
+      tester,
+      trip: _trip(),
+      report: _warmRainyForecast,
+      checklist: const [
+        ChecklistItem(id: 'c1', category: 'general', title: 'Umbrella'),
+        ChecklistItem(
+            id: 'c2', category: 'clothing', title: 'Jacket', checked: true),
+      ],
+    );
+
+    expect(find.text('What to wear & pack'), findsOneWidget);
+    expect(find.text('15° – 24° · rain likely'), findsOneWidget);
+    // Checked count stays glanceable via the pill while recs own the summary.
+    expect(find.text('1/2'), findsOneWidget);
+    // Collapsed: no phrases, no checklist rows.
+    expect(find.textContaining('Warm —'), findsNothing);
+    expect(find.text('Umbrella'), findsNothing);
+  });
+
+  testWidgets('expanded: per-region phrase rows above the intact checklist',
+      (tester) async {
+    await _pump(
+      tester,
+      trip: _trip(),
+      report: _warmRainyForecast,
+      checklist: const [
+        ChecklistItem(id: 'c1', category: 'general', title: 'Umbrella'),
+      ],
+    );
+    await _expand(tester);
+
+    // Region line: label · dates · envelope.
+    expect(_inRecs('Paris · Sep 15 – Sep 16 · 15° – 24°'), findsOneWidget);
+    // Band phrase plus the rain flag, joined on one line; no "typical" for a
+    // forecast, and no swing flag for these mild spreads.
+    expect(_inRecs('Warm — summer clothes, a light evening layer'),
+        findsOneWidget);
+    expect(_inRecs('rain likely, pack an umbrella'), findsOneWidget);
+    expect(_inRecs('typical for these dates'), findsNothing);
+    expect(_inRecs('big day–night range'), findsNothing);
+    // Recs and checklist both present → exactly one separating divider.
+    expect(_wearSectionDividers(), findsOneWidget);
+    // The checklist renders below, still editable: item row + add field.
+    expect(find.text('Umbrella'), findsOneWidget);
+    expect(find.byType(Checkbox), findsOneWidget);
+    expect(find.byType(TextField), findsWidgets);
+  });
+
+  testWidgets('historical report carries the typical qualifier on its row',
+      (tester) async {
+    await _pump(
+      tester,
+      trip: _trip(),
+      report: _dryHistorical,
+      checklist: const [
+        ChecklistItem(id: 'c1', category: 'general', title: 'Umbrella'),
+      ],
+    );
+    await _expand(tester);
+
+    expect(_inRecs('Warm — summer clothes'), findsOneWidget);
+    // Scoped to the wear block: the day chips also render this string, so an
+    // unscoped find would pass even if the wear row dropped it.
+    expect(_inRecs('typical for these dates'), findsOneWidget);
+    // Dry historical days: no rain phrase, summary has no rain suffix.
+    expect(find.textContaining('rain likely'), findsNothing);
+    expect(find.text('17° – 27°'), findsOneWidget);
+  });
+
+  testWidgets('a revisited city gets one row per visit, queried per window',
+      (tester) async {
+    // Paris (day 1) → Nice (day 2) → Paris (day 3): the wear rows must come
+    // from the leg LIST, not a label-keyed map (which would collapse the two
+    // Paris visits into the last window).
+    final weather = _MapWeatherApiService({
+      'Paris|2026-09-15': const WeatherReport(kind: 'forecast', days: [
+        WeatherDay(date: '2026-09-15', tempMinC: 10, tempMaxC: 18),
+      ]),
+      'Nice|2026-09-16': const WeatherReport(kind: 'forecast', days: [
+        WeatherDay(date: '2026-09-16', tempMinC: 14, tempMaxC: 22),
+      ]),
+      'Paris|2026-09-17': const WeatherReport(kind: 'forecast', days: [
+        WeatherDay(date: '2026-09-17', tempMinC: 16, tempMaxC: 25),
+      ]),
+    });
+    await _pump(
+      tester,
+      trip: _trip(endDate: '2026-09-17', items: [
+        _item(0, 'Louvre', 1),
+        _item(1, 'Promenade', 2, city: 'Nice'),
+        _item(2, 'Orsay', 3),
+      ]),
+      weather: weather,
+    );
+    await _expand(tester);
+
+    // Two Paris rows with their own visit windows and temps, Nice between.
+    // Displayed dates are the VISIBLE ranges (arrival-inclusive, matching the
+    // city headers); the weather queries below stay on the raw windows.
+    expect(_inRecs('Paris · Sep 15 · 10° – 18°'), findsOneWidget);
+    expect(_inRecs('Nice · Sep 15 – Sep 16 · 14° – 22°'), findsOneWidget);
+    expect(_inRecs('Paris · Sep 16 – Sep 17 · 16° – 25°'), findsOneWidget);
+    // Both Paris visit windows were genuinely queried (per-visit keys).
+    expect(weather.calls, contains('Paris|2026-09-15'));
+    expect(weather.calls, contains('Paris|2026-09-17'));
+    // Collapsed summary spans all three legs: 10..25, no rain.
+    expect(find.text('10° – 25°'), findsOneWidget);
+  });
+
+  testWidgets('a leg with an empty report drops out; the rest still render',
+      (tester) async {
+    final weather = _MapWeatherApiService({
+      'Paris|2026-09-15': const WeatherReport(kind: 'forecast', days: [
+        WeatherDay(date: '2026-09-15', tempMinC: 16, tempMaxC: 24),
+      ]),
+      // Nice deliberately absent → empty report (provider failure contract).
+    });
+    await _pump(
+      tester,
+      trip: _trip(items: [
+        _item(0, 'Louvre', 1),
+        _item(1, 'Promenade', 2, city: 'Nice'),
+      ]),
+      weather: weather,
+    );
+
+    // Summary is Paris's envelope alone — the unresolved leg can't zero it.
+    expect(find.text('16° – 24°'), findsOneWidget);
+    await _expand(tester);
+    expect(_inRecs('Paris · Sep 15'), findsOneWidget);
+    expect(_inRecs('Nice'), findsNothing);
+  });
+
+  testWidgets('read-only viewer with an empty checklist still sees the recs',
+      (tester) async {
+    await _pump(
+      tester,
+      trip: _trip(access: 'viewer'),
+      report: _warmRainyForecast,
+    );
+
+    expect(find.text('What to wear & pack'), findsOneWidget);
+    expect(find.text('15° – 24° · rain likely'), findsOneWidget);
+    // No checked pill for an empty checklist.
+    expect(find.text('0/0'), findsNothing);
+
+    await _expand(tester);
+    expect(_inRecs('Warm — summer clothes'), findsOneWidget);
+    // Viewer + empty checklist: no add affordance, no checkboxes, and no
+    // dangling divider under the recs (the checklist rendered nothing).
+    expect(find.byType(Checkbox), findsNothing);
+    expect(find.textContaining('Add an item'), findsNothing);
+    expect(_wearSectionDividers(), findsNothing);
+  });
+
+  testWidgets('no weather: gating is exactly the old checklist behavior',
+      (tester) async {
+    // Viewer + empty checklist + empty weather → no section at all.
+    await _pump(
+      tester,
+      trip: _trip(access: 'viewer'),
+      report: const WeatherReport(),
+    );
+    expect(find.text('What to wear & pack'), findsNothing);
+  });
+
+  testWidgets('no weather, owner: checklist-only row with the count summary',
+      (tester) async {
+    await _pump(
+      tester,
+      trip: _trip(),
+      report: const WeatherReport(),
+      checklist: const [
+        ChecklistItem(id: 'c1', category: 'general', title: 'Umbrella'),
+      ],
+    );
+
+    expect(find.text('What to wear & pack'), findsOneWidget);
+    // Old summary shape (checked of total), no envelope text anywhere.
+    expect(find.textContaining('° – '), findsNothing);
+    expect(find.textContaining('0/1'), findsNothing); // count is not a pill…
+    expect(find.textContaining('0 of 1'), findsOneWidget); // …but the summary
+  });
+
+  testWidgets('renders the Spanish strings under the es locale',
+      (tester) async {
+    // The locale provider sets Intl.defaultLocale in the real app; tests set
+    // it explicitly (same pattern as guides_polish_test.dart).
+    await initializeDateFormatting('es');
+    Intl.defaultLocale = 'es';
+    addTearDown(() => Intl.defaultLocale = null);
+
+    await _pump(
+      tester,
+      trip: _trip(),
+      report: _warmRainyForecast,
+      locale: const Locale('es'),
+    );
+
+    expect(find.text('Qué ponerte y qué llevar'), findsOneWidget);
+    expect(find.textContaining('lluvia probable'), findsWidgets);
+    await _expand(tester, title: 'Qué ponerte y qué llevar');
+    expect(
+        find.descendant(
+            of: find.byType(WearRecsList),
+            matching: find.textContaining('Cálido — ropa de verano')),
+        findsOneWidget);
+  });
+}

--- a/src/packages/flutter-app/test/trip_detail_weather_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_weather_test.dart
@@ -102,18 +102,21 @@ void main() {
         WeatherDay(
             date: '2000-$md1', tempMinC: 16, tempMaxC: 24, precipProbability: 70),
         WeatherDay(
-            date: '2000-$md2', tempMinC: 15, tempMaxC: 22, precipProbability: 10),
+            date: '2000-$md2', tempMinC: 15, tempMaxC: 22, precipProbability: 40),
       ],
     );
     await _pump(tester, _twoDayTrip(start), report);
 
-    // Hi/lo temps rendered (rounded) for both days. Day 1 folds the rain
+    // Hi/lo temps rendered (rounded) for both days. Both days fold the rain
     // chance into the same Text, so match on substring.
     expect(find.textContaining('24° / 16°'), findsOneWidget);
-    expect(find.text('22° / 15°'), findsOneWidget);
-    // The rainy day surfaces its chance; the umbrella glyph appears.
+    expect(find.textContaining('22° / 15°'), findsOneWidget);
+    // Each rain tier keeps its glyph through the rainLevel refactor
+    // (specs/what-to-wear): 70% → umbrella, 40% → cloud.
     expect(find.textContaining('70% rain'), findsOneWidget);
+    expect(find.textContaining('40% rain'), findsOneWidget);
     expect(find.byIcon(Icons.umbrella), findsWidgets);
+    expect(find.byIcon(Icons.cloud), findsOneWidget);
     // Forecast, so no "typical" affordance.
     expect(find.textContaining('typical'), findsNothing);
   });
@@ -132,8 +135,10 @@ void main() {
 
     expect(find.text('27° / 18°'), findsOneWidget);
     expect(find.textContaining('typical for these dates'), findsWidgets);
-    // Historical never shows a rain-chance percentage.
+    // Historical never shows a rain-chance percentage; dry days keep the
+    // sunny glyph (RainLevel.none tier).
     expect(find.textContaining('% rain'), findsNothing);
+    expect(find.byIcon(Icons.wb_sunny), findsWidgets);
   });
 
   test('dayFor falls back to the nearest adjacent day for a missing 02-29',


### PR DESCRIPTION
## Summary
- The trip-detail "Packing & prep" row becomes **"What to wear & pack"** (specs/what-to-wear): deterministic per-region clothing recommendations derived from the weather reports the screen already fetches, rendered above the intact editable checklist. Collapsed, the row shows the cross-region temperature envelope + rain signal (e.g. `15° – 24° · rain likely`); the checked count moves to a pill.
- New pure util `lib/utils/clothing_recs.dart` is the client's one definition of weather thresholds: the day-chip glyph and its %-caption cutoff now consume it, and the extreme-heat/freezing edges equal the Go trip review's constants so Trip-health findings and recommendations can never contradict on one screen. Bands from the **median** daily high (freezing ≤0 · cold ≤7 · cool ≤15 · mild ≤22 · warm ≤29 · hot ≥30), any-day flags for rain / big day–night swing / extreme heat / freezing nights.
- Weather queries stay on `rawLegRanges` (the doc-pinned source — byte-identical WeatherQuery keys to the city-group chips, so the provider family dedups); displayed dates come from the index-aligned `visibleLegRanges` pair so rows always match the city headers. Revisited cities get one row per visit (per-visit windows).
- Read-only viewers see the recommendations even with an empty checklist; offline/no-weather reduces bit-identically to the old gating. Checklist backend, agent `add_packing_item`, Trip-health one-tap fixes, export/print: all unchanged. Client-only — no Go changes, no migration; 12 new `wear*` l10n keys (en+es).

## Testing
- `flutter analyze` clean (3 pre-existing infos in untouched `route_response.dart`).
- Full suite green: **765 tests** (`make flutter-test`), including new `clothing_recs_test.dart` (band/rain/swing edges, median-vs-outlier, envelope, glyph-threshold pins) and `trip_detail_wear_section_test.dart` (collapsed summary+pill, expanded rows+checklist, historical "typical" qualifier scoped to the wear block, revisited-city per-visit rows + recorded query windows, empty-report leg drop-out, read-only viewer, no-weather gating, es-locale rendering).
- `l10n_untranslated.json` empty after gen-l10n.
- Multi-agent adversarial review (4 lenses, majority-vote verification): 15 confirmed findings all addressed — notably raw-vs-visible display dates, honest fetch-sharing comments, es title rework, and five tightened/added test pins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)