### PR TITLE
feat(brand): carry the ANEMOS wordmark on every page

### DIFF
--- a/src/packages/flutter-app/lib/navigation/shell_scope.dart
+++ b/src/packages/flutter-app/lib/navigation/shell_scope.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/widgets.dart';
+
+/// Marks the subtree that renders inside the persistent navigation shell
+/// (`AppShell`), which publishes it around the tab navigators.
+///
+/// The house app bar's brand is a logo-links-home affordance, and that only
+/// means something where there is a home to go to. Nine screens render on the
+/// root navigator, outside the shell — landing, auth, splash, SSO callback,
+/// connect-app, verify, reset, shared trip, and the fullscreen trip map — and
+/// on those a pointer cursor plus a "Home" tooltip that does nothing is a dead
+/// affordance. Worst on `/share/<token>`, which strangers open.
+///
+/// Derived rather than declared: a `brandLinksHome: false` parameter would be
+/// one more thing every future screen has to remember, and forgetting it fails
+/// silently. Routes see inherited widgets sitting above their [Navigator], so
+/// pages pushed on a tab navigator inherit this and root-navigator pushes
+/// correctly do not.
+///
+/// Lives in its own file rather than beside `AppShell` so `gradient_app_bar`
+/// can read it without importing the shell that imports every tab root.
+class ShellScope extends InheritedWidget {
+  const ShellScope({super.key, required super.child});
+
+  /// Whether [context] is being built inside the shell.
+  static bool of(BuildContext context) =>
+      context.dependOnInheritedWidgetOfExactType<ShellScope>() != null;
+
+  @override
+  bool updateShouldNotify(ShellScope oldWidget) => false;
+}

--- a/src/packages/flutter-app/lib/screens/admin_metrics_screen.dart
+++ b/src/packages/flutter-app/lib/screens/admin_metrics_screen.dart
@@ -6,6 +6,7 @@ import '../providers/admin_metrics_provider.dart';
 import '../theme/spacing.dart';
 import '../widgets/daily_count_chart.dart';
 import '../widgets/empty_state.dart';
+import '../widgets/gradient_app_bar.dart';
 import '../widgets/health_pane.dart';
 import '../widgets/page_container.dart';
 import '../widgets/section_header.dart';
