### PR TITLE
fix(home): derive the Continue card so a storage wipe can't empty it

### DIFF
--- a/src/packages/flutter-app/lib/providers/recent_trip_provider.dart
+++ b/src/packages/flutter-app/lib/providers/recent_trip_provider.dart
@@ -4,8 +4,12 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import '../models/trip.dart';
+import '../utils/trip_days.dart';
+import '../utils/trip_format.dart';
 import 'auth_provider.dart';
+import 'live_trip_provider.dart';
 import 'trip_cache_provider.dart';
+import 'trips_provider.dart';
 
 /// The trip detail screen the user last opened, remembered on-device so the
 /// home screen can offer a one-tap way back into it. Carries a snapshot of the
@@ -116,4 +120,99 @@ final cachedTripDetailProvider =
   ref.watch(recentTripProvider);
   final cached = await ref.watch(tripCacheProvider).readTrip(tripId);
   return cached?.trip;
+});
+
+/// What Home's "Continue where you left off" card renders: enough to draw the
+/// tile, nothing more. A record, so equal contents compare equal and the
+/// derivation below can recompute freely without rebuilding the card.
+typedef ContinueTrip = ({String tripId, String title, String? dateRange});
+
+/// The trip Home offers as a way back in, or null when there is nothing to
+/// continue.
+///
+/// [recorded] is the *preferred* answer — it is the only thing that knows
+/// which trip this traveler actually looked at. But on web it lives in
+/// origin-scoped storage, so it is absent on a new device, after a storage
+/// clear, and after a domain move (the anemos.travel cutover emptied it for
+/// every existing session). The trips list is the durable backstop: the
+/// server already knows which trip was touched last, so a signed-in traveler
+/// with saved trips is never left with nothing to continue.
+///
+/// Precedence, most specific first:
+///  1. [recorded] found in [trips] — that trip, carrying the **live** title
+///     and dates rather than the stored snapshot, so a rename made anywhere
+///     else can't surface stale text here.
+///  2. [recorded] not found — the snapshot verbatim. Absence is deliberately
+///     NOT read as "the trip was deleted": [trips] is the OWNED list, so a
+///     trip shared with this traveler is never in it, and the list is also
+///     empty before its first load and stale offline. A card pointing at a
+///     trip deleted on another device is the accepted cost of not dropping
+///     those three.
+///  3. No record at all — the most recently updated trip that hasn't already
+///     happened, newest [Trip.createdAt] breaking an exact tie.
+///  4. Nothing left — null. An all-past account gets an honest empty state;
+///     the section can still fill with resumable chats.
+///
+/// [liveTrip] is excluded at every rung: it already has its own card directly
+/// above this one, and the same trip must never stack twice.
+ContinueTrip? continueTripOf(
+  RecentTrip? recorded,
+  List<Trip> trips,
+  Trip? liveTrip,
+  DateTime today,
+) {
+  ContinueTrip of(Trip t) => (
+        tripId: t.id,
+        title: t.title,
+        dateRange: tripDateRange(t.startDate, t.endDate),
+      );
+
+  if (recorded != null && recorded.tripId != liveTrip?.id) {
+    for (final t in trips) {
+      if (t.id == recorded.tripId) return of(t);
+    }
+    return (
+      tripId: recorded.tripId,
+      title: recorded.title,
+      dateRange: recorded.dateRange,
+    );
+  }
+
+  Trip? best;
+  for (final t in trips) {
+    if (t.id == liveTrip?.id) continue;
+    if (tripIsPast(t.startDate, t.endDate, today)) continue;
+    // updatedAt/createdAt are required ISO-8601 strings off the wire, so
+    // lexicographic order is chronological order — the convention
+    // trip_list_order.dart already sorts by.
+    if (best == null ||
+        t.updatedAt.compareTo(best.updatedAt) > 0 ||
+        (t.updatedAt == best.updatedAt &&
+            t.createdAt.compareTo(best.createdAt) > 0)) {
+      best = t;
+    }
+  }
+  return best == null ? null : of(best);
+}
+
+/// The trip Home's "Continue where you left off" card points at. Derived in
+/// this one place from device memory + the loaded trips list — see
+/// [continueTripOf] for the precedence.
+///
+/// Watches the WHOLE [recentTripProvider] state rather than a select, for the
+/// same reason [cachedTripDetailProvider] does: [RecentTripNotifier.record]
+/// mints a fresh [RecentTrip] (no `==`) on every detail load, and that new
+/// instance *is* the signal that the last-viewed trip changed.
+///
+/// Returns a record, so the recompute that every trips refresh triggers only
+/// rebuilds Home when the answer actually changed — the narrow-watch doctrine
+/// the home screen documents at the top of its build.
+final continueTripProvider = Provider<ContinueTrip?>((ref) {
+  final recorded = ref.watch(recentTripProvider);
+  final trips = ref.watch(tripsProvider.select((s) => s.trips));
+  final liveTrip = ref.watch(liveTripProvider);
+  // Sampled at build time, exactly like liveTripProvider: a trip that ages
+  // into "past" at midnight drops out on the next list refresh, not
+  // spontaneously.
+  return continueTripOf(recorded, trips, liveTrip, DateTime.now());
 });

