### PR TITLE
feat(easter-egg): the Konami code rolls the site

### DIFF
--- a/specs/konami-rickroll/spec.md
+++ b/specs/konami-rickroll/spec.md
@@ -1,0 +1,97 @@
+# Spec: Konami-code rickroll
+
+> Deliberately `spec.md` only. There is no data model, no endpoint, and one
+> surface — a `plan.md` and `tasks.md` here would be ceremony, not clarity.
+
+## Context
+
+Anemos has no easter eggs. It should have exactly one. Entering the Konami
+code (↑ ↑ ↓ ↓ ← → ← → B A) anywhere in the app rolls the site: a dancing
+figure takes over the background, the hook plays, and the app carries on
+underneath until it's dismissed.
+
+The point is delight, so the bar is that it costs nothing and breaks nothing.
+Two constraints from the deployment shape the whole feature and are worth
+recording here because they will outlive the joke:
+
+- The `/app/` locations send `Cross-Origin-Embedder-Policy: require-corp`, so a
+  cross-origin YouTube embed — the usual way anyone builds this — is blocked.
+- The CSP declares no `media-src`, so audio falls back to `default-src 'self'`.
+  It ships `Report-Only` today with an intent to enforce, meaning a
+  `data:`/`blob:` clip would work now and break later.
+
+Both are why the picture is drawn and the sound is synthesized rather than
+bundled or streamed. That also means nothing third-party ships, so no bundled
+asset needs a provenance row it could not honestly be given.
+
+## User Stories
+
+- As **someone poking at the site**, I want the Konami code to do something
+  ridiculous, so that finding it feels like a reward.
+- As **anyone who triggers it by accident**, I want one obvious way out, so
+  that a joke never becomes a trap.
+- As **a traveler mid-sentence in the chat composer**, I want my typing, my
+  scroll position and my unsaved edits to survive it, so that the easter egg
+  can never cost me work.
+
+## Acceptance Criteria
+
+- [ ] Entering ↑ ↑ ↓ ↓ ← → ← → B A rolls the site from any screen, signed in or
+      out — including the landing page and the screens outside the tab shell.
+- [ ] The rolled state shows an animated figure over a drifting rainbow, with
+      the app still visible underneath, plus a caption and a close control.
+- [ ] The hook plays on the web. Where the browser refuses to start audio, the
+      visual runs anyway and nothing errors.
+- [ ] It ends on Escape, on a tap or click anywhere, on the close control, and
+      on its own when the tune finishes.
+- [ ] Escape while rolled dismisses **only** the roll — it does not also close
+      the fullscreen map or the refine chat panel underneath it.
+- [ ] No keystroke is swallowed: arrow keys still move a text caret, B and A
+      still type, and every existing keyboard shortcut behaves as before.
+- [ ] Triggering it does not reset or remount anything — an in-progress chat
+      draft, an open expense editor, and the current scroll position all
+      survive.
+- [ ] Overshooting the opening arrows (↑ ↑ ↑ ↓ ↓ …) still completes the code.
+- [ ] Nothing is downloaded to run it, and the page weight is unchanged.
+
+## API Surface
+
+None. This feature does not talk to the API.
+
+## Data Model
+
+None. Nothing is persisted; the rolled state lasts as long as it is on screen.
+
+## UI Behavior
+
+- **Surface:** a layer above every route and dialog, so no screen has to know
+  it exists.
+- **Happy path:** enter the code → the roll appears over the current screen and
+  the tune starts → it ends itself when the tune does, or immediately on
+  Escape / tap / close.
+- **States:** there are only two — rolled and not. There is no loading state
+  (nothing is fetched) and no error state (a browser that will not play audio
+  is an ordinary outcome, not a failure).
+
+## Edge Cases & Error States
+
+- **The browser refuses audio.** Safari can withhold playback even after a
+  keystroke. The visual is never gated on sound.
+- **The code is entered while already rolling.** Ignored — restarting would
+  re-attack the tune from the top.
+- **The code is entered with a text field focused.** It fires, and the field
+  keeps every one of those keystrokes.
+- **No keyboard.** Phones cannot enter the code at all. That is accepted, not
+  worked around: see Out of Scope.
+
+## Out of Scope
+
+- Any mobile or touch trigger. Adding one means threading a tap counter through
+  the shared wordmark widget, and the code is a keyboard joke.
+- Persisting that a user has found it, or any analytics on it.
+- A setting to disable it.
+- Sound on iOS/Android builds — those cannot reach the trigger.
+
+## Open Questions
+
+None outstanding.

--- a/src/packages/flutter-app/lib/l10n/app_en.arb
+++ b/src/packages/flutter-app/lib/l10n/app_en.arb
@@ -2544,5 +2544,13 @@
   "wearExtremeHeat": "very hot days, extra sun protection",
   "wearFreezingNights": "freezing nights, warm layers",
   "wearSummaryRain": "rain likely",
-  "wearHistoricalFootnote": "Beyond the 16-day forecast, ranges show typical weather for these dates."
+  "wearHistoricalFootnote": "Beyond the 16-day forecast, ranges show typical weather for these dates.",
+  "rickRollCaption": "Never gonna give you up",
+  "@rickRollCaption": {
+    "description": "Caption on the Konami-code easter egg. Not translated — it is a song title."
+  },
+  "rickRollDismissHint": "press esc to escape",
+  "@rickRollDismissHint": {
+    "description": "Hint under the easter-egg caption telling the user how to close it."
+  }
 }

--- a/src/packages/flutter-app/lib/l10n/app_es.arb
+++ b/src/packages/flutter-app/lib/l10n/app_es.arb
@@ -1076,5 +1076,7 @@
   "wearExtremeHeat": "días muy calurosos, protección solar extra",
   "wearFreezingNights": "noches bajo cero, capas de abrigo",
   "wearSummaryRain": "lluvia probable",
-  "wearHistoricalFootnote": "Más allá del pronóstico de 16 días, los rangos muestran el tiempo habitual en estas fechas."
+  "wearHistoricalFootnote": "Más allá del pronóstico de 16 días, los rangos muestran el tiempo habitual en estas fechas.",
+  "rickRollCaption": "Never gonna give you up",
+  "rickRollDismissHint": "pulsa esc para salir"
 }

--- a/src/packages/flutter-app/lib/l10n/app_localizations.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations.dart
@@ -6319,6 +6319,18 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Beyond the 16-day forecast, ranges show typical weather for these dates.'**
   String get wearHistoricalFootnote;
