### PR TITLE
fix(budget): the add-expense row keeps what you typed

### DIFF
--- a/docs/friction-log.md
+++ b/docs/friction-log.md
@@ -5,6 +5,62 @@ build queue. Priority when picking work: **breakage > friction in features
 actually used > ideas that recur across ≥2 sessions**. Tag entries `[app]`
 (dogfooding the product) or `[dev]` (workflow/tooling). Newest first.
 
+## 2026-08-15 — the budget row that empties itself while you fetch the price
+
+- **[app] Friction:** logging a flight as an expense means going and getting
+  the price. Type "Flight to Amsterdam", go look it up, come back — the row is
+  blank. Type it again.
+- **[app] Four things unmount that row, and the flow needs at least one of
+  them.** The draft lived only in `_BudgetSectionState`'s two controllers plus
+  `_addCategory`. `BudgetSection` is a **conditional sliver**
+  (`if (_inBudgetView)`), so any header-tab switch destroys it — and "Find
+  flights" only renders on the booking rows, so getting there means leaving
+  Budget. Worse, the **chat panel** (the other place to ask about flights)
+  never pushed a route: the body returns a bare `RefreshIndicator` when closed
+  and a `Row`/`Stack` when open, so `Widget.canUpdate` fails and the entire
+  body subtree is re-inflated — on open **and** on close, and again at the
+  900px docked/undocked boundary. The text was gone before the question was
+  asked. The offline banner (which wraps the body in a `Column`) and any loud
+  `_load()` do the same.
+- **[app] The one that sounded worst was already fine.** Pushing the Find
+  Flights screen is a plain `MaterialPageRoute` with `maintainState: true`, and
+  top-level tab switches keep every tab mounted (`IndexedStack` +
+  `TickerMode`). Both preserve everything. Worth checking before fixing: two of
+  the five suspects were innocent.
+- **[app] Fix: the draft is not widget state.** `expenseDraftProvider`, a
+  non-autoDispose `StateNotifierProvider.family` keyed by trip — the same
+  bargain `tripRefineProvider` already makes for the panel conversation, whose
+  docstring says out loud that keepAlive "preserves the conversation across
+  panel close/reopen". The chat transcript already survived this exact remount
+  because someone hit it before; the expense row never got the same treatment.
+  The category moved there too and stopped being a second copy: it was a
+  *choice*, and silently resetting it to General misfiles the next expense.
+- **[dev] `ref` inside `dispose()` is not a risk to weigh, it is a guaranteed
+  throw.** `StatefulElement.unmount()` nulls `_widget` *before* calling
+  `state.dispose()`, and every riverpod `ref` method gates on
+  `context.mounted`. So "write the draft on the way out" is not an option at
+  all — write-through on change is the only design. Which surfaced the next
+  one:
+- **[app] A shipped bug the draft made visible: `_run` invalidated through a
+  dead `ref`.** `_run` awaits the POST and *then* calls
+  `ref.invalidate(budget/expenses)`. Tab away mid-request — the routine case
+  here, not an edge one — and both throw into `catch (_)`. The server had taken
+  the expense and no client ever refetched it, so it simply did not appear.
+  Fixed by capturing the `ProviderContainer` while still mounted. Pinned by a
+  test that fails with `ref.` restored. **Lesson, the same one the draft
+  teaches: anything that has to happen after an await cannot be reached
+  through the widget that started it.**
+- **[dev] A remount test needs one container, not two.** `pumpWidget` a second
+  time with a fresh `ProviderScope` builds a new `ProviderContainer` and proves
+  nothing — it would pass against the broken code. The section has to be
+  toggled behind a conditional *inside* one scope, which is also exactly what
+  `if (_inBudgetView)` does in the real screen.
+- **[dev] Both non-obvious tests were checked against the un-fixed code
+  first.** The "typing never rebuilds the list" test (watch the
+  `LinearProgressIndicator`'s identity) and the mid-save one both fail when
+  their fix is reverted. A guard test nobody has watched fail is a guard test
+  nobody has tested.
+
 ## 2026-08-15 — the flight that leaves the day before it lands
 
 - **[app] Friction:** the Amsterdam leg read `Aug 24 – Aug 26 · 2 nights` and the

--- a/src/packages/flutter-app/lib/providers/budget_provider.dart
+++ b/src/packages/flutter-app/lib/providers/budget_provider.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../models/budget.dart';
 import '../models/expense.dart';
@@ -22,3 +23,72 @@ final expensesProvider =
     FutureProvider.family<List<Expense>, String>((ref, tripId) async {
   return ref.watch(budgetApiServiceProvider).listExpenses(tripId);
 });
+
+/// What the traveler has typed into the Budget tab's add-expense row and not
+/// saved yet.
+///
+/// It lives here rather than in `BudgetSection`'s State because that widget is
+/// torn down constantly, and none of the reasons are the traveler's doing:
+/// it is a conditional sliver, so switching to Itinerary or Bookings unmounts
+/// it, and opening or closing the refine chat panel re-parents the whole trip
+/// body and disposes everything beneath it. Pricing a flight means doing one
+/// of those — "Find flights" lives on the booking rows, and the chat is the
+/// other place to ask — so the row was reliably empty on the way back.
+///
+/// In-memory and keyed by trip, deliberately: it survives every in-app hop,
+/// and a page reload starts clean. Same lifetime rationale as
+/// `tripRefineProvider` (plan_provider.dart), which keeps a panel conversation
+/// alive across that same remount.
+@immutable
+class ExpenseDraft {
+  /// Empty strings, not nulls: these mirror two `TextField`s, whose empty
+  /// state IS the empty string.
+  final String label;
+
+  /// The literal contents of the amount field — including a half-typed
+  /// `"412."`. Never a parsed number: parsing belongs to the one place that
+  /// submits, and [Expense.amount] is the `double` this is not.
+  final String amountText;
+
+  /// A canonical API category value (`kExpenseCategories`), never a localized
+  /// label. `general` is the server's default and the row's opening pick.
+  final String category;
+
+  const ExpenseDraft({
+    this.label = '',
+    this.amountText = '',
+    this.category = 'general',
+  });
+
+  ExpenseDraft copyWith({String? label, String? amountText, String? category}) =>
+      ExpenseDraft(
+        label: label ?? this.label,
+        amountText: amountText ?? this.amountText,
+        category: category ?? this.category,
+      );
+}
+
+class ExpenseDraftNotifier extends StateNotifier<ExpenseDraft> {
+  ExpenseDraftNotifier() : super(const ExpenseDraft());
+
+  /// Both fields together, because the row's two controllers share one
+  /// listener — whichever fires, the draft records what is on screen.
+  void setText({required String label, required String amountText}) {
+    if (label == state.label && amountText == state.amountText) return;
+    state = state.copyWith(label: label, amountText: amountText);
+  }
+
+  void setCategory(String category) {
+    if (category == state.category) return;
+    state = state.copyWith(category: category);
+  }
+
+  /// After a successful save. Deliberately keeps the category: the row already
+  /// behaves that way within a session, and consecutive expenses tend to share
+  /// one.
+  void clearText() => setText(label: '', amountText: '');
+}
+
+final expenseDraftProvider =
+    StateNotifierProvider.family<ExpenseDraftNotifier, ExpenseDraft, String>(
+        (ref, tripId) => ExpenseDraftNotifier());

--- a/src/packages/flutter-app/lib/widgets/budget_section.dart
+++ b/src/packages/flutter-app/lib/widgets/budget_section.dart
@@ -17,7 +17,10 @@ import 'empty_state.dart';
 /// of expense line-items grouped by category with per-category subtotals, a
 /// running total, and a remaining footer.
 /// Self-contained — it owns its data via [budgetProvider] + [expensesProvider]
-/// and reconciles mutations by invalidating both family keys. (The
+/// and reconciles mutations by invalidating both family keys. The add row's
+/// unsaved contents live in [expenseDraftProvider] rather than in this
+/// widget's State, because the widget is unmounted every time the traveler
+/// changes header tab or opens the chat panel. (The
 /// `showHeader` knob died with the collapsed cluster row this tab replaced —
 /// precedent: [TripReviewSection]'s knob retiring with the health sheet.)
 class BudgetSection extends ConsumerStatefulWidget {
@@ -42,8 +45,66 @@ class BudgetSection extends ConsumerStatefulWidget {
 class _BudgetSectionState extends ConsumerState<BudgetSection> {
   final TextEditingController _labelController = TextEditingController();
   final TextEditingController _amountController = TextEditingController();
-  String _addCategory = 'general';
   bool _busy = false;
+  // The picked category has no field here on purpose: it lives in the draft,
+  // which is the one place any part of this row's unsaved contents lives.
+
+  @override
+  void initState() {
+    super.initState();
+    _seedFrom(widget.tripId);
+  }
+
+  @override
+  void didUpdateWidget(BudgetSection oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    // Nothing to flush — every keystroke already wrote through — so a trip
+    // swap on a reused element only has to re-seed. Unreachable from the one
+    // mount site today, where the id is fixed for the screen's life; here so
+    // that "which trip's draft is in these fields" is answered by the code
+    // rather than by that convention.
+    if (oldWidget.tripId != widget.tripId) _seedFrom(widget.tripId);
+  }
+
+  /// Loads [tripId]'s kept draft into the fields, then arms the write-back.
+  /// Called from `initState`, never from `build`: seeding on rebuild would
+  /// clobber the character just typed, and this way the early
+  /// `SizedBox.shrink()` return cannot race it.
+  ///
+  /// `read`, never `watch` — watching the draft from `build` would re-render
+  /// every expense row on every keystroke.
+  void _seedFrom(String tripId) {
+    final draft = ref.read(expenseDraftProvider(tripId));
+    // Detached across the two assignments: [_saveDraft] writes both fields at
+    // once, so a half-applied seed would post the outgoing trip's amount into
+    // the incoming trip's draft before the next line corrected it. Removing a
+    // listener that was never added is a no-op, so this is safe on first call.
+    _labelController.removeListener(_saveDraft);
+    _amountController.removeListener(_saveDraft);
+    _labelController.value = _endCollapsed(draft.label);
+    _amountController.value = _endCollapsed(draft.amountText);
+    // Recorded on every change rather than on the way out: this row is
+    // unmounted without warning (a header-tab switch, the chat panel
+    // re-parenting the body), and by the time `dispose` runs the element is
+    // already unmounted, so `ref` throws there.
+    _labelController.addListener(_saveDraft);
+    _amountController.addListener(_saveDraft);
+  }
+
+  /// Never assign `controller.text`: that setter parks the selection at
+  /// offset -1, which the engine normalizes to 0, so the next keystroke lands
+  /// in *front* of the restored value (the trap `airport_field.dart`
+  /// documents).
+  static TextEditingValue _endCollapsed(String text) => TextEditingValue(
+        text: text,
+        selection: TextSelection.collapsed(offset: text.length),
+      );
+
+  void _saveDraft() =>
+      ref.read(expenseDraftProvider(widget.tripId).notifier).setText(
+            label: _labelController.text,
+            amountText: _amountController.text,
+          );
 
   @override
   void dispose() {
@@ -64,11 +125,16 @@ class _BudgetSectionState extends ConsumerState<BudgetSection> {
 
   Future<void> _run(Future<void> Function() op) async {
     if (_guard() || _busy) return;
+    // Captured while mounted. `ref` throws the moment this State is disposed
+    // — and tabbing away mid-request is the routine case here, not the edge
+    // one — which used to send both invalidations into the catch below: the
+    // server had taken the write and no client ever refetched it.
+    final container = ProviderScope.containerOf(context, listen: false);
     setState(() => _busy = true);
     try {
       await op();
-      ref.invalidate(budgetProvider(widget.tripId));
-      ref.invalidate(expensesProvider(widget.tripId));
+      container.invalidate(budgetProvider(widget.tripId));
+      container.invalidate(expensesProvider(widget.tripId));
     } catch (_) {
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
@@ -88,15 +154,26 @@ class _BudgetSectionState extends ConsumerState<BudgetSection> {
     final label = _labelController.text.trim();
     final amount = double.tryParse(_amountController.text.trim());
     if (label.isEmpty || amount == null || amount < 0) return;
+    final key = expenseDraftProvider(widget.tripId);
+    final category = ref.read(key).category;
+    // Captured before the await: this row can be unmounted mid-save (tab away
+    // while the POST is in flight), and by the time it returns the controllers
+    // are disposed and `ref` throws. The draft outlives both, so clearing it
+    // has to go through the notifier — otherwise the expense just saved sits
+    // in the row waiting to be added a second time.
+    final draft = ref.read(key.notifier);
     _run(() async {
       await ref.read(budgetApiServiceProvider).addExpense(
             widget.tripId,
-            category: _addCategory,
+            category: category,
             label: label,
             amount: amount,
           );
-      _labelController.clear();
-      _amountController.clear();
+      if (mounted) {
+        _labelController.clear();
+        _amountController.clear();
+      }
+      draft.clearText();
     });
   }
 
@@ -490,40 +567,51 @@ class _BudgetSectionState extends ConsumerState<BudgetSection> {
         // phones); the open menu spells out each category. A popup menu (not
         // a DropdownButton) because a dropdown's menu is hard-constrained to
         // the trigger's width — an icon-only trigger would clip every label.
-        PopupMenuButton<String>(
-          tooltip: context.l10n.budgetCategoryLabel,
-          enabled: !widget.isOffline,
-          position: PopupMenuPosition.under,
-          color: theme.colorScheme.surface,
-          elevation: 3,
-          shape: const RoundedRectangleBorder(borderRadius: AppRadius.mdAll),
-          icon: Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Icon(kExpenseCategoryIcons[_addCategory],
-                  size: 18, color: theme.colorScheme.onSurfaceVariant),
-              Icon(Icons.arrow_drop_down,
-                  size: 18, color: theme.colorScheme.onSurfaceVariant),
-            ],
-          ),
-          onSelected: (v) => setState(() => _addCategory = v),
-          itemBuilder: (_) => [
-            for (final cat in kExpenseCategories)
-              CheckedPopupMenuItem<String>(
-                value: cat,
-                checked: cat == _addCategory,
-                child: Row(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    Icon(kExpenseCategoryIcons[cat],
-                        size: 18, color: theme.colorScheme.onSurfaceVariant),
-                    const SizedBox(width: AppSpacing.sm),
-                    Text(expenseCategoryLabel(context.l10n, cat)),
-                  ],
+        //
+        // The pick is read straight from the draft rather than mirrored into a
+        // field, so there is one answer to "which category is armed". The
+        // watch is scoped to this button and selects one String, so typing in
+        // the fields beside it can never re-render the expense list.
+        Consumer(builder: (context, ref, _) {
+          final category = ref.watch(
+              expenseDraftProvider(widget.tripId).select((d) => d.category));
+          return PopupMenuButton<String>(
+            tooltip: context.l10n.budgetCategoryLabel,
+            enabled: !widget.isOffline,
+            position: PopupMenuPosition.under,
+            color: theme.colorScheme.surface,
+            elevation: 3,
+            shape: const RoundedRectangleBorder(borderRadius: AppRadius.mdAll),
+            icon: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Icon(kExpenseCategoryIcons[category],
+                    size: 18, color: theme.colorScheme.onSurfaceVariant),
+                Icon(Icons.arrow_drop_down,
+                    size: 18, color: theme.colorScheme.onSurfaceVariant),
+              ],
+            ),
+            onSelected: (v) => ref
+                .read(expenseDraftProvider(widget.tripId).notifier)
+                .setCategory(v),
+            itemBuilder: (_) => [
+              for (final cat in kExpenseCategories)
+                CheckedPopupMenuItem<String>(
+                  value: cat,
+                  checked: cat == category,
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Icon(kExpenseCategoryIcons[cat],
+                          size: 18, color: theme.colorScheme.onSurfaceVariant),
+                      const SizedBox(width: AppSpacing.sm),
+                      Text(expenseCategoryLabel(context.l10n, cat)),
+                    ],
+                  ),
                 ),
-              ),
-          ],
-        ),
+            ],
+          );
+        }),
         const SizedBox(width: AppSpacing.sm),
         Expanded(
           child: TextField(

--- a/src/packages/flutter-app/test/budget_section_test.dart
+++ b/src/packages/flutter-app/test/budget_section_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -26,6 +28,10 @@ class _FakeBudgetApiService extends BudgetApiService {
   final List<Map<String, dynamic>> puts = [];
   int addCount = 0;
   int deleteCount = 0;
+
+  /// Set to hold [addExpense] open, so a test can unmount the section while a
+  /// save is still in flight.
+  Completer<void>? addGate;
 
   _FakeBudgetApiService(this.expenses, {this.targetAmount, this.currency = 'USD'})
       : super(ApiClient(baseUrl: 'http://test'));
@@ -60,6 +66,7 @@ class _FakeBudgetApiService extends BudgetApiService {
       required double amount,
       String? sourceKind,
       String? sourceId}) async {
+    if (addGate != null) await addGate!.future;
     addCount++;
     final e = Expense(
         id: 'new-$addCount',
@@ -131,6 +138,87 @@ Future<_FakeBudgetApiService> _pump(
   await tester.pumpAndSettle();
   return fake;
 }
+
+/// The Budget tab in miniature: a `BudgetSection` that comes and goes behind a
+/// conditional, exactly as `trip_detail_screen`'s `if (_inBudgetView)` sliver
+/// does. Everything a header-tab switch, a chat-panel toggle or an offline
+/// banner does to that widget reduces to this.
+class _Mountable extends StatefulWidget {
+  final String tripId;
+  const _Mountable({super.key, this.tripId = 't1'});
+
+  @override
+  State<_Mountable> createState() => _MountableState();
+}
+
+class _MountableState extends State<_Mountable> {
+  bool _shown = true;
+  late String _tripId = widget.tripId;
+
+  /// Same element, different trip — drives `BudgetSection.didUpdateWidget`.
+  void showTrip(String id) => setState(() => _tripId = id);
+
+  @override
+  Widget build(BuildContext context) => SingleChildScrollView(
+        child: Column(
+          children: [
+            TextButton(
+              onPressed: () => setState(() => _shown = !_shown),
+              child: const Text('toggle'),
+            ),
+            if (_shown)
+              BudgetSection(tripId: _tripId, canEdit: true, isOffline: false),
+          ],
+        ),
+      );
+}
+
+/// Pumps [_Mountable]s inside ONE `ProviderScope`. A second `pumpWidget` with
+/// its own scope would build a fresh container and prove nothing about state
+/// surviving — the container has to be the same one throughout.
+Future<_FakeBudgetApiService> _pumpMountable(
+  WidgetTester tester,
+  List<Expense> expenses, {
+  List<String> tripIds = const ['t1'],
+  GlobalKey<_MountableState>? hostKey,
+}) async {
+  final fake = _FakeBudgetApiService(expenses);
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [budgetApiServiceProvider.overrideWithValue(fake)],
+      child: MaterialApp(
+        theme: AppTheme.light,
+        localizationsDelegates: testLocalizationsDelegates,
+        home: Scaffold(
+          body: Column(
+            children: [
+              for (final id in tripIds)
+                Expanded(
+                  child: _Mountable(
+                      key: id == tripIds.first ? hostKey : null, tripId: id),
+                ),
+            ],
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+  return fake;
+}
+
+/// Toggles the [index]th section off and back on — one unmount/remount round
+/// trip.
+Future<void> _remount(WidgetTester tester, {int index = 0}) async {
+  final toggle = find.text('toggle').at(index);
+  await tester.tap(toggle);
+  await tester.pumpAndSettle();
+  await tester.tap(toggle);
+  await tester.pumpAndSettle();
+}
+
+TextEditingController _controllerAt(WidgetTester tester, int index) =>
+    tester.widget<TextField>(find.byType(TextField).at(index)).controller!;
 
 void main() {
   testWidgets(
@@ -347,5 +435,141 @@ void main() {
     await tester.tap(find.byTooltip('Add expense'));
     await tester.pumpAndSettle();
     expect(fake.expenses.last.category, 'flights');
+  });
+
+  // Pricing a flight means leaving this tab — "Find flights" lives on the
+  // booking rows, and asking the chat re-parents the whole trip body — so the
+  // add row is unmounted mid-thought as a matter of course. What was typed
+  // has to be there on the way back.
+  testWidgets('a half-typed expense survives the section being unmounted',
+      (tester) async {
+    await _pumpMountable(tester, []);
+
+    await tester.tap(find.byTooltip('Category'));
+    await tester.pumpAndSettle();
+    await tester
+        .tap(find.widgetWithText(CheckedPopupMenuItem<String>, 'Flights'));
+    await tester.pumpAndSettle();
+    await tester.enterText(find.byType(TextField).first, 'JFK→CDG');
+    await tester.enterText(find.byType(TextField).last, '400');
+
+    await _remount(tester);
+
+    expect(_controllerAt(tester, 0).text, 'JFK→CDG');
+    expect(_controllerAt(tester, 1).text, '400');
+    // The category is part of the draft too — it was a choice, not a default.
+    expect(find.byIcon(Icons.flight_outlined), findsOneWidget);
+  });
+
+  testWidgets('the restored text can be typed onto, not in front of',
+      (tester) async {
+    await _pumpMountable(tester, []);
+    await tester.enterText(find.byType(TextField).first, 'Taxi');
+    await tester.enterText(find.byType(TextField).last, '15');
+
+    await _remount(tester);
+
+    // Assigning `controller.text` would park the caret at -1 (normalized to
+    // 0), so the next keystroke would land in FRONT of the restored value.
+    expect(_controllerAt(tester, 0).selection.baseOffset, 'Taxi'.length);
+    expect(_controllerAt(tester, 1).selection.baseOffset, '15'.length);
+  });
+
+  testWidgets('drafts do not leak between trips', (tester) async {
+    await tester.binding.setSurfaceSize(const Size(800, 1200));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    await _pumpMountable(tester, [], tripIds: const ['t1', 't2']);
+
+    await tester.enterText(find.byType(TextField).at(0), 'Ferry to Naxos');
+    await tester.enterText(find.byType(TextField).at(1), '38');
+    await tester.pumpAndSettle();
+
+    // The other trip's row is its own draft, not a shared one.
+    expect(_controllerAt(tester, 2).text, isEmpty);
+    expect(_controllerAt(tester, 3).text, isEmpty);
+  });
+
+  testWidgets('a saved expense leaves no draft behind', (tester) async {
+    final fake = await _pumpMountable(tester, []);
+    await tester.enterText(find.byType(TextField).first, 'Taxi');
+    await tester.enterText(find.byType(TextField).last, '15');
+    await tester.tap(find.byTooltip('Add expense'));
+    await tester.pumpAndSettle();
+
+    await _remount(tester);
+
+    expect(_controllerAt(tester, 0).text, isEmpty);
+    expect(_controllerAt(tester, 1).text, isEmpty);
+    expect(fake.addCount, 1);
+  });
+
+  // The clear happens after the POST resolves, by which point the row may be
+  // gone and its controllers disposed. If the draft were only cleared through
+  // them, the just-saved expense would still be sitting in the row — one tap
+  // from being added twice — and the refetch that makes it appear would have
+  // been thrown away with them.
+  testWidgets('…even when the section is unmounted mid-save', (tester) async {
+    final fake = await _pumpMountable(tester, []);
+    fake.addGate = Completer<void>();
+    await tester.enterText(find.byType(TextField).first, 'Taxi');
+    await tester.enterText(find.byType(TextField).last, '15');
+    await tester.tap(find.byTooltip('Add expense'));
+    await tester.pump();
+
+    // Tab away while the save is still in flight.
+    await tester.tap(find.text('toggle'));
+    await tester.pumpAndSettle();
+    fake.addGate!.complete();
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('toggle'));
+    await tester.pumpAndSettle();
+
+    expect(_controllerAt(tester, 0).text, isEmpty);
+    expect(_controllerAt(tester, 1).text, isEmpty);
+    expect(fake.addCount, 1);
+    // And the expense is actually on screen: the invalidation that refetches
+    // it outlives the widget too.
+    expect(find.text('Taxi'), findsOneWidget);
+  });
+
+  testWidgets('a trip swap on a reused element re-seeds from the new trip',
+      (tester) async {
+    final host = GlobalKey<_MountableState>();
+    await _pumpMountable(tester, [], hostKey: host);
+    await tester.enterText(find.byType(TextField).first, 'Flight to Amsterdam');
+
+    host.currentState!.showTrip('t2');
+    await tester.pumpAndSettle();
+    expect(_controllerAt(tester, 0).text, isEmpty, reason: "t1's draft leaked");
+
+    host.currentState!.showTrip('t1');
+    await tester.pumpAndSettle();
+    expect(_controllerAt(tester, 0).text, 'Flight to Amsterdam');
+  });
+
+  // The draft is written on every keystroke, so watching it from build() would
+  // re-render the headline, every expense row and the totals per character.
+  testWidgets('typing in the add row never rebuilds the expense list',
+      (tester) async {
+    await _pump(tester, [_exp('a', 'food', 'Lunch', 20)], targetAmount: 100);
+
+    // _buildHeadline constructs a fresh LinearProgressIndicator every build,
+    // so widget identity is a faithful "did build() re-run" sentinel.
+    final before = tester
+        .widget<LinearProgressIndicator>(find.byType(LinearProgressIndicator));
+    await tester.enterText(find.byType(TextField).first, 'Taxi');
+    await tester.pump();
+
+    expect(
+      identical(
+        before,
+        tester.widget<LinearProgressIndicator>(
+            find.byType(LinearProgressIndicator)),
+      ),
+      isTrue,
+      reason: 'the draft is write-through only — ref.watch()ing it from '
+          'build() re-renders every expense row on every keystroke',
+    );
   });
 }


### PR DESCRIPTION
## Summary

Logging a flight as an expense means leaving the Budget tab to go get the price. Come back, and the row you half-typed is blank.

- **The draft is no longer widget state.** `expenseDraftProvider` — a non-autoDispose `StateNotifierProvider.family` keyed by trip — holds the label, the amount text and the picked category. Same bargain `tripRefineProvider` already makes for the panel conversation, whose docstring says keepAlive "preserves the conversation across panel close/reopen"; the chat transcript already survived this exact remount, the expense row never got the same treatment.
- **Four things unmount `BudgetSection`, and this flow needs at least one of them:**
  1. Any header-tab switch — it's a conditional sliver (`if (_inBudgetView)`), and "Find flights" only renders on the booking rows, so reaching the flight lookup means leaving Budget.
  2. The chat panel opening **or** closing — the body returns a bare `RefreshIndicator` when closed and a `Row`/`Stack` when open, so `Widget.canUpdate` fails and the entire subtree is re-inflated. Also fires when crossing the 900px docked/undocked boundary. The text was gone before the question was asked.
  3. The offline banner appearing/disappearing (wraps the body in a `Column`).
  4. Any loud (non-silent) `_load()`.
- **The suspects that turned out innocent** and are deliberately untouched: pushing the Find Flights screen (plain `MaterialPageRoute`, `maintainState: true`) and top-level nav-tab switches (`IndexedStack` + `TickerMode`) already preserve everything.
- **The category moved into the draft rather than being mirrored in a field**, so there is one answer to "which category is armed". It was a *choice* — silently resetting it to General misfiles the next expense. Its watch is scoped to the picker and `.select`s one `String`, so a keystroke can never re-render the expense list.
- **Fields seed with an explicit end-collapsed `TextEditingValue`**: assigning `controller.text` parks the selection at -1 and the next keystroke lands *in front* of the restored value (the trap `airport_field.dart` documents).

### Also fixes a shipped bug this made reachable

`_run` invalidated both providers through `ref` **after** awaiting the write. `ref` throws the moment the `State` is disposed, so tabbing away mid-request — the routine case here, not an edge one — sent both invalidations into a swallowing `catch (_)`: **the server took the expense and no client ever refetched it, so it simply never appeared.** Now captures the `ProviderContainer` while mounted. Pinned by a test that fails with `ref.` restored.

`trip_detail_screen.dart` is not touched. No l10n, no API change, no migration, no generated code. In-memory only — a page reload starts clean, by decision.

### Road not taken

Hoisting the `TextEditingController`s themselves into the provider is a smaller diff and covers the same triggers, but a non-autoDispose family would never dispose them (a leaked `ChangeNotifier` per trip instead of three `String`s), and no provider in `lib/providers/` holds a Flutter UI object today.

## Testing

- `flutter test` — **1343 passing**. Six new tests in `budget_section_test.dart`: survives unmount/remount (text *and* category), caret lands after the restored text, drafts don't leak between trips, a trip swap on a reused element re-seeds, a save clears the draft, and a save clears it **even when the section is unmounted mid-save** (gated fake) with the expense visible afterwards.
- The remount harness toggles the section inside **one** `ProviderScope` — a second `pumpWidget` builds a fresh `ProviderContainer` and would pass against the broken code.
- **Both non-obvious guard tests were watched fail against the un-fixed code**: the mid-save test finds 0 "Taxi" widgets with `_run` reverted to `ref.invalidate`, and the no-rebuild test flips to `false` when a `ref.watch(expenseDraftProvider(...))` is injected into `build()`.
- `flutter analyze` — clean; the 3 remaining infos are pre-existing in `lib/models/route_response.dart`, untouched here.
- One unrelated flake seen once under full-suite load (`auth_autofill_submit_test.dart`, a timing-threshold test); passes in isolation, on a clean baseline, and on re-run.

Friction-log entry included (`docs/friction-log.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)