### PR TITLE
perf(flutter): overlap trip-open requests in TripDetail _load

### DIFF
--- a/src/packages/flutter-app/lib/providers/preferences_provider.dart
+++ b/src/packages/flutter-app/lib/providers/preferences_provider.dart
@@ -47,6 +47,16 @@ class PreferencesNotifier extends StateNotifier<PreferencesState> {
     }
   }
 
+  /// Loads preferences only when they aren't already in state. Preferences
+  /// change in-session solely through [save] (profile sheet / onboarding),
+  /// which updates state here, so a loaded copy never goes stale — this
+  /// method is the one place that decides whether a network load is needed.
+  /// A previous failed load (prefs still null) retries, matching [load].
+  Future<void> loadIfNeeded() async {
+    if (state.prefs != null) return;
+    await load();
+  }
+
   Future<bool> save({
     String? budget,
     String? pace,

--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -437,14 +437,25 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
               status: trip.status,
             );
       }
-      // Load the home airport so the booking checklist can derive the outbound
-      // and return flights (no-op / null for anonymous sessions).
-      await ref.read(preferencesProvider.notifier).load();
-      _homeAirport = ref.read(preferencesProvider).prefs?.homeAirport;
-      if (mounted && (trip.items ?? const []).isNotEmpty) {
-        await _syncBookingTodos(trip);
-        await _computeTravelTimes(trip);
+      // The travel-time computation needs only the trip, while the booking-todo
+      // sync must wait for the home airport from preferences (the checklist
+      // derives the outbound and return flights from it; no-op / null for
+      // anonymous sessions). Run the two chains concurrently and join, so
+      // _load's completion, error, and offline semantics are unchanged — both
+      // helpers self-guard with mounted checks and swallow their own errors.
+      Future<void> syncTodosAfterPrefs() async {
+        await ref.read(preferencesProvider.notifier).loadIfNeeded();
+        _homeAirport = ref.read(preferencesProvider).prefs?.homeAirport;
+        if (mounted && (trip.items ?? const []).isNotEmpty) {
+          await _syncBookingTodos(trip);
+        }
       }
+
+      await Future.wait([
+        if (mounted && (trip.items ?? const []).isNotEmpty)
+          _computeTravelTimes(trip),
+        syncTodosAfterPrefs(),
+      ]);
     } catch (e) {
       // Loud path + network-level failure: fall back to the cached copy and
       // render it read-only. HTTP errors (403/404/500) never reach here —


### PR DESCRIPTION
## Summary
- Lane 2C (`perf-trip-open-parallel`), Wave 2 of the perf program — this wave's only `trip_detail_screen.dart` toucher; change stays strictly inside the `_load` tail plus the preferences provider (no build()/slivers/widgets).
- `preferences_provider.dart`: new `loadIfNeeded()` — the single place that owns the "do we already have prefs" decision. Returns immediately when preferences are already in state (in-session they only change via `save()`, which updates state through this same notifier), otherwise delegates to the existing `load()`. A previously failed load (prefs still null) retries, matching today's behavior.
- `trip_detail_screen.dart` `_load`: restructured the post-getTrip tail so the independent work overlaps.

**Request ordering, before → after:**
- Before (strictly serial): `GET /trips/{id}` → `GET /preferences` → `PUT` booking-todos sync → `POST /optimize-route`
- After: `GET /trips/{id}` → **max(** `POST /optimize-route` **,** `GET /preferences` (session-cached after first load) → `PUT` booking-todos sync **)** — joined with `Future.wait`, so `_load`'s completion point, `finally` block, error handling, and offline paths are byte-for-byte the same semantics.

**Home airport still reaches the todo derivation:** the booking-todo sync stays strictly ordered *after* the preferences load inside its own chain — `loadIfNeeded()` → `_homeAirport = ...prefs?.homeAirport` → `_syncBookingTodos(trip)` (which calls `_deriveTodos`, reading `_homeAirport`). Only `_computeTravelTimes` (which never needed preferences) was moved to run concurrently. Both helpers already self-guard (`mounted` checks + swallow-own-errors), verified unchanged.

No test files were modified — the existing booking-todo / trip-detail tests pass as-is (fresh `ProviderScope` per test means `loadIfNeeded()` hits `load()` on first call exactly like before).

## Testing
- `make flutter-analyze`: zero issues in changed files (only the 3 known pre-existing infos in `lib/models/route_response.dart`).
- `make flutter-test`: all 765 tests pass, including the booking-todo derivation tests (`trip_detail_stay_dates_test.dart`, `trip_detail_home_legs_test.dart`, booking lockstep/reorder, squeezed-leg, filter-lenses).

🤖 Generated with [Claude Code](https://claude.com/claude-code)