### PR TITLE
feat(auth): the SSO callback joins the family photo pass

### DIFF
--- a/specs/auth-redesign/plan.md
+++ b/specs/auth-redesign/plan.md
@@ -88,9 +88,11 @@ decision, so its LayoutBuilder must wrap the whole Scaffold, while the
 siblings' bars are layout-independent and `AuthPhotoBody` measures the body
 box below them (band threshold therefore reads ~56px conservative there,
 deliberately — the question is whether the form under the chrome breathes).
-`reset_password_screen.dart` and `verify_email_screen.dart` wrap their
-existing bodies in `AuthPhotoBody`; columns, bars, and logic untouched.
-Tests: `test/auth_family_photo_test.dart`.
+`reset_password_screen.dart`, `verify_email_screen.dart`, and
+`sso_callback_screen.dart` wrap their existing bodies in `AuthPhotoBody`;
+columns, bars, and logic untouched.
+Tests: `test/auth_family_photo_test.dart` (SSO cases pump `code: 'error'`,
+the synchronous OAuth-declined path — no service fake needed).
 
 ## Verification
 

--- a/specs/auth-redesign/spec.md
+++ b/specs/auth-redesign/spec.md
@@ -58,20 +58,21 @@ None.
 
 ## Family pass (second wave)
 
-The deep-link siblings — reset password and verify email — wear the same
-photo composition. They differ from sign-in deliberately: as deep-link
+The deep-link siblings — reset password, verify email, and the SSO
+callback's outcome states — wear the same photo composition. They differ
+from sign-in deliberately: as deep-link
 landing pages they keep their gradient title bar (the landing page is the
 precedent for the bar sitting atop a photograph), with the photo starting
 below it.
 
-- [ ] Reset password and verify email show the photo pane beside their
-      unchanged column on wide screens, the band above it on tall phones,
-      and exactly their pre-photo layout on short viewports.
+- [ ] Reset password, verify email, and the SSO callback show the photo
+      pane beside their unchanged column on wide screens, the band above it
+      on tall phones, and exactly their pre-photo layout on short
+      viewports.
 - [ ] Their gradient title bars, form logic, outcome states, and copy are
       unchanged.
 
 ## Out of Scope
 
-- The SSO-error screen keeps its current treatment.
 - Any change to form fields, validation, copy other than the new tagline, or
   the onboarding quiz.

--- a/src/packages/flutter-app/lib/screens/sso_callback_screen.dart
+++ b/src/packages/flutter-app/lib/screens/sso_callback_screen.dart
@@ -4,6 +4,7 @@ import '../l10n/l10n.dart';
 import '../providers/auth_provider.dart';
 import '../services/pending_connect.dart';
 import '../theme/spacing.dart';
+import '../widgets/auth_photo_panel.dart';
 import '../widgets/empty_state.dart';
 import '../widgets/gradient_app_bar.dart';
 import '../widgets/page_container.dart';
