### PR TITLE
perf(gateway): origin gzip, api keepalive upstream, dedicated /plan SSE lane

### DIFF
--- a/dockerize/deployment/Dockerfile
+++ b/dockerize/deployment/Dockerfile
@@ -59,6 +59,7 @@ FROM nginx:alpine
 # separately so both shells can include/rely on them.
 COPY dockerize/deployment/nginx/default.conf /etc/nginx/conf.d/default.conf
 COPY dockerize/deployment/nginx/share-prerender-map.conf /etc/nginx/conf.d/share-prerender-map.conf
+COPY dockerize/deployment/nginx/perf.conf /etc/nginx/conf.d/perf.conf
 COPY dockerize/deployment/nginx/snippets/ /etc/nginx/snippets/
 COPY dockerize/static /usr/share/nginx/html/static
 COPY --from=flutter-build /app/build/web /usr/share/nginx/html/app

--- a/dockerize/deployment/nginx/perf.conf
+++ b/dockerize/deployment/nginx/perf.conf
@@ -1,0 +1,35 @@
+# Performance directives shared by every server shell in this image
+# (http scope — nginx.conf includes /etc/nginx/conf.d/*.conf). Baked into
+# the image next to default.conf; the production stack volume-mounts only
+# prod.conf and cloudflare-realip.conf over their targets, so this file
+# reaches production automatically.
+
+# Origin gzip. Cloudflare only compresses the edge→browser leg; the
+# droplet→edge tunnel leg and local deploys were shipping the ~5.5 MB
+# main.dart.js, fonts, and wasm completely raw.
+gzip on;
+gzip_comp_level 5;
+gzip_min_length 1024;
+gzip_vary on;
+gzip_proxied any;
+gzip_types
+    application/javascript
+    text/javascript
+    application/json
+    text/css
+    image/svg+xml
+    application/wasm
+    font/ttf
+    application/octet-stream
+    text/plain
+    application/manifest+json;
+
+# Keepalive pool to the Go API. Without an upstream block nginx dials a
+# fresh TCP connection to api:8080 for every proxied request — per-request
+# TCP churn the app's fan-out-heavy screens pay ~10× per navigation.
+# Locations that proxy_pass here must also set `proxy_set_header
+# Connection ""` (with proxy_http_version 1.1) or keepalive never engages.
+upstream api_backend {
+    server api:8080;
+    keepalive 16;
+}

