### PR TITLE
chore(api): bump Go toolchain to 1.26.6

### DIFF
--- a/src/packages/api/go.mod
+++ b/src/packages/api/go.mod
@@ -2,7 +2,7 @@ module travel-route-planner
 
 go 1.26
 
-toolchain go1.26.5
+toolchain go1.26.6
 
 require (
 	github.com/anthropics/anthropic-sdk-go v1.45.0


### PR DESCRIPTION
## Summary
- Bump `go.mod` `toolchain` from go1.26.5 to go1.26.6. govulncheck currently fails CI on every branch: five Go standard-library vulnerabilities (GO-2026-6088/6089/6090/6091/6218) are present in 1.26.5 and fixed in 1.26.6.
- No other pin needs to move: the API image builds `FROM golang:1.26-alpine` (floating patch tag) and CI's setup-go reads `go-version-file: src/packages/api/go.mod`.

## Testing
- `go vet ./...` clean under go1.26.6
- `govulncheck ./...` locally: "No vulnerabilities found" (0 called, the 14 module-level findings are uncalled)

🤖 Generated with [Claude Code](https://claude.com/claude-code)