### PR TITLE
fix(budget): name the Planned/Paid control and tie it to the row it arms

### DIFF
--- a/src/packages/flutter-app/lib/l10n/app_en.arb
+++ b/src/packages/flutter-app/lib/l10n/app_en.arb
@@ -456,6 +456,7 @@
   "budgetCategoryTransport": "Transport",
   "budgetCategoryShopping": "Shopping",
   "budgetCategoryGeneral": "General",
+  "budgetPlanAddAs": "Add as",
   "budgetPlanStatePlanned": "Planned",
   "budgetPlanStatePaid": "Paid",
   "budgetPlanRowBothSemantics": "Planned {planned}, paid {paid}",

--- a/src/packages/flutter-app/lib/l10n/app_es.arb
+++ b/src/packages/flutter-app/lib/l10n/app_es.arb
@@ -300,6 +300,7 @@
   "budgetCategoryTransport": "Transporte",
   "budgetCategoryShopping": "Compras",
   "budgetCategoryGeneral": "General",
+  "budgetPlanAddAs": "Añadir como",
   "budgetPlanStatePlanned": "Previsto",
   "budgetPlanStatePaid": "Pagado",
   "budgetPlanRowBothSemantics": "Previsto {planned}, pagado {paid}",

--- a/src/packages/flutter-app/lib/l10n/app_localizations.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations.dart
@@ -1898,6 +1898,12 @@ abstract class AppLocalizations {
   /// **'General'**
   String get budgetCategoryGeneral;
 
+  /// No description provided for @budgetPlanAddAs.
+  ///
+  /// In en, this message translates to:
+  /// **'Add as'**
+  String get budgetPlanAddAs;
+
   /// No description provided for @budgetPlanStatePlanned.
   ///
   /// In en, this message translates to:

--- a/src/packages/flutter-app/lib/l10n/app_localizations_en.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations_en.dart
@@ -966,6 +966,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get budgetCategoryGeneral => 'General';
 
   @override
+  String get budgetPlanAddAs => 'Add as';
+
+  @override
   String get budgetPlanStatePlanned => 'Planned';
 
   @override

--- a/src/packages/flutter-app/lib/l10n/app_localizations_es.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations_es.dart
@@ -975,6 +975,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get budgetCategoryGeneral => 'General';
 
   @override
+  String get budgetPlanAddAs => 'Añadir como';
+
+  @override
   String get budgetPlanStatePlanned => 'Previsto';
 
   @override

--- a/src/packages/flutter-app/lib/widgets/budget_section.dart
+++ b/src/packages/flutter-app/lib/widgets/budget_section.dart
@@ -498,7 +498,6 @@ class _BudgetSectionState extends ConsumerState<BudgetSection> {
             isOffline: widget.isOffline,
             onAdd: _addDailySpend,
           ),
-          const SizedBox(height: AppSpacing.sm),
           _buildModeControl(theme),
           _buildAddRow(theme),
         ],
