### PR TITLE
feat(flutter): ops alerts name what is wrong and open the Health tab

### DIFF
--- a/src/packages/flutter-app/lib/l10n/app_en.arb
+++ b/src/packages/flutter-app/lib/l10n/app_en.arb
@@ -1241,6 +1241,8 @@
     }
   },
   "healthDegradedTitle": "System degraded",
+  "healthRecoveredTitle": "System recovered",
+  "notifOpsOpenHealth": "View system health",
   "reviewSectionTitle": "Trip health",
   "reviewHeaderAttention": "{count, plural, one{Mostly ready — 1 to fix} other{Mostly ready — {count} to fix}}",
   "@reviewHeaderAttention": {

--- a/src/packages/flutter-app/lib/l10n/app_es.arb
+++ b/src/packages/flutter-app/lib/l10n/app_es.arb
@@ -551,6 +551,8 @@
   "healthBuildSection": "Compilación",
   "healthRelease": "versión {release}",
   "healthDegradedTitle": "Sistema degradado",
+  "healthRecoveredTitle": "Sistema recuperado",
+  "notifOpsOpenHealth": "Ver el estado del sistema",
   "reviewSectionTitle": "Estado del viaje",
   "reviewHeaderAttention": "{count, plural, one{Casi listo — 1 por resolver} other{Casi listo — {count} por resolver}}",
   "reviewHeaderSuggestionsOnly": "{count, plural, one{En buen estado — 1 sugerencia} other{En buen estado — {count} sugerencias}}",

--- a/src/packages/flutter-app/lib/l10n/app_localizations.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations.dart
@@ -3404,6 +3404,18 @@ abstract class AppLocalizations {
   /// **'System degraded'**
   String get healthDegradedTitle;
 
+  /// No description provided for @healthRecoveredTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'System recovered'**
+  String get healthRecoveredTitle;
+
+  /// No description provided for @notifOpsOpenHealth.
+  ///
+  /// In en, this message translates to:
+  /// **'View system health'**
+  String get notifOpsOpenHealth;
+
   /// No description provided for @reviewSectionTitle.
   ///
   /// In en, this message translates to:

--- a/src/packages/flutter-app/lib/l10n/app_localizations_en.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations_en.dart
@@ -1903,6 +1903,12 @@ class AppLocalizationsEn extends AppLocalizations {
   String get healthDegradedTitle => 'System degraded';
 
   @override
+  String get healthRecoveredTitle => 'System recovered';
+
+  @override
+  String get notifOpsOpenHealth => 'View system health';
+
+  @override
   String get reviewSectionTitle => 'Trip health';
 
   @override

--- a/src/packages/flutter-app/lib/l10n/app_localizations_es.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations_es.dart
@@ -1917,6 +1917,12 @@ class AppLocalizationsEs extends AppLocalizations {
   String get healthDegradedTitle => 'Sistema degradado';
 
   @override
+  String get healthRecoveredTitle => 'Sistema recuperado';
+
+  @override
+  String get notifOpsOpenHealth => 'Ver el estado del sistema';
+
+  @override
   String get reviewSectionTitle => 'Estado del viaje';
 
   @override

--- a/src/packages/flutter-app/lib/screens/admin_metrics_screen.dart
+++ b/src/packages/flutter-app/lib/screens/admin_metrics_screen.dart
@@ -19,7 +19,16 @@ import '../widgets/status_pill.dart';
 ///   Activity — the latest analytics events, newest first, load-more.
 ///   Users    — per-user activity aggregates, most recently active first.
 class AdminMetricsScreen extends ConsumerStatefulWidget {
-  const AdminMetricsScreen({super.key});
+  /// Index of the Health tab in the tab list below. Named so callers in other
+  /// files (the ops rows in the notification center) never carry a bare
+  /// literal — the tab order stays defined in exactly one place.
+  static const int healthTabIndex = 4;
+
+  /// Which tab to open on. Transient view state, deliberately NOT part of the
+  /// URL: `/admin/metrics` stays one location, so a refresh lands on Overview.
+  final int initialTabIndex;
+
+  const AdminMetricsScreen({super.key, this.initialTabIndex = 0});
 
   @override
   ConsumerState<AdminMetricsScreen> createState() => _AdminMetricsScreenState();
@@ -33,6 +42,7 @@ class _AdminMetricsScreenState extends ConsumerState<AdminMetricsScreen> {
   Widget build(BuildContext context) {
     return DefaultTabController(
       length: 5,
+      initialIndex: widget.initialTabIndex,
       child: Scaffold(
         appBar: AppBar(
           title: const Text('Metrics'),

--- a/src/packages/flutter-app/lib/screens/notification_center_screen.dart
+++ b/src/packages/flutter-app/lib/screens/notification_center_screen.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../l10n/l10n.dart';
 import '../models/notification.dart';
+import '../navigation/app_nav.dart';
+import '../navigation/app_routes.dart';
 import '../providers/notifications_provider.dart';
 import '../theme/spacing.dart';
 import '../utils/errors.dart';
@@ -10,6 +12,7 @@ import '../widgets/empty_state.dart';
 import '../widgets/gradient_app_bar.dart';
 import '../widgets/offline_banner.dart' show relativeTime;
 import '../widgets/page_container.dart';
+import 'admin_metrics_screen.dart';
 
 /// The notification center (Wave 16): every notification as a durable,
 /// read/unread feed row. Type-agnostic — each row renders from its `type` +
@@ -102,12 +105,32 @@ class _NotificationCenterScreenState
 /// is chosen by `type`: `price_drop` renders the flight-specific layout from its
 /// payload, and any unrecognized type falls back to a generic title/subtitle so
 /// a new backend type is never a blank row.
-class _NotificationTile extends StatelessWidget {
+class _NotificationTile extends ConsumerWidget {
   final AppNotification notification;
   const _NotificationTile({required this.notification});
 
+  /// Where this row leads, or null when it leads nowhere. Nullable by design:
+  /// `InkWell(onTap: null)` renders no ripple, no hover cursor and no button
+  /// semantics, so every type without a destination behaves exactly as it did
+  /// before there was a tap target at all. This is the one place to add the
+  /// next destination (`collab_edit` -> the trip, via `notification.tripId`).
+  ///
+  /// No admin gate on the ops arm: only admins are ever written `ops_alert`
+  /// rows (the monitor fans out over `ListAdminUsers`), and the screen it
+  /// opens is enforced by `adminMiddleware` server-side regardless. A second,
+  /// client-side notion of who is an admin would be a duplicated derivation.
+  VoidCallback? _tapAction(WidgetRef ref) => switch (notification.type) {
+        'ops_alert' || 'ops_recovered' => () => pushOnActiveTab(
+              ref,
+              const AdminMetricsScreen(
+                  initialTabIndex: AdminMetricsScreen.healthTabIndex),
+              location: utilityLocation(BootUtility.adminMetrics),
+            ),
+        _ => null,
+      };
+
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final theme = Theme.of(context);
     final unread = notification.isUnread;
     // tryParse: one malformed timestamp must degrade to a row without a
@@ -125,6 +148,11 @@ class _NotificationTile extends StatelessWidget {
           payload: notification.payload,
           unread: unread,
         ),
+      'ops_alert' || 'ops_recovered' => _OpsBody(
+          type: notification.type,
+          payload: notification.payload,
+          unread: unread,
+        ),
       _ => _GenericBody(
           type: notification.type,
           payload: notification.payload,
@@ -133,47 +161,54 @@ class _NotificationTile extends StatelessWidget {
     };
 
     return Card(
-      child: Padding(
-        padding: const EdgeInsets.all(AppSpacing.lg),
-        child: Row(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            // Unread accent dot; a spacer keeps read rows aligned. The
-            // Semantics label announces unread state to screen readers —
-            // color/weight alone don't.
-            Padding(
-              padding: const EdgeInsets.only(top: 6, right: AppSpacing.md),
-              child: Semantics(
-                label: unread ? context.l10n.notifUnreadSemantic : null,
-                child: Container(
-                  width: 8,
-                  height: 8,
-                  decoration: BoxDecoration(
-                    shape: BoxShape.circle,
-                    color:
-                        unread ? theme.colorScheme.primary : Colors.transparent,
+      // The ripple must be clipped to the card's rounded shape, or tapping
+      // squares off the corners.
+      clipBehavior: Clip.antiAlias,
+      child: InkWell(
+        onTap: _tapAction(ref),
+        child: Padding(
+          padding: const EdgeInsets.all(AppSpacing.lg),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              // Unread accent dot; a spacer keeps read rows aligned. The
+              // Semantics label announces unread state to screen readers —
+              // color/weight alone don't.
+              Padding(
+                padding: const EdgeInsets.only(top: 6, right: AppSpacing.md),
+                child: Semantics(
+                  label: unread ? context.l10n.notifUnreadSemantic : null,
+                  child: Container(
+                    width: 8,
+                    height: 8,
+                    decoration: BoxDecoration(
+                      shape: BoxShape.circle,
+                      color: unread
+                          ? theme.colorScheme.primary
+                          : Colors.transparent,
+                    ),
                   ),
                 ),
               ),
-            ),
-            Expanded(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  content,
-                  if (when != null) ...[
-                    const SizedBox(height: 2),
-                    Text(
-                      when,
-                      style: theme.textTheme.bodySmall?.copyWith(
-                        color: theme.colorScheme.onSurfaceVariant,
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    content,
+                    if (when != null) ...[
+                      const SizedBox(height: 2),
+                      Text(
+                        when,
+                        style: theme.textTheme.bodySmall?.copyWith(
+                          color: theme.colorScheme.onSurfaceVariant,
+                        ),
                       ),
-                    ),
+                    ],
                   ],
-                ],
+                ),
               ),
-            ),
-          ],
+            ],
+          ),
         ),
       ),
     );
@@ -261,10 +296,108 @@ class _PriceDropBody extends StatelessWidget {
   }
 }
 
+/// Ops health signals for admins (`ops_alert` / `ops_recovered`, written by
+/// the API's health self-check). The payload carries `{degraded, reasons[]}`,
+/// so the row names WHAT is wrong — "backups stale", "AI provider failing:
+/// credit balance" — instead of falling through to [_GenericBody], which could
+/// only title-case the type into a contentless "Ops Alert".
+///
+/// The variant comes from `type`, not `payload['degraded']`: the type is
+/// already the discriminator, and deriving the same fact twice is how the two
+/// drift apart.
+///
+/// Layout deliberately mirrors `_DegradedBanner` in `widgets/health_pane.dart`
+/// (icon + title + reason bullets) WITHOUT its full-bleed errorContainer box —
+/// the feed row already supplies card chrome, the unread dot and the
+/// timestamp, so reusing the banner would nest a card inside a card. If a
+/// third context ever needs this, extract the shared shape then.
+class _OpsBody extends StatelessWidget {
+  final String type;
+  final Map<String, dynamic> payload;
+  final bool unread;
+  const _OpsBody({
+    required this.type,
+    required this.payload,
+    required this.unread,
+  });
+
+  /// The reasons the server recorded, defensively parsed: a malformed or
+  /// absent list must degrade to "no bullets", never throw in a feed row.
+  List<String> get _reasons {
+    final raw = payload['reasons'];
+    return raw is List ? raw.whereType<String>().toList() : const [];
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final l10n = context.l10n;
+    final degraded = type == 'ops_alert';
+    final reasons = _reasons;
+
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+          padding: const EdgeInsets.only(top: 2, right: AppSpacing.sm),
+          child: Icon(
+            degraded ? Icons.warning_amber_rounded : Icons.check_circle_outline,
+            size: 18,
+            color: degraded
+                ? theme.colorScheme.error
+                : theme.colorScheme.onSurfaceVariant,
+          ),
+        ),
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                degraded ? l10n.healthDegradedTitle : l10n.healthRecoveredTitle,
+                style: theme.textTheme.titleMedium?.copyWith(
+                  fontWeight: unread ? FontWeight.w700 : FontWeight.w500,
+                  color: unread
+                      ? theme.colorScheme.onSurface
+                      : theme.colorScheme.onSurfaceVariant,
+                ),
+              ),
+              // Reason strings are canonical server values (computeHealthState
+              // in ops_health.go) and operator-facing, exactly like the ops
+              // alert email — rendered verbatim, only the headline is
+              // localized.
+              for (final r in reasons) ...[
+                const SizedBox(height: 2),
+                Text(
+                  '• $r',
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: theme.colorScheme.onSurfaceVariant,
+                  ),
+                ),
+              ],
+              const SizedBox(height: 2),
+              // Without a hint the row is silently tappable — the exact
+              // discoverability gap this screen already had.
+              Text(
+                l10n.notifOpsOpenHealth,
+                style: theme.textTheme.bodySmall
+                    ?.copyWith(color: theme.colorScheme.primary),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
 /// Fallback layout for any type the client doesn't specialize yet. Reads a
 /// `title` (or `message`/`body`) from the payload, else humanizes the type
 /// name, so a newly-added backend notification always renders something
 /// sensible instead of a blank row.
+///
+/// A row showing a title-cased type name (e.g. "Ops Alert") is the signal that
+/// the type has outgrown this fallback and wants its own arm in the switch
+/// above.
 class _GenericBody extends StatelessWidget {
   final String type;
   final Map<String, dynamic> payload;

--- a/src/packages/flutter-app/test/admin_metrics_screen_test.dart
+++ b/src/packages/flutter-app/test/admin_metrics_screen_test.dart
@@ -4,8 +4,13 @@ import 'package:flutter_test/flutter_test.dart';
 
 import 'package:travel_route_planner/models/admin_insights.dart';
 import 'package:travel_route_planner/models/admin_metrics.dart';
+import 'package:travel_route_planner/models/ops_health.dart';
+import 'package:travel_route_planner/models/ops_metrics.dart';
 import 'package:travel_route_planner/providers/admin_metrics_provider.dart';
+import 'package:travel_route_planner/providers/ops_admin_provider.dart';
 import 'package:travel_route_planner/screens/admin_metrics_screen.dart';
+
+import 'support/l10n_test_app.dart';
 
 // The Overview tab (default) watches totals alongside the windowed metrics;
 // tests that only exercise Overview still need this override so the totals
@@ -28,8 +33,7 @@ const _totals = AdminTotals(
 );
 
 void main() {
-  testWidgets('renders funnel and AI tiles from metrics',
-      (tester) async {
+  testWidgets('renders funnel and AI tiles from metrics', (tester) async {
     tester.view.physicalSize = const Size(800, 3600);
     tester.view.devicePixelRatio = 1.0;
     addTearDown(tester.view.reset);
@@ -408,5 +412,41 @@ void main() {
     expect(find.text('1.5M / 250.0k'), findsOneWidget);
     expect(find.text('\$8.25'), findsOneWidget);
     expect(find.text('2026-06-01'), findsOneWidget);
+  });
+
+  // The destination half of the ops-notification tap: an ops_alert row pushes
+  // AdminMetricsScreen(initialTabIndex: healthTabIndex), so the Health pane
+  // must be on screen at the first frame without anyone tapping a tab.
+  testWidgets('initialTabIndex opens straight onto the Health tab',
+      (tester) async {
+    tester.view.physicalSize = const Size(800, 2400);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          adminMetricsProvider(30)
+              .overrideWith((ref) async => const AdminMetrics(days: 30)),
+          adminTotalsProvider.overrideWith((ref) async => _totals),
+          opsHealthProvider.overrideWith((ref) async => const OpsHealth(
+                db: HealthDb(status: 'ok', pingMs: 3),
+                degraded: true,
+                reasons: ['backups stale'],
+                backups: BackupInfo(stale: true),
+              )),
+          opsMetricsProvider.overrideWith((ref) async => const OpsMetrics()),
+        ],
+        child: MaterialApp(
+          localizationsDelegates: testLocalizationsDelegates,
+          home: const AdminMetricsScreen(
+              initialTabIndex: AdminMetricsScreen.healthTabIndex),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('System degraded'), findsOneWidget);
+    expect(find.text('• backups stale'), findsOneWidget);
   });
 }

--- a/src/packages/flutter-app/test/notification_center_test.dart
+++ b/src/packages/flutter-app/test/notification_center_test.dart
@@ -54,7 +54,8 @@ class _FakeNotificationsApiService extends NotificationsApiService {
   }
 
   @override
-  Future<int> unreadCount() async => notifications.where((n) => n.isUnread).length;
+  Future<int> unreadCount() async =>
+      notifications.where((n) => n.isUnread).length;
 }
 
 UserModel _user() => UserModel(
@@ -93,6 +94,30 @@ AppNotification _priceDrop({
       readAt: readAt,
     );
 
+/// An ops health row as the API writes it: the payload carries only
+/// `{degraded, reasons[]}` — no title/message — which is why these rows used to
+/// fall through to the generic body and render a bare "Ops Alert".
+AppNotification _ops({
+  String id = 'ops-1',
+  String type = 'ops_alert',
+  Object? reasons = const [
+    'backups stale',
+    'AI provider failing: credit balance'
+  ],
+  String createdAt = '2026-07-15T12:00:00Z',
+  String? readAt,
+}) =>
+    AppNotification(
+      id: id,
+      type: type,
+      payload: {
+        'degraded': type == 'ops_alert',
+        if (reasons != null) 'reasons': reasons,
+      },
+      createdAt: createdAt,
+      readAt: readAt,
+    );
+
 Future<_FakeNotificationsApiService> _pump(
   WidgetTester tester,
   List<AppNotification> notifications,
@@ -105,7 +130,8 @@ Future<_FakeNotificationsApiService> _pump(
         notificationsApiServiceProvider.overrideWithValue(service),
       ],
       child: MaterialApp(
-      localizationsDelegates: testLocalizationsDelegates,home: NotificationCenterScreen()),
+          localizationsDelegates: testLocalizationsDelegates,
+          home: NotificationCenterScreen()),
     ),
   );
   await tester.pumpAndSettle();
@@ -233,6 +259,67 @@ void main() {
       ),
     ]);
     expect(find.text('Weekly Digest'), findsOneWidget);
+  });
+
+  testWidgets('ops_alert names what is wrong instead of a bare type name',
+      (tester) async {
+    await _pump(tester, [_ops()]);
+    expect(find.text('System degraded'), findsOneWidget);
+    expect(find.text('• backups stale'), findsOneWidget);
+    expect(find.text('• AI provider failing: credit balance'), findsOneWidget);
+    // The regression this whole change exists to prevent.
+    expect(find.text('Ops Alert'), findsNothing);
+  });
+
+  testWidgets('ops_recovered reads as all clear', (tester) async {
+    await _pump(tester, [_ops(type: 'ops_recovered', reasons: const [])]);
+    expect(find.text('System recovered'), findsOneWidget);
+    expect(find.textContaining('•'), findsNothing);
+    expect(find.text('Ops Recovered'), findsNothing);
+  });
+
+  testWidgets('an ops row with a missing reasons list still renders',
+      (tester) async {
+    await _pump(tester, [_ops(reasons: null)]);
+    expect(find.text('System degraded'), findsOneWidget);
+    expect(find.text('View system health'), findsOneWidget);
+  });
+
+  testWidgets('an ops row with a malformed reasons payload still renders',
+      (tester) async {
+    // Not a list, and a list with non-string members: neither may throw in a
+    // feed row.
+    await _pump(tester, [
+      _ops(id: 'ops-a', reasons: 'backups stale'),
+      _ops(id: 'ops-b', reasons: const [42, 'backups stale']),
+    ]);
+    expect(find.text('System degraded'), findsNWidgets(2));
+    expect(find.text('• backups stale'), findsOneWidget);
+  });
+
+  testWidgets('ops rows are tappable; other rows are not', (tester) async {
+    // The affordance is what this screen lacked; the destination is asserted
+    // in admin_metrics_screen_test.dart, since pushOnActiveTab needs mounted
+    // tab navigators this harness deliberately doesn't build.
+    await _pump(tester, [_ops()]);
+    expect(
+      find.byWidgetPredicate((w) => w is InkWell && w.onTap != null),
+      findsOneWidget,
+    );
+
+    await _pump(tester, [_priceDrop()]);
+    expect(
+      find.byWidgetPredicate((w) => w is InkWell && w.onTap != null),
+      findsNothing,
+    );
+  });
+
+  testWidgets('tapping an ops row does not throw without a nav host',
+      (tester) async {
+    await _pump(tester, [_ops()]);
+    await tester.tap(find.text('System degraded'));
+    await tester.pumpAndSettle();
+    expect(tester.takeException(), isNull);
   });
 
   testWidgets('empty feed shows the how-to empty state', (tester) async {


### PR DESCRIPTION
## Summary

The admin notification center showed a stream of identical, contentless **"Ops Alert"** cards — no indication of what was wrong, and not tappable.

Nothing was missing server-side. `opsAlertPayload` (`ops_monitor.go`) has always written `{degraded, reasons[]}` into the notification payload; the Flutter switch simply had no arm for the type, so ops rows fell through to `_GenericBody`, which could only title-case `ops_alert` into "Ops Alert" and looked for a `title`/`message`/`body` the ops payload never carries. No notification type was tappable either — there was no `InkWell` anywhere in that screen.

- **New `_OpsBody` arm** renders the stored reasons (`backups stale`, `AI provider failing: credit balance`) as bullets under a localized headline. Mirrors the shape of `_DegradedBanner` in `health_pane.dart` *without* its full-bleed `errorContainer` box — the feed row already supplies card chrome, the unread dot and the timestamp, so reusing the banner would nest a card in a card. The degraded/recovered variant comes from `type`, not `payload['degraded']`: one discriminator, derived once.
- **Tap through to the Health tab.** The shared `Card` gains a nullable, type-dispatched `onTap`; ops rows push the admin Metrics screen straight onto its existing **Health** tab, which already renders live reasons, backup age and dependency status. Every other type keeps a `null` `onTap`, so `InkWell` draws no ripple, no hover cursor and no button semantics — those rows look and behave exactly as before. This is the one place to add the next destination (`collab_edit` → the trip, via the `tripId` field currently read nowhere).
- **`AdminMetricsScreen`** takes an `initialTabIndex` (default `0`) plus a named `healthTabIndex` constant, so no caller carries a bare literal and the tab order stays defined in one place. Tab position deliberately stays out of the URL — transient view state, not a location.
- Reason strings are canonical server values and operator-facing (same as the ops alert email), so they render verbatim; only the headline is localized. New keys added to **both** `app_en.arb` and `app_es.arb`, which were at exact parity.

Existing rows become readable retroactively — this is purely a read-side fix, so the whole backlog of past alerts gains its context on deploy.

### Not in scope (deliberate)

Server-side noise suppression and notification pruning were considered and declined for this PR. Context for the follow-up: `healthMonitor.lastReasons` is in-memory, so every deploy re-fires any standing reason; and a standing reason plus a flapping one emits `ops_alert` on every flip and never `ops_recovered` (documented by `TestHealthMonitorAlertsOnOverlappingOutages`). Notifications are never pruned and the feed is capped at 50, so ops rows do crowd out real notifications over time.

## Testing

- `flutter test` — **973/973 pass**, including 7 new cases:
  - `notification_center_test.dart`: `ops_alert` renders "System degraded" plus both reason bullets and **no longer** renders "Ops Alert"; `ops_recovered` reads as all-clear with no bullets; a missing `reasons` key still renders; a malformed `reasons` payload (a bare string, and a list with non-string members) still renders and doesn't throw; ops rows expose a non-null `InkWell.onTap` while `price_drop` rows don't; tapping without a nav host doesn't throw.
  - `admin_metrics_screen_test.dart`: `initialTabIndex: healthTabIndex` lands on the Health pane at the first frame — the destination half of the tap, asserted here because `pushOnActiveTab` needs mounted tab navigators the notification harness deliberately doesn't build.
- `flutter analyze --no-fatal-infos --fatal-warnings` (as CI runs it) — clean. The 3 remaining `info`s are pre-existing in `models/route_response.dart`, untouched here and dating to the initial commit.
- l10n regenerated with `flutter pub get` before `gen-l10n`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)