### PR TITLE
fix(shell): sit the rail wind-rose on the app-bar wordmark centre line

### DIFF
--- a/src/packages/flutter-app/lib/screens/app_shell.dart
+++ b/src/packages/flutter-app/lib/screens/app_shell.dart
@@ -130,18 +130,41 @@ const List<Widget> _tabRoots = [
   TripsListScreen(),
 ];
 
+/// Flutter's [NavigationRail] hard-codes an 8px spacer above (and below) its
+/// `leading` slot. That is the rail's geometry, not ours, so any alignment
+/// maths against the content area has to subtract it.
+const double _kRailLeadingGap = 8;
+
+/// The mark's box, solved so its centre lands on the app-bar centre line: the
+/// rail and the content Scaffold both start at window y = 0, so
+///   _kRailLeadingGap + _kRailMarkBox / 2 == kToolbarHeight / 2
+/// is the whole alignment contract. Keep it a derivation — a literal here goes
+/// stale the moment GradientAppBar's height moves.
+const double _kRailMarkBox = kToolbarHeight - _kRailLeadingGap * 2; // 40
+const double _kRailMarkSize = 36;
+
 /// The Anemos brand mark for the top of the rail — the persistent
 /// Site ID (Krug). Bare mark: the teal/gold rose reads on the rail surface in
 /// both themes, so no badge plate; the InkWell supplies the hover/focus
 /// highlight and web pointer cursor. Tapping it goes Home, per the universal
 /// logo-links-home convention.
+///
+/// The rose sits on the same line as the "Anemos" wordmark in the app bar
+/// across the divider — at rail widths that wordmark is the app-bar title's
+/// only content, so the two read as one lockup or as nothing. That is why the
+/// tap box is [_kRailMarkBox] (40) rather than the usual [kMinTouchTarget]:
+/// the rail's own 8px spacer puts a symmetric 48px box's centre at y = 32, so
+/// 48 cannot reach the y = 28 centre line. Growing it back breaks the
+/// alignment silently. The rail only exists at [kRailBreakpoint] and above —
+/// pointer-first — and Home is a rail destination immediately below, so the
+/// smaller target costs nothing reachable.
 class _RailBrand extends ConsumerWidget {
   const _RailBrand();
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     return Padding(
-      padding: const EdgeInsets.only(top: AppSpacing.lg, bottom: AppSpacing.sm),
+      padding: const EdgeInsets.only(bottom: AppSpacing.md),
       child: Semantics(
         button: true,
         child: Material(
@@ -149,9 +172,10 @@ class _RailBrand extends ConsumerWidget {
           child: InkWell(
             onTap: () => goHome(ref),
             borderRadius: AppRadius.mdAll,
-            child: const Padding(
-              padding: EdgeInsets.all(AppSpacing.sm),
-              child: BrandLogo.mark(size: 36),
+            child: const SizedBox(
+              width: _kRailMarkBox,
+              height: _kRailMarkBox,
+              child: Center(child: BrandLogo.mark(size: _kRailMarkSize)),
             ),
           ),
         ),

--- a/src/packages/flutter-app/test/nav_tab_reset_test.dart
+++ b/src/packages/flutter-app/test/nav_tab_reset_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import 'package:travel_route_planner/constants/app_info.dart';
 import 'package:travel_route_planner/main.dart';
 import 'package:travel_route_planner/navigation/app_nav.dart';
 import 'package:travel_route_planner/navigation/url_sync.dart';
@@ -125,6 +126,23 @@ void main() {
         of: find.byType(NavigationRail), matching: find.byType(BrandLogo)));
     await tester.pumpAndSettle();
     expect(container.read(navIndexProvider), AppTab.home.index);
+  });
+
+  testWidgets('the rail mark sits on the app-bar wordmark centre line',
+      (tester) async {
+    // The rose lives in the rail and the wordmark in the content area's app
+    // bar — different subtrees, same window y = 0, and nothing structural
+    // holds them on one line. Pin the two against EACH OTHER, not against a
+    // literal, so this still catches a regression if the toolbar height moves.
+    await pumpApp(tester);
+
+    final mark = tester.getCenter(find.descendant(
+        of: find.byType(NavigationRail), matching: find.byType(BrandLogo)));
+    final wordmark = tester.getCenter(find.descendant(
+        of: find.byType(AppBar), matching: find.text(AppInfo.name)));
+
+    expect(mark.dy, wordmark.dy);
+    expect(mark.dy, kToolbarHeight / 2);
   });
 
   testWidgets('re-tapping the active Trips tab pops it to root',


### PR DESCRIPTION
## Summary

- At rail widths (≥800px) the brand is split across two subtrees — the wind-rose in the `NavigationRail`'s `leading` slot, the Cinzel "Anemos" wordmark as the app-bar title beside it — and nothing held them on one line. They sat **22px apart** (rose centre y=50 vs wordmark centre y=28), with the rose overhanging the app bar's bottom edge by 12px, so it read as hanging off the header rather than belonging to it.
- The 22px was three unreconciled paddings: the rail's own hard-coded 8px spacer above `leading`, plus `AppSpacing.lg`, plus the `InkWell`'s `AppSpacing.sm`. Replaced with a box **solved from the constraint** — `_kRailLeadingGap + _kRailMarkBox / 2 == kToolbarHeight / 2` — so the alignment is a derivation in one place instead of a top padding that goes stale the moment `GradientAppBar`'s height moves.
- That box is **40, not `kMinTouchTarget`**: the rail's 8px spacer puts a symmetric 48px box's centre at y=32, so 48 structurally cannot reach the centre line. The dartdoc records why, because growing it back breaks the alignment silently. The rail is pointer-first (≥800px) and Home is a destination directly below, so the smaller target costs nothing reachable.
- Rail destinations rise ~22px with the header. The narrow (<800px) badge + wordmark fallback is untouched.

## Testing

- `flutter analyze` — clean (only 3 pre-existing infos in `models/route_response.dart`).
- `flutter test` — **1170 tests pass**, including a new pin in `nav_tab_reset_test.dart` that asserts the rail mark's centre against the **live app-bar wordmark's** centre (not a literal), so it still catches a regression if the toolbar height changes.
- Real browser, release web build at 1280×900, measured from the screenshot's pixels rather than eyeballed:
  - rose ink centre **27.75** CSS px, wordmark ink centre **27.5** — a quarter-pixel apart, i.e. antialiasing noise.
  - Plan and Trips tabs (same `GradientAppBar`) keep the rose inside the header band.
  - Below 800px the rail disappears and the badge + wordmark fallback renders unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)