### PR TITLE
fix(chat): the mobile refine sheet opens full-height

### DIFF
--- a/docs/friction-log.md
+++ b/docs/friction-log.md
@@ -5,6 +5,40 @@ build queue. Priority when picking work: **breakage > friction in features
 actually used > ideas that recur across ≥2 sessions**. Tag entries `[app]`
 (dogfooding the product) or `[dev]` (workflow/tooling). Newest first.
 
+## 2026-08-17 — The chat opened too short to chat in
+
+- **[app] Friction → fixed:** *"Clicking the chat button on mobile doesn't
+  bring the chat window high enough to see."* On a phone the refine sheet
+  opened at `initialChildSize: 0.45`. Inside that box the panel's header
+  (~55px) and the composer (~140px) are **fixed costs**, so 45% of the body
+  bought roughly **200px of transcript** — one quick-reply chip and a clipped
+  bubble. The fraction was never the problem on its own; the problem is that a
+  fraction was chosen without subtracting what the box already owed.
+- **[app] The default was also not a resting place.** `snap: true` with no
+  `snapSizes` snaps to `[minChildSize, maxChildSize]` — so `0.45` was a
+  starting extent the sheet could never return to. Drag it at all and it left
+  and never came back, which is why the thing felt arbitrary rather than
+  merely small. It now opens at `1.0` with min `0.4`: **both** resting places
+  are reachable, and the one you land in is the useful one.
+- **[app] Full-height is the default, not the cage.** The itinerary is still
+  behind the sheet and still one drag away, which is what kept this a
+  three-number change instead of a new route. The drag strip's margin went
+  `8 → 14` in the same pass: it is the **grab area**, not decoration, and at
+  full extent a ~20px target pinned to the top edge of the screen is the only
+  way back down.
+- **[dev] A comment claimed a job the framework was already doing.** The sheet
+  padded itself by `MediaQuery.viewInsets.bottom` "so the input clears the
+  keyboard". `Scaffold._resizeToAvoidBottomInset` defaults **true** and passes
+  `removeBottomInset` when building the body's MediaQuery, so that value is
+  **always 0** in a Scaffold body — the composer was cleared by the body
+  shrinking, and had been all along. Harmless while the sheet was 45% tall;
+  worth checking rather than inheriting once it went full-height. Deleted.
+- **[dev] Both new tests were run against the old numbers before being kept.**
+  They failed at `0.409` and `0.109` — i.e. `0.45` and `0.15` each minus the
+  handle strip, which is also how we know the ratios are measuring the extent
+  and not something incidental. A height assertion that passes both ways is
+  worth nothing.
+
 ## 2026-08-17 — "What to wear & pack" never said what to pack
 
 - **[app] Friction → fixed:** on the 8-city Europe trip the sheet opened as

--- a/specs/itinerary-editing/spec.md
+++ b/specs/itinerary-editing/spec.md
@@ -40,8 +40,11 @@ changes applied to the same trip in place.
 - [ ] Each "Day N" sub-header, each city group header, and the trip header
       offer a "refine" action that opens an AI chat panel.
 - [ ] On a wide window (desktop/web), the chat panel docks to the right of the
-      itinerary; on a narrow window it appears as a collapsible/draggable
-      bottom sheet. In both cases the itinerary remains visible and scrollable.
+      itinerary and both stay visible and scrollable. On a narrow window it is a
+      draggable bottom sheet that **opens at full height** — a 45% default left
+      the transcript ~200px once the panel's own header and composer were
+      subtracted — and the itinerary is reached by dragging the sheet down to
+      its peek position or closing it.
 - [ ] Asking the panel for a change updates only the targeted section; items
       outside the section are unchanged, and the page refreshes in place
       without navigation.
@@ -94,7 +97,8 @@ changes applied to the same trip in place.
   category → Save → dialog closes, itinerary refreshes with the new item at
   the end of its day.
 - **Refine happy path:** tap the refine icon on a day, city, or the trip
-  header → chat panel opens (right dock ≥ ~900px, bottom sheet below) seeded
+  header → chat panel opens (right dock ≥ ~900px, full-height bottom sheet
+  below) seeded
   with that section's contents → user types a request → AI streams its
   reasoning, shows an "Updating itinerary…" indicator while applying → the
   itinerary refreshes in place → conversation can continue for further tweaks.

--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -6799,50 +6799,75 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
                           ],
                         );
                       }
