### PR TITLE
feat(easter-egg): seven taps on the brand roll the site

### DIFF
--- a/specs/konami-rickroll/spec.md
+++ b/specs/konami-rickroll/spec.md
@@ -28,6 +28,8 @@ asset needs a provenance row it could not honestly be given.
 
 - As **someone poking at the site**, I want the Konami code to do something
   ridiculous, so that finding it feels like a reward.
+- As **someone on a phone**, I want a way in that does not need arrow keys, so
+  that the egg is not reserved for people at desks.
 - As **anyone who triggers it by accident**, I want one obvious way out, so
   that a joke never becomes a trap.
 - As **a traveler mid-sentence in the chat composer**, I want my typing, my
@@ -38,6 +40,12 @@ asset needs a provenance row it could not honestly be given.
 
 - [ ] Entering ↑ ↑ ↓ ↓ ← → ← → B A rolls the site from any screen, signed in or
       out — including the landing page and the screens outside the tab shell.
+- [ ] Seven taps in quick succession on the brand in the app bar do the same,
+      with no keyboard — on every screen the app bar appears, including the
+      ones where the brand is not a button at all.
+- [ ] Those taps change nothing else: a single tap still goes home where it did
+      before, the brand gains no ripple, tooltip or button role where it had
+      none, and taps spread out over ordinary navigation never accumulate.
 - [ ] The rolled state shows an animated figure over a drifting rainbow, with
       the app still visible underneath, plus a caption and a close control.
 - [ ] The hook plays on the web. Where the browser refuses to start audio, the
@@ -65,10 +73,11 @@ None. Nothing is persisted; the rolled state lasts as long as it is on screen.
 ## UI Behavior
 
 - **Surface:** a layer above every route and dialog, so no screen has to know
-  it exists.
-- **Happy path:** enter the code → the roll appears over the current screen and
-  the tune starts → it ends itself when the tune does, or immediately on
-  Escape / tap / close.
+  it exists. The two triggers are the keyboard anywhere in the app, and the
+  brand in the app bar.
+- **Happy path:** enter the code (or tap the brand seven times) → the roll
+  appears over the current screen and the tune starts → it ends itself when the
+  tune does, or immediately on Escape / tap / close.
 - **States:** there are only two — rolled and not. There is no loading state
   (nothing is fetched) and no error state (a browser that will not play audio
   is an ordinary outcome, not a failure).
@@ -81,13 +90,21 @@ None. Nothing is persisted; the rolled state lasts as long as it is on screen.
   re-attack the tune from the top.
 - **The code is entered with a text field focused.** It fires, and the field
   keeps every one of those keystrokes.
-- **No keyboard.** Phones cannot enter the code at all. That is accepted, not
-  worked around: see Out of Scope.
+- **No keyboard.** Phones cannot enter the Konami code at all, which is what
+  the seven-tap trigger exists for.
+- **Taps that are not a burst.** A stray tap long before a deliberate run must
+  not cost the user a tap — it starts the new run rather than being discarded.
+- **The brand is tapped mid-navigation.** Each of the seven taps still does
+  whatever it did before, so on the shell the first one goes home. Accepted: a
+  single tap already does that.
 
 ## Out of Scope
 
-- Any mobile or touch trigger. Adding one means threading a tap counter through
-  the shared wordmark widget, and the code is a keyboard joke.
+- A trigger anywhere but the app-bar brand. The landing page's large hero
+  wordmark is a tempting second target but is not on every screen, and one
+  trigger is enough to find.
+- A shake gesture. It would mean a sensor dependency and, on iOS Safari, a
+  motion-permission prompt — a lot of machinery for a second way in.
 - Persisting that a user has found it, or any analytics on it.
 - A setting to disable it.
 - Sound on iOS/Android builds — those cannot reach the trigger.

--- a/src/packages/flutter-app/lib/l10n/app_en.arb
+++ b/src/packages/flutter-app/lib/l10n/app_en.arb
@@ -2615,8 +2615,8 @@
   "@rickRollCaption": {
     "description": "Caption on the Konami-code easter egg. Not translated — it is a song title."
   },
