### PR TITLE
feat(flutter): accordion city focus on trip detail

### DIFF
--- a/docs/friction-log.md
+++ b/docs/friction-log.md
@@ -7,6 +7,30 @@ actually used > ideas that recur across ≥2 sessions**. Tag entries `[app]`
 
 ## 2026-08-12 — trip-detail dogfooding (bookings view exit)
 
+- **[app] Friction → fixed (accordion city focus, supersedes the 08-11
+  two-way rules):** the 08-11 city-focus feel didn't hold up in use —
+  expanding one city didn't close the previously focused one; collapsing a
+  non-focused group did nothing to the map while re-expanding it re-fired
+  the camera; collapsing the focused group reset to All. All three were the
+  documented "multi-expansion, focus = last expanded, non-focused collapse
+  inert" design — the incoherence was the contract, not a bug. New
+  contract, one sentence: **the open group IS the selection** — expanding a
+  header (or tapping its chip) focuses its leg and closes the previous
+  group; collapsing the open group, or tapping All, deselects both ways
+  (map to overview, list all collapsed); Add place and Today/health
+  day-links select the target leg so list and map can never disagree; a map
+  pin tap stays reveal-only (camera must not refit under the zoom-to-pin);
+  `<2` legs still never focus. Implementation follows docs/zen.md: the
+  hand-synced `_expandedCities` set (6 writers, the drift source) is GONE —
+  the open group is **derived** from the focused leg at read time via
+  `TripDerivation.groupKeyForLeg` (lenses only merge runs, so leg → group
+  is a function), with one narrow reveal-only field (`_unfocusedOpenLegKey`)
+  for pin-tap/seed/single-leg, and one writer (`_setCityFocus`) asserting
+  the two never coexist. Deriving through the group key also fixed two
+  latent lens bugs for free: the desktop chip scroll targeted a leg key the
+  header registry never held, and the Add-place reveal added leg keys to a
+  group-keyed set — both silently inert under a places lens.
+
 - **[app] Friction → fixed (Itinerary | Bookings header tabs):** clicking
   "0 of 21 booked" opened the all-bookings view — "interesting view,
   actually" — but there was no visible way back; the only exit was buried

--- a/src/packages/flutter-app/lib/screens/trip_detail_derivation.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_derivation.dart
@@ -350,6 +350,28 @@ class TripDerivation {
     return null;
   }
 
+  /// The CURRENT-filter group holding [legKey]'s items: the leg key itself
+  /// under the full itinerary, possibly a merged run's key under a places
+  /// lens, or null when the key is stale or the lens dropped every item of
+  /// the leg (nothing should render open — its items aren't in the list).
+  /// Positions-based like [legFilteredItems]: lenses only MERGE adjacent
+  /// runs, never split one, so leg → group is a function. This is the one
+  /// leg→group mapping (specs/map-city-focus accordion) — expansion is
+  /// derived through it at read time, and it clamps, so build never needs
+  /// to write focus state. Null in → null out, matching a no-focus screen.
+  String? groupKeyForLeg(String? legKey) {
+    if (legKey == null) return null;
+    final i = legIndexOf(legKey);
+    if (i == null) return null;
+    final positions = {for (final it in legs[i].items) it.position};
+    for (final group in groups) {
+      if (group.items.any((it) => positions.contains(it.position))) {
+        return group.key;
+      }
+    }
+    return null;
+  }
+
   /// Day preselect for adding a place to a focused leg: the smallest day tag
   /// among the leg's items, else the leg's raw start offset from the trip
   /// start (clamped to day 1), else null — no preselection, matching the

--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -166,10 +166,14 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
       _itemFilter == 'unbooked' || _itemFilter == 'bookings';
   // Focused leg on the map (specs/map-city-focus); null = All. Keyed by the
   // FULL-itinerary run key (leg.key, `#2`-suffixed on revisits) — never the
-  // lens-dependent group key. A ValueNotifier so a chip tap rebuilds only
-  // the map card's ListenableBuilder, never the whole screen. May hold a
-  // stale key after an edit removes the leg — readers clamp via
-  // _clampedLegKey (read-side, so build never mutates state).
+  // lens-dependent group key. A ValueNotifier so re-focusing the SAME leg
+  // (a re-tap of the selected chip) rebuilds only the map card's
+  // ListenableBuilder — the notifier drops the same-value write. A focus
+  // CHANGE also flips the derived open group, so _setCityFocus setStates
+  // the screen for the accordion; the notifier scope still spares the
+  // whole-screen rebuild on the no-op re-tap. May hold a stale key after
+  // an edit removes the leg — readers clamp via _clampedLegKey (read-side,
+  // so build never mutates state).
   final ValueNotifier<String?> _focusedLegKey = ValueNotifier<String?>(null);
   // Whether the map renders as the wide layout's pinned header (true) or the
   // phone layout's scroll-away tap-to-expand card (false). Assigned each
@@ -192,7 +196,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
   // Stable identities for the pinned headers so the Today scroller can find
   // their render objects. Days share the `'$cityKey#$day'` scheme with
   // _collapsedDays; cities are keyed by run key (group.key) like
-  // _expandedCities.
+  // _openGroupKey resolves.
   final Map<String, GlobalKey> _dayHeaderKeys = {};
   final Map<String, GlobalKey> _cityHeaderKeys = {};
   // Position of the place focused via a map pin / list tap. A ValueNotifier
@@ -207,14 +211,22 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
   // every consumer filters on !auto.
   List<Accommodation> _stays = [];
   List<TripSegment> _segments = [];
-  // City groups the user opened, keyed by run key (group.key, `#2`-suffixed
-  // on revisits): empty => all collapsed, the default view (place + dates
-  // headers only). A sole group is seeded open once (_citySeedConsumed) so a
-  // one-city trip isn't an empty screen; late-arriving groups (refine adds a
-  // city mid-session) start collapsed by absence. Days stay inverted —
-  // _collapsedDays empty => open within an expanded group, keyed
-  // "<cityKey>#<day>" since day numbers repeat across cities.
-  final Set<String> _expandedCities = {};
+  // Accordion city focus (specs/map-city-focus): at most ONE city group is
+  // open, and it is DERIVED from the focused leg at read time
+  // (_openGroupKey) — never stored as its own set (docs/zen.md: derived
+  // state is computed in exactly one place; the hand-synced set drifted).
+  // _unfocusedOpenLegKey is the narrow escape hatch — a group open in the
+  // list while the map stays on All: the pin-tap reveal (a focus write
+  // would refit the camera out from under the zoom-to-pin move), the
+  // sole-group seed (a one-city trip collapsed to a single header line is
+  // an empty screen; one-shot via _citySeedConsumed so later groups arrive
+  // collapsed), and every toggle on a <2-leg trip (focus is disabled
+  // there). FULL-itinerary leg key like _focusedLegKey and mutually
+  // exclusive with it (asserted in _setCityFocus, the one writer of both);
+  // stale keys clamp read-side in groupKeyForLeg, never write-side. Days
+  // stay inverted — _collapsedDays empty => open within the open group,
+  // keyed "<cityKey>#<day>" since day numbers repeat across cities.
+  String? _unfocusedOpenLegKey;
   final Set<String> _collapsedDays = {};
   bool _citySeedConsumed = false;
   // Trailing sections (Packing/Budget/Trip health) render as collapsed
@@ -603,13 +615,15 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
       return;
     }
     _autoScrolledToday = true;