@@ -109,10 +110,15 @@ class _SsoCallbackScreenState extends ConsumerState<SsoCallbackScreen> {
     }
     return Scaffold(
       appBar: GradientAppBar(title: l10n.ssoTitle),
-      body: Center(
-        child: SingleChildScrollView(
-          padding: const EdgeInsets.all(AppSpacing.xl),
-          child: body,
+      // The family photo composition around the untouched outcome column
+      // (specs/auth-redesign); the gradient bar stays atop the photo, the
+      // landing page's precedent — same wrap as verify-email.
+      body: AuthPhotoBody(
+        child: Center(
+          child: SingleChildScrollView(
+            padding: const EdgeInsets.all(AppSpacing.xl),
+            child: body,
+          ),
         ),
       ),
     );

--- a/src/packages/flutter-app/test/auth_family_photo_test.dart
+++ b/src/packages/flutter-app/test/auth_family_photo_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:travel_route_planner/providers/auth_provider.dart';
 import 'package:travel_route_planner/screens/reset_password_screen.dart';
+import 'package:travel_route_planner/screens/sso_callback_screen.dart';
 import 'package:travel_route_planner/screens/verify_email_screen.dart';
 import 'package:travel_route_planner/services/auth_service.dart';
 import 'package:travel_route_planner/widgets/auth_photo_panel.dart';
@@ -12,11 +13,14 @@ import 'package:travel_route_planner/widgets/gradient_app_bar.dart';
 import 'support/l10n_test_app.dart';
 
 /// The family pass (specs/auth-redesign): the deep-link siblings — reset
-/// password and verify email — wear the same photo composition as the
-/// sign-in screen, via the shared AuthPhotoBody. Unlike the sign-in screen
-/// they keep their GradientAppBar (the landing page's bar-over-photo
-/// precedent), so the photo starts below the bar and the band threshold
-/// measures the body box.
+/// password, verify email, and the SSO callback — wear the same photo
+/// composition as the sign-in screen, via the shared AuthPhotoBody. Unlike
+/// the sign-in screen they keep their GradientAppBar (the landing page's
+/// bar-over-photo precedent), so the photo starts below the bar and the
+/// band threshold measures the body box.
+///
+/// SSO cases pump `code: 'error'` — the OAuth-declined path, which reaches
+/// the failure state synchronously without touching the auth service.
 class _FakeAuthService extends AuthService {
   final bool verifySucceeds;
   _FakeAuthService({this.verifySucceeds = true})
@@ -134,5 +138,35 @@ void main() {
 
     expect(panel, findsNothing);
     expect(find.byType(EmptyState), findsOneWidget);
+  });
+
+  testWidgets('sso error: the failure sits beside the pane on wide',
+      (tester) async {
+    await _pump(tester, const SsoCallbackScreen(code: 'error'),
+        const Size(1280, 800));
+
+    expect(find.byIcon(Icons.link_off), findsOneWidget);
+    expect(find.byType(GradientAppBar), findsOneWidget);
+    // WIDE-discriminating, as on the reset/verify tests.
+    expect(tester.getSize(panel).width, 1280 - authFormPaneWidth(1280));
+  });
+
+  testWidgets('sso error: tall phone gets the band', (tester) async {
+    await _pump(tester, const SsoCallbackScreen(code: 'error'),
+        const Size(420, 1200));
+
+    expect(find.byIcon(Icons.link_off), findsOneWidget);
+    // BAND-discriminating: full-width at the clamped max height.
+    expect(tester.getSize(panel).width, 420);
+    expect(tester.getSize(panel).height, 220);
+  });
+
+  testWidgets('sso error: short viewports keep the pre-photo screen',
+      (tester) async {
+    await _pump(tester, const SsoCallbackScreen(code: 'error'),
+        const Size(800, 600));
+
+    expect(panel, findsNothing);
+    expect(find.byIcon(Icons.link_off), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- The last flat surface in the auth family: `sso_callback_screen.dart` wraps its body in the shared `AuthPhotoBody` — exactly the verify-email wrap from #481. Pane beside the outcome state on wide, tagline band above it on tall phones, the pre-photo layout on short viewports.
- GradientAppBar ("Signing you in"), the exchange spinner, both failure states (cancelled/expired), and the pending-connect resume logic are untouched.
- Spec updated: the SSO screen moves out of `specs/auth-redesign`'s out-of-scope list into the family-pass criteria.

## Testing
- Three new cases in `test/auth_family_photo_test.dart` pumping `code: 'error'` (the synchronous OAuth-declined path — reaches the failure state with no service fake), carrying the pane/band-discriminating assertions the #481 mutation pass taught (`panel width == window − authFormPaneWidth`, band 420×220, `link_off` icon).
- Full `flutter test`: 1684 passing; analyzer clean; brand `check.sh` clean on the touched file.
- CDP headless-Chrome: `/sso/error` at 1440×900 and 390×844 — pane and band render with the failure state unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)