### PR TITLE
fix(flutter): align booking-row titles on one leading grid

### DIFF
--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -2404,8 +2404,10 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
             Padding(
+              // left: lines the icon up with the booking rows' kind icons,
+              // which sit at 12px (BookingTodoRow's own left padding).
               padding: const EdgeInsets.only(
-                  top: AppSpacing.sm, bottom: AppSpacing.xs),
+                  left: AppSpacing.md, top: AppSpacing.sm, bottom: AppSpacing.xs),
               child: Row(
                 children: [
                   Icon(Icons.verified, size: 16, color: AppColors.toolLocal),
@@ -2514,7 +2516,10 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
       child: Consumer(builder: (context, ref, _) {
         final async = ref.watch(eventsByCityProvider(query));
         final header = Padding(
-          padding: const EdgeInsets.only(top: AppSpacing.sm, bottom: AppSpacing.xs),
+          // left: lines the icon up with the booking rows' kind icons, which
+          // sit at 12px (BookingTodoRow's own left padding).
+          padding: const EdgeInsets.only(
+              left: AppSpacing.md, top: AppSpacing.sm, bottom: AppSpacing.xs),
           child: Row(
             children: [
               Icon(Icons.local_activity, size: 16, color: AppColors.toolEvents),

--- a/src/packages/flutter-app/lib/widgets/booking_detail_row.dart
+++ b/src/packages/flutter-app/lib/widgets/booking_detail_row.dart
@@ -7,6 +7,7 @@ import '../utils/tracked_launch.dart';
 import '../utils/trip_format.dart';
 import 'add_to_calendar_button.dart';
 import 'booking_sheets.dart';
+import 'booking_todo_card.dart' show kBookingRowLeadingSlot;
 
 /// A confirmed booking's saved details, rendered as a slim indented line
 /// under its [BookingTodoRow] in the itinerary (or standalone in detail-only
@@ -153,11 +154,12 @@ class BookingDetailRow extends StatelessWidget {
     }
     final calendar = _calendarButton(l10n);
 
-    // Indented to sit under the todo row's title column (12px padding + 18px
-    // icon + 8px gap); detail-only rows share the alignment so mixed lists
-    // stay rhythmic.
+    // Indented to sit under the todo rows' title column (12px row padding +
+    // the fixed leading slot + 8px gap); detail-only rows share the alignment
+    // so mixed lists stay rhythmic.
     return Padding(
-      padding: const EdgeInsets.only(left: 38, top: 2, bottom: 2),
+      padding: const EdgeInsets.only(
+          left: 12 + kBookingRowLeadingSlot + 8, top: 2, bottom: 2),
       child: Row(
         children: [
           Icon(

--- a/src/packages/flutter-app/lib/widgets/booking_todo_card.dart
+++ b/src/packages/flutter-app/lib/widgets/booking_todo_card.dart
@@ -51,6 +51,13 @@ String _providerOpenLabel(
       : l10n.bookingCardOpenIn(brand);
 }
 
+/// Width of the fixed leading slot in a [BookingTodoRow]: the 18px kind icon
+/// plus the 16px mode-menu caret (see [_ModeMenu]). Every row reserves the
+/// full slot — stay rows, transport rows with the mode menu, and transport
+/// rows without it — so their titles all start at the same x.
+/// BookingDetailRow derives its indent from this; change it here only.
+const double kBookingRowLeadingSlot = 34; // 18 icon + 16 caret
+
 /// A styled booking checklist card: an icon by kind, the title + dates, a
 /// "Booked" checkbox, and a button that opens the pre-filled search link.
 class BookingTodoCard extends StatelessWidget {
@@ -198,10 +205,19 @@ class BookingTodoRow extends StatelessWidget {
       padding: const EdgeInsets.only(left: 12, top: 2, bottom: 2),
       child: Row(
         children: [
-          if (todo.kind == 'transport' && onModeChanged != null)
-            _ModeMenu(todo: todo, onModeChanged: onModeChanged!)
-          else
-            Icon(_kindIcon(todo), size: 18, color: theme.colorScheme.primary),
+          // Fixed-width slot, left-aligned child: with or without the caret,
+          // every row's title starts at the same x. Align keeps the
+          // constraints loose so the menu's hit target is unchanged.
+          SizedBox(
+            width: kBookingRowLeadingSlot,
+            child: Align(
+              alignment: Alignment.centerLeft,
+              child: todo.kind == 'transport' && onModeChanged != null
+                  ? _ModeMenu(todo: todo, onModeChanged: onModeChanged!)
+                  : Icon(_kindIcon(todo),
+                      size: 18, color: theme.colorScheme.primary),
+            ),
+          ),
           const SizedBox(width: 8),
           Expanded(
             child: Column(
@@ -226,19 +242,34 @@ class BookingTodoRow extends StatelessWidget {
               ],
             ),
           ),
-          TextButton.icon(
-            onPressed: onOpen,
-            icon: const Icon(Icons.open_in_new, size: 18),
-            // Booked rows recede: the link stays usable (re-check a price,
-            // find the confirmation email's provider) but stops competing
-            // with unbooked rows for attention.
-            style: todo.booked
-                ? TextButton.styleFrom(foregroundColor: muted)
-                : null,
-            label: Text(_providerOpenLabel(
-                context.l10n, todo, openLabelOverride,
-                compact: compact)),
-          ),
+          // Compact rows drop the external-link glyph along with the long
+          // label: at the 360px overflow floor the row's fixed chrome
+          // (leading slot + button + kebab + checkbox) must leave the title
+          // a nonzero share.
+          if (compact)
+            TextButton(
+              onPressed: onOpen,
+              style: todo.booked
+                  ? TextButton.styleFrom(foregroundColor: muted)
+                  : null,
+              child: Text(_providerOpenLabel(
+                  context.l10n, todo, openLabelOverride,
+                  compact: true)),
+            )
+          else
+            TextButton.icon(
+              onPressed: onOpen,
+              icon: const Icon(Icons.open_in_new, size: 18),
+              // Booked rows recede: the link stays usable (re-check a price,
+              // find the confirmation email's provider) but stops competing
+              // with unbooked rows for attention.
+              style: todo.booked
+                  ? TextButton.styleFrom(foregroundColor: muted)
+                  : null,
+              label: Text(_providerOpenLabel(
+                  context.l10n, todo, openLabelOverride,
+                  compact: false)),
+            ),
           if (onAddDetails != null)
             PopupMenuButton<String>(
               icon: Icon(Icons.more_vert, size: 18, color: muted),

--- a/src/packages/flutter-app/test/trip_detail_booking_alignment_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_booking_alignment_test.dart
@@ -1,0 +1,186 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:travel_route_planner/models/trip.dart';
+import 'package:travel_route_planner/models/itinerary_item.dart';
+import 'package:travel_route_planner/models/accommodation.dart';
+import 'package:travel_route_planner/models/booking_todo.dart';
+import 'package:travel_route_planner/models/event.dart';
+import 'package:travel_route_planner/services/api_client.dart';
+import 'package:travel_route_planner/services/booking_todos_api_service.dart';
+import 'package:travel_route_planner/services/trips_api_service.dart';
+import 'package:travel_route_planner/providers/booking_todos_provider.dart';
+import 'package:travel_route_planner/providers/events_provider.dart';
+import 'package:travel_route_planner/providers/trips_provider.dart';
+import 'package:travel_route_planner/screens/trip_detail_screen.dart';
+import 'package:travel_route_planner/widgets/booking_detail_row.dart';
+import 'package:travel_route_planner/widgets/booking_todo_card.dart';
+
+import 'support/city_groups.dart';
+import 'support/l10n_test_app.dart';
+
+// Leading-edge alignment contract for the itinerary's booking surface: every
+// BookingTodoRow reserves the same fixed leading slot (kBookingRowLeadingSlot),
+// so titles share one x whether the row leads with the bare kind icon (stays,
+// menu-suppressed transport rows — same code branch) or with the wider
+// icon+caret mode menu. BookingDetailRow and the section headers align to the
+// same grid.
+
+class _FakeTripsApiService extends TripsApiService {
+  final Trip trip;
+  _FakeTripsApiService(this.trip) : super(ApiClient(baseUrl: 'http://test'));
+
+  @override
+  Future<Trip> getTrip(String id) async => trip;
+}
+
+/// Sync fails (mirroring the screen's swallow-on-error), so the todos seeded
+/// on the trip payload survive verbatim. A failed sync does NOT flip the
+/// screen offline — only a failed trip fetch does — so the mode menu stays
+/// live on transport rows.
+class _FakeBookingTodosApiService extends BookingTodosApiService {
+  _FakeBookingTodosApiService() : super(ApiClient(baseUrl: 'http://test'));
+
+  @override
+  Future<List<BookingTodo>> syncTodos(
+          String tripId, List<Map<String, dynamic>> derived) async =>
+      throw Exception('offline test env');
+}
+
+ItineraryItem _item(int pos, String name, String address, String city,
+        {int? day}) =>
+    ItineraryItem(
+      id: 'i$pos',
+      position: pos,
+      name: name,
+      address: address,
+      latitude: 0,
+      longitude: 0,
+      category: 'attraction',
+      day: day,
+      city: city,
+    );
+
+const _confirmedStay = Accommodation(
+  id: 'acc1',
+  name: 'Hotel Lutetia',
+  address: 'Paris',
+  provider: 'Booking.com',
+  checkIn: '2026-06-10',
+  checkOut: '2026-06-12',
+);
+
+Trip _twoCityTrip() => Trip(
+      id: 't1',
+      title: 'Europe',
+      startDate: '2026-06-10',
+      endDate: '2026-06-13',
+      createdAt: '2026-06-01',
+      updatedAt: '2026-06-01',
+      items: [
+        _item(0, 'Louvre', 'Paris, France', 'Paris', day: 1),
+        _item(1, 'Colosseum', 'Rome, Italy', 'Rome', day: 3),
+      ],
+      bookingTodos: const [
+        BookingTodo(
+            id: 'td-stay',
+            kind: 'stay',
+            todoKey: 'stay:paris',
+            title: 'Stay in Paris',
+            provider: 'airbnb'),
+        // No confirmed segment matches this leg, so it carries the mode menu.
+        BookingTodo(
+            id: 'td-leg',
+            kind: 'transport',
+            todoKey: 'transport:paris>>rome',
+            title: 'Paris → Rome'),
+      ],
+      accommodations: const [_confirmedStay],
+    );
+
+void _useTallViewport(WidgetTester tester) {
+  tester.view.physicalSize = const Size(1200, 2400);
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.reset);
+}
+
+Future<void> _pump(WidgetTester tester, Trip trip) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        tripsApiServiceProvider.overrideWithValue(_FakeTripsApiService(trip)),
+        bookingTodosApiServiceProvider
+            .overrideWithValue(_FakeBookingTodosApiService()),
+        // One event for Paris so its group renders the events header; empty
+        // for Rome (the non-Greek fallback renders nothing).
+        eventsByCityProvider.overrideWith((ref, query) async =>
+            query.city == 'Paris'
+                ? const [
+                    Event(
+                        id: 'e1',
+                        name: 'Jazz night',
+                        venue: 'Le Duc',
+                        startDate: '2026-06-10')
+                  ]
+                : const <Event>[]),
+      ],
+      child: MaterialApp(
+          localizationsDelegates: testLocalizationsDelegates,
+          home: TripDetailScreen(tripId: trip.id)),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+Finder _inRow(String title, Finder inner) => find.descendant(
+    of: find.widgetWithText(BookingTodoRow, title), matching: inner);
+
+void main() {
+  testWidgets(
+      'todo titles, detail rows, and section headers share one leading grid',
+      (tester) async {
+    _useTallViewport(tester);
+    await _pump(tester, _twoCityTrip());
+
+    double dx(Finder f) => tester.getTopLeft(f).dx;
+
+    // City groups are an accordion — only one can be open — so measure the
+    // Paris surfaces first, then swap to Rome and compare against the
+    // captured x (same gutter both times).
+    await expandCity(tester, 'Paris');
+
+    // The stay row leads with the bare kind icon (the same branch
+    // menu-suppressed transport rows take, so it stands in for both).
+    expect(_inRow('Stay in Paris', find.byIcon(Icons.arrow_drop_down)),
+        findsNothing);
+    final stayTitleDx = dx(find.text('Stay in Paris'));
+
+    // The matched confirmed stay's detail row: its icon sits under the todo
+    // titles.
+    expect(
+        dx(find.descendant(
+            of: find.widgetWithText(BookingDetailRow, 'Hotel Lutetia'),
+            matching: find.byIcon(Icons.hotel_outlined))),
+        moreOrLessEquals(stayTitleDx, epsilon: 0.1));
+
+    // The events header icon (16px — the EventCard below carries its own
+    // 20px copy) lines up with the rows' kind icons.
+    final headerIcon = find.byWidgetPredicate(
+        (w) => w is Icon && w.icon == Icons.local_activity && w.size == 16);
+    expect(headerIcon, findsOneWidget);
+    expect(dx(headerIcon),
+        moreOrLessEquals(
+            dx(_inRow('Stay in Paris', find.byIcon(Icons.hotel))),
+            epsilon: 0.1));
+
+    await expandCity(tester, 'Rome');
+
+    // Sanity: the leg row carries the icon+caret mode menu...
+    expect(_inRow('Paris → Rome', find.byIcon(Icons.arrow_drop_down)),
+        findsOneWidget);
+    // ...and its title still starts at the same x as the stay title.
+    expect(dx(find.text('Paris → Rome')),
+        moreOrLessEquals(stayTitleDx, epsilon: 0.1));
+  });
+}


### PR DESCRIPTION
## Summary
- Every `BookingTodoRow` now reserves a fixed 34px leading slot (`kBookingRowLeadingSlot`, left-aligned child), so titles start at the same x whether the row leads with the bare kind icon (stays, menu-suppressed transport rows) or the wider icon+caret mode menu — previously flight titles sat 16px right of stay titles.
- `BookingDetailRow` derives its indent from the same constant instead of a stale `left: 38` literal computed against stay geometry, so detail lines sit exactly under the todo titles for every row type.
- The "Events while you're here" and "Local intel" section headers pick up the rows' 12px left inset so their icons join the same column as the row kind icons.
- Compact (<800px) rows drop the open-link button's `open_in_new` glyph: the reserved slot costs 16px and the 360px overflow floor had ~1px slack, so the glyph — redundant next to the already-shortened brand label — funds the alignment.

## Testing
- New `test/trip_detail_booking_alignment_test.dart` pins the contract: transport-with-menu title dx == stay title dx, detail-row icon dx == title dx, events-header icon dx == row kind-icon dx.
- `flutter analyze`: no new issues (3 pre-existing baseline infos in `route_response.dart` untouched).
- Full suite: 857 tests pass, including the previously-fragile 360px overflow-floor test.
- Browser-verified on the lane stack (:3001) at 1440px and 390px: transport/stay titles share one left edge, caret tucks into the slot, detail row indents under the titles, compact rows show plain "Flights"/"Airbnb" links with no overflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)