### PR TITLE
fix(flutter): keep the map empty state inside short preview cards

### DIFF
--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -4365,10 +4365,13 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
               emptyLabel: day == null
                   ? l10n.tripNoMappedPlaces
                   : l10n.tripNoPlacesOnDay(day),
-              emptyMessage: _isOffline ? null : l10n.tripAddPlaceMapHint,
-              // The preview absorbs pointers, so its empty-state CTA could
-              // never be tapped; the pinned "+ Add place" button sits right
-              // below anyway.
+              // The preview absorbs pointers, so its empty-state add-place
+              // hint and CTA would invite an action it can't take (tapping
+              // opens the full-screen map, which has both); dropping them
+              // also keeps the empty state inside the 180px preview card.
+              // The pinned "+ Add place" button sits right below anyway.
+              emptyMessage:
+                  (expandable || _isOffline) ? null : l10n.tripAddPlaceMapHint,
               emptyAction: (expandable || _isOffline || _readOnly)
                   ? null
                   : FilledButton.tonalIcon(

--- a/src/packages/flutter-app/lib/widgets/empty_state.dart
+++ b/src/packages/flutter-app/lib/widgets/empty_state.dart
@@ -34,46 +34,55 @@ class EmptyState extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     return Center(
-      child: Padding(
-        padding: EdgeInsets.all(compact ? AppSpacing.lg : AppSpacing.xxl),
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            Icon(
-              icon,
-              size: compact ? 32 : 64,
-              color: iconColor ?? theme.colorScheme.primary.withValues(alpha: 0.5),
-            ),
-            SizedBox(height: compact ? AppSpacing.sm : AppSpacing.lg),
-            Text(
-              title,
-              style: (compact
-                      ? theme.textTheme.titleMedium
-                      : theme.textTheme.titleLarge)
-                  ?.copyWith(fontWeight: FontWeight.bold),
-              textAlign: TextAlign.center,
-            ),
-            if (message != null) ...[
-              const SizedBox(height: AppSpacing.sm),
+      // Overflow floor for short fixed-height containers (inline map preview,
+      // large accessibility text scales, longer locales): when the content
+      // fits, the scroll view shrink-wraps and rendering is identical; when
+      // it doesn't, the block clips/scrolls instead of throwing a RenderFlex
+      // overflow.
+      child: SingleChildScrollView(
+        child: Padding(
+          padding: EdgeInsets.all(compact ? AppSpacing.lg : AppSpacing.xxl),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Icon(
+                icon,
+                size: compact ? 32 : 64,
+                color: iconColor ??
+                    theme.colorScheme.primary.withValues(alpha: 0.5),
+              ),
+              SizedBox(height: compact ? AppSpacing.sm : AppSpacing.lg),
               Text(
-                message!,
-                textAlign: TextAlign.center,
+                title,
                 style: (compact
-                        ? theme.textTheme.bodySmall
-                        : theme.textTheme.bodyMedium)
-                    ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+                        ? theme.textTheme.titleMedium
+                        : theme.textTheme.titleLarge)
+                    ?.copyWith(fontWeight: FontWeight.bold),
+                textAlign: TextAlign.center,
               ),
+              if (message != null) ...[
+                const SizedBox(height: AppSpacing.sm),
+                Text(
+                  message!,
+                  textAlign: TextAlign.center,
+                  style: (compact
+                          ? theme.textTheme.bodySmall
+                          : theme.textTheme.bodyMedium)
+                      ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+                ),
+              ],
+              if (actions.isNotEmpty) ...[
+                SizedBox(height: compact ? AppSpacing.md : AppSpacing.xl),
+                Wrap(
+                  spacing: AppSpacing.sm,
+                  runSpacing: AppSpacing.sm,
+                  alignment: WrapAlignment.center,
+                  children: actions,
+                ),
+              ],
             ],
-            if (actions.isNotEmpty) ...[
-              SizedBox(height: compact ? AppSpacing.md : AppSpacing.xl),
-              Wrap(
-                spacing: AppSpacing.sm,
-                runSpacing: AppSpacing.sm,
-                alignment: WrapAlignment.center,
-                children: actions,
-              ),
-            ],
-          ],
+          ),
         ),
       ),
     );

