### PR TITLE
feat(flutter): wear & pack leaves the body for an app-bar icon + sheet

### DIFF
--- a/docs/friction-log.md
+++ b/docs/friction-log.md
@@ -5,6 +5,34 @@ build queue. Priority when picking work: **breakage > friction in features
 actually used > ideas that recur across ≥2 sessions**. Tag entries `[app]`
 (dogfooding the product) or `[dev]` (workflow/tooling). Newest first.
 
+## 2026-08-13 — trip-detail dogfooding (wear & pack → app-bar icon)
+
+- **[app] Friction → fixed (packing dropdown → app-bar icon + sheet):**
+  "What to wear and pack shouldn't be a separate dropdown" — with health in
+  the app bar and Budget a header tab, the lone collapsed row at the page
+  tail read as leftover chrome. It followed health's exact path: an
+  **app-bar luggage icon** (right of health, every breakpoint, still there
+  in the Budget view) opening a **bottom-sheet modal**
+  (`showWearPackSheet`); the trailing-cluster scaffolding
+  (`_sectionCluster`/`_expandedSections`) retired with its last row. The
+  old collapsed summary (temp envelope · rain) and checked/total pill
+  moved into the sheet header. Deliberately **no badge** on the icon —
+  health's severity count sits next door, and two adjacent numbers would
+  compete for the glance. Two mechanics diverge from the health sheet:
+  weather **regions are a press-time snapshot** (the screen's
+  `_legClothingRecs` stays the one producer; the checklist half stays
+  live via its provider — a checkbox ticked in the sheet updates the
+  header pill in place), and the scrollable pads by `viewInsets.bottom`
+  because this sheet hosts a TextField (the add-item row) and
+  `showModalBottomSheet` applies no keyboard insets itself.
+  `ChecklistSection.isOffline` became a live callback (the
+  TripReviewSection trade). Known debt carried over, slightly widened:
+  the checklist's offline/error snackbars render behind the sheet barrier
+  — for health only success-path snackbars were affected; here errors
+  are too. Accepted because the live list is the primary feedback (a
+  failed toggle visibly doesn't stick); a sheet-local inline note like the
+  hours-check revert is the named follow-up if it bites.
+
 ## 2026-08-12 — trip-detail dogfooding (trip health modal)
 
 - **[app] Friction → fixed (health row → app-bar icon + badge, the 08-03

--- a/specs/what-to-wear/plan.md
+++ b/specs/what-to-wear/plan.md
@@ -150,3 +150,27 @@ Go-twin contract", `leg_ranges.dart:227`).
   with chip umbrella days; far trip = "typical" per row; read-only viewer;
   agent `add_packing_item` + Trip-health one-tap fix land in the merged
   section; print packet unchanged; Spanish spot-check).
+
+## Amendment 2026-08-13 — surface move: app-bar icon + modal sheet
+
+The trailing-cluster row retired; the entry is now an app-bar luggage icon
+opening a modal bottom sheet (the Trip health precedent, friction-log
+2026-08-13). Design decisions: no count badge on the icon (health's numeric
+badge sits next door; the checked/total pill moved into the sheet header);
+weather regions are a press-time snapshot passed into the sheet
+(`_legClothingRecs` stays the one producer) while the checklist stays live
+via its own provider; the old two-tier visibility gate collapsed into the
+icon's single Consumer (`_legClothingRecsVisible` deleted); the sheet pads
+its scrollable by `viewInsets.bottom` because it hosts the add-item
+TextField (the health sheet has no input).
+
+Files: new `lib/widgets/wear_pack_sheet.dart` (`showWearPackSheet` +
+`WearPackSheetBody`); `lib/screens/trip_detail_screen.dart`
+(`_wearAppBarAction`, cluster scaffolding `_sectionCluster` /
+`_expandedSections` / `_packingSectionRow` / `_wearSummary` /
+`_legClothingRecsVisible` deleted, packing sliver → plain 96px FAB spacer);
+`lib/widgets/checklist_section.dart` (`isOffline` bool → live callback);
+tests: `trip_detail_wear_section_test.dart` reworked to the icon/sheet
+surface + new cases (Escape, breakpoints, live pill, Budget-view icon),
+`trip_detail_fix_actions_test.dart` layout contract, `checklist_section_test.dart`
+callback form, `trip_detail_filter_lenses_test.dart` comment.

--- a/specs/what-to-wear/spec.md
+++ b/specs/what-to-wear/spec.md
@@ -18,6 +18,19 @@ these dates" qualifier became a single trailing footnote — on real trips the
 repetition read as noise, and three near-identical "Warm — …" rows said
 nothing the fold doesn't.
 
+Amended 2026-08-13 (direction picked by Brian): the surface moved. The
+trailing-cluster dropdown row retired; the section is now an **app-bar
+luggage icon** (next to Trip health, no breakpoint gate, visible in the
+Budget view too) opening a **modal bottom sheet** (`wear_pack_sheet.dart`) —
+the Trip health precedent. The sheet header carries the title, the old
+collapsed summary, and the checked/total pill; the body is unchanged
+(guidance rows, footnote, checklist). The icon has **no** count badge —
+health's numeric badge sits next door — so the envelope/checked-count are
+now one tap away instead of glanceable in the body. The icon hides exactly
+when the old row did (no resolved checklist and no leg with weather).
+Weather regions are a press-time snapshot; the checklist stays live inside
+the sheet.
+
 ## User Stories
 
 - As a **traveler planning a trip**, I want **to see what kind of clothes suit
@@ -31,10 +44,12 @@ nothing the fold doesn't.
 
 ## Acceptance Criteria
 
-- [ ] The trailing-cluster row is titled "What to wear & pack" and, when
-      weather is available, its collapsed summary shows the cross-region
-      temperature envelope and rain signal (e.g. "21°–31° · rain likely").
-- [ ] Expanded, the section lists one row per run of consecutive same-guidance
+- [ ] The app-bar luggage icon (tooltip "What to wear & pack") opens a modal
+      sheet whose header shows the title and, when weather is available, the
+      cross-region temperature envelope and rain signal (e.g. "21°–31° ·
+      rain likely"). *(2026-08-13: was the trailing-cluster row's collapsed
+      summary.)*
+- [ ] The sheet lists one row per run of consecutive same-guidance
       legs: legs merge when the temperature band and the surviving advisory
       phrases match AND the date ranges are adjacent (≤1 day apart). A row
       shows the joined region labels, the merged date span, the merged
@@ -52,12 +67,13 @@ nothing the fold doesn't.
 - [ ] The editable packing checklist renders below the recommendations, fully
       intact: add/edit/check/delete, AI-seeded items, Trip-health one-tap
       fixes, export and print packet are all unchanged.
-- [ ] The checked-count stays glanceable while collapsed (pill on the row).
-- [ ] A read-only viewer with an empty checklist sees the section when weather
-      resolves (recommendations only, no add affordance).
+- [ ] The checked-count renders as the pill in the sheet header (2026-08-13:
+      was on the collapsed row) and live-updates with edits made in the sheet.
+- [ ] A read-only viewer with an empty checklist sees the icon and sheet when
+      weather resolves (recommendations only, no add affordance).
 - [ ] When no weather resolves (offline, undated trip, provider failure), the
-      section gates exactly as today: nothing until the checklist loads,
-      hidden for viewers with an empty checklist.
+      icon gates exactly as the old row did: nothing until the checklist
+      loads, hidden for viewers with an empty checklist.
 - [ ] Recommendations never contradict Trip-health weather findings shown on
       the same screen (shared edges: extreme heat, freezing, rain-likely).
 

--- a/specs/what-to-wear/tasks.md
+++ b/specs/what-to-wear/tasks.md
@@ -35,3 +35,30 @@
 - [ ] Manual end-to-end via this lane's gateway (`make docker-dev` →
       http://localhost:3001): every acceptance criterion in `spec.md`
 - [ ] `ship pr` (lane stops at PR-open; integrator merges)
+
+## Amendment 2026-08-13 — app-bar icon + sheet
+
+- [x] `lib/widgets/wear_pack_sheet.dart`: `showWearPackSheet` shell (560px
+      cap, 0.8 height, keyboard-inset padding, no Scaffold) +
+      `WearPackSheetBody` (header title · summary · pill; rows; live
+      checklist)
+- [x] `checklist_section.dart`: `isOffline` bool → live callback
+- [x] `trip_detail_screen.dart`: `_wearAppBarAction` next to health; cluster
+      scaffolding + row + visibility gate deleted; 96px FAB spacer keeps the
+      `!_inBudgetView` gate (Budget pads its own)
+- [x] Tests: wear-section file reworked to tooltip finders + sheet scoping;
+      new Escape / breakpoints / live-pill / Budget-view cases; fix-actions
+      layout contract; checklist callback call site
+- [x] Spec + friction log amended
+
+## Verification (2026-08-13)
+
+- [x] `make flutter-analyze` clean (3 pre-existing route_response infos only)
+- [x] Affected test files green (64 tests)
+- [x] `make flutter-test` full suite (933 passing; sticky-headers offsets
+      retuned for the 8px tail-extent change)
+- [x] Manual via this lane's gateway (http://localhost:3011): icon next to
+      health, sheet content, add-item with keyboard, live pill, Escape,
+      Budget view, viewer gating
+- [ ] `ship pr` (lane stops at PR-open; integrator merges — NOTE: PR #356
+      also touches the trip-detail app bar; hub-file resolve expected)

--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -60,8 +60,6 @@ import '../widgets/booking_sheets.dart';
 import '../widgets/booking_todo_card.dart';
 import '../widgets/budget_section.dart';
 import '../widgets/budget_target_dialog.dart';
-import '../widgets/checklist_section.dart';
-import '../widgets/collapsible_section.dart';
 import '../widgets/trip_health_sheet.dart';
 import '../widgets/trip_review_section.dart';
 import '../widgets/empty_state.dart';
@@ -75,7 +73,7 @@ import '../widgets/source_links_card.dart';
 import '../widgets/status_pill.dart';
 import '../widgets/trip_map.dart';
 import '../widgets/trip_refine_panel.dart';
-import '../widgets/wear_recs.dart';
+import '../widgets/wear_pack_sheet.dart';
 import 'flight_search_screen.dart';
 import 'local_guide_detail_screen.dart';
 import 'trip_detail_derivation.dart';
@@ -239,11 +237,6 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
   String? _unfocusedOpenLegKey;
   final Set<String> _collapsedDays = {};
   bool _citySeedConsumed = false;
-  // Trailing sections (Packing/Budget) render as collapsed one-line
-  // summaries; this holds the ones the user opened. Session-only, like the
-  // city/day sets, and held HERE (not in the section widgets) so expansion
-  // survives silent refreshes and the offline-banner reparent.
-  final Set<String> _expandedSections = {};
   String?
       _homeAirport; // traveler's saved home airport (IATA), for outbound/return flights
   // todo_key -> flight leg, so a transport booking item can open Find Flights
@@ -4217,39 +4210,6 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
   /// reorders to "mié, 15 jul" on its own.
   String _fmtDayHeader(DateTime d) => mmmed().format(d);
 
-  // ── Trailing collapsed sections ─────────────────────────────────────────
-  // Packing ends the page as a one-line summary row, closed by default.
-  // Summary data comes from watches HERE in the parent — the section widget
-  // is only mounted while expanded, so a child-side watch could never feed
-  // a collapsed row's counts. (Trip health left this cluster for the
-  // app-bar icon + sheet — see _healthAppBarAction; Budget left it for the
-  // header tab — see _budgetTabVisible.)
-
-  bool _sectionExpanded(String id) => _expandedSections.contains(id);
-
-  void _toggleSection(String id) => setState(() {
-        if (!_expandedSections.add(id)) _expandedSections.remove(id);
-      });
-
-  /// Lays out the trailing section rows in a settings-list rhythm: hairline
-  /// dividers between the rows that are present. Hidden rows are null, so a
-  /// divider never renders against a missing neighbor.
-  Widget _sectionCluster(List<Widget?> rows) {
-    final present = rows.whereType<Widget>().toList();
-    if (present.isEmpty) return const SizedBox.shrink();
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      children: [
-        const SizedBox(height: AppSpacing.md),
-        const Divider(height: 1),
-        for (final (i, row) in present.indexed) ...[
-          if (i > 0) const Divider(height: 1),
-          row,
-        ],
-      ],
-    );
-  }
-
   /// The itinerary's trailing "Other bookings" area — the home for
   /// everything the retired Bookings section held that has no city slot:
   /// residual todos (custom bookings, stale autos) and confirmed records
