### PR TITLE
perf(web): gate the autofill shim off auth screens, boot optimistically, fix SW cache keys

### DIFF
--- a/dockerize/deployment/Dockerfile
+++ b/dockerize/deployment/Dockerfile
@@ -50,6 +50,19 @@ ARG GIT_SHA=
 RUN sed -i 's/}[[:space:]]*$/,"release":"'"${GIT_SHA}"'"}/' build/web/version.json \
     && grep -q '"release"' build/web/version.json
 
+# Flutter's stock service worker computes cache keys as
+# `url.substring(origin.length + 1)` — but with `--base-href /app/` the
+# cached request URLs are `<origin>/app/main.dart.js` while RESOURCES keys
+# are bare (`main.dart.js`), so `RESOURCES[key]` never matches: the cache
+# is populated on install but never READ, and every load re-fetches from
+# the network. Strip the 4-char `app/` prefix too (+1 -> +5) at all three
+# key-computation sites. Guarded to fail the build loudly if Flutter ever
+# changes the service-worker layout: at least one replacement must have
+# happened and none of the old pattern may remain.
+RUN sed -i 's/origin\.length + 1/origin.length + 5/g' build/web/flutter_service_worker.js \
+    && grep -q 'origin.length + 5' build/web/flutter_service_worker.js \
+    && ! grep -q 'origin\.length + 1' build/web/flutter_service_worker.js
+
 # Serve static files and proxy API via nginx
 FROM nginx:alpine
 

--- a/src/packages/flutter-app/lib/main.dart
+++ b/src/packages/flutter-app/lib/main.dart
@@ -176,7 +176,7 @@ class _AuthGateState extends ConsumerState<AuthGate> {
     // Fade between splash and destination so instant auth resolution isn't a
     // one-frame hard cut. Branches are distinct types, so no keys needed.
     return AnimatedSwitcher(
-      duration: const Duration(milliseconds: 250),
+      duration: const Duration(milliseconds: 120),
       child: child,
     );
   }

--- a/src/packages/flutter-app/lib/providers/auth_provider.dart
+++ b/src/packages/flutter-app/lib/providers/auth_provider.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:convert';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -80,15 +81,29 @@ class AuthNotifier extends StateNotifier<AuthState> {
   }
 
   /// On startup, restore the session from a stored token if one exists.
