### PR TITLE
docs(spec): commit the iOS App Store v1 spec (migration reservation off burned 00058)

### DIFF
--- a/specs/ios-app-store/plan.md
+++ b/specs/ios-app-store/plan.md
@@ -1,0 +1,183 @@
+# Plan: iOS App Store v1
+
+> **HOW.** Full audit + program roadmap: the approved plan of 2026-08-13
+> (3-agent audit; Apple-side program in Workstream A there is Brian-side and
+> not repeated here). Repo conventions: see `../../CLAUDE.md` and
+> `../../docs/parallel-dev.md`.
+
+## Technical Approach
+
+Five lanes over two waves. The through-line, per `docs/zen.md`: every place
+the web app *implied* its identity from the browser page (origin from
+`Uri.base`, SSO return via same-tab navigation, deep links via the URL bar)
+gets an **explicit** replacement (a `PUBLIC_BASE_URL` define, a server-chosen
+callback scheme, OS-delivered links normalized into the existing router).
+Web behavior stays byte-identical — the proof is that no web build config
+changes.
+
+Key decisions:
+
+1. **SSO return leg: in-app web-auth session (`flutter_web_auth_2`), not
+   native SSO plugins.** Reuses the entire server flow + `SsoCallbackScreen`
+   + `POST /auth/sso/exchange` unchanged; guideline 4.8 is satisfied by
+   offering Sign in with Apple (Hide My Email works through the web flow).
+   Native `sign_in_with_apple` sheet is a documented fast-follow only if
+   review objects; nuclear fallback: hide Google on iOS.
+2. **`platform=ios` is a server-validated enum, not a redirect URL.** The
+   callback scheme `goldentempo://` is hardcoded server-side — the platform
+   param can never become an open redirect. Anything outside `{"", "ios"}`
+   is a 400.
+3. **Universal links feed the existing router.** `app_links` (uni_links is
+   deprecated) delivers URIs; a pure normalizer maps them to the same route
+   strings the web engine produces; `generateInitialRoutes` /
+   `parseBootTarget` are untouched (one grammar, N sources).
+4. **Build identity:** marketing version `1.0.0` via `--build-name`; build
+   number `git rev-list --count HEAD` (monotonic, 1:1 with main commits);
+   uploads tagged `ios/1.0.0+<N>`. pubspec and the web SHA release identity
+   untouched.
+5. **CI: unsigned compile canary only** (dispatch + weekly macOS job). v1
+   uploads are local `make flutter-build-ipa` + Transporter.
+
+## Go API Changes
+
+`src/packages/api/`:
+
+- **`google_auth_handler.go`** — `googleStartHandler`: read `platform`,
+  reject ∉ {"", "ios"}; state cookie value becomes
+  `state + "." + verifier + "." + platform` (parse with `SplitN(…, ".", 3)`,
+  tolerating the legacy 2-field form during the deploy window).
+  `googleCallbackHandler`: success and error redirects go through a new
+  shared `ssoFinishURL(platform, codeOrError)` → `goldentempo://sso/<…>` for
+  ios, `publicAppURL("sso/", …)` otherwise.
+- **`apple_auth_handler.go`** — same, cookie gains a platform field (today
+  bare state); the 303-after-form_post to a custom scheme is intercepted
+  fine by the auth session. Also: persist the Apple refresh token on every
+  successful sign-in (latest wins).
+- **`apple_oauth.go`** — `exchangeAppleCode` (~line 171) currently keeps only
+  `id_token`; also capture `refresh_token`. New `revokeAppleToken(ctx, token)`
+  posting `client_id` + ES256 client secret + `token` +
+  `token_type_hint=refresh_token` to `APPLE_REVOKE_URL` (default
+  `https://appleid.apple.com/auth/revoke`; env seam = fake-Apple test route).
+- **`account_handler.go`** — `deleteAccountHandler` (~line 161): before
+  `DeleteUser`, if the user has an apple identity with a stored refresh
+  token, call `revokeAppleToken`; log-and-continue on failure (explicitly
+  silenced, per zen: deletion must never depend on Apple availability).
+- **`auth_handler.go`** — `UserResponse` gains `has_password bool` populated
+  via the existing `hasPassword(u)`.
+- **Migration `<next>_apple_refresh_token.sql`** — take the next free number
+  at lane time (`ls src/packages/api/migrations | tail -1`); **00058 is
+  permanently burned** and must never be used (`docs/parallel-dev.md` §4a):
+  `ALTER TABLE auth_identities ADD COLUMN refresh_token text;` (nullable).
+- **`query/auth_identities.sql`** — add `SetAuthIdentityRefreshToken` +
+  `GetAuthIdentityForUserByProvider`; `make api-sqlc`.
+- **Routes:** none added or changed in `main.go`.
+
+## Flutter Changes
+
+`src/packages/flutter-app/`:
+
+- **`lib/constants/public_origin.dart` (new)** — `PUBLIC_BASE_URL` define;
+  resolution: define wins → else the page's own origin (web) → else `''` +
+  debug assert (a native build missing the define dies on first
+  `flutter run`). Pure `resolvePublicOrigin(...)` core for tests.
+  Converted call sites: `lib/utils/share_link.dart` (`shareUrl`, `_exportUrl`),
+  `lib/widgets/legal_links.dart` (localhost fallback deleted), both SSO
+  buttons; `lib/screens/connect_app_screen.dart:81` gains
+  `LaunchMode.externalApplication` off-web.
+- **`lib/services/sso_web_auth.dart` (new)** — thin provider seam over
+  `FlutterWebAuth2.authenticate(url: '$base/auth/<p>?platform=ios',
+  callbackUrlScheme: 'goldentempo')` so button widget tests fake it. Buttons:
+  web path unchanged; native path pushes `/sso/<code>` so `SsoCallbackScreen`
+  does exchange/adopt exactly as web. Cancellation swallowed.
+- **`lib/navigation/incoming_links.dart` (new)** — pure
+  `normalizeIncomingLink(Uri)`:
+  `https://goldentempotravel.com/app/<rest>` → `/<rest>`;
+  `goldentempo://sso/<c>` → `/sso/<c>`; else null. Cold start:
+  `AppLinks().getInitialLink()` → `MaterialApp.initialRoute` (null on web).
+  Warm: `uriLinkStream` pushes token routes
+  (`share|invite|reset|verify|sso|connect`) on a new root `navigatorKey`
+  (`lib/main.dart`, currently unset). Warm grammar paths ignored in v1
+  (documented).
+- **`lib/providers/dictation_provider.dart:28`** —
+  `fallback: kIsWeb ? RecorderEngine(...) : null` (the recorder engine is
+  web-shaped and hard-fails if ever selected on iOS).
+- **User model** — add `hasPassword` with `@JsonKey(name: 'has_password',
+  defaultValue: false)`; `make flutter-build-models`. Default-false rationale
+  (zen: worst failure mode chosen explicitly): a stale cached snapshot
+  without the field renders the passwordless dialog, and the server still
+  enforces password verification — one retriable error, never the blocked
+  deletion the old behavior caused.
+- **`lib/screens/account_settings_screen.dart`** — `_DeleteAccountDialog`
+  (~407–418): password field + non-empty gate only when `hasPassword`;
+  otherwise plain confirm with `settingsDeleteSsoBody` copy (en+es).
+- **AI disclosure** — one-time pre-first-send notice in the chat composer
+  flow (`lib/widgets/chat_panel.dart` + a small new widget), acknowledged
+  flag in shared_preferences; arb prefix `chatAiDisclosure*`.
+- **iOS shell** (`ios/`): bundle ID `com.goldentempo.travel` everywhere
+  (pbxproj ~371/550 + RunnerTests); delete legacy
+  `CODE_SIGN_IDENTITY "iPhone Developer"` (~335); `TARGETED_DEVICE_FAMILY=1`
+  (~353/479/532); `CODE_SIGN_ENTITLEMENTS` → new `Runner/Runner.entitlements`
+  (`applinks:` + `webcredentials:` goldentempotravel.com); `DEVELOPMENT_TEAM`
+  left unset with comment (fills post-enrollment). `Info.plist`:
+  `NSPhotoLibraryUsageDescription`, `ITSAppUsesNonExemptEncryption=false`,
+  `CFBundleLocalizations` [en, es], `CFBundleURLTypes` (`goldentempo`).
+  Icons: `flutter_launcher_icons` seeded from `web/icons/Icon-512.png`
+  (1024², mark-only), `remove_alpha_ios: true` onto `#00695C`; commit the
+  appiconset. `pod install` → commit `ios/Podfile.lock`.
+- **New deps:** `flutter_web_auth_2` (L3), `app_links` (L4),
+  `flutter_launcher_icons` dev-dep (L1).
+
+## Contract Parity  ← anti-drift gate
+
+| JSON key | Go type | Dart type | Nullable? | ✓ |
+|----------|---------|-----------|-----------|---|
+| `has_password` | `bool` (`UserResponse`, `auth_handler.go`) | `bool` (`@JsonKey(defaultValue: false)`) | no (absent → false) | ☐ |
+
+Redirect contract (not JSON, pinned by Go integration tests + Dart widget
+tests): `platform=ios` ⇒ callback `Location` is
+`goldentempo://sso/<code>` on success and `goldentempo://sso/error` on
+failure; empty platform ⇒ byte-identical `publicAppURL("sso/", …)`; any other
+platform value ⇒ 400 at start.
+
+## Cross-cutting
+
+- **Env vars:** `APPLE_REVOKE_URL` (test seam, default Apple's real endpoint)
+  → `.env.sample`. No other new server config.
+- **Dart defines (native builds only):**
+  `API_BASE_URL=https://goldentempotravel.com/api/v1`, `APP_BASE_PATH=/app/`,
+  `PUBLIC_BASE_URL=https://goldentempotravel.com` — carried exclusively by
+  new Makefile targets `flutter-build-ipa` / `flutter-run-ios` (never
+  hand-typed). Web builds unchanged.
+- **Gateway:** AASA file committed under `dockerize/deployment/nginx/` +
+  exact-match location for `/.well-known/apple-app-site-association`
+  (`app-locations.conf` reserves the path, ~line 113); JSON content-type, no
+  redirect; `appIDs: ["TEAMID.com.goldentempo.travel"]` with `TEAMID`
+  placeholder (single post-enrollment edit + redeploy); include
+  `webcredentials` block. Verify whether `dockerize/production/nginx` shares
+  the snippet.
+- **CI:** new `.github/workflows/ios.yml` — `workflow_dispatch` + weekly
+  cron, `macos-15`, flutter pinned 3.35.4,
+  `flutter build ios --release --no-codesign` with the three prod defines.
+  Not wired into the deploy chain.
+
+## Verification
+
+(Mirrored into `tasks.md`; per-lane detail lives there.)
+
+- Go: extend `google_auth_integration_test.go` /
+  `apple_auth_integration_test.go` (fake seams exist) for the platform
+  matrix; fake-Apple gains an `/auth/revoke` recorder; delete-account
+  matrix (apple user → exactly 1 revoke + 204; email → 0; revoke-500 →
+  deletion still succeeds); `has_password` asserted in login/me payloads.
+- Flutter: `test/public_origin_test.dart` pure matrix; share/export/legal
+  URL tests in the VM env (where `Uri.base` is `file:` — exactly the iOS
+  failure mode); `test/incoming_links_test.dart` mirroring every path in
+  `deep_link_initial_routes_test.dart` + `/app/`-prefixed + scheme forms,
+  re-asserting the single-initial-route invariant; delete-dialog widget test
+  both variants; SSO button tests with the faked web-auth seam.
+- Device (TestFlight) checklist: email signup + verify link; Google + Apple
+  sign-in incl. Hide My Email; share/invite cold+warm; both password-reset
+  paths; legal links; photo attach permission prompt; dictation;
+  background-mid-stream graceful failure; map/offline/print/.ics; deletion
+  for both account kinds (revocation in server log); Spanish locale; dark
+  mode.

--- a/specs/ios-app-store/spec.md
+++ b/specs/ios-app-store/spec.md
@@ -1,0 +1,135 @@
+# Spec: iOS App Store v1
+
+> **WHAT & WHY only.** Tech choices, file names, and libraries live in
+> `plan.md`.
+
+## Context
+
+Golden Tempo Travel has only ever shipped as a web app. Being on the iOS App
+Store is how a consumer travel product reaches most of its users, and the
+founder's own dogfooding (the product north star) happens mostly away from a
+desk. An audit (2026-08-13) found the app's core — chat, maps, trips, offline
+cache, dictation — already works natively; what's missing is the iOS shell
+(identity, icons, permissions), a working sign-in round trip, working links
+(share/legal/deep links currently assume a browser page origin), and a handful
+of App Review compliance requirements. This spec covers the smallest
+review-passing v1. Apple Developer enrollment (Organization, Golden Tempo LLC)
+runs in parallel; everything here except final signing and store setup is
+buildable before it completes.
+
+## User Stories
+
+- As a **traveler**, I want to install Golden Tempo Travel from the App Store
+  on my iPhone so that I can plan and check my trips without a browser.
+- As an **iPhone user**, I want Google/Apple sign-in to finish inside the app
+  so that I end up signed in where I started.
+- As a **trip owner**, I want share and invite links I send from the app to be
+  real absolute links, and links I receive to open the app directly.
+- As a **signed-in user without a password** (Google/Apple-only), I want to
+  delete my account from the app, which today wrongly demands a password.
+- As a **chat user**, I want to be told once that my messages are processed by
+  an AI provider before I start chatting (App Review requires this).
+
+## Acceptance Criteria
+
+- [ ] The app installs and runs on a physical iPhone with the Golden Tempo
+      icon, name, and branded launch screen; Spanish devices get the Spanish UI.
+- [ ] Google and Apple sign-in complete inside an in-app authentication sheet
+      and land the user signed in on the home screen; cancelling the sheet is
+      silent. Web sign-in behavior is byte-identical to today.
+- [ ] Trip share, invite, print, calendar-export, and Privacy/Terms links
+      opened or shared from the iOS app are absolute `https://goldentempotravel.com`
+      URLs (no relative paths, no localhost).
+- [ ] Tapping a share, invite, verify-email, or password-reset link on iPhone
+      opens the app (installed) at the right screen — cold start and warm.
+- [ ] Attaching a photo in chat prompts with a purpose-specific photo-library
+      permission message and works; dictation uses native speech recognition.
+- [ ] An account with no password can delete itself from the app with a plain
+      confirmation; an account with a password is still password-gated. On web
+      too (this is a live web bug).
+- [ ] Deleting an account that signed in with Apple revokes its Apple tokens
+      server-side; Apple being unreachable never blocks the deletion.
+- [ ] Before a user's first chat message on any platform, a one-time notice
+      states messages are processed by our AI provider; it never reappears
+      after acknowledgment.
+- [ ] A release build can be produced with one make target and uploaded to
+      TestFlight; every reviewer-visible URL in the binary resolves.
+
+## API Surface
+
+### `GET /api/v1/auth/google` and `GET /api/v1/auth/apple` (changed)
+- **Purpose:** start SSO; now aware of native callers.
+- **Request:** optional `platform` query param. Only the empty value and `ios`
+  are accepted; anything else is rejected as a bad request (refuse the
+  temptation to guess).
+- **Response:** unchanged redirect dance, except the final redirect for
+  `platform=ios` targets the app's own callback scheme with the same one-time
+  handoff code (or the literal `error`). The scheme is fixed server-side; the
+  caller cannot choose a redirect target.
+- **Errors:** unchanged; error outcomes also ride the platform-appropriate
+  redirect.
+
+### `DELETE /api/v1/auth/account` (changed behavior, same contract)
+- **Purpose:** unchanged. For accounts with an Apple identity, the server now
+  also revokes the stored Apple token before deleting. Revocation failure is
+  logged, never surfaced, and never blocks deletion.
+
+### Authenticated user payload (changed)
+- **Purpose:** the client must know whether the account has a password —
+  today it guesses (and guesses wrong for SSO-only users).
+- **Response:** gains an explicit boolean stating whether a password exists.
+
+## Data Model
+
+- **Apple identity** — gains an optional stored refresh token, captured at
+  sign-in (latest sign-in wins), existing only to make account-deletion
+  revocation possible. Absent for Google/email identities and for Apple
+  identities created before this change (revocation is then skipped).
+
+## UI Behavior
+
+- **Sign-in (iOS):** Google/Apple buttons open the system in-app auth sheet;
+  on success the app shows the same completion screen as web, then home.
+- **Account settings → Danger zone:** delete dialog shows the password field
+  only when the account has a password; otherwise a plain confirm with copy
+  explaining the deletion is immediate and irreversible.
+- **Chat:** first-ever send is preceded by a one-time AI-processing notice
+  with an acknowledge action; acknowledging proceeds with the send.
+- **Incoming links (iOS):** open the same screens the web routes show; links
+  the app can't handle open in the browser as today.
+
+## Edge Cases & Error States
+
+- SSO sheet cancelled → no error UI, stay on the auth screen.
+- Handoff code expired (60s) or already used → same error screen web shows.
+- Apple revocation endpoint down during deletion → deletion succeeds; failure
+  logged server-side.
+- Stale cached user snapshot lacking the password flag → treated as
+  passwordless in the dialog; the server still enforces password verification,
+  so the worst case is one retriable error, never a blocked deletion.
+- Link for a screen requiring auth opened while signed out → existing web
+  behavior (auth screen first).
+- App backgrounded mid-chat-stream → stream may die; the existing manual
+  retry affordance is the v1 answer (documented limitation).
+
+## Out of Scope (v1 cut line)
+
+- Native GPS for "near me" (manual entry fallback ships; keeps the privacy
+  label at "Location: not collected").
+- Client crash reporting, map tile cache, in-app print/calendar polish
+  (Safari bounce ships), stream auto-resume after backgrounding.
+- iPad targeting (iPhone-only v1; compatibility mode covers iPad), iPad
+  drag-drop.
+- Native Sign in with Apple sheet (the in-app web-session flow ships;
+  fast-follow only if review objects).
+- Hover-only control visibility on touch — promoted only if device dogfooding
+  shows a core action unreachable.
+- CI-driven signing/TestFlight upload (local build + upload ships).
+- Push notifications, payments/IAP (none exist; nothing to declare).
+
+## Open Questions
+
+None blocking implementation. Two values arrive mid-flight from enrollment
+(Apple Team ID for the site-association file; signing team in the project) —
+both are placeholder-then-fill steps listed in `tasks.md`, not design
+decisions.

--- a/specs/ios-app-store/tasks.md
+++ b/specs/ios-app-store/tasks.md
@@ -1,0 +1,139 @@
+# Tasks: iOS App Store v1
+
+> Dependency-ordered. `[P]` = parallel-safe. Lanes below; Brian-side
+> (enrollment/store) items live in the approved roadmap, not here — except
+> where a code task blocks on them (marked ⏳ enrollment).
+
+## L1 `ios-scaffold`
+
+- [ ] pbxproj: bundle ID → `com.goldentempo.travel` (all configs incl.
+      RunnerTests); delete legacy `CODE_SIGN_IDENTITY`; `TARGETED_DEVICE_FAMILY=1`;
+      `CODE_SIGN_ENTITLEMENTS`; `DEVELOPMENT_TEAM` unset + comment
+- [ ] New `ios/Runner/Runner.entitlements` (applinks + webcredentials)
+- [ ] Info.plist: `NSPhotoLibraryUsageDescription`,
+      `ITSAppUsesNonExemptEncryption=false`, `CFBundleLocalizations` [en, es],
+      `CFBundleURLTypes` (`goldentempo` scheme)
+- [x] Icons: DONE early by the Phase-B brand lane (PR #374, 2026-08-13):
+      `flutter_launcher_icons` dev-dep seeded from `web/icons/Icon-maskable-512.png`
+      (wind rose on WHITE — the planned `#00695C` background was dropped
+      because the new rose is teal-on-teal against it), appiconset committed
+- [ ] `dictation_provider.dart`: `fallback: kIsWeb ? RecorderEngine(...) : null`
+      + widget test (no fallback engine off-web)
+- [ ] `pod install` → commit `ios/Podfile.lock` (host needs CocoaPods installed)
+- [ ] New `.github/workflows/ios.yml` (dispatch + weekly, macos-15, 3.35.4,
+      `flutter build ios --release --no-codesign`, prod defines); one dispatch run
+- [ ] Local `flutter build ios --release --no-codesign` succeeds
+
+## L2 `ios-public-origin`
+
+- [ ] New `lib/constants/public_origin.dart` (define → web origin → '' +
+      debug assert; pure `resolvePublicOrigin`)
+- [ ] Convert `share_link.dart` (`shareUrl`, `_exportUrl`), `legal_links.dart`
+      (delete localhost fallback), `connect_app_screen.dart`
+      (`LaunchMode.externalApplication` off-web)
+- [ ] Makefile: `flutter-build-ipa` (3 prod defines + `--build-name=1.0.0`
+      `--build-number=$$(git rev-list --count HEAD)`), `flutter-run-ios`
+      (dev-gateway defines)
+- [ ] `test/public_origin_test.dart` matrix + share/export/legal URL tests in
+      the VM env (Uri.base = file:)
+- [ ] Web parity: zero diffs to web build configs (Dockerfiles, ci.yml,
+      `make flutter-build-web`)
+
+## L3 `sso-native-return`
+
+- [ ] `google_auth_handler.go`: `platform` param (400 unless ∈ {"", "ios"}),
+      3-field state cookie (tolerate legacy 2-field), `ssoFinishURL` helper
+- [ ] `apple_auth_handler.go`: same (cookie gains platform field)
+- [ ] Go integration tests: platform matrix (ios → `goldentempo://sso/<code>`
+      / `goldentempo://sso/error`; empty → byte-identical; other → 400)
+- [ ] New `lib/services/sso_web_auth.dart` seam + `flutter_web_auth_2` dep
+- [ ] Both sign-in buttons: web unchanged; native → auth session → push
+      `/sso/<code>`; cancellation silent; widget tests with faked seam
+- [ ] One-time AI-processing disclosure before first chat send
+      (`chat_panel.dart` + small widget, shared_preferences flag,
+      `chatAiDisclosure*` arbs en+es) + widget test
+
+## L4 `universal-links` (wave 2)
+
+- [ ] `app_links` dep; new `lib/navigation/incoming_links.dart`
+      (`normalizeIncomingLink` pure fn)
+- [ ] `lib/main.dart`: cold-start initial route (native only) + root
+      `navigatorKey` + warm-link subscription (token routes only)
+- [ ] `test/incoming_links_test.dart`: normalization matrix mirroring
+      `deep_link_initial_routes_test.dart` + `/app/` + scheme forms;
+      single-initial-route invariant re-asserted
+- [ ] AASA file under `dockerize/deployment/nginx/` + exact-match
+      `/.well-known/apple-app-site-association` location (JSON content-type);
+      `TEAMID` placeholder; webcredentials block; check
+      `dockerize/production/nginx` snippet sharing
+- [ ] ⏳ enrollment: fill real `TEAMID` → deploy → `curl` AASA + on-device
+      link-open verification
+
+## L5 `apple-revoke-delete-ux` (wave 2)
+
+- [ ] Migration `<next free>_apple_refresh_token.sql` (nullable `refresh_token`
+      on `auth_identities`) — **not 00058, that number is burned**; take the
+      next number above main's highest; queries `SetAuthIdentityRefreshToken` +
+      `GetAuthIdentityForUserByProvider`; `make api-sqlc`
+- [ ] `apple_oauth.go`: capture `refresh_token` in `exchangeAppleCode`;
+      `revokeAppleToken` + `APPLE_REVOKE_URL` seam (→ `.env.sample`)
+- [ ] `apple_auth_handler.go`: persist refresh token on sign-in (latest wins)
+- [ ] `account_handler.go`: revoke-before-delete for apple identities,
+      log-and-continue on failure
+- [ ] Go tests: fake-Apple `/auth/revoke` recorder; apple delete → 1 revoke +
+      204; email delete → 0; revoke-500 → delete succeeds; `has_password` in
+      login/me payloads
+- [ ] `UserResponse.has_password` + Dart user model
+      (`@JsonKey(defaultValue: false)`) + `make flutter-build-models`;
+      parity row ✓ in `plan.md`
+- [ ] `_DeleteAccountDialog`: password gate only when `hasPassword`; plain
+      confirm + `settingsDeleteSso*` copy (en+es); widget test both variants
+
+## Verification (workstream close-out)
+
+- [ ] `make api-fmt && make api-vet && make api-test` clean
+- [ ] `make flutter-analyze && make flutter-test` clean (l10n coverage gate)
+- [ ] Manual web pass via `make docker-dev`: sign-in, share, legal links,
+      delete dialog (both account kinds) — proves web parity
+- [ ] Device checklist (TestFlight, post-enrollment): every acceptance
+      criterion in `spec.md` on a physical iPhone (list in `plan.md`
+      §Verification)
+
+## Lanes
+
+| Lane | Branch | Tasks | Migration # | Registry tail? | ARB key prefix | trip_detail? | Depends on |
+|------|--------|-------|-------------|----------------|----------------|--------------|------------|
+| L1 | `ios-scaffold` | L1 block | — | no | — | no | — |
+| L2 | `ios-public-origin` | L2 block | — | no | — | no | — |
+| L3 | `sso-native-return` | L3 block | — | no | `chatAiDisclosure` | no | — |
+| L4 | `universal-links` | L4 block | — | no | — | no | L1 (scheme/entitlements settled) |
+| L5 | `apple-revoke-delete-ux` | L5 block | **next free** (NOT 00058 — burned) | no | `settingsDeleteSso` | no | L3 (`apple_auth_handler.go`) |
+
+**Conflict manifest** (existing files edited per lane; new files free):
+
+- L1: `ios/Runner.xcodeproj/project.pbxproj`, `ios/Runner/Info.plist`,
+  `ios/Podfile`, `pubspec.yaml` (dev-dep), `lib/providers/dictation_provider.dart`
+- L2: `lib/utils/share_link.dart`, `lib/widgets/legal_links.dart`,
+  `lib/screens/connect_app_screen.dart`, `Makefile`
+- L3: `src/packages/api/google_auth_handler.go`,
+  `src/packages/api/apple_auth_handler.go`,
+  `lib/widgets/google_sign_in_button.dart`,
+  `lib/widgets/apple_sign_in_button.dart`, `lib/widgets/chat_panel.dart`,
+  `pubspec.yaml`, arbs
+- L4: `lib/main.dart`, `pubspec.yaml`,
+  `dockerize/deployment/nginx/snippets/app-locations.conf`
+- L5: `src/packages/api/apple_oauth.go`,
+  `src/packages/api/apple_auth_handler.go`,
+  `src/packages/api/account_handler.go`, `src/packages/api/auth_handler.go`,
+  `src/packages/api/query/auth_identities.sql`, `.env.sample`, user model +
+  `.g.dart` (regen), `lib/screens/account_settings_screen.dart`, arbs
+
+Constraints check: no lane touches `trip_detail_screen.dart` or
+`plan_tool_registry.go`; one migration total (L5); ARB prefixes unique;
+`pubspec.yaml` is take-both across L1/L3/L4; `ios/Podfile.lock` and `store/`
+and `.g.dart` are regen-last (integrator runs `pod install` /
+`make api-sqlc` / `make flutter-build-models` after the last relevant merge).
+
+**Merge order:** L1, L2, L3 in any order (wave 1) → L4 after L1, L5 after L3
+(wave 2). Lane agents stop at PR-open (`ship pr`); integrator merges
+(`/integrate`).


### PR DESCRIPTION
## Summary

The approved **iOS App Store v1** spec (5 lanes across 2 waves) had been sitting untracked in the working tree since 2026-08-13 — it was never committed, so nothing in the repo recorded the plan. This commits all three files as written.

One correction on the way in: lane **L5** reserved migration `00058_apple_refresh_token.sql`, and **00058 is permanently burned** — production is already at 00061, and goose (called without `WithAllowMissing`) refuses any unapplied version below the database's max, which `main.go` turns into a fatal crash-loop. See `docs/parallel-dev.md` §4a. L5 now takes the next free number at lane time (`ls src/packages/api/migrations | tail -1`) instead of a stale reservation, and the lanes table records the same.

No other content was changed. Checked before committing: all template sections present, zero unresolved `[NEEDS CLARIFICATION]`, and no credentials or personal data in the files.

## Testing

Docs only — no code, no migration, no generated files. CI runs for completeness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)