### PR TITLE
fix(flutter): stack resets land instantly, and pushes are double-tap guarded

### DIFF
--- a/src/packages/flutter-app/lib/navigation/app_nav.dart
+++ b/src/packages/flutter-app/lib/navigation/app_nav.dart
@@ -35,6 +35,62 @@ Route<T> locatedRoute<T>(Widget page, String location) => MaterialPageRoute<T>(
       builder: (_) => page,
     );
 
+/// [locatedRoute]'s sibling for navigation the user never performed as a
+/// gesture — restoring a page from the URL, or a jump that also switches tabs
+/// (where the tab switch *is* the transition). The page is simply there.
+///
+/// A separate name rather than a flag on [locatedRoute] so which kind of
+/// navigation a call site performs is visible at the call site.
+Route<T> instantRoute<T>(Widget page, String location) => _InstantPageRoute<T>(
+      settings: RouteSettings(name: location),
+      builder: (_) => page,
+    );
+
+/// A page that arrives with no transition. Overrides ONLY [transitionDuration]
+/// — [reverseTransitionDuration] stays the platform's, so backing out of the
+/// page animates like any other pop. (MaterialRouteTransitionMixin re-applies
+/// each onto the controller in didPush/didPop, so overriding the getter holds.)
+class _InstantPageRoute<T> extends MaterialPageRoute<T> {
+  _InstantPageRoute({required super.builder, super.settings});
+
+  @override
+  Duration get transitionDuration => Duration.zero;
+}
+
+/// [nav]'s topmost route, **without popping anything**: [NavigatorState]
+/// exposes no stack getter, but [NavigatorState.popUntil] hands its predicate
+/// the top route and returns having popped nothing when the predicate answers
+/// true. This is a peek — the `true` is load-bearing, not a placeholder.
+Route<dynamic>? _topRouteOf(NavigatorState nav) {
+  Route<dynamic>? top;
+  nav.popUntil((route) {
+    top = route;
+    return true;
+  });
+  return top;
+}
+
+/// Clear [nav] back to its root with NO transition.
+///
+/// A stack reset is bookkeeping, not a gesture: the user asked for the
+/// destination, never to watch the page they left behind slide away. It also
+/// cannot be *popped* from here — the shell freezes hidden tabs' tickers
+/// (app_shell.dart), so a pop started on a tab that is about to be revealed
+/// parks fully painted and then plays its whole exit transition in the user's
+/// face. [NavigatorState.removeRoute] takes each route out immediately
+/// instead, and still reports didRemove — the same bookkeeping TabUrlObserver
+/// already does for didPop (url_sync.dart), so this is URL-transparent.
+void resetToRoot(NavigatorState? nav) {
+  if (nav == null) return;
+  // Bounded only so that no future SDK change can turn this into a hung
+  // frame; removeRoute always shortens the stack, so the guard never trips.
+  for (var i = 0; i < 50; i++) {
+    final top = _topRouteOf(nav);
+    if (top == null || top.isFirst) return;
+    nav.removeRoute(top);
+  }
+}
+
 /// Push [page] onto the currently-selected tab's navigator, so the content area
 /// animates while the persistent rail/bar stays put. Pass [location] when the
 /// page is restorable from a URL (see [locatedRoute]).
