### PR TITLE
perf(flutter): memoize trip-detail derivation behind one identity-keyed cache

### DIFF
--- a/src/packages/flutter-app/lib/screens/trip_detail_derivation.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_derivation.dart
@@ -1,0 +1,577 @@
+// The trip-detail screen's derivation pipeline, computed ONCE per input
+// signature (specs/perf-program, Wave 4 PR1).
+//
+// Before this file, every setState on the 6000-line hub screen re-ran the
+// whole pipeline inside build() — the tripLegs split ~5-6× and the filtered
+// list ~4× per build — on view-only taps (row select, city expand, day
+// collapse, filter, Today chip, map day chips, pin tap, booked checkbox,
+// section toggles). [TripDerivation] absorbs those method bodies verbatim and
+// the State memoizes one instance behind `_derive(trip)`:
+//
+//   * [TripDerivation.compute] is THE one computation site.
+//   * [TripDerivation.matches] is the memo signature: `identical()` on the
+//     object inputs (trip, bookingTodos, stays, segments, travelByPos, l10n)
+//     plus `==` on itemFilter and the item-order epoch. Identity works as an
+//     invalidation signal because every mutation path on the screen replaces
+//     its input objects wholesale — EXCEPT `_reorderBatchInline`, the one
+//     in-place mutation, which bumps the epoch instead (the stated contract:
+//     any in-place mutation of a derivation input MUST bump the epoch).
+//   * The lazy per-day accessors ([dayFilteredItems], [dayFilteredStays],
+//     [staysOnNight]) return a stable List identity per (derivation, day) —
+//     the map-isolation follow-up (Wave 4 PR2) keys its marker cache on that
+//     identity, so keep it stable.
+//
+// The class is immutable in the docs/zen.md sense: all derived state is
+// computed from the constructor inputs and nothing here reads the widget
+// tree, providers, or the clock. Time-dependent decisions (today's day, the
+// Tonight caption gate) stay in build and query this object
+// ([firstGroupKeyForDay], [staysOnNight]).
+
+import 'package:latlong2/latlong.dart' show LatLng;
+
+import '../l10n/l10n.dart';
+import '../models/accommodation.dart';
+import '../models/booking_todo.dart';
+import '../models/itinerary_item.dart';
+import '../models/location_timing.dart';
+import '../models/trip.dart';
+import '../models/trip_segment.dart';
+import '../utils/date_formats.dart';
+import '../utils/leg_ranges.dart';
+import '../utils/trip_days.dart';
+import '../utils/trip_legs.dart';
+import '../widgets/trip_map.dart';
+
+/// City-header date-chip parts, kept separate so the header can align them as
+/// columns across rows: [range] renders left-aligned after the calendar icon,
+/// [nights] (the localized "· N nights" suffix) renders flush right. Null
+/// [nights] = zero-night squeezed leg — no nights widget renders at all.
+typedef LegDateChip = ({String range, String? nights});
+
+/// One city group as built by [TripDerivation.compute] and consumed by the
+/// screen's `_cityHeader` / group slivers.
+typedef CityGroup = ({
+  String key,
+  String label,
+  LegDateChip? dateRange,
+  List<ItineraryItem> items
+});
+
+/// One city's embedded booking rows: the flight that arrives at the city, its
+/// stay, and (for the last city) the return flight home — each todo paired
+/// with its matched confirmed record.
+typedef BookingSlot = ({
+  BookingTodo? arrival,
+  TripSegment? arrivalMatch,
+  BookingTodo? stay,
+  Accommodation? stayMatch,
+  BookingTodo? departure,
+  TripSegment? departureMatch,
+});
+
+/// The one full-label booking partition (see [TripDerivation.groupedBookings]).
+typedef GroupedBookings = ({
+  List<BookingSlot> slots,
+  List<BookingTodo> residual,
+  List<Accommodation> residualStays,
+  List<TripSegment> residualSegments,
+});
+
+/// Display text for a city-group label: the canonical [kOtherPlacesLabel] key
+/// gets a translated label, every real city keeps the name as-is.
+String groupLabelText(AppLocalizations l10n, String label) =>
+    label == kOtherPlacesLabel ? l10n.tripOtherPlaces : label;
+
+/// True for the AI's "city filler" placeholder — an item whose name is just
+/// the city it renders under (e.g. name 'Prague', city 'Prague'), emitted for
+/// days with no specific activities. Its text duplicates the city/day-trip
+/// header it sits below, so hiding the tile is lossless. The SUPPRESSION
+/// itself stays in the screen's `_buildGroupItemSlivers` — an all-filler city
+/// must keep its group (city header + embedded booking rows).
+bool isCityFiller(ItineraryItem item) {
+  final name = item.name.trim().toLowerCase();
+  if (name.isEmpty) return false;
+  bool eq(String? s) => s != null && s.trim().toLowerCase() == name;
+  return eq(cityOf(item)) || eq(item.dayTripFrom);
+}
+
+/// Formats a travel duration: "45 min", "1h", or "1h 20m".
+String fmtTravel(AppLocalizations l10n, int min) {
+  if (min < 60) return l10n.tripTravelMinutes(min);
+  final h = min ~/ 60;
+  final m = min % 60;
+  return m == 0 ? l10n.tripTravelHours(h) : l10n.tripTravelHoursMinutes(h, m);
+}
+
+class TripDerivation {
+  // ── Signature inputs (see [matches]) ──────────────────────────────────
+  final Trip trip;
+  final List<BookingTodo> bookingTodos;
+  final List<Accommodation> stays;
+  final List<TripSegment> segments;
+  final Map<int, LocationTiming> travelByPos;
+  final String itemFilter;
+
+  /// The derivation OUTPUT is localized (nights suffixes, travel labels,
+  /// 'Other places'), so the localizations object is a signature input: a
+  /// locale switch delivers a new instance and forces a recompute.
+  final AppLocalizations l10n;
+
+  /// See the header comment: bumped by the screen for any in-place mutation
+  /// of a derivation input, because identity checks can't see those.
+  final int itemOrderEpoch;
+
+  // ── Derived state, computed once in [compute] ─────────────────────────
+
+  /// Itinerary items matching the active places lens, used by both the map
+  /// and the list so they stay in sync. 'unbooked' and 'bookings' are
+  /// bookings lenses, not places ones — the list swaps to booking rows while
+  /// the places set (and thus the maps) stays whole.
+  final List<ItineraryItem> filtered;
+
+  /// The canonical locality runs over the FULL itinerary (shared [tripLegs]
+  /// split) — what the map pin-tap and expand-new-items flows walk.
+  final List<TripLeg> legs;
+
+  /// The leg date ranges, raw and as rendered. Both live HERE so every
+  /// consumer — header chips, nights suffixes, stay/leg booking todos,
+  /// what-to-wear rows — structurally reads the same pair (docs/zen.md: one
+  /// derivation, N call sites).
+  final List<LegRange> rawRanges;
+  final List<LegRange> visibleRanges;
+
+  /// Leg labels in trip order ([rawRanges] order) — the booking-slot keys.
+  final List<String> legLabels;
+
+  /// Date window per city-group label (label-keyed, last-wins for revisited
+  /// cities), for the embedded weather/events lookups.
+  final Map<String, ({DateTime? start, DateTime? end})> groupRanges;
+
+  /// Each itinerary item's position mapped to its location's date-chip parts
+  /// (arrival-adjusted [visibleRanges] + localized nights suffix).
+  final Map<int, LegDateChip> locationDates;
+
+  /// Consecutive same-locality runs of [filtered], labelled with the date
+  /// range precomputed for that location.
+  final List<CityGroup> groups;
+
+  /// The one full-label booking partition: todos AND confirmed stays/segments
+  /// claimed at most once into per-city slots, plus the residual lists.
+  /// Consumers filter this OUTPUT (never re-partition on a label subset — the
+  /// claim-once matching is order-dependent, docs/zen.md).
+  final GroupedBookings groupedBookings;
+
+  /// Travel-time labels for the trip map, keyed by the source item's
+  /// position. Empty while a category filter is active.
+  final Map<int, String> segmentLabels;
+
+  /// Destination pins for the trip-overview map, derived from the FULL
+  /// itinerary — never the filtered view, which would shift the numbering.
+  final List<TripMapDestination> mapDestinations;
+
+  /// The trip's first/last location-group coordinates — the same derivation
+  /// the outbound/return booking todos trust.
+  final ({LatLng? first, LatLng? last}) homeLegEndpoints;
+
+  /// Map-visibility gate: a filtered item with coordinates OR a geocoded
+  /// stay. Shared by build and the pinned-chrome scroll math.
+  final bool mapShown;
+
+  /// The trip's user-confirmed stays (auto=false). Suggested drafts are
+  /// working state for the bookings hub only — never the map, the Tonight
+  /// caption, or the leg ranges.
+  final List<Accommodation> confirmedStays;
+
+  /// Map day-chip count — spans the whole trip, never the category filter.
+  final int mapDayCount;
+
+  /// Days that would plot something on the map (muted chips otherwise).
+  final Set<int> mappedDays;
+
+  /// Day keys (`'$groupKey#$day'`) of the CURRENT groups, collapsed ones
+  /// included, so day-jump resolution can expand a group that has never
+  /// rendered and still land (specs/today-mode).
+  final Set<String> liveDayKeys;
+
+  // Lazy per-day caches — see the header comment for the identity contract.
+  final Map<int?, List<ItineraryItem>> _dayItemsCache = {};
+  final Map<int, List<Accommodation>> _staysOnNightCache = {};
+
+  TripDerivation._({
+    required this.trip,
+    required this.bookingTodos,
+    required this.stays,
+    required this.segments,
+    required this.travelByPos,
+    required this.itemFilter,
+    required this.l10n,
+    required this.itemOrderEpoch,
+    required this.filtered,
+    required this.legs,
+    required this.rawRanges,
+    required this.visibleRanges,
+    required this.legLabels,
+    required this.groupRanges,
+    required this.locationDates,
+    required this.groups,
+    required this.groupedBookings,
+    required this.segmentLabels,
+    required this.mapDestinations,
+    required this.homeLegEndpoints,
+    required this.mapShown,
+    required this.confirmedStays,
+    required this.mapDayCount,
+    required this.mappedDays,
+    required this.liveDayKeys,
+  });
+
+  /// Whether this derivation is still valid for the given inputs: identity
+  /// on the object inputs, equality on the filter and the epoch. Every
+  /// mutation path on the screen replaces its input objects wholesale, so a
+  /// surviving identity means unchanged content (the epoch covers the one
+  /// documented in-place exception).
+  bool matches({
+    required Trip trip,
+    required List<BookingTodo> bookingTodos,
+    required List<Accommodation> stays,
+    required List<TripSegment> segments,
+    required Map<int, LocationTiming> travelByPos,
+    required String itemFilter,
+    required AppLocalizations l10n,
+    required int itemOrderEpoch,
+  }) =>
+      identical(trip, this.trip) &&
+      identical(bookingTodos, this.bookingTodos) &&
+      identical(stays, this.stays) &&
+      identical(segments, this.segments) &&
+      identical(travelByPos, this.travelByPos) &&
+      identical(l10n, this.l10n) &&
+      itemFilter == this.itemFilter &&
+      itemOrderEpoch == this.itemOrderEpoch;
+
+  /// [filtered] further narrowed to a map day chip selection (null = All).
+  /// The maps are the only consumers — the itinerary list never day-filters.
+  /// Untagged items (day == null) show only under All. Stable List identity
+  /// per (derivation, day).
+  List<ItineraryItem> dayFilteredItems(int? day) =>
+      _dayItemsCache.putIfAbsent(
+          day,
+          () => day == null
+              ? filtered
+              : filtered.where((i) => i.day == day).toList());
+
+  /// Stays the map should plot for a day chip selection: under All (null),
+  /// every confirmed stay; under Day N, only stays covering that night
+  /// (checkout-exclusive). Stable List identity per (derivation, day).
+  List<Accommodation> dayFilteredStays(int? day) =>
+      day == null ? confirmedStays : staysOnNight(day);
+
+  /// Stays covering the night of trip day [day], checkout-exclusively — the
+  /// single home of the day→night math shared by the map's day filter and
+  /// the Tonight caption. A trip without a parseable start date can't map
+  /// Day N to a calendar date, so no stay matches. Stable List identity per
+  /// (derivation, day).
+  List<Accommodation> staysOnNight(int day) =>
+      _staysOnNightCache.putIfAbsent(day, () {
+        final start = DateTime.tryParse(trip.startDate ?? '');
+        if (start == null) return const [];
+        // Calendar-day arithmetic (constructor normalizes overflow) rather
+        // than Duration, which drifts a date across a DST transition.
+        final night = DateTime(start.year, start.month, start.day + day - 1);
+        return confirmedStays
+            .where((a) => stayCoversDate(a.checkIn, a.checkOut, night))
+            .toList();
+      });
+
+  /// The FIRST group (build order) containing an item on trip day [day], or
+  /// null. Feeds the Tonight-caption seeding: day numbers repeat across city
+  /// groups, so exactly one group may ever show the caption. Matched on the
+  /// run key, not the label: a revisited city has two runs sharing a label.
+  String? firstGroupKeyForDay(int? day) {
+    if (day == null) return null;
+    for (final group in groups) {
+      if (group.items.any((it) => it.day == day)) return group.key;
+    }
+    return null;
+  }
+
+  /// THE one computation site for everything above. Bodies are verbatim from
+  /// the screen's former per-build methods; see each field's doc.
+  static TripDerivation compute({
+    required Trip trip,
+    required List<BookingTodo> bookingTodos,
+    required List<Accommodation> stays,
+    required List<TripSegment> segments,
+    required Map<int, LocationTiming> travelByPos,
+    required String itemFilter,
+    required AppLocalizations l10n,
+    required int itemOrderEpoch,
+  }) {
+    final items = trip.items ?? const <ItineraryItem>[];
+
+    final filtered = switch (itemFilter) {
+      'all' || 'unbooked' || 'bookings' => items.toList(),
+      'local' => items
+          .where((i) => (i.localSourceName ?? '').trim().isNotEmpty)
+          .toList(),
+      _ => items.where((i) => i.category == itemFilter).toList(),
+    };
+
+    final confirmedStays = (trip.accommodations ?? const <Accommodation>[])
+        .where((a) => !a.auto)
+        .toList();
+
+    final legs = tripLegs(items);
+    final rawRanges = rawLegRanges(trip);
+    final visibleRanges = visibleLegRanges(trip);
+    final legLabels = [for (final r in rawRanges) r.label];
+    final groupRanges = {
+      for (final r in rawRanges) r.label: (start: r.start, end: r.end)
+    };
+
+    // Per-position date chips from the arrival-adjusted visible ranges —
+    // index-aligned with [legs] by construction (both run the same tripLegs
+    // split over the same items). Both strings are final display text: the
+    // chip-width measurement must see these exact strings, never
+    // re-formatted copies.
+    final locationDates = <int, LegDateChip>{};
+    for (var gi = 0; gi < legs.length; gi++) {
+      final start = visibleRanges[gi].start;
+      final end = visibleRanges[gi].end;
+      if (start == null || end == null) continue;
+      final nights = nightsBetween(start, end);
+      final chip = (
+        range: formatShortRange(start, end),
+        nights: nights > 0 ? l10n.tripLegNights(nights) : null,
+      );
+      for (final item in legs[gi].items) {
+        locationDates[item.position] = chip;
+      }
+    }
+
+    // Groups run the split over the FILTERED items (a category filter can
+    // merge adjacent same-label runs); chips key by first item position into
+    // the full-itinerary map above.
+    final groups = <CityGroup>[
+      for (final leg in tripLegs(filtered))
+        (
+          key: leg.key,
+          label: leg.label,
+          dateRange: locationDates[leg.items.first.position],
+          items: leg.items,
+        ),
+    ];
+
+    final groupedBookings = _computeGroupedBookings(
+        legLabels, bookingTodos, stays, segments);
+
+    // Travel-time labels for the map: one entry per within-city leg (same
+    // hub, adjacent in itinerary order). Empty while a category filter is
+    // active (legs aren't globally adjacent).
+    final segmentLabels = <int, String>{};
+    if (itemFilter == 'all') {
+      final byPos = {for (final it in items) it.position: it};
+      for (final it in items) {
+        final next = byPos[it.position + 1];
+        if (next == null || hubOf(it) != hubOf(next)) continue;
+        final t = travelByPos[it.position];
+        if (t == null || t.travelToNextMin <= 0) continue;
+        segmentLabels[it.position] = fmtTravel(l10n, t.travelToNextMin);
+      }
+    }
+
+    // Destination pins: one per location group with a real coordinate, in
+    // visit order; ungeocoded groups are skipped so the visible numbering
+    // stays contiguous.
+    final mapDestinations = <TripMapDestination>[
+      for (final r in rawRanges)
+        if (r.coord != null)
+          TripMapDestination(
+            label: groupLabelText(l10n, r.label),
+            point: LatLng(r.coord!.lat, r.coord!.lng),
+            dates: r.start != null && r.end != null
+                ? formatShortRange(r.start!, r.end!)
+                : null,
+          ),
+    ];
+
+    final firstCoord = rawRanges.isEmpty ? null : rawRanges.first.coord;
+    final lastCoord = rawRanges.isEmpty ? null : rawRanges.last.coord;
+    final homeLegEndpoints = (
+      first:
+          firstCoord == null ? null : LatLng(firstCoord.lat, firstCoord.lng),
+      last: lastCoord == null ? null : LatLng(lastCoord.lat, lastCoord.lng),
+    );
+
+    final mapShown =
+        filtered.any((i) => i.latitude != 0 || i.longitude != 0) ||
+            confirmedStays.any(TripMap.stayHasCoords);
+
+    final mapDayCount =
+        dayCount(trip.startDate, trip.endDate, items.map((i) => i.day));
+
+    final mappedDays = daysWithMappedContent(
+      trip.startDate,
+      mapDayCount,
+      [
+        for (final i in items)
+          if (i.latitude != 0 || i.longitude != 0) i.day,
+      ],
+      [
+        for (final a in confirmedStays)
+          if (TripMap.stayHasCoords(a))
+            (checkIn: a.checkIn, checkOut: a.checkOut),
+      ],
+    );
+
+    // Mirrors the screen's `_buildGroupItemSlivers` day-header rule:
+    // non-filler items carrying a day tag.
+    final liveDayKeys = <String>{
+      for (final g in groups)
+        for (final it in g.items)
+          if (!isCityFiller(it) && it.day != null) '${g.key}#${it.day}',
+    };
+
+    return TripDerivation._(
+      trip: trip,
+      bookingTodos: bookingTodos,
+      stays: stays,
+      segments: segments,
+      travelByPos: travelByPos,
+      itemFilter: itemFilter,
+      l10n: l10n,
+      itemOrderEpoch: itemOrderEpoch,
+      filtered: filtered,
+      legs: legs,
+      rawRanges: rawRanges,
+      visibleRanges: visibleRanges,
+      legLabels: legLabels,
+      groupRanges: groupRanges,
+      locationDates: locationDates,
+      groups: groups,
+      groupedBookings: groupedBookings,
+      segmentLabels: segmentLabels,
+      mapDestinations: mapDestinations,
+      homeLegEndpoints: homeLegEndpoints,
+      mapShown: mapShown,
+      confirmedStays: confirmedStays,
+      mapDayCount: mapDayCount,
+      mappedDays: mappedDays,
+      liveDayKeys: liveDayKeys,
+    );
+  }
+
+  /// Partitions the booking todos AND the confirmed stays/segments into
+  /// per-city embedded slots — the flight that arrives at the city, its stay,
+  /// and (for the last city) the return flight home — plus the residual lists
+  /// of everything that matched no city (user-added `custom:*` todos, stale
+  /// auto todos, confirmed records for legs no longer in the trip). Each todo
+  /// and record is claimed at most once, so repeated city labels still render
+  /// each booking exactly once.
+  ///
+  /// Confirmed records match their slot by the shared key grammar first
+  /// (`stay:<city>` / `transport:<a>>><b>` on auto_key, stamped when a draft
+  /// was confirmed) and fall back to the same fuzzy rules the old drafts
+  /// derivation used: stays by bidirectional name/address contains of the
+  /// city label, segments by destination (arrivals) or origin (departure)
+  /// equality — mirroring how the todo keys themselves are claimed.
+  static GroupedBookings _computeGroupedBookings(
+    List<String> groupLabels,
+    List<BookingTodo> bookingTodos,
+    List<Accommodation> stays,
+    List<TripSegment> segments,
+  ) {
+    final claimed = <String>{};
+    BookingTodo? claim(bool Function(BookingTodo) test) {
+      for (final t in bookingTodos) {
+        if (!claimed.contains(t.id) && test(t)) {
+          claimed.add(t.id);
+          return t;
+        }
+      }
+      return null;
+    }
+
+    final confirmedStays = stays.where((a) => !a.auto).toList();
+    final confirmedSegments = segments.where((s) => !s.auto).toList();
+    final claimedStayIds = <String>{};
+    final claimedSegmentIds = <String>{};
+    Accommodation? claimStay(bool Function(Accommodation) test) {
+      for (final a in confirmedStays) {
+        if (!claimedStayIds.contains(a.id) && test(a)) {
+          claimedStayIds.add(a.id);
+          return a;
+        }
+      }
+      return null;
+    }
+
+    TripSegment? claimSegment(bool Function(TripSegment) test) {
+      for (final s in confirmedSegments) {
+        if (!claimedSegmentIds.contains(s.id) && test(s)) {
+          claimedSegmentIds.add(s.id);
+          return s;
+        }
+      }
+      return null;
+    }
+
+    final arrivals = <BookingTodo?>[];
+    final arrivalMatches = <TripSegment?>[];
+    final staySlots = <BookingTodo?>[];
+    final stayMatches = <Accommodation?>[];
+    for (final label in groupLabels) {
+      final l = label.toLowerCase();
+      arrivals.add(
+          claim((t) => t.kind == 'transport' && t.todoKey.endsWith('>>$l')));
+      arrivalMatches.add(claimSegment((s) =>
+          (s.autoKey?.endsWith('>>$l') ?? false) ||
+          s.destination?.toLowerCase() == l));
+      staySlots.add(claim((t) => t.todoKey == 'stay:$l'));
+      stayMatches.add(claimStay((a) {
+        if (a.autoKey == 'stay:$l') return true;
+        for (final field in [a.name, a.address]) {
+          final f = field?.toLowerCase();
+          if (f != null && f.isNotEmpty && (f.contains(l) || l.contains(f))) {
+            return true;
+          }
+        }
+        return false;
+      }));
+    }
+    // Claimed after all arrivals so an inter-city leg can't be taken as its
+    // origin's departure — only the final leg home remains unclaimed by then.
+    BookingTodo? departure;
+    TripSegment? departureMatch;
+    if (groupLabels.isNotEmpty) {
+      final last = groupLabels.last.toLowerCase();
+      departure = claim((t) =>
+          t.kind == 'transport' && t.todoKey.startsWith('transport:$last>>'));
+      departureMatch = claimSegment((s) =>
+          (s.autoKey?.startsWith('transport:$last>>') ?? false) ||
+          s.origin?.toLowerCase() == last);
+    }
+
+    return (
+      slots: [
+        for (var i = 0; i < groupLabels.length; i++)
+          (
+            arrival: arrivals[i],
+            arrivalMatch: arrivalMatches[i],
+            stay: staySlots[i],
+            stayMatch: stayMatches[i],
+            departure: i == groupLabels.length - 1 ? departure : null,
+            departureMatch:
+                i == groupLabels.length - 1 ? departureMatch : null,
+          ),
+      ],
+      residual: bookingTodos.where((t) => !claimed.contains(t.id)).toList(),
+      residualStays: confirmedStays
+          .where((a) => !claimedStayIds.contains(a.id))
+          .toList(),
+      residualSegments: confirmedSegments
+          .where((s) => !claimedSegmentIds.contains(s.id))
+          .toList(),
+    );
+  }
+}