+
+  /// Caption on the Konami-code easter egg. Not translated — it is a song title.
+  ///
+  /// In en, this message translates to:
+  /// **'Never gonna give you up'**
+  String get rickRollCaption;
+
+  /// Hint under the easter-egg caption telling the user how to close it.
+  ///
+  /// In en, this message translates to:
+  /// **'press esc to escape'**
+  String get rickRollDismissHint;
 }
 
 class _AppLocalizationsDelegate

--- a/src/packages/flutter-app/lib/l10n/app_localizations_en.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations_en.dart
@@ -3809,4 +3809,10 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String get wearHistoricalFootnote =>
       'Beyond the 16-day forecast, ranges show typical weather for these dates.';
+
+  @override
+  String get rickRollCaption => 'Never gonna give you up';
+
+  @override
+  String get rickRollDismissHint => 'press esc to escape';
 }

--- a/src/packages/flutter-app/lib/l10n/app_localizations_es.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations_es.dart
@@ -3835,4 +3835,10 @@ class AppLocalizationsEs extends AppLocalizations {
   @override
   String get wearHistoricalFootnote =>
       'Más allá del pronóstico de 16 días, los rangos muestran el tiempo habitual en estas fechas.';
+
+  @override
+  String get rickRollCaption => 'Never gonna give you up';
+
+  @override
+  String get rickRollDismissHint => 'pulsa esc para salir';
 }

--- a/src/packages/flutter-app/lib/main.dart
+++ b/src/packages/flutter-app/lib/main.dart
@@ -10,6 +10,7 @@ import 'providers/auth_provider.dart';
 import 'providers/locale_provider.dart';
 import 'providers/theme_mode_provider.dart';
 import 'theme/app_theme.dart';
+import 'widgets/konami_listener.dart';
 import 'screens/connect_app_screen.dart';
 import 'screens/landing_screen.dart';
 import 'screens/app_shell.dart';
@@ -139,6 +140,11 @@ class TravelRoutePlannerApp extends ConsumerWidget {
       // URL persistence write half: re-asserts the synced location after
       // root-navigator events (specs/url-page-persistence).
       navigatorObservers: [ref.watch(rootUrlObserverProvider)],
+      // Wraps the root Navigator, so the Konami code is heard on every screen
+      // — including the nine that render outside AppShell — and its overlay
+      // draws above every route and dialog. The listener passes `child`
+      // straight through untouched; see konami_listener.dart.
+      builder: (context, child) => KonamiListener(child: child!),
     );
   }
 }

--- a/src/packages/flutter-app/lib/providers/easter_egg_provider.dart
+++ b/src/packages/flutter-app/lib/providers/easter_egg_provider.dart
@@ -1,0 +1,27 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Whether the Konami code is currently rolling the site.
+///
+/// A provider rather than local state in the listener widget for one reason
+/// that matters: it is the seam tests drive. The overlay lives in
+/// `MaterialApp.builder`, above every route, so there is no screen to pump on
+/// its own — a test either sends ten keystrokes or flips this.
+class RickRollNotifier extends StateNotifier<bool> {
+  RickRollNotifier() : super(false);
+
+  /// Starts the roll. Entering the code again while it is already running is
+  /// a no-op rather than a restart: re-triggering would tear down the audio
+  /// context mid-phrase and re-attack the tune from bar one.
+  void roll() {
+    if (!state) state = true;
+  }
+
+  /// Ends the roll — Escape, a tap, the close button, or the tune running out.
+  void stop() {
+    if (state) state = false;
+  }
+}
+
+final rickRollProvider = StateNotifierProvider<RickRollNotifier, bool>(
+  (ref) => RickRollNotifier(),
+);

--- a/src/packages/flutter-app/lib/utils/konami_detector.dart
+++ b/src/packages/flutter-app/lib/utils/konami_detector.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/foundation.dart' show listEquals;
+import 'package:flutter/services.dart' show LogicalKeyboardKey;
+
+/// The Konami code, in the order it has to arrive: ↑ ↑ ↓ ↓ ← → ← → B A.
+const List<LogicalKeyboardKey> kKonamiCode = [
+  LogicalKeyboardKey.arrowUp,
+  LogicalKeyboardKey.arrowUp,
+  LogicalKeyboardKey.arrowDown,
+  LogicalKeyboardKey.arrowDown,
+  LogicalKeyboardKey.arrowLeft,
+  LogicalKeyboardKey.arrowRight,
+  LogicalKeyboardKey.arrowLeft,
+  LogicalKeyboardKey.arrowRight,
+  LogicalKeyboardKey.keyB,
+  LogicalKeyboardKey.keyA,
+];
+
+/// Watches a keystroke stream for [kKonamiCode].
+///
+/// Deliberately a **rolling buffer of the last ten keys** rather than the
+/// obvious advance-an-index matcher. The code opens `↑ ↑`, so an index matcher
+/// desyncs the moment somebody overshoots: at `↑ ↑ ↑` the third arrow fails
+/// the expected `↓`, the index resets to 0, and every subsequent key is then
+/// tested against the wrong position — the sequence can never complete no
+/// matter how correctly the rest of it is typed. Recovering from that needs a
+/// KMP failure table; comparing the tail of a ten-element buffer needs four
+/// lines and is right for *any* prefix of junk.
+///
+/// Pure Dart on purpose ([LogicalKeyboardKey] is the only Flutter type here),
+/// so the matching rules are unit-testable without pumping a widget.
+class KonamiDetector {
+  final List<LogicalKeyboardKey> _recent = <LogicalKeyboardKey>[];
+
+  /// Records [key] and reports whether the code has just completed.
+  ///
+  /// Returns true on the keystroke that finishes the sequence and not again
+  /// until the whole thing is re-entered — the buffer keeps its contents, so
+  /// one extra `A` after a successful run does not re-fire.
+  bool accept(LogicalKeyboardKey key) {
+    _recent.add(key);
+    if (_recent.length > kKonamiCode.length) {
+      _recent.removeAt(0);
+    }
+    return listEquals(_recent, kKonamiCode);
+  }
+
+  /// Forgets the keys seen so far. Not needed for correctness — the buffer
+  /// self-heals — but lets a caller draw a hard line under a session.
+  void reset() => _recent.clear();
+}

