### PR TITLE
fix(flutter): trip-detail scroll slowdown — instant hover reveal + repaint-isolate pinned chrome

### DIFF
--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -2261,7 +2261,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
       {required bool cityCollapsed}) {
     final l10n = context.l10n;
     final chipStyle = _chipTextStyle(theme);
-    return HoverReveal(
+    final header = HoverReveal(
       builder: (context, revealed) => Material(
         color: theme.scaffoldBackgroundColor,
         child: InkWell(
@@ -2418,6 +2418,11 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
         ),
       ),
     );
+    // Repaint-isolate the header: the open city's header rides pinned over
+    // the scrolling list (and collapsed ones scroll with it), and the hover
+    // setState + InkWell highlight must repaint this header's own layer, not
+    // re-record the viewport picture. Covers pinned and collapsed branches.
+    return RepaintBoundary(child: header);
   }
 
   /// Curated, locally-sourced recommendations for a city group — vetted picks
@@ -3339,7 +3344,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
         ? _fmtDayHeader(tripStart.add(Duration(days: day - 1)))
         : l10n.tripDayN(day);
     final muted = theme.colorScheme.onSurfaceVariant;
-    return HoverReveal(
+    final header = HoverReveal(
       builder: (context, revealed) => Material(
         key: headerKey,
         color: isToday
@@ -3417,6 +3422,9 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
         ),
       ),
     );
+    // Repaint-isolate like _cityHeader: open days pin their header over the
+    // scrolling list; hover/InkWell repaints must stay in this layer.
+    return RepaintBoundary(child: header);
   }
 
   /// Per-day weather chip (specs/weather-in-itinerary): hi/lo temp + a
@@ -4659,7 +4667,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
     // leg-filtered lists come from the derivation's lazy per-leg caches, so
     // a selection-only rebuild passes TripMap the identical lists and its
     // marker cache skips re-clustering.
-    return ListenableBuilder(
+    final card = ListenableBuilder(
       listenable: Listenable.merge([_focusedLegKey, _selectedPosition]),
       builder: (context, _) {
         final focusKey = _clampedLegKey(derivation);
@@ -4775,6 +4783,13 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
         );
       },
     );
+    // Repaint-isolate the card: on the wide layout it sits pinned over the
+    // scrolling itinerary, and without a boundary its picture (card chrome +
+    // chip strip — flutter_map keeps its own internal boundary) is
+    // re-recorded every scroll frame. The boundary also keeps tap-time card
+    // rebuilds from dirtying the page layer. Inside the method so both call
+    // sites (pinned wide band, scroll-away phone card) are covered.
+    return RepaintBoundary(child: card);
   }
 
   /// Read-side clamp for [_focusedLegKey]: a refresh can remove the focused
