### PR TITLE
feat(home): make the app-bar wordmark a real tap target

### DIFF
--- a/src/packages/flutter-app/lib/screens/home_screen.dart
+++ b/src/packages/flutter-app/lib/screens/home_screen.dart
@@ -49,16 +49,48 @@ String greetingText(AppLocalizations l10n, Greeting greeting) =>
       Greeting.evening => l10n.homeGreetingEvening,
     };
 
-/// Below this app-bar-title width the wordmark would ellipsize next to the
-/// badge (Playfair 20px "Anemos" ≈ 75px + badge + gap), so the
-/// header drops to the brand mark alone.
+/// Below this width the wordmark would ellipsize next to the badge (Cinzel
+/// 19px small-caps "ANEMOS" ≈ 80px + badge + gap), so the header drops to the
+/// brand mark alone. Measured on the space the brand Row itself gets — the
+/// [_BrandTitle] LayoutBuilder sits *inside* the tap padding — not on the
+/// whole app-bar title slot.
 const double _wordmarkMinWidth = 145;
 
-class HomeScreen extends ConsumerWidget {
+class HomeScreen extends ConsumerStatefulWidget {
   const HomeScreen({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<HomeScreen> createState() => _HomeScreenState();
+}
+
+class _HomeScreenState extends ConsumerState<HomeScreen> {
+  /// Owned explicitly rather than relying on `primary: true`: the implicit
+  /// primary-controller attach is platform-gated to mobile, so on web the
+  /// brand tap would silently have nothing to scroll.
+  final ScrollController _scroll = ScrollController();
+
+  @override
+  void dispose() {
+    _scroll.dispose();
+    super.dispose();
+  }
+
+  /// Logo-links-home. Note which half of this the traveler actually sees:
+  /// each tab owns its own Scaffold (the shell supplies no app bar), so this
+  /// brand is on screen ONLY at the Home root — [goHome] is therefore a
+  /// no-op-you-can't-see, kept so the brand tap honors the same contract as
+  /// the rail brand (app_shell.dart `_RailBrand`), which CAN be tapped from
+  /// anywhere. The visible half is the scroll back to the top.
+  void _onBrandTap() {
+    goHome(ref);
+    if (!_scroll.hasClients) return;
+    _scroll.animateTo(0,
+        duration: const Duration(milliseconds: 350),
+        curve: Curves.easeOutCubic);
+  }
+
+  @override
+  Widget build(BuildContext context) {
     // Narrow selects throughout: Home only decorates what other screens load
     // (a background trips refresh emits several states), so every watch is
     // scoped to the minimal shape this build actually renders — records
@@ -110,61 +142,12 @@ class HomeScreen extends ConsumerWidget {
     return Scaffold(
       appBar: GradientAppBar(
         centerTitle: false,
-        // Three states, keyed off window width (same measurement as the
-        // shell's rail check, NOT the title slot's constraints):
-        //  - rail visible (>= kRailBreakpoint): wordmark only — the rail brand
-        //    already shows the mark one corner over, so the badge here would
-        //    be a duplicate. Static: the rail brand is the logo-home tap.
-        //  - no rail: brand mark on a light badge (so the black/gold logo
-        //    reads on the teal app bar) next to the wordmark in white.
-        //  - compact title slot (< _wordmarkMinWidth): if the title slot can't
-        //    fit the full wordmark, the badge shows alone rather than an
-        //    ellipsized brand.
-        title: LayoutBuilder(
-          builder: (context, constraints) {
-            final hasRail =
-                MediaQuery.sizeOf(context).width >= kRailBreakpoint;
-            final compact = constraints.maxWidth < _wordmarkMinWidth;
-            const wordmark = Flexible(
-              child: Text(
-                AppInfo.name,
-                overflow: TextOverflow.ellipsis,
-                // Cinzel has no true lowercase — "Anemos" paints as small-caps
-                // ANEMOS. Caps run wide, hence the tighter size + open tracking.
-                style: TextStyle(
-                  fontFamily: 'Cinzel',
-                  fontWeight: FontWeight.w600,
-                  fontSize: 19,
-                  letterSpacing: 1.0,
-                  color: Colors.white,
-                ),
-              ),
-            );
-            return Row(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                if (!hasRail)
-                  BrandBadge(
-                    padding: const EdgeInsets.symmetric(
-                        horizontal: AppSpacing.sm, vertical: AppSpacing.xs),
-                    // Logo-links-home: pops anything pushed on the Home stack.
-                    onTap: () => goHome(ref),
-                    child: const BrandLogo.mark(size: 28),
-                  ),
-                if (hasRail)
-                  wordmark
-                else if (!compact) ...const [
-                  SizedBox(width: AppSpacing.sm),
-                  wordmark,
-                ],
-              ],
-            );
-          },
-        ),
+        title: _BrandTitle(onTap: _onBrandTap),
         actions: const [LanguageMenuButton(), AccountMenu()],
       ),
       body: SafeArea(
         child: SingleChildScrollView(
+          controller: _scroll,
           padding: const EdgeInsets.all(AppSpacing.lg),
           child: PageContainer(
             child: Column(
@@ -236,6 +219,94 @@ class HomeScreen extends ConsumerWidget {
 
                 const SizedBox(height: AppSpacing.lg),
               ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// The Home app bar's brand — the Site ID (Krug) — as ONE tap target at every
+/// width, per the universal logo-links-home convention. Three render states,
+/// keyed off window width (same measurement as the shell's rail check, NOT the
+/// title slot's constraints):
+///  - rail visible (>= kRailBreakpoint): wordmark only — the rail brand
+///    already shows the mark one corner over, so the badge here would be a
+///    duplicate. Still tappable: two brand affordances, same destination.
+///  - no rail: brand mark on a light badge (so the teal/gold logo reads on the
+///    teal app bar) next to the wordmark in white.
+///  - compact slot (< _wordmarkMinWidth): if the brand's own slot can't fit
+///    the full wordmark, the badge shows alone rather than an ellipsized brand.
+///
+/// The [InkWell] is the single target for whichever of those is on screen —
+/// the badge deliberately does NOT carry its own onTap here, or the lockup
+/// would hit-test and ripple twice. The LayoutBuilder sits inside the tap
+/// padding so the compact threshold measures the width the Row actually gets.
+class _BrandTitle extends StatelessWidget {
+  final VoidCallback onTap;
+
+  const _BrandTitle({required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    return Tooltip(
+      message: context.l10n.shellNavHome,
+      // The mark's Image already carries the "Anemos" semanticLabel and the
+      // wordmark is the literal word, so without excludeSemantics a screen
+      // reader announces the button as "Anemos Anemos".
+      child: Semantics(
+        button: true,
+        label: AppInfo.name,
+        excludeSemantics: true,
+        child: Material(
+          type: MaterialType.transparency,
+          child: InkWell(
+            onTap: onTap,
+            borderRadius: AppRadius.mdAll,
+            child: Padding(
+              padding: const EdgeInsets.all(AppSpacing.xs),
+              child: LayoutBuilder(
+                builder: (context, constraints) {
+                  final hasRail =
+                      MediaQuery.sizeOf(context).width >= kRailBreakpoint;
+                  final compact = constraints.maxWidth < _wordmarkMinWidth;
+                  const wordmark = Flexible(
+                    child: Text(
+                      AppInfo.name,
+                      overflow: TextOverflow.ellipsis,
+                      // Cinzel has no true lowercase — "Anemos" paints as
+                      // small-caps ANEMOS. Caps run wide, hence the tighter
+                      // size + open tracking.
+                      style: TextStyle(
+                        fontFamily: 'Cinzel',
+                        fontWeight: FontWeight.w600,
+                        fontSize: 19,
+                        letterSpacing: 1.0,
+                        color: Colors.white,
+                      ),
+                    ),
+                  );
+                  return Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      if (!hasRail)
+                        const BrandBadge(
+                          padding: EdgeInsets.symmetric(
+                              horizontal: AppSpacing.sm,
+                              vertical: AppSpacing.xs),
+                          child: BrandLogo.mark(size: 28),
+                        ),
+                      if (hasRail)
+                        wordmark
+                      else if (!compact) ...const [
+                        SizedBox(width: AppSpacing.sm),
+                        wordmark,
+                      ],
+                    ],
+                  );
+                },
+              ),
             ),
           ),
         ),

--- a/src/packages/flutter-app/test/home_polish_test.dart
+++ b/src/packages/flutter-app/test/home_polish_test.dart
@@ -6,6 +6,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:travel_route_planner/constants/app_info.dart';
 import 'package:travel_route_planner/models/trip.dart';
 import 'package:travel_route_planner/models/user.dart';
+import 'package:travel_route_planner/navigation/app_nav.dart';
 import 'package:travel_route_planner/providers/auth_provider.dart';
 import 'package:travel_route_planner/providers/live_trip_provider.dart';
 import 'package:travel_route_planner/providers/resumable_chats_provider.dart';
@@ -149,6 +150,77 @@ void main() {
     final tagline = tester.widget<Text>(find.text('Plan less. Travel more.'));
     expect(tagline.maxLines, 2);
     expect(tester.takeException(), isNull);
+  });
+
+  // Logo-links-home for the WORDMARK, not just the plated mark: at rail
+  // widths the wordmark is the only brand in the app bar, and it used to be
+  // inert (no InkWell at all). These two pin the goHome WIRING at the widths
+  // that render each shape — in the real shell Home's app bar only ever shows
+  // at the Home root, so the visible half of the tap is the scroll-to-top
+  // case below.
+  testWidgets('wide app bar: tapping the wordmark goes Home',
+      (WidgetTester tester) async {
+    await _pumpHome(tester, surface: const Size(1200, 800));
+
+    expect(
+      find.ancestor(
+          of: find.text(AppInfo.name), matching: find.byType(InkWell)),
+      findsOneWidget,
+    );
+
+    final container =
+        ProviderScope.containerOf(tester.element(find.byType(HomeScreen)));
+    container.read(navIndexProvider.notifier).state = AppTab.plan.index;
+
+    await tester.tap(find.text(AppInfo.name));
+    await tester.pump();
+
+    expect(container.read(navIndexProvider), AppTab.home.index);
+  });
+
+  testWidgets('mid width: the wordmark beside the badge is the same target',
+      (WidgetTester tester) async {
+    await _pumpHome(tester, surface: const Size(700, 800));
+
+    final container =
+        ProviderScope.containerOf(tester.element(find.byType(HomeScreen)));
+    container.read(navIndexProvider.notifier).state = AppTab.plan.index;
+
+    // The wordmark text, NOT the badge — the half of the lockup that used to
+    // be dead space.
+    await tester.tap(find.text(AppInfo.name));
+    await tester.pump();
+
+    expect(container.read(navIndexProvider), AppTab.home.index);
+  });
+
+  testWidgets('the lockup is ONE tap target, not a badge nested in a target',
+      (WidgetTester tester) async {
+    await _pumpHome(tester, surface: const Size(700, 800));
+
+    // Mutation pin against re-adding BrandBadge's own onTap: a second,
+    // nested InkWell would hit-test and ripple twice over the same brand.
+    expect(
+      find.ancestor(of: find.byType(BrandLogo), matching: find.byType(InkWell)),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('tapping the brand scrolls Home back to the top',
+      (WidgetTester tester) async {
+    await _pumpHome(tester, surface: const Size(360, 690));
+
+    await tester.drag(
+        find.byType(SingleChildScrollView), const Offset(0, -240));
+    await tester.pumpAndSettle();
+    final position =
+        tester.state<ScrollableState>(find.byType(Scrollable).first).position;
+    expect(position.pixels, greaterThan(0));
+
+    await tester.tap(find.byType(BrandLogo));
+    await tester.pumpAndSettle();
+
+    expect(position.pixels, 0);
   });
 
   testWidgets('overflow floor: home with the plan strip at 360x690 in es',


### PR DESCRIPTION
## Summary

- The Anemos wordmark at the top of Home was **inert**. At rail widths (≥800px) it is the only brand in the app bar and had no `InkWell` at all; at mid widths it was half a target — the plated rose mark was tappable, the word beside it wasn't.
- The whole lockup is now **one** tap target at every width: pointer cursor, hover highlight, and a "Home" tooltip (reuses `shellNavHome`, so no ARB edit and no `gen-l10n` regen).
- `BrandBadge` no longer carries its own `onTap` here — nested `InkWell`s would hit-test and ripple twice over the same brand. A test pins the single-target shape.
- The tap calls `goHome` for contract parity with the rail brand, but the **visible** half is the scroll back to the top: each tab owns its own `Scaffold` (the shell supplies no app bar), so Home's app bar is only ever on screen at the Home root. Documented in the handler rather than left as a puzzle.
- `HomeScreen` becomes a `ConsumerStatefulWidget` to own the `ScrollController` — explicit, not `primary: true`, whose implicit attach is platform-gated to mobile and would have silently no-op'd on web.
- The existing responsive `LayoutBuilder` moves *inside* the tap padding so the `_wordmarkMinWidth` compact threshold still measures the width the brand Row actually gets. Stale comments fixed on the way through (`_wordmarkMinWidth` still cited "Playfair 20px"; the three-state doc still called the rail state static).

## Testing

- `make flutter-analyze` — clean (only the 3 pre-existing `route_response.dart` infos).
- `make flutter-test` — full suite green, including the four existing responsive app-bar cases and `logo_home_nav_test` / `nav_tab_reset_test` / `splash_screen_test`.
- Four new tests in `home_polish_test.dart`: goHome wiring at 1200px and at 700px (tapping the *wordmark*, not the badge), a mutation pin that the lockup holds exactly one `InkWell`, and a scroll-to-top test that drags Home down and asserts the tap returns `position.pixels` to 0.
- Manual verification in the real app (host headless Chrome against the dev stack, signed in via SSO handoff): at 1440px, hovering the wordmark shows the highlight + "Home" tooltip, and clicking it animates a scrolled Home back to the top; at 700px, clicking the *word* beside the badge — the half that used to be dead space — does the same, with one highlight across the whole lockup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)