### PR TITLE
feat(auth): family photo pass — reset and verify wear the pane and band

### DIFF
--- a/.impeccable/config.json
+++ b/.impeccable/config.json
@@ -1,7 +1,9 @@
 {
   "detector": {
     "ignoreRules": [],
-    "ignoreFiles": [],
+    "ignoreFiles": [
+      "docs/branding/brand-guidelines.html"
+    ],
     "ignoreValues": [
       {
         "rule": "dark-glow",

--- a/specs/auth-redesign/plan.md
+++ b/specs/auth-redesign/plan.md
@@ -75,6 +75,23 @@ scroller's top padding adds `kToolbarHeight` so scroll-to-top clears the bar.
 - The photo pane ends on a hard seam against the form pane — deliberately no
   `landingHeroBlend` dissolve; the committed-dark treatment ends at sign-in.
 
+## Family pass (second wave)
+
+The composition moved to one home: `lib/widgets/auth_photo_panel.dart` now
+holds `AuthPhotoPanel` (the photo stack, verbatim from the sign-in screen),
+the layout numbers (`kAuthWideBreakpoint`, `kAuthBandMinViewportHeight`,
+`authFormPaneWidth`, `authBandHeight` — the clamp bounds stay private), and
+`AuthPhotoBody`, the pane/band/nothing ladder for the gradient-bar screens.
+The sign-in screen imports the pieces but keeps composing them itself: its
+transparent bar's icon colors and extend-behind flag depend on the layout
+decision, so its LayoutBuilder must wrap the whole Scaffold, while the
+siblings' bars are layout-independent and `AuthPhotoBody` measures the body
+box below them (band threshold therefore reads ~56px conservative there,
+deliberately — the question is whether the form under the chrome breathes).
+`reset_password_screen.dart` and `verify_email_screen.dart` wrap their
+existing bodies in `AuthPhotoBody`; columns, bars, and logic untouched.
+Tests: `test/auth_family_photo_test.dart`.
+
 ## Verification
 
 `make flutter-analyze`, full `make flutter-test` (run

--- a/specs/auth-redesign/spec.md
+++ b/specs/auth-redesign/spec.md
@@ -56,9 +56,22 @@ None — this is a Flutter-only visual change.
 
 None.
 
+## Family pass (second wave)
+
+The deep-link siblings — reset password and verify email — wear the same
+photo composition. They differ from sign-in deliberately: as deep-link
+landing pages they keep their gradient title bar (the landing page is the
+precedent for the bar sitting atop a photograph), with the photo starting
+below it.
+
+- [ ] Reset password and verify email show the photo pane beside their
+      unchanged column on wide screens, the band above it on tall phones,
+      and exactly their pre-photo layout on short viewports.
+- [ ] Their gradient title bars, form logic, outcome states, and copy are
+      unchanged.
+
 ## Out of Scope
 
-- The auth siblings (reset password, verify email, SSO-error screens) keep
-  their current treatment; a family-consistency pass is a possible follow-up.
+- The SSO-error screen keeps its current treatment.
 - Any change to form fields, validation, copy other than the new tagline, or
   the onboarding quiz.

--- a/src/packages/flutter-app/lib/screens/auth_screen.dart
+++ b/src/packages/flutter-app/lib/screens/auth_screen.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -7,9 +6,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../l10n/l10n.dart';
 import '../providers/auth_provider.dart';
 import '../services/auth_service.dart';
-import '../theme/app_colors.dart';
-import '../theme/app_typography.dart';
 import '../theme/spacing.dart';
+import '../widgets/auth_photo_panel.dart';
 import '../widgets/brand_logo.dart';
 import '../widgets/language_menu_button.dart';
 import '../widgets/page_container.dart';
@@ -17,26 +15,6 @@ import '../widgets/sso_buttons.dart';
 import '../widgets/legal_links.dart';
 import '../utils/errors.dart';
 import '../utils/snack.dart';
-
-/// The landing family's established wide switch: at 900px and up the photo
-/// becomes a full-height pane beside the form.
-const double _kWideBreakpoint = 900;
-
-/// The form pane's clamp on wide layouts. The floor is the 420px auth column
-/// plus its two xl gutters, so the column never compresses; the cap keeps the
-/// photograph dominant on ultrawide windows.
-const double _kFormPaneMinWidth = 468;
-const double _kFormPaneMaxWidth = 560;
-
-/// Below the wide switch, the photo band appears only when the viewport is at
-/// least this tall, so small phones and keyboard-up viewports keep the
-/// pre-photo layout with the form fully in reach.
-const double _kBandMinViewportHeight = 620;
-
-/// The band takes 22% of the viewport within these bounds: enough photo to
-/// set the scene, never enough to bury the fields.
-const double _kBandMinHeight = 140;
-const double _kBandMaxHeight = 220;
 
 class AuthScreen extends ConsumerStatefulWidget {
   /// Whether the form opens in sign-in (true) or create-account (false) mode.
@@ -211,14 +189,14 @@ class _AuthScreenState extends ConsumerState<AuthScreen> {
     // must follow the box this route was given — constraints, never
     // MediaQuery.sizeOf.
     return LayoutBuilder(builder: (context, constraints) {
-      final wide = constraints.maxWidth >= _kWideBreakpoint;
+      final wide = constraints.maxWidth >= kAuthWideBreakpoint;
       // The pinned band earns its place only when the viewport is tall
       // enough to keep the form comfortably reachable below it. Deliberate
       // side effect: opening the keyboard shrinks maxHeight below the
       // threshold and the band yields its space to the form — form first
       // when typing. Not a bug to "fix" with MediaQuery.sizeOf.
       final showBand =
-          !wide && constraints.maxHeight >= _kBandMinViewportHeight;
+          !wide && constraints.maxHeight >= kAuthBandMinViewportHeight;
       final hasPhoto = wide || showBand;
 
       return Scaffold(
@@ -253,7 +231,7 @@ class _AuthScreenState extends ConsumerState<AuthScreen> {
             ? Row(
                 children: [
                   const Expanded(
-                    child: _AuthPhotoPanel(
+                    child: AuthPhotoPanel(
                       key: Key('auth-photo-panel'),
                       wide: true,
                     ),
@@ -263,8 +241,7 @@ class _AuthScreenState extends ConsumerState<AuthScreen> {
                     // field), floored so the 420px column and its gutters
                     // never compress, capped so the photo stays dominant
                     // on ultrawide screens.
-                    width: (constraints.maxWidth * 0.45)
-                        .clamp(_kFormPaneMinWidth, _kFormPaneMaxWidth),
+                    width: authFormPaneWidth(constraints.maxWidth),
                     // The transparent bar floats over this pane; give
                     // scroll-to-top room to clear it.
                     child: _formScroller(topInset: kToolbarHeight),
@@ -275,9 +252,8 @@ class _AuthScreenState extends ConsumerState<AuthScreen> {
                 ? Column(
                     children: [
                       SizedBox(
-                        height: (constraints.maxHeight * 0.22)
-                            .clamp(_kBandMinHeight, _kBandMaxHeight),
-                        child: const _AuthPhotoPanel(
+                        height: authBandHeight(constraints.maxHeight),
+                        child: const AuthPhotoPanel(
                           key: Key('auth-photo-panel'),
                           wide: false,
                         ),
@@ -468,92 +444,6 @@ class _AuthScreenState extends ConsumerState<AuthScreen> {
         ),
       ),
     );
-  }
-}
-
-/// The destination photograph that gives sign-in its atmosphere: a
-/// full-height pane on wide layouts, a pinned top band on narrow ones.
-/// The landing hero's photo stack — gradient fallback, cover photo,
-/// heroScrim — without a logo: the form column already carries the brand,
-/// and the landing hero records why a surface brands only once.
-class _AuthPhotoPanel extends StatelessWidget {
-  /// Pane vs band — decides the tagline's scale and padding.
-  final bool wide;
-
-  const _AuthPhotoPanel({super.key, required this.wide});
-
-  @override
-  Widget build(BuildContext context) {
-    return LayoutBuilder(builder: (context, constraints) {
-      return Stack(
-        fit: StackFit.expand,
-        children: [
-          // Branded gradient behind the photo: visible until the image
-          // decodes and whenever it fails to load, so the scrim and the
-          // tagline always sit on a dark branded surface.
-          DecoratedBox(
-            decoration: BoxDecoration(gradient: AppColors.brandGradient),
-          ),
-          Image.asset(
-            'assets/images/hero_santorini.jpg',
-            fit: BoxFit.cover,
-            // Decorative — the form column carries the screen's meaning.
-            excludeFromSemantics: true,
-            // Bound the decode to the panel, not the window: on wide
-            // layouts this pane is roughly half the window. Quantized to
-            // 320px buckets so a continuous resize reuses the cached
-            // decode instead of minting one per pixel of width.
-            cacheWidth: math.min(
-              1600,
-              ((constraints.maxWidth *
-                          MediaQuery.devicePixelRatioOf(context)) /
-                      320)
-                  .ceil() *
-                  320,
-            ),
-            // Hold the previous frame while a new bucket decodes
-            // mid-resize.
-            gaplessPlayback: true,
-            frameBuilder: (context, child, frame, wasSynchronouslyLoaded) {
-              if (wasSynchronouslyLoaded) return child;
-              return AnimatedOpacity(
-                opacity: frame == null ? 0 : 1,
-                duration: const Duration(milliseconds: 250),
-                curve: Curves.easeOut,
-                child: child,
-              );
-            },
-            // The gradient underneath is the fallback.
-            errorBuilder: (_, __, ___) => const SizedBox.shrink(),
-          ),
-          DecoratedBox(
-            decoration: BoxDecoration(gradient: AppColors.heroScrim),
-          ),
-          // The scrim is bottomLeft-darkest — the tagline sits exactly
-          // there.
-          Align(
-            alignment: Alignment.bottomLeft,
-            child: Padding(
-              padding: EdgeInsets.all(wide ? AppSpacing.xl : AppSpacing.lg),
-              child: Text(
-                context.l10n.authTagline,
-                style: TextStyle(
-                  // Marcellus ships only w400 — always stated, or web
-                  // synthesizes faux-bold. Display sizes stated locally,
-                  // the landing-hero precedent: 38 suits the half-window
-                  // pane, 24 the band.
-                  fontFamily: AppFonts.display,
-                  fontWeight: FontWeight.w400,
-                  fontSize: wide ? 38 : 24,
-                  height: 1.15,
-                  color: Colors.white,
-                ),
-              ),
-            ),
-          ),
-        ],
-      );
-    });
   }
 }
 

--- a/src/packages/flutter-app/lib/screens/reset_password_screen.dart
+++ b/src/packages/flutter-app/lib/screens/reset_password_screen.dart
@@ -5,6 +5,7 @@ import '../l10n/l10n.dart';
 import '../providers/auth_provider.dart';
 import '../theme/spacing.dart';
 import '../utils/errors.dart';
+import '../widgets/auth_photo_panel.dart';
 import '../widgets/empty_state.dart';
 import '../widgets/gradient_app_bar.dart';
 import '../widgets/page_container.dart';
@@ -71,13 +72,19 @@ class _ResetPasswordScreenState extends ConsumerState<ResetPasswordScreen> {
     final theme = Theme.of(context);
     return Scaffold(
       appBar: GradientAppBar(title: context.l10n.resetAppBarTitle),
-      body: Center(
-        child: SingleChildScrollView(
-          padding: const EdgeInsets.all(AppSpacing.xl),
-          // The auth family's shared 420px column (see auth_screen.dart).
-          child: PageContainer(
-            maxWidth: 420,
-            child: _done ? _buildSuccess(theme) : _buildForm(theme),
+      // The family photo composition around the untouched column
+      // (specs/auth-redesign): pane beside the form on wide, band above it
+      // on tall phones, nothing on short viewports. The gradient bar stays —
+      // the landing page is the precedent for it sitting atop the photo.
+      body: AuthPhotoBody(
+        child: Center(
+          child: SingleChildScrollView(
+            padding: const EdgeInsets.all(AppSpacing.xl),
+            // The auth family's shared 420px column (see auth_screen.dart).
+            child: PageContainer(
+              maxWidth: 420,
+              child: _done ? _buildSuccess(theme) : _buildForm(theme),
+            ),
           ),
         ),
       ),

--- a/src/packages/flutter-app/lib/screens/verify_email_screen.dart
+++ b/src/packages/flutter-app/lib/screens/verify_email_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../l10n/l10n.dart';
 import '../providers/auth_provider.dart';
 import '../theme/spacing.dart';
+import '../widgets/auth_photo_panel.dart';
 import '../widgets/empty_state.dart';
 import '../widgets/gradient_app_bar.dart';
 import '../widgets/page_container.dart';
@@ -92,10 +93,15 @@ class _VerifyEmailScreenState extends ConsumerState<VerifyEmailScreen> {
     }
     return Scaffold(
       appBar: GradientAppBar(title: l10n.verifyTitle),
-      body: Center(
-        child: SingleChildScrollView(
-          padding: const EdgeInsets.all(AppSpacing.xl),
-          child: body,
+      // The family photo composition around the untouched outcome column
+      // (specs/auth-redesign); the gradient bar stays atop the photo, the
+      // landing page's precedent.
+      body: AuthPhotoBody(
+        child: Center(
+          child: SingleChildScrollView(
+            padding: const EdgeInsets.all(AppSpacing.xl),
+            child: body,
+          ),
         ),
       ),
     );

--- a/src/packages/flutter-app/lib/widgets/auth_photo_panel.dart
+++ b/src/packages/flutter-app/lib/widgets/auth_photo_panel.dart
@@ -1,0 +1,183 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+
+import '../l10n/l10n.dart';
+import '../theme/app_colors.dart';
+import '../theme/app_typography.dart';
+import '../theme/spacing.dart';
+
+/// The auth family's photo composition (specs/auth-redesign): shared by the
+/// sign-in screen and the deep-link siblings (reset-password, verify-email)
+/// so the numbers and the photo stack have exactly one home.
+///
+/// The landing family's established wide switch: at 900px and up the photo
+/// becomes a full-height pane beside the form.
+const double kAuthWideBreakpoint = 900;
+
+/// Below the wide switch, the photo band appears only when the measured box
+/// is at least this tall, so small phones and keyboard-up viewports keep the
+/// pre-photo layout with the form fully in reach.
+const double kAuthBandMinViewportHeight = 620;
+
+/// The form pane's clamp on wide layouts. The floor is the 420px auth column
+/// plus its two xl gutters, so the column never compresses; the cap keeps the
+/// photograph dominant on ultrawide windows.
+const double _kFormPaneMinWidth = 468;
+const double _kFormPaneMaxWidth = 560;
+
+/// The band takes 22% of the measured box within these bounds: enough photo
+/// to set the scene, never enough to bury the fields.
+const double _kBandMinHeight = 140;
+const double _kBandMaxHeight = 220;
+
+/// The one derivation of the wide layout's form-pane width — 45% of the
+/// window, the split-pane proportion of the field.
+double authFormPaneWidth(double maxWidth) =>
+    (maxWidth * 0.45).clamp(_kFormPaneMinWidth, _kFormPaneMaxWidth);
+
+/// The one derivation of the narrow layout's band height.
+double authBandHeight(double maxHeight) =>
+    (maxHeight * 0.22).clamp(_kBandMinHeight, _kBandMaxHeight);
+
+/// The destination photograph that gives the auth family its atmosphere: a
+/// full-height pane on wide layouts, a pinned top band on narrow ones.
+/// The landing hero's photo stack — gradient fallback, cover photo,
+/// heroScrim — without a logo: the form column (or the bar above) already
+/// carries the brand, and the landing hero records why a surface brands
+/// only once.
+class AuthPhotoPanel extends StatelessWidget {
+  /// Pane vs band — decides the tagline's scale and padding.
+  final bool wide;
+
+  const AuthPhotoPanel({super.key, required this.wide});
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(builder: (context, constraints) {
+      return Stack(
+        fit: StackFit.expand,
+        children: [
+          // Branded gradient behind the photo: visible until the image
+          // decodes and whenever it fails to load, so the scrim and the
+          // tagline always sit on a dark branded surface.
+          DecoratedBox(
+            decoration: BoxDecoration(gradient: AppColors.brandGradient),
+          ),
+          Image.asset(
+            'assets/images/hero_santorini.jpg',
+            fit: BoxFit.cover,
+            // Decorative — the form column carries the screen's meaning.
+            excludeFromSemantics: true,
+            // Bound the decode to the panel, not the window: on wide
+            // layouts this pane is roughly half the window. Quantized to
+            // 320px buckets so a continuous resize reuses the cached
+            // decode instead of minting one per pixel of width.
+            cacheWidth: math.min(
+              1600,
+              ((constraints.maxWidth *
+                          MediaQuery.devicePixelRatioOf(context)) /
+                      320)
+                  .ceil() *
+                  320,
+            ),
+            // Hold the previous frame while a new bucket decodes
+            // mid-resize.
+            gaplessPlayback: true,
+            frameBuilder: (context, child, frame, wasSynchronouslyLoaded) {
+              if (wasSynchronouslyLoaded) return child;
+              return AnimatedOpacity(
+                opacity: frame == null ? 0 : 1,
+                duration: const Duration(milliseconds: 250),
+                curve: Curves.easeOut,
+                child: child,
+              );
+            },
+            // The gradient underneath is the fallback.
+            errorBuilder: (_, __, ___) => const SizedBox.shrink(),
+          ),
+          DecoratedBox(
+            decoration: BoxDecoration(gradient: AppColors.heroScrim),
+          ),
+          // The scrim is bottomLeft-darkest — the tagline sits exactly
+          // there.
+          Align(
+            alignment: Alignment.bottomLeft,
+            child: Padding(
+              padding: EdgeInsets.all(wide ? AppSpacing.xl : AppSpacing.lg),
+              child: Text(
+                context.l10n.authTagline,
+                style: TextStyle(
+                  // Marcellus ships only w400 — always stated, or web
+                  // synthesizes faux-bold. Display sizes stated locally,
+                  // the landing-hero precedent: 38 suits the half-window
+                  // pane, 24 the band.
+                  fontFamily: AppFonts.display,
+                  fontWeight: FontWeight.w400,
+                  fontSize: wide ? 38 : 24,
+                  height: 1.15,
+                  color: Colors.white,
+                ),
+              ),
+            ),
+          ),
+        ],
+      );
+    });
+  }
+}
+
+/// The photo composition for the auth family's GRADIENT-BAR screens
+/// (reset-password, verify-email): the same pane / band / nothing ladder as
+/// the sign-in screen, built inside the body so the bar above stays exactly
+/// what it was — the landing page is the precedent for the gradient bar
+/// sitting atop the photo. The sign-in screen composes the same pieces
+/// itself instead: its transparent bar's icon colors and extend-behind flag
+/// depend on the layout decision, so there the LayoutBuilder must wrap the
+/// whole Scaffold.
+///
+/// Because this measures the body box (below the bar), the band threshold
+/// runs ~56px conservative next to the sign-in screen — deliberate: the
+/// question the threshold answers is whether the form under the chrome
+/// still breathes.
+class AuthPhotoBody extends StatelessWidget {
+  /// The screen's own centered scroller, laid unchanged in every branch.
+  final Widget child;
+
+  const AuthPhotoBody({super.key, required this.child});
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(builder: (context, constraints) {
+      if (constraints.maxWidth >= kAuthWideBreakpoint) {
+        return Row(
+          children: [
+            const Expanded(
+              child: AuthPhotoPanel(
+                key: Key('auth-photo-panel'),
+                wide: true,
+              ),
+            ),
+            SizedBox(
+              width: authFormPaneWidth(constraints.maxWidth),
+              child: child,
+            ),
+          ],
+        );
+      }
+      if (constraints.maxHeight < kAuthBandMinViewportHeight) return child;
+      return Column(
+        children: [
+          SizedBox(
+            height: authBandHeight(constraints.maxHeight),
+            child: const AuthPhotoPanel(
+              key: Key('auth-photo-panel'),
+              wide: false,
+            ),
+          ),
+          Expanded(child: child),
+        ],
+      );
+    });
+  }
+}

--- a/src/packages/flutter-app/test/auth_family_photo_test.dart
+++ b/src/packages/flutter-app/test/auth_family_photo_test.dart
@@ -1,0 +1,138 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:travel_route_planner/providers/auth_provider.dart';
+import 'package:travel_route_planner/screens/reset_password_screen.dart';
+import 'package:travel_route_planner/screens/verify_email_screen.dart';
+import 'package:travel_route_planner/services/auth_service.dart';
+import 'package:travel_route_planner/widgets/auth_photo_panel.dart';
+import 'package:travel_route_planner/widgets/empty_state.dart';
+import 'package:travel_route_planner/widgets/gradient_app_bar.dart';
+
+import 'support/l10n_test_app.dart';
+
+/// The family pass (specs/auth-redesign): the deep-link siblings — reset
+/// password and verify email — wear the same photo composition as the
+/// sign-in screen, via the shared AuthPhotoBody. Unlike the sign-in screen
+/// they keep their GradientAppBar (the landing page's bar-over-photo
+/// precedent), so the photo starts below the bar and the band threshold
+/// measures the body box.
+class _FakeAuthService extends AuthService {
+  final bool verifySucceeds;
+  _FakeAuthService({this.verifySucceeds = true})
+      : super(baseUrl: 'http://unused');
+
+  @override
+  Future<void> verifyEmail(String token) async {
+    if (!verifySucceeds) throw Exception('expired');
+  }
+}
+
+Future<void> _pump(
+  WidgetTester tester,
+  Widget screen,
+  Size surface, {
+  bool verifySucceeds = true,
+}) async {
+  await tester.binding.setSurfaceSize(surface);
+  addTearDown(() => tester.binding.setSurfaceSize(null));
+  await tester.pumpWidget(ProviderScope(
+    overrides: [
+      authServiceProvider
+          .overrideWithValue(_FakeAuthService(verifySucceeds: verifySucceeds)),
+    ],
+    child: localizedTestApp(home: screen),
+  ));
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  final panel = find.byKey(const Key('auth-photo-panel'));
+  final tagline = find.text('Plan less. Travel more.');
+
+  testWidgets('reset: wide shows the pane beside the unchanged 420 column',
+      (tester) async {
+    await _pump(tester, const ResetPasswordScreen(token: 't'),
+        const Size(1280, 800));
+
+    expect(panel, findsOneWidget);
+    expect(tagline, findsOneWidget);
+    // The gradient bar survives the pass, and the photo starts below it.
+    expect(find.byType(GradientAppBar), findsOneWidget);
+    expect(tester.getTopLeft(panel).dy,
+        tester.getBottomLeft(find.byType(AppBar)).dy);
+    expect(tester.getSize(find.byType(TextFormField).first).width, 420);
+
+    // WIDE-discriminating (the verify workflow's mutation run proved the
+    // band branch satisfies everything above): the pane is exactly the
+    // window minus the form pane, and the tagline sits LEFT of the form.
+    expect(tester.getSize(panel).width, 1280 - authFormPaneWidth(1280));
+    expect(tester.getTopLeft(tagline).dx,
+        lessThan(tester.getTopLeft(find.byType(TextFormField).first).dx));
+  });
+
+  testWidgets('reset: tall phone gets the band above the form',
+      (tester) async {
+    await _pump(tester, const ResetPasswordScreen(token: 't'),
+        const Size(420, 1200));
+
+    expect(panel, findsOneWidget);
+    expect(tester.getTopLeft(panel).dy,
+        tester.getBottomLeft(find.byType(AppBar)).dy);
+    expect(tester.getTopLeft(tagline).dy,
+        lessThan(tester.getTopLeft(find.byType(TextFormField).first).dy));
+    // BAND-discriminating: full-width, clamped to the band's max height.
+    expect(tester.getSize(panel).width, 420);
+    expect(tester.getSize(panel).height, 220);
+  });
+
+  testWidgets('reset: short viewports keep the pre-photo screen',
+      (tester) async {
+    await _pump(tester, const ResetPasswordScreen(token: 't'),
+        const Size(800, 600));
+
+    expect(panel, findsNothing);
+    expect(tagline, findsNothing);
+    expect(find.byType(TextFormField), findsNWidgets(2));
+  });
+
+  testWidgets('verify: success outcome sits beside the pane on wide',
+      (tester) async {
+    await _pump(tester, const VerifyEmailScreen(token: 't'),
+        const Size(1280, 800));
+
+    expect(panel, findsOneWidget);
+    // Outcome-specific, not just an EmptyState — the screen renders one for
+    // BOTH outcomes, so the icon is what tells success from failure.
+    expect(find.byIcon(Icons.mark_email_read_outlined), findsOneWidget);
+    expect(find.byIcon(Icons.link_off), findsNothing);
+    expect(find.byType(GradientAppBar), findsOneWidget);
+    // WIDE-discriminating, as on the reset test.
+    expect(tester.getSize(panel).width, 1280 - authFormPaneWidth(1280));
+  });
+
+  testWidgets('verify: failure outcome gets the band on a tall phone',
+      (tester) async {
+    await _pump(tester, const VerifyEmailScreen(token: 't'),
+        const Size(420, 1200),
+        verifySucceeds: false);
+
+    expect(panel, findsOneWidget);
+    // The failure outcome specifically — an EmptyState alone can't tell it
+    // from success, and takeException() is vacuous (the screen catches).
+    expect(find.byIcon(Icons.link_off), findsOneWidget);
+    expect(find.byIcon(Icons.mark_email_read_outlined), findsNothing);
+    // BAND-discriminating: full-width at the clamped max height.
+    expect(tester.getSize(panel).width, 420);
+    expect(tester.getSize(panel).height, 220);
+  });
+
+  testWidgets('verify: short viewports keep the pre-photo screen',
+      (tester) async {
+    await _pump(tester, const VerifyEmailScreen(token: 't'),
+        const Size(800, 600));
+
+    expect(panel, findsNothing);
+    expect(find.byType(EmptyState), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- Extends the #480 split-pane composition to the deep-link siblings: **reset password** and **verify email** now show the Santorini pane beside their unchanged column on wide screens, the pinned tagline band above it on tall phones, and exactly their pre-photo layout on short viewports.
- The composition moves to one home, `lib/widgets/auth_photo_panel.dart`: `AuthPhotoPanel` (the photo stack, verbatim from the sign-in screen), the layout constants, the two derivations (`authFormPaneWidth`, `authBandHeight`), and `AuthPhotoBody` — the pane/band/nothing ladder for gradient-bar screens. The sign-in screen imports the pieces but keeps composing them itself: its transparent bar's slot colors and extend-behind flag depend on the layout decision, so its `LayoutBuilder` must wrap the whole Scaffold.
- The siblings keep their `GradientAppBar` deliberately — they're deep-link landing pages whose bar carries the page name, and the landing page is the precedent for the gradient bar sitting atop a photo. `AuthPhotoBody` measures the body box below the bar, so the band threshold reads ~56px conservative there (documented in the widget).
- Columns, bars, outcome states, and all logic on both siblings untouched; sign-in behavior byte-identical after the extraction (its 13 tests pass unmodified).
- Rides along: the impeccable design hook now ignores `docs/branding/brand-guidelines.html` wholesale (`.impeccable/config.json`) — the guideline document is its own designed artifact, not app UI on the DESIGN.md ramp; it was generating 103 category-error findings.

## Testing
- Full `flutter test`: 1681 passing (1675 baseline + 6 new in `test/auth_family_photo_test.dart`); analyzer clean (3 pre-existing infos elsewhere); brand `check.sh` clean on all four touched Dart files.
- **Adversarial verify workflow** (4 dimension reviewers + 2 refuters per finding, mutation-tested): confirmed two soft spots in the new tests — the wide assertions all held in band mode, and the verify outcome tests couldn't distinguish success from failure (both render `EmptyState`; the screen catches, so `takeException` was vacuous). Both hardened: tests now pin pane-vs-band geometry (`panel width == window − authFormPaneWidth`) and the outcome icons (`link_off` vs `mark_email_read_outlined`); re-ran the wide-branch mutation and it now fails 2 tests, restored and green.
- CDP headless-Chrome verification against the lane's dev build: `/reset/<token>` and `/verify/<bad token>` at 1440×900 and 390×844 — gradient bar atop the pane/band, tagline in the scrim's darkest corner, forms and outcome states unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)