### PR TITLE
feat(auth): put "Continue with Google" above the email form

### DIFF
--- a/src/packages/flutter-app/lib/providers/auth_provider.dart
+++ b/src/packages/flutter-app/lib/providers/auth_provider.dart
@@ -1,7 +1,9 @@
 import 'dart:async';
 import 'dart:convert';
 
-import 'package:flutter/foundation.dart';
+// widgets.dart (not foundation.dart) for the BuildContext that
+// warmSsoAvailability takes; it re-exports everything foundation does.
+import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../models/user.dart';
 import '../services/api_client.dart';
@@ -28,6 +30,26 @@ final googleSsoAvailableProvider = FutureProvider<bool>((ref) {
 final appleSsoAvailableProvider = FutureProvider<bool>((ref) {
   return ref.watch(authServiceProvider).appleSignInAvailable();
 });
+
+/// Starts both SSO availability fetches on the tap that opens [AuthScreen],
+/// so the route transition covers the round trip and the screen's first frame
+/// already knows whether to draw the buttons. Without this the SSO block sits
+/// above the email form and un-collapses a round trip late, shoving the form
+/// down under the reader's finger.
+///
+/// Fire-and-forget, and deliberately not done at boot — these providers are
+/// non-autoDispose, so this is at most one request per provider per session
+/// and nothing at all on a second visit, while a boot-time fetch would join
+/// the cold-start burst.
+void warmSsoAvailability(BuildContext context) {
+  try {
+    final container = ProviderScope.containerOf(context, listen: false);
+    container.read(googleSsoAvailableProvider);
+    container.read(appleSsoAvailableProvider);
+  } catch (_) {
+    // A tree without a ProviderScope must never break navigation.
+  }
+}
 
 class AuthState {
   final UserModel? user;

--- a/src/packages/flutter-app/lib/screens/agent_screen.dart
+++ b/src/packages/flutter-app/lib/screens/agent_screen.dart
@@ -52,6 +52,7 @@ class _AgentScreenState extends ConsumerState<AgentScreen> {
   /// transcript survives sign-in because the plan notifier keeps its
   /// singleton ApiClient (the token mutates in place).
   void _openSignIn() {
+    warmSsoAvailability(context);
     Navigator.of(context).push(
       MaterialPageRoute(builder: (_) => const AuthScreen()),
     );

--- a/src/packages/flutter-app/lib/screens/auth_screen.dart
+++ b/src/packages/flutter-app/lib/screens/auth_screen.dart
@@ -225,6 +225,10 @@ class _AuthScreenState extends ConsumerState<AuthScreen> {
                       textAlign: TextAlign.center,
                     ),
                     const SizedBox(height: AppSpacing.xl),
+                    // One-tap sign-in first: position alone marks it the
+                    // default path. The block owns the "or" divider that
+                    // separates it from the email form below.
+                    const SsoButtons(),
                     TextFormField(
                       controller: _emailController,
                       keyboardType: TextInputType.emailAddress,
@@ -339,7 +343,7 @@ class _AuthScreenState extends ConsumerState<AuthScreen> {
                         onPressed: auth.loading ? null : _forgotPassword,
                         child: Text(l10n.authForgotPassword),
                       ),
-                    const SsoButtons(),
+                    const SsoLegalAgreement(),
                   ],
                 ),
               ),

--- a/src/packages/flutter-app/lib/screens/auth_screen.dart
+++ b/src/packages/flutter-app/lib/screens/auth_screen.dart
@@ -343,7 +343,10 @@ class _AuthScreenState extends ConsumerState<AuthScreen> {
                         onPressed: auth.loading ? null : _forgotPassword,
                         child: Text(l10n.authForgotPassword),
                       ),
-                    const SsoLegalAgreement(),
+                    // Sign-in only: sign-up already states the terms in the
+                    // blocking LegalConsentCheckbox above the button, and two
+                    // copies on one screen read as boilerplate.
+                    if (_isLogin) const SsoLegalAgreement(),
                   ],
                 ),
               ),

