### PR TITLE
chore(integrate): assert a run exists for main's tip

### DIFF
--- a/.claude/skills/integrate/SKILL.md
+++ b/.claude/skills/integrate/SKILL.md
@@ -167,6 +167,14 @@ cancelled ones would have shipped. Tell the two apart by the jobs list, not the
 badge — `gh run view <id> --json jobs --jq '.jobs|length'` returns `0` for a
 superseded run and non-zero for one that actually ran and broke.
 
+**A run that was never created is a THIRD state, and the jobs check cannot see
+it** — there is no run to inspect. Observed 2026-08-19: three merges 5–6 seconds
+apart produced runs for only the first two; main's tip had **zero** check-runs.
+It is not the superseded case — main's concurrency keeps the newest *pending*
+run, so a run for the tip would have cancelled its predecessor; instead the
+predecessor survived and ran. Merging back-to-back is what this loop encourages,
+so this window is one the loop actively creates. Step 6.1 is the check for it.
+
 The consequence: **a wave is only verified when its LAST deploy succeeds.**
 Intermediate `cancelled` runs prove nothing either way, so step 6's accounting
 is load-bearing rather than a formality.
@@ -211,14 +219,71 @@ run, which would redeploy an old SHA.
 
 When the queue is empty: `git checkout main && git pull`, then
 `make wt-rm NAME=<lane>` for each merged lane (from the main checkout — it
-deletes the lane's worktree and branch), and report the wave summary — PRs
-merged, and **the wave's final deploy watched to a green finish**
-(`gh run watch <id> --exit-status`), since that is the run that actually ships
-every merge in the wave. Superseded `cancelled` runs are expected and need no
-action; a `failure` at any point does. Confirm prod serves the new SHA —
-`/health` `release` or `/app/version.json` — before declaring the wave done.
-This accounting is what step 3's per-merge watch was traded for, so it is the
-one deploy check that must not be skipped.
+deletes the lane's worktree and branch). Then the deploy accounting below, which
+is what step 3's per-merge watch was traded for and is the one deploy check that
+must not be skipped.
+
+### 6.1 Assert a run EXISTS for main's tip — before watching anything
+
+**Never assume the newest run corresponds to the tip.** Resolve the tip's SHA
+and ask for *its* runs by SHA, not by recency:
+
+```bash
+git fetch origin -q
+SHA=$(git rev-parse origin/main)
+gh api "repos/golden-tempo/anemos-travel/commits/$SHA/check-runs" --jq .total_count
+```
+
+`0` means no workflow was ever created for that push. Poll for a minute before
+concluding it (run creation is not instant), then treat it as a **stop**, not a
+formality: this is the state step 3 describes, and no amount of inspecting the
+newest run will reveal it — that run is green and belongs to a different commit.
+
+Why the distinction is load-bearing rather than pedantic: `build-push` tags
+images `ghcr.io/...:${{ github.sha }}` and `deploy` uses
+`IMAGE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.image_tag || github.sha }}`.
+**A run ships its OWN commit, not main's tip.** So a missing run for the tip
+means the last merged PR is on main and not in production, with every check
+green and nothing to notice.
+
+**`workflow_dispatch` cannot repair it.** Its `image_tag` input requires the SHA
+of *a previously green main build*, and `build-push` is gated
+`if: github.event_name == 'push'`, so dispatch never builds. No image exists for
+the tip. The remedy is a push event that never happened:
+
+```bash
+git commit --allow-empty -m "chore(ci): trigger the deploy main's tip never got"
+git push origin main
+```
+
+Do it **after** any in-flight deploy completes, so deploy order stays clean, and
+only once that one is green — a failure still stops the queue. Then re-run the
+check above and confirm the count is non-zero before moving on.
+
+### 6.2 Watch that run to a green finish — but do not trust the exit code
+
+`gh run watch <id> --exit-status` is the natural spelling and has misreported
+twice in one day: piped (`| tail`) it returns the **pipe's** exit code, and
+unpiped it returned `1` on a run that concluded `success` (a transient
+`api.github.com` timeout during the watch, not a red deploy). Read the verdict
+from the run itself:
+
+```bash
+until [ "$(gh run view <id> --json status --jq .status)" = completed ]; do sleep 25; done
+gh run view <id> --json conclusion --jq .conclusion      # this is the answer
+gh run view <id> --json jobs --jq '.jobs[] | "\(.name): \(.conclusion)"'
+```
+
+Superseded `cancelled` runs are expected and need no action; a `failure` does.
+
+### 6.3 Confirm production actually serves the tip
+
+`/health` `release` or `/app/version.json` must equal `git rev-parse HEAD`.
+This is the only step that speaks for what is really running, and it is what
+catches 6.1's failure mode even if every other check was skipped.
+
+Then report the wave summary: PRs merged, the path each took, and the deploy
+that shipped them.
 
 ## Notes
 

--- a/docs/friction-log.md
+++ b/docs/friction-log.md
@@ -5,6 +5,39 @@ build queue. Priority when picking work: **breakage > friction in features
 actually used > ideas that recur across ≥2 sessions**. Tag entries `[app]`
 (dogfooding the product) or `[dev]` (workflow/tooling). Newest first.
 
+## 2026-08-19 — a push that produced no workflow run at all
+
+- **[dev] Breakage:** wave 3's three merges (#504/#505/#506) landed 5-6 seconds
+  apart and GitHub created runs for only the **first two**. Main's tip —
+  `5579282`, the #506 merge — had **zero** check-runs. Prod deployed `5c5496b`
+  and sat one PR behind with every check green and nothing to notice.
+- **[dev] It is not the superseded case, and the recorded test says so.** Main's
+  concurrency keeps the newest *pending* run, so a run for the tip would have
+  cancelled #505's pending run. Instead #505's survived and ran — meaning
+  nothing was superseded, a run was simply never created. The
+  `gh run view --json jobs | length == 0` test for "superseded vs broken"
+  structurally cannot see this: there is no run to inspect.
+- **[dev] Why one missing run silently drops a PR from prod:** `build-push` tags
+  images `ghcr.io/...:${{ github.sha }}` and `deploy` defaults `IMAGE_TAG` to
+  the same. **A run ships its OWN commit, not main's tip.** So "the newest run
+  is green" and "the tip is deployed" are different claims, and only the second
+  one matters.
+- **[dev] `workflow_dispatch` cannot repair it** — its `image_tag` input wants
+  the SHA of a previously green main build, and `build-push` is gated
+  `if: github.event_name == 'push'`, so dispatch never builds. No image exists
+  for the missing SHA. The remedy is an empty commit to recreate the push event,
+  pushed only after any in-flight deploy is green.
+- **[dev] `gh run watch --exit-status` misreported twice in one day.** Piped to
+  `tail` it returns the pipe's exit code (the `flutter test | tail` trap, again);
+  unpiped it returned `1` on a run that concluded `success`, from a transient
+  `api.github.com` timeout mid-watch. Read
+  `gh run view <id> --json conclusion` instead — an `until status == completed`
+  loop plus the conclusion is the only spelling that answered correctly.
+- **[dev] Encoded in `/integrate` step 6**, now three explicit sub-steps: assert
+  a run exists **for main's tip by SHA** (never by recency) → watch it and read
+  the conclusion → confirm prod serves that SHA. The window is one the loop
+  actively creates: merging back-to-back is exactly what it encourages.
+
 ## 2026-08-18 — /integrate charged every PR the conflict price
 
 - **[dev] Friction:** Brian — *"I think perhaps the /integrate skill has more

--- a/docs/parallel-dev.md
+++ b/docs/parallel-dev.md
@@ -214,10 +214,26 @@ check `gh run view <id> --json jobs`: `0` jobs means superseded, not broken.
 The surviving run builds a main that already contains the cancelled runs'
 commits.
 
-So the wave is verified by its **last** deploy, not by each one: watch that
-run to green and confirm prod serves the new SHA before calling the wave
-done. Not blocking is a bet that deploys usually pass, never a reason to skip
-that final check.
+**A run that was never created is a third state, and the jobs check cannot see
+it.** On 2026-08-19 three merges 5-6 seconds apart produced runs for only the
+first two; main's tip had zero check-runs. It is not the superseded case — the
+concurrency group keeps the newest *pending* run, so a run for the tip would
+have cancelled its predecessor, and instead the predecessor survived and ran.
+This matters because `build-push` tags images with `github.sha` and `deploy`
+defaults `IMAGE_TAG` to the same: **a run ships its own commit, not main's
+tip**, so a missing run leaves the last merged PR on main and out of
+production with every check green. `workflow_dispatch` cannot repair it (its
+`image_tag` needs an already-built image and `build-push` is push-only); the
+remedy is an empty commit to recreate the push event.
+
+So the wave is verified by its **last** deploy, not by each one — and "last"
+means *the run whose head SHA equals main's tip*, asserted by SHA rather than
+by recency (`gh api repos/<owner>/<repo>/commits/$(git rev-parse origin/main)/check-runs`),
+never by picking the newest run off the list. Watch it to green, read the
+verdict from `gh run view --json conclusion` rather than `gh run watch
+--exit-status` (which has misreported in both directions), and confirm prod
+serves the new SHA before calling the wave done. Not blocking is a bet that
+deploys usually pass, never a reason to skip that final check.
 
 Who fixes a red check: **the integrator fixes anything integration created**
 (hub resolution, cross-lane contract parity, codegen drift, fmt);


### PR DESCRIPTION
Wave 3 (#504/#505/#506) merged clean in 11 seconds, then **only two of the three merges got a workflow run.** Main's tip — `5579282`, the #506 merge — had **zero** check-runs. Prod deployed `5c5496b` and sat one PR behind, with every check green and nothing to notice.

## Why the existing check couldn't see it

Step 3 teaches one abnormal deploy state — `cancelled` meaning superseded — and distinguishes it with `gh run view --json jobs --jq '.jobs|length'`. That test is structurally blind here: **there is no run to inspect.**

It also wasn't the superseded case, and the concurrency rule proves it. Main keeps the newest *pending* run, so a run for the tip would have cancelled #505's pending run. Instead #505's survived and ran — nothing was superseded, a run was simply never created.

## Why one missing run drops a PR from production

`build-push` tags images `ghcr.io/...:${{ github.sha }}` and `deploy` uses `IMAGE_TAG: ${{ ... || github.sha }}`. **A run ships its OWN commit, not main's tip.** So "the newest run is green" and "the tip is deployed" are different claims, and only the second one matters.

`workflow_dispatch` can't repair it: `image_tag` wants the SHA of a previously green main build, and `build-push` is gated `if: github.event_name == 'push'`, so dispatch never builds. No image exists for the missing SHA. The remedy is an empty commit recreating the push event — done here as `f41eb10`.

## What changed

Step 6 becomes three explicit sub-steps:

- **6.1 — assert a run exists for main's tip, by SHA, never by recency.** `gh api repos/.../commits/$(git rev-parse origin/main)/check-runs --jq .total_count`. Zero is a stop, not a formality. Includes the empty-commit remedy and the rule to apply it only after any in-flight deploy is green.
- **6.2 — watch it, but don't trust the watcher.** `gh run watch --exit-status` misreported twice in one day: piped to `tail` it returns the pipe's exit code (the `flutter test | tail` trap again), and unpiped it returned `1` on a run that concluded `success` — a transient `api.github.com` timeout mid-watch. Read `gh run view --json conclusion`.
- **6.3 — confirm prod serves that SHA.** The only step that speaks for what is really running.

Step 3 names the missing-run case as a third state and points at 6.1. Mirrored into `docs/parallel-dev.md` §6, plus a friction-log entry.

## Verification

The check was dry-run in both directions against real commits:

| Commit | `check-runs` total | Outcome |
|---|---|---|
| `f41eb10` (current tip) | 4 | passes |
| `5579282` (the tip that had no run) | 0 | **would have stopped the close-out** |

Docs and skills only — no Go or Dart touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/golden-tempo/codesmith/anemos-travel/pr/507"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789749277&installation_model_id=433099&pr_number=507&repository=golden-tempo%2Fanemos-travel&return_to=https%3A%2F%2Fgithub.com%2Fgolden-tempo%2Fanemos-travel%2Fpull%2F507&signature=8eaf762c69149ef10f3eacb1903dd369e4dd4c5404f20f7bcdcf280d378c9cea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->