### PR TITLE
polish(flutter): open up the home page vertical rhythm

### DIFF
--- a/src/packages/flutter-app/lib/screens/home_screen.dart
+++ b/src/packages/flutter-app/lib/screens/home_screen.dart
@@ -171,11 +171,11 @@ class HomeScreen extends ConsumerWidget {
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.stretch,
               children: [
-                const SizedBox(height: AppSpacing.sm),
+                const SizedBox(height: AppSpacing.lg),
 
                 _GreetingHeader(displayName: displayName),
 
-                const SizedBox(height: AppSpacing.lg),
+                const SizedBox(height: AppSpacing.xl),
 
                 // AI Travel Agent entry: the full photo hero sells the
                 // product to a brand-new account; returning users get a slim
@@ -184,7 +184,7 @@ class HomeScreen extends ConsumerWidget {
                   _PlanStrip(onStart: startPlanning),
                   // The strip row is width-starved on phones, so the near-me
                   // starter sits on its own line beneath it.
-                  const SizedBox(height: AppSpacing.sm),
+                  const SizedBox(height: AppSpacing.md),
                   Align(
                     alignment: Alignment.centerLeft,
                     child: NearMeChip(
@@ -195,7 +195,7 @@ class HomeScreen extends ConsumerWidget {
                 ] else
                   _AgentHeroCard(onStart: startPlanning),
 
-                SizedBox(height: returning ? AppSpacing.lg : AppSpacing.xl),
+                const SizedBox(height: AppSpacing.xl),
 
                 // The trip happening today (specs/happening-now).
                 if (liveTrip != null) ...[
@@ -205,7 +205,7 @@ class HomeScreen extends ConsumerWidget {
                     // item highlights and back lands on the trips list.
                     onTap: () => openTripOnTripsTab(ref, liveTrip.id),
                   ),
-                  const SizedBox(height: AppSpacing.lg),
+                  const SizedBox(height: AppSpacing.xl),
                 ],
                 // One "Continue where you left off" section: the most
                 // recently viewed trip (hidden when it *is* the live trip,

--- a/src/packages/flutter-app/lib/widgets/continue_chats_section.dart
+++ b/src/packages/flutter-app/lib/widgets/continue_chats_section.dart
@@ -39,13 +39,13 @@ class ContinueChatsSection extends ConsumerWidget {
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
         SectionHeader(title: context.l10n.continueChatsTitle),
-        const SizedBox(height: AppSpacing.sm),
+        const SizedBox(height: AppSpacing.md),
         if (leading != null) ...[
           leading!,
           const SizedBox(height: AppSpacing.sm),
         ],
         for (final c in resumable) ContinueChatCard(chat: c),
-        const SizedBox(height: AppSpacing.lg),
+        const SizedBox(height: AppSpacing.xl),
       ],
     );
   }


### PR DESCRIPTION
## Summary
- Friction-log item: the returning-user home top half (greeting → plan strip → near-me chip → Continue section) sat on 8/16px gaps and read as one cluster.
- Step the gaps up one `AppSpacing` token: section seams `lg`→`xl` (16→24), app-bar→greeting `sm`→`lg` (8→16), plan-strip→chip and Continue-header→card `sm`→`md` (8→12).
- The Continue-header gap now matches the Local-guides header gap (`md`), fixing a pre-existing inconsistency; the `returning ? lg : xl` ternary collapses to a single `const xl` (non-returning hero state unchanged at 24).

## Testing
- `flutter analyze` — same 3 pre-existing infos as main (`route_response.dart`); CI runs `--no-fatal-infos`.
- `flutter test` — all 939 tests pass.
- Manual: lane dev stack + headless Chrome, signed-in returning user with a seeded 3-stop trip — verified the new rhythm on the exact screenshot state (greeting / strip / chip / Continue map card), no overflow; signed-out hero state unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)