### PR TITLE
feat(flutter): home Continue card shows the trip's map band

### DIFF
--- a/src/packages/flutter-app/lib/providers/recent_trip_provider.dart
+++ b/src/packages/flutter-app/lib/providers/recent_trip_provider.dart
@@ -3,7 +3,9 @@ import 'dart:convert';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import '../models/trip.dart';
 import 'auth_provider.dart';
+import 'trip_cache_provider.dart';
 
 /// The trip detail screen the user last opened, remembered on-device so the
 /// home screen can offer a one-tap way back into it. Carries a snapshot of the
@@ -97,4 +99,24 @@ final recentTripProvider =
     StateNotifierProvider<RecentTripNotifier, RecentTrip?>((ref) {
   final userId = ref.watch(authProvider.select((s) => s.user?.id));
   return RecentTripNotifier(userId)..load();
+});
+
+/// Full cached detail of the recently viewed trip, feeding the home tile's
+/// map band. Cache-first and cache-ONLY: a miss (MRU eviction, fresh device)
+/// yields null and the tile renders its plain row — home never fetches, it
+/// only decorates what other screens load. The band therefore shows the trip
+/// *as of the last time this device viewed its detail* (accepted staleness:
+/// a collaborator's edit elsewhere appears on the next detail open).
+///
+/// Watches the WHOLE [recentTripProvider] state on purpose: [record] mints a
+/// fresh [RecentTrip] instance on every successful detail load, so this
+/// re-reads the just-rewritten cache after each detail view (edit → back home
+/// shows the new route). [TripCache.readTrip] drains queued writes first, so
+/// that read-after-write is safe. Watching [tripCacheProvider] (auth-keyed)
+/// re-resolves to null on sign-out.
+final recentTripDetailProvider = FutureProvider<Trip?>((ref) async {
+  final recent = ref.watch(recentTripProvider);
+  if (recent == null) return null;
+  final cached = await ref.watch(tripCacheProvider).readTrip(recent.tripId);
+  return cached?.trip;
 });

--- a/src/packages/flutter-app/lib/screens/home_screen.dart
+++ b/src/packages/flutter-app/lib/screens/home_screen.dart
@@ -2,7 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../constants/app_info.dart';
 import '../l10n/l10n.dart';
+import '../models/accommodation.dart';
 import '../models/local_guide.dart';
+import '../models/trip.dart';
 import '../providers/auth_provider.dart';
 import '../providers/live_trip_provider.dart';
 import '../providers/local_provider.dart';
@@ -15,6 +17,7 @@ import '../navigation/app_routes.dart';
 import '../theme/app_colors.dart';
 import '../theme/app_shadows.dart';
 import '../theme/spacing.dart';
+import '../utils/leg_ranges.dart';
 import '../widgets/account_menu.dart';
 import '../widgets/brand_logo.dart';
 import '../widgets/continue_chats_section.dart';
@@ -24,6 +27,8 @@ import '../widgets/live_trip_card.dart';
 import '../widgets/near_me_chip.dart';
 import '../widgets/page_container.dart';
 import '../widgets/section_header.dart';
+import '../widgets/trip_map.dart';
+import '../widgets/trip_map_destinations.dart';
 import 'guides_screen.dart';
 import 'local_guide_detail_screen.dart';
 
