### PR TITLE
fix(brand): cache-bust favicon link so Chrome drops the old logo

### DIFF
--- a/src/packages/flutter-app/web/index.html
+++ b/src/packages/flutter-app/web/index.html
@@ -51,8 +51,9 @@
   <!-- ?v=2 busts nginx's year-long immutable cache on /app/icons/* (Anemos art) -->
   <link rel="apple-touch-icon" href="icons/Icon-192.png?v=2">
 
-  <!-- Favicon -->
-  <link rel="icon" type="image/png" href="favicon.png"/>
+  <!-- Favicon: ?v=2 because Chrome's favicon cache is keyed by URL and
+       refreshes lazily — new bytes at the same URL can stay stale for weeks. -->
+  <link rel="icon" type="image/png" href="favicon.png?v=2"/>
 
   <title>Anemos</title>
   <link rel="manifest" href="manifest.json">


### PR DESCRIPTION
## Summary
- Add `?v=2` to the `<link rel="icon">` favicon ref in `web/index.html` — the one icon ref #374 missed when it cache-busted the apple-touch-icon and manifest icons.
- Prod already serves the new wind-rose bytes at `/app/favicon.png` (sha-verified identical to the repo), but Chrome's favicon cache is keyed by URL and refreshes lazily, so returning browsers kept painting the old metronome in the tab strip / history / tab search. A changed URL is the one signal Chrome treats as a new favicon.
- `index.html` is served `no-cache`, so the updated link reaches returning visitors on their next page load — no user-side cache clearing needed.

## Testing
- Verified live `/app/favicon.png` sha1 matches the repo file (deploy is fine; this is purely a client favicon-cache issue).
- Confirmed nginx serves `favicon.png` via the ETag-revalidated `/app/` block (not the immutable `icons/` block), so the query param is only needed for Chrome's favicon DB, not an edge-cache pin.
- Static-file change only; no analyzer/tests apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)