### PR TITLE
feat(flutter): Bookings tab counter becomes a StatusPill; dropped on narrow

### DIFF
--- a/docs/friction-log.md
+++ b/docs/friction-log.md
@@ -5,6 +5,21 @@ build queue. Priority when picking work: **breakage > friction in features
 actually used > ideas that recur across ≥2 sessions**. Tag entries `[app]`
 (dogfooding the product) or `[dev]` (workflow/tooling). Newest first.
 
+## 2026-08-13 — trip-detail dogfooding (Bookings tab counter → pill)
+
+- **[app] Friction → fixed (counter styling unified):** with the wear/pack
+  checked-count now a StatusPill in its sheet header, the Bookings tab's
+  inline "Bookings · 0/3" label was the last count not wearing the shared
+  pill chrome. The count moved out of the label into a `StatusPill.custom`
+  beside it (same surfaceContainerHighest/onSurfaceVariant pair as the
+  wear-sheet and checklist headers; `_headerTab` grew a `trailing` slot
+  inside the underlined region so the underline spans label + pill). On
+  **narrow** the pill is dropped entirely — the tab trio + counter was
+  exactly what pushed the FittedBox into visible scale-down at phone
+  widths (the narrow-header test's documented tripwire), and the count is
+  one tap away inside the view. `tripTabBookingsCounted` deleted from
+  both ARBs (dead key).
+
 ## 2026-08-13 — trip-detail dogfooding (expanded groups + navigable map)
 
 - **[app] Friction → fixed (decoupled expansion, supersedes the 08-1x

--- a/src/packages/flutter-app/lib/l10n/app_en.arb
+++ b/src/packages/flutter-app/lib/l10n/app_en.arb
@@ -781,17 +781,6 @@
   "tripFilterAllBooked": "Everything's booked",
   "tripFilterAllBookedMessage": "Nothing left to book on this trip — you're all set.",
   "tripTabBookings": "Bookings",
-  "tripTabBookingsCounted": "Bookings · {booked}/{total}",
-  "@tripTabBookingsCounted": {
-    "placeholders": {
-      "booked": {
-        "type": "int"
-      },
-      "total": {
-        "type": "int"
-      }
-    }
-  },
   "tripBookingsLensEmptyTitle": "No bookings yet",
   "tripBookingsLensEmptyMessage": "Flights, stays, and reservations for this trip will show up here.",
   "tripBookingsLensNoneForDestination": "No bookings for this destination.",

--- a/src/packages/flutter-app/lib/l10n/app_es.arb
+++ b/src/packages/flutter-app/lib/l10n/app_es.arb
@@ -385,7 +385,6 @@
   "tripFilterAllBooked": "Todo reservado",
   "tripFilterAllBookedMessage": "No queda nada por reservar en este viaje — todo listo.",
   "tripTabBookings": "Reservas",
-  "tripTabBookingsCounted": "Reservas · {booked}/{total}",
   "tripBookingsLensEmptyTitle": "Aún no hay reservas",
   "tripBookingsLensEmptyMessage": "Los vuelos, alojamientos y reservas de este viaje aparecerán aquí.",
   "tripBookingsLensNoneForDestination": "No hay reservas para este destino.",

--- a/src/packages/flutter-app/lib/l10n/app_localizations.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations.dart
@@ -63,7 +63,7 @@ import 'app_localizations_es.dart';
 /// property.
 abstract class AppLocalizations {
   AppLocalizations(String locale)
-    : localeName = intl.Intl.canonicalizedLocale(locale.toString());
+      : localeName = intl.Intl.canonicalizedLocale(locale.toString());
 
   final String localeName;
 
@@ -86,16 +86,16 @@ abstract class AppLocalizations {
   /// of delegates is preferred or required.
   static const List<LocalizationsDelegate<dynamic>> localizationsDelegates =
       <LocalizationsDelegate<dynamic>>[
-        delegate,
-        GlobalMaterialLocalizations.delegate,
-        GlobalCupertinoLocalizations.delegate,
-        GlobalWidgetsLocalizations.delegate,
-      ];
+    delegate,
+    GlobalMaterialLocalizations.delegate,
+    GlobalCupertinoLocalizations.delegate,
+    GlobalWidgetsLocalizations.delegate,
+  ];
 
   /// A list of this localizations delegate's supported locales.
   static const List<Locale> supportedLocales = <Locale>[
     Locale('en'),
-    Locale('es'),
+    Locale('es')
   ];
 
   /// Product name. Not translated — it is a brand name.
@@ -5130,9 +5130,8 @@ AppLocalizations lookupAppLocalizations(Locale locale) {
   }
 
   throw FlutterError(
-    'AppLocalizations.delegate failed to load unsupported locale "$locale". This is likely '
-    'an issue with the localizations generation tool. Please file an issue '
-    'on GitHub with a reproducible sample app and the gen-l10n configuration '
-    'that was used.',
-  );
+      'AppLocalizations.delegate failed to load unsupported locale "$locale". This is likely '
+      'an issue with the localizations generation tool. Please file an issue '
+      'on GitHub with a reproducible sample app and the gen-l10n configuration '
+      'that was used.');
 }

--- a/src/packages/flutter-app/lib/l10n/app_localizations.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations.dart
@@ -63,7 +63,7 @@ import 'app_localizations_es.dart';
 /// property.
 abstract class AppLocalizations {
   AppLocalizations(String locale)
-      : localeName = intl.Intl.canonicalizedLocale(locale.toString());
+    : localeName = intl.Intl.canonicalizedLocale(locale.toString());
 
   final String localeName;
 
@@ -86,16 +86,16 @@ abstract class AppLocalizations {
   /// of delegates is preferred or required.
   static const List<LocalizationsDelegate<dynamic>> localizationsDelegates =
       <LocalizationsDelegate<dynamic>>[
-    delegate,
-    GlobalMaterialLocalizations.delegate,
-    GlobalCupertinoLocalizations.delegate,
-    GlobalWidgetsLocalizations.delegate,
-  ];
+        delegate,
+        GlobalMaterialLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+      ];
 
   /// A list of this localizations delegate's supported locales.
   static const List<Locale> supportedLocales = <Locale>[
     Locale('en'),
-    Locale('es')
+    Locale('es'),
   ];
 
   /// Product name. Not translated — it is a brand name.
@@ -2407,12 +2407,6 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Bookings'**
   String get tripTabBookings;
-
-  /// No description provided for @tripTabBookingsCounted.
-  ///
-  /// In en, this message translates to:
-  /// **'Bookings · {booked}/{total}'**
-  String tripTabBookingsCounted(int booked, int total);
 
   /// No description provided for @tripBookingsLensEmptyTitle.
   ///
@@ -5136,8 +5130,9 @@ AppLocalizations lookupAppLocalizations(Locale locale) {
   }
 
   throw FlutterError(
-      'AppLocalizations.delegate failed to load unsupported locale "$locale". This is likely '
-      'an issue with the localizations generation tool. Please file an issue '
-      'on GitHub with a reproducible sample app and the gen-l10n configuration '
-      'that was used.');
+    'AppLocalizations.delegate failed to load unsupported locale "$locale". This is likely '
+    'an issue with the localizations generation tool. Please file an issue '
+    'on GitHub with a reproducible sample app and the gen-l10n configuration '
+    'that was used.',
+  );
 }

