### PR TITLE
feat(map): toggle for the home-airport overlay (on desktop, off mobile by default)

### DIFF
--- a/src/packages/flutter-app/lib/l10n/app_en.arb
+++ b/src/packages/flutter-app/lib/l10n/app_en.arb
@@ -1911,6 +1911,14 @@
       }
     }
   },
+  "mapShowHomeAirport": "Show home airport",
+  "@mapShowHomeAirport": {
+    "description": "Tooltip on the trip map's home-airport toggle button while the overlay (the flight_takeoff pin and its dashed journey legs) is hidden; tapping shows it. Named map*HomeAirport to sit beside mapHomeAirport, the pin tooltip this button shows and hides — deliberately not mapToggle*: the tooltip states the action, not the mechanism."
+  },
+  "mapHideHomeAirport": "Hide home airport",
+  "@mapHideHomeAirport": {
+    "description": "Tooltip on the same toggle button while the overlay is shown; tapping hides it, tightening the camera on the destinations instead of the leg home."
+  },
   "accountMenuTooltip": "Account",
   "accountMenuTravelProfile": "Travel profile",
   "accountMenuNotifications": "Notifications",

--- a/src/packages/flutter-app/lib/l10n/app_es.arb
+++ b/src/packages/flutter-app/lib/l10n/app_es.arb
@@ -787,6 +787,8 @@
   "mapDepartureAirport": "Aeropuerto de salida ({code})",
   "mapReturnAirport": "Aeropuerto de regreso ({code})",
   "mapHomeAirport": "Aeropuerto de origen ({code})",
+  "mapShowHomeAirport": "Mostrar aeropuerto de origen",
+  "mapHideHomeAirport": "Ocultar aeropuerto de origen",
   "accountMenuTooltip": "Cuenta",
   "accountMenuTravelProfile": "Perfil de viaje",
   "accountMenuNotifications": "Notificaciones",

