### PR TITLE
feat(trip-detail): one trailing grammar for booking rows, dated section heads

### DIFF
--- a/src/packages/flutter-app/lib/widgets/booking_todo_card.dart
+++ b/src/packages/flutter-app/lib/widgets/booking_todo_card.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import '../l10n/l10n.dart';
 import '../models/booking_todo.dart';
+import '../theme/spacing.dart';
 import '../utils/travel_mode.dart';
 import 'booking_sheets.dart' show transportModeIcon, transportModeLabel;
 
@@ -61,6 +62,130 @@ String _providerOpenLabel(
 /// BookingDetailRow derives its indent from this; change it here only.
 const double kBookingRowLeadingSlot = 34; // 18 icon + 16 caret
 
+/// One entry in a booking row's overflow menu.
+typedef BookingRowMenuItem = ({String value, String label});
+
+/// The one trailing grammar every booking row speaks: **an action, an
+/// overflow, then state** — the phrasing [BookingDetailRow] adopted when its
+/// four peer icon buttons folded into a kebab, now owned in ONE place so the
+/// family can't drift apart again.
+///
+/// The complaint this exists to answer: the three arrived as three peers of
+/// equal weight, so nothing said which was which. The fix is a weight LADDER,
+/// not fewer elements — the checkbox is behaviour (a filter test counts one
+/// per row, and it is the thing a traveler came to flip) and the named action
+/// is what the row is FOR ("Find ferries" vs "Open in Airbnb" is real
+/// information, pinned by ~27 assertions). So:
+///
+///   * the action is a LINK, not a button — full button padding at primary
+///     strength made it louder than the row's own title, and heavier than the
+///     very same action on the [BookingDetailRow] nested underneath it, which
+///     is a bare 18px glyph. It keeps teal: brand reserves that for identity
+///     and the primary action, and this is the row's primary action.
+///   * the overflow sits tight against it, so the two read as one group of
+///     things-you-can-do rather than as two more peers.
+///   * a deliberate gap then separates STATE, so the checkbox reads as its own
+///     column instead of as the third item in an undifferentiated run.
+///
+/// [alignment] is centerRight on the action so that if a short label ever hits
+/// the button's minimum width the slack lands on the LEFT — which is what
+/// keeps every row's `open_in_new` glyph on one column
+/// (trip_detail_booking_alignment_test).
+class _BookingRowTrailing extends StatelessWidget {
+  /// The open-search action's label; null renders no action at all — a
+  /// permanently disabled control is noise, not an affordance.
+  final String? actionLabel;
+  final VoidCallback? onAction;
+
+  /// Overflow entries; empty renders no kebab.
+  final List<BookingRowMenuItem> menuItems;
+  final ValueChanged<String>? onMenuSelected;
+
+  /// Booked rows recede: the link stays usable (re-check a price, find the
+  /// confirmation email's provider) but stops competing with unbooked rows.
+  final bool booked;
+
+  /// Narrow rows drop the external-link glyph along with the long label: at
+  /// the 360px overflow floor the row's fixed chrome must leave the title a
+  /// nonzero share.
+  final bool compact;
+
+  final bool checkboxValue;
+  final ValueChanged<bool> onCheckboxChanged;
+
+  /// Rendered after the checkbox (the reorder handle on residual cards).
+  final Widget? trailingExtra;
+
+  const _BookingRowTrailing({
+    required this.actionLabel,
+    required this.onAction,
+    required this.menuItems,
+    required this.onMenuSelected,
+    required this.booked,
+    required this.compact,
+    required this.checkboxValue,
+    required this.onCheckboxChanged,
+    this.trailingExtra,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final muted = theme.colorScheme.onSurfaceVariant;
+    final style = TextButton.styleFrom(
+      visualDensity: VisualDensity.compact,
+      padding: const EdgeInsets.symmetric(horizontal: AppSpacing.xs),
+      minimumSize: Size.zero,
+      alignment: Alignment.centerRight,
+      foregroundColor: booked ? muted : null,
+    );
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        if (actionLabel case final label?)
+          if (compact)
+            TextButton(
+              onPressed: onAction,
+              style: style,
+              child: Text(label),
+            )
+          else
+            TextButton.icon(
+              onPressed: onAction,
+              icon: const Icon(Icons.open_in_new, size: 18),
+              // Trailing glyph: everything after it is fixed-width and packs
+              // right, so with the icon AFTER the label every row's
+              // open_in_new lands on one column no matter how wide the label.
+              iconAlignment: IconAlignment.end,
+              style: style,
+              label: Text(label),
+            ),
+        if (menuItems.isNotEmpty)
+          PopupMenuButton<String>(
+            icon: Icon(Icons.more_vert, size: 18, color: muted),
+            tooltip: context.l10n.bookingRowOptions,
+            onSelected: onMenuSelected,
+            itemBuilder: (_) => [
+              for (final item in menuItems)
+                PopupMenuItem(value: item.value, child: Text(item.label)),
+            ],
+          ),
+        // The seam between doing and recording.
+        const SizedBox(width: AppSpacing.xs),
+        // Last so the fixed-width checkboxes stay flush right and aligned
+        // across rows despite varying button-label widths.
+        Checkbox(
+          value: checkboxValue,
+          onChanged: (v) => onCheckboxChanged(v ?? false),
+          visualDensity: VisualDensity.compact,
+          materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+        ),
+        if (trailingExtra != null) trailingExtra!,
+      ],
+    );
+  }
+}
+
 /// A styled booking checklist card: an icon by kind, the title + dates, a
 /// "Booked" checkbox, and a button that opens the pre-filled search link.
 class BookingTodoCard extends StatelessWidget {
@@ -96,62 +221,76 @@ class BookingTodoCard extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final l10n = context.l10n;
+    final muted = theme.colorScheme.onSurfaceVariant;
     return Card(
       margin: EdgeInsets.zero,
       child: Padding(
-        padding: const EdgeInsets.fromLTRB(12, 8, 12, 12),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
+        padding: const EdgeInsets.fromLTRB(12, AppSpacing.xs, 0, AppSpacing.xs),
+        child: Row(
           children: [
-            Row(
-              children: [
-                Icon(_icon, color: theme.colorScheme.primary),
-                const SizedBox(width: 12),
-                Expanded(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text(todo.title, style: theme.textTheme.titleSmall),
-                      if (todo.subtitle != null && todo.subtitle!.isNotEmpty)
-                        Text(
-                          todo.subtitle!,
-                          style: theme.textTheme.bodySmall?.copyWith(
-                            color: theme.colorScheme.onSurfaceVariant,
-                          ),
-                        ),
-                    ],
-                  ),
-                ),
-                if (onEdit != null)
-                  IconButton(
-                    icon: const Icon(Icons.edit_outlined),
-                    tooltip: l10n.bookingCardEdit,
-                    onPressed: onEdit,
-                  ),
-                if (onDelete != null)
-                  IconButton(
-                    icon: const Icon(Icons.delete_outline),
-                    tooltip: l10n.bookingCardRemove,
-                    onPressed: onDelete,
-                  ),
-                if (dragHandle != null) dragHandle!,
-              ],
+            // The slim row's own leading grid, so a residual booking lines up
+            // with the city rows above it instead of reading as another
+            // species.
+            SizedBox(
+              width: kBookingRowLeadingSlot,
+              child: Align(
+                alignment: Alignment.centerLeft,
+                child: Icon(_icon, size: 18, color: theme.colorScheme.primary),
+              ),
             ),
-            Row(
-              children: [
-                Checkbox(
-                  value: todo.booked,
-                  onChanged: (v) => onBookedChanged(v ?? false),
-                ),
-                Text(l10n.bookingCardBooked, style: theme.textTheme.bodyMedium),
-                const Spacer(),
-                FilledButton.tonalIcon(
-                  onPressed: onOpen,
-                  icon: const Icon(Icons.open_in_new, size: 18),
-                  label:
-                      Text(_providerOpenLabel(l10n, todo, openLabelOverride)),
-                ),
+            const SizedBox(width: 8),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    todo.title,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: theme.textTheme.bodyMedium?.copyWith(
+                      color: todo.booked ? muted : null,
+                      decoration:
+                          todo.booked ? TextDecoration.lineThrough : null,
+                    ),
+                  ),
+                  if (todo.subtitle != null && todo.subtitle!.isNotEmpty)
+                    Text(
+                      todo.subtitle!,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: theme.textTheme.bodySmall?.copyWith(color: muted),
+                    ),
+                ],
+              ),
+            ),
+            // Edit and delete fold into the same kebab the city rows carry.
+            // This is the only booking widget that owns them, and spelled out
+            // as two peer icon buttons beside a filled "Open search" and a
+            // labelled checkbox, a custom booking arrived with FOUR trailing
+            // weights and twice the height of the rows it sits under —
+            // destructive delete one pixel from a routine edit. Housing them
+            // (rather than dropping them) is what keeps the register change
+            // from being a feature removal.
+            _BookingRowTrailing(
+              // A custom todo has no provider to search, so its action is
+              // null and simply doesn't render — it used to sit there as a
+              // permanently greyed-out filled button.
+              actionLabel: onOpen == null
+                  ? null
+                  : _providerOpenLabel(l10n, todo, openLabelOverride),
+              onAction: onOpen,
+              menuItems: [
+                if (onEdit != null) (value: 'edit', label: l10n.bookingCardEdit),
+                if (onDelete != null)
+                  (value: 'delete', label: l10n.bookingCardRemove),
               ],
+              onMenuSelected: (v) =>
+                  v == 'edit' ? onEdit?.call() : onDelete?.call(),
+              booked: todo.booked,
+              compact: false,
+              checkboxValue: todo.booked,
+              onCheckboxChanged: onBookedChanged,
+              trailingExtra: dragHandle,
             ),
           ],
         ),