--- a/src/packages/flutter-app/lib/l10n/app_localizations_en.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations_en.dart
@@ -1297,11 +1297,6 @@ class AppLocalizationsEn extends AppLocalizations {
   String get tripTabBookings => 'Bookings';
 
   @override
-  String tripTabBookingsCounted(int booked, int total) {
-    return 'Bookings · $booked/$total';
-  }
-
-  @override
   String get tripBookingsLensEmptyTitle => 'No bookings yet';
 
   @override

--- a/src/packages/flutter-app/lib/l10n/app_localizations_es.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations_es.dart
@@ -1308,11 +1308,6 @@ class AppLocalizationsEs extends AppLocalizations {
   String get tripTabBookings => 'Reservas';
 
   @override
-  String tripTabBookingsCounted(int booked, int total) {
-    return 'Reservas · $booked/$total';
-  }
-
-  @override
   String get tripBookingsLensEmptyTitle => 'Aún no hay reservas';
 
   @override

--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -2930,16 +2930,19 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
     );
   }
 
-  /// One header view tab ("Itinerary" / "Bookings · 2/21"). The selected tab
-  /// doesn't take taps — re-tap is a no-op, which also keeps an idle tap on
-  /// the already-selected Itinerary tab from clearing an active places
-  /// filter. The 2px underline is reserved (transparent) when unselected so
-  /// selection never shifts layout; Center(widthFactor: 1) hugs the label's
-  /// width while filling the header row's height for a real touch target.
+  /// One header view tab ("Itinerary" / "Bookings" + count pill). The
+  /// selected tab doesn't take taps — re-tap is a no-op, which also keeps an
+  /// idle tap on the already-selected Itinerary tab from clearing an active
+  /// places filter. The 2px underline is reserved (transparent) when
+  /// unselected so selection never shifts layout; Center(widthFactor: 1)
+  /// hugs the label's width while filling the header row's height for a real
+  /// touch target. [trailing] renders inside the underlined region so the
+  /// underline spans label + pill as one tab.
   Widget _headerTab(ThemeData theme,
       {required String label,
       required bool selected,
-      required VoidCallback onTap}) {
+      required VoidCallback onTap,
+      Widget? trailing}) {
     return Semantics(
       button: true,
       selected: selected,
@@ -2961,16 +2964,25 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
                 ),
               ),
             ),
