### PR TITLE
fix(trip): give the city name the row back on a phone

### DIFF
--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -2810,6 +2810,13 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
     final todayDay =
         tripDayOn(_trip?.startDate, _trip?.endDate, DateTime.now());
     final slivers = <Widget>[];
+    // Running month for the narrow day labels: the month is spelled out when
+    // it is the first dated day of this group and whenever it CHANGES, and
+    // dropped in between. So a city reads "Sat, Aug 29 · Sun 30 · Mon 31 ·
+    // Tue, Sep 1 · Wed 2" — the way a person writes a list of dates. Dropping
+    // it unconditionally would leave "Sun 31 / Tue 2" genuinely ambiguous
+    // across a month rollover, which is exactly where a traveler is checking.
+    int? lastMonth;
     var i = 0;
     while (i < items.length) {
       final day = items[i].day;
@@ -2821,6 +2828,9 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
       if (day != null) {
         final dayKey = '$groupKey#$day';
         final collapsed = _collapsedDays.contains(dayKey);
+        final month = tripStart?.add(Duration(days: day - 1)).month;
+        final showMonth = month == null || month != lastMonth;
+        lastMonth = month;
         final header = _daySubHeader(
             day, tripStart, theme, collapsed, _runTravelMin(run), () {
           setState(() {
@@ -2847,7 +2857,8 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
                   }
                 : null,
             headerKey: _dayHeaderKeys.putIfAbsent(dayKey, GlobalKey.new),
-            isToday: day == todayDay);
+            isToday: day == todayDay,
+            showMonth: showMonth);
         // Tonight caption (specs/happening-now): a non-pinned content row —
         // it scrolls and collapses with the section, never joining the
         // pinned chrome. [showTonight] is true for at most one group, so
@@ -2961,6 +2972,13 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
       {required bool cityCollapsed}) {
     final l10n = context.l10n;
     final chipStyle = _chipTextStyle(theme);
+    // Narrow drops the dates OUT of the header row and stacks them under the
+    // name (see [_cityHeaderMetaLine]). The row's rigid chip is measured for
+    // the widest group and can claim up to [_chipMaxWidth] of a ~300px phone
+    // row, and since the label's Expanded is the only flex child it absorbs
+    // the whole deficit — which is how "Prague" rendered as "Pra…". Columns
+    // are what the chip buys, and a phone has no room to spend on them.
+    final stackDates = _narrow && group.dateRange != null;
     final header = HoverReveal(
       builder: (context, revealed) => Material(
         color: theme.scaffoldBackgroundColor,
@@ -2977,7 +2995,12 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
             });
           },
           child: Padding(
-            padding: const EdgeInsets.fromLTRB(16, 16, 16, 4),
+            // Narrow buys back some of the second line's height at the top,
+            // where the gap between a city and the day header under it was
+            // the loosest thing on the phone.
+            padding: _narrow
+                ? const EdgeInsets.fromLTRB(16, 12, 16, 4)
+                : const EdgeInsets.fromLTRB(16, 16, 16, 4),
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
@@ -2995,9 +3018,12 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
                     // nearest Row ancestor — the header tests navigate that
                     // ancestry to pair a city with its date chip.
                     Expanded(
-                      child: _cityHeaderLabel(l10n, group, theme),
+                      child: _cityHeaderLabel(l10n, group, theme,
+                          metaLine: stackDates
+                              ? _cityHeaderMetaLine(group, chipStyle)
+                              : null),
                     ),
-                    if (group.dateRange != null)
+                    if (group.dateRange != null && !stackDates)
                       // A rigid SizedBox at the per-build shared width
                       // ([_dateChipWidth]), so calendar icons, range starts,
                       // and nights suffixes form columns across rows.
@@ -3061,7 +3087,11 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
                     // one per-row variance: it keeps an invisible,
                     // width-identical placeholder (same IconButton config, so
                     // density changes can't drift it) or its chip cluster
-                    // would sit a button-slot right of the other rows.
+                    // would sit a button-slot right of the other rows —
+                    // EXCEPT on narrow, where the dates have left the row and
+                    // there is no cluster left to align. Holding ~40px of a
+                    // phone row for a button nobody can see is the density
+                    // this pass exists to remove.
                     if (trip.canEdit && !_isOffline)
                       group.label != _kOtherPlaces
                           ? HoverRevealed(
@@ -3075,21 +3105,24 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
                                     trip, RefineTarget.city(group.label)),
                               ),
                             )
-                          : ExcludeSemantics(
-                              child: IgnorePointer(
-                                child: Opacity(
-                                  opacity: 0,
-                                  // No tooltip: IgnorePointer blocks hover, a
-                                  // ghost tooltip target would outlive it.
-                                  child: IconButton(
-                                    icon: const Icon(Icons.auto_awesome,
-                                        size: 16),
-                                    visualDensity: VisualDensity.compact,
-                                    onPressed: null,
+                          : _narrow
+                              ? const SizedBox.shrink()
+                              : ExcludeSemantics(
+                                  child: IgnorePointer(
+                                    child: Opacity(
+                                      opacity: 0,
+                                      // No tooltip: IgnorePointer blocks
+                                      // hover, a ghost tooltip target would
+                                      // outlive it.
+                                      child: IconButton(
+                                        icon: const Icon(Icons.auto_awesome,
+                                            size: 16),
+                                        visualDensity: VisualDensity.compact,
+                                        onPressed: null,
+                                      ),
+                                    ),
                                   ),
                                 ),
-                              ),
-                            ),
                     const SizedBox(width: 4),
                     Icon(
                       cityCollapsed ? Icons.chevron_right : Icons.expand_more,
@@ -3999,12 +4032,20 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
   /// The city header's name, with the repeat qualifier stacked beneath it when
   /// another group renders the SAME label — a revisited city, or one a bad
   /// section rewrite split in two. Without it the two headers read identically
-  /// and the duplicate looks like a rendering bug.
+  /// and the duplicate looks like a rendering bug. [metaLine] stacks under
+  /// both on narrow (the date range — see [_cityHeaderMetaLine]).
   ///
-  /// When there is no qualifier (every ordinary trip) this returns the bare
-  /// [Text] the header has always used, so the widget tree is unchanged.
+  /// This is the ONE place that decides the stacked-label shape: everything
+  /// that drops below the name joins this Column, so the name's [Text] keeps
+  /// the header's outer Row as its nearest Row ancestor and the header tests
+  /// can still navigate that ancestry to pair a city with its dates.
+  ///
+  /// With neither a qualifier nor a meta line (every ordinary trip on a
+  /// desktop) this returns the bare [Text] the header has always used, so the
+  /// widget tree is unchanged.
   Widget _cityHeaderLabel(
-      AppLocalizations l10n, CityGroup group, ThemeData theme) {
+      AppLocalizations l10n, CityGroup group, ThemeData theme,
+      {Widget? metaLine}) {
     final label = Text(
       groupLabelText(l10n, group.label),
       maxLines: 1,
@@ -4012,20 +4053,62 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
       style: theme.textTheme.titleSmall?.copyWith(fontWeight: FontWeight.bold),
     );
     final qualifier = group.qualifier;
-    if (qualifier == null) return label;
+    if (qualifier == null && metaLine == null) return label;
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       mainAxisSize: MainAxisSize.min,
       children: [
         label,
-        Text(
-          qualifier,
-          maxLines: 1,
-          overflow: TextOverflow.ellipsis,
-          style: theme.textTheme.labelSmall
-              ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
-        ),
+        if (qualifier != null)
+          Text(
+            qualifier,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: theme.textTheme.labelSmall
+                ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+          ),
+        if (metaLine != null) metaLine,
       ],
+    );
+  }
+
+  /// The narrow city header's second line: "Aug 24 – Aug 27 · 3 nights".
+  ///
+  /// Carries no calendar icon — the pin above it already anchors the row, and
+  /// a second glyph on a phone is the noise this pass removes. The range and
+  /// the nights stay TWO Texts, as they have since the chip columns landed:
+  /// `tripLegNights` owns the leading "· ", so a zero-night leg drops the
+  /// middot structurally rather than by a conditional in the format string.
+  /// Both are Flexible so an extreme text scale ellipsizes inside the label
+  /// column instead of overflowing it.
+  Widget _cityHeaderMetaLine(CityGroup group, TextStyle? chipStyle) {
+    final nights = group.dateRange!.nights;
+    return MergeSemantics(
+      // One utterance, matching the reading order the chip had.
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Flexible(
+            child: Text(
+              group.dateRange!.range,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: chipStyle,
+            ),
+          ),
+          if (nights != null) ...[
+            const SizedBox(width: AppSpacing.xs),
+            Flexible(
+              child: Text(
+                nights,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: chipStyle,
+              ),
+            ),
+          ],
+        ],
+      ),
     );
   }
 
@@ -4107,6 +4190,10 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
   /// today's tint is alpha-blended onto the scaffold background (never a
   /// translucent color) for the same reason. [headerKey] gives the Today
   /// scroller a stable handle on the header's render box.
+  ///
+  /// [showMonth] is the caller's answer to "would dropping the month here lose
+  /// anything" — see the running-month rule in [_buildGroupItemSlivers]. It
+  /// only bites on narrow; a desktop row has the width to spell every date.
   Widget _daySubHeader(
       int day,
       DateTime? tripStart,
@@ -4116,11 +4203,13 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
       VoidCallback onTap,
       VoidCallback? onRefine,
       {Key? headerKey,
-      bool isToday = false}) {
+      bool isToday = false,
+      bool showMonth = true}) {
     final l10n = context.l10n;
-    final label = tripStart != null
-        ? _fmtDayHeader(tripStart.add(Duration(days: day - 1)))
-        : l10n.tripDayN(day);
+    final date = tripStart?.add(Duration(days: day - 1));
+    final label = date == null
+        ? l10n.tripDayN(day)
+        : (_narrow && !showMonth ? weekdayDay(date) : _fmtDayHeader(date));
     final muted = theme.colorScheme.onSurfaceVariant;
     final header = HoverReveal(
       builder: (context, revealed) => Material(
@@ -4133,11 +4222,19 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
         child: InkWell(
           onTap: onTap,
           child: Padding(
-            padding: const EdgeInsets.fromLTRB(16, 12, 16, 2),
+            // Narrow drops the calendar glyph and indents to where the city
+            // name (and its dates) start instead: two calendar icons stacked
+            // two rows apart said less than one clean indent column does, and
+            // the day is subordinate to the city, so it should read that way.
+            padding: _narrow
+                ? const EdgeInsets.fromLTRB(24, 8, 16, 2)
+                : const EdgeInsets.fromLTRB(16, 12, 16, 2),
             child: Row(
               children: [
-                Icon(Icons.today, size: 16, color: theme.colorScheme.primary),
-                const SizedBox(width: 6),
+                if (!_narrow) ...[
+                  Icon(Icons.today, size: 16, color: theme.colorScheme.primary),
+                  const SizedBox(width: 6),
+                ],
                 Expanded(
                   child: Row(
                     children: [
@@ -6165,8 +6262,12 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
                       final grouped = derivation.groupedBookings;
                       final groups = derivation.groups;
                       // Shared per-build chip width — see _dateChipWidth's
-                      // doc for why this must stay a build-local.
-                      final dateChipWidth = _dateChipWidth(groups, theme);
+                      // doc for why this must stay a build-local. Narrow
+                      // stacks the dates under the name instead of rendering
+                      // the chip, so nothing consumes the measurement and the
+                      // TextPainter sweep over every group is skipped.
+                      final dateChipWidth =
+                          _narrow ? 0.0 : _dateChipWidth(groups, theme);
                       // Day-header GlobalKeys for the CURRENT groups' day
                       // keys, not just whatever happens to be built: a
                       // collapsed group's day headers don't exist yet, but

--- a/src/packages/flutter-app/lib/utils/date_formats.dart
+++ b/src/packages/flutter-app/lib/utils/date_formats.dart
@@ -14,6 +14,8 @@ import 'package:intl/intl.dart';
 String? _cachedLocaleTag;
 DateFormat? _mmmd;
 DateFormat? _mmmed;
+DateFormat? _e;
+DateFormat? _d;
 
 void _syncLocale() {
   final tag = Intl.defaultLocale;
@@ -21,6 +23,8 @@ void _syncLocale() {
     _cachedLocaleTag = tag;
     _mmmd = null;
     _mmmed = null;
+    _e = null;
+    _d = null;
   }
 }
 
@@ -36,6 +40,22 @@ DateFormat mmmd() {
 DateFormat mmmed() {
   _syncLocale();
   return _mmmed ??= DateFormat.MMMEd();
+}
+
+/// "Sat 29" — abbreviated weekday plus day of month, for the narrow trip-detail
+/// day header, where the city header directly above already states the month.
+///
+/// Composed from the two sub-patterns rather than asked for as a skeleton
+/// because **intl ships no `Ed` pattern**: it is absent from every locale in
+/// `data/dates/patterns/`, so `DateFormat.Ed()` does not exist. Both shipped
+/// locales lead with the weekday for this pair (`en: EEE, MMM d`,
+/// `es: EEE, d MMM`), so one order is right for both — revisit when adding a
+/// locale that puts the day first.
+String weekdayDay(DateTime date) {
+  _syncLocale();
+  final e = _e ??= DateFormat.E();
+  final d = _d ??= DateFormat.d();
+  return '${e.format(date)} ${d.format(date)}';
 }
 
 /// "Jul 15 – Jul 18" via [mmmd], collapsing a same-day pair to the single

--- a/src/packages/flutter-app/test/trip_detail_day_header_narrow_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_day_header_narrow_test.dart
@@ -1,0 +1,175 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:travel_route_planner/models/booking_todo.dart';
+import 'package:travel_route_planner/models/itinerary_item.dart';
+import 'package:travel_route_planner/models/trip.dart';
+import 'package:travel_route_planner/services/api_client.dart';
+import 'package:travel_route_planner/services/booking_todos_api_service.dart';
+import 'package:travel_route_planner/services/trips_api_service.dart';
+import 'package:travel_route_planner/providers/booking_todos_provider.dart';
+import 'package:travel_route_planner/providers/trips_provider.dart';
+import 'package:travel_route_planner/screens/trip_detail_screen.dart';
+
+import 'support/l10n_test_app.dart';
+
+/// The day sub-header on a phone: no calendar glyph (the city header's pin
+/// two rows up already anchors the section, and two calendars said less than
+/// one indent column does), and the month spelled out only where dropping it
+/// would lose something — the first dated day of a group, and every month
+/// rollover after it. Desktop keeps the icon and the full date on every row.
+
+class _FakeTripsApiService extends TripsApiService {
+  final Trip trip;
+  _FakeTripsApiService(this.trip) : super(ApiClient(baseUrl: 'http://test'));
+
+  @override
+  Future<Trip> getTrip(String id) async => trip;
+}
+
+/// Swallows the derived-payload sync like the offline test env.
+class _FakeBookingTodosApiService extends BookingTodosApiService {
+  _FakeBookingTodosApiService() : super(ApiClient(baseUrl: 'http://test'));
+
+  @override
+  Future<List<BookingTodo>> syncTodos(
+          String tripId, List<Map<String, dynamic>> derived) async =>
+      throw Exception('offline test env');
+}
+
+ItineraryItem _item(int pos, String name, String city, int day) =>
+    ItineraryItem(
+      id: 'i$pos',
+      position: pos,
+      name: name,
+      address: '$city address',
+      // Zero coords so the screen skips the map widget in the test env.
+      latitude: 0,
+      longitude: 0,
+      category: 'attraction',
+      day: day,
+      city: city,
+    );
+
+/// Kraków Aug 29 → Sep 2: one city whose days cross a month boundary, which
+/// is the case the running-month rule exists for. Days 1..5 of the trip map
+/// to Aug 29, 30, 31, Sep 1, Sep 2.
+Trip _monthCrossingTrip() => Trip(
+      id: 't1',
+      title: 'Kraków',
+      startDate: '2026-08-29',
+      endDate: '2026-09-02',
+      createdAt: '2026-08-01',
+      updatedAt: '2026-08-01',
+      items: [
+        _item(0, 'Rynek Główny', 'Kraków', 1),
+        _item(1, 'Wawel', 'Kraków', 2),
+        _item(2, 'Kazimierz', 'Kraków', 3),
+        _item(3, 'Wieliczka', 'Kraków', 4),
+        _item(4, 'Planty', 'Kraków', 5),
+      ],
+    );
+
+Future<void> _pump(WidgetTester tester, Trip trip, Size size,
+    {Locale? locale}) async {
+  await tester.binding.setSurfaceSize(size);
+  addTearDown(() => tester.binding.setSurfaceSize(null));
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        tripsApiServiceProvider.overrideWithValue(_FakeTripsApiService(trip)),
+        bookingTodosApiServiceProvider
+            .overrideWithValue(_FakeBookingTodosApiService()),
+      ],
+      child: localizedTestApp(
+        home: TripDetailScreen(tripId: 't1'),
+        locale: locale,
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+const _phone = Size(390, 1600);
+// 800 is the wide floor: _narrow is strictly `< kRailBreakpoint`.
+const _desktop = Size(800, 1600);
+
+void main() {
+  testWidgets('phone: the month is stated once, then again when it changes',
+      (WidgetTester tester) async {
+    await _pump(tester, _monthCrossingTrip(), _phone);
+
+    // First dated day of the group keeps the month...
+    expect(find.text('Sat, Aug 29'), findsOneWidget);
+    // ...the days that follow inside the same month drop it...
+    expect(find.text('Sun 30'), findsOneWidget);
+    expect(find.text('Mon 31'), findsOneWidget);
+    expect(find.text('Sun, Aug 30'), findsNothing);
+    expect(find.text('Mon, Aug 31'), findsNothing);
+    // ...and the rollover states it again, because "Mon 31 / Tue 1" is
+    // genuinely ambiguous and that is exactly where a traveler is checking.
+    expect(find.text('Tue, Sep 1'), findsOneWidget);
+    expect(find.text('Wed 2'), findsOneWidget);
+    expect(find.text('Wed, Sep 2'), findsNothing);
+  });
+
+  testWidgets('phone: the day header drops its calendar glyph',
+      (WidgetTester tester) async {
+    await _pump(tester, _monthCrossingTrip(), _phone);
+
+    expect(find.byIcon(Icons.today), findsNothing,
+        reason: 'the pin on the city header above is the section anchor');
+  });
+
+  testWidgets('desktop keeps the icon and spells every date',
+      (WidgetTester tester) async {
+    // The wide layout is deliberately untouched by this pass: it has the
+    // width to say the whole thing on every row, and the chip columns that
+    // narrow gives up are worth having there.
+    await _pump(tester, _monthCrossingTrip(), _desktop);
+
+    expect(find.byIcon(Icons.today), findsWidgets);
+    expect(find.text('Sat, Aug 29'), findsOneWidget);
+    expect(find.text('Sun, Aug 30'), findsOneWidget);
+    expect(find.text('Mon, Aug 31'), findsOneWidget);
+    expect(find.text('Tue, Sep 1'), findsOneWidget);
+    expect(find.text('Wed, Sep 2'), findsOneWidget);
+    expect(find.text('Sun 30'), findsNothing);
+  });
+
+  testWidgets('phone: the short label localizes', (WidgetTester tester) async {
+    // weekdayDay composes DateFormat.E() + DateFormat.d(); both shipped
+    // locales lead with the weekday, so one order serves both. The month-
+    // bearing label comes from DateFormat.MMMEd(), which reads
+    // Intl.defaultLocale (English in the test env) rather than the widget
+    // locale — so only the short half is assertable here.
+    await _pump(tester, _monthCrossingTrip(), _phone,
+        locale: const Locale('es'));
+
+    expect(find.text('Sun 30'), findsOneWidget);
+  });
+
+  testWidgets('an undated trip still falls back to "Day N"',
+      (WidgetTester tester) async {
+    // No start date => no calendar date to shorten; the fallback label is
+    // untouched by the running-month rule.
+    await _pump(
+      tester,
+      Trip(
+        id: 't1',
+        title: 'Someday',
+        createdAt: '2026-08-01',
+        updatedAt: '2026-08-01',
+        items: [
+          _item(0, 'Rynek Główny', 'Kraków', 1),
+          _item(1, 'Wawel', 'Kraków', 2),
+        ],
+      ),
+      _phone,
+    );
+
+    expect(find.text('Day 1'), findsOneWidget);
+    expect(find.text('Day 2'), findsOneWidget);
+  });
+}

--- a/src/packages/flutter-app/test/trip_detail_leg_nights_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_leg_nights_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -14,6 +15,7 @@ import 'package:travel_route_planner/providers/trips_provider.dart';
 import 'package:travel_route_planner/screens/trip_detail_screen.dart';
 
 import 'support/chip_finders.dart';
+import 'support/city_groups.dart';
 import 'support/l10n_test_app.dart';
 
 /// Returns a fixed trip without hitting the network, so we can exercise the
@@ -243,16 +245,38 @@ void main() {
         reason: 'chevrons must align across rows');
   });
 
-  testWidgets('phone width: header row never overflows and stays flush right',
+  testWidgets('phone width: the city name gets the row, dates go beneath it',
       (WidgetTester tester) async {
-    // The test font renders every glyph as a full-size square, so the chip
-    // here measures far wider than any real font — the harshest squeeze the
-    // row can see. The shared-width cap must ellipsize the chip (never
-    // overflow), and the chevron must stay flush with the row end.
+    // The regression this pass exists to kill: the chip is rigid and the
+    // label's Expanded is the only flex child, so on a phone the chip took
+    // its measured width first and "Prague" rendered as "Pra…". The test font
+    // renders every glyph as a full-size square, so the squeeze here is
+    // harsher than any real font — if the name survives this, it survives.
     await tester.binding.setSurfaceSize(const Size(375, 667));
     addTearDown(() => tester.binding.setSurfaceSize(null));
     await _pump(tester, _pragueKrakowTrip());
 
+    // The dates still belong to Prague's header (chipTextIn scopes to the
+    // row), but they now sit on a SECOND line under the name.
+    final name = cityHeaderLabel('Prague');
+    final dates = chipTextIn('Prague', 'Aug 24 – Aug 27');
+    expect(dates, findsOneWidget);
+    expect(chipTextIn('Prague', '· 3 nights'), findsOneWidget);
+    expect(
+      tester.getTopLeft(dates).dy,
+      greaterThan(tester.getTopLeft(name).dy),
+      reason: 'the date range must stack BELOW the city name on a phone',
+    );
+
+    // The name is not truncated: it paints its full intrinsic width. A
+    // regression to the one-line layout clamps this well under it.
+    final painted = tester.getSize(name).width;
+    final intrinsic = (tester.renderObject(name) as RenderParagraph)
+        .getMaxIntrinsicWidth(double.infinity);
+    expect(painted, moreOrLessEquals(intrinsic, epsilon: 0.5),
+        reason: '"Prague" must render whole, never ellipsized, at 375px');
+
+    // And the row still ends where it always did.
     final row = headerRowOf('Prague');
     // expand_more: groups land expanded (see the chevron test above).
     final chevron = find.descendant(
@@ -262,6 +286,35 @@ void main() {
       moreOrLessEquals(tester.getTopRight(row).dx, epsilon: 0.1),
       reason: 'chevron must stay flush with the row end at phone width',
     );
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('phone width: no calendar chip icon, and no ghost refine slot',
+      (WidgetTester tester) async {
+    // The chip's Icons.event is gone with the chip; the pin above the second
+    // line is the row's only anchor. And 'Other places' no longer holds an
+    // invisible ~40px IconButton — that placeholder exists to keep the chip
+    // columns aligned, and narrow has no columns to keep. (The wide twin of
+    // this test, below, asserts the opposite on both counts.)
+    await tester.binding.setSurfaceSize(const Size(390, 844));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    await _pump(tester, _pragueMysteryTrip());
+
+    expect(find.descendant(
+            of: headerRowOf('Prague'), matching: find.byIcon(Icons.event)),
+        findsNothing);
+
+    final ghosts = find.descendant(
+        of: headerRowOf('Other places'),
+        matching: find.widgetWithIcon(IconButton, Icons.auto_awesome));
+    expect(ghosts, findsNothing,
+        reason: "'Other places' must not reserve a refine slot on a phone");
+    // The real button still renders on a city that HAS a hub.
+    expect(
+        find.descendant(
+            of: headerRowOf('Prague'),
+            matching: find.widgetWithIcon(IconButton, Icons.auto_awesome)),
+        findsOneWidget);
   });
 
   testWidgets('chip columns align across rows', (WidgetTester tester) async {


### PR DESCRIPTION
## Summary

Brian's dogfood screenshot: on a phone, every itinerary city header rendered its name as **"Pra…" / "Kra…"**. The cause is structural, not spacing — the header row has exactly one flex child (the label's `Expanded`) and hands the date chip a *rigid* `SizedBox` at a width measured across every group, so the chip takes up to 200px of a ~300px content row and the name eats the entire deficit. The refine ✨ squeezed from the other side: it reserves ~40px whether or not it is drawn, and on a real phone (`HoverReveal` reveals when no mouse is connected) it *is* drawn.

**City header, narrow only:**
- Dates stack **under** the name — inside the label's `Expanded`, exactly where the revisit `qualifier` already lives, so the name's `Text` keeps the outer `Row` as its nearest ancestor and every shared test finder still resolves.
- Name gets the full row and stops truncating; the ranges form an indent column for free, with no measurement.
- Chip's `Icons.event` dropped (the pin above already anchors the row), `_dateChipWidth`'s `TextPainter` sweep skipped, and the invisible `'Other places'` placeholder — which existed only to hold the chip columns — no longer reserved.
- Top padding 16 → 12.

**Day header, narrow only:**
- No second calendar glyph two rows under the first; indented to 24 so it starts where the city name and its dates do.
- Month spelled out only where dropping it would lose something — the first dated day of a group and **every rollover after it**: `Sat, Aug 29 · Sun 30 · Mon 31 · Tue, Sep 1 · Wed 2`. Unconditional shortening would make `Mon 31 / Tue 1` genuinely ambiguous, which is exactly where a traveler is checking.
- `weekdayDay()` composes `DateFormat.E()` + `DateFormat.d()` rather than asking for an `Ed` skeleton — **intl ships no `Ed` pattern in any locale**, so `DateFormat.Ed()` does not exist. Both shipped locales lead with the weekday (`en: EEE, MMM d`, `es: EEE, d MMM`), so one order serves both.

**No ARB changes**, so no `gen-l10n` regen. Wide is deliberately untouched.

## Testing

- `flutter analyze` — clean (3 pre-existing infos in `models/route_response.dart`, untouched here).
- `flutter test` — **1509 pass**, 0 fail.
- **Wide is provably unchanged**: `_narrow` is strictly `< kRailBreakpoint`, and every existing chip-column / re-measure / boldText / `'Other places'`-placeholder test pumps at 800 or 1200. All pass without edits.
- **Mutation-tested, not just green** — each new assertion was confirmed red against the unfixed code: forcing `stackDates` off fails both new phone-width tests; forcing `showMonth` always-true *and* always-false each fail the running-month test.
- Rewrote `trip_detail_leg_nights_test.dart`'s 375×667 case, which only checked the chevron and would have passed vacuously. It now pins the actual fix: dates below the name, name painting its full intrinsic width, chevron still flush right, no exception.
- New `trip_detail_day_header_narrow_test.dart` (5 tests): running month at a real rollover, no `Icons.today` on narrow, desktop keeps icon + full dates, Spanish short label, undated `"Day N"` fallback.
- **Browser-verified** on the lane stack (headless Chrome, seeded Prague→Kraków trip crossing Aug→Sep, plus an `Other places` group): **390px with touch emulation** (so the ✨ actually renders — the real phone density), 375, 799, 800 and 1440, in **en and es**. Confirmed the names render whole, the rollover restores the month, `'Otros lugares'` has no ghost slot with its chevron still aligned, and 1440 is byte-for-byte the layout it was.
- Note: an 800px *window* is still narrow — the nav rail eats 81px, so the body is 719. The real wide floor is ~881px, which the 1440 shot covers.

## Note for the integrator

⚠ #442 (`shape-before-schedule`) is open and also touches `trip_detail_screen.dart`. Its hunks are in the derivation / next-step / empty-days regions, not the header builders, and it is 12 commits behind main — it will be resolving conflicts here regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)