@@ -266,72 +405,33 @@ class BookingTodoRow extends StatelessWidget {
               ],
             ),
           ),
-          // Compact rows drop the external-link glyph along with the long
-          // label: at the 360px overflow floor the row's fixed chrome
-          // (leading slot + button + kebab + checkbox) must leave the title
-          // a nonzero share.
-          if (compact)
-            TextButton(
-              onPressed: onOpen,
-              style: todo.booked
-                  ? TextButton.styleFrom(foregroundColor: muted)
-                  : null,
-              child: Text(_providerOpenLabel(
-                  context.l10n, todo, openLabelOverride,
-                  compact: true)),
-            )
-          else
-            TextButton.icon(
-              onPressed: onOpen,
-              icon: const Icon(Icons.open_in_new, size: 18),
-              // Trailing glyph: the kebab + checkbox after the button are
-              // fixed-width and the cluster packs right, so with the icon
-              // after the label every row's open_in_new lands on one column
-              // no matter how wide the label is.
-              iconAlignment: IconAlignment.end,
-              // Booked rows recede: the link stays usable (re-check a price,
-              // find the confirmation email's provider) but stops competing
-              // with unbooked rows for attention.
-              style: todo.booked
-                  ? TextButton.styleFrom(foregroundColor: muted)
-                  : null,
-              label: Text(_providerOpenLabel(
-                  context.l10n, todo, openLabelOverride,
-                  compact: false)),
-            ),
-          if (onAddDetails != null || onChangeAirport != null)
-            PopupMenuButton<String>(
-              icon: Icon(Icons.more_vert, size: 18, color: muted),
-              tooltip: context.l10n.bookingRowOptions,
-              onSelected: (v) => switch (v) {
-                'airport' => onChangeAirport?.call(),
-                _ => onAddDetails?.call(),
-              },
-              itemBuilder: (_) => [
-                // First: on a home leg it is the more consequential of the two,
-                // and it is what a traveler reaching for "Add details…" to
-                // retype an airport was actually looking for.
-                if (onChangeAirport != null)
-                  PopupMenuItem(
-                    value: 'airport',
-                    child: Text(todo.role == 'home_return'
-                        ? context.l10n.tripAirportsChangeReturn
-                        : context.l10n.tripAirportsChangeDeparture),
-                  ),
-                if (onAddDetails != null)
-                  PopupMenuItem(
-                    value: 'details',
-                    child: Text(context.l10n.bookingRowAddDetails),
-                  ),
-              ],
-            ),
-          // Last so the fixed-width checkboxes stay flush right and aligned
-          // across rows despite varying button-label widths.
-          Checkbox(
-            value: todo.booked,
-            onChanged: (v) => onBookedChanged(v ?? false),
-            visualDensity: VisualDensity.compact,
-            materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+          _BookingRowTrailing(
+            actionLabel: _providerOpenLabel(
+                context.l10n, todo, openLabelOverride,
+                compact: compact),
+            onAction: onOpen,
+            menuItems: [
+              // First: on a home leg it is the more consequential of the two,
+              // and it is what a traveler reaching for "Add details…" to
+              // retype an airport was actually looking for.
+              if (onChangeAirport != null)
+                (
+                  value: 'airport',
+                  label: todo.role == 'home_return'
+                      ? context.l10n.tripAirportsChangeReturn
+                      : context.l10n.tripAirportsChangeDeparture
+                ),
+              if (onAddDetails != null)
+                (value: 'details', label: context.l10n.bookingRowAddDetails),
+            ],
+            onMenuSelected: (v) => switch (v) {
+              'airport' => onChangeAirport?.call(),
+              _ => onAddDetails?.call(),
+            },
+            booked: todo.booked,
+            compact: compact,
+            checkboxValue: todo.booked,
+            onCheckboxChanged: onBookedChanged,
           ),
         ],
       ),