--- a/src/packages/flutter-app/lib/utils/rick_roll_audio_stub.dart
+++ b/src/packages/flutter-app/lib/utils/rick_roll_audio_stub.dart
@@ -1,0 +1,14 @@
+import 'rick_roll_tune.dart';
+
+/// Non-web stub for the Konami hook: there is no audio dependency in this app
+/// (the only sound code is dictation *recording*), and adding an audio plugin
+/// plus its per-platform boilerplate to make an easter egg audible on mobile
+/// is not a trade worth making — the code needs arrow keys anyway, so the
+/// mobile builds can never reach it.
+///
+/// VM widget tests resolve to this file too, which is what keeps them silent
+/// and synchronous. The overlay is written to look identical either way.
+///
+/// See rick_roll_audio_web.dart for the real implementation and
+/// rick_roll_tune.dart for the contract.
+RickRollPlayback playRickRollHook() => const SilentRickRollPlayback();

--- a/src/packages/flutter-app/lib/utils/rick_roll_audio_web.dart
+++ b/src/packages/flutter-app/lib/utils/rick_roll_audio_web.dart
@@ -1,0 +1,109 @@
+import 'dart:js_interop';
+import 'dart:math' as math;
+
+import 'package:web/web.dart' as web;
+
+import 'rick_roll_tune.dart';
+
+/// Peak amplitude of the whole tune. Square waves carry far more energy than
+/// their amplitude suggests, so this sits low deliberately: an easter egg that
+/// blows somebody's headphones off is a bug report, not a joke.
+const double _masterGain = 0.12;
+
+/// Seconds of lead-in before the first note. The scheduler needs a moment of
+/// headroom or the browser drops the attack of note one.
+const double _leadIn = 0.06;
+
+/// Attack, and how long before a note's end its release begins. The release is
+/// what separates the two identical `B4`s that open the phrase — without it
+/// they run together into one long note and the melody stops being
+/// recognizable.
+const double _attack = 0.01;
+const double _release = 0.05;
+
+/// Plays [kRickRollHook] through one [web.AudioContext] of scheduled square
+/// waves.
+///
+/// Every note is scheduled up front against the context clock rather than
+/// driven by a Dart timer: timers drift, and a melody that drifts is a melody
+/// nobody recognizes.
+///
+/// Returns [SilentRickRollPlayback] rather than throwing if the browser will
+/// not give us a context. A keystroke grants user activation in Chrome and
+/// Firefox, but Safari can still hand back a context that never starts, so the
+/// caller must treat "no sound" as an ordinary outcome.
+RickRollPlayback playRickRollHook() {
+  final web.AudioContext ctx;
+  try {
+    ctx = web.AudioContext();
+  } catch (_) {
+    return const SilentRickRollPlayback();
+  }
+
+  try {
+    // Best-effort: a context created before the browser considers the page
+    // "activated" starts suspended. Failure here is not fatal — the notes are
+    // still scheduled, they just may never sound.
+    ctx.resume().toDart.catchError((Object _) => null);
+
+    final master = ctx.createGain();
+    master.gain.setValueAtTime(_masterGain, ctx.currentTime);
+    master.connect(ctx.destination);
+
+    var at = ctx.currentTime + _leadIn;
+    for (final note in kRickRollHook) {
+      final seconds = note.length.inMicroseconds / 1000000.0;
+      final hertz = note.hertz;
+      if (hertz != null) {
+        final end = at + seconds;
+        // Clamp so a note shorter than attack + release still gets a shape
+        // instead of a backwards envelope.
+        final releaseAt = math.max(at + _attack, end - _release);
+
+        final osc = ctx.createOscillator();
+        osc.type = 'square';
+        osc.frequency.setValueAtTime(hertz, at);
+
+        final env = ctx.createGain();
+        env.gain.setValueAtTime(0, at);
+        env.gain.linearRampToValueAtTime(1, at + _attack);
+        env.gain.setValueAtTime(1, releaseAt);
+        env.gain.linearRampToValueAtTime(0, end);
+
+        osc.connect(env);
+        env.connect(master);
+        osc.start(at);
+        osc.stop(end + 0.01);
+      }
+      at += seconds;
+    }
+    return _AudioContextPlayback(ctx);
+  } catch (_) {
+    // Half-scheduled is worse than silent: tear the context down so no
+    // fragment of the tune is left playing.
+    final playback = _AudioContextPlayback(ctx)..stop();
+    return playback;
+  }
+}
+
+class _AudioContextPlayback implements RickRollPlayback {
+  _AudioContextPlayback(this._ctx);
+
+  final web.AudioContext _ctx;
+  bool _stopped = false;
+
+  /// Closing the context kills every scheduled note at once, which is why
+  /// nothing here tracks the individual oscillators. Guarded and wrapped
+  /// because closing twice — dismissing by hand at the exact moment the tune
+  /// ends on its own — throws `InvalidStateError`.
+  @override
+  void stop() {
+    if (_stopped) return;
+    _stopped = true;
+    try {
+      _ctx.close().toDart.catchError((Object _) => null);
+    } catch (_) {
+      // Already closed, or the context was never usable.
+    }
+  }
+}