--- a/dockerize/deployment/nginx/snippets/app-locations.conf
+++ b/dockerize/deployment/nginx/snippets/app-locations.conf
@@ -16,14 +16,52 @@ index index.html;
 include /etc/nginx/snippets/security-headers.conf;
 
 location /api/ {
-    proxy_pass http://api:8080;
+    # api_backend (nginx/perf.conf) keeps a keepalive pool to the Go API;
+    # clearing the Connection header is required for upstream keepalive
+    # over HTTP/1.1 (nginx otherwise sends "Connection: close").
+    proxy_pass http://api_backend;
     proxy_http_version 1.1;
+    proxy_set_header Connection "";
     # Above nginx's 1 MiB default for /transcribe audio clips and /plan
     # image attachments; the Go bodyLimitMiddleware enforces the real
     # per-endpoint caps (widest lane: 20 MiB for /plan).
     client_max_body_size 20m;
     proxy_read_timeout 180s;
     proxy_send_timeout 180s;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    # REPLACE (not append) X-Forwarded-For with the single peer address this
+    # gateway vouches for. The Go rate limiter (ratelimit.go clientIP) takes
+    # the RIGHTMOST XFF entry; appending would make that entry whatever peer
+    # dialed nginx — behind Cloudflare that is a CF edge IP, collapsing all
+    # users into shared rate-limit buckets. In production the realip module
+    # (production/nginx/cloudflare-realip.conf) has already rewritten
+    # $remote_addr to CF-Connecting-IP for connections from Cloudflare's
+    # ranges; direct peers keep their socket IP, so the value stays
+    # unspoofable either way. In the deployment stack (no realip conf)
+    # $remote_addr is nginx's actual peer — the same value
+    # $proxy_add_x_forwarded_for used to put rightmost.
+    proxy_set_header X-Forwarded-For $remote_addr;
+    proxy_set_header X-Forwarded-Proto $scheme;
+}
+
+# Dedicated SSE lane for the /plan agent stream. Exact match wins over the
+# /api/ prefix block above, so this — not /api/ — serves the one endpoint
+# that streams tokens: buffering fully off in both directions (no stutter,
+# no spooling 20 MiB image posts to disk before Go sees byte one), and
+# timeouts of 660s so the gateway outlives planMaxDuration (10 min) in
+# plan_handler.go instead of severing long tool-heavy turns.
+location = /api/v1/plan {
+    proxy_pass http://api_backend;
+    proxy_http_version 1.1;
+    proxy_set_header Connection "";
+    proxy_buffering off;
+    proxy_cache off;
+    proxy_request_buffering off;
+    chunked_transfer_encoding off;
+    client_max_body_size 20m;
+    proxy_read_timeout 660s;
+    proxy_send_timeout 660s;
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;
     # REPLACE (not append) X-Forwarded-For with the single peer address this
@@ -49,8 +87,9 @@ location /api/ {
 # timeout clears the MCP client's 300s ceiling. XFF is REPLACED for the same
 # reason as /api/ above.
 location = /mcp {
-    proxy_pass http://api:8080;
+    proxy_pass http://api_backend;
     proxy_http_version 1.1;
+    proxy_set_header Connection "";
     proxy_buffering off;
     proxy_cache off;
     chunked_transfer_encoding off;

--- a/dockerize/development/nginx/default.conf
+++ b/dockerize/development/nginx/default.conf
@@ -1,3 +1,36 @@
+# Top of a conf.d file is http scope — the gzip/upstream directives below
+# mirror dockerize/deployment/nginx/perf.conf so dev behaves like prod.
+
+# Origin gzip. Cloudflare only compresses the edge→browser leg in prod; the
+# droplet→edge tunnel leg and local deploys were shipping the multi-MB
+# main.dart.js, fonts, and wasm completely raw. Dev has no edge at all.
+gzip on;
+gzip_comp_level 5;
+gzip_min_length 1024;
+gzip_vary on;
+gzip_proxied any;
+gzip_types
+    application/javascript
+    text/javascript
+    application/json
+    text/css
+    image/svg+xml
+    application/wasm
+    font/ttf
+    application/octet-stream
+    text/plain
+    application/manifest+json;
+
+# Keepalive pool to the Go API. Without an upstream block nginx dials a
+# fresh TCP connection to api:8080 for every proxied request — per-request
+# TCP churn on the app's fan-out-heavy screens. Locations that proxy_pass
+# here must also set `proxy_set_header Connection ""` (with
+# proxy_http_version 1.1) or keepalive never engages.
+upstream api_backend {
+    server api:8080;
+    keepalive 16;
+}
+
 map $http_upgrade $connection_upgrade {
     default upgrade;
     ''      close;
@@ -8,8 +41,12 @@ server {
     server_name localhost;
 
     location /api/ {
-        proxy_pass http://api:8080;
+        # api_backend (top of this file) keeps a keepalive pool to the Go
+        # API; clearing the Connection header is required for upstream
+        # keepalive over HTTP/1.1.
+        proxy_pass http://api_backend;
         proxy_http_version 1.1;
+        proxy_set_header Connection "";
         # Above nginx's 1 MiB default for /transcribe audio clips and /plan
         # image attachments; the Go bodyLimitMiddleware enforces the real
         # per-endpoint caps (widest lane: 20 MiB for /plan).
@@ -22,12 +59,37 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 
+    # Dedicated SSE lane for the /plan agent stream — mirrors the
+    # deployment snippet. Exact match wins over the /api/ prefix block, so
+    # this serves the one endpoint that streams tokens: buffering fully off
+    # in both directions (no stutter, no spooling 20 MiB image posts to
+    # disk before Go sees byte one), and timeouts of 660s so the gateway
+    # outlives planMaxDuration (10 min) in plan_handler.go instead of
+    # severing long tool-heavy turns.
+    location = /api/v1/plan {
+        proxy_pass http://api_backend;
+        proxy_http_version 1.1;
+        proxy_set_header Connection "";
+        proxy_buffering off;
+        proxy_cache off;
+        proxy_request_buffering off;
+        chunked_transfer_encoding off;
+        client_max_body_size 20m;
+        proxy_read_timeout 660s;
+        proxy_send_timeout 660s;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
     # MCP connector (specs/mcp-connector) — same shape as the deployment
     # snippet so the MCP Inspector can drive http://localhost:3000/mcp.
     # Streamable HTTP can answer with SSE: no buffering, generous read timeout.
     location = /mcp {
-        proxy_pass http://api:8080;
+        proxy_pass http://api_backend;
         proxy_http_version 1.1;
+        proxy_set_header Connection "";
         proxy_buffering off;
         proxy_cache off;
         chunked_transfer_encoding off;
@@ -41,7 +103,7 @@ server {
 
     # Only the OAuth discovery documents — the rest of /.well-known/ stays free.
     location ~ ^/\.well-known/(oauth-protected-resource(/mcp)?|oauth-authorization-server|openid-configuration)$ {
-        proxy_pass http://api:8080;
+        proxy_pass http://api_backend;
         proxy_set_header Host $host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;

--- a/src/packages/api/plan_handler.go
+++ b/src/packages/api/plan_handler.go
@@ -124,11 +124,20 @@ func planHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/event-stream")
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Connection", "keep-alive")
+	// Tell nginx to never buffer this response, independent of location
+	// config — belt and braces with the gateway's dedicated /plan lane.
+	w.Header().Set("X-Accel-Buffering", "no")
 
 	if _, ok := w.(http.Flusher); !ok {
 		http.Error(w, "streaming not supported", http.StatusInternalServerError)
 		return
 	}
+	// Priming SSE comment, flushed before any body parsing or DB work:
+	// commits nginx/Cloudflare to streaming mode and gives the browser
+	// instant TTFB. The Dart client only parses `data: ` lines, so a
+	// comment frame is invisible to it.
+	fmt.Fprint(w, ": stream-open\n\n")
+	w.(http.Flusher).Flush()
 
 	// Overall wall-clock ceiling on the whole request (see planMaxDuration): a
 	// stuck stream eventually closes and frees its goroutine + concurrency slot.


### PR DESCRIPTION
## Summary

Wave 1 lane **1A `perf-nginx-gateway`** of the performance program.

- **NEW `dockerize/deployment/nginx/perf.conf`** (http-scope conf.d file): origin gzip (`gzip_comp_level 5`, min 1024, `gzip_vary`, `gzip_proxied any`, types covering JS/JSON/CSS/svg/wasm/ttf/octet-stream/plain/manifest) + `upstream api_backend { server api:8080; keepalive 16; }`. Cloudflare only compresses the edge→browser leg — the droplet→edge tunnel leg and local deploys were shipping ~5.5 MB of main.dart.js + fonts + wasm raw; the upstream block ends per-request TCP churn to the Go API.
- **Deployment Dockerfile** bakes `perf.conf` into `/etc/nginx/conf.d/` next to the existing nginx COPY lines. **Production's compose volume-mounts only `prod.conf` and `cloudflare-realip.conf`, so this baked conf.d file reaches prod automatically** — no deploy-side config change needed.
- **`app-locations.conf`**: `/api/` and `/mcp` now `proxy_pass http://api_backend` with `proxy_set_header Connection ""` (required for upstream keepalive over HTTP/1.1). NEW `location = /api/v1/plan` SSE lane (exact match beats the `/api/` prefix): `proxy_buffering off`, `proxy_cache off`, `proxy_request_buffering off` (20 MiB image posts no longer spool to nginx disk before Go sees byte one), `chunked_transfer_encoding off`, `client_max_body_size 20m`, read/send timeouts **660s** — outlives `planMaxDuration` (10 min) in `plan_handler.go` instead of severing long tool-heavy turns at 180s. Keeps the `/api/` block's REPLACE-semantics XFF style + rationale comment; all existing headers/behaviors preserved.
- **Dev nginx** (`dockerize/development/nginx/default.conf`) mirrors everything: top-of-file gzip + upstream (http scope), `= /api/v1/plan` block with dev's `$proxy_add_x_forwarded_for` XFF style, api-container proxy_pass targets switched to the upstream.
- **`plan_handler.go`**: sets `X-Accel-Buffering: no` with the other SSE headers, and writes a `: stream-open` SSE comment + flush immediately after the Flusher check — before any body parsing/DB work. Commits nginx/Cloudflare to streaming mode and gives the browser instant TTFB; the Dart client only parses `data: ` lines, so the comment frame is invisible to it.

## Testing

- `make api-fmt`, `make api-vet`, `go build ./...` — clean.
- `go test ./...` in `src/packages/api` — pass (incl. the fake-Anthropic SSE harness tests; the priming comment doesn't break event parsing).
- **nginx syntax**: `nginx -t` in one-off `nginx:alpine` containers with the full deployment layout mirrored the way the Dockerfile lays it out (default.conf + share-prerender-map.conf + perf.conf in conf.d, snippets dir at `/etc/nginx/snippets`) and with the dev config — both pass.
- **Runtime, on this lane's dev stack (`make wt-init` + `docker-dev-bg`, gateway :3002)**:
  - Gateway boots healthy; `/api/v1/health` OK through the proxy.
  - `curl -s -D - -H 'Accept-Encoding: gzip' localhost:3002/app/` → `Content-Encoding: gzip` + `Vary: Accept-Encoding` (also on main.dart.js path).
  - `curl -N -X POST localhost:3002/api/v1/plan` → `: stream-open` arrives instantly (**TTFB 2.2 ms**) followed by the normal SSE error event for the junk body.
  - Direct API probe confirms Go emits `X-Accel-Buffering: no` (nginx correctly consumes it as an internal instruction, so it doesn't reach the client).
  - `make api-test` — all tests pass through the new gateway config.
- Not validated here: the production `prod.conf` TLS shell itself (it includes the same `app-locations.conf` snippet that passed `nginx -t`, and `perf.conf` is http-scope, loaded identically from conf.d).

🤖 Generated with [Claude Code](https://claude.com/claude-code)