-  "rickRollDismissHint": "press esc to escape",
+  "rickRollDismissHint": "tap anywhere to escape",
   "@rickRollDismissHint": {
-    "description": "Hint under the easter-egg caption telling the user how to close it."
+    "description": "Hint under the easter-egg caption telling the user how to close it. Deliberately not 'press esc' — the egg has a touch trigger, and a phone has no Escape key. Escape still works; a tap is the instruction that is true on every device."
   }
 }

--- a/src/packages/flutter-app/lib/l10n/app_es.arb
+++ b/src/packages/flutter-app/lib/l10n/app_es.arb
@@ -1096,5 +1096,5 @@
   "wearSummaryRain": "lluvia probable",
   "wearHistoricalFootnote": "Más allá del pronóstico de 16 días, los rangos muestran el tiempo habitual en estas fechas.",
   "rickRollCaption": "Never gonna give you up",
-  "rickRollDismissHint": "pulsa esc para salir"
+  "rickRollDismissHint": "toca donde sea para salir"
 }

--- a/src/packages/flutter-app/lib/l10n/app_localizations.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations.dart
@@ -6434,10 +6434,10 @@ abstract class AppLocalizations {
   /// **'Never gonna give you up'**
   String get rickRollCaption;
 
-  /// Hint under the easter-egg caption telling the user how to close it.
+  /// Hint under the easter-egg caption telling the user how to close it. Deliberately not 'press esc' — the egg has a touch trigger, and a phone has no Escape key. Escape still works; a tap is the instruction that is true on every device.
   ///
   /// In en, this message translates to:
-  /// **'press esc to escape'**
+  /// **'tap anywhere to escape'**
   String get rickRollDismissHint;
 }
 

--- a/src/packages/flutter-app/lib/l10n/app_localizations_en.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations_en.dart
@@ -3893,5 +3893,5 @@ class AppLocalizationsEn extends AppLocalizations {
   String get rickRollCaption => 'Never gonna give you up';
 
   @override
-  String get rickRollDismissHint => 'press esc to escape';
+  String get rickRollDismissHint => 'tap anywhere to escape';
 }

--- a/src/packages/flutter-app/lib/l10n/app_localizations_es.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations_es.dart
@@ -3920,5 +3920,5 @@ class AppLocalizationsEs extends AppLocalizations {
   String get rickRollCaption => 'Never gonna give you up';
 
   @override
-  String get rickRollDismissHint => 'pulsa esc para salir';
+  String get rickRollDismissHint => 'toca donde sea para salir';
 }

--- a/src/packages/flutter-app/lib/providers/easter_egg_provider.dart
+++ b/src/packages/flutter-app/lib/providers/easter_egg_provider.dart
@@ -1,19 +1,49 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-/// Whether the Konami code is currently rolling the site.
+import '../utils/secret_tap_counter.dart';
+
+/// Whether the easter egg is currently rolling the site, and the two ways in.
 ///
 /// A provider rather than local state in the listener widget for one reason
 /// that matters: it is the seam tests drive. The overlay lives in
 /// `MaterialApp.builder`, above every route, so there is no screen to pump on
 /// its own — a test either sends ten keystrokes or flips this.
