### PR TITLE
fix(flutter): raise desktop trip-map band to 340px so auto-fit shows every pin

### DIFF
--- a/src/packages/flutter-app/lib/screens/shared_trip_screen.dart
+++ b/src/packages/flutter-app/lib/screens/shared_trip_screen.dart
@@ -299,7 +299,12 @@ class _SharedTripBodyState extends ConsumerState<_SharedTripBody> {
                     ClipRRect(
                       borderRadius: AppRadius.lgAll,
                       child: SizedBox(
-                        height: 240,
+                        // Match the trip-detail map band: taller on wide
+                        // layouts so the auto-fit can show every pin.
+                        height:
+                            MediaQuery.sizeOf(context).width >= kRailBreakpoint
+                            ? 340
+                            : 240,
                         child: Stack(
                           children: [
                             Positioned.fill(

--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -554,7 +554,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
   /// Pinned-header heights, shared by the build method and the Today scroll
   /// math so the two can never drift apart.
   static const double _mapHeaderHeight =
-      12 + 240 + 12; // top gap + map + bottom gap
+      12 + 340 + 12; // top gap + map + bottom gap
   /// Map card height on phones, where the map scrolls away instead of
   /// pinning (a preview — the full-screen map is one tap away).
   static const double _mapHeightNarrow = 180;

--- a/src/packages/flutter-app/lib/widgets/app_map.dart
+++ b/src/packages/flutter-app/lib/widgets/app_map.dart
@@ -34,7 +34,7 @@ double appMapMinZoomFor(double viewportWidth) {
 ///
 /// flutter_map's stock [Epsg3857] replicates longitude, so tiles, pins and
 /// route lines repeat sideways whenever the world is narrower than the
-/// viewport. Our maps are short, fixed-height bands (240px) that auto-fit a
+/// viewport. Our maps are short, fixed-height bands that auto-fit a
 /// trip's full extent: on a wide window a tall trip forces a zoom low enough
 /// that two or three copies of the planet sit side by side — visually a bug.
 /// Drawing a single world shows [appMapBackground] past the edges instead.


### PR DESCRIPTION
## Summary
- Raise the trip-detail map band on desktop (≥800px) from 240px to 340px. The minZoom floor is width-aware only, so on wide windows the camera fit is width-clamped and trips with a large latitude spread (Europe → Central America in the friction screenshot) lose their southernmost pins off the bottom edge. Extra height converts directly into visible latitude at the clamped zoom.
- Shared trip view gets the same 340px band on wide layouts (240 unchanged on phones, gated on `kRailBreakpoint`).
- Mobile trip-detail map stays at 180px (tap-to-fullscreen preview, unchanged).
- Drop the stale "(240px)" from the `AppMapCrs` doc comment.

## Testing
- `flutter analyze` (3 pre-existing infos in `route_response.dart`, present on clean main; nothing new)
- `flutter test` — 796 passed
- Headless-Chrome verification against the dev stack with a seeded 7-city Europe→Colombia→Mexico→LA trip: desktop map shows all pins including the southernmost (previously cut off), pinned header scrolls correctly at the new height, phone layout unchanged at 180px, shared view renders the taller band.

🤖 Generated with [Claude Code](https://claude.com/claude-code)