### PR TITLE
feat(trip-detail): the title collapses into the app bar; the tint follows the theme

### DIFF
--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -337,6 +337,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
   void initState() {
     super.initState();
     WidgetsBinding.instance.addObserver(this);
+    _scroll.addListener(_syncCollapsedTitle);
     _load();
   }
 
@@ -344,10 +345,100 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
   void dispose() {
     WidgetsBinding.instance.removeObserver(this);
     _statusPoll?.cancel();
+    _scroll.removeListener(_syncCollapsedTitle);
     _scroll.dispose();
     _focusedLegKey.dispose();
     _selectedPosition.dispose();
+    _titleCollapsed.dispose();
     super.dispose();
+  }
+
+  // ── The collapsing title ──────────────────────────────────────────────
+  // The trip's name used to render twice about 60px apart: once in the app
+  // bar and again as the first line of the header block. It now renders in
+  // exactly one of those places at a time — the header block owns it at rest,
+  // and the bar takes it over once the header's copy has scrolled out from
+  // under it (the TripAdvisor trip-page move; Mobbin). Scrolling back up
+  // hands it back.
+  //
+  // The bar keeps carrying the name at NARROW on purpose, because that is
+  // where it matters most: [GradientAppBar]'s ladder drops a page title
+  // outright when the row can't hold it, and its own comment names trip
+  // detail as the screen that covers for that by repeating the title in the
+  // body. That contract is unchanged — the body copy is still there, still
+  // the one the traveler reads at rest.
+
+  /// Attached to the header block's title so its position can be measured.
+  /// A key rather than arithmetic on the sliver: the title's height moves
+  /// with the text scaler and the trip's name, and a hardcoded threshold
+  /// would take the name over early for a large-text traveler.
+  final GlobalKey _headerTitleKey = GlobalKey();
+
+  /// Whether the app bar is currently carrying the trip's name.
+  ///
+  /// A ValueNotifier, NOT setState: this changes on scroll, and this screen
+  /// is 4k lines whose scroll performance is a fixed bug (#352/#353).
+  /// Rebuilding the body on a scroll tick is exactly what that fixed — so
+  /// only the app bar listens, via the [ValueListenableBuilder] in build.
+  final ValueNotifier<bool> _titleCollapsed = ValueNotifier<bool>(false);
+
+  /// Hysteresis band, in logical pixels, around the handover point.
+  ///
+  /// The bar takes the name when the header title is fully gone and gives it
+  /// back only once [_kTitleHandoffSlack] of it is showing again. One
+  /// threshold for both directions would let a scroll resting exactly on it
+  /// (or a bouncing overscroll settling) flip the bar back and forth.
+  static const double _kTitleHandoffSlack = 12;
+
+  /// The scroll offset at which the header title's last pixel leaves the
+  /// viewport — the handover point, in scroll coordinates.
+  ///
+  /// Cached rather than measured on every tick, because the thing being
+  /// measured stops existing: the header is a plain [SliverToBoxAdapter], so
+  /// once it is past the cache extent it UNMOUNTS and its key has no context.
+  /// Measuring live meant a fast fling scrolled the header away and the bar
+  /// never took the name over — the handover worked only for scrolls slow or
+  /// short enough to keep the sliver alive. Held in scroll coordinates, the
+  /// answer survives the widget that produced it.
+  ///
+  /// Re-derived on every tick the header IS mounted, so a text-scale change,
+  /// a rename, or a rewrapped overview moves the handover point without
+  /// anything having to invalidate this.
+  double? _titleHandoff;
+
+  void _syncCollapsedTitle() {
+    if (!mounted || !_scroll.hasClients) return;
+    final box = _headerTitleKey.currentContext?.findRenderObject();
+    if (box is RenderBox && box.attached) {
+      final viewport = RenderAbstractViewport.maybeOf(box);
+      if (viewport != null) {
+        // getOffsetToReveal, NOT localToGlobal against the viewport. A scroll
+        // listener runs from `ScrollPosition.setPixels`, BEFORE the frame that
+        // lays the viewport out at the new offset — so the render tree it can
+        // see is one layout stale, and a position read out of it is wrong by
+        // however far this notification just scrolled. A single-step drag of
+        // 380px measured the title as still sitting at the top and put the
+        // handover 387px late, which is exactly far enough that it never
+        // fired. This asks for the target's place in the SCROLL extent, which
+        // no scroll offset can stale: the offset at which its leading edge
+        // reaches the top, plus its own height, is the offset at which its
+        // last pixel leaves.
+        //
+        // No pinned-chrome subtraction is owed (unlike the Today scroll
+        // above): the header is the FIRST sliver, so nothing pinned precedes
+        // it and getOffsetToReveal's obstruction term is zero here.
+        _titleHandoff =
+            viewport.getOffsetToReveal(box, 0).offset + box.size.height;
+      }
+    }
+    final handoff = _titleHandoff;
+    // Nothing measured yet (the first tick can precede the header's layout).
+    // Leaving the bar as it is beats guessing: the header block is on screen
+    // in exactly that case, so the name is already showing somewhere.
+    if (handoff == null) return;
+    final past = _scroll.offset - handoff;
+    _titleCollapsed.value =
+        _titleCollapsed.value ? past > -_kTitleHandoffSlack : past >= 0;
   }
 
   // ── Freshness polling (specs/shared-trip-freshness) ───────────────────