--- a/src/packages/flutter-app/lib/widgets/trip_detail/bookings_tab.dart
+++ b/src/packages/flutter-app/lib/widgets/trip_detail/bookings_tab.dart
@@ -808,6 +808,42 @@ extension on _TripDetailScreenState {
     return [for (final label in order) (label: label, rows: rows[label]!)];
   }
 
+  /// The dates a section head may honestly show, or null.
+  ///
+  /// Only a label the TRIP visits exactly once gets a date. A revisited city
+  /// merges its runs into one section, and those runs are genuinely different
+  /// windows on screen — pinned in trip_detail_derivation_test's section-head
+  /// group, which is also where the index alignment this relies on is proven.
+  /// Showing the first run's dates would re-create the label-keyed range map
+  /// [TripDerivation] deliberately deleted for "collapsing revisited cities
+  /// onto one window"; a head is exactly where it would come back.
+  ///
+  /// Counted over [labels] — every leg the trip has — and deliberately NOT
+  /// over the legs that contributed ROWS. Claim-once matching means a revisit
+  /// usually has no bookings of its own (it cannot re-claim the first run's
+  /// stay), so a rows-based count would see one leg, and the head would date
+  /// the whole destination from run 1 while the traveler is also there on run
+  /// 2. 'Other places' appears in no leg, so it is dateless by the same rule.
+  ///
+  /// The range is [CityGroup.dateRange] — the SAME chip the itinerary's city
+  /// header renders, built from visibleLegRanges. Never re-derived here:
+  /// anything that promises something about the dates on screen reads the one
+  /// derivation that owns them (docs/zen.md). `_derive` is memoized on the
+  /// input signature, so this is a cache hit during build.
+  String? _sectionHeadDate(String label, List<String> labels) {
+    var found = -1;
+    for (var i = 0; i < labels.length; i++) {
+      if (labels[i] != label) continue;
+      if (found >= 0) return null; // visited more than once
+      found = i;
+    }
+    if (found < 0) return null;
+    final trip = _trip;
+    if (trip == null) return null;
+    final groups = _derive(trip).groups;
+    return found < groups.length ? groups[found].dateRange?.range : null;
+  }
+
 
   /// A section head: tinted icon tile, the destination, and — when every
   /// booking under it is done — a quiet check.
