### PR TITLE
feat(ui): redesign popup menus (account, language, app-wide menu theme)

### DIFF
--- a/src/packages/flutter-app/lib/theme/app_theme.dart
+++ b/src/packages/flutter-app/lib/theme/app_theme.dart
@@ -82,7 +82,7 @@ abstract final class AppTheme {
       cardTheme: CardThemeData(
         elevation: 3,
         color: isDark ? colorScheme.surfaceContainerHigh : null,
-        shadowColor: Colors.black.withValues(alpha: isDark ? 0.5 : 0.16),
+        shadowColor: _raisedShadow(isDark),
         surfaceTintColor: Colors.transparent,
         shape: const RoundedRectangleBorder(borderRadius: AppRadius.mdAll),
       ),
@@ -90,18 +90,61 @@ abstract final class AppTheme {
       // most of them didn't and took raw M3 instead — including the trip's
       // own `⋮`, which then opened as a panel OVERLAPPING the gradient app
       // bar and inheriting its white foreground. Stated once here:
-      // `under` clears the bar, and the surface/elevation/radius match
+      // `under` clears the bar, and the surface/elevation/radius/shadow match
       // cardTheme so a menu reads like every other raised thing in the app.
       // Dark takes the same explicit tonal step cardTheme does, for the same
       // reason: a `surface`-colored menu floating over a `surface`-colored
       // page is a hairline border away from invisible, and the tint that
       // would otherwise separate it is deliberately off everywhere.
+      //
+      // Row text is the READING register, not the button one: our labelLarge
+      // carries w600 for buttons, and menus inherit labelLarge by default, so
+      // every row shouted equally. bodyMedium at w500 sits menu rows on the
+      // Inter weight ladder below titles (hierarchy is weight, not size) and
+      // leaves w600 free to mean something inside a menu — the selected
+      // language, a row a widget chooses to emphasize. Disabled keeps M3's
+      // onSurface-at-38% so items a consumer disables still read disabled.
       popupMenuTheme: PopupMenuThemeData(
         color: isDark ? colorScheme.surfaceContainerHigh : colorScheme.surface,
         elevation: 3,
+        shadowColor: _raisedShadow(isDark),
         surfaceTintColor: Colors.transparent,
         shape: const RoundedRectangleBorder(borderRadius: AppRadius.mdAll),
         position: PopupMenuPosition.under,
+        labelTextStyle: WidgetStateProperty.resolveWith((states) {
+          final style = _menuRowStyle(textTheme, colorScheme);
+          if (states.contains(WidgetState.disabled)) {
+            return style?.copyWith(
+              color: colorScheme.onSurface.withValues(alpha: 0.38),
+            );
+          }
+          return style;
+        }),
+      ),
+      // MenuAnchor menus (the Bookings view's "+ Add booking") are a second
+      // menu system with its own M3 defaults — surfaceContainer fill, tonal
+      // tint, 4px corners — so without this block they read as a stranger
+      // next to every popup menu. Same card treatment, same row register,
+      // stated once for both systems via the shared helpers above.
+      menuTheme: MenuThemeData(
+        style: MenuStyle(
+          backgroundColor: WidgetStatePropertyAll(
+            isDark ? colorScheme.surfaceContainerHigh : colorScheme.surface,
+          ),
+          elevation: const WidgetStatePropertyAll(3),
+          shadowColor: WidgetStatePropertyAll(_raisedShadow(isDark)),
+          surfaceTintColor: const WidgetStatePropertyAll(Colors.transparent),
+          shape: const WidgetStatePropertyAll(
+            RoundedRectangleBorder(borderRadius: AppRadius.mdAll),
+          ),
+        ),
+      ),
+      menuButtonTheme: MenuButtonThemeData(
+        style: ButtonStyle(
+          textStyle: WidgetStatePropertyAll(
+            _menuRowStyle(textTheme, colorScheme),
+          ),
+        ),
       ),
       inputDecorationTheme: InputDecorationTheme(
         border: const OutlineInputBorder(borderRadius: AppRadius.smAll),
@@ -137,4 +180,20 @@ abstract final class AppTheme {
       ),
     );
   }
+
+  /// The one shadow color every raised surface casts (cards, popup menus,
+  /// MenuAnchor menus). Light is a soft 16% black; dark goes 50% because the
+  /// shadow only grounds the surface there — the tonal step does the
+  /// separating.
+  static Color _raisedShadow(bool isDark) =>
+      Colors.black.withValues(alpha: isDark ? 0.5 : 0.16);
+
+  /// Menu-row text for BOTH menu systems (popup menus and MenuAnchor items),
+  /// so the two can't drift apart: Inter at bodyMedium size, w500 — below
+  /// titles on the weight ladder, above body. See popupMenuTheme's comment.
+  static TextStyle? _menuRowStyle(TextTheme textTheme, ColorScheme scheme) =>
+      textTheme.bodyMedium?.copyWith(
+        fontWeight: FontWeight.w500,
+        color: scheme.onSurface,
+      );
 }

