### PR TITLE
feat(flutter): move trip delete behind an app-bar overflow menu

### DIFF
--- a/src/packages/flutter-app/lib/l10n/app_en.arb
+++ b/src/packages/flutter-app/lib/l10n/app_en.arb
@@ -707,6 +707,7 @@
   "tripTurnOffSharing": "Turn off sharing",
   "tripDeleteTrip": "Delete trip",
   "tripRemoveFromMyTrips": "Remove from my trips",
+  "tripMoreActions": "More options",
   "tripLocalIntel": "Local intel",
   "tripLocalGuideTitle": "Local guide: {title}",
   "@tripLocalGuideTitle": {

--- a/src/packages/flutter-app/lib/l10n/app_es.arb
+++ b/src/packages/flutter-app/lib/l10n/app_es.arb
@@ -346,6 +346,7 @@
   "tripTurnOffSharing": "Desactivar el uso compartido",
   "tripDeleteTrip": "Eliminar viaje",
   "tripRemoveFromMyTrips": "Quitar de mis viajes",
+  "tripMoreActions": "Más opciones",
   "tripLocalIntel": "Información local",
   "tripLocalGuideTitle": "Guía local: {title}",
   "tripGuideBy": "Por {name}",

--- a/src/packages/flutter-app/lib/l10n/app_localizations.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations.dart
@@ -63,7 +63,7 @@ import 'app_localizations_es.dart';
 /// property.
 abstract class AppLocalizations {
   AppLocalizations(String locale)
-    : localeName = intl.Intl.canonicalizedLocale(locale.toString());
+      : localeName = intl.Intl.canonicalizedLocale(locale.toString());
 
   final String localeName;
 
@@ -86,16 +86,16 @@ abstract class AppLocalizations {
   /// of delegates is preferred or required.
   static const List<LocalizationsDelegate<dynamic>> localizationsDelegates =
       <LocalizationsDelegate<dynamic>>[
-        delegate,
-        GlobalMaterialLocalizations.delegate,
-        GlobalCupertinoLocalizations.delegate,
-        GlobalWidgetsLocalizations.delegate,
-      ];
+    delegate,
+    GlobalMaterialLocalizations.delegate,
+    GlobalCupertinoLocalizations.delegate,
+    GlobalWidgetsLocalizations.delegate,
+  ];
 
   /// A list of this localizations delegate's supported locales.
   static const List<Locale> supportedLocales = <Locale>[
     Locale('en'),
-    Locale('es'),
+    Locale('es')
   ];
 
   /// Product name. Not translated — it is a brand name.
@@ -5136,9 +5136,8 @@ AppLocalizations lookupAppLocalizations(Locale locale) {
   }
 
   throw FlutterError(
-    'AppLocalizations.delegate failed to load unsupported locale "$locale". This is likely '
-    'an issue with the localizations generation tool. Please file an issue '
-    'on GitHub with a reproducible sample app and the gen-l10n configuration '
-    'that was used.',
-  );
+      'AppLocalizations.delegate failed to load unsupported locale "$locale". This is likely '
+      'an issue with the localizations generation tool. Please file an issue '
+      'on GitHub with a reproducible sample app and the gen-l10n configuration '
+      'that was used.');
 }

