### PR TITLE
fix(flutter): align booking-row open_in_new glyphs on one trailing column

### DIFF
--- a/src/packages/flutter-app/lib/widgets/booking_todo_card.dart
+++ b/src/packages/flutter-app/lib/widgets/booking_todo_card.dart
@@ -260,6 +260,11 @@ class BookingTodoRow extends StatelessWidget {
             TextButton.icon(
               onPressed: onOpen,
               icon: const Icon(Icons.open_in_new, size: 18),
+              // Trailing glyph: the kebab + checkbox after the button are
+              // fixed-width and the cluster packs right, so with the icon
+              // after the label every row's open_in_new lands on one column
+              // no matter how wide the label is.
+              iconAlignment: IconAlignment.end,
               // Booked rows recede: the link stays usable (re-check a price,
               // find the confirmation email's provider) but stops competing
               // with unbooked rows for attention.

--- a/src/packages/flutter-app/test/trip_detail_booking_alignment_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_booking_alignment_test.dart
@@ -20,12 +20,18 @@ import 'package:travel_route_planner/widgets/booking_todo_card.dart';
 import 'support/city_groups.dart';
 import 'support/l10n_test_app.dart';
 
-// Leading-edge alignment contract for the itinerary's booking surface: every
-// BookingTodoRow reserves the same fixed leading slot (kBookingRowLeadingSlot),
-// so titles share one x whether the row leads with the bare kind icon (stays,
-// menu-suppressed transport rows — same code branch) or with the wider
-// icon+caret mode menu. BookingDetailRow and the section headers align to the
-// same grid.
+// Alignment contracts for the itinerary's booking surface.
+//
+// Leading edge: every BookingTodoRow reserves the same fixed leading slot
+// (kBookingRowLeadingSlot), so titles share one x whether the row leads with
+// the bare kind icon (stays, menu-suppressed transport rows — same code
+// branch) or with the wider icon+caret mode menu. BookingDetailRow and the
+// section headers align to the same grid.
+//
+// Trailing edge: the open button renders its open_in_new glyph after the
+// label (iconAlignment.end), so with the fixed-width kebab + checkbox
+// packing the cluster right, every row's glyph lands on one column despite
+// varying label widths ("Open in Airbnb" vs "Find flights").
 
 class _FakeTripsApiService extends TripsApiService {
   final Trip trip;
@@ -182,5 +188,27 @@ void main() {
     // ...and its title still starts at the same x as the stay title.
     expect(dx(find.text('Paris → Rome')),
         moreOrLessEquals(stayTitleDx, epsilon: 0.1));
+  });
+
+  testWidgets('open buttons share one trailing column', (tester) async {
+    _useTallViewport(tester);
+    await _pump(tester, _twoCityTrip());
+
+    double dx(Finder f) => tester.getTopLeft(f).dx;
+
+    // The _inRow scoping is load-bearing: the Paris group also renders an
+    // EventCard with its own bare open_in_new, and the matched stay's
+    // BookingDetailRow carries trailing IconButtons.
+    await expandCity(tester, 'Paris');
+    // Differing label widths are what make the dx equality meaningful.
+    expect(_inRow('Stay in Paris', find.text('Open in Airbnb')),
+        findsOneWidget);
+    final iconDx =
+        dx(_inRow('Stay in Paris', find.byIcon(Icons.open_in_new)));
+
+    await expandCity(tester, 'Rome');
+    expect(_inRow('Paris → Rome', find.text('Find flights')), findsOneWidget);
+    expect(dx(_inRow('Paris → Rome', find.byIcon(Icons.open_in_new))),
+        moreOrLessEquals(iconDx, epsilon: 0.1));
   });
 }


### PR DESCRIPTION
## Summary
- Bookings-view rows: the open button's `open_in_new` glyph now renders **after** the label (`iconAlignment: IconAlignment.end`), so every row's glyph lands on one trailing column against the fixed kebab + checkbox columns — previously the icon's x wandered with the label width ("Find flights" vs "Open in Airbnb"). Follow-up to #342 (leading-grid alignment), from Brian's Bookings-view dogfooding.
- Labels read right-aligned ("label ↗", the standard external-link idiom); their ragged left edge faces the flexible title gap. No width constants; locale- and text-scale-proof (the M3 icon-label gap is a single `spacing` identical for both orders).
- Compact rows (<800px `kRailBreakpoint`) carry no glyph (deliberate, #342 — the 360px overflow floor funds it) and are byte-identical.
- New trailing-column contract test in `trip_detail_booking_alignment_test.dart` — verified it **fails against the previous icon-first layout** ("Open in Airbnb" vs "Find flights" rows, `_inRow`-scoped so the EventCard/BookingDetailRow glyphs can't over-match; accordion capture pattern).

## Testing
- `flutter analyze` — clean apart from the 3 pre-existing baseline infos in `route_response.dart`.
- `flutter test test/trip_detail_booking_alignment_test.dart test/trip_detail_narrow_rows_test.dart` — pass (new contract test fails when the lib change is stashed, passes with it).
- Full `flutter test` — 873 tests, all pass.
- Browser check on the lane stack (:3001, headless Chrome at 1440px): seeded a Prague/Kraków trip — "Open in Airbnb ↗" / "Find flights ↗" / "Open in Airbnb ↗" glyphs sit on one column beside the kebab column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)