### PR TITLE
fix(bookings): stop deriving a leg's identity from its airport

### DIFF
--- a/src/packages/api/booking_draft_handler.go
+++ b/src/packages/api/booking_draft_handler.go
@@ -21,6 +21,16 @@ type DraftStay struct {
 	CheckOut *string `json:"check_out"`
 }
 
+// DraftTransport's auto_key is the ONE place the endpoint-labelled
+// `transport:<a>>><b>` grammar still doubles as an identity (booking_todos
+// moved off it in 00064). Deliberately frozen rather than canonicalized: no
+// current client posts to this endpoint, so surviving rows are legacy and are
+// never re-derived — which means they can never be pruned by a label change
+// either. _computeGroupedBookings matches them on the CITY side of the key
+// (endsWith '>><city>' / startsWith 'transport:<city>>>') with an origin/
+// destination equality fallback, so a stale endpoint label costs nothing.
+// If this endpoint is ever revived, canonicalize it through
+// classifyDerivedTodos instead of growing a second grammar.
 type DraftTransport struct {
 	AutoKey     string  `json:"auto_key"` // transport:<a>>><b>
 	Mode        string  `json:"mode"`

--- a/src/packages/api/booking_todo_handler.go
+++ b/src/packages/api/booking_todo_handler.go
@@ -59,9 +59,11 @@ type BookingTodoResponse struct {
 
 func toBookingTodoResponse(t store.BookingTodo) BookingTodoResponse {
 	return BookingTodoResponse{
-		ID:         t.ID.String(),
-		Kind:       t.Kind,
-		TodoKey:    t.TodoKey,
+		ID:   t.ID.String(),
+		Kind: t.Kind,
+		// The endpoint-labelled key, not the storage key — see
+		// displayBookingTodoKey (booking_todo_identity.go).
+		TodoKey:    displayBookingTodoKey(t),
 		Title:      t.Title,
 		Subtitle:   t.Subtitle,
 		Provider:   t.Provider,
@@ -170,6 +172,13 @@ func strPtrOrNil(s string) *string {
 // syncBookingTodosHandler upserts the client's itinerary-derived auto-TODOs and
 // prunes any auto rows whose legs no longer exist, preserving the booked flag
 // across syncs. Returns the full ordered list.
+//
+// Two things happen here that the client cannot do for itself (00064):
+// classifyDerivedTodos rewrites the two home legs onto their canonical @home
+// keys, so whoever posts — a stale tab, an old cached bundle, a collaborator's
+// device — lands on the SAME row; and the home legs' endpoint labels are then
+// taken from the TRIP rather than from the poster, so a collaborator's saved
+// airport can no longer retitle the owner's flights.
 func syncBookingTodosHandler(w http.ResponseWriter, r *http.Request) {
 	trip, ok := editableTrip(w, r)
 	if !ok {
@@ -183,13 +192,26 @@ func syncBookingTodosHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	q := store.New(dbPool)
+	idents := classifyDerivedTodos(derived)
+	// The owner's saved airport is the last rung of the endpoint ladder, so it
+	// is read only when a home leg exists and the trip states nothing itself.
+	var departureLabel, arrivalLabel string
+	if hasHomeLeg(idents) {
+		var ownerHome *string
+		if strings.TrimSpace(strPtrVal(trip.Origin)) == "" && strings.TrimSpace(strPtrVal(trip.OriginAirport)) == "" {
+			if prefs, err := q.GetPreferences(r.Context(), trip.UserID); err == nil {
+				ownerHome = prefs.HomeAirport
+			}
+		}
+		departureLabel, arrivalLabel = tripEndpointLabels(trip, ownerHome)
+	}
 	keys := make([]string, 0, len(derived))
 	// One batch upsert instead of a round trip per row. The batch statement
 	// cannot touch the same (trip_id, todo_key) twice, so duplicate keys are
 	// collapsed last-wins — the same final state sequential upserts produced.
 	rows := make([]store.UpsertBookingTodoParams, 0, len(derived))
 	rowIdx := make(map[string]int, len(derived))
-	for _, d := range derived {
+	for i, d := range derived {
 		kind := strings.TrimSpace(d.Kind)
 		if !allowedBookingKinds[kind] || strings.TrimSpace(d.TodoKey) == "" || strings.TrimSpace(d.Title) == "" {
 			writeJSONError(w, http.StatusBadRequest, "each todo needs a valid kind, todo_key, and title")
@@ -205,12 +227,28 @@ func syncBookingTodosHandler(w http.ResponseWriter, r *http.Request) {
 			writeJSONError(w, http.StatusBadRequest, "return_date must be YYYY-MM-DD")
 			return
 		}
-		url, provider := bookingSearchURL(kind, d.Destination, d.Origin, d.DepartDate, d.ReturnDate, d.Guests, d.Passengers, d.Provider)
+		ident := idents[i]
+		// The endpoints actually stored. For the two home legs the trip's own
+		// answer overrides whatever the posting device derived — that is the
+		// whole point of holding the endpoints on the trip. Resolved BEFORE
+		// the link builders so the search URL, the title and the labels can
+		// never disagree with each other.
+		origin, destination := d.Origin, d.Destination
+		title := strings.TrimSpace(d.Title)
+		switch {
+		case ident.role == roleHomeOutbound && departureLabel != "":
+			origin = &departureLabel
+			title = departureLabel + " → " + destination
+		case ident.role == roleHomeReturn && arrivalLabel != "":
+			destination = arrivalLabel
+			title = strPtrVal(origin) + " → " + arrivalLabel
+		}
+		url, provider := bookingSearchURL(kind, destination, origin, d.DepartDate, d.ReturnDate, d.Guests, d.Passengers, d.Provider)
 		if kind == "transport" && strPtrVal(d.Provider) == "ferry" {
 			// pickProviderLink has no ferry candidate, so the fallback would
 			// store google_flights for a derived ferry leg; keep the ferry
 			// provider and its Ferryhopper deep link instead.
-			if u, p := transportModeLink("ferry", d.Destination, d.Origin, d.DepartDate, d.Passengers); u != "" {
+			if u, p := transportModeLink("ferry", destination, origin, d.DepartDate, d.Passengers); u != "" {
 				url, provider = u, p
 			}
 		}
@@ -219,24 +257,27 @@ func syncBookingTodosHandler(w http.ResponseWriter, r *http.Request) {
 			providerPtr = d.Provider
 		}
 		row := store.UpsertBookingTodoParams{
-			TripID:     tripID,
-			Kind:       kind,
-			TodoKey:    d.TodoKey,
-			Title:      strings.TrimSpace(d.Title),
-			Subtitle:   d.Subtitle,
-			Provider:   providerPtr,
-			SearchUrl:  strPtrOrNil(url),
-			DepartDate: depart,
-			ReturnDate: ret,
-			Position:   int32(d.Position),
+			TripID:           tripID,
+			Kind:             kind,
+			TodoKey:          ident.key,
+			Title:            title,
+			Subtitle:         d.Subtitle,
+			Provider:         providerPtr,
+			SearchUrl:        strPtrOrNil(url),
+			DepartDate:       depart,
+			ReturnDate:       ret,
+			Position:         int32(d.Position),
+			Role:             strPtrOrNil(ident.role),
+			OriginLabel:      strPtrOrNil(strPtrVal(origin)),
+			DestinationLabel: strPtrOrNil(destination),
 		}
-		if i, seen := rowIdx[d.TodoKey]; seen {
-			rows[i] = row
+		if j, seen := rowIdx[ident.key]; seen {
+			rows[j] = row
 		} else {
-			rowIdx[d.TodoKey] = len(rows)
+			rowIdx[ident.key] = len(rows)
 			rows = append(rows, row)
 		}
-		keys = append(keys, d.TodoKey)
+		keys = append(keys, ident.key)
 	}
 	if len(rows) > 0 {
 		if err := q.UpsertBookingTodosBatch(r.Context(), upsertBookingTodosBatchParams(tripID, rows)); err != nil {
@@ -245,6 +286,17 @@ func syncBookingTodosHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Demote before delete, and never the other way round: a stale row the
+	// traveler has booked, given a mode, or spent money against becomes an
+	// ordinary manual row (it then falls outside the DELETE, which only sees
+	// auto rows) instead of being destroyed along with its expense link.
+	if _, err := q.DemoteStaleAutoBookingTodos(r.Context(), store.DemoteStaleAutoBookingTodosParams{
+		TripID: tripID,
+		Keys:   keys,
+	}); err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "could not prune booking todos")
+		return
+	}
 	if _, err := q.DeleteStaleAutoBookingTodos(r.Context(), store.DeleteStaleAutoBookingTodosParams{
 		TripID: tripID,
 		Keys:   keys,
@@ -254,6 +306,17 @@ func syncBookingTodosHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeBookingTodos(w, r, tripID)
+}
+
+// hasHomeLeg reports whether any posted row was recognized as a journey
+// endpoint — the only case where the trip's endpoint labels are needed.
+func hasHomeLeg(idents []derivedIdentity) bool {
+	for _, id := range idents {
+		if isHomeRole(id.role) {
+			return true
+		}
+	}
+	return false
 }
 
 // upsertBookingTodosBatchParams flattens per-row upsert params into the
@@ -276,6 +339,11 @@ func upsertBookingTodosBatchParams(tripID uuid.UUID, rows []store.UpsertBookingT
 		DepartDates:    make([]pgtype.Date, len(rows)),
 		ReturnDates:    make([]pgtype.Date, len(rows)),
 		Positions:      make([]int32, len(rows)),
+		// role/origin_label/destination_label need no null mask: the statement
+		// NULLIFs the empty string, and a label has no meaningful empty value.
+		Roles:             make([]string, len(rows)),
+		OriginLabels:      make([]string, len(rows)),
+		DestinationLabels: make([]string, len(rows)),
 	}
 	for i, r := range rows {
 		p.Kinds[i] = r.Kind
@@ -299,6 +367,9 @@ func upsertBookingTodosBatchParams(tripID uuid.UUID, rows []store.UpsertBookingT
 		p.DepartDates[i] = r.DepartDate
 		p.ReturnDates[i] = r.ReturnDate
 		p.Positions[i] = r.Position
+		p.Roles[i] = strPtrVal(r.Role)
+		p.OriginLabels[i] = strPtrVal(r.OriginLabel)
+		p.DestinationLabels[i] = strPtrVal(r.DestinationLabel)
 	}
 	return p
 }
@@ -561,7 +632,9 @@ func patchBookingTodoHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	if req.Booked != nil && *req.Booked {
 		user, _ := userFromContext(r.Context())
-		meta := map[string]any{"kind": todo.Kind, "todo_key": todo.TodoKey}
+		// The endpoint-labelled key, so this event stays comparable with the
+		// years of booking_marked_booked rows recorded before 00064.
+		meta := map[string]any{"kind": todo.Kind, "todo_key": displayBookingTodoKey(todo)}
 		if todo.Provider != nil {
 			meta["provider"] = *todo.Provider
 		}

--- a/src/packages/api/booking_todo_identity.go
+++ b/src/packages/api/booking_todo_identity.go
@@ -1,0 +1,238 @@
+package main
+
+import (
+	"strings"
+
+	"travel-route-planner/store"
+)
+
+// booking_todo_identity.go — what makes a derived checklist row THE SAME ROW
+// across syncs (migration 00064).
+//
+// A derived leg used to be identified by its endpoint labels:
+// `transport:<origin>>><dest>`, where the origin token was whatever the
+// renderer had on hand — trips.origin, or failing that the VIEWER's saved home
+// airport. Label and identity were the same string, so changing the label
+// changed the key, and the prune deleted the row: booked flag, per-leg mode
+// override, manual position and the linked expense's source all went with it.
+// That fired on an ordinary Settings edit of a home airport, and on any
+// collaborator opening a shared trip.
+//
+// Now the two home legs key on a reserved token whose POSITION carries the
+// direction, and the labels are content:
+//
+//	home_outbound  transport:@home>>amsterdam   origin_label="ALB"
+//	home_return    transport:rome>>@home        destination_label="EWR"
+//	inter_city     transport:paris>>rome        (key unchanged)
+//	stay           stay:paris                   (key unchanged)
+//
+// Because the key no longer names an airport, changing one is an in-place
+// title/label update that UpsertBookingTodosBatch already performs — booked,
+// auto and mode are deliberately outside its DO UPDATE set. And because the
+// token's position distinguishes the directions, a trip can leave from ALB and
+// come home into EWR without the two legs colliding.
+//
+// The canonical form is computed HERE, server-side, from the posted payload —
+// never sent by the client. That is what makes a stale tab, an old cached
+// bundle, or a collaborator's device land on the same row instead of pruning
+// it, and it is why this change needs no client flag day.
+//
+// The client is deliberately NOT asked to label its own rows. It would be the
+// more direct source ("refuse the temptation to guess"), but a posted role is
+// a second writer of identity that every old bundle would omit anyway, so the
+// inference below has to exist and be correct regardless — and two paths that
+// can disagree is the failure mode this file exists to end. The inference is
+// not really a guess: it is a total function of the payload, using the rule
+// stayCitySet already applies, over rows the client builds outbound-first and
+// return-last.
+
+// homeEndpointToken stands in for "wherever this trip starts or ends" inside a
+// derived transport key. `@` rather than a bare word: namesAPlace accepts
+// "home" as a city name and would leak it into traveler-facing copy, while `@`
+// cannot occur in an IATA code or a Google Places city label — so one prefix
+// guard covers every reserved token we ever add.
+const homeEndpointToken = "@home"
+
+// The closed vocabulary of booking_todos.role. Home roles are paired with the
+// key shape by CHECK constraints (00064), so a wrong canonicalization fails at
+// write time instead of storing a plausible-looking wrong row.
+const (
+	roleHomeOutbound = "home_outbound"
+	roleHomeReturn   = "home_return"
+	roleInterCity    = "inter_city"
+	roleStay         = "stay"
+)
+
+// transportTodoKey builds a derived transport row's key from its two endpoint
+// tokens. The single definition of the `transport:a>>b` grammar — its Dart twin
+// is _deriveTodos in trip_detail_screen.dart, pinned by the parity fixtures.
+func transportTodoKey(origin, destination string) string {
+	return "transport:" + strings.ToLower(strings.TrimSpace(origin)) + ">>" + strings.ToLower(strings.TrimSpace(destination))
+}
+
+// isDerivedTransportKey reports whether a key speaks the itinerary-derived leg
+// grammar (`transport:<a>>><b>`). Custom, agent-added and legacy rows use other
+// shapes and are left exactly as posted.
+func isDerivedTransportKey(key string) bool {
+	rest, ok := strings.CutPrefix(key, "transport:")
+	if !ok {
+		return false
+	}
+	a, b, found := strings.Cut(rest, ">>")
+	return found && a != "" && b != ""
+}
+
+// isHomeRole reports whether a role names one of the two journey endpoints.
+func isHomeRole(role string) bool {
+	return role == roleHomeOutbound || role == roleHomeReturn
+}
+
+// derivedIdentity is one posted row's canonical identity.
+type derivedIdentity struct {
+	role string
+	// key is the STORAGE key. It differs from what the client posted only for
+	// the two home legs; displayBookingTodoKey maps it back for the wire.
+	key string
+}
+
+// classifyDerivedTodos assigns a role and a canonical storage key to every
+// posted row, in posted order.
+//
+// The rule is the one stayCitySet already states for generating copy — a
+// transport endpoint outside the trip's stay cities is a home leg, and an EMPTY
+// stay set never reads as home — promoted here from copy-generation to
+// identity, so there is one definition rather than two that can drift. It is
+// restricted to the FIRST and LAST transport row because that is
+// _deriveTodos' construction order: outbound before the city loop, return
+// after it.
+//
+// Everything is computed from the payload alone, with no reference to the
+// trip's current origin or the traveler's saved airport, so a sync that races
+// an origin change still lands on the same row.
+func classifyDerivedTodos(derived []DerivedBookingTodo) []derivedIdentity {
+	out := make([]derivedIdentity, len(derived))
+	stayCities := make(map[string]bool)
+	transportIdx := make([]int, 0, len(derived))
+	for i, d := range derived {
+		kind := strings.TrimSpace(d.Kind)
+		out[i] = derivedIdentity{role: roleInterCity, key: d.TodoKey}
+		switch kind {
+		case "stay":
+			out[i].role = roleStay
+			if c := strings.ToLower(strings.TrimSpace(d.Destination)); c != "" {
+				stayCities[c] = true
+			}
+		case "transport":
+			// Only rows that already speak the derived-leg grammar are
+			// candidates. A transport row keyed some other way is not part of
+			// the itinerary derivation (an agent- or hand-added leg, or an
+			// older client's private key), so rewriting its identity would be
+			// a rename nobody asked for — and it must not count toward
+			// "first"/"last" either.
+			if isDerivedTransportKey(d.TodoKey) {
+				transportIdx = append(transportIdx, i)
+			}
+		default:
+			// "other" rows carry no leg semantics; role stays inter_city and
+			// the key is whatever the client sent.
+			out[i].role = ""
+		}
+	}
+	// No stay rows means no itinerary to be outside of, so nothing can be
+	// recognized as a home leg. Guessing here is how an inter-city leg would
+	// get promoted to "the flight home".
+	if len(stayCities) == 0 || len(transportIdx) == 0 {
+		return out
+	}
+
+	classify := func(i int, first, last bool) {
+		d := derived[i]
+		o := strings.ToLower(strings.TrimSpace(strPtrVal(d.Origin)))
+		dest := strings.ToLower(strings.TrimSpace(d.Destination))
+		if o == "" || dest == "" {
+			return
+		}
+		// Outbound is checked first, so a lone transport row whose BOTH
+		// endpoints sit outside the itinerary reads as the departure.
+		if first && !stayCities[o] {
+			out[i] = derivedIdentity{role: roleHomeOutbound, key: transportTodoKey(homeEndpointToken, dest)}
+			return
+		}
+		if last && !stayCities[dest] {
+			out[i] = derivedIdentity{role: roleHomeReturn, key: transportTodoKey(o, homeEndpointToken)}
+		}
+	}
+	firstT, lastT := transportIdx[0], transportIdx[len(transportIdx)-1]
+	classify(firstT, true, firstT == lastT)
+	if lastT != firstT {
+		classify(lastT, false, true)
+	}
+
+	// Canonicalization must never make two rows collide: the batch upsert
+	// collapses duplicate keys last-wins, which would silently drop a leg.
+	// A loser keeps the literal key the client posted and reads as inter_city
+	// — never a home role with a non-canonical key, which the CHECK
+	// constraints would reject. The migration's backfill has the identical
+	// fallback, so the two paths agree.
+	seen := make(map[string]int, len(out))
+	for i := range out {
+		key := out[i].key
+		if prev, dup := seen[key]; dup && prev != i {
+			if isHomeRole(out[i].role) {
+				out[i] = derivedIdentity{role: roleInterCity, key: derived[i].TodoKey}
+			}
+			continue
+		}
+		seen[key] = i
+	}
+	return out
+}
+
+// tripEndpointLabels returns the labels this trip's two home legs must carry,
+// one explicit ladder per direction:
+//
+//	that direction's airport -> the origin the traveler stated in words -> the
+//	trip OWNER's saved home airport
+//
+// The owner's, never the viewer's: a collaborator's device re-deriving with
+// their own airport is how a shared trip's legs used to get rewritten out from
+// under its owner. Empty means "nothing to say", and the label the client
+// posted is then left alone.
+//
+// origin_airport and return_airport are written together or not at all (CHECK
+// trips_endpoint_airport_pair), so NULL here never has to be read as "same as
+// the other direction" — it means only that this trip never stated an airport.
+func tripEndpointLabels(trip store.Trip, ownerHomeAirport *string) (departure, arrival string) {
+	stated := strings.TrimSpace(strPtrVal(trip.Origin))
+	home := strings.TrimSpace(strPtrVal(ownerHomeAirport))
+	pick := func(airport *string) string {
+		if code := strings.TrimSpace(strPtrVal(airport)); code != "" {
+			return strings.ToUpper(code)
+		}
+		if stated != "" {
+			return stated
+		}
+		return home
+	}
+	return pick(trip.OriginAirport), pick(trip.ReturnAirport)
+}
+
+// displayBookingTodoKey maps a storage key back to the endpoint-labelled key
+// the client derives and matches on (its per-leg mode overrides, its Find
+// Flights prefill, and the analytics todo_key history are all keyed that way).
+// Storage key = identity; wire key = display.
+//
+// This is a deliberate divergence — two spellings of one key — and it is the
+// price of changing identity without a client flag day. It dies at the
+// specs/server-booking-todos flip, when the client stops deriving keys at all;
+// keep it to this one function so that deletion is a one-file diff.
+func displayBookingTodoKey(t store.BookingTodo) string {
+	if !isHomeRole(strPtrVal(t.Role)) {
+		return t.TodoKey
+	}
+	o, d := strings.TrimSpace(strPtrVal(t.OriginLabel)), strings.TrimSpace(strPtrVal(t.DestinationLabel))
+	if o == "" || d == "" {
+		return t.TodoKey
+	}
+	return transportTodoKey(o, d)
+}

--- a/src/packages/api/booking_todo_identity_integration_test.go
+++ b/src/packages/api/booking_todo_identity_integration_test.go
@@ -1,0 +1,224 @@
+package main
+
+import (
+	"net/http"
+	"testing"
+)
+
+// booking_todo_identity_integration_test.go — the outcome contract for
+// migration 00064, written against what the traveler keeps rather than against
+// the mechanism that keeps it. These assertions must survive the eventual move
+// to server-side derivation (specs/server-booking-todos) unchanged.
+
+// homeLegPayload is what _deriveTodos posts for a one-city round trip out of
+// `home`: outbound, stay, return — in that construction order.
+func homeLegPayload(home, city string) []map[string]any {
+	return []map[string]any{
+		{"kind": "transport", "todo_key": "transport:" + lower(home) + ">>" + lower(city),
+			"title": home + " → " + city, "origin": home, "destination": city,
+			"position": 0, "depart_date": "2026-09-01", "passengers": 1},
+		{"kind": "stay", "todo_key": "stay:" + lower(city), "title": "Stay in " + city,
+			"destination": city, "position": 1, "depart_date": "2026-09-01",
+			"return_date": "2026-09-05", "guests": 1},
+		{"kind": "transport", "todo_key": "transport:" + lower(city) + ">>" + lower(home),
+			"title": city + " → " + home, "origin": city, "destination": home,
+			"position": 2, "depart_date": "2026-09-05", "passengers": 1},
+	}
+}
+
+func lower(s string) string {
+	out := []rune(s)
+	for i, r := range out {
+		if r >= 'A' && r <= 'Z' {
+			out[i] = r + 32
+		}
+	}
+	return string(out)
+}
+
+// The bug that was live in production: correcting a saved home airport rekeyed
+// every home leg the traveler owned, and the prune deleted the old rows —
+// taking the booked flag, the per-leg mode override and the linked expense's
+// source with them. The row must now survive with its id, because its identity
+// no longer contains the airport.
+func TestHomeLegSurvivesHomeAirportChange(t *testing.T) {
+	resetDB(t)
+	owner, token := createTestUser(t, "owner@example.com")
+	trip := createTestTrip(t, owner.ID, 0)
+	tripID := trip.ID.String()
+	base := "/api/v1/trips/" + tripID
+
+	if rec := doJSON(t, "PUT", "/api/v1/preferences", token, map[string]any{"home_airport": "EWR"}); rec.Code != http.StatusOK {
+		t.Fatalf("save home airport = %d: %s", rec.Code, rec.Body.String())
+	}
+	rec := doJSON(t, "PUT", base+"/booking-todos", token, homeLegPayload("EWR", "Amsterdam"))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("first sync = %d: %s", rec.Code, rec.Body.String())
+	}
+	first := decodeTodoList(t, rec)
+	if len(first) != 3 {
+		t.Fatalf("first sync rows = %d, want 3: %v", len(first), first)
+	}
+	// The wire still speaks endpoint-labelled keys, so the client matches on
+	// exactly what it derived.
+	if first[0]["todo_key"] != "transport:ewr>>amsterdam" || first[2]["todo_key"] != "transport:amsterdam>>ewr" {
+		t.Fatalf("wire keys are not the endpoint-labelled ones: %v", first)
+	}
+	outboundID, returnID := first[0]["id"].(string), first[2]["id"].(string)
+
+	// Everything a traveler can invest in a row: booked, a per-leg mode, and a
+	// budget expense linked to it.
+	if rec := doJSON(t, "PATCH", base+"/booking-todos/"+outboundID, token, map[string]any{"booked": true}); rec.Code != http.StatusOK {
+		t.Fatalf("book outbound = %d: %s", rec.Code, rec.Body.String())
+	}
+	if rec := doJSON(t, "PATCH", base+"/booking-todos/"+outboundID, token, map[string]any{
+		"mode": "train", "origin": "EWR", "destination": "Amsterdam", "depart_date": "2026-09-01",
+	}); rec.Code != http.StatusOK {
+		t.Fatalf("set mode = %d: %s", rec.Code, rec.Body.String())
+	}
+	rec = doJSON(t, "POST", base+"/budget/expenses", token, map[string]any{
+		"label": "EWR → Amsterdam", "category": "flights", "amount": 344,
+		"source_kind": "booking_todo", "source_id": outboundID})
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("link expense = %d: %s", rec.Code, rec.Body.String())
+	}
+	expenseID := decode(t, rec)["id"].(string)
+
+	// The traveler corrects their home airport, and the trip page re-derives
+	// with the new one — the exact sequence that used to destroy the row.
+	if rec := doJSON(t, "PUT", "/api/v1/preferences", token, map[string]any{"home_airport": "ALB"}); rec.Code != http.StatusOK {
+		t.Fatalf("change home airport = %d: %s", rec.Code, rec.Body.String())
+	}
+	rec = doJSON(t, "PUT", base+"/booking-todos", token, homeLegPayload("ALB", "Amsterdam"))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("resync = %d: %s", rec.Code, rec.Body.String())
+	}
+	after := decodeTodoList(t, rec)
+	if len(after) != 3 {
+		t.Fatalf("resync rows = %d, want 3 (a duplicate means the rename split the row): %v", len(after), after)
+	}
+	if after[0]["id"] != outboundID {
+		t.Fatalf("outbound row was replaced: %v", after[0])
+	}
+	if after[2]["id"] != returnID {
+		t.Fatalf("return row was replaced: %v", after[2])
+	}
+	if after[0]["booked"] != true {
+		t.Fatalf("booked flag lost: %v", after[0])
+	}
+	if after[0]["mode"] != "train" {
+		t.Fatalf("per-leg mode lost: %v", after[0])
+	}
+	// The labels followed the airport, so the traveler sees the right leg.
+	if after[0]["title"] != "ALB → Amsterdam" || after[2]["title"] != "Amsterdam → ALB" {
+		t.Fatalf("titles did not follow the new airport: %v / %v", after[0]["title"], after[2]["title"])
+	}
+	if after[0]["todo_key"] != "transport:alb>>amsterdam" {
+		t.Fatalf("wire key did not follow the new airport: %v", after[0])
+	}
+	// And the money is still attached to a row that exists.
+	rec = doJSON(t, "GET", base+"/budget/expenses", token, nil)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("list expenses = %d", rec.Code)
+	}
+	var found bool
+	for _, e := range decodeList(t, rec) {
+		if e["id"] == expenseID {
+			found = true
+			if e["source_id"] != outboundID {
+				t.Fatalf("expense link points at a different row now: %v", e)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("linked expense vanished: %s", rec.Body.String())
+	}
+}
+
+// A trip that leaves from one airport and comes home into another: the two
+// legs are distinct rows, and moving one must not disturb the other.
+func TestAsymmetricHomeLegsAreIndependent(t *testing.T) {
+	resetDB(t)
+	owner, token := createTestUser(t, "owner@example.com")
+	trip := createTestTrip(t, owner.ID, 0)
+	base := "/api/v1/trips/" + trip.ID.String()
+
+	payload := homeLegPayload("EWR", "Amsterdam")
+	rec := doJSON(t, "PUT", base+"/booking-todos", token, payload)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("first sync = %d: %s", rec.Code, rec.Body.String())
+	}
+	first := decodeTodoList(t, rec)
+	outboundID, returnID := first[0]["id"].(string), first[2]["id"].(string)
+	if rec := doJSON(t, "PATCH", base+"/booking-todos/"+returnID, token, map[string]any{"booked": true}); rec.Code != http.StatusOK {
+		t.Fatalf("book return = %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// Only the departure moves to ALB; the return still comes home into EWR.
+	payload[0]["todo_key"] = "transport:alb>>amsterdam"
+	payload[0]["title"] = "ALB → Amsterdam"
+	payload[0]["origin"] = "ALB"
+	rec = doJSON(t, "PUT", base+"/booking-todos", token, payload)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("resync = %d: %s", rec.Code, rec.Body.String())
+	}
+	after := decodeTodoList(t, rec)
+	if len(after) != 3 {
+		t.Fatalf("resync rows = %d, want 3: %v", len(after), after)
+	}
+	if after[0]["id"] != outboundID || after[0]["title"] != "ALB → Amsterdam" {
+		t.Fatalf("outbound did not move in place: %v", after[0])
+	}
+	if after[2]["id"] != returnID || after[2]["title"] != "Amsterdam → EWR" || after[2]["booked"] != true {
+		t.Fatalf("return leg was disturbed by a departure-only change: %v", after[2])
+	}
+}
+
+// A row the traveler has invested in is never destroyed by the prune. It leaves
+// the derived set — auto:false — and lands in the residual "Other bookings"
+// list, where it can be edited or removed. Untouched rows are still deleted.
+func TestStalePruneDemotesInvestedRowsAndDeletesTheRest(t *testing.T) {
+	resetDB(t)
+	owner, token := createTestUser(t, "owner@example.com")
+	trip := createTestTrip(t, owner.ID, 0)
+	base := "/api/v1/trips/" + trip.ID.String()
+
+	payload := []map[string]any{
+		{"kind": "stay", "todo_key": "stay:paris", "title": "Stay in Paris",
+			"destination": "Paris", "position": 0, "guests": 1},
+		{"kind": "stay", "todo_key": "stay:lyon", "title": "Stay in Lyon",
+			"destination": "Lyon", "position": 1, "guests": 1},
+	}
+	rec := doJSON(t, "PUT", base+"/booking-todos", token, payload)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("first sync = %d: %s", rec.Code, rec.Body.String())
+	}
+	first := decodeTodoList(t, rec)
+	parisID := first[0]["id"].(string)
+	if rec := doJSON(t, "PATCH", base+"/booking-todos/"+parisID, token, map[string]any{"booked": true}); rec.Code != http.StatusOK {
+		t.Fatalf("book Paris = %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// Both cities leave the itinerary. Paris was booked; Lyon was not.
+	rec = doJSON(t, "PUT", base+"/booking-todos", token, []map[string]any{})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("prune sync = %d: %s", rec.Code, rec.Body.String())
+	}
+	after := decodeTodoList(t, rec)
+	if len(after) != 1 {
+		t.Fatalf("rows after prune = %d, want 1 (booked survives, untouched is deleted): %v", len(after), after)
+	}
+	if after[0]["id"] != parisID {
+		t.Fatalf("the wrong row survived: %v", after[0])
+	}
+	if after[0]["booked"] != true {
+		t.Fatalf("survivor lost its booked flag: %v", after[0])
+	}
+	if after[0]["auto"] != false {
+		t.Fatalf("survivor must be demoted to manual so it stops being re-derived and can be removed: %v", after[0])
+	}
+	// Demoted means the traveler can now delete it — an auto row cannot be.
+	if rec := doJSON(t, "DELETE", base+"/booking-todos/"+parisID, token, nil); rec.Code != http.StatusNoContent {
+		t.Fatalf("delete demoted row = %d: %s", rec.Code, rec.Body.String())
+	}
+}

--- a/src/packages/api/booking_todo_identity_test.go
+++ b/src/packages/api/booking_todo_identity_test.go
@@ -1,0 +1,311 @@
+package main
+
+import (
+	"testing"
+
+	"travel-route-planner/store"
+)
+
+// booking_todo_identity_test.go — the canonicalization table (migration 00064).
+//
+// These cases are the contract the Dart derivation is held to: _deriveTodos
+// builds the outbound before the city loop and the return after it, and every
+// city it emits a leg for also gets a stay row. Everything here is a pure
+// function of one posted payload, so a divergence shows up as a table row
+// rather than as a deleted booking flag in production.
+
+func leg(key, origin, dest string) DerivedBookingTodo {
+	o := origin
+	return DerivedBookingTodo{Kind: "transport", TodoKey: key, Title: origin + " → " + dest, Origin: &o, Destination: dest}
+}
+
+func stay(city string) DerivedBookingTodo {
+	return DerivedBookingTodo{Kind: "stay", TodoKey: "stay:" + city, Title: "Stay in " + city, Destination: city}
+}
+
+func TestClassifyDerivedTodos(t *testing.T) {
+	cases := []struct {
+		name  string
+		in    []DerivedBookingTodo
+		roles []string
+		keys  []string
+	}{
+		{
+			name: "round trip through two cities",
+			in: []DerivedBookingTodo{
+				leg("transport:ewr>>amsterdam", "EWR", "Amsterdam"),
+				stay("Amsterdam"),
+				leg("transport:amsterdam>>rome", "Amsterdam", "Rome"),
+				stay("Rome"),
+				leg("transport:rome>>ewr", "Rome", "EWR"),
+			},
+			roles: []string{roleHomeOutbound, roleStay, roleInterCity, roleStay, roleHomeReturn},
+			keys: []string{"transport:@home>>amsterdam", "stay:Amsterdam", "transport:amsterdam>>rome",
+				"stay:Rome", "transport:rome>>@home"},
+		},
+		{
+			// The user's trip: out of ALB, home into EWR. The two endpoints
+			// differ, and the two keys must stay distinct so changing one can
+			// never disturb the other.
+			name: "asymmetric endpoints keep distinct keys",
+			in: []DerivedBookingTodo{
+				leg("transport:alb>>amsterdam", "ALB", "Amsterdam"),
+				stay("Amsterdam"),
+				leg("transport:amsterdam>>ewr", "Amsterdam", "EWR"),
+			},
+			roles: []string{roleHomeOutbound, roleStay, roleHomeReturn},
+			keys:  []string{"transport:@home>>amsterdam", "stay:Amsterdam", "transport:amsterdam>>@home"},
+		},
+		{
+			name: "single city round trip",
+			in: []DerivedBookingTodo{
+				leg("transport:ewr>>amsterdam", "EWR", "Amsterdam"),
+				stay("Amsterdam"),
+				leg("transport:amsterdam>>ewr", "Amsterdam", "EWR"),
+			},
+			roles: []string{roleHomeOutbound, roleStay, roleHomeReturn},
+			keys:  []string{"transport:@home>>amsterdam", "stay:Amsterdam", "transport:amsterdam>>@home"},
+		},
+		{
+			// Only one leg, and both its endpoints sit outside the itinerary.
+			// Outbound is checked first, so it reads as the departure.
+			name: "lone leg outside the itinerary reads as departure",
+			in: []DerivedBookingTodo{
+				leg("transport:ewr>>alb", "EWR", "ALB"),
+				stay("Amsterdam"),
+			},
+			roles: []string{roleHomeOutbound, roleStay},
+			keys:  []string{"transport:@home>>alb", "stay:Amsterdam"},
+		},
+		{
+			name: "one way out keeps the return unclaimed",
+			in: []DerivedBookingTodo{
+				leg("transport:ewr>>amsterdam", "EWR", "Amsterdam"),
+				stay("Amsterdam"),
+			},
+			roles: []string{roleHomeOutbound, roleStay},
+			keys:  []string{"transport:@home>>amsterdam", "stay:Amsterdam"},
+		},
+		{
+			// No stays means no itinerary to be outside of. Guessing here is
+			// how an inter-city leg would get promoted to "the flight home".
+			name: "empty stay set never reads as home",
+			in: []DerivedBookingTodo{
+				leg("transport:ewr>>amsterdam", "EWR", "Amsterdam"),
+				leg("transport:amsterdam>>rome", "Amsterdam", "Rome"),
+			},
+			roles: []string{roleInterCity, roleInterCity},
+			keys:  []string{"transport:ewr>>amsterdam", "transport:amsterdam>>rome"},
+		},
+		{
+			name: "revisited city stays inter-city",
+			in: []DerivedBookingTodo{
+				leg("transport:ewr>>athens", "EWR", "Athens"),
+				stay("Athens"),
+				leg("transport:athens>>fira", "Athens", "Fira"),
+				stay("Fira"),
+				leg("transport:fira>>athens", "Fira", "Athens"),
+				leg("transport:athens>>ewr", "Athens", "EWR"),
+			},
+			roles: []string{roleHomeOutbound, roleStay, roleInterCity, roleStay, roleInterCity, roleHomeReturn},
+			keys: []string{"transport:@home>>athens", "stay:Athens", "transport:athens>>fira",
+				"stay:Fira", "transport:fira>>athens", "transport:athens>>@home"},
+		},
+		{
+			// A hubless first group. The label survives verbatim into the key,
+			// spaces and all; namesAPlace rejects it downstream.
+			name: "other places label survives",
+			in: []DerivedBookingTodo{
+				leg("transport:ewr>>other places", "EWR", "Other places"),
+				stay("Other places"),
+			},
+			roles: []string{roleHomeOutbound, roleStay},
+			keys:  []string{"transport:@home>>other places", "stay:Other places"},
+		},
+		{
+			// A non-derived key (agent-added, custom, or an older client's
+			// private shape) is never renamed and never counts as first/last.
+			name: "foreign transport key is left alone",
+			in: []DerivedBookingTodo{
+				leg("leg:paris-lyon", "Paris", "Lyon"),
+				stay("Paris"),
+			},
+			roles: []string{roleInterCity, roleStay},
+			keys:  []string{"leg:paris-lyon", "stay:Paris"},
+		},
+		{
+			// Canonicalizing must never collide two rows onto one key: the
+			// batch upsert collapses duplicates last-wins, which would silently
+			// drop a leg. The loser keeps its literal key and its inter_city
+			// role — never a home role with a non-canonical key, which the
+			// CHECK constraints reject.
+			name: "collision falls back to the literal key",
+			in: []DerivedBookingTodo{
+				leg("transport:ewr>>amsterdam", "EWR", "Amsterdam"),
+				leg("transport:@home>>amsterdam", "@home", "Amsterdam"),
+				stay("Amsterdam"),
+			},
+			roles: []string{roleHomeOutbound, roleInterCity, roleStay},
+			keys:  []string{"transport:@home>>amsterdam", "transport:@home>>amsterdam", "stay:Amsterdam"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := classifyDerivedTodos(tc.in)
+			if len(got) != len(tc.in) {
+				t.Fatalf("got %d identities, want %d", len(got), len(tc.in))
+			}
+			for i := range got {
+				if got[i].role != tc.roles[i] {
+					t.Errorf("row %d role = %q, want %q", i, got[i].role, tc.roles[i])
+				}
+				if got[i].key != tc.keys[i] {
+					t.Errorf("row %d key = %q, want %q", i, got[i].key, tc.keys[i])
+				}
+			}
+		})
+	}
+}
+
+// The collision loser must never end up as a home role with a literal key —
+// that pairing is rejected by the 00064 CHECK constraints, so an inference bug
+// here would surface as a 500 on sync rather than a wrong row.
+func TestClassifyDerivedTodosNeverPairsHomeRoleWithLiteralKey(t *testing.T) {
+	for _, id := range classifyDerivedTodos([]DerivedBookingTodo{
+		leg("transport:ewr>>amsterdam", "EWR", "Amsterdam"),
+		leg("transport:@home>>amsterdam", "@home", "Amsterdam"),
+		stay("Amsterdam"),
+	}) {
+		if id.role == roleHomeOutbound && !isDerivedTransportKey(id.key) {
+			t.Fatalf("home_outbound with unparseable key %q", id.key)
+		}
+		if id.role == roleHomeOutbound && id.key != "transport:@home>>amsterdam" {
+			t.Fatalf("home_outbound key = %q, want the canonical form", id.key)
+		}
+		if id.role == roleHomeReturn && !hasSuffix(id.key, ">>"+homeEndpointToken) {
+			t.Fatalf("home_return key = %q, want the @home suffix", id.key)
+		}
+	}
+}
+
+func hasSuffix(s, suffix string) bool {
+	return len(s) >= len(suffix) && s[len(s)-len(suffix):] == suffix
+}
+
+// The wire keeps the endpoint-labelled key the client derives and matches on,
+// so a storage rename is invisible to it. Round-trip: what we hand back must be
+// what a fresh client would post.
+func TestDisplayBookingTodoKeyRoundTrips(t *testing.T) {
+	ptr := func(s string) *string { return &s }
+	cases := []struct {
+		name string
+		row  store.BookingTodo
+		want string
+	}{
+		{"home outbound renders its labels",
+			store.BookingTodo{TodoKey: "transport:@home>>amsterdam", Role: ptr(roleHomeOutbound),
+				OriginLabel: ptr("ALB"), DestinationLabel: ptr("Amsterdam")},
+			"transport:alb>>amsterdam"},
+		{"home return renders its labels",
+			store.BookingTodo{TodoKey: "transport:rome>>@home", Role: ptr(roleHomeReturn),
+				OriginLabel: ptr("Rome"), DestinationLabel: ptr("EWR")},
+			"transport:rome>>ewr"},
+		{"inter city passes through",
+			store.BookingTodo{TodoKey: "transport:amsterdam>>rome", Role: ptr(roleInterCity),
+				OriginLabel: ptr("Amsterdam"), DestinationLabel: ptr("Rome")},
+			"transport:amsterdam>>rome"},
+		{"stay passes through",
+			store.BookingTodo{TodoKey: "stay:rome", Role: ptr(roleStay), DestinationLabel: ptr("Rome")},
+			"stay:rome"},
+		{"a home row with no labels keeps its storage key rather than inventing one",
+			store.BookingTodo{TodoKey: "transport:@home>>amsterdam", Role: ptr(roleHomeOutbound)},
+			"transport:@home>>amsterdam"},
+		{"a pre-00064 row has no role and is untouched",
+			store.BookingTodo{TodoKey: "transport:ewr>>amsterdam"},
+			"transport:ewr>>amsterdam"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := displayBookingTodoKey(tc.row); got != tc.want {
+				t.Fatalf("display key = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// One ladder per direction, and the airport columns are written together, so
+// "return_airport is NULL" never has to be read as "same as departure".
+func TestTripEndpointLabels(t *testing.T) {
+	ptr := func(s string) *string { return &s }
+	cases := []struct {
+		name             string
+		trip             store.Trip
+		ownerHome        *string
+		wantDep, wantArr string
+	}{
+		{"trip airports win and may differ",
+			store.Trip{OriginAirport: ptr("ALB"), ReturnAirport: ptr("EWR"), Origin: ptr("Lake George, NY")},
+			ptr("BOS"), "ALB", "EWR"},
+		{"a stated origin beats the saved airport",
+			store.Trip{Origin: ptr("Lake George, NY")}, ptr("EWR"),
+			"Lake George, NY", "Lake George, NY"},
+		{"the owner's saved airport is the last rung",
+			store.Trip{}, ptr("EWR"), "EWR", "EWR"},
+		{"nothing stated anywhere says nothing",
+			store.Trip{}, nil, "", ""},
+		{"a lowercase stored code is normalized",
+			store.Trip{OriginAirport: ptr("alb"), ReturnAirport: ptr("alb")}, nil, "ALB", "ALB"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dep, arr := tripEndpointLabels(tc.trip, tc.ownerHome)
+			if dep != tc.wantDep || arr != tc.wantArr {
+				t.Fatalf("labels = (%q, %q), want (%q, %q)", dep, arr, tc.wantDep, tc.wantArr)
+			}
+		})
+	}
+}
+
+// A three-letter endpoint must not substring-claim a longer place name: "alb"
+// vs "Albufeira" would silently mark the flight out as already booked. Short
+// city names must still work.
+//
+// The deliberate cost: a code no longer claims the spelled-out airport it
+// stands for ("alb" vs "Albany International Airport"), because nothing here
+// knows IATA. That direction is the safe one to lose — a missed claim offers to
+// book something already booked, while a false claim hides an unbooked flight.
+func TestFuzzyMatchShortTokens(t *testing.T) {
+	cases := []struct {
+		a, b string
+		want bool
+	}{
+		{"albufeira", "alb", false},
+		{"alb", "alb", true},
+		{"albany international airport", "alb", false},
+		{"rio de janeiro", "rio", true},
+		{"new york, ny", "ny", true},
+		{"amsterdam", "rome", false},
+		{"amsterdam schiphol", "amsterdam", true},
+	}
+	for _, tc := range cases {
+		if got := fuzzyMatch(tc.a, tc.b); got != tc.want {
+			t.Errorf("fuzzyMatch(%q, %q) = %v, want %v", tc.a, tc.b, got, tc.want)
+		}
+	}
+}
+
+// @home must never reach a traveler: it would ride into Next Step copy, a
+// finding's fix, and the canonical-English agent seed.
+func TestNamesAPlaceRejectsReservedTokens(t *testing.T) {
+	for _, s := range []string{"@home", "@anything", "", "Itinerary", "Other places"} {
+		if namesAPlace(s) {
+			t.Errorf("namesAPlace(%q) = true, want false", s)
+		}
+	}
+	for _, s := range []string{"Amsterdam", "ALB", "Lake George, NY"} {
+		if !namesAPlace(s) {
+			t.Errorf("namesAPlace(%q) = false, want true", s)
+		}
+	}
+}

--- a/src/packages/api/migration_00064_backfill_test.go
+++ b/src/packages/api/migration_00064_backfill_test.go
@@ -1,0 +1,227 @@
+package main
+
+import (
+	"database/sql"
+	"net/url"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/pressly/goose/v3"
+)
+
+// migration_00064_backfill_test.go — the part of 00064 that touches live data.
+//
+// "Migrations apply from zero" (CI) runs the backfill against an empty table,
+// which proves the SQL parses and proves nothing about what it does to the rows
+// already in production. Every home leg a traveler owns goes through these
+// statements exactly once, on deploy day, and a row the backfill leaves behind
+// falls outside the next sync's key set — so this is the one test standing
+// between a booked flight and a demoted orphan.
+//
+// It migrates a scratch database to 00063, seeds rows in the OLD shape, then
+// applies 00064 and reads back what happened.
+
+// migrateScratchDB creates a throwaway database, brings it to `version`, and
+// returns a handle plus a cleanup. Skips (rather than fails) when the test
+// server won't allow CREATE DATABASE — the assertions below are worth having
+// wherever they can run, and are not worth a red build where they can't.
+func migrateScratchDB(t *testing.T, version int64) *sql.DB {
+	t.Helper()
+	base := os.Getenv("TEST_DATABASE_URL")
+	if base == "" {
+		t.Skip("TEST_DATABASE_URL not set")
+	}
+	u, err := url.Parse(base)
+	if err != nil {
+		t.Fatalf("parse TEST_DATABASE_URL: %v", err)
+	}
+	const scratch = "travel_mig64_scratch"
+
+	adminURL := *u
+	adminURL.Path = "/postgres"
+	admin, err := sql.Open("pgx", adminURL.String())
+	if err != nil {
+		t.Fatalf("open admin db: %v", err)
+	}
+	defer admin.Close()
+	if _, err := admin.Exec(`DROP DATABASE IF EXISTS ` + scratch); err != nil {
+		t.Skipf("cannot manage databases on this server: %v", err)
+	}
+	if _, err := admin.Exec(`CREATE DATABASE ` + scratch); err != nil {
+		t.Skipf("cannot create a scratch database on this server: %v", err)
+	}
+
+	scratchURL := *u
+	scratchURL.Path = "/" + scratch
+	db, err := sql.Open("pgx", scratchURL.String())
+	if err != nil {
+		t.Fatalf("open scratch db: %v", err)
+	}
+	t.Cleanup(func() {
+		db.Close()
+		admin2, err := sql.Open("pgx", adminURL.String())
+		if err != nil {
+			return
+		}
+		defer admin2.Close()
+		admin2.Exec(`DROP DATABASE IF EXISTS ` + scratch)
+	})
+
+	goose.SetBaseFS(embeddedMigrations)
+	if err := goose.SetDialect("postgres"); err != nil {
+		t.Fatalf("goose dialect: %v", err)
+	}
+	if err := goose.UpTo(db, "migrations", version); err != nil {
+		t.Fatalf("migrate to %d: %v", version, err)
+	}
+	return db
+}
+
+// seedLegacyTrip writes rows exactly as the pre-00064 code stored them: keys
+// built from the endpoint labels, no role, no endpoint columns.
+func seedLegacyTrip(t *testing.T, db *sql.DB, rows [][3]any) string {
+	t.Helper()
+	var userID, tripID string
+	if err := db.QueryRow(
+		`INSERT INTO users (email) VALUES ($1) RETURNING id`,
+		// Emails are stored lowercased, enforced by a CHECK since 00002.
+		strings.ToLower("legacy-"+t.Name()+"@example.com")).Scan(&userID); err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+	if err := db.QueryRow(`INSERT INTO trips (user_id, title) VALUES ($1, 'Legacy trip') RETURNING id`,
+		userID).Scan(&tripID); err != nil {
+		t.Fatalf("seed trip: %v", err)
+	}
+	for i, r := range rows {
+		kind, key, title := r[0].(string), r[1].(string), r[2].(string)
+		if _, err := db.Exec(
+			`INSERT INTO booking_todos (trip_id, kind, todo_key, title, position, auto, booked)
+			 VALUES ($1, $2, $3, $4, $5, true, $6)`,
+			tripID, kind, key, title, i, i == 0); err != nil {
+			t.Fatalf("seed row %q: %v", key, err)
+		}
+	}
+	return tripID
+}
+
+type legacyRow struct {
+	key, role, originLabel, destLabel string
+	booked                            bool
+}
+
+func readRows(t *testing.T, db *sql.DB, tripID string) map[string]legacyRow {
+	t.Helper()
+	rows, err := db.Query(
+		`SELECT title, todo_key, coalesce(role,''), coalesce(origin_label,''),
+		        coalesce(destination_label,''), booked
+		   FROM booking_todos WHERE trip_id = $1`, tripID)
+	if err != nil {
+		t.Fatalf("read rows: %v", err)
+	}
+	defer rows.Close()
+	out := map[string]legacyRow{}
+	for rows.Next() {
+		var title string
+		var r legacyRow
+		if err := rows.Scan(&title, &r.key, &r.role, &r.originLabel, &r.destLabel, &r.booked); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		out[title] = r
+	}
+	return out
+}
+
+func TestMigration00064BackfillsLiveRows(t *testing.T) {
+	db := migrateScratchDB(t, 63)
+
+	// A two-city round trip out of EWR, stored the old way. The outbound is
+	// booked — the flag the old prune destroyed.
+	tripID := seedLegacyTrip(t, db, [][3]any{
+		{"transport", "transport:ewr>>amsterdam", "EWR → Amsterdam"},
+		{"stay", "stay:amsterdam", "Stay in Amsterdam"},
+		{"transport", "transport:amsterdam>>rome", "Amsterdam → Rome"},
+		{"stay", "stay:rome", "Stay in Rome"},
+		{"transport", "transport:rome>>ewr", "Rome → EWR"},
+	})
+
+	if err := goose.UpTo(db, "migrations", 64); err != nil {
+		t.Fatalf("apply 00064: %v", err)
+	}
+
+	got := readRows(t, db, tripID)
+	cases := []struct {
+		title string
+		want  legacyRow
+	}{
+		{"EWR → Amsterdam", legacyRow{
+			key: "transport:@home>>amsterdam", role: roleHomeOutbound,
+			originLabel: "EWR", destLabel: "Amsterdam", booked: true}},
+		{"Rome → EWR", legacyRow{
+			key: "transport:rome>>@home", role: roleHomeReturn,
+			originLabel: "Rome", destLabel: "EWR"}},
+		// An inter-city leg is not a journey endpoint: its key is untouched.
+		{"Amsterdam → Rome", legacyRow{
+			key: "transport:amsterdam>>rome", role: roleInterCity,
+			originLabel: "Amsterdam", destLabel: "Rome"}},
+		{"Stay in Amsterdam", legacyRow{
+			key: "stay:amsterdam", role: roleStay, destLabel: "Amsterdam"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.title, func(t *testing.T) {
+			r, ok := got[tc.title]
+			if !ok {
+				t.Fatalf("row %q vanished in the backfill", tc.title)
+			}
+			if r != tc.want {
+				t.Fatalf("row %q = %+v, want %+v", tc.title, r, tc.want)
+			}
+		})
+	}
+
+	// The identity the runtime canonicalizer produces for the same payload must
+	// be the one the backfill just wrote — otherwise the first sync after the
+	// deploy prunes every home leg it didn't recognize.
+	idents := classifyDerivedTodos([]DerivedBookingTodo{
+		leg("transport:ewr>>amsterdam", "EWR", "Amsterdam"),
+		stay("Amsterdam"),
+		leg("transport:amsterdam>>rome", "Amsterdam", "Rome"),
+		stay("Rome"),
+		leg("transport:rome>>ewr", "Rome", "EWR"),
+	})
+	if idents[0].key != got["EWR → Amsterdam"].key {
+		t.Fatalf("runtime key %q != backfilled key %q", idents[0].key, got["EWR → Amsterdam"].key)
+	}
+	if idents[4].key != got["Rome → EWR"].key {
+		t.Fatalf("runtime key %q != backfilled key %q", idents[4].key, got["Rome → EWR"].key)
+	}
+}
+
+// A trip whose canonical key is already taken must not lose a leg, and must not
+// end up with a home role on a non-canonical key — the 00064 CHECK constraints
+// reject that pairing, so a careless backfill would abort the whole migration.
+func TestMigration00064CollisionKeepsBothRows(t *testing.T) {
+	db := migrateScratchDB(t, 63)
+
+	tripID := seedLegacyTrip(t, db, [][3]any{
+		{"transport", "transport:ewr>>amsterdam", "EWR → Amsterdam"},
+		{"transport", "transport:@home>>amsterdam", "@home → Amsterdam"},
+		{"stay", "stay:amsterdam", "Stay in Amsterdam"},
+	})
+
+	if err := goose.UpTo(db, "migrations", 64); err != nil {
+		t.Fatalf("apply 00064 over a collision: %v", err)
+	}
+
+	got := readRows(t, db, tripID)
+	if len(got) != 3 {
+		t.Fatalf("rows after backfill = %d, want 3 (nothing may be dropped): %+v", len(got), got)
+	}
+	loser := got["EWR → Amsterdam"]
+	if loser.key != "transport:ewr>>amsterdam" {
+		t.Fatalf("blocked rename should keep the literal key, got %q", loser.key)
+	}
+	if isHomeRole(loser.role) {
+		t.Fatalf("a home role on a literal key violates the CHECK pairing: %+v", loser)
+	}
+}

--- a/src/packages/api/migrations/00064_booking_todo_identity.sql
+++ b/src/packages/api/migrations/00064_booking_todo_identity.sql
@@ -1,0 +1,177 @@
+-- +goose Up
+-- Derived transport rows stop taking their identity from a mutable endpoint
+-- label, and a trip gains its own departure/return airports.
+--
+-- WHY. A derived leg's identity was the endpoint string itself
+-- (`transport:<origin>>><dest>`, 00010). The origin token is whatever the
+-- renderer had on hand — trips.origin (00062) or, failing that, the VIEWER's
+-- saved home airport. So the label was both content and identity, and the
+-- moment it changed the key changed: DeleteStaleAutoBookingTodos hard-deleted
+-- the row and took the booked flag, the per-leg mode override (00055), the
+-- manual position, and any linked expense's source (00061, no FK on purpose)
+-- with it. 00062 froze trips.origin to dodge that, but left the wider door
+-- open — traveler_preferences.home_airport is freely mutable (Settings, the
+-- save_preferences agent tool, the background profile distiller), and the trip
+-- screen re-derives and re-syncs on the very next open. Correcting a home
+-- airport therefore dropped booked flags on every trip the traveler owned, and
+-- a collaborator opening a shared trip did the same with THEIR airport.
+-- docs/zen.md names this exactly: an invariant that only holds implicitly —
+-- via rows that can be deleted — is not an invariant.
+--
+-- WHAT. The two home legs key on a reserved `@home` token whose POSITION in
+-- the key carries the direction, and the endpoints move to columns:
+--     home_outbound  transport:@home>>amsterdam   origin_label='ALB'
+--     home_return    transport:rome>>@home        destination_label='EWR'
+--     inter_city     transport:paris>>rome        (key unchanged)
+--     stay           stay:paris                   (key unchanged)
+-- Changing either airport is then a title/label update that
+-- UpsertBookingTodosBatch already performs in place — booked/auto/mode are
+-- deliberately outside its DO UPDATE set, so they survive. The two directions
+-- stay distinct keys, which is what lets a trip fly out of ALB and home into
+-- EWR. `@` rather than a bare `home`: namesAPlace (trip_next_step.go) accepts
+-- the word "home" as a city and would leak it into traveler-facing copy, while
+-- `@` cannot occur in an IATA code or a Places label, so one guard is total.
+--
+-- The canonical key is computed SERVER-side in syncBookingTodosHandler, never
+-- trusted from the client. That is what makes a stale tab, an old cached
+-- bundle, or a collaborator's device land on the SAME row instead of pruning
+-- it.
+--
+-- Every backfill statement below is an id-preserving UPDATE — never
+-- delete+insert — so booked, mode, position, created_at and every
+-- trip_expenses.source_id link survive by construction.
+ALTER TABLE booking_todos ADD COLUMN role              text; -- home_outbound | home_return | inter_city | stay
+ALTER TABLE booking_todos ADD COLUMN origin_label      text; -- cased display label, e.g. "ALB"
+ALTER TABLE booking_todos ADD COLUMN destination_label text; -- cased display label, e.g. "Amsterdam"
+
+-- This trip's own flight endpoints. Two columns, not one, because a trip can
+-- leave from ALB and come home into EWR. NULL never means "same as the other
+-- one": the single writer (the agent's set_trip_origin tool) always writes
+-- BOTH, copying the departure into return_airport when the traveler named only
+-- one — a default nobody can see is what put an EWR leg on an Albany trip in
+-- the first place. NULL means only "this trip never stated an airport", which
+-- keeps the legacy fallback to trips.origin and then the saved home airport.
+-- Distinct from trips.origin (00062), which stays free text: origin is where
+-- they set out from IN THEIR OWN WORDS ("Lake George, NY") and resolves to no
+-- coordinates; these are codes, so the map can pin them.
+ALTER TABLE trips ADD COLUMN origin_airport text;
+ALTER TABLE trips ADD COLUMN return_airport text;
+ALTER TABLE trips ADD CONSTRAINT trips_origin_airport_iata
+    CHECK (origin_airport IS NULL OR origin_airport ~ '^[A-Z]{3}$');
+ALTER TABLE trips ADD CONSTRAINT trips_return_airport_iata
+    CHECK (return_airport IS NULL OR return_airport ~ '^[A-Z]{3}$');
+-- Written together or not at all (the trip_expenses_source_pair pattern, 00061).
+ALTER TABLE trips ADD CONSTRAINT trips_endpoint_airport_pair
+    CHECK ((origin_airport IS NULL) = (return_airport IS NULL));
+
+-- 1. Stay rows. The title is the only carrier of the client's casing (see the
+--    section comment above legEndpoints in trip_next_step.go), so it wins and
+--    the key suffix is the fallback. regexp_replace returns its input unchanged
+--    on no-match, which is what NULLIF(..., title) tests for.
+UPDATE booking_todos SET
+    role = 'stay',
+    destination_label = COALESCE(
+        NULLIF(regexp_replace(title, '^Stay in ', ''), title),
+        substring(todo_key from 6))
+WHERE kind = 'stay' AND todo_key LIKE 'stay:%';
+
+-- 2. Transport endpoints, same title-then-key precedence. ' → ' is U+2192,
+--    the separator _deriveTodos builds titles with.
+UPDATE booking_todos SET
+    origin_label = COALESCE(
+        NULLIF(split_part(title, ' → ', 1), ''),
+        split_part(substring(todo_key from 11), '>>', 1)),
+    destination_label = COALESCE(
+        NULLIF(split_part(title, ' → ', 2), ''),
+        split_part(substring(todo_key from 11), '>>', 2))
+WHERE kind = 'transport' AND todo_key LIKE 'transport:%>>%';
+
+-- 3. Role + canonical key. The classifier is the rule stayCitySet already
+--    states (a transport endpoint outside the trip's stay cities is a home
+--    leg; an EMPTY stay set never reads as home), restricted to the first and
+--    last transport row — which is _deriveTodos' construction order: outbound
+--    first, return last. `substring(from 11)` strips the 10-char 'transport:'.
+WITH stays AS (
+    SELECT trip_id, lower(substring(todo_key from 6)) AS city
+    FROM booking_todos
+    WHERE auto AND todo_key LIKE 'stay:%'
+), legs AS (
+    SELECT b.id, b.trip_id,
+           lower(split_part(substring(b.todo_key from 11), '>>', 1)) AS o,
+           lower(split_part(substring(b.todo_key from 11), '>>', 2)) AS d,
+           row_number() OVER (PARTITION BY b.trip_id ORDER BY b.position, b.created_at) AS rn,
+           count(*)     OVER (PARTITION BY b.trip_id)                                   AS n,
+           EXISTS (SELECT 1 FROM stays s WHERE s.trip_id = b.trip_id)                   AS has_stays
+    FROM booking_todos b
+    WHERE b.auto AND b.kind = 'transport' AND b.todo_key LIKE 'transport:%>>%'
+), classified AS (
+    SELECT l.*, CASE
+        WHEN l.has_stays AND l.rn = 1
+             AND NOT EXISTS (SELECT 1 FROM stays s WHERE s.trip_id = l.trip_id AND s.city = l.o)
+            THEN 'home_outbound'
+        WHEN l.has_stays AND l.rn = l.n
+             AND NOT EXISTS (SELECT 1 FROM stays s WHERE s.trip_id = l.trip_id AND s.city = l.d)
+            THEN 'home_return'
+        ELSE 'inter_city'
+    END AS role FROM legs l
+), targets AS (
+    SELECT c.id, c.trip_id, c.role, CASE c.role
+        WHEN 'home_outbound' THEN 'transport:@home>>' || c.d
+        WHEN 'home_return'   THEN 'transport:' || c.o || '>>@home'
+        ELSE NULL
+    END AS new_key FROM classified c
+)
+UPDATE booking_todos b
+SET todo_key = COALESCE(t.new_key, b.todo_key),
+    -- A home role is only legal once the key actually became canonical (the
+    -- CHECKs below enforce that pairing). When the rename is blocked by a
+    -- collision the row keeps its literal key and reads as inter_city — the
+    -- runtime canonicalizer has the identical fallback, so the two agree.
+    role = CASE
+        WHEN t.new_key IS NULL THEN t.role
+        WHEN EXISTS (SELECT 1 FROM booking_todos x
+                     WHERE x.trip_id = t.trip_id AND x.todo_key = t.new_key AND x.id <> t.id)
+            THEN 'inter_city'
+        ELSE t.role
+    END
+FROM targets t
+WHERE b.id = t.id
+  -- Never violate idx_booking_todos_trip_key: a collision on a pathological
+  -- itinerary is a no-op rename, not an aborted migration.
+  AND (t.new_key IS NULL OR NOT EXISTS (
+        SELECT 1 FROM booking_todos x
+        WHERE x.trip_id = t.trip_id AND x.todo_key = t.new_key AND x.id <> t.id));
+
+-- 4. Only now, with every home row canonical, can the pairing bind. A wrong
+--    canonicalization then fails loudly at write time instead of producing a
+--    plausible-looking wrong row.
+ALTER TABLE booking_todos ADD CONSTRAINT booking_todos_home_outbound_key
+    CHECK (role IS DISTINCT FROM 'home_outbound' OR todo_key LIKE 'transport:@home>>%');
+ALTER TABLE booking_todos ADD CONSTRAINT booking_todos_home_return_key
+    CHECK (role IS DISTINCT FROM 'home_return' OR todo_key LIKE '%>>@home');
+
+-- +goose Down
+-- Rebuilds literal keys from the labels. Note this reconstructs the CURRENT
+-- endpoints, not the historical ones: if a trip's departure airport changed
+-- while the new code was live, the restored key names the new airport. That is
+-- what the old client would derive anyway, so it is correct — but it is worth
+-- saying out loud rather than leaving to be discovered.
+ALTER TABLE booking_todos DROP CONSTRAINT IF EXISTS booking_todos_home_return_key;
+ALTER TABLE booking_todos DROP CONSTRAINT IF EXISTS booking_todos_home_outbound_key;
+UPDATE booking_todos b
+SET todo_key = 'transport:' || lower(b.origin_label) || '>>' || lower(b.destination_label)
+WHERE b.role IN ('home_outbound', 'home_return')
+  AND b.origin_label IS NOT NULL AND b.destination_label IS NOT NULL
+  AND NOT EXISTS (
+        SELECT 1 FROM booking_todos x
+        WHERE x.trip_id = b.trip_id
+          AND x.todo_key = 'transport:' || lower(b.origin_label) || '>>' || lower(b.destination_label)
+          AND x.id <> b.id);
+ALTER TABLE trips DROP CONSTRAINT IF EXISTS trips_endpoint_airport_pair;
+ALTER TABLE trips DROP CONSTRAINT IF EXISTS trips_return_airport_iata;
+ALTER TABLE trips DROP CONSTRAINT IF EXISTS trips_origin_airport_iata;
+ALTER TABLE trips DROP COLUMN IF EXISTS return_airport;
+ALTER TABLE trips DROP COLUMN IF EXISTS origin_airport;
+ALTER TABLE booking_todos DROP COLUMN IF EXISTS destination_label;
+ALTER TABLE booking_todos DROP COLUMN IF EXISTS origin_label;
+ALTER TABLE booking_todos DROP COLUMN IF EXISTS role;

--- a/src/packages/api/query/booking_todos.sql
+++ b/src/packages/api/query/booking_todos.sql
@@ -6,8 +6,13 @@ SELECT * FROM booking_todos WHERE trip_id = $1 ORDER BY position ASC, created_at
 -- reference for UpsertBookingTodosBatch's column list / ON CONFLICT set, and
 -- its generated Params struct is the row type the batch path builds
 -- (booking_todo_handler.go). Delete only together with a handler refactor.
-INSERT INTO booking_todos (trip_id, kind, todo_key, title, subtitle, provider, search_url, depart_date, return_date, position, auto)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, true)
+--
+-- role/origin_label/destination_label (00064) are CONTENT, like title: they
+-- ride the DO UPDATE set so a re-sync refreshes them. What must never join it
+-- is booked/auto/mode — that exclusion is the whole preservation contract, and
+-- it is what lets a changed departure airport rewrite a home leg in place.
+INSERT INTO booking_todos (trip_id, kind, todo_key, title, subtitle, provider, search_url, depart_date, return_date, position, auto, role, origin_label, destination_label)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, true, $11, $12, $13)
 ON CONFLICT (trip_id, todo_key) DO UPDATE SET
     kind = EXCLUDED.kind,
     title = EXCLUDED.title,
@@ -16,7 +21,10 @@ ON CONFLICT (trip_id, todo_key) DO UPDATE SET
     search_url = EXCLUDED.search_url,
     depart_date = EXCLUDED.depart_date,
     return_date = EXCLUDED.return_date,
-    position = EXCLUDED.position
+    position = EXCLUDED.position,
+    role = EXCLUDED.role,
+    origin_label = EXCLUDED.origin_label,
+    destination_label = EXCLUDED.destination_label
 RETURNING *;
 
 -- name: UpsertBookingTodosBatch :exec
@@ -32,12 +40,16 @@ RETURNING *;
 -- CONFLICT cannot update the same row twice. (Parallel single-array unnest
 -- calls in one SELECT list expand in lockstep for equal-length arrays;
 -- sqlc's catalog lacks the multi-array unnest form.)
-INSERT INTO booking_todos (trip_id, kind, todo_key, title, subtitle, provider, search_url, depart_date, return_date, position, auto)
+INSERT INTO booking_todos (trip_id, kind, todo_key, title, subtitle, provider, search_url, depart_date, return_date, position, auto, role, origin_label, destination_label)
 SELECT sqlc.arg(trip_id)::uuid, u.kind, u.todo_key, u.title,
        CASE WHEN u.subtitle_null THEN NULL ELSE u.subtitle END,
        CASE WHEN u.provider_null THEN NULL ELSE u.provider END,
        CASE WHEN u.search_url_null THEN NULL ELSE u.search_url END,
-       u.depart_date, u.return_date, u.position, true
+       u.depart_date, u.return_date, u.position, true,
+       u.role,
+       -- A label has no meaningful empty value, so NULLIF carries the "this
+       -- row has no origin" case (every stay row) without a third null mask.
+       NULLIF(u.origin_label, ''), NULLIF(u.destination_label, '')
 FROM (
     SELECT unnest(sqlc.arg(kinds)::text[])            AS kind,
            unnest(sqlc.arg(todo_keys)::text[])        AS todo_key,
@@ -50,7 +62,10 @@ FROM (
            unnest(sqlc.arg(search_url_nulls)::bool[]) AS search_url_null,
            unnest(sqlc.arg(depart_dates)::date[])     AS depart_date,
            unnest(sqlc.arg(return_dates)::date[])     AS return_date,
-           unnest(sqlc.arg(positions)::int[])         AS position
+           unnest(sqlc.arg(positions)::int[])         AS position,
+           unnest(sqlc.arg(roles)::text[])            AS role,
+           unnest(sqlc.arg(origin_labels)::text[])    AS origin_label,
+           unnest(sqlc.arg(destination_labels)::text[]) AS destination_label
 ) AS u
 ON CONFLICT (trip_id, todo_key) DO UPDATE SET
     kind = EXCLUDED.kind,
@@ -60,9 +75,36 @@ ON CONFLICT (trip_id, todo_key) DO UPDATE SET
     search_url = EXCLUDED.search_url,
     depart_date = EXCLUDED.depart_date,
     return_date = EXCLUDED.return_date,
-    position = EXCLUDED.position;
+    position = EXCLUDED.position,
+    role = EXCLUDED.role,
+    origin_label = EXCLUDED.origin_label,
+    destination_label = EXCLUDED.destination_label;
+
+-- name: DemoteStaleAutoBookingTodos :execrows
+-- Half of the prune, and it MUST run before DeleteStaleAutoBookingTodos.
+--
+-- A stale auto row that carries traveler state is not garbage — it is a booked
+-- flight, a per-leg mode override, or the source of a budget expense. Deleting
+-- it destroys all three silently (the expense survives with a dangling
+-- source_id, still summed into `spent`, and unbooking can never find it again
+-- — 00061 has no FK by design). So state-carrying rows are DEMOTED to manual
+-- instead: auto = false takes them out of the derived set for good, they stop
+-- being re-derived, and they render in the existing residual "Other bookings"
+-- list where the traveler and the agent can edit or remove them. Demote rather
+-- than merely skip: DeleteBookingTodoNonAuto refuses auto rows, so a skipped
+-- survivor would be an undeletable zombie.
+UPDATE booking_todos b
+SET auto = false
+WHERE b.trip_id = $1 AND b.auto = true AND b.todo_key <> ALL(@keys::text[])
+  AND (b.booked OR b.mode IS NOT NULL OR EXISTS (
+        SELECT 1 FROM trip_expenses e
+        WHERE e.trip_id = b.trip_id
+          AND e.source_kind = 'booking_todo' AND e.source_id = b.id));
 
 -- name: DeleteStaleAutoBookingTodos :execrows
+-- The rest of the prune: stale rows nobody has touched. Runs AFTER
+-- DemoteStaleAutoBookingTodos, whose survivors are auto = false by then and so
+-- fall outside this statement.
 DELETE FROM booking_todos
 WHERE trip_id = $1 AND auto = true AND todo_key <> ALL(@keys::text[]);
 

--- a/src/packages/api/store/booking_todos.sql.go
+++ b/src/packages/api/store/booking_todos.sql.go
@@ -15,7 +15,7 @@ import (
 const createBookingTodo = `-- name: CreateBookingTodo :one
 INSERT INTO booking_todos (trip_id, kind, todo_key, title, subtitle, provider, search_url, depart_date, return_date, position, auto)
 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, false)
-RETURNING id, trip_id, kind, todo_key, title, subtitle, provider, search_url, depart_date, return_date, booked, auto, position, created_at, updated_at, mode
+RETURNING id, trip_id, kind, todo_key, title, subtitle, provider, search_url, depart_date, return_date, booked, auto, position, created_at, updated_at, mode, role, origin_label, destination_label
 `
 
 type CreateBookingTodoParams struct {
@@ -62,6 +62,9 @@ func (q *Queries) CreateBookingTodo(ctx context.Context, arg CreateBookingTodoPa
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.Mode,
+		&i.Role,
+		&i.OriginLabel,
+		&i.DestinationLabel,
 	)
 	return i, err
 }
@@ -110,6 +113,9 @@ type DeleteStaleAutoBookingTodosParams struct {
 	Keys   []string  `json:"keys"`
 }
 
+// The rest of the prune: stale rows nobody has touched. Runs AFTER
+// DemoteStaleAutoBookingTodos, whose survivors are auto = false by then and so
+// fall outside this statement.
 func (q *Queries) DeleteStaleAutoBookingTodos(ctx context.Context, arg DeleteStaleAutoBookingTodosParams) (int64, error) {
 	result, err := q.db.Exec(ctx, deleteStaleAutoBookingTodos, arg.TripID, arg.Keys)
 	if err != nil {
@@ -118,8 +124,43 @@ func (q *Queries) DeleteStaleAutoBookingTodos(ctx context.Context, arg DeleteSta
 	return result.RowsAffected(), nil
 }
 
+const demoteStaleAutoBookingTodos = `-- name: DemoteStaleAutoBookingTodos :execrows
+UPDATE booking_todos b
+SET auto = false
+WHERE b.trip_id = $1 AND b.auto = true AND b.todo_key <> ALL($2::text[])
+  AND (b.booked OR b.mode IS NOT NULL OR EXISTS (
+        SELECT 1 FROM trip_expenses e
+        WHERE e.trip_id = b.trip_id
+          AND e.source_kind = 'booking_todo' AND e.source_id = b.id))
+`
+
+type DemoteStaleAutoBookingTodosParams struct {
+	TripID uuid.UUID `json:"trip_id"`
+	Keys   []string  `json:"keys"`
+}
+
+// Half of the prune, and it MUST run before DeleteStaleAutoBookingTodos.
+//
+// A stale auto row that carries traveler state is not garbage — it is a booked
+// flight, a per-leg mode override, or the source of a budget expense. Deleting
+// it destroys all three silently (the expense survives with a dangling
+// source_id, still summed into `spent`, and unbooking can never find it again
+// — 00061 has no FK by design). So state-carrying rows are DEMOTED to manual
+// instead: auto = false takes them out of the derived set for good, they stop
+// being re-derived, and they render in the existing residual "Other bookings"
+// list where the traveler and the agent can edit or remove them. Demote rather
+// than merely skip: DeleteBookingTodoNonAuto refuses auto rows, so a skipped
+// survivor would be an undeletable zombie.
+func (q *Queries) DemoteStaleAutoBookingTodos(ctx context.Context, arg DemoteStaleAutoBookingTodosParams) (int64, error) {
+	result, err := q.db.Exec(ctx, demoteStaleAutoBookingTodos, arg.TripID, arg.Keys)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
 const listBookingTodosByTrip = `-- name: ListBookingTodosByTrip :many
-SELECT id, trip_id, kind, todo_key, title, subtitle, provider, search_url, depart_date, return_date, booked, auto, position, created_at, updated_at, mode FROM booking_todos WHERE trip_id = $1 ORDER BY position ASC, created_at ASC
+SELECT id, trip_id, kind, todo_key, title, subtitle, provider, search_url, depart_date, return_date, booked, auto, position, created_at, updated_at, mode, role, origin_label, destination_label FROM booking_todos WHERE trip_id = $1 ORDER BY position ASC, created_at ASC
 `
 
 func (q *Queries) ListBookingTodosByTrip(ctx context.Context, tripID uuid.UUID) ([]BookingTodo, error) {
@@ -148,6 +189,9 @@ func (q *Queries) ListBookingTodosByTrip(ctx context.Context, tripID uuid.UUID) 
 			&i.CreatedAt,
 			&i.UpdatedAt,
 			&i.Mode,
+			&i.Role,
+			&i.OriginLabel,
+			&i.DestinationLabel,
 		); err != nil {
 			return nil, err
 		}
@@ -160,7 +204,7 @@ func (q *Queries) ListBookingTodosByTrip(ctx context.Context, tripID uuid.UUID) 
 }
 
 const setBookingTodoBooked = `-- name: SetBookingTodoBooked :one
-UPDATE booking_todos SET booked = $3 WHERE id = $1 AND trip_id = $2 RETURNING id, trip_id, kind, todo_key, title, subtitle, provider, search_url, depart_date, return_date, booked, auto, position, created_at, updated_at, mode
+UPDATE booking_todos SET booked = $3 WHERE id = $1 AND trip_id = $2 RETURNING id, trip_id, kind, todo_key, title, subtitle, provider, search_url, depart_date, return_date, booked, auto, position, created_at, updated_at, mode, role, origin_label, destination_label
 `
 
 type SetBookingTodoBookedParams struct {
@@ -189,6 +233,9 @@ func (q *Queries) SetBookingTodoBooked(ctx context.Context, arg SetBookingTodoBo
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.Mode,
+		&i.Role,
+		&i.OriginLabel,
+		&i.DestinationLabel,
 	)
 	return i, err
 }
@@ -197,7 +244,7 @@ const setBookingTodoMode = `-- name: SetBookingTodoMode :one
 UPDATE booking_todos
 SET mode = $3, provider = $4, search_url = $5
 WHERE id = $1 AND trip_id = $2 AND kind = 'transport'
-RETURNING id, trip_id, kind, todo_key, title, subtitle, provider, search_url, depart_date, return_date, booked, auto, position, created_at, updated_at, mode
+RETURNING id, trip_id, kind, todo_key, title, subtitle, provider, search_url, depart_date, return_date, booked, auto, position, created_at, updated_at, mode, role, origin_label, destination_label
 `
 
 type SetBookingTodoModeParams struct {
@@ -238,6 +285,9 @@ func (q *Queries) SetBookingTodoMode(ctx context.Context, arg SetBookingTodoMode
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.Mode,
+		&i.Role,
+		&i.OriginLabel,
+		&i.DestinationLabel,
 	)
 	return i, err
 }
@@ -299,7 +349,7 @@ SET kind        = COALESCE($1, kind),
     provider    = COALESCE($7, provider),
     booked      = COALESCE($8, booked)
 WHERE id = $9 AND trip_id = $10 AND auto = false
-RETURNING id, trip_id, kind, todo_key, title, subtitle, provider, search_url, depart_date, return_date, booked, auto, position, created_at, updated_at, mode
+RETURNING id, trip_id, kind, todo_key, title, subtitle, provider, search_url, depart_date, return_date, booked, auto, position, created_at, updated_at, mode, role, origin_label, destination_label
 `
 
 type UpdateBookingTodoParams struct {
@@ -350,13 +400,16 @@ func (q *Queries) UpdateBookingTodo(ctx context.Context, arg UpdateBookingTodoPa
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.Mode,
+		&i.Role,
+		&i.OriginLabel,
+		&i.DestinationLabel,
 	)
 	return i, err
 }
 
 const upsertBookingTodo = `-- name: UpsertBookingTodo :one
-INSERT INTO booking_todos (trip_id, kind, todo_key, title, subtitle, provider, search_url, depart_date, return_date, position, auto)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, true)
+INSERT INTO booking_todos (trip_id, kind, todo_key, title, subtitle, provider, search_url, depart_date, return_date, position, auto, role, origin_label, destination_label)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, true, $11, $12, $13)
 ON CONFLICT (trip_id, todo_key) DO UPDATE SET
     kind = EXCLUDED.kind,
     title = EXCLUDED.title,
@@ -365,27 +418,38 @@ ON CONFLICT (trip_id, todo_key) DO UPDATE SET
     search_url = EXCLUDED.search_url,
     depart_date = EXCLUDED.depart_date,
     return_date = EXCLUDED.return_date,
-    position = EXCLUDED.position
-RETURNING id, trip_id, kind, todo_key, title, subtitle, provider, search_url, depart_date, return_date, booked, auto, position, created_at, updated_at, mode
+    position = EXCLUDED.position,
+    role = EXCLUDED.role,
+    origin_label = EXCLUDED.origin_label,
+    destination_label = EXCLUDED.destination_label
+RETURNING id, trip_id, kind, todo_key, title, subtitle, provider, search_url, depart_date, return_date, booked, auto, position, created_at, updated_at, mode, role, origin_label, destination_label
 `
 
 type UpsertBookingTodoParams struct {
-	TripID     uuid.UUID   `json:"trip_id"`
-	Kind       string      `json:"kind"`
-	TodoKey    string      `json:"todo_key"`
-	Title      string      `json:"title"`
-	Subtitle   *string     `json:"subtitle"`
-	Provider   *string     `json:"provider"`
-	SearchUrl  *string     `json:"search_url"`
-	DepartDate pgtype.Date `json:"depart_date"`
-	ReturnDate pgtype.Date `json:"return_date"`
-	Position   int32       `json:"position"`
+	TripID           uuid.UUID   `json:"trip_id"`
+	Kind             string      `json:"kind"`
+	TodoKey          string      `json:"todo_key"`
+	Title            string      `json:"title"`
+	Subtitle         *string     `json:"subtitle"`
+	Provider         *string     `json:"provider"`
+	SearchUrl        *string     `json:"search_url"`
+	DepartDate       pgtype.Date `json:"depart_date"`
+	ReturnDate       pgtype.Date `json:"return_date"`
+	Position         int32       `json:"position"`
+	Role             *string     `json:"role"`
+	OriginLabel      *string     `json:"origin_label"`
+	DestinationLabel *string     `json:"destination_label"`
 }
 
 // KEPT deliberately though no handler calls it directly: it is the semantic
 // reference for UpsertBookingTodosBatch's column list / ON CONFLICT set, and
 // its generated Params struct is the row type the batch path builds
 // (booking_todo_handler.go). Delete only together with a handler refactor.
+//
+// role/origin_label/destination_label (00064) are CONTENT, like title: they
+// ride the DO UPDATE set so a re-sync refreshes them. What must never join it
+// is booked/auto/mode — that exclusion is the whole preservation contract, and
+// it is what lets a changed departure airport rewrite a home leg in place.
 func (q *Queries) UpsertBookingTodo(ctx context.Context, arg UpsertBookingTodoParams) (BookingTodo, error) {
 	row := q.db.QueryRow(ctx, upsertBookingTodo,
 		arg.TripID,
@@ -398,6 +462,9 @@ func (q *Queries) UpsertBookingTodo(ctx context.Context, arg UpsertBookingTodoPa
 		arg.DepartDate,
 		arg.ReturnDate,
 		arg.Position,
+		arg.Role,
+		arg.OriginLabel,
+		arg.DestinationLabel,
 	)
 	var i BookingTodo
 	err := row.Scan(
@@ -417,17 +484,24 @@ func (q *Queries) UpsertBookingTodo(ctx context.Context, arg UpsertBookingTodoPa
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.Mode,
+		&i.Role,
+		&i.OriginLabel,
+		&i.DestinationLabel,
 	)
 	return i, err
 }
 
 const upsertBookingTodosBatch = `-- name: UpsertBookingTodosBatch :exec
-INSERT INTO booking_todos (trip_id, kind, todo_key, title, subtitle, provider, search_url, depart_date, return_date, position, auto)
+INSERT INTO booking_todos (trip_id, kind, todo_key, title, subtitle, provider, search_url, depart_date, return_date, position, auto, role, origin_label, destination_label)
 SELECT $1::uuid, u.kind, u.todo_key, u.title,
        CASE WHEN u.subtitle_null THEN NULL ELSE u.subtitle END,
        CASE WHEN u.provider_null THEN NULL ELSE u.provider END,
        CASE WHEN u.search_url_null THEN NULL ELSE u.search_url END,
-       u.depart_date, u.return_date, u.position, true
+       u.depart_date, u.return_date, u.position, true,
+       u.role,
+       -- A label has no meaningful empty value, so NULLIF carries the "this
+       -- row has no origin" case (every stay row) without a third null mask.
+       NULLIF(u.origin_label, ''), NULLIF(u.destination_label, '')
 FROM (
     SELECT unnest($2::text[])            AS kind,
            unnest($3::text[])        AS todo_key,
@@ -440,7 +514,10 @@ FROM (
            unnest($10::bool[]) AS search_url_null,
            unnest($11::date[])     AS depart_date,
            unnest($12::date[])     AS return_date,
-           unnest($13::int[])         AS position
+           unnest($13::int[])         AS position,
+           unnest($14::text[])            AS role,
+           unnest($15::text[])    AS origin_label,
+           unnest($16::text[]) AS destination_label
 ) AS u
 ON CONFLICT (trip_id, todo_key) DO UPDATE SET
     kind = EXCLUDED.kind,
@@ -450,23 +527,29 @@ ON CONFLICT (trip_id, todo_key) DO UPDATE SET
     search_url = EXCLUDED.search_url,
     depart_date = EXCLUDED.depart_date,
     return_date = EXCLUDED.return_date,
-    position = EXCLUDED.position
+    position = EXCLUDED.position,
+    role = EXCLUDED.role,
+    origin_label = EXCLUDED.origin_label,
+    destination_label = EXCLUDED.destination_label
 `
 
 type UpsertBookingTodosBatchParams struct {
-	TripID         uuid.UUID     `json:"trip_id"`
-	Kinds          []string      `json:"kinds"`
-	TodoKeys       []string      `json:"todo_keys"`
-	Titles         []string      `json:"titles"`
-	Subtitles      []string      `json:"subtitles"`
-	SubtitleNulls  []bool        `json:"subtitle_nulls"`
-	Providers      []string      `json:"providers"`
-	ProviderNulls  []bool        `json:"provider_nulls"`
-	SearchUrls     []string      `json:"search_urls"`
-	SearchUrlNulls []bool        `json:"search_url_nulls"`
-	DepartDates    []pgtype.Date `json:"depart_dates"`
-	ReturnDates    []pgtype.Date `json:"return_dates"`
-	Positions      []int32       `json:"positions"`
+	TripID            uuid.UUID     `json:"trip_id"`
+	Kinds             []string      `json:"kinds"`
+	TodoKeys          []string      `json:"todo_keys"`
+	Titles            []string      `json:"titles"`
+	Subtitles         []string      `json:"subtitles"`
+	SubtitleNulls     []bool        `json:"subtitle_nulls"`
+	Providers         []string      `json:"providers"`
+	ProviderNulls     []bool        `json:"provider_nulls"`
+	SearchUrls        []string      `json:"search_urls"`
+	SearchUrlNulls    []bool        `json:"search_url_nulls"`
+	DepartDates       []pgtype.Date `json:"depart_dates"`
+	ReturnDates       []pgtype.Date `json:"return_dates"`
+	Positions         []int32       `json:"positions"`
+	Roles             []string      `json:"roles"`
+	OriginLabels      []string      `json:"origin_labels"`
+	DestinationLabels []string      `json:"destination_labels"`
 }
 
 // Batch twin of UpsertBookingTodo: one round trip for the whole derived set.
@@ -496,6 +579,9 @@ func (q *Queries) UpsertBookingTodosBatch(ctx context.Context, arg UpsertBooking
 		arg.DepartDates,
 		arg.ReturnDates,
 		arg.Positions,
+		arg.Roles,
+		arg.OriginLabels,
+		arg.DestinationLabels,
 	)
 	return err
 }

--- a/src/packages/api/store/collaborators.sql.go
+++ b/src/packages/api/store/collaborators.sql.go
@@ -52,7 +52,7 @@ func (q *Queries) CreateTripCollaborator(ctx context.Context, arg CreateTripColl
 }
 
 const getEditableTripByID = `-- name: GetEditableTripByID :one
-SELECT t.id, t.user_id, t.created_at, t.updated_at, t.title, t.start_date, t.end_date, t.chat_id, t.summary, t.updated_by, t.travel_mode, t.origin FROM trips t
+SELECT t.id, t.user_id, t.created_at, t.updated_at, t.title, t.start_date, t.end_date, t.chat_id, t.summary, t.updated_by, t.travel_mode, t.origin, t.origin_airport, t.return_airport FROM trips t
 WHERE t.id = $1
   AND (t.user_id = $2 OR EXISTS (
         SELECT 1 FROM trip_collaborators c
@@ -84,12 +84,14 @@ func (q *Queries) GetEditableTripByID(ctx context.Context, arg GetEditableTripBy
 		&i.UpdatedBy,
 		&i.TravelMode,
 		&i.Origin,
+		&i.OriginAirport,
+		&i.ReturnAirport,
 	)
 	return i, err
 }
 
 const getViewableTripByID = `-- name: GetViewableTripByID :one
-SELECT t.id, t.user_id, t.created_at, t.updated_at, t.title, t.start_date, t.end_date, t.chat_id, t.summary, t.updated_by, t.travel_mode, t.origin, CASE WHEN t.user_id = $2 THEN 'owner' ELSE c.role END::text AS access
+SELECT t.id, t.user_id, t.created_at, t.updated_at, t.title, t.start_date, t.end_date, t.chat_id, t.summary, t.updated_by, t.travel_mode, t.origin, t.origin_airport, t.return_airport, CASE WHEN t.user_id = $2 THEN 'owner' ELSE c.role END::text AS access
 FROM trips t
 LEFT JOIN trip_collaborators c ON c.owner_id = t.user_id AND c.chat_id = t.chat_id
      AND c.user_id = $2 AND c.revoked_at IS NULL
@@ -102,19 +104,21 @@ type GetViewableTripByIDParams struct {
 }
 
 type GetViewableTripByIDRow struct {
-	ID         uuid.UUID   `json:"id"`
-	UserID     uuid.UUID   `json:"user_id"`
-	CreatedAt  time.Time   `json:"created_at"`
-	UpdatedAt  time.Time   `json:"updated_at"`
-	Title      string      `json:"title"`
-	StartDate  pgtype.Date `json:"start_date"`
-	EndDate    pgtype.Date `json:"end_date"`
-	ChatID     *string     `json:"chat_id"`
-	Summary    *string     `json:"summary"`
-	UpdatedBy  pgtype.UUID `json:"updated_by"`
-	TravelMode *string     `json:"travel_mode"`
-	Origin     *string     `json:"origin"`
-	Access     string      `json:"access"`
+	ID            uuid.UUID   `json:"id"`
+	UserID        uuid.UUID   `json:"user_id"`
+	CreatedAt     time.Time   `json:"created_at"`
+	UpdatedAt     time.Time   `json:"updated_at"`
+	Title         string      `json:"title"`
+	StartDate     pgtype.Date `json:"start_date"`
+	EndDate       pgtype.Date `json:"end_date"`
+	ChatID        *string     `json:"chat_id"`
+	Summary       *string     `json:"summary"`
+	UpdatedBy     pgtype.UUID `json:"updated_by"`
+	TravelMode    *string     `json:"travel_mode"`
+	Origin        *string     `json:"origin"`
+	OriginAirport *string     `json:"origin_airport"`
+	ReturnAirport *string     `json:"return_airport"`
+	Access        string      `json:"access"`
 }
 
 // Read access: owner or ANY active collaborator (viewer follows included).
@@ -137,6 +141,8 @@ func (q *Queries) GetViewableTripByID(ctx context.Context, arg GetViewableTripBy
 		&i.UpdatedBy,
 		&i.TravelMode,
 		&i.Origin,
+		&i.OriginAirport,
+		&i.ReturnAirport,
 		&i.Access,
 	)
 	return i, err

--- a/src/packages/api/store/models.go
+++ b/src/packages/api/store/models.go
@@ -51,22 +51,25 @@ type AuthIdentity struct {
 }
 
 type BookingTodo struct {
-	ID         uuid.UUID   `json:"id"`
-	TripID     uuid.UUID   `json:"trip_id"`
-	Kind       string      `json:"kind"`
-	TodoKey    string      `json:"todo_key"`
-	Title      string      `json:"title"`
-	Subtitle   *string     `json:"subtitle"`
-	Provider   *string     `json:"provider"`
-	SearchUrl  *string     `json:"search_url"`
-	DepartDate pgtype.Date `json:"depart_date"`
-	ReturnDate pgtype.Date `json:"return_date"`
-	Booked     bool        `json:"booked"`
-	Auto       bool        `json:"auto"`
-	Position   int32       `json:"position"`
-	CreatedAt  time.Time   `json:"created_at"`
-	UpdatedAt  time.Time   `json:"updated_at"`
-	Mode       *string     `json:"mode"`
+	ID               uuid.UUID   `json:"id"`
+	TripID           uuid.UUID   `json:"trip_id"`
+	Kind             string      `json:"kind"`
+	TodoKey          string      `json:"todo_key"`
+	Title            string      `json:"title"`
+	Subtitle         *string     `json:"subtitle"`
+	Provider         *string     `json:"provider"`
+	SearchUrl        *string     `json:"search_url"`
+	DepartDate       pgtype.Date `json:"depart_date"`
+	ReturnDate       pgtype.Date `json:"return_date"`
+	Booked           bool        `json:"booked"`
+	Auto             bool        `json:"auto"`
+	Position         int32       `json:"position"`
+	CreatedAt        time.Time   `json:"created_at"`
+	UpdatedAt        time.Time   `json:"updated_at"`
+	Mode             *string     `json:"mode"`
+	Role             *string     `json:"role"`
+	OriginLabel      *string     `json:"origin_label"`
+	DestinationLabel *string     `json:"destination_label"`
 }
 
 type EmailToken struct {
@@ -270,18 +273,20 @@ type TravelerPreference struct {
 }
 
 type Trip struct {
-	ID         uuid.UUID   `json:"id"`
-	UserID     uuid.UUID   `json:"user_id"`
-	CreatedAt  time.Time   `json:"created_at"`
-	UpdatedAt  time.Time   `json:"updated_at"`
-	Title      string      `json:"title"`
-	StartDate  pgtype.Date `json:"start_date"`
-	EndDate    pgtype.Date `json:"end_date"`
-	ChatID     *string     `json:"chat_id"`
-	Summary    *string     `json:"summary"`
-	UpdatedBy  pgtype.UUID `json:"updated_by"`
-	TravelMode *string     `json:"travel_mode"`
-	Origin     *string     `json:"origin"`
+	ID            uuid.UUID   `json:"id"`
+	UserID        uuid.UUID   `json:"user_id"`
+	CreatedAt     time.Time   `json:"created_at"`
+	UpdatedAt     time.Time   `json:"updated_at"`
+	Title         string      `json:"title"`
+	StartDate     pgtype.Date `json:"start_date"`
+	EndDate       pgtype.Date `json:"end_date"`
+	ChatID        *string     `json:"chat_id"`
+	Summary       *string     `json:"summary"`
+	UpdatedBy     pgtype.UUID `json:"updated_by"`
+	TravelMode    *string     `json:"travel_mode"`
+	Origin        *string     `json:"origin"`
+	OriginAirport *string     `json:"origin_airport"`
+	ReturnAirport *string     `json:"return_airport"`
 }
 
 type TripBudget struct {

--- a/src/packages/api/store/shares.sql.go
+++ b/src/packages/api/store/shares.sql.go
@@ -95,7 +95,7 @@ func (q *Queries) GetActiveShareByToken(ctx context.Context, token string) (Trip
 }
 
 const getLatestTripByOwnerAndChat = `-- name: GetLatestTripByOwnerAndChat :one
-SELECT id, user_id, created_at, updated_at, title, start_date, end_date, chat_id, summary, updated_by, travel_mode, origin FROM trips
+SELECT id, user_id, created_at, updated_at, title, start_date, end_date, chat_id, summary, updated_by, travel_mode, origin, origin_airport, return_airport FROM trips
 WHERE user_id = $1 AND chat_id = $2
 ORDER BY created_at DESC
 LIMIT 1
@@ -123,6 +123,8 @@ func (q *Queries) GetLatestTripByOwnerAndChat(ctx context.Context, arg GetLatest
 		&i.UpdatedBy,
 		&i.TravelMode,
 		&i.Origin,
+		&i.OriginAirport,
+		&i.ReturnAirport,
 	)
 	return i, err
 }

--- a/src/packages/api/store/trips.sql.go
+++ b/src/packages/api/store/trips.sql.go
@@ -110,7 +110,7 @@ func (q *Queries) CreateItineraryItem(ctx context.Context, arg CreateItineraryIt
 const createTrip = `-- name: CreateTrip :one
 INSERT INTO trips (user_id, title, chat_id, summary, travel_mode, origin, updated_by)
 VALUES ($1, $2, $3, $4, $5, $6, $1)
-RETURNING id, user_id, created_at, updated_at, title, start_date, end_date, chat_id, summary, updated_by, travel_mode, origin
+RETURNING id, user_id, created_at, updated_at, title, start_date, end_date, chat_id, summary, updated_by, travel_mode, origin, origin_airport, return_airport
 `
 
 type CreateTripParams struct {
@@ -147,6 +147,8 @@ func (q *Queries) CreateTrip(ctx context.Context, arg CreateTripParams) (Trip, e
 		&i.UpdatedBy,
 		&i.TravelMode,
 		&i.Origin,
+		&i.OriginAirport,
+		&i.ReturnAirport,
 	)
 	return i, err
 }
@@ -246,7 +248,7 @@ func (q *Queries) GetItineraryItemsByTrip(ctx context.Context, tripID uuid.UUID)
 }
 
 const getTripByIDAndOwner = `-- name: GetTripByIDAndOwner :one
-SELECT id, user_id, created_at, updated_at, title, start_date, end_date, chat_id, summary, updated_by, travel_mode, origin FROM trips WHERE id = $1 AND user_id = $2
+SELECT id, user_id, created_at, updated_at, title, start_date, end_date, chat_id, summary, updated_by, travel_mode, origin, origin_airport, return_airport FROM trips WHERE id = $1 AND user_id = $2
 `
 
 type GetTripByIDAndOwnerParams struct {
@@ -270,12 +272,14 @@ func (q *Queries) GetTripByIDAndOwner(ctx context.Context, arg GetTripByIDAndOwn
 		&i.UpdatedBy,
 		&i.TravelMode,
 		&i.Origin,
+		&i.OriginAirport,
+		&i.ReturnAirport,
 	)
 	return i, err
 }
 
 const getTripForUpdate = `-- name: GetTripForUpdate :one
-SELECT id, user_id, created_at, updated_at, title, start_date, end_date, chat_id, summary, updated_by, travel_mode, origin FROM trips WHERE id = $1 FOR UPDATE
+SELECT id, user_id, created_at, updated_at, title, start_date, end_date, chat_id, summary, updated_by, travel_mode, origin, origin_airport, return_airport FROM trips WHERE id = $1 FOR UPDATE
 `
 
 // Row-locks the trip for the duration of the transaction. Full-itinerary
@@ -298,6 +302,8 @@ func (q *Queries) GetTripForUpdate(ctx context.Context, id uuid.UUID) (Trip, err
 		&i.UpdatedBy,
 		&i.TravelMode,
 		&i.Origin,
+		&i.OriginAirport,
+		&i.ReturnAirport,
 	)
 	return i, err
 }
@@ -529,7 +535,7 @@ func (q *Queries) ListLatestTripsByOwner(ctx context.Context, userID uuid.UUID) 
 }
 
 const listTripVersionsByChat = `-- name: ListTripVersionsByChat :many
-SELECT id, user_id, created_at, updated_at, title, start_date, end_date, chat_id, summary, updated_by, travel_mode, origin FROM trips WHERE user_id = $1 AND chat_id = $2 ORDER BY created_at DESC
+SELECT id, user_id, created_at, updated_at, title, start_date, end_date, chat_id, summary, updated_by, travel_mode, origin, origin_airport, return_airport FROM trips WHERE user_id = $1 AND chat_id = $2 ORDER BY created_at DESC
 `
 
 type ListTripVersionsByChatParams struct {
@@ -559,6 +565,8 @@ func (q *Queries) ListTripVersionsByChat(ctx context.Context, arg ListTripVersio
 			&i.UpdatedBy,
 			&i.TravelMode,
 			&i.Origin,
+			&i.OriginAirport,
+			&i.ReturnAirport,
 		); err != nil {
 			return nil, err
 		}
@@ -571,7 +579,7 @@ func (q *Queries) ListTripVersionsByChat(ctx context.Context, arg ListTripVersio
 }
 
 const listTripsByOwner = `-- name: ListTripsByOwner :many
-SELECT id, user_id, created_at, updated_at, title, start_date, end_date, chat_id, summary, updated_by, travel_mode, origin FROM trips WHERE user_id = $1 ORDER BY created_at DESC
+SELECT id, user_id, created_at, updated_at, title, start_date, end_date, chat_id, summary, updated_by, travel_mode, origin, origin_airport, return_airport FROM trips WHERE user_id = $1 ORDER BY created_at DESC
 `
 
 func (q *Queries) ListTripsByOwner(ctx context.Context, userID uuid.UUID) ([]Trip, error) {
@@ -596,6 +604,8 @@ func (q *Queries) ListTripsByOwner(ctx context.Context, userID uuid.UUID) ([]Tri
 			&i.UpdatedBy,
 			&i.TravelMode,
 			&i.Origin,
+			&i.OriginAirport,
+			&i.ReturnAirport,
 		); err != nil {
 			return nil, err
 		}
@@ -780,7 +790,7 @@ SET title      = COALESCE($1, title),
     chat_id    = COALESCE($4, chat_id),
     travel_mode = COALESCE($5, travel_mode)
 WHERE id = $6 AND user_id = $7
-RETURNING id, user_id, created_at, updated_at, title, start_date, end_date, chat_id, summary, updated_by, travel_mode, origin
+RETURNING id, user_id, created_at, updated_at, title, start_date, end_date, chat_id, summary, updated_by, travel_mode, origin, origin_airport, return_airport
 `
 
 type UpdateTripParams struct {
@@ -817,6 +827,8 @@ func (q *Queries) UpdateTrip(ctx context.Context, arg UpdateTripParams) (Trip, e
 		&i.UpdatedBy,
 		&i.TravelMode,
 		&i.Origin,
+		&i.OriginAirport,
+		&i.ReturnAirport,
 	)
 	return i, err
 }

--- a/src/packages/api/trip_next_step.go
+++ b/src/packages/api/trip_next_step.go
@@ -455,9 +455,11 @@ func todoClaimed(d exportData, t store.BookingTodo) bool {
 			}
 		}
 	case "transport":
-		key := strings.TrimPrefix(t.TodoKey, "transport:")
-		origin, dest, ok := strings.Cut(key, ">>")
-		if !ok || key == t.TodoKey {
+		// The stored endpoints (00064), not a key parse: a home leg's key
+		// carries the reserved @home token, which names no place a segment
+		// could connect. legEndpoints applies the same precedence.
+		origin, dest, ok := legEndpoints(t)
+		if !ok {
 			return false
 		}
 		var confirmed []store.TripSegment
@@ -613,13 +615,17 @@ func bookingSlotStep(locale string, d exportData, t store.BookingTodo) *NextStep
 	return staySlotStep(locale, d, t)
 }
 
-// legEndpoints extracts a transport slot's origin/destination, preferring the
-// title ("<Origin> → <Destination>", the only survivor of the client's
-// casing — see the section comment above) and falling back to the todo_key
-// "transport:<o>>><d>" parse todoClaimed uses (lowercase). ok=false when both
-// fail (a hand-renamed title over an unparseable key); the step then keeps
-// the generic endpoint-less copy.
+// legEndpoints extracts a transport slot's origin/destination. The stored
+// endpoint labels win (00064 promoted them out of the string), then the title
+// ("<Origin> → <Destination>", which carried the client's casing before those
+// columns existed), then the todo_key parse — which a home leg's key can no
+// longer satisfy, since @home names no place. ok=false when all three fail (a
+// hand-renamed title over an unparseable key); the step then keeps the generic
+// endpoint-less copy.
 func legEndpoints(t store.BookingTodo) (origin, dest string, ok bool) {
+	if o, d := strings.TrimSpace(strPtrVal(t.OriginLabel)), strings.TrimSpace(strPtrVal(t.DestinationLabel)); namesAPlace(o) && namesAPlace(d) {
+		return o, d, true
+	}
 	if o, d, found := strings.Cut(t.Title, " → "); found {
 		if o, d = strings.TrimSpace(o), strings.TrimSpace(d); namesAPlace(o) && namesAPlace(d) {
 			return o, d, true
@@ -635,17 +641,20 @@ func legEndpoints(t store.BookingTodo) (origin, dest string, ok bool) {
 	return "", "", false
 }
 
-// namesAPlace rejects the empty string and the two grouping placeholders that
-// stand in for "we could not resolve a city": the server's own "Itinerary"
-// hub and the client's kOtherPlacesLabel (trip_legs.dart — documented as
-// never translated, because screens localize it at render time). Neither is
-// somewhere a traveler can sleep or fly to, so a slot naming one keeps the
-// generic copy and an endpoint-less fix — the same silence checkLodging and
-// checkTransit keep for a hubless group, and it also keeps the placeholder
-// out of the canonical-English seed, where it would send the agent hunting
-// for hotels in a city called "Other places".
+// namesAPlace rejects the empty string, any reserved `@`-prefixed identity
+// token (@home — see booking_todo_identity.go; `@` cannot occur in an IATA
+// code or a Places label, so the prefix covers every token we ever add), and
+// the two grouping placeholders that stand in for "we could not resolve a
+// city": the server's own "Itinerary" hub and the client's kOtherPlacesLabel
+// (trip_legs.dart — documented as never translated, because screens localize
+// it at render time). None is somewhere a traveler can sleep or fly to, so a
+// slot naming one keeps the generic copy and an endpoint-less fix — the same
+// silence checkLodging and checkTransit keep for a hubless group, and it also
+// keeps the placeholder out of the canonical-English seed, where it would send
+// the agent hunting for hotels in a city called "Other places".
 func namesAPlace(s string) bool {
-	return s != "" && !strings.EqualFold(s, "Itinerary") && !strings.EqualFold(s, "Other places")
+	return s != "" && !strings.HasPrefix(s, "@") &&
+		!strings.EqualFold(s, "Itinerary") && !strings.EqualFold(s, "Other places")
 }
 
 // staySlotCity extracts a stay slot's city: the "Stay in <Label>" title keeps
@@ -653,6 +662,9 @@ func namesAPlace(s string) bool {
 // fallback for hand-renamed titles; "" when neither yields one (the step then
 // keeps the generic addLodging title).
 func staySlotCity(t store.BookingTodo) string {
+	if c := strings.TrimSpace(strPtrVal(t.DestinationLabel)); namesAPlace(c) {
+		return c
+	}
 	if c := strings.TrimPrefix(t.Title, "Stay in "); c != t.Title {
 		if c = strings.TrimSpace(c); namesAPlace(c) {
 			return c
@@ -736,8 +748,14 @@ func slotDay(trip store.Trip, depart pgtype.Date) *int {
 func transportSlotStep(locale string, d exportData, t store.BookingTodo) *NextStep {
 	origin, dest, ok := legEndpoints(t)
 	mode := transportSlotMode(d.Trip, t)
-	set := stayCitySet(d.BookingTodos)
-	home := ok && len(set) > 0 && !set[strings.ToLower(dest)]
+	// The stored role (00064) says outright whether this is the leg home; the
+	// stay-set inference below is the fallback for rows written before it, and
+	// is what the role column was promoted from.
+	home := strPtrVal(t.Role) == roleHomeReturn
+	if t.Role == nil {
+		set := stayCitySet(d.BookingTodos)
+		home = ok && len(set) > 0 && !set[strings.ToLower(dest)]
+	}
 
 	modeKey := "generic"
 	switch strPtrVal(mode) {

--- a/src/packages/api/trip_review.go
+++ b/src/packages/api/trip_review.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/jackc/pgx/v5/pgtype"
 	"golang.org/x/sync/errgroup"
@@ -713,7 +714,28 @@ func fuzzyMatch(a, b string) bool {
 	if a == "" || b == "" {
 		return false
 	}
+	// Short tokens match whole WORDS, not substrings. A derived home leg's
+	// endpoint can now be an IATA code (00064), and a plain substring test lets
+	// "alb" claim a confirmed segment to "Albufeira" — which would silently
+	// mark the flight out as already booked. Whole-word matching still lets
+	// genuinely short city names work ("rio" ↔ "Rio de Janeiro").
+	if len(a) <= 3 || len(b) <= 3 {
+		return a == b || hasWord(a, b) || hasWord(b, a)
+	}
 	return strings.Contains(a, b) || strings.Contains(b, a)
+}
+
+// hasWord reports whether w appears in s as a whole alphanumeric word, so
+// punctuation and separators ("New York, NY") don't hide a match.
+func hasWord(s, w string) bool {
+	for _, f := range strings.FieldsFunc(s, func(r rune) bool {
+		return !unicode.IsLetter(r) && !unicode.IsDigit(r)
+	}) {
+		if f == w {
+			return true
+		}
+	}
+	return false
 }
 
 // checkBudget flags a trip whose spending exceeds its target.


### PR DESCRIPTION
Stage 1 of the fix for "the trip planning tool couldn't change the airport from EWR to ALB." **Inert to users on its own** — it changes what makes a derived checklist row *the same row*, so that stage 2 (per-trip departure/return airports + the `set_trip_origin` agent tool) can move an airport without destroying anything.

## The bug this closes on its own

A derived transport row was identified by its endpoint labels — `transport:<origin>>><dest>` — where the origin token was whatever the renderer had on hand: `trips.origin`, or failing that **the viewer's saved home airport**. Label and identity were the same string, so changing the label changed the key and `DeleteStaleAutoBookingTodos` deleted the row, taking the `booked` flag, the per-leg `mode` override (00055) and the linked expense's `source_id` (00061, no FK) with it.

Migration 00062 froze `trips.origin` to dodge exactly this. But the wider door stayed open: `traveler_preferences.home_airport` is freely mutable (Settings, the `save_preferences` agent tool, the background profile distiller), and the trip screen re-derives and re-syncs on the very next open. **Correcting your home airport silently dropped booked flags and stranded budget money on every trip you own** — and a collaborator opening a shared trip did the same with *their* airport.

`docs/zen.md` names this failure mode: *an invariant that only holds implicitly — via rows that can be deleted — is not an invariant.*

## What changes

The two home legs key on a reserved `@home` token whose **position** carries the direction, and the endpoints become columns:

```
home_outbound  transport:@home>>amsterdam   origin_label='ALB'
home_return    transport:rome>>@home        destination_label='EWR'
inter_city     transport:paris>>rome        (key unchanged)
stay           stay:paris                   (key unchanged)
```

Changing an airport is then an in-place title/label update the existing batch upsert already performs (`booked`/`auto`/`mode` are deliberately outside its `DO UPDATE`). Because the token's position distinguishes the directions, a trip can leave from ALB and come home into EWR without the two legs colliding. CHECK constraints pair each home role with its key shape, so a wrong canonicalization fails at write time instead of storing a plausible-looking wrong row.

**Canonicalization is server-side, never posted by the client.** That is what makes a stale tab, an old cached bundle, or a collaborator's device land on the *same* row instead of pruning it — and why this needs no client flag day. The home legs' labels are then taken from the **trip** rather than from the poster, which is what stops a collaborator retitling the owner's flights.

Also in here:

- **The prune demotes rather than deletes.** A stale row carrying a booked flag, a mode, or an expense link becomes an ordinary manual row in the existing "Other bookings" list instead of being destroyed. Demote (`auto = false`) rather than merely skip: `DeleteBookingTodoNonAuto` refuses auto rows, so a skipped survivor would be an undeletable zombie.
- `todoClaimed` / `legEndpoints` / `staySlotCity` / `transportSlotStep` read the stored endpoints instead of parsing the key.
- `namesAPlace` rejects `@`-prefixed tokens, so `@home` can never reach traveler-facing copy or the agent seed.
- `fuzzyMatch` matches short tokens as whole words — `"alb"` no longer claims a confirmed segment to **Albufeira** and silently marks the flight out as booked. Deliberate cost, documented in the test: a code no longer claims the spelled-out airport it stands for. A missed claim offers to book something already booked; a false claim hides an unbooked flight.
- The wire keeps the endpoint-labelled key (`displayBookingTodoKey`), so every existing client matcher and the `booking_marked_booked` analytics history are untouched. It dies at the `specs/server-booking-todos` flip.
- `trips` gains `origin_airport` / `return_airport` with **no writer yet** — stage 2 adds the tool.

## Migration 00064

Every backfill statement is an id-preserving `UPDATE`, never delete+insert, so `booked`, `mode`, `position`, `created_at` and every `trip_expenses.source_id` link survive by construction. A rename blocked by a key collision is a no-op that leaves the row `inter_city` — the runtime canonicalizer has the identical fallback, so the two paths agree.

Worth running before deploy, as the honest accounting of what this has already cost:

```sql
SELECT count(*) FROM trip_expenses e WHERE e.source_kind='booking_todo'
  AND NOT EXISTS (SELECT 1 FROM booking_todos b WHERE b.id = e.source_id);
```

## Tests

New: the canonicalization table (round trip, **asymmetric endpoints**, single-city, lone leg, one-way, empty stay set, revisited city, "Other places", foreign key shape, collision fallback); the display-key round trip; the endpoint ladder; short-token `fuzzyMatch`; `namesAPlace` rejecting reserved tokens.

Integration, written against the outcome rather than the mechanism so they survive the eventual move to server-side derivation:

- `TestHomeLegSurvivesHomeAirportChange` — book the outbound, set a mode, link an expense, change the saved home airport, re-sync. Same row id, flag/mode/expense intact, titles followed the airport, no duplicate.
- `TestAsymmetricHomeLegsAreIndependent` — moving only the departure leaves the booked return byte-identical.
- `TestStalePruneDemotesInvestedRowsAndDeletesTheRest` — booked row survives as manual and is now deletable; untouched row is still pruned.

I sabotaged the canonicalizer and re-ran to confirm these fail without it: the re-sync produced **4 rows** — a stranded `EWR → Amsterdam` alongside a fresh duplicate `ALB → Amsterdam`. That is the duplicate-row mess from the original report.

Full suite green (`go test ./...`), `go vet` and `go fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)