### PR TITLE
feat(trip-detail): group same-guidance wear rows + drop null Open-Meteo days

### DIFF
--- a/specs/what-to-wear/spec.md
+++ b/specs/what-to-wear/spec.md
@@ -12,6 +12,12 @@ one-line summary while collapsed. Direction settled with Brian (2026-08-07):
 merge into ONE section (nothing about the checklist retires), render in the
 trailing cluster (no inline per-city chrome), deterministic rules — no AI.
 
+Amended 2026-08-11 (friction log, direction picked by Brian): consecutive
+same-guidance legs fold into one displayed row, and the per-row "typical for
+these dates" qualifier became a single trailing footnote — on real trips the
+repetition read as noise, and three near-identical "Warm — …" rows said
+nothing the fold doesn't.
+
 ## User Stories
 
 - As a **traveler planning a trip**, I want **to see what kind of clothes suit
@@ -28,15 +34,21 @@ trailing cluster (no inline per-city chrome), deterministic rules — no AI.
 - [ ] The trailing-cluster row is titled "What to wear & pack" and, when
       weather is available, its collapsed summary shows the cross-region
       temperature envelope and rain signal (e.g. "21°–31° · rain likely").
-- [ ] Expanded, the section lists one row per leg visit (a revisited city gets
-      one row per visit, disambiguated by date range): region label, date
-      range, per-region temperature envelope, and a deterministic phrase built
-      from the temperature band plus condition flags (rain, day–night swing,
-      extreme heat, freezing nights). The dates shown are the same visible
-      ranges the city headers display, so the two never disagree.
-- [ ] Legs beyond the forecast horizon show the existing italic "typical for
-      these dates" qualifier on their row; the collapsed summary stays
-      kind-neutral (no qualifier).
+- [ ] Expanded, the section lists one row per run of consecutive same-guidance
+      legs: legs merge when the temperature band and the surviving advisory
+      phrases match AND the date ranges are adjacent (≤1 day apart). A row
+      shows the joined region labels, the merged date span, the merged
+      temperature envelope, and the deterministic phrase built from the
+      temperature band plus condition flags (rain, day–night swing, extreme
+      heat, freezing nights). Different guidance or a ≥2-day gap keeps
+      separate rows; per-visit weather queries are unchanged either way. The
+      dates shown are the same visible ranges the city headers display, so
+      the two never disagree.
+- [ ] When any displayed leg is beyond the forecast horizon, ONE italic
+      footnote after the rows says ranges beyond the 16-day forecast show
+      typical weather for the dates; there is no per-row qualifier, and
+      forecast-vs-typical kind never splits a row. The collapsed summary
+      stays kind-neutral.
 - [ ] The editable packing checklist renders below the recommendations, fully
       intact: add/edit/check/delete, AI-seeded items, Trip-health one-tap
       fixes, export and print packet are all unchanged.
@@ -81,9 +93,12 @@ is client display only and not part of any server contract).
 - "Other places" (items with no real city) → skipped; nothing to geocode.
 - A region stayed in longer than two weeks → guidance covers the served
   window silently (same accepted limitation as the day chips).
-- Mixed near/far regions in one trip (forecast + typical) → per-row
-  qualifiers carry the nuance; the collapsed summary makes no forecast claim.
-- Revisited city → one row per visit with its own dates.
+- Mixed near/far regions in one trip (forecast + typical) → the single
+  footnote carries the nuance (rows merge regardless of kind); the collapsed
+  summary makes no forecast claim.
+- Revisited city → per-visit weather queries always; a visit shares a row
+  only under the same-guidance + adjacency rule (labels dedupe, so never
+  "Paris, Paris").
 - Weather provider outage → empty reports by server contract; recommendations
   absent, no error surfaced.
 

--- a/src/packages/api/weather_handler_test.go
+++ b/src/packages/api/weather_handler_test.go
@@ -76,6 +76,132 @@ func TestWeatherHandlerReturnsReport(t *testing.T) {
 	}
 }
 
