### PR TITLE
perf(api): parallelize trip-read fan-out and per-city weather lookups

### DIFF
--- a/src/packages/api/go.mod
+++ b/src/packages/api/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/modelcontextprotocol/go-sdk v1.7.0
 	github.com/pressly/goose/v3 v3.27.1
 	golang.org/x/crypto v0.50.0
+	golang.org/x/sync v0.21.0
 	golang.org/x/time v0.15.0
 )
 
@@ -39,7 +40,6 @@ require (
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/oauth2 v0.35.0 // indirect
-	golang.org/x/sync v0.21.0 // indirect
 	golang.org/x/sys v0.45.0 // indirect
 	golang.org/x/text v0.39.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/src/packages/api/query/users.sql
+++ b/src/packages/api/query/users.sql
@@ -48,6 +48,12 @@ RETURNING *;
 -- name: DeleteUser :execrows
 DELETE FROM users WHERE id = $1;
 
+-- name: GetUserDisplayNames :many
+-- Batch display-name lookup for response attribution (owner name + last-editor
+-- name on the trip view) — one round trip instead of N GetUserByID calls.
+-- Array-param pattern per query/admin.sql / query/price_alerts.sql.
+SELECT id, display_name FROM users WHERE id = ANY($1::uuid[]);
+
 -- name: ListAdminUsers :many
 -- All admin accounts (is_admin = true), for operational fan-out such as the
 -- ops-health degradation alert. Returns just what an alert needs: id + email +

--- a/src/packages/api/store/users.sql.go
+++ b/src/packages/api/store/users.sql.go
@@ -115,6 +115,38 @@ func (q *Queries) GetUserByID(ctx context.Context, id uuid.UUID) (User, error) {
 	return i, err
 }
 
+const getUserDisplayNames = `-- name: GetUserDisplayNames :many
+SELECT id, display_name FROM users WHERE id = ANY($1::uuid[])
+`
+
+type GetUserDisplayNamesRow struct {
+	ID          uuid.UUID `json:"id"`
+	DisplayName *string   `json:"display_name"`
+}
+
+// Batch display-name lookup for response attribution (owner name + last-editor
+// name on the trip view) — one round trip instead of N GetUserByID calls.
+// Array-param pattern per query/admin.sql / query/price_alerts.sql.
+func (q *Queries) GetUserDisplayNames(ctx context.Context, dollar_1 []uuid.UUID) ([]GetUserDisplayNamesRow, error) {
+	rows, err := q.db.Query(ctx, getUserDisplayNames, dollar_1)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []GetUserDisplayNamesRow
+	for rows.Next() {
+		var i GetUserDisplayNamesRow
+		if err := rows.Scan(&i.ID, &i.DisplayName); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listAdminUsers = `-- name: ListAdminUsers :many
 SELECT id, email, display_name
 FROM users

--- a/src/packages/api/trip_get_roles_integration_test.go
+++ b/src/packages/api/trip_get_roles_integration_test.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"travel-route-planner/store"
+)
+
+// Table test pinning getTripHandler's per-role response shape: owner, editor
+// collaborator, and viewer follow each GET the same trip and must see exactly
+// the fields their role allows. The trip carries confirmed + draft (auto)
+// accommodations and segments plus a booking todo, so every viewer-conditional
+// read branch is exercised. This locks the shape across the read-fanout
+// (errgroup) refactor — the concurrency change must be invisible.
+func TestGetTripResponseShapeByRole(t *testing.T) {
+	resetDB(t)
+	ctx := context.Background()
+	q := store.New(dbPool)
+
+	owner, ownerToken := createTestUser(t, "owner@example.com")
+	editor, editorToken := createTestUser(t, "editor@example.com")
+	_, viewerToken := createTestUser(t, "viewer@example.com")
+	setDisplayName := func(email, name string) {
+		t.Helper()
+		if _, err := dbPool.Exec(ctx, `UPDATE users SET display_name = $1 WHERE email = $2`, name, email); err != nil {
+			t.Fatalf("setDisplayName(%s): %v", email, err)
+		}
+	}
+	setDisplayName("owner@example.com", "Olive Owner")
+	setDisplayName("editor@example.com", "Eddie Editor")
+
+	trip := createTestTrip(t, owner.ID, 2)
+
+	// Confirmed rows all roles must see...
+	if _, err := q.CreateAccommodation(ctx, store.CreateAccommodationParams{
+		TripID: trip.ID, Name: "Confirmed Hotel",
+	}); err != nil {
+		t.Fatalf("create accommodation: %v", err)
+	}
+	if _, err := q.CreateSegment(ctx, store.CreateSegmentParams{
+		TripID: trip.ID, Mode: "train",
+	}); err != nil {
+		t.Fatalf("create segment: %v", err)
+	}
+	// ...draft (auto=true) rows only owner/editor may see...
+	if _, err := dbPool.Exec(ctx, `INSERT INTO accommodations (trip_id, name, auto, auto_key)
+		VALUES ($1, 'Draft Hotel', true, 'stay-key')`, trip.ID); err != nil {
+		t.Fatalf("insert draft accommodation: %v", err)
+	}
+	if _, err := dbPool.Exec(ctx, `INSERT INTO trip_segments (trip_id, mode, auto, auto_key)
+		VALUES ($1, 'flight', true, 'seg-key')`, trip.ID); err != nil {
+		t.Fatalf("insert draft segment: %v", err)
+	}
+	// ...and a booking todo, which viewers never see.
+	if _, err := q.CreateBookingTodo(ctx, store.CreateBookingTodoParams{
+		TripID: trip.ID, Kind: "flight", TodoKey: "todo-key", Title: "Book flight",
+	}); err != nil {
+		t.Fatalf("create booking todo: %v", err)
+	}
+
+	// Editor + viewer join the lineage; the last edit is attributed to the
+	// editor so updated_by_name resolution is exercised for every role.
+	if rec := joinShare(t, editorToken, createShare(t, ownerToken, trip.ID.String(), "editor")); rec.Code != http.StatusOK {
+		t.Fatalf("editor join = %d: %s", rec.Code, rec.Body.String())
+	}
+	if rec := joinShare(t, viewerToken, createShare(t, ownerToken, trip.ID.String(), "viewer")); rec.Code != http.StatusOK {
+		t.Fatalf("viewer join = %d: %s", rec.Code, rec.Body.String())
+	}
+	if _, err := dbPool.Exec(ctx, `UPDATE trips SET updated_by = $1 WHERE id = $2`, editor.ID, trip.ID); err != nil {
+		t.Fatalf("stamp updated_by: %v", err)
+	}
+
+	arrLen := func(v any) int {
+		arr, _ := v.([]any)
+		return len(arr)
+	}
+	cases := []struct {
+		role          string
+		token         string
+		wantChatID    bool // owner-only: collaborators never get the lineage key
+		wantStays     int  // drafts (auto=true) are editor-facing working state
+		wantSegments  int
+		wantTodos     int  // booking todos are hidden from viewer follows
+		wantOwnerName any  // set for collaborators, absent for the owner
+		wantUpdatedBy any  // absent for the attributed editor's own view
+		wantShared    bool // owner-only freshness-poll hint
+	}{
+		{role: "owner", token: ownerToken, wantChatID: true, wantStays: 2, wantSegments: 2,
+			wantTodos: 1, wantOwnerName: nil, wantUpdatedBy: "Eddie Editor", wantShared: true},
+		{role: "editor", token: editorToken, wantChatID: false, wantStays: 2, wantSegments: 2,
+			wantTodos: 1, wantOwnerName: "Olive Owner", wantUpdatedBy: nil, wantShared: false},
+		{role: "viewer", token: viewerToken, wantChatID: false, wantStays: 1, wantSegments: 1,
+			wantTodos: 0, wantOwnerName: "Olive Owner", wantUpdatedBy: "Eddie Editor", wantShared: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.role, func(t *testing.T) {
+			rec := doJSON(t, "GET", "/api/v1/trips/"+trip.ID.String(), tc.token, nil)
+			if rec.Code != http.StatusOK {
+				t.Fatalf("GET = %d: %s", rec.Code, rec.Body.String())
+			}
+			body := decode(t, rec)
+			// Shared core fields — identical for every role.
+			if body["id"] != trip.ID.String() || body["title"] != "Test Trip" {
+				t.Fatalf("core fields = %v / %v", body["id"], body["title"])
+			}
+			if n := arrLen(body["items"]); n != 2 {
+				t.Fatalf("items = %d, want 2", n)
+			}
+			// Role-dependent fields.
+			if body["access"] != tc.role {
+				t.Fatalf("access = %v, want %s", body["access"], tc.role)
+			}
+			if got := body["chat_id"] != nil; got != tc.wantChatID {
+				t.Fatalf("chat_id present = %v, want %v", got, tc.wantChatID)
+			}
+			if n := arrLen(body["accommodations"]); n != tc.wantStays {
+				t.Fatalf("accommodations = %d, want %d", n, tc.wantStays)
+			}
+			if n := arrLen(body["segments"]); n != tc.wantSegments {
+				t.Fatalf("segments = %d, want %d", n, tc.wantSegments)
+			}
+			if n := arrLen(body["booking_todos"]); n != tc.wantTodos {
+				t.Fatalf("booking_todos = %d, want %d", n, tc.wantTodos)
+			}
+			if body["owner_name"] != tc.wantOwnerName {
+				t.Fatalf("owner_name = %v, want %v", body["owner_name"], tc.wantOwnerName)
+			}
+			if body["updated_by_name"] != tc.wantUpdatedBy {
+				t.Fatalf("updated_by_name = %v, want %v", body["updated_by_name"], tc.wantUpdatedBy)
+			}
+			if got := body["shared"] == true; got != tc.wantShared {
+				t.Fatalf("shared = %v, want %v", body["shared"], tc.wantShared)
+			}
+		})
+	}
+}

--- a/src/packages/api/trip_handler.go
+++ b/src/packages/api/trip_handler.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
+	"golang.org/x/sync/errgroup"
 
 	"travel-route-planner/store"
 )
@@ -435,42 +436,118 @@ func getTripHandler(w http.ResponseWriter, r *http.Request) {
 		Summary: row.Summary, UpdatedBy: row.UpdatedBy, TravelMode: row.TravelMode,
 	}
 	q := store.New(dbPool)
-	items, err := q.GetItineraryItemsByTrip(r.Context(), trip.ID)
-	if err != nil {
-		writeJSONError(w, http.StatusInternalServerError, "could not load itinerary")
-		return
-	}
+	// The reads below are independent of each other — fan them out on the
+	// pool (pgxpool handles concurrent acquires) instead of paying serial
+	// round-trip latency. Every permission branch is unchanged; only the
+	// scheduling differs. Each goroutine writes its own variable, so there
+	// is no shared mutable state until g.Wait() returns.
+	g, ctx := errgroup.WithContext(r.Context())
+	var (
+		items          []store.ItineraryItem
+		accommodations []store.Accommodation
+		segments       []store.TripSegment
+		bookingTodos   []store.BookingTodo
+		ownerName      *string
+		updatedByName  *string
+		shared         bool
+	)
+	g.Go(func() error {
+		var err error
+		items, err = q.GetItineraryItemsByTrip(ctx, trip.ID)
+		if err != nil {
+			return errors.New("could not load itinerary")
+		}
+		return nil
+	})
 	// Suggested booking drafts (auto=true) are editor-facing working state;
 	// viewer follows get confirmed rows only, matching the public share view.
-	var accommodations []store.Accommodation
-	var segments []store.TripSegment
-	if row.Access == "viewer" {
-		accommodations, err = q.ListConfirmedAccommodationsByTrip(r.Context(), trip.ID)
-	} else {
-		accommodations, err = q.ListAccommodationsByTrip(r.Context(), trip.ID)
-	}
-	if err != nil {
-		writeJSONError(w, http.StatusInternalServerError, "could not load accommodations")
-		return
-	}
-	if row.Access == "viewer" {
-		segments, err = q.ListConfirmedSegmentsByTrip(r.Context(), trip.ID)
-	} else {
-		segments, err = q.ListSegmentsByTrip(r.Context(), trip.ID)
-	}
-	if err != nil {
-		writeJSONError(w, http.StatusInternalServerError, "could not load segments")
-		return
-	}
+	g.Go(func() error {
+		var err error
+		if row.Access == "viewer" {
+			accommodations, err = q.ListConfirmedAccommodationsByTrip(ctx, trip.ID)
+		} else {
+			accommodations, err = q.ListAccommodationsByTrip(ctx, trip.ID)
+		}
+		if err != nil {
+			return errors.New("could not load accommodations")
+		}
+		return nil
+	})
+	g.Go(func() error {
+		var err error
+		if row.Access == "viewer" {
+			segments, err = q.ListConfirmedSegmentsByTrip(ctx, trip.ID)
+		} else {
+			segments, err = q.ListSegmentsByTrip(ctx, trip.ID)
+		}
+		if err != nil {
+			return errors.New("could not load segments")
+		}
+		return nil
+	})
 	// Booking todos encode the owner's booking state and prices — viewer
 	// follows don't get them, matching the public share view's boundary.
-	var bookingTodos []store.BookingTodo
 	if row.Access != "viewer" {
-		bookingTodos, err = q.ListBookingTodosByTrip(r.Context(), trip.ID)
-		if err != nil {
-			writeJSONError(w, http.StatusInternalServerError, "could not load booking todos")
-			return
-		}
+		g.Go(func() error {
+			var err error
+			bookingTodos, err = q.ListBookingTodosByTrip(ctx, trip.ID)
+			if err != nil {
+				return errors.New("could not load booking todos")
+			}
+			return nil
+		})
+	}
+	// Display-name attribution: owner name (for collaborators) and last-editor
+	// name resolve from ONE batch lookup. Best-effort like the old per-id
+	// GetUserByID calls — a lookup failure just omits the names.
+	needOwnerName := row.Access != "owner"
+	needEditorName := trip.UpdatedBy.Valid && trip.UpdatedBy.Bytes != user.ID
+	if needOwnerName || needEditorName {
+		g.Go(func() error {
+			ids := make([]uuid.UUID, 0, 2)
+			if needOwnerName {
+				ids = append(ids, trip.UserID)
+			}
+			if needEditorName {
+				ids = append(ids, trip.UpdatedBy.Bytes)
+			}
+			rows, err := q.GetUserDisplayNames(ctx, ids)
+			if err != nil {
+				return nil // best-effort
+			}
+			names := make(map[uuid.UUID]*string, len(rows))
+			for _, u := range rows {
+				names[u.ID] = u.DisplayName
+			}
+			if needOwnerName {
+				if n := names[trip.UserID]; n != nil && *n != "" {
+					ownerName = n
+				}
+			}
+			if needEditorName {
+				if n := names[trip.UpdatedBy.Bytes]; n != nil && *n != "" {
+					updatedByName = n
+				}
+			}
+			return nil
+		})
+	}
+	// Tell the owner's client this trip has co-planners (worth polling for
+	// freshness). Editors know to poll from access alone. Best-effort.
+	if trip.UserID == user.ID && trip.ChatID != nil {
+		chatID := *trip.ChatID
+		g.Go(func() error {
+			if s, err := q.HasActiveCollaborators(ctx, store.HasActiveCollaboratorsParams{
+				OwnerID: trip.UserID, ChatID: chatID,
+			}); err == nil {
+				shared = s
+			}
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		writeJSONError(w, http.StatusInternalServerError, err.Error())
+		return
 	}
 	resp := toTripResponse(trip, items, accommodations, segments, bookingTodos)
 	resp.Legs = tripLegsResponse(trip, items, accommodations)
@@ -480,27 +557,11 @@ func getTripHandler(w http.ResponseWriter, r *http.Request) {
 		// freeform /plan chat with it would fork the lineage under their own
 		// account. Refine binds by trip_id, so members never need it.
 		resp.ChatID = nil
-		if owner, err := q.GetUserByID(r.Context(), trip.UserID); err == nil &&
-			owner.DisplayName != nil && *owner.DisplayName != "" {
-			resp.OwnerName = owner.DisplayName
-		}
+		resp.OwnerName = ownerName
 	}
 	// "Updated by X" attribution — omitted for the caller's own edits.
-	if trip.UpdatedBy.Valid && trip.UpdatedBy.Bytes != user.ID {
-		if editor, err := q.GetUserByID(r.Context(), trip.UpdatedBy.Bytes); err == nil &&
-			editor.DisplayName != nil && *editor.DisplayName != "" {
-			resp.UpdatedByName = editor.DisplayName
-		}
-	}
-	// Tell the owner's client this trip has co-planners (worth polling for
-	// freshness). Editors know to poll from access alone.
-	if trip.UserID == user.ID && trip.ChatID != nil {
-		if shared, err := q.HasActiveCollaborators(r.Context(), store.HasActiveCollaboratorsParams{
-			OwnerID: trip.UserID, ChatID: *trip.ChatID,
-		}); err == nil {
-			resp.Shared = shared
-		}
-	}
+	resp.UpdatedByName = updatedByName
+	resp.Shared = shared
 	writeJSON(w, http.StatusOK, resp)
 }
 

--- a/src/packages/api/trip_review.go
+++ b/src/packages/api/trip_review.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5/pgtype"
+	"golang.org/x/sync/errgroup"
 
 	"travel-route-planner/store"
 )
@@ -676,9 +677,11 @@ func checkWeather(ctx context.Context, locale string, d exportData, weather *Wea
 		}
 	}
 
-	var out []Finding
-	for _, city := range order {
-		days := cityDays[city]
+	// cityFindings is checkWeather's per-city body: one GetTripWeather lookup
+	// spanning the city's trip days, matched back day-by-day. Returns nil on
+	// any provider error or empty report (best-effort, as before).
+	cityFindings := func(city string, days map[int]*dayInfo) []Finding {
+		var out []Finding
 		var first, last time.Time
 		for _, di := range days {
 			if first.IsZero() || di.date.Before(first) {
@@ -690,7 +693,7 @@ func checkWeather(ctx context.Context, locale string, d exportData, weather *Wea
 		}
 		report, err := weather.GetTripWeather(ctx, city, first.Format(dateLayout), last.Format(dateLayout))
 		if err != nil || len(report.Days) == 0 {
-			continue // best-effort
+			return nil // best-effort
 		}
 		// Index the report by day. A forecast carries real (this-year) dates —
 		// match exact. The archive fallback carries LAST year's dates for the
@@ -743,6 +746,30 @@ func checkWeather(ctx context.Context, locale string, d exportData, weather *Wea
 				})
 			}
 		}
+		return out
+	}
+
+	// One lookup per city, fanned out with a small concurrency cap (the
+	// service is TTL-cached and keyless, but stay polite). Findings order is
+	// user-visible, so each city's findings land in the slot indexed by its
+	// position in `order` and are appended in order after Wait. Best-effort
+	// semantics are unchanged: the goroutines always return nil, so a
+	// per-city provider error skips that city, never fails the review.
+	perCity := make([][]Finding, len(order))
+	var g errgroup.Group
+	g.SetLimit(4)
+	for i, city := range order {
+		i, city := i, city
+		days := cityDays[city]
+		g.Go(func() error {
+			perCity[i] = cityFindings(city, days)
+			return nil
+		})
+	}
+	_ = g.Wait() // never errors; Wait just joins the goroutines
+	var out []Finding
+	for _, findings := range perCity {
+		out = append(out, findings...)
 	}
 	return out
 }


### PR DESCRIPTION
## Summary
- **getTripHandler read fan-out** (`trip_handler.go`): the reads after the initial `viewableTrip` authorization query now run concurrently via `errgroup.WithContext` instead of strictly serially. Parallelized reads: itinerary items, accommodations (viewer-conditional confirmed-only variant preserved), segments (same), booking todos (skip-for-viewer branch preserved), the display-name attribution lookup, and `HasActiveCollaborators` (owner-only, best-effort). Response assembly is unchanged after `g.Wait()`; every permission branch and error message is behavior-identical. pgxpool handles concurrent acquires — MaxConns 10 > the at-most-6 concurrent reads this handler issues.
- **One batch name lookup**: the up-to-2 serial `GetUserByID` calls (owner name for collaborators + updated-by attribution) are replaced by a single new `GetUserDisplayNames :many` query (`query/users.sql`, `id = ANY($1::uuid[])` — same array-param pattern as `query/admin.sql` / `query/price_alerts.sql`). Both names resolve from its result set inside the errgroup, still best-effort. `store/` regenerated with `make api-sqlc` (committed).
- **checkWeather parallelized** (`trip_review.go`): the per-city `weather.GetTripWeather` loop — the cold `/review` path's dominant wall time — now fans out with an errgroup + `g.SetLimit(4)`. Findings order is user-visible, so per-city results land in a slice indexed by the city's position in `order` and are appended in order after Wait. Best-effort semantics kept exactly: goroutines always return nil, a per-city error skips that city, the review never fails.
- `golang.org/x/sync` promoted from indirect to direct in `go.mod` (no `go.sum` change — it was already pinned).
- New `trip_get_roles_integration_test.go`: a three-role table test (owner / editor / viewer) pinning the GET `/trips/{id}` response shape — access, chat_id presence, draft-vs-confirmed stays/segments counts, booking-todos visibility, owner_name / updated_by_name / shared — so the concurrency change is provably invisible.

## Testing
- `make api-sqlc` (regen committed), `make api-fmt`, `make api-vet`, `go build ./...` — clean.
- `go test ./... -count=1` against an ephemeral postgres:16 (`TEST_DATABASE_URL`) — full suite green, including the new `TestGetTripResponseShapeByRole` (all three role subtests) and the existing collaborator/share/trip-status/review suites.
- `go test -race -count=1 .` with the same test DB — green (each errgroup goroutine writes only its own variable; no shared mutable state until `g.Wait()`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)