### PR TITLE
fix(ops): create the backups dir with an explicit 0755 mode

### DIFF
--- a/dockerize/production/backup.sh
+++ b/dockerize/production/backup.sh
@@ -49,7 +49,13 @@ compose() {
     fi
 }
 
-mkdir -p "$BACKUP_DIR"
+# install -d, not mkdir -p: the mode must be explicit AND applied even when
+# the directory already exists. This job runs as root, and root's umask once
+# created the directory 0700 — the api container (uid 1001, read-only mount)
+# couldn't traverse it, so /admin/ops/health reported "backups stale" forever
+# despite fresh nightly dumps. 0755 is required for the heartbeat to be
+# readable through the compose bind mount; self-heals on every run.
+install -d -m 755 "$BACKUP_DIR"
 
 out="$BACKUP_DIR/${PG_DB}-$(date +%F).dump.gz"
 tmp="$out.tmp"


### PR DESCRIPTION
## Summary

- Root cause of the 2026-08-13 admin "Ops Alert" flood: `backup.sh`'s bare `mkdir -p` runs as root, whose umask created `/opt/goldentempo/backups` as `0700`. The api container (uid 1001) couldn't traverse the read-only bind mount, `readBackupHealth` got `Permission denied`, and `/admin/ops/health` reported **"backups stale" forever** — despite fresh nightly dumps sitting in the directory. That one standing false reason then re-fired an `ops_alert` on every deploy restart (the monitor's transition state is in-memory), one alert per each of the day's ~14 merges.
- Fix: `install -d -m 755 "$BACKUP_DIR"` — the mode is explicit and reapplied even when the directory already exists, so every nightly run self-heals the permission and a re-homed box can never regress into the same silent mismatch.
- The live host was already fixed with a one-off `chmod 755`; this makes it durable. (Backups themselves were verified healthy: heartbeat ~20h old vs. the 36h threshold, dumps present daily through 08-13.)

## Testing

- `bash -n dockerize/production/backup.sh` — syntax clean.
- Verified on prod that the 0700 directory was exactly what the container hit (`docker compose exec api cat …/.last_success` → `Permission denied`; api log at boot: `ops health degraded — reasons="backups stale"`), and that dumps + heartbeat are fresh on the host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)