### PR TITLE
feat(wear): lead with what to pack, put the city detail one tap away

### DIFF
--- a/docs/friction-log.md
+++ b/docs/friction-log.md
@@ -5,6 +5,52 @@ build queue. Priority when picking work: **breakage > friction in features
 actually used > ideas that recur across ≥2 sessions**. Tag entries `[app]`
 (dogfooding the product) or `[dev]` (workflow/tooling). Newest first.
 
+## 2026-08-17 — "What to wear & pack" never said what to pack
+
+- **[app] Friction → fixed:** on the 8-city Europe trip the sheet opened as
+  **sixteen lines of prose** — one two-line paragraph per city, "Mild — light
+  layers", "Warm — summer clothes, a light evening layer", four times over —
+  and never answered the question its own title asks. The reader had to hold
+  eight phrasings in their head and do the union themselves: *three of these
+  say rain, so… umbrella.* The #330 fold was working correctly; the trip
+  genuinely has eight distinct weather stories. **Volume was the problem, not
+  a bug**, which is why the previous fix (merge same-guidance rows) couldn't
+  reach it — there was nothing left to merge.
+- **[app] The summary had to be the union, not a second opinion.** The
+  tempting version writes a fresh trip-level phrase from the raw flags. That
+  gives you two derivations of one thing, and the day the header says
+  "umbrella" while no visible row says rain, nobody can tell which is wrong.
+  Instead `packEssentials` iterates **`groupWearRegions`** — the exact list
+  the rows render — and maps each displayed phrase to the objects it asks for.
+  Every suggestion is backed by a visible row and every row contributes at
+  least one suggestion, which is what makes collapsing the detail behind
+  "City by city" lossless rather than lossy. Same rule that moved
+  `effectiveAdvisories` widget→util in #330, one level up.
+- **[app] What a row promises decides where it can hide.** The historical
+  footnote ("ranges show typical weather for these dates") qualifies the
+  **header's** temperature envelope as much as the rows', so putting it inside
+  the collapsible would have let the numbers make a forecast claim they can't
+  back, one tap away from the correction. It renders outside the disclosure
+  and is pinned that way. Corollary the other direction: with one displayed
+  group the detail adds only its dates — the envelope is already in the header
+  — so there is no disclosure at all rather than a tap that buys nothing.
+- **[dev] A "nothing is a no-op" loop is a claim you have to check per case.**
+  First draft of the advisory test asserted that every `WearAdvisory` adds an
+  essential *over the mild band*. `bigSwing` ("big day–night range, bring
+  layers") maps to the same light layer `mild` already yields, so it failed —
+  correctly. The honest form pairs each advisory with a band that does **not**
+  already imply its object, and the overlap gets its own test saying so: one
+  object, one row, the union is idempotent. A green universal loop here would
+  have meant the table was wrong, not that the code was right.
+- **[dev] A fixture keyed on a derivation restates the derivation.** The
+  wear tests' weather fake keys on `'<city>|<startDate>'`, and *startDate* is
+  the **visible** leg range — so a new two-city fixture with the obvious dates
+  silently resolved one leg to an empty report, folded the trip to a single
+  group, and failed two tests for a reason that had nothing to do with them.
+  Tests about what the sheet SAYS now use a city-keyed fake; the one test that
+  is genuinely about windows keeps the city|date fake and stays the only
+  place that spelling appears.
+
 ## 2026-08-17 — Trip Health argued with the checklist
 
 - **[app] Friction → fixed:** *"It says I don't have lodging booked for days

--- a/specs/what-to-wear/plan.md
+++ b/specs/what-to-wear/plan.md
@@ -174,3 +174,48 @@ tests: `trip_detail_wear_section_test.dart` reworked to the icon/sheet
 surface + new cases (Escape, breakpoints, live pill, Budget-view icon),
 `trip_detail_fix_actions_test.dart` layout contract, `checklist_section_test.dart`
 callback form, `trip_detail_filter_lenses_test.dart` comment.
+
+## Amendment 2026-08-17 — summary first, city detail behind a disclosure
+
+Client-only again; **`trip_detail_screen.dart` is untouched** (`_wearState` /
+`_legClothingRecs` already hand the sheet a `List<WearRegionRec>` and
+`showWearPackSheet`'s signature is unchanged), so the lane never contended for
+the god file.
+
+- **`lib/utils/clothing_recs.dart`** — the derivation stays in one place:
+  `enum PackEssential` (declaration order IS render order — nothing sorts, so
+  Dart's sub-32 insertion-sort fallback can't make an ordering test vacuous),
+  `essentialsFor(TempBand, Set<WearAdvisory>)` mapping each rendered phrase to
+  the objects it asks for, `typedef PackItem`, and `packEssentials(regions)`
+  built by iterating **`groupWearRegions`** — the exact list `WearRecsList`
+  renders. That is what makes the collapse lossless, and it is pinned by a
+  test asserting set-equality between the summary and the union over the
+  groups. `PackItem.everyStop` counts contributing GROUPS, not labels: a
+  merged run is one stop's worth of guidance however many cities it names.
+  `anyHistorical(regions)` hoists the footnote gate out of the widget (equal
+  to `groups.any((g) => g.historical)` because groups partition the regions
+  and OR the flag).
+- **`lib/widgets/wear_recs.dart`** — new `PackEssentialsList` (muted 18px
+  leading glyph, object over its attribution). `rainGear`/`sunProtection`
+  reuse the day chip's `Icons.umbrella`/`Icons.wb_sunny` so the two surfaces
+  share one vocabulary. `WearRecsList` loses its footnote block and is
+  otherwise unchanged.
+- **`lib/widgets/wear_pack_sheet.dart`** — `WearPackSheetBody` becomes a
+  `ConsumerStatefulWidget` owning `_cityDetailOpen` (`CollapsibleSection`
+  requires the parent to own `expanded`; route-scoped, and reopening the sheet
+  is meant to start closed). Order: header · muted `wearPackTitle` label ·
+  `PackEssentialsList` · footnote · disclosure-or-inline rows · divider ·
+  checklist. `groupWearRegions(regions).length < 2` renders the rows inline.
+  `regions.isEmpty` (the Next Step `add_packing` entry, offline, undated) keeps
+  today's checklist-only body verbatim.
+- **l10n:** ten `wear*` keys in `app_en.arb` + `app_es.arb`.
+- **Tests:** `clothing_recs_test.dart` gains `essentialsFor` (band table,
+  per-advisory table, and the idempotence of an advisory that restates its
+  band — "bring layers" on a mild leg is the same light layer, one row not
+  two), `packEssentials` (union invariant, fixed order under reversal,
+  attribution + revisit dedupe, group-not-city `everyStop`) and `anyHistorical`.
+  `trip_detail_wear_section_test.dart` gains `_inSheet`/`_inPack` finders and
+  a `_CityWeatherApiService` (keyed by city, so tests about what the sheet SAYS
+  don't restate the visible-range derivation the revisited-city test pins),
+  plus cases for the summary, collapsed-by-default, footnote-visible-while-
+  collapsed, and the one-group inline rule.

--- a/specs/what-to-wear/spec.md
+++ b/specs/what-to-wear/spec.md
@@ -31,8 +31,19 @@ when the old row did (no resolved checklist and no leg with weather).
 Weather regions are a press-time snapshot; the checklist stays live inside
 the sheet.
 
+Amended 2026-08-17 (friction log, direction picked by Brian): the sheet leads
+with a **trip-level packing summary** — the objects to bring — and the per-city
+guidance rows move behind a collapsed "City by city" disclosure. On an
+eight-city trip the rows opened as sixteen lines of prose and never answered
+"what goes in the bag"; the reader had to do the union themselves. The summary
+IS that union, computed from the same displayed groups, so collapsing the
+detail loses nothing.
+
 ## User Stories
 
+- As a **traveler about to pack**, I want **one short list of what to bring for
+  the whole trip** so that **I can fill a bag without reading a paragraph per
+  city and doing the union in my head**.
 - As a **traveler planning a trip**, I want **to see what kind of clothes suit
   each region during my dates** so that **I can pack right without researching
   climate myself**.
@@ -49,6 +60,21 @@ the sheet.
       cross-region temperature envelope and rain signal (e.g. "21°–31° ·
       rain likely"). *(2026-08-13: was the trailing-cluster row's collapsed
       summary.)*
+- [ ] *(2026-08-17)* Under the header, the sheet leads with **one row per thing
+      to pack**: a muted icon, the object, and the stops that ask for it —
+      "every stop" when every displayed group does. The set is the UNION of
+      what the per-city rows say, mapped object-by-object from the same band
+      phrase and surviving advisories (`essentialsFor`), so every suggestion is
+      backed by a visible row and every row contributes at least one
+      suggestion. Rows render in a fixed order, never a sorted one.
+- [ ] *(2026-08-17)* The per-city guidance sits behind a collapsed **"City by
+      city"** disclosure and is byte-identical to what it was when expanded. A
+      trip with only ONE displayed group skips the disclosure and renders that
+      row inline — its only extra fact is its dates, and the envelope is
+      already in the header.
+- [ ] *(2026-08-17)* The historical footnote renders OUTSIDE the disclosure,
+      so it is visible while the detail is closed: it qualifies the header's
+      temperature envelope as much as the rows.
 - [ ] The sheet lists one row per run of consecutive same-guidance
       legs: legs merge when the temperature band and the surviving advisory
       phrases match AND the date ranges are adjacent (≤1 day apart). A row
@@ -122,7 +148,12 @@ is client display only and not part of any server contract).
 
 - Wind, UV, snow, humidity, or condition icons (daily min/max/precip only).
 - Per-day recommendations (per-region granularity only).
-- Auto-adding checklist items from recommendations.
+- Auto-adding checklist items from recommendations — reconfirmed 2026-08-17
+  when the summary made a one-tap "add to checklist" tempting. A truthful
+  "already added" state needs a real identity on `checklist_items`; matching
+  the generated label would make the LABEL the key, the failure migration
+  00064 was written to undo (and 00070's `leg_key` written to avoid). Without
+  it a second tap silently duplicates. Named as the sequel, not smuggled in.
 - Temperature units preference (°C-only today app-wide; noted as a separate
   follow-up this feature makes more visible).
 - Any server-side clothing phrasing (the chat agent already reads raw weather

--- a/src/packages/flutter-app/lib/l10n/app_en.arb
+++ b/src/packages/flutter-app/lib/l10n/app_en.arb
@@ -2611,6 +2611,16 @@
   "wearFreezingNights": "freezing nights, warm layers",
   "wearSummaryRain": "rain likely",
   "wearHistoricalFootnote": "Beyond the 16-day forecast, ranges show typical weather for these dates.",
+  "wearPackTitle": "Pack for this trip",
+  "wearByCityTitle": "City by city",
+  "wearEveryStop": "every stop",
+  "wearPackThermals": "Thermals",
+  "wearPackWarmCoat": "A warm coat, hat, and gloves",
+  "wearPackJacket": "A jacket or warm layer",
+  "wearPackLightLayer": "A light layer for evenings",
+  "wearPackSummerClothes": "Summer clothes",
+  "wearPackRainGear": "An umbrella or rain jacket",
+  "wearPackSunProtection": "Sun protection",
   "rickRollCaption": "Never gonna give you up",
   "@rickRollCaption": {
     "description": "Caption on the Konami-code easter egg. Not translated — it is a song title."

--- a/src/packages/flutter-app/lib/l10n/app_es.arb
+++ b/src/packages/flutter-app/lib/l10n/app_es.arb
@@ -1095,6 +1095,16 @@
   "wearFreezingNights": "noches bajo cero, capas de abrigo",
   "wearSummaryRain": "lluvia probable",
   "wearHistoricalFootnote": "Más allá del pronóstico de 16 días, los rangos muestran el tiempo habitual en estas fechas.",
+  "wearPackTitle": "Qué llevar en este viaje",
+  "wearByCityTitle": "Ciudad por ciudad",
+  "wearEveryStop": "todas las paradas",
+  "wearPackThermals": "Ropa térmica",
+  "wearPackWarmCoat": "Abrigo, gorro y guantes",
+  "wearPackJacket": "Una chaqueta o capa de abrigo",
+  "wearPackLightLayer": "Una capa ligera para la noche",
+  "wearPackSummerClothes": "Ropa de verano",
+  "wearPackRainGear": "Un paraguas o chubasquero",
+  "wearPackSunProtection": "Protección solar",
   "rickRollCaption": "Never gonna give you up",
   "rickRollDismissHint": "toca donde sea para salir"
 }

--- a/src/packages/flutter-app/lib/l10n/app_localizations.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations.dart
@@ -6428,6 +6428,66 @@ abstract class AppLocalizations {
   /// **'Beyond the 16-day forecast, ranges show typical weather for these dates.'**
   String get wearHistoricalFootnote;
 
+  /// No description provided for @wearPackTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Pack for this trip'**
+  String get wearPackTitle;
+
+  /// No description provided for @wearByCityTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'City by city'**
+  String get wearByCityTitle;
+
+  /// No description provided for @wearEveryStop.
+  ///
+  /// In en, this message translates to:
+  /// **'every stop'**
+  String get wearEveryStop;
+
+  /// No description provided for @wearPackThermals.
+  ///
+  /// In en, this message translates to:
+  /// **'Thermals'**
+  String get wearPackThermals;
+
+  /// No description provided for @wearPackWarmCoat.
+  ///
+  /// In en, this message translates to:
+  /// **'A warm coat, hat, and gloves'**
+  String get wearPackWarmCoat;
+
+  /// No description provided for @wearPackJacket.
+  ///
+  /// In en, this message translates to:
+  /// **'A jacket or warm layer'**
+  String get wearPackJacket;
+
+  /// No description provided for @wearPackLightLayer.
+  ///
+  /// In en, this message translates to:
+  /// **'A light layer for evenings'**
+  String get wearPackLightLayer;
+
+  /// No description provided for @wearPackSummerClothes.
+  ///
+  /// In en, this message translates to:
+  /// **'Summer clothes'**
+  String get wearPackSummerClothes;
+
+  /// No description provided for @wearPackRainGear.
+  ///
+  /// In en, this message translates to:
+  /// **'An umbrella or rain jacket'**
+  String get wearPackRainGear;
+
+  /// No description provided for @wearPackSunProtection.
+  ///
+  /// In en, this message translates to:
+  /// **'Sun protection'**
+  String get wearPackSunProtection;
+
   /// Caption on the Konami-code easter egg. Not translated — it is a song title.
   ///
   /// In en, this message translates to:

--- a/src/packages/flutter-app/lib/l10n/app_localizations_en.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations_en.dart
@@ -3890,6 +3890,36 @@ class AppLocalizationsEn extends AppLocalizations {
       'Beyond the 16-day forecast, ranges show typical weather for these dates.';
 
   @override
+  String get wearPackTitle => 'Pack for this trip';
+
+  @override
+  String get wearByCityTitle => 'City by city';
+
+  @override
+  String get wearEveryStop => 'every stop';
+
+  @override
+  String get wearPackThermals => 'Thermals';
+
+  @override
+  String get wearPackWarmCoat => 'A warm coat, hat, and gloves';
+
+  @override
+  String get wearPackJacket => 'A jacket or warm layer';
+
+  @override
+  String get wearPackLightLayer => 'A light layer for evenings';
+
+  @override
+  String get wearPackSummerClothes => 'Summer clothes';
+
+  @override
+  String get wearPackRainGear => 'An umbrella or rain jacket';
+
+  @override
+  String get wearPackSunProtection => 'Sun protection';
+
+  @override
   String get rickRollCaption => 'Never gonna give you up';
 
   @override

--- a/src/packages/flutter-app/lib/l10n/app_localizations_es.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations_es.dart
@@ -3917,6 +3917,36 @@ class AppLocalizationsEs extends AppLocalizations {
       'Más allá del pronóstico de 16 días, los rangos muestran el tiempo habitual en estas fechas.';
 
   @override
+  String get wearPackTitle => 'Qué llevar en este viaje';
+
+  @override
+  String get wearByCityTitle => 'Ciudad por ciudad';
+
+  @override
+  String get wearEveryStop => 'todas las paradas';
+
+  @override
+  String get wearPackThermals => 'Ropa térmica';
+
+  @override
+  String get wearPackWarmCoat => 'Abrigo, gorro y guantes';
+
+  @override
+  String get wearPackJacket => 'Una chaqueta o capa de abrigo';
+
+  @override
+  String get wearPackLightLayer => 'Una capa ligera para la noche';
+
+  @override
+  String get wearPackSummerClothes => 'Ropa de verano';
+
+  @override
+  String get wearPackRainGear => 'Un paraguas o chubasquero';
+
+  @override
+  String get wearPackSunProtection => 'Protección solar';
+
+  @override
   String get rickRollCaption => 'Never gonna give you up';
 
   @override

--- a/src/packages/flutter-app/lib/utils/clothing_recs.dart
+++ b/src/packages/flutter-app/lib/utils/clothing_recs.dart
@@ -7,7 +7,9 @@
 // bands live here, so the chip and the recs can never disagree. The wear
 // rows' advisory suppression and same-guidance grouping live here too
 // ([effectiveAdvisories]/[groupWearRegions]), so the fold compares exactly
-// what the widget renders. The Go trip
+// what the widget renders, and the sheet's trip-level packing summary
+// ([packEssentials]) is derived from those same groups, so collapsing the
+// per-city rows behind a disclosure loses nothing. The Go trip
 // review keeps its own advisory constants (trip_review.go: rainProbPct,
 // rainHistoricMM, hotThresholdC, coldThresholdC) for a different job —
 // exception findings, not banded phrasing. They are deliberately NOT twinned,
@@ -146,9 +148,9 @@ ClothingRec? clothingRec(WeatherReport report) {
   );
 }
 
-/// Cross-region envelope for the collapsed one-liner ("21°–31° · rain
+/// Cross-region envelope for the sheet's header one-liner ("21°–31° · rain
 /// likely"). Kind-neutral by design: the numbers make no forecast claim, so
-/// the "typical" qualifier stays on the expanded per-leg rows.
+/// the "typical" qualifier stays in the footnote.
 ({int loC, int hiC, bool rainLikely}) clothingSummary(List<ClothingRec> recs) {
   assert(recs.isNotEmpty, 'clothingSummary needs at least one rec');
   var lo = recs.first.loC;
@@ -261,4 +263,117 @@ List<WearGroup> groupWearRegions(List<WearRegionRec> regions) {
     ));
   }
   return groups;
+}
+
+/// Whether any displayed row is an archive ("typical") report — the gate for
+/// the sheet's single historical footnote. Reads the regions rather than the
+/// groups deliberately, and the two agree by construction: [groupWearRegions]
+/// partitions the regions and ORs `historical` across each run, so
+/// `groups.any((g) => g.historical)` and this are the same predicate. The
+/// footnote qualifies the header envelope as well as the rows, so it renders
+/// outside the collapsible city detail — hence a gate the sheet can call
+/// without building groups.
+bool anyHistorical(List<WearRegionRec> regions) =>
+    regions.any((r) => r.rec.historical);
+
+/// One thing to put in the bag. The sheet leads with these — the trip-level
+/// answer — and the per-region rows sit behind a disclosure.
+///
+/// Values are in RENDER order (warmest clothing → lightest → weather gear).
+/// [packEssentials] emits by iterating this list, so ordering is fixed at
+/// declaration and nothing sorts: a comparator here would be both redundant
+/// and, under Dart's insertion-sort fallback below 32 elements, untestable.
+enum PackEssential {
+  thermals,
+  warmCoat,
+  jacket,
+  lightLayer,
+  summerClothes,
+  rainGear,
+  sunProtection,
+}
+
+/// The objects a displayed row's phrasing asks for: the band phrase plus each
+/// surviving advisory, re-expressed as things to pack. Every arm is non-empty
+/// (pinned by test), so no rendered row can contribute nothing to the summary.
+///
+/// This is the ONE mapping — read it against the `wearBand*`/`wear*` ARB
+/// strings the rows render (`WearRecsList._phrases`): the cold band says
+/// "warm coat, hat, and gloves", so it yields [PackEssential.warmCoat]. Change
+/// a phrase and change the arm with it, or the summary starts promising
+/// something the detail below it never says.
+Set<PackEssential> essentialsFor(
+  TempBand band,
+  Set<WearAdvisory> advisories,
+) =>
+    {
+      ...switch (band) {
+        TempBand.freezing => {PackEssential.thermals, PackEssential.warmCoat},
+        TempBand.cold => {PackEssential.warmCoat},
+        TempBand.cool => {PackEssential.jacket},
+        TempBand.mild => {PackEssential.lightLayer},
+        TempBand.warm => {
+            PackEssential.summerClothes,
+            PackEssential.lightLayer,
+          },
+        TempBand.hot => {
+            PackEssential.summerClothes,
+            PackEssential.sunProtection,
+          },
+      },
+      for (final a in advisories)
+        ...switch (a) {
+          WearAdvisory.rainLikely => {PackEssential.rainGear},
+          WearAdvisory.extremeHeat => {PackEssential.sunProtection},
+          WearAdvisory.freezingNights => {PackEssential.jacket},
+          WearAdvisory.bigSwing => {PackEssential.lightLayer},
+        },
+    };
+
+/// One summary row: the thing to pack, the stops that ask for it, and whether
+/// that is every stop on the trip (the labels then read as noise — "every
+/// stop" says it shorter and stays true as the itinerary grows).
+typedef PackItem = ({
+  PackEssential essential,
+  List<String> labels,
+  bool everyStop,
+});
+
+/// The trip-level packing answer: the UNION of what the displayed rows already
+/// say, grouped by object instead of by city.
+///
+/// Built by iterating [groupWearRegions] — the exact list `WearRecsList`
+/// renders — so the summary and the city detail behind the disclosure cannot
+/// disagree: every essential here is claimed by at least one visible row, and
+/// every visible row contributes at least one essential (see [essentialsFor]).
+/// That is what makes collapsing the rows lossless.
+///
+/// [PackItem.everyStop] counts contributing GROUPS, not labels: a merged run
+/// is one stop's worth of guidance however many cities it names, so a
+/// two-city group that folded because its guidance is identical must not read
+/// as broader coverage than a single-city one.
+List<PackItem> packEssentials(List<WearRegionRec> regions) {
+  final groups = groupWearRegions(regions);
+  final labelsBy = <PackEssential, List<String>>{};
+  final groupsBy = <PackEssential, int>{};
+  for (final g in groups) {
+    for (final e in essentialsFor(g.band, g.advisories)) {
+      final labels = labelsBy.putIfAbsent(e, () => <String>[]);
+      for (final label in g.labels) {
+        // Itinerary order, deduped — a revisited city must not read
+        // "Paris, Paris" (the [groupWearRegions] label rule).
+        if (!labels.contains(label)) labels.add(label);
+      }
+      groupsBy[e] = (groupsBy[e] ?? 0) + 1;
+    }
+  }
+  return [
+    for (final e in PackEssential.values)
+      if (labelsBy[e] case final labels?)
+        (
+          essential: e,
+          labels: labels,
+          everyStop: groupsBy[e] == groups.length,
+        ),
+  ];
 }

--- a/src/packages/flutter-app/lib/widgets/wear_pack_sheet.dart
+++ b/src/packages/flutter-app/lib/widgets/wear_pack_sheet.dart
@@ -6,6 +6,7 @@ import '../providers/checklist_provider.dart';
 import '../theme/spacing.dart';
 import '../utils/clothing_recs.dart';
 import 'checklist_section.dart';
+import 'collapsible_section.dart';
 import 'status_pill.dart';
 import 'wear_recs.dart';
 
@@ -75,11 +76,16 @@ Future<void> showWearPackSheet(
   );
 }
 
-/// The sheet body: a header line (title · summary · checked-count pill) over
-/// the per-leg guidance rows and the live checklist — the same composition
-/// the old collapsed-section row expanded to. Public so tests can scope
-/// finders to the sheet.
-class WearPackSheetBody extends ConsumerWidget {
+/// The sheet body: a header line (title · summary · checked-count pill), then
+/// the trip-level packing answer, then the per-region guidance behind a
+/// "City by city" disclosure, then the live checklist. Public so tests can
+/// scope finders to the sheet.
+///
+/// Leading with the summary is the 2026-08-17 amendment: on an eight-city trip
+/// the per-region rows opened as sixteen lines of prose and left the reader to
+/// work out the union themselves. [packEssentials] does that union from the
+/// same groups [WearRecsList] renders, so the detail collapses losslessly.
+class WearPackSheetBody extends ConsumerStatefulWidget {
   final String tripId;
   final List<WearRegionRec> regions;
   final bool canEdit;
@@ -97,7 +103,20 @@ class WearPackSheetBody extends ConsumerWidget {
   });
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<WearPackSheetBody> createState() => _WearPackSheetBodyState();
+}
+
+class _WearPackSheetBodyState extends ConsumerState<WearPackSheetBody> {
+  /// [CollapsibleSection] requires the parent to own this. Route-scoped here —
+  /// the sheet body never reparents, and reopening the sheet is meant to start
+  /// closed again, so there is nothing to lift higher.
+  bool _cityDetailOpen = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final tripId = widget.tripId;
+    final regions = widget.regions;
+    final canEdit = widget.canEdit;
     final theme = Theme.of(context);
     final l10n = context.l10n;
     final items = ref.watch(checklistProvider(tripId)).valueOrNull;
@@ -108,8 +127,8 @@ class WearPackSheetBody extends ConsumerWidget {
     if (regions.isEmpty && !showChecklist) return const SizedBox.shrink();
     final checked = items?.where((i) => i.checked).length ?? 0;
     // Header one-liner: the cross-region temperature envelope plus the rain
-    // signal — kind-neutral by design, the "typical" qualifier lives in
-    // [WearRecsList]'s single footnote. Spaced dash like the date ranges
+    // signal — kind-neutral by design, the "typical" qualifier lives in the
+    // single footnote below the summary. Spaced dash like the date ranges
     // ("Sep 15 – Sep 20"), so a negative low never collides with it
     // ("-6° – 2°"). Without weather, the checked-count summary stands in.
     final String summary;
@@ -151,12 +170,61 @@ class WearPackSheetBody extends ConsumerWidget {
           ],
         ),
         const SizedBox(height: AppSpacing.sm),
-        if (regions.isNotEmpty) WearRecsList(regions: regions),
+        if (regions.isNotEmpty) ...[
+          Padding(
+            padding: const EdgeInsets.only(bottom: AppSpacing.xs),
+            child: Text(
+              l10n.wearPackTitle,
+              // Muted labelLarge section label — the city_events_sheet group
+              // header treatment, which is what keeps this read-only block
+              // visibly distinct from the editable checklist below it.
+              style: theme.textTheme.labelLarge?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ),
+          PackEssentialsList(regions: regions),
+          // Outside the disclosure on purpose: this qualifies the header's
+          // temperature envelope as much as the rows, so it can't hide behind
+          // a tap (specs/what-to-wear, the "framed as typical" story).
+          if (anyHistorical(regions))
+            Padding(
+              padding: const EdgeInsets.only(bottom: AppSpacing.sm),
+              child: Text(
+                // Italic+muted only — the _weatherChip qualifier treatment.
+                l10n.wearHistoricalFootnote,
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                  fontStyle: FontStyle.italic,
+                ),
+              ),
+            ),
+          // One displayed group means the detail adds only its dates — the
+          // envelope is already in the header — so a disclosure would be a tap
+          // charged for nothing. Render it inline instead.
+          //
+          // Grouping is recomputed rather than threaded through: it is pure
+          // and runs over a handful of legs, and passing groups down would
+          // cost [WearRecsList] and [PackEssentialsList] the regions-in
+          // contract that keeps them display-only.
+          if (groupWearRegions(regions).length < 2)
+            WearRecsList(regions: regions)
+          else
+            CollapsibleSection(
+              title: l10n.wearByCityTitle,
+              icon: Icons.location_on_outlined,
+              expanded: _cityDetailOpen,
+              onToggle: () =>
+                  setState(() => _cityDetailOpen = !_cityDetailOpen),
+              child: WearRecsList(regions: regions),
+            ),
+        ],
         if (regions.isNotEmpty && showChecklist) const Divider(height: 24),
         ChecklistSection(
           tripId: tripId,
           canEdit: canEdit,
-          isOffline: isOffline,
+          isOffline: widget.isOffline,
           showHeader: false,
         ),
       ],

--- a/src/packages/flutter-app/lib/widgets/wear_recs.dart
+++ b/src/packages/flutter-app/lib/widgets/wear_recs.dart
@@ -5,15 +5,19 @@ import '../l10n/l10n.dart';
 import '../theme/spacing.dart';
 import '../utils/clothing_recs.dart';
 
-/// The what-to-wear block at the top of the merged "What to wear & pack"
-/// section (specs/what-to-wear): consecutive same-guidance regions fold into
-/// one row ([groupWearRegions]) — a muted "Prague, Kraków · Aug 24 – Sep 1 ·
-/// 15°–27°" line followed by the deterministic clothing phrase. When any
-/// displayed region is historical, ONE italic footnote after the rows says
-/// the ranges are typical rather than a forecast — the old per-row qualifier
-/// read as repetition. Display-only: the trip screen builds the
-/// [WearRegionRec]s from its own weather watches (collapsed-row summaries
-/// must be fed by the parent).
+/// The city-by-city detail inside the "What to wear & pack" sheet
+/// (specs/what-to-wear): consecutive same-guidance regions fold into one row
+/// ([groupWearRegions]) — a muted "Prague, Kraków · Aug 24 – Sep 1 · 15°–27°"
+/// line followed by the deterministic clothing phrase.
+///
+/// These rows sit behind a collapsed disclosure; [PackEssentialsList] carries
+/// the trip-level answer above it. The historical footnote is NOT here: it
+/// qualifies the sheet header's temperature envelope too, so hiding it behind
+/// the same tap would let the numbers make a forecast claim they can't back.
+/// The sheet owns it (gate: [anyHistorical]).
+///
+/// Display-only: the trip screen builds the [WearRegionRec]s from its own
+/// weather watches and passes a press-time snapshot.
 class WearRecsList extends StatelessWidget {
   final List<WearRegionRec> regions;
 
@@ -90,16 +94,94 @@ class WearRecsList extends StatelessWidget {
               ],
             ),
           ),
-        if (groups.any((g) => g.historical))
+      ],
+    );
+  }
+}
+
+/// The trip-level packing answer at the top of the sheet: one row per thing to
+/// bring, with the stops that ask for it. Reads [packEssentials], which is the
+/// union over the very groups [WearRecsList] renders below — so this list can
+/// never promise something the city detail doesn't say, nor drop something it
+/// does.
+///
+/// Read-only by design (specs/what-to-wear amendment 2026-08-17): these are a
+/// derivation, the checklist under them is the traveler's own state, and
+/// nothing here writes into it.
+class PackEssentialsList extends StatelessWidget {
+  final List<WearRegionRec> regions;
+
+  const PackEssentialsList({super.key, required this.regions});
+
+  /// Muted 18px leading glyph — the [CollapsibleSection] row convention.
+  /// [PackEssential.rainGear] and [PackEssential.sunProtection] deliberately
+  /// reuse the day chip's rain/sun glyphs (`_weatherGlyph`) so the two
+  /// surfaces read as one vocabulary.
+  IconData _iconFor(PackEssential e) => switch (e) {
+        PackEssential.thermals => Icons.thermostat,
+        PackEssential.warmCoat => Icons.ac_unit,
+        PackEssential.jacket => Icons.dry_cleaning_outlined,
+        PackEssential.lightLayer => Icons.layers_outlined,
+        PackEssential.summerClothes => Icons.checkroom,
+        PackEssential.rainGear => Icons.umbrella,
+        PackEssential.sunProtection => Icons.wb_sunny,
+      };
+
+  /// Pure l10n mapping — which essentials a region earns lives in
+  /// [essentialsFor], next to the band phrases these echo.
+  String _labelFor(AppLocalizations l10n, PackEssential e) => switch (e) {
+        PackEssential.thermals => l10n.wearPackThermals,
+        PackEssential.warmCoat => l10n.wearPackWarmCoat,
+        PackEssential.jacket => l10n.wearPackJacket,
+        PackEssential.lightLayer => l10n.wearPackLightLayer,
+        PackEssential.summerClothes => l10n.wearPackSummerClothes,
+        PackEssential.rainGear => l10n.wearPackRainGear,
+        PackEssential.sunProtection => l10n.wearPackSunProtection,
+      };
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final l10n = context.l10n;
+    final muted = theme.colorScheme.onSurfaceVariant;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        for (final item in packEssentials(regions))
           Padding(
             padding: const EdgeInsets.only(bottom: AppSpacing.sm),
-            child: Text(
-              // Italic+muted only — the _weatherChip qualifier treatment.
-              l10n.wearHistoricalFootnote,
-              style: theme.textTheme.bodyMedium?.copyWith(
-                color: muted,
-                fontStyle: FontStyle.italic,
-              ),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Padding(
+                  // Optical nudge onto the label's first line, which is
+                  // taller than the glyph.
+                  padding: const EdgeInsets.only(top: 2),
+                  child: Icon(_iconFor(item.essential), size: 18, color: muted),
+                ),
+                const SizedBox(width: AppSpacing.sm),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        _labelFor(l10n, item.essential),
+                        style: theme.textTheme.bodyMedium,
+                      ),
+                      Text(
+                        // Plain ', ' join — locale-safe with no conjunction,
+                        // the same rule as the row labels above.
+                        item.everyStop
+                            ? l10n.wearEveryStop
+                            : item.labels.join(', '),
+                        maxLines: 2,
+                        overflow: TextOverflow.ellipsis,
+                        style: theme.textTheme.bodySmall?.copyWith(color: muted),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
             ),
           ),
       ],

