### PR TITLE
fix(trips): split "Your travels" into traveled and planned

### DIFF
--- a/specs/trips-page-insights/spec.md
+++ b/specs/trips-page-insights/spec.md
@@ -133,3 +133,42 @@ full trip view they already have access to.
 None — the five surfaces, the shared-with-me exclusion, the confirmed-stays
 rule, the 14-day nudge window, and the 2+-trips footprint gate were all
 decided at approval.
+
+## Amendment 2026-08-14 — "Your travels" splits traveled from planned
+
+**Supersedes the "all-time" wording above** (the lifetime-band user story, its
+acceptance criterion, and the UI-behavior bullet). The band shipped as one
+all-time total over every owned trip, which counted a trip starting next month
+as travel already taken: an account with a 2-day past trip and two upcoming
+ones reported *40 travel days*, of which 2 had happened. The map had the same
+defect — every located city drew the same "been there" dot. Both contradicted
+what this section is placed to be: the retrospective, where the page turns from
+plans to history.
+
+The corrected contract (client-side only — no payload, SQL, or migration
+change; `utils/trip_list_insights.dart` remains the one derivation site):
+
+- **Two labeled groups, traveled and planned**, and a group with **no trips
+  does not render**. That single rule replaces every special case: a planner
+  who has taken no trips yet sees only "Planned" instead of a row of zeros, an
+  account with nothing upcoming sees only "Traveled", and under the unchanged
+  2+-owned-trips gate at least one group always renders because every trip
+  lands on exactly one side.
+- **Bucket** — a trip is traveled once it has *started* (`tripHasStarted`:
+  first day = `start_date ?? end_date`, today or earlier). Future trips and
+  undated drafts are planned. Mirrors `tripIsPast`'s last-day rule, so every
+  trip filed under "Past trips" is also counted as travelled.
+- **Travel days** — traveled counts only days already lived through, so an
+  in-progress trip's counter ticks up daily rather than banking all 35 days on
+  day one; planned counts the full span of trips that haven't started. The
+  remaining days of an in-progress trip are on neither side: each group stays
+  consistent with the trips shown beside it, which is the arithmetic a reader
+  can check, and the old grand total is no longer on screen.
+- **Cities** — traveled wins the overlap, so a city on both a past and a
+  future trip counts once, as visited. The two counts partition.
+- **Map pins** — solid dot = visited, ring = still ahead, with the state in
+  the tap tooltip ("Kraków · Planned") because two dot styles are a fast read,
+  not a precise one. `visited` is taken from the set of cities on started
+  trips, **never** from whichever trip supplied the winning coordinate: server
+  order is newest-created-first, so a planned trip routinely lands ahead of the
+  past trip that earned the dot.

--- a/src/packages/flutter-app/lib/l10n/app_en.arb
+++ b/src/packages/flutter-app/lib/l10n/app_en.arb
@@ -1121,6 +1121,8 @@
   "tripsListNewTrip": "New trip",
   "tripsListYourTravels": "Your travels",
   "tripsListTravelMap": "Your travel map",
