### PR TITLE
fix(chat): the composer keeps what you were writing

### DIFF
--- a/docs/friction-log.md
+++ b/docs/friction-log.md
@@ -5,6 +5,45 @@ build queue. Priority when picking work: **breakage > friction in features
 actually used > ideas that recur across ≥2 sessions**. Tag entries `[app]`
 (dogfooding the product) or `[dev]` (workflow/tooling). Newest first.
 
+## 2026-08-15 — the second half of the composer bug
+
+- **[app] Same defect, second surface.** The Budget row fix (#435) named the
+  cause: trip detail's body returns a bare `RefreshIndicator` when the chat
+  panel is closed and a `Row`/`Stack` when it's open, so `Widget.canUpdate`
+  fails at that slot and the whole subtree is re-inflated. `ChatPanel` lives
+  *inside* that subtree — so the half-written question died on the same
+  gesture, plus one the budget row never sees: **crossing 900px re-parents
+  `Stack` → `Row` and wipes the composer mid-typing, with no gesture at all.**
+- **[app] Closing the panel is the common case, not an edge one.** #441 gave
+  the panel three ways to close (✕, Escape, back) and made all of them keep the
+  transcript. What it did not do — because it never touched `chat_panel.dart` —
+  is keep the sentence you were in the middle of writing. So "back doesn't lose
+  my chat" shipped while back still lost the thing actually being typed.
+- **[app] The attachments ride along, deliberately.** Re-picking four photos is
+  worse than retyping a sentence. The cost is honest: their bytes now outlive
+  the panel, bounded by the 4-per-message cap, one draft per chat, and the
+  clear on send. `_processingCount` is *not* kept — the `await` it counts
+  cannot outlive the State, so an image still downscaling when the panel closes
+  is genuinely gone, and that's now written down rather than assumed.
+- **[dev] The key had to be the conversation's identity, not a second one.**
+  The obvious move was a `draftKey` prop each host passes. But `PlanNotifier`
+  already carries `tripId` — null on the Agent tab, the trip in the refine
+  panel — so a prop would have been a *second* name for one thing, and a host
+  that got it wrong would put one chat's words in another's composer with
+  nothing to catch it. Deriving it (`chatDraftKeyFor`) also left all **14**
+  `chat_panel_*_test.dart` harnesses untouched: they build `PlanNotifier`
+  directly, get `tripId == null`, and land in the `agent` bucket for free.
+  Explicit does not always mean "add a parameter" — sometimes it means naming
+  the identity that already exists.
+- **[dev] Three of eight new tests were vacuous until mutation testing said
+  so.** With the restore neutered, only 4 of 8 failed. Two more were fine
+  (they guard clear-on-send and write-back-on-remove; each fails against *its*
+  mutation). But **"two trips do not share one draft" passed with the key
+  hardcoded to a constant** — because both panels were mounted, and a mounted
+  panel never re-reads the draft, so a shared key was invisible. The test only
+  bites if you remount the *other* panel. A test asserting isolation between
+  two live widgets proves nothing about a key.
+
 ## 2026-08-15 — chat dogfooding (hotels)
 
 - **[app] Friction → fixed: "Chat can't lookup hotel data — doesn't have it in

--- a/src/packages/flutter-app/lib/providers/plan_provider.dart
+++ b/src/packages/flutter-app/lib/providers/plan_provider.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:math';
+import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../models/plan_message.dart';
 import '../models/agent_place.dart';
@@ -999,3 +1000,71 @@ final tripRefineProvider = StateNotifierProvider.family<PlanNotifier, PlanState,
       tripId: tripId,
       onProfileFieldsChanged: (f) => _refetchProfileFields(ref, f));
 });
