### PR TITLE
perf(flutter): isolate trip-detail map from screen rebuilds and selection re-clustering

### DIFF
--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -157,7 +157,12 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
   // Reset on every lens change so the lens always opens at All; clamped in
   // _bookingsLensBody against the current leg labels (edits can stale it).
   String? _bookingsLensDestination;
-  int? _selectedDay; // map day-chip selection; null = All (specs/today-mode)
+  // Map day-chip selection; null = All (specs/today-mode). A ValueNotifier
+  // so a day-chip tap rebuilds only the map card's ListenableBuilder, never
+  // the whole screen. May hold a stale out-of-range day after an edit
+  // shrinks the trip — readers clamp via _clampedDay (read-side, so build
+  // never mutates state).
+  final ValueNotifier<int?> _selectedDay = ValueNotifier<int?>(null);
   // Whether the map renders as the wide layout's pinned header (true) or the
   // phone layout's scroll-away tap-to-expand card (false). Assigned each
   // build from the body width; also feeds the Today-scroll chrome math.
@@ -182,8 +187,11 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
   // _expandedCities.
   final Map<String, GlobalKey> _dayHeaderKeys = {};
   final Map<String, GlobalKey> _cityHeaderKeys = {};
-  int?
-      _selectedPosition; // position of the place focused via a map pin / list tap
+  // Position of the place focused via a map pin / list tap. A ValueNotifier
+  // consumed by the map card's ListenableBuilder and each item tile, so
+  // selecting a place rebuilds the map subtree + visible tiles — never the
+  // whole screen, and (via TripMap's marker cache) never re-clusters.
+  final ValueNotifier<int?> _selectedPosition = ValueNotifier<int?>(null);
   List<BookingTodo> _bookingTodos = [];
   // Mutable copies of the trip's stays/segments, like _bookingTodos, so the
   // booked checkboxes can flip optimistically without rebuilding the
@@ -289,6 +297,8 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
     WidgetsBinding.instance.removeObserver(this);
     _statusPoll?.cancel();
     _scroll.dispose();
+    _selectedDay.dispose();
+    _selectedPosition.dispose();
     super.dispose();
   }
 
@@ -585,7 +595,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
       return;
     }
     _autoScrolledToday = true;
-    _selectedDay = today; // map day-chip preselect
+    _selectedDay.value = today; // map day-chip preselect
     // The scroll itself waits for the first build that actually shows the
     // scroll view: this setState still renders the loading spinner (the
     // loud path clears _loading later, in its finally), so a post-frame
@@ -3100,12 +3110,18 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
 
   Widget _itemTile(ItineraryItem item, double indentLeft, ThemeData theme,
           {Widget? dragHandle}) =>
-      // Secondary controls (maps link, kebab, drag handle) reveal on hover:
-      // opacity-only, so layout never shifts, drag geometry stays stable for
-      // the reorderable list, and touch devices (no mouse) keep them
-      // permanently visible. The time-of-day chip is content, not a control
-      // — it stays.
-      HoverReveal(
+      // Selection is notifier-driven (see _selectedPosition): each tile
+      // listens itself, so selecting a place rebuilds only the visible
+      // tiles rather than the whole screen.
+      ValueListenableBuilder<int?>(
+        valueListenable: _selectedPosition,
+        builder: (context, selectedPos, _) =>
+            // Secondary controls (maps link, kebab, drag handle) reveal on
+            // hover: opacity-only, so layout never shifts, drag geometry
+            // stays stable for the reorderable list, and touch devices (no
+            // mouse) keep them permanently visible. The time-of-day chip is
+            // content, not a control — it stays.
+            HoverReveal(
         builder: (context, revealed) => Padding(
           padding: EdgeInsets.only(left: indentLeft),
           child: ListTile(
@@ -3174,12 +3190,14 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
               ),
             ],
           ),
-          selected: _selectedPosition == item.position,
+          selected: selectedPos == item.position,
           selectedTileColor:
               theme.colorScheme.primary.withValues(alpha: 0.08),
           // The map is pinned and always on screen, so tapping an item only
-          // needs to update the selection; TripMap recenters on the new pin.
-          onTap: () => setState(() => _selectedPosition = item.position),
+          // needs to update the selection; the notifier rebuilds the map
+          // card (TripMap recenters) and the visible tiles — no setState.
+          onTap: () => _selectedPosition.value = item.position,
+        ),
         ),
         ),
       );
