### PR TITLE
docs: track PRODUCT.md, DESIGN.md and .impeccable/design.json

### DIFF
--- a/.impeccable/design.json
+++ b/.impeccable/design.json
@@ -1,0 +1,174 @@
+{
+  "schemaVersion": 2,
+  "generatedAt": "2026-08-18T00:00:00Z",
+  "title": "Design System: Anemos",
+  "extensions": {
+    "colorMeta": {
+      "aegean-teal": {
+        "role": "primary",
+        "displayName": "Aegean Teal",
+        "canonical": "#00796B",
+        "tonalRamp": ["#004D40", "#00695C", "#00796B", "#00897B", "#009688", "#26A69A", "#4DB6AC", "#80CBC4", "#B2DFDB", "#E0F2F1"]
+      },
+      "harbor-light": {
+        "role": "primary",
+        "displayName": "Harbor Light",
+        "canonical": "#00897B"
+      },
+      "harbor-dark": {
+        "role": "primary",
+        "displayName": "Harbor Dark",
+        "canonical": "#004D40"
+      },
+      "shallows-tint": {
+        "role": "primary",
+        "displayName": "Shallows Tint",
+        "canonical": "#E0F2F1"
+      },
+      "heritage-gold": {
+        "role": "secondary",
+        "displayName": "Heritage Gold",
+        "canonical": "#E8C452"
+      },
+      "heritage-gold-deep": {
+        "role": "secondary",
+        "displayName": "Heritage Gold (deep)",
+        "canonical": "#B98B1E"
+      },
+      "midnight-harbor": {
+        "role": "secondary",
+        "displayName": "Midnight Harbor",
+        "canonical": "#00231D"
+      },
+      "map-scrim": {
+        "role": "neutral",
+        "displayName": "Map Scrim",
+        "canonical": "rgba(0, 0, 0, 0.6)"
+      },
+      "paper-fill": {
+        "role": "neutral",
+        "displayName": "Paper Fill",
+        "canonical": "#FAFAFA"
+      }
+    },
+    "typographyMeta": {
+      "wordmark": { "displayName": "Wordmark (Cinzel)", "purpose": "The ANEMOS wordmark only, via BrandWordmark; small caps, per-surface measured tracking. Never retyped." },
+      "headline": { "displayName": "Headline (Marcellus)", "purpose": "Page and section headings, app-bar titles. One weight (w400), sentence case, sizes 34/30/26." },
+      "title": { "displayName": "Title (Inter)", "purpose": "Card titles and row headers; w700 large, w600 medium/small — hierarchy by weight." },
+      "body": { "displayName": "Body (Inter)", "purpose": "Prose and transcripts; regular weight." },
+      "label": { "displayName": "Label (Inter)", "purpose": "Buttons, chips, field labels; w600, sentence case. Every number in the app is Inter." }
+    },
+    "shadows": [
+      { "name": "soft", "value": "0 3px 10px rgba(0,0,0,0.10)", "purpose": "Custom raised containers outside the Material Card." },
+      { "name": "card-light", "value": "0 3px 6px rgba(0,0,0,0.16)", "purpose": "Card theme, light mode (elevation 3, surface tint off)." },
+      { "name": "brand-card", "value": "0 4px 10px rgba(0,77,64,0.30)", "purpose": "Under brand-gradient cards — hero strips, recent/live trip cards." },
+      { "name": "hero", "value": "0 6px 16px rgba(0,77,64,0.40)", "purpose": "Full-bleed landing heroes. All shadows offset downward — light from above." }
+    ],
+    "motion": [],
+    "breakpoints": [
+      { "name": "auth-band", "value": "620px" },
+      { "name": "split-pane", "value": "900px" }
+    ]
+  },
+  "components": [
+    {
+      "name": "Primary Button",
+      "kind": "button",
+      "refersTo": "button-primary",
+      "description": "The one primary action per surface — filled scheme primary seeded from Aegean Teal, card radius.",
+      "html": "<button class=\"ds-btn-primary\">Plan a trip</button>",
+      "css": ".ds-btn-primary { background: #00796B; color: #fff; font-family: Inter, system-ui, sans-serif; font-size: 14px; font-weight: 600; padding: 12px 24px; border: none; border-radius: 12px; cursor: pointer; transition: background 0.2s; } .ds-btn-primary:hover { background: #00695C; } .ds-btn-primary:focus-visible { outline: 2px solid #00796B; outline-offset: 2px; }"
+    },
+    {
+      "name": "Secondary Button",
+      "kind": "button",
+      "refersTo": "button-secondary",
+      "description": "Raised secondary action — white surface, teal foreground, input radius, soft downward shadow.",
+      "html": "<button class=\"ds-btn-secondary\">See all</button>",
+      "css": ".ds-btn-secondary { background: #fff; color: #00796B; font-family: Inter, system-ui, sans-serif; font-size: 14px; font-weight: 600; padding: 12px 24px; border: none; border-radius: 8px; box-shadow: 0 3px 10px rgba(0,0,0,0.10); cursor: pointer; transition: box-shadow 0.2s; } .ds-btn-secondary:hover { box-shadow: 0 4px 12px rgba(0,0,0,0.14); } .ds-btn-secondary:focus-visible { outline: 2px solid #00796B; outline-offset: 2px; }"
+    },
+    {
+      "name": "Card",
+      "kind": "card",
+      "refersTo": "card",
+      "description": "The standard raised surface — 12px radius, real downward shadow, no Material tonal tint.",
+      "html": "<div class=\"ds-card\"><div class=\"ds-card-title\">4 nights in Naxos</div><div class=\"ds-card-body\">Old Town stay, ferry to Santorini on Friday morning.</div></div>",
+      "css": ".ds-card { background: #fff; border-radius: 12px; padding: 16px; box-shadow: 0 3px 6px rgba(0,0,0,0.16); max-width: 320px; } .ds-card-title { font-family: Inter, system-ui, sans-serif; font-size: 16px; font-weight: 700; color: #191c1c; margin-bottom: 8px; } .ds-card-body { font-family: Inter, system-ui, sans-serif; font-size: 14px; font-weight: 400; line-height: 1.43; color: #3f4947; }"
+    },
+    {
+      "name": "Brand Hero Card",
+      "kind": "custom",
+      "refersTo": "card",
+      "description": "Brand-gradient field (Harbor Light → Harbor Dark, top-left → bottom-right) with white type and the Harbor Dark shadow — the app bar and hero-card treatment.",
+      "html": "<div class=\"ds-hero-card\"><div class=\"ds-hero-eyebrow\">Naxos, Greece</div><div class=\"ds-hero-title\">Island hopping, September</div></div>",
+      "css": ".ds-hero-card { background: linear-gradient(135deg, #00897B, #004D40); border-radius: 20px; padding: 24px; box-shadow: 0 4px 10px rgba(0,77,64,0.30); max-width: 360px; } .ds-hero-eyebrow { font-family: Inter, system-ui, sans-serif; font-size: 12px; font-weight: 600; letter-spacing: 0.12em; text-transform: uppercase; color: rgba(255,255,255,0.85); margin-bottom: 8px; } .ds-hero-title { font-family: Marcellus, Georgia, serif; font-size: 26px; font-weight: 400; line-height: 1.2; color: #fff; }"
+    },
+    {
+      "name": "Input Field",
+      "kind": "input",
+      "refersTo": "input",
+      "description": "Outlined, filled field — paper fill, 8px radius, primary outline on focus, no glow.",
+      "html": "<input class=\"ds-input\" type=\"text\" placeholder=\"Where to?\" />",
+      "css": ".ds-input { background: #FAFAFA; border: 1px solid #6f7977; border-radius: 8px; padding: 12px 16px; font-family: Inter, system-ui, sans-serif; font-size: 14px; color: #191c1c; width: 260px; transition: border-color 0.2s; } .ds-input::placeholder { color: #6f7977; } .ds-input:focus { outline: none; border: 2px solid #00796B; padding: 11px 15px; }"
+    },
+    {
+      "name": "Filter Chip",
+      "kind": "chip",
+      "refersTo": "chip",
+      "description": "Fully-rounded chip; chip rows are the entire secondary navigation on list screens. Selected takes the brand tint family.",
+      "html": "<span class=\"ds-chip\">Flights</span> <span class=\"ds-chip ds-chip-selected\">Stays</span>",
+      "css": ".ds-chip { display: inline-block; font-family: Inter, system-ui, sans-serif; font-size: 14px; font-weight: 500; color: #3f4947; background: transparent; border: 1px solid #bec9c6; border-radius: 999px; padding: 8px 16px; cursor: pointer; transition: background 0.2s; } .ds-chip:hover { background: rgba(0,121,107,0.06); } .ds-chip-selected { background: #E0F2F1; border-color: #E0F2F1; color: #004D40; font-weight: 600; }"
+    },
+    {
+      "name": "Wordmark",
+      "kind": "custom",
+      "refersTo": "wordmark",
+      "description": "The ANEMOS wordmark — Cinzel 600 small caps, measured tracking. A component (BrandWordmark), never retyped in product code.",
+      "html": "<div class=\"ds-wordmark\">ANEMOS</div>",
+      "css": ".ds-wordmark { font-family: Cinzel, Georgia, serif; font-size: 19px; font-weight: 600; letter-spacing: 0.053em; color: #004D40; }"
+    },
+    {
+      "name": "Status Pill",
+      "kind": "custom",
+      "refersTo": "chip",
+      "description": "Translucent semantic container pair — the pill-on-card register (the solid marks register is for status strips).",
+      "html": "<span class=\"ds-pill-success\">Booked</span> <span class=\"ds-pill-warning\">Needs dates</span>",
+      "css": ".ds-pill-success { display: inline-block; font-family: Inter, system-ui, sans-serif; font-size: 12px; font-weight: 600; color: #2E7D32; background: rgba(76,175,80,0.15); border-radius: 999px; padding: 4px 12px; } .ds-pill-warning { display: inline-block; font-family: Inter, system-ui, sans-serif; font-size: 12px; font-weight: 600; color: #FF6F00; background: rgba(255,193,7,0.20); border-radius: 999px; padding: 4px 12px; }"
+    }
+  ],
+  "narrative": {
+    "northStar": "The Aegean Journal",
+    "overview": "Anemos is a polished travel product that reads like a luxury travel journal: the product craft of Airbnb, Hopper, and Flighty carrying the editorial restraint of Aman, Belmond, and Cereal. Aegean, not tropical. Engraved, not shouted. One deep-teal spine runs through everything; surfaces stay quiet like sun-bleached plaster; photography of real places in real light does the emotional work; and a design earns attention by making the space around the important thing quieter, not by making the thing bigger.\n\nThe interface vocabulary is deliberately small — cards, bottom sheets, chips, and pills at comfortable density — extended rather than added to. Restraint is enforced, not aspirational: Material 3's surface tint is off everywhere, separation between surfaces is always an explicit color choice, and every non-teal color must earn its place by meaning exactly one thing.",
+    "keyCharacteristics": [
+      "One teal spine; every other color earned and single-meaning",
+      "Editorial serif headings at one weight; hierarchy below them is weight, not size",
+      "Photography-forward, always behind a scrim when text sits on it",
+      "Flat-calm surfaces, light from above, no tonal tint",
+      "Card-and-sheet vocabulary, comfortable density, 48px touch floor"
+    ],
+    "rules": [
+      { "name": "The Earned Color Rule", "body": "Every non-teal color means exactly one thing and appears at chip-and-pin scale, never as a field. Color is never decoration.", "section": "colors" },
+      { "name": "The Gold-in-the-Mark Rule", "body": "Heritage Gold enters a screen only inside the wind-rose mark. Anywhere else it is a finding.", "section": "colors" },
+      { "name": "The One Dark Exception Rule", "body": "Midnight Harbor exists only on the signed-out landing. Everywhere else, surfaces are the neutral scheme and dark mode is the same build with brightness flipped.", "section": "colors" },
+      { "name": "The One Weight Rule", "body": "Marcellus ships in exactly one weight; every style naming it states w400 explicitly, or the web synthesizes faux-bold and smears the serif.", "section": "typography" },
+      { "name": "The Weight-Not-Size Rule", "body": "Below the headline line, hierarchy is built with Inter's weight ladder (400/500/600/700), not with size steps.", "section": "typography" },
+      { "name": "The One Eyebrow Rule", "body": "Capitals belong to the wordmark and to ONE display device: the letterspaced small-caps place eyebrow on destination surfaces (the Amanzoe move). No other kickers or eyebrows exist.", "section": "typography" },
+      { "name": "The Light-From-Above Rule", "body": "Every shadow offsets downward. A zero-offset colored halo is never ours.", "section": "elevation" },
+      { "name": "The No-Tint Rule", "body": "Surface separation is a color someone chose, never an implicit function of elevation.", "section": "elevation" }
+    ],
+    "dos": [
+      "Do build only with tokens — AppColors, AppFonts/textTheme, AppSpacing, AppRadius, AppShadows, BrandLogo/BrandWordmark; a value that isn't a token becomes one in lib/theme/ first.",
+      "Do keep photography real — real places in real light, credited in CREDITS.md/LICENSES.md — and put a scrim under any text on it.",
+      "Do check both themes; the gradient bar staying teal in dark is correct.",
+      "Do state w400 on every Marcellus style and set numbers in Inter.",
+      "Do run .claude/skills/brand-guidelines/scripts/check.sh on touched Dart files before shipping."
+    ],
+    "donts": [
+      "Don't put a plate, tile, or container behind the wind rose, or redraw the mark \"close enough\".",
+      "Don't use gradient text, colored glows, zero-offset halos, teal-tinted photos, purple-blue AI gradients, or glassmorphism as decoration.",
+      "Don't add a fourth typeface, load google_fonts (prod CSP blocks it), or let emoji stand in for icons.",
+      "Don't use off-ladder spacing, radii outside 8/12/20/full, ad-hoc BoxShadows, or raw hex in widgets (sanctioned exceptions: app_map.dart canvas, the easter egg).",
+      "Don't ship kickers/eyebrows (except the one destination place eyebrow), Title Case Headings, section-number decoration, same-size icon-card grids as page structure, or the hero-metric template."
+    ]
+  }
+}

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,333 @@
+---
+name: Anemos
+description: Travel planning with the calm of a luxury travel journal — Aegean, not tropical; engraved, not shouted.
+colors:
+  aegean-teal: "#00796B"
+  harbor-light: "#00897B"
+  harbor-dark: "#004D40"
+  shallows-tint: "#E0F2F1"
+  heritage-gold: "#E8C452"
+  heritage-gold-deep: "#B98B1E"
+  midnight-harbor: "#00231D"
+  map-scrim: "rgba(0, 0, 0, 0.6)"
+  paper-fill: "#FAFAFA"
+typography:
+  wordmark:
+    fontFamily: "Cinzel, Georgia, serif"
+    fontWeight: 600
+    letterSpacing: "0.05em"
+  headline:
+    fontFamily: "Marcellus, Georgia, serif"
+    fontSize: "26px"
+    fontWeight: 400
+    lineHeight: 1.2
+  title:
+    fontFamily: "Inter, system-ui, sans-serif"
+    fontSize: "16px"
+    fontWeight: 600
+    lineHeight: 1.5
+  body:
+    fontFamily: "Inter, system-ui, sans-serif"
+    fontSize: "14px"
+    fontWeight: 400
+    lineHeight: 1.43
+  label:
+    fontFamily: "Inter, system-ui, sans-serif"
+    fontSize: "14px"
+    fontWeight: 600
+    lineHeight: 1.43
+rounded:
+  sm: "8px"
+  md: "12px"
+  lg: "20px"
+  full: "999px"
+spacing:
+  xs: "4px"
+  sm: "8px"
+  md: "12px"
+  lg: "16px"
+  xl: "24px"
+  xxl: "32px"
+components:
+  button-primary:
+    backgroundColor: "{colors.aegean-teal}"
+    textColor: "#FFFFFF"
+    rounded: "{rounded.md}"
+    padding: "12px 24px"
+  button-primary-hover:
+    backgroundColor: "#00695C"
+  button-secondary:
+    backgroundColor: "#FFFFFF"
+    textColor: "{colors.aegean-teal}"
+    rounded: "{rounded.sm}"
+    padding: "12px 24px"
+  card:
+    backgroundColor: "#FFFFFF"
+    rounded: "{rounded.md}"
+    padding: "{spacing.lg}"
+  input:
+    backgroundColor: "{colors.paper-fill}"
+    rounded: "{rounded.sm}"
+  chip:
+    rounded: "{rounded.full}"
+---
+
+# Design System: Anemos
+
+> **Authority map (binding).** This file records the system; the repo's
+> four-layer stack enforces it. `src/packages/flutter-app/lib/theme/` is law
+> for values; `.claude/skills/brand-guidelines/` + `docs/branding/brand-guidelines.html`
+> (v1.2) is law for rules and carries the pre-ship checklist and lint;
+> `.claude/skills/design-inspiration/` holds the reference images. If this
+> file and those ever disagree, fix this file.
+
+## Overview
+
+**Creative North Star: "The Aegean Journal"**
+
+Anemos is a polished travel product that reads like a luxury travel journal:
+the product craft of Airbnb, Hopper, and Flighty carrying the editorial
+restraint of Aman, Belmond, and Cereal. Aegean, not tropical. Engraved, not
+shouted. One deep-teal spine runs through everything; surfaces stay quiet like
+sun-bleached plaster; photography of real places in real light does the
+emotional work; and a design earns attention by making the space around the
+important thing quieter, not by making the thing bigger.
+
+The interface vocabulary is deliberately small — cards, bottom sheets, chips,
+and pills at comfortable density — extended rather than added to. Restraint is
+enforced, not aspirational: Material 3's surface tint is off everywhere,
+separation between surfaces is always an explicit color choice, and every
+non-teal color must earn its place by meaning exactly one thing. Confirmed
+anti-references: generic AI gradients (purple-blue fields), gradient text,
+glassmorphism as decoration, and the hero-metric template.
+
+**Key Characteristics:**
+- One teal spine; every other color earned and single-meaning
+- Editorial serif headings at one weight; hierarchy below them is weight, not size
+- Photography-forward, always behind a scrim when text sits on it
+- Flat-calm surfaces, light from above, no tonal tint
+- Card-and-sheet vocabulary, comfortable density, 48px touch floor
+
+## Colors
+
+One deep-teal spine seeded into the whole Material 3 scheme; warm neutral
+surfaces; accents at chip-and-pin scale only.
+
+### Primary
+- **Aegean Teal** (#00796B): the brand seed (`AppColors.brand`, teal-700). The
+  entire M3 `ColorScheme` in both light and dark derives from it. Identity and
+  the primary action — nothing else.
+- **Harbor Light** (#00897B) and **Harbor Dark** (#004D40): the ends of
+  `brandGradient` (top-left → bottom-right), the one sanctioned teal field —
+  the app bar and brand hero cards. The gradient bar stays teal in dark mode
+  by design. Harbor Dark also anchors `heroScrim` (0.88 alpha lower-left →
+  0.35 upper-right) — the layer under any text on a photo.
+- **Shallows Tint** (#E0F2F1): the faint teal wash (`brandTint`) for selected
+  and brand-touched surfaces at rest.
+
+### Secondary
+- **Heritage Gold** (#E8C452 / deep #B98B1E): lives in the wind-rose mark and
+  nowhere else. Never text, never a button, never a UI accent.
+- **Midnight Harbor** (≈#00231D, `landingCanvas`): the signed-out landing
+  page's dark canvas — the ONE recorded exception (doc v1.2) to neutral
+  surfaces. On it, every raised fill is a rung of the glass ladder (white at
+  6/8/10/12%, hairline 14%) and every text tone a rung of the ink ladder
+  (white at 35/60/70/85%). New landing surfaces pick a rung, never mint a
+  fresh alpha. The exception ends at sign-in.
+
+### Tertiary
+- **Tool accents** (chip-and-pin scale only, one meaning each): route
+  deep-orange 600 · flights blue 700 · stays pink 600 · events purple 600 ·
+  ferries cyan 700 · local amber 800 · parking blue-grey 700.
+- **Semantic pairs, two registers**: translucent containers (green 15% /
+  amber 20% alpha with shade-800/900 foregrounds) for pills on cards; solid
+  brightness-aware marks (`upMark`/`degradedMark`/`downMark`, shade 400 dark /
+  600–700 light) for status strips. "No data" deliberately has no token — it
+  takes `outlineVariant` so absence can never read as a severity.
+
+### Neutral
+- Surfaces are the seed-derived M3 neutrals — warm, plaster-leaning; light
+  input fields take **Paper Fill** (#FAFAFA), dark takes
+  `surfaceContainerHighest`.
+- **Map Scrim** (black 60%): the one translucent layer for text and controls
+  over satellite imagery.
+
+### Named Rules
+**The Earned Color Rule.** Every non-teal color means exactly one thing and
+appears at chip-and-pin scale, never as a field. Color is never decoration.
+
+**The Gold-in-the-Mark Rule.** Heritage Gold enters a screen only inside the
+wind-rose mark. Anywhere else it is a finding.
+
+**The One Dark Exception Rule.** Midnight Harbor exists only on the signed-out
+landing. Everywhere else, surfaces are the neutral scheme and dark mode is the
+same build with brightness flipped.
+
+## Typography
+
+**Display Font:** Marcellus (with Georgia, serif)
+**Body Font:** Inter (with system-ui, sans-serif)
+**Wordmark Font:** Cinzel 600 (wordmark only, via `BrandWordmark`)
+
+**Character:** Roman inscriptional letterforms carrying the register of the
+Cinzel wordmark, but with a true lowercase — headings read engraved rather
+than shouted, over a working sans that does everything else.
+
+### Hierarchy
+- **Wordmark** (Cinzel 600, small-caps ANEMOS): only via `BrandWordmark`, with
+  per-surface measured tracking (app bar 19px/1.0, auth 26px/1.5, boot splash
+  22px/3.0). Never retyped, never rasterized outside `brand-render.sh`.
+- **Headline** (Marcellus w400, 34/30/26px, line-height 1.2): page and section
+  headings, app-bar titles. Sentence case, always. Sizes step up 2px over the
+  M3 defaults to match Inter's x-height optically.
+- **Title** (Inter w700 large / w600 medium-small, M3 sizes): card titles and
+  row headers.
+- **Body** (Inter w400, 14–16px): prose and transcripts.
+- **Label** (Inter w600, 14px): buttons, chips, field labels — sentence case.
+- **Numbers** (Inter, always): stat values opt out of the serif on purpose.
+
+### Named Rules
+**The One Weight Rule.** Marcellus ships in exactly one weight; every style
+naming it states `w400` explicitly, or the web synthesizes faux-bold and
+smears the serif.
+
+**The Weight-Not-Size Rule.** Below the headline line, hierarchy is built
+with Inter's weight ladder (400/500/600/700), not with size steps.
+
+**The One Eyebrow Rule.** Capitals belong to the wordmark and to ONE display
+device: the letterspaced small-caps place eyebrow on destination surfaces
+(the Amanzoe move). No other kickers or eyebrows exist.
+
+## Layout
+
+Spacing comes only from the 4/8/12/16/24/32 ladder (`AppSpacing.xs→xxl`);
+values off the ladder are findings. Interactive rows and tiles keep a 48px
+minimum height (`kMinTouchTarget`). Density is comfortable — a travel journal,
+not a dashboard: generous padding inside cards (16px), 24px between sections,
+whitespace doing the layout work the way the Flighty and Aman references do.
+
+The app is one Material 3 build across web and mobile widths. Known
+responsive seams are measured, not guessed: the auth screen goes split-pane at
+≥900px and photo-band at ≥620px; the trip detail's side chat panel opens at
+≥900px. Buttons pad 24px horizontal / 12px vertical. Heroes are full-bleed
+photography inset within the page's own margins — the page, not the photo,
+owns the edges.
+
+## Elevation & Depth
+
+A hybrid, with an explicit doctrine: **light from above, tint off
+everywhere.** Real downward-offset drop shadows do the raising; Material 3's
+surface tint is disabled on every themed surface (`surfaceTintColor:
+transparent`), so separation is always an explicit color choice, never a side
+effect of elevation. In dark mode the shadow is invisible, so an explicit
+tonal step (`surfaceContainerHigh`) does the separating and the stronger
+shadow only grounds the card.
+
+### Shadow Vocabulary
+- **Soft** (`0 3px 10px rgba(0,0,0,0.10)`): custom raised containers outside
+  the Material `Card`.
+- **Card theme** (elevation 3, shadow black 16% light / 50% dark): the
+  standard card and menu treatment.
+- **Brand card** (`0 4px 10px` Harbor Dark 30%): under brand-gradient cards —
+  hero strips, recent/live trip cards.
+- **Hero** (`0 6px 16px` Harbor Dark 40%): full-bleed landing heroes.
+
+### Named Rules
+**The Light-From-Above Rule.** Every shadow offsets downward. A zero-offset
+colored halo is never ours.
+
+**The No-Tint Rule.** Surface separation is a color someone chose, never an
+implicit function of elevation.
+
+## Shapes
+
+Three radii and a circle: **8px** for inputs and small badges, **12px** for
+cards, menus, and sections, **20px** for heroes and large containers; chips
+are fully rounded. Nothing else. Borders are hairlines when they exist at all
+(the landing's white-14% hairline; `outlineVariant` elsewhere). The wind-rose
+mark always floats bare — no plate, tile, chip, or container behind it,
+anywhere (plate policy v3); the only per-surface question is which cut: dark
+mark on neutral or scrimmed fields, light mark on teal gradient fields.
+
+## Components
+
+### Buttons
+- **Shape:** primary (Filled) at card radius (12px); secondary (Elevated) at
+  input radius (8px).
+- **Primary:** scheme primary (seeded from Aegean Teal) with white foreground;
+  padding 24px horizontal, 12px vertical; Inter w600 label, sentence case.
+- **Hover / Focus:** Material state layers; no glows, no halos.
+- **Note:** M3 `copyWith` without an explicit color paints `onSurface`, not
+  the button foreground — state colors are always set explicitly.
+
+### Chips
+- **Style:** fully-rounded (999px), Inter label, quiet fills — tint or tool
+  accent at low alpha; on the landing canvas, the glass-ladder well (white 12%).
+- **State:** selected takes the brand tint family; filter chip rows are the
+  entire secondary navigation on list screens (the Airbnb move).
+
+### Cards / Containers
+- **Corner Style:** 12px.
+- **Background:** surface (light) / `surfaceContainerHigh` (dark); brand hero
+  cards take `brandGradient`.
+- **Shadow Strategy:** card theme elevation 3, tint transparent (see
+  Elevation); brand cards take the Harbor Dark shadow.
+- **Internal Padding:** 16px.
+- **Photo-led cards** (place/hotel/event rails): the image owns the card top,
+  text is a few quiet rows where only the key figure carries weight; fixed
+  200×160 chat cards so images never reflow the transcript.
+
+### Inputs / Fields
+- **Style:** outlined at 8px radius, filled — Paper Fill (#FAFAFA) light,
+  `surfaceContainerHighest` dark; on the landing canvas, the glass-ladder
+  field rung (white 10%).
+- **Focus:** scheme primary outline; no glow.
+
+### Navigation
+- **App bar:** the teal `brandGradient` in both themes, centered title in
+  Marcellus, `BrandWordmark` as the persistent brand anchor (left-aligned,
+  measured tracking). White foreground throughout.
+- **Menus:** open below the bar (`position: under`), styled to match cards
+  (12px radius, elevation 3, tint off) so every raised thing reads the same.
+- **Mobile:** bottom sheets are the phone's overflow vocabulary; the wordmark
+  yields to the page title when width demands it.
+
+### The Wind Rose & Wordmark (signature)
+`BrandLogo` (mark) and `BrandWordmark` (Cinzel small-caps ANEMOS) are
+components, not assets to recreate. Sizes shipped: 36 in chrome, 28 default,
+72 auth, 96 boot splash, 16 legible floor. Clear space ≥25% of mark height.
+Rasters come only from `scripts/brand-render.sh`.
+
+### The Hero Scrim (signature)
+Text sits on photography only over `heroScrim` — Harbor Dark densest in the
+lower-left where text and actions live, opening to the photo upper-right — or
+over `mapScrim` on satellite imagery. The landing hero may additionally
+dissolve its photo into Midnight Harbor via `landingHeroBlend`, but that
+gradient never carries text.
+
+## Do's and Don'ts
+
+### Do:
+- **Do** build only with tokens — `AppColors`, `AppFonts`/textTheme,
+  `AppSpacing`, `AppRadius`, `AppShadows`, `BrandLogo`/`BrandWordmark`; a
+  value that isn't a token becomes one in `lib/theme/` first.
+- **Do** keep photography real — real places in real light, credited in
+  `CREDITS.md`/`LICENSES.md` — and put a scrim under any text on it.
+- **Do** check both themes; the gradient bar staying teal in dark is correct.
+- **Do** state `w400` on every Marcellus style and set numbers in Inter.
+- **Do** run `.claude/skills/brand-guidelines/scripts/check.sh` on touched
+  Dart files before shipping.
+
+### Don't:
+- **Don't** put a plate, tile, or container behind the wind rose, or redraw
+  the mark "close enough".
+- **Don't** use gradient text, colored glows, zero-offset halos, teal-tinted
+  photos, purple-blue AI gradients, or glassmorphism as decoration.
+- **Don't** add a fourth typeface, load `google_fonts` (prod CSP blocks it),
+  or let emoji stand in for icons.
+- **Don't** use off-ladder spacing, radii outside 8/12/20/full, ad-hoc
+  `BoxShadow`s, or raw hex in widgets (sanctioned exceptions: `app_map.dart`
+  canvas, the easter egg).
+- **Don't** ship kickers/eyebrows (except the one destination place eyebrow),
+  Title Case Headings, section-number decoration, same-size icon-card grids
+  as page structure, or the hero-metric template.

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,131 @@
+# Product
+
+<!-- impeccable:product-schema 1 -->
+
+## Platform
+
+web
+
+## Users
+
+Primary user: Brian — a frequent traveler planning his own real trips. The bar
+for every decision is "does Brian reach for it for his own trips," not "would
+people pay for this." Second ring: the friends-and-family pre-beta cohort
+(non-technical, arriving via a personal DM, asked to find what's rough and say
+so). Third ring: public frequent travelers — people currently planning trips
+across a dozen tabs and a ChatGPT window that forgets everything.
+
+Collaborators are a real role: trips are shared with editors and viewers
+(co-planners), and the product distinguishes owner planning state from what a
+co-planner sees.
+
+## Product Purpose
+
+Anemos (anemos.travel) turns a conversation into a real, saved, refinable trip.
+You describe the trip; an AI planning agent builds the actual day-by-day
+itinerary — real flights, real places, real events, on a map — and the trip
+persists as structured data you can book against, budget, share, pack for, and
+keep refining in the same chat. Success means the trip you actually take was
+planned here, end to end, with less friction than the twelve-tab alternative.
+
+## Positioning
+
+**Chat → real persisted trip.** A ChatGPT window produces a wall of text that
+forgets; a booking site starts from an airport code. Anemos is the only place
+where describing a trip yields a persistent, structured itinerary — coordinates
+verified against Google Places, flights from live inventory, legs with modes and
+dates — that both the chat agent and the trip page continue to edit as the same
+underlying object. This is the claim future work must protect.
+
+Supporting differentiators (real, but secondary): the product learns how you
+travel (home airport, baggage tier, budget tier, preferences quietly shape every
+plan); locally-sourced, attributed recommendations ("legit info you can't
+google") that the agent cites first; and the whole trip — flights, stays,
+ferries, events, budget, packing — in one product.
+
+## Operating Context
+
+- Planning happens conversationally (the plan chat, desktop and mobile web) and
+  on the trip page (tabs: itinerary, bookings, budget, map); both surfaces write
+  the same server-side truth, by design and by pinned test.
+- Trips are also **imported** from external AI chats (paste a ChatGPT/Claude
+  conversation) and created from other assistants via the MCP connector.
+- Real bookings happen off-platform today via handoff links (Booking.com
+  affiliate, Google Flights, Ferryhopper); the product tracks what's booked,
+  chosen, and still open per leg.
+- Provider data is live-lookup (Duffel/SerpApi flights, SerpApi hotels,
+  Ticketmaster events, Google Places) under free-tier quotas with caps, caches,
+  and daily budgets; the local-recommendations layer is persisted and
+  admin-curated.
+- Production is live on DigitalOcean behind an nginx gateway; deploys run from
+  CI; an admin ops/metrics surface monitors health and uptime.
+
+## Capabilities and Constraints
+
+- Core loop: SSE-streamed agent chat over an ordered tool registry (search
+  places / local recs / flights / hotels / events / ferries, itinerary create
+  and update, preferences, booking todos, trip endpoints, transport modes,
+  descriptions). Registry order is part of the prompt-cache prefix — a hard
+  technical constraint on how tools evolve (append-only).
+- Trips: legs with derived transport modes, booking shortlists per leg, budget
+  with planned-vs-paid expenses, daily food-spend estimates (labelled model
+  estimates, never presented as provider data), events rails, wear/pack guide,
+  shared maps, collaborators and public share pages.
+- Accounts: email+password, Google and Apple SSO; anonymous use works for
+  planning (free caps apply); i18n is live (English, Spanish; client owns
+  locale).
+- **No FX anywhere in the app**: prices are never converted between currencies —
+  a mismatch is reported, not converted. Model estimates are always labelled as
+  such on the wire and on render.
+- **Degrade, never invent**: every provider failure path returns an honest
+  absence with a stable reason code, not a plausible substitute.
+- Business model (working strategy, not shipped UI): booking-linked revenue as
+  the base; a future annual/per-trip "power traveler" tier — never monthly; the
+  entire core loop stays free. Keeping the product free is a revenue decision.
+- Undecided product facts: the pre-beta `[FEEDBACK CHANNEL]` destination;
+  paid-tier scope and timing (deliberately deferred until evidence).
+
+## Brand Commitments
+
+- Name **Anemos**, domain anemos.travel, operated by Golden Tempo LLC. (Phase 0
+  trademark/DBA work is owed; the racehorse origin story — Golden Tempo — is
+  part of the founder voice, not the product name.)
+- Visual identity is governed by an existing four-layer stack that is binding on
+  all UI work: `.claude/skills/design-inspiration` (taste),
+  `src/packages/flutter-app/lib/theme/` (token values),
+  `.claude/skills/brand-guidelines` + `docs/branding/brand-guidelines.html`
+  v1.2 (conformance, with `scripts/check.sh` on touched Dart files).
+- Standing identity facts: Cinzel wordmark, Marcellus headings, the teal palette
+  stays, no plate behind the logo anywhere; the landing page's dark canvas is a
+  recorded exception to the light app surface. A rule that must break gets
+  written into the guideline doc in the same PR.
+- Voice (from the pre-beta pitch): first-person, warm, honest about roughness;
+  "complaints are useful" — never corporate, never overclaiming.
+
+## Evidence on Hand
+
+- Live production app at anemos.travel with real accounts, real flight/hotel/
+  event/place data, and real trips.
+- `docs/prebeta-pitch.md` (channel-ready launch copy), `docs/sales-pitch.md`
+  (investor framing), `docs/business-model.md` (revenue reasoning),
+  `docs/friction-log.md` (the queue-driving dogfood log).
+- No user testimonials, case studies, press, usage benchmarks, or revenue
+  numbers exist yet — future surfaces must not fabricate any. Legal review of
+  the live terms (arbitration/class-waiver) has not happened; do not cite legal
+  sign-off.
+
+## Product Principles
+
+1. **The bar is Brian's own trips.** The friction log drives the queue; a
+   feature that doesn't make his next real trip easier is deferred.
+2. **Explicit is better than implicit** (docs/zen.md, binding): data semantics
+   live in schema and enforced boundaries, derived state is computed in exactly
+   one place, and a mutating action's result states the post-state its consumer
+   observes.
+3. **Chat and page write the same truth.** Every trip fact has exactly one
+   server-side writer that both surfaces call; parity is pinned by tests, not
+   convention.
+4. **Degrade, never invent.** An unavailable provider, price, or estimate
+   yields a labelled absence with a reason — never a plausible-looking number.
+5. **The funnel stays open.** The core planning loop is free; monetization
+   rides bookings and heavy use, never a gate in front of the first trip.


### PR DESCRIPTION
## Why

These three files hold the product framing, design system and brand rules, but were untracked. That meant they existed only in the main checkout — every git worktree started without them.

Concretely, in the existing `home-editorial-redesign` worktree:

```
$ ls .claude/worktrees/home-editorial-redesign/
CLAUDE.md   Makefile   README.md   content   docker-compose.yml   ...
```

`CLAUDE.md` is there (tracked), `PRODUCT.md` and `DESIGN.md` are not. Any agent working in a worktree was blind to the two documents most recently updated.

## What

Tracks `PRODUCT.md`, `DESIGN.md` and `.impeccable/design.json` so the context inherits into worktrees automatically. Docs only — no code paths touched.

Deliberately **not** included: `.claude/RESUME.md`. It's an auto-generated per-session checkpoint referencing a local-only `refs/claude/checkpoint-*` that expires in ~2 weeks, and it's already in `.git/info/exclude`.

## Follow-up

`CLAUDE.md` has no references to any of these files, so they're still only read when named explicitly. A short pointer section would make them load-bearing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)