### PR TITLE
feat(flutter): one-line Bookings destination filter with per-city counts

### DIFF
--- a/docs/friction-log.md
+++ b/docs/friction-log.md
@@ -5,6 +5,44 @@ build queue. Priority when picking work: **breakage > friction in features
 actually used > ideas that recur across ≥2 sessions**. Tag entries `[app]`
 (dogfooding the product) or `[dev]` (workflow/tooling). Newest first.
 
+## 2026-08-17 — The Bookings filter cost more screen than the bookings
+
+- **[app] Friction → fixed:** *"Should these big buttons for each city be a
+  dropdown instead?"* On an eight-city trip the destination filter was a `Wrap`
+  of chips under a separate "Not booked yet" chip — **~5 rows of chrome before
+  the first booking row**, and it grew with the trip. It is now one row at every
+  width: the scope chip, a pinned **All** chip, and a horizontally scrolling
+  strip. Not a dropdown, because a dropdown trades one tap per city switch for
+  the same row it saves; the strip keeps the trip's shape visible.
+- **[app] The old control had no visible "everything".** Clearing the filter
+  meant re-tapping the already-selected chip — an affordance nothing on screen
+  advertised. The All chip states the resting state, and a re-tap on a selected
+  destination is now a dead gesture rather than a second, hidden way to do the
+  same thing. (`MapLegChips` deliberately has no All chip: on a map a chip
+  selected at rest would put the strongest treatment on "no filter". Here the
+  resting state is the answer to a question the traveler asks.)
+- **[app] Each chip carries its own count (`Prague · 1/2`),** so the filter
+  doubles as a per-city progress read. Counts come from the same enumeration
+  and the same booked-predicate the ROWS use (`bookingSlotEntries` /
+  `bookingEntryBooked`, extracted for exactly this reason) — the #455 rule that
+  a count answers for the rows beneath it. Open debt unchanged: the Bookings
+  tab's own pill still counts booking *todos*, so a trip with confirmed records
+  that matched no todo sums higher on the chips than in the pill. Documented at
+  both sites rather than quietly reconciled — the pill is load-bearing for
+  `specs/next-step-cta` parity.
+- **[dev] Two layout bugs the new widget tests caught, not the eye.** A 320px
+  Spanish row at 1.3× text **overflowed by 94px**, and short of overflowing the
+  pinned pair starved the strip to ~180px on a 420px body — less than one
+  `Gothenburg · 0/2` chip, so it could never show a whole destination. Fix: cap
+  the pinned half at 50% and scale it down inside that (the view-tabs lever).
+- **[dev] Swapping a `ShaderMask` in and out re-parents the scroll view.** The
+  leading fade (which stops a scrolled-under chip's `· 0/2` tail from reading as
+  *All's* count) was applied only when scrolled — and inserting it rebuilt the
+  `SingleChildScrollView`, dropping the `ScrollController` position, so the strip
+  snapped back to the first chip the instant the fade engaged. The mask now
+  stays in the tree and only its gradient changes. Caught by the
+  reveal-the-selected-chip test.
+
 ## 2026-08-17 — the button named what it creates, not what it destroys
 
 - **[app] Friction → fixed:** *"Maybe rename 'New chat' to 'Clear chat'?"* The

--- a/src/packages/flutter-app/lib/l10n/app_en.arb
+++ b/src/packages/flutter-app/lib/l10n/app_en.arb
@@ -1113,6 +1113,14 @@
   "tripBookingsLensEmptyTitle": "No bookings yet",
   "tripBookingsLensEmptyMessage": "Flights, stays, and reservations for this trip will show up here.",
   "tripBookingsLensNoneForDestination": "No bookings for this destination.",
+  "tripBookingsAllBookedForDestination": "Nothing left to book here.",
+  "@tripBookingsAllBookedForDestination": {
+    "description": "Shown in the 'Not booked yet' scope when ONE destination is selected and that destination is fully booked. Deliberately not tripFilterAllBooked, which claims the whole trip is done."
+  },
+  "tripBookingsAllDestinations": "All",
+  "@tripBookingsAllDestinations": {
+    "description": "The Bookings filter strip's pinned chip: clears the destination filter and shows every booking. Kept short — it sits beside city names in a one-line strip."
+  },
   "tripNoPlacesYet": "No places yet",
   "tripNoPlacesYetMessage": "Refine with AI or add a place to start your itinerary.",
   "tripNoMappedPlaces": "No mapped places",

--- a/src/packages/flutter-app/lib/l10n/app_es.arb
+++ b/src/packages/flutter-app/lib/l10n/app_es.arb
@@ -505,6 +505,8 @@
   "tripBookingsLensEmptyTitle": "Aún no hay reservas",
   "tripBookingsLensEmptyMessage": "Los vuelos, alojamientos y reservas de este viaje aparecerán aquí.",
   "tripBookingsLensNoneForDestination": "No hay reservas para este destino.",
+  "tripBookingsAllBookedForDestination": "Aquí no queda nada por reservar.",
+  "tripBookingsAllDestinations": "Todas",
   "tripNoPlacesYet": "Aún no hay lugares",
   "tripNoPlacesYetMessage": "Refina con IA o añade un lugar para empezar tu itinerario.",
   "tripNoMappedPlaces": "No hay lugares en el mapa",

--- a/src/packages/flutter-app/lib/l10n/app_localizations.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations.dart
@@ -3128,7 +3128,7 @@ abstract class AppLocalizations {
   /// **'No bookings for this destination.'**
   String get tripBookingsLensNoneForDestination;
 
-  /// No description provided for @tripBookingsAllBookedForDestination.
+  /// Shown in the 'Not booked yet' scope when ONE destination is selected and that destination is fully booked. Deliberately not tripFilterAllBooked, which claims the whole trip is done.
   ///
   /// In en, this message translates to:
   /// **'Nothing left to book here.'**

--- a/src/packages/flutter-app/lib/l10n/app_localizations.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations.dart
@@ -3128,6 +3128,18 @@ abstract class AppLocalizations {
   /// **'No bookings for this destination.'**
   String get tripBookingsLensNoneForDestination;
 
+  /// No description provided for @tripBookingsAllBookedForDestination.
+  ///
+  /// In en, this message translates to:
+  /// **'Nothing left to book here.'**
+  String get tripBookingsAllBookedForDestination;
+
+  /// The Bookings filter strip's pinned chip: clears the destination filter and shows every booking. Kept short — it sits beside city names in a one-line strip.
+  ///
+  /// In en, this message translates to:
+  /// **'All'**
+  String get tripBookingsAllDestinations;
+
   /// No description provided for @tripNoPlacesYet.
   ///
   /// In en, this message translates to:

--- a/src/packages/flutter-app/lib/l10n/app_localizations_en.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations_en.dart
@@ -1750,6 +1750,13 @@ class AppLocalizationsEn extends AppLocalizations {
       'No bookings for this destination.';
 
   @override
+  String get tripBookingsAllBookedForDestination =>
+      'Nothing left to book here.';
+
+  @override
+  String get tripBookingsAllDestinations => 'All';
+
+  @override
   String get tripNoPlacesYet => 'No places yet';
 
   @override

--- a/src/packages/flutter-app/lib/l10n/app_localizations_es.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations_es.dart
@@ -1763,6 +1763,13 @@ class AppLocalizationsEs extends AppLocalizations {
       'No hay reservas para este destino.';
 
   @override
+  String get tripBookingsAllBookedForDestination =>
+      'Aquí no queda nada por reservar.';
+
+  @override
+  String get tripBookingsAllDestinations => 'Todas';
+
+  @override
   String get tripNoPlacesYet => 'Aún no hay lugares';
 
   @override

--- a/src/packages/flutter-app/lib/screens/trip_detail_derivation.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_derivation.dart
@@ -91,6 +91,94 @@ typedef GroupedBookings = ({
   List<TripSegment> residualSegments,
 });
 
+/// One booking as the traveler sees it: **one visible checkbox**. A todo, the
+/// confirmed record matched to it, or a confirmed record standing alone
+/// (viewers, and anything that matched no todo).
+///
+/// NOT one rendered widget — a todo plus its confirmed detail row is ONE
+/// booking rendered as two widgets. Counting widgets would double every
+/// confirmed booking.
+typedef BookingEntry = ({
+  BookingTodo? todo,
+  Accommodation? stay,
+  TripSegment? segment,
+});
+
+/// The entries a slot contributes, in render order. THE one enumeration of
+/// "what rows does this slot have" — the screen's `_bookingRowWidgets` builds
+/// from it and every count iterates it, so a row and its count can never
+/// disagree about what exists.
+///
+/// [departureOnly] splits the slot the way the screen renders it: the arrival
+/// flight + stay inline, and the flight home as a separate trailing call the
+/// screen makes for the LAST slot only.
+List<BookingEntry> bookingSlotEntries(BookingSlot slot,
+        {required bool departureOnly}) =>
+    departureOnly
+        ? [(todo: slot.departure, stay: null, segment: slot.departureMatch)]
+        : [
+            (todo: slot.arrival, stay: null, segment: slot.arrivalMatch),
+            (todo: slot.stay, stay: slot.stayMatch, segment: null),
+          ];
+
+/// The state of an entry's visible checkbox — THE one definition, shared by
+/// the "Not booked yet" filter and every count on the screen.
+///
+/// The todo's flag wins when a todo row drives the entry, the confirmed
+/// record's otherwise (PR #455: a ticked booking row IS booked). An entry with
+/// nothing in it reads booked so it never lands in the left-to-book list.
+bool bookingEntryBooked(BookingEntry e) =>
+    e.todo?.booked ?? e.stay?.booked ?? e.segment?.booked ?? true;
+
+/// True when the entry has anything to render at all.
+bool bookingEntryExists(BookingEntry e) =>
+    e.todo != null || e.stay != null || e.segment != null;
+
+/// booked/total per destination label, for the Bookings filter strip's chip
+/// counts. Mirrors the screen's `_allBookingRows` exactly — slot i belongs to
+/// `labels[i]`, the departure entry counts only on the LAST slot, and
+/// residuals count under [otherKey] alone — so a chip's count always equals
+/// what selecting that chip reveals. A revisited city has one entry here and
+/// one chip, summing both of its runs.
+///
+/// Counts ENTRIES, not todos: the Bookings tab's own pill counts booking todos
+/// only, so a trip with confirmed records that matched no todo sums higher
+/// here. That divergence is the tab pill's (it is load-bearing for
+/// specs/next-step-cta parity); these counts answer for the rows beneath them.
+Map<String, ({int booked, int total})> bookingDestinationCounts(
+  GroupedBookings grouped,
+  List<String> labels, {
+  required String otherKey,
+}) {
+  final counts = <String, ({int booked, int total})>{};
+  void add(String key, bool booked) {
+    final c = counts[key] ?? (booked: 0, total: 0);
+    counts[key] = (booked: c.booked + (booked ? 1 : 0), total: c.total + 1);
+  }
+
+  for (final (i, slot) in grouped.slots.indexed) {
+    if (i >= labels.length) continue;
+    final entries = [
+      ...bookingSlotEntries(slot, departureOnly: false),
+      if (i == grouped.slots.length - 1)
+        ...bookingSlotEntries(slot, departureOnly: true),
+    ];
+    for (final e in entries.where(bookingEntryExists)) {
+      add(labels[i], bookingEntryBooked(e));
+    }
+  }
+  for (final todo in grouped.residual) {
+    add(otherKey, todo.booked);
+  }
+  for (final a in grouped.residualStays) {
+    add(otherKey, a.booked);
+  }
+  for (final s in grouped.residualSegments) {
+    add(otherKey, s.booked);
+  }
+  return counts;
+}
+
 /// True for the AI's "city filler" placeholder — an item whose name is just
 /// the city it renders under (e.g. name 'Prague', city 'Prague'), emitted for
 /// days with no specific activities. Its text duplicates the city/day-trip

--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -65,6 +65,7 @@ import '../widgets/app_map.dart';
 import '../services/api_client.dart' show ApiException;
 import '../widgets/booked_expense_prompt.dart';
 import '../widgets/booking_detail_row.dart';
+import '../widgets/booking_filter_bar.dart';
 import '../widgets/booking_sheets.dart';
 import '../widgets/booking_todo_card.dart';
 import '../widgets/budget_section.dart';
@@ -72,7 +73,6 @@ import '../widgets/budget_target_dialog.dart';
 import '../widgets/trip_health_sheet.dart';
 import '../widgets/trip_review_section.dart';
 import '../widgets/empty_state.dart';
-import '../widgets/choice_chip_row.dart';
 import '../widgets/city_events_sheet.dart';
 import '../widgets/hover_reveal.dart';
 import '../widgets/local_rec_card.dart';
@@ -3479,26 +3479,23 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
   /// [departureOnly] is false, the return-home flight when true. Each todo
   /// row is followed by its matched confirmed record's details; a match
   /// without a todo (viewers) renders as a standalone detail row.
-  /// [unbookedOnly] keeps only rows whose visible checkbox is unchecked (the
-  /// todo's flag when a todo row drives the entry, the record's otherwise) —
-  /// the "Not booked yet" lens.
+  /// [unbookedOnly] keeps only rows whose visible checkbox is unchecked — the
+  /// "Not booked yet" lens.
+  ///
+  /// The slot's entries and their checkbox state both come from the
+  /// derivation ([bookingSlotEntries] / [bookingEntryBooked]) rather than
+  /// being spelled out here, because the filter-strip counts iterate the same
+  /// two functions: a chip's count and the rows it reveals cannot disagree
+  /// about what a slot holds or about what "booked" means.
   List<Widget> _bookingRowWidgets(
     BookingSlot slot, {
     required bool departureOnly,
     bool unbookedOnly = false,
   }) {
     final l10n = context.l10n;
-    var entries = departureOnly
-        ? [(todo: slot.departure, stay: null as Accommodation?, segment: slot.departureMatch)]
-        : [
-            (todo: slot.arrival, stay: null as Accommodation?, segment: slot.arrivalMatch),
-            (todo: slot.stay, stay: slot.stayMatch, segment: null as TripSegment?),
-          ];
+    var entries = bookingSlotEntries(slot, departureOnly: departureOnly);
     if (unbookedOnly) {
-      entries = entries
-          .where((e) =>
-              !(e.todo?.booked ?? e.stay?.booked ?? e.segment?.booked ?? true))
-          .toList();
+      entries = entries.where((e) => !bookingEntryBooked(e)).toList();
     }
     return [
       for (final e in entries) ...[
@@ -3558,32 +3555,50 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
   /// records that matched no city. Reuses the same row widgets (and the
   /// _setRowBooked writer) as the inline city view, so checking a box here
   /// behaves identically and the row leaves the lens on the rebuild.
-  List<Widget> _unbookedRows(GroupedBookings grouped) {
+  ///
+  /// [destination] narrows to one leg label exactly as [_allBookingRows] does
+  /// — the destination strip renders in BOTH scopes, so a chosen city has to
+  /// mean the same thing in both. Same discipline too: this filters the OUTPUT
+  /// of the one full-label partition, never a re-partition on a label subset.
+  List<Widget> _unbookedRows(
+    GroupedBookings grouped,
+    List<String> labels, {
+    String? destination,
+  }) {
     final l10n = context.l10n;
+    bool slotShown(int i) =>
+        destination == null ||
+        (i < labels.length && labels[i] == destination);
+    final showResiduals =
+        destination == null || destination == _kOtherPlaces;
     return [
-      for (final (i, slot) in grouped.slots.indexed) ...[
-        ..._bookingRowWidgets(slot, departureOnly: false, unbookedOnly: true),
-        if (i == grouped.slots.length - 1)
-          ..._bookingRowWidgets(slot, departureOnly: true, unbookedOnly: true),
-      ],
-      for (final todo in grouped.residual.where((t) => !t.booked))
-        Padding(
-          padding: const EdgeInsets.symmetric(vertical: 4),
-          child: BookingTodoCard(
-            todo: todo,
-            onBookedChanged: (v) => _setRowBooked(v, todo: todo),
-            onOpen: _openCallbackFor(todo),
-            openLabelOverride: _flightLegs.containsKey(todo.todoKey)
-                ? l10n.tripFindFlights
-                : null,
-            onEdit: todo.auto ? null : () => _editTodo(todo),
-            onDelete: todo.auto ? null : () => _deleteTodo(todo),
+      for (final (i, slot) in grouped.slots.indexed)
+        if (slotShown(i)) ...[
+          ..._bookingRowWidgets(slot, departureOnly: false, unbookedOnly: true),
+          if (i == grouped.slots.length - 1)
+            ..._bookingRowWidgets(slot,
+                departureOnly: true, unbookedOnly: true),
+        ],
+      if (showResiduals) ...[
+        for (final todo in grouped.residual.where((t) => !t.booked))
+          Padding(
+            padding: const EdgeInsets.symmetric(vertical: 4),
+            child: BookingTodoCard(
+              todo: todo,
+              onBookedChanged: (v) => _setRowBooked(v, todo: todo),
+              onOpen: _openCallbackFor(todo),
+              openLabelOverride: _flightLegs.containsKey(todo.todoKey)
+                  ? l10n.tripFindFlights
+                  : null,
+              onEdit: todo.auto ? null : () => _editTodo(todo),
+              onDelete: todo.auto ? null : () => _deleteTodo(todo),
+            ),
           ),
-        ),
-      for (final a in grouped.residualStays.where((a) => !a.booked))
-        _detailRowFor(stay: a, segment: null, detailOnly: true),
-      for (final s in grouped.residualSegments.where((s) => !s.booked))
-        _detailRowFor(stay: null, segment: s, detailOnly: true),
+        for (final a in grouped.residualStays.where((a) => !a.booked))
+          _detailRowFor(stay: a, segment: null, detailOnly: true),
+        for (final s in grouped.residualSegments.where((s) => !s.booked))
+          _detailRowFor(stay: null, segment: s, detailOnly: true),
+      ],
     ];
   }
 
@@ -3641,30 +3656,109 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
     ];
   }
 
-  /// Chip values for the 'bookings' lens destination filter: the leg labels
-  /// deduped in trip order (a revisited city gets ONE chip covering both its
-  /// runs — chips select by label equality, and run-suffixed chips would
-  /// leak the internal `#2` key grammar), plus the canonical 'Other places'
-  /// value when residual bookings exist and no real 'Other places' leg
-  /// already supplied it.
-  List<String> _bookingsLensChips(List<String> labels,
-      {required bool hasResiduals}) {
-    final chips = <String>[];
+  /// Chips for the Bookings destination filter: the leg labels deduped in trip
+  /// order (a revisited city gets ONE chip covering both its runs — chips
+  /// select by label equality, and run-suffixed chips would leak the internal
+  /// `#2` key grammar), plus the canonical 'Other places' value when residual
+  /// bookings exist and no real 'Other places' leg already supplied it. Each
+  /// carries its own booked count from [bookingDestinationCounts].
+  ///
+  /// A stale selection (leg labels change when the itinerary is edited) is
+  /// clamped HERE rather than in either view body, because both scopes render
+  /// the strip and both need the same clamp before they filter their rows.
+  /// We're already in build, so this frame renders the clamped value (the
+  /// _focusedLegKey clamp idiom).
+  List<BookingDestination> _bookingsLensDestinations(
+    GroupedBookings grouped,
+    List<String> labels,
+  ) {
+    final l10n = context.l10n;
+    final hasResiduals = grouped.residual.isNotEmpty ||
+        grouped.residualStays.isNotEmpty ||
+        grouped.residualSegments.isNotEmpty;
+    final values = <String>[];
     for (final l in labels) {
-      if (!chips.contains(l)) chips.add(l);
+      if (!values.contains(l)) values.add(l);
     }
-    if (hasResiduals && !chips.contains(_kOtherPlaces)) {
-      chips.add(_kOtherPlaces);
+    if (hasResiduals && !values.contains(_kOtherPlaces)) {
+      values.add(_kOtherPlaces);
     }
-    return chips;
+    if (_bookingsLensDestination != null &&
+        !values.contains(_bookingsLensDestination)) {
+      _bookingsLensDestination = null;
+    }
+    final counts =
+        bookingDestinationCounts(grouped, labels, otherKey: _kOtherPlaces);
+    return [
+      for (final v in values)
+        (
+          value: v,
+          label: v == _kOtherPlaces ? l10n.tripOtherBookings : v,
+          booked: counts[v]?.booked ?? 0,
+          total: counts[v]?.total ?? 0,
+        ),
+    ];
   }
 
-  /// The 'bookings' lens body: destination filter chips above the flat
-  /// all-bookings list. Returns [] when the trip has no bookings at all so
-  /// build can swap in the lens empty state. A stale chip selection (leg
-  /// labels change when the itinerary is edited) is clamped here — we're
-  /// already in build, so this frame renders the clamped value (the
-  /// _focusedLegKey clamp idiom).
+  /// The Bookings view's one filter row — scope chip + destination strip —
+  /// rendered by BOTH scopes so toggling "Not booked yet" doesn't change the
+  /// shape of the chrome above the rows. The destination deliberately SURVIVES
+  /// that toggle: it is a different question ("where"), and clearing it would
+  /// silently widen what the traveler is looking at.
+  Widget _bookingsFilterBar(List<BookingDestination> destinations) =>
+      BookingFilterBar(
+        unbookedOnly: _itemFilter == 'unbooked',
+        onUnbookedOnlyChanged: (v) =>
+            setState(() => _itemFilter = v ? 'unbooked' : 'bookings'),
+        destinations: destinations,
+        selected: _bookingsLensDestination,
+        onSelected: (v) => setState(() => _bookingsLensDestination = v),
+      );
+
+  /// The 'unbooked' scope body: the same filter row as the all-bookings lens
+  /// above the flat left-to-book list. Never returns [] — the filter row is
+  /// the way out of an empty state, so it renders above both arms.
+  ///
+  /// The two empty arms say different true things. With no destination
+  /// chosen, an empty list means the TRIP is fully booked (the celebration).
+  /// With one chosen it means only that city is, so it gets its own line —
+  /// the trip-wide copy would be a claim this list cannot support.
+  List<Widget> _unbookedViewBody(
+    GroupedBookings grouped,
+    List<String> labels,
+  ) {
+    final l10n = context.l10n;
+    final destinations = _bookingsLensDestinations(grouped, labels);
+    final rows = _unbookedRows(grouped, labels,
+        destination: _bookingsLensDestination);
+    return [
+      _bookingsFilterBar(destinations),
+      if (rows.isEmpty && _bookingsLensDestination == null)
+        SizedBox(
+          height: 260,
+          child: EmptyState(
+            icon: Icons.celebration_outlined,
+            title: l10n.tripFilterAllBooked,
+            message: l10n.tripFilterAllBookedMessage,
+          ),
+        )
+      else if (rows.isEmpty)
+        SizedBox(
+          height: 120,
+          child: EmptyState(
+            icon: Icons.celebration_outlined,
+            title: l10n.tripBookingsAllBookedForDestination,
+            compact: true,
+          ),
+        )
+      else
+        ...rows,
+    ];
+  }
+
+  /// The 'bookings' lens body: the filter row above the flat all-bookings
+  /// list. Returns [] when the trip has no bookings at all so build can swap
+  /// in the lens empty state.
   List<Widget> _bookingsLensBody(
     GroupedBookings grouped,
     List<String> labels,
@@ -3672,30 +3766,15 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
     final l10n = context.l10n;
     final all = _allBookingRows(grouped, labels);
     if (all.isEmpty) return const [];
-    final hasResiduals = grouped.residual.isNotEmpty ||
-        grouped.residualStays.isNotEmpty ||
-        grouped.residualSegments.isNotEmpty;
-    final chips = _bookingsLensChips(labels, hasResiduals: hasResiduals);
-    if (_bookingsLensDestination != null &&
-        !chips.contains(_bookingsLensDestination)) {
-      _bookingsLensDestination = null;
-    }
+    // Builds the chips AND clamps a stale selection — so it runs before the
+    // rows below are filtered by that selection.
+    final destinations = _bookingsLensDestinations(grouped, labels);
     final rows = _bookingsLensDestination == null
         ? all
         : _allBookingRows(grouped, labels,
             destination: _bookingsLensDestination);
     return [
-      _bookingsScopeChip(),
-      Padding(
-        padding: const EdgeInsets.only(bottom: AppSpacing.sm),
-        child: ChoiceChipRow(
-          options: chips,
-          selected: _bookingsLensDestination,
-          onSelected: (v) => setState(() => _bookingsLensDestination = v),
-          labelBuilder: (v) =>
-              v == _kOtherPlaces ? l10n.tripOtherBookings : v,
-        ),
-      ),
+      _bookingsFilterBar(destinations),
       if (rows.isEmpty)
         SizedBox(
           height: 120,
@@ -3709,25 +3788,6 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
         ...rows,
     ];
   }
-
-  /// Booked-state scope for the Bookings view: off = every booking, on = the
-  /// left-to-book list. A moved entry point, not new behavior — it toggles
-  /// the same 'unbooked' state the filter menu used to own before the view
-  /// tabs landed.
-  Widget _bookingsScopeChip() => Padding(
-        padding: const EdgeInsets.only(bottom: AppSpacing.xs),
-        child: Align(
-          alignment: Alignment.centerLeft,
-          child: FilterChip(
-            label: Text(context.l10n.tripFilterUnbooked),
-            selected: _itemFilter == 'unbooked',
-            onSelected: (v) => setState(() {
-              _itemFilter = v ? 'unbooked' : 'bookings';
-              _bookingsLensDestination = null;
-            }),
-          ),
-        ),
-      );
 
   /// "+ Add booking" — the Bookings view's one add CTA (its "Add place").
   /// A single menu fans out to the three record kinds so the itinerary tail
@@ -6593,29 +6653,15 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
                             )
                           else if (_itemFilter == 'unbooked')
                             // Bookings view, left-to-book scope: a flat list
-                            // in place of the city groups. The scope chip
+                            // in place of the city groups. The filter row
                             // renders above BOTH arms — selected atop the
                             // celebration it says why the list is empty
                             // and is the one-tap way back to every booking.
                             SliverPadding(
                               padding:
                                   EdgeInsets.fromLTRB(gutter, 4, gutter, 0),
-                              sliver: switch (_unbookedRows(grouped)) {
-                                [] => _boxSliver([
-                                    _bookingsScopeChip(),
-                                    SizedBox(
-                                      height: 260,
-                                      child: EmptyState(
-                                        icon: Icons.celebration_outlined,
-                                        title: l10n.tripFilterAllBooked,
-                                        message:
-                                            l10n.tripFilterAllBookedMessage,
-                                      ),
-                                    ),
-                                  ]),
-                                final rows => _boxSliver(
-                                    [_bookingsScopeChip(), ...rows]),
-                              },
+                              sliver: _boxSliver(
+                                  _unbookedViewBody(grouped, legLabels)),
                             )
                           else if (_itemFilter == 'bookings')
                             // All-bookings lens: the whole trip's bookings

--- a/src/packages/flutter-app/lib/widgets/booking_filter_bar.dart
+++ b/src/packages/flutter-app/lib/widgets/booking_filter_bar.dart
@@ -1,0 +1,275 @@
+import 'package:flutter/material.dart';
+
+import '../l10n/l10n.dart';
+import '../theme/spacing.dart';
+
+/// One destination the Bookings filter can narrow to, with the count of the
+/// bookings it holds. Build these with `bookingDestinationCounts`
+/// (trip_detail_derivation.dart), which owns the rule that a chip's count
+/// equals what selecting that chip reveals.
+typedef BookingDestination = ({
+  String value,
+  String label,
+  int booked,
+  int total,
+});
+
+/// The Bookings view's filter row: the "Not booked yet" scope chip, an **All**
+/// chip, and a horizontally scrolling strip of destination chips carrying
+/// their own booked counts (`Prague · 0/3`).
+///
+/// It replaced a `Wrap` of the same destination chips stacked under a separate
+/// scope chip. On an eight-city trip at phone width that wrap cost ~5 rows of
+/// chrome before the first booking row — the control took more screen than the
+/// content it filtered, and it grew with the trip. One row, at every width.
+///
+/// Two rules carried over from [MapLegChips], which solved this strip first:
+///
+///   * The way back is pinned OUTSIDE the scroll view. On a ten-city trip the
+///     strip scrolls, and an exit that can scroll off-screen is not an exit.
+///   * The selected chip is revealed through the strip's OWN scroll position,
+///     never `Scrollable.ensureVisible` — that walks every ancestor scrollable
+///     and would yank the trip page's scroll along with it.
+///
+/// One rule deliberately diverges from it. The map has no "All" chip: there,
+/// a chip that is selected at rest would put the strongest treatment on "no
+/// filter applied", competing with the ring that means "you are focused on
+/// this city". Here the resting state IS the answer to a question the traveler
+/// asks ("am I seeing everything?"), and before this chip the only way back to
+/// every booking was re-tapping the already-selected chip — an affordance
+/// nothing on screen advertised (docs/zen.md: explicit is better than
+/// implicit). So All is always painted, and re-tapping a selected destination
+/// chip is a no-op rather than a second, invisible way to do the same thing.
+///
+/// The count rides as a separate [Text] at one weight down rather than being
+/// interpolated into the label, so the strip still scans as a row of place
+/// names — the same treatment [MapLegChips] gives its qualifier.
+class BookingFilterBar extends StatefulWidget {
+  /// The "Not booked yet" scope: false = every booking, true = the left-to-book
+  /// list. A moved entry point, not a lens of its own — it toggles the same
+  /// state the filter menu owned before the view tabs landed.
+  final bool unbookedOnly;
+  final ValueChanged<bool> onUnbookedOnlyChanged;
+
+  /// Destinations in trip order (a revisited city appears once, its counts
+  /// summed), with the 'Other bookings' bucket last when residuals exist.
+  /// Fewer than two and the strip renders nothing: there is nothing a
+  /// destination filter could narrow.
+  final List<BookingDestination> destinations;
+
+  /// The selected destination's value; null = All.
+  final String? selected;
+  final ValueChanged<String?> onSelected;
+
+  const BookingFilterBar({
+    super.key,
+    required this.unbookedOnly,
+    required this.onUnbookedOnlyChanged,
+    required this.destinations,
+    required this.selected,
+    required this.onSelected,
+  });
+
+  @override
+  State<BookingFilterBar> createState() => _BookingFilterBarState();
+}
+
+class _BookingFilterBarState extends State<BookingFilterBar> {
+  final ScrollController _controller = ScrollController();
+
+  /// Rides whichever chip is currently selected so [_revealSelected] can
+  /// measure it (SingleChildScrollView lays out off-viewport children, so the
+  /// context exists even when the chip is scrolled out of sight).
+  final GlobalKey _selectedKey = GlobalKey();
+
+  @override
+  void initState() {
+    super.initState();
+    // First layout: land the strip on the selected chip. A destination can be
+    // selected before this widget ever renders — the selection survives a
+    // scope toggle and an offscreen rebuild.
+    WidgetsBinding.instance.addPostFrameCallback((_) => _revealSelected());
+  }
+
+  @override
+  void didUpdateWidget(covariant BookingFilterBar oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.selected != oldWidget.selected && widget.selected != null) {
+      WidgetsBinding.instance.addPostFrameCallback(
+        (_) => _revealSelected(animate: true),
+      );
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  /// Centers the selected chip in the strip (clamped to its extent), through
+  /// this strip's own [ScrollPosition] — see the class doc.
+  void _revealSelected({bool animate = false}) {
+    if (!mounted || !_controller.hasClients) return;
+    final target = _selectedKey.currentContext?.findRenderObject();
+    if (target == null) return;
+    _controller.position.ensureVisible(
+      target,
+      alignment: 0.5,
+      duration: animate ? const Duration(milliseconds: 200) : Duration.zero,
+      curve: Curves.easeOutCubic,
+    );
+  }
+
+  Widget _destinationChip(ThemeData theme, BookingDestination d) {
+    final isSelected = widget.selected == d.value;
+    final chip = ChoiceChip(
+      // Label and count are two Texts, never one interpolated string: the
+      // count is a qualifier, not part of the city's name (and every finder
+      // that looks for the bare label keeps working).
+      label: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(d.label),
+          Text(
+            ' · ${d.booked}/${d.total}',
+            style: theme.textTheme.labelSmall?.copyWith(
+              color: isSelected
+                  ? theme.colorScheme.onSecondaryContainer
+                  : theme.colorScheme.onSurfaceVariant,
+              fontWeight: FontWeight.w500,
+            ),
+          ),
+        ],
+      ),
+      selected: isSelected,
+      // A re-tap is a dead gesture, not a clear: All is the way back.
+      onSelected: isSelected ? null : (_) => widget.onSelected(d.value),
+      showCheckmark: false,
+      // Full 48px hit box even though the chip paints compact — the padded
+      // tap target's extra area is transparent, and compact density would
+      // shave it under the 44px touch minimum.
+      visualDensity: VisualDensity.standard,
+      materialTapTargetSize: MaterialTapTargetSize.padded,
+    );
+    return isSelected ? KeyedSubtree(key: _selectedKey, child: chip) : chip;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final l10n = context.l10n;
+    // One destination is not a filter — it would show exactly what All shows.
+    final showStrip = widget.destinations.length > 1;
+    final pinned = Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        FilterChip(
+          label: Text(l10n.tripFilterUnbooked),
+          selected: widget.unbookedOnly,
+          onSelected: widget.onUnbookedOnlyChanged,
+          materialTapTargetSize: MaterialTapTargetSize.padded,
+        ),
+        if (showStrip) ...[
+          const SizedBox(width: AppSpacing.sm),
+          ChoiceChip(
+            label: Text(l10n.tripBookingsAllDestinations),
+            selected: widget.selected == null,
+            onSelected:
+                widget.selected == null ? null : (_) => widget.onSelected(null),
+            showCheckmark: false,
+            materialTapTargetSize: MaterialTapTargetSize.padded,
+          ),
+        ],
+      ],
+    );
+    if (!showStrip) {
+      return Padding(
+        padding: const EdgeInsets.only(bottom: AppSpacing.sm),
+        child: Align(alignment: Alignment.centerLeft, child: pinned),
+      );
+    }
+    return Padding(
+      padding: const EdgeInsets.only(bottom: AppSpacing.sm),
+      // The two pinned controls are capped at half the row and scale down
+      // inside it, rather than taking their natural width. Natural width is
+      // what a 320px Spanish row at 1.3× text overflowed by 94px, and short of
+      // overflowing it starved the strip: on a 420px body the pinned pair left
+      // ~180px, less than one "Gothenburg · 0/2" chip, so the strip could
+      // never show a whole destination. The cap is on the half that can be
+      // read at a glance; the strip is the half that has somewhere to put the
+      // overflow. FittedBox scale-down engages only when the pair genuinely
+      // cannot fit (tiny windows, large accessibility text) — the same lever,
+      // for the same reason, as the header's view tabs.
+      child: LayoutBuilder(
+        builder: (context, constraints) => Row(
+          children: [
+            ConstrainedBox(
+              constraints: BoxConstraints(maxWidth: constraints.maxWidth / 2),
+              child: FittedBox(
+                fit: BoxFit.scaleDown,
+                alignment: Alignment.centerLeft,
+                child: pinned,
+              ),
+            ),
+            Expanded(
+              // The leading edge fades out ONCE the strip has scrolled. A chip
+              // scrolled under the pinned pair shows only its TAIL, and a
+              // chip's tail is its count — so a hard edge parks a stray
+              // "· 0/2" beside the All chip, where it reads as All's own
+              // count. All deliberately carries no count (that number is the
+              // tab pill's), and the one thing this edge must never do is
+              // appear to give it one.
+              //
+              // At rest there is nothing sliding under, so the fade would only
+              // dim the first destination for no reason — hence the listen on
+              // the offset rather than a constant gradient.
+              //
+              // The mask stays in the tree at every offset and only its
+              // GRADIENT changes. Swapping the ShaderMask in and out instead
+              // re-parents the scroll view, which rebuilds it and drops the
+              // ScrollController's position — the strip snapped back to the
+              // first chip the moment the fade engaged.
+              child: AnimatedBuilder(
+                animation: _controller,
+                builder: (context, child) {
+                  final fadeEnd =
+                      _controller.hasClients && _controller.offset > 1
+                          ? 0.10
+                          : 0.0;
+                  return ShaderMask(
+                    blendMode: BlendMode.dstIn,
+                    shaderCallback: (rect) => LinearGradient(
+                      begin: Alignment.centerLeft,
+                      end: Alignment.centerRight,
+                      colors: const [Colors.transparent, Colors.black],
+                      stops: [0.0, fadeEnd],
+                    ).createShader(rect),
+                    child: child,
+                  );
+                },
+                child: SingleChildScrollView(
+                  controller: _controller,
+                  scrollDirection: Axis.horizontal,
+                  // Draggable even when the chips fit; the leading pad keeps
+                  // the first chip off the All chip it scrolls under.
+                  physics: const AlwaysScrollableScrollPhysics(),
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: AppSpacing.sm),
+                  child: Row(
+                    children: [
+                      for (final (i, d) in widget.destinations.indexed) ...[
+                        if (i > 0) const SizedBox(width: AppSpacing.xs),
+                        _destinationChip(theme, d),
+                      ],
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/src/packages/flutter-app/test/trip_detail_bookings_filter_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_bookings_filter_test.dart
@@ -1,0 +1,408 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:travel_route_planner/models/trip.dart';
+import 'package:travel_route_planner/models/itinerary_item.dart';
+import 'package:travel_route_planner/models/accommodation.dart';
+import 'package:travel_route_planner/models/booking_todo.dart';
+import 'package:travel_route_planner/models/trip_segment.dart';
+import 'package:travel_route_planner/services/accommodations_api_service.dart';
+import 'package:travel_route_planner/services/api_client.dart';
+import 'package:travel_route_planner/services/booking_todos_api_service.dart';
+import 'package:travel_route_planner/services/trips_api_service.dart';
+import 'package:travel_route_planner/providers/accommodations_provider.dart';
+import 'package:travel_route_planner/providers/booking_todos_provider.dart';
+import 'package:travel_route_planner/providers/trips_provider.dart';
+import 'package:travel_route_planner/screens/trip_detail_screen.dart';
+import 'package:travel_route_planner/widgets/booking_detail_row.dart';
+import 'package:travel_route_planner/widgets/booking_filter_bar.dart';
+import 'package:travel_route_planner/widgets/booking_todo_card.dart';
+
+import 'support/l10n_test_app.dart';
+
+/// The Bookings view's filter row: the "Not booked yet" scope chip, the All
+/// chip, and the scrolling destination strip whose chips carry their own
+/// booked counts.
+///
+/// The load-bearing property is the one PR #455 paid for on the Trip Health
+/// badge: **a count and the rows it summarizes must be the same answer**. So
+/// the counting tests never assert a hard-coded number against a hard-coded
+/// number — they select the chip and count the checkboxes that appear.
+
+class _FakeTripsApiService extends TripsApiService {
+  final Trip trip;
+  _FakeTripsApiService(this.trip) : super(ApiClient(baseUrl: 'http://test'));
+
+  @override
+  Future<Trip> getTrip(String id) async => trip;
+}
+
+class _FakeBookingTodosApiService extends BookingTodosApiService {
+  _FakeBookingTodosApiService() : super(ApiClient(baseUrl: 'http://test'));
+
+  // Mirrors the screen's swallow-on-error so the seeded todos survive.
+  @override
+  Future<List<BookingTodo>> syncTodos(
+          String tripId, List<Map<String, dynamic>> derived) async =>
+      throw Exception('offline test env');
+}
+
+class _FakeAccommodationsApiService extends AccommodationsApiService {
+  _FakeAccommodationsApiService() : super(ApiClient(baseUrl: 'http://test'));
+}
+
+ItineraryItem _item(int pos, String name, String city, int day) =>
+    ItineraryItem(
+      id: 'i$pos',
+      position: pos,
+      name: name,
+      address: '$city, Europe',
+      latitude: 0,
+      longitude: 0,
+      category: 'attraction',
+      day: day,
+      city: city,
+    );
+
+Trip _trip({
+  required List<ItineraryItem> items,
+  List<BookingTodo>? todos,
+  List<Accommodation>? accommodations,
+  List<TripSegment>? segments,
+}) =>
+    Trip(
+      id: 't1',
+      title: 'Europe',
+      startDate: '2026-06-10',
+      endDate: '2026-06-20',
+      createdAt: '2026-06-01',
+      updatedAt: '2026-06-01',
+      items: items,
+      bookingTodos: todos,
+      accommodations: accommodations,
+      segments: segments,
+    );
+
+/// A trip through [cities], one item per city, one stay todo per city. The
+/// [booked] set names the cities whose stay is already booked.
+Trip _cityTrip(List<String> cities, {Set<String> booked = const {}}) => _trip(
+      items: [
+        for (final (i, c) in cities.indexed) _item(i, 'Sight in $c', c, i + 1),
+      ],
+      todos: [
+        for (final c in cities)
+          BookingTodo(
+            id: 'td-${c.toLowerCase()}',
+            kind: 'stay',
+            todoKey: 'stay:${c.toLowerCase()}',
+            title: 'Stay in $c',
+            booked: booked.contains(c),
+          ),
+      ],
+    );
+
+void _useViewport(WidgetTester tester, Size size) {
+  tester.view.physicalSize = size;
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.reset);
+}
+
+Future<void> _pump(WidgetTester tester, Trip trip,
+    {Locale? locale, double textScale = 1.0}) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        tripsApiServiceProvider
+            .overrideWithValue(_FakeTripsApiService(trip)),
+        bookingTodosApiServiceProvider
+            .overrideWithValue(_FakeBookingTodosApiService()),
+        accommodationsApiServiceProvider
+            .overrideWithValue(_FakeAccommodationsApiService()),
+      ],
+      child: MaterialApp(
+        localizationsDelegates: testLocalizationsDelegates,
+        supportedLocales: const [Locale('en'), Locale('es')],
+        locale: locale,
+        home: MediaQuery(
+          data: MediaQueryData(textScaler: TextScaler.linear(textScale)),
+          child: const TripDetailScreen(tripId: 't1'),
+        ),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+Future<void> _openBookingsTab(WidgetTester tester,
+    {String label = 'Bookings'}) async {
+  await tester.tap(find.text(label));
+  await tester.pumpAndSettle();
+}
+
+Finder _chip(String label) =>
+    find.ancestor(of: find.text(label), matching: find.byType(ChoiceChip));
+
+/// Brings a chip into view (the strip scrolls) and taps it.
+Future<void> _tapDestination(WidgetTester tester, String label) async {
+  await tester.ensureVisible(_chip(label));
+  await tester.pumpAndSettle();
+  await tester.tap(_chip(label));
+  await tester.pumpAndSettle();
+}
+
+/// The `· n/m` count riding a destination chip, parsed back out.
+({int booked, int total}) _countOn(WidgetTester tester, String label) {
+  final text = tester
+      .widgetList<Text>(find.descendant(
+          of: _chip(label), matching: find.byType(Text)))
+      .map((t) => t.data ?? '')
+      .firstWhere((d) => d.contains('/'),
+          orElse: () => throw StateError('no count on chip "$label"'));
+  final parts = text.replaceAll('·', '').trim().split('/');
+  return (booked: int.parse(parts[0]), total: int.parse(parts[1]));
+}
+
+/// Every booking checkbox currently on screen, and how many are ticked — the
+/// rows' own answer to the question the chip count claims to answer.
+({int booked, int total}) _visibleRowCounts(WidgetTester tester) {
+  final boxes = tester.widgetList<Checkbox>(find.byType(Checkbox));
+  return (
+    booked: boxes.where((c) => c.value == true).length,
+    total: boxes.length,
+  );
+}
+
+void main() {
+  testWidgets('a chip count equals the rows that chip reveals', (tester) async {
+    _useViewport(tester, const Size(900, 3000));
+    await _pump(
+      tester,
+      _cityTrip(const ['Paris', 'Rome', 'Berlin'], booked: {'Rome'}),
+    );
+    await _openBookingsTab(tester);
+
+    for (final city in const ['Paris', 'Rome', 'Berlin']) {
+      final claimed = _countOn(tester, city);
+      await _tapDestination(tester, city);
+      final rendered = _visibleRowCounts(tester);
+      expect(rendered.total, claimed.total,
+          reason: '$city chip claims ${claimed.total} bookings');
+      expect(rendered.booked, claimed.booked,
+          reason: '$city chip claims ${claimed.booked} booked');
+      await _tapDestination(tester, 'All');
+    }
+  });
+
+  testWidgets('a revisited city gets one chip whose count sums both runs',
+      (tester) async {
+    _useViewport(tester, const Size(900, 3000));
+    // Paris → Rome → Paris: two Paris runs, ONE Paris chip.
+    await _pump(
+      tester,
+      _trip(
+        items: [
+          _item(0, 'Louvre', 'Paris', 1),
+          _item(1, 'Colosseum', 'Rome', 2),
+          _item(2, 'Orsay', 'Paris', 3),
+        ],
+        todos: const [
+          BookingTodo(
+              id: 'td-p1',
+              kind: 'stay',
+              todoKey: 'stay:paris',
+              title: 'Stay in Paris'),
+          BookingTodo(
+              id: 'td-r',
+              kind: 'stay',
+              todoKey: 'stay:rome',
+              title: 'Stay in Rome'),
+        ],
+      ),
+    );
+    await _openBookingsTab(tester);
+
+    expect(_chip('Paris'), findsOneWidget);
+    final claimed = _countOn(tester, 'Paris');
+    await _tapDestination(tester, 'Paris');
+    expect(_visibleRowCounts(tester).total, claimed.total);
+  });
+
+  testWidgets('the Other chip counts the residuals, and only those',
+      (tester) async {
+    _useViewport(tester, const Size(900, 3000));
+    await _pump(
+      tester,
+      _trip(
+        items: [
+          _item(0, 'Louvre', 'Paris', 1),
+          _item(1, 'Colosseum', 'Rome', 2),
+        ],
+        todos: const [
+          BookingTodo(
+              id: 'td-paris',
+              kind: 'stay',
+              todoKey: 'stay:paris',
+              title: 'Stay in Paris'),
+          BookingTodo(
+              id: 'td-custom',
+              kind: 'other',
+              todoKey: 'custom:1',
+              title: 'Museum tickets',
+              auto: false),
+        ],
+      ),
+    );
+    await _openBookingsTab(tester);
+
+    final claimed = _countOn(tester, 'Other bookings');
+    expect(claimed.total, 1);
+    await _tapDestination(tester, 'Other bookings');
+    expect(
+        find.widgetWithText(BookingTodoCard, 'Museum tickets'), findsOneWidget);
+    expect(_visibleRowCounts(tester).total, claimed.total);
+  });
+
+  testWidgets('a confirmed record with no todo still counts as one booking',
+      (tester) async {
+    _useViewport(tester, const Size(900, 3000));
+    await _pump(
+      tester,
+      _trip(
+        items: [_item(0, 'Louvre', 'Paris', 1)],
+        todos: const [
+          BookingTodo(
+              id: 'td-paris',
+              kind: 'stay',
+              todoKey: 'stay:paris',
+              title: 'Stay in Paris'),
+        ],
+        // Matches no leg — lands in the residual bucket as a detail row.
+        segments: const [
+          TripSegment(
+              id: 'seg-x',
+              mode: 'train',
+              origin: 'Lyon',
+              destination: 'Marseille',
+              booked: true),
+        ],
+      ),
+    );
+    await _openBookingsTab(tester);
+
+    // One entry, already booked: the row is a BookingDetailRow with no todo.
+    expect(_countOn(tester, 'Other bookings'), (booked: 1, total: 1));
+    await _tapDestination(tester, 'Other bookings');
+    expect(find.byType(BookingDetailRow), findsOneWidget);
+  });
+
+  testWidgets('the chosen destination survives a "Not booked yet" toggle',
+      (tester) async {
+    _useViewport(tester, const Size(900, 3000));
+    await _pump(
+      tester,
+      _cityTrip(const ['Paris', 'Rome'], booked: {'Paris'}),
+    );
+    await _openBookingsTab(tester);
+
+    await _tapDestination(tester, 'Rome');
+    expect(find.widgetWithText(BookingTodoRow, 'Stay in Paris'), findsNothing);
+
+    await tester.tap(find.widgetWithText(FilterChip, 'Not booked yet'));
+    await tester.pumpAndSettle();
+
+    // Still on Rome — the scope answered "what", not "where".
+    final rome = tester.widget<ChoiceChip>(_chip('Rome'));
+    expect(rome.selected, isTrue);
+    expect(find.widgetWithText(BookingTodoRow, 'Stay in Rome'), findsOneWidget);
+    expect(find.widgetWithText(BookingTodoRow, 'Stay in Paris'), findsNothing);
+  });
+
+  testWidgets(
+      'a fully booked destination says so without claiming the trip is done',
+      (tester) async {
+    _useViewport(tester, const Size(900, 3000));
+    await _pump(
+      tester,
+      _cityTrip(const ['Paris', 'Rome'], booked: {'Paris'}),
+    );
+    await _openBookingsTab(tester);
+    await _tapDestination(tester, 'Paris');
+    await tester.tap(find.widgetWithText(FilterChip, 'Not booked yet'));
+    await tester.pumpAndSettle();
+
+    // Paris is booked, Rome is not: the trip-wide celebration would be a lie.
+    expect(find.text('Nothing left to book here.'), findsOneWidget);
+    expect(find.text("Everything's booked"), findsNothing);
+
+    // Clearing to All reveals what is genuinely left.
+    await _tapDestination(tester, 'All');
+    expect(find.widgetWithText(BookingTodoRow, 'Stay in Rome'), findsOneWidget);
+  });
+
+  testWidgets('one destination and no residuals renders no strip at all',
+      (tester) async {
+    _useViewport(tester, const Size(900, 3000));
+    await _pump(tester, _cityTrip(const ['Paris']));
+    await _openBookingsTab(tester);
+
+    // The scope chip stays — it still has something to say.
+    expect(find.widgetWithText(FilterChip, 'Not booked yet'), findsOneWidget);
+    // A one-city filter would show exactly what All shows.
+    expect(find.byType(ChoiceChip), findsNothing);
+  });
+
+  testWidgets('the selected chip is revealed when it starts past the fold',
+      (tester) async {
+    // Narrow body, ten cities: the strip genuinely scrolls.
+    _useViewport(tester, const Size(420, 2400));
+    await _pump(
+      tester,
+      _cityTrip(const [
+        'Paris',
+        'Rome',
+        'Berlin',
+        'Prague',
+        'Vienna',
+        'Madrid',
+        'Lisbon',
+        'Athens',
+        'Oslo',
+        'Dublin',
+      ]),
+    );
+    await _openBookingsTab(tester);
+
+    await _tapDestination(tester, 'Dublin');
+
+    // The strip scrolled the last chip into its OWN viewport rather than
+    // leaving the selection somewhere off-screen.
+    final strip = tester.getRect(find.descendant(
+        of: find.byType(BookingFilterBar),
+        matching: find.byType(Scrollable)));
+    final chip = tester.getRect(_chip('Dublin'));
+    expect(chip.left, greaterThanOrEqualTo(strip.left - 1));
+    expect(chip.right, lessThanOrEqualTo(strip.right + 1));
+
+    // The way back never scrolls away with it.
+    expect(_chip('All'), findsOneWidget);
+    expect(tester.getRect(_chip('All')).right, lessThanOrEqualTo(strip.left));
+  });
+
+  testWidgets('the filter row survives a narrow Spanish viewport at 1.3x',
+      (tester) async {
+    _useViewport(tester, const Size(320, 2400));
+    await _pump(
+      tester,
+      _cityTrip(const ['Paris', 'Rome', 'Berlin']),
+      locale: const Locale('es'),
+      textScale: 1.3,
+    );
+    await _openBookingsTab(tester, label: 'Reservas');
+
+    // A RenderFlex overflow throws, so this assert is not vacuous.
+    expect(tester.takeException(), isNull);
+    expect(find.widgetWithText(FilterChip, 'Sin reservar'), findsOneWidget);
+    expect(_chip('Todas'), findsOneWidget);
+  });
+}

--- a/src/packages/flutter-app/test/trip_detail_derivation_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_derivation_test.dart
@@ -323,6 +323,59 @@ void main() {
       expect(grouped.residualSegments, isEmpty);
     });
 
+    // The Bookings filter strip's chip counts. The rule they must obey is the
+    // one PR #455 paid for on the Trip Health badge: a count answers for the
+    // rows it sits above, so it counts ENTRIES (one visible checkbox each)
+    // over exactly the slots that chip reveals.
+    test('bookingDestinationCounts: one entry per visible checkbox', () {
+      final todos = [
+        _todo('transport:home>>paris'),
+        _todo('stay:paris', kind: 'stay', booked: true),
+        _todo('transport:paris>>rome'),
+        _todo('stay:rome', kind: 'stay'),
+        _todo('transport:paris>>home'),
+        _todo('custom:helicopter', kind: 'other', booked: true),
+      ];
+      final d = _compute(bookingTodos: todos, stays: [_parisStay, _draftStay]);
+      final counts = bookingDestinationCounts(d.groupedBookings, d.legLabels,
+          otherKey: 'Other places');
+
+      // Paris' two runs sum into ONE entry: run 1 has an arrival + a booked
+      // stay; the revisited run has the flight home (departure counts only on
+      // the LAST slot) and no stay to re-claim.
+      expect(counts['Paris'], (booked: 1, total: 3));
+      expect(counts['Rome'], (booked: 0, total: 2));
+      // Residuals answer under Other, and only there.
+      expect(counts['Other places'], (booked: 1, total: 1));
+    });
+
+    test('bookingDestinationCounts: a stay match rides its todo, not a second '
+        'entry', () {
+      final todos = [_todo('stay:paris', kind: 'stay')];
+      final d = _compute(bookingTodos: todos, stays: [_parisStay]);
+      final grouped = d.groupedBookings;
+      // The confirmed stay filled the todo's slot...
+      expect(grouped.slots[0].stayMatch?.id, 'a1');
+      // ...so it is ONE booking, not two, and its checkbox is the todo's.
+      expect(
+          bookingDestinationCounts(grouped, d.legLabels, otherKey: 'Other')[
+              'Paris'],
+          (booked: 0, total: 1));
+    });
+
+    test('bookingEntryBooked: the todo wins, then the record', () {
+      const bookedStay = Accommodation(id: 'a9', name: 'X', booked: true);
+      expect(
+          bookingEntryBooked(
+              (todo: _todo('stay:x', kind: 'stay'), stay: bookedStay, segment: null)),
+          isFalse,
+          reason: 'an unticked todo row is unbooked whatever its match says');
+      expect(bookingEntryBooked((todo: null, stay: bookedStay, segment: null)),
+          isTrue);
+      expect(bookingEntryBooked((todo: null, stay: null, segment: null)), isTrue,
+          reason: 'nothing to book never lands in the left-to-book list');
+    });
+
     // A confirmed segment fills a leg's slot only when it connects BOTH of the
     // leg's endpoints — the rule the server has always applied in todoClaimed
     // (trip_review.go), now applied here too.

--- a/src/packages/flutter-app/test/trip_detail_view_tabs_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_view_tabs_test.dart
@@ -182,6 +182,19 @@ Future<void> _openBookingsTab(WidgetTester tester, [String? count]) async {
   await tester.pumpAndSettle();
 }
 
+/// Taps a destination chip in the Bookings filter strip. The strip scrolls
+/// horizontally (that is the point of it), so a chip past the fold has to be
+/// brought into view before it can be hit — exactly what a traveler does with
+/// a drag.
+Future<void> _tapDestination(WidgetTester tester, String label) async {
+  final chip = find.ancestor(
+      of: find.text(label), matching: find.byType(ChoiceChip));
+  await tester.ensureVisible(chip);
+  await tester.pumpAndSettle();
+  await tester.tap(chip);
+  await tester.pumpAndSettle();
+}
+
 void main() {
   testWidgets(
       'unbooked lens lists only unbooked booking rows and no item tiles',
@@ -399,7 +412,7 @@ void main() {
     expect(find.text("Everything's booked"), findsNothing);
   });
 
-  testWidgets('destination chips narrow the lens; re-tap returns to All',
+  testWidgets('destination chips narrow the lens; the All chip is the way back',
       (tester) async {
     _useTallViewport(tester);
     await _pump(tester, twoCityTrip());
@@ -410,15 +423,18 @@ void main() {
     expect(
         find.widgetWithText(BookingTodoRow, 'Stay in Rome'), findsOneWidget);
 
-    await tester.tap(find.widgetWithText(ChoiceChip, 'Rome'));
-    await tester.pumpAndSettle();
+    await _tapDestination(tester, 'Rome');
     expect(find.widgetWithText(BookingTodoRow, 'Stay in Paris'), findsNothing);
     expect(
         find.widgetWithText(BookingTodoRow, 'Stay in Rome'), findsOneWidget);
 
-    // Tapping the selected chip clears back to All.
-    await tester.tap(find.widgetWithText(ChoiceChip, 'Rome'));
-    await tester.pumpAndSettle();
+    // Re-tapping the selected chip is a dead gesture, not a hidden clear —
+    // the filter is still on Rome.
+    await _tapDestination(tester, 'Rome');
+    expect(find.widgetWithText(BookingTodoRow, 'Stay in Paris'), findsNothing);
+
+    // The All chip is the visible way back to every booking.
+    await _tapDestination(tester, 'All');
     expect(
         find.widgetWithText(BookingTodoRow, 'Stay in Paris'), findsOneWidget);
     expect(
@@ -449,16 +465,14 @@ void main() {
         find.widgetWithText(BookingTodoCard, 'Museum tickets'), findsOneWidget);
 
     // A destination chip hides the residual (it matched no destination)...
-    await tester.tap(find.widgetWithText(ChoiceChip, 'Paris'));
-    await tester.pumpAndSettle();
+    await _tapDestination(tester, 'Paris');
     expect(find.widgetWithText(BookingTodoCard, 'Museum tickets'),
         findsNothing);
     expect(
         find.widgetWithText(BookingTodoRow, 'Stay in Paris'), findsOneWidget);
 
     // ...and the Other chip shows only residuals.
-    await tester.tap(find.widgetWithText(ChoiceChip, 'Other bookings'));
-    await tester.pumpAndSettle();
+    await _tapDestination(tester, 'Other bookings');
     expect(
         find.widgetWithText(BookingTodoCard, 'Museum tickets'), findsOneWidget);
     expect(find.widgetWithText(BookingTodoRow, 'Stay in Paris'), findsNothing);


### PR DESCRIPTION
## Summary

Brian's ask: *"In the bookings section, should these big buttons for each city be a dropdown instead?"* — on an eight-city trip the destination filter was a `Wrap` of chips under a separate "Not booked yet" chip, **~5 rows of chrome before the first booking row**, growing with the trip.

- **One row at every width**: scope chip + a pinned **All** chip + a horizontally scrolling strip of destination chips. Not a dropdown — that trades a tap per city switch for the same row it saves, and hides the trip's shape.
- **Each chip carries its own count** (`Prague · 1/2`), so the filter doubles as a per-city progress read.
- **"All" is now visible.** Before, the only way back to every booking was re-tapping the already-selected chip — an affordance nothing on screen advertised (`docs/zen.md`). Re-tapping a selected chip is now a dead gesture, not a second hidden way to do the same thing.
- **The destination survives a "Not booked yet" toggle** — the scope answers *what*, the strip answers *where*. A fully booked single destination gets its own line rather than the trip-wide "Everything's booked", which that list cannot support.

### Counts answer for the rows beneath them

`bookingSlotEntries` + `bookingEntryBooked` are extracted into `trip_detail_derivation.dart` so `_bookingRowWidgets` and every count iterate the **same enumeration** and share **one definition of "booked"** — the PR #455 rule. The tests assert chip counts against the checkboxes each chip reveals, never number-against-number.

Stated divergence, documented at both sites rather than quietly reconciled: the Bookings **tab pill** still counts booking *todos*, so a trip with confirmed records that matched no todo sums higher on the chips. The pill is load-bearing for `specs/next-step-cta` parity, so it is left alone.

### Borrowed, and deliberately diverged, from `MapLegChips`

Carried over: the way back is pinned **outside** the scroll view (an exit that can scroll off-screen is not an exit), and the selected chip is revealed through the strip's **own** `ScrollPosition` — never `Scrollable.ensureVisible`, which walks ancestors and would yank the trip page's scroll. Diverged: the map has no All chip (a chip selected at rest would put the strongest treatment on "no filter", competing with map focus); here the resting state is the answer to a question the traveler asks.

## Testing

- `flutter analyze` — clean (3 pre-existing infos in `route_response.dart`).
- `flutter test` — **1582 passed**. New `test/trip_detail_bookings_filter_test.dart` (9 tests: count-equals-rendered-rows per chip, revisited city sums both runs, Other counts residuals only, a confirmed record with no todo counts once, destination survives the scope toggle, per-destination empty state, no strip for one destination, selected-chip reveal, 320px Spanish @1.3× no-overflow) + 3 derivation unit tests. Updated the two view-tab tests whose re-tap-clears behavior changed.
- **Browser-verified** on a seeded 8-city trip (Amsterdam → Rome, 15 booking todos) at 1440px, 390px, and 390px Spanish: one filter row, counts summing to the tab pill (15), a tick updating its chip live to `1/2`, the strip scrolling with All pinned, and the destination surviving the scope toggle.

Two layout bugs the new tests caught, not the eye:
- A 320px Spanish row at 1.3× text **overflowed by 94px**, and short of overflowing the pinned pair starved the strip to ~180px on a 420px body — less than one `Gothenburg · 0/2` chip. Fix: cap the pinned half at 50% and scale it down inside that (the view-tabs lever).
- The leading fade (which stops a scrolled-under chip's `· 0/2` tail from reading as *All's* count) was applied only when scrolled — and swapping the `ShaderMask` in **re-parented the scroll view**, dropping the `ScrollController` position, so the strip snapped back to the first chip the instant the fade engaged. The mask now stays in the tree and only its gradient changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
