### PR TITLE
fix(gateway): stop serving Flutter's mutable assets as immutable

### DIFF
--- a/dockerize/deployment/Dockerfile
+++ b/dockerize/deployment/Dockerfile
@@ -89,6 +89,46 @@ RUN sed -i 's/origin\.length + 1/origin.length + 5/g' build/web/flutter_service_
     && grep -q 'origin.length + 5' build/web/flutter_service_worker.js \
     && ! grep -q 'origin\.length + 1' build/web/flutter_service_worker.js
 
+# One-time content-cache eviction for clients poisoned while nginx still served
+# /app/assets/ as `immutable` (see app-locations.conf). activate() only drops a
+# cached entry when its RESOURCES md5 differs between the OLD and NEW manifest,
+# so once a client stored stale bytes under the CURRENT hash, nothing will ever
+# evict them: the hash is already "right". Renaming the manifest cache makes
+# activate() take its no-prior-manifest branch, which opens with
+# `caches.delete(CACHE_NAME)` — Flutter's own first-install path — nuking the
+# poisoned content cache exactly once per bump. Renaming CACHE_NAME instead
+# would orphan that whole multi-MB cache in storage forever; this leaks only
+# the ~4 KB old manifest cache. Idempotent on later deploys: the manifest
+# exists under the new name, so the normal diff path resumes. Bump the suffix
+# again only if this class ever recurs.
+RUN sed -i "s/'flutter-app-manifest'/'flutter-app-manifest-v2'/" build/web/flutter_service_worker.js \
+    && grep -q "const MANIFEST = 'flutter-app-manifest-v2';" build/web/flutter_service_worker.js \
+    && ! grep -q "'flutter-app-manifest'" build/web/flutter_service_worker.js
+
+# Send every service-worker cache MISS to the network instead of to the
+# browser's HTTP cache. The stock fetch handler falls back to a default-mode
+# `fetch(event.request)`, which the HTTP cache answers — and a client that
+# stored an asset while the header still said `max-age=31536000, immutable`
+# keeps that copy for a YEAR whatever the origin sends afterwards, because a
+# stored response's freshness lifetime is fixed at store time and the client
+# never revalidates, so it never learns the new header. `reload` bypasses that
+# entry AND overwrites it with the network response, healing the poisoned
+# HTTP-cache entry on the same request; `no-cache` mode would not, since a
+# stale ETag can still earn a 304.
+#
+# Only the cache-miss site is patched, NOT onlineFirst()'s twin: that one
+# serves the navigation request, and passing any init coerces a navigate-mode
+# Request to same-origin, changing redirect handling for no benefit
+# (index.html is uncached at the edge and already revalidates). downloadOffline()
+# is deliberately left alone too — nothing posts it that message, so it is dead
+# code in this app.
+#
+# This does NOT bypass Cloudflare, which ignores client Cache-Control/Pragma
+# request headers — which is why the fix shipped alongside an edge purge.
+RUN sed -i 's/return response || fetch(event\.request)/return response || fetch(event.request, {cache: "reload"})/' build/web/flutter_service_worker.js \
+    && grep -q 'fetch(event.request, {cache: "reload"})' build/web/flutter_service_worker.js \
+    && ! grep -q 'return response || fetch(event\.request)\.' build/web/flutter_service_worker.js
+
 # Serve static files and proxy API via nginx. alpine-slim is the base the
 # stock nginx:alpine image is built FROM by adding a ~50 MB dynamic-module
 # layer (xslt, geoip, image-filter, njs, acme) that no config here loads —

