### PR TITLE
Trip detail wave 2: header block + tab-bar seam redesign

### DIFF
--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -641,11 +641,16 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
   // ([_dateChipWidth]), so calendar icons, range starts, and nights suffixes
   // form columns across rows.
 
-  // Itinerary/Bookings/Budget tab row (44 — real touch targets for the view
-  // tabs)
-  // + bottom padding (8) + breathing room (4); the header is one
-  // fixed-height row whether or not the trip has items.
+  // Itinerary/Bookings/Budget tab row + the hairline baseline it rests on.
+  // The header is one fixed-height row whether or not the trip has items, and
+  // its total is what the Today-scroll chrome math reads — so the two parts
+  // are split here rather than padded apart: the row fills everything above
+  // the rule, which is what puts the selected tab's underline ON the rule
+  // instead of a dozen pixels above it.
   static const double _listHeaderHeight = 56;
+  static const double _headerTabBaseline = 1;
+  static const double _headerTabRowHeight =
+      _listHeaderHeight - _headerTabBaseline;
 
   /// Combined height of the chrome pinned above the itinerary slivers: the
   /// map header (when it renders AND is pinned — on phones the map scrolls
@@ -2223,6 +2228,14 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
   /// hugs the label's width while filling the header row's height for a real
   /// touch target. [trailing] renders inside the underlined region so the
   /// underline spans label + pill as one tab.
