### PR TITLE
perf(api): hourly janitor for hot-path cleanup, MinConns=2, shared HTTP transport

### DIFF
--- a/src/packages/api/apple_oauth.go
+++ b/src/packages/api/apple_oauth.go
@@ -26,7 +26,7 @@ import (
 // .p8 key (not a static string), PKCE is not supported, and the callback is a
 // form_post POST (see apple_auth_handler.go).
 
-var appleOAuthHTTPClient = &http.Client{Timeout: 15 * time.Second}
+var appleOAuthHTTPClient = newUpstreamClient(15 * time.Second)
 
 func appleTeamID() string   { return os.Getenv("APPLE_TEAM_ID") }
 func appleClientID() string { return os.Getenv("APPLE_CLIENT_ID") } // the Services ID

--- a/src/packages/api/auth_handler.go
+++ b/src/packages/api/auth_handler.go
@@ -179,7 +179,8 @@ func authMiddleware(next http.Handler) http.Handler {
 			writeJSONError(w, http.StatusUnauthorized, "invalid or expired session")
 			return
 		}
-		_ = q.DeleteExpiredSessions(r.Context()) // opportunistic cleanup
+		// Expired-session rows are pruned by the hourly janitor (janitor.go);
+		// the ExpiresAt check above is what actually rejects stale tokens.
 		ctx := context.WithValue(r.Context(), userContextKey, row.User)
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})

