### PR TITLE
fix(landing): set the closing CTA bare on the canvas — drop the gradient card

### DIFF
--- a/src/packages/flutter-app/lib/screens/landing/landing_cta_band.dart
+++ b/src/packages/flutter-app/lib/screens/landing/landing_cta_band.dart
@@ -2,12 +2,13 @@ import 'package:flutter/material.dart';
 
 import '../../l10n/l10n.dart';
 import '../../theme/app_colors.dart';
-import '../../theme/app_shadows.dart';
+import '../../theme/app_typography.dart';
 import '../../theme/spacing.dart';
-import '../../widgets/page_container.dart';
 
-/// Closing CTA: the one intentionally lighter-teal surface on the landing
-/// canvas, so the last thing the page says pops. Plain sign-up entry — the
+/// Closing CTA: the page's last word, set directly on the landing canvas.
+/// Every other section sits bare on Midnight Harbor, so the close does too —
+/// the emptiness around one Marcellus line and one action is the emphasis
+/// (the Aman move), not a raised field. Plain sign-up entry — the
 /// prompt-carrying paths live in the hero and the destination rail.
 class LandingCtaBand extends StatelessWidget {
   final VoidCallback onGetStarted;
@@ -21,24 +22,32 @@ class LandingCtaBand extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
     final l10n = context.l10n;
-    return PageContainer(
-      child: Container(
-        padding: const EdgeInsets.all(AppSpacing.xl + AppSpacing.sm),
-        decoration: BoxDecoration(
-          gradient: AppColors.brandGradient,
-          borderRadius: AppRadius.lgAll,
-          boxShadow: AppShadows.brandCard,
-        ),
+    return LayoutBuilder(builder: (context, constraints) {
+      // Same self-measured threshold as the hero: the section reads its own
+      // box, not the window.
+      final narrow = constraints.maxWidth < 600;
+      return Padding(
+        padding: const EdgeInsets.symmetric(vertical: AppSpacing.xxl),
         child: Column(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
-            Text(
-              l10n.landingCtaTitle,
-              textAlign: TextAlign.center,
-              style: theme.textTheme.headlineSmall
-                  ?.copyWith(color: Colors.white),
+            ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: 640),
+              child: Text(
+                l10n.landingCtaTitle,
+                textAlign: TextAlign.center,
+                style: TextStyle(
+                  // Marcellus ships one weight; the explicit w400 keeps a
+                  // theme bold from asking for a face that doesn't exist.
+                  // One tier above the section titles (26) — the closing
+                  // line outranks a chapter heading, stays under the hero.
+                  fontFamily: AppFonts.display,
+                  fontWeight: FontWeight.w400,
+                  fontSize: narrow ? 30 : 34,
+                  height: 1.2,
+                  color: Colors.white,
+                ),
+              ),
             ),
             const SizedBox(height: AppSpacing.xl),
             FilledButton(
@@ -46,7 +55,12 @@ class LandingCtaBand extends StatelessWidget {
               style: FilledButton.styleFrom(
                 backgroundColor: Colors.white,
                 foregroundColor: AppColors.brandDark,
-                padding: const EdgeInsets.symmetric(vertical: AppSpacing.lg),
+                // Intrinsic width, centered: a button sized by its label is
+                // an action; edge-to-edge white is a field.
+                padding: const EdgeInsets.symmetric(
+                  horizontal: AppSpacing.xxl,
+                  vertical: AppSpacing.lg,
+                ),
                 shape: const RoundedRectangleBorder(
                   borderRadius: AppRadius.mdAll,
                 ),
@@ -68,14 +82,16 @@ class LandingCtaBand extends StatelessWidget {
             TextButton(
               onPressed: onSignIn,
               style: TextButton.styleFrom(
-                foregroundColor: Colors.white,
-                padding: const EdgeInsets.symmetric(vertical: AppSpacing.md),
+                // The muted ink rung, not white: beside the one white button
+                // the alternate path is secondary copy, and the ladder
+                // already names that role.
+                foregroundColor: AppColors.landingInkMuted,
               ),
               child: Text(l10n.landingHaveAccount),
             ),
           ],
         ),
-      ),
-    );
+      );
+    });
   }
 }


### PR DESCRIPTION
## Summary
- The closing CTA was the one landing section still wearing a container — a lighter-teal gradient rounded card with a full-width white pill, the classic generic-AI closing-CTA template. It now sits directly on the landing canvas like every other section.
- One Marcellus headline at 34 (one tier above the 26 section titles, under the hero's 48; 30 on narrow, self-measured at <600 like the hero), an intrinsic-width white Get-started button, and the sign-in link on the ink ladder's muted rung (`landingInkMuted`) so the alternate path reads as secondary copy beside the one white action.
- The pinned explicit-`brandDark` button-label color (the M3 `copyWith`-paints-`onSurface` regression) is unchanged.

## Testing
- `flutter analyze` clean on the touched file.
- `flutter test test/landing_polish_test.dart` — all 10 pass, including the section-order pin and the CTA label-color regression pin.
- `.claude/skills/brand-guidelines/scripts/check.sh` clean.
- Verified by headless-Chrome screenshots at 1440 and 500 wide: the close reads as quiet typography on the canvas, headline wraps to two clean lines on narrow, button holds intrinsic width.

🤖 Generated with [Claude Code](https://claude.com/claude-code)