### PR TITLE
test(plan): pin the prompt rules a restructure can delete silently

### DIFF
--- a/src/packages/api/plan_language_integration_test.go
+++ b/src/packages/api/plan_language_integration_test.go
@@ -180,6 +180,39 @@ func TestSystemPromptEnglishUnchanged(t *testing.T) {
 		if !strings.Contains(prompt, "one the TRAVELER wrote is theirs") {
 			t.Errorf("Accept-Language %q: prompt lost the traveler-authored-description boundary", header)
 		}
+		// The four rules below were each restored by hand during #442's
+		// integration, which is why they are pinned now: that branch rewrote
+		// basePrompt wholesale, dropped them, and nothing in CI noticed. A
+		// prompt rule worth shipping is worth a pin.
+		//
+		// #429: without this the model omits end_date and trip_handler derives
+		// it from maxDay — so a trip whose last day is deliberately empty ends a
+		// day early, and every leg's rendered span shifts with it.
+		if !strings.Contains(prompt, "no longer tells the trip when it ends") {
+			t.Errorf("Accept-Language %q: prompt lost the trip-end-is-not-the-last-item-day rule", header)
+		}
+		// #438, both halves. The first stops the flight reflex on a short hop;
+		// the second is the only way the model learns the app already DERIVED a
+		// mode and echoed it back — without it the Italy chat narrated flights
+		// while the checklist row said train, and nothing reconciled them.
+		if !strings.Contains(prompt, "suggest_transport with mode 'ground'") {
+			t.Errorf("Accept-Language %q: prompt lost the ground-transport routing rule", header)
+		}
+		if !strings.Contains(prompt, "call set_leg_transport_mode for that leg") {
+			t.Errorf("Accept-Language %q: prompt lost the correct-a-derived-leg-mode rule", header)
+		}
+		// #437: search_hotels is ungated, so it reaches every session shape — but
+		// a tool the prompt never mentions is a tool that does not exist. The
+		// price clause is pinned separately because it is the honest half: the
+		// provider can return properties whose rates were not checked, and
+		// quoting those anyway is how a traveler budgets against a number nobody
+		// verified.
+		if !strings.Contains(prompt, "call search_hotels with the city") {
+			t.Errorf("Accept-Language %q: prompt lost the hotel-search instruction", header)
+		}
+		if !strings.Contains(prompt, "never quote, estimate, or imply a price") {
+			t.Errorf("Accept-Language %q: prompt lost the unchecked-hotel-price boundary", header)
+		}
 		// These requests are anonymous and not trip-bound, so the prompt is
 		// exactly basePrompt — it must still end on basePrompt's final
 		// sentence, proving nothing was appended.

--- a/src/packages/api/trip_refine_chat_integration_test.go
+++ b/src/packages/api/trip_refine_chat_integration_test.go
@@ -437,6 +437,14 @@ func TestBoundPromptSteersToGetTrip(t *testing.T) {
 		"may be resumed days later",
 		"AS IT WAS",
 		"call get_trip",
+		// #434's scope guard, pinned here after #442's integration restored it
+		// by hand: a cross-section reorder must be scope 'trip'. A rewrite
+		// replaces its section IN PLACE, so mixing another section's places
+		// into a 'city' or 'day' call duplicates them instead of moving them.
+		// Unpinned, a prompt restructure deletes this and the duplication bug
+		// #434 fixed comes back silently.
+		"is a whole-trip change",
+		"would duplicate those places rather than move them",
 	} {
 		if !strings.Contains(prompt, want) {
 			t.Errorf("bound prompt lost %q:\n%s", want, prompt)


### PR DESCRIPTION
## Summary

#442 rewrote `basePrompt` wholesale and dropped five shipped rules. **CI was green.** `plan_language_integration_test.go` pins about a dozen prompt sentences and none of those five, so the only thing between a prompt restructure and a silent behaviour revert was somebody diffing the two sides by hand. That isn't a gate.

Test-only and additive — 41 lines, no product code.

### Pinned in `basePrompt` (four rules, five asserts)

| Rule | What its absence costs |
|---|---|
| **#429** trip-end clause | the model omits `end_date`, `trip_handler` derives it from `maxDay`, so a trip whose last day is deliberately empty ends a day early — and every leg's rendered span shifts with it |
| **#438** ground-transport routing | the flight reflex returns on short hops where rail wins door-to-door |
| **#438** `set_leg_transport_mode` correction | the only way the model learns the app already *derived* a mode and echoed it back. Without it the Italy chat narrated flights while the checklist row said train, and nothing reconciled them |
| **#437** `search_hotels` instruction | a tool the prompt never mentions is a tool that doesn't exist |
| **#437** unchecked-price boundary | the provider can return properties whose rates were not checked; quoting those anyway is how a traveler budgets against a number nobody verified |

### Pinned in the bound/refine prompt

Beside #441's existing freshness pin: **#434's scope guard** — a cross-section reorder must be `scope: 'trip'`. A rewrite replaces its section *in place*, so mixing another section's places into a `'city'` or `'day'` call duplicates them instead of moving them. Unpinned, deleting it brings back the exact bug #434 fixed.

### Already covered

**#460's `set_trip_description` rule was pinned already** (both halves), so it needed nothing. I'd previously reported five unpinned rules; four is the accurate count, plus #434's guard as a sixth found in the same pass.

## Testing

- Full Go suite green; `gofmt` and `go vet` clean.
- **Every pin mutation-checked.** Each rule was removed from the prompt in turn and the corresponding assert confirmed to fail — five in `TestSystemPromptEnglishUnchanged`, two in `TestBoundPromptSteersToGetTrip`. A pin that cannot fail is decoration, and one of these looked like it wasn't firing until I noticed my `-run` filter didn't match the test name.

## Why this shape

Substring pins, not a golden-file hash: a hash would fail on every legitimate prompt edit and get regenerated reflexively, which is how the current gap opened. These fail only when a *named rule* leaves, and each carries a comment saying what breaks — so the next restructure gets told which sentence it must carry forward, and why.

🤖 Generated with [Claude Code](https://claude.com/claude-code)