### PR TITLE
fix(trip): reveal what a refine adds, even into a folded city

### DIFF
--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -556,6 +556,27 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
   bool _refreshQueued = false;
   Future<void>? _refreshFuture;
 
+  /// Item ids as they stood before something the traveler ASKED FOR started
+  /// writing — armed by [_armRevealOfNewItems], consumed by [_refresh] once
+  /// its coalescing loop has settled. Null on every other refresh (the
+  /// background status poll, the chat-delete cleanup), which is what keeps a
+  /// collaborator's edit from unfolding a list you deliberately folded.
+  Set<String>? _revealBaseline;
+
+  /// Arms the next [_refresh] to reveal whatever it brings in.
+  ///
+  /// Idempotent across a streaming turn: the FIRST snapshot wins. A second
+  /// `trip_updated` landing mid-fetch must not redefine "new" as "added after
+  /// the batch I already missed" — one turn is one baseline.
+  void _armRevealOfNewItems() {
+    if (_revealBaseline != null) return;
+    final trip = _trip;
+    if (trip == null) return;
+    _revealBaseline = {
+      for (final i in trip.items ?? const <ItineraryItem>[]) i.id
+    };
+  }
+
   /// Silent in-place reload with trailing coalescing. The server can emit
   /// several `trip_updated` events in one streaming turn; a bump that lands
   /// mid-fetch queues exactly one more pass so the final state always
@@ -585,6 +606,11 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
         _invalidateReview();
         await _load(silent: true);
       } while (mounted && _refreshQueued);
+      // AFTER the loop, not inside it: a turn that writes three times in a
+      // row should reveal once, against the state the turn started from.
+      final baseline = _revealBaseline;
+      _revealBaseline = null;
+      if (mounted && baseline != null) _revealNewItems(baseline);
       _refreshFuture = null;
     }();
     _refreshFuture = future;
@@ -1898,30 +1924,52 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
     if (added == true) {
       await _load();
       if (!mounted) return; // _load awaited: the screen may be gone
-      _expandRunsOfNewItems(beforeIds);
+      // Open whatever it landed in, then point the map at it. The map write
+      // is THIS path's alone: adding one place is a request to look at it.
+      final legKey = _revealNewItems(beforeIds);
+      final t = _trip;
+      if (legKey != null && t != null) _setMapFocus(_derive(t), legKey);
     }
   }
 
