### PR TITLE
fix(profile): let a home airport actually be cleared, and stop lying on save

### DIFF
--- a/src/packages/api/plan_tool_registry.go
+++ b/src/packages/api/plan_tool_registry.go
@@ -766,13 +766,35 @@ func runSavePreferencesTool(s *planSession, input json.RawMessage) (string, bool
 	}
 	json.Unmarshal(input, &in)
 
-	budget, _ := normalizeChoice(in.Budget, allowedBudgets, "budget")
-	pace, _ := normalizeChoice(in.Pace, allowedPaces, "pace")
-	workStyle, _ := normalizeChoice(in.WorkStyle, allowedWorkStyles, "work_style")
-	fitnessRoutine, _ := normalizeChoice(in.FitnessRoutine, allowedFitnessRoutines, "fitness_routine")
-	outdoorIntensity, _ := normalizeChoice(in.OutdoorIntensity, allowedOutdoorIntensities, "outdoor_intensity")
-	companions, _ := normalizeChoice(in.Companions, allowedCompanions, "companions")
-	homeAirport, _ := normalizeAirportCode(in.HomeAirport)
+	// A value the model got wrong is dropped, not saved — and the tool result is
+	// the only channel that can say so. It used to answer a flat "Preferences
+	// saved." while the rejected field kept its old value, so the model learned
+	// its write had landed; the field is absent from `changed` too, so nothing
+	// else contradicted it. Collect the rejections and report them.
+	var rejected []string
+	keep := func(v *string, err error) *string {
+		if err != nil {
+			rejected = append(rejected, err.Error())
+			return nil
+		}
+		return v
+	}
+
+	budget := keep(normalizeChoice(in.Budget, allowedBudgets, "budget"))
+	pace := keep(normalizeChoice(in.Pace, allowedPaces, "pace"))
+	workStyle := keep(normalizeChoice(in.WorkStyle, allowedWorkStyles, "work_style"))
+	fitnessRoutine := keep(normalizeChoice(in.FitnessRoutine, allowedFitnessRoutines, "fitness_routine"))
+	outdoorIntensity := keep(normalizeChoice(in.OutdoorIntensity, allowedOutdoorIntensities, "outdoor_intensity"))
+	companions := keep(normalizeChoice(in.Companions, allowedCompanions, "companions"))
+
+	// The clear flag is deliberately dropped: like profile_notes below, only the
+	// user (PUT) can empty a home airport — an agent sending "" means it had
+	// nothing to say, not that the traveler wants theirs removed.
+	homeAirport, _, airportErr := normalizeAirportCode(in.HomeAirport)
+	if airportErr != nil {
+		rejected = append(rejected, airportErr.Error())
+		homeAirport = nil
+	}
 	var interestsArg interface{}
 	if in.Interests != nil {
 		interestsArg = normalizeInterests(in.Interests)
@@ -821,6 +843,11 @@ func runSavePreferencesTool(s *planSession, input json.RawMessage) (string, bool
 		sendSSE(s.w, "profile_updated", map[string]any{
 			"fields": changed, "notes_preview": notesPreview(notes),
 		})
+	}
+	if len(rejected) > 0 {
+		// Not an error result: whatever else was in the call did save.
+		return "Preferences saved, except: " + strings.Join(rejected, "; ") +
+			". Those fields were left unchanged — retry with a valid value.", false
 	}
 	return "Preferences saved.", false
 }