@@ -4289,7 +4249,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
     );
   }
 
-  /// Per-leg what-to-wear derivations for the merged section
+  /// Per-leg what-to-wear derivations for the wear/pack sheet
   /// (specs/what-to-wear). Weather queries stay on rawLegRanges — the
   /// doc-pinned range source shared with the day chips (leg_ranges.dart) —
   /// while the DISPLAYED dates come from the index-aligned visibleLegRanges
@@ -4304,12 +4264,12 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
   /// per-visit rows. Loading or failed reports derive null and drop out;
   /// offline this is simply empty. Consecutive same-guidance recs fold into
   /// one displayed row inside [WearRecsList] ([groupWearRegions]) — a
-  /// display-layer concern only, so the watches and [_wearSummary] stay
-  /// per-leg here.
+  /// display-layer concern only, so the watches and the sheet header's
+  /// summary stay per-leg here.
   List<WearRegionRec> _legClothingRecs(Trip trip, WidgetRef ref) {
-    // NOTE: [ref] is the packing row's Consumer ref, NOT the State's — the
-    // weather watches here must subscribe that row, never the whole screen
-    // (the screen-scope visibility gate is [_legClothingRecsVisible]).
+    // NOTE: [ref] is the app-bar wear action's Consumer ref, NOT the
+    // State's — the weather watches here must subscribe that icon, never
+    // the whole screen (see _wearAppBarAction).
     final derivation = _derive(trip);
     final raw = derivation.rawRanges;
     final visible = derivation.visibleRanges; // 1:1 by index with raw
@@ -4337,104 +4297,6 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
       ));
     }
     return recs;
