### PR TITLE
fix(flutter): show overview toggle only when the 2-line clamp clips

### DIFF
--- a/docs/friction-log.md
+++ b/docs/friction-log.md
@@ -5,6 +5,22 @@ build queue. Priority when picking work: **breakage > friction in features
 actually used > ideas that recur across ≥2 sessions**. Tag entries `[app]`
 (dogfooding the product) or `[dev]` (workflow/tooling). Newest first.
 
+## 2026-08-11 — trip-detail dogfooding (overview show-more)
+
+- **[app] Friction → fixed (dead "Show more" toggle):** the header overview's
+  "Show more" appeared on wide windows even when the whole summary already fit
+  the 2-line clamp — clicking flipped it to "Show less" with zero visual
+  change. Root cause: the toggle was gated on `text.length > 140`, a
+  character-count proxy for "does the clamp clip", which false-positives on
+  wide layouts and false-negatives on short newline-heavy summaries (3 hard
+  lines, silent clipping, no toggle). Fix: `_OverviewText` now measures —
+  LayoutBuilder width + a TextPainter configured exactly as the rendered
+  Text's RenderParagraph (DefaultTextStyle merge, boldText, TextScaler
+  object, locale, ellipsis) against one shared `_collapsedMaxLines` constant,
+  so the toggle renders iff `didExceedMaxLines`. Lesson: **a proxy signal for
+  a layout question re-derives the renderer's decision and will drift from
+  it — ask the text engine the same question the renderer asks.**
+
 ## 2026-08-06 — trip-detail dogfooding (top-level clutter)
 
 - **[app] Friction → fixed (collapse default + All-bookings lens):** on a

--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -6201,8 +6201,10 @@ class _ReorderSectionSheetState extends State<_ReorderSectionSheet> {
 
 /// The trip overview paragraph with its "Show more/less" toggle — a
 /// self-contained leaf so expanding it rebuilds this block, never the
-/// screen that hosts it. Collapsed = 2 lines; the toggle only renders for
-/// text long enough to plausibly clip (same 140-char heuristic as before).
+/// screen that hosts it. Collapsed = [_OverviewTextState._collapsedMaxLines]
+/// lines; the toggle renders only when that clamp actually clips at the
+/// laid-out width (a character-count heuristic misfired both ways: wide
+/// windows got a dead toggle, short newline-heavy text got none).
 class _OverviewText extends StatefulWidget {
   final String text;
   final TextStyle? style;
@@ -6214,34 +6216,80 @@ class _OverviewText extends StatefulWidget {
 }
 
 class _OverviewTextState extends State<_OverviewText> {
+  /// One constant read by BOTH the rendered Text.maxLines and the measuring
+  /// painter, so the render and the toggle decision cannot drift.
+  static const int _collapsedMaxLines = 2;
+
   bool _expanded = false;
+
+  /// Whether the collapsed clamp would clip the text at [maxWidth] — the
+  /// same verdict the collapsed Text's RenderParagraph reaches. Mirrors
+  /// Text.build: DefaultTextStyle merge for inherited styles, the boldText
+  /// accessibility merge (Text applies it internally; TextPainter does not),
+  /// the ambient TextScaler OBJECT (Android 14+ scaling is nonlinear),
+  /// directionality, locale, and the same ellipsis. Same measurement pattern
+  /// as [_dateChipWidth].
+  bool _collapsedClips(BuildContext context, double maxWidth) {
+    var style = widget.style;
+    if (style == null || style.inherit) {
+      style = DefaultTextStyle.of(context).style.merge(style);
+    }
+    if (MediaQuery.boldTextOf(context)) {
+      style = style.copyWith(fontWeight: FontWeight.bold);
+    }
+    final tp = TextPainter(
+      text: TextSpan(text: widget.text, style: style),
+      maxLines: _collapsedMaxLines,
+      ellipsis: '…',
+      textDirection: Directionality.of(context),
+      textScaler: MediaQuery.textScalerOf(context),
+      locale: Localizations.maybeLocaleOf(context),
+    )..layout(maxWidth: maxWidth);
+    final clips = tp.didExceedMaxLines;
+    tp.dispose();
+    return clips;
+  }
 
   @override
   Widget build(BuildContext context) {
     final l10n = context.l10n;
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      children: [
-        Text(
-          widget.text,
-          style: widget.style,
-          maxLines: _expanded ? null : 2,
-          overflow: _expanded ? TextOverflow.visible : TextOverflow.ellipsis,
-        ),
-        if (widget.text.length > 140)
-          Align(
-            alignment: Alignment.centerLeft,
-            child: TextButton(
-              style: TextButton.styleFrom(
-                padding: EdgeInsets.zero,
-                minimumSize: const Size(0, 32),
-                tapTargetSize: MaterialTapTargetSize.shrinkWrap,
-              ),
-              onPressed: () => setState(() => _expanded = !_expanded),
-              child: Text(_expanded ? l10n.tripShowLess : l10n.tripShowMore),
-            ),
+    // LayoutBuilder so the toggle decision sees the exact width the Text
+    // wraps at. Synchronous, one layout pass — no post-frame re-measure, so
+    // the header extent is settled the frame it builds (the today-mode
+    // auto-scroll in the hosting scroll view assumes settled extents).
+    return LayoutBuilder(builder: (context, constraints) {
+      // Unbounded width can't wrap, so it can't clip (and never occurs
+      // under this stretched header column).
+      final clips = constraints.maxWidth.isFinite &&
+          _collapsedClips(context, constraints.maxWidth);
+      return Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Text(
+            widget.text,
+            style: widget.style,
+            maxLines: _expanded ? null : _collapsedMaxLines,
+            overflow: _expanded ? TextOverflow.visible : TextOverflow.ellipsis,
           ),
-      ],
-    );
+          // _expanded is deliberately not reset when the toggle disappears
+          // (window grown until the text fits): expanded and collapsed
+          // renders of fitting text are pixel-identical, so the stale flag
+          // is unobservable.
+          if (clips)
+            Align(
+              alignment: Alignment.centerLeft,
+              child: TextButton(
+                style: TextButton.styleFrom(
+                  padding: EdgeInsets.zero,
+                  minimumSize: const Size(0, 32),
+                  tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                ),
+                onPressed: () => setState(() => _expanded = !_expanded),
+                child: Text(_expanded ? l10n.tripShowLess : l10n.tripShowMore),
+              ),
+            ),
+        ],
+      );
+    });
   }
 }