+
+/// What someone has composed in a chat but not sent yet — the message text and
+/// any images they attached.
+///
+/// Held here rather than in `ChatPanel`'s State because the panel is taken
+/// away from under them: closing the trip's refine panel disposes it outright,
+/// and opening it — or crossing the docked/undocked width — re-parents the
+/// whole trip body, which re-inflates everything beneath it. The transcript
+/// already survives all of that ([tripRefineProvider] is keepAlive for exactly
+/// this reason), so a half-written question was the one thing still being
+/// thrown away by the same gesture.
+///
+/// The attachments ride along deliberately: re-picking four photos is worse
+/// than retyping a sentence. The cost is that their bytes now outlive the
+/// panel — bounded by the 4-per-message cap, one draft per key, and the clear
+/// on send.
+@immutable
+class ChatDraft {
+  final String text;
+
+  /// Attached but unsent. Never the resumed-transcript placeholders (those
+  /// have null `bytes` and belong to a message that was already sent).
+  final List<PlanAttachment> attachments;
+
+  const ChatDraft({this.text = '', this.attachments = const []});
+
+  bool get isEmpty => text.isEmpty && attachments.isEmpty;
+}
+
+class ChatDraftNotifier extends StateNotifier<ChatDraft> {
+  ChatDraftNotifier() : super(const ChatDraft());
+
+  void setText(String text) {
+    if (text == state.text) return;
+    state = ChatDraft(text: text, attachments: state.attachments);
+  }
+
+  /// Copied, not aliased: the caller's list is the composer's own mutable
+  /// `_pending`, and sharing it would let a later `add` mutate state that has
+  /// already been published.
+  void setAttachments(List<PlanAttachment> attachments) {
+    state = ChatDraft(text: state.text, attachments: List.of(attachments));
+  }
+
+  /// After a send. Also the only path that frees attachment bytes.
+  void clear() {
+    if (state.isEmpty) return;
+    state = const ChatDraft();
+  }
+}
+
+/// The [chatDraftProvider] key for a conversation, derived from the ONE
+/// identity a chat already has: [PlanNotifier.tripId], null on the Agent tab
+/// and the trip's id in the refine panel. A draft key handed down as its own
+/// prop would be a second identity for the same thing, and a host that got it
+/// wrong would silently put one chat's words in another's composer.
+///
+/// (A trip id is a uuid, so it can never collide with the unbound bucket; the
+/// prefix is for whoever reads the key in a debugger.)
+String chatDraftKeyFor(String? tripId) =>
+    tripId == null ? 'agent' : 'trip:$tripId';
+
+/// One composer draft per chat surface. The Agent tab and a trip's refine
+/// panel can be mounted at the same time, so they must not share one — and a
+/// trip's draft has to outlive its panel, which is the whole point.
+final chatDraftProvider =
+    StateNotifierProvider.family<ChatDraftNotifier, ChatDraft, String>(
+        (ref, draftKey) => ChatDraftNotifier());