-  }
-
-  /// Collapsed one-liner for the merged row: the cross-region temperature
-  /// envelope plus the rain signal. Kind-neutral by design — the "typical"
-  /// qualifier lives in the expanded block's single footnote.
-  String _wearSummary(List<WearRegionRec> recs) {
-    final s = clothingSummary([for (final r in recs) r.rec]);
-    // Spaced dash like the date ranges ("Sep 15 – Sep 20"), so a negative low
-    // never collides with it ("-6° – 2°").
-    final range = '${s.loC}° – ${s.hiC}°';
-    return s.rainLikely ? '$range · ${context.l10n.wearSummaryRain}' : range;
-  }
-
-  Widget? _packingSectionRow(Trip trip, ThemeData theme) {
-    // Merged "What to wear & pack" (specs/what-to-wear): weather-derived
-    // recommendations on top, the editable checklist below. Recommendations
-    // alone can show the row (read-only viewers get guidance even with an
-    // empty checklist); without weather the gate reduces exactly to the old
-    // checklist-only rule, which mirrors ChecklistSection's own gates
-    // (nothing until loaded; viewers with an empty list get no checklist).
-    // The parent (whole-screen) watch is VISIBILITY only — narrow bool
-    // selects, so the screen rebuilds when the row appears or disappears
-    // (preserving _sectionCluster's null-counting divider contract) while
-    // content updates (checks ticked, weather details) rebuild only the
-    // Consumer below.
-    final showChecklistGate = ref.watch(checklistProvider(trip.id).select((a) {
-      final items = a.valueOrNull;
-      return items != null && !(items.isEmpty && _readOnly);
-    }));
-    if (!showChecklistGate && !_legClothingRecsVisible(trip)) return null;
-    return Consumer(
-      builder: (context, ref, _) {
-        final items = ref.watch(checklistProvider(trip.id)).valueOrNull;
-        final recs = _legClothingRecs(trip, ref);
-        final showChecklist = items != null && !(items.isEmpty && _readOnly);
-        // The parent gate and this content can disagree for one frame while
-        // a provider flips; render nothing rather than dereference a state
-        // the gate no longer justifies.
-        if (recs.isEmpty && !showChecklist) return const SizedBox.shrink();
-        final checked = items?.where((i) => i.checked).length ?? 0;
-        // With recs in the summary slot, the checked-count stays glanceable
-        // via the pill (same chrome as ChecklistSection's standalone header).
-        final summary = recs.isNotEmpty
-            ? _wearSummary(recs)
-            : context.l10n.checklistSummary(checked, items!.length);
-        return CollapsibleSection(
-          title: context.l10n.wearSectionTitle,
-          icon: Icons.luggage_outlined,
-          summary: summary,
-          pill: (recs.isEmpty || items == null || items.isEmpty)
-              ? null
-              : StatusPill.custom(
-                  label: '$checked/${items.length}',
-                  background: theme.colorScheme.surfaceContainerHighest,
-                  foreground: theme.colorScheme.onSurfaceVariant,
-                ),
-          expanded: _sectionExpanded('packing'),
-          onToggle: () => _toggleSection('packing'),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
-              if (recs.isNotEmpty) WearRecsList(regions: recs),
-              if (recs.isNotEmpty && showChecklist) const Divider(height: 24),
-              ChecklistSection(
-                tripId: trip.id,
-                canEdit: !_readOnly,
-                isOffline: _isOffline,
-                showHeader: false,
-              ),
-            ],
-          ),
-        );
-      },
-    );
-  }
-
-  /// Visibility half of [_legClothingRecs]: does ANY leg currently have a
-  /// clothing recommendation? Watched at screen scope with per-leg bool
-  /// selects, so a weather report resolving flips this at most once — the
-  /// full recommendation content is watched only inside the packing row's
-  /// Consumer. The early return is deliberate: once one leg says visible,
-  /// later legs don't need subscriptions to answer the question.
-  bool _legClothingRecsVisible(Trip trip) {
-    for (final r in _derive(trip).rawRanges) {
-      if (r.label == _kOtherPlaces || r.start == null || r.end == null) {
-        continue;
-      }
-      final has = ref.watch(weatherByCityProvider(WeatherQuery(
-        city: r.label,
-        startDate: _fmt(r.start!),
-        endDate: _fmt(r.end!),
-      )).select((a) {
-        final report = a.valueOrNull;
-        return report != null && clothingRec(report) != null;
-      }));
-      if (has) return true;
-    }
-    return false;
   }
 
   /// Whether the Budget header tab renders. Editors/owners: always — tab
@@ -4502,6 +4364,47 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
                   label: Text('${findings.length}'),
                   child: icon,
                 ),
+        );
+      },
+    );
+  }
+
+  /// The app-bar "What to wear & pack" entry: the luggage icon, opening the
+  /// wear/pack sheet. Replaced the trailing-cluster row (friction-log
+  /// 2026-08-13) — the last of the trailing sections, so the cluster
+  /// scaffolding left with it. No count badge: health's severity count sits
+  /// next door and two adjacent numbers would compete; the checked/total
+  /// pill lives in the sheet header instead.
+  ///
+  /// One Consumer scopes every watch to this icon, collapsing the old
+  /// two-tier gate split (screen-scope bool selects + row-scope content
+  /// watches): full watches here repaint the icon alone — the cost class
+  /// the old row's Consumer already paid. Hidden while neither half has
+  /// data (checklist unresolved or viewer-empty, and no leg with weather),
+  /// matching the old row's gate. Not _inBudgetView-gated: that gate
+  /// belonged to the scroll body, and health set the precedent that
+  /// app-bar icons stay put across views.
+  Widget _wearAppBarAction(Trip trip) {
+    return Consumer(
+      builder: (context, ref, _) {
+        final items = ref.watch(checklistProvider(trip.id)).valueOrNull;
+        final showChecklist = items != null && !(items.isEmpty && _readOnly);
+        final recs = _legClothingRecs(trip, ref);
+        if (recs.isEmpty && !showChecklist) return const SizedBox.shrink();
+        return IconButton(
+          tooltip: context.l10n.wearSectionTitle,
+          icon: const Icon(Icons.luggage_outlined),
+          onPressed: () => showWearPackSheet(
+            context,
+            tripId: trip.id,
+            // Snapshot: regions freeze at open (reopen refreshes); the
+            // checklist half stays live via its own provider watch.
+            regions: recs,
+            canEdit: !_readOnly,
+            // Live read, not a captured bool: the sheet route never
+            // rebuilds on this screen's connectivity setState.
+            isOffline: () => _isOffline,
+          ),
         );
       },
     );
@@ -4917,8 +4820,10 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
           // Contextual icons lead; share/delete/leave keep the outer-edge
           // spots for every role. Health goes first: its severity count
           // badge is glanceable state, worth the leading slot on every
-          // breakpoint (it replaced the trailing-cluster row).
+          // breakpoint. Wear & pack rides beside it — both replaced
+          // trailing-cluster rows, and neither is breakpoint-gated.
           if (trip != null) _healthAppBarAction(trip, theme),
+          if (trip != null) _wearAppBarAction(trip),
           // Narrow: the header card drops its Refine button (one clean chip
           // row), so the trip-level refine entry moves up here.
           // Same gates as the button it replaces: editors only
@@ -5532,24 +5437,16 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
                                     gutter, AppSpacing.sm, gutter, 0),
                                 sliver: SliverToBoxAdapter(child: other),
                               ),
