### PR TITLE
feat(flutter): surface Import-from-AI-chat on the Plan empty state and Home hero

### DIFF
--- a/specs/import-trip-from-ai-chat/spec.md
+++ b/specs/import-trip-from-ai-chat/spec.md
@@ -78,7 +78,12 @@ No schema changes. Writes `trips` + `itinerary_items` through the existing
 ## UI Behavior
 
 - Surface: "Import from AI chat" icon action on the Trips list app bar, plus a
-  button on the trips-list empty state.
+  button on the trips-list empty state; also a labeled button on the Agent
+  chat's empty state and a white text-button line under the Home new-user
+  hero's suggestion chips (buttons, not chips — neighboring chips put words
+  into the chat, import navigates). Every entry funnels through
+  `openImportOnTripsTab`: it switches to the Trips tab and pushes `/import`,
+  so the post-import trip detail lands on the stack-keeping Trips tab.
 - Screen: explainer, "Copy planning prompt" button, large paste field, Import
   button. During import: indeterminate progress with staged copy (extraction
   takes 5–20 s). Success: navigate (replace) to the new trip's detail screen;

--- a/specs/import-trip-from-ai-chat/tasks.md
+++ b/specs/import-trip-from-ai-chat/tasks.md
@@ -24,6 +24,8 @@
 - [x] `lib/screens/import_trip_screen.dart` (copy-prompt, paste, progress,
       warnings, error/retry)
 - [x] Entry points: trips-list app bar action + empty-state action
+- [x] Entry points v2: Agent empty-state button + Home new-user hero line,
+      all via the shared `openImportOnTripsTab` helper (app_nav.dart)
 - [x] ARB strings en+es (incl. planning prompt) + regenerate l10n
 - [x] `flutter analyze` green
 

--- a/src/packages/flutter-app/lib/navigation/app_nav.dart
+++ b/src/packages/flutter-app/lib/navigation/app_nav.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../screens/import_trip_screen.dart';
 import '../screens/trip_detail_screen.dart';
 import 'app_routes.dart';
 
@@ -105,6 +106,22 @@ void openTripOnTripsTab(WidgetRef ref, String tripId) {
     navKeys[AppTab.trips.index].currentState?.popUntil((r) => r.isFirst);
     return locatedRoute(
         TripDetailScreen(tripId: tripId), tripDetailLocation(tripId));
+  });
+}
+
+/// Open the import-from-AI-chat screen on the Trips tab — every entry point
+/// funnels here so the Trips nav item highlights, back lands on the trips
+/// list, and the URL reports /import (whose refresh restores onto Trips).
+/// The import screen's success replace-navigates to the new trip's detail,
+/// which must land on the stack-keeping Trips tab, not whichever tab hosted
+/// the entry point.
+void openImportOnTripsTab(WidgetRef ref) {
+  ref.read(navIndexProvider.notifier).state = AppTab.trips.index;
+  final navKeys = ref.read(tabNavKeysProvider);
+  pushOnTabWhenReady(navKeys, AppTab.trips, () {
+    navKeys[AppTab.trips.index].currentState?.popUntil((r) => r.isFirst);
+    return locatedRoute(
+        const ImportTripScreen(), utilityLocation(BootUtility.importTrip));
   });
 }
 

--- a/src/packages/flutter-app/lib/screens/agent_screen.dart
+++ b/src/packages/flutter-app/lib/screens/agent_screen.dart
@@ -135,6 +135,15 @@ class _EmptyState extends ConsumerWidget {
                 .sendMessage(text, displayLabel: displayLabel),
           ),
           for (final prompt in prompts) _SuggestionChip(prompt),
+          // Planned elsewhere (ChatGPT/Claude)? Paste it in instead
+          // (specs/import-trip-from-ai-chat). A button, not a chip: the
+          // chips above put words into the chat, this navigates — to the
+          // Trips tab, same as /import's refresh-restore.
+          OutlinedButton.icon(
+            onPressed: () => openImportOnTripsTab(ref),
+            icon: const Icon(Icons.content_paste_go, size: 18),
+            label: Text(l10n.importFromAi),
+          ),
         ],
       ),
     );