-            child: Text(
-              label,
-              maxLines: 1,
-              overflow: TextOverflow.ellipsis,
-              style: theme.textTheme.titleSmall?.copyWith(
-                fontWeight: selected ? FontWeight.w700 : FontWeight.w500,
-                color: selected
-                    ? theme.colorScheme.onSurface
-                    : theme.colorScheme.onSurfaceVariant,
-              ),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(
+                  label,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: theme.textTheme.titleSmall?.copyWith(
+                    fontWeight: selected ? FontWeight.w700 : FontWeight.w500,
+                    color: selected
+                        ? theme.colorScheme.onSurface
+                        : theme.colorScheme.onSurfaceVariant,
+                  ),
+                ),
+                if (trailing != null) ...[
+                  const SizedBox(width: AppSpacing.xs),
+                  trailing,
+                ],
+              ],
             ),
           ),
         ),
@@ -3027,16 +3039,24 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
             ),
             if (!itemsEmpty) ...[
               SizedBox(width: tabGap),
-              // The booking progress count rides the tab label — this tab
-              // replaced the counter that was the old (one-way) door into
-              // this view.
+              // The booking progress count rides the tab as a pill — the
+              // same checked/total chrome as the wear-sheet header and the
+              // checklist header, so every count reads as one language.
+              // (This tab replaced the counter that was the old one-way
+              // door into this view.) Dropped on narrow: three tabs +
+              // pill is what genuinely shrinks the FittedBox trio at
+              // 390px, and the count is one tap away inside the view.
               _headerTab(
                 theme,
-                label: _bookingTodos.isEmpty
-                    ? l10n.tripTabBookings
-                    : l10n.tripTabBookingsCounted(
-                        _bookingTodos.where((t) => t.booked).length,
-                        _bookingTodos.length),
+                label: l10n.tripTabBookings,
+                trailing: (_narrow || _bookingTodos.isEmpty)
+                    ? null
+                    : StatusPill.custom(
+                        label:
+                            '${_bookingTodos.where((t) => t.booked).length}/${_bookingTodos.length}',
+                        background: theme.colorScheme.surfaceContainerHighest,
+                        foreground: theme.colorScheme.onSurfaceVariant,
+                      ),
                 selected: _inBookingsView,
                 onTap: () => setState(() {
                   _itemFilter = 'bookings';

--- a/src/packages/flutter-app/test/trip_detail_bookings_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_bookings_test.dart
@@ -13,6 +13,7 @@ import 'package:travel_route_planner/providers/accommodations_provider.dart';
 import 'package:travel_route_planner/providers/trips_provider.dart';
 import 'package:travel_route_planner/screens/trip_detail_screen.dart';
 import 'package:travel_route_planner/widgets/booking_todo_card.dart';
+import 'package:travel_route_planner/widgets/status_pill.dart';
 
 import 'support/l10n_test_app.dart';
 
@@ -138,8 +139,13 @@ void main() {
         greaterThan(tester.getTopLeft(find.text('Trastevere')).dy));
 
     // The separate Bookings section is retired; the header's Bookings tab
-    // carries the booking progress in its label instead.
-    expect(find.text('Bookings · 0/6'), findsOneWidget);
+    // carries the booking progress as a StatusPill beside the label — the
+    // same checked/total chrome as the wear-sheet and checklist headers.
+    expect(find.text('Bookings'), findsOneWidget);
+    expect(
+        find.descendant(
+            of: find.byType(StatusPill), matching: find.text('0/6')),
+        findsOneWidget);
 
     // Only the unmatched custom todo lands in the "Other bookings" area at
     // the itinerary's tail, as a card — directly visible, no expand step.

--- a/src/packages/flutter-app/test/trip_detail_filter_lenses_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_filter_lenses_test.dart
@@ -22,6 +22,7 @@ import 'package:travel_route_planner/providers/transport_provider.dart';
 import 'package:travel_route_planner/providers/trips_provider.dart';
 import 'package:travel_route_planner/screens/trip_detail_screen.dart';
 import 'package:travel_route_planner/widgets/booking_detail_row.dart';
+import 'package:travel_route_planner/widgets/status_pill.dart';
 import 'package:travel_route_planner/widgets/booking_sheets.dart';
 import 'package:travel_route_planner/widgets/booking_todo_card.dart';
 
@@ -176,12 +177,19 @@ Future<void> _selectFilter(WidgetTester tester, String label) async {
   await tester.pumpAndSettle();
 }
 
-/// Taps the Bookings header tab by its exact label — callers pass the
-/// counted form ('Bookings · 1/2') so every use also pins the label the
-/// booked-progress count renders as (or the plain 'Bookings' when the
-/// trip has no todos).
-Future<void> _openBookingsTab(WidgetTester tester, String label) async {
-  await tester.tap(find.text(label));
+/// Taps the Bookings header tab; when [count] is given, first pins the
+/// booked-progress pill riding the tab ('1/2' etc.) — the counter is a
+/// [StatusPill] beside the label now, not part of it (dropped entirely on
+/// narrow; these tests run wide at 800). Pass no count for a trip whose
+/// todos are empty (viewer trips included): the tab renders bare.
+Future<void> _openBookingsTab(WidgetTester tester, [String? count]) async {
+  if (count != null) {
+    expect(
+        find.descendant(
+            of: find.byType(StatusPill), matching: find.text(count)),
+        findsOneWidget);
+  }
+  await tester.tap(find.text('Bookings'));
   await tester.pumpAndSettle();
 }
 
@@ -244,7 +252,7 @@ void main() {
           ],
         ));
 
-    await _openBookingsTab(tester, 'Bookings · 1/2');
+    await _openBookingsTab(tester, '1/2');
     await tester.tap(find.widgetWithText(FilterChip, 'Not booked yet'));
     await tester.pumpAndSettle();
 
@@ -287,7 +295,7 @@ void main() {
               booked: true),
         ]));
 