-                          // Trailing section (Packing), collapsed to a
-                          // one-line summary row (settings-list rhythm);
-                          // the 96px bottom padding keeps the chat FAB off
-                          // the last row. The row hides itself exactly when
-                          // its expanded section would (see the builder).
-                          // Suppressed in the Budget view — packing under
-                          // the budget body would be noise. (Budget's own
-                          // row left this cluster for the header tab.)
+                          // Keeps the chat FAB off the last row. Stays
+                          // gated: the Budget view's sliver above pads its
+                          // own 96, so an unconditional spacer would
+                          // double-pad it. The trailing section cluster
+                          // that lived here is gone — Wear & pack was its
+                          // last row and now opens from the app bar
+                          // (_wearAppBarAction).
                           if (!_inBudgetView)
-                            SliverPadding(
-                              padding: EdgeInsets.fromLTRB(
-                                  gutter, AppSpacing.sm, gutter, 96),
-                              sliver: SliverToBoxAdapter(
-                                child: _sectionCluster([
-                                  _packingSectionRow(trip, theme),
-                                ]),
-                              ),
-                            ),
+                            const SliverToBoxAdapter(
+                                child: SizedBox(height: 96)),
                         ],
                       );
 

--- a/src/packages/flutter-app/lib/widgets/checklist_section.dart
+++ b/src/packages/flutter-app/lib/widgets/checklist_section.dart
@@ -11,15 +11,24 @@ import 'status_pill.dart';
 
 /// The per-trip packing checklist: a lightweight list the AI assistant seeds
 /// (add_packing_item) and the traveler edits freely. On trip detail it renders
-/// body-only (showHeader: false) inside the merged "What to wear & pack" row
-/// (specs/what-to-wear), below the weather-derived recommendations; standalone
-/// it keeps its own "Packing & prep" header. Self-contained — it owns its data
-/// via [checklistProvider] and reconciles mutations by invalidating that
-/// family key.
+/// body-only (showHeader: false) inside the "What to wear & pack" sheet
+/// (specs/what-to-wear, wear_pack_sheet.dart), below the weather-derived
+/// recommendations; standalone it keeps its own "Packing & prep" header.
+/// Self-contained — it owns its data via [checklistProvider] and reconciles
+/// mutations by invalidating that family key.
 class ChecklistSection extends ConsumerStatefulWidget {
   final String tripId;
   final bool canEdit;
-  final bool isOffline;
+
+  /// Live read, not a captured bool: this widget's host is a modal sheet
+  /// route that never rebuilds on the screen's connectivity setState. The
+  /// action guards read it at call time; the add row's disabled VISUAL only
+  /// reflects the last build, so it can stay stale until something else
+  /// rebuilds the sheet body (a connectivity flip alone never does) — the
+  /// TripReviewSection trade. A guarded tap while stale-enabled shows the
+  /// offline snackbar behind the sheet barrier (known debt, friction-log
+  /// 2026-08-13); the mutation itself never fires.
+  final bool Function() isOffline;
 
   /// False when a parent (trip detail's collapsed-section row) already
   /// renders the divider/title/count, so this widget is body-only.
@@ -83,7 +92,7 @@ class _ChecklistSectionState extends ConsumerState<ChecklistSection> {
   }
 
   bool _guard() {
-    if (widget.isOffline) {
+    if (widget.isOffline()) {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(content: Text(context.l10n.commonOffline)),
       );
@@ -294,7 +303,7 @@ class _ChecklistSectionState extends ConsumerState<ChecklistSection> {
         DropdownButton<String>(
           value: _addCategory,
           underline: const SizedBox.shrink(),
-          onChanged: widget.isOffline
+          onChanged: widget.isOffline()
               ? null
               : (v) => setState(() => _addCategory = v ?? 'general'),
           items: [
@@ -321,7 +330,7 @@ class _ChecklistSectionState extends ConsumerState<ChecklistSection> {
         IconButton(
           icon: const Icon(Icons.add),
           tooltip: context.l10n.checklistAddItemTooltip,
-          onPressed: widget.isOffline ? null : _add,
+          onPressed: widget.isOffline() ? null : _add,
         ),
       ],
     );

--- a/src/packages/flutter-app/lib/widgets/wear_pack_sheet.dart
+++ b/src/packages/flutter-app/lib/widgets/wear_pack_sheet.dart
@@ -1,0 +1,165 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../l10n/l10n.dart';
+import '../providers/checklist_provider.dart';
+import '../theme/spacing.dart';
+import '../utils/clothing_recs.dart';
+import 'checklist_section.dart';
+import 'status_pill.dart';
+import 'wear_recs.dart';
+
+/// Opens "What to wear & pack" as a modal bottom sheet — the body behind the
+/// app-bar luggage icon on the trip detail screen. It replaced the
+/// trailing-cluster row, the same move Trip health made (friction-log
+/// 2026-08-13).
+///
+/// [regions] is a snapshot computed by the screen's `_legClothingRecs` at
+/// press time, so that derivation stays in exactly one place. The weather
+/// providers behind it are settled before the icon renders; the only loss is
+/// a report resolving while the sheet is open (reopen refreshes). The
+/// checklist is NOT snapshotted: [ChecklistSection] owns the data via
+/// [checklistProvider], and the header pill watches the same family key, so
+/// edits made inside the sheet update both live.
+///
+/// Feedback contract: the checklist's snackbars (offline guard, generic
+/// error) render BEHIND this sheet's barrier — same accepted debt class as
+/// the health sheet's fix snackbars. Primary feedback is the live list
+/// itself: a failed toggle visibly doesn't stick.
+///
+/// No Scaffold inside the sheet, so the framework's Escape→dismiss handling
+/// works as-is (a nested Scaffold would swallow DismissIntent — the
+/// trip_map_screen trap).
+Future<void> showWearPackSheet(
+  BuildContext context, {
+  required String tripId,
+  required List<WearRegionRec> regions,
+  required bool canEdit,
+  required bool Function() isOffline,
+}) {
+  return showModalBottomSheet<void>(
+    context: context,
+    showDragHandle: true,
+    isScrollControlled: true,
+    useSafeArea: true,
+    // Width cap centers the sheet on desktop, same as the health sheet:
+    // guidance rows and checklist entries read stranded at full bleed.
+    constraints: const BoxConstraints(maxWidth: 560),
+    builder: (sheetContext) {
+      return SafeArea(
+        child: ConstrainedBox(
+          constraints: BoxConstraints(
+            maxHeight: MediaQuery.of(sheetContext).size.height * 0.8,
+          ),
+          child: SingleChildScrollView(
+            // Unlike the health sheet, this one hosts a TextField (the
+            // add-item row), and showModalBottomSheet applies no keyboard
+            // insets itself — pad the scrollable by viewInsets so the field
+            // stays above the keyboard (add_to_trip_sheet's recipe).
+            padding: EdgeInsets.fromLTRB(
+              AppSpacing.lg,
+              0,
+              AppSpacing.lg,
+              AppSpacing.lg + MediaQuery.of(sheetContext).viewInsets.bottom,
+            ),
+            child: WearPackSheetBody(
+              tripId: tripId,
+              regions: regions,
+              canEdit: canEdit,
+              isOffline: isOffline,
+            ),
+          ),
+        ),
+      );
+    },
+  );
+}
+
+/// The sheet body: a header line (title · summary · checked-count pill) over
+/// the per-leg guidance rows and the live checklist — the same composition
+/// the old collapsed-section row expanded to. Public so tests can scope
+/// finders to the sheet.
+class WearPackSheetBody extends ConsumerWidget {
+  final String tripId;
+  final List<WearRegionRec> regions;
+  final bool canEdit;
+
+  /// Live read, not a captured bool: the sheet route never rebuilds on the
+  /// screen's connectivity setState.
+  final bool Function() isOffline;
+
+  const WearPackSheetBody({
+    super.key,
+    required this.tripId,
+    required this.regions,
+    required this.canEdit,
+    required this.isOffline,
+  });
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final theme = Theme.of(context);
+    final l10n = context.l10n;
+    final items = ref.watch(checklistProvider(tripId)).valueOrNull;
+    final showChecklist = items != null && !(items.isEmpty && !canEdit);
+    // The app-bar icon's gate and this body can disagree for one frame while
+    // a provider flips; render nothing rather than dereference a state the
+    // gate no longer justifies.
+    if (regions.isEmpty && !showChecklist) return const SizedBox.shrink();
+    final checked = items?.where((i) => i.checked).length ?? 0;
+    // Header one-liner: the cross-region temperature envelope plus the rain
+    // signal — kind-neutral by design, the "typical" qualifier lives in
+    // [WearRecsList]'s single footnote. Spaced dash like the date ranges
+    // ("Sep 15 – Sep 20"), so a negative low never collides with it
+    // ("-6° – 2°"). Without weather, the checked-count summary stands in.
+    final String summary;
+    if (regions.isNotEmpty) {
+      final s = clothingSummary([for (final r in regions) r.rec]);
+      final range = '${s.loC}° – ${s.hiC}°';
+      summary = s.rainLikely ? '$range · ${l10n.wearSummaryRain}' : range;
+    } else {
+      summary = l10n.checklistSummary(checked, items!.length);
+    }
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Row(
+          children: [
+            Text(
+              l10n.wearSectionTitle,
+              style: theme.textTheme.titleSmall
+                  ?.copyWith(fontWeight: FontWeight.w600),
+            ),
+            const SizedBox(width: AppSpacing.md),
+            Expanded(
+              child: Text(
+                summary,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: theme.textTheme.bodySmall
+                    ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+              ),
+            ),
+            // With recs in the summary slot, the checked count stays
+            // glanceable via the pill (the old collapsed row's rule).
+            if (regions.isNotEmpty && items != null && items.isNotEmpty)
+              StatusPill.custom(
+                label: '$checked/${items.length}',
+                background: theme.colorScheme.surfaceContainerHighest,
+                foreground: theme.colorScheme.onSurfaceVariant,
+              ),
+          ],
+        ),
+        const SizedBox(height: AppSpacing.sm),
+        if (regions.isNotEmpty) WearRecsList(regions: regions),
+        if (regions.isNotEmpty && showChecklist) const Divider(height: 24),
+        ChecklistSection(
+          tripId: tripId,
+          canEdit: canEdit,
+          isOffline: isOffline,
+          showHeader: false,
+        ),
+      ],
+    );
+  }
+}

--- a/src/packages/flutter-app/test/checklist_section_test.dart
+++ b/src/packages/flutter-app/test/checklist_section_test.dart
@@ -76,7 +76,7 @@ Future<_FakeChecklistApiService> _pump(
         home: Scaffold(
           body: SingleChildScrollView(
             child: ChecklistSection(
-                tripId: 't1', canEdit: canEdit, isOffline: isOffline),
+                tripId: 't1', canEdit: canEdit, isOffline: () => isOffline),
           ),
         ),
       ),

--- a/src/packages/flutter-app/test/trip_detail_filter_lenses_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_filter_lenses_test.dart
@@ -784,7 +784,9 @@ void main() {
     expect(tester.widget<Text>(find.text('Budget')).style?.fontWeight,
         FontWeight.w700);
     expect(find.text('Hotel'), findsOneWidget);
-    // The city groups and the packing cluster row are swapped out.
+    // The city groups are swapped out. (Wear & pack left the body for the
+    // app-bar icon — its title text appears in NEITHER view now; the
+    // positive Budget-view icon pin lives in trip_detail_wear_section_test.)
     expect(find.text('Louvre'), findsNothing);
     expect(find.text('What to wear & pack'), findsNothing);
   });

