### PR TITLE
fix(review): a ticked booking row is booked, and the badge counts only gaps

### DIFF
--- a/docs/friction-log.md
+++ b/docs/friction-log.md
@@ -5,6 +5,62 @@ build queue. Priority when picking work: **breakage > friction in features
 actually used > ideas that recur across ≥2 sessions**. Tag entries `[app]`
 (dogfooding the product) or `[dev]` (workflow/tooling). Newest first.
 
+## 2026-08-17 — Trip Health argued with the checklist
+
+- **[app] Friction → fixed:** *"It says I don't have lodging booked for days
+  that I do."* Trip Health read **"Mostly ready — 28 to fix"** and led with
+  *"No lodging booked for the nights of Mon, Aug 24 – Fri, Aug 28 (5
+  nights)"* — while two scrolls up, `Stay in Amsterdam · Aug 24 – Aug 26` and
+  `Stay in Prague · Aug 26 – Aug 29` were both **ticked and struck through**.
+  The app was contradicting the traveler about the traveler's own trip, on one
+  screen, at the same moment.
+- **[app] The divergence was designed, written down, and wrong.**
+  `specs/next-step-cta/plan.md` said it outright: *"a checked checkbox with no
+  accommodation row is the traveler telling us they booked elsewhere. Trip
+  Health still reports the gap — that is its job, and **the two surfaces are
+  allowed to differ here**."* The Next Step walk honored the tick
+  (`walkBookingSlots`); `checkLodging` never read `booking_todos` at all,
+  though `exportData` had been carrying them the whole time. This is the same
+  shape as the 2026-08-15 entry below — *"Two answers to one question, and the
+  rendering one was the lie"* — with the polarity flipped: here the **server**
+  was the liar and the screen was right. **When two surfaces answer one
+  question, "they're allowed to differ" is a decision with a shelf life** — it
+  survives exactly until someone sees both at once. `nightCovered` is now the
+  one answer to "does the traveler have a bed this night", and takes the whole
+  `exportData` so a caller holding only the accommodations can't ask it.
+- **[app] The same hole was one scroll further down, unreported.**
+  `checkTransit` ignored booked transport to-dos identically — invisible only
+  because transit findings carry no `Day` and sort to the bottom of the list.
+  Fixed in the same pass; **directional**, unlike `segmentConnects`, because
+  00064 made a derived leg's direction load-bearing and a booked return
+  silencing the outbound would be a fresh instance of the bug. Fixing only
+  what was pointed at would have re-earned the same complaint next week.
+- **[app] The badge counted taste as if it were a gap.** Of the 28, one
+  over-stuffed day contributed **four**: "Day 6 has 9 items planned" plus one
+  row for each of morning/afternoon/evening. And the slot rule fired at *two*
+  — so "Day 1 has 2 things scheduled for the evening" was the app flagging
+  dinner and a bar. Now: at most one density finding per day, the slot
+  threshold is 3, and every `checkDensity` finding is `info`, so scheduling
+  taste lands in the collapsed Suggestions tier and the badge counts only what
+  you must actually fill. **A count you can't act on isn't information, it's
+  weather** — and it was sitting on the same number as five unbooked nights.
+- **[dev] Two causes wore one symptom, and only one was the rule.** "Out of
+  date" was also literally true: `tripReviewProvider` is non-`autoDispose` and
+  `_load()` never invalidated it, so **adding a stay, editing one, deleting
+  one, adding a segment, adding a place, editing or deleting an item, and
+  reordering a section** all left the previous answer on screen — leaving and
+  returning to the trip didn't help either. Eight callers, eight chances to
+  forget; `_load()` owns the invalidation now. The near-miss: the rule fix
+  alone would have made the reported screenshot correct and left the next
+  mutation stale, which is how a bug comes back wearing a different hat.
+- **[dev] A stable-sort test is vacuous under 32 elements.** The client
+  re-sorts the attention tier by severity, and `List.sort` is not stable in
+  Dart — but below length 32 it falls back to insertion sort, which is. The
+  six-finding fixture passed against the *unfixed* implementation; only a
+  40-finding one failed. Worth remembering whenever a test's subject is an
+  ordering guarantee: **pick the fixture size that reaches the code path, not
+  the size that reads nicely.**
+
 ## 2026-08-16 — daily food & drink budget
 
 - **[dev] The tests were all green and the section still read badly.** The

--- a/specs/next-step-cta/plan.md
+++ b/specs/next-step-cta/plan.md
@@ -150,8 +150,16 @@ precisely the "five ways to group a leg" failure the doc was written after.
 - **Fallback, never mixed.** Trips with zero derived slots keep the old
   findings behavior verbatim. A *satisfied* walk never falls through to the
   findings: a checked checkbox with no accommodation row is the traveler
-  telling us they booked elsewhere. Trip Health still reports the gap — that is
-  its job, and the two surfaces are allowed to differ here.
+  telling us they booked elsewhere.
+  - **SUPERSEDED 2026-08-17.** This bullet used to end "Trip Health still
+    reports the gap — that is its job, and the two surfaces are allowed to
+    differ here." They are not. Dogfooding produced a trip whose stay rows were
+    all ticked, under a Trip Health banner reading *"No lodging booked for the
+    nights of Mon, Aug 24 – Fri, Aug 28 (5 nights)"* — the app contradicting
+    the traveler on one screen. `nightCovered` (`trip_review.go`) now counts a
+    booked lodging to-do as coverage, and `checkTransit` does the same for a
+    booked leg, so the walk's rule IS the shared rule. Nights no slot spans are
+    a different question and still surface (`firstUnslottedLodging`).
 - **Ladder 7 → 6.** `PlanProgress.Total` was already a wire field, so the UI
   renumbers itself with no client release.
 - **Convention now has three readers.** Derived todo titles/keys

