### PR TITLE
fix: collapse duplicate tool chips to one per rendered label

### DIFF
--- a/specs/chat-working-indicator/spec.md
+++ b/specs/chat-working-indicator/spec.md
@@ -88,7 +88,10 @@ None. No persistence changes.
 - Compaction failure emits nothing of its own → the next `thinking` frame
   retires the summarizing chip instead of it lingering until the first token.
 - A model response with several tool calls announces each chip as the model
-  writes it; chips retire one by one as the tools finish executing.
+  writes it; chips retire one by one as the tools finish executing. Calls that
+  render the same label (parallel `search_places`, or two unnamed quick
+  writes both showing "Working…") collapse into a single chip that clears
+  when the last matching call finishes.
 - Older deployed clients that don't know `thinking` ignore unknown SSE event
   types by falling through their event switch — the stream stays compatible.
 

--- a/src/packages/flutter-app/lib/widgets/chat_panel.dart
+++ b/src/packages/flutter-app/lib/widgets/chat_panel.dart
@@ -744,18 +744,27 @@ class _ActiveToolChips extends ConsumerWidget {
     final activeTools = ref.watch(state.select((s) => s.activeTools));
     if (activeTools.isEmpty) return const SizedBox.shrink();
     final l10n = context.l10n;
+    // Parallel tool_use blocks announce one activeTools entry each; identical
+    // labels collapse to one chip — the chip says what's happening, not how
+    // many calls are in flight. Deduped on the rendered label (not the tool
+    // name) so unnamed tools sharing the generic "Working..." collapse too;
+    // the set keeps first-occurrence order, and the chip stays up until the
+    // last same-label call finishes.
+    final labels = <String>{
+      for (final tool in activeTools) _toolLabel(l10n, tool),
+    };
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: AppSpacing.sm),
       child: Wrap(
         spacing: AppSpacing.sm,
-        children: activeTools.map((tool) {
+        children: labels.map((label) {
           return Chip(
             avatar: const SizedBox(
               width: 16,
               height: 16,
               child: CircularProgressIndicator(strokeWidth: 2),
             ),
-            label: Text(_toolLabel(l10n, tool)),
+            label: Text(label),
           );
         }).toList(),
       ),

--- a/src/packages/flutter-app/test/chat_panel_tool_chip_test.dart
+++ b/src/packages/flutter-app/test/chat_panel_tool_chip_test.dart
@@ -128,4 +128,58 @@ void main() {
     afterToolCall.complete();
     await tester.pumpAndSettle();
   });
+
+  testWidgets('parallel same-tool calls collapse to one chip',
+      (WidgetTester tester) async {
+    final afterBothCalls = Completer<void>();
+    final afterFirstResult = Completer<void>();
+    final service = _StagedPlanService([
+      const PlanEvent(type: 'tool_call', data: {'name': 'search_places'}),
+      const PlanEvent(type: 'tool_call', data: {'name': 'search_places'}),
+      afterBothCalls,
+      const PlanEvent(type: 'tool_result', data: {'name': 'search_places'}),
+      afterFirstResult,
+      const PlanEvent(type: 'tool_result', data: {'name': 'search_places'}),
+    ]);
+    await _pumpPanel(tester, service);
+
+    await _send(tester);
+    await tester.pump(const Duration(milliseconds: 20));
+    // Two parallel search_places blocks announced — one chip, not twins.
+    expect(find.text('Searching places...'), findsOneWidget);
+
+    afterBothCalls.complete();
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 20));
+    // First result in: one call still running, so the chip stays.
+    expect(find.text('Searching places...'), findsOneWidget);
+
+    afterFirstResult.complete();
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 20));
+    // Last result clears it.
+    expect(find.text('Searching places...'), findsNothing);
+    await tester.pumpAndSettle();
+  });
+
+  testWidgets('different unlabeled tools share one working chip',
+      (WidgetTester tester) async {
+    final afterBothCalls = Completer<void>();
+    final service = _StagedPlanService([
+      const PlanEvent(type: 'tool_call', data: {'name': 'save_preferences'}),
+      const PlanEvent(type: 'tool_call', data: {'name': 'set_travel_mode'}),
+      afterBothCalls,
+      const PlanEvent(type: 'tool_result', data: {'name': 'save_preferences'}),
+      const PlanEvent(type: 'tool_result', data: {'name': 'set_travel_mode'}),
+    ]);
+    await _pumpPanel(tester, service);
+
+    await _send(tester);
+    await tester.pump(const Duration(milliseconds: 20));
+    // The dedupe is by rendered label, not tool name: two distinct quick
+    // writes both fall back to the generic label and must share a chip.
+    expect(find.text('Working...'), findsOneWidget);
+    afterBothCalls.complete();
+    await tester.pumpAndSettle();
+  });
 }


### PR DESCRIPTION
## Summary
- Two parallel `search_places` tool_use blocks in one model message each announce a `tool_call` SSE event (by design — #370's early announce), which rendered as two identical "Searching places..." chips side by side in the plan chat.
- `_ActiveToolChips` now dedupes at render time on the localized label (insertion-ordered set), so identical labels collapse into a single spinning chip; distinct unnamed tools sharing the generic "Working..." label collapse too.
- `activeTools` state semantics are untouched: one entry per `tool_call`, one removed per `tool_result`, so the collapsed chip clears only when the last matching call finishes. The server's exactly-one-`tool_call`-per-block contract is unchanged.
- Amended `specs/chat-working-indicator/spec.md`'s multi-tool scenario with the collapse rule.

## Testing
- `flutter test test/chat_panel_tool_chip_test.dart test/chat_panel_typing_indicator_test.dart test/chat_panel_quick_replies_test.dart` — 22 tests pass, including two new ones: parallel same-tool calls show one chip that survives the first `tool_result` and clears on the last; two distinct unlabeled tools share one "Working..." chip.
- `flutter analyze` — clean (3 pre-existing infos in `route_response.dart`, untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)