--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -3,8 +3,6 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart' show RenderAbstractViewport;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:intl/intl.dart';
-import 'package:latlong2/latlong.dart' show LatLng;
 import 'package:sliver_tools/sliver_tools.dart';
 import 'package:url_launcher/url_launcher.dart';
 import '../widgets/gradient_app_bar.dart';
@@ -46,8 +44,8 @@ import '../theme/app_colors.dart';
 import '../theme/spacing.dart';
 import '../utils/calendar_links.dart';
 import '../utils/clothing_recs.dart';
+import '../utils/date_formats.dart';
 import '../utils/leg_parity.dart';
-import '../utils/leg_ranges.dart';
 import '../utils/money_format.dart';
 import '../utils/share_link.dart';
 import '../utils/tracked_launch.dart';
@@ -78,6 +76,7 @@ import '../widgets/trip_refine_panel.dart';
 import '../widgets/wear_recs.dart';
 import 'flight_search_screen.dart';
 import 'local_guide_detail_screen.dart';
+import 'trip_detail_derivation.dart';
 import 'trip_map_screen.dart';
 import '../utils/snack.dart';
 
@@ -91,25 +90,9 @@ typedef _Coord = ({double lat, double lng});
 /// canonically defined next to the shared leg split (utils/trip_legs.dart).
 const _kOtherPlaces = kOtherPlacesLabel;
 
