### PR TITLE
docs(integrate): a cancelled main deploy is superseded, not broken

### DIFF
--- a/.claude/skills/integrate/SKILL.md
+++ b/.claude/skills/integrate/SKILL.md
@@ -66,19 +66,39 @@ here: `docs/parallel-dev.md` §3–6.
 
    **The safety valve stays — it is just moved, not removed.** Check the
    deploys you already started between merges (a non-blocking
-   `gh run list --branch main --limit 3` is enough), and the moment one goes
-   red: **stop the queue**, fix forward on main (or revert), resume only when
-   prod is green. A broken deploy under a stacked queue is un-bisectable, so
-   not-blocking is a bet that deploys usually pass — never a licence to leave
-   a failure unnoticed. Every deploy must be accounted for by step 10.
+   `gh run list --branch main --limit 5` is enough), and the moment one
+   **fails**: stop the queue, fix forward on main (or revert), resume only
+   when prod is green. A broken deploy under a stacked queue is un-bisectable,
+   so not-blocking is a bet that deploys usually pass — never a licence to
+   leave a failure unnoticed.
+
+   **`cancelled` on a main run is normal here — do NOT treat it as a
+   failure.** Merging back-to-back is exactly what this step now encourages,
+   so main deploy runs queue up, and GitHub keeps only the newest *pending*
+   run in the concurrency group (`ci-${{ github.ref }}`, `cancel-in-progress`
+   is false for main — see `.github/workflows/ci.yml`). The superseded ones
+   are cancelled **before running a single job**, so nothing was interrupted
+   mid-deploy and nothing is lost: the surviving run builds the newest main,
+   which already contains every commit the cancelled ones would have shipped.
+   Tell the two apart by the jobs list, not the badge —
+   `gh run view <id> --json jobs --jq '.jobs|length'` returns `0` for a
+   superseded run and non-zero for one that actually ran and broke.
+
+   The consequence: **a wave is only verified when its LAST deploy succeeds.**
+   Intermediate `cancelled` runs prove nothing either way, so step 10's
+   accounting is now load-bearing rather than a formality.
 
 10. **Next PR.** When the queue is empty: return to the main checkout,
     `git checkout main && git pull`, then `make wt-rm NAME=<lane>` for each
     merged lane (from the main checkout — it deletes the lane's worktree and
-    branch), and report the wave summary — PRs merged, **the outcome of every
-    deploy the wave started** (confirm each one actually landed before
-    declaring the wave done; this is where the step-9 watch was traded for),
-    final prod SHA.
+    branch), and report the wave summary — PRs merged, and **the wave's final
+    deploy watched to a green finish** (`gh run watch <id> --exit-status`),
+    since that is the run that actually ships every merge in the wave.
+    Superseded `cancelled` runs are expected and need no action; a `failure`
+    at any point does. Confirm prod serves the new SHA — `/health` `release`
+    or `/app/version.json` — before declaring the wave done. This accounting
+    is what step 9's per-merge watch was traded for, so it is the one deploy
+    check that must not be skipped.
 
 ## Notes
 

--- a/docs/parallel-dev.md
+++ b/docs/parallel-dev.md
@@ -169,11 +169,22 @@ the next PR immediately; do NOT wait for the deploy**.
 
 The prod deploy each merge triggers is self-verifying and runs off the
 critical path. Check the ones already in flight between merges, and **the
-moment one goes red, stop the queue** — fix forward on main (or revert) and
+moment one FAILS, stop the queue** — fix forward on main (or revert) and
 resume only when prod is green, because a broken deploy under a stacked queue
-is un-bisectable. Every deploy the wave started must be accounted for in the
-final summary; not blocking is a bet that deploys usually pass, never a reason
-to leave one unchecked.
+is un-bisectable.
+
+**A `cancelled` main run is not a failure.** Back-to-back merges queue their
+deploys, and GitHub keeps only the newest *pending* run in the concurrency
+group (`cancel-in-progress` is false for main, so nothing is ever killed
+mid-deploy). Superseded runs are cancelled before executing a single job —
+check `gh run view <id> --json jobs`: `0` jobs means superseded, not broken.
+The surviving run builds a main that already contains the cancelled runs'
+commits.
+
+So the wave is verified by its **last** deploy, not by each one: watch that
+run to green and confirm prod serves the new SHA before calling the wave
+done. Not blocking is a bet that deploys usually pass, never a reason to skip
+that final check.
 
 Who fixes a red check: **the integrator fixes anything integration created**
 (hub resolution, cross-lane contract parity, codegen drift, fmt);


### PR DESCRIPTION
## Summary

Follow-up to #410. That PR told the integrator to check in-flight deploys and "stop the queue the moment one goes red" — but never said what red actually looks like under the new cadence.

**Observed on the first wave run under the new rule:** #402, #403 and #407 all show `conclusion=cancelled` on main. That reads as three failed deploys. It isn't.

Merging back-to-back is precisely what #410 encourages, so main deploy runs queue up, and GitHub keeps only the newest **pending** run in the concurrency group. `cancel-in-progress` is `false` for main (`.github/workflows/ci.yml`), so nothing is ever killed mid-deploy — the superseded runs are cancelled **before executing a single job**, and the surviving run builds a main that already contains their commits.

Verified rather than assumed: run `31848697761` (the #407 merge) has `jobs: []` and was cancelled 36s after creation, having started nothing.

So #410 left two ways to get this wrong:
- stop a perfectly healthy queue over a `cancelled` badge, or
- scan a list of `cancelled` runs, assume the wave deployed, and ship nothing.

## Changes

- Distinguish **`cancelled`** (superseded — no action) from **`failure`** (stop the queue, fix forward or revert).
- Give the test for telling them apart: `gh run view <id> --json jobs --jq '.jobs|length'` → `0` means superseded, non-zero means it ran and broke.
- Make step 10 **watch the wave's last deploy to green** (`gh run watch <id> --exit-status`) and confirm prod serves the new SHA (`/health` `release` or `/app/version.json`).

That final check is now load-bearing: intermediate cancelled runs prove nothing either way, so the last deploy is the only thing that shows the wave actually shipped — and it's what step 9's per-merge watch was traded for.

## Testing

Docs and skill text only. The behavioral claim was verified against the live runs from tonight's wave (jobs list empty on a superseded run, non-empty on one that executes) and against the `concurrency` block in `.github/workflows/ci.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)