--- a/dockerize/deployment/nginx/snippets/app-locations.conf
+++ b/dockerize/deployment/nginx/snippets/app-locations.conf
@@ -166,10 +166,23 @@ location /app/ {
 # App-shell files that change IN PLACE on every deploy — flutter build does
 # NOT content-hash their filenames (verified against a real build/web output),
 # so they must never be immutable. `no-cache` (not no-store) lets browsers
-# keep a copy but forces ETag revalidation, so returning visitors pick up a
-# new release on the next load. index.html is also the try_files fallback for
-# /app/ deep links and bare /app/, which land here via internal redirect.
-# Headers repeated: add_header is not inherited between blocks.
+# keep a copy but forces ETag revalidation. index.html is also the try_files
+# fallback for /app/ deep links and bare /app/, which land here via internal
+# redirect. Headers repeated: add_header is not inherited between blocks.
+#
+# What the CLIENT actually sees is split, because Cloudflare's Browser Cache
+# TTL (4 h default) rewrites `no-cache` for any extension it caches:
+# index.html/version.json/manifest.json are `.html`/`.json`, which Cloudflare
+# does not cache, so they arrive `no-cache` intact; the four .js members arrive
+# `max-age=14400`. The edge revalidates against us either way, so a new deploy
+# is always available — but a returning browser can hold .js for up to 4 h.
+# Three of the four are immune anyway: main.dart.js and flutter_bootstrap.js
+# sit in the service worker's CORE list, which install() fetches with
+# {'cache': 'reload'}, and flutter_service_worker.js is exempt because browsers
+# bypass the HTTP cache when checking a worker script for updates. Only
+# flutter.js is genuinely exposed, and it is SDK loader boilerplate that
+# changes on Flutter upgrades. Do not drop a file from CORE while relying on
+# this block alone.
 location ~ ^/app/(?:index\.html|flutter_service_worker\.js|flutter_bootstrap\.js|main\.dart\.js|flutter\.js|version\.json|manifest\.json)$ {
     add_header Cache-Control "no-cache";
     add_header Cross-Origin-Embedder-Policy require-corp;
@@ -177,15 +190,49 @@ location ~ ^/app/(?:index\.html|flutter_service_worker\.js|flutter_bootstrap\.js
     include /etc/nginx/snippets/security-headers.conf;
 }
 
-# Long-lived caching ONLY for the service-worker-managed resource trees
-# (fonts live under assets/). Their URLs are stable across deploys;
-# flutter_service_worker.js (no-cache above) owns their versioning via its
-# content-hash manifest and re-fetches entries whose hash changed. Anything
-# else that used to match a blanket *.js/*.css/... extension rule (e.g.
-# favicon.png, splash/) now falls through to the /app/ prefix block and gets
-# default ETag-validated caching instead of being pinned for a year.
+# Service-worker-managed resource trees (fonts live under assets/). These are
+# NEVER `immutable`: flutter build web does not content-hash these filenames,
+# so the URLs are stable while the BYTES change on any deploy that alters the
+# asset set — notably MaterialIcons-Regular.otf, which --release re-tree-shakes
+# to only the codepoints the code statically references.
+#
+# This block used to pin them for a year and delegate versioning to
+# flutter_service_worker.js. That does not work, and the failure is silent and
+# permanent. The service worker CAN detect the change — activate() drops an
+# entry whose manifest hash moved — but it then re-downloads with a
+# DEFAULT-mode fetch, which is answered by the browser HTTP cache and by
+# Cloudflare: the very caches this header just pinned. It stores the STALE
+# bytes under the NEW hash, and no future deploy will ever evict them, because
+# the hash is now "correct". Staleness becomes self-certifying.
+# Cost, 2026-08-14: Cloudflare served a pre-#419 icon font for five deploys and
+# three icons rendered blank in prod (settings, calendar_month, edit_calendar).
+#
+# `no-cache` (not no-store) keeps the browser copy but forces ETag
+# revalidation. The service-worker cache is the real long-lived cache for
+# repeat visitors — the HTTP layer's only job is to not defeat its
+# invalidation. A short max-age is NOT a middle ground: because the SW cache is
+# sticky, any nonzero TTL turns a brief serving window into permanent
+# corruption for every client that loads inside it.
+#
+# canvaskit/ is included deliberately. Today it is never requested —
+# flutter_bootstrap.js carries no useLocalCanvasKit, so CanvasKit loads from
+# gstatic — but flipping to local CanvasKit under `immutable` would pin a 7 MB
+# wasm against a fresh main.dart.js, which is a white screen rather than a
+# missing glyph. Disarmed in advance, at zero measured cost.
+#
+# Anything that used to match a blanket *.js/*.css/... extension rule (e.g.
+# favicon.png, splash/) falls through to the /app/ prefix block and gets
+# default ETag-validated caching.
+#
+# NOTE: Cloudflare's Browser Cache TTL (4 h default) rewrites a `no-cache`
+# response into `max-age=14400` for the browser whenever the extension is one
+# it caches — the edge still revalidates against us, so the edge cannot go
+# stale, and the service worker's {cache: "reload"} fetch (see the Dockerfile
+# patch) bypasses that browser copy, so it cannot poison the SW cache either.
+# The residual is cosmetic: returning visitors may run a build up to 4 h old.
+# Setting Browser Cache TTL to "Respect Existing Headers" removes it.
 location ~ ^/app/(?:assets|canvaskit|icons)/ {
-    add_header Cache-Control "public, max-age=31536000, immutable";
+    add_header Cache-Control "no-cache";
     add_header Cross-Origin-Embedder-Policy require-corp;
     add_header Cross-Origin-Opener-Policy same-origin;
     include /etc/nginx/snippets/security-headers.conf;

--- a/docs/branding/README.md
+++ b/docs/branding/README.md
@@ -75,6 +75,11 @@ Historical gotcha this table exists to prevent: og-card and badge_4x were
 missing from the old README's table, so they silently kept two-brands-ago art
 (a metronome!) through two renames. If you add a brand asset, add its row.
 
-Cache note: `/app/icons/*` is served `immutable` for a year (nginx) — when the
-art changes, bump the `?v=N` query in `web/index.html`, `web/manifest.json`,
-and `print_view_handler.go`.
+Cache note: `/app/icons/*` is served `no-cache` (nginx), so a changed icon
+propagates on the next load without help. It used to be `immutable` for a year,
+which is why the `?v=N` query exists in `web/index.html`, `web/manifest.json`
+and `print_view_handler.go` — those are now belt-and-braces rather than the
+mechanism, and are still worth bumping for anything a browser may have cached
+from before 2026-08-15. (The `immutable` header was removed because Flutter
+does not content-hash these filenames; see
+`dockerize/deployment/nginx/snippets/app-locations.conf`.)

--- a/src/packages/flutter-app/web/index.html
+++ b/src/packages/flutter-app/web/index.html
@@ -48,7 +48,8 @@
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black">
   <meta name="apple-mobile-web-app-title" content="Anemos">
-  <!-- ?v=2 busts nginx's year-long immutable cache on /app/icons/* (Anemos art) -->
+  <!-- ?v=2 dates from when nginx served /app/icons/* immutable for a year; it
+       is now no-cache, so this is belt-and-braces for pre-2026-08-15 caches. -->
   <link rel="apple-touch-icon" href="icons/Icon-192.png?v=2">
 
   <!-- Favicon: ?v=2 because Chrome's favicon cache is keyed by URL and


### PR DESCRIPTION
The **Settings** row in the account menu renders a blank space where its gear should be. The widget is fine — `account_menu.dart:154` passes `Icons.settings_outlined` and #419 is live. Cloudflare has been handing every browser an icon font subset built *before* that PR.

### Measured

| | edge (what browsers get) | origin (current build) |
|---|---|---|
| md5 | `809c6fbc…` | `b56585c7…` |
| bytes | 28 124 | 28 580 |
| glyphs | 215 | 217 |
| `last-modified` | **Fri 14 Aug 18:22 UTC** | Sat 15 Aug 02:24 UTC |
| has `0xf36e` | **no** | yes |

Nine hours and five deploys stale (`cf-cache-status: HIT`, `age: 32740`). **Three** icons are blank, not one — every codepoint the old subset lacks: `settings_outlined`, `calendar_month_outlined` (`log_trip_screen.dart:249`), `edit_calendar_outlined` (`trips_list_screen.dart:136`, `:361`). Not a local browser issue: a fresh incognito window is equally broken.

### Cause

We promised something the build does not keep. Flutter does not content-hash asset filenames, so `/app/assets/` URLs are stable while the bytes change — and we served them `immutable` for a year on the theory that the service worker owns versioning. It can't: `activate()` does evict the entry whose hash moved, but the re-download is a **default-mode fetch**, answered by the browser HTTP cache and Cloudflare — the very caches that header pinned. The worker stores the stale bytes under the *new* hash, and no later deploy will ever evict them, because the hash is now "correct". Staleness certified itself.

Which file broke was luck. The at-risk set is *"extension Cloudflare caches + stable URL + mutates per deploy"* — the icon font, `AssetManifest.bin`, `canvaskit/`, any image replaced in place. `AssetManifest.bin` would have silently broken newly-added images instead.

### Change

- **nginx** — `/app/(assets|canvaskit|icons)/` now `no-cache`. The SW cache is the real long-lived cache; the HTTP layer's job is to not defeat its invalidation. A short `max-age` is *not* a middle ground: the SW cache is sticky, so any nonzero TTL turns a brief window into permanent corruption for whoever loads inside it. `canvaskit/` swept in deliberately — unreachable today (CanvasKit loads from gstatic), but going local under `immutable` pairs a 7 MB wasm with a fresh `main.dart.js`, which is a white screen not a missing glyph.
- **Two guarded seds** (joining the base-href patch) to repair already-poisoned clients, which the header alone cannot reach. Renaming the manifest cache sends `activate()` down its no-prior-manifest branch, opening with `caches.delete(CACHE_NAME)` — Flutter's own first-install path — wiping the bad cache exactly once; renaming `CACHE_NAME` would orphan it in storage forever. The cache-miss fetch takes `{cache: "reload"}`, the only way past an entry stored under `max-age=31536000` (freshness is fixed at store time, so such a client never revalidates and never learns the new header); `reload` also writes through, healing the entry on the same request. `onlineFirst()` untouched (any init coerces its navigate-mode request to same-origin); `downloadOffline()` untouched (nothing posts it that message — dead code here).
- Corrected three stale comments that named the year-long cache as current fact.

### Verified

- Built the gateway image: exit 0, both sed guards pass, and the resulting font is **byte-identical to what the origin already serves**.
- `nginx:1.31-alpine-slim` over the real confs: `no-cache` on the font/wasm/icon trees with COEP + security headers intact, and `immutable` on no `/app/` path.

### Deploy notes

- Cloudflare needs **one purge** to drop the year-pinned object. Purge *before* this reaches clients — the rescue is one-shot, and a client that wipes its cache and refetches from a still-stale edge is permanently re-poisoned. `{cache: "reload"}` can't help: CF ignores client `Cache-Control`/`Pragma`.
- A poisoned browser's **first** load after this still paints blank (old worker controls the page while the new one installs); it heals on the second.
- The CI gate asserting edge bytes == origin bytes follows in a separate PR, so it can't race the purge into a red deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)