@@ -827,6 +863,7 @@ extension on _TripDetailScreenState {
     ThemeData theme,
     String label, {
     required bool allBooked,
+    String? dateRange,
   }) {
     final l10n = context.l10n;
     final isOther = label == _kOtherPlaces;
@@ -864,6 +901,17 @@ extension on _TripDetailScreenState {
                   ?.copyWith(fontWeight: FontWeight.w600),
             ),
           ),
+          // Context, not a claim the head owns: same quiet weight as a row's
+          // subtitle, so the destination stays the head's one strong word.
+          if (dateRange != null) ...[
+            Text(
+              dateRange,
+              maxLines: 1,
+              style: theme.textTheme.bodySmall
+                  ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+            ),
+            const SizedBox(width: AppSpacing.sm),
+          ],
           if (allBooked)
             Tooltip(
               message: l10n.bookingsSectionAllBooked,
@@ -952,8 +1000,18 @@ extension on _TripDetailScreenState {
       return c != null && c.total > 0 && c.booked == c.total;
     }
 
-    Widget head(String label) =>
-        _bookingSectionHeader(theme, label, allBooked: allBooked(label));
+    // Narrow drops the head's dates, the same call the itinerary's city
+    // header makes ("narrow stacks the dates under the name instead of
+    // rendering the chip") — and for the same reason: at 320px the head is
+    // down to ~268px of usable width, and a rigid date beside a flexible
+    // label is exactly the shape that truncates the DESTINATION, which is the
+    // head's one strong word. Not stacked here either: this is a lightweight
+    // label row, not a city header, and the dates are one tab away on the
+    // itinerary. Pinned by the Spanish-at-1.3x filter-row test, which throws
+    // on a RenderFlex overflow.
+    Widget head(String label) => _bookingSectionHeader(theme, label,
+        allBooked: allBooked(label),
+        dateRange: _narrow ? null : _sectionHeadDate(label, labels));
 
     final cities = [for (final s in sections) if (s.label != _kOtherPlaces) s];
     final other = [for (final s in sections) if (s.label == _kOtherPlaces) s];

--- a/src/packages/flutter-app/test/trip_detail_bookings_register_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_bookings_register_test.dart
@@ -1,0 +1,227 @@
+// Wave 3 bookings register cleanup: the trailing grammar every booking row
+// speaks, and the dates a section head is allowed to claim.
+//
+// These cover paths that had NO coverage before this lane, which on this
+// surface is the documented place bugs ship (#501's own edit/delete assertion
+// was a `findsNothing` on a VIEWER row, where the affordance is null anyway):
+//
+//   1. BookingTodoCard's edit/delete moved into the kebab. Nothing asserted
+//      they rendered at all for an EDITOR, so nothing would have caught the
+//      fold dropping them.
+//   2. A residual todo has no provider to search, so its action is null and
+//      must not render — it used to sit there as a permanently greyed-out
+//      filled button.
+//   3. Section-head dates, guarded by the revisited-city rule proven in
+//      trip_detail_derivation_test's section-head pin group.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:travel_route_planner/models/booking_todo.dart';
+import 'package:travel_route_planner/models/itinerary_item.dart';
+import 'package:travel_route_planner/models/trip.dart';
+import 'package:travel_route_planner/screens/trip_detail_screen.dart';
+import 'package:travel_route_planner/services/api_client.dart';
+import 'package:travel_route_planner/services/trips_api_service.dart';
+import 'package:travel_route_planner/providers/trips_provider.dart';
+import 'package:travel_route_planner/widgets/booking_todo_card.dart';
+
+import 'support/l10n_test_app.dart';
+
+class _FakeTripsApiService extends TripsApiService {
+  final Trip trip;
+  _FakeTripsApiService(this.trip) : super(ApiClient(baseUrl: 'http://test'));
+
+  @override
+  Future<Trip> getTrip(String id) async => trip;
+}
+
+ItineraryItem _item(int pos, String name, String city, int day) =>
+    ItineraryItem(
+      id: 'i$pos',
+      position: pos,
+      name: name,
+      address: '$name, $city',
+      // Zero coords so the screen skips the map widget in the test env.
+      latitude: 0,
+      longitude: 0,
+      category: 'attraction',
+      city: city,
+      day: day,
+    );
+
+BookingTodo _todo(String kind, String key, String title,
+        {bool auto = true, String? subtitle}) =>
+    BookingTodo(
+      id: key,
+      kind: kind,
+      todoKey: key,
+      title: title,
+      auto: auto,
+      subtitle: subtitle,
+    );
+
+/// Paris (days 1-2) → Rome (day 3) → Paris again (day 4): Rome owns exactly
+/// one leg (a head that CAN carry dates), Paris owns two (one that cannot).
+Trip _trip({List<BookingTodo>? todos}) => Trip(
+      id: 't1',
+      title: 'Europe',
+      startDate: '2026-06-10',
+      endDate: '2026-06-13',
+      createdAt: '2026-06-01',
+      updatedAt: '2026-06-01',
+      items: [
+        _item(0, 'Louvre', 'Paris', 1),
+        _item(1, 'Café de Flore', 'Paris', 2),
+        _item(2, 'Colosseum', 'Rome', 3),
+        _item(3, 'Louvre again', 'Paris', 4),
+      ],
+      bookingTodos: todos ??
+          [
+            _todo('stay', 'stay:paris', 'Stay in Paris'),
+            _todo('transport', 'transport:paris>>rome', 'Paris → Rome'),
+            _todo('stay', 'stay:rome', 'Stay in Rome'),
+            _todo('other', 'custom:x', 'Museum tickets', auto: false),
+          ],
+    );
+
+void _useTallViewport(WidgetTester tester) {
+  tester.view.physicalSize = const Size(900, 3000);
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.reset);
+}
+
+Future<void> _pump(WidgetTester tester, Trip trip) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        tripsApiServiceProvider.overrideWithValue(_FakeTripsApiService(trip)),
+      ],
+      child: MaterialApp(
+        localizationsDelegates: testLocalizationsDelegates,
+        home: TripDetailScreen(tripId: 't1'),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+Future<void> _openBookingsTab(WidgetTester tester) async {
+  await tester.tap(find.text('Bookings'));
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  group('BookingTodoCard trailing register', () {
+    testWidgets('an editor gets edit + remove inside the kebab, not as peers',
+        (tester) async {
+      _useTallViewport(tester);
+      await _pump(tester, _trip());
+      await _openBookingsTab(tester);
+
+      final card = find.widgetWithText(BookingTodoCard, 'Museum tickets');
+      expect(card, findsOneWidget);
+
+      // The two peer icon buttons are gone from the card…
+      expect(find.descendant(of: card, matching: find.byIcon(Icons.edit_outlined)),
+          findsNothing);
+      expect(find.descendant(of: card, matching: find.byIcon(Icons.delete_outline)),
+          findsNothing);
+
+      // …and both actions survive, housed in the row's one overflow. This is
+      // the assertion that makes the fold a register change rather than a
+      // feature removal.
+      final kebab =
+          find.descendant(of: card, matching: find.byIcon(Icons.more_vert));
+      expect(kebab, findsOneWidget);
+      await tester.tap(kebab);
+      await tester.pumpAndSettle();
+      expect(find.text('Edit'), findsOneWidget);
+      expect(find.text('Remove'), findsOneWidget);
+    });
+
+    testWidgets('a residual todo renders no action and no "Booked" label',
+        (tester) async {
+      _useTallViewport(tester);
+      await _pump(tester, _trip());
+      await _openBookingsTab(tester);
+
+      final card = find.widgetWithText(BookingTodoCard, 'Museum tickets');
+      // A custom todo has no provider, so `onOpen` is null: the action is
+      // withheld rather than rendered permanently disabled.
+      expect(find.descendant(of: card, matching: find.text('Open search')),
+          findsNothing);
+      // The checkbox carries the state on its own, as it does on every slim
+      // row; the word beside it was a second spelling of the same fact.
+      expect(find.descendant(of: card, matching: find.text('Booked')),
+          findsNothing);
+      // The state itself is untouched — one checkbox, still there. The
+      // bookings filter test counts these, so this is load-bearing.
+      expect(find.descendant(of: card, matching: find.byType(Checkbox)),
+          findsOneWidget);
+    });
+
+    testWidgets('the card reads at the slim rows\' height, not twice it',
+        (tester) async {
+      _useTallViewport(tester);
+      await _pump(tester, _trip());
+      await _openBookingsTab(tester);
+
+      final cardH = tester
+          .getSize(find.widgetWithText(BookingTodoCard, 'Museum tickets'))
+          .height;
+      final rowH = tester
+          .getSize(find.widgetWithText(BookingTodoRow, 'Stay in Rome'))
+          .height;
+      // Was ~2x: a two-line card (title row + Booked/action row) against a
+      // one-line row. Both carry a subtitle slot, so a small delta is fine —
+      // what must not come back is the doubled register.
+      expect(cardH, lessThan(rowH * 1.5),
+          reason: 'residual card $cardH vs slim row $rowH');
+    });
+  });
+
+  group('section-head dates', () {
+    testWidgets('a head owning ONE leg carries that leg\'s visible dates',
+        (tester) async {
+      _useTallViewport(tester);
+      await _pump(tester, _trip());
+      await _openBookingsTab(tester);
+
+      // Rome is one leg, so its head can speak for it. The string is the same
+      // chip the itinerary city header renders — Rome's items sit on day 3,
+      // but the leg RENDERS from its arrival (the previous leg's visible end,
+      // Jun 11), which is the visibleLegRanges rule. A head derived from the
+      // raw ranges would have said "Jun 12" and contradicted the city header.
+      //
+      // Anchored on the DATE, not on 'Rome': the destination filter chip also
+      // renders the bare label, so scoping the other way round picks the chip.
+      final date = find.text('Jun 11 – Jun 12');
+      expect(date, findsOneWidget);
+      final head = find.ancestor(of: date, matching: find.byType(Row)).first;
+      expect(find.descendant(of: head, matching: find.text('Rome')),
+          findsOneWidget);
+    });
+
+    testWidgets('a revisited city\'s head stays silent rather than pick a run',
+        (tester) async {
+      _useTallViewport(tester);
+      await _pump(tester, _trip());
+      await _openBookingsTab(tester);
+
+      // Paris owns legs 0 and 2 — two genuinely different windows merged into
+      // ONE section. Showing either would re-create the label-keyed range map
+      // TripDerivation deleted for collapsing revisits onto one window, so the
+      // head shows no date at all.
+      //
+      // Both windows are named explicitly. Asserting only "the head has no
+      // date" would pass just as well if the feature had silently stopped
+      // working everywhere; naming the two strings that MUST NOT appear is
+      // what makes this fail for the right reason.
+      expect(find.text('Paris'), findsWidgets); // the section is there…
+      expect(find.text('Jun 10 – Jun 11'), findsNothing); // …run 1's window
+      expect(find.text('Jun 12 – Jun 13'), findsNothing); // …and run 2's
+    });
+  });
+}

--- a/src/packages/flutter-app/test/trip_detail_derivation_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_derivation_test.dart
@@ -681,6 +681,65 @@ void main() {
     });
   });
 
