### PR TITLE
feat(ops): track mail send results so a rejected sender alerts

### DIFF
--- a/src/packages/api/email_health.go
+++ b/src/packages/api/email_health.go
@@ -4,6 +4,8 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
+	"time"
 )
 
 // Does the address we send mail FROM belong to the site we are? A cheap,
@@ -108,4 +110,170 @@ func emailAvailabilityHandler(w http.ResponseWriter, r *http.Request) {
 		Available:         emailService.Configured(),
 		SenderDomainCheck: senderDomainState(emailService.From, publicBaseURL()),
 	})
+}
+
+// --- send-result tracking -----------------------------------------------
+//
+// The domain check above is static: it catches a sender pointing at the wrong
+// domain, but not a right-looking domain the provider no longer accepts. Only
+// a real send result sees that, so — exactly as ai_health.go does for the
+// Anthropic call sites — the one place that sends mail classifies the error it
+// already observes, and the ops health verdict reads the result.
+//
+// Same class rules as the AI tracker, for the same reasons: a permanent SMTP
+// rejection is deterministic, is never retried, and does not heal on its own,
+// so it alerts. Anything transient or unrecognized is counted and never
+// alerts — a misread error that pages someone at 3am teaches people to ignore
+// the pager.
+//
+// Known circularity, stated so nobody relies on the wrong channel: the alert
+// path itself sends email (ops_monitor.go alertTransition), so a broken sender
+// cannot page by email. The same transition also emits a Sentry-teed
+// slog.Error and an in-app notification per admin, and those are what actually
+// carry this one.
+
+type emailErrorClass string
+
+const (
+	emailClassOK        emailErrorClass = "ok"
+	emailClassFatal     emailErrorClass = "fatal"     // permanent rejection — alerts
+	emailClassTransient emailErrorClass = "transient" // network/greylist — never alerts
+	emailClassUnknown   emailErrorClass = "unknown"   // unrecognized — never alerts
+)
+
+// classifyEmailError maps one send result to a class plus a short human
+// reason. Pure.
+//
+// It leads with the SMTP reply code, not the message text, because the text is
+// provider-specific prose ("domain is not verified", "sender address rejected")
+// that changes without notice while the codes are RFC 5321. An unrecognized
+// error is deliberately NOT fatal: we would rather miss one outage than raise
+// false alarms, which is the same call ai_health.go makes for unfamiliar
+// provider envelopes.
+func classifyEmailError(err error) (emailErrorClass, string) {
+	if err == nil {
+		return emailClassOK, ""
+	}
+	msg := err.Error()
+	switch smtpReplyCode(msg) {
+	case 535:
+		return emailClassFatal, "authentication"
+	case 550, 553:
+		// What an unverified or unknown sending domain answers.
+		return emailClassFatal, "sender rejected"
+	case 554:
+		return emailClassFatal, "transaction failed"
+	case 421, 450, 451, 452:
+		// 4xx is "try later" by definition.
+		return emailClassTransient, "temporary"
+	}
+	// No parsable reply code: a dial/TLS/timeout failure, or something new.
+	if isTransportError(msg) {
+		return emailClassTransient, "transport"
+	}
+	return emailClassUnknown, ""
+}
+
+// smtpReplyCode reads the leading three-digit reply code from an SMTP error.
+// Go's net/smtp renders these as "550 5.7.1 ..." — returns 0 when absent.
+func smtpReplyCode(msg string) int {
+	s := strings.TrimSpace(msg)
+	if len(s) < 3 {
+		return 0
+	}
+	code := 0
+	for i := 0; i < 3; i++ {
+		if s[i] < '0' || s[i] > '9' {
+			return 0
+		}
+		code = code*10 + int(s[i]-'0')
+	}
+	// Guard against matching a bare number inside prose.
+	if len(s) > 3 && s[3] != ' ' && s[3] != '-' {
+		return 0
+	}
+	return code
+}
+
+func isTransportError(msg string) bool {
+	m := strings.ToLower(msg)
+	for _, hint := range []string{
+		"timeout", "timed out", "connection refused", "no such host",
+		"network is unreachable", "broken pipe", "connection reset", "eof",
+		"i/o timeout", "tls",
+	} {
+		if strings.Contains(m, hint) {
+			return true
+		}
+	}
+	return false
+}
+
+type emailHealthTracker struct {
+	mu              sync.Mutex
+	lastSuccessAt   time.Time
+	lastFatalAt     time.Time
+	lastFatalReason string
+	successTotal    int64
+	transientTotal  int64
+	fatalTotal      int64
+}
+
+var emailHealth = &emailHealthTracker{}
+
+// emailHealthState is a consistent read snapshot; a plain value struct so
+// computeHealthState stays pure and tests construct it literally.
+type emailHealthState struct {
+	Failing        bool
+	Reason         string
+	LastFatalAt    time.Time
+	LastSuccessAt  time.Time
+	SuccessTotal   int64
+	TransientTotal int64
+	FatalTotal     int64
+}
+
+// record folds one classified send in. Transient/unknown results touch neither
+// timestamp, so a blip during a real outage cannot fake a recovery.
+func (t *emailHealthTracker) record(now time.Time, class emailErrorClass, reason string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	switch class {
+	case emailClassOK:
+		t.lastSuccessAt = now
+		t.successTotal++
+	case emailClassFatal:
+		t.lastFatalAt = now
+		t.lastFatalReason = reason
+		t.fatalTotal++
+	case emailClassTransient, emailClassUnknown:
+		t.transientTotal++
+	}
+}
+
+// state returns the snapshot the health verdict and metrics read. Failing
+// clears only on the next successful send — with no mail traffic a fatal state
+// persists, which is correct: a rejected sender does not fix itself, and this
+// whole file exists because a silent two-week version of exactly that went
+// unnoticed.
+func (t *emailHealthTracker) state() emailHealthState {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return emailHealthState{
+		Failing:        !t.lastFatalAt.IsZero() && t.lastFatalAt.After(t.lastSuccessAt),
+		Reason:         t.lastFatalReason,
+		LastFatalAt:    t.lastFatalAt,
+		LastSuccessAt:  t.lastSuccessAt,
+		SuccessTotal:   t.successTotal,
+		TransientTotal: t.transientTotal,
+		FatalTotal:     t.fatalTotal,
+	}
+}
+
+// recordEmailResult is the one-liner the send site uses, exactly once per send
+// attempt (nil err records a success).
+func recordEmailResult(err error) (emailErrorClass, string) {
+	class, reason := classifyEmailError(err)
+	emailHealth.record(time.Now(), class, reason)
+	return class, reason
 }

