### PR TITLE
fix(api): absorb the trip-detail boot burst — rate limiter sizing, keepalive race, Duffel cache pinning

### DIFF
--- a/dockerize/deployment/nginx/perf.conf
+++ b/dockerize/deployment/nginx/perf.conf
@@ -32,4 +32,10 @@ gzip_types
 upstream api_backend {
     server api:8080;
     keepalive 16;
+    # Close pooled connections well before the Go API's IdleTimeout (120s,
+    # startServer in main.go) so nginx never dispatches a request onto a
+    # connection the upstream is closing. The nginx default (60s) matched
+    # Go's old 60s exactly — the simultaneous expiry raced into intermittent
+    # "upstream prematurely closed connection" 502s after idle gaps.
+    keepalive_timeout 55s;
 }

--- a/src/packages/api/duffel_service.go
+++ b/src/packages/api/duffel_service.go
@@ -287,7 +287,14 @@ func (d *DuffelService) placeSuggestions(ctx context.Context, params url.Values)
 			Longitude: p.Longitude,
 		})
 	}
-	d.placesCache.set(cacheKey, airports)
+	// Only cache non-empty results: entries live 24h, so a transient Duffel
+	// hiccup that answers 200-with-empty (or with only IATA-less entries,
+	// filtered above) must not pin "no such airport" for a day — that reads
+	// as a missing home-airport pin for every user resolving that code.
+	// Genuine no-match queries are rare and cheap to re-ask.
+	if len(airports) > 0 {
+		d.placesCache.set(cacheKey, airports)
+	}
 	return airports, nil
 }
 

--- a/src/packages/api/duffel_service_test.go
+++ b/src/packages/api/duffel_service_test.go
@@ -230,6 +230,86 @@ func TestSearchFlightOffersDefaultsToEconomy(t *testing.T) {
 	}
 }
 
