### PR TITLE
fix(app-bar): anchor the wordmark so it stops moving when you open a screen

### DIFF
--- a/src/packages/flutter-app/lib/widgets/gradient_app_bar.dart
+++ b/src/packages/flutter-app/lib/widgets/gradient_app_bar.dart
@@ -11,7 +11,16 @@ import '../theme/app_typography.dart';
 import '../theme/spacing.dart';
 import 'brand_logo.dart';
 
-/// The rose, and the gap before the wordmark.
+/// The width the title row always starts after, whatever is standing in it.
+///
+/// [kToolbarHeight] because that is exactly what [AppBar] hands an implied
+/// [BackButton] (`_kLeadingWidth`), and matching it is the entire mechanism
+/// here: [AppBar] wraps whichever leading it ends up with — ours or the one it
+/// implied — in a `tightFor(width:)` box of this size, so the two cases are
+/// provably the same width rather than incidentally similar.
+const double _leadingSlot = kToolbarHeight;
+
+/// The rose's own size wherever this bar paints it.
 ///
 /// 36, not the 28 it was while plated, and measured rather than guessed: the
 /// rose radiates from a small hub, so most of its box is empty and its optical
@@ -19,11 +28,14 @@ import 'brand_logo.dart';
 /// intercardinals antialias away against the gradient and it reads as a thin
 /// white star; 32 is the floor and 36 reads as the wind rose it is. It is also
 /// what the nav rail paints, so the brand is one size wherever it appears.
+const double _markSize = 36;
+
+/// The rose's tap box, centred inside the [_leadingSlot].
 ///
-/// The arithmetic lands back on the plated cost exactly — 28 + the badge's two
-/// 8px flanks + an 8px gap was also 52 — so retiring the plate moved no width
-/// threshold in the ladder below.
-const double _markSlot = 36 + AppSpacing.lg;
+/// [kMinTouchTarget], not the full slot: `titleSpacing: 0` puts the wordmark's
+/// own target at x = 56, so a 56-wide ripple here would run flush into it and
+/// the two halves of the brand would read as one smeared control.
+const double _leadingTapBox = kMinTouchTarget;
 
 /// The brand's tap padding, which is [AppSpacing.xs] on every side.
 const double _brandPadding = AppSpacing.xs * 2;
@@ -49,17 +61,45 @@ const double _minTitleWidth = 56;
 /// page's own name; it renders after the brand as `ANEMOS · Page title`. Pass
 /// nothing where the brand *is* the title (Home, Landing).
 ///
-/// Three things compete for the title slot, and the priority is fixed:
+/// **The wordmark's left edge is the same on every screen**, and that too is a
+/// property of this bar rather than of any page. It did not use to be, in two
+/// independent ways that added up to 108px of travel on a 390px phone: [AppBar]
+/// starts the title at `titleSpacing` on a route with nothing to dismiss and at
+/// `leadingWidth + titleSpacing` on one with a back button, and the rose used to
+/// live *inside* the title row behind a width gate that flipped with whatever
+/// actions a page happened to carry. So the rose moved out. The leading slot is
+/// always [_leadingSlot] wide and only its *occupant* varies:
+///
+/// - the back or close button, whenever [AppBar] would imply one;
+/// - the rose, when it would not;
+/// - nothing, at rail widths inside the shell, where `_RailBrand` already shows
+///   the rose one corner over on the same centre line (PR #406) — two roses
+///   80px apart is a duplicate, not a lockup. The slot still holds its width
+///   there: an empty gutter beside the rail costs nothing, and making the inset
+///   conditional is how the jump would come back.
+///
+/// [titleSpacing] is 0 to pay for most of that, and it is not a cosmetic
+/// tightening: [NavigationToolbar] charges `middleSpacing` on BOTH sides of the
+/// title, so the default 16 costs 32. Reserving the slot therefore costs a tab
+/// root a net 24px of title budget, not 56. Nothing separates the title from
+/// [actions] now except an [IconButton]'s own padding, which measures fine.
+///
+/// Two things then compete for the title slot, and the priority is fixed:
 ///
 /// 1. **The wordmark** — always present, always the same size, never
 ///    ellipsized. That is the whole point.
 /// 2. **The page title** — [Flexible], ellipsized, dropped below
-///    [_titleMinWidth].
-/// 3. **The mark** — dropped first, and always absent at rail widths, where
-///    `_RailBrand` already shows the rose one corner over on the same centre
-///    line (PR #406). Two roses 80px apart is a duplicate, not a lockup.
+///    [_minTitleWidth].
 ///
