### PR TITLE
fix(app-bar): the wordmark yields to the page's own name on a phone

### DIFF
--- a/src/packages/flutter-app/lib/screens/account_settings_screen.dart
+++ b/src/packages/flutter-app/lib/screens/account_settings_screen.dart
@@ -169,7 +169,7 @@ class _AccountSettingsScreenState extends ConsumerState<AccountSettingsScreen> {
     final user = ref.watch(authProvider).user;
 
     return Scaffold(
-      appBar: GradientAppBar(title: Text(l10n.settingsTitle)),
+      appBar: GradientAppBar(title: l10n.settingsTitle),
       body: Column(
         children: [
           // A thin global activity bar (the account calls all share one _busy

--- a/src/packages/flutter-app/lib/screens/admin_metrics_screen.dart
+++ b/src/packages/flutter-app/lib/screens/admin_metrics_screen.dart
@@ -49,7 +49,7 @@ class _AdminMetricsScreenState extends ConsumerState<AdminMetricsScreen> {
         // The house app bar, like every other screen — which also puts the
         // brand up here. This was the one screen still wearing raw M3 chrome.
         appBar: const GradientAppBar(
-          title: Text('Metrics'),
+          title: 'Metrics',
           bottom: TabBar(
             isScrollable: true,
             // The gradient is dark, so the tabs carry their own light palette

--- a/src/packages/flutter-app/lib/screens/agent_screen.dart
+++ b/src/packages/flutter-app/lib/screens/agent_screen.dart
@@ -80,7 +80,7 @@ class _AgentScreenState extends ConsumerState<AgentScreen> {
 
     return Scaffold(
       appBar: GradientAppBar(
-        title: Text(l10n.agentScreenTitle),
+        title: l10n.agentScreenTitle,
         actions: [
           if (showReset)
             IconButton(

--- a/src/packages/flutter-app/lib/screens/connect_app_screen.dart
+++ b/src/packages/flutter-app/lib/screens/connect_app_screen.dart
@@ -291,7 +291,7 @@ class _ConnectAppScreenState extends ConsumerState<ConnectAppScreen> {
     }
 
     return Scaffold(
-      appBar: GradientAppBar(title: Text(l10n.connectAppBarTitle)),
+      appBar: GradientAppBar(title: l10n.connectAppBarTitle),
       body: Center(
         child: SingleChildScrollView(
           padding: const EdgeInsets.all(AppSpacing.xl),

--- a/src/packages/flutter-app/lib/screens/flight_search_screen.dart
+++ b/src/packages/flutter-app/lib/screens/flight_search_screen.dart
@@ -424,7 +424,7 @@ class _FlightSearchScreenState extends ConsumerState<FlightSearchScreen> {
     final l10n = context.l10n;
 
     return Scaffold(
-      appBar: GradientAppBar(title: Text(l10n.flightSearchTitle)),
+      appBar: GradientAppBar(title: l10n.flightSearchTitle),
       // One scroll surface for form + results (declutter series): the form
       // can't push results off a phone viewport, and the whole page scrolls.
       body: CustomScrollView(

--- a/src/packages/flutter-app/lib/screens/guides_screen.dart
+++ b/src/packages/flutter-app/lib/screens/guides_screen.dart
@@ -23,7 +23,7 @@ class GuidesScreen extends ConsumerWidget {
     final guides = ref.watch(allGuidesProvider);
 
     return Scaffold(
-      appBar: GradientAppBar(title: Text(l10n.guidesTitle)),
+      appBar: GradientAppBar(title: l10n.guidesTitle),
       body: guides.when(
         loading: () => const Center(child: CircularProgressIndicator()),
         error: (_, __) => EmptyState(

--- a/src/packages/flutter-app/lib/screens/import_trip_screen.dart
+++ b/src/packages/flutter-app/lib/screens/import_trip_screen.dart
@@ -127,7 +127,7 @@ class _ImportTripScreenState extends ConsumerState<ImportTripScreen> {
     final hasText = _controller.text.trim().isNotEmpty;
 
     return Scaffold(
-      appBar: GradientAppBar(title: Text(l10n.importFromAi)),
+      appBar: GradientAppBar(title: l10n.importFromAi),
       body: ListView(
         padding: const EdgeInsets.all(AppSpacing.md),
         children: [

--- a/src/packages/flutter-app/lib/screens/local_admin_screen.dart
+++ b/src/packages/flutter-app/lib/screens/local_admin_screen.dart
@@ -27,7 +27,7 @@ class _LocalAdminScreenState extends ConsumerState<LocalAdminScreen> {
       length: 3,
       child: Scaffold(
         appBar: const GradientAppBar(
-          title: Text('Local intel admin'),
+          title: 'Local intel admin',
         ),
         body: Column(
           children: const [

--- a/src/packages/flutter-app/lib/screens/local_guide_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/local_guide_detail_screen.dart
@@ -36,19 +36,12 @@ class LocalGuideDetailScreen extends ConsumerWidget {
 
     return Scaffold(
       appBar: GradientAppBar(
-        title: Row(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            const Icon(Icons.menu_book, size: 20),
-            const SizedBox(width: AppSpacing.sm),
-            Flexible(
-              child: Text(
-                l10n.guideDetailTitle,
-                overflow: TextOverflow.ellipsis,
-              ),
-            ),
-          ],
-        ),
+        // Was an Icons.menu_book + label lockup; the icon is gone, because the
+        // bar now measures its title to decide what the brand can afford
+        // beside it and a widget cannot be measured. No loss — this was the
+        // one header of twenty-odd wearing an icon, and the page below it
+        // opens with the guide's own cover.
+        title: l10n.guideDetailTitle,
       ),
       body: detail.when(
         loading: () => const Center(child: CircularProgressIndicator()),

--- a/src/packages/flutter-app/lib/screens/log_trip_screen.dart
+++ b/src/packages/flutter-app/lib/screens/log_trip_screen.dart
@@ -177,7 +177,7 @@ class _LogTripScreenState extends ConsumerState<LogTripScreen> {
     final range = _dates;
 
     return Scaffold(
-      appBar: GradientAppBar(title: Text(l10n.logTripTitle)),
+      appBar: GradientAppBar(title: l10n.logTripTitle),
       body: ListView(
         padding: const EdgeInsets.all(AppSpacing.md),
         children: [

--- a/src/packages/flutter-app/lib/screens/notification_center_screen.dart
+++ b/src/packages/flutter-app/lib/screens/notification_center_screen.dart
@@ -106,7 +106,7 @@ class _NotificationCenterScreenState
         notifs.maybeWhen(data: (list) => list.isNotEmpty, orElse: () => false);
     return Scaffold(
       appBar: GradientAppBar(
-        title: Text(l10n.notifTitle),
+        title: l10n.notifTitle,
         actions: [
           if (hasRows)
             // Destructive exits live behind an overflow menu, not a bare icon

--- a/src/packages/flutter-app/lib/screens/onboarding_quiz_screen.dart
+++ b/src/packages/flutter-app/lib/screens/onboarding_quiz_screen.dart
@@ -240,7 +240,7 @@ class _OnboardingQuizScreenState extends ConsumerState<OnboardingQuizScreen> {
       },
       child: Scaffold(
         appBar: GradientAppBar(
-          title: Text(l10n.quizTitle),
+          title: l10n.quizTitle,
           actions: [
             TextButton(
               onPressed: _submitting ? null : _skip,

--- a/src/packages/flutter-app/lib/screens/preferences_screen.dart
+++ b/src/packages/flutter-app/lib/screens/preferences_screen.dart
@@ -357,7 +357,7 @@ class _PreferencesScreenState extends ConsumerState<PreferencesScreen> {
 
     return Scaffold(
       appBar: GradientAppBar(
-        title: Text(l10n.prefsTitle),
+        title: l10n.prefsTitle,
       ),
       body: body,
     );

--- a/src/packages/flutter-app/lib/screens/reset_password_screen.dart
+++ b/src/packages/flutter-app/lib/screens/reset_password_screen.dart
@@ -70,7 +70,7 @@ class _ResetPasswordScreenState extends ConsumerState<ResetPasswordScreen> {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     return Scaffold(
-      appBar: GradientAppBar(title: Text(context.l10n.resetAppBarTitle)),
+      appBar: GradientAppBar(title: context.l10n.resetAppBarTitle),
       body: Center(
         child: SingleChildScrollView(
           padding: const EdgeInsets.all(AppSpacing.xl),

--- a/src/packages/flutter-app/lib/screens/shared_trip_screen.dart
+++ b/src/packages/flutter-app/lib/screens/shared_trip_screen.dart
@@ -58,8 +58,8 @@ class SharedTripScreen extends ConsumerWidget {
     return Scaffold(
       appBar: GradientAppBar(
         title: shared.maybeWhen(
-          data: (s) => Text(s.trip.title),
-          orElse: () => Text(l10n.sharedTitle),
+          data: (s) => s.trip.title,
+          orElse: () => l10n.sharedTitle,
         ),
       ),
       body: shared.when(

--- a/src/packages/flutter-app/lib/screens/sso_callback_screen.dart
+++ b/src/packages/flutter-app/lib/screens/sso_callback_screen.dart
@@ -108,7 +108,7 @@ class _SsoCallbackScreenState extends ConsumerState<SsoCallbackScreen> {
       );
     }
     return Scaffold(
-      appBar: GradientAppBar(title: Text(l10n.ssoTitle)),
+      appBar: GradientAppBar(title: l10n.ssoTitle),
       body: Center(
         child: SingleChildScrollView(
           padding: const EdgeInsets.all(AppSpacing.xl),

--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -5611,6 +5611,23 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
                 onSelected: () => _openWearSheet(trip, wear.regions),
               ),
           ],
+          // Refine, narrow only — it held an app-bar icon until the header
+          // needed that ~48px for the trip's own name. Its own section
+          // because the group above is "look at this trip differently" and
+          // this one changes it.
+          //
+          // Editors only (specs/collaborator-refine), and offline HIDES it
+          // rather than disabling it: the icon could gray out, but a sheet row
+          // has no disabled state, and hiding a mutating entry offline is
+          // already this menu's vocabulary — same as share and the exits.
+          [
+            if (_narrow && trip.canEdit && !_isOffline)
+              TripAction(
+                icon: Icons.auto_awesome,
+                label: l10n.tripRefineWithAI,
+                onSelected: () => _openRefine(trip, const RefineTarget.trip()),
+              ),
+          ],
           if (absorbsShare) ..._shareActionSections(l10n),
           [
             if (canExit)
@@ -6180,33 +6197,28 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
             )
           : null,
       appBar: GradientAppBar(
-        title: Text(
-            trip != null ? _displayTitle(trip) : l10n.tripTitleFallback,
-            maxLines: 1,
-            overflow: TextOverflow.ellipsis),
+        title: trip != null ? _displayTitle(trip) : l10n.tripTitleFallback,
         actions: [
-          // The app bar now also carries the ANEMOS wordmark, and a phone
-          // cannot fit five icons beside it — at 360px five actions leave the
-          // title slot ~48px, less than the wordmark itself. So at narrow the
-          // two actions that are already menus/sheets fold into the overflow
-          // (see [_overflowAppBarAction]) and the icon row drops to three.
+          // This is the app's width-budget boss: five icons beside the brand
+          // fit at rail widths and nowhere near it on a phone. At narrow
+          // everything that is already a menu or a sheet folds into the
+          // overflow (see [_overflowAppBarAction]) and the icon row drops to
+          // TWO — health plus the `⋮` itself.
           //
-          // The two that keep their icons earned it: health leads because its
-          // severity count is a glanceable badge, and refine is the header
-          // card's own Refine button relocated — narrow drops it down there
-          // (one clean chip row) precisely so the app bar can carry it.
+          // Health is the one action that earns an icon on a phone: its
+          // severity count is a glanceable badge, and a badge inside a menu is
+          // a badge nobody sees. Everything else is one tap further away and
+          // the trip's NAME gets the ~48px back — at 375px that is the
+          // difference between "Big Su…" and a name you can read, which is
+          // what the traveler actually needed the header for.
+          //
+          // Refine used to hold an icon here at narrow — it is the header
+          // card's own Refine button relocated, since narrow drops it down
+          // there for one clean chip row. It now rides the `⋮` instead, and
+          // the header card must STAY as it is: putting its button back is
+          // what #457's chip row was tidying away.
           if (trip != null) _healthAppBarAction(trip, theme),
           if (trip != null && !_narrow) _wearAppBarAction(trip),
-          // Same gates as the button it replaces: editors only
-          // (specs/collaborator-refine), disabled — not hidden — offline.
-          if (_narrow && trip != null && trip.canEdit)
-            IconButton(
-              icon: const Icon(Icons.auto_awesome),
-              tooltip: l10n.tripRefineWithAI,
-              onPressed: _isOffline
-                  ? null
-                  : () => _openRefine(trip, const RefineTarget.trip()),
-            ),
           // Sharing is an owner-only surface; it mutates, so it's hidden
           // while offline-serving.
           if (trip != null && trip.isOwner && !_isOffline && !_narrow)

--- a/src/packages/flutter-app/lib/screens/trip_map_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_map_screen.dart
@@ -250,9 +250,10 @@ class _TripMapScreenState extends ConsumerState<TripMapScreen> {
         backgroundColor: appMapBackground,
         appBar: GradientAppBar(
           // Multi-city titles ("Barcelona, Madrid & 3 more") must ellipsize —
-          // the fullscreenDialog close button already eats leading width.
-          title:
-              Text(widget.title, maxLines: 1, overflow: TextOverflow.ellipsis),
+          // the fullscreenDialog close button already eats leading width. The
+          // bar owns that now, and measures this string to decide whether the
+          // wordmark can stay beside it.
+          title: widget.title,
           actions: [
             // Persistent add affordance: the on-map CTA only exists in the
             // empty state, so once a leg has a single pin the full-screen map

--- a/src/packages/flutter-app/lib/screens/trips_list_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trips_list_screen.dart
@@ -358,7 +358,7 @@ class _TripsListScreenState extends ConsumerState<TripsListScreen> {
 
     return Scaffold(
       appBar: GradientAppBar(
-        title: Text(l10n.tripsListTitle),
+        title: l10n.tripsListTitle,
         actions: [
           // The entry point that covers the gap the other two leave: an
           // account with exactly one trip sees neither the empty state nor

--- a/src/packages/flutter-app/lib/screens/verify_email_screen.dart
+++ b/src/packages/flutter-app/lib/screens/verify_email_screen.dart
@@ -91,7 +91,7 @@ class _VerifyEmailScreenState extends ConsumerState<VerifyEmailScreen> {
       );
     }
     return Scaffold(
-      appBar: GradientAppBar(title: Text(l10n.verifyTitle)),
+      appBar: GradientAppBar(title: l10n.verifyTitle),
       body: Center(
         child: SingleChildScrollView(
           padding: const EdgeInsets.all(AppSpacing.xl),

--- a/src/packages/flutter-app/lib/widgets/gradient_app_bar.dart
+++ b/src/packages/flutter-app/lib/widgets/gradient_app_bar.dart
@@ -84,20 +84,39 @@ const double _minTitleWidth = 56;
 /// root a net 24px of title budget, not 56. Nothing separates the title from
 /// [actions] now except an [IconButton]'s own padding, which measures fine.
 ///
-/// Two things then compete for the title slot, and the priority is fixed:
+/// Two things then compete for the title slot, and **the wordmark is the one
+/// that yields**:
 ///
-/// 1. **The wordmark** — always present, always the same size, never
-///    ellipsized. That is the whole point.
-/// 2. **The page title** — [Flexible], ellipsized, dropped below
-///    [_minTitleWidth].
+/// 1. **The page title** — whole, if the row can hold it whole.
+/// 2. **The wordmark** — always the same size and never ellipsized, but it
+///    steps out of the row when keeping it is exactly what would clip the
+///    page's own name. It never yields at rail widths, where it is the bar's
+///    only brand (the rose is on the rail, not in the leading slot).
 ///
-/// Rung 2 barely moves on a tab root — 24px shifts the drop threshold by about
-/// a phone-width hair, and Trips reads the same at 320 (dropped, as before),
-/// 360 (ellipsized) and 390 (whole). On a **pushed** page it moves a long way
-/// the *good* way: the rose leaving the row hands the title back the 52px it
-/// used to spend, which is why trip detail now shows its trip name on a phone
-/// at all. Measured in a browser against real Cinzel, not computed — the
-/// numbers here are easy to get wrong and the comment is load-bearing.
+/// That ordering is the reverse of PR #418's, and it was reversed by what the
+/// old one shipped to a phone: `ANEMOS · Plan your t…`. A stub of a page name
+/// tells a traveler nothing they did not already know, and on a tab root the
+/// bottom bar names the tab one row down anyway.
+///
+/// **Measured, not thresholded.** `width < kRailBreakpoint` would strip the
+/// wordmark off a 744px iPad in portrait and a 799px desktop window, both of
+/// which have hundreds of pixels to spare. Measuring means nothing changes
+/// anywhere there is room — which, after the 84px the leading slot and
+/// `titleSpacing: 0` above hand back, is most places: at 390px a tab root now
+/// fits `ANEMOS · Plan your trip` whole and the ladder never reaches rung 2.
+/// What still reaches it are the long ones — a trip name, `Set up your travel
+/// profile`, Spanish — and on a pushed page, where the leading slot holds a
+/// back button rather than the rose, that leaves the bar carrying no brand at
+/// all. Deliberate: back-button + the thing you opened is the universal mobile
+/// header, and the traveler branded the app one tap ago.
+///
+/// Rung ordering aside, the threshold arithmetic barely moves on a tab root —
+/// 24px shifts it by about a phone-width hair, and Trips reads the same at 320,
+/// 360 and 390. On a **pushed** page it moves a long way the *good* way: the
+/// rose leaving the row hands the title back the 52px it used to spend, which
+/// is why trip detail shows its trip name on a phone at all. Measured in a
+/// browser against real Cinzel, not computed — the numbers here are easy to get
+/// wrong and the comment is load-bearing.
 ///
 /// The rose floats bare, as it does everywhere: this bar just takes the
 /// reversed cut ([BrandLogo.markLight]) because its field is the teal gradient
@@ -106,7 +125,13 @@ const double _minTitleWidth = 56;
 /// why, and re-litigate it there rather than reintroducing a plate here.
 class GradientAppBar extends ConsumerWidget implements PreferredSizeWidget {
   /// The page's own title. Null where the brand stands alone.
-  final Widget? title;
+  ///
+  /// Text, not a [Widget], because the ladder has to **measure** it to decide
+  /// what fits — and a widget cannot be measured before it is laid out. Taking
+  /// the string also puts the whole title contract in one place: this bar owns
+  /// its face, its colour, its `maxLines` and its ellipsis, instead of owning
+  /// half of them and trusting twenty call sites for the rest.
+  final String? title;
   final List<Widget>? actions;
 
   /// Defaults to false: the brand is left-anchored, so the whole title row is
@@ -133,6 +158,52 @@ class GradientAppBar extends ConsumerWidget implements PreferredSizeWidget {
   @override
   Size get preferredSize =>
       Size.fromHeight(kToolbarHeight + (bottom?.preferredSize.height ?? 0));
+
+  /// The face a page title paints in, exposed so anything that needs to
+  /// *measure* one uses the exact numbers it renders with — see [titleWidthIn].
+  /// Same pairing as [BrandWordmark.styleOf]/[BrandWordmark.widthIn], for the
+  /// same reason: two copies of a font spec drift, and the drift shows up as a
+  /// clipped header nobody can reproduce.
+  ///
+  /// The page title is a heading, so it takes the display face — a trip name
+  /// reads the same here as it does in the header below it.
+  ///
+  /// Handed to [AppBar.titleTextStyle] rather than to
+  /// `AppBarTheme.titleTextStyle` because AppBar folds `foregroundColor` into
+  /// the *defaults* branch only (`widget.titleTextStyle ??
+  /// appBarTheme.titleTextStyle ?? defaults.titleTextStyle?.copyWith(color:
+  /// foregroundColor)`): a themed style without a color would quietly paint
+  /// every title onSurface — dark text on the teal gradient. Hence the
+  /// explicit white.
+  ///
+  /// Size holds at 22 despite the face change: Marcellus sets ~9% narrower than
+  /// Inter Bold, so the longest trip titles gain room here, not lose it.
+  static const TextStyle titleStyle = TextStyle(
+    fontFamily: AppFonts.display,
+    fontWeight: FontWeight.w400,
+    fontSize: 22,
+    letterSpacing: 0.2,
+    color: Colors.white,
+  );
+
+  /// How wide [text] will actually paint as a page title in [context].
+  ///
+  /// Measured for the same reasons [BrandWordmark.widthIn] is: Marcellus may
+  /// not have loaded (widget tests fall back to a font of quite different
+  /// metrics), and the traveler's text-scale setting multiplies the answer. The
+  /// ladder is arithmetic on this number, so a hardcoded width would decide
+  /// "it fits" for a large-text user it does not fit for.
+  static double titleWidthIn(BuildContext context, String text) {
+    final painter = TextPainter(
+      text: TextSpan(text: text, style: titleStyle),
+      textDirection: Directionality.of(context),
+      textScaler: MediaQuery.textScalerOf(context),
+      maxLines: 1,
+    )..layout();
+    final width = painter.width;
+    painter.dispose();
+    return width;
+  }
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -181,32 +252,20 @@ class GradientAppBar extends ConsumerWidget implements PreferredSizeWidget {
       // from whatever precedes it, and on a phone those 16px are worth more as
       // title width. See [_titleEndGap] for what this costs on the other side.
       titleSpacing: 0,
-      title: _BrandTitle(title: title, onTap: onTap),
+      // railCarriesMark is passed down rather than recomputed: it is the same
+      // fact the leading slot above turns on, and the ladder needs it to know
+      // whether the wordmark is the bar's ONLY brand (rail widths) or has a
+      // rose standing beside it.
+      title: _BrandTitle(
+          title: title, onTap: onTap, railCarriesMark: railCarriesMark),
       actions: actions,
       centerTitle: centerTitle ?? false,
       bottom: bottom,
       backgroundColor: Colors.transparent,
       foregroundColor: Colors.white,
-      // The page title is a heading, so it takes the display face — a trip
-      // name reads the same here as it does in the header below it.
-      //
-      // Set here rather than on AppBarTheme.titleTextStyle because AppBar
-      // folds foregroundColor into the *defaults* branch only
-      // (`widget.titleTextStyle ?? appBarTheme.titleTextStyle ??
-      // defaults.titleTextStyle?.copyWith(color: foregroundColor)`): a themed
-      // style without a color would quietly paint every title onSurface —
-      // dark text on the teal gradient. Hence the explicit white.
-      //
-      // Size holds at 22 despite the face change: Marcellus sets ~9% narrower
-      // than Inter Bold, so the longest trip titles gain room here, not lose
-      // it.
-      titleTextStyle: const TextStyle(
-        fontFamily: AppFonts.display,
-        fontWeight: FontWeight.w400,
-        fontSize: 22,
-        letterSpacing: 0.2,
-        color: Colors.white,
-      ),
+      // Rationale on [titleStyle] itself, which is also what the ladder
+      // measures against.
+      titleTextStyle: titleStyle,
       flexibleSpace: Container(
         decoration: BoxDecoration(gradient: AppColors.brandGradient),
       ),
@@ -309,10 +368,18 @@ class _LeadingSlot extends ConsumerWidget {
 /// positioned identically whether a back button, the rose, or nothing at all is
 /// standing to its left.
 class _BrandTitle extends ConsumerWidget {
-  final Widget? title;
+  final String? title;
   final VoidCallback? onTap;
 
-  const _BrandTitle({required this.title, required this.onTap});
+  /// Whether the rail is showing the rose, which is the one case where this
+  /// row's wordmark is the bar's ONLY brand — so the one case where it does
+  /// not step aside for a page title.
+  final bool railCarriesMark;
+
+  const _BrandTitle(
+      {required this.title,
+      required this.onTap,
+      required this.railCarriesMark});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -321,16 +388,52 @@ class _BrandTitle extends ConsumerWidget {
     // around it.
     return LayoutBuilder(
       builder: (context, constraints) {
-        // The ladder, as arithmetic on what the wordmark actually measures —
-        // so it holds under a missing font or a large text-scale setting,
-        // where fixed thresholds would silently start clipping.
-        // Two rungs now, not three: the only question this row still asks is
-        // whether a page title fits beside the word.
+        // The ladder, as arithmetic on what the wordmark and the title
+        // actually measure — so it holds under a missing font or a large
+        // text-scale setting, where fixed thresholds would silently start
+        // clipping. Two rungs, and the wordmark is the one that yields.
         final slot = constraints.maxWidth;
         final brandCost = _brandPadding + BrandWordmark.widthIn(context);
+        final titleWidth = title == null
+            ? 0.0
+            : GradientAppBar.titleWidthIn(context, title!);
 
-        final showTitle =
-            title != null && slot >= brandCost + _separatorSlot + _minTitleWidth;
+        // What the title gets with the word beside it, and what it gets with
+        // the row to itself.
+        final roomBesideWordmark = slot - brandCost - _separatorSlot;
+
+        final bool showWordmark, showTitle;
+        if (title == null) {
+          // Home and Landing: the brand IS the title, so nothing competes.
+          showWordmark = true;
+          showTitle = false;
+        } else if (roomBesideWordmark >= titleWidth) {
+          // Room for both — which, after the leading slot handed back 84px, is
+          // most bars including a 390px tab root. Nothing yields when nothing
+          // has to, so this is also every width at or above the rail.
+          showWordmark = true;
+          showTitle = true;
+        } else if (railCarriesMark) {
+          // The rail has the rose, so the word is this bar's only brand and
+          // cannot leave. Ellipsize the title as before, and drop it below the
+          // floor. Unreachable in practice — a rail-width bar has the room —
+          // but stating it is what keeps #418's promise true by construction
+          // rather than by luck.
+          showWordmark = true;
+          showTitle = roomBesideWordmark >= _minTitleWidth;
+        } else if (slot - _brandPadding >= _minTitleWidth) {
+          // The wordmark steps out so the page's own name can be read. On a
+          // tab root the rose is still in the leading slot; on a pushed page
+          // the back button is, and the bar carries no brand — see the class
+          // doc, that is the deliberate half of this.
+          showWordmark = false;
+          showTitle = true;
+        } else {
+          // Not even a stub fits. Fall back to the brand alone and let the
+          // FittedBox below absorb the squeeze.
+          showWordmark = true;
+          showTitle = false;
+        }
 
         Widget brand = const Padding(
           padding: EdgeInsets.all(AppSpacing.xs),
@@ -405,15 +508,17 @@ class _BrandTitle extends ConsumerWidget {
         return Row(
           mainAxisSize: MainAxisSize.min,
           children: [
-            brand,
-            const _BrandSeparator(),
-            // The 20 screens that pass a bare Text keep ellipsizing correctly
-            // without any of them being edited.
+            // Both drop together: the interpunct pairs the brand with the page,
+            // and with no brand in the row it is a bullet in front of a
+            // sentence.
+            if (showWordmark) ...[brand, const _BrandSeparator()],
+            // Flexible, so a title the ladder admitted but cannot fit whole —
+            // an unbounded trip name — ellipsizes instead of overflowing.
             Flexible(
-              child: DefaultTextStyle.merge(
-                overflow: TextOverflow.ellipsis,
+              child: Text(
+                title!,
                 maxLines: 1,
-                child: title!,
+                overflow: TextOverflow.ellipsis,
               ),
             ),
           ],

--- a/src/packages/flutter-app/test/brand_everywhere_test.dart
+++ b/src/packages/flutter-app/test/brand_everywhere_test.dart
@@ -22,14 +22,36 @@ import 'support/l10n_test_app.dart';
 /// the action counts that actually squeeze the title slot (trip detail's five
 /// icons being the worst case in the app).
 ///
-/// Two things are asserted everywhere, and they are the promise: the wordmark
-/// is **present**, and it is **neither truncated nor scaled down**. A brand
-/// that survives as "ANEM…" or as illegibly small type has not survived.
+/// **The promise, in three statements:**
+///
+/// 1. With **no page title** (Home, Landing) the wordmark is present at every
+///    width, **neither truncated nor scaled down**. A brand that survives as
+///    "ANEM…" or as illegibly small type has not survived.
+/// 2. At **rail widths**, beside a title, the same holds — in every locale and
+///    at every text scale. The rail has the rose, so the word is the bar's only
+///    brand there and never steps aside.
+/// 3. **Below** rail widths, beside a title, the wordmark is whole **or
+///    absent**: it yields the row when keeping it is what would clip the page's
+///    own name. What the bar must never do is show half of it.
+///
+/// Statement 3 reverses the ordering PR #418 shipped, and it was reversed by
+/// what the old one produced on a phone: `ANEMOS · Plan your t…`.
+///
+/// The yield is **measured, not thresholded** — see `the wordmark yields on
+/// measurement, never on a breakpoint`, the test that fails if somebody
+/// rewrites the ladder as `width < 800`.
+///
+/// One caveat that shapes what can be asserted here: widget tests render in a
+/// fallback face with quite different metrics from Marcellus/Cinzel (a page
+/// title measures ~2.2x its browser width), so *which* branch a given width
+/// lands in diverges from production. Assertions below are therefore on the
+/// invariant, never on "the wordmark is present at width N" for a narrow N —
+/// the browser pass owns that. Same reason [_fallbackFontScalesAt] exists.
 ///
 /// The action counts are a ceiling, not decoration. Five icons fit beside the
 /// wordmark at rail widths and nowhere near it on a phone — which is why trip
-/// detail folds two of its five into the overflow below 800px. Add a fourth
-/// narrow action anywhere and [_narrowActionCounts] is what fails.
+/// detail folds everything but health into the overflow below 800px. Add a
+/// fourth narrow action anywhere and [_narrowActionCounts] is what fails.
 const _widths = <double>[320, 360, 390, 700, 800, 1200];
 const _narrowActionCounts = <int>[0, 2, 3];
 const _wideActionCounts = <int>[0, 2, 5];
@@ -61,7 +83,7 @@ final _fallbackFontScalesAt = <(double, int)>{(320.0, 3)};
 
 Future<void> _pumpBar(
   WidgetTester tester, {
-  Widget? title,
+  String? title,
   int actions = 0,
   required double width,
   bool inShell = true,
@@ -158,6 +180,29 @@ void _expectScaledNoWorseThan(
       reason: 'scaled past $floor of natural: $where');
 }
 
+/// Whole, or gone — never half. The invariant on the phone side of the ladder,
+/// where the word may legitimately have stepped out of the row so the page's
+/// own name could be read.
+void _expectWordmarkWholeOrAbsent(
+    WidgetTester tester, double natural, String where) {
+  if (find.text(AppInfo.name).evaluate().isEmpty) {
+    expect(tester.takeException(), isNull, reason: 'overflow or throw: $where');
+    return;
+  }
+  _expectWordmarkWhole(tester, natural, where);
+}
+
+/// Wherever the title row starts — the wordmark when it is there, the page
+/// title when the wordmark has yielded. Used to assert the row's left edge is
+/// invariant across a push, which is [_leadingSlot]'s whole job and is a
+/// separate question from which element happens to occupy it.
+double _rowLeft(WidgetTester tester, String title) {
+  final wordmark = find.text(AppInfo.name);
+  return wordmark.evaluate().isNotEmpty
+      ? tester.getTopLeft(wordmark).dx
+      : tester.getTopLeft(find.text(title)).dx;
+}
+
 /// The full promise: whole *and* painted at full size.
 void _expectWordmarkFullSize(
     WidgetTester tester, double natural, String where) {
@@ -182,16 +227,25 @@ void main() {
     for (final width in _widths) {
       final counts = width >= 800 ? _wideActionCounts : _narrowActionCounts;
       for (final actions in counts) {
-        for (final title in [null, const Text('Greece 2026')]) {
-          final where =
-              'w=$width actions=$actions title=${title == null ? 'none' : 'yes'}';
-          await _pumpBar(tester, title: title, actions: actions, width: width);
-          if (_fallbackFontScalesAt.contains((width, actions))) {
-            _expectWordmarkWhole(tester, natural, where);
-            _expectScaledNoWorseThan(tester, natural, 0.9, where);
-          } else {
-            _expectWordmarkFullSize(tester, natural, where);
-          }
+        // No title: nothing competes, so the strongest form of the promise
+        // holds — present, whole, full size (statement 1).
+        final where = 'w=$width actions=$actions';
+        await _pumpBar(tester, actions: actions, width: width);
+        if (_fallbackFontScalesAt.contains((width, actions))) {
+          _expectWordmarkWhole(tester, natural, where);
+          _expectScaledNoWorseThan(tester, natural, 0.9, where);
+        } else {
+          _expectWordmarkFullSize(tester, natural, where);
+        }
+
+        // With a title: full size at rail widths (statement 2), whole-or-gone
+        // below them (statement 3).
+        await _pumpBar(tester,
+            title: 'Greece 2026', actions: actions, width: width);
+        if (width >= 800) {
+          _expectWordmarkFullSize(tester, natural, 'titled, $where');
+        } else {
+          _expectWordmarkWholeOrAbsent(tester, natural, 'titled, $where');
         }
       }
     }
@@ -210,14 +264,19 @@ void main() {
           final where = 'w=$width actions=$actions inShell=$inShell';
 
           await _pumpBar(tester,
-              title: const Text('Greece 2026'),
+              title: 'Greece 2026',
               actions: actions,
               width: width,
               inShell: inShell);
-          final atRoot = tester.getTopLeft(find.text(AppInfo.name)).dx;
+          // The row's left edge, not specifically the wordmark's: on a narrow
+          // titled bar the word may have yielded the row to the title. Both
+          // sides of this comparison get the same title-row width — that is
+          // what the reserved slot buys — so both take the same ladder branch
+          // and the two reads are of the same element.
+          final atRoot = _rowLeft(tester, 'Greece 2026');
 
           await _pumpBar(tester,
-              title: const Text('Greece 2026'),
+              title: 'Greece 2026',
               actions: actions,
               width: width,
               inShell: inShell,
@@ -227,7 +286,7 @@ void main() {
           expect(find.byType(BackButton), findsOneWidget,
               reason: 'no back button to be anchored against: $where');
 
-          expect(tester.getTopLeft(find.text(AppInfo.name)).dx,
+          expect(_rowLeft(tester, 'Greece 2026'),
               moreOrLessEquals(atRoot, epsilon: 0.5),
               reason: 'the brand moved on push: $where');
         }
@@ -254,9 +313,18 @@ void main() {
     final natural = await _naturalWidth(tester);
 
     for (final width in _widths) {
+      final where = 'outside shell, w=$width';
       await _pumpBar(tester,
-          title: const Text('Connect app'), width: width, inShell: false);
-      _expectWordmarkFullSize(tester, natural, 'outside shell, w=$width');
+          title: 'Connect app', width: width, inShell: false);
+      if (width >= 800) {
+        _expectWordmarkFullSize(tester, natural, where);
+      } else {
+        _expectWordmarkWholeOrAbsent(tester, natural, where);
+      }
+      // Outside the shell there is no rail, so the rose is in the leading slot
+      // on every one of these — the brand is on screen even where the word
+      // yielded.
+      expect(find.byType(BrandLogo), findsOneWidget, reason: where);
     }
   });
 
@@ -266,11 +334,15 @@ void main() {
     for (final width in _widths) {
       await _pumpBar(tester,
           // The longest app-bar title the app ships (quizTitle, es).
-          title: const Text('Configura tu perfil de viaje'),
+          title: 'Configura tu perfil de viaje',
           actions: 2,
           width: width,
           locale: const Locale('es'));
-      _expectWordmarkFullSize(tester, natural, 'es, w=$width');
+      if (width >= 800) {
+        _expectWordmarkFullSize(tester, natural, 'es, w=$width');
+      } else {
+        _expectWordmarkWholeOrAbsent(tester, natural, 'es, w=$width');
+      }
     }
   });
 
@@ -293,11 +365,16 @@ void main() {
       for (final actions in counts) {
         final where = 'textScale=$scale w=$width actions=$actions';
         await _pumpBar(tester,
-            title: const Text('Greece 2026'),
+            title: 'Greece 2026',
             actions: actions,
             width: width,
             textScale: scale);
-        _expectWordmarkWhole(tester, natural, where);
+        _expectWordmarkWholeOrAbsent(tester, natural, where);
+
+        // Where the word yielded the row to the title there is nothing left to
+        // measure — a scale that grows the word is exactly what makes it yield,
+        // and yielding whole is the correct outcome, not a clip.
+        if (find.text(AppInfo.name).evaluate().isEmpty) continue;
 
         if (_fallbackFontScalesAt.contains((width, actions))) {
           // The backstop scales the 1.6x word down to the slot, and this one
@@ -333,21 +410,91 @@ void main() {
         reason: 'scaled past legibility');
   });
 
-  testWidgets('the page title is what yields — ellipsized, then dropped',
+  testWidgets('the wordmark is what yields, and the page name is what stays',
       (tester) async {
     // Wide: both on screen, brand first.
-    await _pumpBar(tester, title: const Text('Greece 2026'), width: 1200);
+    await _pumpBar(tester, title: 'Greece 2026', width: 1200);
     expect(find.text('Greece 2026'), findsOneWidget);
     expect(tester.getTopLeft(find.text(AppInfo.name)).dx,
         lessThan(tester.getTopLeft(find.text('Greece 2026')).dx));
 
-    // Squeezed to nothing: the title goes, the brand stays. Trip detail on
-    // the smallest phone is the real shape here, and it repeats its title in
-    // the body one line down.
-    await _pumpBar(tester,
-        title: const Text('Greece 2026'), actions: 3, width: 320);
-    expect(find.text('Greece 2026'), findsNothing);
-    expect(find.text(AppInfo.name), findsOneWidget);
+    // Squeezed — trip detail's icon row on the smallest phone. Under #418 the
+    // title went and `ANEMOS` stayed, so the traveler got a header naming the
+    // app they had open rather than the trip they were looking at. Now it is
+    // the other way round, and the rose in the leading slot keeps the brand on
+    // screen on a tab root.
+    await _pumpBar(tester, title: 'Greece 2026', actions: 3, width: 320);
+    expect(find.text('Greece 2026'), findsOneWidget,
+        reason: 'the page name is what a phone header is for');
+    expect(find.text(AppInfo.name), findsNothing,
+        reason: 'the wordmark is what yields on a squeezed phone bar');
+    expect(find.byType(BrandLogo), findsOneWidget,
+        reason: 'a tab root still shows the rose in its leading slot');
+  });
+
+  testWidgets('the wordmark yields on measurement, never on a breakpoint',
+      (tester) async {
+    // The regression guard for the cheap version of this fix. A narrow bar is
+    // not automatically a cramped one: an iPad in portrait (744) and a
+    // half-width desktop window (799) are both below kRailBreakpoint and both
+    // have hundreds of pixels to spare, so gating on the breakpoint would
+    // strip the wordmark off them for nothing.
+    //
+    // Deliberately paired with the squeeze case above — same title, same
+    // locale, differing only in room. If the two stop disagreeing, the ladder
+    // has become a threshold.
+    for (final width in [744.0, 799.0]) {
+      await _pumpBar(tester, title: 'Greece 2026', actions: 1, width: width);
+      expect(find.text(AppInfo.name), findsOneWidget,
+          reason: 'wordmark dropped at $width, which has room to spare');
+      expect(find.text('Greece 2026'), findsOneWidget);
+      expect(tester.takeException(), isNull);
+    }
+  });
+
+  testWidgets('a phone hands the page name the wordmark\'s room',
+      (tester) async {
+    // Brian's screenshot, as an assertion. The bug was never that the title was
+    // absent — it was 126px of `Plan your t…`, which cleared _minTitleWidth
+    // comfortably and still read as broken chrome. The fix is that the word's
+    // pixels go to the title, so that is what is asserted: the title starts at
+    // the row's left edge, with no room for a word in front of it.
+    //
+    // GEOMETRY rather than "the string renders whole", because a widget test
+    // renders in a fallback face where every glyph is a full em: 'Plan your
+    // trip' measures ~311px here against ~143px of Marcellus in a browser. A
+    // whole-string assertion at a real phone width would be testing the test
+    // font. The real string at the real width is the browser pass's job.
+    const title = 'Plan your trip';
+
+    await _pumpBar(tester, title: title, actions: 1, width: 375);
+    expect(find.text(title), findsOneWidget);
+    expect(find.text(AppInfo.name), findsNothing);
+    expect(tester.takeException(), isNull);
+
+    // The row starts at the leading slot's edge, so the title's left is the
+    // slot width plus its own Flexible's zero padding — i.e. it did not begin
+    // a wordmark further in.
+    expect(tester.getTopLeft(find.text(title)).dx,
+        lessThan(kToolbarHeight + await _naturalWidth(tester)),
+        reason: 'something wordmark-sized is still sitting in front of it');
+  });
+
+  testWidgets('a short page name renders whole beside the wordmark',
+      (tester) async {
+    // The other half of the pair above: the ladder admits a title only when it
+    // fits WHOLE, so a short one keeps both. Short enough that even the test
+    // font's em-per-glyph metrics fit at 375.
+    const title = 'Greece 26';
+
+    await _pumpBar(tester, title: title, width: 4000, inShell: false);
+    final natural = tester.getSize(find.text(title)).width;
+
+    await _pumpBar(tester, title: title, actions: 1, width: 375);
+    expect(tester.getSize(find.text(title)).width,
+        moreOrLessEquals(natural, epsilon: 0.5),
+        reason: 'ellipsized despite fitting — the ladder is not measuring');
+    expect(tester.takeException(), isNull);
   });
 
   testWidgets('the rose lives in the leading slot and no longer yields to '
@@ -432,7 +579,7 @@ void main() {
     // The brand carries excludeSemantics (the mark and the word would
     // otherwise announce "Anemos" twice), so the title must sit outside it.
     final handle = tester.ensureSemantics();
-    await _pumpBar(tester, title: const Text('Notifications'), width: 1200);
+    await _pumpBar(tester, title: 'Notifications', width: 1200);
 
     expect(find.bySemanticsLabel('Notifications'), findsOneWidget);
     expect(find.bySemanticsLabel(AppInfo.name), findsOneWidget);
@@ -446,7 +593,7 @@ void main() {
     // label is "Anemos" too, so an unlabelled slot would announce the product
     // name twice and bury the only thing about the control worth knowing.
     final handle = tester.ensureSemantics();
-    await _pumpBar(tester, title: const Text('Notifications'), width: 700);
+    await _pumpBar(tester, title: 'Notifications', width: 700);
 
     expect(find.bySemanticsLabel(AppInfo.name), findsOneWidget,
         reason: 'the rose must not announce the product name a second time');
@@ -483,11 +630,11 @@ void main() {
       final counts = width >= 800 ? _wideActionCounts : _narrowActionCounts;
       for (final actions in counts) {
         await _pumpBar(tester,
-            title: const Text('Greece 2026'), actions: actions, width: width);
+            title: 'Greece 2026', actions: actions, width: width);
         final atRoot = find.text('Greece 2026').evaluate().length;
 
         await _pumpBar(tester,
-            title: const Text('Greece 2026'),
+            title: 'Greece 2026',
             actions: actions,
             width: width,
             pushed: true);

--- a/src/packages/flutter-app/test/language_menu_button_test.dart
+++ b/src/packages/flutter-app/test/language_menu_button_test.dart
@@ -129,7 +129,7 @@ void main() {
       child: localizedTestApp(
         home: Scaffold(
           appBar: GradientAppBar(
-            title: const Text('t'),
+            title: 't',
             actions: const [LanguageMenuButton()],
           ),
         ),

--- a/src/packages/flutter-app/test/trip_detail_narrow_header_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_narrow_header_test.dart
@@ -15,9 +15,17 @@ import 'package:travel_route_planner/widgets/trip_refine_panel.dart';
 import 'support/l10n_test_app.dart';
 
 /// Mobile declutter, header half: on narrow the meta row drops the Refine
-/// button (it becomes an app-bar sparkle). The dates chip humanizes at BOTH
-/// widths — it read raw ISO on wide until 2026-08-14, so the two assertions
-/// below are deliberately the same string.
+/// button. It became an app-bar sparkle, and since 2026-08-17 it is a row in
+/// the `⋮` actions sheet instead — the app bar needed those ~48px so the
+/// trip's own NAME could be read at 375px rather than clipped to "Big Su…".
+/// Health keeps the only narrow icon, because its severity badge is glanceable
+/// and a badge inside a menu is a badge nobody sees.
+///
+/// The header card is deliberately NOT where refine went back to: narrow drops
+/// its button for one clean chip row, and putting it back undoes that.
+///
+/// The dates chip humanizes at BOTH widths — it read raw ISO on wide until
+/// 2026-08-14, so the two assertions below are deliberately the same string.
 class _FakeTripsApiService extends TripsApiService {
   final Trip trip;
   _FakeTripsApiService(this.trip) : super(ApiClient(baseUrl: 'http://test'));
@@ -70,10 +78,21 @@ Future<void> _pump(WidgetTester tester, Trip trip,
   await tester.pumpAndSettle();
 }
 
+/// Opens the `⋮` sheet and picks Refine — the phone route since refine gave
+/// up its app-bar icon to the trip's name.
+Future<void> _refineFromOverflow(WidgetTester tester) async {
+  await tester.tap(find.byTooltip('More options'));
+  await tester.pumpAndSettle();
+  await tester.tap(find.text('Refine with AI'));
+  // The caller runs the action AFTER the sheet closes — never from inside its
+  // dead context — so this settles two transitions, not one.
+  await tester.pumpAndSettle();
+}
+
 void main() {
   const phone = Size(390, 844);
 
-  testWidgets('narrow owner: sparkle in app bar opens refine; dates humanize',
+  testWidgets('narrow owner: refine rides the ⋮; dates humanize',
       (tester) async {
     await _pump(tester, _trip(), surface: phone);
 
@@ -86,11 +105,18 @@ void main() {
     expect(find.textContaining('2026-09-01'), findsNothing);
     expect(find.widgetWithText(ActionChip, 'Sep 1 – Sep 3'), findsOneWidget);
 
-    // The app-bar sparkle opens the refine panel (narrow => sheet).
-    final sparkle = find.byTooltip('Refine with AI');
-    expect(sparkle, findsOneWidget);
-    await tester.tap(sparkle);
-    await tester.pumpAndSettle();
+    // ...and no app-bar sparkle either: that icon is what bought the header
+    // the room for the trip's name. Scoped to the AppBar — the itinerary rows
+    // keep their own per-item sparkles, which is why an unscoped byIcon here
+    // finds two and says nothing about the header.
+    expect(find.byTooltip('Refine with AI'), findsNothing);
+    expect(
+      find.descendant(
+          of: find.byType(AppBar), matching: find.byIcon(Icons.auto_awesome)),
+      findsNothing,
+    );
+
+    await _refineFromOverflow(tester);
     expect(find.byType(TripRefinePanel), findsOneWidget);
   });
 
@@ -101,8 +127,7 @@ void main() {
   // it, so the assertion doesn't hardcode the app bar's height.
   testWidgets('narrow: the refine sheet opens full-height', (tester) async {
     await _pump(tester, _trip(), surface: phone);
-    await tester.tap(find.byTooltip('Refine with AI'));
-    await tester.pumpAndSettle();
+    await _refineFromOverflow(tester);
 
     final available = tester.getRect(find.byType(DraggableScrollableSheet));
     final panel = tester.getRect(find.byType(TripRefinePanel));
@@ -121,8 +146,7 @@ void main() {
   testWidgets('narrow: dragging the handle down shrinks the sheet',
       (tester) async {
     await _pump(tester, _trip(), surface: phone);
-    await tester.tap(find.byTooltip('Refine with AI'));
-    await tester.pumpAndSettle();
+    await _refineFromOverflow(tester);
 
     final available = tester.getRect(find.byType(DraggableScrollableSheet));
     final opened = tester.getRect(find.byType(TripRefinePanel)).height;
@@ -137,16 +161,60 @@ void main() {
     expect(dragged / available.height, closeTo(0.4, 0.06));
   });
 
-  testWidgets('narrow editor collaborator keeps the sparkle (spec)',
+  testWidgets('the phone app bar folds everything but health into the ⋮',
       (tester) async {
-    await _pump(tester, _trip(access: 'editor'), surface: phone);
-    expect(find.byTooltip('Refine with AI'), findsOneWidget);
+    // The width budget, enumerated. Every icon up here costs the trip's name
+    // ~48px, and at 375px the name has only ~131px to begin with — so what is
+    // pinned is which actions are ALLOWED an icon, not a count. (A count would
+    // need the health provider resolved; this fixture leaves it pending, so
+    // health renders a SizedBox and any total would be fixture noise. The
+    // ceiling on how many the bar can hold lives in brand_everywhere_test's
+    // _narrowActionCounts.)
+    await _pump(tester, _trip(), surface: phone);
+
+    final bar = find.byType(AppBar);
+    void expectFolded(IconData icon, String what) {
+      expect(find.descendant(of: bar, matching: find.byIcon(icon)), findsNothing,
+          reason: '$what belongs in the ⋮ on a phone');
+    }
+
+    // Both mutation-checked: restoring the refine icon, or dropping `!_narrow`
+    // from share, reds this test.
+    expectFolded(Icons.auto_awesome, 'refine');
+    expectFolded(Icons.share_outlined, 'share');
+    // Wear is deliberately NOT asserted here. Its action reads a provider this
+    // fixture leaves unresolved, so it renders a SizedBox either way and
+    // `expectFolded(Icons.luggage_outlined, …)` passes whether it is folded or
+    // not — a green line that proves nothing. Its fold predates this lane and
+    // is unchanged; a real assertion needs a wear-state override.
+    expect(find.descendant(of: bar, matching: find.byIcon(Icons.more_vert)),
+        findsOneWidget);
+
+    // And the point of the budget: the trip's name is up there, whole.
+    final title = find.descendant(of: bar, matching: find.text('Sevilla week'));
+    expect(title, findsOneWidget);
+    expect(tester.takeException(), isNull);
   });
 
-  testWidgets('narrow viewer never gets the sparkle', (tester) async {
+  testWidgets('narrow editor collaborator keeps refine (spec)',
+      (tester) async {
+    await _pump(tester, _trip(access: 'editor'), surface: phone);
+    await tester.tap(find.byTooltip('More options'));
+    await tester.pumpAndSettle();
+    expect(find.text('Refine with AI'), findsOneWidget);
+  });
+
+  testWidgets('narrow viewer never gets refine', (tester) async {
     await _pump(tester, _trip(access: 'viewer'), surface: phone);
     expect(find.byTooltip('Refine with AI'), findsNothing);
     expect(find.byIcon(Icons.auto_awesome), findsNothing);
+
+    // ...and it is not hiding in the ⋮ either. Without opening the sheet this
+    // assertion would pass on a build that put refine in there ungated —
+    // exactly the regression moving it into a menu makes easy to ship.
+    await tester.tap(find.byTooltip('More options'));
+    await tester.pumpAndSettle();
+    expect(find.text('Refine with AI'), findsNothing);
   });
 
   testWidgets('wide keeps the header button; dates humanize there too',

--- a/src/packages/flutter-app/test/trip_detail_narrow_rows_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_narrow_rows_test.dart
@@ -198,18 +198,27 @@ void main() {
 
   testWidgets('threshold: 800 keeps desktop affordances, 799 flips to narrow',
       (tester) async {
+    // The app bar's own tell used to be the refine sparkle: absent at 800,
+    // present at 799. Refine no longer holds an icon at any width — it moved
+    // into the `⋮` so the trip's name could have those ~48px — so the tell is
+    // now share, which keeps its icon at 800 and folds below it.
+    final shareIcon = find.byIcon(Icons.share_outlined);
+
     await _pump(tester, _trip(), surface: const Size(800, 900));
-    // Desktop: maps button + full chip labels + no app-bar sparkle.
+    // Desktop: maps button + full chip labels + header Refine + share icon.
     expect(_inTiles(find.byIcon(Icons.map_outlined)), findsNWidgets(2));
     expect(find.text('Morning'), findsOneWidget);
     expect(find.text('Refine with AI'), findsOneWidget);
-    expect(find.byTooltip('Refine with AI'), findsNothing);
+    expect(shareIcon, findsOneWidget);
 
     await tester.binding.setSurfaceSize(const Size(799, 900));
     await tester.pumpAndSettle();
     expect(_inTiles(find.byIcon(Icons.map_outlined)), findsNothing);
     expect(find.text('Morning'), findsNothing);
     expect(find.text('Refine with AI'), findsNothing);
-    expect(find.byTooltip('Refine with AI'), findsOneWidget); // app-bar sparkle
+    expect(shareIcon, findsNothing);
+    // Refine has no icon on either side of the threshold now, so this says
+    // "it did not sneak back", not "it flipped".
+    expect(find.byTooltip('Refine with AI'), findsNothing);
   });
 }


### PR DESCRIPTION
## Summary

Brian's dogfood screenshot: the Plan tab read **`ANEMOS · Plan your t…`** at 375px.

Not a slip — the brand ladder was doing exactly what #418 documented: *the wordmark never yields, the page title ellipsizes, and below `_minTitleWidth` it is dropped.* On a phone that ordering spends the whole bar on brand and leaves the title whatever falls out. And `_minTitleWidth = 56` is why it shipped looking **broken** rather than looking dropped — it is a floor on the title's *space*, never on its *legibility*. 126px of room cleared it comfortably, and 126px of "Plan your trip" is a stub.

So the priority inverts, on phones only: **the page title is whole, or the wordmark steps out of the row.**

> **Stacked on #466** (base is `appbar-brand-anchor`, so this diff is one commit). That PR had already moved the rose into the leading slot and taken `titleSpacing` to 0; those 84px mean this ladder rarely has to fire at all. GitHub will retarget to `main` when #466 merges.

## Measured, not thresholded

`width < kRailBreakpoint` would strip the wordmark off a 744px iPad in portrait and a 799px window — both below the breakpoint, both with hundreds of pixels to spare. `GradientAppBar.titleWidthIn` is the title's twin of `BrandWordmark.widthIn`, so the ladder is arithmetic on what the two actually paint, under a missing font, a locale, or a text-scale setting. The word yields only where keeping it is exactly what would clip the page's name.

Two rules survive the inversion:

- **At rail widths the wordmark never yields** — the rose is on the rail, so the word is the bar's only brand.
- On a **pushed** phone page the leading slot holds a back button, so a yield leaves the bar carrying no brand. Deliberate, and the half worth arguing with: back-button + the thing you opened is the universal mobile header, and the traveler branded the app one tap ago.

## `title` is a `String` now

A widget cannot be measured before it is laid out. It also puts the whole title contract in one place — face, colour, `maxLines`, ellipsis — instead of owning half and trusting 21 call sites for the rest. All 21 are mechanical; the only visible cost is the guide-detail header losing its `menu_book` icon, the one header of twenty-odd that had one.

## Trip detail buys ~48px

Refine folds into the `⋮` it already owns, so the phone bar carries health + `⋮`. Health keeps the only icon because its severity badge is glanceable and a badge inside a menu is a badge nobody sees. The header card's own Refine button **stays gone** at narrow — #457 removed it for one clean chip row.

## Testing

`make flutter-test` — **1580 passed**. `make flutter-analyze` clean (its 3 infos are pre-existing in `lib/models/route_response.dart`).

`brand_everywhere_test`'s promise is restated as three statements, and the two tests encoding the old ordering are **inverted rather than deleted**. New: the 744/799 guard that fails if anyone rewrites this as a breakpoint.

**Mutation-checked in three directions** — never-yield reds 7 tests; always-yield reds the breakpoint guard; dropping the rail guard reds the Spanish case. On the trip-detail side, removing the `⋮` entry and un-gating it for viewers each red their own test. The wear assertion there is **documented as vacuous** (its provider never resolves in that fixture) rather than left looking green.

Browser pass on the lane stack, en + es, light + dark, at 375/390/744/799/800/1200:

| | before | after |
|---|---|---|
| Plan @375 | `ANEMOS · Plan your t…` | `ANEMOS · Plan your trip` |
| Notifications, Travel profile, Trips @375 | mixed stubs | whole, both locales |
| Trip detail @375 | stub / no name | `Big Summer Adventur…` |
| Quiz @375 en | stub | `Set up your travel profile` |
| **744 / 799** | — | `ANEMOS · Big Summer Adventure 2026` intact |
| 800 / 1200 | — | unchanged |

Also confirmed Refine opens the full-height panel from the `⋮`, and the bar renders identically in light and dark.

**One truncation left in the app at 375**: the onboarding quiz in Spanish, `Configura tu perfil de v…`, about 21px short. The ladder already hands it every pixel there is — the remaining fix would be copy, which is not mine to make.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