-    // Map focus preselect: the leg holding today's items. Exact-day match
-    // only — a day with nothing tagged reads as All (the whole-trip
-    // overview), never an empty map. Single-leg trips have no focus.
+    // Selection preselect: the leg holding today's items, set before the
+    // first paint so the camera doesn't hop All → today one frame later.
+    // Exact-day match only — an untagged today leaves the default (All /
+    // collapsed) and the pending scroll's nearest-day fallback selects.
+    // On a <2-leg trip the writer routes this through the reveal-only
+    // hatch (focus is disabled there).
     final d = _derive(trip);
-    if (d.legs.length >= 2) {
-      _focusedLegKey.value = d.legKeyForDay(today);
-    }
+    final todayLeg = d.legKeyForDay(today);
+    if (todayLeg != null) _setCityFocus(d, todayLeg);
     // The scroll itself waits for the first build that actually shows the
     // scroll view: this setState still renders the loading spinner (the
     // loud path clears _loading later, in its finally), so a post-frame
@@ -625,21 +639,51 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
   /// itinerary — the Today chip and health day-links read as "show me that
   /// day". Pure view work — safe offline and with the panel open.
   void _scrollToDay(int day) {
+    final trip = _trip;
+    if (trip == null) return;
     final dayKey = _resolveDayHeaderKey(day);
     if (dayKey == null) return;
     final cityKey = dayKey.substring(0, dayKey.lastIndexOf('#'));
     final inBookingsLens = _inBookingsView;
-    if (inBookingsLens ||
-        !_expandedCities.contains(cityKey) ||
-        _collapsedDays.contains(dayKey)) {
+    final d = _derive(trip);
+    // "Show me that day" SELECTS that day's leg (accordion: its group
+    // becomes the one open group and the map focuses it) — even when the
+    // group is already open reveal-only, so the map always follows the
+    // jump. cityKey is a GROUP key from liveDayKeys; resolve the leg
+    // through an item actually tagged the landed-on day, NOT the group's
+    // first item — under a places lens a merged group spans several runs,
+    // and the first item can belong to an earlier run than the day we're
+    // jumping to (the map would then fit the wrong run). Bookings lenses
+    // keep the places set whole, so the pre-exit derivation's groups are
+    // the post-exit ones too.
+    final dayNum = int.tryParse(dayKey.substring(dayKey.lastIndexOf('#') + 1));
+    String? legKey;
+    for (final g in d.groups) {
+      if (g.key != cityKey || g.items.isEmpty) continue;
+      final anchor = g.items.firstWhere(
+        (it) => it.day == dayNum && !isCityFiller(it),
+        orElse: () => g.items.first,
+      );
+      legKey = d.legKeyOfPosition(anchor.position);
+      break;
+    }
+    // Whether the target section still has layout work to settle before
+    // the scroll can measure it (a closed group opening, a collapsed day
+    // opening, or the lens swap rebuilding the list).
+    final needsLayout = inBookingsLens ||
+        _openGroupKey(d) != cityKey ||
+        _collapsedDays.contains(dayKey);
+    if (inBookingsLens || _collapsedDays.contains(dayKey)) {
       setState(() {
         if (inBookingsLens) {
           _itemFilter = 'all';
           _bookingsLensDestination = null;
         }
-        _expandedCities.add(cityKey);
         _collapsedDays.remove(dayKey);
       });
+    }
+    if (legKey != null) _setCityFocus(d, legKey); // no-op if already selected
+    if (needsLayout) {
       // Continue once the expanded section has laid out.
       WidgetsBinding.instance
           .addPostFrameCallback((_) => _scrollToDayHeader(dayKey));
@@ -716,36 +760,91 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
     }
   }
 
-  /// THE focus write for a chip tap (inline strip and full-screen map's
-  /// report-back): focus the leg, expand its section, and on the wide layout
-  /// rest that section under the pinned map (specs/map-city-focus). Header
-  /// taps write focus themselves — the user is already at the header, so
-  /// they expand/collapse without scrolling.
+  /// The ONE open city group, derived from the selection at read time
+  /// (specs/map-city-focus accordion): the current-filter group holding the
+  /// focused leg's items, else the reveal-only open leg's — null means
+  /// everything is collapsed. Stale keys clamp inside
+  /// [TripDerivation.groupKeyForLeg], so build never writes focus state.
+  String? _openGroupKey(TripDerivation d) =>
+      d.groupKeyForLeg(_focusedLegKey.value ?? _unfocusedOpenLegKey);
+
+  /// THE writer for city focus + list expansion (specs/map-city-focus
+  /// accordion): at most one group open ⇔ the map focused on its leg;
+  /// null collapses everything and returns the map to the All overview.
   ///
-  /// Under a places lens the expanded key may match no group (a lens can
-  /// merge adjacent runs) — the set entry is inert and the MAP stays right,
-  /// because content comes from the full leg's position set. Under a
-  /// bookings lens no city headers exist at all: the chip drives the map
-  /// only and the lens is NOT exited (unlike _scrollToDay, whose whole job
-  /// is list navigation).
-  void _setFocusedLeg(TripDerivation d, String? key) {
-    if (d.legs.length < 2) return; // single-leg trips have no focus
-    // Clear the pin selection with the focus change: a lingering selection
-    // would suppress later content refits and keep a ghost highlight from
-    // another leg.
-    _selectedPosition.value = null;
-    _focusedLegKey.value = key;
-    if (key == null) return; // "All": list expansion untouched
-    final expanded = _expandedCities.add(key);
-    if (expanded) setState(() {});
-    if (_mapPinned) {
-      // Post-frame so a freshly expanded section has laid out first (the
-      // _scrollToDay pattern); on phones the chips ride the scroll-away
-      // preview card, so scrolling the list would hide the very map being
-      // focused — desktop only.
-      WidgetsBinding.instance
-          .addPostFrameCallback((_) => _scrollToCityHeader(key));
+  /// [keepCamera] opens the run in the list WITHOUT a focus write or a
+  /// selection clear — the pin-tap invariant: a focus write would refit the
+  /// camera out from under the zoom-to-pin move, and the tap just set the
+  /// selection. It can only diverge from focus on the All view (a focused
+  /// map renders its own leg's pins alone), so it no-ops when a live focus
+  /// exists.
+  void _setCityFocus(TripDerivation d, String? legKey,
+      {bool keepCamera = false}) {
+    final beforeFocus = _focusedLegKey.value;
+    final beforeOpen = _unfocusedOpenLegKey;
+    if (keepCamera && legKey != null) {
+      if (_clampedLegKey(d) != null) return; // focused: its own pins only
+      // Clear a stale focus key (clamped to All by the guard above) so the
+      // hatch is the one live truth. This write DOES notify when the old
+      // key was non-null-but-stale, but the camera is unaffected:
+      // fitSignature reads _clampedLegKey, which already resolved to null,
+      // so the null write doesn't change it — no refit over the pin move.
+      _focusedLegKey.value = null;
+      _unfocusedOpenLegKey = legKey;
+    } else if (legKey != null && d.legs.length >= 2) {
+      // Clear the pin selection with the focus change: a lingering
+      // selection would suppress later content refits and keep a ghost
+      // highlight from another leg.
+      _selectedPosition.value = null;
+      _unfocusedOpenLegKey = null;
+      // Same-value writes are dropped by the notifier: re-selecting the
+      // focused leg (or a places-lens sibling run whose group is already
+      // open) never bumps the camera.
+      _focusedLegKey.value = legKey;
+    } else {
+      // Collapse → All, and every open/close on a <2-leg trip, where focus
+      // is disabled (a fit bump would snap a user-panned camera for no
+      // visible change).
+      _selectedPosition.value = null;
+      _unfocusedOpenLegKey = legKey;
+      _focusedLegKey.value = null;
     }
+    assert(_focusedLegKey.value == null || _unfocusedOpenLegKey == null,
+        'reveal-only open must not coexist with a focused leg');
+    if (_focusedLegKey.value != beforeFocus ||
+        _unfocusedOpenLegKey != beforeOpen) {
+      setState(() {});
+    }
+  }
+
+  /// THE selection write for a chip tap (inline strip and the full-screen
+  /// map's report-back) and header expands: accordion focus via
+  /// [_setCityFocus], plus the wide layout's rest-under-the-pinned-map
+  /// scroll (specs/map-city-focus). The All chip (null) deselects
+  /// everywhere — map to the overview AND the open group closed: chips and
+  /// headers are two views of one selection. Header taps pass
+  /// [revealHeader] false — the user is already at the header.
+  ///
+  /// Under a places lens the focused leg may belong to a merged group
+  /// ([TripDerivation.groupKeyForLeg]) — that group opens and the desktop
+  /// scroll targets it — or to none (the lens dropped the leg's items): the
+  /// MAP stays right regardless, content comes from the full leg's position
+  /// set. Under a bookings lens no city headers exist at all: the chip
+  /// drives the map only and the lens is NOT exited (unlike _scrollToDay,
+  /// whose whole job is list navigation).
+  void _setFocusedLeg(TripDerivation d, String? key,
+      {bool revealHeader = true}) {
+    if (d.legs.length < 2) return; // single-leg trips have no focus
+    _setCityFocus(d, key);
+    if (key == null || !revealHeader || !_mapPinned) return;
+    final groupKey = d.groupKeyForLeg(key);
+    if (groupKey == null) return; // lens dropped the leg: nothing to rest
+    // Post-frame so the freshly expanded section has laid out first (the
+    // _scrollToDay pattern); on phones the chips ride the scroll-away
+    // preview card, so scrolling the list would hide the very map being
+    // focused — desktop only.
+    WidgetsBinding.instance
+        .addPostFrameCallback((_) => _scrollToCityHeader(groupKey));
   }
 
   /// Offset-reveal scroll resting [cityKey]'s header just below the pinned
@@ -1316,29 +1415,26 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
     );
     if (added == true) {
       await _load();
+      if (!mounted) return; // _load awaited: the screen may be gone
       _expandRunsOfNewItems(beforeIds);
     }
   }
 
   /// Groups default collapsed, so a place added into a collapsed run would
-  /// vanish with zero visible feedback — open the run(s) holding items that
-  /// weren't in the trip before the add.
+  /// vanish with zero visible feedback — select the run holding the first
+  /// item that wasn't in the trip before the add: its group becomes the one
+  /// open group and the map focuses it, so the new pin is immediately
+  /// visible (specs/map-city-focus accordion).
   void _expandRunsOfNewItems(Set<String> beforeIds) {
     final trip = _trip;
     if (trip == null) return;
-    final items = trip.items ?? const <ItineraryItem>[];
-    final fresh = {
-      for (final i in items)
-        if (!beforeIds.contains(i.id)) i.id
-    };
-    if (fresh.isEmpty) return;
-    setState(() {
-      for (final leg in _derive(trip).legs) {
-        if (leg.items.any((i) => fresh.contains(i.id))) {
-          _expandedCities.add(leg.key);
-        }
-      }
-    });
+    final d = _derive(trip);
+    for (final i in trip.items ?? const <ItineraryItem>[]) {
+      if (beforeIds.contains(i.id)) continue;
+      final legKey = d.legKeyOfPosition(i.position);
+      if (legKey != null) _setCityFocus(d, legKey);
+      return;
+    }
   }
 
   Future<void> _patch(
@@ -2129,41 +2225,40 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
 
   /// City group header: name, date range, refine + collapse controls. Pinned
   /// at the top of the scroll area while its group scrolls past; the opaque
-  /// Material keeps items from showing through while pinned.
-  Widget _cityHeader(
-      Trip trip, CityGroup group, ThemeData theme, double dateChipWidth) {
+  /// Material keeps items from showing through while pinned. [cityCollapsed]
+  /// comes from the caller's render branch — the one _openGroupKey read.
+  Widget _cityHeader(Trip trip, CityGroup group, ThemeData theme,
+      double dateChipWidth,
+      {required bool cityCollapsed}) {
     final l10n = context.l10n;
-    final cityCollapsed = !_expandedCities.contains(group.key);
     final chipStyle = _chipTextStyle(theme);
     return HoverReveal(
       builder: (context, revealed) => Material(
         color: theme.scaffoldBackgroundColor,
         child: InkWell(
           onTap: () {
-            setState(() {
-              if (cityCollapsed) {
-                _expandedCities.add(group.key);
-              } else {
-                _expandedCities.remove(group.key);
-              }
-            });
-            // Two-way focus (specs/map-city-focus): expanding a section
-            // focuses its LEG on the map (focus = last expanded); collapsing
-            // the focused section returns the map to All; collapsing any
-            // other section leaves the map alone. Resolved through the item
-            // position because under a places lens the group key may name a
-            // merged run that isn't a full-itinerary leg. No scroll here —
-            // the user is already at the header.
+            // Accordion (specs/map-city-focus): expanding a section IS
+            // selecting it — the previously open group closes and the map
+            // focuses this leg (resolved through the item position: under a
+            // places lens the group key may name a merged run that isn't a
+            // full-itinerary leg). Collapsing the open group always returns
+            // the map to All — only one group can ever be open, so there is
+            // no focused/non-focused asymmetry. No scroll here — the user
+            // is already at the header.
             final d = _derive(trip);
-            if (d.legs.length < 2 || group.items.isEmpty) return;
+            if (!cityCollapsed) {
+              _setCityFocus(d, null);
+              return;
+            }
+            if (group.items.isEmpty) return;
             final legKey = d.legKeyOfPosition(group.items.first.position);
             if (legKey == null) return;
-            if (cityCollapsed) {
-              _selectedPosition.value = null;
-              _focusedLegKey.value = legKey;
-            } else if (_focusedLegKey.value == legKey) {
-              _selectedPosition.value = null;
-              _focusedLegKey.value = null;
+            if (d.legs.length >= 2) {
+              _setFocusedLeg(d, legKey, revealHeader: false);
+            } else {
+              // Sole-group toggle: focus is disabled below two legs, so
+              // this opens through the reveal-only hatch.
+              _setCityFocus(d, legKey);
             }
           },
           child: Padding(
@@ -4556,20 +4651,17 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
                       _selectedPosition.value = pos;
                       // The highlighted row can only be seen if its run
                       // renders: groups default collapsed, so open the
-                      // tapped item's run — expansion only, never a focus
-                      // write, which would refit the camera out from under
-                      // the zoom-to-pin move. Selection itself is
-                      // notifier-driven; setState only when expansion
-                      // actually changed (the one thing the wider screen
-                      // must re-render).
-                      var expandedChanged = false;
-                      for (final leg in _derive(trip).legs) {
-                        if (leg.items.any((i) => i.position == pos)) {
-                          expandedChanged =
-                              _expandedCities.add(leg.key) || expandedChanged;
-                        }
+                      // tapped item's run — reveal-only ([keepCamera]),
+                      // never a focus write, which would refit the camera
+                      // out from under the zoom-to-pin move. The writer
+                      // setStates only when the open group actually
+                      // changed (the one thing the wider screen must
+                      // re-render — selection itself is notifier-driven).
+                      final d = _derive(trip);
+                      final legKey = d.legKeyOfPosition(pos);
+                      if (legKey != null) {
+                        _setCityFocus(d, legKey, keepCamera: true);
                       }
-                      if (expandedChanged) setState(() {});
                       _showSnack(it.name);
                     },
               onExpand: expandable ? null : () => _openFullMap(trip),
@@ -4677,8 +4769,8 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
           initialLegKey: _clampedLegKey(derivation),
           // The full-screen chip tap reports here: the embedded card's
           // ListenableBuilder keeps its own chips in sync live, and
-          // _setFocusedLeg pre-expands (and on desktop pre-scrolls) the
-          // section behind the modal, so focus survives close.
+          // _setFocusedLeg pre-selects (opens the group exclusively; on
+          // desktop pre-scrolls) behind the modal, so focus survives close.
           onLegSelected: (k) {
             final t = _trip;
             if (t != null) _setFocusedLeg(_derive(t), k);
@@ -4848,17 +4940,29 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
                       // Shared per-build chip width — see _dateChipWidth's
                       // doc for why this must stay a build-local.
                       final dateChipWidth = _dateChipWidth(groups, theme);
-                      // Groups default collapsed (empty _expandedCities); a
-                      // sole group is seeded open once — a one-city trip
+                      // Groups default collapsed (no selection); a sole
+                      // group is seeded open once — a one-city trip
                       // collapsed to a single header line is an empty screen.
                       // One-shot so later groups (refine adds a city) arrive
                       // collapsed and the seeded one stays re-collapsible.
+                      // A plain field write, NOT _setCityFocus: we're
+                      // mid-build (no setState) and the value is consumed
+                      // later this same build; guarded on a null focus so
+                      // the reveal-hatch/focus exclusivity holds (a today
+                      // preselect from the load path wins).
                       if (!_citySeedConsumed && groups.isNotEmpty) {
                         _citySeedConsumed = true;
-                        if (groups.length == 1) {
-                          _expandedCities.add(groups.first.key);
+                        if (groups.length == 1 &&
+                            groups.first.items.isNotEmpty &&
+                            _focusedLegKey.value == null) {
+                          _unfocusedOpenLegKey ??= derivation.legKeyOfPosition(
+                              groups.first.items.first.position);
                         }
                       }
+                      // The one open group this build renders expanded —
+                      // derived from the selection AFTER the seed above so
+                      // a seeded sole group opens on its first frame.
+                      final openGroupKey = _openGroupKey(derivation);
                       // Day-header GlobalKeys for the CURRENT groups' day
                       // keys, not just whatever happens to be built: a
                       // collapsed group's day headers don't exist yet, but
@@ -5067,23 +5171,15 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
                                           materialTapTargetSize:
                                               MaterialTapTargetSize
                                                   .shrinkWrap,
-                                          // Pure view work (focus +
-                                          // expand + scroll): allowed
-                                          // offline and while the refine
-                                          // panel is open. Map focus is
-                                          // exact-day (null → All); the
-                                          // scroll keeps its own
-                                          // nearest-day fallback.
-                                          onPressed: () {
-                                            if (derivation.legs.length >=
-                                                2) {
-                                              _selectedPosition.value = null;
-                                              _focusedLegKey.value =
-                                                  derivation
-                                                      .legKeyForDay(todayDay);
-                                            }
-                                            _scrollToDay(todayDay);
-                                          },
+                                          // Pure view work (select +
+                                          // scroll): allowed offline and
+                                          // while the refine panel is
+                                          // open. _scrollToDay owns the
+                                          // selection write (accordion:
+                                          // the landed-on day's leg) — no
+                                          // duplicate focus write here.
+                                          onPressed: () =>
+                                              _scrollToDay(todayDay),
                                         ),
                                         const SizedBox(width: 4),
                                       ],
@@ -5261,7 +5357,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
                                   // in. (pushPinnedChildren: false is no
                                   // fix either — the header would pin
                                   // forever and overlay the next group.)
-                                  if (!_expandedCities.contains(group.key))
+                                  if (group.key != openGroupKey)
                                     SliverToBoxAdapter(
                                         child: KeyedSubtree(
                                             // Keyed by the run, not the city:
@@ -5270,8 +5366,10 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
                                             // GlobalKey would break the build.
                                             key: _cityHeaderKeys.putIfAbsent(
                                                 group.key, GlobalKey.new),
-                                            child: _cityHeader(trip, group,
-                                                theme, dateChipWidth)))
+                                            child: _cityHeader(
+                                                trip, group, theme,
+                                                dateChipWidth,
+                                                cityCollapsed: true)))
                                   else
                                     MultiSliver(
                                       pushPinnedChildren: true,
@@ -5281,8 +5379,10 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
                                                 key: _cityHeaderKeys
                                                     .putIfAbsent(group.key,
                                                         GlobalKey.new),
-                                                child: _cityHeader(trip, group,
-                                                    theme, dateChipWidth))),
+                                                child: _cityHeader(
+                                                    trip, group, theme,
+                                                    dateChipWidth,
+                                                    cityCollapsed: false))),
                                         // Embedded bookings render only in the
                                         // unfiltered view: a category filter can
                                         // merge adjacent same-label runs, which

--- a/src/packages/flutter-app/test/trip_detail_bookings_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_bookings_test.dart
@@ -117,23 +117,27 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    // Groups default collapsed — open both cities to reach the embedded
-    // rows (the header counter and Other bookings render regardless).
-    await expandCity(tester, 'Paris');
-    await expandCity(tester, 'Rome');
+    // Groups default collapsed, and the accordion contract allows at most ONE
+    // open city at a time (expanding a city closes the previous one), so each
+    // city's embedded rows are asserted while that city is the open group.
+    // Headers, the tab counter, and Other bookings render regardless.
 
-    // City-matched bookings render once each, as compact embedded rows.
+    // Paris open: its city-matched bookings render once each, as compact
+    // embedded rows, with arrival + stay above the city's first item.
+    await expandCity(tester, 'Paris');
     expect(
         find.widgetWithText(BookingTodoRow, 'Stay in Paris'), findsOneWidget);
-    expect(find.widgetWithText(BookingTodoRow, 'Stay in Rome'), findsOneWidget);
     expect(find.widgetWithText(BookingTodoRow, 'JFK → Paris'), findsOneWidget);
-    expect(find.widgetWithText(BookingTodoRow, 'Paris → Rome'), findsOneWidget);
-    expect(find.widgetWithText(BookingTodoRow, 'Rome → JFK'), findsOneWidget);
-
-    // Arrival + stay sit above the city's first item; the return flight home
-    // comes after the last city's last item.
     expect(tester.getTopLeft(find.text('JFK → Paris')).dy,
         lessThan(tester.getTopLeft(find.text('Louvre')).dy));
+
+    // Rome open (Paris closes): 'Paris → Rome' is Rome's ARRIVAL row, so it
+    // renders inside Rome's group above Rome's first item; the return flight
+    // home comes after the last city's last item.
+    await expandCity(tester, 'Rome');
+    expect(find.widgetWithText(BookingTodoRow, 'Stay in Rome'), findsOneWidget);
+    expect(find.widgetWithText(BookingTodoRow, 'Paris → Rome'), findsOneWidget);
+    expect(find.widgetWithText(BookingTodoRow, 'Rome → JFK'), findsOneWidget);
     expect(tester.getTopLeft(find.text('Paris → Rome')).dy,
         lessThan(tester.getTopLeft(find.text('Colosseum')).dy));
     expect(tester.getTopLeft(find.text('Rome → JFK')).dy,

--- a/src/packages/flutter-app/test/trip_detail_derivation_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_derivation_test.dart
@@ -557,6 +557,37 @@ void main() {
       expect(dayless.dayForLeg('Rome'), 4);
     });
 
+    test('groupKeyForLeg: identity without a lens, merged key under one', () {
+      // No places lens → groups run the same split as legs: identity.
+      final d = _compute();
+      expect(d.groupKeyForLeg('Paris'), 'Paris');
+      expect(d.groupKeyForLeg('Rome'), 'Rome');
+      expect(d.groupKeyForLeg('Paris#2'), 'Paris#2');
+      expect(d.groupKeyForLeg('Nowhere'), isNull, reason: 'stale keys clamp');
+      expect(d.groupKeyForLeg(null), isNull);
+
+      // Bookings lenses keep the places set whole → still identity.
+      final bookings = _compute(itemFilter: 'bookings');
+      expect(bookings.groupKeyForLeg('Paris#2'), 'Paris#2');
+
+      // An attractions lens drops Rome's only item and merges the two Paris
+      // runs into ONE group keyed 'Paris': both legs map to it, and the
+      // fully-filtered-out leg maps to nothing (its items aren't in the
+      // list, so nothing should render open).
+      final merged = [
+        _item(0, 'Louvre', city: 'Paris', day: 1, lat: 48.86, lng: 2.35),
+        _item(1, 'Osteria',
+            city: 'Rome', day: 2, lat: 41.89, lng: 12.49,
+            category: 'restaurant'),
+        _item(2, 'Louvre Again', city: 'Paris', day: 3, lat: 48.86, lng: 2.35),
+      ];
+      final lensed =
+          _compute(trip: _trip(items: merged), itemFilter: 'attraction');
+      expect(lensed.groupKeyForLeg('Paris'), 'Paris');
+      expect(lensed.groupKeyForLeg('Paris#2'), 'Paris');
+      expect(lensed.groupKeyForLeg('Rome'), isNull);
+    });
+
     test('city fillers keep their group but drop their day keys', () {
       final items = [
         _item(0, 'Prague', city: 'Prague', day: 1, lat: 50.1, lng: 14.4),

--- a/src/packages/flutter-app/test/trip_detail_filler_suppression_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_filler_suppression_test.dart
@@ -118,16 +118,20 @@ void main() {
 
     await _pump(tester, trip);
 
-    // Both groups default collapsed — expand them so these asserts exercise
-    // the filler suppression, not the collapse (a collapsed Vienna hides day
-    // headers regardless).
+    // Groups default collapsed and the accordion keeps at most ONE open:
+    // expanding Vienna closes Prague. So assert each city's body content
+    // while that city is the open group, one at a time — the asserts must
+    // exercise the filler suppression, not the collapse (a collapsed Vienna
+    // hides day headers regardless).
     await expandCity(tester, 'Prague');
+    expect(find.text('Prague Castle'), findsOneWidget);
+
+    // Selecting Vienna collapses Prague (its body content hides).
     await expandCity(tester, 'Vienna');
 
     // Still exactly one 'Vienna': the header. A broken filler filter would
     // render the filler tile as a second one inside the expanded group.
     expect(find.text('Vienna'), findsOneWidget);
-    expect(find.text('Prague Castle'), findsOneWidget);
     expect(find.text('Fri, Jun 12'), findsNothing);
   });
 }

--- a/src/packages/flutter-app/test/trip_detail_grouping_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_grouping_test.dart
@@ -97,15 +97,18 @@ void main() {
     expect(chipTextIn('Green Turtle Cay', 'Jun 10 – Jun 12'), findsOneWidget);
     expect(chipTextIn('Green Turtle Cay', '· 2 nights'), findsOneWidget);
 
-    // Groups default collapsed — open both to reach their contents.
+    // Groups default collapsed and at most ONE is open at a time (accordion):
+    // expanding a city closes the previously open one. Assert each group's
+    // body while that group is the open one.
     await expandCity(tester, 'Green Turtle Cay');
-    await expandCity(tester, 'Great Guana Cay');
-
-    // Items still render under their groups.
     expect(find.text("Brendal's Dive Center"), findsOneWidget);
-    expect(find.text('Dive Guana'), findsOneWidget);
-
     // Legacy items (no day) render with no "Day N" sub-headers.
+    expect(find.textContaining('Day 1'), findsNothing);
+
+    // Opening Great Guana Cay collapses Green Turtle Cay.
+    await expandCity(tester, 'Great Guana Cay');
+    expect(find.text('Dive Guana'), findsOneWidget);
+    // Legacy rule holds in this group too.
     expect(find.textContaining('Day 1'), findsNothing);
   });
 
@@ -147,22 +150,27 @@ void main() {
     expect(find.text('Paris'), findsOneWidget);
     expect(find.text('Rome'), findsOneWidget);
 
-    // Groups default collapsed — open both to reach the day sub-headers.
+    // Groups default collapsed and at most ONE is open at a time (accordion):
+    // opening Rome would collapse Paris, so each city's day sub-headers are
+    // asserted while that city is the open group.
     await expandCity(tester, 'Paris');
-    await expandCity(tester, 'Rome');
 
     // Day sub-headers show the weekday + date derived from the trip start
     // (day N -> startDate + (N-1)). Jun 10 2026 is a Wednesday.
     expect(find.text('Wed, Jun 10'), findsOneWidget);
     expect(find.text('Thu, Jun 11'), findsOneWidget);
-    expect(find.text('Sat, Jun 13'), findsOneWidget);
 
     // Paris spans days 1–2 -> Jun 10 – Jun 11 (1 night) next to the city name.
+    // (Chip-level: renders regardless of expansion.)
     expect(chipTextIn('Paris', 'Jun 10 – Jun 11'), findsOneWidget);
     expect(chipTextIn('Paris', '· 1 night'), findsOneWidget);
 
-    // The Versailles day trip still nests under its day.
+    // The Versailles day trip still nests under its day (Paris group body).
     expect(find.text('Day trip · Versailles'), findsOneWidget);
+
+    // Opening Rome collapses Paris.
+    await expandCity(tester, 'Rome');
+    expect(find.text('Sat, Jun 13'), findsOneWidget);
     expect(find.text('Colosseum'), findsOneWidget);
   });
 }

--- a/src/packages/flutter-app/test/trip_detail_leg_focus_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_leg_focus_test.dart
@@ -14,15 +14,19 @@ import 'package:travel_route_planner/widgets/trip_map.dart';
 import 'support/city_groups.dart';
 import 'support/l10n_test_app.dart';
 
-// The two-way leg focus contract (specs/map-city-focus):
-//   * expanding a city header focuses its leg on the map; focus follows the
-//     LAST expanded section;
-//   * collapsing the focused section returns the map to All; collapsing any
-//     other section leaves the map alone;
-//   * a chip tap focuses + expands, and on the wide layout rests the city
-//     header just below the pinned chrome — phones never scroll;
-//   * a focus change clears the map pin selection;
+// The accordion city-focus contract (specs/map-city-focus, accordion rev):
+//   * the open group IS the selection: expanding a city header focuses its
+//     leg on the map and closes the previously open group — at most one
+//     group is ever open;
+//   * collapsing the open group (or tapping the All chip) deselects both
+//     ways: the map returns to All and everything is collapsed;
+//   * a chip tap selects — focuses + opens the leg's group — and on the
+//     wide layout rests the city header just below the pinned chrome;
+//     phones never scroll;
+//   * a map pin tap reveals its run in the list WITHOUT moving the camera
+//     (reveal-only), and a focus change clears the map pin selection;
 //   * bookings lenses (no city headers) get map-only chips, lens kept;
+//     places lenses resolve legs onto merged groups (groupKeyForLeg);
 //   * revisited cities focus per RUN key; single-leg trips have no focus.
 
 class _FakeTripsApiService extends TripsApiService {
@@ -31,6 +35,25 @@ class _FakeTripsApiService extends TripsApiService {
 
   @override
   Future<Trip> getTrip(String id) async => trip;
+}
+
+/// getTrip flips from [v1] to [v2] once addItineraryItem is called, so the
+/// screen's post-add `_load()` sees the new item (the Add-place flow).
+class _AddingTripsApiService extends TripsApiService {
+  final Trip v1;
+  final Trip v2;
+  bool added = false;
+  _AddingTripsApiService(this.v1, this.v2)
+      : super(ApiClient(baseUrl: 'http://test'));
+
+  @override
+  Future<Trip> getTrip(String id) async => added ? v2 : v1;
+
+  @override
+  Future<Trip> addItineraryItem(String tripId, Map<String, dynamic> body) async {
+    added = true;
+    return v2;
+  }
 }
 
 ItineraryItem _item(
@@ -106,8 +129,8 @@ void _useSurface(WidgetTester tester, Size size) {
 
 void main() {
   testWidgets(
-      'header taps drive focus: expand focuses, last expanded wins, '
-      'collapsing the focused leg restores All, others are inert',
+      'header taps drive the accordion: expanding selects and closes the '
+      'previous group, collapsing the open group restores All',
       (tester) async {
     // Tall surface: with the 364px map band pinned, expanded sections push
     // later headers below an 800px fold and header taps would miss.
@@ -120,20 +143,20 @@ void main() {
     await expandCity(tester, 'Paris');
     expect(_map(tester).fitSignature, 'Paris');
     expect(_map(tester).items.map((i) => i.name), ['Louvre', 'Orsay']);
+    expect(find.text('Louvre'), findsOneWidget);
 
-    // Expanding Rome steals the focus (focus = last expanded).
+    // Expanding Rome selects it — and closes Paris: at most one group open.
     await expandCity(tester, 'Rome');
     expect(_map(tester).fitSignature, 'Rome');
     expect(_map(tester).items, hasLength(8));
+    expect(find.text('Louvre'), findsNothing,
+        reason: 'selecting Rome must close the previously open Paris');
 
-    // Collapsing NON-focused Paris leaves the map alone.
-    await expandCity(tester, 'Paris');
-    expect(_map(tester).fitSignature, 'Rome');
-
-    // Collapsing the focused Rome returns the map to All.
+    // Collapsing the open Rome deselects: map to All, list all collapsed.
     await expandCity(tester, 'Rome');
     expect(_map(tester).fitSignature, isNull);
     expect(_map(tester).items, hasLength(11));
+    expect(find.text('Roman Forum 0'), findsNothing);
   });
 
   testWidgets(
@@ -142,14 +165,19 @@ void main() {
     _useSurface(tester, const Size(1200, 800));
     await _pump(tester, _threeCityTrip());
 
-    // Rome starts collapsed: its items aren't built.
+    // Rome starts collapsed: its items aren't built. Open Paris first so
+    // the chip tap also proves the accordion closes it.
     expect(find.text('Roman Forum 0'), findsNothing);
+    await expandCity(tester, 'Paris');
+    expect(find.text('Louvre'), findsOneWidget);
 
     await _tapChip(tester, 'Rome');
 
     expect(_map(tester).fitSignature, 'Rome');
-    // The section expanded…
+    // The section expanded — exclusively…
     expect(find.text('Roman Forum 0'), findsOneWidget);
+    expect(find.text('Louvre'), findsNothing,
+        reason: 'a chip tap closes the previously open group');
     // …and its header rests right below the pinned chrome: the 364px map
     // band (12 + 340 + 12) + the 56px itinerary tab row = 420, measured
     // from the viewport top (the app bar's bottom — the scroll math lives
@@ -163,6 +191,24 @@ void main() {
         .dy;
     expect((headerTop - (viewportTop + 420)).abs(), lessThanOrEqualTo(2),
         reason: 'Rome header should rest below map band + tab row');
+  });
+
+  testWidgets('the All chip deselects both ways: map to All, group closed',
+      (tester) async {
+    _useSurface(tester, const Size(1200, 800));
+    await _pump(tester, _threeCityTrip());
+
+    await _tapChip(tester, 'Rome');
+    expect(_map(tester).fitSignature, 'Rome');
+    expect(find.text('Roman Forum 0'), findsOneWidget);
+
+    // All = nothing selected: chips and headers are two views of ONE
+    // selection, so the open group closes with the map reset.
+    await _tapChip(tester, 'All');
+    expect(_map(tester).fitSignature, isNull);
+    expect(_map(tester).items, hasLength(11));
+    expect(find.text('Roman Forum 0'), findsNothing,
+        reason: 'the All chip closes the open group');
   });
 
   testWidgets('phone chip tap focuses the map without scrolling the list',
@@ -201,6 +247,52 @@ void main() {
     await _tapChip(tester, 'Paris');
     expect(_map(tester).selectedPosition, isNull);
     expect(_map(tester).fitSignature, 'Paris');
+  });
+
+  testWidgets('a pin tap reveals its run without moving the camera',
+      (tester) async {
+    _useSurface(tester, const Size(1200, 2200));
+    await _pump(tester, _threeCityTrip());
+
+    // From the All view, tap a Rome pin (invoked directly — marker hit
+    // boxes cluster-shift): its run opens so the highlighted row is
+    // reachable, but the camera must NOT refit out from under the
+    // zoom-to-pin move — fitSignature stays All.
+    _map(tester).onPinTap!(2);
+    await tester.pumpAndSettle();
+    expect(_map(tester).selectedPosition, 2);
+    expect(_map(tester).fitSignature, isNull);
+    // A sibling row, not the tapped item's name — that one also renders in
+    // the pin-tap snackbar.
+    expect(find.text('Roman Forum 1'), findsOneWidget);
+
+    // The reveal-only open group still collapses coherently: the map is
+    // already on All, so closing it changes nothing on the map.
+    await expandCity(tester, 'Rome');
+    expect(_map(tester).fitSignature, isNull);
+    expect(find.text('Roman Forum 1'), findsNothing);
+  });
+
+  testWidgets('a pin tap while a leg is focused keeps the camera and selection',
+      (tester) async {
+    _useSurface(tester, const Size(1200, 2200));
+    await _pump(tester, _threeCityTrip());
+
+    // Focus Rome, then tap a Rome pin: keepCamera must be a no-op on the
+    // focus (a focused map already renders only that leg's pins), so the
+    // camera stays on Rome AND the selection is NOT cleared — the pin-tap
+    // camera invariant.
+    await _tapChip(tester, 'Rome');
+    expect(_map(tester).fitSignature, 'Rome');
+
+    _map(tester).onPinTap!(3);
+    await tester.pumpAndSettle();
+    expect(_map(tester).fitSignature, 'Rome', reason: 'camera must not refit');
+    expect(_map(tester).selectedPosition, 3,
+        reason: 'keepCamera must not clear the selection');
+    // Rome stays the open group; Paris stays closed.
+    expect(find.text('Roman Forum 1'), findsWidgets);
+    expect(find.text('Louvre'), findsNothing);
   });
 
   testWidgets('bookings lens: a chip tap filters the map and keeps the lens',
@@ -254,6 +346,151 @@ void main() {
     expect(_map(tester).items.map((i) => i.name), ['Louvre']);
   });
 
+  testWidgets(
+      'places lens: a merged group opens for either of its legs '
+      '(groupKeyForLeg)', (tester) async {
+    _useSurface(tester, const Size(1200, 2200));
+    await _pump(
+      tester,
+      Trip(
+        id: 't1',
+        title: 'Paris twice',
+        status: 'planned',
+        createdAt: '2026-06-01',
+        updatedAt: '2026-06-01',
+        startDate: '2026-09-01',
+        endDate: '2026-09-03',
+        items: [
+          _item(0, 'Louvre', 'Paris', 48.8606, 2.3376, 1),
+          ItineraryItem(
+            id: 'i1',
+            position: 1,
+            name: 'Osteria',
+            latitude: 41.8902,
+            longitude: 12.4922,
+            category: 'restaurant',
+            day: 2,
+            city: 'Rome',
+          ),
+          _item(2, 'Marmottan', 'Paris', 48.8592, 2.2670, 3),
+        ],
+      ),
+    );
+
+    // The Attractions lens drops Rome's only item: the two Paris runs merge
+    // into ONE group keyed 'Paris', while the chips stay trip-wide (All +
+    // Paris + Rome + Paris).
+    await tester.tap(find.byIcon(Icons.filter_list));
+    await tester.pumpAndSettle();
+    await tester.tap(find.ancestor(
+        of: find.text('Attractions'),
+        matching: find.byWidgetPredicate((w) => w is CheckedPopupMenuItem)));
+    await tester.pumpAndSettle();
+
+    // Selecting the SECOND Paris run focuses its leg — and opens the one
+    // merged group both runs resolve to.
+    final parisChips = find.descendant(
+        of: find.byType(MapLegChips), matching: find.text('Paris'));
+    await tester.tap(parisChips.at(1));
+    await tester.pumpAndSettle();
+    expect(_map(tester).fitSignature, 'Paris#2');
+    expect(_map(tester).items.map((i) => i.name), ['Marmottan']);
+    expect(find.text('Louvre'), findsOneWidget,
+        reason: 'the merged Paris group holds both runs\' attractions');
+    expect(find.text('Marmottan'), findsWidgets);
+
+    // Selecting the first run refocuses the map; the same merged group
+    // simply stays open.
+    await tester.tap(parisChips.at(0));
+    await tester.pumpAndSettle();
+    expect(_map(tester).fitSignature, 'Paris');
+    expect(_map(tester).items.map((i) => i.name), ['Louvre']);
+    expect(find.text('Louvre'), findsOneWidget);
+  });
+
+  testWidgets('adding a place focuses the added city, closing the previous',
+      (tester) async {
+    _useSurface(tester, const Size(1200, 2200));
+    final v1 = _threeCityTrip();
+    // v2 inserts a fresh Rome item (consecutive with the existing Rome run,
+    // so it stays leg 'Rome'), Berlin shifted after it.
+    final v2 = Trip(
+      id: 't1',
+      title: 'Grand tour',
+      status: 'planned',
+      createdAt: '2026-06-01',
+      updatedAt: '2026-06-01',
+      startDate: '2026-09-01',
+      endDate: '2026-09-05',
+      items: [
+        _item(0, 'Louvre', 'Paris', 48.8606, 2.3376, 1),
+        _item(1, 'Orsay', 'Paris', 48.8600, 2.3266, 2),
+        for (var k = 0; k < 8; k++)
+          _item(2 + k, 'Roman Forum $k', 'Rome', 41.89 + k * 0.001, 12.49, 3),
+        // Fresh item: a unique id (NOT position-derived, which would collide
+        // with v1's Berlin id 'i10'); consecutive with Rome so it stays
+        // leg 'Rome'.
+        const ItineraryItem(
+          id: 'fresh-trevi',
+          position: 10,
+          name: 'Trevi Fountain',
+          latitude: 41.9009,
+          longitude: 12.4833,
+          category: 'attraction',
+          day: 3,
+          city: 'Rome',
+        ),
+        // Berlin keeps its v1 id ('i10') so it is NOT seen as fresh; only
+        // the position shifts.
+        const ItineraryItem(
+          id: 'i10',
+          position: 11,
+          name: 'Brandenburg Gate',
+          latitude: 52.5163,
+          longitude: 13.3777,
+          category: 'attraction',
+          day: 4,
+          city: 'Berlin',
+        ),
+      ],
+    );
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          tripsApiServiceProvider
+              .overrideWithValue(_AddingTripsApiService(v1, v2)),
+        ],
+        child: MaterialApp(
+            localizationsDelegates: testLocalizationsDelegates,
+            home: TripDetailScreen(tripId: 't1')),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // Open Paris so the add can be shown to CLOSE it (the item lands in Rome).
+    await expandCity(tester, 'Paris');
+    expect(_map(tester).fitSignature, 'Paris');
+    expect(find.text('Louvre'), findsOneWidget);
+
+    // Header "Add place" → manual entry → name → Add.
+    await tester.tap(find.text('Add place'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text("Can't find it? Add manually"));
+    await tester.pumpAndSettle();
+    await tester.enterText(
+        find.widgetWithText(TextField, 'Place name').first, 'Trevi Fountain');
+    await tester.tap(
+        find.descendant(of: find.byType(AlertDialog), matching: find.text('Add')));
+    await tester.pumpAndSettle();
+
+    // The new item's leg (Rome) is now focused and its group open; Paris,
+    // the previously open group, is closed.
+    expect(_map(tester).fitSignature, 'Rome');
+    expect(find.text('Trevi Fountain'), findsWidgets);
+    expect(find.text('Louvre'), findsNothing,
+        reason: 'the previously open Paris closes under the accordion');
+  });
+
   testWidgets('single-leg trip: no chip strip, header taps never focus',
       (tester) async {
     _useSurface(tester, const Size(1200, 800));
@@ -283,10 +520,15 @@ void main() {
 
     // The sole group seeds open; toggling it never writes focus — with one
     // leg, "All" and "the leg" are the same map, and a fit bump would snap
-    // a user-panned camera for no visible change.
+    // a user-panned camera for no visible change. The LIST still toggles
+    // through the reveal-only hatch (this is the same writer path an
+    // 'Other places'-only trip takes).
+    expect(find.text('Louvre'), findsOneWidget); // seeded open
     await expandCity(tester, 'Paris'); // collapse (seeded open)
     expect(_map(tester).fitSignature, isNull);
+    expect(find.text('Louvre'), findsNothing, reason: 'list collapsed');
     await expandCity(tester, 'Paris'); // expand again
     expect(_map(tester).fitSignature, isNull);
+    expect(find.text('Louvre'), findsOneWidget, reason: 'list reopened');
   });
 }

--- a/src/packages/flutter-app/test/trip_detail_map_expand_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_map_expand_test.dart
@@ -193,10 +193,37 @@ void main() {
     await tester.tap(find.byType(CloseButton));
     await tester.pumpAndSettle();
 
-    // Back on the trip screen, the inline chips kept the focus.
+    // Back on the trip screen, the inline chips kept the focus AND the
+    // report-back opened Rome's group exclusively behind the modal
+    // (accordion: the selection materializes in the list on close).
     expect(find.byType(TripMapScreen), findsNothing);
     final inlineChips = tester.widget<MapLegChips>(find.byType(MapLegChips));
     expect(inlineChips.selected, 'Rome');
+    expect(find.text('Colosseum'), findsOneWidget);
+    expect(find.text('Louvre'), findsNothing,
+        reason: 'Paris stays collapsed — only Rome is open');
+  });
+
+  testWidgets(
+      'wide: the full-screen All chip collapses the group behind the modal',
+      (WidgetTester tester) async {
+    await pumpScreen(tester, surface: const Size(1200, 800));
+
+    await tester.tap(inMap(find.byIcon(Icons.fullscreen)));
+    await tester.pumpAndSettle();
+    await tapChip(tester, 'Rome');
+    // All deselects both ways, even reported back from the full-screen map.
+    await tapChip(tester, 'All');
+
+    await tester.tap(find.byType(CloseButton));
+    await tester.pumpAndSettle();
+
+    final inlineChips = tester.widget<MapLegChips>(find.byType(MapLegChips));
+    expect(inlineChips.selected, isNull);
+    final inlineMap = tester.widget<TripMap>(find.byType(TripMap));
+    expect(inlineMap.fitSignature, isNull);
+    expect(find.text('Colosseum'), findsNothing,
+        reason: 'the All chip closed the open group behind the modal');
   });
 
   testWidgets(

--- a/src/packages/flutter-app/test/trip_detail_sticky_headers_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_sticky_headers_test.dart
@@ -50,8 +50,8 @@ void main() {
         _item(0, 'Louvre', 'Paris', 1),
         _item(1, 'Orsay', 'Paris', 1),
         for (var k = 0; k < 6; k++) _item(2 + k, 'Paris stop $k', 'Paris', 2),
-        // Rome needs enough content that scrolling can carry its header all
-        // the way up to the pinned slot, fully pushing Paris off.
+        // Rome needs enough content that, once it is the open group, scrolling
+        // can carry its header all the way up to the pinned slot.
         for (var k = 0; k < 4; k++) _item(8 + k, 'Rome stop $k', 'Rome', 3),
         for (var k = 0; k < 4; k++)
           _item(12 + k, 'Rome day4 stop $k', 'Rome', 4),
@@ -69,21 +69,22 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    // Groups default collapsed — open both so scrolling has content. Rome
-    // first: while everything is collapsed both headers sit in the viewport,
-    // whereas expanding Paris first would push Rome's header below the fold
-    // and the tap would miss.
-    await expandCity(tester, 'Rome');
+    // Groups default collapsed. The accordion allows at most ONE open group
+    // (specs/map-city-focus, accordion rev) — expanding a city closes any
+    // other open group — so only Paris is opened here; its items alone
+    // provide the scroll extent for the Paris pinned-header assertions.
     await expandCity(tester, 'Paris');
 
     expect(find.text('Paris'), findsOneWidget);
 
     // Scroll into the middle of Paris day 2, far enough that both the city
     // and day headers have reached their pinned slots. jumpTo keeps offsets
-    // exact (drag gestures fling unpredictably past the target).
+    // exact (drag gestures fling unpredictably past the target). Offsets
+    // retuned for the accordion: with Rome collapsed, only Paris's items
+    // contribute extent (max ~626), so 450/600 replace the old 550/700.
     final position =
         tester.state<ScrollableState>(find.byType(Scrollable).first).position;
-    position.jumpTo(550);
+    position.jumpTo(450);
     await tester.pumpAndSettle();
 
     final parisDyA = tester.getTopLeft(find.text('Paris')).dy;
@@ -92,7 +93,7 @@ void main() {
 
     // Scroll a bit further, still within Paris day 2: the pinned city and
     // day headers hold their position while the items keep moving.
-    position.jumpTo(700);
+    position.jumpTo(600);
     await tester.pumpAndSettle();
 
     expect(
@@ -104,8 +105,17 @@ void main() {
     expect(parisDyA, greaterThan(0));
     expect(day2DyA, greaterThan(parisDyA));
 
-    // Scroll to the bottom: Rome takes over the pinned city slot, pushing
-    // the Paris and Day 2 headers off.
+    // Rome's turn in the pinned slot. Under the accordion Rome's body only
+    // exists while Rome is the open group, so bring its collapsed header
+    // fully into view and expand it — which also closes Paris (its Day 2
+    // header and items unbuild; the Paris header row itself still renders).
+    position.jumpTo(position.maxScrollExtent);
+    await tester.pumpAndSettle();
+    await expandCity(tester, 'Rome');
+
+    // Scroll to the bottom: Rome's header reaches the pinned city slot —
+    // the same slot Paris pinned in (parisDyA) — with its Day 4 header
+    // pinned below it.
     position.jumpTo(position.maxScrollExtent);
     await tester.pumpAndSettle();
 
@@ -114,7 +124,8 @@ void main() {
     expect(tester.getTopLeft(find.text('Day 4')).dy, greaterThan(parisDyA));
     final parisAfter = find.text('Paris');
     if (parisAfter.evaluate().isNotEmpty) {
-      // Still built within the cache extent, but scrolled above Rome.
+      // Collapsed Paris header still built, but scrolled above Rome's
+      // pinned slot.
       expect(tester.getTopLeft(parisAfter).dy, lessThan(parisDyA));
     }
   });


### PR DESCRIPTION
## Summary

- Reworks the trip-detail map city-focus feature (from PR #333) from multi-expand "focus = last expanded" to **accordion** semantics after Brian's dogfooding surfaced three feel problems: expanding one city group didn't collapse the previously focused one; collapsing a non-focused group did nothing to the map yet re-expanding it re-fired the camera; and collapsing the focused group reset to All.
- **New contract (one sentence): the open city group IS the selection.** Expanding a header or tapping its chip focuses that leg and closes the previously open group (at most one open); collapsing the open group — or tapping the **All chip** — deselects both ways (map to overview, list all collapsed); **Add place** and **Today / trip-health day-links** select the target leg so list and map can't disagree; a **map pin tap** stays reveal-only (camera never refits under the zoom-to-pin move); `<2` legs never focus.
- **Design (docs/zen.md — derived state in one place):** deletes the hand-synced `_expandedCities` set (6 drift-prone writers, the incoherence source). The open group is now *derived* from the focused leg via the new `TripDerivation.groupKeyForLeg` (lenses only merge runs, so leg→group is a function), with one reveal-only escape field (`_unfocusedOpenLegKey`) for pin-tap / sole-group seed / single-leg toggles, and a single writer `_setCityFocus` that asserts focus and reveal never coexist.
- Deriving through the group key also fixed **two latent lens bugs**: the desktop chip scroll targeted a leg key the header registry never held (silently no-op under a places lens), and `_scrollToDay` focused a merged group's *first* run instead of the landed-on day's leg.
- Invariants preserved: build never writes focus (readers clamp); a focus change clears `_selectedPosition`; collapsed groups render as plain non-pinned headers; phones never page-scroll on focus; bookings-lens chip taps keep the lens.

## Review

An adversarial multi-agent review (state-machine / lifecycle / coverage lenses, each finding independently refuted) produced 14 confirmed findings. Addressed: the `_scrollToDay` wrong-run correctness bug, a missing `mounted` guard after `await _load()` in `_expandRunsOfNewItems`, three misleading comments, and the highest-value coverage gaps (Add-place focus flow, full-screen All-chip report-back, pin-tap-while-focused, single-leg list reopen). **Deferred (documented):** the zero-body-pinned-sliver route for an all-filler open group is pre-existing (reachable via manual expand before this change) and cosmetic-under-scroll — the existing filler-suppression test already renders that state without crashing — so it's not a regression from this PR; the render-branch rework was judged higher-risk than the LOW finding warrants.

## Testing

- `flutter analyze` — clean (only 3 pre-existing infos in `route_response.dart`, unrelated).
- `flutter test` — full suite green (**871 tests**), including the rewritten `trip_detail_leg_focus_test.dart` contract, four restructured multi-expand tests, new `groupKeyForLeg` unit cases, and the new coverage tests above.
- Manual browser pass on a 3-city trip (lane stack): expand A→B closes A and moves the map; collapse the open group → All; chip select; All chip closes the open group; pin tap from All reveals the run with the camera unmoved; adding a place to a non-focused city focuses that city and collapses the previous.

🤖 Generated with [Claude Code](https://claude.com/claude-code)