+  "tripsListStatsTraveled": "Traveled",
+  "tripsListStatsPlanned": "Planned",
   "tripsListStatTrips": "{count, plural, one{Trip} other{Trips}}",
   "@tripsListStatTrips": {
     "placeholders": {

--- a/src/packages/flutter-app/lib/l10n/app_es.arb
+++ b/src/packages/flutter-app/lib/l10n/app_es.arb
@@ -501,6 +501,8 @@
   "tripsListNewTrip": "Nuevo viaje",
   "tripsListYourTravels": "Tus viajes",
   "tripsListTravelMap": "Tu mapa de viajes",
+  "tripsListStatsTraveled": "Viajado",
+  "tripsListStatsPlanned": "Planeado",
   "tripsListStatTrips": "{count, plural, one{Viaje} other{Viajes}}",
   "tripsListStatTravelDays": "{count, plural, one{Día de viaje} other{Días de viaje}}",
   "tripsListStatCities": "{count, plural, one{Ciudad} other{Ciudades}}",

--- a/src/packages/flutter-app/lib/l10n/app_localizations.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations.dart
@@ -3104,6 +3104,18 @@ abstract class AppLocalizations {
   /// **'Your travel map'**
   String get tripsListTravelMap;
 
+  /// No description provided for @tripsListStatsTraveled.
+  ///
+  /// In en, this message translates to:
+  /// **'Traveled'**
+  String get tripsListStatsTraveled;
+
+  /// No description provided for @tripsListStatsPlanned.
+  ///
+  /// In en, this message translates to:
+  /// **'Planned'**
+  String get tripsListStatsPlanned;
+
   /// No description provided for @tripsListStatTrips.
   ///
   /// In en, this message translates to:

--- a/src/packages/flutter-app/lib/l10n/app_localizations_en.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations_en.dart
@@ -1730,6 +1730,12 @@ class AppLocalizationsEn extends AppLocalizations {
   String get tripsListTravelMap => 'Your travel map';
 
   @override
+  String get tripsListStatsTraveled => 'Traveled';
+
+  @override
+  String get tripsListStatsPlanned => 'Planned';
+
+  @override
   String tripsListStatTrips(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,

--- a/src/packages/flutter-app/lib/l10n/app_localizations_es.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations_es.dart
@@ -1742,6 +1742,12 @@ class AppLocalizationsEs extends AppLocalizations {
   String get tripsListTravelMap => 'Tu mapa de viajes';
 
   @override
+  String get tripsListStatsTraveled => 'Viajado';
+
+  @override
+  String get tripsListStatsPlanned => 'Planeado';
+
+  @override
   String tripsListStatTrips(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,

--- a/src/packages/flutter-app/lib/screens/trips_list_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trips_list_screen.dart
@@ -144,11 +144,14 @@ class _TripsListScreenState extends ConsumerState<TripsListScreen> {
         for (final t in groups.upcoming)
           if (t.id != hero?.id) t
       ];
-      // "Your travels" is all-time over OWNED trips (shared-with-me is
-      // someone else's travel, and its payload carries no pins anyway).
-      // Gated at 2+: a lifetime aggregate of one trip only restates the hero.
-      final stats = lifetimeStats(state.trips);
-      final pins = footprintPins(state.trips);
+      // "Your travels" is over OWNED trips (shared-with-me is someone else's
+      // travel, and its payload carries no pins anyway), split into what's
+      // been travelled and what's still planned — the band sits where the page
+      // turns from plans to history, so a number that silently mixed the two
+      // was reading as travel already taken. Gated at 2+: an aggregate of one
+      // trip only restates the hero.
+      final stats = travelStats(state.trips, now);
+      final pins = footprintPins(state.trips, now);
       final showFootprint = state.trips.length >= 2;
       body = RefreshIndicator(
         onRefresh: () async {
@@ -239,7 +242,11 @@ class _TripsListScreenState extends ConsumerState<TripsListScreen> {
                           AppSpacing.xs, AppSpacing.xl, 0, AppSpacing.sm),
                       child: SectionHeader(title: l10n.tripsListYourTravels),
                     ),
-                    TravelFootprintCard(pins: pins, stats: stats),
+                    TravelFootprintCard(
+                      pins: pins,
+                      traveled: stats.traveled,
+                      planned: stats.planned,
+                    ),
                   ],
                   if (groups.past.isNotEmpty)
                     Padding(

--- a/src/packages/flutter-app/lib/utils/trip_days.dart
+++ b/src/packages/flutter-app/lib/utils/trip_days.dart
@@ -60,6 +60,23 @@ bool tripIsPast(String? startDate, String? endDate, DateTime today) {
       .isBefore(DateTime(today.year, today.month, today.day));
 }
 
+/// Whether the trip has begun as of [today]'s device-local calendar date: its
+/// first day — [startDate], falling back to [endDate] for start-less trips —
+/// is today or earlier. Undated trips have not started.
+///
+/// The mirror of [tripIsPast] (which measures the LAST day the same way), and
+/// deliberately so: every past trip has started, and a trip that has started
+/// but is not past is the one in progress. The first-day fallback also matches
+/// trip_list_order.dart's `_firstDay` sort key, so the "Your travels" split
+/// and the list's own ordering can't disagree about the same card.
+bool tripHasStarted(String? startDate, String? endDate, DateTime today) {
+  final first =
+      DateTime.tryParse(startDate ?? '') ?? DateTime.tryParse(endDate ?? '');
+  if (first == null) return false;
+  return !DateTime(first.year, first.month, first.day)
+      .isAfter(DateTime(today.year, today.month, today.day));
+}
+
 /// How many days a trip spans for day chips / pickers: the later of the
 /// highest tagged day in [itemDays] and the [startDate]–[endDate] span (so an
 /// empty dated trip still offers its real days, and an item tagged beyond the
@@ -76,6 +93,27 @@ int dayCount(String? startDate, String? endDate, Iterable<int?> itemDays) {
     if (span > max) max = span;
   }
   return max;
+}
+
+/// The travel days of a trip already LIVED THROUGH as of [today]: the
+/// inclusive span from [startDate] through the earlier of [today] and
+/// [endDate]. 0 for a trip that hasn't started yet, and — like [dayCount] —
+/// 0 whenever either date is missing, so a half-dated trip contributes no days
+/// on either side of a traveled/planned split. Equals [dayCount] once the trip
+/// is over, so a finished trip counts in full.
+///
+/// UTC-normalized before subtracting (the [daysUntilTrip] rule) so a DST
+/// transition inside the span can't drop a calendar day.
+int traveledDayCount(String? startDate, String? endDate, DateTime today) {
+  final start = DateTime.tryParse(startDate ?? '');
+  final end = DateTime.tryParse(endDate ?? '');
+  if (start == null || end == null) return 0;
+  final from = DateTime.utc(start.year, start.month, start.day);
+  final until = DateTime.utc(end.year, end.month, end.day);
+  final now = DateTime.utc(today.year, today.month, today.day);
+  final last = now.isBefore(until) ? now : until;
+  final days = last.difference(from).inDays + 1;
+  return days < 0 ? 0 : days;
 }
 
 /// Whether a stay covers ANY night in `[start, end)` — the leg-focus stay

--- a/src/packages/flutter-app/lib/utils/trip_list_insights.dart
+++ b/src/packages/flutter-app/lib/utils/trip_list_insights.dart
@@ -1,46 +1,130 @@
 // Insight facts derived from the GET /trips list payload
-// (specs/trips-page-insights): lifetime aggregates, footprint pins, and the
-// booking-urgency window. Pure and payload-only — every fact here has this
-// file as its ONE derivation site; the server row is the one derivation for
-// everything else (null fields ⇒ the UI hides, never recomputes locally).
-// Ordering stays trip_list_order.dart's charter; date math stays
-// trip_days.dart's.
+// (specs/trips-page-insights): the traveled/planned travel aggregates,
+// footprint pins, and the booking-urgency window. Pure and payload-only —
+// every fact here has this file as its ONE derivation site; the server row is
+// the one derivation for everything else (null fields ⇒ the UI hides, never
+// recomputes locally). Ordering stays trip_list_order.dart's charter; date
+// math stays trip_days.dart's.
 
 import '../models/city_pin.dart';
 import '../models/trip.dart';
 import 'trip_days.dart';
 
-/// All-time "Your travels" stats over the caller's OWNED trips (the caller
-/// filters out shared-with-me rows): trip count, summed dated travel days
-/// (undated trips contribute 0 via [dayCount]), and distinct hub cities
-/// deduped case- and whitespace-insensitively.
-({int trips, int travelDays, int cities}) lifetimeStats(List<Trip> trips) {
-  var days = 0;
-  final cities = <String>{};
+/// One side of the "Your travels" split: trip count, travel days, and distinct
+/// hub cities.
+typedef TravelStats = ({int trips, int travelDays, int cities});
+
+/// "Your travels" over the caller's OWNED trips (the caller filters out
+/// shared-with-me rows), split into what has been TRAVELED and what is still
+/// PLANNED. The band used to report one all-time total, which counted a trip
+/// that starts next month as travel already taken — the section sits where the
+/// page turns from plans to history, so its numbers have to say which is which.
+///
+/// Every trip lands on exactly one side, so under the card's 2+ owned trips
+/// gate at least one side always has something to show:
+///
+/// - **Trips** — traveled once the trip has started ([tripHasStarted]); future
+///   trips and undated drafts are planned.
+/// - **Travel days** — traveled counts only days already lived through
+///   ([traveledDayCount]), so an in-progress trip's counter ticks up daily
+///   instead of banking all 35 days on day one; planned counts the full span
+///   ([dayCount]) of trips that haven't started. The remaining days of an
+///   in-progress trip land on neither side: each side stays internally
+///   consistent with the trips shown beside it, which is the arithmetic a
+///   reader can actually check, and the old grand total is no longer on screen.
+/// - **Cities** — deduped case- and whitespace-insensitively, with **traveled
+///   winning** the overlap, so a city on both a past and a future trip counts
+///   once and counts as visited. The two counts partition rather than
+///   double-count, matching the map's two pin styles.
+({TravelStats traveled, TravelStats planned}) travelStats(
+    List<Trip> trips, DateTime today) {
+  var traveledTrips = 0;
+  var traveledDays = 0;
+  var plannedTrips = 0;
+  var plannedDays = 0;
+  final traveledCities = <String>{};
+  final plannedCities = <String>{};
   for (final t in trips) {
-    days += dayCount(t.startDate, t.endDate, const <int?>[]);
+    final started = tripHasStarted(t.startDate, t.endDate, today);
     for (final c in t.cities ?? const <String>[]) {
-      cities.add(c.trim().toLowerCase());
+      (started ? traveledCities : plannedCities).add(_cityKey(c));
+    }
+    if (started) {
+      traveledTrips++;
+      traveledDays += traveledDayCount(t.startDate, t.endDate, today);
+    } else {
+      plannedTrips++;
+      plannedDays += dayCount(t.startDate, t.endDate, const <int?>[]);
     }
   }
-  return (trips: trips.length, travelDays: days, cities: cities.length);
+  // Resolved after the loop, not inside it: server order is
+  // newest-created-first, so a city is routinely seen on a planned trip before
+  // the past trip that visited it shows up.
+  plannedCities.removeAll(traveledCities);
+  return (
+    traveled: (
+      trips: traveledTrips,
+      travelDays: traveledDays,
+      cities: traveledCities.length,
+    ),
+    planned: (
+      trips: plannedTrips,
+      travelDays: plannedDays,
+      cities: plannedCities.length,
+    ),
+  );
 }
 
+/// One dot on the footprint map: a located hub city, and whether the traveler
+/// has actually been there.
+typedef FootprintPin = ({String city, double lat, double lng, bool visited});
+
 /// Every located hub city across [trips] for the footprint map, flattened in
-/// list order and deduped on the [lifetimeStats] city key — the FIRST
-/// coordinate seen for a city wins, so revisits can't move a pin.
-List<({String city, double lat, double lng})> footprintPins(List<Trip> trips) {
+/// list order and deduped on the [travelStats] city key — the FIRST coordinate
+/// seen for a city wins, so revisits can't move a pin.
+///
+/// [visited] is read from the set of cities on trips that have STARTED, never
+/// from whichever trip supplied the winning coordinate: with the list in
+/// newest-created-first order a planned trip routinely lands ahead of the past
+/// trip that visited the same city, and taking the flag off the coordinate's
+/// own row would hollow out pins the traveler has already earned.
+List<FootprintPin> footprintPins(List<Trip> trips, DateTime today) {
+  final visited = <String>{};
+  for (final t in trips) {
+    if (!tripHasStarted(t.startDate, t.endDate, today)) continue;
+    // Pins are a subset of cities on the wire (one server lateral emits both),
+    // but this function is keyed on the PIN list — reading the flag out of
+    // cities alone would make it depend on a sibling field being populated,
+    // and a row that somehow carried pins without cities would render every
+    // dot as unvisited. Union, so the flag stands on its own.
+    for (final c in t.cities ?? const <String>[]) {
+      visited.add(_cityKey(c));
+    }
+    for (final p in t.cityPins ?? const <CityPin>[]) {
+      visited.add(_cityKey(p.city));
+    }
+  }
   final seen = <String>{};
-  final pins = <({String city, double lat, double lng})>[];
+  final pins = <FootprintPin>[];
   for (final t in trips) {
     for (final p in t.cityPins ?? const <CityPin>[]) {
-      if (seen.add(p.city.trim().toLowerCase())) {
-        pins.add((city: p.city, lat: p.lat, lng: p.lng));
+      final key = _cityKey(p.city);
+      if (seen.add(key)) {
+        pins.add((
+          city: p.city,
+          lat: p.lat,
+          lng: p.lng,
+          visited: visited.contains(key),
+        ));
       }
     }
   }
   return pins;
 }
+
+/// The dedupe key both derivations share, so " lisbon " and "Lisbon" are one
+/// city on the tiles and one dot on the map.
+String _cityKey(String city) => city.trim().toLowerCase();
 
 /// How close an unbooked first transport leg must be before the hero shows
 /// the urgency nudge. Lives beside its one consumer, [bookingNudgeDate].

--- a/src/packages/flutter-app/lib/widgets/travel_footprint_card.dart
+++ b/src/packages/flutter-app/lib/widgets/travel_footprint_card.dart
@@ -6,15 +6,31 @@ import 'package:latlong2/latlong.dart';
 
 import '../l10n/l10n.dart';
 import '../theme/spacing.dart';
+import '../utils/trip_list_insights.dart';
 import 'app_map.dart';
 import 'stat_tile_row.dart';
 
+/// Handles for the two stat groups. Locale-free on purpose: "is the traveled
+/// group on screen?" is the invariant this card turns on, and a test that
+/// asked by label would answer it differently in Spanish.
+const kTraveledStatsKey = ValueKey('travelStats.traveled');
+const kPlannedStatsKey = ValueKey('travelStats.planned');
+
 /// The body of the "Your travels" section on the trips list: a world map
-/// pinning every hub city across the user's owned trips, with lifetime stat
+/// pinning every hub city across the user's owned trips, with the travel stat
 /// tiles beneath. One merged card (not separate stats + map bands) so the
 /// sparse one-trip-each-way page gains a single substantial scroll stop, and
 /// so the whole block shares one gating story: with no located cities the map
 /// sub-band collapses and the card degrades to a bare stats strip.
+///
+/// **Traveled and planned are separate, labeled groups**, and the map says
+/// which pins are which (filled = been there, hollow = still ahead). The band
+/// reported one all-time total until 2026-08-14, which counted a trip starting
+/// next month as travel already taken — 40 "travel days" when 2 had happened.
+/// This card sits exactly where the page turns from plans to history, so its
+/// numbers have to name which of the two they are. A group whose trip count is
+/// zero does not render at all: that one rule is why a brand-new planner never
+/// meets a row of zeros, and why nothing here needs a second display mode.
 ///
 /// **Unlabeled by design** — the "Your travels" title is a page-level
 /// SectionHeader the caller renders directly above, under the same gate.
@@ -31,13 +47,15 @@ import 'stat_tile_row.dart';
 /// per-trip detail cache — unlike TripMapBand this band must render for
 /// trips never opened on this device.
 class TravelFootprintCard extends StatelessWidget {
-  final List<({String city, double lat, double lng})> pins;
-  final ({int trips, int travelDays, int cities}) stats;
+  final List<FootprintPin> pins;
+  final TravelStats traveled;
+  final TravelStats planned;
 
   const TravelFootprintCard({
     super.key,
     required this.pins,
-    required this.stats,
+    required this.traveled,
+    required this.planned,
   });
 
   /// Slightly shorter than TripMapBand's 160 hero band so the retrospective
@@ -47,10 +65,87 @@ class TravelFootprintCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final l10n = context.l10n;
+    // Every trip lands on exactly one side (travelStats), and the caller gates
+    // the card on >= 2 owned trips, so at least one group always survives.
+    final groups = [
+      if (traveled.trips > 0)
+        (
+          key: kTraveledStatsKey,
+          label: l10n.tripsListStatsTraveled,
+          stats: traveled,
+        ),
+      if (planned.trips > 0)
+        (
+          key: kPlannedStatsKey,
+          label: l10n.tripsListStatsPlanned,
+          stats: planned,
+        ),
+    ];
+    return Card(
+      // The map tiles paint square corners; the card's own clip rounds them.
+      clipBehavior: Clip.antiAlias,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          if (pins.isNotEmpty)
+            SizedBox(
+              height: _bandHeight,
+              child: Semantics(
+                label: l10n.tripsListTravelMap,
+                child: _FootprintMap(
+                  pins: pins,
+                  tooltipFor: (p) => '${p.city} · '
+                      '${p.visited ? l10n.tripsListStatsTraveled : l10n.tripsListStatsPlanned}',
+                ),
+              ),
+            ),
+          Padding(
+            padding: const EdgeInsets.all(AppSpacing.lg),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                for (var i = 0; i < groups.length; i++) ...[
+                  // xl, not md: an eyebrow sits ~26px above its own numbers,
+                  // so a 12px seam left it equidistant between the two groups
+                  // and it read as floating between them rather than heading
+                  // the one below. A group label has to be nearer its group
+                  // than its neighbour by a visible margin.
+                  if (i > 0) const SizedBox(height: AppSpacing.xl),
+                  _StatGroup(
+                    key: groups[i].key,
+                    label: groups[i].label,
+                    stats: groups[i].stats,
+                  ),
+                ],
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// One labeled side of the split: a quiet eyebrow over the shared stat tiles.
+///
+/// The eyebrow borrows UpNextTripCard's treatment but stays **sentence case**
+/// where that one is caps — the same l10n string labels the map's pin tooltips
+/// ("Kraków · Planned"), and one string beats a second key plus a
+/// locale-unsafe toUpperCase(). It must also read quieter than the page-level
+/// "Your travels" SectionHeader above the card: header > eyebrow > tile label.
+class _StatGroup extends StatelessWidget {
+  final String label;
+  final TravelStats stats;
+
+  const _StatGroup({super.key, required this.label, required this.stats});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final l10n = context.l10n;
     // Zero-valued tiles drop out segment-wise (undated trips contribute no
-    // travel days, city-less legacy rows no cities), same rule the old
-    // upcoming-only stats line used. Trips is never zero here — the caller
-    // gates the card on >= 2 owned trips.
+    // travel days, city-less legacy rows no cities), the rule this card has
+    // always used. Trips is never zero — the caller drops the whole group.
     final tiles = [
       StatTileData(
         value: '${stats.trips}',
@@ -67,26 +162,22 @@ class TravelFootprintCard extends StatelessWidget {
           label: l10n.tripsListStatCities(stats.cities),
         ),
     ];
-    return Card(
-      // The map tiles paint square corners; the card's own clip rounds them.
-      clipBehavior: Clip.antiAlias,
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: [
-          if (pins.isNotEmpty)
-            SizedBox(
-              height: _bandHeight,
-              child: Semantics(
-                label: l10n.tripsListTravelMap,
-                child: _FootprintMap(pins: pins),
-              ),
-            ),
-          Padding(
-            padding: const EdgeInsets.all(AppSpacing.lg),
-            child: StatTileRow(tiles: tiles),
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Text(
+          label,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+          style: theme.textTheme.labelSmall?.copyWith(
+            color: theme.colorScheme.onSurfaceVariant,
+            fontWeight: FontWeight.w600,
+            letterSpacing: 0.8,
           ),
-        ],
-      ),
+        ),
+        const SizedBox(height: AppSpacing.xs),
+        StatTileRow(tiles: tiles),
+      ],
     );
   }
 }
@@ -97,11 +188,14 @@ class TravelFootprintCard extends StatelessWidget {
 /// fit once over all pins. Static camera: a mid-list band that pans would
 /// steal the page's scroll gesture. Pins keep tap-tooltips ("what city is
 /// that?" costs nothing), which is also why there is no AbsorbPointer and no
-/// ExcludeSemantics — the tooltips carry the city names for screen readers.
+/// ExcludeSemantics — the tooltips carry the city names for screen readers,
+/// and now the traveled/planned state too: the two dot styles are the fast
+/// read, the tooltip is the one that can't be misread.
 class _FootprintMap extends StatefulWidget {
-  final List<({String city, double lat, double lng})> pins;
+  final List<FootprintPin> pins;
+  final String Function(FootprintPin) tooltipFor;
 
-  const _FootprintMap({required this.pins});
+  const _FootprintMap({required this.pins, required this.tooltipFor});
 
   @override
   State<_FootprintMap> createState() => _FootprintMapState();
@@ -180,7 +274,10 @@ class _FootprintMapState extends State<_FootprintMap> {
                     point: LatLng(p.lat, p.lng),
                     width: _pinHitBox,
                     height: _pinHitBox,
-                    child: _FootprintPin(city: p.city),
+                    child: _FootprintPin(
+                      tooltip: widget.tooltipFor(p),
+                      visited: p.visited,
+                    ),
                   ),
               ],
             ),
@@ -196,22 +293,36 @@ class _FootprintMapState extends State<_FootprintMap> {
 /// over satellite imagery, brand primary, no ordinal. The tooltip's tap
 /// detector fills the marker's hit box, so the whole transparent halo around
 /// the 12px dot triggers it.
+///
+/// [visited] changes only the FILL — brand primary for a city already
+/// travelled, hollow (a dark translucent core) for one still ahead: the
+/// filled-vs-empty idiom, and the same reading as a ticked box. The white ring
+/// and shadow stay on both so the two are equally findable on busy imagery.
+///
+/// Swapping the ring colour instead was tried first and inverted the emphasis:
+/// at 12px a primary ring on a white core just reads "white dot", which shouts
+/// louder than the teal one — the trips you HAVEN'T taken became the loud
+/// pins in a section headed by the ones you have. Both stay hardcoded white
+/// rather than a surface token: these sit on satellite imagery, which looks
+/// the same in either app theme, so a theme-following ring would vanish.
 class _FootprintPin extends StatelessWidget {
-  final String city;
+  final String tooltip;
+  final bool visited;
 
-  const _FootprintPin({required this.city});
+  const _FootprintPin({required this.tooltip, required this.visited});
 
   @override
   Widget build(BuildContext context) {
+    final primary = Theme.of(context).colorScheme.primary;
     return Tooltip(
-      message: city,
+      message: tooltip,
       triggerMode: TooltipTriggerMode.tap,
       child: Center(
         child: Container(
           width: 12,
           height: 12,
           decoration: BoxDecoration(
-            color: Theme.of(context).colorScheme.primary,
+            color: visited ? primary : Colors.black.withValues(alpha: 0.35),
             shape: BoxShape.circle,
             border: Border.all(color: Colors.white, width: 2),
             boxShadow: [

--- a/src/packages/flutter-app/test/trip_days_test.dart
+++ b/src/packages/flutter-app/test/trip_days_test.dart
@@ -87,6 +87,65 @@ void main() {
     });
   });
 
+  group('tripHasStarted', () {
+    final today = DateTime(2026, 8, 13, 22, 30); // time of day is ignored
+
+    test('a trip starting today has started; tomorrow has not', () {
+      expect(tripHasStarted('2026-08-13', '2026-08-20', today), isTrue);
+      expect(tripHasStarted('2026-08-14', '2026-08-20', today), isFalse);
+    });
+
+    test('every past trip has started (the tripIsPast mirror)', () {
+      expect(tripHasStarted('2026-07-01', '2026-07-05', today), isTrue);
+      expect(tripIsPast('2026-07-01', '2026-07-05', today), isTrue);
+    });
+
+    test('an in-progress trip has started but is not past', () {
+      expect(tripHasStarted('2026-08-10', '2026-08-20', today), isTrue);
+      expect(tripIsPast('2026-08-10', '2026-08-20', today), isFalse);
+    });
+
+    test('falls back to the end date when there is no start', () {
+      expect(tripHasStarted(null, '2026-07-05', today), isTrue);
+      expect(tripHasStarted(null, '2026-09-05', today), isFalse);
+    });
+
+    test('undated and garbage trips have not started', () {
+      expect(tripHasStarted(null, null, today), isFalse);
+      expect(tripHasStarted('not-a-date', null, today), isFalse);
+    });
+  });
+
+  group('traveledDayCount', () {
+    final today = DateTime(2026, 8, 13, 22, 30); // time of day is ignored
+
+    test('a finished trip counts in full, matching dayCount', () {
+      expect(traveledDayCount('2026-06-10', '2026-06-14', today), 5);
+      expect(dayCount('2026-06-10', '2026-06-14', const <int?>[]), 5);
+    });
+
+    test('an in-progress trip counts only the days lived through', () {
+      // Day 1 was Aug 10; today is Aug 13 ⇒ 4 days behind us, 7 to go.
+      expect(traveledDayCount('2026-08-10', '2026-08-20', today), 4);
+    });
+
+    test('a trip starting today counts its first day', () {
+      expect(traveledDayCount('2026-08-13', '2026-08-20', today), 1);
+    });
+
+    test('a future trip counts nothing', () {
+      expect(traveledDayCount('2026-08-14', '2026-08-20', today), 0);
+      expect(traveledDayCount('2027-01-01', '2027-01-10', today), 0);
+    });
+
+    test('half-dated and undated trips count nothing (the dayCount rule)', () {
+      expect(traveledDayCount('2026-06-10', null, today), 0);
+      expect(traveledDayCount(null, '2026-06-14', today), 0);
+      expect(traveledDayCount(null, null, today), 0);
+      expect(traveledDayCount('junk', 'junk', today), 0);
+    });
+  });
+
   group('stayCoversDate', () {
     const checkIn = '2026-06-10';
     const checkOut = '2026-06-13';

--- a/src/packages/flutter-app/test/trip_list_insights_test.dart
+++ b/src/packages/flutter-app/test/trip_list_insights_test.dart
@@ -4,9 +4,9 @@ import 'package:travel_route_planner/models/city_pin.dart';
 import 'package:travel_route_planner/models/trip.dart';
 import 'package:travel_route_planner/utils/trip_list_insights.dart';
 
-/// List-payload insight derivations (utils/trip_list_insights.dart): lifetime
-/// stats, footprint pins, and the booking-nudge window — plus the Trip model's
-/// tolerance for payloads with and without the new insight keys.
+/// List-payload insight derivations (utils/trip_list_insights.dart): the
+/// traveled/planned split, footprint pins, and the booking-nudge window — plus
+/// the Trip model's tolerance for payloads with and without the insight keys.
 
 Trip _trip(
   String id, {
@@ -33,45 +33,102 @@ Trip _trip(
 final _today = DateTime(2026, 8, 6);
 
 void main() {
-  group('lifetimeStats', () {
-    test('counts all trips and sums dated spans; undated contribute zero days',
-        () {
-      final s = lifetimeStats([
-        _trip('dated', start: '2026-08-20', end: '2026-08-24'), // 5 days
-        _trip('draft'),
-      ]);
-      expect(s.trips, 2);
-      expect(s.travelDays, 5);
-      expect(s.cities, 0);
-    });
-
-    test('is all-time: past and upcoming trips both count', () {
-      final s = lifetimeStats([
+  group('travelStats', () {
+    test('a finished trip is traveled in full; a future one is planned', () {
+      final s = travelStats([
         _trip('past',
             start: '2026-01-01', end: '2026-01-05', // 5 days, long over
             cities: const ['Lisbon']),
         _trip('future',
             start: '2026-09-01', end: '2026-09-03', // 3 days
             cities: const ['Madrid']),
-      ]);
-      expect(s.trips, 2);
-      expect(s.travelDays, 8);
-      expect(s.cities, 2);
+      ], _today);
+      expect(s.traveled, (trips: 1, travelDays: 5, cities: 1));
+      expect(s.planned, (trips: 1, travelDays: 3, cities: 1));
     });
 
-    test('dedupes cities case- and whitespace-insensitively across trips', () {
-      final s = lifetimeStats([
-        _trip('a', cities: const ['Lisbon', 'Porto']),
-        _trip('b', cities: const [' lisbon ', 'PORTO', 'Madrid']),
-      ]);
-      expect(s.cities, 3);
+    test('an in-progress trip counts only the days lived through so far', () {
+      // Day 1 was Aug 4; today is Aug 6 ⇒ 3 of the 10 days are behind us. The
+      // remaining 7 belong to neither side: each side stays consistent with
+      // the trips shown beside it.
+      final s = travelStats([
+        _trip('live', start: '2026-08-04', end: '2026-08-13', cities: const [
+          'Athens',
+          'Naxos',
+        ]),
+      ], _today);
+      expect(s.traveled, (trips: 1, travelDays: 3, cities: 2));
+      expect(s.planned, (trips: 0, travelDays: 0, cities: 0));
     });
 
-    test('an empty list yields all zeros', () {
-      final s = lifetimeStats(const []);
-      expect(s.trips, 0);
-      expect(s.travelDays, 0);
-      expect(s.cities, 0);
+    test('a trip starting today has started (1 day travelled)', () {
+      final s = travelStats(
+          [_trip('t', start: '2026-08-06', end: '2026-08-08')], _today);
+      expect(s.traveled.trips, 1);
+      expect(s.traveled.travelDays, 1);
+      expect(s.planned.trips, 0);
+    });
+
+    test('a trip starting tomorrow is still planned, at its full span', () {
+      final s = travelStats(
+          [_trip('t', start: '2026-08-07', end: '2026-08-09')], _today);
+      expect(s.traveled.trips, 0);
+      expect(s.planned, (trips: 1, travelDays: 3, cities: 0));
+    });
+
+    test('undated drafts are planned and contribute no days', () {
+      final s = travelStats([
+        _trip('draft', cities: const ['Tokyo']),
+        _trip('dated', start: '2026-08-20', end: '2026-08-24'), // 5 days
+      ], _today);
+      expect(s.traveled, (trips: 0, travelDays: 0, cities: 0));
+      expect(s.planned, (trips: 2, travelDays: 5, cities: 1));
+    });
+
+    test('a half-dated trip buckets by its one date but adds no days', () {
+      // start-only in the past: the list files it under Past trips, so the
+      // band must agree it has been travelled — dayCount needs both dates,
+      // so it lands there with 0 days rather than sitting among the plans.
+      final s = travelStats([_trip('t', start: '2026-05-01')], _today);
+      expect(s.traveled, (trips: 1, travelDays: 0, cities: 0));
+      expect(s.planned.trips, 0);
+    });
+
+    test('dedupes cities case- and whitespace-insensitively within a side', () {
+      final s = travelStats([
+        _trip('a', start: '2026-09-01', end: '2026-09-03', cities: const [
+          'Lisbon',
+          'Porto',
+        ]),
+        _trip('b', start: '2026-10-01', end: '2026-10-03', cities: const [
+          ' lisbon ',
+          'PORTO',
+          'Madrid',
+        ]),
+      ], _today);
+      expect(s.planned.cities, 3);
+    });
+
+    test('a city on both sides counts once, as traveled', () {
+      final s = travelStats([
+        // Newest-created first, exactly like the server's order: the planned
+        // trip is seen BEFORE the past one that actually visited Lisbon.
+        _trip('return', start: '2026-09-01', end: '2026-09-03', cities: const [
+          'Lisbon',
+          'Madrid',
+        ]),
+        _trip('first', start: '2026-01-01', end: '2026-01-05', cities: const [
+          'Lisbon',
+        ]),
+      ], _today);
+      expect(s.traveled.cities, 1); // Lisbon
+      expect(s.planned.cities, 1); // Madrid only
+    });
+
+    test('an empty list yields two zeroed sides', () {
+      final s = travelStats(const [], _today);
+      expect(s.traveled, (trips: 0, travelDays: 0, cities: 0));
+      expect(s.planned, (trips: 0, travelDays: 0, cities: 0));
     });
   });
 
@@ -130,7 +187,7 @@ void main() {
         _trip('b', pins: const [
           CityPin(city: 'Madrid', lat: 40.4, lng: -3.7),
         ]),
-      ]);
+      ], _today);
       expect(pins.map((p) => p.city), ['Lisbon', 'Porto', 'Madrid']);
     });
 
@@ -141,7 +198,7 @@ void main() {
           CityPin(city: ' LISBON ', lat: 0.1, lng: 0.2), // revisit — ignored
           CityPin(city: 'Athens', lat: 37.9, lng: 23.7),
         ]),
-      ]);
+      ], _today);
       expect(pins, hasLength(2));
       expect(pins[0].city, 'Lisbon');
       expect(pins[0].lat, 38.7);
@@ -153,8 +210,54 @@ void main() {
       final pins = footprintPins([
         _trip('bare'),
         _trip('a', pins: const [CityPin(city: 'Lisbon', lat: 38.7, lng: -9.1)]),
-      ]);
+      ], _today);
       expect(pins.map((p) => p.city), ['Lisbon']);
+    });
+
+    test('visited tracks whether the trip has started', () {
+      final pins = footprintPins([
+        _trip('past',
+            start: '2026-01-01',
+            end: '2026-01-05',
+            cities: const ['Lisbon'],
+            pins: const [CityPin(city: 'Lisbon', lat: 38.7, lng: -9.1)]),
+        _trip('future',
+            start: '2026-09-01',
+            end: '2026-09-03',
+            cities: const ['Madrid'],
+            pins: const [CityPin(city: 'Madrid', lat: 40.4, lng: -3.7)]),
+      ], _today);
+      expect(pins.map((p) => p.visited), [true, false]);
+    });
+
+    test('a visited city stays visited when a PLANNED trip wins its coordinate',
+        () {
+      // Server order is newest-created-first, so the upcoming return trip
+      // supplies the winning pin for a city the traveler has already been to.
+      // Reading `visited` off that row would hollow out an earned dot.
+      final pins = footprintPins([
+        _trip('return',
+            start: '2026-09-01',
+            end: '2026-09-03',
+            cities: const ['Lisbon'],
+            pins: const [CityPin(city: ' lisbon ', lat: 38.7, lng: -9.1)]),
+        _trip('first',
+            start: '2026-01-01',
+            end: '2026-01-05',
+            cities: const ['Lisbon'],
+            pins: const [CityPin(city: 'Lisbon', lat: 38.71, lng: -9.14)]),
+      ], _today);
+      expect(pins, hasLength(1));
+      expect(pins.single.visited, isTrue);
+    });
+
+    test('an undated draft pins as planned', () {
+      final pins = footprintPins([
+        _trip('draft',
+            cities: const ['Tokyo'],
+            pins: const [CityPin(city: 'Tokyo', lat: 35.7, lng: 139.7)]),
+      ], _today);
+      expect(pins.single.visited, isFalse);
     });
   });
 

--- a/src/packages/flutter-app/test/trip_list_order_test.dart
+++ b/src/packages/flutter-app/test/trip_list_order_test.dart
@@ -171,6 +171,6 @@ void main() {
   });
 
   // The old upcomingStats group moved with its derivation: the header line it
-  // fed was replaced by the all-time "Your travels" band, so its cases now
-  // live in trip_list_insights_test.dart against lifetimeStats.
+  // fed was replaced by the "Your travels" band, so its cases now live in
+  // trip_list_insights_test.dart against travelStats.
 }

--- a/src/packages/flutter-app/test/trips_list_footprint_test.dart
+++ b/src/packages/flutter-app/test/trips_list_footprint_test.dart
@@ -21,19 +21,25 @@ import 'package:travel_route_planner/widgets/travel_footprint_card.dart';
 import 'support/l10n_test_app.dart';
 
 /// The "Your travels" section on the trips list (specs/trips-page-insights):
-/// the lifetime stat tiles plus the footprint map, gated at 2+ OWNED trips —
+/// the travel stat tiles plus the footprint map, gated at 2+ OWNED trips —
 /// shared-with-me is someone else's travel and carries none of the fields.
 /// The map sub-band is gated separately on having pins; with none the card
 /// degrades to a bare stats strip rather than showing an empty globe.
+///
+/// The tiles come in two labeled groups, traveled and planned, and **a group
+/// with no trips does not render** — the rule that keeps a planner who has
+/// taken no trips yet from meeting a row of zeros, and the reason this card
+/// needs no second display mode. Groups are found by key, not by label, so the
+/// invariant is asserted the same way in any locale.
 ///
 /// The "Your travels" title is a page-level SectionHeader ABOVE the card, not
 /// inside it — an unlabeled map over a stats panel is the "Up next" hero's
 /// silhouette, so an in-card label let the whole thing read as another
 /// upcoming trip. Header and card share one gate, so neither renders alone.
 ///
-/// Dates are relative to DateTime.now() so the all-time totals stay
-/// deterministic. Tile HTTP in widget tests 400s and is silently tolerated,
-/// so map assertions are structural (FlutterMap presence), never imagery.
+/// Dates are relative to DateTime.now() so the split stays deterministic. Tile
+/// HTTP in widget tests 400s and is silently tolerated, so map assertions are
+/// structural (FlutterMap presence), never imagery.
 class _FixedTripsApiService extends TripsApiService {
   final List<Trip> trips;
 
@@ -91,6 +97,11 @@ Future<void> _pumpList(
 /// number printed on a trip card elsewhere on the page.
 Finder _inBand(Finder matching) => find.descendant(
     of: find.byType(TravelFootprintCard), matching: matching);
+
+/// Scopes a finder to ONE stat group — with two groups on screen, "2" and
+/// "Trips" both appear twice, so every tile assertion has to say which side.
+Finder _inGroup(Key group, Finder matching) =>
+    find.descendant(of: find.byKey(group), matching: matching);
 
 void main() {
   setUp(() {
@@ -183,38 +194,124 @@ void main() {
     expect(find.byType(FlutterMap), findsNothing);
   });
 
-  testWidgets('the tiles are all-time — a finished trip counts',
+  testWidgets('a finished trip and an upcoming one report as separate groups',
       (WidgetTester tester) async {
     await _pumpList(tester, trips: [
       // 5 travel days, long over.
       _trip('past', 'Iberia Loop',
           start: _rel(-30), end: _rel(-26), cities: const ['Lisbon', 'Porto']),
-      // 3 travel days, still ahead.
+      // 3 travel days over 2 cities, still ahead.
       _trip('next', 'Madrid Trip',
+          start: _rel(10),
+          end: _rel(12),
+          cities: const ['Madrid', 'Toledo']),
+    ]);
+    await tester.pumpAndSettle();
+
+    expect(find.text('Traveled'), findsOneWidget);
+    expect(_inGroup(kTraveledStatsKey, find.text('1')), findsOneWidget);
+    expect(_inGroup(kTraveledStatsKey, find.text('Trip')), findsOneWidget);
+    expect(_inGroup(kTraveledStatsKey, find.text('5')), findsOneWidget);
+    expect(_inGroup(kTraveledStatsKey, find.text('2')), findsOneWidget);
+    expect(_inGroup(kTraveledStatsKey, find.text('Cities')), findsOneWidget);
+
+    expect(find.text('Planned'), findsOneWidget);
+    expect(_inGroup(kPlannedStatsKey, find.text('1')), findsOneWidget);
+    expect(_inGroup(kPlannedStatsKey, find.text('3')), findsOneWidget);
+    expect(_inGroup(kPlannedStatsKey, find.text('Travel days')), findsOneWidget);
+    expect(_inGroup(kPlannedStatsKey, find.text('2')), findsOneWidget);
+
+    // The old single all-time strip would have said 2 trips / 8 days / 3
+    // cities — no tile anywhere now claims travel that hasn't happened.
+    expect(_inBand(find.text('8')), findsNothing);
+  });
+
+  testWidgets('an in-progress trip counts only the days lived through',
+      (WidgetTester tester) async {
+    await _pumpList(tester, trips: [
+      // Started 2 days ago, 5 more to run: 3 days travelled so far.
+      _trip('live', 'Athens Now',
+          start: _rel(-2), end: _rel(5), cities: const ['Athens']),
+      _trip('later', 'Madrid Trip',
           start: _rel(10), end: _rel(12), cities: const ['Madrid']),
     ]);
     await tester.pumpAndSettle();
 
-    expect(_inBand(find.text('2')), findsOneWidget);
-    expect(_inBand(find.text('Trips')), findsOneWidget);
-    expect(_inBand(find.text('8')), findsOneWidget);
-    expect(_inBand(find.text('Travel days')), findsOneWidget);
-    expect(_inBand(find.text('3')), findsOneWidget);
-    expect(_inBand(find.text('Cities')), findsOneWidget);
+    expect(_inGroup(kTraveledStatsKey, find.text('3')), findsOneWidget);
+    expect(_inGroup(kTraveledStatsKey, find.text('8')), findsNothing);
+  });
+
+  testWidgets('a planner with nothing travelled yet gets no Traveled group',
+      (WidgetTester tester) async {
+    // The whole reason the groups are gated: three zeros would be a worse
+    // welcome than the old (wrong) all-time totals.
+    await _pumpList(tester, trips: [
+      _trip('t1', 'Lisbon Trip',
+          start: _rel(10), end: _rel(13), cities: const ['Lisbon']),
+      _trip('t2', 'Athens Trip',
+          start: _rel(40), end: _rel(45), cities: const ['Athens', 'Delphi']),
+    ]);
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(kTraveledStatsKey), findsNothing);
+    expect(find.text('Traveled'), findsNothing);
+    expect(find.byKey(kPlannedStatsKey), findsOneWidget);
+    expect(_inGroup(kPlannedStatsKey, find.text('2')), findsOneWidget);
+    expect(_inBand(find.text('0')), findsNothing);
+  });
+
+  testWidgets('an account with only finished trips gets no Planned group',
+      (WidgetTester tester) async {
+    await _pumpList(tester, trips: [
+      _trip('t1', 'Iberia Loop',
+          start: _rel(-30), end: _rel(-26), cities: const ['Lisbon']),
+      _trip('t2', 'Athens Trip',
+          start: _rel(-90), end: _rel(-85), cities: const ['Athens', 'Delphi']),
+    ]);
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(kPlannedStatsKey), findsNothing);
+    expect(find.text('Planned'), findsNothing);
+    expect(_inGroup(kTraveledStatsKey, find.text('2')), findsOneWidget);
+    expect(_inBand(find.text('0')), findsNothing);
   });
 
   testWidgets('zero-valued segments drop out; the trips tile always stays',
       (WidgetTester tester) async {
-    // Undated, city-less legacy rows contribute no days and no cities.
+    // Undated, city-less legacy rows contribute no days and no cities — and
+    // an undated draft is a plan, not travel taken.
     await _pumpList(tester, trips: [
       _trip('d1', 'Someday Trip'),
       _trip('d2', 'Another Someday'),
     ]);
     await tester.pumpAndSettle();
 
-    expect(_inBand(find.text('2')), findsOneWidget);
-    expect(_inBand(find.text('Trips')), findsOneWidget);
+    expect(find.byKey(kTraveledStatsKey), findsNothing);
+    expect(_inGroup(kPlannedStatsKey, find.text('2')), findsOneWidget);
+    expect(_inGroup(kPlannedStatsKey, find.text('Trips')), findsOneWidget);
     expect(find.text('Travel days'), findsNothing);
     expect(find.text('Cities'), findsNothing);
+  });
+
+  testWidgets('the map marks visited cities apart from planned ones',
+      (WidgetTester tester) async {
+    await _pumpList(tester, trips: [
+      _trip('past', 'Iberia Loop',
+          start: _rel(-30),
+          end: _rel(-26),
+          cities: const ['Lisbon'],
+          pins: const [CityPin(city: 'Lisbon', lat: 38.7, lng: -9.1)]),
+      _trip('next', 'Madrid Trip',
+          start: _rel(10),
+          end: _rel(12),
+          cities: const ['Madrid'],
+          pins: const [CityPin(city: 'Madrid', lat: 40.4, lng: -3.7)]),
+    ]);
+    await tester.pumpAndSettle();
+
+    // The dot styles are the fast read; the tooltip is the one that can't be
+    // misread, so that is what the test pins.
+    expect(_inBand(find.byTooltip('Lisbon · Traveled')), findsOneWidget);
+    expect(_inBand(find.byTooltip('Madrid · Planned')), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary

- **The band was counting the future as travel taken.** `lifetimeStats()` ran over every owned trip with no date filter, so an account with a 2-day past trip and two upcoming ones reported **40 travel days** when 2 had happened — and all 12 map pins drew as the same "been there" dot. Both contradicted where the section sits (`trips_list_screen.dart`: *"the retrospective section, where the page turns from plans to history"*) and what its own spec asked the map for (*"so that I can see where I've been at a glance"*).
- **Two labeled groups now, Traveled and Planned** — and **a group with no trips does not render**. That one rule replaces every special case: a planner who has taken no trips yet sees only "Planned" instead of a row of zeros, an account with nothing upcoming sees only "Traveled", and under the unchanged 2+-owned-trips gate at least one group always renders because every trip lands on exactly one side.
- **Bucket**: a trip is traveled once it has *started* (`tripHasStarted` — first day = `start ?? end`, today or earlier). Mirrors `tripIsPast`'s last-day rule, so every trip filed under "Past trips" is also counted as travelled.
- **Travel days**: traveled counts only days already lived through, so an in-progress trip's counter ticks up daily rather than banking all 35 days on day one; planned counts the full span of trips that haven't started. Each group stays consistent with the trips shown beside it — the arithmetic a reader can actually check.
- **Cities** partition, with traveled winning the overlap, so a city on both a past and a future trip counts once, as visited.
- **Map**: filled dot = visited, hollow = still ahead, with the state in the tap tooltip ("Kraków · Planned") because two dot styles are a fast read, not a precise one. `visited` is taken from the set of cities on started trips, **never** from whichever trip supplied the winning coordinate — server order is newest-created-first, so a planned trip routinely lands ahead of the past trip that earned the dot.
- Client-only: **no payload, SQL, or migration change**. `lifetimeStats` is deleted rather than kept alongside `travelStats`, so `utils/trip_list_insights.dart` stays the one derivation site.
- `specs/trips-page-insights/spec.md` gains a dated amendment; its "all-time" wording would otherwise be stale.

## Testing

- `flutter analyze` — clean (only 3 pre-existing infos in the untouched `route_response.dart`).
- `flutter test` — **1188 passing**. New/rewritten coverage: the traveled/planned split (past-only, future-only, mixed, undated draft, in-progress elapsed days, half-dated, a city on both sides), the `visited` flag including the planned-trip-wins-the-coordinate trap, `tripHasStarted`/`traveledDayCount` unit cases, and widget-level assertions that a zero-trip group renders **nothing** (found by key, so the invariant holds in any locale).
- Browser-verified on a seeded 4-trip fixture (past / in-progress / starts-tomorrow / big future) at 1440px and 390px, light and dark:
  - Traveled **2 / 5 / 3**, Planned **2 / 34 / 5** — and the Happening-Now pill independently read "Day 3 of 6", matching the 5 traveled days (2 past + 3 elapsed).
  - Guadalajara stayed a **filled** pin even though the *planned* Big Summer trip supplied its coordinate — the trap above, confirmed live.
  - Two design fixes came out of the screenshots: the planned pin originally inverted the ring instead of the fill, which at 12px just read "white dot" and made the trips you *haven't* taken the loud ones; and a 12px inter-group seam left the "Planned" eyebrow equidistant between the two groups, so it read as floating rather than heading the one below (now `xl`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)