--- a/src/packages/flutter-app/test/trip_detail_overview_showmore_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_overview_showmore_test.dart
@@ -1,0 +1,154 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:travel_route_planner/models/itinerary_item.dart';
+import 'package:travel_route_planner/models/trip.dart';
+import 'package:travel_route_planner/services/api_client.dart';
+import 'package:travel_route_planner/services/trips_api_service.dart';
+import 'package:travel_route_planner/providers/trips_provider.dart';
+import 'package:travel_route_planner/screens/trip_detail_screen.dart';
+
+import 'support/l10n_test_app.dart';
+
+/// Header overview "Show more": the toggle must track what the collapsed
+/// 2-line clamp actually clips at the laid-out width, not a character count.
+/// Regression coverage for BOTH failure directions of the old `length > 140`
+/// heuristic: a long summary that fits on a wide window got a dead toggle,
+/// and a short newline-heavy one clipped with no toggle at all.
+class _FakeTripsApiService extends TripsApiService {
+  final Trip trip;
+  _FakeTripsApiService(this.trip) : super(ApiClient(baseUrl: 'http://test'));
+
+  @override
+  Future<Trip> getTrip(String id) async => trip;
+}
+
+/// 150 chars (> the old 140 gate), no newlines, longest word 9 chars — fits
+/// the 2-line clamp at the wide surface under _shrinkText, clips on a phone.
+const _fittingSummary =
+    'Ten days across Andalusia with slow mornings, tapas crawls, palaces, '
+    'patios, flamenco, day trips to Ronda and Cadiz, and one lazy beach day '
+    'to finish.';
+
+/// 56 chars (≪ 140) but three hard lines, each short enough (≤ 23 chars)
+/// never to soft-wrap even at phone width — clips the 2-line clamp while the
+/// old heuristic saw "short text" and hid the toggle.
+const _newlineSummary = 'Pack light.\nBook the Alcazar early.\n'
+    'Eat at Casa Morales.';
+
+Trip _trip(String summary) => Trip(
+      id: 't1',
+      title: 'Sevilla week',
+      summary: summary,
+      status: 'planned',
+      createdAt: '2026-06-01',
+      updatedAt: '2026-06-01',
+      startDate: '2026-09-01',
+      endDate: '2026-09-03',
+      items: [
+        ItineraryItem(
+          id: 'i0',
+          position: 0,
+          name: 'Real Alcázar',
+          // Zero coords so the screen skips the map widget in the test env.
+          latitude: 0,
+          longitude: 0,
+          category: 'attraction',
+          day: 1,
+          city: 'Sevilla',
+        ),
+      ],
+    );
+
+Future<void> _pump(WidgetTester tester, Trip trip,
+    {required Size surface}) async {
+  await tester.binding.setSurfaceSize(surface);
+  addTearDown(() => tester.binding.setSurfaceSize(null));
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        tripsApiServiceProvider.overrideWithValue(_FakeTripsApiService(trip)),
+      ],
+      child: localizedTestApp(home: const TripDetailScreen(tripId: 't1')),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+/// Halves text so a >140-char summary can FIT the wide 2-line clamp: at
+/// scale 1.0 the header's 900px content cap holds only ~126 test-font chars
+/// in two lines, so every >140-char string would clip and the no-toggle
+/// assertion would be vacuous (old and new code agree). Also exercises the
+/// textScaler-aware measurement path in _collapsedClips.
+void _shrinkText(WidgetTester tester) {
+  tester.platformDispatcher.textScaleFactorTestValue = 0.5;
+  addTearDown(tester.platformDispatcher.clearTextScaleFactorTestValue);
+}
+
+void main() {
+  const phone = Size(390, 844);
+  const wide = Size(1000, 800);
+
+  testWidgets('no toggle when a >140-char summary fits the 2-line clamp',
+      (WidgetTester tester) async {
+    expect(_fittingSummary.length, greaterThan(140)); // old-code trigger
+    _shrinkText(tester);
+    await _pump(tester, _trip(_fittingSummary), surface: wide);
+
+    expect(find.text(_fittingSummary), findsOneWidget); // anti-vacuity
+    expect(find.text('Show more'), findsNothing);
+    expect(find.text('Show less'), findsNothing);
+  });
+
+  testWidgets('same summary on a phone clips: toggle shows and expands',
+      (WidgetTester tester) async {
+    await _pump(tester, _trip(_fittingSummary), surface: phone);
+
+    expect(find.text('Show more'), findsOneWidget);
+    final collapsed = tester.getSize(find.text(_fittingSummary)).height;
+
+    await tester.tap(find.text('Show more'));
+    await tester.pumpAndSettle();
+    expect(find.text('Show less'), findsOneWidget);
+    // The expanded text really renders more lines — kills "toggle flips but
+    // nothing changes".
+    expect(tester.getSize(find.text(_fittingSummary)).height,
+        greaterThan(collapsed));
+
+    await tester.tap(find.text('Show less'));
+    await tester.pumpAndSettle();
+    expect(find.text('Show more'), findsOneWidget);
+    expect(tester.getSize(find.text(_fittingSummary)).height, collapsed);
+  });
+
+  testWidgets('short newline-heavy summary (<140 chars) still gets a toggle',
+      (WidgetTester tester) async {
+    expect(_newlineSummary.length, lessThan(140)); // old code hid the toggle
+    await _pump(tester, _trip(_newlineSummary), surface: phone);
+
+    expect(find.text('Show more'), findsOneWidget);
+    final collapsed = tester.getSize(find.text(_newlineSummary)).height;
+    await tester.tap(find.text('Show more'));
+    await tester.pumpAndSettle();
+    expect(find.text('Show less'), findsOneWidget);
+    expect(tester.getSize(find.text(_newlineSummary)).height,
+        greaterThan(collapsed)); // 2 lines -> 3 lines
+  });
+
+  testWidgets('stale expanded state is harmless once the text fits',
+      (WidgetTester tester) async {
+    _shrinkText(tester);
+    await _pump(tester, _trip(_fittingSummary), surface: phone);
+
+    await tester.tap(find.text('Show more')); // clips at 390 even at 0.5
+    await tester.pumpAndSettle();
+    expect(find.text('Show less'), findsOneWidget);
+
+    await tester.binding.setSurfaceSize(wide); // now fits the clamp
+    await tester.pumpAndSettle();
+    expect(find.text('Show less'), findsNothing);
+    expect(find.text('Show more'), findsNothing);
+    expect(find.text(_fittingSummary), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- The trip-detail overview's "Show more" was gated on `text.length > 140` — a character-count proxy that showed a dead toggle on wide windows (summary already fits the 2-line clamp; clicking flips to "Show less" with zero visual change — the reported friction) and hid the toggle for short newline-heavy summaries that really do clip.
- `_OverviewText` now asks the text engine the renderer's own question: LayoutBuilder width + a TextPainter configured exactly as the rendered Text's RenderParagraph (DefaultTextStyle merge for inherited styles, boldText accessibility merge, ambient TextScaler object, directionality, locale, same ellipsis) against one shared `_collapsedMaxLines` constant — the toggle renders iff `didExceedMaxLines`.
- Measurement is synchronous in the same layout pass (no post-frame re-measure), keeping header extents settled for today-mode auto-scroll; the widget stays a pure leaf (no ref/Consumer), preserving the 2e537c1 perf isolation.
- Friction-log entry added (2026-08-11, overview show-more).

## Testing
- `flutter analyze --no-fatal-infos --fatal-warnings` (CI flags): clean — only the 3 pre-existing `route_response.dart` infos.
- New `test/trip_detail_overview_showmore_test.dart` (4 tests): wide+fitting ⇒ no toggle; phone ⇒ toggle expands/collapses with real height change; newline-heavy short summary ⇒ toggle appears; resize-while-expanded ⇒ stale flag harmless. Mutation-checked: 3 of 4 fail against the old heuristic (`+1 -3`), so the assertions aren't vacuous.
- Full suite: 804 tests, all passed.

**Integrator note**: `trip_detail_screen.dart` is a hub file and PR #326 (desktop map height) plus the in-progress `fix/map-escape-close` branch also touch it — regions are disjoint (`_OverviewText` leaf vs map code), merge serially and rebase whichever lands later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)