--- a/src/packages/flutter-app/lib/screens/home_screen.dart
+++ b/src/packages/flutter-app/lib/screens/home_screen.dart
@@ -66,13 +66,12 @@ class HomeScreen extends ConsumerWidget {
     // hero/greeting/guides subtree.
     final displayName =
         ref.watch(authProvider.select((s) => s.user?.displayName));
-    final recentTrip = ref.watch(recentTripProvider.select((r) => r == null
-        ? null
-        : (
-            tripId: r.tripId,
-            title: r.title,
-            dateRange: r.dateRange,
-          )));
+    // Derived, never read straight off device storage: continueTripProvider
+    // prefers the trip this device last viewed and falls back to the trips
+    // list when this origin has no record of one (new device, cleared
+    // storage, domain move) — precedence in continueTripOf. It already
+    // excludes the live trip, so nothing here has to.
+    final continueTrip = ref.watch(continueTripProvider);
     // Populated app-wide: AppShell's IndexedStack keeps TripsListScreen
     // mounted, and its loadTrips() feeds tripsProvider — no fetch from here.
     //
@@ -89,7 +88,7 @@ class HomeScreen extends ConsumerWidget {
     // While providers are still loading this reads false and the full hero
     // shows briefly — same async-appearance behavior as LiveTripCard.
     final returning = liveTrip != null ||
-        recentTrip != null ||
+        continueTrip != null ||
         ref.watch(tripsProvider.select((s) => s.trips.isNotEmpty)) ||
         ref.watch(resumableChatsProvider
             .select((a) => a.valueOrNull?.isNotEmpty ?? false));
@@ -209,21 +208,19 @@ class HomeScreen extends ConsumerWidget {
                   ),
                   const SizedBox(height: AppSpacing.xl),
                 ],
-                // One "Continue where you left off" section: the most
-                // recently viewed trip (hidden when it *is* the live trip,
-                // so the same trip never stacks twice), then in-progress AI
+                // One "Continue where you left off" section: the trip to pick
+                // back up (see continueTripProvider), then in-progress AI
                 // conversations that haven't produced a trip yet
                 // (specs/continue-where-you-left-off). Collapses to nothing
-                // when there is nothing to resume.
+                // only when the account genuinely has nothing to resume.
                 ContinueChatsSection(
-                  leading: recentTrip != null &&
-                          recentTrip.tripId != liveTrip?.id
+                  leading: continueTrip != null
                       ? _RecentTripCard(
-                          tripId: recentTrip.tripId,
-                          title: recentTrip.title,
-                          dateRange: recentTrip.dateRange,
+                          tripId: continueTrip.tripId,
+                          title: continueTrip.title,
+                          dateRange: continueTrip.dateRange,
                           onTap: () =>
-                              openTripOnTripsTab(ref, recentTrip.tripId),
+                              openTripOnTripsTab(ref, continueTrip.tripId),
                         )
                       : null,
                 ),
@@ -489,8 +486,10 @@ class _AgentHeroCard extends StatelessWidget {
   }
 }
 