@@ -526,48 +531,145 @@ class _RecentTripCard extends StatelessWidget {
         child: InkWell(
           onTap: onTap,
           borderRadius: AppRadius.mdAll,
-          child: Padding(
-            padding: const EdgeInsets.all(AppSpacing.lg),
-            child: Row(
-              children: [
-                Container(
-                  padding: const EdgeInsets.all(AppSpacing.sm + 2),
-                  decoration: BoxDecoration(
-                    color: Colors.white.withValues(alpha: 0.15),
-                    shape: BoxShape.circle,
-                  ),
-                  child:
-                      const Icon(Icons.luggage, color: Colors.white, size: 26),
-                ),
-                const SizedBox(width: AppSpacing.lg),
-                Expanded(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text(
-                        title,
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
-                        style: theme.textTheme.titleMedium?.copyWith(
-                          fontWeight: FontWeight.bold,
-                          color: Colors.white,
-                        ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              const _RecentTripMapBand(),
+              Padding(
+                padding: const EdgeInsets.all(AppSpacing.lg),
+                child: Row(
+                  children: [
+                    Container(
+                      padding: const EdgeInsets.all(AppSpacing.sm + 2),
+                      decoration: BoxDecoration(
+                        color: Colors.white.withValues(alpha: 0.15),
+                        shape: BoxShape.circle,
                       ),
-                      const SizedBox(height: 2),
-                      Text(
-                        meta,
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
-                        style: theme.textTheme.bodySmall?.copyWith(
-                          color: Colors.white.withValues(alpha: 0.85),
-                        ),
+                      child: const Icon(Icons.luggage,
+                          color: Colors.white, size: 26),
+                    ),
+                    const SizedBox(width: AppSpacing.lg),
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            title,
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                            style: theme.textTheme.titleMedium?.copyWith(
+                              fontWeight: FontWeight.bold,
+                              color: Colors.white,
+                            ),
+                          ),
+                          const SizedBox(height: 2),
+                          Text(
+                            meta,
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                            style: theme.textTheme.bodySmall?.copyWith(
+                              color: Colors.white.withValues(alpha: 0.85),
+                            ),
+                          ),
+                        ],
                       ),
-                    ],
-                  ),
+                    ),
+                    const Icon(Icons.arrow_forward_ios,
+                        size: 16, color: Colors.white70),
+                  ],
                 ),
-                const Icon(Icons.arrow_forward_ios,
-                    size: 16, color: Colors.white70),
-              ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Height of the recent-trip card's map band — slightly shorter than the
+/// trip-detail phone preview (180) so the Continue section doesn't dominate
+/// the home fold.
+const double _recentTripMapHeight = 160;
+
+/// The recent-trip card's map band: the cached trip's overview map (numbered
+/// destination pins + route line, the trip-detail visual) rendered as a
+/// static preview above the title row. Collapses to nothing while the cache
+/// read resolves, on a miss (MRU eviction, fresh device), and when nothing on
+/// the trip is mappable — the card then renders exactly as it did before the
+/// band existed. The ONLY watcher of [recentTripDetailProvider], so home's
+/// narrow-select doctrine holds: cache resolution rebuilds this leaf, never
+/// the hero/greeting/guides subtree, and a suppressed card (recent == live
+/// trip) never mounts it, so no cache read happens at all.
+class _RecentTripMapBand extends ConsumerStatefulWidget {
+  const _RecentTripMapBand();
+
+  @override
+  ConsumerState<_RecentTripMapBand> createState() =>
+      _RecentTripMapBandState();
+}
+
+class _RecentTripMapBandState extends ConsumerState<_RecentTripMapBand> {
+  /// Derived-list memo, keyed the TripDerivation.matches way: identity on the
+  /// cached Trip and the localizations object (a locale switch delivers a new
+  /// instance and re-labels the pins). Stable list identities across home
+  /// rebuilds keep TripMap's identity-keyed caches valid.
+  Trip? _memoTrip;
+  AppLocalizations? _memoL10n;
+  List<TripMapDestination> _destinations = const [];
+  List<Accommodation> _stays = const [];
+  bool _mappable = false;
+
+  void _recompute(Trip trip, AppLocalizations l10n) {
+    if (identical(trip, _memoTrip) && identical(l10n, _memoL10n)) return;
+    _memoTrip = trip;
+    _memoL10n = l10n;
+    // Confirmed stays only — the same !auto rule as the trip screen: a
+    // suggested draft's dates/position are themselves derived, so it must
+    // not render as a real stay pin.
+    _stays = [
+      for (final a in trip.accommodations ?? const <Accommodation>[])
+        if (!a.auto) a
+    ];
+    _destinations = tripMapDestinations(rawLegRanges(trip), l10n);
+    // Mirrors the trip-detail derivation's mapShown gate: mount the map only
+    // when something would actually plot — TripMap's light empty-state box
+    // is the wrong surface inside this brand-gradient card.
+    _mappable = (trip.items ?? const [])
+            .any((i) => i.latitude != 0 || i.longitude != 0) ||
+        _stays.any(TripMap.stayHasCoords);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // valueOrNull keeps the previous trip through the cache re-read that
+    // follows every detail view (record() mints a fresh RecentTrip), so a
+    // resolved band never collapses and re-grows on the way back home.
+    final trip = ref.watch(recentTripDetailProvider).valueOrNull;
+    if (trip == null) return const SizedBox.shrink();
+    _recompute(trip, context.l10n);
+    if (!_mappable) return const SizedBox.shrink();
+    return ClipRRect(
+      // Tiles paint square corners; clip to the card's top radius (the
+      // bottom edge sits mid-card above the title row).
+      borderRadius:
+          const BorderRadius.vertical(top: Radius.circular(AppRadius.md)),
+      child: SizedBox(
+        height: _recentTripMapHeight,
+        child: ExcludeSemantics(
+          // Decorative band: keep pin tooltips and the (tap-dead) attribution
+          // button out of the a11y tree. AbsorbPointer swallows descendant
+          // taps but not the ancestor InkWell, so the whole card stays one
+          // tap target — the trip-detail phone preview's mechanism.
+          child: AbsorbPointer(
+            child: TripMap(
+              items: trip.items ?? const [],
+              accommodations: _stays,
+              // ≥2 destinations → overview pins + route line; fewer (single-
+              // city trips) falls back to per-item pins inside TripMap, the
+              // same as the detail screen's All view.
+              destinations: _destinations,
+              interactive: false,
             ),
           ),
         ),

--- a/src/packages/flutter-app/lib/screens/trip_detail_derivation.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_derivation.dart
@@ -41,6 +41,12 @@ import '../utils/leg_ranges.dart';
 import '../utils/trip_days.dart';
 import '../utils/trip_legs.dart';
 import '../widgets/trip_map.dart';
+import '../widgets/trip_map_destinations.dart';
+
+// [groupLabelText] moved next to the map widget (trip_map_destinations.dart)
+// so the home screen's recent-trip map band shares it; re-exported here for
+// this file's existing consumers (the trip-detail screen).
+export '../widgets/trip_map_destinations.dart' show groupLabelText;
 
 /// City-header date-chip parts, kept separate so the header can align them as
 /// columns across rows: [range] renders left-aligned after the calendar icon,
@@ -76,11 +82,6 @@ typedef GroupedBookings = ({
   List<Accommodation> residualStays,
   List<TripSegment> residualSegments,
 });
-
-/// Display text for a city-group label: the canonical [kOtherPlacesLabel] key
-/// gets a translated label, every real city keeps the name as-is.
-String groupLabelText(AppLocalizations l10n, String label) =>
-    label == kOtherPlacesLabel ? l10n.tripOtherPlaces : label;
 
 /// True for the AI's "city filler" placeholder — an item whose name is just
 /// the city it renders under (e.g. name 'Prague', city 'Prague'), emitted for
@@ -460,20 +461,9 @@ class TripDerivation {
       }
     }
 
-    // Destination pins: one per location group with a real coordinate, in
-    // visit order; ungeocoded groups are skipped so the visible numbering
-    // stays contiguous.
-    final mapDestinations = <TripMapDestination>[
-      for (final r in rawRanges)
-        if (r.coord != null)
-          TripMapDestination(
-            label: groupLabelText(l10n, r.label),
-            point: LatLng(r.coord!.lat, r.coord!.lng),
-            dates: r.start != null && r.end != null
-                ? formatShortRange(r.start!, r.end!)
-                : null,
-          ),
-    ];
+    // Destination pins: the one construction site lives with the map widget
+    // (trip_map_destinations.dart), shared with the home recent-trip band.
+    final mapDestinations = tripMapDestinations(rawRanges, l10n);
 
     final firstCoord = rawRanges.isEmpty ? null : rawRanges.first.coord;
     final lastCoord = rawRanges.isEmpty ? null : rawRanges.last.coord;

--- a/src/packages/flutter-app/lib/widgets/trip_map_destinations.dart
+++ b/src/packages/flutter-app/lib/widgets/trip_map_destinations.dart
@@ -1,0 +1,38 @@
+// Destination-pin construction for the trip-overview map, extracted verbatim
+// from TripDerivation.compute so the trip-detail derivation and the home
+// screen's recent-trip map band share ONE construction site (docs/zen.md:
+// derived state is computed in exactly one place). Lives in widgets/ because
+// it returns [TripMapDestination] and takes localizations — the utils
+// date-derivation files (leg_ranges.dart and friends) stay pure by doctrine:
+// no widget/l10n imports, they have Go twins.
+
+import 'package:latlong2/latlong.dart' show LatLng;
+
+import '../l10n/l10n.dart';
+import '../utils/date_formats.dart';
+import '../utils/leg_ranges.dart';
+import '../utils/trip_legs.dart';
+import 'trip_map.dart';
+
+/// Display text for a city-group label: the canonical [kOtherPlacesLabel] key
+/// gets a translated label, every real city keeps the name as-is.
+String groupLabelText(AppLocalizations l10n, String label) =>
+    label == kOtherPlacesLabel ? l10n.tripOtherPlaces : label;
+
+/// Destination pins for the trip-overview map: one per location group with a
+/// real coordinate, in visit order; ungeocoded groups are skipped so the
+/// visible numbering stays contiguous. Callers pass [rawLegRanges] output —
+/// map pins stay on the RAW ranges by doctrine (see leg_ranges.dart).
+List<TripMapDestination> tripMapDestinations(
+        List<LegRange> rawRanges, AppLocalizations l10n) =>
+    [
+      for (final r in rawRanges)
+        if (r.coord != null)
+          TripMapDestination(
+            label: groupLabelText(l10n, r.label),
+            point: LatLng(r.coord!.lat, r.coord!.lng),
+            dates: r.start != null && r.end != null
+                ? formatShortRange(r.start!, r.end!)
+                : null,
+          ),
+    ];

--- a/src/packages/flutter-app/test/home_recent_trip_map_test.dart
+++ b/src/packages/flutter-app/test/home_recent_trip_map_test.dart
@@ -1,0 +1,267 @@
+import 'dart:convert';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:travel_route_planner/main.dart';
+import 'package:travel_route_planner/models/chat_session.dart';
+import 'package:travel_route_planner/models/itinerary_item.dart';
+import 'package:travel_route_planner/models/trip.dart';
+import 'package:travel_route_planner/models/user.dart';
+import 'package:travel_route_planner/navigation/app_nav.dart';
+import 'package:travel_route_planner/navigation/url_sync.dart';
+import 'package:travel_route_planner/providers/auth_provider.dart';
+import 'package:travel_route_planner/providers/live_trip_provider.dart';
+import 'package:travel_route_planner/providers/resumable_chats_provider.dart';
+import 'package:travel_route_planner/providers/trips_provider.dart';
+import 'package:travel_route_planner/screens/home_screen.dart';
+import 'package:travel_route_planner/screens/trip_detail_screen.dart';
+import 'package:travel_route_planner/widgets/continue_chats_section.dart';
+import 'package:travel_route_planner/widgets/trip_map.dart';
+
+import 'support/l10n_test_app.dart';
+import 'support/url_sync_fakes.dart';
+
+/// The recent-trip card's map band (home "Continue where you left off"):
+/// renders the CACHED trip's overview map above the title row on a cache hit,
+/// and collapses back to the plain card on a miss or when nothing is
+/// mappable. Cache-only by design — home never fetches.
+///
+/// Seeding writes the raw prefs keys (recent_trip_provider storage format +
+/// TripCache's entry format) in ONE setMockInitialValues call — never
+/// `await cache.writeTrip(...)` mid-test: its deferred write queue has
+/// wedged fake-async tests before (see trip_cache.dart's deferred-writes
+/// note). Tile HTTP in widget tests 400s and is silently tolerated, so
+/// assertions are structural (TripMap presence), never imagery.
+class _FakeAuthNotifier extends StateNotifier<AuthState>
+    implements AuthNotifier {
+  _FakeAuthNotifier(UserModel? user)
+      : super(AuthState(user: user, initialized: true));
+
+  @override
+  void clearError() => state = state.copyWith(clearError: true);
+
+  @override
+  Future<bool> login(String email, String password) async => false;
+
+  @override
+  Future<bool> register(String email, String password,
+          {String? displayName}) async =>
+      false;
+
+  @override
+  Future<void> completeOnboarding() async {}
+
+  @override
+  Future<void> logout() async {}
+
+  @override
+  Future<void> signOutLocally() async {}
+
+  @override
+  void setUser(UserModel user) {}
+
+  @override
+  Future<void> adoptSession(String token, UserModel user) async {}
+}
+
+UserModel _user() => UserModel(
+      id: 'user-1',
+      email: 'test@example.com',
+      displayName: 'Brian',
+      createdAt: DateTime(2026, 1, 1),
+    );
+
+ChatSessionSummary _chat(String id, String title) => ChatSessionSummary(
+      chatId: id,
+      title: title,
+      preview: 'Thinking about a week of island hopping.',
+      messageCount: 4,
+      createdAt: '2026-07-01T10:00:00Z',
+      updatedAt: '2026-07-02T10:00:00Z',
+    );
+
+/// Two geocoded cities — enough for TripMap's destination-overview mode.
+Trip _mappableTrip(String id, String title) => Trip(
+      id: id,
+      title: title,
+      status: 'planned',
+      startDate: '2026-09-01',
+      endDate: '2026-09-06',
+      createdAt: '2026-06-01',
+      updatedAt: '2026-06-01',
+      items: [
+        ItineraryItem(
+          id: 'i0',
+          position: 0,
+          name: 'Alfama',
+          city: 'Lisbon',
+          latitude: 38.7139,
+          longitude: -9.1334,
+          category: 'attraction',
+        ),
+        ItineraryItem(
+          id: 'i1',
+          position: 1,
+          name: 'Alhambra',
+          city: 'Granada',
+          latitude: 37.1761,
+          longitude: -3.5881,
+          category: 'attraction',
+        ),
+      ],
+    );
+
+/// Same shape with the (0,0) "not geocoded" sentinel everywhere — nothing to
+/// plot, so the band must not mount.
+Trip _unmappableTrip(String id, String title) => Trip(
+      id: id,
+      title: title,
+      status: 'planned',
+      createdAt: '2026-06-01',
+      updatedAt: '2026-06-01',
+      items: [
+        ItineraryItem(
+          id: 'i0',
+          position: 0,
+          name: 'Acropolis',
+          city: 'Athens',
+          latitude: 0,
+          longitude: 0,
+          category: 'attraction',
+        ),
+      ],
+    );
+
+/// The recent-trip snapshot entry, as the detail screen records it.
+MapEntry<String, Object> _recentTripEntry(String tripId, String title) =>
+    MapEntry(
+      'recent_trip.user-1',
+      jsonEncode({'id': tripId, 'title': title, 'status': 'planned'}),
+    );
+
+/// A TripCache detail entry, as writeTrip persists it (trip_cache.dart).
+MapEntry<String, Object> _cachedTripEntry(Trip trip) => MapEntry(
+      'trip_cache.user-1.trip.${trip.id}',
+      jsonEncode({
+        'saved_at': '2026-08-01T10:00:00.000',
+        'trip': trip.toJson(),
+      }),
+    );
+
+void _seed(List<MapEntry<String, Object>> entries) =>
+    SharedPreferences.setMockInitialValues(Map.fromEntries(entries));
+
+Future<void> _pumpHome(
+  WidgetTester tester, {
+  List<ChatSessionSummary> chats = const [],
+}) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        authProvider.overrideWith((ref) => _FakeAuthNotifier(_user())),
+        liveTripProvider.overrideWithValue(null),
+        resumableChatsProvider.overrideWith((ref) async => chats),
+      ],
+      child: MaterialApp(
+          localizationsDelegates: testLocalizationsDelegates,
+          home: const HomeScreen()),
+    ),
+  );
+  // Flush the prefs read behind recentTripProvider, then the chained cache
+  // read behind recentTripDetailProvider (which only starts once the card —
+  // and with it the band — is mounted).
+  await tester.pump();
+  await tester.pump();
+  await tester.pump();
+  await tester.pump();
+}
+
+void main() {
+  setUp(() => SharedPreferences.setMockInitialValues({}));
+
+  testWidgets('cache hit renders the map band on the recent-trip card',
+      (WidgetTester tester) async {
+    final trip = _mappableTrip('t1', 'Lisbon Trip');
+    _seed([_recentTripEntry('t1', 'Lisbon Trip'), _cachedTripEntry(trip)]);
+    await _pumpHome(tester);
+
+    expect(find.byType(TripMap), findsOneWidget);
+    // The plain row survives underneath the band.
+    expect(find.text('Lisbon Trip'), findsOneWidget);
+    expect(find.byIcon(Icons.luggage), findsOneWidget);
+  });
+
+  testWidgets('cache miss keeps the plain card', (WidgetTester tester) async {
+    _seed([_recentTripEntry('t1', 'Lisbon Trip')]);
+    await _pumpHome(tester);
+
+    expect(find.byType(TripMap), findsNothing);
+    expect(find.text('Lisbon Trip'), findsOneWidget);
+  });
+
+  testWidgets('unmappable cached trip keeps the plain card',
+      (WidgetTester tester) async {
+    final trip = _unmappableTrip('t1', 'Lisbon Trip');
+    _seed([_recentTripEntry('t1', 'Lisbon Trip'), _cachedTripEntry(trip)]);
+    await _pumpHome(tester);
+
+    expect(find.byType(TripMap), findsNothing);
+    expect(find.text('Lisbon Trip'), findsOneWidget);
+  });
+
+  testWidgets('band keeps the section order: trip card above chats',
+      (WidgetTester tester) async {
+    final trip = _mappableTrip('t1', 'Lisbon Trip');
+    _seed([_recentTripEntry('t1', 'Lisbon Trip'), _cachedTripEntry(trip)]);
+    await _pumpHome(tester, chats: [_chat('c1', 'Greek islands')]);
+
+    expect(find.byType(TripMap), findsOneWidget);
+    expect(
+      tester.getTopLeft(find.text('Lisbon Trip')).dy,
+      lessThan(tester.getTopLeft(find.byType(ContinueChatCard)).dy),
+    );
+    // And the band sits above its own card's title.
+    expect(
+      tester.getTopLeft(find.byType(TripMap)).dy,
+      lessThan(tester.getTopLeft(find.text('Lisbon Trip')).dy),
+    );
+  });
+
+  testWidgets('tapping the map band opens the trip on the Trips tab',
+      (WidgetTester tester) async {
+    // Full-app pump (home_open_trip_on_trips_tab_test pattern): the band's
+    // AbsorbPointer must swallow pin/attribution taps WITHOUT breaking the
+    // ancestor InkWell — so tapping the map itself opens the trip.
+    tester.binding.platformDispatcher.defaultRouteNameTestValue = '/';
+    final trip = _mappableTrip('t2', 'Lisbon Trip');
+    _seed([_recentTripEntry('t2', 'Lisbon Trip'), _cachedTripEntry(trip)]);
+    final reports = <String>[];
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          authProvider.overrideWith((ref) => FakeAuthNotifier(fakeUser())),
+          tripsApiServiceProvider
+              .overrideWithValue(FakeTripsApiService(fakeTrip('t2'))),
+          liveTripProvider.overrideWithValue(null),
+          resumableChatsProvider.overrideWith((ref) async => const []),
+          urlReporterProvider.overrideWithValue(reports.add),
+        ],
+        child: const TravelRoutePlannerApp(),
+      ),
+    );
+    await tester.pumpAndSettle();
+    final container = ProviderScope.containerOf(
+        tester.element(find.byType(TravelRoutePlannerApp)));
+
+    expect(find.byType(TripMap), findsOneWidget);
+    await tester.tap(find.byType(TripMap), warnIfMissed: false);
+    await tester.pumpAndSettle();
+
+    expect(container.read(navIndexProvider), AppTab.trips.index);
+    expect(find.byType(TripDetailScreen), findsOneWidget);
+    expect(reports.last, '/trips/t2');
+  });
+}