+  ///
+  /// Warm boots (token + cached user snapshot) are **optimistic**: the shell
+  /// mounts immediately on the snapshot while `/auth/me` revalidates in the
+  /// background (see [_revalidate] for the revalidate-on-boot semantics).
+  /// First-ever boots (no snapshot yet) keep the serial check-then-mount
+  /// path so a never-verified token can't flash the shell.
   Future<void> _restore() async {
     final token = await _storage.loadToken();
     if (token == null) {
       state = state.copyWith(initialized: true);
       return;
     }
+    final cached = await _loadUserSnapshot();
+    if (cached != null) {
+      _apiClient.authToken = token;
+      state = state.copyWith(user: cached, initialized: true);
+      unawaited(_revalidate(token));
+      return;
+    }
     try {
       final user = await _service.me(token).timeout(restoreTimeout);
       _apiClient.authToken = token;
+      unawaited(_saveUserSnapshot(user));
       state = state.copyWith(user: user, initialized: true);
     } on TimeoutException {
       // Backend slow/unreachable — fail open as signed out, but KEEP the
@@ -98,9 +113,67 @@ class AuthNotifier extends StateNotifier<AuthState> {
     } catch (_) {
       // Token invalid/expired — clear it and start signed out.
       await _storage.clearToken();
+      unawaited(_clearUserSnapshot());
       _apiClient.authToken = null;
       state = state.copyWith(initialized: true, clearUser: true);
     }
+  }
+
+  /// Background `/auth/me` check behind an optimistic warm boot
+  /// (revalidate-on-boot):
+  /// - success → refresh the in-memory user and the stored snapshot;
+  /// - auth rejection (401/403 — the token was revoked/expired server-side)
+  ///   → clear the stored session and flip to signed out;
+  /// - timeout / network error / server 5xx → KEEP the optimistic state.
+  ///   A valid cached session with a briefly unreachable backend beats the
+  ///   old behavior of bouncing the user to the landing screen; the next
+  ///   boot revalidates again.
+  Future<void> _revalidate(String token) async {
+    try {
+      final user = await _service.me(token).timeout(restoreTimeout);
+      unawaited(_saveUserSnapshot(user));
+      if (!mounted) return;
+      state = state.copyWith(user: user);
+    } on AuthException catch (e) {
+      if (e.statusCode == 401 || e.statusCode == 403) {
+        await _storage.clearToken();
+        unawaited(_clearUserSnapshot());
+        _apiClient.authToken = null;
+        if (mounted) state = state.copyWith(clearUser: true);
+      }
+      // Other statuses (5xx etc.): keep the optimistic session.
+    } catch (_) {
+      // Timeout or transport failure: keep the optimistic session.
+    }
+  }
+
+  /// Decodes the cached user snapshot; null (→ serial restore path) when
+  /// absent, unreadable, or corrupt. Best-effort by design: snapshot
+  /// failures must never break boot.
+  Future<UserModel?> _loadUserSnapshot() async {
+    try {
+      final raw = await _storage.loadUserSnapshot();
+      if (raw == null) return null;
+      return UserModel.fromJson(jsonDecode(raw) as Map<String, dynamic>);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  /// Persists the freshest server-provided user for the next warm boot.
+  /// Best-effort by design, so callers fire-and-forget it (`unawaited`):
+  /// a user-visible state transition must never block on — or hang with —
+  /// snapshot persistence; a failure only costs the next boot its warm path.
+  Future<void> _saveUserSnapshot(UserModel user) async {
+    try {
+      await _storage.saveUserSnapshot(jsonEncode(user.toJson()));
+    } catch (_) {/* best effort */}
+  }
+
+  Future<void> _clearUserSnapshot() async {
+    try {
+      await _storage.clearUserSnapshot();
+    } catch (_) {/* best effort */}
   }
 
   Future<bool> login(String email, String password) =>
@@ -115,6 +188,7 @@ class AuthNotifier extends StateNotifier<AuthState> {
     try {
       final res = await call();
       await _storage.saveToken(res.token);
+      unawaited(_saveUserSnapshot(res.user));
       _apiClient.authToken = res.token;
       state = state.copyWith(user: res.user, loading: false);
       return true;
@@ -138,6 +212,7 @@ class AuthNotifier extends StateNotifier<AuthState> {
       final token = await _storage.loadToken();
       if (token != null) {
         final user = await _service.completeOnboarding(token);
+        unawaited(_saveUserSnapshot(user));
         state = state.copyWith(user: user);
         return;
       }
@@ -172,6 +247,7 @@ class AuthNotifier extends StateNotifier<AuthState> {
   Future<void> signOutLocally() async {
     final userId = state.user?.id;
     await _storage.clearToken();
+    unawaited(_clearUserSnapshot());
     _apiClient.authToken = null;
     state = state.copyWith(clearUser: true, clearError: true);
     // Privacy: drop the offline trip cache alongside the credentials so the
@@ -182,12 +258,14 @@ class AuthNotifier extends StateNotifier<AuthState> {
   /// Replaces the in-memory user (e.g. after a profile edit).
   void setUser(UserModel user) {
     state = state.copyWith(user: user);
+    unawaited(_saveUserSnapshot(user)); // keep the warm-boot snapshot fresh
   }
 
   /// Adopts a fresh session minted by the server (e.g. after a password
   /// change revoked every other session).
   Future<void> adoptSession(String token, UserModel user) async {
     await _storage.saveToken(token);
+    unawaited(_saveUserSnapshot(user));
     _apiClient.authToken = token;
     state = state.copyWith(user: user, clearError: true);
   }

--- a/src/packages/flutter-app/lib/services/auth_storage.dart
+++ b/src/packages/flutter-app/lib/services/auth_storage.dart
@@ -3,8 +3,15 @@ import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 /// Persists the session token on-device so the user stays signed in across
 /// app restarts. Backed by Keychain/Keystore on mobile and an encrypted
 /// store on web.
+///
+/// Alongside the token it caches the last server-provided user JSON
+/// (specs: optimistic shell boot) so a warm boot can mount the shell
+/// immediately from the snapshot while `/auth/me` revalidates in the
+/// background. The snapshot lives and dies with the token: both are written
+/// on sign-in and cleared together on sign-out/revocation.
 class AuthStorage {
   static const _tokenKey = 'session_token';
+  static const _userKey = 'session_user';
   final FlutterSecureStorage _storage;
 
   AuthStorage({FlutterSecureStorage? storage})
@@ -16,4 +23,12 @@ class AuthStorage {
   Future<String?> loadToken() => _storage.read(key: _tokenKey);
 
   Future<void> clearToken() => _storage.delete(key: _tokenKey);
+
+  /// Caches the last successful auth user payload (encoded JSON).
+  Future<void> saveUserSnapshot(String userJson) =>
+      _storage.write(key: _userKey, value: userJson);
+
+  Future<String?> loadUserSnapshot() => _storage.read(key: _userKey);
+
+  Future<void> clearUserSnapshot() => _storage.delete(key: _userKey);
 }

--- a/src/packages/flutter-app/test/auth_restore_timeout_test.dart
+++ b/src/packages/flutter-app/test/auth_restore_timeout_test.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:convert';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:travel_route_planner/models/user.dart';
@@ -19,8 +20,10 @@ class _FakeAuthService extends AuthService {
 /// In-memory AuthStorage that records whether the token was cleared.
 class _FakeAuthStorage extends AuthStorage {
   String? token;
+  String? userSnapshot;
   bool cleared = false;
-  _FakeAuthStorage(this.token);
+  bool snapshotCleared = false;
+  _FakeAuthStorage(this.token, {this.userSnapshot});
 
   @override
   Future<String?> loadToken() async => token;
@@ -33,7 +36,28 @@ class _FakeAuthStorage extends AuthStorage {
     token = null;
     cleared = true;
   }
+
+  @override
+  Future<String?> loadUserSnapshot() async => userSnapshot;
+
+  @override
+  Future<void> saveUserSnapshot(String value) async => userSnapshot = value;
+
+  @override
+  Future<void> clearUserSnapshot() async {
+    userSnapshot = null;
+    snapshotCleared = true;
+  }
 }
+
+UserModel _user({String displayName = 'Traveler'}) => UserModel(
+      id: 'u1',
+      email: 'traveler@example.com',
+      displayName: displayName,
+      createdAt: DateTime.utc(2026, 1, 1),
+    );
+
+String _snapshotOf(UserModel u) => jsonEncode(u.toJson());
 
 void main() {
   late Duration originalTimeout;
@@ -47,55 +71,179 @@ void main() {
     AuthNotifier.restoreTimeout = originalTimeout;
   });
 
-  test('restore timeout fails open signed-out and keeps the token', () async {
-    final storage = _FakeAuthStorage('stored-token');
-    // `me` never completes — simulates a hung/cold backend.
-    final service = _FakeAuthService(() => Completer<UserModel>().future);
-    final apiClient = ApiClient(baseUrl: 'http://unused');
+  group('first-ever boot (no cached user snapshot) — serial path', () {
+    test('restore timeout fails open signed-out and keeps the token',
+        () async {
+      final storage = _FakeAuthStorage('stored-token');
+      // `me` never completes — simulates a hung/cold backend.
+      final service = _FakeAuthService(() => Completer<UserModel>().future);
+      final apiClient = ApiClient(baseUrl: 'http://unused');
 
-    final notifier = AuthNotifier(service, storage, apiClient);
-    await Future<void>.delayed(const Duration(milliseconds: 200));
+      final notifier = AuthNotifier(service, storage, apiClient);
+      await Future<void>.delayed(const Duration(milliseconds: 200));
 
-    expect(notifier.state.initialized, isTrue);
-    expect(notifier.state.isSignedIn, isFalse);
-    expect(storage.cleared, isFalse, reason: 'timeout must keep the token');
-    expect(storage.token, 'stored-token');
-    expect(apiClient.authToken, isNull);
+      expect(notifier.state.initialized, isTrue);
+      expect(notifier.state.isSignedIn, isFalse);
+      expect(storage.cleared, isFalse, reason: 'timeout must keep the token');
+      expect(storage.token, 'stored-token');
+      expect(apiClient.authToken, isNull);
+    });
+
+    test('restore error clears the token', () async {
+      final storage = _FakeAuthStorage('stored-token');
+      final service = _FakeAuthService(() async => throw const AuthException(
+          statusCode: 401, message: 'invalid token'));
+      final apiClient = ApiClient(baseUrl: 'http://unused');
+
+      final notifier = AuthNotifier(service, storage, apiClient);
+      await Future<void>.delayed(const Duration(milliseconds: 200));
+
+      expect(notifier.state.initialized, isTrue);
+      expect(notifier.state.isSignedIn, isFalse);
+      expect(storage.cleared, isTrue);
+      expect(storage.token, isNull);
+    });
+
+    test('restore success signs the user in and caches the snapshot',
+        () async {
+      final storage = _FakeAuthStorage('stored-token');
+      final service = _FakeAuthService(() async => _user());
+      final apiClient = ApiClient(baseUrl: 'http://unused');
+
+      final notifier = AuthNotifier(service, storage, apiClient);
+      await Future<void>.delayed(const Duration(milliseconds: 200));
+
+      expect(notifier.state.initialized, isTrue);
+      expect(notifier.state.isSignedIn, isTrue);
+      expect(apiClient.authToken, 'stored-token');
+      expect(storage.cleared, isFalse);
+      expect(storage.userSnapshot, isNotNull,
+          reason: 'a successful /auth/me must cache the user for warm boots');
+    });
   });
 
-  test('restore error clears the token', () async {
-    final storage = _FakeAuthStorage('stored-token');
-    final service =
-        _FakeAuthService(() async =>
-            throw const AuthException(statusCode: 401, message: 'invalid token'));
-    final apiClient = ApiClient(baseUrl: 'http://unused');
+  group('warm boot (token + cached user snapshot) — optimistic path', () {
+    test('mounts immediately from the snapshot while me() is still pending',
+        () async {
+      final storage =
+          _FakeAuthStorage('stored-token', userSnapshot: _snapshotOf(_user()));
+      // `me` never completes: the shell must still mount from the snapshot.
+      final service = _FakeAuthService(() => Completer<UserModel>().future);
+      final apiClient = ApiClient(baseUrl: 'http://unused');
 
-    final notifier = AuthNotifier(service, storage, apiClient);
-    await Future<void>.delayed(const Duration(milliseconds: 200));
+      final notifier = AuthNotifier(service, storage, apiClient);
+      // Only a couple of microtask-level storage awaits stand between boot
+      // and the optimistic state — well under the 50 ms restore timeout.
+      await Future<void>.delayed(const Duration(milliseconds: 10));
 
-    expect(notifier.state.initialized, isTrue);
-    expect(notifier.state.isSignedIn, isFalse);
-    expect(storage.cleared, isTrue);
-    expect(storage.token, isNull);
+      expect(notifier.state.initialized, isTrue);
+      expect(notifier.state.isSignedIn, isTrue);
+      expect(notifier.state.user!.email, 'traveler@example.com');
+      expect(apiClient.authToken, 'stored-token');
+    });
+
+    test('background revalidation timeout KEEPS the optimistic session',
+        () async {
+      final storage =
+          _FakeAuthStorage('stored-token', userSnapshot: _snapshotOf(_user()));
+      final service = _FakeAuthService(() => Completer<UserModel>().future);
+      final apiClient = ApiClient(baseUrl: 'http://unused');
+
+      final notifier = AuthNotifier(service, storage, apiClient);
+      // Wait past the 50 ms restore timeout: unlike the serial path, a
+      // slow/unreachable backend must NOT bounce a cached session.
+      await Future<void>.delayed(const Duration(milliseconds: 200));
+
+      expect(notifier.state.isSignedIn, isTrue);
+      expect(storage.cleared, isFalse);
+      expect(storage.userSnapshot, isNotNull);
+      expect(apiClient.authToken, 'stored-token');
+    });
+
+    test('background revalidation success refreshes the user in place',
+        () async {
+      final storage =
+          _FakeAuthStorage('stored-token', userSnapshot: _snapshotOf(_user()));
+      final service =
+          _FakeAuthService(() async => _user(displayName: 'Renamed'));
+      final apiClient = ApiClient(baseUrl: 'http://unused');
+
+      final notifier = AuthNotifier(service, storage, apiClient);
+      await Future<void>.delayed(const Duration(milliseconds: 200));
+
+      expect(notifier.state.isSignedIn, isTrue);
+      expect(notifier.state.user!.displayName, 'Renamed');
+      expect(storage.userSnapshot, contains('Renamed'),
+          reason: 'the refreshed user must become the next warm-boot snapshot');
+    });
+
+    test('background revalidation 401 signs out and clears the session',
+        () async {
+      final storage =
+          _FakeAuthStorage('stored-token', userSnapshot: _snapshotOf(_user()));
+      final service = _FakeAuthService(() async => throw const AuthException(
+          statusCode: 401, message: 'invalid token'));
+      final apiClient = ApiClient(baseUrl: 'http://unused');
+
+      final notifier = AuthNotifier(service, storage, apiClient);
+      await Future<void>.delayed(const Duration(milliseconds: 200));
+
+      expect(notifier.state.initialized, isTrue);
+      expect(notifier.state.isSignedIn, isFalse);
+      expect(storage.cleared, isTrue);
+      expect(storage.snapshotCleared, isTrue);
+      expect(storage.token, isNull);
+      expect(storage.userSnapshot, isNull);
+      expect(apiClient.authToken, isNull);
+    });
+
+    test('background revalidation 5xx KEEPS the optimistic session',
+        () async {
+      final storage =
+          _FakeAuthStorage('stored-token', userSnapshot: _snapshotOf(_user()));
+      final service = _FakeAuthService(() async => throw const AuthException(
+          statusCode: 503, message: 'backend degraded'));
+      final apiClient = ApiClient(baseUrl: 'http://unused');
+
+      final notifier = AuthNotifier(service, storage, apiClient);
+      await Future<void>.delayed(const Duration(milliseconds: 200));
+
+      expect(notifier.state.isSignedIn, isTrue);
+      expect(storage.cleared, isFalse);
+      expect(apiClient.authToken, 'stored-token');
+    });
+
+    test('corrupt snapshot falls back to the serial path', () async {
+      final storage =
+          _FakeAuthStorage('stored-token', userSnapshot: 'not json{');
+      final service = _FakeAuthService(() async => _user());
+      final apiClient = ApiClient(baseUrl: 'http://unused');
+
+      final notifier = AuthNotifier(service, storage, apiClient);
+      await Future<void>.delayed(const Duration(milliseconds: 200));
+
+      expect(notifier.state.initialized, isTrue);
+      expect(notifier.state.isSignedIn, isTrue);
+      expect(storage.userSnapshot, _snapshotOf(_user()),
+          reason: 'serial restore success must repair the snapshot');
+    });
   });
 
-  test('restore success signs the user in', () async {
-    final user = UserModel(
-      id: 'u1',
-      email: 'traveler@example.com',
-      displayName: 'Traveler',
-      createdAt: DateTime.utc(2026, 1, 1),
-    );
-    final storage = _FakeAuthStorage('stored-token');
-    final service = _FakeAuthService(() async => user);
+  test('signOutLocally clears the cached user snapshot with the token',
+      () async {
+    final storage =
+        _FakeAuthStorage('stored-token', userSnapshot: _snapshotOf(_user()));
+    final service = _FakeAuthService(() async => _user());
     final apiClient = ApiClient(baseUrl: 'http://unused');
 
     final notifier = AuthNotifier(service, storage, apiClient);
     await Future<void>.delayed(const Duration(milliseconds: 200));
-
-    expect(notifier.state.initialized, isTrue);
     expect(notifier.state.isSignedIn, isTrue);
-    expect(apiClient.authToken, 'stored-token');
-    expect(storage.cleared, isFalse);
+
+    await notifier.signOutLocally();
+
+    expect(notifier.state.isSignedIn, isFalse);
+    expect(storage.token, isNull);
+    expect(storage.userSnapshot, isNull);
   });
 }

--- a/src/packages/flutter-app/web/index.html
+++ b/src/packages/flutter-app/web/index.html
@@ -160,7 +160,20 @@
     // beneath, so a user click on a sibling still focuses the right
     // Flutter field.
     (function () {
-      console.info('[autofill] shim v3.2 active');
+      // Perf gate (v3.3): the shim's expensive work (forced-reflow
+      // getBoundingClientRect/getComputedStyle in sizeAutofillForm, the
+      // 200 ms relay poll) only matters while an auth screen's autofill
+      // form is in the DOM — those flt-text-editing-host form fields exist
+      // ONLY on auth screens. `active` flips on via the capture-phase
+      // focusin listener below and back off after ~25 consecutive relay
+      // ticks (~5 s) find no autofill form. While dormant, non-auth
+      // screens pay exactly one boolean read per mutation batch and run
+      // NO polling interval.
+      var active = false;
+      var relayTimer = null;
+      var idleTicks = 0;
+      var AUTOFILL_PROBE =
+          'flt-text-editing-host form input, flt-text-editing-host form textarea';
       var diagnosed = new WeakSet();
       var forwarded = new WeakSet();
       // Last value the engine is known to have ingested per input — kept in
@@ -170,6 +183,7 @@
         // Verbose-level breadcrumbs for debugging real password-manager
         // behavior (DevTools console, "Verbose" filter, search "autofill").
         lastSeen.set(e.target, e.target.value || '');
+        if (!active) return; // breadcrumbs only while an auth form is live
         console.debug('[autofill] ' + e.type +
             ' on ' + (e.target.getAttribute('autocomplete') || e.target.name) +
             ' len=' + (e.target.value || '').length +
@@ -183,10 +197,20 @@
       // input event for any value that changed with no event — the engine's
       // own listener then ingests it. Duplicate delivery for event-ful
       // writes is harmless: same-value updates are dropped app-side.
-      setInterval(function () {
-        var probe = document.querySelector(
-            'flt-text-editing-host form input, flt-text-editing-host form textarea');
-        if (!probe) return;
+      // The interval is NOT started at boot: focusin on an auth form starts
+      // it (see the activation listener at the bottom) and ~25 consecutive
+      // empty ticks (~5 s after the auth form leaves the DOM) stop it.
+      function relayTick() {
+        var probe = document.querySelector(AUTOFILL_PROBE);
+        if (!probe) {
+          if (++idleTicks >= 25) { // ~5 s with no auth form: go dormant
+            active = false;
+            clearInterval(relayTimer);
+            relayTimer = null;
+          }
+          return;
+        }
+        idleTicks = 0;
         var fields = probe.form.querySelectorAll('input, textarea');
         for (var i = 0; i < fields.length; i++) {
           var el = fields[i];
@@ -208,7 +232,7 @@
             data: value,
           }));
         }
-      }, 200);
+      }
       // A pointer event landed on a non-focused autofill input. Cancel it
       // (also suppresses the compatibility mouse events) and re-dispatch a
       // clone at whatever the engine has under that point, found by
@@ -240,6 +264,7 @@
         }));
       }
       function sizeAutofillForm() {
+        if (!active) return; // dormant off auth screens (perf gate above)
         var focused = document.querySelector(
             'form input.flt-text-editing, form textarea.flt-text-editing');
         if (!focused || !focused.form) return;
@@ -315,14 +340,35 @@
       // Run synchronously inside the observer callback: our observer is
       // registered before extension content scripts, so the fields are
       // already sized when the extension's own observer sees the same
-      // mutation batch and analyzes the form.
-      new MutationObserver(sizeAutofillForm).observe(document.body, {
+      // mutation batch and analyzes the form. The observer stays
+      // registered permanently to preserve that ordering guarantee — the
+      // `active` gate (not observer teardown) is what makes non-auth
+      // screens cheap.
+      new MutationObserver(function () {
+        if (!active) return; // dormant: one boolean read per mutation batch
+        sizeAutofillForm();
+      }).observe(document.body, {
         childList: true,
         subtree: true,
         attributes: true,
         attributeFilter: ['style', 'class'],
       });
-      document.addEventListener('focusin', sizeAutofillForm, true);
+      // Activation: permanent capture-phase focusin listener (event-driven,
+      // cheap). Auth-screen text fields are the only ones Flutter mounts
+      // inside a flt-text-editing-host <form> (AutofillGroup), so a focusin
+      // with that probe present means an auth screen is up: wake the shim
+      // and start the relay poll. Focus lands synchronously in the same
+      // task that inserts the form, so the fields are sized here before
+      // any observer (ours or an extension's) processes that mutation
+      // batch — the ordering guarantee above still holds while gated.
+      document.addEventListener('focusin', function () {
+        if (!active && document.querySelector(AUTOFILL_PROBE)) {
+          active = true;
+          idleTicks = 0;
+          if (relayTimer === null) relayTimer = setInterval(relayTick, 200);
+        }
+        sizeAutofillForm();
+      }, true);
     })();
   </script>
 


### PR DESCRIPTION
Wave 3 Lane 3A of the perf program (plan: the-app-feels-pretty-sorted-crescent).

## What

1. **Autofill shim perf gate** (`web/index.html`, shim v3.3). The whole-document MutationObserver callback (forced-reflow measurement work) and the 200 ms relay poll now run only while an auth screen's autofill form is live. A permanent capture-phase `focusin` listener activates the shim when the `flt-text-editing-host form` probe matches; ~25 consecutive empty relay ticks (~5 s after the form leaves the DOM) return it to dormant. The observer stays **registered** permanently — activation gating, not teardown — preserving the registered-before-extension-scripts ordering guarantee. Dormant screens pay one boolean read per mutation batch and zero polling. The PARKED web-autofill feature keeps working on auth screens unchanged.
2. **Optimistic shell boot** (`auth_provider.dart` / `auth_storage.dart`). Warm boots (token + cached `/auth/me` snapshot) mount the shell immediately and revalidate in the background: 401/403 clears the session and signs out; timeout/network/5xx keeps the optimistic session. First-ever boots keep the serial check-then-mount path so a never-verified token can't flash the shell. Snapshot is written on sign-in/adopt/profile-refresh and cleared with the token everywhere it dies.
3. **Service-worker cache fixed for `--base-href /app/`** (deployment Dockerfile). Stock SW computes cache keys as `url.substring(origin.length + 1)`, so under `/app/` request keys carry an `app/` prefix that never matches the bare RESOURCES keys — the cache was written on install and never read (baseline D2 finding). A guarded sed rewrites the key computation to `+ 5`; the image build fails loudly if the SW layout ever changes.
4. **AuthGate AnimatedSwitcher 250 ms → 120 ms.**

## Verification

- 27 targeted tests pass (auth_restore_timeout incl. new optimistic-boot/revalidate coverage, auth_autofill_submit, url_boot_restore, sso_buttons); `flutter analyze` clean (3 pre-existing infos).
- Full suite + image build via CI/deploy.
- Post-deploy manual check for Brian: real password-manager fill on sign-in still works (parked web-autofill feature), and a warm reload's waterfall should show /auth/me overlapping /trips + /chats.

🤖 Generated with [Claude Code](https://claude.com/claude-code)