+///
+/// The tap counter lives here rather than in the app bar because **the app bar
+/// is rebuilt constantly** — every screen constructs its own `GradientAppBar`,
+/// and navigating rebuilds it. A counter held in that widget would reset
+/// halfway through the gesture. This notifier is app-scoped, so a burst of
+/// taps survives whatever the taps themselves make the app do.
 class RickRollNotifier extends StateNotifier<bool> {
-  RickRollNotifier() : super(false);
+  RickRollNotifier({DateTime Function()? now})
+      : _now = now ?? DateTime.now,
+        super(false);
+
+  /// The clock, injectable so a test can state the gaps it means rather than
+  /// racing a real one.
+  final DateTime Function() _now;
+
+  final SecretTapCounter _taps = SecretTapCounter();
 
   /// Starts the roll. Entering the code again while it is already running is
   /// a no-op rather than a restart: re-triggering would tear down the audio
   /// context mid-phrase and re-attack the tune from bar one.
   void roll() {
     if (!state) state = true;
+  }
+
+  /// The brand was tapped. Rolls the site on the seventh in quick succession
+  /// — the touch way in, for the phones that cannot enter a Konami code
+  /// because they have no arrow keys.
+  ///
+  /// This never consumes or replaces the tap: the brand still navigates home
+  /// exactly as before, and on the screens where it does nothing at all
+  /// (landing, auth) this is the only thing listening. Counting is
+  /// unconditional for the same reason the key detector is — a caller that
+  /// had to know whether it was on a touch device would be a caller that can
+  /// get it wrong.
+  void brandTapped() {
+    if (_taps.tap(_now())) roll();
   }
 
   /// Ends the roll — Escape, a tap, the close button, or the tune running out.

--- a/src/packages/flutter-app/lib/utils/secret_tap_counter.dart
+++ b/src/packages/flutter-app/lib/utils/secret_tap_counter.dart
@@ -1,0 +1,49 @@
+/// How many taps in a row open the easter egg on a device with no keyboard.
+///
+/// Seven, because that is the number Android's "tap the build number" gesture
+/// taught everyone. Fewer would be reachable by an impatient traveler tapping
+/// the logo to get home.
+const int kSecretTapCount = 7;
+
+/// How long a tap stays "part of the same burst". Measured between
+/// *consecutive* taps, not across the whole run, so the gesture stays
+/// achievable for someone who is not especially quick without ever
+/// accumulating across the minutes of ordinary navigation taps a session
+/// contains.
+const Duration kSecretTapWindow = Duration(milliseconds: 700);
+
+/// Counts taps arriving in rapid succession — the touch counterpart to
+/// [KonamiDetector], and pure for the same reason: the interesting cases are
+/// about timing, which is miserable to drive through a widget pump but trivial
+/// to state directly.
+///
+/// The clock is a parameter rather than a call to `DateTime.now()` inside, so
+/// a test can state the gaps it means instead of hoping the machine is fast.
+class SecretTapCounter {
+  DateTime? _last;
+  int _count = 0;
+
+  /// Records a tap at [now] and reports whether it was the one that completed
+  /// the run.
+  ///
+  /// A tap that arrives more than [kSecretTapWindow] after the previous one
+  /// does not merely fail — it *restarts* the count at one, so the slow tap is
+  /// treated as the beginning of a fresh burst rather than being thrown away.
+  /// Without that, seven deliberate taps following one stray earlier tap would
+  /// need an eighth.
+  bool tap(DateTime now) {
+    final last = _last;
+    _count = (last != null && now.difference(last) <= kSecretTapWindow)
+        ? _count + 1
+        : 1;
+    _last = now;
+    if (_count >= kSecretTapCount) {
+      // Reset rather than leaving the counter at the threshold, so the next
+      // tap cannot fire it a second time.
+      _count = 0;
+      _last = null;
+      return true;
+    }
+    return false;
+  }
+}

--- a/src/packages/flutter-app/lib/widgets/gradient_app_bar.dart
+++ b/src/packages/flutter-app/lib/widgets/gradient_app_bar.dart
@@ -5,6 +5,7 @@ import '../constants/app_info.dart';
 import '../l10n/l10n.dart';
 import '../navigation/app_nav.dart';
 import '../navigation/shell_scope.dart';
+import '../providers/easter_egg_provider.dart';
 import '../theme/app_colors.dart';
 import '../theme/app_typography.dart';
 import '../theme/spacing.dart';
@@ -127,7 +128,7 @@ class GradientAppBar extends ConsumerWidget implements PreferredSizeWidget {
 /// navigate — which is also why `Semantics(excludeSemantics: true)` wraps just
 /// the brand. Wrapping the whole row would swallow the page title from screen
 /// readers and hand the title a "Home" button role it does not have.
-class _BrandTitle extends StatelessWidget {
+class _BrandTitle extends ConsumerWidget {
   final Widget? title;
   final VoidCallback? onTap;
 
@@ -141,7 +142,7 @@ class _BrandTitle extends StatelessWidget {
       {required this.title, required this.onTap, required this.inShell});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     // Measures the true title slot, so the thresholds above are stated in the
     // width the row actually gets — the tap padding sits inside this, not
     // around it.
@@ -212,6 +213,24 @@ class _BrandTitle extends StatelessWidget {
             ),
           );
         }
+
+        // The touch way into the easter egg (specs/konami-rickroll): seven
+        // taps in quick succession. Deliberately OUTSIDE the `onTap != null`
+        // branch — the brand is not tappable on the signed-out screens, and
+        // the landing page is exactly where somebody idly prodding the logo
+        // is standing.
+        //
+        // A Listener, not a GestureDetector: raw pointer events never enter
+        // the gesture arena, so this cannot compete with the InkWell above
+        // for the tap (nested recognizers resolve to the innermost, and the
+        // outer one would simply never fire). It adds no ripple, no tap
+        // target and no semantics, so the brand looks and reads exactly as it
+        // did — including on the screens where it is not a button.
+        brand = Listener(
+          onPointerDown: (_) =>
+              ref.read(rickRollProvider.notifier).brandTapped(),
+          child: brand,
+        );
 
         if (!showTitle) {
           // Nothing left to compete with, so this is the one place a squeeze

--- a/src/packages/flutter-app/test/secret_tap_counter_test.dart
+++ b/src/packages/flutter-app/test/secret_tap_counter_test.dart
@@ -1,0 +1,75 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:travel_route_planner/utils/secret_tap_counter.dart';
+
+/// Timing rules for the touch way into the easter egg. Pure, so the gaps are
+/// stated rather than raced.
+void main() {
+  final t0 = DateTime.utc(2026, 1, 1, 12);
+
+  /// Taps at the given offsets from [t0] (in ms); returns the offsets that
+  /// fired.
+  List<int> firesAt(List<int> offsetsMs) {
+    final counter = SecretTapCounter();
+    return [
+      for (final ms in offsetsMs)
+        if (counter.tap(t0.add(Duration(milliseconds: ms)))) ms,
+    ];
+  }
+
+  /// n taps 100 ms apart starting at [from].
+  List<int> burst(int n, {int from = 0}) =>
+      [for (var i = 0; i < n; i++) from + i * 100];
+
+  /// The first offset that is definitely a NEW run — one millisecond past the
+  /// window measured from [lastTapAt], not from t0. Getting that reference
+  /// point wrong is the easy mistake: the window is a gap between two taps.
+  int afterPause(int lastTapAt) =>
+      lastTapAt + kSecretTapWindow.inMilliseconds + 1;
+
+  test('the seventh rapid tap fires, and not the sixth', () {
+    expect(firesAt(burst(kSecretTapCount)), [(kSecretTapCount - 1) * 100]);
+    expect(firesAt(burst(kSecretTapCount - 1)), isEmpty);
+  });
+
+  test('a gap longer than the window restarts the count', () {
+    // Six taps, a pause, then five more: eleven taps, no fire — the pause
+    // means the second run is only five long.
+    final resume = afterPause(500);
+    expect(firesAt([...burst(6), ...burst(5, from: resume)]), isEmpty);
+  });
+
+  test('the slow tap begins the new run rather than being discarded', () {
+    // One stray tap, a long pause, then seven more. The stray must not cost
+    // the user a tap: the pause-crossing tap is number one of the new run.
+    final resume = afterPause(0);
+    expect(
+      firesAt([0, ...burst(kSecretTapCount, from: resume)]),
+      [resume + (kSecretTapCount - 1) * 100],
+    );
+  });
+
+  test('the window is measured between consecutive taps, not across the run',
+      () {
+    // Every gap is just inside the window, so a run far longer than the
+    // window still counts.
+    final gap = kSecretTapWindow.inMilliseconds;
+    final offsets = [for (var i = 0; i < kSecretTapCount; i++) i * gap];
+    expect(firesAt(offsets), [offsets.last]);
+  });
+
+  test('one tap over the window does not fire, but the next run can', () {
+    final gap = kSecretTapWindow.inMilliseconds + 1;
+    expect(firesAt([for (var i = 0; i < 20; i++) i * gap]), isEmpty);
+  });
+
+  test('firing resets, so an eighth tap does not fire again', () {
+    expect(firesAt(burst(kSecretTapCount + 1)), [(kSecretTapCount - 1) * 100]);
+  });
+
+  test('a second full burst fires again', () {
+    expect(
+      firesAt([...burst(kSecretTapCount), ...burst(kSecretTapCount, from: 2000)]),
+      [(kSecretTapCount - 1) * 100, 2000 + (kSecretTapCount - 1) * 100],
+    );
+  });
+}

--- a/src/packages/flutter-app/test/secret_tap_trigger_test.dart
+++ b/src/packages/flutter-app/test/secret_tap_trigger_test.dart
@@ -1,0 +1,115 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:travel_route_planner/main.dart';
+import 'package:travel_route_planner/navigation/url_sync.dart';
+import 'package:travel_route_planner/providers/auth_provider.dart';
+import 'package:travel_route_planner/providers/easter_egg_provider.dart';
+import 'package:travel_route_planner/providers/live_trip_provider.dart';
+import 'package:travel_route_planner/providers/resumable_chats_provider.dart';
+import 'package:travel_route_planner/providers/trips_provider.dart';
+import 'package:travel_route_planner/utils/secret_tap_counter.dart';
+import 'package:travel_route_planner/widgets/brand_logo.dart';
+import 'package:travel_route_planner/widgets/gradient_app_bar.dart';
+import 'package:travel_route_planner/widgets/rick_roll_overlay.dart';
+
+import 'support/url_sync_fakes.dart';
+
+/// The touch way into the easter egg: seven taps on the brand. The timing
+/// rules are covered exhaustively in `secret_tap_counter_test.dart`; what is
+/// proved here is the wiring, on the two screens that differ — one where the
+/// brand is a button and one where it is not.
+///
+/// The overlay animates forever while it is up: never `pumpAndSettle` with it
+/// on screen, and always dismiss before a test ends so its auto-dismiss timer
+/// is cancelled.
+void main() {
+  setUp(() => SharedPreferences.setMockInitialValues({}));
+
+  // A frozen clock, so seven taps are always "in quick succession" no matter
+  // how loaded the machine running the test is.
+  final frozen = DateTime.utc(2026, 1, 1, 12);
+
+  Future<void> pumpApp(WidgetTester tester, {required bool signedIn}) async {
+    tester.binding.platformDispatcher.defaultRouteNameTestValue = '/';
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          rickRollProvider
+              .overrideWith((ref) => RickRollNotifier(now: () => frozen)),
+          authProvider.overrideWith(
+              (ref) => FakeAuthNotifier(signedIn ? fakeUser() : null)),
+          tripsApiServiceProvider
+              .overrideWithValue(FakeTripsApiService(fakeTrip('t1'))),
+          liveTripProvider.overrideWithValue(null),
+          resumableChatsProvider.overrideWith((ref) async => const []),
+          urlReporterProvider.overrideWithValue((_) {}),
+        ],
+        child: const TravelRoutePlannerApp(),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  /// The app bar's brand specifically. Scoped, because the landing page also
+  /// renders a large [BrandWordmark] in its hero — a bare `byType().first`
+  /// finds that one, which carries no trigger and is not what ships on every
+  /// screen. `hitTestable` then picks the visible app bar out of the three the
+  /// shell keeps mounted in its IndexedStack.
+  Finder appBarBrand() => find
+      .descendant(
+        of: find.byType(GradientAppBar),
+        matching: find.byType(BrandWordmark),
+      )
+      .hitTestable();
+
+  Future<void> tapBrand(WidgetTester tester, int times) async {
+    for (var i = 0; i < times; i++) {
+      await tester.tap(appBarBrand().first);
+      await tester.pump();
+    }
+  }
+
+  testWidgets('seven taps on the brand roll the site, signed in',
+      (tester) async {
+    await pumpApp(tester, signedIn: true);
+    expect(find.byType(RickRollOverlay), findsNothing);
+
+    await tapBrand(tester, kSecretTapCount - 1);
+    expect(find.byType(RickRollOverlay), findsNothing,
+        reason: 'six taps must not be enough');
+
+    await tapBrand(tester, 1);
+    expect(find.byType(RickRollOverlay), findsOneWidget);
+
+    await tester.tapAt(const Offset(40, 400));
+    await tester.pump();
+    expect(find.byType(RickRollOverlay), findsNothing);
+  });
+
+  testWidgets('it also works where the brand is not a button', (tester) async {
+    // Signed out, the brand has no onTap at all — no InkWell, no button
+    // semantics. The Listener is deliberately outside that branch, because
+    // the landing page is exactly where somebody idly prodding the logo is
+    // standing. Tapping through the InkWell is what this proves is NOT
+    // required.
+    await pumpApp(tester, signedIn: false);
+    expect(appBarBrand(), findsOneWidget);
+    // Ancestors of the brand, not of the app bar — the bar's own language and
+    // sign-in actions are InkWells and always were.
+    expect(
+      find.ancestor(of: appBarBrand(), matching: find.byType(InkWell)),
+      findsNothing,
+      reason: 'the signed-out brand must still not be a button',
+    );
+
+    await tapBrand(tester, kSecretTapCount);
+    expect(find.byType(RickRollOverlay), findsOneWidget);
+
+    await tester.tapAt(const Offset(40, 400));
+    await tester.pump();
+    expect(find.byType(RickRollOverlay), findsNothing);
+  });
+}


### PR DESCRIPTION
## Summary

Follow-up to #449, which was keyboard-only — so phones couldn't reach the egg at all. **Seven taps in quick succession on the app-bar brand** now do the same thing (the number Android's build-number gesture taught everyone), within a 700 ms window measured between *consecutive* taps.

Three decisions are load-bearing:

- **The `Listener` sits outside the `onTap != null` branch.** `GradientAppBar` only gives the brand an `onTap` `inShell` — signed out it is not tappable at all, and the landing page is exactly where somebody idly prodding a logo is standing. Hooking the existing tap handler would have missed it. A test pins this on the signed-out screen specifically.
- **A `Listener`, not a `GestureDetector`.** Raw pointer events never enter the gesture arena; nested tap recognizers resolve to the innermost, so an outer `GestureDetector` would simply never fire while the `InkWell` is there. It also adds no ripple, no tap target and no semantics, so the brand looks and reads exactly as before — including where it is not a button. Single-tap-to-go-home is untouched.
- **The counter lives in the notifier, not the app bar.** Every screen builds its own `GradientAppBar` and each tap rebuilds it, so a counter held there would reset halfway through its own gesture. Its clock is injectable, so the timing rules are stated in tests rather than raced against the machine.
- A tap arriving after the window **restarts** the run rather than being discarded — otherwise one stray earlier tap silently costs the user an eighth.

Also fixes copy the new trigger made wrong: the overlay said "press esc to escape", which is no advice at all on a phone. Now "tap anywhere to escape" — true on every device; Escape still works.

`specs/konami-rickroll/spec.md` updated: the touch trigger moves from Out of Scope to acceptance criteria, and the two things now explicitly out of scope are a landing-hero trigger and a shake gesture (sensor dependency + an iOS Safari motion prompt).

## Testing

- `flutter analyze` — clean (the 3 remaining infos are pre-existing in `models/route_response.dart`).
- `flutter test` — **1470 passed, 0 failed**, including 9 new. The full suite matters here: `_BrandTitle` became a `ConsumerWidget`, so any test pumping an app bar without a `ProviderScope` would have broken. None did.
  - `secret_tap_counter_test.dart` — the seventh fires and the sixth does not; a gap restarts the count; the late tap *begins* the new run; the window is between consecutive taps, not across the run; firing resets so an eighth does not re-fire.
  - `secret_tap_trigger_test.dart` — the real app, signed in and signed out. The signed-out case also asserts the brand still has **no `InkWell` ancestor**, i.e. it gained no button affordance.
- **Browser, headless Chrome at a 390×844 phone viewport with touch emulation and no mouse** — `Input.dispatchTouchEvent` only, on the signed-out landing page: six taps show nothing, the seventh rolls the site, and instrumented Web Audio recorded **25 oscillators** — the same 25 the keyboard path produces, so touch reaches identical code. No exceptions. Screenshot confirms the corrected hint copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)