### PR TITLE
feat(flutter): Trip health as app-bar icon + badge opening a modal sheet

### DIFF
--- a/docs/friction-log.md
+++ b/docs/friction-log.md
@@ -5,6 +5,33 @@ build queue. Priority when picking work: **breakage > friction in features
 actually used > ideas that recur across ≥2 sessions**. Tag entries `[app]`
 (dogfooding the product) or `[dev]` (workflow/tooling). Newest first.
 
+## 2026-08-12 — trip-detail dogfooding (trip health modal)
+
+- **[app] Friction → fixed (health row → app-bar icon + badge, the 08-03
+  remedy delivered):** the 08-03 resolution kept Trip health inline for
+  glanceability and named the fix if reachability recurred — "surfacing the
+  health pill higher"; the 08-04 cluster reorder was the stopgap. This is
+  the full remedy: Trip health left the trailing cluster for a fact-check
+  **app-bar icon with a severity-colored count badge** — visible from the
+  first frame on every breakpoint, which answers the 08-03 "a menu would
+  hide glanceable state" objection (count + worst severity are MORE
+  glanceable in the app bar than below the whole itinerary). Tapping opens
+  a **bottom-sheet modal** (`showTripHealthSheet`) whose body is
+  `TripReviewSection` (its body-only `showHeader` knob retired with the
+  row); fix flows stack their own sheets above it on the same tab
+  navigator, and the list + badge live-update through the one provider
+  invalidation; tapping a day-anchored finding pops the sheet, then
+  scrolls. The badge needed **solid** color pairs (`AppColors.warningSolid`
+  + neutral) — the .20-alpha container amber vanishes on the teal gradient.
+  Cluster is now Packing → Budget. Sheet feedback contract (post-review
+  hardening): a FAILED fix throws out of `_applyFix` and the sheet closes
+  itself so the error snackbar is seen (never a silent no-op); a failed
+  hours-check reverts to the cached list with an inline note instead of
+  blanking the modal; `isOffline` is a live callback, not a bool frozen at
+  open. Known debt: success-path Undo snackbars still render behind the
+  open sheet on phones (primary feedback = the finding dropping off the
+  list), and there is still zero usage telemetry on any of these surfaces.
+
 ## 2026-08-12 — trip-detail dogfooding (add-CTA declutter)
 
 - **[app] Friction → fixed (one add CTA per view):** the itinerary tail

--- a/src/packages/flutter-app/lib/l10n/app_en.arb
+++ b/src/packages/flutter-app/lib/l10n/app_en.arb
@@ -1264,6 +1264,7 @@
   "reviewOfflineSnack": "You're offline — reconnect to run more checks.",
   "reviewHoursChecked": "Opening hours checked",
   "reviewCheckHours": "Also check opening hours",
+  "reviewHoursCheckFailed": "Couldn't check opening hours — try again.",
   "liveTripEyebrow": "HAPPENING NOW",
   "liveTripStatusLive": "Live",
   "liveTripDay": "Day {day}",

--- a/src/packages/flutter-app/lib/l10n/app_es.arb
+++ b/src/packages/flutter-app/lib/l10n/app_es.arb
@@ -565,6 +565,7 @@
   "reviewOfflineSnack": "Estás sin conexión — vuelve a conectarte para hacer más comprobaciones.",
   "reviewHoursChecked": "Horarios comprobados",
   "reviewCheckHours": "Comprobar también los horarios",
+  "reviewHoursCheckFailed": "No se pudieron comprobar los horarios — inténtalo de nuevo.",
   "liveTripEyebrow": "SUCEDIENDO AHORA",
   "liveTripStatusLive": "En curso",
   "liveTripDay": "Día {day}",

--- a/src/packages/flutter-app/lib/l10n/app_localizations.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations.dart
@@ -3488,6 +3488,12 @@ abstract class AppLocalizations {
   /// **'Also check opening hours'**
   String get reviewCheckHours;
 
+  /// No description provided for @reviewHoursCheckFailed.
+  ///
+  /// In en, this message translates to:
+  /// **'Couldn\'t check opening hours — try again.'**
+  String get reviewHoursCheckFailed;
+
   /// No description provided for @liveTripEyebrow.
   ///
   /// In en, this message translates to:

--- a/src/packages/flutter-app/lib/l10n/app_localizations_en.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations_en.dart
@@ -1953,6 +1953,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get reviewCheckHours => 'Also check opening hours';
 
   @override
+  String get reviewHoursCheckFailed =>
+      'Couldn\'t check opening hours — try again.';
+
+  @override
   String get liveTripEyebrow => 'HAPPENING NOW';
 
   @override

--- a/src/packages/flutter-app/lib/l10n/app_localizations_es.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations_es.dart
@@ -1968,6 +1968,10 @@ class AppLocalizationsEs extends AppLocalizations {
   String get reviewCheckHours => 'Comprobar también los horarios';
 
   @override
+  String get reviewHoursCheckFailed =>
+      'No se pudieron comprobar los horarios — inténtalo de nuevo.';
+
+  @override
   String get liveTripEyebrow => 'SUCEDIENDO AHORA';
 
   @override

--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -61,6 +61,7 @@ import '../widgets/booking_todo_card.dart';
 import '../widgets/budget_section.dart';
 import '../widgets/checklist_section.dart';
 import '../widgets/collapsible_section.dart';
+import '../widgets/trip_health_sheet.dart';
 import '../widgets/trip_review_section.dart';
 import '../widgets/empty_state.dart';
 import '../widgets/choice_chip_row.dart';
@@ -229,10 +230,10 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
   String? _unfocusedOpenLegKey;
   final Set<String> _collapsedDays = {};
   bool _citySeedConsumed = false;
-  // Trailing sections (Packing/Budget/Trip health) render as collapsed
-  // one-line summaries; this holds the ones the user opened. Session-only,
-  // like the city/day sets, and held HERE (not in the section widgets) so
-  // expansion survives silent refreshes and the offline-banner reparent.
+  // Trailing sections (Packing/Budget) render as collapsed one-line
+  // summaries; this holds the ones the user opened. Session-only, like the
+  // city/day sets, and held HERE (not in the section widgets) so expansion
+  // survives silent refreshes and the offline-banner reparent.
   final Set<String> _expandedSections = {};
   String?
       _homeAirport; // traveler's saved home airport (IATA), for outbound/return flights
@@ -3821,8 +3822,15 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
   /// adds open the existing sheet PREFILLED; set-dates / raise-budget open the
   /// existing editors. After any success the trip reloads and the review
   /// re-reads (see [_afterFix]) so the resolved finding drops off.
+  ///
+  /// THROWS on the offline guard and on API failure — after showing this
+  /// screen's error snackbar, which renders BEHIND the health sheet's modal
+  /// barrier. The throw is the sheet's signal to close itself so that
+  /// snackbar is actually seen (trip_health_sheet.dart's onApplyFix wrapper);
+  /// user-cancelled flows (dismissed prefill sheet, missing fix fields)
+  /// return normally.
   Future<void> _applyFix(TripFinding finding) async {
-    if (_guardOffline()) return;
+    if (_guardOffline()) throw StateError('offline');
     final l10n = context.l10n;
     final fix = finding.fix;
     if (fix == null) return;
@@ -3846,6 +3854,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
           await _afterFix();
         } catch (e) {
           _showSnack(l10n.tripAddStayFailed(friendlyError(l10n, e)));
+          rethrow;
         }
         break;
       case 'add_transport':
@@ -3867,6 +3876,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
           await _afterFix();
         } catch (e) {
           _showSnack(l10n.tripAddTransportFailed(friendlyError(l10n, e)));
+          rethrow;
         }
         break;
       case 'move_item':
@@ -3891,6 +3901,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
           ));
         } catch (e) {
           _showSnack(l10n.tripMoveItemFailed(friendlyError(l10n, e)));
+          rethrow;
         }
         break;
       case 'mark_booked':
