### PR TITLE
feat(budget): the Budget tab tells plan from payment

### DIFF
--- a/src/packages/flutter-app/lib/providers/budget_provider.dart
+++ b/src/packages/flutter-app/lib/providers/budget_provider.dart
@@ -54,17 +54,35 @@ class ExpenseDraft {
   /// label. `general` is the server's default and the row's opening pick.
   final String category;
 
+  /// Whether the row will add a PLAN or a PAYMENT (00067).
+  ///
+  /// Defaults to planned, and lives here for the same reason [category] does:
+  /// it is a *choice*, and resetting it on the next remount would silently
+  /// re-file the following expense. Planned is the safer default because the
+  /// two mistakes are not symmetric — a wrongly-planned row is visible (it
+  /// shows a hollow mark and "Total spent" doesn't move) and is two taps to
+  /// fix, while a wrongly-paid one inflates spend quietly and can fire a false
+  /// over-budget warning.
+  final bool planned;
+
   const ExpenseDraft({
     this.label = '',
     this.amountText = '',
     this.category = 'general',
+    this.planned = true,
   });
 
-  ExpenseDraft copyWith({String? label, String? amountText, String? category}) =>
+  ExpenseDraft copyWith({
+    String? label,
+    String? amountText,
+    String? category,
+    bool? planned,
+  }) =>
       ExpenseDraft(
         label: label ?? this.label,
         amountText: amountText ?? this.amountText,
         category: category ?? this.category,
+        planned: planned ?? this.planned,
       );
 }
 
@@ -83,9 +101,15 @@ class ExpenseDraftNotifier extends StateNotifier<ExpenseDraft> {
     state = state.copyWith(category: category);
   }
 
-  /// After a successful save. Deliberately keeps the category: the row already
-  /// behaves that way within a session, and consecutive expenses tend to share
-  /// one.
+  void setPlanned(bool planned) {
+    if (planned == state.planned) return;
+    state = state.copyWith(planned: planned);
+  }
+
+  /// After a successful save. Deliberately keeps the category AND the
+  /// planned/paid pick: both are choices, and a traveler entering eight
+  /// estimates before a trip — or logging five purchases during one — should
+  /// state it once, not once per line.
   void clearText() => setText(label: '', amountText: '');
 }
 