--- a/src/packages/flutter-app/test/trip_detail_fix_actions_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_fix_actions_test.dart
@@ -353,13 +353,13 @@ void main() {
   });
 
   testWidgets(
-      'health lives in the app bar; Budget is a header tab and the cluster '
-      'is packing-only', (tester) async {
-    // Layout contract (friction-log 2026-08-12, evolving 2026-08-04): Trip
+      'health and packing live in the app bar; Budget is a header tab',
+      (tester) async {
+    // Layout contract (friction-log 2026-08-13, evolving 2026-08-04): Trip
     // health left the trailing cluster for the always-visible app-bar icon
-    // (its count badge is the glanceable state), and Budget left it for the
-    // third header tab — the cluster is What to wear & pack only, with no
-    // health row in the body.
+    // (its count badge is the glanceable state), Budget left it for the
+    // third header tab, and What to wear & pack — the cluster's last row —
+    // left for the app-bar luggage icon, retiring the cluster entirely.
     final review = _FakeReviewApiService([
       _finding('packing', 'No umbrella for rainy Athens',
           const FindingFix(
@@ -375,22 +375,21 @@ void main() {
         budget: _FakeBudgetApiService(),
         openSheet: false);
 
-    // The health entry is the app-bar icon; no "Trip health" row in the body.
+    // Both contextual entries are app-bar icons; neither renders a body row.
     expect(find.byTooltip('Trip health'), findsOneWidget);
     expect(find.text('Trip health'), findsNothing);
+    expect(find.byTooltip('What to wear & pack'), findsOneWidget);
+    expect(find.text('What to wear & pack'), findsNothing);
 
-    // Budget renders exactly once — as the tab, above the packing row (the
-    // tall test viewport lays the whole page out in one frame).
+    // Budget renders exactly once — as the tab.
     final budgetTab = find.text('Budget');
     expect(budgetTab, findsOneWidget);
-    expect(tester.getTopLeft(budgetTab).dy,
-        lessThan(tester.getTopLeft(find.text('What to wear & pack')).dy));
 
-    // Tapping it swaps the body for the budget view: the empty state
-    // arrives, the packing cluster row goes.
+    // Tapping it swaps the body for the budget view; the app-bar icons are
+    // not view-gated and stay put.
     await tester.tap(budgetTab);
     await tester.pumpAndSettle();
     expect(find.text('No budget yet'), findsOneWidget);
-    expect(find.text('What to wear & pack'), findsNothing);
+    expect(find.byTooltip('What to wear & pack'), findsOneWidget);
   });
 }

--- a/src/packages/flutter-app/test/trip_detail_sticky_headers_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_sticky_headers_test.dart
@@ -80,9 +80,11 @@ void main() {
     // and day headers have reached their pinned slots. jumpTo keeps offsets
     // exact (drag gestures fling unpredictably past the target). Offsets
     // retuned for the accordion (only the open Paris group contributes
-    // extent), then again when the add-button trio left the itinerary tail
-    // for the Bookings view's header menu: max extent is now ~570, so a
-    // 600 target would clamp — 450/570 replace the old 450/600.
+    // extent), again when the add-button trio left the itinerary tail for
+    // the Bookings view's header menu (450/570 replaced 450/600), and again
+    // when the wear/pack section left the tail for the app-bar icon — its
+    // sliver's 8px top pad went with it, so max extent is now ~562 and a
+    // 570 target would clamp: 450/550.
     final position =
         tester.state<ScrollableState>(find.byType(Scrollable).first).position;
     position.jumpTo(450);
@@ -94,14 +96,14 @@ void main() {
 
     // Scroll a bit further, still within Paris day 2: the pinned city and
     // day headers hold their position while the items keep moving.
-    position.jumpTo(570);
+    position.jumpTo(550);
     await tester.pumpAndSettle();
 
     expect(
         tester.getTopLeft(find.text('Paris')).dy, moreOrLessEquals(parisDyA));
     expect(tester.getTopLeft(find.text('Day 2')).dy, moreOrLessEquals(day2DyA));
     expect(tester.getTopLeft(find.text('Paris stop 4')).dy,
-        moreOrLessEquals(stopDyA - 120));
+        moreOrLessEquals(stopDyA - 100));
     // Pinned headers sit on screen, day header below the city header.
     expect(parisDyA, greaterThan(0));
     expect(day2DyA, greaterThan(parisDyA));

--- a/src/packages/flutter-app/test/trip_detail_wear_section_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_wear_section_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
@@ -16,20 +17,23 @@ import 'package:travel_route_planner/providers/checklist_provider.dart';
 import 'package:travel_route_planner/providers/trips_provider.dart';
 import 'package:travel_route_planner/providers/weather_provider.dart';
 import 'package:travel_route_planner/screens/trip_detail_screen.dart';
-import 'package:travel_route_planner/widgets/collapsible_section.dart';
+import 'package:travel_route_planner/widgets/wear_pack_sheet.dart';
 import 'package:travel_route_planner/widgets/wear_recs.dart';
 
 import 'support/l10n_test_app.dart';
 
-/// The merged "What to wear & pack" section (specs/what-to-wear): collapsed
-/// summary = cross-region temperature envelope + rain signal; expanded =
-/// deterministic phrase rows above the intact checklist, with consecutive
-/// same-guidance legs folded into ONE grouped row (groupWearRegions);
-/// historical data yields a single trailing footnote, never a per-row
-/// qualifier; a revisited city keeps per-visit weather queries (distinct
-/// guidance keeps its rows separate); a leg whose report is empty drops out
-/// without hiding the section; recommendations alone show the row for
-/// read-only viewers; without weather the old checklist gating holds.
+/// "What to wear & pack" (specs/what-to-wear), now an app-bar luggage icon
+/// opening a modal sheet (the Trip health precedent): the sheet header shows
+/// the cross-region temperature envelope + rain signal and the checked/total
+/// pill; the body is deterministic phrase rows above the intact checklist,
+/// with consecutive same-guidance legs folded into ONE grouped row
+/// (groupWearRegions); historical data yields a single trailing footnote,
+/// never a per-row qualifier; a revisited city keeps per-visit weather
+/// queries (distinct guidance keeps its rows separate); a leg whose report is
+/// empty drops out without hiding the icon; recommendations alone show the
+/// icon for read-only viewers; without weather the old checklist gating
+/// holds. The checklist stays LIVE inside the sheet (its provider), while
+/// the regions are a press-time snapshot.
 
 class _FakeTripsApiService extends TripsApiService {
   final Trip trip;
@@ -76,6 +80,29 @@ class _FakeChecklistApiService extends ChecklistApiService {
 
   @override
   Future<List<ChecklistItem>> list(String tripId) async => items;
+}
+
+/// Mutable checklist fake: update() patches in place so the reconcile-by-
+/// invalidate round trip (toggle → PATCH → list) is observable — pins the
+/// live-checklist half of the sheet's snapshot/live split.
+class _MutableChecklistApiService extends ChecklistApiService {
+  final List<ChecklistItem> items;
+  _MutableChecklistApiService(this.items)
+      : super(ApiClient(baseUrl: 'http://test'));
+
+  @override
+  Future<List<ChecklistItem>> list(String tripId) async => List.of(items);
+
+  @override
+  Future<ChecklistItem> update(
+      String tripId, String itemId, Map<String, dynamic> body) async {
+    final i = items.indexWhere((e) => e.id == itemId);
+    items[i] = items[i].copyWith(
+      checked: body['checked'] as bool?,
+      title: body['title'] as String?,
+    );
+    return items[i];
+  }
 }
 
 ItineraryItem _item(int pos, String name, int day, {String city = 'Paris'}) =>
@@ -135,10 +162,12 @@ Future<void> _pump(
   WeatherReport? report,
   WeatherApiService? weather,
   List<ChecklistItem> checklist = const [],
+  ChecklistApiService? checklistApi,
   Locale? locale,
+  Size size = const Size(800, 3000),
 }) async {
-  // Tall viewport so the trailing cluster lays out without scrolling.
-  tester.view.physicalSize = const Size(800, 3000);
+  // Tall default viewport so the whole page lays out without scrolling.
+  tester.view.physicalSize = size;
   tester.view.devicePixelRatio = 1.0;
   addTearDown(tester.view.reset);
   await tester.pumpWidget(
@@ -147,8 +176,8 @@ Future<void> _pump(
         tripsApiServiceProvider.overrideWithValue(_FakeTripsApiService(trip)),
         weatherApiServiceProvider
             .overrideWithValue(weather ?? _FakeWeatherApiService(report!)),
-        checklistApiServiceProvider
-            .overrideWithValue(_FakeChecklistApiService(checklist)),
+        checklistApiServiceProvider.overrideWithValue(
+            checklistApi ?? _FakeChecklistApiService(checklist)),
       ],
       child: localizedTestApp(
           home: TripDetailScreen(tripId: 't1'), locale: locale),
@@ -157,10 +186,14 @@ Future<void> _pump(
   await tester.pumpAndSettle();
 }
 
-Future<void> _expand(WidgetTester tester,
-    {String title = 'What to wear & pack'}) async {
-  await tester.ensureVisible(find.text(title));
-  await tester.tap(find.text(title));
+Finder _wearIcon({String tooltip = 'What to wear & pack'}) =>
+    find.byTooltip(tooltip);
+
+/// Taps the app-bar luggage icon (always on screen — no ensureVisible) and
+/// settles with the sheet open.
+Future<void> _openSheet(WidgetTester tester,
+    {String tooltip = 'What to wear & pack'}) async {
+  await tester.tap(_wearIcon(tooltip: tooltip));
   await tester.pumpAndSettle();
 }
 
@@ -169,12 +202,11 @@ Future<void> _expand(WidgetTester tester,
 Finder _inRecs(String text) => find.descendant(
     of: find.byType(WearRecsList), matching: find.textContaining(text));
 
-Finder _wearSectionDividers() => find.descendant(
-    of: find.widgetWithText(CollapsibleSection, 'What to wear & pack'),
-    matching: find.byType(Divider));
+Finder _sheetDividers() => find.descendant(
+    of: find.byType(WearPackSheetBody), matching: find.byType(Divider));
 
 void main() {
-  testWidgets('collapsed row shows the envelope summary and the checked pill',
+  testWidgets('icon opens the sheet; header shows the summary and the pill',
       (tester) async {
     await _pump(
       tester,
@@ -187,16 +219,22 @@ void main() {
       ],
     );
 
+    // The entry is the app-bar icon: no body row, no summary, no content
+    // until the sheet opens.
+    expect(_wearIcon(), findsOneWidget);
+    expect(find.text('What to wear & pack'), findsNothing);
+    expect(find.text('15° – 24° · rain likely'), findsNothing);
+    expect(find.textContaining('Warm —'), findsNothing);
+    expect(find.text('Umbrella'), findsNothing);
+
+    await _openSheet(tester);
     expect(find.text('What to wear & pack'), findsOneWidget);
     expect(find.text('15° – 24° · rain likely'), findsOneWidget);
     // Checked count stays glanceable via the pill while recs own the summary.
     expect(find.text('1/2'), findsOneWidget);
-    // Collapsed: no phrases, no checklist rows.
-    expect(find.textContaining('Warm —'), findsNothing);
-    expect(find.text('Umbrella'), findsNothing);
   });
 
-  testWidgets('expanded: per-region phrase rows above the intact checklist',
+  testWidgets('sheet body: per-region phrase rows above the intact checklist',
       (tester) async {
     await _pump(
       tester,
@@ -206,7 +244,7 @@ void main() {
         ChecklistItem(id: 'c1', category: 'general', title: 'Umbrella'),
       ],
     );
-    await _expand(tester);
+    await _openSheet(tester);
 
     // Region line: label · dates · envelope.
     expect(_inRecs('Paris · Sep 15 – Sep 16 · 15° – 24°'), findsOneWidget);
@@ -220,7 +258,7 @@ void main() {
     // All-forecast trip: no historical footnote either.
     expect(_inRecs('Beyond the 16-day forecast'), findsNothing);
     // Recs and checklist both present → exactly one separating divider.
-    expect(_wearSectionDividers(), findsOneWidget);
+    expect(_sheetDividers(), findsOneWidget);
     // The checklist renders below, still editable: item row + add field.
     expect(find.text('Umbrella'), findsOneWidget);
     expect(find.byType(Checkbox), findsOneWidget);
@@ -237,7 +275,7 @@ void main() {
         ChecklistItem(id: 'c1', category: 'general', title: 'Umbrella'),
       ],
     );
-    await _expand(tester);
+    await _openSheet(tester);
 
     expect(_inRecs('Warm — summer clothes'), findsOneWidget);
     // The old per-row tail is gone. Scoped to the wear block: the day chips
@@ -278,7 +316,7 @@ void main() {
       ]),
       weather: weather,
     );
-    await _expand(tester);
+    await _openSheet(tester);
 
     // Two Paris rows with their own visit windows and temps, Nice between.
     // Displayed dates are the VISIBLE ranges (arrival-inclusive, matching the
@@ -289,7 +327,7 @@ void main() {
     // Both Paris visit windows were genuinely queried (per-visit keys).
     expect(weather.calls, contains('Paris|2026-09-15'));
     expect(weather.calls, contains('Paris|2026-09-17'));
-    // Collapsed summary spans all three legs: 8..25, no rain.
+    // Header summary spans all three legs: 8..25, no rain.
     expect(find.text('8° – 25°'), findsOneWidget);
   });
 
@@ -297,8 +335,9 @@ void main() {
       (tester) async {
     // Paris and Nice both derive warm with no advisories → one row with the
     // joined labels and the merged envelope. Exactly one band phrase pins the
-    // fold (a regression to per-leg rows would find two). The collapsed
-    // summary is computed from the UNGROUPED per-leg recs and must agree.
+    // fold (a regression to per-leg rows would find two). The header summary
+    // is computed from the UNGROUPED per-leg recs and must agree (exact-text
+    // match: the grouped row's longer string can't satisfy it).
     final weather = _MapWeatherApiService({
       'Paris|2026-09-15': const WeatherReport(kind: 'forecast', days: [
         WeatherDay(date: '2026-09-15', tempMinC: 16, tempMaxC: 24),
@@ -315,9 +354,9 @@ void main() {
       ]),
       weather: weather,
     );
+    await _openSheet(tester);
 
     expect(find.text('15° – 24°'), findsOneWidget);
-    await _expand(tester);
     expect(
         _inRecs('Paris, Nice · Sep 15 – Sep 16 · 15° – 24°'), findsOneWidget);
     expect(_inRecs('Warm — summer clothes, a light evening layer'),
@@ -348,7 +387,7 @@ void main() {
       ]),
       weather: weather,
     );
-    await _expand(tester);
+    await _openSheet(tester);
 
     expect(
         _inRecs('Paris, Nice · Sep 15 – Sep 16 · 15° – 24°'), findsOneWidget);
@@ -375,10 +414,10 @@ void main() {
       ]),
       weather: weather,
     );
+    await _openSheet(tester);
 
     // Summary is Paris's envelope alone — the unresolved leg can't zero it.
     expect(find.text('16° – 24°'), findsOneWidget);
-    await _expand(tester);
     expect(_inRecs('Paris · Sep 15'), findsOneWidget);
     expect(_inRecs('Nice'), findsNothing);
   });
@@ -391,32 +430,34 @@ void main() {
       report: _warmRainyForecast,
     );
 
+    expect(_wearIcon(), findsOneWidget);
+    await _openSheet(tester);
+
     expect(find.text('What to wear & pack'), findsOneWidget);
     expect(find.text('15° – 24° · rain likely'), findsOneWidget);
     // No checked pill for an empty checklist.
     expect(find.text('0/0'), findsNothing);
-
-    await _expand(tester);
     expect(_inRecs('Warm — summer clothes'), findsOneWidget);
     // Viewer + empty checklist: no add affordance, no checkboxes, and no
     // dangling divider under the recs (the checklist rendered nothing).
     expect(find.byType(Checkbox), findsNothing);
     expect(find.textContaining('Add an item'), findsNothing);
-    expect(_wearSectionDividers(), findsNothing);
+    expect(_sheetDividers(), findsNothing);
   });
 
   testWidgets('no weather: gating is exactly the old checklist behavior',
       (tester) async {
-    // Viewer + empty checklist + empty weather → no section at all.
+    // Viewer + empty checklist + empty weather → no icon at all.
     await _pump(
       tester,
       trip: _trip(access: 'viewer'),
       report: const WeatherReport(),
     );
+    expect(_wearIcon(), findsNothing);
     expect(find.text('What to wear & pack'), findsNothing);
   });
 
-  testWidgets('no weather, owner: checklist-only row with the count summary',
+  testWidgets('no weather, owner: checklist-only sheet with the count summary',
       (tester) async {
     await _pump(
       tester,
@@ -427,11 +468,98 @@ void main() {
       ],
     );
 
+    // The checklist gate alone shows the icon.
+    expect(_wearIcon(), findsOneWidget);
+    await _openSheet(tester);
+
     expect(find.text('What to wear & pack'), findsOneWidget);
     // Old summary shape (checked of total), no envelope text anywhere.
     expect(find.textContaining('° – '), findsNothing);
     expect(find.textContaining('0/1'), findsNothing); // count is not a pill…
     expect(find.textContaining('0 of 1'), findsOneWidget); // …but the summary
+  });
+
+  testWidgets('ticking a checkbox in the sheet live-updates the header pill',
+      (tester) async {
+    // Pins the sheet's snapshot/live split: regions freeze at open, but the
+    // checklist half (rows AND the header pill) watches the provider the
+    // toggle invalidates, so an edit made inside the sheet lands live.
+    final api = _MutableChecklistApiService([
+      const ChecklistItem(id: 'c1', category: 'general', title: 'Umbrella'),
+      const ChecklistItem(
+          id: 'c2', category: 'clothing', title: 'Jacket', checked: true),
+    ]);
+    await _pump(
+      tester,
+      trip: _trip(),
+      report: _warmRainyForecast,
+      checklistApi: api,
+    );
+    await _openSheet(tester);
+    expect(find.text('1/2'), findsOneWidget);
+
+    await tester.tap(find
+        .byWidgetPredicate((w) => w is Checkbox && w.value == false));
+    await tester.pumpAndSettle();
+
+    expect(find.text('2/2'), findsOneWidget);
+    // The weather half kept its snapshot — summary unchanged.
+    expect(find.text('15° – 24° · rain likely'), findsOneWidget);
+  });
+
+  testWidgets('Escape dismisses the sheet', (tester) async {
+    await _pump(
+      tester,
+      trip: _trip(),
+      report: _warmRainyForecast,
+      checklist: const [
+        ChecklistItem(id: 'c1', category: 'general', title: 'Umbrella'),
+      ],
+    );
+    await _openSheet(tester);
+    expect(find.byType(WearPackSheetBody), findsOneWidget);
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.escape);
+    await tester.pumpAndSettle();
+    expect(find.byType(WearPackSheetBody), findsNothing);
+  });
+
+  testWidgets('icon shows on phone and desktop widths (not narrow-gated)',
+      (tester) async {
+    await _pump(
+      tester,
+      trip: _trip(),
+      report: _warmRainyForecast,
+      size: const Size(390, 800),
+    );
+    expect(_wearIcon(), findsOneWidget);
+
+    await _pump(
+      tester,
+      trip: _trip(),
+      report: _warmRainyForecast,
+      size: const Size(1200, 800),
+    );
+    expect(_wearIcon(), findsOneWidget);
+  });
+
+  testWidgets('the icon stays put in the Budget view', (tester) async {
+    // The old body row was suppressed under Budget; the app-bar icon is not
+    // view-gated (the health precedent) — packing stays one tap away.
+    await _pump(
+      tester,
+      trip: _trip(),
+      report: _warmRainyForecast,
+      checklist: const [
+        ChecklistItem(id: 'c1', category: 'general', title: 'Umbrella'),
+      ],
+    );
+    await tester.tap(find.text('Budget'));
+    await tester.pumpAndSettle();
+
+    expect(_wearIcon(), findsOneWidget);
+    await _openSheet(tester);
+    expect(find.text('15° – 24° · rain likely'), findsOneWidget);
   });
 
   testWidgets('renders the Spanish strings under the es locale',
@@ -449,9 +577,10 @@ void main() {
       locale: const Locale('es'),
     );
 
+    expect(_wearIcon(tooltip: 'Qué ponerte y qué llevar'), findsOneWidget);
+    await _openSheet(tester, tooltip: 'Qué ponerte y qué llevar');
     expect(find.text('Qué ponerte y qué llevar'), findsOneWidget);
     expect(find.textContaining('lluvia probable'), findsWidgets);
-    await _expand(tester, title: 'Qué ponerte y qué llevar');
     expect(
         find.descendant(
             of: find.byType(WearRecsList),
@@ -471,7 +600,7 @@ void main() {
       report: _dryHistorical,
       locale: const Locale('es'),
     );
-    await _expand(tester, title: 'Qué ponerte y qué llevar');
+    await _openSheet(tester, tooltip: 'Qué ponerte y qué llevar');
 
     expect(
         find.descendant(


### PR DESCRIPTION
## Summary
- The "What to wear & pack" collapsed dropdown at the trip-detail tail is replaced by an **app-bar luggage icon** next to Trip health (no breakpoint gate, visible in the Budget view too) that opens a **modal bottom sheet** — the #343 Trip-health pattern.
- New `wear_pack_sheet.dart`: `showWearPackSheet` (560px cap, 0.8 height, nearest navigator, no Scaffold so Escape dismisses, keyboard-inset padding for the add-item TextField) + public `WearPackSheetBody` (header = title · temp-envelope/rain summary · checked-total pill; then guidance rows, divider, live checklist).
- **No badge** on the icon — health's severity count sits next door; the checked/total pill moved into the sheet header.
- Weather regions are a **press-time snapshot** (`_legClothingRecs` stays the one producer; the old two-tier gate collapsed into the icon's Consumer, `_legClothingRecsVisible` deleted); the **checklist stays live** — a checkbox ticked inside the sheet updates the header pill in place. `ChecklistSection.isOffline` bool → live callback.
- Trailing-cluster scaffolding (`_sectionCluster`/`_expandedSections`/`_packingSectionRow`) retired with its last row; the tail sliver is a plain 96px FAB spacer (still `!_inBudgetView` — Budget pads its own 96), shifting max scroll extent by 8px (sticky-headers offsets retuned per that test's own convention).
- Spec (`specs/what-to-wear`) amended + friction-log entry; known debt carried over: checklist offline/error snackbars render behind the sheet barrier (live list is the primary feedback).

## Testing
- `flutter analyze` clean (3 pre-existing route_response infos only).
- Full `make flutter-test` suite green (933 tests), including the reworked `trip_detail_wear_section_test.dart` (tooltip finders + sheet scoping, new Escape / 390px+1200px breakpoint / live-pill / Budget-view cases), the rewritten fix-actions layout contract, and the sticky-headers retune.
- Manual on the lane stack (headless Chrome + CDP, seeded trip): icon renders next to health; sheet shows header summary "16° – 29°" + 0/2 pill, merged "Paris, Nice" guidance row, divider, checklist; ticking a box live-updates the pill; add-item via Enter lands grouped; Escape dismisses; icon persists in the Budget view.
- `/code-review medium`: no correctness findings; doc-comment accuracy fix applied.

## Integrator notes
- **PR #356 (delete → overflow menu) also touches the trip-detail app-bar actions block** — expect a small hub-file resolve there; this PR adds `_wearAppBarAction` immediately after the health action.
- Follow-up candidate (review finding, deliberately not in this PR): the modal-sheet shell (drag handle / 560 cap / 0.8 height / SafeArea) now exists in three widgets — a shared `showAppSheet` helper would collapse it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)