### PR TITLE
fix(ci): guard migration numbers against main's highest; burn 00058

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,6 +177,51 @@ jobs:
             exit 1
           fi
 
+      # A migration numbered at or BELOW main's highest passes every other
+      # check here and then takes production down. "Apply migrations" below
+      # starts from an empty database, where any ordering is trivially valid,
+      # so it cannot see this; the duplicate guard above cannot either, since
+      # filling a gap collides with nothing. But db.go runs goose.Up without
+      # WithAllowMissing, and goose refuses to apply a version below the
+      # database's current max ("found N missing migrations before current
+      # version M") — which main.go escalates to log.Fatalf, so the API exits
+      # before binding its port and crash-loops with the old container already
+      # replaced. Paid for by the 00058 gap (2026-08-14): that number can
+      # never be used again, because production is past it.
+      - name: Guard against out-of-order migration numbers
+        run: |
+          git fetch --no-tags --depth=1 origin +refs/heads/main:refs/remotes/origin/main
+          # Pathspec is relative to this job's working-directory, not the repo
+          # root; anchoring it wrong makes main_max empty and the guard passes
+          # everything silently.
+          main_files=$(git ls-tree --name-only -r origin/main -- migrations/ \
+            | sed 's#.*/##' | grep -E '^[0-9]{5}_' | sort)
+          main_max=$(printf '%s\n' "$main_files" | grep -oE '^[0-9]{5}' | sort | tail -1)
+          if [ -z "$main_max" ]; then
+            echo "::error::could not read main's migrations — the guard cannot verify ordering, so failing closed."
+            exit 1
+          fi
+          added=$(comm -13 <(printf '%s\n' "$main_files") <(ls migrations/ | grep -E '^[0-9]{5}_' | sort))
+          if [ -z "$added" ]; then
+            echo "no migrations added against main (highest on main: $main_max)"
+            exit 0
+          fi
+          rc=0
+          while IFS= read -r f; do
+            [ -n "$f" ] || continue
+            n=${f%%_*}
+            # 10# forces base 10: 00058 is not a valid octal literal.
+            if [ "$((10#$n))" -le "$((10#$main_max))" ]; then
+              echo "::error::migration $f is numbered $n, at or below main's highest ($main_max). Production has already applied past it, so goose would refuse it at boot and the deploy would crash-loop. Renumber it above $main_max."
+              rc=1
+            fi
+          done <<< "$added"
+          if [ "$rc" -eq 0 ]; then
+            echo "added migration(s) sort above main's highest ($main_max):"
+            printf '%s\n' "$added" | sed 's/^/  /'
+          fi
+          exit $rc
+
       - name: Apply migrations
         env:
           DATABASE_URL: postgres://postgres:postgres@localhost:5432/travel?sslmode=disable

--- a/docs/friction-log.md
+++ b/docs/friction-log.md
@@ -5,6 +5,48 @@ build queue. Priority when picking work: **breakage > friction in features
 actually used > ideas that recur across ≥2 sessions**. Tag entries `[app]`
 (dogfooding the product) or `[dev]` (workflow/tooling). Newest first.
 