+  ///
+  /// The underline sits on the tab's BOTTOM edge, and the tab fills the pinned
+  /// row's full height — so it lands on the row's own hairline baseline (see
+  /// the tab-row sliver below) the way the TripAdvisor and Vrbo references
+  /// draw it. It used to hug the label inside a vertically-centred box, which
+  /// left a 2px teal dash floating a dozen pixels above nothing and made the
+  /// whole row read as underlined text on the void rather than as the top edge
+  /// of the content below.
   Widget _headerTab(ThemeData theme,
       {required String label,
       required bool selected,
@@ -2234,21 +2247,19 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
       child: InkWell(
         borderRadius: AppRadius.smAll,
         onTap: selected ? null : onTap,
-        child: Center(
-          widthFactor: 1,
-          child: Container(
-            padding: const EdgeInsets.fromLTRB(
-                AppSpacing.xs, 0, AppSpacing.xs, 4),
-            decoration: BoxDecoration(
-              border: Border(
-                bottom: BorderSide(
-                  width: 2,
-                  color: selected
-                      ? theme.colorScheme.primary
-                      : Colors.transparent,
-                ),
+        child: Container(
+          padding: const EdgeInsets.symmetric(horizontal: AppSpacing.xs),
+          decoration: BoxDecoration(
+            border: Border(
+              bottom: BorderSide(
+                width: 2,
+                color:
+                    selected ? theme.colorScheme.primary : Colors.transparent,
               ),
             ),
+          ),
+          child: Center(
+            widthFactor: 1,
             child: Row(
               mainAxisSize: MainAxisSize.min,
               children: [
@@ -2304,14 +2315,24 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
     // in English. Scale-down only engages when the whole cluster genuinely
     // can't fit (tiny windows, giant accessibility text) and shrinks the
     // trio uniformly instead of eating one label. The inner SizedBox keeps
-    // the 44px tap-target height the pinned header row provides.
+    // the tap-target height the pinned header row provides.
+    //
+    // bottomLeft, not centerLeft: a scaled-down cluster is SHORTER than the
+    // row, and the selected tab's underline has to keep landing on the row's
+    // hairline baseline. Centring it would float the underline back off the
+    // rule at exactly the widths that trigger scaling — a 390px phone in
+    // Spanish — which is the register this redesign is fixing. Identical to
+    // centerLeft whenever nothing scales, since the child then fills the box.
     return FittedBox(
       fit: BoxFit.scaleDown,
-      alignment: Alignment.centerLeft,
+      alignment: Alignment.bottomLeft,
       child: SizedBox(
-        height: 44,
+        height: _headerTabRowHeight,
         child: Row(
           mainAxisSize: MainAxisSize.min,
+          // Stretch, so each tab's underline lands on the row's own baseline
+          // instead of hugging its label. See _headerTab.
+          crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
             _headerTab(
               theme,
@@ -3548,20 +3569,44 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
                           // button stay reachable while scrolling. One
                           // fixed-height row keeps the pinned chrome (and
                           // the Today scroll math) constant.
+                          //
+                          // It closes on a content-width hairline, and that
+                          // rule is the whole point: it is the bottom edge of
+                          // the pinned chrome and the top edge of the list
+                          // below, so the tabs read as the head of a surface
+                          // rather than as three words floating between a map
+                          // card and a city header. The selected tab's own
+                          // underline lands ON it (see _headerTab), which is
+                          // how the TripAdvisor and Vrbo trip pages draw this
+                          // exact seam. Content-width, not edge-to-edge: the
+                          // page owns its margins, like every other band here.
                           SliverPersistentHeader(
                             pinned: true,
                             delegate: _PinnedHeaderDelegate(
                               height: _listHeaderHeight,
                               backgroundColor: theme.scaffoldBackgroundColor,
-                              padding: EdgeInsets.fromLTRB(gutter, 0, gutter, 8),
-                              // Align fills the header's full extent so the child's
-                              // measured height matches maxExtent (a min-sized
-                              // Column would be shorter, yielding an invalid sliver
-                              // geometry: layoutExtent > paintExtent).
+                              padding:
+                                  EdgeInsets.symmetric(horizontal: gutter),
+                              // Align fills the header's full extent so the
+                              // child's measured height matches maxExtent (a
+                              // min-sized box would be shorter, yielding an
+                              // invalid sliver geometry: layoutExtent >
+                              // paintExtent); the box inside states that
+                              // height outright and spends its last pixel on
+                              // the rule.
                               child: Align(
                                 alignment: Alignment.topLeft,
-                                child: SizedBox(
-                                  height: 44,
+                                child: Container(
+                                  height: _listHeaderHeight,
+                                  decoration: BoxDecoration(
+                                    border: Border(
+                                      bottom: BorderSide(
+                                        width: _headerTabBaseline,
+                                        color:
+                                            theme.colorScheme.outlineVariant,
+                                      ),
+                                    ),
+                                  ),
                                   child: Row(
                                     children: [
                                       Expanded(
@@ -3605,11 +3650,13 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
                                       // most. Do not copy the add CTAs'
                                       // gates below.
                                       //
-                                      // Compact density is load-bearing: the
-                                      // row is a hard 44px SizedBox feeding
-                                      // _listHeaderHeight (56) and the
-                                      // Today-scroll chrome math, and a
-                                      // default-density IconButton is 48.
+                                      // Compact density: the row is a fixed
+                                      // _headerTabRowHeight box inside
+                                      // _listHeaderHeight (56), which the
+                                      // Today-scroll chrome math reads — so
+                                      // nothing in here may size the row.
+                                      // Compact keeps this and its siblings
+                                      // optically level with the tab labels.
                                       if (foldShown)
                                         IconButton(
                                           onPressed: () =>

--- a/src/packages/flutter-app/lib/widgets/trip_detail/map_band.dart
+++ b/src/packages/flutter-app/lib/widgets/trip_detail/map_band.dart
@@ -19,7 +19,17 @@ import '../trip_map.dart';
 
 /// Wide pinned-header extent: top gap + map + bottom gap (the phone layout's
 /// preview is [mapBandHeightNarrow] and scrolls away instead).
-const double mapBandHeaderHeight = 12 + 340 + 12;
+///
+/// 280, down from 340 (wave 2, header/shell lane): this band does not scroll
+/// away — it and the tab row below it are PERMANENT chrome, so every pixel
+/// here is a pixel the itinerary never gets back. At 340 the pinned stack came
+/// to 420px and a 1000px window opened on the header, the map, the tab row and
+/// exactly one city heading, with the first day below the fold on the page
+/// whose job is the days. 280 keeps the card comfortably cinematic at the
+/// 900px content cap (~3.2:1) and leaves the map lane's own composition
+/// untouched — its chip strip insets 8 from the top and its control cluster 8
+/// from the bottom, so both still clear each other by a wide margin.
+const double mapBandHeaderHeight = 12 + 280 + 12;
 
 /// Map card height on phones, where the map scrolls away instead of
 /// pinning (a preview — the full-screen map is one tap away).

--- a/src/packages/flutter-app/lib/widgets/trip_detail/trip_header_card.dart
+++ b/src/packages/flutter-app/lib/widgets/trip_detail/trip_header_card.dart
@@ -93,7 +93,14 @@ class _TripHeaderCardState extends ConsumerState<TripHeaderCard> {
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Row(
-          crossAxisAlignment: CrossAxisAlignment.start,
+          // Centered, not top-aligned: the pencil's tap target is taller than
+          // the title line, and a start-aligned row parks the title at the top
+          // of that box — so the "8px" gap below rendered as ~30px and the
+          // name floated away from the dates it belongs to (the TripAdvisor
+          // reference stacks title and meta as one block). Centering spends
+          // the button's slack symmetrically and lets the gap below be the
+          // real one.
+          crossAxisAlignment: CrossAxisAlignment.center,
           children: [
             Expanded(
               child: Text(
@@ -114,11 +121,14 @@ class _TripHeaderCardState extends ConsumerState<TripHeaderCard> {
               IconButton(
                 icon: const Icon(Icons.edit, size: 20),
                 tooltip: l10n.tripEditDetails,
+                // Compact (40px, the pinned tab row's density) so the chrome
+                // affordance stops setting the identity block's line height.
+                visualDensity: VisualDensity.compact,
                 onPressed: widget.isOffline ? null : widget.onEditDetails,
               ),
           ],
         ),
-        const SizedBox(height: 8),
+        const SizedBox(height: AppSpacing.sm),
         Wrap(
           spacing: 8,
           runSpacing: 8,
@@ -157,16 +167,24 @@ class _TripHeaderCardState extends ConsumerState<TripHeaderCard> {
             // collaborators keep their spec-mandated entry point
             // (specs/collaborator-refine); the per-city/day sparkles and the
             // chat FAB are unchanged. On narrow this moves to the app bar.
+            //
+            // An ActionChip, not a tonal FilledButton — this is the entry that
+            // finally makes the demotion true. As a filled button it was the
+            // loudest thing in the top 200px and it rhymed exactly with the
+            // Next Step card's own tonal CTA ~130px below ("Refine with AI"
+            // over "Find lodging"), so the header opened with two equal-weight
+            // teal buttons asking for the same kind of attention. The header
+            // now carries exactly ONE filled action — the next step's — and
+            // refine reads as what the comment above always claimed: a peer of
+            // the dates chip. The brand stays, at chip-and-pin scale, in the
+            // sparkle.
             if (trip.canEdit && !widget.narrow)
-              FilledButton.tonalIcon(
-                // Chat/refine needs the network — disabled while offline.
-                onPressed: widget.isOffline
-                    ? null
-                    : widget.onRefine,
-                style: FilledButton.styleFrom(
-                    visualDensity: VisualDensity.compact),
-                icon: const Icon(Icons.auto_awesome, size: 16),
+              ActionChip(
+                avatar: Icon(Icons.auto_awesome,
+                    size: 16, color: theme.colorScheme.primary),
                 label: Text(l10n.tripRefineWithAI),
+                // Chat/refine needs the network — disabled while offline.
+                onPressed: widget.isOffline ? null : widget.onRefine,
               ),
           ],
         ),
@@ -278,6 +296,23 @@ class _TripHeaderCardState extends ConsumerState<TripHeaderCard> {
     );
   }
 
+  /// The saved-conversation row, rendered as the Next Step card's quiet
+  /// sequel rather than as a second, unrelated card.
+  ///
+  /// It used to be an elevated Material [Card] sitting `AppSpacing.md` below a
+  /// flat tinted panel: two boxes in two different depth registers, doing one
+  /// job each — "what to do next" and "where you left off" — and reading as
+  /// two unrelated surfaces stacked on the page. They are now one sequence:
+  /// same corner radius, the same 24px leading-icon column and `AppSpacing.md`
+  /// icon gutter as [NextStepCard], and only `AppSpacing.sm` between them, so
+  /// the pair scans as one plan block whose second line is quieter than its
+  /// first. Flat, not elevated — the post-#494 doctrine, and a shadow here
+  /// would put the SECONDARY entry above the primary one in depth.
+  ///
+  /// Deliberately NOT merged into the tinted panel itself: [NextStepCard]
+  /// paints a fixed light `brandTint`, so a shared field would have to be that
+  /// same light tint and dark mode would gain a light block twice the size.
+  /// Sequence, not fusion.
   Widget _continueChatRow(ThemeData theme, AppLocalizations l10n) {
     final trip = widget.trip;
     final chat = trip.refineChat;
@@ -285,54 +320,85 @@ class _TripHeaderCardState extends ConsumerState<TripHeaderCard> {
       return const SizedBox.shrink();
     }
     final updated = DateTime.tryParse(chat.updatedAt);
-    return Padding(
-      padding: const EdgeInsets.only(top: AppSpacing.md),
-      child: Card(
-        margin: EdgeInsets.zero,
-        child: ListTile(
-          leading: const Icon(Icons.forum_outlined),
-          title: Text(l10n.tripContinueChat,
-              style: theme.textTheme.titleSmall
-                  ?.copyWith(fontWeight: FontWeight.w600)),
-          subtitle: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
+    // relativeTime already exists (offline_banner.dart) — reuse it rather than
+    // growing a second "how long ago" rule.
+    final meta = updated == null
+        ? l10n.tripContinueChatMeta(chat.messageCount, '')
+        : l10n.tripContinueChatMeta(
+            chat.messageCount, relativeTime(l10n, updated));
+    final mutedStyle = theme.textTheme.bodySmall
+        ?.copyWith(color: theme.colorScheme.onSurfaceVariant);
+    return Container(
+      // Addressable the way NextStepCard's own ValueKey is: the screen carries
+      // several PopupMenuButton<String>s, and scoping to this row's structure
+      // is what broke when the row stopped being a ListTile.
+      key: const ValueKey('continue-chat-row'),
+      margin: const EdgeInsets.only(top: AppSpacing.sm),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.surfaceContainerHigh,
+        borderRadius: AppRadius.mdAll,
+      ),
+      child: InkWell(
+        borderRadius: AppRadius.mdAll,
+        onTap: () => widget.onOpenChat(),
+        child: Padding(
+          // Left/top/bottom match NextStepCard's uniform lg inset; the trailing
+          // side is tightened to sm because the menu button carries its own.
+          padding: const EdgeInsets.fromLTRB(
+              AppSpacing.lg, AppSpacing.md, AppSpacing.sm, AppSpacing.md),
+          child: Row(
             children: [
-              if (chat.preview.isNotEmpty)
-                Text(chat.preview, maxLines: 2, overflow: TextOverflow.ellipsis),
-              Padding(
-                padding: const EdgeInsets.only(top: AppSpacing.xs),
-                child: Text(
-                  // relativeTime already exists (offline_banner.dart) — reuse
-                  // it rather than growing a second "how long ago" rule.
-                  updated == null
-                      ? l10n.tripContinueChatMeta(chat.messageCount, '')
-                      : l10n.tripContinueChatMeta(
-                          chat.messageCount, relativeTime(l10n, updated)),
-                  style: theme.textTheme.bodySmall
-                      ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+              Icon(Icons.forum_outlined,
+                  size: 24, color: theme.colorScheme.onSurfaceVariant),
+              const SizedBox(width: AppSpacing.md),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    // Title and meta share a line via a Wrap: on a phone (or in
+                    // Spanish, where both strings are longer) the counter drops
+                    // to its own line instead of ellipsizing the label the
+                    // tests — and the traveler — tap.
+                    Wrap(
+                      spacing: AppSpacing.sm,
+                      crossAxisAlignment: WrapCrossAlignment.center,
+                      children: [
+                        Text(l10n.tripContinueChat,
+                            style: theme.textTheme.titleSmall
+                                ?.copyWith(fontWeight: FontWeight.w600)),
+                        Text(meta, style: mutedStyle),
+                      ],
+                    ),
+                    if (chat.preview.isNotEmpty) ...[
+                      const SizedBox(height: AppSpacing.xs),
+                      Text(chat.preview,
+                          maxLines: 2,
+                          overflow: TextOverflow.ellipsis,
+                          style: mutedStyle),
+                    ],
+                  ],
                 ),
+              ),
+              // A menu, not a bare icon: this sits a thumb's width from the
+              // row's own onTap, which OPENS the conversation, and discarding
+              // one must never be the near miss of resuming it. It is also the
+              // only way to be rid of a saved chat without first opening it and
+              // waiting out a full restore just to throw the transcript away.
+              PopupMenuButton<String>(
+                onSelected: (_) => widget.onNewChat(),
+                itemBuilder: (context) => [
+                  PopupMenuItem(
+                    value: 'clear',
+                    child: ListTile(
+                      leading: const Icon(Icons.delete_outline),
+                      title: Text(l10n.refineClearChat),
+                      contentPadding: EdgeInsets.zero,
+                    ),
+                  ),
+                ],
               ),
             ],
           ),
-          // A menu, not a bare icon: this sits a thumb's width from the row's
-          // own onTap, which OPENS the conversation, and discarding one must
-          // never be the near miss of resuming it. It is also the only way to
-          // be rid of a saved chat without first opening it and waiting out a
-          // full restore just to throw the transcript away.
-          trailing: PopupMenuButton<String>(
-            onSelected: (_) => widget.onNewChat(),
-            itemBuilder: (context) => [
-              PopupMenuItem(
-                value: 'clear',
-                child: ListTile(
-                  leading: const Icon(Icons.delete_outline),
-                  title: Text(l10n.refineClearChat),
-                  contentPadding: EdgeInsets.zero,
-                ),
-              ),
-            ],
-          ),
-          onTap: () => widget.onOpenChat(),
         ),
       ),
     );

--- a/src/packages/flutter-app/test/trip_detail_all_expanded_headers_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_all_expanded_headers_test.dart
@@ -9,6 +9,7 @@ import 'package:travel_route_planner/services/api_client.dart';
 import 'package:travel_route_planner/services/trips_api_service.dart';
 import 'package:travel_route_planner/providers/trips_provider.dart';
 import 'package:travel_route_planner/screens/trip_detail_screen.dart';
+import 'package:travel_route_planner/widgets/trip_detail/map_band.dart';
 import 'package:travel_route_planner/widgets/trip_map.dart';
 
 import 'support/city_groups.dart';
@@ -22,8 +23,8 @@ import 'support/l10n_test_app.dart';
 //   * while scrolling, exactly ONE city header obstructs at a time: each
 //     group's containing MultiSliver pushes its own header off at the
 //     group's end, so consecutive headers hand off edge-to-edge and the
-//     pinned slot (viewport top + 420: the 364px map band + 56px tab row)
-//     never accumulates obstruction as more groups pin and unpin;
+//     pinned slot ([_pinnedSlot]: the map band plus the tab row) never
+//     accumulates obstruction as more groups pin and unpin;
 //   * header taps are pure list toggles — the map-side assertions live in
 //     trip_detail_leg_focus_test.dart; here they only pin down that N
 //     groups collapse and re-expand independently;
@@ -150,10 +151,22 @@ ScrollPosition _position(WidgetTester tester) => tester
 double _viewportTop(WidgetTester tester) =>
     tester.getBottomLeft(find.byType(AppBar)).dy;
 
+/// The screen's own pinned tab-row extent (`_listHeaderHeight`, private to
+/// the screen). Restated, not derived — but paired with [mapBandHeaderHeight]
+/// below so the half of this sum that DOES move with a redesign is read from
+/// its source. It was a bare `420` until the wave-2 header lane retuned the
+/// band, which failed these two tests by exactly the 60px it removed.
+const double _tabRowHeight = 56;
+
+/// Where a pinned city header comes to rest: below the map band and the tab
+/// row, in viewport coordinates.
+double _pinnedSlot(WidgetTester tester) =>
+    _viewportTop(tester) + mapBandHeaderHeight + _tabRowHeight;
+
 void main() {
   testWidgets('exactly one city header pins; the next city pushes it off',
       (tester) async {
-    // Tall surface: the 364px pinned map band pushes deep-group geometry
+    // Tall surface: the pinned map band pushes deep-group geometry
     // below an 800px fold. Berlin's six days keep enough trailing extent
     // (item tiles are ~58px) that a mid-group-3 offset stays reachable on
     // the ~1724px content viewport.
@@ -161,7 +174,7 @@ void main() {
     await _pump(tester, _trip(perDay: 6, berlinDays: 6));
 
     final position = _position(tester);
-    final slot = _viewportTop(tester) + 420; // 364 map band + 56 tab row
+    final slot = _pinnedSlot(tester);
     final headerH = tester.getRect(_headerMaterialOf('Paris')).height;
 
     // Deep inside Rome's body: Rome's header has pinned.
@@ -324,7 +337,7 @@ void main() {
             '(overshoot-then-snap-back reversal); from $start: $samples');
 
     // And it lands exactly: city 1's header rests in the pinned slot.
-    final slot = _viewportTop(tester) + 420;
+    final slot = _pinnedSlot(tester);
     expect((_headerTop(tester, 'Paris') - slot).abs(), lessThanOrEqualTo(2),
         reason: 'Paris header should rest below map band + tab row');
     // The navigation was list-only: no focus write, camera untouched, the

--- a/src/packages/flutter-app/test/trip_detail_leg_focus_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_leg_focus_test.dart
@@ -9,6 +9,7 @@ import 'package:travel_route_planner/services/trips_api_service.dart';
 import 'package:travel_route_planner/providers/trips_provider.dart';
 import 'package:travel_route_planner/screens/trip_detail_screen.dart';
 import 'package:travel_route_planner/widgets/map_leg_chips.dart';
+import 'package:travel_route_planner/widgets/trip_detail/map_band.dart';
 import 'package:travel_route_planner/widgets/trip_map.dart';
 
 import 'support/chip_finders.dart';
@@ -128,11 +129,25 @@ void _useSurface(WidgetTester tester, Size size) {
   addTearDown(tester.view.reset);
 }
 
+/// The screen's own pinned tab-row extent (`_listHeaderHeight`, private to
+/// the screen); [mapBandHeaderHeight] is read from its source so a band
+/// retune can't silently invalidate this math again. These three assertions
+/// carried a bare `420` until the wave-2 header lane shortened the band.
+const double _tabRowHeight = 56;
+
+/// Where a city header comes to rest: below the pinned map band and tab row,
+/// measured from the viewport top (the app bar's bottom — the scroll math
+/// lives in viewport coordinates).
+double _pinnedSlot(WidgetTester tester) =>
+    tester.getBottomLeft(find.byType(AppBar)).dy +
+    mapBandHeaderHeight +
+    _tabRowHeight;
+
 void main() {
   testWidgets(
       'header taps are pure list toggles: the map never moves, focused '
       'or not', (tester) async {
-    // Tall surface: with the 364px map band pinned, expanded sections push
+    // Tall surface: with the map band pinned, expanded sections push
     // later headers below an 800px fold and header taps would miss.
     _useSurface(tester, const Size(1200, 2200));
     await _pump(tester, _threeCityTrip());
@@ -176,18 +191,16 @@ void main() {
     // The group's items are reachable (expanded — the landing default; the
     // chip tap re-opens a manually collapsed group)…
     expect(find.text('Roman Forum 0'), findsOneWidget);
-    // …and its header rests right below the pinned chrome: the 364px map
-    // band (12 + 340 + 12) + the 56px itinerary tab row = 420, measured
-    // from the viewport top (the app bar's bottom — the scroll math lives
-    // in viewport coordinates). The one correction pass tolerates ±2.
-    final viewportTop = tester.getBottomLeft(find.byType(AppBar)).dy;
+    // …and its header rests right below the pinned chrome (see [_pinnedSlot]).
+    // The one correction pass tolerates ±2.
+    final slot = _pinnedSlot(tester);
     final headerTop = tester
         .getTopLeft(find
             .ancestor(
                 of: cityHeaderLabel('Rome'), matching: find.byType(Material))
             .first)
         .dy;
-    expect((headerTop - (viewportTop + 420)).abs(), lessThanOrEqualTo(2),
+    expect((headerTop - slot).abs(), lessThanOrEqualTo(2),
         reason: 'Rome header should rest below map band + tab row');
   });
 
@@ -214,7 +227,8 @@ void main() {
     final start = position.pixels;
 
     // Tap Paris WITHOUT settling, then sample the scroll frame by frame:
-    // double-subtracting the pinned chrome animated ~420px past the target
+    // double-subtracting the pinned chrome animated a full chrome height
+    // past the target
     // and let the correction pass snap back down — a direction reversal
     // mid-gesture.
     await tester.tap(find.descendant(
@@ -240,14 +254,14 @@ void main() {
             '(up-then-down jank); from $start: $samples');
 
     // And it still lands exactly: Paris rests below the pinned chrome.
-    final viewportTop = tester.getBottomLeft(find.byType(AppBar)).dy;
+    final slot = _pinnedSlot(tester);
     final headerTop = tester
         .getTopLeft(find
             .ancestor(
                 of: cityHeaderLabel('Paris'), matching: find.byType(Material))
             .first)
         .dy;
-    expect((headerTop - (viewportTop + 420)).abs(), lessThanOrEqualTo(2),
+    expect((headerTop - slot).abs(), lessThanOrEqualTo(2),
         reason: 'Paris header should rest below map band + tab row');
   });
 
@@ -357,16 +371,16 @@ void main() {
 
     expect(find.text('Roman Forum 0'), findsOneWidget,
         reason: 'the region tap re-opens its collapsed group');
-    // Same rest math as a chip tap: map band + tab row = 420, ±2 for the
+    // Same rest math as a chip tap: map band + tab row, ±2 for the
     // one correction pass.
-    final viewportTop = tester.getBottomLeft(find.byType(AppBar)).dy;
+    final slot = _pinnedSlot(tester);
     final headerTop = tester
         .getTopLeft(find
             .ancestor(
                 of: cityHeaderLabel('Rome'), matching: find.byType(Material))
             .first)
         .dy;
-    expect((headerTop - (viewportTop + 420)).abs(), lessThanOrEqualTo(2),
+    expect((headerTop - slot).abs(), lessThanOrEqualTo(2),
         reason: 'Rome header should rest below map band + tab row');
     final position = tester
         .state<ScrollableState>(find

--- a/src/packages/flutter-app/test/trip_detail_offline_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_offline_test.dart
@@ -66,6 +66,17 @@ T _labeledButton<T extends ButtonStyleButton>(
       matching: find.bySubtype<T>(),
     ));
 
+/// Same idea for the header's Refine entry, which is a chip rather than a
+/// button since the wave-2 header redesign (it is a peer of the dates chip
+/// now, so the header carries exactly one filled action — the Next Step
+/// card's). ActionChip is not a ButtonStyleButton, so it needs its own finder;
+/// the assertion it feeds — onPressed nulled while offline — is unchanged.
+ActionChip _labeledChip(WidgetTester tester, String label) =>
+    tester.widget<ActionChip>(find.ancestor(
+      of: find.text(label),
+      matching: find.byType(ActionChip),
+    ));
+
 /// Crosses the RefreshIndicator's arm threshold to fire a quiet _load.
 Future<void> _triggerRefresh(WidgetTester tester) async {
   await tester.fling(
@@ -139,7 +150,7 @@ void main() {
     expect(find.text('Could not load this trip'), findsNothing);
 
     // Mutation affordances are disabled or hidden.
-    final refine = _labeledButton<FilledButton>(tester, 'Refine with AI');
+    final refine = _labeledChip(tester, 'Refine with AI');
     expect(refine.onPressed, isNull, reason: 'chat/refine needs the network');
     final addPlace = _labeledButton<TextButton>(tester, 'Add place');
     expect(addPlace.onPressed, isNull);
@@ -198,7 +209,7 @@ void main() {
     expect(find.textContaining('Offline — showing saved copy from'),
         findsNothing);
     expect(find.text('Athens Trip (live)'), findsWidgets);
-    final refine = _labeledButton<FilledButton>(tester, 'Refine with AI');
+    final refine = _labeledChip(tester, 'Refine with AI');
     expect(refine.onPressed, isNotNull, reason: 'back online — re-enabled');
   });
 
@@ -269,7 +280,7 @@ void main() {
     expect(find.text('Could not load this trip'), findsNothing);
 
     // Mutation affordances are guarded, same as a loud offline entry.
-    final refine = _labeledButton<FilledButton>(tester, 'Refine with AI');
+    final refine = _labeledChip(tester, 'Refine with AI');
     expect(refine.onPressed, isNull);
     final addPlace = _labeledButton<TextButton>(tester, 'Add place');
     expect(addPlace.onPressed, isNull);
@@ -294,7 +305,7 @@ void main() {
         findsNothing);
     expect(find.text('Could not load this trip'), findsNothing);
     expect(find.text('Athens Trip'), findsWidgets);
-    final refine = _labeledButton<FilledButton>(tester, 'Refine with AI');
+    final refine = _labeledChip(tester, 'Refine with AI');
     expect(refine.onPressed, isNotNull);
   });
 
@@ -324,7 +335,7 @@ void main() {
     expect(find.textContaining('Offline — showing saved copy from'),
         findsNothing);
     expect(find.text('Athens Trip (back online)'), findsWidgets);
-    final refine = _labeledButton<FilledButton>(tester, 'Refine with AI');
+    final refine = _labeledChip(tester, 'Refine with AI');
     expect(refine.onPressed, isNotNull, reason: 'back online — re-enabled');
   });
 

--- a/src/packages/flutter-app/test/trip_detail_resume_chat_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_resume_chat_test.dart
@@ -418,8 +418,11 @@ void main() {
 }
 
 /// The Continue-chat row's own ⋮ — the screen has several
-/// `PopupMenuButton<String>`s, so this is scoped to the row.
+/// `PopupMenuButton<String>`s, so this is scoped to the row. Scoped by the
+/// row's ValueKey rather than by the widget it happens to be built from: it
+/// was a ListTile until the wave-2 header redesign made it a flat row in the
+/// Next Step card's family, and this finder was the only thing that noticed.
 final Finder _rowMenu = find.descendant(
-  of: find.widgetWithText(ListTile, 'Continue chat'),
+  of: find.byKey(const ValueKey('continue-chat-row')),
   matching: find.byType(PopupMenuButton<String>),
 );


### PR DESCRIPTION
## Summary

Wave 2 of the trip-detail redesign — the header card and the page shell
(`trip-header-shell-redesign`). References: **TripAdvisor** and **Vrbo**
trip-detail pages via Mobbin, the repo's `design-inspiration` +
`brand-guidelines` skills, and DESIGN.md's post-#494 flat doctrine.
Four register problems from the ticket, four moves. **No behavior
change** — edit dialog, refine panel, health sheet, links, tab switching
and message counts all work exactly as before.

**1. The title floated far above its metadata.** The edit pencil's 48px
tap box was setting the title row's height and the title was *top*-aligned
inside it, so the nominal 8px gap below rendered as ~30px. Centred, with
compact density on the pencil: ~14px, and the name sits on its dates the
way the reference stacks title and meta as one block.

**2. Two competing CTAs.** "Refine with AI" was a tonal `FilledButton`
that rhymed exactly with the Next Step card's tonal CTA 130px below — two
equal-weight teal buttons in the top 300px asking for the same kind of
attention. It is an `ActionChip` now, a real peer of the dates chip,
which is what its own code comment has claimed since #457. The header
carries exactly **one** filled action. The brand stays, at chip-and-pin
scale, in the sparkle avatar.

**3. Next-step and continue-chat were two unrelated cards.** The chat row
was an elevated Material `Card` sitting `md` below a flat tinted panel:
two boxes, two depth registers, one job each. It is now flat, on the same
radius, the same 24px leading-icon column and `md` icon gutter as
`NextStepCard`, `sm` below it — one plan block whose second line is
quieter than its first. Deliberately **not** merged into the tint:
`NextStepCard` paints a fixed light `brandTint`, so a shared field would
have to be that light tint and dark mode would gain a light block twice
the size. Sequence, not fusion.

**4. The tab bar read as plain underlined text on the void.** The
selected tab's 2px underline hugged its label inside a vertically-centred
box — a teal dash floating a dozen pixels above nothing. It now sits on
the tab's bottom edge, the tab fills the pinned row, and the row closes
on a content-width `outlineVariant` hairline. That rule is the bottom
edge of the pinned chrome and the top edge of the list — the seam both
TripAdvisor and Vrbo draw. The tab cluster's `FittedBox` moved from
`centerLeft` to `bottomLeft` so a *scaled-down* cluster (390px in
Spanish) keeps its underline on the rule; identical whenever nothing
scales.

**The seam, and 60px.** `mapBandHeaderHeight` 340 → 280. The band and the
tab row are both *permanent* chrome on wide, so at 340 a 1000px window
opened on the header, the map, the tab row and exactly one city heading —
the first day below the fold, on the page whose job is the days. 280
keeps the card cinematic at the 900px content cap (~3.2:1) and leaves the
map lane's own composition (#497) untouched: its chip strip insets 8 from
the top and its control cluster 8 from the bottom, so 264px still
separates them.

## Test changes (4 assertions, all pinning the old spelling)

- `trip_detail_all_expanded_headers_test.dart` + `trip_detail_leg_focus_test.dart`
  carried the pinned-chrome math as a bare `420` (= 364 + 56) in five
  places and failed by exactly the 60px the band lost. Both now derive it
  from `mapBandHeaderHeight` via a local `_pinnedSlot`, so a future band
  retune can't invalidate the scroll math silently.
- `trip_detail_offline_test.dart` pinned Refine as a `FilledButton`
  (`_labeledButton<T extends ButtonStyleButton>`); `ActionChip` isn't one,
  so it gets a sibling `_labeledChip`. The assertion it feeds —
  `onPressed` nulled while offline-serving — is unchanged at all five sites.
- `trip_detail_resume_chat_test.dart` scoped the Continue-chat row's ⋮ to
  `find.widgetWithText(ListTile, …)`. It scopes to a `ValueKey` now (the
  `NextStepCard` idiom), so restyling the row can't move the finder again.

## Testing

- `flutter analyze` — no issues in either touched `lib/` file. Three
  pre-existing `info` findings remain in `lib/models/route_response.dart`,
  a file this PR never touches (present on `main`).
- `flutter test` — **`All tests passed!`**, 1708 tests, zero `[E]` lines
  (the literal summary line, not a piped exit code).
- `brand-guidelines/scripts/check.sh` — one finding,
  `trip_detail_screen.dart` `Radius.circular(16)`, **pre-existing on
  `main`** (there at line 3987) in the mobile chat sheet — outside this
  PR's hunks, and the chat panel is out of scope for the whole trip-detail
  redesign per the wave plan. Everything this PR adds is a token.
- In-browser on the lane stack (`localhost:3003`), one seeded trip
  (Kraków & Prague, 10 days, 2 cities, 7 places, a description, a live
  `add_lodging` Next Step and a 4-message saved conversation): **light ×
  dark × desktop 1440 × phone 390 × EN × ES**, plus tab switching to
  Bookings and Budget, the Continue-chat ⋮ menu, and the header pencil's
  edit dialog. Before-frames were shot from a clean tree *before* the
  first edit, so they are that build, not a mixed one.
- Screenshots + the register table:
  `artifacts/trip-detail-redesign/trip-header-shell-redesign/before-after/`.

## Note for the reviewer (not fixed here — out of lane)

`NextStepCard` paints `AppColors.brandTint`, a fixed light teal, in
**both** themes — so in dark mode the Next Step panel is a light mint
block on a dark page. That predates this PR and is unchanged by it
(`BEFORE-desktop-dark.png` shows the same), and `next_step_card.dart` is
not in this lane's conflict manifest, so it is reported rather than
touched. It is the reason the chat row is sequenced beside that panel
instead of merged into it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