@@ -940,6 +939,15 @@ class _BudgetSectionState extends ConsumerState<BudgetSection> {
   /// rather than reversing it — putting it back in the row would only make the
   /// row stack at wider and wider windows.
   ///
+  /// It carries a visible "Add as" label because the pick has **no immediate
+  /// on-screen consequence** — tapping it changes nothing but itself, and the
+  /// result only appears one action later, on the line you then add. An
+  /// unlabelled pill sitting between the daily-spend card and the add row was
+  /// read as belonging to the card, or as a filter over the list above, and so
+  /// as a control that did nothing. The label is what ties it to the row it
+  /// arms; the [AppSpacing.md] above and [AppSpacing.xs] below are the rest of
+  /// that tie.
+  ///
   /// The pick is read from the draft, so it survives the remount that changing
   /// header tab or opening the chat panel causes — a choice, like the category
   /// beside it.
@@ -948,33 +956,55 @@ class _BudgetSectionState extends ConsumerState<BudgetSection> {
       final planned = ref
           .watch(expenseDraftProvider(widget.tripId).select((d) => d.planned));
       final l10n = context.l10n;
-      return Align(
-        alignment: Alignment.centerRight,
-        child: Padding(
-          padding: const EdgeInsets.only(bottom: AppSpacing.xs),
-          child: SegmentedButton<bool>(
-            showSelectedIcon: false,
-            style: ButtonStyle(
-              visualDensity: VisualDensity.compact,
-              textStyle: WidgetStatePropertyAll(theme.textTheme.labelMedium),
+      return Padding(
+        // The top gap lives here rather than in a sibling SizedBox because
+        // DailySpendSection collapses to nothing when offline or empty — a
+        // sibling would dangle above the add row in the common case.
+        padding:
+            const EdgeInsets.only(top: AppSpacing.md, bottom: AppSpacing.xs),
+        // Wrap, not Row: the label and the pill sit side by side when they
+        // fit and the pill drops to its own line when they don't, which is
+        // what Spanish does at 360px ("Añadir como" wants more than the
+        // leftover beside a two-segment pill). A Row would have to choose
+        // between ellipsizing the label and wrapping it mid-phrase, and both
+        // fail silently — the add row's hints already taught this file that
+        // "nothing threw" proves nothing. Wrap needs no measurement, so it is
+        // right in every language and at every text scale by construction.
+        child: Wrap(
+          alignment: WrapAlignment.end,
+          crossAxisAlignment: WrapCrossAlignment.center,
+          spacing: AppSpacing.sm,
+          runSpacing: AppSpacing.xs,
+          children: [
+            Text(
+              l10n.budgetPlanAddAs,
+              style: theme.textTheme.labelMedium
+                  ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
             ),
-            segments: [
-              ButtonSegment(
-                value: true,
-                label: Text(l10n.budgetPlanStatePlanned),
+            SegmentedButton<bool>(
+              showSelectedIcon: false,
+              style: ButtonStyle(
+                visualDensity: VisualDensity.compact,
+                textStyle: WidgetStatePropertyAll(theme.textTheme.labelMedium),
               ),
-              ButtonSegment(
-                value: false,
-                label: Text(l10n.budgetPlanStatePaid),
-              ),
-            ],
-            selected: {planned},
-            onSelectionChanged: widget.isOffline
-                ? null
-                : (picked) => ref
-                    .read(expenseDraftProvider(widget.tripId).notifier)
-                    .setPlanned(picked.first),
-          ),
+              segments: [
+                ButtonSegment(
+                  value: true,
+                  label: Text(l10n.budgetPlanStatePlanned),
+                ),
+                ButtonSegment(
+                  value: false,
+                  label: Text(l10n.budgetPlanStatePaid),
+                ),
+              ],
+              selected: {planned},
+              onSelectionChanged: widget.isOffline
+                  ? null
+                  : (picked) => ref
+                      .read(expenseDraftProvider(widget.tripId).notifier)
+                      .setPlanned(picked.first),
+            ),
+          ],
         ),
       );
     });

--- a/src/packages/flutter-app/test/budget_section_test.dart
+++ b/src/packages/flutter-app/test/budget_section_test.dart
@@ -1051,6 +1051,10 @@ void main() {
       final fake = await _pump(tester, [_exp('a', 'food', 'Lunch', 20)],
           targetAmount: 2000);
 
+      // The pick has no immediate on-screen effect, so the label is the only
+      // thing saying what the pill arms. Without it the control reads as dead.
+      expect(find.text('Add as'), findsOneWidget);
+
       await tester.enterText(find.byType(TextField).first, 'Museum pass');
       await tester.enterText(find.byType(TextField).last, '42');
       await tester.tap(find.byTooltip('Add expense'));
@@ -1098,6 +1102,9 @@ void main() {
       expect(find.byTooltip('Mark as paid'), findsNothing);
       expect(find.byTooltip('Mark as planned'), findsNothing);
       expect(find.byType(SegmentedButton<bool>), findsNothing);
+      // The label and the pill share one `canEdit` guard; assert both so they
+      // cannot drift into a label naming a control that isn't there.
+      expect(find.text('Add as'), findsNothing);
     });
 
     testWidgets('Spanish keeps Previsto for money and fits at 360px',
@@ -1113,7 +1120,12 @@ void main() {
       expect(find.text('Previsto'), findsOneWidget);
       expect(find.text('Pagado'), findsOneWidget);
       expect(find.text('Total previsto'), findsOneWidget);
-      expect(tester.takeException(), isNull);
+      // The widest form of the new label, on the narrowest phone. Asserted
+      // through expectHintsWhole rather than by finding it: the label shares
+      // its row with a natural-width pill, and "it is on screen and nothing
+      // threw" is exactly the vacuous check the add-row hints taught us to
+      // distrust — a Text that does not fit shrinks quietly instead.
+      expectHintsWhole(tester, ['Añadir como'], 'in the mode control at 360px');
     });
   });
 


### PR DESCRIPTION
## Why

Brian, on the Budget tab: *"planned vs paid slider at the bottom doesn't do anything."*

It does work. It's a `SegmentedButton` (there is no `Slider` anywhere in `lib/`), and the whole path is intact and covered by a passing test: tap → `ExpenseDraft.planned` → `addExpense(planned:)` → `planned_amount` **or** `actual_amount` on the wire, never the legacy `amount`.

What was broken is the affordance:

- it carried **no label**, so nothing said what it was for;
- tapping it **changes nothing on screen but itself** — the consequence only appears one action later, on the line you then add;
- it sat `AppSpacing.sm` below the Daily food & drink card and `AppSpacing.xs` above the add row, so it read as belonging to **the card above**, or as a filter over the expense list.

## What changed

`Add as   [ Planned │ Paid ]` — the pill is unchanged, including its offline `null` guard. Behaviour, wire format and server are untouched; this is purely how the control presents itself.

**`Wrap`, not `Row`.** The first cut used `Row` + `Expanded` on the label. The strengthened test caught that Spanish at 360px wants **137.5px** for "Añadir como" and a Row's leftover beside a two-segment pill is **104px** — so it silently wrapped mid-phrase. A Row can only pick between ellipsizing and wrapping, and both fail quietly. `Wrap` seats them side by side when they fit and drops the pill to its own line when they don't, with no measurement, so it's right in every language and at every text scale by construction.

**The 8px gap** moved out of a sibling `SizedBox` and into the control's own `top` padding — `DailySpendSection` collapses to `SizedBox.shrink()` when offline or empty, so that sibling dangled above the add row in the common case.

## Tests

49/49 in `budget_section_test.dart`.

The Spanish fit assertion goes through #461's `expectHintsWhole` instead of `find.text` + `takeException`. That is what caught the 104px squeeze — a `Text` that doesn't fit shrinks quietly, so "it's on screen and nothing threw" proves nothing. Two more assertions pin that the label and the pill share one `canEdit` guard and can't drift apart.

## Not in scope

- `addExpense`'s `planned` parameter defaults to `false` while `ExpenseDraft` defaults to `true`. A trap for a future caller, but making it `required` drags in `trip_detail_screen.dart`, which `specs/budget-planned-vs-paid/plan.md` keeps out of this feature on purpose.
- Offline still makes the pill inert with no explanation, unlike every other offline action here (which routes through `_guard()` and snackbars). Pre-existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)