### PR TITLE
fix(flutter): the Bookings tab pill is the fold of the destination chips

### DIFF
--- a/docs/friction-log.md
+++ b/docs/friction-log.md
@@ -119,6 +119,28 @@ actually used > ideas that recur across ≥2 sessions**. Tag entries `[app]`
   already predicted it: *"a timing test whose failure mode is 'the machine got
   busier' fails for whoever adds the next test file."* This was that file.
 
+## 2026-08-17 — The pill now sums the chips (follow-up to the filter strip)
+
+- **[app] Debt paid the same day it was logged.** The entry below left the
+  Bookings tab pill counting booking *todos* while the new destination chips
+  count *entries* (one visible checkbox each), so a confirmed record with no
+  todo made the chips sum past the pill. Brian: *"reconcile the pill counts
+  too."* The pill is now `bookingOverallCount` — literally the **fold of
+  `bookingDestinationCounts`** — so the tab's number and the chips' numbers
+  are one count split two ways; they cannot drift because there is nothing
+  to drift between.
+- **[app] The claimed blocker was misread.** The entry below said the pill was
+  "load-bearing for `specs/next-step-cta` parity". The spec says the opposite:
+  exact parity between the book-everything count and the bookings tab's
+  partition is **Out of Scope** ("the trigger is exact; the count is
+  motivational"). Re-read the spec section, not the summary of it, before
+  declaring a constraint.
+- **[app] Viewers stay un-counted, now for a stated reason.** The server
+  withholds todos from viewers, so a viewer's entries are only the confirmed
+  records — their pill would read "3/3, all booked" while the owner sees the
+  real remainder. A partial count states a false total; no number beats a
+  partial one. The existing `_bookingTodos.isEmpty` gate keeps that job.
+
 ## 2026-08-17 — The Bookings filter cost more screen than the bookings
 
 - **[app] Friction → fixed:** *"Should these big buttons for each city be a
@@ -139,11 +161,9 @@ actually used > ideas that recur across ≥2 sessions**. Tag entries `[app]`
   doubles as a per-city progress read. Counts come from the same enumeration
   and the same booked-predicate the ROWS use (`bookingSlotEntries` /
   `bookingEntryBooked`, extracted for exactly this reason) — the #455 rule that
-  a count answers for the rows beneath it. Open debt unchanged: the Bookings
-  tab's own pill still counts booking *todos*, so a trip with confirmed records
-  that matched no todo sums higher on the chips than in the pill. Documented at
-  both sites rather than quietly reconciled — the pill is load-bearing for
-  `specs/next-step-cta` parity.
+  a count answers for the rows beneath it. ~~Open debt: the Bookings tab's own
+  pill still counts booking *todos*~~ — reconciled the same day (entry above):
+  the pill is now the fold of the chips.
 - **[dev] Two layout bugs the new widget tests caught, not the eye.** A 320px
   Spanish row at 1.3× text **overflowed by 94px**, and short of overflowing the
   pinned pair starved the strip to ~180px on a 420px body — less than one

--- a/src/packages/flutter-app/lib/screens/trip_detail_derivation.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_derivation.dart
@@ -162,10 +162,10 @@ bool bookingEntryExists(BookingEntry e) =>
 /// what selecting that chip reveals. A revisited city has one entry here and
 /// one chip, summing both of its runs.
 ///
-/// Counts ENTRIES, not todos: the Bookings tab's own pill counts booking todos
-/// only, so a trip with confirmed records that matched no todo sums higher
-/// here. That divergence is the tab pill's (it is load-bearing for
-/// specs/next-step-cta parity); these counts answer for the rows beneath them.
+/// Counts ENTRIES (one visible checkbox each), not todos — these counts
+/// answer for the rows beneath them. The Bookings tab pill is the FOLD of
+/// this map ([bookingOverallCount]), so the pill and the chips agree by
+/// construction rather than by two spellings kept in step.
 Map<String, ({int booked, int total})> bookingDestinationCounts(
   GroupedBookings grouped,
   List<String> labels, {
@@ -198,6 +198,33 @@ Map<String, ({int booked, int total})> bookingDestinationCounts(
     add(otherKey, s.booked);
   }
   return counts;
+}
+
+/// The trip-wide booked/total the Bookings tab pill shows: the SUM of the
+/// destination chips, computed by folding [bookingDestinationCounts] rather
+/// than by a second walk over the slots. Whatever that partition decides —
+/// which records claim a slot, which fall residual — the pill inherits, so
+/// the tab's promise and the chips' promises are one number split two ways.
+///
+/// Before this fold the pill counted booking TODOS while the chips counted
+/// entries, so a confirmed record with no todo (a viewer-visible stay, a
+/// manually added segment) made the chips sum past the pill.
+({int booked, int total}) bookingOverallCount(
+  GroupedBookings grouped,
+  List<String> labels,
+) {
+  var booked = 0, total = 0;
+  // otherKey only names the residual bucket; any non-label value works here
+  // because the fold reads values, not keys. Using the canonical label keeps
+  // a real 'Other places' leg and the residual bucket merged the same way
+  // the strip merges them.
+  for (final c
+      in bookingDestinationCounts(grouped, labels, otherKey: kOtherPlacesLabel)
+          .values) {
+    booked += c.booked;
+    total += c.total;
+  }
+  return (booked: booked, total: total);
 }
 
 /// True for the AI's "city filler" placeholder — an item whose name is just

--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -4130,17 +4130,32 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
               // door into this view.) Dropped on narrow: three tabs +
               // pill is what genuinely shrinks the FittedBox trio at
               // 390px, and the count is one tap away inside the view.
+              //
+              // The number is the FOLD of the destination chips
+              // (bookingOverallCount over the one groupedBookings
+              // partition), not a count of todos: the pill's promise is
+              // "this many checkboxes behind this tab", and confirmed
+              // records with no todo are checkboxes too. Still gated on
+              // having todos at all — the server withholds them from
+              // viewers, whose entries are only the confirmed records, so
+              // a viewer's count would read "all booked" while the owner
+              // sees the real remainder. No number beats a partial one.
               _headerTab(
                 theme,
                 label: l10n.tripTabBookings,
                 trailing: (_narrow || _bookingTodos.isEmpty)
                     ? null
-                    : StatusPill.custom(
-                        label:
-                            '${_bookingTodos.where((t) => t.booked).length}/${_bookingTodos.length}',
-                        background: theme.colorScheme.surfaceContainerHighest,
-                        foreground: theme.colorScheme.onSurfaceVariant,
-                      ),
+                    : () {
+                        final d = _derive(trip);
+                        final c = bookingOverallCount(
+                            d.groupedBookings, d.legLabels);
+                        return StatusPill.custom(
+                          label: '${c.booked}/${c.total}',
+                          background:
+                              theme.colorScheme.surfaceContainerHighest,
+                          foreground: theme.colorScheme.onSurfaceVariant,
+                        );
+                      }(),
                 selected: _inBookingsView,
                 onTap: () => setState(() {
                   _itemFilter = 'bookings';

--- a/src/packages/flutter-app/test/trip_detail_bookings_filter_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_bookings_filter_test.dart
@@ -18,6 +18,7 @@ import 'package:travel_route_planner/screens/trip_detail_screen.dart';
 import 'package:travel_route_planner/widgets/booking_detail_row.dart';
 import 'package:travel_route_planner/widgets/booking_filter_bar.dart';
 import 'package:travel_route_planner/widgets/booking_todo_card.dart';
+import 'package:travel_route_planner/widgets/status_pill.dart';
 
 import 'support/l10n_test_app.dart';
 
@@ -174,6 +175,67 @@ Future<void> _tapDestination(WidgetTester tester, String label) async {
 }
 
 void main() {
+  testWidgets('the tab pill is the sum of the destination chips',
+      (tester) async {
+    _useViewport(tester, const Size(900, 3000));
+    // A fixture where todos and entries genuinely differ: two stay todos
+    // (one booked) plus a booked confirmed segment that matched no todo — a
+    // third checkbox the old todo-count pill never saw ('1/2' vs the three
+    // rows actually behind the tab).
+    await _pump(
+      tester,
+      _trip(
+        items: [
+          _item(0, 'Louvre', 'Paris', 1),
+          _item(1, 'Colosseum', 'Rome', 2),
+        ],
+        todos: const [
+          BookingTodo(
+              id: 'td-paris',
+              kind: 'stay',
+              todoKey: 'stay:paris',
+              title: 'Stay in Paris',
+              booked: true),
+          BookingTodo(
+              id: 'td-rome',
+              kind: 'stay',
+              todoKey: 'stay:rome',
+              title: 'Stay in Rome'),
+        ],
+        segments: const [
+          TripSegment(
+              id: 'seg-x',
+              mode: 'train',
+              origin: 'Lyon',
+              destination: 'Marseille',
+              booked: true),
+        ],
+      ),
+    );
+
+    // The pill already carries the entries count before the tab is opened.
+    expect(
+        find.descendant(
+            of: find.byType(StatusPill), matching: find.text('2/3')),
+        findsOneWidget);
+    expect(find.text('1/2'), findsNothing,
+        reason: 'the todo-only count must not survive anywhere');
+
+    await _openBookingsTab(tester);
+
+    // The pill equals the fold of the chips — parsed from the same render.
+    var booked = 0, total = 0;
+    for (final label in const ['Paris', 'Rome', 'Other bookings']) {
+      final c = _countOn(tester, label);
+      booked += c.booked;
+      total += c.total;
+    }
+    expect((booked: booked, total: total), (booked: 2, total: 3));
+
+    // ...and both equal the checkboxes the tab actually reveals.
+    expect(_visibleRowCounts(tester), (booked: 2, total: 3));
+  });
+
   testWidgets('a chip count equals the rows that chip reveals', (tester) async {
     _useViewport(tester, const Size(900, 3000));
     await _pump(

--- a/src/packages/flutter-app/test/trip_detail_derivation_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_derivation_test.dart
@@ -363,6 +363,30 @@ void main() {
           (booked: 0, total: 1));
     });
 
+    test('bookingOverallCount is the fold of bookingDestinationCounts', () {
+      final todos = [
+        _todo('transport:home>>paris'),
+        _todo('stay:paris', kind: 'stay', booked: true),
+        _todo('custom:helicopter', kind: 'other', booked: true),
+      ];
+      final d = _compute(bookingTodos: todos, stays: [_parisStay]);
+      final perChip = bookingDestinationCounts(d.groupedBookings, d.legLabels,
+          otherKey: 'Other places');
+      final overall = bookingOverallCount(d.groupedBookings, d.legLabels);
+      var booked = 0, total = 0;
+      for (final c in perChip.values) {
+        booked += c.booked;
+        total += c.total;
+      }
+      // The pill and the chips are one number split two ways — whatever the
+      // partition decides, both inherit it.
+      expect(overall, (booked: booked, total: total));
+      // And it counts entries, not todos: here they coincide in total (every
+      // entry has a todo) but the shape is pinned by the widget test with a
+      // todo-less confirmed segment.
+      expect(overall.total, greaterThanOrEqualTo(todos.length));
+    });
+
     test('bookingEntryBooked: the todo wins, then the record', () {
       const bookedStay = Accommodation(id: 'a9', name: 'X', booked: true);
       expect(

--- a/src/packages/flutter-app/test/trip_detail_view_tabs_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_view_tabs_test.dart
@@ -167,7 +167,7 @@ Future<(_FakeBookingTodosApiService, _FakeAccommodationsApiService)> _pump(
 }
 
 /// Taps the Bookings header tab; when [count] is given, first pins the
-/// booked-progress pill riding the tab ('1/2' etc.) — the counter is a
+/// booked-progress pill riding the tab ('2/3' etc.) — the counter is a
 /// [StatusPill] beside the label now, not part of it (dropped entirely on
 /// narrow; these tests run wide at 800). Pass no count for a trip whose
 /// todos are empty (viewer trips included): the tab renders bare.
@@ -229,7 +229,7 @@ void main() {
           ],
         ));
 
-    await _openBookingsTab(tester, '1/2');
+    await _openBookingsTab(tester, '2/3');
     await tester.tap(find.widgetWithText(FilterChip, 'Not booked yet'));
     await tester.pumpAndSettle();
 
@@ -376,7 +376,7 @@ void main() {
     _useTallViewport(tester);
     await _pump(tester, mixedTrip());
 
-    await _openBookingsTab(tester, '1/2');
+    await _openBookingsTab(tester, '2/3');
 
     expect(find.text('Louvre'), findsNothing);
     expect(find.text('Café de Flore'), findsNothing);
@@ -397,7 +397,7 @@ void main() {
     _useTallViewport(tester);
     final (todosApi, accApi) = await _pump(tester, mixedTrip());
 
-    await _openBookingsTab(tester, '1/2');
+    await _openBookingsTab(tester, '2/3');
     await tester.tap(find.descendant(
         of: find.widgetWithText(BookingTodoRow, 'Stay in Paris'),
         matching: find.byType(Checkbox)));
@@ -484,9 +484,12 @@ void main() {
     _useTallViewport(tester);
     await _pump(tester, mixedTrip());
 
-    // Pill '1/2' — one booked custom todo of two todos. The count rides
+    // Pill '2/3' — every visible checkbox behind the tab: the unbooked stay
+    // todo, the booked custom todo, and the booked detail-only arrival
+    // segment. Entries, not todos — the pill is the fold of the destination
+    // chips (bookingOverallCount). The count rides
     // the tab as a StatusPill (this tab replaced the old one-way counter).
-    await _openBookingsTab(tester, '1/2');
+    await _openBookingsTab(tester, '2/3');
 
     expect(find.text('Louvre'), findsNothing);
     expect(
@@ -619,7 +622,7 @@ void main() {
     expect(find.text('Add transport'), findsNothing);
 
     // Bookings view: the swap, not an addition.
-    await _openBookingsTab(tester, '1/2');
+    await _openBookingsTab(tester, '2/3');
     expect(find.text('Add booking'), findsOneWidget);
     expect(find.text('Add place'), findsNothing);
 
@@ -635,7 +638,7 @@ void main() {
       'custom-booking dialog', (tester) async {
     _useTallViewport(tester);
     await _pump(tester, mixedTrip());
-    await _openBookingsTab(tester, '1/2');
+    await _openBookingsTab(tester, '2/3');
 
     Future<void> pick(String item) async {
       await tester.tap(find.text('Add booking'));
@@ -664,7 +667,7 @@ void main() {
     _useTallViewport(tester);
     await _pump(tester, mixedTrip());
 
-    await _openBookingsTab(tester, '1/2');
+    await _openBookingsTab(tester, '2/3');
     await tester.tap(find.widgetWithText(FilterChip, 'Not booked yet'));
     await tester.pumpAndSettle();
     expect(find.text('Add booking'), findsOneWidget);
@@ -692,7 +695,7 @@ void main() {
     _useTallViewport(tester);
     await _pump(tester, mixedTrip());
 
-    await _openBookingsTab(tester, '1/2');
+    await _openBookingsTab(tester, '2/3');
     await tester.tap(find.widgetWithText(FilterChip, 'Not booked yet'));
     await tester.pumpAndSettle();
 


### PR DESCRIPTION
## Summary

Follow-up to #467, on Brian's ask: *"reconcile the pill counts too."*

- The Bookings tab pill counted booking **todos** while the destination chips count **entries** (one visible checkbox each), so a confirmed record with no todo made the chips sum past the pill. The pill is now `bookingOverallCount` — **literally the fold of `bookingDestinationCounts`** — so the tab's number and the chips' numbers are one count split two ways; there is nothing left to drift between.
- **Corrected a wrong claim from #467**: the friction log said the pill was load-bearing for `specs/next-step-cta` parity. The spec says the opposite — exact parity between the book-everything count and the bookings tab's partition is explicitly **Out of Scope** ("the trigger is exact; the count is motivational"). Fixed at both sites.
- **Viewers stay un-counted, now for a stated reason**: the server withholds their todos, so a viewer's entries are only the confirmed records — their pill would read "all booked" while the owner sees the real remainder. A partial count states a false total; the existing `_bookingTodos.isEmpty` gate keeps that job.
- `mixedTrip` pill pins move `1/2 → 2/3`: the booked detail-only arrival segment was always a checkbox behind the tab; the pill just never counted it.

## Testing

- `flutter analyze` — clean (3 pre-existing infos).
- `flutter test` — **1613 passed.** New: a widget test on a fixture where todos ≠ entries (a todo-less booked segment) asserting pill = Σ(chip counts) = rendered checkboxes, and that the old todo-only `1/2` renders nowhere; a derivation unit test pinning `bookingOverallCount` as the fold of `bookingDestinationCounts`. Updated the eight `mixedTrip` pill pins with the entry-by-entry derivation in the fixture comment.
- No browser pass: the seeded verification trip from #467 has todos == entries (auto todos cover every leg), so the divergence is only exercisable by the widget fixture — which pumps the real `TripDetailScreen`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
