### PR TITLE
fix(easter-egg): make the tap gesture reachable and the audio audible

### DIFF
--- a/specs/konami-rickroll/spec.md
+++ b/specs/konami-rickroll/spec.md
@@ -43,6 +43,10 @@ asset needs a provenance row it could not honestly be given.
 - [ ] Seven taps in quick succession on the brand in the app bar do the same,
       with no keyboard — on every screen the app bar appears, including the
       ones where the brand is not a button at all.
+- [ ] "Quick succession" means a pace a person can actually produce by hand:
+      tapping about once a second, or pausing between taps, still gets there.
+      A tap every three seconds does not.
+- [ ] The hook is audible on a phone, not only on a desktop browser.
 - [ ] Those taps change nothing else: a single tap still goes home where it did
       before, the brand gains no ripple, tooltip or button role where it had
       none, and taps spread out over ordinary navigation never accumulate.
@@ -84,8 +88,14 @@ None. Nothing is persisted; the rolled state lasts as long as it is on screen.
 
 ## Edge Cases & Error States
 
-- **The browser refuses audio.** Safari can withhold playback even after a
-  keystroke. The visual is never gated on sound.
+- **The browser refuses audio.** The visual is never gated on sound. Note the
+  rule is stricter than "the user has interacted at some point": Safari wants
+  audio opened *inside* a gesture handler, and the egg starts its tune a frame
+  later than the gesture that triggered it. Audio is therefore made ready at
+  the user's first interaction with the page, not when the egg fires — the
+  first version did the latter and was silent on phones.
+- **The phone is on silent.** Web audio obeys the hardware switch on iOS and
+  nothing in a web page can override it. Not a bug we can fix.
 - **The code is entered while already rolling.** Ignored — restarting would
   re-attack the tune from the top.
 - **The code is entered with a text field focused.** It fires, and the field

--- a/src/packages/flutter-app/lib/utils/rick_roll_audio_stub.dart
+++ b/src/packages/flutter-app/lib/utils/rick_roll_audio_stub.dart
@@ -12,3 +12,6 @@ import 'rick_roll_tune.dart';
 /// See rick_roll_audio_web.dart for the real implementation and
 /// rick_roll_tune.dart for the contract.
 RickRollPlayback playRickRollHook() => const SilentRickRollPlayback();
+
+/// Nothing to unlock without a browser audio policy to unlock it against.
+void primeRickRollAudio() {}

--- a/src/packages/flutter-app/lib/utils/rick_roll_audio_web.dart
+++ b/src/packages/flutter-app/lib/utils/rick_roll_audio_web.dart
@@ -6,9 +6,10 @@ import 'package:web/web.dart' as web;
 import 'rick_roll_tune.dart';
 
 /// Peak amplitude of the whole tune. Square waves carry far more energy than
-/// their amplitude suggests, so this sits low deliberately: an easter egg that
-/// blows somebody's headphones off is a bug report, not a joke.
-const double _masterGain = 0.12;
+/// their amplitude suggests, so this stays low — an easter egg that blows
+/// somebody's headphones off is a bug report, not a joke — but not so low that
+/// a phone speaker cannot produce it.
+const double _masterGain = 0.18;
 
 /// Seconds of lead-in before the first note. The scheduler needs a moment of
 /// headroom or the browser drops the attack of note one.
@@ -21,31 +22,70 @@ const double _leadIn = 0.06;
 const double _attack = 0.01;
 const double _release = 0.05;
 