--- a/src/packages/flutter-app/lib/utils/rick_roll_tune.dart
+++ b/src/packages/flutter-app/lib/utils/rick_roll_tune.dart
@@ -1,0 +1,118 @@
+/// The tune the Konami code plays, and the contract the two playback
+/// implementations share.
+///
+/// Imported by `rick_roll_audio_stub.dart`, `rick_roll_audio_web.dart` and by
+/// the overlay itself, so the conditional import only ever swaps *how* sound
+/// is made — never what is played or how long it lasts. Same split as
+/// `geolocation_types.dart`.
+///
+/// Nothing is bundled: the hook is synthesized from this table at trigger
+/// time. That is not only a size choice. The deployment sets
+/// `Cross-Origin-Embedder-Policy: require-corp` on `/app/`, which blocks a
+/// cross-origin YouTube embed outright, and the CSP declares no `media-src`,
+/// so audio falls back to `default-src 'self'` — a `data:`/`blob:` clip would
+/// work today and break the day that policy stops being Report-Only.
+/// Oscillators are subject to neither.
+library;
+
+import 'dart:math' as math;
+
+/// Beats per minute of the original chorus.
+const int _tempoBpm = 114;
+
+/// A whole note in microseconds — four beats at [_tempoBpm]. Every note length
+/// is derived from this one number, so the tune cannot half-retune itself.
+const int _wholeNoteMicros = 4 * 60 * 1000000 ~/ _tempoBpm;
+
+/// One entry in the melody.
+class RickRollNote {
+  /// MIDI note number, or null for a rest.
+  final int? midi;
+
+  /// Note value in the usual score sense: `4` is a quarter, `8` an eighth,
+  /// `16` a sixteenth. **Negative means dotted** (`-4` = dotted quarter), the
+  /// convention the transcription this table came from uses.
+  final int divisor;
+
+  const RickRollNote(this.midi, this.divisor);
+
+  /// How long this note sounds. Derived, never stored — see [_wholeNoteMicros].
+  Duration get length {
+    final base = _wholeNoteMicros ~/ divisor.abs();
+    return Duration(microseconds: divisor < 0 ? base * 3 ~/ 2 : base);
+  }
+
+  /// Equal-temperament frequency in Hz, A4 (MIDI 69) = 440. Null for a rest.
+  double? get hertz {
+    final n = midi;
+    return n == null ? null : 440.0 * math.pow(2, (n - 69) / 12.0);
+  }
+}
+
+/// The first five bars of the chorus — "never gonna give you up …" — from the
+/// widely-circulated buzzer transcription in `robsoncouto/arduino-songs`
+/// (D major; the phrase lands back on the tonic, so it stops cleanly rather
+/// than needing a fade). Ten and a half seconds: long enough to land the joke,
+/// short enough that nobody has to sit through it.
+const List<RickRollNote> kRickRollHook = [
+  // "Never gonna give you up"
+  RickRollNote(null, 8),
+  RickRollNote(71, 8), // B4
+  RickRollNote(71, 8), // B4
+  RickRollNote(73, 8), // C#5
+  RickRollNote(74, 8), // D5
+  RickRollNote(71, 4), // B4
+  RickRollNote(69, 8), // A4
+  // answering figure
+  RickRollNote(81, 8), // A5
+  RickRollNote(null, 8),
+  RickRollNote(81, 8), // A5
+  RickRollNote(76, -4), // E5, dotted
+  RickRollNote(null, 4),
+  // "Never gonna run around and desert you"
+  RickRollNote(71, 8), // B4
+  RickRollNote(71, 8), // B4
+  RickRollNote(73, 8), // C#5
+  RickRollNote(74, 8), // D5
+  RickRollNote(71, 8), // B4
+  RickRollNote(74, 8), // D5
+  RickRollNote(76, 8), // E5
+  RickRollNote(null, 8),
+  RickRollNote(null, 8),
+  RickRollNote(73, 8), // C#5
+  RickRollNote(71, 8), // B4
+  RickRollNote(69, -4), // A4, dotted
+  RickRollNote(null, 4),
+  // "Never gonna make you cry"
+  RickRollNote(null, 8),
+  RickRollNote(71, 8), // B4
+  RickRollNote(71, 8), // B4
+  RickRollNote(73, 8), // C#5
+  RickRollNote(74, 8), // D5
+  RickRollNote(71, 8), // B4
+  RickRollNote(69, 4), // A4
+];
+
+/// How long the hook runs, summed from [kRickRollHook]. The overlay shows
+/// itself for exactly this long, so the picture and the sound can never
+/// disagree about when the joke is over.
+final Duration kRickRollHookDuration =
+    kRickRollHook.fold(Duration.zero, (sum, note) => sum + note.length);
+
+/// A handle on a running hook. `stop()` must be safe to call more than once
+/// and safe to call after the tune has already finished on its own.
+abstract interface class RickRollPlayback {
+  void stop();
+}
+
+/// The "no sound happened" answer — returned by the non-web stub and by the
+/// web implementation when the browser refuses to give us an audio context.
+/// The overlay treats it exactly like a successful one: the visual never
+/// depends on audio, because Safari can still withhold playback even though a
+/// keystroke granted user activation.
+class SilentRickRollPlayback implements RickRollPlayback {
+  const SilentRickRollPlayback();
+
+  @override
+  void stop() {}
+}

--- a/src/packages/flutter-app/lib/widgets/konami_listener.dart
+++ b/src/packages/flutter-app/lib/widgets/konami_listener.dart
@@ -1,0 +1,94 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../providers/easter_egg_provider.dart';
+import '../utils/konami_detector.dart';
+import 'rick_roll_overlay.dart';
+
+/// Listens for the Konami code everywhere in the app, and hosts the overlay it
+/// triggers.
+///
+/// Mounted from `MaterialApp.builder`, which is the only spot that covers
+/// everything: it wraps the root `Navigator`, so it sees dialogs and the nine
+/// screens that render outside `AppShell` (landing, auth, splash, the SSO
+/// callback…) as well as the tabs.
+///
+/// **Why `HardwareKeyboard` and not a `Focus`.** Handlers registered with
+/// `HardwareKeyboard.instance.addHandler` run in `KeyEventManager` *before*
+/// the focus tree gets the event, and returning false leaves normal handling
+/// completely untouched. A `Focus(onKeyEvent:)` here would sit above the
+/// focused node in the bubble chain and would therefore never see arrow keys
+/// while a text field has focus — and this app has text fields on 21 screens,
+/// including the one people spend the most time in.
+///
+/// The handler **always returns false**, so it cannot swallow a keystroke from
+/// anything. Note that returning true would not help even where you might want
+/// it to: `KeyEventManager` dispatches to the focus tree either way, and a
+/// handler's result only reports back to the engine. Dismissal keys are
+/// therefore the overlay's own business — see [RickRollOverlay], which takes
+/// focus and handles Escape where it can actually stop it travelling.
+class KonamiListener extends ConsumerStatefulWidget {
+  const KonamiListener({super.key, required this.child});
+
+  /// The app itself — whatever `MaterialApp.builder` handed us.
+  final Widget child;
+
+  @override
+  ConsumerState<KonamiListener> createState() => _KonamiListenerState();
+}
+
+class _KonamiListenerState extends ConsumerState<KonamiListener> {
+  final KonamiDetector _detector = KonamiDetector();
+
+  @override
+  void initState() {
+    super.initState();
+    HardwareKeyboard.instance.addHandler(_onKey);
+  }
+
+  @override
+  void dispose() {
+    HardwareKeyboard.instance.removeHandler(_onKey);
+    super.dispose();
+  }
+
+  bool _onKey(KeyEvent event) {
+    // Key *down* only. Taking repeats and ups as well would mean a held arrow
+    // key walks the sequence on its own.
+    if (event is! KeyDownEvent) return false;
+
+    // Keep feeding the detector while the roll is up — it costs one list
+    // compare and means the buffer is never in a half-matched state when the
+    // overlay goes away. roll() is a no-op if it is already running.
+    if (_detector.accept(event.logicalKey)) {
+      ref.read(rickRollProvider.notifier).roll();
+    }
+    return false;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      // Non-directional alignment and an explicit expand: this sits above the
+      // Navigator, and the app must fill the window exactly as it did before
+      // the Stack existed.
+      fit: StackFit.expand,
+      alignment: Alignment.center,
+      children: [
+        widget.child,
+        // The overlay slot is ALWAYS present — an empty box when idle rather
+        // than a conditionally-added child. Keeping the children list a fixed
+        // length pins the app at index 0 forever, so triggering the egg can
+        // never re-key the slot below it and remount the entire app. (An
+        // unnoticed remount is exactly how the chat panel used to destroy
+        // every unsaved draft on the trip page.)
+        Consumer(
+          builder: (context, ref, _) => ref.watch(rickRollProvider)
+              ? const RickRollOverlay()
+              : const SizedBox.shrink(),
+        ),
+      ],
+    );
+  }
+}

