### PR TITLE
feat(trip): a trip keeps its chat — back closes it, nothing else loses it

### DIFF
--- a/docs/friction-log.md
+++ b/docs/friction-log.md
@@ -5,6 +5,83 @@ build queue. Priority when picking work: **breakage > friction in features
 actually used > ideas that recur across ≥2 sessions**. Tag entries `[app]`
 (dogfooding the product) or `[dev]` (workflow/tooling). Newest first.
 
+## 2026-08-15 — the chat you lose by pressing the wrong button
+
+- **[app] Friction, recurring:** *"when editing a trip via the chat, should keep
+  track of the last chat for the trip so you can go back to it. I've
+  accidentally clicked the back button and had to restart a chat **several
+  times**."* Recurrence rule satisfied on its own.
+- **[app] One complaint, three independent causes — and only one of them was
+  the back button.**
+  1. **Back left the page.** The refine panel is drawn *inside* trip detail
+     (`_panelOpen` is widget state, not a route) and the screen had no
+     `PopScope`. On narrow it renders as a `DraggableScrollableSheet`, so it
+     *looks* modal — back is the obvious gesture for dismissing it, and it threw
+     away the whole page instead.
+  2. **Five of the six ways back in destroyed the conversation.** Every ✨ entry
+     (header chip, app-bar sparkle, per-day, per-city, Next Step) went through
+     `beginSectionRefinement`, which called `reset()` first. Only the 💬 FAB
+     reopened what was there — and it's hidden while the panel is open, so it
+     isn't the button you associate with "the chat". Going back in through the
+     button you started with is the one gesture guaranteed to wipe it.
+  3. **It was never saved at all.** `persistSession` required
+     `boundTripID == nil`, so a trip-bound turn wrote nothing. Even with 1 and 2
+     fixed, a refresh or a deploy still lost it.
+- **[app] "Nothing to resume" was a claim about the trip, not the conversation.**
+  `specs/continue-where-you-left-off` put trip-bound panels out of scope because
+  a refine "patches a trip in place — nothing to continue". True of the *trip*.
+  The transcript is the thing with continuity, and it was the thing being
+  thrown away.
+- **[app] The fix: one running conversation per trip, and `UNIQUE (user_id,
+  trip_id)` is that sentence.** New table `trip_refine_sessions` (00069) rather
+  than a nullable `trip_id` on `plan_chat_sessions`, for a reason worth
+  remembering: a refine transcript then has **no chat id anywhere**, so
+  `GET /chats/{id}` and `/plan/<id>` *structurally cannot* reach it and can
+  never rehydrate it into the unbound Agent tab (where the trip binding would
+  silently vanish and the agent would fall back to `create_itinerary`). The
+  column version needed `AND trip_id IS NULL` remembered in five places —
+  resumable list, get-by-chat-id, the 60-day prune, the weekly-nudge predicate,
+  and the upsert's conflict target. **Reusing `trips.chat_id` would have been
+  worse than untidy: that key already owns the plan_chat_sessions row of the
+  chat that CREATED the trip, so refine turns would have upserted over the
+  original planning transcript.**
+- **[app] Retention is the trip, not 60 days.** Plan chats are pruned when idle
+  two months; a trip planned in August for next March must still have its chat
+  in November. `ON DELETE CASCADE` is the entire GC story — no janitor rule.
+- **[app] Appending seeds needed the stub, or the fix would have caused the next
+  bug.** `_buildSectionSeed` dumps every item with coordinates and tags. Now
+  that ✨ appends instead of resetting, a conversation would accumulate
+  near-duplicate snapshots and the agent could not tell which is current — the
+  same shape as the `update_itinerary_section` scope bugs. So each new seed
+  rewrites the earlier ones' listings to a one-line "superseded" stub, **in
+  place and never removing a message**, because `compactedCount` is a
+  start-anchored index into `messages`. Free for the reader: labeled messages
+  render as context chips and their content is never shown.
+- **[app] The freshness hole the feature exposed.** A conversation you can
+  resume days later is a conversation whose opening description is stale — and
+  `update_itinerary_section` takes the COMPLETE list, so rebuilding from memory
+  silently reverts anything changed since, including a co-planner's edits. The
+  bound prompt now says earlier messages describe the itinerary AS IT WAS and
+  requires `get_trip` before any edit. Which surfaced a live bug: `get_trip`
+  with no `trip_id` listed `ListLatestTripsByOwner(uid)` — for a **collaborator**
+  that is their own other trips and never the trip being refined. In a bound
+  session it now returns that trip.
+- **[dev] The back fix would have introduced a silent staleness bug.** The
+  `trip_updated` → reload listener lived *inside* `TripRefinePanel`. Once back
+  can close the panel mid-turn, a patch landing afterwards would never have been
+  picked up and the itinerary would have sat there stale after an edit the agent
+  really made. Moved to the screen. **A listener's lifetime must be at least as
+  long as the thing it listens for.**
+- **[dev] A test found a dead end in the error state itself.** The
+  expired/failed panel body overflowed the narrow sheet by 48px, so its
+  "New chat" button was unreachable — an escape hatch you cannot tap is the
+  dead end it exists to escape. Now scrollable.
+- **[dev] `pumpAndSettle` never settles behind a live turn.** The closed-panel
+  FAB shows a progress indicator while a turn streams, so the mid-stream tests
+  have to `pump()` a fixed number of frames. Also: `FilledButton.tonalIcon` is
+  not found by `widgetWithText(FilledButton, …)` — the wave-20 subtype trap,
+  hit again.
+
 ## 2026-08-15 — a flight link for a 1h35 train
 
 - **[app] Friction:** planning Italy, the obvious way from Rome to Florence is

--- a/specs/collaborator-refine/spec.md
+++ b/specs/collaborator-refine/spec.md
@@ -37,7 +37,12 @@ itinerary.
 - [ ] Two simultaneous whole-itinerary writes (refine vs. refine, refine vs.
       reorder) serialize — last write wins cleanly, never a merged/duplicated
       item set.