--- a/src/packages/api/preferences_handler.go
+++ b/src/packages/api/preferences_handler.go
@@ -133,7 +133,7 @@ func putPreferencesHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	homeAirport, err := normalizeAirportCode(req.HomeAirport)
+	homeAirport, clearHomeAirport, err := normalizeAirportCode(req.HomeAirport)
 	if err != nil {
 		writeJSONError(w, http.StatusBadRequest, err.Error())
 		return
@@ -151,6 +151,7 @@ func putPreferencesHandler(w http.ResponseWriter, r *http.Request) {
 		Pace:             pace,
 		Interests:        interestsArg,
 		HomeAirport:      homeAirport,
+		ClearHomeAirport: clearHomeAirport,
 		ProfileNotes:     normalizeNotes(req.ProfileNotes),
 		WorkStyle:        workStyle,
 		FitnessRoutine:   fitnessRoutine,
@@ -180,20 +181,32 @@ func normalizeChoice(v *string, allowed map[string]bool, field string) (*string,
 	return &s, nil
 }
 
-// normalizeAirportCode validates and upper-cases a home airport. Empty/nil ->
-// nil (omit, keep existing); anything other than a 3-letter IATA code -> error.
-func normalizeAirportCode(v *string) (*string, error) {
+// normalizeAirportCode validates and upper-cases a home airport, and reports
+// the three request shapes separately rather than folding two of them together:
+//
+//	nil        -> (nil, false, nil)  omitted: keep whatever is stored
+//	"" / "  "  -> (nil, true,  nil)  explicit clear: write NULL
+//	"bos"      -> ("BOS", false, nil)
+//	anything else                    -> error
+//
+// The empty case used to collapse into the omitted case, which made a home
+// airport impossible to remove: the upsert COALESCEs a nil back to the existing
+// value, so clearing the field returned 200 with the old code still stored. The
+// clear bool is what UpsertPreferences.ClearHomeAirport consumes. Mirrors the
+// omitted-vs-cleared split already documented on PutPreferencesRequest's
+// Interests and ProfileNotes.
+func normalizeAirportCode(v *string) (value *string, clear bool, err error) {
 	if v == nil {
-		return nil, nil
+		return nil, false, nil
 	}
 	s := strings.ToUpper(strings.TrimSpace(*v))
 	if s == "" {
-		return nil, nil
+		return nil, true, nil
 	}
 	if len(s) != 3 || !isAlpha(s) {
-		return nil, errors.New("home_airport must be a 3-letter IATA code")
+		return nil, false, errors.New("home_airport must be a 3-letter IATA code")
 	}
-	return &s, nil
+	return &s, false, nil
 }
 
 const maxProfileNotesLen = 2000

--- a/src/packages/api/preferences_handler_test.go
+++ b/src/packages/api/preferences_handler_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -87,6 +88,55 @@ func TestNormalizeActiveProfileChoices(t *testing.T) {
 			// other choice field on this profile.
 			if got, err := normalizeChoice(strPtr(""), c.allowed, c.field); got != nil || err != nil {
 				t.Fatalf("normalizeChoice(\"\") = %v, %v; want nil, nil", got, err)
+			}
+		})
+	}
+}
+
+// Home airport is the one field on this profile that CAN be emptied, so its
+// normalizer has to report three request shapes, not two. Before the clear
+// flag existed, "" collapsed into nil and the upsert COALESCEd nil back to the
+// stored value — a traveler could set or replace a home airport but never
+// remove one, and the attempt returned 200 with the old code still in the
+// response. Untested until now.
+func TestNormalizeAirportCode(t *testing.T) {
+	t.Run("nil keeps existing", func(t *testing.T) {
+		got, clear, err := normalizeAirportCode(nil)
+		if got != nil || clear || err != nil {
+			t.Fatalf("got %v, clear=%v, err=%v; want nil, false, nil", got, clear, err)
+		}
+	})
+
+	// The distinction the whole change turns on: empty is a request, not an
+	// omission.
+	for _, empty := range []string{"", "   ", "\t"} {
+		t.Run("empty clears "+strconv.Quote(empty), func(t *testing.T) {
+			got, clear, err := normalizeAirportCode(strPtr(empty))
+			if got != nil || !clear || err != nil {
+				t.Fatalf("got %v, clear=%v, err=%v; want nil, true, nil", got, clear, err)
+			}
+		})
+	}
+
+	for _, in := range []string{"bos", "BOS", "  bos  ", "Bos"} {
+		t.Run("accepts "+strconv.Quote(in), func(t *testing.T) {
+			got, clear, err := normalizeAirportCode(strPtr(in))
+			if err != nil || got == nil || *got != "BOS" || clear {
+				t.Fatalf("got %v, clear=%v, err=%v; want BOS, false, nil", got, clear, err)
+			}
+		})
+	}
+
+	// A rejection must not read as a clear: answering (nil, true) here would
+	// wipe a good home airport because the model spelled the city out.
+	for _, bad := range []string{"Boston", "KBOS", "B", "BO", "B0S", "B S", "BÓS"} {
+		t.Run("rejects "+strconv.Quote(bad), func(t *testing.T) {
+			got, clear, err := normalizeAirportCode(strPtr(bad))
+			if err == nil {
+				t.Fatalf("normalizeAirportCode(%q) = %v; want an error", bad, got)
+			}
+			if clear {
+				t.Fatalf("normalizeAirportCode(%q) set clear; a bad value must never empty the column", bad)
 			}
 		})
 	}

--- a/src/packages/api/profile_distiller.go
+++ b/src/packages/api/profile_distiller.go
@@ -133,13 +133,32 @@ func distillTravelerProfile(ctx context.Context, client anthropic.Client, uid uu
 		return
 	}
 
-	budget, _ := normalizeChoice(in.Budget, allowedBudgets, "budget")
-	pace, _ := normalizeChoice(in.Pace, allowedPaces, "pace")
-	workStyle, _ := normalizeChoice(in.WorkStyle, allowedWorkStyles, "work_style")
-	fitnessRoutine, _ := normalizeChoice(in.FitnessRoutine, allowedFitnessRoutines, "fitness_routine")
-	outdoorIntensity, _ := normalizeChoice(in.OutdoorIntensity, allowedOutdoorIntensities, "outdoor_intensity")
-	companions, _ := normalizeChoice(in.Companions, allowedCompanions, "companions")
-	homeAirport, _ := normalizeAirportCode(in.HomeAirport)
+	// Distillation runs in the background with no caller to answer, so a value
+	// the model got wrong is dropped — but it is logged rather than discarded
+	// silently, because a model that keeps emitting e.g. "Boston" for an IATA
+	// field is a prompt bug and nothing else would ever surface it.
+	keep := func(v *string, err error) *string {
+		if err != nil {
+			log.Printf("profile distill: %v (field left unchanged)", err)
+			return nil
+		}
+		return v
+	}
+
+	budget := keep(normalizeChoice(in.Budget, allowedBudgets, "budget"))
+	pace := keep(normalizeChoice(in.Pace, allowedPaces, "pace"))
+	workStyle := keep(normalizeChoice(in.WorkStyle, allowedWorkStyles, "work_style"))
+	fitnessRoutine := keep(normalizeChoice(in.FitnessRoutine, allowedFitnessRoutines, "fitness_routine"))
+	outdoorIntensity := keep(normalizeChoice(in.OutdoorIntensity, allowedOutdoorIntensities, "outdoor_intensity"))
+	companions := keep(normalizeChoice(in.Companions, allowedCompanions, "companions"))
+
+	// Clear flag dropped on purpose: distillation can no more empty a home
+	// airport than it can wipe notes below.
+	homeAirport, _, airportErr := normalizeAirportCode(in.HomeAirport)
+	if airportErr != nil {
+		log.Printf("profile distill: %v (field left unchanged)", airportErr)
+		homeAirport = nil
+	}
 	var interestsArg interface{}
 	if in.Interests != nil {
 		interestsArg = normalizeInterests(in.Interests)

--- a/src/packages/api/query/preferences.sql
+++ b/src/packages/api/query/preferences.sql
@@ -19,7 +19,14 @@ ON CONFLICT (user_id) DO UPDATE SET
     budget            = COALESCE(sqlc.narg('budget'), traveler_preferences.budget),
     pace              = COALESCE(sqlc.narg('pace'), traveler_preferences.pace),
     interests         = COALESCE(sqlc.narg('interests'), traveler_preferences.interests),
-    home_airport      = COALESCE(sqlc.narg('home_airport'), traveler_preferences.home_airport),
+    -- Removing a home airport needs a signal COALESCE cannot carry: NULL means
+    -- "omitted, keep what's there", so without this flag the column could only
+    -- ever be set or replaced, never emptied. Writes a real NULL rather than an
+    -- empty-string sentinel, so "no home airport" has exactly one representation.
+    home_airport      = CASE
+        WHEN sqlc.arg('clear_home_airport')::boolean THEN NULL
+        ELSE COALESCE(sqlc.narg('home_airport'), traveler_preferences.home_airport)
+    END,
     profile_notes     = COALESCE(sqlc.narg('profile_notes'), traveler_preferences.profile_notes),
     work_style        = COALESCE(sqlc.narg('work_style'), traveler_preferences.work_style),
     fitness_routine   = COALESCE(sqlc.narg('fitness_routine'), traveler_preferences.fitness_routine),

--- a/src/packages/api/store/preferences.sql.go
+++ b/src/packages/api/store/preferences.sql.go
@@ -53,7 +53,14 @@ ON CONFLICT (user_id) DO UPDATE SET
     budget            = COALESCE($2, traveler_preferences.budget),
     pace              = COALESCE($3, traveler_preferences.pace),
     interests         = COALESCE($4, traveler_preferences.interests),
-    home_airport      = COALESCE($5, traveler_preferences.home_airport),
+    -- Removing a home airport needs a signal COALESCE cannot carry: NULL means
+    -- "omitted, keep what's there", so without this flag the column could only
+    -- ever be set or replaced, never emptied. Writes a real NULL rather than an
+    -- empty-string sentinel, so "no home airport" has exactly one representation.
+    home_airport      = CASE
+        WHEN $11::boolean THEN NULL
+        ELSE COALESCE($5, traveler_preferences.home_airport)
+    END,
     profile_notes     = COALESCE($6, traveler_preferences.profile_notes),
     work_style        = COALESCE($7, traveler_preferences.work_style),
     fitness_routine   = COALESCE($8, traveler_preferences.fitness_routine),
@@ -73,6 +80,7 @@ type UpsertPreferencesParams struct {
 	FitnessRoutine   *string     `json:"fitness_routine"`
 	OutdoorIntensity *string     `json:"outdoor_intensity"`
 	Companions       *string     `json:"companions"`
+	ClearHomeAirport bool        `json:"clear_home_airport"`
 }
 
 func (q *Queries) UpsertPreferences(ctx context.Context, arg UpsertPreferencesParams) (TravelerPreference, error) {
@@ -87,6 +95,7 @@ func (q *Queries) UpsertPreferences(ctx context.Context, arg UpsertPreferencesPa
 		arg.FitnessRoutine,
 		arg.OutdoorIntensity,
 		arg.Companions,
+		arg.ClearHomeAirport,
 	)
 	var i TravelerPreference
 	err := row.Scan(

--- a/src/packages/flutter-app/lib/l10n/app_en.arb
+++ b/src/packages/flutter-app/lib/l10n/app_en.arb
@@ -92,6 +92,10 @@
   "prefsAddInterest": "Add an interest",
   "prefsHomeAirport": "Home airport",
   "prefsHomeAirportHelp": "Used as the default origin when planning flights.",
+  "prefsHomeAirportPickOne": "Pick an airport from the list, or clear the field.",
+  "@prefsHomeAirportPickOne": {
+    "description": "Shown under the home airport field when the traveler typed something but never chose a suggestion, so there is no airport to save."
+  },
   "prefsProfileNotes": "Profile notes",
   "prefsProfileNotesHelp": "Your AI agent keeps these notes as it learns about you. Edit or clear them anytime.",
   "prefsProfileNotesHint": "Nothing noted yet — the agent adds to this as you plan trips.",

--- a/src/packages/flutter-app/lib/l10n/app_es.arb
+++ b/src/packages/flutter-app/lib/l10n/app_es.arb
@@ -29,6 +29,7 @@
   "prefsAddInterest": "Añadir un interés",
   "prefsHomeAirport": "Aeropuerto de origen",
   "prefsHomeAirportHelp": "Se usa como origen predeterminado al planificar vuelos.",
+  "prefsHomeAirportPickOne": "Elige un aeropuerto de la lista o vacía el campo.",
   "prefsProfileNotes": "Notas del perfil",
   "prefsProfileNotesHelp": "Tu agente de IA mantiene estas notas a medida que te conoce. Puedes editarlas o borrarlas cuando quieras.",
   "prefsProfileNotesHint": "Todavía no hay notas: el agente las va añadiendo mientras planificas viajes.",

--- a/src/packages/flutter-app/lib/l10n/app_localizations.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations.dart
@@ -272,6 +272,12 @@ abstract class AppLocalizations {
   /// **'Used as the default origin when planning flights.'**
   String get prefsHomeAirportHelp;
 
+  /// Shown under the home airport field when the traveler typed something but never chose a suggestion, so there is no airport to save.
+  ///
+  /// In en, this message translates to:
+  /// **'Pick an airport from the list, or clear the field.'**
+  String get prefsHomeAirportPickOne;
+
   /// No description provided for @prefsProfileNotes.
   ///
   /// In en, this message translates to:

--- a/src/packages/flutter-app/lib/l10n/app_localizations_en.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations_en.dart
@@ -102,6 +102,10 @@ class AppLocalizationsEn extends AppLocalizations {
       'Used as the default origin when planning flights.';
 
   @override
+  String get prefsHomeAirportPickOne =>
+      'Pick an airport from the list, or clear the field.';
+
+  @override
   String get prefsProfileNotes => 'Profile notes';
 
   @override

--- a/src/packages/flutter-app/lib/l10n/app_localizations_es.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations_es.dart
@@ -102,6 +102,10 @@ class AppLocalizationsEs extends AppLocalizations {
       'Se usa como origen predeterminado al planificar vuelos.';
 
   @override
+  String get prefsHomeAirportPickOne =>
+      'Elige un aeropuerto de la lista o vacía el campo.';
+
+  @override
   String get prefsProfileNotes => 'Notas del perfil';
 
   @override

--- a/src/packages/flutter-app/lib/screens/preferences_screen.dart
+++ b/src/packages/flutter-app/lib/screens/preferences_screen.dart
@@ -59,6 +59,16 @@ class _PreferencesScreenState extends ConsumerState<PreferencesScreen> {
   String? _outdoorIntensity;
   final Set<String> _interests = {};
   Airport? _homeAirport;
+
+  /// Mirror of the airport field's raw text. `_homeAirport == null` is two
+  /// different states — "no home airport" and "typed something, never picked
+  /// it" — and only this tells them apart. Saving the second as the first is
+  /// what used to discard an edit under a "Preferences saved" toast.
+  String _homeAirportText = '';
+  String? _homeAirportError;
+
+  bool get _homeAirportUnresolved =>
+      _homeAirport == null && _homeAirportText.trim().isNotEmpty;
   final _notesController = TextEditingController();
   bool _initialized = false;
 
@@ -88,14 +98,26 @@ class _PreferencesScreenState extends ConsumerState<PreferencesScreen> {
         _fitnessRoutine = prefs.fitnessRoutine;
         _outdoorIntensity = prefs.outdoorIntensity;
         _interests.addAll(prefs.interests);
-        final home = prefs.homeAirport;
-        if (home != null && home.isNotEmpty) {
-          _homeAirport = Airport(iataCode: home, name: home);
-        }
+        _seedHomeAirport(prefs.homeAirport);
         _notesController.text = prefs.profileNotes ?? '';
       }
       _initialized = true;
     });
+  }
+
+  /// Seeds (or re-seeds) the airport field from a server value. Call inside a
+  /// setState. An absent code resets the field rather than leaving the previous
+  /// one on screen — after a clear, the form has to show what was actually
+  /// stored, not what the user hoped for.
+  void _seedHomeAirport(String? code) {
+    if (code != null && code.isNotEmpty) {
+      _homeAirport = Airport(iataCode: code, name: code);
+      _homeAirportText = _homeAirport!.label;
+    } else {
+      _homeAirport = null;
+      _homeAirportText = '';
+    }
+    _homeAirportError = null;
   }
 
   @override
@@ -105,6 +127,13 @@ class _PreferencesScreenState extends ConsumerState<PreferencesScreen> {
   }
 
   Future<void> _save() async {
+    // An unresolved airport edit is refused rather than dropped. Sending it as
+    // "no change" would return 200 with the old code still stored, and the user
+    // would get "Preferences saved" for an edit that never happened.
+    if (_homeAirportUnresolved) {
+      setState(() => _homeAirportError = context.l10n.prefsHomeAirportPickOne);
+      return;
+    }
     final ok = await ref.read(preferencesProvider.notifier).save(
           budget: _budget,
           pace: _pace,
@@ -113,11 +142,19 @@ class _PreferencesScreenState extends ConsumerState<PreferencesScreen> {
           fitnessRoutine: _fitnessRoutine,
           outdoorIntensity: _outdoorIntensity,
           interests: _interests.toList(),
-          homeAirport: _homeAirport?.iataCode,
+          // "" is an explicit clear, not an omission — null would be COALESCEd
+          // back to the stored code, making a home airport unremovable.
+          homeAirport: _homeAirport?.iataCode ?? '',
           // Always send the field's text: an emptied field clears the notes.
           profileNotes: _notesController.text.trim(),
         );
     if (!mounted) return;
+    if (ok) {
+      // Re-seed from what the server actually stored, so the form shows the
+      // post-state rather than a hopeful local one (docs/zen.md).
+      setState(
+          () => _seedHomeAirport(ref.read(preferencesProvider).prefs?.homeAirport));
+    }
     showSnack(
         context, ok ? context.l10n.prefsSaved : context.l10n.prefsSaveFailed);
   }
@@ -249,7 +286,16 @@ class _PreferencesScreenState extends ConsumerState<PreferencesScreen> {
                   label: l10n.prefsHomeAirport,
                   icon: Icons.home,
                   selected: _homeAirport,
-                  onSelected: (a) => setState(() => _homeAirport = a),
+                  errorText: _homeAirportError,
+                  onSelected: (a) => setState(() {
+                    _homeAirport = a;
+                    if (a != null) _homeAirportError = null;
+                  }),
+                  onQueryChanged: (t) => setState(() {
+                    _homeAirportText = t;
+                    // Any edit retracts the complaint; Save re-checks.
+                    _homeAirportError = null;
+                  }),
                 ),
                 const SizedBox(height: AppSpacing.xl),
                 SectionHeader(title: l10n.prefsProfileNotes),

--- a/src/packages/flutter-app/lib/widgets/airport_field.dart
+++ b/src/packages/flutter-app/lib/widgets/airport_field.dart
@@ -34,12 +34,26 @@ class AirportField extends ConsumerStatefulWidget {
   final Airport? selected;
   final ValueChanged<Airport?> onSelected;
 
+  /// Mirrors the raw field text to the parent on every change, including the
+  /// programmatic writes made when a suggestion is picked or the field cleared.
+  ///
+  /// A parent that saves needs this: [selected] alone cannot tell "no airport"
+  /// apart from "typed something and never picked it", and those must not be
+  /// treated the same — silently saving the second as the first is how an edit
+  /// gets thrown away under a success message.
+  final ValueChanged<String>? onQueryChanged;
+
+  /// Shown under the field, e.g. to say an edit is unresolved.
+  final String? errorText;
+
   const AirportField({
     super.key,
     required this.label,
     required this.icon,
     required this.selected,
     required this.onSelected,
+    this.onQueryChanged,
+    this.errorText,
   });
 
   @override
@@ -182,8 +196,12 @@ class _AirportFieldState extends ConsumerState<AirportField> {
   }
 
   /// Commits a pick: the field shows the chosen label and the list closes.
+  /// [AirportField.onQueryChanged] fires before [AirportField.onSelected] here
+  /// and in [_clear], so a parent that derives "unresolved" from the pair never
+  /// observes the new text against the old selection.
   void _commit(Airport airport) {
     _debounce?.cancel();
+    widget.onQueryChanged?.call(airport.label);
     widget.onSelected(airport);
     setState(() {
       _setText(airport.label);
@@ -199,6 +217,7 @@ class _AirportFieldState extends ConsumerState<AirportField> {
   /// Clears both the text and the selection (the trailing X).
   void _clear() {
     _debounce?.cancel();
+    widget.onQueryChanged?.call('');
     widget.onSelected(null);
     setState(() {
       _controller.clear();
@@ -244,6 +263,7 @@ class _AirportFieldState extends ConsumerState<AirportField> {
               hintText: l10n.airportFieldHint,
               prefixIcon: Icon(widget.icon),
               border: const OutlineInputBorder(),
+              errorText: widget.errorText,
               suffixIcon: _controller.text.isEmpty
                   ? null
                   : IconButton(
@@ -265,6 +285,7 @@ class _AirportFieldState extends ConsumerState<AirportField> {
               // never reach onChanged, so this cannot loop with the
               // didUpdateWidget re-seed.
               if (widget.selected != null) widget.onSelected(null);
+              widget.onQueryChanged?.call(v);
               setState(() {
                 _dirty = true;
                 _dismissed = false;

--- a/src/packages/flutter-app/test/preferences_home_airport_test.dart
+++ b/src/packages/flutter-app/test/preferences_home_airport_test.dart
@@ -1,0 +1,182 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:travel_route_planner/models/airport.dart';
+import 'package:travel_route_planner/models/traveler_preferences.dart';
+import 'package:travel_route_planner/providers/flights_provider.dart';
+import 'package:travel_route_planner/providers/preferences_provider.dart';
+import 'package:travel_route_planner/screens/preferences_screen.dart';
+import 'package:travel_route_planner/services/api_client.dart';
+import 'package:travel_route_planner/services/flights_api_service.dart';
+import 'package:travel_route_planner/services/preferences_api_service.dart';
+import 'package:travel_route_planner/widgets/airport_field.dart';
+
+import 'support/l10n_test_app.dart';
+
+/// Saving a home airport tells the truth about what was stored.
+///
+/// Two silent failures used to live here. Typing an airport without picking it
+/// from the dropdown left the selection null, which went out as
+/// `home_airport: null` — "omitted, keep existing" to the server — so the PUT
+/// returned 200 with the OLD code and the screen said "Preferences saved".
+/// And clearing the field was impossible for the same reason: nothing the
+/// client could send meant "remove it".
+
+class _FakePrefsApi implements PreferencesApiService {
+  TravelerPreferences stored;
+  int saveCalls = 0;
+  final List<String?> homeAirportArgs = [];
+
+  _FakePrefsApi({required this.stored});
+
+  @override
+  ApiClient get apiClient => throw UnsupportedError('unused in tests');
+
+  @override
+  Future<TravelerPreferences> getPreferences() async => stored;
+
+  @override
+  Future<TravelerPreferences> savePreferences({
+    String? budget,
+    String? pace,
+    required List<String> interests,
+    String? homeAirport,
+    String? profileNotes,
+    String? workStyle,
+    String? fitnessRoutine,
+    String? outdoorIntensity,
+    String? companions,
+  }) async {
+    saveCalls++;
+    homeAirportArgs.add(homeAirport);
+    // Mirror the server: "" clears, a code replaces, null keeps.
+    final next = homeAirport == null
+        ? stored.homeAirport
+        : (homeAirport.isEmpty ? null : homeAirport);
+    stored = TravelerPreferences(
+      budget: budget,
+      pace: pace,
+      interests: interests,
+      homeAirport: next,
+      profileNotes: profileNotes,
+      workStyle: workStyle,
+    );
+    return stored;
+  }
+}
+
+class _FakeFlightsApi extends FlightsApiService {
+  _FakeFlightsApi() : super(ApiClient(baseUrl: 'http://test'));
+
+  @override
+  Future<List<Airport>> searchAirports(String query) async => const [
+        Airport(
+          iataCode: 'SEA',
+          name: 'Seattle-Tacoma International Airport',
+          city: 'Seattle',
+          country: 'US',
+          subType: 'airport',
+        ),
+      ];
+}
+
+Future<_FakePrefsApi> _pump(WidgetTester tester, {String? saved}) async {
+  // The profile is ~2000px tall since the active-profile sections landed, so
+  // the airport field and Save sit far below the default 800x600 surface and
+  // taps miss the hit test. Give the test a surface tall enough to hold it all.
+  tester.view.physicalSize = const Size(1000, 3000);
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.resetPhysicalSize);
+  addTearDown(tester.view.resetDevicePixelRatio);
+
+  final api = _FakePrefsApi(stored: TravelerPreferences(homeAirport: saved));
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        preferencesApiServiceProvider.overrideWithValue(api),
+        flightsApiServiceProvider.overrideWithValue(_FakeFlightsApi()),
+      ],
+      child: localizedTestApp(home: const PreferencesScreen()),
+    ),
+  );
+  await tester.pumpAndSettle();
+  return api;
+}
+
+/// The airport field specifically. `find.byType(TextField).first` would grab
+/// the InterestPicker's "add an interest" box, which sits above this section.
+Finder _airportFinder() => find.descendant(
+      of: find.byType(AirportField),
+      matching: find.byType(TextField),
+    );
+
+TextField _airportField(WidgetTester tester) =>
+    tester.widget<TextField>(_airportFinder());
+
+Future<void> _save(WidgetTester tester) async {
+  await tester.tap(find.text('Save'));
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  testWidgets('clearing the field sends an explicit clear, not a null',
+      (t) async {
+    final api = await _pump(t, saved: 'BOS');
+    expect(_airportField(t).controller?.text, 'BOS');
+
+    await t.tap(find.byIcon(Icons.close));
+    await t.pumpAndSettle();
+    await _save(t);
+
+    // "" is the clear signal; null would be COALESCEd back to BOS server-side.
+    expect(api.homeAirportArgs, ['']);
+    expect(api.stored.homeAirport, isNull);
+    expect(_airportField(t).controller?.text, isEmpty);
+  });
+
+  testWidgets('typing without picking blocks the save and says why', (t) async {
+    final api = await _pump(t, saved: 'BOS');
+
+    await t.enterText(_airportFinder(), 'sea');
+    await t.pumpAndSettle();
+    await _save(t);
+
+    expect(api.saveCalls, 0,
+        reason: 'an unresolved edit must not reach the server as a no-op');
+    expect(find.text('Pick an airport from the list, or clear the field.'),
+        findsOneWidget);
+    expect(find.text('Preferences saved'), findsNothing);
+  });
+
+  testWidgets('picking a suggestion clears the complaint and saves the code',
+      (t) async {
+    final api = await _pump(t, saved: 'BOS');
+
+    await t.enterText(_airportFinder(), 'sea');
+    await t.pumpAndSettle();
+    await _save(t); // refused
+    expect(api.saveCalls, 0);
+
+    await t.tap(find.text('Seattle (SEA)'));
+    await t.pumpAndSettle();
+    expect(find.text('Pick an airport from the list, or clear the field.'),
+        findsNothing);
+
+    await _save(t);
+    expect(api.homeAirportArgs, ['SEA']);
+    expect(api.stored.homeAirport, 'SEA');
+  });
+
+  testWidgets('the form re-seeds from what the server stored', (t) async {
+    final api = await _pump(t, saved: 'BOS');
+    // Server normalizes to something other than what was sent.
+    await t.tap(find.byIcon(Icons.close));
+    await t.pumpAndSettle();
+    await _save(t);
+
+    expect(api.stored.homeAirport, isNull);
+    // The field shows the stored post-state, not a hopeful local one.
+    expect(_airportField(t).controller?.text, isEmpty);
+  });
+}


### PR DESCRIPTION
## Summary

Follow-up to #405. That made the home airport field editable; this fixes what still went wrong *once you edited it*. Three silent failures, all of the same shape — a write that changes nothing while reporting success.

**1. `home_airport` could never be cleared.** `normalizeAirportCode` folded `""` into `nil`, and `UpsertPreferences` does `COALESCE(narg, existing)` where `nil` means *keep*. Nothing a client could send meant "remove it": clearing the field returned 200 with the old code still stored, and `personalizedSystemPrompt` kept telling the planner to default flight origins to an airport the traveler thought they'd deleted.

`normalizeAirportCode` now reports three shapes instead of two — `nil` → keep, `""`/whitespace → clear, 3 letters → value — and the clear rides a new `clear_home_airport` arg on `UpsertPreferences`, written as a `CASE` that sets a real `NULL`. No empty-string sentinel, so "no home airport" keeps exactly one representation. The agent and distiller callers use named struct literals, so they inherit `false` and still cannot wipe a traveler's airport.

**2. Typing an airport without picking it saved nothing and said it had.** The selection stayed null, went out as `home_airport: null` (= keep), and the screen showed "Preferences saved". `AirportField` now mirrors its raw text to the parent via `onQueryChanged`, and Save refuses an unresolved edit with an inline error instead of issuing a PUT. A successful save re-seeds the form from the server's response, so the page shows the stored post-state rather than a hopeful local one (`docs/zen.md`).

**3. The agent path swallowed every validation error.** `runSavePreferencesTool` discarded **seven** normalize errors and returned a flat `"Preferences saved."` — and the rejected field is absent from `changed` too, so nothing contradicted it and the model learned its write had landed. Rejections are now collected and named in the tool result. `profile_distiller.go` has no caller to answer, so it logs instead: a model that keeps emitting `"Boston"` for an IATA field is a prompt bug, and nothing else would ever surface it.

## Testing

- **End-to-end against a real Postgres** on the lane stack, which is the only thing that actually proves the COALESCE fix: set → `BOS`; key omitted → `BOS` (keep); `""` → `null` (**clear**); `GET` confirms it stuck; `"Boston"` → 400 with the column untouched.
- New `test/preferences_home_airport_test.dart` (4): clearing sends `""` not `null`; an unresolved edit blocks the save, shows the inline error and issues **no** PUT; picking clears the complaint and saves the code; the form re-seeds from what the server stored.
- New `TestNormalizeAirportCode` in `preferences_handler_test.go` — the function had **no** coverage. Includes the case that matters most: a rejected value must not read as a clear, or a good airport would be wiped because the model spelled the city out.
- `make flutter-test` — 1237 pass. `make api-test-go` with `TEST_DATABASE_URL` — pass (39s, DB-backed integration tests included). `flutter analyze` clean; `go vet`/`go fmt` clean. `l10n_untranslated.json` is `{}`.

## Deliberately not fixed here

`budget` / `pace` / `work_style` / `outdoor_intensity` / `companions` share the same un-clearable behavior via `normalizeChoice`. Generalizing the sentinel is its own change — and `fitness_routine` must be **excluded** from it: its `"none"` is a real answer ("not a factor") that the agent acts on, not an absence. Flattening the two would be a regression, not a cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)