### PR TITLE
fix(trips): the live trip renders once — the hero replaces its card

### DIFF
--- a/specs/happening-now/plan.md
+++ b/specs/happening-now/plan.md
@@ -62,7 +62,8 @@ None.
   the trip card share one formatter (behavior-neutral refactor).
 - **`lib/screens/trips_list_screen.dart`**: render `LiveTripCard` as the
   first `ListView` child (above the resumable-chats section); tap →
-  existing `_openTrip`. The trip stays in "My Trips".
+  existing `_openTrip`. The trip stays in "My Trips". *(Amended 2026-08-15:
+  the hero REPLACES the trip's plain card — see spec.md's amendment.)*
 - **`lib/screens/home_screen.dart`**: watch `liveTripProvider`; render the
   card in the recent-trip slot, with `_RecentTripCard` below it only when
   `recentTrip.tripId != liveTrip.id`. No `loadTrips()` call from home.

--- a/specs/happening-now/spec.md
+++ b/specs/happening-now/spec.md
@@ -158,6 +158,12 @@ made the old one wrong.
   line, summary — with the Live pill and "Day N of M" in the countdown's slot,
   and the trip's own duration chip suppressed because "Day 1 of 3" already
   names the span.
+- **The route band is the trips list's, not Home's.** The live card is the
+  one card that renders on both surfaces at once (AppShell's IndexedStack
+  keeps both alive), and two flutter_map instances racing for the same tiles
+  cancel each other's requests until BOTH render blank — verified A/B/A in a
+  browser. The trips list keeps the band; Home's copy carries the same facts
+  without it. The Up-next hero, which lives on one surface, is unaffected.
 - **The booking nudge stays off a started trip.** It is pre-departure copy
   ("first leg departs …"), and its window gate fires on any unbooked future
   departure — including a return leg, mid-trip. It was hero-only, never on the

--- a/specs/happening-now/spec.md
+++ b/specs/happening-now/spec.md
@@ -42,7 +42,8 @@ inside today's day section (PR 2).
 - [ ] **Trips list:** when a live trip exists, a promoted card renders at the
       very top of the list — above "Continue where you left off" and above
       "My Trips". The live trip still appears in "My Trips" below (the card
-      is a shortcut, not a filter).
+      is a shortcut, not a filter). *(Amended 2026-08-15 — the second
+      sentence is superseded; see the amendment at the end of this file.)*
 - [ ] **Home screen:** the same card renders in the recent-trip slot. When
       the most-recently-viewed trip *is* the live trip, only the live card
       shows; when they differ, the recent-trip tile renders below it.
@@ -131,3 +132,44 @@ No persisted entities change. Client-side derived concepts:
 ## Open Questions
 
 None.