-    await _openBookingsTab(tester, 'Bookings · 1/1');
+    await _openBookingsTab(tester, '1/1');
     expect(find.widgetWithText(BookingTodoRow, 'Stay in Paris'),
         findsOneWidget);
 
@@ -391,7 +399,7 @@ void main() {
     _useTallViewport(tester);
     await _pump(tester, mixedTrip());
 
-    await _openBookingsTab(tester, 'Bookings · 1/2');
+    await _openBookingsTab(tester, '1/2');
 
     expect(find.text('Louvre'), findsNothing);
     expect(find.text('Café de Flore'), findsNothing);
@@ -412,7 +420,7 @@ void main() {
     _useTallViewport(tester);
     final (todosApi, accApi) = await _pump(tester, mixedTrip());
 
-    await _openBookingsTab(tester, 'Bookings · 1/2');
+    await _openBookingsTab(tester, '1/2');
     await tester.tap(find.descendant(
         of: find.widgetWithText(BookingTodoRow, 'Stay in Paris'),
         matching: find.byType(Checkbox)));
@@ -432,7 +440,7 @@ void main() {
     _useTallViewport(tester);
     await _pump(tester, twoCityTrip());
 
-    await _openBookingsTab(tester, 'Bookings · 0/2');
+    await _openBookingsTab(tester, '0/2');
     expect(
         find.widgetWithText(BookingTodoRow, 'Stay in Paris'), findsOneWidget);
     expect(
@@ -472,7 +480,7 @@ void main() {
               auto: false),
         ]));
 
-    await _openBookingsTab(tester, 'Bookings · 0/2');
+    await _openBookingsTab(tester, '0/2');
     expect(
         find.widgetWithText(BookingTodoCard, 'Museum tickets'), findsOneWidget);
 
@@ -498,15 +506,15 @@ void main() {
     _useTallViewport(tester);
     await _pump(tester, mixedTrip());
 
-    // 'Bookings · 1/2' — one booked custom todo of two todos. The count
-    // rides the tab label (this tab replaced the old one-way counter).
-    await _openBookingsTab(tester, 'Bookings · 1/2');
+    // Pill '1/2' — one booked custom todo of two todos. The count rides
+    // the tab as a StatusPill (this tab replaced the old one-way counter).
+    await _openBookingsTab(tester, '1/2');
 
     expect(find.text('Louvre'), findsNothing);
     expect(
         find.widgetWithText(BookingTodoRow, 'Stay in Paris'), findsOneWidget);
     // The selected tab is bold; the unselected one isn't.
-    expect(tester.widget<Text>(find.text('Bookings · 1/2')).style?.fontWeight,
+    expect(tester.widget<Text>(find.text('Bookings')).style?.fontWeight,
         FontWeight.w700);
     expect(tester.widget<Text>(find.text('Itinerary')).style?.fontWeight,
         FontWeight.w500);
@@ -558,7 +566,7 @@ void main() {
           ],
         ));
 
-    await _openBookingsTab(tester, 'Bookings · 0/2');
+    await _openBookingsTab(tester, '0/2');
     expect(find.widgetWithText(ChoiceChip, 'Paris'), findsOneWidget);
 
     await tester.tap(find.widgetWithText(ChoiceChip, 'Paris'));
@@ -590,7 +598,7 @@ void main() {
     // carries no count.
     expect(find.textContaining('booked'), findsNothing);
 
-    await _openBookingsTab(tester, 'Bookings');
+    await _openBookingsTab(tester);
     expect(
         find.widgetWithText(BookingDetailRow, 'Hotel Lutetia'), findsOneWidget);
     expect(find.text('Louvre'), findsNothing);
@@ -602,7 +610,7 @@ void main() {
     _useTallViewport(tester);
     await _pump(tester, _trip());
 
-    await _openBookingsTab(tester, 'Bookings');
+    await _openBookingsTab(tester);
     expect(find.text('No bookings yet'), findsOneWidget);
     expect(find.byType(ChoiceChip), findsNothing);
     // No scope chip in the nothing-at-all state — scoping an empty list is
@@ -651,7 +659,7 @@ void main() {
     expect(find.text('Add transport'), findsNothing);
 
     // Bookings view: the swap, not an addition.
-    await _openBookingsTab(tester, 'Bookings · 1/2');
+    await _openBookingsTab(tester, '1/2');
     expect(find.text('Add booking'), findsOneWidget);
     expect(find.text('Add place'), findsNothing);
 
@@ -667,7 +675,7 @@ void main() {
       'custom-booking dialog', (tester) async {
     _useTallViewport(tester);
     await _pump(tester, mixedTrip());
-    await _openBookingsTab(tester, 'Bookings · 1/2');
+    await _openBookingsTab(tester, '1/2');
 
     Future<void> pick(String item) async {
       await tester.tap(find.text('Add booking'));
@@ -696,7 +704,7 @@ void main() {
     _useTallViewport(tester);
     await _pump(tester, mixedTrip());
 
-    await _openBookingsTab(tester, 'Bookings · 1/2');
+    await _openBookingsTab(tester, '1/2');
     await tester.tap(find.widgetWithText(FilterChip, 'Not booked yet'));
     await tester.pumpAndSettle();
     expect(find.text('Add booking'), findsOneWidget);
@@ -714,7 +722,7 @@ void main() {
 
     // Entering the Bookings view drops the places filter (as the menu and
     // counter always did)...
-    await _openBookingsTab(tester, 'Bookings · 1/2');
+    await _openBookingsTab(tester, '1/2');
     expect(
         find.widgetWithText(BookingTodoRow, 'Stay in Paris'), findsOneWidget);
 
@@ -751,13 +759,13 @@ void main() {
     _useTallViewport(tester);
     await _pump(tester, mixedTrip());
 
-    await _openBookingsTab(tester, 'Bookings · 1/2');
+    await _openBookingsTab(tester, '1/2');
     await tester.tap(find.widgetWithText(FilterChip, 'Not booked yet'));
     await tester.pumpAndSettle();
 
     expect(find.widgetWithText(BookingTodoRow, 'Stay in Paris'),
         findsOneWidget);
-    expect(tester.widget<Text>(find.text('Bookings · 1/2')).style?.fontWeight,
+    expect(tester.widget<Text>(find.text('Bookings')).style?.fontWeight,
         FontWeight.w700);
 
     // Itinerary exits the whole Bookings view, scope included.

--- a/src/packages/flutter-app/test/trip_detail_narrow_header_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_narrow_header_test.dart
@@ -151,10 +151,14 @@ void main() {
     addTearDown(tester.platformDispatcher.clearAllTestValues);
     await _pump(tester, _trip(todos: oneTodo), surface: phone);
 
-    for (final label in ['Itinerary', 'Bookings · 0/1', 'Budget']) {
+    for (final label in ['Itinerary', 'Bookings', 'Budget']) {
       expect(find.text(label), findsOneWidget);
       expectNoTruncation(tester, label);
     }
+    // Narrow drops the booked-progress pill from the Bookings tab — the
+    // trio + pill is what genuinely shrank the FittedBox at phone widths;
+    // the count is one tap away inside the view.
+    expect(find.text('0/1'), findsNothing);
     expect(find.text('Add place'), findsNothing);
     expect(find.byTooltip('Add place'), findsOneWidget);
   });
@@ -165,14 +169,12 @@ void main() {
     await _pump(tester, _trip(todos: oneTodo),
         surface: phone, locale: const Locale('es'));
 
-    // minScale 0.95: the square test font at 0.5 overshoots real glyph
-    // widths by a few percent on the long Spanish trio (every glyph is
-    // fontSize/2 wide; real 'i'/'r'/'l' are narrower), so the cluster may
-    // sit a hair into the FittedBox's scale-down here while fitting whole
-    // in a real browser at 390px (verified 2026-08-13). Anything below
-    // ~0.95 would be a genuinely visible shrink — that's the tripwire for
-    // dropping the Bookings counter on narrow.
-    for (final label in ['Itinerario', 'Reservas · 0/1', 'Presupuesto']) {
+    // The counter tripwire fired (2026-08-13): the Bookings counter is now
+    // dropped on narrow, which shortens the Spanish trio. The 0.95 hedge
+    // stays only for the square test font's overshoot (every glyph is
+    // fontSize/2 wide; real 'i'/'r'/'l' are narrower) — the cluster fits
+    // whole in a real browser at 390px.
+    for (final label in ['Itinerario', 'Reservas', 'Presupuesto']) {
       expect(find.text(label), findsOneWidget);
       expectNoTruncation(tester, label, minScale: 0.95);
     }
@@ -203,7 +205,7 @@ void main() {
       (tester) async {
     await _pump(tester, _trip(todos: oneTodo), surface: phone);
 
-    await tester.tap(find.text('Bookings · 0/1'));
+    await tester.tap(find.text('Bookings'));
     await tester.pumpAndSettle();
 
     // Same icon-only rule as Add place, same row-must-fit reason; the swap


### PR DESCRIPTION
## Summary
- The Bookings tab's booked-progress count moves out of the label into a `StatusPill.custom` beside it — the same surfaceContainerHighest/onSurfaceVariant checked/total chrome as the wear-sheet header (#357) and the checklist header, so every count in the app reads as one visual language. `_headerTab` gains a `trailing` slot inside the underlined region (underline spans label + pill).
- **Narrow drops the counter entirely** — the tab trio + counter was the documented FittedBox scale-down tripwire at phone widths; the count is one tap away inside the Bookings view. (Also retires the Spanish narrow-fit hedge's raison d'être; the 0.95 minScale stays only for the square-test-font overshoot.)
- `tripTabBookingsCounted` removed from both ARBs (dead key), `flutter gen-l10n` regenerated.

## Testing
- `flutter analyze` clean (3 pre-existing route_response infos only).
- Full `make flutter-test` suite green (945 tests): `trip_detail_filter_lenses_test` reworked `_openBookingsTab` helper (pins the pill count by StatusPill-scoped finder on every use), `trip_detail_narrow_header_test` asserts plain labels + counter absence on narrow, `trip_detail_bookings_test` asserts label + pill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)