-- [ ] A collaborator's refine session is ephemeral: it does not appear in
+- [ ] *(Amended by specs/trip-refine-memory: a collaborator's refine
+      conversation is no longer ephemeral — it is saved under their own account
+      for that trip, visible to no one else, deleted with the trip, and a
+      revoked collaborator loses access to it without it being destroyed. It
+      still appears in nobody's resumable chats.)*
+      A collaborator's refine session is ephemeral: it does not appear in
       anyone's resumable chats.
 - [ ] Refine usage is metered against the person pressing the button (their
       own free-tier session count, not the owner's).

--- a/specs/continue-where-you-left-off/spec.md
+++ b/specs/continue-where-you-left-off/spec.md
@@ -42,7 +42,10 @@ agent actually saved.
 - [ ] Once the agent saves a trip from a conversation, that conversation no
       longer appears in the section (the trip card represents it).
 - [ ] A conversation abandoned while refining an existing saved trip does not
-      appear in the section.
+      appear in the section. (Still true since specs/trip-refine-memory, by a
+      stronger mechanism: a trip's conversation is stored per (traveler, trip)
+      in its own table with no chat id at all, so it is resumed from the trip's
+      own page and cannot be named here.)
 - [ ] Dismissing an entry removes it immediately.
 - [ ] Anonymous users see no section and nothing is saved for them; the chat
       behaves exactly as before.
@@ -114,7 +117,8 @@ agent actually saved.
 - Server-side rendering of tool results/cards in a resumed transcript — only
   the text conversation is restored.
 - Cross-device real-time sync or conflict resolution.
-- Resuming trip-bound refine panels.
+- Resuming trip-bound refine panels — **shipped separately** as
+  `specs/trip-refine-memory`, from the trip's own page rather than this section.
 
 ## Open Questions
 

--- a/specs/conversation-compaction/spec.md
+++ b/specs/conversation-compaction/spec.md
@@ -89,7 +89,9 @@ travels with each request, like the rest of the transcript.
   current at send time.
 - The long refinement seed message eventually falls into the summary; trip-
   bound sessions re-read authoritative trip state via tools, so no special
-  casing.
+  casing. *(specs/trip-refine-memory made this true rather than assumed: the
+  bound system prompt now requires get_trip before any edit, and each new
+  section seed collapses the earlier ones' listings.)*
 - The summary itself can never exceed the per-message limit (the server caps
   and truncates its own output defensively).
 

--- a/specs/refine-panel-polish/spec.md
+++ b/specs/refine-panel-polish/spec.md
@@ -69,7 +69,10 @@ display label (UI-only; never sent to the server).
   final state always reflects the last patch.
 - Refresh failing mid-refine must not replace the screen with an error page.
 - Re-opening Refine on another section re-seeds; each session starts with its
-  own context chip.
+  own context chip. *(Amended by specs/trip-refine-memory: it re-seeds into the
+  SAME conversation, adding a second context chip rather than discarding what
+  came before, and the earlier chip's itinerary listing is collapsed so only
+  one authoritative listing is ever in play.)*
 
 ## Out of Scope
 

--- a/specs/trip-refine-memory/plan.md
+++ b/specs/trip-refine-memory/plan.md
@@ -1,0 +1,174 @@
+# Plan: Trip Refine Memory
+
+## Technical Approach
+
+Four load-bearing decisions; the rest follows.
+
+### 1. Its own table, `trip_refine_sessions`, keyed `UNIQUE (user_id, trip_id)`
+
+Not a nullable `trip_id` on `plan_chat_sessions`, and emphatically not
+`trips.chat_id`.
+
+- The product decision ("one running chat per trip") becomes a **constraint the
+  database enforces**, not a convention the client maintains.
+- A refine transcript then has **no chat id anywhere** — not in the table, not
+  on the wire — so `GET /chats/{chatId}` and `/plan/<chatId>` *structurally
+  cannot* address it. "A trip chat can never be resumed into the unbound Agent
+  tab, silently dropping the trip binding" stops being a filter someone can
+  delete and becomes a fact about the schema.
+- A nullable column would instead require `AND trip_id IS NULL` remembered in
+  five places: `ListResumablePlanChatSessions`, `GetPlanChatSessionByChatID`,
+  `DeleteStalePlanChatSessions`, the weekly-nudge predicate in
+  `query/reengagement.sql`, and the upsert's conflict target. `docs/zen.md`:
+  promote the convention to storage.
+- **Reusing `trips.chat_id` is a data-loss bug, not a smell.** That key already
+  owns a `plan_chat_sessions` row — the freeform chat that created the trip —
+  so refine turns would `ON CONFLICT DO UPDATE` over the original planning
+  transcript. It is also non-unique (one lineage, N version rows), NULL for
+  imported and logged trips, deliberately withheld from collaborators
+  (`trip_handler.go`), and already used to resolve a trip in
+  `plan_trip_dates.go`.
+- **This does not contradict migration 00031's header**, which chose read-time
+  graduation over a column. That was a *derived, racy* question ("has this chat
+  produced a trip?") about a text key with a competing writer
+  (`create_itinerary`). "Which trip is this conversation about?" is validated
+  request input, resolved before a byte streams, and immutable for the row's
+  life. Storing an identity is not the thing 00031 argued against.
+- **Retention is the trip**, not 60 days: a trip planned in August for next
+  March must still have its chat in November. `ON DELETE CASCADE` is the whole
+  GC story — enforced by the database rather than by a janitor rule.
+- Cost accepted: two tables share transcript shape. Paid for by extracting one
+  derivation, `planTranscriptFields`, used by both savers and pinned by a
+  parity test (`docs/zen.md`: a second implementation owes a parity contract).
+
+### 2. The panel header is a function of the transcript
+
+`_refineTarget` was screen state whose only job was the panel title — and the
+title is already in the transcript, since every seed message carries a
+`displayLabel` that `chat_panel.dart` renders as a context chip. Deleting it
+makes `_panelOpen` the panel's only state, so back has exactly one thing to
+undo, and the "restore a header if the screen was rebuilt" hack disappears.
+
+### 3. Appending a section seed stubs the earlier ones
+
+`_buildSectionSeed` dumps every item with coordinates and tags. Repeating that
+per ✨ tap would leave the agent holding N near-duplicate itinerary snapshots
+with no way to tell which is current — the failure class behind the
+`update_itinerary_section` scope bugs. On append, each *earlier* labeled user
+message's `content` is rewritten **in place** to a one-line "superseded" stub
+while its `displayLabel` is kept, so exactly one authoritative listing is ever
+in context. Nearly free, because seed content is never rendered.
+
+**Rewrite, never remove**: `compactedCount` is a start-anchored index into
+`messages`, so deleting a message would misalign the wire history.
+
+### 4. Freshness is the server's job, unconditionally
+
+A resumed conversation that rebuilt a section from its remembered listing would
+silently revert hand edits and a co-planner's changes. Fixed in the bound
+system prompt plus `get_trip` — not with a client-side re-seed.
+`specs/conversation-compaction` already claimed trip-bound sessions "re-read
+authoritative trip state via tools"; this makes it true. Applied to every bound
+session, not just resumed ones, so there is no special case to remember — and
+it is already correct for fresh ones, since a co-planner can edit mid-chat.
+
+## Go API Changes
+
+`src/packages/api/`
+
+- **Migration** `migrations/00069_trip_refine_sessions.sql` (00058 stays
+  burned). Header carries decision 1 verbatim.
+- **Queries** appended to `query/chat_sessions.sql`, then `make api-sqlc`
+  (never hand-edit `store/`): `UpsertTripRefineSession`,
+  `GetTripRefineSession`, `GetTripRefineSessionSummary` (summary columns only —
+  the transcript can run to hundreds of KB and must not ride every trip load),
+  `DeleteTripRefineSession`.
+- **`chat_session_handler.go`**: extract `planTranscriptFields` (image-byte
+  stripping, title, preview) — one derivation, two savers.
+- **New `trip_refine_handler.go`**: `saveTripRefineSession` (best-effort +
+  logged, like its sibling), `getTripRefineChatHandler`,
+  `deleteTripRefineChatHandler`, and the response types. Both handlers resolve
+  access with `editableTrip`, so a revoked collaborator gets the same 404 as a
+  stranger with no extra check. Routes registered in `main.go` with startup log
+  lines.
+- **`plan_handler.go`**: the persistence gate splits into `persistPlan`
+  (unbound, needs `chat_id`) and `persistRefine` (bound, needs no chat id at
+  all — the client's per-session one is meaningless here) resolving a single
+  `saveTurn` closure. The existing two-write block — `startSaved` ordering, the
+  5 s background contexts, the pre-compaction snapshot rule — is reused
+  verbatim. One implementation, two destinations.
+- **`trip_handler.go`**: `TripResponse.RefineChat` (`json:"refine_chat"`),
+  filled by one more `g.Go` in `getTripHandler`'s existing errgroup, gated on
+  `Access != "viewer"`, assigned outside the branch that nils `ChatID` so the
+  two visibly never travel together. Named `refine_chat`, not `last_chat`:
+  "last" implies a series, which implies a picker this design does not have.
+- **`plan_tools_extra.go`**: `runGetTripTool` with no `trip_id` in a bound
+  session returns *that* trip instead of listing. Today it lists
+  `ListLatestTripsByOwner(uid)`, which for a collaborator is their own other
+  trips and never the trip being refined — a live bug. Tool description updated
+  to match (one deliberate prompt-cache re-warm).
+
+## Flutter Changes
+
+`src/packages/flutter-app/lib/`
+
+- **Models**: `models/trip_refine_chat.dart` (summary + detail; the detail
+  reuses `ChatSessionMessage` — same wire shape, consume the first
+  implementation) and `Trip.refineChat`. `make flutter-build-models`.
+- **Service**: `getTripRefineChat` / `deleteTripRefineChat` in
+  `services/trips_api_service.dart`, throwing `ApiException` **with the status
+  code** so "gone" is decidable from "failed".
+- **Provider**: `providers/plan_resume.dart` grows `planMessagesFrom` (extracted
+  from `resumePlanChat`) and `resumeTripRefineChat`, so both resume paths share
+  one mapping by construction. `resumeConversation`'s `chatId` becomes optional.
+- **Notifier**: `beginSectionRefinement` → `appendSectionRefinement` (no
+  `reset()`, stubs earlier seeds) and `startOver`.
+- **Screen**: `PopScope` + Escape; the `trip_updated` listener moves from the
+  panel to the screen (a patch landing after back closed the panel must still
+  refresh the trip — a bug the back fix would otherwise introduce); a
+  `_ensureRefineHydrated` gate every entry funnel awaits and **aborts on**; a
+  Continue-chat row below the Next Step card; the FAB's `items.isNotEmpty` gate
+  widened so a zero-item trip's chat is reachable.
+- **Panel**: nullable target, a New-chat action with a confirm, and the
+  restoring / expired / failed states.
+
+## Contract Parity
+
+| JSON key | Go type | Dart type | Nullable? | ✓ |
+|---|---|---|---|---|
+| `refine_chat` | `*TripRefineChatSummary` | `TripRefineChat?` | yes | ☐ |
+| `refine_chat.message_count` | `int` | `int` | no | ☐ |
+| `refine_chat.preview` | `string` | `String` | no | ☐ |
+| `refine_chat.updated_at` | `time.Time` | `String` | no | ☐ |
+| `trip_id` (detail) | `string` | `String` | no | ☐ |
+| `summary` (detail) | `string` | `String` | no | ☐ |
+| `messages` (detail) | `[]PlanChatMessage` | `List<ChatSessionMessage>` | no | ☐ |
+| `message_count` (detail) | `int` | `int` | no | ☐ |
+| `updated_at` (detail) | `time.Time` | `String` | no | ☐ |
+
+## Decision records (divergences, per `docs/zen.md`)
+
+- **`DELETE …/refine-chat` returns 200 when nothing existed**, unlike
+  `DELETE /chats/{chatId}`'s 404. Clearing state the caller cannot observe
+  beforehand must be idempotent — "New chat" tapped on a conversation that
+  never completed a turn is not an error. Pinned by
+  `TestDeleteTripRefineChatIsIdempotent`.
+- **Two transcript tables.** Justified above; the parity contract is
+  `TestTranscriptFieldsParity` (Go) and the shared `planMessagesFrom` (Dart).
+- **No URL for the open panel.** Trip detail is a pushed route, so URL sync
+  reads the route name and cannot see panel state; reflecting a *pane* would
+  need a new seam plus a third `BootTarget` axis. With the chat persisted and a
+  visible row, a refresh costs one tap on a card that proves the transcript
+  survived. Pinned by a test so it cannot drift in by accident.
+
+## Cross-cutting
+
+- No new env vars, no gateway changes (new paths are under `/api/v1/`).
+- New l10n keys in `app_en.arb` **and** `app_es.arb`; regenerate
+  `app_localizations*.dart` LAST if this lane rebases.
+- Specs amended: `continue-where-you-left-off`, `collaborator-refine`,
+  `refine-panel-polish`, `url-page-persistence`, `conversation-compaction`.
+
+## Verification
+
+See `tasks.md`.

--- a/specs/trip-refine-memory/spec.md
+++ b/specs/trip-refine-memory/spec.md
@@ -1,0 +1,147 @@
+# Spec: Trip Refine Memory
+
+## Context
+
+The trip-detail refine panel is where a traveler edits a saved trip by talking
+to the assistant — and today that conversation is the most fragile thing on the
+page. It lives only in memory, so a refresh or a deploy loses it. Five of the
+six ways to open the panel silently wipe it before you can say anything. And
+because the panel is drawn inside the screen rather than pushed as its own
+route, pressing back — the obvious gesture for something that looks like a
+sheet — throws away the whole page, chat included. Dogfooding on 2026-08-15:
+*"I've accidentally clicked the back button and had to restart a chat several
+times."* The outcome: a trip has **one running conversation** that is saved for
+as long as the trip exists, is visible on the trip page, survives a refresh,
+and is discarded only when the traveler explicitly asks for a new one.
+
+## User Stories
+
+- As a **traveler editing a trip**, I want back to close the chat rather than
+  the page, so that a misfired gesture costs me nothing.
+- As a **traveler**, I want to come back tomorrow and pick up the same
+  conversation about my trip, so that I don't re-explain what I already said.
+- As a **traveler**, I want to switch the chat's focus from one day to another
+  without losing what we already discussed, so that the conversation reads as
+  one thread.
+- As a **traveler**, I want to see on the trip page that a conversation is
+  waiting, so that I don't have to remember which button is the safe one.
+- As a **traveler**, I want a deliberate way to start fresh, so that "one
+  conversation" never becomes a conversation I can't escape.
+- As a **co-planner**, I want my own conversation about a shared trip, so that
+  the owner and I never read or overwrite each other's chats.
+
+## Acceptance Criteria
+
+- [ ] With the chat panel open, back (system, browser, or the app-bar chevron)
+      closes the panel and leaves the trip on screen; a second back leaves the
+      trip. Escape does the same on desktop.
+- [ ] Closing the panel — by back or by ✕ — never cancels a turn in flight, and
+      an itinerary change that lands after the panel closed still refreshes the
+      trip.
+- [ ] While a turn streams with the panel closed, the chat button shows the
+      turn is still running.
+- [ ] Tapping ✨ on a day, a city, or the whole trip adds a new context marker
+      to the existing conversation; nothing already said is removed.
+- [ ] After a full page reload, the trip page shows that a conversation exists
+      (with its last reply and how long ago), and opening it restores the
+      transcript — context markers intact, images as placeholders.
+- [ ] The chat is reachable the same way on a trip that has no places yet.
+- [ ] "New chat" asks first, then clears the conversation; the trip is
+      unaffected and the page stops advertising a saved chat.
+- [ ] A trip's conversation never appears in "Continue where you left off", and
+      the Plan tab can never be made to open it.
+- [ ] The assistant re-reads the trip before applying a change, so resuming an
+      older conversation cannot revert edits made since.
+- [ ] Deleting a trip deletes its conversations.
+- [ ] The owner and each editor co-planner have separate conversations about
+      the same trip; neither can see the other's. A revoked collaborator loses
+      access to theirs without it being destroyed.
+- [ ] Offline, the trip page offers no chat entry it cannot honor.
+
+## API Surface
+
+### `GET /api/v1/trips/{id}/refine-chat`
+- **Purpose:** the caller's saved conversation about this trip, in full.
+- **Request:** authenticated; the caller must be allowed to edit the trip.
+- **Response:** the trip it belongs to, the running compaction summary, the
+  message list (roles, text, context labels, image placeholders), how many
+  messages, and when it was last touched.
+- **Errors:** 404 when the caller has no conversation about this trip, when the
+  trip does not exist, or when the caller may not edit it — the three are
+  deliberately indistinguishable. 401/503 as elsewhere.
+
+### `DELETE /api/v1/trips/{id}/refine-chat`
+- **Purpose:** discard the conversation ("New chat").
+- **Request:** authenticated; caller must be allowed to edit the trip.
+- **Response:** 200 stating the post-state the caller will observe — the trip,
+  and no conversation. **Idempotent:** succeeds whether or not one existed,
+  because the caller cannot know beforehand and clearing nothing is not an
+  error.
+- **Errors:** 404 only when the trip is unreachable to this caller.
+
+### `GET /api/v1/trips/{id}` (changed)
+Full trip responses gain an optional **refine chat** object: how many messages,
+the last assistant reply as a preview, and when it was last touched — presence
+and freshness only, never the transcript, and deliberately carrying no
+identifier. It is per-caller: an owner and each co-planner see only their own,
+and it is absent when they have none. It is **not** the trip's existing
+conversation key, which identifies the owner's itinerary version lineage and is
+withheld from collaborators.
+
+### `POST /api/v1/plan` (behavior change, no wire change)
+A turn bound to a trip is now saved. Free planning chats are unchanged.
+
+## Data Model
+
+- **Trip refine session** — one traveler's conversation about one trip. Its
+  identity is the pair (traveler, trip): there is at most one, which is what
+  makes "the trip's chat" a fact rather than a convention. It holds the
+  transcript, the running compaction summary, a preview of the last reply, a
+  message count, and timestamps. It deliberately has **no conversation id** —
+  nothing outside the trip can name it, so it can never be opened as a free
+  planning chat, which would silently drop the trip binding. It has no title:
+  the trip's title names it. It lives as long as the trip and is deleted with
+  it; unlike free planning chats it is never pruned on age, because a trip
+  planned in August for next March must still have its chat in November.
+
+## UI Behavior
+
+- **Surface:** trip detail. The panel is docked beside the itinerary on wide
+  layouts and a drag sheet on narrow ones, unchanged.
+- **Happy path:** the trip page shows a "Continue chat" row when a conversation
+  exists → tap it (or the chat button) → the transcript is restored → ask for a
+  change → the itinerary updates behind the panel → press back → the panel
+  closes and the trip is still there.
+- **States:** *restoring* — the panel opens immediately showing that it is
+  restoring, with no composer, so nothing can be sent before the history is
+  back. *expired* — the conversation is gone; say so and offer a new chat, not
+  a retry. *failed* — say so, offer retry and a new chat. *none* — the ordinary
+  fresh chat, exactly as today.
+- The panel's title follows the newest context marker in the conversation, so
+  it is a function of what was said rather than of screen state that a gesture
+  can destroy.
+
+## Edge Cases & Error States
+
+- **Restore fails and the traveler types anyway** — impossible by construction:
+  the composer does not exist until the transcript is in. Sending onto an empty
+  panel would overwrite the stored conversation with two messages.
+- **Trip deleted mid-conversation** — the turn finishes; the save is dropped.
+- **No database (degraded mode)** — the chat works and simply isn't remembered.
+- **Two devices** — last writer wins, as for free planning chats.
+- **A new itinerary version** — a conversation belongs to the version it was
+  about; a brand-new version starts a fresh one.
+- **A very long conversation** — existing compaction applies unchanged; the
+  superseded itinerary listings inside old context markers are collapsed as
+  each new one is added, so only one authoritative listing is ever in play.
+
+## Out of Scope
+
+- A per-trip chat history or picker — there is one running conversation.
+- Giving the open panel its own URL, so that a refresh reopens it.
+- Any client-side mirror of the transcript for offline use.
+- Reviving the unused "reopen this trip in the Plan tab" path.
+
+## Open Questions
+
+None.

--- a/specs/trip-refine-memory/tasks.md
+++ b/specs/trip-refine-memory/tasks.md
@@ -1,0 +1,73 @@
+# Tasks: Trip Refine Memory
+
+## Stage 1 — Back stops destroying things (client only)
+
+- [ ] `PopScope(canPop: !_panelOpen)` around trip detail's root builder.
+- [ ] Escape closes the panel.
+- [ ] Move the `trip_updated` → `_refresh` listener from `TripRefinePanel` into
+      the screen; drop `onTripUpdated`.
+- [ ] Delete `_refineTarget`; panel title derives from the newest labeled
+      message.
+- [ ] FAB shows a spinner while a turn streams with the panel closed.
+
+## Stage 2 — One conversation (client only)
+
+- [ ] `appendSectionRefinement` replaces `beginSectionRefinement`; earlier seeds
+      stubbed in place (never removed).
+- [ ] All five ✨ call sites repointed.
+- [ ] "New chat" in the panel header, with a confirm.
+
+## Stage 3 — Persistence
+
+- [ ] `migrations/00069_trip_refine_sessions.sql`.
+- [ ] Four queries in `query/chat_sessions.sql`; `make api-sqlc`.
+- [ ] `planTranscriptFields` extracted in `chat_session_handler.go`.
+- [ ] `trip_refine_handler.go` + routes + startup log lines.
+- [ ] `plan_handler.go` persistence gate split.
+- [ ] `TripResponse.RefineChat` in `getTripHandler`'s errgroup.
+- [ ] `trip_refine_sessions` added to `resetDB`'s TRUNCATE list.
+- [ ] Dart models + `make flutter-build-models`; service methods throwing
+      `ApiException` with the status.
+- [ ] `planMessagesFrom` + `resumeTripRefineChat`; `resumeConversation.chatId`
+      optional.
+- [ ] `_ensureRefineHydrated` gate (aborts the send on failure), Continue-chat
+      row, FAB gate widened, offline hides both.
+- [ ] Restoring / expired / failed panel states.
+
+## Stage 4 — Freshness
+
+- [ ] `runGetTripTool` returns the bound trip when `trip_id` is omitted;
+      description updated.
+- [ ] Bound system-prompt suffix rewritten to require `get_trip` before an edit.
+
+## Tests
+
+- [ ] Go: `trip_refine_chat_integration_test.go` (persistence, one-row append,
+      unaddressable-as-plan-chat, `refine_chat` on the trip, GET/DELETE/access,
+      idempotent DELETE, per-user rows, cascade, revoked collaborator,
+      reengagement unaffected).
+- [ ] Go: `TestTranscriptFieldsParity`, `TestBoundPromptSteersToGetTrip`,
+      `TestGetTripToolReturnsBoundTripWithoutArgs`.
+- [ ] Go: amend `TestPlanTurnNotPersistedWhenAnonymousOrBound`.
+- [ ] Flutter: `trip_detail_chat_back_test.dart`,
+      `trip_detail_resume_chat_test.dart`,
+      `trip_detail_refine_append_test.dart`,
+      `plan_provider_refine_append_test.dart`, plus the URL pin in
+      `url_plan_chat_test.dart`.
+- [ ] Mutation-check: back-closes-panel, append-not-reset, hydrate-before-send.
+
+## Spec amendments
+
+- [ ] `continue-where-you-left-off`, `collaborator-refine`,
+      `refine-panel-polish`, `url-page-persistence`, `conversation-compaction`.
+
+## Verification
+
+- [ ] `make api-fmt && make api-vet && make api-sqlc`; `go test ./...` with
+      `TEST_DATABASE_URL`; goose up/down of 00069 round-trips.
+- [ ] `make flutter-build-models && make flutter-analyze` (CI runs
+      `--no-fatal-infos --fatal-warnings`) and `make flutter-test`.
+- [ ] Manual through the lane gateway: back closes the panel; ✨ appends; a hard
+      refresh leaves the Continue-chat row; restore shows the transcript; an
+      edit calls `get_trip` first; New chat clears; `GET /chats` never lists it.
+- [ ] `docs/friction-log.md` entry.

--- a/specs/url-page-persistence/spec.md
+++ b/specs/url-page-persistence/spec.md
@@ -34,8 +34,8 @@ land on Home) start working.
       refreshing there reopens that screen inside the shell.
 - [ ] Once a plan conversation exists, the Plan tab's URL becomes
       `/plan/<chatId>`; refreshing there restores the conversation transcript.
-      If the conversation can't be restored (expired, trip-bound, someone
-      else's), the Plan tab opens fresh — no error dialog.
+      If the conversation can't be restored (expired, someone else's, or not a
+      freeform plan chat at all), the Plan tab opens fresh — no error dialog.
 - [ ] Going back (browser back button) and popping in-app screens keeps the URL
       in sync with what's on screen.
 - [ ] Signing out resets the URL to `/`.
@@ -73,7 +73,10 @@ None. No new persistence; the URL itself is the state.
 - A Google/Apple sign-in redirect leaves the page, so a deep-link target does
   not survive SSO — the user lands on Home. Known limitation.
 - Restoring `/plan/<chatId>` for a conversation with no stored transcript
-  (trip-bound, anonymous, graduated, or foreign) opens a fresh Plan tab.
+  (anonymous, graduated, or foreign) opens a fresh Plan tab. A trip's own
+  conversation has no chat id at all (specs/trip-refine-memory), so this URL
+  can never name one — and the open refine panel is deliberately not a
+  location either.
 - Screens that can't be reconstructed from a URL (full-screen trip map, guide
   detail, flight search with prefill) keep the URL of the page beneath them;
   refresh lands on that page.

--- a/src/packages/api/chat_session_handler.go
+++ b/src/packages/api/chat_session_handler.go
@@ -52,13 +52,17 @@ func truncateRunes(s string, max int) string {
 	return string(r)
 }
 
-// savePlanChatSession upserts the whole transcript for one plan conversation.
-// Best-effort by design: a failure is logged and the turn proceeds — session
-// persistence must never break the chat itself.
-func savePlanChatSession(ctx context.Context, uid uuid.UUID, chatID, summary string, msgs []PlanChatMessage) {
-	if dbPool == nil || len(msgs) == 0 {
-		return
-	}
+// planTranscriptFields derives the storable form of one conversation: the
+// JSONB payload with image bytes stripped to media-type markers, the title
+// (first user message, preferring its display label), and the preview (last
+// assistant message).
+//
+// The ONE derivation, consumed by savePlanChatSession here and by
+// saveTripRefineSession (trip_refine_handler.go), so the two transcript tables
+// can never disagree about what a stored conversation looks like — pinned by
+// TestTranscriptFieldsParity. The refine saver has no title column and ignores
+// that return.
+func planTranscriptFields(msgs []PlanChatMessage) (payload []byte, title, preview string, err error) {
 	// Persist images as markers only: the transcript is upserted wholesale
 	// twice per turn, so inlined base64 would rewrite megabytes to the JSONB
 	// column every message. MediaType survives so a resumed client can render
@@ -75,16 +79,15 @@ func savePlanChatSession(ctx context.Context, uid uuid.UUID, chatID, summary str
 		}
 		persistable[i].Images = stripped
 	}
-	payload, err := json.Marshal(persistable)
+	payload, err = json.Marshal(persistable)
 	if err != nil {
-		log.Printf("failed to marshal chat session %s: %v", chatID, err)
-		return
+		return nil, "", "", err
 	}
-	var title, preview string
 	for _, m := range msgs {
 		if m.Role == "user" {
-			// Machine-built seed messages (near-me coordinates) carry a
-			// human-friendly display label — title from that, never the raw text.
+			// Machine-built seed messages (near-me coordinates, refine section
+			// seeds) carry a human-friendly display label — title from that,
+			// never the raw text.
 			src := m.Content
 			if strings.TrimSpace(m.DisplayLabel) != "" {
 				src = m.DisplayLabel
@@ -98,6 +101,21 @@ func savePlanChatSession(ctx context.Context, uid uuid.UUID, chatID, summary str
 			preview = truncateRunes(msgs[i].Content, chatPreviewMaxRunes)
 			break
 		}
+	}
+	return payload, title, preview, nil
+}
+
+// savePlanChatSession upserts the whole transcript for one plan conversation.
+// Best-effort by design: a failure is logged and the turn proceeds — session
+// persistence must never break the chat itself.
+func savePlanChatSession(ctx context.Context, uid uuid.UUID, chatID, summary string, msgs []PlanChatMessage) {
+	if dbPool == nil || len(msgs) == 0 {
+		return
+	}
+	payload, title, preview, err := planTranscriptFields(msgs)
+	if err != nil {
+		log.Printf("failed to marshal chat session %s: %v", chatID, err)
+		return
 	}
 	err = store.New(dbPool).UpsertPlanChatSession(ctx, store.UpsertPlanChatSessionParams{
 		UserID:       uid,

--- a/src/packages/api/chat_session_integration_test.go
+++ b/src/packages/api/chat_session_integration_test.go
@@ -85,9 +85,12 @@ func TestPlanTurnPersistsChatSession(t *testing.T) {
 	}
 }
 
-// (b) No persistence for anonymous turns, turns without a chat_id, or
-// trip-bound refine turns.
-func TestPlanTurnNotPersistedWhenAnonymousOrBound(t *testing.T) {
+// (b) No plan_chat_sessions row for anonymous turns or turns without a
+// chat_id. A trip-bound turn writes no row HERE either, but for a different
+// reason since specs/trip-refine-memory: it is stored in trip_refine_sessions,
+// keyed by (user, trip) and carrying no chat id at all — asserted below and,
+// in full, by trip_refine_chat_integration_test.go.
+func TestPlanTurnNotPersistedWhenAnonymousOrChatless(t *testing.T) {
 	resetDB(t)
 	user, token := createTestUser(t, "ephemeral@example.com")
 	trip := createTestTrip(t, user.ID, 1)
@@ -118,7 +121,13 @@ func TestPlanTurnNotPersistedWhenAnonymousOrBound(t *testing.T) {
 		t.Fatalf("count query: %v", err)
 	}
 	if rows != 0 {
-		t.Fatalf("session rows = %d, want 0 (anonymous, no chat_id, trip-bound)", rows)
+		t.Fatalf("plan_chat_sessions rows = %d, want 0 (anonymous, no chat_id, and the bound turn belongs in trip_refine_sessions)", rows)
+	}
+
+	// The bound turn's throwaway chat id must not be an address for anything:
+	// resuming it into the unbound Agent tab would drop the trip binding.
+	if rec := doJSON(t, "GET", "/api/v1/chats/chat-bound", token, nil); rec.Code != http.StatusNotFound {
+		t.Fatalf("GET /chats/chat-bound = %d, want 404 (a refine transcript has no chat id)", rec.Code)
 	}
 }
 

--- a/src/packages/api/integration_test.go
+++ b/src/packages/api/integration_test.go
@@ -70,7 +70,7 @@ func resetDB(t *testing.T) {
 			notifications, reminder_sends,
 			local_sources, local_recommendations, local_guides,
 			local_guide_recommendations, local_source_material,
-			plan_chat_sessions, oauth_clients, oauth_auth_codes,
+			plan_chat_sessions, trip_refine_sessions, oauth_clients, oauth_auth_codes,
 			oauth_grants, oauth_tokens, health_samples CASCADE`)
 		if err == nil {
 			return

--- a/src/packages/api/main.go
+++ b/src/packages/api/main.go
@@ -846,6 +846,12 @@ func buildRouter() *mux.Router {
 	api.Handle("/trips/{id}", authMiddleware(http.HandlerFunc(deleteTripHandler))).Methods("DELETE")
 	api.Handle("/trips/{id}/status", authMiddleware(http.HandlerFunc(tripStatusHandler))).Methods("GET")
 	api.Handle("/trips/{id}/refine", strict(authMiddleware(http.HandlerFunc(refineTripHandler)))).Methods("POST")
+	// The trip's own saved chat (specs/trip-refine-memory) — distinct from the
+	// legacy POST /trips/{id}/refine above, which hands back the OWNER's
+	// itinerary version-lineage chat id. This one is addressed by trip alone
+	// and is per-caller.
+	api.Handle("/trips/{id}/refine-chat", authMiddleware(http.HandlerFunc(getTripRefineChatHandler))).Methods("GET")
+	api.Handle("/trips/{id}/refine-chat", authMiddleware(http.HandlerFunc(deleteTripRefineChatHandler))).Methods("DELETE")
 	api.Handle("/trips/{id}/share", authMiddleware(http.HandlerFunc(createShareHandler))).Methods("POST")
 	api.Handle("/trips/{id}/share", authMiddleware(http.HandlerFunc(revokeShareHandler))).Methods("DELETE")
 	// Owner-private export: the authed owner/editor mints a short-lived signed
@@ -1032,6 +1038,7 @@ func startServer(router *mux.Router) {
 	log.Printf("  GET  /api/v1/trips              - List trips (auth)")
 	log.Printf("  GET  /api/v1/chats              - Resumable plan conversations (auth)")
 	log.Printf("  GET/DELETE /api/v1/chats/{chatId} - Resume / dismiss a conversation (auth)")
+	log.Printf("  GET/DELETE /api/v1/trips/{id}/refine-chat - Resume / clear a trip's own chat (auth)")
 	log.Printf("  GET/PATCH/DELETE /api/v1/trips/{id} - Trip detail (auth)")
 	log.Printf("  GET/PUT /api/v1/preferences      - Traveler preferences (auth)")
 	log.Printf("  GET  /api/v1/accommodation-links - Airbnb/Booking browse links")

--- a/src/packages/api/migrations/00069_trip_refine_sessions.sql
+++ b/src/packages/api/migrations/00069_trip_refine_sessions.sql
@@ -1,0 +1,63 @@
+-- +goose Up
+-- The traveler's saved conversation ABOUT ONE TRIP (specs/trip-refine-memory):
+-- the chat behind the trip-detail refine panel, so closing that panel — or
+-- hitting back, which used to pop the whole page — never loses it.
+--
+-- Its own table, not a nullable trip_id on plan_chat_sessions, for three
+-- reasons:
+--
+--   * Identity differs. A plan chat is identified by an opaque client-minted
+--     chat id, and its lifecycle question ("did it graduate into a trip?") is
+--     derived, racy, and rightly answered at read time — that is what 00031
+--     argued, and it still holds. "Which trip is this conversation about?" is
+--     the opposite kind of fact: validated request input (plan_handler.go
+--     resolves and authorizes req.trip_id before a byte streams) that is
+--     immutable for the row's life. Storing an identity is not the thing
+--     00031 argued against.
+--   * Addressability is a boundary, not a preference. A refine conversation
+--     has NO chat id — not here, not on the wire. GET /chats/{chatId} and
+--     /plan/<chatId> therefore CANNOT reach it, so a trip-bound transcript can
+--     never be resumed into the unbound Agent tab, where the trip binding
+--     would silently vanish and the agent would fall back to create_itinerary.
+--     Structural, rather than a filter someone can delete.
+--   * A nullable column would instead have required "AND trip_id IS NULL"
+--     remembered in five places: ListResumablePlanChatSessions,
+--     GetPlanChatSessionByChatID, DeleteStalePlanChatSessions, the weekly-nudge
+--     predicate in query/reengagement.sql, and the upsert's conflict target.
+--     docs/zen.md: promote the convention.
+--
+-- UNIQUE (user_id, trip_id) IS the product decision — one running conversation
+-- per trip — enforced by the database instead of maintained by the client. The
+-- owner and each editor co-planner keep their OWN conversation about the same
+-- trip, visible to no one else.
+--
+-- trip_id points at one trips ROW (one itinerary version), not at the chat_id
+-- lineage: a conversation belongs to the itinerary it was about, and a bound
+-- session cannot create a new version anyway (the tool registry swaps
+-- create_itinerary for update_itinerary_section).
+--
+-- No title column — the trip's own title names this conversation. No
+-- time-based prune either, unlike plan_chat_sessions' 60-day janitor rule:
+-- retention is the trip's lifetime, because a trip planned in August for next
+-- March must still have its chat in November. ON DELETE CASCADE is the whole
+-- GC story.
+CREATE TABLE trip_refine_sessions (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    trip_id UUID NOT NULL REFERENCES trips(id) ON DELETE CASCADE,
+    preview TEXT NOT NULL DEFAULT '',
+    summary TEXT NOT NULL DEFAULT '',
+    messages JSONB NOT NULL,
+    message_count INT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (user_id, trip_id)
+);
+
+-- Postgres does not index FK columns automatically and the unique index above
+-- is user-leading. DeleteTrip removes an entire version lineage in one
+-- statement; without this the cascade check seq-scans this table per row.
+CREATE INDEX trip_refine_sessions_trip_idx ON trip_refine_sessions (trip_id);
+
+-- +goose Down
+DROP TABLE trip_refine_sessions;

--- a/src/packages/api/plan_handler.go
+++ b/src/packages/api/plan_handler.go
@@ -358,11 +358,35 @@ func planHandler(w http.ResponseWriter, r *http.Request) {
 	// appends whatever assistant text streamed — the same text the client
 	// commits, on both its success and error paths. When compaction ran this
 	// turn, the compacted history + new summary are stored instead of the raw
-	// snapshot, matching the client's post-`compacted` wire state. Trip-bound
-	// sessions patch a saved trip in place — nothing to resume — and anonymous
-	// or degraded sessions stay ephemeral, like anonymous trips.
-	persistSession := authed && dbPool != nil &&
-		strings.TrimSpace(req.ChatID) != "" && boundTripID == nil
+	// snapshot, matching the client's post-`compacted` wire state. Anonymous and
+	// degraded sessions stay ephemeral, like anonymous trips.
+	//
+	// Every authenticated turn is resumable, but the two kinds land in different
+	// tables (specs/trip-refine-memory). A freeform plan chat is stored under its
+	// client-minted chat id. A trip-bound refine chat is stored under
+	// (user, trip) in trip_refine_sessions, where it has NO chat id at all — so
+	// it can never be reached by GET /chats/{chatId} or /plan/<chatId> and
+	// resumed into the unbound Agent tab, which would silently drop the trip
+	// binding. A bound turn therefore deliberately does NOT require req.ChatID:
+	// the client mints a throwaway one per panel session and the server has no
+	// use for it.
+	//
+	// saveTurn is nil when nothing is to be persisted; the block below is one
+	// ordering implementation with two destinations.
+	var saveTurn func(ctx context.Context, summary string, msgs []PlanChatMessage)
+	switch {
+	case authed && dbPool != nil && boundTripID != nil:
+		tid := *boundTripID
+		saveTurn = func(ctx context.Context, summary string, msgs []PlanChatMessage) {
+			saveTripRefineSession(ctx, uid, tid, summary, msgs)
+		}
+	case authed && dbPool != nil && strings.TrimSpace(req.ChatID) != "":
+		chatID := req.ChatID
+		saveTurn = func(ctx context.Context, summary string, msgs []PlanChatMessage) {
+			savePlanChatSession(ctx, uid, chatID, summary, msgs)
+		}
+	}
+	persistSession := saveTurn != nil
 	var turnText strings.Builder
 	// Set when an iteration ended in tool calls with text already streamed:
 	// the next text delta opens a new paragraph, in the streamed bytes and
@@ -398,7 +422,7 @@ func planHandler(w http.ResponseWriter, r *http.Request) {
 			defer close(startSaved)
 			sctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
-			savePlanChatSession(sctx, uid, req.ChatID, persistSummary, persistMsgs)
+			saveTurn(sctx, persistSummary, persistMsgs)
 		})
 		defer func() {
 			msgs := persistMsgs
@@ -410,7 +434,7 @@ func planHandler(w http.ResponseWriter, r *http.Request) {
 			// The request context is gone once the handler returns.
 			dctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
-			savePlanChatSession(dctx, uid, req.ChatID, persistSummary, msgs)
+			saveTurn(dctx, persistSummary, msgs)
 		}()
 	}
 
@@ -468,7 +492,7 @@ func planHandler(w http.ResponseWriter, r *http.Request) {
 		systemPrompt += profileNotesInstruction
 	}
 	if boundTripID != nil {
-		systemPrompt += "\n\nYou are refining an existing saved trip in place. The conversation's first message describes the current itinerary and which section the traveler wants to change. Apply changes by calling update_itinerary_section with the targeted scope and the COMPLETE updated list of places for that section — include unchanged places with their existing coordinates, city, day, time_of_day and category tags so they aren't lost. Use search_places to find real coordinates for any new place before adding it. Only change the section the traveler asked about unless they broaden the request. A reorder that moves places BETWEEN cities or days — swapping two cities, shifting a stop from one city to another — is a whole-trip change: call update_itinerary_section with scope 'trip' and the complete itinerary in the new order, never scope 'city' or 'day' with another section's places mixed in. A section rewrite replaces its section in place and cannot move places across sections, so mixing them in would duplicate those places rather than move them, and the call will be rejected. The traveler may also ask questions about the trip without wanting changes — answer those directly from the itinerary and your search tools; only call update_itinerary_section when they explicitly ask for a modification. If the traveler changes WHEN the trip happens — 'shift everything a week later', 'we actually start June 12' — call set_trip_dates with the new start date (and end date if the length changes): it moves the trip and every dated stay, transport leg, and booking to-do together. If only ONE city's dates change, call set_leg_dates for that city instead — it moves that leg, extends the previous city's end to meet a later start (and says so), and reports any remaining gap or overlap with the neighboring cities, all of which you should relay and offer to fix. If the result says a later city was squeezed to no nights or overlapped, offer to shift the remaining cities and, when the traveler agrees, call set_leg_dates for each in order (earliest first) in that same turn. A change to when the FIRST city begins is a change to the trip's start — use set_trip_dates. Never rebuild sections with update_itinerary_section just to change dates — its day numbers are positional (a city's LAST item day is its departure day, and the page derives each leg from the previous city's departure through its own last day), so recomputing day numbers will not produce the calendar dates you intend and can undo earlier date moves. To change WHEN anything happens, use set_trip_dates or set_leg_dates with calendar dates, and always verify the 'page now renders' ranges a tool result reports against what the traveler asked for before replying."
+		systemPrompt += "\n\nYou are refining an existing saved trip in place. This conversation is saved and may be resumed days later, so its earlier messages describe the itinerary AS IT WAS, not as it is — the traveler or a co-planner may have changed the trip since, and an earlier message may have been superseded by a later one in this same conversation. Before you apply ANY change with update_itinerary_section, call get_trip (with no arguments — in this conversation it returns THIS trip) and build the complete list of places from THAT result, never from an earlier message. Earlier messages still tell you which section the traveler is working on. Apply changes by calling update_itinerary_section with the targeted scope and the COMPLETE updated list of places for that section — include unchanged places with their existing coordinates, city, day, time_of_day and category tags so they aren't lost. Use search_places to find real coordinates for any new place before adding it. Only change the section the traveler asked about unless they broaden the request. A reorder that moves places BETWEEN cities or days — swapping two cities, shifting a stop from one city to another — is a whole-trip change: call update_itinerary_section with scope 'trip' and the complete itinerary in the new order, never scope 'city' or 'day' with another section's places mixed in. A section rewrite replaces its section in place and cannot move places across sections, so mixing them in would duplicate those places rather than move them, and the call will be rejected. The traveler may also ask questions about the trip without wanting changes — answer those directly from the itinerary and your search tools; only call update_itinerary_section when they explicitly ask for a modification. If the traveler changes WHEN the trip happens — 'shift everything a week later', 'we actually start June 12' — call set_trip_dates with the new start date (and end date if the length changes): it moves the trip and every dated stay, transport leg, and booking to-do together. If only ONE city's dates change, call set_leg_dates for that city instead — it moves that leg, extends the previous city's end to meet a later start (and says so), and reports any remaining gap or overlap with the neighboring cities, all of which you should relay and offer to fix. If the result says a later city was squeezed to no nights or overlapped, offer to shift the remaining cities and, when the traveler agrees, call set_leg_dates for each in order (earliest first) in that same turn. A change to when the FIRST city begins is a change to the trip's start — use set_trip_dates. Never rebuild sections with update_itinerary_section just to change dates — its day numbers are positional (a city's LAST item day is its departure day, and the page derives each leg from the previous city's departure through its own last day), so recomputing day numbers will not produce the calendar dates you intend and can undo earlier date moves. To change WHEN anything happens, use set_trip_dates or set_leg_dates with calendar dates, and always verify the 'page now renders' ranges a tool result reports against what the traveler asked for before replying."
 		if boundTripTravelMode != nil && *boundTripTravelMode != "" {
 			systemPrompt += "\n\nThis trip's travel mode is " + *boundTripTravelMode + "; keep new transport suggestions in that mode."
 		}

--- a/src/packages/api/plan_tools_extra.go
+++ b/src/packages/api/plan_tools_extra.go
@@ -43,12 +43,12 @@ var getWeatherTool = anthropic.ToolParam{
 
 var getTripTool = anthropic.ToolParam{
 	Name:        "get_trip",
-	Description: anthropic.String("Read the traveler's saved trips. Without trip_id: list their trips (id, title, dates, cities). With trip_id: the full itinerary of that trip. Use it when they reference an existing trip ('my Lisbon trip', 'the trip we planned last week') so you can build on what's already saved instead of asking again."),
+	Description: anthropic.String("Read the traveler's saved trips, as they are right now. Without trip_id: in a trip refinement conversation, the full current itinerary of the trip being refined; otherwise a list of their trips (id, title, dates, cities). With trip_id: the full itinerary of that trip. Use it when they reference an existing trip ('my Lisbon trip', 'the trip we planned last week') so you can build on what's already saved instead of asking again, and to re-read a trip you are refining before you change it."),
 	InputSchema: anthropic.ToolInputSchemaParam{
 		Properties: map[string]any{
 			"trip_id": map[string]any{
 				"type":        "string",
-				"description": "A trip id from a previous get_trip listing; omit to list all trips",
+				"description": "A trip id from a previous get_trip listing; omit for the trip being refined, or to list all trips",
 			},
 		},
 	},
@@ -691,6 +691,15 @@ func runGetTripTool(ctx context.Context, authed bool, uid uuid.UUID, boundTripID
 	}
 	json.Unmarshal(input, &in)
 	q := store.New(dbPool)
+
+	// In a refinement conversation "the trip" is unambiguous, so answer with it
+	// rather than a list the model then has to index into
+	// (specs/trip-refine-memory). This also fixes the collaborator case: the
+	// listing below is strictly caller-OWNED, so for a co-planner it was their
+	// own other trips and never the trip being refined.
+	if strings.TrimSpace(in.TripID) == "" && boundTripID != nil {
+		in.TripID = boundTripID.String()
+	}
 
 	if strings.TrimSpace(in.TripID) == "" {
 		trips, err := q.ListLatestTripsByOwner(ctx, uid)

--- a/src/packages/api/query/chat_sessions.sql
+++ b/src/packages/api/query/chat_sessions.sql
@@ -36,6 +36,41 @@ WHERE user_id = $1 AND chat_id = $2;
 
 -- name: DeleteStalePlanChatSessions :exec
 -- Opportunistic prune (called from the list handler): a conversation idle for
--- two months is abandoned, not "in progress".
+-- two months is abandoned, not "in progress". Deliberately does NOT reach
+-- trip_refine_sessions: a trip planned in August for next March must still
+-- have its chat in November, so those are retained for the trip's lifetime and
+-- collected by the FK cascade instead (specs/trip-refine-memory).
 DELETE FROM plan_chat_sessions
 WHERE updated_at < now() - interval '60 days';
+
+-- name: UpsertTripRefineSession :exec
+-- Whole-transcript upsert, twice per trip-bound /plan turn (start + deferred
+-- end), under the same start→final ordering contract as
+-- UpsertPlanChatSession. Keyed by (user, trip): the client's per-panel chat_id
+-- is meaningless here and is deliberately not stored, which is what makes a
+-- refine transcript unaddressable by chat id (specs/trip-refine-memory).
+INSERT INTO trip_refine_sessions (
+    user_id, trip_id, preview, summary, messages, message_count
+) VALUES ($1, $2, $3, $4, $5, $6)
+ON CONFLICT (user_id, trip_id) DO UPDATE SET
+    preview = EXCLUDED.preview,
+    summary = EXCLUDED.summary,
+    messages = EXCLUDED.messages,
+    message_count = EXCLUDED.message_count,
+    updated_at = now();
+
+-- name: GetTripRefineSession :one
+SELECT * FROM trip_refine_sessions
+WHERE user_id = $1 AND trip_id = $2;
+
+-- name: GetTripRefineSessionSummary :one
+-- Presence + freshness for GET /trips/{id} (the refine_chat object). Summary
+-- columns only: the transcript can run to hundreds of KB and is fetched on
+-- demand from GET /trips/{id}/refine-chat, never on every trip page load —
+-- the same list/detail split as /chats.
+SELECT preview, message_count, updated_at FROM trip_refine_sessions
+WHERE user_id = $1 AND trip_id = $2;
+
+-- name: DeleteTripRefineSession :execrows
+DELETE FROM trip_refine_sessions
+WHERE user_id = $1 AND trip_id = $2;

--- a/src/packages/api/store/chat_sessions.sql.go
+++ b/src/packages/api/store/chat_sessions.sql.go
@@ -36,10 +36,31 @@ WHERE updated_at < now() - interval '60 days'
 `
 
 // Opportunistic prune (called from the list handler): a conversation idle for
-// two months is abandoned, not "in progress".
+// two months is abandoned, not "in progress". Deliberately does NOT reach
+// trip_refine_sessions: a trip planned in August for next March must still
+// have its chat in November, so those are retained for the trip's lifetime and
+// collected by the FK cascade instead (specs/trip-refine-memory).
 func (q *Queries) DeleteStalePlanChatSessions(ctx context.Context) error {
 	_, err := q.db.Exec(ctx, deleteStalePlanChatSessions)
 	return err
+}
+
+const deleteTripRefineSession = `-- name: DeleteTripRefineSession :execrows
+DELETE FROM trip_refine_sessions
+WHERE user_id = $1 AND trip_id = $2
+`
+
+type DeleteTripRefineSessionParams struct {
+	UserID uuid.UUID `json:"user_id"`
+	TripID uuid.UUID `json:"trip_id"`
+}
+
+func (q *Queries) DeleteTripRefineSession(ctx context.Context, arg DeleteTripRefineSessionParams) (int64, error) {
+	result, err := q.db.Exec(ctx, deleteTripRefineSession, arg.UserID, arg.TripID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
 }
 
 const getPlanChatSessionByChatID = `-- name: GetPlanChatSessionByChatID :one
@@ -67,6 +88,60 @@ func (q *Queries) GetPlanChatSessionByChatID(ctx context.Context, arg GetPlanCha
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)
+	return i, err
+}
+
+const getTripRefineSession = `-- name: GetTripRefineSession :one
+SELECT id, user_id, trip_id, preview, summary, messages, message_count, created_at, updated_at FROM trip_refine_sessions
+WHERE user_id = $1 AND trip_id = $2
+`
+
+type GetTripRefineSessionParams struct {
+	UserID uuid.UUID `json:"user_id"`
+	TripID uuid.UUID `json:"trip_id"`
+}
+
+func (q *Queries) GetTripRefineSession(ctx context.Context, arg GetTripRefineSessionParams) (TripRefineSession, error) {
+	row := q.db.QueryRow(ctx, getTripRefineSession, arg.UserID, arg.TripID)
+	var i TripRefineSession
+	err := row.Scan(
+		&i.ID,
+		&i.UserID,
+		&i.TripID,
+		&i.Preview,
+		&i.Summary,
+		&i.Messages,
+		&i.MessageCount,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
+}
+
+const getTripRefineSessionSummary = `-- name: GetTripRefineSessionSummary :one
+SELECT preview, message_count, updated_at FROM trip_refine_sessions
+WHERE user_id = $1 AND trip_id = $2
+`
+
+type GetTripRefineSessionSummaryParams struct {
+	UserID uuid.UUID `json:"user_id"`
+	TripID uuid.UUID `json:"trip_id"`
+}
+
+type GetTripRefineSessionSummaryRow struct {
+	Preview      string    `json:"preview"`
+	MessageCount int32     `json:"message_count"`
+	UpdatedAt    time.Time `json:"updated_at"`
+}
+
+// Presence + freshness for GET /trips/{id} (the refine_chat object). Summary
+// columns only: the transcript can run to hundreds of KB and is fetched on
+// demand from GET /trips/{id}/refine-chat, never on every trip page load —
+// the same list/detail split as /chats.
+func (q *Queries) GetTripRefineSessionSummary(ctx context.Context, arg GetTripRefineSessionSummaryParams) (GetTripRefineSessionSummaryRow, error) {
+	row := q.db.QueryRow(ctx, getTripRefineSessionSummary, arg.UserID, arg.TripID)
+	var i GetTripRefineSessionSummaryRow
+	err := row.Scan(&i.Preview, &i.MessageCount, &i.UpdatedAt)
 	return i, err
 }
 
@@ -153,6 +228,44 @@ func (q *Queries) UpsertPlanChatSession(ctx context.Context, arg UpsertPlanChatS
 		arg.UserID,
 		arg.ChatID,
 		arg.Title,
+		arg.Preview,
+		arg.Summary,
+		arg.Messages,
+		arg.MessageCount,
+	)
+	return err
+}
+
+const upsertTripRefineSession = `-- name: UpsertTripRefineSession :exec
+INSERT INTO trip_refine_sessions (
+    user_id, trip_id, preview, summary, messages, message_count
+) VALUES ($1, $2, $3, $4, $5, $6)
+ON CONFLICT (user_id, trip_id) DO UPDATE SET
+    preview = EXCLUDED.preview,
+    summary = EXCLUDED.summary,
+    messages = EXCLUDED.messages,
+    message_count = EXCLUDED.message_count,
+    updated_at = now()
+`
+
+type UpsertTripRefineSessionParams struct {
+	UserID       uuid.UUID `json:"user_id"`
+	TripID       uuid.UUID `json:"trip_id"`
+	Preview      string    `json:"preview"`
+	Summary      string    `json:"summary"`
+	Messages     []byte    `json:"messages"`
+	MessageCount int32     `json:"message_count"`
+}
+
+// Whole-transcript upsert, twice per trip-bound /plan turn (start + deferred
+// end), under the same start→final ordering contract as
+// UpsertPlanChatSession. Keyed by (user, trip): the client's per-panel chat_id
+// is meaningless here and is deliberately not stored, which is what makes a
+// refine transcript unaddressable by chat id (specs/trip-refine-memory).
+func (q *Queries) UpsertTripRefineSession(ctx context.Context, arg UpsertTripRefineSessionParams) error {
+	_, err := q.db.Exec(ctx, upsertTripRefineSession,
+		arg.UserID,
+		arg.TripID,
 		arg.Preview,
 		arg.Summary,
 		arg.Messages,

--- a/src/packages/api/store/models.go
+++ b/src/packages/api/store/models.go
@@ -376,6 +376,18 @@ type TripInvite struct {
 	CreatedAt  time.Time          `json:"created_at"`
 }
 
+type TripRefineSession struct {
+	ID           uuid.UUID `json:"id"`
+	UserID       uuid.UUID `json:"user_id"`
+	TripID       uuid.UUID `json:"trip_id"`
+	Preview      string    `json:"preview"`
+	Summary      string    `json:"summary"`
+	Messages     []byte    `json:"messages"`
+	MessageCount int32     `json:"message_count"`
+	CreatedAt    time.Time `json:"created_at"`
+	UpdatedAt    time.Time `json:"updated_at"`
+}
+
 type TripSegment struct {
 	ID          uuid.UUID   `json:"id"`
 	TripID      uuid.UUID   `json:"trip_id"`

--- a/src/packages/api/transcript_fields_test.go
+++ b/src/packages/api/transcript_fields_test.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// planTranscriptFields is the ONE derivation behind both transcript tables —
+// plan_chat_sessions (savePlanChatSession) and trip_refine_sessions
+// (saveTripRefineSession). docs/zen.md: a second implementation owes a parity
+// contract, so the two savers consume this instead of each rolling their own,
+// and this fixture pins what they both store.
+//
+// The DB-backed half of the contract — that a refine row and a plan-chat row
+// hold byte-identical payloads for the same transcript — lives in
+// TestTranscriptFieldsParityAcrossTables.
+
+func TestPlanTranscriptFieldsStripsImageBytes(t *testing.T) {
+	msgs := []PlanChatMessage{
+		{Role: "user", Content: "what is this?", Images: []PlanImage{
+			{MediaType: "image/png", Data: "AAAABBBBCCCC"},
+			{MediaType: "image/jpeg", Data: "DDDDEEEE"},
+		}},
+		{Role: "assistant", Content: "A funicular."},
+	}
+	payload, _, _, err := planTranscriptFields(msgs)
+	if err != nil {
+		t.Fatalf("planTranscriptFields: %v", err)
+	}
+	if strings.Contains(string(payload), "AAAABBBBCCCC") || strings.Contains(string(payload), "DDDDEEEE") {
+		t.Fatalf("base64 image bytes reached the JSONB payload: %s", payload)
+	}
+	var stored []PlanChatMessage
+	if err := json.Unmarshal(payload, &stored); err != nil {
+		t.Fatalf("payload unparseable: %v", err)
+	}
+	if len(stored[0].Images) != 2 {
+		t.Fatalf("stored %d image markers, want 2 — the placeholder must survive", len(stored[0].Images))
+	}
+	for i, img := range stored[0].Images {
+		if img.MediaType == "" || img.Data != "" {
+			t.Fatalf("marker %d = %+v, want a media type and no data", i, img)
+		}
+	}
+	// The caller's slice must not be mutated: plan_handler.go persists the same
+	// messages it is about to send to the model.
+	if msgs[0].Images[0].Data == "" {
+		t.Fatal("planTranscriptFields mutated the caller's messages")
+	}
+}
+
+func TestPlanTranscriptFieldsTitleAndPreview(t *testing.T) {
+	cases := []struct {
+		name        string
+		msgs        []PlanChatMessage
+		wantTitle   string
+		wantPreview string
+	}{
+		{
+			name: "title is the first user message, preview the last assistant one",
+			msgs: []PlanChatMessage{
+				{Role: "user", Content: "where should I go in May?"},
+				{Role: "assistant", Content: "Portugal."},
+				{Role: "user", Content: "and after?"},
+				{Role: "assistant", Content: "Galicia."},
+			},
+			wantTitle:   "where should I go in May?",
+			wantPreview: "Galicia.",
+		},
+		{
+			name: "a machine-built seed titles from its display label, never its raw text",
+			msgs: []PlanChatMessage{
+				{Role: "user", Content: "I want to refine my saved trip … 37.9,23.7 …",
+					DisplayLabel: "Refining Day 2 — Athens"},
+				{Role: "assistant", Content: "What would you like to change?"},
+			},
+			wantTitle:   "Refining Day 2 — Athens",
+			wantPreview: "What would you like to change?",
+		},
+		{
+			name:        "an unanswered opening turn has no preview",
+			msgs:        []PlanChatMessage{{Role: "user", Content: "hello"}},
+			wantTitle:   "hello",
+			wantPreview: "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, title, preview, err := planTranscriptFields(tc.msgs)
+			if err != nil {
+				t.Fatalf("planTranscriptFields: %v", err)
+			}
+			if title != tc.wantTitle {
+				t.Errorf("title = %q, want %q", title, tc.wantTitle)
+			}
+			if preview != tc.wantPreview {
+				t.Errorf("preview = %q, want %q", preview, tc.wantPreview)
+			}
+		})
+	}
+}

--- a/src/packages/api/trip_handler.go
+++ b/src/packages/api/trip_handler.go
@@ -48,14 +48,23 @@ var allowedItemCategories = map[string]bool{"attraction": true, "restaurant": tr
 var allowedTimesOfDay = map[string]bool{"morning": true, "afternoon": true, "evening": true}
 
 type TripResponse struct {
-	ID         string  `json:"id"`
-	Title      string  `json:"title"`
-	Summary    *string `json:"summary,omitempty"`
-	StartDate  *string `json:"start_date,omitempty"`
-	EndDate    *string `json:"end_date,omitempty"`
-	ChatID     *string `json:"chat_id,omitempty"`
-	TravelMode *string `json:"travel_mode,omitempty"`
-	Origin     *string `json:"origin,omitempty"`
+	ID        string  `json:"id"`
+	Title     string  `json:"title"`
+	Summary   *string `json:"summary,omitempty"`
+	StartDate *string `json:"start_date,omitempty"`
+	EndDate   *string `json:"end_date,omitempty"`
+	ChatID    *string `json:"chat_id,omitempty"`
+	// RefineChat is presence + freshness for the CALLER'S OWN saved
+	// conversation about THIS trip (specs/trip-refine-memory); the transcript
+	// comes from GET /trips/{id}/refine-chat. Per-caller: an owner and each
+	// co-planner see only their own, and it is absent when they have none.
+	//
+	// NOT ChatID above — that is the OWNER's itinerary version-lineage key, a
+	// string, withheld from collaborators entirely. This is an object with no
+	// id inside it. Full trip views only.
+	RefineChat *TripRefineChatSummary `json:"refine_chat,omitempty"`
+	TravelMode *string                `json:"travel_mode,omitempty"`
+	Origin     *string                `json:"origin,omitempty"`
 	// This trip's own flight endpoints (migration 00064). Written together or
 	// not at all: absent means the trip states no airport and the legs fall
 	// back to Origin, then to the owner's saved home airport — never "same as
@@ -900,6 +909,21 @@ func getTripHandler(w http.ResponseWriter, r *http.Request) {
 			return nil
 		})
 	}
+	// The caller's own saved conversation about this trip
+	// (specs/trip-refine-memory) — presence + freshness only, so the page can
+	// offer "Continue chat" without fetching a transcript nobody may open.
+	// Viewers are skipped: they cannot open the panel at all.
+	var refineChat *TripRefineChatSummary
+	if row.Access != "viewer" {
+		g.Go(func() error {
+			s, err := tripRefineChatSummary(ctx, q, user.ID, trip.ID)
+			if err != nil {
+				return errors.New("could not load the trip conversation")
+			}
+			refineChat = s
+			return nil
+		})
+	}
 	if err := g.Wait(); err != nil {
 		writeJSONError(w, http.StatusInternalServerError, err.Error())
 		return
@@ -921,6 +945,10 @@ func getTripHandler(w http.ResponseWriter, r *http.Request) {
 		resp.ChatID = nil
 		resp.OwnerName = ownerName
 	}
+	// Deliberately outside the block above: a collaborator loses the owner's
+	// ChatID and keeps their OWN RefineChat. The two must visibly never travel
+	// together (specs/trip-refine-memory).
+	resp.RefineChat = refineChat
 	// "Updated by X" attribution — omitted for the caller's own edits.
 	resp.UpdatedByName = updatedByName
 	resp.Shared = shared

--- a/src/packages/api/trip_refine_chat_integration_test.go
+++ b/src/packages/api/trip_refine_chat_integration_test.go
@@ -1,0 +1,490 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+// Trip refine conversations (specs/trip-refine-memory): the /plan persistence
+// hook for trip-bound turns, the /trips/{id}/refine-chat surface, and the
+// boundary that keeps a refine transcript out of the freeform /chats world.
+
+// refineRow reads one trip refine session straight from the table.
+func refineRow(t *testing.T, userID, tripID uuid.UUID) (msgs []PlanChatMessage, preview, summary string, count int, found bool) {
+	t.Helper()
+	var raw []byte
+	err := dbPool.QueryRow(context.Background(),
+		`SELECT messages, preview, summary, message_count FROM trip_refine_sessions
+		 WHERE user_id = $1 AND trip_id = $2`, userID, tripID).Scan(&raw, &preview, &summary, &count)
+	if err != nil {
+		return nil, "", "", 0, false
+	}
+	if err := json.Unmarshal(raw, &msgs); err != nil {
+		t.Fatalf("stored refine messages unparseable: %v", err)
+	}
+	return msgs, preview, summary, count, true
+}
+
+// boundTurn drives one trip-bound /plan turn that rewrites the itinerary.
+func boundTurn(t *testing.T, token, tripID, userText, reply string) {
+	t.Helper()
+	newFakeAnthropic(t, toolTurn("update_itinerary_section",
+		`{"scope":"trip","items":[{"name":"Cafe","latitude":1,"longitude":2,"day":1}]}`),
+		textTurn(reply))
+	rec := doJSON(t, "POST", "/api/v1/plan", token, PlanRequest{
+		// A throwaway chat id, exactly as the panel sends one. The server must
+		// ignore it for a bound turn.
+		ChatID:   "chat-" + uuid.NewString(),
+		TripID:   tripID,
+		Messages: []PlanChatMessage{{Role: "user", Content: userText}},
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("/plan = %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// (a) A trip-bound turn is saved — under (user, trip), with both sides of the
+// turn — and it is saved in trip_refine_sessions, not plan_chat_sessions.
+func TestTripBoundPlanTurnPersistsRefineSession(t *testing.T) {
+	resetDB(t)
+	user, token := createTestUser(t, "refiner@example.com")
+	trip := createTestTrip(t, user.ID, 2)
+
+	boundTurn(t, token, trip.ID.String(), "make day 2 more relaxed", "Done — day 2 is lighter now.")
+
+	msgs, preview, _, count, found := refineRow(t, user.ID, trip.ID)
+	if !found {
+		t.Fatal("no trip_refine_sessions row after a bound turn")
+	}
+	if count != 2 || len(msgs) != 2 {
+		t.Fatalf("stored %d messages (count %d), want 2 — the user turn and the reply", len(msgs), count)
+	}
+	if msgs[0].Content != "make day 2 more relaxed" || msgs[1].Role != "assistant" {
+		t.Fatalf("stored messages = %+v, want the user message then the assistant reply", msgs)
+	}
+	if preview != "Done — day 2 is lighter now." {
+		t.Fatalf("preview = %q, want the last assistant message", preview)
+	}
+
+	var planRows int
+	if err := dbPool.QueryRow(context.Background(),
+		`SELECT count(*) FROM plan_chat_sessions`).Scan(&planRows); err != nil {
+		t.Fatalf("count query: %v", err)
+	}
+	if planRows != 0 {
+		t.Fatalf("plan_chat_sessions rows = %d, want 0 — a bound turn belongs in trip_refine_sessions", planRows)
+	}
+}
+
+// (b) The append contract: more turns, including a fresh section seed, keep
+// ONE row and grow it. This is what "one running chat per trip" means in
+// storage, and it is enforced by UNIQUE (user_id, trip_id).
+func TestTripRefineSessionIsOneRowPerUserPerTrip(t *testing.T) {
+	resetDB(t)
+	user, token := createTestUser(t, "appender@example.com")
+	trip := createTestTrip(t, user.ID, 2)
+
+	boundTurn(t, token, trip.ID.String(), "first ask", "First answer.")
+
+	// A second turn resends the whole transcript, as the client does, plus a
+	// new section seed.
+	newFakeAnthropic(t, textTurn("Second answer."))
+	rec := doJSON(t, "POST", "/api/v1/plan", token, PlanRequest{
+		ChatID: "chat-" + uuid.NewString(),
+		TripID: trip.ID.String(),
+		Messages: []PlanChatMessage{
+			{Role: "user", Content: "first ask"},
+			{Role: "assistant", Content: "First answer."},
+			{Role: "user", Content: "now Day 3", DisplayLabel: "Refining Day 3 — Rome"},
+		},
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("second /plan = %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var rows int
+	if err := dbPool.QueryRow(context.Background(),
+		`SELECT count(*) FROM trip_refine_sessions`).Scan(&rows); err != nil {
+		t.Fatalf("count query: %v", err)
+	}
+	if rows != 1 {
+		t.Fatalf("trip_refine_sessions rows = %d, want 1 (upsert, not insert)", rows)
+	}
+	msgs, _, _, count, _ := refineRow(t, user.ID, trip.ID)
+	if count != 4 {
+		t.Fatalf("message_count = %d, want 4 — the conversation grows, it is not replaced", count)
+	}
+	if msgs[0].Content != "first ask" {
+		t.Fatalf("first stored message = %q, want the original ask still there", msgs[0].Content)
+	}
+	if msgs[2].DisplayLabel != "Refining Day 3 — Rome" {
+		t.Fatalf("seed label = %q, want it round-tripped", msgs[2].DisplayLabel)
+	}
+}
+
+// (c) The structural boundary: a refine transcript has no chat id, so nothing
+// in the freeform /chats world can name it. Without this, /plan/<chatId> would
+// rehydrate it into the unbound Agent tab and silently drop the trip binding.
+func TestTripRefineChatUnreachableAsPlanChat(t *testing.T) {
+	resetDB(t)
+	user, token := createTestUser(t, "unaddressable@example.com")
+	trip := createTestTrip(t, user.ID, 2)
+
+	newFakeAnthropic(t, textTurn("Sure."))
+	rec := doJSON(t, "POST", "/api/v1/plan", token, PlanRequest{
+		ChatID:   "chat-panel-session",
+		TripID:   trip.ID.String(),
+		Messages: []PlanChatMessage{{Role: "user", Content: "tighten day 1"}},
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("/plan = %d", rec.Code)
+	}
+
+	list := doJSON(t, "GET", "/api/v1/chats", token, nil)
+	if list.Code != http.StatusOK {
+		t.Fatalf("GET /chats = %d", list.Code)
+	}
+	var summaries []ChatSessionSummaryResponse
+	if err := json.Unmarshal(list.Body.Bytes(), &summaries); err != nil {
+		t.Fatalf("decode /chats: %v", err)
+	}
+	if len(summaries) != 0 {
+		t.Fatalf("resumable list = %+v, want empty — a trip's chat lives on the trip", summaries)
+	}
+	if got := doJSON(t, "GET", "/api/v1/chats/chat-panel-session", token, nil); got.Code != http.StatusNotFound {
+		t.Fatalf("GET /chats/chat-panel-session = %d, want 404", got.Code)
+	}
+	_, _, _, _, found := refineRow(t, user.ID, trip.ID)
+	if !found {
+		t.Fatal("the conversation should still exist — just not as a plan chat")
+	}
+}
+
+// (d) GET /trips/{id} advertises the conversation with presence + freshness,
+// and carries no identifier for it.
+func TestGetTripIncludesRefineChatSummary(t *testing.T) {
+	resetDB(t)
+	user, token := createTestUser(t, "advertised@example.com")
+	trip := createTestTrip(t, user.ID, 2)
+
+	before := decode(t, doJSON(t, "GET", "/api/v1/trips/"+trip.ID.String(), token, nil))
+	if _, ok := before["refine_chat"]; ok {
+		t.Fatalf("refine_chat present with no conversation: %v", before["refine_chat"])
+	}
+
+	boundTurn(t, token, trip.ID.String(), "swap the museum", "Swapped for a park.")
+
+	body := decode(t, doJSON(t, "GET", "/api/v1/trips/"+trip.ID.String(), token, nil))
+	chat, ok := body["refine_chat"].(map[string]any)
+	if !ok {
+		t.Fatalf("refine_chat = %v, want an object", body["refine_chat"])
+	}
+	if chat["message_count"] != float64(2) {
+		t.Fatalf("message_count = %v, want 2", chat["message_count"])
+	}
+	if chat["preview"] != "Swapped for a park." {
+		t.Fatalf("preview = %v, want the last reply", chat["preview"])
+	}
+	if _, bad := chat["chat_id"]; bad {
+		t.Fatal("refine_chat carries a chat_id — the absence of one is the whole boundary")
+	}
+	if _, bad := chat["id"]; bad {
+		t.Fatal("refine_chat carries an id — it must not be addressable")
+	}
+}
+
+// (e) The transcript endpoint, its access boundary, and the clear.
+func TestTripRefineChatGetDeleteAndAccess(t *testing.T) {
+	resetDB(t)
+	user, token := createTestUser(t, "reader@example.com")
+	_, strangerToken := createTestUser(t, "stranger@example.com")
+	trip := createTestTrip(t, user.ID, 2)
+	path := "/api/v1/trips/" + trip.ID.String() + "/refine-chat"
+
+	if rec := doJSON(t, "GET", path, token, nil); rec.Code != http.StatusNotFound {
+		t.Fatalf("GET with no conversation = %d, want 404", rec.Code)
+	}
+
+	boundTurn(t, token, trip.ID.String(), "add a bakery", "Added Boulangerie X.")
+
+	get := doJSON(t, "GET", path, token, nil)
+	if get.Code != http.StatusOK {
+		t.Fatalf("GET = %d: %s", get.Code, get.Body.String())
+	}
+	var detail TripRefineChatResponse
+	if err := json.Unmarshal(get.Body.Bytes(), &detail); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if detail.TripID != trip.ID.String() || len(detail.Messages) != 2 {
+		t.Fatalf("detail = %+v, want this trip and both messages", detail)
+	}
+
+	if rec := doJSON(t, "GET", path, strangerToken, nil); rec.Code != http.StatusNotFound {
+		t.Fatalf("stranger GET = %d, want 404", rec.Code)
+	}
+	if rec := doJSON(t, "DELETE", path, strangerToken, nil); rec.Code != http.StatusNotFound {
+		t.Fatalf("stranger DELETE = %d, want 404", rec.Code)
+	}
+
+	del := doJSON(t, "DELETE", path, token, nil)
+	if del.Code != http.StatusOK {
+		t.Fatalf("DELETE = %d: %s", del.Code, del.Body.String())
+	}
+	cleared := decode(t, del)
+	if cleared["trip_id"] != trip.ID.String() {
+		t.Fatalf("DELETE trip_id = %v, want the trip", cleared["trip_id"])
+	}
+	if v, ok := cleared["refine_chat"]; !ok || v != nil {
+		t.Fatalf("DELETE refine_chat = %v (present=%v), want an explicit null post-state", v, ok)
+	}
+	if rec := doJSON(t, "GET", path, token, nil); rec.Code != http.StatusNotFound {
+		t.Fatalf("GET after DELETE = %d, want 404", rec.Code)
+	}
+	body := decode(t, doJSON(t, "GET", "/api/v1/trips/"+trip.ID.String(), token, nil))
+	if _, ok := body["refine_chat"]; ok {
+		t.Fatal("the trip still advertises a conversation the traveler cleared")
+	}
+}
+
+// (f) Clearing is idempotent: the traveler cannot know whether a row existed,
+// so "New chat" on a conversation that never completed a turn is not an error.
+// This is the documented divergence from DELETE /chats/{chatId}'s 404.
+func TestDeleteTripRefineChatIsIdempotent(t *testing.T) {
+	resetDB(t)
+	user, token := createTestUser(t, "clearer@example.com")
+	trip := createTestTrip(t, user.ID, 1)
+	path := "/api/v1/trips/" + trip.ID.String() + "/refine-chat"
+
+	for i, want := range []int{http.StatusOK, http.StatusOK} {
+		if rec := doJSON(t, "DELETE", path, token, nil); rec.Code != want {
+			t.Fatalf("DELETE #%d = %d, want %d — clearing nothing is not an error", i+1, rec.Code, want)
+		}
+	}
+}
+
+// (g) Owner and editor co-planner each keep their own conversation about the
+// same trip, and neither can read the other's.
+func TestTripRefineChatIsPerUser(t *testing.T) {
+	resetDB(t)
+	owner, ownerToken := createTestUser(t, "owner@example.com")
+	_, editorToken := createTestUser(t, "editor@example.com")
+	trip := createTestTrip(t, owner.ID, 2)
+	shareToken := createShare(t, ownerToken, trip.ID.String(), "editor")
+	if rec := joinShare(t, editorToken, shareToken); rec.Code >= 300 {
+		t.Fatalf("join = %d: %s", rec.Code, rec.Body.String())
+	}
+
+	boundTurn(t, ownerToken, trip.ID.String(), "owner's ask", "Owner's answer.")
+	boundTurn(t, editorToken, trip.ID.String(), "editor's ask", "Editor's answer.")
+
+	var rows int
+	if err := dbPool.QueryRow(context.Background(),
+		`SELECT count(*) FROM trip_refine_sessions WHERE trip_id = $1`, trip.ID).Scan(&rows); err != nil {
+		t.Fatalf("count query: %v", err)
+	}
+	if rows != 2 {
+		t.Fatalf("rows for one trip = %d, want 2 — one conversation each", rows)
+	}
+
+	path := "/api/v1/trips/" + trip.ID.String() + "/refine-chat"
+	ownerMsgs := decode(t, doJSON(t, "GET", path, ownerToken, nil))
+	editorMsgs := decode(t, doJSON(t, "GET", path, editorToken, nil))
+	if !strings.Contains(toJSONString(t, ownerMsgs), "owner's ask") ||
+		strings.Contains(toJSONString(t, ownerMsgs), "editor's ask") {
+		t.Fatalf("owner sees the wrong transcript: %v", ownerMsgs)
+	}
+	if !strings.Contains(toJSONString(t, editorMsgs), "editor's ask") ||
+		strings.Contains(toJSONString(t, editorMsgs), "owner's ask") {
+		t.Fatalf("editor sees the wrong transcript: %v", editorMsgs)
+	}
+
+	// The editor's trip view still withholds the owner's lineage chat_id while
+	// carrying their own conversation.
+	body := decode(t, doJSON(t, "GET", "/api/v1/trips/"+trip.ID.String(), editorToken, nil))
+	if _, leaked := body["chat_id"]; leaked {
+		t.Fatal("editor received the owner's chat_id")
+	}
+	if _, ok := body["refine_chat"].(map[string]any); !ok {
+		t.Fatalf("editor's refine_chat = %v, want their own conversation", body["refine_chat"])
+	}
+}
+
+// (h) Retention is the trip: deleting it takes the conversations with it.
+func TestTripRefineChatCascadesOnTripDelete(t *testing.T) {
+	resetDB(t)
+	user, token := createTestUser(t, "deleter@example.com")
+	trip := createTestTrip(t, user.ID, 1)
+
+	boundTurn(t, token, trip.ID.String(), "one more stop", "Added.")
+	if _, _, _, _, found := refineRow(t, user.ID, trip.ID); !found {
+		t.Fatal("no conversation to cascade")
+	}
+
+	if rec := doJSON(t, "DELETE", "/api/v1/trips/"+trip.ID.String(), token, nil); rec.Code >= 300 {
+		t.Fatalf("DELETE trip = %d: %s", rec.Code, rec.Body.String())
+	}
+	var rows int
+	if err := dbPool.QueryRow(context.Background(),
+		`SELECT count(*) FROM trip_refine_sessions`).Scan(&rows); err != nil {
+		t.Fatalf("count query: %v", err)
+	}
+	if rows != 0 {
+		t.Fatalf("trip_refine_sessions rows = %d after the trip was deleted, want 0", rows)
+	}
+}
+
+// (i) A revoked collaborator loses access to their conversation — but we do
+// not destroy a person's own writing as a side effect of someone else's action.
+func TestRevokedCollaboratorLosesAccessButKeepsTheirRow(t *testing.T) {
+	resetDB(t)
+	owner, ownerToken := createTestUser(t, "owner@example.com")
+	editor, editorToken := createTestUser(t, "editor@example.com")
+	trip := createTestTrip(t, owner.ID, 2)
+	shareToken := createShare(t, ownerToken, trip.ID.String(), "editor")
+	if rec := joinShare(t, editorToken, shareToken); rec.Code >= 300 {
+		t.Fatalf("join = %d", rec.Code)
+	}
+	boundTurn(t, editorToken, trip.ID.String(), "editor's ask", "Editor's answer.")
+
+	rec := doJSON(t, "DELETE",
+		"/api/v1/trips/"+trip.ID.String()+"/collaborators/"+editor.ID.String(), ownerToken, nil)
+	if rec.Code >= 300 {
+		t.Fatalf("revoke = %d: %s", rec.Code, rec.Body.String())
+	}
+
+	path := "/api/v1/trips/" + trip.ID.String() + "/refine-chat"
+	if got := doJSON(t, "GET", path, editorToken, nil); got.Code != http.StatusNotFound {
+		t.Fatalf("revoked editor GET = %d, want 404", got.Code)
+	}
+	if _, _, _, _, found := refineRow(t, editor.ID, trip.ID); !found {
+		t.Fatal("the revoked editor's own conversation was destroyed by someone else's action")
+	}
+}
+
+// (j) The parity contract (docs/zen.md): the two transcript tables must store
+// the same bytes for the same conversation, because they share one derivation
+// (planTranscriptFields). If someone re-rolls either saver, this goes red.
+func TestTranscriptFieldsParityAcrossTables(t *testing.T) {
+	resetDB(t)
+	user, token := createTestUser(t, "parity@example.com")
+	trip := createTestTrip(t, user.ID, 1)
+
+	transcript := []PlanChatMessage{
+		{Role: "user", Content: "look at this", DisplayLabel: "Refining Day 1 — Rome",
+			Images: []PlanImage{{MediaType: "image/png", Data: "QUJD"}}},
+	}
+
+	newFakeAnthropic(t, textTurn("Same answer."))
+	doJSON(t, "POST", "/api/v1/plan", token, PlanRequest{
+		ChatID: "chat-free", Messages: transcript,
+	})
+	newFakeAnthropic(t, textTurn("Same answer."))
+	doJSON(t, "POST", "/api/v1/plan", token, PlanRequest{
+		ChatID: "chat-throwaway", TripID: trip.ID.String(), Messages: transcript,
+	})
+
+	var planRaw, refineRaw []byte
+	var planPreview, refinePreview string
+	if err := dbPool.QueryRow(context.Background(),
+		`SELECT messages, preview FROM plan_chat_sessions WHERE user_id = $1 AND chat_id = 'chat-free'`,
+		user.ID).Scan(&planRaw, &planPreview); err != nil {
+		t.Fatalf("plan chat row: %v", err)
+	}
+	if err := dbPool.QueryRow(context.Background(),
+		`SELECT messages, preview FROM trip_refine_sessions WHERE user_id = $1 AND trip_id = $2`,
+		user.ID, trip.ID).Scan(&refineRaw, &refinePreview); err != nil {
+		t.Fatalf("refine row: %v", err)
+	}
+	if string(planRaw) != string(refineRaw) {
+		t.Fatalf("stored transcripts diverged:\n plan   = %s\n refine = %s", planRaw, refineRaw)
+	}
+	if planPreview != refinePreview {
+		t.Fatalf("previews diverged: plan = %q, refine = %q", planPreview, refinePreview)
+	}
+	if strings.Contains(string(refineRaw), "QUJD") {
+		t.Fatal("image bytes reached the refine table")
+	}
+}
+
+// (k) The freshness contract: a bound session is told its own earlier messages
+// may be stale and to re-read the trip before writing. Without this a resumed
+// conversation reverts edits made since — including a co-planner's.
+func TestBoundPromptSteersToGetTrip(t *testing.T) {
+	resetDB(t)
+	user, token := createTestUser(t, "fresh@example.com")
+	trip := createTestTrip(t, user.ID, 2)
+
+	fa := newFakeAnthropic(t, textTurn("ok"))
+	rec := doJSON(t, "POST", "/api/v1/plan", token, PlanRequest{
+		ChatID:   "chat-bound-prompt",
+		TripID:   trip.ID.String(),
+		Messages: []PlanChatMessage{{Role: "user", Content: "tweak day 1"}},
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("/plan = %d", rec.Code)
+	}
+	bodies := fa.requestBodies()
+	if len(bodies) == 0 {
+		t.Fatal("fake anthropic received no requests")
+	}
+	prompt := systemPromptFrom(t, bodies[0])
+	for _, want := range []string{
+		"may be resumed days later",
+		"AS IT WAS",
+		"call get_trip",
+	} {
+		if !strings.Contains(prompt, want) {
+			t.Errorf("bound prompt lost %q:\n%s", want, prompt)
+		}
+	}
+}
+
+// (l) get_trip with no arguments, in a bound session, means THIS trip. Before
+// this it listed the caller's own trips — which for a co-planner never
+// contained the trip being refined.
+func TestGetTripToolReturnsBoundTripWithoutArgs(t *testing.T) {
+	resetDB(t)
+	owner, ownerToken := createTestUser(t, "owner@example.com")
+	editor, editorToken := createTestUser(t, "editor@example.com")
+	trip := createTestTrip(t, owner.ID, 2)
+	// The collaborator has a trip of their own, which is what the old listing
+	// would have answered with.
+	createTestTrip(t, editor.ID, 1)
+	shareToken := createShare(t, ownerToken, trip.ID.String(), "editor")
+	if rec := joinShare(t, editorToken, shareToken); rec.Code >= 300 {
+		t.Fatalf("join = %d", rec.Code)
+	}
+
+	out, isErr := runGetTripTool(context.Background(), true, owner.ID, &trip.ID, json.RawMessage(`{}`))
+	if isErr {
+		t.Fatalf("owner get_trip errored: %s", out)
+	}
+	if strings.Contains(out, "saved trips (") {
+		t.Fatalf("owner got a listing in a bound session:\n%s", out)
+	}
+	if !strings.Contains(out, "Place 1") {
+		t.Fatalf("owner get_trip did not return the bound trip's itinerary:\n%s", out)
+	}
+
+	out, isErr = runGetTripTool(context.Background(), true, editor.ID, &trip.ID, json.RawMessage(`{}`))
+	if isErr {
+		t.Fatalf("collaborator get_trip errored: %s", out)
+	}
+	if !strings.Contains(out, "Place 1") {
+		t.Fatalf("collaborator get_trip did not return the trip being refined:\n%s", out)
+	}
+}
+
+func toJSONString(t *testing.T, v any) string {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return string(b)
+}

--- a/src/packages/api/trip_refine_handler.go
+++ b/src/packages/api/trip_refine_handler.go
@@ -1,0 +1,166 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	"travel-route-planner/store"
+)
+
+// Trip refine conversations (specs/trip-refine-memory). One saved conversation
+// per traveler per trip: the chat behind the trip-detail refine panel, so
+// closing the panel — or hitting back, which used to pop the whole page —
+// never loses it.
+//
+// Addressed by trip id and nothing else. There is deliberately no chat id in
+// this table or on this wire: a refine transcript must never be resumable into
+// the unbound Agent tab, where the trip binding would silently vanish and the
+// agent would fall back to create_itinerary. See the 00069 migration header for
+// why this is a separate table rather than a nullable column on
+// plan_chat_sessions.
+
+// TripRefineChatSummary is presence + freshness, attached to full trip views as
+// `refine_chat`. It carries NO identifier — that absence is the feature.
+//
+// Not to be confused with TripResponse.ChatID, which is the OWNER's itinerary
+// version-lineage key: different entity, different lifetime, different
+// visibility (collaborators never receive ChatID; they always receive their own
+// RefineChat).
+type TripRefineChatSummary struct {
+	MessageCount int       `json:"message_count"`
+	Preview      string    `json:"preview"`
+	UpdatedAt    time.Time `json:"updated_at"`
+}
+
+// TripRefineChatResponse is the full transcript (GET /trips/{id}/refine-chat).
+// Messages reuse PlanChatMessage so display labels and the data-less image
+// markers round-trip exactly as they do for /chats/{chatId}.
+type TripRefineChatResponse struct {
+	TripID       string            `json:"trip_id"`
+	Summary      string            `json:"summary"`
+	Messages     []PlanChatMessage `json:"messages"`
+	MessageCount int               `json:"message_count"`
+	UpdatedAt    time.Time         `json:"updated_at"`
+}
+
+// TripRefineChatClearedResponse states the post-state a DELETE leaves behind
+// (docs/zen.md: a mutating result must state what the consumer will observe).
+// RefineChat is always null; the field exists so this shape names the same
+// thing TripResponse does.
+type TripRefineChatClearedResponse struct {
+	TripID     string                 `json:"trip_id"`
+	RefineChat *TripRefineChatSummary `json:"refine_chat"`
+}
+
+// saveTripRefineSession upserts the whole transcript for one trip's refine
+// conversation. Best-effort by design, exactly like savePlanChatSession: a
+// failure is logged and the turn proceeds.
+//
+// One case is expected rather than exceptional: a trip deleted between the
+// pre-stream authorization check and this deferred save fails the trip_id
+// foreign key. The turn is already over and its edits are already gone with the
+// trip, so the log line is the whole response.
+func saveTripRefineSession(ctx context.Context, uid, tripID uuid.UUID, summary string, msgs []PlanChatMessage) {
+	if dbPool == nil || len(msgs) == 0 {
+		return
+	}
+	payload, _, preview, err := planTranscriptFields(msgs)
+	if err != nil {
+		log.Printf("failed to marshal refine session for trip %s: %v", tripID, err)
+		return
+	}
+	if err := store.New(dbPool).UpsertTripRefineSession(ctx, store.UpsertTripRefineSessionParams{
+		UserID:       uid,
+		TripID:       tripID,
+		Preview:      preview,
+		Summary:      summary,
+		Messages:     payload,
+		MessageCount: int32(len(msgs)),
+	}); err != nil {
+		log.Printf("failed to persist refine session for trip %s: %v", tripID, err)
+	}
+}
+
+// tripRefineChatSummary reads presence + freshness for one caller and trip.
+// Returns nil when there is no conversation — an absence, not an error.
+func tripRefineChatSummary(ctx context.Context, q *store.Queries, uid, tripID uuid.UUID) (*TripRefineChatSummary, error) {
+	row, err := q.GetTripRefineSessionSummary(ctx, store.GetTripRefineSessionSummaryParams{
+		UserID: uid, TripID: tripID,
+	})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &TripRefineChatSummary{
+		MessageCount: int(row.MessageCount),
+		Preview:      row.Preview,
+		UpdatedAt:    row.UpdatedAt,
+	}, nil
+}
+
+// getTripRefineChatHandler is GET /trips/{id}/refine-chat: the caller's own
+// saved conversation about this trip, in full.
+//
+// editableTrip, not viewableTrip: only someone who may edit a trip can hold a
+// refine conversation about it, so a downgraded or removed collaborator gets
+// the same 404 as a stranger with no extra check. "No conversation", "no trip"
+// and "not yours" are deliberately one answer.
+func getTripRefineChatHandler(w http.ResponseWriter, r *http.Request) {
+	user, _ := userFromContext(r.Context())
+	trip, ok := editableTrip(w, r)
+	if !ok {
+		return
+	}
+	row, err := store.New(dbPool).GetTripRefineSession(r.Context(),
+		store.GetTripRefineSessionParams{UserID: user.ID, TripID: trip.ID})
+	if err != nil {
+		writeJSONError(w, http.StatusNotFound, "conversation not found")
+		return
+	}
+	var msgs []PlanChatMessage
+	if err := json.Unmarshal(row.Messages, &msgs); err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "could not load the conversation")
+		return
+	}
+	writeJSON(w, http.StatusOK, TripRefineChatResponse{
+		TripID:       trip.ID.String(),
+		Summary:      row.Summary,
+		Messages:     msgs,
+		MessageCount: int(row.MessageCount),
+		UpdatedAt:    row.UpdatedAt,
+	})
+}
+
+// deleteTripRefineChatHandler is DELETE /trips/{id}/refine-chat — the "New
+// chat" action.
+//
+// Deliberate divergence from its sibling DELETE /chats/{chatId}, which 404s
+// when no row existed: this one answers 200 with the post-state whether or not
+// there was a conversation. Clearing state the caller cannot observe beforehand
+// must be idempotent — "New chat" tapped on a conversation that never completed
+// a turn is not an error, and a client that retries after a dropped response
+// must not see one either. (docs/zen.md: divergence gets a comment, a decision
+// record in specs/trip-refine-memory/plan.md, and a test —
+// TestDeleteTripRefineChatIsIdempotent.)
+func deleteTripRefineChatHandler(w http.ResponseWriter, r *http.Request) {
+	user, _ := userFromContext(r.Context())
+	trip, ok := editableTrip(w, r)
+	if !ok {
+		return
+	}
+	if _, err := store.New(dbPool).DeleteTripRefineSession(r.Context(),
+		store.DeleteTripRefineSessionParams{UserID: user.ID, TripID: trip.ID}); err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "could not clear the conversation")
+		return
+	}
+	writeJSON(w, http.StatusOK, TripRefineChatClearedResponse{TripID: trip.ID.String()})
+}

--- a/src/packages/flutter-app/lib/l10n/app_en.arb
+++ b/src/packages/flutter-app/lib/l10n/app_en.arb
@@ -2135,6 +2135,25 @@
   },
   "refineAssistantHint": "Ask anything about this trip…",
   "refineHint": "Ask for changes...",
+  "refineNewChat": "New chat",
+  "refineNewChatConfirmTitle": "Start a new chat?",
+  "refineNewChatConfirmBody": "This conversation will be cleared. Your trip is not affected.",
+  "refineResumeLoading": "Restoring your conversation…",
+  "refineResumeGone": "This conversation has expired.",
+  "refineResumeGoneDetail": "It was cleared or removed with its trip. You can start a new one.",
+  "refineResumeFailed": "Couldn't reopen this conversation.",
+  "tripContinueChat": "Continue chat",
+  "tripContinueChatMeta": "{count, plural, =1{1 message} other{{count} messages}} · {age}",
+  "@tripContinueChatMeta": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "age": {
+        "type": "String"
+      }
+    }
+  },
   "chatDictationPermission": "Microphone access was blocked. Check your browser settings.",
   "chatDictationUnsupported": "Voice input isn't available in this browser.",
   "chatDictationUnavailable": "Voice input isn't available right now.",

--- a/src/packages/flutter-app/lib/l10n/app_es.arb
+++ b/src/packages/flutter-app/lib/l10n/app_es.arb
@@ -878,6 +878,25 @@
   "refineHeader": "Ajustando · {target}",
   "refineAssistantHint": "Pregunta lo que quieras sobre este viaje…",
   "refineHint": "Pide cambios...",
+  "refineNewChat": "Chat nuevo",
+  "refineNewChatConfirmTitle": "\u00bfEmpezar un chat nuevo?",
+  "refineNewChatConfirmBody": "Se borrar\u00e1 esta conversaci\u00f3n. Tu viaje no se ve afectado.",
+  "refineResumeLoading": "Restaurando tu conversaci\u00f3n…",
+  "refineResumeGone": "Esta conversaci\u00f3n ha caducado.",
+  "refineResumeGoneDetail": "Se borr\u00f3 o se elimin\u00f3 junto con su viaje. Puedes empezar una nueva.",
+  "refineResumeFailed": "No se pudo reabrir esta conversaci\u00f3n.",
+  "tripContinueChat": "Continuar chat",
+  "tripContinueChatMeta": "{count, plural, =1{1 mensaje} other{{count} mensajes}} \u00b7 {age}",
+  "@tripContinueChatMeta": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "age": {
+        "type": "String"
+      }
+    }
+  },
   "chatDictationPermission": "Se bloqueó el acceso al micrófono. Revisa la configuración de tu navegador.",
   "chatDictationUnsupported": "La entrada por voz no está disponible en este navegador.",
   "chatDictationUnavailable": "La entrada por voz no está disponible en este momento.",

--- a/src/packages/flutter-app/lib/l10n/app_localizations.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations.dart
@@ -5306,6 +5306,60 @@ abstract class AppLocalizations {
   /// **'Ask for changes...'**
   String get refineHint;
 
+  /// No description provided for @refineNewChat.
+  ///
+  /// In en, this message translates to:
+  /// **'New chat'**
+  String get refineNewChat;
+
+  /// No description provided for @refineNewChatConfirmTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Start a new chat?'**
+  String get refineNewChatConfirmTitle;
+
+  /// No description provided for @refineNewChatConfirmBody.
+  ///
+  /// In en, this message translates to:
+  /// **'This conversation will be cleared. Your trip is not affected.'**
+  String get refineNewChatConfirmBody;
+
+  /// No description provided for @refineResumeLoading.
+  ///
+  /// In en, this message translates to:
+  /// **'Restoring your conversation…'**
+  String get refineResumeLoading;
+
+  /// No description provided for @refineResumeGone.
+  ///
+  /// In en, this message translates to:
+  /// **'This conversation has expired.'**
+  String get refineResumeGone;
+
+  /// No description provided for @refineResumeGoneDetail.
+  ///
+  /// In en, this message translates to:
+  /// **'It was cleared or removed with its trip. You can start a new one.'**
+  String get refineResumeGoneDetail;
+
+  /// No description provided for @refineResumeFailed.
+  ///
+  /// In en, this message translates to:
+  /// **'Couldn\'t reopen this conversation.'**
+  String get refineResumeFailed;
+
+  /// No description provided for @tripContinueChat.
+  ///
+  /// In en, this message translates to:
+  /// **'Continue chat'**
+  String get tripContinueChat;
+
+  /// No description provided for @tripContinueChatMeta.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, =1{1 message} other{{count} messages}} · {age}'**
+  String tripContinueChatMeta(int count, String age);
+
   /// No description provided for @chatDictationPermission.
   ///
   /// In en, this message translates to:

--- a/src/packages/flutter-app/lib/l10n/app_localizations_en.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations_en.dart
@@ -3178,6 +3178,43 @@ class AppLocalizationsEn extends AppLocalizations {
   String get refineHint => 'Ask for changes...';
 
   @override
+  String get refineNewChat => 'New chat';
+
+  @override
+  String get refineNewChatConfirmTitle => 'Start a new chat?';
+
+  @override
+  String get refineNewChatConfirmBody =>
+      'This conversation will be cleared. Your trip is not affected.';
+
+  @override
+  String get refineResumeLoading => 'Restoring your conversation…';
+
+  @override
+  String get refineResumeGone => 'This conversation has expired.';
+
+  @override
+  String get refineResumeGoneDetail =>
+      'It was cleared or removed with its trip. You can start a new one.';
+
+  @override
+  String get refineResumeFailed => 'Couldn\'t reopen this conversation.';
+
+  @override
+  String get tripContinueChat => 'Continue chat';
+
+  @override
+  String tripContinueChatMeta(int count, String age) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count messages',
+      one: '1 message',
+    );
+    return '$_temp0 · $age';
+  }
+
+  @override
   String get chatDictationPermission =>
       'Microphone access was blocked. Check your browser settings.';
 

--- a/src/packages/flutter-app/lib/l10n/app_localizations_es.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations_es.dart
@@ -3196,6 +3196,43 @@ class AppLocalizationsEs extends AppLocalizations {
   String get refineHint => 'Pide cambios...';
 
   @override
+  String get refineNewChat => 'Chat nuevo';
+
+  @override
+  String get refineNewChatConfirmTitle => '¿Empezar un chat nuevo?';
+
+  @override
+  String get refineNewChatConfirmBody =>
+      'Se borrará esta conversación. Tu viaje no se ve afectado.';
+
+  @override
+  String get refineResumeLoading => 'Restaurando tu conversación…';
+
+  @override
+  String get refineResumeGone => 'Esta conversación ha caducado.';
+
+  @override
+  String get refineResumeGoneDetail =>
+      'Se borró o se eliminó junto con su viaje. Puedes empezar una nueva.';
+
+  @override
+  String get refineResumeFailed => 'No se pudo reabrir esta conversación.';
+
+  @override
+  String get tripContinueChat => 'Continuar chat';
+
+  @override
+  String tripContinueChatMeta(int count, String age) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count mensajes',
+      one: '1 mensaje',
+    );
+    return '$_temp0 · $age';
+  }
+
+  @override
   String get chatDictationPermission =>
       'Se bloqueó el acceso al micrófono. Revisa la configuración de tu navegador.';
 

--- a/src/packages/flutter-app/lib/models/trip.dart
+++ b/src/packages/flutter-app/lib/models/trip.dart
@@ -5,6 +5,7 @@ import 'trip_segment.dart';
 import 'booking_todo.dart';
 import 'city_pin.dart';
 import 'trip_leg_dto.dart';
+import 'trip_refine_chat.dart';
 
 part 'trip.g.dart';
 
@@ -19,6 +20,16 @@ class Trip {
   final String? endDate;
   @JsonKey(name: 'chat_id')
   final String? chatId;
+
+  /// This traveler's own saved conversation about this trip
+  /// (specs/trip-refine-memory) — presence + freshness only; the transcript is
+  /// fetched on demand from `GET /trips/{id}/refine-chat`. Null means they have
+  /// none, and the trip page offers a fresh chat instead of "Continue chat".
+  ///
+  /// Per-caller, unlike [chatId]: an owner and each co-planner have their own,
+  /// and a collaborator receives this while never receiving [chatId].
+  @JsonKey(name: 'refine_chat')
+  final TripRefineChat? refineChat;
 
   /// How the traveler moves between cities on this trip: 'flight', 'car',
   /// 'train', 'bus', 'ferry', or 'mixed'. Null = never stated ⇒ the legacy
@@ -136,6 +147,7 @@ class Trip {
     this.startDate,
     this.endDate,
     this.chatId,
+    this.refineChat,
     this.travelMode,
     this.origin,
     this.originAirport,

--- a/src/packages/flutter-app/lib/models/trip.g.dart
+++ b/src/packages/flutter-app/lib/models/trip.g.dart
@@ -13,6 +13,10 @@ Trip _$TripFromJson(Map<String, dynamic> json) => Trip(
       startDate: json['start_date'] as String?,
       endDate: json['end_date'] as String?,
       chatId: json['chat_id'] as String?,
+      refineChat: json['refine_chat'] == null
+          ? null
+          : TripRefineChat.fromJson(
+              json['refine_chat'] as Map<String, dynamic>),
       travelMode: json['travel_mode'] as String?,
       origin: json['origin'] as String?,
       originAirport: json['origin_airport'] as String?,
@@ -64,6 +68,7 @@ Map<String, dynamic> _$TripToJson(Trip instance) => <String, dynamic>{
       'start_date': instance.startDate,
       'end_date': instance.endDate,
       'chat_id': instance.chatId,
+      'refine_chat': instance.refineChat?.toJson(),
       'travel_mode': instance.travelMode,
       'origin': instance.origin,
       'origin_airport': instance.originAirport,

--- a/src/packages/flutter-app/lib/models/trip_refine_chat.dart
+++ b/src/packages/flutter-app/lib/models/trip_refine_chat.dart
@@ -1,0 +1,66 @@
+import 'package:json_annotation/json_annotation.dart';
+
+import 'chat_session.dart';
+
+part 'trip_refine_chat.g.dart';
+
+/// Presence + freshness for the caller's own saved conversation about one trip
+/// (specs/trip-refine-memory), as it rides `GET /trips/{id}` in `refine_chat`.
+///
+/// Deliberately carries **no identifier**: a refine conversation is addressed
+/// by its trip and nothing else, so it can never be opened as a freeform plan
+/// chat (which would silently drop the trip binding). Not to be confused with
+/// [Trip.chatId], the owner's itinerary version-lineage key.
+@JsonSerializable()
+class TripRefineChat {
+  @JsonKey(name: 'message_count')
+  final int messageCount;
+
+  /// The assistant's last reply, truncated — what the "Continue chat" row shows.
+  final String preview;
+
+  @JsonKey(name: 'updated_at')
+  final String updatedAt;
+
+  const TripRefineChat({
+    required this.messageCount,
+    required this.preview,
+    required this.updatedAt,
+  });
+
+  factory TripRefineChat.fromJson(Map<String, dynamic> json) =>
+      _$TripRefineChatFromJson(json);
+  Map<String, dynamic> toJson() => _$TripRefineChatToJson(this);
+}
+
+/// The full transcript from `GET /trips/{id}/refine-chat`.
+///
+/// Messages reuse [ChatSessionMessage] rather than growing a twin: the two
+/// endpoints serialize the same server type, so one Dart model keeps them from
+/// drifting (docs/zen.md — consume the first implementation).
+@JsonSerializable(explicitToJson: true)
+class TripRefineChatDetail {
+  @JsonKey(name: 'trip_id')
+  final String tripId;
+
+  /// Running compaction summary; empty when the conversation was never
+  /// compacted. Restored as the resumed session's compactedSummary.
+  final String summary;
+  final List<ChatSessionMessage> messages;
+  @JsonKey(name: 'message_count')
+  final int messageCount;
+  @JsonKey(name: 'updated_at')
+  final String updatedAt;
+
+  const TripRefineChatDetail({
+    required this.tripId,
+    required this.summary,
+    required this.messages,
+    required this.messageCount,
+    required this.updatedAt,
+  });
+
+  factory TripRefineChatDetail.fromJson(Map<String, dynamic> json) =>
+      _$TripRefineChatDetailFromJson(json);
+  Map<String, dynamic> toJson() => _$TripRefineChatDetailToJson(this);
+}

--- a/src/packages/flutter-app/lib/models/trip_refine_chat.g.dart
+++ b/src/packages/flutter-app/lib/models/trip_refine_chat.g.dart
@@ -1,0 +1,43 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'trip_refine_chat.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+TripRefineChat _$TripRefineChatFromJson(Map<String, dynamic> json) =>
+    TripRefineChat(
+      messageCount: (json['message_count'] as num).toInt(),
+      preview: json['preview'] as String,
+      updatedAt: json['updated_at'] as String,
+    );
+
+Map<String, dynamic> _$TripRefineChatToJson(TripRefineChat instance) =>
+    <String, dynamic>{
+      'message_count': instance.messageCount,
+      'preview': instance.preview,
+      'updated_at': instance.updatedAt,
+    };
+
+TripRefineChatDetail _$TripRefineChatDetailFromJson(
+        Map<String, dynamic> json) =>
+    TripRefineChatDetail(
+      tripId: json['trip_id'] as String,
+      summary: json['summary'] as String,
+      messages: (json['messages'] as List<dynamic>)
+          .map((e) => ChatSessionMessage.fromJson(e as Map<String, dynamic>))
+          .toList(),
+      messageCount: (json['message_count'] as num).toInt(),
+      updatedAt: json['updated_at'] as String,
+    );
+
+Map<String, dynamic> _$TripRefineChatDetailToJson(
+        TripRefineChatDetail instance) =>
+    <String, dynamic>{
+      'trip_id': instance.tripId,
+      'summary': instance.summary,
+      'messages': instance.messages.map((e) => e.toJson()).toList(),
+      'message_count': instance.messageCount,
+      'updated_at': instance.updatedAt,
+    };

--- a/src/packages/flutter-app/lib/providers/plan_provider.dart
+++ b/src/packages/flutter-app/lib/providers/plan_provider.dart
@@ -799,8 +799,12 @@ class PlanNotifier extends StateNotifier<PlanState> {
   /// without sending anything: the transcript renders immediately and the next
   /// send carries the same chat_id plus [summary] (the server-side compaction
   /// summary) exactly as a never-closed session would.
+  ///
+  /// [chatId] is optional because a trip's own conversation has none
+  /// (specs/trip-refine-memory): it is keyed by (traveler, trip) server-side,
+  /// and the throwaway id the next send mints is ignored for a bound turn.
   void resumeConversation({
-    required String chatId,
+    String? chatId,
     required List<PlanMessage> messages,
     String? summary,
   }) {
@@ -823,15 +827,72 @@ class PlanNotifier extends StateNotifier<PlanState> {
     sendMessage(seedMessage);
   }
 
-  /// Start (or restart) an in-place section refinement on the bound trip:
-  /// clears any prior conversation and sends the seed describing the targeted
-  /// section. Requires [tripId]; the server patches that trip directly, so no
-  /// chat-group binding is needed.
-  void beginSectionRefinement(String seedMessage, {String? displayLabel}) {
-    reset();
-    sendMessage(seedMessage, displayLabel: displayLabel);
+  /// Point the trip's running conversation at another section
+  /// (specs/trip-refine-memory). A refine tap is a change of subject, not a new
+  /// chat — it appends a context chapter and discards nothing; only
+  /// [startOver] discards. Requires [tripId]; the server patches that trip
+  /// directly, so no chat-group binding is needed.
+  ///
+  /// Every EARLIER seed's itinerary listing is collapsed to a stub first. The
+  /// seed built by the trip screen dumps every item with coordinates and tags,
+  /// so without this a conversation would accumulate near-duplicate snapshots
+  /// and the agent could not tell which one is current — the failure class
+  /// behind the update_itinerary_section scope bugs. Costs the reader nothing:
+  /// a labeled message renders as a context chip and its content is never shown.
+  ///
+  /// Rewrites content **in place and never removes a message**: [compactedCount]
+  /// is a start-anchored index into [PlanState.messages], so dropping one would
+  /// misalign the wire history against the server's compaction summary.
+  void appendSectionRefinement(String seedMessage, {String? displayLabel}) {
+    var hadEarlierSeed = false;
+    final superseded = [
+      for (final m in state.messages)
+        if (m.role == MessageRole.user && m.displayLabel != null) ...[
+          if (m.content.startsWith(_supersededSeedPrefix))
+            m
+          else
+            PlanMessage(
+              role: m.role,
+              content: _supersededSeed(m.displayLabel!),
+              displayLabel: m.displayLabel,
+              attachments: m.attachments,
+            ),
+        ] else
+          m,
+    ];
+    for (final m in state.messages) {
+      if (m.role == MessageRole.user && m.displayLabel != null) {
+        hadEarlierSeed = true;
+        break;
+      }
+    }
+    state = state.copyWith(messages: superseded);
+    // Only when there is something to ignore. A first seed — especially a
+    // server-built Next Step prompt — reaches the model verbatim.
+    sendMessage(
+        hadEarlierSeed ? '$seedMessage\n\n$_ignoreStaleListings' : seedMessage,
+        displayLabel: displayLabel);
   }
+
+  /// Explicit "New chat" on a trip: drop the transcript and the chat id. The
+  /// caller is responsible for clearing the stored copy
+  /// (`DELETE /trips/{id}/refine-chat`) — otherwise the page would go on
+  /// advertising a conversation the traveler just dismissed.
+  void startOver() => reset();
 }
+
+/// Canonical **English**, like RefineTarget.label: these strings go on the wire
+/// to the agent, never to the reader (see [PlanNotifier.appendSectionRefinement]).
+const _supersededSeedPrefix = '(Earlier listing for ';
+
+String _supersededSeed(String label) =>
+    '$_supersededSeedPrefix$label — superseded; the itinerary as it stands is '
+    'described in the latest message below, and get_trip returns the '
+    'authoritative version.)';
+
+const _ignoreStaleListings =
+    'Ignore any earlier itinerary listings in this conversation; they are '
+    'stale. This one, and get_trip, are current.';
 
 /// Re-reads the traveler profile after the agent writes it. `load()`, not
 /// `loadIfNeeded()`: the cached copy is exactly what is wrong here.

--- a/src/packages/flutter-app/lib/providers/plan_resume.dart
+++ b/src/packages/flutter-app/lib/providers/plan_resume.dart
@@ -1,14 +1,42 @@
+import '../models/chat_session.dart';
 import '../models/plan_message.dart';
 import '../services/chats_api_service.dart';
+import '../services/trips_api_service.dart';
 import 'plan_provider.dart';
+
+/// Turns a persisted transcript into chat state. The ONE mapping, shared by
+/// both resume paths — the freeform plan chat below and the per-trip refine
+/// chat ([resumeTripRefineChat]) — so a stored conversation can never render
+/// differently depending on which surface reopened it.
+List<PlanMessage> planMessagesFrom(List<ChatSessionMessage> messages) => [
+      for (final m in messages)
+        PlanMessage(
+          role: m.role == 'user' ? MessageRole.user : MessageRole.assistant,
+          content: m.content,
+          // Restores the seed context chip (e.g. "Near my current location",
+          // "Refining Day 2 — Athens") instead of the raw message bubble.
+          displayLabel: m.displayLabel,
+          // Pixels are stripped server-side; null bytes renders the
+          // "Image" placeholder chip and stays out of resent history.
+          attachments: [
+            for (final img in m.images)
+              PlanAttachment(bytes: null, mediaType: img.mediaType),
+          ],
+        ),
+    ];
 
 /// Fetches a persisted conversation transcript and rehydrates it into [plan]
 /// (specs/continue-where-you-left-off). Shared by the home-screen Continue
 /// card and the /plan/<chatId> URL restore (specs/url-page-persistence).
 ///
 /// False on any failure — including the expected 404s for ids with no stored
-/// transcript (trip-bound, anonymous, graduated, or someone else's chat).
-/// Callers decide how loud to be; the URL restore degrades silently.
+/// transcript (anonymous, graduated, or someone else's chat). Callers decide
+/// how loud to be; the URL restore degrades silently.
+///
+/// A trip's own conversation is deliberately unreachable here: it has no chat
+/// id at all (specs/trip-refine-memory), so no value of [chatId] can name one
+/// and resuming it into the unbound Agent tab — which would drop the trip
+/// binding — is impossible rather than merely guarded against.
 Future<bool> resumePlanChat({
   required ChatsApiService chats,
   required PlanNotifier plan,
@@ -19,25 +47,33 @@ Future<bool> resumePlanChat({
     plan.resumeConversation(
       chatId: detail.chatId,
       summary: detail.summary,
-      messages: [
-        for (final m in detail.messages)
-          PlanMessage(
-            role: m.role == 'user' ? MessageRole.user : MessageRole.assistant,
-            content: m.content,
-            // Restores the seed context chip (e.g. "Near my current
-            // location") instead of the raw coordinate bubble.
-            displayLabel: m.displayLabel,
-            // Pixels are stripped server-side; null bytes renders the
-            // "Image" placeholder chip and stays out of resent history.
-            attachments: [
-              for (final img in m.images)
-                PlanAttachment(bytes: null, mediaType: img.mediaType),
-            ],
-          ),
-      ],
+      messages: planMessagesFrom(detail.messages),
     );
     return true;
   } catch (_) {
     return false;
   }
+}
+
+/// Rehydrates a trip's own saved conversation into its refine-panel notifier
+/// (specs/trip-refine-memory).
+///
+/// Unlike [resumePlanChat] this **rethrows**: the panel has to tell "this
+/// conversation expired" from "we couldn't reach it", and — more importantly —
+/// a caller must never proceed to send a message onto an empty panel after a
+/// failed restore. The transcript is upserted wholesale each turn, so that
+/// would overwrite a long conversation with two messages.
+///
+/// Passes no chat id: a refine conversation has none, and the throwaway one the
+/// next send mints is ignored by the server for a bound turn.
+Future<void> resumeTripRefineChat({
+  required TripsApiService trips,
+  required PlanNotifier plan,
+  required String tripId,
+}) async {
+  final detail = await trips.getTripRefineChat(tripId);
+  plan.resumeConversation(
+    summary: detail.summary,
+    messages: planMessagesFrom(detail.messages),
+  );
 }

--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart' show RenderAbstractViewport;
+import 'package:flutter/services.dart' show LogicalKeyboardKey;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:sliver_tools/sliver_tools.dart';
 import 'package:url_launcher/url_launcher.dart';
@@ -26,6 +27,7 @@ import '../providers/booking_todos_provider.dart';
 import '../providers/preferences_provider.dart';
 import '../providers/api_client_provider.dart';
 import '../providers/plan_provider.dart';
+import '../providers/plan_resume.dart';
 import '../providers/events_provider.dart';
 import '../providers/weather_provider.dart';
 import '../models/weather.dart';
@@ -154,9 +156,16 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
   // in this mode; a successful live load clears it.
   DateTime? _offlineSince;
   // In-page AI refinement panel (side dock on wide layouts, bottom sheet on
-  // narrow ones); null target while closed.
+  // narrow ones). This bool is ALL the panel's screen state: the header derives
+  // from the conversation itself, so back has exactly one thing to undo
+  // (specs/trip-refine-memory).
   bool _panelOpen = false;
-  RefineTarget? _refineTarget;
+
+  // Where the trip's saved conversation is in its restore. `_chatResumeTried`
+  // makes the fetch once-per-screen so a 404 doesn't refetch on every tap.
+  RefineChatPhase _chatPhase = RefineChatPhase.ready;
+  Object? _chatError;
+  bool _chatResumeTried = false;
 
   // Next Step CTA session state (specs/next-step-cta): the all_set
   // celebration shows only after this session actually watched a step resolve
@@ -1841,10 +1850,116 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
     }
   }
 
-  /// Opens the in-page refinement panel on [target], seeding a fresh session
-  /// with the section's current contents. The session is bound to this trip
-  /// server-side, so changes patch the trip in place (no new versions).
-  void _openRefine(Trip trip, RefineTarget target) {
+  /// The trip page's visible proof that a conversation is waiting
+  /// (specs/trip-refine-memory). Without it, resuming would be an invisible
+  /// behavior of a button the traveler has to guess at — which is how the
+  /// conversation got lost in the first place.
+  ///
+  /// Hidden offline: reopening needs a fetch, and a dead row is worse than
+  /// none. Hidden while the panel is open — the conversation is right there.
+  Widget _continueChatRow(Trip trip, ThemeData theme, AppLocalizations l10n) {
+    final chat = trip.refineChat;
+    if (chat == null || _panelOpen || !trip.canEdit || _isOffline) {
+      return const SizedBox.shrink();
+    }
+    final updated = DateTime.tryParse(chat.updatedAt);
+    return Padding(
+      padding: const EdgeInsets.only(top: AppSpacing.md),
+      child: Card(
+        margin: EdgeInsets.zero,
+        child: ListTile(
+          leading: const Icon(Icons.forum_outlined),
+          title: Text(l10n.tripContinueChat,
+              style: theme.textTheme.titleSmall
+                  ?.copyWith(fontWeight: FontWeight.w600)),
+          subtitle: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              if (chat.preview.isNotEmpty)
+                Text(chat.preview, maxLines: 2, overflow: TextOverflow.ellipsis),
+              Padding(
+                padding: const EdgeInsets.only(top: AppSpacing.xs),
+                child: Text(
+                  // relativeTime already exists (offline_banner.dart) — reuse
+                  // it rather than growing a second "how long ago" rule.
+                  updated == null
+                      ? l10n.tripContinueChatMeta(chat.messageCount, '')
+                      : l10n.tripContinueChatMeta(
+                          chat.messageCount, relativeTime(l10n, updated)),
+                  style: theme.textTheme.bodySmall
+                      ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+                ),
+              ),
+            ],
+          ),
+          onTap: () => _openChat(trip),
+        ),
+      ),
+    );
+  }
+
+  /// Makes sure the trip's saved conversation is loaded before anything is
+  /// sent into it (specs/trip-refine-memory). Returns false when the caller
+  /// must NOT proceed.
+  ///
+  /// This gate is load-bearing, not politeness: the transcript is upserted
+  /// wholesale every turn, so sending a seed into a panel that failed to
+  /// restore would overwrite a fifty-message conversation with two messages.
+  ///
+  /// The empty-transcript precondition is what makes it safe to call
+  /// [PlanNotifier.resumeConversation] (which resets): a turn can never be in
+  /// flight with an empty transcript, because sendMessage appends the user's
+  /// message first.
+  Future<bool> _ensureRefineHydrated(Trip trip) async {
+    final notifier = ref.read(tripRefineProvider(widget.tripId).notifier);
+    // Memory beats server: an in-progress conversation is already the truth,
+    // and refetching would discard anything streaming.
+    if (ref.read(tripRefineProvider(widget.tripId)).messages.isNotEmpty) {
+      return true;
+    }
+    // Nothing stored: a fresh conversation can't overwrite anything.
+    if (trip.refineChat == null) return true;
+    if (_chatResumeTried) {
+      // Already answered once this screen session. "Expired" means there is
+      // nothing left to protect, so a fresh chat is fine; a FAILURE means a
+      // stored conversation may still be there, and sending into an empty
+      // panel would upsert over it.
+      return _chatPhase != RefineChatPhase.failed;
+    }
+    _chatResumeTried = true;
+    setState(() {
+      _panelOpen = true;
+      _chatPhase = RefineChatPhase.restoring;
+      _chatError = null;
+    });
+    // Captured while mounted: after the await, `ref` may be unreachable
+    // through a disposed element.
+    final trips = ref.read(tripsApiServiceProvider);
+    try {
+      await resumeTripRefineChat(
+          trips: trips, plan: notifier, tripId: widget.tripId);
+      if (!mounted) return false;
+      setState(() => _chatPhase = RefineChatPhase.ready);
+      return true;
+    } catch (e) {
+      if (!mounted) return false;
+      final gone = e is ApiException && e.statusCode == 404;
+      setState(() {
+        _chatPhase =
+            gone ? RefineChatPhase.expired : RefineChatPhase.failed;
+        _chatError = e;
+      });
+      return false;
+    }
+  }
+
+  /// Points the trip's running conversation at [target], seeding it with that
+  /// section's current contents. The session is bound to this trip server-side,
+  /// so changes patch the trip in place (no new versions).
+  ///
+  /// Since specs/trip-refine-memory this APPENDS: a ✨ tap is a change of
+  /// subject, not a new chat. Only "New chat" discards one.
+  Future<void> _openRefine(Trip trip, RefineTarget target) async {
     // Chat/refine needs the network; also keeps the refine panel from ever
     // observing a cached (read-only) trip.
     if (_guardOffline()) return;
@@ -1857,19 +1972,21 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
       _showSnack(l10n.tripAddPlacesBeforeRefine);
       return;
     }
+    if (!await _ensureRefineHydrated(trip)) return;
+    if (!mounted) return;
+    final continuing =
+        ref.read(tripRefineProvider(widget.tripId)).messages.isNotEmpty;
     ref
         .read(tripRefineProvider(widget.tripId).notifier)
-        .beginSectionRefinement(_buildSectionSeed(trip, target),
+        .appendSectionRefinement(
+            _buildSectionSeed(trip, target, continuing: continuing),
             // displayLabel is what the traveler reads in the panel header, so
             // it uses the localized form; the seed prompt above keeps the
             // canonical English label the agent expects (specs/i18n-spanish).
             displayLabel: target.assistant
                 ? l10n.tripAssistantLabel
                 : l10n.tripRefiningSection(target.displayLabel(l10n)));
-    setState(() {
-      _panelOpen = true;
-      _refineTarget = target;
-    });
+    setState(() => _panelOpen = true);
   }
 
   /// Next Step chat entry (specs/next-step-cta): the same offline + canEdit
@@ -1878,38 +1995,79 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
   /// plan_itinerary step exists precisely for empty trips. [displayLabel] is
   /// the step's server-localized title; the seed stays canonical English
   /// (specs/i18n-spanish).
-  void _openSeededChat(Trip trip,
-      {required String seed, required String displayLabel}) {
+  Future<void> _openSeededChat(Trip trip,
+      {required String seed, required String displayLabel}) async {
     if (_guardOffline()) return;
     if (!trip.canEdit) return;
+    if (!await _ensureRefineHydrated(trip)) return;
+    if (!mounted) return;
     ref
         .read(tripRefineProvider(widget.tripId).notifier)
-        .beginSectionRefinement(seed, displayLabel: displayLabel);
-    setState(() {
-      _panelOpen = true;
-      _refineTarget = const RefineTarget.assistant();
-    });
+        .appendSectionRefinement(seed, displayLabel: displayLabel);
+    setState(() => _panelOpen = true);
   }
 
-  /// FAB entry point: resumes the panel conversation if one is in progress,
-  /// otherwise starts a fresh whole-trip assistant session.
-  void _openChat(Trip trip) {
+  /// FAB / "Continue chat" entry point: reopens the conversation in progress,
+  /// restores the saved one, or starts a fresh whole-trip assistant session.
+  Future<void> _openChat(Trip trip) async {
     if (_guardOffline()) return;
     // The FAB is hidden for read-only viewers; belt-and-braces like
     // _openRefine.
     if (!trip.canEdit) return;
+    if (ref.read(tripRefineProvider(widget.tripId)).messages.isNotEmpty) {
+      setState(() => _panelOpen = true);
+      return;
+    }
+    if (trip.refineChat != null && !_chatResumeTried) {
+      await _ensureRefineHydrated(trip);
+      return; // the panel is open either way — restored, expired, or failed
+    }
+    await _openRefine(trip, const RefineTarget.assistant());
+  }
+
+  /// Explicit "New chat": discard the conversation here and server-side, so the
+  /// page stops advertising one the traveler just dismissed. Confirms first —
+  /// with one running chat per trip, this really does throw the thread away.
+  Future<void> _newChat(Trip trip) async {
+    final l10n = context.l10n;
     final hasConversation =
         ref.read(tripRefineProvider(widget.tripId)).messages.isNotEmpty;
     if (hasConversation) {
-      setState(() {
-        _panelOpen = true;
-        // Restore a header if the screen was rebuilt and lost it; keep a
-        // surviving section-refine target so its header stays accurate.
-        _refineTarget ??= const RefineTarget.assistant();
-      });
-      return;
+      final confirm = await showDialog<bool>(
+        context: context,
+        builder: (context) => AlertDialog(
+          title: Text(l10n.refineNewChatConfirmTitle),
+          content: Text(l10n.refineNewChatConfirmBody),
+          actions: [
+            TextButton(
+                onPressed: () => Navigator.pop(context, false),
+                child: Text(l10n.commonCancel)),
+            FilledButton(
+                onPressed: () => Navigator.pop(context, true),
+                child: Text(l10n.refineNewChat)),
+          ],
+        ),
+      );
+      if (confirm != true || !mounted) return;
     }
-    _openRefine(trip, const RefineTarget.assistant());
+    final trips = ref.read(tripsApiServiceProvider);
+    ref.read(tripRefineProvider(widget.tripId).notifier).startOver();
+    setState(() {
+      _chatPhase = RefineChatPhase.ready;
+      _chatError = null;
+      // A cleared conversation is not one we failed to restore: allow a fresh
+      // restore attempt if the traveler somehow gets a new one.
+      _chatResumeTried = false;
+    });
+    try {
+      // Idempotent server-side, so a conversation that never completed a turn
+      // is not an error here either.
+      await trips.deleteTripRefineChat(widget.tripId);
+    } catch (_) {
+      // Best-effort: the local conversation is already gone, and the next trip
+      // load re-reads whatever the server still holds.
+    }
+    if (mounted) await _refresh();
   }
 
   /// Whether an item falls inside the refinement target (client-side mirror of
@@ -1945,11 +2103,18 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
   /// Builds the panel's seed message: trip context, the target section's items
   /// in full detail, and explicit instructions to patch only that section via
   /// update_itinerary_section.
-  String _buildSectionSeed(Trip trip, RefineTarget t) {
+  ///
+  /// [continuing] marks a seed appended to a conversation already under way
+  /// (specs/trip-refine-memory) — it opens as a change of subject and drops the
+  /// "start by asking" framing, so the assistant doesn't re-introduce itself
+  /// mid-thread. Canonical English throughout: this text goes to the agent.
+  String _buildSectionSeed(Trip trip, RefineTarget t,
+      {required bool continuing}) {
     final items = trip.items ?? [];
-    final b =
-        StringBuffer('I want to refine my saved trip "${_displayTitle(trip)}"');
-    if (trip.startDate != null && trip.endDate != null) {
+    final b = StringBuffer(continuing
+        ? "Let's turn to another part of the same trip"
+        : 'I want to refine my saved trip "${_displayTitle(trip)}"');
+    if (!continuing && trip.startDate != null && trip.endDate != null) {
       b.write(' (${trip.startDate} to ${trip.endDate})');
     }
     b.writeln('.');
@@ -1981,11 +2146,16 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
     }
     b.write(' and the COMPLETE updated list for the section, keeping unchanged '
         'places exactly as listed above (same coordinates and tags). ');
-    b.write(t.assistant
-        ? 'I may also just ask questions about the trip (flights, bookings, '
-            'timing) — answer those directly without changing anything. '
-            'Start by asking how you can help.'
-        : 'Start by asking what I want to change.');
+    if (t.assistant) {
+      b.write('I may also just ask questions about the trip (flights, '
+          'bookings, timing) — answer those directly without changing '
+          'anything. ');
+    }
+    b.write(continuing
+        ? 'Wait for what I want to change before editing anything.'
+        : (t.assistant
+            ? 'Start by asking how you can help.'
+            : 'Start by asking what I want to change.'));
     return b.toString();
   }
 
@@ -5601,24 +5771,60 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
       }
     });
 
+    // The trip-update listener lives HERE, not in TripRefinePanel: back closes
+    // the panel (see the PopScope below) and a turn keeps streaming after it,
+    // so a patch that lands once the panel is gone must still refresh the
+    // itinerary. Monotonic counter — see chat-panel-architecture.
+    ref.listen(
+        tripRefineProvider(widget.tripId).select((s) => s.tripUpdateCount),
+        (prev, next) {
+      if (mounted && next > (prev ?? 0)) _refresh();
+    });
+    // A turn still running behind a closed panel: the FAB says so, or an
+    // accidental back reads as "did that kill it?".
+    final chatStreaming = ref.watch(
+        tripRefineProvider(widget.tripId).select((s) => s.isStreaming));
+
     return LayoutBuilder(builder: (context, constraints) {
       // Same width the body LayoutBuilder sees (Scaffold adds no horizontal
       // chrome), so this always agrees with _mapPinned. Plain assignment:
       // we're in build, like _mapPinned's own write.
       _narrow = constraints.maxWidth < kRailBreakpoint;
-      return Scaffold(
+      return PopScope(
+        // Back closes the chat before it leaves the trip. The panel is drawn
+        // inside the screen rather than pushed as a route, and on narrow it
+        // looks like a sheet — so back is the obvious gesture for dismissing
+        // it, and used to throw away the whole page instead
+        // (specs/trip-refine-memory). Composes with AppShell's own
+        // PopScope(canPop: false), which forwards to this tab navigator's
+        // maybePop(); that consults the top route's PopScope, i.e. this one.
+        canPop: !_panelOpen,
+        onPopInvokedWithResult: (didPop, _) {
+          if (!didPop && _panelOpen) setState(() => _panelOpen = false);
+        },
+        child: Scaffold(
       // Always-reachable chat entry, mirroring the _openRefine guards so it's
       // never a dead button. Hidden while the panel is open: on wide layouts
       // the panel is docked (redundant), on narrow it would overlap the sheet.
+      //
+      // A saved conversation ALSO opens the gate: the zero-item plan_itinerary
+      // Next Step seeds a chat on an empty trip, so requiring items would make
+      // the saved chat unreachable on exactly the trips that most need it.
       floatingActionButton: (trip != null &&
               !_panelOpen &&
               trip.canEdit &&
               !_isOffline &&
-              (trip.items?.isNotEmpty ?? false))
+              ((trip.items?.isNotEmpty ?? false) || trip.refineChat != null))
           ? FloatingActionButton(
               tooltip: l10n.tripAskAI,
               onPressed: () => _openChat(trip),
-              child: const Icon(Icons.chat_bubble_outline),
+              child: chatStreaming
+                  ? const SizedBox(
+                      width: 20,
+                      height: 20,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : const Icon(Icons.chat_bubble_outline),
             )
           : null,
       appBar: GradientAppBar(
@@ -5699,9 +5905,8 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
                       // builder): the docked panel + divider eat 401px of this
                       // width, so the gutter must be computed from what the
                       // scroll view actually gets.
-                      final panelDocked = _panelOpen &&
-                          _refineTarget != null &&
-                          constraints.maxWidth >= 900;
+                      final panelDocked =
+                          _panelOpen && constraints.maxWidth >= 900;
                       final bodyWidth = panelDocked
                           ? constraints.maxWidth - 401
                           : constraints.maxWidth;
@@ -5802,6 +6007,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
                                 children: [
                                   _buildHeaderCard(trip, theme),
                                   _nextStepArea(trip),
+                                  _continueChatRow(trip, theme, l10n),
                                   const SizedBox(height: AppSpacing.lg),
                                 ],
                               ),
@@ -6170,14 +6376,40 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
                         );
                       }
 
-                      if (!_panelOpen || _refineTarget == null) {
+                      if (!_panelOpen) {
                         return refreshable;
                       }
-                      final panel = TripRefinePanel(
-                        tripId: widget.tripId,
-                        target: _refineTarget!,
-                        onClose: () => setState(() => _panelOpen = false),
-                        onTripUpdated: _refresh,
+                      // Escape is back's desktop twin: the panel is where focus
+                      // lives while chatting, so the binding rides it rather
+                      // than the whole screen (the map's own Escape layer is a
+                      // pushed route and never collides).
+                      final panel = CallbackShortcuts(
+                        bindings: {
+                          const SingleActivator(LogicalKeyboardKey.escape): () =>
+                              setState(() => _panelOpen = false),
+                        },
+                        // The binding only fires along the focus chain, and the
+                        // composer isn't focused until the traveler clicks it —
+                        // so the panel takes focus on open and every descendant
+                        // (composer included) still bubbles Escape up through
+                        // here. skipTraversal keeps it out of the tab order.
+                        child: Focus(
+                          autofocus: true,
+                          skipTraversal: true,
+                          child: TripRefinePanel(
+                            tripId: widget.tripId,
+                            phase: _chatPhase,
+                            error: _chatError,
+                            onClose: () => setState(() => _panelOpen = false),
+                            onNewChat: () => _newChat(trip),
+                            onRetry: _chatPhase == RefineChatPhase.failed
+                                ? () {
+                                    _chatResumeTried = false;
+                                    _ensureRefineHydrated(trip);
+                                  }
+                                : null,
+                          ),
+                        ),
                       );
                       if (panelDocked) {
                         // Wide: dock the chat beside the itinerary.
@@ -6239,6 +6471,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
                         ],
                       );
                     }),
+        ),
       );
     });
   }

--- a/src/packages/flutter-app/lib/services/trips_api_service.dart
+++ b/src/packages/flutter-app/lib/services/trips_api_service.dart
@@ -3,6 +3,7 @@ import '../models/import_trip_result.dart';
 import '../models/itinerary_item.dart';
 import '../models/shared_trip.dart';
 import '../models/trip.dart';
+import '../models/trip_refine_chat.dart';
 import 'api_client.dart';
 
 /// Wraps the authenticated /trips endpoints. Reads the bearer token from the
@@ -72,6 +73,25 @@ class TripsApiService {
   Future<Trip> getTrip(String id) async {
     final res = await apiClient.send('GET', '/trips/$id');
     return Trip.fromJson(jsonDecode(res.body));
+  }
+
+  /// This traveler's saved conversation about [tripId]
+  /// (specs/trip-refine-memory), in full.
+  ///
+  /// Deliberately goes through [ApiClient.send], which throws an
+  /// [ApiException] carrying the status: the panel has to tell "this
+  /// conversation is gone" (404 — say so and offer a new chat) from "we
+  /// couldn't reach it" (5xx/429/network — offer a retry), and a bare
+  /// `Exception('failed (404)')` cannot be classified.
+  Future<TripRefineChatDetail> getTripRefineChat(String tripId) async {
+    final res = await apiClient.send('GET', '/trips/$tripId/refine-chat');
+    return TripRefineChatDetail.fromJson(jsonDecode(res.body));
+  }
+
+  /// Discards this traveler's conversation about [tripId] ("New chat").
+  /// Idempotent server-side: succeeds whether or not one existed.
+  Future<void> deleteTripRefineChat(String tripId) async {
+    await apiClient.send('DELETE', '/trips/$tripId/refine-chat');
   }
 
   Future<Trip> patchTrip(

--- a/src/packages/flutter-app/lib/widgets/trip_refine_panel.dart
+++ b/src/packages/flutter-app/lib/widgets/trip_refine_panel.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../l10n/l10n.dart';
 import '../providers/plan_provider.dart';
+import '../utils/errors.dart';
 import 'chat_panel.dart';
 
 /// Which slice of the itinerary an AI refinement session targets. Mirrors the
@@ -54,32 +55,77 @@ class RefineTarget {
   }
 }
 
+/// Where the trip's saved conversation is in its restore
+/// (specs/trip-refine-memory). Owned by the host screen; the panel only draws
+/// it, so the two can never disagree about whether a composer should exist.
+enum RefineChatPhase {
+  /// Nothing to restore, or the restore finished — the chat is live.
+  ready,
+
+  /// Fetching the stored transcript. The composer is deliberately ABSENT, not
+  /// disabled: a message typed at 200 ms must not be sendable with no history
+  /// behind it, because the transcript is upserted wholesale and would
+  /// overwrite the stored conversation with one message.
+  restoring,
+
+  /// The conversation is gone (pruned with its trip, or already cleared).
+  /// Terminal — a retry would fail identically, so we only offer a new chat.
+  expired,
+
+  /// The restore failed for a reason that might not repeat.
+  failed,
+}
+
 /// The in-page AI refinement chat for one trip, shown beside (wide layouts) or
 /// over (bottom sheet) the trip detail page. Drives the per-trip
-/// [tripRefineProvider] session and calls [onTripUpdated] whenever the server
-/// reports the trip was patched in place, so the host screen can reload.
+/// [tripRefineProvider] session.
+///
+/// The host screen owns the trip-update listener: this panel can be closed
+/// mid-turn (back closes it since specs/trip-refine-memory), and a patch that
+/// lands afterwards must still refresh the itinerary.
 class TripRefinePanel extends ConsumerWidget {
   final String tripId;
-  final RefineTarget target;
+  final RefineChatPhase phase;
+
+  /// The failure behind [RefineChatPhase.failed], rendered via [friendlyError].
+  final Object? error;
   final VoidCallback onClose;
-  final VoidCallback onTripUpdated;
+  final VoidCallback onNewChat;
+  final VoidCallback? onRetry;
 
   const TripRefinePanel({
     super.key,
     required this.tripId,
-    required this.target,
     required this.onClose,
-    required this.onTripUpdated,
+    required this.onNewChat,
+    this.phase = RefineChatPhase.ready,
+    this.error,
+    this.onRetry,
   });
+
+  /// The newest context chip in the conversation — what the traveler last
+  /// pointed the chat at.
+  String? _newestChapter(WidgetRef ref) {
+    final messages = ref.watch(
+        tripRefineProvider(tripId).select((s) => s.messages));
+    for (final m in messages.reversed) {
+      final label = m.displayLabel;
+      if (label != null && label.isNotEmpty) return label;
+    }
+    return null;
+  }
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final theme = Theme.of(context);
     final l10n = context.l10n;
-    ref.listen(tripRefineProvider(tripId).select((s) => s.tripUpdateCount),
-        (prev, next) {
-      if (next > (prev ?? 0)) onTripUpdated();
-    });
+    // The header is a function of the transcript, never of screen state a
+    // gesture can destroy: a ✨ tap appends its own labeled seed, so the newest
+    // chapter is already correct by the time this builds.
+    final chapter = _newestChapter(ref);
+    final title = chapter ?? l10n.refineAssistantTitle;
+    final hasConversation = ref.watch(
+        tripRefineProvider(tripId).select((s) => s.messages.isNotEmpty));
 
     return Column(
       children: [
@@ -88,7 +134,7 @@ class TripRefinePanel extends ConsumerWidget {
           child: Row(
             children: [
               Icon(
-                target.assistant
+                chapter == null
                     ? Icons.chat_bubble_outline
                     : Icons.auto_awesome,
                 size: 18,
@@ -97,14 +143,20 @@ class TripRefinePanel extends ConsumerWidget {
               const SizedBox(width: 8),
               Expanded(
                 child: Text(
-                  target.assistant
-                      ? l10n.refineAssistantTitle
-                      : l10n.refineHeader(target.displayLabel(l10n)),
+                  title,
                   style: theme.textTheme.titleSmall
                       ?.copyWith(fontWeight: FontWeight.bold),
                   overflow: TextOverflow.ellipsis,
                 ),
               ),
+              // The only thing that discards a trip's conversation, now that no
+              // ✨ tap does.
+              if (phase == RefineChatPhase.ready && hasConversation)
+                IconButton(
+                  icon: const Icon(Icons.add_comment_outlined),
+                  tooltip: l10n.refineNewChat,
+                  onPressed: onNewChat,
+                ),
               IconButton(
                 icon: const Icon(Icons.close),
                 tooltip: l10n.commonClose,
@@ -114,16 +166,99 @@ class TripRefinePanel extends ConsumerWidget {
           ),
         ),
         const Divider(height: 1),
-        Expanded(
-          child: ChatPanel(
-            state: tripRefineProvider(tripId),
-            notifier: tripRefineProvider(tripId).notifier,
-            inputHint: target.assistant
-                ? l10n.refineAssistantHint
-                : l10n.refineHint,
-          ),
-        ),
+        Expanded(child: _body(context, l10n)),
       ],
+    );
+  }
+
+  Widget _body(BuildContext context, AppLocalizations l10n) {
+    switch (phase) {
+      case RefineChatPhase.restoring:
+        return Center(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const SizedBox(
+                  width: 24, height: 24, child: CircularProgressIndicator(strokeWidth: 2)),
+              const SizedBox(height: 12),
+              Text(l10n.refineResumeLoading,
+                  style: Theme.of(context).textTheme.bodySmall),
+            ],
+          ),
+        );
+      case RefineChatPhase.expired:
+        return _Problem(
+          icon: Icons.history_toggle_off,
+          title: l10n.refineResumeGone,
+          detail: l10n.refineResumeGoneDetail,
+          // No retry: the transcript is gone, so retrying fails identically.
+          actions: [
+            FilledButton(onPressed: onNewChat, child: Text(l10n.refineNewChat)),
+          ],
+        );
+      case RefineChatPhase.failed:
+        return _Problem(
+          icon: Icons.error_outline,
+          title: l10n.refineResumeFailed,
+          detail: friendlyError(l10n, error),
+          actions: [
+            if (onRetry != null)
+              FilledButton(onPressed: onRetry, child: Text(l10n.commonRetry)),
+            TextButton(onPressed: onNewChat, child: Text(l10n.refineNewChat)),
+          ],
+        );
+      case RefineChatPhase.ready:
+        return ChatPanel(
+          state: tripRefineProvider(tripId),
+          notifier: tripRefineProvider(tripId).notifier,
+          // One running conversation carries both jobs — questions and edits —
+          // so the open-ended hint is the honest one.
+          inputHint: l10n.refineAssistantHint,
+        );
+    }
+  }
+}
+
+class _Problem extends StatelessWidget {
+  final IconData icon;
+  final String title;
+  final String detail;
+  final List<Widget> actions;
+
+  const _Problem({
+    required this.icon,
+    required this.title,
+    required this.detail,
+    required this.actions,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    // Scrollable: on narrow the panel is a drag sheet that opens at 0.45 of
+    // the screen, which is shorter than this block — and an unreachable
+    // "New chat" button is the same dead end the state exists to escape.
+    return SingleChildScrollView(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(icon, color: theme.colorScheme.onSurfaceVariant),
+            const SizedBox(height: 12),
+            Text(title,
+                textAlign: TextAlign.center,
+                style: theme.textTheme.titleSmall),
+            const SizedBox(height: 4),
+            Text(detail,
+                textAlign: TextAlign.center,
+                style: theme.textTheme.bodySmall
+                    ?.copyWith(color: theme.colorScheme.onSurfaceVariant)),
+            const SizedBox(height: 16),
+            Wrap(spacing: 8, children: actions),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/src/packages/flutter-app/test/chat_panel_seed_chip_test.dart
+++ b/src/packages/flutter-app/test/chat_panel_seed_chip_test.dart
@@ -44,7 +44,7 @@ void main() {
 
     const seed = 'I want to refine my saved trip "Athens & Santorini". '
         '- Acropolis [attraction] (37.9715, 23.7257), city: Athens, day 1';
-    notifier.beginSectionRefinement(seed,
+    notifier.appendSectionRefinement(seed,
         displayLabel: 'Refining Day 1 — Athens');
 
     await tester.pumpWidget(

--- a/src/packages/flutter-app/test/plan_provider_refine_append_test.dart
+++ b/src/packages/flutter-app/test/plan_provider_refine_append_test.dart
@@ -1,0 +1,139 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:travel_route_planner/providers/plan_provider.dart';
+import 'package:travel_route_planner/services/api_client.dart';
+import 'package:travel_route_planner/services/plan_service.dart';
+
+/// appendSectionRefinement is what stopped a ✨ tap from wiping the trip's
+/// conversation (specs/trip-refine-memory). Two contracts here:
+///
+///  1. It appends. Nothing already said is removed.
+///  2. It collapses EARLIER seeds' itinerary listings in place, so the agent
+///     only ever holds one authoritative listing — and it rewrites content
+///     rather than removing messages, because compactedCount is a
+///     start-anchored index into `messages`.
+
+class _SilentPlanService extends PlanService {
+  final List<List<Map<String, dynamic>>> histories = [];
+  _SilentPlanService() : super('http://unused');
+
+  @override
+  Stream<PlanEvent> streamPlan(
+    List<Map<String, dynamic>> messages, {
+    String? bearerToken,
+    String? chatId,
+    String? tripId,
+    String? summary,
+    Future<void>? abortTrigger,
+  }) async* {
+    histories.add(messages);
+  }
+}
+
+const _daySeed = 'The section to refine — Day 3 — Medellín:\n'
+    '- Comuna 13 [attraction] (6.24, -75.57), city: Medellín, day 3';
+const _citySeed = 'The section to refine — Cartagena:\n'
+    '- Getsemaní [attraction] (10.42, -75.55), city: Cartagena, day 5';
+
+void main() {
+  test('appending a section keeps the conversation and adds exactly one message',
+      () async {
+    final service = _SilentPlanService();
+    final notifier = PlanNotifier(service, ApiClient(), tripId: 't1');
+
+    notifier.appendSectionRefinement(_daySeed,
+        displayLabel: 'Refining Day 3 — Medellín');
+    await Future<void>.delayed(Duration.zero);
+    notifier.appendSectionRefinement(_citySeed,
+        displayLabel: 'Refining Cartagena');
+    await Future<void>.delayed(Duration.zero);
+
+    final messages = notifier.state.messages;
+    expect(messages, hasLength(2));
+    expect(messages.first.displayLabel, 'Refining Day 3 — Medellín');
+    expect(messages.last.displayLabel, 'Refining Cartagena');
+  });
+
+  test('an appended seed supersedes the earlier listing, in place', () async {
+    final service = _SilentPlanService();
+    final notifier = PlanNotifier(service, ApiClient(), tripId: 't1');
+
+    notifier.appendSectionRefinement(_daySeed,
+        displayLabel: 'Refining Day 3 — Medellín');
+    await Future<void>.delayed(Duration.zero);
+    notifier.appendSectionRefinement(_citySeed,
+        displayLabel: 'Refining Cartagena');
+    await Future<void>.delayed(Duration.zero);
+
+    final messages = notifier.state.messages;
+    // The stale coordinates are gone from the wire…
+    expect(messages.first.content, isNot(contains('Comuna 13')));
+    expect(messages.first.content, contains('superseded'));
+    // …while the chip the reader sees is untouched.
+    expect(messages.first.displayLabel, 'Refining Day 3 — Medellín');
+    // Only the newest listing survives, and it says the older ones are stale.
+    expect(messages.last.content, contains('Getsemaní'));
+    expect(messages.last.content, contains('Ignore any earlier itinerary'));
+
+    // What the model actually received on the second turn.
+    final sent = service.histories.last;
+    expect(sent, hasLength(2));
+    expect(sent.first['content'], isNot(contains('Comuna 13')));
+    expect(sent.last['content'], contains('Getsemaní'));
+  });
+
+  test('ordinary user messages are never stubbed', () async {
+    final service = _SilentPlanService();
+    final notifier = PlanNotifier(service, ApiClient(), tripId: 't1');
+
+    notifier.appendSectionRefinement(_daySeed,
+        displayLabel: 'Refining Day 3 — Medellín');
+    await Future<void>.delayed(Duration.zero);
+    notifier.sendMessage('swap the museum for something outdoors');
+    await Future<void>.delayed(Duration.zero);
+    notifier.appendSectionRefinement(_citySeed,
+        displayLabel: 'Refining Cartagena');
+    await Future<void>.delayed(Duration.zero);
+
+    final messages = notifier.state.messages;
+    expect(messages, hasLength(3));
+    // A real thing the traveler said keeps its words, forever.
+    expect(messages[1].content, 'swap the museum for something outdoors');
+    expect(messages[1].displayLabel, isNull);
+    // Indices are preserved — compactedCount counts from the start.
+    expect(messages[0].displayLabel, 'Refining Day 3 — Medellín');
+    expect(messages[2].displayLabel, 'Refining Cartagena');
+  });
+
+  test('stubbing is idempotent — an already-superseded seed is left alone',
+      () async {
+    final service = _SilentPlanService();
+    final notifier = PlanNotifier(service, ApiClient(), tripId: 't1');
+
+    notifier.appendSectionRefinement(_daySeed,
+        displayLabel: 'Refining Day 3 — Medellín');
+    await Future<void>.delayed(Duration.zero);
+    notifier.appendSectionRefinement(_citySeed, displayLabel: 'Refining Cartagena');
+    await Future<void>.delayed(Duration.zero);
+    final stubbed = notifier.state.messages.first.content;
+    notifier.appendSectionRefinement('third', displayLabel: 'Refining Day 1');
+    await Future<void>.delayed(Duration.zero);
+
+    expect(notifier.state.messages.first.content, stubbed);
+    expect(notifier.state.messages, hasLength(3));
+  });
+
+  test('startOver drops the transcript and the chat id', () async {
+    final service = _SilentPlanService();
+    final notifier = PlanNotifier(service, ApiClient(), tripId: 't1');
+
+    notifier.appendSectionRefinement(_daySeed, displayLabel: 'Refining Day 3');
+    await Future<void>.delayed(Duration.zero);
+    expect(notifier.state.messages, isNotEmpty);
+
+    notifier.startOver();
+
+    expect(notifier.state.messages, isEmpty);
+    expect(notifier.state.chatId, isNull);
+  });
+}

--- a/src/packages/flutter-app/test/trip_detail_chat_back_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_chat_back_test.dart
@@ -1,0 +1,298 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:travel_route_planner/models/itinerary_item.dart';
+import 'package:travel_route_planner/models/trip.dart';
+import 'package:travel_route_planner/providers/plan_provider.dart';
+import 'package:travel_route_planner/providers/trips_provider.dart';
+import 'package:travel_route_planner/services/api_client.dart';
+import 'package:travel_route_planner/services/plan_service.dart';
+import 'package:travel_route_planner/services/trips_api_service.dart';
+import 'package:travel_route_planner/screens/trip_detail_screen.dart';
+import 'package:travel_route_planner/widgets/trip_refine_panel.dart';
+
+import 'support/l10n_test_app.dart';
+
+/// Back closes the trip's chat before it leaves the trip
+/// (specs/trip-refine-memory). The panel is drawn inside the screen rather
+/// than pushed as a route, so before this back threw away the whole page —
+/// the reported friction.
+
+class _FakeTripsApiService extends TripsApiService {
+  final Trip trip;
+  int getTripCalls = 0;
+  _FakeTripsApiService(this.trip) : super(ApiClient(baseUrl: 'http://test'));
+
+  @override
+  Future<Trip> getTrip(String id) async {
+    getTripCalls++;
+    return trip;
+  }
+}
+
+/// Emits [events], then waits on [gate] before emitting [tailEvents] — so a
+/// test can press back mid-turn and let the rest of the stream land afterwards.
+/// Never completing [gate] leaves the turn hanging in flight.
+class _ScriptedPlanService extends PlanService {
+  final List<PlanEvent> events;
+  final Completer<void>? gate;
+  final List<PlanEvent> tailEvents;
+
+  _ScriptedPlanService(this.events, {this.gate, this.tailEvents = const []})
+      : super('http://unused');
+
+  @override
+  Stream<PlanEvent> streamPlan(
+    List<Map<String, dynamic>> messages, {
+    String? bearerToken,
+    String? chatId,
+    String? tripId,
+    String? summary,
+    Future<void>? abortTrigger,
+  }) async* {
+    for (final e in events) {
+      yield e;
+    }
+    if (gate != null) {
+      await gate!.future;
+      for (final e in tailEvents) {
+        yield e;
+      }
+    }
+  }
+}
+
+ItineraryItem _item(int pos, String name, {int? day, String? city}) =>
+    ItineraryItem(
+      id: 'i$pos',
+      position: pos,
+      name: name,
+      address: '$city, Colombia',
+      latitude: 0,
+      longitude: 0,
+      category: 'attraction',
+      day: day,
+      city: city,
+    );
+
+Trip _trip() => Trip(
+      id: 't1',
+      title: 'Colombia Hop',
+      startDate: '2026-08-01',
+      endDate: '2026-08-05',
+      createdAt: '2026-07-01',
+      updatedAt: '2026-07-01',
+      items: [
+        _item(0, 'Johnny Cay', day: 1, city: 'San Andrés'),
+        _item(1, 'Comuna 13', day: 3, city: 'Medellín'),
+      ],
+    );
+
+const _homeKey = Key('home-placeholder');
+
+/// Pushes the trip over a placeholder home, so a real pop is observable.
+Widget _app(
+  _FakeTripsApiService api, {
+  List<PlanEvent> events = const [],
+  Completer<void>? gate,
+  List<PlanEvent> tailEvents = const [],
+}) =>
+    ProviderScope(
+      overrides: [
+        tripsApiServiceProvider.overrideWithValue(api),
+        tripRefineProvider.overrideWith((ref, tripId) => PlanNotifier(
+            _ScriptedPlanService(events, gate: gate, tailEvents: tailEvents),
+            ApiClient(),
+            tripId: tripId)),
+      ],
+      child: MaterialApp(
+        localizationsDelegates: testLocalizationsDelegates,
+        home: Builder(
+          builder: (context) => Scaffold(
+            key: _homeKey,
+            body: Center(
+              child: ElevatedButton(
+                onPressed: () => Navigator.of(context).push(MaterialPageRoute(
+                    builder: (_) => const TripDetailScreen(tripId: 't1'))),
+                child: const Text('open trip'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+Future<void> _openTripAndChat(WidgetTester tester) async {
+  await tester.tap(find.text('open trip'));
+  await tester.pumpAndSettle();
+  await tester.tap(find.byType(FloatingActionButton));
+  await tester.pumpAndSettle();
+  expect(find.byType(TripRefinePanel), findsOneWidget);
+}
+
+Future<bool> _back(WidgetTester tester) =>
+    tester.state<NavigatorState>(find.byType(Navigator)).maybePop();
+
+PlanState _refineState(WidgetTester tester) =>
+    ProviderScope.containerOf(tester.element(find.byType(TripDetailScreen)))
+        .read(tripRefineProvider('t1'));
+
+void main() {
+  testWidgets('back closes the chat panel and keeps the trip on screen',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(_app(_FakeTripsApiService(_trip())));
+    await tester.pumpAndSettle();
+    await _openTripAndChat(tester);
+    final seeded = _refineState(tester).messages.length;
+    expect(seeded, greaterThan(0));
+
+    expect(await _back(tester), isTrue);
+    await tester.pumpAndSettle();
+
+    expect(find.byType(TripRefinePanel), findsNothing);
+    expect(find.byType(TripDetailScreen), findsOneWidget);
+    // The conversation is untouched — closing is not discarding.
+    expect(_refineState(tester).messages.length, seeded);
+  });
+
+  testWidgets('a second back leaves the trip, conversation intact',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(_app(_FakeTripsApiService(_trip())));
+    await tester.pumpAndSettle();
+    await _openTripAndChat(tester);
+    final container =
+        ProviderScope.containerOf(tester.element(find.byType(TripDetailScreen)));
+    final seeded = container.read(tripRefineProvider('t1')).messages.length;
+
+    expect(await _back(tester), isTrue);
+    await tester.pumpAndSettle();
+    expect(await _back(tester), isTrue);
+    await tester.pumpAndSettle();
+
+    expect(find.byType(TripDetailScreen), findsNothing);
+    expect(find.byKey(_homeKey), findsOneWidget);
+    // keepAlive family: leaving the page does not drop the conversation.
+    expect(container.read(tripRefineProvider('t1')).messages.length, seeded);
+  });
+
+  testWidgets('the app-bar back arrow closes the panel before the screen',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(_app(_FakeTripsApiService(_trip())));
+    await tester.pumpAndSettle();
+    await _openTripAndChat(tester);
+
+    await tester.tap(find.byType(BackButton));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(TripRefinePanel), findsNothing);
+    expect(find.byType(TripDetailScreen), findsOneWidget);
+  });
+
+  testWidgets('back closes the docked panel exactly like the sheet',
+      (WidgetTester tester) async {
+    tester.view.physicalSize = const Size(1400, 1000);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+
+    await tester.pumpWidget(_app(_FakeTripsApiService(_trip())));
+    await tester.pumpAndSettle();
+    await _openTripAndChat(tester);
+    expect(find.byType(VerticalDivider), findsOneWidget); // docked
+
+    expect(await _back(tester), isTrue);
+    await tester.pumpAndSettle();
+
+    expect(find.byType(TripRefinePanel), findsNothing);
+    expect(find.byType(VerticalDivider), findsNothing);
+    expect(find.byType(TripDetailScreen), findsOneWidget);
+  });
+
+  testWidgets('back mid-stream closes the panel without aborting the turn',
+      (WidgetTester tester) async {
+    final gate = Completer<void>();
+    await tester.pumpWidget(_app(
+      _FakeTripsApiService(_trip()),
+      events: const [
+        PlanEvent(type: 'text_delta', data: {'text': 'Working'})
+      ],
+      gate: gate,
+    ));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('open trip'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byType(FloatingActionButton));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+
+    expect(_refineState(tester).isStreaming, isTrue);
+    expect(await _back(tester), isTrue);
+    await tester.pump();
+
+    expect(find.byType(TripRefinePanel), findsNothing);
+    // Still running behind the closed panel, and the FAB says so — otherwise
+    // an accidental back reads as "did that kill it?".
+    expect(_refineState(tester).isStreaming, isTrue);
+    expect(
+        find.descendant(
+            of: find.byType(FloatingActionButton),
+            matching: find.byType(CircularProgressIndicator)),
+        findsOneWidget);
+
+    gate.complete();
+    await tester.pumpAndSettle();
+  });
+
+  testWidgets('a trip_updated landing after the panel closed still refreshes',
+      (WidgetTester tester) async {
+    // The listener used to live inside TripRefinePanel; closing the panel
+    // mid-turn would then have silently dropped the reload, and the itinerary
+    // would sit there stale after an edit the agent really made.
+    final gate = Completer<void>();
+    final api = _FakeTripsApiService(_trip());
+    await tester.pumpWidget(_app(
+      api,
+      events: const [
+        PlanEvent(type: 'text_delta', data: {'text': 'On it'})
+      ],
+      gate: gate,
+      tailEvents: const [
+        PlanEvent(type: 'trip_updated', data: {'trip_id': 't1'})
+      ],
+    ));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('open trip'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byType(FloatingActionButton));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+
+    expect(await _back(tester), isTrue);
+    // pump, not pumpAndSettle: the turn is still in flight, so the FAB's
+    // progress indicator never settles.
+    await tester.pump();
+    final before = api.getTripCalls;
+
+    // The patch lands with the panel already gone.
+    gate.complete();
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+
+    expect(api.getTripCalls, greaterThan(before));
+  });
+
+  testWidgets('Escape closes the panel', (WidgetTester tester) async {
+    await tester.pumpWidget(_app(_FakeTripsApiService(_trip())));
+    await tester.pumpAndSettle();
+    await _openTripAndChat(tester);
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.escape);
+    await tester.pumpAndSettle();
+
+    expect(find.byType(TripRefinePanel), findsNothing);
+    expect(find.byType(TripDetailScreen), findsOneWidget);
+  });
+}

--- a/src/packages/flutter-app/test/trip_detail_refine_append_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_refine_append_test.dart
@@ -1,0 +1,150 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:travel_route_planner/models/itinerary_item.dart';
+import 'package:travel_route_planner/models/trip.dart';
+import 'package:travel_route_planner/providers/plan_provider.dart';
+import 'package:travel_route_planner/providers/trips_provider.dart';
+import 'package:travel_route_planner/services/api_client.dart';
+import 'package:travel_route_planner/services/plan_service.dart';
+import 'package:travel_route_planner/services/trips_api_service.dart';
+import 'package:travel_route_planner/screens/trip_detail_screen.dart';
+
+import 'support/l10n_test_app.dart';
+
+/// A ✨ tap is a change of subject, not a new chat (specs/trip-refine-memory).
+/// Before this, every refine entry point but the FAB called reset() first —
+/// which is how a conversation vanished when the traveler went back in through
+/// the button they had used to start it.
+
+class _FakeTripsApiService extends TripsApiService {
+  final Trip trip;
+  _FakeTripsApiService(this.trip) : super(ApiClient(baseUrl: 'http://test'));
+
+  @override
+  Future<Trip> getTrip(String id) async => trip;
+}
+
+class _SilentPlanService extends PlanService {
+  _SilentPlanService() : super('http://unused');
+
+  @override
+  Stream<PlanEvent> streamPlan(
+    List<Map<String, dynamic>> messages, {
+    String? bearerToken,
+    String? chatId,
+    String? tripId,
+    String? summary,
+    Future<void>? abortTrigger,
+  }) async* {}
+}
+
+ItineraryItem _item(int pos, String name, {int? day, String? city}) =>
+    ItineraryItem(
+      id: 'i$pos',
+      position: pos,
+      name: name,
+      address: '$city, Colombia',
+      latitude: 0,
+      longitude: 0,
+      category: 'attraction',
+      day: day,
+      city: city,
+    );
+
+Trip _trip() => Trip(
+      id: 't1',
+      title: 'Colombia Hop',
+      startDate: '2026-08-01',
+      endDate: '2026-08-05',
+      createdAt: '2026-07-01',
+      updatedAt: '2026-07-01',
+      items: [
+        _item(0, 'Johnny Cay', day: 1, city: 'San Andrés'),
+        _item(1, 'Comuna 13', day: 3, city: 'Medellín'),
+      ],
+    );
+
+Widget _app() => ProviderScope(
+      overrides: [
+        tripsApiServiceProvider
+            .overrideWithValue(_FakeTripsApiService(_trip())),
+        tripRefineProvider.overrideWith((ref, tripId) =>
+            PlanNotifier(_SilentPlanService(), ApiClient(), tripId: tripId)),
+      ],
+      child: MaterialApp(
+        localizationsDelegates: testLocalizationsDelegates,
+        home: const TripDetailScreen(tripId: 't1'),
+      ),
+    );
+
+PlanState _refineState(WidgetTester tester) =>
+    ProviderScope.containerOf(tester.element(find.byType(TripDetailScreen)))
+        .read(tripRefineProvider('t1'));
+
+void main() {
+  testWidgets('Refine with AI continues the conversation instead of resetting',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(_app());
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byType(FloatingActionButton));
+    await tester.pumpAndSettle();
+    expect(_refineState(tester).messages, hasLength(1));
+
+    await tester.tap(find.byTooltip('Close'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Refine with AI'));
+    await tester.pumpAndSettle();
+
+    final messages = _refineState(tester).messages;
+    expect(messages, hasLength(2),
+        reason: 'the ✨ must append a chapter, not replace the conversation');
+    expect(messages.first.displayLabel, isNotNull);
+    expect(messages.last.displayLabel, isNotNull);
+  });
+
+  testWidgets('the appended seed supersedes the earlier itinerary listing',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(_app());
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byType(FloatingActionButton));
+    await tester.pumpAndSettle();
+    expect(_refineState(tester).messages.first.content, contains('Comuna 13'));
+
+    await tester.tap(find.byTooltip('Close'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Refine with AI'));
+    await tester.pumpAndSettle();
+
+    final messages = _refineState(tester).messages;
+    // Exactly one authoritative listing is in play.
+    expect(messages.first.content, isNot(contains('Comuna 13')));
+    expect(messages.first.content, contains('superseded'));
+    expect(messages.last.content, contains('Comuna 13'));
+    // …and it opens as a change of subject, not a fresh introduction.
+    expect(messages.last.content, contains('another part of the same trip'));
+    expect(messages.last.content, isNot(contains('Start by asking')));
+  });
+
+  testWidgets('the panel header follows the newest context chip',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(_app());
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byType(FloatingActionButton));
+    await tester.pumpAndSettle();
+    expect(find.text('Trip assistant'), findsWidgets);
+
+    await tester.tap(find.byTooltip('Close'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Refine with AI'));
+    await tester.pumpAndSettle();
+
+    // The header is derived, so it is right even though no screen field holds
+    // the target any more.
+    expect(find.text('Refining Whole trip'), findsWidgets);
+  });
+}

--- a/src/packages/flutter-app/test/trip_detail_resume_chat_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_resume_chat_test.dart
@@ -1,0 +1,318 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:travel_route_planner/models/chat_session.dart';
+import 'package:travel_route_planner/models/itinerary_item.dart';
+import 'package:travel_route_planner/models/trip.dart';
+import 'package:travel_route_planner/models/trip_refine_chat.dart';
+import 'package:travel_route_planner/providers/plan_provider.dart';
+import 'package:travel_route_planner/providers/trips_provider.dart';
+import 'package:travel_route_planner/services/api_client.dart';
+import 'package:travel_route_planner/services/plan_service.dart';
+import 'package:travel_route_planner/services/trips_api_service.dart';
+import 'package:travel_route_planner/screens/trip_detail_screen.dart';
+import 'package:travel_route_planner/widgets/chat_panel.dart';
+
+import 'support/l10n_test_app.dart';
+
+/// Coming back to a trip's conversation after a reload
+/// (specs/trip-refine-memory): the page says one is waiting, opening it
+/// restores the transcript, and every failure is answered where the traveler
+/// asked — in the panel — never as a snackbar over the itinerary.
+
+class _FakeTripsApiService extends TripsApiService {
+  final Trip trip;
+  final TripRefineChatDetail? detail;
+  final Object? failWith;
+
+  /// Gates the fetch so a test can inspect the loading state.
+  final Completer<void>? gate;
+
+  int getChatCalls = 0;
+  int deleteCalls = 0;
+
+  _FakeTripsApiService(this.trip, {this.detail, this.failWith, this.gate})
+      : super(ApiClient(baseUrl: 'http://test'));
+
+  @override
+  Future<Trip> getTrip(String id) async => trip;
+
+  @override
+  Future<TripRefineChatDetail> getTripRefineChat(String tripId) async {
+    getChatCalls++;
+    if (gate != null) await gate!.future;
+    final e = failWith;
+    if (e != null) throw e;
+    return detail!;
+  }
+
+  @override
+  Future<void> deleteTripRefineChat(String tripId) async {
+    deleteCalls++;
+  }
+}
+
+class _SilentPlanService extends PlanService {
+  _SilentPlanService() : super('http://unused');
+
+  @override
+  Stream<PlanEvent> streamPlan(
+    List<Map<String, dynamic>> messages, {
+    String? bearerToken,
+    String? chatId,
+    String? tripId,
+    String? summary,
+    Future<void>? abortTrigger,
+  }) async* {}
+}
+
+ItineraryItem _item(int pos, String name, {int? day, String? city}) =>
+    ItineraryItem(
+      id: 'i$pos',
+      position: pos,
+      name: name,
+      address: '$city, Greece',
+      latitude: 0,
+      longitude: 0,
+      category: 'attraction',
+      day: day,
+      city: city,
+    );
+
+Trip _trip({TripRefineChat? chat, bool withItems = true}) => Trip(
+      id: 't1',
+      title: 'Greek Islands',
+      startDate: '2026-08-01',
+      endDate: '2026-08-05',
+      createdAt: '2026-07-01',
+      updatedAt: '2026-07-01',
+      refineChat: chat,
+      items: withItems
+          ? [
+              _item(0, 'Acropolis', day: 1, city: 'Athens'),
+              _item(1, 'Portara', day: 2, city: 'Naxos'),
+            ]
+          : const [],
+    );
+
+TripRefineChat _summary({int count = 4}) => TripRefineChat(
+      messageCount: count,
+      preview: 'Naxos then Paros.',
+      updatedAt: '2026-07-30T10:00:00Z',
+    );
+
+TripRefineChatDetail _detail() => const TripRefineChatDetail(
+      tripId: 't1',
+      summary: '',
+      messages: [
+        ChatSessionMessage(
+            role: 'user',
+            content: 'I want to refine my saved trip … latitude 37.9 …',
+            displayLabel: 'Refining Day 2 — Athens'),
+        ChatSessionMessage(role: 'assistant', content: 'Naxos then Paros.'),
+      ],
+      messageCount: 2,
+      updatedAt: '2026-07-30T10:00:00Z',
+    );
+
+Widget _app(_FakeTripsApiService api) => ProviderScope(
+      overrides: [
+        tripsApiServiceProvider.overrideWithValue(api),
+        tripRefineProvider.overrideWith((ref, tripId) =>
+            PlanNotifier(_SilentPlanService(), ApiClient(), tripId: tripId)),
+      ],
+      child: MaterialApp(
+        localizationsDelegates: testLocalizationsDelegates,
+        home: const TripDetailScreen(tripId: 't1'),
+      ),
+    );
+
+PlanState _refineState(WidgetTester tester) =>
+    ProviderScope.containerOf(tester.element(find.byType(TripDetailScreen)))
+        .read(tripRefineProvider('t1'));
+
+void main() {
+  testWidgets('a trip with a saved conversation says so on the page',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(
+        _app(_FakeTripsApiService(_trip(chat: _summary()), detail: _detail())));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Continue chat'), findsOneWidget);
+    expect(find.text('Naxos then Paros.'), findsOneWidget);
+  });
+
+  testWidgets('no saved conversation, no row', (WidgetTester tester) async {
+    await tester.pumpWidget(_app(_FakeTripsApiService(_trip())));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Continue chat'), findsNothing);
+  });
+
+  testWidgets('the chat is reachable on a trip with no places yet',
+      (WidgetTester tester) async {
+    // The zero-item plan_itinerary Next Step seeds a chat on an empty trip, so
+    // gating the FAB on items would strand the saved conversation on exactly
+    // the trips that most need it.
+    await tester.pumpWidget(_app(_FakeTripsApiService(
+        _trip(chat: _summary(), withItems: false),
+        detail: _detail())));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(FloatingActionButton), findsOneWidget);
+    expect(find.text('Continue chat'), findsOneWidget);
+  });
+
+  testWidgets('restoring shows the placeholder, then the transcript',
+      (WidgetTester tester) async {
+    final gate = Completer<void>();
+    final api = _FakeTripsApiService(_trip(chat: _summary()),
+        detail: _detail(), gate: gate);
+    await tester.pumpWidget(_app(api));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Continue chat'));
+    await tester.pump();
+
+    expect(find.text('Restoring your conversation…'), findsOneWidget);
+    // No composer until the history is back: sending onto an empty panel would
+    // overwrite the stored conversation.
+    expect(find.byType(ChatPanel), findsNothing);
+
+    gate.complete();
+    await tester.pumpAndSettle();
+
+    expect(find.byType(ChatPanel), findsOneWidget);
+    expect(_refineState(tester).messages, hasLength(2));
+    // The seed renders as its chip, not as a wall of coordinates.
+    expect(find.text('Refining Day 2 — Athens'), findsWidgets);
+    expect(find.textContaining('latitude 37.9'), findsNothing);
+  });
+
+  testWidgets('an expired conversation is reported in the panel, with no retry',
+      (WidgetTester tester) async {
+    final api = _FakeTripsApiService(
+      _trip(chat: _summary()),
+      failWith: const ApiException(
+          statusCode: 404, message: 'gone', endpoint: '/trips/t1/refine-chat'),
+    );
+    await tester.pumpWidget(_app(api));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Continue chat'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('This conversation has expired.'), findsOneWidget);
+    expect(find.byType(SnackBar), findsNothing);
+    expect(find.text('Retry'), findsNothing);
+    expect(find.text('New chat'), findsOneWidget);
+    // Nothing was sent into the empty panel.
+    expect(_refineState(tester).messages, isEmpty);
+  });
+
+  testWidgets('a failed restore offers a retry that actually refetches',
+      (WidgetTester tester) async {
+    final api = _FakeTripsApiService(
+      _trip(chat: _summary()),
+      failWith: const ApiException(
+          statusCode: 500, message: 'boom', endpoint: '/trips/t1/refine-chat'),
+    );
+    await tester.pumpWidget(_app(api));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Continue chat'));
+    await tester.pumpAndSettle();
+
+    expect(find.text("Couldn't reopen this conversation."), findsOneWidget);
+    expect(find.byType(SnackBar), findsNothing);
+    expect(api.getChatCalls, 1);
+
+    // The failure block scrolls inside the narrow sheet (it is taller than the
+    // 0.45 opening height), so bring the action into view like a traveler
+    // dragging the sheet would.
+    await tester.ensureVisible(find.text('Retry'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Retry'));
+    await tester.pumpAndSettle();
+    expect(api.getChatCalls, 2);
+  });
+
+  testWidgets('a failed restore blocks the ✨ from sending onto an empty panel',
+      (WidgetTester tester) async {
+    // The load-bearing guard. The transcript is upserted wholesale every turn,
+    // so seeding a panel that failed to restore would overwrite a long stored
+    // conversation with two messages.
+    final api = _FakeTripsApiService(
+      _trip(chat: _summary()),
+      failWith: const ApiException(
+          statusCode: 500, message: 'boom', endpoint: '/trips/t1/refine-chat'),
+    );
+    await tester.pumpWidget(_app(api));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Continue chat'));
+    await tester.pumpAndSettle();
+    expect(find.text("Couldn't reopen this conversation."), findsOneWidget);
+
+    await tester.tap(find.byTooltip('Close'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Refine with AI'));
+    await tester.pumpAndSettle();
+
+    expect(_refineState(tester).messages, isEmpty,
+        reason: 'nothing may be sent until the stored transcript is back');
+  });
+
+  testWidgets('an in-memory conversation reopens without a fetch',
+      (WidgetTester tester) async {
+    final api =
+        _FakeTripsApiService(_trip(chat: _summary()), detail: _detail());
+    await tester.pumpWidget(_app(api));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Continue chat'));
+    await tester.pumpAndSettle();
+    expect(api.getChatCalls, 1);
+
+    await tester.tap(find.byTooltip('Close'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byType(FloatingActionButton));
+    await tester.pumpAndSettle();
+
+    // Memory beats server: refetching would discard anything mid-stream.
+    expect(api.getChatCalls, 1);
+    expect(_refineState(tester).messages, hasLength(2));
+  });
+
+  testWidgets('New chat clears the conversation only after confirmation',
+      (WidgetTester tester) async {
+    final api =
+        _FakeTripsApiService(_trip(chat: _summary()), detail: _detail());
+    await tester.pumpWidget(_app(api));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Continue chat'));
+    await tester.pumpAndSettle();
+    expect(_refineState(tester).messages, hasLength(2));
+
+    await tester.tap(find.byTooltip('New chat'));
+    await tester.pumpAndSettle();
+    expect(find.text('Start a new chat?'), findsOneWidget);
+
+    await tester.tap(find.text('Cancel'));
+    await tester.pumpAndSettle();
+    expect(_refineState(tester).messages, hasLength(2));
+    expect(api.deleteCalls, 0);
+
+    await tester.tap(find.byTooltip('New chat'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.widgetWithText(FilledButton, 'New chat'));
+    await tester.pumpAndSettle();
+
+    expect(_refineState(tester).messages, isEmpty);
+    expect(api.deleteCalls, 1);
+  });
+}

--- a/src/packages/flutter-app/test/url_plan_chat_test.dart
+++ b/src/packages/flutter-app/test/url_plan_chat_test.dart
@@ -20,7 +20,12 @@ import 'support/url_sync_fakes.dart';
 /// /plan/<chatId> (specs/url-page-persistence): the Plan tab's URL carries
 /// the conversation id once one exists, and booting on it rehydrates the
 /// transcript — with a silent fresh-chat fallback when there is nothing to
-/// restore (trip-bound, foreign, or expired ids).
+/// restore (foreign or expired ids).
+///
+/// A trip's own conversation can never be named here: since
+/// specs/trip-refine-memory it lives in its own table keyed by (traveler,
+/// trip) and has no chat id at all, so this URL has nothing to point at and
+/// the refine panel stays deliberately absent from the address bar.
 class _FakeChatsApiService extends ChatsApiService {
   final ChatSessionDetail? detail;
 


### PR DESCRIPTION
## Summary

Friction (2026-08-15): *"when editing a trip via the chat, should keep track of the last chat for the trip so you can go back to it. I've accidentally clicked the back button and had to restart a chat **several times**."*

One complaint, **three independent causes** — only one of them the back button:

1. **Back left the page.** The refine panel is drawn *inside* trip detail (`_panelOpen` is widget state, not a route) and the screen had no `PopScope`. On narrow it renders as a drag sheet, so back is the obvious dismiss gesture — and it threw away the whole page.
2. **Five of the six ways back in destroyed the conversation.** Every ✨ entry (header chip, app-bar sparkle, per-day, per-city, Next Step) went through `beginSectionRefinement`, which called `reset()` first. Only the 💬 FAB reopened what was there, and it's hidden while the panel is open — so going back in through the button you started with was the one gesture guaranteed to wipe it.
3. **It was never saved.** `persistSession` required `boundTripID == nil`, so a trip-bound turn wrote nothing; a refresh or deploy lost it regardless.

A trip now has **one running conversation**, stored for as long as the trip exists, advertised on the page, and discarded only when the traveler explicitly asks.

### What changed

- **Back / Escape close the chat**, never the page. A turn in flight keeps running and the FAB shows it.
- **✨ appends a chapter** instead of resetting; **New chat** (with a confirm) is the only thing that discards.
- **`trip_refine_sessions`** (migration **00066**) — its own table, not a nullable `trip_id` on `plan_chat_sessions`. `UNIQUE (user_id, trip_id)` *is* the product rule, and a refine transcript then has **no chat id anywhere**, so `GET /chats/{id}` and `/plan/<id>` structurally cannot reach it and can never rehydrate it into the unbound Agent tab (where the trip binding would silently vanish). Reusing `trips.chat_id` would have been worse than untidy: that key already owns the `plan_chat_sessions` row of the chat that *created* the trip, so refine turns would have upserted over the original planning transcript. Retention is the trip (`ON DELETE CASCADE`), not the 60-day idle prune.
- **`GET /trips/{id}` carries `refine_chat`** — presence + freshness, per-caller, deliberately carrying no identifier. New `GET`/`DELETE /trips/{id}/refine-chat`; the DELETE is idempotent and states its post-state (documented divergence from `DELETE /chats/{chatId}`).
- **Freshness:** the bound prompt now requires `get_trip` before any edit, because a conversation you can resume days later has a stale opening description and `update_itinerary_section` takes the COMPLETE list. That surfaced a live bug — `get_trip` with no `trip_id` listed the *caller's own* trips, which for a collaborator never contained the trip being refined.
- **Seed stubbing:** now that ✨ appends, each new seed collapses earlier ones' itinerary listings — in place, never removing a message (`compactedCount` is a start-anchored index) — so exactly one authoritative listing is ever in context.
- Owner and each editor co-planner keep **their own** conversation; a revoked collaborator loses access without it being destroyed.

### Fixed on the way

- The `trip_updated` → reload listener moved from the panel to the screen. Back can now close the panel mid-turn, and a patch landing afterwards would otherwise never have been picked up — the itinerary would sit stale after an edit the agent really made.
- The panel's error state was taller than the narrow sheet, so its "New chat" button was unreachable — an escape hatch you can't tap.
- The FAB's `items.isNotEmpty` gate would have stranded the saved chat on zero-item trips (the `plan_itinerary` Next Step seeds a chat on exactly those).
- A hole this PR's own test caught: after a *failed* restore the "already tried" short-circuit let ✨ through, which would have upserted a two-message transcript over the stored conversation.

Specs amended: `continue-where-you-left-off`, `collaborator-refine`, `refine-panel-polish`, `url-page-persistence`, `conversation-compaction`. New spec: `specs/trip-refine-memory`.

## Testing

- `gofmt -l` clean, `go vet ./...` clean.
- **Full Go suite against a real Postgres** (lane DB on :5438): `ok travel-route-planner 130.9s`. Includes 12 new integration tests in `trip_refine_chat_integration_test.go` — persistence, the one-row append contract, unaddressable-as-plan-chat, `refine_chat` on the trip payload, GET/DELETE/access, idempotent DELETE, per-user rows, cascade on trip delete, revoked collaborator, the transcript **parity contract** across both tables, the bound-prompt pins, and `get_trip` returning the bound trip for owner *and* collaborator.
- `flutter analyze --no-fatal-infos`: only the 3 pre-existing infos in `route_response.dart`.
- **Full Flutter suite: 1360 passed, 0 failed.** 4 new test files (24 cases): back/Escape/app-bar-back/docked/mid-stream/late-`trip_updated`, restore loading → transcript, expired vs failed states, the no-fetch memory path, New chat confirm, the append + stub contracts.
- **Mutation-checked** — each new behavior reverted in place and confirmed to turn the suite red, then restored: back-closes-panel (5 red), append-not-reset (6 red), hydrate-before-send (1 red, the data-loss guard).
- Not run: manual end-to-end through the gateway — the lane's dev stack was not brought up (only its Postgres, for the integration tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
