### PR TITLE
fix(flutter): make a chosen airport editable in place

### DIFF
--- a/src/packages/flutter-app/lib/screens/flight_search_screen.dart
+++ b/src/packages/flutter-app/lib/screens/flight_search_screen.dart
@@ -71,6 +71,14 @@ class FlightSearchScreen extends ConsumerStatefulWidget {
 class _FlightSearchScreenState extends ConsumerState<FlightSearchScreen> {
   Airport? _origin;
   Airport? _destination;
+
+  /// Whether the traveler has touched each endpoint. `_origin == null` is NOT a
+  /// stand-in for "untouched": typing in an [AirportField] voids the held
+  /// selection, so a slow seed (`_seedInitial` awaits the profile load and up to
+  /// three lookups) would otherwise land on a field the user is typing in and
+  /// overwrite it.
+  bool _originTouched = false;
+  bool _destinationTouched = false;
   DateTime? _departDate;
 
   /// Optional round-trip return date; null = one-way (the default).
@@ -155,10 +163,13 @@ class _FlightSearchScreenState extends ConsumerState<FlightSearchScreen> {
     final resolved = await Future.wait([originFuture, destFuture]);
     final origin = resolved[0];
     final dest = resolved[1];
-    if (origin != null && _origin == null && mounted) {
+    if (origin != null && _origin == null && !_originTouched && mounted) {
       setState(() => _origin = origin);
     }
-    if (dest != null && _destination == null && mounted) {
+    if (dest != null &&
+        _destination == null &&
+        !_destinationTouched &&
+        mounted) {
       setState(() => _destination = dest);
     }
 
@@ -428,14 +439,20 @@ class _FlightSearchScreenState extends ConsumerState<FlightSearchScreen> {
           label: l10n.flightSearchFrom,
           icon: Icons.flight_takeoff,
           selected: _origin,
-          onSelected: (a) => setState(() => _origin = a),
+          onSelected: (a) => setState(() {
+            _origin = a;
+            _originTouched = true;
+          }),
         ),
         const SizedBox(height: AppSpacing.md),
         AirportField(
           label: l10n.flightSearchTo,
           icon: Icons.flight_land,
           selected: _destination,
-          onSelected: (a) => setState(() => _destination = a),
+          onSelected: (a) => setState(() {
+            _destination = a;
+            _destinationTouched = true;
+          }),
         ),
         const SizedBox(height: AppSpacing.md),
         Row(

--- a/src/packages/flutter-app/lib/widgets/airport_field.dart
+++ b/src/packages/flutter-app/lib/widgets/airport_field.dart
@@ -8,10 +8,26 @@ import '../providers/flights_provider.dart';
 import '../theme/spacing.dart';
 import '../utils/errors.dart';
 
-/// An airport/city autocomplete field backed by [airportSearchProvider]. When a
-/// place is selected it shows the chosen label with a clear button; otherwise it
-/// shows a search box with a live suggestion dropdown. Shared by the Find
-/// Flights screen and the Travel profile (home airport).
+/// An airport/city autocomplete field backed by [airportSearchProvider]. Shared
+/// by the Find Flights screen, the onboarding quiz and the Travel profile
+/// (home airport).
+///
+/// **One mode, always editable.** The field is a real [TextField] holding the
+/// selected airport's label, so a value that is already set can be typed over
+/// in place. It used to render a chosen airport as static text with only a
+/// clear button, which made an existing value impossible to edit — the Travel
+/// profile seeds [selected] from the server, so that page always opened in the
+/// non-editable state.
+///
+/// [selected] remains the authoritative value: typing voids a stale pick
+/// (`onSelected(null)`) so the visible text can never disagree with what the
+/// parent will save. A parent therefore has to treat "text present, selection
+/// null" as an unresolved edit rather than as "no airport".
+///
+/// [selected] must be a stable field on the parent's `State`. The re-seed guard
+/// compares [Airport.label] rather than instances (Airport has no `==`), so a
+/// value rebuilt each frame is harmless, but a parent that derives [selected]
+/// instead of honoring `onSelected(null)` would fight the user's typing.
 class AirportField extends ConsumerStatefulWidget {
   final String label;
   final IconData icon;
@@ -32,20 +48,99 @@ class AirportField extends ConsumerStatefulWidget {
 
 class _AirportFieldState extends ConsumerState<AirportField> {
   final _controller = TextEditingController();
+  final _focus = FocusNode();
   Timer? _debounce;
   String _query = ''; // debounced search text driving airportSearchProvider
+
+  /// True once the user has edited the text and before that edit is committed
+  /// (a pick, a clear, or an accepted seed). While dirty the field belongs to
+  /// the user: a parent selection that lands late must not overwrite what they
+  /// are in the middle of typing.
+  bool _dirty = false;
+
+  /// At most one pending post-frame `onSelected(null)` (see [_voidSelectionSoon]).
+  bool _pendingVoid = false;
+
+  /// One-shot: the next tap after focusing an untouched value selects the whole
+  /// label so typing replaces the airport, instead of editing "Paris (CDG)"
+  /// character by character. Later taps position the caret normally.
+  bool _selectAllOnTap = false;
 
   /// Hides the suggestion list after an outside tap without discarding the
   /// typed text; typing or tapping back into the field re-opens it.
   bool _dismissed = false;
 
+  /// Deliberately does NOT test [_focus] — a suggestion row is an [InkWell],
+  /// which takes focus on click on desktop/web, so a focus term here would
+  /// tear the list down under the pointer and make picking impossible. The
+  /// orphaned-list case it would have guarded (a seed landing under an open
+  /// dropdown) is already closed by [_acceptSeed].
   bool get _listOpen => !_dismissed && _query.trim().length >= 2;
+
+  @override
+  void initState() {
+    super.initState();
+    // Load-bearing on Find Flights: that form is built only while expanded, so
+    // this State is recreated on every collapse/expand and a value already held
+    // by the parent would otherwise come back as an empty box.
+    final label = widget.selected?.label;
+    if (label != null) _setText(label);
+    _focus.addListener(_onFocusChanged);
+  }
+
+  @override
+  void didUpdateWidget(AirportField oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    final selected = widget.selected;
+    // Never re-seed from a null selection: onChanged voids the pick on every
+    // keystroke, so doing so would wipe the character just typed.
+    if (selected == null || selected.label == _controller.text) return;
+    if (_dirty) {
+      // A parent selection landed while the user was typing — Find Flights
+      // resolves its origin asynchronously and can answer minutes after the
+      // field was first shown. The user wins; the parent is told its selection
+      // is void, but not from here (see [_voidSelectionSoon]).
+      _voidSelectionSoon();
+      return;
+    }
+    _acceptSeed(selected.label);
+  }
 
   @override
   void dispose() {
     _debounce?.cancel();
+    _focus.removeListener(_onFocusChanged);
+    _focus.dispose();
     _controller.dispose();
     super.dispose();
+  }
+
+  /// Writes [text] with the caret at the end. Never assign `_controller.text`
+  /// directly: that setter parks the selection at offset -1, which the engine
+  /// normalizes to 0, so the next keystroke lands in *front* of the value.
+  void _setText(String text) {
+    if (text == _controller.text) return; // don't disturb the user's caret
+    _controller.value = TextEditingValue(
+      text: text,
+      selection: TextSelection.collapsed(offset: text.length),
+    );
+  }
+
+  void _selectAll() {
+    if (_controller.text.isEmpty) return;
+    _controller.selection =
+        TextSelection(baseOffset: 0, extentOffset: _controller.text.length);
+  }
+
+  void _onFocusChanged() {
+    if (!_focus.hasFocus) {
+      _selectAllOnTap = false;
+      return;
+    }
+    _selectAllOnTap = !_dirty && widget.selected != null;
+    // Covers focus arriving without a tap (keyboard traversal); a tap re-runs
+    // it from onTap, after the gesture has positioned the caret.
+    if (_selectAllOnTap) _selectAll();
   }
 
   /// Debounces the [_query] update that drives [airportSearchProvider] so one
@@ -59,12 +154,58 @@ class _AirportFieldState extends ConsumerState<AirportField> {
     });
   }
 
-  /// Clears the field immediately (selection / clear button), cancelling any
-  /// pending debounce so stale text can't resurrect the dropdown afterwards.
-  void _resetQuery() {
+  /// Accepts a selection handed down by the parent (first seed, or an async
+  /// resolve). A full reset, not just a text write: leaving [_query] and the
+  /// armed debounce in place would keep the dropdown showing results for the
+  /// text this just replaced, or reopen it 350 ms later.
+  void _acceptSeed(String label) {
     _debounce?.cancel();
-    _controller.clear();
-    setState(() => _query = '');
+    _setText(label);
+    _query = '';
+    _dismissed = true;
+    _dirty = false;
+  }
+
+  /// Reports a voided selection to the parent after the current frame.
+  /// [didUpdateWidget] runs during build and every call site sits below the
+  /// element owning the build scope, so calling [AirportField.onSelected]
+  /// synchronously from there throws "setState() called during build".
+  void _voidSelectionSoon() {
+    if (_pendingVoid) return;
+    _pendingVoid = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _pendingVoid = false;
+      if (mounted && _dirty && widget.selected != null) {
+        widget.onSelected(null);
+      }
+    });
+  }
+
+  /// Commits a pick: the field shows the chosen label and the list closes.
+  void _commit(Airport airport) {
+    _debounce?.cancel();
+    widget.onSelected(airport);
+    setState(() {
+      _setText(airport.label);
+      // Clearing _query is what closes the list. airportSearchProvider is not
+      // autoDispose, so leaving a stale query would let the next onTap reopen
+      // the dropdown instantly with the pre-pick rows.
+      _query = '';
+      _dismissed = true;
+      _dirty = false;
+    });
+  }
+
+  /// Clears both the text and the selection (the trailing X).
+  void _clear() {
+    _debounce?.cancel();
+    widget.onSelected(null);
+    setState(() {
+      _controller.clear();
+      _query = '';
+      _dismissed = false;
+      _dirty = false;
+    });
   }
 
   /// Shared bordered shell for the suggestion list and its empty/error rows,
@@ -85,33 +226,7 @@ class _AirportFieldState extends ConsumerState<AirportField> {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final l10n = context.l10n;
-    final selected = widget.selected;
     final muted = theme.colorScheme.onSurfaceVariant;
-
-    if (selected != null) {
-      return InputDecorator(
-        decoration: InputDecoration(
-          labelText: widget.label,
-          prefixIcon: Icon(widget.icon),
-          border: const OutlineInputBorder(),
-          suffixIcon: IconButton(
-            tooltip: l10n.airportFieldClearTooltip,
-            icon: const Icon(Icons.close),
-            onPressed: () {
-              widget.onSelected(null);
-              _resetQuery();
-            },
-          ),
-        ),
-        child: Text(
-          selected.label,
-          maxLines: 1,
-          overflow: TextOverflow.ellipsis,
-          style:
-              theme.textTheme.bodyLarge?.copyWith(fontWeight: FontWeight.w500),
-        ),
-      );
-    }
 
     // TapRegion: a tap anywhere outside the field + list dismisses the list
     // (the inline dropdown otherwise only closes on selection).
@@ -123,17 +238,37 @@ class _AirportFieldState extends ConsumerState<AirportField> {
         children: [
           TextField(
             controller: _controller,
+            focusNode: _focus,
             decoration: InputDecoration(
               labelText: widget.label,
               hintText: l10n.airportFieldHint,
               prefixIcon: Icon(widget.icon),
               border: const OutlineInputBorder(),
+              suffixIcon: _controller.text.isEmpty
+                  ? null
+                  : IconButton(
+                      tooltip: l10n.airportFieldClearTooltip,
+                      icon: const Icon(Icons.close),
+                      onPressed: _clear,
+                    ),
             ),
-            onTap: () => setState(() => _dismissed = false),
-            onChanged: (v) {
-              // Reopen the list immediately; only the provider-feeding
-              // _query update is debounced.
+            onTap: () {
+              if (_selectAllOnTap) {
+                _selectAllOnTap = false;
+                _selectAll();
+              }
               setState(() => _dismissed = false);
+            },
+            onChanged: (v) {
+              // Typing voids a stale pick so the text on screen can never
+              // disagree with the value the parent holds. Programmatic writes
+              // never reach onChanged, so this cannot loop with the
+              // didUpdateWidget re-seed.
+              if (widget.selected != null) widget.onSelected(null);
+              setState(() {
+                _dirty = true;
+                _dismissed = false;
+              });
               _onSearchChanged(v);
             },
           ),
@@ -172,10 +307,7 @@ class _AirportFieldState extends ConsumerState<AirportField> {
                                       subtitle: a.country.isEmpty
                                           ? null
                                           : Text(a.country),
-                                      onTap: () {
-                                        widget.onSelected(a);
-                                        _resetQuery();
-                                      },
+                                      onTap: () => _commit(a),
                                     ))
                                 .toList(),
                           ),

--- a/src/packages/flutter-app/test/airport_field_edit_test.dart
+++ b/src/packages/flutter-app/test/airport_field_edit_test.dart
@@ -1,0 +1,174 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:travel_route_planner/models/airport.dart';
+import 'package:travel_route_planner/providers/flights_provider.dart';
+import 'package:travel_route_planner/services/api_client.dart';
+import 'package:travel_route_planner/services/flights_api_service.dart';
+import 'package:travel_route_planner/widgets/airport_field.dart';
+
+import 'support/l10n_test_app.dart';
+
+/// AirportField is editable in place.
+///
+/// It used to render a chosen airport as static text with only a clear button,
+/// so a value that was already set could not be typed over at all. The Travel
+/// profile seeds its home airport from the server, which meant that page always
+/// opened in the non-editable state — "I am unable to edit the home airport".
+///
+/// These pin the single-mode behavior and the two ways the old two-mode design
+/// could lose an edit: text wiped by a late parent seed, and a pick that blanks
+/// the field instead of showing what was picked.
+
+class _FakeFlightsApiService extends FlightsApiService {
+  _FakeFlightsApiService() : super(ApiClient(baseUrl: 'http://test'));
+
+  @override
+  Future<List<Airport>> searchAirports(String query) async => const [
+        Airport(
+          iataCode: 'SEA',
+          name: 'Seattle-Tacoma International Airport',
+          city: 'Seattle',
+          country: 'US',
+          subType: 'airport',
+        ),
+      ];
+}
+
+/// Hosts the field and owns `selected`, the way every real call site does.
+/// [seed] lets a test push a selection in *after* first build, reproducing Find
+/// Flights resolving its origin asynchronously.
+class _Host extends StatefulWidget {
+  final Airport? initial;
+  const _Host({super.key, this.initial});
+
+  @override
+  State<_Host> createState() => _HostState();
+}
+
+class _HostState extends State<_Host> {
+  Airport? selected;
+  int voided = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    selected = widget.initial;
+  }
+
+  void seed(Airport a) => setState(() => selected = a);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: AirportField(
+        label: 'Home airport',
+        icon: Icons.home,
+        selected: selected,
+        onSelected: (a) => setState(() {
+          if (a == null) voided++;
+          selected = a;
+        }),
+      ),
+    );
+  }
+}
+
+const _saved = Airport(iataCode: 'BOS', name: 'BOS');
+
+Future<_HostState> _pumpField(WidgetTester tester, {Airport? initial}) async {
+  final key = GlobalKey<_HostState>();
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        flightsApiServiceProvider.overrideWithValue(_FakeFlightsApiService()),
+      ],
+      child: localizedTestApp(home: _Host(key: key, initial: initial)),
+    ),
+  );
+  await tester.pumpAndSettle();
+  return key.currentState!;
+}
+
+TextField _field(WidgetTester tester) =>
+    tester.widget<TextField>(find.byType(TextField));
+
+void main() {
+  testWidgets('a saved airport renders in an editable TextField', (t) async {
+    await _pumpField(t, initial: _saved);
+
+    // The regression: this used to be an InputDecorator wrapping a static Text,
+    // with no TextField to put a cursor in.
+    expect(find.byType(TextField), findsOneWidget);
+    expect(_field(t).controller?.text, 'BOS');
+  });
+
+  testWidgets('typing over a saved airport keeps the text and voids the pick',
+      (t) async {
+    final host = await _pumpField(t, initial: _saved);
+
+    await t.enterText(find.byType(TextField), 'sea');
+    await t.pump();
+
+    expect(_field(t).controller?.text, 'sea');
+    expect(host.selected, isNull,
+        reason: 'the stale pick must not survive an edit');
+    expect(host.voided, 1);
+  });
+
+  testWidgets('picking a suggestion shows the picked label, not a blank field',
+      (t) async {
+    final host = await _pumpField(t);
+
+    await t.enterText(find.byType(TextField), 'sea');
+    await t.pump(const Duration(milliseconds: 350)); // debounce
+    await t.pumpAndSettle();
+
+    await t.tap(find.text('Seattle (SEA)'));
+    await t.pumpAndSettle();
+
+    expect(host.selected?.iataCode, 'SEA');
+    expect(_field(t).controller?.text, 'Seattle (SEA)');
+    // The list closed rather than staying open over the committed value.
+    expect(find.byType(ListTile), findsNothing);
+  });
+
+  testWidgets('a late parent seed does not overwrite in-progress typing',
+      (t) async {
+    final host = await _pumpField(t);
+
+    await t.enterText(find.byType(TextField), 'lis');
+    await t.pump();
+
+    // Find Flights' home-airport seed landing mid-edit.
+    host.seed(const Airport(iataCode: 'JFK', name: 'JFK'));
+    await t.pumpAndSettle();
+
+    expect(_field(t).controller?.text, 'lis');
+    expect(host.selected, isNull,
+        reason: 'the widget reports the seed void rather than adopting it');
+  });
+
+  testWidgets('a seed arriving on an untouched field is adopted', (t) async {
+    final host = await _pumpField(t);
+    expect(_field(t).controller?.text, isEmpty);
+
+    host.seed(const Airport(iataCode: 'JFK', name: 'JFK'));
+    await t.pumpAndSettle();
+
+    expect(_field(t).controller?.text, 'JFK');
+    expect(host.selected?.iataCode, 'JFK');
+  });
+
+  testWidgets('the clear button empties both the text and the selection',
+      (t) async {
+    final host = await _pumpField(t, initial: _saved);
+
+    await t.tap(find.byIcon(Icons.close));
+    await t.pumpAndSettle();
+
+    expect(_field(t).controller?.text, isEmpty);
+    expect(host.selected, isNull);
+  });
+}


### PR DESCRIPTION
## Summary

- `AirportField` had two mutually exclusive render modes: with a value selected it rendered an `InputDecorator` wrapping a **static `Text`** — not a `TextField`, no cursor, nothing to click into — and only became a real input once the value was cleared. `PreferencesScreen._load()` seeds the home airport from the server, so **the Travel profile always opened in the non-editable mode**: "I am unable to edit the home airport." Find Flights and the onboarding quiz shared the same friction.
- Collapse to one mode: always a `TextField` holding the selected airport's label. `selected` stays the authoritative value — typing voids a stale pick so the visible text can never disagree with what the parent will save — and a pick now writes its label into the field instead of blanking it.
- On Find Flights, `_origin == null` was standing in for "the user hasn't touched this", which the new voiding behavior makes false. Tracked explicitly via `_originTouched` / `_destinationTouched` so the async home-airport seed can't land on a field being typed in.

### Four non-obvious things this design has to get right

- Writes go through `_setText`, never `controller.text =`. That setter parks the selection at **offset -1**, which the engine normalizes to 0, so the next keystroke would land in *front* of the value (`xParis (CDG)`).
- `didUpdateWidget` re-seeds only from a non-null selection whose label differs, and never while `_dirty`. `onChanged` voids the pick on every keystroke, so an unguarded re-seed would wipe the character just typed.
- A seed landing mid-edit reports the void from a **post-frame callback**. `didUpdateWidget` runs during build and every call site sits below the element owning the build scope, so calling `onSelected` there throws `setState() called during build`.
- `_listOpen` deliberately does **not** test focus: a suggestion row is an `InkWell` and takes focus on click, which would tear the list down under the pointer and make picking impossible. The orphaned-list case it would have guarded is closed by `_acceptSeed` resetting query + debounce.

## Scope

Widget-only by design. The Travel profile's two remaining home-airport defects — typed-but-unpicked text saved as a silent no-op, and `home_airport` being **impossible to clear at all** (`normalizeAirportCode` collapses `""` to nil, which `UpsertPreferences` COALESCEs to "keep existing") — need `preferences_screen.dart`, `preferences_handler.go` and `query/preferences.sql`, all of which the in-flight `active-profile` lane is currently editing. They follow in a second lane once that merges.

## Testing

- New `test/airport_field_edit_test.dart` (6 tests): a saved airport renders in an editable `TextField`; typing over it keeps the text and voids the pick; picking shows the picked label rather than a blank field; a late parent seed does not overwrite in-progress typing; a seed on an untouched field *is* adopted; the clear button empties both text and selection. **5 of the 6 fail against the previous widget** — verified by stashing the change and re-running.
- `flutter analyze` — clean (the 3 remaining infos are pre-existing in `lib/models/route_response.dart`, untouched here).
- `make flutter-test` — 1171 pass. The one failure, `auth_autofill_submit_test.dart :: keystroke-simulated burst fill auto-submits`, reproduces identically on a clean `main` checkout and is unrelated to this change.
- Previously-passing `AirportField` consumers re-run green: `flight_search_polish_test.dart`, `secondary_width_sweep_test.dart`, `onboarding_quiz_test.dart`, `settings_polish_test.dart`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)