--- a/src/packages/flutter-app/test/clothing_recs_test.dart
+++ b/src/packages/flutter-app/test/clothing_recs_test.dart
@@ -330,6 +330,187 @@ void main() {
       expect((g.loC, g.hiC), (15, 26));
     });
   });
+
+  group('essentialsFor', () {
+    test('every band asks for something', () {
+      for (final band in TempBand.values) {
+        expect(essentialsFor(band, const {}), isNotEmpty,
+            reason: '$band contributes nothing to the summary');
+      }
+    });
+
+    test('the band table matches the phrases the rows render', () {
+      expect(essentialsFor(TempBand.freezing, const {}),
+          {PackEssential.thermals, PackEssential.warmCoat});
+      expect(essentialsFor(TempBand.cold, const {}), {PackEssential.warmCoat});
+      expect(essentialsFor(TempBand.cool, const {}), {PackEssential.jacket});
+      expect(essentialsFor(TempBand.mild, const {}), {PackEssential.lightLayer});
+      expect(essentialsFor(TempBand.warm, const {}),
+          {PackEssential.summerClothes, PackEssential.lightLayer});
+      expect(essentialsFor(TempBand.hot, const {}),
+          {PackEssential.summerClothes, PackEssential.sunProtection});
+    });
+
+    test('every advisory contributes its object', () {
+      // Paired with a band that does NOT already imply it, so each row proves
+      // the advisory arm rather than the band's.
+      const table = {
+        WearAdvisory.rainLikely: (TempBand.mild, PackEssential.rainGear),
+        WearAdvisory.extremeHeat: (TempBand.mild, PackEssential.sunProtection),
+        WearAdvisory.freezingNights: (TempBand.mild, PackEssential.jacket),
+        WearAdvisory.bigSwing: (TempBand.hot, PackEssential.lightLayer),
+      };
+      expect(table.keys, WearAdvisory.values.toSet(),
+          reason: 'a new advisory needs a row here');
+      table.forEach((advisory, expected) {
+        final (band, essential) = expected;
+        final bare = essentialsFor(band, const {});
+        expect(bare, isNot(contains(essential)),
+            reason: 'pick a band that does not already imply $essential');
+        expect(essentialsFor(band, {advisory}), containsAll([...bare, essential]));
+      });
+    });
+
+    test('an advisory restating the band is idempotent, not a second row', () {
+      // "big day–night range, bring layers" on a mild leg asks for the same
+      // light layer "Mild — light layers" already does. One object, one row —
+      // the union is what the summary shows.
+      expect(essentialsFor(TempBand.mild, {WearAdvisory.bigSwing}),
+          essentialsFor(TempBand.mild, const {}));
+    });
+  });
+
+  group('packEssentials', () {
+    // The screenshot trip that prompted the summary: eight distinct stories,
+    // none of which fold.
+    List<WearRegionRec> europeTrip() => [
+          region('Amsterdam', '2026-08-24', '2026-08-26',
+              rec(band: TempBand.mild, lo: 13, hi: 22)),
+          region('Prague', '2026-08-26', '2026-08-29', rec(lo: 17, hi: 27)),
+          region('Kraków', '2026-08-29', '2026-09-04',
+              rec(lo: 15, hi: 32, rainLikely: true, bigSwing: true)),
+          region('Copenhagen', '2026-09-04', '2026-09-07',
+              rec(band: TempBand.mild, lo: 13, hi: 23, rainLikely: true)),
+          region('Berlin', '2026-09-07', '2026-09-10',
+              rec(band: TempBand.mild, lo: 12, hi: 24)),
+          region('Gothenburg', '2026-09-10', '2026-09-13',
+              rec(band: TempBand.mild, lo: 11, hi: 22, rainLikely: true)),
+          region('Sorrento', '2026-09-13', '2026-09-18', rec(lo: 18, hi: 28)),
+          region('Rome', '2026-09-18', '2026-09-22',
+              rec(band: TempBand.hot, lo: 19, hi: 32, bigSwing: true)),
+        ];
+
+    test('is exactly the union of what the displayed rows say', () {
+      final regions = europeTrip();
+      final groups = groupWearRegions(regions);
+      expect(groups, hasLength(8), reason: 'fixture must not fold');
+
+      final fromRows = <PackEssential>{
+        for (final g in groups) ...essentialsFor(g.band, g.advisories),
+      };
+      final summary =
+          packEssentials(regions).map((i) => i.essential).toSet();
+      expect(summary, fromRows);
+    });
+
+    test('renders in PackEssential order, whatever the itinerary order', () {
+      final forward = packEssentials(europeTrip()).map((i) => i.essential);
+      expect(forward, [
+        PackEssential.lightLayer,
+        PackEssential.summerClothes,
+        PackEssential.rainGear,
+        PackEssential.sunProtection,
+      ]);
+      // Reversing the trip reverses the labels, never the row order.
+      final reversed =
+          packEssentials(europeTrip().reversed.toList()).map((i) => i.essential);
+      expect(reversed, forward);
+    });
+
+    test('attributes each object to its stops, in itinerary order', () {
+      final items = {
+        for (final i in packEssentials(europeTrip())) i.essential: i,
+      };
+      expect(items[PackEssential.summerClothes]!.labels,
+          ['Prague', 'Kraków', 'Sorrento', 'Rome']);
+      expect(items[PackEssential.rainGear]!.labels,
+          ['Kraków', 'Copenhagen', 'Gothenburg']);
+      expect(items[PackEssential.sunProtection]!.labels, ['Rome']);
+    });
+
+    test('everyStop only when every displayed group asks for it', () {
+      final items = {
+        for (final i in packEssentials(europeTrip())) i.essential: i,
+      };
+      // Every band on this trip wants a light layer; nothing else does.
+      expect(items[PackEssential.lightLayer]!.everyStop, isTrue);
+      expect(items[PackEssential.summerClothes]!.everyStop, isFalse);
+      expect(items[PackEssential.rainGear]!.everyStop, isFalse);
+    });
+
+    test('everyStop counts GROUPS, not cities — a merged run is one', () {
+      // Two mild+rain legs fold into one group; the lone hot leg is the other.
+      // Rain covers 2 of 3 cities but only 1 of 2 displayed rows.
+      final regions = [
+        region('Bergen', '2026-09-01', '2026-09-04',
+            rec(band: TempBand.mild, rainLikely: true)),
+        region('Ålesund', '2026-09-04', '2026-09-07',
+            rec(band: TempBand.mild, rainLikely: true)),
+        region('Seville', '2026-09-09', '2026-09-13', rec(band: TempBand.hot)),
+      ];
+      expect(groupWearRegions(regions), hasLength(2));
+      final items = {
+        for (final i in packEssentials(regions)) i.essential: i,
+      };
+      expect(items[PackEssential.rainGear]!.everyStop, isFalse);
+      expect(items[PackEssential.rainGear]!.labels, ['Bergen', 'Ålesund']);
+      expect(items[PackEssential.summerClothes]!.labels, ['Seville']);
+    });
+
+    test('a revisited city is named once', () {
+      final items = packEssentials([
+        region('Paris', '2026-09-15', '2026-09-17', rec(rainLikely: true)),
+        region('Nice', '2026-09-17', '2026-09-20', rec(band: TempBand.hot)),
+        region('Paris', '2026-09-20', '2026-09-22', rec(rainLikely: true)),
+      ]);
+      final rain =
+          items.firstWhere((i) => i.essential == PackEssential.rainGear);
+      expect(rain.labels, ['Paris']);
+    });
+
+    test('a cold trip asks for the cold things', () {
+      final items = packEssentials([
+        region('Tromsø', '2026-01-05', '2026-01-09',
+            rec(band: TempBand.freezing, lo: -12, hi: -3, freezingNights: true)),
+      ]).map((i) => i.essential);
+      // freezingNights is suppressed on a freezing band, so no jacket row —
+      // the coat already said it.
+      expect(items, [PackEssential.thermals, PackEssential.warmCoat]);
+    });
+
+    test('empty in, empty out', () {
+      expect(packEssentials([]), isEmpty);
+    });
+  });
+
+  group('anyHistorical', () {
+    test('agrees with the grouped rows it gates the footnote for', () {
+      for (final regions in [
+        <WearRegionRec>[],
+        [region('Prague', '2026-08-24', '2026-08-27', rec())],
+        [
+          region('Prague', '2026-08-24', '2026-08-27', rec()),
+          region('Lisbon', '2026-09-10', '2026-09-14', rec(historical: true)),
+        ],
+        [region('Lisbon', '2026-09-10', '2026-09-14', rec(historical: true))],
+      ]) {
+        expect(
+          anyHistorical(regions),
+          groupWearRegions(regions).any((g) => g.historical),
+        );
+      }
+    });
+  });
 }
 
 /// Direct [ClothingRec] builder for grouping tests — grouping consumes the