+  // The pin the bookings section heads stand on (wave 3). #501 shipped those
+  // heads with no dates on the stated reason that [legLabels] comes from
+  // rawLegRanges while visibleLegRanges is "a separate list" — so before any
+  // date goes on a head, prove what a head is actually allowed to say.
+  //
+  // Two facts, and the SECOND is the one that constrains the design:
+  //   1. The lists are index-aligned, so leg i's on-screen dates are
+  //      reachable from leg i's label. A head CAN carry a date.
+  //   2. A section is keyed by LABEL and a revisited city merges its runs into
+  //      one section — so a label can own two indices with two DIFFERENT
+  //      windows, and no single range is true for it. This is the failure
+  //      [TripDerivation]'s own doc records as "the label-keyed copy ...
+  //      collapsed revisited cities onto one window and is gone"; a head that
+  //      showed run 1's dates would put it straight back.
+  group('section-head dates: the legLabels <-> visibleRanges pin', () {
+    test('legLabels, rawRanges, visibleRanges and groups are index-aligned',
+        () {
+      final d = _compute();
+      final n = d.legLabels.length;
+      expect(n, 3);
+      expect(d.rawRanges, hasLength(n));
+      expect(d.visibleRanges, hasLength(n));
+      expect(d.groups, hasLength(n));
+      // visibleLegRanges is a pure forward map over rawLegRanges — it adjusts
+      // start/end and carries the label through untouched — so index i names
+      // the same leg in all four lists. That is what makes groups[i].dateRange
+      // (built from visibleRanges[i]) the right dates for legLabels[i].
+      for (var i = 0; i < n; i++) {
+        expect(d.visibleRanges[i].label, d.legLabels[i], reason: 'leg $i');
+        expect(d.rawRanges[i].label, d.legLabels[i], reason: 'leg $i');
+        expect(d.groups[i].label, d.legLabels[i], reason: 'leg $i');
+      }
+    });
+
+    test('a revisited label owns two legs whose visible windows differ', () {
+      final d = _compute();
+      // Paris -> Rome -> Paris: ONE 'Paris' section, TWO Paris legs.
+      expect(d.legLabels, ['Paris', 'Rome', 'Paris']);
+      final paris = [
+        for (var i = 0; i < d.legLabels.length; i++)
+          if (d.legLabels[i] == 'Paris') i,
+      ];
+      expect(paris, [0, 2]);
+      // The two runs are genuinely different stays on screen, so the merged
+      // section has no single range to show. A head may only date a label that
+      // owns exactly one leg; anything else has to stay silent.
+      expect(d.groups[0].dateRange?.range, 'Sep 1 – Sep 2');
+      expect(d.groups[2].dateRange?.range, 'Sep 4 – Sep 5');
+      expect(d.groups[0].dateRange, isNot(d.groups[2].dateRange));
+      // Rome owns exactly one leg — the case a head CAN date.
+      final rome = [
+        for (var i = 0; i < d.legLabels.length; i++)
+          if (d.legLabels[i] == 'Rome') i,
+      ];
+      expect(rome, [1]);
+      expect(d.groups[1].dateRange?.range, 'Sep 2 – Sep 4');
+    });
+  });
+
   // TWIN of TestIsCityFillerParity in api/city_filler_test.go. Same cases, same
   // expectations, in the same order — docs/zen.md requires the parity contract
   // because "city filler" has two implementations now: this one, which HIDES