+// A 200-with-empty places answer must not be cached: entries live 24h, and
+// pinning a transient empty payload would erase an airport (and the trip
+// map's home-airport pin) for a day, for every user resolving that code.
+// Non-empty results ARE cached.
+func TestPlaceSuggestionsDoesNotCacheEmptyResults(t *testing.T) {
+	var hits int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		w.Header().Set("Content-Type", "application/json")
+		if hits <= 2 {
+			w.Write([]byte(`{"data":[]}`))
+			return
+		}
+		w.Write([]byte(`{"data":[{"type":"airport","name":"Los Angeles International Airport","iata_code":"LAX","city_name":"Los Angeles","iata_country_code":"US","latitude":33.9425,"longitude":-118.408}]}`))
+	}))
+	t.Cleanup(srv.Close)
+	d := &DuffelService{
+		Token:       "test-token",
+		BaseURL:     srv.URL,
+		Version:     "v2",
+		Client:      &http.Client{Timeout: 5 * time.Second},
+		placesCache: newTTLCache[[]Airport](time.Minute, 10),
+	}
+
+	ctx := context.Background()
+	if got, err := d.SearchAirports(ctx, "LAX"); err != nil || len(got) != 0 {
+		t.Fatalf("first call = %v, %v; want empty success", got, err)
+	}
+	// The empty answer was not cached: the second call reaches upstream again.
+	if _, err := d.SearchAirports(ctx, "LAX"); err != nil {
+		t.Fatalf("second call: %v", err)
+	}
+	if hits != 2 {
+		t.Fatalf("upstream hits after two empty rounds = %d, want 2", hits)
+	}
+	// The third call gets a real result...
+	if got, err := d.SearchAirports(ctx, "LAX"); err != nil || len(got) != 1 {
+		t.Fatalf("third call = %v, %v; want the LAX row", got, err)
+	}
+	// ...which IS cached: a fourth call must not touch upstream.
+	if _, err := d.SearchAirports(ctx, "LAX"); err != nil {
+		t.Fatalf("fourth call: %v", err)
+	}
+	if hits != 3 {
+		t.Fatalf("upstream hits = %d, want 3 (non-empty result served from cache)", hits)
+	}
+}
+
+// A Duffel upstream failure must answer 502 with a JSON body: the old
+// http.Error(500, text/plain) read as our fault rather than the provider's,
+// and clients treat 502 on a GET as retryable.
+func TestAirportsSearchHandlerDuffelFailureIs502JSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "duffel exploded", http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+	old := duffelService
+	duffelService = &DuffelService{
+		Token:       "test-token",
+		BaseURL:     srv.URL,
+		Version:     "v2",
+		Client:      &http.Client{Timeout: 5 * time.Second},
+		placesCache: newTTLCache[[]Airport](time.Minute, 10),
+	}
+	t.Cleanup(func() { duffelService = old })
+
+	rec := httptest.NewRecorder()
+	airportsSearchHandler(rec, httptest.NewRequest(http.MethodGet, "/api/v1/flights/airports?q=LAX", nil))
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); !strings.Contains(ct, "application/json") {
+		t.Fatalf("Content-Type = %q, want application/json", ct)
+	}
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("502 body is not JSON (%v): %s", err, rec.Body.String())
+	}
+}
+
 func TestPlaceSuggestionsCarriesCoordinates(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/src/packages/api/main.go
+++ b/src/packages/api/main.go
@@ -318,9 +318,12 @@ func airportsSearchHandler(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		// Duffel's key travels in a header (no URL leak), but its error
 		// strings can echo upstream response bodies — same policy: log the
-		// detail, answer generically.
+		// detail, answer generically. 502, not 500: the failure is the
+		// upstream provider's, clients treat 502 on a GET as retryable, and
+		// writeJSONError keeps the Content-Type set above honest
+		// (http.Error overwrote it with text/plain).
 		ctxLog(r.Context()).Error("airport search failed", "error", err)
-		http.Error(w, "Failed to search airports", http.StatusInternalServerError)
+		writeJSONError(w, http.StatusBadGateway, "airport search unavailable")
 		return
 	}
 
@@ -598,6 +601,23 @@ func main() {
 // buildRouter wires all routes and middleware. It reads only package globals
 // (dbPool, service singletons), so main() and the integration tests construct
 // identical routers.
+// generalRate* size the per-IP backstop bucket against the app's own boot
+// fan-out, not against abuse: a cold boot onto a trip-detail page fires ~15
+// fixed API calls plus ~5 per city (weather, local recs, guides, events,
+// greece-links), and each /places/photo also debits this bucket (tier buckets
+// are additive) — a 10-city trip is ~90 requests in 1-3s. Burst 180 = two
+// back-to-back hard refreshes with zero refill headroom; 120/min (2 tokens/s)
+// restores a full boot's budget in ~45s while still capping sustained abuse
+// at 2 rps/IP (the strict/photo/transcribe/oauth/import tiers and the
+// concurrency shedder are unchanged). The prod realip chain keys the bucket
+// per end user; if shared-NAT contention ever shows in rate_limited_total,
+// the escalation is per-user keying for authenticated requests, not a bigger
+// burst. Sizing pinned by TestGeneralLimiterAbsorbsColdBootBurst.
+const (
+	generalRatePerMinute = 120
+	generalRateBurst     = 180
+)
+
 func buildRouter() *mux.Router {
 	router := mux.NewRouter()
 
@@ -615,7 +635,7 @@ func buildRouter() *mux.Router {
 	// Rate limiting: a general per-IP cap on everything, plus a strict tier
 	// on the endpoints that are expensive (AI streaming) or brute-forceable
 	// (credentials). Health checks stay exempt for container probes.
-	generalLimiter := newIPRateLimiter(60, 30)
+	generalLimiter := newIPRateLimiter(generalRatePerMinute, generalRateBurst)
 	strictLimiter := newIPRateLimiter(5, 3)
 	strict := rateLimitMiddleware(strictLimiter)
 	// Anonymous analytics gets its own bucket: sharing the strict one would let
@@ -626,16 +646,20 @@ func buildRouter() *mux.Router {
 	anonEvents := rateLimitMiddleware(anonEventsLimiter)
 	router.Use(requestIDMiddleware)
 	router.Use(recoveryMiddleware)
-	// Global concurrency ceiling (abuse_caps.go): a single Pi instance with
-	// WriteTimeout:0 (needed for SSE) has no cap on concurrent in-flight
-	// requests, so a burst could swamp it. Shed excess load early — right after
-	// recovery/requestID — with a non-blocking 503 + Retry-After (/health is
-	// exempt so probes still answer under saturation).
-	router.Use(newConcurrencyLimiter(maxInflightRequests()).middleware)
 	// metricsMiddleware sits right after recovery so it times the full handler
 	// (recovered panics count as the 500 they return) and folds each request
-	// into the in-process opsMetrics registry (ops_metrics.go).
+	// into the in-process opsMetrics registry (ops_metrics.go). It must wrap
+	// the concurrency shedder below: registered the other way round, shed
+	// 503s never reached the metrics layer and were invisible to the ops
+	// view.
 	router.Use(metricsMiddleware)
+	// Global concurrency ceiling (abuse_caps.go): a single small instance
+	// with WriteTimeout:0 (needed for SSE) has no cap on concurrent in-flight
+	// requests, so a burst could swamp it. Shed excess load early — before
+	// any per-request work beyond metrics — with a non-blocking 503 +
+	// Retry-After (/health is exempt so probes still answer under
+	// saturation).
+	router.Use(newConcurrencyLimiter(maxInflightRequests()).middleware)
 	router.Use(corsMiddleware)
 	// Negotiates the response language for every route, including the public
 	// token-gated exports that have no session to read a stored locale from
@@ -906,7 +930,13 @@ func startServer(router *mux.Router) {
 		Handler:      router,
 		ReadTimeout:  15 * time.Second,
 		WriteTimeout: 0,
-		IdleTimeout:  60 * time.Second,
+		// Must strictly exceed the nginx gateway's upstream keepalive idle
+		// (keepalive_timeout 55s, dockerize/deployment/nginx/perf.conf) so
+		// nginx always closes pooled connections first. When both sides
+		// idled out at exactly 60s, nginx could dispatch a request onto a
+		// connection Go was simultaneously closing — intermittent "upstream
+		// prematurely closed connection" 502s after idle gaps.
+		IdleTimeout: 120 * time.Second,
 	}
 
 	log.Printf("Starting Travel Route Planner API server on port %s", port)

--- a/src/packages/api/ops_metrics.go
+++ b/src/packages/api/ops_metrics.go
@@ -306,6 +306,9 @@ func upstreamCountsSnapshot() map[string]int64 {
 		m["serpapi_flights_upstream"] = serpapiFlights.calls.upstream.Load()
 		m["serpapi_flights_cache_hits"] = serpapiFlights.calls.cacheHits.Load()
 	}
+	// The only 429-specific signal: per-route request counts fold 429 into
+	// the generic 4xx class (ratelimit.go).
+	m["rate_limited_total"] = rateLimited429s.Load()
 	ai := aiHealth.state()
 	m["ai_success_total"] = ai.SuccessTotal
 	m["ai_transient_total"] = ai.TransientTotal

--- a/src/packages/api/ops_metrics_test.go
+++ b/src/packages/api/ops_metrics_test.go
@@ -239,6 +239,51 @@ func TestUpstreamCountsIncludeAIHealth(t *testing.T) {
 	}
 }
 
+func TestUpstreamCountsIncludeRateLimitedTotal(t *testing.T) {
+	before := upstreamCountsSnapshot()["rate_limited_total"]
+	rateLimited429s.Add(1)
+	if after := upstreamCountsSnapshot()["rate_limited_total"]; after != before+1 {
+		t.Fatalf("rate_limited_total = %d then %d, want +1", before, after)
+	}
+}
+
+// Shed 503s must be visible in ops metrics: buildRouter registers
+// metricsMiddleware BEFORE the concurrency shedder, so a request rejected by
+// the semaphore is still timed and recorded. This mirrors that order.
+func TestShed503IsRecordedByMetricsMiddleware(t *testing.T) {
+	router := mux.NewRouter()
+	router.Use(metricsMiddleware)
+	router.Use(newConcurrencyLimiter(1).middleware)
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	parked := make(chan struct{})
+	router.HandleFunc("/api/v1/busy", func(w http.ResponseWriter, r *http.Request) {
+		entered <- struct{}{}
+		<-release
+		w.WriteHeader(http.StatusOK)
+	})
+
+	// Occupy the single slot with a request parked inside the handler.
+	go func() {
+		defer close(parked)
+		router.ServeHTTP(httptest.NewRecorder(),
+			httptest.NewRequest(http.MethodGet, "/api/v1/busy", nil))
+	}()
+	<-entered
+
+	before := opsMetrics.snapshot().Requests.ByClass["5xx"]
+	shed := httptest.NewRecorder()
+	router.ServeHTTP(shed, httptest.NewRequest(http.MethodGet, "/api/v1/busy", nil))
+	if shed.Code != http.StatusServiceUnavailable {
+		t.Fatalf("second request = %d, want 503", shed.Code)
+	}
+	if after := opsMetrics.snapshot().Requests.ByClass["5xx"]; after != before+1 {
+		t.Fatalf("5xx count = %d then %d; the shed 503 must be recorded", before, after)
+	}
+	close(release)
+	<-parked
+}
+
 // TestOpsMetricsEndpoint is the DB-backed admin auth path: an admin token gets
 // 200 + the expected shape; a non-admin gets 403.
 func TestOpsMetricsEndpoint(t *testing.T) {

--- a/src/packages/api/ratelimit.go
+++ b/src/packages/api/ratelimit.go
@@ -2,10 +2,13 @@ package main
 
 import (
 	"log"
+	"math"
 	"net"
 	"net/http"
+	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"golang.org/x/time/rate"
@@ -25,17 +28,28 @@ type ipRateLimiter struct {
 	entries map[string]*ipLimiterEntry
 	rate    rate.Limit
 	burst   int
+	// Seconds until one token refills at this bucket's rate — the honest
+	// Retry-After for a 429. A blanket "60" taught clients to give up on
+	// buckets that refill in a second.
+	retryAfter string
 }
 
 func newIPRateLimiter(perMinute float64, burst int) *ipRateLimiter {
 	l := &ipRateLimiter{
-		entries: make(map[string]*ipLimiterEntry),
-		rate:    rate.Limit(perMinute / 60.0),
-		burst:   burst,
+		entries:    make(map[string]*ipLimiterEntry),
+		rate:       rate.Limit(perMinute / 60.0),
+		burst:      burst,
+		retryAfter: strconv.Itoa(int(math.Max(1, math.Ceil(60.0/perMinute)))),
 	}
 	go l.janitor()
 	return l
 }
+
+// rateLimited429s counts every 429 served across all buckets. It is the only
+// unambiguous "the limiter fired" signal in /admin/ops/metrics
+// (rate_limited_total): the per-route request counts fold 429 into a generic
+// 4xx class alongside 401/404.
+var rateLimited429s atomic.Int64
 
 func (l *ipRateLimiter) allow(ip string) bool {
 	l.mu.Lock()
@@ -88,8 +102,9 @@ func rateLimitMiddleware(l *ipRateLimiter) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if !l.allow(clientIP(r)) {
+				rateLimited429s.Add(1)
 				log.Printf("rate limited %s %s from %s", r.Method, r.URL.Path, clientIP(r))
-				w.Header().Set("Retry-After", "60")
+				w.Header().Set("Retry-After", l.retryAfter)
 				writeJSONError(w, http.StatusTooManyRequests, "rate limited; retry shortly")
 				return
 			}

--- a/src/packages/api/ratelimit_test.go
+++ b/src/packages/api/ratelimit_test.go
@@ -51,12 +51,64 @@ func TestRateLimitMiddlewareReturns429(t *testing.T) {
 		t.Fatalf("first request status = %d, want 200", first.Code)
 	}
 
+	before := rateLimited429s.Load()
 	second := httptest.NewRecorder()
 	handler.ServeHTTP(second, httptest.NewRequest(http.MethodGet, "/", nil))
 	if second.Code != http.StatusTooManyRequests {
 		t.Fatalf("second request status = %d, want 429", second.Code)
 	}
-	if second.Header().Get("Retry-After") == "" {
-		t.Fatal("429 response should carry Retry-After")
+	// 60/min refills one token per second — Retry-After must say so, not the
+	// old blanket "60".
+	if got := second.Header().Get("Retry-After"); got != "1" {
+		t.Fatalf("Retry-After = %q, want \"1\"", got)
+	}
+	if rateLimited429s.Load() != before+1 {
+		t.Fatal("a served 429 must increment rateLimited429s")
+	}
+}
+
+// TestGeneralLimiterAbsorbsColdBootBurst pins the general bucket's sizing to
+// the load it exists to absorb (see the generalRate* comment in main.go): two
+// back-to-back hard refreshes of a 10-city trip-detail page ≈ 175 requests
+// with no meaningful refill in between. If this fails after a resize, the
+// boot fan-out no longer fits and real page loads will shed.
+func TestGeneralLimiterAbsorbsColdBootBurst(t *testing.T) {
+	l := newIPRateLimiter(generalRatePerMinute, generalRateBurst)
+	for i := 0; i < 175; i++ {
+		if !l.allow("203.0.113.1") {
+			t.Fatalf("request %d of a double cold boot should pass (burst %d)",
+				i+1, generalRateBurst)
+		}
+	}
+	// The abuse backstop must still exist: a sustained flood past the burst
+	// gets shed.
+	blocked := false
+	for i := 0; i < 30; i++ {
+		if !l.allow("203.0.113.1") {
+			blocked = true
+			break
+		}
+	}
+	if !blocked {
+		t.Fatal("sustained flood past the burst must eventually be rate limited")
+	}
+}
+
+// Retry-After must reflect each bucket's actual refill rate: seconds until
+// one token becomes available.
+func TestRetryAfterDerivedFromRefillRate(t *testing.T) {
+	cases := []struct {
+		perMinute float64
+		want      string
+	}{
+		{120, "1"}, // general (2 tokens/s)
+		{40, "2"},  // photo tier
+		{10, "6"},  // transcribe / anon-events tiers
+		{5, "12"},  // strict tier
+	}
+	for _, c := range cases {
+		if got := newIPRateLimiter(c.perMinute, 1).retryAfter; got != c.want {
+			t.Fatalf("retryAfter(%v/min) = %q, want %q", c.perMinute, got, c.want)
+		}
 	}
 }


### PR DESCRIPTION
## Summary
- **Root cause fix for the intermittent hard-refresh failures** ("Could not load this trip", missing home-airport map legs, vanished trip-health icon): a cold boot onto a trip-detail page fires ~15 fixed API calls + ~5 per city (~90 requests in 1-3s on a 10-city trip), while the general per-IP bucket allowed burst 30 — every refresh shed ~50 requests and the losing endpoint picked the symptom.
- Resize `generalLimiter` 60/30 → **120/180** (two back-to-back cold boots with zero refill headroom; 2 rps sustained abuse backstop unchanged elsewhere). Sizing arithmetic lives on the new `generalRate*` consts and is pinned by `TestGeneralLimiterAbsorbsColdBootBurst`.
- `Retry-After` on 429s is now derived from each bucket's refill rate (general "1", strict "12") instead of a blanket "60".
- New `rate_limited_total` counter in `/admin/ops/metrics` — the only unambiguous 429 signal (per-route counts fold 429 into generic 4xx) — and `metricsMiddleware` now wraps the concurrency shedder so shed 503s are recorded per-route.
- **Keepalive race fix** (intermittent post-idle 502s): Go `IdleTimeout` 60s → 120s and nginx upstream `keepalive_timeout 55s;` — both sides previously idled out at exactly 60s, so nginx could dispatch onto a connection Go was closing ("upstream prematurely closed connection").
- **Duffel hardening**: a 200-with-empty places answer is no longer cached for 24h (it pinned "no such airport" — and a missing home-airport pin — for a day, process-wide); the airports handler answers a JSON **502** on Duffel failure instead of a text/plain 500.

Client-side follow-up lane (bounded retry helper, provider self-heal timers, cached-trip fallback, `setState` fix) is planned separately and waits on #350 (trip_detail_screen.dart contention).

## Testing
- `go vet ./...` clean; `gofmt` clean.
- `go test -count=1 ./...` green.
- New tests: `TestGeneralLimiterAbsorbsColdBootBurst` (sizing pin), `TestRetryAfterDerivedFromRefillRate`, 429-counter assertion in `TestRateLimitMiddlewareReturns429`, `TestPlaceSuggestionsDoesNotCacheEmptyResults`, `TestAirportsSearchHandlerDuffelFailureIs502JSON`, `TestUpstreamCountsIncludeRateLimitedTotal`, `TestShed503IsRecordedByMetricsMiddleware`.
- Prod verification plan: hard-refresh the 10-city trip twice rapidly with DevTools open (expect zero 429/502, home legs + health icon present), `rate_limited_total` ≈ 0 under normal use, gateway logs free of "upstream prematurely closed connection" after an idle gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)