--- a/src/packages/flutter-app/lib/l10n/app_localizations.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations.dart
@@ -63,7 +63,7 @@ import 'app_localizations_es.dart';
 /// property.
 abstract class AppLocalizations {
   AppLocalizations(String locale)
-      : localeName = intl.Intl.canonicalizedLocale(locale.toString());
+    : localeName = intl.Intl.canonicalizedLocale(locale.toString());
 
   final String localeName;
 
@@ -86,16 +86,16 @@ abstract class AppLocalizations {
   /// of delegates is preferred or required.
   static const List<LocalizationsDelegate<dynamic>> localizationsDelegates =
       <LocalizationsDelegate<dynamic>>[
-    delegate,
-    GlobalMaterialLocalizations.delegate,
-    GlobalCupertinoLocalizations.delegate,
-    GlobalWidgetsLocalizations.delegate,
-  ];
+        delegate,
+        GlobalMaterialLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+      ];
 
   /// A list of this localizations delegate's supported locales.
   static const List<Locale> supportedLocales = <Locale>[
     Locale('en'),
-    Locale('es')
+    Locale('es'),
   ];
 
   /// Product name. Not translated — it is a brand name.
@@ -2173,6 +2173,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Remove from my trips'**
   String get tripRemoveFromMyTrips;
+
+  /// No description provided for @tripMoreActions.
+  ///
+  /// In en, this message translates to:
+  /// **'More options'**
+  String get tripMoreActions;
 
   /// No description provided for @tripLocalIntel.
   ///
@@ -5130,8 +5136,9 @@ AppLocalizations lookupAppLocalizations(Locale locale) {
   }
 
   throw FlutterError(
-      'AppLocalizations.delegate failed to load unsupported locale "$locale". This is likely '
-      'an issue with the localizations generation tool. Please file an issue '
-      'on GitHub with a reproducible sample app and the gen-l10n configuration '
-      'that was used.');
+    'AppLocalizations.delegate failed to load unsupported locale "$locale". This is likely '
+    'an issue with the localizations generation tool. Please file an issue '
+    'on GitHub with a reproducible sample app and the gen-l10n configuration '
+    'that was used.',
+  );
 }

--- a/src/packages/flutter-app/lib/l10n/app_localizations_en.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations_en.dart
@@ -1169,6 +1169,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get tripRemoveFromMyTrips => 'Remove from my trips';
 
   @override
+  String get tripMoreActions => 'More options';
+
+  @override
   String get tripLocalIntel => 'Local intel';
 
   @override

--- a/src/packages/flutter-app/lib/l10n/app_localizations_es.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations_es.dart
@@ -1180,6 +1180,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get tripRemoveFromMyTrips => 'Quitar de mis viajes';
 
   @override
+  String get tripMoreActions => 'Más opciones';
+
+  @override
   String get tripLocalIntel => 'Información local';
 
   @override

--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -4931,8 +4931,8 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
                   ? null
                   : () => _openRefine(trip, const RefineTarget.trip()),
             ),
-          // Sharing and deletion are owner-only surfaces; editors see
-          // neither. Both mutate, so they're hidden while offline-serving.
+          // Sharing is an owner-only surface; it mutates, so it's hidden
+          // while offline-serving.
           if (trip != null && trip.isOwner && !_isOffline)
             PopupMenuButton<String>(
               key: _shareMenuKey,
@@ -4969,19 +4969,41 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
                     value: 'revoke', child: Text(l10n.tripTurnOffSharing)),
               ],
             ),
-          if (trip != null && trip.isOwner && !_isOffline)
-            IconButton(
-              icon: const Icon(Icons.delete_outline),
-              tooltip: l10n.tripDeleteTrip,
-              onPressed: _delete,
-            ),
-          // Members (editors and viewer follows) can drop the trip from
-          // their own list; the owner's trip is untouched.
-          if (trip != null && !trip.isOwner && !_isOffline)
-            IconButton(
-              icon: const Icon(Icons.bookmark_remove_outlined),
-              tooltip: l10n.tripRemoveFromMyTrips,
-              onPressed: _leaveTrip,
+          // Destructive exits live behind an overflow menu, not a bare
+          // icon: owners get delete, members (editors and viewer follows)
+          // get remove-from-my-list — the owner's trip is untouched. Both
+          // still confirm via their handlers' dialogs.
+          if (trip != null && !_isOffline)
+            PopupMenuButton<String>(
+              icon: const Icon(Icons.more_vert),
+              tooltip: l10n.tripMoreActions,
+              onSelected: (v) => switch (v) {
+                'delete' => _delete(),
+                _ => _leaveTrip(),
+              },
+              itemBuilder: (context) => [
+                if (trip.isOwner)
+                  PopupMenuItem(
+                    value: 'delete',
+                    child: ListTile(
+                      leading: Icon(Icons.delete_outline,
+                          color: Theme.of(context).colorScheme.error),
+                      title: Text(l10n.tripDeleteTrip,
+                          style: TextStyle(
+                              color: Theme.of(context).colorScheme.error)),
+                      contentPadding: EdgeInsets.zero,
+                    ),
+                  )
+                else
+                  PopupMenuItem(
+                    value: 'leave',
+                    child: ListTile(
+                      leading: const Icon(Icons.bookmark_remove_outlined),
+                      title: Text(l10n.tripRemoveFromMyTrips),
+                      contentPadding: EdgeInsets.zero,
+                    ),
+                  ),
+              ],
             ),
         ],
       ),