### PR DESCRIPTION
## Summary
- The **"Continue where you left off" recent-trip card** now shows a **160px non-interactive map band** — satellite tiles, numbered destination pins, route line (the trip-detail visual) — above the existing title row. Tapping anywhere on the card (band included) still opens the trip on the Trips tab.
- **Cache-first, cache-only data**: new `recentTripDetailProvider` reads the full trip from `TripCache` (the recent trip was just opened in detail, so a hit is the common case). Miss / unmappable trip → the card renders exactly as before; home never fetches. Watching the whole `RecentTrip` state re-reads the cache after every detail view, so an edited trip shows its new route on return.
- **Derived-once extraction**: the destination-pin construction moved verbatim from `TripDerivation.compute` into `lib/widgets/trip_map_destinations.dart`, shared by both callers; `groupLabelText` re-exported from the derivation so `trip_detail_screen.dart` (hub file) is untouched.
- Band mechanics: `ClipRRect` to the card's top radius, `ExcludeSemantics` + `AbsorbPointer` (decorative — pin tooltips and the attribution expander are inert; the ancestor `InkWell` keeps the whole-card tap, same as the trip-detail phone preview), `mapShown`-mirror gate so TripMap's empty state never mounts inside the brand card, memoized derived lists (`identical(trip)`/`identical(l10n)`) keeping TripMap's identity-keyed caches valid.
- Single-city trips fall back to per-item pins inside TripMap (detail All-view parity); accepted staleness: the band shows the trip as of this device's last detail view.

## Testing
- `flutter analyze` — clean (3 pre-existing infos in `route_response.dart`, untouched).
- `flutter test` — full suite, 869 passed, including new `test/home_recent_trip_map_test.dart`: cache hit renders the band, miss and unmappable keep the plain card, section order holds, and tapping the map itself navigates to the trip (full-app pump).
- Browser verification on the lane stack (:3004, headless Chrome + SSO handoff): multi-city trip renders pins 1→2→3 with route + attribution; band tap navigates to `/trips/<id>`; single-city trip renders per-item pins; fresh profile shows no section; recent-trip swap refits the camera.

🤖 Generated with [Claude Code](https://claude.com/claude-code)