### PR DESCRIPTION
Wave 3 of the trip-detail redesign — the three cross-lane follow-ups #501 logged, all in `booking_todo_card.dart`, the file that lane could not touch. Ticket: `wave3-bookings-cleanup`.

## Summary

**1. The row trailing trio.** Open-link + kebab + checkbox arrived as three peers of equal weight, so nothing said which was which. The fix is a weight **ladder, not fewer elements** — the checkbox is behaviour (`trip_detail_bookings_filter_test` counts one per row) and the named action is what the row is *for*. Folding the action into the kebab was ruled out: `trip_detail_narrow_rows_test` pins the brand label inside the row, and the label is pinned by ~27 assertions suite-wide. So the action became a **link rather than a button**, the kebab tightened against it, and a gap separates state. Both widgets now share one `_BookingRowTrailing` — *an action, an overflow, then state*, the grammar `BookingDetailRow` adopted in #501, now owned in one place. Measured on one row: action↔kebab **57→45px**, kebab↔checkbox **33→37px**, checkbox column **unmoved**, so the one-trailing-column invariant holds.

**2. `BookingTodoCard` heaviness.** A custom booking arrived with **four** trailing weights (edit, delete, a filled `Open search`, a labelled checkbox) at **116px** against the slim row's 52px. It is **56px** now — 2.23× → 1.08×. Edit/delete are **housed in the kebab, not dropped**; that is what keeps this a register change rather than a feature removal, and it is now asserted (the editor path had *zero* coverage — #501's only edit/delete assertion was a `findsNothing` on a viewer row, where the affordance is null anyway). The permanently disabled `Open search` is withheld rather than greyed.

