### PR TITLE
fix(trips): make "Your travels" its own section, not part of Upcoming

### DIFF
--- a/src/packages/flutter-app/lib/screens/trips_list_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trips_list_screen.dart
@@ -220,18 +220,30 @@ class _TripsListScreenState extends ConsumerState<TripsListScreen> {
                     ),
                   for (final t in upcomingCards)
                     _TripCard(trip: t, isAdmin: isAdmin),
-                  // "Your travels": the retrospective band, placed where the
-                  // page turns from plans to history — after the upcoming
-                  // cards, bridging into Past trips. Page gravity stays
-                  // action-first above it.
-                  if (showFootprint)
+                  // "Your travels": the retrospective section, where the page
+                  // turns from plans to history. Its own titled section, not
+                  // a card in the Upcoming run — an unlabeled map over a
+                  // stats panel is the "Up next" hero's silhouette, so at the
+                  // 8px card gap it read as another upcoming trip. The header
+                  // and the card share one gate: a title with nothing under
+                  // it is worse than neither.
+                  //
+                  // AppSpacing.xl is this page's section seam from here down —
+                  // Past trips and Shared with you use the same 24px, so the
+                  // three sections below Upcoming read as peers. Dropping any
+                  // one of them back to sm re-attaches that section to the one
+                  // above it.
+                  if (showFootprint) ...[
                     Padding(
-                      padding: const EdgeInsets.only(top: AppSpacing.sm),
-                      child: TravelFootprintCard(pins: pins, stats: stats),
+                      padding: const EdgeInsets.fromLTRB(
+                          AppSpacing.xs, AppSpacing.xl, 0, AppSpacing.sm),
+                      child: SectionHeader(title: l10n.tripsListYourTravels),
                     ),
+                    TravelFootprintCard(pins: pins, stats: stats),
+                  ],
                   if (groups.past.isNotEmpty)
                     Padding(
-                      padding: const EdgeInsets.only(top: AppSpacing.sm),
+                      padding: const EdgeInsets.only(top: AppSpacing.xl),
                       child: CollapsibleSection(
                         title: l10n.tripsListPastTrips,
                         icon: Icons.history,
@@ -267,7 +279,7 @@ class _TripsListScreenState extends ConsumerState<TripsListScreen> {
                   if (sharedOrdered.isNotEmpty) ...[
                     Padding(
                       padding: const EdgeInsets.fromLTRB(
-                          AppSpacing.xs, AppSpacing.lg, 0, AppSpacing.sm),
+                          AppSpacing.xs, AppSpacing.xl, 0, AppSpacing.sm),
                       child: SectionHeader(title: l10n.tripsListSharedWithYou),
                     ),
                     for (final t in sharedOrdered)

--- a/src/packages/flutter-app/lib/widgets/travel_footprint_card.dart
+++ b/src/packages/flutter-app/lib/widgets/travel_footprint_card.dart
@@ -9,13 +9,21 @@ import '../theme/spacing.dart';
 import 'app_map.dart';
 import 'stat_tile_row.dart';
 
-/// The "Your travels" block on the trips list: a world map pinning every hub
-/// city across the user's owned trips, with lifetime stat tiles beneath — the
-/// retrospective bridge between the Upcoming cards above it and the Past
-/// section below. One merged card (not separate stats + map bands) so the
+/// The body of the "Your travels" section on the trips list: a world map
+/// pinning every hub city across the user's owned trips, with lifetime stat
+/// tiles beneath. One merged card (not separate stats + map bands) so the
 /// sparse one-trip-each-way page gains a single substantial scroll stop, and
 /// so the whole block shares one gating story: with no located cities the map
-/// sub-band collapses and the card degrades to a labeled stats strip.
+/// sub-band collapses and the card degrades to a bare stats strip.
+///
+/// **Unlabeled by design** — the "Your travels" title is a page-level
+/// SectionHeader the caller renders directly above, under the same gate.
+/// This card carried its own in-card header until 2026-08-14; that read as
+/// clutter-avoidance at the time but cost more than it saved, because a map
+/// over an info panel IS the "Up next" hero's silhouette. With the only label
+/// tucked *under* the map, the eye hit an unlabeled map inside a run of trip
+/// cards and parsed the whole thing as another upcoming trip. A section's
+/// label has to sit outside and above its visual, not inside it.
 ///
 /// Neutral [Card] chrome on purpose — the brand gradient stays reserved for
 /// the two promoted cards (live spotlight, "Up next" hero). Pins come from
@@ -38,7 +46,6 @@ class TravelFootprintCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
     final l10n = context.l10n;
     // Zero-valued tiles drop out segment-wise (undated trips contribute no
     // travel days, city-less legacy rows no cities), same rule the old
@@ -76,29 +83,7 @@ class TravelFootprintCard extends StatelessWidget {
             ),
           Padding(
             padding: const EdgeInsets.all(AppSpacing.lg),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                // In-card header (not a page-level SectionHeader): a third
-                // header tier between "Upcoming" and "Past trips" would read
-                // as clutter, and the label must stay attached when the map
-                // collapses.
-                Row(
-                  children: [
-                    Icon(Icons.public,
-                        size: 18, color: theme.colorScheme.onSurfaceVariant),
-                    const SizedBox(width: AppSpacing.sm),
-                    Text(
-                      l10n.tripsListYourTravels,
-                      style: theme.textTheme.titleSmall
-                          ?.copyWith(fontWeight: FontWeight.w600),
-                    ),
-                  ],
-                ),
-                const SizedBox(height: AppSpacing.sm),
-                StatTileRow(tiles: tiles),
-              ],
-            ),
+            child: StatTileRow(tiles: tiles),
           ),
         ],
       ),