--- a/src/packages/flutter-app/lib/widgets/account_menu.dart
+++ b/src/packages/flutter-app/lib/widgets/account_menu.dart
@@ -20,20 +20,30 @@ String _initialFor(String displayName) {
   return t.isEmpty ? '?' : t[0].toUpperCase();
 }
 
+/// Width floor for the account panel (the 280px popup cap stays the max).
+/// Short names would otherwise hug to a strip; a floored panel reads as a
+/// designed surface and keeps its geometry stable across users.
+const BoxConstraints _accountMenuConstraints = BoxConstraints(minWidth: 240);
+
 /// One style for the avatar initial everywhere it renders, so the popup
 /// header, app-bar avatar and rail avatar can't drift apart.
 TextStyle? _avatarLabelStyle(ThemeData theme) => theme.textTheme.labelLarge
     ?.copyWith(color: Colors.white, fontWeight: FontWeight.w600);
 
-/// Icon + label row for the popup actions. `Flexible` + ellipsis keeps long
-/// translations inside the 280px popup cap instead of overflowing the row.
-Widget _menuRow(Widget icon, String label) => Row(
+/// Icon + label row for the popup actions. `Expanded` + ellipsis keeps long
+/// translations inside the 280px popup cap instead of overflowing the row,
+/// and gives [trailing] (the unread count) a stable right edge to sit on.
+Widget _menuRow(Widget icon, String label, {Widget? trailing}) => Row(
       children: [
         icon,
         const SizedBox(width: AppSpacing.md),
-        Flexible(
+        Expanded(
           child: Text(label, maxLines: 1, overflow: TextOverflow.ellipsis),
         ),
+        if (trailing != null) ...[
+          const SizedBox(width: AppSpacing.sm),
+          trailing,
+        ],
       ],
     );
 
@@ -75,13 +85,21 @@ List<PopupMenuEntry<String>> _items(
   return [
     if (displayName != null) ...[
       // Identity, not an action — styled explicitly so the disabled item
-      // doesn't read as greyed-out.
+      // doesn't read as greyed-out. The header is the menu's anchor: a 40px
+      // avatar and a titleMedium name give "who am I" real presence (the
+      // Etsy/Hootsuite identity-block move), and the extra vertical padding
+      // is what separates a designed panel from a list that happens to
+      // start with a name.
       PopupMenuItem<String>(
         enabled: false,
+        padding: const EdgeInsets.symmetric(
+          horizontal: AppSpacing.md,
+          vertical: AppSpacing.md,
+        ),
         child: Row(
           children: [
             CircleAvatar(
-              radius: 16,
+              radius: 20,
               backgroundColor: AppColors.brand,
               child: Text(
                 _initialFor(displayName),
@@ -89,7 +107,7 @@ List<PopupMenuEntry<String>> _items(
               ),
             ),
             const SizedBox(width: AppSpacing.md),
-            Flexible(
+            Expanded(
               child: Column(
                 mainAxisSize: MainAxisSize.min,
                 crossAxisAlignment: CrossAxisAlignment.start,
@@ -98,7 +116,7 @@ List<PopupMenuEntry<String>> _items(
                     displayName,
                     maxLines: 1,
                     overflow: TextOverflow.ellipsis,
-                    style: theme.textTheme.titleSmall?.copyWith(
+                    style: theme.textTheme.titleMedium?.copyWith(
                       color: theme.colorScheme.onSurface,
                     ),
                   ),
@@ -119,6 +137,9 @@ List<PopupMenuEntry<String>> _items(
       ),
       const PopupMenuDivider(),
     ],
+    // "How I travel" first (the quiz rebuilds the profile, so it sits with
+    // it), then account plumbing. One group — four rows don't need divider
+    // chrome between them.
     PopupMenuItem<String>(
       value: 'preferences',
       child: _menuRow(
@@ -127,25 +148,25 @@ List<PopupMenuEntry<String>> _items(
       ),
     ),
     PopupMenuItem<String>(
-      value: 'notifications',
-      child: _menuRow(
-        unreadNotifications > 0
-            ? Badge.count(
-                count: unreadNotifications,
-                child: Icon(Icons.notifications_none,
-                    size: 20, color: theme.colorScheme.onSurfaceVariant),
-              )
-            : Icon(Icons.notifications_none,
-                size: 20, color: theme.colorScheme.onSurfaceVariant),
-        l10n.accountMenuNotifications,
-      ),
-    ),
-    PopupMenuItem<String>(
       value: 'retake_quiz',
       child: _menuRow(
         Icon(Icons.refresh,
             size: 20, color: theme.colorScheme.onSurfaceVariant),
         l10n.accountMenuRetakeQuiz,
+      ),
+    ),
+    PopupMenuItem<String>(
+      value: 'notifications',
+      child: _menuRow(
+        Icon(Icons.notifications_none,
+            size: 20, color: theme.colorScheme.onSurfaceVariant),
+        l10n.accountMenuNotifications,
+        // The count sits at the row's end as its own quiet figure instead of
+        // riding the icon — the row stays scannable and the number reads at
+        // a glance.
+        trailing: unreadNotifications > 0
+            ? Badge.count(count: unreadNotifications)
+            : null,
       ),
     ),
     PopupMenuItem<String>(
@@ -215,6 +236,7 @@ class AccountMenu extends ConsumerWidget {
       // Surface, elevation, radius and the below-the-bar position now come
       // from `popupMenuTheme` (app_theme.dart) — stated once for every menu
       // in the app rather than per call site.
+      constraints: _accountMenuConstraints,
       icon: unread > 0 ? Badge.count(count: unread, child: avatar) : avatar,
       onSelected: (v) => _onSelected(context, ref, v),
       itemBuilder: (_) => _items(theme, l10n, user?.displayName, user?.email,
@@ -244,6 +266,7 @@ class RailAccountButton extends ConsumerWidget {
     );
     return PopupMenuButton<String>(
       tooltip: l10n.accountMenuTooltip,
+      constraints: _accountMenuConstraints,
       icon: unread > 0 ? Badge.count(count: unread, child: avatar) : avatar,
       onSelected: (v) => _onSelected(context, ref, v),
       itemBuilder: (_) => _items(theme, l10n, user?.displayName, user?.email,

--- a/src/packages/flutter-app/lib/widgets/language_menu_button.dart
+++ b/src/packages/flutter-app/lib/widgets/language_menu_button.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../l10n/l10n.dart';
 import '../providers/locale_provider.dart';
+import '../theme/spacing.dart';
 
 /// App-bar globe button offering the same choices as the account-settings
 /// language picker (specs/i18n-spanish): every entry in [kSupportedLocales].
@@ -16,6 +17,7 @@ class LanguageMenuButton extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final theme = Theme.of(context);
     final l10n = context.l10n;
     // Checked state mirrors the settings picker.
     final language = ref.watch(localeProvider.select((s) => s.language));
@@ -25,16 +27,52 @@ class LanguageMenuButton extends ConsumerWidget {
       // `popupMenuTheme` (app_theme.dart).
       // No explicit color: inherits the bar's foreground (white on the
       // gradient bars, onSurface on the auth screen's transparent bar).
+      // Floored so a two-entry list reads as a panel, not a hug-width strip.
+      constraints: const BoxConstraints(minWidth: 200),
       icon: const Icon(Icons.language),
       onSelected: (v) => ref.read(localeProvider.notifier).setLanguage(v),
       itemBuilder: (_) => [
         for (final locale in kSupportedLocales)
-          CheckedPopupMenuItem<String>(
+          PopupMenuItem<String>(
             value: locale.languageCode,
-            checked: language == locale.languageCode,
-            child: Text(languageDisplayName(l10n, locale.languageCode)),
+            // Hand-rolled rather than CheckedPopupMenuItem: the stock item
+            // is a ListTile with its own metrics, so its rows sat on a
+            // different grid than every other menu row in the app. This row
+            // shares the account menu's geometry (20px leading slot, 12px
+            // gap), reserves the slot when unchecked so labels never shift,
+            // and marks selection the ladder way — the check in primary plus
+            // a w600 label, weight not size.
+            child: Semantics(
+              checked: language == locale.languageCode,
+              child: _languageRow(
+                theme,
+                selected: language == locale.languageCode,
+                label: languageDisplayName(l10n, locale.languageCode),
+              ),
+            ),
           ),
       ],
     );
   }
+}
+
+Widget _languageRow(ThemeData theme,
+    {required bool selected, required String label}) {
+  return Row(
+    children: [
+      if (selected)
+        Icon(Icons.check_rounded, size: 20, color: theme.colorScheme.primary)
+      else
+        const SizedBox(width: 20),
+      const SizedBox(width: AppSpacing.md),
+      Expanded(
+        child: Text(
+          label,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+          style: selected ? const TextStyle(fontWeight: FontWeight.w600) : null,
+        ),
+      ),
+    ],
+  );
 }

--- a/src/packages/flutter-app/test/language_menu_button_test.dart
+++ b/src/packages/flutter-app/test/language_menu_button_test.dart
@@ -123,10 +123,19 @@ class _FakeAuthNotifier extends StateNotifier<AuthState>
   Future<void> adoptSession(String token, UserModel user) async {}
 }
 
-bool _checkedOf(WidgetTester tester, String label) => tester
-    .widget<CheckedPopupMenuItem<String>>(
-        find.widgetWithText(CheckedPopupMenuItem<String>, label))
-    .checked;
+/// The menu marks the active language with a primary check icon inside the
+/// row (hand-rolled rows since the popup-menus redesign — no
+/// CheckedPopupMenuItem), so "checked" is asserted as that visible marker.
+bool _checkedOf(WidgetTester tester, String label) {
+  final row = find.ancestor(
+    of: find.text(label),
+    matching: find.byType(PopupMenuItem<String>),
+  );
+  return find
+      .descendant(of: row, matching: find.byIcon(Icons.check_rounded))
+      .evaluate()
+      .isNotEmpty;
+}
 
 void main() {
   setUp(() => SharedPreferences.setMockInitialValues({}));
@@ -184,8 +193,7 @@ void main() {
 
     await tester.tap(find.byIcon(Icons.language));
     await tester.pumpAndSettle();
-    await tester
-        .tap(find.widgetWithText(CheckedPopupMenuItem<String>, 'Español'));
+    await tester.tap(find.widgetWithText(PopupMenuItem<String>, 'Español'));
     await tester.pumpAndSettle();
 
     expect(ref.read(localeProvider).language, 'es');


### PR DESCRIPTION
## Summary

Component lane in the editorial redesign arc: the popup menus. Two layers, per the ticket — the app-wide menu theme (lifting all nine consumer files without touching them) and the two menu widgets.

**Theme layer (`lib/theme/app_theme.dart`)**
- **Menu rows drop from the button register to the reading register.** Our `labelLarge` carries w600 for buttons, and M3 menus inherit `labelLarge` — so every row in every menu shouted equally. `popupMenuTheme.labelTextStyle` now resolves to Inter `bodyMedium` at w500 (disabled keeps M3's onSurface-38%), leaving w600 free to *mean* something inside a menu (the selected language). Weight-not-size, applied to menus.
- **Menus now cast the card shadow.** `popupMenuTheme` gets the exact `cardTheme` shadow color (16% light / 50% dark) via a shared `_raisedShadow` helper, so "every raised thing reads the same" includes the shadow. Previously menus cast the harsher default black.
- **`MenuAnchor` joins the family.** The Bookings view's "+ Add booking" menu is a second menu system with its own M3 defaults — `surfaceContainer` fill, tonal tint ON, 4px corners — a stranger next to our 12px cards. `menuTheme` + `menuButtonTheme` give it the same surface/elevation/radius/shadow and the same row register, through the same shared helpers so the two systems can't drift.

**Widget layer**
- **`account_menu.dart`**: identity header gets real presence (40px avatar, `titleMedium` name over a quiet `onSurfaceVariant` email, `md` vertical padding) — the Etsy/Hootsuite identity-block move. "Retake travel quiz" moves next to "Travel profile" (the quiz rebuilds the profile; they're one thought). The unread count moves off the bell icon to the row's end as a trailing `Badge.count` — the row stays scannable, the figure reads at a glance. Panel floored at 240px so short-name accounts don't hug to a strip.
- **`language_menu_button.dart`**: replaces stock `CheckedPopupMenuItem` (ListTile metrics — its rows sat on a different grid than every other menu row in the app) with hand-rolled rows on the account menu's geometry: 20px leading slot (check in scheme primary when active, reserved when not, so labels never shift), selected label at w600, `Semantics(checked:)` preserved, panel floored at 200px.

No new l10n strings; no consumer file touched; no new color/spacing values — everything traces to existing tokens, scheme roles, or the two new theme-file helpers.

## Design references

Per the ticket's method: `DESIGN.md` / `PRODUCT.md` / `.impeccable/design.json` read first; design-inspiration consulted (airbnb--search-cards for quiet-row anatomy where one element carries weight, cereal--home-editorial for restraint/density, aman--resort-detail for hierarchy); Mobbin research on account/profile dropdowns (Etsy/Hootsuite/Airbnb identity-header + grouped-rows patterns; Airbnb's roomy uniform-width panel).

## Testing

- `flutter analyze`: no new findings (the 3 pre-existing `unnecessary_brace_in_string_interps` infos in `lib/models/route_response.dart` are identical with this diff stashed; file outside this lane's manifest).
- Full `flutter test` suite green (see checks).
- `language_menu_button_test.dart` updated with the redesign: the two "checked" assertions pinned the `CheckedPopupMenuItem` implementation detail this PR deliberately replaces; they now assert the user-visible marker (the primary `check_rounded` icon inside the row) with intent unchanged — languages listed, active one checked, selecting Español switches the app.

## Browser QA

Headless-Chrome pass on the lane build (host dev server, 1440×900, seeded account, light **and** dark): account menu (rail presentation, incl. 2-unread trailing badge + rail-avatar badge intact), language menu, and five theme-lifted consumers — the "+ Add booking" `MenuAnchor` (light+dark), the leg transport-mode menu (icons + trailing check intact), the itinerary-row menu, the trip-actions menu (explicit red "Delete trip" styling wins over the theme row style, as intended), and the notification center's "Clear all" (dark). No degradation anywhere; dark verified by pixel-sampling surfaces, not eyeballing.

Before/after screenshots (17, both themes) are filed in the epic artifact `popup-menus-redesign/screenshots/` with a walkthrough index.

## Brand conformance

- `.claude/skills/brand-guidelines/scripts/check.sh`: clean on all 3 touched files.
- Both themes checked; menus take the dark tonal step (`surfaceContainerHigh`) with tint off in both modes; radii stay on the 8/12/20 ladder (menus 12); no raw hex outside `lib/theme/`; sentence case throughout; no generic-AI-guard patterns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