+// Like withTestWeatherService, but the daily endpoints return the given JSON
+// body verbatim — for exercising null and short daily arrays (Open-Meteo keeps
+// unmodelable days in time[] with null metric values).
+func withTestWeatherServiceDaily(t *testing.T, dailyJSON string) {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if strings.Contains(r.URL.Path, "/search") {
+			w.Write([]byte(`{"results":[{"name":"Paris","country":"France","latitude":48.85,"longitude":2.35}]}`))
+			return
+		}
+		w.Write([]byte(dailyJSON))
+	}))
+	t.Cleanup(srv.Close)
+	prev := weatherService
+	t.Cleanup(func() { weatherService = prev })
+	weatherService = &WeatherService{
+		GeocodeBaseURL:  srv.URL,
+		ForecastBaseURL: srv.URL,
+		ArchiveBaseURL:  srv.URL,
+		Client:          srv.Client(),
+		geoCache:        newTTLCache[geoResult](time.Hour, 10),
+		summaryCache:    newTTLCache[WeatherReport](time.Hour, 10),
+	}
+}
+
+func getWeatherReport(t *testing.T, query string) (WeatherReport, *httptest.ResponseRecorder) {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/weather?"+query, nil)
+	rec := httptest.NewRecorder()
+	weatherSearchHandler(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var report WeatherReport
+	if err := json.Unmarshal(rec.Body.Bytes(), &report); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	return report, rec
+}
+
+// A near-future range so the forecast branch runs (the fake ignores the query
+// dates; 2099 ranges steer to the archive branch instead).
+func nearFutureRange(days int) string {
+	now := time.Now().UTC()
+	return "city=Paris&start_date=" + now.AddDate(0, 0, 1).Format(dateLayout) +
+		"&end_date=" + now.AddDate(0, 0, days).Format(dateLayout)
+}
+
+func TestWeatherServiceDropsNullTailDays(t *testing.T) {
+	// The day past Open-Meteo's forecast horizon still appears in time[] but
+	// carries null temps; it must be dropped, not parsed as a phantom 0°C.
+	withTestWeatherServiceDaily(t, `{"daily":{"time":["2026-08-24","2026-08-25","2026-08-26"],"temperature_2m_max":[26,28,null],"temperature_2m_min":[17,18,null],"precipitation_sum":[0,3,null],"precipitation_probability_mean":[10,60,null]}}`)
+	report, _ := getWeatherReport(t, nearFutureRange(3))
+	if report.Kind != "forecast" {
+		t.Fatalf("expected forecast branch, got %q", report.Kind)
+	}
+	if len(report.Days) != 2 {
+		t.Fatalf("expected the null-temp day dropped (2 days), got %d", len(report.Days))
+	}
+	for _, d := range report.Days {
+		if d.TempMinC == 0 || d.TempMaxC == 0 {
+			t.Fatalf("phantom 0° leaked: %+v", d)
+		}
+		if d.Date == "2026-08-26" {
+			t.Fatalf("null-temp day survived: %+v", d)
+		}
+	}
+}
+
+func TestWeatherServiceNullPrecipKeepsDay(t *testing.T) {
+	// Null precip must not discard a day with valid temps: a missing sum
+	// stays 0mm, and a missing probability stays nil — not a false "0%".
+	withTestWeatherServiceDaily(t, `{"daily":{"time":["2026-08-24","2026-08-25"],"temperature_2m_max":[26,28],"temperature_2m_min":[17,18],"precipitation_sum":[null,3],"precipitation_probability_mean":[10,null]}}`)
+	report, _ := getWeatherReport(t, nearFutureRange(2))
+	if len(report.Days) != 2 {
+		t.Fatalf("expected both days kept, got %d", len(report.Days))
+	}
+	if report.Days[0].PrecipPct == nil || *report.Days[0].PrecipPct != 10 {
+		t.Fatalf("expected day 1 precip probability 10, got %v", report.Days[0].PrecipPct)
+	}
+	if report.Days[1].PrecipPct != nil {
+		t.Fatalf("expected nil probability for null, got %d", *report.Days[1].PrecipPct)
+	}
+	if report.Days[0].PrecipMM != 0 || report.Days[1].PrecipMM != 3 {
+		t.Fatalf("unexpected precip mm: %+v", report.Days)
+	}
+}
+
+func TestWeatherServiceDropsShortArrayDays(t *testing.T) {
+	// A temp array shorter than time[] means the tail days carry no data —
+	// they must be dropped, not zero-filled.
+	withTestWeatherServiceDaily(t, `{"daily":{"time":["2099-08-01","2099-08-02","2099-08-03"],"temperature_2m_max":[26,28],"temperature_2m_min":[17,18],"precipitation_sum":[0,3]}}`)
+	report, _ := getWeatherReport(t, "city=Paris&start_date=2099-08-01&end_date=2099-08-03")
+	if len(report.Days) != 2 {
+		t.Fatalf("expected short-array tail dropped (2 days), got %d", len(report.Days))
+	}
+}
+
+func TestWeatherHandlerAllNullDaysIsEmptyReport(t *testing.T) {
+	withTestWeatherServiceDaily(t, `{"daily":{"time":["2026-08-24","2026-08-25"],"temperature_2m_max":[null,null],"temperature_2m_min":[null,null],"precipitation_sum":[null,null],"precipitation_probability_mean":[null,null]}}`)
+	report, rec := getWeatherReport(t, nearFutureRange(2))
+	if len(report.Days) != 0 {
+		t.Fatalf("expected all days dropped, got %d", len(report.Days))
+	}
+	if report.Location == "" {
+		t.Fatalf("expected the success path (resolved location), not the error path")
+	}
+	if !strings.Contains(rec.Body.String(), `"days":[]`) {
+		t.Fatalf("expected days to serialize as [], got %s", rec.Body.String())
+	}
+}
+
+func TestWeatherServiceArchiveDropsNullDays(t *testing.T) {
+	// The forecast and archive branches share fetchDaily; the null-day drop
+	// must hold for historical data too.
+	withTestWeatherServiceDaily(t, `{"daily":{"time":["2099-08-01","2099-08-02","2099-08-03"],"temperature_2m_max":[26,null,28],"temperature_2m_min":[17,null,18],"precipitation_sum":[0,null,3]}}`)
+	report, _ := getWeatherReport(t, "city=Paris&start_date=2099-08-01&end_date=2099-08-03")
+	if report.Kind != "historical" {
+		t.Fatalf("expected archive branch, got %q", report.Kind)
+	}
+	if len(report.Days) != 2 {
+		t.Fatalf("expected the null middle day dropped (2 days), got %d", len(report.Days))
+	}
+}
+
 func TestWeatherHandlerGeocodeMissIsEmptyNot500(t *testing.T) {
 	withTestWeatherService(t, false)
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/weather?city=Nowheresville&start_date=2099-08-01", nil)

--- a/src/packages/api/weather_service.go
+++ b/src/packages/api/weather_service.go
@@ -152,7 +152,11 @@ func (s *WeatherService) GetTripWeather(ctx context.Context, city, startDate, en
 	// Real forecast whenever the range's REMAINING days fit the horizon —
 	// including mid-trip queries whose start date is already past (clamp the
 	// fetch to today). Only ranges ending beyond the horizon (or entirely in
-	// the past) fall back to last year's observations as "typical".
+	// the past) fall back to last year's observations as "typical". A range
+	// ending exactly at today+16 requests one day past Open-Meteo's modeled
+	// coverage (today..today+15); that day comes back null-valued and
+	// fetchDaily drops it — forecast for 15 of 16 days beats flipping the
+	// whole window to climatology.
 	today := time.Now().UTC().Truncate(24 * time.Hour)
 	fcStart := start
 	if fcStart.Before(today) {
@@ -176,13 +180,18 @@ func (s *WeatherService) GetTripWeather(ctx context.Context, city, startDate, en
 // the same daily-series shape, except the archive carries no precipitation
 // probability — and maps the response onto a WeatherReport.
 func (s *WeatherService) fetchDaily(ctx context.Context, geo geoResult, start, end time.Time, forecast bool) (WeatherReport, error) {
+	// Open-Meteo keeps every requested date in time[] but emits null metric
+	// values for days it cannot model (e.g. the day past the forecast
+	// horizon). Decoding null into a []float64 element silently leaves 0.0 —
+	// a phantom 0°C. Pointer slices keep absence explicit; the loop below
+	// drops any day missing either temperature.
 	var out struct {
 		Daily struct {
-			Time         []string  `json:"time"`
-			TempMax      []float64 `json:"temperature_2m_max"`
-			TempMin      []float64 `json:"temperature_2m_min"`
-			PrecipSum    []float64 `json:"precipitation_sum"`
-			PrecipChance []int     `json:"precipitation_probability_mean"`
+			Time         []string   `json:"time"`
+			TempMax      []*float64 `json:"temperature_2m_max"`
+			TempMin      []*float64 `json:"temperature_2m_min"`
+			PrecipSum    []*float64 `json:"precipitation_sum"`
+			PrecipChance []*int     `json:"precipitation_probability_mean"`
 		} `json:"daily"`
 	}
 	base, endpoint, daily, kind := s.ArchiveBaseURL, "archive",
@@ -196,20 +205,27 @@ func (s *WeatherService) fetchDaily(ctx context.Context, geo geoResult, start, e
 	if err := s.getJSON(ctx, u, &out); err != nil {
 		return WeatherReport{}, err
 	}
-	report := WeatherReport{Kind: kind}
+	report := WeatherReport{Kind: kind, Days: []WeatherDay{}}
 	for i, d := range out.Daily.Time {
-		day := WeatherDay{Date: d}
-		if i < len(out.Daily.TempMax) {
-			day.TempMaxC = out.Daily.TempMax[i]
-		}
+		var lo, hi *float64
 		if i < len(out.Daily.TempMin) {
-			day.TempMinC = out.Daily.TempMin[i]
+			lo = out.Daily.TempMin[i]
 		}
-		if i < len(out.Daily.PrecipSum) {
-			day.PrecipMM = out.Daily.PrecipSum[i]
+		if i < len(out.Daily.TempMax) {
+			hi = out.Daily.TempMax[i]
 		}
-		if forecast && i < len(out.Daily.PrecipChance) {
-			p := out.Daily.PrecipChance[i]
+		if lo == nil || hi == nil {
+			// A day without both temps is no data, not 0°C — drop it.
+			continue
+		}
+		day := WeatherDay{Date: d, TempMinC: *lo, TempMaxC: *hi}
+		// Missing precip keeps the day: 0mm already means "no rain signal",
+		// and a nil probability stays nil rather than shipping a false "0%".
+		if i < len(out.Daily.PrecipSum) && out.Daily.PrecipSum[i] != nil {
+			day.PrecipMM = *out.Daily.PrecipSum[i]
+		}
+		if forecast && i < len(out.Daily.PrecipChance) && out.Daily.PrecipChance[i] != nil {
+			p := *out.Daily.PrecipChance[i]
 			day.PrecipPct = &p
 		}
 		report.Days = append(report.Days, day)

--- a/src/packages/flutter-app/lib/l10n/app_en.arb
+++ b/src/packages/flutter-app/lib/l10n/app_en.arb
@@ -2064,5 +2064,6 @@
   "wearBigSwing": "big day–night range, bring layers",
   "wearExtremeHeat": "very hot days, extra sun protection",
   "wearFreezingNights": "freezing nights, warm layers",
-  "wearSummaryRain": "rain likely"
+  "wearSummaryRain": "rain likely",
+  "wearHistoricalFootnote": "Beyond the 16-day forecast, ranges show typical weather for these dates."
 }

--- a/src/packages/flutter-app/lib/l10n/app_es.arb
+++ b/src/packages/flutter-app/lib/l10n/app_es.arb
@@ -903,5 +903,6 @@
   "wearBigSwing": "gran variación día-noche, lleva capas",
   "wearExtremeHeat": "días muy calurosos, protección solar extra",
   "wearFreezingNights": "noches bajo cero, capas de abrigo",
-  "wearSummaryRain": "lluvia probable"
+  "wearSummaryRain": "lluvia probable",
+  "wearHistoricalFootnote": "Más allá del pronóstico de 16 días, los rangos muestran el tiempo habitual en estas fechas."
 }

--- a/src/packages/flutter-app/lib/l10n/app_localizations.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations.dart
@@ -5401,6 +5401,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'rain likely'**
   String get wearSummaryRain;
+
+  /// No description provided for @wearHistoricalFootnote.
+  ///
+  /// In en, this message translates to:
+  /// **'Beyond the 16-day forecast, ranges show typical weather for these dates.'**
+  String get wearHistoricalFootnote;
 }
 
 class _AppLocalizationsDelegate

--- a/src/packages/flutter-app/lib/l10n/app_localizations_en.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations_en.dart
@@ -3161,4 +3161,8 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get wearSummaryRain => 'rain likely';
+
+  @override
+  String get wearHistoricalFootnote =>
+      'Beyond the 16-day forecast, ranges show typical weather for these dates.';
 }

--- a/src/packages/flutter-app/lib/l10n/app_localizations_es.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations_es.dart
@@ -3186,4 +3186,8 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get wearSummaryRain => 'lluvia probable';
+
+  @override
+  String get wearHistoricalFootnote =>
+      'Más allá del pronóstico de 16 días, los rangos muestran el tiempo habitual en estas fechas.';
 }

--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -3891,7 +3891,10 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
   /// a revisited city's earlier visits query per-visit windows the chips
   /// never build — one extra cached /weather call each, the accepted cost of
   /// per-visit rows. Loading or failed reports derive null and drop out;
-  /// offline this is simply empty.
+  /// offline this is simply empty. Consecutive same-guidance recs fold into
+  /// one displayed row inside [WearRecsList] ([groupWearRegions]) — a
+  /// display-layer concern only, so the watches and [_wearSummary] stay
+  /// per-leg here.
   List<WearRegionRec> _legClothingRecs(Trip trip, WidgetRef ref) {
     // NOTE: [ref] is the packing row's Consumer ref, NOT the State's — the
     // weather watches here must subscribe that row, never the whole screen
@@ -3927,7 +3930,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
 
   /// Collapsed one-liner for the merged row: the cross-region temperature
   /// envelope plus the rain signal. Kind-neutral by design — the "typical"
-  /// qualifier stays on the expanded per-region rows.
+  /// qualifier lives in the expanded block's single footnote.
   String _wearSummary(List<WearRegionRec> recs) {
     final s = clothingSummary([for (final r in recs) r.rec]);
     // Spaced dash like the date ranges ("Sep 15 – Sep 20"), so a negative low

--- a/src/packages/flutter-app/lib/utils/clothing_recs.dart
+++ b/src/packages/flutter-app/lib/utils/clothing_recs.dart
@@ -4,7 +4,10 @@
 //
 // This file is the client's ONE definition of weather thresholds: the
 // trip-detail condition glyph consumes [rainLevel] and the recommendation
-// bands live here, so the chip and the recs can never disagree. The Go trip
+// bands live here, so the chip and the recs can never disagree. The wear
+// rows' advisory suppression and same-guidance grouping live here too
+// ([effectiveAdvisories]/[groupWearRegions]), so the fold compares exactly
+// what the widget renders. The Go trip
 // review keeps its own advisory constants (trip_review.go: rainProbPct,
 // rainHistoricMM, hotThresholdC, coldThresholdC) for a different job —
 // exception findings, not banded phrasing. They are deliberately NOT twinned,
@@ -19,6 +22,7 @@
 // WeatherReport.dayFor is irrelevant here.
 
 import '../models/weather.dart';
+import 'leg_ranges.dart' show nightsBetween;
 
 /// Rain banding shared by the day-chip glyph and the recommendations.
 /// Forecast days key off the rain probability (%), historical days off
@@ -156,4 +160,105 @@ ClothingRec? clothingRec(WeatherReport report) {
     if (r.rainLikely) rainy = true;
   }
   return (loC: lo, hiC: hi, rainLikely: rainy);
+}
+
+/// Advisory phrases that survive band suppression — the DISPLAYED set, in
+/// render order (the widget iterates [WearAdvisory.values]). Flag phrases that
+/// would restate the band's own advice are dropped: freezing/cold bands
+/// already say coat (no "freezing nights"), cool and below already say layers
+/// (no "big day–night range"), and the hot band already says sun protection
+/// (no "very hot days"). Lives here rather than in the widget so the grouping
+/// fold below compares exactly what gets rendered.
+enum WearAdvisory { rainLikely, extremeHeat, freezingNights, bigSwing }
+
+Set<WearAdvisory> effectiveAdvisories(ClothingRec rec) {
+  final coldish = rec.band == TempBand.freezing || rec.band == TempBand.cold;
+  return {
+    if (rec.rainLikely) WearAdvisory.rainLikely,
+    if (rec.extremeHeat && rec.band != TempBand.hot) WearAdvisory.extremeHeat,
+    if (rec.freezingNights && !coldish) WearAdvisory.freezingNights,
+    if (rec.bigSwing && !coldish && rec.band != TempBand.cool)
+      WearAdvisory.bigSwing,
+  };
+}
+
+/// One region's precomputed guidance: the leg label, its date window, and the
+/// derived [ClothingRec]. The trip screen builds these from its own weather
+/// watches (collapsed-row summaries must be fed by the parent), so the wear
+/// widget stays display-only.
+typedef WearRegionRec = ({
+  String label,
+  DateTime start,
+  DateTime end,
+  ClothingRec rec,
+});
+
+/// One DISPLAYED wear row: a run of date-adjacent regions whose displayed
+/// guidance (band + effective advisories) is identical.
+typedef WearGroup = ({
+  List<String> labels,
+  DateTime start,
+  DateTime end,
+  TempBand band,
+  Set<WearAdvisory> advisories,
+  bool historical,
+  int loC,
+  int hiC,
+});
+
+/// Days between one group's end and the next region's start that still count
+/// as consecutive: adjacent legs share a boundary date under visible ranges
+/// (distance 0), and a single skipped/undated day between two legs shouldn't
+/// split otherwise-identical guidance. Gaps of two or more days (home between
+/// legs) keep their own rows so a merged span never swallows a real gap.
+const int wearMergeMaxGapDays = 1;
+
+/// Folds per-leg regions into displayed rows: a region merges into the
+/// previous group when the band and effective advisory set match AND the
+/// dates are adjacent (see [wearMergeMaxGapDays]). Forecast-vs-historical
+/// kind never blocks a merge — a group is historical if any member is, which
+/// drives only the single footnote. The group envelope is min-of-los /
+/// max-of-highs, so summing groups equals [clothingSummary] over the input
+/// (the collapsed header and the expanded rows can't disagree). Display-layer
+/// fold only: per-leg weather queries stay per-leg.
+List<WearGroup> groupWearRegions(List<WearRegionRec> regions) {
+  final groups = <WearGroup>[];
+  for (final r in regions) {
+    final adv = effectiveAdvisories(r.rec);
+    if (groups.isNotEmpty) {
+      final last = groups.last;
+      final sameDisplay = last.band == r.rec.band &&
+          last.advisories.length == adv.length &&
+          last.advisories.containsAll(adv);
+      if (sameDisplay &&
+          nightsBetween(last.end, r.start) <= wearMergeMaxGapDays) {
+        groups[groups.length - 1] = (
+          // Dedupe revisits ("Paris, Paris") — labels repeat the locality.
+          labels: [
+            ...last.labels,
+            if (!last.labels.contains(r.label)) r.label,
+          ],
+          start: last.start,
+          end: r.end.isAfter(last.end) ? r.end : last.end,
+          band: last.band,
+          advisories: last.advisories,
+          historical: last.historical || r.rec.historical,
+          loC: r.rec.loC < last.loC ? r.rec.loC : last.loC,
+          hiC: r.rec.hiC > last.hiC ? r.rec.hiC : last.hiC,
+        );
+        continue;
+      }
+    }
+    groups.add((
+      labels: [r.label],
+      start: r.start,
+      end: r.end,
+      band: r.rec.band,
+      advisories: adv,
+      historical: r.rec.historical,
+      loC: r.rec.loC,
+      hiC: r.rec.hiC,
+    ));
+  }
+  return groups;
 }

--- a/src/packages/flutter-app/lib/widgets/wear_recs.dart
+++ b/src/packages/flutter-app/lib/widgets/wear_recs.dart
@@ -5,33 +5,26 @@ import '../l10n/l10n.dart';
 import '../theme/spacing.dart';
 import '../utils/clothing_recs.dart';
 
-/// One region's precomputed guidance: the leg label, its date window, and the
-/// derived [ClothingRec]. The trip screen builds these from its own weather
-/// watches (collapsed-row summaries must be fed by the parent), so this
-/// widget stays display-only.
-typedef WearRegionRec = ({
-  String label,
-  DateTime start,
-  DateTime end,
-  ClothingRec rec,
-});
-
 /// The what-to-wear block at the top of the merged "What to wear & pack"
-/// section (specs/what-to-wear): per region, a muted "Lisbon · Sep 15 – Sep 20
-/// · 17°–28°" line followed by the deterministic clothing phrase. Historical
-/// reports get the same italic "typical for these dates" qualifier as the
-/// day chips — never presented as a forecast.
+/// section (specs/what-to-wear): consecutive same-guidance regions fold into
+/// one row ([groupWearRegions]) — a muted "Prague, Kraków · Aug 24 – Sep 1 ·
+/// 15°–27°" line followed by the deterministic clothing phrase. When any
+/// displayed region is historical, ONE italic footnote after the rows says
+/// the ranges are typical rather than a forecast — the old per-row qualifier
+/// read as repetition. Display-only: the trip screen builds the
+/// [WearRegionRec]s from its own weather watches (collapsed-row summaries
+/// must be fed by the parent).
 class WearRecsList extends StatelessWidget {
   final List<WearRegionRec> regions;
 
   const WearRecsList({super.key, required this.regions});
 
-  /// Flag phrases that would restate the band's own advice are dropped:
-  /// freezing/cold bands already say coat (so no "freezing nights"), cool and
-  /// below already say layers (no "big day–night range"), and the hot band
-  /// already says sun protection (no "very hot days").
-  List<String> _phrases(AppLocalizations l10n, ClothingRec rec) {
-    final band = switch (rec.band) {
+  /// Band phrase plus the group's surviving advisories, in
+  /// [WearAdvisory.values] order. Pure l10n mapping — the suppression rules
+  /// live in [effectiveAdvisories] so the grouping fold compares exactly
+  /// what renders here.
+  List<String> _phrases(AppLocalizations l10n, WearGroup g) {
+    final band = switch (g.band) {
       TempBand.freezing => l10n.wearBandFreezing,
       TempBand.cold => l10n.wearBandCold,
       TempBand.cool => l10n.wearBandCool,
@@ -39,14 +32,16 @@ class WearRecsList extends StatelessWidget {
       TempBand.warm => l10n.wearBandWarm,
       TempBand.hot => l10n.wearBandHot,
     };
-    final coldish = rec.band == TempBand.freezing || rec.band == TempBand.cold;
     return [
       band,
-      if (rec.rainLikely) l10n.wearRainLikely,
-      if (rec.extremeHeat && rec.band != TempBand.hot) l10n.wearExtremeHeat,
-      if (rec.freezingNights && !coldish) l10n.wearFreezingNights,
-      if (rec.bigSwing && !coldish && rec.band != TempBand.cool)
-        l10n.wearBigSwing,
+      for (final a in WearAdvisory.values)
+        if (g.advisories.contains(a))
+          switch (a) {
+            WearAdvisory.rainLikely => l10n.wearRainLikely,
+            WearAdvisory.extremeHeat => l10n.wearExtremeHeat,
+            WearAdvisory.freezingNights => l10n.wearFreezingNights,
+            WearAdvisory.bigSwing => l10n.wearBigSwing,
+          },
     ];
   }
 
@@ -57,7 +52,9 @@ class WearRecsList extends StatelessWidget {
     final sameDay = start.year == end.year &&
         start.month == end.month &&
         start.day == end.day;
-    return sameDay ? fmt.format(start) : '${fmt.format(start)} – ${fmt.format(end)}';
+    return sameDay
+        ? fmt.format(start)
+        : '${fmt.format(start)} – ${fmt.format(end)}';
   }
 
   @override
@@ -65,45 +62,44 @@ class WearRecsList extends StatelessWidget {
     final theme = Theme.of(context);
     final l10n = context.l10n;
     final muted = theme.colorScheme.onSurfaceVariant;
+    final groups = groupWearRegions(regions);
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
-        for (final region in regions)
+        for (final g in groups)
           Padding(
             padding: const EdgeInsets.only(bottom: AppSpacing.sm),
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 Text(
+                  // Plain ', ' label join — locale-safe with no conjunction.
                   // Spaced temp dash like the date range beside it, so a
                   // negative low never collides with the dash ("-6° – 2°").
-                  '${region.label} · ${_dateRange(region.start, region.end)}'
-                  ' · ${region.rec.loC}° – ${region.rec.hiC}°',
+                  '${g.labels.join(', ')} · ${_dateRange(g.start, g.end)}'
+                  ' · ${g.loC}° – ${g.hiC}°',
                   maxLines: 1,
                   overflow: TextOverflow.ellipsis,
                   style: theme.textTheme.labelLarge?.copyWith(color: muted),
                 ),
                 const SizedBox(height: 2),
-                Text.rich(
-                  TextSpan(
-                    children: [
-                      // '  ·  ' joins throughout, and the qualifier keeps the
-                      // line's own size with italic+muted only — both the
-                      // _weatherChip treatment.
-                      TextSpan(text: _phrases(l10n, region.rec).join('  ·  ')),
-                      if (region.rec.historical)
-                        TextSpan(
-                          text: '  ·  ${l10n.tripTypicalForDates}',
-                          style: theme.textTheme.bodyMedium?.copyWith(
-                            color: muted,
-                            fontStyle: FontStyle.italic,
-                          ),
-                        ),
-                    ],
-                  ),
+                Text(
+                  _phrases(l10n, g).join('  ·  '),
                   style: theme.textTheme.bodyMedium,
                 ),
               ],
+            ),
+          ),
+        if (groups.any((g) => g.historical))
+          Padding(
+            padding: const EdgeInsets.only(bottom: AppSpacing.sm),
+            child: Text(
+              // Italic+muted only — the _weatherChip qualifier treatment.
+              l10n.wearHistoricalFootnote,
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: muted,
+                fontStyle: FontStyle.italic,
+              ),
             ),
           ),
       ],

--- a/src/packages/flutter-app/test/clothing_recs_test.dart
+++ b/src/packages/flutter-app/test/clothing_recs_test.dart
@@ -167,4 +167,197 @@ void main() {
       expect(s.rainLikely, isFalse);
     });
   });
+
+  group('effectiveAdvisories (the displayed set after band suppression)', () {
+    test('rain always survives, any band', () {
+      expect(effectiveAdvisories(rec(band: TempBand.hot, rainLikely: true)),
+          contains(WearAdvisory.rainLikely));
+      expect(effectiveAdvisories(rec(band: TempBand.freezing, rainLikely: true)),
+          contains(WearAdvisory.rainLikely));
+    });
+
+    test('extremeHeat suppressed only when the band already says hot', () {
+      expect(effectiveAdvisories(rec(band: TempBand.hot, extremeHeat: true)),
+          isNot(contains(WearAdvisory.extremeHeat)));
+      expect(effectiveAdvisories(rec(band: TempBand.warm, extremeHeat: true)),
+          contains(WearAdvisory.extremeHeat));
+    });
+
+    test('freezingNights suppressed for freezing/cold, kept for cool', () {
+      expect(
+          effectiveAdvisories(rec(band: TempBand.cold, freezingNights: true)),
+          isNot(contains(WearAdvisory.freezingNights)));
+      expect(
+          effectiveAdvisories(
+              rec(band: TempBand.freezing, freezingNights: true)),
+          isNot(contains(WearAdvisory.freezingNights)));
+      expect(
+          effectiveAdvisories(rec(band: TempBand.cool, freezingNights: true)),
+          contains(WearAdvisory.freezingNights));
+    });
+
+    test('bigSwing suppressed for cool and below, kept for mild', () {
+      expect(effectiveAdvisories(rec(band: TempBand.cool, bigSwing: true)),
+          isNot(contains(WearAdvisory.bigSwing)));
+      expect(effectiveAdvisories(rec(band: TempBand.cold, bigSwing: true)),
+          isNot(contains(WearAdvisory.bigSwing)));
+      expect(effectiveAdvisories(rec(band: TempBand.mild, bigSwing: true)),
+          contains(WearAdvisory.bigSwing));
+    });
+
+    test('no flags means no advisories', () {
+      expect(effectiveAdvisories(rec()), isEmpty);
+    });
+  });
+
+  group('groupWearRegions', () {
+    test('consecutive same-guidance legs fold into one row', () {
+      final groups = groupWearRegions([
+        region('Prague', '2026-08-24', '2026-08-27', rec(lo: 15, hi: 26)),
+        region('Kraków', '2026-08-27', '2026-09-01', rec(lo: 16, hi: 27)),
+        region('Berlin', '2026-09-01', '2026-09-04', rec(lo: 17, hi: 25)),
+      ]);
+      expect(groups, hasLength(1));
+      final g = groups.single;
+      expect(g.labels, ['Prague', 'Kraków', 'Berlin']);
+      expect(g.start, DateTime.parse('2026-08-24'));
+      expect(g.end, DateTime.parse('2026-09-04'));
+      expect(g.band, TempBand.warm);
+      expect(g.loC, 15);
+      expect(g.hiC, 27);
+    });
+
+    test('a different band splits', () {
+      final groups = groupWearRegions([
+        region('Prague', '2026-08-24', '2026-08-27', rec(band: TempBand.warm)),
+        region('Gothenburg', '2026-08-27', '2026-08-29',
+            rec(band: TempBand.mild, lo: 14, hi: 18)),
+      ]);
+      expect(groups, hasLength(2));
+    });
+
+    test('same band but rain-vs-dry splits (advisory set is the key)', () {
+      final groups = groupWearRegions([
+        region('Prague', '2026-08-24', '2026-08-27', rec(rainLikely: true)),
+        region('Kraków', '2026-08-27', '2026-09-01', rec()),
+      ]);
+      expect(groups, hasLength(2));
+    });
+
+    test('a suppressed-flag mismatch still merges (displayed content rule)', () {
+      // Both display just "Hot — …": extremeHeat is suppressed for the hot
+      // band, so the raw-flag difference must not block the merge.
+      final groups = groupWearRegions([
+        region('Athens', '2026-08-24', '2026-08-27',
+            rec(band: TempBand.hot, extremeHeat: true, lo: 25, hi: 36)),
+        region('Santorini', '2026-08-27', '2026-08-30',
+            rec(band: TempBand.hot, lo: 24, hi: 31)),
+      ]);
+      expect(groups, hasLength(1));
+      expect(groups.single.advisories, isEmpty);
+      expect(groups.single.loC, 24);
+      expect(groups.single.hiC, 36);
+    });
+
+    test('gap rule: one day apart merges, two days apart splits', () {
+      final oneDay = groupWearRegions([
+        region('Prague', '2026-08-24', '2026-08-27', rec()),
+        region('Kraków', '2026-08-28', '2026-08-31', rec()),
+      ]);
+      expect(oneDay, hasLength(1));
+
+      final twoDays = groupWearRegions([
+        region('Prague', '2026-08-24', '2026-08-27', rec()),
+        region('Kraków', '2026-08-29', '2026-09-01', rec()),
+      ]);
+      expect(twoDays, hasLength(2));
+    });
+
+    test('forecast-vs-historical kind never blocks; group ORs historical', () {
+      final groups = groupWearRegions([
+        region('Prague', '2026-08-24', '2026-08-27', rec()),
+        region('Kraków', '2026-08-27', '2026-09-01', rec(historical: true)),
+      ]);
+      expect(groups, hasLength(1));
+      expect(groups.single.historical, isTrue);
+    });
+
+    test('an adjacent revisit dedupes the label', () {
+      final groups = groupWearRegions([
+        region('Paris', '2026-09-15', '2026-09-16', rec()),
+        region('Paris', '2026-09-17', '2026-09-18', rec()),
+      ]);
+      expect(groups, hasLength(1));
+      expect(groups.single.labels, ['Paris']);
+    });
+
+    test('group envelope agrees with clothingSummary over the input', () {
+      final recs = [
+        rec(lo: 15, hi: 26, rainLikely: true),
+        rec(band: TempBand.mild, lo: 10, hi: 18),
+        rec(lo: 12, hi: 30),
+      ];
+      final groups = groupWearRegions([
+        region('Prague', '2026-08-24', '2026-08-27', recs[0]),
+        region('Gothenburg', '2026-08-27', '2026-08-30', recs[1]),
+        region('Lisbon', '2026-08-30', '2026-09-02', recs[2]),
+      ]);
+      var lo = groups.first.loC;
+      var hi = groups.first.hiC;
+      var rainy = false;
+      for (final g in groups) {
+        if (g.loC < lo) lo = g.loC;
+        if (g.hiC > hi) hi = g.hiC;
+        if (g.advisories.contains(WearAdvisory.rainLikely)) rainy = true;
+      }
+      final s = clothingSummary(recs);
+      expect(lo, s.loC);
+      expect(hi, s.hiC);
+      expect(rainy, s.rainLikely);
+    });
+
+    test('empty in, empty out; a single region passes through', () {
+      expect(groupWearRegions([]), isEmpty);
+      final groups = groupWearRegions([
+        region('Prague', '2026-08-24', '2026-08-27',
+            rec(rainLikely: true, historical: true)),
+      ]);
+      expect(groups, hasLength(1));
+      final g = groups.single;
+      expect(g.labels, ['Prague']);
+      expect(g.advisories, {WearAdvisory.rainLikely});
+      expect(g.historical, isTrue);
+      expect((g.loC, g.hiC), (15, 26));
+    });
+  });
 }
+
+/// Direct [ClothingRec] builder for grouping tests — grouping consumes the
+/// derived rec, so these bypass the day-level derivation pinned above.
+ClothingRec rec({
+  TempBand band = TempBand.warm,
+  bool rainLikely = false,
+  bool bigSwing = false,
+  bool extremeHeat = false,
+  bool freezingNights = false,
+  bool historical = false,
+  int lo = 15,
+  int hi = 26,
+}) =>
+    ClothingRec(
+      band: band,
+      rainLikely: rainLikely,
+      bigSwing: bigSwing,
+      extremeHeat: extremeHeat,
+      freezingNights: freezingNights,
+      historical: historical,
+      loC: lo,
+      hiC: hi,
+    );
+
+WearRegionRec region(String label, String start, String end, ClothingRec r) => (
+      label: label,
+      start: DateTime.parse(start),
+      end: DateTime.parse(end),
+      rec: r,
+    );

--- a/src/packages/flutter-app/test/trip_detail_wear_section_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_wear_section_test.dart
@@ -23,12 +23,13 @@ import 'support/l10n_test_app.dart';
 
 /// The merged "What to wear & pack" section (specs/what-to-wear): collapsed
 /// summary = cross-region temperature envelope + rain signal; expanded =
-/// per-region deterministic phrases above the intact checklist; historical
-/// reports carry the "typical" qualifier ON THE WEAR ROW; a revisited city
-/// gets one row per visit with per-visit weather queries; a leg whose report
-/// is empty drops out without hiding the section; recommendations alone show
-/// the row for read-only viewers; without weather the old checklist gating
-/// holds.
+/// deterministic phrase rows above the intact checklist, with consecutive
+/// same-guidance legs folded into ONE grouped row (groupWearRegions);
+/// historical data yields a single trailing footnote, never a per-row
+/// qualifier; a revisited city keeps per-visit weather queries (distinct
+/// guidance keeps its rows separate); a leg whose report is empty drops out
+/// without hiding the section; recommendations alone show the row for
+/// read-only viewers; without weather the old checklist gating holds.
 
 class _FakeTripsApiService extends TripsApiService {
   final Trip trip;
@@ -217,6 +218,8 @@ void main() {
     expect(_inRecs('rain likely, pack an umbrella'), findsOneWidget);
     expect(_inRecs('typical for these dates'), findsNothing);
     expect(_inRecs('big day–night range'), findsNothing);
+    // All-forecast trip: no historical footnote either.
+    expect(_inRecs('Beyond the 16-day forecast'), findsNothing);
     // Recs and checklist both present → exactly one separating divider.
     expect(_wearSectionDividers(), findsOneWidget);
     // The checklist renders below, still editable: item row + add field.
@@ -225,7 +228,7 @@ void main() {
     expect(find.byType(TextField), findsWidgets);
   });
 
-  testWidgets('historical report carries the typical qualifier on its row',
+  testWidgets('historical: no per-row qualifier, one footnote after the rows',
       (tester) async {
     await _pump(
       tester,
@@ -238,22 +241,27 @@ void main() {
     await _expand(tester);
 
     expect(_inRecs('Warm — summer clothes'), findsOneWidget);
-    // Scoped to the wear block: the day chips also render this string, so an
-    // unscoped find would pass even if the wear row dropped it.
-    expect(_inRecs('typical for these dates'), findsOneWidget);
+    // The old per-row tail is gone. Scoped to the wear block: the day chips
+    // still render the shared qualifier string elsewhere on the screen, and
+    // wearHistoricalFootnote says "typical weather for these dates" so the
+    // footnote can never satisfy this substring by accident.
+    expect(_inRecs('typical for these dates'), findsNothing);
+    expect(_inRecs('Beyond the 16-day forecast'), findsOneWidget);
     // Dry historical days: no rain phrase, summary has no rain suffix.
     expect(find.textContaining('rain likely'), findsNothing);
     expect(find.text('17° – 27°'), findsOneWidget);
   });
 
-  testWidgets('a revisited city gets one row per visit, queried per window',
+  testWidgets('a revisited city queries per visit; distinct guidance keeps rows',
       (tester) async {
     // Paris (day 1) → Nice (day 2) → Paris (day 3): the wear rows must come
     // from the leg LIST, not a label-keyed map (which would collapse the two
-    // Paris visits into the last window).
+    // Paris visits into the last window). Bands differ on purpose — cool /
+    // mild / warm — so same-guidance grouping cannot merge them and the
+    // per-visit contract stays observable.
     final weather = _MapWeatherApiService({
       'Paris|2026-09-15': const WeatherReport(kind: 'forecast', days: [
-        WeatherDay(date: '2026-09-15', tempMinC: 10, tempMaxC: 18),
+        WeatherDay(date: '2026-09-15', tempMinC: 8, tempMaxC: 15),
       ]),
       'Nice|2026-09-16': const WeatherReport(kind: 'forecast', days: [
         WeatherDay(date: '2026-09-16', tempMinC: 14, tempMaxC: 22),
@@ -276,14 +284,80 @@ void main() {
     // Two Paris rows with their own visit windows and temps, Nice between.
     // Displayed dates are the VISIBLE ranges (arrival-inclusive, matching the
     // city headers); the weather queries below stay on the raw windows.
-    expect(_inRecs('Paris · Sep 15 · 10° – 18°'), findsOneWidget);
+    expect(_inRecs('Paris · Sep 15 · 8° – 15°'), findsOneWidget);
     expect(_inRecs('Nice · Sep 15 – Sep 16 · 14° – 22°'), findsOneWidget);
     expect(_inRecs('Paris · Sep 16 – Sep 17 · 16° – 25°'), findsOneWidget);
     // Both Paris visit windows were genuinely queried (per-visit keys).
     expect(weather.calls, contains('Paris|2026-09-15'));
     expect(weather.calls, contains('Paris|2026-09-17'));
-    // Collapsed summary spans all three legs: 10..25, no rain.
-    expect(find.text('10° – 25°'), findsOneWidget);
+    // Collapsed summary spans all three legs: 8..25, no rain.
+    expect(find.text('8° – 25°'), findsOneWidget);
+  });
+
+  testWidgets('consecutive same-guidance legs merge into one grouped row',
+      (tester) async {
+    // Paris and Nice both derive warm with no advisories → one row with the
+    // joined labels and the merged envelope. Exactly one band phrase pins the
+    // fold (a regression to per-leg rows would find two). The collapsed
+    // summary is computed from the UNGROUPED per-leg recs and must agree.
+    final weather = _MapWeatherApiService({
+      'Paris|2026-09-15': const WeatherReport(kind: 'forecast', days: [
+        WeatherDay(date: '2026-09-15', tempMinC: 16, tempMaxC: 24),
+      ]),
+      'Nice|2026-09-16': const WeatherReport(kind: 'forecast', days: [
+        WeatherDay(date: '2026-09-16', tempMinC: 15, tempMaxC: 23),
+      ]),
+    });
+    await _pump(
+      tester,
+      trip: _trip(items: [
+        _item(0, 'Louvre', 1),
+        _item(1, 'Promenade', 2, city: 'Nice'),
+      ]),
+      weather: weather,
+    );
+
+    expect(find.text('15° – 24°'), findsOneWidget);
+    await _expand(tester);
+    expect(
+        _inRecs('Paris, Nice · Sep 15 – Sep 16 · 15° – 24°'), findsOneWidget);
+    expect(_inRecs('Warm — summer clothes, a light evening layer'),
+        findsOneWidget);
+    expect(_inRecs('Beyond the 16-day forecast'), findsNothing);
+    // The display merged, but weather stayed per-leg.
+    expect(weather.calls, contains('Paris|2026-09-15'));
+    expect(weather.calls, contains('Nice|2026-09-16'));
+  });
+
+  testWidgets('forecast + historical legs still merge; one footnote total',
+      (tester) async {
+    // Kind must not block the fold — the nuance moves into the single
+    // footnote, which renders once for the whole block.
+    final weather = _MapWeatherApiService({
+      'Paris|2026-09-15': const WeatherReport(kind: 'forecast', days: [
+        WeatherDay(date: '2026-09-15', tempMinC: 16, tempMaxC: 24),
+      ]),
+      'Nice|2026-09-16': const WeatherReport(kind: 'historical', days: [
+        WeatherDay(date: '2025-09-16', tempMinC: 15, tempMaxC: 23),
+      ]),
+    });
+    await _pump(
+      tester,
+      trip: _trip(items: [
+        _item(0, 'Louvre', 1),
+        _item(1, 'Promenade', 2, city: 'Nice'),
+      ]),
+      weather: weather,
+    );
+    await _expand(tester);
+
+    expect(
+        _inRecs('Paris, Nice · Sep 15 – Sep 16 · 15° – 24°'), findsOneWidget);
+    expect(
+        _inRecs('Beyond the 16-day forecast, ranges show typical weather'
+            ' for these dates.'),
+        findsOneWidget);
+    expect(_inRecs('typical for these dates'), findsNothing);
   });
 
   testWidgets('a leg with an empty report drops out; the rest still render',
@@ -383,6 +457,28 @@ void main() {
         find.descendant(
             of: find.byType(WearRecsList),
             matching: find.textContaining('Cálido — ropa de verano')),
+        findsOneWidget);
+  });
+
+  testWidgets('renders the Spanish footnote for historical data',
+      (tester) async {
+    await initializeDateFormatting('es');
+    Intl.defaultLocale = 'es';
+    addTearDown(() => Intl.defaultLocale = null);
+
+    await _pump(
+      tester,
+      trip: _trip(),
+      report: _dryHistorical,
+      locale: const Locale('es'),
+    );
+    await _expand(tester, title: 'Qué ponerte y qué llevar');
+
+    expect(
+        find.descendant(
+            of: find.byType(WearRecsList),
+            matching:
+                find.textContaining('el tiempo habitual en estas fechas')),
         findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- Fix a zero-vs-missing bug in the Open-Meteo fetch: a request whose end date sits one day past the 16-day forecast horizon gets that day back with **null temps**, which decoded into `[]float64` as a silent `0.0` — a phantom 0°C low that fired "freezing nights, warm layers", dragged the section header to "0° – 30°", raised a spurious Trip-health "very cold" finding, and could print 0–0°C in the travel packet. `fetchDaily` now parses metrics as pointer slices and drops any day missing either temp (both forecast and archive branches); a null precip probability stays `nil` instead of shipping a false "0%".
- Consolidate the "What to wear & pack" rows: consecutive legs whose **displayed** guidance is identical (band + surviving advisory phrases) and whose dates are adjacent (≤1 day) fold into one row — "Prague, Kraków, Berlin · Aug 24 – Sep 4 · 15° – 27°". The suppression rules moved from the widget into `clothing_recs.dart` (`effectiveAdvisories`) so the grouping fold compares exactly what renders; ≥2-day gaps (home between legs) and different guidance keep separate rows; revisit labels dedupe.
- Replace the repeated per-row italic "typical for these dates" tail with **one** trailing footnote shown when any displayed leg is beyond the forecast horizon (new l10n key `wearHistoricalFootnote`, en + es; forecast-vs-typical kind no longer splits rows).
- Per-leg weather queries, the collapsed summary contract, checklist behavior, and the CollapsibleSection chrome are unchanged; `specs/what-to-wear/spec.md` amended to the new contract.

## Testing
- Go: 5 new tests in `weather_handler_test.go` (null tail day dropped, null precip keeps the day with nil probability, short arrays dropped, all-null → 200 with `"days":[]`, archive-branch null) — full `go test ./...` green.
- Flutter: `flutter analyze` clean (3 pre-existing infos in `route_response.dart`); full `flutter test` 825/825 green, including 14 new unit tests (`effectiveAdvisories` suppression matrix; `groupWearRegions` fold/band-split/rain-split/suppressed-flag-merge/gap-boundary/kind-OR/label-dedupe/summary-agreement) and the reworked wear-section widget tests (grouped row + merged envelope, footnote exactly once and absent when all-forecast, kind doesn't block merging, Spanish footnote, per-visit weather calls preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)