### PR TITLE
feat(trip-detail): budget composer surface + map-band seam (wave 3)

### DIFF
--- a/src/packages/flutter-app/lib/widgets/trip_detail/budget_composer.dart
+++ b/src/packages/flutter-app/lib/widgets/trip_detail/budget_composer.dart
@@ -152,16 +152,81 @@ class _BudgetComposerState extends ConsumerState<BudgetComposer> {
     });
   }
 
+  /// The panel's inset, and it is asymmetric for the reason this whole file is
+  /// asymmetric: **vertical space in a scrolling tab body is nearly free;
+  /// horizontal space is the scarce resource.** [_buildAddRow]'s ladder is
+  /// measured against the width it is handed, and after wave 3 that is this
+  /// panel's interior rather than the tab's full width — so every horizontal
+  /// pixel spent here is a pixel the ladder concedes, at a lower width, to a
+  /// worse rung.
+  ///
+  /// Not free-hand numbers: at [AppSpacing.md] a side, a 360px phone lost the
+  /// category trigger off the description's line — rung 3, which the row is
+  /// only supposed to reach at accessibility widths, and which puts the
+  /// trigger between the two fields in reading order so `next` stops there
+  /// instead of reaching the amount. [AppSpacing.sm] a side keeps 360 on rung
+  /// 2, and the ladder tests at that width are the standing guard: they name
+  /// no width this padding is allowed to be, only that whatever it is, a
+  /// 360px row still seats the category beside the label.
+  static const EdgeInsets _panelPadding = EdgeInsets.symmetric(
+    horizontal: AppSpacing.sm,
+    vertical: AppSpacing.md,
+  );
+
+  /// The composer as a surface of its own — the blank line at the foot of the
+  /// receipt.
+  ///
+  /// Until wave 3 this was the last thing on the tab with no surface at all:
+  /// #498 gave the record a raised card and the model's estimate a recessed
+  /// well, and then the traveler's own write — the one thing on the tab that
+  /// creates an expense — scattered across the bare page below both, wider
+  /// than either, its options line right-aligned over left-aligned fields. It
+  /// read as debris under the cards rather than as the tab's write affordance
+  /// (see the Rocket Money / Airwallex entry forms in the wave's Mobbin pass:
+  /// the fields are always INSIDE something).
+  ///
+  /// Surface + a hairline, and NEITHER a fill nor an elevation, because the
+  /// tab already spends both: the receipt is raised (the record), the
+  /// suggestion is a recessed `surfaceContainerHighest` well (an estimate that
+  /// is not yours yet). A filled panel here was tried first and read as a
+  /// second well — `surfaceContainerHigh` lands 6/255 off `Highest`, so the
+  /// two stacked as one grey block split by a gap. An outlined sheet is the
+  /// third register the tab was missing and the one an entry surface wants
+  /// anyway: a blank line, edge drawn, nothing written on it yet.
+  ///
+  /// The fill is `surface` and in LIGHT that is the page exactly (both
+  /// `(244,251,248)`), so there the hairline alone draws the panel — which is
+  /// the intent, not an accident: an outlined region on the page is what an
+  /// empty line looks like. Dark parts company usefully — `surface` there is
+  /// darker than the well above, the opposite direction from light and the
+  /// same "not that other block" either way. In both, the fields (grey[50]
+  /// light, `surfaceContainerHighest` dark) sit clearly ON the panel.
+  ///
+  /// The top gap is this widget's own margin rather than a sibling gap, for
+  /// the reason the options line used to carry it: `DailySpendSection`
+  /// collapses to nothing when offline or empty, and a sibling `SizedBox`
+  /// would dangle above the panel in the common case.
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        _buildAddOptions(theme),
-        _buildAddRow(theme),
-      ],
+    return Padding(
+      padding: const EdgeInsets.only(top: AppSpacing.md),
+      child: Container(
+        decoration: BoxDecoration(
+          color: theme.colorScheme.surface,
+          border: Border.all(color: theme.colorScheme.outlineVariant),
+          borderRadius: AppRadius.mdAll,
+        ),
+        padding: _panelPadding,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            _buildAddOptions(theme),
+            _buildAddRow(theme),
+          ],
+        ),
+      ),
     );
   }
 