**3. Section-head dates — the pin held, with a constraint it surfaced.** `visibleLegRanges` is a pure forward map over `rawLegRanges`, so `legLabels[i]` and `visibleRanges[i]` name the same leg; the head reuses `CityGroup.dateRange`, **the same chip the itinerary city header renders**, rather than deriving a second time. But a section is keyed by LABEL and a revisited city merges its runs, so a head may only date a label the trip visits **once** — dating it from run 1 would re-create the label-keyed range map `TripDerivation` deleted for *"collapsing revisited cities onto one window"*. Narrow drops the dates, the same call the city header makes.

### Two bugs the new tests caught before review

Both in the first implementation of item 3:

1. Counting a label's legs from the ones that contributed **rows**. Claim-once means a revisit usually has no bookings of its own, so the count saw one leg and dated the whole destination from run 1. Now counted over the trip's own `labels`.
2. A **22px `RenderFlex` overflow** at 320px + Spanish + 1.3× text scale.

### Two corrections to the ticket's premises (both grep-verified)

- **`trip_header_card.dart` is not a render consumer** — it only *mentions* `BookingTodoRow` in a comment about the retired trip-wide mode pill. The three real render contexts are the bookings lens, the "Not booked yet" scope, and the itinerary's inline city rows.
- **`BookingTodoRow` has exactly one construction site** (`bookings_tab.dart`, inside `_bookingRowWidgets`), which the itinerary calls too — so one change reached all three surfaces.

