### PR TITLE
fix(trips): humanize the trip-detail date chip at every width

### DIFF
--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -4762,13 +4762,23 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
           children: [
             ActionChip(
               avatar: const Icon(Icons.event, size: 16),
-              // Narrow: humanized short range ("Jul 20 – Jul 27") — the raw
-              // ISO pair is ~200px and forces the meta row to wrap.
+              // Humanized short range ("Jul 20 – Jul 27") at every width, and
+              // localized with it (tripDateRange goes through the app locale,
+              // so Spanish reads "20 jul – 27 jul"). Narrow got this first,
+              // because the raw ISO pair is ~200px and forced the meta row to
+              // wrap; wide simply kept the machine form it started with, which
+              // left the SAME trip reading "2026-07-21 → 2026-07-22" on desktop
+              // and "Jul 21 – Jul 22" on a phone. Width is not a reason to
+              // show a different date format — and the layout that has more
+              // room was the one showing the denser string.
+              //
+              // The ISO pair survives only as the unparseable-date fallback:
+              // tripDateRange returns null there, and echoing back whatever is
+              // stored beats an empty chip on a trip whose dates are the thing
+              // you came to fix.
               label: Text(hasDates
-                  ? (_narrow
-                      ? (tripDateRange(trip.startDate, trip.endDate) ??
-                          '${trip.startDate} → ${trip.endDate}')
-                      : '${trip.startDate} → ${trip.endDate}')
+                  ? (tripDateRange(trip.startDate, trip.endDate) ??
+                      '${trip.startDate} → ${trip.endDate}')
                   : l10n.tripAddDates),
               onPressed: (_isOffline || !trip.canEdit) ? null : _editDates,
             ),

--- a/src/packages/flutter-app/test/trip_detail_narrow_header_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_narrow_header_test.dart
@@ -15,7 +15,9 @@ import 'package:travel_route_planner/widgets/trip_refine_panel.dart';
 import 'support/l10n_test_app.dart';
 
 /// Mobile declutter, header half: on narrow the meta row drops the Refine
-/// button (it becomes an app-bar sparkle) and the dates chip humanizes.
+/// button (it becomes an app-bar sparkle). The dates chip humanizes at BOTH
+/// widths — it read raw ISO on wide until 2026-08-14, so the two assertions
+/// below are deliberately the same string.
 class _FakeTripsApiService extends TripsApiService {
   final Trip trip;
   _FakeTripsApiService(this.trip) : super(ApiClient(baseUrl: 'http://test'));
@@ -100,11 +102,15 @@ void main() {
     expect(find.byIcon(Icons.auto_awesome), findsNothing);
   });
 
-  testWidgets('wide keeps the header button and raw ISO dates; no sparkle',
+  testWidgets('wide keeps the header button; dates humanize there too',
       (tester) async {
     await _pump(tester, _trip(), surface: const Size(1200, 900));
     expect(find.text('Refine with AI'), findsOneWidget);
-    expect(find.text('2026-09-01 → 2026-09-03'), findsOneWidget);
+    // Same string as narrow: the chip's format is a property of the trip, not
+    // of the viewport. Wide showed the raw ISO pair until 2026-08-14 purely
+    // because only narrow was ever fixed.
+    expect(find.text('Sep 1 – Sep 3'), findsOneWidget);
+    expect(find.text('2026-09-01 → 2026-09-03'), findsNothing);
     expect(find.byTooltip('Refine with AI'), findsNothing);
   });
 


### PR DESCRIPTION
## Summary

- The same trip's header date chip rendered **`2026-07-21 → 2026-07-22` on desktop** and **`Jul 21 – Jul 22` on a phone**. Found while sweeping trip detail after #409.
- Not a regression: narrow was humanized in the mobile-declutter pass (`f548441`, Jul 22) because the raw ISO pair is ~200px and forced the meta row to wrap. Wide just kept the machine form it had carried since the original trip UI (`b407847`, May 27). Width isn't a reason to show a different date format — and the layout with *more* room was the one showing the denser string.
- Drops the `_narrow` branch so both widths call `tripDateRange(...)`. `_narrow` still governs the Refine button's placement, so nothing is orphaned.
- **Also fixes Spanish on wide**: `tripDateRange` goes through the app locale, which the raw interpolation never did, so the chip now reads `21 jul – 22 jul` instead of an ISO pair.
- The ISO pair survives as the unparseable-date fallback — `tripDateRange` returns null there, and echoing back what's stored beats an empty chip on a trip whose dates are the thing you came to fix.

## Testing

- `flutter analyze` — clean (only the 3 pre-existing infos in the untouched `route_response.dart`).
- `flutter test` — **1237 passing**. `trip_detail_narrow_header_test.dart`'s wide case pinned the old behavior by name (`'wide keeps the header button and raw ISO dates'`); it now asserts the humanized string *and* that the ISO pair is absent, so the two width cases deliberately expect the same text. The other two tests matching an ISO pair are the stay-sheet prefill, not this chip — untouched and still green.
- Browser-verified at 1440px in both locales: `Jul 21 – Jul 22` / `21 jul – 22 jul`, with `Refine with AI` still sitting correctly beside the now-narrower chip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)