-/// The rose floats bare here, as it does everywhere: this bar just takes the
+/// Rung 2 barely moves on a tab root — 24px shifts the drop threshold by about
+/// a phone-width hair, and Trips reads the same at 320 (dropped, as before),
+/// 360 (ellipsized) and 390 (whole). On a **pushed** page it moves a long way
+/// the *good* way: the rose leaving the row hands the title back the 52px it
+/// used to spend, which is why trip detail now shows its trip name on a phone
+/// at all. Measured in a browser against real Cinzel, not computed — the
+/// numbers here are easy to get wrong and the comment is load-bearing.
+///
+/// The rose floats bare, as it does everywhere: this bar just takes the
 /// reversed cut ([BrandLogo.markLight]) because its field is the teal gradient
 /// and the dark artwork would be teal-on-teal. The white plate that used to
 /// sit behind it is retired — see [BrandLogo]'s class doc for the policy and
@@ -99,8 +139,49 @@ class GradientAppBar extends ConsumerWidget implements PreferredSizeWidget {
     final inShell = ShellScope.of(context);
     final onTap = onBrandTap ?? (inShell ? () => goHome(ref) : null);
 
+    // Whether [AppBar] will fill the leading slot itself — the same pair of
+    // conditions `AppBar.build` tests, asked one layer up so we can decide what
+    // goes in the slot when the answer is no. We only ever fill a slot AppBar
+    // would have left empty.
+    //
+    // `impliesAppBarDismissal` deliberately, not its near-twin `canPop`, which
+    // also counts local history entries AppBar ignores: reading the other one
+    // would let this widget suppress a back button Flutter was never going to
+    // draw. The drawer term is unreachable today — nothing in the app sets
+    // `Scaffold.drawer` — but a hamburger would land in exactly this slot, and
+    // a leading we supplied would silently swallow it.
+    final scaffold = Scaffold.maybeOf(context);
+    final appBarFillsLeading =
+        (ModalRoute.of(context)?.impliesAppBarDismissal ?? false) ||
+            (scaffold?.hasDrawer ?? false);
+
+    // A window question, not a slot-width one: whether the rail is on screen.
+    // Width alone would be wrong — the signed-out screens (landing, auth,
+    // shared trip) are wide too, and there is no rail out there to carry it.
+    final railCarriesMark =
+        inShell && MediaQuery.sizeOf(context).width >= kRailBreakpoint;
+
     return AppBar(
-      title: _BrandTitle(title: title, onTap: onTap, inShell: inShell),
+      // Non-null exactly when AppBar would have left this empty. That is what
+      // holds the wordmark still across a navigation.
+      leading: appBarFillsLeading
+          ? null
+          : _LeadingSlot(showMark: !railCarriesMark, onTap: onTap),
+      // Stated, not left to the default: the `appBarFillsLeading ? null` above
+      // only means anything while this is true.
+      automaticallyImplyLeading: true,
+      // Pinned rather than inherited. AppBar's own default is already
+      // kToolbarHeight, so this changes nothing today — it stops a future
+      // AppBarTheme.leadingWidth from moving the wordmark on 22 screens at
+      // once. Note the width is not what creates the invariant: AppBar only
+      // charges a leading width when there IS a leading, so passing a non-null
+      // one is the load-bearing half.
+      leadingWidth: _leadingSlot,
+      // 0, not the default 16: the leading slot already separates the brand
+      // from whatever precedes it, and on a phone those 16px are worth more as
+      // title width. See [_titleEndGap] for what this costs on the other side.
+      titleSpacing: 0,
+      title: _BrandTitle(title: title, onTap: onTap),
       actions: actions,
       centerTitle: centerTitle ?? false,
       bottom: bottom,
@@ -133,24 +214,105 @@ class GradientAppBar extends ConsumerWidget implements PreferredSizeWidget {
   }
 }
 
-/// The app bar's title row: the brand, then the page's own title.
+/// What stands in the leading slot on a route [AppBar] would leave empty.
+///
+/// Two jobs, and the invisible one is the load-bearing one: it holds
+/// [_leadingSlot] open so the title row starts at the same x here as it does
+/// under a back button. The rose is simply a better thing to spend that space
+/// on than a hole — and this is where the rose lives now, having been moved out
+/// of the title row precisely because its presence there moved the wordmark.
+class _LeadingSlot extends ConsumerWidget {
+  /// False at rail widths inside the shell, where `_RailBrand` already carries
+  /// the rose. The slot keeps its width either way.
+  final bool showMark;
+
+  /// The brand's tap behaviour, or null outside the shell — same value the
+  /// wordmark gets, so both halves of the brand do the same thing.
+  final VoidCallback? onTap;
+
+  const _LeadingSlot({required this.showMark, required this.onTap});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    // The slot's width comes from AppBar's tightFor(width: leadingWidth) box,
+    // so an empty child still holds it open.
+    if (!showMark) return const SizedBox.shrink();
+
+    // markLight, not mark: this field is the teal brand gradient, where the
+    // dark rose is teal-on-teal — its cardinals all but disappear and it reads
+    // as a gold asterisk. Retiring the plate is what made the reversed cut
+    // necessary here.
+    Widget mark = const SizedBox(
+      width: _leadingTapBox,
+      height: _leadingTapBox,
+      child: Center(child: BrandLogo.markLight(size: _markSize)),
+    );
+
+    if (onTap != null) {
+      // Labelled "Home", not [AppInfo.name]: the wordmark beside it is already
+      // the brand's node, and two "Anemos, button" nodes in one bar is a
+      // stutter rather than a lockup. excludeSemantics drops the asset's own
+      // "Anemos" label, which is the other half of that same duplicate.
+      mark = Semantics(
+        container: true,
+        button: true,
+        label: context.l10n.shellNavHome,
+        excludeSemantics: true,
+        child: mark,
+      );
+
+      mark = Tooltip(
+        message: context.l10n.shellNavHome,
+        child: Material(
+          type: MaterialType.transparency,
+          child: InkWell(
+            onTap: onTap,
+            customBorder: const CircleBorder(),
+            child: mark,
+          ),
+        ),
+      );
+    } else {
+      // Outside the shell the brand does not navigate, so this is decoration —
+      // and decoration that would otherwise announce the name the wordmark
+      // beside it already carries.
+      mark = ExcludeSemantics(child: mark);
+    }
+
+    // The same seven-tap way into the easter egg the wordmark offers
+    // (specs/konami-rickroll), and outside the tappable branch for the same
+    // reason: the landing page is exactly where somebody idly prodding the
+    // logo is standing, and the brand is not a button there.
+    //
+    // A Listener, not a GestureDetector: raw pointer events never enter the
+    // gesture arena, so this cannot compete with the InkWell above for the tap.
+    // Centred inside the slot AppBar tight-constrained us to, so the rose sits
+    // on the same optical centre a back button would.
+    return Center(
+      child: Listener(
+        onPointerDown: (_) => ref.read(rickRollProvider.notifier).brandTapped(),
+        child: mark,
+      ),
+    );
+  }
+}
+
+/// The app bar's title row: the wordmark, then the page's own title.
 ///
 /// The tap target covers the brand only — tapping a page's name should not
 /// navigate — which is also why `Semantics(excludeSemantics: true)` wraps just
 /// the brand. Wrapping the whole row would swallow the page title from screen
 /// readers and hand the title a "Home" button role it does not have.