--- a/src/packages/flutter-app/lib/widgets/chat_panel.dart
+++ b/src/packages/flutter-app/lib/widgets/chat_panel.dart
@@ -113,8 +113,13 @@ class _ChatPanelState extends ConsumerState<ChatPanel> {
   final List<PlanAttachment> _pending = [];
 
   /// Images currently going through the downscale pipeline (spinner chips);
-  /// sending is deferred until this reaches zero.
+  /// sending is deferred until this reaches zero. Deliberately NOT part of the
+  /// kept draft: the `await` it counts cannot outlive this State, so an image
+  /// still being downscaled when the panel closes is genuinely gone.
   int _processingCount = 0;
+
+  /// Which kept draft is ours — see [chatDraftKeyFor].
+  late final String _draftKey;
 
   /// Whether a drag hovers over the panel — drives the drop overlay.
   bool _dragging = false;
@@ -124,6 +129,10 @@ class _ChatPanelState extends ConsumerState<ChatPanel> {
   @override
   void initState() {
     super.initState();
+    // Fixed for this panel's life: a notifier's tripId is final, and neither
+    // host ever swaps the notifier it passes.
+    _draftKey = chatDraftKeyFor(ref.read(widget.notifier).tripId);
+    _restoreDraft();
     _dictation = ref.read(dictationControllerFactoryProvider)(_controller);
     _dictation.addListener(_onDictationChanged);
     // Paste-from-clipboard (web only): focus-gated so exactly one mounted
@@ -135,6 +144,41 @@ class _ChatPanelState extends ConsumerState<ChatPanel> {
       },
     );
   }
+
+  /// Puts back whatever was composed and not sent before this panel was last
+  /// torn down. Called from `initState` only — never from `build`, where it
+  /// would clobber the character just typed.
+  ///
+  /// `read`, never `watch`: the draft is written on every keystroke, so
+  /// watching it would rebuild the whole transcript per character.
+  void _restoreDraft() {
+    final draft = ref.read(chatDraftProvider(_draftKey));
+    // Never assign `controller.text` — that setter parks the selection at
+    // offset -1, which the engine normalizes to 0, so the next keystroke lands
+    // in *front* of the restored text (see airport_field.dart).
+    _controller.value = TextEditingValue(
+      text: draft.text,
+      selection: TextSelection.collapsed(offset: draft.text.length),
+    );
+    _pending.addAll(draft.attachments);
+    // After the seed, so restoring cannot echo back into the draft it read.
+    _controller.addListener(_saveDraft);
+  }
+
+  /// Records the composer as it stands. Called on every change rather than on
+  /// the way out: this panel is unmounted without warning — closing it, and
+  /// the trip body re-inflating when it opens or crosses the docked width —
+  /// and by the time `dispose` runs the element is already unmounted, so `ref`
+  /// throws there.
+  void _saveDraft() => ref
+      .read(chatDraftProvider(_draftKey).notifier)
+      .setText(_controller.text);
+
+  /// The attachment half. Separate from [_saveDraft] because the two are
+  /// edited by different gestures and the list write copies.
+  void _saveDraftAttachments() => ref
+      .read(chatDraftProvider(_draftKey).notifier)
+      .setAttachments(_pending);
 
   void _onDictationChanged() {
     final error = _dictation.consumeError();
@@ -199,6 +243,9 @@ class _ChatPanelState extends ConsumerState<ChatPanel> {
     final attachments = List<PlanAttachment>.of(_pending);
     _controller.clear();
     setState(_pending.clear);
+    // One call for both halves — and the only thing that frees the kept
+    // attachment bytes.
+    ref.read(chatDraftProvider(_draftKey).notifier).clear();
     ref.read(widget.notifier).sendMessage(text, attachments: attachments);
     _stickToBottom = true;
     _scrollToBottom();
@@ -229,6 +276,7 @@ class _ChatPanelState extends ConsumerState<ChatPanel> {
         _processingCount--;
         if (attachment != null) _pending.add(attachment);
       });
+      if (attachment != null) _saveDraftAttachments();
       if (attachment == null) {
         _notify(l10n.chatImageUnreadable);
       }
@@ -367,7 +415,10 @@ class _ChatPanelState extends ConsumerState<ChatPanel> {
             _PendingAttachmentsRow(
               pending: _pending,
               processingCount: _processingCount,
-              onRemove: (i) => setState(() => _pending.removeAt(i)),
+              onRemove: (i) {
+                setState(() => _pending.removeAt(i));
+                _saveDraftAttachments();
+              },
             ),
           _InputBar(
             controller: _controller,

--- a/src/packages/flutter-app/test/chat_draft_test.dart
+++ b/src/packages/flutter-app/test/chat_draft_test.dart
@@ -1,0 +1,283 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:travel_route_planner/models/plan_message.dart';
+import 'package:travel_route_planner/providers/dictation_provider.dart';
+import 'package:travel_route_planner/providers/plan_provider.dart';
+import 'package:travel_route_planner/services/api_client.dart';
+import 'package:travel_route_planner/services/dictation_controller.dart';
+import 'package:travel_route_planner/services/dictation_engine.dart';
+import 'package:travel_route_planner/services/image_attachment_pipeline.dart';
+import 'package:travel_route_planner/services/plan_service.dart';
+import 'package:travel_route_planner/widgets/chat_panel.dart';
+
+import 'support/l10n_test_app.dart';
+
+/// The composer keeps what you composed and did not send.
+///
+/// The panel is destroyed by the ordinary gestures of using it — closing the
+/// trip's refine panel, and the trip body re-inflating when it opens or
+/// crosses the docked width — so the draft lives in [chatDraftProvider], not
+/// in the widget. `trip_detail_chat_back_test.dart` covers the real close and
+/// reopen; this file covers the unit: unmount, remount, what comes back.
+
+final _tinyPng = base64Decode(
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==');
+
+/// Engine decoding never completes in a widget test's fake-async zone; echo
+/// the bytes through instead (same seam `chat_panel_attachments_test` uses).
+class _EchoPipeline extends ImageAttachmentPipeline {
+  const _EchoPipeline();
+
+  @override
+  Future<PlanAttachment?> process(Uint8List bytes, String mediaType) async =>
+      PlanAttachment(bytes: bytes, mediaType: mediaType);
+}
+
+class _NoDictationEngine implements DictationEngine {
+  @override
+  Future<bool> initialize() async => false;
+  @override
+  Stream<DictationEvent> start() => const Stream.empty();
+  @override
+  Future<void> stop() async {}
+  @override
+  Future<void> cancel() async {}
+}
+
+class _RecordingPlanService extends PlanService {
+  final List<List<Map<String, dynamic>>> histories = [];
+
+  _RecordingPlanService() : super('http://unused');
+
+  @override
+  Stream<PlanEvent> streamPlan(
+    List<Map<String, dynamic>> messages, {
+    String? bearerToken,
+    String? chatId,
+    String? tripId,
+    String? summary,
+    Future<void>? abortTrigger,
+  }) async* {
+    histories.add(List.of(messages));
+    yield PlanEvent(type: 'text_delta', data: {'text': 'ok'});
+  }
+}
+
+/// A chat that can be taken away and put back **inside one `ProviderScope`**.
+/// A second `pumpWidget` with a fresh scope would build a new
+/// `ProviderContainer` and pass against the un-fixed code; the container has
+/// to be the same one throughout. Mirrors the real cause: trip detail's body
+/// returns a differently-typed widget once the panel opens, so the whole
+/// subtree — panel included — is re-inflated.
+class _Mountable extends StatefulWidget {
+  final StateNotifierProvider<PlanNotifier, PlanState> provider;
+  final List<(Uint8List, String)> Function() pick;
+
+  const _Mountable({required this.provider, required this.pick});
+
+  @override
+  State<_Mountable> createState() => _MountableState();
+}
+
+class _MountableState extends State<_Mountable> {
+  bool _shown = true;
+
+  @override
+  Widget build(BuildContext context) => Column(
+        children: [
+          TextButton(
+            onPressed: () => setState(() => _shown = !_shown),
+            child: const Text('toggle'),
+          ),
+          if (_shown)
+            Expanded(
+              child: ChatPanel(
+                state: widget.provider,
+                notifier: widget.provider.notifier,
+                attachmentPipeline: const _EchoPipeline(),
+                pickImages: () async => widget.pick(),
+              ),
+            ),
+        ],
+      );
+}
+
+class _Harness {
+  final _RecordingPlanService service;
+  final PlanNotifier notifier;
+  List<(Uint8List, String)> nextPick = [];
+
+  _Harness._(this.service, this.notifier);
+
+  /// [tripIds] builds one chat per id; a null id is the unbound Agent tab.
+  static Future<List<_Harness>> build(
+    WidgetTester tester, {
+    List<String?> tripIds = const [null],
+  }) async {
+    final harnesses = <_Harness>[];
+    final panels = <Widget>[];
+    for (final tripId in tripIds) {
+      final service = _RecordingPlanService();
+      final notifier = PlanNotifier(service, ApiClient(), tripId: tripId);
+      final harness = _Harness._(service, notifier);
+      harnesses.add(harness);
+      final provider =
+          StateNotifierProvider<PlanNotifier, PlanState>((ref) => notifier);
+      panels.add(Expanded(
+        child: _Mountable(provider: provider, pick: () => harness.nextPick),
+      ));
+    }
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          dictationControllerFactoryProvider.overrideWithValue(
+            (textController) => DictationController(
+              textController: textController,
+              primary: _NoDictationEngine(),
+              fallback: null,
+              fallbackAvailable: () async => false,
+            ),
+          ),
+        ],
+        child: MaterialApp(
+          localizationsDelegates: testLocalizationsDelegates,
+          home: Scaffold(body: Column(children: panels)),
+        ),
+      ),
+    );
+    await tester.pump();
+    return harnesses;
+  }
+}
+
+/// Take the [index]th chat away and put it back — one unmount/remount trip.
+Future<void> _remount(WidgetTester tester, {int index = 0}) async {
+  final toggle = find.text('toggle').at(index);
+  await tester.tap(toggle);
+  await tester.pumpAndSettle();
+  await tester.tap(toggle);
+  await tester.pumpAndSettle();
+}
+
+Future<void> _attach(WidgetTester tester, _Harness harness) async {
+  harness.nextPick = [(_tinyPng, 'image/png')];
+  await tester.tap(find.byIcon(Icons.attach_file));
+  await tester.pumpAndSettle();
+}
+
+TextEditingController _composerAt(WidgetTester tester, int index) =>
+    tester.widget<TextField>(find.byType(TextField).at(index)).controller!;
+
+void main() {
+  testWidgets('an unsent message survives the panel being torn down',
+      (tester) async {
+    await _Harness.build(tester);
+
+    await tester.enterText(
+        find.byType(TextField), 'what else is near the Rijksmuseum?');
+    await _remount(tester);
+
+    expect(_composerAt(tester, 0).text, 'what else is near the Rijksmuseum?');
+  });
+
+  testWidgets('so do the images attached to it', (tester) async {
+    final harness = (await _Harness.build(tester)).single;
+
+    await _attach(tester, harness);
+    expect(find.byType(Image), findsOneWidget, reason: 'pending chip');
+
+    await _remount(tester);
+
+    expect(find.byType(Image), findsOneWidget, reason: 'chip is back');
+    // And it is still a real attachment, not a placeholder: it sends.
+    await tester.tap(find.byIcon(Icons.send));
+    await tester.pumpAndSettle();
+    final sent = harness.service.histories.single.single;
+    expect((sent['images'] as List).single['data'], base64Encode(_tinyPng));
+  });
+
+  testWidgets('the restored text can be typed onto, not in front of',
+      (tester) async {
+    await _Harness.build(tester);
+
+    await tester.enterText(find.byType(TextField), 'two nights in Naxos');
+    await _remount(tester);
+
+    // Assigning `controller.text` would park the selection at -1, which the
+    // engine normalizes to 0 — the next keystroke would land at the front.
+    expect(_composerAt(tester, 0).selection.baseOffset,
+        'two nights in Naxos'.length);
+  });
+
+  testWidgets('removing an attachment before the panel closes sticks',
+      (tester) async {
+    final harness = (await _Harness.build(tester)).single;
+
+    await _attach(tester, harness);
+    await tester.tap(find.byIcon(Icons.close));
+    await tester.pump();
+
+    await _remount(tester);
+
+    expect(find.byType(Image), findsNothing);
+  });
+
+  testWidgets('sending clears the draft, text and images alike',
+      (tester) async {
+    final harness = (await _Harness.build(tester)).single;
+
+    await _attach(tester, harness);
+    await tester.enterText(find.byType(TextField), 'this one?');
+    await tester.tap(find.byIcon(Icons.send));
+    await tester.pumpAndSettle();
+
+    await _remount(tester);
+
+    expect(_composerAt(tester, 0).text, isEmpty);
+    // The bubble's own thumbnail is in the transcript; no pending chip.
+    expect(harness.notifier.state.messages.first.attachments, hasLength(1));
+    expect(find.byIcon(Icons.close), findsNothing, reason: 'no pending chip');
+  });
+
+  testWidgets('a trip chat and the Agent tab keep separate drafts',
+      (tester) async {
+    await _Harness.build(tester, tripIds: const [null, 'trip-1']);
+
+    await tester.enterText(find.byType(TextField).at(1), 'about this trip');
+    // The unbound chat writes LAST: on one shared key its text is what the
+    // trip's composer would come back holding.
+    await tester.enterText(find.byType(TextField).at(0), 'unbound');
+    await tester.pumpAndSettle();
+
+    await _remount(tester, index: 1);
+
+    expect(_composerAt(tester, 1).text, 'about this trip');
+    expect(_composerAt(tester, 0).text, 'unbound');
+  });
+
+  testWidgets('two trips do not share one draft', (tester) async {
+    await _Harness.build(tester, tripIds: const ['trip-1', 'trip-2']);
+
+    await tester.enterText(find.byType(TextField).at(0), 'Amsterdam plans');
+    await tester.pumpAndSettle();
+
+    // Only a remount re-reads the draft, so only a remount can catch a key
+    // that does not distinguish the two trips.
+    await _remount(tester, index: 1);
+
+    expect(_composerAt(tester, 1).text, isEmpty);
+  });
+
+  test('the draft key is the conversation\'s own identity', () {
+    // Not a second identity a host could get wrong: null is the Agent tab,
+    // anything else is that trip.
+    expect(chatDraftKeyFor(null), 'agent');
+    expect(chatDraftKeyFor('trip-1'), 'trip:trip-1');
+    expect(chatDraftKeyFor('trip-1') == chatDraftKeyFor('trip-2'), isFalse);
+  });
+}

--- a/src/packages/flutter-app/test/trip_detail_chat_back_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_chat_back_test.dart
@@ -159,6 +159,54 @@ void main() {
     expect(_refineState(tester).messages.length, seeded);
   });
 
+  // Closing the panel is the same gesture that used to discard whatever was
+  // half-typed in it: the body's slot changes runtime type, so the subtree —
+  // composer included — is re-inflated. The transcript already survived this;
+  // the question being written did not.
+  testWidgets('closing and reopening keeps the half-typed question',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(_app(_FakeTripsApiService(_trip())));
+    await tester.pumpAndSettle();
+    await _openTripAndChat(tester);
+
+    await tester.enterText(find.byType(TextField), 'why not Utrecht instead?');
+    expect(await _back(tester), isTrue);
+    await tester.pumpAndSettle();
+    expect(find.byType(TripRefinePanel), findsNothing);
+
+    await tester.tap(find.byType(FloatingActionButton));
+    await tester.pumpAndSettle();
+
+    expect(
+      tester.widget<TextField>(find.byType(TextField)).controller!.text,
+      'why not Utrecht instead?',
+    );
+  });
+
+  // Same re-inflation, no gesture at all: the panel crosses 900px and the body
+  // swaps Stack for Row underneath it.
+  testWidgets('resizing across the docked width keeps it too',
+      (WidgetTester tester) async {
+    tester.view.physicalSize = const Size(700, 1000);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+
+    await tester.pumpWidget(_app(_FakeTripsApiService(_trip())));
+    await tester.pumpAndSettle();
+    await _openTripAndChat(tester);
+    expect(find.byType(VerticalDivider), findsNothing); // sheet, not docked
+
+    await tester.enterText(find.byType(TextField), 'and the ferry times?');
+    tester.view.physicalSize = const Size(1400, 1000);
+    await tester.pumpAndSettle();
+    expect(find.byType(VerticalDivider), findsOneWidget); // now docked
+
+    expect(
+      tester.widget<TextField>(find.byType(TextField)).controller!.text,
+      'and the ferry times?',
+    );
+  });
+
   testWidgets('a second back leaves the trip, conversation intact',
       (WidgetTester tester) async {
     await tester.pumpWidget(_app(_FakeTripsApiService(_trip())));


### PR DESCRIPTION
## Summary

The second half of #435. That PR named the cause — trip detail's body returns a bare `RefreshIndicator` when the chat panel is closed and a `Row`/`Stack` when it's open, so `Widget.canUpdate` fails at that slot and the whole subtree is re-inflated — and `ChatPanel` lives *inside* that subtree.

- **Closing the panel discarded the half-written question.** All three ways: the ✕, Escape, and back.
- **So did crossing 900px**, which re-parents `Stack` → `Row` with no gesture at all — the composer is wiped mid-typing on a window resize or an iPad rotation. The budget row never sees this one.
- **#441 made "back doesn't lose my chat" true for the transcript only.** It gave the panel its three close paths and persisted the conversation, but never touched `chat_panel.dart` — so back kept the chat and still lost the sentence being typed into it.

The draft moves into `chatDraftProvider`, a non-autoDispose family sitting next to `tripRefineProvider` — which is keepAlive for exactly this reason, and whose docstring already said so.

### Two judgement calls worth reviewing

**Attachments ride along.** Re-picking four photos is worse than retyping a sentence. The cost is real and stated: their bytes now outlive the panel, bounded by the 4-per-message cap, one draft per chat, and the clear on send. `_processingCount` deliberately does *not* persist — the `await` it counts cannot outlive the `State`, so an image still downscaling when the panel closes is genuinely gone. That's now a comment rather than an assumption.

**The key is derived, not passed.** The obvious move was a `draftKey` prop each host supplies. But `PlanNotifier` already carries `tripId` — null on the Agent tab, the trip id in the refine panel — so a prop would be a *second* name for one thing, and a host that got it wrong would put one chat's words into another's composer with nothing to catch it. `chatDraftKeyFor(tripId)` reads the identity the conversation already has. It also leaves all **14** `chat_panel_*_test.dart` harnesses untouched: they build `PlanNotifier` directly, get `tripId == null`, and land in the `agent` bucket for free.

Not changed: "Start over" still leaves the composer alone, exactly as today. The Agent tab never actually lost its composer (`IndexedStack` keeps it mounted); it gets the same protection for free.

## Testing

- `flutter test` — **1417 passing** (1407 on this branch point, so +10). New `test/chat_draft_test.dart` (8) covers text and attachments surviving a teardown, the caret landing *after* the restored text, remove-before-close sticking, send clearing both halves, and per-chat isolation. Two more in `trip_detail_chat_back_test.dart` drive the **real** gestures on a real `TripDetailScreen`: close-and-reopen, and the 900px resize.
- **Every new test was watched failing against the specific defect it guards** — restore neutered (6 fail), clear-on-send dropped, save-on-remove dropped, key hardcoded to a constant.
- That last one mattered: **"two trips do not share one draft" was vacuous as first written** and passed with the key hardcoded. Both panels were mounted, and a mounted panel never re-reads the draft, so a shared key was invisible. It only bites if the *other* panel is remounted. Fixed, then re-checked against the mutation.
- The remount harness toggles the panel inside **one** `ProviderScope`; a second `pumpWidget` builds a fresh `ProviderContainer` and would pass against the broken code.
- `flutter analyze` — clean; the 3 remaining infos are pre-existing in `lib/models/route_response.dart`, untouched here.

Friction-log entry included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)