### PR TITLE
docs(integrate): deploys never block the next merge

### DIFF
--- a/.claude/skills/integrate/SKILL.md
+++ b/.claude/skills/integrate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: integrate
-description: Serially merge a wave of open lane PRs — rebase, resolve hub files, regenerate generated code, wait for green CI, merge, watch the deploy, repeat. Use after a parallel wave's lane agents have stopped at PR-open.
+description: Serially merge a wave of open lane PRs — rebase, resolve hub files, regenerate generated code, wait for green CI, merge, repeat. Deploys run in the background and never block the next merge. Use after a parallel wave's lane agents have stopped at PR-open.
 ---
 
 # Integrate a wave of lane PRs
@@ -57,17 +57,27 @@ here: `docs/parallel-dev.md` §3–6.
 
 8. **Merge**: `gh pr merge <number> --merge --delete-branch`.
 
-9. **Watch the deploy**: every main merge triggers build-push → a
-   self-verifying prod deploy. `gh run watch` the run for the merge commit
-   until "Verify deployed release" succeeds. **Do not start the next merge
-   before this** — a broken deploy under a stacked queue is un-bisectable.
-   If it fails: stop the queue, fix forward on main (or revert), resume only
-   when prod is green.
+9. **Start the deploy, but do NOT block the queue on it**: every main merge
+   triggers build-push → a self-verifying prod deploy. Go straight to
+   rebasing the next PR — **do not wait for "Verify deployed release"**.
+   Brian's standing instruction: a multi-PR wave otherwise spends most of its
+   wall-clock idling on `gh run watch`, and the deploy is self-verifying with
+   its result still visible afterward.
+
+   **The safety valve stays — it is just moved, not removed.** Check the
+   deploys you already started between merges (a non-blocking
+   `gh run list --branch main --limit 3` is enough), and the moment one goes
+   red: **stop the queue**, fix forward on main (or revert), resume only when
+   prod is green. A broken deploy under a stacked queue is un-bisectable, so
+   not-blocking is a bet that deploys usually pass — never a licence to leave
+   a failure unnoticed. Every deploy must be accounted for by step 10.
 
 10. **Next PR.** When the queue is empty: return to the main checkout,
     `git checkout main && git pull`, then `make wt-rm NAME=<lane>` for each
     merged lane (from the main checkout — it deletes the lane's worktree and
-    branch), and report the wave summary — PRs merged, deploys verified,
+    branch), and report the wave summary — PRs merged, **the outcome of every
+    deploy the wave started** (confirm each one actually landed before
+    declaring the wave done; this is where the step-9 watch was traded for),
     final prod SHA.
 
 ## Notes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,8 @@ worktree (`make wt-new NAME=…`, own dev stack on its own ports) = one PR. Lane
 agents STOP at PR-open (`ship pr` — never merge); one integrator session
 (`/integrate`) rebases, resolves hub files, regenerates generated code
 (`store/`, `lib/l10n/app_localizations*.dart`, `*.g.dart` are NEVER
-hand-merged — regen LAST), merges serially, and watches each deploy. Wave
+hand-merged — regen LAST), and merges serially. Deploys run in the background
+and never block the next merge; a red one stops the queue. Wave
 planning reserves goose migration numbers; at most one in-flight lane may touch
 `trip_detail_screen.dart` or append to `plan_tool_registry.go`. Full rules and
 runbooks: [`docs/parallel-dev.md`](docs/parallel-dev.md). Triggers: `/wave`

--- a/docs/parallel-dev.md
+++ b/docs/parallel-dev.md
@@ -9,8 +9,10 @@ the process half.
 One feature wave = N **lanes**. One lane = one branch = one git worktree = one
 coding agent = one PR (or a short PR chain). Lane agents **stop at PR-open** —
 they never merge. One **integrator** session merges serially: rebase → resolve
-hub files → regenerate generated code → green CI → merge → watch the deploy →
-next. Brian approves the lane plan and steers; agents code.
+hub files → regenerate generated code → green CI → merge → next. The prod
+deploy each merge triggers runs in the background and **never blocks the next
+merge** (§6); it is checked as it lands, and a red one stops the queue. Brian
+approves the lane plan and steers; agents code.
 
 Roles:
 
@@ -20,7 +22,8 @@ Roles:
   rebases, never touches files outside its conflict manifest.
 - **Integrator** — owns `main`. Runs the `/integrate` loop
   (`.claude/skills/integrate`). Only the integrator rebases, force-pushes
