### PR TITLE
fix(flutter): client resilience for the hard-refresh burst — retry, provider self-heal, cache fallback

### DIFF
--- a/src/packages/flutter-app/lib/providers/flights_provider.dart
+++ b/src/packages/flutter-app/lib/providers/flights_provider.dart
@@ -1,7 +1,10 @@
+import 'dart:async';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../models/airport.dart';
 import '../models/flight_offer.dart';
 import '../models/flight_search_request.dart';
+import '../services/api_client.dart';
 import '../services/flights_api_service.dart';
 import 'api_client_provider.dart';
 
@@ -18,10 +21,17 @@ final airportSearchProvider =
 });
 
 /// Resolves a saved home-airport IATA code to map coordinates (a record, not
-/// LatLng, so the providers layer stays free of map imports). Errors resolve
-/// to null rather than surfacing: the one contract callers rely on is
-/// "no coordinates → no home legs on the map", and a session-cached errored
-/// family provider would otherwise pin the failure until restart.
+/// LatLng, so the providers layer stays free of map imports).
+///
+/// `null` means CONFIRMED empty — the lookup succeeded and found no
+/// coordinates for the code — and is correctly cached for the session.
+/// Transport/HTTP failures surface as AsyncError instead (the map renders
+/// them identically via `valueOrNull`), and transient ones arm a one-shot
+/// 30s `invalidateSelf` so the overlay self-heals while watched. Without
+/// that, this non-autoDispose family would pin one bad boot-time request —
+/// and an empty home overlay — for the whole session; autoDispose alone
+/// can't help because the map watches continuously, so a cached error is
+/// never released.
 final homeAirportPointProvider =
     FutureProvider.family<({double lat, double lng})?, String>(
         (ref, iata) async {
@@ -30,8 +40,12 @@ final homeAirportPointProvider =
   final List<Airport> results;
   try {
     results = await ref.watch(flightsApiServiceProvider).searchAirports(code);
-  } catch (_) {
-    return null;
+  } catch (e) {
+    if (isTransientError(e)) {
+      final retry = Timer(const Duration(seconds: 30), ref.invalidateSelf);
+      ref.onDispose(retry.cancel);
+    }
+    rethrow;
   }
   Airport? match;
   for (final a in results) {

--- a/src/packages/flutter-app/lib/providers/trip_review_provider.dart
+++ b/src/packages/flutter-app/lib/providers/trip_review_provider.dart
@@ -1,5 +1,8 @@
+import 'dart:async';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../models/trip_finding.dart';
+import '../services/api_client.dart';
 import '../services/trip_review_api_service.dart';
 import 'api_client_provider.dart';
 
@@ -29,9 +32,23 @@ class TripReviewKey {
 /// A trip's health review, keyed by (trip id, check-hours). Mirrors
 /// [checklistProvider]: refreshable by invalidating the family key. The
 /// hours-on variant is fetched lazily when the section flips the flag.
+///
+/// Transient failures (429/5xx/network) self-heal via a one-shot 30s
+/// `invalidateSelf`: this family is not autoDispose, so a cached error would
+/// otherwise hide the health app-bar icon for the whole session — and the
+/// only manual retry path lives inside the sheet that the hidden icon can no
+/// longer open. Stable errors (the viewer's 404) stay cached, as before.
 final tripReviewProvider =
     FutureProvider.family<List<TripFinding>, TripReviewKey>((ref, key) async {
-  return ref
-      .watch(tripReviewApiServiceProvider)
-      .getReview(key.tripId, checkHours: key.checkHours);
+  try {
+    return await ref
+        .watch(tripReviewApiServiceProvider)
+        .getReview(key.tripId, checkHours: key.checkHours);
+  } catch (e) {
+    if (isTransientError(e)) {
+      final retry = Timer(const Duration(seconds: 30), ref.invalidateSelf);
+      ref.onDispose(retry.cancel);
+    }
+    rethrow;
+  }
 });

--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -39,6 +39,7 @@ import '../providers/budget_provider.dart';
 import '../models/trip_finding.dart';
 import '../models/budget.dart';
 import '../navigation/app_nav.dart';
+import '../services/api_client.dart' show isTransientError;
 import '../services/trip_cache.dart';
 import '../theme/app_colors.dart';
 import '../theme/spacing.dart';
@@ -141,7 +142,9 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
     with WidgetsBindingObserver {
   Trip? _trip;
   bool _loading = true;
-  String? _error;
+  // The raw caught load error (not a string): the error screen classifies it
+  // via friendlyError(l10n, ...) so a 429 reads differently from a 500.
+  Object? _error;
   // Non-null while _trip is a cached copy served because the network was
   // unreachable (value = when the copy was saved). The screen is read-only
   // in this mode; a successful live load clears it.
@@ -437,7 +440,15 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
       // helpers self-guard with mounted checks and swallow their own errors.
       Future<void> syncTodosAfterPrefs() async {
         await ref.read(preferencesProvider.notifier).loadIfNeeded();
-        _homeAirport = ref.read(preferencesProvider).prefs?.homeAirport;
+        // Under setState: the map's home overlay reads _homeAirport, and a
+        // prefs load that lands after the first build must trigger its own
+        // rebuild — riding on _syncBookingTodos' setState left the overlay
+        // permanently absent whenever that sync was skipped (empty trip) or
+        // failed.
+        final home = ref.read(preferencesProvider).prefs?.homeAirport;
+        if (mounted && home != _homeAirport) {
+          setState(() => _homeAirport = home);
+        }
         if (mounted && (trip.items ?? const []).isNotEmpty) {
           await _syncBookingTodos(trip);
         }
@@ -449,11 +460,14 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
         syncTodosAfterPrefs(),
       ]);
     } catch (e) {
-      // Loud path + network-level failure: fall back to the cached copy and
-      // render it read-only. HTTP errors (403/404/500) never reach here —
-      // isNetworkError excludes them — so a revoked or deleted trip can't
-      // resurrect from a stale copy.
-      if (mounted && !quiet && TripCache.isNetworkError(e)) {
+      // Loud path: fall back to the cached copy and render it read-only for
+      // network-level failures AND transient HTTP failures (429/502/503/504
+      // surviving send()'s own retries) — a rate-limited boot with a good
+      // cached copy must not dead-end on an error screen. Stable HTTP errors
+      // (403/404/500) never match either predicate, so a revoked or deleted
+      // trip can't resurrect from a stale copy.
+      if (mounted && !quiet &&
+          (TripCache.isNetworkError(e) || isTransientError(e))) {
         final cached = await ref.read(tripCacheProvider).readTrip(widget.tripId);
         if (cached != null && mounted) {
           setState(() {
@@ -496,7 +510,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
         }
         return;
       }
-      if (mounted && !quiet) setState(() => _error = e.toString());
+      if (mounted && !quiet) setState(() => _error = e);
     } finally {
       if (mounted && !quiet) setState(() => _loading = false);
       if (mounted) _syncStatusPolling();
@@ -4964,6 +4978,15 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
                     mainAxisAlignment: MainAxisAlignment.center,
                     children: [
                       Text(l10n.tripLoadFailed),
+                      const SizedBox(height: 4),
+                      // Status-aware subtitle: a residual 429 reads as "slow
+                      // down a moment", offline as a network problem — not
+                      // one opaque dead end for every failure.
+                      Text(
+                        friendlyError(l10n, _error),
+                        style: Theme.of(context).textTheme.bodySmall,
+                        textAlign: TextAlign.center,
+                      ),
                       const SizedBox(height: 8),
                       FilledButton(
                           onPressed: _load, child: Text(l10n.commonRetry)),

--- a/src/packages/flutter-app/lib/services/api_client.dart
+++ b/src/packages/flutter-app/lib/services/api_client.dart
@@ -1,4 +1,6 @@
+import 'dart:async';
 import 'dart:convert';
+import 'dart:math';
 import 'package:http/http.dart' as http;
 import '../models/route_request.dart';
 import '../models/route_response.dart';
@@ -45,6 +47,97 @@ class ApiClient {
     final token = authToken;
     if (token != null) h['Authorization'] = 'Bearer $token';
     return h;
+  }
+
+  /// One shared request path for boot-critical JSON calls: a per-attempt
+  /// [timeout] plus a small bounded retry, so one transient hiccup (a
+  /// rate-limit 429, a load-shed 503, a dropped keepalive connection) doesn't
+  /// become a dead screen or a session-pinned provider error.
+  ///
+  /// Retry rules, explicit by design:
+  /// - **429/503 retry for any method**: this API emits them only from the
+  ///   rate limiter and the concurrency shedder, both of which reject BEFORE
+  ///   the handler runs, so the request provably had no effect. If a handler
+  ///   ever emits its own 429/503, revisit this rule.
+  /// - **502 and transport failures** ([http.ClientException],
+  ///   [TimeoutException]) **retry GETs only** — whether the handler ran is
+  ///   unknowable.
+  /// - Any other status fails immediately (no retry).
+  /// Delays honor `Retry-After` clamped to 4s, else 500ms·2ⁿ plus jitter.
+  ///
+  /// Exhausted attempts: HTTP failures throw [ApiException] with the status;
+  /// transport failures rethrow the ORIGINAL exception unwrapped — callers
+  /// like `TripCache.isNetworkError` classify on the concrete type.
+  Future<http.Response> send(
+    String method,
+    String path, {
+    Map<String, String>? query,
+    Object? jsonBody,
+    Duration timeout = const Duration(seconds: 12),
+    int attempts = 3,
+  }) async {
+    var uri = Uri.parse('$_baseUrl$path');
+    if (query != null) uri = uri.replace(queryParameters: query);
+    final headers = jsonHeaders(json: jsonBody != null);
+    final body = jsonBody == null ? null : jsonEncode(jsonBody);
+
+    http.Response? res;
+    for (var attempt = 0; attempt < attempts; attempt++) {
+      final lastAttempt = attempt == attempts - 1;
+      try {
+        res = await _issue(method, uri, headers, body).timeout(timeout);
+      } on Exception catch (e) {
+        final transport = e is http.ClientException || e is TimeoutException;
+        if (!transport || lastAttempt || method != 'GET') rethrow;
+        await Future<void>.delayed(_retryDelay(attempt, null));
+        continue;
+      }
+      final code = res.statusCode;
+      if (code >= 200 && code < 300) return res;
+      final retryable =
+          code == 429 || code == 503 || (code == 502 && method == 'GET');
+      if (!retryable || lastAttempt) break;
+      await Future<void>.delayed(
+          _retryDelay(attempt, res.headers['retry-after']));
+    }
+    final failed = res!;
+    final snippet = failed.body.length > 200
+        ? failed.body.substring(0, 200)
+        : failed.body;
+    throw ApiException(
+      statusCode: failed.statusCode,
+      message: 'Request failed: $snippet',
+      endpoint: path,
+    );
+  }
+
+  Future<http.Response> _issue(
+      String method, Uri uri, Map<String, String> headers, String? body) {
+    switch (method) {
+      case 'GET':
+        return _client.get(uri, headers: headers);
+      case 'POST':
+        return _client.post(uri, headers: headers, body: body);
+      case 'PUT':
+        return _client.put(uri, headers: headers, body: body);
+      case 'PATCH':
+        return _client.patch(uri, headers: headers, body: body);
+      case 'DELETE':
+        return _client.delete(uri, headers: headers, body: body);
+      default:
+        throw ArgumentError.value(method, 'method', 'unsupported HTTP method');
+    }
+  }
+
+  static final Random _retryJitter = Random();
+
+  Duration _retryDelay(int attempt, String? retryAfterHeader) {
+    // Retry-After (seconds form) is authoritative but clamped: the UI cannot
+    // hang multiple seconds on a value meant for background clients.
+    final ra = int.tryParse(retryAfterHeader ?? '');
+    if (ra != null) return Duration(seconds: ra.clamp(0, 4));
+    return Duration(
+        milliseconds: 500 * (1 << attempt) + _retryJitter.nextInt(250));
   }
 
   /// Optimize a route for locations
@@ -170,3 +263,18 @@ class ApiException implements Exception {
   /// Whether this is a server error (5xx)
   bool get isServerError => statusCode >= 500;
 }
+
+/// True when [e] describes a transient condition worth an automatic retry or
+/// self-heal: a transport-level failure, or an HTTP status this API emits
+/// only for temporary states (rate limit 429, shed 503, gateway 502/504).
+/// Stable outcomes (401/403/404/422…) never match — retrying them can only
+/// mask a real bug or resurrect revoked data.
+bool isTransientError(Object e) =>
+    e is http.ClientException ||
+    e is TimeoutException ||
+    (e is ApiException &&
+        (e.statusCode == 0 ||
+            e.statusCode == 429 ||
+            e.statusCode == 502 ||
+            e.statusCode == 503 ||
+            e.statusCode == 504));

--- a/src/packages/flutter-app/lib/services/flights_api_service.dart
+++ b/src/packages/flutter-app/lib/services/flights_api_service.dart
@@ -38,21 +38,15 @@ class FlightsApiService {
   Future<List<Airport>> nearestAirports(double lat, double lng) =>
       _airports({'lat': '$lat', 'lng': '$lng'});
 
+  /// Boot-critical (home-airport resolution feeds the trip map): rides
+  /// [ApiClient.send] for its timeout + bounded retry; non-2xx surfaces as
+  /// [ApiException] exactly as before.
   Future<List<Airport>> _airports(Map<String, String> params) async {
-    final uri = Uri.parse('${apiClient.baseUrl}/flights/airports')
-        .replace(queryParameters: params);
-    final res = await apiClient.httpClient.get(uri, headers: apiClient.jsonHeaders());
-    if (res.statusCode == 200) {
-      final body = jsonDecode(res.body) as Map<String, dynamic>;
-      final list = (body['results'] as List<dynamic>? ?? []);
-      return list
-          .map((e) => Airport.fromJson(e as Map<String, dynamic>))
-          .toList();
-    }
-    throw ApiException(
-      statusCode: res.statusCode,
-      message: 'Failed to search airports: ${res.body}',
-      endpoint: 'flights/airports',
-    );
+    final res = await apiClient.send('GET', '/flights/airports', query: params);
+    final body = jsonDecode(res.body) as Map<String, dynamic>;
+    final list = (body['results'] as List<dynamic>? ?? []);
+    return list
+        .map((e) => Airport.fromJson(e as Map<String, dynamic>))
+        .toList();
   }
 }

--- a/src/packages/flutter-app/lib/services/preferences_api_service.dart
+++ b/src/packages/flutter-app/lib/services/preferences_api_service.dart
@@ -8,13 +8,11 @@ class PreferencesApiService {
 
   PreferencesApiService(this.apiClient);
 
+  /// Boot-critical (home airport rides on this): [ApiClient.send] gives it a
+  /// timeout + bounded retry; HTTP failures throw a typed [ApiException].
   Future<TravelerPreferences> getPreferences() async {
-    final res = await apiClient.httpClient
-        .get(Uri.parse('${apiClient.baseUrl}/preferences'), headers: apiClient.jsonHeaders());
-    if (res.statusCode == 200) {
-      return TravelerPreferences.fromJson(jsonDecode(res.body));
-    }
-    throw Exception('Failed to load preferences (${res.statusCode})');
+    final res = await apiClient.send('GET', '/preferences');
+    return TravelerPreferences.fromJson(jsonDecode(res.body));
   }
 
   Future<TravelerPreferences> savePreferences({

--- a/src/packages/flutter-app/lib/services/trip_cache.dart
+++ b/src/packages/flutter-app/lib/services/trip_cache.dart
@@ -39,9 +39,13 @@ class TripCache {
   /// opposed to an HTTP error response. `package:http` >=1.0 wraps socket/IO
   /// failures in [http.ClientException] on every platform; the string check
   /// is belt-and-braces for raw dart:io SocketExceptions (dart:io itself is
-  /// not importable on web). HTTP non-200s in TripsApiService are thrown as
-  /// plain `Exception('... (status)')` and therefore never match — a
-  /// 403/404/500 must NOT fall back to the cache.
+  /// not importable on web). HTTP failures never match: `getTrip` throws a
+  /// typed [ApiException] (and other TripsApiService methods plain
+  /// `Exception('... (status)')`), neither of which is a transport type — a
+  /// 403/404/500 must NOT fall back to the cache here. The trip screen's
+  /// loud-load path separately opts transient HTTP statuses (429/502/503)
+  /// into the fallback via `isTransientError`; that gate is the caller's,
+  /// deliberately not this predicate's.
   static bool isNetworkError(Object e) =>
       e is http.ClientException ||
       e is TimeoutException ||

--- a/src/packages/flutter-app/lib/services/trip_review_api_service.dart
+++ b/src/packages/flutter-app/lib/services/trip_review_api_service.dart
@@ -11,20 +11,17 @@ class TripReviewApiService {
 
   TripReviewApiService(this.apiClient);
 
+  /// Boot-critical (the health app-bar icon watches this): [ApiClient.send]
+  /// gives it a timeout + bounded retry; HTTP failures — including the
+  /// viewer's stable 404 — throw a typed [ApiException].
   Future<List<TripFinding>> getReview(String tripId,
       {bool checkHours = false}) async {
-    final res = await apiClient.httpClient.get(
-      Uri.parse(
-          '${apiClient.baseUrl}/trips/$tripId/review?check_hours=$checkHours'),
-      headers: apiClient.jsonHeaders(),
-    );
-    if (res.statusCode == 200) {
-      final body = jsonDecode(res.body) as Map<String, dynamic>;
-      final list = (body['findings'] as List<dynamic>?) ?? const [];
-      return list
-          .map((e) => TripFinding.fromJson(e as Map<String, dynamic>))
-          .toList();
-    }
-    throw Exception('Failed to load trip review (${res.statusCode})');
+    final res = await apiClient.send('GET', '/trips/$tripId/review',
+        query: {'check_hours': '$checkHours'});
+    final body = jsonDecode(res.body) as Map<String, dynamic>;
+    final list = (body['findings'] as List<dynamic>?) ?? const [];
+    return list
+        .map((e) => TripFinding.fromJson(e as Map<String, dynamic>))
+        .toList();
   }
 }

--- a/src/packages/flutter-app/lib/services/trips_api_service.dart
+++ b/src/packages/flutter-app/lib/services/trips_api_service.dart
@@ -65,13 +65,13 @@ class TripsApiService {
     throw Exception('Failed to load trip status (${res.statusCode})');
   }
 
+  /// The boot-critical read: rides [ApiClient.send] (timeout + bounded retry)
+  /// and throws a typed [ApiException] on HTTP failure, so the trip screen
+  /// can distinguish a transient 429/503 (cached-copy fallback) from a stable
+  /// 403/404 (never resurrect) and render a status-aware message.
   Future<Trip> getTrip(String id) async {
-    final res = await apiClient.httpClient
-        .get(Uri.parse('${apiClient.baseUrl}/trips/$id'), headers: apiClient.jsonHeaders());
-    if (res.statusCode == 200) {
-      return Trip.fromJson(jsonDecode(res.body));
-    }
-    throw Exception('Failed to load trip (${res.statusCode})');
+    final res = await apiClient.send('GET', '/trips/$id');
+    return Trip.fromJson(jsonDecode(res.body));
   }
 
   Future<Trip> patchTrip(

--- a/src/packages/flutter-app/pubspec.lock
+++ b/src/packages/flutter-app/pubspec.lock
@@ -250,7 +250,7 @@ packages:
     source: hosted
     version: "0.6.1"
   fake_async:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: fake_async
       sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"

--- a/src/packages/flutter-app/pubspec.yaml
+++ b/src/packages/flutter-app/pubspec.yaml
@@ -94,6 +94,10 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
 
+  # Fake-clock provider tests (boot_burst_providers_test.dart); already in
+  # the resolution via flutter_test, declared so imports are direct.
+  fake_async: ^1.3.3
+
   # The "flutter_lints" package below contains a set of recommended lints to
   # encourage good coding practices. The lint set provided by the package is
   # activated in the `analysis_options.yaml` file located at the root of your

--- a/src/packages/flutter-app/test/api_client_send_test.dart
+++ b/src/packages/flutter-app/test/api_client_send_test.dart
@@ -1,0 +1,158 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+import 'package:travel_route_planner/services/api_client.dart';
+import 'package:travel_route_planner/services/trip_cache.dart';
+
+/// ApiClient.send: the shared boot-critical request path (timeout + bounded
+/// retry). The retry matrix is a contract — 429/503 retry any method (this
+/// API emits them only pre-handler), 502/transport retry GETs only, and an
+/// exhausted transport failure rethrows the ORIGINAL exception so
+/// TripCache.isNetworkError keeps classifying on the concrete type.
+void main() {
+  ApiClient client(Future<http.Response> Function(http.Request) handler) =>
+      ApiClient(baseUrl: 'http://test/api/v1', client: MockClient(handler));
+
+  test('429 with Retry-After: 0 retries (any method) and then succeeds',
+      () async {
+    var calls = 0;
+    final api = client((req) async {
+      calls++;
+      if (calls == 1) {
+        return http.Response('rate limited', 429,
+            headers: {'retry-after': '0'});
+      }
+      return http.Response('{"ok":true}', 200);
+    });
+
+    final res = await api.send('POST', '/plan-adjacent', jsonBody: {'a': 1});
+    expect(res.statusCode, 200);
+    expect(calls, 2);
+  });
+
+  test('GET 502 retries and succeeds', () async {
+    var calls = 0;
+    final api = client((req) async {
+      calls++;
+      return calls == 1
+          ? http.Response('bad gateway', 502)
+          : http.Response('{}', 200);
+    });
+
+    final res = await api.send('GET', '/trips/t1');
+    expect(res.statusCode, 200);
+    expect(calls, 2);
+  });
+
+  test('POST 502 throws immediately — no retry for non-GET on 502', () async {
+    var calls = 0;
+    final api = client((req) async {
+      calls++;
+      return http.Response('bad gateway', 502);
+    });
+
+    await expectLater(
+      api.send('POST', '/trips', jsonBody: {'title': 'x'}),
+      throwsA(isA<ApiException>()
+          .having((e) => e.statusCode, 'statusCode', 502)),
+    );
+    expect(calls, 1);
+  });
+
+  test('stable statuses (404) fail on the first attempt with the status',
+      () async {
+    var calls = 0;
+    final api = client((req) async {
+      calls++;
+      return http.Response('not found', 404);
+    });
+
+    await expectLater(
+      api.send('GET', '/trips/gone'),
+      throwsA(isA<ApiException>()
+          .having((e) => e.statusCode, 'statusCode', 404)
+          .having((e) => e.endpoint, 'endpoint', '/trips/gone')),
+    );
+    expect(calls, 1);
+  });
+
+  test('exhausted attempts on 429 surface an ApiException(429)', () async {
+    var calls = 0;
+    final api = client((req) async {
+      calls++;
+      return http.Response('rate limited', 429, headers: {'retry-after': '0'});
+    });
+
+    await expectLater(
+      api.send('GET', '/trips/t1', attempts: 2),
+      throwsA(isA<ApiException>()
+          .having((e) => e.statusCode, 'statusCode', 429)),
+    );
+    expect(calls, 2);
+  });
+
+  test(
+      'an exhausted transport failure rethrows the original ClientException '
+      'and still classifies as a network error for the trip cache', () async {
+    var calls = 0;
+    final api = client((req) async {
+      calls++;
+      throw http.ClientException('connection refused');
+    });
+
+    Object? caught;
+    try {
+      // attempts: 1 keeps the test instant (no backoff sleeps).
+      await api.send('GET', '/trips/t1', attempts: 1);
+    } catch (e) {
+      caught = e;
+    }
+    expect(calls, 1);
+    expect(caught, isA<http.ClientException>(),
+        reason: 'must rethrow unwrapped, never wrap in ApiException');
+    expect(TripCache.isNetworkError(caught!), isTrue);
+  });
+
+  test('POST transport failure never retries (handler may have run)',
+      () async {
+    var calls = 0;
+    final api = client((req) async {
+      calls++;
+      throw http.ClientException('reset');
+    });
+
+    await expectLater(api.send('POST', '/trips', jsonBody: {}),
+        throwsA(isA<http.ClientException>()));
+    expect(calls, 1);
+  });
+
+  test('query parameters and JSON body are applied', () async {
+    late http.Request seen;
+    final api = client((req) async {
+      seen = req;
+      return http.Response('{}', 200);
+    });
+
+    await api.send('GET', '/flights/airports', query: {'q': 'LAX'});
+    expect(seen.url.toString(), 'http://test/api/v1/flights/airports?q=LAX');
+
+    await api.send('POST', '/x', jsonBody: {'k': 'v'});
+    expect(seen.body, '{"k":"v"}');
+    expect(seen.headers['Content-Type'], startsWith('application/json'));
+  });
+
+  test('isTransientError matches transient shapes only', () {
+    ApiException ex(int s) =>
+        ApiException(statusCode: s, message: '', endpoint: 'x');
+    expect(isTransientError(http.ClientException('x')), isTrue);
+    for (final s in [0, 429, 502, 503, 504]) {
+      expect(isTransientError(ex(s)), isTrue, reason: '$s is transient');
+    }
+    for (final s in [400, 401, 403, 404, 422, 500]) {
+      expect(isTransientError(ex(s)), isFalse, reason: '$s is stable');
+    }
+    expect(isTransientError(Exception('Failed to load trip (429)')), isFalse,
+        reason: 'untyped exceptions never match');
+  });
+}

--- a/src/packages/flutter-app/test/boot_burst_providers_test.dart
+++ b/src/packages/flutter-app/test/boot_burst_providers_test.dart
@@ -1,0 +1,167 @@
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:travel_route_planner/models/airport.dart';
+import 'package:travel_route_planner/models/trip_finding.dart';
+import 'package:travel_route_planner/providers/flights_provider.dart';
+import 'package:travel_route_planner/providers/trip_review_provider.dart';
+import 'package:travel_route_planner/services/api_client.dart';
+import 'package:travel_route_planner/services/flights_api_service.dart';
+import 'package:travel_route_planner/services/trip_review_api_service.dart';
+
+/// Self-heal semantics for the two providers a transient boot-time failure
+/// used to pin for the whole session (neither family is autoDispose):
+/// a transient error arms a one-shot 30s invalidateSelf; a stable error
+/// (404) and a confirmed-empty success stay cached with no retry traffic.
+
+class _ScriptedFlightsApi extends FlightsApiService {
+  final List<Object> script; // List<Airport> resolves, anything else throws.
+  int calls = 0;
+  _ScriptedFlightsApi(this.script) : super(ApiClient(baseUrl: 'http://test'));
+
+  @override
+  Future<List<Airport>> searchAirports(String query) {
+    final next = script[calls < script.length ? calls : script.length - 1];
+    calls++;
+    if (next is List<Airport>) return Future.value(next);
+    return Future.error(next);
+  }
+}
+
+class _ScriptedReviewApi extends TripReviewApiService {
+  final List<Object> script;
+  int calls = 0;
+  _ScriptedReviewApi(this.script) : super(ApiClient(baseUrl: 'http://test'));
+
+  @override
+  Future<List<TripFinding>> getReview(String tripId,
+      {bool checkHours = false}) {
+    final next = script[calls < script.length ? calls : script.length - 1];
+    calls++;
+    if (next is List<TripFinding>) return Future.value(next);
+    return Future.error(next);
+  }
+}
+
+const _lax = Airport(
+    iataCode: 'LAX',
+    name: 'Los Angeles International',
+    subType: 'airport',
+    latitude: 33.9425,
+    longitude: -118.408);
+
+ApiException _ex(int status) =>
+    ApiException(statusCode: status, message: 'x', endpoint: 'x');
+
+void main() {
+  group('homeAirportPointProvider', () {
+    test('transient error self-heals: refetches 30s later while watched', () {
+      fakeAsync((async) {
+        final api = _ScriptedFlightsApi([
+          _ex(429),
+          const [_lax],
+        ]);
+        final container = ProviderContainer(overrides: [
+          flightsApiServiceProvider.overrideWithValue(api),
+        ]);
+        addTearDown(container.dispose);
+        container.listen(homeAirportPointProvider('LAX'), (_, __) {});
+        async.flushMicrotasks();
+
+        expect(container.read(homeAirportPointProvider('LAX')).hasError,
+            isTrue);
+        expect(api.calls, 1);
+
+        async.elapse(const Duration(seconds: 30));
+        async.flushMicrotasks();
+
+        final healed = container.read(homeAirportPointProvider('LAX'));
+        expect(api.calls, 2);
+        expect(healed.value, isNotNull);
+        expect(healed.value!.lat, 33.9425);
+      });
+    });
+
+    test('stable error (404) is cached — no retry timer', () {
+      fakeAsync((async) {
+        final api = _ScriptedFlightsApi([_ex(404)]);
+        final container = ProviderContainer(overrides: [
+          flightsApiServiceProvider.overrideWithValue(api),
+        ]);
+        addTearDown(container.dispose);
+        container.listen(homeAirportPointProvider('LAX'), (_, __) {});
+        async.flushMicrotasks();
+        async.elapse(const Duration(minutes: 5));
+        async.flushMicrotasks();
+
+        expect(api.calls, 1, reason: 'no self-heal for stable errors');
+        expect(container.read(homeAirportPointProvider('LAX')).hasError,
+            isTrue);
+      });
+    });
+
+    test('confirmed-empty success caches null with no retry traffic', () {
+      fakeAsync((async) {
+        final api = _ScriptedFlightsApi([const <Airport>[]]);
+        final container = ProviderContainer(overrides: [
+          flightsApiServiceProvider.overrideWithValue(api),
+        ]);
+        addTearDown(container.dispose);
+        container.listen(homeAirportPointProvider('LAX'), (_, __) {});
+        async.flushMicrotasks();
+        async.elapse(const Duration(minutes: 5));
+        async.flushMicrotasks();
+
+        final v = container.read(homeAirportPointProvider('LAX'));
+        expect(v.hasValue, isTrue);
+        expect(v.value, isNull, reason: 'no coordinates → confirmed empty');
+        expect(api.calls, 1);
+      });
+    });
+  });
+
+  group('tripReviewProvider', () {
+    test('503 self-invalidates and recovers 30s later', () {
+      fakeAsync((async) {
+        final api = _ScriptedReviewApi([
+          _ex(503),
+          const <TripFinding>[],
+        ]);
+        final container = ProviderContainer(overrides: [
+          tripReviewApiServiceProvider.overrideWithValue(api),
+        ]);
+        addTearDown(container.dispose);
+        const key = TripReviewKey('t1');
+        container.listen(tripReviewProvider(key), (_, __) {});
+        async.flushMicrotasks();
+
+        expect(container.read(tripReviewProvider(key)).hasError, isTrue);
+
+        async.elapse(const Duration(seconds: 30));
+        async.flushMicrotasks();
+
+        expect(api.calls, 2);
+        expect(container.read(tripReviewProvider(key)).hasValue, isTrue);
+      });
+    });
+
+    test('the viewer 404 stays a stable cached error', () {
+      fakeAsync((async) {
+        final api = _ScriptedReviewApi([_ex(404)]);
+        final container = ProviderContainer(overrides: [
+          tripReviewApiServiceProvider.overrideWithValue(api),
+        ]);
+        addTearDown(container.dispose);
+        const key = TripReviewKey('t1');
+        container.listen(tripReviewProvider(key), (_, __) {});
+        async.flushMicrotasks();
+        async.elapse(const Duration(minutes: 5));
+        async.flushMicrotasks();
+
+        expect(api.calls, 1);
+        expect(container.read(tripReviewProvider(key)).hasError, isTrue);
+      });
+    });
+  });
+}

--- a/src/packages/flutter-app/test/trip_detail_health_modal_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_health_modal_test.dart
@@ -54,6 +54,25 @@ class _FakeReviewApiService extends TripReviewApiService {
   }
 }
 
+/// First fetch fails transiently (503); later fetches serve the findings.
+/// The provider's one-shot 30s invalidateSelf must restore the hidden icon
+/// with no user action — the manual retry lives behind the icon itself.
+class _TransientThenOkReviewApi extends _FakeReviewApiService {
+  int calls = 0;
+  _TransientThenOkReviewApi(super.findings);
+
+  @override
+  Future<List<TripFinding>> getReview(String tripId,
+      {bool checkHours = false}) {
+    calls++;
+    if (calls == 1) {
+      return Future.error(ApiException(
+          statusCode: 503, message: 'shed', endpoint: 'review'));
+    }
+    return super.getReview(tripId, checkHours: checkHours);
+  }
+}
+
 class _FakeAccommodationsApiService extends AccommodationsApiService {
   final List<Map<String, dynamic>> patches = [];
   bool failUpdate = false;
@@ -326,5 +345,26 @@ void main() {
     await _pumpScreen(tester,
         review: review, surface: const Size(1200, 800));
     expect(_healthIcon(), findsOneWidget);
+  });
+
+  testWidgets('a transient review failure self-heals and restores the icon',
+      (tester) async {
+    final review = _TransientThenOkReviewApi([
+      _finding('warn', 'No lodging for the night of Aug 3.'),
+    ]);
+    await _pumpScreen(tester, review: review);
+
+    // The 503 hid the icon — previously for the whole session, since the
+    // only retry path (the sheet) opens from the icon itself.
+    expect(_healthIcon(), findsNothing);
+
+    // The provider's one-shot 30s invalidateSelf fires on the fake clock and
+    // the active app-bar watch refetches.
+    await tester.pump(const Duration(seconds: 31));
+    await tester.pumpAndSettle();
+
+    expect(review.calls, 2);
+    expect(_healthIcon(), findsOneWidget);
+    expect(find.byType(Badge), findsOneWidget);
   });
 }

--- a/src/packages/flutter-app/test/trip_detail_home_legs_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_home_legs_test.dart
@@ -34,6 +34,37 @@ class _FakeTripsApiService extends TripsApiService {
   Future<Trip> getTrip(String id) async => trip;
 }
 
+/// First getPreferences call fails transiently; later calls return EWR. The
+/// A4 regression fixture: a prefs value that lands only after the first
+/// build must reach the map through the screen's own guarded setState, not
+/// an incidental rebuild from an unrelated code path.
+class _QueuedPrefsApi implements PreferencesApiService {
+  int calls = 0;
+
+  @override
+  ApiClient get apiClient => throw UnsupportedError('unused in tests');
+
+  @override
+  Future<TravelerPreferences> getPreferences() async {
+    calls++;
+    if (calls == 1) {
+      throw ApiException(
+          statusCode: 429, message: 'rate limited', endpoint: '/preferences');
+    }
+    return const TravelerPreferences(homeAirport: 'EWR');
+  }
+
+  @override
+  Future<TravelerPreferences> savePreferences({
+    String? budget,
+    String? pace,
+    required List<String> interests,
+    String? homeAirport,
+    String? profileNotes,
+  }) async =>
+      const TravelerPreferences(homeAirport: 'EWR');
+}
+
 class _FakePrefsApi implements PreferencesApiService {
   @override
   ApiClient get apiClient => throw UnsupportedError('unused in tests');
@@ -180,6 +211,46 @@ void main() {
 
     expect(map(tester).home, isNull);
     expect(find.byIcon(Icons.flight_takeoff), findsNothing);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets(
+      'prefs failing on boot and succeeding on a quiet refresh still reach '
+      'the map (guarded setState, not an incidental rebuild)',
+      (WidgetTester tester) async {
+    final prefsApi = _QueuedPrefsApi();
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          tripsApiServiceProvider.overrideWithValue(_FakeTripsApiService(trip)),
+          preferencesApiServiceProvider.overrideWithValue(prefsApi),
+          homeAirportPointProvider('EWR')
+              .overrideWith((ref) async => homePoint),
+        ],
+        child: MaterialApp(
+          localizationsDelegates: testLocalizationsDelegates,
+          home: const TripDetailScreen(tripId: 't1'),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // Boot: the prefs fetch 429'd — no home overlay yet.
+    expect(map(tester).home, isNull);
+
+    // Quiet refresh (drive RefreshIndicator.onRefresh directly — the fling
+    // path is covered by the offline tests; over the pinned map card the
+    // gesture is unreliable): loadIfNeeded retries the still-null prefs and
+    // succeeds; the change-guarded setState must rebuild the map. On the
+    // quiet path there is no incidental full-screen setState to hide behind.
+    final indicator =
+        tester.widget<RefreshIndicator>(find.byType(RefreshIndicator));
+    await indicator.onRefresh();
+    await tester.pumpAndSettle();
+
+    expect(prefsApi.calls, 2);
+    expect(map(tester).home, isNotNull);
+    expect(map(tester).home!.label, 'EWR');
     expect(tester.takeException(), isNull);
   });
 }

--- a/src/packages/flutter-app/test/trip_detail_offline_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_offline_test.dart
@@ -307,4 +307,57 @@ void main() {
     final refine = _labeledButton<FilledButton>(tester, 'Refine with AI');
     expect(refine.onPressed, isNotNull, reason: 'back online — re-enabled');
   });
+
+  testWidgets(
+      'a transient 429 with a cached copy falls back to it read-only '
+      'instead of dead-ending', (WidgetTester tester) async {
+    final cache = TripCache('u1');
+    await cache.writeTrip(_trip('Athens Trip'));
+    final service = _QueuedTripsApiService([
+      ApiException(
+          statusCode: 429, message: 'rate limited', endpoint: '/trips/t1'),
+    ]);
+
+    await _pumpDetail(tester, service, cache);
+    await tester.pumpAndSettle();
+
+    expect(find.text('Acropolis'), findsOneWidget);
+    expect(find.textContaining('Offline — showing saved copy from'),
+        findsOneWidget);
+    expect(find.text('Could not load this trip'), findsNothing);
+  });
+
+  testWidgets('a typed 404 shows the error page, never the cached copy',
+      (WidgetTester tester) async {
+    final cache = TripCache('u1');
+    await cache.writeTrip(_trip('Athens Trip'));
+    final service = _QueuedTripsApiService([
+      ApiException(statusCode: 404, message: 'gone', endpoint: '/trips/t1'),
+    ]);
+
+    await _pumpDetail(tester, service, cache);
+    await tester.pumpAndSettle();
+
+    expect(find.text('Could not load this trip'), findsOneWidget);
+    expect(find.text('Acropolis'), findsNothing);
+    expect(find.textContaining('Offline — showing saved copy from'),
+        findsNothing);
+  });
+
+  testWidgets('a 429 with no cached copy shows the rate-limit subtitle',
+      (WidgetTester tester) async {
+    final service = _QueuedTripsApiService([
+      ApiException(
+          statusCode: 429, message: 'rate limited', endpoint: '/trips/t1'),
+    ]);
+
+    await _pumpDetail(tester, service, TripCache('u1'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Could not load this trip'), findsOneWidget);
+    expect(
+        find.text(
+            "You're going a little too fast — wait a moment and try again."),
+        findsOneWidget);
+  });
 }


### PR DESCRIPTION
## Summary
Client half of the hard-refresh burst fix (server half: #351, deployed). Makes the app structurally unable to pin a transient failure for a whole session:

- **`ApiClient.send()`** — one explicit shared request path for the boot-critical calls: 12s per-attempt timeout + bounded retry (429/503 retry any method — this API emits them only pre-handler from the limiter/shedder; 502 and transport failures retry GETs only), `Retry-After` honored clamped to 4s. Exhausted transport failures rethrow the original exception unwrapped, preserving the `TripCache.isNetworkError` offline contract. Migrated call sites: `getTrip`, airports lookup, `getPreferences`, `getReview` (the rest of the services move in a later cleanup lane).
- **Provider self-heal** — `homeAirportPointProvider` no longer swallows errors into a session-pinned `null` (null now = confirmed empty only); both it and `tripReviewProvider` arm a one-shot 30s `invalidateSelf` on transient errors, so the home-airport map legs and the health app-bar icon reappear on their own. This breaks the deadlock where the health icon's only retry path lived behind the icon the error had hidden. Stable errors (viewer 404) stay cached as before.
- **Trip screen** — transient `getTrip` failures (429/502/503) now fall back to the cached trip read-only with the existing offline banner instead of the dead-end screen (403/404 still never resurrect from cache); `_homeAirport` reaches the map via a change-guarded `setState` instead of riding incidental rebuilds; the error screen gains a status-aware `friendlyError` subtitle (existing en+es l10n keys — zero ARB churn, no gen-l10n run).

## Testing
- `flutter analyze --no-fatal-infos --fatal-warnings` clean (3 pre-existing infos in an untouched file).
- Full `flutter test` suite green: **917 tests**, including new:
  - `api_client_send_test.dart` — the full retry matrix incl. unwrapped-transport-rethrow asserting `TripCache.isNetworkError` still matches.
  - `boot_burst_providers_test.dart` — fake-clock proof both providers refetch 30s after a transient error, and that 404/confirmed-empty are cached with zero retry traffic.
  - Widget tests: 429-with-cache → offline banner (not the dead end); typed 404 → error page (no resurrect); 429-no-cache → rate-limit subtitle; prefs failing on boot then succeeding on a quiet refresh reaches the map (the guarded-setState regression); transient review failure self-heals and restores the health icon + badge.
- `fake_async` promoted from transitive to declared dev dependency (only pubspec change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)