--- a/src/packages/api/trip_next_step.go
+++ b/src/packages/api/trip_next_step.go
@@ -543,17 +543,17 @@ func walkBookingSlots(d exportData) bookingWalk {
 // auto drafts too (pinned by TestNextStep_WalkTransportClaims).
 func bookingSlotClaimed(d exportData, t store.BookingTodo) bool {
 	if strings.HasPrefix(t.TodoKey, "stay:") && t.DepartDate.Valid && t.ReturnDate.Valid {
-		return stayNightsCovered(d.Accommodations, t.DepartDate.Time, t.ReturnDate.Time)
+		return stayNightsCovered(d, t.DepartDate.Time, t.ReturnDate.Time)
 	}
 	return todoClaimed(d, t)
 }
 
 // stayNightsCovered reports whether every night in [from, to) — checkout-
-// exclusive, matching stayCoversNight — has a real (non-auto) stay covering
-// it. Vacuously true when from >= to.
-func stayNightsCovered(accs []store.Accommodation, from, to time.Time) bool {
+// exclusive, matching stayCoversNight — has a bed under nightCovered.
+// Vacuously true when from >= to.
+func stayNightsCovered(d exportData, from, to time.Time) bool {
 	for night := from; night.Before(to); night = night.AddDate(0, 0, 1) {
-		if !nightCovered(accs, night) {
+		if !nightCovered(d, night) {
 			return false
 		}
 	}

--- a/src/packages/api/trip_next_step_test.go
+++ b/src/packages/api/trip_next_step_test.go
@@ -413,12 +413,17 @@ func TestNextStep_WalkReturnHomeLast(t *testing.T) {
 	}
 }
 
-// A satisfied walk NEVER falls through to the findings: every slot checked off
-// with zero accommodation rows still means "booked elsewhere", so the ladder
-// moves on (the health sheet keeps flagging the same gap — that's its job).
-func TestNextStep_WalkNeverFallsThroughToFindings(t *testing.T) {
+// Every slot checked off with zero accommodation rows means "booked
+// elsewhere", and BOTH surfaces now believe it: the ladder moves on AND Trip
+// Health raises nothing. The health sheet used to keep flagging the same
+// nights — "the two surfaces are allowed to differ here", specs/next-step-cta
+// — until dogfooding produced a trip whose stay rows were all ticked under a
+// banner reading "No lodging booked for the nights of Aug 24 – Aug 28".
+// Nights no slot spans are a different question, and still surface:
+// see TestNextStep_WalkUnslottedNightsStillSurface.
+func TestNextStep_CheckedSlotsSilenceLodgingAndAdvance(t *testing.T) {
 	d := nextStepFixture(t)
-	d.Accommodations = nil // checkLodging WILL emit findings for every night
+	d.Accommodations = nil // the ONLY lodging evidence is the checked boxes
 	d.BookingTodos = bookSlots(walkTodos(t),
 		"transport:ewr>>paris", "stay:paris", "transport:paris>>lyon",
 		"stay:lyon", "transport:lyon>>ewr")
@@ -427,8 +432,11 @@ func TestNextStep_WalkNeverFallsThroughToFindings(t *testing.T) {
 		ID: uuid.New(), Kind: "other", TodoKey: "custom:abc", Title: "Rent a car"})
 
 	findings := reviewTrip(context.Background(), "en", d, reviewOptions{}, reviewDeps{})
-	if firstFindingIn(findings, "lodging") == nil {
-		t.Fatal("fixture precondition: expected lodging findings to exist")
+	if f := firstFindingIn(findings, "lodging"); f != nil {
+		t.Fatalf("checked stay slots cover their nights, got %q", f.Message)
+	}
+	if f := firstFindingIn(findings, "transit"); f != nil {
+		t.Fatalf("checked transport slots cover their legs, got %q", f.Message)
 	}
 	step, progress := deriveNextStep("en", nextStepNow, d, findings)
 	mustStep(t, step, progress, "book_trip", 4)

--- a/src/packages/api/trip_review.go
+++ b/src/packages/api/trip_review.go
@@ -337,11 +337,17 @@ func walkDayCoverage(d exportData) dayCoverage {
 
 // checkDensity flags days with nothing planned (walkDayCoverage owns what that
 // means — whole trip span, city fillers excluded, travel days included) and
-// over-packed days (more than 6 items, or two+ items sharing a time_of_day).
-// Buckets by absolute day so a day split across hubs still counts once. The
-// zero-dated-items early return stands: "no places saved yet" is
-// checkUnscheduled's finding to make, and one empty run spanning the whole trip
-// would only repeat it.
+// over-packed days (more than 6 items, or 3+ items sharing a time_of_day —
+// AT MOST ONE finding per day, see the packed branch). Buckets by absolute day
+// so a day split across hubs still counts once. The zero-dated-items early
+// return stands: "no places saved yet" is checkUnscheduled's finding to make,
+// and one empty run spanning the whole trip would only repeat it.
+//
+// Every finding here is INFO, so none of them reach the attention tier or the
+// health badge (TripReviewSection.partition splits on severity alone). How you
+// arranged a day is taste; the badge counts the gaps you have to fill — a
+// night with no bed, a leg with no booking — and a busy Tuesday sitting in
+// that same count is what made "28 to fix" unreadable.
 func checkDensity(locale string, d exportData) []Finding {
 	tripID := d.Trip.ID.String()
 	buckets := map[int][]store.ItineraryItem{}
@@ -384,7 +390,7 @@ func checkDensity(locale string, d exportData) []Finding {
 		dd := day
 		if len(items) > 6 {
 			f := Finding{
-				Severity: "warn", Category: "packing", TripID: tripID, Day: &dd,
+				Severity: "info", Category: "packing", TripID: tripID, Day: &dd,
 				Message: tr(locale, "review.packedDay", day, len(items)),
 			}
 			// Offer a one-tap move of the last item in the crowded day to the
@@ -398,6 +404,12 @@ func checkDensity(locale string, d exportData) []Finding {
 				}
 			}
 			out = append(out, f)
+			// One finding per day. A packed day's slots are all crowded by
+			// construction, so emitting them too said the same thing four ways
+			// (an over-stuffed Day 6 produced "too packed" plus one row for
+			// each of morning/afternoon/evening) and buried the days that had
+			// a genuinely lopsided schedule without being full.
+			continue
 		}
 		todCount := map[string]int{}
 		for _, it := range items {
@@ -405,11 +417,13 @@ func checkDensity(locale string, d exportData) []Finding {
 				todCount[t]++
 			}
 		}
-		// Fixed order keeps the output deterministic.
+		// Fixed order keeps the output deterministic. Three in a slot, not two:
+		// dinner and a bar is an evening, not a scheduling defect, and flagging
+		// every pair made the commonest shape of a good evening a warning.
 		for _, tod := range []string{"morning", "afternoon", "evening"} {
-			if todCount[tod] > 1 {
+			if todCount[tod] > 2 {
 				f := Finding{
-					Severity: "warn", Category: "packing", TripID: tripID, Day: &dd,
+					Severity: "info", Category: "packing", TripID: tripID, Day: &dd,
 					Message: tr(locale, "review.timeOfDayCollision", day, todCount[tod], tr(locale, "review.tod."+tod)),
 				}
 				if target := lighterDay(d, day); target != nil {
@@ -498,7 +512,7 @@ func checkLodging(locale string, d exportData) []Finding {
 	var cur *nightRun
 	for n := 0; n < nights; n++ {
 		night := start.AddDate(0, 0, n)
-		if nightCovered(d.Accommodations, night) {
+		if nightCovered(d, night) {
 			cur = nil
 			continue
 		}
@@ -545,18 +559,52 @@ func checkLodging(locale string, d exportData) []Finding {
 	return out
 }
 
-// nightCovered reports whether any real (non-auto) accommodation covers the
-// given night. Auto drafts are itinerary-derived suggestions, not real
-// lodging — counting them as coverage hides genuinely unbooked nights (same
-// skip as checkBookings). Shared by checkLodging's night walk and the
-// next-step booking-slot walk (trip_next_step.go) so "covered" has one
-// definition.
-func nightCovered(accs []store.Accommodation, night time.Time) bool {
-	for _, a := range accs {
+// nightCovered is the ONE answer to "does the traveler have a bed this night".
+// Two sources close a night, and both are the traveler's own assertion:
+//
+//   - a real (non-auto) accommodation covering it. Auto drafts are itinerary-
+//     derived suggestions, not real lodging — counting them as coverage hides
+//     genuinely unbooked nights (same skip as checkBookings).
+//   - a lodging booking-todo they TICKED, spanning it. A checked box with no
+//     accommodation row means "booked elsewhere, details not entered here", and
+//     answering "No lodging booked" to that contradicts the checklist two
+//     scrolls up the same screen.
+//
+// The second source was deliberately excluded once (specs/next-step-cta:
+// "the two surfaces are allowed to differ here") — dogfooding said otherwise,
+// so the walk's rule is now the shared one. Shared by checkLodging's night walk
+// and the next-step booking-slot walk (trip_next_step.go), which is why it
+// takes the whole exportData: a caller holding only the accommodations cannot
+// answer this question, and the signature should say so.
+func nightCovered(d exportData, night time.Time) bool {
+	for _, a := range d.Accommodations {
 		if a.Auto {
 			continue
 		}
 		if stayCoversNight(a.CheckIn, a.CheckOut, night) {
+			return true
+		}
+	}
+	return bookedStayTodoCoversNight(d.BookingTodos, night)
+}
+
+// bookedStayTodoCoversNight reports whether a lodging to-do the traveler
+// checked off spans this night. An UNBOOKED row covers nothing — the tick is
+// the assertion, not the row's existence — and a row missing either date
+// covers nothing, the same guard stayCoversNight applies to accommodations.
+//
+// The filter is `kind`, not the "stay:" todo_key prefix: kind is the column
+// that MEANS "this row is about lodging" (migration 00010), and a custom row
+// the traveler added by hand carries only kind — its key is "custom:<uuid>"
+// (booking_todo_handler.go). walkBookingSlots filters on the key prefix
+// instead because it asks a different question ("which slots are in itinerary
+// order"), which custom rows have no place in.
+func bookedStayTodoCoversNight(todos []store.BookingTodo, night time.Time) bool {
+	for _, t := range todos {
+		if !t.Booked || t.Kind != "stay" {
+			continue
+		}
+		if stayCoversNight(t.DepartDate, t.ReturnDate, night) {
 			return true
 		}
 	}
@@ -646,6 +694,11 @@ func checkTransit(locale string, d exportData) []Finding {
 		if segmentConnects(d.Segments, from, to) {
 			continue
 		}
+		// Same rule nightCovered applies to lodging: a leg the traveler ticked
+		// off is booked, whether or not they entered the segment here.
+		if bookedTransportTodoConnects(d.BookingTodos, from, to) {
+			continue
+		}
 		origin, dest := from, to
 		// One resolution for the whole app (leg_transport_mode.go): a bookable
 		// ferry pair, then the trip's stated mode, then geography, then flight.
@@ -705,6 +758,34 @@ func segmentConnects(segs []store.TripSegment, from, to string) bool {
 			return true
 		}
 		if fuzzyMatch(o, to) && fuzzyMatch(dst, from) {
+			return true
+		}
+	}
+	return false
+}
+
+// bookedTransportTodoConnects reports whether a transport to-do the traveler
+// checked off runs from -> to. Endpoints come from legEndpoints, which already
+// walks the 00064 label columns -> title -> todo_key ladder and refuses the
+// reserved @home token (so a home leg, which names no city, never claims a
+// city pair — and checkTransit only ever asks about city pairs anyway).
+//
+// DIRECTIONAL, unlike segmentConnects. A hand-entered segment may well have
+// its endpoints the other way round, but 00064 made a derived leg's direction
+// load-bearing precisely because a trip can leave from ALB and come home into
+// EWR — so letting a booked return silence the outbound would be a fresh
+// instance of the lie this rule exists to remove.
+func bookedTransportTodoConnects(todos []store.BookingTodo, from, to string) bool {
+	from, to = strings.ToLower(from), strings.ToLower(to)
+	for _, t := range todos {
+		if !t.Booked || t.Kind != "transport" {
+			continue
+		}
+		o, dst, ok := legEndpoints(t)
+		if !ok {
+			continue
+		}
+		if fuzzyMatch(strings.ToLower(o), from) && fuzzyMatch(strings.ToLower(dst), to) {
 			return true
 		}
 	}

--- a/src/packages/api/trip_review_integration_test.go
+++ b/src/packages/api/trip_review_integration_test.go
@@ -126,6 +126,68 @@ func TestTripReview_BrokenTrip(t *testing.T) {
 	}
 }
 
+// The reported bug, end to end on the wire: a dated trip whose derived stay
+// rows are all TICKED — and which has no accommodation records at all, because
+// the traveler booked on Airbnb and never typed the details in here — must not
+// be told "No lodging booked". Unticking brings the nights straight back: the
+// checkbox is the assertion, and it is the only thing that moved.
+func TestTripReview_CheckedStayRowsAreNotALodgingGap(t *testing.T) {
+	resetDB(t)
+	owner, token := createTestUser(t, "owner@example.com")
+	trip := createTestTrip(t, owner.ID, 0)
+	id := trip.ID.String()
+
+	rec := doJSON(t, "PATCH", "/api/v1/trips/"+id, token, map[string]any{
+		"start_date": "2026-08-24", "end_date": "2026-08-29",
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("patch trip = %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// The two derived stay rows the trip page syncs, spanning every night.
+	rec = doJSON(t, "PUT", "/api/v1/trips/"+id+"/booking-todos", token, []map[string]any{
+		{"kind": "stay", "todo_key": "stay:amsterdam", "title": "Stay in Amsterdam",
+			"destination": "Amsterdam", "depart_date": "2026-08-24", "return_date": "2026-08-26"},
+		{"kind": "stay", "todo_key": "stay:prague", "title": "Stay in Prague",
+			"destination": "Prague", "depart_date": "2026-08-26", "return_date": "2026-08-29"},
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("sync todos = %d: %s", rec.Code, rec.Body.String())
+	}
+	todos := decodeTodoList(t, rec)
+	if len(todos) != 2 {
+		t.Fatalf("expected 2 synced stay rows, got %d", len(todos))
+	}
+
+	// Unticked, they are the app's own suggestions — the gap stands.
+	if got := reviewCategories(t, id, token); !got["lodging"] {
+		t.Fatalf("unticked stay rows must not cover anything, got %v", got)
+	}
+
+	setBooked := func(todo map[string]any, booked bool) {
+		t.Helper()
+		r := doJSON(t, "PATCH", "/api/v1/trips/"+id+"/booking-todos/"+todo["id"].(string),
+			token, map[string]any{"booked": booked})
+		if r.Code != http.StatusOK {
+			t.Fatalf("set booked=%v = %d: %s", booked, r.Code, r.Body.String())
+		}
+	}
+	for _, todo := range todos {
+		setBooked(todo, true)
+	}
+
+	if got := reviewCategories(t, id, token); got["lodging"] {
+		rec := doJSON(t, "GET", "/api/v1/trips/"+id+"/review", token, nil)
+		t.Fatalf("ticked stay rows still reported a lodging gap: %s", rec.Body.String())
+	}
+
+	// Unticking one city brings back exactly that city's nights.
+	setBooked(todos[0], false)
+	if got := reviewCategories(t, id, token); !got["lodging"] {
+		t.Fatalf("unticking a stay must restore its nights, got %v", got)
+	}
+}
+
 func TestTripReview_CleanTrip(t *testing.T) {
 	resetDB(t)
 	owner, ownerToken := createTestUser(t, "owner@example.com")

--- a/src/packages/api/trip_review_test.go
+++ b/src/packages/api/trip_review_test.go
@@ -67,23 +67,76 @@ func TestCheckDensity_EmptyAndPacked(t *testing.T) {
 	morning := strp("morning")
 	items := []store.ItineraryItem{
 		{ID: uuid.New(), Name: "A", Day: i32p(1), TimeOfDay: morning},
-		{ID: uuid.New(), Name: "B", Day: i32p(1), TimeOfDay: morning}, // two mornings on day 1
+		{ID: uuid.New(), Name: "B", Day: i32p(1), TimeOfDay: morning},
+		{ID: uuid.New(), Name: "C", Day: i32p(1), TimeOfDay: morning}, // three mornings on day 1
 		// day 2 empty
-		{ID: uuid.New(), Name: "C", Day: i32p(3)},
+		{ID: uuid.New(), Name: "D", Day: i32p(3)},
 	}
 	fs := checkDensity("en", exportData{Trip: store.Trip{ID: uuid.New()}, Items: items})
-	cats := map[string][]Finding{}
+	// Everything checkDensity emits is a suggestion, never attention-tier.
 	for _, f := range fs {
-		cats[f.Severity] = append(cats[f.Severity], f)
+		if f.Severity != "info" {
+			t.Fatalf("density findings must all be info, got %+v", f)
+		}
 	}
-	if len(cats["info"]) != 1 { // day 2 empty
-		t.Fatalf("expected one empty-day info, got %+v", fs)
+	msgs := map[string]bool{}
+	for _, f := range fs {
+		msgs[f.Message] = true
 	}
-	if got := cats["info"][0].Message; got != "Day 2 has nothing planned." {
-		t.Fatalf("single empty day should keep the singular message, got %q", got)
+	if len(fs) != 2 {
+		t.Fatalf("expected exactly two findings (empty day + morning collision), got %+v", fs)
 	}
-	if len(cats["warn"]) != 1 { // two mornings day 1
-		t.Fatalf("expected one over-packed warn, got %+v", fs)
+	if !msgs["Day 2 has nothing planned."] {
+		t.Fatalf("single empty day should keep the singular message, got %+v", fs)
+	}
+	if !msgs["Day 1 has 3 things scheduled for the morning."] {
+		t.Fatalf("expected the 3-item morning collision, got %+v", fs)
+	}
+}
+
+// Two things in one slot is a normal evening — dinner and a bar — not a
+// scheduling defect. Flagging every pair is what made Trip Health unreadable,
+// so the collision threshold is 3.
+func TestCheckDensity_TwoInASlotIsFine(t *testing.T) {
+	evening := strp("evening")
+	items := []store.ItineraryItem{
+		{ID: uuid.New(), Name: "Moeders", Day: i32p(1), TimeOfDay: evening},
+		{ID: uuid.New(), Name: "Door 74", Day: i32p(1), TimeOfDay: evening},
+	}
+	fs := checkDensity("en", exportData{Trip: store.Trip{ID: uuid.New()}, Items: items})
+	for _, f := range fs {
+		if strings.Contains(f.Message, "scheduled for the") {
+			t.Fatalf("two items in a slot must not be flagged, got %+v", f)
+		}
+	}
+}
+
+// A packed day says one thing once. Its slots are all crowded by construction,
+// so emitting them too said the same thing four times over.
+func TestCheckDensity_PackedDayEmitsOneFinding(t *testing.T) {
+	var items []store.ItineraryItem
+	for i, tod := range []string{
+		"morning", "morning", "morning",
+		"afternoon", "afternoon", "afternoon",
+		"evening", "evening", "evening",
+	} {
+		items = append(items, store.ItineraryItem{
+			ID: uuid.New(), Name: fmt.Sprintf("A%d", i), Day: i32p(1), TimeOfDay: strp(tod)})
+	}
+	// A second, lighter day so the packed finding still earns its move fix.
+	items = append(items, store.ItineraryItem{ID: uuid.New(), Name: "B", Day: i32p(2)})
+	fs := checkDensity("en", exportData{Trip: store.Trip{ID: uuid.New()}, Items: items})
+	var forDay1 []Finding
+	for _, f := range fs {
+		if f.Day != nil && *f.Day == 1 {
+			forDay1 = append(forDay1, f)
+		}
+	}
+	if len(forDay1) != 1 {
+		t.Fatalf("a packed day should emit exactly one finding, got %+v", forDay1)
+	}
+	if !strings.Contains(forDay1[0].Message, "too packed") {
+		t.Fatalf("the one finding should be the packed-day one, got %q", forDay1[0].Message)
 	}
 }
 
@@ -224,6 +277,74 @@ func TestCheckLodging_GateAndCoverage(t *testing.T) {
 	}
 }
 
+// A stay row the traveler TICKED is lodging, even with no accommodation row
+// behind it — that is what "booked elsewhere, details not entered here" looks
+// like, and answering "No lodging booked" to it contradicts the checklist on
+// the same screen. Ticking the box is the assertion; the row's existence is
+// not.
+func TestCheckLodging_CheckedStayTodoCoversItsNights(t *testing.T) {
+	trip := store.Trip{ID: uuid.New(),
+		StartDate: dateVal(t, "2026-08-01"), EndDate: dateVal(t, "2026-08-04")} // nights 1,2,3
+
+	stayTodo := func(booked bool, in, out string) store.BookingTodo {
+		td := store.BookingTodo{ID: uuid.New(), Kind: "stay",
+			TodoKey: "stay:amsterdam", Title: "Stay in Amsterdam", Booked: booked, Auto: true}
+		if in != "" {
+			td.DepartDate, td.ReturnDate = dateVal(t, in), dateVal(t, out)
+		}
+		return td
+	}
+
+	// Booked, spanning nights 1-2 (checkout 08-03, exclusive) → only night 3 left.
+	fs := checkLodging("en", exportData{Trip: trip,
+		BookingTodos: []store.BookingTodo{stayTodo(true, "2026-08-01", "2026-08-03")}})
+	if len(fs) != 1 || fs[0].Day == nil || *fs[0].Day != 3 {
+		t.Fatalf("checked stay should cover nights 1-2, got %+v", fs)
+	}
+
+	// Booked across the whole trip → silent.
+	fs = checkLodging("en", exportData{Trip: trip,
+		BookingTodos: []store.BookingTodo{stayTodo(true, "2026-08-01", "2026-08-04")}})
+	if len(fs) != 0 {
+		t.Fatalf("a checked stay spanning the trip should silence the check, got %+v", fs)
+	}
+
+	// UNCHECKED, same dates → every night still flagged. The row alone is the
+	// app's own suggestion, not a booking.
+	fs = checkLodging("en", exportData{Trip: trip,
+		BookingTodos: []store.BookingTodo{stayTodo(false, "2026-08-01", "2026-08-04")}})
+	if len(fs) != 1 || fs[0].Day == nil || *fs[0].Day != 1 {
+		t.Fatalf("an unchecked stay row must not cover anything, got %+v", fs)
+	}
+
+	// Checked but DATELESS → covers nothing; we cannot know which nights.
+	fs = checkLodging("en", exportData{Trip: trip,
+		BookingTodos: []store.BookingTodo{stayTodo(true, "", "")}})
+	if len(fs) != 1 || fs[0].Day == nil || *fs[0].Day != 1 {
+		t.Fatalf("a dateless stay row covers no specific night, got %+v", fs)
+	}
+
+	// A transport row never counts as a bed, however it is dated or ticked.
+	flight := store.BookingTodo{ID: uuid.New(), Kind: "transport",
+		TodoKey: "transport:@home>>amsterdam", Title: "ALB → Amsterdam", Booked: true,
+		DepartDate: dateVal(t, "2026-08-01"), ReturnDate: dateVal(t, "2026-08-04")}
+	fs = checkLodging("en", exportData{Trip: trip, BookingTodos: []store.BookingTodo{flight}})
+	if len(fs) != 1 || fs[0].Day == nil || *fs[0].Day != 1 {
+		t.Fatalf("a transport row is not lodging, got %+v", fs)
+	}
+
+	// A CUSTOM row the traveler added by hand carries kind but no "stay:" key
+	// (booking_todo_handler mints "custom:<uuid>"), which is why the filter is
+	// kind and not the key prefix.
+	custom := store.BookingTodo{ID: uuid.New(), Kind: "stay",
+		TodoKey: "custom:" + uuid.NewString(), Title: "Hotel Ibis", Booked: true,
+		DepartDate: dateVal(t, "2026-08-01"), ReturnDate: dateVal(t, "2026-08-04")}
+	if fs := checkLodging("en", exportData{Trip: trip,
+		BookingTodos: []store.BookingTodo{custom}}); len(fs) != 0 {
+		t.Fatalf("a checked custom stay should cover its nights, got %+v", fs)
+	}
+}
+
 func TestCheckLodging_GroupsRuns(t *testing.T) {
 	// gap–covered–gap: 5 nights, a stay covers only night 3 → two range runs.
 	trip := store.Trip{ID: uuid.New(),
@@ -300,6 +421,49 @@ func TestCheckTransit_MissingLeg(t *testing.T) {
 		Origin: strp("Rome"), Destination: strp("Florence")}}
 	if fs := checkTransit("en", exportData{Trip: trip, Items: items, Segments: segs}); len(fs) != 0 {
 		t.Fatalf("connected legs should be silent, got %+v", fs)
+	}
+}
+
+// Lodging's rule, applied to legs: a transport row the traveler ticked off is
+// booked, whether or not they also entered the segment here.
+func TestCheckTransit_CheckedTransportTodoCoversItsLeg(t *testing.T) {
+	trip := store.Trip{ID: uuid.New()}
+	items := []store.ItineraryItem{
+		{ID: uuid.New(), Name: "Colosseum", City: strp("Rome"), Day: i32p(1)},
+		{ID: uuid.New(), Name: "Duomo", City: strp("Florence"), Day: i32p(2)},
+	}
+	leg := func(booked bool, key, title string) store.BookingTodo {
+		return store.BookingTodo{ID: uuid.New(), Kind: "transport",
+			TodoKey: key, Title: title, Booked: booked, Auto: true}
+	}
+
+	if fs := checkTransit("en", exportData{Trip: trip, Items: items,
+		BookingTodos: []store.BookingTodo{leg(true, "transport:rome>>florence", "Rome → Florence")},
+	}); len(fs) != 0 {
+		t.Fatalf("a checked leg should be silent, got %+v", fs)
+	}
+
+	// Unchecked → the row is the app's own suggestion, and the gap stands.
+	if fs := checkTransit("en", exportData{Trip: trip, Items: items,
+		BookingTodos: []store.BookingTodo{leg(false, "transport:rome>>florence", "Rome → Florence")},
+	}); len(fs) != 1 {
+		t.Fatalf("an unchecked leg must not cover anything, got %+v", fs)
+	}
+
+	// DIRECTIONAL, unlike segmentConnects: 00064 made a derived leg's direction
+	// load-bearing, so a booked return must not silence the outbound.
+	if fs := checkTransit("en", exportData{Trip: trip, Items: items,
+		BookingTodos: []store.BookingTodo{leg(true, "transport:florence>>rome", "Florence → Rome")},
+	}); len(fs) != 1 {
+		t.Fatalf("the booked RETURN must not cover the outbound, got %+v", fs)
+	}
+
+	// A stay row is not transport, however it is titled.
+	if fs := checkTransit("en", exportData{Trip: trip, Items: items,
+		BookingTodos: []store.BookingTodo{{ID: uuid.New(), Kind: "stay",
+			TodoKey: "stay:rome", Title: "Rome → Florence", Booked: true}},
+	}); len(fs) != 1 {
+		t.Fatalf("a stay row is not a leg, got %+v", fs)
 	}
 }
 
@@ -721,12 +885,12 @@ func TestFix_OverPacked_LighterDayAndNone(t *testing.T) {
 	fs := checkDensity("en", exportData{Trip: store.Trip{ID: tripID}, Items: items})
 	var packed *Finding
 	for i := range fs {
-		if fs[i].Severity == "warn" && strings.Contains(fs[i].Message, "too packed") {
+		if fs[i].Severity == "info" && strings.Contains(fs[i].Message, "too packed") {
 			packed = &fs[i]
 		}
 	}
 	if packed == nil || packed.Fix == nil {
-		t.Fatalf("expected an over-packed warn with a fix, got %+v", fs)
+		t.Fatalf("expected an over-packed info with a fix, got %+v", fs)
 	}
 	if packed.Fix.Action != "move_item" || packed.Fix.TargetDay == nil || *packed.Fix.TargetDay != 2 {
 		t.Fatalf("over-packed fix = %+v", packed.Fix)

--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -479,6 +479,18 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
           _computeTravelTimes(trip),
         syncTodosAfterPrefs(),
       ]);
+      // Trip Health is a SEPARATE fetch (GET /trips/{id}/review) behind a
+      // non-autoDispose provider, so nothing expires it on its own — leaving
+      // the screen and coming back re-reads the same cached answer. Every
+      // mutation on this screen ends here, so this is the one place that can
+      // promise the badge, the sheet and the Next Step card describe the trip
+      // that was just loaded. It used to be the caller's job, and eight of
+      // them didn't do it: adding a stay from the Bookings view left "no
+      // lodging booked" on screen next to the stay you had just added. The
+      // booking-todo sync's own invalidate was no help — it only fired when
+      // the DERIVED todo set changed, and a new accommodation changes no todo
+      // key and no booked flag.
+      if (mounted) _invalidateReview();
     } catch (e) {
       // Loud path: fall back to the cached copy and render it read-only for
       // network-level failures AND transient HTTP failures (429/502/503/504
@@ -599,11 +611,10 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
         // current values on screen — no flash.
         ref.invalidate(budgetProvider(widget.tripId));
         ref.invalidate(expensesProvider(widget.tripId));
-        // Re-read the health review too: chat-driven mutations arrive through
-        // this refresh (trip_updated → onTripUpdated), and the health badge
-        // and Next Step card must advance behind an open panel — not on the
-        // next cold load. Also covers pull-to-refresh.
-        _invalidateReview();
+        // The health review rides along inside _load, which owns that
+        // invalidation for every path — including this one, so the badge and
+        // Next Step card advance behind an open panel rather than on the next
+        // cold load.
         await _load(silent: true);
       } while (mounted && _refreshQueued);
       // AFTER the loop, not inside it: a turn that writes three times in a
@@ -1060,7 +1071,6 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
           .read(bookingTodosApiServiceProvider)
           .syncTodos(trip.id, _deriveTodos(trip));
       if (mounted) {
-        final changed = !_sameTodoState(_bookingTodos, todos);
         setState(() {
           _bookingTodos = todos;
           // Re-derive against the server's answer. A row's TAP TARGET comes
@@ -1071,26 +1081,10 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
           // discarded here; the registries are the point.
           _deriveTodos(trip);
         });
-        // The server's Next Step "book everything" aggregate reads booking
-        // todos, which lag until this sync lands — re-read the review when
-        // the sync actually changed them (specs/next-step-cta).
-        if (changed) _invalidateReview();
       }
     } catch (_) {
       // Non-fatal: keep whatever booking todos came with the trip.
     }
-  }
-
-  /// Same todo set as far as the review cares: matching (todo_key, booked)
-  /// pairs in order. Anything else re-reads the review.
-  static bool _sameTodoState(List<BookingTodo> a, List<BookingTodo> b) {
-    if (a.length != b.length) return false;
-    for (var i = 0; i < a.length; i++) {
-      if (a[i].todoKey != b[i].todoKey || a[i].booked != b[i].booked) {
-        return false;
-      }
-    }
-    return true;
   }
 
   /// The trip's stated non-flight travel mode ('car'|'train'|'bus'|'ferry')
@@ -4902,12 +4896,11 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
     }
   }
 
-  /// Reloads the trip payload and re-reads the health review so a resolved
-  /// finding disappears on the next fetch.
-  Future<void> _afterFix() async {
-    await _load();
-    _invalidateReview();
-  }
+  /// Reloads the trip payload — which re-reads the health review with it — so
+  /// a resolved finding disappears on the next fetch. Kept as a named step
+  /// because nine fix paths read better saying what they just finished than
+  /// saying "load".
+  Future<void> _afterFix() => _load();
 
   /// Invalidates both review variants (hours-off and hours-on) so whichever the
   /// section is showing re-fetches.

--- a/src/packages/flutter-app/lib/widgets/trip_review_section.dart
+++ b/src/packages/flutter-app/lib/widgets/trip_review_section.dart
@@ -103,6 +103,13 @@ class TripReviewSection extends ConsumerStatefulWidget {
   /// section) and "suggestions" (info and anything unrecognized, server order
   /// — the collapsed sheet section / neutral dot). The single
   /// severity-partition definition shared by the app-bar badge and the sheet.
+  ///
+  /// The attention sort is STABLE on the wire order, which the server has
+  /// already put in day order. `List.sort` is not stable in Dart, so comparing
+  /// severity alone let same-severity findings come out in any order — and now
+  /// that scheduling taste is `info`, this tier is almost entirely `warn`, so
+  /// that "any order" would be the whole list. A run of unbooked nights has to
+  /// read Aug before Sep.
   static ({List<TripFinding> attention, List<TripFinding> suggestions})
       partition(Iterable<TripFinding> findings) {
     final attention = <TripFinding>[];
@@ -111,9 +118,16 @@ class TripReviewSection extends ConsumerStatefulWidget {
       (_rankOf(f.severity) <= _severityRank['warn']! ? attention : suggestions)
           .add(f);
     }
-    attention
-        .sort((a, b) => _rankOf(a.severity).compareTo(_rankOf(b.severity)));
-    return (attention: attention, suggestions: suggestions);
+    final ranked = attention.indexed.toList()
+      ..sort((a, b) {
+        final bySeverity =
+            _rankOf(a.$2.severity).compareTo(_rankOf(b.$2.severity));
+        return bySeverity != 0 ? bySeverity : a.$1.compareTo(b.$1);
+      });
+    return (
+      attention: [for (final (_, f) in ranked) f],
+      suggestions: suggestions,
+    );
   }
 
   @override

--- a/src/packages/flutter-app/test/trip_detail_fix_actions_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_fix_actions_test.dart
@@ -66,6 +66,7 @@ class _FakeReviewApiService extends TripReviewApiService {
 
 class _FakeAccommodationsApiService extends AccommodationsApiService {
   final List<Map<String, dynamic>> patches = [];
+  final List<Map<String, dynamic>> added = [];
   _FakeAccommodationsApiService() : super(ApiClient(baseUrl: 'http://test'));
 
   @override
@@ -73,6 +74,13 @@ class _FakeAccommodationsApiService extends AccommodationsApiService {
       String tripId, String accId, Map<String, dynamic> body) async {
     patches.add({'id': accId, ...body});
     return Accommodation(id: accId, name: 'Stay');
+  }
+
+  @override
+  Future<Accommodation> add(String tripId, Map<String, dynamic> body) async {
+    added.add(body);
+    return Accommodation(
+        id: 'acc-new', name: body['name'] as String? ?? 'Stay');
   }
 }
 
@@ -391,5 +399,49 @@ void main() {
     await tester.pumpAndSettle();
     expect(find.text('No budget yet'), findsOneWidget);
     expect(find.byTooltip('What to wear & pack'), findsOneWidget);
+  });
+
+  // The health review is a SEPARATE fetch behind a non-autoDispose provider,
+  // so only an explicit invalidation can move it. Adding a stay from the
+  // Bookings view (not from a health fix, which always refreshed) used to skip
+  // that: the badge kept reading "no lodging booked" next to the stay just
+  // added. _load owns the invalidation now, so every mutation that reloads the
+  // trip re-reads the review with it.
+  testWidgets('adding a stay from the Bookings view re-reads the review',
+      (tester) async {
+    final review = _FakeReviewApiService([
+      _finding('lodging', 'No lodging booked for the night of Sat, Aug 1',
+          const FindingFix(action: 'add_lodging', label: 'Add a stay')),
+    ]);
+    final accommodations = _FakeAccommodationsApiService();
+    await _pumpScreen(tester,
+        trip: _trip(),
+        review: review,
+        accommodations: accommodations,
+        openSheet: false);
+
+    await tester.tap(find.text('Bookings'));
+    await tester.pumpAndSettle();
+
+    final callsBefore = review.calls;
+    review.resolved = true; // the stay now covers the night
+
+    await tester.tap(find.text('Add booking'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Stay'));
+    await tester.pumpAndSettle();
+    expect(find.byType(AddStaySheet), findsOneWidget);
+
+    await tester.enterText(
+        find.descendant(
+            of: find.byType(AddStaySheet), matching: find.byType(TextField).first),
+        'Hotel Ibis');
+    await tester.tap(find.widgetWithText(FilledButton, 'Add stay'));
+    await tester.pumpAndSettle();
+
+    expect(accommodations.added, hasLength(1));
+    expect(accommodations.added.single['name'], 'Hotel Ibis');
+    expect(review.calls, greaterThan(callsBefore),
+        reason: 'adding a stay must re-read the health review');
   });
 }

--- a/src/packages/flutter-app/test/trip_review_section_test.dart
+++ b/src/packages/flutter-app/test/trip_review_section_test.dart
@@ -315,4 +315,47 @@ void main() {
     // Button is disabled offline — no extra fetch.
     expect(fake.checkHoursCalls, isNot(contains(true)));
   });
+
+  group('partition', () {
+    // The server sorts day-major; the tier sort only hoists criticals. Dart's
+    // List.sort is NOT stable, so comparing severity alone left equal-severity
+    // findings in arbitrary order — and now that scheduling taste is `info`,
+    // this tier is almost entirely `warn`. Unbooked nights have to read in
+    // calendar order.
+    // Sized past 32 deliberately: below that, Dart's sort falls back to
+    // insertion sort, which happens to be stable — so a short fixture would
+    // pass against the unstable implementation and prove nothing.
+    test('keeps the wire (day) order within a severity', () {
+      final wire = [
+        for (var day = 1; day <= 40; day++)
+          _f('warn', day.isEven ? 'lodging' : 'transit', 'day $day', day: day),
+      ];
+      final split = TripReviewSection.partition(wire);
+      expect([for (final f in split.attention) f.message],
+          [for (var day = 1; day <= 40; day++) 'day $day']);
+    });
+
+    test('still hoists critical above warn, each half in wire order', () {
+      final split = TripReviewSection.partition([
+        _f('warn', 'lodging', 'warn early', day: 1),
+        _f('critical', 'dates', 'critical late', day: 8),
+        _f('warn', 'transit', 'warn late', day: 9),
+        _f('critical', 'dates', 'critical later', day: 12),
+      ]);
+      expect([for (final f in split.attention) f.message],
+          ['critical late', 'critical later', 'warn early', 'warn late']);
+    });
+
+    test('info and unknown severities fall to suggestions, in wire order', () {
+      final split = TripReviewSection.partition([
+        _f('info', 'packing', 'day 6 packed', day: 6),
+        _f('warn', 'lodging', 'no bed', day: 2),
+        _f('nonsense', 'packing', 'unknown severity', day: 1),
+        _f('info', 'weather', 'rain', day: 3),
+      ]);
+      expect([for (final f in split.attention) f.message], ['no bed']);
+      expect([for (final f in split.suggestions) f.message],
+          ['day 6 packed', 'unknown severity', 'rain']);
+    });
+  });
 }


### PR DESCRIPTION
## Summary

Trip Health read **"Mostly ready — 28 to fix"** and led with *"No lodging booked for the nights of Mon, Aug 24 – Fri, Aug 28 (5 nights)"* — while two scrolls up on the same screen, `Stay in Amsterdam · Aug 24 – Aug 26` and `Stay in Prague · Aug 26 – Aug 29` were both ticked and struck through. Two independent causes; fixing either alone leaves the complaint alive.

**1. The rule never looked at the checkbox.** `checkLodging` asked one question — "does a non-`auto` `accommodations` row cover this night?" — and never read `booking_todos`, though `exportData` had been carrying them all along. `checkTransit` had the identical hole for ticked legs, invisible only because transit findings carry no `Day` and sort to the bottom of the list.

This divergence was deliberate and written down (`specs/next-step-cta/plan.md`: *"a checked checkbox with no accommodation row is the traveler telling us they booked elsewhere. Trip Health still reports the gap — that is its job, and **the two surfaces are allowed to differ here**"*). The Next Step walk honored the tick; Trip Health did not. That bullet is now marked superseded, with the reason. `nightCovered` is the one answer to "does the traveler have a bed this night" and takes the whole `exportData`, so a caller holding only the accommodations structurally cannot ask it.

- The lodging filter keys on `booking_todos.kind`, not the `stay:` key prefix — a custom row the traveler adds by hand carries only `kind` (its key is `custom:<uuid>`). `walkBookingSlots` keeps its prefix filter; it asks a different question.
- The transport check is **directional**, unlike `segmentConnects`: 00064 made a derived leg's direction load-bearing (a trip can leave from ALB and come home into EWR), so a booked return must not silence the outbound.
- An **unticked** row still covers nothing, and a **dateless** one covers nothing.

**2. The answer went stale and nothing knocked it loose.** `tripReviewProvider` is not `autoDispose` and `_load()` never invalidated it, so **adding a stay, editing one, deleting one, adding a segment, adding a place, editing or deleting an item, and reordering a section** all left the previous answer on screen — leaving the trip and coming back didn't help either. `_load()` owns that invalidation now instead of eight callers who could each forget; the three call sites that already reload were removed, and `_sameTodoState` (whose gate was why the booking sync never helped) is gone with them.

**3. Relevance pass** (both decisions confirmed with Brian): at most **one** density finding per day — an over-stuffed day emitted four ("too packed" plus one row per time-of-day) — the slot threshold moves **2 → 3** (dinner and a bar is an evening, not a defect), and every `checkDensity` finding is now `info`, so scheduling taste lands in the collapsed Suggestions tier and the badge counts only the gaps you must fill. The client's attention sort is now stable on the wire's day order, so unbooked nights read Aug before Sep.

No migration, no new copy, no translation work. `TripReviewSection.partition` already split on severity alone, so the demotion needed no client change.

## Testing

- `go vet` + `gofmt` clean; **full Go suite green with a real Postgres** (the DB-backed integration tests skip without one).
- New Go coverage: ticked stay covers its nights / unticked doesn't / dateless doesn't / transport isn't lodging / a ticked `custom:` row with `kind=stay` does; ticked leg silences its gap, and the booked **return** does **not** silence the outbound; density 2-in-a-slot is silent, 3 fires, a packed day emits exactly one finding.
- **`TestTripReview_CheckedStayRowsAreNotALodgingGap`** reproduces the reported trip end-to-end on the wire (Amsterdam Aug 24–26 + Prague Aug 26–29, both ticked, zero accommodations): no lodging finding, and unticking one city restores exactly that city's nights.
- `flutter analyze` clean (3 pre-existing infos in `route_response.dart`, untouched); **1496 tests pass**.
- New Flutter coverage: adding a stay from the Bookings view re-reads the review; `partition` keeps day order, still hoists critical, and drops info/unknown to suggestions.
- **Mutation-checked** — every new test was re-run against the unfixed code and fails there. Worth noting: the partition fixture needed **40** findings, because below 32 Dart's sort falls back to insertion sort (which is stable) and a 6-finding fixture passed against the broken implementation.
- **Verified in the real app** (lane stack, seeded trip): before ticking, 3 attention findings incl. both lodging runs; after ticking every row, **"In good shape — 1 suggestion"**, no Needs-attention section, badge a neutral dot, Next Step 3 of 6 → 6 of 6. The 9-item day shows **one** Suggestions row, and a day with two evening items shows none. Unticking one stay live-updates the badge to "1" and the card to "Book your stay in Amsterdam / No lodging booked for the night of Mon, Aug 24" — Amsterdam's night only. Deleting an item (a `_load()`-only path) moved the suggestion from "9 items" to "8 items" with no reload, which is cause 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