@@ -3913,6 +3924,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
           ));
         } catch (e) {
           _showSnack(l10n.tripUpdateBookingFailed(friendlyError(l10n, e)));
+          rethrow;
         }
         break;
       case 'add_packing':
@@ -3945,6 +3957,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
           ));
         } catch (e) {
           _showSnack(l10n.tripAddPackingFailed(friendlyError(l10n, e)));
+          rethrow;
         }
         break;
       case 'set_dates':
@@ -4107,11 +4120,11 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
   String _fmtDayHeader(DateTime d) => mmmed().format(d);
 
   // ── Trailing collapsed sections ─────────────────────────────────────────
-  // Trip health / Packing / Budget end the page as one-line summary rows,
-  // closed by default — health first so its actionable review pill is met
-  // before the empty-state rows. Summary data comes from watches HERE in
-  // the parent — the section widgets are only mounted while expanded, so a
-  // child-side watch could never feed a collapsed row's counts.
+  // Packing / Budget end the page as one-line summary rows, closed by
+  // default. Summary data comes from watches HERE in the parent — the
+  // section widgets are only mounted while expanded, so a child-side watch
+  // could never feed a collapsed row's counts. (Trip health left this
+  // cluster for the app-bar icon + sheet — see _healthAppBarAction.)
 
   bool _sectionExpanded(String id) => _expandedSections.contains(id);
 
@@ -4375,52 +4388,49 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
     );
   }
 
