### PR TITLE
fix(next-step): move "Plan your days" to the rung that walks the days, and raise the progress sheet

### DIFF
--- a/specs/next-step-cta/plan.md
+++ b/specs/next-step-cta/plan.md
@@ -196,3 +196,71 @@ Four defects the first cut of the walk shipped with, all now fixed and pinned:
   `transportHandsOff` from the same lookup the tap performs, and `_setRowMode`
   invalidates the review (the sync's `_sameTodoState` gate compares only
   key+booked, so a mode-only edit never re-read it).
+
+### "Plan your days" told the truth about the wrong rung (2026-08-14)
+
+Dogfooding a 37-day, 10-destination trip, Brian opened the progress sheet and
+found "Plan your days" checked on a trip with no activities at all. The rung's
+test is `len(items) > 0 && at least one item has a day` — an *any*, not an
+*all* — and the ten rows satisfying it were **city fillers**, the placeholders
+`create_itinerary` emits for a day with no specific activity, which the app
+HIDES (`isCityFiller`, trip_detail_derivation.dart). The server was checking a
+rung off against places the traveler could not see.
+
+**Rename over re-predicate.** The alternative — make rung 2 demand real
+activities — was rejected: it would have dropped an actively-booking traveler
+back to step 2 and held eleven flights hostage to day planning, which is not
+the order anyone books a trip in. So the *label* moved to the rung whose test
+it actually describes:
+
+| rung | was | now |
+|---|---|---|
+| 2 (`itinerary`) | Plan your days | **Add your destinations** |
+| 4 (`schedule`) | Tidy up your schedule | **Plan your days** |
+
+Ids did not move — they are identity, the labels are copy — so the wire, the
+client's ValueKeys and every test key are unchanged. `review.ladder.days`
+carries the exact strings rung 2 gave up, in both languages, so no wording is
+new. Rung 4's *step* title stays "Tidy up your schedule" when loose places
+drive it and becomes "Plan your days" when an empty day does; the sheet
+suppresses a step title identical to its rung label rather than printing it
+twice.
+
+**What made the rename safe was fixing rung 4 underneath it.** Renaming alone
+would have handed the promise to a rung that could not keep it:
+
+- `emptyDayRuns` counted ANY item, fillers included — so the rows that lied to
+  rung 2 would have lied to rung 4 too. `isCityFiller` is now ported to Go,
+  with a documented divergence (no address-regex fallback) and twin fixture
+  tables in `city_filler_test.go` ↔ `test/trip_detail_derivation_test.dart`,
+  per docs/zen.md's rule for a second implementation.
+- It also scanned only first-to-last scheduled day, so ONE dated item collapsed
+  the window to a point and declared the trip scheduled — the same bug one
+  activity later. The window is now the whole trip.
+- …minus the departure day. Extending to the literal span put "Day 2 has
+  nothing planned" on a one-night trip whose traveler flies home that morning
+  (`TestReviewTrip_CleanTripNoFindings` caught it). Plannable days = the trip's
+  nights, the unit the rest of the app already measures a stay in.
+- Travel days count as planned when a real (non-auto, non-dismissed) segment
+  lands on them. Without this the rung would have traded one lie for another,
+  calling the day you fly to Kraków empty. Booking *to-dos* deliberately do not
+  count: intending to book is not a plan for the day.
+
+`walkDayCoverage` is the single pass all of this lives in — Trip Health's
+empty-day findings, rung 4's test and rung 4's tally read the same value, so
+they cannot disagree. That earns the schedule rung a `progress` tally on the
+same terms the bookings rung has one: an exact denominator, and a Done counted
+by the very test that satisfies the rung. On Brian's trip it reads **0 of 36**,
+which is the number that was missing — a rung sitting quietly at "later" says
+nothing about how much of it is undone.
+
+**Blast radius, accepted:** every dated trip with unplanned days now gains one
+`info` health finding and stalls at rung 4, so "Book everything", "Start your
+packing list" and the all-set celebration are harder to reach. That is the
+honest ladder; the tally is what keeps it from feeling stuck.
+
+**Sheet placement (same PR).** The sheet sized to its content, so six short
+rows anchored to the bottom ~46% of a tall window and read as a footer. It now
+carries a `minHeight` floor of 62% of the window under the existing 80% cap —
+the only Tier-A sheet with a floor, because it is the only one whose content
+has a fixed, short length.

--- a/specs/next-step-cta/plan.md
+++ b/specs/next-step-cta/plan.md
@@ -259,6 +259,19 @@ nothing about how much of it is undone.
 packing list" and the all-set celebration are harder to reach. That is the
 honest ladder; the tally is what keeps it from feeling stuck.
 
+**Count vs tally (Brian, same day, after first review).** The destinations rung
+was going to ship with no number — the tally rule says "exact denominator or
+nothing", and destinations have none. Brian asked for the badge back, which is
+the right call for a different reason: the number he wants is not progress, it
+is *how big is this trip*. So `PlanPhase` grows a second, separate field,
+`count`, and a rung carries at most one of the two. Keeping them apart is the
+whole point — a count squeezed into `progress` renders "10 of 10", which claims
+the rung is finished. The number is `countDestinations`: the trip's rendered
+legs with a hub, so it equals the map chips and the itinerary headers rather
+than being a third opinion about what a destination is (hubless "Other places"
+runs excluded, a revisited city counted once per visit, absent — not zero — on
+a trip with no places).
+
 **Sheet placement (same PR).** The sheet sized to its content, so six short
 rows anchored to the bottom ~46% of a tall window and read as a footer. It now
 carries a `minHeight` floor of 62% of the window under the existing 80% cap —

--- a/specs/next-step-cta/spec.md
+++ b/specs/next-step-cta/spec.md
@@ -42,7 +42,14 @@ straight to the right control.
       primary action.
 - [ ] The step is the FIRST unmet phase of this fixed ladder, in order:
       1. **Set dates** — trip has no start/end dates.
-      2. **Plan itinerary** — trip has no places, or none is assigned to a day.
+      2. **Add your destinations** — trip has no places, or none is assigned to
+         a day. The test is deliberately weak (one dated place clears it), so
+         the rung is NAMED for it. It used to be labelled "Plan your days",
+         which promised a filled calendar and then checked itself off against
+         ten bare city pins over 37 empty days (Brian, 2026-08-14). A rung's
+         label is a promise about its test. City-filler rows — the placeholders
+         the app hides, whose name is just their city — count here, because a
+         filler is still a destination pin.
       3. **Book travel & stays, in itinerary order** — walks the synced
          booking checklist (outbound leg → stay → next leg → … → return leg,
          the order the trip is actually travelled) and names the first OPEN
@@ -53,7 +60,16 @@ straight to the right control.
          agent-created, never opened in the app — fall back to the lodging-
          then-transport health findings. A satisfied walk never falls back: a
          checked slot with no matching row means booked elsewhere.
-      4. **Tidy schedule** — places with no day, or empty days mid-trip.
+      4. **Plan your days** — places with no day, or days with nothing planned.
+         One walk defines "a planned day", and Trip Health's empty-day findings
+         read the same one: a day counts planned when it carries a non-filler
+         itinerary item OR a real transport segment (travel days are planned
+         days — otherwise the rung calls the day you fly to Kraków empty). The
+         window is the WHOLE trip minus its departure day — its nights — not
+         the first-to-last scheduled day, which let one dated item declare a
+         37-day trip scheduled and hid every day past the last one. The step
+         is titled "Tidy up your schedule" when loose places drive it and
+         "Plan your days" when an empty day does.
       5. **Book everything** — any unbooked stay/segment/booking to-do remains.
       6. **Start packing** — packing checklist is empty (only before the trip
          starts).
@@ -65,15 +81,17 @@ straight to the right control.
       since prefix progress cannot speak for phases past the current one. A
       payload with no ladder (older server, cached response) simply renders the
       plain eyebrow.
-- [ ] The **bookings rung carries its own tally** ("4 of 11"): a many-city trip
-      closes eleven booking slots under one rung, so the ladder's "3 of 6"
-      cannot move for weeks and the rung's sub-progress is the only honest
-      signal of movement. Its units are the derived booking slots and a slot
-      counts done whichever way the walk closes it — checked off, or covered by
-      a real accommodation/segment — so the tally and the rung's completion
-      can never disagree. Rungs without an exact denominator (unscheduled
-      places, the book_trip aggregate) show no tally rather than a made-up one,
-      and a trip with no derived slots shows none at all.
+- [ ] **Rungs with an exact denominator carry their own tally** ("4 of 11",
+      "0 of 36"): a many-city trip closes eleven booking slots and fills
+      thirty-six days under two rungs, so the ladder's "3 of 6" cannot move for
+      weeks and the sub-progress is the only honest signal of movement — and on
+      the days rung it is what makes "nothing planned yet" visible while the
+      rung is still ahead. Each tally's Done is counted by the very test that
+      decides its rung is satisfied — a booking slot closed either way the walk
+      closes it, a day planned either way the day walk fills it — so a tally
+      and its rung can never disagree. Rungs without an exact denominator
+      (destinations, the book_trip aggregate) show no tally rather than a
+      made-up one; a trip with no derived slots and an undated trip show none.
 - [ ] The card's secondary entry names its destination — "Trip health", the
       title of the sheet it opens — rather than "View all", which beside a step
       counter promised the steps and delivered the findings list.
@@ -119,12 +137,14 @@ straight to the right control.
   `seed_prompt` for chat-driven steps. `plan_progress` — `done`/`total` phases
   (total is 6) plus `phases[]`, the ladder itself: `{id, label}` per rung, in
   order, ids stable across rewordings and locales (`dates`, `itinerary`,
-  `bookings`, `schedule`, `confirm`, `packing`), labels localized. No per-rung
-  DONE state ships: `done` already defines it (index < done complete, == done
-  current, > done later), so the client derives it in one place. A rung MAY
-  carry `progress: {done, total}` — its internal tally, present only where the
-  denominator is exact (today: the bookings rung's derived slots, absent when
-  the trip has none). Both omitted for past trips. The step is identical
+  `bookings`, `schedule`, `confirm`, `packing` — the ids did NOT move when
+  rungs 2 and 4 were renamed; ids are identity, labels are copy), labels
+  localized. No per-rung DONE state ships: `done` already defines it (index <
+  done complete, == done current, > done later), so the client derives it in one
+  place. A rung MAY carry `progress: {done, total}` — its internal tally,
+  present only where the denominator is exact: the bookings rung's derived slots
+  (absent when the trip has none) and the schedule rung's plannable days (absent
+  when the trip is undated). Both omitted for past trips. The step is identical
   whether or not `check_hours` is requested.
 - **Errors:** unchanged (404 for viewers/missing trips).
 

--- a/specs/next-step-cta/spec.md
+++ b/specs/next-step-cta/spec.md
@@ -89,9 +89,18 @@ straight to the right control.
       rung is still ahead. Each tally's Done is counted by the very test that
       decides its rung is satisfied — a booking slot closed either way the walk
       closes it, a day planned either way the day walk fills it — so a tally
