### PR TITLE
perf(api): move pre-stream chat-session save off the /plan hot path

### DIFF
--- a/src/packages/api/plan_handler.go
+++ b/src/packages/api/plan_handler.go
@@ -332,8 +332,9 @@ func planHandler(w http.ResponseWriter, r *http.Request) {
 
 	// Persist the conversation from its very first turn so leaving
 	// mid-discussion never loses it (specs/continue-where-you-left-off).
-	// Two best-effort writes: a synchronous one now, so the user's message
-	// survives even if the stream dies immediately, and a deferred one that
+	// Two best-effort writes: an async one started now (off the SSE hot
+	// path), so the user's message survives even if the stream dies
+	// immediately, and a deferred one — ordered strictly after it — that
 	// appends whatever assistant text streamed — the same text the client
 	// commits, on both its success and error paths. When compaction ran this
 	// turn, the compacted history + new summary are stored instead of the raw
@@ -358,13 +359,34 @@ func planHandler(w http.ResponseWriter, r *http.Request) {
 			// the summary carried separately — store it the same way.
 			persistMsgs, persistSummary = req.Messages[1:], req.Summary
 		}
-		savePlanChatSession(ctx, uid, req.ChatID, persistSummary, persistMsgs)
+		// The start-of-turn save runs off the hot path: a whole-transcript
+		// JSONB upsert before the model call would delay time-to-first-token.
+		// It gets its own background context — a canceled stream (client
+		// abort, timeout) must not cancel this write, because the user's
+		// message surviving a dead stream is the entire point of it.
+		//
+		// Ordering contract (what a consumer observes after the turn): the
+		// deferred end-of-turn save below awaits startSaved before writing, so
+		// the two upserts always land start → final and the stored row after
+		// the handler returns is the final assistant-text-bearing transcript —
+		// a slow start upsert can never overwrite it. startSaved closes even
+		// if the save panics (the deferred close unwinds before safeGo's
+		// recover), so the final save can never deadlock; its wait is bounded
+		// by the start save's own 5 s timeout.
+		startSaved := make(chan struct{})
+		safeGo("savePlanChatSessionStart", func() {
+			defer close(startSaved)
+			sctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			savePlanChatSession(sctx, uid, req.ChatID, persistSummary, persistMsgs)
+		})
 		defer func() {
 			msgs := persistMsgs
 			if t := turnText.String(); t != "" {
 				msgs = append(append([]PlanChatMessage{}, persistMsgs...),
 					PlanChatMessage{Role: "assistant", Content: t})
 			}
+			<-startSaved // start → final ordering; see contract above
 			// The request context is gone once the handler returns.
 			dctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()


### PR DESCRIPTION
## Summary
- Wave 2 lane 2D (`perf-plan-first-token`) of the perf program: the start-of-turn `savePlanChatSession` whole-transcript JSONB upsert no longer runs synchronously before the model stream — it now runs in a `safeGo` goroutine, removing a DB round-trip from the time-to-first-token path.
- The async save gets its own `context.WithTimeout(context.Background(), 5s)` — deliberately NOT the request ctx, so a canceled/aborted stream can never cancel the persistence (the user's message surviving a dead stream is the entire point of that write).
- A `startSaved` channel makes the ordering contract explicit: the existing deferred end-of-turn save awaits `<-startSaved` before writing, so the two upserts always land start → final and the post-state after the handler returns is the assistant-text-bearing transcript — a slow start upsert can never overwrite it. The channel closes even if the save panics (deferred close unwinds before `safeGo`'s recover), so the final save can never deadlock; the wait is bounded by the start save's own 5 s timeout.
- Comment blocks updated to state the post-state a consumer observes (docs/zen.md: a mutating call's consumer must be able to state the post-state).

## Test changes
- None. The fake-Anthropic chat-session persistence tests (`chat_session_integration_test.go`) all read the DB after the handler returns; the deferred final save still runs synchronously inside the handler (now after `<-startSaved`), so both upserts have landed by the time any test observes the row — no polling or timing changes needed. The mid-turn-error test (c) still proves the user message survives, and test (a) still proves the assistant text is present after completion.

## Testing
- `gofmt -l` clean, `go vet ./...` clean, `go build ./...` OK
- `go test ./... -count=1` against a local Postgres 16 (`TEST_DATABASE_URL` set): full suite green
- `go test -race ./... -count=1`: full suite green (new goroutine touches shared `persistMsgs`/`persistSummary` read-only; race detector confirms)

🤖 Generated with [Claude Code](https://claude.com/claude-code)