### PR TITLE
fix(api,gateway): read /plan body before priming the SSE stream

### DIFF
--- a/dockerize/deployment/nginx/snippets/app-locations.conf
+++ b/dockerize/deployment/nginx/snippets/app-locations.conf
@@ -47,17 +47,25 @@ location /api/ {
 
 # Dedicated SSE lane for the /plan agent stream. Exact match wins over the
 # /api/ prefix block above, so this — not /api/ — serves the one endpoint
-# that streams tokens: buffering fully off in both directions (no stutter,
-# no spooling 20 MiB image posts to disk before Go sees byte one), and
-# timeouts of 660s so the gateway outlives planMaxDuration (10 min) in
-# plan_handler.go instead of severing long tool-heavy turns.
+# that streams tokens: response buffering off (no token stutter), request
+# buffering ON (see below), and timeouts of 660s so the gateway outlives
+# planMaxDuration (10 min) in plan_handler.go instead of severing long
+# tool-heavy turns.
 location = /api/v1/plan {
     proxy_pass http://api_backend;
     proxy_http_version 1.1;
     proxy_set_header Connection "";
     proxy_buffering off;
     proxy_cache off;
-    proxy_request_buffering off;
+    # Request buffering deliberately ON (the default): the upstream commits
+    # its SSE response within microseconds of the request headers, and with
+    # unbuffered forwarding nginx stops relaying the request body once the
+    # upstream responds — the Go decoder then reads EOF and every request
+    # fails (2026-08-12 prod incident, fix for b476b79). Buffering also
+    # absorbs slow client uploads (Go's ReadTimeout is 15s) and keeps POST
+    # bodies replayable if a pooled keepalive upstream connection has gone
+    # stale.
+    proxy_request_buffering on;
     chunked_transfer_encoding off;
     client_max_body_size 20m;
     proxy_read_timeout 660s;

--- a/dockerize/development/nginx/default.conf
+++ b/dockerize/development/nginx/default.conf
@@ -61,18 +61,25 @@ server {
 
     # Dedicated SSE lane for the /plan agent stream — mirrors the
     # deployment snippet. Exact match wins over the /api/ prefix block, so
-    # this serves the one endpoint that streams tokens: buffering fully off
-    # in both directions (no stutter, no spooling 20 MiB image posts to
-    # disk before Go sees byte one), and timeouts of 660s so the gateway
-    # outlives planMaxDuration (10 min) in plan_handler.go instead of
-    # severing long tool-heavy turns.
+    # this serves the one endpoint that streams tokens: response buffering
+    # off (no token stutter), request buffering ON (see below), and
+    # timeouts of 660s so the gateway outlives planMaxDuration (10 min) in
+    # plan_handler.go instead of severing long tool-heavy turns.
     location = /api/v1/plan {
         proxy_pass http://api_backend;
         proxy_http_version 1.1;
         proxy_set_header Connection "";
         proxy_buffering off;
         proxy_cache off;
-        proxy_request_buffering off;
+        # Request buffering deliberately ON (the default): the upstream
+        # commits its SSE response within microseconds of the request
+        # headers, and with unbuffered forwarding nginx stops relaying the
+        # request body once the upstream responds — the Go decoder then
+        # reads EOF and every request fails (2026-08-12 prod incident, fix
+        # for b476b79). Buffering also absorbs slow client uploads (Go's
+        # ReadTimeout is 15s) and keeps POST bodies replayable if a pooled
+        # keepalive upstream connection has gone stale.
+        proxy_request_buffering on;
         chunked_transfer_encoding off;
         client_max_body_size 20m;
         proxy_read_timeout 660s;

--- a/src/packages/api/plan_handler.go
+++ b/src/packages/api/plan_handler.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log"
 	"net/http"
 	"os"
@@ -132,24 +133,43 @@ func planHandler(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "streaming not supported", http.StatusInternalServerError)
 		return
 	}
-	// Priming SSE comment, flushed before any body parsing or DB work:
-	// commits nginx/Cloudflare to streaming mode and gives the browser
-	// instant TTFB. The Dart client only parses `data: ` lines, so a
-	// comment frame is invisible to it.
-	fmt.Fprint(w, ": stream-open\n\n")
-	w.(http.Flusher).Flush()
-
 	// Overall wall-clock ceiling on the whole request (see planMaxDuration): a
 	// stuck stream eventually closes and frees its goroutine + concurrency slot.
 	ctx, cancel := context.WithTimeout(r.Context(), planMaxDuration)
 	defer cancel()
 	r = r.WithContext(ctx)
 
-	var req PlanRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	// INVARIANT: fully consume the request body BEFORE the first response
+	// write or flush. Writing commits the response, and a reverse proxy
+	// forwarding the request body unbuffered stops relaying it the moment
+	// the upstream responds — a decode after the first flush then reads EOF
+	// and every real-network request fails "invalid request body", while
+	// loopback dev and buffered test bodies pass (prod incident, 2026-08-12;
+	// TestPlanHandlerReadsBodyBeforeFirstWrite). The gateway now buffers
+	// /plan request bodies (dockerize/*/nginx), but this ordering must hold
+	// on its own; do not move the stream-open flush above this read.
+	// io.ReadAll (not json.Decoder, which stops at the first JSON value)
+	// drains to EOF; the body is MaxBytesReader-capped at 20 MiB
+	// (bodyLimitMiddleware).
+	raw, err := io.ReadAll(r.Body)
+	if err != nil {
+		log.Printf("plan body read: %v (read=%d content_length=%d)", err, len(raw), r.ContentLength)
 		sendSSE(w, "error", map[string]string{"message": "invalid request body"})
 		return
 	}
+	var req PlanRequest
+	if err := json.Unmarshal(raw, &req); err != nil {
+		log.Printf("plan body decode: %v (read=%d content_length=%d)", err, len(raw), r.ContentLength)
+		sendSSE(w, "error", map[string]string{"message": "invalid request body"})
+		return
+	}
+
+	// Priming SSE comment — flushed only after the body is fully consumed
+	// (invariant above) but still before any DB work or model calls: commits
+	// nginx/Cloudflare to streaming mode and keeps TTFB tight. The Dart
+	// client only parses `data: ` lines, so a comment frame is invisible.
+	fmt.Fprint(w, ": stream-open\n\n")
+	w.(http.Flusher).Flush()
 
 	// Cap the conversation before any model call: the whole history is resent
 	// on every agent-loop iteration, so these bounds are a hard cost lever.

--- a/src/packages/api/plan_handler_test.go
+++ b/src/packages/api/plan_handler_test.go
@@ -3,8 +3,11 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"io"
+	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"travel-route-planner/store"
@@ -129,5 +132,88 @@ func TestNotesPreview(t *testing.T) {
 	got := notesPreview(&long)
 	if r := []rune(got); len(r) != 81 || !strings.HasSuffix(got, "…") {
 		t.Fatalf("preview should be 80 runes + ellipsis, got %d runes: %q", len([]rune(got)), got)
+	}
+}
+
+// relayCutBody simulates a reverse proxy forwarding the request body
+// unbuffered (proxy_request_buffering off): the moment the handler commits
+// any response bytes, the proxy stops relaying the body and the handler's
+// reads hit EOF. This is exactly what nginx does — "upstream sent response
+// while sending request body" — and what broke prod chat on 2026-08-12.
+type relayCutBody struct {
+	data      *bytes.Reader
+	committed *atomic.Bool
+}
+
+func (b *relayCutBody) Read(p []byte) (int, error) {
+	if b.committed.Load() {
+		return 0, io.EOF
+	}
+	return b.data.Read(p)
+}
+
+func (b *relayCutBody) Close() error { return nil }
+
+// commitTrackingRecorder arms the relay cut on the first Write, WriteHeader,
+// or Flush. Embedding *httptest.ResponseRecorder keeps it an http.Flusher,
+// so planHandler's streaming assert passes.
+type commitTrackingRecorder struct {
+	*httptest.ResponseRecorder
+	committed *atomic.Bool
+}
+
+func (w *commitTrackingRecorder) Write(p []byte) (int, error) {
+	w.committed.Store(true)
+	return w.ResponseRecorder.Write(p)
+}
+
+func (w *commitTrackingRecorder) WriteHeader(code int) {
+	w.committed.Store(true)
+	w.ResponseRecorder.WriteHeader(code)
+}
+
+func (w *commitTrackingRecorder) Flush() {
+	w.committed.Store(true)
+	w.ResponseRecorder.Flush()
+}
+
+// planHandler must fully consume the request body BEFORE its first response
+// write or flush: a reverse proxy relaying the body unbuffered stops the
+// moment the upstream responds, so a decode after the priming flush reads
+// EOF and every real-network request dies with "invalid request body" while
+// buffered test bodies pass. This test wires the proxy behavior into the
+// recorder so that ordering violation fails here instead of on prod.
+func TestPlanHandlerReadsBodyBeforeFirstWrite(t *testing.T) {
+	anonPlanCounter.resetAll()
+	t.Setenv("FREE_ANON_PLAN_PER_DAY", "100")
+	// Deterministic post-decode short-circuit (same trick as
+	// TestPlanHandlerAnonCapEmitsFriendlySSE): with no key, the handler emits
+	// the not-configured error right after the decode + cap checks.
+	t.Setenv("ANTHROPIC_API_KEY", "")
+
+	payload, err := json.Marshal(PlanRequest{Messages: []PlanChatMessage{{Role: "user", Content: "hi"}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var committed atomic.Bool
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/plan",
+		&relayCutBody{data: bytes.NewReader(payload), committed: &committed})
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Forwarded-For", "203.0.113.77")
+	rec := &commitTrackingRecorder{ResponseRecorder: httptest.NewRecorder(), committed: &committed}
+
+	planHandler(rec, req)
+
+	out := rec.Body.String()
+	if strings.Contains(out, "invalid request body") {
+		t.Fatalf("response committed before the body was fully read:\n%s", out)
+	}
+	// Positive proof the decode completed and the stream reached post-decode
+	// logic — guards against the tripwire silently never engaging.
+	if !strings.Contains(out, "ANTHROPIC_API_KEY not configured") {
+		t.Fatalf("stream never reached post-decode logic:\n%s", out)
+	}
+	if !committed.Load() {
+		t.Fatal("handler wrote no response at all")
 	}
 }

--- a/src/packages/api/plan_integration_test.go
+++ b/src/packages/api/plan_integration_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -709,4 +710,66 @@ func TestPlanSummaryPrependedBelowThreshold(t *testing.T) {
 	if !strings.HasPrefix(first, "Summary of the conversation so far") || !strings.Contains(first, "one vegetarian") {
 		t.Fatalf("first streamed message is not the summary: %q", first)
 	}
+}
+
+// The exact wire shape the Dart client emits (plan_service.dart builds the
+// top-level object; plan_provider.dart builds each message map), pinned as
+// raw hand-written JSON. Every other /plan test round-trips the server's own
+// PlanRequest struct, which can never catch client/server field-name or
+// nesting drift — this one can (2026-08-12 prod incident postmortem gap).
+func TestPlanWireShapeFromDartClient(t *testing.T) {
+	resetDB(t)
+
+	postRaw := func(t *testing.T, raw, token string) *httptest.ResponseRecorder {
+		t.Helper()
+		req := httptest.NewRequest("POST", "/api/v1/plan", strings.NewReader(raw))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("X-Forwarded-For", nextTestIP())
+		if token != "" {
+			req.Header.Set("Authorization", "Bearer "+token)
+		}
+		rec := httptest.NewRecorder()
+		testRouter.ServeHTTP(rec, req)
+		return rec
+	}
+
+	assertCleanStream := func(t *testing.T, rec *httptest.ResponseRecorder, answer string) {
+		t.Helper()
+		if rec.Code != http.StatusOK {
+			t.Fatalf("/plan = %d, want 200", rec.Code)
+		}
+		events := planEvents(t, rec.Body.String())
+		if errs := eventsOfType(events, "error"); len(errs) != 0 {
+			t.Fatalf("stream has error events: %v", errs)
+		}
+		if got := joinedText(events); got != answer {
+			t.Fatalf("streamed text = %q, want %q", got, answer)
+		}
+	}
+
+	t.Run("anonymous chat with display_label", func(t *testing.T) {
+		const answer = "Athens it is."
+		newFakeAnthropic(t, textTurn(answer))
+		raw := `{"messages":[{"role":"user","content":"plan a day in Athens","display_label":"Near me: 37.9838, 23.7275"}],"chat_id":"` + uuid.NewString() + `"}`
+		assertCleanStream(t, postRaw(t, raw, ""), answer)
+	})
+
+	t.Run("authed trip-bound refine", func(t *testing.T) {
+		u, token := createTestUser(t, "wire-shape@example.com")
+		trip := createTestTrip(t, u.ID, 2)
+		const answer = "Day 2 relaxed."
+		newFakeAnthropic(t, textTurn(answer))
+		raw := fmt.Sprintf(`{"messages":[{"role":"user","content":"make day 2 more relaxed"}],"chat_id":%q,"trip_id":%q}`,
+			uuid.NewString(), trip.ID.String())
+		assertCleanStream(t, postRaw(t, raw, token), answer)
+	})
+
+	t.Run("chat with image attachment", func(t *testing.T) {
+		const answer = "That looks like the Acropolis."
+		newFakeAnthropic(t, textTurn(answer))
+		// 1x1 transparent PNG, base64 without a data: URI prefix — exactly how
+		// plan_provider.dart serializes attachment bytes.
+		raw := `{"messages":[{"role":"user","content":"where is this?","images":[{"media_type":"image/png","data":"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg=="}]}],"chat_id":"` + uuid.NewString() + `"}`
+		assertCleanStream(t, postRaw(t, raw, ""), answer)
+	})
 }


### PR DESCRIPTION
## Summary
- **Prod-down hotfix**: every chat request failed instantly with the SSE error `invalid request body`. Root cause is b476b79's two interacting halves: the handler flushed `: stream-open` (committing the response) *before* decoding the request body, and the dedicated nginx `/plan` lane set `proxy_request_buffering off` — nginx stops relaying a request body once the upstream responds, so the decoder read EOF on every body that arrived after the headers (i.e. everything through Cloudflare; loopback dev and buffered `httptest` bodies never hit it).
- `plan_handler.go`: fully consume the body (`io.ReadAll`) **before** the first response write, log the previously-discarded decode error, and state the ordering invariant at the point of enforcement. Stream-open still precedes all DB/model work.
- Both nginx `/plan` lanes (deployment snippet + dev conf): `proxy_request_buffering on`, explicit with the incident rationale. Either half alone kills the bug; buffering also stops the lane racing Go's 15s `ReadTimeout` on slow uploads and keeps POST bodies replayable across stale keepalive upstream connections.
- Regression tests for both blind spots that let this through: `TestPlanHandlerReadsBodyBeforeFirstWrite` simulates the proxy relay-cut (verified failing against the old ordering), `TestPlanWireShapeFromDartClient` pins the exact raw Dart-client JSON instead of round-tripping Go structs.

## Testing
- `go vet` + `gofmt` clean; full `go test -race ./...` green including the DB-gated suite.
- Invariant test confirmed **failing** pre-fix (reproduces `: stream-open` + `invalid request body`) and passing post-fix.
- End-to-end through a real nginx gateway with a delayed-body probe (the Cloudflare arrival shape), zero-cost 61-message payload: broken baseline reproduces the exact prod symptom (same 81-byte error response); Go fix alone passes even against the hostile conf; both halves together pass; `nginx -t` successful.

## Follow-ups (deliberately not in the hotfix)
- `client_body_buffer_size 1m;` on the /plan lanes to keep typical image posts in memory now that buffering is back.
- `specs/perf-program/measurements.md` correction: stream-open now follows the body read; the surviving perf win is priming before validation/DB/model work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)