### PR TITLE
feat(brand): the rose floats bare on the app bar — the white plate is retired

### DIFF
--- a/docs/branding/README.md
+++ b/docs/branding/README.md
@@ -20,10 +20,22 @@ lockup.svg as a plain `<img>`.
 splash): cardinal points recolored white/`#B2DFDB` (teal-100), gold
 intercardinals and the hub unchanged. It duplicates mark.svg's point geometry
 — a geometry change in one must be mirrored in the other (both headers say
-so). Plate policy after the splash redesign: the **splash floats the bare
-light mark** on the teal gradient — no white plate; **gradient app bars still
-plate the dark mark** on a light `BrandBadge` (see
-`lib/widgets/brand_logo.dart`).
+so).
+
+**Plate policy (v3): the rose always floats bare.** No plate is drawn anywhere
+in the app. The only question a surface asks is which cut it needs: neutral
+page surfaces and scrimmed imagery take the dark `mark`; the teal
+`brandGradient` fields — the splash **and the gradient app bar** — take
+`mark-light`, where the dark artwork would be teal-on-teal. v2 kept a white
+plate on gradient app bars; it was retired because that gradient does not
+change with theme, so the plate stayed white in dark mode and became the
+brightest object on the screen. The policy is stated in
+`lib/widgets/brand_logo.dart` — re-litigate it there.
+
+Two artifacts outside the app keep a baked-in plate on purpose: `web/og-card.png`
+(lands on arbitrary social backgrounds) and `web/icons/Icon-maskable-512.png`
+(the maskable spec requires an opaque field). The print packet's header keeps
+one too — see `print_view_handler.go`.
 
 ## Type
 

