### PR TITLE
fix(trip): the New chat button says what it is

### DIFF
--- a/docs/friction-log.md
+++ b/docs/friction-log.md
@@ -5,6 +5,28 @@ build queue. Priority when picking work: **breakage > friction in features
 actually used > ideas that recur across ≥2 sessions**. Tag entries `[app]`
 (dogfooding the product) or `[dev]` (workflow/tooling). Newest first.
 
+## 2026-08-16 — the New chat button nobody could find
+
+- **[app] It shipped, and I went looking for it anyway.** #441 put "New chat"
+  in the refine panel header as an icon-only button with a tooltip. On a
+  touchscreen a tooltip does not exist, `add_comment_outlined` reads as "add a
+  comment", and beside the ✕ an unlabeled glyph reads as chrome. It was live in
+  prod, working, for a day — and the person who wrote the spec asked for the
+  feature to be built. An action whose only name is a tooltip is an
+  undocumented action. Now it carries its label.
+- **[app] It was also in the wrong place.** The page advertises the saved
+  conversation on the Continue-chat card, so that is where you go to be rid of
+  it — but the only route was to open the chat and wait out a full transcript
+  restore just to throw it away. The card now carries the action itself.
+- **[dev] The confirm was reading the wrong copy of the truth.** `_newChat`
+  skipped its dialog when the *in-memory* transcript was empty — which is true
+  on every card-path tap, because that path deliberately never hydrates. Adding
+  the entry point without fixing the gate would have made one tap destroy a
+  fifty-message conversation with no dialog at all. "Is there a conversation?"
+  has to be answered from wherever one can exist (memory *or* the trip's
+  `refine_chat` summary), never from whichever copy this code path happens to
+  hold. Mutation-checked: the new test fails with the gate reverted.
+
 ## 2026-08-15 — the second half of the composer bug
 
 - **[app] Same defect, second surface.** The Budget row fix (#435) named the

--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -1892,6 +1892,24 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
               ),
             ],
           ),
+          // A menu, not a bare icon: this sits a thumb's width from the row's
+          // own onTap, which OPENS the conversation, and discarding one must
+          // never be the near miss of resuming it. It is also the only way to
+          // be rid of a saved chat without first opening it and waiting out a
+          // full restore just to throw the transcript away.
+          trailing: PopupMenuButton<String>(
+            onSelected: (_) => _newChat(trip),
+            itemBuilder: (context) => [
+              PopupMenuItem(
+                value: 'new',
+                child: ListTile(
+                  leading: const Icon(Icons.add_comment_outlined),
+                  title: Text(l10n.refineNewChat),
+                  contentPadding: EdgeInsets.zero,
+                ),
+              ),
+            ],
+          ),
           onTap: () => _openChat(trip),
         ),
       ),
