### PR TITLE
feat(flutter): float the brand rose on neutral surfaces, keep the plate on teal

### DIFF
--- a/src/packages/api/print_view_handler.go
+++ b/src/packages/api/print_view_handler.go
@@ -248,7 +248,16 @@ var printViewTmpl = template.Must(template.New("print-view").Parse(`<!DOCTYPE ht
       font-size: 0.8rem; letter-spacing: 0.08em; text-transform: uppercase;
       opacity: 0.85; margin: 0 0 6px; display: flex; align-items: center; gap: 10px;
     }
-    header .brand img { height: 22px; width: 22px; border-radius: 5px; }
+    header .brand img {
+      /* White plate behind the teal rose (the icon PNG is transparent), same
+         treatment as the in-app BrandBadge; box-sizing is border-box, so grow
+         the box to keep an 18px glyph. print-color-adjust keeps the plate in
+         print output, where backgrounds are stripped by default. */
+      height: 26px; width: 26px; padding: 4px;
+      background: rgba(255, 255, 255, 0.92);
+      border-radius: 5px;
+      -webkit-print-color-adjust: exact; print-color-adjust: exact;
+    }
     header h1 { margin: 0; font-size: 1.7rem; }
     header .meta { margin: 8px 0 0; opacity: 0.9; font-size: 0.95rem; }
     main { max-width: 820px; margin: 0 auto; padding: 28px 24px 56px; }

--- a/src/packages/flutter-app/lib/screens/app_shell.dart
+++ b/src/packages/flutter-app/lib/screens/app_shell.dart
@@ -131,9 +131,10 @@ const List<Widget> _tabRoots = [
 ];
 
 /// The Anemos brand mark for the top of the rail — the persistent
-/// Site ID (Krug). The horseshoe mark on a light badge so it fits the narrow
-/// rail and the black/gold artwork reads on the surface. Tapping it goes Home,
-/// per the universal logo-links-home convention.
+/// Site ID (Krug). Bare mark: the teal/gold rose reads on the rail surface in
+/// both themes, so no badge plate; the InkWell supplies the hover/focus
+/// highlight and web pointer cursor. Tapping it goes Home, per the universal
+/// logo-links-home convention.
 class _RailBrand extends ConsumerWidget {
   const _RailBrand();
 
@@ -141,10 +142,19 @@ class _RailBrand extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     return Padding(
       padding: const EdgeInsets.only(top: AppSpacing.lg, bottom: AppSpacing.sm),
-      child: BrandBadge(
-        padding: const EdgeInsets.all(AppSpacing.sm),
-        onTap: () => goHome(ref),
-        child: const BrandLogo.mark(size: 36),
+      child: Semantics(
+        button: true,
+        child: Material(
+          type: MaterialType.transparency,
+          child: InkWell(
+            onTap: () => goHome(ref),
+            borderRadius: AppRadius.mdAll,
+            child: const Padding(
+              padding: EdgeInsets.all(AppSpacing.sm),
+              child: BrandLogo.mark(size: 36),
+            ),
+          ),
+        ),
       ),
     );
   }

--- a/src/packages/flutter-app/lib/screens/landing_screen.dart
+++ b/src/packages/flutter-app/lib/screens/landing_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../constants/app_info.dart';
 import '../l10n/l10n.dart';
 import '../providers/analytics_provider.dart';
 import '../theme/app_colors.dart';
@@ -227,15 +228,34 @@ class _LandingHero extends StatelessWidget {
                   mainAxisAlignment: MainAxisAlignment.center,
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    BrandBadge(
-                      padding: narrow
-                          ? const EdgeInsets.symmetric(
-                              horizontal: AppSpacing.md,
-                              vertical: AppSpacing.sm)
-                          : const EdgeInsets.symmetric(
-                              horizontal: AppSpacing.lg,
-                              vertical: AppSpacing.md),
-                      child: BrandLogo.lockup(height: narrow ? 72 : 132),
+                    // Bare mark + white wordmark floating on the scrimmed
+                    // photo, matching the auth screen's plateless mark. The
+                    // lockup PNG's baked-in charcoal wordmark needed the
+                    // white badge plate; white Playfair text does not.
+                    BrandLogo.mark(size: narrow ? 52 : 96),
+                    const SizedBox(height: AppSpacing.sm),
+                    ExcludeSemantics(
+                      // The mark's Image already carries the "Anemos"
+                      // semantic label.
+                      child: Text(
+                        AppInfo.name,
+                        style: TextStyle(
+                          fontFamily: 'Playfair Display',
+                          fontWeight: FontWeight.w600,
+                          fontSize: narrow ? 26 : 44,
+                          height: 1.1,
+                          letterSpacing: 0.5,
+                          color: Colors.white,
+                          // Guards the scrim's lighter top-right corner
+                          // (alpha 0.35) against bright photo patches.
+                          shadows: const [
+                            Shadow(
+                                color: Colors.black26,
+                                blurRadius: 8,
+                                offset: Offset(0, 2)),
+                          ],
+                        ),
+                      ),
                     ),
                     const SizedBox(height: AppSpacing.lg),
                     Text(

--- a/src/packages/flutter-app/lib/widgets/brand_logo.dart
+++ b/src/packages/flutter-app/lib/widgets/brand_logo.dart
@@ -9,11 +9,12 @@ import '../theme/spacing.dart';
 /// - [BrandLogo.lockup] — the full rose + "Anemos" wordmark image, for spots
 ///   with horizontal room (app-bar titles).
 /// - [BrandLogo.mark] — the rose icon only, for tight spots (nav rail,
-///   hero badge).
+///   landing hero).
 ///
-/// The artwork is teal + gold on a transparent background, so it needs a light
-/// surface behind it on teal app bars / dark photos. Wrap either form in
-/// [BrandBadge] for that.
+/// The artwork is teal + gold on a transparent background. It floats bare on
+/// page surfaces and scrimmed imagery (auth screen, nav rail, landing hero);
+/// only on flat teal chrome — gradient app bars, the splash field — does the
+/// teal rose need a light plate behind it. Wrap in [BrandBadge] there.
 class BrandLogo extends StatelessWidget {
   static const String _lockupAsset = 'assets/images/anemos_logo.png';
   static const String _markAsset = 'assets/images/anemos_mark.png';
@@ -22,13 +23,13 @@ class BrandLogo extends StatelessWidget {
   final double _height;
   final bool _isLockup;
 
-  /// Full lockup (horseshoe mark + wordmark), sized by [height].
+  /// Full lockup (wind-rose mark + wordmark), sized by [height].
   const BrandLogo.lockup({super.key, double height = 36})
       : _asset = _lockupAsset,
         _height = height,
         _isLockup = true;
 
-  /// Horseshoe mark only, rendered as a [size]×[size] square.
+  /// Wind-rose mark only, rendered as a [size]×[size] square.
   const BrandLogo.mark({super.key, double size = 28})
       : _asset = _markAsset,
         _height = size,
@@ -50,10 +51,10 @@ class BrandLogo extends StatelessWidget {
   }
 }
 
-/// "A" monogram stand-in for the horseshoe mark when the image asset is
+/// "A" monogram stand-in for the wind-rose mark when the image asset is
 /// unavailable. Fills the same [size]×[size] square the icon glyph did, so
-/// layout is identical either way, and uses the same black-on-light palette
-/// as the artwork (it sits on a light [BrandBadge] surface).
+/// layout is identical either way. Its own black87 tile keeps it readable on
+/// any surface — badge plate or bare page background alike.
 class _MonogramFallback extends StatelessWidget {
   final double size;
   const _MonogramFallback({required this.size});
@@ -110,8 +111,8 @@ class _WordmarkFallback extends StatelessWidget {
   }
 }
 
-/// A light rounded surface that lets the black/gold [BrandLogo] read on teal
-/// app bars and dark hero imagery.
+/// A light rounded surface that lets the teal/gold [BrandLogo] read on flat
+/// teal chrome (gradient app bars, the splash field).
 class BrandBadge extends StatelessWidget {
   final Widget child;
   final EdgeInsetsGeometry padding;

--- a/src/packages/flutter-app/test/logo_home_nav_test.dart
+++ b/src/packages/flutter-app/test/logo_home_nav_test.dart
@@ -5,10 +5,11 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:travel_route_planner/navigation/app_nav.dart';
 import 'package:travel_route_planner/widgets/brand_logo.dart';
 
-/// Logo-links-home: the brand badge is tappable when given onTap (rail brand
-/// and Home app bar), and goHome mirrors the shell's tab-select behavior
-/// (selectTab): land on the Home ROOT — the Home stack is popped to its root
-/// whether the tap switches tabs or Home is already active.
+/// Logo-links-home: the brand badge is tappable when given onTap (Home app
+/// bar; the rail brand is a bare mark with its own InkWell, pinned in
+/// nav_tab_reset_test.dart), and goHome mirrors the shell's tab-select
+/// behavior (selectTab): land on the Home ROOT — the Home stack is popped to
+/// its root whether the tap switches tabs or Home is already active.
 void main() {
   testWidgets('BrandBadge with onTap fires the callback',
       (WidgetTester tester) async {

--- a/src/packages/flutter-app/test/nav_tab_reset_test.dart
+++ b/src/packages/flutter-app/test/nav_tab_reset_test.dart
@@ -11,6 +11,7 @@ import 'package:travel_route_planner/providers/live_trip_provider.dart';
 import 'package:travel_route_planner/providers/resumable_chats_provider.dart';
 import 'package:travel_route_planner/providers/trips_provider.dart';
 import 'package:travel_route_planner/screens/trip_detail_screen.dart';
+import 'package:travel_route_planner/widgets/brand_logo.dart';
 
 import 'support/url_sync_fakes.dart';
 
@@ -107,6 +108,23 @@ void main() {
     // Pop-before-switch: the stacked page's didPop drains while Trips is
     // still the active tab, so '/preferences' never reaches the address bar.
     expect(reports.sublist(reportsAfterTrips), isNot(contains('/preferences')));
+  });
+
+  testWidgets('the rail brand mark taps through to the Home root',
+      (tester) async {
+    // Logo-links-home through the real rail: the brand mark at the top of the
+    // rail is a bare BrandLogo with its own InkWell (no BrandBadge plate), so
+    // pin that the tap surface survived the plate's removal.
+    final container = await pumpApp(tester);
+
+    await tester.tap(railDestination('Trips'));
+    await tester.pumpAndSettle();
+    expect(container.read(navIndexProvider), AppTab.trips.index);
+
+    await tester.tap(find.descendant(
+        of: find.byType(NavigationRail), matching: find.byType(BrandLogo)));
+    await tester.pumpAndSettle();
+    expect(container.read(navIndexProvider), AppTab.home.index);
   });
 
   testWidgets('re-tapping the active Trips tab pops it to root',


### PR DESCRIPTION
## Summary
- Remove the white `BrandBadge` tile behind the logo on neutral surfaces, matching the login screen's floating mark: the nav rail now shows the bare rose in a transparent InkWell (hover/focus highlight is visible now instead of hidden behind the opaque plate; tap-to-home kept), and the landing hero swaps the badged lockup PNG for the bare mark + a white Playfair "Anemos" wordmark (the lockup's baked-in charcoal text needed the plate; white text doesn't).
- Keep the badge where it does real contrast work on flat teal chrome: landing/home gradient app bars and every splash surface are untouched, and `brand_logo.dart`'s docs now state that policy explicitly (also drops leftover "horseshoe" naming from before the Anemos rename).
- Fix the inverse bug in the print/export header, which rendered the transparent icon straight onto the teal gradient — it gets the same white plate via CSS, with `print-color-adjust: exact` so the plate survives print output.
- New widget test pins the rail's plateless tap path (rail rose tap lands on the Home root).

## Testing
- `flutter analyze` clean (3 pre-existing infos in an untouched file); full `flutter test` suite passes (1054 tests), including the landing fold assertions and the new rail-tap test.
- `go build ./... && go vet ./... && go test ./...` pass in `src/packages/api`.
- Verified in the lane's dev stack (headless Chrome, port 3003): landing hero at 1440px and 375px shows the floating rose + white wordmark with CTAs above the fold; signed-in rail shows the bare mark in both dark and light themes with a visible hover highlight, and clicking it navigates `/trips` → `/`; the narrow home app bar keeps its badge; the print header CSS was rendered against the real transparent icon to confirm the plate (the dev gateway serves that icon path empty — prod serves the real PNG).

🤖 Generated with [Claude Code](https://claude.com/claude-code)