--- a/src/packages/flutter-app/lib/screens/home_screen.dart
+++ b/src/packages/flutter-app/lib/screens/home_screen.dart
@@ -190,7 +190,10 @@ class HomeScreen extends ConsumerWidget {
                     ),
                   ),
                 ] else
-                  _AgentHeroCard(onStart: startPlanning),
+                  _AgentHeroCard(
+                    onStart: startPlanning,
+                    onImport: () => openImportOnTripsTab(ref),
+                  ),
 
                 const SizedBox(height: AppSpacing.xl),
 
@@ -349,8 +352,9 @@ class _GreetingHeader extends StatelessWidget {
 
 class _AgentHeroCard extends StatelessWidget {
   final void Function({String? initialMessage, String? displayLabel}) onStart;
+  final VoidCallback onImport;
 
-  const _AgentHeroCard({required this.onStart});
+  const _AgentHeroCard({required this.onStart, required this.onImport});
 
   @override
   Widget build(BuildContext context) {
@@ -466,6 +470,16 @@ class _AgentHeroCard extends StatelessWidget {
                     )),
               ],
             ),
+          ),
+          const SizedBox(height: AppSpacing.sm),
+          // Already planned in ChatGPT/Claude? Its own line, not another
+          // chip: the chips above put words into the chat, this navigates
+          // (specs/import-trip-from-ai-chat).
+          TextButton.icon(
+            onPressed: onImport,
+            style: TextButton.styleFrom(foregroundColor: Colors.white),
+            icon: const Icon(Icons.content_paste_go, size: 18),
+            label: Text(l10n.importFromAi),
           ),
         ],
       ),

--- a/src/packages/flutter-app/lib/screens/trips_list_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trips_list_screen.dart
@@ -28,7 +28,6 @@ import '../providers/live_trip_provider.dart';
 import '../providers/resumable_chats_provider.dart';
 import '../providers/shared_with_me_provider.dart';
 import '../providers/trips_provider.dart';