-/// Plays [kRickRollHook] through one [web.AudioContext] of scheduled square
-/// waves.
+/// The one audio context for the page's lifetime.
+///
+/// Shared rather than per-play because it can only be opened at a moment the
+/// browser allows, and that moment is the user's first interaction — long
+/// before anybody enters the code. See [primeRickRollAudio].
+web.AudioContext? _shared;
+bool _primed = false;
+
+/// Opens the audio context on the first real interaction with the page.
+///
+/// The listeners sit on `document` in the **capture** phase so they see the
+/// event before Flutter's own handling, and they are never removed: a context
+/// can be suspended again by the browser (a backgrounded tab, an iOS call),
+/// and re-resuming on the next interaction is exactly the recovery wanted.
+///
+/// Creating the context here rather than at import time is deliberate. A
+/// context constructed with no user activation is born `suspended`, and on
+/// Safari `resume()` outside a gesture handler will not revive it — so an
+/// eagerly-built one would be permanently silent, which is the failure this
+/// function exists to prevent.
+void primeRickRollAudio() {
+  if (_primed) return;
+  _primed = true;
+  try {
+    final unlock = ((web.Event _) => _openContext()).toJS;
+    final options = web.AddEventListenerOptions(capture: true, passive: true);
+    for (final type in const ['pointerdown', 'keydown', 'touchend']) {
+      web.document.addEventListener(type, unlock, options);
+    }
+  } catch (_) {
+    // No document, or an engine that dislikes the options bag. The egg still
+    // runs; it may just be silent.
+  }
+}
+
+/// The context if we have a usable one, opening or resuming it if we can.
+/// Returns null rather than throwing — silence is an ordinary outcome.
+web.AudioContext? _openContext() {
+  try {
+    final ctx = _shared ??= web.AudioContext();
+    if (ctx.state != 'running') {
+      ctx.resume().toDart.catchError((Object _) => null);
+    }
+    return ctx;
+  } catch (_) {
+    return null;
+  }
+}
+
+/// Plays [kRickRollHook] as scheduled square waves.
 ///
 /// Every note is scheduled up front against the context clock rather than
 /// driven by a Dart timer: timers drift, and a melody that drifts is a melody
 /// nobody recognizes.
 ///
-/// Returns [SilentRickRollPlayback] rather than throwing if the browser will
-/// not give us a context. A keystroke grants user activation in Chrome and
-/// Firefox, but Safari can still hand back a context that never starts, so the
-/// caller must treat "no sound" as an ordinary outcome.
+/// Returns [SilentRickRollPlayback] rather than throwing if there is no usable
+/// context. The caller treats that exactly like success, because the visual
+/// must never depend on audio.
 RickRollPlayback playRickRollHook() {
-  final web.AudioContext ctx;
-  try {
-    ctx = web.AudioContext();
-  } catch (_) {
-    return const SilentRickRollPlayback();
-  }
+  final ctx = _openContext();
+  if (ctx == null) return const SilentRickRollPlayback();
 
+  final oscillators = <web.OscillatorNode>[];
   try {
-    // Best-effort: a context created before the browser considers the page
-    // "activated" starts suspended. Failure here is not fatal — the notes are
-    // still scheduled, they just may never sound.
-    ctx.resume().toDart.catchError((Object _) => null);
-
     final master = ctx.createGain();
     master.gain.setValueAtTime(_masterGain, ctx.currentTime);
     master.connect(ctx.destination);
@@ -74,36 +114,47 @@ RickRollPlayback playRickRollHook() {
         env.connect(master);
         osc.start(at);
         osc.stop(end + 0.01);
+        oscillators.add(osc);
       }
       at += seconds;
     }
-    return _AudioContextPlayback(ctx);
+    return _ScheduledPlayback(oscillators, master);
   } catch (_) {
-    // Half-scheduled is worse than silent: tear the context down so no
-    // fragment of the tune is left playing.
-    final playback = _AudioContextPlayback(ctx)..stop();
+    // Half-scheduled is worse than silent: silence what was scheduled.
+    final playback = _ScheduledPlayback(oscillators, null)..stop();
     return playback;
   }
 }
 