@@ -4247,100 +4265,134 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
   }) {
     final derivation = _derive(trip);
     final endpoints = derivation.homeLegEndpoints;
-    final home = homeOverlayFor(
-      ref,
-      homeAirport: _homeAirport,
-      day: _selectedDay,
-      dayCount: mapDayCount,
-      firstCityPoint: endpoints.first,
-      lastCityPoint: endpoints.last,
-    );
-    Widget map = TripMap(
-      items: derivation.dayFilteredItems(_selectedDay),
-      accommodations: derivation.dayFilteredStays(_selectedDay),
-      destinations:
-          _selectedDay == null ? derivation.mapDestinations : null,
-      selectedPosition: _selectedPosition,
-      // Unfiltered by day: TripMap's position+1 adjacency guard drops labels
-      // across the gaps a day filter creates, and the category filter
-      // already empties this map.
-      segmentLabels: derivation.segmentLabels,
-      home: home,
-      fitSignature: _selectedDay,
-      // Keep fitted markers clear of the chip row overlaid below.
-      topOverlayInset: mapDayCount > 0 ? MapDayChips.mapTopInset : 0,
-      interactive: !expandable,
-      emptyLabel: _selectedDay == null
-          ? l10n.tripNoMappedPlaces
-          : l10n.tripNoPlacesOnDay(_selectedDay!),
-      emptyMessage: _isOffline ? null : l10n.tripAddPlaceMapHint,
-      // The preview absorbs pointers, so its empty-state CTA could never be
-      // tapped; the pinned "+ Add place" button sits right below anyway.
-      emptyAction: (expandable || _isOffline || _readOnly)
-          ? null
-          : FilledButton.tonalIcon(
-              onPressed: () => _addPlace(day: _selectedDay),
-              icon: const Icon(Icons.add, size: 18),
-              label: Text(l10n.tripAddPlace),
-            ),
-      onPinTap: expandable
-          ? null
-          : (pos) {
-              final it = trip.items!.firstWhere((i) => i.position == pos);
-              setState(() {
-                _selectedPosition = pos;
-                // The highlighted row can only be seen if its run renders:
-                // groups default collapsed, so open the tapped item's run.
-                for (final leg in _derive(trip).legs) {
-                  if (leg.items.any((i) => i.position == pos)) {
-                    _expandedCities.add(leg.key);
-                  }
-                }
-              });
-              _showSnack(it.name);
-            },
-      onExpand: expandable
-          ? null
-          : () => _openFullMap(trip, mapDayCount, mappedDays),
-    );
-    if (expandable) {
-      map = GestureDetector(
-        behavior: HitTestBehavior.opaque,
-        onTap: () => _openFullMap(trip, mapDayCount, mappedDays),
-        child: AbsorbPointer(child: map),
-      );
-    }
-    return ClipRRect(
-      borderRadius: AppRadius.lgAll,
-      child: Stack(
-        children: [
-          Positioned.fill(child: map),
-          // Above the map's gesture layer, so chip taps and row scrolls
-          // never pan the map.
-          Positioned(
-            top: 8,
-            left: 8,
-            right: 8,
-            child: MapDayChips(
+    // Day + selection live in ValueNotifiers: this builder — not the whole
+    // screen — is what a day-chip tap or pin/row selection rebuilds. The
+    // day-filtered lists come from the derivation's lazy per-day caches, so
+    // a selection-only rebuild passes TripMap the identical lists and its
+    // marker cache skips re-clustering.
+    return ListenableBuilder(
+      listenable: Listenable.merge([_selectedDay, _selectedPosition]),
+      builder: (context, _) {
+        final day = _clampedDay(mapDayCount);
+        // Consumer, not the screen's ref: homeOverlayFor watches the
+        // home-airport resolution provider, and that watch belongs to the
+        // map subtree — resolution landing must not rebuild the screen.
+        Widget map = Consumer(
+          builder: (context, ref, _) {
+            final home = homeOverlayFor(
+              ref,
+              homeAirport: _homeAirport,
+              day: day,
               dayCount: mapDayCount,
-              selected: _selectedDay,
-              mappedDays: mappedDays,
-              onSelected: (d) => setState(() => _selectedDay = d),
-            ),
-          ),
-          if (expandable)
-            Positioned(
-              right: 8,
-              bottom: 8,
-              child: MapControlButton(
-                icon: Icons.fullscreen,
-                tooltip: l10n.tripExpandMap,
-                onTap: () => _openFullMap(trip, mapDayCount, mappedDays),
+              firstCityPoint: endpoints.first,
+              lastCityPoint: endpoints.last,
+            );
+            return TripMap(
+              items: derivation.dayFilteredItems(day),
+              accommodations: derivation.dayFilteredStays(day),
+              destinations: day == null ? derivation.mapDestinations : null,
+              selectedPosition: _selectedPosition.value,
+              // Unfiltered by day: TripMap's position+1 adjacency guard
+              // drops labels across the gaps a day filter creates, and the
+              // category filter already empties this map.
+              segmentLabels: derivation.segmentLabels,
+              home: home,
+              fitSignature: day,
+              // Keep fitted markers clear of the chip row overlaid below.
+              topOverlayInset: mapDayCount > 0 ? MapDayChips.mapTopInset : 0,
+              interactive: !expandable,
+              emptyLabel: day == null
+                  ? l10n.tripNoMappedPlaces
+                  : l10n.tripNoPlacesOnDay(day),
+              emptyMessage: _isOffline ? null : l10n.tripAddPlaceMapHint,
+              // The preview absorbs pointers, so its empty-state CTA could
+              // never be tapped; the pinned "+ Add place" button sits right
+              // below anyway.
+              emptyAction: (expandable || _isOffline || _readOnly)
+                  ? null
+                  : FilledButton.tonalIcon(
+                      onPressed: () => _addPlace(day: day),
+                      icon: const Icon(Icons.add, size: 18),
+                      label: Text(l10n.tripAddPlace),
+                    ),
+              onPinTap: expandable
+                  ? null
+                  : (pos) {
+                      final it =
+                          trip.items!.firstWhere((i) => i.position == pos);
+                      _selectedPosition.value = pos;
+                      // The highlighted row can only be seen if its run
+                      // renders: groups default collapsed, so open the
+                      // tapped item's run. Selection itself is
+                      // notifier-driven; setState only when expansion
+                      // actually changed (the one thing the wider screen
+                      // must re-render).
+                      var expandedChanged = false;
+                      for (final leg in _derive(trip).legs) {
+                        if (leg.items.any((i) => i.position == pos)) {
+                          expandedChanged =
+                              _expandedCities.add(leg.key) || expandedChanged;
+                        }
+                      }
+                      if (expandedChanged) setState(() {});
+                      _showSnack(it.name);
+                    },
+              onExpand: expandable
+                  ? null
+                  : () => _openFullMap(trip, mapDayCount, mappedDays),
+            );
+          },
+        );
+        if (expandable) {
+          map = GestureDetector(
+            behavior: HitTestBehavior.opaque,
+            onTap: () => _openFullMap(trip, mapDayCount, mappedDays),
+            child: AbsorbPointer(child: map),
+          );
+        }
+        return ClipRRect(
+          borderRadius: AppRadius.lgAll,
+          child: Stack(
+            children: [
+              Positioned.fill(child: map),
+              // Above the map's gesture layer, so chip taps and row scrolls
+              // never pan the map.
+              Positioned(
+                top: 8,
+                left: 8,
+                right: 8,
+                child: MapDayChips(
+                  dayCount: mapDayCount,
+                  selected: day,
+                  mappedDays: mappedDays,
+                  onSelected: (d) => _selectedDay.value = d,
+                ),
               ),
-            ),
-        ],
-      ),
+              if (expandable)
+                Positioned(
+                  right: 8,
+                  bottom: 8,
+                  child: MapControlButton(
+                    icon: Icons.fullscreen,
+                    tooltip: l10n.tripExpandMap,
+                    onTap: () => _openFullMap(trip, mapDayCount, mappedDays),
+                  ),
+                ),
+            ],
+          ),
+        );
+      },
     );
+  }
+
+  /// Read-side clamp for [_selectedDay]: a refresh can shrink the trip below
+  /// a stale selection (fewer days after an edit); an out-of-range day reads
+  /// as All. Clamping at read — instead of writing the notifier during
+  /// build — keeps build pure; the stale value is harmless because every
+  /// consumer goes through here with the current day count.
+  int? _clampedDay(int mapDayCount) {
+    final day = _selectedDay.value;
+    return (day != null && day > mapDayCount) ? null : day;
   }
 
   // Home-leg endpoints live in [TripDerivation.homeLegEndpoints] — the
@@ -4378,8 +4430,10 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
           segmentLabels: derivation.segmentLabels,
           dayCount: mapDayCount,
           mappedDays: mappedDays,
-          initialDay: _selectedDay,
-          onDaySelected: (d) => setState(() => _selectedDay = d),
+          initialDay: _clampedDay(mapDayCount),
+          // The embedded map card listens to the notifier, so the full-screen
+          // selection stays in sync with the card behind it — no setState.
+          onDaySelected: (d) => _selectedDay.value = d,
           onAddPlace: (_isOffline || _readOnly)
               ? null
               : (day) => _addPlace(day: day),
@@ -4569,13 +4623,9 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
                       // whole trip, not the category filter, so chips never
                       // come and go with the Attractions/Restaurants toggle.
                       final mapDayCount = derivation.mapDayCount;
-                      // A refresh can shrink the trip below a stale selection
-                      // (fewer days after an edit); fall back to All. Plain
-                      // assignment: we're already in build, so this frame
-                      // renders the clamped value.
-                      if (_selectedDay != null && _selectedDay! > mapDayCount) {
-                        _selectedDay = null;
-                      }
+                      // A stale out-of-range day selection (a refresh can
+                      // shrink the trip) is clamped read-side by every
+                      // consumer — see _clampedDay; build never writes it.
                       // Days that would plot something, so empty days (e.g.
                       // the fly-out day, all booking todos) get muted chips.
                       // Trip-wide like mapDayCount — the category filter never
@@ -4786,8 +4836,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
                                           // offline and while the refine
                                           // panel is open.
                                           onPressed: () {
-                                            setState(() =>
-                                                _selectedDay = todayDay);
+                                            _selectedDay.value = todayDay;
                                             _scrollToDay(todayDay);
                                           },
                                         ),

--- a/src/packages/flutter-app/lib/widgets/trip_map.dart
+++ b/src/packages/flutter-app/lib/widgets/trip_map.dart
@@ -188,6 +188,35 @@ class _TripMapState extends State<TripMap> {
   /// LayoutBuilder (they never reach [didUpdateWidget]).
   double? _lastMapWidth;
 
+  /// [TripMap.selectedPosition], mirrored into a notifier (synced in
+  /// [initState]/[didUpdateWidget]) so pins can render their selected state
+  /// via [ValueListenableBuilder] WITHOUT the selection being baked into
+  /// marker construction. The cluster layer decides whether to re-run full
+  /// cluster-tree construction by an identity check on its marker list, so
+  /// selection must never force a fresh list — see [_clusterMarkers].
+  final ValueNotifier<int?> _selection = ValueNotifier<int?>(null);
+
+  /// Cluster marker cache: valid while [TripMap.items] keeps its identity and
+  /// the tappable flag is unchanged. `mapped` is a pure function of items, so
+  /// items identity covers it. Returning the identical list makes the cluster
+  /// package's `oldWidget.options.markers != widget.options.markers` check
+  /// pass and skip re-clustering (selection changes, parent setStates).
+  List<Marker>? _markerCache;
+  List<ItineraryItem>? _markerCacheItems;
+  bool _markerCacheTappable = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _selection.value = widget.selectedPosition;
+  }
+
+  @override
+  void dispose() {
+    _selection.dispose();
+    super.dispose();
+  }
+
   /// Fit padding shared by the initial fit and every re-fit; asymmetric so a
   /// top overlay (day chips) never covers the topmost fitted marker.
   EdgeInsets get _fitPadding =>
@@ -349,6 +378,9 @@ class _TripMapState extends State<TripMap> {
         _fitToTrip(_fitPoints());
       });
     }
