### PR TITLE
feat(flutter): column-align city date chips on trip detail

### DIFF
--- a/src/packages/flutter-app/lib/l10n/app_en.arb
+++ b/src/packages/flutter-app/lib/l10n/app_en.arb
@@ -829,12 +829,9 @@
       }
     }
   },
-  "tripLegDatesWithNights": "{range} · {count, plural, one{1 night} other{{count} nights}}",
-  "@tripLegDatesWithNights": {
+  "tripLegNights": "· {count, plural, one{1 night} other{{count} nights}}",
+  "@tripLegNights": {
     "placeholders": {
-      "range": {
-        "type": "String"
-      },
       "count": {
         "type": "int"
       }

--- a/src/packages/flutter-app/lib/l10n/app_es.arb
+++ b/src/packages/flutter-app/lib/l10n/app_es.arb
@@ -404,7 +404,7 @@
   "tripDayTripTo": "Excursión · {town}",
   "tripDayTripFallback": "Excursión",
   "tripTonight": "Esta noche: {stays}",
-  "tripLegDatesWithNights": "{range} · {count, plural, one{1 noche} other{{count} noches}}",
+  "tripLegNights": "· {count, plural, one{1 noche} other{{count} noches}}",
   "tripTravelMinutes": "{minutes} min",
   "tripTravelHours": "{hours} h",
   "tripTravelHoursMinutes": "{hours} h {minutes} min",

--- a/src/packages/flutter-app/lib/l10n/app_localizations.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations.dart
@@ -2522,11 +2522,11 @@ abstract class AppLocalizations {
   /// **'Tonight: {stays}'**
   String tripTonight(String stays);
 
-  /// No description provided for @tripLegDatesWithNights.
+  /// No description provided for @tripLegNights.
   ///
   /// In en, this message translates to:
-  /// **'{range} · {count, plural, one{1 night} other{{count} nights}}'**
-  String tripLegDatesWithNights(String range, int count);
+  /// **'· {count, plural, one{1 night} other{{count} nights}}'**
+  String tripLegNights(int count);
 
   /// No description provided for @tripTravelMinutes.
   ///

--- a/src/packages/flutter-app/lib/l10n/app_localizations_en.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations_en.dart
@@ -1367,14 +1367,14 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
-  String tripLegDatesWithNights(String range, int count) {
+  String tripLegNights(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
       other: '$count nights',
       one: '1 night',
     );
-    return '$range · $_temp0';
+    return '· $_temp0';
   }
 
   @override

--- a/src/packages/flutter-app/lib/l10n/app_localizations_es.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations_es.dart
@@ -1378,14 +1378,14 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
-  String tripLegDatesWithNights(String range, int count) {
+  String tripLegNights(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
       locale: localeName,
       other: '$count noches',
       one: '1 noche',
     );
-    return '$range · $_temp0';
+    return '· $_temp0';
   }
 
   @override

--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -96,6 +96,21 @@ const _kOtherPlaces = kOtherPlacesLabel;
 String _groupLabelText(AppLocalizations l10n, String label) =>
     label == _kOtherPlaces ? l10n.tripOtherPlaces : label;
 
+/// City-header date-chip parts, kept separate so the header can align them as
+/// columns across rows: [range] renders left-aligned after the calendar icon,
+/// [nights] (the localized "· N nights" suffix) renders flush right. Null
+/// [nights] = zero-night squeezed leg — no nights widget renders at all.
+typedef _LegDateChip = ({String range, String? nights});
+
+/// One city group as built by [_TripDetailScreenState._buildGroups] and
+/// consumed by [_TripDetailScreenState._cityHeader].
+typedef _CityGroup = ({
+  String key,
+  String label,
+  _LegDateChip? dateRange,
+  List<ItineraryItem> items
+});
+
 // Canonical API values. These are sent to the server (or matched against
 // server data), so they are NEVER translated — only their display labels are.
 // 'local', 'unbooked', and 'bookings' are client-only lenses: locals' picks
@@ -535,6 +550,29 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
   /// map-pinning and refine-dock breakpoints (a constraining wrapper would
   /// starve them and the map would never pin).
   static const double _contentMaxWidth = 900;
+
+  // ── City-header date-chip columns ─────────────────────────────────────
+  // Every header's chip renders inside one shared width measured per build
+  // ([_dateChipWidth]), so calendar icons, range starts, and nights suffixes
+  // form columns across rows.
+
+  /// Calendar icon size and trailing gap inside the chip — consumed by both
+  /// the render and the measurement ([_chipIconSpan]) so they cannot drift.
+  static const double _chipIconSize = 14;
+  static const double _chipIconGap = 4;
+  static const double _chipIconSpan = _chipIconSize + _chipIconGap;
+
+  /// Minimum gap between the range text and the nights suffix. Also the
+  /// error budget for TextPainter-vs-Text measurement divergence: a chip can
+  /// only spuriously ellipsize if measurement undershoots by more than this.
+  static const double _chipInnerGap = 8;
+
+  /// Pathological ceiling (kept from the pre-column layout): real localized
+  /// chips measure well under it; absurd text scales ellipsize instead of
+  /// overflowing the header row. Never scale this with the textScaler — the
+  /// chip is a rigid child of the header row and a scaled cap could exceed a
+  /// phone row's width.
+  static const double _chipMaxWidth = 200;
 
   /// Pinned-header heights, shared by the build method and the Today scroll
   /// math so the two can never drift apart.
@@ -1981,15 +2019,9 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
   /// apart or two live widgets share one GlobalKey and the itinerary fails to
   /// build. Repeats get a `#2`, `#3`, … suffix; the scroll helpers parse day
   /// keys with `lastIndexOf('#')`, so a suffixed key round-trips fine.
-  List<
-      ({
-        String key,
-        String label,
-        String? dateRange,
-        List<ItineraryItem> items
-      })> _buildGroups(
+  List<_CityGroup> _buildGroups(
     List<ItineraryItem> items,
-    Map<int, String> locationDates,
+    Map<int, _LegDateChip> locationDates,
   ) {
     return [
       for (final leg in tripLegs(items))
@@ -2134,20 +2166,58 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
         ),
       );
 
+  /// Shared width for every city-header date chip this build: max over groups
+  /// of icon + range + gap + nights, measured with the exact strings and the
+  /// exact style the chips render, capped at [_chipMaxWidth]. One width for
+  /// all rows is what makes the chips align as columns. Compute it as a
+  /// build-local alongside the groups list — never cache it in state: pinned
+  /// headers rebuild from the same pass as scrolling rows, and a stale cached
+  /// width would misalign them against fresh ones.
+  /// The one chip text style, shared by the chip Texts and the measurement
+  /// so the two cannot drift.
+  TextStyle? _chipTextStyle(ThemeData theme) =>
+      theme.textTheme.labelMedium?.copyWith(color: theme.colorScheme.primary);
+
+  double _dateChipWidth(List<_CityGroup> groups, ThemeData theme) {
+    var style = _chipTextStyle(theme);
+    // Text applies the boldText accessibility flag internally; TextPainter
+    // does not — merge it here or measurement undershoots the rendered width.
+    if (MediaQuery.boldTextOf(context)) {
+      style = style?.copyWith(fontWeight: FontWeight.bold);
+    }
+    final tp = TextPainter(
+      textDirection: Directionality.of(context),
+      // The TextScaler object, not a factor: Android 14+ scaling is nonlinear.
+      textScaler: MediaQuery.textScalerOf(context),
+      maxLines: 1,
+    );
+    double measure(String s) {
+      tp.text = TextSpan(text: s, style: style);
+      tp.layout();
+      // Whole px: a float-exact fit on the widest row would self-ellipsize.
+      return tp.width.ceilToDouble();
+    }
+
+    var w = 0.0;
+    for (final g in groups) {
+      final chip = g.dateRange;
+      if (chip == null) continue;
+      var cw = _chipIconSpan + measure(chip.range);
+      if (chip.nights != null) cw += _chipInnerGap + measure(chip.nights!);
+      if (cw > w) w = cw;
+    }
+    tp.dispose();
+    return w > _chipMaxWidth ? _chipMaxWidth : w;
+  }
+
   /// City group header: name, date range, refine + collapse controls. Pinned
   /// at the top of the scroll area while its group scrolls past; the opaque
   /// Material keeps items from showing through while pinned.
   Widget _cityHeader(
-      Trip trip,
-      ({
-        String key,
-        String label,
-        String? dateRange,
-        List<ItineraryItem> items
-      }) group,
-      ThemeData theme) {
+      Trip trip, _CityGroup group, ThemeData theme, double dateChipWidth) {
     final l10n = context.l10n;
     final cityCollapsed = !_expandedCities.contains(group.key);
+    final chipStyle = _chipTextStyle(theme);
     return HoverReveal(
       builder: (context, revealed) => Material(
         color: theme.scaffoldBackgroundColor,
@@ -2178,46 +2248,99 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
                             ?.copyWith(fontWeight: FontWeight.bold),
                       ),
                     ),
-                    if (group.dateRange != null) ...[
-                      Icon(Icons.event,
-                          size: 14, color: theme.colorScheme.primary),
-                      const SizedBox(width: 4),
+                    if (group.dateRange != null)
+                      // A rigid SizedBox at the per-build shared width
+                      // ([_dateChipWidth]), so calendar icons, range starts,
+                      // and nights suffixes form columns across rows.
                       // Deliberately NOT Flexible: a second flex child would
                       // split the free space with the label's Expanded and
-                      // drag the chip+chevron cluster off the right edge.
-                      // The fixed cap bounds the cluster instead — the
-                      // longest localized chip ("27 ago – 1 sep · 5 noches")
-                      // measures ~175px, so real text never truncates; only
-                      // pathological widths ellipsize rather than overflow.
-                      ConstrainedBox(
-                        constraints: const BoxConstraints(maxWidth: 200),
-                        child: Text(
-                          group.dateRange!,
-                          maxLines: 1,
-                          overflow: TextOverflow.ellipsis,
-                          style: theme.textTheme.labelMedium
-                              ?.copyWith(color: theme.colorScheme.primary),
+                      // drag the chip+chevron cluster off the right edge
+                      // (PR #307) — the inner Expanded on the range lives
+                      // inside the chip's own Row, invisible to the outer
+                      // flex accounting, and absorbs any deficit by
+                      // ellipsizing when the shared width hits the
+                      // pathological [_chipMaxWidth] cap; the nights suffix
+                      // keeps its intrinsic width flush right.
+                      MergeSemantics(
+                        // One utterance per chip ("Aug 24 – Aug 27 · 3
+                        // nights"), matching the pre-split reading order.
+                        child: SizedBox(
+                          width: dateChipWidth,
+                          child: Row(
+                            children: [
+                              Icon(Icons.event,
+                                  size: _chipIconSize,
+                                  color: theme.colorScheme.primary),
+                              const SizedBox(width: _chipIconGap),
+                              Expanded(
+                                child: Text(
+                                  group.dateRange!.range,
+                                  maxLines: 1,
+                                  overflow: TextOverflow.ellipsis,
+                                  style: chipStyle,
+                                ),
+                              ),
+                              if (group.dateRange!.nights != null) ...[
+                                const SizedBox(width: _chipInnerGap),
+                                ConstrainedBox(
+                                  // Guard: at extreme accessibility scale a
+                                  // nights label alone could exceed the
+                                  // capped chip — bound it so it ellipsizes
+                                  // instead of overflowing the inner Row.
+                                  constraints: const BoxConstraints(
+                                      maxWidth: _chipMaxWidth -
+                                          _chipIconSpan -
+                                          _chipInnerGap),
+                                  child: Text(
+                                    group.dateRange!.nights!,
+                                    maxLines: 1,
+                                    overflow: TextOverflow.ellipsis,
+                                    style: chipStyle,
+                                  ),
+                                ),
+                              ],
+                            ],
+                          ),
                         ),
                       ),
-                    ],
                     // 'Other places' has no hub the section tool can target;
                     // refine also needs the network. Hover-revealed on
                     // pointer devices (always visible on touch) to keep the
-                    // resting row quiet.
-                    if (group.label != _kOtherPlaces &&
-                        trip.canEdit &&
-                        !_isOffline)
-                      HoverRevealed(
-                        revealed: revealed,
-                        child: IconButton(
-                          icon: const Icon(Icons.auto_awesome, size: 16),
-                          tooltip: l10n.tripRefineCity(group.label),
-                          visualDensity: VisualDensity.compact,
-                          color: theme.colorScheme.primary,
-                          onPressed: () =>
-                              _openRefine(trip, RefineTarget.city(group.label)),
-                        ),
-                      ),
+                    // resting row quiet. canEdit/offline are screen-wide —
+                    // when they drop the button they drop it on EVERY row, so
+                    // the chip columns stay aligned. 'Other places' is the
+                    // one per-row variance: it keeps an invisible,
+                    // width-identical placeholder (same IconButton config, so
+                    // density changes can't drift it) or its chip cluster
+                    // would sit a button-slot right of the other rows.
+                    if (trip.canEdit && !_isOffline)
+                      group.label != _kOtherPlaces
+                          ? HoverRevealed(
+                              revealed: revealed,
+                              child: IconButton(
+                                icon: const Icon(Icons.auto_awesome, size: 16),
+                                tooltip: l10n.tripRefineCity(group.label),
+                                visualDensity: VisualDensity.compact,
+                                color: theme.colorScheme.primary,
+                                onPressed: () => _openRefine(
+                                    trip, RefineTarget.city(group.label)),
+                              ),
+                            )
+                          : ExcludeSemantics(
+                              child: IgnorePointer(
+                                child: Opacity(
+                                  opacity: 0,
+                                  // No tooltip: IgnorePointer blocks hover, a
+                                  // ghost tooltip target would outlive it.
+                                  child: IconButton(
+                                    icon: const Icon(Icons.auto_awesome,
+                                        size: 16),
+                                    visualDensity: VisualDensity.compact,
+                                    onPressed: null,
+                                  ),
+                                ),
+                              ),
+                            ),
                     const SizedBox(width: 4),
                     Icon(
                       cityCollapsed ? Icons.chevron_right : Icons.expand_more,
@@ -3852,33 +3975,38 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
     return '$base&query=${Uri.encodeComponent('${it.name} ${it.address ?? ''}'.trim())}';
   }
 
-  /// Maps each itinerary item's position to its location's formatted date range.
+  /// Maps each itinerary item's position to its location's date-chip parts.
   /// Delegates to [visibleLegRanges] so the itinerary labels and the booking
   /// checklist derive dates the same way. The two derivations index-align by
   /// construction: both run the same [tripLegs] split over the same items. The
   /// visible ranges are arrival-adjusted, matching the stay todos — a leg whose
   /// items collapse onto one day reads "Sep 24 – Sep 27", not a bare "Sep 27"
   /// contradicting the stay row beneath it, and a squeezed leg collapses to a
-  /// zero-night stop at its arrival. Multi-night legs carry a nights suffix
-  /// ("Aug 24 – Aug 27 · 3 nights") computed from the same range pair;
-  /// squeezed zero-night legs keep the bare single-date label.
-  Map<int, String> _locationDates(Trip trip) {
+  /// zero-night stop at its arrival. Multi-night legs carry a localized nights
+  /// suffix ("· 3 nights") computed from the same range pair; squeezed
+  /// zero-night legs get `nights: null` and render the bare single date. Both
+  /// strings are final display text — [_dateChipWidth] measures these exact
+  /// strings, never re-formatted copies (the range follows
+  /// Intl.defaultLocale via DateFormat while nights follows the widget
+  /// locale, so re-deriving could measure different text than renders).
+  Map<int, _LegDateChip> _locationDates(Trip trip) {
     final l10n = context.l10n;
     final items = trip.items ?? const <ItineraryItem>[];
     if (items.isEmpty) return const {};
     final ranges = visibleLegRanges(trip);
     final legs = tripLegs(items);
-    final result = <int, String>{};
+    final result = <int, _LegDateChip>{};
     for (var gi = 0; gi < legs.length; gi++) {
       final start = ranges[gi].start;
       final end = ranges[gi].end;
       if (start == null || end == null) continue;
-      final text = _formatRange(start, end);
       final nights = nightsBetween(start, end);
-      final label =
-          nights > 0 ? l10n.tripLegDatesWithNights(text, nights) : text;
+      final chip = (
+        range: _formatRange(start, end),
+        nights: nights > 0 ? l10n.tripLegNights(nights) : null,
+      );
       for (final item in legs[gi].items) {
-        result[item.position] = label;
+        result[item.position] = chip;
       }
     }
     return result;
@@ -4712,6 +4840,9 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
                       final filtered = _filtered(trip);
                       final groups =
                           _buildGroups(filtered, _locationDates(trip));
+                      // Shared per-build chip width — see _dateChipWidth's
+                      // doc for why this must stay a build-local.
+                      final dateChipWidth = _dateChipWidth(groups, theme);
                       // Groups default collapsed (empty _expandedCities); a
                       // sole group is seeded open once — a one-city trip
                       // collapsed to a single header line is an empty screen.
@@ -5159,8 +5290,8 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
                                             // GlobalKey would break the build.
                                             key: _cityHeaderKeys.putIfAbsent(
                                                 group.key, GlobalKey.new),
-                                            child: _cityHeader(
-                                                trip, group, theme)))
+                                            child: _cityHeader(trip, group,
+                                                theme, dateChipWidth)))
                                   else
                                     MultiSliver(
                                       pushPinnedChildren: true,
@@ -5170,8 +5301,8 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
                                                 key: _cityHeaderKeys
                                                     .putIfAbsent(group.key,
                                                         GlobalKey.new),
-                                                child: _cityHeader(
-                                                    trip, group, theme))),
+                                                child: _cityHeader(trip, group,
+                                                    theme, dateChipWidth))),
                                         // Embedded bookings render only in the
                                         // unfiltered view: a category filter can
                                         // merge adjacent same-label runs, which

--- a/src/packages/flutter-app/test/support/chip_finders.dart
+++ b/src/packages/flutter-app/test/support/chip_finders.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Finders that scope city-header date-chip assertions to ONE city's row.
+///
+/// The chip renders its range and nights suffix as two separate Text widgets
+/// (shared-width columns), so a global `find.text('· 2 nights')` can be
+/// satisfied by ANY city's chip — another leg with the same night count
+/// aliases the assertion. Scoping through the header row is what pins the
+/// PR #306 invariant that a range and its night count come from the SAME
+/// visibleLegRanges pair.
+
+/// The header Row for a city group — the nearest Row ancestor of its label
+/// text. Reliable while the label text is unique on screen (it is for
+/// collapsed groups, where item rows aren't built; expanded fixtures must
+/// not name an item exactly like a city).
+Finder headerRowOf(String cityLabel) =>
+    find.ancestor(of: find.text(cityLabel), matching: find.byType(Row)).first;
+
+/// A chip text inside one city's header row.
+Finder chipTextIn(String cityLabel, String text) =>
+    find.descendant(of: headerRowOf(cityLabel), matching: find.text(text));

--- a/src/packages/flutter-app/test/trip_detail_collapsed_default_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_collapsed_default_test.dart
@@ -12,6 +12,7 @@ import 'package:travel_route_planner/screens/trip_detail_screen.dart';
 import 'package:travel_route_planner/widgets/booking_todo_card.dart';
 import 'package:travel_route_planner/widgets/status_pill.dart';
 
+import 'support/chip_finders.dart';
 import 'support/city_groups.dart';
 import 'support/l10n_test_app.dart';
 
@@ -98,7 +99,12 @@ void main() {
     // Headers with their date ranges are the whole resting view.
     expect(find.text('Paris'), findsOneWidget);
     expect(find.text('Rome'), findsOneWidget);
-    expect(find.text('Jun 10 – Jun 11 · 1 night'), findsOneWidget);
+    // Scoping revealed what the old global finder hid: the counted range
+    // belongs to ROME (Paris's single day-1 item makes it a zero-night leg
+    // with a bare date chip).
+    expect(chipTextIn('Paris', 'Jun 10'), findsOneWidget);
+    expect(chipTextIn('Rome', 'Jun 10 – Jun 11'), findsOneWidget);
+    expect(chipTextIn('Rome', '· 1 night'), findsOneWidget);
 
     // Items and embedded booking rows are hidden until a group is opened.
     expect(find.text('Louvre'), findsNothing);

--- a/src/packages/flutter-app/test/trip_detail_grouping_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_grouping_test.dart
@@ -10,6 +10,7 @@ import 'package:travel_route_planner/services/trips_api_service.dart';
 import 'package:travel_route_planner/providers/trips_provider.dart';
 import 'package:travel_route_planner/screens/trip_detail_screen.dart';
 
+import 'support/chip_finders.dart';
 import 'support/city_groups.dart';
 import 'support/l10n_test_app.dart';
 
@@ -93,7 +94,8 @@ void main() {
 
     // The Green Turtle Cay group is labelled with the stay's date range
     // plus its night count.
-    expect(find.text('Jun 10 – Jun 12 · 2 nights'), findsOneWidget);
+    expect(chipTextIn('Green Turtle Cay', 'Jun 10 – Jun 12'), findsOneWidget);
+    expect(chipTextIn('Green Turtle Cay', '· 2 nights'), findsOneWidget);
 
     // Groups default collapsed — open both to reach their contents.
     await expandCity(tester, 'Green Turtle Cay');
@@ -156,7 +158,8 @@ void main() {
     expect(find.text('Sat, Jun 13'), findsOneWidget);
 
     // Paris spans days 1–2 -> Jun 10 – Jun 11 (1 night) next to the city name.
-    expect(find.text('Jun 10 – Jun 11 · 1 night'), findsOneWidget);
+    expect(chipTextIn('Paris', 'Jun 10 – Jun 11'), findsOneWidget);
+    expect(chipTextIn('Paris', '· 1 night'), findsOneWidget);
 
     // The Versailles day trip still nests under its day.
     expect(find.text('Day trip · Versailles'), findsOneWidget);

--- a/src/packages/flutter-app/test/trip_detail_leg_nights_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_leg_nights_test.dart
@@ -13,6 +13,7 @@ import 'package:travel_route_planner/providers/booking_todos_provider.dart';
 import 'package:travel_route_planner/providers/trips_provider.dart';
 import 'package:travel_route_planner/screens/trip_detail_screen.dart';
 
+import 'support/chip_finders.dart';
 import 'support/l10n_test_app.dart';
 
 /// Returns a fixed trip without hitting the network, so we can exercise the
@@ -23,6 +24,23 @@ class _FakeTripsApiService extends TripsApiService {
 
   @override
   Future<Trip> getTrip(String id) async => trip;
+}
+
+/// getTrip answers from a queue, so a pull-to-refresh can deliver a
+/// DIFFERENT trip (the re-measure-on-refresh test).
+class _QueuedTripsApiService extends TripsApiService {
+  final List<Trip> responses;
+  int calls = 0;
+  _QueuedTripsApiService(this.responses)
+      : super(ApiClient(baseUrl: 'http://test'));
+
+  @override
+  Future<Trip> getTrip(String id) async {
+    final next =
+        responses[calls < responses.length ? calls : responses.length - 1];
+    calls++;
+    return next;
+  }
 }
 
 /// Swallows the derived-payload sync like the offline test env.
@@ -82,43 +100,111 @@ Trip _pragueKrakowTrip() => Trip(
       ],
     );
 
+/// [_pragueKrakowTrip] with Kraków run through Sep 12 (16 nights) plus Vienna
+/// Sep 12 – Sep 14 (2 nights). Kraków's chip is the strict widest (26 glyphs
+/// under the uniform-advance test font vs 25 for the others), so a regression
+/// to per-row intrinsic widths misaligns its row against the other two, and
+/// the shared width here is one glyph wider than [_pragueKrakowTrip]'s — the
+/// re-measure-on-refresh test depends on that inequality.
+Trip _threeCityTrip() => Trip(
+      id: 't1',
+      title: 'Big Summer',
+      status: 'planned',
+      startDate: '2026-08-24',
+      endDate: '2026-09-14',
+      createdAt: '2026-08-01',
+      updatedAt: '2026-08-01',
+      items: [
+        _item(0, 'Prague', 'Prague', day: 4),
+        _item(1, 'Kraków', 'Kraków', day: 20),
+        _item(2, 'Vienna', 'Vienna', day: 22),
+      ],
+    );
+
+/// Quito is squeezed onto its Sep 6 arrival (see
+/// trip_detail_squeezed_leg_test.dart) — a zero-night leg with a bare
+/// single-date chip between two counted legs.
+Trip _squeezeTrip() => Trip(
+      id: 't1',
+      title: 'Squeeze',
+      status: 'planned',
+      startDate: '2026-09-01',
+      endDate: '2026-09-07',
+      createdAt: '2026-08-01',
+      updatedAt: '2026-08-01',
+      items: [
+        _item(0, 'Museo', 'Medellín', day: 1),
+        _item(1, 'Comuna 13', 'Medellín', day: 6),
+        _item(2, 'Quito', 'Quito', day: 5),
+        _item(3, 'Mitad del Mundo', 'Galápagos', day: 6),
+        _item(4, 'Tortuga Bay', 'Galápagos', day: 7),
+      ],
+    );
+
+/// Prague plus an item whose locality can't be resolved — the 'Other places'
+/// group, whose header has no refine sparkle to align against.
+Trip _pragueMysteryTrip() => Trip(
+      id: 't1',
+      title: 'Big Summer',
+      status: 'planned',
+      startDate: '2026-08-24',
+      endDate: '2026-09-01',
+      createdAt: '2026-08-01',
+      updatedAt: '2026-08-01',
+      items: [
+        _item(0, 'Prague', 'Prague', day: 4),
+        // No city AND no address: cityOf falls back to parsing the address,
+        // so only a fully unlocatable item lands in 'Other places'.
+        ItineraryItem(
+          id: 'i1',
+          position: 1,
+          name: 'Mystery beach',
+          latitude: 0,
+          longitude: 0,
+          category: 'attraction',
+          day: 9,
+        ),
+      ],
+    );
+
+/// Left x of the chip's calendar icon in a city's header row.
+double _eventIconX(WidgetTester tester, String cityLabel) => tester
+    .getTopLeft(find.descendant(
+        of: headerRowOf(cityLabel), matching: find.byIcon(Icons.event)))
+    .dx;
+
+/// Shrinks text so the shared chip width is intrinsic-driven. Under the
+/// square test font every realistic chip exceeds the 200px pathological cap,
+/// where per-row (broken) and shared (correct) widths are geometrically
+/// identical and alignment assertions would pass vacuously. This also
+/// exercises the textScaler-aware measurement path in _dateChipWidth.
+void _shrinkText(WidgetTester tester) {
+  tester.platformDispatcher.textScaleFactorTestValue = 0.4;
+  addTearDown(tester.platformDispatcher.clearTextScaleFactorTestValue);
+}
+
 void main() {
   testWidgets('city headers carry a night count next to the date range',
       (WidgetTester tester) async {
     await _pump(tester, _pragueKrakowTrip());
 
-    expect(find.text('Aug 24 – Aug 27 · 3 nights'), findsOneWidget);
-    expect(find.text('Aug 27 – Sep 1 · 5 nights'), findsOneWidget);
+    // Scoped per row: the count must sit in the SAME chip as its range.
+    expect(chipTextIn('Prague', 'Aug 24 – Aug 27'), findsOneWidget);
+    expect(chipTextIn('Prague', '· 3 nights'), findsOneWidget);
+    expect(chipTextIn('Kraków', 'Aug 27 – Sep 1'), findsOneWidget);
+    expect(chipTextIn('Kraków', '· 5 nights'), findsOneWidget);
   });
 
   testWidgets('a squeezed zero-night leg keeps its bare single-date chip',
       (WidgetTester tester) async {
-    // Quito is squeezed onto its Sep 6 arrival (see
-    // trip_detail_squeezed_leg_test.dart) — no "0 nights" noise on it, while
-    // the following Galápagos leg still gets its counter.
-    await _pump(
-      tester,
-      Trip(
-        id: 't1',
-        title: 'Squeeze',
-        status: 'planned',
-        startDate: '2026-09-01',
-        endDate: '2026-09-07',
-        createdAt: '2026-08-01',
-        updatedAt: '2026-08-01',
-        items: [
-          _item(0, 'Museo', 'Medellín', day: 1),
-          _item(1, 'Comuna 13', 'Medellín', day: 6),
-          _item(2, 'Quito', 'Quito', day: 5),
-          _item(3, 'Mitad del Mundo', 'Galápagos', day: 6),
-          _item(4, 'Tortuga Bay', 'Galápagos', day: 7),
-        ],
-      ),
-    );
+    // No "0 nights" noise on the squeezed Quito leg, while the following
+    // Galápagos leg still gets its counter.
+    await _pump(tester, _squeezeTrip());
 
-    expect(find.text('Sep 6'), findsWidgets);
+    expect(chipTextIn('Quito', 'Sep 6'), findsOneWidget);
     expect(find.textContaining('0 nights'), findsNothing);
-    expect(find.text('Sep 6 – Sep 7 · 1 night'), findsWidgets);
+    expect(chipTextIn('Galápagos', 'Sep 6 – Sep 7'), findsOneWidget);
+    expect(chipTextIn('Galápagos', '· 1 night'), findsOneWidget);
   });
 
   testWidgets('night counts pluralize in Spanish',
@@ -134,29 +220,27 @@ void main() {
 
   testWidgets('date chips sit flush right with aligned chevrons',
       (WidgetTester tester) async {
-    // Regression: wrapping the chip Text in Flexible gave the header Row two
+    // Regression: wrapping the chip in Flexible gave the header Row two
     // flex children, so the label's Expanded only claimed half the free
     // space and the chip+chevron cluster drifted left by a per-row amount.
     // The chevron must end exactly where its Row ends, on every row.
     await _pump(tester, _pragueKrakowTrip());
 
-    double chevronRightIn(String chipText) {
-      final row = find
-          .ancestor(of: find.text(chipText), matching: find.byType(Row))
-          .first;
+    double chevronRightIn(String city) {
+      final row = headerRowOf(city);
       final chevron = find.descendant(
           of: row, matching: find.byIcon(Icons.chevron_right));
       expect(chevron, findsOneWidget);
       expect(
         tester.getTopRight(chevron).dx,
         moreOrLessEquals(tester.getTopRight(row).dx, epsilon: 0.1),
-        reason: 'chevron of "$chipText" must be flush with its row end',
+        reason: 'chevron of "$city" must be flush with its row end',
       );
       return tester.getTopRight(chevron).dx;
     }
 
-    final prague = chevronRightIn('Aug 24 – Aug 27 · 3 nights');
-    final krakow = chevronRightIn('Aug 27 – Sep 1 · 5 nights');
+    final prague = chevronRightIn('Prague');
+    final krakow = chevronRightIn('Kraków');
     expect(prague, moreOrLessEquals(krakow, epsilon: 0.1),
         reason: 'chevrons must align across rows');
   });
@@ -165,17 +249,13 @@ void main() {
       (WidgetTester tester) async {
     // The test font renders every glyph as a full-size square, so the chip
     // here measures far wider than any real font — the harshest squeeze the
-    // row can see. The ConstrainedBox cap must ellipsize the chip (never
+    // row can see. The shared-width cap must ellipsize the chip (never
     // overflow), and the chevron must stay flush with the row end.
     await tester.binding.setSurfaceSize(const Size(375, 667));
     addTearDown(() => tester.binding.setSurfaceSize(null));
     await _pump(tester, _pragueKrakowTrip());
 
-    final row = find
-        .ancestor(
-            of: find.text('Aug 24 – Aug 27 · 3 nights'),
-            matching: find.byType(Row))
-        .first;
+    final row = headerRowOf('Prague');
     final chevron = find.descendant(
         of: row, matching: find.byIcon(Icons.chevron_right));
     expect(
@@ -185,15 +265,158 @@ void main() {
     );
   });
 
+  testWidgets('chip columns align across rows', (WidgetTester tester) async {
+    // The point of the shared chip width: calendar icons, range starts, and
+    // nights suffixes each form a column across header rows even though the
+    // strings differ in length per row.
+    _shrinkText(tester);
+    await _pump(tester, _threeCityTrip());
+
+    final iconX = _eventIconX(tester, 'Prague');
+    expect(_eventIconX(tester, 'Kraków'),
+        moreOrLessEquals(iconX, epsilon: 0.1),
+        reason: 'calendar icons must form a column');
+    expect(_eventIconX(tester, 'Vienna'),
+        moreOrLessEquals(iconX, epsilon: 0.1),
+        reason: 'calendar icons must form a column');
+
+    final rangeX = tester.getTopLeft(find.text('Aug 24 – Aug 27')).dx;
+    expect(tester.getTopLeft(find.text('Aug 27 – Sep 12')).dx,
+        moreOrLessEquals(rangeX, epsilon: 0.1),
+        reason: 'range starts must form a column');
+    expect(tester.getTopLeft(find.text('Sep 12 – Sep 14')).dx,
+        moreOrLessEquals(rangeX, epsilon: 0.1),
+        reason: 'range starts must form a column');
+
+    final nightsRight = tester.getTopRight(find.text('· 3 nights')).dx;
+    expect(tester.getTopRight(find.text('· 16 nights')).dx,
+        moreOrLessEquals(nightsRight, epsilon: 0.1),
+        reason: 'nights suffixes must share a right edge');
+    expect(tester.getTopRight(find.text('· 2 nights')).dx,
+        moreOrLessEquals(nightsRight, epsilon: 0.1),
+        reason: 'nights suffixes must share a right edge');
+  });
+
+  testWidgets('a refresh that widens the longest chip re-measures the width',
+      (WidgetTester tester) async {
+    // Pins the W-is-a-build-local invariant (_dateChipWidth doc): a
+    // State-cached width would survive a silent refresh that changes the
+    // legs (a set_leg_dates refine), leaving stale columns until remount.
+    _shrinkText(tester);
+    final service =
+        _QueuedTripsApiService([_pragueKrakowTrip(), _threeCityTrip()]);
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          tripsApiServiceProvider.overrideWithValue(service),
+          bookingTodosApiServiceProvider
+              .overrideWithValue(_FakeBookingTodosApiService()),
+        ],
+        child: localizedTestApp(home: TripDetailScreen(tripId: 't1')),
+      ),
+    );
+    await tester.pumpAndSettle();
+    final iconXBefore = _eventIconX(tester, 'Prague');
+
+    // Pull-to-refresh delivers _threeCityTrip, whose widest chip (Kraków)
+    // is one glyph wider than the widest before.
+    await tester.fling(
+        find.byType(CustomScrollView), const Offset(0, 400), 1000);
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1));
+    await tester.pumpAndSettle();
+    expect(service.calls, greaterThan(1));
+
+    // The mutation-killing inequality: the whole column must move left for
+    // the wider chip. A cached width leaves iconX unchanged.
+    final iconXAfter = _eventIconX(tester, 'Prague');
+    expect(iconXAfter, lessThan(iconXBefore - 1),
+        reason: 'shared width must be re-measured for the wider chip');
+
+    // And the columns re-form at the new width.
+    expect(_eventIconX(tester, 'Kraków'),
+        moreOrLessEquals(iconXAfter, epsilon: 0.1));
+    expect(_eventIconX(tester, 'Vienna'),
+        moreOrLessEquals(iconXAfter, epsilon: 0.1));
+    expect(tester.getTopRight(find.text('· 16 nights')).dx,
+        moreOrLessEquals(tester.getTopRight(find.text('· 3 nights')).dx,
+            epsilon: 0.1));
+  });
+
+  testWidgets('columns hold under the boldText accessibility flag',
+      (WidgetTester tester) async {
+    // Text applies boldText internally; _dateChipWidth merges it into the
+    // measured style. Exercises that branch end-to-end: columns must still
+    // form and nothing may overflow (an undershoot surfaces as a RenderFlex
+    // exception in this harness).
+    _shrinkText(tester);
+    tester.platformDispatcher.accessibilityFeaturesTestValue =
+        const FakeAccessibilityFeatures(boldText: true);
+    addTearDown(
+        tester.platformDispatcher.clearAccessibilityFeaturesTestValue);
+    await _pump(tester, _threeCityTrip());
+
+    final iconX = _eventIconX(tester, 'Prague');
+    expect(_eventIconX(tester, 'Kraków'),
+        moreOrLessEquals(iconX, epsilon: 0.1));
+    expect(_eventIconX(tester, 'Vienna'),
+        moreOrLessEquals(iconX, epsilon: 0.1));
+  });
+
+  testWidgets('zero-night bare chip joins the icon column, with no nights text',
+      (WidgetTester tester) async {
+    _shrinkText(tester);
+    await _pump(tester, _squeezeTrip());
+
+    final iconX = _eventIconX(tester, 'Medellín');
+    expect(_eventIconX(tester, 'Quito'),
+        moreOrLessEquals(iconX, epsilon: 0.1),
+        reason: 'the bare-date chip must keep the icon column');
+    expect(_eventIconX(tester, 'Galápagos'),
+        moreOrLessEquals(iconX, epsilon: 0.1),
+        reason: 'the bare-date chip must keep the icon column');
+
+    // The squeezed row renders the bare date only — no nights widget exists.
+    expect(
+        find.descendant(
+            of: headerRowOf('Quito'), matching: find.textContaining('night')),
+        findsNothing);
+  });
+
+  testWidgets("'Other places' keeps the columns without a refine sparkle",
+      (WidgetTester tester) async {
+    // That header has no refine button; it reserves an invisible
+    // width-identical slot so its chip cluster can't sit a button-slot right
+    // of the other rows.
+    _shrinkText(tester);
+    await _pump(tester, _pragueMysteryTrip());
+
+    expect(_eventIconX(tester, 'Other places'),
+        moreOrLessEquals(_eventIconX(tester, 'Prague'), epsilon: 0.1),
+        reason: "the 'Other places' chip must keep the icon column");
+    expect(tester.getTopRight(find.text('· 5 nights')).dx,
+        moreOrLessEquals(tester.getTopRight(find.text('· 3 nights')).dx,
+            epsilon: 0.1),
+        reason: "the 'Other places' nights suffix must share the right edge");
+
+    // The phantom slot is width-only: exactly one LIVE refine button.
+    final live = tester
+        .widgetList<IconButton>(
+            find.widgetWithIcon(IconButton, Icons.auto_awesome))
+        .where((b) => b.onPressed != null);
+    expect(live.length, 1,
+        reason: 'the Other-places placeholder must stay inert');
+  });
+
   // The only tests that pin the separator and order — if the format ever
   // changes, the ARB lines and these literals are the whole diff.
   test('message-level plural forms in en and es', () async {
     final en = await AppLocalizations.delegate.load(const Locale('en'));
-    expect(en.tripLegDatesWithNights('R', 1), 'R · 1 night');
-    expect(en.tripLegDatesWithNights('R', 3), 'R · 3 nights');
+    expect(en.tripLegNights(1), '· 1 night');
+    expect(en.tripLegNights(3), '· 3 nights');
 
     final es = await AppLocalizations.delegate.load(const Locale('es'));
-    expect(es.tripLegDatesWithNights('R', 1), 'R · 1 noche');
-    expect(es.tripLegDatesWithNights('R', 5), 'R · 5 noches');
+    expect(es.tripLegNights(1), '· 1 noche');
+    expect(es.tripLegNights(5), '· 5 noches');
   });
 }

--- a/src/packages/flutter-app/test/trip_detail_squeezed_leg_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_squeezed_leg_test.dart
@@ -13,6 +13,7 @@ import 'package:travel_route_planner/providers/booking_todos_provider.dart';
 import 'package:travel_route_planner/providers/trips_provider.dart';
 import 'package:travel_route_planner/screens/trip_detail_screen.dart';
 
+import 'support/chip_finders.dart';
 import 'support/l10n_test_app.dart';
 
 /// Returns a fixed trip without hitting the network, so we can exercise the
@@ -130,8 +131,9 @@ void main() {
     // its bare arrival (zero nights -> no counter) and the next leg follows
     // from it with a night count.
     expect(find.text('Sep 5'), findsNothing);
-    expect(find.text('Sep 6'), findsWidgets);
-    expect(find.text('Sep 6 – Sep 7 · 1 night'), findsWidgets);
+    expect(chipTextIn('Quito', 'Sep 6'), findsOneWidget);
+    expect(chipTextIn('Galápagos', 'Sep 6 – Sep 7'), findsOneWidget);
+    expect(chipTextIn('Galápagos', '· 1 night'), findsOneWidget);
   });
 
   testWidgets('consecutive squeezed legs chain onto the same arrival',
@@ -191,6 +193,7 @@ void main() {
         derived.singleWhere((t) => t['todo_key'] == 'stay:quito');
     expect(quitoStay['depart_date'], '2026-09-03');
     expect(quitoStay['return_date'], '2026-09-05');
-    expect(find.text('Sep 3 – Sep 5 · 2 nights'), findsWidgets);
+    expect(chipTextIn('Quito', 'Sep 3 – Sep 5'), findsOneWidget);
+    expect(chipTextIn('Quito', '· 2 nights'), findsOneWidget);
   });
 }

--- a/src/packages/flutter-app/test/trip_detail_stay_dates_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_stay_dates_test.dart
@@ -15,6 +15,7 @@ import 'package:travel_route_planner/providers/preferences_provider.dart';
 import 'package:travel_route_planner/providers/trips_provider.dart';
 import 'package:travel_route_planner/screens/trip_detail_screen.dart';
 
+import 'support/chip_finders.dart';
 import 'support/l10n_test_app.dart';
 
 /// Returns a fixed trip without hitting the network, so we can exercise the
@@ -171,7 +172,10 @@ void main() {
 
     // Header shows the anchored range with its night count, not a bare
     // end date.
-    expect(find.text('Aug 24 – Aug 27 · 3 nights'), findsWidgets);
+    // Scoped to Prague's row: the count must sit in the SAME chip as the
+    // anchored range (nights from the same visibleLegRanges pair).
+    expect(chipTextIn('Prague', 'Aug 24 – Aug 27'), findsOneWidget);
+    expect(chipTextIn('Prague', '· 3 nights'), findsOneWidget);
     expect(find.text('Aug 27'), findsNothing);
 
     // The prefs load is async and can re-trigger the derivation — assert on
@@ -233,7 +237,10 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    expect(find.text('Aug 26 – Aug 28 · 2 nights'), findsWidgets);
+    // Scoped to Madrid's row — Gothenburg is ALSO 2 nights, so a global
+    // find would be satisfied by the wrong chip.
+    expect(chipTextIn('Madrid', 'Aug 26 – Aug 28'), findsOneWidget);
+    expect(chipTextIn('Madrid', '· 2 nights'), findsOneWidget);
     expect(find.text('Aug 28'), findsNothing);
   });
 }


