### PR TITLE
fix(budget): the add row sizes itself from the strings it draws

### DIFF
--- a/specs/budget-planned-vs-paid/plan.md
+++ b/specs/budget-planned-vs-paid/plan.md
@@ -120,6 +120,11 @@ something cost has always been a takeover.
   un-pay, edit dialog, sticky mode control on its own line so the add row's
   horizontal composition — and its 136px no-ellipsis regression test — is
   untouched).
+  *[Later: the add row's OTHER hint was truncating to "Add a…" on every phone,
+  which no test covered. It now measures both hints and stacks onto two lines
+  when one line can't seat them, so the 136 is gone and the row's shape is
+  derived rather than assumed. Keeping this control on its own line was the
+  right call and is now a stronger one — see `_buildModeControl`.]*
 - **Provider:** `providers/budget_provider.dart` — the planned/paid mode joins
   `ExpenseDraft` (PR #435), not widget `State`: it is a *choice*, like category,
   and must survive the remount that opening the chat panel causes.

--- a/src/packages/flutter-app/lib/widgets/budget_section.dart
+++ b/src/packages/flutter-app/lib/widgets/budget_section.dart
@@ -1,3 +1,5 @@
+import 'dart:math' as math;
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -928,10 +930,15 @@ class _BudgetSectionState extends ConsumerState<BudgetSection> {
   ///
   /// On its OWN LINE rather than inside the add row: that row already spends
   /// 240px of its 358 on fixed-width controls, and the "Add an expense…" hint
-  /// barely fits in what's left — any horizontal addition kills it and puts the
-  /// 136px Amount field's no-ellipsis regression under pressure. Vertical space
-  /// in a scrolling tab body is nearly free; horizontal space is the scarce
-  /// resource. The add row's composition is therefore byte-identical to before.
+  /// barely fits in what's left — any horizontal addition kills it. Vertical
+  /// space in a scrolling tab body is nearly free; horizontal space is the
+  /// scarce resource.
+  ///
+  /// "Barely fits" turned out to be "doesn't": the hint was truncating to
+  /// "Add a…" on every phone, and [_buildAddRow] now stacks onto two lines
+  /// when it can't seat both fields. That vindicates this control's own line
+  /// rather than reversing it — putting it back in the row would only make the
+  /// row stack at wider and wider windows.
   ///
   /// The pick is read from the draft, so it survives the remount that changing
   /// header tab or opening the chat panel causes — a choice, like the category
@@ -973,98 +980,304 @@ class _BudgetSectionState extends ConsumerState<BudgetSection> {
     });
   }
 