-/// Display text for a city-group label: the canonical [_kOtherPlaces] key gets
-/// a translated label, every real city keeps the name as-is.
-String _groupLabelText(AppLocalizations l10n, String label) =>
-    label == _kOtherPlaces ? l10n.tripOtherPlaces : label;
-
-/// City-header date-chip parts, kept separate so the header can align them as
-/// columns across rows: [range] renders left-aligned after the calendar icon,
-/// [nights] (the localized "· N nights" suffix) renders flush right. Null
-/// [nights] = zero-night squeezed leg — no nights widget renders at all.
-typedef _LegDateChip = ({String range, String? nights});
-
-/// One city group as built by [_TripDetailScreenState._buildGroups] and
-/// consumed by [_TripDetailScreenState._cityHeader].
-typedef _CityGroup = ({
-  String key,
-  String label,
-  _LegDateChip? dateRange,
-  List<ItineraryItem> items
-});
+// The city-group/date-chip/booking-slot shapes ([CityGroup], [LegDateChip],
+// [BookingSlot], [GroupedBookings]) and the label/filler helpers now live in
+// trip_detail_derivation.dart with the pipeline that builds them.
 
 // Canonical API values. These are sent to the server (or matched against
 // server data), so they are NEVER translated — only their display labels are.
@@ -198,12 +181,6 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
   // _collapsedDays; cities are keyed by run key (group.key) like
   // _expandedCities.
   final Map<String, GlobalKey> _dayHeaderKeys = {};
-  // Day keys of the CURRENT groups, collapsed ones included — recomputed each
-  // build. _dayHeaderKeys only gains entries when a group's slivers build, so
-  // on a cold all-collapsed screen it would be empty; day-jump resolution
-  // reads THIS set instead, so _scrollToDay can expand a group that has never
-  // rendered and still land (specs/today-mode).
-  Set<String> _liveDayKeys = const {};
   final Map<String, GlobalKey> _cityHeaderKeys = {};
   int?
       _selectedPosition; // position of the place focused via a map pin / list tap
@@ -253,72 +230,52 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
   // any failure — travel times are an enhancement and never block the itinerary.
   Map<int, LocationTiming> _travelByPos = {};
 