--- a/src/packages/flutter-app/lib/services/budget_api_service.dart
+++ b/src/packages/flutter-app/lib/services/budget_api_service.dart
@@ -53,10 +53,17 @@ class BudgetApiService {
   /// upsert-by-source (200 on a refresh/no-op, 201 on create) and marks the
   /// row auto. Throws [ApiException] so callers can tell the 422 per-trip
   /// cap apart from other failures.
+  ///
+  /// [planned] says which of the two columns [amount] is (00067). It defaults
+  /// to **false — a payment** — which is what every pre-split caller meant, so
+  /// the booked-flip prompt on the trip screen keeps both compiling and its
+  /// semantics. A linked add must stay a payment: the server 400s a plan-only
+  /// one rather than guessing.
   Future<Expense> addExpense(String tripId,
       {required String category,
       required String label,
       required double amount,
+      bool planned = false,
       String? sourceKind,
       String? sourceId}) async {
     final res = await apiClient.httpClient.post(
@@ -65,7 +72,7 @@ class BudgetApiService {
       body: jsonEncode({
         'category': category,
         'label': label,
-        'amount': amount,
+        if (planned) 'planned_amount': amount else 'actual_amount': amount,
         if (sourceKind != null) 'source_kind': sourceKind,
         if (sourceId != null) 'source_id': sourceId,
       }),
@@ -79,8 +86,47 @@ class BudgetApiService {
         endpoint: 'budget/expenses');
   }
 
-  /// Partial update — pass only the fields to change (category / label / amount
-  /// / position).
+  /// Records what a line actually cost. Omitting [amount] means "paid exactly
+  /// what I planned" — the one-tap case; the server 409s when there is no plan
+  /// to fall back on. Re-calling it edits what was paid.
+  ///
+  /// Paying is its own verb rather than a PATCH field because it is the only
+  /// way to CLEAR the amount again, and a `null`-means-clear JSON convention
+  /// would let a stale client un-pay every line it touched (00067).
+  Future<Expense> purchaseExpense(String tripId, String expenseId,
+      {double? amount}) async {
+    final res = await apiClient.httpClient.post(
+      Uri.parse(
+          '${apiClient.baseUrl}/trips/$tripId/budget/expenses/$expenseId/purchase'),
+      headers: apiClient.jsonHeaders(json: true),
+      body: jsonEncode({if (amount != null) 'amount': amount}),
+    );
+    if (res.statusCode == 200) return Expense.fromJson(jsonDecode(res.body));
+    throw ApiException(
+        statusCode: res.statusCode,
+        message: res.body,
+        endpoint: 'budget/expenses/purchase');
+  }
+
+  /// "I haven't actually paid this." Clears what was paid and keeps the plan.
+  /// The server 409s when the line has no plan — un-paying it would leave it
+  /// with no amount at all, and deleting on the traveler's behalf is a guess.
+  Future<Expense> unpurchaseExpense(String tripId, String expenseId) async {
+    final res = await apiClient.httpClient.delete(
+      Uri.parse(
+          '${apiClient.baseUrl}/trips/$tripId/budget/expenses/$expenseId/purchase'),
+      headers: apiClient.jsonHeaders(),
+    );
+    if (res.statusCode == 200) return Expense.fromJson(jsonDecode(res.body));
+    throw ApiException(
+        statusCode: res.statusCode,
+        message: res.body,
+        endpoint: 'budget/expenses/purchase');
+  }
+
+  /// Partial update — pass only the fields to change (category / label /
+  /// planned_amount / amount / position). It cannot clear a plan: that is the
+  /// 00067 contract, not an oversight.
   Future<Expense> updateExpense(
       String tripId, String expenseId, Map<String, dynamic> body) async {
     final res = await apiClient.httpClient.patch(

--- a/src/packages/flutter-app/lib/widgets/budget_section.dart
+++ b/src/packages/flutter-app/lib/widgets/budget_section.dart
@@ -8,6 +8,7 @@ import '../models/expense.dart';
 import '../providers/budget_provider.dart';
 import '../theme/spacing.dart';
 import '../utils/money_format.dart';
+import 'budget_amounts.dart';
 import 'budget_categories.dart';
 import 'budget_target_dialog.dart';
 import 'empty_state.dart';
@@ -40,7 +41,25 @@ class BudgetSection extends ConsumerStatefulWidget {
 }
 
 // Category vocabulary/labels/icons live in budget_categories.dart, shared
-// with the booked-flip expense prompt.
+// with the booked-flip expense prompt; the planned-vs-paid row vocabulary
+// lives in budget_amounts.dart.
+
+/// What the edit dialog came back with. A record of the four editable things,
+/// so the caller can tell "left empty" (null) from "set to zero" — a plan of
+/// zero is real data.
+class _ExpenseEdit {
+  final String category;
+  final String label;
+  final double? planned;
+  final double? paid;
+
+  const _ExpenseEdit({
+    required this.category,
+    required this.label,
+    required this.planned,
+    required this.paid,
+  });
+}
 
 class _BudgetSectionState extends ConsumerState<BudgetSection> {
   final TextEditingController _labelController = TextEditingController();
@@ -150,12 +169,120 @@ class _BudgetSectionState extends ConsumerState<BudgetSection> {
       .read(budgetApiServiceProvider)
       .deleteExpense(widget.tripId, expense.id));
 
+  /// [_run] plus a confirmation snackbar carrying an Undo — for the one-tap
+  /// actions, which are the ones worth mis-tapping. Delete deliberately keeps
+  /// its no-undo behaviour: it asks nothing and takes a whole line, so it is
+  /// already behind the overflow menu.
+  Future<void> _runWithUndo(
+    Future<void> Function() op, {
+    required String message,
+    required Future<void> Function() undo,
+  }) async {
+    final l10n = context.l10n;
+    final messenger = ScaffoldMessenger.of(context);
+    await _run(op);
+    if (!mounted) return;
+    messenger.showSnackBar(SnackBar(
+      content: Text(message),
+      action: SnackBarAction(
+        label: l10n.tripUndo,
+        onPressed: () => _run(undo),
+      ),
+    ));
+  }
+
+  /// "I paid this." Prefilled with the plan, so paying exactly what you
+  /// budgeted is Save — the common case — and a different price is one edit.
+  Future<void> _markPaid(Expense expense, String currency) async {
+    if (_guard()) return;
+    final l10n = context.l10n;
+    final planned = expense.plannedFor;
+    final controller = TextEditingController(
+        text: planned == null ? '' : _trimAmount(planned));
+    final amount = await showDialog<double>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: Text(l10n.budgetPlanMarkPaid),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(expense.label, style: Theme.of(ctx).textTheme.bodySmall),
+            TextField(
+              controller: controller,
+              autofocus: true,
+              keyboardType: const TextInputType.numberWithOptions(decimal: true),
+              inputFormatters: [
+                FilteringTextInputFormatter.allow(RegExp(r'[0-9.]')),
+              ],
+              decoration: InputDecoration(
+                labelText: l10n.budgetPlanPaidAmountLabel(currency),
+                helperText: planned == null
+                    ? null
+                    : l10n.budgetPlanPlannedHelper(
+                        formatMoney(planned, currency)),
+              ),
+              onSubmitted: (v) {
+                final parsed = double.tryParse(v.trim());
+                if (parsed != null && parsed >= 0) Navigator.of(ctx).pop(parsed);
+              },
+            ),
+          ],
+        ),
+        actions: [
+          TextButton(
+              onPressed: () => Navigator.of(ctx).pop(),
+              child: Text(l10n.commonCancel)),
+          FilledButton(
+            onPressed: () {
+              final parsed = double.tryParse(controller.text.trim());
+              if (parsed == null || parsed < 0) return;
+              Navigator.of(ctx).pop(parsed);
+            },
+            child: Text(l10n.commonSave),
+          ),
+        ],
+      ),
+    );
+    if (amount == null) return;
+    await _run(() => ref
+        .read(budgetApiServiceProvider)
+        .purchaseExpense(widget.tripId, expense.id, amount: amount));
+  }
+
+  /// "I haven't actually paid this." One tap, no dialog — the snackbar's Undo
+  /// is the confirmation, matching the booked-flip pattern.
+  ///
+  /// A line with no plan can't be un-paid server-side (it would be left with no
+  /// amount at all), so it is CONVERTED first: what was paid becomes the plan.
+  /// Lossless and comprehensible — and it beats answering a mis-tap with a 409.
+  Future<void> _unpay(Expense expense) async {
+    final l10n = context.l10n;
+    final api = ref.read(budgetApiServiceProvider);
+    final paid = expense.paidAmount;
+    final needsPlan = expense.plannedFor == null && paid != null;
+    await _runWithUndo(
+      () async {
+        if (needsPlan) {
+          await api.updateExpense(
+              widget.tripId, expense.id, {'planned_amount': paid});
+        }
+        await api.unpurchaseExpense(widget.tripId, expense.id);
+      },
+      message: l10n.budgetPlanMovedBack(expense.label),
+      undo: () =>
+          api.purchaseExpense(widget.tripId, expense.id, amount: paid),
+    );
+  }
+
   void _add() {
     final label = _labelController.text.trim();
     final amount = double.tryParse(_amountController.text.trim());
     if (label.isEmpty || amount == null || amount < 0) return;
     final key = expenseDraftProvider(widget.tripId);
-    final category = ref.read(key).category;
+    final draftNow = ref.read(key);
+    final category = draftNow.category;
+    final planned = draftNow.planned;
     // Captured before the await: this row can be unmounted mid-save (tab away
     // while the POST is in flight), and by the time it returns the controllers
     // are disposed and `ref` throws. The draft outlives both, so clearing it
@@ -168,6 +295,7 @@ class _BudgetSectionState extends ConsumerState<BudgetSection> {
             category: category,
             label: label,
             amount: amount,
+            planned: planned,
           );
       if (mounted) {
         _labelController.clear();
@@ -177,20 +305,33 @@ class _BudgetSectionState extends ConsumerState<BudgetSection> {
     });
   }
 
-  Future<void> _editExpense(Expense expense) async {
+  /// Edit everything about a line: its category, its label, what it was
+  /// planned at, and what it cost.
+  ///
+  /// The two amounts are stacked, not side by side — at 390px each would get
+  /// ~127px and "Planned (USD)" / "Previsto (USD)" breaks under text scale.
+  /// Emptying the Paid field un-pays the line; emptying Planned does NOT clear
+  /// the plan, because nothing can (00067) — a plan, once stated, is history,
+  /// and deleting the line is how you get rid of it.
+  Future<void> _editExpense(Expense expense, String currency) async {
     if (_guard()) return;
     final l10n = context.l10n;
     final labelController = TextEditingController(text: expense.label);
-    final amountController =
-        TextEditingController(text: _trimAmount(expense.amount));
+    final plannedBefore = expense.plannedFor;
+    final paidBefore = expense.paidAmount;
+    final plannedController = TextEditingController(
+        text: plannedBefore == null ? '' : _trimAmount(plannedBefore));
+    final paidController = TextEditingController(
+        text: paidBefore == null ? '' : _trimAmount(paidBefore));
     var category = normalizeExpenseCategory(expense.category);
-    final result = await showDialog<Map<String, dynamic>>(
+    final result = await showDialog<_ExpenseEdit>(
       context: context,
       builder: (ctx) => StatefulBuilder(
         builder: (ctx, setLocal) => AlertDialog(
           title: Text(l10n.budgetEditExpenseTitle),
           content: Column(
             mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               DropdownButtonFormField<String>(
                 initialValue: category,
@@ -208,14 +349,28 @@ class _BudgetSectionState extends ConsumerState<BudgetSection> {
                 decoration: InputDecoration(labelText: l10n.budgetLabelField),
               ),
               TextField(
-                controller: amountController,
+                controller: plannedController,
                 keyboardType:
                     const TextInputType.numberWithOptions(decimal: true),
                 inputFormatters: [
                   FilteringTextInputFormatter.allow(RegExp(r'[0-9.]')),
                 ],
-                decoration: InputDecoration(labelText: l10n.budgetAmount),
+                decoration: InputDecoration(
+                    labelText: l10n.budgetPlanPlannedAmountLabel(currency)),
               ),
+              TextField(
+                controller: paidController,
+                keyboardType:
+                    const TextInputType.numberWithOptions(decimal: true),
+                inputFormatters: [
+                  FilteringTextInputFormatter.allow(RegExp(r'[0-9.]')),
+                ],
+                decoration: InputDecoration(
+                    labelText: l10n.budgetPlanPaidAmountLabel(currency)),
+              ),
+              const SizedBox(height: AppSpacing.xs),
+              Text(l10n.budgetPlanAmountsHelp,
+                  style: Theme.of(ctx).textTheme.bodySmall),
             ],
           ),
           actions: [
@@ -225,13 +380,21 @@ class _BudgetSectionState extends ConsumerState<BudgetSection> {
             FilledButton(
               onPressed: () {
                 final label = labelController.text.trim();
-                final amount = double.tryParse(amountController.text.trim());
-                if (label.isEmpty || amount == null || amount < 0) return;
-                Navigator.of(ctx).pop({
-                  'category': category,
-                  'label': label,
-                  'amount': amount,
-                });
+                final planned = double.tryParse(plannedController.text.trim());
+                final paid = double.tryParse(paidController.text.trim());
+                // At least one number, and no negatives — the same rule the
+                // server enforces, so Save can't produce a 400.
+                if (label.isEmpty ||
+                    (planned == null && paid == null) ||
+                    (planned != null && planned < 0) ||
+                    (paid != null && paid < 0)) {
+                  return;
+                }
+                Navigator.of(ctx).pop(_ExpenseEdit(
+                    category: category,
+                    label: label,
+                    planned: planned,
+                    paid: paid));
               },
               child: Text(l10n.commonSave),
             ),
@@ -239,11 +402,29 @@ class _BudgetSectionState extends ConsumerState<BudgetSection> {
         ),
       ),
     );
-    if (result != null) {
-      _run(() => ref
-          .read(budgetApiServiceProvider)
-          .updateExpense(widget.tripId, expense.id, result));
-    }
+    if (result == null) return;
+
+    final api = ref.read(budgetApiServiceProvider);
+    await _run(() async {
+      // Content first, then the payment — the verbs own actual_amount and
+      // PATCH owns everything else, so an edit that changes both is two calls
+      // by construction, not by accident.
+      final patch = <String, dynamic>{
+        'category': result.category,
+        'label': result.label,
+        if (result.planned != null && result.planned != plannedBefore)
+          'planned_amount': result.planned,
+      };
+      await api.updateExpense(widget.tripId, expense.id, patch);
+      if (result.paid != paidBefore) {
+        if (result.paid == null) {
+          await api.unpurchaseExpense(widget.tripId, expense.id);
+        } else {
+          await api.purchaseExpense(widget.tripId, expense.id,
+              amount: result.paid);
+        }
+      }
+    });
   }
 
   Future<void> _editTarget(Budget budget) async {
@@ -304,6 +485,7 @@ class _BudgetSectionState extends ConsumerState<BudgetSection> {
         ],
         if (widget.canEdit) ...[
           const SizedBox(height: AppSpacing.sm),
+          _buildModeControl(theme),
           _buildAddRow(theme),
         ],
       ],
@@ -359,27 +541,7 @@ class _BudgetSectionState extends ConsumerState<BudgetSection> {
             const SizedBox(height: AppSpacing.xs),
             Row(
               children: [
-                Expanded(
-                  child: ClipRRect(
-                    borderRadius: BorderRadius.circular(4),
-                    child: LinearProgressIndicator(
-                      // Clamped: the bar caps at full; "over" signals through
-                      // the error color (bar + headline) and the negative
-                      // Remaining line below.
-                      value: (budget.spent / budget.targetAmount!)
-                          .clamp(0.0, 1.0)
-                          .toDouble(),
-                      minHeight: 6,
-                      backgroundColor:
-                          theme.colorScheme.surfaceContainerHighest,
-                      color: over
-                          ? theme.colorScheme.error
-                          : theme.colorScheme.primary,
-                      semanticsLabel: l10n.budgetTitle,
-                      semanticsValue: '$pct%',
-                    ),
-                  ),
-                ),
+                Expanded(child: _buildBar(theme, budget, over, pct)),
                 const SizedBox(width: AppSpacing.sm),
                 Text(
                   '$pct%',
@@ -389,9 +551,84 @@ class _BudgetSectionState extends ConsumerState<BudgetSection> {
               ],
             ),
           ],
+          ..._buildProjectionLine(theme, budget),
         ],
       ),
     );
+  }
+
+  /// One bar, filled in two shades: solid is money gone, translucent is money
+  /// still committed. The translucent segment is drawn only when there IS
+  /// unspent plan, so a finished trip — and any payload from before the split
+  /// — has exactly one bar, as it always did.
+  Widget _buildBar(ThemeData theme, Budget budget, bool over, int pct) {
+    final target = budget.targetAmount!;
+    final projected = budget.projected;
+    final spentValue = (budget.spent / target).clamp(0.0, 1.0).toDouble();
+    // Two "over" states, and they are not the same claim: money you have
+    // actually overspent is an error, money you merely plan to is a heads-up.
+    final projectedOver = projected != null && projected > target;
+    final showProjected = projected != null && projected > budget.spent;
+    final bar = LinearProgressIndicator(
+      key: const ValueKey('budgetBarSpent'),
+      // Clamped: the bar caps at full; "over" signals through the error color
+      // (bar + headline) and the negative Remaining line below.
+      value: spentValue,
+      minHeight: 6,
+      // Transparent when the projected track is behind it, so the two segments
+      // read as one bar rather than two stacked ones.
+      backgroundColor: showProjected
+          ? Colors.transparent
+          : theme.colorScheme.surfaceContainerHighest,
+      color: over ? theme.colorScheme.error : theme.colorScheme.primary,
+      semanticsLabel: context.l10n.budgetTitle,
+      semanticsValue: '$pct%',
+    );
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(4),
+      child: showProjected
+          ? Stack(children: [
+              LinearProgressIndicator(
+                key: const ValueKey('budgetBarProjected'),
+                value: (projected / target).clamp(0.0, 1.0).toDouble(),
+                minHeight: 6,
+                backgroundColor: theme.colorScheme.surfaceContainerHighest,
+                color: (projectedOver
+                        ? theme.colorScheme.error
+                        : theme.colorScheme.primary)
+                    .withValues(alpha: 0.35),
+              ),
+              bar,
+            ])
+          : bar,
+    );
+  }
+
+  /// "Projected $2,134 · $134 over target" — where the trip lands if every
+  /// unpaid line comes in at its plan. Absent when there is nothing left to
+  /// spend, so it never restates the headline.
+  List<Widget> _buildProjectionLine(ThemeData theme, Budget budget) {
+    final projected = budget.projected;
+    if (projected == null || projected <= budget.spent) return const [];
+    final l10n = context.l10n;
+    final target = budget.targetAmount;
+    final currency = budget.currency;
+    final overBy = target == null ? null : projected - target;
+    final heading = overBy != null && overBy > 0;
+    return [
+      const SizedBox(height: AppSpacing.xs),
+      Text(
+        [
+          l10n.budgetPlanProjected(formatMoney(projected, currency)),
+          if (heading) l10n.budgetPlanOverTargetBy(formatMoney(overBy, currency)),
+        ].join(' · '),
+        style: theme.textTheme.bodySmall?.copyWith(
+          color: heading
+              ? theme.colorScheme.error
+              : theme.colorScheme.onSurfaceVariant,
+        ),
+      ),
+    ];
   }
 
   Widget _buildTargetControl(ThemeData theme, Budget budget) {
@@ -439,7 +676,13 @@ class _BudgetSectionState extends ConsumerState<BudgetSection> {
     for (final cat in kExpenseCategories) {
       final group = byCategory[cat];
       if (group == null || group.isEmpty) continue;
-      final subtotal = group.fold<double>(0, (sum, e) => sum + e.amount);
+      // ONE number per group — the projected one, which is the only subtotal
+      // that stays continuous across a trip (it equals the plan before
+      // departure and the spend after it). A second column here would turn
+      // the section into a spreadsheet; the hollow mark says "not all of this
+      // has left yet" without spending a word or a line.
+      final subtotal = groupProjectedSubtotal(group);
+      final hasPlanned = groupHasPlanned(group);
       widgets.add(Padding(
         padding:
             const EdgeInsets.only(top: AppSpacing.sm, bottom: AppSpacing.xs),
@@ -455,6 +698,14 @@ class _BudgetSectionState extends ConsumerState<BudgetSection> {
                     ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
               ),
             ),
+            if (hasPlanned) ...[
+              Tooltip(
+                message: context.l10n.budgetPlanGroupHasPlanned,
+                child: Icon(Icons.radio_button_unchecked,
+                    size: 12, color: theme.colorScheme.onSurfaceVariant),
+              ),
+              const SizedBox(width: AppSpacing.xs),
+            ],
             Text(
               formatMoney(subtotal, currency),
               style: theme.textTheme.labelLarge
@@ -471,12 +722,27 @@ class _BudgetSectionState extends ConsumerState<BudgetSection> {
   }
 
   Widget _buildRow(ThemeData theme, Expense expense, String currency) {
+    final l10n = context.l10n;
+    final paid = expenseIsPaid(expense);
+    // A booking-created line is a mirror of its booking: its payment is the
+    // system's, so it is un-paid by un-booking, not from here. Editing it is
+    // still the documented takeover hatch (00061).
+    final locked = expense.auto;
+    final canFlip = widget.canEdit && !locked;
     return Padding(
       key: ValueKey(expense.id),
       padding: const EdgeInsets.symmetric(vertical: 2),
       child: Row(
         children: [
-          const SizedBox(width: AppSpacing.lg),
+          // Replaces the dead indent this row used to carry: the state signal
+          // and its tap target cost 12px net, not a new column.
+          ExpenseStateGlyph(
+            paid: paid,
+            tooltip: locked ? l10n.budgetPlanAutoLocked : null,
+            onTap: !canFlip
+                ? null
+                : () => paid ? _unpay(expense) : _markPaid(expense, currency),
+          ),
           Expanded(
             child: Text(
               expense.label,
@@ -484,24 +750,32 @@ class _BudgetSectionState extends ConsumerState<BudgetSection> {
                   ?.copyWith(color: theme.colorScheme.onSurface),
             ),
           ),
-          Text(
-            formatMoney(expense.amount, currency),
-            style: theme.textTheme.bodyMedium,
-          ),
+          ExpenseAmountCell(expense: expense, currency: currency),
           if (widget.canEdit)
             PopupMenuButton<String>(
               icon: Icon(Icons.more_vert,
                   size: 18, color: theme.colorScheme.onSurfaceVariant),
-              tooltip: context.l10n.budgetExpenseOptions,
+              tooltip: l10n.budgetExpenseOptions,
               onSelected: (v) {
-                if (v == 'edit') _editExpense(expense);
+                if (v == 'edit') _editExpense(expense, currency);
                 if (v == 'delete') _delete(expense);
+                if (v == 'paid') _markPaid(expense, currency);
+                if (v == 'planned') _unpay(expense);
               },
+              // The glyph is a 28px target, below the minimum tap size, so the
+              // menu carries its accessible twin rather than being the only
+              // way in.
               itemBuilder: (_) => [
+                if (canFlip)
+                  PopupMenuItem(
+                    value: paid ? 'planned' : 'paid',
+                    child: Text(paid
+                        ? l10n.budgetPlanMarkPlanned
+                        : l10n.budgetPlanMarkPaid),
+                  ),
+                PopupMenuItem(value: 'edit', child: Text(l10n.budgetMenuEdit)),
                 PopupMenuItem(
-                    value: 'edit', child: Text(context.l10n.budgetMenuEdit)),
-                PopupMenuItem(
-                    value: 'delete', child: Text(context.l10n.commonDelete)),
+                    value: 'delete', child: Text(l10n.commonDelete)),
               ],
             )
           else
@@ -511,8 +785,14 @@ class _BudgetSectionState extends ConsumerState<BudgetSection> {
     );
   }
 
+  /// The receipt: what you planned, what you spent, how the two compare, and
+  /// what's left against the target. Every number is the server's — they are
+  /// derived once, together, so no two lines here can disagree.
   Widget _buildTotals(ThemeData theme, Budget budget, List<Expense> expenses) {
     final currency = budget.currency;
+    final l10n = context.l10n;
+    final planned = budget.planned;
+    final variance = budget.planVariance;
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
@@ -520,10 +800,29 @@ class _BudgetSectionState extends ConsumerState<BudgetSection> {
           padding: EdgeInsets.symmetric(vertical: AppSpacing.xs),
           child: Divider(height: 1),
         ),
+        // Absent until something is actually planned, so a trip tracking spend
+        // only reads exactly as it did before the split.
+        if (planned != null && planned > 0) ...[
+          Row(
+            children: [
+              Expanded(
+                child: Text(l10n.budgetPlanTotalPlanned,
+                    style: theme.textTheme.titleSmall
+                        ?.copyWith(fontWeight: FontWeight.bold)),
+              ),
+              Text(
+                formatMoney(planned, currency),
+                style: theme.textTheme.titleSmall
+                    ?.copyWith(fontWeight: FontWeight.bold),
+              ),
+            ],
+          ),
+          const SizedBox(height: 2),
+        ],
         Row(
           children: [
             Expanded(
-              child: Text(context.l10n.budgetTotalSpent,
+              child: Text(l10n.budgetTotalSpent,
                   style: theme.textTheme.titleSmall
                       ?.copyWith(fontWeight: FontWeight.bold)),
             ),
@@ -534,12 +833,42 @@ class _BudgetSectionState extends ConsumerState<BudgetSection> {
             ),
           ],
         ),
+        // Scoped by the server to lines carrying BOTH numbers: planned minus
+        // spent mid-trip is "money not yet spent" plus variance, which is two
+        // claims in one number. Null means nothing to compare yet — not zero.
+        if (variance != null) ...[
+          const SizedBox(height: 2),
+          Row(
+            children: [
+              Expanded(
+                child: Text(l10n.budgetPlanVsPlan,
+                    style: theme.textTheme.bodyMedium
+                        ?.copyWith(color: theme.colorScheme.onSurfaceVariant)),
+              ),
+              Text(
+                variance == 0
+                    ? l10n.budgetPlanDeltaOnPlan
+                    : variance > 0
+                        ? l10n.budgetPlanDeltaOver(
+                            formatMoney(variance, currency))
+                        : l10n.budgetPlanDeltaUnder(
+                            formatMoney(-variance, currency)),
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  color: variance > 0
+                      ? theme.colorScheme.error
+                      : theme.colorScheme.onSurfaceVariant,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ],
+          ),
+        ],
         if (budget.remaining != null) ...[
           const SizedBox(height: 2),
           Row(
             children: [
               Expanded(
-                child: Text(context.l10n.budgetRemaining,
+                child: Text(l10n.budgetRemaining,
                     style: theme.textTheme.bodyMedium
                         ?.copyWith(color: theme.colorScheme.onSurfaceVariant)),
               ),
@@ -557,6 +886,55 @@ class _BudgetSectionState extends ConsumerState<BudgetSection> {
         ],
       ],
     );
+  }
+
+  /// Planned or paid, for whatever the add row is about to save.
+  ///
+  /// On its OWN LINE rather than inside the add row: that row already spends
+  /// 240px of its 358 on fixed-width controls, and the "Add an expense…" hint
+  /// barely fits in what's left — any horizontal addition kills it and puts the
+  /// 136px Amount field's no-ellipsis regression under pressure. Vertical space
+  /// in a scrolling tab body is nearly free; horizontal space is the scarce
+  /// resource. The add row's composition is therefore byte-identical to before.
+  ///
+  /// The pick is read from the draft, so it survives the remount that changing
+  /// header tab or opening the chat panel causes — a choice, like the category
+  /// beside it.
+  Widget _buildModeControl(ThemeData theme) {
+    return Consumer(builder: (context, ref, _) {
+      final planned = ref
+          .watch(expenseDraftProvider(widget.tripId).select((d) => d.planned));
+      final l10n = context.l10n;
+      return Align(
+        alignment: Alignment.centerRight,
+        child: Padding(
+          padding: const EdgeInsets.only(bottom: AppSpacing.xs),
+          child: SegmentedButton<bool>(
+            showSelectedIcon: false,
+            style: ButtonStyle(
+              visualDensity: VisualDensity.compact,
+              textStyle: WidgetStatePropertyAll(theme.textTheme.labelMedium),
+            ),
+            segments: [
+              ButtonSegment(
+                value: true,
+                label: Text(l10n.budgetPlanStatePlanned),
+              ),
+              ButtonSegment(
+                value: false,
+                label: Text(l10n.budgetPlanStatePaid),
+              ),
+            ],
+            selected: {planned},
+            onSelectionChanged: widget.isOffline
+                ? null
+                : (picked) => ref
+                    .read(expenseDraftProvider(widget.tripId).notifier)
+                    .setPlanned(picked.first),
+          ),
+        ),
+      );
+    });
   }
 
   Widget _buildAddRow(ThemeData theme) {

--- a/src/packages/flutter-app/test/budget_api_service_test.dart
+++ b/src/packages/flutter-app/test/budget_api_service_test.dart
@@ -1,0 +1,188 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+import 'package:travel_route_planner/services/api_client.dart';
+import 'package:travel_route_planner/services/budget_api_service.dart';
+
+// budget_api_service_test.dart — the WIRE, which the widget tests cannot see:
+// they drive a fake service, so a wrong field name or path would pass every
+// one of them and fail against the real API. These pin the four request shapes
+// the planned/paid split added (00067) against budget_handler.go.
+
+BudgetApiService _service(MockClient client) =>
+    BudgetApiService(ApiClient(baseUrl: 'http://test/api/v1', client: client));
+
+/// The server's expense shape, minus whatever a case wants to override.
+String _expenseJson({
+  double? planned,
+  double? actual,
+  bool purchased = false,
+}) =>
+    jsonEncode({
+      'id': 'e1',
+      'category': 'flights',
+      'label': 'Flights',
+      'amount': actual ?? planned ?? 0,
+      'planned_amount': planned,
+      'actual_amount': actual,
+      'purchased': purchased,
+      'position': 0,
+      'auto': false,
+      'source_kind': null,
+      'source_id': null,
+    });
+
+void main() {
+  test('adding a planned expense sends planned_amount, never amount', () async {
+    late http.Request captured;
+    final service = _service(MockClient((request) async {
+      captured = request;
+      return http.Response(_expenseJson(planned: 400), 201,
+          headers: {'content-type': 'application/json'});
+    }));
+
+    final expense = await service.addExpense('t1',
+        category: 'flights', label: 'Flights', amount: 400, planned: true);
+
+    expect(captured.method, 'POST');
+    expect(captured.url.path, '/api/v1/trips/t1/budget/expenses');
+    final body = jsonDecode(captured.body) as Map<String, dynamic>;
+    expect(body['planned_amount'], 400);
+    expect(body.containsKey('actual_amount'), isFalse);
+    // The legacy field must NOT ride along: the server ignores it when an
+    // explicit one is present, but sending both invites the two to disagree.
+    expect(body.containsKey('amount'), isFalse);
+    expect(expense.plannedFor, 400);
+    expect(expense.paidAmount, isNull);
+  });
+
+  test('the default add is a PAYMENT — what every pre-split caller meant',
+      () async {
+    late http.Request captured;
+    final service = _service(MockClient((request) async {
+      captured = request;
+      return http.Response(_expenseJson(actual: 150, purchased: true), 201,
+          headers: {'content-type': 'application/json'});
+    }));
+
+    // Exactly the call the trip screen's booked-flip prompt makes.
+    await service.addExpense('t1',
+        category: 'lodging',
+        label: 'Hotel',
+        amount: 150,
+        sourceKind: 'accommodation',
+        sourceId: 'acc1');
+
+    final body = jsonDecode(captured.body) as Map<String, dynamic>;
+    expect(body['actual_amount'], 150);
+    expect(body.containsKey('planned_amount'), isFalse);
+    expect(body['source_kind'], 'accommodation');
+  });
+
+  test('paying posts the price to the purchase verb', () async {
+    late http.Request captured;
+    final service = _service(MockClient((request) async {
+      captured = request;
+      return http.Response(_expenseJson(planned: 400, actual: 372, purchased: true), 200,
+          headers: {'content-type': 'application/json'});
+    }));
+
+    final expense =
+        await service.purchaseExpense('t1', 'e1', amount: 372);
+
+    expect(captured.method, 'POST');
+    expect(captured.url.path, '/api/v1/trips/t1/budget/expenses/e1/purchase');
+    expect(jsonDecode(captured.body), {'amount': 372});
+    // The plan came back intact — the whole point of the verb.
+    expect(expense.plannedFor, 400);
+    expect(expense.paidAmount, 372);
+    expect(expense.showsPair, isTrue);
+  });
+
+  test('paying with no amount sends an empty body, meaning "at the plan"',
+      () async {
+    late http.Request captured;
+    final service = _service(MockClient((request) async {
+      captured = request;
+      return http.Response(_expenseJson(planned: 42, actual: 42, purchased: true), 200,
+          headers: {'content-type': 'application/json'});
+    }));
+
+    await service.purchaseExpense('t1', 'e1');
+
+    expect(jsonDecode(captured.body), isEmpty,
+        reason: 'an absent amount is what the server reads as "the plan"');
+  });
+
+  test('un-paying DELETEs the same path and keeps the plan', () async {
+    late http.Request captured;
+    final service = _service(MockClient((request) async {
+      captured = request;
+      return http.Response(_expenseJson(planned: 400), 200,
+          headers: {'content-type': 'application/json'});
+    }));
+
+    final expense = await service.unpurchaseExpense('t1', 'e1');
+
+    expect(captured.method, 'DELETE');
+    expect(captured.url.path, '/api/v1/trips/t1/budget/expenses/e1/purchase');
+    expect(expense.paidAmount, isNull);
+    expect(expense.plannedFor, 400);
+  });
+
+  test('a 409 surfaces as ApiException so the caller can tell it apart',
+      () async {
+    final service = _service(MockClient((request) async => http.Response(
+        jsonEncode({'message': 'this expense has no planned amount'}), 409)));
+
+    await expectLater(
+      service.unpurchaseExpense('t1', 'e1'),
+      throwsA(isA<ApiException>()
+          .having((e) => e.statusCode, 'statusCode', 409)),
+    );
+  });
+
+  test('the budget response carries all four totals', () async {
+    final service = _service(MockClient((request) async => http.Response(
+        jsonEncode({
+          'target_amount': 2000,
+          'currency': 'USD',
+          'spent': 378,
+          'remaining': 1622,
+          'planned': 1150,
+          'projected': 1128,
+          'plan_variance': -28,
+        }),
+        200,
+        headers: {'content-type': 'application/json'})));
+
+    final budget = await service.getBudget('t1');
+
+    expect(budget.spent, 378);
+    expect(budget.planned, 1150);
+    expect(budget.projected, 1128);
+    expect(budget.planVariance, -28);
+  });
+
+  test('a server that predates the split leaves the new totals null', () async {
+    final service = _service(MockClient((request) async => http.Response(
+        jsonEncode({
+          'target_amount': 2000,
+          'currency': 'USD',
+          'spent': 378,
+          'remaining': 1622,
+        }),
+        200,
+        headers: {'content-type': 'application/json'})));
+
+    final budget = await service.getBudget('t1');
+
+    // null means unknown, never 0 — the tab renders its pre-split self.
+    expect(budget.planned, isNull);
+    expect(budget.projected, isNull);
+    expect(budget.planVariance, isNull);
+  });
+}

--- a/src/packages/flutter-app/test/budget_section_test.dart
+++ b/src/packages/flutter-app/test/budget_section_test.dart
@@ -26,6 +26,9 @@ class _FakeBudgetApiService extends BudgetApiService {
 
   final List<Map<String, dynamic>> patches = [];
   final List<Map<String, dynamic>> puts = [];
+  final List<Map<String, dynamic>> adds = [];
+  final List<Map<String, dynamic>> purchases = [];
+  final List<String> unpurchases = [];
   int addCount = 0;
   int deleteCount = 0;
 
@@ -36,7 +39,27 @@ class _FakeBudgetApiService extends BudgetApiService {
   _FakeBudgetApiService(this.expenses, {this.targetAmount, this.currency = 'USD'})
       : super(ApiClient(baseUrl: 'http://test'));
 
-  double get _spent => expenses.fold<double>(0, (s, e) => s + e.amount);
+  // Mirrors the server's sumExpenses (budget_handler.go) off the raw columns,
+  // not off the widget's helpers — that is the whole point of the fake.
+  double get _spent =>
+      expenses.fold<double>(0, (s, e) => s + (e.actualAmount ?? 0));
+  double get _planned =>
+      expenses.fold<double>(0, (s, e) => s + (e.plannedAmount ?? 0));
+  double get _projected => expenses.fold<double>(
+      0, (s, e) => s + (e.actualAmount ?? e.plannedAmount ?? 0));
+
+  /// Scoped to lines carrying BOTH numbers; null when none do.
+  double? get _variance {
+    double sum = 0;
+    var compared = false;
+    for (final e in expenses) {
+      if (e.actualAmount != null && e.plannedAmount != null) {
+        sum += e.actualAmount! - e.plannedAmount!;
+        compared = true;
+      }
+    }
+    return compared ? sum : null;
+  }
 
   @override
   Future<Budget> getBudget(String tripId) async => Budget(
@@ -44,6 +67,9 @@ class _FakeBudgetApiService extends BudgetApiService {
         currency: currency,
         spent: _spent,
         remaining: targetAmount == null ? null : targetAmount! - _spent,
+        planned: _planned,
+        projected: _projected,
+        planVariance: _variance,
       );
 
   @override
@@ -64,20 +90,55 @@ class _FakeBudgetApiService extends BudgetApiService {
       {required String category,
       required String label,
       required double amount,
+      bool planned = false,
       String? sourceKind,
       String? sourceId}) async {
     if (addGate != null) await addGate!.future;
     addCount++;
+    adds.add({'label': label, 'category': category, 'amount': amount, 'planned': planned});
     final e = Expense(
         id: 'new-$addCount',
         category: category,
         label: label,
-        amount: amount,
+        amount: amount, // the derived column: one number either way
+        plannedAmount: planned ? amount : null,
+        actualAmount: planned ? null : amount,
+        purchased: !planned,
         auto: sourceKind != null, // server rule mirrored
         sourceKind: sourceKind,
         sourceId: sourceId);
     expenses.add(e);
     return e;
+  }
+
+  /// The purchase verb pair (00067). `amount` omitted means "paid the planned
+  /// amount"; the server 409s without a plan, which the widget never asks for.
+  @override
+  Future<Expense> purchaseExpense(String tripId, String expenseId,
+      {double? amount}) async {
+    purchases.add({'id': expenseId, 'amount': amount});
+    return _replace(expenseId, (e) {
+      final paid = amount ?? e.plannedAmount!;
+      return e.copyWith(actualAmount: paid, purchased: true, amount: paid);
+    });
+  }
+
+  @override
+  Future<Expense> unpurchaseExpense(String tripId, String expenseId) async {
+    unpurchases.add(expenseId);
+    return _replace(expenseId, (e) {
+      // Keeps the plan and restores it as the headline — the trigger's
+      // COALESCE(actual, planned), mirrored.
+      final plan = e.plannedAmount!;
+      return e.copyWith(clearActual: true, purchased: false, amount: plan);
+    });
+  }
+
+  Expense _replace(String expenseId, Expense Function(Expense) f) {
+    final idx = expenses.indexWhere((e) => e.id == expenseId);
+    if (idx < 0) throw Exception('not found');
+    expenses[idx] = f(expenses[idx]);
+    return expenses[idx];
   }
 
   @override
@@ -86,10 +147,19 @@ class _FakeBudgetApiService extends BudgetApiService {
     patches.add({'id': expenseId, ...body});
     final idx = expenses.indexWhere((e) => e.id == expenseId);
     if (idx >= 0) {
-      expenses[idx] = expenses[idx].copyWith(
+      final before = expenses[idx];
+      final plan = (body['planned_amount'] as num?)?.toDouble();
+      // The legacy `amount` writes back to whichever column it was read from,
+      // exactly as UpdateExpense resolves it in SQL.
+      final legacy = (body['amount'] as num?)?.toDouble();
+      final planned = plan ?? (legacy != null && !before.purchased ? legacy : null);
+      final paid = legacy != null && before.purchased ? legacy : null;
+      expenses[idx] = before.copyWith(
         category: body['category'] as String?,
         label: body['label'] as String?,
-        amount: (body['amount'] as num?)?.toDouble(),
+        plannedAmount: planned,
+        actualAmount: paid,
+        amount: paid ?? planned ?? before.amount,
       );
       return expenses[idx];
     }
@@ -103,8 +173,39 @@ class _FakeBudgetApiService extends BudgetApiService {
   }
 }
 
+/// A PAID line — what every expense was before the planned/paid split, so
+/// every assertion written against these fixtures keeps its meaning.
 Expense _exp(String id, String category, String label, double amount) =>
-    Expense(id: id, category: category, label: label, amount: amount);
+    Expense(
+        id: id,
+        category: category,
+        label: label,
+        amount: amount,
+        actualAmount: amount,
+        purchased: true);
+
+/// A line that is only planned: no payment, so it counts toward `planned` and
+/// `projected` but never toward `spent`.
+Expense _planned(String id, String category, String label, double amount) =>
+    Expense(
+        id: id,
+        category: category,
+        label: label,
+        amount: amount,
+        plannedAmount: amount,
+        purchased: false);
+
+/// A line planned at one price and paid at another.
+Expense _both(String id, String category, String label,
+        {required double planned, required double paid}) =>
+    Expense(
+        id: id,
+        category: category,
+        label: label,
+        amount: paid,
+        plannedAmount: planned,
+        actualAmount: paid,
+        purchased: true);
 
 Future<_FakeBudgetApiService> _pump(
   WidgetTester tester,
@@ -113,6 +214,7 @@ Future<_FakeBudgetApiService> _pump(
   String currency = 'USD',
   bool canEdit = true,
   bool isOffline = false,
+  Locale? locale,
 }) async {
   final fake = _FakeBudgetApiService(expenses,
       targetAmount: targetAmount, currency: currency);
@@ -125,6 +227,8 @@ Future<_FakeBudgetApiService> _pump(
       // unthemed harness is exactly how the truncated-hint bug escaped.
       child: MaterialApp(
       theme: AppTheme.light,
+      locale: locale,
+      supportedLocales: const [Locale('en'), Locale('es')],
       localizationsDelegates: testLocalizationsDelegates,
         home: Scaffold(
           body: SingleChildScrollView(
@@ -572,4 +676,297 @@ void main() {
           'build() re-renders every expense row on every keystroke',
     );
   });
+
+  // --- planned vs paid (00067) -------------------------------------------
+  //
+  // The totals are the server's; what these assert is which of them reach the
+  // screen, and how one line reads.
+
+  group('planned vs paid', () {
+    testWidgets('pre-trip: nothing is spent and the plan carries the summary',
+        (tester) async {
+      await _pump(tester, [
+        _planned('a', 'flights', 'Flights', 1100),
+        _planned('b', 'lodging', 'Hotel', 750),
+        _planned('c', 'food', 'Dinners', 200),
+      ], targetAmount: 2000);
+
+      expect(find.text('\$0 / \$2,000'), findsOneWidget);
+      // Two segments: money gone (none) behind money still committed.
+      expect(find.byType(LinearProgressIndicator), findsNWidgets(2));
+      expect(
+        tester
+            .widget<LinearProgressIndicator>(
+                find.byKey(const ValueKey('budgetBarProjected')))
+            .value,
+        1.0,
+        reason: 'the plan already fills the target',
+      );
+      expect(find.text('Projected \$2,050 · \$50 over target'), findsOneWidget);
+      expect(find.text('Total planned'), findsOneWidget);
+      // Nothing has been paid, so there is nothing to compare — and the row
+      // says nothing rather than saying zero.
+      expect(find.text('Vs plan'), findsNothing);
+    });
+
+    testWidgets('mid-trip: a pair row, the group marker, and the comparison',
+        (tester) async {
+      await _pump(tester, [
+        _both('a', 'flights', 'JFK → CDG', planned: 1100, paid: 1150),
+        _planned('b', 'food', 'Dinners', 200),
+        _exp('c', 'food', 'Lunch at Nikkei', 34),
+      ], targetAmount: 2000);
+
+      // A line that came in at a different price shows both numbers; the two
+      // settled ones show one.
+      expect(find.text('\$1,100→\$1,150'), findsOneWidget);
+      expect(find.text('\$200'), findsOneWidget);
+      expect(find.text('\$34'), findsOneWidget);
+
+      // The marker rides the group that still contains unpaid money, and only
+      // that one.
+      expect(find.byTooltip('Includes planned amounts'), findsOneWidget);
+
+      expect(find.text('Total planned'), findsOneWidget);
+      expect(find.text('Vs plan'), findsOneWidget);
+      expect(find.text('\$50 over'), findsOneWidget);
+    });
+
+    testWidgets('end of trip: one bar, and the plan is still there to compare',
+        (tester) async {
+      await _pump(tester, [
+        _both('a', 'flights', 'Flights', planned: 400, paid: 437),
+        _both('b', 'lodging', 'Hotel', planned: 750, paid: 750),
+        _both('c', 'food', 'Food', planned: 350, paid: 291),
+      ], targetAmount: 2000);
+
+      // Everything is bought, so there is no committed-but-unspent segment.
+      expect(find.byType(LinearProgressIndicator), findsOneWidget);
+      expect(find.textContaining('Projected'), findsNothing);
+      expect(find.byTooltip('Includes planned amounts'), findsNothing);
+      // THE feature: the plan did not collapse to zero when the trip ended.
+      expect(find.text('Total planned'), findsOneWidget);
+      expect(find.text('\$1,500'), findsOneWidget);
+      expect(find.text('\$1,478'), findsOneWidget);
+      expect(find.text('\$22 under'), findsOneWidget);
+    });
+
+    testWidgets('a payload from before the split renders exactly as today',
+        (tester) async {
+      // An old server, or a bundle cached before 00067: no planned/projected,
+      // rows carrying only `amount`.
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            budgetApiServiceProvider.overrideWithValue(
+                _LegacyBudgetApiService([
+              const Expense(
+                  id: 'a', category: 'food', label: 'Lunch', amount: 20),
+            ])),
+          ],
+          child: MaterialApp(
+            theme: AppTheme.light,
+            localizationsDelegates: testLocalizationsDelegates,
+            home: const Scaffold(
+              body: SingleChildScrollView(
+                child: BudgetSection(
+                    tripId: 't1', canEdit: true, isOffline: false),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('\$20 / \$100'), findsOneWidget);
+      expect(find.byType(LinearProgressIndicator), findsOneWidget);
+      expect(find.textContaining('Projected'), findsNothing);
+      expect(find.text('Total planned'), findsNothing);
+      expect(find.text('Vs plan'), findsNothing);
+      // The line counted as spend before the split, so it still reads as paid.
+      expect(find.byTooltip('Mark as planned'), findsOneWidget);
+    });
+
+    testWidgets('marking a line paid prefills the plan and posts the price',
+        (tester) async {
+      final fake = await _pump(
+          tester, [_planned('a', 'lodging', 'Hotel Nacional', 750)],
+          targetAmount: 2000);
+
+      await tester.tap(find.byTooltip('Mark as paid'));
+      await tester.pumpAndSettle();
+
+      final field = find.descendant(
+          of: find.byType(AlertDialog), matching: find.byType(TextField));
+      expect(tester.widget<TextField>(field).controller!.text, '750',
+          reason: 'paying exactly what you planned should be one tap');
+
+      await tester.enterText(field, '812');
+      await tester.tap(find.widgetWithText(FilledButton, 'Save'));
+      await tester.pumpAndSettle();
+
+      expect(fake.purchases, [
+        {'id': 'a', 'amount': 812.0}
+      ]);
+      // The row now carries both numbers, and the totals follow.
+      expect(find.text('\$750→\$812'), findsOneWidget);
+      expect(find.text('\$62 over'), findsOneWidget);
+    });
+
+    testWidgets('un-paying keeps the plan and offers Undo', (tester) async {
+      final fake = await _pump(
+          tester, [_both('a', 'flights', 'Flights', planned: 400, paid: 372)],
+          targetAmount: 2000);
+
+      await tester.tap(find.byTooltip('Mark as planned'));
+      await tester.pumpAndSettle();
+
+      expect(fake.unpurchases, ['a']);
+      expect(find.text('Flights moved back to planned'), findsOneWidget);
+      // The plan survived: the line is offering to be paid again, and the
+      // headline it shows is the plan rather than the payment it lost.
+      expect(find.byTooltip('Mark as paid'), findsOneWidget);
+      expect(find.text('\$372'), findsNothing);
+
+      await tester.tap(find.text('Undo'));
+      await tester.pumpAndSettle();
+      expect(fake.purchases, [
+        {'id': 'a', 'amount': 372.0}
+      ]);
+    });
+
+    testWidgets('a line with no plan converts instead of failing',
+        (tester) async {
+      // The server cannot un-pay a line with no plan — it would be left with
+      // no amount at all — so the client states the plan first.
+      final fake = await _pump(tester, [_exp('a', 'food', 'Gelato', 6)],
+          targetAmount: 2000);
+
+      await tester.tap(find.byTooltip('Mark as planned'));
+      await tester.pumpAndSettle();
+
+      expect(fake.patches, [
+        {'id': 'a', 'planned_amount': 6.0}
+      ]);
+      expect(fake.unpurchases, ['a']);
+    });
+
+    testWidgets('a booking-created line cannot be un-paid from here',
+        (tester) async {
+      final fake = await _pump(tester, [
+        const Expense(
+            id: 'a',
+            category: 'lodging',
+            label: 'Hotel',
+            amount: 300,
+            actualAmount: 300,
+            purchased: true,
+            auto: true,
+            sourceKind: 'accommodation',
+            sourceId: 'acc1'),
+      ], targetAmount: 2000);
+
+      // Its payment mirrors the booking, so it is un-paid by un-booking.
+      expect(find.byTooltip('From a booking — un-book it to remove'),
+          findsOneWidget);
+      expect(find.byTooltip('Mark as planned'), findsNothing);
+
+      // .first is the ROW's menu; the add row's category picker is also a
+      // PopupMenuButton<String> and sits after it.
+      await tester.tap(find.byType(PopupMenuButton<String>).first);
+      await tester.pumpAndSettle();
+      expect(find.text('Mark as planned'), findsNothing);
+      expect(find.text('Edit'), findsOneWidget);
+      expect(fake.unpurchases, isEmpty);
+    });
+
+    testWidgets('the add row defaults to planned and remembers the pick',
+        (tester) async {
+      final fake = await _pump(tester, [_exp('a', 'food', 'Lunch', 20)],
+          targetAmount: 2000);
+
+      await tester.enterText(find.byType(TextField).first, 'Museum pass');
+      await tester.enterText(find.byType(TextField).last, '42');
+      await tester.tap(find.byTooltip('Add expense'));
+      await tester.pumpAndSettle();
+      expect(fake.adds.single['planned'], isTrue,
+          reason: 'a wrongly-planned row is visible; a wrongly-paid one is not');
+
+      // Flip once, and it stays flipped for the rest of the session.
+      await tester.tap(find.text('Paid'));
+      await tester.pumpAndSettle();
+      for (final label in ['Taxi', 'Coffee']) {
+        await tester.enterText(find.byType(TextField).first, label);
+        await tester.enterText(find.byType(TextField).last, '9');
+        await tester.tap(find.byTooltip('Add expense'));
+        await tester.pumpAndSettle();
+      }
+      expect(fake.adds.skip(1).every((a) => a['planned'] == false), isTrue);
+    });
+
+    testWidgets('offline cannot flip the mode or a line', (tester) async {
+      final fake = await _pump(
+          tester, [_planned('a', 'lodging', 'Hotel', 750)],
+          targetAmount: 2000, isOffline: true);
+
+      expect(
+          tester
+              .widget<SegmentedButton<bool>>(find.byType(SegmentedButton<bool>))
+              .onSelectionChanged,
+          isNull);
+      await tester.tap(find.byTooltip('Mark as paid'));
+      await tester.pumpAndSettle();
+      expect(find.textContaining("You're offline"), findsOneWidget);
+      expect(fake.purchases, isEmpty);
+    });
+
+    testWidgets('a viewer sees the state marks but cannot flip them',
+        (tester) async {
+      await _pump(tester, [
+        _planned('a', 'lodging', 'Hotel', 750),
+        _exp('b', 'food', 'Lunch', 20),
+      ], targetAmount: 2000, canEdit: false);
+
+      // Sharing a budget means sharing the whole story, read-only.
+      expect(find.text('Total planned'), findsOneWidget);
+      expect(find.byTooltip('Mark as paid'), findsNothing);
+      expect(find.byTooltip('Mark as planned'), findsNothing);
+      expect(find.byType(SegmentedButton<bool>), findsNothing);
+    });
+
+    testWidgets('Spanish keeps Previsto for money and fits at 360px',
+        (tester) async {
+      tester.view.physicalSize = const Size(360, 900);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+      await _pump(tester, [_planned('a', 'lodging', 'Hotel', 750)],
+          targetAmount: 2000, locale: const Locale('es'));
+
+      // "Planeado" is the trips-list travel-stats word for a whole trip; money
+      // uses Previsto.
+      expect(find.text('Previsto'), findsOneWidget);
+      expect(find.text('Pagado'), findsOneWidget);
+      expect(find.text('Total previsto'), findsOneWidget);
+      expect(tester.takeException(), isNull);
+    });
+  });
+}
+
+/// A server that predates the split: no `planned`/`projected` totals, and rows
+/// carrying only the legacy `amount`.
+class _LegacyBudgetApiService extends BudgetApiService {
+  final List<Expense> expenses;
+  _LegacyBudgetApiService(this.expenses)
+      : super(ApiClient(baseUrl: 'http://test'));
+
+  @override
+  Future<Budget> getBudget(String tripId) async => Budget(
+        targetAmount: 100,
+        currency: 'USD',
+        spent: expenses.fold<double>(0, (s, e) => s + e.amount),
+        remaining: 100 - expenses.fold<double>(0, (s, e) => s + e.amount),
+      );
+
+  @override
+  Future<List<Expense>> listExpenses(String tripId) async => List.of(expenses);
 }

--- a/src/packages/flutter-app/test/trip_detail_booked_expense_prompt_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_booked_expense_prompt_test.dart
@@ -101,12 +101,14 @@ class _FakeBudgetApiService extends BudgetApiService {
       {required String category,
       required String label,
       required double amount,
+      bool planned = false,
       String? sourceKind,
       String? sourceId}) async {
     addCalls.add({
       'category': category,
       'label': label,
       'amount': amount,
+      'planned': planned,
       'source_kind': sourceKind,
       'source_id': sourceId,
     });
@@ -115,6 +117,10 @@ class _FakeBudgetApiService extends BudgetApiService {
         category: category,
         label: label,
         amount: amount,
+        // A booked flip records a PAYMENT (00067) — the prompt never plans.
+        actualAmount: planned ? null : amount,
+        plannedAmount: planned ? amount : null,
+        purchased: !planned,
         auto: sourceKind != null,
         sourceKind: sourceKind,
         sourceId: sourceId);
@@ -226,6 +232,9 @@ void main() {
       'category': 'lodging',
       'label': 'Hotel Lutetia',
       'amount': 150.0,
+      // A booked flip records a PAYMENT, never a plan (00067) — the server's
+      // linked path refuses a plan-only add outright.
+      'planned': false,
       // The link rides the most durable row: the confirmed stay, not the todo.
       'source_kind': 'accommodation',
       'source_id': 'acc1',


### PR DESCRIPTION
## Summary

The visible half of planned-vs-paid. #439 shipped the columns, the verbs and
the totals; until now the tab rendered exactly as it had before, so opening it
showed nothing new. This is the door.

**The summary keeps its headline** — `spent / target`, so the number Brian reads
daily doesn't silently change and stays in step with the over-budget health
warning — and grows a **second shade behind the bar**: solid is money gone,
translucent is money still committed. The translucent segment renders only when
there *is* unspent plan, so a finished trip and any pre-split payload have
exactly one bar, as they always did. Two "over" states stay distinct: money
overspent is `error`; money merely *planned* past the target tints only the
projection.

**Rows** carry `○` / `✓` where a dead indent used to be — a state signal, its
semantics label, and the mark-paid tap target for 12px net. Both numbers appear
only when they differ (`$1,100→$1,150`); equal amounts collapse, because
"$750 → $750" is noise. Group subtotals stay one number with a small hollow
mark when the group still holds unpaid money.

**The footer becomes a receipt:** Total planned · Total spent · Vs plan ·
Remaining. `Vs plan` is the server's variance, scoped to lines carrying *both*
numbers — planned-minus-spent mid-trip is "money not yet spent" plus variance,
which is two claims in one number. Absent means nothing to compare yet, never
zero.

**Adding** gets a `Planned | Paid` control on its **own line**. The add row
already spends 240 of its 358px on fixed-width controls and the "Add an
expense…" hint barely fits; vertical space in a scrolling tab body is nearly
free, horizontal space is the scarce resource. The add row's composition is
byte-identical, so the 136px no-ellipsis regression test still means what it
meant. The pick lives in `ExpenseDraft` beside the category — a *choice*, and
one that has to survive the remount opening the chat panel causes (#435) — and
defaults to **Planned**: a wrongly-planned row is visible and two taps to fix,
while a wrongly-paid one inflates spend quietly and can fire a false
over-budget warning.

**Marking paid** prefills the plan, so paying what you budgeted is one tap and a
different price is one edit. **Un-paying** is one tap plus an Undo snackbar. A
line with no plan is *converted* first — what you paid becomes the plan — rather
than answering a mis-tap with the server's 409. A booking-created line's `✓` is
inert with an explanation: its payment mirrors the booking, so un-booking is
what clears it, and Edit remains the documented takeover hatch.

## Testing

- **1419 Flutter tests pass**, including 12 new Budget-tab cases: pre-trip (two
  bars, projection line, no `Vs plan`), mid-trip (pair row, group marker, the
  comparison), end-of-trip (**one** bar and the plan still there to compare —
  the acceptance case), a **pre-split payload rendering exactly as today**,
  mark-paid, un-pay + Undo, the plan-less conversion, the inert `auto` row,
  sticky add mode, offline, viewer, and Spanish at 360px.
- **All 19 pre-existing `budget_section_test.dart` cases pass unchanged** — the
  fake was taught the new derivation and `_exp()` still builds a *paid* row, so
  every old assertion keeps its meaning. That is the backward-compatibility
  proof.
- New **`budget_api_service_test.dart`** pins the wire the widget tests cannot
  see: they drive a fake service, so a wrong field name or path would pass every
  one of them and fail against the real API. It asserts the exact request bodies
  (`planned_amount` vs `actual_amount`, the empty purchase body meaning "at the
  plan", the DELETE path) and that a pre-split budget response leaves the new
  totals null.
- `flutter analyze` clean on every touched file; `l10n_untranslated.json` is
  `{}`.
- **Not done:** a manual walk in a running app. Three attempts at an in-container
  HTTP round-trip died on BusyBox/shell quoting, so I stopped rather than keep
  digging — both sides of the contract are pinned by tests instead (Go
  integration tests exercise the real router and DB; the service test exercises
  the real request construction). Worth a two-minute click-through on the dev
  stack before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)