--- a/src/packages/flutter-app/test/trips_list_footprint_test.dart
+++ b/src/packages/flutter-app/test/trips_list_footprint_test.dart
@@ -14,16 +14,22 @@ import 'package:travel_route_planner/screens/trips_list_screen.dart';
 import 'package:travel_route_planner/services/api_client.dart';
 import 'package:travel_route_planner/services/trip_cache.dart';
 import 'package:travel_route_planner/services/trips_api_service.dart';
+import 'package:travel_route_planner/widgets/section_header.dart';
 import 'package:travel_route_planner/widgets/stat_tile_row.dart';
 import 'package:travel_route_planner/widgets/travel_footprint_card.dart';
 
 import 'support/l10n_test_app.dart';
 
-/// The "Your travels" band on the trips list (specs/trips-page-insights): the
-/// lifetime stat tiles plus the footprint map, gated at 2+ OWNED trips —
+/// The "Your travels" section on the trips list (specs/trips-page-insights):
+/// the lifetime stat tiles plus the footprint map, gated at 2+ OWNED trips —
 /// shared-with-me is someone else's travel and carries none of the fields.
 /// The map sub-band is gated separately on having pins; with none the card
-/// degrades to header + tiles rather than showing an empty globe.
+/// degrades to a bare stats strip rather than showing an empty globe.
+///
+/// The "Your travels" title is a page-level SectionHeader ABOVE the card, not
+/// inside it — an unlabeled map over a stats panel is the "Up next" hero's
+/// silhouette, so an in-card label let the whole thing read as another
+/// upcoming trip. Header and card share one gate, so neither renders alone.
 ///
 /// Dates are relative to DateTime.now() so the all-time totals stay
 /// deterministic. Tile HTTP in widget tests 400s and is silently tolerated,