--- a/src/packages/flutter-app/test/trip_detail_map_expand_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_map_expand_test.dart
@@ -186,6 +186,24 @@ void main() {
   });
 
   testWidgets(
+      'phone: a pin-less day keeps the inline preview inside its card '
+      '(no hint, no overflow)', (WidgetTester tester) async {
+    await pumpScreen(tester, surface: phone);
+
+    final chips = find.byType(MapDayChips);
+    await tester.tap(find.descendant(of: chips, matching: find.text('Day 3')));
+    await tester.pumpAndSettle();
+
+    // The preview shows only the label: the add-place hint invites an action
+    // the pointer-absorbing preview can't take, and it's what overflowed the
+    // 180px card. Widget tests rethrow RenderFlex overflows at test end —
+    // settling cleanly here IS the no-overflow assertion.
+    expect(find.text('No places pinned on Day 3'), findsOneWidget);
+    expect(find.text('Add a place to see it on the map.'), findsNothing);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets(
       'escape key closes the full-screen map; a day picked '
       'there survives closing', (WidgetTester tester) async {
     await pumpScreen(tester, surface: phone);
@@ -211,12 +229,9 @@ void main() {
 
   testWidgets("escape closes the map from a pin-less day's empty state",
       (WidgetTester tester) async {
-    // Wide surface: the phone-size inline preview behind the route has a
-    // pre-existing EmptyState overflow on pin-less days that would fail this
-    // test before Escape is ever pressed.
-    await pumpScreen(tester, surface: const Size(1200, 800));
+    await pumpScreen(tester, surface: phone);
 
-    await tester.tap(inMap(find.byIcon(Icons.fullscreen)));
+    await tester.tap(find.byType(TripMap), warnIfMissed: false);
     await tester.pumpAndSettle();
 
     // Day 3 has no pins: TripMap drops the FlutterMap (and its focused

--- a/src/packages/flutter-app/test/trip_map_test.dart
+++ b/src/packages/flutter-app/test/trip_map_test.dart
@@ -145,6 +145,36 @@ void main() {
     expect(tapped, isTrue);
   });
 
+  testWidgets('empty state never overflows a short preview-height box', (
+    WidgetTester tester,
+  ) async {
+    // Harsher than any real call site: the 180px phone preview minus the
+    // 44px chip-band inset and EmptyState's own padding leaves ~104px, and
+    // label + message + CTA (in the longer Spanish strings) is more content
+    // than any surface passes at that height. Widget tests rethrow
+    // RenderFlex overflows when the test ends, so a clean settle IS the
+    // no-overflow assertion.
+    await tester.pumpWidget(
+      _hostSized(
+        TripMap(
+          items: const [],
+          topOverlayInset: 64,
+          emptyLabel: 'No hay lugares marcados el día 3',
+          emptyMessage: 'Añade un lugar para verlo en el mapa.',
+          emptyAction: FilledButton(
+            onPressed: () {},
+            child: const Text('Añadir lugar'),
+          ),
+        ),
+        const Size(375, 180),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.text('No hay lugares marcados el día 3'), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+
   testWidgets('changing fitSignature re-fits without crashing (smoke)', (
     WidgetTester tester,
   ) async {


### PR DESCRIPTION
## Summary
- Fixes the pre-existing overflow found by PR #327's empty-state test: on phones, selecting a pin-less day overflowed the 180px inline map preview by 24px (striped banner in debug).
- The preview no longer passes the add-place hint, extending the existing CTA suppression comment-and-condition: under `AbsorbPointer` both invite an action the preview can't take, and tapping opens the full-screen map, which shows both. The wide pinned card is untouched (its hint + CTA tests still pass).
- `EmptyState` gains a structural never-overflow floor (`mainAxisSize: min` Column inside a `SingleChildScrollView`): pixel-identical at every current call site when content fits; clips/scrolls instead of throwing when a short box, longer locale, or large accessibility text scale makes it tight.

## Testing
- New floor test in `trip_map_test.dart` (label + hint + CTA in Spanish at the 180px preview height) — mutation-checked: it fails against the previous `EmptyState`.
- New phone test in `trip_detail_map_expand_test.dart`: tapping a pin-less day on the inline chips shows only the label, no hint, no overflow — the exact original repro.
- The Escape empty-state test moves back to the phone surface it previously had to dodge (the workaround comment said a fix should allow this).
- `flutter analyze` clean (3 pre-existing infos); full suite 808/808.

🤖 Generated with [Claude Code](https://claude.com/claude-code)