### PR TITLE
feat(budget): spend-per-city breakdown — group the receipt by city leg

### DIFF
--- a/src/packages/api/booking_option_choose.go
+++ b/src/packages/api/booking_option_choose.go
@@ -174,6 +174,7 @@ func chooseBookingOptionHandler(w http.ResponseWriter, r *http.Request) {
 	resp := ChooseBookingOptionResponse{}
 	var promotedAcc, promotedSeg pgtype.UUID
 	var expenseSourceID uuid.UUID
+	var stayLegKey *string
 	category := ""
 
 	if todo.Kind == "stay" {
@@ -194,6 +195,15 @@ func chooseBookingOptionHandler(w http.ResponseWriter, r *http.Request) {
 		promotedAcc = pgtype.UUID{Bytes: acc.ID, Valid: true}
 		expenseSourceID = todo.ID
 		category = expenseCategoryForLeg("stay", "")
+		// Same server-side city stamp the booked-flip POST gets (00072):
+		// a hotel chosen from the shortlist must land under its city too, or
+		// the answer to "where is this line filed" depends on which door the
+		// traveler booked through. Best-effort — a failed derivation leaves
+		// the line untagged, never blocks the choice. Segments stay untagged:
+		// a flight is between cities.
+		if legs, _, err := tripRenderLegs(ctx, q, trip); err == nil {
+			stayLegKey = legKeyForStay(legs, acc)
+		}
 		accResp := toAccommodationResponse(acc)
 		resp.Accommodation = &accResp
 	} else {
@@ -265,6 +275,7 @@ func chooseBookingOptionHandler(w http.ResponseWriter, r *http.Request) {
 			ActualAmount: opt.Price,
 			SourceKind:   ptrTo("booking_todo"),
 			SourceID:     pgtype.UUID{Bytes: expenseSourceID, Valid: true},
+			LegKey:       stayLegKey, // nil on transport; fill-in-only on refresh
 		})
 		if err != nil {
 			// The booking itself is the point; a full budget or a racing write

--- a/src/packages/api/budget_handler.go
+++ b/src/packages/api/budget_handler.go
@@ -130,11 +130,19 @@ type ExpenseResponse struct {
 	// prompt and to find the row to remove on unbook.
 	SourceKind *string `json:"source_kind"`
 	SourceID   *string `json:"source_id"`
-	// LegKey is the city leg this line plans for (00070), nil for every other
-	// expense. It rides the wire so the daily-spend card can find ITS OWN line
-	// by identity instead of by matching the label it generated — the label
-	// being the key is what 00064 was written to undo.
+	// LegKey is the city leg this money belongs to (00070, generalized by
+	// 00072), nil when the line isn't filed under a city. It is the Budget
+	// tab's spend-per-city grouping key and — together with LegPlan — the
+	// identity the daily-spend card finds ITS OWN line by, instead of by
+	// matching the label it generated (the label being the key is what 00064
+	// was written to undo).
 	LegKey *string `json:"leg_key"`
+	// LegPlan is true on the one row that IS this city's per-day plan slot
+	// for its category (00072) — STATED rather than left for the client to
+	// re-derive (the Purchased/`chosen` treatment), because since 00072 any
+	// line can carry a leg_key and "has a city" no longer implies "is the
+	// plan".
+	LegPlan bool `json:"leg_plan"`
 }
 
 func toExpenseResponse(e store.TripExpense) ExpenseResponse {
@@ -150,6 +158,7 @@ func toExpenseResponse(e store.TripExpense) ExpenseResponse {
 		Auto:          e.Auto,
 		SourceKind:    e.SourceKind,
 		LegKey:        e.LegKey,
+		LegPlan:       e.LegPlan,
 	}
 	if e.SourceID.Valid {
 		id := uuid.UUID(e.SourceID.Bytes).String()
@@ -331,12 +340,21 @@ type AddExpenseRequest struct {
 	// contract). Plain manual adds omit them, byte-identical to before.
 	SourceKind *string `json:"source_kind"`
 	SourceID   *string `json:"source_id"`
-	// LegKey binds this line to ONE city leg of the trip (00070) — the daily
-	// food & drink guide's "add to plan". It makes the POST an
-	// upsert-by-leg so a double tap returns the existing plan instead of
-	// filing a second one. Unlike SourceKind it does NOT mark the row auto:
-	// this is the traveler's own plan, not a mirror of a booking.
+	// LegKey files this line under ONE city leg of the trip (00070,
+	// generalized by 00072) — the spend-per-city grouping. Unlike SourceKind
+	// it does NOT mark the row auto: which city money belongs to is the
+	// traveler's own organization, not a mirror of a booking. Empty-string is
+	// a 400 here; on PATCH the same spelling means "clear the tag" — that
+	// asymmetry is intentional (POST empty = junk in, PATCH empty = remove),
+	// so don't "fix" either side to match the other.
 	LegKey *string `json:"leg_key"`
+	// LegPlan marks this add as the city's plan SLOT (00072) — the daily
+	// food & drink guide's "add to plan". It is what makes the POST an
+	// upsert-by-leg (one per city per category, the partial unique index) so
+	// a double tap returns the existing plan instead of filing a second one.
+	// Requires LegKey; refused without it rather than silently downgraded.
+	// Only the daily-spend card sends it; the city picker sends LegKey alone.
+	LegPlan *bool `json:"leg_plan"`
 }
 
 // resolveAddAmounts maps the request's three money fields onto the two columns.
@@ -411,11 +429,21 @@ func addExpenseHandler(w http.ResponseWriter, r *http.Request) {
 
 	q := store.New(dbPool)
 
-	// A city plan and a booking mirror are different things with different
-	// owners (00070 vs 00061), and a row that was both would have two rules for
-	// what unbooking does to it. Refuse rather than pick one.
+	// A client-CHOSEN city and a booking mirror are different things with
+	// different owners (00070/00072 vs 00061), and a row that was both would
+	// have two rules for what unbooking does to it. Refuse rather than pick
+	// one. (A stay-linked add still gets a city — stamped server-side below,
+	// where the trip decides, not the client.)
 	if req.LegKey != nil && req.SourceKind != nil {
 		writeJSONError(w, http.StatusBadRequest, "leg_key and source_kind cannot be combined")
+		return
+	}
+	legPlan := req.LegPlan != nil && *req.LegPlan
+	if legPlan && req.LegKey == nil {
+		// A plan slot with no city has no identity to upsert on; refuse
+		// rather than quietly filing an ordinary line the daily-spend card
+		// could then never find.
+		writeJSONError(w, http.StatusBadRequest, "leg_plan requires leg_key")
 		return
 	}
 	var legKey *string
@@ -442,6 +470,15 @@ func addExpenseHandler(w http.ResponseWriter, r *http.Request) {
 		legKey = &key
 	}
 
+	// A stay-linked expense gets its city stamped by the SERVER (00072): the
+	// stay knows which leg it sits in, so the lodging line lands under its
+	// city with no one typing anything. Best-effort by design — a failed
+	// resolution leaves the line untagged (the traveler can tag it by hand);
+	// the money is the point and is never held hostage to a grouping.
+	if req.SourceKind != nil && *req.SourceKind == "accommodation" {
+		legKey = stayLegKeyByID(r.Context(), q, trip, uuid.UUID(sourceID.Bytes))
+	}
+
 	expense, outcome, err := upsertLinkedExpense(r.Context(), q, linkedExpense{
 		TripID:        trip.ID,
 		Category:      category,
@@ -451,6 +488,7 @@ func addExpenseHandler(w http.ResponseWriter, r *http.Request) {
 		SourceKind:    req.SourceKind,
 		SourceID:      sourceID,
 		LegKey:        legKey,
+		LegPlan:       legPlan,
 	})
 	if err != nil {
 		if errors.Is(err, errExpenseLimitReached) {
@@ -486,7 +524,7 @@ func addExpenseHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 // PatchExpenseRequest is a partial update: recategorize, relabel, restate the
-// plan, reposition.
+// plan, reposition, re-file under a city.
 //
 // Note what is deliberately NOT here:
 //
@@ -507,6 +545,18 @@ type PatchExpenseRequest struct {
 	// re-classifying the line.
 	Amount   *float64 `json:"amount"`
 	Position *int     `json:"position"`
+	// LegKey re-files the line under another city (00072). Three shapes:
+	// nil = omitted, keep; "" = clear the tag; "Rome" = tag (canonicalized
+	// against the trip's real legs, 400 on an unknown key). Empty-means-clear
+	// rather than a null (00067's argument: an old client serializing absent
+	// fields as null would silently untag everything it touched) and rather
+	// than a verb pair (the thing at risk is a grouping, not money — a
+	// mistaken clear costs a subtotal and one tap). NOTE the deliberate
+	// asymmetry with POST, where "" is a 400: empty in is junk, empty on an
+	// existing row is a removal. Refused outright on a leg_plan row — a plan
+	// slot's city is fixed at creation (00070's rule, narrowed to the rows it
+	// was written for).
+	LegKey *string `json:"leg_key"`
 }
 
 func patchExpenseHandler(w http.ResponseWriter, r *http.Request) {
@@ -525,9 +575,9 @@ func patchExpenseHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if req.Category == nil && req.Label == nil && req.Amount == nil &&
-		req.PlannedAmount == nil && req.Position == nil {
+		req.PlannedAmount == nil && req.Position == nil && req.LegKey == nil {
 		writeJSONError(w, http.StatusBadRequest,
-			"pass at least one field to change (category, label, planned_amount, amount, or position)")
+			"pass at least one field to change (category, label, planned_amount, amount, position, or leg_key)")
 		return
 	}
 	// Two writers for one column: `amount` resolves to planned_amount on an
@@ -576,6 +626,40 @@ func patchExpenseHandler(w http.ResponseWriter, r *http.Request) {
 		p := int32(*req.Position)
 		params.Position = &p
 	}
+	q := store.New(dbPool)
+	if req.LegKey != nil {
+		// Re-filing needs the row first: a plan slot's city is fixed at
+		// creation (00070), so the refusal has to know what it is refusing.
+		// This read only happens on the leg_key path — every other PATCH
+		// stays one statement.
+		existing, err := q.GetExpense(r.Context(), store.GetExpenseParams{ID: expenseID, TripID: trip.ID})
+		if err != nil {
+			writeJSONError(w, http.StatusNotFound, "expense not found")
+			return
+		}
+		if existing.LegPlan {
+			writeJSONError(w, http.StatusConflict,
+				"this line is a city's daily plan — its city is fixed; delete the line instead")
+			return
+		}
+		if key := strings.TrimSpace(*req.LegKey); key == "" {
+			params.ClearLegKey = true
+		} else {
+			// The 00064 rule, same as the POST: the server confirms the key
+			// against the trip's real legs so a stale tab cannot re-file a
+			// line onto a leg that no longer exists.
+			known, err := tripLegKeyExists(r.Context(), q, trip, key)
+			if err != nil {
+				writeJSONError(w, http.StatusInternalServerError, "could not save expense")
+				return
+			}
+			if !known {
+				writeJSONError(w, http.StatusBadRequest, "leg_key is not a city on this trip")
+				return
+			}
+			params.LegKey = &key
+		}
+	}
 	// Server rule (never a request field): editing the CONTENT of an
 	// auto-created expense is a manual takeover — the row stops mirroring
 	// its booking's booked state (unbook then leaves it; see the 00061
@@ -588,12 +672,16 @@ func patchExpenseHandler(w http.ResponseWriter, r *http.Request) {
 	// system-generated and never system-clobbered. So writing in the field you
 	// own is not a takeover: a planned_amount-only PATCH leaves auto alone,
 	// which is also what stops unbook from stranding a stale payment.
+	//
+	// leg_key is likewise the traveler's field on every row (00072): filing a
+	// booking's line under a city is organization, not authorship, so a
+	// leg_key-only PATCH leaves auto alone — flipping it would strand the
+	// payment the system still owes the row on unbook.
 	if req.Category != nil || req.Label != nil || req.Amount != nil {
 		autoFalse := false
 		params.Auto = &autoFalse
 	}
 
-	q := store.New(dbPool)
 	expense, err := q.UpdateExpense(r.Context(), params)
 	if err != nil {
 		writeJSONError(w, http.StatusNotFound, "expense not found")
@@ -781,10 +869,18 @@ type linkedExpense struct {
 	ActualAmount  *float64
 	SourceKind    *string
 	SourceID      pgtype.UUID
-	// LegKey is the OTHER identity a line can carry (00070) — the city leg it
-	// plans for. Mutually exclusive with the source link, and deliberately NOT
-	// an auto marker: the booking paths own a payment, this owns a plan.
+	// LegKey is the city leg this money belongs to (00070, generalized by
+	// 00072). Deliberately NOT an auto marker: where a line is filed is the
+	// traveler's organization. A CLIENT-chosen key is mutually exclusive with
+	// the source link (the handler refuses the pair); a stay-linked add still
+	// arrives here with a key because the SERVER stamped it from the stay's
+	// own leg.
 	LegKey *string
+	// LegPlan marks the one row that IS the city's per-day plan slot for its
+	// category (00072) — the upsert-by-leg identity. A stay's server-stamped
+	// LegKey rides with LegPlan false, which is why a hotel and a food plan
+	// can share a city.
+	LegPlan bool
 }
 
 // upsertLinkedExpense is the ONE implementation of "record this booking's price
@@ -812,11 +908,19 @@ func upsertLinkedExpense(ctx context.Context, q *store.Queries, in linkedExpense
 				return existing, expenseUntouched, nil
 			}
 			autoTrue := true
+			// The city stamp is a fill-in, never an overwrite (00072): if the
+			// traveler has since re-filed this hotel under another city, a
+			// re-book must not move it back — the same "never clobber a
+			// manual takeover" rule the !Auto branch above obeys for content.
+			var legKey *string
+			if existing.LegKey == nil {
+				legKey = in.LegKey
+			}
 			updated, err := q.UpdateExpense(ctx, store.UpdateExpenseParams{
 				ID: existing.ID, TripID: in.TripID,
 				Category: &in.Category, Label: &in.Label,
 				PlannedAmount: in.PlannedAmount, ActualAmount: in.ActualAmount,
-				Auto: &autoTrue,
+				Auto: &autoTrue, LegKey: legKey,
 			})
 			if err != nil {
 				return store.TripExpense{}, expenseUntouched, err
@@ -825,12 +929,14 @@ func upsertLinkedExpense(ctx context.Context, q *store.Queries, in linkedExpense
 		}
 	}
 
-	// Leg-keyed adds are an upsert-by-leg (the 00070 partial unique index).
-	// Found -> return it UNTOUCHED, always: unlike the booking mirror above
-	// there is no "still auto" case to refresh, because the number on this line
-	// is the traveler's plan the moment it exists. A second tap on a city
-	// already in the plan must not quietly restate it at today's tier.
-	if in.SourceKind == nil && in.LegKey != nil {
+	// Plan-slot adds are an upsert-by-leg (the 00070 partial unique index,
+	// narrowed by 00072 to leg_plan rows — an ordinary city-tagged add always
+	// creates; twenty dinners can share a city). Found -> return it UNTOUCHED,
+	// always: unlike the booking mirror above there is no "still auto" case to
+	// refresh, because the number on this line is the traveler's plan the
+	// moment it exists. A second tap on a city already in the plan must not
+	// quietly restate it at today's tier.
+	if in.SourceKind == nil && in.LegKey != nil && in.LegPlan {
 		if existing, err := q.GetExpenseByLegKey(ctx, store.GetExpenseByLegKeyParams{
 			TripID: in.TripID, LegKey: in.LegKey, Category: in.Category,
 		}); err == nil {
@@ -855,6 +961,7 @@ func upsertLinkedExpense(ctx context.Context, q *store.Queries, in linkedExpense
 		SourceKind:    in.SourceKind,
 		SourceID:      in.SourceID,
 		LegKey:        in.LegKey,
+		LegPlan:       in.LegPlan,
 	})
 	if err != nil {
 		// Concurrent POSTs can race past either lookup; the partial unique
@@ -869,7 +976,10 @@ func upsertLinkedExpense(ctx context.Context, q *store.Queries, in linkedExpense
 					return existing, expenseUntouched, nil
 				}
 			}
-			if in.LegKey != nil {
+			// Only a plan-slot create can land on the leg index since 00072
+			// (it no longer covers ordinary tagged lines), so only that path
+			// has a row to recover.
+			if in.LegKey != nil && in.LegPlan {
 				if existing, lookupErr := q.GetExpenseByLegKey(ctx, store.GetExpenseByLegKeyParams{
 					TripID: in.TripID, LegKey: in.LegKey, Category: in.Category,
 				}); lookupErr == nil {

--- a/src/packages/api/daily_spend_handler.go
+++ b/src/packages/api/daily_spend_handler.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"log"
 	"net/http"
 	"os"
@@ -22,25 +21,8 @@ import (
 // section. A suggestion that cannot be produced is not an error the traveler
 // did anything to cause.
 
-// tripLegKeyExists reports whether key names one of the trip's CURRENT rendered
-// legs. It is the canonicalization boundary for the leg-keyed expense POST: the
-// client proposes a key, the server confirms it against computeTripLegs, and an
-// unrecognized one is refused rather than stored. Without this a stale bundle
-// could file "Rome#2" against a trip that no longer has one, and the plan would
-// sit in the list forever with no card able to claim it.
-func tripLegKeyExists(ctx context.Context, q *store.Queries, trip store.Trip, key string) (bool, error) {
-	items, err := q.GetItineraryItemsByTrip(ctx, trip.ID)
-	if err != nil {
-		return false, err
-	}
-	stays, _ := q.ListAccommodationsByTrip(ctx, trip.ID)
-	for _, l := range computeTripLegs(trip, items, stays) {
-		if l.Key == key {
-			return true, nil
-		}
-	}
-	return false, nil
-}
+// tripLegKeyExists moved to expense_leg_key.go when 00072 made leg tagging a
+// budget-wide concern rather than a daily-spend one.
 
 func dailySpendHandler(w http.ResponseWriter, r *http.Request) {
 	trip, ok := editableTrip(w, r)

--- a/src/packages/api/daily_spend_integration_test.go
+++ b/src/packages/api/daily_spend_integration_test.go
@@ -299,15 +299,15 @@ func TestLegKeyedExpenseIsUpsertNotDuplicate(t *testing.T) {
 
 	add := map[string]any{
 		"label": "Food & drink · Lisbon", "category": "food",
-		"planned_amount": 200, "leg_key": "Lisbon",
+		"planned_amount": 200, "leg_key": "Lisbon", "leg_plan": true,
 	}
 	rec := doJSON(t, "POST", path, token, add)
 	if rec.Code != http.StatusCreated {
 		t.Fatalf("first add = %d: %s", rec.Code, rec.Body.String())
 	}
 	first := decode(t, rec)
-	if first["leg_key"] != "Lisbon" {
-		t.Fatalf("leg_key must ride the wire so the card can find its own line: %v", first)
+	if first["leg_key"] != "Lisbon" || first["leg_plan"] != true {
+		t.Fatalf("leg_key + leg_plan must ride the wire so the card can find its own line: %v", first)
 	}
 	// A city plan is the TRAVELER's, never a system mirror — no booking-state
 	// change may reach it.
@@ -338,7 +338,7 @@ func TestLegKeyedExpenseIsUpsertNotDuplicate(t *testing.T) {
 	// category would be too.
 	if rec := doJSON(t, "POST", path, token, map[string]any{
 		"label": "Food & drink · Porto", "category": "food",
-		"planned_amount": 135, "leg_key": "Porto",
+		"planned_amount": 135, "leg_key": "Porto", "leg_plan": true,
 	}); rec.Code != http.StatusCreated {
 		t.Fatalf("second city = %d, want 201: %s", rec.Code, rec.Body.String())
 	}
@@ -388,10 +388,10 @@ func TestLegKeyedExpenseRejectsUnknownAndConflictingKeys(t *testing.T) {
 	}
 }
 
-// PATCH has no mechanism to move a line to another city — the same shape as
-// TestPatchTripCannotSetOrigin. Which leg a plan belongs to is decided once, by
-// the one writer, against the trip's real legs.
-func TestPatchExpenseCannotSetLegKey(t *testing.T) {
+// A city PLAN's city is fixed at creation (00070's rule, narrowed by 00072 to
+// the rows it was written for — the shape of TestPatchTripCannotSetOrigin).
+// The refusal covers the whole request: a 409, never a partial apply.
+func TestPatchCannotMoveACityPlan(t *testing.T) {
 	resetDB(t)
 	owner, token := createTestUser(t, "legkey-patch@example.com")
 	trip := createTestTrip(t, owner.ID, 0)
@@ -400,25 +400,220 @@ func TestPatchExpenseCannotSetLegKey(t *testing.T) {
 
 	created := decode(t, doJSON(t, "POST", path, token, map[string]any{
 		"label": "Food & drink · Lisbon", "category": "food",
-		"planned_amount": 200, "leg_key": "Lisbon",
+		"planned_amount": 200, "leg_key": "Lisbon", "leg_plan": true,
 	}))
 	id := created["id"].(string)
 
-	patched := decode(t, doJSON(t, "PATCH", path+"/"+id, token,
-		map[string]any{"label": "Eating in Lisbon", "leg_key": "Porto"}))
-	if patched["leg_key"] != "Lisbon" {
-		t.Fatalf("PATCH moved the line to another city: %v", patched["leg_key"])
+	if rec := doJSON(t, "PATCH", path+"/"+id, token,
+		map[string]any{"label": "Eating in Lisbon", "leg_key": "Porto"}); rec.Code != http.StatusConflict {
+		t.Fatalf("moving a plan = %d, want 409: %s", rec.Code, rec.Body.String())
 	}
-	if patched["label"] != "Eating in Lisbon" {
-		t.Fatalf("the rest of the PATCH should still apply: %v", patched)
+	var rows []map[string]any
+	if err := json.Unmarshal(doJSON(t, "GET", path, token, nil).Body.Bytes(), &rows); err != nil || len(rows) != 1 {
+		t.Fatalf("decode expenses: %v (%d rows)", err, len(rows))
 	}
+	if rows[0]["leg_key"] != "Lisbon" || rows[0]["label"] != "Food & drink · Lisbon" {
+		t.Fatalf("a refused PATCH must apply nothing: %v", rows[0])
+	}
+	// Clearing is a move too — same refusal.
+	if rec := doJSON(t, "PATCH", path+"/"+id, token,
+		map[string]any{"leg_key": ""}); rec.Code != http.StatusConflict {
+		t.Fatalf("clearing a plan's city = %d, want 409", rec.Code)
+	}
+}
 
-	// A plain expense stays plain — PATCH cannot give one a city either.
+// Since 00072 an ordinary line can be filed under a city, re-filed, and
+// un-filed — with every key still canonicalized against the trip's real legs
+// (the 00064 rule; PATCH "" clears, deliberately asymmetric with POST where
+// "" is a 400).
+func TestPatchTagsAndClearsCity(t *testing.T) {
+	resetDB(t)
+	owner, token := createTestUser(t, "legkey-tag@example.com")
+	trip := createTestTrip(t, owner.ID, 0)
+	seedTwoCityTrip(t, trip, owner.ID)
+	path := "/api/v1/trips/" + trip.ID.String() + "/budget/expenses"
+
 	plain := decode(t, doJSON(t, "POST", path, token,
 		map[string]any{"label": "Souvenirs", "planned_amount": 20}))
-	got := decode(t, doJSON(t, "PATCH", path+"/"+plain["id"].(string), token,
+	id := plain["id"].(string)
+	if plain["leg_key"] != nil || plain["leg_plan"] != false {
+		t.Fatalf("a plain add carries no city and is no plan: %v", plain)
+	}
+
+	tagged := decode(t, doJSON(t, "PATCH", path+"/"+id, token,
 		map[string]any{"leg_key": "Lisbon"}))
-	if got["leg_key"] != nil {
-		t.Fatalf("PATCH gave a plain line a city: %v", got["leg_key"])
+	if tagged["leg_key"] != "Lisbon" || tagged["leg_plan"] != false {
+		t.Fatalf("tagging files the line without minting a plan: %v", tagged)
+	}
+	moved := decode(t, doJSON(t, "PATCH", path+"/"+id, token,
+		map[string]any{"leg_key": "Porto"}))
+	if moved["leg_key"] != "Porto" {
+		t.Fatalf("re-filing = %v, want Porto", moved["leg_key"])
+	}
+	cleared := decode(t, doJSON(t, "PATCH", path+"/"+id, token,
+		map[string]any{"leg_key": ""}))
+	if cleared["leg_key"] != nil {
+		t.Fatalf("empty string must clear the tag: %v", cleared["leg_key"])
+	}
+	if rec := doJSON(t, "PATCH", path+"/"+id, token,
+		map[string]any{"leg_key": "Atlantis"}); rec.Code != http.StatusBadRequest {
+		t.Fatalf("unknown city = %d, want 400", rec.Code)
+	}
+}
+
+// Filing a booking's line under a city is organization, not authorship: a
+// leg_key-only PATCH must leave `auto` alone (the planned_amount rule), or
+// unbook would strand the payment the system still owes the row.
+func TestTaggingDoesNotFlipAuto(t *testing.T) {
+	resetDB(t)
+	owner, token := createTestUser(t, "legkey-auto@example.com")
+	trip := createTestTrip(t, owner.ID, 0)
+	seedTwoCityTrip(t, trip, owner.ID)
+	path := "/api/v1/trips/" + trip.ID.String() + "/budget/expenses"
+
+	linked := decode(t, doJSON(t, "POST", path, token, map[string]any{
+		"label": "Hotel Mundial", "category": "lodging", "actual_amount": 400,
+		"source_kind": "booking_todo", "source_id": uuid.NewString(),
+	}))
+	if linked["auto"] != true {
+		t.Fatalf("a linked add must be auto: %v", linked)
+	}
+	id := linked["id"].(string)
+
+	tagged := decode(t, doJSON(t, "PATCH", path+"/"+id, token,
+		map[string]any{"leg_key": "Lisbon"}))
+	if tagged["auto"] != true {
+		t.Fatalf("a leg_key-only PATCH is not a takeover: %v", tagged)
+	}
+	// The control: a content edit IS a takeover, exactly as before.
+	relabelled := decode(t, doJSON(t, "PATCH", path+"/"+id, token,
+		map[string]any{"label": "Hotel Mundial Lisboa"}))
+	if relabelled["auto"] != false {
+		t.Fatalf("a content PATCH must still flip auto: %v", relabelled)
+	}
+}
+
+// The 00072 point: many ordinary lines can share a city (the old wide unique
+// index forbade exactly this), while the plan slot stays one-per-city-per-
+// category underneath them.
+func TestManyLinesCanShareACity(t *testing.T) {
+	resetDB(t)
+	owner, token := createTestUser(t, "legkey-many@example.com")
+	trip := createTestTrip(t, owner.ID, 0)
+	seedTwoCityTrip(t, trip, owner.ID)
+	path := "/api/v1/trips/" + trip.ID.String() + "/budget/expenses"
+
+	ids := map[string]bool{}
+	for i, label := range []string{"Dinner at Ramiro", "Pastéis run", "Fado night"} {
+		rec := doJSON(t, "POST", path, token, map[string]any{
+			"label": label, "category": "food", "planned_amount": 30 + i,
+			"leg_key": "Lisbon",
+		})
+		if rec.Code != http.StatusCreated {
+			t.Fatalf("tagged add %d = %d: %s", i, rec.Code, rec.Body.String())
+		}
+		row := decode(t, rec)
+		if row["leg_plan"] != false {
+			t.Fatalf("an ordinary tagged line is not a plan: %v", row)
+		}
+		ids[row["id"].(string)] = true
+	}
+	if len(ids) != 3 {
+		t.Fatalf("three tagged food lines must be three rows, got %d", len(ids))
+	}
+
+	// The plan slot still upserts to ONE row beneath them.
+	first := decode(t, doJSON(t, "POST", path, token, map[string]any{
+		"label": "Food & drink · Lisbon", "category": "food",
+		"planned_amount": 200, "leg_key": "Lisbon", "leg_plan": true,
+	}))
+	again := doJSON(t, "POST", path, token, map[string]any{
+		"label": "Food & drink · Lisbon", "category": "food",
+		"planned_amount": 999, "leg_key": "Lisbon", "leg_plan": true,
+	})
+	if again.Code != http.StatusOK {
+		t.Fatalf("second plan tap = %d, want 200: %s", again.Code, again.Body.String())
+	}
+	if decode(t, again)["id"] != first["id"] {
+		t.Fatalf("the plan slot must stay one row")
+	}
+}
+
+// A plan slot with no city has no identity to upsert on.
+func TestPlanRowRequiresLegKey(t *testing.T) {
+	resetDB(t)
+	owner, token := createTestUser(t, "legplan-bare@example.com")
+	trip := createTestTrip(t, owner.ID, 0)
+	seedTwoCityTrip(t, trip, owner.ID)
+	if rec := doJSON(t, "POST", "/api/v1/trips/"+trip.ID.String()+"/budget/expenses", token,
+		map[string]any{"label": "Food", "category": "food", "planned_amount": 100,
+			"leg_plan": true}); rec.Code != http.StatusBadRequest {
+		t.Fatalf("leg_plan without leg_key = %d, want 400", rec.Code)
+	}
+}
+
+// A stay-linked expense gets its city stamped by the SERVER (00072) — and the
+// stamp is a fill-in, never an overwrite: once the traveler re-files the line,
+// a re-book must not move it back.
+func TestStayExpenseIsStampedWithItsCity(t *testing.T) {
+	resetDB(t)
+	owner, token := createTestUser(t, "legkey-stay@example.com")
+	trip := createTestTrip(t, owner.ID, 0)
+	seedTwoCityTrip(t, trip, owner.ID)
+	path := "/api/v1/trips/" + trip.ID.String() + "/budget/expenses"
+
+	// The seeded "Lisbon Stay" — fetched for its id, the link target.
+	q := store.New(dbPool)
+	stays, err := q.ListAccommodationsByTrip(context.Background(), trip.ID)
+	if err != nil || len(stays) == 0 {
+		t.Fatalf("list stays: %v", err)
+	}
+	var lisbonStay store.Accommodation
+	for _, s := range stays {
+		if s.Name == "Lisbon Stay" {
+			lisbonStay = s
+		}
+	}
+
+	linked := decode(t, doJSON(t, "POST", path, token, map[string]any{
+		"label": "Lisbon Stay", "category": "lodging", "actual_amount": 480,
+		"source_kind": "accommodation", "source_id": lisbonStay.ID.String(),
+	}))
+	if linked["leg_key"] != "Lisbon" {
+		t.Fatalf("a stay-linked line lands under its city with nobody typing: %v", linked)
+	}
+	if linked["leg_plan"] != false || linked["auto"] != true {
+		t.Fatalf("the stamp is a tag on a booking mirror, never a plan: %v", linked)
+	}
+
+	// The traveler re-files it; a refresh (re-book) must not move it back.
+	id := linked["id"].(string)
+	if got := decode(t, doJSON(t, "PATCH", path+"/"+id, token,
+		map[string]any{"leg_key": "Porto"})); got["leg_key"] != "Porto" {
+		t.Fatalf("re-file: %v", got)
+	}
+	refreshed := decode(t, doJSON(t, "POST", path, token, map[string]any{
+		"label": "Lisbon Stay", "category": "lodging", "actual_amount": 510,
+		"source_kind": "accommodation", "source_id": lisbonStay.ID.String(),
+	}))
+	if refreshed["id"] != id {
+		t.Fatalf("refresh must land on the same row")
+	}
+	if refreshed["leg_key"] != "Porto" {
+		t.Fatalf("the stamp is fill-in only — a re-book moved the traveler's filing: %v", refreshed["leg_key"])
+	}
+}
+
+// A flight is between cities: segment- and todo-linked lines stay untagged.
+func TestSegmentExpenseIsNotStamped(t *testing.T) {
+	resetDB(t)
+	owner, token := createTestUser(t, "legkey-segment@example.com")
+	trip := createTestTrip(t, owner.ID, 0)
+	seedTwoCityTrip(t, trip, owner.ID)
+	linked := decode(t, doJSON(t, "POST", "/api/v1/trips/"+trip.ID.String()+"/budget/expenses", token,
+		map[string]any{"label": "LIS → OPO", "category": "transport", "actual_amount": 60,
+			"source_kind": "segment", "source_id": uuid.NewString()}))
+	if linked["leg_key"] != nil {
+		t.Fatalf("a segment line is between cities, not in one: %v", linked["leg_key"])
 	}
 }

--- a/src/packages/api/expense_leg_key.go
+++ b/src/packages/api/expense_leg_key.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"context"
+	"strings"
+
+	"github.com/google/uuid"
+
+	"travel-route-planner/store"
+)
+
+// expense_leg_key.go — which city leg does a budget expense belong to.
+//
+// Since 00072 any expense can carry a leg_key (the spend-per-city breakdown),
+// so the questions "is this key one of the trip's legs?" and "which leg does
+// this stay sit in?" are budget-wide concerns, not daily-spend ones. Every
+// answer here goes through computeTripLegs — the ONE leg derivation
+// (trip_render_legs.go) — so a canonicalized key and a server-stamped key can
+// never come from two different rules.
+
+// tripRenderLegs loads the trip's items + stays and returns computeTripLegs's
+// answer. Items arrive in position order (GetItineraryItemsByTrip's ORDER BY),
+// which computeTripLegs requires. A stays load failure degrades to no stays,
+// matching the pre-00072 tripLegKeyExists behaviour: stays only refine leg
+// SPANS, never leg identity, so the key set is unaffected.
+func tripRenderLegs(ctx context.Context, q *store.Queries, trip store.Trip) ([]RenderLeg, []store.Accommodation, error) {
+	items, err := q.GetItineraryItemsByTrip(ctx, trip.ID)
+	if err != nil {
+		return nil, nil, err
+	}
+	stays, _ := q.ListAccommodationsByTrip(ctx, trip.ID)
+	return computeTripLegs(trip, items, stays), stays, nil
+}
+
+// tripLegKeyExists reports whether key names one of the trip's CURRENT rendered
+// legs. It is the canonicalization boundary for every expense write that names
+// a city (POST and, since 00072, PATCH): the client proposes a key, the server
+// confirms it against computeTripLegs, and an unrecognized one is refused
+// rather than stored. Without this a stale bundle could file "Rome#2" against
+// a trip that no longer has one, and the line would sit in the list forever
+// with no leg able to claim it.
+func tripLegKeyExists(ctx context.Context, q *store.Queries, trip store.Trip, key string) (bool, error) {
+	legs, _, err := tripRenderLegs(ctx, q, trip)
+	if err != nil {
+		return false, err
+	}
+	for _, l := range legs {
+		if l.Key == key {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// legKeyForStay returns the key of the first leg whose hub this stay matches,
+// or nil when none does. stayMatchesHub (plan_leg_dates.go) is the SAME
+// predicate computeTripLegs uses to give a leg its dates, so a hotel's expense
+// lands under the header its own check-in dates drew. Hubless legs (the
+// "Other places" run) are skipped — a stay can't match a leg that names no
+// city. No match returns nil: an untagged line is the honest answer, and
+// guessing a city is how the leg-dates arc started.
+func legKeyForStay(legs []RenderLeg, acc store.Accommodation) *string {
+	for i := range legs {
+		if legs[i].Hub == nil {
+			continue
+		}
+		if stayMatchesHub(acc, strings.ToLower(*legs[i].Hub)) {
+			return &legs[i].Key
+		}
+	}
+	return nil
+}
+
+// stayLegKeyByID resolves the leg an accommodation sits in, for the server-side
+// city stamp on a stay-linked expense (00072). Every failure degrades to nil:
+// the money on a booked-flip expense is the point, and a grouping is not worth
+// losing it over — the traveler can always tag the line by hand.
+func stayLegKeyByID(ctx context.Context, q *store.Queries, trip store.Trip, accID uuid.UUID) *string {
+	legs, stays, err := tripRenderLegs(ctx, q, trip)
+	if err != nil {
+		return nil
+	}
+	for i := range stays {
+		if stays[i].ID == accID {
+			return legKeyForStay(legs, stays[i])
+		}
+	}
+	return nil
+}

--- a/src/packages/api/migrations/00072_expense_leg_tagging.sql
+++ b/src/packages/api/migrations/00072_expense_leg_tagging.sql
@@ -1,0 +1,75 @@
+-- +goose Up
+-- Frees 00070's leg_key for general city tagging (spend-per-city breakdown).
+--
+-- 00070 gave leg_key ONE job: be the identity of a city's daily food & drink
+-- plan, so a double tap returns the row that exists instead of filing a
+-- second one. That job is enforced by a partial UNIQUE index, and the index
+-- is why the column could never also mean "this line happened in Rome": the
+-- second Rome food line the traveler types would collide with the plan.
+--
+-- So the JOB moves out of the column and into its own boolean. leg_plan =
+-- true means "this row IS the city's per-day plan slot for its category" —
+-- the thing daily_spend_section.dart finds itself by, and the thing the
+-- unique index guards. leg_key keeps only its plain meaning: the city leg
+-- this money belongs to, RenderLeg.Key from computeTripLegs ("Rome",
+-- "Rome#2"), still a SNAPSHOT with no FK — drop the city and the line
+-- degrades to an untagged expense and lands in "Rest of trip", exactly as
+-- 00070 promised.
+--
+-- Two facts, two columns, one representation each (docs/zen.md). The
+-- alternative — inferring "is this the plan slot?" from category = 'food' —
+-- is a convention someone must remember, and 00070's own comment already
+-- anticipated a city carrying more than one kind of per-day plan.
+ALTER TABLE trip_expenses ADD COLUMN leg_plan boolean NOT NULL DEFAULT false;
+
+-- Backfill: the daily-spend card is, before this migration, the ONLY writer
+-- of leg_key (POST /budget/expenses with leg_key), so every leg-keyed row
+-- that exists is a plan slot. An id-preserving UPDATE, the 00064 rule.
+UPDATE trip_expenses SET leg_plan = true WHERE leg_key IS NOT NULL;
+
+-- A plan slot always names its city, and is never a booking mirror. Both
+-- were true by construction before; now that leg_key has other writers they
+-- have to be stated, or "leg_plan" becomes another thing held up by
+-- convention.
+ALTER TABLE trip_expenses ADD CONSTRAINT trip_expenses_leg_plan_needs_leg
+    CHECK (NOT leg_plan OR leg_key IS NOT NULL);
+ALTER TABLE trip_expenses ADD CONSTRAINT trip_expenses_leg_plan_not_linked
+    CHECK (NOT leg_plan OR source_kind IS NULL);
+
+-- The invariant narrows to the rows it was written for. One plan slot per
+-- city per category stays a DB invariant (a double tap still can only ever
+-- return the row that exists); ordinary tagged lines are unconstrained, so a
+-- city can carry twenty dinners. A useful side effect: a PATCH that tags a
+-- line can no longer raise 23505, because the index does not cover it. (A
+-- category PATCH on a plan row can still, in principle, collide with this
+-- index — pre-existing since 00070, surfaces as the handler's blanket 404,
+-- and is LESS reachable than before; noted, not fixed here.)
+DROP INDEX IF EXISTS idx_trip_expenses_leg;
+CREATE UNIQUE INDEX idx_trip_expenses_leg
+    ON trip_expenses (trip_id, leg_key, category)
+    WHERE leg_key IS NOT NULL AND leg_plan;
+
+-- What this migration does NOT change: leg_key is still not part of the
+-- `auto` contract (00061). A stay's leg is stamped server-side at create as
+-- a convenience and never re-stamped over a traveler's later choice;
+-- unbooking still deletes/un-pays by the source link and never reads
+-- leg_key. WHERE THE "a plan row's city is fixed" RULE LIVES:
+-- patchExpenseHandler (budget_handler.go), which refuses a leg_key change on
+-- a leg_plan row — not expressible as a CHECK (no OLD/NEW), and a trigger
+-- for one guarded PATCH would hide the rule from the only file that can
+-- explain it.
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_trip_expenses_leg;
+-- Restore 00070's world exactly: only plan rows carry a leg_key. Ordinary
+-- tags must be cleared BEFORE the wide index returns — two tagged dinners in
+-- the same city would otherwise make the CREATE itself fail. Lossy of the
+-- tags, by design: they are a 00072 concept. Production only runs goose.Up
+-- (db.go); Down is a dev affordance.
+UPDATE trip_expenses SET leg_key = NULL WHERE leg_key IS NOT NULL AND NOT leg_plan;
+CREATE UNIQUE INDEX idx_trip_expenses_leg
+    ON trip_expenses (trip_id, leg_key, category)
+    WHERE leg_key IS NOT NULL;
+ALTER TABLE trip_expenses DROP CONSTRAINT IF EXISTS trip_expenses_leg_plan_not_linked;
+ALTER TABLE trip_expenses DROP CONSTRAINT IF EXISTS trip_expenses_leg_plan_needs_leg;
+ALTER TABLE trip_expenses DROP COLUMN IF EXISTS leg_plan;

--- a/src/packages/api/query/trip_budgets.sql
+++ b/src/packages/api/query/trip_budgets.sql
@@ -22,14 +22,18 @@ SELECT * FROM trip_expenses WHERE id = $1 AND trip_id = $2;
 -- name: CreateExpense :one
 -- auto/source_kind/source_id: the booking-autopopulate link (00061). The
 -- handler sets auto=true iff a source link is present — never the client.
--- leg_key: the city leg this line plans for (00070); NULL on every other path.
--- It is deliberately NOT part of the auto contract — a leg-keyed row is the
--- traveler's own plan, not a mirror of a booking.
+-- leg_key: the city leg this money belongs to (00070, generalized by 00072);
+-- NULL when the line isn't filed under a city. It is deliberately NOT part of
+-- the auto contract — where a line is filed is the traveler's organization,
+-- not a mirror of a booking.
+-- leg_plan: marks the ONE row per city per category that IS that city's
+-- per-day plan slot (00072) — the daily food & drink card's identity, guarded
+-- by the partial unique index. Ordinary city-tagged lines carry false.
 -- `amount` is deliberately absent from the column list: set_expense_amount()
 -- (00067) computes it as COALESCE(actual_amount, planned_amount). One
 -- definition, in the database, on every write path.
-INSERT INTO trip_expenses (trip_id, category, label, planned_amount, actual_amount, position, auto, source_kind, source_id, leg_key)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+INSERT INTO trip_expenses (trip_id, category, label, planned_amount, actual_amount, position, auto, source_kind, source_id, leg_key, leg_plan)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
 RETURNING *;
 
 -- name: GetExpenseBySource :one
@@ -39,11 +43,14 @@ SELECT * FROM trip_expenses
 WHERE trip_id = $1 AND source_kind = $2 AND source_id = $3;
 
 -- name: GetExpenseByLegKey :one
--- The leg-keyed lookup (00070): at most one plan per city per category
--- (partial unique index idx_trip_expenses_leg). Category is in the key because
--- a city may carry more than one kind of per-day plan; food is the first.
+-- The PLAN-SLOT lookup (00070/00072), not a leg lookup: at most one plan per
+-- city per category (partial unique index idx_trip_expenses_leg). Category is
+-- in the key because a city may carry more than one kind of per-day plan;
+-- food is the first. `leg_plan` is load-bearing since 00072 — without it this
+-- would find one of the many ordinary lines the traveler merely tagged with
+-- the same city.
 SELECT * FROM trip_expenses
-WHERE trip_id = $1 AND leg_key = $2 AND category = $3;
+WHERE trip_id = $1 AND leg_key = $2 AND category = $3 AND leg_plan;
 
 -- name: UpdateExpense :one
 -- Partial update (COALESCE sqlc.narg idiom, see query/trip_checklist_items.sql
@@ -65,13 +72,25 @@ WHERE trip_id = $1 AND leg_key = $2 AND category = $3;
 --     re-classifying the line.
 --  3. `amount` is never listed. The trigger recomputes it; writing it by hand
 --     raises.
---  4. `leg_key` is never listed either (00070). Which city a plan belongs to is
---     fixed at creation and canonicalized against the trip's real legs by the
---     one writer; an edit that could re-point it would let a stale client move
---     a line onto a leg the server never agreed to.
+--  4. `leg_key` is writable since 00072 — which city a line belongs to is the
+--     traveler's organization, and organizing is an edit. Clearing needs a
+--     signal COALESCE cannot carry, so it rides the `clear_leg_key` flag, the
+--     same escape hatch query/preferences.sql uses for clear_home_airport and
+--     for the same reason. NOT a null-means-clear JSON convention (00067's
+--     verb-pair argument) and NOT a verb pair either: the thing at risk is a
+--     grouping, not money, so a mistaken clear costs a subtotal and one tap —
+--     which is the whole reason actual_amount needed a verb and this does not.
+--     The handler still canonicalizes every non-nil key against the trip's
+--     real legs (tripLegKeyExists) and refuses the write outright on a
+--     leg_plan row: a plan slot's city is fixed at creation, as 00070 said.
+--  5. `leg_plan` is deliberately absent: a plan slot is minted at CREATE,
+--     never converted from (or to) an ordinary line.
 UPDATE trip_expenses
 SET category = COALESCE(sqlc.narg('category'), category),
     label    = COALESCE(sqlc.narg('label'), label),
+    leg_key  = CASE
+        WHEN sqlc.arg('clear_leg_key')::boolean THEN NULL
+        ELSE COALESCE(sqlc.narg('leg_key'), leg_key) END,
     planned_amount = CASE
         WHEN sqlc.narg('legacy_amount')::float8 IS NOT NULL AND actual_amount IS NULL
             THEN sqlc.narg('legacy_amount')::float8

--- a/src/packages/api/store/models.go
+++ b/src/packages/api/store/models.go
@@ -362,6 +362,7 @@ type TripExpense struct {
 	PlannedAmount *float64    `json:"planned_amount"`
 	ActualAmount  *float64    `json:"actual_amount"`
 	LegKey        *string     `json:"leg_key"`
+	LegPlan       bool        `json:"leg_plan"`
 }
 
 type TripInvite struct {

--- a/src/packages/api/store/trip_budgets.sql.go
+++ b/src/packages/api/store/trip_budgets.sql.go
@@ -37,9 +37,9 @@ func (q *Queries) ClearExpenseActualAmount(ctx context.Context, arg ClearExpense
 }
 
 const createExpense = `-- name: CreateExpense :one
-INSERT INTO trip_expenses (trip_id, category, label, planned_amount, actual_amount, position, auto, source_kind, source_id, leg_key)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
-RETURNING id, trip_id, category, label, amount, position, auto, created_at, updated_at, source_kind, source_id, planned_amount, actual_amount, leg_key
+INSERT INTO trip_expenses (trip_id, category, label, planned_amount, actual_amount, position, auto, source_kind, source_id, leg_key, leg_plan)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+RETURNING id, trip_id, category, label, amount, position, auto, created_at, updated_at, source_kind, source_id, planned_amount, actual_amount, leg_key, leg_plan
 `
 
 type CreateExpenseParams struct {
@@ -53,13 +53,18 @@ type CreateExpenseParams struct {
 	SourceKind    *string     `json:"source_kind"`
 	SourceID      pgtype.UUID `json:"source_id"`
 	LegKey        *string     `json:"leg_key"`
+	LegPlan       bool        `json:"leg_plan"`
 }
 
 // auto/source_kind/source_id: the booking-autopopulate link (00061). The
 // handler sets auto=true iff a source link is present — never the client.
-// leg_key: the city leg this line plans for (00070); NULL on every other path.
-// It is deliberately NOT part of the auto contract — a leg-keyed row is the
-// traveler's own plan, not a mirror of a booking.
+// leg_key: the city leg this money belongs to (00070, generalized by 00072);
+// NULL when the line isn't filed under a city. It is deliberately NOT part of
+// the auto contract — where a line is filed is the traveler's organization,
+// not a mirror of a booking.
+// leg_plan: marks the ONE row per city per category that IS that city's
+// per-day plan slot (00072) — the daily food & drink card's identity, guarded
+// by the partial unique index. Ordinary city-tagged lines carry false.
 // `amount` is deliberately absent from the column list: set_expense_amount()
 // (00067) computes it as COALESCE(actual_amount, planned_amount). One
 // definition, in the database, on every write path.
@@ -75,6 +80,7 @@ func (q *Queries) CreateExpense(ctx context.Context, arg CreateExpenseParams) (T
 		arg.SourceKind,
 		arg.SourceID,
 		arg.LegKey,
+		arg.LegPlan,
 	)
 	var i TripExpense
 	err := row.Scan(
@@ -92,6 +98,7 @@ func (q *Queries) CreateExpense(ctx context.Context, arg CreateExpenseParams) (T
 		&i.PlannedAmount,
 		&i.ActualAmount,
 		&i.LegKey,
+		&i.LegPlan,
 	)
 	return i, err
 }
@@ -132,7 +139,7 @@ func (q *Queries) GetBudgetByTrip(ctx context.Context, tripID uuid.UUID) (TripBu
 }
 
 const getExpense = `-- name: GetExpense :one
-SELECT id, trip_id, category, label, amount, position, auto, created_at, updated_at, source_kind, source_id, planned_amount, actual_amount, leg_key FROM trip_expenses WHERE id = $1 AND trip_id = $2
+SELECT id, trip_id, category, label, amount, position, auto, created_at, updated_at, source_kind, source_id, planned_amount, actual_amount, leg_key, leg_plan FROM trip_expenses WHERE id = $1 AND trip_id = $2
 `
 
 type GetExpenseParams struct {
@@ -158,13 +165,14 @@ func (q *Queries) GetExpense(ctx context.Context, arg GetExpenseParams) (TripExp
 		&i.PlannedAmount,
 		&i.ActualAmount,
 		&i.LegKey,
+		&i.LegPlan,
 	)
 	return i, err
 }
 
 const getExpenseByLegKey = `-- name: GetExpenseByLegKey :one
-SELECT id, trip_id, category, label, amount, position, auto, created_at, updated_at, source_kind, source_id, planned_amount, actual_amount, leg_key FROM trip_expenses
-WHERE trip_id = $1 AND leg_key = $2 AND category = $3
+SELECT id, trip_id, category, label, amount, position, auto, created_at, updated_at, source_kind, source_id, planned_amount, actual_amount, leg_key, leg_plan FROM trip_expenses
+WHERE trip_id = $1 AND leg_key = $2 AND category = $3 AND leg_plan
 `
 
 type GetExpenseByLegKeyParams struct {
@@ -173,9 +181,12 @@ type GetExpenseByLegKeyParams struct {
 	Category string    `json:"category"`
 }
 
-// The leg-keyed lookup (00070): at most one plan per city per category
-// (partial unique index idx_trip_expenses_leg). Category is in the key because
-// a city may carry more than one kind of per-day plan; food is the first.
+// The PLAN-SLOT lookup (00070/00072), not a leg lookup: at most one plan per
+// city per category (partial unique index idx_trip_expenses_leg). Category is
+// in the key because a city may carry more than one kind of per-day plan;
+// food is the first. `leg_plan` is load-bearing since 00072 — without it this
+// would find one of the many ordinary lines the traveler merely tagged with
+// the same city.
 func (q *Queries) GetExpenseByLegKey(ctx context.Context, arg GetExpenseByLegKeyParams) (TripExpense, error) {
 	row := q.db.QueryRow(ctx, getExpenseByLegKey, arg.TripID, arg.LegKey, arg.Category)
 	var i TripExpense
@@ -194,12 +205,13 @@ func (q *Queries) GetExpenseByLegKey(ctx context.Context, arg GetExpenseByLegKey
 		&i.PlannedAmount,
 		&i.ActualAmount,
 		&i.LegKey,
+		&i.LegPlan,
 	)
 	return i, err
 }
 
 const getExpenseBySource = `-- name: GetExpenseBySource :one
-SELECT id, trip_id, category, label, amount, position, auto, created_at, updated_at, source_kind, source_id, planned_amount, actual_amount, leg_key FROM trip_expenses
+SELECT id, trip_id, category, label, amount, position, auto, created_at, updated_at, source_kind, source_id, planned_amount, actual_amount, leg_key, leg_plan FROM trip_expenses
 WHERE trip_id = $1 AND source_kind = $2 AND source_id = $3
 `
 
@@ -229,12 +241,13 @@ func (q *Queries) GetExpenseBySource(ctx context.Context, arg GetExpenseBySource
 		&i.PlannedAmount,
 		&i.ActualAmount,
 		&i.LegKey,
+		&i.LegPlan,
 	)
 	return i, err
 }
 
 const listExpensesByTrip = `-- name: ListExpensesByTrip :many
-SELECT id, trip_id, category, label, amount, position, auto, created_at, updated_at, source_kind, source_id, planned_amount, actual_amount, leg_key FROM trip_expenses
+SELECT id, trip_id, category, label, amount, position, auto, created_at, updated_at, source_kind, source_id, planned_amount, actual_amount, leg_key, leg_plan FROM trip_expenses
 WHERE trip_id = $1
 ORDER BY position ASC, created_at ASC
 `
@@ -263,6 +276,7 @@ func (q *Queries) ListExpensesByTrip(ctx context.Context, tripID uuid.UUID) ([]T
 			&i.PlannedAmount,
 			&i.ActualAmount,
 			&i.LegKey,
+			&i.LegPlan,
 		); err != nil {
 			return nil, err
 		}
@@ -280,7 +294,7 @@ SET actual_amount = COALESCE($1::float8, planned_amount),
     auto = false
 WHERE id = $2 AND trip_id = $3
   AND ($1::float8 IS NOT NULL OR planned_amount IS NOT NULL)
-RETURNING id, trip_id, category, label, amount, position, auto, created_at, updated_at, source_kind, source_id, planned_amount, actual_amount, leg_key
+RETURNING id, trip_id, category, label, amount, position, auto, created_at, updated_at, source_kind, source_id, planned_amount, actual_amount, leg_key, leg_plan
 `
 
 type PurchaseExpenseParams struct {
@@ -317,6 +331,7 @@ func (q *Queries) PurchaseExpense(ctx context.Context, arg PurchaseExpenseParams
 		&i.PlannedAmount,
 		&i.ActualAmount,
 		&i.LegKey,
+		&i.LegPlan,
 	)
 	return i, err
 }
@@ -325,7 +340,7 @@ const unpurchaseExpense = `-- name: UnpurchaseExpense :one
 UPDATE trip_expenses
 SET actual_amount = NULL, auto = false
 WHERE id = $1 AND trip_id = $2 AND planned_amount IS NOT NULL
-RETURNING id, trip_id, category, label, amount, position, auto, created_at, updated_at, source_kind, source_id, planned_amount, actual_amount, leg_key
+RETURNING id, trip_id, category, label, amount, position, auto, created_at, updated_at, source_kind, source_id, planned_amount, actual_amount, leg_key, leg_plan
 `
 
 type UnpurchaseExpenseParams struct {
@@ -358,6 +373,7 @@ func (q *Queries) UnpurchaseExpense(ctx context.Context, arg UnpurchaseExpensePa
 		&i.PlannedAmount,
 		&i.ActualAmount,
 		&i.LegKey,
+		&i.LegPlan,
 	)
 	return i, err
 }
@@ -366,23 +382,28 @@ const updateExpense = `-- name: UpdateExpense :one
 UPDATE trip_expenses
 SET category = COALESCE($1, category),
     label    = COALESCE($2, label),
+    leg_key  = CASE
+        WHEN $3::boolean THEN NULL
+        ELSE COALESCE($4, leg_key) END,
     planned_amount = CASE
-        WHEN $3::float8 IS NOT NULL AND actual_amount IS NULL
-            THEN $3::float8
-        ELSE COALESCE($4, planned_amount) END,
+        WHEN $5::float8 IS NOT NULL AND actual_amount IS NULL
+            THEN $5::float8
+        ELSE COALESCE($6, planned_amount) END,
     actual_amount = CASE
-        WHEN $3::float8 IS NOT NULL AND actual_amount IS NOT NULL
-            THEN $3::float8
-        ELSE COALESCE($5, actual_amount) END,
-    position = COALESCE($6, position),
-    auto     = COALESCE($7, auto)
-WHERE id = $8 AND trip_id = $9
-RETURNING id, trip_id, category, label, amount, position, auto, created_at, updated_at, source_kind, source_id, planned_amount, actual_amount, leg_key
+        WHEN $5::float8 IS NOT NULL AND actual_amount IS NOT NULL
+            THEN $5::float8
+        ELSE COALESCE($7, actual_amount) END,
+    position = COALESCE($8, position),
+    auto     = COALESCE($9, auto)
+WHERE id = $10 AND trip_id = $11
+RETURNING id, trip_id, category, label, amount, position, auto, created_at, updated_at, source_kind, source_id, planned_amount, actual_amount, leg_key, leg_plan
 `
 
 type UpdateExpenseParams struct {
 	Category      *string   `json:"category"`
 	Label         *string   `json:"label"`
+	ClearLegKey   bool      `json:"clear_leg_key"`
+	LegKey        *string   `json:"leg_key"`
 	LegacyAmount  *float64  `json:"legacy_amount"`
 	PlannedAmount *float64  `json:"planned_amount"`
 	ActualAmount  *float64  `json:"actual_amount"`
@@ -411,14 +432,25 @@ type UpdateExpenseParams struct {
 //     re-classifying the line.
 //  3. `amount` is never listed. The trigger recomputes it; writing it by hand
 //     raises.
-//  4. `leg_key` is never listed either (00070). Which city a plan belongs to is
-//     fixed at creation and canonicalized against the trip's real legs by the
-//     one writer; an edit that could re-point it would let a stale client move
-//     a line onto a leg the server never agreed to.
+//  4. `leg_key` is writable since 00072 — which city a line belongs to is the
+//     traveler's organization, and organizing is an edit. Clearing needs a
+//     signal COALESCE cannot carry, so it rides the `clear_leg_key` flag, the
+//     same escape hatch query/preferences.sql uses for clear_home_airport and
+//     for the same reason. NOT a null-means-clear JSON convention (00067's
+//     verb-pair argument) and NOT a verb pair either: the thing at risk is a
+//     grouping, not money, so a mistaken clear costs a subtotal and one tap —
+//     which is the whole reason actual_amount needed a verb and this does not.
+//     The handler still canonicalizes every non-nil key against the trip's
+//     real legs (tripLegKeyExists) and refuses the write outright on a
+//     leg_plan row: a plan slot's city is fixed at creation, as 00070 said.
+//  5. `leg_plan` is deliberately absent: a plan slot is minted at CREATE,
+//     never converted from (or to) an ordinary line.
 func (q *Queries) UpdateExpense(ctx context.Context, arg UpdateExpenseParams) (TripExpense, error) {
 	row := q.db.QueryRow(ctx, updateExpense,
 		arg.Category,
 		arg.Label,
+		arg.ClearLegKey,
+		arg.LegKey,
 		arg.LegacyAmount,
 		arg.PlannedAmount,
 		arg.ActualAmount,
@@ -443,6 +475,7 @@ func (q *Queries) UpdateExpense(ctx context.Context, arg UpdateExpenseParams) (T
 		&i.PlannedAmount,
 		&i.ActualAmount,
 		&i.LegKey,
+		&i.LegPlan,
 	)
 	return i, err
 }

--- a/src/packages/flutter-app/lib/l10n/app_en.arb
+++ b/src/packages/flutter-app/lib/l10n/app_en.arb
@@ -437,6 +437,20 @@
   "budgetEditExpenseTitle": "Edit expense",
   "budgetSetTargetTitle": "Set budget target",
   "budgetCategoryLabel": "Category",
+  "budgetGroupBy": "Group by",
+  "budgetGroupByCategory": "Category",
+  "budgetGroupByCity": "City",
+  "budgetGroupRestOfTrip": "Rest of trip",
+  "budgetCityLabel": "City",
+  "budgetCityNone": "No city",
+  "budgetCityPlanLocked": "This is {city}'s daily plan — its city can't be changed.",
+  "@budgetCityPlanLocked": {
+    "placeholders": {
+      "city": {
+        "type": "String"
+      }
+    }
+  },
   "budgetLabelField": "Label",
   "budgetAmount": "Amount",
   "budgetCurrencyLabel": "Currency",

--- a/src/packages/flutter-app/lib/l10n/app_es.arb
+++ b/src/packages/flutter-app/lib/l10n/app_es.arb
@@ -281,6 +281,20 @@
   "budgetEditExpenseTitle": "Editar gasto",
   "budgetSetTargetTitle": "Fijar objetivo de presupuesto",
   "budgetCategoryLabel": "Categoría",
+  "budgetGroupBy": "Agrupar por",
+  "budgetGroupByCategory": "Categoría",
+  "budgetGroupByCity": "Ciudad",
+  "budgetGroupRestOfTrip": "Resto del viaje",
+  "budgetCityLabel": "Ciudad",
+  "budgetCityNone": "Sin ciudad",
+  "budgetCityPlanLocked": "Este es el plan diario de {city}: no se puede cambiar de ciudad.",
+  "@budgetCityPlanLocked": {
+    "placeholders": {
+      "city": {
+        "type": "String"
+      }
+    }
+  },
   "budgetLabelField": "Etiqueta",
   "budgetAmount": "Importe",
   "budgetCurrencyLabel": "Moneda",

--- a/src/packages/flutter-app/lib/l10n/app_localizations.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations.dart
@@ -1784,6 +1784,48 @@ abstract class AppLocalizations {
   /// **'Category'**
   String get budgetCategoryLabel;
 
+  /// No description provided for @budgetGroupBy.
+  ///
+  /// In en, this message translates to:
+  /// **'Group by'**
+  String get budgetGroupBy;
+
+  /// No description provided for @budgetGroupByCategory.
+  ///
+  /// In en, this message translates to:
+  /// **'Category'**
+  String get budgetGroupByCategory;
+
+  /// No description provided for @budgetGroupByCity.
+  ///
+  /// In en, this message translates to:
+  /// **'City'**
+  String get budgetGroupByCity;
+
+  /// No description provided for @budgetGroupRestOfTrip.
+  ///
+  /// In en, this message translates to:
+  /// **'Rest of trip'**
+  String get budgetGroupRestOfTrip;
+
+  /// No description provided for @budgetCityLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'City'**
+  String get budgetCityLabel;
+
+  /// No description provided for @budgetCityNone.
+  ///
+  /// In en, this message translates to:
+  /// **'No city'**
+  String get budgetCityNone;
+
+  /// No description provided for @budgetCityPlanLocked.
+  ///
+  /// In en, this message translates to:
+  /// **'This is {city}\'s daily plan — its city can\'t be changed.'**
+  String budgetCityPlanLocked(String city);
+
   /// No description provided for @budgetLabelField.
   ///
   /// In en, this message translates to:

--- a/src/packages/flutter-app/lib/l10n/app_localizations_en.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations_en.dart
@@ -908,6 +908,29 @@ class AppLocalizationsEn extends AppLocalizations {
   String get budgetCategoryLabel => 'Category';
 
   @override
+  String get budgetGroupBy => 'Group by';
+
+  @override
+  String get budgetGroupByCategory => 'Category';
+
+  @override
+  String get budgetGroupByCity => 'City';
+
+  @override
+  String get budgetGroupRestOfTrip => 'Rest of trip';
+
+  @override
+  String get budgetCityLabel => 'City';
+
+  @override
+  String get budgetCityNone => 'No city';
+
+  @override
+  String budgetCityPlanLocked(String city) {
+    return 'This is $city\'s daily plan — its city can\'t be changed.';
+  }
+
+  @override
   String get budgetLabelField => 'Label';
 
   @override

--- a/src/packages/flutter-app/lib/l10n/app_localizations_es.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations_es.dart
@@ -917,6 +917,29 @@ class AppLocalizationsEs extends AppLocalizations {
   String get budgetCategoryLabel => 'Categoría';
 
   @override
+  String get budgetGroupBy => 'Agrupar por';
+
+  @override
+  String get budgetGroupByCategory => 'Categoría';
+
+  @override
+  String get budgetGroupByCity => 'Ciudad';
+
+  @override
+  String get budgetGroupRestOfTrip => 'Resto del viaje';
+
+  @override
+  String get budgetCityLabel => 'Ciudad';
+
+  @override
+  String get budgetCityNone => 'Sin ciudad';
+
+  @override
+  String budgetCityPlanLocked(String city) {
+    return 'Este es el plan diario de $city: no se puede cambiar de ciudad.';
+  }
+
+  @override
   String get budgetLabelField => 'Etiqueta';
 
   @override

--- a/src/packages/flutter-app/lib/models/expense.dart
+++ b/src/packages/flutter-app/lib/models/expense.dart
@@ -44,12 +44,21 @@ class Expense {
   @JsonKey(name: 'source_id')
   final String? sourceId;
 
-  /// The city leg this line plans for (migration 00070), or null for every
-  /// other expense — the identity the daily food & drink card finds its own
-  /// line by. Deliberately NOT part of the `auto` contract above: a leg-keyed
-  /// row is the traveler's own plan, so no booking-state change touches it.
+  /// The city leg this money belongs to (migration 00070, generalized by
+  /// 00072), or null when the line isn't filed under a city. The Budget tab's
+  /// spend-per-city grouping key. Deliberately NOT part of the `auto`
+  /// contract above: where a line is filed is the traveler's organization, so
+  /// no booking-state change touches it.
   @JsonKey(name: 'leg_key')
   final String? legKey;
+
+  /// True on the one row that IS this city's per-day plan slot for its
+  /// category (00072) — the identity the daily food & drink card finds its
+  /// own line by. NEVER infer plan-ness from `legKey != null`: since 00072
+  /// any line can carry a city. Defaults false so a cached pre-00072 payload
+  /// reads as "not a plan slot", the safe meaning.
+  @JsonKey(name: 'leg_plan')
+  final bool legPlan;
 
   const Expense({
     required this.id,
@@ -64,6 +73,7 @@ class Expense {
     this.sourceKind,
     this.sourceId,
     this.legKey,
+    this.legPlan = false,
   });
 
   /// What this line was planned at, or null if it never carried a plan.
@@ -109,6 +119,7 @@ class Expense {
         sourceKind: sourceKind,
         sourceId: sourceId,
         legKey: legKey,
+        legPlan: legPlan,
       );
 
   factory Expense.fromJson(Map<String, dynamic> json) =>

--- a/src/packages/flutter-app/lib/models/expense.g.dart
+++ b/src/packages/flutter-app/lib/models/expense.g.dart
@@ -19,6 +19,7 @@ Expense _$ExpenseFromJson(Map<String, dynamic> json) => Expense(
       sourceKind: json['source_kind'] as String?,
       sourceId: json['source_id'] as String?,
       legKey: json['leg_key'] as String?,
+      legPlan: json['leg_plan'] as bool? ?? false,
     );
 
 Map<String, dynamic> _$ExpenseToJson(Expense instance) => <String, dynamic>{
@@ -34,4 +35,5 @@ Map<String, dynamic> _$ExpenseToJson(Expense instance) => <String, dynamic>{
       'source_kind': instance.sourceKind,
       'source_id': instance.sourceId,
       'leg_key': instance.legKey,
+      'leg_plan': instance.legPlan,
     };

--- a/src/packages/flutter-app/lib/providers/budget_provider.dart
+++ b/src/packages/flutter-app/lib/providers/budget_provider.dart
@@ -67,11 +67,17 @@ class ExpenseDraft {
   /// over-budget warning.
   final bool planned;
 
+  /// The city leg the next add will be filed under (00072), or null for "no
+  /// city". A canonical `RenderLeg.Key` (`Rome`, `Rome#2`), never a localized
+  /// label — the same spelling [Expense.legKey] carries.
+  final String? legKey;
+
   const ExpenseDraft({
     this.label = '',
     this.amountText = '',
     this.category = 'general',
     this.planned = true,
+    this.legKey,
   });
 
   ExpenseDraft copyWith({
@@ -79,12 +85,15 @@ class ExpenseDraft {
     String? amountText,
     String? category,
     bool? planned,
+    String? legKey,
+    bool clearLegKey = false,
   }) =>
       ExpenseDraft(
         label: label ?? this.label,
         amountText: amountText ?? this.amountText,
         category: category ?? this.category,
         planned: planned ?? this.planned,
+        legKey: clearLegKey ? null : (legKey ?? this.legKey),
       );
 }
 
@@ -108,16 +117,37 @@ class ExpenseDraftNotifier extends StateNotifier<ExpenseDraft> {
     state = state.copyWith(planned: planned);
   }
 
-  /// After a successful save. Deliberately keeps the category AND the
-  /// planned/paid pick: both are choices, and a traveler entering eight
-  /// estimates before a trip — or logging five purchases during one — should
-  /// state it once, not once per line.
+  /// null = "no city". Empty string is not a value here — the wire's
+  /// ''-clears sentinel belongs to the PATCH path, not the draft.
+  void setLegKey(String? legKey) {
+    if (legKey == state.legKey) return;
+    state = state.copyWith(legKey: legKey, clearLegKey: legKey == null);
+  }
+
+  /// After a successful save. Deliberately keeps the category, the
+  /// planned/paid pick AND the city: all three are choices, and a traveler
+  /// entering eight estimates before a trip — or logging five dinners in
+  /// Rome — should state each once, not once per line.
   void clearText() => setText(label: '', amountText: '');
 }
 
 final expenseDraftProvider =
     StateNotifierProvider.family<ExpenseDraftNotifier, ExpenseDraft, String>(
         (ref, tripId) => ExpenseDraftNotifier());
+
+/// How the Budget tab's receipt is grouped: by expense category (the
+/// original view) or by city leg (spend-per-city, 00072). Neither mode hides
+/// a line — every expense appears in exactly one group either way.
+///
+/// Session-local and keyed by trip, the [DailySpendSettings] lifetime and
+/// rationale: this is a way of *looking* at the receipt, not a property of
+/// the trip, so it survives the constant remounts (tab switches, the chat
+/// panel re-parenting the body) and a page reload starting on Category is
+/// correct.
+enum BudgetGrouping { category, city }
+
+final budgetGroupingProvider = StateProvider.family<BudgetGrouping, String>(
+    (ref, tripId) => BudgetGrouping.category);
 
 // --- daily food & drink suggestion (specs/daily-spend-guide) ----------------
 

--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -6922,6 +6922,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
                                   tripId: trip.id,
                                   canEdit: !_readOnly,
                                   isOffline: _isOffline,
+                                  legChips: derivation.legChips,
                                 ),
                               ),
                             )

--- a/src/packages/flutter-app/lib/services/budget_api_service.dart
+++ b/src/packages/flutter-app/lib/services/budget_api_service.dart
@@ -61,11 +61,17 @@ class BudgetApiService {
   /// semantics. A linked add must stay a payment: the server 400s a plan-only
   /// one rather than guessing.
   ///
-  /// [legKey] binds the line to one city leg (00070) — the daily food & drink
-  /// "Add to plan". That makes the POST an upsert-by-leg: a second tap returns
-  /// the row that already exists (200) instead of filing a duplicate. It is
-  /// mutually exclusive with [sourceKind]; the server 400s a request naming
-  /// both, and 400s a key that is not one of the trip's current legs.
+  /// [legKey] files the line under one city leg (00070/00072) — the
+  /// spend-per-city grouping. Mutually exclusive with [sourceKind]; the
+  /// server 400s a request naming both, and 400s a key that is not one of
+  /// the trip's current legs.
+  ///
+  /// [legPlan] marks the add as that city's PLAN SLOT (requires [legKey]) —
+  /// the daily food & drink "Add to plan". It is what makes the POST an
+  /// upsert-by-leg: a second tap returns the row that already exists (200)
+  /// instead of filing a duplicate. An ordinary city-tagged add (the picker)
+  /// leaves it false and always creates. Guarded `if (legPlan)` so a plain
+  /// add's body stays byte-identical to before.
   Future<Expense> addExpense(String tripId,
       {required String category,
       required String label,
@@ -73,7 +79,8 @@ class BudgetApiService {
       bool planned = false,
       String? sourceKind,
       String? sourceId,
-      String? legKey}) async {
+      String? legKey,
+      bool legPlan = false}) async {
     final res = await apiClient.httpClient.post(
       Uri.parse('${apiClient.baseUrl}/trips/$tripId/budget/expenses'),
       headers: apiClient.jsonHeaders(json: true),
@@ -84,6 +91,7 @@ class BudgetApiService {
         if (sourceKind != null) 'source_kind': sourceKind,
         if (sourceId != null) 'source_id': sourceId,
         if (legKey != null) 'leg_key': legKey,
+        if (legPlan) 'leg_plan': true,
       }),
     );
     if (res.statusCode == 201 || res.statusCode == 200) {
@@ -134,8 +142,13 @@ class BudgetApiService {
   }
 
   /// Partial update — pass only the fields to change (category / label /
-  /// planned_amount / amount / position). It cannot clear a plan: that is the
-  /// 00067 contract, not an oversight.
+  /// planned_amount / amount / position / leg_key). It cannot clear a plan:
+  /// that is the 00067 contract, not an oversight.
+  ///
+  /// `'leg_key': 'Rome'` re-files the line under that city; `'leg_key': ''`
+  /// clears the tag (empty-means-clear is the PATCH sentinel — a null decodes
+  /// as "omitted, keep" like every other field). The server 409s a leg_key
+  /// change on a plan-slot row ([Expense.legPlan]) — a plan's city is fixed.
   Future<Expense> updateExpense(
       String tripId, String expenseId, Map<String, dynamic> body) async {
     final res = await apiClient.httpClient.patch(

--- a/src/packages/flutter-app/lib/widgets/budget_section.dart
+++ b/src/packages/flutter-app/lib/widgets/budget_section.dart
@@ -12,6 +12,7 @@ import '../providers/budget_provider.dart';
 import '../theme/spacing.dart';
 import '../utils/daily_spend.dart';
 import '../utils/money_format.dart';
+import '../utils/trip_legs.dart';
 import 'budget_amounts.dart';
 import 'budget_categories.dart';
 import 'budget_target_dialog.dart';
@@ -34,11 +35,19 @@ class BudgetSection extends ConsumerStatefulWidget {
   final bool canEdit;
   final bool isOffline;
 
+  /// The trip's city legs in itinerary order — the screen derivation's
+  /// `legChips`, the same list the map strip renders. Required, not defaulted:
+  /// an empty default would let the mount site silently lose the whole
+  /// spend-per-city view. Keys are canonical `RenderLeg.Key` spellings
+  /// (`Rome`, `Rome#2`); labels/qualifiers are display text.
+  final List<({String key, String label, String? qualifier})> legChips;
+
   const BudgetSection({
     super.key,
     required this.tripId,
     required this.canEdit,
     required this.isOffline,
+    required this.legChips,
   });
 
   @override
@@ -49,20 +58,23 @@ class BudgetSection extends ConsumerStatefulWidget {
 // with the booked-flip expense prompt; the planned-vs-paid row vocabulary
 // lives in budget_amounts.dart.
 
-/// What the edit dialog came back with. A record of the four editable things,
+/// What the edit dialog came back with. A record of the editable things,
 /// so the caller can tell "left empty" (null) from "set to zero" — a plan of
-/// zero is real data.
+/// zero is real data. [legKey] null means "no city" (00072); the caller
+/// compares it against the expense to decide whether to PATCH at all.
 class _ExpenseEdit {
   final String category;
   final String label;
   final double? planned;
   final double? paid;
+  final String? legKey;
 
   const _ExpenseEdit({
     required this.category,
     required this.label,
     required this.planned,
     required this.paid,
+    required this.legKey,
   });
 }
 
@@ -288,6 +300,11 @@ class _BudgetSectionState extends ConsumerState<BudgetSection> {
     final draftNow = ref.read(key);
     final category = draftNow.category;
     final planned = draftNow.planned;
+    // Same stale-key resolution the picker renders with: a draft city the
+    // trip no longer has posts as "no city", never as a 400.
+    final legKey = _cityOptions.any((c) => c.key == draftNow.legKey)
+        ? draftNow.legKey
+        : null;
     // Captured before the await: this row can be unmounted mid-save (tab away
     // while the POST is in flight), and by the time it returns the controllers
     // are disposed and `ref` throws. The draft outlives both, so clearing it
@@ -301,6 +318,7 @@ class _BudgetSectionState extends ConsumerState<BudgetSection> {
             label: label,
             amount: amount,
             planned: planned,
+            legKey: legKey,
           );
       if (mounted) {
         _labelController.clear();
@@ -329,6 +347,16 @@ class _BudgetSectionState extends ConsumerState<BudgetSection> {
     final paidController = TextEditingController(
         text: paidBefore == null ? '' : _trimAmount(paidBefore));
     var category = normalizeExpenseCategory(expense.category);
+    final cityOptions = _cityOptions;
+    // Resolved against the CURRENT legs: a key the trip no longer renders
+    // seeds as "No city" (and, unchanged, never posts).
+    final legKeyBefore =
+        cityOptions.any((c) => c.key == expense.legKey) ? expense.legKey : null;
+    var legKey = legKeyBefore;
+    var planCityLabel = expense.legKey ?? '';
+    for (final c in cityOptions) {
+      if (c.key == expense.legKey) planCityLabel = c.label;
+    }
     final result = await showDialog<_ExpenseEdit>(
       context: context,
       builder: (ctx) => StatefulBuilder(
@@ -353,6 +381,38 @@ class _BudgetSectionState extends ConsumerState<BudgetSection> {
                 autofocus: true,
                 decoration: InputDecoration(labelText: l10n.budgetLabelField),
               ),
+              if (cityOptions.isNotEmpty) ...[
+                // Disabled-but-present on a plan row, not absent: "this line
+                // is Rome's daily plan" is exactly what the traveler needs to
+                // know when the control won't move (the server 409s the write
+                // anyway — a plan slot's city is fixed, 00072).
+                DropdownButtonFormField<String?>(
+                  key: const Key('budget-edit-city'),
+                  initialValue: legKey,
+                  decoration:
+                      InputDecoration(labelText: l10n.budgetCityLabel),
+                  onChanged: expense.legPlan
+                      ? null
+                      : (v) => setLocal(() => legKey = v),
+                  items: [
+                    DropdownMenuItem<String?>(
+                        value: null, child: Text(l10n.budgetCityNone)),
+                    for (final c in cityOptions)
+                      DropdownMenuItem<String?>(
+                          value: c.key,
+                          child: Text(c.qualifier == null
+                              ? c.label
+                              : '${c.label} · ${c.qualifier}')),
+                  ],
+                ),
+                if (expense.legPlan) ...[
+                  const SizedBox(height: AppSpacing.xs),
+                  Text(
+                    l10n.budgetCityPlanLocked(planCityLabel),
+                    style: Theme.of(ctx).textTheme.bodySmall,
+                  ),
+                ],
+              ],
               TextField(
                 controller: plannedController,
                 keyboardType:
@@ -399,7 +459,8 @@ class _BudgetSectionState extends ConsumerState<BudgetSection> {
                     category: category,
                     label: label,
                     planned: planned,
-                    paid: paid));
+                    paid: paid,
+                    legKey: legKey));
               },
               child: Text(l10n.commonSave),
             ),
@@ -419,6 +480,12 @@ class _BudgetSectionState extends ConsumerState<BudgetSection> {
         'label': result.label,
         if (result.planned != null && result.planned != plannedBefore)
           'planned_amount': result.planned,
+        // Only on change, and against the RESOLVED before-value, so opening
+        // and saving an untouched dialog sends no leg_key at all. null →
+        // the wire's ''-clears sentinel (see updateExpense's doc); a plan
+        // row's dropdown is disabled, so this can never fire for one.
+        if (result.legKey != legKeyBefore)
+          'leg_key': result.legKey ?? '',
       };
       await api.updateExpense(widget.tripId, expense.id, patch);
       if (result.paid != paidBefore) {
@@ -485,6 +552,7 @@ class _BudgetSectionState extends ConsumerState<BudgetSection> {
           ),
         ] else ...[
           _buildHeadline(theme, budget),
+          if (_cityOptions.isNotEmpty) _buildGroupControl(theme),
           ..._buildGroups(theme, expenses, currency),
           _buildTotals(theme, budget, expenses),
         ],
@@ -498,7 +566,7 @@ class _BudgetSectionState extends ConsumerState<BudgetSection> {
             isOffline: widget.isOffline,
             onAdd: _addDailySpend,
           ),
-          _buildModeControl(theme),
+          _buildAddOptions(theme),
           _buildAddRow(theme),
         ],
       ],
@@ -522,6 +590,9 @@ class _BudgetSectionState extends ConsumerState<BudgetSection> {
           amount: total,
           planned: true,
           legKey: city.legKey,
+          // The flag, not the mere presence of legKey, is what makes this the
+          // city's plan slot since 00072.
+          legPlan: true,
         ));
     if (!mounted) return;
     messenger.showSnackBar(
@@ -703,7 +774,122 @@ class _BudgetSectionState extends ConsumerState<BudgetSection> {
     );
   }
 
+  /// The pickable cities: the trip's legs minus the "Other places" run, which
+  /// names no city. Filtered on the KEY, never the label — the label is
+  /// localized, the key is canonical.
+  List<({String key, String label, String? qualifier})> get _cityOptions => [
+        for (final c in widget.legChips)
+          if (c.key != kOtherPlacesLabel) c
+      ];
+
+  /// The Group-by toggle. Labelled, and above the list rather than below it,
+  /// for the reason [_buildAddOptions] documents in reverse: an unlabelled
+  /// pill sitting BELOW the receipt was read as a filter over the list above.
+  /// This one really does act on the list, so it sits at its head and says
+  /// what it does. It never hides a line — every expense appears in exactly
+  /// one group in both modes, and the group subtotals sum to the same total
+  /// either way (the property the widget test pins).
+  ///
+  /// Shown to viewers too, unlike every other control here: it is a way of
+  /// reading the receipt, not a write.
+  Widget _buildGroupControl(ThemeData theme) {
+    return Consumer(builder: (context, ref, _) {
+      final grouping = ref.watch(budgetGroupingProvider(widget.tripId));
+      final l10n = context.l10n;
+      return Padding(
+        padding: const EdgeInsets.only(top: AppSpacing.sm),
+        child: Wrap(
+          crossAxisAlignment: WrapCrossAlignment.center,
+          spacing: AppSpacing.sm,
+          runSpacing: AppSpacing.xs,
+          children: [
+            Text(
+              l10n.budgetGroupBy,
+              style: theme.textTheme.labelMedium
+                  ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+            ),
+            SegmentedButton<BudgetGrouping>(
+              key: const Key('budget-group-by'),
+              showSelectedIcon: false,
+              style: ButtonStyle(
+                visualDensity: VisualDensity.compact,
+                textStyle: WidgetStatePropertyAll(theme.textTheme.labelMedium),
+              ),
+              segments: [
+                ButtonSegment(
+                  value: BudgetGrouping.category,
+                  label: Text(l10n.budgetGroupByCategory),
+                ),
+                ButtonSegment(
+                  value: BudgetGrouping.city,
+                  label: Text(l10n.budgetGroupByCity),
+                ),
+              ],
+              selected: {grouping},
+              onSelectionChanged: (picked) => ref
+                  .read(budgetGroupingProvider(widget.tripId).notifier)
+                  .state = picked.first,
+            ),
+          ],
+        ),
+      );
+    });
+  }
+
   List<Widget> _buildGroups(
+          ThemeData theme, List<Expense> expenses, String currency) =>
+      ref.watch(budgetGroupingProvider(widget.tripId)) == BudgetGrouping.city
+          ? _buildCityGroups(theme, expenses, currency)
+          : _buildCategoryGroups(theme, expenses, currency);
+
+  /// One group header: icon + label + the hollow "still has planned money"
+  /// mark + ONE subtotal — the projected one, which is the only subtotal that
+  /// stays continuous across a trip (it equals the plan before departure and
+  /// the spend after it). A second column here would turn the section into a
+  /// spreadsheet; the hollow mark says "not all of this has left yet" without
+  /// spending a word or a line. Shared by both groupings so their subtotals
+  /// cannot diverge.
+  Widget _buildGroupHeader(ThemeData theme,
+      {required Key key,
+      required IconData icon,
+      required String label,
+      required List<Expense> group,
+      required String currency}) {
+    final subtotal = groupProjectedSubtotal(group);
+    final hasPlanned = groupHasPlanned(group);
+    return Padding(
+      key: key,
+      padding: const EdgeInsets.only(top: AppSpacing.sm, bottom: AppSpacing.xs),
+      child: Row(
+        children: [
+          Icon(icon, size: 16, color: theme.colorScheme.onSurfaceVariant),
+          const SizedBox(width: AppSpacing.xs),
+          Expanded(
+            child: Text(
+              label,
+              style: theme.textTheme.labelLarge
+                  ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+            ),
+          ),
+          if (hasPlanned) ...[
+            Tooltip(
+              message: context.l10n.budgetPlanGroupHasPlanned,
+              child: Icon(Icons.radio_button_unchecked,
+                  size: 12, color: theme.colorScheme.onSurfaceVariant),
+            ),
+            const SizedBox(width: AppSpacing.xs),
+          ],
+          Text(
+            formatMoney(subtotal, currency),
+            style: theme.textTheme.labelLarge
+                ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+          ),
+        ],
+      ),
+    );
+  }
+
+  List<Widget> _buildCategoryGroups(
       ThemeData theme, List<Expense> expenses, String currency) {
     final byCategory = <String, List<Expense>>{};
     for (final e in expenses) {
@@ -713,44 +899,12 @@ class _BudgetSectionState extends ConsumerState<BudgetSection> {
     for (final cat in kExpenseCategories) {
       final group = byCategory[cat];
       if (group == null || group.isEmpty) continue;
-      // ONE number per group — the projected one, which is the only subtotal
-      // that stays continuous across a trip (it equals the plan before
-      // departure and the spend after it). A second column here would turn
-      // the section into a spreadsheet; the hollow mark says "not all of this
-      // has left yet" without spending a word or a line.
-      final subtotal = groupProjectedSubtotal(group);
-      final hasPlanned = groupHasPlanned(group);
-      widgets.add(Padding(
-        padding:
-            const EdgeInsets.only(top: AppSpacing.sm, bottom: AppSpacing.xs),
-        child: Row(
-          children: [
-            Icon(kExpenseCategoryIcons[cat],
-                size: 16, color: theme.colorScheme.onSurfaceVariant),
-            const SizedBox(width: AppSpacing.xs),
-            Expanded(
-              child: Text(
-                expenseCategoryLabel(context.l10n, cat),
-                style: theme.textTheme.labelLarge
-                    ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
-              ),
-            ),
-            if (hasPlanned) ...[
-              Tooltip(
-                message: context.l10n.budgetPlanGroupHasPlanned,
-                child: Icon(Icons.radio_button_unchecked,
-                    size: 12, color: theme.colorScheme.onSurfaceVariant),
-              ),
-              const SizedBox(width: AppSpacing.xs),
-            ],
-            Text(
-              formatMoney(subtotal, currency),
-              style: theme.textTheme.labelLarge
-                  ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
-            ),
-          ],
-        ),
-      ));
+      widgets.add(_buildGroupHeader(theme,
+          key: Key('budget-group-$cat'),
+          icon: kExpenseCategoryIcons[cat] ?? Icons.receipt_long_outlined,
+          label: expenseCategoryLabel(context.l10n, cat),
+          group: group,
+          currency: currency));
       for (final e in group) {
         widgets.add(_buildRow(theme, e, currency));
       }
@@ -758,7 +912,59 @@ class _BudgetSectionState extends ConsumerState<BudgetSection> {
     return widgets;
   }
 
-  Widget _buildRow(ThemeData theme, Expense expense, String currency) {
+  /// The spend-per-city view (00072): the same lines bucketed by
+  /// [Expense.legKey], in the trip's own leg order, with everything unfiled —
+  /// no key, or a key the trip no longer renders — under a trailing "Rest of
+  /// trip". A line whose city is gone falls there rather than vanishing or
+  /// minting a ghost header: 00070's snapshot promise, rendered. Rows keep a
+  /// small category icon because the header no longer says what kind of spend
+  /// a line is.
+  List<Widget> _buildCityGroups(
+      ThemeData theme, List<Expense> expenses, String currency) {
+    final cities = _cityOptions;
+    final known = {for (final c in cities) c.key};
+    final byLeg = <String, List<Expense>>{};
+    final rest = <Expense>[];
+    for (final e in expenses) {
+      final key = e.legKey;
+      if (key != null && known.contains(key)) {
+        byLeg.putIfAbsent(key, () => []).add(e);
+      } else {
+        rest.add(e);
+      }
+    }
+    final widgets = <Widget>[];
+    void emit(Key key, String label, List<Expense> group) {
+      widgets.add(_buildGroupHeader(theme,
+          key: key,
+          icon: Icons.place_outlined,
+          label: label,
+          group: group,
+          currency: currency));
+      for (final e in group) {
+        widgets.add(_buildRow(theme, e, currency, showCategoryIcon: true));
+      }
+    }
+
+    for (final c in cities) {
+      final group = byLeg[c.key];
+      if (group == null || group.isEmpty) continue;
+      final label =
+          c.qualifier == null ? c.label : '${c.label} · ${c.qualifier}';
+      emit(Key('budget-group-city-${c.key}'), label, group);
+    }
+    if (rest.isNotEmpty) {
+      emit(const Key('budget-group-rest'), context.l10n.budgetGroupRestOfTrip,
+          rest);
+    }
+    return widgets;
+  }
+
+  /// [showCategoryIcon] restores the category signal in the city grouping,
+  /// where the header no longer carries it. Defaults false so the category
+  /// view renders byte-identically to before the split.
+  Widget _buildRow(ThemeData theme, Expense expense, String currency,
+      {bool showCategoryIcon = false}) {
     final l10n = context.l10n;
     final paid = expenseIsPaid(expense);
     // A booking-created line is a mirror of its booking: its payment is the
@@ -780,6 +986,15 @@ class _BudgetSectionState extends ConsumerState<BudgetSection> {
                 ? null
                 : () => paid ? _unpay(expense) : _markPaid(expense, currency),
           ),
+          if (showCategoryIcon) ...[
+            Icon(
+                kExpenseCategoryIcons[
+                        normalizeExpenseCategory(expense.category)] ??
+                    Icons.receipt_long_outlined,
+                size: 14,
+                color: theme.colorScheme.onSurfaceVariant),
+            const SizedBox(width: AppSpacing.xs),
+          ],
           Expanded(
             child: Text(
               expense.label,
@@ -951,7 +1166,13 @@ class _BudgetSectionState extends ConsumerState<BudgetSection> {
   /// The pick is read from the draft, so it survives the remount that changing
   /// header tab or opening the chat panel causes — a choice, like the category
   /// beside it.
-  Widget _buildModeControl(ThemeData theme) {
+  ///
+  /// Since 00072 the line also carries the CITY picker — deliberately here
+  /// and not in [_buildAddRow]: that row is measured against
+  /// [_addRowFixedWidth] and a third fixed control would move every one of
+  /// the 8-widths × 2-locales assertions, while this line is a [Wrap] with
+  /// slack, right at every width and locale by construction.
+  Widget _buildAddOptions(ThemeData theme) {
     return Consumer(builder: (context, ref, _) {
       final planned = ref
           .watch(expenseDraftProvider(widget.tripId).select((d) => d.planned));
@@ -1004,6 +1225,71 @@ class _BudgetSectionState extends ConsumerState<BudgetSection> {
                       .read(expenseDraftProvider(widget.tripId).notifier)
                       .setPlanned(picked.first),
             ),
+            if (_cityOptions.isNotEmpty) _buildCityPicker(theme),
+          ],
+        ),
+      );
+    });
+  }
+
+  /// The add row's city pick (00072): which leg the next line is filed under.
+  /// A popup menu, not a DropdownButton, for [_buildCategoryTrigger]'s reason
+  /// (a dropdown's menu is constrained to its trigger's width) — but with a
+  /// TEXT trigger, unlike the category's icon: this control has no width
+  /// pressure on its Wrap line, and an icon cannot say "Rome".
+  ///
+  /// The selected key is resolved against [_cityOptions] before rendering, so
+  /// a stale draft key — the trip lost a city since it was picked — displays
+  /// and posts as "No city" instead of a 400.
+  Widget _buildCityPicker(ThemeData theme) {
+    return Consumer(builder: (context, ref, _) {
+      final draftKey = ref
+          .watch(expenseDraftProvider(widget.tripId).select((d) => d.legKey));
+      final l10n = context.l10n;
+      final options = _cityOptions;
+      ({String key, String label, String? qualifier})? selected;
+      for (final c in options) {
+        if (c.key == draftKey) selected = c;
+      }
+      final muted = theme.colorScheme.onSurfaceVariant;
+      return PopupMenuButton<String>(
+        key: const Key('budget-add-city'),
+        tooltip: l10n.budgetCityLabel,
+        enabled: !widget.isOffline,
+        // '' is the menu's "No city" value (a PopupMenuItem value can't be
+        // null); it reaches the draft as null via setLegKey.
+        onSelected: (v) => ref
+            .read(expenseDraftProvider(widget.tripId).notifier)
+            .setLegKey(v.isEmpty ? null : v),
+        itemBuilder: (_) => [
+          CheckedPopupMenuItem<String>(
+            value: '',
+            checked: selected == null,
+            child: Text(l10n.budgetCityNone),
+          ),
+          for (final c in options)
+            CheckedPopupMenuItem<String>(
+              value: c.key,
+              checked: c.key == selected?.key,
+              child: Text(c.qualifier == null
+                  ? c.label
+                  : '${c.label} · ${c.qualifier}'),
+            ),
+        ],
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(Icons.place_outlined, size: 18, color: muted),
+            const SizedBox(width: 2),
+            Text(
+              selected == null
+                  ? l10n.budgetCityNone
+                  : (selected.qualifier == null
+                      ? selected.label
+                      : '${selected.label} · ${selected.qualifier}'),
+              style: theme.textTheme.labelMedium?.copyWith(color: muted),
+            ),
+            Icon(Icons.arrow_drop_down, size: 18, color: muted),
           ],
         ),
       );

--- a/src/packages/flutter-app/lib/widgets/daily_spend_section.dart
+++ b/src/packages/flutter-app/lib/widgets/daily_spend_section.dart
@@ -45,9 +45,14 @@ class DailySpendSection extends ConsumerWidget {
   /// The line this city already has, or null. Found by IDENTITY — the leg key
   /// the server stamped (00070) — never by matching the label this widget
   /// generated, which is how a renamed line would silently duplicate itself.
+  /// `legPlan` is load-bearing since 00072: a manually tagged Rome food line
+  /// carries the same legKey and category, and without the flag this card
+  /// would adopt the traveler's dinner as its plan.
   Expense? _planFor(DailySpendCity city) {
     for (final e in expenses) {
-      if (e.legKey == city.legKey && e.category == kDailySpendCategory) {
+      if (e.legPlan &&
+          e.legKey == city.legKey &&
+          e.category == kDailySpendCategory) {
         return e;
       }
     }

--- a/src/packages/flutter-app/test/budget_api_service_test.dart
+++ b/src/packages/flutter-app/test/budget_api_service_test.dart
@@ -20,6 +20,8 @@ String _expenseJson({
   double? planned,
   double? actual,
   bool purchased = false,
+  String? legKey,
+  bool legPlan = false,
 }) =>
     jsonEncode({
       'id': 'e1',
@@ -33,6 +35,8 @@ String _expenseJson({
       'auto': false,
       'source_kind': null,
       'source_id': null,
+      'leg_key': legKey,
+      'leg_plan': legPlan,
     });
 
 void main() {
@@ -207,6 +211,7 @@ void main() {
             'source_kind': null,
             'source_id': null,
             'leg_key': 'Lisbon',
+            'leg_plan': true,
           }),
           201,
           headers: {'content-type': 'application/json'});
@@ -217,18 +222,47 @@ void main() {
         label: 'Food & drink · Lisbon',
         amount: 400,
         planned: true,
-        legKey: 'Lisbon');
+        legKey: 'Lisbon',
+        legPlan: true);
 
     expect(captured.url.path, '/api/v1/trips/t1/budget/expenses');
     final body = jsonDecode(captured.body) as Map<String, dynamic>;
     expect(body['leg_key'], 'Lisbon');
+    // The slot marker (00072): without it the server files an ordinary tagged
+    // line the card could never find, and a second tap duplicates.
+    expect(body['leg_plan'], true);
     expect(body['planned_amount'], 400);
     expect(body['category'], 'food');
     // A city plan is never a booking mirror — sending a source link alongside
     // it is a 400 server-side, so it must not leak into this call.
     expect(body.containsKey('source_kind'), isFalse);
     expect(expense.legKey, 'Lisbon');
+    expect(expense.legPlan, isTrue);
     expect(expense.auto, isFalse);
+  });
+
+  test('a city-tagged add sends leg_key and NO leg_plan', () async {
+    late http.Request captured;
+    final service = _service(MockClient((request) async {
+      captured = request;
+      return http.Response(_expenseJson(planned: 30, legKey: 'Rome'), 201,
+          headers: {'content-type': 'application/json'});
+    }));
+
+    // Exactly the call the add row's city picker arms (00072).
+    final expense = await service.addExpense('t1',
+        category: 'food',
+        label: 'Dinner',
+        amount: 30,
+        planned: true,
+        legKey: 'Rome');
+
+    final body = jsonDecode(captured.body) as Map<String, dynamic>;
+    expect(body['leg_key'], 'Rome');
+    // Absent, not false: the flag is guarded so an ordinary add's body can
+    // never accidentally claim a plan slot.
+    expect(body.containsKey('leg_plan'), isFalse);
+    expect(expense.legPlan, isFalse);
   });
 
   test('a plain add sends no leg_key at all', () async {
@@ -244,6 +278,26 @@ void main() {
 
     final body = jsonDecode(captured.body) as Map<String, dynamic>;
     expect(body.containsKey('leg_key'), isFalse);
+    expect(body.containsKey('leg_plan'), isFalse);
+  });
+
+  test('re-filing PATCHes the key and clearing sends an empty string, never null',
+      () async {
+    final bodies = <Map<String, dynamic>>[];
+    final service = _service(MockClient((request) async {
+      bodies.add(jsonDecode(request.body) as Map<String, dynamic>);
+      return http.Response(_expenseJson(planned: 30, legKey: 'Rome'), 200,
+          headers: {'content-type': 'application/json'});
+    }));
+
+    await service.updateExpense('t1', 'e1', {'leg_key': 'Rome'});
+    // The PATCH sentinel (00072): '' clears; a null would decode server-side
+    // as "omitted, keep" like every other field.
+    await service.updateExpense('t1', 'e1', {'leg_key': ''});
+
+    expect(bodies[0]['leg_key'], 'Rome');
+    expect(bodies[1]['leg_key'], '');
+    expect(bodies[1]['leg_key'], isNot(isNull));
   });
 
   test('the daily-spend read hits its own path and passes the tier through',

--- a/src/packages/flutter-app/test/budget_section_test.dart
+++ b/src/packages/flutter-app/test/budget_section_test.dart
@@ -94,7 +94,8 @@ class _FakeBudgetApiService extends BudgetApiService {
       bool planned = false,
       String? sourceKind,
       String? sourceId,
-      String? legKey}) async {
+      String? legKey,
+      bool legPlan = false}) async {
     if (addGate != null) await addGate!.future;
     addCount++;
     adds.add({
@@ -103,13 +104,16 @@ class _FakeBudgetApiService extends BudgetApiService {
       'amount': amount,
       'planned': planned,
       if (legKey != null) 'leg_key': legKey,
+      if (legPlan) 'leg_plan': true,
     });
-    // Upsert-by-leg, mirrored from the server (00070): a second add for a city
-    // already in the plan returns the existing row untouched. Mirroring it here
-    // is what makes "a double tap can't duplicate" a real widget assertion.
-    if (legKey != null) {
+    // Upsert-by-leg, mirrored from the server (00070, narrowed by 00072 to
+    // plan-slot adds — an ordinary city-tagged add always creates): a second
+    // plan add for a city already in the plan returns the existing row
+    // untouched. Mirroring it here is what makes "a double tap can't
+    // duplicate" a real widget assertion.
+    if (legKey != null && legPlan) {
       final existing = expenses.indexWhere(
-          (e) => e.legKey == legKey && e.category == category);
+          (e) => e.legPlan && e.legKey == legKey && e.category == category);
       if (existing >= 0) return expenses[existing];
     }
     final e = Expense(
@@ -123,7 +127,8 @@ class _FakeBudgetApiService extends BudgetApiService {
         auto: sourceKind != null, // server rule mirrored
         sourceKind: sourceKind,
         sourceId: sourceId,
-        legKey: legKey);
+        legKey: legKey,
+        legPlan: legPlan);
     expenses.add(e);
     return e;
   }
@@ -255,6 +260,9 @@ Future<_FakeBudgetApiService> _pump(
   bool isOffline = false,
   Locale? locale,
   DailySpendGuide? dailySpend,
+  // The trip's city legs (00072). Defaults empty so every pre-existing case
+  // renders exactly the tab it rendered before — no toggle, no picker.
+  List<({String key, String label, String? qualifier})> legChips = const [],
   // Width the section is laid out at, when a case is about the add row's
   // shape. Applied only when passed, so every existing call stays
   // byte-identical (and keeps the full surface width it always had).
@@ -282,7 +290,10 @@ Future<_FakeBudgetApiService> _pump(
             width,
             SingleChildScrollView(
               child: BudgetSection(
-                  tripId: 't1', canEdit: canEdit, isOffline: isOffline),
+                  tripId: 't1',
+                  canEdit: canEdit,
+                  isOffline: isOffline,
+                  legChips: legChips),
             ),
           ),
         ),
@@ -299,7 +310,8 @@ Future<_FakeBudgetApiService> _pump(
 /// banner does to that widget reduces to this.
 class _Mountable extends StatefulWidget {
   final String tripId;
-  const _Mountable({super.key, this.tripId = 't1'});
+  final List<({String key, String label, String? qualifier})> legChips;
+  const _Mountable({super.key, this.tripId = 't1', this.legChips = const []});
 
   @override
   State<_Mountable> createState() => _MountableState();
@@ -321,7 +333,11 @@ class _MountableState extends State<_Mountable> {
               child: const Text('toggle'),
             ),
             if (_shown)
-              BudgetSection(tripId: _tripId, canEdit: true, isOffline: false),
+              BudgetSection(
+                  tripId: _tripId,
+                  canEdit: true,
+                  isOffline: false,
+                  legChips: widget.legChips),
           ],
         ),
       );
@@ -334,6 +350,7 @@ Future<_FakeBudgetApiService> _pumpMountable(
   WidgetTester tester,
   List<Expense> expenses, {
   List<String> tripIds = const ['t1'],
+  List<({String key, String label, String? qualifier})> legChips = const [],
   GlobalKey<_MountableState>? hostKey,
 }) async {
   final fake = _FakeBudgetApiService(expenses);
@@ -349,7 +366,9 @@ Future<_FakeBudgetApiService> _pumpMountable(
               for (final id in tripIds)
                 Expanded(
                   child: _Mountable(
-                      key: id == tripIds.first ? hostKey : null, tripId: id),
+                      key: id == tripIds.first ? hostKey : null,
+                      tripId: id,
+                      legChips: legChips),
                 ),
             ],
           ),
@@ -936,7 +955,10 @@ void main() {
             home: const Scaffold(
               body: SingleChildScrollView(
                 child: BudgetSection(
-                    tripId: 't1', canEdit: true, isOffline: false),
+                    tripId: 't1',
+                    canEdit: true,
+                    isOffline: false,
+                    legChips: []),
               ),
             ),
           ),
@@ -1270,6 +1292,9 @@ void main() {
         'amount': 200.0,
         'planned': true,
         'leg_key': 'Lisbon',
+        // The slot marker (00072): the flag, not the key, is what makes the
+        // POST an upsert.
+        'leg_plan': true,
       });
       // Planned, not paid: the money hasn't left yet, so "Total spent" must not
       // move while "Total planned" does.
@@ -1290,6 +1315,7 @@ void main() {
         plannedAmount: 260, // the traveler edited it up from 200
         purchased: false,
         legKey: 'Lisbon',
+        legPlan: true, // the slot flag, not the key, is the identity (00072)
       );
       await _pump(tester, [planned], targetAmount: 2000, dailySpend: guide);
 
@@ -1332,6 +1358,26 @@ void main() {
       expect(find.byKey(const ValueKey('dailySpendInPlan_Lisbon')), findsNothing);
     });
 
+    testWidgets('a manually tagged food line is not the plan', (tester) async {
+      // Since 00072 an ordinary dinner can carry the SAME legKey and
+      // category as the plan slot — only legPlan separates them. Without the
+      // flag in _planFor the card would adopt the traveler's dinner as its
+      // plan and never offer the button.
+      const dinner = Expense(
+        id: 'e1',
+        category: 'food',
+        label: 'Dinner at Ramiro',
+        amount: 60,
+        plannedAmount: 60,
+        purchased: false,
+        legKey: 'Lisbon',
+      );
+      await _pump(tester, [dinner], targetAmount: 2000, dailySpend: guide);
+
+      expect(find.byKey(const ValueKey('dailySpendAdd_Lisbon')), findsOneWidget);
+      expect(find.byKey(const ValueKey('dailySpendInPlan_Lisbon')), findsNothing);
+    });
+
     testWidgets('fits a 360px phone in Spanish', (tester) async {
       tester.view.physicalSize = const Size(360, 900);
       tester.view.devicePixelRatio = 1.0;
@@ -1344,6 +1390,227 @@ void main() {
       expect(find.text('Lisbon · 4 noches'), findsOneWidget);
       expect(find.text('Añadir al plan'), findsNWidgets(2));
       expect(tester.takeException(), isNull);
+    });
+  });
+
+  group('spend per city', () {
+    const legs = <({String key, String label, String? qualifier})>[
+      (key: 'Rome', label: 'Rome', qualifier: null),
+      (key: 'Lisbon', label: 'Lisbon', qualifier: null),
+      (key: 'Rome#2', label: 'Rome', qualifier: '2nd visit'),
+    ];
+
+    /// A receipt spanning tagged, untagged and stale-tagged lines.
+    List<Expense> mixed() => [
+          const Expense(
+              id: 'a',
+              category: 'lodging',
+              label: 'Hotel Roma',
+              amount: 400,
+              actualAmount: 400,
+              purchased: true,
+              legKey: 'Rome'),
+          const Expense(
+              id: 'b',
+              category: 'food',
+              label: 'Dinner at Ramiro',
+              amount: 60,
+              actualAmount: 60,
+              purchased: true,
+              legKey: 'Lisbon'),
+          _exp('c', 'flights', 'JFK→FCO', 700), // untagged
+          const Expense(
+              id: 'd',
+              category: 'food',
+              label: 'Old plan',
+              amount: 90,
+              plannedAmount: 90,
+              purchased: false,
+              legKey: 'Naples'), // a city the trip no longer renders
+        ];
+
+    testWidgets('the toggle exists only when the trip has city legs',
+        (tester) async {
+      await _pump(tester, mixed(), targetAmount: 2000);
+      expect(find.byKey(const Key('budget-group-by')), findsNothing);
+      expect(find.byKey(const Key('budget-add-city')), findsNothing);
+
+      await _pump(tester, mixed(), targetAmount: 2000, legChips: legs);
+      expect(find.byKey(const Key('budget-group-by')), findsOneWidget);
+      expect(find.byKey(const Key('budget-add-city')), findsOneWidget);
+    });
+
+    testWidgets(
+        'city mode groups by leg in trip order, banks the rest, and hides nothing',
+        (tester) async {
+      await _pump(tester, mixed(), targetAmount: 2000, legChips: legs);
+
+      // Category mode first: every line renders once.
+      expect(find.byKey(const ValueKey('a')), findsOneWidget);
+      expect(find.byKey(const ValueKey('d')), findsOneWidget);
+
+      await tester.tap(find.text('City'));
+      await tester.pumpAndSettle();
+
+      // The same four lines — the toggle is a grouping, never a filter.
+      for (final id in ['a', 'b', 'c', 'd']) {
+        expect(find.byKey(ValueKey(id)), findsOneWidget,
+            reason: 'line $id must survive the regroup');
+      }
+      // One header per city that HAS lines, in leg order; empty legs
+      // (Rome#2) get no header; the untagged flight and the stale Naples
+      // plan share the trailing Rest of trip.
+      expect(find.byKey(const Key('budget-group-city-Rome')), findsOneWidget);
+      expect(find.byKey(const Key('budget-group-city-Lisbon')), findsOneWidget);
+      expect(find.byKey(const Key('budget-group-city-Rome#2')), findsNothing);
+      expect(find.byKey(const Key('budget-group-rest')), findsOneWidget);
+      expect(find.text('Rest of trip'), findsOneWidget);
+      final romeY =
+          tester.getTopLeft(find.byKey(const Key('budget-group-city-Rome'))).dy;
+      final lisbonY = tester
+          .getTopLeft(find.byKey(const Key('budget-group-city-Lisbon')))
+          .dy;
+      final restY =
+          tester.getTopLeft(find.byKey(const Key('budget-group-rest'))).dy;
+      expect(romeY, lessThan(lisbonY));
+      expect(lisbonY, lessThan(restY));
+
+      // Per-city subtotals are the same projected arithmetic category mode
+      // uses ($400 Rome, $60 Lisbon, $700 + $90 rest — total unchanged).
+      expect(find.text('\$400'), findsWidgets);
+      expect(find.text('\$790'), findsOneWidget);
+
+      // Back to category mode: the original headers return.
+      await tester.tap(find.text('Category'));
+      await tester.pumpAndSettle();
+      expect(find.byKey(const Key('budget-group-lodging')), findsOneWidget);
+      expect(find.byKey(const Key('budget-group-rest')), findsNothing);
+    });
+
+    testWidgets('the picker files the next add under the picked city',
+        (tester) async {
+      final fake =
+          await _pump(tester, [], targetAmount: 2000, legChips: legs);
+
+      await tester.tap(find.byKey(const Key('budget-add-city')));
+      await tester.pumpAndSettle();
+      // Every leg plus the "No city" way out (the trigger itself reads
+      // "No city" too while nothing is picked); the revisit is qualified.
+      expect(find.text('No city'), findsNWidgets(2));
+      expect(find.text('Rome · 2nd visit'), findsOneWidget);
+      await tester.tap(find.text('Lisbon').last);
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.byType(TextField).first, 'Fado night');
+      await tester.enterText(find.byType(TextField).at(1), '35');
+      await tester.tap(find.widgetWithIcon(IconButton, Icons.add));
+      await tester.pumpAndSettle();
+
+      expect(fake.adds.single['leg_key'], 'Lisbon');
+      // An ordinary tagged add, never a plan slot.
+      expect(fake.adds.single.containsKey('leg_plan'), isFalse);
+    });
+
+    testWidgets('the picked city survives the remount, like the category',
+        (tester) async {
+      final fake = await _pumpMountable(tester, [], legChips: legs);
+
+      await tester.tap(find.byKey(const Key('budget-add-city')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Rome').last);
+      await tester.pumpAndSettle();
+
+      await _remount(tester);
+
+      await tester.enterText(find.byType(TextField).first, 'Trevi coins');
+      await tester.enterText(find.byType(TextField).at(1), '2');
+      await tester.tap(find.widgetWithIcon(IconButton, Icons.add));
+      await tester.pumpAndSettle();
+      expect(fake.adds.single['leg_key'], 'Rome');
+    });
+
+    testWidgets('the edit dialog re-files and un-files a line',
+        (tester) async {
+      final fake =
+          await _pump(tester, mixed(), targetAmount: 2000, legChips: legs);
+      // The hotel's own menu, not `.first` — category order puts flights
+      // above lodging, so the first ⋮ on screen belongs to another row.
+      final hotelMenu = find.descendant(
+          of: find.byKey(const ValueKey('a')),
+          matching: find.byIcon(Icons.more_vert));
+
+      // Re-file the Rome hotel under Lisbon.
+      await tester.tap(hotelMenu);
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Edit'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const Key('budget-edit-city')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Lisbon').last);
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Save'));
+      await tester.pumpAndSettle();
+      expect(fake.patches.single['id'], 'a');
+      expect(fake.patches.single['leg_key'], 'Lisbon');
+
+      // Un-file it: "No city" travels as the ''-clears sentinel.
+      fake.patches.clear();
+      await tester.tap(hotelMenu);
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Edit'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const Key('budget-edit-city')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('No city').last);
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Save'));
+      await tester.pumpAndSettle();
+      expect(fake.patches.single['leg_key'], '');
+    });
+
+    testWidgets('an untouched dialog PATCHes no leg_key', (tester) async {
+      final fake =
+          await _pump(tester, mixed(), targetAmount: 2000, legChips: legs);
+
+      await tester.tap(find.byIcon(Icons.more_vert).first);
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Edit'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Save'));
+      await tester.pumpAndSettle();
+
+      expect(fake.patches.single.containsKey('leg_key'), isFalse);
+    });
+
+    testWidgets("a plan row's city control is locked and says why",
+        (tester) async {
+      const plan = Expense(
+        id: 'p1',
+        category: 'food',
+        label: 'Food & drink · Rome',
+        amount: 200,
+        plannedAmount: 200,
+        purchased: false,
+        legKey: 'Rome',
+        legPlan: true,
+      );
+      final fake =
+          await _pump(tester, [plan], targetAmount: 2000, legChips: legs);
+
+      await tester.tap(find.byIcon(Icons.more_vert).first);
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Edit'));
+      await tester.pumpAndSettle();
+
+      final dropdown = tester.widget<DropdownButtonFormField<String?>>(
+          find.byKey(const Key('budget-edit-city')));
+      expect(dropdown.onChanged, isNull,
+          reason: 'a plan slot\'s city is fixed (the server 409s the write)');
+      expect(find.textContaining("Rome's daily plan"), findsOneWidget);
+
+      await tester.tap(find.text('Save'));
+      await tester.pumpAndSettle();
+      expect(fake.patches.single.containsKey('leg_key'), isFalse);
     });
   });
 }

--- a/src/packages/flutter-app/test/trip_detail_booked_expense_prompt_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_booked_expense_prompt_test.dart
@@ -104,7 +104,8 @@ class _FakeBudgetApiService extends BudgetApiService {
       bool planned = false,
       String? sourceKind,
       String? sourceId,
-      String? legKey}) async {
+      String? legKey,
+      bool legPlan = false}) async {
     addCalls.add({
       'category': category,
       'label': label,


### PR DESCRIPTION
## Summary
- **Migration 00072** (`00072_expense_leg_tagging.sql`): `trip_expenses.leg_key` becomes general city attribution; the daily-spend plan-slot identity moves into a new explicit `leg_plan boolean` (backfilled true for every pre-existing leg-keyed row). The partial unique index narrows to `WHERE leg_key IS NOT NULL AND leg_plan`, so ordinary tagged lines are unconstrained while one-plan-per-city-per-category stays a DB invariant. Two CHECKs pin that a plan slot always names its city and is never a booking mirror.
- **Server**: new `expense_leg_key.go` owns leg resolution (`tripRenderLegs`, `tripLegKeyExists` moved from the daily-spend handler, `legKeyForStay` on the same `stayMatchesHub` predicate the leg dates use). POST accepts `leg_plan` (requires `leg_key`); accommodation-linked adds get their city **stamped server-side** — best-effort, fill-in-never-overwrite on refresh — and the shortlist `choose` path stamps identically so both booking doors agree. PATCH gains `leg_key` (canonicalized against the trip's real legs; `''` clears — deliberately asymmetric with POST where `''` is a 400; **409** on a `leg_plan` row; a leg_key-only PATCH does NOT flip `auto`).
- **Budget tab**: a labelled **Group by: Category | City** toggle above the receipt (session-local per-trip provider; never a filter — every line appears in exactly one group in both modes and subtotals reuse `groupProjectedSubtotal`). City groups render in itinerary leg order with qualifiers for revisits; untagged or stale-keyed lines fall to a trailing **Rest of trip**; rows keep a small category icon in city mode. The add-options line gains a **city picker** (kept off the measured add row on purpose), the edit dialog gains a city dropdown (disabled-with-explanation on plan rows), and the picked city lives in the draft so it survives remounts.
- The daily-spend card's `_planFor` now matches on `legPlan` — without it a manually tagged Rome food line would shadow the plan slot.

## Testing
- `go vet` + full Go suite green, including 7 new integration tests (tag/clear/canonicalize, plan-row 409 with nothing partially applied, auto not flipped by tagging, many lines per city + slot still upserts, `leg_plan` requires `leg_key`, stay auto-stamp + fill-in-only refresh, segments never stamped). `TestPatchExpenseCannotSetLegKey` renamed to `TestPatchCannotMoveACityPlan`; its "plain line can't get a city" half deleted deliberately (false by design now, and it passed for the wrong reason).
- `flutter analyze` clean (3 pre-existing infos); full suite **1621 tests green**, including a new `spend per city` widget group (toggle gating, leg-order grouping + Rest of trip, the anti-filter pin, picker → draft → POST, remount survival, edit-dialog re-file/un-file/untouched, plan-row lock) and new wire-oracle cases (`leg_plan` present on plan adds, absent otherwise; `''`-clears PATCH).
- Migration applied cleanly on the lane DB (goose → v72; narrowed index verified in `pg_indexes`).
- **Live browser verification** on the lane stack (headless Chrome, SSO-handoff login): seeded a two-city trip; City mode grouped Lisbon/Porto with correct subtotals and Rest of trip; picker filed a new line under Porto (confirmed `leg_key='Porto', leg_plan=false` in postgres); PATCH tag → clear round-trip via API; unknown key 400s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)