### PR TITLE
perf(chat): drop KaTeX from chat rendering and ship no KaTeX fonts

### DIFF
--- a/dockerize/deployment/Dockerfile
+++ b/dockerize/deployment/Dockerfile
@@ -29,6 +29,7 @@ RUN flutter pub get
 COPY src/packages/flutter-app/lib/ lib/
 COPY src/packages/flutter-app/web/ web/
 COPY src/packages/flutter-app/assets/ assets/
+COPY src/packages/flutter-app/tool/ tool/
 COPY src/packages/flutter-app/analysis_options.yaml ./
 
 RUN mkdir -p web/icons
@@ -39,6 +40,19 @@ RUN flutter build web --release \
     --base-href /app/ \
     --dart-define=API_BASE_URL=/api/v1 \
     --dart-define=APP_BASE_PATH=/app/
+
+# Strip flutter_math_fork's 16 KaTeX font families (~597 KB, downloaded
+# before first frame) from the shipped bundle: the app excludes gpt_markdown's
+# LaTeX components (chat_panel.dart), so the fonts are unreachable. Guard
+# rails are deliberate — fail the build loudly rather than ship silent bloat:
+# the grep asserts the entries exist BEFORE stripping (if gpt_markdown's
+# layout changes, this goes red instead of quietly doing nothing), the tool
+# itself exits non-zero on any surprise, and the final greps assert the
+# post-state (no KaTeX left in manifest or on disk).
+RUN grep -q 'packages/flutter_math_fork/' build/web/assets/FontManifest.json \
+    && dart run tool/strip_katex_fonts.dart build/web \
+    && ! grep -q 'flutter_math_fork' build/web/assets/FontManifest.json \
+    && [ ! -d build/web/assets/packages/flutter_math_fork ]
 
 # Release identifier for the web build, mirroring the api image's
 # SENTRY_RELEASE: CI passes the git SHA so /app/version.json answers

--- a/src/packages/flutter-app/lib/widgets/chat_panel.dart
+++ b/src/packages/flutter-app/lib/widgets/chat_panel.dart
@@ -1343,6 +1343,44 @@ const double _kBubbleMaxWidth = 720;
 double _bubbleMaxWidthFor(double panelWidth) =>
     min(panelWidth * 0.78, _kBubbleMaxWidth);
 
+/// gpt_markdown component lists with the LaTeX components removed. A travel
+/// chat never renders LaTeX, but the package's defaults include
+/// LatexMath/LatexMathMultiLine, which (a) add their regex alternations to
+/// every parse of every bubble and (b) are the only reachable path into
+/// flutter_math_fork's KaTeX rendering. Excluding them here keeps that path
+/// dead at runtime; the deployment Dockerfile separately strips the 16 KaTeX
+/// font families from the shipped web bundle (tool/strip_katex_fonts.dart).
+///
+/// These mirror `MarkdownComponent.globalComponents` / `.inlineComponents`
+/// in gpt_markdown 1.1.7 (lib/markdown_component.dart) minus the two LaTeX
+/// entries, in the SAME order — the list order is the combined-regex
+/// alternation order, so reordering would change parse precedence.
+final List<MarkdownComponent> _markdownComponents = [
+  CodeBlockMd(),
+  NewLines(),
+  BlockQuote(),
+  TableMd(),
+  HTag(),
+  UnOrderedList(),
+  OrderedList(),
+  RadioButtonMd(),
+  CheckBoxMd(),
+  HrLine(),
+  IndentMd(),
+];
+
+final List<MarkdownComponent> _markdownInlineComponents = [
+  ATagMd(),
+  ImageMd(),
+  TableMd(),
+  StrikeMd(),
+  BoldMd(),
+  ItalicMd(),
+  UnderLineMd(),
+  HighlightedText(),
+  SourceTag(),
+];
+
 class ChatMessageBubble extends StatelessWidget {
   final PlanMessage message;
   final bool isStreaming;
@@ -1415,11 +1453,25 @@ class ChatMessageBubble extends StatelessWidget {
                           ),
                       ],
                     )