--- a/src/packages/flutter-app/test/trip_detail_wear_section_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_wear_section_test.dart
@@ -22,18 +22,23 @@ import 'package:travel_route_planner/widgets/wear_recs.dart';
 
 import 'support/l10n_test_app.dart';
 
-/// "What to wear & pack" (specs/what-to-wear), now an app-bar luggage icon
-/// opening a modal sheet (the Trip health precedent): the sheet header shows
-/// the cross-region temperature envelope + rain signal and the checked/total
-/// pill; the body is deterministic phrase rows above the intact checklist,
-/// with consecutive same-guidance legs folded into ONE grouped row
-/// (groupWearRegions); historical data yields a single trailing footnote,
-/// never a per-row qualifier; a revisited city keeps per-visit weather
-/// queries (distinct guidance keeps its rows separate); a leg whose report is
-/// empty drops out without hiding the icon; recommendations alone show the
-/// icon for read-only viewers; without weather the old checklist gating
-/// holds. The checklist stays LIVE inside the sheet (its provider), while
-/// the regions are a press-time snapshot.
+/// "What to wear & pack" (specs/what-to-wear), an app-bar luggage icon opening
+/// a modal sheet (the Trip health precedent): the sheet header shows the
+/// cross-region temperature envelope + rain signal and the checked/total pill;
+/// the body LEADS with the trip-level packing summary (packEssentials —
+/// objects, attributed to the stops that ask for them, "every stop" when that
+/// is all of them) and puts the deterministic per-city phrase rows behind a
+/// collapsed "City by city" disclosure, above the intact checklist.
+///
+/// Invariants pinned here: consecutive same-guidance legs fold into ONE
+/// grouped row (groupWearRegions), and a trip with only one such group skips
+/// the disclosure entirely; the historical footnote renders ONCE and stays
+/// OUTSIDE the disclosure (it qualifies the header envelope too), never as a
+/// per-row qualifier; a revisited city keeps per-visit weather queries; a leg
+/// whose report is empty drops out without hiding the icon; recommendations
+/// alone show the icon for read-only viewers; without weather the old
+/// checklist gating holds. The checklist stays LIVE inside the sheet (its
+/// provider), while the regions are a press-time snapshot.
 
 class _FakeTripsApiService extends TripsApiService {
   final Trip trip;
@@ -71,6 +76,20 @@ class _MapWeatherApiService extends WeatherApiService {
     calls.add(key);
     return byKey[key] ?? const WeatherReport();
   }
+}
+
+/// Per-CITY reports, whatever window is asked for. The visible-range windows
+/// are pinned by the revisited-city test above; tests about what the sheet
+/// SAYS use this so they don't restate that derivation in their fixture keys.
+class _CityWeatherApiService extends WeatherApiService {
+  final Map<String, WeatherReport> byCity;
+  _CityWeatherApiService(this.byCity)
+      : super(ApiClient(baseUrl: 'http://test'));
+
+  @override
+  Future<WeatherReport> getTripWeather(String city, String startDate,
+          {String? endDate}) async =>
+      byCity[city] ?? const WeatherReport();
 }
 
 class _FakeChecklistApiService extends ChecklistApiService {
@@ -197,10 +216,31 @@ Future<void> _openSheet(WidgetTester tester,
   await tester.pumpAndSettle();
 }
 
-/// Finder scoped to the wear block, so day-chip text (which shares strings
+/// Finder scoped to the per-city rows, so day-chip text (which shares strings
 /// like the "typical" qualifier) can never satisfy a wear-row assertion.
 Finder _inRecs(String text) => find.descendant(
     of: find.byType(WearRecsList), matching: find.textContaining(text));
+
+/// Finder scoped to the sheet as a whole — for the summary rows and the
+/// footnote, which live OUTSIDE [WearRecsList] (the footnote qualifies the
+/// header envelope too, so it must not hide behind the disclosure).
+Finder _inSheet(String text) => find.descendant(
+    of: find.byType(WearPackSheetBody), matching: find.textContaining(text));
+
+/// Finder scoped to the summary rows only, so a per-city phrase can never
+/// stand in for a packing suggestion.
+Finder _inPack(String text) => find.descendant(
+    of: find.byType(PackEssentialsList), matching: find.textContaining(text));
+
+Finder _cityDetailRow({String title = 'City by city'}) => find.text(title);
+
+/// Opens the collapsed per-city detail. Only present on trips with two or
+/// more displayed groups — a single group renders its row inline.
+Future<void> _expandCityDetail(WidgetTester tester,
+    {String title = 'City by city'}) async {
+  await tester.tap(_cityDetailRow(title: title));
+  await tester.pumpAndSettle();
+}
 
 Finder _sheetDividers() => find.descendant(
     of: find.byType(WearPackSheetBody), matching: find.byType(Divider));
@@ -256,7 +296,7 @@ void main() {
     expect(_inRecs('typical for these dates'), findsNothing);
     expect(_inRecs('big day–night range'), findsNothing);
     // All-forecast trip: no historical footnote either.
-    expect(_inRecs('Beyond the 16-day forecast'), findsNothing);
+    expect(_inSheet('Beyond the 16-day forecast'), findsNothing);
     // Recs and checklist both present → exactly one separating divider.
     expect(_sheetDividers(), findsOneWidget);
     // The checklist renders below, still editable: item row + add field.
@@ -283,7 +323,7 @@ void main() {
     // wearHistoricalFootnote says "typical weather for these dates" so the
     // footnote can never satisfy this substring by accident.
     expect(_inRecs('typical for these dates'), findsNothing);
-    expect(_inRecs('Beyond the 16-day forecast'), findsOneWidget);
+    expect(_inSheet('Beyond the 16-day forecast'), findsOneWidget);
     // Dry historical days: no rain phrase, summary has no rain suffix.
     expect(find.textContaining('rain likely'), findsNothing);
     expect(find.text('17° – 27°'), findsOneWidget);
@@ -317,6 +357,8 @@ void main() {
       weather: weather,
     );
     await _openSheet(tester);
+    // Three distinct groups → the rows live behind the disclosure.
+    await _expandCityDetail(tester);
 
     // Two Paris rows with their own visit windows and temps, Nice between.
     // Displayed dates AND the weather queries are both the VISIBLE ranges
@@ -362,7 +404,7 @@ void main() {
         _inRecs('Paris, Nice · Sep 15 – Sep 16 · 15° – 24°'), findsOneWidget);
     expect(_inRecs('Warm — summer clothes, a light evening layer'),
         findsOneWidget);
-    expect(_inRecs('Beyond the 16-day forecast'), findsNothing);
+    expect(_inSheet('Beyond the 16-day forecast'), findsNothing);
     // The display merged, but weather stayed per-leg.
     expect(weather.calls, contains('Paris|2026-09-15'));
     expect(weather.calls, contains('Nice|2026-09-15'));
@@ -393,7 +435,7 @@ void main() {
     expect(
         _inRecs('Paris, Nice · Sep 15 – Sep 16 · 15° – 24°'), findsOneWidget);
     expect(
-        _inRecs('Beyond the 16-day forecast, ranges show typical weather'
+        _inSheet('Beyond the 16-day forecast, ranges show typical weather'
             ' for these dates.'),
         findsOneWidget);
     expect(_inRecs('typical for these dates'), findsNothing);
@@ -571,6 +613,137 @@ void main() {
     expect(find.text('15° – 24° · rain likely'), findsOneWidget);
   });
 
+  testWidgets('the summary leads with the objects, attributed to their stops',
+      (tester) async {
+    // Four cities, four distinct stories — the shape that made the old sheet
+    // sixteen lines of prose. Rain hits two of them; only Rome is hot.
+    final weather = _CityWeatherApiService({
+      'Amsterdam': const WeatherReport(kind: 'forecast', days: [
+        WeatherDay(date: '2026-09-15', tempMinC: 13, tempMaxC: 22),
+      ]),
+      'Kraków': const WeatherReport(kind: 'forecast', days: [
+        WeatherDay(
+            date: '2026-09-16',
+            tempMinC: 15,
+            tempMaxC: 27,
+            precipProbability: 80),
+      ]),
+      'Gothenburg': const WeatherReport(kind: 'forecast', days: [
+        WeatherDay(
+            date: '2026-09-17',
+            tempMinC: 11,
+            tempMaxC: 20,
+            precipProbability: 90),
+      ]),
+      'Rome': const WeatherReport(kind: 'forecast', days: [
+        WeatherDay(date: '2026-09-18', tempMinC: 19, tempMaxC: 32),
+      ]),
+    });
+    await _pump(
+      tester,
+      trip: _trip(endDate: '2026-09-19', items: [
+        _item(0, 'Rijksmuseum', 1, city: 'Amsterdam'),
+        _item(1, 'Wawel', 2, city: 'Kraków'),
+        _item(2, 'Haga', 3, city: 'Gothenburg'),
+        _item(3, 'Forum', 4, city: 'Rome'),
+      ]),
+      weather: weather,
+    );
+    await _openSheet(tester);
+
+    expect(_inSheet('Pack for this trip'), findsOneWidget);
+    // Every band here wants a light layer, so it collapses to "every stop"
+    // rather than naming all four.
+    expect(_inPack('A light layer for evenings'), findsOneWidget);
+    expect(_inPack('every stop'), findsOneWidget);
+    // The rest name exactly the stops that ask for them, in itinerary order.
+    expect(_inPack('Summer clothes'), findsOneWidget);
+    expect(_inPack('Kraków, Rome'), findsOneWidget);
+    expect(_inPack('An umbrella or rain jacket'), findsOneWidget);
+    expect(_inPack('Kraków, Gothenburg'), findsOneWidget);
+    expect(_inPack('Sun protection'), findsOneWidget);
+    expect(_inPack('Rome'), findsWidgets);
+    // Nothing cold on this trip.
+    expect(_inPack('A warm coat'), findsNothing);
+    expect(_inPack('Thermals'), findsNothing);
+  });
+
+  testWidgets('the per-city rows start collapsed and open on tap',
+      (tester) async {
+    final weather = _CityWeatherApiService({
+      'Paris': const WeatherReport(kind: 'forecast', days: [
+        WeatherDay(date: '2026-09-15', tempMinC: 8, tempMaxC: 15),
+      ]),
+      'Nice': const WeatherReport(kind: 'forecast', days: [
+        WeatherDay(date: '2026-09-16', tempMinC: 19, tempMaxC: 31),
+      ]),
+    });
+    await _pump(
+      tester,
+      trip: _trip(endDate: '2026-09-17', items: [
+        _item(0, 'Louvre', 1),
+        _item(1, 'Promenade', 2, city: 'Nice'),
+      ]),
+      weather: weather,
+    );
+    await _openSheet(tester);
+
+    // The summary is up front; the detail is a closed row, not content.
+    expect(_inPack('Sun protection'), findsOneWidget);
+    expect(_cityDetailRow(), findsOneWidget);
+    expect(find.byType(WearRecsList), findsNothing);
+    expect(_inSheet('Cool — a jacket and layers'), findsNothing);
+
+    await _expandCityDetail(tester);
+    expect(find.byType(WearRecsList), findsOneWidget);
+    expect(_inRecs('Paris ·'), findsOneWidget);
+    expect(_inRecs('Cool — a jacket and layers'), findsOneWidget);
+    expect(_inRecs('Nice ·'), findsOneWidget);
+    expect(_inRecs('Hot — light fabrics and sun protection'), findsOneWidget);
+  });
+
+  testWidgets('the historical footnote stays visible while the detail is closed',
+      (tester) async {
+    // The footnote qualifies the header envelope as much as the rows, so
+    // hiding it behind the disclosure would let the numbers make a forecast
+    // claim they cannot back.
+    final weather = _CityWeatherApiService({
+      'Paris': const WeatherReport(kind: 'historical', days: [
+        WeatherDay(date: '2025-09-15', tempMinC: 8, tempMaxC: 15),
+      ]),
+      'Nice': const WeatherReport(kind: 'historical', days: [
+        WeatherDay(date: '2025-09-16', tempMinC: 19, tempMaxC: 31),
+      ]),
+    });
+    await _pump(
+      tester,
+      trip: _trip(endDate: '2026-09-17', items: [
+        _item(0, 'Louvre', 1),
+        _item(1, 'Promenade', 2, city: 'Nice'),
+      ]),
+      weather: weather,
+    );
+    await _openSheet(tester);
+
+    expect(find.byType(WearRecsList), findsNothing);
+    expect(_inSheet('Beyond the 16-day forecast'), findsOneWidget);
+    // …and still exactly once when the rows come out.
+    await _expandCityDetail(tester);
+    expect(_inSheet('Beyond the 16-day forecast'), findsOneWidget);
+  });
+
+  testWidgets('one displayed group renders its row inline, with no disclosure',
+      (tester) async {
+    // A single group's only extra facts are its dates — the envelope is
+    // already in the header — so charging a tap for it would be theatre.
+    await _pump(tester, trip: _trip(), report: _warmRainyForecast);
+    await _openSheet(tester);
+
+    expect(_cityDetailRow(), findsNothing);
+    expect(find.byType(WearRecsList), findsOneWidget);
+    expect(_inRecs('Paris · Sep 15 – Sep 16 · 15° – 24°'), findsOneWidget);
+  });
+
   testWidgets('renders the Spanish strings under the es locale',
       (tester) async {
     // The locale provider sets Intl.defaultLocale in the real app; tests set
@@ -590,6 +763,12 @@ void main() {
     await _openSheet(tester, tooltip: 'Qué ponerte y qué llevar');
     expect(find.text('Qué ponerte y qué llevar'), findsOneWidget);
     expect(find.textContaining('lluvia probable'), findsWidgets);
+    // The summary leads, translated: heading, objects, and the every-stop
+    // stand-in (one leg, so every group asks for each of them).
+    expect(_inSheet('Qué llevar en este viaje'), findsOneWidget);
+    expect(_inPack('Ropa de verano'), findsOneWidget);
+    expect(_inPack('Un paraguas o chubasquero'), findsOneWidget);
+    expect(_inPack('todas las paradas'), findsWidgets);
     expect(
         find.descendant(
             of: find.byType(WearRecsList),
@@ -611,11 +790,6 @@ void main() {
     );
     await _openSheet(tester, tooltip: 'Qué ponerte y qué llevar');
 
-    expect(
-        find.descendant(
-            of: find.byType(WearRecsList),
-            matching:
-                find.textContaining('el tiempo habitual en estas fechas')),
-        findsOneWidget);
+    expect(_inSheet('el tiempo habitual en estas fechas'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary

- On the 8-city Europe trip the **"What to wear & pack" sheet opened as sixteen lines of prose** — one two-line paragraph per city — and never answered the question its own title asks. The [#330](https://github.com/bdowe/anemos-travel/pull/330) fold was working correctly; the trip genuinely has eight distinct weather stories, so there was nothing left to merge. **Volume was the problem, not a bug.**
- The sheet now **leads with the objects to bring**, each attributed to the stops that ask for it — collapsing to "every stop" when that is all of them — and the per-city rows move behind a **collapsed "City by city" disclosure**.
- **The summary is the UNION of what the rows already say, not a second opinion.** `packEssentials` iterates `groupWearRegions` — the exact list `WearRecsList` renders — and maps each displayed phrase to the objects it asks for (`essentialsFor`). Every suggestion is backed by a visible row and every row contributes at least one, which is what makes collapsing the detail **lossless**. Pinned by a set-equality test against the union over the groups.
- **What a row promises decides where it can hide.** The historical footnote qualifies the *header's* temperature envelope as much as the rows', so it renders **outside** the disclosure rather than one tap away from the numbers it corrects. Corollary: a trip with only **one** displayed group skips the disclosure entirely — its only extra fact is its dates, and the envelope is already in the header.
- **Read-only by design.** Tapping a suggestion does *not* add it to the checklist: a truthful "already added" state needs a real identity on `checklist_items`, and matching the generated label would make the LABEL the key — the failure 00064 was written to undo and 00070's `leg_key` written to avoid. Named as the sequel in the spec's Out of Scope.
- `enum PackEssential`'s declaration order **is** render order — nothing sorts, so Dart's sub-32 insertion-sort fallback can't make an ordering test vacuous (the trap from the 08-17 friction-log entry).
- **`trip_detail_screen.dart` is untouched** — `_legClothingRecs` already hands the sheet its regions and `showWearPackSheet`'s signature is unchanged, so this lane never contends for the god file.
- Spec + plan carry an Amendment 2026-08-17; friction log has the entry.

### Before → after

| | |
|---|---|
| **Before** | 8 cities × 2 lines of prose, checklist pushed below the fold |
| **After** | `A light layer for evenings · every stop` / `Summer clothes · Sorrento, Rome` / `An umbrella or rain jacket · Berlin, Sorrento` / `Sun protection · Rome`, then the footnote, then a closed `City by city` — whole sheet including the checklist fits a phone screen |

## Testing

- `flutter analyze` — clean (3 pre-existing infos in `route_response.dart`, untouched).
- `flutter test` full suite. One failure, `auth_autofill_submit_test`, is a **load flake, not a regression**: the unmodified main checkout at the same commit fails that same test *plus two `budget_section_test` cases* under the same concurrent-suite load. My branch hit one of the three.
- `test/clothing_recs_test.dart` — new `essentialsFor` group (band table, per-advisory table paired against a band that doesn't already imply the object, and the idempotence of an advisory that restates its band: "bring layers" on a mild leg is the same light layer, one row not two), `packEssentials` (the union invariant, fixed order under input reversal, attribution + revisited-city dedupe, group-not-city `everyStop`), `anyHistorical`.
- `test/trip_detail_wear_section_test.dart` — summary content + attribution, collapsed-by-default (city names absent until tapped), footnote visible while collapsed and exactly once after expanding, the one-group inline rule, Spanish strings; existing footnote assertions retargeted from the `WearRecsList`-scoped finder to a sheet-scoped one.
- **Manual, against the lane stack on :3005** with a seeded 8-city trip (Amsterdam → Rome, Aug 24 – Sep 22) pulling **real Open-Meteo weather**: desktop dark, phone dark, phone light, and the expanded detail. Checked by eye that every summary claim is backed by a visible row — umbrella named exactly the two rows that say "rain likely", sun protection exactly the "Hot" row, light layer genuinely every row. On a phone the whole sheet including the checklist and add-field now fits without scrolling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