-  (`--force-with-lease`), merges, and watches deploys.
+  (`--force-with-lease`), and merges. It tracks deploys without serializing
+  the queue behind them, and accounts for every one in the wave summary.
 - **Brian** — wave-planning approval, lane steering, anything requiring
   product judgment.
 
@@ -145,10 +148,11 @@ rebase that conflicts in generated files you **never hand-merge them**:
 - `trip_detail_screen.dart` is in ~1 of 3 PRs: in a wave of k typical lanes,
   expected god-screen touchers ≈ 0.31k. Past 3–4 lanes you can't fill a wave
   that avoids it. (Splitting that screen is the single biggest future unlock.)
-- Integration is serial: rebase + regen + CI wait + merge + deploy watch is
-  ~15–25 min per PR, and every merge to main is a queued, self-verifying prod
-  deploy. Four lanes ≈ a 1.5 h integrator tail; beyond that the parallel
-  coding gain is eaten by the tail.
+- Integration is serial: rebase + regen + CI wait + merge is ~10–20 min per
+  PR. The prod deploy each merge triggers is queued and self-verifying, but
+  sits **off** the critical path (§6), so it no longer adds to the per-PR
+  cost — it only stops the queue if it goes red. Four lanes ≈ a 1 h
+  integrator tail; beyond that the parallel coding gain is eaten by the tail.
 - The ≤1-migration-per-lane and single-registry-lane rules cap schema- or
   agent-tool-heavy waves regardless.
 - Each Mode-B lane also runs a full 4-container stack (~1–2 GB peak during the
@@ -160,9 +164,16 @@ Summary (the operational skill is `.claude/skills/integrate` — run
 `/integrate`): merge in dependency order; one PR at a time; rebase (inside the
 lane's worktree — the branch is checked out there) → resolve per §3–4 →
 local checks → `--force-with-lease` → wait green (the rebase rerun
-is also what makes the duplicate-migration CI guard bite) → merge → **watch
-the deploy until prod serves the new SHA before starting the next merge** — a
-broken deploy under a stacked queue is un-bisectable.
+is also what makes the duplicate-migration CI guard bite) → merge → **start
+the next PR immediately; do NOT wait for the deploy**.
+
+The prod deploy each merge triggers is self-verifying and runs off the
+critical path. Check the ones already in flight between merges, and **the
+moment one goes red, stop the queue** — fix forward on main (or revert) and
+resume only when prod is green, because a broken deploy under a stacked queue
+is un-bisectable. Every deploy the wave started must be accounted for in the
+final summary; not blocking is a bet that deploys usually pass, never a reason
+to leave one unchecked.
 
 Who fixes a red check: **the integrator fixes anything integration created**
 (hub resolution, cross-lane contract parity, codegen drift, fmt);


### PR DESCRIPTION
## Summary

When integrating a wave, the integrator now starts rebasing the next PR **immediately after a merge** instead of waiting for that merge's prod deploy to finish.

Brian gave this instruction once before and it didn't stick — because it lived only in session memory while `.claude/skills/integrate` step 9 said the opposite ("**Do not start the next merge before this**"). The skill loads as authoritative context on every `/integrate` run, so the checked-in text won every time. This fixes it at the source.

Changed in four places so nothing contradicts:
- `.claude/skills/integrate/SKILL.md` — description, step 9 (rewritten), step 10 (deploy accounting)
- `docs/parallel-dev.md` — §1 model, roles list, §5 sizing math, §6 merge queue
- `CLAUDE.md` — the Parallel Development paragraph

## The safety valve moved, it did not disappear

The old rule had a real rationale — *a broken deploy under a stacked queue is un-bisectable* — so that protection is preserved, just off the critical path:

- Check in-flight deploys between merges (`gh run list --branch main --limit 3`, non-blocking).
- **The moment one goes red, stop the queue** — fix forward on main or revert, resume only when prod is green.
- **Every deploy the wave started must be accounted for in the final summary.** This is what step 9's watch was traded for.

Not blocking is a bet that deploys usually pass — never a reason to leave one unchecked.

Also updates the now-stale cost model: per-PR integrator time ~15–25 min → ~10–20 min, four-lane tail ~1.5 h → ~1 h, since the deploy no longer sits on the critical path.

## Testing

Docs and skill text only — no code, no tests affected. Verified by grep that no block-on-deploy phrasing survives in the skill, `docs/parallel-dev.md`, `CLAUDE.md`, or the `wave` skill, and that the new `§6` cross-references point at the right section ("The integrator merge queue").

🤖 Generated with [Claude Code](https://claude.com/claude-code)