### PR TITLE
feat(flutter): trip detail groups land expanded, decoupled from the map; region pins navigate

### DIFF
--- a/docs/friction-log.md
+++ b/docs/friction-log.md
@@ -5,6 +5,41 @@ build queue. Priority when picking work: **breakage > friction in features
 actually used > ideas that recur across ≥2 sessions**. Tag entries `[app]`
 (dogfooding the product) or `[dev]` (workflow/tooling). Newest first.
 
+## 2026-08-13 — trip-detail dogfooding (expanded groups + navigable map)
+
+- **[app] Friction → fixed (decoupled expansion, supersedes the 08-1x
+  "accordion city focus" contract):** the single-open accordion didn't
+  survive daily use either — landing on a trip showed a wall of collapsed
+  headers, and because the open group WAS the map selection, every list
+  action moved the camera and vice versa. Third iteration of this contract
+  (08-11 partial coupling → accordion full coupling → now full
+  DEcoupling), and this one is directional: **expansion is list-only
+  state; focus is map-only state; the map's region pins are how the map
+  drives the list.** Concretely: all city groups land EXPANDED
+  (`_collapsedGroups`, inverted like `_collapsedDays` — empty set = the
+  default, so new cities from a refine arrive open and keys staled by a
+  lens switch fail safe as expanded); a header tap toggles only its own
+  group and never touches the map; `_focusedLegKey` survives as
+  notifier-only map state (chips, camera fit, per-leg pin filtering) with
+  one slim writer (`_setMapFocus`); chip taps keep the combined gesture
+  (focus map + un-collapse + desktop rest-under-chrome scroll) while the
+  All chip resets the map ONLY; and destination pins on the All overview
+  became navigation — tap scrolls the list to that region's group, with
+  deliberately NO focus write (focusing would swap the overview to
+  per-item pins and delete the very pin under the pointer). In the
+  full-screen map a region-pin tap focuses that city in place (the
+  chip-equivalent — there's no list to scroll), and the report-back now
+  pre-scrolls the list on phones too, so closing the modal lands on the
+  region. The accordion machinery went with the contract: the derived
+  `_openGroupKey`, the reveal-only `_unfocusedOpenLegKey` hatch, the
+  sole-group seed, and the one-writer assert are all deleted. N groups now
+  pin N city headers concurrently — safe because each group's containing
+  `MultiSliver` pushes its own header off at the group's end
+  (contacts-style handoff; verified against sliver_tools 0.2.12 source):
+  the OUTER groups `MultiSliver` must stay non-containing or every header
+  would pin to the itinerary's end and stack. The zero-body pinned-header
+  rule below (2026-08-0x entry) still governs collapsed rows verbatim.
+
 ## 2026-08-13 — trip-detail dogfooding (wear & pack → app-bar icon)
 
 - **[app] Friction → fixed (packing dropdown → app-bar icon + sheet):**

--- a/src/packages/flutter-app/lib/screens/trip_detail_derivation.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_derivation.dart
@@ -357,9 +357,9 @@ class TripDerivation {
   /// the leg (nothing should render open — its items aren't in the list).
   /// Positions-based like [legFilteredItems]: lenses only MERGE adjacent
   /// runs, never split one, so leg → group is a function. This is the one
-  /// leg→group mapping (specs/map-city-focus accordion) — expansion is
-  /// derived through it at read time, and it clamps, so build never needs
-  /// to write focus state. Null in → null out, matching a no-focus screen.
+  /// leg→group mapping — chip taps and map region-pin taps resolve their
+  /// un-collapse/scroll target through it, and it clamps, so stale keys
+  /// read as null. Null in → null out, matching a no-focus map.
   String? groupKeyForLeg(String? legKey) {
     if (legKey == null) return null;
     final i = legIndexOf(legKey);
@@ -487,7 +487,10 @@ class TripDerivation {
 
     // Destination pins: the one construction site lives with the map widget
     // (trip_map_destinations.dart), shared with the home recent-trip band.
-    final mapDestinations = tripMapDestinations(rawRanges, l10n);
+    // Leg keys ride along index-aligned ([legs] and [rawRanges] both run the
+    // tripLegs split over the full itinerary) so the pins are navigable.
+    final mapDestinations = tripMapDestinations(rawRanges, l10n,
+        legKeys: [for (final leg in legs) leg.key]);
 
     final firstCoord = rawRanges.isEmpty ? null : rawRanges.first.coord;
     final lastCoord = rawRanges.isEmpty ? null : rawRanges.last.coord;

--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -172,16 +172,14 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
 
   /// Whether the Budget view (third header tab) is active.
   bool get _inBudgetView => _itemFilter == 'budget';
-  // Focused leg on the map (specs/map-city-focus); null = All. Keyed by the
-  // FULL-itinerary run key (leg.key, `#2`-suffixed on revisits) — never the
-  // lens-dependent group key. A ValueNotifier so re-focusing the SAME leg
-  // (a re-tap of the selected chip) rebuilds only the map card's
-  // ListenableBuilder — the notifier drops the same-value write. A focus
-  // CHANGE also flips the derived open group, so _setCityFocus setStates
-  // the screen for the accordion; the notifier scope still spares the
-  // whole-screen rebuild on the no-op re-tap. May hold a stale key after
-  // an edit removes the leg — readers clamp via _clampedLegKey (read-side,
-  // so build never mutates state).
+  // Focused leg on the map; null = All. MAP-ONLY state (chips, camera fit,
+  // per-leg item/stay filtering) — group expansion is _collapsedGroups,
+  // fully decoupled. Keyed by the FULL-itinerary run key (leg.key,
+  // `#2`-suffixed on revisits) — never the lens-dependent group key. A
+  // ValueNotifier consumed solely by the map card's ListenableBuilder, so a
+  // focus write never rebuilds the screen and a same-value write is dropped.
+  // May hold a stale key after an edit removes the leg — readers clamp via
+  // _clampedLegKey (read-side, so build never mutates state).
   final ValueNotifier<String?> _focusedLegKey = ValueNotifier<String?>(null);
   // Whether the map renders as the wide layout's pinned header (true) or the
   // phone layout's scroll-away tap-to-expand card (false). Assigned each
@@ -203,8 +201,8 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
   int? _pendingTodayScroll;
   // Stable identities for the pinned headers so the Today scroller can find
   // their render objects. Days share the `'$cityKey#$day'` scheme with
-  // _collapsedDays; cities are keyed by run key (group.key) like
-  // _openGroupKey resolves.
+  // _collapsedDays; cities are keyed by run key (group.key), the same
+  // keyspace as _collapsedGroups.
   final Map<String, GlobalKey> _dayHeaderKeys = {};
   final Map<String, GlobalKey> _cityHeaderKeys = {};
   // Position of the place focused via a map pin / list tap. A ValueNotifier
@@ -219,24 +217,19 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
   // every consumer filters on !auto.
   List<Accommodation> _stays = [];
   List<TripSegment> _segments = [];
-  // Accordion city focus (specs/map-city-focus): at most ONE city group is
-  // open, and it is DERIVED from the focused leg at read time
-  // (_openGroupKey) — never stored as its own set (docs/zen.md: derived
-  // state is computed in exactly one place; the hand-synced set drifted).
-  // _unfocusedOpenLegKey is the narrow escape hatch — a group open in the
-  // list while the map stays on All: the pin-tap reveal (a focus write
-  // would refit the camera out from under the zoom-to-pin move), the
-  // sole-group seed (a one-city trip collapsed to a single header line is
-  // an empty screen; one-shot via _citySeedConsumed so later groups arrive
-  // collapsed), and every toggle on a <2-leg trip (focus is disabled
-  // there). FULL-itinerary leg key like _focusedLegKey and mutually
-  // exclusive with it (asserted in _setCityFocus, the one writer of both);
-  // stale keys clamp read-side in groupKeyForLeg, never write-side. Days
-  // stay inverted — _collapsedDays empty => open within the open group,
-  // keyed "<cityKey>#<day>" since day numbers repeat across cities.
-  String? _unfocusedOpenLegKey;
+  // Group expansion is LIST-ONLY state, fully decoupled from map focus
+  // (this supersedes the specs/map-city-focus accordion, where the open
+  // group was derived from the focused leg): _collapsedGroups is inverted
+  // like _collapsedDays — empty = ALL groups expanded, the landing default —
+  // and keyed by GROUP key (group.key run keys, `#2`-suffixed on revisits;
+  // the _cityHeaderKeys keyspace). A header tap toggles only its group and
+  // never touches the map; chip taps and map region-pin taps un-collapse
+  // their target on the way to it. Session-only, never pruned: a key staled
+  // by a lens switch or an edit just misses contains() and the group renders
+  // expanded — the safe default. Days stay inverted the same way, keyed
+  // "<cityKey>#<day>" since day numbers repeat across cities.
+  final Set<String> _collapsedGroups = {};
   final Set<String> _collapsedDays = {};
-  bool _citySeedConsumed = false;
   String?
       _homeAirport; // traveler's saved home airport (IATA), for outbound/return flights
   // todo_key -> flight leg, so a transport booking item can open Find Flights
@@ -639,15 +632,14 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
       return;
     }
     _autoScrolledToday = true;
-    // Selection preselect: the leg holding today's items, set before the
-    // first paint so the camera doesn't hop All → today one frame later.
-    // Exact-day match only — an untagged today leaves the default (All /
-    // collapsed) and the pending scroll's nearest-day fallback selects.
-    // On a <2-leg trip the writer routes this through the reveal-only
-    // hatch (focus is disabled there).
+    // Map preselect: the leg holding today's items, set before the first
+    // paint so the camera doesn't hop All → today one frame later.
+    // Exact-day match only — an untagged today leaves the default (All)
+    // and the pending scroll's nearest-day fallback selects. Map-only:
+    // groups land expanded by default, so there is nothing to open.
     final d = _derive(trip);
     final todayLeg = d.legKeyForDay(today);
-    if (todayLeg != null) _setCityFocus(d, todayLeg);
+    if (todayLeg != null) _setMapFocus(d, todayLeg);
     // The scroll itself waits for the first build that actually shows the
     // scroll view: this setState still renders the loading spinner (the
     // loud path clears _loading later, in its finally), so a post-frame
@@ -671,16 +663,14 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
     final cityKey = dayKey.substring(0, dayKey.lastIndexOf('#'));
     final inAltView = _inBookingsView || _inBudgetView;
     final d = _derive(trip);
-    // "Show me that day" SELECTS that day's leg (accordion: its group
-    // becomes the one open group and the map focuses it) — even when the
-    // group is already open reveal-only, so the map always follows the
-    // jump. cityKey is a GROUP key from liveDayKeys; resolve the leg
-    // through an item actually tagged the landed-on day, NOT the group's
-    // first item — under a places lens a merged group spans several runs,
-    // and the first item can belong to an earlier run than the day we're
-    // jumping to (the map would then fit the wrong run). Bookings lenses
-    // and the Budget view keep the places set whole, so the pre-exit
-    // derivation's groups are the post-exit ones too.
+    // "Show me that day" focuses the MAP on that day's leg and un-collapses
+    // its group/day so the header can be measured. cityKey is a GROUP key
+    // from liveDayKeys; resolve the leg through an item actually tagged the
+    // landed-on day, NOT the group's first item — under a places lens a
+    // merged group spans several runs, and the first item can belong to an
+    // earlier run than the day we're jumping to (the map would then fit the
+    // wrong run). Bookings lenses and the Budget view keep the places set
+    // whole, so the pre-exit derivation's groups are the post-exit ones too.
     final dayNum = int.tryParse(dayKey.substring(dayKey.lastIndexOf('#') + 1));
     String? legKey;
     for (final g in d.groups) {
@@ -693,21 +683,22 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
       break;
     }
     // Whether the target section still has layout work to settle before
-    // the scroll can measure it (a closed group opening, a collapsed day
-    // opening, or the lens swap rebuilding the list).
+    // the scroll can measure it (a collapsed group/day opening, or the
+    // lens swap rebuilding the list).
     final needsLayout = inAltView ||
-        _openGroupKey(d) != cityKey ||
+        _collapsedGroups.contains(cityKey) ||
         _collapsedDays.contains(dayKey);
-    if (inAltView || _collapsedDays.contains(dayKey)) {
+    if (needsLayout) {
       setState(() {
         if (inAltView) {
           _itemFilter = 'all';
           _bookingsLensDestination = null;
         }
+        _collapsedGroups.remove(cityKey);
         _collapsedDays.remove(dayKey);
       });
     }
-    if (legKey != null) _setCityFocus(d, legKey); // no-op if already selected
+    if (legKey != null) _setMapFocus(d, legKey); // no-op if already selected
     if (needsLayout) {
       // Continue once the expanded section has laid out.
       WidgetsBinding.instance
@@ -797,100 +788,66 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
     }
   }
 
-  /// The ONE open city group, derived from the selection at read time
-  /// (specs/map-city-focus accordion): the current-filter group holding the
-  /// focused leg's items, else the reveal-only open leg's — null means
-  /// everything is collapsed. Stale keys clamp inside
-  /// [TripDerivation.groupKeyForLeg], so build never writes focus state.
-  String? _openGroupKey(TripDerivation d) =>
-      d.groupKeyForLeg(_focusedLegKey.value ?? _unfocusedOpenLegKey);
-
-  /// THE writer for city focus + list expansion (specs/map-city-focus
-  /// accordion): at most one group open ⇔ the map focused on its leg;
-  /// null collapses everything and returns the map to the All overview.
-  ///
-  /// [keepCamera] opens the run in the list WITHOUT a focus write or a
-  /// selection clear — the pin-tap invariant: a focus write would refit the
-  /// camera out from under the zoom-to-pin move, and the tap just set the
-  /// selection. It can only diverge from focus on the All view (a focused
-  /// map renders its own leg's pins alone), so it no-ops when a live focus
-  /// exists.
-  void _setCityFocus(TripDerivation d, String? legKey,
-      {bool keepCamera = false}) {
-    final beforeFocus = _focusedLegKey.value;
-    final beforeOpen = _unfocusedOpenLegKey;
-    if (keepCamera && legKey != null) {
-      if (_clampedLegKey(d) != null) return; // focused: its own pins only
-      // Clear a stale focus key (clamped to All by the guard above) so the
-      // hatch is the one live truth. This write DOES notify when the old
-      // key was non-null-but-stale, but the camera is unaffected:
-      // fitSignature reads _clampedLegKey, which already resolved to null,
-      // so the null write doesn't change it — no refit over the pin move.
-      _focusedLegKey.value = null;
-      _unfocusedOpenLegKey = legKey;
-    } else if (legKey != null && d.legs.length >= 2) {
-      // Clear the pin selection with the focus change: a lingering
-      // selection would suppress later content refits and keep a ghost
-      // highlight from another leg.
-      _selectedPosition.value = null;
-      _unfocusedOpenLegKey = null;
-      // Same-value writes are dropped by the notifier: re-selecting the
-      // focused leg (or a places-lens sibling run whose group is already
-      // open) never bumps the camera.
-      _focusedLegKey.value = legKey;
-    } else {
-      // Collapse → All, and every open/close on a <2-leg trip, where focus
-      // is disabled (a fit bump would snap a user-panned camera for no
-      // visible change).
-      _selectedPosition.value = null;
-      _unfocusedOpenLegKey = legKey;
-      _focusedLegKey.value = null;
-    }
-    assert(_focusedLegKey.value == null || _unfocusedOpenLegKey == null,
-        'reveal-only open must not coexist with a focused leg');
-    if (_focusedLegKey.value != beforeFocus ||
-        _unfocusedOpenLegKey != beforeOpen) {
-      setState(() {});
-    }
+  /// THE writer for map focus, and ONLY map focus — group expansion is
+  /// [_collapsedGroups], never touched here. No setState: the chips and
+  /// camera both render inside the map card's ListenableBuilder, and the
+  /// notifier drops same-value writes (re-selecting the focused leg never
+  /// bumps the camera). Focus is disabled below two legs (a fit bump would
+  /// snap a user-panned camera for no visible change).
+  void _setMapFocus(TripDerivation d, String? legKey) {
+    if (legKey != null && d.legs.length < 2) return;
+    // Clear the pin selection with the focus change: a lingering selection
+    // would suppress later content refits and keep a ghost highlight from
+    // another leg.
+    _selectedPosition.value = null;
+    _focusedLegKey.value = legKey;
   }
 
-  /// THE selection write for a chip tap (inline strip and the full-screen
-  /// map's report-back) and header expands: accordion focus via
-  /// [_setCityFocus], plus the wide layout's rest-under-the-pinned-map
-  /// scroll (specs/map-city-focus). The All chip (null) deselects
-  /// everywhere — map to the overview AND the open group closed: chips and
-  /// headers are two views of one selection. Header taps pass
-  /// [revealHeader] false — the user is already at the header.
+  /// The combined chip action (inline strip and the full-screen map's
+  /// report-back): focus the map on the leg via [_setMapFocus], un-collapse
+  /// its group, and rest the header under the pinned map (wide layout). The
+  /// All chip (null) resets the MAP only — the list is untouched, since
+  /// expansion is decoupled from focus.
   ///
-  /// Under a places lens the focused leg may belong to a merged group
-  /// ([TripDerivation.groupKeyForLeg]) — that group opens and the desktop
-  /// scroll targets it — or to none (the lens dropped the leg's items): the
-  /// MAP stays right regardless, content comes from the full leg's position
+  /// Under a places lens the leg may belong to a merged group
+  /// ([TripDerivation.groupKeyForLeg]) — that group is the un-collapse and
+  /// scroll target — or to none (the lens dropped the leg's items): the MAP
+  /// stays right regardless, content comes from the full leg's position
   /// set. Under a bookings lens no city headers exist at all: the chip
   /// drives the map only and the lens is NOT exited (unlike _scrollToDay,
   /// whose whole job is list navigation).
-  void _setFocusedLeg(TripDerivation d, String? key,
-      {bool revealHeader = true}) {
+  void _setFocusedLeg(TripDerivation d, String? key) {
     if (d.legs.length < 2) return; // single-leg trips have no focus
-    _setCityFocus(d, key);
-    if (key == null || !revealHeader || !_mapPinned) return;
+    _setMapFocus(d, key);
+    if (key == null) return; // All: map overview only, list untouched
     final groupKey = d.groupKeyForLeg(key);
     if (groupKey == null) return; // lens dropped the leg: nothing to rest
-    // Post-frame so the freshly expanded section has laid out first (the
+    if (_collapsedGroups.remove(groupKey)) setState(() {});
+    // Post-frame so a freshly expanded section has laid out first (the
     // _scrollToDay pattern); on phones the chips ride the scroll-away
     // preview card, so scrolling the list would hide the very map being
     // focused — desktop only.
+    if (!_mapPinned) return;
+    _revealCityHeader(groupKey);
+  }
+
+  /// Scrolls [groupKey]'s header under the chrome on the frame after next —
+  /// post-frame so any un-collapse this tap made has laid out first.
+  /// addPostFrameCallback does NOT itself request a frame, and with groups
+  /// expanded by default the common case (tap on an already-expanded,
+  /// already-focused target) changes no state at all — on a quiescent UI no
+  /// frame would ever come and the scroll would silently stall until
+  /// unrelated activity. ensureVisualUpdate guarantees the frame.
+  void _revealCityHeader(String groupKey) {
     WidgetsBinding.instance
         .addPostFrameCallback((_) => _scrollToCityHeader(groupKey));
+    WidgetsBinding.instance.ensureVisualUpdate();
   }
 
   /// Offset-reveal scroll resting [cityKey]'s header just below the pinned
   /// chrome — [_scrollToDayHeader] minus the city-header term (this header
   /// IS the target; the chrome rests via getOffsetToReveal's own
-  /// obstruction handling, see there). Same one-correction contract. The
-  /// accordion collapse of the previously open group in the same tap frame
-  /// is deliberately uncompensated: with the animation running straight at
-  /// the target it reads as a collapse, not as scroll misbehavior.
+  /// obstruction handling, see there). Same one-correction contract.
   Future<void> _scrollToCityHeader(String cityKey) async {
     final trip = _trip;
     if (!mounted || trip == null || !_scroll.hasClients) return;
@@ -1460,11 +1417,11 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
     }
   }
 
-  /// Groups default collapsed, so a place added into a collapsed run would
-  /// vanish with zero visible feedback — select the run holding the first
-  /// item that wasn't in the trip before the add: its group becomes the one
-  /// open group and the map focuses it, so the new pin is immediately
-  /// visible (specs/map-city-focus accordion).
+  /// Focus the map on the run holding the first item that wasn't in the
+  /// trip before the add, so the new pin is immediately visible. Groups
+  /// default expanded now, so the un-collapse only matters when the user
+  /// manually collapsed the target group — a place added into a collapsed
+  /// run would otherwise land with zero visible feedback.
   void _expandRunsOfNewItems(Set<String> beforeIds) {
     final trip = _trip;
     if (trip == null) return;
@@ -1472,7 +1429,12 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
     for (final i in trip.items ?? const <ItineraryItem>[]) {
       if (beforeIds.contains(i.id)) continue;
       final legKey = d.legKeyOfPosition(i.position);
-      if (legKey != null) _setCityFocus(d, legKey);
+      if (legKey == null) return;
+      _setMapFocus(d, legKey);
+      final groupKey = d.groupKeyForLeg(legKey);
+      if (groupKey != null && _collapsedGroups.remove(groupKey)) {
+        setState(() {});
+      }
       return;
     }
   }
@@ -2262,7 +2224,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
   /// City group header: name, date range, refine + collapse controls. Pinned
   /// at the top of the scroll area while its group scrolls past; the opaque
   /// Material keeps items from showing through while pinned. [cityCollapsed]
-  /// comes from the caller's render branch — the one _openGroupKey read.
+  /// comes from the caller's render branch — the one _collapsedGroups read.
   Widget _cityHeader(Trip trip, CityGroup group, ThemeData theme,
       double dateChipWidth,
       {required bool cityCollapsed}) {
@@ -2273,29 +2235,15 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
         color: theme.scaffoldBackgroundColor,
         child: InkWell(
           onTap: () {
-            // Accordion (specs/map-city-focus): expanding a section IS
-            // selecting it — the previously open group closes and the map
-            // focuses this leg (resolved through the item position: under a
-            // places lens the group key may name a merged run that isn't a
-            // full-itinerary leg). Collapsing the open group always returns
-            // the map to All — only one group can ever be open, so there is
-            // no focused/non-focused asymmetry. No scroll here — the user
-            // is already at the header.
-            final d = _derive(trip);
-            if (!cityCollapsed) {
-              _setCityFocus(d, null);
-              return;
-            }
-            if (group.items.isEmpty) return;
-            final legKey = d.legKeyOfPosition(group.items.first.position);
-            if (legKey == null) return;
-            if (d.legs.length >= 2) {
-              _setFocusedLeg(d, legKey, revealHeader: false);
-            } else {
-              // Sole-group toggle: focus is disabled below two legs, so
-              // this opens through the reveal-only hatch.
-              _setCityFocus(d, legKey);
-            }
+            // A pure list toggle: expansion is decoupled from the map, so a
+            // header tap never writes focus, never moves the camera, and
+            // never touches any other group. No scroll either — the user is
+            // already at the header.
+            setState(() {
+              cityCollapsed
+                  ? _collapsedGroups.remove(group.key)
+                  : _collapsedGroups.add(group.key);
+            });
           },
           child: Padding(
             padding: const EdgeInsets.fromLTRB(16, 16, 16, 4),
@@ -4642,19 +4590,39 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
                           trip.items!.firstWhere((i) => i.position == pos);
                       _selectedPosition.value = pos;
                       // The highlighted row can only be seen if its run
-                      // renders: groups default collapsed, so open the
-                      // tapped item's run — reveal-only ([keepCamera]),
-                      // never a focus write, which would refit the camera
-                      // out from under the zoom-to-pin move. The writer
-                      // setStates only when the open group actually
-                      // changed (the one thing the wider screen must
-                      // re-render — selection itself is notifier-driven).
+                      // renders: un-collapse the tapped item's group in
+                      // case the user closed it. Never a focus write —
+                      // that would refit the camera out from under the
+                      // zoom-to-pin move (the invariant holds by
+                      // construction: nothing here touches
+                      // _focusedLegKey). Selection itself is
+                      // notifier-driven, so setState only on a real
+                      // un-collapse.
                       final d = _derive(trip);
-                      final legKey = d.legKeyOfPosition(pos);
-                      if (legKey != null) {
-                        _setCityFocus(d, legKey, keepCamera: true);
+                      final groupKey =
+                          d.groupKeyForLeg(d.legKeyOfPosition(pos));
+                      if (groupKey != null &&
+                          _collapsedGroups.remove(groupKey)) {
+                        setState(() {});
                       }
                       _showSnack(it.name);
+                    },
+              // Region-pin navigation (All overview only — that's the only
+              // mode destination pins render in): scroll the list to the
+              // region's group. Deliberately NO focus write: focusing
+              // would swap the map to per-item pins and delete the very
+              // pins under the pointer; the camera must not move either.
+              onDestinationTap: expandable
+                  ? null // phone preview: AbsorbPointer'd, tap opens full map
+                  : (legKey) {
+                      final d = _derive(trip);
+                      final groupKey = d.groupKeyForLeg(legKey);
+                      if (groupKey == null) return; // lens dropped the leg
+                      if (_collapsedGroups.remove(groupKey)) setState(() {});
+                      // Under a bookings/budget lens no header builds and
+                      // the scroll no-ops harmlessly (the chip-tap stance:
+                      // no lens exit).
+                      _revealCityHeader(groupKey);
                     },
               onExpand: expandable ? null : () => _openFullMap(trip),
             );
@@ -4766,13 +4734,23 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
           legChips: derivation.legChips,
           mappedLegKeys: derivation.mappedLegKeys,
           initialLegKey: _clampedLegKey(derivation),
-          // The full-screen chip tap reports here: the embedded card's
-          // ListenableBuilder keeps its own chips in sync live, and
-          // _setFocusedLeg pre-selects (opens the group exclusively; on
-          // desktop pre-scrolls) behind the modal, so focus survives close.
+          // A full-screen chip or region-pin tap reports here: the embedded
+          // card's ListenableBuilder keeps its own chips in sync live, and
+          // _setFocusedLeg pre-selects (un-collapses the target; on desktop
+          // pre-scrolls) behind the modal, so focus survives close. On
+          // phones _setFocusedLeg skips its scroll (the inline chips ride
+          // the scroll-away preview), but a selection made INSIDE the full
+          // map should land the list on that region when the modal closes —
+          // there is no visible list to disturb — so pre-scroll here too.
           onLegSelected: (k) {
             final t = _trip;
-            if (t != null) _setFocusedLeg(_derive(t), k);
+            if (t == null) return;
+            final d = _derive(t);
+            _setFocusedLeg(d, k);
+            if (k == null || _mapPinned) return;
+            final groupKey = d.groupKeyForLeg(k);
+            if (groupKey == null) return;
+            _revealCityHeader(groupKey);
           },
           onAddPlace: (_isOffline || _readOnly)
               ? null
@@ -4976,29 +4954,6 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
                       // Shared per-build chip width — see _dateChipWidth's
                       // doc for why this must stay a build-local.
                       final dateChipWidth = _dateChipWidth(groups, theme);
-                      // Groups default collapsed (no selection); a sole
-                      // group is seeded open once — a one-city trip
-                      // collapsed to a single header line is an empty screen.
-                      // One-shot so later groups (refine adds a city) arrive
-                      // collapsed and the seeded one stays re-collapsible.
-                      // A plain field write, NOT _setCityFocus: we're
-                      // mid-build (no setState) and the value is consumed
-                      // later this same build; guarded on a null focus so
-                      // the reveal-hatch/focus exclusivity holds (a today
-                      // preselect from the load path wins).
-                      if (!_citySeedConsumed && groups.isNotEmpty) {
-                        _citySeedConsumed = true;
-                        if (groups.length == 1 &&
-                            groups.first.items.isNotEmpty &&
-                            _focusedLegKey.value == null) {
-                          _unfocusedOpenLegKey ??= derivation.legKeyOfPosition(
-                              groups.first.items.first.position);
-                        }
-                      }
-                      // The one open group this build renders expanded —
-                      // derived from the selection AFTER the seed above so
-                      // a seeded sole group opens on its first frame.
-                      final openGroupKey = _openGroupKey(derivation);
                       // Day-header GlobalKeys for the CURRENT groups' day
                       // keys, not just whatever happens to be built: a
                       // collapsed group's day headers don't exist yet, but
@@ -5145,8 +5100,8 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
                                           // scroll): allowed offline and
                                           // while the refine panel is
                                           // open. _scrollToDay owns the
-                                          // selection write (accordion:
-                                          // the landed-on day's leg) — no
+                                          // map-focus write (the
+                                          // landed-on day's leg) — no
                                           // duplicate focus write here.
                                           onPressed: () =>
                                               _scrollToDay(todayDay),
@@ -5354,7 +5309,22 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
                                   // in. (pushPinnedChildren: false is no
                                   // fix either — the header would pin
                                   // forever and overlay the next group.)
-                                  if (group.key != openGroupKey)
+                                  // An expanded group always has a body (a
+                                  // CityGroup exists only because its leg
+                                  // has items, and _buildGroupItemSlivers
+                                  // emits at least the day rows), so the
+                                  // pinned branch can never go zero-body.
+                                  // N groups expand at once now (all, by
+                                  // default): each inner containing
+                                  // MultiSliver pushes its own header off
+                                  // at its group's end, so headers hand off
+                                  // edge-to-edge and exactly one obstructs
+                                  // at rest — the outer MultiSliver must
+                                  // stay NON-containing (no
+                                  // pushPinnedChildren), or every header
+                                  // would pin to the end of the itinerary
+                                  // and stack.
+                                  if (_collapsedGroups.contains(group.key))
                                     SliverToBoxAdapter(
                                         child: KeyedSubtree(
                                             // Keyed by the run, not the city:

--- a/src/packages/flutter-app/lib/screens/trip_map_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_map_screen.dart
@@ -224,6 +224,18 @@ class _TripMapScreenState extends ConsumerState<TripMapScreen> {
                       }
                     }
                   },
+                  // A region pin tap focuses that city in place — the
+                  // chip-equivalent (there is no list here to scroll to):
+                  // the map flips from the overview to the leg's item pins,
+                  // and the report-back lets trip detail pre-scroll the
+                  // list behind the modal so closing lands on the region.
+                  onDestinationTap: (legKey) {
+                    setState(() {
+                      _legKey = legKey;
+                      _selectedPosition = null;
+                    });
+                    widget.onLegSelected(legKey);
+                  },
                 ),
               ),
               // Above the map's gesture layer, so chip taps and row scrolls never

--- a/src/packages/flutter-app/lib/widgets/trip_map.dart
+++ b/src/packages/flutter-app/lib/widgets/trip_map.dart
@@ -73,10 +73,17 @@ class TripMapDestination {
   /// Pre-formatted date range for the tooltip; null shows the label alone.
   final String? dates;
 
+  /// Full-itinerary leg run key ('Prague', 'Prague#2') for callers that make
+  /// destination pins navigable via [TripMap.onDestinationTap]. Null — the
+  /// default, and what the shared/home views pass — keeps the pin a
+  /// tooltip-only marker.
+  final String? legKey;
+
   const TripMapDestination({
     required this.label,
     required this.point,
     this.dates,
+    this.legKey,
   });
 }
 
@@ -95,6 +102,11 @@ class TripMap extends StatefulWidget {
   final List<ItineraryItem> items;
   final int? selectedPosition;
   final void Function(int position)? onPinTap;
+
+  /// Tap handler for destination (trip-overview) pins, called with the pin's
+  /// [TripMapDestination.legKey]. Null — the default — keeps destination pins
+  /// tooltip-only (tap shows city + dates), the pre-existing behavior.
+  final void Function(String legKey)? onDestinationTap;
 
   /// Stays to plot alongside the itinerary. Entries without coordinates are
   /// skipped; the default keeps existing call sites unchanged.
@@ -155,6 +167,7 @@ class TripMap extends StatefulWidget {
     required this.items,
     this.selectedPosition,
     this.onPinTap,
+    this.onDestinationTap,
     this.segmentLabels = const {},
     this.accommodations = const [],
     this.fitSignature,
@@ -765,6 +778,10 @@ class _TripMapState extends State<TripMap> {
                             label: '${k + 1}',
                             name: d.label,
                             dates: d.dates,
+                            onTap: (widget.onDestinationTap != null &&
+                                    d.legKey != null)
+                                ? () => widget.onDestinationTap!(d.legKey!)
+                                : null,
                           ),
                         ),
                     ],
@@ -1014,8 +1031,10 @@ class _Pin extends StatelessWidget {
 /// A destination (city-leg) pin for the trip-overview mode: the same round
 /// numbered dot as itinerary pins, in one consistent color (category tinting
 /// is meaningless for a whole city). Destinations sit outside the
-/// position-based selection sync, so a tap shows a self-contained tooltip
-/// (city + dates) like [_StayPin] instead of driving [TripMap.onPinTap].
+/// position-based selection sync: with [onTap] wired the tap drives
+/// [TripMap.onDestinationTap] (the tooltip stays on hover/long-press);
+/// without it a tap shows a self-contained tooltip (city + dates) like
+/// [_StayPin] instead of driving [TripMap.onPinTap].
 class _DestinationPin extends StatelessWidget {
   /// The 1..N visit-order ordinal shown in the dot.
   final String label;
@@ -1026,30 +1045,46 @@ class _DestinationPin extends StatelessWidget {
   /// Pre-formatted date range; null shows the name alone.
   final String? dates;
 
+  /// Navigation tap, pre-bound to the pin's leg key by the caller. Null keeps
+  /// the pin tooltip-only.
+  final VoidCallback? onTap;
+
   const _DestinationPin({
     required this.label,
     required this.name,
     this.dates,
+    this.onTap,
   });
 
   @override
   Widget build(BuildContext context) {
-    // The tooltip's tap detector fills the marker's [_pinHitBox] box, so the
-    // whole transparent halo around the 24px dot triggers it.
-    return Tooltip(
-      message: dates == null ? name : '$name\n$dates',
-      triggerMode: TooltipTriggerMode.tap,
-      child: Center(
-        child: SizedBox.square(
-          dimension: 24,
-          child: _Pin(
-            label: label,
-            category: null,
-            selected: false,
-            color: Theme.of(context).colorScheme.primary,
-          ),
+    final message = dates == null ? name : '$name\n$dates';
+    final dot = Center(
+      child: SizedBox.square(
+        dimension: 24,
+        child: _Pin(
+          label: label,
+          category: null,
+          selected: false,
+          color: Theme.of(context).colorScheme.primary,
         ),
       ),
+    );
+    if (onTap == null) {
+      // The tooltip's tap detector fills the marker's [_pinHitBox] box, so
+      // the whole transparent halo around the 24px dot triggers it.
+      return Tooltip(
+        message: message,
+        triggerMode: TooltipTriggerMode.tap,
+        child: dot,
+      );
+    }
+    // Navigable pin: the opaque detector claims the full [_pinHitBox] halo
+    // for the tap; the tooltip keeps hover (desktop) and long-press.
+    return GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onTap: onTap,
+      child: Tooltip(message: message, child: dot),
     );
   }
 }

--- a/src/packages/flutter-app/lib/widgets/trip_map_destinations.dart
+++ b/src/packages/flutter-app/lib/widgets/trip_map_destinations.dart
@@ -23,16 +23,26 @@ String groupLabelText(AppLocalizations l10n, String label) =>
 /// real coordinate, in visit order; ungeocoded groups are skipped so the
 /// visible numbering stays contiguous. Callers pass [rawLegRanges] output —
 /// map pins stay on the RAW ranges by doctrine (see leg_ranges.dart).
+///
+/// [legKeys] (optional) makes the pins navigable: index-aligned with
+/// [rawRanges] — both follow tripLegs order, which is why the zip happens
+/// BEFORE the coord filter. [LegRange] itself stays key-free by doctrine
+/// (record typedef with a Go twin); the key comes from [TripLeg.key].
 List<TripMapDestination> tripMapDestinations(
-        List<LegRange> rawRanges, AppLocalizations l10n) =>
-    [
-      for (final r in rawRanges)
-        if (r.coord != null)
-          TripMapDestination(
-            label: groupLabelText(l10n, r.label),
-            point: LatLng(r.coord!.lat, r.coord!.lng),
-            dates: r.start != null && r.end != null
-                ? formatShortRange(r.start!, r.end!)
-                : null,
-          ),
-    ];
+    List<LegRange> rawRanges, AppLocalizations l10n,
+    {List<String>? legKeys}) {
+  assert(legKeys == null || legKeys.length == rawRanges.length,
+      'legKeys must be index-aligned with rawRanges (both follow tripLegs order)');
+  return [
+    for (final (i, r) in rawRanges.indexed)
+      if (r.coord != null)
+        TripMapDestination(
+          label: groupLabelText(l10n, r.label),
+          point: LatLng(r.coord!.lat, r.coord!.lng),
+          dates: r.start != null && r.end != null
+              ? formatShortRange(r.start!, r.end!)
+              : null,
+          legKey: legKeys?[i],
+        ),
+  ];
+}

--- a/src/packages/flutter-app/test/support/city_groups.dart
+++ b/src/packages/flutter-app/test/support/city_groups.dart
@@ -13,12 +13,19 @@ Finder cityHeaderLabel(String label) => find.descendant(
       matching: find.text(label),
     );
 
-/// Expands the trip-detail city group whose header shows [label] by tapping
-/// it. Groups default to collapsed (only a sole group is seeded open), so
-/// tests that assert on a group's contents expand it first. [index] picks
-/// among duplicate headers when a trip revisits a city (first run = 0).
-Future<void> expandCity(WidgetTester tester, String label,
+/// Toggles the trip-detail city group whose header shows [label] by tapping
+/// it. Groups default to EXPANDED (expansion is list-only state, decoupled
+/// from the map), so the first toggle collapses; tests that assert on a
+/// collapsed group's behavior collapse it here first. [index] picks among
+/// duplicate headers when a trip revisits a city (first run = 0).
+Future<void> toggleCity(WidgetTester tester, String label,
     {int index = 0}) async {
   await tester.tap(cityHeaderLabel(label).at(index));
   await tester.pumpAndSettle();
 }
+
+/// Collapse-intent alias of [toggleCity] for call sites where the direction
+/// matters to the reader; the tap itself is the same list-only toggle.
+Future<void> collapseCity(WidgetTester tester, String label,
+        {int index = 0}) =>
+    toggleCity(tester, label, index: index);

--- a/src/packages/flutter-app/test/trip_detail_all_expanded_headers_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_all_expanded_headers_test.dart
@@ -1,0 +1,337 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:travel_route_planner/models/trip.dart';
+import 'package:travel_route_planner/models/itinerary_item.dart';
+import 'package:travel_route_planner/services/api_client.dart';
+import 'package:travel_route_planner/services/trips_api_service.dart';
+import 'package:travel_route_planner/providers/trips_provider.dart';
+import 'package:travel_route_planner/screens/trip_detail_screen.dart';
+import 'package:travel_route_planner/widgets/trip_map.dart';
+
+import 'support/city_groups.dart';
+import 'support/l10n_test_app.dart';
+
+// The N-expanded-groups pinning + scroll-math contract (list expansion is
+// decoupled from map focus; there is no single-open accordion):
+//   * every city group defaults EXPANDED and toggles independently —
+//     _collapsedGroups is inverted state (empty = all expanded), so all N
+//     bodies contribute scroll extent from the first frame;
+//   * while scrolling, exactly ONE city header obstructs at a time: each
+//     group's containing MultiSliver pushes its own header off at the
+//     group's end, so consecutive headers hand off edge-to-edge and the
+//     pinned slot (viewport top + 420: the 364px map band + 56px tab row)
+//     never accumulates obstruction as more groups pin and unpin;
+//   * header taps are pure list toggles — the map-side assertions live in
+//     trip_detail_leg_focus_test.dart; here they only pin down that N
+//     groups collapse and re-expand independently;
+//   * destination (region) pins on the All-overview map navigate the LIST:
+//     un-collapse the group + rest its header in the pinned slot, with NO
+//     focus write and no camera move. The far-upward-scroll probe rides
+//     that path because it is the one that crosses unbuilt item batches,
+//     where the scroll target comes from SliverList extent ESTIMATES.
+
+class _FakeTripsApiService extends TripsApiService {
+  final Trip trip;
+  _FakeTripsApiService(this.trip) : super(ApiClient(baseUrl: 'http://test'));
+
+  @override
+  Future<Trip> getTrip(String id) async => trip;
+}
+
+ItineraryItem _item(
+  int pos,
+  String name,
+  String city,
+  double lat,
+  double lng,
+  int day,
+) =>
+    ItineraryItem(
+      id: 'i$pos',
+      position: pos,
+      name: name,
+      latitude: lat,
+      longitude: lng,
+      category: 'attraction',
+      day: day,
+      city: city,
+    );
+
+/// Paris (days 1–2) → Rome (days 3–4) → Berlin ([berlinDays] days from day
+/// 5), [perDay] geocoded items per day. With every group expanded by
+/// default all three bodies contribute extent immediately. The pinning
+/// tests give Berlin extra days so the trailing extent is deep enough for
+/// its header to reach the pinned slot on the tall surface — and, in the
+/// estimation probe, so Paris's item batches sit far beyond the cache
+/// extent when parked at the bottom.
+Trip _trip({required int perDay, required int berlinDays}) {
+  final items = <ItineraryItem>[];
+  var pos = 0;
+  void city(String name, double lat, double lng, List<int> days) {
+    var n = 0;
+    for (final day in days) {
+      for (var k = 0; k < perDay; k++) {
+        items.add(
+            _item(pos++, '$name stop ${n++}', name, lat + n * 0.001, lng, day));
+      }
+    }
+  }
+
+  city('Paris', 48.86, 2.33, [1, 2]);
+  city('Rome', 41.89, 12.49, [3, 4]);
+  city('Berlin', 52.51, 13.37, [for (var d = 0; d < berlinDays; d++) 5 + d]);
+  return Trip(
+    id: 't1',
+    title: 'Grand tour',
+    createdAt: '2026-06-01',
+    updatedAt: '2026-06-01',
+    startDate: '2026-09-01',
+    endDate: '2026-09-${(4 + berlinDays).toString().padLeft(2, '0')}',
+    items: items,
+  );
+}
+
+Future<void> _pump(WidgetTester tester, Trip trip) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        tripsApiServiceProvider.overrideWithValue(_FakeTripsApiService(trip)),
+      ],
+      child: MaterialApp(
+          localizationsDelegates: testLocalizationsDelegates,
+          home: TripDetailScreen(tripId: 't1')),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+TripMap _map(WidgetTester tester) =>
+    tester.widget<TripMap>(find.byType(TripMap));
+
+void _useSurface(WidgetTester tester, Size size) {
+  tester.view.physicalSize = size;
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.reset);
+}
+
+/// The city header's own Material (opaque so items can't show through while
+/// pinned) — the same box the screen's _cityHeaderKeys target, so geometry
+/// measured here matches the scroll math's.
+Finder _headerMaterialOf(String city) => find
+    .ancestor(of: cityHeaderLabel(city), matching: find.byType(Material))
+    .first;
+
+double _headerTop(WidgetTester tester, String city) =>
+    tester.getTopLeft(_headerMaterialOf(city)).dy;
+
+/// The scroll offset that rests [city]'s header in the pinned slot —
+/// getOffsetToReveal at alignment 0, which already subtracts the pinned
+/// map band + tab row (maxScrollObstructionExtentBefore). City headers are
+/// SliverPinnedHeader children, always built, so this works at any offset;
+/// accuracy depends on how much of the intervening item batches is built.
+double _reveal(WidgetTester tester, String city) {
+  final target = tester.renderObject(_headerMaterialOf(city));
+  return RenderAbstractViewport.of(target).getOffsetToReveal(target, 0).offset;
+}
+
+ScrollPosition _position(WidgetTester tester) => tester
+    .state<ScrollableState>(find
+        .descendant(
+            of: find.byType(CustomScrollView),
+            matching: find.byType(Scrollable))
+        .first)
+    .position;
+
+/// Viewport top in global coordinates — the app bar's bottom; the pinned
+/// chrome math lives in viewport coordinates.
+double _viewportTop(WidgetTester tester) =>
+    tester.getBottomLeft(find.byType(AppBar)).dy;
+
+void main() {
+  testWidgets('exactly one city header pins; the next city pushes it off',
+      (tester) async {
+    // Tall surface: the 364px pinned map band pushes deep-group geometry
+    // below an 800px fold. Berlin's six days keep enough trailing extent
+    // (item tiles are ~58px) that a mid-group-3 offset stays reachable on
+    // the ~1724px content viewport.
+    _useSurface(tester, const Size(1200, 2200));
+    await _pump(tester, _trip(perDay: 6, berlinDays: 6));
+
+    final position = _position(tester);
+    final slot = _viewportTop(tester) + 420; // 364 map band + 56 tab row
+    final headerH = tester.getRect(_headerMaterialOf('Paris')).height;
+
+    // Deep inside Rome's body: Rome's header has pinned.
+    final romeMid = _reveal(tester, 'Rome') + 250;
+    expect(romeMid, lessThan(position.maxScrollExtent),
+        reason: 'premise: mid-group-2 must be reachable');
+    position.jumpTo(romeMid);
+    await tester.pumpAndSettle();
+
+    final slotDy = _headerTop(tester, 'Rome');
+    expect((slotDy - slot).abs(), lessThanOrEqualTo(2),
+        reason: 'Rome header should pin below map band + tab row');
+    // Paris — the previous group's header — has been pushed fully off the
+    // slot (its own MultiSliver's end carried it up), not stacked above it.
+    expect(_headerTop(tester, 'Paris'), lessThanOrEqualTo(slotDy - headerH + 2),
+        reason: 'the pushed-off Paris header must sit clear above the slot');
+    // Berlin's header is still in flow below the pinned one.
+    expect(_headerTop(tester, 'Berlin'), greaterThan(slotDy + headerH),
+        reason: 'Berlin scrolls in flow until its own body reaches the slot');
+
+    // Same jump into group 3: the slot dy is CONSTANT. If pushed-off
+    // headers accumulated as obstructions, each later group would rest
+    // lower than the one before.
+    final berlinMid = _reveal(tester, 'Berlin') + 250;
+    expect(berlinMid, lessThan(position.maxScrollExtent),
+        reason: 'premise: mid-group-3 must be reachable');
+    position.jumpTo(berlinMid);
+    await tester.pumpAndSettle();
+
+    expect((_headerTop(tester, 'Berlin') - slotDy).abs(), lessThanOrEqualTo(2),
+        reason: 'slot constancy: no obstruction accumulation across groups');
+    expect(_headerTop(tester, 'Rome'), lessThanOrEqualTo(slotDy - headerH + 2),
+        reason: 'Rome is pushed off the slot in turn');
+  });
+
+  testWidgets('push handoff is edge-to-edge', (tester) async {
+    _useSurface(tester, const Size(1200, 2200));
+    await _pump(tester, _trip(perDay: 6, berlinDays: 6));
+    final position = _position(tester);
+
+    // Approach the boundary first so the item batches around it build and
+    // the reveal offset is exact, not a SliverList estimate.
+    position.jumpTo(_reveal(tester, 'Rome') - 400);
+    await tester.pumpAndSettle();
+    final r2 = _reveal(tester, 'Rome');
+    final headerH = tester.getRect(_headerMaterialOf('Paris')).height;
+    // Paris is pinned here, so its top measures the slot empirically.
+    final slotDy = _headerTop(tester, 'Paris');
+
+    // Fine sweep across the group-1 → group-2 boundary. The push window in
+    // offset terms is [r2 - headerH, r2]: Rome's header enters the band at
+    // Paris's pinned bottom and finishes at the slot itself.
+    var handoffSamples = 0;
+    for (var off = r2 - headerH - 24; off <= r2 + 24; off += 4) {
+      position.jumpTo(off);
+      await tester.pump();
+      final paris = tester.getRect(_headerMaterialOf('Paris'));
+      final rome = tester.getRect(_headerMaterialOf('Rome'));
+      // Both headers occupy the band: Rome has entered it and Paris has
+      // not fully left it.
+      if (rome.top < slotDy + headerH - 0.5 && paris.bottom > slotDy + 0.5) {
+        handoffSamples++;
+        expect((paris.bottom - rome.top).abs(), lessThanOrEqualTo(1),
+            reason: 'at offset $off the handoff must be edge-to-edge: '
+                'no gap and no overlap between the outgoing and incoming '
+                'headers (Paris bottom ${paris.bottom}, Rome top ${rome.top})');
+      }
+    }
+    expect(handoffSamples, greaterThan(3),
+        reason: 'premise: the sweep must actually cross the push window');
+  });
+
+  testWidgets('multi-group independent collapse', (tester) async {
+    _useSurface(tester, const Size(1200, 2200));
+    await _pump(tester, _trip(perDay: 4, berlinDays: 2));
+
+    // Groups default EXPANDED: bodies render with no tap.
+    expect(find.text('Paris stop 0'), findsOneWidget);
+    expect(find.text('Rome stop 0'), findsOneWidget);
+
+    // Collapse groups 1 and 3. Paris first: dropping its body pulls
+    // Berlin's header above the fold, so the second tap lands (offscreen
+    // taps no-op with only a warning).
+    await collapseCity(tester, 'Paris');
+    expect(_headerTop(tester, 'Berlin'), lessThan(2100),
+        reason: 'premise: Berlin header must be on screen for its tap');
+    await collapseCity(tester, 'Berlin');
+
+    // Each group renders per its OWN state — no accordion coupling.
+    expect(find.text('Paris stop 0'), findsNothing);
+    expect(find.text('Rome stop 0'), findsOneWidget);
+    expect(find.text('Berlin stop 0'), findsNothing);
+
+    // Re-expanding Berlin leaves the other two alone.
+    await toggleCity(tester, 'Berlin');
+    expect(find.text('Paris stop 0'), findsNothing,
+        reason: 'expanding one group must not re-expand another');
+    expect(find.text('Rome stop 0'), findsOneWidget);
+    expect(find.text('Berlin stop 0'), findsOneWidget);
+    // And none of the header taps touched the map: pure list toggles.
+    expect(_map(tester).fitSignature, isNull);
+  });
+
+  // Doubles as the regression test for the quiescent-tap frame stall: a
+  // destination-pin tap on an already-expanded group (the default state)
+  // changes no state, and addPostFrameCallback does not request a frame —
+  // _revealCityHeader's ensureVisualUpdate is what guarantees the scroll
+  // runs at all (deterministic under the test binding, whose pump skips
+  // frame production while hasScheduledFrame is false).
+  testWidgets('far upward scroll to a region lands without reversal',
+      (tester) async {
+    _useSurface(tester, const Size(1200, 2200));
+    await _pump(tester, _trip(perDay: 6, berlinDays: 6));
+    final position = _position(tester);
+
+    // Park at the very bottom. Twice: the first jump can shift
+    // maxScrollExtent as SliverList estimates correct against built
+    // children; the second lands on the settled value.
+    position.jumpTo(position.maxScrollExtent);
+    await tester.pumpAndSettle();
+    position.jumpTo(position.maxScrollExtent);
+    await tester.pumpAndSettle();
+    final start = position.pixels;
+
+    // Premise for the estimation regime: Paris's item tiles sit beyond the
+    // cache extent, so the scroll target for its header is computed over
+    // ESTIMATED child offsets — the overshoot-prone path.
+    expect(find.text('Paris stop 0'), findsNothing,
+        reason: 'premise: city-1 items must be unbuilt for the probe to '
+            'exercise offset estimation');
+
+    // Region-pin tap for city 1 on the inline All-overview map, invoked
+    // directly (the robust pattern at the screen level). No settle: the
+    // whole point is to watch the motion.
+    final map = _map(tester);
+    expect(map.onDestinationTap, isNotNull,
+        reason: 'the desktop inline card wires destination-pin navigation');
+    map.onDestinationTap!('Paris');
+
+    // Sample the scroll frame by frame across the 350ms animation plus the
+    // one-jump correction pass.
+    final samples = <double>[];
+    for (var i = 0; i < 16; i++) {
+      await tester.pump(const Duration(milliseconds: 50));
+      samples.add(position.pixels);
+    }
+    await tester.pumpAndSettle();
+    samples.add(position.pixels);
+
+    expect(samples.last, lessThan(start),
+        reason: 'premise: the Paris rest offset must sit above the parked '
+            'bottom position — otherwise this scenario went vacuous');
+    var maxRise = 0.0;
+    for (var i = 1; i < samples.length; i++) {
+      final rise = samples[i] - samples[i - 1];
+      if (rise > maxRise) maxRise = rise;
+    }
+    expect(maxRise, lessThanOrEqualTo(2),
+        reason: 'a net-upward scroll must never move back down '
+            '(overshoot-then-snap-back reversal); from $start: $samples');
+
+    // And it lands exactly: city 1's header rests in the pinned slot.
+    final slot = _viewportTop(tester) + 420;
+    expect((_headerTop(tester, 'Paris') - slot).abs(), lessThanOrEqualTo(2),
+        reason: 'Paris header should rest below map band + tab row');
+    // The navigation was list-only: no focus write, camera untouched, the
+    // destination pins still render.
+    expect(_map(tester).fitSignature, isNull,
+        reason: 'a destination-pin tap must not write map focus');
+    expect(_map(tester).destinations, isNotNull,
+        reason: 'the All-overview pins must survive their own tap');
+  });
+}

--- a/src/packages/flutter-app/test/trip_detail_booking_alignment_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_booking_alignment_test.dart
@@ -17,7 +17,6 @@ import 'package:travel_route_planner/screens/trip_detail_screen.dart';
 import 'package:travel_route_planner/widgets/booking_detail_row.dart';
 import 'package:travel_route_planner/widgets/booking_todo_card.dart';
 
-import 'support/city_groups.dart';
 import 'support/l10n_test_app.dart';
 
 // Alignment contracts for the itinerary's booking surface.
@@ -151,10 +150,8 @@ void main() {
 
     double dx(Finder f) => tester.getTopLeft(f).dx;
 
-    // City groups are an accordion — only one can be open — so measure the
-    // Paris surfaces first, then swap to Rome and compare against the
-    // captured x (same gutter both times).
-    await expandCity(tester, 'Paris');
+    // Groups default EXPANDED, so both cities' surfaces are measured in one
+    // rendered pass (same gutter throughout).
 
     // The stay row leads with the bare kind icon (the same branch
     // menu-suppressed transport rows take, so it stands in for both).
@@ -180,8 +177,6 @@ void main() {
             dx(_inRow('Stay in Paris', find.byIcon(Icons.hotel))),
             epsilon: 0.1));
 
-    await expandCity(tester, 'Rome');
-
     // Sanity: the leg row carries the icon+caret mode menu...
     expect(_inRow('Paris → Rome', find.byIcon(Icons.arrow_drop_down)),
         findsOneWidget);
@@ -199,14 +194,12 @@ void main() {
     // The _inRow scoping is load-bearing: the Paris group also renders an
     // EventCard with its own bare open_in_new, and the matched stay's
     // BookingDetailRow carries trailing IconButtons.
-    await expandCity(tester, 'Paris');
     // Differing label widths are what make the dx equality meaningful.
     expect(_inRow('Stay in Paris', find.text('Open in Airbnb')),
         findsOneWidget);
     final iconDx =
         dx(_inRow('Stay in Paris', find.byIcon(Icons.open_in_new)));
 
-    await expandCity(tester, 'Rome');
     expect(_inRow('Paris → Rome', find.text('Find flights')), findsOneWidget);
     expect(dx(_inRow('Paris → Rome', find.byIcon(Icons.open_in_new))),
         moreOrLessEquals(iconDx, epsilon: 0.1));

--- a/src/packages/flutter-app/test/trip_detail_bookings_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_bookings_test.dart
@@ -14,7 +14,6 @@ import 'package:travel_route_planner/providers/trips_provider.dart';
 import 'package:travel_route_planner/screens/trip_detail_screen.dart';
 import 'package:travel_route_planner/widgets/booking_todo_card.dart';
 
-import 'support/city_groups.dart';
 import 'support/l10n_test_app.dart';
 
 /// Returns a fixed trip without hitting the network, so we can exercise the
@@ -116,24 +115,20 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    // Groups default collapsed, and the accordion contract allows at most ONE
-    // open city at a time (expanding a city closes the previous one), so each
-    // city's embedded rows are asserted while that city is the open group.
-    // Headers, the tab counter, and Other bookings render regardless.
+    // Groups default EXPANDED (list expansion is decoupled from the map),
+    // so every city's embedded rows are asserted in one rendered pass.
 
-    // Paris open: its city-matched bookings render once each, as compact
+    // Paris: its city-matched bookings render once each, as compact
     // embedded rows, with arrival + stay above the city's first item.
-    await expandCity(tester, 'Paris');
     expect(
         find.widgetWithText(BookingTodoRow, 'Stay in Paris'), findsOneWidget);
     expect(find.widgetWithText(BookingTodoRow, 'JFK → Paris'), findsOneWidget);
     expect(tester.getTopLeft(find.text('JFK → Paris')).dy,
         lessThan(tester.getTopLeft(find.text('Louvre')).dy));
 
-    // Rome open (Paris closes): 'Paris → Rome' is Rome's ARRIVAL row, so it
-    // renders inside Rome's group above Rome's first item; the return flight
-    // home comes after the last city's last item.
-    await expandCity(tester, 'Rome');
+    // Rome: 'Paris → Rome' is Rome's ARRIVAL row, so it renders inside
+    // Rome's group above Rome's first item; the return flight home comes
+    // after the last city's last item.
     expect(find.widgetWithText(BookingTodoRow, 'Stay in Rome'), findsOneWidget);
     expect(find.widgetWithText(BookingTodoRow, 'Paris → Rome'), findsOneWidget);
     expect(find.widgetWithText(BookingTodoRow, 'Rome → JFK'), findsOneWidget);

--- a/src/packages/flutter-app/test/trip_detail_expanded_default_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_expanded_default_test.dart
@@ -16,9 +16,10 @@ import 'support/chip_finders.dart';
 import 'support/city_groups.dart';
 import 'support/l10n_test_app.dart';
 
-/// Destination groups default to COLLAPSED: the resting view is one
-/// place-plus-dates header line per destination. Only a sole group is seeded
-/// open, and today-mode force-expands today's group on live trips.
+/// Destination groups default to EXPANDED: landing shows the whole
+/// itinerary. Collapse is list-only session state (a Set of collapsed run
+/// keys, decoupled from map focus) and a header tap toggles exactly ONE
+/// group — there is no single-open accordion and no sole-group seed.
 class _FakeTripsApiService extends TripsApiService {
   final Trip trip;
   int calls = 0;
@@ -91,11 +92,18 @@ void main() {
         ],
       );
 
-  testWidgets('destination groups start collapsed: headers and dates only',
+  testWidgets('destination groups start expanded',
       (WidgetTester tester) async {
+    // Tall surface: with everything expanded, Rome's item tile sits past
+    // the default 600px viewport's cache extent and would never build
+    // (lazy SliverList).
+    tester.view.physicalSize = const Size(1200, 2200);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
     await _pump(tester, twoCityTrip());
 
-    // Headers with their date ranges are the whole resting view.
+    // Headers still lead each group with their date ranges.
     expect(find.text('Paris'), findsOneWidget);
     expect(find.text('Rome'), findsOneWidget);
     // Scoping revealed what the old global finder hid: the counted range
@@ -105,29 +113,37 @@ void main() {
     expect(chipTextIn('Rome', 'Jun 10 – Jun 11'), findsOneWidget);
     expect(chipTextIn('Rome', '· 1 night'), findsOneWidget);
 
-    // Items and embedded booking rows are hidden until a group is opened.
-    expect(find.text('Louvre'), findsNothing);
-    expect(find.text('Colosseum'), findsNothing);
-    expect(find.byType(BookingTodoRow), findsNothing);
+    // Every group's items and embedded booking rows are visible on landing
+    // — no expand step.
+    expect(find.text('Louvre'), findsOneWidget);
+    expect(find.text('Colosseum'), findsOneWidget);
+    expect(find.widgetWithText(BookingTodoRow, 'Stay in Paris'),
+        findsOneWidget);
   });
 
-  testWidgets('a header tap expands only that group, and toggles back',
+  testWidgets('a header tap collapses only that group, and toggles back',
       (WidgetTester tester) async {
+    // Tall surface for the same lazy-build reason as the landing test.
+    tester.view.physicalSize = const Size(1200, 2200);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
     await _pump(tester, twoCityTrip());
 
-    await expandCity(tester, 'Paris');
+    await collapseCity(tester, 'Paris');
+    expect(find.text('Louvre'), findsNothing);
+    expect(find.byType(BookingTodoRow), findsNothing);
+    // Other groups are untouched — no single-open accordion.
+    expect(find.text('Colosseum'), findsOneWidget);
+
+    await toggleCity(tester, 'Paris');
     expect(find.text('Louvre'), findsOneWidget);
     expect(find.widgetWithText(BookingTodoRow, 'Stay in Paris'),
         findsOneWidget);
-    expect(find.text('Colosseum'), findsNothing);
-
-    await tester.tap(find.text('Paris'));
-    await tester.pumpAndSettle();
-    expect(find.text('Louvre'), findsNothing);
-    expect(find.byType(BookingTodoRow), findsNothing);
+    expect(find.text('Colosseum'), findsOneWidget);
   });
 
-  testWidgets('a single-destination trip is seeded open',
+  testWidgets('a sole group still collapses and re-expands',
       (WidgetTester tester) async {
     await _pump(
         tester,
@@ -142,31 +158,13 @@ void main() {
           ],
         ));
 
-    // One group: collapsed-to-one-line would be an empty screen, so the
-    // sole group opens by default (and stays collapsible).
+    // One group, expanded like any other — no special seeding in either
+    // direction; the header stays a live per-group toggle.
     expect(find.text('Louvre'), findsOneWidget);
-    await tester.tap(find.text('Paris'));
-    await tester.pumpAndSettle();
+    await collapseCity(tester, 'Paris');
     expect(find.text('Louvre'), findsNothing);
-  });
-
-  testWidgets('a sole Other-places group is seeded open too',
-      (WidgetTester tester) async {
-    await _pump(
-        tester,
-        Trip(
-          id: 't1',
-          title: 'Mystery',
-          createdAt: '2026-06-01',
-          updatedAt: '2026-06-01',
-          items: [
-            _item(0, 'Hidden gem', null, 1, address: null),
-            _item(1, 'Second stop', null, 1, address: null),
-          ],
-        ));
-
-    expect(find.text('Other places'), findsOneWidget);
-    expect(find.text('Hidden gem'), findsOneWidget);
+    await toggleCity(tester, 'Paris');
+    expect(find.text('Orsay'), findsOneWidget);
   });
 
   testWidgets('collapsed headers scroll as full-height rows (no squish)',
@@ -174,7 +172,9 @@ void main() {
     // Eight collapsed groups in the default 600px viewport: scrolling pins
     // the chrome, which used to subtract its overlap from every zero-body
     // pinned group — headers squished to slivers, then vanished, leaving
-    // phantom scroll extent.
+    // phantom scroll extent. Groups now land expanded, so build the shape
+    // by hand: collapse all eight on a tall surface (offscreen taps no-op),
+    // then shrink back to the 600px viewport the regression lived in.
     final trip = Trip(
       id: 't1',
       title: 'Grand Tour',
@@ -186,7 +186,20 @@ void main() {
         for (var k = 1; k <= 8; k++) _item(k, 'Place $k', 'Stop$k', k),
       ],
     );
+    tester.view.physicalSize = const Size(1200, 2200);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
     await _pump(tester, trip);
+
+    for (var k = 1; k <= 8; k++) {
+      await collapseCity(tester, 'Stop$k');
+    }
+    expect(find.textContaining('Place '), findsNothing);
+
+    tester.view.resetPhysicalSize();
+    tester.view.resetDevicePixelRatio();
+    await tester.pumpAndSettle();
 
     final position = _position(tester);
     position.jumpTo(position.maxScrollExtent);
@@ -203,9 +216,9 @@ void main() {
   testWidgets(
       'a collapsed day header scrolls at full height inside an expanded group',
       (WidgetTester tester) async {
-    // Same zero-body pinned hazard one level down (pre-dates the collapsed
-    // city default): a collapsed day's header used to vanish once the
-    // chrome plus the pinned city header exceeded its height.
+    // Same zero-body pinned hazard one level down: a collapsed day's header
+    // used to vanish once the chrome plus the pinned city header exceeded
+    // its height.
     final trip = Trip(
       id: 't1',
       title: 'Getaway',
@@ -221,8 +234,9 @@ void main() {
     );
     await _pump(tester, trip);
 
-    // Sole group is seeded open; collapse every day — four consecutive
-    // zero-body day sections, the same stacked shape as collapsed cities.
+    // The group lands expanded like any other; collapse every day — four
+    // consecutive zero-body day sections, the same stacked shape as
+    // collapsed cities.
     for (final label in const [
       'Wed, Jun 10',
       'Thu, Jun 11',
@@ -248,16 +262,16 @@ void main() {
     expect(dy4 - dy3, greaterThan(30));
   });
 
-  testWidgets('expansion survives a silent refresh; the seed stays one-shot',
+  testWidgets('collapse state survives a silent refresh',
       (WidgetTester tester) async {
     final service = await _pump(tester, twoCityTrip());
 
-    await expandCity(tester, 'Paris');
-    expect(find.text('Louvre'), findsOneWidget);
+    await collapseCity(tester, 'Paris');
+    expect(find.text('Louvre'), findsNothing);
 
     // Pull-to-refresh really refetches (the fake counts calls) without
-    // resetting the user's expansion — and without the sole-group seed
-    // re-firing to open anything on a multi-group trip.
+    // resetting the user's collapse state — session state, and no seed
+    // exists to re-fire and reopen anything.
     await tester.fling(
         find.byType(CustomScrollView), const Offset(0, 400), 1000);
     await tester.pump();
@@ -265,15 +279,17 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(service.calls, greaterThan(1));
-    expect(find.text('Louvre'), findsOneWidget);
-    expect(find.text('Colosseum'), findsNothing);
+    expect(find.text('Louvre'), findsNothing);
+    expect(find.text('Colosseum'), findsOneWidget);
   });
 
   testWidgets(
-      'cold start on a live trip auto-expands only today\'s collapsed group',
+      'cold start on a live trip lands on today with every group expanded',
       (WidgetTester tester) async {
     // Today is day 2 of a 3-day trip that started yesterday; day 1 is a
-    // different city, so today's group starts collapsed two groups deep.
+    // different city. Groups land expanded, so the one-shot auto-scroll has
+    // nothing to open — it preselects today's leg on the map and scrolls
+    // the list to today's header.
     final now = DateTime.now();
     final trip = Trip(
       id: 't1',
@@ -290,26 +306,25 @@ void main() {
     );
     await _pump(tester, trip);
 
-    // The one-shot auto-scroll expanded Rome (never rendered before — its
-    // day keys come from the build-time registry, not built headers) and
-    // landed on today's header; Paris stayed collapsed.
     expect(_position(tester).pixels, greaterThan(0));
     expect(find.text('Today stop 0'), findsOneWidget);
     expect(find.widgetWithText(StatusPill, 'Today'), findsOneWidget);
-    expect(find.text('Past stop 0'), findsNothing);
 
     // The Today jump chip re-expands after a manual collapse of the CITY
-    // (not just the day): collapse Rome, park at the top, jump.
-    await tester.tap(find.text('Rome'));
-    await tester.pumpAndSettle();
+    // (the _scrollToDay un-collapse): collapse Rome in place — its pinned
+    // header is under the chrome here — then park at the top.
+    await collapseCity(tester, 'Rome');
     expect(find.text('Today stop 0'), findsNothing);
     _position(tester).jumpTo(0);
     await tester.pumpAndSettle();
 
+    // Paris landed expanded too (no collapse seed): its items are right
+    // there at the top of the list.
+    expect(find.text('Past stop 0'), findsOneWidget);
+
     await tester.tap(find.widgetWithText(ActionChip, 'Today'));
     await tester.pumpAndSettle();
     expect(find.text('Today stop 0'), findsOneWidget);
-    expect(find.text('Past stop 0'), findsNothing);
     expect(_position(tester).pixels, greaterThan(0));
   });
 }

--- a/src/packages/flutter-app/test/trip_detail_filler_suppression_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_filler_suppression_test.dart
@@ -9,7 +9,6 @@ import 'package:travel_route_planner/services/trips_api_service.dart';
 import 'package:travel_route_planner/providers/trips_provider.dart';
 import 'package:travel_route_planner/screens/trip_detail_screen.dart';
 
-import 'support/city_groups.dart';
 import 'support/l10n_test_app.dart';
 
 /// Returns a fixed trip without hitting the network, so we can exercise the
@@ -116,16 +115,10 @@ void main() {
 
     await _pump(tester, trip);
 
-    // Groups default collapsed and the accordion keeps at most ONE open:
-    // expanding Vienna closes Prague. So assert each city's body content
-    // while that city is the open group, one at a time — the asserts must
-    // exercise the filler suppression, not the collapse (a collapsed Vienna
-    // hides day headers regardless).
-    await expandCity(tester, 'Prague');
+    // Groups default EXPANDED, so both cities' bodies render at once — the
+    // asserts exercise the filler suppression itself, not collapse (a
+    // collapsed Vienna would hide day headers regardless).
     expect(find.text('Prague Castle'), findsOneWidget);
-
-    // Selecting Vienna collapses Prague (its body content hides).
-    await expandCity(tester, 'Vienna');
 
     // Still exactly one 'Vienna': the header. A broken filler filter would
     // render the filler tile as a second one inside the expanded group.

--- a/src/packages/flutter-app/test/trip_detail_grouping_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_grouping_test.dart
@@ -11,7 +11,6 @@ import 'package:travel_route_planner/providers/trips_provider.dart';
 import 'package:travel_route_planner/screens/trip_detail_screen.dart';
 
 import 'support/chip_finders.dart';
-import 'support/city_groups.dart';
 import 'support/l10n_test_app.dart';
 
 /// Returns a fixed trip without hitting the network, so we can exercise the
@@ -96,18 +95,12 @@ void main() {
     expect(chipTextIn('Green Turtle Cay', 'Jun 10 – Jun 12'), findsOneWidget);
     expect(chipTextIn('Green Turtle Cay', '· 2 nights'), findsOneWidget);
 
-    // Groups default collapsed and at most ONE is open at a time (accordion):
-    // expanding a city closes the previously open one. Assert each group's
-    // body while that group is the open one.
-    await expandCity(tester, 'Green Turtle Cay');
+    // Groups default EXPANDED (list expansion is decoupled from the map),
+    // so both groups' bodies render on landing.
     expect(find.text("Brendal's Dive Center"), findsOneWidget);
-    // Legacy items (no day) render with no "Day N" sub-headers.
-    expect(find.textContaining('Day 1'), findsNothing);
-
-    // Opening Great Guana Cay collapses Green Turtle Cay.
-    await expandCity(tester, 'Great Guana Cay');
     expect(find.text('Dive Guana'), findsOneWidget);
-    // Legacy rule holds in this group too.
+    // Legacy items (no day) render with no "Day N" sub-headers, in either
+    // group.
     expect(find.textContaining('Day 1'), findsNothing);
   });
 
@@ -148,10 +141,8 @@ void main() {
     expect(find.text('Paris'), findsOneWidget);
     expect(find.text('Rome'), findsOneWidget);
 
-    // Groups default collapsed and at most ONE is open at a time (accordion):
-    // opening Rome would collapse Paris, so each city's day sub-headers are
-    // asserted while that city is the open group.
-    await expandCity(tester, 'Paris');
+    // Groups default EXPANDED, so both cities' day sub-headers render on
+    // landing.
 
     // Day sub-headers show the weekday + date derived from the trip start
     // (day N -> startDate + (N-1)). Jun 10 2026 is a Wednesday.
@@ -166,8 +157,7 @@ void main() {
     // The Versailles day trip still nests under its day (Paris group body).
     expect(find.text('Day trip · Versailles'), findsOneWidget);
 
-    // Opening Rome collapses Paris.
-    await expandCity(tester, 'Rome');
+    // Rome's day sub-header (day 4 -> Jun 13) renders alongside Paris's.
     expect(find.text('Sat, Jun 13'), findsOneWidget);
     expect(find.text('Colosseum'), findsOneWidget);
   });

--- a/src/packages/flutter-app/test/trip_detail_leg_focus_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_leg_focus_test.dart
@@ -14,17 +14,19 @@ import 'package:travel_route_planner/widgets/trip_map.dart';
 import 'support/city_groups.dart';
 import 'support/l10n_test_app.dart';
 
-// The accordion city-focus contract (specs/map-city-focus, accordion rev):
-//   * the open group IS the selection: expanding a city header focuses its
-//     leg on the map and closes the previously open group — at most one
-//     group is ever open;
-//   * collapsing the open group (or tapping the All chip) deselects both
-//     ways: the map returns to All and everything is collapsed;
-//   * a chip tap selects — focuses + opens the leg's group — and on the
-//     wide layout rests the city header just below the pinned chrome;
-//     phones never scroll;
+// The map/list decoupling contract (specs/map-city-focus, decoupled rev):
+//   * city groups default EXPANDED; expansion is list-only state
+//     (_collapsedGroups) — a header tap is a pure toggle of that ONE group:
+//     it never writes map focus, never moves the camera, never touches
+//     other groups;
+//   * map focus (_focusedLegKey) is MAP-only state: a chip tap focuses the
+//     leg, un-collapses its group, and on the wide layout rests the city
+//     header just below the pinned chrome; phones never scroll. The All
+//     chip resets the MAP only — the list is untouched;
 //   * a map pin tap reveals its run in the list WITHOUT moving the camera
 //     (reveal-only), and a focus change clears the map pin selection;
+//   * a destination (region) pin tap on the All overview scrolls the list
+//     to the region's group — no focus write, the camera never moves;
 //   * bookings lenses (no city headers) get map-only chips, lens kept;
 //     places lenses resolve legs onto merged groups (groupKeyForLeg);
 //   * revisited cities focus per RUN key; single-leg trips have no focus.
@@ -128,55 +130,52 @@ void _useSurface(WidgetTester tester, Size size) {
 
 void main() {
   testWidgets(
-      'header taps drive the accordion: expanding selects and closes the '
-      'previous group, collapsing the open group restores All',
-      (tester) async {
+      'header taps are pure list toggles: the map never moves, focused '
+      'or not', (tester) async {
     // Tall surface: with the 364px map band pinned, expanded sections push
     // later headers below an 800px fold and header taps would miss.
     _useSurface(tester, const Size(1200, 2200));
     await _pump(tester, _threeCityTrip());
 
     expect(_map(tester).fitSignature, isNull);
+    expect(find.text('Louvre'), findsOneWidget); // groups default expanded
 
-    // Expand Paris → its leg focuses; the map filters to Paris.
-    await expandCity(tester, 'Paris');
-    expect(_map(tester).fitSignature, 'Paris');
-    expect(_map(tester).items.map((i) => i.name), ['Louvre', 'Orsay']);
-    expect(find.text('Louvre'), findsOneWidget);
-
-    // Expanding Rome selects it — and closes Paris: at most one group open.
-    await expandCity(tester, 'Rome');
-    expect(_map(tester).fitSignature, 'Rome');
-    expect(_map(tester).items, hasLength(8));
-    expect(find.text('Louvre'), findsNothing,
-        reason: 'selecting Rome must close the previously open Paris');
-
-    // Collapsing the open Rome deselects: map to All, list all collapsed.
-    await expandCity(tester, 'Rome');
+    // Collapse Paris → the LIST folds; the map stays the All overview.
+    await toggleCity(tester, 'Paris');
+    expect(find.text('Louvre'), findsNothing);
     expect(_map(tester).fitSignature, isNull);
     expect(_map(tester).items, hasLength(11));
+
+    // Re-expand: still not a focus write.
+    await toggleCity(tester, 'Paris');
+    expect(find.text('Louvre'), findsOneWidget);
+    expect(_map(tester).fitSignature, isNull);
+    expect(_map(tester).items, hasLength(11));
+
+    // Under an active focus the toggle is just as map-inert: collapsing
+    // the focused Rome folds the list, but the camera and its leg filter
+    // both hold — there is no accordion tying the two together anymore.
+    await _tapChip(tester, 'Rome');
+    expect(_map(tester).fitSignature, 'Rome');
+    await toggleCity(tester, 'Rome');
     expect(find.text('Roman Forum 0'), findsNothing);
+    expect(_map(tester).fitSignature, 'Rome',
+        reason: 'collapsing a group must not reset the map');
+    expect(_map(tester).items, hasLength(8));
   });
 
   testWidgets(
-      'desktop chip tap expands the section and rests its header just '
-      'below the pinned chrome', (tester) async {
+      'desktop chip tap rests the city header just below the pinned chrome',
+      (tester) async {
     _useSurface(tester, const Size(1200, 800));
     await _pump(tester, _threeCityTrip());
-
-    // Rome starts collapsed: its items aren't built. Open Paris first so
-    // the chip tap also proves the accordion closes it.
-    expect(find.text('Roman Forum 0'), findsNothing);
-    await expandCity(tester, 'Paris');
-    expect(find.text('Louvre'), findsOneWidget);
 
     await _tapChip(tester, 'Rome');
 
     expect(_map(tester).fitSignature, 'Rome');
-    // The section expanded — exclusively…
+    // The group's items are reachable (expanded — the landing default; the
+    // chip tap re-opens a manually collapsed group)…
     expect(find.text('Roman Forum 0'), findsOneWidget);
-    expect(find.text('Louvre'), findsNothing,
-        reason: 'a chip tap closes the previously open group');
     // …and its header rests right below the pinned chrome: the 364px map
     // band (12 + 340 + 12) + the 56px itinerary tab row = 420, measured
     // from the viewport top (the app bar's bottom — the scroll math lives
@@ -198,10 +197,11 @@ void main() {
     _useSurface(tester, const Size(1200, 800));
     await _pump(tester, _threeCityTrip());
 
-    // Open Rome (8 items) for scroll extent, then park at the very bottom.
-    // The regression only shows on a net-upward scroll: from the top the
-    // buggy motion (animate clamped at ~0, one down-snap) was still
-    // monotone and the resting assert above passed all along.
+    // Focus Rome, then park at the very bottom (every group lands expanded,
+    // so the 8 Rome items give plenty of scroll extent). The regression
+    // only shows on a net-upward scroll: from the top the buggy motion
+    // (animate clamped at ~0, one down-snap) was still monotone and the
+    // resting assert above passed all along.
     await _tapChip(tester, 'Rome');
     final scrollable = find
         .descendant(
@@ -251,7 +251,7 @@ void main() {
         reason: 'Paris header should rest below map band + tab row');
   });
 
-  testWidgets('the All chip deselects both ways: map to All, group closed',
+  testWidgets('the All chip resets the map only: the list is untouched',
       (tester) async {
     _useSurface(tester, const Size(1200, 800));
     await _pump(tester, _threeCityTrip());
@@ -260,13 +260,13 @@ void main() {
     expect(_map(tester).fitSignature, 'Rome');
     expect(find.text('Roman Forum 0'), findsOneWidget);
 
-    // All = nothing selected: chips and headers are two views of ONE
-    // selection, so the open group closes with the map reset.
+    // All = no focus: the camera returns to the overview, but expansion is
+    // list-only state — nothing collapses, no scroll happens.
     await _tapChip(tester, 'All');
     expect(_map(tester).fitSignature, isNull);
     expect(_map(tester).items, hasLength(11));
-    expect(find.text('Roman Forum 0'), findsNothing,
-        reason: 'the All chip closes the open group');
+    expect(find.text('Roman Forum 0'), findsOneWidget,
+        reason: 'the All chip must leave the list untouched');
   });
 
   testWidgets('phone chip tap focuses the map without scrolling the list',
@@ -284,9 +284,10 @@ void main() {
     await _tapChip(tester, 'Rome');
 
     expect(_map(tester).fitSignature, 'Rome');
-    // The section expanded, but the page did not move — the chips ride the
-    // scroll-away preview card, and scrolling would hide the map itself.
-    expect(find.text('Roman Forum 0'), findsOneWidget);
+    // The page did not move — the chips ride the scroll-away preview card,
+    // and scrolling would hide the map itself. (No item assert: with every
+    // group expanded, Rome's lazy tiles sit beyond the unscrolled cache
+    // extent and never build.)
     expect(tester.state<ScrollableState>(scrollable).position.pixels, 0);
   });
 
@@ -294,8 +295,8 @@ void main() {
     _useSurface(tester, const Size(1200, 2200));
     await _pump(tester, _threeCityTrip());
 
-    await expandCity(tester, 'Rome');
-    // Tapping an item row selects its pin on the map.
+    // Tapping an item row selects its pin on the map (the row is already
+    // built: groups land expanded).
     await tester.tap(find.text('Roman Forum 1'));
     await tester.pumpAndSettle();
     expect(_map(tester).selectedPosition, 3);
@@ -312,10 +313,14 @@ void main() {
     _useSurface(tester, const Size(1200, 2200));
     await _pump(tester, _threeCityTrip());
 
+    // A collapsed Rome is the case that matters: the reveal must re-open it.
+    await collapseCity(tester, 'Rome');
+    expect(find.text('Roman Forum 1'), findsNothing);
+
     // From the All view, tap a Rome pin (invoked directly — marker hit
-    // boxes cluster-shift): its run opens so the highlighted row is
+    // boxes cluster-shift): its run un-collapses so the highlighted row is
     // reachable, but the camera must NOT refit out from under the
-    // zoom-to-pin move — fitSignature stays All.
+    // zoom-to-pin move — fitSignature stays All, focus is never written.
     _map(tester).onPinTap!(2);
     await tester.pumpAndSettle();
     expect(_map(tester).selectedPosition, 2);
@@ -323,12 +328,53 @@ void main() {
     // A sibling row, not the tapped item's name — that one also renders in
     // the pin-tap snackbar.
     expect(find.text('Roman Forum 1'), findsOneWidget);
+  });
 
-    // The reveal-only open group still collapses coherently: the map is
-    // already on All, so closing it changes nothing on the map.
-    await expandCity(tester, 'Rome');
+  testWidgets(
+      'a destination pin tap scrolls to the region without touching the map',
+      (tester) async {
+    // Tall enough that Rome's header sits above the fold for the collapse
+    // tap, short enough that the fixture still has the ~425px of scroll
+    // extent the rest-below-chrome assertion needs (a 2200 surface
+    // swallows the whole trip: maxScrollExtent 0, nothing can scroll).
+    _useSurface(tester, const Size(1200, 1100));
+    await _pump(tester, _threeCityTrip());
+
+    await collapseCity(tester, 'Rome');
+    expect(find.text('Roman Forum 0'), findsNothing);
     expect(_map(tester).fitSignature, isNull);
-    expect(find.text('Roman Forum 1'), findsNothing);
+
+    // A region pin on the All overview reads as "take me there in the
+    // LIST" (invoked directly — the robust pattern at this level; the
+    // trip_map suite covers real taps): un-collapse + scroll, with NO
+    // focus write — focusing would swap the map to per-item pins and
+    // delete the very pins under the pointer.
+    _map(tester).onDestinationTap!('Rome');
+    await tester.pumpAndSettle();
+
+    expect(find.text('Roman Forum 0'), findsOneWidget,
+        reason: 'the region tap re-opens its collapsed group');
+    // Same rest math as a chip tap: map band + tab row = 420, ±2 for the
+    // one correction pass.
+    final viewportTop = tester.getBottomLeft(find.byType(AppBar)).dy;
+    final headerTop = tester
+        .getTopLeft(find
+            .ancestor(
+                of: cityHeaderLabel('Rome'), matching: find.byType(Material))
+            .first)
+        .dy;
+    expect((headerTop - (viewportTop + 420)).abs(), lessThanOrEqualTo(2),
+        reason: 'Rome header should rest below map band + tab row');
+    final position = tester
+        .state<ScrollableState>(find
+            .descendant(
+                of: find.byType(CustomScrollView),
+                matching: find.byType(Scrollable))
+            .first)
+        .position;
+    expect(position.pixels, greaterThan(0));
+    expect(_map(tester).fitSignature, isNull,
+        reason: 'a region tap never moves the camera');
   });
 
   testWidgets('a pin tap while a leg is focused keeps the camera and selection',
@@ -348,9 +394,8 @@ void main() {
     expect(_map(tester).fitSignature, 'Rome', reason: 'camera must not refit');
     expect(_map(tester).selectedPosition, 3,
         reason: 'keepCamera must not clear the selection');
-    // Rome stays the open group; Paris stays closed.
+    // Rome's rows stay in place (a pin tap never collapses anything).
     expect(find.text('Roman Forum 1'), findsWidgets);
-    expect(find.text('Louvre'), findsNothing);
   });
 
   testWidgets('bookings lens: a chip tap filters the map and keeps the lens',
@@ -372,7 +417,7 @@ void main() {
         reason: 'a map chip must not exit the bookings lens');
   });
 
-  testWidgets('revisited city: each header run focuses its own leg',
+  testWidgets('revisited city: each chip run focuses its own leg',
       (tester) async {
     _useSurface(tester, const Size(1200, 2200));
     await _pump(
@@ -392,13 +437,18 @@ void main() {
       ),
     );
 
-    // The second Paris header focuses the SECOND run only.
-    await expandCity(tester, 'Paris', index: 1);
+    // Header taps no longer focus, so the two same-label Paris CHIPS drive
+    // per-run focus. The second chip focuses the SECOND run only.
+    final parisChips = find.descendant(
+        of: find.byType(MapLegChips), matching: find.text('Paris'));
+    await tester.tap(parisChips.at(1));
+    await tester.pumpAndSettle();
     expect(_map(tester).fitSignature, 'Paris#2');
     expect(_map(tester).items.map((i) => i.name), ['Marmottan']);
 
     // And the first run stays its own focus target.
-    await expandCity(tester, 'Paris', index: 0);
+    await tester.tap(parisChips.at(0));
+    await tester.pumpAndSettle();
     expect(_map(tester).fitSignature, 'Paris');
     expect(_map(tester).items.map((i) => i.name), ['Louvre']);
   });
@@ -443,7 +493,12 @@ void main() {
         matching: find.byWidgetPredicate((w) => w is CheckedPopupMenuItem)));
     await tester.pumpAndSettle();
 
-    // Selecting the SECOND Paris run focuses its leg — and opens the one
+    // Collapse the merged group first, so the chip tap's un-collapse must
+    // resolve the leg onto it (groupKeyForLeg) rather than find it open.
+    await collapseCity(tester, 'Paris');
+    expect(find.text('Louvre'), findsNothing);
+
+    // Selecting the SECOND Paris run focuses its leg — and re-opens the one
     // merged group both runs resolve to.
     final parisChips = find.descendant(
         of: find.byType(MapLegChips), matching: find.text('Paris'));
@@ -464,7 +519,7 @@ void main() {
     expect(find.text('Louvre'), findsOneWidget);
   });
 
-  testWidgets('adding a place focuses the added city, closing the previous',
+  testWidgets('adding a place focuses the added city on the map',
       (tester) async {
     _useSurface(tester, const Size(1200, 2200));
     final v1 = _threeCityTrip();
@@ -522,8 +577,9 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    // Open Paris so the add can be shown to CLOSE it (the item lands in Rome).
-    await expandCity(tester, 'Paris');
+    // Focus Paris first, so the add provably REfocuses the map (the item
+    // lands in Rome).
+    await _tapChip(tester, 'Paris');
     expect(_map(tester).fitSignature, 'Paris');
     expect(find.text('Louvre'), findsOneWidget);
 
@@ -538,12 +594,13 @@ void main() {
         find.descendant(of: find.byType(AlertDialog), matching: find.text('Add')));
     await tester.pumpAndSettle();
 
-    // The new item's leg (Rome) is now focused and its group open; Paris,
-    // the previously open group, is closed.
+    // The new item's leg (Rome) is now focused so the fresh pin is visible;
+    // Paris stays expanded — expansion is not the map's state, so a focus
+    // change collapses nothing.
     expect(_map(tester).fitSignature, 'Rome');
     expect(find.text('Trevi Fountain'), findsWidgets);
-    expect(find.text('Louvre'), findsNothing,
-        reason: 'the previously open Paris closes under the accordion');
+    expect(find.text('Louvre'), findsOneWidget,
+        reason: 'a focus change must not collapse any group');
   });
 
   testWidgets('single-leg trip: no chip strip, header taps never focus',
@@ -572,16 +629,16 @@ void main() {
       findsNothing,
     );
 
-    // The sole group seeds open; toggling it never writes focus — with one
-    // leg, "All" and "the leg" are the same map, and a fit bump would snap
-    // a user-panned camera for no visible change. The LIST still toggles
-    // through the reveal-only hatch (this is the same writer path an
-    // 'Other places'-only trip takes).
-    expect(find.text('Louvre'), findsOneWidget); // seeded open
-    await expandCity(tester, 'Paris'); // collapse (seeded open)
+    // The sole group lands expanded like every other; toggling it never
+    // writes focus — with one leg, "All" and "the leg" are the same map,
+    // and a fit bump would snap a user-panned camera for no visible
+    // change. The LIST still toggles through the same pure-toggle path
+    // every header tap takes.
+    expect(find.text('Louvre'), findsOneWidget); // expanded by default
+    await collapseCity(tester, 'Paris');
     expect(_map(tester).fitSignature, isNull);
     expect(find.text('Louvre'), findsNothing, reason: 'list collapsed');
-    await expandCity(tester, 'Paris'); // expand again
+    await toggleCity(tester, 'Paris'); // expand again
     expect(_map(tester).fitSignature, isNull);
     expect(find.text('Louvre'), findsOneWidget, reason: 'list reopened');
   });

--- a/src/packages/flutter-app/test/trip_detail_leg_mode_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_leg_mode_test.dart
@@ -13,7 +13,6 @@ import 'package:travel_route_planner/providers/trips_provider.dart';
 import 'package:travel_route_planner/screens/trip_detail_screen.dart';
 import 'package:travel_route_planner/widgets/booking_todo_card.dart';
 
-import 'support/city_groups.dart';
 import 'support/l10n_test_app.dart';
 
 // Per-leg transport mode: the header pill is gone; each transport row carries
@@ -178,7 +177,6 @@ void main() {
       (WidgetTester tester) async {
     _useTallViewport(tester);
     final todosApi = await _pump(tester, _twoCityTrip());
-    await expandCity(tester, 'Rome');
 
     // The derived flight leg starts on Find flights with a mode menu.
     expect(find.textContaining('Find flights'), findsOneWidget);
@@ -212,7 +210,6 @@ void main() {
     // derive it as ground (rome2rio), not fall back to the flight default.
     final todosApi = await _pump(tester, _twoCityTrip(legMode: 'train'),
         modes: {'transport:paris>>rome': 'train'});
-    await expandCity(tester, 'Rome');
 
     final leg = todosApi.lastDerived!
         .singleWhere((d) => d['todo_key'] == 'transport:paris>>rome');
@@ -226,7 +223,6 @@ void main() {
     _useTallViewport(tester);
     final todosApi = await _pump(tester, _twoCityTrip(legMode: 'ferry'),
         modes: {'transport:paris>>rome': 'ferry'});
-    await expandCity(tester, 'Rome');
 
     final leg = todosApi.lastDerived!
         .singleWhere((d) => d['todo_key'] == 'transport:paris>>rome');
@@ -238,7 +234,6 @@ void main() {
       (WidgetTester tester) async {
     _useTallViewport(tester);
     await _pump(tester, _twoCityTrip(access: 'viewer'));
-    await expandCity(tester, 'Rome');
 
     expect(find.byType(BookingTodoRow), findsWidgets);
     expect(_rowModeMenu(), findsNothing);

--- a/src/packages/flutter-app/test/trip_detail_leg_nights_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_leg_nights_test.dart
@@ -224,8 +224,10 @@ void main() {
 
     double chevronRightIn(String city) {
       final row = headerRowOf(city);
+      // Groups land expanded, so the header chevron is expand_more (a
+      // collapsed row would show chevron_right); geometry is the same slot.
       final chevron = find.descendant(
-          of: row, matching: find.byIcon(Icons.chevron_right));
+          of: row, matching: find.byIcon(Icons.expand_more));
       expect(chevron, findsOneWidget);
       expect(
         tester.getTopRight(chevron).dx,
@@ -252,8 +254,9 @@ void main() {
     await _pump(tester, _pragueKrakowTrip());
 
     final row = headerRowOf('Prague');
+    // expand_more: groups land expanded (see the chevron test above).
     final chevron = find.descendant(
-        of: row, matching: find.byIcon(Icons.chevron_right));
+        of: row, matching: find.byIcon(Icons.expand_more));
     expect(
       tester.getTopRight(chevron).dx,
       moreOrLessEquals(tester.getTopRight(row).dx, epsilon: 0.1),
@@ -395,12 +398,19 @@ void main() {
             epsilon: 0.1),
         reason: "the 'Other places' nights suffix must share the right edge");
 
-    // The phantom slot is width-only: exactly one LIVE refine button.
-    final live = tester
-        .widgetList<IconButton>(
-            find.widgetWithIcon(IconButton, Icons.auto_awesome))
-        .where((b) => b.onPressed != null);
-    expect(live.length, 1,
+    // The phantom slot is width-only. Scoped to the two header rows: with
+    // groups expanded by default the day sub-headers mount too, and their
+    // own live refine buttons would alias a global count.
+    Iterable<IconButton> refinesIn(String city) =>
+        tester.widgetList<IconButton>(find.descendant(
+            of: headerRowOf(city),
+            matching: find.widgetWithIcon(IconButton, Icons.auto_awesome)));
+    expect(refinesIn('Prague').where((b) => b.onPressed != null).length, 1,
+        reason: 'the real city header keeps its live refine button');
+    final other = refinesIn('Other places').toList();
+    expect(other.length, 1,
+        reason: "the 'Other places' slot must exist (width-identical)");
+    expect(other.single.onPressed, isNull,
         reason: 'the Other-places placeholder must stay inert');
   });
 

--- a/src/packages/flutter-app/test/trip_detail_map_expand_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_map_expand_test.dart
@@ -106,6 +106,17 @@ void main() {
     await tester.pumpAndSettle();
   }
 
+  /// The trip-detail page's scroll position (the outer CustomScrollView's
+  /// own scrollable — `.first` skips nested horizontal strips).
+  ScrollPosition pagePosition(WidgetTester tester) => tester
+      .state<ScrollableState>(find
+          .descendant(
+            of: find.byType(CustomScrollView),
+            matching: find.byType(Scrollable),
+          )
+          .first)
+      .position;
+
   testWidgets('phone: map is a static preview and scrolls away with the page',
       (WidgetTester tester) async {
     await pumpScreen(tester, surface: phone);
@@ -150,8 +161,12 @@ void main() {
     await tester.tap(find.byType(CloseButton));
     await tester.pumpAndSettle();
 
-    // Back on the trip screen, the inline chips kept the focus.
+    // Back on the trip screen, the focus survived — but the phone
+    // report-back pre-scrolled the list to Rome, carrying the scroll-away
+    // preview card (and its chips) offscreen; scroll back up to read them.
     expect(find.byType(TripMapScreen), findsNothing);
+    pagePosition(tester).jumpTo(0);
+    await tester.pumpAndSettle();
     final inlineChips = tester.widget<MapLegChips>(find.byType(MapLegChips));
     expect(inlineChips.selected, 'Rome');
     final inlineMap = tester.widget<TripMap>(find.byType(TripMap));
@@ -193,18 +208,16 @@ void main() {
     await tester.pumpAndSettle();
 
     // Back on the trip screen, the inline chips kept the focus AND the
-    // report-back opened Rome's group exclusively behind the modal
-    // (accordion: the selection materializes in the list on close).
+    // report-back pre-scrolled Rome's header into place behind the modal
+    // (expansion is decoupled from focus: no group collapses, the
+    // selection just lands in view on close).
     expect(find.byType(TripMapScreen), findsNothing);
     final inlineChips = tester.widget<MapLegChips>(find.byType(MapLegChips));
     expect(inlineChips.selected, 'Rome');
     expect(find.text('Colosseum'), findsOneWidget);
-    expect(find.text('Louvre'), findsNothing,
-        reason: 'Paris stays collapsed — only Rome is open');
   });
 
-  testWidgets(
-      'wide: the full-screen All chip collapses the group behind the modal',
+  testWidgets('wide: the full-screen All chip resets the map only',
       (WidgetTester tester) async {
     await pumpScreen(tester, surface: const Size(1200, 800));
 
@@ -221,8 +234,42 @@ void main() {
     expect(inlineChips.selected, isNull);
     final inlineMap = tester.widget<TripMap>(find.byType(TripMap));
     expect(inlineMap.fitSignature, isNull);
-    expect(find.text('Colosseum'), findsNothing,
-        reason: 'the All chip closed the open group behind the modal');
+    expect(find.text('Colosseum'), findsOneWidget,
+        reason: 'All resets the MAP only — the list is untouched, so the '
+            'previously focused group stays expanded');
+  });
+
+  testWidgets(
+      'phone: a full-screen region-pin tap focuses that leg and pre-scrolls '
+      'the list behind the modal', (WidgetTester tester) async {
+    await pumpScreen(tester, surface: phone);
+
+    // Open the full map from the All view — the only mode destination
+    // (region) pins render in.
+    await tester.tap(find.byType(TripMap), warnIfMissed: false);
+    await tester.pumpAndSettle();
+    expect(find.byType(TripMapScreen), findsOneWidget);
+
+    // Invoke the FULL-SCREEN map's destination callback directly (the
+    // inline preview passes null — its tap opens this modal instead).
+    // Chip-equivalent inside the modal: the map flips to the leg's pins.
+    tester.widget<TripMap>(find.byType(TripMap)).onDestinationTap!('Rome');
+    await tester.pumpAndSettle();
+
+    final fullMap = tester.widget<TripMap>(find.byType(TripMap));
+    expect(fullMap.fitSignature, 'Rome');
+    expect(fullMap.items.map((i) => i.name), ['Colosseum']);
+    final fullChips = tester.widget<MapLegChips>(find.byType(MapLegChips));
+    expect(fullChips.selected, 'Rome');
+
+    await tester.tap(find.byType(CloseButton));
+    await tester.pumpAndSettle();
+
+    // The report-back pre-scrolls the list on phones, so closing the modal
+    // lands on the region instead of the top of the page (the chips ride
+    // the scroll-away preview card, so they're offscreen by design).
+    expect(find.byType(TripMapScreen), findsNothing);
+    expect(pagePosition(tester).pixels, greaterThan(0));
   });
 
   testWidgets(
@@ -256,8 +303,11 @@ void main() {
     await tester.sendKeyEvent(LogicalKeyboardKey.escape);
     await tester.pumpAndSettle();
 
-    // Same pop path as the close button: screen gone, focus kept.
+    // Same pop path as the close button: screen gone, focus kept (undo the
+    // phone report-back's pre-scroll to read the preview card's chips).
     expect(find.byType(TripMapScreen), findsNothing);
+    pagePosition(tester).jumpTo(0);
+    await tester.pumpAndSettle();
     final inlineChips = tester.widget<MapLegChips>(find.byType(MapLegChips));
     expect(inlineChips.selected, 'Rome');
   });

--- a/src/packages/flutter-app/test/trip_detail_revisited_city_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_revisited_city_test.dart
@@ -77,13 +77,18 @@ void main() {
     expect(find.text('Fira'), findsNWidgets(2));
     expect(find.text('Oia'), findsNWidgets(2));
     expect(find.text('Athens'), findsOneWidget);
-    // Groups default collapsed — expanding Athens reveals its items.
-    await expandCity(tester, 'Athens');
+    // Groups default expanded — Athens's items render without any tap.
     expect(find.text('Acropolis'), findsOneWidget);
   });
 
-  testWidgets('expanding one visit leaves the other visit collapsed',
+  testWidgets('collapsing one visit leaves the other visit expanded',
       (WidgetTester tester) async {
+    // Groups default expanded, so the last group's item tile sits below the
+    // default 600px viewport's cache extent (lazy SliverList) and would never
+    // build — use a tall surface so the whole itinerary is findable.
+    tester.view.physicalSize = const Size(800, 2400);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
     final trip = Trip(
       id: 't2',
       title: 'Athens & Santorini',
@@ -109,21 +114,22 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    // All three groups start collapsed.
-    expect(find.text('Fira first stop'), findsNothing);
-
-    // Expanding the first Fira run reveals only that run's items — a
-    // label-keyed expansion set would have opened both Fira runs.
-    await expandCity(tester, 'Fira');
+    // All three groups start expanded.
     expect(find.text('Fira first stop'), findsOneWidget);
-    expect(find.text('Fira second stop'), findsNothing);
-    expect(find.text('Oia detour'), findsNothing);
+    expect(find.text('Fira second stop'), findsOneWidget);
+    expect(find.text('Oia detour'), findsOneWidget);
+
+    // Collapsing the first Fira run hides only that run's items — a
+    // label-keyed collapse set would have closed both Fira runs.
+    await collapseCity(tester, 'Fira', index: 0);
+    expect(find.text('Fira first stop'), findsNothing);
+    expect(find.text('Fira second stop'), findsOneWidget);
+    expect(find.text('Oia detour'), findsOneWidget);
     expect(find.text('Fira'), findsNWidgets(2));
 
-    // Collapsing it again hides that run without touching the other header.
-    await tester.tap(find.text('Fira').first);
-    await tester.pumpAndSettle();
-    expect(find.text('Fira first stop'), findsNothing);
+    // Toggling it again restores that run without touching the other header.
+    await toggleCity(tester, 'Fira', index: 0);
+    expect(find.text('Fira first stop'), findsOneWidget);
     expect(find.text('Fira'), findsNWidgets(2));
   });
 }

--- a/src/packages/flutter-app/test/trip_detail_scroll_perf_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_scroll_perf_test.dart
@@ -111,7 +111,7 @@ void main() {
       reason: 'the pinned map card must repaint in its own layer',
     );
 
-    // City headers (collapsed at boot) are individually boundaried.
+    // City headers (expanded at boot) are individually boundaried.
     expect(
       directlyBoundaried(
           tester,
@@ -124,11 +124,11 @@ void main() {
       reason: 'city headers must repaint in their own layer',
     );
 
-    // Expanding a city mounts its pinned day headers — those are
-    // boundaried too (city header + ≥1 day header ⇒ ≥2 direct wraps; item
-    // tiles rely on the reorderable list's automatic row boundaries and are
-    // deliberately NOT double-wrapped).
-    await expandCity(tester, 'Paris');
+    // Every group defaults expanded, so all pinned day headers mount at
+    // boot — those are boundaried too. Census: 3 city headers + 4 day
+    // headers (Paris days 1-2, Rome day 3, Berlin day 4) = 7 direct wraps;
+    // item tiles rely on the reorderable list's automatic row boundaries
+    // and are deliberately NOT double-wrapped.
     final directWraps = find
         .byType(HoverReveal)
         .evaluate()
@@ -141,8 +141,8 @@ void main() {
       });
       return parent is RepaintBoundary;
     }).length;
-    expect(directWraps, greaterThanOrEqualTo(2),
-        reason: 'city and day headers must both carry direct boundaries');
+    expect(directWraps, 7,
+        reason: 'every city and day header must carry a direct boundary');
 
     // The regression guard for the fade itself. Scoped to HoverReveal
     // subtrees: flutter_map legitimately keeps a couple of idle
@@ -185,7 +185,6 @@ void main() {
       (tester) async {
     useSurface(tester, const Size(1200, 2200));
     await pump(tester, threeCityTrip());
-    await expandCity(tester, 'Paris');
 
     final gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
     await gesture.addPointer(location: Offset.zero);

--- a/src/packages/flutter-app/test/trip_detail_sticky_headers_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_sticky_headers_test.dart
@@ -9,7 +9,6 @@ import 'package:travel_route_planner/services/trips_api_service.dart';
 import 'package:travel_route_planner/providers/trips_provider.dart';
 import 'package:travel_route_planner/screens/trip_detail_screen.dart';
 
-import 'support/city_groups.dart';
 import 'support/l10n_test_app.dart';
 
 class _FakeTripsApiService extends TripsApiService {
@@ -68,23 +67,20 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    // Groups default collapsed. The accordion allows at most ONE open group
-    // (specs/map-city-focus, accordion rev) — expanding a city closes any
-    // other open group — so only Paris is opened here; its items alone
-    // provide the scroll extent for the Paris pinned-header assertions.
-    await expandCity(tester, 'Paris');
-
+    // Groups default EXPANDED (list expansion is decoupled from the map;
+    // there is no single-open accordion anymore), so both groups' bodies
+    // contribute scroll extent from the start — no expand tap needed.
     expect(find.text('Paris'), findsOneWidget);
 
     // Scroll into the middle of Paris day 2, far enough that both the city
     // and day headers have reached their pinned slots. jumpTo keeps offsets
     // exact (drag gestures fling unpredictably past the target). Offsets
-    // retuned for the accordion (only the open Paris group contributes
-    // extent), again when the add-button trio left the itinerary tail for
-    // the Bookings view's header menu (450/570 replaced 450/600), and again
-    // when the wear/pack section left the tail for the app-bar icon — its
-    // sliver's 8px top pad went with it, so max extent is now ~562 and a
-    // 570 target would clamp: 450/550.
+    // re-verified for groups defaulting expanded (every group's body is
+    // mounted, so max extent grew to ~1250 — the wear/pack tail spacer
+    // trimmed ~8px of that, absorbed): the Paris header pins from ~400 and
+    // holds — with Day 2 pinned right below it — until Rome's header
+    // starts pushing it off past ~750, so 450/550 both land inside that
+    // stable window with 'Paris stop 4' on screen at each.
     final position =
         tester.state<ScrollableState>(find.byType(Scrollable).first).position;
     position.jumpTo(450);
@@ -108,17 +104,10 @@ void main() {
     expect(parisDyA, greaterThan(0));
     expect(day2DyA, greaterThan(parisDyA));
 
-    // Rome's turn in the pinned slot. Under the accordion Rome's body only
-    // exists while Rome is the open group, so bring its collapsed header
-    // fully into view and expand it — which also closes Paris (its Day 2
-    // header and items unbuild; the Paris header row itself still renders).
-    position.jumpTo(position.maxScrollExtent);
-    await tester.pumpAndSettle();
-    await expandCity(tester, 'Rome');
-
-    // Scroll to the bottom: Rome's header reaches the pinned city slot —
-    // the same slot Paris pinned in (parisDyA) — with its Day 4 header
-    // pinned below it.
+    // Rome's turn in the pinned slot. Its body is already mounted (groups
+    // default expanded), so a single jump to the bottom is enough: Rome's
+    // header reaches the pinned city slot — the same slot Paris pinned in
+    // (parisDyA) — with its Day 4 header pinned below it.
     position.jumpTo(position.maxScrollExtent);
     await tester.pumpAndSettle();
 
@@ -127,8 +116,8 @@ void main() {
     expect(tester.getTopLeft(find.text('Day 4')).dy, greaterThan(parisDyA));
     final parisAfter = find.text('Paris');
     if (parisAfter.evaluate().isNotEmpty) {
-      // Collapsed Paris header still built, but scrolled above Rome's
-      // pinned slot.
+      // Paris's header, if still built (it may unbuild past the cache
+      // extent), has been pushed above Rome's pinned slot.
       expect(tester.getTopLeft(parisAfter).dy, lessThan(parisDyA));
     }
   });

--- a/src/packages/flutter-app/test/trip_map_screen_test.dart
+++ b/src/packages/flutter-app/test/trip_map_screen_test.dart
@@ -41,6 +41,7 @@ const _legChips = [
 Widget _app({
   EdgeInsets viewPadding = EdgeInsets.zero,
   void Function(String? legKey)? onAddPlace,
+  void Function(String? legKey)? onLegSelected,
   String title = 'Paris getaway',
   String? homeAirport,
   LatLng? firstCityPoint,
@@ -64,7 +65,7 @@ Widget _app({
         staysForLeg: (_) => const <Accommodation>[],
         segmentLabels: const {},
         legChips: _legChips,
-        onLegSelected: (_) {},
+        onLegSelected: onLegSelected ?? (_) {},
         onAddPlace: onAddPlace,
         homeAirport: homeAirport,
         firstCityPoint: firstCityPoint,
@@ -216,9 +217,19 @@ void main() {
   });
 
   group('destination pins (trip overview)', () {
+    // Leg keys match the chip keys, as trip detail passes them — the pins on
+    // this screen are navigable (see the chip-equivalent test below).
     const dests = [
-      TripMapDestination(label: 'Paris', point: LatLng(48.8566, 2.3522)),
-      TripMapDestination(label: 'Rome', point: LatLng(41.9028, 12.4964)),
+      TripMapDestination(
+        label: 'Paris',
+        point: LatLng(48.8566, 2.3522),
+        legKey: 'Paris',
+      ),
+      TripMapDestination(
+        label: 'Rome',
+        point: LatLng(41.9028, 12.4964),
+        legKey: 'Rome',
+      ),
     ];
 
     Finder inMap(String text) =>
@@ -243,6 +254,37 @@ void main() {
       expect(find.byType(MarkerClusterLayerWidget), findsNothing);
       expect(inMap('1'), findsOneWidget);
       expect(inMap('2'), findsOneWidget);
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets(
+        'a destination-pin tap is the chip-equivalent: leg selected in '
+        'place and reported back', (tester) async {
+      String? reported = 'sentinel';
+      await tester.pumpWidget(
+        _app(destinations: dests, onLegSelected: (k) => reported = k),
+      );
+      await tester.pumpAndSettle();
+
+      // Drive the wired callback directly (the robust screen-level pattern;
+      // pin tap geometry is covered in trip_map_test).
+      tester.widget<TripMap>(find.byType(TripMap)).onDestinationTap!('Rome');
+      await tester.pumpAndSettle();
+
+      // In place: the camera-refit signal flips to the leg, the overview
+      // pins hand off to per-item pins, and the chip row follows — no pop.
+      final map = tester.widget<TripMap>(find.byType(TripMap));
+      expect(map.fitSignature, 'Rome');
+      expect(map.destinations, isNull);
+      expect(find.byType(MarkerClusterLayerWidget), findsOneWidget);
+      expect(
+        tester.widget<MapLegChips>(find.byType(MapLegChips)).selected,
+        'Rome',
+      );
+
+      // Trip detail hears about it (it pre-scrolls the list behind the
+      // modal so closing lands on the region).
+      expect(reported, 'Rome');
       expect(tester.takeException(), isNull);
     });
   });

--- a/src/packages/flutter-app/test/trip_map_test.dart
+++ b/src/packages/flutter-app/test/trip_map_test.dart
@@ -794,6 +794,122 @@ void main() {
       );
       expect(find.byType(MarkerClusterLayerWidget), findsOneWidget);
     });
+
+    // [dests] with leg keys wired — what the trip detail screen passes when
+    // it makes the overview pins navigable via onDestinationTap.
+    const navDests = [
+      TripMapDestination(
+        label: 'Paris',
+        point: LatLng(48.8566, 2.3522),
+        dates: 'Jun 10 – Jun 12',
+        legKey: 'Paris',
+      ),
+      TripMapDestination(
+        label: 'Rome',
+        point: LatLng(41.9028, 12.4964),
+        dates: 'Jun 12 – Jun 14',
+        legKey: 'Rome',
+      ),
+      TripMapDestination(
+        label: 'Athens',
+        point: LatLng(37.9838, 23.7275),
+        legKey: 'Athens',
+      ),
+    ];
+
+    testWidgets('tapping a navigable pin fires onDestinationTap with its key', (
+      WidgetTester tester,
+    ) async {
+      String? tapped;
+      await tester.pumpWidget(
+        _host(
+          TripMap(
+            items: const [],
+            destinations: navDests,
+            onDestinationTap: (k) => tapped = k,
+          ),
+        ),
+      );
+      await tester.pump();
+
+      // Destination pins never cluster, so a real tap is reliable — on the
+      // mid-map pin (the SE-most pin sits under the zoom/reset column, where
+      // a tap would hit the buttons instead).
+      await tester.tap(inMap('2'));
+      expect(tapped, 'Rome');
+
+      // Navigation, not a tooltip affair: the tap must not raise the overlay.
+      await tester.pump(const Duration(milliseconds: 200));
+      expect(find.text('Rome\nJun 12 – Jun 14'), findsNothing);
+    });
+
+    testWidgets('a navigable pin keeps its tooltip message (hover/long-press)',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        _host(
+          TripMap(
+            items: const [],
+            destinations: navDests,
+            onDestinationTap: (_) {},
+          ),
+        ),
+      );
+      await tester.pump();
+
+      final rome = tester.widget<Tooltip>(
+        find.ancestor(of: inMap('2'), matching: find.byType(Tooltip)),
+      );
+      expect(rome.message, 'Rome\nJun 12 – Jun 14');
+      // The tap trigger is gone — tap navigates now; the tooltip stays
+      // reachable via hover (desktop) and long-press.
+      expect(rome.triggerMode, isNot(TooltipTriggerMode.tap));
+    });
+
+    testWidgets('a null legKey keeps its pin inert under onDestinationTap', (
+      WidgetTester tester,
+    ) async {
+      // Mixed list: only some legs navigable — the key-less pin must fall
+      // back to the tooltip-only widget instead of crashing on tap.
+      const mixed = [
+        TripMapDestination(
+          label: 'Paris',
+          point: LatLng(48.8566, 2.3522),
+          legKey: 'Paris',
+        ),
+        TripMapDestination(
+          label: 'Rome',
+          point: LatLng(41.9028, 12.4964),
+          dates: 'Jun 12 – Jun 14',
+        ),
+        TripMapDestination(
+          label: 'Athens',
+          point: LatLng(37.9838, 23.7275),
+          legKey: 'Athens',
+        ),
+      ];
+      String? tapped;
+      await tester.pumpWidget(
+        _host(
+          TripMap(
+            items: const [],
+            destinations: mixed,
+            onDestinationTap: (k) => tapped = k,
+          ),
+        ),
+      );
+      await tester.pump();
+
+      // Tap shows the old self-contained tooltip; the callback never fires.
+      await tester.tap(inMap('2'));
+      await tester.pump(const Duration(milliseconds: 200));
+      expect(tapped, isNull);
+      expect(find.text('Rome\nJun 12 – Jun 14'), findsOneWidget);
+
+      // Let the tap-triggered tooltip's show timer elapse and fade out so
+      // the test ends without pending timers.
+      await tester.pump(const Duration(seconds: 3));
+      await tester.pumpAndSettle();
+    });
   });
 
   group('single world fills a wide map band (no background side bars)', () {


### PR DESCRIPTION
## Summary
- All city groups on trip detail start **expanded**; expansion is list-only state (`_collapsedGroups`, inverted like `_collapsedDays`). A header tap toggles just that group — it never writes map focus or moves the camera. The PR #339 single-open accordion ("the open group IS the selection"), its reveal-only hatch, sole-group seed, and derived `_openGroupKey` are deleted; the friction log carries the superseding entry.
- `_focusedLegKey` survives as **map-only** state (chips, camera fit, per-leg pin filtering) behind one slim writer (`_setMapFocus`). Chip taps keep the combined gesture (focus + un-collapse + desktop scroll); the **All chip resets the map only** — the list is untouched.
- **Region (destination) pins become navigation**: `TripMapDestination.legKey` + `TripMap.onDestinationTap`. On the inline All-overview map a pin tap scrolls the list to that region's group with no focus write (the overview pins never vanish under the tap; hover tooltip preserved). In the full-screen map a pin tap focuses that city in place (chip-equivalent), and the report-back pre-scrolls the list on phones so closing the modal lands on the region.
- `_revealCityHeader` guarantees a frame behind the post-frame scroll — `addPostFrameCallback` alone stalls on a quiescent UI when the tap changes no state (caught by the new estimation-probe test, which doubles as its regression guard).
- N pinned city headers now coexist; each group's containing `MultiSliver` pushes its own header off at its group's end (contacts-style handoff, verified against sliver_tools 0.2.12 source), and the outer `MultiSliver` stays non-containing so headers can never stack. The zero-body pinned-header rule is untouched.
- Tests: `trip_detail_collapsed_default_test` → `trip_detail_expanded_default_test` (rewritten; zero-body squish regression kept via manual collapse), `trip_detail_leg_focus_test` rewritten for the decoupling contract + a destination-tap-scroll test, new `trip_detail_all_expanded_headers_test` (multi-header push/no-stack, edge-to-edge handoff, independent collapse, far-scroll monotonicity probe), destination-tap unit tests in `trip_map_test`/`trip_map_screen_test`, and the `expandCity` helper is now `toggleCity`/`collapseCity` across 10 suites.

## Testing
- `flutter analyze` clean (3 pre-existing infos in an untouched file).
- `flutter test`: full suite green, 939 tests.
- Headless-Chrome verification on the lane stack (desktop 1440px + phone 375px): all groups expanded on landing; header collapse/expand with zero camera motion; region-pin click from a deep scroll position scrolls to the region with the map pixel-identical; chip tap focuses + scrolls; All chip resets the map with the list untouched; phone preview → full map → region-pin tap focuses in place → closing lands the list on that region.

Note for the integrator: this PR rewrites large parts of `trip_detail_screen.dart` (hub file); #356 (trash-icon → overflow menu) also touches its app bar — merge serially and rebase whichever lands second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)