### PR TITLE
chore(integrate): merge when clean, in PR-open order

### DIFF
--- a/.claude/skills/integrate/SKILL.md
+++ b/.claude/skills/integrate/SKILL.md
@@ -1,109 +1,229 @@
 ---
 name: integrate
-description: Serially merge a wave of open lane PRs — rebase, resolve hub files, regenerate generated code, wait for green CI, merge, repeat. Deploys run in the background and never block the next merge. Use after a parallel wave's lane agents have stopped at PR-open.
+description: Serially merge a wave of open lane PRs in PR-open order — check for conflicts, merge straight away if there are none, resolve first if there are. Deploys run in the background and never block the next merge. Use after a parallel wave's lane agents have stopped at PR-open.
 ---
 
 # Integrate a wave of lane PRs
 
-Preconditions: you are the ONLY session merging; working tree clean; on
-`main`; `gh pr list` shows the wave's PRs; the merge order is the Lanes
-section of the feature's `specs/<feature>/tasks.md`. Rationale for every rule
-here: `docs/parallel-dev.md` §3–6.
+Preconditions: you are the ONLY session merging; the main checkout is clean and
+on `main`; `gh pr list` shows the wave's PRs. Rationale for every rule here:
+`docs/parallel-dev.md` §3–6.
 
-## The loop — repeat per PR, in dependency order
+**The shape of this loop:** most lane PRs do not conflict with `main` — that is
+what the hub table's partitioning rules are FOR. So a PR pays only for what it
+actually needs: a conflict check, then either a merge (seconds, never leaving
+the main checkout) or the resolve tail. Nothing is rebased and nothing is
+force-pushed.
 
-1. **Pick** the next PR whose dependency edges are all merged. Never merge
-   around an edge; if the next PR is blocked, an *independent* PR may go
-   first.
+## 0. Build the queue — PR-open order
 
-2. **Rebase** its branch onto `origin/main`. While the lane's worktree exists,
-   its branch is checked out THERE — `git checkout <branch>` in the main
-   checkout will refuse. Work inside the lane's worktree instead:
-   `git fetch origin && cd .claude/worktrees/<lane> && git rebase origin/main`.
-   (Only if the worktree is already gone: `git checkout <branch>` in the main
-   checkout.) Steps 3–5 run in that same directory — its `.wt.env` keeps the
-   make targets pointed at the lane's own stack.
+```bash
+git fetch origin --prune
+gh pr list --state open \
+  --json number,title,createdAt,headRefName,baseRefName,isDraft \
+  --jq 'sort_by(.createdAt)[] | "\(.number)\t\(.createdAt)\t\(.baseRefName)\t\(.headRefName)"'
+```
 