@@ -3303,42 +3394,65 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
                   : const Icon(Icons.chat_bubble_outline),
             )
           : null,
-      appBar: GradientAppBar(
-        title: trip != null ? _displayTitle(trip) : l10n.tripTitleFallback,
-        actions: [
-          // This is the app's width-budget boss: five icons beside the brand
-          // fit at rail widths and nowhere near it on a phone. At narrow
-          // everything that is already a menu or a sheet folds into the
-          // overflow (see [_overflowAppBarAction]) and the icon row drops to
-          // TWO — health plus the `⋮` itself.
-          //
-          // Health is the one action that earns an icon on a phone: its
-          // severity count is a glanceable badge, and a badge inside a menu is
-          // a badge nobody sees. Everything else is one tap further away and
-          // the trip's NAME gets the ~48px back — at 375px that is the
-          // difference between "Big Su…" and a name you can read, which is
-          // what the traveler actually needed the header for.
-          //
-          // Refine used to hold an icon here at narrow — it is the header
-          // card's own Refine button relocated, since narrow drops it down
-          // there for one clean chip row. It now rides the `⋮` instead, and
-          // the header card must STAY as it is: putting its button back is
-          // what #457's chip row was tidying away.
-          if (trip != null) _healthAppBarAction(trip, theme),
-          if (trip != null && !_narrow) _wearAppBarAction(trip),
-          // Sharing is an owner-only surface; it mutates, so it's hidden
-          // while offline-serving.
-          if (trip != null && trip.isOwner && !_isOffline && !_narrow)
-            PopupMenuButton<TripAction>(
-              key: _shareMenuKey,
-              icon: const Icon(Icons.share_outlined),
-              tooltip: l10n.tripShareTrip,
-              onSelected: (action) => action.onSelected(),
-              itemBuilder: (context) =>
-                  tripActionPopupEntries(context, _shareActionSections(l10n)),
-            ),
-          if (trip != null) _overflowAppBarAction(trip, l10n),
-        ],
+      appBar: PreferredSize(
+        // GradientAppBar's own preferredSize with no `bottom`, restated
+        // because Scaffold has to know the bar's height before the builder
+        // below ever runs.
+        preferredSize: const Size.fromHeight(kToolbarHeight),
+        // Only the bar rebuilds when the title changes hands — see
+        // [_titleCollapsed] for why this is not a setState.
+        child: ValueListenableBuilder<bool>(
+          valueListenable: _titleCollapsed,
+          builder: (context, collapsed, _) => GradientAppBar(
+            // The handover is a cross-fade, not a swap: on a phone the
+            // wordmark yields as the name arrives, so the two states are
+            // different widgets rather than one string changing.
+            animateTitle: true,
+            // Null while the header block is still showing the name itself —
+            // which leaves the bar carrying the wordmark alone, the state
+            // GradientAppBar's ladder already had for Home and Landing. A
+            // trip that hasn't loaded has no header block to defer to, so it
+            // keeps the fallback.
+            title: trip == null
+                ? l10n.tripTitleFallback
+                : (collapsed ? _displayTitle(trip) : null),
+            actions: [
+              // This is the app's width-budget boss: five icons beside the
+              // brand fit at rail widths and nowhere near it on a phone. At
+              // narrow everything that is already a menu or a sheet folds into
+              // the overflow (see [_overflowAppBarAction]) and the icon row
+              // drops to TWO — health plus the `⋮` itself.
+              //
+              // Health is the one action that earns an icon on a phone: its
+              // severity count is a glanceable badge, and a badge inside a
+              // menu is a badge nobody sees. Everything else is one tap
+              // further away and the trip's NAME gets the ~48px back — at
+              // 375px that is the difference between "Big Su…" and a name you
+              // can read, which is what the traveler actually needed the
+              // header for.
+              //
+              // Refine used to hold an icon here at narrow — it is the header
+              // card's own Refine button relocated, since narrow drops it down
+              // there for one clean chip row. It now rides the `⋮` instead,
+              // and the header card must STAY as it is: putting its button
+              // back is what #457's chip row was tidying away.
+              if (trip != null) _healthAppBarAction(trip, theme),
+              if (trip != null && !_narrow) _wearAppBarAction(trip),
+              // Sharing is an owner-only surface; it mutates, so it's hidden
+              // while offline-serving.
+              if (trip != null && trip.isOwner && !_isOffline && !_narrow)
+                PopupMenuButton<TripAction>(
+                  key: _shareMenuKey,
+                  icon: const Icon(Icons.share_outlined),
+                  tooltip: l10n.tripShareTrip,
+                  onSelected: (action) => action.onSelected(),
+                  itemBuilder: (context) => tripActionPopupEntries(
+                      context, _shareActionSections(l10n)),
+                ),
+              if (trip != null) _overflowAppBarAction(trip, l10n),
+            ],
+          ),
+        ),
       ),
       body: _loading
           ? const Center(child: CircularProgressIndicator())
@@ -3497,6 +3611,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
                                     readOnly: _readOnly,
                                     panelOpen: _panelOpen,
                                     displayTitle: _displayTitle(trip),
+                                    titleKey: _headerTitleKey,
                                     overview: _overviewText(trip),
                                     onEditDetails: _editTripDetails,
                                     onEditDates: _editDates,

--- a/src/packages/flutter-app/lib/theme/app_colors.dart
+++ b/src/packages/flutter-app/lib/theme/app_colors.dart
@@ -121,6 +121,32 @@ abstract final class AppColors {
   static Color get neutralSolid => Colors.white;
   static Color get onNeutralSolid => brandDark;
 
+  // The brand-tinted panel: a quiet teal field carrying brand ink, for a
+  // block that is guidance rather than an alarm (the Next Step card, the
+  // preferences screen's selected chips).
+  //
+  // Brightness-aware because [brandTint] is teal-50 — a genuinely light
+  // paper, correct on paper and a light block punched into a dark page
+  // anywhere else. Dark takes the scheme's own primary container, which is
+  // seeded from the same teal, so the pair tracks the seed instead of
+  // pinning a second hand-picked dark teal. Light is byte-identical to the
+  // constants these replaced: this fixes dark mode and changes nothing else.
+  //
+  // Three roles, not two, because the light block is deliberately two-tone —
+  // [brand] as the leading-icon accent under [brandDark] text. Dark has no
+  // such pair to preserve (`onPrimaryContainer` is the only legible ink on
+  // `primaryContainer`), so accent and ink converge there.
+  static Color brandTintFill(ColorScheme scheme) =>
+      scheme.brightness == Brightness.dark
+          ? scheme.primaryContainer
+          : brandTint;
+  static Color onBrandTint(ColorScheme scheme) =>
+      scheme.brightness == Brightness.dark
+          ? scheme.onPrimaryContainer
+          : brandDark;
+  static Color brandTintAccent(ColorScheme scheme) =>
+      scheme.brightness == Brightness.dark ? scheme.onPrimaryContainer : brand;
+
   // Status-strip marks (the Health pane's 90-day uptime history,
   // specs/uptime-history). Solid and brightness-aware: the container pairs
   // above are 15-20% alpha — right for a pill on a card, invisible as a 3px

--- a/src/packages/flutter-app/lib/theme/app_typography.dart
+++ b/src/packages/flutter-app/lib/theme/app_typography.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/material.dart';
+
 /// The app's three typefaces and what each one is for.
 ///
 /// Naming them here means a face swap is one edit instead of a grep, and — the
@@ -25,4 +27,38 @@ abstract final class AppFonts {
   /// The brand wordmark, and nothing else. Cinzel has no true lowercase, so
   /// any text set in it paints as small caps.
   static const wordmark = 'Cinzel';
+}
+
+/// Composed styles that name a REGISTER the `textTheme` slots don't have a
+/// slot for. One entry so far, and it is here because two screens reached for
+/// it independently and had already drifted.
+abstract final class AppTextStyles {
+  /// The display face at title size — the step between a page headline and a
+  /// title.
+  ///
+  /// A headline slot outright (26/30/34) is a PAGE title: it owns the top of a
+  /// screen and sets its own rhythm. This register is for a heading that has
+  /// to stay chrome — a city header that PINS while its days scroll under it,
+  /// the trip's name sitting as a compact anchor over its own metadata. Both
+  /// wanted "the heading face, but it must not inflate into a hero", and both
+  /// said so in their own comments.
+  ///
+  /// Composed from two existing slots rather than written as literals:
+  /// `headlineSmall` contributes the face and its explicit `w400` (Marcellus
+  /// ships in ONE weight — anything else is faux-bold on web), `titleLarge`
+  /// contributes the size. So a face swap or a scale change in
+  /// `app_theme.dart` still reaches every heading in this register, and no
+  /// number lives here but the line height.
+  ///
+  /// Minted because it was already being spelled two ways: the itinerary's
+  /// city header composed exactly this, while the trip header card arrived
+  /// from the other direction (`titleLarge` + `fontFamily` + `w400`) and so
+  /// carried M3's titleLarge line height instead of the headline register's
+  /// 1.2. Same intent, two routes, one already-drifted property — which is
+  /// the case for a token rather than a third inline composition.
+  static TextStyle? sectionHeading(TextTheme textTheme) =>
+      textTheme.headlineSmall?.copyWith(
+        fontSize: textTheme.titleLarge?.fontSize,
+        height: 1.2,
+      );
 }

--- a/src/packages/flutter-app/lib/widgets/gradient_app_bar.dart
+++ b/src/packages/flutter-app/lib/widgets/gradient_app_bar.dart
@@ -153,6 +153,21 @@ class GradientAppBar extends ConsumerWidget implements PreferredSizeWidget {
   /// everything outside it is not tappable at all — see [ShellScope].
   final VoidCallback? onBrandTap;
 
+  /// Cross-fade the title row when [title] appears or disappears, instead of
+  /// swapping it outright.
+  ///
+  /// For a page that hands its title to this bar only once its own copy has
+  /// scrolled away (trip detail's collapse). The two states are different
+  /// WIDGETS, not one string changing — on a phone the ladder below has the
+  /// wordmark yield as the title arrives — so this cannot be an opacity on
+  /// the Text; both sides have to be measured and cross-faded.
+  ///
+  /// Opt-in, and default false, so a bar whose title never changes is
+  /// byte-identical to before: an AnimatedSwitcher that never switches still
+  /// inserts a Stack into every app bar in the app, and this is not worth
+  /// spending on twenty screens with static titles.
+  final bool animateTitle;
+
   const GradientAppBar({
     super.key,
     this.title,
@@ -160,6 +175,7 @@ class GradientAppBar extends ConsumerWidget implements PreferredSizeWidget {
     this.centerTitle,
     this.bottom,
     this.onBrandTap,
+    this.animateTitle = false,
   });
 
   @override
@@ -241,6 +257,36 @@ class GradientAppBar extends ConsumerWidget implements PreferredSizeWidget {
     final railCarriesMark =
         inShell && MediaQuery.sizeOf(context).width >= kRailBreakpoint;
 
+    // railCarriesMark is passed down rather than recomputed: it is the same
+    // fact the leading slot below turns on, and the ladder needs it to know
+    // whether the wordmark is the bar's ONLY brand (rail widths) or has a
+    // rose standing beside it.
+    Widget titleRow = _BrandTitle(
+        title: title, onTap: onTap, railCarriesMark: railCarriesMark);
+
+    if (animateTitle) {
+      titleRow = AnimatedSwitcher(
+        duration: const Duration(milliseconds: 180),
+        switchInCurve: Curves.easeOut,
+        switchOutCurve: Curves.easeIn,
+        // Opacity alone. AnimatedSwitcher's default pairs the fade with a
+        // scale, which on a 22px inscriptional serif reads as a wobble.
+        transitionBuilder: (child, animation) =>
+            FadeTransition(opacity: animation, child: child),
+        // The default layout stacks children CENTRED, which would slide the
+        // row horizontally for the length of the transition — and the whole
+        // point of this bar is that the title row's left edge does not move.
+        layoutBuilder: (current, previous) => Stack(
+          alignment: AlignmentDirectional.centerStart,
+          children: [...previous, if (current != null) current],
+        ),
+        // Keyed on PRESENCE, not on the string: this animates the title
+        // arriving and leaving, and a page that renames itself in place still
+        // just repaints.
+        child: KeyedSubtree(key: ValueKey(title != null), child: titleRow),
+      );
+    }
+
     return AppBar(
       // Non-null exactly when AppBar would have left this empty. That is what
       // holds the wordmark still across a navigation.
@@ -261,12 +307,7 @@ class GradientAppBar extends ConsumerWidget implements PreferredSizeWidget {
       // from whatever precedes it, and on a phone those 16px are worth more as
       // title width. See [_titleEndGap] for what this costs on the other side.
       titleSpacing: 0,
-      // railCarriesMark is passed down rather than recomputed: it is the same
-      // fact the leading slot above turns on, and the ladder needs it to know
-      // whether the wordmark is the bar's ONLY brand (rail widths) or has a
-      // rose standing beside it.
-      title: _BrandTitle(
-          title: title, onTap: onTap, railCarriesMark: railCarriesMark),
+      title: titleRow,
       actions: actions,
       centerTitle: centerTitle ?? false,
       bottom: bottom,

--- a/src/packages/flutter-app/lib/widgets/next_step_card.dart
+++ b/src/packages/flutter-app/lib/widgets/next_step_card.dart
@@ -125,9 +125,16 @@ class NextStepCard extends StatelessWidget {
   Widget _buildStep(BuildContext context, NextStep s) {
     final theme = Theme.of(context);
     final l10n = context.l10n;
+    // The tinted-panel family, resolved once per build. Fixed light constants
+    // here painted teal-50 under teal-900 text in BOTH themes, so dark mode
+    // opened on a light mint block; the pair now tracks the brightness (and,
+    // in dark, the seed) — see [AppColors.brandTintFill].
+    final scheme = theme.colorScheme;
+    final tintFill = AppColors.brandTintFill(scheme);
+    final tintInk = AppColors.onBrandTint(scheme);
 
     final eyebrowStyle = theme.textTheme.labelSmall?.copyWith(
-      color: AppColors.brandDark,
+      color: tintInk,
       fontWeight: FontWeight.w600,
       letterSpacing: 0.8,
     );
@@ -160,7 +167,7 @@ class NextStepCard extends StatelessWidget {
                 // two lines beside the action button, and the counter is the
                 // one thing here that must never be clipped away.
                 Flexible(child: eyebrowText),
-                Icon(Icons.expand_more, size: 14, color: AppColors.brandDark),
+                Icon(Icons.expand_more, size: 14, color: tintInk),
               ],
             ),
           ),
@@ -173,7 +180,7 @@ class NextStepCard extends StatelessWidget {
       key: const ValueKey('next-step-card'),
       margin: const EdgeInsets.only(top: AppSpacing.md),
       decoration: BoxDecoration(
-        color: AppColors.brandTint,
+        color: tintFill,
         borderRadius: AppRadius.mdAll,
       ),
       // The whole card is the primary action; the trailing button is the
@@ -186,7 +193,7 @@ class NextStepCard extends StatelessWidget {
           child: Row(
             children: [
               Icon(_kindIcons[s.kind] ?? Icons.place_outlined,
-                  color: AppColors.brand, size: 24),
+                  color: AppColors.brandTintAccent(scheme), size: 24),
               const SizedBox(width: AppSpacing.md),
               Expanded(
                 child: Column(
@@ -199,7 +206,7 @@ class NextStepCard extends StatelessWidget {
                       maxLines: 2,
                       overflow: TextOverflow.ellipsis,
                       style: theme.textTheme.titleSmall?.copyWith(
-                        color: AppColors.brandDark,
+                        color: tintInk,
                         fontWeight: FontWeight.w600,
                       ),
                     ),
@@ -210,7 +217,7 @@ class NextStepCard extends StatelessWidget {
                         maxLines: 1,
                         overflow: TextOverflow.ellipsis,
                         style: theme.textTheme.bodySmall?.copyWith(
-                          color: AppColors.brandDark.withValues(alpha: 0.85),
+                          color: tintInk.withValues(alpha: 0.85),
                         ),
                       ),
                     ],

--- a/src/packages/flutter-app/lib/widgets/trip_detail/trip_header_card.dart
+++ b/src/packages/flutter-app/lib/widgets/trip_detail/trip_header_card.dart
@@ -28,6 +28,12 @@ class TripHeaderCard extends ConsumerStatefulWidget {
   final bool readOnly;
   final bool panelOpen;
   final String displayTitle;
+
+  /// Attached to the title Text so the screen can measure where it sits and
+  /// hand the name to the app bar once it has scrolled away. Optional: the
+  /// card renders identically without one, and nothing here reads it.
+  final GlobalKey? titleKey;
+
   final String? overview;
   final VoidCallback onEditDetails;
   final VoidCallback onEditDates;
@@ -46,6 +52,7 @@ class TripHeaderCard extends ConsumerStatefulWidget {
     required this.readOnly,
     required this.panelOpen,
     required this.displayTitle,
+    this.titleKey,
     required this.overview,
     required this.onEditDetails,
     required this.onEditDates,
@@ -105,14 +112,21 @@ class _TripHeaderCardState extends ConsumerState<TripHeaderCard> {
             Expanded(
               child: Text(
                 widget.displayTitle,
-                // Same string as the app bar directly above, so same face —
-                // but keeping titleLarge's size, because this block is a
-                // compact anchor and headlineSmall would inflate it into the
-                // hero panel the comment above rules out.
-                style: theme.textTheme.titleLarge?.copyWith(
-                  fontFamily: AppFonts.display,
-                  fontWeight: FontWeight.w400,
-                ),
+                // Keyed so the screen can measure when this title has scrolled
+                // out from under the app bar and take the name over up there
+                // (the collapse). The key rides in from the screen because the
+                // screen is what owns the scroll listener; this widget only
+                // has to hand it the render object.
+                key: widget.titleKey,
+                // The heading face at title size — the same register the
+                // itinerary's pinned city headers take, now stated once in
+                // [AppTextStyles.sectionHeading]. This block is a compact
+                // anchor, so it must not inflate into the hero panel the
+                // comment above rules out; that is exactly what the register
+                // means. Reached this style via titleLarge + fontFamily before
+                // the token, which silently kept M3's titleLarge line height
+                // rather than the headline register's 1.2.
+                style: AppTextStyles.sectionHeading(theme.textTheme),
                 maxLines: 1,
                 overflow: TextOverflow.ellipsis,
               ),
@@ -309,10 +323,14 @@ class _TripHeaderCardState extends ConsumerState<TripHeaderCard> {
   /// first. Flat, not elevated — the post-#494 doctrine, and a shadow here
   /// would put the SECONDARY entry above the primary one in depth.
   ///
-  /// Deliberately NOT merged into the tinted panel itself: [NextStepCard]
-  /// paints a fixed light `brandTint`, so a shared field would have to be that
-  /// same light tint and dark mode would gain a light block twice the size.
-  /// Sequence, not fusion.
+  /// Deliberately NOT merged into the tinted panel itself. The original reason
+  /// was that [NextStepCard] painted a fixed light `brandTint` in both themes,
+  /// so a shared field would have doubled that light block in dark mode; the
+  /// tint is brightness-aware now ([AppColors.brandTintFill]), so that
+  /// particular hazard is gone. The decision stands on the other half of its
+  /// rationale: these are two jobs — "what to do next" and "where you left
+  /// off" — and one tinted field would give the quieter one the emphasis of
+  /// the louder. Sequence, not fusion.
   Widget _continueChatRow(ThemeData theme, AppLocalizations l10n) {
     final trip = widget.trip;
     final chat = trip.refineChat;

--- a/src/packages/flutter-app/test/trip_detail_narrow_header_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_narrow_header_test.dart
@@ -10,6 +10,7 @@ import 'package:travel_route_planner/services/api_client.dart';
 import 'package:travel_route_planner/services/trips_api_service.dart';
 import 'package:travel_route_planner/providers/trips_provider.dart';
 import 'package:travel_route_planner/screens/trip_detail_screen.dart';
+import 'package:travel_route_planner/widgets/trip_detail/trip_header_card.dart';
 import 'package:travel_route_planner/widgets/trip_refine_panel.dart';
 
 import 'support/l10n_test_app.dart';
@@ -190,9 +191,96 @@ void main() {
     expect(find.descendant(of: bar, matching: find.byIcon(Icons.more_vert)),
         findsOneWidget);
 
-    // And the point of the budget: the trip's name is up there, whole.
-    final title = find.descendant(of: bar, matching: find.text('Sevilla week'));
-    expect(title, findsOneWidget);
+    // The name is up there whole once it is the bar's job to show it — which
+    // at rest it is not. The header block owns the name until its own copy
+    // scrolls away (see the handover test below); the two used to render it
+    // ~60px apart at the same time. The width budget this test enumerates is
+    // what makes the handed-over name readable rather than "Big Su…".
+    expect(find.descendant(of: bar, matching: find.text('Sevilla week')),
+        findsNothing,
+        reason: 'the header block owns the name at rest');
+    expect(
+      find.descendant(
+          of: find.byType(TripHeaderCard), matching: find.text('Sevilla week')),
+      findsOneWidget,
+    );
+    expect(tester.takeException(), isNull);
+  });
+
+  // The collapse (TripAdvisor's trip-page move): the header block's title is
+  // the one on screen at rest, and the app bar takes the name over only once
+  // that copy has scrolled out from under it. Its own fixture, because the
+  // action-budget trip above is one item long and its page does not scroll —
+  // AlwaysScrollableScrollPhysics lets a drag overscroll and spring straight
+  // back, so a handover assertion there would have been vacuous.
+  testWidgets('the header title hands the name to the app bar on scroll',
+      (tester) async {
+    // Item shape borrowed from trip_detail_sticky_headers_test: zero coords so
+    // the screen skips the map widget, and undated so no events/weather rail
+    // is fetched — this test is about the title, and the rest is just the
+    // scroll extent it needs.
+    final tall = Trip(
+      id: 't1',
+      title: 'Sevilla week',
+      createdAt: '2026-06-01',
+      updatedAt: '2026-06-01',
+      items: [
+        for (var k = 0; k < 6; k++)
+          ItineraryItem(
+            id: 'i$k',
+            position: k,
+            name: 'Sevilla stop $k',
+            address: 'Stop $k street, Sevilla',
+            latitude: 0,
+            longitude: 0,
+            category: 'attraction',
+            day: 1,
+            city: 'Sevilla',
+          ),
+        for (var k = 0; k < 6; k++)
+          ItineraryItem(
+            id: 'j$k',
+            position: 6 + k,
+            name: 'Cordoba stop $k',
+            address: 'Stop $k street, Cordoba',
+            latitude: 0,
+            longitude: 0,
+            category: 'attraction',
+            day: 2,
+            city: 'Cordoba',
+          ),
+      ],
+    );
+    await _pump(tester, tall, surface: phone);
+
+    final bar = find.byType(AppBar);
+    final headerTitle = find.descendant(
+        of: find.byType(TripHeaderCard), matching: find.text('Sevilla week'));
+    final barTitle =
+        find.descendant(of: bar, matching: find.text('Sevilla week'));
+
+    expect(barTitle, findsNothing);
+    expect(headerTitle, findsOneWidget);
+
+    // Dragged from inside the header block, above the map band — a vertical
+    // drag started over the map is the map's, not the page's.
+    await tester.dragFrom(const Offset(195, 200), const Offset(0, -400));
+    await tester.pumpAndSettle();
+
+    // Premise first: without this the handover assertion would pass vacuously
+    // on a build where the drag scrolled nothing. Asserted as the header copy
+    // being GONE rather than as a smaller dy — the header sliver unmounts once
+    // it is fully off screen, so there is nothing left to measure.
+    expect(headerTitle, findsNothing,
+        reason: 'the drag did not scroll the header block away');
+    expect(barTitle, findsOneWidget,
+        reason: 'the bar takes the name once the header copy has gone');
+
+    // ...and hands it back on the way up, so the name is never in both places.
+    await tester.dragFrom(const Offset(195, 400), const Offset(0, 600));
+    await tester.pumpAndSettle();
+    expect(barTitle, findsNothing);
+    expect(headerTitle, findsOneWidget);
     expect(tester.takeException(), isNull);
   });
 


### PR DESCRIPTION
## Summary

Wave 3 of the trip-detail redesign — the three header-family follow-ups logged by the wave-2 lanes. Reference: TripAdvisor's trip page (Mobbin), held to `design-inspiration` + `brand-guidelines`.

- **The trip name renders once at a time.** It used to render twice ~60px apart — app bar *and* the first line of the header block. The header block owns it at rest; the bar takes it over once that copy has scrolled out from under it, and hands it back on the way up. The pinned tab row is untouched in both states.
- **`NextStepCard`'s tint follows the theme.** It painted a fixed light `brandTint` under teal-900 ink in *both* themes, so dark mode opened on a light mint block. Now a brightness-aware trio in `AppColors` (fill / ink / accent).
- **`AppTextStyles.sectionHeading` minted** and adopted in the header card.

### Decision: the section-heading token — minted, not closed

The composition was already spelled two ways and had **already drifted**:

| site | route | result |
|---|---|---|
| `itinerary_tab.dart` city header | `headlineSmall` + `titleLarge`'s size | Marcellus w400, 22, height **1.2** |
| `trip_header_card.dart` trip title | `titleLarge` + `fontFamily` + `w400` | Marcellus w400, 22, height **~1.27** (M3) |

Same intent, two routes, one divergent property — the case for a token, not a third inline composition. The header card adopts it. The itinerary inherits on next touch: that is a **one-line import**, because `trip_detail_screen.dart` (its `part` library) imports `app_colors` and `spacing` but not `app_typography` — which is the constraint the itinerary lane actually hit, not "a `part` file can't import". Not added here: nothing in the library would use it yet and an unused import is an analyzer warning.

### Decision: full collapse, not the narrowed scroll-fade

The sliver math never got risky, because **the app bar is not a sliver** — it is the Scaffold's `appBar`, outside the `CustomScrollView`. The screen only decides *when* to hand over.

The body copy had to stay: `gradient_app_bar.dart` documents that its ladder **drops a page title outright** when the row can't hold it, and names trip detail as the screen that covers for that by repeating the title below. So "collapse" = the bar defers, not that the header gives its title up.

Side effect worth naming: at rest the bar now falls into the ladder's `title == null` branch, so on a phone it carries the **wordmark** — where before the trip name displaced it entirely.

### Two bugs the tests caught

Both from measuring a moving thing; both found by assertions written to be non-vacuous:

1. **The measurement stops existing.** The header is a plain `SliverToBoxAdapter`, so past the cache extent it *unmounts* and its `GlobalKey` has no context — a fast fling scrolled it away and the bar never took over.
2. **A scroll listener sees a stale layout.** It runs from `ScrollPosition.setPixels`, *before* the frame that lays the viewport out at the new offset, so `localToGlobal` against the viewport is wrong by however far the notification just scrolled. A single-step 380px drag measured the title as still at the top and put the handover **387px late**.

Fixed by caching the handoff as `getOffsetToReveal + height` in **scroll coordinates** — an answer no stale layout spoils and no unmount takes away. 12px hysteresis so an overscroll settling on the boundary can't flip the bar back and forth.

Rebuild cost is confined to the bar: a `ValueNotifier` + `ValueListenableBuilder`, never `setState` — this screen's scroll performance is a fixed bug (#352/#353).

### Shared-widget change, declared

`gradient_app_bar.dart` is outside the ticket's "may edit" list (not in its "must not touch" list). It gains **one opt-in field**, `animateTitle`, default `false` — the other twenty screens are provably byte-identical. It is needed because the handover is not one string changing: the wordmark yields as the name arrives, so the two states are different *widgets*, and an opacity on the `Text` would have rendered the phone bar **empty** at rest. Conflict risk checked first: `gh pr list` showed **zero** open PRs, and the header-family PRs that previously touched this file (#466, #468) are merged.

### Not fixed, deliberately

`NextStepCard`'s `all_set` variant takes `successContainer` / `onSuccessContainer`. Its fill is alpha green (fine on dark) but its ink is `green.shade800` — a **real** dark-mode contrast problem. It is **app-wide**: the same pair paints booked checkmarks (`booking_todo_card.dart`, a sibling lane's file this wave), Planned pills and published counts. Changing it here would restyle three surfaces blind. Logged for a follow-up.

## Testing

- `flutter analyze` — clean. The 3 remaining `unnecessary_brace_in_string_interps` are pre-existing in `lib/models/route_response.dart`, untouched by this branch.
- `flutter test` — **`03:05 +1714: All tests passed!`** (full suite, literal summary line).
  - Earlier runs reported 5–13 failures that were all `loading … [E]` / `TimeoutException after 0:12:00` with a *different* file set each run — host starvation from concurrent sibling-lane suites (load average peaked at 98). They cleared at load 4 with no code change.
- **Brand check** — 1 finding, pre-existing and not in this diff: `trip_detail_screen.dart:4149` `Radius.circular(16)` on the refine sheet's top corners.
- **Real browser, both themes, both widths** — headless Chrome against the lane stack with a seeded trip. Before-frames shot by stashing the branch, restarting the dev container, reshooting and popping; every before/after pair hash-diffed to prove the frames differ. Artifacts: `trip-detail-redesign/wave3-header-cleanup/before-after.md`.
  - Phone dark at rest is the one frame carrying both fixes: before shows the duplicated title *and* the light mint block; after shows the wordmark, one title, and a deep-teal panel.
  - Light mode is byte-identical by construction — each new accessor's light branch returns the exact constant it replaced.

## Test changes

`trip_detail_narrow_header_test.dart` pinned "the trip's name is up there, whole" at rest — now the wrong *moment*, not the wrong claim. It asserts the at-rest split instead, and a new test walks the handover down **and back**, with a premise assertion that the drag actually scrolled. That premise fired on both bugs above rather than passing vacuously.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/golden-tempo/codesmith/anemos-travel/pr/506"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789746366&installation_model_id=433099&pr_number=506&repository=golden-tempo%2Fanemos-travel&return_to=https%3A%2F%2Fgithub.com%2Fgolden-tempo%2Fanemos-travel%2Fpull%2F506&signature=a5ca1e3667da566fcef7025dba7461a3099d630b2dd2736086128ea68eb8a2cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->