-import 'import_trip_screen.dart';
 import 'trip_detail_screen.dart';
 
 class TripsListScreen extends ConsumerStatefulWidget {
@@ -113,7 +112,7 @@ class _TripsListScreenState extends ConsumerState<TripsListScreen> {
           // Planned elsewhere (ChatGPT/Claude)? Paste it in instead
           // (specs/import-trip-from-ai-chat).
           OutlinedButton.icon(
-            onPressed: () => _openImport(context),
+            onPressed: () => openImportOnTripsTab(ref),
             icon: const Icon(Icons.content_paste_go, size: 18),
             label: Text(l10n.importFromAi),
           ),
@@ -303,7 +302,7 @@ class _TripsListScreenState extends ConsumerState<TripsListScreen> {
           IconButton(
             tooltip: l10n.importFromAi,
             icon: const Icon(Icons.content_paste_go),
-            onPressed: () => _openImport(context),
+            onPressed: () => openImportOnTripsTab(ref),
           ),
           const AccountMenu(),
         ],
@@ -326,13 +325,6 @@ Future<void> _openTrip(
   // as pull-to-refresh.
   ref.invalidate(sharedWithMeProvider);
   unawaited(ref.read(tripsProvider.notifier).loadTrips());
-}
-
-void _openImport(BuildContext context) {
-  Navigator.of(context).push(
-    locatedRoute(
-        const ImportTripScreen(), utilityLocation(BootUtility.importTrip)),
-  );
 }
 
 /// A single trip in the list. Shows the latest version of its chat; for admins,

--- a/src/packages/flutter-app/test/agent_empty_state_suggestions_test.dart
+++ b/src/packages/flutter-app/test/agent_empty_state_suggestions_test.dart
@@ -18,9 +18,11 @@ import 'support/l10n_test_app.dart';
 
 /// The agent screen's empty state draws its suggestion chips from the shared
 /// randomized pool: the near-me chip always leads, exactly
-/// [kSuggestionCount] pool picks follow, a pick is drawn once per mount
-/// (a locale switch relabels WITHOUT reshuffling; a chat reset re-rolls),
-/// and tapping a chip sends exactly the visible label.
+/// [kSuggestionCount] pool picks follow (the import-from-AI-chat button
+/// closes the row — a button, not a chip, because it navigates instead of
+/// sending), a pick is drawn once per mount (a locale switch relabels
+/// WITHOUT reshuffling; a chat reset re-rolls), and tapping a chip sends
+/// exactly the visible label.
 
 class _RecordingPlanNotifier extends PlanNotifier {
   final List<(String, String?)> sent = [];
@@ -110,7 +112,9 @@ void main() {
 
     final emptyState = tester.widget<EmptyState>(find.byType(EmptyState));
     expect(emptyState.actions.first, isA<NearMeChip>());
-    expect(emptyState.actions, hasLength(1 + kSuggestionCount));
+    // near-me + pool picks + the trailing import entry point.
+    expect(emptyState.actions, hasLength(1 + kSuggestionCount + 1));
+    expect(emptyState.actions.last, isA<OutlinedButton>());
 
     expect(find.text('Island hopping in Greece'), findsOneWidget);
     expect(find.text('3 days in Lisbon'), findsOneWidget);

--- a/src/packages/flutter-app/test/import_entry_points_test.dart
+++ b/src/packages/flutter-app/test/import_entry_points_test.dart
@@ -1,0 +1,128 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:travel_route_planner/main.dart';
+import 'package:travel_route_planner/models/trip.dart';
+import 'package:travel_route_planner/navigation/app_nav.dart';
+import 'package:travel_route_planner/navigation/url_sync.dart';
+import 'package:travel_route_planner/providers/auth_provider.dart';
+import 'package:travel_route_planner/providers/live_trip_provider.dart';
+import 'package:travel_route_planner/providers/resumable_chats_provider.dart';
+import 'package:travel_route_planner/providers/trips_provider.dart';
+import 'package:travel_route_planner/screens/agent_screen.dart';
+import 'package:travel_route_planner/screens/home_screen.dart';
+import 'package:travel_route_planner/screens/import_trip_screen.dart';
+import 'package:travel_route_planner/screens/trips_list_screen.dart';
+import 'package:travel_route_planner/services/trips_api_service.dart';
+
+import 'support/url_sync_fakes.dart';
+
+/// Every "Import from AI chat" entry point funnels through
+/// openImportOnTripsTab: the import screen opens on the TRIPS tab (whose
+/// stack the post-import trip detail must land on), the URL reports /import,
+/// and back lands on the trips list — regardless of which tab hosted the
+/// entry (specs/import-trip-from-ai-chat).
+///
+/// Finder discipline: the shell's IndexedStack keeps all three tabs mounted,
+/// and with an empty account every tab carries the same import label — scope
+/// every find/tap to its host screen, never a bare byType/text.
+class _EmptyTripsApi extends FakeTripsApiService {
+  _EmptyTripsApi() : super(fakeTrip('unused'));
+
+  @override
+  Future<List<Trip>> listTrips() async => const [];
+}
+
+void main() {
+  late List<String> reports;
+
+  Future<ProviderContainer> pumpApp(WidgetTester tester,
+      {TripsApiService? api}) async {
+    tester.binding.platformDispatcher.defaultRouteNameTestValue = '/';
+    reports = <String>[];
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          authProvider.overrideWith((ref) => FakeAuthNotifier(fakeUser())),
+          tripsApiServiceProvider
+              .overrideWithValue(api ?? FakeTripsApiService(fakeTrip('t1'))),
+          liveTripProvider.overrideWithValue(null),
+          resumableChatsProvider.overrideWith((ref) async => const []),
+          urlReporterProvider.overrideWithValue(reports.add),
+        ],
+        child: const TravelRoutePlannerApp(),
+      ),
+    );
+    await tester.pumpAndSettle();
+    return ProviderScope.containerOf(
+        tester.element(find.byType(TravelRoutePlannerApp)));
+  }
+
+  Finder importLabelIn(Type screen) => find.descendant(
+      of: find.byType(screen), matching: find.text('Import from AI chat'));
+
+  setUp(() => SharedPreferences.setMockInitialValues({}));
+
+  testWidgets('agent empty-state button opens import on the Trips tab',
+      (tester) async {
+    final container = await pumpApp(tester);
+
+    container.read(navIndexProvider.notifier).state = AppTab.plan.index;
+    await tester.pumpAndSettle();
+    await tester.tap(importLabelIn(AgentScreen));
+    await tester.pumpAndSettle();
+
+    expect(container.read(navIndexProvider), AppTab.trips.index);
+    expect(find.byType(ImportTripScreen), findsOneWidget);
+    expect(reports.last, '/import');
+
+    // Back lands on the trips LIST, not the Plan tab that hosted the entry.
+    await tester.pageBack();
+    await tester.pumpAndSettle();
+    expect(find.byType(ImportTripScreen), findsNothing);
+    expect(find.text('Lisbon long weekend'), findsOneWidget);
+    expect(reports.last, '/trips');
+  });
+
+  testWidgets('new-user hero import line opens import on the Trips tab',
+      (tester) async {
+    final container = await pumpApp(tester, api: _EmptyTripsApi());
+
+    // Empty account → Home shows the photo hero, which carries the import
+    // line under its chips.
+    expect(importLabelIn(HomeScreen), findsOneWidget);
+
+    // The line sits below the 600px test viewport's fold — scroll it in.
+    await tester.ensureVisible(importLabelIn(HomeScreen));
+    await tester.pumpAndSettle();
+    await tester.tap(importLabelIn(HomeScreen));
+    await tester.pumpAndSettle();
+
+    expect(container.read(navIndexProvider), AppTab.trips.index);
+    expect(find.byType(ImportTripScreen), findsOneWidget);
+    expect(reports.last, '/import');
+  });
+
+  testWidgets('trips-list app-bar icon still opens import via the helper',
+      (tester) async {
+    final container = await pumpApp(tester);
+
+    container.read(navIndexProvider.notifier).state = AppTab.trips.index;
+    await tester.pumpAndSettle();
+    await tester.tap(find.descendant(
+        of: find.byType(TripsListScreen),
+        matching: find.byIcon(Icons.content_paste_go)));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(ImportTripScreen), findsOneWidget);
+    expect(reports.last, '/import');
+    expect(container.read(navIndexProvider), AppTab.trips.index);
+
+    await tester.pageBack();
+    await tester.pumpAndSettle();
+    expect(find.text('Lisbon long weekend'), findsOneWidget);
+    expect(reports.last, '/trips');
+  });
+}


