### PR TITLE
fix(flutter): scroll straight to the focused city — no more up-then-down jank

### DIFF
--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -587,7 +587,10 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
   /// Combined height of the chrome pinned above the itinerary slivers: the
   /// map header (when it renders AND is pinned — on phones the map scrolls
   /// away, so it never rests above a target header) plus the itinerary
-  /// title header.
+  /// title header. This is the resting-slot measurement for the scroll
+  /// helpers' correction passes ONLY — never subtract it from a
+  /// getOffsetToReveal result, which already accounts for these extents
+  /// (`maxScrollObstructionExtentBefore`).
   double _pinnedChrome(Trip trip) {
     final mapShown = _derive(trip).mapShown;
     return ((_mapPinned && mapShown) ? _mapHeaderHeight : 0) +
@@ -725,9 +728,21 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
 
   /// Offset-reveal scroll to [dayKey]'s header (specs/today-mode plan.md,
   /// D1): `ensureVisible` is unreliable under SliverPinnedHeader /
-  /// MultiSliver, so compute the reveal offset, subtract everything pinned
-  /// above the header's resting slot, animate, then run exactly one
-  /// correction pass against the header's actual on-screen position.
+  /// MultiSliver, so compute the reveal offset, animate, then run exactly
+  /// one correction pass against the header's actual on-screen position.
+  ///
+  /// `getOffsetToReveal(target, 0)` already rests the target below the
+  /// viewport-level pinned chrome: it subtracts the summed obstruction of
+  /// the pinned viewport children before the target's sliver
+  /// (`maxScrollObstructionExtentBefore`) — exactly [_pinnedChrome], so
+  /// subtracting that here again would animate 56–420px past the target
+  /// and leave the correction pass to snap back every time (the
+  /// up-then-down jank). Only the city SliverPinnedHeader needs manual
+  /// subtraction: it sits INSIDE the group's SliverPadding→MultiSliver
+  /// viewport child and the obstruction walk never descends into a child
+  /// sliver. (That SliverPadding reporting 0 obstruction is also what
+  /// keeps getOffsetToReveal's isPinned→infinity branch unreachable for
+  /// these targets — don't unwrap it.)
   Future<void> _scrollToDayHeader(String dayKey) async {
     final trip = _trip;
     if (!mounted || trip == null || !_scroll.hasClients) return;
@@ -735,8 +750,8 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
     if (target == null || !target.attached) return;
     final viewport = RenderAbstractViewport.maybeOf(target);
     if (viewport == null) return;
-    final resting = _pinnedChrome(trip) + _cityHeaderHeight(dayKey);
-    final reveal = viewport.getOffsetToReveal(target, 0).offset - resting;
+    final reveal = viewport.getOffsetToReveal(target, 0).offset -
+        _cityHeaderHeight(dayKey);
     final offset = reveal.clamp(0.0, _scroll.position.maxScrollExtent);
     await _scroll.animateTo(offset,
         duration: const Duration(milliseconds: 350),
@@ -849,7 +864,11 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
 
   /// Offset-reveal scroll resting [cityKey]'s header just below the pinned
   /// chrome — [_scrollToDayHeader] minus the city-header term (this header
-  /// IS the target). Same one-correction contract.
+  /// IS the target; the chrome rests via getOffsetToReveal's own
+  /// obstruction handling, see there). Same one-correction contract. The
+  /// accordion collapse of the previously open group in the same tap frame
+  /// is deliberately uncompensated: with the animation running straight at
+  /// the target it reads as a collapse, not as scroll misbehavior.
   Future<void> _scrollToCityHeader(String cityKey) async {
     final trip = _trip;
     if (!mounted || trip == null || !_scroll.hasClients) return;
@@ -858,8 +877,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
     if (target == null || !target.attached) return;
     final viewport = RenderAbstractViewport.maybeOf(target);
     if (viewport == null) return;
-    final resting = _pinnedChrome(trip);
-    final reveal = viewport.getOffsetToReveal(target, 0).offset - resting;
+    final reveal = viewport.getOffsetToReveal(target, 0).offset;
     final offset = reveal.clamp(0.0, _scroll.position.maxScrollExtent);
     await _scroll.animateTo(offset,
         duration: const Duration(milliseconds: 350),

--- a/src/packages/flutter-app/test/trip_detail_leg_focus_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_leg_focus_test.dart
@@ -192,6 +192,65 @@ void main() {
         reason: 'Rome header should rest below map band + tab row');
   });
 
+  testWidgets(
+      'chip tap scrolls straight to the target: no up-then-down reversal',
+      (tester) async {
+    _useSurface(tester, const Size(1200, 800));
+    await _pump(tester, _threeCityTrip());
+
+    // Open Rome (8 items) for scroll extent, then park at the very bottom.
+    // The regression only shows on a net-upward scroll: from the top the
+    // buggy motion (animate clamped at ~0, one down-snap) was still
+    // monotone and the resting assert above passed all along.
+    await _tapChip(tester, 'Rome');
+    final scrollable = find
+        .descendant(
+            of: find.byType(CustomScrollView),
+            matching: find.byType(Scrollable))
+        .first;
+    final position = tester.state<ScrollableState>(scrollable).position;
+    position.jumpTo(position.maxScrollExtent);
+    await tester.pumpAndSettle();
+    final start = position.pixels;
+
+    // Tap Paris WITHOUT settling, then sample the scroll frame by frame:
+    // double-subtracting the pinned chrome animated ~420px past the target
+    // and let the correction pass snap back down — a direction reversal
+    // mid-gesture.
+    await tester.tap(find.descendant(
+        of: find.byType(MapLegChips), matching: find.text('Paris')));
+    final samples = <double>[];
+    for (var i = 0; i < 12; i++) {
+      await tester.pump(const Duration(milliseconds: 50));
+      samples.add(position.pixels);
+    }
+    await tester.pumpAndSettle();
+    samples.add(position.pixels);
+
+    expect(samples.last, lessThan(start),
+        reason: 'premise: the Paris rest offset must sit above the parked '
+            'bottom position — otherwise this scenario went vacuous');
+    var maxRise = 0.0;
+    for (var i = 1; i < samples.length; i++) {
+      final rise = samples[i] - samples[i - 1];
+      if (rise > maxRise) maxRise = rise;
+    }
+    expect(maxRise, lessThanOrEqualTo(2),
+        reason: 'a net-upward scroll must never move back down '
+            '(up-then-down jank); from $start: $samples');
+
+    // And it still lands exactly: Paris rests below the pinned chrome.
+    final viewportTop = tester.getBottomLeft(find.byType(AppBar)).dy;
+    final headerTop = tester
+        .getTopLeft(find
+            .ancestor(
+                of: cityHeaderLabel('Paris'), matching: find.byType(Material))
+            .first)
+        .dy;
+    expect((headerTop - (viewportTop + 420)).abs(), lessThanOrEqualTo(2),
+        reason: 'Paris header should rest below map band + tab row');
+  });
+
   testWidgets('the All chip deselects both ways: map to All, group closed',
       (tester) async {
     _useSurface(tester, const Size(1200, 800));

--- a/src/packages/flutter-app/test/trip_detail_today_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_today_test.dart
@@ -182,6 +182,50 @@ void main() {
     expect(pillDy, lessThan(viewportTop + 100 + 120));
   });
 
+  testWidgets('the Today chip from deep in the list scrolls monotonically',
+      (WidgetTester tester) async {
+    await _pumpScreen(
+        tester, _FakeTripsApiService(_liveTrip(startDate: start, endDate: end)));
+
+    // Park at the very bottom; today's (day 2) header sits well above it.
+    // This is the map-hidden chrome configuration (56px tab row only) —
+    // the phone-reachable scroll path.
+    final position = _position(tester);
+    position.jumpTo(position.maxScrollExtent);
+    await tester.pumpAndSettle();
+    final parked = position.pixels;
+
+    // Tap WITHOUT settling and sample the scroll frame by frame: double-
+    // subtracting the pinned chrome animated 56px past the target and let
+    // the correction pass snap back down — a direction reversal.
+    await tester.tap(_todayChip());
+    final samples = <double>[];
+    for (var i = 0; i < 12; i++) {
+      await tester.pump(const Duration(milliseconds: 50));
+      samples.add(position.pixels);
+    }
+    await tester.pumpAndSettle();
+    samples.add(position.pixels);
+
+    expect(samples.last, lessThan(parked),
+        reason: "premise: today's rest offset must sit above the parked "
+            'bottom position — otherwise this scenario went vacuous');
+    var maxRise = 0.0;
+    for (var i = 1; i < samples.length; i++) {
+      final rise = samples[i] - samples[i - 1];
+      if (rise > maxRise) maxRise = rise;
+    }
+    expect(maxRise, lessThanOrEqualTo(2),
+        reason: 'a net-upward scroll must never move back down '
+            '(up-then-down jank); from $parked: $samples');
+
+    // And it still lands in the resting window the first test pins down.
+    final viewportTop = tester.getTopLeft(find.byType(CustomScrollView)).dy;
+    final pillDy = tester.getTopLeft(_todayPill()).dy;
+    expect(pillDy, greaterThan(viewportTop + 100));
+    expect(pillDy, lessThan(viewportTop + 100 + 120));
+  });
+
   testWidgets('a trip that ended yesterday gets no Today behavior',
       (WidgetTester tester) async {
     final trip = _liveTrip(


### PR DESCRIPTION
## Summary
- Clicking a destination chip (or the Today chip) from deep in the list scrolled **up past the target, then snapped back down** — a jerky direction reversal on every net-upward scroll.
- Root cause: `_scrollToDayHeader`/`_scrollToCityHeader` subtracted `_pinnedChrome` from `getOffsetToReveal(...)`'s result, but that API already rests the target below the viewport-level pinned chrome (`maxScrollObstructionExtentBefore`) — the double subtraction overshot by 56–420 px and left the one-correction pass to snap back every time.
- Fix: drop the double subtraction; only the city `SliverPinnedHeader` (inside the group's `MultiSliver` child, invisible to the obstruction walk) keeps a manual term. `_pinnedChrome` stays as the correction pass's resting-slot measurement only, with doc comments pinning the invariant.

## Testing
- Two new frame-sampling regression tests: park at the bottom, tap without settling, sample every 50 ms — assert no frame-to-frame rise >2 px (monotone motion) AND exact landing, for both the destination-chip path (`trip_detail_leg_focus_test.dart`) and the Today-chip / map-hidden path (`trip_detail_today_test.dart`). Both were red against the old code.
- Full `make flutter-test` green (874 tests); `flutter analyze` — only 3 pre-existing infos in `route_response.dart`, untouched here.
- Browser-verified on the dev stack (desktop 1440×1000, headless Chrome screencast): chip tap from parked-at-bottom animates monotonically to the target header, rests just below the pinned map band, position pixel-stable afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)