-  Widget _buildAddRow(ThemeData theme) {
-    return Row(
-      crossAxisAlignment: CrossAxisAlignment.center,
-      children: [
-        // Closed state stays icon-compact (the add row is width-tight on
-        // phones); the open menu spells out each category. A popup menu (not
-        // a DropdownButton) because a dropdown's menu is hard-constrained to
-        // the trigger's width — an icon-only trigger would clip every label.
-        //
-        // The pick is read straight from the draft rather than mirrored into a
-        // field, so there is one answer to "which category is armed". The
-        // watch is scoped to this button and selects one String, so typing in
-        // the fields beside it can never re-render the expense list.
-        Consumer(builder: (context, ref, _) {
-          final category = ref.watch(
-              expenseDraftProvider(widget.tripId).select((d) => d.category));
-          return PopupMenuButton<String>(
-            tooltip: context.l10n.budgetCategoryLabel,
-            enabled: !widget.isOffline,
-            position: PopupMenuPosition.under,
-            color: theme.colorScheme.surface,
-            elevation: 3,
-            shape: const RoundedRectangleBorder(borderRadius: AppRadius.mdAll),
-            icon: Row(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Icon(kExpenseCategoryIcons[category],
-                    size: 18, color: theme.colorScheme.onSurfaceVariant),
-                Icon(Icons.arrow_drop_down,
-                    size: 18, color: theme.colorScheme.onSurfaceVariant),
-              ],
-            ),
-            onSelected: (v) => ref
-                .read(expenseDraftProvider(widget.tripId).notifier)
-                .setCategory(v),
-            itemBuilder: (_) => [
-              for (final cat in kExpenseCategories)
-                CheckedPopupMenuItem<String>(
-                  value: cat,
-                  checked: cat == category,
-                  child: Row(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      Icon(kExpenseCategoryIcons[cat],
-                          size: 18, color: theme.colorScheme.onSurfaceVariant),
-                      const SizedBox(width: AppSpacing.sm),
-                      Text(expenseCategoryLabel(context.l10n, cat)),
-                    ],
-                  ),
+  /// What a dense outline field spends on chrome either side of its text.
+  /// Flutter 3.35's `InputDecorator` gives the M3 + dense + outline branch a
+  /// `contentPadding` of 12 per side (input_decorator.dart:2600-2603) and then
+  /// deducts `OutlineInputBorder.gapPadding` (4 — input_border.dart:332) per
+  /// side as well (:2609-2613, :992-1008), so the hint is laid out at exactly
+  /// `fieldWidth - _fieldChrome`. That is the width the regression tests read
+  /// straight off `RenderParagraph.constraints`. (The old note here said "16px
+  /// per side" — right in total, wrong about where it comes from.)
+  static const double _fieldChrome = 32;
+
+  /// A hint whose intrinsic width lands EXACTLY on the interior is one
+  /// sub-pixel from ellipsizing itself, and a fractional device pixel ratio is
+  /// enough to get there. One spacing step of headroom is plenty, because the
+  /// measurement below already uses the same painter inputs the hint's own
+  /// paragraph does — this covers rounding, not disagreement.
+  static const double _hintFitSlack = AppSpacing.xs;
+
+  /// Width of each of the row's two icon affordances.
+  ///
+  /// **Declared, not predicted** — the row renders both inside a `SizedBox` of
+  /// this width, so the number the arithmetic spends is the number the row
+  /// occupies. That is the whole difference between this constant and the 136
+  /// it replaces, and predicting would have been wrong anyway: `IconButton`
+  /// takes its tap-target size from the platform, so the add button is 48 on
+  /// Android/iOS and silently **40** on macOS/Linux/Windows
+  /// (theme_data.dart:398-408). Pinning it makes the row platform-invariant
+  /// and brings the desktop tap target back up to Material's minimum.
+  ///
+  /// Legitimately a constant even in a file about measuring: 48 encodes a
+  /// touch-target spec, not a string, so it doesn't move with locale — and it
+  /// can't move with text scale either, since `Icon.applyTextScaling` defaults
+  /// to false and nothing here enables it.
+  static const double _controlWidth = kMinTouchTarget;
+
+  /// Everything on the add row that is not a field: the two icon affordances
+  /// and the two gaps. None of it is text, so none of it moves with the text
+  /// scaler; the terms that DO move are the hints, and those are measured.
+  static const double _addRowFixedWidth =
+      2 * _controlWidth + 2 * AppSpacing.sm;
+
+  /// The amount field has two things to seat and its hint is the smaller one,
+  /// so the figure is named here instead of folded into a magic width: a
+  /// five-figure amount with cents — a flight or a hotel total, the widest
+  /// thing that lands on one expense line. Sizing the box from
+  /// "Amount"/"Importe" alone would give ~82px, which reads fine and is
+  /// miserable to type in.
+  ///
+  /// Only characters this field's own [FilteringTextInputFormatter] admits: a
+  /// sample containing a thousands separator would size the box for text it
+  /// can never hold.
+  static const String _amountWidthSample = '88888.88';
+
+  /// The width a field needs for [text] to render in full, chrome included —
+  /// directly comparable to the width a `SizedBox`/`Expanded` hands the field.
+  ///
+  /// Measured, not assumed: the strings are translated ("Añade un gasto…"),
+  /// the text scaler is the traveler's, and the 1em-per-glyph FlutterTest font
+  /// moves both again. A constant can only ever be right for the one string
+  /// somebody measured — which is exactly how the description hint shipped
+  /// truncated to "Add a…" while the amount hint had a regression test.
+  ///
+  /// The style is the one `InputDecorator` actually paints a hint with:
+  /// `textTheme.bodyLarge` merged with the M3 default hint style, which sets
+  /// only a colour (input_decorator.dart:2170-2183, :5897-5902). These fields
+  /// pass neither `style` nor `hintStyle`, so nothing else contributes.
+  /// `Text` merges `MediaQuery.boldTextOf` on top of that, so this does too.
+  ///
+  /// `maxIntrinsicWidth`, not `width`: painted width omits the trailing
+  /// letter-spacing the field's constraint still has to cover, and intrinsic
+  /// width is the quantity the tests compare against `constraints.maxWidth` —
+  /// the widget's arithmetic and the tests' oracle have to be the same number.
+  ///
+  /// Same shape as the overview show-more toggle's `_collapsedClips`
+  /// (trip_detail_screen.dart): synchronous, one layout pass, no post-frame
+  /// re-measure.
+  static double _fieldWidthFor(BuildContext context, String text) {
+    var style = Theme.of(context).textTheme.bodyLarge;
+    if (MediaQuery.boldTextOf(context)) {
+      style = style?.merge(const TextStyle(fontWeight: FontWeight.bold));
+    }
+    final painter = TextPainter(
+      text: TextSpan(text: text, style: style),
+      textDirection: Directionality.of(context),
+      textScaler: MediaQuery.textScalerOf(context),
+      locale: Localizations.maybeLocaleOf(context),
+    )..layout();
+    final width = painter.maxIntrinsicWidth;
+    painter.dispose();
+    return (width + _fieldChrome + _hintFitSlack).ceilToDouble();
+  }
+
+  /// Closed state stays icon-compact (the add row is width-tight on phones);
+  /// the open menu spells out each category. A popup menu (not a
+  /// DropdownButton) because a dropdown's menu is hard-constrained to the
+  /// trigger's width — an icon-only trigger would clip every label.
+  ///
+  /// The pick is read straight from the draft rather than mirrored into a
+  /// field, so there is one answer to "which category is armed". The watch is
+  /// scoped to this button and selects one String, so typing in the fields
+  /// beside it can never re-render the expense list — or re-run the
+  /// measurement beside it.
+  Widget _buildCategoryTrigger(ThemeData theme) {
+    return Consumer(builder: (context, ref, _) {
+      final category = ref
+          .watch(expenseDraftProvider(widget.tripId).select((d) => d.category));
+      return SizedBox(
+        width: _controlWidth,
+        child: PopupMenuButton<String>(
+          // Zero, not the default all(8) that PopupMenuButton forwards to its
+          // IconButton: the two 18px icons plus 8+8 measure 52, which would
+          // overflow the 48 the row's arithmetic spends here. 36 centred in 48
+          // leaves 6 a side and reads the same.
+          padding: EdgeInsets.zero,
+          tooltip: context.l10n.budgetCategoryLabel,
+          enabled: !widget.isOffline,
+          position: PopupMenuPosition.under,
+          color: theme.colorScheme.surface,
+          elevation: 3,
+          shape: const RoundedRectangleBorder(borderRadius: AppRadius.mdAll),
+          icon: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(kExpenseCategoryIcons[category],
+                  size: 18, color: theme.colorScheme.onSurfaceVariant),
+              Icon(Icons.arrow_drop_down,
+                  size: 18, color: theme.colorScheme.onSurfaceVariant),
+            ],
+          ),
+          onSelected: (v) => ref
+              .read(expenseDraftProvider(widget.tripId).notifier)
+              .setCategory(v),
+          itemBuilder: (_) => [
+            for (final cat in kExpenseCategories)
+              CheckedPopupMenuItem<String>(
+                value: cat,
+                checked: cat == category,
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Icon(kExpenseCategoryIcons[cat],
+                        size: 18, color: theme.colorScheme.onSurfaceVariant),
+                    const SizedBox(width: AppSpacing.sm),
+                    Text(expenseCategoryLabel(context.l10n, cat)),
+                  ],
                 ),
-            ],
-          );
-        }),
-        const SizedBox(width: AppSpacing.sm),
-        Expanded(
-          child: TextField(
-            controller: _labelController,
-            textInputAction: TextInputAction.next,
-            decoration: InputDecoration(
-              isDense: true,
-              hintText: context.l10n.budgetAddHint,
-            ),
-          ),
+              ),
+          ],
         ),
-        const SizedBox(width: AppSpacing.sm),
-        // 136 leaves a 104px interior after the theme's filled-field content
-        // padding (16px per side) — fits "Amount"/"Importe" in Inter with
-        // text-scale headroom, and fits the 1em-per-glyph FlutterTest font
-        // ("Amount" = 99px incl. letter-spacing) the regression test
-        // measures with.
-        SizedBox(
-          width: 136,
-          child: TextField(
-            controller: _amountController,
-            textInputAction: TextInputAction.done,
-            keyboardType: const TextInputType.numberWithOptions(decimal: true),
-            inputFormatters: [
-              FilteringTextInputFormatter.allow(RegExp(r'[0-9.]')),
-            ],
-            decoration: InputDecoration(
-              isDense: true,
-              hintText: context.l10n.budgetAmount,
-            ),
-            onSubmitted: (_) => _add(),
-          ),
+      );
+    });
+  }
+
+  /// Neither field passes a `style:`, and the theme passes no `hintStyle:`, on
+  /// purpose: that is what makes the hint's metrics exactly `bodyLarge`, which
+  /// is what [_fieldWidthFor] measures. Adding either without teaching the
+  /// measurement about it silently un-derives the row.
+  Widget _buildLabelField() => TextField(
+        controller: _labelController,
+        textInputAction: TextInputAction.next,
+        decoration: InputDecoration(
+          isDense: true,
+          hintText: context.l10n.budgetAddHint,
         ),
-        IconButton(
+      );
+
+  Widget _buildAmountField() => TextField(
+        controller: _amountController,
+        textInputAction: TextInputAction.done,
+        keyboardType: const TextInputType.numberWithOptions(decimal: true),
+        inputFormatters: [
+          FilteringTextInputFormatter.allow(RegExp(r'[0-9.]')),
+        ],
+        decoration: InputDecoration(
+          isDense: true,
+          hintText: context.l10n.budgetAmount,
+        ),
+        onSubmitted: (_) => _add(),
+      );
+
+  /// Pick a category, say what it was, say what it cost, commit.
+  ///
+  /// One line while both fields can have the width their hints need, two lines
+  /// below that. Measured rather than thresholded, because what runs out is a
+  /// translated string at the traveler's text scale and no px breakpoint is
+  /// right for every combination of those: at 390px the description field got
+  /// ~106px and its hint truncated to "Add a…" — illegible, and too narrow to
+  /// type into either, so shortening the copy would only have made an unusable
+  /// field readable.
+  ///
+  /// It truncated rather than wrapped because a field hint inherits
+  /// `hintMaxLines` from `TextField.maxLines`, which is 1, and a hint with a
+  /// max-lines gets `TextOverflow.ellipsis` against a tight layout width. So
+  /// the failure was silent by construction: no overflow stripes, no thrown
+  /// exception, just a shorter string. Only a width assertion catches it,
+  /// which is why the tests measure rather than watch for exceptions.
+  ///
+  /// Stacked, the money and the commit drop to a second line and the
+  /// description takes the width back, while the category trigger stays glued
+  /// to the field it categorizes — where it reads as that field's leading
+  /// icon, which is what it is.
+  ///
+  /// The decision can't oscillate: this row's width comes from the sliver
+  /// above it, never from its own children, so stacking cannot change the
+  /// constraint that caused it.
+  Widget _buildAddRow(ThemeData theme) {
+    // LayoutBuilder, never MediaQuery (house rule, chat_panel.dart): the width
+    // this row gets is the trip BODY's, and a docked chat panel takes 401px of
+    // it without the window changing at all.
+    return LayoutBuilder(builder: (context, constraints) {
+      final labelWidth = _fieldWidthFor(context, context.l10n.budgetAddHint);
+      final amountWidth = math.max(
+        _fieldWidthFor(context, context.l10n.budgetAmount),
+        _fieldWidthFor(context, _amountWidthSample),
+      );
+      final category = _buildCategoryTrigger(theme);
+      final label = _buildLabelField();
+      final amount = _buildAmountField();
+      // Declared to _controlWidth for the same reason as the category trigger
+      // — and it is a fix as well as a declaration: on desktop this button was
+      // 40 wide, under Material's 48 minimum.
+      final add = SizedBox(
+        width: _controlWidth,
+        child: IconButton(
           icon: const Icon(Icons.add),
           tooltip: context.l10n.budgetAddExpenseTooltip,
           onPressed: widget.isOffline ? null : _add,
         ),
-      ],
-    );
+      );
+
+      // A ladder, cheapest concession first — the description keeps whatever
+      // company it can while still showing its hint whole:
+      //
+      //   1. everything on one line
+      //   2. the money and the commit drop to a second line
+      //   3. the category drops too, and the description takes the whole line
+      //
+      // Unbounded width takes rung 1: it seats anything, and the Expanded
+      // would already have thrown there, so the guard only feeds the
+      // arithmetic.
+      if (!constraints.maxWidth.isFinite ||
+          constraints.maxWidth >=
+              _addRowFixedWidth + labelWidth + amountWidth) {
+        return Row(
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            category,
+            const SizedBox(width: AppSpacing.sm),
+            Expanded(child: label),
+            const SizedBox(width: AppSpacing.sm),
+            SizedBox(width: amountWidth, child: amount),
+            add,
+          ],
+        );
+      }
+
+      // Rung 3 is the accessibility rung, not a phone rung: a 320px body at a
+      // large text scale is where the category trigger's 48 + 8 stops being
+      // affordable. Below THIS nothing helps and the hint ellipsizes as it
+      // always did — but by then the description has the widest line the row
+      // can offer, which is the most the layout can honestly do.
+      final categorySharesTheLabelsLine =
+          constraints.maxWidth - _controlWidth - AppSpacing.sm >= labelWidth;
+
+      // Both fields keep their order and their relative position on every
+      // rung, so reading-order traversal carries `next` from the label to the
+      // amount and `done` to _add() — except on rung 3, where the category
+      // trigger now sits between them in reading order and `next` stops there
+      // first. Acceptable at the only width that reaches rung 3, and the
+      // alternative (the category between the amount and the add button)
+      // buys a tidier tab order by making the row look like a mistake.
+      return Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          if (categorySharesTheLabelsLine)
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                category,
+                const SizedBox(width: AppSpacing.sm),
+                Expanded(child: label),
+              ],
+            )
+          else
+            label,
+          const SizedBox(height: AppSpacing.xs),
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              if (!categorySharesTheLabelsLine) ...[
+                category,
+                const SizedBox(width: AppSpacing.sm),
+              ],
+              Expanded(child: amount),
+              add,
+            ],
+          ),
+        ],
+      );
+    });
   }
 }