--- a/src/packages/api/email_send_health_test.go
+++ b/src/packages/api/email_send_health_test.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+// The classifier leads with the SMTP reply code because provider prose changes
+// without notice. An unrecognized error must never classify fatal — the same
+// call ai_health.go makes for unfamiliar envelopes.
+
+func TestClassifyEmailError(t *testing.T) {
+	cases := []struct {
+		name       string
+		err        error
+		wantClass  emailErrorClass
+		wantReason string
+	}{
+		{"success", nil, emailClassOK, ""},
+
+		// Permanent rejections — deterministic, never retried, don't self-heal.
+		{"auth failure", errors.New("535 5.7.8 Authentication credentials invalid"), emailClassFatal, "authentication"},
+		{"sender rejected", errors.New("550 5.7.1 The from address domain is not verified"), emailClassFatal, "sender rejected"},
+		{"mailbox unavailable", errors.New("553 5.1.8 Sender address rejected"), emailClassFatal, "sender rejected"},
+		{"transaction failed", errors.New("554 5.7.1 Message rejected"), emailClassFatal, "transaction failed"},
+		{"code with a hyphen continuation", errors.New("550-5.7.1 rejected"), emailClassFatal, "sender rejected"},
+
+		// 4xx is "try later" by definition.
+		{"service unavailable", errors.New("421 4.7.0 Try again later"), emailClassTransient, "temporary"},
+		{"greylisted", errors.New("450 4.2.0 Greylisted"), emailClassTransient, "temporary"},
+		{"mailbox busy", errors.New("451 4.3.0 Temporary failure"), emailClassTransient, "temporary"},
+		{"insufficient storage", errors.New("452 4.2.2 Over quota"), emailClassTransient, "temporary"},
+
+		// No reply code at all: dial/TLS/timeout.
+		{"connection refused", errors.New("dial tcp 1.2.3.4:587: connect: connection refused"), emailClassTransient, "transport"},
+		{"dns failure", errors.New("dial tcp: lookup smtp.example.com: no such host"), emailClassTransient, "transport"},
+		{"timeout", errors.New("read tcp: i/o timeout"), emailClassTransient, "transport"},
+		{"tls failure", errors.New("tls: first record does not look like a TLS handshake"), emailClassTransient, "transport"},
+
+		// Unrecognized shapes are counted, never alerted.
+		{"unknown shape", errors.New("something nobody has seen before"), emailClassUnknown, ""},
+		// A bare number in prose must not be read as a reply code.
+		{"number inside prose", errors.New("550abc not a reply code"), emailClassUnknown, ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			class, reason := classifyEmailError(c.err)
+			if class != c.wantClass || reason != c.wantReason {
+				t.Fatalf("classifyEmailError(%v) = (%s, %q), want (%s, %q)",
+					c.err, class, reason, c.wantClass, c.wantReason)
+			}
+		})
+	}
+}
+
+func TestEmailHealthTrackerTransitions(t *testing.T) {
+	tr := &emailHealthTracker{}
+	base := time.Date(2026, 8, 15, 12, 0, 0, 0, time.UTC)
+
+	if tr.state().Failing {
+		t.Fatal("a tracker with no sends must not report failing")
+	}
+
+	tr.record(base, emailClassOK, "")
+	if tr.state().Failing {
+		t.Fatal("a success must not report failing")
+	}
+
+	tr.record(base.Add(time.Minute), emailClassFatal, "sender rejected")
+	st := tr.state()
+	if !st.Failing || st.Reason != "sender rejected" {
+		t.Fatalf("a fatal send must flip the signal: %+v", st)
+	}
+
+	// A blip during a real outage must not fake a recovery.
+	tr.record(base.Add(2*time.Minute), emailClassTransient, "transport")
+	tr.record(base.Add(3*time.Minute), emailClassUnknown, "")
+	if !tr.state().Failing {
+		t.Fatal("transient/unknown results must not clear a fatal state")
+	}
+
+	// Only a real success clears it.
+	tr.record(base.Add(4*time.Minute), emailClassOK, "")
+	st = tr.state()
+	if st.Failing {
+		t.Fatal("a successful send must clear the failing state")
+	}
+	if st.SuccessTotal != 2 || st.FatalTotal != 1 || st.TransientTotal != 2 {
+		t.Fatalf("counters wrong: %+v", st)
+	}
+}
+
+func TestRecordEmailResultFeedsTheSharedTracker(t *testing.T) {
+	saved := emailHealth
+	emailHealth = &emailHealthTracker{}
+	defer func() { emailHealth = saved }()
+
+	// What the send site calls, once per attempt.
+	if class, _ := recordEmailResult(errors.New("550 5.7.1 domain not verified")); class != emailClassFatal {
+		t.Fatalf("class = %s, want fatal", class)
+	}
+	if !emailHealth.state().Failing {
+		t.Fatal("the shared tracker did not see the failure")
+	}
+
+	// And it is what the ops verdict reads — the whole point of the exercise.
+	state := computeHealthState(true, false, aiHealthState{}, emailHealth.state())
+	if !state.degraded {
+		t.Fatal("a rejected sender must degrade the ops verdict")
+	}
+	found := false
+	for _, r := range state.reasons {
+		if r == "email failing: sender rejected" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("reason missing from %v", state.reasons)
+	}
+
+	if _, _ = recordEmailResult(nil); emailHealth.state().Failing {
+		t.Fatal("a successful send must clear it")
+	}
+}