-  /// Focus the map on the run holding the first item that wasn't in the
-  /// trip before the add, so the new pin is immediately visible. Groups
-  /// default expanded now, so the un-collapse only matters when the user
-  /// manually collapsed the target group — a place added into a collapsed
-  /// run would otherwise land with zero visible feedback.
-  void _expandRunsOfNewItems(Set<String> beforeIds) {
+  /// Un-collapse every destination group — and every day inside it — that
+  /// gained an item, so something the traveler just asked for can never land
+  /// inside a folded section. Returns the leg key of the FIRST new item in
+  /// build order (null when nothing was added) for callers that also want the
+  /// map to move; the reveal itself NEVER writes focus, so the chat path can
+  /// use it without dragging the camera around mid-conversation.
+  ///
+  /// Two things make this load-bearing rather than defensive. Folding is one
+  /// tap now, so "the traveler folded this city" went from a deliberate act
+  /// to the ordinary posture of anyone surveying a long trip. And the chat
+  /// adds in BATCHES across several cities — the old version stopped at the
+  /// first new item, which was right when [_addPlace] (exactly one place) was
+  /// the only caller and silently wrong for "added 4 places in Rome and
+  /// Paris". Days count as much as cities: un-collapsing Rome reveals nothing
+  /// if the item landed on a day that is itself folded.
+  String? _revealNewItems(Set<String> beforeIds) {
     final trip = _trip;
-    if (trip == null) return;
+    if (trip == null) return null;
     final d = _derive(trip);
+    String? firstLegKey;
+    var changed = false;
     for (final i in trip.items ?? const <ItineraryItem>[]) {
       if (beforeIds.contains(i.id)) continue;
       final legKey = d.legKeyOfPosition(i.position);
-      if (legKey == null) return;
-      _setMapFocus(d, legKey);
+      // `continue`, not `return`: one unresolvable item must not abandon the
+      // rest of the batch.
+      if (legKey == null) continue;
+      firstLegKey ??= legKey;
       final groupKey = d.groupKeyForLeg(legKey);
-      if (groupKey != null && _collapsedGroups.remove(groupKey)) {
-        setState(() {});
+      if (groupKey == null) continue;
+      if (_collapsedGroups.remove(groupKey)) changed = true;
+      final day = i.day;
+      if (day != null && _collapsedDays.remove('$groupKey#$day')) {
+        changed = true;
       }
-      return;
     }
+    if (changed) setState(() {});
+    return firstLegKey;
   }
 
   Future<void> _patch(
@@ -4295,8 +4343,12 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
         await showAddToTripSheet(context, payload, currentTripId: widget.tripId);
     // _refresh(), not a bare silent _load(): it serializes with any reload the
     // refine panel has in flight, so a pre-add snapshot can't land after us
-    // and momentarily erase the just-added item.
-    if (added != null && added.id == widget.tripId) _refresh();
+    // and momentarily erase the just-added item. Armed like the chat path —
+    // an add the traveler just made must be visible, folded city or not.
+    if (added != null && added.id == widget.tripId) {
+      _armRevealOfNewItems();
+      _refresh();
+    }
   }
 
   Widget _itemTile(ItineraryItem item, double indentLeft, ThemeData theme,
@@ -5963,7 +6015,14 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
     ref.listen(
         tripRefineProvider(widget.tripId).select((s) => s.tripUpdateCount),
         (prev, next) {
-      if (mounted && next > (prev ?? 0)) _refresh();
+      if (mounted && next > (prev ?? 0)) {
+        // Snapshot BEFORE the refetch — _trip is still the pre-turn state
+        // here — so the reveal can tell what this turn added. Without it a
+        // chat that reports "added 4 places" leaves them inside folded
+        // cities and the list appears not to have moved.
+        _armRevealOfNewItems();
+        _refresh();
+      }
     });
     // A turn still running behind a closed panel: the FAB says so, or an
     // accidental back reads as "did that kill it?".

--- a/src/packages/flutter-app/test/trip_detail_reveal_new_items_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_reveal_new_items_test.dart
@@ -1,0 +1,289 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:travel_route_planner/models/itinerary_item.dart';
+import 'package:travel_route_planner/models/trip.dart';
+import 'package:travel_route_planner/providers/plan_provider.dart';
+import 'package:travel_route_planner/providers/trips_provider.dart';
+import 'package:travel_route_planner/services/api_client.dart';
+import 'package:travel_route_planner/services/plan_service.dart';
+import 'package:travel_route_planner/services/trips_api_service.dart';
+import 'package:travel_route_planner/screens/trip_detail_screen.dart';
+import 'package:travel_route_planner/widgets/trip_map.dart';
+
+import 'support/l10n_test_app.dart';
+
+// Content the traveler ASKED FOR is revealed; content that merely arrived is
+// not.
+//
+// Folding a destination used to be a deliberate act, so a refine dropping
+// places into a folded city was a corner. Fold-all made it one tap — the
+// ordinary posture of anyone surveying a long trip — and a chat that reports
+// "added 4 places" while the list does not move is the `_addPlace` no-op bug
+// at conversation scale.
+//
+// The line drawn here: `_refresh` reveals only when a caller ARMED it
+// (the refine turn, add-to-trip, add-place). Pull-to-refresh and the
+// background status poll do not arm, so a collaborator's edit can never
+// unfold a list you deliberately folded.
+
+class _StagedTripsApiService extends TripsApiService {
+  Trip current;
+  int calls = 0;
+  _StagedTripsApiService(this.current)
+      : super(ApiClient(baseUrl: 'http://test'));
+
+  @override
+  Future<Trip> getTrip(String id) async {
+    calls++;
+    return current;
+  }
+}
+
+/// Emits a scripted event list for one turn, like the chat-panel suites.
+class _ScriptedPlanService extends PlanService {
+  final List<PlanEvent> events;
+  _ScriptedPlanService(this.events) : super('http://unused');
+
+  @override
+  Stream<PlanEvent> streamPlan(
+    List<Map<String, dynamic>> messages, {
+    String? bearerToken,
+    String? chatId,
+    String? tripId,
+    String? summary,
+    Future<void>? abortTrigger,
+  }) async* {
+    for (final e in events) {
+      yield e;
+    }
+  }
+}
+
+ItineraryItem _item(int pos, String name, String city, int day,
+        {double lat = 0, double lng = 0}) =>
+    ItineraryItem(
+      id: 'i$pos',
+      position: pos,
+      name: name,
+      address: '$city, Europe',
+      latitude: lat,
+      longitude: lng,
+      category: 'attraction',
+      day: day,
+      city: city,
+    );
+
+/// Per-city coordinates. Zero for the list-only tests (the screen then skips
+/// the map widget entirely); real and DISTINCT for the map test — one shared
+/// point is a zero-area bounds and flutter_map asserts on the fit.
+const _geo = {
+  'Paris': (48.86, 2.33),
+  'Rome': (41.89, 12.49),
+};
+
+ItineraryItem _geoItem(int pos, String name, String city, int day) {
+  final c = _geo[city]!;
+  return _item(pos, name, city, day, lat: c.$1, lng: c.$2);
+}
+
+/// The base four — Paris (days 1-2) → Rome (days 3-4) — plus whatever [extra]
+/// the turn "added", each city's additions kept inside its own run.
+List<ItineraryItem> _items(List<ItineraryItem> extra, {bool geo = false}) {
+  final make = geo ? _geoItem : _item;
+  return [
+    make(0, 'Louvre', 'Paris', 1),
+    make(1, 'Orsay', 'Paris', 2),
+    ...extra.where((e) => e.city == 'Paris'),
+    make(2, 'Forum', 'Rome', 3),
+    make(3, 'Pantheon', 'Rome', 4),
+    ...extra.where((e) => e.city == 'Rome'),
+  ];
+}
+
+Trip _trip({List<ItineraryItem>? items, bool geo = false}) => Trip(
+      id: 't1',
+      title: 'Europe',
+      startDate: '2026-06-01',
+      endDate: '2026-06-04',
+      createdAt: '2026-05-01',
+      updatedAt: '2026-05-01',
+      items: items ?? _items(const [], geo: geo),
+    );
+
+class _Harness {
+  final _StagedTripsApiService trips;
+  final PlanNotifier notifier;
+  _Harness(this.trips, this.notifier);
+}
+
+Future<_Harness> _pump(
+  WidgetTester tester, {
+  required Trip initial,
+  List<PlanEvent> turn = const [PlanEvent(type: 'trip_updated', data: {})],
+}) async {
+  tester.view.physicalSize = const Size(1200, 2200);
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.reset);
+
+  final trips = _StagedTripsApiService(initial);
+  final notifier =
+      PlanNotifier(_ScriptedPlanService(turn), ApiClient(), tripId: 't1');
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        tripsApiServiceProvider.overrideWithValue(trips),
+        tripRefineProvider.overrideWith((ref, tripId) => notifier),
+      ],
+      child: MaterialApp(
+        localizationsDelegates: testLocalizationsDelegates,
+        home: const TripDetailScreen(tripId: 't1'),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+  return _Harness(trips, notifier);
+}
+
+/// Runs one refine turn: the scripted service emits `trip_updated`, which
+/// bumps tripUpdateCount and fires the screen's listener.
+Future<void> _refineTurn(WidgetTester tester, _Harness h) async {
+  await h.notifier.sendMessage('add a few things');
+  await tester.pumpAndSettle();
+}
+
+Future<void> _foldAll(WidgetTester tester) async {
+  await tester.tap(find.byTooltip('Collapse all'));
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  testWidgets('a refine reveals the folded city it added to — and only that one',
+      (tester) async {
+    final h = await _pump(tester, initial: _trip());
+    await _foldAll(tester);
+    expect(find.text('Louvre'), findsNothing);
+    expect(find.text('Forum'), findsNothing);
+
+    h.trips.current =
+        _trip(items: _items([_item(9, 'Trevi', 'Rome', 4)]));
+    await _refineTurn(tester, h);
+
+    // The city the turn wrote to is open, with the new place on screen.
+    expect(find.text('Trevi'), findsOneWidget,
+        reason: 'a place the traveler just asked for must be visible');
+    expect(find.text('Pantheon'), findsOneWidget);
+    // Paris gained nothing, so it stays exactly as the traveler left it.
+    expect(find.text('Louvre'), findsNothing,
+        reason: 'revealing must not unfold cities the turn never touched');
+  });
+
+  testWidgets('a refine that writes to two folded cities opens both',
+      (tester) async {
+    // The old reveal stopped at the FIRST new item — correct when _addPlace
+    // (exactly one place) was the only caller, silently wrong for a chat that
+    // adds across cities. Two additions, two cities: the first-only version
+    // leaves the second folded.
+    final h = await _pump(tester, initial: _trip());
+    await _foldAll(tester);
+
+    h.trips.current = _trip(
+        items: _items([
+      _item(8, 'Eiffel', 'Paris', 2),
+      _item(9, 'Trevi', 'Rome', 4),
+    ]));
+    await _refineTurn(tester, h);
+
+    expect(find.text('Eiffel'), findsOneWidget);
+    expect(find.text('Trevi'), findsOneWidget,
+        reason: 'the batch must be revealed whole, not just its first item');
+  });
+
+  testWidgets('a refine reveals a folded DAY, not just its city',
+      (tester) async {
+    // Un-collapsing Rome reveals nothing if the item landed on a day that is
+    // itself folded — the same invisibility one level down.
+    final h = await _pump(tester, initial: _trip());
+    await tester.tap(find.text('Thu, Jun 4')); // fold Rome's day 4 by hand
+    await tester.pumpAndSettle();
+    expect(find.text('Pantheon'), findsNothing);
+
+    h.trips.current = _trip(items: _items([_item(9, 'Trevi', 'Rome', 4)]));
+    await _refineTurn(tester, h);
+
+    expect(find.text('Trevi'), findsOneWidget,
+        reason: 'the day the item landed on must open too');
+  });
+
+  testWidgets('pull-to-refresh does NOT unfold, even when it brings new items',
+      (tester) async {
+    // Only content the traveler asked for reveals itself. A collaborator's
+    // edit arriving on a routine refresh must leave the fold state alone.
+    final h = await _pump(tester, initial: _trip());
+    await _foldAll(tester);
+    // Back to the default viewport before the fling: a folded four-row list
+    // on a 2200px-tall surface leaves the RefreshIndicator nothing to arm
+    // against, and the gesture no-ops (the premise assert below catches it).
+    tester.view.resetPhysicalSize();
+    tester.view.resetDevicePixelRatio();
+    await tester.pumpAndSettle();
+    final before = h.trips.calls;
+
+    h.trips.current = _trip(items: _items([_item(9, 'Trevi', 'Rome', 4)]));
+    await tester.fling(
+        find.byType(CustomScrollView), const Offset(0, 400), 1000);
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1));
+    await tester.pumpAndSettle();
+
+    expect(h.trips.calls, greaterThan(before),
+        reason: 'premise: the refresh must actually have refetched');
+    expect(find.text('Trevi'), findsNothing,
+        reason: 'an unasked-for arrival must not unfold the list');
+    expect(find.text('Forum'), findsNothing);
+  });
+
+  testWidgets('the refine reveal never moves the map', (tester) async {
+    // Focusing a leg is _addPlace's alone ("show me the pin I just added").
+    // A chat turn writing across cities has no single leg to mean, and
+    // dragging the camera mid-conversation is exactly the coupling #358
+    // removed.
+    final h = await _pump(tester, initial: _trip(geo: true));
+    await _foldAll(tester);
+    expect(tester.widget<TripMap>(find.byType(TripMap)).fitSignature, isNull,
+        reason: 'premise: nothing has focused a leg yet');
+
+    h.trips.current = _trip(
+        items: _items([_geoItem(9, 'Trevi', 'Rome', 4)], geo: true));
+    await _refineTurn(tester, h);
+
+    expect(find.text('Trevi'), findsOneWidget, reason: 'premise: it revealed');
+    expect(tester.widget<TripMap>(find.byType(TripMap)).fitSignature, isNull,
+        reason: 'the reveal is list-only — no focus write, no camera move');
+  });
+
+  testWidgets('one turn writing three times reveals against the turn start',
+      (tester) async {
+    // _refresh coalesces several trip_updated events into one trailing pass.
+    // The baseline must be the state the TURN began from, not whatever the
+    // last event happened to see — otherwise the earlier writes read as
+    // "already there" and stay folded.
+    final h = await _pump(tester, initial: _trip(), turn: const [
+      PlanEvent(type: 'trip_updated', data: {}),
+      PlanEvent(type: 'trip_updated', data: {}),
+      PlanEvent(type: 'trip_updated', data: {}),
+    ]);
+    await _foldAll(tester);
+
+    h.trips.current = _trip(
+        items: _items([
+      _item(8, 'Eiffel', 'Paris', 2),
+      _item(9, 'Trevi', 'Rome', 4),
+    ]));
+    await _refineTurn(tester, h);
+
+    expect(find.text('Eiffel'), findsOneWidget);
+    expect(find.text('Trevi'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Why this is a separate PR

This is the second half of #448. It was pushed to that branch **17 minutes after the PR was merged** — #448 merged at `03:03:01Z` with `headRefOid=40899c0`, and this commit was written at `03:20:06Z` — so GitHub accepted the push to a closed PR and the commit never reached `main`. Same content, cherry-picked cleanly onto current `main`. No behaviour change from what was reviewed.

## Summary

The fold control (#448) made "this city is folded" the ordinary posture of anyone surveying a long trip, and nothing on the refresh path opened anything. So a chat turn could report *"added 4 places"* while the list did not visibly move — the `_addPlace` no-op bug (#304) at conversation scale. Reachable before by folding a city by hand; one tap away after #448.

- `_expandRunsOfNewItems` was written when `_addPlace` — exactly one place — was its only caller, so it **stopped at the first new item** and only ever touched `_collapsedGroups`. Both are wrong for a chat writing a batch across cities, and for an item landing on a day the traveler folded: un-collapsing Rome reveals nothing if day 4 is itself shut.
- It becomes `_revealNewItems`: opens every group **and every day** that gained an item, and **returns** the first new leg key rather than writing focus itself. The map write stays `_addPlace`'s alone — adding one place is a request to look at it; a turn writing across three cities has no single leg to mean, and moving the camera mid-conversation is the coupling #358 removed.
- **Revealing is opt-in per caller, not a property of refreshing.** `_armRevealOfNewItems` snapshots item ids; `_refresh` consumes the snapshot once its coalescing loop settles. The refine listener and `_addToTrip` arm it; **pull-to-refresh and the background status poll do not**, so a collaborator's edit can never unfold a list you deliberately folded. Arming is idempotent within a turn (first snapshot wins), or three `trip_updated` events would redefine "new" as "added after the batch I already missed".
- `_addToTrip` (the "Add to trip" flow from a rec/event card) had the identical gap and is armed too — found by tracing every `_refresh` caller.

## Testing

- `flutter analyze` clean (3 pre-existing infos in `models/route_response.dart`); `flutter test` **1498 passing** against current `main`.
- New `trip_detail_reveal_new_items_test.dart` (6 cases) drives real `trip_updated` turns through a scripted `PlanService` + `tripRefineProvider` override — the actual listener, not a stub.
- **Mutation-checked**, four mutations each failing their own test: un-arming the refine path, stopping at the first new item, ignoring days, and arming on *every* refresh (which would let a collaborator's edit unfold your list).
- `_addPlace`'s map-focus behaviour is unchanged and still pinned by the existing assertion in `trip_detail_leg_focus_test.dart`.

Two fixture traps worth knowing, both caught by premise asserts rather than silently passing: a folded four-row list on a 2200px surface can't arm the RefreshIndicator (the fling no-ops), and every item sharing one coordinate is a zero-area bounds that trips a `flutter_map` assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)