### PR TITLE
fix(flutter): trips list headlines the real trip title, cities move to subtitle

### DIFF
--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -1807,8 +1807,9 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
   }
 
   /// A stored title is "long" when it's really the AI summary (multi-line or
-  /// lengthy); such trips get a computed display title instead.
-  bool _titleIsLong(String t) => t.contains('\n') || t.length > 60;
+  /// lengthy); such trips get a computed display title instead. The rule is
+  /// shared (utils/trip_format.dart) so the trips list agrees with this header.
+  bool _titleIsLong(String t) => tripTitleIsLong(t);
 
   /// What to show as the header title: the trip's own title when it's concise,
   /// otherwise a title computed from the itinerary's cities + dates.

--- a/src/packages/flutter-app/lib/screens/trips_list_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trips_list_screen.dart
@@ -282,13 +282,20 @@ class _TripCard extends ConsumerWidget {
     final hasHistory = isAdmin && versions > 1 && trip.chatId != null;
     final range = tripDateRange(trip.startDate, trip.endDate);
 
+    final cities = citiesLabel(
+      trip.cities,
+      two: (a, b) => l10n.citiesTwo(a, b),
+      more: (a, b, n) => l10n.citiesMore(a, b, n),
+    );
+    // Same rule as the trip-detail header (_displayTitle): the trip's own
+    // title unless it's really the AI summary, then the cities label. The
+    // cities line below is only shown when it isn't already the headline.
+    final usableTitle = trip.title.isNotEmpty && !tripTitleIsLong(trip.title);
+    final headline = usableTitle ? trip.title : (cities ?? trip.title);
+    final showCitiesLine = cities != null && headline != cities;
+
     final title = Text(
-      citiesLabel(
-            trip.cities,
-            two: (a, b) => l10n.citiesTwo(a, b),
-            more: (a, b, n) => l10n.citiesMore(a, b, n),
-          ) ??
-          trip.title,
+      headline,
       maxLines: 1,
       overflow: TextOverflow.ellipsis,
       style: Theme.of(context)
@@ -299,23 +306,39 @@ class _TripCard extends ConsumerWidget {
 
     final subtitle = Padding(
       padding: const EdgeInsets.only(top: AppSpacing.sm),
-      child: Wrap(
-        spacing: AppSpacing.sm,
-        runSpacing: AppSpacing.xs,
-        crossAxisAlignment: WrapCrossAlignment.center,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          if (range != null)
-            _DateChip(label: range)
-          else
-            Text(l10n.tripsListCreated(shortDate(trip.createdAt))),
-          StatusPill(status: trip.status),
-          if (!trip.isOwner && (trip.ownerName ?? '').isNotEmpty)
-            Text(
-              trip.canEdit
-                  ? l10n.tripsListPlannedWith(trip.ownerName!)
-                  : l10n.tripsListSharedBy(trip.ownerName!),
-              style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                  color: Theme.of(context).colorScheme.onSurfaceVariant),
+          Wrap(
+            spacing: AppSpacing.sm,
+            runSpacing: AppSpacing.xs,
+            crossAxisAlignment: WrapCrossAlignment.center,
+            children: [
+              if (range != null)
+                _DateChip(label: range)
+              else
+                Text(l10n.tripsListCreated(shortDate(trip.createdAt))),
+              StatusPill(status: trip.status),
+              if (!trip.isOwner && (trip.ownerName ?? '').isNotEmpty)
+                Text(
+                  trip.canEdit
+                      ? l10n.tripsListPlannedWith(trip.ownerName!)
+                      : l10n.tripsListSharedBy(trip.ownerName!),
+                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                      color: Theme.of(context).colorScheme.onSurfaceVariant),
+                ),
+            ],
+          ),
+          if (showCitiesLine)
+            Padding(
+              padding: const EdgeInsets.only(top: AppSpacing.xs),
+              child: Text(
+                cities,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: Theme.of(context).colorScheme.onSurfaceVariant),
+              ),
             ),
         ],
       ),

--- a/src/packages/flutter-app/lib/utils/trip_format.dart
+++ b/src/packages/flutter-app/lib/utils/trip_format.dart
@@ -26,6 +26,12 @@ String? shortDateLabel(String? iso) {
   return d == null ? null : _fmt(d);
 }
 
+/// A stored title is "long" when it's really the AI summary (multi-line or
+/// lengthy); such trips show a cities-derived display title instead. Shared by
+/// the trip-detail header, the trips list, and the home live-trip tile so the
+/// same trip never flips names between screens.
+bool tripTitleIsLong(String title) => title.contains('\n') || title.length > 60;
+
 /// A short destination summary from a trip's hub cities: "Paris",
 /// "Mexico City & Puerto Vallarta", or "Tokyo & Kyoto +2 more". Null when
 /// there is no city data (legacy trips), so callers fall back to the title.

--- a/src/packages/flutter-app/lib/widgets/live_trip_card.dart
+++ b/src/packages/flutter-app/lib/widgets/live_trip_card.dart
@@ -78,12 +78,18 @@ class LiveTripCard extends StatelessWidget {
                       ),
                       const SizedBox(height: 2),
                       Text(
-                        citiesLabel(
-                              trip.cities,
-                              two: (a, b) => l10n.citiesTwo(a, b),
-                              more: (a, b, n) => l10n.citiesMore(a, b, n),
-                            ) ??
-                            trip.title,
+                        // Real trip title, like the trips list and detail
+                        // header; cities label only for legacy AI-summary
+                        // titles (see tripTitleIsLong).
+                        trip.title.isNotEmpty && !tripTitleIsLong(trip.title)
+                            ? trip.title
+                            : citiesLabel(
+                                  trip.cities,
+                                  two: (a, b) => l10n.citiesTwo(a, b),
+                                  more: (a, b, n) =>
+                                      l10n.citiesMore(a, b, n),
+                                ) ??
+                                trip.title,
                         maxLines: 1,
                         overflow: TextOverflow.ellipsis,
                         style: theme.textTheme.titleMedium?.copyWith(

--- a/src/packages/flutter-app/test/trips_list_title_test.dart
+++ b/src/packages/flutter-app/test/trips_list_title_test.dart
@@ -1,0 +1,134 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:travel_route_planner/models/trip.dart';
+import 'package:travel_route_planner/providers/resumable_chats_provider.dart';
+import 'package:travel_route_planner/providers/trip_cache_provider.dart';
+import 'package:travel_route_planner/providers/trips_provider.dart';
+import 'package:travel_route_planner/screens/trips_list_screen.dart';
+import 'package:travel_route_planner/services/api_client.dart';
+import 'package:travel_route_planner/services/trip_cache.dart';
+import 'package:travel_route_planner/services/trips_api_service.dart';
+import 'package:travel_route_planner/widgets/live_trip_card.dart';
+
+import 'support/l10n_test_app.dart';
+
+/// Trip cards headline the trip's own title — the same name the detail header
+/// shows — with the cities summary demoted to a subtitle line. The cities
+/// label is only promoted to headline for legacy trips whose stored "title"
+/// is really the AI summary (tripTitleIsLong in utils/trip_format.dart).
+class _FixedTripsApiService extends TripsApiService {
+  final List<Trip> trips;
+  _FixedTripsApiService(this.trips)
+      : super(ApiClient(baseUrl: 'http://test'));
+
+  @override
+  Future<List<Trip>> listTrips() => Future.value(trips);
+}
+
+String _iso(DateTime d) => '${d.year.toString().padLeft(4, '0')}-'
+    '${d.month.toString().padLeft(2, '0')}-'
+    '${d.day.toString().padLeft(2, '0')}';
+
+String _rel(int days) => _iso(DateTime.now().add(Duration(days: days)));
+
+Trip _trip(String id, String title, {List<String>? cities}) => Trip(
+      id: id,
+      title: title,
+      status: 'planned',
+      startDate: _rel(10),
+      endDate: _rel(20),
+      cities: cities,
+      createdAt: '2026-06-01',
+      updatedAt: '2026-06-01',
+    );
+
+Future<void> _pumpList(WidgetTester tester, List<Trip> trips) {
+  return tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        tripsApiServiceProvider.overrideWithValue(_FixedTripsApiService(trips)),
+        tripCacheProvider.overrideWithValue(TripCache('u1')),
+        resumableChatsProvider.overrideWith((ref) async => const []),
+      ],
+      child: MaterialApp(
+          localizationsDelegates: testLocalizationsDelegates,
+          home: const TripsListScreen()),
+    ),
+  );
+}
+
+void main() {
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  testWidgets('card headlines the trip title with cities as a subtitle line',
+      (WidgetTester tester) async {
+    await _pumpList(tester, [
+      _trip('t1', 'Big Summer Adventure 2026',
+          cities: ['Prague', 'Kraków', 'Berlin', 'Quito']),
+    ]);
+    await tester.pumpAndSettle();
+
+    expect(find.text('Big Summer Adventure 2026'), findsOneWidget);
+    expect(find.text('Prague & Kraków +2 more'), findsOneWidget);
+
+    // The title sits above the cities line, not the other way around.
+    expect(
+      tester.getTopLeft(find.text('Big Summer Adventure 2026')).dy,
+      lessThan(tester.getTopLeft(find.text('Prague & Kraków +2 more')).dy),
+    );
+  });
+
+  testWidgets('legacy AI-summary title falls back to cities, undoubled',
+      (WidgetTester tester) async {
+    final longTitle =
+        'A 37-day trip across Latin America and Europe with food, nightlife, '
+        'nature, and architecture at every stop.';
+    await _pumpList(tester, [
+      _trip('t1', longTitle, cities: ['Prague', 'Kraków', 'Berlin']),
+    ]);
+    await tester.pumpAndSettle();
+
+    // The cities label is the headline exactly once — no duplicate subtitle.
+    expect(find.text('Prague & Kraków +1 more'), findsOneWidget);
+    expect(find.text(longTitle), findsNothing);
+  });
+
+  testWidgets('trip without cities shows just the title',
+      (WidgetTester tester) async {
+    await _pumpList(tester, [
+      _trip('t1', 'Solo Weekend'),
+    ]);
+    await tester.pumpAndSettle();
+
+    expect(find.text('Solo Weekend'), findsOneWidget);
+  });
+
+  testWidgets('live trip card headlines the real title too',
+      (WidgetTester tester) async {
+    final trip = Trip(
+      id: 't1',
+      title: 'Big Summer Adventure 2026',
+      status: 'planned',
+      startDate: _rel(-1),
+      endDate: _rel(1),
+      cities: const ['Prague', 'Kraków', 'Berlin'],
+      createdAt: '2026-06-01',
+      updatedAt: '2026-06-01',
+    );
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: testLocalizationsDelegates,
+        home: Scaffold(body: LiveTripCard(trip: trip, onTap: () {})),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Big Summer Adventure 2026'), findsOneWidget);
+    expect(find.text('Prague & Kraków +1 more'), findsNothing);
+  });
+}


### PR DESCRIPTION
## Summary
- Friction-log item: a trip showed as "Prague & Kraków +8 more" on My Trips but "Big Summer Adventure 2026" on its detail page. Cards now headline the trip's stored title — the same name the detail header shows — and the cities summary moves to a muted subtitle line under the date/status chips (`trips_list_screen.dart`).
- Home's "Happening now" card gets the same title swap (`live_trip_card.dart`); no extra subtitle line there.
- The legacy exception (stored "title" is really the AI summary: multi-line or >60 chars → show the cities label instead) is preserved and hoisted into a single shared predicate `tripTitleIsLong` in `utils/trip_format.dart`; `trip_detail_screen.dart`'s `_titleIsLong` now delegates to it. When the cities label is the headline, the subtitle line is suppressed (no duplication).

## Testing
- `flutter analyze` — no new findings (3 pre-existing infos in `route_response.dart`, untouched).
- `flutter test` — full suite, 800/800 passing, including new `test/trips_list_title_test.dart`: title-headline + cities-subtitle ordering, legacy long-title fallback without duplication, no-cities card, and the live-card headline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)