@@ -6051,10 +6066,17 @@ class _PinnedHeaderDelegate extends SliverPersistentHeaderDelegate {
   @override
   Widget build(
           BuildContext context, double shrinkOffset, bool overlapsContent) =>
-      Container(
-        color: backgroundColor,
-        padding: padding,
-        child: child,
+      // Repaint-isolate the pinned chrome (map band, tab row): while pinned
+      // it would otherwise re-record into the viewport picture every scroll
+      // frame. Child identity is what keeps the layer valid — this method
+      // runs per shrinkOffset change, so never build the child inside it;
+      // always construct it once and pass it in by instance.
+      RepaintBoundary(
+        child: Container(
+          color: backgroundColor,
+          padding: padding,
+          child: child,
+        ),
       );
 
   @override

--- a/src/packages/flutter-app/lib/widgets/hover_reveal.dart
+++ b/src/packages/flutter-app/lib/widgets/hover_reveal.dart
@@ -5,10 +5,15 @@ import 'package:flutter/rendering.dart';
 /// pointer hovers the row, and ALWAYS true when no mouse is connected, so
 /// touch devices keep their controls permanently visible and lose nothing.
 ///
-/// Consumers must hide controls with `AnimatedOpacity` + `IgnorePointer`
-/// (never `Visibility`): opacity preserves layout, so trailing widths don't
-/// jump on hover, drag handles keep stable geometry for reorderable lists,
-/// and widget-test finders still see the icons.
+/// Consumers must hide controls with plain `Opacity` + `IgnorePointer`
+/// (never `Visibility`, never `AnimatedOpacity`): opacity preserves layout,
+/// so trailing widths don't jump on hover, drag handles keep stable geometry
+/// for reorderable lists, and widget-test finders still see the icons. The
+/// INSTANT 0/1 swap is a hard perf requirement, not polish: a mid-fade
+/// fractional opacity forces a saveLayer per row per frame on CanvasKit, and
+/// with a fade every row crossing under a parked cursor during a scroll
+/// starts one — the overlapping fades were the trip-detail progressive
+/// scroll-slowdown bug.
 class HoverReveal extends StatefulWidget {
   final Widget Function(BuildContext context, bool revealed) builder;
 
@@ -52,9 +57,10 @@ class _HoverRevealState extends State<HoverReveal> {
   }
 }
 
-/// The standard wrapper for a hover-revealed control: fades to invisible and
-/// ignores pointers while hidden, but keeps its layout slot (see
-/// [HoverReveal] for why layout must be preserved).
+/// The standard wrapper for a hover-revealed control: instantly invisible and
+/// pointer-ignoring while hidden, but keeps its layout slot (see
+/// [HoverReveal] for why layout must be preserved and why the swap must be
+/// an instant 0/1 — never an animated fade).
 class HoverRevealed extends StatelessWidget {
   final bool revealed;
   final Widget child;
@@ -65,9 +71,8 @@ class HoverRevealed extends StatelessWidget {
   Widget build(BuildContext context) {
     return IgnorePointer(
       ignoring: !revealed,
-      child: AnimatedOpacity(
+      child: Opacity(
         opacity: revealed ? 1 : 0,
-        duration: const Duration(milliseconds: 120),
         child: child,
       ),
     );

--- a/src/packages/flutter-app/test/hover_reveal_test.dart
+++ b/src/packages/flutter-app/test/hover_reveal_test.dart
@@ -1,0 +1,109 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:travel_route_planner/widgets/hover_reveal.dart';
+
+/// HoverReveal/HoverRevealed contract (the trip-detail scroll-slowdown bug):
+///   * hidden controls keep their layout slot (opacity, never Visibility) so
+///     trailing widths and drag geometry never shift and finders see them;
+///   * hidden controls ignore pointers;
+///   * the reveal is an INSTANT 0/1 opacity swap — never an animated fade.
+///     A mid-fade fractional opacity forces a saveLayer per row per frame on
+///     CanvasKit, and with a fade every row crossing under a parked cursor
+///     during a scroll starts one; the overlapping fades made trip-detail
+///     scrolling progressively slower the longer it went on;
+///   * with no mouse connected (touch devices, widget tests) controls are
+///     always revealed.
+void main() {
+  Widget host(Widget child) => MaterialApp(
+        home: Scaffold(body: Center(child: child)),
+      );
+
+  testWidgets('hidden control keeps its layout slot and ignores taps',
+      (tester) async {
+    var pressed = 0;
+    Widget button() => IconButton(
+          icon: const Icon(Icons.more_vert),
+          onPressed: () => pressed++,
+        );
+
+    await tester.pumpWidget(
+        host(HoverRevealed(revealed: true, child: button())));
+    final shownSize = tester.getSize(find.byType(IconButton));
+
+    await tester.pumpWidget(
+        host(HoverRevealed(revealed: false, child: button())));
+    final hiddenSize = tester.getSize(find.byType(IconButton));
+
+    // Same slot whether shown or hidden — layout must never shift on hover.
+    expect(hiddenSize, shownSize);
+
+    // Hidden ⇒ pointer-transparent: the tap lands on nothing.
+    await tester.tap(find.byType(IconButton), warnIfMissed: false);
+    expect(pressed, 0);
+  });
+
+  testWidgets('reveal is an instant 0/1 swap that schedules no animation',
+      (tester) async {
+    await tester.pumpWidget(host(
+      SizedBox(
+        width: 200,
+        height: 48,
+        child: HoverReveal(
+          builder: (context, revealed) => HoverRevealed(
+            revealed: revealed,
+            // Plain child: no InkWell/Material so the only possible ticker
+            // source would be a fade inside HoverRevealed itself.
+            child: const SizedBox.expand(),
+          ),
+        ),
+      ),
+    ));
+
+    Opacity opacity() => tester.widget<Opacity>(find.descendant(
+          of: find.byType(HoverRevealed),
+          matching: find.byType(Opacity),
+        ));
+
+    final gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    await gesture.addPointer(location: Offset.zero);
+    addTearDown(gesture.removePointer);
+    await tester.pump();
+
+    // Mouse connected, pointer away from the region: hidden, exactly 0.
+    expect(opacity().opacity, 0.0);
+
+    // Enter: ONE frame later the control reads exactly 1.0 — no fade, no
+    // implicit-animation ticker left running.
+    await gesture.moveTo(tester.getCenter(find.byType(HoverReveal)));
+    await tester.pump();
+    expect(opacity().opacity, 1.0);
+    expect(find.byType(AnimatedOpacity), findsNothing);
+    expect(tester.binding.transientCallbackCount, 0,
+        reason: 'the reveal must not schedule any animation ticker');
+
+    // Exit: instantly back to exactly 0.0, still no ticker.
+    await gesture.moveTo(Offset.zero);
+    await tester.pump();
+    expect(opacity().opacity, 0.0);
+    expect(tester.binding.transientCallbackCount, 0);
+  });
+
+  testWidgets('no mouse connected (touch) ⇒ always revealed', (tester) async {
+    await tester.pumpWidget(host(
+      HoverReveal(
+        builder: (context, revealed) => HoverRevealed(
+          revealed: revealed,
+          child: const SizedBox(width: 40, height: 40),
+        ),
+      ),
+    ));
+
+    final opacity = tester.widget<Opacity>(find.descendant(
+      of: find.byType(HoverRevealed),
+      matching: find.byType(Opacity),
+    ));
+    expect(opacity.opacity, 1.0);
+  });
+}

--- a/src/packages/flutter-app/test/trip_detail_scroll_perf_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_scroll_perf_test.dart
@@ -1,0 +1,219 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:travel_route_planner/models/trip.dart';
+import 'package:travel_route_planner/models/itinerary_item.dart';
+import 'package:travel_route_planner/services/api_client.dart';
+import 'package:travel_route_planner/services/trips_api_service.dart';
+import 'package:travel_route_planner/providers/trips_provider.dart';
+import 'package:travel_route_planner/screens/trip_detail_screen.dart';
+import 'package:travel_route_planner/widgets/hover_reveal.dart';
+import 'package:travel_route_planner/widgets/map_leg_chips.dart';
+
+import 'support/city_groups.dart';
+import 'support/l10n_test_app.dart';
+
+/// Trip-detail scroll-perf structure (the progressive-slowdown bug, 2026-08):
+/// continuous scrolling got slower the longer it ran because (a) every row
+/// crossing under a parked cursor started a 120ms AnimatedOpacity fade — a
+/// rolling set of saveLayers per frame on CanvasKit — and (b) the pinned
+/// chrome (map band, tab row, city/day headers) had no RepaintBoundary, so
+/// its picture was re-recorded every scroll frame. These tests pin the two
+/// structural fixes:
+///   * no AnimatedOpacity anywhere on the screen — hover reveal is instant;
+///   * the map card, pinned-header chrome, and city/day headers sit behind
+///     RepaintBoundaries (the card's boundary lives INSIDE _mapCard, so both
+///     the pinned wide band and the scroll-away phone card get it).
+void main() {
+  ItineraryItem item(int pos, String name, String city, double lat, double lng,
+          int day) =>
+      ItineraryItem(
+        id: 'i$pos',
+        position: pos,
+        name: name,
+        latitude: lat,
+        longitude: lng,
+        category: 'attraction',
+        day: day,
+        city: city,
+      );
+
+  Trip threeCityTrip() => Trip(
+        id: 't1',
+        title: 'Grand tour',
+        createdAt: '2026-06-01',
+        updatedAt: '2026-06-01',
+        startDate: '2026-09-01',
+        endDate: '2026-09-05',
+        items: [
+          item(0, 'Louvre', 'Paris', 48.8606, 2.3376, 1),
+          item(1, 'Orsay', 'Paris', 48.8600, 2.3266, 2),
+          for (var k = 0; k < 8; k++)
+            item(2 + k, 'Roman Forum $k', 'Rome', 41.89 + k * 0.001, 12.49, 3),
+          item(10, 'Brandenburg Gate', 'Berlin', 52.5163, 13.3777, 4),
+        ],
+      );
+
+  Future<void> pump(WidgetTester tester, Trip trip) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          tripsApiServiceProvider
+              .overrideWithValue(_FakeTripsApiService(trip)),
+        ],
+        child: MaterialApp(
+            localizationsDelegates: testLocalizationsDelegates,
+            home: TripDetailScreen(tripId: 't1')),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  void useSurface(WidgetTester tester, Size size) {
+    tester.view.physicalSize = size;
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+  }
+
+  /// True when [finder]'s single match sits DIRECTLY inside a
+  /// RepaintBoundary — the wrap shape this lane added (boundary → child by
+  /// instance). Direct parenthood distinguishes our boundaries from any the
+  /// framework happens to place higher up the tree.
+  bool directlyBoundaried(WidgetTester tester, Finder finder) {
+    Widget? parent;
+    tester.element(finder).visitAncestorElements((e) {
+      parent = e.widget;
+      return false;
+    });
+    return parent is RepaintBoundary;
+  }
+
+  testWidgets(
+      'wide layout: map card + pinned chrome + city/day headers are '
+      'repaint-isolated and nothing on the screen fades', (tester) async {
+    useSurface(tester, const Size(1200, 2200));
+    await pump(tester, threeCityTrip());
+
+    // The map card's boundary must be an ancestor of the chip strip (the
+    // strip sits outside flutter_map's own internal boundary, so any
+    // boundary above it inside the scroll view is ours).
+    expect(
+      find.descendant(
+        of: find.byType(CustomScrollView),
+        matching: find.ancestor(
+          of: find.byType(MapLegChips),
+          matching: find.byType(RepaintBoundary),
+        ),
+      ),
+      findsWidgets,
+      reason: 'the pinned map card must repaint in its own layer',
+    );
+
+    // City headers (collapsed at boot) are individually boundaried.
+    expect(
+      directlyBoundaried(
+          tester,
+          find
+              .ancestor(
+                  of: cityHeaderLabel('Paris'),
+                  matching: find.byType(HoverReveal))
+              .first),
+      isTrue,
+      reason: 'city headers must repaint in their own layer',
+    );
+
+    // Expanding a city mounts its pinned day headers — those are
+    // boundaried too (city header + ≥1 day header ⇒ ≥2 direct wraps; item
+    // tiles rely on the reorderable list's automatic row boundaries and are
+    // deliberately NOT double-wrapped).
+    await expandCity(tester, 'Paris');
+    final directWraps = find
+        .byType(HoverReveal)
+        .evaluate()
+        .where((e) => e.widget is HoverReveal)
+        .where((e) {
+      Widget? parent;
+      e.visitAncestorElements((a) {
+        parent = a.widget;
+        return false;
+      });
+      return parent is RepaintBoundary;
+    }).length;
+    expect(directWraps, greaterThanOrEqualTo(2),
+        reason: 'city and day headers must both carry direct boundaries');
+
+    // The regression guard for the fade itself. Scoped to HoverReveal
+    // subtrees: flutter_map legitimately keeps a couple of idle
+    // AnimatedOpacity widgets (attribution chrome) that never animate on
+    // scroll — the bug was fades on the hover-revealed row controls.
+    expect(
+        find.descendant(
+            of: find.byType(HoverReveal),
+            matching: find.byType(AnimatedOpacity)),
+        findsNothing,
+        reason: 'hover reveal must be an instant 0/1 swap — a fade brings '
+            'back the rolling saveLayer cost that caused the scroll slowdown');
+  });
+
+  testWidgets('phone layout: the scroll-away map card is boundaried too',
+      (tester) async {
+    useSurface(tester, const Size(500, 900));
+    await pump(tester, threeCityTrip());
+
+    // Same assertion as the wide layout: proves the boundary lives inside
+    // _mapCard rather than only in the pinned-header delegate.
+    expect(
+      find.descendant(
+        of: find.byType(CustomScrollView),
+        matching: find.ancestor(
+          of: find.byType(MapLegChips),
+          matching: find.byType(RepaintBoundary),
+        ),
+      ),
+      findsWidgets,
+    );
+    expect(
+        find.descendant(
+            of: find.byType(HoverReveal),
+            matching: find.byType(AnimatedOpacity)),
+        findsNothing);
+  });
+
+  testWidgets('hover still reveals row controls with a mouse connected',
+      (tester) async {
+    useSurface(tester, const Size(1200, 2200));
+    await pump(tester, threeCityTrip());
+    await expandCity(tester, 'Paris');
+
+    final gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    await gesture.addPointer(location: Offset.zero);
+    addTearDown(gesture.removePointer);
+    await tester.pump();
+
+    Opacity tileControls() => tester.widget<Opacity>(find
+        .descendant(
+          of: find.ancestor(
+              of: find.text('Louvre'), matching: find.byType(HoverReveal)),
+          matching: find.byType(Opacity),
+        )
+        .first);
+
+    // Pointer parked away from the tile: controls hidden, exactly 0.
+    expect(tileControls().opacity, 0.0);
+
+    // Hover the tile: controls appear after a single frame, exactly 1.
+    await gesture.moveTo(tester.getCenter(find.text('Louvre')));
+    await tester.pump();
+    expect(tileControls().opacity, 1.0);
+  });
+}
+
+class _FakeTripsApiService extends TripsApiService {
+  final Trip trip;
+  _FakeTripsApiService(this.trip) : super(ApiClient(baseUrl: 'http://test'));
+
+  @override
+  Future<Trip> getTrip(String id) async => trip;
+}


### PR DESCRIPTION
## Summary
- Fixes the progressive slowdown while scrolling the trip detail page (prod, desktop, wide layout): rows crossing under a parked cursor each started a 120ms `AnimatedOpacity` fade, and the rolling set of mid-fade rows forced a saveLayer per row per frame on CanvasKit — cost that grew the longer the scroll ran.
- `HoverRevealed` now swaps opacity instantly between exactly 0 and 1 (never allocates a layer, schedules no ticker); layout slot, pointer-ignoring, and widget-test finder visibility are unchanged, and the doc comment makes the instant-swap a hard perf requirement.
- Adds `RepaintBoundary` around the scroll-static chrome that was re-recording its picture every frame: the map card (inside `_mapCard`, covering both the pinned wide band and the scroll-away phone card), the `_PinnedHeaderDelegate` chrome (map band + tab row), and each city/day header. Item tiles keep the reorderable list's automatic row boundaries.
- Touch devices are unaffected (controls there are always visible); the `InkWell` row hover highlight still animates, so rows keep the Material hover feel.

## Testing
- `make flutter-analyze`: no new issues (3 pre-existing infos in `route_response.dart` also present on base).
- `make flutter-test`: all 904 tests pass — 898 existing unmodified plus 6 new.
- New `test/hover_reveal_test.dart`: layout-slot parity hidden vs shown, hidden controls untappable, instant 0/1 reveal with `transientCallbackCount == 0`, touch mode always revealed.
- New `test/trip_detail_scroll_perf_test.dart`: RepaintBoundary placement on wide and phone layouts (direct-parent assertions for city/day headers, boundary-above-`MapLegChips` for the map card), no `AnimatedOpacity` inside any `HoverReveal` subtree, and hover-still-reveals with a connected mouse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)