### PR TITLE
fix(flutter): nav buttons always land on the page they name

### DIFF
--- a/src/packages/flutter-app/lib/navigation/app_nav.dart
+++ b/src/packages/flutter-app/lib/navigation/app_nav.dart
@@ -1,6 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../screens/trip_detail_screen.dart';
+import 'app_routes.dart';
+
 /// Top-level destinations. Keeping it to three keeps the choice trivial
 /// (Hick's Law) and puts the chat and saved trips one tap away instead of
 /// buried in a menu.
@@ -41,16 +44,54 @@ void pushOnActiveTab(WidgetRef ref, Widget page, {String? location}) {
       : locatedRoute(page, location));
 }
 
-/// Return to the Home tab — the logo-tap action. Mirrors the shell's
-/// tab-select behavior: already on Home pops its stack to the root, otherwise
-/// the tab switches (keeping the other tab's stack intact for its next visit).
-void goHome(WidgetRef ref) {
-  if (ref.read(navIndexProvider) == AppTab.home.index) {
-    final keys = ref.read(tabNavKeysProvider);
-    keys[AppTab.home.index].currentState?.popUntil((r) => r.isFirst);
-  } else {
-    ref.read(navIndexProvider.notifier).state = AppTab.home.index;
+/// Select a top-level tab the way a nav button does: the destination tab's
+/// stack is reset to its root — nav buttons always go to the page they name,
+/// whether it's a switch or a re-tap of the active tab. Programmatic
+/// switch+push flows (Home trip cards, boot restore, shared-trip join) write
+/// [navIndexProvider] directly instead, so their pushes survive.
+void selectTab(WidgetRef ref, int index) {
+  // Pop before switching: TabUrlObserver didPop bookkeeping (url_sync.dart)
+  // drains while the old tab is still current, so the only URL report is the
+  // destination tab's root.
+  ref.read(tabNavKeysProvider)[index].currentState?.popUntil((r) => r.isFirst);
+  if (ref.read(navIndexProvider) != index) {
+    ref.read(navIndexProvider.notifier).state = index;
   }
+}
+
+/// Return to the Home tab — the logo-tap action.
+void goHome(WidgetRef ref) => selectTab(ref, AppTab.home.index);
+
+/// Push a route onto [tab]'s navigator, retrying across frames while the
+/// nested navigator mounts (cold boot, shell remount after a root reset). If
+/// every attempt misses, the user still lands on the selected tab's root.
+/// Takes the keys — not a ref — so callers whose element is about to be
+/// disposed (shared-trip join) capture them up front, and the Ref-holding
+/// UrlSyncController can share it.
+void pushOnTabWhenReady(List<GlobalKey<NavigatorState>> navKeys, AppTab tab,
+    Route<dynamic> Function() buildRoute,
+    [int attempts = 10]) {
+  final nav = navKeys[tab.index].currentState;
+  if (nav != null) {
+    nav.push(buildRoute());
+  } else if (attempts > 0) {
+    WidgetsBinding.instance.addPostFrameCallback(
+        (_) => pushOnTabWhenReady(navKeys, tab, buildRoute, attempts - 1));
+  }
+}
+
+/// Open [tripId]'s detail on the Trips tab: the Trips nav item highlights and
+/// back lands on the trips list. Pops the Trips stack to root inside the
+/// (possibly retried) push action — not eagerly — so a previously-open detail
+/// doesn't sit underneath, and the reset happens next to the push that lands.
+void openTripOnTripsTab(WidgetRef ref, String tripId) {
+  ref.read(navIndexProvider.notifier).state = AppTab.trips.index;
+  final navKeys = ref.read(tabNavKeysProvider);
+  pushOnTabWhenReady(navKeys, AppTab.trips, () {
+    navKeys[AppTab.trips.index].currentState?.popUntil((r) => r.isFirst);
+    return locatedRoute(
+        TripDetailScreen(tripId: tripId), tripDetailLocation(tripId));
+  });
 }
 
 /// One nav destination's icons. Shared so the shell's rail and bar render the

--- a/src/packages/flutter-app/lib/navigation/url_sync.dart
+++ b/src/packages/flutter-app/lib/navigation/url_sync.dart
@@ -204,13 +204,15 @@ class UrlSyncController {
     final tripId = target.tripId;
     final utility = target.utility;
     final chatId = target.chatId;
+    final navKeys = _ref.read(tabNavKeysProvider);
     if (tripId != null) {
-      _pushOnTabWhenReady(
+      pushOnTabWhenReady(
+          navKeys,
           target.tab,
           () => locatedRoute(
               TripDetailScreen(tripId: tripId), tripDetailLocation(tripId)));
     } else if (utility != null) {
-      _pushOnTabWhenReady(target.tab,
+      pushOnTabWhenReady(navKeys, target.tab,
           () => locatedRoute(_utilityScreen(utility), utilityLocation(utility)));
     } else if (chatId != null) {
       // Fire-and-forget: success rehydrates planProvider (the Plan tab —
@@ -222,21 +224,6 @@ class UrlSyncController {
         plan: _ref.read(planProvider.notifier),
         chatId: chatId,
       );
-    }
-  }
-
-  /// The shell (and the tab's nested navigator) mounts over the next frames;
-  /// retry rather than betting on one frame (the shared-trip join-landing
-  /// pattern). If every attempt misses, the user still lands on the right
-  /// tab and the URL self-corrects to the tab root.
-  void _pushOnTabWhenReady(AppTab tab, Route<dynamic> Function() buildRoute,
-      [int attempts = 10]) {
-    final nav = _ref.read(tabNavKeysProvider)[tab.index].currentState;
-    if (nav != null) {
-      nav.push(buildRoute());
-    } else if (attempts > 0) {
-      WidgetsBinding.instance.addPostFrameCallback(
-          (_) => _pushOnTabWhenReady(tab, buildRoute, attempts - 1));
     }
   }
 

--- a/src/packages/flutter-app/lib/screens/app_shell.dart
+++ b/src/packages/flutter-app/lib/screens/app_shell.dart
@@ -12,8 +12,11 @@ import 'trips_list_screen.dart';
 
 /// Persistent navigation shell. The rail (wide) / bar (narrow) lives here,
 /// outside the per-tab navigators, so it never moves when a page is pushed —
-/// only the content area animates. Each tab keeps its own push stack, so a trip
-/// opened in one tab stays put when you switch away and back.
+/// only the content area animates. Each tab has its own push stack, but a nav
+/// button always lands on the page it names: selecting a tab resets that tab's
+/// stack to its root ([selectTab]). Background stacks survive only for
+/// programmatic switch+push flows (Home trip cards, boot restore, shared-trip
+/// join), which write [navIndexProvider] directly.
 ///
 /// [navDestinations] carries the icons and ordering; its labels are display
 /// copy, so the shell renders the localized label for each tab instead
@@ -36,14 +39,7 @@ class AppShell extends ConsumerWidget {
     final urlSync = ref.watch(urlSyncProvider);
     final isWide = MediaQuery.sizeOf(context).width >= kRailBreakpoint;
 
-    void onSelect(int i) {
-      if (i == ref.read(navIndexProvider)) {
-        // Tapping the active tab again returns it to its root.
-        navKeys[i].currentState?.popUntil((r) => r.isFirst);
-      } else {
-        ref.read(navIndexProvider.notifier).state = i;
-      }
-    }
+    void onSelect(int i) => selectTab(ref, i);
 
     // The root navigator only holds the shell, so forward a system/browser back
     // to the active tab's navigator — otherwise nested pushes (trip detail, etc.)

--- a/src/packages/flutter-app/lib/screens/home_screen.dart
+++ b/src/packages/flutter-app/lib/screens/home_screen.dart
@@ -26,7 +26,6 @@ import '../widgets/page_container.dart';
 import '../widgets/section_header.dart';
 import 'guides_screen.dart';
 import 'local_guide_detail_screen.dart';
-import 'trip_detail_screen.dart';
 
 /// Which time-of-day greeting the home header shows. The variant is chosen
 /// without a BuildContext (and unit-tested that way); [greetingText] maps it to
@@ -198,12 +197,9 @@ class HomeScreen extends ConsumerWidget {
                 if (liveTrip != null) ...[
                   LiveTripCard(
                     trip: liveTrip,
-                    onTap: () => Navigator.of(context).push(
-                      locatedRoute(
-                        TripDetailScreen(tripId: liveTrip.id),
-                        tripDetailLocation(liveTrip.id),
-                      ),
-                    ),
+                    // On the Trips tab (not pushed over Home): the Trips nav
+                    // item highlights and back lands on the trips list.
+                    onTap: () => openTripOnTripsTab(ref, liveTrip.id),
                   ),
                   const SizedBox(height: AppSpacing.lg),
                 ],
@@ -220,12 +216,8 @@ class HomeScreen extends ConsumerWidget {
                           title: recentTrip.title,
                           dateRange: recentTrip.dateRange,
                           status: recentTrip.status,
-                          onTap: () => Navigator.of(context).push(
-                            locatedRoute(
-                              TripDetailScreen(tripId: recentTrip.tripId),
-                              tripDetailLocation(recentTrip.tripId),
-                            ),
-                          ),
+                          onTap: () =>
+                              openTripOnTripsTab(ref, recentTrip.tripId),
                         )
                       : null,
                 ),

--- a/src/packages/flutter-app/lib/screens/shared_trip_screen.dart
+++ b/src/packages/flutter-app/lib/screens/shared_trip_screen.dart
@@ -165,25 +165,20 @@ class _SharedTripBodyState extends ConsumerState<_SharedTripBody> {
       ref.invalidate(sharedWithMeProvider);
       ref.read(navIndexProvider.notifier).state = AppTab.trips.index;
       // Read before navigating: pushNamedAndRemoveUntil disposes this state,
-      // so the callbacks below must not touch ref.
+      // so the callback below must not touch ref.
       final navKeys = ref.read(tabNavKeysProvider);
       Navigator.of(context).pushNamedAndRemoveUntil('/', (route) => false);
       // The shell (and the Trips tab's nested navigator) remounts over the
-      // next frames; retry until it's attached rather than betting on one
-      // frame and silently dropping the push. If every attempt misses, the
-      // user still lands on the Trips tab where the joined trip now shows.
-      void openOnTripsTab([int attempts = 10]) {
-        final nav = navKeys[AppTab.trips.index].currentState;
-        if (nav != null) {
-          nav.push(locatedRoute(
-              TripDetailScreen(tripId: tripId), tripDetailLocation(tripId)));
-        } else if (attempts > 0) {
-          WidgetsBinding.instance
-              .addPostFrameCallback((_) => openOnTripsTab(attempts - 1));
-        }
-      }
-
-      WidgetsBinding.instance.addPostFrameCallback((_) => openOnTripsTab());
+      // next frames; pushOnTabWhenReady retries until it's attached rather
+      // than betting on one frame and silently dropping the push. Deferred a
+      // frame so the push can't land on a navigator the reset just discarded.
+      // If every attempt misses, the user still lands on the Trips tab where
+      // the joined trip now shows.
+      WidgetsBinding.instance.addPostFrameCallback((_) => pushOnTabWhenReady(
+          navKeys,
+          AppTab.trips,
+          () => locatedRoute(
+              TripDetailScreen(tripId: tripId), tripDetailLocation(tripId))));
     } catch (e) {
       if (mounted) {
         showSnack(context, l10n.sharedJoinError(friendlyError(l10n, e)));

--- a/src/packages/flutter-app/test/home_open_trip_on_trips_tab_test.dart
+++ b/src/packages/flutter-app/test/home_open_trip_on_trips_tab_test.dart
@@ -1,0 +1,139 @@
+import 'dart:convert';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:travel_route_planner/main.dart';
+import 'package:travel_route_planner/models/trip.dart';
+import 'package:travel_route_planner/navigation/app_nav.dart';
+import 'package:travel_route_planner/navigation/url_sync.dart';
+import 'package:travel_route_planner/providers/auth_provider.dart';
+import 'package:travel_route_planner/providers/live_trip_provider.dart';
+import 'package:travel_route_planner/providers/resumable_chats_provider.dart';
+import 'package:travel_route_planner/providers/trips_provider.dart';
+import 'package:travel_route_planner/screens/trip_detail_screen.dart';
+import 'package:travel_route_planner/widgets/live_trip_card.dart';
+
+import 'support/url_sync_fakes.dart';
+
+/// Home's trip cards (LiveTripCard + the "Continue where you left off"
+/// recent-trip tile) open the detail on the TRIPS tab via openTripOnTripsTab
+/// — the Trips nav item highlights and back lands on the trips list — instead
+/// of stacking the detail over Home where the Home button would re-reveal it.
+void main() {
+  late List<String> reports;
+
+  String iso(DateTime d) => '${d.year.toString().padLeft(4, '0')}-'
+      '${d.month.toString().padLeft(2, '0')}-'
+      '${d.day.toString().padLeft(2, '0')}';
+
+  Trip liveTrip(String id) => Trip(
+        id: id,
+        title: 'Athens Trip',
+        status: 'planned',
+        startDate: iso(DateTime.now().subtract(const Duration(days: 1))),
+        endDate: iso(DateTime.now().add(const Duration(days: 1))),
+        createdAt: '2026-06-01',
+        updatedAt: '2026-06-01',
+      );
+
+  /// Seeds the persisted recent-trip snapshot the way the detail screen
+  /// records it (recent_trip_provider storage format, keyed by user).
+  void seedRecentTrip(String tripId, String title) {
+    SharedPreferences.setMockInitialValues({
+      'recent_trip.user-1': jsonEncode({
+        'id': tripId,
+        'title': title,
+        'status': 'planned',
+      }),
+    });
+  }
+
+  Future<ProviderContainer> pumpApp(WidgetTester tester,
+      {Trip? live}) async {
+    tester.binding.platformDispatcher.defaultRouteNameTestValue = '/';
+    reports = <String>[];
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          authProvider.overrideWith((ref) => FakeAuthNotifier(fakeUser())),
+          tripsApiServiceProvider
+              .overrideWithValue(FakeTripsApiService(fakeTrip('t1'))),
+          liveTripProvider.overrideWithValue(live),
+          resumableChatsProvider.overrideWith((ref) async => const []),
+          urlReporterProvider.overrideWithValue(reports.add),
+        ],
+        child: const TravelRoutePlannerApp(),
+      ),
+    );
+    await tester.pumpAndSettle();
+    return ProviderScope.containerOf(
+        tester.element(find.byType(TravelRoutePlannerApp)));
+  }
+
+  setUp(() => SharedPreferences.setMockInitialValues({}));
+
+  testWidgets('live trip card opens the detail on the Trips tab',
+      (tester) async {
+    final container = await pumpApp(tester, live: liveTrip('t3'));
+
+    await tester.tap(find.byType(LiveTripCard));
+    await tester.pumpAndSettle();
+
+    expect(container.read(navIndexProvider), AppTab.trips.index);
+    expect(find.byType(TripDetailScreen), findsOneWidget);
+    expect(reports.last, '/trips/t3');
+
+    // Back lands on the trips LIST, not Home.
+    await tester.pageBack();
+    await tester.pumpAndSettle();
+    expect(find.byType(TripDetailScreen), findsNothing);
+    expect(find.text('Lisbon long weekend'), findsOneWidget);
+    expect(reports.last, '/trips');
+  });
+
+  testWidgets('recent trip card opens the detail on the Trips tab',
+      (tester) async {
+    seedRecentTrip('t2', 'Lisbon Trip');
+    final container = await pumpApp(tester);
+
+    await tester.tap(find.text('Lisbon Trip'));
+    await tester.pumpAndSettle();
+
+    expect(container.read(navIndexProvider), AppTab.trips.index);
+    expect(find.byType(TripDetailScreen), findsOneWidget);
+    expect(reports.last, '/trips/t2');
+
+    await tester.pageBack();
+    await tester.pumpAndSettle();
+    expect(find.byType(TripDetailScreen), findsNothing);
+    expect(reports.last, '/trips');
+  });
+
+  testWidgets('a detail already on the Trips stack is replaced, not stacked',
+      (tester) async {
+    // Pins openTripOnTripsTab's pre-push popUntil: back must land on the
+    // trips list, never on a previously-open detail left underneath.
+    final container = await pumpApp(tester, live: liveTrip('t3'));
+
+    container.read(navIndexProvider.notifier).state = AppTab.trips.index;
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Lisbon long weekend'));
+    await tester.pumpAndSettle();
+    expect(reports.last, '/trips/t1');
+
+    container.read(navIndexProvider.notifier).state = AppTab.home.index;
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byType(LiveTripCard));
+    await tester.pumpAndSettle();
+    expect(reports.last, '/trips/t3');
+
+    await tester.pageBack();
+    await tester.pumpAndSettle();
+    expect(find.byType(TripDetailScreen), findsNothing);
+    expect(find.text('Lisbon long weekend'), findsOneWidget);
+    expect(reports.last, '/trips');
+  });
+}

--- a/src/packages/flutter-app/test/logo_home_nav_test.dart
+++ b/src/packages/flutter-app/test/logo_home_nav_test.dart
@@ -6,9 +6,9 @@ import 'package:travel_route_planner/navigation/app_nav.dart';
 import 'package:travel_route_planner/widgets/brand_logo.dart';
 
 /// Logo-links-home: the brand badge is tappable when given onTap (rail brand
-/// and Home app bar), and goHome mirrors the shell's tab-select behavior —
-/// switch to Home from another tab, pop Home's stack to root when already
-/// there.
+/// and Home app bar), and goHome mirrors the shell's tab-select behavior
+/// (selectTab): land on the Home ROOT — the Home stack is popped to its root
+/// whether the tap switches tabs or Home is already active.
 void main() {
   testWidgets('BrandBadge with onTap fires the callback',
       (WidgetTester tester) async {
@@ -95,6 +95,47 @@ void main() {
         .push(MaterialPageRoute(builder: (_) => const Text('pushed page')));
     await tester.pumpAndSettle();
     expect(find.text('pushed page'), findsOneWidget);
+
+    goHome(capturedRef);
+    await tester.pumpAndSettle();
+
+    expect(find.text('pushed page'), findsNothing);
+    expect(find.text('home root'), findsOneWidget);
+    expect(container.read(navIndexProvider), AppTab.home.index);
+  });
+
+  testWidgets(
+      'goHome from another tab also pops the Home stack to its root',
+      (WidgetTester tester) async {
+    // Mutation pin for the selectTab reset: the old goHome only flipped the
+    // index when coming from another tab, leaving a page stacked on Home to
+    // greet the user. Nav buttons must land on the page they name.
+    late WidgetRef capturedRef;
+    await tester.pumpWidget(
+      ProviderScope(
+        child: Consumer(builder: (context, ref, _) {
+          capturedRef = ref;
+          final keys = ref.watch(tabNavKeysProvider);
+          return MaterialApp(
+            home: Navigator(
+              key: keys[AppTab.home.index],
+              onGenerateRoute: (settings) => MaterialPageRoute(
+                builder: (_) => const Text('home root'),
+                settings: settings,
+              ),
+            ),
+          );
+        }),
+      ),
+    );
+    final container =
+        ProviderScope.containerOf(tester.element(find.byType(Consumer)));
+    container
+        .read(tabNavKeysProvider)[AppTab.home.index]
+        .currentState!
+        .push(MaterialPageRoute(builder: (_) => const Text('pushed page')));
+    await tester.pumpAndSettle();
+    container.read(navIndexProvider.notifier).state = AppTab.trips.index;
 
     goHome(capturedRef);
     await tester.pumpAndSettle();

--- a/src/packages/flutter-app/test/nav_tab_reset_test.dart
+++ b/src/packages/flutter-app/test/nav_tab_reset_test.dart
@@ -1,0 +1,90 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:travel_route_planner/main.dart';
+import 'package:travel_route_planner/navigation/url_sync.dart';
+import 'package:travel_route_planner/providers/auth_provider.dart';
+import 'package:travel_route_planner/providers/live_trip_provider.dart';
+import 'package:travel_route_planner/providers/resumable_chats_provider.dart';
+import 'package:travel_route_planner/providers/trips_provider.dart';
+import 'package:travel_route_planner/screens/trip_detail_screen.dart';
+
+import 'support/url_sync_fakes.dart';
+
+/// Nav buttons always land on the page they name (selectTab): selecting a tab
+/// resets that tab's stack to its root, so a trip detail left open on the
+/// Trips tab can never greet the user on the next Trips tap. The default
+/// 800x600 test surface is at kRailBreakpoint, so the NavigationRail renders
+/// and taps go through the real nav-button path.
+void main() {
+  late List<String> reports;
+
+  Finder railDestination(String label) => find.descendant(
+      of: find.byType(NavigationRail), matching: find.text(label));
+
+  Future<void> pumpApp(WidgetTester tester) async {
+    tester.binding.platformDispatcher.defaultRouteNameTestValue = '/';
+    reports = <String>[];
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          authProvider.overrideWith((ref) => FakeAuthNotifier(fakeUser())),
+          tripsApiServiceProvider
+              .overrideWithValue(FakeTripsApiService(fakeTrip('t1'))),
+          liveTripProvider.overrideWithValue(null),
+          resumableChatsProvider.overrideWith((ref) async => const []),
+          urlReporterProvider.overrideWithValue(reports.add),
+        ],
+        child: const TravelRoutePlannerApp(),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  setUp(() => SharedPreferences.setMockInitialValues({}));
+
+  testWidgets('switching tabs via nav buttons resets the destination to root',
+      (tester) async {
+    await pumpApp(tester);
+
+    await tester.tap(railDestination('Trips'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Lisbon long weekend'));
+    await tester.pumpAndSettle();
+    expect(find.byType(TripDetailScreen), findsOneWidget);
+    expect(reports.last, '/trips/t1');
+
+    await tester.tap(railDestination('Home'));
+    await tester.pumpAndSettle();
+    expect(reports.last, '/');
+    final reportsAfterHome = reports.length;
+
+    await tester.tap(railDestination('Trips'));
+    await tester.pumpAndSettle();
+    expect(find.byType(TripDetailScreen), findsNothing);
+    expect(find.text('Lisbon long weekend'), findsOneWidget);
+    expect(reports.last, '/trips');
+    // Pop-before-switch: the detail's didPop drains while Home is still the
+    // active tab, so the stale '/trips/t1' never reaches the address bar.
+    expect(reports.sublist(reportsAfterHome), isNot(contains('/trips/t1')));
+  });
+
+  testWidgets('re-tapping the active tab still pops it to root',
+      (tester) async {
+    await pumpApp(tester);
+
+    await tester.tap(railDestination('Trips'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Lisbon long weekend'));
+    await tester.pumpAndSettle();
+    expect(find.byType(TripDetailScreen), findsOneWidget);
+
+    await tester.tap(railDestination('Trips'));
+    await tester.pumpAndSettle();
+    expect(find.byType(TripDetailScreen), findsNothing);
+    expect(find.text('Lisbon long weekend'), findsOneWidget);
+    expect(reports.last, '/trips');
+  });
+}

--- a/src/packages/flutter-app/test/url_sync_report_test.dart
+++ b/src/packages/flutter-app/test/url_sync_report_test.dart
@@ -75,8 +75,14 @@ void main() {
     expect(reports.last, '/trips');
   });
 
-  testWidgets('per-tab memory: switching away and back restores the page URL',
+  testWidgets(
+      'programmatic tab switches keep the background stack (and its URL)',
       (tester) async {
+    // Direct navIndexProvider writes are the switch+push path (Home trip
+    // cards, boot restore, shared-trip join): they must NOT reset the
+    // destination tab's stack — only nav-button selection does (selectTab).
+    // Guards against moving the reset into a navIndex listener, which would
+    // clobber those flows' pushes.
     final container = await pumpApp(tester);
     container.read(navIndexProvider.notifier).state = AppTab.trips.index;
     await tester.pumpAndSettle();


### PR DESCRIPTION
## Summary
- **Bug** (friction log): after viewing a trip detail, the Home nav button showed the trip detail again, and the Trips button opened a detail instead of the list — per-tab retained navigator stacks meant a nav tap just revealed the tab exactly as it was left.
- Nav-button selection (`selectTab` in `app_nav.dart`, used by the shell's `onSelect` and the logo's `goHome`) now pops the **destination** tab to its root **before** flipping the index — nav buttons always land on the page they name, and URL sync never emits the stale detail location.
- Home's live-trip / "Continue where you left off" cards open the detail **on the Trips tab** (`openTripOnTripsTab`): the Trips nav item highlights while viewing, back lands on the trips list, and a previously-open detail is popped rather than left stacked underneath.
- Programmatic switch+push flows are untouched — boot restore (`/trips/<id>` reload), shared-trip join, and the Home cards write `navIndexProvider` directly and bypass the reset. The duplicated retry-push loop (url_sync + shared_trip_screen) is consolidated into one shared `pushOnTabWhenReady` helper.

## Trade-offs
- Switching to a tab whose stack gets popped shows the route's ~300ms exit animation (same one the active-tab re-tap shows today); unanimated removal would need Route handles we don't keep.
- Utility pushes (Preferences/Alerts via `pushOnActiveTab`) and Plan-tab trip details are likewise discarded by a nav tap targeting their tab — consistent with the rule.

## Testing
- `flutter analyze --no-fatal-infos --fatal-warnings` (CI flags): clean (3 pre-existing info lints in `route_response.dart`, untouched).
- `flutter test`: 814/814 pass. New: `nav_tab_reset_test.dart` (nav switch resets destination + pop-before-switch URL ordering + re-tap pop preserved), `home_open_trip_on_trips_tab_test.dart` (both Home cards land on Trips tab; stacked-detail replaced pin). Updated: `logo_home_nav_test.dart` (goHome-from-another-tab mutation pin), `url_sync_report_test.dart` (per-tab-memory test re-pinned as the *programmatic-path* contract). `url_boot_restore_test.dart` green unchanged.
- Manual pass on the lane dev stack (headless Chrome, `localhost:3002`): Trips→detail→Home→Trips shows the **list**; Happening-Now card opens the detail with **Trips** highlighted at `/trips/<id>`; reload on `/trips/<id>` still restores the detail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)