### PR TITLE
fix(hotels): an empty rates result is a miss, not an answer

### DIFF
--- a/src/packages/api/hotel_search_service.go
+++ b/src/packages/api/hotel_search_service.go
@@ -250,6 +250,23 @@ func searchHotels(ctx context.Context, req HotelSearchRequest) (HotelSearchResul
 			res.RatesNote = "unavailable"
 			break
 		}
+		// An EMPTY rates result is a miss, not an answer. Every city has
+		// hotels, so zero priced properties means a city string the provider
+		// didn't recognise, a response whose rows all lacked a rate, or an
+		// upstream hiccup — none of which is "we checked and there is nothing
+		// to stay in". Returning it as a live-rates answer produced exactly
+		// that lie in prod: `rates_live: true` with `stays: []`, which the
+		// summarizer then reported as "No stays found in Athens."
+		//
+		// This is the same reasoning the cache already uses to refuse to store
+		// an empty result (see SearchStays); the tier decision has to agree
+		// with it, or the two halves of this file disagree about what empty
+		// means.
+		if len(stays) == 0 {
+			fmt.Printf("hotel rates lookup returned no priced stays for %q, falling back to lodging discovery\n", req.City)
+			res.RatesNote = "unavailable"
+			break
+		}
 		res.Stays = stays
 		res.RatesLive = true
 		return res, nil
@@ -393,6 +410,13 @@ func (s *SerpapiHotelsService) SearchStays(ctx context.Context, req HotelSearchR
 	}
 	if status < 200 || status >= 300 {
 		return nil, fmt.Errorf("SerpApi hotels error (%d): %s", status, truncateForLog(body))
+	}
+	// The provider normally signals failure with a 4xx, but the error field is
+	// parsed here and must actually be READ: an error delivered alongside a
+	// 2xx would otherwise fall through as "zero properties" and be reported as
+	// a successful search. Errors should never pass silently (docs/zen.md).
+	if strings.TrimSpace(parsed.Error) != "" {
+		return nil, fmt.Errorf("SerpApi hotels error: %s", parsed.Error)
 	}
 
 	stays := make([]HotelStay, 0, len(parsed.Properties))

--- a/src/packages/api/hotel_search_service_test.go
+++ b/src/packages/api/hotel_search_service_test.go
@@ -507,3 +507,72 @@ func TestHotelDailyCapZeroMeansZero(t *testing.T) {
 		}()
 	}
 }
+
+// Prod shipped `{"rates_live":true,"stays":[]}` for Athens — an empty LIVE
+// RATES answer, which the summarizer then reported as "No stays found in
+// Athens." Every city has hotels, so zero priced properties is a miss (bad
+// city string, rows without rates, upstream hiccup), never a finding. The
+// cache already refused to store an empty result for exactly this reason; the
+// tier decision has to agree with it.
+func TestHotelEmptyRatesResultFallsBackInsteadOfClaimingLiveRates(t *testing.T) {
+	swapHotelStub(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"properties":[]}`))
+	})
+	swapLodgingStub(t, athensLodgingJSON)
+
+	res, err := searchHotels(context.Background(), datedReq())
+	if err != nil {
+		t.Fatalf("searchHotels: %v", err)
+	}
+	if res.RatesLive {
+		t.Error("an empty rates result must never be reported as live rates")
+	}
+	if res.RatesNote != "unavailable" {
+		t.Errorf("rates_note = %q, want unavailable", res.RatesNote)
+	}
+	if len(res.Stays) == 0 {
+		t.Fatal("must fall back to discovery rather than answering with nothing")
+	}
+	if res.Stays[0].RatePerNight != nil {
+		t.Error("fallback stays must carry no price")
+	}
+}
+
+// Same trap one layer down: a response whose rows all lack a rate is not a
+// list of free hotels.
+func TestHotelAllRowsUnpricedFallsBack(t *testing.T) {
+	swapHotelStub(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"properties":[
+			{"name":"No Price Inn","type":"hotel","overall_rating":4.1},
+			{"name":"Also No Price","type":"hotel","overall_rating":4.4}
+		]}`))
+	})
+	swapLodgingStub(t, athensLodgingJSON)
+
+	res, _ := searchHotels(context.Background(), datedReq())
+	if res.RatesLive {
+		t.Error("rows without rates must not produce a live-rates answer")
+	}
+	if len(res.Stays) == 0 {
+		t.Error("expected the discovery fallback to answer")
+	}
+}
+
+// A provider error delivered with a 2xx must not read as "zero properties".
+func TestHotelErrorFieldOn200IsAnError(t *testing.T) {
+	swapHotelStub(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"error":"Your account has run out of searches.","properties":[]}`))
+	})
+	swapLodgingStub(t, athensLodgingJSON)
+
+	res, err := searchHotels(context.Background(), datedReq())
+	if err != nil {
+		t.Fatalf("should degrade, not error: %v", err)
+	}
+	if res.RatesLive {
+		t.Error("a 2xx carrying an error field must not claim live rates")
+	}
+	if len(res.Stays) == 0 {
+		t.Error("expected the discovery fallback to answer")
+	}
+}


### PR DESCRIPTION
Follow-up to #437, found by hitting prod.

## The bug

```
GET /api/v1/hotels/search?city=Athens&check_in=2026-09-03&check_out=2026-09-07&adults=2
→ {"city":"Athens","stays":[],"adults":2,"rates_live":true}
```

`rates_live: true` with **zero stays** — an empty *live rates* answer, which `summarizeHotels` then reports to the model as *"No stays found in Athens."* Athens has hotels.

## Root cause

SerpApi answers some queries with **HTTP 200** and an error in the body:

```json
{"error": "Google Hotels hasn't returned any results for this query.", "properties": []}
```

Confirmed directly against the API. It is intermittent and query-shaped, not account-wide — at the same moment, Athens/Sep 3–7/**adults=3** returned 20 priced properties and Paris and Lisbon both returned 10, while Athens/**adults=2** returned this on two separate date ranges.

`serpapiHotelsResponse.Error` was parsed and **never read**, so a 200 carrying an error fell through as "zero properties" and was reported as a successful search. Two independent defects, both fixed:

1. **An empty rates result was treated as an answer.** Zero priced properties means a city string the provider didn't recognise, rows that all lacked a rate, or an upstream hiccup — never "we checked and there is nothing to stay in". It now falls through to the discovery tier like any other rates miss.
2. **The provider's error field is now read on a 2xx.** Errors should never pass silently (`docs/zen.md`).

The reasoning for #1 was already written down one function away — `SearchStays` refuses to *cache* an empty result because *"an empty route is a real answer, an empty city is not"*. The tier decision simply didn't agree with it. Now it does.

## Verified against the real failure

Same query that fails in prod, run against this build:

```
{"rates_live":false,"rates_note":"unavailable","n":8,
 "first":{"name":"Grand Hyatt Athens","rating":4.3,"has_price":false}}

hotel rates lookup failed for "Athens", falling back to lodging discovery:
  SerpApi hotels error: Google Hotels hasn't returned any results for this query.
```

Eight real Athens hotels with ratings and no prices, honestly labeled, plus a log line naming the upstream cause — instead of a confident "No stays found in Athens."

Three regression tests, one per path: empty `properties`, rows that all lack a rate, and an error field on a 200. `go vet` clean, `go test -race ./...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)