### PR TITLE
fix(gateway): a third eviction shot, and a gate so it can't be spent early

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,54 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  # Raising the service worker's manifest cache name spends a ONE-SHOT eviction:
+  # activate() takes its no-prior-manifest branch and calls
+  # caches.delete(CACHE_NAME) exactly once per client, unrepeatably. Spent while
+  # Cloudflare is serving stale bytes, it refills every client FROM the stale
+  # edge — turning a shipped fix into a wider outage. That has now been paid for
+  # twice (v2 with #426, v3 with #447), both times because the precondition
+  # lived in a PR description, and a description is a convention someone has to
+  # remember at the moment of merging.
+  #
+  # So a PR that raises the suffix has to show the production edge agrees with
+  # the origin. PRs that don't touch it exit in a second, without a network call.
+  #
+  # Known blind spot, stated rather than implied: Cloudflare caches per data
+  # center, so a green here proves the PoP this runner reached — not every PoP.
+  # It is a tripwire, not a proof. The runbook (dockerize/production/README.md)
+  # is still the authority: purge first, then merge.
+  sw-manifest-bump-guard:
+    name: SW manifest bump requires a clean edge
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Does this PR raise the manifest suffix?
+        id: suffix
+        run: |
+          git fetch --no-tags --depth=1 origin "${{ github.base_ref }}"
+          file=dockerize/deployment/Dockerfile
+          head=$(grep -oE 'flutter-app-manifest-v[0-9]+' "$file" | head -1)
+          base=$(git show "FETCH_HEAD:$file" | grep -oE 'flutter-app-manifest-v[0-9]+' | head -1)
+          echo "base=${base:-<none>}  head=${head:-<none>}"
+          if [ "$head" = "$base" ]; then
+            echo "unchanged — this PR does not spend the one-shot eviction"
+            echo "bumped=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "bumped=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: The edge must be clean before the shot is spent
+        if: steps.suffix.outputs.bumped == 'true'
+        run: |
+          echo "This PR raises the service-worker manifest suffix, which fires a"
+          echo "one-shot cache eviction on every client — once, and never again."
+          echo "Merged while the edge is stale, it refills every client FROM the"
+          echo "stale edge. Checking the production edge now:"
+          echo
+          ./scripts/verify-edge-parity.sh https://anemos.travel
+
   go:
     name: Go (fmt, vet, test, sqlc drift)
     runs-on: ubuntu-latest

--- a/dockerize/deployment/Dockerfile
+++ b/dockerize/deployment/Dockerfile
@@ -103,16 +103,29 @@ RUN sed -i 's/origin\.length + 1/origin.length + 5/g' build/web/flutter_service_
 #
 # A BUMP IS ONLY VALID ONCE THE EDGE IS VERIFIED CLEAN. It fires exactly once
 # per client and cannot be re-fired, so it spends its single shot refilling the
-# cache from whatever the CDN is serving at that moment. v2 shipped with #426
-# while Cloudflare still held the pre-#419 icon font under a one-year TTL —
-# correcting the header here did not evict it, because a stored object keeps
-# the freshness lifetime it was stored with. So v2 wiped every client's content
-# cache and refilled it from the stale edge: users who had been fine were healed
-# into breakage, and the one-shot lever was spent. v3 is the replacement shot,
-# fired after the purge. Before ever bumping again: purge the CDN, run
-# scripts/verify-edge-parity.sh until it passes, and only then raise the suffix.
-RUN sed -i "s/'flutter-app-manifest'/'flutter-app-manifest-v3'/" build/web/flutter_service_worker.js \
-    && grep -q "const MANIFEST = 'flutter-app-manifest-v3';" build/web/flutter_service_worker.js \
+# cache from whatever the CDN is serving at that moment. Correcting a cache
+# header does not evict anything already stored — a stored object keeps the
+# freshness lifetime it was stored with — so "we fixed the header" is never
+# evidence the edge is clean.
+#
+# This has now been paid for TWICE:
+#   v2 (#426, 2026-08-14) shipped while Cloudflare still held the pre-#419 icon
+#      font under a one-year TTL. It wiped every client's content cache and
+#      refilled it from the stale edge: users who had been fine were healed
+#      into breakage.
+#   v3 (#447, 2026-08-16) was written as the replacement shot, to be spent
+#      AFTER the purge — and merged before the purge happened, so it burned the
+#      same way. The PR carried the constraint as a note in its body, and a note
+#      is a convention someone has to remember at the moment of merging.
+#
+# v4 is the third shot. The precondition is no longer written down and hoped
+# for: the `sw-manifest-bump-guard` job in .github/workflows/ci.yml fails any PR
+# that raises this suffix while the production edge disagrees with the origin.
+# Before bumping to v5: purge the CDN, then let that job go green — do not
+# override it. (Note its one blind spot: Cloudflare caches per data center, so
+# the guard proves the PoP the runner reached, not every PoP.)
+RUN sed -i "s/'flutter-app-manifest'/'flutter-app-manifest-v4'/" build/web/flutter_service_worker.js \
+    && grep -q "const MANIFEST = 'flutter-app-manifest-v4';" build/web/flutter_service_worker.js \
     && ! grep -q "'flutter-app-manifest'" build/web/flutter_service_worker.js
 
 # Send every service-worker cache MISS to the network instead of to the


