### PR TITLE
fix(ui): stop MetaChip overflowing its run at narrow widths

### DIFF
--- a/src/packages/flutter-app/lib/widgets/meta_chip.dart
+++ b/src/packages/flutter-app/lib/widgets/meta_chip.dart
@@ -29,11 +29,21 @@ class MetaChip extends StatelessWidget {
         children: [
           Icon(icon, size: 13, color: theme.colorScheme.onSurfaceVariant),
           const SizedBox(width: AppSpacing.xs),
-          Text(
-            label,
-            style: theme.textTheme.labelMedium?.copyWith(
-              color: theme.colorScheme.onSurfaceVariant,
-              fontWeight: FontWeight.w600,
+          // Flexible + ellipsis, the StatusPill treatment: these chips sit in
+          // card Wraps whose runs are only as wide as the card, and a chip
+          // wider than its run (a month-crossing date range at 360px) has
+          // nowhere to wrap to — it must truncate rather than stripe the card
+          // with a RenderFlex overflow. Chips that fit are unaffected: the Row
+          // still hugs its content.
+          Flexible(
+            child: Text(
+              label,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: theme.textTheme.labelMedium?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+                fontWeight: FontWeight.w600,
+              ),
             ),
           ),
         ],

--- a/src/packages/flutter-app/test/meta_chip_test.dart
+++ b/src/packages/flutter-app/test/meta_chip_test.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:travel_route_planner/widgets/meta_chip.dart';
+import 'package:travel_route_planner/widgets/status_pill.dart';
+
+// MetaChip carries card facts (date range, duration, city count, stays) inside
+// a Wrap whose runs are only as wide as the card. A chip whose own natural
+// width exceeds that run has nowhere to go — it must truncate its label, the
+// same way StatusPill does, instead of striping the card with a RenderFlex
+// overflow. The 192px constraint below is what a trips-list card's subtitle
+// Wrap hands a chip at a 360px viewport.
+const double _narrowRun = 192;
+
+Widget _host(Widget child) => MaterialApp(
+      home: Scaffold(
+        body: Center(
+          child: SizedBox(
+            width: _narrowRun,
+            child: Wrap(children: [child]),
+          ),
+        ),
+      ),
+    );
+
+void main() {
+  testWidgets('a long label truncates instead of overflowing the chip',
+      (tester) async {
+    await tester.pumpWidget(_host(
+      // A month-crossing range at the widest month-name/day combination —
+      // ~220px natural width against a 192px run.
+      const MetaChip(label: 'Sep 23 – Oct 26', icon: Icons.event),
+    ));
+    await tester.pumpAndSettle();
+
+    // Widget tests rethrow RenderFlex overflows at test end automatically —
+    // reaching this line with a clean settle IS the assertion.
+    expect(tester.takeException(), isNull);
+
+    final text = tester.widget<Text>(find.text('Sep 23 – Oct 26'));
+    expect(text.overflow, TextOverflow.ellipsis);
+    expect(text.maxLines, 1);
+  });
+
+  testWidgets('a chip that fits is not shrunk or truncated', (tester) async {
+    await tester.pumpWidget(_host(const MetaChip(label: '3 days')));
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull);
+    // The chip hugs its content (mainAxisSize.min), so a short label leaves
+    // the pill narrower than the run it sits in.
+    expect(tester.getSize(find.byType(MetaChip)).width, lessThan(_narrowRun));
+  });
+
+  testWidgets('MetaChip and StatusPill survive the same narrow run',
+      (tester) async {
+    // The two chips share a card's Wrap; a guard on only one of them still
+    // stripes the card.
+    await tester.pumpWidget(_host(
+      const Column(
+        children: [
+          MetaChip(label: 'Sep 23 – Oct 26'),
+          StatusPill.custom(
+            label: 'Ahorra 320 € frente a la tarifa flexible',
+            background: Colors.teal,
+            foreground: Colors.white,
+          ),
+        ],
+      ),
+    ));
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull);
+  });
+}


### PR DESCRIPTION
## Summary

`MetaChip`'s label had no `Flexible`, `maxLines` or `overflow` — unlike its sibling `StatusPill`, whose identical guard carries a comment about exactly this case (`status_pill.dart:42-44`).

These chips sit inside card `Wrap`s whose runs are only as wide as the card. A `Wrap` can move a chip to the next run, but it can't shrink one: a chip whose own natural width exceeds the run has nowhere to go. At a 360px viewport a trips-list card hands its subtitle `Wrap` a 192px run, while a month-crossing date range (`Sep 23 – Oct 26`) needs ~220px — so the card gets striped with `A RenderFlex overflowed by 29 pixels on the right`.

This applies `StatusPill`'s treatment so the label truncates instead. Chips that fit are unaffected: the `Row` still hugs its content (`mainAxisSize.min`).

Found while shipping #394 (which adds a stays chip to that same `Wrap`); verified **pre-existing** — it reproduces with every one of that PR's new fields left null, in English and Spanish alike, so it is fixed separately here rather than widening that PR. The two branches touch disjoint files.

## Testing

- New `test/meta_chip_test.dart` (3 tests), written failing first:
  - a long label in a 192px run — reproduced `A RenderFlex overflowed by 29 pixels on the right` before the change, clean after, with `ellipsis`/`maxLines: 1` asserted on the rendered `Text`
  - a short label is neither shrunk nor truncated (the chip stays narrower than its run)
  - `MetaChip` and `StatusPill` survive the same narrow run together — a guard on only one of them still stripes the card
- `flutter analyze` clean (3 pre-existing infos in an untouched file); full suite green (1073 tests).
- `MetaChip` has a single call site (`trips_list_screen.dart`), so the blast radius is one screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)