--- a/src/packages/flutter-app/test/budget_section_test.dart
+++ b/src/packages/flutter-app/test/budget_section_test.dart
@@ -235,6 +235,17 @@ Expense _both(String id, String category, String label,
         actualAmount: paid,
         purchased: true);
 
+/// Lays [child] out at [width] when one is asked for, and otherwise hands back
+/// the same widget untouched — an `Align`/`SizedBox` wrapper applied
+/// unconditionally would loosen the horizontal constraint every other case in
+/// this file relies on.
+Widget _maybeNarrow(double? width, Widget child) => width == null
+    ? child
+    : Align(
+        alignment: Alignment.topLeft,
+        child: SizedBox(width: width, child: child),
+      );
+
 Future<_FakeBudgetApiService> _pump(
   WidgetTester tester,
   List<Expense> expenses, {
@@ -244,6 +255,10 @@ Future<_FakeBudgetApiService> _pump(
   bool isOffline = false,
   Locale? locale,
   DailySpendGuide? dailySpend,
+  // Width the section is laid out at, when a case is about the add row's
+  // shape. Applied only when passed, so every existing call stays
+  // byte-identical (and keeps the full surface width it always had).
+  double? width,
 }) async {
   final fake = _FakeBudgetApiService(expenses,
       targetAmount: targetAmount, currency: currency);
@@ -263,9 +278,12 @@ Future<_FakeBudgetApiService> _pump(
       supportedLocales: const [Locale('en'), Locale('es')],
       localizationsDelegates: testLocalizationsDelegates,
         home: Scaffold(
-          body: SingleChildScrollView(
-            child: BudgetSection(
-                tripId: 't1', canEdit: canEdit, isOffline: isOffline),
+          body: _maybeNarrow(
+            width,
+            SingleChildScrollView(
+              child: BudgetSection(
+                  tripId: 't1', canEdit: canEdit, isOffline: isOffline),
+            ),
           ),
         ),
       ),
@@ -507,28 +525,144 @@ void main() {
     expect(categoryButton.enabled, isFalse);
   });
 
-  testWidgets(
-      'amount hint renders un-truncated under the app theme at phone width',
-      (tester) async {
-    await tester.binding.setSurfaceSize(const Size(360, 690));
-    addTearDown(() => tester.binding.setSurfaceSize(null));
-    await _pump(tester, [_exp('a', 'food', 'Lunch', 20)]);
+  /// Asserts every add-row hint currently on screen renders whole.
+  ///
+  /// A too-narrow hint ellipsizes silently — a field hint inherits
+  /// `hintMaxLines` from `TextField.maxLines` (1), which turns on
+  /// `TextOverflow.ellipsis` against a tight width — so it never throws and
+  /// "no exception" proves nothing. The full string's intrinsic width has to
+  /// fit the width the field gave the hint. Compared against constraints, not
+  /// painted size: painted width drops the trailing letter-spacing that
+  /// intrinsic width keeps, and `bodyLarge` has 0.5 of it.
+  void expectHintsWhole(WidgetTester tester, List<String> hints, String where) {
+    for (final hint in hints) {
+      final finder = find.text(hint);
+      expect(finder, findsOneWidget, reason: '"$hint" is missing $where');
+      final paragraph = tester.renderObject<RenderParagraph>(finder);
+      expect(
+        paragraph.getMaxIntrinsicWidth(double.infinity),
+        lessThanOrEqualTo(paragraph.constraints.maxWidth),
+        reason: '"$hint" is being ellipsized $where',
+      );
+    }
+    expect(tester.takeException(), isNull, reason: 'overflow $where');
+  }
 
-    // A too-narrow hint ellipsizes (never throws), so "no exception" proves
-    // nothing: the full string's intrinsic width must fit in the width the
-    // field gave the hint. (Compared against constraints, not painted size —
-    // painted width excludes trailing letter-spacing that intrinsic width
-    // includes.) English only on purpose — the 1em-per-glyph FlutterTest
-    // font inflates "Importe" past any realistic width, while Inter fits it
-    // easily at the shipped 136px.
-    final hint = find.text('Amount');
-    expect(hint, findsOneWidget);
-    final paragraph = tester.renderObject<RenderParagraph>(hint);
-    expect(
-      paragraph.getMaxIntrinsicWidth(double.infinity),
-      lessThanOrEqualTo(paragraph.constraints.maxWidth),
-      reason: 'the Amount hint is being ellipsized — widen the amount field',
-    );
+  // The real gate, and deliberately CONSTANT-FREE: it never names a width the
+  // row is supposed to have, only the invariant that whatever the row decided,
+  // both hints survived it. So it catches drift in the fixed-width budget or
+  // in the field-chrome figure directly, and names the width that broke.
+  //
+  // Both locales, because measuring in the font the widget renders in is what
+  // finally makes Spanish testable: the old 136px constant was chosen for
+  // Inter and asserted against the 1em-per-glyph FlutterTest font, which is
+  // why its predecessor had to give up and say "English only on purpose".
+  for (final (locale, hints) in [
+    (null, ['Add an expense…', 'Amount']),
+    (const Locale('es'), ['Añade un gasto…', 'Importe']),
+  ]) {
+    final tag = locale?.languageCode ?? 'en';
+    testWidgets('the add row truncates neither hint at any width it can get '
+        '($tag)', (tester) async {
+      for (final width in [
+        320.0, 360.0, 390.0, 412.0, 430.0, 500.0, 700.0, 900.0, //
+      ]) {
+        await _pump(tester, [_exp('a', 'food', 'Lunch', 20)],
+            locale: locale, width: width);
+        expectHintsWhole(tester, hints, 'at ${width}px in $tag');
+      }
+    });
+  }
+
+  testWidgets('the add row is one line when it fits and two when it is not',
+      (tester) async {
+    // Geometry, not widget type: what matters is whether the two fields share
+    // a line, which is what a reader sees. 900 and 360 are widths where Inter
+    // and the FlutterTest font agree on the verdict, so this is font-robust.
+    double topOf(WidgetTester t, int i) =>
+        t.getTopLeft(find.byType(TextField).at(i)).dy;
+
+    await _pump(tester, const [], width: 900);
+    expect(topOf(tester, 0), topOf(tester, 1),
+        reason: 'a 900px row has room for one line');
+
+    await _pump(tester, const [], width: 360);
+    expect(topOf(tester, 1), greaterThan(topOf(tester, 0)),
+        reason: 'a 360px row must drop the amount onto a second line');
+  });
+
+  testWidgets('the split responds to text scale, not to a hardcoded width',
+      (tester) async {
+    // Same width both times — only the type gets bigger. A px breakpoint
+    // cannot pass this; a measurement cannot fail it.
+    double topOf(WidgetTester t, int i) =>
+        t.getTopLeft(find.byType(TextField).at(i)).dy;
+
+    await _pump(tester, const [], width: 800);
+    expect(topOf(tester, 0), topOf(tester, 1));
+
+    tester.platformDispatcher.textScaleFactorTestValue = 2.0;
+    addTearDown(tester.platformDispatcher.clearTextScaleFactorTestValue);
+    await _pump(tester, const [], width: 800);
+    expect(topOf(tester, 1), greaterThan(topOf(tester, 0)),
+        reason: 'bigger type needs more room, so the same width must stack');
+  });
+
+  testWidgets('at the narrowest widths the description gets the line to itself',
+      (tester) async {
+    // The third rung, and the reason the width sweep above passes at 320: the
+    // category trigger costs the description 56px, and there is a width where
+    // that is the difference between a whole hint and a truncated one. This
+    // pins the ladder's last step as a decision rather than an accident.
+    double dyOf(WidgetTester t, Finder f) => t.getTopLeft(f).dy;
+    final categoryFinder = find.byType(PopupMenuButton<String>);
+    final labelFinder = find.byType(TextField).first;
+
+    await _pump(tester, const [], width: 360);
+    expect(dyOf(tester, categoryFinder), dyOf(tester, labelFinder),
+        reason: 'a 360px row can still afford the category beside the label');
+
+    await _pump(tester, const [], width: 320);
+    expect(dyOf(tester, categoryFinder), greaterThan(dyOf(tester, labelFinder)),
+        reason: 'at 320px the category has to move off the label\'s line');
+  });
+
+  testWidgets('next carries from the label to the amount on both shapes',
+      (tester) async {
+    // Untested before this change, and the thing splitting a Row into a Column
+    // is most likely to break silently: `next` walks the ambient
+    // ReadingOrderTraversalPolicy, so it has to cross the line break. (The
+    // commit itself is covered by the add-button tests above; this harness's
+    // testTextInput.receiveAction does not reach onSubmitted, on the one-line
+    // shape either, so asserting it here would pin the harness, not the row.)
+    for (final width in [900.0, 360.0]) {
+      await _pump(tester, const [], width: width);
+      await tester.enterText(find.byType(TextField).first, 'Gelato');
+      await tester.testTextInput.receiveAction(TextInputAction.next);
+      await tester.pumpAndSettle();
+
+      final amount = tester.state<EditableTextState>(find.descendant(
+          of: find.byType(TextField).last,
+          matching: find.byType(EditableText)));
+      expect(amount.widget.focusNode.hasFocus, isTrue,
+          reason: 'next must reach the amount field at ${width}px');
+    }
+  });
+
+  testWidgets('the icon affordances are the widths the row budgets for them',
+      (tester) async {
+    // The row's arithmetic spends 48 on each. It renders them inside a
+    // SizedBox of that width rather than predicting them, so this asserts a
+    // declaration held — and it would fire the moment someone removed those
+    // boxes, since IconButton is 48 only on mobile and 40 on desktop.
+    await _pump(tester, const [], width: 360);
+    for (final finder in [
+      find.byType(PopupMenuButton<String>),
+      find.widgetWithIcon(IconButton, Icons.add),
+    ]) {
+      expect(tester.getSize(finder).width, 48,
+          reason: 'this width is spent by the add row\'s split arithmetic');
+    }
   });
 
   testWidgets(


### PR DESCRIPTION
## Summary

On a phone the Budget tab's add-expense row rendered its description hint as **"Add a…"**. The field was illegible — and at ~106px too narrow to type into either, so shortening the copy would only have made an unusable field readable.

The row spent 252 of its 358px on fixed-width controls, 136 of it on a hard-coded amount box. Measured in Inter, `"Add an expense…"` needs a **180px** field. Nothing caught it: a field hint inherits `hintMaxLines` from `TextField.maxLines` (1), so it ellipsizes silently against a tight width — no overflow stripes, no exception, just a shorter string.

Both widths were folklore. `f162b09` widened the amount box 88 → 136 so *its* hint would stop truncating and pinned that with a test; the description's hint was never measured, and the comment beside it conceded the string "barely fits".

**The row now derives its shape from the strings it is about to draw.** One helper answers "how wide must this field be" (`TextPainter` at the ambient text scale, in the style `InputDecorator` actually paints a hint with), and a ladder spends the result:

1. everything on one line
2. the money and the commit drop to a second line
3. the category drops too, and the description takes the whole line

Measured in the real Inter face, every phone width (320→430px, EN and ES) lands on **rung 2**; tablets and desktop keep today's single line. Rung 3 is purely the large-text-scale rung.

Two corrections found on the way:

- **A dense outline field spends 32px of chrome, not 24.** M3 gives `contentPadding` 12/side, and `_RenderDecoration` *also* deducts `OutlineInputBorder.gapPadding` (4) per side. The old "16px per side" comment was right in total and wrong about why.
- **`IconButton` takes its tap-target size from the platform**, so the add button was 48 on mobile and **40 on desktop** — under Material's minimum. Both icon affordances are now *declared* at 48 rather than predicted, so the number the arithmetic spends is the number the row occupies, and the desktop tap target is correct.

The Planned/Paid control stays on its own line — that call is vindicated, not reversed: putting it back would only make the row stack at wider windows. `trip_detail_screen.dart` is untouched.

## Testing

- `flutter test` — **1509 passed**, 0 failed (49 in `budget_section_test.dart`, up from 43).
- `flutter analyze` — no issues in the changed files; the 3 remaining are pre-existing in `lib/models/route_response.dart`.
- New gate is **constant-free**: a sweep over 8 widths × 2 locales asserting each hint's intrinsic width fits the width its field gave it. It names the width that broke rather than a width the row should have — and it found the 320px case that motivated the third rung.
- Measuring in the font the widget renders in is what finally makes **Spanish** testable; the predecessor had to give up and say "English only on purpose".
- Also pinned: one-line-vs-two by geometry, that the split responds to **text scale** rather than a hardcoded width, that the two icon affordances really are the widths the arithmetic budgets, the third rung, and `next` traversal from label → amount on both shapes.
- Verified separately against the **real Inter face** (throwaway probe, not committed): `"Add an expense…"` = 143.5px, so its field needs 180 where the old row gave it ~106.

🤖 Generated with [Claude Code](https://claude.com/claude-code)