### PR TITLE
fix(flutter): value-equal AppCameraFitBounds — stop resetting the map controller on every rebuild

### DIFF
--- a/src/packages/flutter-app/lib/screens/local_guide_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/local_guide_detail_screen.dart
@@ -380,7 +380,7 @@ class _GuideMapState extends State<_GuideMap> {
                     interactionOptions: interaction,
                   )
                 : appMapOptions(
-                    initialCameraFit: CameraFit.bounds(
+                    initialCameraFit: AppCameraFitBounds(
                       bounds: LatLngBounds.fromPoints(points),
                       padding: const EdgeInsets.all(32),
                     ),

--- a/src/packages/flutter-app/lib/widgets/app_map.dart
+++ b/src/packages/flutter-app/lib/widgets/app_map.dart
@@ -83,12 +83,17 @@ class AppMapCrs extends Crs {
 
 /// Shared [MapOptions] for every [FlutterMap] in the app: single-world
 /// rendering, the space-dark backdrop, and a camera that can't wander off the
-/// planet. Callers pass whichever framing they have — a center+zoom or a
-/// [CameraFit] — plus their interaction flags.
+/// planet. Callers pass whichever framing they have — a center+zoom or an
+/// [AppCameraFitBounds] — plus their interaction flags.
+///
+/// The fit parameter is deliberately the value-equal [AppCameraFitBounds],
+/// not the raw [CameraFit]: a raw fit compares by identity, which silently
+/// breaks the `MapOptions.==` short-circuit this helper exists to enable
+/// (see [AppCameraFitBounds]).
 MapOptions appMapOptions({
   LatLng? initialCenter,
   double? initialZoom,
-  CameraFit? initialCameraFit,
+  AppCameraFitBounds? initialCameraFit,
   double minZoom = 1,
   required InteractionOptions interactionOptions,
 }) {
@@ -181,6 +186,47 @@ class AppMapCameraConstraint extends CameraConstraint {
 
   @override
   int get hashCode => (AppMapCameraConstraint).hashCode;
+}
+
+/// Value-equal [CameraFit.bounds].
+///
+/// flutter_map compares [MapOptions] by value, but a [CameraFit] only by
+/// identity — so a fit constructed fresh each build makes `MapOptions.==`
+/// fail and every rebuild re-runs the map controller's options setter: a new
+/// controller state plus `notifyListeners` through the whole map subtree
+/// (tile, polyline, marker and cluster layers all rebuild for nothing). The
+/// initial fit itself is applied only once per [FlutterMap] state, so equal
+/// inputs producing an equal fit changes no camera behavior.
+///
+/// Wraps rather than subclasses [FitBounds] — its constructor is private —
+/// the same delegation pattern as [AppMapCrs] above. Equality is defined on
+/// exactly the two fields our maps feed the wrapped fit: [bounds] and
+/// [padding].
+@immutable
+class AppCameraFitBounds extends CameraFit {
+  /// The bounds the fitted camera must contain, per [CameraFit.bounds].
+  final LatLngBounds bounds;
+
+  /// Pixel padding around the fitted bounds, per [CameraFit.bounds].
+  final EdgeInsets padding;
+
+  final CameraFit _inner;
+
+  /// Create a value-equal bounds fit.
+  AppCameraFitBounds({required this.bounds, this.padding = EdgeInsets.zero})
+      : _inner = CameraFit.bounds(bounds: bounds, padding: padding);
+
+  @override
+  MapCamera fit(MapCamera camera) => _inner.fit(camera);
+
+  @override
+  bool operator ==(Object other) =>
+      other is AppCameraFitBounds &&
+      bounds == other.bounds &&
+      padding == other.padding;
+
+  @override
+  int get hashCode => Object.hash(bounds, padding);
 }
 
 /// Shared basemap for every map in the app: Esri World Imagery satellite

--- a/src/packages/flutter-app/lib/widgets/trip_map.dart
+++ b/src/packages/flutter-app/lib/widgets/trip_map.dart
@@ -291,7 +291,7 @@ class _TripMapState extends State<TripMap> {
         _controller.move(points.first, 13);
       } else {
         _controller.fitCamera(
-          CameraFit.bounds(
+          AppCameraFitBounds(
             bounds: LatLngBounds.fromPoints(points),
             padding: _fitPadding,
           ),
@@ -642,7 +642,7 @@ class _TripMapState extends State<TripMap> {
                     interactionOptions: interaction,
                   )
                 : appMapOptions(
-                    initialCameraFit: CameraFit.bounds(
+                    initialCameraFit: AppCameraFitBounds(
                       bounds: LatLngBounds.fromPoints(fitPoints),
                       padding: _fitPadding,
                     ),

--- a/src/packages/flutter-app/test/app_camera_fit_bounds_test.dart
+++ b/src/packages/flutter-app/test/app_camera_fit_bounds_test.dart
@@ -1,0 +1,179 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:latlong2/latlong.dart';
+
+import 'package:travel_route_planner/models/itinerary_item.dart';
+import 'package:travel_route_planner/widgets/app_map.dart';
+import 'package:travel_route_planner/widgets/trip_map.dart';
+
+import 'support/l10n_test_app.dart';
+
+// flutter_map's MapOptions.== includes initialCameraFit, but CameraFit has no
+// value equality — so a fit constructed fresh each build made every TripMap
+// rebuild fail the equality check and re-run the controller's options setter
+// (new controller state + notifyListeners → tile/polyline/marker/cluster
+// layers all rebuilt for nothing). AppCameraFitBounds restores the
+// short-circuit by defining == on exactly (bounds, padding). These tests pin
+// the equality contract, fit() delegation parity, and the short-circuit
+// itself: an identical parent re-pump must leave the controller holding the
+// IDENTICAL MapOptions instance.
+
+LatLngBounds _parisRome() => LatLngBounds.fromPoints(const [
+      LatLng(48.8606, 2.3376),
+      LatLng(41.8902, 12.4922),
+    ]);
+
+MapCamera _camera({
+  required double zoom,
+  LatLng center = const LatLng(45, 7),
+  Size size = const Size(900, 240),
+}) =>
+    MapCamera(
+      crs: const AppMapCrs(),
+      center: center,
+      zoom: zoom,
+      rotation: 0,
+      nonRotatedSize: size,
+    );
+
+ItineraryItem _item(int pos, String name, double lat, double lng) =>
+    ItineraryItem(
+      id: 'i$pos',
+      position: pos,
+      name: name,
+      latitude: lat,
+      longitude: lng,
+      category: 'attraction',
+    );
+
+// Far apart (Paris / Rome) so TripMap takes the bounds-fit options branch,
+// never the single-point center+zoom branch.
+final _itemsA = [
+  _item(0, 'Louvre', 48.8606, 2.3376),
+  _item(1, 'Colosseum', 41.8902, 12.4922),
+];
+
+Widget _app(List<ItineraryItem> items) => MaterialApp(
+      localizationsDelegates: testLocalizationsDelegates,
+      home: Scaffold(
+        body: TripMap(
+          items: items,
+          onPinTap: (_) {},
+        ),
+      ),
+    );
+
+MapOptions _liveOptions(WidgetTester tester) =>
+    MapOptions.of(tester.element(find.byType(TileLayer).first));
+
+MapCamera _liveCamera(WidgetTester tester) =>
+    MapCamera.of(tester.element(find.byType(TileLayer).first));
+
+void main() {
+  group('AppCameraFitBounds equality', () {
+    test('equal-but-not-identical inputs compare equal', () {
+      final a = AppCameraFitBounds(
+        bounds: _parisRome(),
+        padding: const EdgeInsets.all(24),
+      );
+      final b = AppCameraFitBounds(
+        bounds: _parisRome(),
+        padding: const EdgeInsets.all(24),
+      );
+      expect(identical(a, b), isFalse);
+      expect(a, equals(b));
+      expect(a.hashCode, b.hashCode);
+    });
+
+    test('differing bounds or padding compare unequal', () {
+      final base = AppCameraFitBounds(
+        bounds: _parisRome(),
+        padding: const EdgeInsets.all(24),
+      );
+      final otherBounds = AppCameraFitBounds(
+        bounds: LatLngBounds.fromPoints(const [
+          LatLng(48.8606, 2.3376),
+          LatLng(41.8986, 12.4769),
+        ]),
+        padding: const EdgeInsets.all(24),
+      );
+      final otherPadding = AppCameraFitBounds(
+        bounds: _parisRome(),
+        padding: const EdgeInsets.all(32),
+      );
+      expect(base == otherBounds, isFalse);
+      expect(base == otherPadding, isFalse);
+    });
+
+    test('a raw CameraFit.bounds is never equal (guards the type boundary)',
+        () {
+      final wrapped = AppCameraFitBounds(bounds: _parisRome());
+      final raw = CameraFit.bounds(bounds: _parisRome());
+      expect(wrapped == raw, isFalse);
+    });
+  });
+
+  group('AppCameraFitBounds.fit', () {
+    test('delegates to CameraFit.bounds — identical resulting camera', () {
+      const padding = EdgeInsets.all(24);
+      final camera = _camera(zoom: 5);
+      final ours =
+          AppCameraFitBounds(bounds: _parisRome(), padding: padding)
+              .fit(camera);
+      final reference =
+          CameraFit.bounds(bounds: _parisRome(), padding: padding).fit(camera);
+      expect(ours.center, reference.center);
+      expect(ours.zoom, reference.zoom);
+    });
+  });
+
+  group('options-setter short-circuit', () {
+    testWidgets(
+        'an identical parent re-pump leaves the controller holding the '
+        'identical MapOptions instance', (tester) async {
+      await tester.pumpWidget(_app(_itemsA));
+      await tester.pump();
+      final before = _liveOptions(tester);
+
+      // Same items list, fresh TripMap widget — before the fix this built an
+      // ==-unequal MapOptions (fresh identity-compared CameraFit) and the
+      // controller adopted it; now didUpdateWidget must short-circuit.
+      await tester.pumpWidget(_app(_itemsA));
+      await tester.pump();
+      expect(identical(_liveOptions(tester), before), isTrue);
+    });
+
+    testWidgets('a real content change still propagates new options',
+        (tester) async {
+      await tester.pumpWidget(_app(_itemsA));
+      await tester.pump();
+      final before = _liveOptions(tester);
+
+      // Athens sits OUTSIDE the Paris–Rome bounding box, so the fit bounds
+      // genuinely change. (An added pin inside the box keeps the bounds —
+      // and, by design, the options — equal.)
+      final itemsB = List.of(_itemsA)
+        ..add(_item(2, 'Acropolis', 37.9715, 23.7267));
+      await tester.pumpWidget(_app(itemsB));
+      await tester.pump();
+      expect(identical(_liveOptions(tester), before), isFalse);
+    });
+
+    testWidgets('rebuild after a user zoom does not move the camera',
+        (tester) async {
+      await tester.pumpWidget(_app(_itemsA));
+      await tester.pump();
+
+      await tester.tap(find.byIcon(Icons.add));
+      await tester.pump();
+      final zoomed = _liveCamera(tester);
+
+      await tester.pumpWidget(_app(_itemsA));
+      await tester.pump();
+      final after = _liveCamera(tester);
+      expect(after.zoom, zoomed.zoom);
+      expect(after.center, zoomed.center);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- flutter_map's `MapOptions.==` includes `initialCameraFit`, but `CameraFit` has no value equality — the fresh `CameraFit.bounds` built on every build made every `TripMap` (and guide-map) rebuild fail the options equality check and re-run the map controller's options setter: new controller state + `notifyListeners` through the whole map subtree (tile, polyline, marker and cluster layers all rebuilt for nothing).
- New `AppCameraFitBounds extends CameraFit` in `app_map.dart` (the file's established wrap-don't-subclass pattern, next to `AppMapCameraConstraint`): delegates `fit()` to a wrapped `CameraFit.bounds`, defines `==`/`hashCode` on exactly (bounds, padding).
- `appMapOptions` now accepts only `AppCameraFitBounds?` (type-enforced boundary per docs/zen.md), so an identity-compared fit can't be reintroduced through the shared helper. All three construction sites swapped (`trip_map.dart` build + `_fitToTrip`, `local_guide_detail_screen.dart`).
- No camera behavior change: the initial fit applies once per `FlutterMap` state regardless; verified in flutter_map 8.3.0 source that the options setter preserves the live camera.

## Testing
- New `test/app_camera_fit_bounds_test.dart` (7 tests): value-equality contract (equal/unequal/raw-fit guard), `fit()` delegation parity with `CameraFit.bounds`, and the short-circuit itself — an identical parent re-pump leaves the controller holding the *identical* `MapOptions` instance, a genuine bounds change (pin outside the old box) still propagates, and a rebuild after a user zoom leaves the camera untouched.
- `flutter test`: full suite green (+905, 0 failures).
- `make flutter-analyze`: no issues in changed files (3 pre-existing `unnecessary_brace_in_string_interps` infos in `lib/models/route_response.dart` date to the initial commit and only appear under the newer local analyzer; CI's pinned Flutter doesn't flag them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)