--- a/src/packages/flutter-app/test/trip_detail_offline_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_offline_test.dart
@@ -37,9 +37,10 @@ class _QueuedTripsApiService extends TripsApiService {
   }
 }
 
-Trip _trip(String title) => Trip(
+Trip _trip(String title, {String? access}) => Trip(
       id: 't1',
       title: title,
+      access: access,
       createdAt: '2026-06-01',
       updatedAt: '2026-06-01',
       items: [
@@ -148,7 +149,9 @@ void main() {
     ));
     expect(rename.onPressed, isNull);
     expect(find.byTooltip('Share trip'), findsNothing);
-    expect(find.byTooltip('Delete trip'), findsNothing);
+    // Delete/leave live behind the overflow menu, which mutates and is
+    // therefore hidden entirely while offline-serving.
+    expect(find.byTooltip('More options'), findsNothing);
 
     // The Bookings view's add menu is likewise disabled, not hidden. The
     // tab tap itself stays allowed offline — switching views is pure view
@@ -359,5 +362,47 @@ void main() {
         find.text(
             "You're going a little too fast — wait a moment and try again."),
         findsOneWidget);
+  });
+
+  group('app-bar overflow menu', () {
+    testWidgets('owner: delete sits behind the menu and still confirms',
+        (WidgetTester tester) async {
+      final service = _QueuedTripsApiService([_trip('Athens Trip')]);
+
+      await _pumpDetail(tester, service, TripCache('u1'));
+      await tester.pumpAndSettle();
+
+      // No bare delete button in the app bar anymore.
+      expect(find.byTooltip('Delete trip'), findsNothing);
+
+      await tester.tap(find.byTooltip('More options'));
+      await tester.pumpAndSettle();
+      expect(find.text('Delete trip'), findsOneWidget);
+
+      await tester.tap(find.text('Delete trip'));
+      await tester.pumpAndSettle();
+      expect(find.text('Delete trip?'), findsOneWidget);
+      expect(find.text('This cannot be undone.'), findsOneWidget);
+
+      // Cancel keeps the trip.
+      await tester.tap(find.text('Cancel'));
+      await tester.pumpAndSettle();
+      expect(find.text('Delete trip?'), findsNothing);
+      expect(find.text('Acropolis'), findsOneWidget);
+    });
+
+    testWidgets('non-owner: menu offers remove-from-my-trips, not delete',
+        (WidgetTester tester) async {
+      final service =
+          _QueuedTripsApiService([_trip('Athens Trip', access: 'editor')]);
+
+      await _pumpDetail(tester, service, TripCache('u1'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byTooltip('More options'));
+      await tester.pumpAndSettle();
+      expect(find.text('Remove from my trips'), findsOneWidget);
+      expect(find.text('Delete trip'), findsNothing);
+    });
   });
 }


### PR DESCRIPTION
## Summary
- Replace the bare trash `IconButton` (and the non-owner bookmark-remove icon) in the trip detail app bar with a single trailing ⋮ overflow menu: owners see an error-tinted **Delete trip** item, members see **Remove from my trips**.
- The existing confirmation dialog ("Delete trip? This cannot be undone.") and `_delete()`/`_leaveTrip()` handlers are untouched — this only removes the accidental-tap surface from the bar.
- Gating semantics preserved: the menu renders only when the trip is loaded and not offline-serving.
- New l10n key `tripMoreActions` ("More options" / "Más opciones") for the menu tooltip; generated `app_localizations*.dart` regenerated via `flutter gen-l10n`.

## Testing
- `flutter analyze` — clean (3 pre-existing infos in `route_response.dart`, unrelated).
- `flutter test` — full suite green.
- New widget tests in `test/trip_detail_offline_test.dart`: owner path (no bare delete button → menu → Delete trip → confirmation dialog → Cancel keeps trip) and non-owner path (menu shows Remove from my trips, no Delete trip); the offline test now asserts the whole menu is hidden while offline-serving.
- No manual browser pass — widget tests cover all three states; eyeball on the lane stack (`make docker-dev-bg` → localhost:3012) if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)