--- a/src/packages/api/email_service.go
+++ b/src/packages/api/email_service.go
@@ -97,7 +97,13 @@ func (s *EmailService) SendWithHeaders(to, subject, body string, extraHeaders []
 	if s.Username != "" {
 		auth = smtp.PlainAuth("", s.Username, s.Password, s.Host)
 	}
-	return smtp.SendMail(s.Host+":"+s.Port, auth, s.From, []string{to}, []byte(msg))
+	// The ONE send site, so the ONE place a delivery failure can be observed.
+	// Callers only log the error (and log.Printf never reaches Sentry), which
+	// is how a rejected sender stayed invisible for two weeks — see
+	// email_health.go. Record exactly once per attempt.
+	err := smtp.SendMail(s.Host+":"+s.Port, auth, s.From, []string{to}, []byte(msg))
+	recordEmailResult(err)
+	return err
 }
 
 // buildEmailMessage frames the RFC 5322 message (CRLF-delimited). Pure so the

--- a/src/packages/api/ops_health.go
+++ b/src/packages/api/ops_health.go
@@ -83,7 +83,7 @@ func opsHealthHandler(w http.ResponseWriter, r *http.Request) {
 func buildDependencyHealth(ctx context.Context, now time.Time) DependencyHealth {
 	db := probeDB(ctx)
 	backups := readBackupHealth(now)
-	state := computeHealthState(db.Status == "ok", backups.Stale, aiHealth.state())
+	state := computeHealthState(db.Status == "ok", backups.Stale, aiHealth.state(), emailHealth.state())
 	return DependencyHealth{
 		DB:        db,
 		Providers: providerStatuses(),
@@ -198,16 +198,17 @@ type healthState struct {
 	reasons  []string
 }
 
-// computeHealthState derives the top-level degraded verdict from three
-// deterministic, unpriced signals: DB reachability, backup freshness, and the
+// computeHealthState derives the top-level degraded verdict from four
+// deterministic, unpriced signals: DB reachability, backup freshness, the
 // AI provider's passively-tracked health (ai_health.go — fatal billing/auth
-// failures recorded by the real AI call sites; no probe is ever sent). It
+// failures recorded by the real AI call sites; no probe is ever sent), and
+// transactional mail's, tracked the same passive way (email_health.go). It
 // deliberately does NOT consider provider configuration (a missing optional
 // provider key is not "the service is unhealthy") and never pings paid
 // providers. Once fatal, the AI signal clears only on the next successful AI
 // call — with zero AI traffic the state stays degraded, which is correct for
 // billing/auth outages (they don't fix themselves). reasons is always non-nil.
-func computeHealthState(dbOK, backupsStale bool, ai aiHealthState) healthState {
+func computeHealthState(dbOK, backupsStale bool, ai aiHealthState, mail emailHealthState) healthState {
 	reasons := []string{}
 	if !dbOK {
 		reasons = append(reasons, "database unreachable")
@@ -221,6 +222,15 @@ func computeHealthState(dbOK, backupsStale bool, ai aiHealthState) healthState {
 			reason = "unknown"
 		}
 		reasons = append(reasons, "AI provider failing: "+reason)
+	}
+	if mail.Failing {
+		reason := mail.Reason
+		if reason == "" {
+			reason = "unknown"
+		}
+		// Deliberately reported even though the alert email itself cannot get
+		// out — the Sentry log and the in-app admin notification carry it.
+		reasons = append(reasons, "email failing: "+reason)
 	}
 	return healthState{degraded: len(reasons) > 0, reasons: reasons}
 }

--- a/src/packages/api/ops_health_test.go
+++ b/src/packages/api/ops_health_test.go
@@ -114,25 +114,33 @@ func TestEvalBackupHealth(t *testing.T) {
 
 func TestComputeHealthState(t *testing.T) {
 	failing := aiHealthState{Failing: true, Reason: "credit balance"}
+	mailFailing := emailHealthState{Failing: true, Reason: "sender rejected"}
 	cases := []struct {
 		dbOK, backupsStale bool
 		ai                 aiHealthState
+		mail               emailHealthState
 		wantDegraded       bool
 		wantReasons        []string
 	}{
-		{true, false, aiHealthState{}, false, []string{}},
-		{false, false, aiHealthState{}, true, []string{"database unreachable"}},
-		{true, true, aiHealthState{}, true, []string{"backups stale"}},
-		{false, true, aiHealthState{}, true, []string{"database unreachable", "backups stale"}},
-		{true, false, failing, true, []string{"AI provider failing: credit balance"}},
-		{false, true, failing, true, []string{"database unreachable", "backups stale", "AI provider failing: credit balance"}},
+		{true, false, aiHealthState{}, emailHealthState{}, false, []string{}},
+		{false, false, aiHealthState{}, emailHealthState{}, true, []string{"database unreachable"}},
+		{true, true, aiHealthState{}, emailHealthState{}, true, []string{"backups stale"}},
+		{false, true, aiHealthState{}, emailHealthState{}, true, []string{"database unreachable", "backups stale"}},
+		{true, false, failing, emailHealthState{}, true, []string{"AI provider failing: credit balance"}},
+		{false, true, failing, emailHealthState{}, true, []string{"database unreachable", "backups stale", "AI provider failing: credit balance"}},
 		// Defensive: Failing with no reason still yields a readable line.
-		{true, false, aiHealthState{Failing: true}, true, []string{"AI provider failing: unknown"}},
+		{true, false, aiHealthState{Failing: true}, emailHealthState{}, true, []string{"AI provider failing: unknown"}},
 		// A non-failing tracker with history is not degraded.
-		{true, false, aiHealthState{Reason: "credit balance", FatalTotal: 3}, false, []string{}},
+		{true, false, aiHealthState{Reason: "credit balance", FatalTotal: 3}, emailHealthState{}, false, []string{}},
+		// Mail is the fourth signal, and stacks with the others.
+		{true, false, aiHealthState{}, mailFailing, true, []string{"email failing: sender rejected"}},
+		{true, false, aiHealthState{Failing: true}, mailFailing, true, []string{"AI provider failing: unknown", "email failing: sender rejected"}},
+		{true, false, aiHealthState{}, emailHealthState{Failing: true}, true, []string{"email failing: unknown"}},
+		// History without a current failure is not degraded.
+		{true, false, aiHealthState{}, emailHealthState{Reason: "sender rejected", FatalTotal: 2}, false, []string{}},
 	}
 	for _, c := range cases {
-		got := computeHealthState(c.dbOK, c.backupsStale, c.ai)
+		got := computeHealthState(c.dbOK, c.backupsStale, c.ai, c.mail)
 		if got.degraded != c.wantDegraded {
 			t.Errorf("dbOK=%v stale=%v ai=%+v: degraded=%v want %v", c.dbOK, c.backupsStale, c.ai, got.degraded, c.wantDegraded)
 		}

--- a/src/packages/api/ops_metrics.go
+++ b/src/packages/api/ops_metrics.go
@@ -314,6 +314,13 @@ func upstreamCountsSnapshot() map[string]int64 {
 	m["ai_transient_total"] = ai.TransientTotal
 	m["ai_fatal_total"] = ai.FatalTotal
 	m["ai_consecutive_fatal"] = ai.ConsecutiveFatal
+	// Transactional mail, tracked the same passive way (email_health.go).
+	// email_fatal_total rising is the signal that a sender the static domain
+	// check calls fine is being rejected in practice.
+	mail := emailHealth.state()
+	m["email_success_total"] = mail.SuccessTotal
+	m["email_transient_total"] = mail.TransientTotal
+	m["email_fatal_total"] = mail.FatalTotal
 	return m
 }
 

--- a/src/packages/api/ops_monitor.go
+++ b/src/packages/api/ops_monitor.go
@@ -191,7 +191,7 @@ func (m *healthMonitor) runOnce(ctx context.Context, now time.Time) {
 	dbOK := m.pingDBFn(ctx)
 	backups := readBackupHealth(now)
 	ai := m.aiStateFn()
-	state := computeHealthState(dbOK, backups.Stale, ai)
+	state := computeHealthState(dbOK, backups.Stale, ai, emailHealth.state())
 
 	// Persist the observation BEFORE the transition dedup returns: history
 	// records every tick, alerting only changes (specs/uptime-history). Same


### PR DESCRIPTION
## Summary
The sender-domain check in #413 is **static**: it catches mail pointed at the wrong domain, but not a right-looking domain the provider no longer accepts. Only a real send result sees that — and nothing was looking at send results at all. `smtp.SendMail`'s error went to callers that `log.Printf` it, and `log.Printf` never reaches Sentry (only `slog.Error` is teed). That is the precise mechanism by which two weeks of rejected mail passed unnoticed.

This is **`ai_health.go`'s pattern applied to the same class of blind spot**. That file exists because prod ran for days with `/plan` down on exhausted Anthropic credits while `providerStatuses` reported the key as present. Email had the identical gap, so it gets the identical treatment:

- the **one** send site classifies the error it already observes (`recordEmailResult`, exactly once per attempt);
- a process-lifetime tracker folds it in;
- **`computeHealthState` reads it as a fourth signal**, so a rejected sender flips the shared degraded verdict and the existing transition alerts fire. No probe is ever sent — the never-ping-paid-providers invariant holds.
- `email_{success,transient,fatal}_total` join the `ai_*` counters in `/admin/ops/metrics`.

## Classification
Leads with the **SMTP reply code, not the message text** — the text is provider prose that changes without notice, the codes are RFC 5321.

| Class | Codes | Alerts? |
|---|---|---|
| fatal | 535 auth, 550/553 sender rejected, 554 transaction failed | yes — deterministic, never retried, doesn't self-heal |
| transient | 421/450/451/452, and dial/DNS/TLS/timeout failures | no |
| unknown | anything unrecognized | no |

Missing one outage beats crying wolf, which is the same call `ai_health.go` makes for unfamiliar envelopes. Failing clears **only** on the next successful send, so a blip mid-outage can't fake a recovery and zero traffic can't fake health.

## Known circularity — documented in the file
The alert path itself sends email (`alertTransition`), so **a broken sender cannot page you by email**. The same transition also emits a Sentry-teed `slog.Error` and an in-app admin notification, and those are what carry this one. Worth knowing before trusting the mail channel for this specific failure.

## Testing
- 16 classifier cases including the real rejection shapes, hyphen continuations (`550-5.7.1`), every transport failure mode, and a bare number in prose that must **not** parse as a reply code.
- Tracker transitions: fatal flips it, transient/unknown can't fake a recovery, only a real success clears it, counters correct.
- An end-to-end test that `recordEmailResult` feeds the shared tracker **and that `computeHealthState` degrades with the right reason** — the actual point of the change.
- Existing `TestComputeHealthState` matrix widened for the fourth signal, with rows for mail alone, mail stacked with AI, and history-without-current-failure.
- Full `go test ./...` (88s, integration included — verified the DB was actually up, since a skipped run finishes in 3s and looks identical), `go vet`, `gofmt` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)