--- a/src/packages/flutter-app/lib/screens/connect_app_screen.dart
+++ b/src/packages/flutter-app/lib/screens/connect_app_screen.dart
@@ -62,6 +62,7 @@ class _ConnectAppScreenState extends ConsumerState<ConnectAppScreen> {
   }
 
   Future<void> _signIn() async {
+    warmSsoAvailability(context);
     await Navigator.of(context).push(
       MaterialPageRoute(builder: (_) => const AuthScreen()),
     );

--- a/src/packages/flutter-app/lib/screens/landing_screen.dart
+++ b/src/packages/flutter-app/lib/screens/landing_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../constants/app_info.dart';
 import '../l10n/l10n.dart';
 import '../providers/analytics_provider.dart';
+import '../providers/auth_provider.dart';
 import '../theme/app_colors.dart';
 import '../theme/spacing.dart';
 import '../widgets/brand_logo.dart';
@@ -55,6 +56,9 @@ class _LandingScreenState extends State<LandingScreen> {
   }
 
   static void _openAuth(BuildContext context, {required bool isLogin}) {
+    // Start the SSO availability fetches now so the route transition covers
+    // the round trip and the auth form doesn't get shoved down on arrival.
+    warmSsoAvailability(context);
     Navigator.of(context).push(
       MaterialPageRoute(
         builder: (_) => AuthScreen(initialIsLogin: isLogin),

--- a/src/packages/flutter-app/lib/screens/shared_trip_screen.dart
+++ b/src/packages/flutter-app/lib/screens/shared_trip_screen.dart
@@ -127,6 +127,7 @@ class _SharedTripBodyState extends ConsumerState<_SharedTripBody> {
   /// Routes through sign-in if needed; true when a session exists after.
   Future<bool> _ensureSignedIn() async {
     if (ref.read(authProvider).isSignedIn) return true;
+    warmSsoAvailability(context);
     await Navigator.of(context).push(
       MaterialPageRoute(builder: (_) => const AuthScreen()),
     );

--- a/src/packages/flutter-app/lib/widgets/legal_links.dart
+++ b/src/packages/flutter-app/lib/widgets/legal_links.dart
@@ -57,9 +57,10 @@ List<InlineSpan> _legalLinkSpans(
 }
 
 /// "By signing up you agree to the Terms of Service and Privacy Policy" —
-/// informational small print with tappable links. Used under the SSO buttons,
-/// where the provider's own click is the agreement (email sign-up uses the
-/// blocking [LegalConsentCheckbox] instead).
+/// informational small print with tappable links. Rendered as the auth
+/// screen's footer by `SsoLegalAgreement`, where the provider's own click is
+/// the agreement (email sign-up uses the blocking [LegalConsentCheckbox]
+/// instead).
 class LegalAgreementText extends StatefulWidget {
   const LegalAgreementText({super.key});
 

--- a/src/packages/flutter-app/lib/widgets/sso_buttons.dart
+++ b/src/packages/flutter-app/lib/widgets/sso_buttons.dart
@@ -7,19 +7,44 @@ import 'apple_sign_in_button.dart';
 import 'google_sign_in_button.dart';
 import 'legal_links.dart';
 
-/// The SSO section of the auth screen: one "or" divider above whichever
-/// provider buttons the backend has configured (Google, then Apple). Renders
-/// nothing when no provider is available, leaving the form unchanged.
+/// Which provider buttons the backend has configured. The two availabilities
+/// are independent futures over independent requests, so this reports nothing
+/// until BOTH have settled: resolving them one at a time would paint Apple
+/// alone and then insert Google *above* it, sliding a button that navigates
+/// the whole tab under the reader's finger.
+///
+/// The single place either widget below decides what is available — they must
+/// agree, or the small print can outlive the buttons it refers to.
+({bool google, bool apple}) _configuredProviders(WidgetRef ref) {
+  final google = ref.watch(googleSsoAvailableProvider);
+  final apple = ref.watch(appleSsoAvailableProvider);
+  if (google.isLoading || apple.isLoading) {
+    return (google: false, apple: false);
+  }
+  return (google: google.valueOrNull == true, apple: apple.valueOrNull == true);
+}
+
+/// The SSO section of the auth screen: whichever provider buttons are
+/// configured (Google, then Apple), above the single "or" divider that
+/// separates them from the email form beneath. Sits at the TOP of the auth
+/// column so one-tap sign-in is the default path; the matching small print is
+/// [SsoLegalAgreement], at the bottom. Renders nothing when no provider is
+/// available, leaving the form exactly as it was.
 class SsoButtons extends ConsumerWidget {
   const SsoButtons({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final google = ref.watch(googleSsoAvailableProvider).valueOrNull == true;
-    final apple = ref.watch(appleSsoAvailableProvider).valueOrNull == true;
+    final providers = _configuredProviders(ref);
+    final google = providers.google;
+    final apple = providers.apple;
     final theme = Theme.of(context);
-    // Availability resolves one round trip after first paint; animating the
-    // expansion keeps the block from popping in and yanking the form upward.
+    // Availability resolves one round trip after first paint (unless
+    // warmSsoAvailability got there first), so animate rather than pop the
+    // form downward. topCenter anchors the child's top edge, which lets the
+    // block wipe in downward with the buttons growing in place — bottomCenter
+    // would clip from the top and slide the primary CTA out from behind the
+    // title instead.
     return AnimatedSize(
       duration: const Duration(milliseconds: 200),
       alignment: Alignment.topCenter,
@@ -28,6 +53,9 @@ class SsoButtons extends ConsumerWidget {
           : Column(
               crossAxisAlignment: CrossAxisAlignment.stretch,
               children: [
+                if (google) const GoogleSignInButton(),
+                if (google && apple) const SizedBox(height: AppSpacing.md),
+                if (apple) const AppleSignInButton(),
                 const SizedBox(height: AppSpacing.lg + AppSpacing.xs),
                 Row(
                   children: [
@@ -41,16 +69,43 @@ class SsoButtons extends ConsumerWidget {
                     const Expanded(child: Divider()),
                   ],
                 ),
+                // Trailing, not leading: the auth column's own gap under the
+                // title spaces the block from above, this one spaces it from
+                // the email field below.
                 const SizedBox(height: AppSpacing.lg + AppSpacing.xs),
-                if (google) const GoogleSignInButton(),
-                if (google && apple) const SizedBox(height: AppSpacing.md),
-                if (apple) const AppleSignInButton(),
-                const SizedBox(height: AppSpacing.md),
-                // Informational — the provider's own click is the agreement.
-                // Email sign-up uses the blocking LegalConsentCheckbox.
-                const LegalAgreementText(),
               ],
             ),
+    );
+  }
+}
+
+/// The small print that belongs to [SsoButtons] — informational, because the
+/// provider's own click is the agreement (email sign-up uses the blocking
+/// [LegalConsentCheckbox] instead). It is a separate widget because the
+/// buttons sit at the top of the auth column and this reads as the page
+/// footer at the bottom; it carries the same availability gate so no provider
+/// configured still means no small print.
+class SsoLegalAgreement extends ConsumerWidget {
+  const SsoLegalAgreement({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final providers = _configuredProviders(ref);
+    final any = providers.google || providers.apple;
+    // Same curve as SsoButtons: both ends of the column settle together
+    // instead of one easing while the other snaps.
+    return AnimatedSize(
+      duration: const Duration(milliseconds: 200),
+      alignment: Alignment.topCenter,
+      child: any
+          ? const Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                SizedBox(height: AppSpacing.md),
+                LegalAgreementText(),
+              ],
+            )
+          : const SizedBox(width: double.infinity),
     );
   }
 }

--- a/src/packages/flutter-app/lib/widgets/sso_buttons.dart
+++ b/src/packages/flutter-app/lib/widgets/sso_buttons.dart
@@ -80,11 +80,14 @@ class SsoButtons extends ConsumerWidget {
 }
 
 /// The small print that belongs to [SsoButtons] — informational, because the
-/// provider's own click is the agreement (email sign-up uses the blocking
-/// [LegalConsentCheckbox] instead). It is a separate widget because the
+/// provider's own click is the agreement. It is a separate widget because the
 /// buttons sit at the top of the auth column and this reads as the page
 /// footer at the bottom; it carries the same availability gate so no provider
 /// configured still means no small print.
+///
+/// The auth screen renders this in **sign-in mode only**: sign-up states the
+/// same terms in the blocking [LegalConsentCheckbox] right above its button,
+/// and showing both turns the agreement into boilerplate.
 class SsoLegalAgreement extends ConsumerWidget {
   const SsoLegalAgreement({super.key});
 

--- a/src/packages/flutter-app/test/auth_polish_test.dart
+++ b/src/packages/flutter-app/test/auth_polish_test.dart
@@ -81,11 +81,19 @@ Finder _dialogField(int index) => find
     .descendant(of: find.byType(AlertDialog), matching: find.byType(TextField))
     .at(index);
 
-Future<void> _signInAttempt(WidgetTester tester) async {
+/// The email submit button, by its label. Deliberately NOT
+/// `find.byType(FilledButton).first`: the SSO block now precedes the form and
+/// Apple's button is a FilledButton too, so `.first` would silently become
+/// "Continue with Apple" the moment a fake here reports Apple available.
+Finder _submitButton(String label) =>
+    find.ancestor(of: find.text(label), matching: find.byType(FilledButton));
+
+Future<void> _signInAttempt(WidgetTester tester,
+    {String label = 'Sign in'}) async {
   await tester.enterText(
       find.byType(TextFormField).at(0), 'traveler@example.com');
   await tester.enterText(find.byType(TextFormField).at(1), 'wrong-password');
-  await tester.tap(find.byType(FilledButton).first);
+  await tester.tap(_submitButton(label));
   await tester.pumpAndSettle();
 }
 
@@ -98,7 +106,7 @@ void main() {
     await tester.pumpWidget(_wrap(service, locale: const Locale('es')));
     await tester.pump();
 
-    await _signInAttempt(tester);
+    await _signInAttempt(tester, label: 'Iniciar sesión');
 
     expect(find.text('Correo o contraseña incorrectos.'), findsOneWidget);
     expect(find.textContaining('invalid email'), findsNothing);
@@ -148,7 +156,8 @@ void main() {
     expect(box().value, isTrue);
 
     // Create-account button arms only once consent is given.
-    final button = tester.widget<FilledButton>(find.byType(FilledButton).first);
+    final button =
+        tester.widget<FilledButton>(_submitButton('Create account'));
     expect(button.onPressed, isNotNull);
   });
 

--- a/src/packages/flutter-app/test/auth_screen_sso_order_test.dart
+++ b/src/packages/flutter-app/test/auth_screen_sso_order_test.dart
@@ -5,6 +5,7 @@ import 'package:travel_route_planner/providers/auth_provider.dart';
 import 'package:travel_route_planner/screens/auth_screen.dart';
 import 'package:travel_route_planner/services/auth_service.dart';
 import 'package:travel_route_planner/services/auth_storage.dart';
+import 'package:travel_route_planner/widgets/legal_links.dart';
 
 import 'support/l10n_test_app.dart';
 
@@ -37,14 +38,20 @@ class _FakeAuthStorage extends AuthStorage {
   Future<void> clearToken() async {}
 }
 
-Widget _wrap({required bool google, required bool apple}) {
+Widget _wrap({
+  required bool google,
+  required bool apple,
+  bool initialIsLogin = true,
+}) {
   return ProviderScope(
     overrides: [
       authServiceProvider
           .overrideWithValue(_FakeAuthService(google: google, apple: apple)),
       authStorageProvider.overrideWithValue(_FakeAuthStorage()),
     ],
-    child: localizedTestApp(home: const AuthScreen()),
+    child: localizedTestApp(
+      home: AuthScreen(initialIsLogin: initialIsLogin),
+    ),
   );
 }
 
@@ -55,10 +62,12 @@ Future<void> _pumpAuth(
   WidgetTester tester, {
   required bool google,
   required bool apple,
+  bool initialIsLogin = true,
 }) async {
   await tester.binding.setSurfaceSize(const Size(420, 1200));
   addTearDown(() => tester.binding.setSurfaceSize(null));
-  await tester.pumpWidget(_wrap(google: google, apple: apple));
+  await tester.pumpWidget(_wrap(
+      google: google, apple: apple, initialIsLogin: initialIsLogin));
   // Drains the availability futures AND the 200ms AnimatedSize; measuring a
   // mid-animation frame would compare clipped positions.
   await tester.pumpAndSettle();
@@ -98,6 +107,36 @@ void main() {
         lessThan(y(tester, find.text('or'))));
     expect(y(tester, find.text('or')), lessThan(y(tester, emailField)));
     expect(y(tester, emailField), lessThan(y(tester, signInButton)));
+  });
+
+  testWidgets('sign-up states the terms once — the checkbox, not the footer',
+      (tester) async {
+    await _pumpAuth(tester, google: true, apple: false, initialIsLogin: false);
+
+    // The blocking consent row is the agreement in sign-up mode; repeating it
+    // as a footer turned the terms into boilerplate.
+    expect(find.byType(LegalConsentCheckbox), findsOneWidget);
+    expect(find.textContaining('Terms of Service'), findsOneWidget);
+    expect(
+        y(tester, find.textContaining('Terms of Service')),
+        lessThan(y(
+            tester,
+            find.ancestor(
+                of: find.text('Create account'),
+                matching: find.byType(FilledButton)))));
+
+    // Still SSO-first, and the checkbox did not eat the Google button.
+    expect(find.text('Continue with Google'), findsOneWidget);
+    expect(y(tester, find.text('Continue with Google')),
+        lessThan(y(tester, find.byType(TextFormField).first)));
+  });
+
+  testWidgets('sign-in keeps the footer — no consent row to carry the terms',
+      (tester) async {
+    await _pumpAuth(tester, google: true, apple: false);
+
+    expect(find.byType(LegalConsentCheckbox), findsNothing);
+    expect(find.textContaining('Terms of Service'), findsOneWidget);
   });
 
   testWidgets('no provider configured leaves the form where it was',

--- a/src/packages/flutter-app/test/auth_screen_sso_order_test.dart
+++ b/src/packages/flutter-app/test/auth_screen_sso_order_test.dart
@@ -1,0 +1,117 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:travel_route_planner/providers/auth_provider.dart';
+import 'package:travel_route_planner/screens/auth_screen.dart';
+import 'package:travel_route_planner/services/auth_service.dart';
+import 'package:travel_route_planner/services/auth_storage.dart';
+
+import 'support/l10n_test_app.dart';
+
+/// One-tap sign-in is the default path: the SSO buttons sit ABOVE the email
+/// form, separated from it by the "or" divider, and the legal small print
+/// stays the page footer. Ordering is the entire point of that change, so it
+/// gets asserted by geometry — presence-only checks (sso_buttons_test.dart)
+/// pass just as happily with the block back at the bottom.
+class _FakeAuthService extends AuthService {
+  final bool google;
+  final bool apple;
+  _FakeAuthService({required this.google, required this.apple})
+      : super(baseUrl: 'http://unused');
+
+  @override
+  Future<bool> googleSignInAvailable() async => google;
+
+  @override
+  Future<bool> appleSignInAvailable() async => apple;
+}
+
+class _FakeAuthStorage extends AuthStorage {
+  @override
+  Future<String?> loadToken() async => null;
+
+  @override
+  Future<void> saveToken(String value) async {}
+
+  @override
+  Future<void> clearToken() async {}
+}
+
+Widget _wrap({required bool google, required bool apple}) {
+  return ProviderScope(
+    overrides: [
+      authServiceProvider
+          .overrideWithValue(_FakeAuthService(google: google, apple: apple)),
+      authStorageProvider.overrideWithValue(_FakeAuthStorage()),
+    ],
+    child: localizedTestApp(home: const AuthScreen()),
+  );
+}
+
+/// Tall enough that the whole column stays on screen — the login form alone
+/// nearly fills the default 800x600 surface, and `getTopLeft` on a widget
+/// scrolled out of view is not what these assertions mean to compare.
+Future<void> _pumpAuth(
+  WidgetTester tester, {
+  required bool google,
+  required bool apple,
+}) async {
+  await tester.binding.setSurfaceSize(const Size(420, 1200));
+  addTearDown(() => tester.binding.setSurfaceSize(null));
+  await tester.pumpWidget(_wrap(google: google, apple: apple));
+  // Drains the availability futures AND the 200ms AnimatedSize; measuring a
+  // mid-animation frame would compare clipped positions.
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  double y(WidgetTester tester, Finder f) => tester.getTopLeft(f).dy;
+
+  // With Apple configured its black FilledButton precedes the submit button in
+  // tree order, so `find.byType(FilledButton).first` is NOT "Sign in".
+  final signInButton = find.ancestor(
+    of: find.text('Sign in'),
+    matching: find.byType(FilledButton),
+  );
+  final emailField = find.byType(TextFormField).first;
+
+  testWidgets('Google sits above the "or" divider and the email form',
+      (tester) async {
+    await _pumpAuth(tester, google: true, apple: false);
+
+    expect(y(tester, find.text('Continue with Google')),
+        lessThan(y(tester, find.text('or'))));
+    expect(y(tester, find.text('or')), lessThan(y(tester, emailField)));
+    expect(y(tester, emailField), lessThan(y(tester, signInButton)));
+
+    // The small print stays the footer rather than riding the buttons up.
+    expect(y(tester, find.textContaining('Terms of Service')),
+        greaterThan(y(tester, signInButton)));
+  });
+
+  testWidgets('Google above Apple, both above the form', (tester) async {
+    await _pumpAuth(tester, google: true, apple: true);
+
+    expect(y(tester, find.text('Continue with Google')),
+        lessThan(y(tester, find.text('Continue with Apple'))));
+    expect(y(tester, find.text('Continue with Apple')),
+        lessThan(y(tester, find.text('or'))));
+    expect(y(tester, find.text('or')), lessThan(y(tester, emailField)));
+    expect(y(tester, emailField), lessThan(y(tester, signInButton)));
+  });
+
+  testWidgets('no provider configured leaves the form where it was',
+      (tester) async {
+    await _pumpAuth(tester, google: false, apple: false);
+
+    expect(find.text('or'), findsNothing);
+    expect(find.text('Continue with Google'), findsNothing);
+    expect(find.textContaining('Terms of Service'), findsNothing);
+
+    // The block collapses to nothing: the email field sits exactly one
+    // AppSpacing.xl (24) under the title, as it did before SSO moved up.
+    final title = find.text('Welcome back');
+    expect(y(tester, emailField) - tester.getBottomLeft(title).dy,
+        closeTo(24, 0.01));
+  });
+}


### PR DESCRIPTION
## Summary

- **Google (and Apple) move above the email form.** On the sign-in screen the SSO block sat last — under the email form, Sign in, the Sign up toggle and Forgot password — so a new visitor read the whole password form before discovering one-tap Google. Position now marks it the default; the `or` divider separates SSO from the form beneath.
- **Emphasis deliberately unchanged.** Google keeps its `OutlinedButton`, the email **Sign in** button keeps the filled teal `FilledButton` — the conventional pattern, and it keeps the Google brand button on a neutral surface. The email form stays fully visible (no "Continue with email" disclosure).
- **`SsoButtons` inverts** (buttons → divider) and its self-owned 20px gap flips from leading to trailing; the column's existing `AppSpacing.xl` under the title now spaces it from above.
- **New `SsoLegalAgreement`** carries the legal small print, so it stays the page footer rather than landing between the Google button and the email fields — directly above sign-up's blocking `LegalConsentCheckbox`. It renders in **sign-in mode only**: sign-up already states the same terms in that checkbox, and two copies on one screen read as boilerplate, which is what a consent notice must not be.
- **One availability gate, `_configuredProviders`.** Both widgets wait for *both* futures to settle. Reading them independently could paint Apple alone and then insert Google above it, sliding a button that navigates the whole tab (`webOnlyWindowName: '_self'`) under the reader's finger.
- **`warmSsoAvailability()`** starts the two availability fetches on the tap that opens `AuthScreen` (all four push sites), so the route transition absorbs the round trip instead of the form dropping ~108px after first paint. Deliberately *not* at boot — that would rejoin the cold-start burst behind the earlier 429 incident.

No `.arb` / `gen-l10n` changes: `ssoContinueWithGoogle`, `ssoContinueWithApple` and `ssoDividerOr` all already exist. No Go/API changes.

## Testing

- `flutter analyze` — clean (only 3 pre-existing infos in `lib/models/route_response.dart`).
- `flutter test` — **1140 passed**, including the auth suites that were most at risk (`sso_buttons_test`, `auth_polish_test`, `auth_autofill_submit_test`, `language_menu_button_test`, `agent_screen_banner_test`).
- **New `test/auth_screen_sso_order_test.dart`** pins the thing this PR is actually about — vertical order, which nothing asserted before. Five cases: Google-only, Google + Apple, neither-configured (the email field must sit exactly `AppSpacing.xl` under the title, i.e. no visual change when SSO is off), plus the two legal-copy cases — sign-up finds `Terms of Service` **exactly once** and above Create account, sign-in keeps the footer and has no consent row.
- **Hardened two index-fragile finders** in `auth_polish_test.dart`: `find.byType(FilledButton).first` was correct only because that fake reports Apple unavailable — with Apple on, `.first` becomes the black Apple button. Both now resolve by label via `find.ancestor`.
- **Manual run** against this lane's stack in headless Chrome, dark theme: sign-in and sign-up at 1440px and at 360px, in English and Spanish (`Continuar con Google` / `o`) — correct order everywhere, no overflow, terms stated once per mode. Confirmed the cold path too: on a fresh load the block resolves *during* the route transition, and the settled screen shows no jump.

## Notes for review

- Prod currently reports Google `available: true`, Apple `available: false`, so only the Google button renders today — but both paths are exercised by the new tests, since `ios-app-store` will turn Apple on. When it does, Apple's black `FilledButton` will sit above the teal Sign in; that tension exists today in reverse order and is left alone here rather than widening scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)