--- a/src/packages/flutter-app/lib/l10n/app_localizations.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations.dart
@@ -4778,6 +4778,18 @@ abstract class AppLocalizations {
   /// **'Home airport ({code})'**
   String mapHomeAirport(String code);
 
+  /// Tooltip on the trip map's home-airport toggle button while the overlay (the flight_takeoff pin and its dashed journey legs) is hidden; tapping shows it. Named map*HomeAirport to sit beside mapHomeAirport, the pin tooltip this button shows and hides — deliberately not mapToggle*: the tooltip states the action, not the mechanism.
+  ///
+  /// In en, this message translates to:
+  /// **'Show home airport'**
+  String get mapShowHomeAirport;
+
+  /// Tooltip on the same toggle button while the overlay is shown; tapping hides it, tightening the camera on the destinations instead of the leg home.
+  ///
+  /// In en, this message translates to:
+  /// **'Hide home airport'**
+  String get mapHideHomeAirport;
+
   /// No description provided for @accountMenuTooltip.
   ///
   /// In en, this message translates to:

--- a/src/packages/flutter-app/lib/l10n/app_localizations_en.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations_en.dart
@@ -2830,6 +2830,12 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String get mapShowHomeAirport => 'Show home airport';
+
+  @override
+  String get mapHideHomeAirport => 'Hide home airport';
+
+  @override
   String get accountMenuTooltip => 'Account';
 
   @override

--- a/src/packages/flutter-app/lib/l10n/app_localizations_es.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations_es.dart
@@ -2848,6 +2848,12 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
+  String get mapShowHomeAirport => 'Mostrar aeropuerto de origen';
+
+  @override
+  String get mapHideHomeAirport => 'Ocultar aeropuerto de origen';
+
+  @override
   String get accountMenuTooltip => 'Cuenta';
 
   @override

--- a/src/packages/flutter-app/lib/providers/home_overlay_provider.dart
+++ b/src/packages/flutter-app/lib/providers/home_overlay_provider.dart
@@ -1,0 +1,42 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// The traveler's explicit choice about the trip map's home-airport overlay
+/// (the flight_takeoff pin plus its dashed journey legs): true = show,
+/// false = hide, null = no choice made this session. Surfaces resolve the
+/// null through [homeOverlayVisible], so the overlay defaults on where the
+/// map has room for the whole journey (wide, pinned layouts) and off where
+/// the leg home would crowd the destinations out of frame (phones).
+///
+/// App-wide rather than per-trip: this is a framing preference ("do I want
+/// the hop home in frame"), not trip data — the same scope as
+/// themeModeProvider, and the scope a stored device key would have. A
+/// provider rather than widget state so the inline card and the full-screen
+/// map read ONE choice live in both directions, and so tests can drive it
+/// directly (the rickRollProvider rationale).
+///
+/// Session-only, like dailySpendSettingsProvider: the choice resets on
+/// restart so the per-form-factor default re-asserts (a phone's map always
+/// reopens with tight city framing). To persist instead, follow the
+/// theme_mode_provider pattern — a load() plus a best-effort
+/// shared_preferences write in [HomeOverlayChoiceNotifier.setShown]; the
+/// call sites would not change.
+class HomeOverlayChoiceNotifier extends StateNotifier<bool?> {
+  HomeOverlayChoiceNotifier() : super(null);
+
+  /// Records an explicit choice (a toggle tap passes the inverse of the
+  /// visibility it was displaying).
+  void setShown(bool shown) => state = shown;
+}
+
+final homeOverlayChoiceProvider =
+    StateNotifierProvider<HomeOverlayChoiceNotifier, bool?>(
+        (ref) => HomeOverlayChoiceNotifier());
+
+/// Effective home-overlay visibility for one map surface: the explicit
+/// [choice] when one has been made, else the form-factor default — shown on
+/// wide layouts, hidden on phones. The default is the absence of a choice:
+/// null is never written back as a decision. [wideLayout] is the surface's
+/// own layout question — `_mapPinned` (body width) on the inline trip-detail
+/// card, the window-width rail idiom on the full-screen map.
+bool homeOverlayVisible({required bool? choice, required bool wideLayout}) =>
+    choice ?? wideLayout;

--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -24,6 +24,7 @@ import '../providers/trips_provider.dart';
 import '../providers/recent_trip_provider.dart';
 import '../utils/errors.dart';
 import '../providers/booking_todos_provider.dart';
+import '../providers/home_overlay_provider.dart';
 import '../providers/preferences_provider.dart';
 import '../providers/api_client_provider.dart';
 import '../providers/plan_provider.dart';
@@ -6231,7 +6232,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
         // map subtree — resolution landing must not rebuild the screen.
         Widget map = Consumer(
           builder: (context, ref, _) {
-            final home = homeOverlayFor(
+            final candidates = homeOverlayFor(
               ref,
               homeAirport: _homeAirport,
               travelMode: trip.travelMode,
@@ -6244,6 +6245,12 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
               firstCityPoint: endpoints.first,
               lastCityPoint: endpoints.last,
             );
+            // !expandable == _mapPinned at both _mapCard call sites, so the
+            // wide default rides the same slot-width answer as the layout.
+            final showHome = homeOverlayVisible(
+              choice: ref.watch(homeOverlayChoiceProvider),
+              wideLayout: !expandable,
+            );
             return TripMap(
               items: derivation.legFilteredItems(focusKey),
               accommodations: derivation.legFilteredStays(focusKey),
@@ -6253,7 +6260,16 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
               // Unfiltered by leg: TripMap's position+1 adjacency guard
               // already keeps labels within a city.
               segmentLabels: _mapSegmentLabels(derivation),
-              home: home,
+              home: showHome ? candidates : const [],
+              homeShown: showHome,
+              // Narrow preview (expandable) deliberately gets no toggle:
+              // interactive:false suppresses the controls anyway, and the
+              // full-screen map — one tap away — carries it.
+              onToggleHome: (expandable || candidates.isEmpty)
+                  ? null
+                  : () => ref
+                      .read(homeOverlayChoiceProvider.notifier)
+                      .setShown(!showHome),
               fitSignature: focusKey,
               // Keep fitted markers clear of the chip row overlaid below.
               topOverlayInset: hasChips ? MapLegChips.mapTopInset : 0,

--- a/src/packages/flutter-app/lib/screens/trip_map_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_map_screen.dart
@@ -6,7 +6,9 @@ import 'package:latlong2/latlong.dart';
 import '../l10n/l10n.dart';
 import '../models/accommodation.dart';
 import '../models/itinerary_item.dart';
+import '../navigation/app_nav.dart';
 import '../providers/flights_provider.dart';
+import '../providers/home_overlay_provider.dart';
 import '../utils/snack.dart';
 import '../utils/travel_mode.dart';
 import '../widgets/app_map.dart';
@@ -26,6 +28,15 @@ import '../widgets/trip_map.dart';
 /// All shows both; a stale key resolved to -1 shows neither, which is safe
 /// because a stale focus also empties the item list). Shared by the full-screen
 /// map and the inline trip-detail card so both surfaces gate identically.
+///
+/// This returns the CANDIDATES — what the overlay would draw. The traveler's
+/// session show/hide choice ([homeOverlayChoiceProvider], defaulted per form
+/// factor through [homeOverlayVisible]) is applied by both call sites to this
+/// one result, and the toggle button renders only while the candidates are
+/// non-empty — so availability, drawing, and the choice can never disagree.
+/// The choice is deliberately not folded in here: the hosts need the
+/// candidates either way (a hidden overlay still decides whether the button
+/// exists), and the [homeAirportPointProvider] watch stays warm while hidden.
 List<TripMapHome> homeOverlayFor(
   WidgetRef ref, {
   required String? homeAirport,
@@ -230,6 +241,14 @@ class _TripMapScreenState extends ConsumerState<TripMapScreen> {
     final l10n = context.l10n;
     final items = widget.itemsForLeg(_legKey);
     final onAddPlace = widget.onAddPlace;
+    final homeCandidates = _homeOverlay();
+    // Whether the wide default applies is a window question here (the
+    // gradient_app_bar idiom) — this screen is a root-navigator dialog
+    // covering the whole window.
+    final showHome = homeOverlayVisible(
+      choice: ref.watch(homeOverlayChoiceProvider),
+      wideLayout: MediaQuery.sizeOf(context).width >= kRailBreakpoint,
+    );
     // Escape closes the map. Two layers on purpose: this shortcut rides the
     // key-event focus chain, catching Escape while anything in the Scaffold
     // holds focus (the map autofocuses) — the framework's own
@@ -281,7 +300,13 @@ class _TripMapScreenState extends ConsumerState<TripMapScreen> {
                   destinations: _legKey == null ? widget.destinations : null,
                   selectedPosition: _selectedPosition,
                   segmentLabels: widget.segmentLabels,
-                  home: _homeOverlay(),
+                  home: showHome ? homeCandidates : const [],
+                  homeShown: showHome,
+                  onToggleHome: homeCandidates.isEmpty
+                      ? null
+                      : () => ref
+                          .read(homeOverlayChoiceProvider.notifier)
+                          .setShown(!showHome),
                   fitSignature: _legKey,
                   // Keep fitted markers clear of the chip row overlaid below.
                   topOverlayInset: widget.legChips.length >= 2

--- a/src/packages/flutter-app/lib/widgets/app_map.dart
+++ b/src/packages/flutter-app/lib/widgets/app_map.dart
@@ -301,11 +301,17 @@ class MapControlButton extends StatelessWidget {
   final String? tooltip;
   final VoidCallback onTap;
 
+  /// Icon color; callers dim a toggle's off state with Colors.white38 (the
+  /// muted-over-scrim value MapLegChips uses) instead of a selection ring —
+  /// on these maps a ring means "focused on this city".
+  final Color iconColor;
+
   const MapControlButton({
     super.key,
     required this.icon,
     this.tooltip,
     required this.onTap,
+    this.iconColor = Colors.white,
   });
 
   @override
@@ -330,7 +336,7 @@ class MapControlButton extends StatelessWidget {
                   side: BorderSide(color: Colors.white24),
                 ),
               ),
-              child: Icon(icon, size: 20, color: Colors.white),
+              child: Icon(icon, size: 20, color: iconColor),
             ),
           ),
         ),

--- a/src/packages/flutter-app/lib/widgets/trip_map.dart
+++ b/src/packages/flutter-app/lib/widgets/trip_map.dart
@@ -180,6 +180,21 @@ class TripMap extends StatefulWidget {
   /// the control stack exactly as before.
   final VoidCallback? onExpand;
 
+  /// Flips the traveler's show/hide choice for the [home] overlay. Non-null
+  /// renders the toggle as the leftmost bottom-right control when
+  /// [interactive]; null — the default, and what hosts pass whenever the
+  /// trip has nothing to toggle (ground trip, no resolvable airport, a
+  /// mid-trip leg focus, shared views) — renders no button, the [onExpand]
+  /// pattern.
+  final VoidCallback? onToggleHome;
+
+  /// The toggle's current state: whether the host is showing the overlay
+  /// (lit icon, "Hide…" tooltip) or has it hidden (dimmed icon, "Show…").
+  /// Deliberately not inferred from [home]: an empty list means either
+  /// "hidden by choice" or "nothing survived gating", and the button must
+  /// only dim for the first. Meaningless while [onToggleHome] is null.
+  final bool homeShown;
+
   const TripMap({
     super.key,
     required this.items,
@@ -197,6 +212,8 @@ class TripMap extends StatefulWidget {
     this.home = const [],
     this.destinations,
     this.onExpand,
+    this.onToggleHome,
+    this.homeShown = true,
   });
 
   /// Whether [a] would render as a stay pin: geocoded (null means "not
@@ -864,6 +881,21 @@ class _TripMapState extends State<TripMap> {
                   mainAxisSize: MainAxisSize.min,
                   crossAxisAlignment: CrossAxisAlignment.end,
                   children: [
+                    if (widget.onToggleHome != null) ...[
+                      MapControlButton(
+                        icon: Icons.flight_takeoff,
+                        // Dimmed = hidden; no selection ring — on these maps
+                        // the ring means "focused on this city".
+                        iconColor: widget.homeShown
+                            ? Colors.white
+                            : Colors.white38,
+                        tooltip: widget.homeShown
+                            ? l10n.mapHideHomeAirport
+                            : l10n.mapShowHomeAirport,
+                        onTap: widget.onToggleHome!,
+                      ),
+                      const SizedBox(width: 8),
+                    ],
                     if (widget.onExpand != null) ...[
                       MapControlButton(
                         icon: Icons.fullscreen,

--- a/src/packages/flutter-app/test/home_overlay_provider_test.dart
+++ b/src/packages/flutter-app/test/home_overlay_provider_test.dart
@@ -1,0 +1,31 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:travel_route_planner/providers/home_overlay_provider.dart';
+
+void main() {
+  test('no choice: visibility follows the form factor', () {
+    expect(homeOverlayVisible(choice: null, wideLayout: true), isTrue);
+    expect(homeOverlayVisible(choice: null, wideLayout: false), isFalse);
+  });
+
+  test('an explicit choice overrides the form-factor default both ways', () {
+    expect(homeOverlayVisible(choice: false, wideLayout: true), isFalse);
+    expect(homeOverlayVisible(choice: true, wideLayout: false), isTrue);
+    expect(homeOverlayVisible(choice: true, wideLayout: true), isTrue);
+    expect(homeOverlayVisible(choice: false, wideLayout: false), isFalse);
+  });
+
+  test('the provider starts with no choice and records setShown', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    expect(container.read(homeOverlayChoiceProvider), isNull);
+
+    container.read(homeOverlayChoiceProvider.notifier).setShown(false);
+    expect(container.read(homeOverlayChoiceProvider), isFalse);
+
+    container.read(homeOverlayChoiceProvider.notifier).setShown(true);
+    expect(container.read(homeOverlayChoiceProvider), isTrue);
+  });
+}

--- a/src/packages/flutter-app/test/trip_detail_home_legs_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_home_legs_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:latlong2/latlong.dart';
@@ -11,12 +12,15 @@ import 'package:travel_route_planner/providers/flights_provider.dart';
 import 'package:travel_route_planner/providers/preferences_provider.dart';
 import 'package:travel_route_planner/providers/trips_provider.dart';
 import 'package:travel_route_planner/screens/trip_detail_screen.dart';
+import 'package:travel_route_planner/screens/trip_map_screen.dart';
 import 'package:travel_route_planner/services/api_client.dart';
 import 'package:travel_route_planner/services/preferences_api_service.dart';
 import 'package:travel_route_planner/services/trips_api_service.dart';
+import 'package:travel_route_planner/widgets/app_map.dart';
 import 'package:travel_route_planner/widgets/map_leg_chips.dart';
 import 'package:travel_route_planner/widgets/trip_map.dart';
 
+import 'support/chip_finders.dart';
 import 'support/l10n_test_app.dart';
 
 /// Home-airport legs on the INLINE trip-detail map card: the overlay follows
@@ -200,6 +204,19 @@ void main() {
   TripMap map(WidgetTester tester) =>
       tester.widget<TripMap>(find.byType(TripMap));
 
+  // The show/hide toggle reuses the pin's icon, so positive assertions scope
+  // to where each lives: markers inside FlutterMap, the control outside it.
+  // `findsNothing` assertions stay unscoped on purpose — no candidates means
+  // neither pin NOR toggle (a control with nothing to govern is dead weight).
+  final homePin = find.descendant(
+    of: find.byType(FlutterMap),
+    matching: find.byIcon(Icons.flight_takeoff),
+  );
+  final homeToggle = find.descendant(
+    of: find.byType(MapControlButton),
+    matching: find.byIcon(Icons.flight_takeoff),
+  );
+
   testWidgets('All draws both legs, the home pin, and the EWR label',
       (WidgetTester tester) async {
     await pumpScreen(tester);
@@ -213,7 +230,7 @@ void main() {
     expect(home.single.outboundTo, isNotNull);
     expect(home.single.returnFrom, isNotNull);
     expect(home.single.kind, TripMapHomeKind.home);
-    expect(find.byIcon(Icons.flight_takeoff), findsOneWidget);
+    expect(homePin, findsOneWidget);
     expect(tester.takeException(), isNull);
   });
 
@@ -247,6 +264,7 @@ void main() {
 
     expect(map(tester).home, isEmpty);
     expect(find.byIcon(Icons.flight_takeoff), findsNothing);
+    expect(homeToggle, findsNothing); // nothing to govern, no button
     expect(tester.takeException(), isNull);
   });
 
@@ -260,6 +278,7 @@ void main() {
 
     expect(map(tester).home, isEmpty);
     expect(find.byIcon(Icons.flight_takeoff), findsNothing);
+    expect(homeToggle, findsNothing); // nothing to govern, no button
     expect(tester.takeException(), isNull);
   });
 
@@ -280,7 +299,7 @@ void main() {
     expect(home, hasLength(1));
     expect(home.single.label, 'ALB');
     expect(home.single.point, LatLng(albPoint.lat, albPoint.lng));
-    expect(find.byIcon(Icons.flight_takeoff), findsOneWidget);
+    expect(homePin, findsOneWidget);
   });
 
   testWidgets('departing and returning through different airports draws two pins',
@@ -304,7 +323,7 @@ void main() {
     expect(home.last.kind, TripMapHomeKind.arrival);
     expect(home.last.outboundTo, isNull);
     expect(home.last.returnFrom, isNotNull);
-    expect(find.byIcon(Icons.flight_takeoff), findsNWidgets(2));
+    expect(homePin, findsNWidgets(2));
   });
 
   testWidgets('one endpoint resolving still draws its own pin',
@@ -323,7 +342,7 @@ void main() {
     expect(home, hasLength(1));
     expect(home.single.label, 'EWR');
     expect(home.single.kind, TripMapHomeKind.arrival);
-    expect(find.byIcon(Icons.flight_takeoff), findsOneWidget);
+    expect(homePin, findsOneWidget);
   });
 
   testWidgets('a mixed-mode trip keeps its home leg',
@@ -333,7 +352,7 @@ void main() {
     await pumpScreen(tester, tripOverride: makeTrip(travelMode: 'mixed'));
 
     expect(map(tester).home, hasLength(1));
-    expect(find.byIcon(Icons.flight_takeoff), findsOneWidget);
+    expect(homePin, findsOneWidget);
   });
 
   testWidgets('no saved home airport never touches the provider',
@@ -344,6 +363,7 @@ void main() {
 
     expect(map(tester).home, isEmpty);
     expect(find.byIcon(Icons.flight_takeoff), findsNothing);
+    expect(homeToggle, findsNothing); // nothing to govern, no button
     expect(tester.takeException(), isNull);
   });
 
@@ -384,6 +404,129 @@ void main() {
     expect(prefsApi.calls, 2);
     expect(map(tester).home, hasLength(1));
     expect(map(tester).home.single.label, 'EWR');
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('wide card: toggle rides the control row and hides the overlay',
+      (WidgetTester tester) async {
+    await pumpScreen(tester);
+
+    // Default ON at the wide surface: lit toggle, left of the fullscreen
+    // button — beside, not above, the zoom column (PR #291's row shape).
+    expect(homeToggle, findsOneWidget);
+    expect(tester.widget<Icon>(homeToggle).color, Colors.white);
+    final fullscreen = find.byIcon(Icons.fullscreen);
+    expect(
+      tester.getCenter(homeToggle).dx,
+      lessThan(tester.getCenter(fullscreen).dx),
+    );
+    expect(
+      tester.getCenter(homeToggle).dy,
+      closeTo(tester.getCenter(fullscreen).dy, 1),
+    );
+
+    // Hide: the overlay leaves, the way back on stays, the chips stand.
+    await tester.tap(homeToggle);
+    await tester.pumpAndSettle();
+    expect(map(tester).home, isEmpty);
+    expect(homePin, findsNothing);
+    expect(homeToggle, findsOneWidget);
+    expect(tester.widget<Icon>(homeToggle).color, Colors.white38);
+    expect(find.byType(MapLegChips), findsOneWidget);
+
+    // Show again.
+    await tester.tap(homeToggle);
+    await tester.pumpAndSettle();
+    expect(map(tester).home, hasLength(1));
+    expect(homePin, findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('the choice survives a mid-trip focus round trip',
+      (WidgetTester tester) async {
+    await pumpScreen(tester);
+
+    await tester.tap(homeToggle); // explicit OFF on the overview
+    await tester.pumpAndSettle();
+    expect(map(tester).home, isEmpty);
+
+    // Mid-trip focus empties the candidates, so the button goes with them
+    // (contextual, like the strip's reset globe) — but the choice does not.
+    await tapChip(tester, 'Rome');
+    expect(homeToggle, findsNothing);
+
+    await tapMapReset(tester);
+    expect(homeToggle, findsOneWidget);
+    expect(tester.widget<Icon>(homeToggle).color, Colors.white38);
+    expect(map(tester).home, isEmpty);
+
+    await tester.tap(homeToggle);
+    await tester.pumpAndSettle();
+    expect(map(tester).home, hasLength(1));
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('the choice is live across the inline card and the full map',
+      (WidgetTester tester) async {
+    // Provider, not frozen push params: a toggle made inside the modal must
+    // show on the inline card behind it.
+    await pumpScreen(tester);
+
+    await tester.tap(homeToggle); // hide inline
+    await tester.pumpAndSettle();
+    expect(homePin, findsNothing);
+
+    await tester.tap(find.byIcon(Icons.fullscreen));
+    await tester.pumpAndSettle();
+    expect(find.byType(TripMapScreen), findsOneWidget);
+    // The 800px window keeps the wide default, but the explicit choice wins.
+    expect(homePin, findsNothing);
+    expect(tester.widget<Icon>(homeToggle).color, Colors.white38);
+
+    await tester.tap(homeToggle); // show, from the modal
+    await tester.pumpAndSettle();
+    expect(homePin, findsOneWidget);
+
+    await tester.tap(find.byType(CloseButton));
+    await tester.pumpAndSettle();
+    expect(find.byType(TripMapScreen), findsNothing);
+    expect(map(tester).home, hasLength(1)); // inline sees the modal's choice
+    expect(homePin, findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('phone flow: bare preview, toggle lives on the full map, '
+      'an explicit ON rides back to the preview', (WidgetTester tester) async {
+    // The default is a window question on the full map, so shrink the VIEW —
+    // setSurfaceSize only resizes layout, not MediaQuery.sizeOf.
+    tester.view.physicalSize = const Size(375, 667);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await pumpScreen(tester);
+
+    // Phone default: tight city framing, and no toggle on the preview — the
+    // full-screen map (one tap away) carries it.
+    expect(map(tester).home, isEmpty);
+    expect(homePin, findsNothing);
+    expect(homeToggle, findsNothing);
+
+    await tester.tap(find.byIcon(Icons.fullscreen));
+    await tester.pumpAndSettle();
+    expect(find.byType(TripMapScreen), findsOneWidget);
+    expect(homeToggle, findsOneWidget);
+    expect(tester.widget<Icon>(homeToggle).color, Colors.white38);
+
+    await tester.tap(homeToggle);
+    await tester.pumpAndSettle();
+    expect(homePin, findsOneWidget);
+
+    await tester.tap(find.byType(CloseButton));
+    await tester.pumpAndSettle();
+    // The explicit choice overrides the narrow default on the preview too.
+    expect(map(tester).home, hasLength(1));
+    expect(homePin, findsOneWidget);
     expect(tester.takeException(), isNull);
   });
 }

--- a/src/packages/flutter-app/test/trip_map_screen_test.dart
+++ b/src/packages/flutter-app/test/trip_map_screen_test.dart
@@ -9,6 +9,7 @@ import 'package:travel_route_planner/models/accommodation.dart';
 import 'package:travel_route_planner/models/itinerary_item.dart';
 import 'package:travel_route_planner/providers/flights_provider.dart';
 import 'package:travel_route_planner/screens/trip_map_screen.dart';
+import 'package:travel_route_planner/widgets/app_map.dart';
 import 'package:travel_route_planner/widgets/map_leg_chips.dart';
 import 'package:travel_route_planner/widgets/trip_map.dart';
 
@@ -152,6 +153,17 @@ void main() {
     final firstCity = LatLng(_items.first.latitude, _items.first.longitude);
     final lastCity = LatLng(_items.last.latitude, _items.last.longitude);
 
+    // The toggle button reuses the pin's icon, so positive assertions scope
+    // to where each lives: markers inside FlutterMap, the control outside it.
+    final homePin = find.descendant(
+      of: find.byType(FlutterMap),
+      matching: find.byIcon(Icons.flight_takeoff),
+    );
+    final homeToggle = find.descendant(
+      of: find.byType(MapControlButton),
+      matching: find.byIcon(Icons.flight_takeoff),
+    );
+
     Widget appWithHome() => _app(
           homeAirport: 'EWR',
           firstCityPoint: firstCity,
@@ -169,20 +181,72 @@ void main() {
         await tester.pumpAndSettle();
 
         // Unfocused overview: both legs → home pin present.
-        expect(find.byIcon(Icons.flight_takeoff), findsOneWidget);
+        expect(homePin, findsOneWidget);
 
-        // Mid-trip leg: neither home leg belongs to it → no orphan pin.
+        // Mid-trip leg: neither home leg belongs to it → no orphan pin, and
+        // no toggle either (unscoped on purpose: with no candidates the
+        // control would be a dead button).
         await _tapChip(tester, 'Rome');
         expect(find.byIcon(Icons.flight_takeoff), findsNothing);
 
         // The first leg carries the outbound leg, the last leg the return.
         await _tapChip(tester, 'Paris');
-        expect(find.byIcon(Icons.flight_takeoff), findsOneWidget);
+        expect(homePin, findsOneWidget);
         await _tapChip(tester, 'Berlin');
-        expect(find.byIcon(Icons.flight_takeoff), findsOneWidget);
+        expect(homePin, findsOneWidget);
         expect(tester.takeException(), isNull);
       },
     );
+
+    testWidgets('wide window defaults the overlay on; the toggle hides it', (
+      tester,
+    ) async {
+      // Default 800x600 surface: at kRailBreakpoint, the wide default.
+      await tester.pumpWidget(appWithHome());
+      await tester.pumpAndSettle();
+
+      expect(homePin, findsOneWidget);
+      expect(homeToggle, findsOneWidget);
+      Tooltip tooltipOf(Finder f) => tester
+          .widget<Tooltip>(find.ancestor(of: f, matching: find.byType(Tooltip)));
+      expect(tooltipOf(homeToggle).message, 'Hide home airport');
+
+      await tester.tap(homeToggle);
+      await tester.pumpAndSettle();
+      expect(homePin, findsNothing);
+      expect(homeToggle, findsOneWidget); // the way back on survives
+      expect(tooltipOf(homeToggle).message, 'Show home airport');
+
+      await tester.tap(homeToggle);
+      await tester.pumpAndSettle();
+      expect(homePin, findsOneWidget);
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('narrow window defaults the overlay off; the toggle shows it', (
+      tester,
+    ) async {
+      // The default is a WINDOW question (MediaQuery), so shrink the view —
+      // setSurfaceSize only resizes layout, not MediaQuery.sizeOf.
+      tester.view.physicalSize = const Size(360, 690);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      await tester.pumpWidget(appWithHome());
+      await tester.pumpAndSettle();
+
+      // Phone default: tight city framing — no pin, but a dimmed way in.
+      expect(homePin, findsNothing);
+      expect(homeToggle, findsOneWidget);
+      expect(tester.widget<Icon>(homeToggle).color, Colors.white38);
+
+      await tester.tap(homeToggle);
+      await tester.pumpAndSettle();
+      expect(homePin, findsOneWidget);
+      expect(tester.widget<Icon>(homeToggle).color, Colors.white);
+      expect(tester.takeException(), isNull);
+    });
 
     testWidgets('unresolved home airport renders the map as before', (
       tester,

--- a/src/packages/flutter-app/test/trip_map_test.dart
+++ b/src/packages/flutter-app/test/trip_map_test.dart
@@ -556,6 +556,150 @@ void main() {
     });
   });
 
+  group('home overlay toggle', () {
+    const homePoint = LatLng(40.6895, -74.1745); // EWR
+    final home = TripMapHome(
+      point: homePoint,
+      label: 'EWR',
+      outboundTo: LatLng(items.first.latitude, items.first.longitude),
+      returnFrom: LatLng(items.last.latitude, items.last.longitude),
+    );
+    // The toggle reuses the pin's icon, so scope to the control.
+    final toggleIcon = find.descendant(
+      of: find.byType(MapControlButton),
+      matching: find.byIcon(Icons.flight_takeoff),
+    );
+
+    testWidgets('shown state: lit icon, Hide tooltip, tap fires', (
+      WidgetTester tester,
+    ) async {
+      var taps = 0;
+      await tester.pumpWidget(
+        _host(
+          TripMap(
+            items: items,
+            home: [home],
+            homeShown: true,
+            onToggleHome: () => taps++,
+          ),
+        ),
+      );
+      await tester.pump();
+
+      expect(toggleIcon, findsOneWidget);
+      expect(tester.widget<Icon>(toggleIcon).color, Colors.white);
+      final tooltip = tester.widget<Tooltip>(find.ancestor(
+        of: toggleIcon,
+        matching: find.byType(Tooltip),
+      ));
+      expect(tooltip.message, 'Hide home airport');
+
+      await tester.tap(toggleIcon);
+      expect(taps, 1);
+    });
+
+    testWidgets('hidden state: button survives an empty overlay, dimmed', (
+      WidgetTester tester,
+    ) async {
+      // The host hid the overlay, so [home] is empty — the button must key
+      // on onToggleHome, never home.isNotEmpty, or the off state would
+      // delete the way back on.
+      await tester.pumpWidget(
+        _host(
+          TripMap(
+            items: items,
+            home: const [],
+            homeShown: false,
+            onToggleHome: () {},
+          ),
+        ),
+      );
+      await tester.pump();
+
+      expect(toggleIcon, findsOneWidget);
+      // The dimmed treatment, and no pin: the only flight_takeoff on screen
+      // is the control's.
+      expect(find.byIcon(Icons.flight_takeoff), findsOneWidget);
+      expect(tester.widget<Icon>(toggleIcon).color, Colors.white38);
+      final tooltip = tester.widget<Tooltip>(find.ancestor(
+        of: toggleIcon,
+        matching: find.byType(Tooltip),
+      ));
+      expect(tooltip.message, 'Show home airport');
+    });
+
+    testWidgets('hiding the overlay refits the camera off the home point', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        _host(
+          TripMap(
+            items: items,
+            home: [home],
+            homeShown: true,
+            onToggleHome: () {},
+          ),
+        ),
+      );
+      await tester.pump();
+      await tester.pump();
+      expect(_camera(tester).visibleBounds.contains(homePoint), isTrue);
+
+      // The host reacts to a toggle by passing home: const [] —
+      // didUpdateWidget's fit-set comparison must refit down to the trip
+      // (the hide-direction mirror of the async-arrival refit test).
+      await tester.pumpWidget(
+        _host(
+          TripMap(
+            items: items,
+            home: const [],
+            homeShown: false,
+            onToggleHome: () {},
+          ),
+        ),
+      );
+      await tester.pump(); // frame scheduling the post-frame re-fit
+      await tester.pump(); // camera moved
+
+      expect(_camera(tester).visibleBounds.contains(homePoint), isFalse);
+    });
+
+    testWidgets('interactive: false suppresses the toggle with the controls', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        _host(
+          TripMap(
+            items: items,
+            home: [home],
+            interactive: false,
+            onToggleHome: () {},
+          ),
+        ),
+      );
+      await tester.pump();
+
+      expect(find.byType(MapControlButton), findsNothing);
+    });
+
+    testWidgets('toggle joins the control row at the 44px touch target', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        _host(TripMap(items: items, home: [home], onToggleHome: () {})),
+      );
+      await tester.pump();
+
+      final buttons = find.byType(MapControlButton);
+      expect(buttons, findsNWidgets(4)); // toggle / zoom in / zoom out / reset
+      for (var i = 0; i < 4; i++) {
+        final size = tester.getSize(buttons.at(i));
+        expect(size.width, greaterThanOrEqualTo(44));
+        expect(size.height, greaterThanOrEqualTo(44));
+      }
+    });
+  });
+
   testWidgets('interactive: false hides the zoom/reset controls', (
     WidgetTester tester,
   ) async {


### PR DESCRIPTION
## Summary
- New show/hide toggle for the trip map's home-airport overlay (the flight_takeoff pin + dashed journey legs): a `MapControlButton` rendered by `TripMap` as the leftmost element of the bottom-right control row (beside the fullscreen button, the #291 row shape — never a 4th column member, never in the chip strip, and clear of the bottom-left attribution). Lit while the overlay is shown, dimmed (`white38`) while hidden; tooltip flips between new `mapShowHomeAirport`/`mapHideHomeAirport` keys (EN+ES, regen committed).
- Defaults per form factor: **on** at wide layouts (`_mapPinned` on the inline card; `MediaQuery >= kRailBreakpoint` on the full-screen map, a window question), **off** on phones — so the 180px preview keeps tight city framing instead of a mostly-Atlantic fit. Session-only by Brian's choice: an explicit toggle lasts until reload, then the form-factor default re-asserts.
- State is a new app-wide `homeOverlayChoiceProvider` (`bool?`, null = no choice; `homeOverlayVisible(choice, wideLayout)` resolves), so the inline card and the full-screen map read one choice live in both directions — a toggle inside the modal shows on the card behind it.
- `homeOverlayFor` keeps its charter and signature: it returns the **candidates**; each call site applies the one-line `home: showHome ? candidates : const []` filter, and the button renders only while candidates are non-empty — availability and drawing can never disagree. No candidates (ground trip, unresolved airport, free-text origin, mid-trip focus) = no button, the reset-globe convention. The narrow preview deliberately gets no toggle (controls suppressed; the full-screen map one tap away carries it), but an explicit ON shows the overlay on the preview too.
- `MapControlButton` gains an `iconColor` param (default white) for the dimmed state; shared/band call sites are byte-identical (new `TripMap` params default to no-button).

## Testing
- `flutter analyze` clean (3 pre-existing `route_response.dart` infos only).
- Full suite green: **1627 tests passed**, including:
  - `trip_map_test.dart`: new "home overlay toggle" group — lit/dimmed states, tooltip flip, tap fires, button survives an empty overlay (guards keying on `home.isNotEmpty`), hide-direction camera refit, `interactive:false` suppression, 4-button 44px touch-target row.
  - `trip_map_screen_test.dart`: wide default ON → toggle hides/restores; narrow window (via `tester.view.physicalSize` — `setSurfaceSize` does not move `MediaQuery.sizeOf`) defaults OFF → dimmed toggle shows the pin.
  - `trip_detail_home_legs_test.dart`: toggle position in the control row, hide/show round trip, no button without candidates, choice survives a mid-trip focus round trip, choice live across inline↔full-screen, and the full phone flow (bare preview → full map → ON → choice rides back to the preview). Positive pin assertions scoped (`FlutterMap` descendant vs `MapControlButton` descendant) since the toggle reuses the pin's icon; `findsNothing` asserts stay unscoped on purpose (no candidates = neither pin nor button).
  - New `home_overlay_provider_test.dart`: resolution truth table + `setShown`.
- Browser pass (lane stack :3002, host headless Chrome + CDP): desktop default shows the lit toggle + whole-journey fit; toggling off refits tight to Europe with a dimmed button; the full-screen map honors and flips the same choice both directions; phone emulation (375×667) confirms the bare tight preview by default, the dimmed toggle on the full map, and an explicit ON riding back to the preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)