### PR TITLE
fix(map): stop drawing a home-airport flight leg on ground trips

### DIFF
--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -52,6 +52,7 @@ import '../utils/money_format.dart';
 import '../utils/share_link.dart';
 import '../utils/tracked_launch.dart';
 import '../utils/trip_days.dart';
+import '../utils/travel_mode.dart';
 import '../utils/trip_format.dart';
 import '../utils/trip_legs.dart';
 import '../widgets/add_itinerary_item_dialog.dart';
@@ -897,13 +898,9 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
   /// The trip's stated non-flight travel mode ('car'|'train'|'bus'|'ferry')
   /// when set, else null. Such trips derive their legs in that mode with
   /// Rome2Rio route links instead of flight defaults; flight/mixed and unset
-  /// keep the legacy Greek-ferry-else-flight behavior.
-  static String? _groundModeOf(Trip trip) {
-    final tm = trip.travelMode;
-    return (tm == 'car' || tm == 'train' || tm == 'bus' || tm == 'ferry')
-        ? tm
-        : null;
-  }
+  /// keep the legacy Greek-ferry-else-flight behavior. Shared with the map's
+  /// home-leg gate — see [groundTravelMode].
+  static String? _groundModeOf(Trip trip) => groundTravelMode(trip.travelMode);
 
   /// Computes per-leg travel times for the itinerary in its existing display
   /// order by calling /optimize-route in preserve-order mode (no reordering).
