### PR TITLE
feat(infra): domain cutover to anemos.travel (rename Phase C)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -437,9 +437,9 @@ jobs:
         if: steps.gate.outputs.configured == 'true'
         run: |
           for i in $(seq 1 30); do
-            api=$(curl -sS -m 10 "https://goldentempotravel.com/api/v1/health" \
+            api=$(curl -sS -m 10 "https://anemos.travel/api/v1/health" \
               | jq -r '.release // empty' 2>/dev/null || true)
-            web=$(curl -sS -m 10 "https://goldentempotravel.com/app/version.json?deploy=${IMAGE_TAG}" \
+            web=$(curl -sS -m 10 "https://anemos.travel/app/version.json?deploy=${IMAGE_TAG}" \
               | jq -r '.release // empty' 2>/dev/null || true)
             if [ "$api" = "$IMAGE_TAG" ] && [ "$web" = "$IMAGE_TAG" ]; then
               echo "live: api and web both serving ${IMAGE_TAG}"

--- a/Makefile
+++ b/Makefile
@@ -206,7 +206,7 @@ seed-local: ## Bulk-ingest local content via admin API (CONTENT_DIR=./content/lo
 # pass through: SMOKE_SEED_MODE=sql|plan|existing, SMOKE_TRIP_ID, SMOKE_TOKEN,
 # SMOKE_SIGNING_SECRET, SMOKE_DB_CONTAINER (see scripts/smoke.sh header).
 #   make smoke                                         # dev stack, sql seed
-#   make smoke BASE_URL=https://goldentempotravel.com SMOKE_SEED_MODE=plan   # post-deploy
+#   make smoke BASE_URL=https://anemos.travel SMOKE_SEED_MODE=plan   # post-deploy
 smoke: ## Run the end-to-end smoke test (BASE_URL, SMOKE_SEED_MODE, ...)
 	@BASE_URL="$(if $(BASE_URL),$(BASE_URL),$(GATEWAY_URL))" \
 		SMOKE_SEED_MODE="$(SMOKE_SEED_MODE)" SMOKE_TRIP_ID="$(SMOKE_TRIP_ID)" \

--- a/dockerize/README.md
+++ b/dockerize/README.md
@@ -8,7 +8,7 @@ Docker orchestration lives here instead of in individual app packages. A single 
 dockerize/
 ├── development/     # Flutter dev server (hot reload) + Go API + nginx
 ├── deployment/      # Static Flutter build + Go API + nginx
-└── production/      # goldentempotravel.com: prebuilt GHCR images behind a Cloudflare Tunnel (see its README)
+└── production/      # anemos.travel: prebuilt GHCR images behind a Cloudflare Tunnel (see its README)
 ```
 
 ## Quick start

--- a/dockerize/production/.env.sample
+++ b/dockerize/production/.env.sample
@@ -1,4 +1,4 @@
-# Production environment for goldentempotravel.com
+# Production environment for anemos.travel
 # ------------------------------------------
 # Copy to /opt/goldentempo/.env (chmod 600, root-owned) next to
 # docker-compose.yml. This single file serves two purposes:
@@ -31,9 +31,11 @@ IMAGE_TAG=latest
 # connector token for this host: Zero Trust → Networks → Tunnels → your
 # tunnel → the token from the install command. The tunnel is the ONLY path
 # from the internet to this stack (no ports are published, no inbound
-# firewall openings needed); its public hostnames route
-# goldentempotravel.com → http://gateway:80 and ssh.goldentempotravel.com →
-# ssh://172.28.0.1:22 for CI deploys.
+# firewall openings needed); its public hostnames route anemos.travel and
+# www (plus the legacy goldentempotravel.com pair, which nginx 308s to the
+# new apex) → http://gateway:80, and ssh.goldentempotravel.com →
+# ssh://172.28.0.1:22 for CI deploys (the SSH hostname deliberately stays
+# on the legacy domain — tunnel-internal, keeps the DEPLOY_* secrets stable).
 TUNNEL_TOKEN=
 
 # ---------------------------------------------------------------------------
@@ -41,13 +43,13 @@ TUNNEL_TOKEN=
 # ---------------------------------------------------------------------------
 
 # Leave EMPTY in production. The nginx gateway serves the UI and API
-# same-origin (goldentempotravel.com), so no CORS headers are needed; an allowlist
+# same-origin (anemos.travel), so no CORS headers are needed; an allowlist
 # here would only widen the surface. Localhost origins are a dev-only thing.
 ALLOWED_ORIGINS=
 
 # Public URL used in transactional email links (verification, password
 # reset). Static for this deployment.
-PUBLIC_BASE_URL=https://goldentempotravel.com
+PUBLIC_BASE_URL=https://anemos.travel
 
 # Path prefix the Flutter app is served under (deep links in emails).
 PUBLIC_APP_PATH=/app/

--- a/dockerize/production/README.md
+++ b/dockerize/production/README.md
@@ -1,4 +1,4 @@
-# Production stack — goldentempotravel.com
+# Production stack — anemos.travel
 
 > **Box died / provider fired us?** [`REHOME.md`](REHOME.md) is the
 > start-to-finish runbook for standing prod up on a fresh VM in ~90 minutes
@@ -50,13 +50,15 @@ Ubuntu LTS image:
 ## Cloudflare Tunnel
 
 One tunnel (Zero Trust → Networks → Tunnels), token in `.env` as
-`TUNNEL_TOKEN`, with three public hostnames:
+`TUNNEL_TOKEN`, with five public hostnames:
 
 | Hostname | Service | Purpose |
 |----------|---------|---------|
-| `goldentempotravel.com` | `http://gateway:80` | the site |
-| `www.goldentempotravel.com` | `http://gateway:80` | nginx 301s it to the apex |
-| `ssh.goldentempotravel.com` | `ssh://172.28.0.1:22` | CI deploys (host sshd via the pinned bridge gateway IP) |
+| `anemos.travel` | `http://gateway:80` | the site |
+| `www.anemos.travel` | `http://gateway:80` | nginx 301s it to the apex |
+| `goldentempotravel.com` | `http://gateway:80` | legacy domain — nginx 308s to anemos.travel (pre-cutover email/share/unsubscribe links never die; unsubscribe is served in place) |
+| `www.goldentempotravel.com` | `http://gateway:80` | legacy www — same 308 |
+| `ssh.goldentempotravel.com` | `ssh://172.28.0.1:22` | CI deploys (host sshd via the pinned bridge gateway IP; deliberately stays on the legacy domain — tunnel-internal, keeps the `DEPLOY_*`/Access secrets stable) |
 
 The SSH hostname sits behind a Cloudflare **Access** application with a
 **service token**; CI authenticates with it (`CF_ACCESS_*` secrets) and
@@ -195,10 +197,11 @@ fresh scratch volume first, then swap it under the live stack and confirm
 ## Sanity checks after a deploy
 
 ```bash
-curl -fsS https://goldentempotravel.com/health              # gateway
-curl -fsS https://goldentempotravel.com/api/v1/health       # API through the proxy
-curl -sI  http://goldentempotravel.com/                     # 301 → https apex
-curl -sI  https://www.goldentempotravel.com/                # 301 → apex
+curl -fsS https://anemos.travel/health              # gateway
+curl -fsS https://anemos.travel/api/v1/health       # API through the proxy
+curl -sI  http://anemos.travel/                     # 301 → https apex
+curl -sI  https://www.anemos.travel/                # 301 → apex
+curl -sI  https://goldentempotravel.com/            # 308 → anemos.travel (legacy)
 ```
 
 For the full end-to-end journey (register → trip → item → share/OG → export →
@@ -213,7 +216,7 @@ against production:
 # SMOKE_MCP_EXPECT=on hard-fails unless the MCP connector is live — use it
 # whenever MCP_ENABLED=true on the host, so a botched flip can't read as green
 # (auto would happily assert the disabled state); off is the post-rollback run.
-make smoke BASE_URL=https://goldentempotravel.com SMOKE_SEED_MODE=plan SMOKE_MCP_EXPECT=on
+make smoke BASE_URL=https://anemos.travel SMOKE_SEED_MODE=plan SMOKE_MCP_EXPECT=on
 ```
 
 Green means the traveler journey works end to end; the run also prints a

--- a/dockerize/production/REHOME.md
+++ b/dockerize/production/REHOME.md
@@ -141,8 +141,8 @@ docker compose logs cloudflared | tail # connector registered
 From the laptop (no DNS changes — the tunnel route follows the connector):
 
 ```bash
-curl -s https://goldentempotravel.com/api/v1/health | jq '{database, release}'   # ok + your SHA
-curl -s "https://goldentempotravel.com/app/version.json?d=1" | jq -r .release    # same SHA
+curl -s https://anemos.travel/api/v1/health | jq '{database, release}'   # ok + your SHA
+curl -s "https://anemos.travel/app/version.json?d=1" | jq -r .release    # same SHA
 ```
 
 Log into a real account in a browser: proves restored password hashes and
@@ -201,7 +201,7 @@ Green deploy = tunnel SSH proven → finish Phase 5's public-22 removal.
 - [ ] `docker compose ps`: 4 services healthy, restart `unless-stopped`
 - [ ] Public health + `version.json` both report the pinned SHA; `database: ok`
 - [ ] Real-account browser login; trips visible
-- [ ] `make smoke BASE_URL=https://goldentempotravel.com SMOKE_SEED_MODE=plan SMOKE_MCP_EXPECT=on` → 0 failed
+- [ ] `make smoke BASE_URL=https://anemos.travel SMOKE_SEED_MODE=plan SMOKE_MCP_EXPECT=on` → 0 failed
       (`on` catches the re-home footgun: a `.env` rebuilt from `.env.sample`
       comes up `MCP_ENABLED=false` and silently disables the live connector)
 - [ ] Backup timer scheduled + manual run uploaded to R2

--- a/dockerize/production/backup.sh
+++ b/dockerize/production/backup.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Nightly Postgres backup for the goldentempotravel.com production stack.
+# Nightly Postgres backup for the anemos.travel production stack.
 #
 # Dumps the database from the running postgres container (pg_dump custom
 # format, gzipped), prunes local dumps older than RETENTION_DAYS, and — if

--- a/dockerize/production/docker-compose.yml
+++ b/dockerize/production/docker-compose.yml
@@ -1,4 +1,4 @@
-# Production stack for https://goldentempotravel.com — same topology as
+# Production stack for https://anemos.travel — same topology as
 # dockerize/deployment/docker-compose.yml, but runs prebuilt images from
 # GHCR (no build:) and reaches the internet exclusively through a
 # Cloudflare Tunnel (the cloudflared service below dials OUT to Cloudflare;
@@ -114,7 +114,8 @@ services:
 
   # Outbound-only connector to the Cloudflare edge. The tunnel's public
   # hostnames (configured in the Zero Trust dashboard) route
-  # goldentempotravel.com → http://gateway:80 and ssh.goldentempotravel.com →
+  # anemos.travel (+ the legacy goldentempotravel.com hostnames, which nginx
+  # 308s to the new apex) → http://gateway:80 and ssh.goldentempotravel.com →
   # ssh://172.28.0.1:22 (the host, via the pinned bridge gateway address;
   # ufw must allow 22 from 172.28.0.0/16) for CI deploys. cloudflared sets
   # CF-Connecting-IP

--- a/dockerize/production/nginx/prod.conf
+++ b/dockerize/production/nginx/prod.conf
@@ -1,4 +1,4 @@
-# Production gateway for https://goldentempotravel.com — Cloudflare Tunnel
+# Production gateway for https://anemos.travel — Cloudflare Tunnel
 # origin. TLS terminates at the Cloudflare edge; the only client of this
 # server is the cloudflared container on the private compose network (the
 # gateway publishes no host ports), so it listens on plain :80.
@@ -17,11 +17,11 @@
 
 # Canonical apex. default_server so requests without a matching Host —
 # notably the in-container health check against http://localhost/health —
-# land here instead of falling into the www redirect below.
+# land here instead of falling into the redirect servers below.
 server {
     listen 80 default_server;
     listen [::]:80 default_server;
-    server_name goldentempotravel.com;
+    server_name anemos.travel;
 
     # The origin speaks plain http behind the tunnel, so nginx's default
     # absolute redirects (e.g. the snippet's `return 301 /app/;`) would be
@@ -46,7 +46,43 @@ server {
 server {
     listen 80;
     listen [::]:80;
-    server_name www.goldentempotravel.com;
+    server_name www.anemos.travel;
 
-    return 301 https://goldentempotravel.com$request_uri;
+    return 301 https://anemos.travel$request_uri;
+}
+
+# Legacy domain (canonical until 2026-08) → anemos.travel. 308, not 301:
+# unsubscribe links minted before the cutover never expire
+# (unsubscribe_token.go) and RFC 8058 one-click unsubscribe POSTs to them —
+# 308 preserves the request method, where 301 lets clients rewrite POST to
+# GET. The tunnel keeps routing these hostnames here indefinitely; old
+# email/share/export links must never die.
+server {
+    listen 80;
+    listen [::]:80;
+    server_name goldentempotravel.com www.goldentempotravel.com;
+
+    if ($http_x_forwarded_proto = "http") {
+        return 301 https://$host$request_uri;
+    }
+
+    # Served in place, NOT redirected: some mailbox providers refuse to
+    # follow any redirect on the RFC 8058 one-click POST, so the legacy
+    # domain keeps answering unsubscribe itself. Proxy settings mirror the
+    # shared /api/ block (snippets/app-locations.conf) — in particular
+    # X-Forwarded-For is REPLACED with the realip-restored $remote_addr so
+    # the Go rate limiter keeps seeing end-user IPs.
+    location /api/v1/unsubscribe/ {
+        proxy_pass http://api_backend;
+        proxy_http_version 1.1;
+        proxy_set_header Connection "";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $remote_addr;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location / {
+        return 308 https://anemos.travel$request_uri;
+    }
 }

--- a/dockerize/production/restore-drill.sh
+++ b/dockerize/production/restore-drill.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Restore drill for the goldentempotravel.com Postgres backups.
+# Restore drill for the anemos.travel Postgres backups.
 #
 # Codifies the "verify a dump into a throwaway volume" half of restore.md
 # (steps 0–3) as a repeatable, non-destructive check: it NEVER touches the live

--- a/dockerize/production/restore.md
+++ b/dockerize/production/restore.md
@@ -1,4 +1,4 @@
-# Restore runbook — goldentempotravel.com Postgres
+# Restore runbook — anemos.travel Postgres
 
 Restores a `backup.sh` dump (`pg_dump -Fc | gzip`) into a **fresh volume
 first**, verifies it there, and only then swaps it under the live stack.
@@ -103,10 +103,10 @@ docker compose up -d api      # api boot re-applies any missing migrations
 ```bash
 docker compose ps                                        # postgres healthy, api healthy
 docker compose logs --tail 50 api                        # migrations applied, no errors
-curl -fsS https://goldentempotravel.com/api/v1/health           # "database":"ok"
+curl -fsS https://anemos.travel/api/v1/health           # "database":"ok"
 ```
 
-Then a real user check: log in at <https://goldentempotravel.com/app/> and open a
+Then a real user check: log in at <https://anemos.travel/app/> and open a
 trip.
 
 ## 6. Clean up

--- a/dockerize/static/robots.txt
+++ b/dockerize/static/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Disallow: /api/
 
-Sitemap: https://goldentempotravel.com/sitemap.xml
+Sitemap: https://anemos.travel/sitemap.xml

--- a/dockerize/static/sitemap.xml
+++ b/dockerize/static/sitemap.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  <url><loc>https://goldentempotravel.com/</loc></url>
-  <url><loc>https://goldentempotravel.com/app/</loc></url>
-  <url><loc>https://goldentempotravel.com/privacy</loc></url>
-  <url><loc>https://goldentempotravel.com/terms</loc></url>
+  <url><loc>https://anemos.travel/</loc></url>
+  <url><loc>https://anemos.travel/app/</loc></url>
+  <url><loc>https://anemos.travel/privacy</loc></url>
+  <url><loc>https://anemos.travel/terms</loc></url>
 </urlset>

--- a/dockerize/static/terms.html
+++ b/dockerize/static/terms.html
@@ -70,7 +70,7 @@
       These Terms of Service ("Terms") are an agreement between you and
       <strong>Golden Tempo LLC</strong>, a New Jersey limited liability company
       doing business as Anemos ("Anemos," "we," "us"). They
-      govern your use of goldentempotravel.com and the Anemos app
+      govern your use of anemos.travel and the Anemos app
       (together, the "Service"). By creating an account or using the Service,
       you agree to these Terms and to our <a href="/privacy">Privacy Policy</a>.
       If you do not agree, do not use the Service. Questions:

--- a/docs/prebeta-pitch.md
+++ b/docs/prebeta-pitch.md
@@ -1,7 +1,7 @@
 # Pre-Beta Pitch — Friends & Family Launch
 
-Channel-ready copy for the friends-and-family pre-beta of **Golden Tempo Travel**
-(goldentempotravel.com). Four pieces, one shared spine. The investor-facing pitch
+Channel-ready copy for the friends-and-family pre-beta of **Anemos**
+(anemos.travel). Four pieces, one shared spine. The investor-facing pitch
 lives in [sales-pitch.md](sales-pitch.md); this doc is for the humans we actually know.
 
 > **`[FEEDBACK CHANNEL]`** appears wherever a feedback destination is needed —
@@ -52,7 +52,7 @@ Every piece below is a channel-shaped version of the same three beats:
 > plan a trip (real or imaginary), and tell me everything you don't like.
 > Honest complaints are genuinely the best gift you can give me right now.
 >
-> 👉 goldentempotravel.com
+> 👉 anemos.travel
 >
 > `[FEEDBACK CHANNEL]`
 
@@ -61,7 +61,7 @@ Every piece below is a channel-shaped version of the same three beats:
 > I built a travel app — you describe a trip, it builds the real day-by-day
 > itinerary (flights, places, map, all saved). It's early and rough in spots,
 > and I need honest eyes on it. Try it and tell me what you hate:
-> goldentempotravel.com 🐎 `[FEEDBACK CHANNEL]`
+> anemos.travel 🧭 `[FEEDBACK CHANNEL]`
 
 ---
 
@@ -152,7 +152,7 @@ travelers is what shapes what this becomes.
   This is the longer-odds bet.
 
 **Status / traction framing**
-- Live in production at goldentempotravel.com, on real infrastructure, with
+- Live in production at anemos.travel, on real infrastructure, with
   real flight and places data. LLC formed. Pre-beta = invite-only friends &
   family while the rough edges get sanded.
 

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -5,7 +5,7 @@
 # hits) and asserts each step, colored PASS/FAIL, non-zero exit on any failure.
 # Built to run TWICE against the same code: as a rehearsal against the local dev
 # stack, and as the go/no-go sanity check against production the moment DNS flips
-# to https://goldentempotravel.com. Pure bash + curl + jq, cloning the api_call idiom
+# to https://anemos.travel. Pure bash + curl + jq, cloning the api_call idiom
 # from scripts/seed_local_content.sh.
 #
 # It registers a THROWAWAY user (unique email), exercises the traveler journey
@@ -578,7 +578,7 @@ ${C_BOLD}MANUAL CHECKS REMAINING (need real DNS/SMTP/crawler)${C_RESET}
       are gone, but a human still owns the "the copy is correct" sign-off.
     - Prod-only edge checks (skipped against the dev gateway): the security
       headers (step 11) and /app/version.json (step 10) must be re-run against
-      the live https://goldentempotravel.com gateway with curl -I / curl.
+      the live https://anemos.travel gateway with curl -I / curl.
     - MCP connector (when MCP_ENABLED=true): link from ChatGPT (Settings ->
       Apps & Connectors -> Developer Mode) and from claude.ai (Settings ->
       Connectors -> add custom connector) against https://<host>/mcp, exercise

--- a/specs/apple-sso/plan.md
+++ b/specs/apple-sso/plan.md
@@ -58,14 +58,16 @@ mode. Test seams: `APPLE_AUTH_URL` / `APPLE_TOKEN_URL`.
 2. Certificates, Identifiers & Profiles → Identifiers → create an **App ID**
    (primary), then a **Services ID** `com.goldentempotravel.web` with
    "Sign In with Apple" enabled → this is `APPLE_CLIENT_ID`.
-3. Configure the Services ID: register domain `goldentempotravel.com` and
-   Return URL exactly `https://goldentempotravel.com/api/v1/auth/apple/callback`.
+3. Configure the Services ID: register domain `anemos.travel` and
+   Return URL exactly `https://anemos.travel/api/v1/auth/apple/callback`.
+   (The Services ID identifier itself stays `com.goldentempotravel.web` —
+   already registered with Apple; only the domain/return URL are new.)
 4. Keys → create a key with "Sign In with Apple" → download
    `AuthKey_<KEY_ID>.p8` (**one-time download** — store it in the password
    manager), note the Key ID and the Team ID (console top-right).
 5. On the Pi: `base64 -i AuthKey_<KEY_ID>.p8 | tr -d '\n'` → set the four
    `APPLE_*` vars in `/opt/goldentempo/.env`, recreate the api container,
-   confirm `curl https://goldentempotravel.com/api/v1/auth/apple/availability`
+   confirm `curl https://anemos.travel/api/v1/auth/apple/availability`
    → `{"available":true}` and the button appears.
 6. **Email relay**: Certificates → Services → "Sign In with Apple for Email
    Communication" → register the transactional-email sending domain/address

--- a/specs/google-sso/plan.md
+++ b/specs/google-sso/plan.md
@@ -75,6 +75,6 @@ Browser                       API (Go)                          Google
 https://console.cloud.google.com/apis/credentials and register
 `<PUBLIC_BASE_URL>/api/v1/auth/google/callback` as an authorized redirect URI
 — `http://localhost:3000/api/v1/auth/google/callback` for dev,
-`https://goldentempo.co/api/v1/auth/google/callback` for prod. Unset ⇒
+`https://anemos.travel/api/v1/auth/google/callback` for prod. Unset ⇒
 degraded mode: button hidden, `/auth/google` answers 503, everything else
 unaffected.

--- a/specs/ios-app-store/plan.md
+++ b/specs/ios-app-store/plan.md
@@ -91,7 +91,7 @@ Key decisions:
   does exchange/adopt exactly as web. Cancellation swallowed.
 - **`lib/navigation/incoming_links.dart` (new)** — pure
   `normalizeIncomingLink(Uri)`:
-  `https://goldentempotravel.com/app/<rest>` → `/<rest>`;
+  `https://anemos.travel/app/<rest>` → `/<rest>`;
   `goldentempo://sso/<c>` → `/sso/<c>`; else null. Cold start:
   `AppLinks().getInitialLink()` → `MaterialApp.initialRoute` (null on web).
   Warm: `uriLinkStream` pushes token routes
@@ -117,7 +117,7 @@ Key decisions:
   (pbxproj ~371/550 + RunnerTests); delete legacy
   `CODE_SIGN_IDENTITY "iPhone Developer"` (~335); `TARGETED_DEVICE_FAMILY=1`
   (~353/479/532); `CODE_SIGN_ENTITLEMENTS` → new `Runner/Runner.entitlements`
-  (`applinks:` + `webcredentials:` goldentempotravel.com); `DEVELOPMENT_TEAM`
+  (`applinks:` + `webcredentials:` anemos.travel); `DEVELOPMENT_TEAM`
   left unset with comment (fills post-enrollment). `Info.plist`:
   `NSPhotoLibraryUsageDescription`, `ITSAppUsesNonExemptEncryption=false`,
   `CFBundleLocalizations` [en, es], `CFBundleURLTypes` (`goldentempo`).
@@ -144,8 +144,8 @@ platform value ⇒ 400 at start.
 - **Env vars:** `APPLE_REVOKE_URL` (test seam, default Apple's real endpoint)
   → `.env.sample`. No other new server config.
 - **Dart defines (native builds only):**
-  `API_BASE_URL=https://goldentempotravel.com/api/v1`, `APP_BASE_PATH=/app/`,
-  `PUBLIC_BASE_URL=https://goldentempotravel.com` — carried exclusively by
+  `API_BASE_URL=https://anemos.travel/api/v1`, `APP_BASE_PATH=/app/`,
+  `PUBLIC_BASE_URL=https://anemos.travel` — carried exclusively by
   new Makefile targets `flutter-build-ipa` / `flutter-run-ios` (never
   hand-typed). Web builds unchanged.
 - **Gateway:** AASA file committed under `dockerize/deployment/nginx/` +

--- a/specs/ios-app-store/spec.md
+++ b/specs/ios-app-store/spec.md
@@ -38,7 +38,7 @@ buildable before it completes.
       and land the user signed in on the home screen; cancelling the sheet is
       silent. Web sign-in behavior is byte-identical to today.
 - [ ] Trip share, invite, print, calendar-export, and Privacy/Terms links
-      opened or shared from the iOS app are absolute `https://goldentempotravel.com`
+      opened or shared from the iOS app are absolute `https://anemos.travel`
       URLs (no relative paths, no localhost).
 - [ ] Tapping a share, invite, verify-email, or password-reset link on iPhone
       opens the app (installed) at the right screen — cold start and warm.

--- a/src/packages/flutter-app/README.md
+++ b/src/packages/flutter-app/README.md
@@ -1,6 +1,6 @@
-# Golden Tempo Travel - Flutter App
+# Anemos - Flutter App
 
-The Flutter web/mobile front end for Golden Tempo Travel: an AI travel
+The Flutter web/mobile front end for Anemos: an AI travel
 planner that turns a conversation into a day-by-day itinerary with routes,
 places, bookings, and a live trip view. Route optimization (Nearest
 Neighbor + 2-Opt) is baked into itinerary creation server-side rather than

--- a/src/packages/flutter-app/web/index.html
+++ b/src/packages/flutter-app/web/index.html
@@ -33,13 +33,13 @@
 
   <!-- SEO / social sharing (app landing; per-trip share links are prerendered
        server-side via /api/v1/share-preview and don't use these). -->
-  <link rel="canonical" href="https://goldentempotravel.com/app/">
+  <link rel="canonical" href="https://anemos.travel/app/">
   <meta property="og:type" content="website">
   <meta property="og:site_name" content="Anemos">
   <meta property="og:title" content="Anemos">
   <meta property="og:description" content="Plan trips and build day-by-day itineraries with an AI travel assistant.">
-  <meta property="og:url" content="https://goldentempotravel.com/app/">
-  <meta property="og:image" content="https://goldentempotravel.com/app/og-card.png">
+  <meta property="og:url" content="https://anemos.travel/app/">
+  <meta property="og:image" content="https://anemos.travel/app/og-card.png">
   <meta property="og:image:width" content="1200">
   <meta property="og:image:height" content="630">
   <meta name="twitter:card" content="summary_large_image">


### PR DESCRIPTION
## Summary
- Phase C of the Anemos rename: move the canonical origin from goldentempotravel.com to **anemos.travel**
- nginx (`dockerize/production/nginx/prod.conf`): anemos.travel apex (`default_server` kept for the localhost healthcheck) + www→apex 301 + a legacy-domain block that **308s** to the new apex — method-preserving because unsubscribe links never expire and RFC 8058 one-click unsubscribe **POSTs** to them — with `/api/v1/unsubscribe/` **proxied in place** (some mailbox providers won't follow any redirect on the one-click POST)
- CI deploy Verify curls → anemos.travel (`ci.yml`) — **merging this PR is the cutover trigger**
- Baked artifacts: `robots.txt` / `sitemap.xml` / `terms.html` domain line / `web/index.html` canonical+og:url+og:image
- Env sample + production runbooks (README/REHOME/restore/backup/compose comments), Makefile + smoke.sh comments, prebeta-pitch copy, flutter-app README
- Specs now target the final domain (ios-app-store applinks/AASA/dart-defines, apple-sso return URL); fixes the stale `goldentempo.co` redirect-URI doc bug in specs/google-sso
- Deliberately unchanged: `ssh.goldentempotravel.com` + `DEPLOY_*`/Access secrets (tunnel-internal), Apple Services ID `com.goldentempotravel.web`, iCal UIDs/PRODID, GHCR/infra names, LLC legal identity

## Merge gate (integrator: read before merging)
Merging deploys a config whose Verify step polls `https://anemos.travel` and whose nginx 308s the old domain there. **Do NOT merge until** (1) the Cloudflare tunnel routes `anemos.travel` + `www.anemos.travel` → `http://gateway:80`, and (2) the droplet `/opt/goldentempo/.env` has `PUBLIC_BASE_URL=https://anemos.travel`. Pre-flip check that gates the merge: `curl https://anemos.travel/api/v1/health` answers. Merging early = total outage (old domain redirects to an unresolvable host).

## Testing
- `nginx -t` green in nginx:alpine with the real baked snippets + realip + perf/upstream mounted
- Functional host-matrix probe against that container: anemos apex serves; no-Host `/health` 200 (default_server healthcheck path); `www.anemos` 301→apex with path+query; legacy GET/POST 308→anemos with path+query; legacy POST `/api/v1/unsubscribe/…` proxied in place (502 against the stub upstream — proves proxy, not redirect); `X-Forwarded-Proto: http` bounces 301→https on the same host for both domains
- Residual repo grep: every remaining `goldentempotravel` reference is the intentional keep-list (ssh hostname, Services ID, dated history line, `ci.yml` DEPLOY_HOST comment, legacy-redirect config/docs)
- No Go/Dart source touched; no test pins either domain (fixtures use gt.test/localhost)

🤖 Generated with [Claude Code](https://claude.com/claude-code)