@@ -44,10 +45,17 @@ class _AdminMetricsScreenState extends ConsumerState<AdminMetricsScreen> {
       length: 5,
       initialIndex: widget.initialTabIndex,
       child: Scaffold(
-        appBar: AppBar(
-          title: const Text('Metrics'),
-          bottom: const TabBar(
+        // The house app bar, like every other screen — which also puts the
+        // brand up here. This was the one screen still wearing raw M3 chrome.
+        appBar: const GradientAppBar(
+          title: Text('Metrics'),
+          bottom: TabBar(
             isScrollable: true,
+            // The gradient is dark, so the tabs carry their own light palette
+            // rather than inheriting the surface-toned M3 defaults.
+            labelColor: Colors.white,
+            unselectedLabelColor: Colors.white70,
+            indicatorColor: Colors.white,
             tabs: [
               Tab(text: 'Overview'),
               Tab(text: 'Trends'),

--- a/src/packages/flutter-app/lib/screens/app_shell.dart
+++ b/src/packages/flutter-app/lib/screens/app_shell.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../l10n/l10n.dart';
 import '../navigation/app_nav.dart';
+import '../navigation/shell_scope.dart';
 import '../navigation/url_sync.dart';
 import '../theme/spacing.dart';
 import '../widgets/account_menu.dart';
@@ -45,7 +46,8 @@ class AppShell extends ConsumerWidget {
     // The root navigator only holds the shell, so forward a system/browser back
     // to the active tab's navigator — otherwise nested pushes (trip detail, etc.)
     // couldn't be dismissed with the back button. At a tab root this is a no-op.
-    final content = PopScope(
+    final content = ShellScope(
+        child: PopScope(
       canPop: false,
       onPopInvokedWithResult: (didPop, _) {
         if (didPop) return;
@@ -73,7 +75,7 @@ class AppShell extends ConsumerWidget {
             ),
         ],
       ),
-    );
+    ));
 
     if (isWide) {
       return Scaffold(

--- a/src/packages/flutter-app/lib/screens/auth_screen.dart
+++ b/src/packages/flutter-app/lib/screens/auth_screen.dart
@@ -214,6 +214,14 @@ class _AuthScreenState extends ConsumerState<AuthScreen> {
                   crossAxisAlignment: CrossAxisAlignment.stretch,
                   children: [
                     const BrandLogo.mark(size: 72),
+                    const SizedBox(height: AppSpacing.sm),
+                    // Neutral surface, so the wordmark takes the theme's own
+                    // text color rather than the app bars' white — the plate
+                    // policy in brand_logo.dart, applied to type.
+                    const ExcludeSemantics(
+                      // The mark's Image already carries the "Anemos" label.
+                      child: BrandWordmark(fontSize: 26, letterSpacing: 1.5),
+                    ),
                     const SizedBox(height: AppSpacing.lg),
                     Text(
                       _isLogin

--- a/src/packages/flutter-app/lib/screens/home_screen.dart
+++ b/src/packages/flutter-app/lib/screens/home_screen.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import '../constants/app_info.dart';
 import '../l10n/l10n.dart';
 import '../models/local_guide.dart';
 import '../providers/auth_provider.dart';
@@ -16,7 +15,6 @@ import '../theme/app_colors.dart';
 import '../theme/app_shadows.dart';
 import '../theme/spacing.dart';
 import '../widgets/account_menu.dart';
-import '../widgets/brand_logo.dart';
 import '../widgets/continue_chats_section.dart';
 import '../widgets/gradient_app_bar.dart';
 import '../widgets/language_menu_button.dart';
@@ -49,12 +47,6 @@ String greetingText(AppLocalizations l10n, Greeting greeting) =>
       Greeting.evening => l10n.homeGreetingEvening,
     };
 
-/// Below this width the wordmark would ellipsize next to the badge (Cinzel
-/// 19px small-caps "ANEMOS" ≈ 80px + badge + gap), so the header drops to the
-/// brand mark alone. Measured on the space the brand Row itself gets — the
-/// [_BrandTitle] LayoutBuilder sits *inside* the tap padding — not on the
-/// whole app-bar title slot.
-const double _wordmarkMinWidth = 145;
 
 class HomeScreen extends ConsumerStatefulWidget {
   const HomeScreen({super.key});
@@ -75,12 +67,15 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
     super.dispose();
   }
 
-  /// Logo-links-home. Note which half of this the traveler actually sees:
-  /// each tab owns its own Scaffold (the shell supplies no app bar), so this
-  /// brand is on screen ONLY at the Home root — [goHome] is therefore a
-  /// no-op-you-can't-see, kept so the brand tap honors the same contract as
-  /// the rail brand (app_shell.dart `_RailBrand`), which CAN be tapped from
-  /// anywhere. The visible half is the scroll back to the top.
+  /// Logo-links-home, plus Home's own extra: scroll back to the top.
+  ///
+  /// [GradientAppBar] already wires [goHome] for every screen inside the
+  /// shell, so this override exists only for the scroll — which is also the
+  /// visible half here. Each tab owns its own Scaffold (the shell supplies no
+  /// app bar), so this particular brand is on screen only at the Home root,
+  /// where [goHome] is a no-op-you-can't-see. It stays for contract parity
+  /// with the rail brand (app_shell.dart `_RailBrand`), which CAN be tapped
+  /// from anywhere.
   void _onBrandTap() {
     goHome(ref);
     if (!_scroll.hasClients) return;
@@ -140,8 +135,8 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
 
     return Scaffold(
       appBar: GradientAppBar(
-        centerTitle: false,
-        title: _BrandTitle(onTap: _onBrandTap),
+        // No page title: on Home the brand IS the title.
+        onBrandTap: _onBrandTap,
         actions: const [LanguageMenuButton(), AccountMenu()],
       ),
       body: SafeArea(
@@ -216,94 +211,6 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
 
                 const SizedBox(height: AppSpacing.lg),
               ],
-            ),
-          ),
-        ),
-      ),
-    );
-  }
-}
-
-/// The Home app bar's brand — the Site ID (Krug) — as ONE tap target at every
-/// width, per the universal logo-links-home convention. Three render states,
-/// keyed off window width (same measurement as the shell's rail check, NOT the
-/// title slot's constraints):
-///  - rail visible (>= kRailBreakpoint): wordmark only — the rail brand
-///    already shows the mark one corner over, so the badge here would be a
-///    duplicate. Still tappable: two brand affordances, same destination.
-///  - no rail: brand mark on a light badge (so the teal/gold logo reads on the
-///    teal app bar) next to the wordmark in white.
-///  - compact slot (< _wordmarkMinWidth): if the brand's own slot can't fit
-///    the full wordmark, the badge shows alone rather than an ellipsized brand.
-///
-/// The [InkWell] is the single target for whichever of those is on screen —
-/// the badge deliberately does NOT carry its own onTap here, or the lockup
-/// would hit-test and ripple twice. The LayoutBuilder sits inside the tap
-/// padding so the compact threshold measures the width the Row actually gets.
-class _BrandTitle extends StatelessWidget {
-  final VoidCallback onTap;
-
-  const _BrandTitle({required this.onTap});
-
-  @override
-  Widget build(BuildContext context) {
-    return Tooltip(
-      message: context.l10n.shellNavHome,
-      // The mark's Image already carries the "Anemos" semanticLabel and the
-      // wordmark is the literal word, so without excludeSemantics a screen
-      // reader announces the button as "Anemos Anemos".
-      child: Semantics(
-        button: true,
-        label: AppInfo.name,
-        excludeSemantics: true,
-        child: Material(
-          type: MaterialType.transparency,
-          child: InkWell(
-            onTap: onTap,
-            borderRadius: AppRadius.mdAll,
-            child: Padding(
-              padding: const EdgeInsets.all(AppSpacing.xs),
-              child: LayoutBuilder(
-                builder: (context, constraints) {
-                  final hasRail =
-                      MediaQuery.sizeOf(context).width >= kRailBreakpoint;
-                  final compact = constraints.maxWidth < _wordmarkMinWidth;
-                  const wordmark = Flexible(
-                    child: Text(
-                      AppInfo.name,
-                      overflow: TextOverflow.ellipsis,
-                      // Cinzel has no true lowercase — "Anemos" paints as
-                      // small-caps ANEMOS. Caps run wide, hence the tighter
-                      // size + open tracking.
-                      style: TextStyle(
-                        fontFamily: 'Cinzel',
-                        fontWeight: FontWeight.w600,
-                        fontSize: 19,
-                        letterSpacing: 1.0,
-                        color: Colors.white,
-                      ),
-                    ),
-                  );
-                  return Row(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      if (!hasRail)
-                        const BrandBadge(
-                          padding: EdgeInsets.symmetric(
-                              horizontal: AppSpacing.sm,
-                              vertical: AppSpacing.xs),
-                          child: BrandLogo.mark(size: 28),
-                        ),
-                      if (hasRail)
-                        wordmark
-                      else if (!compact) ...const [
-                        SizedBox(width: AppSpacing.sm),
-                        wordmark,
-                      ],
-                    ],
-                  );
-                },
-              ),
             ),
           ),
         ),

--- a/src/packages/flutter-app/lib/screens/landing_screen.dart
+++ b/src/packages/flutter-app/lib/screens/landing_screen.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import '../constants/app_info.dart';
 import '../l10n/l10n.dart';
 import '../providers/analytics_provider.dart';
 import '../providers/auth_provider.dart';
@@ -72,12 +71,9 @@ class _LandingScreenState extends State<LandingScreen> {
 
     return Scaffold(
       appBar: GradientAppBar(
-        centerTitle: false,
-        title: const BrandBadge(
-          padding: EdgeInsets.symmetric(
-              horizontal: AppSpacing.sm, vertical: AppSpacing.xs),
-          child: BrandLogo.mark(size: 30),
-        ),
+        // No page title: the landing page's title is the brand. The bar's own
+        // lockup (plated mark + wordmark) comes from GradientAppBar — this
+        // screen sits outside the shell, so it keeps the mark at every width.
         actions: [
           const LanguageMenuButton(),
           TextButton(
@@ -241,24 +237,20 @@ class _LandingHero extends StatelessWidget {
                     ExcludeSemantics(
                       // The mark's Image already carries the "Anemos"
                       // semantic label.
-                      child: Text(
-                        AppInfo.name,
-                        style: TextStyle(
-                          fontFamily: 'Cinzel',
-                          fontWeight: FontWeight.w600,
-                          fontSize: narrow ? 24 : 40,
-                          height: 1.1,
-                          letterSpacing: 1.5,
-                          color: Colors.white,
-                          // Guards the scrim's lighter top-right corner
-                          // (alpha 0.35) against bright photo patches.
-                          shadows: const [
-                            Shadow(
-                                color: Colors.black26,
-                                blurRadius: 8,
-                                offset: Offset(0, 2)),
-                          ],
-                        ),
+                      child: BrandWordmark(
+                        fontSize: narrow ? 24 : 40,
+                        // Caps run wide, so tracking opens up with the size.
+                        letterSpacing: 1.5,
+                        height: 1.1,
+                        color: Colors.white,
+                        // Guards the scrim's lighter top-right corner
+                        // (alpha 0.35) against bright photo patches.
+                        shadows: const [
+                          Shadow(
+                              color: Colors.black26,
+                              blurRadius: 8,
+                              offset: Offset(0, 2)),
+                        ],
                       ),
                     ),
                     const SizedBox(height: AppSpacing.lg),

--- a/src/packages/flutter-app/lib/screens/splash_screen.dart
+++ b/src/packages/flutter-app/lib/screens/splash_screen.dart
@@ -6,9 +6,13 @@ import '../widgets/brand_logo.dart';
 ///
 /// Pixel-matched to the static HTML splash in web/index.html — same gradient,
 /// mark geometry (96px bare light mark, no plate), pulse (1.0→1.04 over
-/// 1.8s), and spinner position (center 96px below viewport center) — so the
-/// web handoff reads as one continuous screen. If you change dimensions here,
-/// change index.html too.
+/// 1.8s), wordmark (centre 74px below viewport centre) and spinner position
+/// (centre 124px below) — so the web handoff reads as one continuous screen.
+/// If you change dimensions here, change index.html too.
+///
+/// The native mobile splash stays mark-only: flutter_native_splash cannot
+/// render text, and web is the primary surface. Do not re-run its generator
+/// for this.
 class SplashScreen extends StatefulWidget {
   const SplashScreen({super.key});
 
@@ -51,9 +55,25 @@ class _SplashScreenState extends State<SplashScreen>
               ),
             ),
           ),
+          // Outside the ScaleTransition on purpose: the mark pulses, the name
+          // holds still.
           Center(
             child: Transform.translate(
-              offset: const Offset(0, 96),
+              offset: const Offset(0, 74),
+              child: const ExcludeSemantics(
+                // The gradient is the darkest surface in the app, so this is
+                // the one wordmark that names its color instead of inheriting.
+                child: BrandWordmark(
+                  fontSize: 22,
+                  letterSpacing: 3,
+                  color: Colors.white,
+                ),
+              ),
+            ),
+          ),
+          Center(
+            child: Transform.translate(
+              offset: const Offset(0, 124),
               child: const SizedBox.square(
                 dimension: 24,
                 child: CircularProgressIndicator(

--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -4696,27 +4696,170 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
   /// matching the old row's gate. Not _inBudgetView-gated: that gate
   /// belonged to the scroll body, and health set the precedent that
   /// app-bar icons stay put across views.
+  /// Whether wear & pack has anything to show, and the regions it would show.
+  ///
+  /// One derivation with two entry points — the app-bar icon at wide widths
+  /// and the overflow item at narrow ones — so the gate can never disagree
+  /// with itself about whether the surface is worth offering. [ref] must be a
+  /// Consumer's, never the State's: the weather watches inside
+  /// [_legClothingRecs] subscribe whatever ref they are handed, and the whole
+  /// point is to subscribe one app-bar widget rather than the screen.
+  ({bool available, List<WearRegionRec> regions}) _wearState(
+      WidgetRef ref, Trip trip) {
+    final items = ref.watch(checklistProvider(trip.id)).valueOrNull;
+    final showChecklist = items != null && !(items.isEmpty && _readOnly);
+    final recs = _legClothingRecs(trip, ref);
+    return (available: recs.isNotEmpty || showChecklist, regions: recs);
+  }
+
+  void _openWearSheet(Trip trip, List<WearRegionRec> regions) =>
+      showWearPackSheet(
+        context,
+        tripId: trip.id,
+        // Snapshot: regions freeze at open (reopen refreshes); the
+        // checklist half stays live via its own provider watch.
+        regions: regions,
+        canEdit: !_readOnly,
+        // Live read, not a captured bool: the sheet route never
+        // rebuilds on this screen's connectivity setState.
+        isOffline: () => _isOffline,
+      );
+
   Widget _wearAppBarAction(Trip trip) {
     return Consumer(
       builder: (context, ref, _) {
-        final items = ref.watch(checklistProvider(trip.id)).valueOrNull;
-        final showChecklist = items != null && !(items.isEmpty && _readOnly);
-        final recs = _legClothingRecs(trip, ref);
-        if (recs.isEmpty && !showChecklist) return const SizedBox.shrink();
+        final wear = _wearState(ref, trip);
+        if (!wear.available) return const SizedBox.shrink();
         return IconButton(
           tooltip: context.l10n.wearSectionTitle,
           icon: const Icon(Icons.luggage_outlined),
-          onPressed: () => showWearPackSheet(
-            context,
-            tripId: trip.id,
-            // Snapshot: regions freeze at open (reopen refreshes); the
-            // checklist half stays live via its own provider watch.
-            regions: recs,
-            canEdit: !_readOnly,
-            // Live read, not a captured bool: the sheet route never
-            // rebuilds on this screen's connectivity setState.
-            isOffline: () => _isOffline,
-          ),
+          onPressed: () => _openWearSheet(trip, wear.regions),
+        );
+      },
+    );
+  }
+
+  /// The share menu's dispatch and its items, factored out so the wide app
+  /// bar's own share button and the narrow overflow menu that absorbs it can
+  /// never drift into offering different things.
+  void _onShareMenuSelected(String v) {
+    switch (v) {
+      case 'copy':
+        _shareLink();
+      case 'invite':
+        _inviteCoPlanner();
+      case 'manage':
+        _manageCoPlanners();
+      case 'print':
+        _openPrintExport();
+      case 'calendar':
+        _openCalendarExport();
+      case 'revoke':
+        _revokeLink();
+    }
+  }
+
+  List<PopupMenuEntry<String>> _shareMenuItems(AppLocalizations l10n) => [
+        PopupMenuItem(
+            value: 'copy',
+            child: Text(shareUsesNativeSheet
+                ? l10n.tripShareLinkAction
+                : l10n.tripCopyShareLink)),
+        PopupMenuItem(
+            value: 'invite',
+            child: Text(shareUsesNativeSheet
+                ? l10n.tripShareInviteAction
+                : l10n.tripCopyInviteLink)),
+        PopupMenuItem(value: 'manage', child: Text(l10n.tripManageAccess)),
+        const PopupMenuDivider(),
+        PopupMenuItem(value: 'print', child: Text(l10n.tripPrintSavePdf)),
+        PopupMenuItem(value: 'calendar', child: Text(l10n.tripAddToCalendar)),
+        const PopupMenuDivider(),
+        PopupMenuItem(value: 'revoke', child: Text(l10n.tripTurnOffSharing)),
+      ];
+
+  /// The app bar's `⋮`. Always the home of the destructive exits — owners get
+  /// delete, members (editors and viewer follows) get remove-from-my-list, so
+  /// the owner's trip is untouched; both still confirm in their handlers.
+  ///
+  /// At narrow widths it also absorbs wear & pack and the whole share menu.
+  /// That is what buys the ANEMOS wordmark its room: five icons on a 360px
+  /// bar leave the title slot smaller than the wordmark itself.
+  ///
+  /// A Consumer rather than a bare PopupMenuButton because the wear gate is a
+  /// provider watch that must subscribe this button alone, not the screen —
+  /// and the entries are built here rather than inside `itemBuilder` for the
+  /// same reason: a menu builder has no ref to watch with.
+  Widget _overflowAppBarAction(Trip trip, AppLocalizations l10n) {
+    return Consumer(
+      builder: (context, ref, _) {
+        final wear = _narrow
+            ? _wearState(ref, trip)
+            : (available: false, regions: const <WearRegionRec>[]);
+        final absorbsShare = _narrow && trip.isOwner && !_isOffline;
+        // Offline hides the mutating exits; the read-only sheets stay.
+        final canExit = !_isOffline;
+
+        final entries = <PopupMenuEntry<String>>[
+          if (wear.available)
+            PopupMenuItem(
+              value: 'wear',
+              child: ListTile(
+                leading: const Icon(Icons.luggage_outlined),
+                title: Text(l10n.wearSectionTitle),
+                contentPadding: EdgeInsets.zero,
+              ),
+            ),
+          if (absorbsShare) ...[
+            if (wear.available) const PopupMenuDivider(),
+            ..._shareMenuItems(l10n),
+          ],
+          if (canExit) ...[
+            if (wear.available || absorbsShare) const PopupMenuDivider(),
+            if (trip.isOwner)
+              PopupMenuItem(
+                value: 'delete',
+                child: ListTile(
+                  leading: Icon(Icons.delete_outline,
+                      color: Theme.of(context).colorScheme.error),
+                  title: Text(l10n.tripDeleteTrip,
+                      style: TextStyle(
+                          color: Theme.of(context).colorScheme.error)),
+                  contentPadding: EdgeInsets.zero,
+                ),
+              )
+            else
+              PopupMenuItem(
+                value: 'leave',
+                child: ListTile(
+                  leading: const Icon(Icons.bookmark_remove_outlined),
+                  title: Text(l10n.tripRemoveFromMyTrips),
+                  contentPadding: EdgeInsets.zero,
+                ),
+              ),
+          ],
+        ];
+        if (entries.isEmpty) return const SizedBox.shrink();
+
+        return PopupMenuButton<String>(
+          // share_plus needs a rect to point the iPad popover at, and the
+          // anchor has to be whichever button is actually on screen.
+          key: absorbsShare ? _shareMenuKey : null,
+          icon: const Icon(Icons.more_vert),
+          tooltip: l10n.tripMoreActions,
+          onSelected: (v) {
+            switch (v) {
+              case 'wear':
+                _openWearSheet(trip, wear.regions);
+              case 'delete':
+                _delete();
+              case 'leave':
+                _leaveTrip();
+              default:
+                _onShareMenuSelected(v);
+            }
+          },
+          itemBuilder: (context) => entries,
         );
       },
     );
@@ -5172,15 +5315,18 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
             maxLines: 1,
             overflow: TextOverflow.ellipsis),
         actions: [
-          // Contextual icons lead; share/delete/leave keep the outer-edge
-          // spots for every role. Health goes first: its severity count
-          // badge is glanceable state, worth the leading slot on every
-          // breakpoint. Wear & pack rides beside it — both replaced
-          // trailing-cluster rows, and neither is breakpoint-gated.
+          // The app bar now also carries the ANEMOS wordmark, and a phone
+          // cannot fit five icons beside it — at 360px five actions leave the
+          // title slot ~48px, less than the wordmark itself. So at narrow the
+          // two actions that are already menus/sheets fold into the overflow
+          // (see [_overflowAppBarAction]) and the icon row drops to three.
+          //
+          // The two that keep their icons earned it: health leads because its
+          // severity count is a glanceable badge, and refine is the header
+          // card's own Refine button relocated — narrow drops it down there
+          // (one clean chip row) precisely so the app bar can carry it.
           if (trip != null) _healthAppBarAction(trip, theme),
-          if (trip != null) _wearAppBarAction(trip),
-          // Narrow: the header card drops its Refine button (one clean chip
-          // row), so the trip-level refine entry moves up here.
+          if (trip != null && !_narrow) _wearAppBarAction(trip),
           // Same gates as the button it replaces: editors only
           // (specs/collaborator-refine), disabled — not hidden — offline.
           if (_narrow && trip != null && trip.canEdit)
@@ -5193,78 +5339,15 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
             ),
           // Sharing is an owner-only surface; it mutates, so it's hidden
           // while offline-serving.
-          if (trip != null && trip.isOwner && !_isOffline)
+          if (trip != null && trip.isOwner && !_isOffline && !_narrow)
             PopupMenuButton<String>(
               key: _shareMenuKey,
               icon: const Icon(Icons.share_outlined),
               tooltip: l10n.tripShareTrip,
-              onSelected: (v) => switch (v) {
-                'copy' => _shareLink(),
-                'invite' => _inviteCoPlanner(),
-                'manage' => _manageCoPlanners(),
-                'print' => _openPrintExport(),
-                'calendar' => _openCalendarExport(),
-                _ => _revokeLink(),
-              },
-              itemBuilder: (context) => [
-                PopupMenuItem(
-                    value: 'copy',
-                    child: Text(shareUsesNativeSheet
-                        ? l10n.tripShareLinkAction
-                        : l10n.tripCopyShareLink)),
-                PopupMenuItem(
-                    value: 'invite',
-                    child: Text(shareUsesNativeSheet
-                        ? l10n.tripShareInviteAction
-                        : l10n.tripCopyInviteLink)),
-                PopupMenuItem(
-                    value: 'manage', child: Text(l10n.tripManageAccess)),
-                const PopupMenuDivider(),
-                PopupMenuItem(
-                    value: 'print', child: Text(l10n.tripPrintSavePdf)),
-                PopupMenuItem(
-                    value: 'calendar', child: Text(l10n.tripAddToCalendar)),
-                const PopupMenuDivider(),
-                PopupMenuItem(
-                    value: 'revoke', child: Text(l10n.tripTurnOffSharing)),
-              ],
+              onSelected: _onShareMenuSelected,
+              itemBuilder: (context) => _shareMenuItems(l10n),
             ),
-          // Destructive exits live behind an overflow menu, not a bare
-          // icon: owners get delete, members (editors and viewer follows)
-          // get remove-from-my-list — the owner's trip is untouched. Both
-          // still confirm via their handlers' dialogs.
-          if (trip != null && !_isOffline)
-            PopupMenuButton<String>(
-              icon: const Icon(Icons.more_vert),
-              tooltip: l10n.tripMoreActions,
-              onSelected: (v) => switch (v) {
-                'delete' => _delete(),
-                _ => _leaveTrip(),
-              },
-              itemBuilder: (context) => [
-                if (trip.isOwner)
-                  PopupMenuItem(
-                    value: 'delete',
-                    child: ListTile(
-                      leading: Icon(Icons.delete_outline,
-                          color: Theme.of(context).colorScheme.error),
-                      title: Text(l10n.tripDeleteTrip,
-                          style: TextStyle(
-                              color: Theme.of(context).colorScheme.error)),
-                      contentPadding: EdgeInsets.zero,
-                    ),
-                  )
-                else
-                  PopupMenuItem(
-                    value: 'leave',
-                    child: ListTile(
-                      leading: const Icon(Icons.bookmark_remove_outlined),
-                      title: Text(l10n.tripRemoveFromMyTrips),
-                      contentPadding: EdgeInsets.zero,
-                    ),
-                  ),
-              ],
-            ),
+          if (trip != null) _overflowAppBarAction(trip, l10n),
         ],
       ),
       body: _loading

--- a/src/packages/flutter-app/lib/widgets/brand_logo.dart
+++ b/src/packages/flutter-app/lib/widgets/brand_logo.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import '../constants/app_info.dart';
 import '../theme/app_colors.dart';
 import '../theme/spacing.dart';
 
@@ -7,12 +8,16 @@ import '../theme/spacing.dart';
 /// rendered by scripts/brand-render.sh. (The old horse mark retired with the
 /// Golden Tempo name; the agent persona "Ferdinand" keeps the equine nod.)
 /// Three forms:
-/// - [BrandLogo.lockup] — the full rose + "Anemos" wordmark image, for spots
-///   with horizontal room (app-bar titles).
+/// - [BrandLogo.lockup] — the full rose + "Anemos" wordmark image. Currently
+///   unused: the wordmark is live text ([BrandWordmark]) everywhere, and this
+///   PNG's art sits off-centre on a square canvas, so reintroducing it hangs
+///   ~7pt of dead space below the mark.
 /// - [BrandLogo.mark] — the rose icon only, for tight spots (nav rail,
 ///   landing hero).
 /// - [BrandLogo.markLight] — the reversed rose (white/teal-100 cardinals),
 ///   for teal fields (the boot splash).
+///
+/// The word itself is [BrandWordmark], not part of this class — see there.
 ///
 /// The dark artwork is teal + gold on a transparent background. It floats
 /// bare on page surfaces and scrimmed imagery (auth screen, nav rail, landing
@@ -67,6 +72,111 @@ class BrandLogo extends StatelessWidget {
   }
 }
 
+/// The "Anemos" wordmark as live text, in Cinzel — the brand's one piece of
+/// display type. Cinzel has no true lowercase, so the string stays
+/// [AppInfo.name] and paints as small-caps ANEMOS.
+///
+/// This is deliberately text and not the baked [BrandLogo.lockup] PNG: it
+/// recolors, scales and localizes-around cleanly, and it is the thing the
+/// house app bar carries on every page (see [BrandWordmark] call sites in
+/// `gradient_app_bar.dart`).
+///
+/// The invariants — family, weight, and the string itself — live here. The
+/// tuned values are parameters because caps run wide and each surface was
+/// measured separately: tracking opens up as the size grows (app bar 19/1.0,
+/// landing hero 24–40/1.5).
+///
+/// [color] defaults to **inherited**. Every gradient app bar already sets
+/// `foregroundColor: Colors.white`, so those are white for free, while the
+/// neutral surfaces (auth screen) and dark mode get a readable color without
+/// a hardcoded one fighting them.
+class BrandWordmark extends StatelessWidget {
+  /// The app-bar size, tuned in PR #391 when the wordmark moved to Cinzel.
+  static const double appBarFontSize = 19;
+
+  /// The default tracking. Caps run wide, so callers using a larger size open
+  /// this up — the landing hero and the splash both do.
+  static const double defaultLetterSpacing = 1.0;
+
+  final double fontSize;
+  final double letterSpacing;
+  final Color? color;
+  final double? height;
+  final List<Shadow>? shadows;
+
+  const BrandWordmark({
+    super.key,
+    this.fontSize = appBarFontSize,
+    this.letterSpacing = defaultLetterSpacing,
+    this.color,
+    this.height,
+    this.shadows,
+  });
+
+  /// The style this paints with, exposed so anything that needs to *measure*
+  /// the wordmark uses the exact numbers it renders — see [widthIn].
+  static TextStyle styleOf({
+    double fontSize = appBarFontSize,
+    double letterSpacing = defaultLetterSpacing,
+    Color? color,
+    double? height,
+    List<Shadow>? shadows,
+  }) =>
+      TextStyle(
+        fontFamily: 'Cinzel',
+        fontWeight: FontWeight.w600,
+        fontSize: fontSize,
+        letterSpacing: letterSpacing,
+        height: height,
+        color: color,
+        shadows: shadows,
+      );
+
+  /// How wide the wordmark will actually paint in [context].
+  ///
+  /// Measured, not assumed, because the answer moves: Cinzel may not have
+  /// loaded yet (or at all — in widget tests the fallback runs ~35% wider),
+  /// and the traveler's text-scale setting multiplies it. The app bar's
+  /// layout ladder is arithmetic on this number, so a hardcoded width would
+  /// tip a large-text user's bar into overflow — and a release build does not
+  /// stripe an overflow, it silently cuts the glyphs off, which is the one
+  /// thing the wordmark must never do.
+  static double widthIn(
+    BuildContext context, {
+    double fontSize = appBarFontSize,
+    double letterSpacing = defaultLetterSpacing,
+  }) {
+    final painter = TextPainter(
+      text: TextSpan(
+        text: AppInfo.name,
+        style: styleOf(fontSize: fontSize, letterSpacing: letterSpacing),
+      ),
+      textDirection: Directionality.of(context),
+      textScaler: MediaQuery.textScalerOf(context),
+      maxLines: 1,
+    )..layout();
+    final width = painter.width;
+    painter.dispose();
+    return width;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      AppInfo.name,
+      maxLines: 1,
+      softWrap: false,
+      style: styleOf(
+        fontSize: fontSize,
+        letterSpacing: letterSpacing,
+        color: color,
+        height: height,
+        shadows: shadows,
+      ),
+    );
+  }
+}
+
 /// "A" monogram stand-in for the wind-rose mark when the image asset is
 /// unavailable. Fills the same [size]×[size] square the icon glyph did, so
 /// layout is identical either way. The dark form's black87 tile keeps it
@@ -114,15 +224,10 @@ class _WordmarkFallback extends StatelessWidget {
       children: [
         _MonogramFallback(size: height),
         const SizedBox(width: AppSpacing.sm),
-        Text(
-          'Anemos',
-          style: TextStyle(
-            fontFamily: 'Cinzel',
-            fontWeight: FontWeight.w600,
-            fontSize: height * 0.32,
-            color: Colors.black87,
-            letterSpacing: 0.5,
-          ),
+        BrandWordmark(
+          fontSize: height * 0.32,
+          letterSpacing: 0.5,
+          color: Colors.black87,
         ),
       ],
     );

--- a/src/packages/flutter-app/lib/widgets/gradient_app_bar.dart
+++ b/src/packages/flutter-app/lib/widgets/gradient_app_bar.dart
@@ -1,34 +1,250 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../constants/app_info.dart';
+import '../l10n/l10n.dart';
+import '../navigation/app_nav.dart';
+import '../navigation/shell_scope.dart';
 import '../theme/app_colors.dart';
+import '../theme/spacing.dart';
+import 'brand_logo.dart';
+
+/// The mark's own size in the brand row: the 28px rose, [BrandBadge]'s
+/// horizontal padding, and the gap before the wordmark.
+const double _markSlot = 28 + AppSpacing.sm * 2 + AppSpacing.sm;
+
+/// The brand's tap padding, which is [AppSpacing.xs] on every side.
+const double _brandPadding = AppSpacing.xs * 2;
+
+/// The interpunct and its gaps. Only ever decides whether the *title* fits,
+/// so an approximation of the glyph is fine where the wordmark's is not.
+const double _separatorSlot = AppSpacing.sm * 2 + 8;
+
+/// How much page title is worth putting on screen at all. Below this there is
+/// nothing left to ellipsize down to, so the title is dropped and the brand
+/// takes the slot. The screens where that bites repeat their title in the
+/// body — trip detail does, deliberately.
+const double _minTitleWidth = 56;
 
 /// App bar painted with [AppColors.brandGradient] — the same teal pair used by
 /// the home hero banner. Use in place of [AppBar] so every screen shares one
 /// header look.
-class GradientAppBar extends StatelessWidget implements PreferredSizeWidget {
-  final Widget title;
+///
+/// **This bar carries the brand.** Every screen that uses it shows the ANEMOS
+/// wordmark without doing anything, and no future screen can forget to: the
+/// wordmark is a property of the house app bar, not a convention each screen
+/// re-implements (`docs/zen.md` — explicit over implicit). Pass [title] for the
+/// page's own name; it renders after the brand as `ANEMOS · Page title`. Pass
+/// nothing where the brand *is* the title (Home, Landing).
+///
+/// Three things compete for the title slot, and the priority is fixed:
+///
+/// 1. **The wordmark** — always present, always the same size, never
+///    ellipsized. That is the whole point.
+/// 2. **The page title** — [Flexible], ellipsized, dropped below
+///    [_titleMinWidth].
+/// 3. **The plated mark** — dropped first, and always absent at rail widths,
+///    where `_RailBrand` already shows the rose one corner over on the same
+///    centre line (PR #406). Two roses 80px apart is a duplicate, not a
+///    lockup.
+///
+/// The plate is right here and nowhere else by policy: teal/gold artwork needs
+/// a light plate on gradient chrome and floats bare on neutral surfaces — see
+/// [BrandLogo]'s class doc.
+class GradientAppBar extends ConsumerWidget implements PreferredSizeWidget {
+  /// The page's own title. Null where the brand stands alone.
+  final Widget? title;
   final List<Widget>? actions;
 
-  /// Null inherits the app-wide AppBarTheme (centered); the home screen passes
-  /// false so the brand mark sits on the left.
+  /// Defaults to false: the brand is left-anchored, so the whole title row is
+  /// too. (The app-wide [AppBarTheme] centres titles; this deliberately wins.)
   final bool? centerTitle;
 
-  const GradientAppBar(
-      {super.key, required this.title, this.actions, this.centerTitle});
+  /// A [TabBar] or similar, as on [AppBar.bottom].
+  final PreferredSizeWidget? bottom;
+
+  /// Overrides what tapping the brand does. Home passes one to add its
+  /// scroll-to-top; everything else inside the shell goes [goHome], and
+  /// everything outside it is not tappable at all — see [ShellScope].
+  final VoidCallback? onBrandTap;
+
+  const GradientAppBar({
+    super.key,
+    this.title,
+    this.actions,
+    this.centerTitle,
+    this.bottom,
+    this.onBrandTap,
+  });
 
   @override
-  Size get preferredSize => const Size.fromHeight(kToolbarHeight);
+  Size get preferredSize =>
+      Size.fromHeight(kToolbarHeight + (bottom?.preferredSize.height ?? 0));
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final inShell = ShellScope.of(context);
+    final onTap = onBrandTap ?? (inShell ? () => goHome(ref) : null);
+
     return AppBar(
-      title: title,
+      title: _BrandTitle(title: title, onTap: onTap, inShell: inShell),
       actions: actions,
-      centerTitle: centerTitle,
+      centerTitle: centerTitle ?? false,
+      bottom: bottom,
       backgroundColor: Colors.transparent,
       foregroundColor: Colors.white,
       flexibleSpace: Container(
         decoration: BoxDecoration(gradient: AppColors.brandGradient),
+      ),
+    );
+  }
+}
+
+/// The app bar's title row: the brand, then the page's own title.
+///
+/// The tap target covers the brand only — tapping a page's name should not
+/// navigate — which is also why `Semantics(excludeSemantics: true)` wraps just
+/// the brand. Wrapping the whole row would swallow the page title from screen
+/// readers and hand the title a "Home" button role it does not have.
+class _BrandTitle extends StatelessWidget {
+  final Widget? title;
+  final VoidCallback? onTap;
+
+  /// Whether this bar is inside the persistent shell — which is what decides
+  /// if there is a rail out there to carry the mark. Window width alone would
+  /// be wrong: the signed-out screens (landing, auth, shared trip) are wide
+  /// too, and dropping the mark there leaves it nowhere.
+  final bool inShell;
+
+  const _BrandTitle(
+      {required this.title, required this.onTap, required this.inShell});
+
+  @override
+  Widget build(BuildContext context) {
+    // Measures the true title slot, so the thresholds above are stated in the
+    // width the row actually gets — the tap padding sits inside this, not
+    // around it.
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        // Same measurement the shell uses to decide rail-vs-bar, not the slot
+        // width: whether the rail is on screen is a window question.
+        final railCarriesMark =
+            inShell && MediaQuery.sizeOf(context).width >= kRailBreakpoint;
+
+        // The ladder, as arithmetic on what the wordmark actually measures —
+        // so it holds under a missing font or a large text-scale setting,
+        // where fixed thresholds would silently start clipping.
+        final slot = constraints.maxWidth;
+        final brandCost = _brandPadding + BrandWordmark.widthIn(context);
+        final titleCost = _separatorSlot + _minTitleWidth;
+
+        final showTitle = title != null && slot >= brandCost + titleCost;
+        final showMark = !railCarriesMark &&
+            slot >= brandCost + _markSlot + (showTitle ? titleCost : 0);
+
+        Widget brand = Padding(
+          padding: const EdgeInsets.all(AppSpacing.xs),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              if (showMark) ...const [
+                BrandBadge(
+                  padding: EdgeInsets.symmetric(
+                      horizontal: AppSpacing.sm, vertical: AppSpacing.xs),
+                  // No onTap of its own: one outer InkWell only, or the brand
+                  // hit-tests and ripples twice over the same pixels.
+                  child: BrandLogo.mark(size: 28),
+                ),
+                SizedBox(width: AppSpacing.sm),
+              ],
+              const BrandWordmark(),
+            ],
+          ),
+        );
+
+        // The mark's Image already carries the "Anemos" semantic label and the
+        // wordmark is the literal word, so without excludeSemantics a screen
+        // reader announces this twice.
+        //
+        // container: true makes this a semantics boundary. Without it the
+        // brand's annotations merge with the page title beside it into one
+        // node — announced as a run-on "Anemos Notifications" that also
+        // claims the brand's button role on behalf of the title.
+        brand = Semantics(
+          container: true,
+          button: onTap != null,
+          label: AppInfo.name,
+          excludeSemantics: true,
+          child: brand,
+        );
+
+        if (onTap != null) {
+          brand = Tooltip(
+            message: context.l10n.shellNavHome,
+            child: Material(
+              type: MaterialType.transparency,
+              child: InkWell(
+                onTap: onTap,
+                borderRadius: AppRadius.mdAll,
+                child: brand,
+              ),
+            ),
+          );
+        }
+
+        if (!showTitle) {
+          // Nothing left to compete with, so this is the one place a squeeze
+          // can be absorbed: scale rather than clip. In release builds a
+          // RenderFlex overflow does not stripe, it silently cuts glyphs off —
+          // and a truncated wordmark is the exact failure this widget exists
+          // to prevent. The ladder above is supposed to make this unreachable;
+          // brand_everywhere_test asserts it stays that way.
+          return SizedBox(
+            width: constraints.maxWidth,
+            child: FittedBox(
+              fit: BoxFit.scaleDown,
+              alignment: AlignmentDirectional.centerStart,
+              child: brand,
+            ),
+          );
+        }
+
+        return Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            brand,
+            const _BrandSeparator(),
+            // The 20 screens that pass a bare Text keep ellipsizing correctly
+            // without any of them being edited.
+            Flexible(
+              child: DefaultTextStyle.merge(
+                overflow: TextOverflow.ellipsis,
+                maxLines: 1,
+                child: title!,
+              ),
+            ),
+          ],
+        );
+      },
+    );
+  }
+}
+
+/// The interpunct between the brand and the page title, dimmed so the pairing
+/// reads as "brand, then page" rather than as two equal headings.
+class _BrandSeparator extends StatelessWidget {
+  const _BrandSeparator();
+
+  @override
+  Widget build(BuildContext context) {
+    final color = DefaultTextStyle.of(context).style.color;
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: AppSpacing.sm),
+      child: ExcludeSemantics(
+        child: Text(
+          '·',
+          style: TextStyle(color: color?.withValues(alpha: 0.55)),
+        ),
       ),
     );
   }

--- a/src/packages/flutter-app/test/brand_everywhere_test.dart
+++ b/src/packages/flutter-app/test/brand_everywhere_test.dart
@@ -1,0 +1,288 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:travel_route_planner/constants/app_info.dart';
+import 'package:travel_route_planner/navigation/shell_scope.dart';
+import 'package:travel_route_planner/theme/app_theme.dart';
+import 'package:travel_route_planner/widgets/brand_logo.dart';
+import 'package:travel_route_planner/widgets/gradient_app_bar.dart';
+
+import 'support/l10n_test_app.dart';
+
+/// The ANEMOS wordmark has to be on screen on every page — that is the whole
+/// point of moving the brand into [GradientAppBar], and this is the test that
+/// keeps it true.
+///
+/// It exercises the shared app bar directly rather than pumping twenty
+/// screens, which is affordable precisely *because* the brand lives in one
+/// place now: every screen that uses the house app bar is covered by covering
+/// the house app bar. The matrix is the shapes real screens produce — brand
+/// alone (Home, Landing) vs. brand + page title, across the width range, with
+/// the action counts that actually squeeze the title slot (trip detail's five
+/// icons being the worst case in the app).
+///
+/// Two things are asserted everywhere, and they are the promise: the wordmark
+/// is **present**, and it is **neither truncated nor scaled down**. A brand
+/// that survives as "ANEM…" or as illegibly small type has not survived.
+///
+/// The action counts are a ceiling, not decoration. Five icons fit beside the
+/// wordmark at rail widths and nowhere near it on a phone — which is why trip
+/// detail folds two of its five into the overflow below 800px. Add a fourth
+/// narrow action anywhere and [_narrowActionCounts] is what fails.
+const _widths = <double>[320, 360, 390, 700, 800, 1200];
+const _narrowActionCounts = <int>[0, 2, 3];
+const _wideActionCounts = <int>[0, 2, 5];
+
+/// Below every real device width. The ladder runs out of room here and the
+/// FittedBox backstop in gradient_app_bar.dart takes over: the word still
+/// renders whole, just smaller. Covered separately and deliberately, so the
+/// strict matrix above keeps meaning what it says.
+const double _subPhoneWidth = 230;
+
+Future<void> _pumpBar(
+  WidgetTester tester, {
+  Widget? title,
+  int actions = 0,
+  required double width,
+  bool inShell = true,
+  Locale? locale,
+  double textScale = 1.0,
+}) async {
+  // physicalSize, not setSurfaceSize: the bar gates the mark on MediaQuery
+  // width, which setSurfaceSize does not update.
+  tester.view.physicalSize = Size(width, 800);
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.resetPhysicalSize);
+  addTearDown(tester.view.resetDevicePixelRatio);
+
+  Widget page = Scaffold(
+    appBar: GradientAppBar(
+      title: title,
+      actions: [
+        for (var i = 0; i < actions; i++)
+          IconButton(icon: const Icon(Icons.star), onPressed: () {}),
+      ],
+    ),
+    body: const SizedBox.shrink(),
+  );
+  if (inShell) page = ShellScope(child: page);
+
+  final content = page;
+  await tester.pumpWidget(
+    ProviderScope(
+      child: localizedTestApp(
+        locale: locale,
+        theme: AppTheme.light,
+        home: Builder(
+          builder: (context) => MediaQuery(
+            data: MediaQuery.of(context)
+                .copyWith(textScaler: TextScaler.linear(textScale)),
+            child: content,
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+/// The wordmark's width with all the room in the world — the baseline every
+/// constrained case is held to.
+Future<double> _naturalWidth(WidgetTester tester,
+    {double textScale = 1.0}) async {
+  await _pumpBar(tester, width: 1200, inShell: false, textScale: textScale);
+  return tester.getSize(find.text(AppInfo.name)).width;
+}
+
+/// Present, and laid out at its full natural width — i.e. never ellipsized or
+/// clipped. Says nothing about scale.
+void _expectWordmarkWhole(WidgetTester tester, double natural, String where) {
+  final wordmark = find.text(AppInfo.name);
+  expect(wordmark, findsOneWidget, reason: 'no wordmark at all: $where');
+  expect(tester.getSize(wordmark).width, moreOrLessEquals(natural, epsilon: 0.5),
+      reason: 'wordmark laid out narrower than natural — truncated: $where');
+  expect(tester.takeException(), isNull, reason: 'overflow or throw: $where');
+}
+
+/// The full promise: whole *and* painted at full size.
+void _expectWordmarkFullSize(
+    WidgetTester tester, double natural, String where) {
+  _expectWordmarkWhole(tester, natural, where);
+
+  // getSize is the render box's own (untransformed) size; the difference of
+  // the two corner offsets is the PAINTED extent, because localToGlobal
+  // applies ancestor transforms. Comparing the two is what catches the
+  // FittedBox backstop in gradient_app_bar.dart actually engaging.
+  final wordmark = find.text(AppInfo.name);
+  final painted =
+      tester.getBottomRight(wordmark).dx - tester.getTopLeft(wordmark).dx;
+  expect(painted, moreOrLessEquals(natural, epsilon: 0.5),
+      reason: 'wordmark painted smaller than natural — scaled down: $where');
+}
+
+void main() {
+  testWidgets('the wordmark survives every width, with and without a title',
+      (tester) async {
+    final natural = await _naturalWidth(tester);
+
+    for (final width in _widths) {
+      final counts = width >= 800 ? _wideActionCounts : _narrowActionCounts;
+      for (final actions in counts) {
+        for (final title in [null, const Text('Greece 2026')]) {
+          await _pumpBar(tester, title: title, actions: actions, width: width);
+          _expectWordmarkFullSize(tester, natural,
+              'w=$width actions=$actions title=${title == null ? 'none' : 'yes'}');
+        }
+      }
+    }
+  });
+
+  testWidgets('outside the shell too — the signed-out pages are pages',
+      (tester) async {
+    final natural = await _naturalWidth(tester);
+
+    for (final width in _widths) {
+      await _pumpBar(tester,
+          title: const Text('Connect app'), width: width, inShell: false);
+      _expectWordmarkFullSize(tester, natural, 'outside shell, w=$width');
+    }
+  });
+
+  testWidgets('and in Spanish, whose titles run longer', (tester) async {
+    final natural = await _naturalWidth(tester);
+
+    for (final width in _widths) {
+      await _pumpBar(tester,
+          // The longest app-bar title the app ships (quizTitle, es).
+          title: const Text('Configura tu perfil de viaje'),
+          actions: 2,
+          width: width,
+          locale: const Locale('es'));
+      _expectWordmarkFullSize(tester, natural, 'es, w=$width');
+    }
+  });
+
+  testWidgets('a large text-scale setting does not clip it', (tester) async {
+    // The reason the ladder measures the wordmark instead of comparing the
+    // slot against a constant: accessibility text scaling grows the word but
+    // not a hardcoded threshold, so the bar would quietly start clipping for
+    // exactly the travelers least able to read a clipped word.
+    //
+    // The promise at 1.6x is not "full size" — the tightest bar genuinely has
+    // no room for a 1.6x wordmark. It is: never clipped, and never rendered
+    // SMALLER than the default-scale wordmark. Turning text size up must not
+    // make the brand shrink.
+    const scale = 1.6;
+    final unscaled = await _naturalWidth(tester);
+    final natural = await _naturalWidth(tester, textScale: scale);
+
+    for (final width in _widths) {
+      final counts = width >= 800 ? _wideActionCounts : _narrowActionCounts;
+      for (final actions in counts) {
+        final where = 'textScale=$scale w=$width actions=$actions';
+        await _pumpBar(tester,
+            title: const Text('Greece 2026'),
+            actions: actions,
+            width: width,
+            textScale: scale);
+        _expectWordmarkWhole(tester, natural, where);
+
+        final wordmark = find.text(AppInfo.name);
+        final painted =
+            tester.getBottomRight(wordmark).dx - tester.getTopLeft(wordmark).dx;
+        expect(painted, greaterThanOrEqualTo(unscaled - 0.5),
+            reason: 'large-text setting made the brand smaller: $where');
+      }
+    }
+  });
+
+  testWidgets('below phone widths it shrinks to fit rather than clipping',
+      (tester) async {
+    final natural = await _naturalWidth(tester);
+
+    await _pumpBar(tester, actions: 2, width: _subPhoneWidth);
+    // Whole, but not full size — this is the backstop, and it is the correct
+    // trade at a width no device has: a release build does not stripe a
+    // RenderFlex overflow, it silently cuts the glyphs off.
+    _expectWordmarkWhole(tester, natural, 'sub-phone');
+    final painted = tester.getBottomRight(find.text(AppInfo.name)).dx -
+        tester.getTopLeft(find.text(AppInfo.name)).dx;
+    expect(painted, lessThan(natural));
+    expect(painted, greaterThan(natural * 0.5),
+        reason: 'scaled past legibility');
+  });
+
+  testWidgets('the page title is what yields — ellipsized, then dropped',
+      (tester) async {
+    // Wide: both on screen, brand first.
+    await _pumpBar(tester, title: const Text('Greece 2026'), width: 1200);
+    expect(find.text('Greece 2026'), findsOneWidget);
+    expect(tester.getTopLeft(find.text(AppInfo.name)).dx,
+        lessThan(tester.getTopLeft(find.text('Greece 2026')).dx));
+
+    // Squeezed to nothing: the title goes, the brand stays. Trip detail on
+    // the smallest phone is the real shape here, and it repeats its title in
+    // the body one line down.
+    await _pumpBar(tester,
+        title: const Text('Greece 2026'), actions: 3, width: 320);
+    expect(find.text('Greece 2026'), findsNothing);
+    expect(find.text(AppInfo.name), findsOneWidget);
+  });
+
+  testWidgets('the mark yields before the wordmark does', (tester) async {
+    // Roomy phone bar: plated mark and wordmark together.
+    await _pumpBar(tester, width: 700);
+    expect(find.byType(BrandLogo), findsOneWidget);
+    expect(find.text(AppInfo.name), findsOneWidget);
+
+    // Squeezed — trip detail's three icons on the smallest phone. The mark
+    // goes first; the word is what has to remain.
+    await _pumpBar(tester, actions: 3, width: 320);
+    expect(find.byType(BrandLogo), findsNothing);
+    expect(find.text(AppInfo.name), findsOneWidget);
+  });
+
+  testWidgets('at rail widths the bar drops the mark — the rail has it',
+      (tester) async {
+    await _pumpBar(tester, width: 1200);
+    expect(find.byType(BrandLogo), findsNothing,
+        reason: 'two roses 80px apart is a duplicate, not a lockup');
+    expect(find.text(AppInfo.name), findsOneWidget);
+
+    // ...but only when there IS a rail. The signed-out pages are wide too,
+    // and dropping the mark there leaves it nowhere.
+    await _pumpBar(tester, width: 1200, inShell: false);
+    expect(find.byType(BrandLogo), findsOneWidget);
+  });
+
+  testWidgets('the brand links home inside the shell and is inert outside it',
+      (tester) async {
+    await _pumpBar(tester, width: 700);
+    expect(
+      find.ancestor(
+          of: find.text(AppInfo.name), matching: find.byType(InkWell)),
+      findsOneWidget,
+      reason: 'logo-links-home, and exactly one target over the whole lockup',
+    );
+
+    await _pumpBar(tester, width: 700, inShell: false);
+    expect(
+      find.ancestor(
+          of: find.text(AppInfo.name), matching: find.byType(InkWell)),
+      findsNothing,
+      reason: 'a "Home" tooltip that goes nowhere is a dead affordance',
+    );
+  });
+
+  testWidgets('a page title stays readable to a screen reader', (tester) async {
+    // The brand carries excludeSemantics (the mark and the word would
+    // otherwise announce "Anemos" twice), so the title must sit outside it.
+    final handle = tester.ensureSemantics();
+    await _pumpBar(tester, title: const Text('Notifications'), width: 1200);
+
+    expect(find.bySemanticsLabel('Notifications'), findsOneWidget);
+    expect(find.bySemanticsLabel(AppInfo.name), findsOneWidget);
+    handle.dispose();
+  });
+}

--- a/src/packages/flutter-app/test/home_polish_test.dart
+++ b/src/packages/flutter-app/test/home_polish_test.dart
@@ -7,6 +7,7 @@ import 'package:travel_route_planner/constants/app_info.dart';
 import 'package:travel_route_planner/models/trip.dart';
 import 'package:travel_route_planner/models/user.dart';
 import 'package:travel_route_planner/navigation/app_nav.dart';
+import 'package:travel_route_planner/navigation/shell_scope.dart';
 import 'package:travel_route_planner/providers/auth_provider.dart';
 import 'package:travel_route_planner/providers/live_trip_provider.dart';
 import 'package:travel_route_planner/providers/resumable_chats_provider.dart';
@@ -16,8 +17,9 @@ import 'package:travel_route_planner/widgets/brand_logo.dart';
 import 'support/l10n_test_app.dart';
 
 /// Home polish regressions (UI polish wave 2, PR 9):
-/// - the app bar drops the wordmark for the brand mark alone when the
-///   title slot can't fit it, instead of ellipsizing the brand;
+/// - the app bar's brand ladder: the wordmark is always on screen, and it is
+///   the plated MARK that yields when the title slot narrows (the priority
+///   used to be the other way round, back when only Home carried the brand);
 /// - the compact plan strip's tagline wraps to two lines instead of
 ///   truncating ("Plan less. Trav…").
 class _FakeAuthNotifier extends StateNotifier<AuthState>
@@ -93,7 +95,12 @@ Future<void> _pumpHome(
         liveTripProvider.overrideWithValue(liveTrip),
         resumableChatsProvider.overrideWith((ref) async => const []),
       ],
-      child: localizedTestApp(locale: locale, home: const HomeScreen()),
+      // Inside a ShellScope, because in the app Home always is: it is a tab
+      // root. GradientAppBar reads it to know whether there is a rail out
+      // there carrying the mark — pumped bare, Home would (correctly, but
+      // unrepresentatively) keep its own mark at every width.
+      child: localizedTestApp(
+          locale: locale, home: const ShellScope(child: HomeScreen())),
     ),
   );
   // Extra pumps flush the SharedPreferences read behind recentTripProvider
@@ -116,12 +123,13 @@ void main() {
   });
 
   testWidgets(
-      'tiny app bar drops the wordmark for the brand mark alone — '
-      'no ellipsized wordmark', (WidgetTester tester) async {
+      'tiny app bar drops the MARK and keeps the wordmark — the brand '
+      'name is what has to survive', (WidgetTester tester) async {
     await _pumpHome(tester, surface: const Size(230, 690));
 
-    expect(find.text(AppInfo.name), findsNothing);
-    expect(find.byType(BrandLogo), findsOneWidget);
+    expect(find.text(AppInfo.name), findsOneWidget);
+    expect(find.byType(BrandLogo), findsNothing);
+    expect(tester.takeException(), isNull);
   });
 
   testWidgets(

--- a/src/packages/flutter-app/test/trip_detail_wear_section_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_wear_section_test.dart
@@ -525,15 +525,23 @@ void main() {
     expect(find.byType(WearPackSheetBody), findsNothing);
   });
 
-  testWidgets('icon shows on phone and desktop widths (not narrow-gated)',
-      (tester) async {
+  testWidgets(
+      'phone folds it into the overflow menu; desktop keeps the icon — '
+      'reachable at both widths either way', (tester) async {
+    // The app bar carries the ANEMOS wordmark now, and a phone cannot fit
+    // five icons beside it. Wear & pack is one of the two that fold into the
+    // ⋮ at narrow widths — moved, never dropped.
     await _pump(
       tester,
       trip: _trip(),
       report: _warmRainyForecast,
       size: const Size(390, 800),
     );
-    expect(_wearIcon(), findsOneWidget);
+    expect(_wearIcon(), findsNothing);
+
+    await tester.tap(find.byTooltip('More options'));
+    await tester.pumpAndSettle();
+    expect(find.text('What to wear & pack'), findsOneWidget);
 
     await _pump(
       tester,

--- a/src/packages/flutter-app/web/index.html
+++ b/src/packages/flutter-app/web/index.html
@@ -68,11 +68,31 @@
     Boot splash shown while flutter_bootstrap.js + main.dart.js download and
     the engine starts. Pixel-matched to the in-app SplashScreen (lib/screens/
     splash_screen.dart) — same gradient, mark geometry (96px bare light mark,
-    no plate), and spinner position — so the flutter-first-frame handoff reads
-    as one continuous screen. If you change dimensions here, change
-    splash_screen.dart too.
+    no plate), wordmark, and spinner position — so the flutter-first-frame
+    handoff reads as one continuous screen. If you change dimensions here,
+    change splash_screen.dart too.
+
+    The native mobile splash (flutter_native_splash) deliberately stays
+    mark-only: it cannot render text, and web is the primary surface.
   -->
   <style>
+    @font-face {
+      /* The brand wordmark, from the very same file the Flutter build
+         publishes (it is in FontManifest.json and the service-worker
+         precache), so there is no second copy to keep in sync and no CSP
+         problem: same-origin satisfies `font-src 'self'`, while Google Fonts
+         would be blocked by `style-src` regardless.
+
+         The path is a Flutter build-layout detail. If an engine upgrade
+         reshuffles assets/, this silently falls back to the serif stack
+         below — check here if the splash wordmark ever stops matching. */
+      font-family: 'Cinzel';
+      src: url('assets/assets/fonts/Cinzel-SemiBold.ttf') format('truetype');
+      font-weight: 600;
+      /* This layer paints before flutter_bootstrap.js, so the 40 KB face is a
+         fresh fetch: show the fallback immediately rather than a blank gap. */
+      font-display: swap;
+    }
     html {
       /* Paints before/if the gradient parses — no white flash. */
       background-color: #00695C;
@@ -115,9 +135,28 @@
       from { transform: translate(-50%, -50%) scale(1); }
       to   { transform: translate(-50%, -50%) scale(1.04); }
     }
+    .splash-wordmark {
+      position: absolute;
+      /* Centre line 74px below the mark's, which clears the 96px mark's
+         bottom edge (+48) with room to spare. Deliberately NOT inside
+         .splash-mark: that element pulses, and the wordmark should not. */
+      top: calc(50% + 74px);
+      left: 50%;
+      transform: translate(-50%, -50%);
+      font-family: 'Cinzel', Georgia, 'Times New Roman', serif;
+      font-weight: 600;
+      font-size: 22px;
+      letter-spacing: 3px;
+      /* Cinzel has no lowercase, so it paints caps on its own — the fallback
+         serif does not, and this keeps the font swap from also being a case
+         change. */
+      text-transform: uppercase;
+      color: #FFFFFF;
+      white-space: nowrap;
+    }
     .splash-spinner {
       position: absolute;
-      top: calc(50% + 96px);
+      top: calc(50% + 124px);
       left: 50%;
       width: 24px;
       height: 24px;
@@ -134,8 +173,11 @@
 <body>
   <div id="splash">
     <div class="splash-mark">
-      <img src="splash/anemos_mark_light.png" alt="Anemos">
+      <!-- Empty alt: the wordmark below is the visible, readable name, so a
+           labelled image here would just announce "Anemos" twice. -->
+      <img src="splash/anemos_mark_light.png" alt="">
     </div>
+    <div class="splash-wordmark">Anemos</div>
     <div class="splash-spinner"></div>
   </div>
 


### PR DESCRIPTION
## Why

The ANEMOS wordmark was on **exactly one screen in the signed-in app: Home.** Tap Plan or Trips, open a trip or Travel profile, and the brand name was gone. At desktop widths the rail kept a bare wind-rose, but the *word* appeared nowhere. The product was renamed weeks ago and the site went live on anemos.travel this month, so the name still has to earn recognition — and it was spending almost all of its screen time invisible.

## How

Rather than edit twenty screens, the brand moves **into the one shared `GradientAppBar`** that 20 of the 22 headers already route through. Every existing screen gets it with no per-screen edit, and no future screen can forget: the wordmark becomes a property of the house app bar instead of a convention someone must remember (`docs/zen.md`).

The bar's three claimants now have a fixed priority:

1. **The wordmark** — always present, never truncated.
2. **The page title** — `Flexible`, ellipsized, dropped when there is nothing left worth ellipsizing.
3. **The plated mark** — yields first, and is always absent at rail widths, where `_RailBrand` already shows the rose on the same centre line (#406).

The old rule was the inverse: it dropped the *wordmark* and kept the mark.

The ladder is arithmetic on `BrandWordmark.widthIn`, **measured rather than compared against constants** — Cinzel may not have loaded, and a traveler's text-scale setting multiplies the word but not a hardcoded threshold, so fixed numbers would have started clipping the brand for exactly the people least able to read a clipped word.

### Also in here

- **`BrandWordmark`** extracts the Cinzel text that was duplicated, with drifting values, between the Home app bar and the landing hero.
- **Trip detail folds wear & pack and the share menu into its overflow at narrow widths only.** Five icons on a 360px bar leave a ~48px title slot — less than the wordmark itself. Health (glanceable severity badge) and refine (the header card's relocated button) keep their icons. The trip title is already repeated in the body one line down, so the squeeze costs no wayfinding. Wide is untouched.
- **`ShellScope`** derives brand tappability instead of a per-screen flag. Logo-links-home only means something inside the shell; nine root-navigator screens (landing, auth, splash, SSO, connect, verify, reset, shared trip, fullscreen map) would each have been a chance to forget, and a dead "Home" tooltip is worst on `/share/<token>`, which strangers open.
- **A11y fix:** the page title was being swallowed by the brand's `excludeSemantics` — the two merged into one `"Anemos Notifications"` node that also claimed the brand's button role. Caught by the new test.
- **Admin metrics** joins the house app bar; it was the last screen wearing raw M3 chrome.
- **Auth and both web splashes** gain the wordmark. The static `web/index.html` splash pulls Cinzel same-origin from the Flutter build's own published asset, which `font-src 'self'` allows (Google Fonts is blocked by `style-src`). Native mobile splash stays mark-only by design — it cannot render text, and web is the primary surface.

## Tests

`test/brand_everywhere_test.dart` holds the promise structurally, exercising the shared bar rather than twenty screens: a width x action-count x locale x text-scale matrix asserting the wordmark is present and **neither truncated nor scaled**. Its narrow action counts encode the ceiling — add a fourth narrow action anywhere and it fails.

Updated: `home_polish_test` (the mark/wordmark priority inverted), `trip_detail_wear_section_test` (the icon moves into the overflow at narrow, and is asserted reachable there).

`flutter analyze` clean (3 pre-existing infos in `route_response.dart`, which CI's `--no-fatal-infos` ignores). **1258 tests pass.**

## Verified in a browser

Release web build, real Cinzel, headless Chrome at 1440px and 390px across: Home, Plan, Trips, trip detail, Travel profile, Account settings, Notifications, Local guides, Import, Admin metrics, Local intel admin — plus the signed-out landing page and the pre-Flutter boot splash (where `document.fonts.check('600 22px Cinzel')` confirms the face actually loads).

🤖 Generated with [Claude Code](https://claude.com/claude-code)