+
+## Amendment 2026-08-15 — the live trip renders exactly once
+
+**Supersedes the trips-list acceptance criterion above** ("The live trip still
+appears in 'My Trips' below (the card is a shortcut, not a filter)") and the
+matching line in `plan.md`.
+
+As shipped, a trip happening today rendered **twice** on one screen: in the
+HAPPENING NOW hero and again as a plain card under a header reading
+"Upcoming" — a trip already under way, filed under the word *upcoming*, beside
+a copy of itself. "Shortcut, not a filter" was written when the list below was
+one flat run called "My Trips" and this card carried three facts (eyebrow,
+headline, Live · Day N of M): it genuinely showed *less* than the plain card,
+so leaving the card was the only way not to lose the date range, the booking
+progress and the item count. The "Up next" hero (specs/trips-page-insights)
+later established the better rule, and the sections it arrived with are what
+made the old one wrong.
+
+- **A promoted trip renders exactly once.** The hero REPLACES the live trip's
+  plain card; the Upcoming run never repeats it.
+- **Promotion requires the hero to show at least what the card showed.** The
+  Happening-Now card therefore carries the full list-card fact set — cached
+  route band, date range, booking/packing pills, stays, Shared, places, cities
+  line, summary — with the Live pill and "Day N of M" in the countdown's slot,
+  and the trip's own duration chip suppressed because "Day 1 of 3" already
+  names the span.
+- **The booking nudge stays off a started trip.** It is pre-departure copy
+  ("first leg departs …"), and its window gate fires on any unbooked future
+  departure — including a return leg, mid-trip. It was hero-only, never on the
+  plain card, so suppressing it loses nothing the replacement owed. A mid-trip
+  urgency surface, with its own wording, is the deferred option.
+- **Exactly one promoted object** is unchanged: a live trip still suppresses
+  the Up-next hero, and a second overlapping in-progress trip keeps its plain
+  card in the Upcoming run (`liveTripOf` promotes exactly one).
+- **One name for the promoted trip.** The screen derives a single
+  `promotedId` — the live trip if there is one, else the Up-next hero — and
+  subtracts that from the Upcoming run. The duplication existed because there
+  were two notions of "promoted" and only one was subtracted.
+- **Known gap, unchanged:** the admin version-history expander has no hero
+  equivalent, so a promoted trip doesn't offer it on this screen. Pre-existing
+  for the Up-next hero since specs/trips-page-insights; admin-only.

--- a/src/packages/flutter-app/lib/screens/home_screen.dart
+++ b/src/packages/flutter-app/lib/screens/home_screen.dart
@@ -180,6 +180,9 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
                 if (liveTrip != null) ...[
                   LiveTripCard(
                     trip: liveTrip,
+                    // The trips list owns this trip's route band; a second
+                    // one here would starve it (see TripHeroCard.showMap).
+                    showMap: false,
                     // On the Trips tab (not pushed over Home): the Trips nav
                     // item highlights and back lands on the trips list.
                     onTap: () => openTripOnTripsTab(ref, liveTrip.id),

--- a/src/packages/flutter-app/lib/screens/trips_list_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trips_list_screen.dart
@@ -144,7 +144,9 @@ class _TripsListScreenState extends ConsumerState<TripsListScreen> {
       // Server order is newest-created-first; the list shows travel-date
       // order instead — next trip on top, finished trips tucked into a
       // collapsed group (utils/trip_list_order.dart). The live trip is
-      // exempt from the past group so its Live pill never hides in there.
+      // exempt from the past group so the promoted trip can never be filed
+      // under "Past trips"; the promotion below is what takes it out of the
+      // Upcoming run.
       final now = DateTime.now();
       final groups =
           partitionTripsForList(state.trips, now, liveTripId: liveTrip?.id);
@@ -155,12 +157,18 @@ class _TripsListScreenState extends ConsumerState<TripsListScreen> {
       final sharedOrdered = [...sharedGroups.upcoming, ...sharedGroups.past];
       // The soonest dated upcoming trip, promoted to an "Up next" hero. A
       // live trip already owns the promoted slot, so the hero yields to it —
-      // one promoted object at a time. Unlike the live spotlight, the hero
-      // REPLACES its plain card (it shows strictly more), hence the dedupe.
+      // one promoted object at a time.
       final hero = liveTrip == null ? upNextTrip(groups.upcoming, now) : null;
+      // Whichever hero got the slot, it REPLACES its plain card: a promoted
+      // trip is never listed twice, and "Upcoming" never contains a trip
+      // already under way. ONE name for "the promoted trip" and one
+      // subtraction from the run — the live trip used to show twice precisely
+      // because there were two notions of promoted and only `hero` was
+      // subtracted.
+      final promotedId = liveTrip?.id ?? hero?.id;
       final upcomingCards = [
         for (final t in groups.upcoming)
-          if (t.id != hero?.id) t
+          if (t.id != promotedId) t
       ];
       // "Your travels" is over OWNED trips (shared-with-me is someone else's
       // travel, and its payload carries no pins anyway), split into what's
@@ -193,8 +201,9 @@ class _TripsListScreenState extends ConsumerState<TripsListScreen> {
                 crossAxisAlignment: CrossAxisAlignment.stretch,
                 children: [
                   // The trip happening today, promoted to the very top as a
-                  // one-tap shortcut (specs/happening-now). It also stays in
-                  // "My Trips" below — this is a spotlight, not a filter.
+                  // one-tap shortcut (specs/happening-now). It sits ABOVE the
+                  // "Upcoming" header, and its plain card is gone from the
+                  // run below — a trip you're on is not upcoming.
                   if (liveTrip != null)
                     Padding(
                       padding: const EdgeInsets.only(bottom: AppSpacing.lg),

--- a/src/packages/flutter-app/lib/utils/trip_list_order.dart
+++ b/src/packages/flutter-app/lib/utils/trip_list_order.dart
@@ -15,9 +15,12 @@ import 'trip_days.dart';
 ///   plans are actionable, undated drafts wait below them.
 /// - `past`: most recently finished first.
 ///
-/// The trip identified by [liveTripId] (the Happening-Now spotlight) always
-/// stays in the main list, so a Live-pill card can never end up filed under
-/// past — [tripIsPast] and the live-trip rules disagree about end-less trips.
+/// The trip identified by [liveTripId] (the Happening-Now hero) never lands in
+/// `past`, so the promoted trip can't end up filed under a collapsed "Past
+/// trips" group — [tripIsPast] and the live-trip rules disagree about end-less
+/// trips. It stays in `upcoming` here and the CALLER subtracts it, along with
+/// its own "Up next" hero, because a hero replaces the trip's plain card: one
+/// place decides the time buckets, one place decides promotion.
 ({List<Trip> upcoming, List<Trip> past}) partitionTripsForList(
   List<Trip> trips,
   DateTime today, {

--- a/src/packages/flutter-app/lib/widgets/live_trip_card.dart
+++ b/src/packages/flutter-app/lib/widgets/live_trip_card.dart
@@ -1,17 +1,21 @@
 import 'package:flutter/material.dart';
 import '../l10n/l10n.dart';
 import '../models/trip.dart';
-import '../theme/app_colors.dart';
-import '../theme/spacing.dart';
 import '../utils/trip_days.dart';
-import '../utils/trip_format.dart';
-import 'status_pill.dart';
+import 'trip_hero_card.dart';
 
-/// Promoted shortcut into the trip that is happening right now
-/// (specs/happening-now). Same brand-gradient treatment as the home screen's
-/// recent-trip tile, so it reads as the top-priority object wherever it sits;
-/// shown above everything else on the trips list and in the recent-trip slot
-/// on home. Tap goes straight to the trip detail, which auto-scrolls to today.
+/// The trip that is happening right now, promoted to the head of the trips
+/// list and to Home's live slot (specs/happening-now). Tap goes straight to
+/// the trip detail, which auto-scrolls to today.
+///
+/// It REPLACES the trip's plain list card — a promoted trip is never listed
+/// twice. It used to sit above the list AND stay in it ("a shortcut, not a
+/// filter"), which was defensible while the list below was one flat run
+/// called "My Trips" and this card carried nothing the row did; once the list
+/// grew sections, that left a trip already under way filed under "Upcoming".
+/// The card earns the replacement by carrying the row's facts: [TripHeroCard]
+/// is the shared body, and everything below is the two-line difference
+/// between this hero and the pre-trip one, [UpNextTripCard].
 class LiveTripCard extends StatelessWidget {
   final Trip trip;
   final VoidCallback onTap;
@@ -20,7 +24,6 @@ class LiveTripCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
     final l10n = context.l10n;
 
     // Where the trip stands today: "Day N of M", or just "Day N" for an
@@ -32,106 +35,18 @@ class LiveTripCard extends StatelessWidget {
         ? null
         : (total > 0 ? l10n.liveTripDayOfTotal(day, total) : l10n.liveTripDay(day));
 
-    return Container(
-      decoration: BoxDecoration(
-        borderRadius: AppRadius.mdAll,
-        gradient: AppColors.brandGradient,
-        boxShadow: [
-          BoxShadow(
-            color: AppColors.brandDark.withValues(alpha: 0.3),
-            blurRadius: 10,
-            offset: const Offset(0, 4),
-          ),
-        ],
-      ),
-      child: Material(
-        color: Colors.transparent,
-        child: InkWell(
-          onTap: onTap,
-          borderRadius: AppRadius.mdAll,
-          child: Padding(
-            padding: const EdgeInsets.all(AppSpacing.lg),
-            child: Row(
-              children: [
-                Container(
-                  padding: const EdgeInsets.all(AppSpacing.sm + 2),
-                  decoration: BoxDecoration(
-                    color: Colors.white.withValues(alpha: 0.15),
-                    shape: BoxShape.circle,
-                  ),
-                  child:
-                      const Icon(Icons.near_me, color: Colors.white, size: 26),
-                ),
-                const SizedBox(width: AppSpacing.lg),
-                Expanded(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text(
-                        l10n.liveTripEyebrow,
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
-                        style: theme.textTheme.labelSmall?.copyWith(
-                          color: Colors.white70,
-                          letterSpacing: 1.2,
-                        ),
-                      ),
-                      const SizedBox(height: 2),
-                      Text(
-                        // Real trip title, like the trips list and detail
-                        // header; cities label only for legacy AI-summary
-                        // titles (tripHeadline, the one shared rule).
-                        tripHeadline(
-                          trip.title,
-                          citiesLabel(
-                            trip.cities,
-                            two: (a, b) => l10n.citiesTwo(a, b),
-                            more: (a, b, n) => l10n.citiesMore(a, b, n),
-                          ),
-                        ),
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
-                        style: theme.textTheme.titleMedium?.copyWith(
-                          fontWeight: FontWeight.bold,
-                          color: Colors.white,
-                        ),
-                      ),
-                      const SizedBox(height: AppSpacing.xs),
-                      Row(
-                        children: [
-                          // White-tinted pill so it sits on the gradient like
-                          // the rest of the card, not like the light-surface
-                          // StatusPill used on the trips list.
-                          StatusPill.custom(
-                            label: l10n.liveTripStatusLive,
-                            background: Colors.white.withValues(alpha: 0.22),
-                            foreground: Colors.white,
-                          ),
-                          if (progress != null) ...[
-                            const SizedBox(width: AppSpacing.sm),
-                            Flexible(
-                              child: Text(
-                                progress,
-                                maxLines: 1,
-                                overflow: TextOverflow.ellipsis,
-                                style: theme.textTheme.bodySmall?.copyWith(
-                                  color: Colors.white.withValues(alpha: 0.85),
-                                ),
-                              ),
-                            ),
-                          ],
-                        ],
-                      ),
-                    ],
-                  ),
-                ),
-                const Icon(Icons.arrow_forward_ios,
-                    size: 16, color: Colors.white70),
-              ],
-            ),
-          ),
-        ),
-      ),
+    return TripHeroCard(
+      trip: trip,
+      eyebrow: l10n.liveTripEyebrow,
+      icon: Icons.near_me,
+      // "Day 2 of 5" already names the span, so the card's own duration label
+      // would be a second total saying the same thing.
+      showDuration: false,
+      leadingMeta: [
+        TripHeroCard.heroPill(l10n.liveTripStatusLive),
+        if (progress != null) TripHeroCard.heroFact(context, progress),
+      ],
+      onTap: onTap,
     );
   }
 }

--- a/src/packages/flutter-app/lib/widgets/live_trip_card.dart
+++ b/src/packages/flutter-app/lib/widgets/live_trip_card.dart
@@ -20,7 +20,17 @@ class LiveTripCard extends StatelessWidget {
   final Trip trip;
   final VoidCallback onTap;
 
-  const LiveTripCard({super.key, required this.trip, required this.onTap});
+  /// Passed through to [TripHeroCard.showMap]. Home passes false: its copy of
+  /// this card and the trips list's are alive at the same time inside
+  /// AppShell's IndexedStack, and two route bands for one trip starve each
+  /// other's tiles until both render blank.
+  final bool showMap;
+
+  const LiveTripCard(
+      {super.key,
+      required this.trip,
+      required this.onTap,
+      this.showMap = true});
 
   @override
   Widget build(BuildContext context) {
@@ -42,6 +52,7 @@ class LiveTripCard extends StatelessWidget {
       // "Day 2 of 5" already names the span, so the card's own duration label
       // would be a second total saying the same thing.
       showDuration: false,
+      showMap: showMap,
       leadingMeta: [
         TripHeroCard.heroPill(l10n.liveTripStatusLive),
         if (progress != null) TripHeroCard.heroFact(context, progress),

--- a/src/packages/flutter-app/lib/widgets/trip_hero_card.dart
+++ b/src/packages/flutter-app/lib/widgets/trip_hero_card.dart
@@ -49,6 +49,20 @@ class TripHeroCard extends StatelessWidget {
   /// read as a contradiction waiting to happen.
   final bool showDuration;
 
+  /// Whether to mount the cached route band. Off wherever a SECOND band for
+  /// the same trip would be alive at the same time: two flutter_map instances
+  /// racing for the same tile URLs cancel each other's requests
+  /// (`net::ERR_ABORTED`) and BOTH end up blank, which is worse than no band.
+  ///
+  /// That is the live trip's situation and only the live trip's: its card is
+  /// the one that renders on Home AND the trips list, and AppShell's
+  /// IndexedStack keeps both alive at once. Verified A/B/A in a browser —
+  /// black with Home's band mounted, satellite tiles without it, on the same
+  /// trip and the same cache. So the trips list keeps the band and Home's
+  /// copy goes without; the up-next hero, which exists on one surface, is
+  /// unaffected.
+  final bool showMap;
+
   const TripHeroCard({
     super.key,
     required this.trip,
@@ -57,6 +71,7 @@ class TripHeroCard extends StatelessWidget {
     required this.leadingMeta,
     required this.onTap,
     this.showDuration = true,
+    this.showMap = true,
   });
 
   /// A STATE pill in the gradient card's treatment: white-tinted so it sits ON
@@ -138,7 +153,7 @@ class TripHeroCard extends StatelessWidget {
               // leaving the gradient card on its own — TripMapBand's
               // contract. It absorbs its own pointers, so a tap anywhere on
               // the band still opens the trip.
-              TripMapBand(tripId: trip.id),
+              if (showMap) TripMapBand(tripId: trip.id),
               Padding(
                 padding: const EdgeInsets.all(AppSpacing.lg),
                 child: Row(

--- a/src/packages/flutter-app/lib/widgets/trip_hero_card.dart
+++ b/src/packages/flutter-app/lib/widgets/trip_hero_card.dart
@@ -1,0 +1,332 @@
+import 'package:flutter/material.dart';
+
+import '../l10n/l10n.dart';
+import '../models/trip.dart';
+import '../theme/app_colors.dart';
+import '../theme/app_shadows.dart';
+import '../theme/spacing.dart';
+import '../utils/money_format.dart';
+import '../utils/trip_days.dart';
+import '../utils/trip_format.dart';
+import '../utils/trip_list_insights.dart';
+import 'status_pill.dart';
+import 'trip_map_band.dart';
+
+/// The one promoted-trip card, shared by the trips list's two heroes:
+/// `LiveTripCard` (the trip you are ON) and `UpNextTripCard` (the one you
+/// leave for next). They differ in three things — the eyebrow, the leading
+/// icon, and whatever occupies the first meta slot ("Live · Day 2 of 5" vs
+/// "Starts in 10 days") — so those are the parameters and everything else is
+/// this widget.
+///
+/// **A hero REPLACES its trip's plain list card**, which is only honest while
+/// it shows strictly more than that card would: this Wrap therefore carries
+/// every fact the list's `_TripCard` shows, plus the hero-only ones (the
+/// cached route band, the budget pill, the pre-departure booking nudge).
+/// Adding a fact to the plain card without adding it here re-opens the gap
+/// that let a promoted trip lose information by being promoted.
+///
+/// Facts are payload-only and null/zero-hiding (the list response omits them
+/// on old servers and stale offline snapshots; nothing here is derived
+/// locally), so a thin trip's hero stays as small as it is today.
+class TripHeroCard extends StatelessWidget {
+  final Trip trip;
+
+  /// Small caps label above the title ("HAPPENING NOW" / "UP NEXT").
+  final String eyebrow;
+
+  /// Glyph in the circle at the card's leading edge.
+  final IconData icon;
+
+  /// The first slots of the meta Wrap: the hero's status pill and any label
+  /// that belongs beside it. Build them with [heroPill] / [heroFact].
+  final List<Widget> leadingMeta;
+
+  final VoidCallback onTap;
+
+  /// Whether to print the trip's "N days" span. The live hero passes false:
+  /// its "Day 2 of 5" already names the total, and two totals side by side
+  /// read as a contradiction waiting to happen.
+  final bool showDuration;
+
+  const TripHeroCard({
+    super.key,
+    required this.trip,
+    required this.eyebrow,
+    required this.icon,
+    required this.leadingMeta,
+    required this.onTap,
+    this.showDuration = true,
+  });
+
+  /// A STATE pill in the gradient card's treatment: white-tinted so it sits ON
+  /// the gradient, unlike the trips list's light-surface [StatusPill]. Callers
+  /// build their leading pill with this so the treatment has one definition.
+  static Widget heroPill(String label) => StatusPill.custom(
+        label: label,
+        background: Colors.white.withValues(alpha: 0.22),
+        foreground: Colors.white,
+      );
+
+  /// A CONTEXT fact (ranges, counts) on the gradient: plain text, the non-pill
+  /// twin of [heroPill], so the meta row isn't pill soup.
+  static Widget heroFact(BuildContext context, String label) => Text(
+        label,
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+        style: Theme.of(context).textTheme.bodySmall?.copyWith(
+              color: Colors.white.withValues(alpha: 0.85),
+            ),
+      );
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final l10n = context.l10n;
+
+    final cities = citiesLabel(
+      trip.cities,
+      two: (a, b) => l10n.citiesTwo(a, b),
+      more: (a, b, n) => l10n.citiesMore(a, b, n),
+    );
+    final headline = tripHeadline(trip.title, cities);
+    final showCitiesLine = cities != null && headline != cities;
+    final range = tripDateRange(trip.startDate, trip.endDate);
+    // Same payload-only facts the plain card prints, read the same way: 0
+    // without both dates (so an undated trip skips the span), and a "1 city"
+    // label is noise when the headline or the cities line already names it.
+    final days = dayCount(trip.startDate, trip.endDate, const <int?>[]);
+    final cityCount = trip.cities?.length ?? 0;
+    final packingTotal = trip.packingTotal ?? 0;
+    final stays = trip.stayTotal ?? 0;
+    final places = trip.itemCount ?? 0;
+    final spent = trip.budgetSpent ?? 0;
+    final currency = trip.budgetCurrency ?? 'USD';
+    final target = trip.budgetTarget;
+    // The nudge is PRE-DEPARTURE copy — "first leg departs {date}" — and
+    // bookingNudgeDate only gates on the departure being unbooked and within
+    // the window, which an unbooked RETURN leg passes on day 2 of the trip.
+    // So it is silenced once the trip is under way rather than shipped saying
+    // something false. It was never on the plain card being replaced, so
+    // nothing is lost by the card the hero stands in for.
+    final now = DateTime.now();
+    final nudgeDate = tripHasStarted(trip.startDate, trip.endDate, now)
+        ? null
+        : bookingNudgeDate(trip, now);
+    // The summary is the AI's own blurb; suppress it when it IS the title
+    // (long AI titles fall back to the cities headline, which would leave the
+    // same sentence printed twice).
+    final summary = (trip.summary ?? '').trim();
+    final showSummary = summary.isNotEmpty && summary != trip.title;
+
+    return Container(
+      decoration: BoxDecoration(
+        borderRadius: AppRadius.mdAll,
+        gradient: AppColors.brandGradient,
+        boxShadow: AppShadows.brandCard,
+      ),
+      child: Material(
+        color: Colors.transparent,
+        child: InkWell(
+          onTap: onTap,
+          borderRadius: AppRadius.mdAll,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              // Cached route preview; collapses to nothing on a cache miss
+              // (trip never opened on this device) or an unmappable trip,
+              // leaving the gradient card on its own — TripMapBand's
+              // contract. It absorbs its own pointers, so a tap anywhere on
+              // the band still opens the trip.
+              TripMapBand(tripId: trip.id),
+              Padding(
+                padding: const EdgeInsets.all(AppSpacing.lg),
+                child: Row(
+                  children: [
+                    Container(
+                      padding: const EdgeInsets.all(AppSpacing.sm + 2),
+                      decoration: BoxDecoration(
+                        color: Colors.white.withValues(alpha: 0.15),
+                        shape: BoxShape.circle,
+                      ),
+                      child: Icon(icon, color: Colors.white, size: 26),
+                    ),
+                    const SizedBox(width: AppSpacing.lg),
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            eyebrow,
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                            style: theme.textTheme.labelSmall?.copyWith(
+                              color: Colors.white70,
+                              letterSpacing: 1.2,
+                            ),
+                          ),
+                          const SizedBox(height: 2),
+                          Text(
+                            // Real trip title, like the trips list and detail
+                            // header; cities label only for legacy AI-summary
+                            // titles (tripHeadline, the one shared rule).
+                            headline,
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                            style: theme.textTheme.titleMedium?.copyWith(
+                              fontWeight: FontWeight.bold,
+                              color: Colors.white,
+                            ),
+                          ),
+                          const SizedBox(height: AppSpacing.xs),
+                          // A Wrap, not a Row: variable-length labels as
+                          // loose-flex Row children would each be capped at an
+                          // equal share of the free width and ALL ellipsize on
+                          // phones (es strings run long). Wrapping to further
+                          // runs keeps every label whole; a single over-wide
+                          // label still ellipsizes via StatusPill's internal
+                          // Flexible (the flight_offer_card pattern).
+                          Wrap(
+                            spacing: AppSpacing.sm,
+                            runSpacing: AppSpacing.xs,
+                            crossAxisAlignment: WrapCrossAlignment.center,
+                            children: [
+                              // The hero's own status, whatever it is.
+                              ...leadingMeta,
+                              if (range != null) heroFact(context, range),
+                              if (showDuration && days > 0)
+                                heroFact(context, l10n.tripDurationDays(days)),
+                              if (cityCount >= 2)
+                                heroFact(
+                                    context, l10n.tripCitiesCount(cityCount)),
+                              // Booking and packing progress: STATE, so pills.
+                              if ((trip.bookingTotal ?? 0) > 0)
+                                heroPill(l10n.tripsListBookedCount(
+                                    trip.bookingBooked ?? 0,
+                                    trip.bookingTotal!)),
+                              if (packingTotal > 0)
+                                heroPill(l10n.tripsListPackedCount(
+                                    trip.packingDone ?? 0, packingTotal)),
+                              // Stays and places are context, not progress:
+                              // the booking pill already carries "how much is
+                              // booked", so a second progress pill would
+                              // double-count.
+                              if (stays > 0)
+                                heroFact(
+                                    context, l10n.tripsListStaysCount(stays)),
+                              // Shared OUT (the owner has co-planners) — a
+                              // promoted trip must not lose its marker by
+                              // being promoted.
+                              if (trip.isOwner && trip.shared == true)
+                                heroPill(l10n.tripsListShared),
+                              if (places > 0)
+                                heroFact(
+                                    context, l10n.tripsListPlaces(places)),
+                              // Budget rides the hero only — money is the
+                              // noisiest fact and the plain rows stay lean.
+                              // Over target flips to the OPAQUE warning pair:
+                              // alpha containers wash out on the gradient.
+                              if (spent > 0)
+                                StatusPill.custom(
+                                  label: target == null
+                                      ? l10n.budgetSummarySpent(
+                                          formatMoney(spent, currency))
+                                      : l10n.tripsListBudgetSpentOfTarget(
+                                          formatMoney(spent, currency),
+                                          formatMoney(target, currency)),
+                                  background: target != null && spent > target
+                                      ? AppColors.warningSolid
+                                      : Colors.white.withValues(alpha: 0.22),
+                                  foreground: target != null && spent > target
+                                      ? AppColors.onWarningSolid
+                                      : Colors.white,
+                                ),
+                            ],
+                          ),
+                          // The nudge gets its own row, never a Wrap slot: one
+                          // attention object per card, and the status pill
+                          // keeps the first slot it has always had.
+                          if (nudgeDate != null) ...[
+                            const SizedBox(height: AppSpacing.xs),
+                            Align(
+                              alignment: Alignment.centerLeft,
+                              child: Container(
+                                padding: const EdgeInsets.symmetric(
+                                    horizontal: AppSpacing.sm,
+                                    vertical: AppSpacing.xs + 2),
+                                decoration: BoxDecoration(
+                                  color: AppColors.warningSolid,
+                                  borderRadius: AppRadius.smAll,
+                                ),
+                                child: Row(
+                                  mainAxisSize: MainAxisSize.min,
+                                  children: [
+                                    Icon(Icons.airplane_ticket_outlined,
+                                        size: 14,
+                                        color: AppColors.onWarningSolid),
+                                    const SizedBox(width: AppSpacing.xs),
+                                    Flexible(
+                                      child: Text(
+                                        // Rendered from the SAME date the
+                                        // window gate returned, so the nudge
+                                        // can never name a date it didn't
+                                        // qualify on.
+                                        l10n.tripsListBookTransportNudge(
+                                            shortDateOf(nudgeDate)),
+                                        // Two lines, not one: the date is the
+                                        // whole point of the nudge, and it
+                                        // sits at the END of the sentence —
+                                        // a single line ellipsizes exactly
+                                        // the fact being delivered on phones.
+                                        maxLines: 2,
+                                        overflow: TextOverflow.ellipsis,
+                                        style: theme.textTheme.labelSmall
+                                            ?.copyWith(
+                                          color: AppColors.onWarningSolid,
+                                          fontWeight: FontWeight.w600,
+                                        ),
+                                      ),
+                                    ),
+                                  ],
+                                ),
+                              ),
+                            ),
+                          ],
+                          if (showCitiesLine) ...[
+                            const SizedBox(height: 2),
+                            Text(
+                              cities,
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                              style: theme.textTheme.bodySmall?.copyWith(
+                                color: Colors.white.withValues(alpha: 0.85),
+                              ),
+                            ),
+                          ],
+                          // Prose last, after the factual lines have clustered.
+                          if (showSummary) ...[
+                            const SizedBox(height: 2),
+                            Text(
+                              summary,
+                              maxLines: 2,
+                              overflow: TextOverflow.ellipsis,
+                              style: theme.textTheme.bodySmall?.copyWith(
+                                color: Colors.white.withValues(alpha: 0.85),
+                              ),
+                            ),
+                          ],
+                        ],
+                      ),
+                    ),
+                    const Icon(Icons.arrow_forward_ios,
+                        size: 16, color: Colors.white70),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/src/packages/flutter-app/lib/widgets/trip_map_band.dart
+++ b/src/packages/flutter-app/lib/widgets/trip_map_band.dart
@@ -17,8 +17,8 @@ import 'trip_map_destinations.dart';
 /// nothing on the trip is mappable — the host card then renders exactly as it
 /// would without the band. Fed by [cachedTripDetailProvider], so it is
 /// cache-ONLY: the band decorates what other screens loaded, it never
-/// fetches. Hosts: Home's recent-trip card and the trips list's "Up next"
-/// hero.
+/// fetches. Hosts: Home's recent-trip card and the shared TripHeroCard (both
+/// the "Up next" and "Happening now" heroes).
 class TripMapBand extends ConsumerStatefulWidget {
   final String tripId;
 

--- a/src/packages/flutter-app/lib/widgets/up_next_trip_card.dart
+++ b/src/packages/flutter-app/lib/widgets/up_next_trip_card.dart
@@ -2,23 +2,15 @@ import 'package:flutter/material.dart';
 
 import '../l10n/l10n.dart';
 import '../models/trip.dart';
-import '../theme/app_colors.dart';
-import '../theme/app_shadows.dart';
-import '../theme/spacing.dart';
-import '../utils/money_format.dart';
 import '../utils/trip_days.dart';
-import '../utils/trip_format.dart';
-import '../utils/trip_list_insights.dart';
-import 'status_pill.dart';
-import 'trip_map_band.dart';
+import 'trip_hero_card.dart';
 
 /// The soonest upcoming trip, promoted to a hero at the head of the trips
-/// list — the pre-trip sibling of [LiveTripCard] (same brand-gradient card
-/// language), with a countdown pill instead of a Live pill and the cached
-/// route map as a band on top. The hero REPLACES the trip's plain list card
-/// (unlike the live spotlight, it shows strictly more than the card would),
-/// and it never renders while a live trip exists — one promoted object at a
-/// time. Tap goes straight to the trip detail.
+/// list — the pre-trip sibling of [LiveTripCard], with a countdown pill
+/// instead of a Live pill. Like it, the hero REPLACES the trip's plain list
+/// card, and it never renders while a live trip exists — one promoted object
+/// at a time. The shared body (and the reason a hero may replace a card at
+/// all) lives in [TripHeroCard].
 class UpNextTripCard extends StatelessWidget {
   final Trip trip;
   final VoidCallback onTap;
@@ -27,266 +19,19 @@ class UpNextTripCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
     final l10n = context.l10n;
+    // Promoted ⇔ daysUntilTrip is non-null (upNextTrip's own rule), so the
+    // pill can never disagree with the promotion that put the card here.
+    final days = daysUntilTrip(trip.startDate, DateTime.now());
 
-    final cities = citiesLabel(
-      trip.cities,
-      two: (a, b) => l10n.citiesTwo(a, b),
-      more: (a, b, n) => l10n.citiesMore(a, b, n),
-    );
-    final headline = tripHeadline(trip.title, cities);
-    final showCitiesLine = cities != null && headline != cities;
-    final now = DateTime.now();
-    final days = daysUntilTrip(trip.startDate, now);
-    final range = tripDateRange(trip.startDate, trip.endDate);
-    // Insight facts (specs/trips-page-insights). Null hides — list-payload
-    // fields are absent on old servers and stale offline snapshots, and are
-    // never derived locally. Zero hides too: a trip with nothing packed or
-    // nothing spent has no progress to report yet.
-    final packingTotal = trip.packingTotal ?? 0;
-    final stays = trip.stayTotal ?? 0;
-    final spent = trip.budgetSpent ?? 0;
-    final currency = trip.budgetCurrency ?? 'USD';
-    final target = trip.budgetTarget;
-    final nudgeDate = bookingNudgeDate(trip, now);
-    // The summary is the AI's own blurb; suppress it when it IS the title
-    // (long AI titles fall back to the cities headline, which would leave the
-    // same sentence printed twice).
-    final summary = (trip.summary ?? '').trim();
-    final showSummary = summary.isNotEmpty && summary != trip.title;
-
-    return Container(
-      decoration: BoxDecoration(
-        borderRadius: AppRadius.mdAll,
-        gradient: AppColors.brandGradient,
-        boxShadow: AppShadows.brandCard,
-      ),
-      child: Material(
-        color: Colors.transparent,
-        child: InkWell(
-          onTap: onTap,
-          borderRadius: AppRadius.mdAll,
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
-              // Cached route preview; collapses to nothing on a cache miss
-              // (trip never opened on this device) or an unmappable trip,
-              // leaving the gradient card on its own — TripMapBand's
-              // contract.
-              TripMapBand(tripId: trip.id),
-              Padding(
-                padding: const EdgeInsets.all(AppSpacing.lg),
-                child: Row(
-                  children: [
-                    Container(
-                      padding: const EdgeInsets.all(AppSpacing.sm + 2),
-                      decoration: BoxDecoration(
-                        color: Colors.white.withValues(alpha: 0.15),
-                        shape: BoxShape.circle,
-                      ),
-                      child: const Icon(Icons.flight_takeoff,
-                          color: Colors.white, size: 26),
-                    ),
-                    const SizedBox(width: AppSpacing.lg),
-                    Expanded(
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          Text(
-                            l10n.upNextEyebrow,
-                            maxLines: 1,
-                            overflow: TextOverflow.ellipsis,
-                            style: theme.textTheme.labelSmall?.copyWith(
-                              color: Colors.white70,
-                              letterSpacing: 1.2,
-                            ),
-                          ),
-                          const SizedBox(height: 2),
-                          Text(
-                            headline,
-                            maxLines: 1,
-                            overflow: TextOverflow.ellipsis,
-                            style: theme.textTheme.titleMedium?.copyWith(
-                              fontWeight: FontWeight.bold,
-                              color: Colors.white,
-                            ),
-                          ),
-                          const SizedBox(height: AppSpacing.xs),
-                          // A Wrap, not a Row: three variable-length labels
-                          // (countdown, range, booking progress — es strings
-                          // run long) as loose-flex Row children would each
-                          // be capped at a third of the free width and ALL
-                          // ellipsize on phones. Wrapping to a second run
-                          // keeps every label whole; a single over-wide
-                          // label still ellipsizes via StatusPill's internal
-                          // Flexible (the flight_offer_card pattern).
-                          Wrap(
-                            spacing: AppSpacing.sm,
-                            runSpacing: AppSpacing.xs,
-                            crossAxisAlignment: WrapCrossAlignment.center,
-                            children: [
-                              // White-tinted pills on the gradient, the
-                              // LiveTripCard treatment — not the trips
-                              // list's light-surface StatusPill.
-                              if (days != null)
-                                StatusPill.custom(
-                                  label: l10n.upNextStartsIn(days),
-                                  background:
-                                      Colors.white.withValues(alpha: 0.22),
-                                  foreground: Colors.white,
-                                ),
-                              if (range != null)
-                                Text(
-                                  range,
-                                  maxLines: 1,
-                                  overflow: TextOverflow.ellipsis,
-                                  style: theme.textTheme.bodySmall?.copyWith(
-                                    color:
-                                        Colors.white.withValues(alpha: 0.85),
-                                  ),
-                                ),
-                              // Booking progress rides the hero too — it
-                              // replaced the plain card, so the promoted trip
-                              // must not lose its progress pill. Null/zero
-                              // hides it.
-                              if ((trip.bookingTotal ?? 0) > 0)
-                                StatusPill.custom(
-                                  label: l10n.tripsListBookedCount(
-                                      trip.bookingBooked ?? 0,
-                                      trip.bookingTotal!),
-                                  background:
-                                      Colors.white.withValues(alpha: 0.22),
-                                  foreground: Colors.white,
-                                ),
-                              // Packing progress — state, so a pill.
-                              if (packingTotal > 0)
-                                StatusPill.custom(
-                                  label: l10n.tripsListPackedCount(
-                                      trip.packingDone ?? 0, packingTotal),
-                                  background:
-                                      Colors.white.withValues(alpha: 0.22),
-                                  foreground: Colors.white,
-                                ),
-                              // Stays are context, not progress: the booking
-                              // pill already carries "how much is booked", so
-                              // a second progress pill would double-count.
-                              // Plain text like the date range.
-                              if (stays > 0)
-                                Text(
-                                  l10n.tripsListStaysCount(stays),
-                                  maxLines: 1,
-                                  overflow: TextOverflow.ellipsis,
-                                  style: theme.textTheme.bodySmall?.copyWith(
-                                    color:
-                                        Colors.white.withValues(alpha: 0.85),
-                                  ),
-                                ),
-                              // Budget rides the hero only — money is the
-                              // noisiest fact and the plain rows stay lean.
-                              // Over target flips to the OPAQUE warning pair:
-                              // alpha containers wash out on the gradient.
-                              if (spent > 0)
-                                StatusPill.custom(
-                                  label: target == null
-                                      ? l10n.budgetSummarySpent(
-                                          formatMoney(spent, currency))
-                                      : l10n.tripsListBudgetSpentOfTarget(
-                                          formatMoney(spent, currency),
-                                          formatMoney(target, currency)),
-                                  background: target != null && spent > target
-                                      ? AppColors.warningSolid
-                                      : Colors.white.withValues(alpha: 0.22),
-                                  foreground: target != null && spent > target
-                                      ? AppColors.onWarningSolid
-                                      : Colors.white,
-                                ),
-                            ],
-                          ),
-                          // The nudge gets its own row, never a Wrap slot: one
-                          // attention object per card, and the countdown pill
-                          // keeps the first slot it has always had.
-                          if (nudgeDate != null) ...[
-                            const SizedBox(height: AppSpacing.xs),
-                            Align(
-                              alignment: Alignment.centerLeft,
-                              child: Container(
-                                padding: const EdgeInsets.symmetric(
-                                    horizontal: AppSpacing.sm,
-                                    vertical: AppSpacing.xs + 2),
-                                decoration: BoxDecoration(
-                                  color: AppColors.warningSolid,
-                                  borderRadius: AppRadius.smAll,
-                                ),
-                                child: Row(
-                                  mainAxisSize: MainAxisSize.min,
-                                  children: [
-                                    Icon(Icons.airplane_ticket_outlined,
-                                        size: 14,
-                                        color: AppColors.onWarningSolid),
-                                    const SizedBox(width: AppSpacing.xs),
-                                    Flexible(
-                                      child: Text(
-                                        // Rendered from the SAME date the
-                                        // window gate returned, so the nudge
-                                        // can never name a date it didn't
-                                        // qualify on.
-                                        l10n.tripsListBookTransportNudge(
-                                            shortDateOf(nudgeDate)),
-                                        // Two lines, not one: the date is the
-                                        // whole point of the nudge, and it
-                                        // sits at the END of the sentence —
-                                        // a single line ellipsizes exactly
-                                        // the fact being delivered on phones.
-                                        maxLines: 2,
-                                        overflow: TextOverflow.ellipsis,
-                                        style: theme.textTheme.labelSmall
-                                            ?.copyWith(
-                                          color: AppColors.onWarningSolid,
-                                          fontWeight: FontWeight.w600,
-                                        ),
-                                      ),
-                                    ),
-                                  ],
-                                ),
-                              ),
-                            ),
-                          ],
-                          if (showCitiesLine) ...[
-                            const SizedBox(height: 2),
-                            Text(
-                              cities,
-                              maxLines: 1,
-                              overflow: TextOverflow.ellipsis,
-                              style: theme.textTheme.bodySmall?.copyWith(
-                                color: Colors.white.withValues(alpha: 0.85),
-                              ),
-                            ),
-                          ],
-                          // Prose last, after the factual lines have clustered.
-                          if (showSummary) ...[
-                            const SizedBox(height: 2),
-                            Text(
-                              summary,
-                              maxLines: 2,
-                              overflow: TextOverflow.ellipsis,
-                              style: theme.textTheme.bodySmall?.copyWith(
-                                color: Colors.white.withValues(alpha: 0.85),
-                              ),
-                            ),
-                          ],
-                        ],
-                      ),
-                    ),
-                    const Icon(Icons.arrow_forward_ios,
-                        size: 16, color: Colors.white70),
-                  ],
-                ),
-              ),
-            ],
-          ),
-        ),
-      ),
+    return TripHeroCard(
+      trip: trip,
+      eyebrow: l10n.upNextEyebrow,
+      icon: Icons.flight_takeoff,
+      leadingMeta: [
+        if (days != null) TripHeroCard.heroPill(l10n.upNextStartsIn(days)),
+      ],
+      onTap: onTap,
     );
   }
 }

--- a/src/packages/flutter-app/test/home_live_trip_test.dart
+++ b/src/packages/flutter-app/test/home_live_trip_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import 'package:travel_route_planner/models/itinerary_item.dart';
 import 'package:travel_route_planner/models/trip.dart';
 import 'package:travel_route_planner/models/user.dart';
 import 'package:travel_route_planner/providers/auth_provider.dart';
@@ -12,6 +13,7 @@ import 'package:travel_route_planner/providers/live_trip_provider.dart';
 import 'package:travel_route_planner/providers/resumable_chats_provider.dart';
 import 'package:travel_route_planner/screens/home_screen.dart';
 import 'package:travel_route_planner/widgets/live_trip_card.dart';
+import 'package:travel_route_planner/widgets/trip_map_band.dart';
 
 import 'support/l10n_test_app.dart';
 
@@ -112,6 +114,54 @@ void main() {
     expect(find.byType(LiveTripCard), findsOneWidget);
     expect(find.text('HAPPENING NOW'), findsOneWidget);
     expect(find.text('Day 2 of 3'), findsOneWidget);
+  });
+
+  testWidgets('Home\'s live card carries no route band, cache hit or not',
+      (WidgetTester tester) async {
+    // The live card is the ONE card that renders on Home and the trips list
+    // at once (AppShell's IndexedStack keeps both alive), and two flutter_map
+    // instances racing for the same tiles leave BOTH blank — verified in a
+    // browser. The trips list owns this trip's band; suppressing it here is
+    // what makes that one work, so it is pinned rather than left to a
+    // "why is this false?" cleanup.
+    SharedPreferences.setMockInitialValues({
+      'trip_cache.user-1.trip.t1': jsonEncode({
+        'saved_at': '2026-08-01T10:00:00.000',
+        'trip': Trip(
+          id: 't1',
+          title: 'Athens Trip',
+          startDate: _iso(DateTime.now().subtract(const Duration(days: 1))),
+          endDate: _iso(DateTime.now().add(const Duration(days: 1))),
+          createdAt: '2026-06-01',
+          updatedAt: '2026-06-01',
+          items: const [
+            ItineraryItem(
+              id: 'i0',
+              position: 0,
+              name: 'Acropolis',
+              city: 'Athens',
+              latitude: 37.9715,
+              longitude: 23.7267,
+              category: 'attraction',
+            ),
+            ItineraryItem(
+              id: 'i1',
+              position: 1,
+              name: 'Plaka',
+              city: 'Athens',
+              latitude: 37.9725,
+              longitude: 23.7300,
+              category: 'attraction',
+            ),
+          ],
+        ).toJson(),
+      }),
+    });
+    await _pumpHome(tester, _liveTrip('t1'));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(LiveTripCard), findsOneWidget);
+    expect(find.byType(TripMapBand), findsNothing);
   });
 
   testWidgets('recent-trip tile hides when it is the live trip',

--- a/src/packages/flutter-app/test/trip_hero_card_test.dart
+++ b/src/packages/flutter-app/test/trip_hero_card_test.dart
@@ -1,0 +1,136 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:travel_route_planner/models/trip.dart';
+import 'package:travel_route_planner/providers/trip_cache_provider.dart';
+import 'package:travel_route_planner/services/trip_cache.dart';
+import 'package:travel_route_planner/theme/app_theme.dart';
+import 'package:travel_route_planner/widgets/live_trip_card.dart';
+import 'package:travel_route_planner/widgets/up_next_trip_card.dart';
+
+import 'support/l10n_test_app.dart';
+
+/// The shared promoted-trip card (widgets/trip_hero_card.dart) seen through
+/// its two wrappers. The screen-level placement and dedupe live in
+/// trips_list_live_test / trips_list_up_next_test; what's pinned here is the
+/// policy that differs between the two heroes.
+String _iso(DateTime d) => '${d.year.toString().padLeft(4, '0')}-'
+    '${d.month.toString().padLeft(2, '0')}-'
+    '${d.day.toString().padLeft(2, '0')}';
+
+String _rel(int days) => _iso(DateTime.now().add(Duration(days: days)));
+
+Trip _trip({String? start, String? end, String? nextTransportDepart}) => Trip(
+      id: 't1',
+      title: 'Athens Trip',
+      startDate: start,
+      endDate: end,
+      nextTransportDepart: nextTransportDepart,
+      createdAt: '2026-06-01',
+      updatedAt: '2026-06-01',
+    );
+
+Future<void> _pump(WidgetTester tester, Widget card,
+        {Locale? locale, ThemeData? theme}) =>
+    tester.pumpWidget(
+      ProviderScope(
+        // TripMapBand reads the cache and collapses on the miss.
+        overrides: [tripCacheProvider.overrideWithValue(TripCache('u1'))],
+        child: localizedTestApp(
+          home: Scaffold(body: card),
+          locale: locale,
+          theme: theme,
+        ),
+      ),
+    );
+
+void main() {
+  setUp(() => SharedPreferences.setMockInitialValues({}));
+
+  testWidgets('the up-next hero raises the booking nudge',
+      (WidgetTester tester) async {
+    await _pump(
+      tester,
+      UpNextTripCard(
+        trip: _trip(
+            start: _rel(10), end: _rel(13), nextTransportDepart: _rel(5)),
+        onTap: () {},
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('UP NEXT'), findsOneWidget);
+    expect(find.textContaining('Book transport'), findsOneWidget);
+  });
+
+  testWidgets('a started trip never nudges — the copy is pre-departure',
+      (WidgetTester tester) async {
+    // Same window the up-next case passes on (a departure 2 days out), but
+    // the traveler is on day 2: bookingNudgeDate gates only on the departure
+    // being unbooked and near, so an unbooked RETURN leg reaches it — and
+    // "first leg departs …" is then simply false.
+    await _pump(
+      tester,
+      LiveTripCard(
+        trip:
+            _trip(start: _rel(-1), end: _rel(3), nextTransportDepart: _rel(2)),
+        onTap: () {},
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('HAPPENING NOW'), findsOneWidget);
+    expect(find.text('Live'), findsOneWidget);
+    expect(find.textContaining('Book transport'), findsNothing);
+  });
+
+  testWidgets('every fact at once survives a 360px phone in Spanish, dark',
+      (WidgetTester tester) async {
+    // The hero took on the plain card's whole fact set, so its meta row can
+    // now run to nine labels. This is the density guard: a Wrap run that
+    // overflowed would fail the pump outright, and es is the long-string
+    // locale. Dark mode rides along — the pills are alpha-white on the
+    // gradient either way, and this catches a theme-dependent regression.
+    await tester.binding.setSurfaceSize(const Size(360, 800));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    await _pump(
+      tester,
+      LiveTripCard(
+        trip: Trip(
+          id: 't1',
+          title: 'Gran Aventura de Verano',
+          summary: 'Tres días de ruinas, café y mercados.',
+          startDate: _rel(-1),
+          endDate: _rel(3),
+          cities: const ['Atenas', 'El Pireo', 'Salónica'],
+          itemCount: 63,
+          bookingTotal: 18,
+          bookingBooked: 5,
+          stayTotal: 4,
+          packingTotal: 20,
+          packingDone: 12,
+          budgetTarget: 800,
+          budgetSpent: 540,
+          budgetCurrency: 'EUR',
+          shared: true,
+          createdAt: '2026-06-01',
+          updatedAt: '2026-06-01',
+        ),
+        onTap: () {},
+      ),
+      locale: const Locale('es'),
+      theme: AppTheme.dark,
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('SUCEDIENDO AHORA'), findsOneWidget);
+    expect(find.text('En curso'), findsOneWidget);
+    expect(find.text('5/18 reservados'), findsOneWidget);
+    expect(find.text('12/20 en la maleta'), findsOneWidget);
+    expect(find.text('63 lugares'), findsOneWidget);
+    expect(find.text('Compartido'), findsOneWidget);
+  });
+}

--- a/src/packages/flutter-app/test/trips_list_header_test.dart
+++ b/src/packages/flutter-app/test/trips_list_header_test.dart
@@ -116,6 +116,23 @@ void main() {
     expect(find.text('Past trips'), findsOneWidget);
   });
 
+  testWidgets(
+      'a live-trip-only account keeps the Upcoming header over an empty run',
+      (WidgetTester tester) async {
+    // The twin of the all-past case: since the 2026-08-15 amendment the hero
+    // takes the live trip OUT of the run, so the one-trip account is the
+    // second way to reach an empty Upcoming. Same answer — the header stays,
+    // because it carries "New trip".
+    await _pumpList(tester, trips: [
+      _trip('live', 'Athens Trip', start: _rel(-1), end: _rel(1)),
+    ]);
+    await tester.pumpAndSettle();
+
+    expect(find.text('Upcoming'), findsOneWidget);
+    expect(find.text('New trip'), findsOneWidget);
+    expect(find.text('Athens Trip'), findsOneWidget);
+  });
+
   testWidgets('shared-only accounts get no Upcoming header',
       (WidgetTester tester) async {
     await _pumpList(tester, shared: [

--- a/src/packages/flutter-app/test/trips_list_live_test.dart
+++ b/src/packages/flutter-app/test/trips_list_live_test.dart
@@ -20,8 +20,9 @@ import 'package:travel_route_planner/widgets/up_next_trip_card.dart';
 import 'support/l10n_test_app.dart';
 
 /// The "Happening now" card on the trips list (specs/happening-now): promoted
-/// above the continue section and My Trips, live trip left in place below,
-/// tap-through to the trip detail, and offline-cache parity.
+/// above the continue section and the Upcoming run, the trip's plain card
+/// REPLACED rather than repeated (spec.md's 2026-08-15 amendment), tap-through
+/// to the trip detail, and offline-cache parity.
 ///
 /// Dates are relative to DateTime.now() so "today" is always live.
 class _QueuedTripsApiService extends TripsApiService {
@@ -126,9 +127,18 @@ void main() {
     expect(cardY, lessThan(continueY));
     expect(continueY, lessThan(tripCardY));
 
-    // Promoted shortcut, not a filter: the live trip stays in My Trips, so
-    // its title shows twice — once on the card, once on its list card.
-    expect(find.text('Athens Trip'), findsNWidgets(2));
+    // The hero REPLACES the plain card: one copy on the screen, and it is
+    // the hero's. A trip you are ON is not "Upcoming".
+    expect(find.text('Athens Trip'), findsOneWidget);
+    expect(
+      find.descendant(
+          of: find.byType(LiveTripCard), matching: find.text('Athens Trip')),
+      findsOneWidget,
+    );
+    // The genuinely-upcoming trip still lists. Asserting BOTH is what pins
+    // the filter to the promoted id: a filter on "has started" would also
+    // vanish a second, non-promoted in-progress trip.
+    expect(find.text('Lisbon Trip'), findsOneWidget);
   });
 
   testWidgets('live card shows trip progress and the Live pill',
@@ -143,6 +153,64 @@ void main() {
     expect(find.text('HAPPENING NOW'), findsOneWidget);
     expect(find.text('Day 2 of 3'), findsOneWidget);
     expect(find.text('Live'), findsOneWidget);
+  });
+
+  testWidgets('the live hero carries the plain card facts it replaced',
+      (WidgetTester tester) async {
+    // The dedupe is only honest while the hero shows at least what the row
+    // showed, so the facts the row would have printed are asserted INSIDE the
+    // hero. Its own duration chip stays off: "Day 2 of 3" already says 3.
+    final service = _QueuedTripsApiService([
+      [
+        Trip(
+          id: 'live',
+          title: 'Athens Trip',
+          summary: 'Three days of ruins and coffee.',
+          startDate: _rel(-1),
+          endDate: _rel(1),
+          cities: const ['Athens', 'Piraeus'],
+          itemCount: 10,
+          bookingTotal: 3,
+          bookingBooked: 0,
+          stayTotal: 2,
+          shared: true,
+          createdAt: '2026-06-01',
+          updatedAt: '2026-06-01',
+        )
+      ]
+    ]);
+
+    await _pumpList(tester, service);
+    await tester.pumpAndSettle();
+
+    Finder inHero(Finder f) =>
+        find.descendant(of: find.byType(LiveTripCard), matching: f);
+
+    expect(inHero(find.text('0/3 booked')), findsOneWidget);
+    expect(inHero(find.text('2 stays')), findsOneWidget);
+    expect(inHero(find.text('10 places')), findsOneWidget);
+    expect(inHero(find.text('Shared')), findsOneWidget);
+    expect(inHero(find.text('2 cities')), findsOneWidget);
+    expect(inHero(find.text('Athens & Piraeus')), findsOneWidget);
+    expect(inHero(find.text('Three days of ruins and coffee.')), findsOneWidget);
+    expect(find.text('3 days'), findsNothing);
+  });
+
+  testWidgets('an end-less live trip is promoted, not filed under Past',
+      (WidgetTester tester) async {
+    // tripIsPast and the live rule disagree about end-less trips, so the
+    // partition's live exemption is what keeps a Live-pill trip out of the
+    // collapsed group — the promotion only removes it from the Upcoming run.
+    final service = _QueuedTripsApiService([
+      [_trip('live', 'Athens Trip', start: _rel(-1))]
+    ]);
+
+    await _pumpList(tester, service);
+    await tester.pumpAndSettle();
+
+    expect(find.byType(LiveTripCard), findsOneWidget);
+    expect(find.text('Athens Trip'), findsOneWidget);
+    expect(find.text('Past trips'), findsNothing);
   });
 
   testWidgets('tapping the live card opens the trip detail screen',
@@ -188,6 +256,9 @@ void main() {
         findsOneWidget);
     expect(find.byType(LiveTripCard), findsOneWidget);
     expect(find.text('Day 2 of 3'), findsOneWidget);
+    // The cache is its own path into tripsProvider, so it gets its own
+    // dedupe pin.
+    expect(find.text('Athens Trip'), findsOneWidget);
   });
 
   testWidgets('wide layouts cap the list content at 700px, phones fill',

--- a/src/packages/flutter-app/test/trips_list_title_test.dart
+++ b/src/packages/flutter-app/test/trips_list_title_test.dart
@@ -119,14 +119,27 @@ void main() {
       updatedAt: '2026-06-01',
     );
     await tester.pumpWidget(
-      MaterialApp(
-        localizationsDelegates: testLocalizationsDelegates,
-        home: Scaffold(body: LiveTripCard(trip: trip, onTap: () {})),
+      // The hero carries a TripMapBand now, which reads the trip cache — so
+      // even a bare card pump needs the scope (the band collapses on the
+      // miss).
+      ProviderScope(
+        overrides: [tripCacheProvider.overrideWithValue(TripCache('u1'))],
+        child: MaterialApp(
+          localizationsDelegates: testLocalizationsDelegates,
+          home: Scaffold(body: LiveTripCard(trip: trip, onTap: () {})),
+        ),
       ),
     );
     await tester.pumpAndSettle();
 
     expect(find.text('Big Summer Adventure 2026'), findsOneWidget);
-    expect(find.text('Prague & Kraków +1 more'), findsNothing);
+    // The cities label is the SUBTITLE line, never the headline — the hero
+    // gained that line when it took over the plain card's facts, so the
+    // assertion is about where it sits, not whether it exists.
+    expect(find.text('Prague & Kraków +1 more'), findsOneWidget);
+    expect(
+      tester.getTopLeft(find.text('Big Summer Adventure 2026')).dy,
+      lessThan(tester.getTopLeft(find.text('Prague & Kraków +1 more')).dy),
+    );
   });
 }

--- a/src/packages/flutter-app/test/trips_list_up_next_test.dart
+++ b/src/packages/flutter-app/test/trips_list_up_next_test.dart
@@ -180,6 +180,9 @@ void main() {
     expect(find.byType(UpNextTripCard), findsNothing);
     // Not promoted, so the future trip keeps its plain card.
     expect(find.text('Lisbon Trip'), findsOneWidget);
+    // And the promoted one loses its own — whichever hero holds the slot,
+    // it replaces the card (this was 2 before the 2026-08-15 amendment).
+    expect(find.text('Athens Trip'), findsOneWidget);
   });
 
   testWidgets('undated-only lists get no hero', (WidgetTester tester) async {


### PR DESCRIPTION
## Summary

A trip happening today rendered **twice** on the trips list: in the HAPPENING NOW hero and again as a plain card under a header reading "Upcoming" — a trip already under way, filed under the word *upcoming*, beside a copy of itself.

That was `specs/happening-now`'s "a shortcut, not a filter", written when the list below was one flat run called "My Trips" and the card carried three facts. It genuinely showed **less** than the row, so leaving the row was the only way not to lose the dates, the booking progress and the item count. The sections the list has gained since are what made the rule wrong, and the "Up next" hero had already established the better one: **a hero REPLACES its card, and may only be promoted while it shows strictly more.**

- **`lib/widgets/trip_hero_card.dart` (new)** — the one promoted-trip card, lifted out of `UpNextTripCard`. The two heroes differ in an eyebrow, an icon and whatever holds the first meta slot ("Live · Day 2 of 3" vs "Starts in 10 days"), so those are the parameters. Its Wrap now carries **every** fact the plain `_TripCard` prints — adding places and the Shared pill, which the up-next hero was silently dropping — plus the hero-only band, budget pill and nudge. `AppShadows.brandCard` was byte-identical to `LiveTripCard`'s inline shadow, so the shell is a pure move (net −180 lines in `lib/`).
- **`live_trip_card.dart` / `up_next_trip_card.dart`** — thin wrappers; class names kept (six test files find them by type). The live hero passes `showDuration: false` — "Day 2 of 3" already names the span.
- **The booking nudge is silenced once a trip has started.** Its window gate fires on *any* unbooked future departure, so an unbooked return leg raises it on day 2 — under copy that reads *"first leg departs …"*. It was hero-only, never on the card being replaced, so nothing is lost.
- **`trips_list_screen.dart`** — ONE name for the promoted trip (`promotedId` = the live trip, else the up-next hero) and one subtraction from the Upcoming run. The bug existed because there were two notions of "promoted" and only one was subtracted.
- **`trip_list_order.dart`** — doc only. The `liveTripId` past-exemption is still load-bearing: it keeps the promoted trip out of the collapsed "Past trips" group, which an end-less started trip would otherwise land in.
- **`specs/happening-now`** — amended, not silently contradicted (the house pattern from `specs/trips-page-insights`).

### Second commit: the route band is the trips list's, not Home's

Browser verification turned up a bug the change itself created — the band rendered as a **black rectangle** on both surfaces. The live card is the one card that renders on Home *and* the trips list at once (AppShell's `IndexedStack` keeps both alive), so it mounted two `flutter_map` instances asking for the same tile URLs, and they cancel each other (`net::ERR_ABORTED`) until neither paints. `TripHeroCard.showMap`, false from Home. The fact set stays identical on both surfaces — the divergence is one decoration that physically cannot render twice.

## Testing

- `flutter test` — **1343 green**.
- `flutter analyze` — clean at its 3-info baseline (all pre-existing, `route_response.dart`).
- Tests changed/added: the `findsNWidgets(2)` that pinned the duplicate is now `findsOneWidget` scoped to the hero; new coverage for the facts the hero inherited, an end-less live trip staying out of Past, a live-trip-only account keeping the Upcoming header, the nudge policy on both hero kinds, a nine-label meta row at 360px in Spanish + dark (density guard), and Home's band suppression with a **warm** cache (verified to fail with `showMap: true` — a cold cache would have proved nothing). `trips_list_title_test.dart` needed a `ProviderScope` (the card builds a `TripMapBand` now) and its cities-line assertion inverted, since the hero gained that line.
- **Manual, lane stack `:3001`** with a seeded trip spanning today: one Montreal Weekend on the list, hero carrying `Live · Day 2 of 3 · Aug 14 – Aug 16 · 0/1 booked · 2 stays · 10 places · Montreal` + summary, Upcoming starting at the next trip, and the satellite route band rendering after the Home fix. A/B/A'd the band failure and Home re-checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)