-  /// Itinerary items matching the active places lens, used by both the map
-  /// and the list so they stay in sync. 'unbooked' and 'bookings' are
-  /// bookings lenses, not places ones — the list swaps to booking rows while
-  /// the places set (and thus the maps) stays whole.
-  List<ItineraryItem> _filtered(Trip trip) {
-    final items = trip.items ?? const <ItineraryItem>[];
-    return switch (_itemFilter) {
-      'all' || 'unbooked' || 'bookings' => items.toList(),
-      'local' => items
-          .where((i) => (i.localSourceName ?? '').trim().isNotEmpty)
-          .toList(),
-      _ => items.where((i) => i.category == _itemFilter).toList(),
-    };
+  // ── Derivation memo (specs/perf-program, Wave 4 PR1) ──────────────────
+  // The whole per-build pipeline (filtered items, city groups, leg ranges,
+  // date chips, booking slots, map inputs) lives in TripDerivation
+  // (trip_detail_derivation.dart), computed once per input signature.
+
+  TripDerivation? _cachedDerivation;
+
+  /// Bumped by any IN-PLACE mutation of a derivation input, which
+  /// [_derive]'s identity checks cannot see. `_reorderBatchInline` is the
+  /// only such site; every other mutation path replaces its input objects
+  /// wholesale, so identity alone invalidates the memo.
+  int _itemOrderEpoch = 0;
+
+  /// THE access point for derived trip state — build and the non-build
+  /// readers (todo derivation, pin taps, scroll math, full-screen map) all
+  /// go through here, so they can never disagree. Returns the cached
+  /// derivation when the input signature still [TripDerivation.matches];
+  /// recomputes and caches otherwise. No explicit invalidation calls exist
+  /// anywhere — see [_itemOrderEpoch] for the one non-identity signal.
+  TripDerivation _derive(Trip trip) {
+    final l10n = context.l10n;
+    final cached = _cachedDerivation;
+    if (cached != null &&
+        cached.matches(
+          trip: trip,
+          bookingTodos: _bookingTodos,
+          stays: _stays,
+          segments: _segments,
+          travelByPos: _travelByPos,
+          itemFilter: _itemFilter,
+          l10n: l10n,
+          itemOrderEpoch: _itemOrderEpoch,
+        )) {
+      return cached;
+    }
+    return _cachedDerivation = TripDerivation.compute(
+      trip: trip,
+      bookingTodos: _bookingTodos,
+      stays: _stays,
+      segments: _segments,
+      travelByPos: _travelByPos,
+      itemFilter: _itemFilter,
+      l10n: l10n,
+      itemOrderEpoch: _itemOrderEpoch,
+    );
   }
-
-  /// [_filtered] further narrowed to a map day chip selection (null = All).
-  /// The maps are the only consumers — the itinerary list never day-filters.
-  /// Untagged items (day == null) show only under All.
-  List<ItineraryItem> _dayFiltered(Trip trip, int? day) {
-    return _filtered(trip).where((i) => day == null || i.day == day).toList();
-  }
-
-  /// The trip's user-confirmed stays. Suggested drafts (auto=true) are working
-  /// state for the bookings hub only — they must never feed the map, the
-  /// Tonight caption, or (crucially) [rawLegRanges]: seeded draft
-  /// dates flowing back into derivation would freeze the derived ranges.
-  List<Accommodation> _confirmedStays(Trip trip) =>
-      (trip.accommodations ?? const <Accommodation>[])
-          .where((a) => !a.auto)
-          .toList();
-
-  /// Stays the map should plot for a day chip selection: under All (null),
-  /// every stay; under Day N, only stays covering that night
-  /// (checkout-exclusive). A trip without a parseable start date can't map
-  /// Day N to a calendar date, so no stay matches (they all still show under
-  /// All).
-  List<Accommodation> _dayFilteredStays(Trip trip, int? day) {
-    if (day == null) return _confirmedStays(trip);
-    return _staysOnNight(trip, day);
-  }
-
-  /// Stays covering the night of trip day [day], checkout-exclusively — the
-  /// single home of the day→night math shared by the map's day filter and the
-  /// Tonight caption. A trip without a parseable start date can't map Day N
-  /// to a calendar date, so no stay matches.
-  List<Accommodation> _staysOnNight(Trip trip, int day) {
-    final all = _confirmedStays(trip);
-    final start = DateTime.tryParse(trip.startDate ?? '');
-    if (start == null) return const [];
-    // Calendar-day arithmetic (constructor normalizes overflow) rather than
-    // Duration, which drifts a date across a DST transition.
-    final night = DateTime(start.year, start.month, start.day + day - 1);
-    return all
-        .where((a) => stayCoversDate(a.checkIn, a.checkOut, night))
-        .toList();
-  }
-
-  /// Map-visibility gate: a filtered item with coordinates OR a geocoded stay
-  /// (TripMap renders stay pins on its own, so a stays-only trip still has a
-  /// map worth showing). Keyed to the unfiltered stay list — like the items,
-  /// day filtering only narrows what's plotted, never whether the map shows.
-  /// Shared by the build and the pinned-chrome scroll math so the two can
-  /// never drift apart.
-  bool _mapShown(Trip trip) =>
-      _filtered(trip).any((i) => i.latitude != 0 || i.longitude != 0) ||
-      _confirmedStays(trip).any(TripMap.stayHasCoords);
 
   @override
   void initState() {
@@ -602,7 +559,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
   /// away, so it never rests above a target header) plus the itinerary
   /// title header.
   double _pinnedChrome(Trip trip) {
-    final mapShown = _mapShown(trip);
+    final mapShown = _derive(trip).mapShown;
     return ((_mapPinned && mapShown) ? _mapHeaderHeight : 0) +
         _listHeaderHeight;
   }
@@ -670,16 +627,19 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
 
   /// The registry key of the day header [day] should scroll to: the first
   /// (build-order) header for that exact day, else the nearest prior day
-  /// with a header, else the nearest following. Candidates come from
-  /// [_liveDayKeys] — the current build's groups, collapsed ones included
-  /// (still reachable because [_scrollToDay] expands them first) — so days
-  /// removed by an edit can never linger as phantom targets.
+  /// with a header, else the nearest following. Candidates come from the
+  /// derivation's [TripDerivation.liveDayKeys] — the current groups,
+  /// collapsed ones included (still reachable because [_scrollToDay] expands
+  /// them first) — so days removed by an edit can never linger as phantom
+  /// targets.
   String? _resolveDayHeaderKey(int day) {
+    final trip = _trip;
+    if (trip == null) return null;
     String? prior;
     String? next;
     int? priorDay;
     int? nextDay;
-    for (final key in _liveDayKeys) {
+    for (final key in _derive(trip).liveDayKeys) {
       final hashAt = key.lastIndexOf('#');
       final d = int.tryParse(key.substring(hashAt + 1));
       if (d == null) continue;
@@ -846,7 +806,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
   /// dates, and the header chips all agree — including squeezed legs, which
   /// read as a zero-night stop at their arrival.
   List<Map<String, dynamic>> _deriveTodos(Trip trip) {
-    final ranges = visibleLegRanges(trip);
+    final ranges = _derive(trip).visibleRanges;
     final todos = <Map<String, dynamic>>[];
     final legs = <String,
         ({
@@ -972,7 +932,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
         'todo_key': 'stay:${label.toLowerCase()}',
         'title': 'Stay in $label',
         if (start != null && r.end != null)
-          'subtitle': _formatRange(start, r.end!),
+          'subtitle': formatShortRange(start, r.end!),
         'provider': 'airbnb',
         'position': pos++,
         'destination': label,
@@ -1001,127 +961,8 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
     return todos;
   }
 
-  /// Partitions [_bookingTodos] AND the confirmed stays/segments into
-  /// per-city embedded slots — the flight that arrives at the city, its stay,
-  /// and (for the last city) the return flight home — plus the residual lists
-  /// of everything that matched no city (user-added `custom:*` todos, stale
-  /// auto todos, confirmed records for legs no longer in the trip). Each todo
-  /// and record is claimed at most once, so repeated city labels still render
-  /// each booking exactly once.
-  ///
-  /// Confirmed records match their slot by the shared key grammar first
-  /// (`stay:<city>` / `transport:<a>>><b>` on auto_key, stamped when a draft
-  /// was confirmed) and fall back to the same fuzzy rules the old drafts
-  /// derivation used: stays by bidirectional name/address contains of the
-  /// city label, segments by destination (arrivals) or origin (departure)
-  /// equality — mirroring how the todo keys themselves are claimed.
-  ({
-    List<
-        ({
-          BookingTodo? arrival,
-          TripSegment? arrivalMatch,
-          BookingTodo? stay,
-          Accommodation? stayMatch,
-          BookingTodo? departure,
-          TripSegment? departureMatch,
-        })> slots,
-    List<BookingTodo> residual,
-    List<Accommodation> residualStays,
-    List<TripSegment> residualSegments,
-  }) _groupedBookings(List<String> groupLabels) {
-    final claimed = <String>{};
-    BookingTodo? claim(bool Function(BookingTodo) test) {
-      for (final t in _bookingTodos) {
-        if (!claimed.contains(t.id) && test(t)) {
-          claimed.add(t.id);
-          return t;
-        }
-      }
-      return null;
-    }
-
-    final confirmedStays = _stays.where((a) => !a.auto).toList();
-    final confirmedSegments = _segments.where((s) => !s.auto).toList();
-    final claimedStayIds = <String>{};
-    final claimedSegmentIds = <String>{};
-    Accommodation? claimStay(bool Function(Accommodation) test) {
-      for (final a in confirmedStays) {
-        if (!claimedStayIds.contains(a.id) && test(a)) {
-          claimedStayIds.add(a.id);
-          return a;
-        }
-      }
-      return null;
-    }
-
-    TripSegment? claimSegment(bool Function(TripSegment) test) {
-      for (final s in confirmedSegments) {
-        if (!claimedSegmentIds.contains(s.id) && test(s)) {
-          claimedSegmentIds.add(s.id);
-          return s;
-        }
-      }
-      return null;
-    }
-
-    final arrivals = <BookingTodo?>[];
-    final arrivalMatches = <TripSegment?>[];
-    final stays = <BookingTodo?>[];
-    final stayMatches = <Accommodation?>[];
-    for (final label in groupLabels) {
-      final l = label.toLowerCase();
-      arrivals.add(
-          claim((t) => t.kind == 'transport' && t.todoKey.endsWith('>>$l')));
-      arrivalMatches.add(claimSegment((s) =>
-          (s.autoKey?.endsWith('>>$l') ?? false) ||
-          s.destination?.toLowerCase() == l));
-      stays.add(claim((t) => t.todoKey == 'stay:$l'));
-      stayMatches.add(claimStay((a) {
-        if (a.autoKey == 'stay:$l') return true;
-        for (final field in [a.name, a.address]) {
-          final f = field?.toLowerCase();
-          if (f != null && f.isNotEmpty && (f.contains(l) || l.contains(f))) {
-            return true;
-          }
-        }
-        return false;
-      }));
-    }
-    // Claimed after all arrivals so an inter-city leg can't be taken as its
-    // origin's departure — only the final leg home remains unclaimed by then.
-    BookingTodo? departure;
-    TripSegment? departureMatch;
-    if (groupLabels.isNotEmpty) {
-      final last = groupLabels.last.toLowerCase();
-      departure = claim((t) =>
-          t.kind == 'transport' && t.todoKey.startsWith('transport:$last>>'));
-      departureMatch = claimSegment((s) =>
-          (s.autoKey?.startsWith('transport:$last>>') ?? false) ||
-          s.origin?.toLowerCase() == last);
-    }
-
-    return (
-      slots: [
-        for (var i = 0; i < groupLabels.length; i++)
-          (
-            arrival: arrivals[i],
-            arrivalMatch: arrivalMatches[i],
-            stay: stays[i],
-            stayMatch: stayMatches[i],
-            departure: i == groupLabels.length - 1 ? departure : null,
-            departureMatch:
-                i == groupLabels.length - 1 ? departureMatch : null,
-          ),
-      ],
-      residual: _bookingTodos.where((t) => !claimed.contains(t.id)).toList(),
-      residualStays: confirmedStays
-          .where((a) => !claimedStayIds.contains(a.id))
-          .toList(),
-      residualSegments: confirmedSegments
-          .where((s) => !claimedSegmentIds.contains(s.id))
-          .toList(),
-    );
-  }
+  // The per-city booking-slot partition lives in
+  // [TripDerivation.groupedBookings] (trip_detail_derivation.dart).
 
   /// The one "Booked" writer: flips the todo and (when the slot has one) the
   /// matched confirmed record in lockstep, so every reader of either flag —
@@ -1383,14 +1224,16 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
   /// vanish with zero visible feedback — open the run(s) holding items that
   /// weren't in the trip before the add.
   void _expandRunsOfNewItems(Set<String> beforeIds) {
-    final items = _trip?.items ?? const <ItineraryItem>[];
+    final trip = _trip;
+    if (trip == null) return;
+    final items = trip.items ?? const <ItineraryItem>[];
     final fresh = {
       for (final i in items)
         if (!beforeIds.contains(i.id)) i.id
     };
     if (fresh.isEmpty) return;
     setState(() {
-      for (final leg in tripLegs(items)) {
+      for (final leg in _derive(trip).legs) {
         if (leg.items.any((i) => fresh.contains(i.id))) {
           _expandedCities.add(leg.key);
         }
@@ -1993,7 +1836,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
     final start = DateTime.tryParse(t.startDate ?? '');
     final end = DateTime.tryParse(t.endDate ?? '');
     if (start != null && end != null && !end.isBefore(start)) {
-      return '$label · ${_formatRange(start, end)}';
+      return '$label · ${formatShortRange(start, end)}';
     }
     return label;
   }
@@ -2007,44 +1850,6 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
   /// utils/trip_legs.dart).
   String? _cityOf(ItineraryItem item) => cityOf(item);
 
-  /// True for the AI's "city filler" placeholder — an item whose name is just
-  /// the city it renders under (e.g. name 'Prague', city 'Prague'), emitted for
-  /// days with no specific activities. Its text duplicates the city/day-trip
-  /// header it sits below, so hiding the tile is lossless.
-  bool _isCityFiller(ItineraryItem item) {
-    final name = item.name.trim().toLowerCase();
-    if (name.isEmpty) return false;
-    bool eq(String? s) => s != null && s.trim().toLowerCase() == name;
-    return eq(_cityOf(item)) || eq(item.dayTripFrom);
-  }
-
-  /// Groups items into consecutive runs sharing the same locality (the shared
-  /// [tripLegs] split), labelling each run with the date range precomputed for
-  /// that location (keyed by the first item's position).
-  ///
-  /// [label] is the display city and stays shared across runs (it feeds the
-  /// per-city weather/events/local-intel lookups). [key] identifies the *run*:
-  /// a trip that revisits a city (Athens → Fira → Oia → Fira) yields two runs
-  /// with the same label, and everything keyed per-header — the header
-  /// [GlobalKey]s, the collapse sets, the `key#day` day keys — must tell them
-  /// apart or two live widgets share one GlobalKey and the itinerary fails to
-  /// build. Repeats get a `#2`, `#3`, … suffix; the scroll helpers parse day
-  /// keys with `lastIndexOf('#')`, so a suffixed key round-trips fine.
-  List<_CityGroup> _buildGroups(
-    List<ItineraryItem> items,
-    Map<int, _LegDateChip> locationDates,
-  ) {
-    return [
-      for (final leg in tripLegs(items))
-        (
-          key: leg.key,
-          label: leg.label,
-          dateRange: locationDates[leg.items.first.position],
-          items: leg.items,
-        ),
-    ];
-  }
-
   /// Renders a hub group's items as slivers, split into "Day N" sub-sections
   /// when items carry day numbers (day-trip batching applied within each day).
   /// Each day is a [MultiSliver] whose header pins below the city header while
@@ -2057,10 +1862,11 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
   List<Widget> _buildGroupItemSlivers(String cityKey, String groupKey,
       List<ItineraryItem> items, ThemeData theme, DateTime? tripStart,
       {required bool showTonight, ({DateTime? start, DateTime? end})? range}) {
-    // City-filler suppression happens here — NOT in _filtered — so an
-    // all-filler city keeps its group (city header + embedded booking rows;
-    // the slot<->group mapping indexes over the full itinerary).
-    items = items.where((it) => !_isCityFiller(it)).toList();
+    // City-filler suppression happens here — NOT in the derivation's
+    // filtered list — so an all-filler city keeps its group (city header +
+    // embedded booking rows; the slot<->group mapping indexes over the full
+    // itinerary).
+    items = items.where((it) => !isCityFiller(it)).toList();
     if (!items.any((it) => it.day != null)) {
       return _dayTripSectionSlivers(items, theme);
     }
@@ -2130,7 +1936,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
         // repeated day numbers across city groups can't duplicate it.
         final trip = _trip;
         final tonight = (showTonight && day == todayDay && trip != null)
-            ? _tonightCaption(theme, _staysOnNight(trip, day))
+            ? _tonightCaption(theme, _derive(trip).staysOnNight(day))
             : null;
         // Weather chip for this day, if the report covers its date. Historical
         // reports carry last year's month-day, so we match on month-day.
@@ -2189,7 +1995,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
   TextStyle? _chipTextStyle(ThemeData theme) =>
       theme.textTheme.labelMedium?.copyWith(color: theme.colorScheme.primary);
 
-  double _dateChipWidth(List<_CityGroup> groups, ThemeData theme) {
+  double _dateChipWidth(List<CityGroup> groups, ThemeData theme) {
     var style = _chipTextStyle(theme);
     // Text applies the boldText accessibility flag internally; TextPainter
     // does not — merge it here or measurement undershoots the rendered width.
@@ -2225,7 +2031,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
   /// at the top of the scroll area while its group scrolls past; the opaque
   /// Material keeps items from showing through while pinned.
   Widget _cityHeader(
-      Trip trip, _CityGroup group, ThemeData theme, double dateChipWidth) {
+      Trip trip, CityGroup group, ThemeData theme, double dateChipWidth) {
     final l10n = context.l10n;
     final cityCollapsed = !_expandedCities.contains(group.key);
     final chipStyle = _chipTextStyle(theme);
@@ -2252,7 +2058,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
                     const SizedBox(width: 6),
                     Expanded(
                       child: Text(
-                        _groupLabelText(l10n, group.label),
+                        groupLabelText(l10n, group.label),
                         maxLines: 1,
                         overflow: TextOverflow.ellipsis,
                         style: theme.textTheme.titleSmall
@@ -2638,14 +2444,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
   /// todo's flag when a todo row drives the entry, the record's otherwise) —
   /// the "Not booked yet" lens.
   List<Widget> _bookingRowWidgets(
-    ({
-      BookingTodo? arrival,
-      TripSegment? arrivalMatch,
-      BookingTodo? stay,
-      Accommodation? stayMatch,
-      BookingTodo? departure,
-      TripSegment? departureMatch,
-    }) slot, {
+    BookingSlot slot, {
     required bool departureOnly,
     bool unbookedOnly = false,
   }) {
@@ -2695,22 +2494,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
   /// records that matched no city. Reuses the same row widgets (and the
   /// _setRowBooked writer) as the inline city view, so checking a box here
   /// behaves identically and the row leaves the lens on the rebuild.
-  List<Widget> _unbookedRows(
-    ({
-      List<
-          ({
-            BookingTodo? arrival,
-            TripSegment? arrivalMatch,
-            BookingTodo? stay,
-            Accommodation? stayMatch,
-            BookingTodo? departure,
-            TripSegment? departureMatch,
-          })> slots,
-      List<BookingTodo> residual,
-      List<Accommodation> residualStays,
-      List<TripSegment> residualSegments,
-    }) grouped,
-  ) {
+  List<Widget> _unbookedRows(GroupedBookings grouped) {
     final l10n = context.l10n;
     return [
       for (final (i, slot) in grouped.slots.indexed) ...[
@@ -2748,25 +2532,12 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
   /// [destination] narrows to one leg label (null = all): slot i is included
   /// when labels[i] matches; residuals only under All or the 'Other places'
   /// chip (they matched no destination by definition). This filters the
-  /// OUTPUT of the one full-label _groupedBookings call — never re-run
-  /// _groupedBookings on a label subset: its claim-once matching is
+  /// OUTPUT of the one full-label groupedBookings partition — never re-run
+  /// the partition on a label subset: its claim-once matching is
   /// order-dependent, so a subset call would assign rows differently than
   /// the inline city view (docs/zen.md).
   List<Widget> _allBookingRows(
-    ({
-      List<
-          ({
-            BookingTodo? arrival,
-            TripSegment? arrivalMatch,
-            BookingTodo? stay,
-            Accommodation? stayMatch,
-            BookingTodo? departure,
-            TripSegment? departureMatch,
-          })> slots,
-      List<BookingTodo> residual,
-      List<Accommodation> residualStays,
-      List<TripSegment> residualSegments,
-    }) grouped,
+    GroupedBookings grouped,
     List<String> labels, {
     String? destination,
   }) {
@@ -2831,20 +2602,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
   /// already in build, so this frame renders the clamped value (the
   /// _selectedDay clamp idiom).
   List<Widget> _bookingsLensBody(
-    ({
-      List<
-          ({
-            BookingTodo? arrival,
-            TripSegment? arrivalMatch,
-            BookingTodo? stay,
-            Accommodation? stayMatch,
-            BookingTodo? departure,
-            TripSegment? departureMatch,
-          })> slots,
-      List<BookingTodo> residual,
-      List<Accommodation> residualStays,
-      List<TripSegment> residualSegments,
-    }) grouped,
+    GroupedBookings grouped,
     List<String> labels,
   ) {
     final l10n = context.l10n;
@@ -3006,7 +2764,15 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
       for (final it in items)
         if (batchIds.contains(it.id)) newOrder[next++] else it,
     ];
-    setState(() => items.setAll(0, newItems));
+    setState(() {
+      items.setAll(0, newItems);
+      // CONTRACT: any in-place mutation of a derivation input MUST bump the
+      // epoch. This setAll is the screen's ONE in-place write — the trip's
+      // item List keeps its identity, so [_derive]'s identity checks can't
+      // see the new order; the epoch bump is what invalidates the memo and
+      // lets this optimistic frame render the dragged order.
+      _itemOrderEpoch++;
+    });
     try {
       await ref
           .read(tripsApiServiceProvider)
@@ -3066,24 +2832,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
     return total;
   }
 
-  /// Travel-time labels for the trip map, keyed by the source item's position:
-  /// one entry per within-city leg (same hub, adjacent in itinerary order).
-  /// Empty while a category filter is active (legs aren't globally adjacent).
-  Map<int, String> _segmentLabels() {
-    final trip = _trip;
-    if (_itemFilter != 'all' || trip == null) return const {};
-    final items = trip.items ?? const <ItineraryItem>[];
-    final byPos = {for (final it in items) it.position: it};
-    final out = <int, String>{};
-    for (final it in items) {
-      final next = byPos[it.position + 1];
-      if (next == null || _hubOf(it) != _hubOf(next)) continue;
-      final t = _travelByPos[it.position];
-      if (t == null || t.travelToNextMin <= 0) continue;
-      out[it.position] = _fmtTravel(t.travelToNextMin);
-    }
-    return out;
-  }
+  // The map's travel-time labels live in [TripDerivation.segmentLabels].
 
   /// Travel time from the hub city to a day trip, e.g. "45 min from Paris",
   /// taken from the already-computed leg into the day trip's first stop. Null
@@ -3108,16 +2857,9 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
         .tripTravelFromHub(_fmtTravel(timing.travelToNextMin), hub);
   }
 
-  /// Formats a travel duration: "45 min", "1h", or "1h 20m".
-  String _fmtTravel(int min) {
-    final l10n = context.l10n;
-    if (min < 60) return l10n.tripTravelMinutes(min);
-    final h = min ~/ 60;
-    final m = min % 60;
-    return m == 0
-        ? l10n.tripTravelHours(h)
-        : l10n.tripTravelHoursMinutes(h, m);
-  }
+  /// Formats a travel duration: "45 min", "1h", or "1h 20m" (the shared
+  /// [fmtTravel], which the derivation's map labels also use).
+  String _fmtTravel(int min) => fmtTravel(context.l10n, min);
 
   /// Day section header: shows the calendar date (day N -> startDate + (N-1))
   /// when the trip start is known, otherwise falls back to "Day N". The opaque
@@ -3448,9 +3190,6 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
   /// section boundary — cross-day moves go through the edit sheet instead.
   Widget _itemMenu(ItineraryItem item) {
     final l10n = context.l10n;
-    final canUp = _moveNeighbor(item, -1) != null;
-    final canDown = _moveNeighbor(item, 1) != null;
-    final calendarRange = itemCalendarRange(_trip?.startDate, item.day);
     return PopupMenuButton<String>(
       icon: const Icon(Icons.more_vert),
       tooltip: l10n.tripPlaceActions,
@@ -3474,7 +3213,14 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
             _deleteItem(item);
         }
       },
-      itemBuilder: (context) => [
+      itemBuilder: (context) {
+        // Computed lazily — only when the menu actually opens. At the old
+        // call-time spot these three ran O(items) work per rendered tile per
+        // build (specs/perf-program, Wave 4 PR1).
+        final canUp = _moveNeighbor(item, -1) != null;
+        final canDown = _moveNeighbor(item, 1) != null;
+        final calendarRange = itemCalendarRange(_trip?.startDate, item.day);
+        return [
         PopupMenuItem(
           value: 'edit',
           child: ListTile(
@@ -3548,7 +3294,8 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
             contentPadding: EdgeInsets.zero,
           ),
         ),
-      ],
+        ];
+      },
     );
   }
 
@@ -3986,56 +3733,15 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
     return '$base&query=${Uri.encodeComponent('${it.name} ${it.address ?? ''}'.trim())}';
   }
 
-  /// Maps each itinerary item's position to its location's date-chip parts.
-  /// Delegates to [visibleLegRanges] so the itinerary labels and the booking
-  /// checklist derive dates the same way. The two derivations index-align by
-  /// construction: both run the same [tripLegs] split over the same items. The
-  /// visible ranges are arrival-adjusted, matching the stay todos — a leg whose
-  /// items collapse onto one day reads "Sep 24 – Sep 27", not a bare "Sep 27"
-  /// contradicting the stay row beneath it, and a squeezed leg collapses to a
-  /// zero-night stop at its arrival. Multi-night legs carry a localized nights
-  /// suffix ("· 3 nights") computed from the same range pair; squeezed
-  /// zero-night legs get `nights: null` and render the bare single date. Both
-  /// strings are final display text — [_dateChipWidth] measures these exact
-  /// strings, never re-formatted copies (the range follows
-  /// Intl.defaultLocale via DateFormat while nights follows the widget
-  /// locale, so re-deriving could measure different text than renders).
-  Map<int, _LegDateChip> _locationDates(Trip trip) {
-    final l10n = context.l10n;
-    final items = trip.items ?? const <ItineraryItem>[];
-    if (items.isEmpty) return const {};
-    final ranges = visibleLegRanges(trip);
-    final legs = tripLegs(items);
-    final result = <int, _LegDateChip>{};
-    for (var gi = 0; gi < legs.length; gi++) {
-      final start = ranges[gi].start;
-      final end = ranges[gi].end;
-      if (start == null || end == null) continue;
-      final nights = nightsBetween(start, end);
-      final chip = (
-        range: _formatRange(start, end),
-        nights: nights > 0 ? l10n.tripLegNights(nights) : null,
-      );
-      for (final item in legs[gi].items) {
-        result[item.position] = chip;
-      }
-    }
-    return result;
-  }
-
-  // The leg date-range derivation (raw + visible) lives in
+  // The per-position date chips live in [TripDerivation.locationDates]; the
+  // leg date-range derivation itself (raw + visible) stays in
   // utils/leg_ranges.dart (specs/trip-dates-truth stage 0a) — one testable
-  // definition shared with the booking-todo derivation and, soon, the Go
-  // twin behind the server legs payload.
+  // definition shared with the booking-todo derivation and the Go twin
+  // behind the server legs payload.
 
-  String _formatRange(DateTime a, DateTime b) {
-    final sameDay = a.year == b.year && a.month == b.month && a.day == b.day;
-    return sameDay ? _fmtShortDt(a) : '${_fmtShortDt(a)} – ${_fmtShortDt(b)}';
-  }
-
-  /// "Jul 15" in English, "15 jul" in Spanish — DateFormat reads
+  /// "Jul 15" in English, "15 jul" in Spanish — the cached DateFormat reads
   /// Intl.defaultLocale, which the locale provider sets (specs/i18n-spanish).
-  String _fmtShortDt(DateTime d) => DateFormat.MMMd().format(d);
+  String _fmtShortDt(DateTime d) => mmmd().format(d);
 
   /// Coarse relative timestamp for the "Updated by X" line.
   String _relativeTime(String iso) {
@@ -4051,7 +3757,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
 
   /// Day-header date, e.g. "Wed, Jul 15" (weekday + month + day); Spanish
   /// reorders to "mié, 15 jul" on its own.
-  String _fmtDayHeader(DateTime d) => DateFormat.MMMEd().format(d);
+  String _fmtDayHeader(DateTime d) => mmmed().format(d);
 
   // ── Trailing collapsed sections ─────────────────────────────────────────
   // Trip health / Packing / Budget end the page as one-line summary rows,
@@ -4163,8 +3869,9 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
   /// per-visit rows. Loading or failed reports derive null and drop out;
   /// offline this is simply empty.
   List<WearRegionRec> _legClothingRecs(Trip trip) {
-    final raw = rawLegRanges(trip);
-    final visible = visibleLegRanges(trip); // 1:1 by index with raw
+    final derivation = _derive(trip);
+    final raw = derivation.rawRanges;
+    final visible = derivation.visibleRanges; // 1:1 by index with raw
     final recs = <WearRegionRec>[];
     for (var i = 0; i < raw.length; i++) {
       final r = raw[i];
@@ -4519,27 +4226,10 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
     );
   }
 
-  /// Destination pins for the trip-overview map (the All chip): one per
-  /// location group with a real coordinate, in visit order, derived from the
-  /// FULL itinerary — never the day/category-filtered view, which would shift
-  /// the numbering (the home-leg doctrine in [_openFullMap]). Ungeocoded
-  /// groups are skipped so the visible numbering stays contiguous; TripMap
-  /// falls back to per-item pins below two entries, keeping single-city trips
-  /// on place-level detail.
-  List<TripMapDestination> _mapDestinations(Trip trip) {
-    final l10n = context.l10n;
-    return [
-      for (final r in rawLegRanges(trip))
-        if (r.coord != null)
-          TripMapDestination(
-            label: _groupLabelText(l10n, r.label),
-            point: LatLng(r.coord!.lat, r.coord!.lng),
-            dates: r.start != null && r.end != null
-                ? _formatRange(r.start!, r.end!)
-                : null,
-          ),
-    ];
-  }
+  // Destination pins live in [TripDerivation.mapDestinations]: one per
+  // location group with a real coordinate, in visit order, derived from the
+  // FULL itinerary — never the day/category-filtered view, which would shift
+  // the numbering (the home-leg doctrine in [_openFullMap]).
 
   /// The rounded map card shared by the wide (pinned header) and phone
   /// (scroll-away) layouts. When [expandable], the map is a static preview:
@@ -4555,7 +4245,8 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
     Set<int> mappedDays, {
     required bool expandable,
   }) {
-    final endpoints = _homeLegEndpoints(trip);
+    final derivation = _derive(trip);
+    final endpoints = derivation.homeLegEndpoints;
     final home = homeOverlayFor(
       ref,
       homeAirport: _homeAirport,
@@ -4565,14 +4256,15 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
       lastCityPoint: endpoints.last,
     );
     Widget map = TripMap(
-      items: _dayFiltered(trip, _selectedDay),
-      accommodations: _dayFilteredStays(trip, _selectedDay),
-      destinations: _selectedDay == null ? _mapDestinations(trip) : null,
+      items: derivation.dayFilteredItems(_selectedDay),
+      accommodations: derivation.dayFilteredStays(_selectedDay),
+      destinations:
+          _selectedDay == null ? derivation.mapDestinations : null,
       selectedPosition: _selectedPosition,
       // Unfiltered by day: TripMap's position+1 adjacency guard drops labels
       // across the gaps a day filter creates, and the category filter
       // already empties this map.
-      segmentLabels: _segmentLabels(),
+      segmentLabels: derivation.segmentLabels,
       home: home,
       fitSignature: _selectedDay,
       // Keep fitted markers clear of the chip row overlaid below.
@@ -4599,7 +4291,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
                 _selectedPosition = pos;
                 // The highlighted row can only be seen if its run renders:
                 // groups default collapsed, so open the tapped item's run.
-                for (final leg in tripLegs(trip.items!)) {
+                for (final leg in _derive(trip).legs) {
                   if (leg.items.any((i) => i.position == pos)) {
                     _expandedCities.add(leg.key);
                   }
@@ -4651,45 +4343,39 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
     );
   }
 
-  /// Home-leg endpoints are the trip's first/last location groups — the same
-  /// derivation the outbound/return booking todos trust — never the first/
-  /// last mapped pin, which shifts under day/category filters.
-  ({LatLng? first, LatLng? last}) _homeLegEndpoints(Trip trip) {
-    final ranges = rawLegRanges(trip);
-    final firstCoord = ranges.isEmpty ? null : ranges.first.coord;
-    final lastCoord = ranges.isEmpty ? null : ranges.last.coord;
-    return (
-      first:
-          firstCoord == null ? null : LatLng(firstCoord.lat, firstCoord.lng),
-      last: lastCoord == null ? null : LatLng(lastCoord.lat, lastCoord.lng),
-    );
-  }
+  // Home-leg endpoints live in [TripDerivation.homeLegEndpoints] — the
+  // trip's first/last location groups, the same derivation the
+  // outbound/return booking todos trust — never the first/last mapped pin,
+  // which shifts under day/category filters.
 
   /// Pushes the full-screen interactive map. Root navigator so the map
   /// covers the bottom navigation bar; the closures read the live [_trip] so
   /// a silent refresh propagates on the next chip tap.
   void _openFullMap(Trip trip, int mapDayCount, Set<int> mappedDays) {
-    final endpoints = _homeLegEndpoints(trip);
+    final derivation = _derive(trip);
+    final endpoints = derivation.homeLegEndpoints;
     Navigator.of(context, rootNavigator: true).push(
       MaterialPageRoute(
         fullscreenDialog: true,
         builder: (_) => TripMapScreen(
           title: _displayTitle(trip),
-          destinations: _mapDestinations(trip),
+          destinations: derivation.mapDestinations,
           homeAirport: _homeAirport,
           firstCityPoint: endpoints.first,
           lastCityPoint: endpoints.last,
           itemsForDay: (d) {
             final t = _trip;
-            return t == null ? const <ItineraryItem>[] : _dayFiltered(t, d);
+            return t == null
+                ? const <ItineraryItem>[]
+                : _derive(t).dayFilteredItems(d);
           },
           staysForDay: (d) {
             final t = _trip;
             return t == null
                 ? const <Accommodation>[]
-                : _dayFilteredStays(t, d);
+                : _derive(t).dayFilteredStays(d);
           },
-          segmentLabels: _segmentLabels(),
+          segmentLabels: derivation.segmentLabels,
           dayCount: mapDayCount,
           mappedDays: mappedDays,
           initialDay: _selectedDay,
@@ -4841,16 +4527,18 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
                       final gutter = bodyWidth > _contentMaxWidth + 32
                           ? (bodyWidth - _contentMaxWidth) / 2
                           : 16.0;
+                      // One derivation per input signature — a view-only
+                      // setState (row select, expand/collapse, day chip…)
+                      // rebuilds against the cached object instead of
+                      // re-running the pipeline (Wave 4 PR1).
+                      final derivation = _derive(trip);
                       // City-matched bookings render inside their city group;
                       // the rest fall through to the Bookings section's
                       // "Other" sub-group.
-                      final legLabels = [
-                        for (final r in rawLegRanges(trip)) r.label
-                      ];
-                      final grouped = _groupedBookings(legLabels);
-                      final filtered = _filtered(trip);
-                      final groups =
-                          _buildGroups(filtered, _locationDates(trip));
+                      final legLabels = derivation.legLabels;
+                      final grouped = derivation.groupedBookings;
+                      final filtered = derivation.filtered;
+                      final groups = derivation.groups;
                       // Shared per-build chip width — see _dateChipWidth's
                       // doc for why this must stay a build-local.
                       final dateChipWidth = _dateChipWidth(groups, theme);
@@ -4865,37 +4553,22 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
                           _expandedCities.add(groups.first.key);
                         }
                       }
-                      // Day-key registry from the CURRENT groups, not from
-                      // whatever happens to be built: a collapsed group's day
-                      // headers don't exist yet, but their keys must still
-                      // resolve so _scrollToDay can expand the group and land
-                      // (specs/today-mode). Mirrors _buildGroupItemSlivers'
-                      // day-header rule: non-filler items carrying a day tag.
-                      _liveDayKeys = {
-                        for (final g in groups)
-                          for (final it in g.items)
-                            if (!_isCityFiller(it) && it.day != null)
-                              '${g.key}#${it.day}',
-                      };
-                      for (final key in _liveDayKeys) {
+                      // Day-header GlobalKeys for the CURRENT groups' day
+                      // keys, not just whatever happens to be built: a
+                      // collapsed group's day headers don't exist yet, but
+                      // their keys must still resolve so _scrollToDay can
+                      // expand the group and land (specs/today-mode).
+                      for (final key in derivation.liveDayKeys) {
                         _dayHeaderKeys.putIfAbsent(key, GlobalKey.new);
                       }
                       // Date window per city group, for the embedded events
-                      // lookup (keyed by the same label _buildGroups uses).
-                      final groupRanges = {
-                        for (final r in rawLegRanges(trip))
-                          r.label: (start: r.start, end: r.end)
-                      };
+                      // lookup (keyed by the same label the groups use).
+                      final groupRanges = derivation.groupRanges;
                       final tripStart = DateTime.tryParse(trip.startDate ?? '');
                       // Map day chips (specs/today-mode). Day count spans the
                       // whole trip, not the category filter, so chips never
                       // come and go with the Attractions/Restaurants toggle.
-                      final mapDayCount = dayCount(
-                        trip.startDate,
-                        trip.endDate,
-                        (trip.items ?? const <ItineraryItem>[])
-                            .map((i) => i.day),
-                      );
+                      final mapDayCount = derivation.mapDayCount;
                       // A refresh can shrink the trip below a stale selection
                       // (fewer days after an edit); fall back to All. Plain
                       // assignment: we're already in build, so this frame
@@ -4907,20 +4580,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
                       // the fly-out day, all booking todos) get muted chips.
                       // Trip-wide like mapDayCount — the category filter never
                       // flickers the chip treatment.
-                      final mappedDays = daysWithMappedContent(
-                        trip.startDate,
-                        mapDayCount,
-                        [
-                          for (final i
-                              in trip.items ?? const <ItineraryItem>[])
-                            if (i.latitude != 0 || i.longitude != 0) i.day,
-                        ],
-                        [
-                          for (final a in _confirmedStays(trip))
-                            if (TripMap.stayHasCoords(a))
-                              (checkIn: a.checkIn, checkOut: a.checkOut),
-                        ],
-                      );
+                      final mappedDays = derivation.mappedDays;
                       // Today mode: the jump chip renders only when today
                       // falls inside the trip's dates AND some item carries a
                       // day tag (the same gate as the auto-scroll, so the
@@ -4935,16 +4595,11 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
                       // so resolve the FIRST group containing today's day
                       // once, here — exactly one caption can ever render.
                       // Matched on the run key, not the label: a revisited
-                      // city has two runs sharing a label.
-                      String? firstTodayGroupKey;
-                      if (todayDay != null) {
-                        for (final group in groups) {
-                          if (group.items.any((it) => it.day == todayDay)) {
-                            firstTodayGroupKey = group.key;
-                            break;
-                          }
-                        }
-                      }
+                      // city has two runs sharing a label. todayDay is
+                      // clock-derived, so it stays a build-local and queries
+                      // the derivation.
+                      final firstTodayGroupKey =
+                          derivation.firstGroupKeyForDay(todayDay);
                       // A loud load queued the one-shot auto-scroll; this is
                       // the first frame that actually mounts the scroll view
                       // (and registers the day-header keys), so kick it off
@@ -4982,7 +4637,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
                           // to pin — a shorter static preview scrolls away
                           // with the page, and tapping it opens the
                           // full-screen map (TripMapScreen).
-                          if (_mapShown(trip))
+                          if (derivation.mapShown)
                             if (_mapPinned)
                               SliverPersistentHeader(
                                 pinned: true,

--- a/src/packages/flutter-app/lib/utils/date_formats.dart
+++ b/src/packages/flutter-app/lib/utils/date_formats.dart
@@ -1,0 +1,48 @@
+// Cached, locale-keyed [DateFormat] instances for the app's two display date
+// shapes ("Jul 15" / "Wed, Jul 15"), so hot render paths don't re-construct a
+// DateFormat — a symbol-table lookup — per formatted date per build
+// (specs/perf-program, Wave 4 PR1).
+//
+// DateFormat reads Intl.defaultLocale, which the locale provider sets
+// (specs/i18n-spanish). The cache is keyed on that tag: the first call after
+// a locale change drops both cached instances and rebuilds them under the new
+// locale, so callers can never format with a stale language. Outside a
+// Flutter app (pure unit tests) intl falls back to en_US, same as before.
+
+import 'package:intl/intl.dart';
+
+String? _cachedLocaleTag;
+DateFormat? _mmmd;
+DateFormat? _mmmed;
+
+void _syncLocale() {
+  final tag = Intl.defaultLocale;
+  if (tag != _cachedLocaleTag) {
+    _cachedLocaleTag = tag;
+    _mmmd = null;
+    _mmmed = null;
+  }
+}
+
+/// `DateFormat.MMMd()` for the current `Intl.defaultLocale` — "Jul 15" in
+/// English, "15 jul" in Spanish.
+DateFormat mmmd() {
+  _syncLocale();
+  return _mmmd ??= DateFormat.MMMd();
+}
+
+/// `DateFormat.MMMEd()` for the current `Intl.defaultLocale` — "Wed, Jul 15"
+/// in English; Spanish reorders to "mié, 15 jul" on its own.
+DateFormat mmmed() {
+  _syncLocale();
+  return _mmmed ??= DateFormat.MMMEd();
+}
+
+/// "Jul 15 – Jul 18" via [mmmd], collapsing a same-day pair to the single
+/// date. The one shared range shape: the trip header, city-header date chips,
+/// booking-todo subtitles, and map destination pins all speak this.
+String formatShortRange(DateTime a, DateTime b) {
+  final sameDay = a.year == b.year && a.month == b.month && a.day == b.day;
+  final f = mmmd();
+  return sameDay ? f.format(a) : '${f.format(a)} – ${f.format(b)}';
+}

--- a/src/packages/flutter-app/lib/utils/trip_format.dart
+++ b/src/packages/flutter-app/lib/utils/trip_format.dart
@@ -7,9 +7,9 @@
 // flutter_localizations loads the date symbols for the active locale before
 // first paint; outside a Flutter app (unit tests) intl falls back to en_US.
 
-import 'package:intl/intl.dart';
+import 'date_formats.dart';
 
-String _fmt(DateTime d) => DateFormat.MMMd().format(d);
+String _fmt(DateTime d) => mmmd().format(d);
 
 /// "Mon d – Mon d" from ISO start/end (same day collapses to one); null when
 /// either date is missing or unparseable.
@@ -17,8 +17,7 @@ String? tripDateRange(String? startIso, String? endIso) {
   final a = DateTime.tryParse(startIso ?? '');
   final b = DateTime.tryParse(endIso ?? '');
   if (a == null || b == null) return null;
-  final sameDay = a.year == b.year && a.month == b.month && a.day == b.day;
-  return sameDay ? _fmt(a) : '${_fmt(a)} – ${_fmt(b)}';
+  return formatShortRange(a, b);
 }
 
 /// "Mon d" from a single ISO date; null when missing or unparseable.

--- a/src/packages/flutter-app/lib/utils/trip_legs.dart
+++ b/src/packages/flutter-app/lib/utils/trip_legs.dart
@@ -50,6 +50,12 @@ String? cityOf(ItineraryItem item) {
   return cityFromAddress(item.address);
 }
 
+// Hoisted out of [cityFromAddress]: it runs per item per legs split, and a
+// RegExp compile per call was measurable on the trip-detail hot path
+// (specs/perf-program, Wave 4 PR1).
+final RegExp _whitespaceRe = RegExp(r'\s+');
+final RegExp _postalTokenRe = RegExp(r'^[0-9][0-9\-]*$');
+
 /// Fallback city from a formatted address. Drops the country (last segment)
 /// and strips postal-code tokens from the segment before it, e.g.
 /// "Av. ..., 1400-206 Lisboa, Portugal" -> "Lisboa"; a bare "Paris" stays as is.
@@ -64,9 +70,8 @@ String? cityFromAddress(String? address) {
   if (parts.length == 1) return parts.first;
   final candidate = parts[parts.length - 2]; // segment before the country
   final tokens = candidate
-      .split(RegExp(r'\s+'))
-      .where(
-          (t) => !RegExp(r'^[0-9][0-9\-]*$').hasMatch(t)) // drop postal tokens
+      .split(_whitespaceRe)
+      .where((t) => !_postalTokenRe.hasMatch(t)) // drop postal tokens
       .toList();
   final city = tokens.join(' ').trim();
   return city.isEmpty ? candidate : city;

--- a/src/packages/flutter-app/test/trip_detail_derivation_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_derivation_test.dart
@@ -1,0 +1,408 @@
+// TripDerivation memo + parity tests (specs/perf-program, Wave 4 PR1).
+//
+// Pure Dart — no widget pumping. Three concerns:
+//   1. The memo signature: [TripDerivation.matches] reuses on identical
+//      inputs and invalidates on every single input flip (incl. the
+//      item-order epoch, the one non-identity signal).
+//   2. Identity stability of the lazy per-day accessors — the map-isolation
+//      follow-up (Wave 4 PR2) keys a marker cache on those List identities.
+//   3. Parity spot-checks of the absorbed pipeline (groups, locationDates,
+//      groupedBookings, segmentLabels, day math) against the legacy shapes
+//      the screen used to compute inline.
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:travel_route_planner/l10n/app_localizations_en.dart';
+import 'package:travel_route_planner/models/accommodation.dart';
+import 'package:travel_route_planner/models/booking_todo.dart';
+import 'package:travel_route_planner/models/itinerary_item.dart';
+import 'package:travel_route_planner/models/location.dart';
+import 'package:travel_route_planner/models/location_timing.dart';
+import 'package:travel_route_planner/models/trip.dart';
+import 'package:travel_route_planner/models/trip_segment.dart';
+import 'package:travel_route_planner/screens/trip_detail_derivation.dart';
+
+ItineraryItem _item(
+  int pos,
+  String name, {
+  String? city,
+  int? day,
+  double lat = 0,
+  double lng = 0,
+  String category = 'attraction',
+  String? localSourceName,
+}) =>
+    ItineraryItem(
+      id: 'i-$name',
+      position: pos,
+      name: name,
+      address: '$name address, $city',
+      latitude: lat,
+      longitude: lng,
+      category: category,
+      city: city,
+      day: day,
+      localSourceName: localSourceName,
+    );
+
+/// Paris (2 items) → Rome (2 items) → Paris again (1 item): exercises the
+/// revisited-city `#2` run key, per-position date chips, and a coordinate-less
+/// item.
+List<ItineraryItem> _items() => [
+      _item(0, 'Louvre', city: 'Paris', day: 1, lat: 48.86, lng: 2.35),
+      _item(1, 'Le Comptoir',
+          city: 'Paris',
+          day: 2,
+          lat: 48.85,
+          lng: 2.32,
+          category: 'restaurant',
+          localSourceName: 'Maria'),
+      _item(2, 'Colosseum', city: 'Rome', day: 3, lat: 41.89, lng: 12.49),
+      _item(3, 'Trevi', city: 'Rome', day: 4),
+      _item(4, 'Louvre Again', city: 'Paris', day: 5, lat: 48.86, lng: 2.35),
+    ];
+
+Trip _trip({List<ItineraryItem>? items, List<Accommodation>? stays}) => Trip(
+      id: 't1',
+      title: 'Paris & Rome',
+      status: 'planned',
+      startDate: '2026-09-01',
+      endDate: '2026-09-05',
+      createdAt: '2026-08-01',
+      updatedAt: '2026-08-01',
+      items: items ?? _items(),
+      accommodations: stays,
+    );
+
+const _parisStay = Accommodation(
+  id: 'a1',
+  name: 'Hotel Paris',
+  address: 'Rue X, Paris, France',
+  latitude: 48.87,
+  longitude: 2.36,
+  checkIn: '2026-09-01',
+  checkOut: '2026-09-03',
+);
+
+const _draftStay = Accommodation(
+  id: 'a2',
+  name: 'Suggested Rome',
+  address: 'Via Y, Rome, Italy',
+  auto: true,
+);
+
+BookingTodo _todo(String key, {String kind = 'transport', bool booked = false}) =>
+    BookingTodo(
+      id: 'todo-$key',
+      kind: kind,
+      todoKey: key,
+      title: key,
+      booked: booked,
+    );
+
+LocationTiming _timing(int minutes) => LocationTiming(
+      location: const Location(id: 'x', name: 'x'),
+      arrivalTime: '09:00',
+      departureTime: '10:00',
+      visitDurationMin: 60,
+      travelToNextMin: minutes,
+    );
+
+TripDerivation _compute({
+  Trip? trip,
+  List<BookingTodo>? bookingTodos,
+  List<Accommodation>? stays,
+  List<TripSegment>? segments,
+  Map<int, LocationTiming>? travelByPos,
+  String itemFilter = 'all',
+  AppLocalizationsEn? l10n,
+  int itemOrderEpoch = 0,
+}) =>
+    TripDerivation.compute(
+      trip: trip ?? _trip(),
+      bookingTodos: bookingTodos ?? const [],
+      stays: stays ?? const [],
+      segments: segments ?? const [],
+      travelByPos: travelByPos ?? const {},
+      itemFilter: itemFilter,
+      l10n: l10n ?? _l10n,
+      itemOrderEpoch: itemOrderEpoch,
+    );
+
+final _l10n = AppLocalizationsEn();
+
+void main() {
+  group('memo signature', () {
+    test('matches on the identical input signature', () {
+      final trip = _trip();
+      final todos = [_todo('stay:paris', kind: 'stay')];
+      final stays = [_parisStay];
+      final segments = <TripSegment>[];
+      final travel = {0: _timing(30)};
+      final d = _compute(
+          trip: trip,
+          bookingTodos: todos,
+          stays: stays,
+          segments: segments,
+          travelByPos: travel);
+      expect(
+        d.matches(
+          trip: trip,
+          bookingTodos: todos,
+          stays: stays,
+          segments: segments,
+          travelByPos: travel,
+          itemFilter: 'all',
+          l10n: _l10n,
+          itemOrderEpoch: 0,
+        ),
+        isTrue,
+      );
+    });
+
+    test('every single input flip invalidates', () {
+      final trip = _trip();
+      final todos = <BookingTodo>[];
+      final stays = <Accommodation>[];
+      final segments = <TripSegment>[];
+      final travel = <int, LocationTiming>{};
+      final d = _compute(
+          trip: trip,
+          bookingTodos: todos,
+          stays: stays,
+          segments: segments,
+          travelByPos: travel);
+
+      bool matchesWith({
+        Trip? newTrip,
+        List<BookingTodo>? newTodos,
+        List<Accommodation>? newStays,
+        List<TripSegment>? newSegments,
+        Map<int, LocationTiming>? newTravel,
+        String itemFilter = 'all',
+        Object? newL10n,
+        int epoch = 0,
+      }) =>
+          d.matches(
+            trip: newTrip ?? trip,
+            bookingTodos: newTodos ?? todos,
+            stays: newStays ?? stays,
+            segments: newSegments ?? segments,
+            travelByPos: newTravel ?? travel,
+            itemFilter: itemFilter,
+            l10n: (newL10n ?? _l10n) as AppLocalizationsEn,
+            itemOrderEpoch: epoch,
+          );
+
+      expect(matchesWith(), isTrue, reason: 'sanity: unchanged inputs reuse');
+      // Content-equal but NOT identical objects must invalidate: the screen's
+      // mutation paths replace objects wholesale, and identity is the signal.
+      expect(matchesWith(newTrip: _trip()), isFalse, reason: 'trip flip');
+      expect(matchesWith(newTodos: <BookingTodo>[]), isFalse,
+          reason: 'todos flip');
+      expect(matchesWith(newStays: <Accommodation>[]), isFalse,
+          reason: 'stays flip');
+      expect(matchesWith(newSegments: <TripSegment>[]), isFalse,
+          reason: 'segments flip');
+      expect(matchesWith(newTravel: <int, LocationTiming>{}), isFalse,
+          reason: 'travelByPos flip');
+      expect(matchesWith(itemFilter: 'attraction'), isFalse,
+          reason: 'filter flip');
+      expect(matchesWith(newL10n: AppLocalizationsEn()), isFalse,
+          reason: 'l10n flip (locale switch delivers a new instance)');
+      expect(matchesWith(epoch: 1), isFalse,
+          reason: 'epoch flip (the in-place reorder contract)');
+    });
+  });
+
+  group('lazy per-day accessors', () {
+    test('stable List identity per (derivation, day)', () {
+      final d = _compute(stays: [_parisStay]);
+      expect(identical(d.dayFilteredItems(1), d.dayFilteredItems(1)), isTrue);
+      expect(
+          identical(d.dayFilteredItems(null), d.dayFilteredItems(null)), isTrue);
+      expect(identical(d.dayFilteredItems(null), d.filtered), isTrue);
+      expect(identical(d.dayFilteredStays(1), d.dayFilteredStays(1)), isTrue);
+      expect(identical(d.dayFilteredStays(null), d.confirmedStays), isTrue);
+      expect(identical(d.staysOnNight(2), d.staysOnNight(2)), isTrue);
+    });
+
+    test('day filtering matches the legacy per-call rule', () {
+      final trip = _trip(stays: [_parisStay, _draftStay]);
+      final d = _compute(trip: trip);
+      expect([for (final i in d.dayFilteredItems(1)) i.name], ['Louvre']);
+      expect([for (final i in d.dayFilteredItems(4)) i.name], ['Trevi']);
+      // Confirmed stays only — the auto draft never reaches the map.
+      expect([for (final a in d.confirmedStays) a.id], ['a1']);
+      // Checkout-exclusive night math: Sep 1 + Sep 2 covered, Sep 3 not.
+      expect([for (final a in d.staysOnNight(1)) a.id], ['a1']);
+      expect([for (final a in d.staysOnNight(2)) a.id], ['a1']);
+      expect(d.staysOnNight(3), isEmpty);
+      expect([for (final a in d.dayFilteredStays(2)) a.id], ['a1']);
+    });
+  });
+
+  group('pipeline parity', () {
+    test('groups: revisited city gets a #2 run key and per-run items', () {
+      final d = _compute();
+      expect([for (final g in d.groups) g.key], ['Paris', 'Rome', 'Paris#2']);
+      expect([for (final g in d.groups) g.label], ['Paris', 'Rome', 'Paris']);
+      expect([for (final i in d.groups[1].items) i.name],
+          ['Colosseum', 'Trevi']);
+      expect([for (final i in d.groups[2].items) i.name], ['Louvre Again']);
+      // legs (the unfiltered split) mirrors the same runs.
+      expect([for (final l in d.legs) l.key], ['Paris', 'Rome', 'Paris#2']);
+    });
+
+    test('locationDates: visible (arrival-adjusted) ranges + nights suffix',
+        () {
+      final d = _compute();
+      // Paris days 1-2 → Sep 1 – Sep 2, one night; keyed per item position.
+      expect(d.locationDates[0], d.locationDates[1]);
+      expect(d.locationDates[0]?.range, 'Sep 1 – Sep 2');
+      expect(d.locationDates[0]?.nights, _l10n.tripLegNights(1));
+      // Rome renders from its ARRIVAL (previous leg's visible end, Sep 2) —
+      // the visibleLegRanges rule the header chips and stay todos share.
+      expect(d.locationDates[2]?.range, 'Sep 2 – Sep 4');
+      expect(d.locationDates[2]?.nights, _l10n.tripLegNights(2));
+      expect(d.locationDates[4]?.range, 'Sep 4 – Sep 5');
+      expect(d.locationDates[4]?.nights, _l10n.tripLegNights(1));
+      // Group date chips are the same chips, keyed by first item position.
+      expect(d.groups[0].dateRange, d.locationDates[0]);
+      expect(d.groups[2].dateRange, d.locationDates[4]);
+
+      // A same-day trip collapses to the bare date with no nights suffix.
+      final sameDay = _compute(
+        trip: Trip(
+          id: 't2',
+          title: 'Day trip',
+          status: 'planned',
+          startDate: '2026-09-01',
+          endDate: '2026-09-01',
+          createdAt: '2026-08-01',
+          updatedAt: '2026-08-01',
+          items: [
+            _item(0, 'Louvre', city: 'Paris', day: 1, lat: 48.86, lng: 2.35)
+          ],
+        ),
+      );
+      expect(sameDay.locationDates[0]?.range, 'Sep 1');
+      expect(sameDay.locationDates[0]?.nights, isNull);
+    });
+
+    test('groupedBookings: claim-once slot matching + residuals', () {
+      final todos = [
+        _todo('transport:home>>paris'),
+        _todo('stay:paris', kind: 'stay'),
+        _todo('transport:paris>>rome'),
+        _todo('stay:rome', kind: 'stay'),
+        _todo('transport:paris>>home'),
+        _todo('custom:helicopter', kind: 'other'),
+      ];
+      final d = _compute(
+          bookingTodos: todos, stays: [_parisStay, _draftStay]);
+      final grouped = d.groupedBookings;
+      // One slot per leg label (Paris, Rome, Paris-revisit).
+      expect(d.legLabels, ['Paris', 'Rome', 'Paris']);
+      expect(grouped.slots.length, 3);
+      expect(grouped.slots[0].arrival?.todoKey, 'transport:home>>paris');
+      expect(grouped.slots[0].stay?.todoKey, 'stay:paris');
+      expect(grouped.slots[0].stayMatch?.id, 'a1');
+      expect(grouped.slots[1].arrival?.todoKey, 'transport:paris>>rome');
+      expect(grouped.slots[1].stay?.todoKey, 'stay:rome');
+      // Claim-once: the revisited Paris slot cannot re-claim stay:paris.
+      expect(grouped.slots[2].stay, isNull);
+      // Departure only on the last slot; the inter-city paris>>rome leg was
+      // already claimed as Rome's arrival, so the home leg is what's left.
+      expect(grouped.slots[0].departure, isNull);
+      expect(grouped.slots[2].departure?.todoKey, 'transport:paris>>home');
+      // Residuals: the custom todo; the auto draft stay is excluded entirely.
+      expect([for (final t in grouped.residual) t.todoKey],
+          ['custom:helicopter']);
+      expect(grouped.residualStays, isEmpty);
+      expect(grouped.residualSegments, isEmpty);
+    });
+
+    test('segmentLabels: within-city adjacent legs only, localized', () {
+      final travel = {
+        0: _timing(30), // Louvre -> Le Comptoir, same hub: labelled
+        1: _timing(45), // Le Comptoir -> Colosseum, cross-hub: dropped
+        2: _timing(90), // Colosseum -> Trevi, same hub: labelled "1h 30m"
+      };
+      final d = _compute(travelByPos: travel);
+      expect(d.segmentLabels, {0: '30 min', 2: '1h 30m'});
+      // A category filter empties the labels (legs aren't globally adjacent).
+      final filtered =
+          _compute(travelByPos: travel, itemFilter: 'attraction');
+      expect(filtered.segmentLabels, isEmpty);
+    });
+
+    test('places lenses filter items; bookings lenses keep the whole set', () {
+      expect(
+        [for (final i in _compute(itemFilter: 'attraction').filtered) i.name],
+        ['Louvre', 'Colosseum', 'Trevi', 'Louvre Again'],
+      );
+      expect(
+        [for (final i in _compute(itemFilter: 'local').filtered) i.name],
+        ['Le Comptoir'],
+      );
+      expect(_compute(itemFilter: 'unbooked').filtered.length, 5);
+      expect(_compute(itemFilter: 'bookings').filtered.length, 5);
+    });
+
+    test('map inputs: shown gate, day chips, destinations, endpoints', () {
+      final d = _compute(stays: const []);
+      expect(d.mapShown, isTrue);
+      expect(d.mapDayCount, 5);
+      // Coordinate-bearing items carry days 1, 2, 3, 5 (Trevi has none).
+      expect(d.mappedDays, {1, 2, 3, 5});
+      // One destination pin per geocoded leg, visit order, dated.
+      expect([for (final m in d.mapDestinations) m.label],
+          ['Paris', 'Rome', 'Paris']);
+      expect(d.mapDestinations[0].dates, 'Sep 1 – Sep 2');
+      expect(d.homeLegEndpoints.first?.latitude, 48.86);
+      expect(d.homeLegEndpoints.last?.latitude, 48.86);
+
+      // A geocoded stay both shows the map and lights its nights' chips.
+      final stayOnly = _compute(
+        trip: _trip(items: const [], stays: [_parisStay]),
+      );
+      expect(stayOnly.mapShown, isTrue);
+      expect(stayOnly.mapDayCount, 5);
+      expect(stayOnly.mappedDays, {1, 2});
+
+      final bare = _compute(trip: _trip(items: const []));
+      expect(bare.mapShown, isFalse);
+      expect(bare.groups, isEmpty);
+      expect(bare.legLabels, isEmpty);
+      expect(bare.groupedBookings.slots, isEmpty);
+    });
+
+    test('liveDayKeys + firstGroupKeyForDay follow the run keys', () {
+      final d = _compute();
+      expect(d.liveDayKeys,
+          {'Paris#1', 'Paris#2', 'Rome#3', 'Rome#4', 'Paris#2#5'});
+      expect(d.firstGroupKeyForDay(1), 'Paris');
+      expect(d.firstGroupKeyForDay(3), 'Rome');
+      expect(d.firstGroupKeyForDay(5), 'Paris#2');
+      expect(d.firstGroupKeyForDay(9), isNull);
+      expect(d.firstGroupKeyForDay(null), isNull);
+    });
+
+    test('city fillers keep their group but drop their day keys', () {
+      final items = [
+        _item(0, 'Prague', city: 'Prague', day: 1, lat: 50.1, lng: 14.4),
+        _item(1, 'Charles Bridge',
+            city: 'Prague', day: 2, lat: 50.09, lng: 14.41),
+      ];
+      final d = _compute(trip: _trip(items: items));
+      expect(isCityFiller(items[0]), isTrue);
+      expect(isCityFiller(items[1]), isFalse);
+      // The filler still counts toward its group (suppression is render-side,
+      // in _buildGroupItemSlivers)…
+      expect(d.groups.single.items.length, 2);
+      // …but contributes no day key, mirroring the day-header rule.
+      expect(d.liveDayKeys, {'Prague#2'});
+    });
+  });
+}

--- a/src/packages/flutter-app/test/trip_detail_reorder_epoch_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_reorder_epoch_test.dart
@@ -1,0 +1,147 @@
+// Pins the derivation-memo epoch contract (specs/perf-program, Wave 4 PR1).
+//
+// `_reorderBatchInline` mutates the trip's item List IN PLACE
+// (`items.setAll`) — the one derivation input that changes without an
+// identity flip — and must bump `_itemOrderEpoch` inside the same setState so
+// the optimistic frame recomputes the city groups and renders the dragged
+// order. This test drags, then pumps frames BEFORE the silent reload
+// resolves (the fake's getTrip is gated on a Completer): if the epoch bump
+// is ever lost, the memoized derivation serves the stale order and the
+// assertion fails on the optimistic frame.
+//
+// Fake + drag mechanics follow test/trip_detail_itinerary_reorder_test.dart.
+
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:travel_route_planner/models/trip.dart';
+import 'package:travel_route_planner/models/itinerary_item.dart';
+import 'package:travel_route_planner/services/api_client.dart';
+import 'package:travel_route_planner/services/trips_api_service.dart';
+import 'package:travel_route_planner/providers/trips_provider.dart';
+import 'package:travel_route_planner/screens/trip_detail_screen.dart';
+
+import 'support/l10n_test_app.dart';
+
+ItineraryItem _item(int pos, String name) => ItineraryItem(
+      id: 'i-$name',
+      position: pos,
+      name: name,
+      address: '$name address',
+      // Zero coords so the screen skips the map widget in the test env.
+      latitude: 0,
+      longitude: 0,
+      category: 'attraction',
+      day: 1,
+      city: 'Paris',
+    );
+
+Trip _tripWith(List<ItineraryItem> items) => Trip(
+      id: 't1',
+      title: 'Paris',
+      status: 'planned',
+      startDate: '2026-09-01',
+      endDate: '2026-09-03',
+      createdAt: '2026-08-01',
+      updatedAt: '2026-08-01',
+      items: items,
+    );
+
+/// Serves the seeded trip; [gate], when set, stalls every subsequent getTrip
+/// until completed — freezing the screen on its optimistic state so the test
+/// can assert the frame(s) rendered before the silent reload lands.
+class _GatedTripsApiService extends TripsApiService {
+  List<ItineraryItem> items;
+  final List<List<String>> reorderCalls = [];
+  Completer<void>? gate;
+  _GatedTripsApiService(Trip trip)
+      : items = trip.items!,
+        super(ApiClient(baseUrl: 'http://test'));
+
+  @override
+  Future<Trip> getTrip(String id) async {
+    final g = gate;
+    if (g != null) await g.future;
+    // A fresh list per fetch, like a real JSON parse.
+    return _tripWith(List.of(items));
+  }
+
+  @override
+  Future<void> reorderItineraryItems(
+      String tripId, List<String> itemIds) async {
+    reorderCalls.add(itemIds);
+    final byId = {for (final it in items) it.id: it};
+    items = [for (final id in itemIds) byId[id]!];
+  }
+}
+
+double _rowTop(WidgetTester tester, String name) => tester
+    .getTopLeft(
+        find.ancestor(of: find.text(name), matching: find.byType(ListTile)))
+    .dy;
+
+void main() {
+  testWidgets(
+      'inline drag renders the new order optimistically, before the silent '
+      'reload resolves (epoch contract)', (WidgetTester tester) async {
+    tester.view.physicalSize = const Size(800, 2400);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+
+    final fake = _GatedTripsApiService(_tripWith([
+      _item(0, 'Louvre'),
+      _item(1, 'Orsay'),
+      _item(2, 'Pantheon'),
+    ]));
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [tripsApiServiceProvider.overrideWithValue(fake)],
+        child: MaterialApp(
+            localizationsDelegates: testLocalizationsDelegates,
+            home: const TripDetailScreen(tripId: 't1')),
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(_rowTop(tester, 'Louvre'), lessThan(_rowTop(tester, 'Orsay')));
+
+    // Stall the post-reorder silent reload: everything rendered from here
+    // until the gate opens comes from the optimistic in-place mutation.
+    fake.gate = Completer<void>();
+
+    final rowHeight = _rowTop(tester, 'Orsay') - _rowTop(tester, 'Louvre');
+    final row = find.ancestor(
+        of: find.text('Louvre'), matching: find.byType(ListTile));
+    final handle =
+        find.descendant(of: row, matching: find.byIcon(Icons.drag_indicator));
+    final gesture = await tester.startGesture(tester.getCenter(handle));
+    await tester.pump(const Duration(milliseconds: 100));
+    for (var i = 0; i < 5; i++) {
+      await gesture.moveBy(Offset(0, (rowHeight + 20) / 5));
+      await tester.pump(const Duration(milliseconds: 50));
+    }
+    await gesture.up();
+    // ONE frame after the drop: the setState(items.setAll + epoch bump) has
+    // built exactly once and the reload is still gated. A stale derivation
+    // (missing epoch bump) would rebuild the old order here.
+    await tester.pump();
+    // Let the drop animation finish — still fully optimistic (gate closed).
+    await tester.pump(const Duration(milliseconds: 400));
+    expect(fake.reorderCalls, [
+      ['i-Orsay', 'i-Louvre', 'i-Pantheon']
+    ]);
+    expect(_rowTop(tester, 'Orsay'), lessThan(_rowTop(tester, 'Louvre')),
+        reason: 'optimistic frame must render the dragged order');
+    expect(_rowTop(tester, 'Louvre'), lessThan(_rowTop(tester, 'Pantheon')));
+
+    // Release the reload; the server order (same permutation) settles in and
+    // nothing snaps back.
+    fake.gate!.complete();
+    fake.gate = null;
+    await tester.pumpAndSettle();
+    expect(_rowTop(tester, 'Orsay'), lessThan(_rowTop(tester, 'Louvre')));
+    expect(_rowTop(tester, 'Louvre'), lessThan(_rowTop(tester, 'Pantheon')));
+  });
+}


### PR DESCRIPTION
Wave 4 PR1 of the perf program (plan: the-app-feels-pretty-sorted-crescent) — first of three serial trip-detail rendering PRs (PR2 map isolation and PR3 provider scoping follow).

## What

Every `setState` on the 6,000-line trip detail screen re-ran the whole derivation pipeline in `build()` — `tripLegs` ~5-6×, `_filtered` ~4×, plus per-call RegExp allocation in `cityFromAddress` — for view-only taps that change nothing derivation depends on (row select, city expand, day collapse, filter, Today chip, map day chips, pin tap, section toggles).

- **NEW `trip_detail_derivation.dart`**: immutable `TripDerivation` absorbing `_filtered`/`_buildGroups`/`_locationDates`/`_segmentLabels`/`_groupedBookings`/`_mapDestinations`/`_homeLegEndpoints`/`_mapShown` + build-local computations, with lazy per-day item/stay caches that keep stable identities for the map (PR2 depends on this). `compute()` is the single derivation site — the nights counter and bookings groups now structurally read the same ranges.
- **One cache, identity-keyed**: `matches()` = `identical()` on trip/todos/stays/segments/travelByPos/l10n + `==` on itemFilter and `_itemOrderEpoch`. No explicit invalidation calls exist — every mutation path replaces its inputs wholesale, so identity does it.
- **`_itemOrderEpoch` contract**: the screen's ONE in-place mutation (`_reorderBatchInline`'s `items.setAll`) is invisible to identity checks; any in-place write MUST bump the epoch. The new reorder-epoch frame test drags a row and asserts the optimistic order renders before the silent reload — verified mutation-killing (fails with the bump removed).
- Non-build readers (`_deriveTodos`, pin tap, `_expandRunsOfNewItems`, `_pinnedChrome`, `_openFullMap`) rewired through the same `_derive` getter; `_liveDayKeys` field deleted.
- Folded-in cheap wins: static final RegExps in `trip_legs.dart`; locale-keyed cached DateFormats (NEW `date_formats.dart`); `_itemMenu` neighbor/calendar lookups moved inside `PopupMenuButton.itemBuilder`.

Zero intended behavior change.

## Invariants preserved (from repo memory, re-verified)

filter-output-of-one-`_groupedBookings`; nights counter reads the same visibleRanges (now structurally enforced); city-filler suppression stays in `_buildGroupItemSlivers`; `_expandedCities` inversion + collapse-by-default + pinned-header geometry untouched.

## Verification

- All `trip_detail_*` + `trip_map*` test files pass single-isolate, incl. NEW `trip_detail_derivation_test.dart` (identity reuse, per-input invalidation, parity on `city_groups` fixtures) and `trip_detail_reorder_epoch_test.dart`.
- `flutter analyze` clean (3 pre-existing infos). Full suite via CI.
- Post-deploy manual check for Brian (Zen): row tap / checkbox / city expand on a 3-city trip — no map flash, sub-frame response.

🤖 Generated with [Claude Code](https://claude.com/claude-code)