### PR TITLE
feat(flutter): appearance + language as dropdowns in one settings section

### DIFF
--- a/src/packages/flutter-app/lib/l10n/app_en.arb
+++ b/src/packages/flutter-app/lib/l10n/app_en.arb
@@ -6,7 +6,7 @@
   },
   "languageSectionTitle": "Language",
   "@languageSectionTitle": {
-    "description": "Header of the language group in account settings."
+    "description": "Label of the language dropdown in account settings."
   },
   "languageEnglish": "English",
   "@languageEnglish": {
@@ -24,9 +24,13 @@
   "@languageMenuTooltip": {
     "description": "Tooltip of the app-bar globe button that opens the language menu."
   },
+  "appearanceLanguageSectionTitle": "Appearance & language",
+  "@appearanceLanguageSectionTitle": {
+    "description": "Header of the merged appearance + language group in account settings."
+  },
   "appearanceSectionTitle": "Appearance",
   "@appearanceSectionTitle": {
-    "description": "Header of the light/dark appearance group in account settings."
+    "description": "Label of the light/dark appearance dropdown in account settings."
   },
   "appearanceSystem": "Use device setting",
   "@appearanceSystem": {

--- a/src/packages/flutter-app/lib/l10n/app_es.arb
+++ b/src/packages/flutter-app/lib/l10n/app_es.arb
@@ -6,6 +6,7 @@
   "languageSpanish": "Español",
   "languageChangeNote": "Los viajes y las notas que ya guardaste se mantienen en el idioma en que se escribieron.",
   "languageMenuTooltip": "Cambiar idioma",
+  "appearanceLanguageSectionTitle": "Apariencia e idioma",
   "appearanceSectionTitle": "Apariencia",
   "appearanceSystem": "Usar la configuración del dispositivo",
   "appearanceLight": "Claro",

--- a/src/packages/flutter-app/lib/l10n/app_localizations.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations.dart
@@ -104,7 +104,7 @@ abstract class AppLocalizations {
   /// **'Golden Tempo Travel'**
   String get appTitle;
 
-  /// Header of the language group in account settings.
+  /// Label of the language dropdown in account settings.
   ///
   /// In en, this message translates to:
   /// **'Language'**
@@ -134,7 +134,13 @@ abstract class AppLocalizations {
   /// **'Change language'**
   String get languageMenuTooltip;
 
-  /// Header of the light/dark appearance group in account settings.
+  /// Header of the merged appearance + language group in account settings.
+  ///
+  /// In en, this message translates to:
+  /// **'Appearance & language'**
+  String get appearanceLanguageSectionTitle;
+
+  /// Label of the light/dark appearance dropdown in account settings.
   ///
   /// In en, this message translates to:
   /// **'Appearance'**

--- a/src/packages/flutter-app/lib/l10n/app_localizations_en.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations_en.dart
@@ -28,6 +28,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get languageMenuTooltip => 'Change language';
 
   @override
+  String get appearanceLanguageSectionTitle => 'Appearance & language';
+
+  @override
   String get appearanceSectionTitle => 'Appearance';
 
   @override

--- a/src/packages/flutter-app/lib/l10n/app_localizations_es.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations_es.dart
@@ -28,6 +28,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get languageMenuTooltip => 'Cambiar idioma';
 
   @override
+  String get appearanceLanguageSectionTitle => 'Apariencia e idioma';
+
+  @override
   String get appearanceSectionTitle => 'Apariencia';
 
   @override

--- a/src/packages/flutter-app/lib/screens/account_settings_screen.dart
+++ b/src/packages/flutter-app/lib/screens/account_settings_screen.dart
@@ -276,12 +276,13 @@ class _AccountSettingsScreenState extends ConsumerState<AccountSettingsScreen> {
                       const SizedBox(height: AppSpacing.sm),
                       const _ConnectedAppsList(),
                       const SizedBox(height: AppSpacing.xl),
-                      SectionHeader(title: l10n.appearanceSectionTitle),
-                      const SizedBox(height: AppSpacing.sm),
+                      // Both are device-presentation choices, and each is a
+                      // one-line dropdown, so they share a section rather
+                      // than costing two headers.
+                      SectionHeader(title: l10n.appearanceLanguageSectionTitle),
+                      const SizedBox(height: AppSpacing.md),
                       const _AppearancePicker(),
-                      const SizedBox(height: AppSpacing.xl),
-                      SectionHeader(title: l10n.languageSectionTitle),
-                      const SizedBox(height: AppSpacing.sm),
+                      const SizedBox(height: AppSpacing.md),
                       const _LanguagePicker(),
                       const SizedBox(height: AppSpacing.xl),
                       SectionHeader(title: l10n.settingsEmailPrefsSection),
@@ -435,31 +436,41 @@ class _AppearancePicker extends ConsumerWidget {
     final l10n = context.l10n;
     final mode = ref.watch(themeModeProvider.select((s) => s.mode));
 
-    return RadioGroup<ThemeMode>(
-      groupValue: mode,
+    // One source for both `items` and `selectedItemBuilder`: the two lists
+    // must stay index-parallel, and deriving them can't drift.
+    final options = <(ThemeMode, String)>[
+      (ThemeMode.system, l10n.appearanceSystem),
+      (ThemeMode.light, l10n.appearanceLight),
+      (ThemeMode.dark, l10n.appearanceDark),
+    ];
+
+    return DropdownButtonFormField<ThemeMode>(
+      // Not just an initial value: the field re-syncs whenever this changes,
+      // so it still tracks a mode set from somewhere else.
+      initialValue: mode,
+      isExpanded: true,
+      // Null lets a menu row grow to fit a wrapped label instead of clipping
+      // it at the fixed 48px (DropdownMenuItem keeps that as a minimum, so
+      // the touch target survives) — headroom for the long translations,
+      // e.g. Spanish's "Usar la configuración del dispositivo".
+      itemHeight: null,
+      decoration: InputDecoration(labelText: l10n.appearanceSectionTitle),
+      // The closed field ellipsizes to one line so a long label can never
+      // grow the row; the open menu still spells each option out in full.
+      selectedItemBuilder: (context) => [
+        for (final (_, label) in options)
+          Align(
+            alignment: AlignmentDirectional.centerStart,
+            child: Text(label, maxLines: 1, overflow: TextOverflow.ellipsis),
+          ),
+      ],
+      items: [
+        for (final (value, label) in options)
+          DropdownMenuItem(value: value, child: Text(label)),
+      ],
       onChanged: (v) {
         if (v != null) ref.read(themeModeProvider.notifier).setMode(v);
       },
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: [
-          RadioListTile<ThemeMode>(
-            contentPadding: EdgeInsets.zero,
-            title: Text(l10n.appearanceSystem),
-            value: ThemeMode.system,
-          ),
-          RadioListTile<ThemeMode>(
-            contentPadding: EdgeInsets.zero,
-            title: Text(l10n.appearanceLight),
-            value: ThemeMode.light,
-          ),
-          RadioListTile<ThemeMode>(
-            contentPadding: EdgeInsets.zero,
-            title: Text(l10n.appearanceDark),
-            value: ThemeMode.dark,
-          ),
-        ],
-      ),
     );
   }
 }
@@ -485,22 +496,32 @@ class _LanguagePicker extends ConsumerWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
-        RadioGroup<String>(
-          groupValue: state.language,
+        DropdownButtonFormField<String>(
+          initialValue: state.language,
+          isExpanded: true,
+          itemHeight: null,
+          decoration: InputDecoration(labelText: l10n.languageSectionTitle),
+          selectedItemBuilder: (context) => [
+            for (final locale in kSupportedLocales)
+              Align(
+                alignment: AlignmentDirectional.centerStart,
+                child: Text(
+                  languageDisplayName(l10n, locale.languageCode),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+          ],
+          items: [
+            for (final locale in kSupportedLocales)
+              DropdownMenuItem(
+                value: locale.languageCode,
+                child: Text(languageDisplayName(l10n, locale.languageCode)),
+              ),
+          ],
           onChanged: (v) {
             if (v != null) ref.read(localeProvider.notifier).setLanguage(v);
           },
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
-              for (final locale in kSupportedLocales)
-                RadioListTile<String>(
-                  contentPadding: EdgeInsets.zero,
-                  title: Text(languageDisplayName(l10n, locale.languageCode)),
-                  value: locale.languageCode,
-                ),
-            ],
-          ),
         ),
         const SizedBox(height: AppSpacing.xs),
         // Saved trips and AI notes keep the language they were written in;

--- a/src/packages/flutter-app/test/appearance_picker_test.dart
+++ b/src/packages/flutter-app/test/appearance_picker_test.dart
@@ -1,134 +1,39 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
-import 'package:travel_route_planner/models/user.dart';
-import 'package:travel_route_planner/providers/auth_provider.dart';
-import 'package:travel_route_planner/providers/theme_mode_provider.dart';
 import 'package:travel_route_planner/screens/account_settings_screen.dart';
-import 'package:travel_route_planner/services/account_api_service.dart';
-import 'package:travel_route_planner/services/api_client.dart';
-import 'package:travel_route_planner/theme/app_theme.dart';
 
-import 'support/l10n_test_app.dart';
+import 'support/account_settings_harness.dart';
 
 /// End-to-end of the user-visible half of specs/dark-mode: the Appearance
-/// section in account settings restyles the whole app immediately, persists
+/// dropdown in account settings restyles the whole app immediately, persists
 /// the choice, and "Use device setting" follows the platform brightness live.
 ///
-/// The MaterialApp here is wired exactly like main.dart (theme / darkTheme /
-/// themeMode watched from the provider), so a tap on the real RadioListTile
-/// proves the full loop, not just the provider. Fakes follow
-/// settings_polish_test.dart.
+/// The MaterialApp comes from the shared account-settings harness, wired
+/// exactly like main.dart, so picking from the real dropdown proves the full
+/// loop, not just the provider.
 
-class _FakeAccountApi implements AccountApiService {
-  @override
-  ApiClient get apiClient => throw UnsupportedError('unused in tests');
+// Anchored to the screen rather than to a label: the dropdown's closed state
+// keeps every option's text in an IndexedStack, so label finders are ambiguous.
+Brightness _appBrightness(WidgetTester tester) =>
+    Theme.of(tester.element(find.byType(AccountSettingsScreen))).brightness;
 
-  // The settings screen loads the Connected-apps section on build; serve
-  // an empty list so pumping settles without network.
-  @override
-  Future<List<ConnectedApp>> listConnectedApps() async => const [];
-
-  @override
-  Future<void> revokeConnectedApp(String id) async {}
-
-  @override
-  Future<UserModel> updateDisplayName(String displayName) async => _user();
-
-  @override
-  Future<UserModel> updateLocale(String locale) async => _user();
-
-  @override
-  Future<({UserModel user, String token})> changePassword(
-          String current, String newPassword) async =>
-      (user: _user(), token: 'token');
-
-  @override
-  Future<UserModel> updateEmailPreferences({
-    bool? remindersEnabled,
-    bool? nudgesEnabled,
-  }) async =>
-      _user();
-
-  @override
-  Future<void> logoutAll() async {}
-
-  @override
-  Future<void> deleteAccount(String password) async {}
-}
-
-class _FakeAuthNotifier extends StateNotifier<AuthState>
-    implements AuthNotifier {
-  _FakeAuthNotifier(UserModel? user)
-      : super(AuthState(user: user, initialized: true));
-
-  @override
-  void clearError() => state = state.copyWith(clearError: true);
-
-  @override
-  Future<bool> login(String email, String password) async => false;
-
-  @override
-  Future<bool> register(String email, String password,
-          {String? displayName}) async =>
-      false;
-
-  @override
-  Future<void> completeOnboarding() async {}
-
-  @override
-  Future<void> logout() async {}
-
-  @override
-  Future<void> signOutLocally() async {}
-
-  @override
-  void setUser(UserModel user) {
-    state = state.copyWith(user: user);
-  }
-
-  @override
-  Future<void> adoptSession(String token, UserModel user) async {}
-}
-
-UserModel _user() => UserModel(
-      id: 'user-1',
-      email: 'user@example.com',
-      displayName: 'Test User',
-      isAdmin: false,
-      createdAt: DateTime(2026, 1, 1),
-    );
-
-Future<void> _pumpSettings(WidgetTester tester) async {
-  // Tall surface so the Appearance section is on-screen without scrolling
-  // mechanics (same trick as settings_polish_test.dart).
-  await tester.binding.setSurfaceSize(const Size(800, 2000));
-  addTearDown(() => tester.binding.setSurfaceSize(null));
-
-  await tester.pumpWidget(ProviderScope(
-    overrides: [
-      accountApiServiceProvider.overrideWithValue(_FakeAccountApi()),
-      authProvider.overrideWith((ref) => _FakeAuthNotifier(_user())),
-    ],
-    child: Consumer(builder: (context, ref, _) {
-      final mode = ref.watch(themeModeProvider.select((s) => s.mode));
-      return MaterialApp(
-        localizationsDelegates: testLocalizationsDelegates,
-        supportedLocales: const [Locale('en'), Locale('es')],
-        theme: AppTheme.light,
-        darkTheme: AppTheme.dark,
-        themeMode: mode,
-        home: const AccountSettingsScreen(),
-      );
-    }),
+/// Opens the appearance dropdown and picks [label] from the open menu.
+/// `DropdownMenuItem` only exists in the menu — the closed field renders the
+/// `selectedItemBuilder` widgets — so this finder can't hit the button itself.
+Future<void> _pickAppearance(WidgetTester tester, String label) async {
+  final field = find.byType(DropdownButtonFormField<ThemeMode>);
+  await tester.ensureVisible(field);
+  await tester.pumpAndSettle();
+  await tester.tap(field);
+  await tester.pumpAndSettle();
+  await tester.tap(find.descendant(
+    of: find.widgetWithText(DropdownMenuItem<ThemeMode>, label),
+    matching: find.text(label),
   ));
   await tester.pumpAndSettle();
 }
-
-Brightness _appBrightness(WidgetTester tester) =>
-    Theme.of(tester.element(find.text('Appearance'))).brightness;
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -137,12 +42,10 @@ void main() {
 
   testWidgets('tapping Dark restyles the app immediately and persists it',
       (tester) async {
-    await _pumpSettings(tester);
+    await pumpAccountSettings(tester, user: testUser());
     expect(_appBrightness(tester), Brightness.light);
 
-    await tester.ensureVisible(find.text('Dark'));
-    await tester.tap(find.text('Dark'));
-    await tester.pumpAndSettle();
+    await _pickAppearance(tester, 'Dark');
 
     expect(_appBrightness(tester), Brightness.dark);
     final prefs = await SharedPreferences.getInstance();
@@ -151,7 +54,7 @@ void main() {
 
   testWidgets('a stored Dark choice comes up dark on launch', (tester) async {
     SharedPreferences.setMockInitialValues({'theme_mode': 'dark'});
-    await _pumpSettings(tester);
+    await pumpAccountSettings(tester, user: testUser());
     // The platform is light in tests — dark can only come from the store.
     expect(_appBrightness(tester), Brightness.dark);
   });
@@ -162,7 +65,7 @@ void main() {
     addTearDown(tester.platformDispatcher.clearPlatformBrightnessTestValue);
 
     // Nothing stored: the default (system) mode tracks the OS.
-    await _pumpSettings(tester);
+    await pumpAccountSettings(tester, user: testUser());
     expect(_appBrightness(tester), Brightness.dark);
 
     // An OS appearance flip mid-session restyles without any tap.
@@ -176,15 +79,40 @@ void main() {
     tester.platformDispatcher.platformBrightnessTestValue = Brightness.dark;
     addTearDown(tester.platformDispatcher.clearPlatformBrightnessTestValue);
 
-    await _pumpSettings(tester);
+    await pumpAccountSettings(tester, user: testUser());
     expect(_appBrightness(tester), Brightness.dark);
 
-    await tester.ensureVisible(find.text('Light'));
-    await tester.tap(find.text('Light'));
-    await tester.pumpAndSettle();
+    await _pickAppearance(tester, 'Light');
 
     expect(_appBrightness(tester), Brightness.light);
     final prefs = await SharedPreferences.getInstance();
     expect(prefs.getString('theme_mode'), 'light');
+  });
+
+  testWidgets('the appearance dropdown fits a 360px phone in Spanish',
+      (tester) async {
+    // "Usar la configuración del dispositivo" is the longest label either
+    // language ships and 360px is the narrow floor, so this is the case the
+    // closed field's ellipsis and the menu's variable item height exist for.
+    await pumpAccountSettings(
+      tester,
+      user: testUser(),
+      size: const Size(360, 2000),
+      locale: const Locale('es'),
+    );
+
+    final field = find.byType(DropdownButtonFormField<ThemeMode>);
+    await tester.ensureVisible(field);
+    await tester.pumpAndSettle();
+    expect(tester.takeException(), isNull);
+
+    await tester.tap(field);
+    await tester.pumpAndSettle();
+    expect(
+      find.widgetWithText(
+          DropdownMenuItem<ThemeMode>, 'Usar la configuración del dispositivo'),
+      findsOneWidget,
+    );
+    expect(tester.takeException(), isNull);
   });
 }

--- a/src/packages/flutter-app/test/language_picker_test.dart
+++ b/src/packages/flutter-app/test/language_picker_test.dart
@@ -8,6 +8,7 @@ import 'package:travel_route_planner/providers/auth_provider.dart';
 import 'package:travel_route_planner/providers/locale_provider.dart';
 import 'package:travel_route_planner/services/auth_storage.dart';
 
+import 'support/account_settings_harness.dart';
 import 'support/l10n_test_app.dart';
 
 /// End-to-end of the user-visible half of specs/i18n-spanish: picking a
@@ -69,6 +70,33 @@ void main() {
 
     expect(find.text('Idioma'), findsOneWidget);
     expect(find.text('Language'), findsNothing);
+  });
+
+  testWidgets('picking Español from the settings dropdown redraws the app',
+      (tester) async {
+    // The picker itself, driven the way a user drives it. Signed out on
+    // purpose: that is what keeps setLanguage's account sync off the network.
+    await pumpAccountSettings(tester);
+
+    final field = find.byType(DropdownButtonFormField<String>);
+    await tester.ensureVisible(field);
+    await tester.pumpAndSettle();
+    expect(find.text('Appearance & language'), findsOneWidget);
+
+    await tester.tap(field);
+    await tester.pumpAndSettle();
+    // `DropdownMenuItem` exists only in the open menu — the closed field
+    // renders the selectedItemBuilder widgets instead.
+    await tester.tap(find.descendant(
+      of: find.widgetWithText(DropdownMenuItem<String>, 'Español'),
+      matching: find.text('Español'),
+    ));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Apariencia e idioma'), findsOneWidget);
+    expect(find.text('Appearance & language'), findsNothing);
+    final prefs = await SharedPreferences.getInstance();
+    expect(prefs.getString('locale_override'), 'es');
   });
 
   test('an explicit choice is persisted and restored on next launch', () async {

--- a/src/packages/flutter-app/test/support/account_settings_harness.dart
+++ b/src/packages/flutter-app/test/support/account_settings_harness.dart
@@ -1,0 +1,139 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:travel_route_planner/l10n/l10n.dart';
+import 'package:travel_route_planner/models/user.dart';
+import 'package:travel_route_planner/providers/auth_provider.dart';
+import 'package:travel_route_planner/providers/locale_provider.dart';
+import 'package:travel_route_planner/providers/theme_mode_provider.dart';
+import 'package:travel_route_planner/screens/account_settings_screen.dart';
+import 'package:travel_route_planner/services/account_api_service.dart';
+import 'package:travel_route_planner/services/api_client.dart';
+import 'package:travel_route_planner/theme/app_theme.dart';
+
+import 'l10n_test_app.dart';
+
+/// Shared harness for widget tests that drive the real [AccountSettingsScreen]
+/// — the Appearance and Language dropdowns both live there, and both need the
+/// same account fakes to pump without network. Fakes follow
+/// settings_polish_test.dart.
+
+class FakeAccountApi implements AccountApiService {
+  @override
+  ApiClient get apiClient => throw UnsupportedError('unused in tests');
+
+  // The settings screen loads the Connected-apps section on build; serve
+  // an empty list so pumping settles without network.
+  @override
+  Future<List<ConnectedApp>> listConnectedApps() async => const [];
+
+  @override
+  Future<void> revokeConnectedApp(String id) async {}
+
+  @override
+  Future<UserModel> updateDisplayName(String displayName) async => testUser();
+
+  @override
+  Future<UserModel> updateLocale(String locale) async => testUser();
+
+  @override
+  Future<({UserModel user, String token})> changePassword(
+          String current, String newPassword) async =>
+      (user: testUser(), token: 'token');
+
+  @override
+  Future<UserModel> updateEmailPreferences({
+    bool? remindersEnabled,
+    bool? nudgesEnabled,
+  }) async =>
+      testUser();
+
+  @override
+  Future<void> logoutAll() async {}
+
+  @override
+  Future<void> deleteAccount(String password) async {}
+}
+
+class FakeAuthNotifier extends StateNotifier<AuthState> implements AuthNotifier {
+  FakeAuthNotifier(UserModel? user)
+      : super(AuthState(user: user, initialized: true));
+
+  @override
+  void clearError() => state = state.copyWith(clearError: true);
+
+  @override
+  Future<bool> login(String email, String password) async => false;
+
+  @override
+  Future<bool> register(String email, String password,
+          {String? displayName}) async =>
+      false;
+
+  @override
+  Future<void> completeOnboarding() async {}
+
+  @override
+  Future<void> logout() async {}
+
+  @override
+  Future<void> signOutLocally() async {}
+
+  @override
+  void setUser(UserModel user) {
+    state = state.copyWith(user: user);
+  }
+
+  @override
+  Future<void> adoptSession(String token, UserModel user) async {}
+}
+
+UserModel testUser() => UserModel(
+      id: 'user-1',
+      email: 'user@example.com',
+      displayName: 'Test User',
+      isAdmin: false,
+      createdAt: DateTime(2026, 1, 1),
+    );
+
+/// Pumps account settings inside a MaterialApp wired exactly like main.dart
+/// (theme / darkTheme / themeMode / locale from the providers), so a pick from
+/// a real dropdown proves the whole loop rather than just the provider.
+///
+/// [user] `null` signs the session out, which is what keeps
+/// `LocaleNotifier.syncToAccount()` from reaching for the network; pass
+/// [locale] to force a language instead of following `localeProvider`.
+Future<void> pumpAccountSettings(
+  WidgetTester tester, {
+  // Tall surface so the section under test is on-screen without scrolling
+  // mechanics (same trick as settings_polish_test.dart).
+  Size size = const Size(800, 2000),
+  Locale? locale,
+  UserModel? user,
+}) async {
+  await tester.binding.setSurfaceSize(size);
+  addTearDown(() => tester.binding.setSurfaceSize(null));
+
+  await tester.pumpWidget(ProviderScope(
+    overrides: [
+      accountApiServiceProvider.overrideWithValue(FakeAccountApi()),
+      authProvider.overrideWith((ref) => FakeAuthNotifier(user)),
+    ],
+    child: Consumer(builder: (context, ref, _) {
+      final mode = ref.watch(themeModeProvider.select((s) => s.mode));
+      final appLocale =
+          locale ?? ref.watch(localeProvider.select((s) => s.materialLocale));
+      return MaterialApp(
+        localizationsDelegates: testLocalizationsDelegates,
+        supportedLocales: kSupportedLocales,
+        locale: appLocale,
+        theme: AppTheme.light,
+        darkTheme: AppTheme.dark,
+        themeMode: mode,
+        home: const AccountSettingsScreen(),
+      );
+    }),
+  ));
+  await tester.pumpAndSettle();
+}


### PR DESCRIPTION
## Summary

- Account settings' **Appearance** (3 radios) and **Language** (2 radios) sections become two single-line `DropdownButtonFormField`s under one **"Appearance & language"** header — nine rows down to four, so Email preferences / Legal / Danger zone no longer start below the fold.
- Each dropdown carries its own field label, reusing the retained `appearanceSectionTitle` / `languageSectionTitle` keys; one new key `appearanceLanguageSectionTitle` ("Appearance & language" / "Apariencia e idioma") for the merged header.
- No behavior change: same providers and setters, appearance still device-local, language still persists **and** syncs to the account (`users.locale`).
- Long-translation safety — the closed field ellipsizes via `selectedItemBuilder`, the menu uses `itemHeight: null` so a wrapped label grows its row instead of clipping (`DropdownMenuItem` keeps the 48px touch target).
- Test fakes for the settings screen move to `test/support/account_settings_harness.dart` so the language test can drive the real screen too, **signed out** — which is what keeps `setLanguage`'s account sync off the network in a widget test.

## Testing

- `flutter analyze` — clean (only the 3 pre-existing infos in `lib/models/route_response.dart`).
- `flutter test` — 968 tests green. Reworked `appearance_picker_test.dart` (screen-anchored brightness finder, open-then-pick taps) plus a new 360px-wide Spanish overflow test; new settings-screen language-dropdown test in `language_picker_test.dart`.
- Manual, lane stack at `localhost:3014`, signed in via SSO handoff:
  - Section renders as designed; picking **Light** restyles the app instantly.
  - Picking **Español** redraws the whole app ("Apariencia e idioma" / "Apariencia" / "Idioma", note translated) and `users.locale` is `es` in Postgres.
  - Reload keeps both choices.
  - At **360×900 in Spanish**: closed field shows `Usar la configuración del dispos…` on one row with no overflow; the open menu spells the label out in full.

🤖 Generated with [Claude Code](https://claude.com/claude-code)