### PR DESCRIPTION
> **⛔ Merge only after the Cloudflare purge.** This time the pipeline says so too —
> `sw-manifest-bump-guard` runs the parity check against production because this PR
> raises the manifest suffix. Read a red guard as "not yet", not as "broken PR".

## Why

`v3` shipped before the purge, so it burned the same way `v2` did. It is live in
production now, and the edge is still stale:

```
edge   809c6fbc…   age 209154 (58 h)   cache-control: public, max-age=31536000, immutable
origin 2589b4d6…
```

`activate()` took its no-prior-manifest branch on every client, wiped the content
cache, and refilled it **from that stale edge**. Two shots spent, zero clients
repaired. `v4` is the third.

## What actually changes

Not the warning — **where the warning lives**.

#447 carried the precondition as a HOLD in its PR body. That is a convention
someone has to remember at the moment of merging, and it wasn't. `CLAUDE.md`'s
own Zen line covers this case exactly: semantics belong in enforced boundaries,
never in conventions someone must remember.

So the new `sw-manifest-bump-guard` job:

- compares `dockerize/deployment/Dockerfile`'s suffix against the base branch;
- **only when it moved**, runs `scripts/verify-edge-parity.sh` against production;
- exits in ~1 s with no network call on every PR that doesn't touch it.

A PR that spends the one-shot can no longer go green while the edge disagrees
with the origin.

## The blind spot, stated up front

**Cloudflare caches per data center.** The guard proves the PoP *its runner*
reached — not every PoP. That is not theoretical: the last two production deploys
passed the deploy-time parity check while this machine (`cf-ray: …-ORD`) was
still being handed the 58-hour-old font. Both the job comment and the Dockerfile
comment say so.

So the guard is a **tripwire, not a proof**, and
`dockerize/production/README.md` stays the authority: **purge everything →
verify → then merge.** Don't let a green guard talk you out of the purge.

## Summary

- `flutter-app-manifest-v3` → `v4` (`dockerize/deployment/Dockerfile`), with the
  comment now recording that the shot has been burned early **twice**, and why.
- New `sw-manifest-bump-guard` job in `.github/workflows/ci.yml`.

## Testing

- `docker build --target flutter-build -f dockerize/deployment/Dockerfile .`
  green; the built worker contains exactly `flutter-app-manifest-v4`. (Built
  locally because `build-push` never runs on PRs, so the `RUN` guard greps are
  otherwise unexercised until deploy.)
- Guard detection simulated on this branch: `base=v3 head=v4 → bumped=true`;
  unchanged suffix → `bumped=false`, no network call.
- `ci.yml` parses; the guard lands first in the checks list.
- No Dart/Go changes.

## After merge

The purge repairs the edge; `v4` repairs the clients `v2` and `v3` poisoned. If
icons are still blank for a specific browser afterwards, that one client needs
DevTools → Application → Storage → **Clear site data** once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)