@@ -2030,8 +2048,14 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
   /// with one running chat per trip, this really does throw the thread away.
   Future<void> _newChat(Trip trip) async {
     final l10n = context.l10n;
+    // "Is there a conversation?" is answered from wherever one can exist, not
+    // from whichever copy this path happens to hold: the Continue-chat row
+    // clears without ever opening the panel, so the transcript is NOT
+    // hydrated there and an in-memory-only test would skip the confirm on
+    // exactly the fifty-message chat it exists to protect.
     final hasConversation =
-        ref.read(tripRefineProvider(widget.tripId)).messages.isNotEmpty;
+        ref.read(tripRefineProvider(widget.tripId)).messages.isNotEmpty ||
+            trip.refineChat != null;
     if (hasConversation) {
       final confirm = await showDialog<bool>(
         context: context,

--- a/src/packages/flutter-app/lib/widgets/trip_refine_panel.dart
+++ b/src/packages/flutter-app/lib/widgets/trip_refine_panel.dart
@@ -150,11 +150,16 @@ class TripRefinePanel extends ConsumerWidget {
                 ),
               ),
               // The only thing that discards a trip's conversation, now that no
-              // ✨ tap does.
+              // ✨ tap does — so it carries its label. Shipped icon-only and
+              // the person who specified it went looking and couldn't find it:
+              // a tooltip is invisible on touch, and beside the ✕ an unlabeled
+              // glyph reads as chrome. The title above is Expanded and
+              // ellipsizes, so a long chapter yields to this rather than
+              // pushing it off the header.
               if (phase == RefineChatPhase.ready && hasConversation)
-                IconButton(
-                  icon: const Icon(Icons.add_comment_outlined),
-                  tooltip: l10n.refineNewChat,
+                TextButton.icon(
+                  icon: const Icon(Icons.add_comment_outlined, size: 18),
+                  label: Text(l10n.refineNewChat),
                   onPressed: onNewChat,
                 ),
               IconButton(

--- a/src/packages/flutter-app/test/trip_detail_resume_chat_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_resume_chat_test.dart
@@ -25,6 +25,12 @@ import 'support/l10n_test_app.dart';
 
 class _FakeTripsApiService extends TripsApiService {
   final Trip trip;
+
+  /// What `GET /trips/{id}` answers once the conversation has been cleared.
+  /// The server drops `refine_chat` on DELETE, and the row going away is the
+  /// page's only confirmation — a fake that kept serving the summary would
+  /// make that assertion vacuous.
+  final Trip? clearedTrip;
   final TripRefineChatDetail? detail;
   final Object? failWith;
 
@@ -34,11 +40,13 @@ class _FakeTripsApiService extends TripsApiService {
   int getChatCalls = 0;
   int deleteCalls = 0;
 
-  _FakeTripsApiService(this.trip, {this.detail, this.failWith, this.gate})
+  _FakeTripsApiService(this.trip,
+      {this.detail, this.failWith, this.gate, this.clearedTrip})
       : super(ApiClient(baseUrl: 'http://test'));
 
   @override
-  Future<Trip> getTrip(String id) async => trip;
+  Future<Trip> getTrip(String id) async =>
+      deleteCalls > 0 ? (clearedTrip ?? trip) : trip;
 
   @override
   Future<TripRefineChatDetail> getTripRefineChat(String tripId) async {
@@ -298,7 +306,11 @@ void main() {
     await tester.pumpAndSettle();
     expect(_refineState(tester).messages, hasLength(2));
 
-    await tester.tap(find.byTooltip('New chat'));
+    // Tapped by its label, which is the point: it shipped icon-only behind a
+    // tooltip nobody on a touchscreen can see. `find.text` rather than
+    // widgetWithText — TextButton.icon builds a private subtype.
+    expect(find.text('New chat'), findsOneWidget);
+    await tester.tap(find.text('New chat'));
     await tester.pumpAndSettle();
     expect(find.text('Start a new chat?'), findsOneWidget);
 
@@ -307,12 +319,69 @@ void main() {
     expect(_refineState(tester).messages, hasLength(2));
     expect(api.deleteCalls, 0);
 
-    await tester.tap(find.byTooltip('New chat'));
+    await tester.tap(find.text('New chat'));
     await tester.pumpAndSettle();
     await tester.tap(find.widgetWithText(FilledButton, 'New chat'));
     await tester.pumpAndSettle();
 
     expect(_refineState(tester).messages, isEmpty);
     expect(api.deleteCalls, 1);
+    // Nothing left to discard.
+    expect(find.text('New chat'), findsNothing);
+  });
+
+  testWidgets('New chat from the Continue chat row asks first, then clears',
+      (WidgetTester tester) async {
+    // This path clears WITHOUT opening the panel, so no transcript is ever
+    // hydrated here — a confirm gated on the in-memory message list would wave
+    // it straight through on exactly the long conversation it protects.
+    final api = _FakeTripsApiService(_trip(chat: _summary()),
+        detail: _detail(), clearedTrip: _trip());
+    await tester.pumpWidget(_app(api));
+    await tester.pumpAndSettle();
+
+    await tester.tap(_rowMenu);
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('New chat'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Start a new chat?'), findsOneWidget);
+    expect(api.deleteCalls, 0);
+    expect(api.getChatCalls, 0,
+        reason: 'discarding a conversation never restores it first');
+
+    await tester.tap(find.widgetWithText(FilledButton, 'New chat'));
+    await tester.pumpAndSettle();
+
+    expect(api.deleteCalls, 1);
+    // The row going away is the confirmation.
+    expect(find.text('Continue chat'), findsNothing);
+    expect(find.byType(ChatPanel), findsNothing,
+        reason: 'clearing a conversation is not opening one');
+  });
+
+  testWidgets('cancelling from the row leaves the conversation alone',
+      (WidgetTester tester) async {
+    final api = _FakeTripsApiService(_trip(chat: _summary()),
+        detail: _detail(), clearedTrip: _trip());
+    await tester.pumpWidget(_app(api));
+    await tester.pumpAndSettle();
+
+    await tester.tap(_rowMenu);
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('New chat'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Cancel'));
+    await tester.pumpAndSettle();
+
+    expect(api.deleteCalls, 0);
+    expect(find.text('Continue chat'), findsOneWidget);
   });
 }
+
+/// The Continue-chat row's own ⋮ — the screen has several
+/// `PopupMenuButton<String>`s, so this is scoped to the row.
+final Finder _rowMenu = find.descendant(
+  of: find.widgetWithText(ListTile, 'Continue chat'),
+  matching: find.byType(PopupMenuButton<String>),
+);


### PR DESCRIPTION
## Summary

- **Label the header action.** "New chat" shipped with specs/trip-refine-memory (#441) as an icon-only button behind a tooltip, beside the ✕. A tooltip does not exist on a touchscreen, `add_comment_outlined` reads as "add a comment", and an unlabeled glyph next to ✕ reads as chrome — it was live and working in prod for a day, and the person who wrote the spec went looking for it and asked for the feature to be built. It is now a labeled `TextButton.icon`; the header title is already `Expanded` + ellipsized, so a long chapter yields to it.
- **Offer it from the Continue-chat card.** That card is where the page advertises a saved conversation, so it is where you go to be rid of one. The only route before was to open the chat and wait out a full transcript restore just to throw it away. Trailing ⋮ → "New chat" — a menu, not a bare icon, because it sits a thumb's width from the row's own tap target, which *opens* the conversation.
- **Fix the confirm gate (the load-bearing bit).** `_newChat` decided whether to confirm by reading the *in-memory* transcript — which is empty on every card-path tap, because that path deliberately never hydrates. Shipping the new entry point without this would have let one tap discard a fifty-message conversation with no dialog at all. "Is there a conversation?" is now answered from wherever one can exist (memory *or* the trip's `refine_chat` summary).

No API change, no migration, no new l10n keys — `refineNewChat` and the two confirm strings already exist in en + es.

Deliberately unchanged: the composer draft survives "New chat" (unsent words are the traveler's, not the conversation's — #444 exists to stop losing them), and the Plan tab's ⟳ "Start over" is out of scope.

## Testing

- `flutter test` — full suite green (1439 tests), including 2 new ones in `test/trip_detail_resume_chat_test.dart`: the card path asks before clearing then deletes and drops the row, and Cancel leaves everything alone. The existing header test now taps the button *by its label*.
- **Mutation-checked**: reverting the gate to the in-memory-only check fails `New chat from the Continue chat row asks first, then clears`, so the pin is real. The test fake now models the server's post-state (`GET /trips/{id}` drops `refine_chat` after the DELETE) — otherwise "the row goes away" would have been a vacuous assertion.
- `flutter analyze --no-fatal-infos --fatal-warnings` — clean (3 pre-existing infos in `lib/models/route_response.dart`, untouched).
- Not run: a live pass against a dev stack. Reproducing the state needs a real AI turn to persist a refine session; the behaviour here is covered by widget tests and the layout risk is structural (the title is `Expanded`, so the header cannot overflow).

## Hub-file note

`trip_detail_screen.dart` is the contended hub file and two lanes hold it (#442 `shape-before-schedule`, and the unopened `trip-description`). This diff is two small hunks — the `_continueChatRow` `ListTile` and the `_newChat` gate — and neither lane touches those regions, so it should rebase cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)