@@ -111,6 +117,16 @@ void main() {
     expect(find.text('Your travels'), findsOneWidget);
     expect(_inBand(find.byType(FlutterMap)), findsOneWidget);
     expect(_inBand(find.byType(StatTileRow)), findsOneWidget);
+    // The label sits ABOVE the card as a page-level section header, never
+    // inside it: an in-card label under the map is what let this read as
+    // another upcoming trip card.
+    expect(_inBand(find.text('Your travels')), findsNothing);
+    // ...and it renders as a peer of "Upcoming", not as card chrome.
+    expect(
+      find.ancestor(
+          of: find.text('Your travels'), matching: find.byType(SectionHeader)),
+      findsOneWidget,
+    );
   });
 
   testWidgets('one owned trip gets no band — even beside a shared trip',
@@ -147,10 +163,12 @@ void main() {
     expect(find.text('Your travels'), findsNothing);
   });
 
-  testWidgets('pin-less trips collapse the map but keep header and tiles',
+  testWidgets('pin-less trips collapse the map but keep the header and tiles',
       (WidgetTester tester) async {
     // Old server, or trips whose items are all unlocated: coordinates are
-    // never invented, so the card degrades to a labeled stats strip.
+    // never invented, so the card degrades to a bare stats strip. The section
+    // header is a sibling above it, so the tiles stay labeled either way —
+    // one of the reasons the label moved out of the card.
     await _pumpList(tester, trips: [
       _trip('t1', 'Lisbon Trip',
           start: _rel(10), end: _rel(13), cities: const ['Lisbon']),


### PR DESCRIPTION
## Summary

On My Trips, the lifetime **"Your travels"** band read as if it were another *upcoming trip*. Two causes, both fixed here:

- **No separation** — it sat in the run of cards under the single "Upcoming" header at `AppSpacing.sm` (8px), the same gap that separates two trip cards.
- **Silhouette mimicry** — its only label lived *inside* the card, below a 140px world map. That is exactly the "Up next" hero's shape (map on top, info panel beneath), so the eye hit an unlabeled map inside a list of trip cards and parsed "trip card #2".

Changes:

- Promote "Your travels" to a page-level `SectionHeader` above the card — the same bold `titleMedium` tier as "Upcoming" and "Shared with you", so it reads as a peer section.
- Drop the now-duplicate in-card header row (globe + label) from `TravelFootprintCard`, plus the local `theme` it was the only reader of and the single-child `Column` it left behind.
- Open the seam above it from `sm` (8) to `xl` (24). **Past trips** and **Shared with you** take the same 24px so the three sections below Upcoming share one rhythm — otherwise the ambiguity just moves down a notch.
- Header and card sit inside the **same** `showFootprint` gate, so a title can never render with nothing under it.

Reuses the existing `tripsListYourTravels` key — no `.arb` change, no `gen-l10n` regen, so Spanish comes along unchanged. No server change, no migration.

This reverses the in-card-header decision from `specs/trips-page-insights`. The reasoning is **rewritten** onto `TravelFootprintCard`'s dartdoc rather than deleted, so the next reader sees why it moved.

## Testing

- `flutter analyze` — clean (only 3 pre-existing infos in the unrelated `models/route_response.dart`).
- `flutter test` — **1166 tests pass**. The added vertical space did not push "Past trips" off-screen in the 800x600 test viewport, so no `ensureVisible` changes were needed.
- New assertions in `trips_list_footprint_test.dart` pin the invariant this change establishes: "Your travels" is **not** a descendant of `TravelFootprintCard`, and it **is** a descendant of `SectionHeader`.
- **Live browser check** on a lane stack against a seeded 2-trip fixture reproducing the reported screenshot (37-day upcoming trip with the booking nudge + a 2-day past trip, 10 city pins):
  - 1440px desktop — three unmistakable sections: Upcoming → Your travels → Past trips.
  - 390px phone — no overflow, stat tiles fit, seams hold.
  - Light **and** dark themes — the new header has correct contrast in both.

Note: map tile imagery does not paint in headless Chrome (zero tile requests are issued); pins render correctly and `app_map.dart` is untouched by this diff, so that is an environment artifact, not a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)