-class _AudioContextPlayback implements RickRollPlayback {
-  _AudioContextPlayback(this._ctx);
+class _ScheduledPlayback implements RickRollPlayback {
+  _ScheduledPlayback(this._oscillators, this._master);
 
-  final web.AudioContext _ctx;
+  final List<web.OscillatorNode> _oscillators;
+  final web.GainNode? _master;
   bool _stopped = false;
 
-  /// Closing the context kills every scheduled note at once, which is why
-  /// nothing here tracks the individual oscillators. Guarded and wrapped
-  /// because closing twice — dismissing by hand at the exact moment the tune
-  /// ends on its own — throws `InvalidStateError`.
+  /// Stops the notes and cuts the branch off the graph.
+  ///
+  /// It deliberately does NOT close the context — that context is shared and
+  /// unlocked, and closing it would spend the one unlock the page is going to
+  /// get. (The previous version could close it, because it built a throwaway
+  /// context per play; that is exactly the design that was silent on Safari.)
+  /// Disconnecting the master gain is what makes the cut instant, since
+  /// `stop()` on an already-finished node is a no-op and on a not-yet-started
+  /// one throws.
   @override
   void stop() {
     if (_stopped) return;
     _stopped = true;
     try {
-      _ctx.close().toDart.catchError((Object _) => null);
-    } catch (_) {
-      // Already closed, or the context was never usable.
+      _master?.disconnect();
+    } catch (_) {}
+    for (final osc in _oscillators) {
+      try {
+        osc.stop();
+      } catch (_) {
+        // Already finished, or never started. Either way it is not sounding.
+      }
     }
   }
 }

--- a/src/packages/flutter-app/lib/utils/rick_roll_tune.dart
+++ b/src/packages/flutter-app/lib/utils/rick_roll_tune.dart
@@ -105,6 +105,23 @@ abstract interface class RickRollPlayback {
   void stop();
 }
 
+/// The two functions the conditional import must supply, documented here
+/// because this file is the contract both implementations answer to:
+///
+/// * `void primeRickRollAudio()` — called once at app start. A browser will
+///   not let a page make noise until the user has interacted with it, and the
+///   check is stricter than "has the user ever done anything": **Safari
+///   requires the audio context to be resumed inside the gesture handler
+///   itself**. By the time the egg fires, the tune is started from a widget's
+///   `initState`, a frame or more after the tap or keystroke that caused it —
+///   outside any handler. Chrome's page-level sticky activation forgives that;
+///   Safari does not, which is why the sound worked on desktop and not on a
+///   phone. The unlock therefore cannot wait for the egg: it hooks the FIRST
+///   real interaction with the page, where the browser is still willing.
+///
+/// * `RickRollPlayback playRickRollHook()` — schedules [kRickRollHook] and
+///   returns a handle. Must never throw: "no sound" is an ordinary outcome.
+
 /// The "no sound happened" answer — returned by the non-web stub and by the
 /// web implementation when the browser refuses to give us an audio context.
 /// The overlay treats it exactly like a successful one: the visual never

--- a/src/packages/flutter-app/lib/utils/secret_tap_counter.dart
+++ b/src/packages/flutter-app/lib/utils/secret_tap_counter.dart
@@ -10,7 +10,21 @@ const int kSecretTapCount = 7;
 /// achievable for someone who is not especially quick without ever
 /// accumulating across the minutes of ordinary navigation taps a session
 /// contains.
-const Duration kSecretTapWindow = Duration(milliseconds: 700);
+///
+/// **This was 700 ms and that was too strict to use.** It shipped verified
+/// only by automation that tapped every 145 ms — five times faster than the
+/// limit — so the boundary was never near. A person tapping at a natural
+/// once-a-second pace, and especially one pausing to see whether anything is
+/// happening, overruns it and silently restarts at one every time. The gesture
+/// gives no feedback, so an overrun is indistinguishable from a feature that
+/// does not exist, which is exactly how it was reported.
+///
+/// Two seconds is still far too short to accumulate by accident: it needs
+/// SEVEN consecutive taps inside it, and ordinary navigation taps on the brand
+/// are seconds or minutes apart. When changing this, test at the boundary —
+/// the useful measurement is the slowest cadence that still fires, not the
+/// fastest.
+const Duration kSecretTapWindow = Duration(seconds: 2);
 
 /// Counts taps arriving in rapid succession — the touch counterpart to
 /// [KonamiDetector], and pure for the same reason: the interesting cases are

--- a/src/packages/flutter-app/lib/widgets/konami_listener.dart
+++ b/src/packages/flutter-app/lib/widgets/konami_listener.dart
@@ -4,6 +4,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../providers/easter_egg_provider.dart';
 import '../utils/konami_detector.dart';
+import '../utils/rick_roll_audio_stub.dart'
+    if (dart.library.js_interop) '../utils/rick_roll_audio_web.dart';
 import 'rick_roll_overlay.dart';
 
 /// Listens for the Konami code everywhere in the app, and hosts the overlay it
@@ -45,6 +47,12 @@ class _KonamiListenerState extends ConsumerState<KonamiListener> {
   void initState() {
     super.initState();
     HardwareKeyboard.instance.addHandler(_onKey);
+    // Mounted from MaterialApp.builder, so this runs once at app start — the
+    // earliest point that still precedes any interaction, which is the whole
+    // requirement. See primeRickRollAudio: the browser will only open an audio
+    // context inside a real gesture, and by the time the egg fires we are a
+    // frame past one.
+    primeRickRollAudio();
   }
 
   @override

--- a/src/packages/flutter-app/test/secret_tap_counter_test.dart
+++ b/src/packages/flutter-app/test/secret_tap_counter_test.dart
@@ -26,6 +26,29 @@ void main() {
   int afterPause(int lastTapAt) =>
       lastTapAt + kSecretTapWindow.inMilliseconds + 1;
 
+  test('a human cadence fires — stated in milliseconds, not in the constant',
+      () {
+    // Every other test in this file is expressed in terms of
+    // kSecretTapWindow, so all of them stay green no matter how small it gets.
+    // That is exactly how a 700 ms window shipped and turned out to be
+    // unusable by hand: it was verified only by automation tapping every
+    // 145 ms, and a person tapping about once a second could never trigger it.
+    // This test states the human requirement in absolute time, so shrinking
+    // the window has to fail something.
+    for (final cadence in [500, 1000, 1500, 1800]) {
+      expect(
+        firesAt([for (var i = 0; i < kSecretTapCount; i++) i * cadence]),
+        isNotEmpty,
+        reason: 'a tap every ${cadence}ms must reach the egg',
+      );
+    }
+    // Still not something ordinary navigation can stumble into.
+    expect(
+      firesAt([for (var i = 0; i < kSecretTapCount; i++) i * 3000]),
+      isEmpty,
+    );
+  });
+
   test('the seventh rapid tap fires, and not the sixth', () {
     expect(firesAt(burst(kSecretTapCount)), [(kSecretTapCount - 1) * 100]);
     expect(firesAt(burst(kSecretTapCount - 1)), isEmpty);


### PR DESCRIPTION
## Summary

Two bugs in what I shipped in #451, both reported by Brian, and both of which my verification was shaped to miss rather than to catch.

**1. The tap window was unusable by hand.** 700ms between consecutive taps, verified only by automation tapping every **145ms** — five times faster than the limit, so the boundary was never near the measurement. A person tapping at a natural once-a-second pace, or pausing to see whether anything is happening, overruns it and silently restarts at one. The gesture gives no feedback, so an overrun is indistinguishable from a feature that doesn't exist — which is exactly how it got reported. Now **2 seconds**.

**2. Audio was silent on phones.** The context was opened when the egg fired — a frame or more after the gesture that caused it, so outside any handler. Chrome's page-level sticky activation forgives that; **Safari requires the context to be resumed inside the gesture handler itself**, and a context created without activation is born `suspended` and stays silent. That's why it worked on desktop and not on a phone. The unlock now happens on the **first interaction with the page** (any tap, any key, via capture-phase `document` listeners installed at app start), so by the time anyone enters the code the context has been running for a long time.

Consequences worth noting:

- The context is now **shared and long-lived**, so `stop()` disconnects the gain branch and stops the oscillators rather than closing the context — closing it would spend the one unlock the page gets. (The old per-play throwaway context is precisely the design that was silent on Safari.)
- Master gain 0.12 → 0.18, since a phone speaker has to produce it.
- Not fixable from a web page, and now written into the spec: **iOS mutes web audio when the hardware silent switch is on.**

## Testing

- `flutter analyze` clean; `flutter test` — **1493 passed, 0 failed**.
- The new regression test states the cadence in **milliseconds**. Every existing test in that file was written relative to `kSecretTapWindow`, so all of them stayed green at 700ms and would stay green at 100ms — only an absolute assertion can fail when the window stops being usable by a human.
- **Browser, headless Chrome under the REAL autoplay policy** (no `--autoplay-policy` override — my earlier runs passed that flag, which disabled the very policy that would have caught bug 2) and with **trusted** CDP input events rather than synthetic `KeyboardEvent`s (which grant no user activation):
  - `AudioContext` state: **`created:suspended` before → `created:running` now**, opened on the first interaction, zero contexts created before any interaction.
  - Cadence sweep, measuring the real inter-`pointerdown` gaps in the page rather than trusting the harness's sleep:

    | real gap | mouse | touch |
    |---|---|---|
    | 832ms | fires | — |
    | 1231ms | fires | — |
    | 1531ms | fires | fires |
    | 1829ms | fires | — |
    | 2630ms | correctly does not fire | — |

  So a relaxed, pausing tapper gets there, and seven consecutive taps inside 2s remains something ordinary navigation cannot produce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)