-/// One-tap way back into the most recently viewed trip, styled as a lighter
-/// sibling of the hero card (same teal family as the app bar gradient).
+/// One-tap way back into the trip [continueTripProvider] picked — the one this
+/// device last viewed, or the most recently updated one when this origin has
+/// no such memory — styled as a lighter sibling of the hero card (same teal
+/// family as the app bar gradient).
 /// Rendered inside the "Continue where you left off" section, which supplies
 /// the header — the card itself carries no eyebrow.
 class _RecentTripCard extends StatelessWidget {

--- a/src/packages/flutter-app/test/continue_trip_test.dart
+++ b/src/packages/flutter-app/test/continue_trip_test.dart
@@ -1,0 +1,162 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:travel_route_planner/models/trip.dart';
+import 'package:travel_route_planner/providers/recent_trip_provider.dart';
+import 'package:travel_route_planner/utils/trip_format.dart';
+
+/// The precedence ladder behind Home's "Continue where you left off" card.
+///
+/// The card used to read device storage directly, which meant a traveler with
+/// saved trips saw nothing to continue on a new device, after clearing site
+/// data, or after the anemos.travel cutover moved the origin out from under
+/// localStorage. [continueTripOf] keeps the device's own memory as the
+/// preferred answer and falls back to the trips list, which the server owns.
+void main() {
+  final today = DateTime(2026, 8, 14);
+
+  Trip trip(
+    String id, {
+    String title = 'A trip',
+    String? start,
+    String? end,
+    String updatedAt = '2026-08-01T00:00:00Z',
+    String createdAt = '2026-07-01T00:00:00Z',
+  }) =>
+      Trip(
+        id: id,
+        title: title,
+        startDate: start,
+        endDate: end,
+        createdAt: createdAt,
+        updatedAt: updatedAt,
+      );
+
+  const recorded = RecentTrip(
+    tripId: 't1',
+    title: 'Stale snapshot title',
+    dateRange: 'Jan 1 – Jan 2',
+  );
+
+  group('rung 1 — the recorded trip, with live values', () {
+    test('live title and dates beat the stored snapshot', () {
+      final trips = [
+        trip('t1',
+            title: 'Renamed in the trip screen',
+            start: '2026-09-01',
+            end: '2026-09-08'),
+      ];
+
+      final result = continueTripOf(recorded, trips, null, today);
+
+      expect(result?.tripId, 't1');
+      expect(result?.title, 'Renamed in the trip screen');
+      expect(result?.dateRange, tripDateRange('2026-09-01', '2026-09-08'));
+    });
+  });
+
+  group('rung 2 — a recorded trip the owned list does not have', () {
+    test('an unloaded list keeps the stored snapshot verbatim', () {
+      final result = continueTripOf(recorded, const [], null, today);
+
+      expect(result?.tripId, 't1');
+      expect(result?.title, 'Stale snapshot title');
+      expect(result?.dateRange, 'Jan 1 – Jan 2');
+    });
+
+    test('a shared trip is honored, not replaced by an owned one', () {
+      // tripsProvider is the OWNED list — a trip shared with this traveler is
+      // never in it, so absence must not be read as "deleted".
+      final trips = [trip('owned', title: 'My own trip', start: '2026-09-01')];
+
+      final result = continueTripOf(recorded, trips, null, today);
+
+      expect(result?.tripId, 't1');
+      expect(result?.title, 'Stale snapshot title');
+    });
+  });
+
+  group('rung 3 — the fallback', () {
+    test('takes the most recently updated trip', () {
+      final trips = [
+        trip('older', updatedAt: '2026-08-01T00:00:00Z'),
+        trip('newest', updatedAt: '2026-08-13T00:00:00Z'),
+        trip('middle', updatedAt: '2026-08-07T00:00:00Z'),
+      ];
+
+      expect(continueTripOf(null, trips, null, today)?.tripId, 'newest');
+    });
+
+    test('skips trips that have already happened', () {
+      final trips = [
+        trip('finished',
+            start: '2026-07-01',
+            end: '2026-07-10',
+            updatedAt: '2026-08-13T00:00:00Z'),
+        trip('ahead',
+            start: '2026-09-01',
+            end: '2026-09-08',
+            updatedAt: '2026-08-02T00:00:00Z'),
+      ];
+
+      expect(continueTripOf(null, trips, null, today)?.tripId, 'ahead');
+    });
+
+    test('keeps an undated draft, which is not the same as past', () {
+      final trips = [trip('draft')];
+
+      expect(continueTripOf(null, trips, null, today)?.tripId, 'draft');
+      expect(continueTripOf(null, trips, null, today)?.dateRange, isNull);
+    });
+
+    test('skips the live trip, which has its own card', () {
+      final live = trip('live',
+          start: '2026-08-13',
+          end: '2026-08-16',
+          updatedAt: '2026-08-14T00:00:00Z');
+      final trips = [live, trip('other', updatedAt: '2026-08-02T00:00:00Z')];
+
+      expect(continueTripOf(null, trips, live, today)?.tripId, 'other');
+    });
+
+    test('breaks an exact updatedAt tie on the newer createdAt', () {
+      final trips = [
+        trip('older-draft',
+            updatedAt: '2026-08-10T00:00:00Z',
+            createdAt: '2026-07-01T00:00:00Z'),
+        trip('newer-draft',
+            updatedAt: '2026-08-10T00:00:00Z',
+            createdAt: '2026-07-20T00:00:00Z'),
+      ];
+
+      expect(continueTripOf(null, trips, null, today)?.tripId, 'newer-draft');
+    });
+  });
+
+  group('rung 4 — nothing to continue', () {
+    test('an account with no trips and no record yields null', () {
+      expect(continueTripOf(null, const [], null, today), isNull);
+    });
+
+    test('an all-past account yields null rather than a finished trip', () {
+      final trips = [
+        trip('last-year', start: '2025-06-01', end: '2025-06-10'),
+        trip('last-month', start: '2026-07-01', end: '2026-07-10'),
+      ];
+
+      expect(continueTripOf(null, trips, null, today), isNull);
+    });
+
+    test('the live trip alone yields null — it never stacks twice', () {
+      final live = trip('live', start: '2026-08-13', end: '2026-08-16');
+
+      expect(continueTripOf(null, [live], live, today), isNull);
+    });
+
+    test('a record pointing at the live trip falls through, not to itself',
+        () {
+      final live = trip('t1', start: '2026-08-13', end: '2026-08-16');
+
+      expect(continueTripOf(recorded, [live], live, today), isNull);
+    });
+  });
+}

--- a/src/packages/flutter-app/test/home_continue_chats_test.dart
+++ b/src/packages/flutter-app/test/home_continue_chats_test.dart
@@ -9,6 +9,7 @@ import 'package:travel_route_planner/models/chat_session.dart';
 import 'package:travel_route_planner/models/user.dart';
 import 'package:travel_route_planner/providers/auth_provider.dart';
 import 'package:travel_route_planner/providers/live_trip_provider.dart';
+import 'package:travel_route_planner/providers/recent_trip_provider.dart';
 import 'package:travel_route_planner/providers/resumable_chats_provider.dart';
 import 'package:travel_route_planner/screens/home_screen.dart';
 import 'package:travel_route_planner/widgets/continue_chats_section.dart';
@@ -82,6 +83,7 @@ void _seedRecentTrip(String tripId, String title) {
 Future<void> _pumpHome(
   WidgetTester tester, {
   List<ChatSessionSummary> chats = const [],
+  ContinueTrip? continueTrip,
 }) async {
   await tester.pumpWidget(
     ProviderScope(
@@ -89,6 +91,12 @@ Future<void> _pumpHome(
         authProvider.overrideWith((ref) => _FakeAuthNotifier(_user())),
         liveTripProvider.overrideWithValue(null),
         resumableChatsProvider.overrideWith((ref) async => chats),
+        // Left un-overridden by default so the seeded-prefs cases above still
+        // exercise the real derivation (empty trips list => the stored
+        // snapshot). Supplied only where the point is a trip the device has
+        // no record of.
+        if (continueTrip != null)
+          continueTripProvider.overrideWithValue(continueTrip),
       ],
       child: MaterialApp(
       localizationsDelegates: testLocalizationsDelegates,home: HomeScreen()),
@@ -126,6 +134,23 @@ void main() {
 
     expect(find.text('Continue where you left off'), findsOneWidget);
     expect(find.text('Lisbon Trip'), findsOneWidget);
+    expect(find.byType(ContinueChatCard), findsNothing);
+  });
+
+  testWidgets('a trip this device has no record of still carries the section',
+      (WidgetTester tester) async {
+    // No seeded prefs — the post-cutover state: origin-scoped storage is
+    // empty, but the account still has trips, so the section must not
+    // collapse the way it did on anemos.travel launch day.
+    await _pumpHome(tester, continueTrip: (
+      tripId: 't9',
+      title: 'Athens & the islands',
+      dateRange: 'Sep 1 – Sep 8',
+    ));
+
+    expect(find.text('Continue where you left off'), findsOneWidget);
+    expect(find.text('Athens & the islands'), findsOneWidget);
+    expect(find.text('Sep 1 – Sep 8'), findsOneWidget);
     expect(find.byType(ContinueChatCard), findsNothing);
   });
 


### PR DESCRIPTION
## Summary

The Home screen's "Continue where you left off" section vanished from prod today. Nothing removed it — `git log -S "ContinueChatsSection" -- home_screen.dart` returns only the commit that added it. Both of its data sources went empty at the same time:

- **Recent-trip half** — `recentTripProvider` reads SharedPreferences, which on web is **origin-scoped localStorage**. The anemos.travel cutover (`80d96f2`) put every session on a brand-new origin, so `recent_trip.<userId>` was simply gone. (Same reason existing sessions had to sign in again — `AuthStorage` is origin-scoped too.)
- **Chats half** — empty for its own reasons: graduated chats are excluded forever (`chat_sessions.sql:22-25`), and the Aug 7→12 `/plan` body-decode outage (`b476b79` → `a8dbcd1`) wrote zero rows for five days. Unchanged by this PR.

Net effect: a signed-in traveler with saved trips saw **nothing to continue** — and would see nothing again on any new device or after clearing site data.

### What changed

The device-local record stays the *preferred* answer — it is the only thing that knows which trip you actually looked at — but it is no longer the *only* answer. `continueTripOf()` derives the card in one place, pairing a pure function with a thin `Provider` exactly the way `live_trip_provider.dart` already does:

1. The recorded trip, carrying **live** title/dates when the trips list has it, so a rename elsewhere can't surface stale text.
2. The recorded trip's stored snapshot when the list doesn't have it.
3. No record at all → the most recently updated trip that hasn't already happened, newest `createdAt` breaking a tie.
4. Nothing left → null; the section can still fill with resumable chats.

The live trip is excluded throughout — it already has its own card directly above.

**Absence from the trips list is deliberately NOT read as "deleted."** An earlier draft did that, to clear a record pointing at a trip deleted on another device. `home_open_trip_on_trips_tab_test` caught it: `tripsProvider` is the **owned** list, so a trip shared with you is never in it, and the list is also empty before first load and stale offline. A card pointing at a remotely-deleted trip is the accepted cost of not dropping those three.

Client-side only — no migration, no endpoint, no extra writes. `_RecentTripCard`, `ContinueChatsSection` and `TripMapBand` are untouched; the map band still collapses on its own for a trip this device hasn't cached.

## Testing

- `flutter test` — **1148 passing**, none skipped.
- `flutter analyze --no-fatal-infos --fatal-warnings` (CI flags) — exit 0. The 3 remaining `info`s are pre-existing in `route_response.dart`.
- New `test/continue_trip_test.dart` — 12 cases, one per rung, including the shared-trip case that must not be dropped and the all-past account that must yield null.
- New case in `test/home_continue_chats_test.dart` — the section renders from a derived trip with no seeded prefs. The four existing home test files pass untouched.
- **Real browser**, lane stack on `:3006`, throwaway account seeded with two trips where the **past** one is the more recently updated (the trap a naive `max(updatedAt)` would fall into):
  - Signed in via SSO handoff, never opened a trip detail → Home shows **"Athens and the islands · Sep 1 – Sep 8"**, correctly skipping "Lisbon last spring". Confirmed **zero** `recent_trip.*` keys in localStorage, so the card came purely from the fallback — the exact post-cutover state.
  - Then opened the Lisbon (past) trip's detail and returned Home → the card follows the freshly viewed trip. Local memory still wins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)