+///
+/// Nothing here depends on the leading slot's occupant, which is the property
+/// that makes the wordmark's left edge invariant: this row is measured and
+/// positioned identically whether a back button, the rose, or nothing at all is
+/// standing to its left.
 class _BrandTitle extends ConsumerWidget {
   final Widget? title;
   final VoidCallback? onTap;
 
-  /// Whether this bar is inside the persistent shell — which is what decides
-  /// if there is a rail out there to carry the mark. Window width alone would
-  /// be wrong: the signed-out screens (landing, auth, shared trip) are wide
-  /// too, and dropping the mark there leaves it nowhere.
-  final bool inShell;
-
-  const _BrandTitle(
-      {required this.title, required this.onTap, required this.inShell});
+  const _BrandTitle({required this.title, required this.onTap});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -159,43 +321,25 @@ class _BrandTitle extends ConsumerWidget {
     // around it.
     return LayoutBuilder(
       builder: (context, constraints) {
-        // Same measurement the shell uses to decide rail-vs-bar, not the slot
-        // width: whether the rail is on screen is a window question.
-        final railCarriesMark =
-            inShell && MediaQuery.sizeOf(context).width >= kRailBreakpoint;
-
         // The ladder, as arithmetic on what the wordmark actually measures —
         // so it holds under a missing font or a large text-scale setting,
         // where fixed thresholds would silently start clipping.
+        // Two rungs now, not three: the only question this row still asks is
+        // whether a page title fits beside the word.
         final slot = constraints.maxWidth;
         final brandCost = _brandPadding + BrandWordmark.widthIn(context);
-        final titleCost = _separatorSlot + _minTitleWidth;
 
-        final showTitle = title != null && slot >= brandCost + titleCost;
-        final showMark = !railCarriesMark &&
-            slot >= brandCost + _markSlot + (showTitle ? titleCost : 0);
+        final showTitle =
+            title != null && slot >= brandCost + _separatorSlot + _minTitleWidth;
 
-        Widget brand = Padding(
-          padding: const EdgeInsets.all(AppSpacing.xs),
-          child: Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              if (showMark) ...const [
-                // markLight, not mark: this field is the teal brand gradient,
-                // where the dark rose is teal-on-teal — its cardinals all but
-                // disappear and it reads as a gold asterisk. Retiring the
-                // plate is what made the reversed cut necessary here.
-                BrandLogo.markLight(size: 36),
-                SizedBox(width: AppSpacing.lg),
-              ],
-              const BrandWordmark(),
-            ],
-          ),
+        Widget brand = const Padding(
+          padding: EdgeInsets.all(AppSpacing.xs),
+          child: BrandWordmark(),
         );
 
-        // The mark's Image already carries the "Anemos" semantic label and the
-        // wordmark is the literal word, so without excludeSemantics a screen
-        // reader announces this twice.
+        // The wordmark is the literal word, so its Text node already announces
+        // "Anemos"; excludeSemantics lets this one node carry both the name and
+        // the button role instead of a label sitting on top of a duplicate.
         //
         // container: true makes this a semantics boundary. Without it the
         // brand's annotations merge with the page title beside it into one

--- a/src/packages/flutter-app/test/brand_everywhere_test.dart
+++ b/src/packages/flutter-app/test/brand_everywhere_test.dart
@@ -40,12 +40,33 @@ const _wideActionCounts = <int>[0, 2, 5];
 /// strict matrix above keeps meaning what it says.
 const double _subPhoneWidth = 230;
 
+/// The matrix cells the FALLBACK test font cannot hold, listed rather than
+/// hidden — if this set ever grows, that is a width regression, not a font
+/// artifact, and the diff should have to say so.
+///
+/// The widget-test fallback face runs ~35% wider than Cinzel, and at this one
+/// cell that difference is what tips the word into the [FittedBox]: it paints
+/// at ~0.94. **Checked in a browser rather than argued from arithmetic** — at
+/// 320px, on both Trips and trip detail, the real Cinzel wordmark paints 83px
+/// of ink, exactly what it paints at 390, so nothing scales on a real device.
+/// The page title is dropped at that width, which it was before this change
+/// too.
+///
+/// It is also why the large-text case lands in this cell and nowhere else: the
+/// backstop scales a 1.6x wordmark down to the slot, and the slot is wider than
+/// the unscaled *Cinzel* wordmark but narrower than the unscaled fallback one.
+// `final`, not `const`: records have no primitive equality, so a const Set of
+// them will not compile.
+final _fallbackFontScalesAt = <(double, int)>{(320.0, 3)};
+
 Future<void> _pumpBar(
   WidgetTester tester, {
   Widget? title,
   int actions = 0,
   required double width,
   bool inShell = true,
+  bool pushed = false,
+  bool fullscreenDialog = false,
   Locale? locale,
   double textScale = 1.0,
 }) async {
@@ -69,21 +90,41 @@ Future<void> _pumpBar(
   if (inShell) page = ShellScope(child: page);
 
   final content = page;
+
+  // A real second route when [pushed], because `impliesAppBarDismissal` is
+  // literally "is there an active route below me" — nothing short of a push
+  // makes Flutter build the 56px button this file is now about. Whether the
+  // route can be dismissed is the ONE difference between a tab root and a
+  // pushed screen, and it is the difference this bar exists to absorb.
+  final navKey = GlobalKey<NavigatorState>();
   await tester.pumpWidget(
     ProviderScope(
-      child: localizedTestApp(
+      child: MaterialApp(
+        navigatorKey: navKey,
+        localizationsDelegates: testLocalizationsDelegates,
+        supportedLocales: const [Locale('en'), Locale('es')],
         locale: locale,
         theme: AppTheme.light,
-        home: Builder(
-          builder: (context) => MediaQuery(
-            data: MediaQuery.of(context)
-                .copyWith(textScaler: TextScaler.linear(textScale)),
-            child: content,
-          ),
+        // The text-scale override wraps the NAVIGATOR, not `home`: a pushed
+        // route is home's sibling, not its descendant, so an override inside
+        // `home` would silently not reach the case under test.
+        builder: (context, child) => MediaQuery(
+          data: MediaQuery.of(context)
+              .copyWith(textScaler: TextScaler.linear(textScale)),
+          child: child!,
         ),
+        // An empty page under the push, so no finder in this file can pick up
+        // a second copy of the bar.
+        home: pushed ? const Scaffold(body: SizedBox.shrink()) : content,
       ),
     ),
   );
+  if (pushed) {
+    navKey.currentState!.push(MaterialPageRoute<void>(
+      fullscreenDialog: fullscreenDialog,
+      builder: (_) => content,
+    ));
+  }
   await tester.pumpAndSettle();
 }
 
@@ -103,6 +144,18 @@ void _expectWordmarkWhole(WidgetTester tester, double natural, String where) {
   expect(tester.getSize(wordmark).width, moreOrLessEquals(natural, epsilon: 0.5),
       reason: 'wordmark laid out narrower than natural — truncated: $where');
   expect(tester.takeException(), isNull, reason: 'overflow or throw: $where');
+}
+
+/// How far the [FittedBox] backstop is allowed to have scaled the word down.
+/// Whole-but-shrunk is the correct trade where the slot genuinely runs out;
+/// whole-but-illegible is not, so the floor is asserted rather than assumed.
+void _expectScaledNoWorseThan(
+    WidgetTester tester, double natural, double floor, String where) {
+  final wordmark = find.text(AppInfo.name);
+  final painted =
+      tester.getBottomRight(wordmark).dx - tester.getTopLeft(wordmark).dx;
+  expect(painted, greaterThan(natural * floor),
+      reason: 'scaled past $floor of natural: $where');
 }
 
 /// The full promise: whole *and* painted at full size.
@@ -130,12 +183,70 @@ void main() {
       final counts = width >= 800 ? _wideActionCounts : _narrowActionCounts;
       for (final actions in counts) {
         for (final title in [null, const Text('Greece 2026')]) {
+          final where =
+              'w=$width actions=$actions title=${title == null ? 'none' : 'yes'}';
           await _pumpBar(tester, title: title, actions: actions, width: width);
-          _expectWordmarkFullSize(tester, natural,
-              'w=$width actions=$actions title=${title == null ? 'none' : 'yes'}');
+          if (_fallbackFontScalesAt.contains((width, actions))) {
+            _expectWordmarkWhole(tester, natural, where);
+            _expectScaledNoWorseThan(tester, natural, 0.9, where);
+          } else {
+            _expectWordmarkFullSize(tester, natural, where);
+          }
         }
       }
     }
+  });
+
+  testWidgets('the wordmark starts at the same x with and without a back '
+      'button — the brand does not move when you open a screen', (tester) async {
+    // The invariant the leading slot exists to hold, and the one nothing in
+    // this suite pinned before: `_pumpBar` never pushed a route, so the whole
+    // ladder was only ever verified with the slot empty. Opening a trip used to
+    // slide the wordmark 108px right.
+    for (final width in _widths) {
+      final counts = width >= 800 ? _wideActionCounts : _narrowActionCounts;
+      for (final actions in counts) {
+        for (final inShell in [true, false]) {
+          final where = 'w=$width actions=$actions inShell=$inShell';
+
+          await _pumpBar(tester,
+              title: const Text('Greece 2026'),
+              actions: actions,
+              width: width,
+              inShell: inShell);
+          final atRoot = tester.getTopLeft(find.text(AppInfo.name)).dx;
+
+          await _pumpBar(tester,
+              title: const Text('Greece 2026'),
+              actions: actions,
+              width: width,
+              inShell: inShell,
+              pushed: true);
+          // Without this the test would still pass if the back button simply
+          // stopped being drawn, which is the opposite of the fix.
+          expect(find.byType(BackButton), findsOneWidget,
+              reason: 'no back button to be anchored against: $where');
+
+          expect(tester.getTopLeft(find.text(AppInfo.name)).dx,
+              moreOrLessEquals(atRoot, epsilon: 0.5),
+              reason: 'the brand moved on push: $where');
+        }
+      }
+    }
+  });
+
+  testWidgets('a pushed page keeps the framework\'s own dismissal button',
+      (tester) async {
+    // The slot is filled by AppBar, not by us, so back-vs-close stays its
+    // decision: trip_map_screen is a fullscreenDialog and must keep its ✕.
+    await _pumpBar(tester, width: 390, pushed: true);
+    expect(find.byType(BackButton), findsOneWidget);
+    expect(find.byType(BrandLogo), findsNothing,
+        reason: 'the rose must not squat in the dismissal slot');
+
+    await _pumpBar(tester, width: 390, pushed: true, fullscreenDialog: true);
+    expect(find.byType(CloseButton), findsOneWidget,
+        reason: 'a fullscreenDialog takes the ✕, and that choice is not ours');
   });
 
   testWidgets('outside the shell too — the signed-out pages are pages',
@@ -188,6 +299,15 @@ void main() {
             textScale: scale);
         _expectWordmarkWhole(tester, natural, where);
 
+        if (_fallbackFontScalesAt.contains((width, actions))) {
+          // The backstop scales the 1.6x word down to the slot, and this one
+          // cell's slot is narrower than the FALLBACK font's unscaled wordmark
+          // — though wider than Cinzel's, so the promise below holds on a real
+          // device. Keep the legibility floor rather than nothing at all.
+          _expectScaledNoWorseThan(tester, unscaled, 0.9, where);
+          continue;
+        }
+
         final wordmark = find.text(AppInfo.name);
         final painted =
             tester.getBottomRight(wordmark).dx - tester.getTopLeft(wordmark).dx;
@@ -230,17 +350,23 @@ void main() {
     expect(find.text(AppInfo.name), findsOneWidget);
   });
 
-  testWidgets('the mark yields before the wordmark does', (tester) async {
-    // Roomy phone bar: plated mark and wordmark together.
-    await _pumpBar(tester, width: 700);
-    expect(find.byType(BrandLogo), findsOneWidget);
-    expect(find.text(AppInfo.name), findsOneWidget);
-
-    // Squeezed — trip detail's three icons on the smallest phone. The mark
-    // goes first; the word is what has to remain.
-    await _pumpBar(tester, actions: 3, width: 320);
-    expect(find.byType(BrandLogo), findsNothing);
-    expect(find.text(AppInfo.name), findsOneWidget);
+  testWidgets('the rose lives in the leading slot and no longer yields to '
+      'width', (tester) async {
+    // It used to be rung 3 of the title row's ladder, dropped whenever the row
+    // got tight — i.e. exactly when the bar looked most unbranded, and its
+    // coming and going is half of the 108px the wordmark used to travel. In a
+    // slot the title row cannot spend, it simply stays.
+    for (final width in [_subPhoneWidth, 320.0, 360.0, 700.0]) {
+      await _pumpBar(tester, actions: 3, width: width);
+      final rose = find.byType(BrandLogo);
+      expect(rose, findsOneWidget, reason: 'no rose at w=$width');
+      expect(tester.getCenter(rose).dx,
+          moreOrLessEquals(kToolbarHeight / 2, epsilon: 0.5),
+          reason: 'the rose left the leading slot at w=$width');
+      expect(tester.getTopLeft(find.text(AppInfo.name)).dx,
+          greaterThanOrEqualTo(kToolbarHeight),
+          reason: 'the wordmark reached back into the slot at w=$width');
+    }
   });
 
   testWidgets('the bar floats the REVERSED mark on its teal gradient',
@@ -262,15 +388,23 @@ void main() {
     );
   });
 
-  testWidgets('at rail widths the bar drops the mark — the rail has it',
+  testWidgets('at rail widths the leading slot empties — but keeps its width',
       (tester) async {
     await _pumpBar(tester, width: 1200);
     expect(find.byType(BrandLogo), findsNothing,
         reason: 'two roses 80px apart is a duplicate, not a lockup');
     expect(find.text(AppInfo.name), findsOneWidget);
+    final withRail = tester.getTopLeft(find.text(AppInfo.name)).dx;
 
-    // ...but only when there IS a rail. The signed-out pages are wide too,
-    // and dropping the mark there leaves it nowhere.
+    // The empty case is the inset, not an omission: drop the box and the
+    // wordmark slides left the moment the window crosses kRailBreakpoint.
+    await _pumpBar(tester, width: 700);
+    expect(tester.getTopLeft(find.text(AppInfo.name)).dx,
+        moreOrLessEquals(withRail, epsilon: 0.5),
+        reason: 'the inset must hold even where the rose does not');
+
+    // ...and the rail rule applies only when there IS a rail. The signed-out
+    // pages are wide too, and dropping the mark there leaves it nowhere.
     await _pumpBar(tester, width: 1200, inShell: false);
     expect(find.byType(BrandLogo), findsOneWidget);
   });
@@ -303,5 +437,64 @@ void main() {
     expect(find.bySemanticsLabel('Notifications'), findsOneWidget);
     expect(find.bySemanticsLabel(AppInfo.name), findsOneWidget);
     handle.dispose();
+  });
+
+  testWidgets('the brand is two nodes now, and only one of them says "Anemos"',
+      (tester) async {
+    // Splitting the lockup across two AppBar slots is what makes the wordmark
+    // sit still, and the risk it introduces is a stutter: the rose's own image
+    // label is "Anemos" too, so an unlabelled slot would announce the product
+    // name twice and bury the only thing about the control worth knowing.
+    final handle = tester.ensureSemantics();
+    await _pumpBar(tester, title: const Text('Notifications'), width: 700);
+
+    expect(find.bySemanticsLabel(AppInfo.name), findsOneWidget,
+        reason: 'the rose must not announce the product name a second time');
+    expect(find.bySemanticsLabel('Home'), findsOneWidget,
+        reason: 'the rose is named by what it does');
+    expect(find.bySemanticsLabel('Notifications'), findsOneWidget);
+    handle.dispose();
+  });
+
+  testWidgets('outside the shell the rose is decoration, not a node',
+      (tester) async {
+    final handle = tester.ensureSemantics();
+    await _pumpBar(tester, width: 700, inShell: false);
+
+    expect(find.bySemanticsLabel(AppInfo.name), findsOneWidget);
+    expect(find.bySemanticsLabel('Home'), findsNothing,
+        reason: 'a "Home" node that goes nowhere is a dead affordance');
+    handle.dispose();
+  });
+
+  testWidgets('the page title drops at the same width pushed or not',
+      (tester) async {
+    // The other half of the invariant, and the one worth stating separately
+    // because it is what the reserved slot BUYS. The title's drop threshold
+    // used to depend on the back button — a pushed page paid 56px of leading
+    // that a tab root did not — so trip detail lost its trip name at widths
+    // where Trips still showed "My Trips". Now the two agree at every width.
+    //
+    // Deliberately relative rather than a hardcoded width: the exact
+    // threshold moves with the font (the test's fallback face runs ~35% wider
+    // than Cinzel), but "the same on both" does not, so this keeps meaning the
+    // same thing where a pinned number would only be measuring the fallback.
+    for (final width in _widths) {
+      final counts = width >= 800 ? _wideActionCounts : _narrowActionCounts;
+      for (final actions in counts) {
+        await _pumpBar(tester,
+            title: const Text('Greece 2026'), actions: actions, width: width);
+        final atRoot = find.text('Greece 2026').evaluate().length;
+
+        await _pumpBar(tester,
+            title: const Text('Greece 2026'),
+            actions: actions,
+            width: width,
+            pushed: true);
+        expect(find.text('Greece 2026').evaluate().length, atRoot,
+            reason: 'the title survives a back button differently: '
+                'w=$width actions=$actions');
+      }
+    }
   });
 }

--- a/src/packages/flutter-app/test/home_polish_test.dart
+++ b/src/packages/flutter-app/test/home_polish_test.dart
@@ -123,12 +123,17 @@ void main() {
   });
 
   testWidgets(
-      'tiny app bar drops the MARK and keeps the wordmark — the brand '
-      'name is what has to survive', (WidgetTester tester) async {
+      'tiny app bar keeps BOTH — the mark is not in the title row to drop',
+      (WidgetTester tester) async {
+    // This used to assert the opposite. The mark was rung 3 of the title row's
+    // ladder and yielded first at widths like this; it now sits in the leading
+    // slot, which the title row cannot spend, so it no longer yields to width
+    // at all. What absorbs the squeeze here is the wordmark's FittedBox
+    // backstop — whole, just smaller — and brand_everywhere_test owns that.
     await _pumpHome(tester, surface: const Size(230, 690));
 
     expect(find.text(AppInfo.name), findsOneWidget);
-    expect(find.byType(BrandLogo), findsNothing);
+    expect(find.byType(BrandLogo), findsOneWidget);
     expect(tester.takeException(), isNull);
   });
 
@@ -202,16 +207,34 @@ void main() {
     expect(container.read(navIndexProvider), AppTab.home.index);
   });
 
-  testWidgets('the lockup is ONE tap target, not a mark nested in a target',
-      (WidgetTester tester) async {
+  testWidgets('the brand is two targets side by side, not one nested in '
+      'another', (WidgetTester tester) async {
     await _pumpHome(tester, surface: const Size(700, 800));
 
-    // Mutation pin against giving the mark its own onTap: a second, nested
-    // InkWell would hit-test and ripple twice over the same brand.
+    // The brand is split across two AppBar slots now — the rose leads, the
+    // word follows — so "one target over the whole lockup" is no longer the
+    // shape. What still must not happen is NESTING: an InkWell inside an
+    // InkWell hit-tests and ripples twice over the same pixels. One ancestor
+    // each is the assertion, and it is why the rose has no onTap of its own
+    // inside the wordmark's target.
     expect(
       find.ancestor(of: find.byType(BrandLogo), matching: find.byType(InkWell)),
       findsOneWidget,
     );
+    expect(
+      find.ancestor(
+          of: find.text(AppInfo.name), matching: find.byType(InkWell)),
+      findsOneWidget,
+    );
+
+    // ...and both halves do the same thing, which is the point of splitting
+    // them without splitting the behaviour.
+    final container =
+        ProviderScope.containerOf(tester.element(find.byType(HomeScreen)));
+    container.read(navIndexProvider.notifier).state = AppTab.plan.index;
+    await tester.tap(find.byType(BrandLogo));
+    await tester.pump();
+    expect(container.read(navIndexProvider), AppTab.home.index);
   });
 
   testWidgets('tapping the brand scrolls Home back to the top',

--- a/src/packages/flutter-app/test/secret_tap_trigger_test.dart
+++ b/src/packages/flutter-app/test/secret_tap_trigger_test.dart
@@ -89,6 +89,44 @@ void main() {
     expect(find.byType(RickRollOverlay), findsNothing);
   });
 
+  testWidgets('the rose counts too, now that it is the other half of the brand',
+      (tester) async {
+    // The Listener used to ride one widget because the brand WAS one widget.
+    // The rose lives in the app bar's leading slot now, and a trigger that
+    // only rode the wordmark would have silently halved the target — the kind
+    // of regression nothing else in the suite would notice.
+    //
+    // The surface has to be narrow first: at rail widths the leading slot is
+    // deliberately empty (the rail carries the rose), so the default 800x600
+    // test window would find nothing to tap.
+    tester.view.physicalSize = const Size(390, 800);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await pumpApp(tester, signedIn: true);
+
+    // No `hitTestable()` here, unlike [appBarBrand]: finders skip offstage
+    // widgets by default, so the shell's two inactive tabs are already out,
+    // and a RenderImage is not itself a hit-test target — hitTestable would
+    // find nothing to tap even though the rose is right there.
+    final rose = find.descendant(
+      of: find.byType(GradientAppBar),
+      matching: find.byType(BrandLogo),
+    );
+    expect(rose, findsOneWidget);
+
+    for (var i = 0; i < kSecretTapCount; i++) {
+      await tester.tap(rose);
+      await tester.pump();
+    }
+    expect(find.byType(RickRollOverlay), findsOneWidget);
+
+    await tester.tapAt(const Offset(40, 400));
+    await tester.pump();
+    expect(find.byType(RickRollOverlay), findsNothing);
+  });
+
   testWidgets('it also works where the brand is not a button', (tester) async {
     // Signed out, the brand has no onTap at all — no InkWell, no button
     // semantics. The Listener is deliberately outside that branch, because


### PR DESCRIPTION
## Summary

The ANEMOS wordmark jumped ~108px to the right on every navigation — flush left on a tab root, well indented on trip detail. Two independent causes:

- **+56px** — `GradientAppBar` never set `leading`/`leadingWidth`/`titleSpacing`, so `AppBar` starts the title at `titleSpacing` on a route with nothing to dismiss and at `leadingWidth + titleSpacing` on one with a back button.
- **+52px** — the rose lived *inside* the title row behind a width gate that flipped with whatever actions a page carried (absent on My Trips, present on trip detail).

Fix: the rose moves out of the title row, and the leading slot is always 56px wide — only its **occupant** varies.

| route | leading slot |
|---|---|
| dismissible (trip detail, settings…) | the framework's own `BackButton` — or `CloseButton` on a `fullscreenDialog` |
| tab root / landing | the rose, `BrandLogo.markLight(size: 36)` |
| in-shell at rail widths | an empty box — `_RailBrand` already has the rose (PR #406) |

`leading: null` on the dismissible branch is deliberate: back-vs-close stays Flutter's decision, so the fullscreen map keeps its ✕. `titleSpacing: 0` pays back most of the reserved width (`NavigationToolbar` charges `middleSpacing` on **both** sides).

The title-row ladder drops from three rungs to two and gets simpler. Rung 2 barely moves on a tab root (net 24px); on a pushed page it moves the *good* way — the rose leaving the row hands the title back 52px, which is why trip detail now shows its trip name on a phone at all.

No screen edits: `GradientAppBar` exposes no `leading`, and all 22 callers are untouched.

## Testing

- `make flutter-test` — **1576 passed, 0 failed**. (`make flutter-analyze` is clean for this change; its 3 `unnecessary_brace_in_string_interps` infos are pre-existing in `lib/models/route_response.dart`, untouched here.)
- **The gap that shipped this bug**: `brand_everywhere_test`'s `_pumpBar` pumped the bar as `home:` and never pushed a route, so the leading-present case was never exercised. It now takes `pushed` / `fullscreenDialog`, and the new anchor test asserts the wordmark's left `dx` is identical pushed vs. not across every width × action count × shell state. **Mutation-checked** — it fails on `w=320 actions=0` without the fix.
- New pins: a pushed page keeps the framework's dismissal button and shows no rose; the rose no longer yields to width and stays centred in the slot; the empty rail-width slot keeps its inset; the brand is two semantics nodes with only one saying "Anemos" (the rose is labelled *Home*, and is `ExcludeSemantics` decoration outside the shell); the seven-tap easter egg fires from the rose too; the page title's drop threshold is the same pushed or not.
- Retired `the mark yields before the wordmark does` — that rung no longer exists. `home_polish_test`'s "tiny app bar drops the MARK" flips (the rose is no longer in the title row to drop) and "the lockup is ONE tap target" becomes "two targets side by side, not one nested in another".
- One documented exception, `_fallbackFontScalesAt = {(320, 3)}`: the widget-test fallback face runs ~35% wider than Cinzel and tips the word into the `FittedBox` at ~0.94 there. Listed rather than hidden so growth reads as a regression.
- **Browser-verified against real Cinzel** (headless Chrome + CDP, lane stack): the wordmark's left edge is **x=61 on Home, My Trips, trip detail, the fullscreen map and the landing page**, at 320 / 360 / 390 and at rail width. The wordmark paints 83px of ink at 320 exactly as at 390 — nothing scales on a real device. Also confirmed: tapping the rose goes Home, and seven taps still roll the site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)