-  Widget? _healthSectionRow(Trip trip, ThemeData theme) {
-    // Base provider key (checkHours: false): the section's internal opt-in
-    // hours check flips ITS key to the slower variant, so this collapsed
-    // count can briefly lag while that toggle is on — accepted.
-    // Parent watch = loaded-or-not only; finding counts/severity render in
-    // the Consumer, so a background review refresh repaints the row alone.
-    final visible = ref.watch(tripReviewProvider(TripReviewKey(trip.id))
-        .select((a) => a.valueOrNull != null));
-    if (!visible) return null;
+  /// The app-bar Trip health entry: fact-check icon with a severity-colored
+  /// count badge, opening the findings sheet. Replaced the trailing-cluster
+  /// row (friction-log 2026-08-12) — the badge is now the ONLY glanceable
+  /// health surface, so it stays visible on every breakpoint.
+  ///
+  /// Base provider key (checkHours: false): the sheet's internal opt-in hours
+  /// check flips ITS key to the slower variant, so this badge can briefly lag
+  /// while that toggle is on — accepted. The whole action lives in one
+  /// Consumer so review refetches repaint the icon alone; no value yet
+  /// (first load, error, viewer 404) hides it, matching the old row's gate.
+  Widget _healthAppBarAction(Trip trip, ThemeData theme) {
     return Consumer(
       builder: (context, ref, _) {
         final findings = ref
             .watch(tripReviewProvider(TripReviewKey(trip.id)))
             .valueOrNull;
         if (findings == null) return const SizedBox.shrink();
-        final l10n = context.l10n;
+        const icon = Icon(Icons.fact_check_outlined);
+        // Severity → color derived only via the shared statics; badgeColors
+        // is the opaque on-gradient variant of the pill pair.
         final worst = TripReviewSection.worstSeverity(findings);
-        final colors = worst == null
-            ? null
-            : TripReviewSection.severityColors(theme, worst);
-        return CollapsibleSection(
-          title: l10n.reviewSectionTitle,
-          icon: Icons.fact_check_outlined,
-          summary: findings.isEmpty ? l10n.reviewEmptyTitle : null,
-          pill: findings.isEmpty
-              ? null
-              : StatusPill.custom(
-                  label: l10n.reviewCountToReview(findings.length),
-                  background: colors!.bg,
-                  foreground: colors.fg,
-                ),
-          expanded: _sectionExpanded('health'),
-          onToggle: () => _toggleSection('health'),
-          child: TripReviewSection(
+        final colors =
+            worst == null ? null : TripReviewSection.badgeColors(theme, worst);
+        return IconButton(
+          tooltip: context.l10n.reviewSectionTitle,
+          onPressed: () => showTripHealthSheet(
+            context,
             tripId: trip.id,
-            isOffline: _isOffline,
+            // Live read, not a captured bool: the sheet route never rebuilds
+            // on this screen's connectivity setState.
+            isOffline: () => _isOffline,
             onScrollToDay: _scrollToDay,
-            dayForItem: (itemId) {
-              for (final item in trip.items ?? const <ItineraryItem>[]) {
-                if (item.id == itemId) return item.day;
-              }
-              return null;
-            },
+            dayForItem: _dayOfItem,
             onApplyFix: _readOnly ? null : _applyFix,
-            showHeader: false,
           ),
+          icon: findings.isEmpty
+              ? icon
+              : Badge(
+                  backgroundColor: colors!.bg,
+                  textColor: colors.fg,
+                  label: Text('${findings.length}'),
+                  child: icon,
+                ),
         );
       },
     );
@@ -4826,9 +4836,13 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
             maxLines: 1,
             overflow: TextOverflow.ellipsis),
         actions: [
+          // Contextual icons lead; share/delete/leave keep the outer-edge
+          // spots for every role. Health goes first: its severity count
+          // badge is glanceable state, worth the leading slot on every
+          // breakpoint (it replaced the trailing-cluster row).
+          if (trip != null) _healthAppBarAction(trip, theme),
           // Narrow: the header card drops its Refine button (one clean chip
-          // row), so the trip-level refine entry moves up here — first, so
-          // share/delete/leave keep their outer-edge spots for every role.
+          // row), so the trip-level refine entry moves up here.
           // Same gates as the button it replaces: editors only
           // (specs/collaborator-refine), disabled — not hidden — offline.
           if (_narrow && trip != null && trip.canEdit)
@@ -5456,7 +5470,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
                               ),
                           // Trailing sections, collapsed to one-line summary
                           // rows (settings-list rhythm: hairline dividers).
-                          // One sliver for all three; the 96px bottom padding
+                          // One sliver for both; the 96px bottom padding
                           // keeps the chat FAB off the last row. Each _xxx
                           // SectionRow hides itself exactly when its expanded
                           // section would (see the builders).
@@ -5465,11 +5479,6 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
                                 gutter, AppSpacing.sm, gutter, 96),
                             sliver: SliverToBoxAdapter(
                               child: _sectionCluster([
-                                  // Health first: it carries actionable state
-                                  // (the review pill), so it's met right after
-                                  // the itinerary; empty Packing/Budget rows
-                                  // trail at the true page bottom.
-                                  _healthSectionRow(trip, theme),
                                   _packingSectionRow(trip, theme),
                                   _budgetSectionRow(trip, theme),
                                 ]),

--- a/src/packages/flutter-app/lib/theme/app_colors.dart
+++ b/src/packages/flutter-app/lib/theme/app_colors.dart
@@ -47,6 +47,15 @@ abstract final class AppColors {
   static Color get warningContainer => Colors.amber.withValues(alpha: 0.20);
   static Color get onWarningContainer => Colors.amber.shade900;
 
+  // Solid counterparts to the container pairs, for chrome drawn over the
+  // brand gradient (the app-bar health badge): the alpha container colors
+  // disappear against the teal, so on-gradient badges need an opaque fill.
+  // The neutral pair is the no-active-severity fallback.
+  static Color get warningSolid => Colors.amber.shade600;
+  static Color get onWarningSolid => Colors.black87;
+  static Color get neutralSolid => Colors.white;
+  static Color get onNeutralSolid => brandDark;
+
   /// Accent color for an itinerary place by its category. `scheme` supplies the
   /// theme-derived fallbacks so this stays in sync with the seed.
   static Color forCategory(String? category, ColorScheme scheme) {

--- a/src/packages/flutter-app/lib/widgets/collapsible_section.dart
+++ b/src/packages/flutter-app/lib/widgets/collapsible_section.dart
@@ -4,8 +4,8 @@ import '../theme/spacing.dart';
 
 /// A one-line section row (icon · title · summary · pill · chevron) that
 /// expands in place. The trip detail page renders its trailing sections
-/// (Trip health, Packing, Budget) behind these rows, closed by default, so
-/// the page ends in a quiet index instead of three full sections.
+/// (Packing, Budget) behind these rows, closed by default, so the page ends
+/// in a quiet index instead of full sections.
 ///
 /// The parent owns [expanded]: trip detail keeps the set of open sections in
 /// screen state (like its city/day collapse sets), so expansion survives

--- a/src/packages/flutter-app/lib/widgets/trip_health_sheet.dart
+++ b/src/packages/flutter-app/lib/widgets/trip_health_sheet.dart
@@ -1,0 +1,91 @@
+import 'package:flutter/material.dart';
+
+import '../models/trip_finding.dart';
+import '../theme/spacing.dart';
+import 'trip_review_section.dart';
+
+/// Opens the Trip health findings list as a modal bottom sheet — the body
+/// behind the app-bar health icon on the trip detail screen.
+///
+/// Deliberately pushed on the nearest (tab) navigator, NOT the root one:
+/// [onApplyFix] flows open their own sheets via the screen's context on the
+/// same tab navigator, so they must be able to stack ABOVE this sheet and
+/// return to it on close (fix dialogs use root-navigator dialogs, which layer
+/// above either way).
+///
+/// Feedback contract: the screen's snackbars render BEHIND this sheet's
+/// barrier. Success feedback is the finding dropping off the list (the
+/// section watches the provider the screen invalidates after every fix); a
+/// FAILED fix throws out of `_applyFix`, and the wrapper below closes the
+/// sheet so the screen's error snackbar is seen instead of a silent no-op.
+///
+/// No Scaffold inside the sheet, so the framework's Escape→dismiss handling
+/// works as-is (a nested Scaffold would swallow DismissIntent — the
+/// trip_map_screen trap).
+Future<void> showTripHealthSheet(
+  BuildContext context, {
+  required String tripId,
+  required bool Function() isOffline,
+  void Function(int day)? onScrollToDay,
+  int? Function(String itemId)? dayForItem,
+  Future<void> Function(TripFinding finding)? onApplyFix,
+}) {
+  return showModalBottomSheet<void>(
+    context: context,
+    showDragHandle: true,
+    isScrollControlled: true,
+    useSafeArea: true,
+    // Width cap centers the sheet on desktop: findings are a narrow task
+    // list, like the add-to-trip picker — full-bleed rows read stranded.
+    constraints: const BoxConstraints(maxWidth: 560),
+    builder: (sheetContext) {
+      // Single-fire pop: two callbacks landing together (two rows tapped in
+      // the same frame, or a callback racing a drag-dismiss) must not pop
+      // twice — the second pop would eject the trip screen itself off the
+      // tab navigator this sheet shares with it.
+      void popSheet() {
+        final route = ModalRoute.of(sheetContext);
+        if (route != null && route.isCurrent) {
+          Navigator.of(sheetContext).pop();
+        }
+      }
+
+      return SafeArea(
+        child: ConstrainedBox(
+          constraints: BoxConstraints(
+            maxHeight: MediaQuery.of(sheetContext).size.height * 0.8,
+          ),
+          child: SingleChildScrollView(
+            padding: const EdgeInsets.fromLTRB(
+                AppSpacing.lg, 0, AppSpacing.lg, AppSpacing.lg),
+            child: TripReviewSection(
+              tripId: tripId,
+              isOffline: isOffline,
+              // Scroll targets live on the screen beneath: close the sheet
+              // first, then scroll. Safe without a post-frame wait — the
+              // screen stays mounted and laid out under the modal route.
+              onScrollToDay: onScrollToDay == null
+                  ? null
+                  : (day) {
+                      popSheet();
+                      onScrollToDay(day);
+                    },
+              dayForItem: dayForItem,
+              onApplyFix: onApplyFix == null
+                  ? null
+                  : (finding) async {
+                      try {
+                        await onApplyFix(finding);
+                      } catch (_) {
+                        // The screen already showed its error snackbar —
+                        // behind this sheet. Close so the failure is seen.
+                        popSheet();
+                      }
+                    },
+            ),
+          ),
+        ),
+      );
+    },
+  );
+}

--- a/src/packages/flutter-app/lib/widgets/trip_review_section.dart
+++ b/src/packages/flutter-app/lib/widgets/trip_review_section.dart
@@ -4,22 +4,29 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../l10n/l10n.dart';
 import '../models/trip_finding.dart';
 import '../providers/trip_review_provider.dart';
+import '../theme/app_colors.dart';
 import '../theme/spacing.dart';
 import 'empty_state.dart';
 import 'section_header.dart';
 import 'status_pill.dart';
 
-/// The trip-detail "Trip health" section: surfaces the read-only review from
+/// The "Trip health" findings list: surfaces the read-only review from
 /// `GET /trips/{id}/review` as an ordered list of findings, worst-severity
 /// first. Self-contained — it owns its data via [tripReviewProvider], keyed on
-/// (tripId, checkHours). Mirrors [ChecklistSection]/[BudgetSection] structure.
+/// (tripId, checkHours). Rendered as the body of the trip-detail health sheet
+/// (`showTripHealthSheet`), which the app-bar health icon opens.
 ///
 /// Tapping a finding with a resolvable day deep-links the itinerary to that day
 /// via [onScrollToDay]; [dayForItem] resolves an item id → day when a finding
 /// carries only an item id. Both are optional (no-op when absent/unresolvable).
 class TripReviewSection extends ConsumerStatefulWidget {
   final String tripId;
-  final bool isOffline;
+
+  /// Reads the CURRENT offline state at interaction time. A callback rather
+  /// than a bool because the sheet route hosting this widget never rebuilds
+  /// on the screen's connectivity setState — a captured bool would freeze
+  /// the offline guard for the sheet's whole lifetime.
+  final bool Function() isOffline;
 
   /// Scrolls the itinerary to [day]. Wired to the screen's `_scrollToDay`.
   final void Function(int day)? onScrollToDay;
@@ -32,10 +39,6 @@ class TripReviewSection extends ConsumerStatefulWidget {
   /// refresh, so it supplies this; when null the fix button is hidden.
   final Future<void> Function(TripFinding finding)? onApplyFix;
 
-  /// False when a parent (trip detail's collapsed-section row) already
-  /// renders the divider/title/severity pill, so this widget is body-only.
-  final bool showHeader;
-
   const TripReviewSection({
     super.key,
     required this.tripId,
@@ -43,35 +46,57 @@ class TripReviewSection extends ConsumerStatefulWidget {
     this.onScrollToDay,
     this.dayForItem,
     this.onApplyFix,
-    this.showHeader = true,
   });
 
-  /// Severity → pill colors, shared with the collapsed-section row so the
-  /// collapsed count pill matches the expanded rows. Critical reads loud
-  /// (red), warn amber, info neutral.
-  static ({Color bg, Color fg}) severityColors(
+  /// One switch per severity keeps the two color pairs in lockstep — the
+  /// container pair (finding rows and count pills on light surfaces) and the
+  /// solid pair (the app-bar badge over the brand gradient, where translucent
+  /// container fills vanish). A severity added here shows up on every surface
+  /// at once; there is no second case-list to drift.
+  static ({Color bg, Color fg, Color solidBg, Color solidFg}) _severityPalette(
       ThemeData theme, String severity) {
     switch (severity) {
       case 'critical':
         return (
           bg: theme.colorScheme.errorContainer,
           fg: theme.colorScheme.onErrorContainer,
+          solidBg: theme.colorScheme.error,
+          solidFg: theme.colorScheme.onError,
         );
       case 'warn':
         return (
-          bg: Colors.amber.withValues(alpha: 0.20),
-          fg: Colors.amber.shade900,
+          bg: AppColors.warningContainer,
+          fg: AppColors.onWarningContainer,
+          solidBg: AppColors.warningSolid,
+          solidFg: AppColors.onWarningSolid,
         );
       default:
         return (
           bg: theme.colorScheme.surfaceContainerHighest,
           fg: theme.colorScheme.onSurfaceVariant,
+          solidBg: AppColors.neutralSolid,
+          solidFg: AppColors.onNeutralSolid,
         );
     }
   }
 
+  /// Severity → pill colors for rows and count pills on light surfaces.
+  /// Critical reads loud (red), warn amber, info neutral.
+  static ({Color bg, Color fg}) severityColors(
+      ThemeData theme, String severity) {
+    final p = _severityPalette(theme, severity);
+    return (bg: p.bg, fg: p.fg);
+  }
+
+  /// Severity → opaque colors for the app-bar count badge over the brand
+  /// gradient.
+  static ({Color bg, Color fg}) badgeColors(ThemeData theme, String severity) {
+    final p = _severityPalette(theme, severity);
+    return (bg: p.solidBg, fg: p.solidFg);
+  }
+
   /// Worst severity in [findings] ("critical" > "warn" > "info"), or null
-  /// when the list is empty. Shared with the collapsed-section row.
+  /// when the list is empty. Shared with the app-bar badge.
   static String? worstSeverity(Iterable<TripFinding> findings) {
     String? worst;
     for (final f in findings) {
@@ -119,6 +144,11 @@ class _TripReviewSectionState extends ConsumerState<TripReviewSection> {
   // Opt-in opening-hours check: flips the provider key to the slower variant.
   bool _checkHours = false;
 
+  // A failed hours check reverted [_checkHours]; shown as an inline caption
+  // by the toggle (a snackbar would render behind the sheet). Cleared on the
+  // next toggle attempt.
+  bool _hoursCheckFailed = false;
+
   TripReviewKey get _key =>
       TripReviewKey(widget.tripId, checkHours: _checkHours);
 
@@ -136,26 +166,61 @@ class _TripReviewSectionState extends ConsumerState<TripReviewSection> {
   }
 
   void _toggleCheckHours() {
-    if (widget.isOffline) {
+    if (widget.isOffline()) {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(content: Text(context.l10n.reviewOfflineSnack)),
       );
       return;
     }
-    setState(() => _checkHours = !_checkHours);
+    setState(() {
+      _checkHours = !_checkHours;
+      _hoursCheckFailed = false;
+    });
   }
 
   @override
   Widget build(BuildContext context) {
     final async = ref.watch(tripReviewProvider(_key));
+    final theme = Theme.of(context);
+    final l10n = context.l10n;
+    // A failed hours check would otherwise strand the widget on a valueless
+    // provider key — inside the sheet that reads as a blank modal with no way
+    // back. Revert to the base key (whose value is cached) and flag inline.
+    ref.listen(tripReviewProvider(_key), (_, next) {
+      if (next.hasError && !next.isLoading && _checkHours) {
+        // Invalidate the failed variant so a retry refetches instead of
+        // replaying the cached error (the family is not autoDispose).
+        ref.invalidate(tripReviewProvider(_key));
+        setState(() {
+          _checkHours = false;
+          _hoursCheckFailed = true;
+        });
+      }
+    });
     // Best-effort: on error or first load with no data, render nothing rather
     // than an error state — a utility section shouldn't shout. (Offline still
     // shows the last-loaded findings — the read GET is cached by the family.)
     final findings = async.valueOrNull;
-    if (findings == null) return const SizedBox.shrink();
+    if (findings == null) {
+      // In the sheet this is reachable only via the hours-check key switch
+      // (the app-bar icon gates opening on a loaded base list): keep the
+      // sheet's shape — header + spinner — while the slower variant fetches,
+      // never a bare drag handle.
+      if (async.isLoading) {
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            SectionHeader(title: l10n.reviewSectionTitle),
+            const Padding(
+              padding: EdgeInsets.symmetric(vertical: AppSpacing.xl),
+              child: Center(child: CircularProgressIndicator()),
+            ),
+          ],
+        );
+      }
+      return const SizedBox.shrink();
+    }
 
-    final theme = Theme.of(context);
-    final l10n = context.l10n;
     final sorted = [...findings]
       ..sort((a, b) => _rankOf(a.severity).compareTo(_rankOf(b.severity)));
     final worst = sorted.isEmpty ? null : sorted.first.severity;
@@ -163,20 +228,17 @@ class _TripReviewSectionState extends ConsumerState<TripReviewSection> {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
-        if (widget.showHeader) ...[
-          const Divider(height: 32),
-          SectionHeader(
-            title: l10n.reviewSectionTitle,
-            action: findings.isEmpty
-                ? null
-                : StatusPill.custom(
-                    label: l10n.reviewCountToReview(findings.length),
-                    background: _severityColors(theme, worst!).bg,
-                    foreground: _severityColors(theme, worst).fg,
-                  ),
-          ),
-          const SizedBox(height: AppSpacing.sm),
-        ],
+        SectionHeader(
+          title: l10n.reviewSectionTitle,
+          action: findings.isEmpty
+              ? null
+              : StatusPill.custom(
+                  label: l10n.reviewCountToReview(findings.length),
+                  background: _severityColors(theme, worst!).bg,
+                  foreground: _severityColors(theme, worst).fg,
+                ),
+        ),
+        const SizedBox(height: AppSpacing.sm),
         if (findings.isEmpty)
           EmptyState(
             compact: true,
@@ -264,19 +326,31 @@ class _TripReviewSectionState extends ConsumerState<TripReviewSection> {
   Widget _buildCheckHoursAction(ThemeData theme, bool loading) {
     return Align(
       alignment: Alignment.centerLeft,
-      child: TextButton.icon(
-        icon: loading
-            ? const SizedBox(
-                width: 14,
-                height: 14,
-                child: CircularProgressIndicator(strokeWidth: 2),
-              )
-            : Icon(_checkHours ? Icons.check : Icons.access_time),
-        label: Text(_checkHours
-            ? context.l10n.reviewHoursChecked
-            : context.l10n.reviewCheckHours),
-        onPressed:
-            (widget.isOffline || _checkHours) ? null : _toggleCheckHours,
+      child: Wrap(
+        crossAxisAlignment: WrapCrossAlignment.center,
+        spacing: AppSpacing.sm,
+        children: [
+          TextButton.icon(
+            icon: loading
+                ? const SizedBox(
+                    width: 14,
+                    height: 14,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  )
+                : Icon(_checkHours ? Icons.check : Icons.access_time),
+            label: Text(_checkHours
+                ? context.l10n.reviewHoursChecked
+                : context.l10n.reviewCheckHours),
+            onPressed:
+                (widget.isOffline() || _checkHours) ? null : _toggleCheckHours,
+          ),
+          if (_hoursCheckFailed)
+            Text(
+              context.l10n.reviewHoursCheckFailed,
+              style: theme.textTheme.bodySmall
+                  ?.copyWith(color: theme.colorScheme.error),
+            ),
+        ],
       ),
     );
   }

--- a/src/packages/flutter-app/test/trip_detail_fix_actions_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_fix_actions_test.dart
@@ -157,6 +157,8 @@ void _useTallViewport(WidgetTester tester) {
   addTearDown(tester.view.reset);
 }
 
+/// Pumps the trip detail screen; [openSheet] then taps the app-bar health
+/// icon so the finding rows (and their fix buttons) are on screen.
 Future<void> _pumpScreen(
   WidgetTester tester, {
   required Trip trip,
@@ -166,6 +168,7 @@ Future<void> _pumpScreen(
   _FakeTransportApiService? transport,
   _FakeChecklistApiService? checklist,
   _FakeBudgetApiService? budget,
+  bool openSheet = true,
 }) async {
   _useTallViewport(tester);
   await tester.pumpWidget(
@@ -188,10 +191,8 @@ Future<void> _pumpScreen(
     ),
   );
   await tester.pumpAndSettle();
-  // Trip health renders behind a collapsed one-line row — expand it so the
-  // finding rows (and their fix buttons) are on screen.
-  await tester.ensureVisible(find.text('Trip health'));
-  await tester.tap(find.text('Trip health'));
+  if (!openSheet) return;
+  await tester.tap(find.byTooltip('Trip health'));
   await tester.pumpAndSettle();
 }
 
@@ -351,12 +352,12 @@ void main() {
     expect(inSheet('2026-08-03'), findsOneWidget);
   });
 
-  testWidgets('trailing cluster leads with Trip health, empty rows trail',
+  testWidgets('health lives in the app bar; cluster orders packing → budget',
       (tester) async {
-    // Layout contract (friction-log 2026-08-04): the cluster is ordered
-    // Trip health → What to wear & pack → Budget, so actionable review state
-    // is met before the empty-state rows. (The packing slot was retitled by
-    // the merged what-to-wear section, specs/what-to-wear.)
+    // Layout contract (friction-log 2026-08-12, evolving 2026-08-04): Trip
+    // health left the trailing cluster for the always-visible app-bar icon
+    // (its count badge is the glanceable state), so the cluster is now
+    // What to wear & pack → Budget only, with no health row in the body.
     final review = _FakeReviewApiService([
       _finding('packing', 'No umbrella for rainy Athens',
           const FindingFix(
@@ -369,13 +370,16 @@ void main() {
         trip: _trip(),
         review: review,
         checklist: _FakeChecklistApiService(),
-        budget: _FakeBudgetApiService());
+        budget: _FakeBudgetApiService(),
+        openSheet: false);
+
+    // The health entry is the app-bar icon; no "Trip health" row in the body.
+    expect(find.byTooltip('Trip health'), findsOneWidget);
+    expect(find.text('Trip health'), findsNothing);
 
     // The tall test viewport lays out the whole cluster in one frame.
-    final healthY = tester.getTopLeft(find.text('Trip health')).dy;
     final packingY = tester.getTopLeft(find.text('What to wear & pack')).dy;
     final budgetY = tester.getTopLeft(find.text('Budget')).dy;
-    expect(healthY, lessThan(packingY));
     expect(packingY, lessThan(budgetY));
   });
 }

--- a/src/packages/flutter-app/test/trip_detail_health_modal_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_health_modal_test.dart
@@ -1,0 +1,330 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:travel_route_planner/models/trip.dart';
+import 'package:travel_route_planner/models/itinerary_item.dart';
+import 'package:travel_route_planner/models/trip_finding.dart';
+import 'package:travel_route_planner/models/accommodation.dart';
+import 'package:travel_route_planner/services/api_client.dart';
+import 'package:travel_route_planner/services/trips_api_service.dart';
+import 'package:travel_route_planner/services/trip_review_api_service.dart';
+import 'package:travel_route_planner/services/accommodations_api_service.dart';
+import 'package:travel_route_planner/providers/trips_provider.dart';
+import 'package:travel_route_planner/providers/trip_review_provider.dart';
+import 'package:travel_route_planner/providers/accommodations_provider.dart';
+import 'package:travel_route_planner/screens/trip_detail_screen.dart';
+import 'package:travel_route_planner/theme/app_colors.dart';
+import 'package:travel_route_planner/widgets/empty_state.dart';
+import 'package:travel_route_planner/widgets/trip_review_section.dart';
+
+import 'support/l10n_test_app.dart';
+
+/// The app-bar Trip health icon + severity count badge and the bottom-sheet
+/// modal it opens (showTripHealthSheet) — the surface that replaced the
+/// trailing-cluster row (friction-log 2026-08-12).
+
+class _FakeTripsApiService extends TripsApiService {
+  final Trip trip;
+  _FakeTripsApiService(this.trip) : super(ApiClient(baseUrl: 'http://test'));
+
+  @override
+  Future<Trip> getTrip(String id) async => trip;
+}
+
+/// Review fake: serves [findings] until [resolved], then empty; [error]
+/// makes every fetch throw (the viewer-404 analog — provider has no value);
+/// [hoursError] fails only the checkHours variant (flaky hours backend).
+class _FakeReviewApiService extends TripReviewApiService {
+  final List<TripFinding> findings;
+  bool resolved = false;
+  bool error = false;
+  bool hoursError = false;
+
+  _FakeReviewApiService(this.findings)
+      : super(ApiClient(baseUrl: 'http://test'));
+
+  @override
+  Future<List<TripFinding>> getReview(String tripId,
+      {bool checkHours = false}) async {
+    if (error) throw Exception('403');
+    if (checkHours && hoursError) throw Exception('hours backend down');
+    return resolved ? const [] : List.of(findings);
+  }
+}
+
+class _FakeAccommodationsApiService extends AccommodationsApiService {
+  final List<Map<String, dynamic>> patches = [];
+  bool failUpdate = false;
+  _FakeAccommodationsApiService() : super(ApiClient(baseUrl: 'http://test'));
+
+  @override
+  Future<Accommodation> update(
+      String tripId, String accId, Map<String, dynamic> body) async {
+    if (failUpdate) throw Exception('500');
+    patches.add({'id': accId, ...body});
+    return Accommodation(id: accId, name: 'Stay');
+  }
+}
+
+Trip _trip() => Trip(
+      id: 't1',
+      title: 'Greece',
+      startDate: '2026-08-01',
+      endDate: '2026-08-05',
+      createdAt: '2026-07-01',
+      updatedAt: '2026-07-01',
+      items: [
+        ItineraryItem(
+          id: 'i0',
+          position: 0,
+          name: 'Acropolis',
+          address: 'Athens, Greece',
+          latitude: 0,
+          longitude: 0,
+          category: 'attraction',
+          day: 1,
+        ),
+      ],
+    );
+
+TripFinding _finding(String severity, String message, {int? day}) =>
+    TripFinding(
+      severity: severity,
+      category: 'dates',
+      message: message,
+      tripId: 't1',
+      day: day,
+    );
+
+Future<void> _pumpScreen(
+  WidgetTester tester, {
+  required _FakeReviewApiService review,
+  _FakeAccommodationsApiService? accommodations,
+  Size surface = const Size(800, 1000),
+}) async {
+  await tester.binding.setSurfaceSize(surface);
+  addTearDown(() => tester.binding.setSurfaceSize(null));
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        tripsApiServiceProvider.overrideWithValue(_FakeTripsApiService(_trip())),
+        tripReviewApiServiceProvider.overrideWithValue(review),
+        if (accommodations != null)
+          accommodationsApiServiceProvider.overrideWithValue(accommodations),
+      ],
+      child: MaterialApp(
+          localizationsDelegates: testLocalizationsDelegates,
+          home: TripDetailScreen(tripId: 't1')),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+Finder _healthIcon() => find.byTooltip('Trip health');
+
+void main() {
+  testWidgets('badge carries the count, colored by the worst severity',
+      (tester) async {
+    final review = _FakeReviewApiService([
+      _finding('warn', 'No transport booked from Athens to Naxos.'),
+      _finding('warn', 'No lodging for the night of Aug 3.'),
+      _finding('info', 'Day 2 has nothing scheduled.'),
+    ]);
+    await _pumpScreen(tester, review: review);
+
+    expect(_healthIcon(), findsOneWidget);
+    expect(
+        find.descendant(of: find.byType(Badge), matching: find.text('3')),
+        findsOneWidget);
+    // Worst severity is warn → the solid amber on-gradient pair.
+    expect(tester.widget<Badge>(find.byType(Badge)).backgroundColor,
+        AppColors.warningSolid);
+  });
+
+  testWidgets('a critical finding turns the badge red', (tester) async {
+    final review = _FakeReviewApiService([
+      _finding('warn', 'No transport booked from Athens to Naxos.'),
+      _finding('critical', 'Trip dates are in the past.'),
+    ]);
+    await _pumpScreen(tester, review: review);
+
+    final badge = tester.widget<Badge>(find.byType(Badge));
+    final theme = Theme.of(tester.element(find.byType(Badge)));
+    expect(badge.backgroundColor, theme.colorScheme.error);
+  });
+
+  testWidgets('zero findings: bare icon, sheet shows the all-clear',
+      (tester) async {
+    final review = _FakeReviewApiService(const []);
+    await _pumpScreen(tester, review: review);
+
+    expect(_healthIcon(), findsOneWidget);
+    expect(find.byType(Badge), findsNothing);
+
+    await tester.tap(_healthIcon());
+    await tester.pumpAndSettle();
+    expect(find.byType(EmptyState), findsOneWidget);
+    expect(find.text('Looks good'), findsOneWidget);
+  });
+
+  testWidgets('icon hidden while the review has no value (error/viewer)',
+      (tester) async {
+    final review = _FakeReviewApiService(const [])..error = true;
+    await _pumpScreen(tester, review: review);
+
+    expect(_healthIcon(), findsNothing);
+  });
+
+  testWidgets('tapping the icon opens the sheet with header, pill and rows',
+      (tester) async {
+    final review = _FakeReviewApiService([
+      _finding('warn', 'No transport booked from Athens to Naxos.'),
+      _finding('warn', 'No lodging for the night of Aug 3.'),
+      _finding('info', 'Day 2 has nothing scheduled.'),
+    ]);
+    await _pumpScreen(tester, review: review);
+
+    await tester.tap(_healthIcon());
+    await tester.pumpAndSettle();
+
+    expect(find.byType(TripReviewSection), findsOneWidget);
+    expect(find.text('Trip health'), findsOneWidget);
+    expect(find.text('3 to review'), findsOneWidget);
+    expect(
+        find.text('No transport booked from Athens to Naxos.'), findsOneWidget);
+    expect(find.text('Day 2 has nothing scheduled.'), findsOneWidget);
+  });
+
+  testWidgets('tapping a day-anchored finding closes the sheet and scrolls',
+      (tester) async {
+    final review = _FakeReviewApiService([
+      _finding('warn', 'Day 1 is overloaded.', day: 1),
+    ]);
+    await _pumpScreen(tester, review: review);
+
+    await tester.tap(_healthIcon());
+    await tester.pumpAndSettle();
+    expect(find.byType(TripReviewSection), findsOneWidget);
+
+    // The sheet pops first, then the screen beneath scrolls — no crash.
+    await tester.tap(find.text('Day 1 is overloaded.'));
+    await tester.pumpAndSettle();
+    expect(find.byType(TripReviewSection), findsNothing);
+  });
+
+  testWidgets('an in-sheet fix live-updates the list and the badge behind it',
+      (tester) async {
+    final review = _FakeReviewApiService([
+      TripFinding(
+        severity: 'warn',
+        category: 'bookings',
+        message: 'Stay not booked',
+        tripId: 't1',
+        fix: const FindingFix(
+            action: 'mark_booked',
+            label: 'Mark booked',
+            itemId: 'acc-1',
+            entityType: 'accommodation'),
+      ),
+    ]);
+    final accommodations = _FakeAccommodationsApiService();
+    await _pumpScreen(tester, review: review, accommodations: accommodations);
+    expect(find.byType(Badge), findsOneWidget);
+
+    await tester.tap(_healthIcon());
+    await tester.pumpAndSettle();
+
+    review.resolved = true; // the server now considers it booked
+    await tester.tap(find.widgetWithText(FilledButton, 'Mark booked'));
+    await tester.pumpAndSettle();
+
+    expect(accommodations.patches, hasLength(1));
+    // Sheet stays open and re-renders empty; the badge behind it clears too.
+    expect(find.byType(EmptyState), findsOneWidget);
+    expect(find.byType(Badge), findsNothing);
+  });
+
+  testWidgets('a failed fix closes the sheet so the error snackbar is seen',
+      (tester) async {
+    final review = _FakeReviewApiService([
+      TripFinding(
+        severity: 'warn',
+        category: 'bookings',
+        message: 'Stay not booked',
+        tripId: 't1',
+        fix: const FindingFix(
+            action: 'mark_booked',
+            label: 'Mark booked',
+            itemId: 'acc-1',
+            entityType: 'accommodation'),
+      ),
+    ]);
+    final accommodations = _FakeAccommodationsApiService()..failUpdate = true;
+    await _pumpScreen(tester, review: review, accommodations: accommodations);
+
+    await tester.tap(_healthIcon());
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.widgetWithText(FilledButton, 'Mark booked'));
+    await tester.pumpAndSettle();
+
+    // The sheet closed itself so the screen's error snackbar is visible —
+    // never a silent no-op behind the barrier. The finding is unresolved,
+    // so the badge still shows.
+    expect(find.byType(TripReviewSection), findsNothing);
+    expect(find.byType(SnackBar), findsOneWidget);
+    expect(find.byType(Badge), findsOneWidget);
+  });
+
+  testWidgets('a failed hours check reverts to the list with an inline note',
+      (tester) async {
+    final review = _FakeReviewApiService([
+      _finding('warn', 'No transport booked from Athens to Naxos.'),
+    ])..hoursError = true;
+    await _pumpScreen(tester, review: review);
+
+    await tester.tap(_healthIcon());
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Also check opening hours'));
+    await tester.pumpAndSettle();
+
+    // Reverted to the cached base list — never a blank sheet — with the
+    // failure noted inline by the toggle (snackbars render behind sheets).
+    expect(find.text('No transport booked from Athens to Naxos.'),
+        findsOneWidget);
+    expect(find.text("Couldn't check opening hours — try again."),
+        findsOneWidget);
+  });
+
+  testWidgets('Escape dismisses the sheet', (tester) async {
+    final review = _FakeReviewApiService([
+      _finding('warn', 'No transport booked from Athens to Naxos.'),
+    ]);
+    await _pumpScreen(tester, review: review);
+
+    await tester.tap(_healthIcon());
+    await tester.pumpAndSettle();
+    expect(find.byType(TripReviewSection), findsOneWidget);
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.escape);
+    await tester.pumpAndSettle();
+    expect(find.byType(TripReviewSection), findsNothing);
+  });
+
+  testWidgets('icon shows on phone and desktop widths (not narrow-gated)',
+      (tester) async {
+    final review = _FakeReviewApiService([
+      _finding('warn', 'No transport booked from Athens to Naxos.'),
+    ]);
+    await _pumpScreen(tester,
+        review: review, surface: const Size(390, 800));
+    expect(_healthIcon(), findsOneWidget);
+
+    await _pumpScreen(tester,
+        review: review, surface: const Size(1200, 800));
+    expect(_healthIcon(), findsOneWidget);
+  });
+}

--- a/src/packages/flutter-app/test/trip_review_section_test.dart
+++ b/src/packages/flutter-app/test/trip_review_section_test.dart
@@ -60,7 +60,7 @@ Future<_FakeTripReviewApiService> _pump(
           body: SingleChildScrollView(
             child: TripReviewSection(
               tripId: 't1',
-              isOffline: isOffline,
+              isOffline: () => isOffline,
               onScrollToDay: onScrollToDay,
               dayForItem: dayForItem,
               onApplyFix: onApplyFix,


### PR DESCRIPTION
## Summary
- Trip health leaves the trailing section cluster for a **fact-check app-bar icon with a severity-colored count badge** (amber warn / red critical / neutral), visible without scrolling on every breakpoint — the friction log's 08-03 "surface the health pill higher" remedy delivered; the cluster is now Packing → Budget.
- Tapping opens a **bottom-sheet modal** (`showTripHealthSheet`, new `lib/widgets/trip_health_sheet.dart`) hosting `TripReviewSection`; it rides the tab navigator so one-tap fix flows stack their own sheets above it, and the list + badge live-update through the existing review-provider invalidation. Day-anchored findings pop the sheet (single-fire guard), then scroll.
- **Feedback hardening** (from the pre-ship code review): failed fixes throw out of `_applyFix` and the sheet closes so the error snackbar is seen instead of a silent no-op; a failed opening-hours check reverts to the cached list with an inline "try again" note (new `reviewHoursCheckFailed` string, EN+ES) instead of blanking the modal; `isOffline` is a live callback rather than a bool frozen at sheet-open.
- Cleanups: one `_severityPalette` switch feeds both the container pills and the new opaque on-gradient pairs (`AppColors.warningSolid`/`neutralSolid`); the dead body-only `showHeader` knob is retired; stale collapsed-row comments updated; friction-log entry records the decision.

## Testing
- `flutter analyze` — clean (3 pre-existing infos in `route_response.dart`, present on main).
- New `test/trip_detail_health_modal_test.dart` (11 cases): badge count + severity colors, zero-state, provider-error gating, sheet open/contents, pop-then-scroll, in-sheet fix live-updating the badge, failed-fix sheet close + visible snackbar, failed hours check inline note, Escape dismiss, phone + desktop widths.
- Updated `trip_detail_fix_actions_test.dart` (opens via the app-bar tooltip; layout contract now pins icon-in-app-bar + Packing → Budget) and `trip_review_section_test.dart` — all pass.
- Full `make flutter-test` suite green (exit 0, "All tests passed").

🤖 Generated with [Claude Code](https://claude.com/claude-code)