--- a/src/packages/api/chat_session_handler.go
+++ b/src/packages/api/chat_session_handler.go
@@ -118,7 +118,8 @@ func savePlanChatSession(ctx context.Context, uid uuid.UUID, chatID, summary str
 func listChatSessionsHandler(w http.ResponseWriter, r *http.Request) {
 	user, _ := userFromContext(r.Context())
 	q := store.New(dbPool)
-	_ = q.DeleteStalePlanChatSessions(r.Context()) // opportunistic prune
+	// Stale sessions (idle 60+ days) are pruned by the hourly janitor
+	// (janitor.go), no longer opportunistically on every list request.
 	rows, err := q.ListResumablePlanChatSessions(r.Context(), user.ID)
 	if err != nil {
 		writeJSONError(w, http.StatusInternalServerError, "could not load conversations")

--- a/src/packages/api/db.go
+++ b/src/packages/api/db.go
@@ -44,7 +44,12 @@ func initDB(ctx context.Context, databaseURL string) (*pgxpool.Pool, error) {
 	// connections. HealthCheckPeriod actively pings idle conns so a mid-idle
 	// server restart is noticed and the conn replaced before a request grabs it.
 	cfg.MaxConns = 10
-	cfg.MinConns = 0
+	// MinConns = 2 keeps a couple of warm connections through quiet periods.
+	// With MinConns = 0, MaxConnIdleTime (5m) drains the pool to zero on a
+	// quiet single-user deployment, so the first click after any idle stretch
+	// paid a fresh TCP + TLS + Postgres-auth handshake before its query ran.
+	// The pool's background health check maintains the floor.
+	cfg.MinConns = 2
 	cfg.ConnConfig.ConnectTimeout = 5 * time.Second
 	cfg.HealthCheckPeriod = 30 * time.Second
 	cfg.MaxConnLifetime = 1 * time.Hour

--- a/src/packages/api/duffel_service.go
+++ b/src/packages/api/duffel_service.go
@@ -176,7 +176,7 @@ func NewDuffelService() *DuffelService {
 		Token:       token,
 		BaseURL:     strings.TrimRight(baseURL, "/"),
 		Version:     version,
-		Client:      &http.Client{Timeout: 60 * time.Second},
+		Client:      newUpstreamClient(60 * time.Second),
 		placesCache: newTTLCache[[]Airport](24*time.Hour, 5000),
 	}
 }

--- a/src/packages/api/events_service.go
+++ b/src/packages/api/events_service.go
@@ -80,7 +80,7 @@ func NewEventsService() *EventsService {
 	return &EventsService{
 		APIKey:  apiKey,
 		BaseURL: strings.TrimRight(baseURL, "/"),
-		Client:  &http.Client{Timeout: 30 * time.Second},
+		Client:  newUpstreamClient(30 * time.Second),
 		cache:   newTTLCache[[]Event](eventsCacheTTL, 1000),
 	}
 }

--- a/src/packages/api/google_oauth.go
+++ b/src/packages/api/google_oauth.go
@@ -21,7 +21,7 @@ import (
 // read lazily per request so tests can t.Setenv, and the endpoint URLs have
 // overrides as a test seam (same idea as ANTHROPIC_BASE_URL).
 
-var googleOAuthHTTPClient = &http.Client{Timeout: 15 * time.Second}
+var googleOAuthHTTPClient = newUpstreamClient(15 * time.Second)
 
 func googleOAuthClientID() string     { return os.Getenv("GOOGLE_OAUTH_CLIENT_ID") }
 func googleOAuthClientSecret() string { return os.Getenv("GOOGLE_OAUTH_CLIENT_SECRET") }

--- a/src/packages/api/http_client.go
+++ b/src/packages/api/http_client.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"net/http"
+	"time"
+)
+
+// sharedTransport is the one process-wide *http.Transport behind every
+// outbound upstream client (Places, weather, events, Duffel, SerpApi,
+// transcription, Google/Apple OAuth). Each service previously built its own
+// &http.Client{} with a nil Transport, which gave every service a private
+// connection pool sized by DefaultTransport's MaxIdleConnsPerHost of 2 — so
+// hot upstreams (Google Places under the /plan agent loop) paid a fresh
+// TCP+TLS handshake on most calls. One shared transport means one pool of
+// warm keep-alive connections across the process.
+//
+// Cloned from http.DefaultTransport so we inherit its proxy/dialer/TLS
+// defaults and only override pool sizing.
+var sharedTransport = func() *http.Transport {
+	t := http.DefaultTransport.(*http.Transport).Clone()
+	t.MaxIdleConns = 100
+	t.MaxIdleConnsPerHost = 16
+	t.IdleConnTimeout = 90 * time.Second
+	t.ForceAttemptHTTP2 = true
+	return t
+}()
+
+// newUpstreamClient builds an outbound client on the shared transport with
+// the caller's overall-request timeout. Timeouts stay per-service (a Duffel
+// offers search legitimately runs 60s; a Places lookup must die at 15s) —
+// only the connection pool is shared. Sites that need extra client fields
+// (e.g. the Places PhotoClient's CheckRedirect) construct their own
+// http.Client and set Transport: sharedTransport directly.
+func newUpstreamClient(timeout time.Duration) *http.Client {
+	return &http.Client{
+		Timeout:   timeout,
+		Transport: sharedTransport,
+	}
+}

--- a/src/packages/api/janitor.go
+++ b/src/packages/api/janitor.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"context"
+	"log"
+	"log/slog"
+	"math/rand"
+	"time"
+
+	"travel-route-planner/store"
+)
+
+// Background janitor (perf: hot-path tax removal). The expired-session and
+// stale-plan-chat prunes used to run opportunistically inside every
+// authenticated request (authMiddleware) and every GET /chats — a DELETE tax
+// on the hot path. They now run here, once an hour, off the request path.
+// Auth correctness is untouched: authMiddleware still rejects expired
+// sessions by timestamp comparison before any request proceeds; this loop
+// only reclaims dead rows. The opportunistic janitor call in
+// oauth_provider_handler.go is intentionally left in place — /oauth/authorize
+// is a rare path, not a hot one.
+//
+// Loop shape cloned from ops_monitor.go: jittered first tick (so restarts
+// don't synchronize prunes across processes), time.NewTicker, panic-safe per
+// tick via safeRun, context cancel for shutdown, dbPool-nil guard.
+
+const (
+	janitorInterval = time.Hour
+
+	// janitorTickTimeout bounds one tick's DB work so a wedged database can't
+	// pin a tick past its usefulness; the next tick retries anyway.
+	janitorTickTimeout = 30 * time.Second
+)
+
+// startJanitor launches the background loop. No-ops (with a log line) when
+// persistence is unavailable — with no DB there is nothing to prune; the
+// janitor resumes on next boot once a database is configured, exactly like
+// startHealthMonitor.
+func startJanitor(ctx context.Context) {
+	if dbPool == nil {
+		log.Printf("janitor: disabled (no database)")
+		return
+	}
+	go runJanitor(ctx)
+	log.Printf("janitor: started (tick %s)", janitorInterval)
+}
+
+func runJanitor(ctx context.Context) {
+	// Jitter the first tick so restarts don't synchronize a burst of prunes.
+	select {
+	case <-ctx.Done():
+		return
+	case <-time.After(time.Duration(rand.Int63n(int64(janitorInterval)))):
+	}
+	ticker := time.NewTicker(janitorInterval)
+	defer ticker.Stop()
+	for {
+		// Guard each tick: a panic in one cycle must not kill the ticker (and
+		// with it the whole process). Log-and-continue to the next tick.
+		safeRun("janitor tick", func() { janitorTick(ctx) })
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+	}
+}
+
+// janitorTick runs both prunes under one bounded context. The sqlc queries
+// are :exec (no affected-row count comes back), so the debug lines record
+// that the prune ran, not how many rows it reclaimed.
+func janitorTick(ctx context.Context) {
+	tickCtx, cancel := context.WithTimeout(ctx, janitorTickTimeout)
+	defer cancel()
+	q := store.New(dbPool)
+	if err := q.DeleteExpiredSessions(tickCtx); err != nil {
+		slog.Warn("janitor: delete expired sessions failed", "error", err)
+	} else {
+		slog.Debug("janitor: pruned expired sessions")
+	}
+	if err := q.DeleteStalePlanChatSessions(tickCtx); err != nil {
+		slog.Warn("janitor: delete stale plan chat sessions failed", "error", err)
+	} else {
+		slog.Debug("janitor: pruned stale plan chat sessions")
+	}
+}

--- a/src/packages/api/main.go
+++ b/src/packages/api/main.go
@@ -592,6 +592,10 @@ func main() {
 	// transitions (DB reachability + backup freshness); no-op in degraded mode.
 	startHealthMonitor(ctx)
 
+	// Background janitor (perf): hourly prune of expired sessions and stale
+	// plan-chat rows, moved off the request hot path; no-op in degraded mode.
+	startJanitor(ctx)
+
 	startServer(buildRouter())
 }
 

--- a/src/packages/api/migrations/00054_sessions_expires_at_idx.sql
+++ b/src/packages/api/migrations/00054_sessions_expires_at_idx.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+-- Perf (hot-path tax removal): DeleteExpiredSessions filters on expires_at,
+-- which had no index — every prune was a sequential scan over sessions. The
+-- prune now runs hourly in janitor.go instead of inside every authenticated
+-- request, and this index makes that tick an index scan.
+CREATE INDEX idx_sessions_expires_at ON sessions (expires_at);
+
+-- +goose Down
+DROP INDEX idx_sessions_expires_at;

--- a/src/packages/api/places_service.go
+++ b/src/packages/api/places_service.go
@@ -178,9 +178,10 @@ func NewGooglePlacesService() *GooglePlacesService {
 		// with a zero-value (no-timeout) client would stall the whole SSE
 		// stream forever. This is a hard backstop on top of the per-call
 		// context deadline threaded through each method.
-		Client: &http.Client{Timeout: 15 * time.Second},
+		Client: newUpstreamClient(15 * time.Second),
 		PhotoClient: &http.Client{
-			Timeout: 15 * time.Second,
+			Timeout:   15 * time.Second,
+			Transport: sharedTransport, // pool shared with Client; CheckRedirect is per-client
 			CheckRedirect: func(*http.Request, []*http.Request) error {
 				return http.ErrUseLastResponse
 			},

--- a/src/packages/api/serpapi_flights_service.go
+++ b/src/packages/api/serpapi_flights_service.go
@@ -80,7 +80,7 @@ func NewSerpapiFlightsService() *SerpapiFlightsService {
 	}
 	s := &SerpapiFlightsService{
 		BaseURL:     strings.TrimRight(baseURL, "/"),
-		Client:      &http.Client{Timeout: 60 * time.Second},
+		Client:      newUpstreamClient(60 * time.Second),
 		offersCache: newTTLCache[[]FlightOffer](serpapiCacheTTL, 500),
 		daily:       newDailyCounter(),
 	}

--- a/src/packages/api/transcription_service.go
+++ b/src/packages/api/transcription_service.go
@@ -60,7 +60,7 @@ func NewTranscriptionService() *TranscriptionService {
 		APIKey:  key,
 		BaseURL: strings.TrimRight(baseURL, "/"),
 		Model:   model,
-		Client:  &http.Client{Timeout: 60 * time.Second},
+		Client:  newUpstreamClient(60 * time.Second),
 	}
 }
 

--- a/src/packages/api/weather_service.go
+++ b/src/packages/api/weather_service.go
@@ -59,7 +59,7 @@ func NewWeatherService() *WeatherService {
 		GeocodeBaseURL:  "https://geocoding-api.open-meteo.com",
 		ForecastBaseURL: "https://api.open-meteo.com",
 		ArchiveBaseURL:  "https://archive-api.open-meteo.com",
-		Client:          &http.Client{Timeout: 10 * time.Second},
+		Client:          newUpstreamClient(10 * time.Second),
 		geoCache:        newTTLCache[geoResult](24*time.Hour, 500),
 		summaryCache:    newTTLCache[WeatherReport](3*time.Hour, 500),
 	}


### PR DESCRIPTION
## Summary
- **Hourly background janitor** (`janitor.go`, migration `00054_sessions_expires_at_idx.sql`): `DeleteExpiredSessions` and `DeleteStalePlanChatSessions` no longer run opportunistically inside every authenticated request / every `GET /chats` — they run once an hour in a background loop cloned from `ops_monitor.go`'s run-loop shape (jittered first tick, `time.NewTicker`, panic-safe per tick via `safeRun`, ctx cancel, per-tick 30s timeout context, `dbPool != nil` guard). New index `idx_sessions_expires_at` makes the prune an index scan. Auth correctness untouched — `authMiddleware` still rejects expired sessions by timestamp comparison. The `oauth_provider_handler.go` opportunistic janitor is intentionally left alone (rare path).
- **`db.go`**: `MinConns = 2` (was 0) — `MaxConnIdleTime` (5m) drained the pool to zero on a quiet single-user deployment, so the first click after idle paid a fresh TCP+TLS+Postgres-auth handshake.
- **Shared outbound HTTP transport** (`http_client.go`): one `*http.Transport` cloned from `http.DefaultTransport` (MaxIdleConns 100, MaxIdleConnsPerHost 16, IdleConnTimeout 90s, ForceAttemptHTTP2) + `newUpstreamClient(timeout)`, adopted at all 8 construction sites: `places_service.go` (both `Client` and `PhotoClient` — the PhotoClient keeps its `CheckRedirect` and sets `Transport: sharedTransport` directly), `weather_service.go`, `events_service.go`, `duffel_service.go`, `serpapi_flights_service.go`, `transcription_service.go`, `google_oauth.go`, `apple_oauth.go`. Every site's exact `Timeout` preserved; no site had other custom transport needs.

Notes for the integrator:
- The lane spec asked for affected-row counts in the janitor's debug logs, but both queries are sqlc `:exec` (no row count returned) and `query/*.sql` is out of this lane's manifest — the debug lines record that each prune ran (`slog.Debug`), errors log at `slog.Warn`.
- The 8 client-site files are edits beyond the lane's 4-file conflict manifest, but item 5 of the lane spec (and the plan file) explicitly lists them; none are touched by lane 1A (`plan_handler.go`/nginx) so no cross-lane conflict.
- `sqlc` is not installed on this machine, but `query/*.sql` and `store/` are byte-untouched, so `make api-sqlc` is a no-diff by construction.

## Testing
- `go build ./...`, `make api-fmt` (no diffs), `make api-vet`, `go test ./... -count=1` — all green.
- `grep -rn "DeleteExpiredSessions\|DeleteStalePlanChatSessions" --include='*.go'` (excluding store/) shows only `janitor.go` calls + the intentionally-kept oauth comment — no handler-path callers remain.
- Migration proven: ran the full chain against a throwaway `postgres:16` container — `goose: successfully migrated database to version: 54` and `\di idx_sessions_expires_at` shows the index on `sessions`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
