### PR TITLE
fix(flutter): budget add-row amount hint + category menu overflow

### DIFF
--- a/src/packages/flutter-app/lib/widgets/budget_section.dart
+++ b/src/packages/flutter-app/lib/widgets/budget_section.dart
@@ -522,25 +522,32 @@ class _BudgetSectionState extends ConsumerState<BudgetSection> {
     return Row(
       crossAxisAlignment: CrossAxisAlignment.center,
       children: [
-        DropdownButton<String>(
-          value: _addCategory,
-          underline: const SizedBox.shrink(),
-          onChanged: widget.isOffline
-              ? null
-              : (v) => setState(() => _addCategory = v ?? 'general'),
-          // Closed state stays icon-only (the add row is width-tight on
-          // phones); the open menu spells out each category.
-          selectedItemBuilder: (context) => [
+        // Closed state stays icon-compact (the add row is width-tight on
+        // phones); the open menu spells out each category. A popup menu (not
+        // a DropdownButton) because a dropdown's menu is hard-constrained to
+        // the trigger's width — an icon-only trigger would clip every label.
+        PopupMenuButton<String>(
+          tooltip: context.l10n.budgetCategoryLabel,
+          enabled: !widget.isOffline,
+          position: PopupMenuPosition.under,
+          color: theme.colorScheme.surface,
+          elevation: 3,
+          shape: const RoundedRectangleBorder(borderRadius: AppRadius.mdAll),
+          icon: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(_categoryIcons[_addCategory],
+                  size: 18, color: theme.colorScheme.onSurfaceVariant),
+              Icon(Icons.arrow_drop_down,
+                  size: 18, color: theme.colorScheme.onSurfaceVariant),
+            ],
+          ),
+          onSelected: (v) => setState(() => _addCategory = v),
+          itemBuilder: (_) => [
             for (final cat in _categoryOrder)
-              Center(
-                child: Icon(_categoryIcons[cat],
-                    size: 18, color: theme.colorScheme.onSurfaceVariant),
-              ),
-          ],
-          items: [
-            for (final cat in _categoryOrder)
-              DropdownMenuItem(
+              CheckedPopupMenuItem<String>(
                 value: cat,
+                checked: cat == _addCategory,
                 child: Row(
                   mainAxisSize: MainAxisSize.min,
                   children: [
@@ -565,8 +572,13 @@ class _BudgetSectionState extends ConsumerState<BudgetSection> {
           ),
         ),
         const SizedBox(width: AppSpacing.sm),
+        // 136 leaves a 104px interior after the theme's filled-field content
+        // padding (16px per side) — fits "Amount"/"Importe" in Inter with
+        // text-scale headroom, and fits the 1em-per-glyph FlutterTest font
+        // ("Amount" = 99px incl. letter-spacing) the regression test
+        // measures with.
         SizedBox(
-          width: 88,
+          width: 136,
           child: TextField(
             controller: _amountController,
             textInputAction: TextInputAction.done,

--- a/src/packages/flutter-app/lib/widgets/budget_target_dialog.dart
+++ b/src/packages/flutter-app/lib/widgets/budget_target_dialog.dart
@@ -55,8 +55,12 @@ Future<bool> showBudgetTargetDialog(
           children: [
             Row(
               children: [
+                // 112 fits the code + dropdown arrow inside the theme's
+                // filled-field padding (16px per side) in the 1em-per-glyph
+                // FlutterTest font too ("USD" + arrow = ~104px); 96 overflowed
+                // under the themed test harness.
                 SizedBox(
-                  width: 96,
+                  width: 112,
                   child: DropdownButtonFormField<String>(
                     initialValue: currency,
                     decoration:

--- a/src/packages/flutter-app/test/budget_section_test.dart
+++ b/src/packages/flutter-app/test/budget_section_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -7,6 +8,7 @@ import 'package:travel_route_planner/models/expense.dart';
 import 'package:travel_route_planner/services/api_client.dart';
 import 'package:travel_route_planner/services/budget_api_service.dart';
 import 'package:travel_route_planner/providers/budget_provider.dart';
+import 'package:travel_route_planner/theme/app_theme.dart';
 import 'package:travel_route_planner/utils/money_format.dart';
 import 'package:travel_route_planner/widgets/budget_section.dart';
 
@@ -107,7 +109,10 @@ Future<_FakeBudgetApiService> _pump(
       overrides: [
         budgetApiServiceProvider.overrideWithValue(fake),
       ],
+      // The real app theme (filled + outline fields, Inter metrics) — an
+      // unthemed harness is exactly how the truncated-hint bug escaped.
       child: MaterialApp(
+      theme: AppTheme.light,
       localizationsDelegates: testLocalizationsDelegates,
         home: Scaffold(
           body: SingleChildScrollView(
@@ -267,5 +272,75 @@ void main() {
     final addButton =
         tester.widget<IconButton>(find.widgetWithIcon(IconButton, Icons.add));
     expect(addButton.onPressed, isNull);
+    final categoryButton = tester.widget<PopupMenuButton<String>>(find.ancestor(
+        of: find.byTooltip('Category'),
+        matching: find.byType(PopupMenuButton<String>)));
+    expect(categoryButton.enabled, isFalse);
+  });
+
+  testWidgets(
+      'amount hint renders un-truncated under the app theme at phone width',
+      (tester) async {
+    await tester.binding.setSurfaceSize(const Size(360, 690));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    await _pump(tester, [_exp('a', 'food', 'Lunch', 20)]);
+
+    // A too-narrow hint ellipsizes (never throws), so "no exception" proves
+    // nothing: the full string's intrinsic width must fit in the width the
+    // field gave the hint. (Compared against constraints, not painted size —
+    // painted width excludes trailing letter-spacing that intrinsic width
+    // includes.) English only on purpose — the 1em-per-glyph FlutterTest
+    // font inflates "Importe" past any realistic width, while Inter fits it
+    // easily at the shipped 136px.
+    final hint = find.text('Amount');
+    expect(hint, findsOneWidget);
+    final paragraph = tester.renderObject<RenderParagraph>(hint);
+    expect(
+      paragraph.getMaxIntrinsicWidth(double.infinity),
+      lessThanOrEqualTo(paragraph.constraints.maxWidth),
+      reason: 'the Amount hint is being ellipsized — widen the amount field',
+    );
+  });
+
+  testWidgets(
+      'category menu opens with every label visible, checks the current '
+      'category, and the selection flows into the add', (tester) async {
+    await tester.binding.setSurfaceSize(const Size(360, 690));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    // Empty list: category labels would otherwise collide with group headers.
+    final fake = await _pump(tester, []);
+
+    await tester.tap(find.byTooltip('Category'));
+    await tester.pumpAndSettle();
+
+    for (final label in [
+      'Flights', 'Lodging', 'Food', 'Activities', //
+      'Transport', 'Shopping', 'General',
+    ]) {
+      expect(find.text(label), findsOneWidget);
+    }
+    // Current selection is checked (language_menu_button convention).
+    expect(
+      tester
+          .widget<CheckedPopupMenuItem<String>>(find.widgetWithText(
+              CheckedPopupMenuItem<String>, 'General'))
+          .checked,
+      isTrue,
+    );
+
+    // Tap the item, not its Text — CheckedPopupMenuItem wraps its ListTile
+    // in an IgnorePointer (the item's own InkWell handles the tap), so the
+    // Text itself never hit-tests.
+    await tester
+        .tap(find.widgetWithText(CheckedPopupMenuItem<String>, 'Flights'));
+    await tester.pumpAndSettle();
+    // The trigger now shows the selected category's icon.
+    expect(find.byIcon(Icons.flight_outlined), findsOneWidget);
+
+    await tester.enterText(find.byType(TextField).first, 'JFK→CDG');
+    await tester.enterText(find.byType(TextField).last, '400');
+    await tester.tap(find.byTooltip('Add expense'));
+    await tester.pumpAndSettle();
+    expect(fake.expenses.last.category, 'flights');
   });
 }


### PR DESCRIPTION
## Summary
- **"Amount" hint truncated to "Amo…" at every window width**: the add-row amount field was a hard `SizedBox(width: 88)`, but the app theme's filled fields carry 16px-per-side content padding, leaving ~56px for a hint that needs ~66px in Inter. Widened to 136px (fits "Amount"/"Importe" with text-scale headroom, plus the wider FlutterTest font the regression test measures with).
- **Category menu labels spilled off the menu surface**: the picker was a `DropdownButton` kept icon-only when closed via `selectedItemBuilder` — Flutter hard-constrains a dropdown's popup to the *trigger's* width (~44px) and nothing clips, so the item labels painted onto the page behind. Replaced with a `PopupMenuButton` (the `language_menu_button.dart` pattern): compact icon + arrow trigger, self-sizing menu, `CheckedPopupMenuItem` on the current category, and a proper "Category" tooltip (the dropdown had no a11y label).
- **Test harness now pumps `AppTheme.light`**: the unthemed harness (underline fields, zero horizontal padding) is exactly how the 88px box passed before. Theming it also surfaced the same latent class in the budget target dialog's 96px currency box — widened to 112 (test-font-only overflow, same root cause).
- Two regression tests: the amount hint's intrinsic width must fit its layout constraints (ellipsis-proof, not pixel-brittle), and the category menu must show all 7 labels, check the current item, and flow the selection into the added expense.

## Testing
- `flutter analyze` — clean (3 pre-existing infos in `route_response.dart`, untouched)
- `flutter test test/budget_section_test.dart` — 12/12
- `flutter test` — full suite 941/941

## Note for PR #350 (`budget-v2-autopopulate`)
That branch's `budget_section.dart` moves the category constants to `budget_categories.dart` (`kExpenseCategories` / `kExpenseCategoryIcons` / `expenseCategoryLabel`) but its `_buildAddRow` is otherwise identical, so the rebase conflict is mechanical: take this PR's `_buildAddRow` wholesale, then apply those three renames (3 occurrences each: trigger icon, itemBuilder loop, item label).

🤖 Generated with [Claude Code](https://claude.com/claude-code)