-      and its rung can never disagree. Rungs without an exact denominator
-      (destinations, the book_trip aggregate) show no tally rather than a
-      made-up one; a trip with no derived slots and an undated trip show none.
+      and its rung can never disagree. Rungs without an exact denominator (the
+      book_trip aggregate) show no tally rather than a made-up one; a trip with
+      no derived slots and an undated trip show none.
+- [ ] **The destinations rung carries a bare count** ("10") rather than a
+      tally, because adding stops has no target to progress toward and "10 of
+      10" would claim the rung is finished instead of saying how big the trip
+      is. It is a separate wire field from the tally, so the two can never be
+      rendered as each other, and a rung carries at most one. The number is the
+      trip's rendered legs — the stops the map chips and itinerary headers
+      already show, hubless "Other places" runs excluded and a revisited city
+      counted once per visit — so the sheet and the screen agree. Absent, not
+      zero, on a trip with no places.
 - [ ] The card's secondary entry names its destination — "Trip health", the
       title of the sheet it opens — rather than "View all", which beside a step
       counter promised the steps and delivered the findings list.
@@ -141,10 +150,12 @@ straight to the right control.
   rungs 2 and 4 were renamed; ids are identity, labels are copy), labels
   localized. No per-rung DONE state ships: `done` already defines it (index <
   done complete, == done current, > done later), so the client derives it in one
-  place. A rung MAY carry `progress: {done, total}` — its internal tally,
-  present only where the denominator is exact: the bookings rung's derived slots
-  (absent when the trip has none) and the schedule rung's plannable days (absent
-  when the trip is undated). Both omitted for past trips. The step is identical
+  place. A rung MAY carry ONE trailing number, and the two kinds are separate
+  fields: `progress: {done, total}` where the denominator is exact (the bookings
+  rung's derived slots, absent when the trip has none; the schedule rung's
+  plannable days, absent when the trip is undated), or `count: N` where the work
+  has no target at all (the destinations rung's rendered legs, absent when the
+  trip has no places). Both omitted for past trips. The step is identical
   whether or not `check_hours` is requested.
 - **Errors:** unchanged (404 for viewers/missing trips).
 

--- a/src/packages/api/city_filler_test.go
+++ b/src/packages/api/city_filler_test.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"testing"
+
+	"travel-route-planner/store"
+)
+
+// TWIN of the 'isCityFiller parity with the Go server' group in
+// flutter-app/test/trip_detail_derivation_test.dart. Same cases, same
+// expectations, in the same order — docs/zen.md requires the parity contract
+// because "city filler" now has two implementations: the client's, which HIDES
+// these rows, and the server's, which must not count what the client hides.
+// Change one table, change the other.
+//
+// The `dartOnly` column is the ONE documented divergence: Dart compares the
+// name against cityOf(), which falls back to a regex over the address when the
+// city column is empty. The server has no copy of that heuristic and is not
+// growing one — see isCityFiller's comment.
+func TestIsCityFillerParity(t *testing.T) {
+	cases := []struct {
+		desc     string
+		name     string
+		city     *string
+		hub      *string // day_trip_from
+		address  *string
+		want     bool
+		dartOnly bool
+	}{
+		{desc: "name equals city", name: "Prague", city: strp("Prague"), want: true},
+		{desc: "real activity in a city", name: "Charles Bridge", city: strp("Prague"), want: false},
+		{desc: "case and space insensitive", name: "  prague ", city: strp("Prague"), want: true},
+		{desc: "name equals the day-trip hub", name: "Kyoto", hub: strp("Kyoto"), city: strp("Nara"), want: true},
+		{desc: "hub set, name is a real place", name: "Fushimi Inari", hub: strp("Kyoto"), city: strp("Nara"), want: false},
+		{desc: "no city and no hub", name: "Prague", want: false},
+		{desc: "empty name is never a filler", name: "   ", city: strp("Prague"), want: false},
+		{desc: "city empty, name matches the address city", name: "Prague",
+			city: strp(""), address: strp("Old Town, Prague, Czechia"), want: false, dartOnly: true},
+	}
+
+	for _, c := range cases {
+		t.Run(c.desc, func(t *testing.T) {
+			got := isCityFiller(store.ItineraryItem{
+				Name: c.name, City: c.city, DayTripFrom: c.hub, Address: c.address,
+			})
+			want := c.want
+			if c.dartOnly {
+				// Documented divergence: Dart says true here, Go says false.
+				want = false
+			}
+			if got != want {
+				t.Fatalf("isCityFiller(%q, city=%v, hub=%v) = %v, want %v",
+					c.name, deref(c.city), deref(c.hub), got, want)
+			}
+		})
+	}
+}
+
+func deref(s *string) string {
+	if s == nil {
+		return "<nil>"
+	}
+	return *s
+}

