### PR TITLE
feat(auth): split-pane photo sign-in screen

### DIFF
--- a/specs/auth-redesign/plan.md
+++ b/specs/auth-redesign/plan.md
@@ -1,0 +1,84 @@
+# Plan: Auth screen split-pane redesign
+
+> **HOW.** See `spec.md` for what & why. Flutter-only; no API changes.
+
+## Technical Approach
+
+One file carries the redesign: `lib/screens/auth_screen.dart`. A single
+`LayoutBuilder` wrapping the whole `Scaffold` decides the layout — never
+`MediaQuery.sizeOf`, which is nondeterministic under widget-test
+`setSurfaceSize` and would also re-decide per-widget what must be one shared
+decision (the AppBar's icon colors depend on where the photo is). The form
+body is extracted verbatim into `_formScroller()` so all three layouts reuse
+it with zero changes inside the form column — that is what keeps the pinned
+geometry tests (`auth_screen_sso_order_test.dart`'s 24px title gap, the
+vertical ordering) passing unmodified.
+
+Layouts, decided by the incoming constraints:
+
+- `maxWidth >= 900` (**wide**, the landing family's breakpoint):
+  `Row[Expanded(_AuthPhotoPanel), SizedBox(width: formPaneWidth, form)]`
+  with `formPaneWidth = (maxWidth * 0.45).clamp(468, 560)` — the 468 floor is
+  the 420 auth column + 2×`AppSpacing.xl`, so the column never compresses;
+  the cap keeps the photo dominant on ultrawide.
+- narrow and `maxHeight >= 620` (**band**): `Column[SizedBox(height:
+  bandHeight, _AuthPhotoPanel), Expanded(form)]` with `bandHeight =
+  (maxHeight * 0.22).clamp(140, 220)`. The band is pinned outside the scroll
+  view. 620 is chosen so the 800×600 default test surface and 360×450
+  keyboard viewports render today's exact layout; on phones the keyboard
+  shrinking `maxHeight` below 620 collapses the band on purpose (form first
+  when typing) — commented in code, because "fixing" it with
+  `MediaQuery.sizeOf` is the repo's known widget-test trap.
+- otherwise: today's screen, byte-identical (no extend, null icon themes).
+
+`_AuthPhotoPanel` (private, bottom of the same file, `Key('auth-photo-panel')`)
+is the landing-hero idiom: `brandGradient` fallback → `hero_santorini.jpg`
+(`cover`, `excludeFromSemantics`, `gaplessPlayback`, 250ms fade
+`frameBuilder`, `errorBuilder` → shrink, `cacheWidth` quantized to 320px
+buckets against the panel's own constraints, not the window) → `heroScrim` →
+tagline bottom-left. `heroScrim` is `bottomLeft(brandDark 88%)→topRight(35%)`
+— darkest exactly where the tagline sits, so no new tokens are needed. No
+logo on the photo (the form column already brands; the landing hero's
+no-double-branding precedent). Tagline style is stated locally per the
+landing-hero precedent: `AppFonts.display` + explicit `w400` (Marcellus
+one-weight rule), white, `fontSize: wide ? 38 : 24`, height 1.15.
+
+AppBar: the one transparent bar stays; `extendBodyBehindAppBar: wide ||
+showBand`; `iconTheme` white whenever a photo reaches the top-left (both
+photo layouts); `actionsIconTheme` white only in band mode — on wide the
+globe sits over the light form pane and keeps the theme color. The wide form
+scroller's top padding adds `kToolbarHeight` so scroll-to-top clears the bar.
+
+## Flutter Changes
+
+- `lib/screens/auth_screen.dart` — the only screen file touched. Five
+  file-local layout consts with rationale comments (900 / 468 / 560 / 620 /
+  140–220); new imports `dart:math`, `app_colors.dart`, `app_typography.dart`.
+  No touch to state logic, listeners, `_submit`, dialogs, or `SsoButtons`.
+- `lib/l10n/app_en.arb` + `app_es.arb` — new `authTagline` ("Plan less.
+  Travel more." / "Planea menos. Viaja más."). Per-surface key rather than
+  reusing home's `homeHeroTitle`: a shared string is only shared while the
+  sites share a meaning (#464). Regen via `make flutter-gen-l10n`.
+- `test/auth_split_pane_test.dart` — new; reuses the sso-order test's fake
+  service/storage + `setSurfaceSize` pattern. Covers: wide pane full-height
+  with scrim/gradient/tagline beside the 420 column and white-back /
+  theme-globe bar slots; band pinned at the top on 420×1200 with both slots
+  white; 800×600 and 360×450 render today's chrome with no panel; es sign-up
+  at 360×690 with the band throws nothing; dark theme keeps the form on the
+  dark scheme surface.
+
+## Known Tradeoffs
+
+- Crossing 900px swaps the Scaffold body's root (Row↔Column), reparenting the
+  `Form`: controllers and provider error survive; transient field-validation
+  messages and focus reset. Mid-resize only; accepted.
+- The photo pane ends on a hard seam against the form pane — deliberately no
+  `landingHeroBlend` dissolve; the committed-dark treatment ends at sign-in.
+
+## Verification
+
+`make flutter-analyze`, full `make flutter-test` (run
+`auth_screen_sso_order_test.dart` first — it newly renders the band +
+`Image.asset` at 420×1200; if it breaks, fix the implementation, never the
+test), brand `check.sh` on the touched Dart files, CDP screenshots at
+1440×900 / ~950×800 / 390×844 / 360×640 in both themes and both locales.

--- a/specs/auth-redesign/spec.md
+++ b/specs/auth-redesign/spec.md
@@ -1,0 +1,64 @@
+# Spec: Auth screen split-pane redesign
+
+> **WHAT & WHY only.** Tech decisions live in `plan.md`.
+
+## Context
+
+The sign-in/sign-up screen is a flat centered column on the bare app surface —
+no photography, no responsiveness, no continuity with the landing page a
+visitor almost always arrives from. Every competitor cluster surveyed on
+Mobbin treats auth as a brand moment: the web field is unanimous on a
+split-pane layout (a quiet form beside a full-height brand photograph), and
+the premium mobile register is photo-first. This redesign gives the auth
+screen that atmosphere while leaving the form's behavior — which carries
+years of accumulated correctness (SSO gating, autofill auto-submit, handoff
+flows) — completely untouched.
+
+## User Stories
+
+- As a **visitor arriving from the landing page**, I want the sign-in screen
+  to feel like the same product — photography, the tagline, the brand's calm —
+  so the transition doesn't feel like falling out of the app.
+- As a **traveler on a phone**, I want the form to still be the first thing I
+  can use — the photo may set the scene, but it never buries the fields.
+- As a **returning user with a password manager**, I want everything about
+  how the form behaves (autofill, submit, SSO buttons) to work exactly as
+  before.
+
+## Acceptance Criteria
+
+- [ ] On wide screens (desktop-class), a full-height destination photograph
+      fills the left side under the brand scrim, with the tagline set in its
+      darkest corner; the sign-in form sits unchanged on the normal app
+      surface to the right.
+- [ ] On narrow screens tall enough to afford it, a pinned photo band with
+      the scrim and tagline sits above the form; the form scrolls beneath it.
+- [ ] On short viewports (small phones, keyboard open), the screen is exactly
+      today's layout — no photo, nothing displaced.
+- [ ] The back control is legible over the photo wherever the photo reaches
+      the top edge; the language menu stays visible and legible at every
+      width.
+- [ ] If the photograph fails to load or is still decoding, a brand-gradient
+      surface shows in its place and the tagline stays legible.
+- [ ] Light and dark app themes both keep the form on their own surface; only
+      the photograph area is committed-dark.
+- [ ] The tagline is localized (English and Spanish).
+- [ ] All existing auth behavior is unchanged: SSO button gating and order,
+      autofill auto-submit, sign-in/sign-up toggle, forgot-password dialogs,
+      consent gate, and every entry path into the screen. The existing test
+      suite passes unmodified.
+
+## API Surface
+
+None — this is a Flutter-only visual change.
+
+## Data Model
+
+None.
+
+## Out of Scope
+
+- The auth siblings (reset password, verify email, SSO-error screens) keep
+  their current treatment; a family-consistency pass is a possible follow-up.
+- Any change to form fields, validation, copy other than the new tagline, or
+  the onboarding quiz.

--- a/src/packages/flutter-app/lib/l10n/app_en.arb
+++ b/src/packages/flutter-app/lib/l10n/app_en.arb
@@ -179,6 +179,7 @@
   "ssoContinueWithApple": "Continue with Apple",
   "ssoDividerOr": "or",
   "authWelcomeBack": "Welcome back",
+  "authTagline": "Plan less. Travel more.",
   "authCreateAccountTitle": "Create your account",
   "authEmailLabel": "Email",
   "authEmailRequired": "Email is required",

--- a/src/packages/flutter-app/lib/l10n/app_es.arb
+++ b/src/packages/flutter-app/lib/l10n/app_es.arb
@@ -98,6 +98,7 @@
   "ssoContinueWithApple": "Continuar con Apple",
   "ssoDividerOr": "o",
   "authWelcomeBack": "Bienvenido de nuevo",
+  "authTagline": "Planea menos. Viaja más.",
   "authCreateAccountTitle": "Crea tu cuenta",
   "authEmailLabel": "Correo electrónico",
   "authEmailRequired": "El correo electrónico es obligatorio",

--- a/src/packages/flutter-app/lib/l10n/app_localizations.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations.dart
@@ -686,6 +686,12 @@ abstract class AppLocalizations {
   /// **'Welcome back'**
   String get authWelcomeBack;
 
+  /// No description provided for @authTagline.
+  ///
+  /// In en, this message translates to:
+  /// **'Plan less. Travel more.'**
+  String get authTagline;
+
   /// No description provided for @authCreateAccountTitle.
   ///
   /// In en, this message translates to:

--- a/src/packages/flutter-app/lib/l10n/app_localizations_en.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations_en.dart
@@ -315,6 +315,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get authWelcomeBack => 'Welcome back';
 
   @override
+  String get authTagline => 'Plan less. Travel more.';
+
+  @override
   String get authCreateAccountTitle => 'Create your account';
 
   @override

--- a/src/packages/flutter-app/lib/l10n/app_localizations_es.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations_es.dart
@@ -316,6 +316,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get authWelcomeBack => 'Bienvenido de nuevo';
 
   @override
+  String get authTagline => 'Planea menos. Viaja más.';
+
+  @override
   String get authCreateAccountTitle => 'Crea tu cuenta';
 
   @override

--- a/src/packages/flutter-app/lib/screens/auth_screen.dart
+++ b/src/packages/flutter-app/lib/screens/auth_screen.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -6,6 +7,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../l10n/l10n.dart';
 import '../providers/auth_provider.dart';
 import '../services/auth_service.dart';
+import '../theme/app_colors.dart';
+import '../theme/app_typography.dart';
 import '../theme/spacing.dart';
 import '../widgets/brand_logo.dart';
 import '../widgets/language_menu_button.dart';
@@ -14,6 +17,26 @@ import '../widgets/sso_buttons.dart';
 import '../widgets/legal_links.dart';
 import '../utils/errors.dart';
 import '../utils/snack.dart';
+
+/// The landing family's established wide switch: at 900px and up the photo
+/// becomes a full-height pane beside the form.
+const double _kWideBreakpoint = 900;
+
+/// The form pane's clamp on wide layouts. The floor is the 420px auth column
+/// plus its two xl gutters, so the column never compresses; the cap keeps the
+/// photograph dominant on ultrawide windows.
+const double _kFormPaneMinWidth = 468;
+const double _kFormPaneMaxWidth = 560;
+
+/// Below the wide switch, the photo band appears only when the viewport is at
+/// least this tall, so small phones and keyboard-up viewports keep the
+/// pre-photo layout with the form fully in reach.
+const double _kBandMinViewportHeight = 620;
+
+/// The band takes 22% of the viewport within these bounds: enough photo to
+/// set the scene, never enough to bury the fields.
+const double _kBandMinHeight = 140;
+const double _kBandMaxHeight = 220;
 
 class AuthScreen extends ConsumerStatefulWidget {
   /// Whether the form opens in sign-in (true) or create-account (false) mode.
@@ -183,184 +206,354 @@ class _AuthScreenState extends ConsumerState<AuthScreen> {
 
   @override
   Widget build(BuildContext context) {
+    // One LayoutBuilder decides the whole composition: the AppBar's icon
+    // colors and the body have to agree on where the photo is, and layout
+    // must follow the box this route was given — constraints, never
+    // MediaQuery.sizeOf.
+    return LayoutBuilder(builder: (context, constraints) {
+      final wide = constraints.maxWidth >= _kWideBreakpoint;
+      // The pinned band earns its place only when the viewport is tall
+      // enough to keep the form comfortably reachable below it. Deliberate
+      // side effect: opening the keyboard shrinks maxHeight below the
+      // threshold and the band yields its space to the form — form first
+      // when typing. Not a bug to "fix" with MediaQuery.sizeOf.
+      final showBand =
+          !wide && constraints.maxHeight >= _kBandMinViewportHeight;
+      final hasPhoto = wide || showBand;
+
+      return Scaffold(
+        // The photo reaches the top edge whenever it exists; without it,
+        // this is exactly the pre-photo chrome.
+        extendBodyBehindAppBar: hasPhoto,
+        // Transparent AppBar so the implied back arrow gives a way back to
+        // the landing page underneath (this screen is always pushed on top
+        // of it).
+        appBar: AppBar(
+          backgroundColor: Colors.transparent,
+          elevation: 0,
+          scrolledUnderElevation: 0,
+          // The back arrow sits over the photo in both photo layouts (left
+          // pane on wide, top band on narrow); the globe is over the photo
+          // only in the band layout — on wide it sits over the form pane's
+          // own surface and keeps the theme color.
+          iconTheme:
+              hasPhoto ? const IconThemeData(color: Colors.white) : null,
+          // A null actionsIconTheme FALLS BACK to iconTheme, so on wide the
+          // white leading slot would leak onto the globe over the light form
+          // pane — restate M3's own actions default (onSurfaceVariant) there.
+          actionsIconTheme: showBand
+              ? const IconThemeData(color: Colors.white)
+              : wide
+                  ? IconThemeData(
+                      color: Theme.of(context).colorScheme.onSurfaceVariant)
+                  : null,
+          actions: const [LanguageMenuButton()],
+        ),
+        body: wide
+            ? Row(
+                children: [
+                  const Expanded(
+                    child: _AuthPhotoPanel(
+                      key: Key('auth-photo-panel'),
+                      wide: true,
+                    ),
+                  ),
+                  SizedBox(
+                    // 45% of the window (the split-pane proportion of the
+                    // field), floored so the 420px column and its gutters
+                    // never compress, capped so the photo stays dominant
+                    // on ultrawide screens.
+                    width: (constraints.maxWidth * 0.45)
+                        .clamp(_kFormPaneMinWidth, _kFormPaneMaxWidth),
+                    // The transparent bar floats over this pane; give
+                    // scroll-to-top room to clear it.
+                    child: _formScroller(topInset: kToolbarHeight),
+                  ),
+                ],
+              )
+            : showBand
+                ? Column(
+                    children: [
+                      SizedBox(
+                        height: (constraints.maxHeight * 0.22)
+                            .clamp(_kBandMinHeight, _kBandMaxHeight),
+                        child: const _AuthPhotoPanel(
+                          key: Key('auth-photo-panel'),
+                          wide: false,
+                        ),
+                      ),
+                      Expanded(child: _formScroller()),
+                    ],
+                  )
+                : _formScroller(),
+      );
+    });
+  }
+
+  /// Today's auth body, verbatim — every layout shares it, so the form
+  /// column (and the tests pinning its geometry) never changes shape.
+  Widget _formScroller({double topInset = 0}) {
     final theme = Theme.of(context);
     final l10n = context.l10n;
     final auth = ref.watch(authProvider);
 
-    return Scaffold(
-      // Transparent AppBar so the implied back arrow gives a way back to the
-      // landing page underneath (this screen is always pushed on top of it).
-      appBar: AppBar(
-        backgroundColor: Colors.transparent,
-        elevation: 0,
-        scrolledUnderElevation: 0,
-        actions: const [LanguageMenuButton()],
-      ),
-      body: Center(
-        child: SingleChildScrollView(
-          padding: const EdgeInsets.all(AppSpacing.xl),
-          // The auth family's shared 420px column (see also reset/verify/SSO
-          // screens) — PageContainer inside the scroll view, house pattern.
-          child: PageContainer(
-            maxWidth: 420,
-            child: Form(
-              key: _formKey,
-              // AutofillGroup makes Flutter web expose the fields as a DOM
-              // <form> with autocomplete attributes, which is what browser
-              // password managers (1Password etc.) hook into.
-              child: AutofillGroup(
-                child: Column(
-                  mainAxisSize: MainAxisSize.min,
-                  crossAxisAlignment: CrossAxisAlignment.stretch,
-                  children: [
-                    const BrandLogo.mark(size: 72),
-                    const SizedBox(height: AppSpacing.sm),
-                    // Neutral surface, so the wordmark takes the theme's own
-                    // text color rather than the app bars' white — the plate
-                    // policy in brand_logo.dart, applied to type.
-                    const ExcludeSemantics(
-                      // The mark's Image already carries the "Anemos" label.
+    return Center(
+      child: SingleChildScrollView(
+        padding: EdgeInsets.fromLTRB(AppSpacing.xl, AppSpacing.xl + topInset,
+            AppSpacing.xl, AppSpacing.xl),
+        // The auth family's shared 420px column (see also reset/verify/SSO
+        // screens) — PageContainer inside the scroll view, house pattern.
+        child: PageContainer(
+          maxWidth: 420,
+          child: Form(
+            key: _formKey,
+            // AutofillGroup makes Flutter web expose the fields as a DOM
+            // <form> with autocomplete attributes, which is what browser
+            // password managers (1Password etc.) hook into.
+            child: AutofillGroup(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  const BrandLogo.mark(size: 72),
+                  const SizedBox(height: AppSpacing.sm),
+                  // Neutral surface, so the wordmark takes the theme's own
+                  // text color rather than the app bars' white — the plate
+                  // policy in brand_logo.dart, applied to type.
+                  const ExcludeSemantics(
+                    // The mark's Image already carries the "Anemos" label.
+                    // Centered explicitly: the stretch column otherwise
+                    // paints the text run from the left edge, splitting it
+                    // from the centered mark above (latent on the old flat
+                    // screen; the pane composition exposed it).
+                    child: Center(
                       child: BrandWordmark(fontSize: 26, letterSpacing: 1.5),
                     ),
+                  ),
+                  const SizedBox(height: AppSpacing.lg),
+                  Text(
+                    _isLogin
+                        ? l10n.authWelcomeBack
+                        : l10n.authCreateAccountTitle,
+                    style: theme.textTheme.headlineSmall,
+                    textAlign: TextAlign.center,
+                  ),
+                  const SizedBox(height: AppSpacing.xl),
+                  // One-tap sign-in first: position alone marks it the
+                  // default path. The block owns the "or" divider that
+                  // separates it from the email form below.
+                  const SsoButtons(),
+                  TextFormField(
+                    controller: _emailController,
+                    keyboardType: TextInputType.emailAddress,
+                    autocorrect: false,
+                    // Mobile keyboards advance to the password field
+                    // instead of dismissing.
+                    textInputAction: TextInputAction.next,
+                    autofillHints: const [
+                      AutofillHints.username,
+                      AutofillHints.email,
+                    ],
+                    decoration: InputDecoration(
+                      labelText: l10n.authEmailLabel,
+                    ),
+                    validator: (v) {
+                      final value = (v ?? '').trim();
+                      if (value.isEmpty) return l10n.authEmailRequired;
+                      if (!value.contains('@') || !value.contains('.')) {
+                        return l10n.authEmailInvalid;
+                      }
+                      return null;
+                    },
+                  ),
+                  const SizedBox(height: AppSpacing.md),
+                  TextFormField(
+                    controller: _passwordController,
+                    obscureText: true,
+                    autofillHints: [
+                      _isLogin
+                          ? AutofillHints.password
+                          : AutofillHints.newPassword,
+                    ],
+                    // Last field when signing in; sign-up still has the
+                    // display name below.
+                    textInputAction: _isLogin
+                        ? TextInputAction.done
+                        : TextInputAction.next,
+                    onFieldSubmitted: (_) {
+                      if (_isLogin) _submit();
+                    },
+                    decoration: InputDecoration(
+                      labelText: l10n.authPasswordLabel,
+                    ),
+                    validator: (v) {
+                      if ((v ?? '').isEmpty) return l10n.authPasswordRequired;
+                      if (!_isLogin && v!.length < 8) {
+                        return l10n.authPasswordTooShort;
+                      }
+                      return null;
+                    },
+                  ),
+                  if (!_isLogin) ...[
+                    const SizedBox(height: AppSpacing.md),
+                    TextFormField(
+                      controller: _displayNameController,
+                      autofillHints: const [AutofillHints.name],
+                      textInputAction: TextInputAction.done,
+                      onFieldSubmitted: (_) => _submit(),
+                      decoration: InputDecoration(
+                        labelText: l10n.authDisplayNameLabel,
+                      ),
+                    ),
+                  ],
+                  if (auth.error != null) ...[
                     const SizedBox(height: AppSpacing.lg),
                     Text(
-                      _isLogin
-                          ? l10n.authWelcomeBack
-                          : l10n.authCreateAccountTitle,
-                      style: theme.textTheme.headlineSmall,
+                      friendlyError(l10n, auth.error),
+                      style: theme.textTheme.bodyMedium
+                          ?.copyWith(color: theme.colorScheme.error),
                       textAlign: TextAlign.center,
                     ),
-                    const SizedBox(height: AppSpacing.xl),
-                    // One-tap sign-in first: position alone marks it the
-                    // default path. The block owns the "or" divider that
-                    // separates it from the email form below.
-                    const SsoButtons(),
-                    TextFormField(
-                      controller: _emailController,
-                      keyboardType: TextInputType.emailAddress,
-                      autocorrect: false,
-                      // Mobile keyboards advance to the password field
-                      // instead of dismissing.
-                      textInputAction: TextInputAction.next,
-                      autofillHints: const [
-                        AutofillHints.username,
-                        AutofillHints.email,
-                      ],
-                      decoration: InputDecoration(
-                        labelText: l10n.authEmailLabel,
-                      ),
-                      validator: (v) {
-                        final value = (v ?? '').trim();
-                        if (value.isEmpty) return l10n.authEmailRequired;
-                        if (!value.contains('@') || !value.contains('.')) {
-                          return l10n.authEmailInvalid;
-                        }
-                        return null;
-                      },
-                    ),
-                    const SizedBox(height: AppSpacing.md),
-                    TextFormField(
-                      controller: _passwordController,
-                      obscureText: true,
-                      autofillHints: [
-                        _isLogin
-                            ? AutofillHints.password
-                            : AutofillHints.newPassword,
-                      ],
-                      // Last field when signing in; sign-up still has the
-                      // display name below.
-                      textInputAction: _isLogin
-                          ? TextInputAction.done
-                          : TextInputAction.next,
-                      onFieldSubmitted: (_) {
-                        if (_isLogin) _submit();
-                      },
-                      decoration: InputDecoration(
-                        labelText: l10n.authPasswordLabel,
-                      ),
-                      validator: (v) {
-                        if ((v ?? '').isEmpty) return l10n.authPasswordRequired;
-                        if (!_isLogin && v!.length < 8) {
-                          return l10n.authPasswordTooShort;
-                        }
-                        return null;
-                      },
-                    ),
-                    if (!_isLogin) ...[
-                      const SizedBox(height: AppSpacing.md),
-                      TextFormField(
-                        controller: _displayNameController,
-                        autofillHints: const [AutofillHints.name],
-                        textInputAction: TextInputAction.done,
-                        onFieldSubmitted: (_) => _submit(),
-                        decoration: InputDecoration(
-                          labelText: l10n.authDisplayNameLabel,
-                        ),
-                      ),
-                    ],
-                    if (auth.error != null) ...[
-                      const SizedBox(height: AppSpacing.lg),
-                      Text(
-                        friendlyError(l10n, auth.error),
-                        style: theme.textTheme.bodyMedium
-                            ?.copyWith(color: theme.colorScheme.error),
-                        textAlign: TextAlign.center,
-                      ),
-                    ],
-                    const SizedBox(height: AppSpacing.lg),
-                    if (!_isLogin) ...[
-                      LegalConsentCheckbox(
-                        value: _agreedToTerms,
-                        onChanged: (v) => setState(() => _agreedToTerms = v),
-                      ),
-                      const SizedBox(height: AppSpacing.sm),
-                    ],
-                    FilledButton(
-                      onPressed: auth.loading || (!_isLogin && !_agreedToTerms)
-                          ? null
-                          : _submit,
-                      style: FilledButton.styleFrom(
-                        padding:
-                            const EdgeInsets.symmetric(vertical: AppSpacing.lg),
-                      ),
-                      child: auth.loading
-                          ? const SizedBox(
-                              height: 20,
-                              width: 20,
-                              child: CircularProgressIndicator(strokeWidth: 2),
-                            )
-                          : Text(
-                              _isLogin
-                                  ? l10n.authSignIn
-                                  : l10n.authCreateAccount,
-                            ),
-                    ),
-                    const SizedBox(height: AppSpacing.md),
-                    TextButton(
-                      onPressed: auth.loading ? null : _toggleMode,
-                      child: Text(
-                        _isLogin
-                            ? l10n.authNoAccountPrompt
-                            : l10n.authHaveAccountPrompt,
-                      ),
-                    ),
-                    if (_isLogin)
-                      TextButton(
-                        onPressed: auth.loading ? null : _forgotPassword,
-                        child: Text(l10n.authForgotPassword),
-                      ),
-                    // Sign-in only: sign-up already states the terms in the
-                    // blocking LegalConsentCheckbox above the button, and two
-                    // copies on one screen read as boilerplate.
-                    if (_isLogin) const SsoLegalAgreement(),
                   ],
-                ),
+                  const SizedBox(height: AppSpacing.lg),
+                  if (!_isLogin) ...[
+                    LegalConsentCheckbox(
+                      value: _agreedToTerms,
+                      onChanged: (v) => setState(() => _agreedToTerms = v),
+                    ),
+                    const SizedBox(height: AppSpacing.sm),
+                  ],
+                  FilledButton(
+                    onPressed: auth.loading || (!_isLogin && !_agreedToTerms)
+                        ? null
+                        : _submit,
+                    style: FilledButton.styleFrom(
+                      padding:
+                          const EdgeInsets.symmetric(vertical: AppSpacing.lg),
+                    ),
+                    child: auth.loading
+                        ? const SizedBox(
+                            height: 20,
+                            width: 20,
+                            child: CircularProgressIndicator(strokeWidth: 2),
+                          )
+                        : Text(
+                            _isLogin
+                                ? l10n.authSignIn
+                                : l10n.authCreateAccount,
+                          ),
+                  ),
+                  const SizedBox(height: AppSpacing.md),
+                  TextButton(
+                    onPressed: auth.loading ? null : _toggleMode,
+                    child: Text(
+                      _isLogin
+                          ? l10n.authNoAccountPrompt
+                          : l10n.authHaveAccountPrompt,
+                    ),
+                  ),
+                  if (_isLogin)
+                    TextButton(
+                      onPressed: auth.loading ? null : _forgotPassword,
+                      child: Text(l10n.authForgotPassword),
+                    ),
+                  // Sign-in only: sign-up already states the terms in the
+                  // blocking LegalConsentCheckbox above the button, and two
+                  // copies on one screen read as boilerplate.
+                  if (_isLogin) const SsoLegalAgreement(),
+                ],
               ),
             ),
           ),
         ),
       ),
     );
+  }
+}
+
+/// The destination photograph that gives sign-in its atmosphere: a
+/// full-height pane on wide layouts, a pinned top band on narrow ones.
+/// The landing hero's photo stack — gradient fallback, cover photo,
+/// heroScrim — without a logo: the form column already carries the brand,
+/// and the landing hero records why a surface brands only once.
+class _AuthPhotoPanel extends StatelessWidget {
+  /// Pane vs band — decides the tagline's scale and padding.
+  final bool wide;
+
+  const _AuthPhotoPanel({super.key, required this.wide});
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(builder: (context, constraints) {
+      return Stack(
+        fit: StackFit.expand,
+        children: [
+          // Branded gradient behind the photo: visible until the image
+          // decodes and whenever it fails to load, so the scrim and the
+          // tagline always sit on a dark branded surface.
+          DecoratedBox(
+            decoration: BoxDecoration(gradient: AppColors.brandGradient),
+          ),
+          Image.asset(
+            'assets/images/hero_santorini.jpg',
+            fit: BoxFit.cover,
+            // Decorative — the form column carries the screen's meaning.
+            excludeFromSemantics: true,
+            // Bound the decode to the panel, not the window: on wide
+            // layouts this pane is roughly half the window. Quantized to
+            // 320px buckets so a continuous resize reuses the cached
+            // decode instead of minting one per pixel of width.
+            cacheWidth: math.min(
+              1600,
+              ((constraints.maxWidth *
+                          MediaQuery.devicePixelRatioOf(context)) /
+                      320)
+                  .ceil() *
+                  320,
+            ),
+            // Hold the previous frame while a new bucket decodes
+            // mid-resize.
+            gaplessPlayback: true,
+            frameBuilder: (context, child, frame, wasSynchronouslyLoaded) {
+              if (wasSynchronouslyLoaded) return child;
+              return AnimatedOpacity(
+                opacity: frame == null ? 0 : 1,
+                duration: const Duration(milliseconds: 250),
+                curve: Curves.easeOut,
+                child: child,
+              );
+            },
+            // The gradient underneath is the fallback.
+            errorBuilder: (_, __, ___) => const SizedBox.shrink(),
+          ),
+          DecoratedBox(
+            decoration: BoxDecoration(gradient: AppColors.heroScrim),
+          ),
+          // The scrim is bottomLeft-darkest — the tagline sits exactly
+          // there.
+          Align(
+            alignment: Alignment.bottomLeft,
+            child: Padding(
+              padding: EdgeInsets.all(wide ? AppSpacing.xl : AppSpacing.lg),
+              child: Text(
+                context.l10n.authTagline,
+                style: TextStyle(
+                  // Marcellus ships only w400 — always stated, or web
+                  // synthesizes faux-bold. Display sizes stated locally,
+                  // the landing-hero precedent: 38 suits the half-window
+                  // pane, 24 the band.
+                  fontFamily: AppFonts.display,
+                  fontWeight: FontWeight.w400,
+                  fontSize: wide ? 38 : 24,
+                  height: 1.15,
+                  color: Colors.white,
+                ),
+              ),
+            ),
+          ),
+        ],
+      );
+    });
   }
 }
 

--- a/src/packages/flutter-app/test/auth_split_pane_test.dart
+++ b/src/packages/flutter-app/test/auth_split_pane_test.dart
@@ -1,0 +1,195 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:travel_route_planner/providers/auth_provider.dart';
+import 'package:travel_route_planner/screens/auth_screen.dart';
+import 'package:travel_route_planner/services/auth_service.dart';
+import 'package:travel_route_planner/services/auth_storage.dart';
+import 'package:travel_route_planner/theme/app_colors.dart';
+import 'package:travel_route_planner/theme/app_theme.dart';
+import 'package:travel_route_planner/widgets/brand_logo.dart';
+
+import 'support/l10n_test_app.dart';
+
+/// The split-pane photo layout (specs/auth-redesign): a full-height Santorini
+/// pane beside the form on wide screens, a pinned band above it on tall
+/// phones, and — the contract the older auth tests rely on — exactly the
+/// pre-photo screen on short viewports. The form column itself is pinned by
+/// auth_screen_sso_order_test.dart; this file pins what surrounds it.
+class _FakeAuthService extends AuthService {
+  _FakeAuthService() : super(baseUrl: 'http://unused');
+
+  @override
+  Future<bool> googleSignInAvailable() async => false;
+
+  @override
+  Future<bool> appleSignInAvailable() async => false;
+}
+
+class _FakeAuthStorage extends AuthStorage {
+  @override
+  Future<String?> loadToken() async => null;
+
+  @override
+  Future<void> saveToken(String value) async {}
+
+  @override
+  Future<void> clearToken() async {}
+}
+
+Future<void> _pumpAuth(
+  WidgetTester tester,
+  Size surface, {
+  bool initialIsLogin = true,
+  Locale? locale,
+  ThemeData? theme,
+}) async {
+  await tester.binding.setSurfaceSize(surface);
+  addTearDown(() => tester.binding.setSurfaceSize(null));
+  await tester.pumpWidget(ProviderScope(
+    overrides: [
+      authServiceProvider.overrideWithValue(_FakeAuthService()),
+      authStorageProvider.overrideWithValue(_FakeAuthStorage()),
+    ],
+    child: localizedTestApp(
+      home: AuthScreen(initialIsLogin: initialIsLogin),
+      locale: locale,
+      theme: theme,
+    ),
+  ));
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  final panel = find.byKey(const Key('auth-photo-panel'));
+  final tagline = find.text('Plan less. Travel more.');
+
+  // The photo stack is layered DecoratedBoxes; both gradients have value
+  // equality, so the layers can be asserted structurally. The gradient
+  // sitting UNDER the image is also the no-photo fallback contract — the
+  // image's errorBuilder collapses to nothing and leaves it showing.
+  Finder gradientLayer(Gradient gradient) => find.descendant(
+        of: panel,
+        matching: find.byWidgetPredicate((w) =>
+            w is DecoratedBox &&
+            w.decoration is BoxDecoration &&
+            (w.decoration as BoxDecoration).gradient == gradient),
+      );
+
+  testWidgets('wide shows the full-height photo pane beside the form',
+      (tester) async {
+    await _pumpAuth(tester, const Size(1280, 800));
+
+    expect(panel, findsOneWidget);
+    // Full-height and starting at the top edge — the pane runs behind the
+    // transparent app bar.
+    expect(tester.getTopLeft(panel).dy, 0);
+    expect(tester.getSize(panel).height, 800);
+
+    // The scrim over the photo and the branded fallback under it.
+    expect(gradientLayer(AppColors.heroScrim), findsOneWidget);
+    expect(gradientLayer(AppColors.brandGradient), findsOneWidget);
+
+    // The tagline lives on the photo side, left of the form.
+    expect(tagline, findsOneWidget);
+    expect(tester.getTopLeft(tagline).dx,
+        lessThan(tester.getTopLeft(find.byType(TextFormField).first).dx));
+  });
+
+  testWidgets('wide keeps the 420px auth column', (tester) async {
+    await _pumpAuth(tester, const Size(1280, 800));
+
+    expect(tester.getSize(find.byType(TextFormField).first).width, 420);
+
+    // The wordmark centers over the column like the mark above it — the
+    // stretch column otherwise paints its text run from the left edge.
+    expect(
+        tester.getCenter(find.byType(BrandWordmark)).dx,
+        closeTo(
+            tester.getCenter(find.byType(TextFormField).first).dx, 0.01));
+  });
+
+  testWidgets('wide bar: white back slot, theme-colored globe',
+      (tester) async {
+    await _pumpAuth(tester, const Size(1280, 800));
+
+    final bar = tester.widget<AppBar>(find.byType(AppBar));
+    // The leading back arrow sits over the photo; the actions (the language
+    // globe) sit over the form pane's own surface and must NOT be forced
+    // white there. A null actionsIconTheme is NOT enough — it falls back to
+    // the white iconTheme (the CDP run caught the invisible globe) — so the
+    // M3 actions default has to be restated explicitly.
+    expect(bar.iconTheme?.color, Colors.white);
+    expect(
+        bar.actionsIconTheme?.color,
+        Theme.of(tester.element(find.byType(AppBar)))
+            .colorScheme
+            .onSurfaceVariant);
+  });
+
+  testWidgets('narrow tall shows the band pinned above the form',
+      (tester) async {
+    await _pumpAuth(tester, const Size(420, 1200));
+
+    expect(panel, findsOneWidget);
+    // Pinned at the very top (behind the bar), clamped to its max height.
+    expect(tester.getTopLeft(panel).dy, 0);
+    expect(tester.getSize(panel).height, 220);
+    expect(tester.getSize(panel).width, 420);
+
+    // Tagline on the band, above the form.
+    expect(tester.getTopLeft(tagline).dy,
+        lessThan(tester.getTopLeft(find.byType(TextFormField).first).dy));
+
+    // Both bar slots float over the photo here.
+    final bar = tester.widget<AppBar>(find.byType(AppBar));
+    expect(bar.iconTheme?.color, Colors.white);
+    expect(bar.actionsIconTheme?.color, Colors.white);
+  });
+
+  testWidgets('short viewports keep the pre-photo screen exactly',
+      (tester) async {
+    // The default test surface every older auth test pumps at — those tests
+    // tap the submit button without ensureVisible, so this layout has to
+    // stay byte-identical to the pre-photo screen.
+    await _pumpAuth(tester, const Size(800, 600));
+
+    expect(panel, findsNothing);
+    expect(tagline, findsNothing);
+    final scaffold = tester.widget<Scaffold>(find.byType(Scaffold));
+    expect(scaffold.extendBodyBehindAppBar, isFalse);
+    final bar = tester.widget<AppBar>(find.byType(AppBar));
+    expect(bar.iconTheme, isNull);
+    expect(bar.actionsIconTheme, isNull);
+  });
+
+  testWidgets('a keyboard-height viewport also skips the band',
+      (tester) async {
+    // 360x450 is auth_polish_test's keyboard-up floor.
+    await _pumpAuth(tester, const Size(360, 450));
+
+    expect(panel, findsNothing);
+    expect(tagline, findsNothing);
+  });
+
+  testWidgets('Spanish sign-up on a phone renders the band without overflow',
+      (tester) async {
+    await _pumpAuth(tester, const Size(360, 690),
+        initialIsLogin: false, locale: const Locale('es'));
+
+    expect(panel, findsOneWidget);
+    expect(find.text('Planea menos. Viaja más.'), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('dark theme: the photo stays committed-dark, the form follows',
+      (tester) async {
+    await _pumpAuth(tester, const Size(1280, 800), theme: AppTheme.dark);
+
+    expect(panel, findsOneWidget);
+    // The tagline is white by construction (it sits on the scrim, not on a
+    // theme surface), in both themes.
+    expect(tester.widget<Text>(tagline).style?.color, Colors.white);
+    expect(tester.takeException(), isNull);
+  });
+}


### PR DESCRIPTION
## Summary
- Redesigns the sign-in/sign-up screen (specs/auth-redesign, direction chosen from a Mobbin sweep): at ≥900px a full-height Santorini photo pane — `brandGradient` fallback → photo → `heroScrim` → the tagline in the scrim's darkest corner — sits beside the **unchanged** 420px form column on the theme surface; narrow-but-tall viewports get a pinned photo band above the form; short viewports (keyboard up, 320×568-class, the 800×600 default test surface) keep the pre-photo screen byte-identical.
- One `LayoutBuilder` wrapping the Scaffold decides the whole composition (constraints, never `MediaQuery.sizeOf`), so the AppBar's per-slot icon colors agree with where the photo is: back arrow white over the photo in both photo layouts, globe white only over the band. Deliberate side effect, commented in code: the keyboard shrinking `maxHeight` collapses the band — form first when typing.
- Verification-caught fix #1: a null `actionsIconTheme` **falls back to `iconTheme`**, so the wide layout painted the globe white-on-white over the light form pane; M3's actions default (`onSurfaceVariant`) is now restated explicitly and test-pinned.
- Verification-caught fix #2 (incumbent, exposed by the pane): the stretch column had always painted the wordmark's text run from the left edge under the centered mark; now centered explicitly and test-pinned.
- New `authTagline` l10n key (en "Plan less. Travel more." / es "Planea menos. Viaja más.") — a per-surface key rather than reusing home's `homeHeroTitle` (#464: a shared string is only shared while the sites share a meaning).
- Form logic untouched: autofill burst auto-submit, `_submit`-pops-when-poppable, `initialIsLogin`, mode toggle, forgot-password dialogs, settle-gated `SsoButtons`, all five entry paths. No new theme tokens (heroScrim's bottomLeft-darkest geometry fits the composition as-is); layout numbers are file-local consts with rationale comments, the landing-hero precedent.
- Known caveat: crossing 900px swaps the body's root widget (Row↔Column), reparenting the Form — controllers and provider error survive; transient field-validation messages and focus reset. Mid-resize only.

## Testing
- `flutter analyze` clean (3 pre-existing infos elsewhere, untouched files).
- Full `flutter test`: 1675 passing before the two verification fixes, +1 pinning test since — including the whole pinned auth set (`auth_screen_sso_order`, `auth_polish`, `auth_autofill_submit`, sso/google/apple buttons, `language_menu_button`, `landing_default_handoff`, `connect_app_screen`, `agent_screen_banner`) **unmodified**.
- New `test/auth_split_pane_test.dart` (8 cases): wide pane full-height with scrim/gradient/tagline beside the 420 column; per-slot AppBar colors both layouts; band pinned at 420×1200; 800×600 and 360×450 render today's chrome exactly; es sign-up at 360×690 with the band; dark theme smoke; wordmark centering.
- Brand `check.sh` on the touched Dart file: clean.
- CDP headless-Chrome verification (host dev server): 1440×900 + 950/910×800 seam + 390×844 + 320×568, light and dark, en and es — back-arrow legibility over the photo, globe over the form pane in both themes, es tagline wraps cleanly at the minimum pane width, band collapse on short viewports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)