-                      // Narrow: collapsible bottom sheet over the page; bottom
-                      // inset keeps the input above the keyboard.
+                      // Narrow: the chat OPENS FULL — everything between the app
+                      // bar and the nav bar. It used to open at 0.45, where the
+                      // panel's own header and composer are fixed costs that
+                      // left ~200px of transcript: one quick-reply chip and a
+                      // clipped bubble, on the surface the whole feature lives
+                      // on. Shrinking it is now a deliberate drag, not the
+                      // state you land in.
+                      //
+                      // snap with no snapSizes snaps to [min, max], so there
+                      // are exactly two resting places: full, and a 0.4 peek
+                      // that still shows the header and composer over a slice
+                      // of the itinerary. (0.45 wasn't even a snap target,
+                      // which is why the old sheet felt arbitrary.) Nothing is
+                      // remembered — every open starts full, so a peek can't
+                      // silently become the next open's default.
                       return Stack(
                         children: [
                           refreshable,
                           DraggableScrollableSheet(
-                            initialChildSize: 0.45,
-                            minChildSize: 0.15,
-                            maxChildSize: 0.92,
+                            initialChildSize: 1.0,
+                            minChildSize: 0.4,
+                            maxChildSize: 1.0,
                             snap: true,
                             builder: (context, scrollController) => Material(
                               elevation: 8,
                               borderRadius: const BorderRadius.vertical(
                                   top: Radius.circular(16)),
                               clipBehavior: Clip.antiAlias,
-                              child: Padding(
-                                padding: EdgeInsets.only(
-                                    bottom: MediaQuery.of(context)
-                                        .viewInsets
-                                        .bottom),
-                                child: Column(
-                                  children: [
-                                    // Drag handle (also a scrollable so the
-                                    // sheet responds to drags at its header).
-                                    SingleChildScrollView(
-                                      controller: scrollController,
-                                      child: Center(
-                                        child: Container(
-                                          width: 36,
-                                          height: 4,
-                                          margin: const EdgeInsets.symmetric(
-                                              vertical: 8),
-                                          decoration: BoxDecoration(
-                                            color: theme
-                                                .colorScheme.outlineVariant,
-                                            borderRadius:
-                                                BorderRadius.circular(2),
-                                          ),
+                              // No keyboard padding here: the Scaffold's
+                              // resizeToAvoidBottomInset (unset => true) hands
+                              // the body a MediaQuery with viewInsets.bottom
+                              // already removed, so the EdgeInsets.only that
+                              // used to sit here read 0 on every platform and
+                              // the composer was kept above the keyboard by the
+                              // body shrinking, not by this. It mattered more
+                              // once the sheet went full-height, so it was
+                              // checked rather than inherited.
+                              child: Column(
+                                children: [
+                                  // Drag handle (also a scrollable so the sheet
+                                  // responds to drags at its header). This strip
+                                  // is the ONLY place a drag resizes the sheet —
+                                  // the transcript's ListView has its own
+                                  // controller by design, so scrolling messages
+                                  // can't collapse the chat — and now that the
+                                  // sheet opens full, it is also the only way
+                                  // back down. The margin is the grab area, not
+                                  // decoration: 8 left a ~20px target at the
+                                  // very top edge of the screen.
+                                  SingleChildScrollView(
+                                    key: const Key('refineSheetHandle'),
+                                    controller: scrollController,
+                                    child: Center(
+                                      child: Container(
+                                        width: 36,
+                                        height: 4,
+                                        margin: const EdgeInsets.symmetric(
+                                            vertical: 14),
+                                        decoration: BoxDecoration(
+                                          color:
+                                              theme.colorScheme.outlineVariant,
+                                          borderRadius:
+                                              BorderRadius.circular(2),
                                         ),
                                       ),
                                     ),
-                                    Expanded(child: panel),
-                                  ],
-                                ),
+                                  ),
+                                  Expanded(child: panel),
+                                ],
                               ),
                             ),
                           ),

--- a/src/packages/flutter-app/lib/widgets/trip_refine_panel.dart
+++ b/src/packages/flutter-app/lib/widgets/trip_refine_panel.dart
@@ -240,9 +240,11 @@ class _Problem extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    // Scrollable: on narrow the panel is a drag sheet that opens at 0.45 of
-    // the screen, which is shorter than this block — and an unreachable
-    // "New chat" button is the same dead end the state exists to escape.
+    // Scrollable: on narrow the panel is a drag sheet the traveler can pull
+    // down to 0.4 of the screen, which is shorter than this block — and an
+    // unreachable "New chat" button is the same dead end the state exists to
+    // escape. (The sheet OPENS full, so this is now the dragged case rather
+    // than the default one; it is still reachable, so the scroll view stays.)
     return SingleChildScrollView(
       child: Padding(
         padding: const EdgeInsets.all(24),

--- a/src/packages/flutter-app/test/trip_detail_narrow_header_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_narrow_header_test.dart
@@ -94,6 +94,49 @@ void main() {
     expect(find.byType(TripRefinePanel), findsOneWidget);
   });
 
+  // The sheet used to open at 0.45 of the body, and the panel's own header and
+  // composer are fixed costs inside it — so the transcript got ~200px: one
+  // quick-reply chip and a clipped bubble. It now opens full. Measured against
+  // the DraggableScrollableSheet's own box, which IS the space the body gives
+  // it, so the assertion doesn't hardcode the app bar's height.
+  testWidgets('narrow: the refine sheet opens full-height', (tester) async {
+    await _pump(tester, _trip(), surface: phone);
+    await tester.tap(find.byTooltip('Refine with AI'));
+    await tester.pumpAndSettle();
+
+    final available = tester.getRect(find.byType(DraggableScrollableSheet));
+    final panel = tester.getRect(find.byType(TripRefinePanel));
+
+    // > 0.85 rather than == 1.0: the drag handle strip sits above the panel
+    // inside the sheet, so the panel is always the extent minus that strip.
+    expect(panel.height / available.height, greaterThan(0.85));
+    // And it reaches the bottom — a tall panel floating above the fold would
+    // pass the ratio alone.
+    expect(panel.bottom, moreOrLessEquals(available.bottom, epsilon: 1));
+  });
+
+  // The other half of the contract: full is where it OPENS, not where it is
+  // stuck. Dragging the handle down snaps to the 0.4 peek, which is what makes
+  // the itinerary reachable without closing the chat.
+  testWidgets('narrow: dragging the handle down shrinks the sheet',
+      (tester) async {
+    await _pump(tester, _trip(), surface: phone);
+    await tester.tap(find.byTooltip('Refine with AI'));
+    await tester.pumpAndSettle();
+
+    final available = tester.getRect(find.byType(DraggableScrollableSheet));
+    final opened = tester.getRect(find.byType(TripRefinePanel)).height;
+
+    await tester.drag(
+        find.byKey(const Key('refineSheetHandle')), const Offset(0, 300));
+    await tester.pumpAndSettle();
+
+    final dragged = tester.getRect(find.byType(TripRefinePanel)).height;
+    expect(dragged, lessThan(opened));
+    // Snapped to minChildSize (0.4), not to some arbitrary resting point.
+    expect(dragged / available.height, closeTo(0.4, 0.06));
+  });
+
   testWidgets('narrow editor collaborator keeps the sparkle (spec)',
       (tester) async {
     await _pump(tester, _trip(access: 'editor'), surface: phone);


### PR DESCRIPTION
## Summary

- **The mobile chat opens full-height.** Tapping ✨ / the chat FAB on a phone landed the refine sheet at `initialChildSize: 0.45`. The panel's own header (~55px) and composer (~140px) are fixed costs *inside* that box, so 45% of the body bought roughly **200px of transcript** — one quick-reply chip and a clipped bubble, on the surface the whole feature lives on.
- **0.45 was not even a resting place.** `snap: true` with no `snapSizes` snaps to `[minChildSize, maxChildSize]`, so the default extent was one the sheet could never return to — drag it at all and it left for good. That's why it read as arbitrary rather than merely small.
- **Now `1.0 / 0.4 / 1.0`.** It opens full, and **both** snap targets are reachable: full, or a 0.4 peek that still shows the header and composer over a slice of the itinerary. The itinerary stays behind the sheet and one drag away, which is what kept this three numbers instead of a new route. Nothing is remembered — every open starts full, so a peek can't silently become the next open's default.
- **The drag strip's margin goes 8 → 14.** It is the *grab area*, not decoration, and at full extent a ~20px target pinned to the top edge of the screen is the only way back down. Given a `Key` so the test can drive it.
- **Deleted a comment that claimed a job the framework was already doing.** The sheet padded itself by `MediaQuery.viewInsets.bottom` "so the input clears the keyboard". `Scaffold._resizeToAvoidBottomInset` defaults **true** and passes `removeBottomInset` when building the body's MediaQuery, so that value is **always 0** in a Scaffold body — the composer was cleared by the body shrinking, and had been all along. Harmless at 45% tall; worth checking rather than inheriting once the sheet went full-height.

**Unchanged on purpose:** the ≥900px docked path (`Row` + `VerticalDivider` + 400px panel), `_panelOpen` as the panel's only screen state (no controller, no stored fraction), and Back / Escape / ✕ close behaviour.

Spec amended: `specs/itinerary-editing/spec.md` promised "in both cases the itinerary remains visible and scrollable", which a full-height sheet contradicts at its default extent.

## Testing

- `flutter test` — full suite, **1504 passed**. The one failure, `auth_autofill_submit_test.dart :: keystroke-simulated burst fill auto-submits`, is **pre-existing**: verified by stashing this branch's changes and watching it fail identically on the clean base.
- `flutter analyze` — clean (3 pre-existing infos in `models/route_response.dart`, untouched here).
- **Two new tests** in `trip_detail_narrow_header_test.dart` (390×844), measured against the `DraggableScrollableSheet`'s own box so nothing hardcodes the app bar's height: the panel fills >85% of the body and reaches its bottom; dragging the handle down snaps to ~0.4. **Both were run against the old values first** and failed at `0.409` and `0.109` — i.e. `0.45` and `0.15` each minus the handle strip, which is also how we know the ratios measure the extent and not something incidental.
- **Manual, real app** (lane stack, host headless Chrome at 390×844, seeded trip): chat opens filling the body between app bar and nav bar — the whole greeting, all four quick-reply chips and the composer visible at once; drag down → snaps to the peek showing the trip header, dates, Next Step card and map with the composer still usable; drag up → back to full; peek → close → reopen → **full again**. Desktop (1280×900) dock re-checked and pixel-identical.
- Not exercised: an actual on-screen keyboard (headless Chrome has none, so `viewInsets` stays 0 there either way). The padding deletion rests on the Scaffold source cited above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)