+    // Keep the pins' selection notifier in sync (ValueNotifier drops
+    // same-value writes, so this is free when selection didn't change).
+    _selection.value = widget.selectedPosition;
     if (widget.selectedPosition != null &&
         widget.selectedPosition != oldWidget.selectedPosition) {
       final target = _selectedPoint();
@@ -365,6 +397,67 @@ class _TripMapState extends State<TripMap> {
       });
     }
   }
+
+  /// The per-item cluster markers, cached by [TripMap.items] identity (see
+  /// the cache fields above). Pin visuals read the selection from
+  /// [_selection] via [ValueListenableBuilder] and the tap closure derefs
+  /// `widget.onPinTap` lazily, so a cached marker never captures stale
+  /// state — the cache key is only (items identity, tappable-or-not).
+  ///
+  /// Labels count 1..N over what this map view shows (the whole trip on All,
+  /// one day on Day N) — not the item's trip-wide position, which reads as
+  /// arbitrary once the view filters or skips ungeocoded items.
+  List<Marker> _clusterMarkers(
+      List<({ItineraryItem item, LatLng point})> mapped) {
+    final tappable = widget.onPinTap != null;
+    if (_markerCache != null &&
+        identical(_markerCacheItems, widget.items) &&
+        _markerCacheTappable == tappable) {
+      return _markerCache!;
+    }
+    final markers = <Marker>[
+      for (final (k, m) in mapped.indexed)
+        Marker(
+          point: m.point,
+          // Transparent 44px halo around the 24/28px dot, tap handling on
+          // the whole box; centered so the dot stays anchored on its
+          // coordinate (see _pinHitBox).
+          width: _pinHitBox,
+          height: _pinHitBox,
+          child: GestureDetector(
+            behavior: HitTestBehavior.opaque,
+            onTap: tappable ? () => widget.onPinTap!(m.item.position) : null,
+            child: Center(
+              child: ValueListenableBuilder<int?>(
+                valueListenable: _selection,
+                builder: (context, sel, _) {
+                  final selected = sel == m.item.position;
+                  return SizedBox.square(
+                    dimension: selected ? 28 : 24,
+                    child: _Pin(
+                      label: '${k + 1}',
+                      category: m.item.category,
+                      selected: selected,
+                    ),
+                  );
+                },
+              ),
+            ),
+          ),
+        ),
+    ];
+    _markerCacheItems = widget.items;
+    _markerCacheTappable = tappable;
+    _markerCache = markers;
+    return markers;
+  }
+
+  /// Test hook: the current cluster marker list, or null before first build.
+  /// Lets tests assert selection changes and view-only parent rebuilds keep
+  /// the identical list (no re-cluster) while an items swap produces a new
+  /// one.
+  @visibleForTesting
+  List<Marker>? get debugClusterMarkerCache => _markerCache;
 
   @override
   Widget build(BuildContext context) {
@@ -682,42 +775,7 @@ class _TripMapState extends State<TripMap> {
                       maxClusterRadius: 45,
                       size: const Size(32, 32),
                       padding: const EdgeInsets.all(40),
-                      markers: [
-                        // Labels count 1..N over what this map view shows (the
-                        // whole trip on All, one day on Day N) — not the item's
-                        // trip-wide position, which reads as arbitrary once the
-                        // view filters or skips ungeocoded items.
-                        for (final (k, m) in mapped.indexed)
-                          Marker(
-                            point: m.point,
-                            // Transparent 44px halo around the 24/28px dot, tap
-                            // handling on the whole box; centered so the dot
-                            // stays anchored on its coordinate (see
-                            // _pinHitBox).
-                            width: _pinHitBox,
-                            height: _pinHitBox,
-                            child: GestureDetector(
-                              behavior: HitTestBehavior.opaque,
-                              onTap: widget.onPinTap == null
-                                  ? null
-                                  : () => widget.onPinTap!(m.item.position),
-                              child: Center(
-                                child: SizedBox.square(
-                                  dimension:
-                                      widget.selectedPosition == m.item.position
-                                          ? 28
-                                          : 24,
-                                  child: _Pin(
-                                    label: '${k + 1}',
-                                    category: m.item.category,
-                                    selected: widget.selectedPosition ==
-                                        m.item.position,
-                                  ),
-                                ),
-                              ),
-                            ),
-                          ),
-                      ],
+                      markers: _clusterMarkers(mapped),
                       builder: (context, clusterMarkers) =>
                           _ClusterBubble(count: clusterMarkers.length),
                     ),

--- a/src/packages/flutter-app/test/trip_map_marker_cache_test.dart
+++ b/src/packages/flutter-app/test/trip_map_marker_cache_test.dart
@@ -1,0 +1,90 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:travel_route_planner/models/itinerary_item.dart';
+import 'package:travel_route_planner/widgets/trip_map.dart';
+
+import 'support/l10n_test_app.dart';
+
+// The cluster package decides whether to re-run full cluster-tree
+// construction with an identity check on its marker list, so TripMap caches
+// the list keyed on (items identity, tappable). These tests pin that
+// contract: selection changes and parent rebuilds must reuse the identical
+// list; swapping the items list must produce a fresh one.
+
+ItineraryItem _item(int pos, String name, double lat, double lng) =>
+    ItineraryItem(
+      id: 'i$pos',
+      position: pos,
+      name: name,
+      latitude: lat,
+      longitude: lng,
+      category: 'attraction',
+    );
+
+// Far apart (Paris / Rome) so the fitted camera renders two separate pins,
+// never one cluster bubble.
+final _itemsA = [
+  _item(0, 'Louvre', 48.8606, 2.3376),
+  _item(1, 'Colosseum', 41.8902, 12.4922),
+];
+
+Widget _app(List<ItineraryItem> items, {int? selectedPosition}) => MaterialApp(
+      localizationsDelegates: testLocalizationsDelegates,
+      home: Scaffold(
+        body: TripMap(
+          items: items,
+          selectedPosition: selectedPosition,
+          onPinTap: (_) {},
+        ),
+      ),
+    );
+
+void main() {
+  testWidgets(
+      'selection change and view-only rebuild keep the identical marker list',
+      (tester) async {
+    await tester.pumpWidget(_app(_itemsA));
+    await tester.pump();
+
+    final dynamic state = tester.state(find.byType(TripMap));
+    final List<dynamic>? initial = state.debugClusterMarkerCache;
+    expect(initial, isNotNull);
+    expect(initial, hasLength(2));
+
+    // Selecting a pin re-runs build with a new selectedPosition on the SAME
+    // items list — the marker list must be the identical object (the cluster
+    // layer then skips re-clustering) and the selected pin still grows via
+    // its ValueListenableBuilder.
+    await tester.pumpWidget(_app(_itemsA, selectedPosition: 1));
+    await tester.pump();
+    expect(identical(state.debugClusterMarkerCache, initial), isTrue);
+    expect(
+      find.byWidgetPredicate(
+          (w) => w is SizedBox && w.width == 28 && w.height == 28),
+      findsOneWidget,
+    );
+
+    // A view-only parent rebuild (same items, same selection) also reuses it.
+    await tester.pumpWidget(_app(_itemsA, selectedPosition: 1));
+    await tester.pump();
+    expect(identical(state.debugClusterMarkerCache, initial), isTrue);
+  });
+
+  testWidgets('swapping the items list produces a fresh marker list',
+      (tester) async {
+    await tester.pumpWidget(_app(_itemsA));
+    await tester.pump();
+    final dynamic state = tester.state(find.byType(TripMap));
+    final List<dynamic>? initial = state.debugClusterMarkerCache;
+    expect(initial, isNotNull);
+
+    // A new list instance (what a day filter or refresh delivers) must
+    // rebuild markers — identity is the cache key, not deep equality.
+    final itemsB = List.of(_itemsA)..add(_item(2, 'Pantheon', 41.8986, 12.4769));
+    await tester.pumpWidget(_app(itemsB));
+    await tester.pump();
+    expect(identical(state.debugClusterMarkerCache, initial), isFalse);
+    expect(state.debugClusterMarkerCache, hasLength(3));
+  });
+}


### PR DESCRIPTION
Wave 4 PR2 of the perf program (plan: the-app-feels-pretty-sorted-crescent) — follows #321 (derivation memoization); PR3 (provider scoping + shell TickerMode) is last.

## What

The map was fully rebuilt **and re-clustered** on every screen setState, and selecting a pin forced a re-cluster because the selected size was baked into marker construction.

- **`trip_map.dart`**: cluster marker list cached on (`widget.items` identity, tappable flag) so the cluster package's marker-list identity check passes — selection changes and view-only parent rebuilds skip cluster-tree construction entirely. Pins render selection via a `ValueListenableBuilder` on an internal `_selection` notifier synced in `didUpdateWidget` (selection = ~2 pin rebuilds). Camera recenter unchanged.
- **`trip_detail_screen.dart`**: `_selectedDay`/`_selectedPosition` become ValueNotifiers; the map card is one `ListenableBuilder` over both (day chips, empty states, full-map route included), so chip taps and selections rebuild only the map subtree. Item tiles listen per-tile for their highlight — a row tap is a notifier write with zero setState. Pin tap setStates only when it actually expands a collapsed run. The in-build day clamp became read-side `_clampedDay()`. `homeOverlayFor`'s provider watch moved into a Consumer inside the map card (the screen's 6th screen-scope watch, gone).

Combined with #321: a row tap or pin tap now costs a couple of pin/tile rebuilds instead of full derivation + screen build + map re-cluster.

## Verification

- NEW `trip_map_marker_cache_test.dart`: marker-list identity stable across selection + view-only rebuilds (selected pin still grows), fresh list on items swap.
- All `trip_detail_*`, `trip_map*`, `map_day_chips`, `stays_only_map_gate`, `app_map` tests pass single-isolate; `flutter analyze` clean (3 pre-existing infos). Full suite via CI.
- Post-deploy manual check for Brian (Zen): row tap / pin tap on a 3-city trip — no map flash, selection highlight instant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)