-3. **Resolve** conflicts per the hub table (`docs/parallel-dev.md` §3):
-   hand-written hubs by hand (`main.go` / `.env.sample` / `CLAUDE.md` = take
-   both; `.arb`s = take both key sets; `plan_tool_registry.go` = main's order
-   + tail append, never reorder; migrations = the lane's reserved number).
-   Conflicted **generated** files: take main's side unread
-   (`git checkout --ours -- src/packages/api/store src/packages/flutter-app/lib/l10n/app_localizations*.dart 'src/packages/flutter-app/lib/models/*.g.dart'`),
-   then after the whole rebase completes, regen LAST:
-   `make api-sqlc` · `make flutter-gen-l10n` · `make flutter-build-models`,
-   and commit the regen output.
+Oldest `createdAt` first. Exactly **two** exceptions, both cheaper to obey than
+to repair:
+
+- **A stacked PR waits for its base.** If `baseRefName` is another open lane
+  branch, skip it; when the base merges, retarget it
+  (`gh pr edit <n> --base main`) and it re-enters at its own slot. This is the
+  migration-00058 outage class (`docs/parallel-dev.md` §4a): PR #350 was merged
+  into a branch that had already merged to main, so GitHub says MERGED while its
+  migration never reached main. Confirm with
+  `git merge-base --is-ancestor <merge-commit> origin/main`, never the badge.
+- **Migration-carrying PRs merge in ascending migration number** among
+  themselves, whatever order they were opened in. Numbers are reserved at wave
+  planning in ascending order; landing a lower number after a higher one is
+  refused by CI's out-of-order guard and forces a renumber plus a full CI
+  re-run — pure overhead, avoided by ordering.
+
+The `specs/<feature>/tasks.md` dependency edges are now **advisory**: read them
+as a sanity check on the two exceptions above, not as the sequencer.
+
+## 1. Conflict check — one command, no checkout
+
+```bash
+git fetch origin
+git merge-tree --write-tree --name-only origin/main origin/<headRefName>
+```
+
+Exit `0` = clean → step 2a. Exit `1` = conflicts, and the output names the
+conflicted paths → step 2b.
+
+Use this rather than `gh pr view --json mergeable`: GitHub computes mergeability
+asynchronously and answers `UNKNOWN` for a while after the base moves.
+
+## 2a. Clean → merge
+
+1. **Checks green on the PR's own head**: `gh pr checks <n>`. Pending means
+   wait. Red means it is the lane's problem — hand it back (see step 4) and take
+   the next PR.
+
+2. **Migration floor** — only if the PR adds `src/packages/api/migrations/*.sql`:
+
+   ```bash
+   gh pr diff <n> --name-only | grep '^src/packages/api/migrations/'
+   git ls-tree --name-only origin/main -- src/packages/api/migrations/ | tail -1
+   ```
+
+   Every added number must be **strictly greater** than main's highest.
+
+   This is the one check that must survive skipping the rebase, and it is the
+   only place this loop spends effort on a clean PR. Both CI migration guards
+   read live `origin/main` (the out-of-order guard) or the PR merge ref (the
+   duplicate guard) **at run time** — so they are only as fresh as the PR's last
+   run. A competing migration that merged since then is invisible behind a green
+   badge, produces no textual conflict (different filenames — a gap-fill
+   "collides with nothing", §4a), and lands as `goose` refusing at boot:
+   `log.Fatalf` before the port binds, a crash-loop outage that only goes red
+   ~5 minutes later. Failing this check means renumber, which drops the PR into
+   step 2b.
+
+3. **Merge**, from the main checkout:
+   `gh pr merge <n> --merge --delete-branch`.
+
+   No rebase, no force-push, no worktree, no CI re-run. (`deleteBranchOnMerge`
+   is `false` on this repo so the flag stays. The *local* branch delete may warn
+   because the branch is checked out in the lane's worktree — harmless,
+   `make wt-rm` finishes the job in step 6.)
+
+## 2b. Conflicts → merge main in, resolve once, then merge
+
+The lane's branch is checked out in its worktree, so `git checkout <branch>` in
+the main checkout will refuse. Work there:
+
+```bash
+cd .claude/worktrees/<lane>
+git fetch origin && git merge origin/main
+```
+
+(Only if the worktree is already gone: `git checkout <branch>` in the main
+checkout.) The rest of this step runs in that same directory — its `.wt.env`
+keeps the make targets pointed at the lane's own stack.
+
+1. **Resolve** hand-written hubs by hand, per the hub table
+   (`docs/parallel-dev.md` §3): `main.go` / `.env.sample` / `CLAUDE.md` = take
+   both; `.arb`s = take both key sets; `plan_tool_registry.go` = main's order +
+   tail append, never reorder; migrations = the lane's reserved number.
+
+2. **Conflicted generated files: take main's side unread.** Under
+   `git merge origin/main` on the lane branch, main is **`--theirs`**:
+
+   ```bash
+   git checkout --theirs -- src/packages/api/store \
+     src/packages/flutter-app/lib/l10n/app_localizations*.dart \
+     'src/packages/flutter-app/lib/models/*.g.dart'
+   ```
+
+   ⚠️ This is the **inverse** of the rebase spelling (`--ours`), which is what
+   this loop used to run and what §4 of the doc still explains for historical
+   reference. Getting it backwards silently ships main's *stale* generated code
+   into the lane. Verified empirically, both directions.
+
+3. `git add -A && git commit` to conclude the merge, then **regen LAST** —
+   sources settled first:
+   `make api-sqlc` · `make flutter-gen-l10n` · `make flutter-build-models`.
+   Commit the regen output.
 
 4. **Check locally**: `make api-fmt && make api-vet && make flutter-analyze`,
-   plus `make api-test-go` / `make flutter-test` for the sides the lane
-   touched. Verify any migration still carries its reserved number.
+   plus `make api-test-go` / `make flutter-test` for the sides the lane touched.
+   Verify any migration still carries its reserved number.
 
-5. **Push**: `git push --force-with-lease`. This is the ONE sanctioned
-   force-push in this repo: the integrator, after a rebase, on a lane branch
-   whose agent has stopped.
+5. **Push**: `git push`. Plain — a merge commit is a fast-forward on the lane
+   branch, so nothing needs forcing. There is no longer any sanctioned
+   force-push in this repo.
 
-6. **Wait green**: `gh pr checks <number> --watch`. (This rerun is also what
-   arms the duplicate-migration guard against anything merged since the
-   lane's last CI run.)
+6. **Wait green**: `gh pr checks <n> --watch`. This re-run is also what re-arms
+   both migration guards against everything merged since the lane's last run.
 
-7. **If red, classify before touching anything**:
-   - *Integration-caused* — hub resolution, cross-lane Go↔Dart contract
-     parity, codegen drift, l10n coverage, fmt/vet: **fix inline**, you
-     created it.
-   - *In-lane failure* — reproduces on the lane branch before the rebase, or
-     the fix would rewrite lane logic: **hand back** to the owning agent
-     (SendMessage in Mode A; the lane's terminal in Mode B) and integrate an
-     independent PR meanwhile.
+7. **Merge** as in 2a.3.
 
-8. **Merge**: `gh pr merge <number> --merge --delete-branch`.
+## 3. Deploys — start them, never queue behind them
 
-9. **Start the deploy, but do NOT block the queue on it**: every main merge
-   triggers build-push → a self-verifying prod deploy. Go straight to
-   rebasing the next PR — **do not wait for "Verify deployed release"**.
-   Brian's standing instruction: a multi-PR wave otherwise spends most of its
-   wall-clock idling on `gh run watch`, and the deploy is self-verifying with
-   its result still visible afterward.
+Every main merge triggers build-push → a self-verifying prod deploy. Go straight
+to the next PR — **do not wait for "Verify deployed release"**. Brian's standing
+instruction: a multi-PR wave otherwise spends most of its wall-clock idling on
+`gh run watch`, and the deploy is self-verifying with its result still visible
+afterward.
 
-   **The safety valve stays — it is just moved, not removed.** Check the
-   deploys you already started between merges (a non-blocking
-   `gh run list --branch main --limit 5` is enough), and the moment one
-   **fails**: stop the queue, fix forward on main (or revert), resume only
-   when prod is green. A broken deploy under a stacked queue is un-bisectable,
-   so not-blocking is a bet that deploys usually pass — never a licence to
-   leave a failure unnoticed.
+**The safety valve stays — it is just moved, not removed.** Check the deploys
+you already started between merges (a non-blocking
+`gh run list --branch main --limit 5` is enough), and the moment one **fails**:
+stop the queue, fix forward on main (or revert), resume only when prod is green.
+A broken deploy under a stacked queue is un-bisectable, so not-blocking is a bet
+that deploys usually pass — never a licence to leave a failure unnoticed.
 
-   **`cancelled` on a main run is normal here — do NOT treat it as a
-   failure.** Merging back-to-back is exactly what this step now encourages,
-   so main deploy runs queue up, and GitHub keeps only the newest *pending*
-   run in the concurrency group (`ci-${{ github.ref }}`, `cancel-in-progress`
-   is false for main — see `.github/workflows/ci.yml`). The superseded ones
-   are cancelled **before running a single job**, so nothing was interrupted
-   mid-deploy and nothing is lost: the surviving run builds the newest main,
-   which already contains every commit the cancelled ones would have shipped.
-   Tell the two apart by the jobs list, not the badge —
-   `gh run view <id> --json jobs --jq '.jobs|length'` returns `0` for a
-   superseded run and non-zero for one that actually ran and broke.
+**`cancelled` on a main run is normal here — do NOT treat it as a failure.**
+Merging back-to-back is exactly what this loop encourages, so main deploy runs
+queue up, and GitHub keeps only the newest *pending* run in the concurrency
+group (`ci-${{ github.ref }}`, `cancel-in-progress` is false for main — see
+`.github/workflows/ci.yml`). The superseded ones are cancelled **before running
+a single job**, so nothing was interrupted mid-deploy and nothing is lost: the
+surviving run builds the newest main, which already contains every commit the
+cancelled ones would have shipped. Tell the two apart by the jobs list, not the
+badge — `gh run view <id> --json jobs --jq '.jobs|length'` returns `0` for a
+superseded run and non-zero for one that actually ran and broke.
 
-   The consequence: **a wave is only verified when its LAST deploy succeeds.**
-   Intermediate `cancelled` runs prove nothing either way, so step 10's
-   accounting is now load-bearing rather than a formality.
+The consequence: **a wave is only verified when its LAST deploy succeeds.**
+Intermediate `cancelled` runs prove nothing either way, so step 6's accounting
+is load-bearing rather than a formality.
 
-10. **Next PR.** When the queue is empty: return to the main checkout,
-    `git checkout main && git pull`, then `make wt-rm NAME=<lane>` for each
-    merged lane (from the main checkout — it deletes the lane's worktree and
-    branch), and report the wave summary — PRs merged, and **the wave's final
-    deploy watched to a green finish** (`gh run watch <id> --exit-status`),
-    since that is the run that actually ships every merge in the wave.
-    Superseded `cancelled` runs are expected and need no action; a `failure`
-    at any point does. Confirm prod serves the new SHA — `/health` `release`
-    or `/app/version.json` — before declaring the wave done. This accounting
-    is what step 9's per-merge watch was traded for, so it is the one deploy
-    check that must not be skipped.
+## 4. When something is red, classify before touching anything
+
+- *Integration-caused* — hub resolution, cross-lane Go↔Dart contract parity,
+  codegen drift, l10n coverage, fmt/vet: **fix inline**, you created it.
+- *In-lane failure* — reproduces on the lane branch before integration, or the
+  fix would rewrite lane logic: **hand back** to the owning agent (SendMessage
+  in Mode A; the lane's terminal in Mode B) and integrate an independent PR
+  meanwhile.
+
+## 5. A red `main` after a clean merge — the trade this loop accepts
+
+Skipping the rebase means skipping a CI run against the current main, and
+skipping the local checks means cross-lane **semantic** drift is no longer
+caught before the merge. Lane A renames a Go field, lane B adds a Dart call
+site: no textual conflict, both PRs green, main goes red. (`docs/friction-log.md`
+— *"a clean rebase is not a correct one"* — is the recorded instance of this
+class. It was never a git-conflict problem, so the rebase was not what caught it
+either; the local analyzer run was.)
+
+What is deliberately kept vs traded:
+
+| Was caught by | Now caught by |
+|---|---|
+| Rebase CI re-run: duplicate / out-of-order migration | Step 2a.2 migration floor — local, seconds, because the failure is an outage not a red check |
+| Integrator local checks: cross-lane contract drift, codegen drift | `main`'s own CI/deploy → stops the queue → fix forward |
+| Force-push + rebase: tidy lane history | Nothing. No policy required it — `main` has no branch protection and already carries merge bubbles |
+
+Procedure when main goes red: **stop the queue and fix forward on main.** The
+merge is already in, so reverting is the wrong default unless the fix is not
+obvious. Resume when green.
+
+Escalation valve: if a PR looks stale *and* touches a risky surface,
+`gh run rerun <pr-run-id>` re-arms both migration guards against the current
+main without touching the branch. Safe on a **PR** run — never on a **main**
+run, which would redeploy an old SHA.
+
+## 6. Next PR, then close out
+
+When the queue is empty: `git checkout main && git pull`, then
+`make wt-rm NAME=<lane>` for each merged lane (from the main checkout — it
+deletes the lane's worktree and branch), and report the wave summary — PRs
+merged, and **the wave's final deploy watched to a green finish**
+(`gh run watch <id> --exit-status`), since that is the run that actually ships
+every merge in the wave. Superseded `cancelled` runs are expected and need no
+action; a `failure` at any point does. Confirm prod serves the new SHA —
+`/health` `release` or `/app/version.json` — before declaring the wave done.
+This accounting is what step 3's per-merge watch was traded for, so it is the
+one deploy check that must not be skipped.
 
 ## Notes
 
-- Lane agents never rebase or merge; if a lane branch moved after its agent
-  stopped, assume the integrator (you) moved it.
-- If two queued PRs turn out to collide semantically (not textually — e.g.
-  both changed the same behavior), pause and surface it to Brian rather than
-  picking a winner silently.
+- Lane agents never merge, rebase, or integrate; if a lane branch moved after
+  its agent stopped, assume the integrator (you) moved it.
+- If two queued PRs turn out to collide semantically (not textually — e.g. both
+  changed the same behavior), pause and surface it to Brian rather than picking
+  a winner silently.

--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -11,8 +11,9 @@ Take the working-tree changes through commit → push → PR → merge.
 
 - `ship` (default) — the full pipeline through merge. Solo, single-lane work.
 - `ship pr` — stop after step 5 (`gh pr create`). Report the PR URL and STOP:
-  do not merge, do not switch back to `main` (the integrator will rebase this
-  branch). Required for lane agents in a parallel wave (`docs/parallel-dev.md`).
+  do not merge, do not switch back to `main` (the integrator will integrate
+  this branch). Required for lane agents in a parallel wave
+  (`docs/parallel-dev.md`).
 - **Auto-detection**: if running inside a linked worktree
   (`git rev-parse --git-dir` differs from `git rev-parse --git-common-dir`),
   behave as `ship pr` even if no argument was given — worktree agents are wave
@@ -44,5 +45,5 @@ Take the working-tree changes through commit → push → PR → merge.
 
 ## Notes
 
-- Never force-push or amend commits that are already pushed. (Exception owned elsewhere: the integrator may `--force-with-lease` a lane branch after its agent has stopped — see `.claude/skills/integrate`.)
+- Never force-push or amend commits that are already pushed. No exceptions — the integrator resolves conflicts by merging `main` into the lane branch, which is a plain push (see `.claude/skills/integrate`).
 - If the merge is blocked (required checks, review requirements), report the blocker and stop — don't bypass with admin flags.

--- a/.claude/skills/wave/SKILL.md
+++ b/.claude/skills/wave/SKILL.md
@@ -21,8 +21,11 @@ No args in orchestrate intent → ask what to run.
    ≤1 lane touches `trip_detail_screen.dart`; ≤1 lane appends to
    `plan_tool_registry.go`; ARB key prefixes unique across the wave;
    ≤1 migration per lane with numbers reserved NOW
-   (`ls src/packages/api/migrations | tail -1` → next free, assigned in merge
-   order). 2–4 lanes total. If a constraint cannot be satisfied, propose a
+   (`ls src/packages/api/migrations | tail -1` → next free). Merge order is
+   PR-open order and is not knowable here, so the integrator merges
+   migration-carrying PRs in **ascending migration number** regardless — note
+   that in the table so a lane that opens its PR early does not imply an early
+   merge. 2–4 lanes total. If a constraint cannot be satisfied, propose a
    re-split or a serialization edge and say so in the table.
 
 3. **Write the Lanes section** into each spec's `tasks.md` (template:
@@ -49,8 +52,9 @@ No args in orchestrate intent → ask what to run.
    `docs/parallel-dev.md` §6). Collect PR URLs from completion reports.
 
 8. **Auto-integrate.** When EVERY lane has reported PR-open, run the
-   `integrate` skill with the lane table's merge order. No second approval —
-   the step-4 gate covered this.
+   `integrate` skill; it merges in PR-open order (the lane table's edges are
+   advisory — see `docs/parallel-dev.md` §6). No second approval — the step-4
+   gate covered this.
 
 9. **Close.** `make wt-rm NAME=<lane>` per merged lane (from the main
    checkout), then report the wave summary: PRs merged, deploys verified,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,11 +51,14 @@ a rule that must break gets written into the guideline doc in the same PR.
 Feature waves run as parallel **lanes**: one lane = one branch = one git
 worktree (`make wt-new NAME=…`, own dev stack on its own ports) = one PR. Lane
 agents STOP at PR-open (`ship pr` — never merge); one integrator session
-(`/integrate`) rebases, resolves hub files, regenerates generated code
-(`store/`, `lib/l10n/app_localizations*.dart`, `*.g.dart` are NEVER
-hand-merged — regen LAST), and merges serially. Deploys run in the background
-and never block the next merge; a red one stops the queue. Wave
-planning reserves goose migration numbers; at most one in-flight lane may touch
+(`/integrate`) merges them serially **in the order the PRs were opened** —
+checking each for conflicts with `main` first and merging straight away when
+there are none, otherwise merging `main` in, resolving hub files and
+regenerating generated code (`store/`, `lib/l10n/app_localizations*.dart`,
+`*.g.dart` are NEVER hand-merged — regen LAST) before it merges. Nothing is
+rebased or force-pushed. Deploys run in the background and never block the next
+merge; a red one stops the queue. Wave planning reserves goose migration
+numbers; at most one in-flight lane may touch
 `trip_detail_screen.dart` or append to `plan_tool_registry.go`. Full rules and
 runbooks: [`docs/parallel-dev.md`](docs/parallel-dev.md). Triggers: `/wave`
 (orchestrate a wave; also `status`/`abort`) and `/lane` (bootstrap one lane).

--- a/docs/friction-log.md
+++ b/docs/friction-log.md
@@ -5,6 +5,49 @@ build queue. Priority when picking work: **breakage > friction in features
 actually used > ideas that recur across ≥2 sessions**. Tag entries `[app]`
 (dogfooding the product) or `[dev]` (workflow/tooling). Newest first.
 
+## 2026-08-18 — /integrate charged every PR the conflict price
+
+- **[dev] Friction:** Brian — *"I think perhaps the /integrate skill has more
+  overhead than it needs."* The loop rebased **every** lane branch onto main,
+  resolved per conflicted commit, ran local checks, force-pushed, and waited out
+  a full CI re-run — ~10–20 min a PR — before merging. The hub table's entire
+  purpose is lanes that do not touch the same files, so most of that was being
+  paid for a conflict that did not exist. New shape: check
+  `git merge-tree --write-tree`, and on exit 0 just `gh pr merge`. Order is now
+  the order the PRs were opened, not the tasks.md dependency edges.
+- **[dev] The rebase was never what armed the migration guards.** The doc
+  claimed *"the rebase rerun is also what makes the duplicate-migration CI guard
+  bite"*. Reading `.github/workflows/ci.yml`: the duplicate guard runs on
+  `refs/pull/N/merge` — GitHub's ephemeral merge with the current main tip — and
+  the out-of-order guard fetches live `origin/main` at run time. Neither needs
+  the branch rebased; both need a **fresh run**. What a green badge actually
+  certifies is "true as of my last run", which is a different and much smaller
+  claim.
+- **[dev] So exactly one thing had to survive skipping the rebase.** A competing
+  migration merged since the PR's last run produces **no textual conflict**
+  (different filenames), so the conflict check waves it through, and the failure
+  is `goose` refusing at boot → crash-loop outage, not a red check. `/integrate`
+  now runs a local migration-floor check (`git ls-tree origin/main -- migrations/
+  | tail -1`) on any PR that adds one. Everything else a stale run can hide —
+  cross-lane Go↔Dart drift, codegen drift — is a red check, and is deliberately
+  traded to main's own CI: queue stops, fix goes forward on main.
+- **[dev] `--ours` and `--theirs` invert between rebase and merge**, and nothing
+  warns you. Under `git merge origin/main` on the lane branch, main is
+  `--theirs`; under `git rebase origin/main`, main is `--ours`. Both spellings
+  mean "take main's generated files unread"; the wrong one silently commits
+  main's *stale* codegen into the lane with no conflict marker left behind.
+  Verified both directions in a throwaway repo before writing either down.
+- **[dev] Nothing in the repo ever required the rebase.** `main` has no branch
+  protection at all (`gh api …/branches/main/protection` → 404): no required
+  checks, no up-to-date-branch rule, no linear history, and main already carries
+  merge bubbles from PRs merged without one. The force-push exception in
+  `ship`/`integrate` is gone with it — resolving by merge is a plain push.
+- **[dev] Two orderings still beat PR-open order**, both because the repair
+  costs more than the rule: a stacked PR waits for its base and is retargeted to
+  main first (this is how 00058 got burned), and migration-carrying PRs go in
+  ascending number, since a lower number landing after a higher one is refused
+  by CI and forces a renumber plus a re-run.
+
 ## 2026-08-15 — it planned the whole trip before anyone said yes
 
 - **[app] Friction:** Brian — *"when planning a trip, sometimes it pulls the list
@@ -1641,4 +1684,5 @@ Open gaps found while fixing "chat doesn't clearly indicate it's loading"
 - **[dev] Open follow-ups:** trim `Bash(gh pr *)` from
   `.claude/settings.local.json` (pre-approves `gh pr merge`, defeating the
   lane-agent stall); local dev DB is empty — reseed if anything mattered;
-  first real wave should exercise `/integrate` end to end.
+  first real wave should exercise the slimmed `/integrate` end to end (see
+  2026-08-18) — expect at least one PR to take the clean path.

--- a/docs/parallel-dev.md
+++ b/docs/parallel-dev.md
@@ -8,8 +8,10 @@ the process half.
 
 One feature wave = N **lanes**. One lane = one branch = one git worktree = one
 coding agent = one PR (or a short PR chain). Lane agents **stop at PR-open** —
-they never merge. One **integrator** session merges serially: rebase → resolve
-hub files → regenerate generated code → green CI → merge → next. The prod
+they never merge. One **integrator** session merges serially, in the order the
+PRs were opened: check for conflicts → merge if there are none → otherwise
+merge `main` in, resolve hub files, regenerate generated code, green CI → merge
+→ next. Nothing is rebased and nothing is force-pushed (§4, §6). The prod
 deploy each merge triggers runs in the background and **never blocks the next
 merge** (§6); it is checked as it lands, and a red one stops the queue. Brian
 approves the lane plan and steers; agents code.
@@ -21,9 +23,10 @@ Roles:
   (stop-at-PR-open mode), reports the PR URL, stops. Never merges, never
   rebases, never touches files outside its conflict manifest.
 - **Integrator** — owns `main`. Runs the `/integrate` loop
-  (`.claude/skills/integrate`). Only the integrator rebases, force-pushes
-  (`--force-with-lease`), and merges. It tracks deploys without serializing
-  the queue behind them, and accounts for every one in the wave summary.
+  (`.claude/skills/integrate`). Only the integrator merges, and only the
+  integrator pushes to a lane branch (to carry a conflict resolution). It
+  tracks deploys without serializing the queue behind them, and accounts for
+  every one in the wave summary.
 - **Brian** — wave-planning approval, lane steering, anything requiring
   product judgment.
 
@@ -119,40 +122,49 @@ to `main` before merging it**, and check `git merge-base --is-ancestor
 ## 4. Regen-not-merge doctrine
 
 `store/` (sqlc), `lib/l10n/app_localizations*.dart` (gen-l10n), and
-`lib/models/*.g.dart` (build_runner) are committed and CI-drift-checked. On a
-rebase that conflicts in generated files you **never hand-merge them**:
+`lib/models/*.g.dart` (build_runner) are committed and CI-drift-checked. When a
+PR conflicts with `main` in generated files you **never hand-merge them**:
 
-1. `git fetch origin && git rebase origin/main`
-2. In each conflicted commit, hand-resolve ONLY hand-written sources:
+1. In the lane's worktree (the branch is checked out there):
+   `git fetch origin && git merge origin/main`
+2. Hand-resolve ONLY hand-written sources — once, not once per commit:
    `query/*.sql`, `migrations/*.sql`, the `.arb`s (take both key sets),
    `lib/models/*.dart`, `main.go`, `.env.sample`, `plan_tool_registry.go`
    (main's order + your tail append).
 3. For conflicted **generated** files take main's side without reading the
-   diff — during a rebase `--ours` is the branch you're rebasing ONTO:
+   diff — in a merge, main is the side coming IN, so it is `--theirs`:
    ```bash
-   git checkout --ours -- src/packages/api/store \
+   git checkout --theirs -- src/packages/api/store \
      src/packages/flutter-app/lib/l10n/app_localizations*.dart \
      'src/packages/flutter-app/lib/models/*.g.dart'
-   git add -A && git rebase --continue
+   git add -A && git commit
    ```
-4. **After** the rebase completes — sources settled — regenerate everything:
+   ⚠️ This inverts if you ever rebase instead: **during a rebase `--ours` is
+   the branch you are rebasing ONTO**, i.e. main. Both spellings mean "take
+   main"; getting one backwards silently ships main's *stale* generated code
+   into the lane, and no conflict marker is left to notice.
+4. **After** the merge is committed — sources settled — regenerate everything:
    `make api-sqlc` · `make flutter-gen-l10n` · `make flutter-build-models`.
    The three are independent of each other, but all run after ALL hand
    resolution is done ("regen LAST").
 5. Commit the regen output, run
    `make api-fmt && make api-vet && make flutter-analyze` + targeted tests,
-   then `git push --force-with-lease`.
+   then `git push` — plain, no force. A merge commit fast-forwards the lane
+   branch, so there is nothing to force.
 
 ## 5. Wave sizing — 2–4 lanes, usually 3
 
 - `trip_detail_screen.dart` is in ~1 of 3 PRs: in a wave of k typical lanes,
   expected god-screen touchers ≈ 0.31k. Past 3–4 lanes you can't fill a wave
   that avoids it. (Splitting that screen is the single biggest future unlock.)
-- Integration is serial: rebase + regen + CI wait + merge is ~10–20 min per
-  PR. The prod deploy each merge triggers is queued and self-verifying, but
-  sits **off** the critical path (§6), so it no longer adds to the per-PR
-  cost — it only stops the queue if it goes red. Four lanes ≈ a 1 h
-  integrator tail; beyond that the parallel coding gain is eaten by the tail.
+- Integration is serial, but only a *conflicting* PR is expensive: a clean one
+  is a conflict check plus `gh pr merge` (seconds, without leaving the main
+  checkout), while merge + regen + CI wait + merge is the ~10–20 min tail a
+  conflicting one pays (§6). The prod deploy each merge triggers is queued and
+  self-verifying, but sits **off** the critical path (§6), so it never adds to
+  the per-PR cost — it only stops the queue if it goes red. The integrator tail
+  now scales with how many lanes actually collided, not with how many lanes
+  there were.
 - The ≤1-migration-per-lane and single-registry-lane rules cap schema- or
   agent-tool-heavy waves regardless.
 - Each Mode-B lane also runs a full 4-container stack (~1–2 GB peak during the
@@ -161,11 +173,32 @@ rebase that conflicts in generated files you **never hand-merge them**:
 ## 6. The integrator merge queue
 
 Summary (the operational skill is `.claude/skills/integrate` — run
-`/integrate`): merge in dependency order; one PR at a time; rebase (inside the
-lane's worktree — the branch is checked out there) → resolve per §3–4 →
-local checks → `--force-with-lease` → wait green (the rebase rerun
-is also what makes the duplicate-migration CI guard bite) → merge → **start
-the next PR immediately; do NOT wait for the deploy**.
+`/integrate`): one PR at a time, **in the order the PRs were opened**
+(`gh pr list --json createdAt`, ascending). Check for conflicts first —
+`git merge-tree --write-tree --name-only origin/main origin/<branch>`, exit 0 =
+clean. **Clean → merge it** (`gh pr merge --merge --delete-branch`): no rebase,
+no force-push, no worktree, no CI re-run. **Conflicts → merge `origin/main`
+into the lane branch** inside its worktree, resolve per §3–4, regen, local
+checks, plain `git push`, wait green, merge. Either way: **start the next PR
+immediately; do NOT wait for the deploy**.
+
+Two exceptions to PR-open order, both cheaper to obey than to repair: a
+**stacked PR waits for its base** and is retargeted to `main` first (§4a — this
+is how 00058 was burned), and **migration-carrying PRs go in ascending
+migration number** among themselves, since a lower number landing after a
+higher one is refused by CI and forces a renumber. The `tasks.md` dependency
+edges are advisory now — a sanity check on those two cases, not the sequencer.
+
+What skipping the rebase costs, and what is kept: both CI migration guards read
+the PR **merge ref** / live `origin/main` **at run time**, so they never needed
+a rebase — only a fresh *run*. A green badge is therefore only as fresh as the
+PR's last run. That matters for exactly one class: a competing migration merged
+since then produces no textual conflict (different filenames) and lands as a
+boot-time crash-loop (§4a), so `/integrate` keeps a local migration-floor check
+on every PR that adds one. Everything else a stale run could hide — cross-lane
+Go↔Dart contract drift, codegen drift — is a red check, and is now caught by
+`main`'s own CI instead of the integrator's local run: the queue stops and the
+fix goes forward on main.
 
 The prod deploy each merge triggers is self-verifying and runs off the
 critical path. Check the ones already in flight between merges, and **the
@@ -190,7 +223,7 @@ Who fixes a red check: **the integrator fixes anything integration created**
 (hub resolution, cross-lane contract parity, codegen drift, fmt);
 **lane agents fix anything already wrong inside their lane** (hand back via
 SendMessage in Mode A, the lane's terminal in Mode B). Tie-breaker: if the
-failure reproduces on the lane branch *before* the rebase, it's the lane's.
+failure reproduces on the lane branch *before* integration, it's the lane's.
 
 ## 7. Wave runbook
 
@@ -213,7 +246,7 @@ failure reproduces on the lane branch *before* the rebase, it's the lane's.
    not touch files outside your manifest."*
 4. **Monitor** — TaskList / TaskOutput / SendMessage (Mode A) or the
    terminals (Mode B). Collect PR URLs.
-5. **Integrate** — `/integrate`, in the tasks.md merge order.
+5. **Integrate** — `/integrate`, in PR-open order (§6).
 6. **Close** — `make wt-rm` per merged lane, confirm prod SHA + health, check
    off the spec's acceptance criteria.
 

--- a/scripts/worktree.sh
+++ b/scripts/worktree.sh
@@ -119,7 +119,7 @@ EOF
   # project — warn loudly rather than let `make docker-dev` collide.
   if ! grep -q 'GTT_PROJECT' "$wt/dockerize/development/docker-compose.yml" 2>/dev/null; then
     echo "WARNING: this worktree's dev compose is NOT parameterized (branch predates" >&2
-    echo "         parallel lanes). Do not run docker targets here — rebase onto main first." >&2
+    echo "         parallel lanes). Do not run docker targets here — merge main in first." >&2
   fi
 
   cat <<EOF

--- a/specs/_template/tasks.md
+++ b/specs/_template/tasks.md
@@ -48,6 +48,7 @@ are free). Constraints to check before fan-out: ≤1 lane touches
 `trip_detail_screen.dart`; ≤1 lane appends to `plan_tool_registry.go`; ARB
 prefixes unique across the wave; ≤1 migration per lane.
 
-**Merge order** — dependency edges only (e.g. A → B); unordered lanes merge in
-any order. Lane agents stop at PR-open (`ship pr`); the integrator merges
-(`/integrate`).
+**Merge order** — the integrator merges in **PR-open order**; edges listed
+here (e.g. A → B) are advisory. Two things do override it: a stacked PR waits
+for its base, and migration-carrying PRs go in ascending migration number.
+Lane agents stop at PR-open (`ship pr`); the integrator merges (`/integrate`).


### PR DESCRIPTION
Brian: *"I think perhaps the /integrate skill has more overhead than it needs. Instead of always rebasing, let's check for merge conflicts, resolve if yes, if not merge. And let's merge in the order that the PRs were opened."*

`/integrate` rebased **every** lane branch onto main — resolve per conflicted commit, local checks, `--force-with-lease`, full CI re-run — before merging: ~10–20 min a PR. The hub table's whole purpose is lanes that don't touch the same files, so most of that was paid for a conflict that didn't exist.

## The new loop

1. **Queue** — `gh pr list --json createdAt`, ascending. PR-open order.
2. **Conflict check** — `git merge-tree --write-tree --name-only origin/main origin/<branch>`. One command, no checkout.
3. **Exit 0 → merge.** Checks green + `gh pr merge --merge --delete-branch`. No rebase, no force-push, never enters the worktree, no CI re-run.
4. **Exit 1 → merge `origin/main` into the lane branch** in its worktree, resolve **once** (not once per commit), regen last, plain `git push`, wait green, merge.

Two orderings still override PR-open order, because the repair costs more than the rule: a stacked PR waits for its base (how 00058 got burned), and migration-carrying PRs go in ascending number.

## Three things verified rather than assumed

- **`main` has no branch protection** (`gh api …/branches/main/protection` → 404): no required checks, no up-to-date-branch rule, no linear history — and main already carries merge bubbles from un-rebased PRs. Nothing ever required the rebase, so the repo's one sanctioned force-push goes with it.
- **The rebase was never what armed the migration guards.** The doc claimed *"the rebase rerun is also what makes the duplicate-migration CI guard bite"*. Reading `ci.yml`: the duplicate guard runs on `refs/pull/N/merge` (GitHub's ephemeral merge with the current main tip) and the out-of-order guard fetches live `origin/main` at run time. Both need a fresh **run**, never a rebase.
- **`--ours` and `--theirs` invert between rebase and merge**, and nothing warns you. Under `git merge origin/main` on the lane branch, main is `--theirs`; under rebase it's `--ours`. Confirmed both directions in a throwaway repo before writing either down — backwards, it commits main's *stale* codegen with no conflict marker left behind.

## What survives, and what is traded

One guard had to survive skipping the rebase: a competing migration merged since the PR's last run produces **no textual conflict** (different filenames), so the check waves it through, and the failure is `goose` refusing at boot → crash-loop outage, not a red check. So a PR that adds a migration gets a local floor check against `origin/main`.

Everything else a stale green badge can hide — cross-lane Go↔Dart contract drift, codegen drift — is deliberately traded to main's own CI: the queue stops and the fix goes forward on main. That trade is a table in the skill, not a footnote.

## Propagated

`docs/parallel-dev.md` §1/§4/§5/§6/§7 · `CLAUDE.md` · `ship` (the force-push exception is gone, so "never force-push" is now unconditional) · `wave` · `specs/_template/tasks.md` · one `worktree.sh` warning string · a dated friction-log entry. Sweep for stale `rebase`/`force-with-lease` mentions returns only intentional survivors.

## Verification

Docs and skills only — no Go or Dart touched. Every command the new skill issues was dry-run against this repo: the queue query, both `merge-tree` outcomes (0 clean / 1 with paths), `gh pr diff --name-only | grep migrations/`, and `git ls-tree origin/main -- migrations/ | tail -1` (→ `00072`, the current floor). `bash -n scripts/worktree.sh` passes. Real proof is the next wave running `/integrate` end to end — expect at least one PR to take the clean path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