-                  : GptMarkdown(
-                      message.content,
-                      style: TextStyle(color: theme.colorScheme.onSurface),
-                      onLinkTap: (url, title) => _openLink(context, url),
-                    ),
+                  // While streaming, the growing string is re-rendered every
+                  // token flush; a full markdown parse each time is O(n²)
+                  // over the reply. Plain Text keeps flushes O(n) — the
+                  // enclosing SelectionArea keeps it selectable — and the
+                  // bubble switches to GptMarkdown naturally when the message
+                  // commits into the messages list (so bold/lists appear on
+                  // commit rather than live: accepted trade).
+                  : isStreaming
+                      ? Text(
+                          message.content,
+                          style: TextStyle(color: theme.colorScheme.onSurface),
+                        )
+                      : GptMarkdown(
+                          message.content,
+                          style: TextStyle(color: theme.colorScheme.onSurface),
+                          components: _markdownComponents,
+                          inlineComponents: _markdownInlineComponents,
+                          onLinkTap: (url, title) => _openLink(context, url),
+                        ),
             ),
             if (isStreaming) ...[
               const SizedBox(width: 6),

--- a/src/packages/flutter-app/test/chat_panel_markdown_render_test.dart
+++ b/src/packages/flutter-app/test/chat_panel_markdown_render_test.dart
@@ -1,0 +1,147 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:gpt_markdown/custom_widgets/unordered_ordered_list.dart';
+import 'package:gpt_markdown/gpt_markdown.dart';
+
+import 'package:travel_route_planner/models/plan_message.dart';
+import 'package:travel_route_planner/providers/plan_provider.dart';
+import 'package:travel_route_planner/services/api_client.dart';
+import 'package:travel_route_planner/services/plan_service.dart';
+import 'package:travel_route_planner/widgets/chat_panel.dart';
+
+import 'support/l10n_test_app.dart';
+
+/// Chat markdown rendering contracts (perf-chat-render-bundle lane):
+///
+/// 1. Committed assistant messages render full markdown (bold, lists) via
+///    GptMarkdown — with explicit component lists that EXCLUDE the LaTeX
+///    components, so flutter_math_fork's KaTeX path (and its 16 shipped font
+///    families, stripped by tool/strip_katex_fonts.dart) stays unreachable.
+/// 2. The live streaming bubble renders plain Text: re-parsing the whole
+///    growing string as markdown on every token flush is O(n²) over a reply.
+///    Formatting appears when the message commits — accepted trade.
+
+class _SeededPlanNotifier extends PlanNotifier {
+  _SeededPlanNotifier(PlanState seeded)
+      : super(PlanService('http://unused'), ApiClient()) {
+    state = seeded;
+  }
+}
+
+Future<void> _pumpSeededChat(WidgetTester tester, PlanState seeded) async {
+  tester.view.physicalSize = const Size(1200, 900);
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.resetPhysicalSize);
+  addTearDown(tester.view.resetDevicePixelRatio);
+
+  final provider = StateNotifierProvider<PlanNotifier, PlanState>(
+      (ref) => _SeededPlanNotifier(seeded));
+  await tester.pumpWidget(
+    ProviderScope(
+      child: localizedTestApp(
+        home: Scaffold(
+          body: ChatPanel(state: provider, notifier: provider.notifier),
+        ),
+      ),
+    ),
+  );
+}
+
+/// Collects every leaf text fragment rendered under [finder], with the
+/// resolved style it carries.
+List<(String, TextStyle?)> _textFragments(WidgetTester tester, Finder finder) {
+  final fragments = <(String, TextStyle?)>[];
+  void walk(InlineSpan span, TextStyle? inherited) {
+    final style = span.style ?? inherited;
+    if (span is TextSpan) {
+      if (span.text != null) fragments.add((span.text!, style));
+      for (final child in span.children ?? const <InlineSpan>[]) {
+        walk(child, style);
+      }
+    }
+  }
+
+  for (final rich in tester.widgetList<RichText>(
+      find.descendant(of: finder, matching: find.byType(RichText)))) {
+    walk(rich.text, null);
+  }
+  return fragments;
+}
+
+void main() {
+  testWidgets('committed message renders bold and list as markdown',
+      (WidgetTester tester) async {
+    await _pumpSeededChat(
+      tester,
+      PlanState(messages: [
+        PlanMessage(
+          role: MessageRole.assistant,
+          content: '**Lisbon** highlights:\n- Alfama\n- Belém Tower',
+        ),
+      ]),
+    );
+
+    final bubble = find.byType(ChatMessageBubble);
+    expect(find.descendant(of: bubble, matching: find.byType(GptMarkdown)),
+        findsOneWidget);
+
+    final fragments = _textFragments(tester, bubble);
+    final allText = fragments.map((f) => f.$1).join();
+    // Bold parsed, not shown literally, and rendered with a bold weight.
+    expect(allText, isNot(contains('**')));
+    final lisbon = fragments.where((f) => f.$1.contains('Lisbon'));
+    expect(lisbon, isNotEmpty);
+    expect(lisbon.any((f) => f.$2?.fontWeight == FontWeight.bold), isTrue);
+    // The two items render inside real unordered-list widgets (dash consumed).
+    expect(find.descendant(of: bubble, matching: find.byType(UnorderedListView)),
+        findsNWidgets(2));
+    expect(allText, contains('Alfama'));
+    expect(allText, contains('Belém Tower'));
+  });
+
+  testWidgets('LaTeX components are excluded: delimiters stay literal text',
+      (WidgetTester tester) async {
+    await _pumpSeededChat(
+      tester,
+      PlanState(messages: [
+        PlanMessage(
+          role: MessageRole.assistant,
+          content: r'Distance: \(d = vt\) and \[E = mc^2\]',
+        ),
+      ]),
+    );
+
+    // With LatexMath/LatexMathMultiLine passed out of the component lists,
+    // the delimiters survive as plain text instead of a flutter_math_fork
+    // Math widget consuming them.
+    final allText = _textFragments(tester, find.byType(ChatMessageBubble))
+        .map((f) => f.$1)
+        .join();
+    expect(allText, contains(r'\(d = vt\)'));
+    expect(allText, contains(r'\[E = mc^2\]'));
+  });
+
+  testWidgets('streaming bubble renders plain Text, not markdown',
+      (WidgetTester tester) async {
+    await _pumpSeededChat(
+      tester,
+      PlanState(
+        messages: [PlanMessage(role: MessageRole.user, content: 'plan it')],
+        isStreaming: true,
+        streamingText: '**Lisbon** highlights:\n- Alfama',
+      ),
+    );
+
+    // Two bubbles: the committed user message and the streaming tail. The
+    // streaming one must not host a GptMarkdown — its raw markdown shows
+    // verbatim until commit.
+    expect(find.byType(ChatMessageBubble), findsNWidgets(2));
+    expect(
+        find.descendant(
+            of: find.byType(ChatMessageBubble),
+            matching: find.byType(GptMarkdown)),
+        findsNothing);
+    expect(find.text('**Lisbon** highlights:\n- Alfama'), findsOneWidget);
+  });
+}

