### PR TITLE
feat(landing): carry the hero prompt through sign-up into the first chat

### DIFF
--- a/specs/instrumentation-events/spec.md
+++ b/specs/instrumentation-events/spec.md
@@ -44,6 +44,8 @@ Recorded from the client (the moments only the client can see):
 |---|---|---|
 | `booking_link_clicked` | user opens a booking handoff link | trip id, todo id, provider, kind |
 | `landing_viewed` | a signed-out visitor renders the landing page (once per app session) | — |
+| `landing_prompt_submitted` | a landing prompt handed to sign-up (specs/landing-prompt-handoff) | surface (`hero`\|`card`), kind (destination slug, cards only); never the prompt text |
+| `pending_prompt_consumed` | the stored landing prompt reached the signed-in composer | surface (`hero`\|`card`) |
 
 `booking_link_clicked` is the **attach-rate numerator** — the reason this
 feature exists. Completed bookings cannot be observed directly (affiliate
@@ -63,6 +65,7 @@ type must be a moment a signed-out visitor can actually produce:
 |---|---|
 | `landing_viewed` | the top of the funnel: landing-page views over signups is the first conversion number |
 | `booking_link_clicked` | signed-out booking handoffs (e.g. from future public surfaces) still count toward total clicks |
+| `landing_prompt_submitted` | the landing hero's prompt submit is by definition produced signed out; its consume-side sibling `pending_prompt_consumed` stays authed-only |
 
 There is intentionally **no** `plan_started_anonymous`: the Flutter app has no
 signed-out planning entry point (AuthGate routes signed-out visitors to the

--- a/specs/landing-prompt-handoff/plan.md
+++ b/specs/landing-prompt-handoff/plan.md
@@ -1,0 +1,98 @@
+# Plan: Landing Prompt Handoff
+
+> **HOW.** Stacked on `specs/landing-redesign/` (branch `landing-prompt-handoff`
+> on `landing-redesign`).
+
+## Technical Approach
+
+Three pieces, each cloned from a proven precedent:
+
+1. **`PendingPromptStore`** (`lib/services/pending_prompt.dart`) — structural
+   clone of `PendingConnectStore`: SharedPreferences keys
+   `pending_prompt.{text,chip,saved_at}` (SharedPreferences IS localStorage on
+   web, which is what survives the SSO full-page reload), 30-min expiry,
+   `take()` single-use clearing before validating, every method best-effort.
+   One addition: a static in-memory write-through mirror so the email path
+   (no reload) survives private-browsing storage failure; `take()` validates
+   the mirror's age too. `maxPromptLength = 2000` matches the hero field's
+   `maxLength` (`kLandingPromptMaxLength` — moved to the store as the one
+   source of truth, hero imports it).
+2. **`pendingPromptResumeProvider`** (`lib/providers/pending_prompt_provider.dart`)
+   — the ONE consume point, modeled on `urlSyncProvider`'s boot-target
+   consumption: `ref.listen(authProvider)` + a post-frame initial check,
+   eligibility `initialized && isSignedIn && !needsOnboarding`,
+   reentrancy-guarded. On eligible: `take()` → write
+   `chatDraftProvider(chatDraftKeyFor(null))` (prefill, never send) → switch
+   `navIndexProvider` to Plan **unless** `UrlSyncController.bootTargetSeen`
+   (new 2-line getter) — a deep-linked destination outranks the tab
+   preselect — → record `pending_prompt_consumed`. Watched from frame 1 in
+   `TravelRoutePlannerApp.build` next to `rootUrlObserverProvider`, so it is
+   alive on the bare `/sso` route and needs **zero changes** to AuthScreen or
+   sso_callback_screen. Covers all paths: email sign-up (quiz completes →
+   state flips → listener), SSO (prefs survive the reload), sign-in, cold
+   boot.
+3. **`ChatPanel` external-draft listener** — one `ref.listen` on
+   `chatDraftProvider(_draftKey).select((d) => d.text)` in build, applying
+   external writes to `_controller` (guard `next == _controller.text`; the
+   `_saveDraft` echo makes own keystrokes equal, so the loop terminates; the
+   `TextEditingValue` idiom from `_restoreDraft`). Today an external draft
+   write to a MOUNTED composer silently does nothing — this closes the only
+   silent-loss window and makes the consume correct regardless of listener
+   -vs-build ordering.
+
+The landing side already exposes the seam: `landingPromptHandoffProvider`'s
+default in `lib/screens/landing/landing_handoff.dart` becomes the real
+implementation — `await store.save()` BEFORE any navigation (the
+`connect_app_screen.dart:111` rule), best-effort
+`recordLandingPromptSubmitted`, then the same `warmSsoAvailability` +
+`pushOnce(AuthScreen(initialIsLogin: false))`.
+
+**Analytics** rides the existing closed metadata keys — `surface: hero|card`
+(NOT `source`, whose value set is closed for itinerary_item_added) and
+`kind: <destination slug>` for cards; the prompt text never rides.
+
+## Go API Changes
+
+- `analytics.go`: `landing_prompt_submitted` + `pending_prompt_consumed` in
+  `clientEventTypes`; `landing_prompt_submitted` also in
+  `anonymousClientEventTypes` (a signed-out visitor produces it). No
+  metadata-key changes.
+- `admin_metrics_handler.go`: `landing_prompt_submitted` in
+  `timeseriesEventTypes` after `landing_viewed` (funnel order).
+
+## Flutter Changes
+
+- NEW `lib/services/pending_prompt.dart`, `lib/providers/pending_prompt_provider.dart`.
+- `lib/navigation/url_sync.dart`: `bootTargetSeen` getter.
+- `lib/widgets/chat_panel.dart`: the external-draft `ref.listen` (only).
+- `lib/screens/landing/landing_handoff.dart`: real default handoff.
+- `lib/screens/landing/landing_hero.dart`: `kLandingPromptMaxLength` now
+  re-exported from the store constant.
+- `lib/services/analytics_api_service.dart`: `recordLandingPromptSubmitted`
+  (+ anonymous mirror entry), `recordPendingPromptConsumed`.
+- `lib/main.dart`: one `ref.watch(pendingPromptResumeProvider)`.
+- `lib/screens/admin_metrics_screen.dart`: `('landing_prompt_submitted',
+  'Prompts submitted')` in `_series`.
+- `specs/instrumentation-events/spec.md`: taxonomy additions.
+
+## Contract Parity
+
+No new JSON shapes; the events payload is unchanged (existing
+`event_type`/`metadata` contract).
+
+## Cross-cutting
+
+None (no env vars, no gateway changes, no migrations).
+
+## Verification
+
+- `flutter analyze` + full `flutter test`; `make api-fmt api-vet` + Go
+  analytics tests.
+- New tests: store unit tests (clone of `pending_connect_test.dart` +
+  truncation + memory mirror), resume-provider tests (consume on transition;
+  withheld while `needsOnboarding`; stale → nothing; `bootTargetSeen` skips
+  the tab switch; single-use), default-handoff widget test (store written +
+  event recorded + AuthScreen pushed in sign-up mode), ChatPanel
+  external-draft test, Go whitelist/timeseries assertions.
+- Browser QA on the lane stack: type → submit → email sign-up → quiz →
+  Plan tab composer prefilled; same via SSO handoff-seeded sign-in.

--- a/specs/landing-prompt-handoff/spec.md
+++ b/specs/landing-prompt-handoff/spec.md
@@ -1,0 +1,90 @@
+# Spec: Landing Prompt Handoff
+
+> **WHAT & WHY only.** Sibling of `specs/landing-redesign/` (the page that
+> produces the prompt).
+
+## Context
+
+The redesigned landing page's hero is a real prompt input, but a visitor is
+signed out and the app has no signed-out chat surface. Without a handoff, the
+sentence a visitor typed — the strongest intent signal the product ever gets —
+dies at the sign-up form. This feature carries that sentence through sign-up
+(including the SSO full-page navigation) and into the visitor's first agent
+chat, prefilled in the composer in their own words.
+
+## User Stories
+
+- As a **first-time visitor**, I want **the trip I typed on the landing page
+  waiting in the chat after I sign up** so that I never retype it.
+- As a **returning traveler** who typed a prompt before tapping "I already
+  have an account", I want it **waiting after sign-in** too.
+- As **Brian**, I want the funnel instrumented (prompt submitted → consumed)
+  so the landing redesign's effect is measurable.
+
+## Acceptance Criteria
+
+- [ ] Submitting the hero prompt (typed or chip-prefilled) or tapping a
+      destination card stores the prompt and continues into sign-up.
+- [ ] After email+password sign-up and the onboarding quiz (finish or skip),
+      the app lands on the Plan tab with the composer prefilled with the
+      exact submitted text. Nothing is auto-sent.
+- [ ] The same holds through Google and Apple SSO, which reload the page.
+- [ ] The same holds for sign-IN with an existing account.
+- [ ] A prompt older than 30 minutes is never applied.
+- [ ] A prompt is applied at most once — abandoning the quiz, signing out,
+      or signing in again does not replay it.
+- [ ] When the visitor arrived via a deep link (boot target), the prompt
+      still lands in the composer but the deep link keeps the tab.
+- [ ] `landing_prompt_submitted` (anonymous-capable) and
+      `pending_prompt_consumed` (authed) are recorded with a `surface` of
+      `hero` or `card`; the prompt text itself never rides analytics.
+- [ ] Storage being unavailable degrades silently: sign-up proceeds, the
+      prompt is simply absent (email path still works via the in-memory
+      mirror; SSO path loses it).
+
+## API Surface
+
+No new endpoints. `POST /api/v1/events` accepts two new event types:
+`landing_prompt_submitted` (also anonymously) and `pending_prompt_consumed`
+(authed only), both with the existing `surface`/`kind` metadata keys.
+`GET /api/v1/admin/metrics/timeseries` gains the `landing_prompt_submitted`
+daily series.
+
+## Data Model
+
+- **Pending prompt** (device-local only): the trimmed prompt text (≤2000
+  chars), the suggestion slug when a destination card produced it, and when
+  it was saved. One slot, last-write-wins, single-use, 30-minute expiry.
+  Never persisted server-side until the user sends it in chat themselves.
+
+## UI Behavior
+
+- **Consume moment:** the first time the session is signed-in AND onboarded
+  (covers sign-up→quiz, SSO return, plain sign-in, and cold boot with a
+  stored session). The Plan tab is preselected (unless a deep link chose a
+  destination) and the Agent composer carries the text.
+- **Prefill, not auto-send:** minutes pass between intent and arrival; the
+  user reviews and sends. Auto-send would erupt unprompted on first arrival
+  and waste the first turn on quiz-skippers with empty profiles.
+
+## Edge Cases & Error States
+
+- Two tabs consuming at once: worst case two prefilled composers (drafts are
+  device-local; no duplicate sends, no model cost).
+- A second landing submit overwrites the first (one slot).
+- A different user signing in on the same device within 30 minutes receives
+  the device-local prefill — device-scoped by design, text never left the
+  machine.
+- Composer already mounted when the consume fires: the draft write reaches
+  the live composer (no silent-loss window).
+
+## Out of Scope
+
+- Anonymous chat.
+- Seeding the onboarding quiz from the prompt (one home per fact: the
+  composer).
+- Auto-send (a one-line swap at the consume site if product ever wants it).
+
+## Open Questions
+
+None.

--- a/specs/landing-prompt-handoff/tasks.md
+++ b/specs/landing-prompt-handoff/tasks.md
@@ -1,0 +1,44 @@
+# Tasks: Landing Prompt Handoff
+
+> Dependency-ordered. PR 2, stacked on `landing-redesign` (PR 1); merge order
+> UI → Handoff.
+
+## Store
+
+- [ ] `lib/services/pending_prompt.dart` (`PendingPrompt`,
+      `PendingPromptStore` with memory mirror, `maxPromptLength`)
+- [ ] `test/pending_prompt_test.dart`
+
+## Consume point
+
+- [ ] `url_sync.dart`: `bootTargetSeen` getter
+- [ ] `lib/providers/pending_prompt_provider.dart` + `main.dart` watch
+- [ ] `test/pending_prompt_resume_test.dart`
+
+## Composer
+
+- [ ] `chat_panel.dart` external-draft `ref.listen` + test
+
+## Landing wiring
+
+- [ ] `landing_handoff.dart`: real default (save → analytics → auth push);
+      hero `maxLength` sourced from the store constant
+- [ ] `test/landing_default_handoff_test.dart`
+
+## Analytics
+
+- [ ] `analytics_api_service.dart`: two methods + anonymous mirror
+- [ ] Go `analytics.go` whitelists; `admin_metrics_handler.go` timeseries
+- [ ] `admin_metrics_screen.dart` `_series` entry
+- [ ] Go test coverage; `specs/instrumentation-events/spec.md` taxonomy
+
+## Verification
+
+- [ ] `flutter analyze` + `flutter test` clean
+- [ ] `make api-fmt api-vet` + `go test` clean
+- [ ] Browser QA: email path end-to-end; SSO path via handoff seeding
+
+**Conflict manifest** — edits: `landing_handoff.dart`, `landing_hero.dart`,
+`main.dart`, `url_sync.dart`, `chat_panel.dart`, `analytics_api_service.dart`,
+`admin_metrics_screen.dart`, `analytics.go`, `admin_metrics_handler.go`,
+`specs/instrumentation-events/spec.md`.

--- a/src/packages/api/admin_integration_test.go
+++ b/src/packages/api/admin_integration_test.go
@@ -271,8 +271,9 @@ func TestAdminTimeseries(t *testing.T) {
 	if !ok {
 		t.Fatalf("series missing: %v", body["series"])
 	}
-	for _, key := range []string{"landing_viewed", "user_registered", "trip_created",
-		"plan_session_started", "booking_link_clicked", "itinerary_item_added"} {
+	for _, key := range []string{"landing_viewed", "landing_prompt_submitted",
+		"user_registered", "trip_created", "plan_session_started",
+		"booking_link_clicked", "itinerary_item_added"} {
 		if _, ok := series[key]; !ok {
 			t.Errorf("series[%s] missing (stable slots require every type)", key)
 		}

--- a/src/packages/api/admin_metrics_handler.go
+++ b/src/packages/api/admin_metrics_handler.go
@@ -30,6 +30,7 @@ import (
 // response (empty array included) so the client gets stable chart slots.
 var timeseriesEventTypes = []string{
 	"landing_viewed",
+	"landing_prompt_submitted",
 	"user_registered",
 	"trip_created",
 	"plan_session_started",

--- a/src/packages/api/analytics.go
+++ b/src/packages/api/analytics.go
@@ -28,6 +28,12 @@ var clientEventTypes = map[string]bool{
 	// A place added to a trip from a browse surface (local rec, event, guide
 	// pin) — specs/add-to-itinerary. Distinguished by metadata "source".
 	"itinerary_item_added": true,
+	// A landing prompt handed to sign-up, and the moment the stored prompt
+	// reached the signed-in composer (specs/landing-prompt-handoff).
+	// Distinguished by metadata "surface": hero|card; "kind" carries the
+	// destination slug for cards. The prompt text itself never rides.
+	"landing_prompt_submitted": true,
+	"pending_prompt_consumed":  true,
 	// Transition telemetry (specs/server-leg-dates): the client compared the
 	// server `legs` payload against its local derivation on a trip load and
 	// they DISAGREED. Expected volume: zero — any row is a derivation-parity
@@ -52,6 +58,11 @@ var clientEventTypes = map[string]bool{
 var anonymousClientEventTypes = map[string]bool{
 	"landing_viewed":       true,
 	"booking_link_clicked": true,
+	// The landing hero's prompt submit — by definition produced signed out
+	// (specs/landing-prompt-handoff). Its consume-side sibling
+	// (pending_prompt_consumed) is deliberately NOT here: consuming requires
+	// a session.
+	"landing_prompt_submitted": true,
 }
 
 // maxEventMetadataBytes caps the metadata bag (small, flat detail only).

--- a/src/packages/api/analytics_integration_test.go
+++ b/src/packages/api/analytics_integration_test.go
@@ -384,3 +384,52 @@ func TestClientEventMetadataSanitized(t *testing.T) {
 		}
 	}
 }
+
+// --- landing prompt handoff events (specs/landing-prompt-handoff) ---
+
+func TestAnonymousLandingPromptSubmittedAccepted(t *testing.T) {
+	resetDB(t)
+	// The submitter is by definition signed out; surface/kind ride the
+	// existing metadata whitelist and the prompt TEXT never rides at all.
+	rec := doJSON(t, "POST", "/api/v1/events", "", map[string]any{
+		"event_type": "landing_prompt_submitted",
+		"metadata":   map[string]any{"surface": "card", "kind": "rome"},
+	})
+	if rec.Code != 202 {
+		t.Fatalf("anonymous POST /events = %d, want 202: %s", rec.Code, rec.Body.String())
+	}
+	waitForAnonymousEventCount(t, "landing_prompt_submitted", 1)
+
+	var meta map[string]any
+	if err := dbPool.QueryRow(context.Background(),
+		`SELECT metadata FROM analytics_events
+		 WHERE user_id IS NULL AND event_type = 'landing_prompt_submitted'`).Scan(&meta); err != nil {
+		t.Fatalf("row: %v", err)
+	}
+	if meta["surface"] != "card" || meta["kind"] != "rome" || len(meta) != 2 {
+		t.Fatalf("metadata = %v, want {surface: card, kind: rome}", meta)
+	}
+}
+
+func TestPendingPromptConsumedAuthedOnly(t *testing.T) {
+	resetDB(t)
+	// Consuming requires a session — the anonymous whitelist must reject it.
+	rec := doJSON(t, "POST", "/api/v1/events", "", map[string]any{
+		"event_type": "pending_prompt_consumed",
+		"metadata":   map[string]any{"surface": "hero"},
+	})
+	if rec.Code != 400 {
+		t.Fatalf("anonymous POST /events = %d, want 400: %s", rec.Code, rec.Body.String())
+	}
+
+	// The authed path accepts it.
+	user, token := createTestUser(t, "prompt-consumer@example.com")
+	rec = doJSON(t, "POST", "/api/v1/events", token, map[string]any{
+		"event_type": "pending_prompt_consumed",
+		"metadata":   map[string]any{"surface": "hero"},
+	})
+	if rec.Code != 202 {
+		t.Fatalf("authed POST /events = %d, want 202: %s", rec.Code, rec.Body.String())
+	}
+	waitForEventCount(t, user.ID, "pending_prompt_consumed", 1)
+}

--- a/src/packages/flutter-app/lib/main.dart
+++ b/src/packages/flutter-app/lib/main.dart
@@ -8,6 +8,7 @@ import 'navigation/app_routes.dart';
 import 'navigation/url_sync.dart';
 import 'providers/auth_provider.dart';
 import 'providers/locale_provider.dart';
+import 'providers/pending_prompt_provider.dart';
 import 'providers/theme_mode_provider.dart';
 import 'theme/app_theme.dart';
 import 'widgets/konami_listener.dart';
@@ -117,6 +118,10 @@ class TravelRoutePlannerApp extends ConsumerWidget {
     // Watching only the locale the widget layer needs, not the whole state.
     final locale = ref.watch(localeProvider.select((s) => s.materialLocale));
     final themeMode = ref.watch(themeModeProvider.select((s) => s.mode));
+    // Alive from the first frame like rootUrlObserverProvider below: the
+    // landing-prompt resume must hear the auth transition on every route,
+    // including the bare /sso return (specs/landing-prompt-handoff).
+    ref.watch(pendingPromptResumeProvider);
     return MaterialApp(
       title: AppInfo.name,
       debugShowCheckedModeBanner: false,

--- a/src/packages/flutter-app/lib/navigation/url_sync.dart
+++ b/src/packages/flutter-app/lib/navigation/url_sync.dart
@@ -84,11 +84,19 @@ class UrlSyncController {
   BootTarget? _bootTarget;
   bool _bootConsumed = false;
 
-  /// Whether this app run booted with a deep-link target (pending or already
-  /// consumed). The pending-prompt resume (specs/landing-prompt-handoff)
-  /// skips its Plan-tab preselect when true: a destination the user
-  /// explicitly navigated to outranks a remembered prompt's tab choice.
-  bool get bootTargetSeen => _bootTarget != null || _bootConsumed;
+  /// True from the boot target being applied until the NEXT sign-out —
+  /// i.e. scoped to the signed-in cycle the target belonged to, unlike
+  /// [_bootConsumed], whose whole-run latch exists for anti-replay.
+  bool _bootAppliedThisCycle = false;
+
+  /// Whether a deep-link boot target chose a destination for the CURRENT
+  /// sign-in cycle (pending, or applied and not yet signed out of). The
+  /// pending-prompt resume (specs/landing-prompt-handoff) skips its Plan-tab
+  /// preselect when true: a destination the user explicitly navigated to
+  /// outranks a remembered prompt's tab choice. Cycle-scoped so a sign-out →
+  /// new landing prompt → sign-in later in the same app run gets its
+  /// preselect back.
+  bool get bootTargetSeen => _bootTarget != null || _bootAppliedThisCycle;
 
   // ---- write half -------------------------------------------------------
 
@@ -183,6 +191,8 @@ class UrlSyncController {
         stack.clear();
       }
       _shellAttached = false;
+      // The cycle the boot target belonged to is over.
+      _bootAppliedThisCycle = false;
       if (_lastReported != kHomeLocation) {
         _lastReported = kHomeLocation;
         _ref.read(urlReporterProvider)(kHomeLocation);
@@ -201,6 +211,7 @@ class UrlSyncController {
     if (!auth.initialized || !auth.isSignedIn) return;
     if (auth.user!.needsOnboarding) return;
     _bootConsumed = true;
+    _bootAppliedThisCycle = true;
     _bootTarget = null;
 
     // Listener context, never mid-build: the provider write is legal, and it

--- a/src/packages/flutter-app/lib/navigation/url_sync.dart
+++ b/src/packages/flutter-app/lib/navigation/url_sync.dart
@@ -84,6 +84,12 @@ class UrlSyncController {
   BootTarget? _bootTarget;
   bool _bootConsumed = false;
 
+  /// Whether this app run booted with a deep-link target (pending or already
+  /// consumed). The pending-prompt resume (specs/landing-prompt-handoff)
+  /// skips its Plan-tab preselect when true: a destination the user
+  /// explicitly navigated to outranks a remembered prompt's tab choice.
+  bool get bootTargetSeen => _bootTarget != null || _bootConsumed;
+
   // ---- write half -------------------------------------------------------
 
   String get _currentLocation {

--- a/src/packages/flutter-app/lib/providers/pending_prompt_provider.dart
+++ b/src/packages/flutter-app/lib/providers/pending_prompt_provider.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../navigation/app_nav.dart';
 import '../navigation/url_sync.dart';
+import '../services/pending_connect.dart';
 import '../services/pending_prompt.dart';
 import 'analytics_provider.dart';
 import 'auth_provider.dart';
@@ -48,6 +49,11 @@ class PendingPromptResume {
     if (auth.user!.needsOnboarding) return;
     _consuming = true;
     try {
+      // Defer behind an active connector-consent flow: it ends in a
+      // full-page redirect to the external client, which would strand a
+      // prompt consumed now. The prompt stays stored; the next sign-in (or
+      // the 30-min expiry) settles it.
+      if (await const PendingConnectStore().hasPending()) return;
       final pending = await _store.take();
       if (pending == null) return;
 

--- a/src/packages/flutter-app/lib/providers/pending_prompt_provider.dart
+++ b/src/packages/flutter-app/lib/providers/pending_prompt_provider.dart
@@ -1,0 +1,79 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../navigation/app_nav.dart';
+import '../navigation/url_sync.dart';
+import '../services/pending_prompt.dart';
+import 'analytics_provider.dart';
+import 'auth_provider.dart';
+import 'plan_provider.dart';
+
+/// The ONE consume point for a landing prompt (specs/landing-prompt-handoff),
+/// modeled on [urlSyncProvider]'s boot-target consumption: alive from the
+/// first frame (watched in `TravelRoutePlannerApp.build`), so it hears the
+/// auth transition on every path — email sign-up finishing the quiz, the SSO
+/// return landing on the bare /sso route, plain sign-in, and a cold boot
+/// with a stored session — with zero changes to AuthScreen or the SSO
+/// callback screen.
+final pendingPromptResumeProvider = Provider<PendingPromptResume>((ref) {
+  final resume = PendingPromptResume(ref);
+  ref.listen(authProvider, (_, next) => resume.maybeConsume(next));
+  // Cold boot with an already-eligible session: the listener never fires, so
+  // check once outside the build phase (registerBootTarget's idiom).
+  WidgetsBinding.instance.addPostFrameCallback(
+      (_) => resume.maybeConsume(ref.read(authProvider)));
+  return resume;
+});
+
+class PendingPromptResume {
+  PendingPromptResume(this._ref, {PendingPromptStore? store})
+      : _store = store ?? const PendingPromptStore();
+
+  final Ref _ref;
+  final PendingPromptStore _store;
+
+  /// Guards the async window between eligibility and the store's own
+  /// single-use clear — two rapid auth transitions must not both read the
+  /// slot. Reset afterwards: a sign-out → new landing submit → sign-in
+  /// cycle within one app run consumes again (the store being empty is what
+  /// makes an already-consumed prompt a no-op, not this flag).
+  bool _consuming = false;
+
+  Future<void> maybeConsume(AuthState auth) async {
+    if (_consuming) return;
+    // Strictly after onboarding: the quiz seeds the traveler profile that
+    // makes the first plan good, and Skip flips the same flag — mirrors the
+    // boot-target rule ("finish the quiz, then land").
+    if (!auth.initialized || !auth.isSignedIn) return;
+    if (auth.user!.needsOnboarding) return;
+    _consuming = true;
+    try {
+      final pending = await _store.take();
+      if (pending == null) return;
+
+      // Prefill, never auto-send: minutes separate the landing intent from
+      // this moment, and the user should review before the first turn. The
+      // ChatPanel's external-draft listener applies this to a mounted
+      // composer too; an unmounted one restores it on mount. (Auto-send
+      // later = swap this write for planProvider.notifier.sendMessage.)
+      _ref
+          .read(chatDraftProvider(chatDraftKeyFor(null)).notifier)
+          .setText(pending.text);
+
+      // A deep-linked destination the user explicitly requested keeps the
+      // tab; the draft still waits on the Plan tab either way.
+      if (!_ref.read(urlSyncProvider).bootTargetSeen) {
+        _ref.read(navIndexProvider.notifier).state = AppTab.plan.index;
+      }
+
+      try {
+        _ref.read(analyticsApiServiceProvider).recordPendingPromptConsumed(
+            surface: pending.sourceId == null ? 'hero' : 'card');
+      } catch (_) {
+        // Tracking must never affect the handoff.
+      }
+    } finally {
+      _consuming = false;
+    }
+  }
+}

--- a/src/packages/flutter-app/lib/screens/admin_metrics_screen.dart
+++ b/src/packages/flutter-app/lib/screens/admin_metrics_screen.dart
@@ -219,6 +219,7 @@ class _TrendsPane extends ConsumerWidget {
   // timeseriesEventTypes; unknown keys in the payload are simply not shown).
   static const _series = [
     ('landing_viewed', 'Landing views'),
+    ('landing_prompt_submitted', 'Prompts submitted'),
     ('user_registered', 'Signups'),
     ('trip_created', 'Trips created'),
     ('plan_session_started', 'Plan sessions'),

--- a/src/packages/flutter-app/lib/screens/landing/landing_handoff.dart
+++ b/src/packages/flutter-app/lib/screens/landing/landing_handoff.dart
@@ -2,7 +2,10 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../navigation/app_nav.dart';
+import '../../providers/analytics_provider.dart';
 import '../../providers/auth_provider.dart';
+import '../../services/analytics_api_service.dart';
+import '../../services/pending_prompt.dart';
 import '../auth_screen.dart';
 
 /// What the landing page does with a visitor's first prompt: the hero's
@@ -19,18 +22,32 @@ typedef LandingPromptHandoff = void Function(
 
 /// Seam between the landing page UI and the prompt→sign-up→chat handoff
 /// (specs/landing-prompt-handoff). A provider rather than constructor
-/// plumbing so widget tests can override it to record calls, and so the
-/// handoff lane replaces exactly one default.
+/// plumbing so widget tests can override it to record calls.
 final landingPromptHandoffProvider =
     Provider<LandingPromptHandoff>((ref) => _defaultHandoff);
 
-// TODO(specs/landing-prompt-handoff): persist the prompt BEFORE navigation
-// (it must survive the SSO full-page reload) and seed the first chat after
-// auth. Until that lane lands, this degrades to the plain sign-up path and
-// the prompt is dropped.
-void _defaultHandoff(BuildContext context, String prompt, {String? sourceId}) {
-  // Same warm-up + push as the landing page's plain CTAs, so the two entry
-  // styles can't drift apart while the handoff lane is in flight.
+/// The real handoff: persist the prompt BEFORE any navigation — SSO is a
+/// full-page reload and in-memory state dies (the PendingConnectStore rule,
+/// connect_app_screen.dart) — then continue into sign-up exactly like the
+/// plain CTAs. `pendingPromptResumeProvider` consumes the store once the
+/// session is signed in and onboarded.
+Future<void> _defaultHandoff(BuildContext context, String prompt,
+    {String? sourceId}) async {
+  // Container read BEFORE the await (no context across the async gap).
+  AnalyticsApiService? analytics;
+  try {
+    analytics = ProviderScope.containerOf(context, listen: false)
+        .read(analyticsApiServiceProvider);
+  } catch (_) {}
+  await const PendingPromptStore().save(prompt, sourceId: sourceId);
+  try {
+    // Fire-and-forget, and never allowed to break the handoff — the same
+    // stance as the landing_viewed guard. The prompt TEXT never rides
+    // analytics; only which surface produced it.
+    analytics?.recordLandingPromptSubmitted(
+        surface: sourceId == null ? 'hero' : 'card', kind: sourceId);
+  } catch (_) {}
+  if (!context.mounted) return;
   warmSsoAvailability(context);
   pushOnce(
     context,

--- a/src/packages/flutter-app/lib/screens/landing/landing_hero.dart
+++ b/src/packages/flutter-app/lib/screens/landing/landing_hero.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../l10n/l10n.dart';
 import '../../providers/suggestions_provider.dart';
+import '../../services/pending_prompt.dart';
 import '../../theme/app_colors.dart';
 import '../../theme/app_typography.dart';
 import '../../theme/spacing.dart';
@@ -13,8 +14,8 @@ import 'landing_handoff.dart';
 
 /// The hero prompt field caps input at the handoff store's limit so the two
 /// can never disagree about how long a first prompt may be
-/// (specs/landing-prompt-handoff).
-const int kLandingPromptMaxLength = 2000;
+/// (specs/landing-prompt-handoff — the store constant is the one source).
+const int kLandingPromptMaxLength = PendingPromptStore.maxPromptLength;
 
 /// Full-bleed landing hero: the Santorini photo dissolving into the landing
 /// canvas, a Marcellus headline, and a REAL prompt input — the product's

--- a/src/packages/flutter-app/lib/services/analytics_api_service.dart
+++ b/src/packages/flutter-app/lib/services/analytics_api_service.dart
@@ -17,6 +17,7 @@ class AnalyticsApiService {
   static const Set<String> _anonymousEventTypes = {
     'landing_viewed',
     'booking_link_clicked',
+    'landing_prompt_submitted',
   };
 
   /// Records a place added to a trip from a browse surface
@@ -59,6 +60,27 @@ class AnalyticsApiService {
   /// Top of the funnel: a signed-out visitor rendered the landing page.
   /// Call sites guard this to once per app session.
   Future<void> recordLandingViewed() => _record('landing_viewed');
+
+  /// A landing prompt was handed to sign-up (specs/landing-prompt-handoff).
+  /// [surface] is 'hero' (the prompt field, typed or chip-prefilled) or
+  /// 'card' (a destination-rail card); [kind] carries the destination slug
+  /// for cards. The prompt TEXT never rides analytics. Sent anonymously —
+  /// the submitter is by definition signed out.
+  Future<void> recordLandingPromptSubmitted({
+    required String surface,
+    String? kind,
+  }) {
+    return _record(
+      'landing_prompt_submitted',
+      metadata: {'surface': surface, if (kind != null) 'kind': kind},
+    );
+  }
+
+  /// The stored landing prompt reached the signed-in composer — the funnel's
+  /// closing bracket (landing_prompt_submitted → user_registered → this).
+  /// Authed-only by nature: consume requires a session.
+  Future<void> recordPendingPromptConsumed({required String surface}) =>
+      _record('pending_prompt_consumed', metadata: {'surface': surface});
 
   /// Transition telemetry (specs/server-leg-dates): the server `legs`
   /// payload and the local derivation disagreed on a trip load. Expected

--- a/src/packages/flutter-app/lib/services/pending_connect.dart
+++ b/src/packages/flutter-app/lib/services/pending_connect.dart
@@ -41,6 +41,23 @@ class PendingConnectStore {
     }
   }
 
+  /// Non-destructive: whether a fresh request is waiting. The landing-prompt
+  /// resume (specs/landing-prompt-handoff) defers behind an active connect
+  /// flow — that flow ends in a full-page redirect to the external client,
+  /// which would strand a prompt consumed into the dying page's memory.
+  Future<bool> hasPending() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final token = prefs.getString(_tokenKey);
+      final savedAt = prefs.getInt(_savedAtKey);
+      if (token == null || token.isEmpty || savedAt == null) return false;
+      final age = DateTime.now().toUtc().millisecondsSinceEpoch - savedAt;
+      return age >= 0 && age <= maxAge.inMilliseconds;
+    } catch (_) {
+      return false;
+    }
+  }
+
   /// Returns the pending request token and forgets it — single use, so a
   /// completed or abandoned link can never replay on a later sign-in. Null
   /// when nothing is pending or the record aged out.

--- a/src/packages/flutter-app/lib/services/pending_prompt.dart
+++ b/src/packages/flutter-app/lib/services/pending_prompt.dart
@@ -1,0 +1,129 @@
+import 'package:flutter/foundation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// A landing prompt waiting on a session (specs/landing-prompt-handoff).
+///
+/// [sourceId] is the destination-photo slug when a rail card produced the
+/// prompt, null for typed text; it feeds the consume event's `surface`
+/// metadata and nothing else.
+class PendingPrompt {
+  final String text;
+  final String? sourceId;
+  final int savedAtMs;
+
+  const PendingPrompt({
+    required this.text,
+    this.sourceId,
+    required this.savedAtMs,
+  });
+}
+
+/// Remembers the visitor's landing prompt across the sign-up round trip
+/// (specs/landing-prompt-handoff), the same way [PendingConnectStore] carries
+/// the connector consent request: Google/Apple sign-in navigate the whole
+/// page away and come back at /sso/<code>, so every scrap of in-memory state
+/// is gone by the time there is a session. SharedPreferences is localStorage
+/// on web, which survives that reload.
+///
+/// One writer (the landing handoff), one consumer
+/// (`pendingPromptResumeProvider`). One slot, last-write-wins; `take()` is
+/// single-use and clears before validating, so a stale or malformed record
+/// can never replay on a later sign-in.
+class PendingPromptStore {
+  static const _textKey = 'pending_prompt.text';
+  static const _chipKey = 'pending_prompt.chip';
+  static const _savedAtKey = 'pending_prompt.saved_at';
+
+  /// No server token bounds this (unlike PendingConnect's 15 minutes), so the
+  /// window only has to cover sign-up plus the onboarding quiz comfortably
+  /// while making "a forgotten prompt fires days later" impossible.
+  static const maxAge = Duration(minutes: 30);
+
+  /// The one source of truth for how long a first prompt may be — the hero
+  /// field's `maxLength` reads this so the input and the store can never
+  /// disagree.
+  static const int maxPromptLength = 2000;
+
+  /// Write-through mirror: the email+password path never reloads the page,
+  /// so the prompt survives even when device storage is unavailable (private
+  /// browsing, full quota). SSO's full-page reload wipes it — prefs cover
+  /// that path. Static for the same reason `LandingScreen._viewRecorded` is:
+  /// the store is const-constructed at several sites but the slot is one.
+  static PendingPrompt? _memory;
+
+  /// Resets the in-memory slot so tests can isolate runs.
+  @visibleForTesting
+  static void resetMemoryForTest() => _memory = null;
+
+  const PendingPromptStore();
+
+  /// Every method swallows storage failures. Losing the prompt costs the
+  /// user a retype, whereas an exception here would break the sign-up
+  /// handoff itself.
+
+  /// Records [text] (trimmed, capped at [maxPromptLength]) as waiting on a
+  /// session. Call — and await — BEFORE any navigation toward auth. Empty
+  /// or whitespace-only text is not stored.
+  Future<void> save(String text, {String? sourceId}) async {
+    final trimmed = text.trim();
+    if (trimmed.isEmpty) return;
+    final capped = trimmed.length > maxPromptLength
+        ? trimmed.substring(0, maxPromptLength)
+        : trimmed;
+    final now = DateTime.now().toUtc().millisecondsSinceEpoch;
+    _memory = PendingPrompt(text: capped, sourceId: sourceId, savedAtMs: now);
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setString(_textKey, capped);
+      if (sourceId != null) {
+        await prefs.setString(_chipKey, sourceId);
+      } else {
+        await prefs.remove(_chipKey);
+      }
+      await prefs.setInt(_savedAtKey, now);
+    } catch (_) {
+      // Best effort — the memory mirror still covers the same-page paths.
+    }
+  }
+
+  /// Returns the pending prompt and forgets it — storage AND mirror, before
+  /// any validation, so nothing lingers after a consume attempt. Null when
+  /// nothing is pending or the record aged out (both slots age-checked: a
+  /// tab parked on the auth screen for an hour holds the mirror without a
+  /// reload).
+  Future<PendingPrompt?> take() async {
+    final mirror = _memory;
+    _memory = null;
+    PendingPrompt? stored;
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final text = prefs.getString(_textKey);
+      final chip = prefs.getString(_chipKey);
+      final savedAt = prefs.getInt(_savedAtKey);
+      await clear();
+      if (text != null && text.isNotEmpty && savedAt != null) {
+        stored = PendingPrompt(text: text, sourceId: chip, savedAtMs: savedAt);
+      }
+    } catch (_) {
+      // Storage unavailable — the mirror below is all we have.
+    }
+    final candidate = mirror ?? stored;
+    if (candidate == null) return null;
+    final age =
+        DateTime.now().toUtc().millisecondsSinceEpoch - candidate.savedAtMs;
+    if (age < 0 || age > maxAge.inMilliseconds) return null;
+    return candidate;
+  }
+
+  Future<void> clear() async {
+    _memory = null;
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.remove(_textKey);
+      await prefs.remove(_chipKey);
+      await prefs.remove(_savedAtKey);
+    } catch (_) {
+      // Best effort — see the note above.
+    }
+  }
+}

--- a/src/packages/flutter-app/lib/services/pending_prompt.dart
+++ b/src/packages/flutter-app/lib/services/pending_prompt.dart
@@ -1,3 +1,4 @@
+import 'package:characters/characters.dart';
 import 'package:flutter/foundation.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -67,8 +68,10 @@ class PendingPromptStore {
   Future<void> save(String text, {String? sourceId}) async {
     final trimmed = text.trim();
     if (trimmed.isEmpty) return;
-    final capped = trimmed.length > maxPromptLength
-        ? trimmed.substring(0, maxPromptLength)
+    // Grapheme clusters, not code units: the hero field's maxLength counts
+    // characters, and a substring cap could split a surrogate pair.
+    final capped = trimmed.characters.length > maxPromptLength
+        ? trimmed.characters.take(maxPromptLength).toString()
         : trimmed;
     final now = DateTime.now().toUtc().millisecondsSinceEpoch;
     _memory = PendingPrompt(text: capped, sourceId: sourceId, savedAtMs: now);

--- a/src/packages/flutter-app/lib/widgets/chat_panel.dart
+++ b/src/packages/flutter-app/lib/widgets/chat_panel.dart
@@ -345,6 +345,22 @@ class _ChatPanelState extends ConsumerState<ChatPanel> {
         s.streamingText == null &&
         s.queuedMessages.isEmpty));
 
+    // External draft-text writes (the pending-prompt resume,
+    // specs/landing-prompt-handoff) reach a MOUNTED composer too — without
+    // this an external chatDraftProvider write lands only on the next
+    // remount's _restoreDraft, a silent-loss window. Loop-safe: _saveDraft
+    // echoes every keystroke into the provider, so for our own edits `next`
+    // already equals the controller text and the guard no-ops.
+    ref.listen(chatDraftProvider(_draftKey).select((d) => d.text), (_, next) {
+      if (next == _controller.text) return;
+      // Never assign controller.text — that parks the caret at -1 (see
+      // _restoreDraft).
+      _controller.value = TextEditingValue(
+        text: next,
+        selection: TextSelection.collapsed(offset: next.length),
+      );
+    });
+
     ref.listen(widget.state.select((s) => s.streamingText),
         (_, __) => _scrollToBottom());
     ref.listen(widget.state.select((s) => s.messages.length),

--- a/src/packages/flutter-app/pubspec.lock
+++ b/src/packages/flutter-app/pubspec.lock
@@ -130,7 +130,7 @@ packages:
     source: hosted
     version: "8.12.0"
   characters:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: characters
       sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803

--- a/src/packages/flutter-app/pubspec.yaml
+++ b/src/packages/flutter-app/pubspec.yaml
@@ -30,6 +30,9 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  # Grapheme-cluster truncation in PendingPromptStore (already pinned by
+  # Flutter itself; direct dependency so the import is honest).
+  characters: ^1.0.0
   # Path-style web URLs (usePathUrlStrategy in main.dart).
   flutter_web_plugins:
     sdk: flutter

--- a/src/packages/flutter-app/test/chat_panel_external_draft_test.dart
+++ b/src/packages/flutter-app/test/chat_panel_external_draft_test.dart
@@ -1,0 +1,110 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:travel_route_planner/providers/dictation_provider.dart';
+import 'package:travel_route_planner/providers/plan_provider.dart';
+import 'package:travel_route_planner/services/api_client.dart';
+import 'package:travel_route_planner/services/dictation_controller.dart';
+import 'package:travel_route_planner/services/dictation_engine.dart';
+import 'package:travel_route_planner/services/plan_service.dart';
+import 'package:travel_route_planner/widgets/chat_panel.dart';
+
+import 'support/l10n_test_app.dart';
+
+/// An EXTERNAL `chatDraftProvider` write reaches a MOUNTED composer
+/// (specs/landing-prompt-handoff): the pending-prompt resume writes the draft
+/// from outside the panel, possibly after the panel is already up. Before the
+/// listener, such a write landed only on the next remount's `_restoreDraft` —
+/// a silent-loss window.
+
+class _NoDictationEngine implements DictationEngine {
+  @override
+  Future<bool> initialize() async => false;
+  @override
+  Stream<DictationEvent> start() => const Stream.empty();
+  @override
+  Future<void> stop() async {}
+  @override
+  Future<void> cancel() async {}
+}
+
+class _StubPlanService extends PlanService {
+  _StubPlanService() : super('http://unused');
+
+  @override
+  Stream<PlanEvent> streamPlan(
+    List<Map<String, dynamic>> messages, {
+    String? bearerToken,
+    String? chatId,
+    String? tripId,
+    String? summary,
+    Future<void>? abortTrigger,
+  }) async* {
+    yield PlanEvent(type: 'text_delta', data: {'text': 'ok'});
+  }
+}
+
+void main() {
+  Future<ProviderContainer> pumpPanel(WidgetTester tester) async {
+    final notifier = PlanNotifier(_StubPlanService(), ApiClient());
+    final provider =
+        StateNotifierProvider<PlanNotifier, PlanState>((ref) => notifier);
+    await tester.pumpWidget(ProviderScope(
+      overrides: [
+        dictationControllerFactoryProvider.overrideWithValue(
+          (textController) => DictationController(
+            textController: textController,
+            primary: _NoDictationEngine(),
+            fallback: null,
+            fallbackAvailable: () async => false,
+          ),
+        ),
+      ],
+      child: MaterialApp(
+        localizationsDelegates: testLocalizationsDelegates,
+        home: Scaffold(
+          body: ChatPanel(state: provider, notifier: provider.notifier),
+        ),
+      ),
+    ));
+    await tester.pump();
+    return ProviderScope.containerOf(tester.element(find.byType(ChatPanel)));
+  }
+
+  TextEditingController composer(WidgetTester tester) =>
+      tester.widget<TextField>(find.byType(TextField).first).controller!;
+
+  testWidgets('an external draft write lands in the mounted composer, caret '
+      'at the end', (tester) async {
+    final container = await pumpPanel(tester);
+
+    container
+        .read(chatDraftProvider(chatDraftKeyFor(null)).notifier)
+        .setText('A week in Rome');
+    await tester.pump();
+
+    final controller = composer(tester);
+    expect(controller.text, 'A week in Rome');
+    expect(controller.selection.baseOffset, 'A week in Rome'.length);
+  });
+
+  testWidgets('typing after an external write round-trips without loops',
+      (tester) async {
+    final container = await pumpPanel(tester);
+
+    container
+        .read(chatDraftProvider(chatDraftKeyFor(null)).notifier)
+        .setText('A week in Rome');
+    await tester.pump();
+
+    await tester.enterText(
+        find.byType(TextField).first, 'A week in Rome in May');
+    await tester.pump();
+
+    expect(composer(tester).text, 'A week in Rome in May');
+    // The keystroke echoed into the draft (the _saveDraft path still works).
+    expect(container.read(chatDraftProvider(chatDraftKeyFor(null))).text,
+        'A week in Rome in May');
+  });
+}

--- a/src/packages/flutter-app/test/landing_default_handoff_test.dart
+++ b/src/packages/flutter-app/test/landing_default_handoff_test.dart
@@ -5,11 +5,13 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:travel_route_planner/providers/analytics_provider.dart';
 import 'package:travel_route_planner/providers/auth_provider.dart';
+import 'package:travel_route_planner/providers/suggestions_provider.dart';
 import 'package:travel_route_planner/screens/auth_screen.dart';
 import 'package:travel_route_planner/screens/landing_screen.dart';
 import 'package:travel_route_planner/services/analytics_api_service.dart';
 import 'package:travel_route_planner/services/api_client.dart';
 import 'package:travel_route_planner/services/pending_prompt.dart';
+import 'package:travel_route_planner/widgets/destination_suggestion_card.dart';
 
 import 'support/l10n_test_app.dart';
 import 'support/url_sync_fakes.dart';
@@ -68,7 +70,10 @@ void main() {
     LandingScreen.resetViewRecordedForTest();
   });
 
-  Future<_RecordingAnalytics> pumpLanding(WidgetTester tester) async {
+  Future<_RecordingAnalytics> pumpLanding(
+    WidgetTester tester, {
+    List<Override> overrides = const [],
+  }) async {
     await tester.binding.setSurfaceSize(const Size(800, 900));
     addTearDown(() => tester.binding.setSurfaceSize(null));
     final analytics = _RecordingAnalytics();
@@ -80,6 +85,7 @@ void main() {
         authProvider.overrideWith((ref) => FakeAuthNotifier(null)),
         googleSsoAvailableProvider.overrideWith((ref) async => false),
         appleSsoAvailableProvider.overrideWith((ref) async => false),
+        ...overrides,
       ],
       child: localizedTestApp(home: const LandingScreen()),
     ));
@@ -106,5 +112,31 @@ void main() {
     final stored = await const PendingPromptStore().take();
     expect(stored?.text, 'A week in Rome');
     expect(stored?.sourceId, isNull);
+  });
+
+  testWidgets('destination card: store written with the slug, card event '
+      'recorded, sign-up pushed', (tester) async {
+    final analytics = await pumpLanding(tester,
+        overrides: [
+          // Identity order so the first card is pool[0] deterministically.
+          suggestionOrderProvider.overrideWithValue(
+              () => List.generate(suggestionPool.length, (i) => i)),
+        ]);
+
+    final card = find.byType(DestinationSuggestionCard).first;
+    await tester.ensureVisible(card);
+    await tester.pumpAndSettle();
+    final prompt = tester.widget<DestinationSuggestionCard>(card).prompt;
+
+    await tester.tap(card);
+    await tester.pumpAndSettle();
+
+    expect(find.byType(AuthScreen), findsOneWidget);
+    expect(analytics.submitted, hasLength(1));
+    expect(analytics.submitted.single.surface, 'card');
+    expect(analytics.submitted.single.kind, 'paris');
+    final stored = await const PendingPromptStore().take();
+    expect(stored?.text, prompt);
+    expect(stored?.sourceId, 'paris');
   });
 }

--- a/src/packages/flutter-app/test/landing_default_handoff_test.dart
+++ b/src/packages/flutter-app/test/landing_default_handoff_test.dart
@@ -1,0 +1,110 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:travel_route_planner/providers/analytics_provider.dart';
+import 'package:travel_route_planner/providers/auth_provider.dart';
+import 'package:travel_route_planner/screens/auth_screen.dart';
+import 'package:travel_route_planner/screens/landing_screen.dart';
+import 'package:travel_route_planner/services/analytics_api_service.dart';
+import 'package:travel_route_planner/services/api_client.dart';
+import 'package:travel_route_planner/services/pending_prompt.dart';
+
+import 'support/l10n_test_app.dart';
+import 'support/url_sync_fakes.dart';
+
+/// The REAL landing handoff (no provider override): submitting the hero
+/// prompt persists it BEFORE navigation, records the anonymous funnel event,
+/// and continues into sign-up (specs/landing-prompt-handoff).
+
+class _RecordingAnalytics implements AnalyticsApiService {
+  final submitted = <({String surface, String? kind})>[];
+
+  @override
+  ApiClient get apiClient => throw UnimplementedError();
+
+  @override
+  Future<void> recordLandingPromptSubmitted(
+      {required String surface, String? kind}) {
+    submitted.add((surface: surface, kind: kind));
+    return Future.value();
+  }
+
+  @override
+  Future<void> recordPendingPromptConsumed({required String surface}) =>
+      Future.value();
+
+  @override
+  Future<void> recordLandingViewed() => Future.value();
+
+  @override
+  Future<void> recordBookingLinkClicked({
+    String? tripId,
+    String? todoKey,
+    String? provider,
+    String? surface,
+    String? kind,
+  }) =>
+      Future.value();
+
+  @override
+  Future<void> recordItineraryItemAdded({
+    required String tripId,
+    required String source,
+  }) =>
+      Future.value();
+
+  @override
+  Future<void> recordLegsParityMismatch(
+          {required String tripId, required List<String> details}) =>
+      Future.value();
+}
+
+void main() {
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    PendingPromptStore.resetMemoryForTest();
+    LandingScreen.resetViewRecordedForTest();
+  });
+
+  Future<_RecordingAnalytics> pumpLanding(WidgetTester tester) async {
+    await tester.binding.setSurfaceSize(const Size(800, 900));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    final analytics = _RecordingAnalytics();
+    await tester.pumpWidget(ProviderScope(
+      overrides: [
+        analyticsApiServiceProvider.overrideWithValue(analytics),
+        // The push lands on the real AuthScreen; keep its session and SSO
+        // availability deterministic and offline.
+        authProvider.overrideWith((ref) => FakeAuthNotifier(null)),
+        googleSsoAvailableProvider.overrideWith((ref) async => false),
+        appleSsoAvailableProvider.overrideWith((ref) async => false),
+      ],
+      child: localizedTestApp(home: const LandingScreen()),
+    ));
+    await tester.pumpAndSettle();
+    return analytics;
+  }
+
+  testWidgets('hero submit: store written (trimmed), event recorded, '
+      'sign-up pushed', (tester) async {
+    final analytics = await pumpLanding(tester);
+
+    await tester.enterText(
+        find.byKey(const Key('landing-prompt-input')), '  A week in Rome  ');
+    await tester.pump();
+    await tester.tap(find.byKey(const Key('landing-prompt-submit')));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(AuthScreen), findsOneWidget);
+    expect(
+        tester.widget<AuthScreen>(find.byType(AuthScreen)).initialIsLogin,
+        isFalse);
+    expect(analytics.submitted,
+        [(surface: 'hero', kind: null)]);
+    final stored = await const PendingPromptStore().take();
+    expect(stored?.text, 'A week in Rome');
+    expect(stored?.sourceId, isNull);
+  });
+}

--- a/src/packages/flutter-app/test/landing_polish_test.dart
+++ b/src/packages/flutter-app/test/landing_polish_test.dart
@@ -22,6 +22,15 @@ import 'support/l10n_test_app.dart';
 
 class _NoopAnalytics implements AnalyticsApiService {
   @override
+  Future<void> recordLandingPromptSubmitted(
+          {required String surface, String? kind}) =>
+      Future.value();
+
+  @override
+  Future<void> recordPendingPromptConsumed({required String surface}) =>
+      Future.value();
+
+  @override
   Future<void> recordLegsParityMismatch(
           {required String tripId, required List<String> details}) =>
       Future.value();

--- a/src/packages/flutter-app/test/landing_screen_analytics_test.dart
+++ b/src/packages/flutter-app/test/landing_screen_analytics_test.dart
@@ -12,6 +12,15 @@ import 'support/l10n_test_app.dart';
 /// Counts landing-view records instead of hitting the network.
 class _CountingAnalytics implements AnalyticsApiService {
   @override
+  Future<void> recordLandingPromptSubmitted(
+          {required String surface, String? kind}) =>
+      Future.value();
+
+  @override
+  Future<void> recordPendingPromptConsumed({required String surface}) =>
+      Future.value();
+
+  @override
   Future<void> recordLegsParityMismatch(
           {required String tripId, required List<String> details}) =>
       Future.value();
@@ -84,6 +93,15 @@ void main() {
 }
 
 class _ThrowingAnalytics implements AnalyticsApiService {
+  @override
+  Future<void> recordLandingPromptSubmitted(
+          {required String surface, String? kind}) =>
+      Future.value();
+
+  @override
+  Future<void> recordPendingPromptConsumed({required String surface}) =>
+      Future.value();
+
   @override
   Future<void> recordLegsParityMismatch(
           {required String tripId, required List<String> details}) =>

--- a/src/packages/flutter-app/test/language_menu_button_test.dart
+++ b/src/packages/flutter-app/test/language_menu_button_test.dart
@@ -52,6 +52,15 @@ class _FakeAuthService extends AuthService {
 
 class _NoopAnalytics implements AnalyticsApiService {
   @override
+  Future<void> recordLandingPromptSubmitted(
+          {required String surface, String? kind}) =>
+      Future.value();
+
+  @override
+  Future<void> recordPendingPromptConsumed({required String surface}) =>
+      Future.value();
+
+  @override
   Future<void> recordLegsParityMismatch(
           {required String tripId, required List<String> details}) =>
       Future.value();

--- a/src/packages/flutter-app/test/overnight_segment_ui_test.dart
+++ b/src/packages/flutter-app/test/overnight_segment_ui_test.dart
@@ -19,6 +19,15 @@ import 'support/l10n_test_app.dart';
 
 class _NoopAnalytics implements AnalyticsApiService {
   @override
+  Future<void> recordLandingPromptSubmitted(
+          {required String surface, String? kind}) =>
+      Future.value();
+
+  @override
+  Future<void> recordPendingPromptConsumed({required String surface}) =>
+      Future.value();
+
+  @override
   dynamic noSuchMethod(Invocation invocation) => Future.value();
 }
 

--- a/src/packages/flutter-app/test/pending_prompt_resume_test.dart
+++ b/src/packages/flutter-app/test/pending_prompt_resume_test.dart
@@ -191,6 +191,55 @@ void main() {
     expect(analytics.consumed, isEmpty);
   });
 
+  testWidgets('a pending connector consent defers the consume; the prompt '
+      'survives for the next sign-in', (tester) async {
+    await const PendingPromptStore().save('A week in Rome');
+    // An active connect flow ends in a full-page redirect — consuming now
+    // would strand the prompt in the dying page's memory.
+    final freshConnect =
+        DateTime.now().toUtc().millisecondsSinceEpoch;
+    SharedPreferences.setMockInitialValues({
+      'pending_prompt.text': 'A week in Rome',
+      'pending_prompt.saved_at': freshConnect,
+      'pending_connect.request_token': 'gt_rq_live',
+      'pending_connect.saved_at': freshConnect,
+    });
+    PendingPromptStore.resetMemoryForTest();
+    final (container, auth, analytics) = await pumpHost(tester);
+
+    auth.signIn(fakeUser());
+    await tester.pumpAndSettle();
+
+    expect(draftText(container), isEmpty);
+    expect(analytics.consumed, isEmpty);
+    // The prompt is still stored for the sign-in after the connect flow.
+    expect((await const PendingPromptStore().take())?.text, 'A week in Rome');
+  });
+
+  testWidgets('a boot target consumed in a PREVIOUS sign-in cycle does not '
+      'suppress the Plan-tab preselect after sign-out', (tester) async {
+    final (container, auth, _) = await pumpHost(tester);
+    container
+        .read(urlSyncProvider)
+        .registerBootTarget(const BootTarget(AppTab.trips, tripId: 't1'));
+
+    // Cycle 1: deep-linked sign-in consumes the boot target.
+    auth.signIn(fakeUser());
+    await tester.pumpAndSettle();
+    expect(container.read(navIndexProvider), AppTab.trips.index);
+
+    // Cycle 2: sign out, a fresh landing prompt, sign back in — the old
+    // deep link must not steal this cycle's tab.
+    auth.signOut();
+    await tester.pumpAndSettle();
+    await const PendingPromptStore().save('A week in Rome');
+    auth.signIn(fakeUser());
+    await tester.pumpAndSettle();
+
+    expect(draftText(container), 'A week in Rome');
+    expect(container.read(navIndexProvider), AppTab.plan.index);
+  });
+
   testWidgets('sign-out then a new submit consumes again in the same run',
       (tester) async {
     await const PendingPromptStore().save('first trip');

--- a/src/packages/flutter-app/test/pending_prompt_resume_test.dart
+++ b/src/packages/flutter-app/test/pending_prompt_resume_test.dart
@@ -1,0 +1,213 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:travel_route_planner/models/user.dart';
+import 'package:travel_route_planner/navigation/app_nav.dart';
+import 'package:travel_route_planner/navigation/app_routes.dart';
+import 'package:travel_route_planner/navigation/url_sync.dart';
+import 'package:travel_route_planner/providers/analytics_provider.dart';
+import 'package:travel_route_planner/providers/auth_provider.dart';
+import 'package:travel_route_planner/providers/pending_prompt_provider.dart';
+import 'package:travel_route_planner/providers/plan_provider.dart';
+import 'package:travel_route_planner/services/analytics_api_service.dart';
+import 'package:travel_route_planner/services/api_client.dart';
+import 'package:travel_route_planner/services/pending_prompt.dart';
+
+import 'support/url_sync_fakes.dart';
+
+/// The ONE consume point for a landing prompt
+/// (specs/landing-prompt-handoff): fires exactly when the session becomes
+/// signed-in AND onboarded, prefills the Agent composer draft, preselects the
+/// Plan tab unless a deep link chose a destination, and never replays.
+
+class _RecordingAnalytics implements AnalyticsApiService {
+  final consumed = <String>[];
+
+  @override
+  ApiClient get apiClient => throw UnimplementedError();
+
+  @override
+  Future<void> recordPendingPromptConsumed({required String surface}) {
+    consumed.add(surface);
+    return Future.value();
+  }
+
+  @override
+  Future<void> recordLandingPromptSubmitted(
+          {required String surface, String? kind}) =>
+      Future.value();
+
+  @override
+  Future<void> recordLandingViewed() => Future.value();
+
+  @override
+  Future<void> recordBookingLinkClicked({
+    String? tripId,
+    String? todoKey,
+    String? provider,
+    String? surface,
+    String? kind,
+  }) =>
+      Future.value();
+
+  @override
+  Future<void> recordItineraryItemAdded({
+    required String tripId,
+    required String source,
+  }) =>
+      Future.value();
+
+  @override
+  Future<void> recordLegsParityMismatch(
+          {required String tripId, required List<String> details}) =>
+      Future.value();
+}
+
+UserModel _onboardingUser() => UserModel(
+      id: 'user-2',
+      email: 'new@example.com',
+      displayName: 'New',
+      createdAt: DateTime(2026, 1, 1),
+      needsOnboarding: true,
+    );
+
+void main() {
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    PendingPromptStore.resetMemoryForTest();
+  });
+
+  /// Pumps a minimal tree that keeps [pendingPromptResumeProvider] alive from
+  /// the first frame, exactly as TravelRoutePlannerApp's watch does.
+  Future<(ProviderContainer, FakeAuthNotifier, _RecordingAnalytics)> pumpHost(
+    WidgetTester tester, {
+    UserModel? user,
+  }) async {
+    final auth = FakeAuthNotifier(user);
+    final analytics = _RecordingAnalytics();
+    await tester.pumpWidget(ProviderScope(
+      overrides: [
+        authProvider.overrideWith((ref) => auth),
+        analyticsApiServiceProvider.overrideWithValue(analytics),
+        urlReporterProvider.overrideWithValue((_) {}),
+      ],
+      child: Consumer(builder: (context, ref, _) {
+        ref.watch(pendingPromptResumeProvider);
+        return const MaterialApp(home: SizedBox());
+      }),
+    ));
+    final container =
+        ProviderScope.containerOf(tester.element(find.byType(Consumer)));
+    return (container, auth, analytics);
+  }
+
+  String draftText(ProviderContainer c) =>
+      c.read(chatDraftProvider(chatDraftKeyFor(null))).text;
+
+  testWidgets('sign-in transition consumes: draft prefilled, Plan tab '
+      'selected, consume recorded', (tester) async {
+    await const PendingPromptStore().save('A week in Rome', sourceId: 'rome');
+    final (container, auth, analytics) = await pumpHost(tester);
+
+    auth.signIn(fakeUser());
+    await tester.pumpAndSettle();
+
+    expect(draftText(container), 'A week in Rome');
+    expect(container.read(navIndexProvider), AppTab.plan.index);
+    expect(analytics.consumed, ['card']);
+    // Single use: nothing left for a later transition.
+    expect(await const PendingPromptStore().take(), isNull);
+  });
+
+  testWidgets('already-eligible cold boot consumes via the post-frame check',
+      (tester) async {
+    await const PendingPromptStore().save('Street food in Bangkok');
+    final (container, _, analytics) = await pumpHost(tester, user: fakeUser());
+    await tester.pumpAndSettle();
+
+    expect(draftText(container), 'Street food in Bangkok');
+    expect(analytics.consumed, ['hero']);
+  });
+
+  testWidgets('withheld while needsOnboarding; fires when the quiz completes',
+      (tester) async {
+    await const PendingPromptStore().save('A week in Rome');
+    final (container, auth, _) = await pumpHost(tester);
+
+    auth.signIn(_onboardingUser());
+    await tester.pumpAndSettle();
+    expect(draftText(container), isEmpty);
+
+    // The quiz finishing (or Skip) flips the flag on the same user.
+    auth.signIn(fakeUser());
+    await tester.pumpAndSettle();
+    expect(draftText(container), 'A week in Rome');
+  });
+
+  testWidgets('a boot target keeps its tab; the draft still lands',
+      (tester) async {
+    await const PendingPromptStore().save('A week in Rome');
+    final (container, auth, _) = await pumpHost(tester);
+    container
+        .read(urlSyncProvider)
+        .registerBootTarget(const BootTarget(AppTab.trips, tripId: 't1'));
+
+    auth.signIn(fakeUser());
+    await tester.pumpAndSettle();
+
+    expect(draftText(container), 'A week in Rome');
+    // The deep-linked destination wins the tab.
+    expect(container.read(navIndexProvider), isNot(AppTab.plan.index));
+  });
+
+  testWidgets('nothing pending: a transition changes nothing', (tester) async {
+    final (container, auth, analytics) = await pumpHost(tester);
+
+    auth.signIn(fakeUser());
+    await tester.pumpAndSettle();
+
+    expect(draftText(container), isEmpty);
+    expect(container.read(navIndexProvider), AppTab.home.index);
+    expect(analytics.consumed, isEmpty);
+  });
+
+  testWidgets('a stale prompt is not applied', (tester) async {
+    final tooOld = DateTime.now()
+        .toUtc()
+        .subtract(PendingPromptStore.maxAge + const Duration(minutes: 1))
+        .millisecondsSinceEpoch;
+    SharedPreferences.setMockInitialValues({
+      'pending_prompt.text': 'forgotten idea',
+      'pending_prompt.saved_at': tooOld,
+    });
+    final (container, auth, analytics) = await pumpHost(tester);
+
+    auth.signIn(fakeUser());
+    await tester.pumpAndSettle();
+
+    expect(draftText(container), isEmpty);
+    expect(analytics.consumed, isEmpty);
+  });
+
+  testWidgets('sign-out then a new submit consumes again in the same run',
+      (tester) async {
+    await const PendingPromptStore().save('first trip');
+    final (container, auth, analytics) = await pumpHost(tester);
+
+    auth.signIn(fakeUser());
+    await tester.pumpAndSettle();
+    expect(draftText(container), 'first trip');
+
+    auth.signOut();
+    await tester.pumpAndSettle();
+    // A fresh landing submit while signed out…
+    await const PendingPromptStore().save('second trip');
+    auth.signIn(fakeUser());
+    await tester.pumpAndSettle();
+
+    expect(draftText(container), 'second trip');
+    expect(analytics.consumed, hasLength(2));
+  });
+}

--- a/src/packages/flutter-app/test/pending_prompt_test.dart
+++ b/src/packages/flutter-app/test/pending_prompt_test.dart
@@ -1,0 +1,95 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:travel_route_planner/services/pending_prompt.dart';
+
+/// The landing prompt has to outlive a sign-in round trip that replaces the
+/// whole page (SSO), but must never seed an unrelated sign-in later on
+/// (specs/landing-prompt-handoff). Structure mirrors pending_connect_test.
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const store = PendingPromptStore();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    PendingPromptStore.resetMemoryForTest();
+  });
+
+  test('nothing pending yields null', () async {
+    expect(await store.take(), isNull);
+  });
+
+  test('a saved prompt comes back once — trimmed, with its source — then '
+      'is forgotten', () async {
+    await store.save('  A week in Rome  ', sourceId: 'rome');
+    final taken = await store.take();
+    expect(taken?.text, 'A week in Rome');
+    expect(taken?.sourceId, 'rome');
+    // Single use: a consumed prompt must not replay on the next sign-in.
+    expect(await store.take(), isNull);
+  });
+
+  test('a typed prompt carries no source id', () async {
+    await store.save('Tapas crawl in San Sebastián');
+    expect((await store.take())?.sourceId, isNull);
+  });
+
+  test('empty and whitespace-only text is not stored', () async {
+    await store.save('   ');
+    expect(await store.take(), isNull);
+  });
+
+  test('text is capped at maxPromptLength', () async {
+    await store.save('x' * (PendingPromptStore.maxPromptLength + 500));
+    expect(
+        (await store.take())?.text.length, PendingPromptStore.maxPromptLength);
+  });
+
+  test('a second save overwrites the first — one slot, last write wins',
+      () async {
+    await store.save('first idea', sourceId: 'paris');
+    await store.save('second idea');
+    final taken = await store.take();
+    expect(taken?.text, 'second idea');
+    expect(taken?.sourceId, isNull);
+    expect(await store.take(), isNull);
+  });
+
+  test('clear drops a pending prompt', () async {
+    await store.save('A week in Rome');
+    await store.clear();
+    expect(await store.take(), isNull);
+  });
+
+  test('a stale stored record is ignored', () async {
+    final tooOld = DateTime.now()
+        .toUtc()
+        .subtract(PendingPromptStore.maxAge + const Duration(minutes: 1))
+        .millisecondsSinceEpoch;
+    SharedPreferences.setMockInitialValues({
+      'pending_prompt.text': 'A week in Rome',
+      'pending_prompt.saved_at': tooOld,
+    });
+    expect(await store.take(), isNull);
+  });
+
+  test('a record without a timestamp is ignored', () async {
+    SharedPreferences.setMockInitialValues({
+      'pending_prompt.text': 'orphan',
+    });
+    expect(await store.take(), isNull);
+  });
+
+  test('the memory mirror survives a wiped preference store (private '
+      'browsing on the same-page email path)', () async {
+    await store.save('A week in Rome', sourceId: 'rome');
+    // Simulate storage that never accepted the write.
+    SharedPreferences.setMockInitialValues({});
+    final taken = await store.take();
+    expect(taken?.text, 'A week in Rome');
+    expect(taken?.sourceId, 'rome');
+    expect(await store.take(), isNull);
+  });
+}

--- a/src/packages/flutter-app/test/tracked_launch_test.dart
+++ b/src/packages/flutter-app/test/tracked_launch_test.dart
@@ -31,6 +31,15 @@ class _FakeUrlLauncher extends UrlLauncherPlatform {
 /// analytics failure never blocks the launch.
 class _RecordingAnalytics implements AnalyticsApiService {
   @override
+  Future<void> recordLandingPromptSubmitted(
+          {required String surface, String? kind}) =>
+      Future.value();
+
+  @override
+  Future<void> recordPendingPromptConsumed({required String surface}) =>
+      Future.value();
+
+  @override
   Future<void> recordLegsParityMismatch(
           {required String tripId, required List<String> details}) =>
       Future.value();


### PR DESCRIPTION
## Summary
- **Follow-up to #475** (was stacked as #476; GitHub closed it when the base branch merged+deleted — same commits, rebased onto main). specs/landing-prompt-handoff: the sentence a visitor types on the landing page survives auth and lands **prefilled** (never auto-sent) in the Agent composer, with the Plan tab preselected.
- `PendingPromptStore` (`lib/services/pending_prompt.dart`) — structural clone of `PendingConnectStore` + an in-memory write-through mirror for the no-reload email path: trimmed, grapheme-capped at 2000 (one constant shared with the hero field), 30-min expiry, single-use clear-before-validate, persisted BEFORE navigation so it survives the SSO full-page reload.
- `pendingPromptResumeProvider` — the ONE consume point, alive from frame 1 (watched in `main.dart` beside the URL-sync observer): fires when the session becomes signed-in AND onboarded; covers email sign-up + quiz (finish or skip), both SSO reloads, plain sign-in, and cold boot with **zero changes to AuthScreen or sso_callback_screen**. Defers behind a pending connector consent (that flow ends in a full-page redirect); a deep-link boot target keeps its tab via the new cycle-scoped `UrlSyncController.bootTargetSeen`.
- `ChatPanel` external-draft listener: a `chatDraftProvider` write now reaches a MOUNTED composer (previously a silent-loss window).
- Analytics: `landing_prompt_submitted` (anonymous whitelist; metadata `surface: hero|card` + `kind` slug — the prompt text never rides) and `pending_prompt_consumed` (authed); new "Prompts submitted" Trends series; instrumentation-events taxonomy updated.

## Testing
- `flutter analyze` clean; full suite green (1642 tests). `go vet`/`gofmt` clean; full Go suite green against the lane test DB.
- New: store unit tests (single-use, stale, truncation, memory mirror), resume tests (all auth paths, quiz withholding, boot-target tab rule incl. the cycle-2 regression, connect deferral, single-use, re-consume after sign-out), REAL-handoff widget tests (hero and card branches), ChatPanel external-draft tests, Go whitelist + timeseries stable-slot pins.
- Adversarial multi-agent review (4 dimensions × 2 refuters); all 5 confirmed findings fixed in the second commit.
- **End-to-end on the lane stack via CDP through the riskiest path**: type on landing → submit (localStorage holds the prompt) → `/sso/<code>` full-page reload → app lands on the Plan tab, composer prefilled with the exact text, store cleared.
- Brand lint (`brand-guidelines/scripts/check.sh`): 12 findings, all pre-existing chrome in files touched with one-line diffs (`chat_panel.dart` radii/shadows, `admin_metrics_screen.dart`, `destination_carousel.dart`) — none introduced by this stack; left for a dedicated cleanup rather than scope-creeping hub files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