+## 2026-08-14 — the 00058 migration gap (latent prod outage, defused)
+
+- **[dev] BREAKAGE latent in main → fixed before it fired.** The 00058 gap
+  was not a stale reservation — it was a **loaded gun**. `db.go` calls
+  `goose.Up` with no `WithAllowMissing`, so goose refuses any unapplied
+  version below the DB's max (`found N missing migrations before current
+  version 60`), and `main.go` escalates that to `log.Fatalf`. Reproduced
+  end-to-end against a prod-shaped throwaway Postgres: the API **exits ~25ms
+  into boot, never binds :8080**, and under `restart: unless-stopped` with the
+  old container already replaced it crash-loops — a full API outage that the
+  deploy only reports ~5 minutes later, with no auto-rollback. Merging
+  *anything* numbered 00058 would have done this.
+- **[dev] The scariest part: every existing check passed.** "Migrations apply
+  from zero" runs against an empty database where 58 sorts happily between 57
+  and 59 (verified: `OK 00058_…`, exit 0), and the duplicate guard finds no
+  collision because filling a gap collides with nothing. A doomed PR would
+  have gone green and died on deploy. Fixed by an **out-of-order guard** in the
+  same CI job: every migration a branch adds must sort strictly above main's
+  highest. Rejected the alternative of enabling `WithAllowMissing` — that
+  swaps one loud, zero-damage crash for silent order-dependent schema state
+  repo-wide.
+- **[dev] Root cause — a stacked PR merged into a base that no longer
+  existed.** PR #350 (`budget-v2-autopopulate`) was merged into branch
+  `budget-v2` at 17:14Z on 08-13, **47 minutes after `budget-v2` itself merged
+  to main** at 16:27Z. GitHub shows #350 as MERGED, but its merge commit
+  `c16939c` is not an ancestor of main and the feature is absent from main
+  (`git grep source_kind` → nothing). ~1,357 lines of finished work — the
+  expense↔booking link, its migration, and 509 lines of Flutter tests — have
+  been sitting in `origin/budget-v2` unnoticed for a day. **A MERGED badge is
+  not evidence the code is on main**; when a stacked PR's base merges first,
+  retarget the child before merging and verify with
+  `git merge-base --is-ancestor <merge-commit> origin/main`.
+- **[dev] Writing a guard is not the same as having one.** The first draft of
+  the CI guard read `git ls-tree … -- src/packages/api/migrations/` from a job
+  whose `working-directory` is already `src/packages/api`, so the pathspec
+  matched nothing, `main_max` came back empty, and it **passed every case
+  including the one it existed to catch**. Caught only by testing it against a
+  deliberately-bad tree. A guard now fails closed when it cannot read main,
+  and it is exercised across four cases (no-op / gap-fill / correct next /
+  equal-to-max) under real `bash` — the local shell is zsh, which does not
+  word-split unquoted expansions and quietly hid a loop bug.
+
 ## 2026-08-14 — notification-center dogfooding (no way to clear)
 
 - **[app] Friction → fixed (Clear all + 45-day retention,
@@ -24,8 +66,10 @@ actually used > ideas that recur across ≥2 sessions**. Tag entries `[app]`
   "anything you've seen sticks around ~6 more weeks" is a guarantee
   expressible to a user — and `read_at IS NOT NULL` makes "unread never
   expires" structural rather than conventional. Hard delete, **no migration**,
-  which also kept the lane clear of the double-claimed 00058 slot (next free
-  is 00060).
+  which also kept the lane clear of the contested 00058 slot (that slot turned
+  out to be un-mergeable, not merely reserved — see the 08-14 migration entry
+  below; always derive the next number from
+  `ls src/packages/api/migrations | tail -1`).
 - **[dev] BREAKAGE (self-inflicted, caught before merge): a proxy check
   can confirm the absence of the very thing it was meant to prove.** I
   verified a revert-restore with `grep -c maybeWhen` — which matched the word

--- a/docs/parallel-dev.md
+++ b/docs/parallel-dev.md
@@ -77,11 +77,41 @@ template.
 | `lib/screens/trip_detail_screen.dart` | 31% of PRs | **≤ 1 lane per wave.** This 5,900-line god-screen is the throughput governor: beyond 3–4 lanes you usually can't find work that avoids it. | Should never conflict (single writer). |
 | `api/main.go` (buildRouter) | 30% | No constraint — any lane may add routes. | Trivial adjacent-line conflicts; take both, keep the route grouping. |
 | `app_en.arb` + `app_es.arb` | 45% of recent PRs | Each lane declares a unique key prefix (e.g. `tripBudget*`) in its manifest. | Take both key sets on the `.arb`s; **never** hand-edit `app_localizations*.dart` — regen LAST. |
-| `api/migrations/` | 15% | Numbers **reserved at wave planning** (`ls src/packages/api/migrations | tail -1` → next free). ≤ 1 migration per lane. CI guards duplicates, but reservation avoids the renumber round-trip. | Renumber per reservation; never merge two files onto one number. |
+| `api/migrations/` | 15% | Numbers **reserved at wave planning** (`ls src/packages/api/migrations \| tail -1` → next free). ≤ 1 migration per lane. A new number must be **strictly greater than main's highest** — never fill a gap (see §4a). CI guards duplicates and out-of-order numbers. | Renumber per reservation; never merge two files onto one number. |
 | `api/plan_tool_registry.go` | low freq, **high severity** | **≤ 1 tool-adding lane in flight.** Registry order = the Anthropic prompt-cache prefix; append-at-tail only. A reorder-merge silently destroys prompt caching — no test fails. Tool *implementations* in separate `plan_tools_*.go` files are parallel-safe. | Keep main's order byte-stable; re-append the new entry at the tail. |
 | `store/` (sqlc) | 19% | Never a planning constraint. | Regen, don't merge (§4). |
 | `lib/models/*.g.dart`, `lib/l10n/app_localizations*.dart` | — | Same. | Regen, don't merge (§4). |
 | `.env.sample`, `CLAUDE.md` | 15% / 9% | Append-only; no constraint. | Take both. |
+
+## 4a. Migration numbers only ever go up — 00058 is burned
+
+A migration number below the highest number **already deployed** can never be
+merged, no matter how long the gap has sat empty. `db.go` calls `goose.Up`
+without `WithAllowMissing`, so goose refuses any unapplied version below the
+database's current max (`found N missing migrations before current version M`),
+and `main.go` turns that into `log.Fatalf` — the API exits before binding its
+port and crash-loops with the previous container already replaced. It is a full
+outage, and the deploy only goes red ~5 minutes later.
+
+Nothing upstream catches it: the "Migrations apply from zero" CI job starts
+from an empty database, where any ordering is trivially valid, and the
+duplicate guard sees no collision because a gap-fill collides with nothing.
+That is why the **out-of-order guard** now runs in the same CI job — it is the
+only check that can see this class.
+
+**00058 is permanently burned.** Production applied 00057 → 00059 → 00060, so
+58 is forever below the floor. It is not a free slot; it is a hole. Do not
+"tidy up" the sequence by filling it, and do not enable `WithAllowMissing` to
+make it merge — that would trade one loud, zero-damage crash for silent
+order-dependent schema state across the whole repo.
+
+How the hole appeared, so it isn't repeated: PR #350 was stacked on PR #349's
+branch and merged **into that branch 47 minutes after the branch itself had
+already merged to main**. GitHub reports #350 as MERGED, but its commits —
+including `00058_expense_booking_link.sql` — only ever reached
+`origin/budget-v2`. **When a stacked PR's base merges first, retarget the child
+to `main` before merging it**, and check `git merge-base --is-ancestor
+<merge-commit> origin/main` rather than trusting the MERGED badge.
 
 ## 4. Regen-not-merge doctrine
 

--- a/specs/budget-v2/plan.md
+++ b/specs/budget-v2/plan.md
@@ -3,7 +3,9 @@
 > **HOW.** See `spec.md` for what/why. Repo conventions: `../../CLAUDE.md`,
 > `../../docs/zen.md`. Delivered as **two stacked PRs from one lane**
 > (`budget-v2`): PR A = tab promotion + read/refresh fixes, PR B =
-> autopopulate. Migration **00058** is reserved for PR B.
+> autopopulate. Migration **00058** was reserved for PR B — **that number is
+> now burned and PR B is unmerged**; see the PR B section below before
+> reviving it.
 
 ## Technical Approach
 
@@ -55,7 +57,20 @@ already claims.
 
 ## PR B — Autopopulate
 
-**Migration 00058** (`00058_expense_booking_link.sql`): `trip_expenses` +
+> **STATUS 2026-08-14: written but NOT on main.** PR #350 was merged into the
+> `budget-v2` branch 47 minutes after that branch had already merged to main,
+> so GitHub shows it MERGED while its commits live only on
+> `origin/budget-v2` / `origin/budget-v2-autopopulate` (and the local
+> `.claude/worktrees/budget-v2`). **Do not delete those refs — they are the
+> only copies.** To revive: rebase onto main (81+ commits of drift; 9 shared
+> files incl. `trip_detail_screen.dart`, plus l10n/`store/` which are
+> regen-not-merge) and **renumber the migration to the next free number above
+> main's highest** — 00058 can never be merged, because production has already
+> applied past it (see `docs/parallel-dev.md` §4a). The SQL body is additive
+> and needs no redesign.
+
+**Migration 00058** (`00058_expense_booking_link.sql` — number burned, renumber
+on revival): `trip_expenses` +
 nullable `source_kind text` + `source_id uuid` (no FK — snapshot pattern),
 CHECK both-or-neither, partial unique index
 `(trip_id, source_kind, source_id) WHERE source_kind IS NOT NULL`.

--- a/specs/budget-v2/tasks.md
+++ b/specs/budget-v2/tasks.md
@@ -12,7 +12,7 @@
 - [ ] `ship pr`
 
 ## PR B — Autopopulate on mark-booked (stacked on A)
-- [ ] Migration 00058 + queries + `make api-sqlc`
+- [ ] Migration (renumber above main's highest — **00058 is burned**) + queries + `make api-sqlc`
 - [ ] `budget_handler.go` upsert-by-source, PATCH auto-flip, `expense_added`
 - [ ] Go tests: link upsert + validation
 - [ ] Flutter: Expense fields, service params/ApiException, categories lift

--- a/specs/clear-notifications/plan.md
+++ b/specs/clear-notifications/plan.md
@@ -103,8 +103,8 @@ route ↔ caller ↔ status handling:
 - **Env vars:** none.
 - **Gateway:** `/api/v1/notifications` already proxies; DELETE needs no extra
   nginx config.
-- **Migrations:** none — deliberately (00058 is double-claimed by in-flight
-  reservations; this feature stays out of that lane entirely).
+- **Migrations:** none — deliberately (00058 was contested at the time and has
+  since been permanently burned; see `docs/parallel-dev.md` §4a).
 
 ## Verification
 

--- a/specs/uptime-history/plan.md
+++ b/specs/uptime-history/plan.md
@@ -35,7 +35,8 @@ percentage.
 `src/packages/api/`:
 
 - **Migration** `migrations/00059_health_samples.sql` — 00059 because
-  `00058_expense_booking_link.sql` is reserved by the in-flight `budget-v2` lane. Table
+  `00058_expense_booking_link.sql` was reserved by the `budget-v2` lane (that lane never
+  reached main and 00058 is now permanently burned — `docs/parallel-dev.md` §4a). Table
   `health_samples`: `observed_at` PK, `covers_from`, `kind` (`tick`|`gap`), `release`,
   `gap_cause`, and the three nullable booleans, with CHECK constraints binding the columns to
   the kind so a malformed row cannot exist.

--- a/specs/work-style/plan.md
+++ b/specs/work-style/plan.md
@@ -15,9 +15,9 @@ plan-chat integration is an explicit new branch in `personalizedSystemPrompt`
 (field enumeration there is deliberate; nothing flows automatically), with a
 behavioral note per value modeled on the existing home-airport note.
 
-**Migration number: `00060`.** 00058 is reserved by `specs/ios-app-store/`
-(plan.md:67); 00059 shipped with uptime-history; no open PR claims anything
-higher.
+**Migration number: `00060`.** 00059 shipped with uptime-history; no open PR
+claims anything higher. (00058 was skipped as reserved; it is now permanently
+burned — see `docs/parallel-dev.md` §4a.)
 
 **Prompt-cache:** adding a property to `savePrefsTool` changes the tools-block
 bytes → one-time cache invalidation (acceptable, same as every prior field).


### PR DESCRIPTION
## Summary

The 00058 migration gap was **a latent production outage, not a stale reservation** — and every existing check would have waved it through.

- `db.go` calls `goose.Up` without `WithAllowMissing`, so goose refuses any unapplied version below the database's current max (`found N missing migrations before current version 60`), and `main.go` escalates that to `log.Fatalf`. Reproduced end-to-end against a prod-shaped throwaway Postgres: the API **exits ~25 ms into boot, never binds :8080**, and under `restart: unless-stopped` — with the previous container already replaced by `docker compose up -d` — it crash-loops. Full API outage; the deploy only goes red ~5 minutes later, and there is no auto-rollback.
- **Nothing upstream catches it.** "Migrations apply from zero" runs against an empty database where 58 sorts happily between 57 and 59 (verified: `OK 00058_expense_booking_link.sql`, exit 0), and the duplicate guard finds no collision because filling a gap collides with nothing. A doomed PR goes green and dies on deploy.

### What this changes

- **New CI step, `Guard against out-of-order migration numbers`** (same job as the duplicate guard): every migration a branch *adds* must sort strictly above main's highest. It **fails closed** if it cannot read main's tree.
- **`docs/parallel-dev.md` §4a** — migration numbers only ever go up; **00058 is permanently burned** (production applied 00057 → 00059 → 00060, so 58 is forever below the floor). Explicitly warns against "tidying up" the sequence and against enabling `WithAllowMissing`, which would trade one loud, zero-damage crash for silent order-dependent schema state repo-wide.
- **Every stale claim corrected** — `specs/budget-v2` (plan + tasks), `specs/uptime-history`, `specs/work-style`, `specs/clear-notifications`, and a wrong "next free is 00060" line in the friction log.

### Why the hole exists (the real root cause)

PR #350 (`budget-v2-autopopulate`) was merged into branch `budget-v2` **47 minutes after `budget-v2` itself merged to main**. GitHub reports #350 as MERGED, but its merge commit `c16939c` is not an ancestor of main and the feature is absent from main (`git grep source_kind` → nothing). So ~1,357 lines of finished work — the expense↔booking link, its migration, and 509 lines of Flutter tests — live only on `origin/budget-v2` / `origin/budget-v2-autopopulate`.

**Those refs must not be pruned as "merged branches" — they are the only copies.** `specs/budget-v2/plan.md` now carries revival instructions. A MERGED badge is not evidence the code is on main; verify with `git merge-base --is-ancestor <merge-commit> origin/main`.

## Testing

- Guard script extracted from `ci.yml` and executed under **real bash** against four cases: unchanged tree (pass, reads `main_max=00060`), gap-fill 00058 (**fail**, the exact hazard), correct 00061 (pass), and equal-to-max 00060 (fail).
- The first draft was **broken and silently passed everything** — its `git ls-tree` pathspec was resolved relative to the job's `working-directory` (`src/packages/api`), so `main_max` came back empty. Caught only by testing against a deliberately-bad tree; the guard now fails closed on that condition. Local shell is zsh, which does not word-split unquoted expansions, so the loop was rewritten as `while IFS= read -r` and re-verified under bash.
- `ci.yml` parses as valid YAML; the migrations job now lists three steps in order.
- No migration is added or renamed by this PR, so the new guard is a no-op on itself (verified: "no migrations added against main").

🤖 Generated with [Claude Code](https://claude.com/claude-code)