## Testing

- `flutter analyze` — clean. The 3 reported infos are pre-existing on `main` since the initial commit (`4843b22`), in `lib/models/route_response.dart`, untouched here.
- `flutter test` — **`+1720 All tests passed!`** (literal summary line), with **zero edits to existing tests**; +7 new (2 derivation pins, 5 register/date tests).
- Brand check — `scripts/check.sh`: clean on both touched Dart files.
- Browser matrix on this lane's stack (`:3002`), two seeded trips: bookings lens, "Other bookings" residuals, and the itinerary inline consumer; light **and** dark verified by **pixel sample** (light `(244,251,248)`, dark `(14,21,19)`), plus a 390px narrow pass. Before-frames were shot from a clean tree at `be64080` *before* any edit, so the no-op-stash trap does not apply; the A/B measurements came from a stash→measure→pop with the diffstat verified byte-identical afterwards.
- Frames + numbers: `before-after/` in the ticket's artifact dir.

## Notes for the integrator

- **The commit is unsigned.** `commit.gpgsign=true` and a key is configured, but signing produced no signature and no error in this headless lane session — the same situation #501 hit. Note the two wave-2 lane commits already on `main` (`2850adc`, `8a6043c`) are unsigned as well, so this matches the wave's norm; re-commit if `main` starts requiring signatures.
- **No new `.arb` keys** — `bookingCardEdit`/`bookingCardRemove` already existed and the head date is pre-formatted. So the generated-l10n conflict surface that complicated #501's integration is **absent here**; no `make flutter-gen-l10n` regen needed.
- Files touched are disjoint from the wave-3 header-cleanup and composer/seam lanes: `trip_detail_screen.dart`, `itinerary_tab.dart` and `trip_header_card.dart` are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/golden-tempo/codesmith/anemos-travel/pr/505"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789746057&installation_model_id=433099&pr_number=505&repository=golden-tempo%2Fanemos-travel&return_to=https%3A%2F%2Fgithub.com%2Fgolden-tempo%2Fanemos-travel%2Fpull%2F505&signature=a0ed485572a0a8360eb5e702d6b846d631981c638bda1331b38d5cba10172eb3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->