@@ -185,8 +250,9 @@ class _BudgetComposerState extends ConsumerState<BudgetComposer> {
   /// unlabelled pill sitting between the daily-spend card and the add row was
   /// read as belonging to the card, or as a filter over the list above, and so
   /// as a control that did nothing. The label is what ties it to the row it
-  /// arms; the [AppSpacing.md] above and [AppSpacing.xs] below are the rest of
-  /// that tie.
+  /// arms; since wave 3 the panel around both is the rest of that tie, and the
+  /// misreading it was written against — "this belongs to the card above" — is
+  /// the one thing a shared surface can no longer be read as saying.
   ///
   /// The pick is read from the draft, so it survives the remount that changing
   /// header tab or opening the chat panel causes — a choice, like the category
@@ -203,11 +269,10 @@ class _BudgetComposerState extends ConsumerState<BudgetComposer> {
           .watch(expenseDraftProvider(widget.tripId).select((d) => d.planned));
       final l10n = context.l10n;
       return Padding(
-        // The top gap lives here rather than in a sibling SizedBox because
-        // DailySpendSection collapses to nothing when offline or empty — a
-        // sibling would dangle above the add row in the common case.
-        padding:
-            const EdgeInsets.only(top: AppSpacing.md, bottom: AppSpacing.xs),
+        // Only the gap down to the entry row now: the gap ABOVE the composer
+        // became the panel's margin in [build] when the panel arrived, since a
+        // surface's own outer spacing cannot live inside one of its children.
+        padding: const EdgeInsets.only(bottom: AppSpacing.sm),
         // Wrap, not Row: the label and the pill sit side by side when they
         // fit and the pill drops to its own line when they don't, which is
         // what Spanish does at 360px ("Añadir como" wants more than the
@@ -217,7 +282,12 @@ class _BudgetComposerState extends ConsumerState<BudgetComposer> {
         // "nothing threw" proves nothing. Wrap needs no measurement, so it is
         // right in every language and at every text scale by construction.
         child: Wrap(
-          alignment: WrapAlignment.end,
+          // Left, not right (wave 3): on the bare page this line right-aligned
+          // so it would sit over the commit button it arms, which put the
+          // composer's two halves on opposite edges with nothing tying them
+          // together. Inside the panel the left edge IS the tie — the label
+          // now opens the surface the way the receipt's title opens that card.
+          alignment: WrapAlignment.start,
           crossAxisAlignment: WrapCrossAlignment.center,
           spacing: AppSpacing.sm,
           runSpacing: AppSpacing.xs,
@@ -537,9 +607,18 @@ class _BudgetComposerState extends ConsumerState<BudgetComposer> {
       // Declared to _controlWidth for the same reason as the category trigger
       // — and it is a fix as well as a declaration: on desktop this button was
       // 40 wide, under Material's 48 minimum.
+      //
+      // Tonal-filled since wave 3, and still an IconButton at exactly
+      // _controlWidth so the row's arithmetic is untouched: this is the tab's
+      // primary write, and as a bare glyph it sat quieter than the "Add to
+      // plan" links in the suggestion well directly above it — the one action
+      // that files an expense reading weaker than the one that offers an
+      // estimate. Tonal rather than filled because the surface it commits into
+      // is a panel, not a hero, and the teal spine belongs to one action per
+      // screen (#503's header rule).
       final add = SizedBox(
         width: _controlWidth,
-        child: IconButton(
+        child: IconButton.filledTonal(
           icon: const Icon(Icons.add),
           tooltip: context.l10n.budgetAddExpenseTooltip,
           onPressed: widget.isOffline ? null : _add,

--- a/src/packages/flutter-app/lib/widgets/trip_detail/map_band.dart
+++ b/src/packages/flutter-app/lib/widgets/trip_detail/map_band.dart
@@ -17,7 +17,7 @@ import '../app_map.dart';
 import '../map_leg_chips.dart';
 import '../trip_map.dart';
 
-/// Wide pinned-header extent: top gap + map + bottom gap (the phone layout's
+/// Height of the map card on the wide pinned layout (the phone layout's
 /// preview is [mapBandHeightNarrow] and scrolls away instead).
 ///
 /// 280, down from 340 (wave 2, header/shell lane): this band does not scroll
@@ -29,7 +29,36 @@ import '../trip_map.dart';
 /// 900px content cap (~3.2:1) and leaves the map lane's own composition
 /// untouched — its chip strip insets 8 from the top and its control cluster 8
 /// from the bottom, so both still clear each other by a wide margin.
-const double mapBandHeaderHeight = 12 + 280 + 12;
+const double _mapCardHeight = 280;
+
+/// The gap the pinned band keeps ABOVE the map card, and the one it keeps
+/// BELOW it — the band↔tab-bar seam.
+///
+/// Deliberately unequal, and that is the whole fix (wave 3). Pinned, this band
+/// sits inside a block bounded by two hairlines: the app bar's above and the
+/// tab row's below (#503 moved the selected tab's underline onto that lower
+/// rule so the tabs read as the head of the list). With 12 above and 12 below
+/// the map card read as *centred between* those two rules rather than as
+/// belonging to either, and the seam the tab row needs was indistinguishable
+/// from the sliver of scaffold under the app bar — most obviously in dark,
+/// where a bright satellite card is letterboxed by two identical strips of
+/// near-black.
+///
+/// Unequal says which way the card leans: the map hangs off the top chrome it
+/// pins with, and the larger gap below is the seam before the tab row and the
+/// list it heads. The pair still totals the same 24, so this costs the
+/// itinerary nothing and leaves #503's 420→304 argument exactly where it was.
+///
+/// The gap above is the PINNED figure only. On phones the band is not chrome —
+/// it is a card in the page flow under the header's own [AppSpacing.lg] — so
+/// that branch keeps [AppSpacing.md] above and takes only the seam below.
+const double _pinnedTopGap = AppSpacing.sm;
+const double _seamGap = AppSpacing.lg;
+
+/// Wide pinned-header extent: top gap + map + seam. Derived from the three
+/// figures the padding below is built from, never restated, so the delegate's
+/// height and its child's insets cannot drift apart.
+const double mapBandHeaderHeight = _pinnedTopGap + _mapCardHeight + _seamGap;
 
 /// Map card height on phones, where the map scrolls away instead of
 /// pinning (a preview — the full-screen map is one tap away).
@@ -57,14 +86,17 @@ Widget tripDetailMapBandSliver({
       delegate: pinnedDelegateBuilder(
         height: mapBandHeaderHeight,
         backgroundColor: backgroundColor,
-        padding: EdgeInsets.fromLTRB(gutter, 12, gutter, 12),
+        padding: EdgeInsets.fromLTRB(gutter, _pinnedTopGap, gutter, _seamGap),
         child: cardBuilder(false),
       ),
     );
   }
   return SliverToBoxAdapter(
     child: Padding(
-      padding: EdgeInsets.fromLTRB(gutter, 12, gutter, 12),
+      // Phone: the header's own AppSpacing.lg already sits above this card, so
+      // the top gap stays md; the seam below is the same one the pinned layout
+      // draws, because the tab row it introduces is the same tab row.
+      padding: EdgeInsets.fromLTRB(gutter, AppSpacing.md, gutter, _seamGap),
       child: SizedBox(height: mapBandHeightNarrow, child: cardBuilder(true)),
     ),
   );


### PR DESCRIPTION
## Summary

Two deferred wave-3 items from the trip-detail plan. Two files, **no l10n keys, no theme changes, no test edits.**

**1. The budget composer gets a surface.** It was the last thing on the Budget tab with no surface at all — #498 gave the record a raised receipt card and the model's estimate a recessed well, and then the traveler's own write scattered on the bare page below both, *wider than either card*, options line right-aligned over left-aligned fields, commit a bare grey glyph quieter than the "Add to plan" links directly above it.

| Problem | Move |
|---|---|
| No surface | `surface` + `outlineVariant` hairline, radius `md` — the third register. **Not a fill**: `surfaceContainerHigh` was built and screenshotted first and landed 6/255 from the well's `Highest`, so the two stacked as one grey block split by a gap |
| Two halves on opposite edges | `WrapAlignment.end` → `start`; the panel's left edge is the tie |
| The tab's **primary write** read weakest | `IconButton` → `IconButton.filledTonal` — same type, tooltip, icon and 48px, so the row's arithmetic is untouched |

Preserved as the ticket required: the public interface (`tripId`/`isOffline`/`cityOptions`/`run`), full-width behaviour, and the 320px-sweep hint-truncation tests.

**The one trade-off, and it's measured.** The panel's padding comes out of the add row's measured ladder. At `AppSpacing.md` a side, a **360px** phone dropped to rung 3 — the category trigger off the description's line, which (as the file itself predicted) also puts the trigger between the two fields in reading order so `next` stops there instead of reaching the amount. Two *existing* tests caught it, which is the good outcome: they pin the rung at a width, so they measure this padding without naming it. Landed on `sm` horizontal / `md` vertical — asymmetric on the file's own stated principle that vertical space in a scrolling tab is nearly free and horizontal is the scarce resource. The binding numbers were probed rather than guessed (in the FlutterTest font `budgetAddHint` is 284 wide incl. chrome; rung 3 begins below 340 of row width), so `sm` is the largest step that keeps 360 on rung 2.

**2. Map-band ↔ tab-bar seam: `12 / 280 / 12` → `8 / 280 / 16`.** Pinned, the band sits inside a block bounded by two hairlines — the app bar's above, the tab row's below (#503 put the selected tab's underline on that lower rule). Equal gaps read as a card *centred between* those rules rather than belonging to either, so the seam the tab row needs was indistinguishable from the sliver of scaffold under the app bar — clearest in dark, where a bright satellite card is letterboxed by two identical strips of near-black. Unequal says which way it leans: the map hangs off the top chrome it pins with, the larger gap is the seam before the list.

The pair still totals 24, so **`mapBandHeaderHeight` stays 304 and #503's 420→304 argument is untouched** — it's now *derived* from the three figures the padding is built from instead of restated, so the delegate height and its child's insets can't drift. Phone branch keeps `md` above (the header already spends `lg` there) and takes the same `lg` seam below. #497's map internals untouched.

Measured off the pinned frames at 1440 CSS px:

| | before | after |
|---|---|---|
| app-bar hairline | y 55 | y 55 |
| gap above map | **12** | **8** |
| map card | 68–347 (280) | 64–343 (280) |
| seam below map | **12** | **16** |
| tab hairline = chrome's bottom edge | **y 415** | **y 415** |

Research: TripAdvisor returned nothing for expense entry on Mobbin, so the composer's references are **Rocket Money** (slots inside one card, mode pill above), **Airwallex/Brex** (outlined add-a-line slot) and **Wanderlog/Tripsy**; the seam's are **Vrbo / Trip.com / Wanderlog / komoot** trip pages.

## Testing

- `flutter analyze` on both touched files: **No issues found.** Repo-wide there are 3 `unnecessary_brace_in_string_interps` infos in `lib/models/route_response.dart` — **pre-existing**, confirmed by stashing this diff and re-running.
- `flutter test`: **`03:03 +1713: All tests passed!`**, zero `[E]`.
  Earlier full runs on this same tree came back red and *every* failure was `TimeoutException after 12 minutes` while **loading** a test file — host starvation from two sibling lane suites plus three lane Docker stacks on one 7.8 GB VM (48–103 min vs 3:03 clean), never an assertion, different files each time. The two that timed out last (`trip_detail_leg_focus_test.dart`, `home_live_trip_test.dart`) pass in 9 s when run directly alongside `trip_detail_all_expanded_headers_test.dart` — the first and third being exactly the files that derive from `mapBandHeaderHeight`.
- `brand-guidelines/scripts/check.sh`: **clean (2 files)**, no findings.
- Browser matrix on the lane stack (`:3003`, seeded 3-city trip with 7 expenses across 5 categories, a target and a live daily-spend guide): light × dark × 1440 × 390 × EN × ES, plus the pinned **and** unpinned seam and the empty-budget state. Seam geometry verified by pixel scan, not by eye.

Before/after frames and the full register table live in the epic artifact `trip-detail-redesign/wave3-composer-seam/before-after`.

Lane PR — **do not merge**; the integrator merges this in PR-open order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/golden-tempo/codesmith/anemos-travel/pr/504"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789745820&installation_model_id=433099&pr_number=504&repository=golden-tempo%2Fanemos-travel&return_to=https%3A%2F%2Fgithub.com%2Fgolden-tempo%2Fanemos-travel%2Fpull%2F504&signature=33d315d34528af12931b1cc9acc8f65db7d040ef2132b03019fbae77bfb3aa0c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->