@@ -61,14 +117,20 @@ const Set<AppTab> _stackKeepingTabs = {AppTab.trips};
 /// their pushes survive.
 void selectTab(WidgetRef ref, int index) {
   final isActive = ref.read(navIndexProvider) == index;
-  if (isActive || !_stackKeepingTabs.contains(AppTab.values[index])) {
-    // Pop before switching: TabUrlObserver didPop bookkeeping (url_sync.dart)
-    // drains while the old tab is still current, so the only URL report is
-    // the destination tab's root.
-    ref
-        .read(tabNavKeysProvider)[index]
-        .currentState
-        ?.popUntil((r) => r.isFirst);
+  final nav = ref.read(tabNavKeysProvider)[index].currentState;
+  if (isActive) {
+    // Re-tapping the tab you are already on IS the gesture, and it happens on
+    // a tab you can see — so this one pops, and animates, like any other back.
+    nav?.popUntil((r) => r.isFirst);
+  } else if (!_stackKeepingTabs.contains(AppTab.values[index])) {
+    // Remove rather than pop, and before switching. Remove because the
+    // destination tab is still hidden: a pop would freeze mid-flight and then
+    // replay in full the moment the IndexedStack reveals it ([resetToRoot]).
+    // Before, because TabUrlObserver's bookkeeping (url_sync.dart) then drains
+    // while the old tab is still current, so the only URL report is the
+    // destination tab's root — the stale page's location never reaches the
+    // address bar.
+    resetToRoot(nav);
   }
   if (!isActive) {
     ref.read(navIndexProvider.notifier).state = index;
@@ -97,15 +159,20 @@ void pushOnTabWhenReady(List<GlobalKey<NavigatorState>> navKeys, AppTab tab,
 }
 
 /// Open [tripId]'s detail on the Trips tab: the Trips nav item highlights and
-/// back lands on the trips list. Pops the Trips stack to root inside the
-/// (possibly retried) push action — not eagerly — so a previously-open detail
-/// doesn't sit underneath, and the reset happens next to the push that lands.
+/// back lands on the trips list. Resets the Trips stack inside the (possibly
+/// retried) push action — not eagerly — so a previously-open detail doesn't
+/// sit underneath, and the reset happens next to the push that lands.
+///
+/// Both steps are instant. The tab switch is already the transition, and both
+/// run while the Trips tab is still hidden, so an animated reset+push would
+/// freeze and then replay together — the trip you had open sliding out from
+/// under the one you just asked for.
 void openTripOnTripsTab(WidgetRef ref, String tripId) {
   ref.read(navIndexProvider.notifier).state = AppTab.trips.index;
   final navKeys = ref.read(tabNavKeysProvider);
   pushOnTabWhenReady(navKeys, AppTab.trips, () {
-    navKeys[AppTab.trips.index].currentState?.popUntil((r) => r.isFirst);
-    return locatedRoute(
+    resetToRoot(navKeys[AppTab.trips.index].currentState);
+    return instantRoute(
         TripDetailScreen(tripId: tripId), tripDetailLocation(tripId));
   });
 }
@@ -115,13 +182,13 @@ void openTripOnTripsTab(WidgetRef ref, String tripId) {
 /// list, and the URL reports /import (whose refresh restores onto Trips).
 /// The import screen's success replace-navigates to the new trip's detail,
 /// which must land on the stack-keeping Trips tab, not whichever tab hosted
-/// the entry point.
+/// the entry point. Instant for the same reason as [openTripOnTripsTab].
 void openImportOnTripsTab(WidgetRef ref) {
   ref.read(navIndexProvider.notifier).state = AppTab.trips.index;
   final navKeys = ref.read(tabNavKeysProvider);
   pushOnTabWhenReady(navKeys, AppTab.trips, () {
-    navKeys[AppTab.trips.index].currentState?.popUntil((r) => r.isFirst);
-    return locatedRoute(
+    resetToRoot(navKeys[AppTab.trips.index].currentState);
+    return instantRoute(
         const ImportTripScreen(), utilityLocation(BootUtility.importTrip));
   });
 }

--- a/src/packages/flutter-app/lib/navigation/app_nav.dart
+++ b/src/packages/flutter-app/lib/navigation/app_nav.dart
@@ -94,6 +94,13 @@ void resetToRoot(NavigatorState? nav) {
 /// Push [page] onto the currently-selected tab's navigator, so the content area
 /// animates while the persistent rail/bar stays put. Pass [location] when the
 /// page is restorable from a URL (see [locatedRoute]).
+///
+/// No double-tap guard here: [isTopRoute] answers about the CALLER's route,
+/// which this helper cannot see — and its main caller, the rail account menu,
+/// renders outside the tab navigators entirely, so the answer would be about
+/// the wrong navigator. Callers that live on the tab's top route (the
+/// notification card) guard themselves; menu items need no guard because
+/// selecting one dismisses the menu.
 void pushOnActiveTab(WidgetRef ref, Widget page, {String? location}) {
   final keys = ref.read(tabNavKeysProvider);
   final state = keys[ref.read(navIndexProvider)].currentState;
@@ -101,6 +108,45 @@ void pushOnActiveTab(WidgetRef ref, Widget page, {String? location}) {
       ? MaterialPageRoute(builder: (_) => page)
       : locatedRoute(page, location));
 }
+
+/// Whether [context]'s route is still the one on top of its navigator — i.e.
+/// nothing has been pushed since the tap now being handled.
+///
+/// **This is the double-tap guard.** Nothing in this app debounces taps, and
+/// [NavigatorState.push] flushes its history synchronously, so a second tap
+/// already sees the button's own route stop being current. Two pushes leave a
+/// duplicate screen stacked under an opaque one — invisible until "back"
+/// returns you to the page you were already looking at.
+///
+/// Flutter half-covers this itself and says so: `_cancelActivePointers`
+/// (navigator.dart) flips the navigator's AbsorbPointer on when a route
+/// changes between frames, under a comment reading "This mechanism is far from
+/// perfect" (flutter#4770). It only holds for the rest of that inter-frame
+/// gap — it does nothing for a handler that pushes **after an await**, which
+/// is the reachable case here (see `_signIn` in connect_app_screen.dart, where
+/// the second call would also wipe the pending token the first one saved), nor
+/// for a push issued from inside a frame.
+///
+/// Answers about [context]'s OWN navigator, so it cannot see a push onto a
+/// different one (a `rootNavigator: true` push from inside a tab — see
+/// `_openFullMap` in trip_detail_screen.dart, which guards on the root
+/// navigator directly). Fails open when there is no route at all: a missing
+/// guard must never be able to block navigation outright.
+bool isTopRoute(BuildContext context) =>
+    ModalRoute.of(context)?.isCurrent ?? true;
+
+/// Push [route] onto [context]'s navigator unless a push already landed
+/// ([isTopRoute]) — in which case nothing happens and the future completes
+/// with null.
+///
+/// Handlers that do more than push — cleanup after the await, a refetch, a
+/// saved token to clear — must test [isTopRoute] and return early themselves
+/// instead, so that trailing work is skipped too rather than running against
+/// the navigation the first tap started.
+Future<T?> pushOnce<T extends Object?>(BuildContext context, Route<T> route) =>
+    isTopRoute(context)
+        ? Navigator.of(context).push(route)
+        : Future<T?>.value();
 
 /// Tabs whose pushed stack survives switching away and back via a nav
 /// button: selecting the tab returns you to where you left it (e.g. the trip

--- a/src/packages/flutter-app/lib/navigation/url_sync.dart
+++ b/src/packages/flutter-app/lib/navigation/url_sync.dart
@@ -205,15 +205,19 @@ class UrlSyncController {
     final utility = target.utility;
     final chatId = target.chatId;
     final navKeys = _ref.read(tabNavKeysProvider);
+    // instantRoute, not locatedRoute: restoring a page from the URL is not a
+    // gesture. The page the address bar named should be there when the user
+    // looks, rather than the tab root showing first and the restored page
+    // sliding in over it once pushOnTabWhenReady lands.
     if (tripId != null) {
       pushOnTabWhenReady(
           navKeys,
           target.tab,
-          () => locatedRoute(
+          () => instantRoute(
               TripDetailScreen(tripId: tripId), tripDetailLocation(tripId)));
     } else if (utility != null) {
       pushOnTabWhenReady(navKeys, target.tab,
-          () => locatedRoute(_utilityScreen(utility), utilityLocation(utility)));
+          () => instantRoute(_utilityScreen(utility), utilityLocation(utility)));
     } else if (chatId != null) {
       // Fire-and-forget: success rehydrates planProvider (the Plan tab —
       // already selected above — renders it, and the chatId listener restores

--- a/src/packages/flutter-app/lib/screens/agent_screen.dart
+++ b/src/packages/flutter-app/lib/screens/agent_screen.dart
@@ -53,13 +53,17 @@ class _AgentScreenState extends ConsumerState<AgentScreen> {
   /// singleton ApiClient (the token mutates in place).
   void _openSignIn() {
     warmSsoAvailability(context);
-    Navigator.of(context).push(
+    pushOnce(
+      context,
       MaterialPageRoute(builder: (_) => const AuthScreen()),
     );
   }
 
   void _openTrip(String tripId) {
-    Navigator.of(context).push(
+    // pushOnce: the banner and the chat's own "view trip" both land here, so
+    // this is reachable twice in a frame from two different widgets.
+    pushOnce(
+      context,
       locatedRoute(
           TripDetailScreen(tripId: tripId), tripDetailLocation(tripId)),
     );

--- a/src/packages/flutter-app/lib/screens/app_shell.dart
+++ b/src/packages/flutter-app/lib/screens/app_shell.dart
@@ -63,6 +63,14 @@ class AppShell extends ConsumerWidget {
             // GlobalKeys mounted — deliberately NOT unmounting or swapping
             // placeholders, and NOT keyed off ModalRoute.isCurrent (a hidden
             // tab's top route still reports current).
+            //
+            // The catch, and it bites: a nested Navigator is the vsync for its
+            // own route transitions and sits INSIDE this TickerMode, so a
+            // push or pop started on a hidden tab does not advance — it parks
+            // fully painted and then plays its whole transition the moment
+            // this IndexedStack reveals the tab. Anything that changes a
+            // hidden tab's stack must therefore remove routes, never pop
+            // them: see resetToRoot and instantRoute (app_nav.dart).
             TickerMode(
               enabled: i == index,
               child: _TabNavigator(

--- a/src/packages/flutter-app/lib/screens/connect_app_screen.dart
+++ b/src/packages/flutter-app/lib/screens/connect_app_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import '../l10n/l10n.dart';
+import '../navigation/app_nav.dart';
 import '../providers/api_client_provider.dart';
 import '../providers/auth_provider.dart';
 import '../services/connect_app_service.dart';
@@ -99,6 +100,11 @@ class _ConnectAppScreenState extends ConsumerState<ConnectAppScreen> {
   /// Hands off to sign-in, remembering the request first so the browser can
   /// come back here even when SSO replaces the whole page.
   Future<void> _signIn() async {
+    // Early return, not pushOnce: this method both saves the pending request
+    // and clears it after the push returns, so a blocked second call must not
+    // fall through — it would wipe the token the first call just saved. The
+    // auto-trigger in build() and the visible button can both land here.
+    if (!isTopRoute(context)) return;
     // Before any await, while this context is still current.
     warmSsoAvailability(context);
     _promptedSignIn = true;

--- a/src/packages/flutter-app/lib/screens/guides_screen.dart
+++ b/src/packages/flutter-app/lib/screens/guides_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../l10n/l10n.dart';
 import '../models/local_guide.dart';
+import '../navigation/app_nav.dart';
 import '../providers/local_provider.dart';
 import '../theme/app_colors.dart';
 import '../theme/spacing.dart';
@@ -130,7 +131,8 @@ class _GuideListTile extends StatelessWidget {
                 overflow: TextOverflow.ellipsis,
               ),
         trailing: const Icon(Icons.chevron_right),
-        onTap: () => Navigator.of(context).push(
+        onTap: () => pushOnce(
+          context,
           MaterialPageRoute(
             builder: (_) => LocalGuideDetailScreen(guide: guide),
           ),

--- a/src/packages/flutter-app/lib/screens/home_screen.dart
+++ b/src/packages/flutter-app/lib/screens/home_screen.dart
@@ -576,7 +576,8 @@ class _LocalGuidesRow extends ConsumerWidget {
         SectionHeader(
           title: context.l10n.homeLocalGuidesTitle,
           action: TextButton(
-            onPressed: () => Navigator.of(context).push(
+            onPressed: () => pushOnce(
+              context,
               locatedRoute(
                   const GuidesScreen(), utilityLocation(BootUtility.guides)),
             ),
@@ -627,7 +628,8 @@ class _GuideCard extends StatelessWidget {
         child: InkWell(
           // Unnamed on purpose: the screen takes the full guide object, so a
           // URL couldn't reconstruct it — refresh lands on the page beneath.
-          onTap: () => Navigator.of(context).push(
+          onTap: () => pushOnce(
+            context,
             MaterialPageRoute(
               builder: (_) => LocalGuideDetailScreen(guide: guide),
             ),

--- a/src/packages/flutter-app/lib/screens/landing_screen.dart
+++ b/src/packages/flutter-app/lib/screens/landing_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../l10n/l10n.dart';
+import '../navigation/app_nav.dart';
 import '../providers/analytics_provider.dart';
 import '../providers/auth_provider.dart';
 import '../theme/app_colors.dart';
@@ -58,7 +59,8 @@ class _LandingScreenState extends State<LandingScreen> {
     // Start the SSO availability fetches now so the route transition covers
     // the round trip and the auth form doesn't get shoved down on arrival.
     warmSsoAvailability(context);
-    Navigator.of(context).push(
+    pushOnce(
+      context,
       MaterialPageRoute(
         builder: (_) => AuthScreen(initialIsLogin: isLogin),
       ),

--- a/src/packages/flutter-app/lib/screens/notification_center_screen.dart
+++ b/src/packages/flutter-app/lib/screens/notification_center_screen.dart
@@ -195,13 +195,20 @@ class _NotificationTile extends ConsumerWidget {
   /// rows (the monitor fans out over `ListAdminUsers`), and the screen it
   /// opens is enforced by `adminMiddleware` server-side regardless. A second,
   /// client-side notion of who is an admin would be a duplicated derivation.
-  VoidCallback? _tapAction(WidgetRef ref) => switch (notification.type) {
-        'ops_alert' || 'ops_recovered' => () => pushOnActiveTab(
+  VoidCallback? _tapAction(BuildContext context, WidgetRef ref) =>
+      switch (notification.type) {
+        'ops_alert' || 'ops_recovered' => () {
+            // This card sits on the active tab's top route, so pushOnActiveTab
+            // targets the very navigator isTopRoute reports on — a rapid
+            // double tap would otherwise stack two admin screens.
+            if (!isTopRoute(context)) return;
+            pushOnActiveTab(
               ref,
               const AdminMetricsScreen(
                   initialTabIndex: AdminMetricsScreen.healthTabIndex),
               location: utilityLocation(BootUtility.adminMetrics),
-            ),
+            );
+          },
         _ => null,
       };
 
@@ -241,7 +248,7 @@ class _NotificationTile extends ConsumerWidget {
       // squares off the corners.
       clipBehavior: Clip.antiAlias,
       child: InkWell(
-        onTap: _tapAction(ref),
+        onTap: _tapAction(context, ref),
         child: Padding(
           padding: const EdgeInsets.all(AppSpacing.lg),
           child: Row(

--- a/src/packages/flutter-app/lib/screens/shared_trip_screen.dart
+++ b/src/packages/flutter-app/lib/screens/shared_trip_screen.dart
@@ -180,11 +180,13 @@ class _SharedTripBodyState extends ConsumerState<_SharedTripBody> {
       // than betting on one frame and silently dropping the push. Deferred a
       // frame so the push can't land on a navigator the reset just discarded.
       // If every attempt misses, the user still lands on the Trips tab where
-      // the joined trip now shows.
+      // the joined trip now shows. instantRoute because this is a deep link
+      // landing, not a gesture: after the whole-app reset the trip should be
+      // on screen, not slide in over a freshly-remounted trips list.
       WidgetsBinding.instance.addPostFrameCallback((_) => pushOnTabWhenReady(
           navKeys,
           AppTab.trips,
-          () => locatedRoute(
+          () => instantRoute(
               TripDetailScreen(tripId: tripId), tripDetailLocation(tripId))));
     } catch (e) {
       if (mounted) {

--- a/src/packages/flutter-app/lib/screens/shared_trip_screen.dart
+++ b/src/packages/flutter-app/lib/screens/shared_trip_screen.dart
@@ -131,7 +131,12 @@ class _SharedTripBodyState extends ConsumerState<_SharedTripBody> {
   Future<bool> _ensureSignedIn() async {
     if (ref.read(authProvider).isSignedIn) return true;
     warmSsoAvailability(context);
-    await Navigator.of(context).push(
+    // pushOnce: Join and Save-a-copy both route through here and neither sets
+    // its _saving flag until this returns, so a double tap would otherwise
+    // stack two auth screens. A blocked call returns not-signed-in, which
+    // makes the caller bail — correct, since the first tap owns the flow.
+    await pushOnce(
+      context,
       MaterialPageRoute(builder: (_) => const AuthScreen()),
     );
     return ref.read(authProvider).isSignedIn;

--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -2595,7 +2595,9 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
       margin: const EdgeInsets.symmetric(vertical: AppSpacing.xs),
       clipBehavior: Clip.antiAlias,
       child: InkWell(
-        onTap: () => Navigator.of(context).push(MaterialPageRoute(
+        onTap: () => pushOnce(
+            context,
+            MaterialPageRoute(
               builder: (_) => LocalGuideDetailScreen(guide: guide),
             )),
         child: Padding(
@@ -5224,9 +5226,16 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
   /// covers the bottom navigation bar; the closures read the live [_trip] so
   /// a silent refresh propagates on the next chip tap.
   void _openFullMap(Trip trip) {
+    final rootNav = Navigator.of(context, rootNavigator: true);
+    // Double-tap guard, and the one place isTopRoute cannot serve: it answers
+    // about THIS tab's navigator, where the detail stays current no matter
+    // what lands on the root one. The root navigator holds only the shell
+    // (main.dart's one-initial-route invariant), so anything poppable there
+    // is already covering it — including the map a first tap just opened.
+    if (rootNav.canPop()) return;
     final derivation = _derive(trip);
     final endpoints = derivation.homeLegEndpoints;
-    Navigator.of(context, rootNavigator: true).push(
+    rootNav.push(
       MaterialPageRoute(
         fullscreenDialog: true,
         // Escape closes the map when focus rests on the route's own scope
@@ -5998,15 +6007,17 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
             todoKey: todo.todoKey,
             kind: todo.kind,
           );
-          Navigator.of(context).push(MaterialPageRoute(
-            builder: (_) => FlightSearchScreen(
-              prefillOrigin: leg.origin,
-              prefillDestination: leg.destination,
-              prefillDepartDate: leg.date,
-              prefillOriginCoord: leg.originCoord,
-              prefillDestinationCoord: leg.destCoord,
-            ),
-          ));
+          pushOnce(
+              context,
+              MaterialPageRoute(
+                builder: (_) => FlightSearchScreen(
+                  prefillOrigin: leg.origin,
+                  prefillDestination: leg.destination,
+                  prefillDepartDate: leg.date,
+                  prefillOriginCoord: leg.originCoord,
+                  prefillDestinationCoord: leg.destCoord,
+                ),
+              ));
         };
       }
     }

--- a/src/packages/flutter-app/lib/screens/trips_list_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trips_list_screen.dart
@@ -394,6 +394,9 @@ String _pastSummary(Trip trip, AppLocalizations l10n) {
 
 Future<void> _openTrip(
     BuildContext context, WidgetRef ref, String tripId) async {
+  // Guarded here rather than with pushOnce so the resync below is skipped
+  // too: a second tap that opened nothing must not refetch the list.
+  if (!isTopRoute(context)) return;
   await Navigator.of(context).push(
     locatedRoute(TripDetailScreen(tripId: tripId), tripDetailLocation(tripId)),
   );

--- a/src/packages/flutter-app/test/double_tap_push_guard_test.dart
+++ b/src/packages/flutter-app/test/double_tap_push_guard_test.dart
@@ -1,0 +1,91 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:travel_route_planner/navigation/app_nav.dart';
+
+/// The double-tap guard (isTopRoute / pushOnce, app_nav.dart): two pushes
+/// leave a duplicate screen stacked under an opaque one, so it looks fine
+/// until "back" lands on the page you were already looking at.
+///
+/// Both cases below pop once and assert the destination is GONE — the stacked
+/// duplicate is invisible to a finder while it sits under an opaque route, so
+/// "exactly one on screen" would pass either way.
+///
+/// Deliberately NOT tested through a real double tap on a trip card: Flutter's
+/// own `_cancelActivePointers` absorbs the second pointer when a route changes
+/// between frames, so such a test passes with the guard removed and would pin
+/// nothing. What it does not cover — a push after an await — is case two, and
+/// that is the shape this app actually reaches (connect_app_screen `_signIn`).
+void main() {
+  Widget harness(GlobalKey<NavigatorState> navKey, VoidCallback onPressed) =>
+      MaterialApp(
+        navigatorKey: navKey,
+        home: Scaffold(
+          body: Center(
+            child: TextButton(onPressed: onPressed, child: const Text('go')),
+          ),
+        ),
+      );
+
+  Route<void> pushedRoute() =>
+      MaterialPageRoute<void>(builder: (_) => const Text('pushed'));
+
+  testWidgets('pushOnce drops a second push, and does not wedge later ones',
+      (tester) async {
+    final navKey = GlobalKey<NavigatorState>();
+    late BuildContext ctx;
+    await tester.pumpWidget(harness(navKey, () {
+      // Twice from one handler: the guard's job without any dependence on
+      // gesture timing.
+      pushOnce(ctx, pushedRoute());
+      pushOnce(ctx, pushedRoute());
+    }));
+    ctx = tester.element(find.text('go'));
+
+    await tester.tap(find.text('go'));
+    await tester.pumpAndSettle();
+    expect(find.text('pushed'), findsOneWidget);
+
+    navKey.currentState!.pop();
+    await tester.pumpAndSettle();
+    expect(find.text('pushed'), findsNothing,
+        reason: 'a second route was stacked underneath');
+    expect(find.text('go'), findsOneWidget);
+
+    // Not sticky: the next tap pushes normally.
+    await tester.tap(find.text('go'));
+    await tester.pumpAndSettle();
+    expect(find.text('pushed'), findsOneWidget);
+  });
+
+  testWidgets('a push after an await is guarded too', (tester) async {
+    // The case Flutter's pointer-absorb cannot reach: nothing has changed in
+    // the route stack at tap time, so both taps are delivered, and only the
+    // guard stops the second handler from pushing when it wakes up.
+    final navKey = GlobalKey<NavigatorState>();
+    final gate = Completer<void>();
+    late BuildContext ctx;
+    await tester.pumpWidget(harness(navKey, () async {
+      await gate.future;
+      pushOnce(ctx, pushedRoute());
+    }));
+    ctx = tester.element(find.text('go'));
+
+    await tester.tap(find.text('go'));
+    await tester.pump();
+    await tester.tap(find.text('go'));
+    await tester.pump();
+
+    gate.complete();
+    await tester.pumpAndSettle();
+    expect(find.text('pushed'), findsOneWidget);
+
+    navKey.currentState!.pop();
+    await tester.pumpAndSettle();
+    expect(find.text('pushed'), findsNothing,
+        reason: 'both parked handlers pushed');
+    expect(find.text('go'), findsOneWidget);
+  });
+}

--- a/src/packages/flutter-app/test/home_open_trip_on_trips_tab_test.dart
+++ b/src/packages/flutter-app/test/home_open_trip_on_trips_tab_test.dart
@@ -126,6 +126,22 @@ void main() {
     await tester.pumpAndSettle();
 
     await tester.tap(find.byType(LiveTripCard));
+    // One frame, no settling: the reset and the push are both instant, so on
+    // the frame the Trips tab appears there is exactly ONE detail on it. Both
+    // steps run while that tab is still hidden, where the shell freezes
+    // tickers (app_shell.dart) — animated, they would park and then replay
+    // together, the trip you had open sliding out from under the one you
+    // asked for.
+    await tester.pump();
+    expect(find.byType(TripDetailScreen, skipOffstage: false), findsOneWidget,
+        reason: 'the previously-open trip must be gone, not sliding out');
+    expect(
+        tester
+            .widget<TripDetailScreen>(
+                find.byType(TripDetailScreen, skipOffstage: false))
+            .tripId,
+        't3');
+
     await tester.pumpAndSettle();
     expect(reports.last, '/trips/t3');
 

--- a/src/packages/flutter-app/test/nav_tab_reset_test.dart
+++ b/src/packages/flutter-app/test/nav_tab_reset_test.dart
@@ -111,6 +111,58 @@ void main() {
     expect(reports.sublist(reportsAfterTrips), isNot(contains('/preferences')));
   });
 
+  testWidgets('the Home button leaves nothing behind to animate away',
+      (tester) async {
+    // The artifact this pins: selectTab used to POP the destination tab's
+    // stack, and the shell freezes hidden tabs' tickers (app_shell.dart), so
+    // that pop parked fully painted and then played its whole exit transition
+    // the moment the IndexedStack revealed the tab — you tapped Home and
+    // watched a page you had left there slide away. The case above cannot see
+    // it because pumpAndSettle pumps straight past it, so assert on the very
+    // next frame instead. skipOffstage: false because the contract is that
+    // the route is GONE, not merely hidden.
+    final container = await pumpApp(tester);
+
+    container
+        .read(tabNavKeysProvider)[AppTab.home.index]
+        .currentState!
+        .push(locatedRoute(
+            const Scaffold(body: Text('stacked on home')), '/preferences'));
+    await tester.pumpAndSettle();
+
+    await tester.tap(railDestination('Trips'));
+    await tester.pumpAndSettle();
+
+    await tester.tap(railDestination('Home'));
+    await tester.pump();
+    expect(find.text('stacked on home', skipOffstage: false), findsNothing,
+        reason: 'the stale page must already be gone, not mid-transition');
+  });
+
+  testWidgets('re-tapping the active tab still animates its pop',
+      (tester) async {
+    // The other half of selectTab's split: a re-tap happens on a tab you can
+    // see and IS the gesture, so it keeps the ordinary animated pop. Same
+    // single-frame probe as above, with the opposite expectation.
+    final container = await pumpApp(tester);
+
+    container
+        .read(tabNavKeysProvider)[AppTab.home.index]
+        .currentState!
+        .push(locatedRoute(
+            const Scaffold(body: Text('stacked on home')), '/preferences'));
+    await tester.pumpAndSettle();
+
+    await tester.tap(railDestination('Home'));
+    await tester.pump();
+    expect(find.text('stacked on home', skipOffstage: false), findsOneWidget,
+        reason: 'a re-tap pops with a transition, so the page is still there');
+
+    await tester.pumpAndSettle();
+    expect(find.text('stacked on home', skipOffstage: false), findsNothing);
+    expect(reports.last, '/');
+  });
+
   testWidgets('the rail brand mark taps through to the Home root',
       (tester) async {
     // Logo-links-home through the real rail: the brand mark at the top of the

--- a/src/packages/flutter-app/test/url_boot_restore_test.dart
+++ b/src/packages/flutter-app/test/url_boot_restore_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -93,6 +94,19 @@ void main() {
     expect(read(tester, navIndexProvider), AppTab.trips.index);
     expect(find.byType(ImportTripScreen), findsOneWidget);
     expect(reports.last, '/import');
+  });
+
+  testWidgets('a restored page lands, it does not slide in', (tester) async {
+    // A URL restore is not a gesture, so url_sync.dart uses instantRoute: the
+    // page the address bar named is simply there, instead of the tab root
+    // showing first and the page sliding in over it once pushOnTabWhenReady
+    // lands. Only the ENTRY is instant — backing out of the restored page
+    // must still animate like any other pop.
+    await pumpApp(tester, initialUrl: '/trips/t1', user: fakeUser());
+
+    final route = ModalRoute.of(tester.element(find.byType(TripDetailScreen)))!;
+    expect(route.transitionDuration, Duration.zero);
+    expect(route.reverseTransitionDuration, isNot(Duration.zero));
   });
 
   testWidgets('an unknown path behaves like the plain catch-all',


### PR DESCRIPTION
Two related navigation fixes. Both come down to the same thing: navigation the user did not perform as a gesture should not behave like one.

## 1. Stack resets land instantly

Fixes Brian's report: *"Sometimes screen transitions are a bit buggy. Old screen scrolls in for a half second then scrolls out."* Both numbers turned out to be literal — on macOS (what Flutter web reports for Chrome on a Mac) `MaterialPageRoute` resolves to `CupertinoPageTransitionsBuilder`: a horizontal slide of exactly **500 ms**.

**Root cause: two individually-correct commits meeting.** `2e537c1` froze hidden tabs' tickers for perf; #331 made nav buttons land on the page they name by having `selectTab` `popUntil` the **destination** tab before flipping `navIndexProvider`. A nested `Navigator` is the vsync for its own route transitions and sits *inside* that `TickerMode` — so the pop never advanced. The exiting page parked fully painted, and its whole 500 ms exit then played the instant the `IndexedStack` revealed the tab. You tapped Home and watched a page you had left there slide away. "Sometimes" = only when the destination tab had a stack, i.e. Home and Plan.

- `resetToRoot` **removes** routes (`NavigatorState.removeRoute` is documented immediate) rather than popping them, so there is no animation left to freeze. URL-transparent: `TabUrlObserver` already treats `didRemove` exactly like `didPop`, and the removal still drains *before* the index flips, so the stale page's location still never reaches the address bar.
- `instantRoute` overrides **only** `transitionDuration` — backing out of a page still animates like any other pop.
- Applied to `selectTab`, `openTripOnTripsTab` / `openImportOnTripsTab` (which popped **and** pushed in one frame on a hidden tab — the trip you had open slid out from under the one you asked for), the URL boot restore, and the shared-trip join landing.
- The `TickerMode` comment now carries the trap, since that is what a future reader hits first.

Deliberately unchanged: transition **style** stays Flutter's per-OS default, and `ImportTripScreen`'s success `pushReplacement` stays animated — a user action completing on a visible tab is exactly the case that should still slide.

## 2. Pushes are guarded against a double tap

The item the first commit listed as not covered. No push in the app had re-entrancy protection, so two landing close together leave a duplicate screen stacked under an opaque one — invisible until "back" returns you to the page you were already looking at.

`isTopRoute(context)` answers "has a push already landed since this tap?"; `pushOnce` wraps it for the plain tap-to-push sites. Handlers that do more than push (a refetch after the await, a saved token to clear) test `isTopRoute` and return early instead, so the trailing work is skipped too.

**What Flutter already does, and where it stops** — worth stating, because it changed the shape of the tests: `Navigator._cancelActivePointers` flips an `AbsorbPointer` on when a route changes between frames, under a comment reading *"This mechanism is far from perfect"* (flutter#4770), and it resets the next frame. It does nothing for a handler that pushes **after an await** — the reachable case here: `connect_app_screen._signIn` saves the pending request, awaits, then pushes, and a second call would clear the token the first one just saved.

`_openFullMap` is the one site `isTopRoute` cannot serve (it pushes onto the **root** navigator while the context's own tab route stays current), so it guards on the root navigator having nothing over the shell. Left alone on purpose: `pushOnActiveTab` (its main caller, the rail account menu, renders outside the tab navigators, so a route-local answer would be about the wrong navigator — and menu selection dismisses the menu), and `SnackBarAction`, already single-shot in the framework.

## Testing

- `flutter test` — **1263 tests green**. `flutter analyze --no-fatal-infos --fatal-warnings` — only the 3 pre-existing `route_response.dart` infos.
- **Every new assertion was verified to fail without its fix**, by reverting the fix and re-running:
  - `nav_tab_reset_test.dart` — "Found 1 widget with text 'stacked on home'": the stale page still mounted a frame after the Home tap.
  - `home_open_trip_on_trips_tab_test.dart` — "Found 2 widgets with type TripDetailScreen": the old trip really was sliding out under the new one.
  - `url_boot_restore_test.dart` — `transitionDuration` 300 ms, not zero.
  - `double_tap_push_guard_test.dart` — "a second route was stacked underneath" / "both parked handlers pushed".
- The transition tests probe a **single frame**, because `pumpAndSettle` pumps straight past the artifact. The guard tests **pop once and assert the destination is gone**, because a stacked duplicate is invisible while it sits under an opaque route. A companion test pins that re-tapping the active tab *still* animates, and that the guard is not sticky.
- **A test I wrote and then deleted, deliberately**: a real double tap on a trip card. The framework's pointer-absorb eats the second tap there, so it passed with the guard removed — it would have looked like proof and been none. Replaced with the async-gap case, which does fail without the guard.
- **Browser-verified** on the lane stack (headless Chrome + CDP, SSO-handoff login): Home → open Notifications → Trips → Home now shows a clean Home root on the very first frame. Control, to prove the harness can see a transition at all: an ordinary push and an ordinary back-pop were both caught mid-slide in the same setup. Reload on `/notifications` restores in-shell and renders correctly.

**Knowingly not covered** (documented in code): a transition *already in flight* when you leave a tab — a mid-pop route is no longer "present" so `resetToRoot` can't see it, and on stack-keeping Trips a frozen push just resumes. Both need sub-500 ms timing, and no public API force-completes a route transition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)