@@ -2852,6 +2849,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
         if (e.todo case final todo?)
           BookingTodoRow(
             todo: todo,
+            tripTravelMode: _trip?.travelMode,
             compact: _narrow,
             onBookedChanged: (v) => _setRowBooked(v,
                 todo: todo, stay: e.stay, segment: e.segment),
@@ -4897,6 +4895,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
             final home = homeOverlayFor(
               ref,
               homeAirport: _homeAirport,
+              travelMode: trip.travelMode,
               focusedLegIndex:
                   focusKey == null ? null : derivation.legIndexOf(focusKey),
               legCount: derivation.legs.length,
@@ -5068,6 +5067,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
           title: _displayTitle(trip),
           destinations: derivation.mapDestinations,
           homeAirport: _homeAirport,
+          travelMode: trip.travelMode,
           firstCityPoint: endpoints.first,
           lastCityPoint: endpoints.last,
           itemsForLeg: (k) {

--- a/src/packages/flutter-app/lib/screens/trip_map_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_map_screen.dart
@@ -8,6 +8,7 @@ import '../models/accommodation.dart';
 import '../models/itinerary_item.dart';
 import '../providers/flights_provider.dart';
 import '../utils/snack.dart';
+import '../utils/travel_mode.dart';
 import '../widgets/app_map.dart';
 import '../widgets/gradient_app_bar.dart';
 import '../widgets/map_leg_chips.dart';
@@ -25,11 +26,17 @@ import '../widgets/trip_map.dart';
 TripMapHome? homeOverlayFor(
   WidgetRef ref, {
   required String? homeAirport,
+  required String? travelMode,
   required int? focusedLegIndex, // null = All
   required int legCount,
   required LatLng? firstCityPoint,
   required LatLng? lastCityPoint,
 }) {
+  // A saved home *airport* only says where this traveler flies from. On a
+  // stated ground trip it is not the origin — someone driving to Montreal from
+  // upstate New York does not set out from Newark — so drawing a leg from it
+  // would invent a journey the trip never described. Say nothing instead.
+  if (groundTravelMode(travelMode) != null) return null;
   final code = homeAirport;
   if (code == null || code.isEmpty) return null;
   final point = ref.watch(homeAirportPointProvider(code)).valueOrNull;
@@ -90,6 +97,10 @@ class TripMapScreen extends ConsumerStatefulWidget {
   /// city coordinates it draws the journey's home legs (owner surfaces only —
   /// shared views pass nothing). Null = no home overlay.
   final String? homeAirport;
+
+  /// The trip's `travel_mode`. A stated ground mode suppresses the home-airport
+  /// overlay entirely (see [homeOverlayFor]).
+  final String? travelMode;
   final LatLng? firstCityPoint;
   final LatLng? lastCityPoint;
 
@@ -111,6 +122,7 @@ class TripMapScreen extends ConsumerStatefulWidget {
     this.initialLegKey,
     this.onAddPlace,
     this.homeAirport,
+    this.travelMode,
     this.firstCityPoint,
     this.lastCityPoint,
     this.destinations,
@@ -127,6 +139,7 @@ class _TripMapScreenState extends ConsumerState<TripMapScreen> {
   TripMapHome? _homeOverlay() => homeOverlayFor(
         ref,
         homeAirport: widget.homeAirport,
+        travelMode: widget.travelMode,
         focusedLegIndex: _legKey == null
             ? null
             : widget.legChips.indexWhere((c) => c.key == _legKey),

--- a/src/packages/flutter-app/lib/utils/travel_mode.dart
+++ b/src/packages/flutter-app/lib/utils/travel_mode.dart
@@ -1,0 +1,17 @@
+/// The trip's stated non-flight travel mode ('car'|'train'|'bus'|'ferry') when
+/// it has one, else null.
+///
+/// 'flight', 'mixed' and unset all return null on purpose: 'mixed' means the
+/// trip has no single mode (so a flight leg is still plausible) and unset is
+/// the legacy default. Mirrors the server's reading of `trips.travel_mode`
+/// (`allowedTravelModes` in trip_handler.go, and the same narrowing in
+/// trip_review.go).
+///
+/// Derived in one place because two very different surfaces branch on it: the
+/// booking-todo derivation (a ground trip books Rome2Rio routes, not flights)
+/// and the map's home-airport leg (a saved home *airport* is a flying concept,
+/// so it is not where a road trip starts).
+String? groundTravelMode(String? travelMode) => switch (travelMode) {
+      'car' || 'train' || 'bus' || 'ferry' => travelMode,
+      _ => null,
+    };

--- a/src/packages/flutter-app/lib/widgets/booking_todo_card.dart
+++ b/src/packages/flutter-app/lib/widgets/booking_todo_card.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import '../l10n/l10n.dart';
 import '../models/booking_todo.dart';
+import '../utils/travel_mode.dart';
 import 'booking_sheets.dart' show transportModeIcon, transportModeLabel;
 
 IconData _kindIcon(BookingTodo todo) {
@@ -186,6 +187,12 @@ class BookingTodoRow extends StatelessWidget {
   /// whose mode truth is a confirmed segment) keeps the plain icon.
   final ValueChanged<String>? onModeChanged;
 
+  /// The trip's `travel_mode`, so a leg with no override can still name the
+  /// mode it was derived in. Without it a Rome2Rio ground leg has nothing to
+  /// point at — 'rome2rio' alone doesn't say car, train or bus — and the menu
+  /// opens with nothing checked on a trip that plainly stated how it travels.
+  final String? tripTravelMode;
+
   const BookingTodoRow({
     super.key,
     required this.todo,
@@ -195,6 +202,7 @@ class BookingTodoRow extends StatelessWidget {
     this.onAddDetails,
     this.compact = false,
     this.onModeChanged,
+    this.tripTravelMode,
   });
 
   @override
@@ -213,7 +221,10 @@ class BookingTodoRow extends StatelessWidget {
             child: Align(
               alignment: Alignment.centerLeft,
               child: todo.kind == 'transport' && onModeChanged != null
-                  ? _ModeMenu(todo: todo, onModeChanged: onModeChanged!)
+                  ? _ModeMenu(
+                      todo: todo,
+                      tripTravelMode: tripTravelMode,
+                      onModeChanged: onModeChanged!)
                   : Icon(_kindIcon(todo),
                       size: 18, color: theme.colorScheme.primary),
             ),
@@ -302,22 +313,32 @@ class BookingTodoRow extends StatelessWidget {
 }
 
 /// The row's per-leg mode picker: the kind icon plus a dropdown caret, opening
-/// a menu of the five leg modes. The current mode (the override when set, else
-/// the one the provider implies) is checkmarked; 'rome2rio' alone can't name a
-/// ground mode, so such rows simply show no checkmark until overridden.
+/// a menu of the five leg modes, with the current mode checkmarked.
+///
+/// "Current" is the same ladder the server walks in `transportSlotMode`
+/// (trip_next_step.go): an explicit per-leg override, else what the provider
+/// implies, else the trip's own ground mode. That last rung matters because
+/// 'rome2rio' is the link for driving, training and busing alike — without the
+/// trip to ask, a car trip's legs opened this menu with nothing checked.
 class _ModeMenu extends StatelessWidget {
   static const _legModes = ['flight', 'car', 'train', 'bus', 'ferry'];
 
   final BookingTodo todo;
+  final String? tripTravelMode;
   final ValueChanged<String> onModeChanged;
 
-  const _ModeMenu({required this.todo, required this.onModeChanged});
+  const _ModeMenu({
+    required this.todo,
+    required this.onModeChanged,
+    this.tripTravelMode,
+  });
 
   String? get _currentMode =>
       todo.mode ??
       switch (todo.provider) {
         'ferry' => 'ferry',
         'google_flights' => 'flight',
+        'rome2rio' => groundTravelMode(tripTravelMode),
         _ => null,
       };
 

--- a/src/packages/flutter-app/test/trip_detail_home_legs_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_home_legs_test.dart
@@ -111,13 +111,14 @@ void main() {
   const homePoint = (lat: 40.6895, lng: -74.1745);
 
   // Three legs so the gate has a first, a middle, and a last.
-  final trip = Trip(
+  Trip makeTrip({String? travelMode}) => Trip(
     id: 't1',
     title: 'Grand tour',
     createdAt: '2026-06-01',
     updatedAt: '2026-06-01',
     startDate: '2026-09-01',
     endDate: '2026-09-03',
+    travelMode: travelMode,
     items: [
       _item(0, 'Louvre', 'Paris', 48.8606, 2.3376, 1),
       _item(1, 'Colosseum', 'Rome', 41.8902, 12.4922, 2),
@@ -135,11 +136,18 @@ void main() {
     ],
   );
 
-  Future<void> pumpScreen(WidgetTester tester, {bool withHome = true}) async {
+  final trip = makeTrip();
+
+  Future<void> pumpScreen(
+    WidgetTester tester, {
+    bool withHome = true,
+    Trip? tripOverride,
+  }) async {
     await tester.pumpWidget(
       ProviderScope(
         overrides: [
-          tripsApiServiceProvider.overrideWithValue(_FakeTripsApiService(trip)),
+          tripsApiServiceProvider
+              .overrideWithValue(_FakeTripsApiService(tripOverride ?? trip)),
           if (withHome) ...[
             // Populates _homeAirport via the screen's prefs load...
             preferencesApiServiceProvider.overrideWithValue(_FakePrefsApi()),
@@ -203,6 +211,29 @@ void main() {
     expect(home!.outboundTo, isNull);
     expect(home.returnFrom, isNotNull);
     expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('a stated ground trip draws no home-airport leg',
+      (WidgetTester tester) async {
+    // A saved home *airport* says where this traveler flies from, so on a
+    // driving trip it is not the origin — drawing a leg from it invents a
+    // journey the trip never described (a Claude-authored road trip to
+    // Montreal rendered as a flight from Newark, 2026-08-14).
+    await pumpScreen(tester, tripOverride: makeTrip(travelMode: 'car'));
+
+    expect(map(tester).home, isNull);
+    expect(find.byIcon(Icons.flight_takeoff), findsNothing);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('a mixed-mode trip keeps its home leg',
+      (WidgetTester tester) async {
+    // 'mixed' means the trip has no single mode, so a flight leg is still
+    // plausible — only a stated ground mode suppresses the overlay.
+    await pumpScreen(tester, tripOverride: makeTrip(travelMode: 'mixed'));
+
+    expect(map(tester).home, isNotNull);
+    expect(find.byIcon(Icons.flight_takeoff), findsOneWidget);
   });
 
   testWidgets('no saved home airport never touches the provider',

--- a/src/packages/flutter-app/test/trip_detail_leg_mode_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_leg_mode_test.dart
@@ -218,6 +218,25 @@ void main() {
     expect(find.textContaining('Rome2Rio'), findsOneWidget);
   });
 
+  testWidgets("a ground trip's leg menu checks the trip's own mode",
+      (WidgetTester tester) async {
+    _useTallViewport(tester);
+    // No per-leg override: the leg is derived as ground, and 'rome2rio' alone
+    // can't say which ground mode. Before the trip was consulted this menu
+    // opened with nothing checked on a trip that plainly stated it drives.
+    await _pump(tester, _twoCityTrip(travelMode: 'car'));
+
+    await tester.tap(_rowModeMenu());
+    await tester.pumpAndSettle();
+
+    final checked = find.ancestor(
+      of: find.byIcon(Icons.check),
+      matching: find.widgetWithText(Row, 'car'),
+    );
+    expect(checked, findsOneWidget);
+    expect(find.byIcon(Icons.check), findsOneWidget);
+  });
+
   testWidgets('a ferry override on a non-Greek leg gets Find ferries',
       (WidgetTester tester) async {
     _useTallViewport(tester);


### PR DESCRIPTION
## Summary
A trip saved from Claude as a three-day **drive** to Montreal rendered with a dashed flight path and a plane pin at **EWR**, and transport rows reading "EWR → Montreal". The trip said `travel_mode=car`; the map never asked — `homeOverlayFor()` took only a home-airport code and coordinates, so it drew the leg whenever a home airport existed, and `TripMapHome` carries no mode to render differently even if it had known.

- **Home-airport overlay suppressed on stated ground trips.** A saved home *airport* says where this traveler flies from; on a road trip it isn't the origin (the drive started in Lake George, not Newark), so drawing nothing beats inventing a journey the trip never described. `car|train|bus|ferry` suppress it; **`mixed` and unset keep it**, since neither rules out a flight.
- **Leg-mode menu no longer opens with nothing checked** on those trips. `rome2rio` is the link for driving, training and busing alike, so without the trip to ask it couldn't name the mode. It now walks the same ladder the server already walks in `transportSlotMode`: override → provider → trip's ground mode.
- **`groundTravelMode()`** (new, `utils/travel_mode.dart`) is the single definition of "ground trip", shared by the map gate and the existing booking-todo derivation, which had its own private copy.

## Deliberately NOT done: persisting mode onto `booking_todos`
The obvious-looking fix — write the derived mode onto the auto todos — is wrong. That column is an **override**: migration 00055 defines `NULL` as *"use the derived default"*, and it's excluded from the sync upsert's `DO UPDATE` precisely so a re-sync can't clobber a user's choice. Writing derived values into it would destroy that distinction and freeze existing legs against a later `travel_mode` change. So no schema, query, sqlc, or server change here — the consumers compute the default, which is what the design intended.

Untouched by design: the **EWR origin in the todo titles**. `create_trip` has no origin field, so the server can only assume the home airport. That's a tool-contract gap, not this bug.

## Testing
- `flutter test` — full suite green. New: a `travel_mode='car'` trip draws no home leg (`trip_detail_home_legs_test.dart`, whose fixture previously had no travel mode at all, so ground trips had **zero** coverage), a `'mixed'` trip still does, and a car trip's leg menu checks `car` (`trip_detail_leg_mode_test.dart`).
- **Verified the new test fails without the fix** — disabling the guard turns the suite red (`+5 -1`), so it's a real regression test rather than one that passes trivially.
- `flutter analyze` clean (3 pre-existing infos in an unrelated file). No Go changes; no new l10n strings.
- Note: one unrelated auth-autofill timing test flaked once under full-suite parallelism; it passes standalone with and without these changes, and a clean full re-run passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)