--- a/src/packages/flutter-app/tool/strip_katex_fonts.dart
+++ b/src/packages/flutter-app/tool/strip_katex_fonts.dart
@@ -1,0 +1,54 @@
+// Post-build strip of flutter_math_fork's KaTeX fonts from a `flutter build
+// web` output. gpt_markdown hard-depends on flutter_math_fork, whose 16 KaTeX
+// font families land in FontManifest.json and are downloaded before first
+// frame — but the app excludes the LaTeX markdown components (chat_panel.dart)
+// so the fonts are dead weight (~597 KB). Run by dockerize/deployment/
+// Dockerfile after the build; CI's plain compile-check build is unaffected.
+//
+// FAILS LOUDLY (exit 1) if the manifest has no flutter_math_fork entries:
+// if gpt_markdown drops the dep or the manifest layout changes we want a red
+// build, not a silently different bundle. Running it twice therefore fails.
+//
+// Usage: dart run tool/strip_katex_fonts.dart [build/web]
+import 'dart:convert';
+import 'dart:io';
+
+void main(List<String> args) {
+  final buildDir = args.isEmpty ? 'build/web' : args.first;
+  const marker = 'packages/flutter_math_fork/';
+  final manifestFile = File('$buildDir/assets/FontManifest.json');
+  if (!manifestFile.existsSync()) {
+    stderr.writeln('strip_katex_fonts: ${manifestFile.path} not found');
+    exit(1);
+  }
+  final manifest = jsonDecode(manifestFile.readAsStringSync()) as List<dynamic>;
+  bool isKatex(dynamic e) =>
+      (e as Map<String, dynamic>)['family'].toString().startsWith(marker) ||
+      (e['fonts'] as List<dynamic>)
+          .any((f) => (f as Map)['asset'].toString().startsWith(marker));
+  final katex = manifest.where(isKatex).toList();
+  if (katex.isEmpty) {
+    stderr.writeln('strip_katex_fonts: no $marker families in '
+        '${manifestFile.path} — manifest layout changed? Refusing to guess.');
+    exit(1);
+  }
+  var deleted = 0;
+  for (final entry in katex) {
+    for (final font in (entry as Map)['fonts'] as List<dynamic>) {
+      final file = File('$buildDir/assets/${(font as Map)['asset']}');
+      if (!file.existsSync()) {
+        stderr.writeln('strip_katex_fonts: listed font missing: ${file.path}');
+        exit(1);
+      }
+      file.deleteSync();
+      deleted++;
+    }
+  }
+  // The package ships nothing but these fonts; drop its now-empty asset tree.
+  final pkgDir = Directory('$buildDir/assets/$marker');
+  if (pkgDir.existsSync()) pkgDir.deleteSync(recursive: true);
+  manifestFile.writeAsStringSync(
+      jsonEncode(manifest.where((e) => !isKatex(e)).toList()));
+  stdout.writeln('strip_katex_fonts: removed ${katex.length} families '
+      '($deleted font files); ${manifest.length - katex.length} families kept');
+}


