### PR TITLE
feat(trip): fold the whole itinerary in one tap

### DIFF
--- a/src/packages/flutter-app/lib/l10n/app_en.arb
+++ b/src/packages/flutter-app/lib/l10n/app_en.arb
@@ -1028,6 +1028,14 @@
   "tripItinerary": "Itinerary",
   "tripToday": "Today",
   "tripAddPlace": "Add place",
+  "tripCollapseAll": "Collapse all",
+  "@tripCollapseAll": {
+    "description": "Tooltip (and phone overflow-menu label) for the one-tap control that folds every destination group on the trip itinerary. Flips to tripExpandAll once everything is collapsed. 'All' means every destination — say it without naming them, the way a file tree's collapse-all does."
+  },
+  "tripExpandAll": "Expand all",
+  "@tripExpandAll": {
+    "description": "The other face of tripCollapseAll: re-opens every destination group AND every day section inside them."
+  },
   "tripFilterUnbooked": "Not booked yet",
   "tripFilterAllBooked": "Everything's booked",
   "tripFilterAllBookedMessage": "Nothing left to book on this trip — you're all set.",

--- a/src/packages/flutter-app/lib/l10n/app_es.arb
+++ b/src/packages/flutter-app/lib/l10n/app_es.arb
@@ -471,6 +471,8 @@
   "tripItinerary": "Itinerario",
   "tripToday": "Hoy",
   "tripAddPlace": "Añadir lugar",
+  "tripCollapseAll": "Contraer todo",
+  "tripExpandAll": "Expandir todo",
   "tripFilterUnbooked": "Sin reservar",
   "tripFilterAllBooked": "Todo reservado",
   "tripFilterAllBookedMessage": "No queda nada por reservar en este viaje — todo listo.",

