### PR TITLE
chore: move container images to ghcr.io/golden-tempo namespace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -308,8 +308,8 @@ jobs:
           platforms: linux/amd64
           push: true
           tags: |
-            ghcr.io/bdowe/goldentempo-api:latest
-            ghcr.io/bdowe/goldentempo-api:${{ github.sha }}
+            ghcr.io/golden-tempo/goldentempo-api:latest
+            ghcr.io/golden-tempo/goldentempo-api:${{ github.sha }}
           build-args: |
             SENTRY_RELEASE=${{ github.sha }}
           cache-from: type=gha,scope=api
@@ -325,8 +325,8 @@ jobs:
           platforms: linux/amd64
           push: true
           tags: |
-            ghcr.io/bdowe/goldentempo-gateway:latest
-            ghcr.io/bdowe/goldentempo-gateway:${{ github.sha }}
+            ghcr.io/golden-tempo/goldentempo-gateway:latest
+            ghcr.io/golden-tempo/goldentempo-gateway:${{ github.sha }}
           build-args: |
             GIT_SHA=${{ github.sha }}
           cache-from: type=gha,scope=gateway

--- a/dockerize/production/docker-compose.yml
+++ b/dockerize/production/docker-compose.yml
@@ -43,7 +43,7 @@ services:
       - travel-planner-network
 
   api:
-    image: ghcr.io/bdowe/goldentempo-api:${IMAGE_TAG:-latest}
+    image: ghcr.io/golden-tempo/goldentempo-api:${IMAGE_TAG:-latest}
     expose:
       - "8080"
     # All runtime config reaches the api via env_file passthrough from .env:
@@ -90,7 +90,7 @@ services:
       - travel-planner-network
 
   gateway:
-    image: ghcr.io/bdowe/goldentempo-gateway:${IMAGE_TAG:-latest}
+    image: ghcr.io/golden-tempo/goldentempo-gateway:${IMAGE_TAG:-latest}
     # No ports: on purpose — the only way in is the cloudflared service on
     # the private compose network. Publishing 80/443 here would bypass the
     # tunnel AND the real-IP trust model in nginx/cloudflare-realip.conf.


### PR DESCRIPTION
**Do not merge until the repo transfer to `golden-tempo` is done — then merge FIRST, before any other PR.**

Post-transfer, `GITHUB_TOKEN` can't push to `ghcr.io/bdowe/*`; this points build-push and prod compose at `ghcr.io/golden-tempo/*` instead.

Server-side checklist before the first post-transfer deploy:
- [ ] If the old GHCR packages were **private**: ensure the VPS's stored docker credential can read `golden-tempo` org packages (PAT with `read:packages` + org access), or set the new packages public after first push.
- [ ] After first green deploy, old `ghcr.io/bdowe/goldentempo-*` packages can be deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)