--- a/src/packages/flutter-app/lib/widgets/rick_roll_overlay.dart
+++ b/src/packages/flutter-app/lib/widgets/rick_roll_overlay.dart
@@ -1,0 +1,378 @@
+import 'dart:async';
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../l10n/l10n.dart';
+import '../providers/easter_egg_provider.dart';
+import '../theme/app_typography.dart';
+import '../utils/rick_roll_audio_stub.dart'
+    if (dart.library.js_interop) '../utils/rick_roll_audio_web.dart';
+import '../utils/rick_roll_tune.dart';
+
+/// What the Konami code gets you.
+///
+/// Rendered by [KonamiListener] from `MaterialApp.builder`, so it covers every
+/// screen at once. The app is *below* this widget in that stack, which is why
+/// "the site dims behind him" is a single [Opacity] here rather than a change
+/// to any of the 25 screens — none of which is touched, rebuilt, or remounted.
+///
+/// Everything is drawn: no image ships, nothing is fetched, and the sprite is
+/// ours. See rick_roll_tune.dart for why the sound is synthesized too.
+class RickRollOverlay extends ConsumerStatefulWidget {
+  const RickRollOverlay({super.key});
+
+  @override
+  ConsumerState<RickRollOverlay> createState() => _RickRollOverlayState();
+}
+
+class _RickRollOverlayState extends ConsumerState<RickRollOverlay>
+    with TickerProviderStateMixin {
+  /// The dance: fast enough to read as dancing, and the beat the sprite's two
+  /// frames alternate on.
+  late final AnimationController _dance;
+
+  /// The background hue drift. Deliberately an order of magnitude slower than
+  /// the dance — a full-screen rainbow cycling at dance speed is a strobe, and
+  /// a strobe is a photosensitivity hazard, not a joke.
+  late final AnimationController _hue;
+
+  RickRollPlayback? _audio;
+  Timer? _autoDismiss;
+
+  /// Escape has to be *ours* while the roll is up, and the only way to get
+  /// first refusal on a key in Flutter is to hold primary focus: dispatch
+  /// starts at the focused node and bubbles outward, so a handler that does
+  /// not own focus always runs after the map's Escape shortcut and the refine
+  /// panel's. (Consuming it from the HardwareKeyboard handler in
+  /// [KonamiListener] looks like it would work and does not — the focus tree
+  /// is dispatched to regardless of what those handlers return.)
+  final FocusNode _focus = FocusNode(debugLabel: 'RickRollOverlay');
+
+  /// Whatever had focus when the code fired — a chat composer, most likely.
+  /// Taking focus is a means to an end, not a thing we want to leave behind,
+  /// so it goes back when the joke is over.
+  FocusNode? _restoreFocusTo;
+
+  @override
+  void initState() {
+    super.initState();
+    _restoreFocusTo = FocusManager.instance.primaryFocus;
+    // After the frame: the node has to be attached before it can be focused.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) _focus.requestFocus();
+    });
+    _dance = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 480),
+    )..repeat();
+    _hue = AnimationController(
+      vsync: this,
+      duration: const Duration(seconds: 6),
+    )..repeat();
+
+    // This widget owns the sound for exactly as long as it is on screen:
+    // started here, stopped in dispose. Nothing else can start or stop it, so
+    // the picture and the audio cannot get out of step.
+    _audio = playRickRollHook();
+    _autoDismiss = Timer(kRickRollHookDuration, _dismiss);
+  }
+
+  @override
+  void dispose() {
+    _autoDismiss?.cancel();
+    // No ref.read here — reading a provider during dispose throws. Stopping
+    // the audio is this widget's own business anyway.
+    _audio?.stop();
+    _dance.dispose();
+    _hue.dispose();
+    _focus.dispose();
+    // Hand focus back on the next frame — requesting it mid-teardown, while
+    // this node is still unwinding, is not a safe moment. Guarded on context
+    // because whatever held focus may itself be gone by now.
+    final restore = _restoreFocusTo;
+    if (restore != null) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (restore.context != null) restore.requestFocus();
+      });
+    }
+    super.dispose();
+  }
+
+  void _dismiss() {
+    if (!mounted) return;
+    ref.read(rickRollProvider.notifier).stop();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = context.l10n;
+    return Positioned.fill(
+      // We render above the root Navigator, where there is no Material and no
+      // Overlay — routes bring their own. A transparent Material supplies the
+      // text defaults; anything needing an Overlay (a Tooltip, an InkWell's
+      // splash) would throw up here, which is why the close control below is
+      // hand-built rather than an IconButton.
+      child: Material(
+        type: MaterialType.transparency,
+        child: CallbackShortcuts(
+          bindings: {
+            const SingleActivator(LogicalKeyboardKey.escape): _dismiss,
+          },
+          child: Focus(
+            focusNode: _focus,
+            // Not a stop on the way round the app with Tab — it exists only to
+            // own the key. Same shape the trip page uses for its panel.
+            skipTraversal: true,
+            child: GestureDetector(
+              behavior: HitTestBehavior.opaque,
+              onTap: _dismiss,
+              child: Stack(
+                fit: StackFit.expand,
+                alignment: Alignment.center,
+                children: [
+                  // The roll itself, drawn over the live app.
+                  Opacity(
+                    opacity: 0.82,
+                    child: AnimatedBuilder(
+                      animation: Listenable.merge([_dance, _hue]),
+                      builder: (context, _) => CustomPaint(
+                        painter: _RickRollPainter(
+                          dance: _dance.value,
+                          hue: _hue.value,
+                        ),
+                      ),
+                    ),
+                  ),
+                  // Caption at full strength so it stays legible whatever hue is
+                  // passing underneath it.
+                  Align(
+                    alignment: const Alignment(0, 0.82),
+                    child: Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 24),
+                      child: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          Text(
+                            l10n.rickRollCaption,
+                            textAlign: TextAlign.center,
+                            style: const TextStyle(
+                              fontFamily: AppFonts.display,
+                              // Marcellus ships in 400 only; naming the weight
+                              // keeps the web build off synthetic faux-bold.
+                              fontWeight: FontWeight.w400,
+                              fontSize: 34,
+                              height: 1.1,
+                              color: Colors.white,
+                              shadows: _captionShadows,
+                            ),
+                          ),
+                          const SizedBox(height: 8),
+                          Text(
+                            l10n.rickRollDismissHint,
+                            textAlign: TextAlign.center,
+                            style: const TextStyle(
+                              fontFamily: AppFonts.ui,
+                              fontSize: 14,
+                              letterSpacing: 0.6,
+                              color: Colors.white,
+                              shadows: _captionShadows,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                  // An explicit way out, for anyone who does not think to press a
+                  // key or tap the background. Hand-built rather than an
+                  // IconButton: no Material for the splash, no Overlay for the
+                  // tooltip. The label rides Semantics instead.
+                  SafeArea(
+                    child: Align(
+                      alignment: Alignment.topRight,
+                      child: Semantics(
+                        button: true,
+                        label: l10n.commonClose,
+                        child: GestureDetector(
+                          onTap: _dismiss,
+                          child: Container(
+                            margin: const EdgeInsets.all(12),
+                            padding: const EdgeInsets.all(10),
+                            decoration: BoxDecoration(
+                              color: Colors.black.withValues(alpha: 0.45),
+                              shape: BoxShape.circle,
+                            ),
+                            child: const Icon(
+                              Icons.close,
+                              color: Colors.white,
+                              size: 22,
+                            ),
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+const List<Shadow> _captionShadows = [
+  Shadow(color: Colors.black, blurRadius: 12),
+  Shadow(color: Colors.black54, blurRadius: 2, offset: Offset(0, 2)),
+];
+
+// ---------------------------------------------------------------------------
+// The sprite.
+//
+// A rectangle table rather than an image asset, for three reasons: every
+// Flutter asset is precached by the service worker for every visitor on every
+// deploy (so a picture nobody asked for would cost everybody), a drawn figure
+// is unambiguously ours and needs no row in assets/images/LICENSES.md, and it
+// scales to any screen without a second resolution.
+//
+// Coordinates are cells in a [_gridW] x [_gridH] grid, drawn into whatever box
+// the painter is given.
+// ---------------------------------------------------------------------------
+
+const double _gridW = 16;
+const double _gridH = 26;
+
+class _Cell {
+  final double x, y, w, h;
+  const _Cell(this.x, this.y, this.w, this.h);
+}
+
+const Color _hairColor = Color(0xFFE8622A);
+const Color _skinColor = Color(0xFFF2C9A0);
+const Color _inkColor = Color(0xFF2A1A12);
+const Color _coatColor = Color(0xFF23272E);
+const Color _shirtColor = Color(0xFFF5F5F5);
+const Color _trouserColor = Color(0xFF2F3A56);
+const Color _shoeColor = Color(0xFF14161A);
+
+// Parts that do not change between frames.
+const List<_Cell> _hair = [
+  _Cell(4, 2, 8, 3), // the mass
+  _Cell(6, 0, 5, 2), // the quiff
+  _Cell(4, 5, 1, 2), // sideburns
+  _Cell(11, 5, 1, 2),
+];
+const List<_Cell> _head = [
+  _Cell(5, 5, 6, 5), // face
+  _Cell(7, 10, 2, 1), // neck
+];
+const List<_Cell> _face = [
+  _Cell(6, 6, 1, 1), // eyes
+  _Cell(9, 6, 1, 1),
+  _Cell(7, 8, 2, 1), // mouth
+];
+const List<_Cell> _coat = [_Cell(4, 11, 8, 7)];
+const List<_Cell> _shirt = [_Cell(7, 11, 2, 5)];
+
+// Frame 0: right arm up, legs together. Frame 1: left arm up, legs apart.
+const List<List<_Cell>> _sleeves = [
+  [
+    _Cell(2, 12, 2, 2),
+    _Cell(1, 14, 2, 3),
+    _Cell(12, 11, 2, 2),
+    _Cell(13, 8, 2, 3)
+  ],
+  [
+    _Cell(2, 11, 2, 2),
+    _Cell(1, 8, 2, 3),
+    _Cell(12, 12, 2, 2),
+    _Cell(13, 14, 2, 3)
+  ],
+];
+const List<List<_Cell>> _hands = [
+  [_Cell(1, 17, 2, 1), _Cell(13, 7, 2, 1)],
+  [_Cell(1, 7, 2, 1), _Cell(13, 17, 2, 1)],
+];
+const List<List<_Cell>> _legs = [
+  [_Cell(5, 18, 3, 6), _Cell(8, 18, 3, 6)],
+  [_Cell(4, 18, 3, 6), _Cell(9, 18, 3, 6)],
+];
+const List<List<_Cell>> _shoes = [
+  [_Cell(4, 24, 4, 2), _Cell(8, 24, 4, 2)],
+  [_Cell(3, 24, 4, 2), _Cell(9, 24, 4, 2)],
+];
+
+class _RickRollPainter extends CustomPainter {
+  /// Dance phase, 0..1. Drives the bob, the lean, and which of the two arm/leg
+  /// frames is showing.
+  final double dance;
+
+  /// Background hue phase, 0..1.
+  final double hue;
+
+  const _RickRollPainter({required this.dance, required this.hue});
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final bounds = Offset.zero & size;
+
+    // Rainbow ground.
+    canvas.drawRect(
+      bounds,
+      Paint()
+        ..shader = LinearGradient(
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+          colors: [
+            for (var i = 0; i < 6; i++)
+              HSVColor.fromAHSV(1, (hue * 360 + i * 60) % 360, 0.62, 0.88)
+                  .toColor(),
+          ],
+        ).createShader(bounds),
+    );
+
+    // Fit the sprite into the middle of whatever box we were given, leaving
+    // room at the bottom for the caption.
+    final cell =
+        math.min(size.width / (_gridW * 2.2), size.height / (_gridH * 1.9));
+    final spriteW = _gridW * cell;
+    final spriteH = _gridH * cell;
+    final bob = math.sin(dance * 2 * math.pi) * cell * 0.7;
+    final lean = math.sin(dance * 2 * math.pi) * 0.05;
+    final frame = dance < 0.5 ? 0 : 1;
+
+    canvas.save();
+    canvas.translate(size.width / 2, size.height / 2 - spriteH * 0.08 + bob);
+    canvas.rotate(lean);
+    canvas.translate(-spriteW / 2, -spriteH / 2);
+
+    void fill(List<_Cell> cells, Color color) {
+      final paint = Paint()..color = color;
+      for (final c in cells) {
+        canvas.drawRect(
+          Rect.fromLTWH(c.x * cell, c.y * cell, c.w * cell, c.h * cell),
+          paint,
+        );
+      }
+    }
+
+    fill(_legs[frame], _trouserColor);
+    fill(_shoes[frame], _shoeColor);
+    fill(_sleeves[frame], _coatColor);
+    fill(_hands[frame], _skinColor);
+    fill(_coat, _coatColor);
+    fill(_shirt, _shirtColor);
+    fill(_head, _skinColor);
+    fill(_hair, _hairColor);
+    fill(_face, _inkColor);
+
+    canvas.restore();
+  }
+
+  @override
+  bool shouldRepaint(_RickRollPainter old) =>
+      old.dance != dance || old.hue != hue;
+}

--- a/src/packages/flutter-app/test/konami_detector_test.dart
+++ b/src/packages/flutter-app/test/konami_detector_test.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:travel_route_planner/utils/konami_detector.dart';
+
+/// Matching rules for the Konami code. Pure — no widget pump — because the
+/// interesting cases are all about what a *sloppy* entry does, and those are
+/// tedious to drive through a key simulator.
+void main() {
+  const up = LogicalKeyboardKey.arrowUp;
+  const down = LogicalKeyboardKey.arrowDown;
+  const left = LogicalKeyboardKey.arrowLeft;
+  const right = LogicalKeyboardKey.arrowRight;
+  const b = LogicalKeyboardKey.keyB;
+  const a = LogicalKeyboardKey.keyA;
+
+  /// Feeds every key and returns which positions reported a completed code.
+  List<int> firesAt(List<LogicalKeyboardKey> keys) {
+    final detector = KonamiDetector();
+    return [
+      for (var i = 0; i < keys.length; i++)
+        if (detector.accept(keys[i])) i,
+    ];
+  }
+
+  test('the code completes on its last key and not before', () {
+    expect(firesAt(kKonamiCode), [kKonamiCode.length - 1]);
+  });
+
+  test('an overshot leading arrow still completes', () {
+    // The reason this detector is a rolling buffer and not an index. The code
+    // opens with two Ups; press three and an index matcher can never recover,
+    // no matter how correctly the remaining eight keys are typed.
+    expect(firesAt([up, ...kKonamiCode]), [kKonamiCode.length]);
+    expect(firesAt([up, up, ...kKonamiCode]), [kKonamiCode.length + 1]);
+  });
+
+  test('unrelated keystrokes before the code are ignored', () {
+    expect(
+      firesAt([a, b, down, right, ...kKonamiCode]),
+      [kKonamiCode.length + 3],
+    );
+  });
+
+  test('a wrong key inside the sequence stops it completing', () {
+    expect(
+      firesAt([up, up, down, down, left, left, left, right, b, a]),
+      isEmpty,
+    );
+  });
+
+  test('one more key after a completed code does not fire again', () {
+    expect(firesAt([...kKonamiCode, a]), [kKonamiCode.length - 1]);
+    expect(firesAt([...kKonamiCode, b, a]), [kKonamiCode.length - 1]);
+  });
+
+  test('the code fires again after a full re-entry', () {
+    expect(
+      firesAt([...kKonamiCode, ...kKonamiCode]),
+      [kKonamiCode.length - 1, kKonamiCode.length * 2 - 1],
+    );
+  });
+
+  test('reset drops a sequence in progress', () {
+    final detector = KonamiDetector();
+    for (final key in kKonamiCode.take(kKonamiCode.length - 1)) {
+      expect(detector.accept(key), isFalse);
+    }
+    detector.reset();
+    expect(detector.accept(kKonamiCode.last), isFalse);
+  });
+}

--- a/src/packages/flutter-app/test/rick_roll_overlay_test.dart
+++ b/src/packages/flutter-app/test/rick_roll_overlay_test.dart
@@ -1,0 +1,131 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:travel_route_planner/main.dart';
+import 'package:travel_route_planner/navigation/url_sync.dart';
+import 'package:travel_route_planner/providers/auth_provider.dart';
+import 'package:travel_route_planner/providers/live_trip_provider.dart';
+import 'package:travel_route_planner/providers/resumable_chats_provider.dart';
+import 'package:travel_route_planner/providers/trips_provider.dart';
+import 'package:travel_route_planner/screens/app_shell.dart';
+import 'package:travel_route_planner/utils/konami_detector.dart';
+import 'package:travel_route_planner/widgets/konami_listener.dart';
+import 'package:travel_route_planner/widgets/rick_roll_overlay.dart';
+
+import 'support/l10n_test_app.dart';
+import 'support/url_sync_fakes.dart';
+
+/// The Konami-code easter egg, from the two angles that can break something
+/// real: it has to reach the whole app without remounting any of it, and it
+/// has to leave every other key handler in the app alone.
+///
+/// Audio resolves to `rick_roll_audio_stub.dart` on the VM, so these run
+/// silent. Note that the overlay animates forever while it is up — never
+/// `pumpAndSettle` with it on screen, and always dismiss before a test ends so
+/// its auto-dismiss timer is cancelled.
+void main() {
+  setUp(() => SharedPreferences.setMockInitialValues({}));
+
+  Future<void> enterKonamiCode(WidgetTester tester) async {
+    for (final key in kKonamiCode) {
+      await tester.sendKeyEvent(key);
+    }
+    await tester.pump();
+  }
+
+  testWidgets('the code rolls the site, and Escape ends it', (tester) async {
+    tester.binding.platformDispatcher.defaultRouteNameTestValue = '/';
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          authProvider.overrideWith((ref) => FakeAuthNotifier(fakeUser())),
+          tripsApiServiceProvider
+              .overrideWithValue(FakeTripsApiService(fakeTrip('t1'))),
+          liveTripProvider.overrideWithValue(null),
+          resumableChatsProvider.overrideWith((ref) async => const []),
+          urlReporterProvider.overrideWithValue((_) {}),
+        ],
+        child: const TravelRoutePlannerApp(),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byType(RickRollOverlay), findsNothing);
+    // The app's own element, captured before the trigger. The overlay is a
+    // sibling appended after this in a fixed-length Stack, so the app must
+    // come through untouched — a remount here would be the trip page losing
+    // every unsaved draft the moment somebody pressed Up.
+    final shell = tester.element(find.byType(AppShell));
+
+    await enterKonamiCode(tester);
+    expect(find.byType(RickRollOverlay), findsOneWidget);
+    expect(tester.element(find.byType(AppShell)), same(shell));
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.escape);
+    await tester.pump();
+    expect(find.byType(RickRollOverlay), findsNothing);
+    expect(tester.element(find.byType(AppShell)), same(shell));
+  });
+
+  testWidgets('no key is swallowed — except Escape while rolling',
+      (tester) async {
+    final seen = <LogicalKeyboardKey>[];
+    await tester.pumpWidget(
+      ProviderScope(
+        child: localizedTestApp(
+          home: KonamiListener(
+            child: Focus(
+              autofocus: true,
+              onKeyEvent: (node, event) {
+                if (event is KeyDownEvent) seen.add(event.logicalKey);
+                return KeyEventResult.ignored;
+              },
+              child: const SizedBox.expand(),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    await enterKonamiCode(tester);
+
+    // Every key of the code still reached the focus tree. This is the whole
+    // reason the detector hangs off HardwareKeyboard and returns false: a
+    // focused text field keeps its arrow keys for the caret, and B and A keep
+    // typing letters.
+    expect(seen, kKonamiCode);
+    expect(find.byType(RickRollOverlay), findsOneWidget);
+
+    seen.clear();
+    await tester.sendKeyEvent(LogicalKeyboardKey.escape);
+    await tester.pump();
+
+    // The one documented exception. Escape is consumed while the roll is up,
+    // so escaping the joke cannot also close the fullscreen map or the refine
+    // chat panel sitting underneath it.
+    expect(seen, isEmpty);
+    expect(find.byType(RickRollOverlay), findsNothing);
+  });
+
+  testWidgets('a tap anywhere ends it', (tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        child: localizedTestApp(
+          home: const KonamiListener(child: SizedBox.expand()),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    await enterKonamiCode(tester);
+    expect(find.byType(RickRollOverlay), findsOneWidget);
+
+    await tester.tapAt(const Offset(40, 300));
+    await tester.pump();
+    expect(find.byType(RickRollOverlay), findsNothing);
+  });
+}


### PR DESCRIPTION
## Summary

- ↑ ↑ ↓ ↓ ← → ← → B A on any screen rolls the site: a drawn figure dances over a drifting rainbow, the hook plays, and the app ghosts through at 20% underneath. Escape, a tap, the ✕, or the tune ending dismisses it.
- **Nothing ships to make it work** — no asset, no dependency, no `pubspec.yaml` change, no nginx change. The figure is a rectangle table in a `CustomPainter`; the sound is scheduled square waves on one `AudioContext`.
- That is forced, not chosen: `/app/` sends `Cross-Origin-Embedder-Policy: require-corp`, which blocks a cross-origin YouTube embed outright, and the CSP declares no `media-src`, so audio falls back to `default-src 'self'` — a `data:`/`blob:` clip would work today and break when that policy stops being `Report-Only`. Oscillators are subject to neither. Drawing it also means no bundled third party that `assets/images/LICENSES.md` could not honestly account for.
- Detection hangs off `HardwareKeyboard.instance.addHandler`, which runs **before** the focus tree — so the code is heard through a focused text field, and this app has text fields on 21 screens. The handler **always returns false** and cannot swallow a keystroke.
- Escape is owned by the overlay, not that handler. Returning `true` from a `HardwareKeyboard` handler does not stop focus-tree dispatch (`KeyEventManager` dispatches either way), so the overlay takes primary focus and hands it back on dismiss — which is what stops escaping the joke from also closing the fullscreen map or the refine chat panel underneath it.
- The overlay mounts from `MaterialApp.builder` — the one place that covers all routes, dialogs, and the nine screens outside `AppShell` — as the second child of a **fixed-length** `Stack` with the app pinned at index 0 and an empty box in the slot when idle. Triggering the egg rebuilds nothing below it, so no in-progress draft can be lost.
- The matcher is a rolling buffer of the last ten keys, not an advance-an-index one: the code opens `↑ ↑`, so overshooting to `↑ ↑ ↑` permanently desyncs an index matcher.
- Two new l10n keys (`commonClose` is reused for the ✕). The caption is a song title and is deliberately identical in ES, following the `appTitle` brand-name precedent.

## Testing

- `flutter analyze` — clean (the 3 remaining infos are pre-existing in `models/route_response.dart`).
- `flutter test` — **1447 passed, 0 failed**, including 10 new ones.
  - `konami_detector_test.dart` — completion, overshoot recovery, junk prefixes, no re-fire on an extra key, re-entry.
  - `rick_roll_overlay_test.dart` — the real app pumped end to end: the code rolls it, Escape ends it, and the shell's `Element` is **identical** across the trigger (the no-remount pin). Plus: every one of the ten keys still reaches the focus tree, while Escape does not while rolling.
- `make flutter-gen-l10n` run last; `l10n_untranslated.json` is `{}`.
- **Browser, headless Chrome over CDP against the lane's dev stack** — screenshots before / rolled / dismissed, and instrumented Web Audio:
  - 1 `AudioContext`, **25 oscillators** (exactly the pitched notes in the table), frequencies `440, 494, 554, 587, 659, 880` Hz = A4, B4, C♯5, D5, E5, A5, last note scheduled at +10.06 s.
  - The context is **closed exactly once** on dismiss — no orphaned oscillators.
  - 5 distinct sprite crops over 5 samples 240 ms apart: it animates.
  - **Zero network requests** during the roll, and no blocked-resource or CSP console messages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)