### PR DESCRIPTION
Wave 3 Lane 3B of the perf program (plan: the-app-feels-pretty-sorted-crescent).

## What

1. **KaTeX dead weight removed.** gpt_markdown hard-depends on flutter_math_fork, whose KaTeX font families (~660 KB across 20 files) ship in FontManifest.json and download before first frame — a travel chat never renders LaTeX.
   - Runtime: `GptMarkdown` gets explicit `components`/`inlineComponents` lists mirroring the pinned 1.1.7 defaults minus `LatexMath`/`LatexMathMultiLine`, which also removes the LaTeX regex alternations from every bubble parse.
   - Bytes: the deployment Dockerfile runs `tool/strip_katex_fonts.dart` after `flutter build web`, removing the families from FontManifest.json and deleting the font files. Guard-railed to fail the image build loudly (pre-grep, tool exit codes, post-state greps) if gpt_markdown's manifest layout ever changes — drift shows as a red build, not silent bloat. CI's plain compile-check build is unaffected.
2. **Streaming markdown O(n²) fixed.** The live streaming bubble re-parsed the whole growing reply as markdown on every 48 ms flush. It now renders plain `Text` while streaming (still selectable) and switches to `GptMarkdown` when the message commits. Visible trade accepted per plan: bold/lists appear on commit rather than live. The 48 ms coalescing is untouched.

## Verification

- All 56 `chat_panel_*` widget tests pass (incl. new `chat_panel_markdown_render_test.dart`); `flutter analyze` clean (3 pre-existing `route_response.dart` infos).
- Strip tool exercised against a synthetic build dir: removes the KaTeX family + files and the package asset tree, keeps other fonts, and a second run (nothing left to strip) exits 1 — the loud-failure guard works.
- Full suite + real image build verified by CI / the deploy job.

Note for integrator (self): flutter_markdown is discontinued upstream — renderer swap was explicitly rejected in the plan; this keeps gpt_markdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)