### PR DESCRIPTION
## Summary
- Adds an outlined **Import from AI chat** button to the Agent chat's empty state — the highest-intent surface (someone about to re-type a finished ChatGPT plan into the $1–5 agent path instead of the ~$0.07 import), styled identically to the trips-empty-state button so import is one recognizable object across both empty states.
- Adds a white **Import from AI chat** text-button line under the Home new-user hero's suggestion chips — a fresh account that already planned in ChatGPT lands on Home and may never meet the Trips empty state. On its own line, not a fourth chip: the chips put words into the chat, this navigates.
- New shared `openImportOnTripsTab(ref)` helper in `app_nav.dart` (mirrors `openTripOnTripsTab`): switches to the Trips tab, pops its stack, pushes `/import` — so the post-import `pushReplacement` to trip detail lands on the stack-keeping Trips tab and `/import` refresh-restore stays consistent from every entry. Both existing trips-list entries now delegate to it (behavior byte-identical there).
- All labels reuse the existing `importFromAi` l10n key — zero ARB churn, no gen-l10n regen.
- Spec/tasks updated (`specs/import-trip-from-ai-chat`); scope (these two surfaces only, returning-user Home row and landing card deliberately dropped) confirmed with Brian.

## Testing
- `flutter analyze --no-fatal-infos --fatal-warnings` clean (3 pre-existing infos in `route_response.dart`, untouched).
- New `test/import_entry_points_test.dart` (full-app pumps): agent empty-state button and hero line each land on `ImportTripScreen` with the Trips tab selected and URL `/import`, back lands on the trips *list*; plus a regression pin for the trips app-bar icon through the new helper. Finders scoped per-screen (IndexedStack keeps all tabs mounted).
- Updated `agent_empty_state_suggestions_test.dart` contract: near-me + pool picks + trailing import button.
- Full suite: **1014 passed, 0 failed**.
- Manual browser verification on the lane stack (headless Chrome + SSO-handoff login, fresh account): hero line renders white-on-photo, Plan empty state shows the outlined button, both taps land on `/import` with the Trips rail item highlighted, back lands on the trips list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)