### PR TITLE
fix(flutter): Trips tab keeps your place; Home still always lands home

### DIFF
--- a/src/packages/flutter-app/lib/navigation/app_nav.dart
+++ b/src/packages/flutter-app/lib/navigation/app_nav.dart
@@ -44,17 +44,31 @@ void pushOnActiveTab(WidgetRef ref, Widget page, {String? location}) {
       : locatedRoute(page, location));
 }
 
-/// Select a top-level tab the way a nav button does: the destination tab's
-/// stack is reset to its root — nav buttons always go to the page they name,
-/// whether it's a switch or a re-tap of the active tab. Programmatic
-/// switch+push flows (Home trip cards, boot restore, shared-trip join) write
-/// [navIndexProvider] directly instead, so their pushes survive.
+/// Tabs whose pushed stack survives switching away and back via a nav
+/// button: selecting the tab returns you to where you left it (e.g. the trip
+/// you were viewing); selecting it again pops to its root. Every other tab
+/// always lands on its root. Only Trips earns this: a trip is a workspace
+/// you step out of and back into, while Home and Plan are destinations.
+const Set<AppTab> _stackKeepingTabs = {AppTab.trips};
+
+/// Select a top-level tab the way a nav button does. Destinations outside
+/// [_stackKeepingTabs] are reset to their root — those nav buttons always go
+/// to the page they name — and a re-tap of the active tab pops to root
+/// everywhere. Programmatic switch+push flows (Home trip cards, boot
+/// restore, shared-trip join) write [navIndexProvider] directly instead, so
+/// their pushes survive.
 void selectTab(WidgetRef ref, int index) {
-  // Pop before switching: TabUrlObserver didPop bookkeeping (url_sync.dart)
-  // drains while the old tab is still current, so the only URL report is the
-  // destination tab's root.
-  ref.read(tabNavKeysProvider)[index].currentState?.popUntil((r) => r.isFirst);
-  if (ref.read(navIndexProvider) != index) {
+  final isActive = ref.read(navIndexProvider) == index;
+  if (isActive || !_stackKeepingTabs.contains(AppTab.values[index])) {
+    // Pop before switching: TabUrlObserver didPop bookkeeping (url_sync.dart)
+    // drains while the old tab is still current, so the only URL report is
+    // the destination tab's root.
+    ref
+        .read(tabNavKeysProvider)[index]
+        .currentState
+        ?.popUntil((r) => r.isFirst);
+  }
+  if (!isActive) {
     ref.read(navIndexProvider.notifier).state = index;
   }
 }

--- a/src/packages/flutter-app/lib/screens/app_shell.dart
+++ b/src/packages/flutter-app/lib/screens/app_shell.dart
@@ -12,11 +12,12 @@ import 'trips_list_screen.dart';
 
 /// Persistent navigation shell. The rail (wide) / bar (narrow) lives here,
 /// outside the per-tab navigators, so it never moves when a page is pushed —
-/// only the content area animates. Each tab has its own push stack, but a nav
-/// button always lands on the page it names: selecting a tab resets that tab's
-/// stack to its root ([selectTab]). Background stacks survive only for
-/// programmatic switch+push flows (Home trip cards, boot restore, shared-trip
-/// join), which write [navIndexProvider] directly.
+/// only the content area animates. Each tab has its own push stack; nav-button
+/// behavior is [selectTab]'s contract: Home (and Plan) always land on their
+/// root, while Trips keeps your place — first tap returns to the trip you
+/// were viewing, a second tap pops to the list. Programmatic switch+push
+/// flows (Home trip cards, boot restore, shared-trip join) write
+/// [navIndexProvider] directly, so their pushes survive regardless.
 ///
 /// [navDestinations] carries the icons and ordering; its labels are display
 /// copy, so the shell renders the localized label for each tab instead

--- a/src/packages/flutter-app/test/nav_tab_reset_test.dart
+++ b/src/packages/flutter-app/test/nav_tab_reset_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:travel_route_planner/main.dart';
+import 'package:travel_route_planner/navigation/app_nav.dart';
 import 'package:travel_route_planner/navigation/url_sync.dart';
 import 'package:travel_route_planner/providers/auth_provider.dart';
 import 'package:travel_route_planner/providers/live_trip_provider.dart';
@@ -13,18 +14,18 @@ import 'package:travel_route_planner/screens/trip_detail_screen.dart';
 
 import 'support/url_sync_fakes.dart';
 
-/// Nav buttons always land on the page they name (selectTab): selecting a tab
-/// resets that tab's stack to its root, so a trip detail left open on the
-/// Trips tab can never greet the user on the next Trips tap. The default
-/// 800x600 test surface is at kRailBreakpoint, so the NavigationRail renders
-/// and taps go through the real nav-button path.
+/// Nav-button contract (selectTab): Home always lands on its root, while
+/// Trips keeps your place — the first tap returns to the trip you were
+/// viewing, a second tap pops to the list. The default 800x600 test surface
+/// is at kRailBreakpoint, so the NavigationRail renders and taps go through
+/// the real nav-button path.
 void main() {
   late List<String> reports;
 
   Finder railDestination(String label) => find.descendant(
       of: find.byType(NavigationRail), matching: find.text(label));
 
-  Future<void> pumpApp(WidgetTester tester) async {
+  Future<ProviderContainer> pumpApp(WidgetTester tester) async {
     tester.binding.platformDispatcher.defaultRouteNameTestValue = '/';
     reports = <String>[];
     await tester.pumpWidget(
@@ -41,11 +42,14 @@ void main() {
       ),
     );
     await tester.pumpAndSettle();
+    return ProviderScope.containerOf(
+        tester.element(find.byType(TravelRoutePlannerApp)));
   }
 
   setUp(() => SharedPreferences.setMockInitialValues({}));
 
-  testWidgets('switching tabs via nav buttons resets the destination to root',
+  testWidgets(
+      'Trips keeps your place: first tap returns to the trip, second pops to the list',
       (tester) async {
     await pumpApp(tester);
 
@@ -59,19 +63,53 @@ void main() {
     await tester.tap(railDestination('Home'));
     await tester.pumpAndSettle();
     expect(reports.last, '/');
-    final reportsAfterHome = reports.length;
 
+    // First Trips tap restores the trip that was open (and its URL).
+    await tester.tap(railDestination('Trips'));
+    await tester.pumpAndSettle();
+    expect(find.byType(TripDetailScreen), findsOneWidget);
+    expect(reports.last, '/trips/t1');
+
+    // Second tap pops the tab to the list.
     await tester.tap(railDestination('Trips'));
     await tester.pumpAndSettle();
     expect(find.byType(TripDetailScreen), findsNothing);
     expect(find.text('Lisbon long weekend'), findsOneWidget);
     expect(reports.last, '/trips');
-    // Pop-before-switch: the detail's didPop drains while Home is still the
-    // active tab, so the stale '/trips/t1' never reaches the address bar.
-    expect(reports.sublist(reportsAfterHome), isNot(contains('/trips/t1')));
   });
 
-  testWidgets('re-tapping the active tab still pops it to root',
+  testWidgets('the Home button always lands on the Home root',
+      (tester) async {
+    // Home is not a stack-keeping tab: a page left on its stack (utility
+    // pushes via pushOnActiveTab land there) must not greet the user on the
+    // next Home tap. Pop-before-switch also keeps the stale page's URL out
+    // of the address bar.
+    final container = await pumpApp(tester);
+
+    container
+        .read(tabNavKeysProvider)[AppTab.home.index]
+        .currentState!
+        .push(locatedRoute(
+            const Scaffold(body: Text('stacked on home')), '/preferences'));
+    await tester.pumpAndSettle();
+    expect(find.text('stacked on home'), findsOneWidget);
+    expect(reports.last, '/preferences');
+
+    await tester.tap(railDestination('Trips'));
+    await tester.pumpAndSettle();
+    expect(reports.last, '/trips');
+    final reportsAfterTrips = reports.length;
+
+    await tester.tap(railDestination('Home'));
+    await tester.pumpAndSettle();
+    expect(find.text('stacked on home'), findsNothing);
+    expect(reports.last, '/');
+    // Pop-before-switch: the stacked page's didPop drains while Trips is
+    // still the active tab, so '/preferences' never reaches the address bar.
+    expect(reports.sublist(reportsAfterTrips), isNot(contains('/preferences')));
+  });
+
+  testWidgets('re-tapping the active Trips tab pops it to root',
       (tester) async {
     await pumpApp(tester);
 


### PR DESCRIPTION
## Summary
- Dogfood feedback on #331: Brian wants the Trips tab's per-tab memory back — "takes you to trip list unless you already were on a trip — then first click takes you to that trip, second click after that takes you to trip list."
- `selectTab` now consults an explicit `_stackKeepingTabs` set (`{AppTab.trips}`): selecting Trips reveals its retained stack (first tap = the trip you were viewing), re-tap pops to the list. Home and Plan keep the always-land-on-root behavior from #331 — the original bug (Home button showing a stale trip detail) stays fixed.
- Home cards still open trips on the Trips tab (#331's `openTripOnTripsTab`), which now composes nicely with the memory: view a trip from Home, tap Home, tap Trips → you're back in that trip.

## Testing
- `flutter analyze --no-fatal-infos --fatal-warnings`: clean (3 pre-existing infos in `route_response.dart`).
- `flutter test`: 837/837. `nav_tab_reset_test.dart` re-pinned to the new contract: Trips first-tap-restores/second-tap-pops; Home always resets (with the pop-before-switch URL assertion moved to the Home case); re-tap pop unchanged.
- Lane stack up on http://localhost:3001 for the owner's feel-check before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)