### PR DESCRIPTION
## Summary
- City-header date chips now form **columns across rows**: calendar icons aligned, range starts aligned, "· N nights" suffixes sharing a right edge — instead of ragged right-flushed intrinsic-width blocks.
- Each chip is a rigid `SizedBox` at a **shared per-build width** (`_dateChipWidth`): TextPainter over the exact rendered strings and style, with the ambient `TextScaler` and a `boldText` merge; computed as a build-local (never cached) so pinned headers can't see a stale width. PR #307's invariants hold: one flex child in the header Row, 200px pathological cap, ellipsize-never-overflow (range gives way; nights stays flush right).
- l10n: the fused `tripLegDatesWithNights` ICU message splits into the Dart-formatted range + a nights-only `tripLegNights` ("· 3 nights" / "· 3 noches") — the middot stays translator-owned and disappears structurally on zero-night legs, which render the bare date left-aligned in the shared box.
- 'Other places' headers reserve an invisible width-identical refine-button slot (same IconButton config under `ExcludeSemantics`/`IgnorePointer`/`Opacity(0)`) so the one per-row trailing-cluster variance can't shift that row's columns. `MergeSemantics` keeps the chip a single screen-reader utterance.
- Tests: new geometry regressions pumped at a reduced text scale (the square test font clamps every realistic chip to the cap, where broken and correct layouts are indistinguishable); chip string assertions scoped per header row via `test/support/chip_finders.dart` — scoping exposed that the collapsed-default fixture's counted range was actually Rome's chip, which the old global finder couldn't see; a queued-trips pull-to-refresh test pins re-measurement (kills a State-cached-width mutant); boldText and 'Other places' variants included.

## Testing
- `flutter analyze` clean (3 pre-existing infos in untouched `route_response.dart`).
- Full `flutter test`: **770/770 passing** after rebase onto latest `main` (includes the merged perf wave).
- `flutter gen-l10n` (bare, in-package): zero drift against the committed generated files; `l10n_untranslated.json` empty.
- Adversarial multi-agent review of the diff (3 lenses + refutation verify); all confirmed findings fixed in this branch, including regenerating l10n in the correct formatter mode so CI's stale-l10n gate matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)