--- a/src/packages/api/i18n.go
+++ b/src/packages/api/i18n.go
@@ -267,11 +267,16 @@ var messages = map[string]map[string]string{
 	"review.fix.setDates":         {"en": "Set dates", "es": "Añadir fechas"},
 	"review.itemBeyondSpan":       {"en": "%q is on day %d, past the trip's %d-day span.", "es": "%q está en el día %d, más allá de la duración de %d días del viaje."},
 	// review.ladder.* — rung labels for the plan-progress sheet, needed only by
-	// the rungs with no step title of their own. Phase 3 covers lodging AND
-	// transport, so neither review.next.addLodging/addTransport title names it;
-	// every other rung reuses its step title (see planLadder).
+	// the rungs whose step title cannot serve as a label. Phase 3 covers lodging
+	// AND transport, so neither review.next.addLodging/addTransport title names
+	// it; phase 4 covers loose places AND empty days, and only the second is
+	// what the rung promises. The rest reuse their step title (see planLadder).
 	"review.ladder.bookings": {"en": "Book travel & stays", "es": "Reserva transporte y alojamiento"},
-	"review.mayBeClosed":     {"en": "%s may be closed on %s (Day %d).", "es": "%s puede estar cerrado el %s (día %d)."},
+	// The exact strings review.next.planItinerary.title used to carry: the name
+	// moved to the rung that actually walks the days, so no wording — and no
+	// translation — is new here.
+	"review.ladder.days": {"en": "Plan your days", "es": "Planifica tus días"},
+	"review.mayBeClosed": {"en": "%s may be closed on %s (Day %d).", "es": "%s puede estar cerrado el %s (día %d)."},
 	// review.next.* — the Next Step CTA ladder (trip_next_step.go). Titles are
 	// short imperatives; details are one supporting line. The booking-slot walk
 	// (phase 3) builds its own bookStay/bookTransport copy from the slot; the
@@ -295,26 +300,30 @@ var messages = map[string]map[string]string{
 	"review.next.bookTransport.genericHome": {"en": "Book transport home", "es": "Reserva el transporte de vuelta"},
 	"review.next.packing.detail":            {"en": "Your packing checklist is empty.", "es": "Tu lista de equipaje está vacía."},
 	"review.next.packing.title":             {"en": "Start your packing list", "es": "Empieza tu lista de equipaje"},
-	"review.next.planItinerary.empty":       {"en": "No places saved yet — plan your days in chat.", "es": "Aún no hay lugares guardados — planifica tus días en el chat."},
-	"review.next.planItinerary.title":       {"en": "Plan your days", "es": "Planifica tus días"},
-	"review.next.scheduleItems.title":       {"en": "Tidy up your schedule", "es": "Ordena tu agenda"},
-	"review.next.setDates.detail":           {"en": "Dates unlock lodging, transport and day-by-day checks.", "es": "Las fechas desbloquean el alojamiento, el transporte y las comprobaciones día a día."},
-	"review.next.setDates.title":            {"en": "Set your travel dates", "es": "Elige las fechas del viaje"},
-	"review.noDates":                        {"en": "Add trip dates to unlock day-by-day checks.", "es": "Añade las fechas del viaje para desbloquear las comprobaciones día a día."},
-	"review.noLodging":                      {"en": "No lodging booked for the night of %s.", "es": "No hay alojamiento reservado para la noche del %s."},
-	"review.noLodgingRange":                 {"en": "No lodging booked for the nights of %s – %s (%d nights).", "es": "No hay alojamiento reservado para las noches del %s al %s (%d noches)."},
-	"review.noTransport":                    {"en": "No transport booked from %s to %s.", "es": "No hay transporte reservado de %s a %s."},
-	"review.overBudget":                     {"en": "Over budget by %.2f %s.", "es": "Te has pasado del presupuesto por %.2f %s."},
-	"review.packedDay":                      {"en": "Day %d has %d items planned — that may be too packed.", "es": "El día %d tiene %d actividades planificadas — puede que sea demasiado."},
-	"review.rainLikely":                     {"en": "Rain likely on Day %d (%s) — pack an umbrella.", "es": "Es probable que llueva el día %d (%s) — lleva paraguas."},
-	"review.timeOfDayCollision":             {"en": "Day %d has %d things scheduled for the %s.", "es": "El día %d tiene %d cosas programadas para %s."},
-	"review.tod.afternoon":                  {"en": "afternoon", "es": "la tarde"},
-	"review.tod.evening":                    {"en": "evening", "es": "la noche"},
-	"review.tod.morning":                    {"en": "morning", "es": "la mañana"},
-	"review.unscheduledMany":                {"en": "%d items have no day assigned — schedule them to see them on the day plan.", "es": "%d actividades no tienen día asignado — prográmalas para verlas en el plan diario."},
-	"review.unscheduledOne":                 {"en": "1 item has no day assigned — schedule it to see it on the day plan.", "es": "1 actividad no tiene día asignado — prográmala para verla en el plan diario."},
-	"review.veryCold":                       {"en": "Day %d (%s) could be very cold (%.0f°C) — pack warm layers.", "es": "El día %d (%s) puede hacer mucho frío (%.0f °C) — lleva ropa de abrigo."},
-	"review.veryHot":                        {"en": "Day %d (%s) could be very hot (%.0f°C) — plan for the heat.", "es": "El día %d (%s) puede hacer mucho calor (%.0f °C) — prepárate para el calor."},
+	"review.next.planItinerary.empty":       {"en": "No places saved yet — add your destinations in chat.", "es": "Aún no hay lugares guardados — añade tus destinos en el chat."},
+	// Rung 2's test is "some place is on some day", so its title says exactly
+	// that much. It used to say "Plan your days", which promised a filled
+	// calendar and checked itself off against ten bare city pins.
+	"review.next.planItinerary.title":   {"en": "Add your destinations", "es": "Añade tus destinos"},
+	"review.next.planItinerary.undated": {"en": "Put your places on the calendar", "es": "Pon tus lugares en el calendario"},
+	"review.next.scheduleItems.title":   {"en": "Tidy up your schedule", "es": "Ordena tu agenda"},
+	"review.next.setDates.detail":       {"en": "Dates unlock lodging, transport and day-by-day checks.", "es": "Las fechas desbloquean el alojamiento, el transporte y las comprobaciones día a día."},
+	"review.next.setDates.title":        {"en": "Set your travel dates", "es": "Elige las fechas del viaje"},
+	"review.noDates":                    {"en": "Add trip dates to unlock day-by-day checks.", "es": "Añade las fechas del viaje para desbloquear las comprobaciones día a día."},
+	"review.noLodging":                  {"en": "No lodging booked for the night of %s.", "es": "No hay alojamiento reservado para la noche del %s."},
+	"review.noLodgingRange":             {"en": "No lodging booked for the nights of %s – %s (%d nights).", "es": "No hay alojamiento reservado para las noches del %s al %s (%d noches)."},
+	"review.noTransport":                {"en": "No transport booked from %s to %s.", "es": "No hay transporte reservado de %s a %s."},
+	"review.overBudget":                 {"en": "Over budget by %.2f %s.", "es": "Te has pasado del presupuesto por %.2f %s."},
+	"review.packedDay":                  {"en": "Day %d has %d items planned — that may be too packed.", "es": "El día %d tiene %d actividades planificadas — puede que sea demasiado."},
+	"review.rainLikely":                 {"en": "Rain likely on Day %d (%s) — pack an umbrella.", "es": "Es probable que llueva el día %d (%s) — lleva paraguas."},
+	"review.timeOfDayCollision":         {"en": "Day %d has %d things scheduled for the %s.", "es": "El día %d tiene %d cosas programadas para %s."},
+	"review.tod.afternoon":              {"en": "afternoon", "es": "la tarde"},
+	"review.tod.evening":                {"en": "evening", "es": "la noche"},
+	"review.tod.morning":                {"en": "morning", "es": "la mañana"},
+	"review.unscheduledMany":            {"en": "%d items have no day assigned — schedule them to see them on the day plan.", "es": "%d actividades no tienen día asignado — prográmalas para verlas en el plan diario."},
+	"review.unscheduledOne":             {"en": "1 item has no day assigned — schedule it to see it on the day plan.", "es": "1 actividad no tiene día asignado — prográmala para verla en el plan diario."},
+	"review.veryCold":                   {"en": "Day %d (%s) could be very cold (%.0f°C) — pack warm layers.", "es": "El día %d (%s) puede hacer mucho frío (%.0f °C) — lleva ropa de abrigo."},
+	"review.veryHot":                    {"en": "Day %d (%s) could be very hot (%.0f°C) — plan for the heat.", "es": "El día %d (%s) puede hacer mucho calor (%.0f °C) — prepárate para el calor."},
 
 	"share.aTraveler":              {"en": "a traveler", "es": "un viajero"},
 	"share.dateWithYear":           {"en": "%s, %d", "es": "%s de %d"},

--- a/src/packages/api/trip_next_step.go
+++ b/src/packages/api/trip_next_step.go
@@ -78,37 +78,50 @@ type PlanPhase struct {
 }
 
 // PhaseProgress is a rung's INTERNAL progress — the units of work inside one
-// ladder phase, not the ladder itself. Only the bookings rung reports one
-// today: its units are the derived booking slots, so the denominator is exact
-// and Done counts a slot closed EITHER WAY the walk closes it (checked off, or
-// claimed by a real accommodation/segment) — the same test that decides the
-// phase is satisfied, so the tally and the rung's completion cannot disagree.
+// ladder phase, not the ladder itself. Two rungs report one, and both earn it
+// the same way: an exact denominator, and a Done counted by the very test that
+// decides the phase is satisfied, so a tally can never disagree with its rung.
+//   - bookings: the derived booking slots; Done counts a slot closed EITHER WAY
+//     the walk closes it (checked off, or claimed by a real
+//     accommodation/segment). Absent when the trip has no derived slots.
+//   - schedule: the trip's days; Done counts the days walkDayCoverage calls
+//     planned. Absent when the trip is undated — no span, no honest total.
+//
 // The other rungs deliberately stay nil: "3 unscheduled places" and the
 // book_trip aggregate have no honest total (specs/next-step-cta puts the
 // aggregate's parity out of scope), and a made-up denominator is worse than
-// none. Absent whenever the trip has no derived slots at all.
+// none. Destinations have no denominator either — the rung above counts places
+// the traveler chooses to add, and there is no number they are counting toward.
 type PhaseProgress struct {
 	Done  int `json:"done"`
 	Total int `json:"total"`
 }
 
-// planPhaseBookings is the rung the booking-slot walk tallies — named so the
-// ladder table above and the tally below refer to the same rung explicitly,
-// rather than agreeing on a bare string in two places.
-const planPhaseBookings = "bookings"
+// planPhaseBookings / planPhaseSchedule are the rungs the two walks tally —
+// named so the ladder table above and the tallies below refer to the same rung
+// explicitly, rather than agreeing on a bare string in two places.
+const (
+	planPhaseBookings = "bookings"
+	planPhaseSchedule = "schedule"
+)
 
 // planLadder IS the ladder, in order — the phase ids paired with the catalog
-// key for each rung's short label. Five of the six reuse the step titles the
-// card already shows, so the progress sheet and the card speak in one voice
-// (the same reuse staySlotStep makes of review.noLodging); only phase 3 needs
-// its own copy, because it covers lodging AND transport and neither step title
-// names the pair. Adding or reordering a rung here changes the wire, the
-// count, and the sheet together.
+// key for each rung's short label. Most reuse the step titles the card already
+// shows, so the progress sheet and the card speak in one voice (the same reuse
+// staySlotStep makes of review.noLodging); the review.ladder.* rungs are the
+// ones whose step title cannot serve as a label. Adding or reordering a rung
+// here changes the wire, the count, and the sheet together.
+//
+// A rung's label is a PROMISE about its test. "Plan your days" sat on rung 2,
+// whose test is only "some place is on some day" — so a 37-day trip with ten
+// city pins and nothing to do checked it off (Brian, 2026-08-14). The name
+// moved down to the rung that actually walks the days; rung 2 now says what it
+// checks.
 var planLadder = [...]struct{ ID, Key string }{
 	{"dates", "review.next.setDates.title"},
 	{"itinerary", "review.next.planItinerary.title"},
 	{planPhaseBookings, "review.ladder.bookings"},
-	{"schedule", "review.next.scheduleItems.title"},
+	{planPhaseSchedule, "review.ladder.days"},
 	{"confirm", "review.next.book.title"},
 	{"packing", "review.next.packing.title"},
 }
@@ -117,16 +130,20 @@ var planLadder = [...]struct{ ID, Key string }{
 // the single source of the total the phases below already imply.
 const planLadderTotal = len(planLadder)
 
-// planLadderPhases renders the ladder for one locale, hanging the booking
-// walk's tally on the rung that owns it. The walk is passed in rather than
-// re-run here: it is the same single pass phase 3 decides on, so the sheet's
-// "4 of 11" and the card's step can never come from different counts.
-func planLadderPhases(locale string, slots bookingWalk) []PlanPhase {
+// planLadderPhases renders the ladder for one locale, hanging each walk's tally
+// on the rung that owns it. Both walks are passed in rather than re-run here:
+// they are the same single passes phases 3 and 4 decide on, so the sheet's
+// "4 of 11" and "12 of 37" can never come from different counts than the card's
+// step.
+func planLadderPhases(locale string, slots bookingWalk, days dayCoverage) []PlanPhase {
 	phases := make([]PlanPhase, 0, len(planLadder))
 	for _, p := range planLadder {
 		phase := PlanPhase{ID: p.ID, Label: tr(locale, p.Key)}
-		if p.ID == planPhaseBookings && slots.Total > 0 {
+		switch {
+		case p.ID == planPhaseBookings && slots.Total > 0:
 			phase.Progress = &PhaseProgress{Done: slots.Closed, Total: slots.Total}
+		case p.ID == planPhaseSchedule && days.Total > 0:
+			phase.Progress = &PhaseProgress{Done: days.Planned, Total: days.Total}
 		}
 		phases = append(phases, phase)
 	}
@@ -144,17 +161,19 @@ func deriveNextStep(locale string, now time.Time, data exportData, findings []Fi
 		return nil, nil
 	}
 
-	// One pass over the booking checklist, up front: phase 3 picks its step
-	// from it below, and EVERY phase's payload carries its tally — a trip
-	// stopped at "set your dates" still gets to see how much of the booking
-	// rung is already done.
+	// One pass each over the booking checklist and the trip's days, up front:
+	// phases 3 and 4 pick their steps from them below, and EVERY phase's
+	// payload carries both tallies — a trip stopped at "set your dates" still
+	// gets to see how much of the booking and day-planning rungs is already
+	// done.
 	slots := walkBookingSlots(data)
+	days := walkDayCoverage(data)
 
 	progress := func(done int) *PlanProgress {
 		return &PlanProgress{
 			Done:   done,
 			Total:  planLadderTotal,
-			Phases: planLadderPhases(locale, slots),
+			Phases: planLadderPhases(locale, slots, days),
 		}
 	}
 
@@ -170,10 +189,15 @@ func deriveNextStep(locale string, now time.Time, data exportData, findings []Fi
 		}, progress(0)
 	}
 
-	// Phase 2 — an itinerary that exists and is scheduled. The none-scheduled
-	// variant is folded in here (not phase 5): with zero scheduled days the
-	// hub/night walks below would run on air and their prefills would be
-	// meaningless.
+	// Phase 2 — destinations that exist and sit on the calendar. The
+	// none-scheduled variant is folded in here (not phase 5): with zero
+	// scheduled days the hub/night walks below would run on air and their
+	// prefills would be meaningless.
+	//
+	// The test is deliberately weak — one dated place clears it — and the rung
+	// is named for exactly that: adding destinations. City-filler rows count
+	// here, because a filler IS a destination pin even though the app hides its
+	// tile. Whether those days have anything TO DO is phase 4's question.
 	if len(data.Items) == 0 {
 		return &NextStep{
 			Kind:       "plan_itinerary",
@@ -185,8 +209,11 @@ func deriveNextStep(locale string, now time.Time, data exportData, findings []Fi
 	if unscheduled := countUnscheduled(data.Items); unscheduled == len(data.Items) {
 		count := unscheduled
 		return &NextStep{
-			Kind:       "plan_itinerary",
-			Title:      tr(locale, "review.next.planItinerary.title"),
+			Kind: "plan_itinerary",
+			// Its own title: the places are already added, so "Add your
+			// destinations" over "3 items have no day assigned" would name a
+			// job that is done and ask for one it doesn't describe.
+			Title:      tr(locale, "review.next.planItinerary.undated"),
 			Detail:     unscheduledMessage(locale, count),
 			Count:      &count,
 			SeedPrompt: seedPlanItineraryUnscheduled(data, count),
@@ -257,20 +284,24 @@ func deriveNextStep(locale string, now time.Time, data exportData, findings []Fi
 		}
 	}
 
-	// Phase 4 — schedule cleanup: leftover unscheduled places and empty days.
-	// Read via the shared helpers, not by sniffing findings — empty-day
-	// findings share category "packing" with the over-packed warnings and
-	// carry no distinguishing field.
+	// Phase 4 — the days themselves: leftover unscheduled places, and days with
+	// nothing planned. Read via the shared walk, not by sniffing findings —
+	// empty-day findings share category "packing" with the over-packed warnings
+	// and carry no distinguishing field.
 	unscheduled := countUnscheduled(data.Items)
-	emptyRuns := emptyDayRuns(data.Items)
+	emptyRuns := days.Empty
 	if unscheduled > 0 || len(emptyRuns) > 0 {
 		step := &NextStep{
-			Kind:       "schedule_items",
-			Title:      tr(locale, "review.next.scheduleItems.title"),
+			Kind: "schedule_items",
+			// Two jobs live on this rung, so the title names the one the
+			// traveler is actually being handed. Loose places are tidying; a
+			// day with nothing on it is the rung's own name.
+			Title:      tr(locale, "review.ladder.days"),
 			SeedPrompt: seedScheduleItems(data, unscheduled, emptyRuns),
 		}
 		switch {
 		case unscheduled > 0:
+			step.Title = tr(locale, "review.next.scheduleItems.title")
 			step.Detail = unscheduledMessage(locale, unscheduled)
 			step.Count = &unscheduled
 		case emptyRuns[0].first == emptyRuns[0].last:

--- a/src/packages/api/trip_next_step.go
+++ b/src/packages/api/trip_next_step.go
@@ -67,14 +67,21 @@ type PlanProgress struct {
 	Phases []PlanPhase `json:"phases,omitempty"`
 }
 
-// PlanPhase is one rung: a stable id, its localized short label, and — where
-// the rung has an exact denominator — its own internal tally. The id is the
-// identity clients and tests key on (locale-independent, unchanged when the
-// copy is reworded); the label is display copy and nothing else.
+// PlanPhase is one rung: a stable id, its localized short label, and at most
+// one trailing number. The id is the identity clients and tests key on
+// (locale-independent, unchanged when the copy is reworded); the label is
+// display copy and nothing else.
+//
+// Progress and Count are DIFFERENT claims and a rung carries at most one.
+// Progress is "how far through this rung are you" and needs an exact
+// denominator. Count is "how many of these do you have" — a rung whose work has
+// no target at all, where a denominator would have to be invented. Keeping them
+// as separate fields is what stops a count from being rendered as "10 of 10".
 type PlanPhase struct {
 	ID       string         `json:"id"`
 	Label    string         `json:"label"`
 	Progress *PhaseProgress `json:"progress,omitempty"`
+	Count    *int           `json:"count,omitempty"`
 }
 
 // PhaseProgress is a rung's INTERNAL progress — the units of work inside one
@@ -97,12 +104,14 @@ type PhaseProgress struct {
 	Total int `json:"total"`
 }
 
-// planPhaseBookings / planPhaseSchedule are the rungs the two walks tally —
-// named so the ladder table above and the tallies below refer to the same rung
-// explicitly, rather than agreeing on a bare string in two places.
+// planPhaseItinerary / planPhaseBookings / planPhaseSchedule are the rungs that
+// carry a trailing number — named so the ladder table above and the numbers
+// below refer to the same rung explicitly, rather than agreeing on a bare
+// string in two places.
 const (
-	planPhaseBookings = "bookings"
-	planPhaseSchedule = "schedule"
+	planPhaseItinerary = "itinerary"
+	planPhaseBookings  = "bookings"
+	planPhaseSchedule  = "schedule"
 )
 
 // planLadder IS the ladder, in order — the phase ids paired with the catalog
@@ -119,7 +128,7 @@ const (
 // checks.
 var planLadder = [...]struct{ ID, Key string }{
 	{"dates", "review.next.setDates.title"},
-	{"itinerary", "review.next.planItinerary.title"},
+	{planPhaseItinerary, "review.next.planItinerary.title"},
 	{planPhaseBookings, "review.ladder.bookings"},
 	{planPhaseSchedule, "review.ladder.days"},
 	{"confirm", "review.next.book.title"},
@@ -130,16 +139,35 @@ var planLadder = [...]struct{ ID, Key string }{
 // the single source of the total the phases below already imply.
 const planLadderTotal = len(planLadder)
 
-// planLadderPhases renders the ladder for one locale, hanging each walk's tally
-// on the rung that owns it. Both walks are passed in rather than re-run here:
-// they are the same single passes phases 3 and 4 decide on, so the sheet's
-// "4 of 11" and "12 of 37" can never come from different counts than the card's
-// step.
-func planLadderPhases(locale string, slots bookingWalk, days dayCoverage) []PlanPhase {
+// countDestinations counts the trip's rendered city legs — the stops the map
+// chips and the itinerary headers show — so the number beside "Add your
+// destinations" is the number already on screen rather than a second opinion
+// about what a destination is. Hubless runs ("Other places") never count: the
+// same reason namesAPlace rejects that label, it is a grouping placeholder, not
+// somewhere anyone goes. A revisited city counts once per visit, because that
+// is how the trip renders it.
+func countDestinations(d exportData) int {
+	n := 0
+	for _, leg := range computeTripLegs(d.Trip, d.Items, d.Accommodations) {
+		if leg.Hub != nil {
+			n++
+		}
+	}
+	return n
+}
+
+// planLadderPhases renders the ladder for one locale, hanging each walk's
+// number on the rung that owns it. The walks are passed in rather than re-run
+// here: they are the same single passes phases 2–4 decide on, so the sheet's
+// "10", "4 of 11" and "12 of 37" can never come from different counts than the
+// card's step.
+func planLadderPhases(locale string, slots bookingWalk, days dayCoverage, destinations int) []PlanPhase {
 	phases := make([]PlanPhase, 0, len(planLadder))
 	for _, p := range planLadder {
 		phase := PlanPhase{ID: p.ID, Label: tr(locale, p.Key)}
 		switch {
+		case p.ID == planPhaseItinerary && destinations > 0:
+			phase.Count = ptrTo(destinations)
 		case p.ID == planPhaseBookings && slots.Total > 0:
 			phase.Progress = &PhaseProgress{Done: slots.Closed, Total: slots.Total}
 		case p.ID == planPhaseSchedule && days.Total > 0:
@@ -161,19 +189,20 @@ func deriveNextStep(locale string, now time.Time, data exportData, findings []Fi
 		return nil, nil
 	}
 
-	// One pass each over the booking checklist and the trip's days, up front:
-	// phases 3 and 4 pick their steps from them below, and EVERY phase's
-	// payload carries both tallies — a trip stopped at "set your dates" still
-	// gets to see how much of the booking and day-planning rungs is already
-	// done.
+	// One pass each over the booking checklist, the trip's days and its legs,
+	// up front: phases 3 and 4 pick their steps from the first two below, and
+	// EVERY phase's payload carries all three numbers — a trip stopped at "set
+	// your dates" still gets to see how many stops it has and how much of the
+	// booking and day-planning rungs is already done.
 	slots := walkBookingSlots(data)
 	days := walkDayCoverage(data)
+	destinations := countDestinations(data)
 
 	progress := func(done int) *PlanProgress {
 		return &PlanProgress{
 			Done:   done,
 			Total:  planLadderTotal,
-			Phases: planLadderPhases(locale, slots, days),
+			Phases: planLadderPhases(locale, slots, days, destinations),
 		}
 	}
 

--- a/src/packages/api/trip_next_step_test.go
+++ b/src/packages/api/trip_next_step_test.go
@@ -128,9 +128,10 @@ func mustLadder(t *testing.T, progress *PlanProgress) {
 		if p.Label == "" {
 			t.Fatalf("phase %d (%s) has no label", i, p.ID)
 		}
-		// Only the bookings rung has an exact denominator; every other rung
-		// stays silent rather than inventing one.
-		if p.Progress != nil && p.ID != planPhaseBookings {
+		// Only the bookings (derived slots) and schedule (plannable days) rungs
+		// have an exact denominator; every other rung stays silent rather than
+		// inventing one.
+		if p.Progress != nil && p.ID != planPhaseBookings && p.ID != planPhaseSchedule {
 			t.Fatalf("phase %s must not carry a tally: %+v", p.ID, p.Progress)
 		}
 		if p.Progress != nil && (p.Progress.Total <= 0 || p.Progress.Done > p.Progress.Total) {
@@ -143,12 +144,18 @@ func mustLadder(t *testing.T, progress *PlanProgress) {
 // bookingsTally returns the bookings rung's tally (nil when it has none).
 func bookingsTally(t *testing.T, progress *PlanProgress) *PhaseProgress {
 	t.Helper()
+	return rungTally(t, progress, planPhaseBookings)
+}
+
+// rungTally returns one rung's tally (nil when it has none).
+func rungTally(t *testing.T, progress *PlanProgress, id string) *PhaseProgress {
+	t.Helper()
 	for _, p := range progress.Phases {
-		if p.ID == planPhaseBookings {
+		if p.ID == id {
 			return p.Progress
 		}
 	}
-	t.Fatalf("no %q rung in %+v", planPhaseBookings, progress.Phases)
+	t.Fatalf("no %q rung in %+v", id, progress.Phases)
 	return nil
 }
 
@@ -426,8 +433,12 @@ func TestNextStep_WalkNeverFallsThroughToFindings(t *testing.T) {
 // no lodging.
 func TestNextStep_WalkUnslottedNightsStillSurface(t *testing.T) {
 	d := nextStepFixture(t)
-	// Stretch the trip two nights past the last slot's checkout.
+	// Stretch the trip two nights past the last slot's checkout. The stretched
+	// days need something planned on them too, or phase 4 (which now walks the
+	// whole trip) would answer before the lodging gap this test is about.
 	d.Trip.EndDate = dateVal(t, "2026-09-06")
+	d.Items = append(d.Items, store.ItineraryItem{
+		ID: uuid.New(), Name: "Presqu'île stroll", City: strp("Lyon"), Day: i32p(5), Position: 5})
 	d.BookingTodos = bookSlots(walkTodos(t),
 		"transport:ewr>>paris", "stay:paris", "transport:paris>>lyon",
 		"stay:lyon", "transport:lyon>>ewr")
@@ -712,6 +723,92 @@ func TestNextStep_ScheduleCleanup_EmptyDayAnchor(t *testing.T) {
 	if !strings.Contains(step.SeedPrompt, "day 2 is empty") {
 		t.Fatalf("empty-day seed off:\n%s", step.SeedPrompt)
 	}
+	// The rung says "Plan your days" when a day is what's missing; "Tidy up
+	// your schedule" is for loose places, and this trip has none.
+	if step.Title != "Plan your days" {
+		t.Fatalf("empty-day step title = %q", step.Title)
+	}
+}
+
+// The regression this whole change exists for (Brian, 2026-08-14): a dated
+// multi-city trip whose only itinerary rows are the AI's city fillers — the
+// tiles the app HIDES. The old ladder read "some item has a day", checked
+// "Plan your days" off, and moved on; the traveler had planned nothing.
+//
+// The rung the traveler is on must not move, though: they are booking eleven
+// flights, and holding booking guidance hostage to day planning would be a
+// worse ladder than the wrong checkmark.
+func TestNextStep_CityFillersAreNotAPlannedDay(t *testing.T) {
+	d := nextStepFixture(t)
+	// One filler per city, on the day the traveler arrives there — exactly what
+	// create_itinerary emits for a day with no specific activities.
+	d.Items = []store.ItineraryItem{
+		{ID: uuid.New(), Name: "Paris", City: strp("Paris"), Day: i32p(1), Position: 1},
+		{ID: uuid.New(), Name: "Lyon", City: strp("Lyon"), Day: i32p(3), Position: 2},
+	}
+
+	// Rung 2 still passes — a filler IS a destination pin, and the rung is
+	// named for adding those. Rung 3 (booking) is where the traveler stands.
+	open := d
+	open.Accommodations, open.Segments, open.BookingTodos = nil, nil, nil
+	step, progress := derive("en", nextStepNow, open)
+	mustStep(t, step, progress, "add_lodging", 2)
+
+	// …and the day rung reports the truth underneath it: nothing planned, out
+	// of the trip's three plannable days (4-day span minus the departure day).
+	tally := rungTally(t, progress, planPhaseSchedule)
+	if tally == nil || tally.Done != 0 || tally.Total != 3 {
+		t.Fatalf("schedule tally = %+v, want 0 of 3", tally)
+	}
+
+	// With the booking rung closed (the fixture's booked stays and segment) the
+	// ladder stops AT the day rung rather than sailing past it to "all set".
+	step, progress = derive("en", nextStepNow, d)
+	mustStep(t, step, progress, "schedule_items", 3)
+	if step.Title != "Plan your days" {
+		t.Fatalf("step title = %q, want the day rung's own name", step.Title)
+	}
+
+	// One real activity does NOT re-satisfy the rung: the old min..max window
+	// would have collapsed to that single day and declared the trip scheduled.
+	d.Items = append(d.Items, store.ItineraryItem{
+		ID: uuid.New(), Name: "Louvre", City: strp("Paris"), Day: i32p(1), Position: 3})
+	step, progress = derive("en", nextStepNow, d)
+	mustStep(t, step, progress, "schedule_items", 3)
+	if tally := rungTally(t, progress, planPhaseSchedule); tally == nil || tally.Done != 1 {
+		t.Fatalf("schedule tally = %+v, want 1 planned day", tally)
+	}
+	if step.Day == nil || *step.Day != 2 {
+		t.Fatalf("day anchor = %v, want the first day with nothing on it", step.Day)
+	}
+}
+
+// Travel days are planned days: the traveller is on a train, and a rung that
+// called that "nothing planned" would trade one lie for another.
+func TestNextStep_TravelDayCountsAsPlanned(t *testing.T) {
+	d := nextStepFixture(t)
+	d.Items = []store.ItineraryItem{
+		{ID: uuid.New(), Name: "Louvre", City: strp("Paris"), Day: i32p(1), Position: 1},
+		{ID: uuid.New(), Name: "Vieux Lyon", City: strp("Lyon"), Day: i32p(3), Position: 2},
+	}
+	// Day 2 is empty…
+	step, progress := derive("en", nextStepNow, d)
+	mustStep(t, step, progress, "schedule_items", 3)
+
+	// …until the Paris→Lyon train is a real booked segment ON it.
+	d.Segments[0].DepartDate = dateVal(t, "2026-09-02")
+	step, progress = derive("en", nextStepNow, d)
+	mustStep(t, step, progress, "all_set", planLadderTotal)
+	if tally := rungTally(t, progress, planPhaseSchedule); tally == nil ||
+		tally.Done != tally.Total {
+		t.Fatalf("schedule tally = %+v, want every plannable day planned", tally)
+	}
+
+	// An auto (itinerary-seeded draft) segment is not a booking anyone made,
+	// so it must not silently fill the day either.
+	d.Segments[0].Auto = true
+	step, progress = derive("en", nextStepNow, d)
+	mustStep(t, step, progress, "schedule_items", 3)
 }
 
 func TestNextStep_BookAggregateDedupe(t *testing.T) {
@@ -849,11 +946,15 @@ func TestNextStep_LadderPhases(t *testing.T) {
 	mustLadder(t, es)
 
 	wantIDs := []string{"dates", "itinerary", "bookings", "schedule", "confirm", "packing"}
+	// A rung's label is a promise about its TEST. Rung 2 asks only whether some
+	// place sits on some day, so it says "Add your destinations"; the "Plan your
+	// days" promise belongs to rung 4, the one that walks the days (Brian,
+	// 2026-08-14 — ten city pins over 37 empty days used to check rung 2 off).
 	wantEN := []string{
 		"Set your travel dates",
-		"Plan your days",
+		"Add your destinations",
 		"Book travel & stays",
-		"Tidy up your schedule",
+		"Plan your days",
 		"Book everything",
 		"Start your packing list",
 	}

--- a/src/packages/api/trip_next_step_test.go
+++ b/src/packages/api/trip_next_step_test.go
@@ -138,6 +138,14 @@ func mustLadder(t *testing.T, progress *PlanProgress) {
 			t.Fatalf("phase %s tally = %d/%d, want 0 <= done <= total, total > 0",
 				p.ID, p.Progress.Done, p.Progress.Total)
 		}
+		// A bare count belongs only to the rung with no denominator at all,
+		// and never alongside a tally — the sheet renders one trailing number.
+		if p.Count != nil && p.ID != planPhaseItinerary {
+			t.Fatalf("phase %s must not carry a count: %d", p.ID, *p.Count)
+		}
+		if p.Count != nil && p.Progress != nil {
+			t.Fatalf("phase %s carries both a count and a tally", p.ID)
+		}
 	}
 }
 
@@ -150,13 +158,19 @@ func bookingsTally(t *testing.T, progress *PlanProgress) *PhaseProgress {
 // rungTally returns one rung's tally (nil when it has none).
 func rungTally(t *testing.T, progress *PlanProgress, id string) *PhaseProgress {
 	t.Helper()
+	return phaseByID(t, progress, id).Progress
+}
+
+// phaseByID returns one rung of the wire ladder.
+func phaseByID(t *testing.T, progress *PlanProgress, id string) PlanPhase {
+	t.Helper()
 	for _, p := range progress.Phases {
 		if p.ID == id {
-			return p.Progress
+			return p
 		}
 	}
 	t.Fatalf("no %q rung in %+v", id, progress.Phases)
-	return nil
+	return PlanPhase{}
 }
 
 func TestNextStep_Undated(t *testing.T) {
@@ -969,6 +983,50 @@ func TestNextStep_LadderPhases(t *testing.T) {
 		if es.Phases[i].Label == en.Phases[i].Label {
 			t.Fatalf("phase %d (%s) is not translated: %q", i, wantIDs[i], es.Phases[i].Label)
 		}
+	}
+}
+
+// The destinations rung carries a bare COUNT, not a tally: adding stops has no
+// target to progress toward, and "10 of 10" would claim the rung is finished
+// rather than saying how many stops the trip has. The number is the trip's
+// rendered legs, so it matches the map chips and the itinerary headers.
+func TestNextStep_DestinationsCount(t *testing.T) {
+	d := nextStepFixture(t) // Paris → Lyon
+
+	_, progress := derive("en", nextStepNow, d)
+	phase := phaseByID(t, progress, planPhaseItinerary)
+	if phase.Count == nil || *phase.Count != 2 {
+		t.Fatalf("destinations count = %v, want 2", phase.Count)
+	}
+	if phase.Progress != nil {
+		t.Fatalf("the destinations rung has no denominator: %+v", phase.Progress)
+	}
+
+	// A revisited city counts once per VISIT — that is how the trip renders it,
+	// and the rung's number must match what is on screen.
+	d.Items = append(d.Items, store.ItineraryItem{
+		ID: uuid.New(), Name: "Musée Rodin", City: strp("Paris"), Day: i32p(4), Position: 5})
+	_, progress = derive("en", nextStepNow, d)
+	if c := phaseByID(t, progress, planPhaseItinerary).Count; c == nil || *c != 3 {
+		t.Fatalf("count after a revisit = %v, want 3 (Paris, Lyon, Paris)", c)
+	}
+
+	// "Other places" is a grouping placeholder, not somewhere anyone goes —
+	// the same reason namesAPlace rejects it.
+	d = nextStepFixture(t)
+	d.Items = append(d.Items, store.ItineraryItem{
+		ID: uuid.New(), Name: "Some idea", Day: i32p(4), Position: 5}) // no city
+	_, progress = derive("en", nextStepNow, d)
+	if c := phaseByID(t, progress, planPhaseItinerary).Count; c == nil || *c != 2 {
+		t.Fatalf("count with a hubless item = %v, want 2", c)
+	}
+
+	// No places at all: no count rather than a zero.
+	d = nextStepFixture(t)
+	d.Items = nil
+	_, progress = derive("en", nextStepNow, d)
+	if c := phaseByID(t, progress, planPhaseItinerary).Count; c != nil {
+		t.Fatalf("count on an empty trip = %d, want none", *c)
 	}
 }
 

--- a/src/packages/api/trip_review.go
+++ b/src/packages/api/trip_review.go
@@ -208,21 +208,74 @@ type dayRun struct {
 	first, last int
 }
 
-// emptyDayRuns returns the runs of consecutive empty days between the first
-// and last scheduled day, collapsed exactly the way checkDensity reports them.
-// Extracted so deriveNextStep (trip_next_step.go) reads the same runs instead
-// of sniffing empty-day findings by convention (they share category "packing"
-// with the over-packed warnings and carry no distinguishing field). Nil when
-// no item is scheduled at all.
-func emptyDayRuns(items []store.ItineraryItem) []dayRun {
-	counts := map[int]int{}
+// isCityFiller reports the AI's "city filler" placeholder — an item whose name
+// is just the city (or day-trip hub) it renders under, emitted by
+// create_itinerary for days with no specific activities.
+//
+// SECOND IMPLEMENTATION, deliberately: the Flutter app owns the first
+// (isCityFiller, lib/screens/trip_detail_derivation.dart) and HIDES these rows,
+// so a server that counts them speaks about places the traveler cannot see —
+// which is exactly how "Plan your days" came to check itself off on a trip with
+// nothing planned. docs/zen.md requires a parity contract for the second
+// implementation: twin fixture tables in city_filler_test.go and
+// test/trip_detail_derivation_test.dart, each naming the other.
+//
+// One DOCUMENTED divergence, pinned in both tables: the Dart predicate compares
+// against cityOf(), which falls back to a regex over the item's address when
+// the city column is empty. The server has no copy of that heuristic and is not
+// growing one — a second regex would drift. AI-emitted fillers always set city,
+// so the divergence only reaches hand-made rows with an empty city column,
+// where the server is merely less aggressive about hiding.
+func isCityFiller(it store.ItineraryItem) bool {
+	name := strings.ToLower(strings.TrimSpace(it.Name))
+	if name == "" {
+		return false
+	}
+	eq := func(s *string) bool {
+		return s != nil && strings.ToLower(strings.TrimSpace(*s)) == name
+	}
+	return eq(it.City) || eq(it.DayTripFrom)
+}
+
+// dayCoverage is the trip's day-by-day planning state, in ONE pass: which days
+// carry real content, the runs that do not, and the exact denominator the
+// ladder's "Plan your days" rung reports. Trip Health's empty-day findings, the
+// ladder's rung-4 test and that rung's tally all read this one value, so they
+// cannot disagree — the doctrine walkBookingSlots already follows for rung 3.
+type dayCoverage struct {
+	Planned int      // days inside Total carrying real content
+	Total   int      // PLANNABLE days (see walkDayCoverage); 0 when undated
+	Empty   []dayRun // runs of consecutive days with nothing planned
+}
+
+// walkDayCoverage decides what "a planned day" means, once.
+//
+// A day counts as planned when it carries at least one non-filler itinerary
+// item, OR a real transport segment departing/arriving on it: travel days ARE
+// planned days, and without that an eleven-flight trip would trade one lie
+// ("Plan your days" checked with nothing planned) for another ("Day 5 has
+// nothing planned" on the day you fly to Kraków). Booking TO-DOS deliberately
+// do not count — intending to book transport is not yet a plan for the day, and
+// counting them would let the todo list silently satisfy a rung about the
+// itinerary.
+//
+// The span is the WHOLE trip, not the first-to-last scheduled day it used to
+// be: that older window made a single dated item enough to declare a 37-day
+// trip scheduled, and hid every day past the last one. Undated trips have no
+// honest span, so they keep the old min..max window and report no denominator.
+//
+// PLANNABLE days are the span minus its last day, which is the day you leave —
+// there is nothing to plan on it, and flagging it would put a finding on every
+// tidy trip in the app. That count is the trip's nights, the unit the rest of
+// the app already measures a stay in. A single-day trip keeps its one day.
+func walkDayCoverage(d exportData) dayCoverage {
+	real := map[int]bool{}
 	minDay, maxDay := 0, 0
-	for _, it := range items {
-		if it.Day == nil {
-			continue
+	mark := func(day int) {
+		if day < 1 {
+			return
 		}
-		day := int(*it.Day)
-		counts[day]++
+		real[day] = true
 		if minDay == 0 || day < minDay {
 			minDay = day
 		}
@@ -230,26 +283,64 @@ func emptyDayRuns(items []store.ItineraryItem) []dayRun {
 			maxDay = day
 		}
 	}
-	if len(counts) == 0 {
-		return nil
-	}
-	var runs []dayRun
-	for day := minDay; day <= maxDay; day++ {
-		if counts[day] != 0 {
+	for _, it := range d.Items {
+		if it.Day == nil || isCityFiller(it) {
 			continue
 		}
-		first := day
-		for day < maxDay && counts[day+1] == 0 {
+		mark(int(*it.Day))
+	}
+
+	cov := dayCoverage{Total: tripDayCount(d.Trip)}
+	if cov.Total > 1 {
+		cov.Total-- // drop the departure day
+	}
+	if cov.Total > 0 && d.Trip.StartDate.Valid {
+		start := d.Trip.StartDate.Time
+		for _, s := range d.Segments {
+			if s.Auto || s.Dismissed {
+				continue
+			}
+			for _, when := range []pgtype.Date{s.DepartDate, s.ArriveDate} {
+				if !when.Valid {
+					continue
+				}
+				if day := nightsBetween(start, when.Time) + 1; day <= cov.Total {
+					mark(day)
+				}
+			}
+		}
+	}
+
+	first, last := 1, cov.Total
+	if cov.Total == 0 {
+		// Undated: the only span we can speak for is the one the items
+		// themselves describe. No items, no runs — same as before.
+		if len(real) == 0 {
+			return cov
+		}
+		first, last = minDay, maxDay
+	}
+	for day := first; day <= last; day++ {
+		if real[day] {
+			cov.Planned++
+			continue
+		}
+		runStart := day
+		for day < last && !real[day+1] {
 			day++
 		}
-		runs = append(runs, dayRun{first: first, last: day})
+		cov.Empty = append(cov.Empty, dayRun{first: runStart, last: day})
 	}
-	return runs
+	return cov
 }
 
-// checkDensity flags empty days between the first and last scheduled day, and
+// checkDensity flags days with nothing planned (walkDayCoverage owns what that
+// means — whole trip span, city fillers excluded, travel days included) and
 // over-packed days (more than 6 items, or two+ items sharing a time_of_day).
-// Buckets by absolute day so a day split across hubs still counts once.
+// Buckets by absolute day so a day split across hubs still counts once. The
+// zero-dated-items early return stands: "no places saved yet" is
+// checkUnscheduled's finding to make, and one empty run spanning the whole trip
+// would only repeat it.
 func checkDensity(locale string, d exportData) []Finding {
 	tripID := d.Trip.ID.String()
 	buckets := map[int][]store.ItineraryItem{}
@@ -273,7 +364,7 @@ func checkDensity(locale string, d exportData) []Finding {
 	var out []Finding
 	// One finding per empty-day run, anchored on the run's first day (that's
 	// where tap-to-scroll lands).
-	for _, r := range emptyDayRuns(d.Items) {
+	for _, r := range walkDayCoverage(d).Empty {
 		msg := tr(locale, "review.emptyDay", r.first)
 		if r.last > r.first {
 			msg = tr(locale, "review.emptyDayRange", r.first, r.last)

--- a/src/packages/api/trip_review_integration_test.go
+++ b/src/packages/api/trip_review_integration_test.go
@@ -55,10 +55,14 @@ func assertLadderJSON(t *testing.T, progress map[string]any) {
 			t.Fatalf("phase %d (%v) has no label", i, p["id"])
 		}
 		// Only the bookings (derived slots) and schedule (plannable days) rungs
-		// have an exact denominator to report.
+		// have an exact denominator to report; the bare count belongs only to
+		// the destinations rung, which has none.
 		if _, has := p["progress"]; has &&
 			p["id"] != planPhaseBookings && p["id"] != planPhaseSchedule {
 			t.Fatalf("phase %v must not carry a tally: %v", p["id"], p["progress"])
+		}
+		if _, has := p["count"]; has && p["id"] != planPhaseItinerary {
+			t.Fatalf("phase %v must not carry a count: %v", p["id"], p["count"])
 		}
 	}
 }

--- a/src/packages/api/trip_review_integration_test.go
+++ b/src/packages/api/trip_review_integration_test.go
@@ -54,8 +54,10 @@ func assertLadderJSON(t *testing.T, progress map[string]any) {
 		if label, _ := p["label"].(string); label == "" {
 			t.Fatalf("phase %d (%v) has no label", i, p["id"])
 		}
-		// Only the bookings rung has an exact denominator to report.
-		if _, has := p["progress"]; has && p["id"] != planPhaseBookings {
+		// Only the bookings (derived slots) and schedule (plannable days) rungs
+		// have an exact denominator to report.
+		if _, has := p["progress"]; has &&
+			p["id"] != planPhaseBookings && p["id"] != planPhaseSchedule {
 			t.Fatalf("phase %v must not carry a tally: %v", p["id"], p["progress"])
 		}
 	}

--- a/src/packages/api/trip_review_test.go
+++ b/src/packages/api/trip_review_test.go
@@ -107,6 +107,77 @@ func TestCheckDensity_EmptyDayRuns(t *testing.T) {
 	}
 }
 
+// walkDayCoverage is the ONE definition of "a planned day" — Trip Health's
+// empty-day findings, the ladder's rung 4 and that rung's tally all read it, so
+// they cannot disagree about what counts.
+func TestWalkDayCoverage(t *testing.T) {
+	// 2026-09-01 → 09-05 is a 5-day span, so 4 plannable days (you fly home on
+	// the 5th and there is nothing to plan on it).
+	trip := store.Trip{ID: uuid.New(),
+		StartDate: dateVal(t, "2026-09-01"), EndDate: dateVal(t, "2026-09-05")}
+
+	t.Run("city fillers are not content", func(t *testing.T) {
+		cov := walkDayCoverage(exportData{Trip: trip, Items: []store.ItineraryItem{
+			{ID: uuid.New(), Name: "Prague", City: strp("Prague"), Day: i32p(1)},
+			{ID: uuid.New(), Name: "Prague", City: strp("Prague"), Day: i32p(2)},
+		}})
+		if cov.Planned != 0 || cov.Total != 4 {
+			t.Fatalf("coverage = %d of %d, want 0 of 4", cov.Planned, cov.Total)
+		}
+		if len(cov.Empty) != 1 || cov.Empty[0].first != 1 || cov.Empty[0].last != 4 {
+			t.Fatalf("empty runs = %+v, want one run covering 1–4", cov.Empty)
+		}
+	})
+
+	t.Run("the departure day is never empty", func(t *testing.T) {
+		// Days 1–4 covered; day 5 (departure) is deliberately outside the span.
+		var items []store.ItineraryItem
+		for day := 1; day <= 4; day++ {
+			items = append(items, store.ItineraryItem{
+				ID: uuid.New(), Name: "Museum", City: strp("Prague"), Day: i32p(int32(day))})
+		}
+		cov := walkDayCoverage(exportData{Trip: trip, Items: items})
+		if cov.Planned != 4 || cov.Total != 4 || len(cov.Empty) != 0 {
+			t.Fatalf("coverage = %d of %d, empty %+v, want a clean 4 of 4",
+				cov.Planned, cov.Total, cov.Empty)
+		}
+	})
+
+	t.Run("real segments fill their travel days, drafts do not", func(t *testing.T) {
+		d := exportData{Trip: trip, Items: []store.ItineraryItem{
+			{ID: uuid.New(), Name: "Museum", City: strp("Prague"), Day: i32p(1)},
+		}}
+		d.Segments = []store.TripSegment{{ID: uuid.New(), Mode: "train",
+			DepartDate: dateVal(t, "2026-09-02"), ArriveDate: dateVal(t, "2026-09-03")}}
+		if cov := walkDayCoverage(d); cov.Planned != 3 {
+			t.Fatalf("planned = %d, want 3 (day 1 + the two travel days)", cov.Planned)
+		}
+		d.Segments[0].Auto = true
+		if cov := walkDayCoverage(d); cov.Planned != 1 {
+			t.Fatalf("an itinerary-seeded draft must not fill a day: %+v", cov)
+		}
+		d.Segments[0].Auto, d.Segments[0].Dismissed = false, true
+		if cov := walkDayCoverage(d); cov.Planned != 1 {
+			t.Fatalf("a dismissed segment must not fill a day: %+v", cov)
+		}
+	})
+
+	t.Run("undated trips keep the item window and report no denominator", func(t *testing.T) {
+		cov := walkDayCoverage(exportData{
+			Trip: store.Trip{ID: uuid.New()},
+			Items: []store.ItineraryItem{
+				{ID: uuid.New(), Name: "A", Day: i32p(1)},
+				{ID: uuid.New(), Name: "C", Day: i32p(3)},
+			}})
+		if cov.Total != 0 {
+			t.Fatalf("total = %d, want 0 — an undated trip has no honest span", cov.Total)
+		}
+		if len(cov.Empty) != 1 || cov.Empty[0].first != 2 || cov.Empty[0].last != 2 {
+			t.Fatalf("empty runs = %+v, want just day 2", cov.Empty)
+		}
+	})
+}
+
 func TestCheckLodging_GateAndCoverage(t *testing.T) {
 	trip := store.Trip{ID: uuid.New(),
 		StartDate: dateVal(t, "2026-08-01"), EndDate: dateVal(t, "2026-08-04")} // 3 nights: 1,2,3

--- a/src/packages/flutter-app/lib/models/trip_finding.dart
+++ b/src/packages/flutter-app/lib/models/trip_finding.dart
@@ -206,12 +206,23 @@ class PlanPhase {
   final String id;
   final String label;
 
-  /// The rung's own tally, when it has an exact denominator — today only the
-  /// bookings rung, whose units are the trip's derived booking slots. Null
-  /// means the rung has nothing honest to count, NOT zero.
+  /// The rung's own tally, when it has an exact denominator: the bookings
+  /// rung's derived slots, the schedule rung's plannable days. Null means the
+  /// rung has nothing honest to count, NOT zero.
   final PhaseProgress? progress;
 
-  const PlanPhase({required this.id, required this.label, this.progress});
+  /// A bare count, for a rung whose work has no target to progress toward —
+  /// the destinations rung. Distinct from [progress] on purpose: a count
+  /// rendered as a tally would read "10 of 10", i.e. finished. At most one of
+  /// the two is ever set.
+  final int? count;
+
+  const PlanPhase({
+    required this.id,
+    required this.label,
+    this.progress,
+    this.count,
+  });
 
   factory PlanPhase.fromJson(Map<String, dynamic> json) =>
       _$PlanPhaseFromJson(json);

--- a/src/packages/flutter-app/lib/models/trip_finding.g.dart
+++ b/src/packages/flutter-app/lib/models/trip_finding.g.dart
@@ -128,12 +128,14 @@ PlanPhase _$PlanPhaseFromJson(Map<String, dynamic> json) => PlanPhase(
       progress: json['progress'] == null
           ? null
           : PhaseProgress.fromJson(json['progress'] as Map<String, dynamic>),
+      count: (json['count'] as num?)?.toInt(),
     );
 
 Map<String, dynamic> _$PlanPhaseToJson(PlanPhase instance) => <String, dynamic>{
       'id': instance.id,
       'label': instance.label,
       'progress': instance.progress,
+      'count': instance.count,
     };
 
 PhaseProgress _$PhaseProgressFromJson(Map<String, dynamic> json) =>

--- a/src/packages/flutter-app/lib/widgets/plan_progress_sheet.dart
+++ b/src/packages/flutter-app/lib/widgets/plan_progress_sheet.dart
@@ -184,14 +184,21 @@ class _PhaseRow extends StatelessWidget {
     // two colors. The label already said it; only the detail adds anything.
     final showTitle = showStep && s.title != phase.label;
 
-    // The rung's own tally ("4 of 11"), for rungs that have one. It is the
-    // only number that moves while a many-city trip sits on "3 of 6" —
-    // eleven booking slots close one at a time under a single rung. The rung
-    // label supplies the noun, so this reuses the bare "{n} of {total}" the
-    // eyebrow counter already speaks.
+    // The rung's own number. A tally ("4 of 11") for rungs measured against an
+    // exact denominator — the only number that moves while a many-city trip
+    // sits on "3 of 6", since eleven booking slots close one at a time under a
+    // single rung. Otherwise a bare count ("10") for a rung with no target to
+    // progress toward; rendering that as a tally would say "10 of 10", which
+    // claims the rung is finished. The server never sets both. Either way the
+    // rung label supplies the noun, so this reuses the bare "{n} of {total}"
+    // the eyebrow counter already speaks and adds no copy of its own.
     final tally = phase.progress;
-    final tallyLabel =
-        tally == null ? null : l10n.nextStepProgress(tally.done, tally.total);
+    final count = phase.count;
+    final String? tallyLabel = tally != null
+        ? l10n.nextStepProgress(tally.done, tally.total)
+        : count != null
+            ? '$count'
+            : null;
 
     return Semantics(
       label: [phase.label, stateLabel, if (tallyLabel != null) tallyLabel]

--- a/src/packages/flutter-app/lib/widgets/plan_progress_sheet.dart
+++ b/src/packages/flutter-app/lib/widgets/plan_progress_sheet.dart
@@ -33,10 +33,17 @@ Future<void> showPlanProgressSheet(
     // sheets: a six-row list reads stranded at full bleed.
     constraints: const BoxConstraints(maxWidth: 560),
     builder: (sheetContext) {
+      final screenHeight = MediaQuery.of(sheetContext).size.height;
       return SafeArea(
         child: ConstrainedBox(
+          // A FLOOR as well as a ceiling, unlike the sibling sheets. This is
+          // the only one whose content has a fixed, short length — six rows
+          // never grow — so on a tall window it hugged the bottom edge and
+          // read as a footer rather than a panel (Brian, 2026-08-14). The
+          // slack falls below the last rung; rows stay top-aligned.
           constraints: BoxConstraints(
-            maxHeight: MediaQuery.of(sheetContext).size.height * 0.8,
+            minHeight: screenHeight * 0.62,
+            maxHeight: screenHeight * 0.8,
           ),
           child: SingleChildScrollView(
             padding: const EdgeInsets.fromLTRB(
@@ -172,6 +179,10 @@ class _PhaseRow extends StatelessWidget {
     final s = step;
     final showStep = s != null && s.kind != 'all_set';
     final detail = s?.detail;
+    // Rungs whose step title IS the rung label (the schedule rung, when the
+    // driver is empty days) would otherwise print "Plan your days" twice, in
+    // two colors. The label already said it; only the detail adds anything.
+    final showTitle = showStep && s.title != phase.label;
 
     // The rung's own tally ("4 of 11"), for rungs that have one. It is the
     // only number that moves while a many-city trip sits on "3 of 6" —
@@ -209,11 +220,12 @@ class _PhaseRow extends StatelessWidget {
                   ),
                   if (showStep) ...[
                     const SizedBox(height: AppSpacing.xs),
-                    Text(
-                      s.title,
-                      style: theme.textTheme.bodySmall
-                          ?.copyWith(color: theme.colorScheme.primary),
-                    ),
+                    if (showTitle)
+                      Text(
+                        s.title,
+                        style: theme.textTheme.bodySmall
+                            ?.copyWith(color: theme.colorScheme.primary),
+                      ),
                     if (detail != null && detail.isNotEmpty)
                       Text(
                         detail,

--- a/src/packages/flutter-app/test/plan_progress_sheet_test.dart
+++ b/src/packages/flutter-app/test/plan_progress_sheet_test.dart
@@ -12,7 +12,7 @@ import 'support/l10n_test_app.dart';
 
 const _phases = [
   PlanPhase(id: 'dates', label: 'Set your travel dates'),
-  PlanPhase(id: 'itinerary', label: 'Add your destinations'),
+  PlanPhase(id: 'itinerary', label: 'Add your destinations', count: 10),
   PlanPhase(
     id: 'bookings',
     label: 'Book travel & stays',
@@ -108,6 +108,22 @@ void main() {
     // The header pill is the ladder's own counter; no other rung invents one.
     expect(find.textContaining(' of '),
         findsNWidgets(3)); // "3 of 6" + "4 of 11" + "0 of 37"
+  });
+
+  // Adding destinations has no target to progress toward, so that rung carries
+  // a bare count. Rendered as a tally it would read "10 of 10" — finished.
+  testWidgets('a rung with a count shows the bare number', (tester) async {
+    await tester.pumpWidget(_app(const PlanProgressSheetBody(
+      progress: PlanProgress(done: 2, total: 6, phases: _phases),
+      currentStep: _step,
+    )));
+
+    expect(
+        find.descendant(
+            of: find.byKey(const ValueKey('plan-phase-itinerary')),
+            matching: find.text('10')),
+        findsOneWidget);
+    expect(find.text('10 of 10'), findsNothing);
   });
 
   // The days rung's step title IS its label, so printing both would say "Plan

--- a/src/packages/flutter-app/test/plan_progress_sheet_test.dart
+++ b/src/packages/flutter-app/test/plan_progress_sheet_test.dart
@@ -12,13 +12,17 @@ import 'support/l10n_test_app.dart';
 
 const _phases = [
   PlanPhase(id: 'dates', label: 'Set your travel dates'),
-  PlanPhase(id: 'itinerary', label: 'Plan your days'),
+  PlanPhase(id: 'itinerary', label: 'Add your destinations'),
   PlanPhase(
     id: 'bookings',
     label: 'Book travel & stays',
     progress: PhaseProgress(done: 4, total: 11),
   ),
-  PlanPhase(id: 'schedule', label: 'Tidy up your schedule'),
+  PlanPhase(
+    id: 'schedule',
+    label: 'Plan your days',
+    progress: PhaseProgress(done: 0, total: 37),
+  ),
   PlanPhase(id: 'confirm', label: 'Book everything'),
   PlanPhase(id: 'packing', label: 'Start your packing list'),
 ];
@@ -81,7 +85,9 @@ void main() {
 
   // Sub-progress: eleven booking slots close one at a time under a single
   // rung, so the rung carries the only number that moves while the ladder
-  // itself sits on "3 of 6". Rungs with no honest denominator show nothing.
+  // itself sits on "3 of 6". Same for the days rung, whose "0 of 37" is the
+  // signal that nothing is planned even though the rung is still ahead.
+  // Rungs with no honest denominator show nothing.
   testWidgets('a rung with a tally shows it, the others show none',
       (tester) async {
     await tester.pumpWidget(_app(const PlanProgressSheetBody(
@@ -94,8 +100,37 @@ void main() {
             of: find.byKey(const ValueKey('plan-phase-bookings')),
             matching: find.text('4 of 11')),
         findsOneWidget);
+    expect(
+        find.descendant(
+            of: find.byKey(const ValueKey('plan-phase-schedule')),
+            matching: find.text('0 of 37')),
+        findsOneWidget);
     // The header pill is the ladder's own counter; no other rung invents one.
-    expect(find.textContaining(' of '), findsNWidgets(2)); // "3 of 6" + "4 of 11"
+    expect(find.textContaining(' of '),
+        findsNWidgets(3)); // "3 of 6" + "4 of 11" + "0 of 37"
+  });
+
+  // The days rung's step title IS its label, so printing both would say "Plan
+  // your days" twice in two colors. The detail still carries the news.
+  testWidgets('a step title identical to the rung label is not repeated',
+      (tester) async {
+    await tester.pumpWidget(_app(const PlanProgressSheetBody(
+      progress: PlanProgress(done: 3, total: 6, phases: _phases),
+      currentStep: NextStep(
+        kind: 'schedule_items',
+        title: 'Plan your days',
+        detail: 'Days 1–36 have nothing planned.',
+      ),
+    )));
+
+    final schedule = find.byKey(const ValueKey('plan-phase-schedule'));
+    expect(find.descendant(of: schedule, matching: find.text('Plan your days')),
+        findsOneWidget);
+    expect(
+        find.descendant(
+            of: schedule,
+            matching: find.text('Days 1–36 have nothing planned.')),
+        findsOneWidget);
   });
 
   testWidgets('a complete ladder is all checks and no step block',
@@ -118,6 +153,47 @@ void main() {
     )));
 
     expect(find.text('Plan progress'), findsNothing);
+  });
+
+  // Six short rows sized the sheet to its content, which on a tall window
+  // anchored it to the bottom ~46% and read as a footer (Brian, 2026-08-14).
+  // The floor is what puts it on screen rather than under the fold, so it is
+  // worth a geometry assertion — the sheet's own body tests cannot see it.
+  testWidgets('the modal opens with a height floor, not hugging the bottom',
+      (tester) async {
+    tester.view.physicalSize = const Size(1200, 1800); // 600 x 900 logical
+    tester.view.devicePixelRatio = 2.0;
+    addTearDown(tester.view.reset);
+
+    await tester.pumpWidget(localizedTestApp(
+      home: Scaffold(
+        body: Builder(
+          builder: (context) => TextButton(
+            onPressed: () => showPlanProgressSheet(context,
+                progress:
+                    const PlanProgress(done: 2, total: 6, phases: _phases),
+                currentStep: _step),
+            child: const Text('open'),
+          ),
+        ),
+      ),
+    ));
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+
+    const screen = 900.0;
+    // The scroll viewport is what the floor stretches; its child stays
+    // content-sized and top-aligned inside it (the slack falls below).
+    final viewport = tester.getSize(find.ancestor(
+      of: find.byType(PlanProgressSheetBody),
+      matching: find.byType(SingleChildScrollView),
+    ));
+    expect(viewport.height, greaterThanOrEqualTo(screen * 0.62),
+        reason: 'the floor must survive a short ladder');
+
+    // The user-facing claim: the sheet starts above the halfway line.
+    final top = tester.getTopLeft(find.byType(PlanProgressSheetBody)).dy;
+    expect(top, lessThan(screen / 2));
   });
 
   testWidgets('labels are server copy, chrome is localized', (tester) async {

--- a/src/packages/flutter-app/test/trip_detail_derivation_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_derivation_test.dart
@@ -90,7 +90,8 @@ const _draftStay = Accommodation(
   auto: true,
 );
 
-BookingTodo _todo(String key, {String kind = 'transport', bool booked = false}) =>
+BookingTodo _todo(String key,
+        {String kind = 'transport', bool booked = false}) =>
     BookingTodo(
       id: 'todo-$key',
       kind: kind,
@@ -230,8 +231,8 @@ void main() {
       final d = _compute();
       expect([for (final g in d.groups) g.key], ['Paris', 'Rome', 'Paris#2']);
       expect([for (final g in d.groups) g.label], ['Paris', 'Rome', 'Paris']);
-      expect([for (final i in d.groups[1].items) i.name],
-          ['Colosseum', 'Trevi']);
+      expect(
+          [for (final i in d.groups[1].items) i.name], ['Colosseum', 'Trevi']);
       expect([for (final i in d.groups[2].items) i.name], ['Louvre Again']);
       // legs (the unfiltered split) mirrors the same runs.
       expect([for (final l in d.legs) l.key], ['Paris', 'Rome', 'Paris#2']);
@@ -281,8 +282,7 @@ void main() {
         _todo('transport:paris>>home'),
         _todo('custom:helicopter', kind: 'other'),
       ];
-      final d = _compute(
-          bookingTodos: todos, stays: [_parisStay, _draftStay]);
+      final d = _compute(bookingTodos: todos, stays: [_parisStay, _draftStay]);
       final grouped = d.groupedBookings;
       // One slot per leg label (Paris, Rome, Paris-revisit).
       expect(d.legLabels, ['Paris', 'Rome', 'Paris']);
@@ -299,8 +299,8 @@ void main() {
       expect(grouped.slots[0].departure, isNull);
       expect(grouped.slots[2].departure?.todoKey, 'transport:paris>>home');
       // Residuals: the custom todo; the auto draft stay is excluded entirely.
-      expect([for (final t in grouped.residual) t.todoKey],
-          ['custom:helicopter']);
+      expect(
+          [for (final t in grouped.residual) t.todoKey], ['custom:helicopter']);
       expect(grouped.residualStays, isEmpty);
       expect(grouped.residualSegments, isEmpty);
     });
@@ -353,8 +353,7 @@ void main() {
     test('legChips: full-leg keys in visit order, localized labels', () {
       final d = _compute();
       expect([for (final c in d.legChips) c.key], ['Paris', 'Rome', 'Paris#2']);
-      expect(
-          [for (final c in d.legChips) c.label], ['Paris', 'Rome', 'Paris']);
+      expect([for (final c in d.legChips) c.label], ['Paris', 'Rome', 'Paris']);
       // A single-leg trip still yields its one entry — hiding the <2-leg
       // strip is the widget's rule, so the gate has one home.
       final solo = _compute(
@@ -402,8 +401,7 @@ void main() {
         checkIn: '2026-09-03',
         checkOut: '2026-09-05',
       );
-      final withStay =
-          _compute(trip: _trip(items: items, stays: [romeStay]));
+      final withStay = _compute(trip: _trip(items: items, stays: [romeStay]));
       expect(withStay.mappedLegKeys, {'Paris', 'Rome'});
     });
 
@@ -417,7 +415,8 @@ void main() {
       expect(d.legFilteredItems('Nowhere'), isEmpty);
       expect(identical(d.legFilteredItems(null), d.items), isTrue);
       expect(identical(d.legFilteredItems('Rome'), d.legFilteredItems('Rome')),
-          isTrue, reason: 'stable identity per (derivation, key)');
+          isTrue,
+          reason: 'stable identity per (derivation, key)');
     });
 
     test('legFilteredStays: raw-range night overlap, checkout-exclusive', () {
@@ -433,8 +432,7 @@ void main() {
       expect([for (final a in d.legFilteredStays('Paris#2')) a.id], ['a1']);
       expect(identical(d.legFilteredStays(null), d.confirmedStays), isTrue);
       expect(
-          identical(
-              d.legFilteredStays('Paris'), d.legFilteredStays('Paris')),
+          identical(d.legFilteredStays('Paris'), d.legFilteredStays('Paris')),
           isTrue,
           reason: 'stable identity per (derivation, key)');
       expect(d.legFilteredStays('Nowhere'), isEmpty);
@@ -461,8 +459,8 @@ void main() {
         ),
       );
       expect(squeezed.legFilteredStays('Prague'), isEmpty);
-      expect([for (final a in squeezed.legFilteredStays('Vienna')) a.id],
-          ['a4']);
+      expect(
+          [for (final a in squeezed.legFilteredStays('Vienna')) a.id], ['a4']);
 
       // An undated leg (no parseable range) plots no stays.
       final undated = _compute(
@@ -537,4 +535,98 @@ void main() {
       expect(d.liveDayKeys, {'Prague#2'});
     });
   });
+
+  // TWIN of TestIsCityFillerParity in api/city_filler_test.go. Same cases, same
+  // expectations, in the same order — docs/zen.md requires the parity contract
+  // because "city filler" has two implementations now: this one, which HIDES
+  // these rows, and the server's, which must not count what this one hides
+  // (a 37-day trip of bare city pins used to check "Plan your days" off).
+  // Change one table, change the other.
+  group('isCityFiller parity with the Go server', () {
+    // dartOnly marks the ONE documented divergence: this predicate compares the
+    // name against cityOf(), which falls back to a regex over the address when
+    // the city field is empty. The server reads the explicit columns only —
+    // a second regex would drift, and AI-emitted fillers always set city.
+    final cases =
+        <({String desc, ItineraryItem item, bool want, bool dartOnly})>[
+      (
+        desc: 'name equals city',
+        item: _filler(name: 'Prague', city: 'Prague'),
+        want: true,
+        dartOnly: false
+      ),
+      (
+        desc: 'real activity in a city',
+        item: _filler(name: 'Charles Bridge', city: 'Prague'),
+        want: false,
+        dartOnly: false
+      ),
+      (
+        desc: 'case and space insensitive',
+        item: _filler(name: '  prague ', city: 'Prague'),
+        want: true,
+        dartOnly: false
+      ),
+      (
+        desc: 'name equals the day-trip hub',
+        item: _filler(name: 'Kyoto', city: 'Nara', dayTripFrom: 'Kyoto'),
+        want: true,
+        dartOnly: false
+      ),
+      (
+        desc: 'hub set, name is a real place',
+        item:
+            _filler(name: 'Fushimi Inari', city: 'Nara', dayTripFrom: 'Kyoto'),
+        want: false,
+        dartOnly: false
+      ),
+      (
+        desc: 'no city and no hub',
+        item: _filler(name: 'Prague'),
+        want: false,
+        dartOnly: false
+      ),
+      (
+        desc: 'empty name is never a filler',
+        item: _filler(name: '   ', city: 'Prague'),
+        want: false,
+        dartOnly: false
+      ),
+      (
+        desc: 'city empty, name matches the address city',
+        item: _filler(
+            name: 'Prague', city: '', address: 'Old Town, Prague, Czechia'),
+        want: true,
+        dartOnly: true
+      ),
+    ];
+
+    for (final c in cases) {
+      test(c.desc, () {
+        expect(isCityFiller(c.item), c.want,
+            reason: c.dartOnly
+                ? 'documented divergence: the Go twin expects false here'
+                : 'the Go twin must agree');
+      });
+    }
+  });
 }
+
+/// Bare item for the parity table — no address is synthesized (unlike [_item]),
+/// because the address is one of the inputs under test.
+ItineraryItem _filler({
+  required String name,
+  String? city,
+  String? dayTripFrom,
+  String? address,
+}) =>
+    ItineraryItem(
+      id: 'filler-$name',
+      position: 0,
+      name: name,
+      address: address,
+      latitude: 0,
+      longitude: 0,
+      city: city,
+      dayTripFrom: dayTripFrom,
+    );


### PR DESCRIPTION
## Summary

Two things from dogfooding the 37-day "Big Summer Adventure" trip (Brian, 2026-08-14).

**1. "Plan your days" was checked on a trip with no activities.** Rung 2's test is `len(items) > 0 && at least one item has a day` — an *any*, not an *all* — and the rows satisfying it were **city fillers**, the placeholders `create_itinerary` emits for a day with nothing specific, which the app **hides**. The server was checking a rung off against places the traveler could not see.

Renamed rather than re-predicated (demanding real activities on rung 2 would have dropped an actively-booking traveler back to step 2 and held eleven flights hostage to day planning):

| rung | was | now |
|---|---|---|
| 2 (`itinerary`) | Plan your days | **Add your destinations** |
| 4 (`schedule`) | Tidy up your schedule | **Plan your days** |

Ids did not move — ids are identity, labels are copy — so the wire, the client's ValueKeys and every test key are unchanged. `review.ladder.days` carries the exact strings rung 2 gave up, in both languages, so no wording is new.

**What made the rename safe was fixing rung 4 underneath it.** `emptyDayRuns` counted *any* item (fillers included) across the first-to-last scheduled day only — so one dated item collapsed the window to a point and declared a 37-day trip scheduled. `walkDayCoverage` replaces it as the ONE definition of "a planned day":

- **filler-aware** — `isCityFiller` ported to Go;
- **the whole trip span minus the departure day** (= the trip's nights). Extending to the literal span put "Day 2 has nothing planned" on a one-night trip whose traveler flies home that morning — `TestReviewTrip_CleanTripNoFindings` caught it;
- **segment-aware** — a real (non-auto, non-dismissed) segment makes its travel days planned, so the rung never calls the day you fly to Kraków empty. Booking *to-dos* deliberately don't count.

Trip Health's empty-day findings, rung 4's test and rung 4's new **`0 of 36`** tally all read that one value, so they cannot disagree — the same doctrine the bookings rung's tally follows.

`isCityFiller` is a second implementation, so it ships with the parity contract `docs/zen.md` requires: twin fixture tables in `city_filler_test.go` ↔ `trip_detail_derivation_test.dart`, including the one documented divergence (no address-regex fallback server-side).

**2. The progress sheet sat too low.** It sized to its content, so six short rows anchored to the bottom ~46% of a tall window and read as a footer. It now carries a `minHeight` floor of 62% under the existing 80% cap — the only Tier-A sheet with a floor, because it is the only one whose content has a fixed, short length. The sheet also stops printing a step title identical to its rung label (now possible on rung 4).

### The destinations rung gets a bare count, not a tally

`PlanPhase` grows a **separate `count` field** beside `progress`, and a rung carries at most one. Adding destinations has no target to progress toward, so a denominator would have to be invented and "10 of 10" would read as a *finished* rung. Keeping the two apart at the type level is what stops a count from ever being rendered through the tally's `{n} of {total}`.

The number is `countDestinations` — the trip's rendered legs that have a hub, so it equals the map chips and the itinerary headers rather than being a third opinion about what a destination is. Hubless "Other places" runs never count (same reason `namesAPlace` rejects that label), a revisited city counts once per visit, and a trip with no places carries no count rather than a zero.

### Blast radius, accepted

Every dated trip with unplanned days gains one `info` health finding and stalls at rung 4, so "Book everything", "Start your packing list" and the all-set celebration are harder to reach. That is the honest ladder; the `N of 36` tally is what keeps it from feeling stuck.

## Testing

- `go vet ./...`, `gofmt -l .`, full `go test ./...` — green.
- New Go coverage for the gap that let this ship (every prior test was all-dated or none-dated): `TestNextStep_CityFillersAreNotAPlannedDay` (filler-only trip; ladder stays on the booking rung, tally `0 of 3`, then stops AT the day rung; one real activity does **not** re-satisfy it), `TestNextStep_TravelDayCountsAsPlanned` (incl. auto/dismissed segments), `TestWalkDayCoverage` (4 sub-cases), `TestIsCityFillerParity` (8 cases), `TestNextStep_DestinationsCount` (revisits, hubless runs, empty trip).
- `flutter analyze` (3 pre-existing infos in an untouched file), full `flutter test` — green. New: the twin parity group, the duplicate-title suppression case, and a real-modal **geometry** assertion (viewport ≥ 62% of a 600×900 window; sheet top above the halfway line).
- **Live on a lane stack**, seeding a trip with this exact shape (37 days, 10 city fillers, nothing booked): sheet now opens at 33% down instead of 54%, and the ladder reads `✓ Set your travel dates / ✓ Add your destinations 10 / ◉ Book travel & stays 1 of 19 / ○ Plan your days 0 of 36 / ○ Book everything / ○ Start your packing list`. Trip Health says "Days 1–36 have nothing planned." Spanish verified via `Accept-Language: es` (`Añade tus destinos`, `Planifica tus días 0 de 36`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