--- a/src/packages/flutter-app/lib/l10n/app_localizations.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations.dart
@@ -2924,6 +2924,18 @@ abstract class AppLocalizations {
   /// **'Add place'**
   String get tripAddPlace;
 
+  /// Tooltip (and phone overflow-menu label) for the one-tap control that folds every destination group on the trip itinerary. Flips to tripExpandAll once everything is collapsed. 'All' means every destination — say it without naming them, the way a file tree's collapse-all does.
+  ///
+  /// In en, this message translates to:
+  /// **'Collapse all'**
+  String get tripCollapseAll;
+
+  /// The other face of tripCollapseAll: re-opens every destination group AND every day section inside them.
+  ///
+  /// In en, this message translates to:
+  /// **'Expand all'**
+  String get tripExpandAll;
+
   /// No description provided for @tripFilterUnbooked.
   ///
   /// In en, this message translates to:

--- a/src/packages/flutter-app/lib/l10n/app_localizations_en.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations_en.dart
@@ -1617,6 +1617,12 @@ class AppLocalizationsEn extends AppLocalizations {
   String get tripAddPlace => 'Add place';
 
   @override
+  String get tripCollapseAll => 'Collapse all';
+
+  @override
+  String get tripExpandAll => 'Expand all';
+
+  @override
   String get tripFilterUnbooked => 'Not booked yet';
 
   @override

--- a/src/packages/flutter-app/lib/l10n/app_localizations_es.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations_es.dart
@@ -1629,6 +1629,12 @@ class AppLocalizationsEs extends AppLocalizations {
   String get tripAddPlace => 'Añadir lugar';
 
   @override
+  String get tripCollapseAll => 'Contraer todo';
+
+  @override
+  String get tripExpandAll => 'Expandir todo';
+
+  @override
   String get tripFilterUnbooked => 'Sin reservar';
 
   @override

--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -860,9 +860,15 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
   /// already-focused target) changes no state at all — on a quiescent UI no
   /// frame would ever come and the scroll would silently stall until
   /// unrelated activity. ensureVisualUpdate guarantees the frame.
-  void _revealCityHeader(String groupKey) {
-    WidgetsBinding.instance
-        .addPostFrameCallback((_) => _scrollToCityHeader(groupKey));
+  ///
+  /// [animate] false lands the header in one jump instead of the 350ms glide.
+  /// The fold-all control passes false because it changes the whole list's
+  /// extent at once: collapsing everything can leave the current offset far
+  /// past the new maxScrollExtent, and gliding from an out-of-range offset
+  /// paints blank while it travels.
+  void _revealCityHeader(String groupKey, {bool animate = true}) {
+    WidgetsBinding.instance.addPostFrameCallback(
+        (_) => _scrollToCityHeader(groupKey, animate: animate));
     WidgetsBinding.instance.ensureVisualUpdate();
   }
 
@@ -870,7 +876,10 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
   /// chrome — [_scrollToDayHeader] minus the city-header term (this header
   /// IS the target; the chrome rests via getOffsetToReveal's own
   /// obstruction handling, see there). Same one-correction contract.
-  Future<void> _scrollToCityHeader(String cityKey) async {
+  ///
+  /// [animate] false jumps instead — see [_revealCityHeader].
+  Future<void> _scrollToCityHeader(String cityKey,
+      {bool animate = true}) async {
     final trip = _trip;
     if (!mounted || trip == null || !_scroll.hasClients) return;
     final target =
@@ -880,9 +889,17 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
     if (viewport == null) return;
     final reveal = viewport.getOffsetToReveal(target, 0).offset;
     final offset = reveal.clamp(0.0, _scroll.position.maxScrollExtent);
-    await _scroll.animateTo(offset,
-        duration: const Duration(milliseconds: 350),
-        curve: Curves.easeOutCubic);
+    if (animate) {
+      await _scroll.animateTo(offset,
+          duration: const Duration(milliseconds: 350),
+          curve: Curves.easeOutCubic);
+    } else {
+      _scroll.jumpTo(offset);
+      // Unlike the awaited animateTo, jumpTo does not relayout before it
+      // returns: the correction pass below would measure the offset we just
+      // left and then "correct" by that stale delta. Wait for the frame.
+      await WidgetsBinding.instance.endOfFrame;
+    }
     if (!mounted || !_scroll.hasClients) return;
     final box = _cityHeaderKeys[cityKey]?.currentContext?.findRenderObject();
     if (box is! RenderBox || !box.attached) return;
@@ -894,6 +911,119 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
       _scroll.jumpTo((_scroll.offset + delta)
           .clamp(0.0, _scroll.position.maxScrollExtent));
     }
+  }
+
+  // ── Fold all / unfold all ─────────────────────────────────────────────
+  // One control, two directions, kept next to the reveal machinery it
+  // reuses. Both flags are DERIVED from the live derivation every build and
+  // never stored — the view-tabs doctrine (PR #335): a stored "is everything
+  // collapsed?" bit drifts the moment a refresh adds or drops a destination,
+  // and the two placements (wide header button, narrow overflow entry) would
+  // then disagree about what one tap means.
+
+  /// Whether the fold control has anything to act on. The Bookings and
+  /// Budget views swap the city groups out for flat lists — there is no
+  /// accordion there to fold — and an items-empty trip renders the
+  /// EmptyState branch with no groups behind it.
+  bool _foldControlShown(TripDerivation d) =>
+      !_inBookingsView && !_inBudgetView && d.groups.isNotEmpty;
+
+  /// True only when EVERY live group is collapsed — the one state in which
+  /// the control flips to "Expand all". `<empty>.every(...)` is true in
+  /// Dart, so the isNotEmpty guard is what keeps this predicate honest on
+  /// its own terms; no live caller reaches it with an empty list, since
+  /// they all gate on [_foldControlShown] first.
+  bool _allGroupsCollapsed(TripDerivation d) =>
+      d.groups.isNotEmpty &&
+      d.groups.every((g) => _collapsedGroups.contains(g.key));
+
+  /// THE fold action, shared by the wide header button and the narrow
+  /// overflow entry so the two can never disagree. Re-derives at ACTION
+  /// time rather than trusting a captured flag: the overflow entry is built
+  /// when the menu opens and selected a beat later.
+  ///
+  /// Pure LIST work, exactly like a header tap: it never writes map focus
+  /// ([_setMapFocus] stays the only writer), never moves the camera, and
+  /// never exits a lens.
+  ///
+  /// Deliberately asymmetric. Collapsing touches GROUPS only — a collapsed
+  /// city's day headers aren't rendered, so [_collapsedDays] is invisible
+  /// either way, and preserving it means re-opening one city by its own
+  /// chevron restores the day state the traveler left. Expanding clears
+  /// BOTH: an "expand all" that leaves a day shut is a liar, and a day
+  /// folded three cities ago is not something anyone will think to go
+  /// looking for. Consequence to know: fold→unfold is NOT an identity
+  /// round-trip.
+  void _toggleAllGroups(Trip trip) {
+    final d = _derive(trip);
+    if (!_foldControlShown(d)) return; // stale entry: no-op, never a crash
+    final collapsed = _allGroupsCollapsed(d);
+    // Measured BEFORE the mutation — it reads the CURRENT layout.
+    final anchor = _anchorGroupKey(trip, d);
+    setState(() {
+      if (collapsed) {
+        _collapsedGroups.clear();
+        _collapsedDays.clear();
+      } else {
+        // clear-then-addAll, not a bare addAll: the resulting visible state
+        // is identical (every live group collapses either way), but the
+        // rebuild drops run keys staled by an edit. That matters here and
+        // nowhere else — with one or two hand-picked keys a stale one
+        // fails safe by missing contains(), but a set holding EVERY key
+        // makes the positional `#2` suffixes collide: delete the first
+        // Paris visit and the bare `Paris` key now names what used to be
+        // `Paris#2`, so a group the traveler never folded would render
+        // folded.
+        _collapsedGroups
+          ..clear()
+          ..addAll(d.groups.map((g) => g.key));
+      }
+    });
+    // Keep the traveler where they were. No _mapPinned guard (unlike
+    // _setFocusedLeg, which skips this on phones so the list can't scroll
+    // the just-tapped map chip out of view): no map focus is in play here,
+    // and keeping your place matters more on a phone, not less.
+    if (anchor != null) _revealCityHeader(anchor, animate: false);
+  }
+
+  /// The destination group the traveler is currently reading: the one whose
+  /// header sits LOWEST while still at or above its resting slot under the
+  /// pinned chrome. While a group's body scrolls, its header is pinned
+  /// exactly at that slot, the previous group's has been pushed clear above
+  /// and the next is still in flow below. With everything folded nothing
+  /// pins, and the same rule picks the topmost row still on screen — the
+  /// right visual anchor either way.
+  ///
+  /// Null means "leave the scroll alone": the traveler is above the first
+  /// group (still in the header card), where a fold changes nothing above
+  /// them and there is nothing to re-rest.
+  ///
+  /// Reads [TripDerivation.groups], never the never-pruned [_cityHeaderKeys]
+  /// map, so a key staled by an edit cannot vote for a group that no longer
+  /// renders. Every city header is laid out at every offset — folded ones
+  /// are SliverToBoxAdapters, open ones SliverPinnedHeaders, and neither is
+  /// lazy (only the item lists INSIDE a group are) — so this needs no
+  /// scroll-range heuristics and the guards below are belt-and-braces.
+  String? _anchorGroupKey(Trip trip, TripDerivation d) {
+    if (!_scroll.hasClients || _scroll.offset <= 0) return null;
+    final rest = _pinnedChrome(trip) + 1; // slot + float epsilon
+    String? anchor;
+    var best = double.negativeInfinity;
+    for (final group in d.groups) {
+      final box =
+          _cityHeaderKeys[group.key]?.currentContext?.findRenderObject();
+      if (box is! RenderBox || !box.attached || !box.hasSize) continue;
+      final vp = RenderAbstractViewport.maybeOf(box);
+      if (vp == null) continue;
+      // Same coordinate space as _scrollToCityHeader's correction pass, so
+      // the anchor and its resting slot are never measured differently.
+      final dy = box.localToGlobal(Offset.zero, ancestor: vp).dy;
+      if (dy <= rest && dy > best) {
+        best = dy;
+        anchor = group.key;
+      }
+    }
+    return anchor;
   }
 
   /// Pushes the itinerary-derived booking checklist to the server, which upserts
@@ -5255,9 +5385,33 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
         final absorbsShare = _narrow && trip.isOwner && !_isOffline;
         // Offline hides the mutating exits; the read-only sheets stay.
         final canExit = !_isOffline;
+        // Fold all / unfold all, narrow only (wide keeps it in the itinerary
+        // header row). The one entry here with NO gate at all — folding is
+        // view work, so viewers and offline-served copies get it, which is
+        // also why it leads: the destructive exits own the bottom. It does
+        // mean a narrow viewer reading offline now sees a `⋮` where every
+        // entry used to be gated away and the button collapsed to nothing —
+        // correct, since it finally has something they can do.
+        final d = _derive(trip);
+        final foldShown = _narrow && _foldControlShown(d);
+        final foldCollapsed = foldShown && _allGroupsCollapsed(d);
 
         final entries = <PopupMenuEntry<String>>[
-          if (wear.available)
+          if (foldShown)
+            PopupMenuItem(
+              value: 'foldall',
+              child: ListTile(
+                leading: Icon(foldCollapsed
+                    ? Icons.unfold_more
+                    : Icons.unfold_less),
+                title: Text(foldCollapsed
+                    ? l10n.tripExpandAll
+                    : l10n.tripCollapseAll),
+                contentPadding: EdgeInsets.zero,
+              ),
+            ),
+          if (wear.available) ...[
+            if (foldShown) const PopupMenuDivider(),
             PopupMenuItem(
               value: 'wear',
               child: ListTile(
@@ -5266,14 +5420,16 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
                 contentPadding: EdgeInsets.zero,
               ),
             ),
+          ],
           if (absorbsShare) ...[
-            if (wear.available) const PopupMenuDivider(),
+            if (foldShown || wear.available) const PopupMenuDivider(),
             ..._shareMenuItems(l10n),
           ],
           // Reachable even on a trip with no cities yet, where there are no
           // derived legs to carry the row-level entry.
           if (!_isOffline && !_readOnly) ...[
-            if (wear.available || absorbsShare) const PopupMenuDivider(),
+            if (foldShown || wear.available || absorbsShare)
+              const PopupMenuDivider(),
             PopupMenuItem(
               value: 'airports',
               child: ListTile(
@@ -5284,7 +5440,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
             ),
           ],
           if (canExit) ...[
-            if (wear.available || absorbsShare || !_readOnly)
+            if (foldShown || wear.available || absorbsShare || !_readOnly)
               const PopupMenuDivider(),
             if (trip.isOwner)
               PopupMenuItem(
@@ -5318,7 +5474,12 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
           icon: const Icon(Icons.more_vert),
           tooltip: l10n.tripMoreActions,
           onSelected: (v) {
+            // Every value needs its own case: the default arm forwards to
+            // the share handler, whose own switch has no default — so a
+            // missing case compiles clean, runs clean, and does nothing.
             switch (v) {
+              case 'foldall':
+                _toggleAllGroups(trip);
               case 'wear':
                 _openWearSheet(trip, wear.regions);
               case 'airports':
@@ -5994,6 +6155,15 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
                       final hasTodayTarget = todayDay != null &&
                           (trip.items ?? const <ItineraryItem>[])
                               .any((i) => i.day != null);
+                      // Fold-all control: WIDE only. On narrow it moves into
+                      // the app-bar overflow (the wear & pack / share
+                      // precedent) — the phone row's three tabs, Today chip
+                      // and add button are already the FittedBox budget that
+                      // cost the Bookings count pill its place.
+                      final foldShown =
+                          !_narrow && _foldControlShown(derivation);
+                      final foldCollapsed =
+                          foldShown && _allGroupsCollapsed(derivation);
                       // Tonight caption (specs/happening-now): day numbers
                       // repeat across city groups (keys are '$groupKey#$day'),
                       // so resolve the FIRST group containing today's day
@@ -6120,6 +6290,37 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
                                         ),
                                         const SizedBox(width: 4),
                                       ],
+                                      // Fold or unfold every destination in
+                                      // one tap. PURE VIEW WORK, so — like
+                                      // the view tabs and the Today chip
+                                      // above — it is NOT gated on offline,
+                                      // canEdit or the refine panel: viewers
+                                      // and offline-served copies fold too,
+                                      // and a long itinerary you can only
+                                      // read is exactly where this helps
+                                      // most. Do not copy the add CTAs'
+                                      // gates below.
+                                      //
+                                      // Compact density is load-bearing: the
+                                      // row is a hard 44px SizedBox feeding
+                                      // _listHeaderHeight (56) and the
+                                      // Today-scroll chrome math, and a
+                                      // default-density IconButton is 48.
+                                      if (foldShown)
+                                        IconButton(
+                                          onPressed: () =>
+                                              _toggleAllGroups(trip),
+                                          tooltip: foldCollapsed
+                                              ? l10n.tripExpandAll
+                                              : l10n.tripCollapseAll,
+                                          visualDensity:
+                                              VisualDensity.compact,
+                                          icon: Icon(
+                                              foldCollapsed
+                                                  ? Icons.unfold_more
+                                                  : Icons.unfold_less,
+                                              size: 20),
+                                        ),
                                       // One add CTA per view: Add place on
                                       // the itinerary, the Add-booking menu
                                       // in the Bookings view (a swap, not an

--- a/src/packages/flutter-app/test/trip_detail_collapse_all_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_collapse_all_test.dart
@@ -1,0 +1,395 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:travel_route_planner/models/trip.dart';
+import 'package:travel_route_planner/models/itinerary_item.dart';
+import 'package:travel_route_planner/services/api_client.dart';
+import 'package:travel_route_planner/services/trips_api_service.dart';
+import 'package:travel_route_planner/providers/trips_provider.dart';
+import 'package:travel_route_planner/screens/trip_detail_screen.dart';
+import 'package:travel_route_planner/widgets/trip_map.dart';
+
+import 'support/city_groups.dart';
+import 'support/l10n_test_app.dart';
+
+// Fold all / unfold all — the bulk destination-accordion control.
+//
+// The contract, in one place:
+//   * ONE control with two directions, its state DERIVED every build from
+//     the live groups — never stored, so an edit that adds or drops a
+//     destination can't leave it lying;
+//   * folding touches the CITY groups only, unfolding clears cities AND
+//     days — deliberately not an identity round-trip, so that re-opening
+//     one city by its own chevron restores the day state you left, while
+//     "Expand all" is literally true;
+//   * it is PURE LIST work: no map focus write, no camera move (the
+//     decoupling #358 paid for), and no lens exit;
+//   * it is NOT gated on canEdit or offline — a long itinerary you can only
+//     read is exactly where folding helps most;
+//   * wide carries it in the itinerary header row, narrow in the app-bar
+//     overflow (the phone row's FittedBox budget is already spent).
+
+class _FakeTripsApiService extends TripsApiService {
+  final Trip trip;
+  _FakeTripsApiService(this.trip) : super(ApiClient(baseUrl: 'http://test'));
+
+  @override
+  Future<Trip> getTrip(String id) async => trip;
+}
+
+/// Zero coords everywhere: the screen then skips the map widget, so
+/// `mapShown` is false and `_pinnedChrome` is just the 56px tab row. That
+/// keeps the resting-slot arithmetic one constant instead of two.
+ItineraryItem _item(int pos, String name, String city, int day) =>
+    ItineraryItem(
+      id: 'i$pos',
+      position: pos,
+      name: name,
+      latitude: 0,
+      longitude: 0,
+      category: 'attraction',
+      day: day,
+      city: city,
+    );
+
+/// [cities] consecutive city runs, [days] days each, [perDay] items per day.
+/// Item names carry city AND day so the two accordion levels stay separately
+/// observable.
+Trip _trip({
+  int cities = 3,
+  int days = 2,
+  int perDay = 2,
+  String? access,
+}) {
+  final items = <ItineraryItem>[];
+  var pos = 0;
+  var day = 1;
+  for (var c = 1; c <= cities; c++) {
+    for (var d = 1; d <= days; d++) {
+      for (var k = 0; k < perDay; k++) {
+        items.add(_item(pos++, 'C$c D$d stop $k', 'City$c', day));
+      }
+      day++;
+    }
+  }
+  return Trip(
+    id: 't1',
+    title: 'Grand tour',
+    createdAt: '2026-06-01',
+    updatedAt: '2026-06-01',
+    // Past dates: no Today chip, so the header row is the resting shape.
+    startDate: '2026-06-01',
+    endDate: '2026-06-${(cities * days).toString().padLeft(2, '0')}',
+    access: access,
+    ownerName: access == null ? null : 'Brian',
+    items: items,
+  );
+}
+
+Future<void> _pump(WidgetTester tester, Trip trip) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        tripsApiServiceProvider.overrideWithValue(_FakeTripsApiService(trip)),
+      ],
+      child: MaterialApp(
+        localizationsDelegates: testLocalizationsDelegates,
+        home: const TripDetailScreen(tripId: 't1'),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+void _useSurface(WidgetTester tester, Size size) {
+  tester.view.physicalSize = size;
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.reset);
+}
+
+ScrollPosition _position(WidgetTester tester) => tester
+    .state<ScrollableState>(find
+        .descendant(
+            of: find.byType(CustomScrollView), matching: find.byType(Scrollable))
+        .first)
+    .position;
+
+/// The city header's own Material — the same box `_cityHeaderKeys` target,
+/// so geometry measured here matches the screen's scroll math.
+Finder _headerMaterialOf(String city) => find
+    .ancestor(of: cityHeaderLabel(city), matching: find.byType(Material))
+    .first;
+
+double _headerTop(WidgetTester tester, String city) =>
+    tester.getTopLeft(_headerMaterialOf(city)).dy;
+
+/// Scroll offset that rests [city]'s header in the pinned slot.
+double _reveal(WidgetTester tester, String city) {
+  final target = tester.renderObject(_headerMaterialOf(city));
+  return RenderAbstractViewport.of(target).getOffsetToReveal(target, 0).offset;
+}
+
+/// Viewport top in global coordinates — the app bar's bottom.
+double _viewportTop(WidgetTester tester) =>
+    tester.getBottomLeft(find.byType(AppBar)).dy;
+
+Future<void> _tapFold(WidgetTester tester, String tooltip) async {
+  await tester.tap(find.byTooltip(tooltip));
+  await tester.pumpAndSettle();
+}
+
+/// Opens the app-bar `⋮` and taps [label].
+Future<void> _tapOverflow(WidgetTester tester, String label) async {
+  await tester.tap(find.byTooltip('More options'));
+  await tester.pumpAndSettle();
+  await tester.tap(find.text(label));
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  testWidgets('one tap folds every destination, and the control flips',
+      (tester) async {
+    _useSurface(tester, const Size(1200, 2200));
+    await _pump(tester, _trip());
+
+    // Landing: everything open, the control offers the fold direction.
+    expect(find.text('C1 D1 stop 0'), findsOneWidget);
+    expect(find.text('C3 D2 stop 0'), findsOneWidget);
+    expect(find.byTooltip('Collapse all'), findsOneWidget);
+    expect(find.byIcon(Icons.unfold_less), findsOneWidget);
+
+    await _tapFold(tester, 'Collapse all');
+
+    // Every city's body is gone — not just the first — and every header
+    // survives as a row.
+    expect(find.textContaining('stop'), findsNothing);
+    for (final city in const ['City1', 'City2', 'City3']) {
+      expect(cityHeaderLabel(city), findsOneWidget);
+    }
+    // The control now offers the other direction, glyph and label together.
+    expect(find.byTooltip('Expand all'), findsOneWidget);
+    expect(find.byTooltip('Collapse all'), findsNothing);
+    expect(find.byIcon(Icons.unfold_more), findsOneWidget);
+
+    await _tapFold(tester, 'Expand all');
+    expect(find.text('C1 D1 stop 0'), findsOneWidget);
+    expect(find.text('C3 D2 stop 0'), findsOneWidget);
+    expect(find.byTooltip('Collapse all'), findsOneWidget);
+  });
+
+  testWidgets('expand all re-opens days a header tap folded, not just cities',
+      (tester) async {
+    // The asymmetry, asserted. Unfold clears BOTH sets — an "Expand all"
+    // that leaves a day shut is a liar, and nobody goes looking for a day
+    // they folded three cities ago.
+    _useSurface(tester, const Size(1200, 2200));
+    await _pump(tester, _trip());
+
+    // Fold City1's day 1 by its own header.
+    await tester.tap(find.text('Mon, Jun 1'));
+    await tester.pumpAndSettle();
+    expect(find.text('C1 D1 stop 0'), findsNothing);
+    expect(find.text('C1 D2 stop 0'), findsOneWidget);
+
+    await _tapFold(tester, 'Collapse all');
+    await _tapFold(tester, 'Expand all');
+
+    expect(find.text('C1 D1 stop 0'), findsOneWidget,
+        reason: 'expand all must clear the day set too');
+  });
+
+  testWidgets('collapse all leaves day state alone', (tester) async {
+    // The other half of the asymmetry: a folded city's days are invisible
+    // either way, so folding preserves them and re-opening ONE city by its
+    // own chevron restores exactly what the traveler left.
+    _useSurface(tester, const Size(1200, 2200));
+    await _pump(tester, _trip());
+
+    await tester.tap(find.text('Mon, Jun 1')); // City1 day 1
+    await tester.pumpAndSettle();
+    expect(find.text('C1 D1 stop 0'), findsNothing);
+
+    await _tapFold(tester, 'Collapse all');
+    await toggleCity(tester, 'City1'); // re-open just this city
+
+    expect(find.text('C1 D1 stop 0'), findsNothing,
+        reason: 'collapse all must not touch the day set');
+    expect(find.text('C1 D2 stop 0'), findsOneWidget,
+        reason: 'the rest of the city is back');
+  });
+
+  testWidgets('folding never touches the map', (tester) async {
+    _useSurface(tester, const Size(1200, 2200));
+    // Real coordinates so the map renders and can record a fit.
+    final items = <ItineraryItem>[
+      for (var c = 1; c <= 3; c++)
+        for (var k = 0; k < 2; k++)
+          ItineraryItem(
+            id: 'i$c$k',
+            position: (c - 1) * 2 + k,
+            name: 'C$c D1 stop $k',
+            latitude: 40.0 + c,
+            longitude: 10.0 + c,
+            category: 'attraction',
+            day: c,
+            city: 'City$c',
+          ),
+    ];
+    await _pump(
+        tester,
+        Trip(
+          id: 't1',
+          title: 'Grand tour',
+          createdAt: '2026-06-01',
+          updatedAt: '2026-06-01',
+          startDate: '2026-06-01',
+          endDate: '2026-06-03',
+          items: items,
+        ));
+
+    await _tapFold(tester, 'Collapse all');
+    await _tapFold(tester, 'Expand all');
+
+    // Expansion is list-only: a fold must not focus a leg or refit the
+    // camera (specs/map-scroll-decouple).
+    expect(tester.widget<TripMap>(find.byType(TripMap)).fitSignature, isNull);
+  });
+
+  testWidgets('folding keeps you on the destination you were reading',
+      (tester) async {
+    // Without the anchor re-rest, folding shrinks maxScrollExtent by
+    // thousands of px and the position clamps — the traveler is dumped at
+    // the end of a list they were reading the middle of.
+    // 24 destinations so the FOLDED list is still taller than the viewport.
+    // With fewer, the whole folded outline fits on screen, maxScrollExtent
+    // is 0, and City6 cannot physically reach the resting slot — the
+    // documented graceful degradation (_scrollToCityHeader clamps and the
+    // correction pass no-ops), but it would make this test assert nothing.
+    _useSurface(tester, const Size(1200, 900));
+    await _pump(tester, _trip(cities: 24, days: 1, perDay: 2));
+
+    final position = _position(tester);
+    final slot = _viewportTop(tester) + 56; // no map: tab row only
+    final mid = _reveal(tester, 'City6') + 200;
+    expect(mid, lessThan(position.maxScrollExtent),
+        reason: 'premise: mid-group-6 must be reachable');
+    position.jumpTo(mid);
+    await tester.pumpAndSettle();
+
+    await _tapFold(tester, 'Collapse all');
+
+    expect(_reveal(tester, 'City6'), lessThan(position.maxScrollExtent),
+        reason: 'premise: the folded list must still be able to rest City6');
+    expect((_headerTop(tester, 'City6') - slot).abs(), lessThanOrEqualTo(2),
+        reason: 'the anchor group stays under the chrome after folding');
+
+    // And back the other way: unfolding inserts five cities' bodies above
+    // City6, so without the re-rest it would drop far below the fold.
+    await _tapFold(tester, 'Expand all');
+    expect((_headerTop(tester, 'City6') - slot).abs(), lessThanOrEqualTo(2),
+        reason: 'the anchor group stays under the chrome after unfolding');
+  });
+
+  testWidgets('at the top of the list, folding leaves the scroll alone',
+      (tester) async {
+    _useSurface(tester, const Size(1200, 900));
+    await _pump(tester, _trip(cities: 4));
+
+    expect(_position(tester).pixels, 0);
+    await _tapFold(tester, 'Collapse all');
+    expect(_position(tester).pixels, 0,
+        reason: 'no anchor above the rest line means no scroll at all');
+  });
+
+  testWidgets('a partly folded itinerary still offers Collapse all',
+      (tester) async {
+    // `every`, not `any`: one open destination means there is still
+    // something to fold, and one tap must finish the job.
+    _useSurface(tester, const Size(1200, 2200));
+    await _pump(tester, _trip());
+
+    await collapseCity(tester, 'City1');
+    expect(find.byTooltip('Collapse all'), findsOneWidget);
+    expect(find.byTooltip('Expand all'), findsNothing);
+
+    await _tapFold(tester, 'Collapse all');
+    expect(find.textContaining('stop'), findsNothing);
+    expect(find.byTooltip('Expand all'), findsOneWidget);
+  });
+
+  testWidgets('a place-less trip has no fold control', (tester) async {
+    _useSurface(tester, const Size(1200, 900));
+    await _pump(
+        tester,
+        Trip(
+          id: 't1',
+          title: 'Someday',
+          createdAt: '2026-06-01',
+          updatedAt: '2026-06-01',
+          items: const [],
+        ));
+
+    // Both glyphs, deliberately. Dropping the groups.isNotEmpty gate from
+    // _foldControlShown renders the control here in its UNFOLD face — an
+    // empty list satisfies `every`, so "everything is collapsed" comes out
+    // true — which an unfold_less-only assertion would sail straight past
+    // (mutation-checked: it does).
+    expect(find.byIcon(Icons.unfold_less), findsNothing);
+    expect(find.byIcon(Icons.unfold_more), findsNothing);
+  });
+
+  testWidgets('the Bookings and Budget views have no fold control',
+      (tester) async {
+    // Both swap the city groups out for flat lists — there is no accordion
+    // there to fold.
+    _useSurface(tester, const Size(1200, 2200));
+    await _pump(tester, _trip());
+
+    await tester.tap(find.text('Bookings'));
+    await tester.pumpAndSettle();
+    expect(find.byIcon(Icons.unfold_less), findsNothing);
+
+    await tester.tap(find.text('Budget'));
+    await tester.pumpAndSettle();
+    expect(find.byIcon(Icons.unfold_less), findsNothing);
+
+    await tester.tap(find.text('Itinerary'));
+    await tester.pumpAndSettle();
+    expect(find.byTooltip('Collapse all'), findsOneWidget);
+  });
+
+  testWidgets('a viewer folds too', (tester) async {
+    // Pure view work: never gated on canEdit. A long shared itinerary you
+    // can only read is exactly where this helps most.
+    _useSurface(tester, const Size(1200, 2200));
+    await _pump(tester, _trip(access: 'viewer'));
+
+    expect(find.text('Add place'), findsNothing, reason: 'premise: read-only');
+    await _tapFold(tester, 'Collapse all');
+    expect(find.textContaining('stop'), findsNothing);
+  });
+
+  testWidgets('narrow keeps the row clean and folds from the overflow menu',
+      (tester) async {
+    _useSurface(tester, const Size(390, 1600));
+    await _pump(tester, _trip());
+
+    // The phone header row is untouched — its FittedBox budget is spent.
+    expect(find.byIcon(Icons.unfold_less), findsNothing);
+    expect(find.byTooltip('Collapse all'), findsNothing);
+
+    await _tapOverflow(tester, 'Collapse all');
+    expect(find.textContaining('stop'), findsNothing);
+
+    // ONE entry that flips, not two — a menu must not offer a dead action.
+    await tester.tap(find.byTooltip('More options'));
+    await tester.pumpAndSettle();
+    expect(find.text('Expand all'), findsOneWidget);
+    expect(find.text('Collapse all'), findsNothing);
+    await tester.tap(find.text('Expand all'));
+    await tester.pumpAndSettle();
+    expect(find.text('C1 D1 stop 0'), findsOneWidget);
+  });
+}

--- a/src/packages/flutter-app/test/trip_detail_narrow_header_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_narrow_header_test.dart
@@ -171,6 +171,59 @@ void main() {
     expect(find.text('0/1'), findsNothing);
     expect(find.text('Add place'), findsNothing);
     expect(find.byTooltip('Add place'), findsOneWidget);
+    // The fold-all control is wide-only for this exact reason — it lives in
+    // the app-bar overflow at phone widths (trip_detail_collapse_all_test).
+    expect(find.byIcon(Icons.unfold_less), findsNothing);
+  });
+
+  // The row's real budget is not 390px — it is the docked-refine-panel
+  // width. `_narrow` is read from the WINDOW, but the body loses 401px to
+  // the panel, so a 1000px window on the wide path lays this row out in
+  // ~567px. 800 is the floor of that band and the width at which the fold
+  // control has to share the row with a labeled Add place, a Today chip and
+  // the Spanish tab trio.
+  testWidgets('wide floor: the tab row still fits with the fold control',
+      (tester) async {
+    tester.platformDispatcher.textScaleFactorTestValue = 0.5;
+    addTearDown(tester.platformDispatcher.clearAllTestValues);
+    // Dated around today so the Today chip is present — the worst case.
+    final now = DateTime.now();
+    String iso(DateTime d) =>
+        '${d.year.toString().padLeft(4, '0')}-'
+        '${d.month.toString().padLeft(2, '0')}-'
+        '${d.day.toString().padLeft(2, '0')}';
+    final live = Trip(
+      id: 't1',
+      title: 'Sevilla week',
+      createdAt: '2026-06-01',
+      updatedAt: '2026-06-01',
+      startDate: iso(now.subtract(const Duration(days: 1))),
+      endDate: iso(now.add(const Duration(days: 1))),
+      items: [
+        ItineraryItem(
+          id: 'i0',
+          position: 0,
+          name: 'Real Alcázar',
+          latitude: 0,
+          longitude: 0,
+          category: 'attraction',
+          day: 1,
+          city: 'Sevilla',
+        ),
+      ],
+      bookingTodos: oneTodo,
+    );
+    await _pump(tester, live,
+        surface: const Size(800, 900), locale: const Locale('es'));
+
+    // Premise first: without this the test would pass with the control
+    // deleted, which is the failure mode it exists to catch.
+    expect(find.byTooltip('Contraer todo'), findsOneWidget);
+    expect(find.widgetWithText(ActionChip, 'Hoy'), findsOneWidget);
+    for (final label in ['Itinerario', 'Reservas', 'Presupuesto']) {
+      expectNoTruncation(tester, label, minScale: 0.95);
+    }
+    expect(tester.takeException(), isNull);
   });
 
   testWidgets('narrow Spanish: tabs render whole too', (tester) async {

--- a/src/packages/flutter-app/test/trip_detail_offline_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_offline_test.dart
@@ -150,8 +150,22 @@ void main() {
     expect(rename.onPressed, isNull);
     expect(find.byTooltip('Share trip'), findsNothing);
     // Delete/leave live behind the overflow menu, which mutates and is
-    // therefore hidden entirely while offline-serving.
+    // therefore hidden entirely while offline-serving. (This is a WIDE
+    // surface — _narrow is strictly < 800 — which is what keeps the
+    // narrow-only fold entry out of the menu and this assertion true.)
     expect(find.byTooltip('More options'), findsNothing);
+
+    // Folding the itinerary is pure view work, so it survives the network
+    // loss — like the view tabs below, and unlike every affordance above.
+    // A long saved itinerary you can only read is where it helps most.
+    expect(find.byTooltip('Collapse all'), findsOneWidget);
+    await tester.tap(find.byTooltip('Collapse all'));
+    await tester.pumpAndSettle();
+    expect(find.text('Acropolis'), findsNothing);
+    expect(find.byTooltip('Expand all'), findsOneWidget);
+    await tester.tap(find.byTooltip('Expand all'));
+    await tester.pumpAndSettle();
+    expect(find.text('Acropolis'), findsOneWidget);
 
     // The Bookings view's add menu is likewise disabled, not hidden. The
     // tab tap itself stays allowed offline — switching views is pure view


### PR DESCRIPTION
## Summary

Two commits: the fold control, and closing the invisibility gap it exposed.

### 1. Fold the whole itinerary in one tap

- A seven-destination trip could only be surveyed by tapping seven city headers, and only be re-opened by tapping all seven again. One control now does both.
- **Wide:** an icon in the itinerary header row, between *Today* and *Add place*. **Narrow:** an entry leading the app-bar `⋮` — the rule wear & pack and share already follow, and the reason the Bookings count pill lost its place at 390px.
- **Deliberately asymmetric.** Folding closes the **destinations only**; a folded city's day headers aren't rendered, so preserving `_collapsedDays` means re-opening one city by its own chevron restores the day state you left. Unfolding clears **both** sets, because an "Expand all" that leaves a day shut is a liar. Fold→unfold is therefore not an identity round-trip — that is the point, and it is commented at the mutator.
- **Nothing is stored.** The direction is derived from the live groups every build (the view-tabs doctrine): a cached "is everything folded?" bit drifts the moment a refresh adds or drops a destination, and the wide button and the narrow entry would then disagree about what one tap means.
- **Pure list work.** No map focus write, no camera move, no lens exit — the #358 decoupling is intact.
- **Not gated on `canEdit` or offline.** A long shared itinerary you can only read is exactly where folding helps most; the offline test pins that.

Three things that had to be got right:

- **You keep your place.** Folding shrinks `maxScrollExtent` by thousands of px, so the position clamps and you land at the end of a list you were reading the middle of. The group whose header sits at the resting slot is measured *before* the mutation and re-rested after. It **jumps rather than glides** (new `animate` flag) because gliding from an out-of-range offset paints blank while it travels — and the jump path must `await endOfFrame`, since unlike the awaited `animateTo`, `jumpTo` does not relayout before it returns and the correction pass would otherwise correct by a stale delta.
- **The fold branch rebuilds `_collapsedGroups` rather than adding to it.** Same visible result, but a set holding *every* key makes the positional `#2` run-key suffixes collide: delete the first Paris visit and the bare `Paris` key names what used to be `Paris#2`, so a group nobody folded renders folded. The documented "stale keys fail safe" reasoning holds for one or two hand-picked keys and inverts for all of them.
- **The overflow `onSelected` switch has a `default:` arm** forwarding to the share handler, whose own switch has no default — a missing `case` would compile clean, run clean, and do nothing.

### 2. Reveal what a refine adds, even into a folded city

Making folding one tap turned a corner case into the common one: nothing on the refresh path opened anything, so a chat turn could report *"added 4 places"* while the list did not visibly move.

- `_expandRunsOfNewItems` was written when `_addPlace` — exactly one place — was its only caller, so it **stopped at the first new item** and only touched `_collapsedGroups`. Both are wrong for a chat writing a batch across cities, and for an item landing on a day the traveler folded: un-collapsing Rome reveals nothing if day 4 is itself shut.
- It becomes `_revealNewItems`, opening every group **and every day** that gained an item, and **returning** the first new leg key rather than writing focus itself. The map write stays `_addPlace`'s alone — adding one place is a request to look at it; a turn writing across three cities has no single leg to mean.
- **Revealing is opt-in per caller, not a property of refreshing.** `_armRevealOfNewItems` snapshots item ids; `_refresh` consumes the snapshot once its coalescing loop settles. The refine listener and add-to-trip arm it; **pull-to-refresh and the background status poll do not**, so a collaborator's edit can never unfold a list you deliberately folded. Arming is idempotent within a turn (first snapshot wins), or three `trip_updated` events would redefine "new" as "added after the batch I already missed".

## Testing

- `flutter analyze` clean (3 pre-existing infos in `models/route_response.dart`, untouched); `flutter test` **1467 passing**.
- New `trip_detail_collapse_all_test.dart` (11) and `trip_detail_reveal_new_items_test.dart` (6, driving real `trip_updated` turns through a scripted `PlanService`).
- **Mutation-checked, not just green.** Eight mutations, each failing its own test: dropping `_collapsedDays.clear()`, dropping the anchor re-rest, folding only the first group, `every`→`any`, un-arming the refine path, stopping at the first new item, ignoring days, and arming on *every* refresh. One assertion was found **vacuous** this way (the `isNotEmpty` guard inside `_allGroupsCollapsed` is unreachable — every caller gates first); its comment now names the mutation it *does* catch and the guard is documented as belt-and-braces rather than load-bearing.
- `_addPlace`'s map-focus behaviour is unchanged and still pinned by the existing `trip_detail_leg_focus_test.dart` assertion.
- Extended `trip_detail_narrow_header_test.dart` (wide-floor Spanish fit with the Today chip present; a one-liner pinning the control's absence from the 390px row) and `trip_detail_offline_test.dart` (fold and unfold on the cached copy).
- **Browser-verified** on the lane stack at 1440/890/1000/390 CSS px, English and Spanish: one tap folds six destinations into a dated outline; the anchor city stays under the chrome in both directions; the map never moves; the phone row is byte-identical and the `⋮` leads with the entry, whose label flips to *Expand all*; the Spanish trio and `+ Añadir lugar` stay whole both at the wide floor and with the refine panel docked (body ~518px).

## Merge order

Touches `trip_detail_screen.dart`, so it wants the god-file slot. **#442 currently holds it** and is conflicting with main — this should rebase and merge after that one, expecting a small resolve near the pinned header row. No migrations; `lib/l10n/app_localizations*.dart` is the only regen, so do it last.

🤖 Generated with [Claude Code](https://claude.com/claude-code)