--- a/src/packages/api/print_view_handler.go
+++ b/src/packages/api/print_view_handler.go
@@ -258,10 +258,16 @@ var printViewTmpl = template.Must(template.New("print-view").Parse(`<!DOCTYPE ht
       opacity: 0.85; margin: 0 0 6px; display: flex; align-items: center; gap: 10px;
     }
     header .brand img {
-      /* White plate behind the teal rose (the icon PNG is transparent), same
-         treatment as the in-app BrandBadge; box-sizing is border-box, so grow
-         the box to keep an 18px glyph. print-color-adjust keeps the plate in
-         print output, where backgrounds are stripped by default. */
+      /* White plate behind the teal rose (the icon PNG is transparent).
+         The app retired its plate and floats the reversed rose on teal
+         instead (brand_logo.dart, policy v3) — print deliberately does not
+         follow, because paper has a second state the app does not: the
+         header's teal band is a background, stripped by default in print
+         output, while print-color-adjust keeps this plate. The dark rose
+         therefore reads either way — separated by the plate on the teal
+         band, and on plain white when the band is gone. The reversed rose
+         would be invisible in that second state. box-sizing is border-box,
+         so grow the box to keep an 18px glyph. */
       height: 26px; width: 26px; padding: 4px;
       background: rgba(255, 255, 255, 0.92);
       border-radius: 5px;

--- a/src/packages/flutter-app/lib/widgets/brand_logo.dart
+++ b/src/packages/flutter-app/lib/widgets/brand_logo.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import '../constants/app_info.dart';
-import '../theme/app_colors.dart';
 import '../theme/spacing.dart';
 
 /// Anemos brand mark: an 8-point wind rose (άνεμος = wind) — teal cardinal
@@ -15,15 +14,22 @@ import '../theme/spacing.dart';
 /// - [BrandLogo.mark] — the rose icon only, for tight spots (nav rail,
 ///   landing hero).
 /// - [BrandLogo.markLight] — the reversed rose (white/teal-100 cardinals),
-///   for teal fields (the boot splash).
+///   for teal fields (the boot splash, the gradient app bar).
 ///
 /// The word itself is [BrandWordmark], not part of this class — see there.
 ///
-/// The dark artwork is teal + gold on a transparent background. It floats
-/// bare on page surfaces and scrimmed imagery (auth screen, nav rail, landing
-/// hero); on gradient app bars it still needs a light plate behind it — wrap
-/// in [BrandBadge] there. The splash field carries no plate: the bare
-/// [BrandLogo.markLight] floats directly on the teal gradient.
+/// **Plate policy, v3: the rose always floats bare.** No plate is drawn
+/// anywhere in the app; the only question a surface asks is which cut of the
+/// rose it needs. Page surfaces and scrimmed imagery (auth screen, nav rail,
+/// landing hero) take the dark [BrandLogo.mark]; the teal
+/// `AppColors.brandGradient` fields (the splash, the gradient app bar) take
+/// [BrandLogo.markLight], because the dark artwork is teal-on-teal there.
+///
+/// v2 kept a white `BrandBadge` plate on gradient app bars. v3 retired it: the
+/// gradient behind it never changes with theme, so the plate was white in dark
+/// mode too, where it was the brightest object on the screen — and the splash
+/// had already shown (PR #390) that the reversed rose reads on this exact
+/// gradient unaided. Re-litigate the policy here, not at a call site.
 class BrandLogo extends StatelessWidget {
   static const String _lockupAsset = 'assets/images/anemos_logo.png';
   static const String _markAsset = 'assets/images/anemos_mark.png';
@@ -48,8 +54,8 @@ class BrandLogo extends StatelessWidget {
         _isLockup = false,
         _isLight = false;
 
-  /// Reversed wind-rose mark (white/teal-100 cardinals) for teal fields,
-  /// rendered as a [size]×[size] square.
+  /// Reversed wind-rose mark (white/teal-100 cardinals) for teal fields — the
+  /// splash and the gradient app bar — rendered as a [size]×[size] square.
   const BrandLogo.markLight({super.key, double size = 28})
       : _asset = _markLightAsset,
         _height = size,
@@ -180,8 +186,9 @@ class BrandWordmark extends StatelessWidget {
 /// "A" monogram stand-in for the wind-rose mark when the image asset is
 /// unavailable. Fills the same [size]×[size] square the icon glyph did, so
 /// layout is identical either way. The dark form's black87 tile keeps it
-/// readable on any page surface; the [light] form inverts to a white tile
-/// with a dark glyph so it still reads on the splash's teal field.
+/// readable on any page surface; the [light] form is a bare white glyph — it
+/// stands on a teal field, where white reads unaided and a tile would be the
+/// plate the policy above retired.
 class _MonogramFallback extends StatelessWidget {
   final double size;
   final bool light;
@@ -193,10 +200,12 @@ class _MonogramFallback extends StatelessWidget {
       width: size,
       height: size,
       alignment: Alignment.center,
-      decoration: BoxDecoration(
-        color: light ? Colors.white.withValues(alpha: 0.92) : Colors.black87,
-        borderRadius: AppRadius.smAll,
-      ),
+      decoration: light
+          ? null
+          : const BoxDecoration(
+              color: Colors.black87,
+              borderRadius: AppRadius.smAll,
+            ),
       child: Text(
         'A',
         style: TextStyle(
@@ -204,7 +213,7 @@ class _MonogramFallback extends StatelessWidget {
           fontWeight: FontWeight.w600,
           fontSize: size * 0.42,
           height: 1,
-          color: light ? AppColors.brandDark : Colors.white,
+          color: Colors.white,
           letterSpacing: 0.5,
         ),
       ),
@@ -230,55 +239,6 @@ class _WordmarkFallback extends StatelessWidget {
           color: Colors.black87,
         ),
       ],
-    );
-  }
-}
-
-/// A light rounded surface that lets the teal/gold [BrandLogo] read on flat
-/// teal chrome (gradient app bars, the splash field).
-class BrandBadge extends StatelessWidget {
-  final Widget child;
-  final EdgeInsetsGeometry padding;
-  final BorderRadius borderRadius;
-  final bool circle;
-  final VoidCallback? onTap;
-
-  const BrandBadge({
-    super.key,
-    required this.child,
-    this.padding = const EdgeInsets.symmetric(
-        horizontal: AppSpacing.md, vertical: AppSpacing.sm),
-    this.borderRadius = AppRadius.mdAll,
-    this.circle = false,
-    this.onTap,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    final badge = Container(
-      padding: padding,
-      decoration: BoxDecoration(
-        color: Colors.white.withValues(alpha: 0.92),
-        shape: circle ? BoxShape.circle : BoxShape.rectangle,
-        borderRadius: circle ? null : borderRadius,
-      ),
-      child: child,
-    );
-    if (onTap == null) return badge;
-    // The badge surface is opaque, so the ripple mostly hides behind it —
-    // the InkWell is here for the tap target, web pointer cursor, and focus
-    // handling rather than the splash.
-    return Semantics(
-      button: true,
-      child: Material(
-        type: MaterialType.transparency,
-        child: InkWell(
-          onTap: onTap,
-          customBorder: circle ? const CircleBorder() : null,
-          borderRadius: circle ? null : borderRadius,
-          child: badge,
-        ),
-      ),
     );
   }
 }

--- a/src/packages/flutter-app/lib/widgets/gradient_app_bar.dart
+++ b/src/packages/flutter-app/lib/widgets/gradient_app_bar.dart
@@ -11,9 +11,19 @@ import '../theme/app_typography.dart';
 import '../theme/spacing.dart';
 import 'brand_logo.dart';
 
-/// The mark's own size in the brand row: the 28px rose, [BrandBadge]'s
-/// horizontal padding, and the gap before the wordmark.
-const double _markSlot = 28 + AppSpacing.sm * 2 + AppSpacing.sm;
+/// The rose, and the gap before the wordmark.
+///
+/// 36, not the 28 it was while plated, and measured rather than guessed: the
+/// rose radiates from a small hub, so most of its box is empty and its optical
+/// size runs well under its layout size. At 28 the reversed cut's gold
+/// intercardinals antialias away against the gradient and it reads as a thin
+/// white star; 32 is the floor and 36 reads as the wind rose it is. It is also
+/// what the nav rail paints, so the brand is one size wherever it appears.
+///
+/// The arithmetic lands back on the plated cost exactly — 28 + the badge's two
+/// 8px flanks + an 8px gap was also 52 — so retiring the plate moved no width
+/// threshold in the ladder below.
+const double _markSlot = 36 + AppSpacing.lg;
 
 /// The brand's tap padding, which is [AppSpacing.xs] on every side.
 const double _brandPadding = AppSpacing.xs * 2;
@@ -45,14 +55,15 @@ const double _minTitleWidth = 56;
 ///    ellipsized. That is the whole point.
 /// 2. **The page title** — [Flexible], ellipsized, dropped below
 ///    [_titleMinWidth].
-/// 3. **The plated mark** — dropped first, and always absent at rail widths,
-///    where `_RailBrand` already shows the rose one corner over on the same
-///    centre line (PR #406). Two roses 80px apart is a duplicate, not a
-///    lockup.
+/// 3. **The mark** — dropped first, and always absent at rail widths, where
+///    `_RailBrand` already shows the rose one corner over on the same centre
+///    line (PR #406). Two roses 80px apart is a duplicate, not a lockup.
 ///
-/// The plate is right here and nowhere else by policy: teal/gold artwork needs
-/// a light plate on gradient chrome and floats bare on neutral surfaces — see
-/// [BrandLogo]'s class doc.
+/// The rose floats bare here, as it does everywhere: this bar just takes the
+/// reversed cut ([BrandLogo.markLight]) because its field is the teal gradient
+/// and the dark artwork would be teal-on-teal. The white plate that used to
+/// sit behind it is retired — see [BrandLogo]'s class doc for the policy and
+/// why, and re-litigate it there rather than reintroducing a plate here.
 class GradientAppBar extends ConsumerWidget implements PreferredSizeWidget {
   /// The page's own title. Null where the brand stands alone.
   final Widget? title;
@@ -170,14 +181,12 @@ class _BrandTitle extends ConsumerWidget {
             mainAxisSize: MainAxisSize.min,
             children: [
               if (showMark) ...const [
-                BrandBadge(
-                  padding: EdgeInsets.symmetric(
-                      horizontal: AppSpacing.sm, vertical: AppSpacing.xs),
-                  // No onTap of its own: one outer InkWell only, or the brand
-                  // hit-tests and ripples twice over the same pixels.
-                  child: BrandLogo.mark(size: 28),
-                ),
-                SizedBox(width: AppSpacing.sm),
+                // markLight, not mark: this field is the teal brand gradient,
+                // where the dark rose is teal-on-teal — its cardinals all but
+                // disappear and it reads as a gold asterisk. Retiring the
+                // plate is what made the reversed cut necessary here.
+                BrandLogo.markLight(size: 36),
+                SizedBox(width: AppSpacing.lg),
               ],
               const BrandWordmark(),
             ],

--- a/src/packages/flutter-app/test/brand_everywhere_test.dart
+++ b/src/packages/flutter-app/test/brand_everywhere_test.dart
@@ -243,6 +243,25 @@ void main() {
     expect(find.text(AppInfo.name), findsOneWidget);
   });
 
+  testWidgets('the bar floats the REVERSED mark on its teal gradient',
+      (tester) async {
+    // The bar's field is AppColors.brandGradient, where the dark teal/gold
+    // rose is teal-on-teal — unreadable, which is what the retired white
+    // plate existed to fix. Since v3 of the plate policy nothing sits behind
+    // the rose, so the cut is load-bearing: swapping this back to
+    // BrandLogo.mark makes the brand vanish into the header rather than
+    // merely look wrong. Mirrors splash_screen_test's identical assertion.
+    await _pumpBar(tester, width: 700);
+
+    final image = tester.widget<Image>(
+      find.descendant(of: find.byType(BrandLogo), matching: find.byType(Image)),
+    );
+    expect(
+      (image.image as AssetImage).assetName,
+      'assets/images/anemos_mark_light.png',
+    );
+  });
+
   testWidgets('at rail widths the bar drops the mark — the rail has it',
       (tester) async {
     await _pumpBar(tester, width: 1200);

--- a/src/packages/flutter-app/test/home_polish_test.dart
+++ b/src/packages/flutter-app/test/home_polish_test.dart
@@ -18,7 +18,7 @@ import 'support/l10n_test_app.dart';
 
 /// Home polish regressions (UI polish wave 2, PR 9):
 /// - the app bar's brand ladder: the wordmark is always on screen, and it is
-///   the plated MARK that yields when the title slot narrows (the priority
+///   the MARK that yields when the title slot narrows (the priority
 ///   used to be the other way round, back when only Home carried the brand);
 /// - the compact plan strip's tagline wraps to two lines instead of
 ///   truncating ("Plan less. Trav…").
@@ -113,7 +113,7 @@ void main() {
   setUp(() => SharedPreferences.setMockInitialValues({}));
 
   testWidgets(
-      'narrow app bar fits the short wordmark next to the badge — '
+      'narrow app bar fits the short wordmark next to the mark — '
       'no ellipsis', (WidgetTester tester) async {
     await _pumpHome(tester, surface: const Size(360, 690));
 
@@ -141,7 +141,7 @@ void main() {
     expect(find.byType(BrandLogo), findsNothing);
   });
 
-  testWidgets('mid width (no rail) keeps badge and wordmark together',
+  testWidgets('mid width (no rail) keeps mark and wordmark together',
       (WidgetTester tester) async {
     await _pumpHome(tester, surface: const Size(700, 800));
 
@@ -160,7 +160,7 @@ void main() {
     expect(tester.takeException(), isNull);
   });
 
-  // Logo-links-home for the WORDMARK, not just the plated mark: at rail
+  // Logo-links-home for the WORDMARK, not just the mark: at rail
   // widths the wordmark is the only brand in the app bar, and it used to be
   // inert (no InkWell at all). These two pin the goHome WIRING at the widths
   // that render each shape — in the real shell Home's app bar only ever shows
@@ -186,7 +186,7 @@ void main() {
     expect(container.read(navIndexProvider), AppTab.home.index);
   });
 
-  testWidgets('mid width: the wordmark beside the badge is the same target',
+  testWidgets('mid width: the wordmark beside the mark is the same target',
       (WidgetTester tester) async {
     await _pumpHome(tester, surface: const Size(700, 800));
 
@@ -194,7 +194,7 @@ void main() {
         ProviderScope.containerOf(tester.element(find.byType(HomeScreen)));
     container.read(navIndexProvider.notifier).state = AppTab.plan.index;
 
-    // The wordmark text, NOT the badge — the half of the lockup that used to
+    // The wordmark text, NOT the mark — the half of the lockup that used to
     // be dead space.
     await tester.tap(find.text(AppInfo.name));
     await tester.pump();
@@ -202,12 +202,12 @@ void main() {
     expect(container.read(navIndexProvider), AppTab.home.index);
   });
 
-  testWidgets('the lockup is ONE tap target, not a badge nested in a target',
+  testWidgets('the lockup is ONE tap target, not a mark nested in a target',
       (WidgetTester tester) async {
     await _pumpHome(tester, surface: const Size(700, 800));
 
-    // Mutation pin against re-adding BrandBadge's own onTap: a second,
-    // nested InkWell would hit-test and ripple twice over the same brand.
+    // Mutation pin against giving the mark its own onTap: a second, nested
+    // InkWell would hit-test and ripple twice over the same brand.
     expect(
       find.ancestor(of: find.byType(BrandLogo), matching: find.byType(InkWell)),
       findsOneWidget,

--- a/src/packages/flutter-app/test/logo_home_nav_test.dart
+++ b/src/packages/flutter-app/test/logo_home_nav_test.dart
@@ -3,49 +3,17 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:travel_route_planner/navigation/app_nav.dart';
-import 'package:travel_route_planner/widgets/brand_logo.dart';
 
-/// Logo-links-home: the brand badge is tappable when given onTap (Home app
-/// bar; the rail brand is a bare mark with its own InkWell, pinned in
-/// nav_tab_reset_test.dart), and goHome mirrors the shell's tab-select
-/// behavior (selectTab): land on the Home ROOT — the Home stack is popped to
-/// its root whether the tap switches tabs or Home is already active.
+/// Logo-links-home: goHome mirrors the shell's tab-select behavior
+/// (selectTab): land on the Home ROOT — the Home stack is popped to its root
+/// whether the tap switches tabs or Home is already active.
+///
+/// The tap target itself is pinned elsewhere, not here: the brand row carries
+/// exactly one InkWell over the whole lockup (home_polish_test.dart), and the
+/// rail brand is a bare mark with its own (nav_tab_reset_test.dart). The two
+/// widget tests that used to stand in this file exercised the retired
+/// BrandBadge plate directly and went with it.
 void main() {
-  testWidgets('BrandBadge with onTap fires the callback',
-      (WidgetTester tester) async {
-    var taps = 0;
-    await tester.pumpWidget(
-      MaterialApp(
-        home: Scaffold(
-          body: BrandBadge(
-            onTap: () => taps++,
-            child: const SizedBox(width: 24, height: 24),
-          ),
-        ),
-      ),
-    );
-
-    await tester.tap(find.byType(BrandBadge));
-    expect(taps, 1);
-  });
-
-  testWidgets('BrandBadge without onTap stays a plain surface',
-      (WidgetTester tester) async {
-    await tester.pumpWidget(
-      const MaterialApp(
-        home: Scaffold(
-          body: BrandBadge(child: SizedBox(width: 24, height: 24)),
-        ),
-      ),
-    );
-
-    expect(
-      find.descendant(
-          of: find.byType(BrandBadge), matching: find.byType(InkWell)),
-      findsNothing,
-    );
-  });
-
   testWidgets('goHome switches back to the Home tab from another tab',
       (WidgetTester tester) async {
     late WidgetRef capturedRef;

--- a/src/packages/flutter-app/test/nav_tab_reset_test.dart
+++ b/src/packages/flutter-app/test/nav_tab_reset_test.dart
@@ -166,8 +166,8 @@ void main() {
   testWidgets('the rail brand mark taps through to the Home root',
       (tester) async {
     // Logo-links-home through the real rail: the brand mark at the top of the
-    // rail is a bare BrandLogo with its own InkWell (no BrandBadge plate), so
-    // pin that the tap surface survived the plate's removal.
+    // rail is a bare BrandLogo with its own InkWell — no plate anywhere in the
+    // app since v3 — so pin that the tap surface survived the plate's removal.
     final container = await pumpApp(tester);
 
     await tester.tap(railDestination('Trips'));

--- a/src/packages/flutter-app/test/splash_screen_test.dart
+++ b/src/packages/flutter-app/test/splash_screen_test.dart
@@ -6,12 +6,13 @@ import 'package:travel_route_planner/widgets/brand_logo.dart';
 void main() {
   // The splash pulse controller repeats forever, so these tests use pump()
   // with explicit durations — pumpAndSettle would never settle.
-  testWidgets('splash floats the bare light mark — no badge plate',
-      (tester) async {
+  // "No plate" is no longer asserted here: the plate widget is gone from the
+  // app entirely (v3 of the policy in brand_logo.dart), so the compiler pins
+  // what an expectation used to. What still needs pinning is the *cut* — the
+  // reversed mark is what reads on the teal gradient.
+  testWidgets('splash floats the bare light mark', (tester) async {
     await tester.pumpWidget(const MaterialApp(home: SplashScreen()));
     await tester.pump(const Duration(milliseconds: 100));
-
-    expect(find.byType(BrandBadge), findsNothing);
 
     final image = tester.widget<Image>(
       find.descendant(of: find.byType(BrandLogo), matching: find.byType(Image)),


### PR DESCRIPTION
## Summary

The mark in the mobile app bar sat on a white plate that, in dark mode, was the brightest object on the screen.

The plate was never a dark-mode bug: it is `Colors.white.withValues(alpha: 0.92)` in **both** themes, painted over `AppColors.brandGradient` (`teal.shade600 → teal.shade900`), which does not change with theme. Only the UI around it got dark. A dark-mode-only fix would have left two identical teal bars carrying two different brand treatments, and put a brightness branch on a background that never changes brightness.

So this is a brand-policy change — and one this repo has already made once. #390 retired this same 92%-white plate from the splash screen, which paints the **identical** gradient, and floated the reversed mark on it instead. The app bar now does the same. **Plate policy goes to v3: the rose always floats bare**; the only question a surface asks is which cut it needs.

- `BrandBadge` loses its last call site and is **deleted** — no plate is left anywhere in the running app, and the compiler now pins that more strongly than an assertion could.
- **The cut is load-bearing.** The dark rose is teal-on-teal on this gradient — its cardinals all but vanish and it reads as a gold asterisk, which is exactly what the plate existed to fix. `markLight` is what reads there, so a new test asserts the bar renders that asset.
- **28 → 36.** The rose radiates from a small hub, so most of its box is empty and its optical size runs well under its layout size. At 28 the reversed cut's gold intercardinals antialias away against the gradient and it reads as a thin white star; 32 is the floor, 36 reads as the wind rose and matches what the nav rail already paints. The slot arithmetic lands back on **52 exactly** (28 + the badge's two 8px flanks + an 8px gap was also 52), so **no width threshold in the ladder moved**.
- The asset-load fallback loses its white tile for the same reason: on a teal field a bare white glyph reads unaided, and a tile would be the plate returning through the degraded path.

**Deliberately unchanged:** the nav rail / auth / landing hero keep the dark rose bare on their neutral surfaces; `web/og-card.png` and `Icon-maskable-512.png` keep baked-in plates (arbitrary social backgrounds; the maskable spec requires an opaque field); no `AppColors` token or brightness branch was added, so this does not collide with the pending `dark-mode-tokens` lane.

**Print deliberately does not follow** — paper has a second state the app does not. The print header's teal band is a background, stripped by default in print output, while `print-color-adjust` keeps its plate: the dark rose therefore reads both ways, and the reversed one would be invisible on white. The comment there now says so instead of pointing at a deleted widget.

## Testing

- `flutter test` — **1502 passing**, including the brand width-ladder tests, which needed no re-tuning (the slot cost is unchanged).
- `flutter analyze` — clean (3 pre-existing infos in untouched `lib/models/route_response.dart`).
- `gofmt -l` / `go vet ./...` — clean.
- New test: `brand_everywhere_test.dart` asserts the bar renders `anemos_mark_light.png`, mirroring `splash_screen_test.dart`'s check — a future edit restoring `BrandLogo.mark` would make the brand vanish into the header, not merely look wrong.
- Manual verification in headless Chrome against this lane's stack at 390×844, signed in:
  - **Dark and light Home** — no plate in either; the app bar is **pixel-identical across themes** (same gradient at (56,28), same near-white rose-point count), while the page body correctly flips `(14,21,19)` ↔ `(244,251,248)`.
  - **Size chosen by measurement, not eye** — rendered the asset over the gradient at 28/32/36/40 before picking; the same sweep on the dark mark is what confirmed it is unusable on this field.
  - **1280px (rail width)** — the bar drops the mark and the rail carries it: one rose on screen, not two.
  - **Titled bar** (`← ANEMOS · Travel profile` at 390px) — mark, wordmark, back button and title all fit, no truncation.
  - **Fallback path** — forced the asset to fail via CDP URL blocking: renders a bare white "A" on the gradient, no tile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)