### PR TITLE
feat(trips): the travel atlas behind "Your travels — See all"

### DIFF
--- a/src/packages/flutter-app/lib/l10n/app_en.arb
+++ b/src/packages/flutter-app/lib/l10n/app_en.arb
@@ -2745,5 +2745,26 @@
   "splashLoading": "Loading",
   "@splashLoading": {
     "description": "Screen-reader label on the boot splash's breathing-dots loading signal. The dots themselves are decorative; this is the only text the loading state speaks."
+  },
+  "travelAtlasSeeAll": "See all",
+  "@travelAtlasSeeAll": {
+    "description": "Action on the \"Your travels\" section header that opens the travel atlas. Rendered only once the account has 2+ FINISHED trips, so it never opens onto an empty retrospective."
+  },
+  "travelAtlasIndexTitle": "Past trips",
+  "@travelAtlasIndexTitle": {
+    "description": "Heading over the atlas's index of finished trips. Deliberately its own key rather than tripsListPastTrips: that one labels a collapsible group with a count pill on the trips list, and the two sites are free to drift."
+  },
+  "travelAtlasAllTime": "All time",
+  "@travelAtlasAllTime": {
+    "description": "The atlas year filter's unfiltered option, leading the row of year chips."
+  },
+  "travelAtlasFilterByYear": "Filter by year",
+  "@travelAtlasFilterByYear": {
+    "description": "Screen-reader label for the atlas's row of year filter chips. The chips themselves are bare year numbers, which say nothing about what they do."
+  },
+  "travelAtlasEmptyTitle": "No finished trips yet",
+  "travelAtlasEmptyMessage": "Trips land here once they are behind you \u2014 every city you have been to, on one map.",
+  "@travelAtlasEmptyMessage": {
+    "description": "Body of the atlas empty state. Only reachable by URL: the See all door is gated on 2+ finished trips, so nobody arrives here from the app."
   }
 }

--- a/src/packages/flutter-app/lib/l10n/app_es.arb
+++ b/src/packages/flutter-app/lib/l10n/app_es.arb
@@ -1181,5 +1181,11 @@
   "wearPackSunProtection": "Protección solar",
   "rickRollCaption": "Never gonna give you up",
   "rickRollDismissHint": "toca donde sea para salir",
-  "splashLoading": "Cargando"
+  "splashLoading": "Cargando",
+  "travelAtlasSeeAll": "Ver todo",
+  "travelAtlasIndexTitle": "Viajes pasados",
+  "travelAtlasAllTime": "Todos los a\u00f1os",
+  "travelAtlasFilterByYear": "Filtrar por a\u00f1o",
+  "travelAtlasEmptyTitle": "A\u00fan no tienes viajes terminados",
+  "travelAtlasEmptyMessage": "Los viajes aparecen aqu\u00ed cuando ya los has hecho: todas las ciudades donde has estado, en un mapa."
 }

--- a/src/packages/flutter-app/lib/l10n/app_localizations.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations.dart
@@ -6907,6 +6907,42 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Loading'**
   String get splashLoading;
+
+  /// Action on the "Your travels" section header that opens the travel atlas. Rendered only once the account has 2+ FINISHED trips, so it never opens onto an empty retrospective.
+  ///
+  /// In en, this message translates to:
+  /// **'See all'**
+  String get travelAtlasSeeAll;
+
+  /// Heading over the atlas's index of finished trips. Deliberately its own key rather than tripsListPastTrips: that one labels a collapsible group with a count pill on the trips list, and the two sites are free to drift.
+  ///
+  /// In en, this message translates to:
+  /// **'Past trips'**
+  String get travelAtlasIndexTitle;
+
+  /// The atlas year filter's unfiltered option, leading the row of year chips.
+  ///
+  /// In en, this message translates to:
+  /// **'All time'**
+  String get travelAtlasAllTime;
+
+  /// Screen-reader label for the atlas's row of year filter chips. The chips themselves are bare year numbers, which say nothing about what they do.
+  ///
+  /// In en, this message translates to:
+  /// **'Filter by year'**
+  String get travelAtlasFilterByYear;
+
+  /// No description provided for @travelAtlasEmptyTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'No finished trips yet'**
+  String get travelAtlasEmptyTitle;
+
+  /// Body of the atlas empty state. Only reachable by URL: the See all door is gated on 2+ finished trips, so nobody arrives here from the app.
+  ///
+  /// In en, this message translates to:
+  /// **'Trips land here once they are behind you — every city you have been to, on one map.'**
+  String get travelAtlasEmptyMessage;
 }
 
 class _AppLocalizationsDelegate

--- a/src/packages/flutter-app/lib/l10n/app_localizations_en.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations_en.dart
@@ -4162,4 +4162,23 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get splashLoading => 'Loading';
+
+  @override
+  String get travelAtlasSeeAll => 'See all';
+
+  @override
+  String get travelAtlasIndexTitle => 'Past trips';
+
+  @override
+  String get travelAtlasAllTime => 'All time';
+
+  @override
+  String get travelAtlasFilterByYear => 'Filter by year';
+
+  @override
+  String get travelAtlasEmptyTitle => 'No finished trips yet';
+
+  @override
+  String get travelAtlasEmptyMessage =>
+      'Trips land here once they are behind you — every city you have been to, on one map.';
 }

--- a/src/packages/flutter-app/lib/l10n/app_localizations_es.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations_es.dart
@@ -4190,4 +4190,23 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get splashLoading => 'Cargando';
+
+  @override
+  String get travelAtlasSeeAll => 'Ver todo';
+
+  @override
+  String get travelAtlasIndexTitle => 'Viajes pasados';
+
+  @override
+  String get travelAtlasAllTime => 'Todos los años';
+
+  @override
+  String get travelAtlasFilterByYear => 'Filtrar por año';
+
+  @override
+  String get travelAtlasEmptyTitle => 'Aún no tienes viajes terminados';
+
+  @override
+  String get travelAtlasEmptyMessage =>
+      'Los viajes aparecen aquí cuando ya los has hecho: todas las ciudades donde has estado, en un mapa.';
 }

--- a/src/packages/flutter-app/lib/navigation/app_nav.dart
+++ b/src/packages/flutter-app/lib/navigation/app_nav.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../screens/import_trip_screen.dart';
 import '../screens/log_trip_screen.dart';
+import '../screens/travel_atlas_screen.dart';
 import '../screens/trip_detail_screen.dart';
 import 'app_routes.dart';
 
@@ -251,6 +252,24 @@ void openLogTripOnTripsTab(WidgetRef ref) {
     navKeys[AppTab.trips.index].currentState?.popUntil((r) => r.isFirst);
     return locatedRoute(
         const LogTripScreen(), utilityLocation(BootUtility.logTrip));
+  });
+}
+
+/// Open the travel atlas on the Trips tab — the "See all" destination of the
+/// trips list's "Your travels" section. The [openLogTripOnTripsTab] shape:
+/// same tab, same pop-to-root, and a [locatedRoute] rather than an
+/// [instantRoute] because its one entry point sits ON the Trips tab, so the
+/// push IS the transition the user asked for.
+///
+/// Funnelled through a helper anyway, for the reason its twin was: a screen
+/// pushed from the wrong tab strands its back button on the wrong list.
+void openAtlasOnTripsTab(WidgetRef ref) {
+  ref.read(navIndexProvider.notifier).state = AppTab.trips.index;
+  final navKeys = ref.read(tabNavKeysProvider);
+  pushOnTabWhenReady(navKeys, AppTab.trips, () {
+    navKeys[AppTab.trips.index].currentState?.popUntil((r) => r.isFirst);
+    return locatedRoute(
+        const TravelAtlasScreen(), utilityLocation(BootUtility.travelAtlas));
   });
 }
 

--- a/src/packages/flutter-app/lib/navigation/app_routes.dart
+++ b/src/packages/flutter-app/lib/navigation/app_routes.dart
@@ -20,6 +20,7 @@ enum BootUtility {
   logTrip,
   guides,
   notifications,
+  travelAtlas,
 }
 
 /// Where a URL lands after boot: a tab, plus at most one of an inner screen
@@ -65,13 +66,18 @@ String utilityLocation(BootUtility utility) => switch (utility) {
       BootUtility.logTrip => '/log-trip',
       BootUtility.guides => '/guides',
       BootUtility.notifications => '/notifications',
+      BootUtility.travelAtlas => '/atlas',
     };
 
-/// The tab a utility screen is restored onto. Import and log-a-past-trip both
-/// live in the trips flow; everything else hangs off Home (the account menu is
-/// reachable from any tab, so restore needs one deterministic choice).
+/// The tab a utility screen is restored onto. Import, log-a-past-trip and the
+/// travel atlas all live in the trips flow; everything else hangs off Home
+/// (the account menu is reachable from any tab, so restore needs one
+/// deterministic choice).
 AppTab utilityTab(BootUtility utility) => switch (utility) {
-      BootUtility.importTrip || BootUtility.logTrip => AppTab.trips,
+      BootUtility.importTrip ||
+      BootUtility.logTrip ||
+      BootUtility.travelAtlas =>
+        AppTab.trips,
       _ => AppTab.home,
     };
 
@@ -117,6 +123,7 @@ BootTarget? parseBootTarget(Uri uri) {
           'log-trip' => BootUtility.logTrip,
           'guides' => BootUtility.guides,
           'notifications' => BootUtility.notifications,
+          'atlas' => BootUtility.travelAtlas,
           _ => null,
         };
         if (utility != null) {

--- a/src/packages/flutter-app/lib/navigation/url_sync.dart
+++ b/src/packages/flutter-app/lib/navigation/url_sync.dart
@@ -15,6 +15,7 @@ import '../screens/local_admin_screen.dart';
 import '../screens/log_trip_screen.dart';
 import '../screens/notification_center_screen.dart';
 import '../screens/preferences_screen.dart';
+import '../screens/travel_atlas_screen.dart';
 import '../screens/trip_detail_screen.dart';
 import 'app_nav.dart';
 import 'app_routes.dart';
@@ -257,6 +258,7 @@ class UrlSyncController {
         BootUtility.logTrip => const LogTripScreen(),
         BootUtility.guides => const GuidesScreen(),
         BootUtility.notifications => const NotificationCenterScreen(),
+        BootUtility.travelAtlas => const TravelAtlasScreen(),
       };
 }
 

--- a/src/packages/flutter-app/lib/screens/travel_atlas_screen.dart
+++ b/src/packages/flutter-app/lib/screens/travel_atlas_screen.dart
@@ -1,0 +1,735 @@
+import 'dart:async';
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:latlong2/latlong.dart';
+
+import '../l10n/l10n.dart';
+import '../navigation/app_nav.dart';
+import '../navigation/app_routes.dart';
+import '../providers/trips_provider.dart';
+import '../theme/spacing.dart';
+import '../utils/trip_days.dart';
+import '../utils/trip_format.dart';
+import '../utils/trip_list_insights.dart';
+import '../widgets/app_map.dart';
+import '../widgets/empty_state.dart';
+import '../widgets/gradient_app_bar.dart';
+import '../widgets/page_container.dart';
+import '../widgets/section_header.dart';
+import '../widgets/travel_footprint_parts.dart';
+import 'trip_detail_screen.dart';
+
+/// Handles for the atlas's two colophon groups and its index. Locale-free on
+/// purpose (the [kTraveledStatsKey] convention): "is the traveled group on
+/// screen?" is the invariant, and a test that asked by label would answer it
+/// differently in Spanish. Deliberately NOT the trips-list card's keys — two
+/// surfaces, two handles, so neither test can accidentally answer about the
+/// other.
+const kAtlasTraveledStatsKey = ValueKey('travelAtlas.stats.traveled');
+const kAtlasPlannedStatsKey = ValueKey('travelAtlas.stats.planned');
+const kAtlasIndexKey = ValueKey('travelAtlas.index');
+
+/// The travel atlas: everywhere this traveler has been, given room.
+///
+/// The "See all" destination of the trips list's "Your travels" section. The
+/// band up there stays exactly what PR #488 made it — a 140px static plate
+/// closing the page — because the case for this screen is **size and focus**,
+/// not impossibility: a 140px band is a thumbnail of the whole planet, and no
+/// gesture policy fixes that. Growing the band instead would mean promoting
+/// the retrospective above the plans, which is the ordering PR #488 settled.
+///
+/// Three elements, top to bottom:
+///
+///  1. **The plate** — satellite tiles under the same footprint pins, pan and
+///     zoom, and **no text on the image**. That last one is a brand
+///     requirement rather than a preference: text on satellite would need a
+///     scrim, and `heroScrim` over imagery is a teal-tinted photo — a named
+///     instant finding. With the caption on paper below, the question does
+///     not arise, which is also where a journal actually puts a plate caption.
+///  2. **The colophon** — [travelStats] unchanged, traveled/planned split
+///     intact, rendered by the same [TravelStatGroup] the band uses. A group
+///     whose trip count is zero still doesn't render.
+///  3. **The index** — [atlasRows]: **past trips only** ([tripIsPast]),
+///     complete, newest first, no cap. Planned trips stay on the map as hollow
+///     pins and stay out of here: the map is *everywhere*, the index is
+///     *where you've been*.
+///
+/// Route arcs are deliberately absent. [CityPin] carries `{city, lat, lng}` —
+/// no ordinal, no date, no trip id — and the server's hub lateral is a deduped
+/// set in first-appearance order, so a round trip's return leg is
+/// structurally unrepresentable. Arcs need a server change to the list
+/// lateral and are out of scope.
+class TravelAtlasScreen extends ConsumerStatefulWidget {
+  const TravelAtlasScreen({super.key});
+
+  @override
+  ConsumerState<TravelAtlasScreen> createState() => _TravelAtlasScreenState();
+}
+
+class _TravelAtlasScreenState extends ConsumerState<TravelAtlasScreen> {
+  /// The plate's height below the wide seam.
+  ///
+  /// Measured, not picked between the wireframe's 280 and `_GuideMap`'s
+  /// shipped 240 — and measured against the **binding** case rather than the
+  /// comfortable one: a 375×667 phone (the smallest this app supports)
+  /// carrying the tallest chrome this screen can have, which is the year chip
+  /// row above a colophon rendering BOTH groups. On a roomier phone every
+  /// candidate looks fine, so the roomy case decides nothing.
+  ///
+  /// Under that chrome, the first index row's bottom edge lands at
+  /// `240 + 424`, and each row after it is 49 tall. What separates the
+  /// candidates is therefore only what sits ON the 667px fold:
+  ///
+  ///   * **280** — the heading and one whole row; the second starts below the
+  ///     fold. Reads as a list of one.
+  ///   * **256** — the same, with a 2px sliver of the second row's box and
+  ///     none of its text. Still reads as a list of one.
+  ///   * **240** — the heading, one whole row, and the second cut through its
+  ///     text: the plainest "there is more" a list can give.
+  ///
+  /// So 240 — which is also, independently, the height this app already ships
+  /// for an interactive map inside a scrolling column (`_GuideMap`), so the
+  /// atlas is not introducing a third map size. With no chip row (a history
+  /// inside one year) the same height clears two whole rows and cuts a third.
+  ///
+  /// Pinned by the smallest-phone case in this screen's test: change this and
+  /// re-measure, don't change this and re-guess.
+  static const double _plateHeight = 240;
+
+  /// Width at which the index moves beside the plate instead of under it, and
+  /// the width it takes there. 900 is this app's established side-by-side seam
+  /// (the trip detail docks its chat panel at exactly 900, in a 400px column);
+  /// matching both means the atlas's wide layout is the one the app already
+  /// teaches rather than a third answer.
+  static const double _wideSeam = 900;
+  static const double _sideColumnWidth = 400;
+
+  /// The selected year, or null for "All time". Screen state rather than a
+  /// provider: it is a lens on this screen, not a fact about the account, and
+  /// leaving the atlas should forget it.
+  int? _year;
+
+  @override
+  void initState() {
+    super.initState();
+    // Deep-link arrival (/atlas in the address bar, a refresh) reaches this
+    // screen with the trips list never fetched. Pushed arrivals find it
+    // already loaded and skip the call.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      final state = ref.read(tripsProvider);
+      if (state.trips.isEmpty && !state.loading) {
+        ref.read(tripsProvider.notifier).loadTrips();
+      }
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = context.l10n;
+    final state = ref.watch(tripsProvider);
+    // The title is the section's own string, not a second one: the door and
+    // the page behind it can never end up calling the place two names.
+    Widget scaffold(Widget body) => Scaffold(
+          appBar: GradientAppBar(title: l10n.tripsListYourTravels),
+          body: body,
+        );
+
+    if (state.loading && state.trips.isEmpty) {
+      return scaffold(const Center(child: CircularProgressIndicator()));
+    }
+    if (state.error != null && state.trips.isEmpty) {
+      return scaffold(EmptyState(
+        icon: Icons.cloud_off,
+        title: l10n.tripsListErrorTitle,
+        message: l10n.tripsListErrorMessage,
+        actions: [
+          FilledButton(
+            onPressed: () => ref.read(tripsProvider.notifier).loadTrips(),
+            child: Text(l10n.commonRetry),
+          ),
+        ],
+      ));
+    }
+
+    final now = DateTime.now();
+    final trips = state.trips;
+    final rows = atlasRows(trips, now);
+
+    // Only reachable by URL: the door is gated on 2+ finished trips precisely
+    // so nobody navigates into a retrospective of a past that hasn't happened.
+    // The way out is the way the history gets here (specs/log-past-trip).
+    if (rows.isEmpty) {
+      return scaffold(EmptyState(
+        icon: Icons.public,
+        title: l10n.travelAtlasEmptyTitle,
+        message: l10n.travelAtlasEmptyMessage,
+        actions: [
+          OutlinedButton.icon(
+            onPressed: () => openLogTripOnTripsTab(ref),
+            icon: const Icon(Icons.edit_calendar_outlined, size: 18),
+            label: Text(l10n.logTripAction),
+          ),
+        ],
+      ));
+    }
+
+    // Chips come from the WHOLE account, so the set on screen doesn't change
+    // as you pick through it. A selection that no longer exists (a refetch
+    // dropped its trips) falls back to All time rather than filtering to
+    // nothing.
+    final years = atlasYears(trips, now);
+    final year = years.contains(_year) ? _year : null;
+    // One filter, three views. The map and the colophon narrow over ALL trips
+    // of that year — planned ones included, still hollow — because the map is
+    // *everywhere*; only the index is past-only.
+    final filtered = year == null ? trips : tripsInAtlasYear(trips, year);
+    // Whether there is a plate at all is answered by the WHOLE account, not by
+    // the filter: a year whose trips carry no coordinates (name-only
+    // destinations on a logged trip) would otherwise make the map appear and
+    // disappear as you pick through the chips. It renders dot-less instead,
+    // holding the camera it had.
+    final hasPlate = footprintPins(trips, now).isNotEmpty;
+    final pins = footprintPins(filtered, now);
+    final stats = travelStats(filtered, now);
+
+    final paper = _AtlasPaper(
+      // A lone "2026" beside "All time" is chrome that filters nothing — the
+      // empty affordance the artifact's thin-history drawing was written to
+      // catch. Under two distinct years the row does not render at all.
+      years: years.length >= 2 ? years : const <int>[],
+      selectedYear: year,
+      onYearSelected: (y) => setState(() => _year = y),
+      traveled: stats.traveled,
+      planned: stats.planned,
+      rows: year == null ? rows : atlasRows(trips, now, year: year),
+      onOpenTrip: _openTrip,
+    );
+
+    return scaffold(LayoutBuilder(
+      builder: (context, constraints) {
+        if (constraints.maxWidth >= _wideSeam) {
+          // Map-led at width: the plate takes the room and the index reads
+          // beside it, rather than a 700px column of paper with a letterboxed
+          // map at the top. The two scroll independently — the plate doesn't
+          // scroll at all.
+          return Row(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              if (hasPlate) ...[
+                Expanded(child: _plate(pins)),
+                const VerticalDivider(width: 1),
+              ],
+              SizedBox(
+                width: hasPlate ? _sideColumnWidth : constraints.maxWidth,
+                child: SingleChildScrollView(
+                  child: hasPlate ? paper : PageContainer(child: paper),
+                ),
+              ),
+            ],
+          );
+        }
+        return ListView(
+          // No padding: the plate is full-bleed — the atlas does not inherit
+          // the trips list's capped reading column, because the surface is
+          // map-led. The paper below supplies its own margins.
+          padding: EdgeInsets.zero,
+          children: [
+            if (hasPlate) SizedBox(height: _plateHeight, child: _plate(pins)),
+            PageContainer(child: paper),
+          ],
+        );
+      },
+    ));
+  }
+
+  Widget _plate(List<FootprintPin> pins) => Semantics(
+        label: context.l10n.tripsListTravelMap,
+        child: _AtlasPlate(pins: pins),
+      );
+
+  Future<void> _openTrip(BuildContext context, String tripId) async {
+    // Guarded here rather than with pushOnce so the resync below is skipped
+    // too: a second tap that opened nothing must not refetch the list.
+    if (!isTopRoute(context)) return;
+    await Navigator.of(context).push(
+      locatedRoute(
+          TripDetailScreen(tripId: tripId), tripDetailLocation(tripId)),
+    );
+    // The detail screen can move a trip's dates, which is the one edit that
+    // changes what this screen says. Fire-and-forget, like the list's own
+    // pop-refresh.
+    if (!mounted) return;
+    unawaited(ref.read(tripsProvider.notifier).loadTrips());
+  }
+}
+
+/// Everything on paper: the colophon under the plate, then the index.
+///
+/// One widget for both layouts so the narrow stack and the wide side column
+/// can never drift into two different captions.
+class _AtlasPaper extends StatelessWidget {
+  /// The years to offer, newest first. Empty means no filter row at all.
+  final List<int> years;
+  final int? selectedYear;
+  final ValueChanged<int?> onYearSelected;
+  final TravelStats traveled;
+  final TravelStats planned;
+  final List<AtlasRow> rows;
+  final Future<void> Function(BuildContext context, String tripId) onOpenTrip;
+
+  const _AtlasPaper({
+    required this.years,
+    required this.selectedYear,
+    required this.onYearSelected,
+    required this.traveled,
+    required this.planned,
+    required this.rows,
+    required this.onOpenTrip,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = context.l10n;
+    // A group whose trip count is zero does not render — the same rule the
+    // band uses, and the reason a traveler never meets a row of zeros.
+    final groups = [
+      if (traveled.trips > 0)
+        (
+          key: kAtlasTraveledStatsKey,
+          label: l10n.tripsListStatsTraveled,
+          stats: traveled,
+        ),
+      if (planned.trips > 0)
+        (
+          key: kAtlasPlannedStatsKey,
+          label: l10n.tripsListStatsPlanned,
+          stats: planned,
+        ),
+    ];
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        if (years.isNotEmpty) ...[
+          _YearChips(
+            years: years,
+            selected: selectedYear,
+            onSelected: onYearSelected,
+          ),
+          const Divider(height: 1),
+        ],
+        Padding(
+          padding: const EdgeInsets.all(AppSpacing.lg),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              for (var i = 0; i < groups.length; i++) ...[
+                if (i > 0) const SizedBox(height: AppSpacing.lg),
+                TravelStatGroup(
+                  key: groups[i].key,
+                  label: groups[i].label,
+                  stats: groups[i].stats,
+                ),
+              ],
+            ],
+          ),
+        ),
+        const Divider(height: 1),
+        Padding(
+          padding: const EdgeInsets.fromLTRB(
+              AppSpacing.lg, AppSpacing.lg, AppSpacing.lg, AppSpacing.xxl),
+          child: Column(
+            key: kAtlasIndexKey,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              SectionHeader(title: l10n.travelAtlasIndexTitle),
+              for (var i = 0; i < rows.length; i++) ...[
+                // Hairlines between rows, never around them — the index has no
+                // box of its own, so a divider only has to separate siblings,
+                // and the first row needs none: its heading is directly above.
+                if (i > 0) const Divider(height: 1),
+                _IndexRow(row: rows[i], onOpen: onOpenTrip),
+              ],
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+/// The explore axis: a filter-chip row that narrows the map, the colophon and
+/// the index together. Time is the dimension travel history is actually
+/// explored along, and the band this screen came from has no analogue for it.
+///
+/// Chips, not the vertical rail an earlier draft drew ON the map: those rungs
+/// measured ~21px against the 48px [kMinTouchTarget] floor and sat inside a
+/// pan-and-zoom gesture arena. `DESIGN.md` blesses this shape outright —
+/// *"filter chip rows are the entire secondary navigation on list screens"*.
+///
+/// **"All time" leads and is pinned outside the scroll view.** It is both the
+/// resting state and the only way back, and [BookingFilterBar] already settled
+/// what happens otherwise: on ten years of history the strip scrolls, and an
+/// exit that can scroll off-screen is not an exit. Re-tapping a selected year
+/// is a dead gesture rather than a second, invisible way to clear — the years
+/// have somewhere to say it, and All time is already saying it.
+///
+/// Unlike that strip there is no leading fade under the pinned chip: a year
+/// half-scrolled under it reads as a clipped number, not as a stray count
+/// attaching itself to the wrong chip, which is the specific harm that mask
+/// exists to prevent.
+class _YearChips extends StatelessWidget {
+  final List<int> years;
+  final int? selected;
+  final ValueChanged<int?> onSelected;
+
+  const _YearChips({
+    required this.years,
+    required this.selected,
+    required this.onSelected,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = context.l10n;
+    // Bare year numbers say nothing about what tapping one does; the row says
+    // it once, for a screen reader, instead of every chip repeating it.
+    return Semantics(
+      label: l10n.travelAtlasFilterByYear,
+      container: true,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(
+            horizontal: AppSpacing.lg, vertical: AppSpacing.sm),
+        child: Row(
+          children: [
+            _chip(
+              label: l10n.travelAtlasAllTime,
+              isSelected: selected == null,
+              onTap: () => onSelected(null),
+            ),
+            const SizedBox(width: AppSpacing.sm),
+            Expanded(
+              child: SingleChildScrollView(
+                scrollDirection: Axis.horizontal,
+                // A traveler with ten years of history overflows any phone.
+                child: Row(
+                  children: [
+                    for (var i = 0; i < years.length; i++) ...[
+                      if (i > 0) const SizedBox(width: AppSpacing.sm),
+                      _chip(
+                        // Formatted, never translated — and never through an
+                        // ICU int placeholder, which would group 2026 as
+                        // "2,026".
+                        label: '${years[i]}',
+                        isSelected: selected == years[i],
+                        onTap: () => onSelected(years[i]),
+                      ),
+                    ],
+                  ],
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  /// The house filter chip: fully round, no checkmark, and a padded tap target
+  /// so the 48px floor holds even though the chip paints compact.
+  Widget _chip({
+    required String label,
+    required bool isSelected,
+    required VoidCallback onTap,
+  }) =>
+      ChoiceChip(
+        label: Text(label),
+        selected: isSelected,
+        onSelected: isSelected ? null : (_) => onTap(),
+        showCheckmark: false,
+        visualDensity: VisualDensity.standard,
+        materialTapTargetSize: MaterialTapTargetSize.padded,
+      );
+}
+
+/// One finished trip, as an index entry: `2026–02 · Lisbon & Porto · 12 days`.
+///
+/// Typographic rows, deliberately not an icon-card grid — same-size card grids
+/// as page structure are a named ban, and Flighty's flag collection translates
+/// to type here rather than to tiles.
+///
+/// The reference column needs no fixed width: every reference is `YYYY–MM`, so
+/// with tabular figures they are all exactly as wide as each other and the
+/// rail aligns itself at any text scale. A magic column width would align at
+/// one scale and clip at the next.
+class _IndexRow extends StatelessWidget {
+  final AtlasRow row;
+  final Future<void> Function(BuildContext context, String tripId) onOpen;
+
+  const _IndexRow({required this.row, required this.onOpen});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final l10n = context.l10n;
+    final trip = row.trip;
+    final cities = citiesLabel(
+      trip.cities,
+      two: (a, b) => l10n.citiesTwo(a, b),
+      more: (a, b, n) => l10n.citiesMore(a, b, n),
+    );
+    // The same display-title rule as every other trip surface, so a trip never
+    // flips names between the list and its own index entry. citiesLabel's
+    // "Tokyo & Kyoto +2 more" cap is what bounds this row's width.
+    final name = tripHeadline(trip.title, cities);
+    final muted = theme.textTheme.bodySmall?.copyWith(
+      color: theme.colorScheme.onSurfaceVariant,
+      fontFeatures: const [FontFeature.tabularFigures()],
+    );
+    return InkWell(
+      onTap: () => onOpen(context, trip.id),
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(minHeight: kMinTouchTarget),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(vertical: AppSpacing.sm),
+          child: Row(
+            children: [
+              Text(_reference(row), style: muted),
+              const SizedBox(width: AppSpacing.md),
+              Expanded(
+                child: Text(
+                  name,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: theme.textTheme.titleSmall
+                      ?.copyWith(fontWeight: FontWeight.w600),
+                ),
+              ),
+              // A half-dated trip prints NO length rather than "0 days":
+              // dayCount answers 0 whenever either date is missing, and an
+              // end-date-only trip can still be past. Same drop the colophon
+              // performs on a zero-valued stat.
+              if (row.days case final days?) ...[
+                const SizedBox(width: AppSpacing.sm),
+                Text(l10n.tripDurationDays(days), style: muted),
+              ],
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  /// `2026–02`, composed here rather than translated: it is digits and an en
+  /// dash, with nothing in it to translate and a thousands separator to avoid
+  /// (an ICU int placeholder would render the year as "2,026"). The same
+  /// reasoning `shortDate` records for its machine-facing form.
+  static String _reference(AtlasRow row) =>
+      '${row.year}–${row.month.toString().padLeft(2, '0')}';
+}
+
+/// The plate: satellite under the footprint pins, and nothing else on it.
+///
+/// **Interaction follows `_GuideMap`, not the trips-list band.**
+/// `InteractiveFlag.all & ~scrollWheelZoom` plus explicit zoom buttons, and
+/// both halves are required: the wheel opt-out stops a desktop page-scroll
+/// becoming a zoom, and the buttons exist *because* of that opt-out — without
+/// them a full-bleed desktop map cannot be zoomed at all.
+///
+/// The cost this accepts, in the open: on touch, a vertical drag that starts
+/// on the plate pans the map instead of scrolling the page. That is the trade
+/// `_GuideMap` already ships at 240px mid-page; here the surface is map-led,
+/// so it is the right way round.
+class _AtlasPlate extends StatefulWidget {
+  final List<FootprintPin> pins;
+
+  const _AtlasPlate({required this.pins});
+
+  @override
+  State<_AtlasPlate> createState() => _AtlasPlateState();
+}
+
+class _AtlasPlateState extends State<_AtlasPlate> {
+  /// Marker box: transparent halo padding the 12px dot to the 44px touch
+  /// minimum, centered on the coordinate (the trip_map hit-box idiom).
+  static const double _pinHitBox = 44;
+
+  /// Zoom for the degenerate single-pin fit, where bounds collapse to a point:
+  /// continental context, not a street view — an atlas locates cities on the
+  /// globe, it doesn't tour one.
+  static const double _singlePinZoom = 4;
+
+  final MapController _controller = MapController();
+  double? _lastMapWidth;
+  double? _minZoom;
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  void didUpdateWidget(covariant _AtlasPlate old) {
+    super.didUpdateWidget(old);
+    // `initialCameraFit` applies once per FlutterMap state, so a filtered pin
+    // set would change the dots and leave the camera over the old extent —
+    // the filter would look broken. Re-fit whenever the points move.
+    if (!_samePoints(old.pins, widget.pins)) _fitPins();
+  }
+
+  static bool _samePoints(List<FootprintPin> a, List<FootprintPin> b) {
+    if (a.length != b.length) return false;
+    for (var i = 0; i < a.length; i++) {
+      if (a[i].lat != b[i].lat || a[i].lng != b[i].lng) return false;
+    }
+    return true;
+  }
+
+  List<LatLng> get _points => [
+        for (final p in widget.pins) LatLng(p.lat, p.lng),
+      ];
+
+  /// Move the camera onto the current pins. Deliberately a no-op when there
+  /// are none: a year whose trips carry no coordinates keeps the camera it
+  /// had, rather than jumping to nowhere.
+  void _fitPins() {
+    final points = _points;
+    if (points.isEmpty) return;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      try {
+        if (points.length == 1) {
+          _controller.move(points.first, _singlePinZoom);
+        } else {
+          _controller.fitCamera(CameraFit.bounds(
+            bounds: LatLngBounds.fromPoints(points),
+            padding: const EdgeInsets.all(AppSpacing.xxl),
+          ));
+        }
+        _clampToFloor();
+      } catch (_) {}
+    });
+  }
+
+  /// Nudge the camera back over the zoom floor. flutter_map adopts a changed
+  /// minZoom into the camera's options but never re-clamps the live zoom, so
+  /// both a resize and a fresh fit can leave it under the floor — which shows
+  /// [appMapBackground] as bars down both sides.
+  void _clampToFloor() {
+    final floor = _minZoom;
+    if (floor == null) return;
+    try {
+      final camera = _controller.camera;
+      _controller.move(camera.center, math.max(camera.zoom, floor));
+    } catch (_) {}
+  }
+
+  void _zoomBy(double delta) {
+    try {
+      _controller.move(
+          _controller.camera.center, _controller.camera.zoom + delta);
+    } catch (_) {}
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = context.l10n;
+    final points = _points;
+    const interaction = InteractionOptions(
+      flags: InteractiveFlag.all & ~InteractiveFlag.scrollWheelZoom,
+    );
+    // The zoom floor that keeps the single world filling the box depends on
+    // the width the map is given, so the options are assembled in a
+    // LayoutBuilder (the TripMap pattern).
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final minZoom = appMapMinZoomFor(constraints.maxWidth);
+        _minZoom = minZoom;
+
+        if (_lastMapWidth != null && _lastMapWidth != constraints.maxWidth) {
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            if (!mounted) return;
+            _clampToFloor();
+          });
+        }
+        _lastMapWidth = constraints.maxWidth;
+
+        final options = points.length == 1
+            ? appMapOptions(
+                initialCenter: points.first,
+                initialZoom: _singlePinZoom,
+                minZoom: minZoom,
+                interactionOptions: interaction,
+              )
+            : appMapOptions(
+                initialCameraFit: points.isEmpty
+                    ? null
+                    : AppCameraFitBounds(
+                        bounds: LatLngBounds.fromPoints(points),
+                        padding: const EdgeInsets.all(AppSpacing.xxl),
+                      ),
+                minZoom: minZoom,
+                interactionOptions: interaction,
+              );
+
+        return Stack(
+          children: [
+            FlutterMap(
+              mapController: _controller,
+              options: options,
+              children: [
+                ...appMapTileLayers(context),
+                MarkerLayer(
+                  markers: [
+                    for (final p in widget.pins)
+                      Marker(
+                        point: LatLng(p.lat, p.lng),
+                        width: _pinHitBox,
+                        height: _pinHitBox,
+                        // Tap-tooltips, as on the band: the two dot styles are
+                        // the fast read, the tooltip is the one that can't be
+                        // misread — and it is what carries the city names to
+                        // a screen reader.
+                        child: Tooltip(
+                          message: '${p.city} · '
+                              '${p.visited ? l10n.tripsListStatsTraveled : l10n.tripsListStatsPlanned}',
+                          triggerMode: TooltipTriggerMode.tap,
+                          child: FootprintDot(visited: p.visited),
+                        ),
+                      ),
+                  ],
+                ),
+                // Required by both tile providers' terms, and it keeps its
+                // clear space here because nothing else sits on the image.
+                appMapAttribution(),
+              ],
+            ),
+            Positioned(
+              right: AppSpacing.sm,
+              bottom: AppSpacing.sm,
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  MapControlButton(
+                    icon: Icons.add,
+                    tooltip: l10n.mapZoomIn,
+                    onTap: () => _zoomBy(1),
+                  ),
+                  const SizedBox(height: AppSpacing.sm),
+                  MapControlButton(
+                    icon: Icons.remove,
+                    tooltip: l10n.mapZoomOut,
+                    onTap: () => _zoomBy(-1),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        );
+      },
+    );
+  }
+}

--- a/src/packages/flutter-app/lib/screens/trips_list_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trips_list_screen.dart
@@ -40,6 +40,11 @@ const kLogTripSectionActionKey = ValueKey('logTrip.entry.section');
 const kLogTripAppBarKey = ValueKey('logTrip.entry.appBar');
 const kLogTripEmptyStateKey = ValueKey('logTrip.entry.emptyState');
 
+/// Handle for the "Your travels" section's atlas door. Locale-free, the same
+/// convention: the invariant is whether the door EXISTS for this account, and
+/// a text finder would answer it differently in Spanish.
+const kTravelAtlasSeeAllKey = ValueKey('travelAtlas.entry.section');
+
 /// The trips list, read as a journal index rather than a dashboard.
 ///
 /// The page runs in narrative order — **what's next, what you're co-planning,
@@ -194,6 +199,15 @@ class _TripsListScreenState extends ConsumerState<TripsListScreen> {
       final stats = travelStats(state.trips, now);
       final pins = footprintPins(state.trips, now);
       final showFootprint = state.trips.length >= 2;
+      // The atlas door opens on FINISHED trips (tripIsPast), not on the card's
+      // own owned-trip count and not on travelStats' traveled count — that one
+      // partitions on tripHasStarted, so it would open for someone on their
+      // second-ever trip, mid-flight. Below two there is nothing behind the
+      // door: no traveled pins, no Traveled colophon group (it doesn't render
+      // at zero) and an index with no rows at all. So the door doesn't exist,
+      // and the header keeps "+ Add past trip", which is how the history that
+      // unlocks the atlas gets here in the first place.
+      final showAtlas = pastTrips(state.trips, now).length >= 2;
       body = RefreshIndicator(
         onRefresh: () async {
           ref.invalidate(sharedWithMeProvider);
@@ -359,17 +373,55 @@ class _TripsListScreenState extends ConsumerState<TripsListScreen> {
                           AppSpacing.xs, AppSpacing.xl, 0, AppSpacing.sm),
                       child: SectionHeader(
                         title: l10n.tripsListYourTravels,
-                        // The band's own gap-filler (specs/log-past-trip): the
-                        // section reads as "everywhere you've been" while
-                        // knowing only what this app planned, so the way to
-                        // correct it belongs in its header. It can't be the
-                        // ONLY way in — the header is gated at 2+ owned trips
-                        // — hence the app-bar and empty-state twins.
-                        action: TextButton.icon(
-                          key: kLogTripSectionActionKey,
-                          onPressed: () => openLogTripOnTripsTab(ref),
-                          icon: const Icon(Icons.add, size: 18),
-                          label: Text(l10n.logTripAction),
+                        // Two actions, passed as one WRAP — not a Row.
+                        // SectionHeader's own Wrap can drop this whole group
+                        // onto a second line, which is what its dartdoc
+                        // promises, but a Row inside it still cannot be
+                        // narrower than its two buttons: at 360dp (the
+                        // commonest Android width) the English pair measures
+                        // wider than the column and a Row overflows it by
+                        // 28px. Wrapping instead lets the second button take a
+                        // third line on exactly those widths and changes
+                        // nothing anywhere else.
+                        //
+                        // Both actions stay here. "+ Add past trip" does not
+                        // move: specs/log-past-trip placed it in this header
+                        // deliberately, and relocating it re-opens that
+                        // decision.
+                        // Runs stack flush-LEFT when the pair breaks, so the
+                        // buttons land on the title's own edge. Right-aligning
+                        // them instead lines them up on the wider button's
+                        // right edge, which is neither margin and reads as an
+                        // accident.
+                        action: Wrap(
+                          crossAxisAlignment: WrapCrossAlignment.center,
+                          children: [
+                            // The way into the atlas. A marked action rather
+                            // than a tappable card: the card carries no
+                            // affordance, and every pin on it is a 44px hit
+                            // box already spending taps on a tooltip — the
+                            // most inviting targets would be the ones that
+                            // didn't open it.
+                            if (showAtlas)
+                              TextButton(
+                                key: kTravelAtlasSeeAllKey,
+                                onPressed: () => openAtlasOnTripsTab(ref),
+                                child: Text(l10n.travelAtlasSeeAll),
+                              ),
+                            // The band's own gap-filler
+                            // (specs/log-past-trip): the section reads as
+                            // "everywhere you've been" while knowing only what
+                            // this app planned, so the way to correct it
+                            // belongs in its header. It can't be the ONLY way
+                            // in — the header is gated at 2+ owned trips —
+                            // hence the app-bar and empty-state twins.
+                            TextButton.icon(
+                              key: kLogTripSectionActionKey,
+                              onPressed: () => openLogTripOnTripsTab(ref),
+                              icon: const Icon(Icons.add, size: 18),
+                              label: Text(l10n.logTripAction),
+                            ),
+                          ],
                         ),
                       ),
                     ),

--- a/src/packages/flutter-app/lib/utils/trip_list_insights.dart
+++ b/src/packages/flutter-app/lib/utils/trip_list_insights.dart
@@ -142,3 +142,109 @@ DateTime? bookingNudgeDate(Trip trip, DateTime today) {
   if (days == null || days > kBookingNudgeWindowDays) return null;
   return DateTime.parse(raw!); // non-null and parseable: days != null
 }
+
+// ---- the atlas (specs-less; artifact "My Trips — the Atlas") --------------
+//
+// The travel-history surface behind "Your travels — See all" reads the same
+// payload as the band above, but through a STRICTER membership rule:
+// [tripIsPast], not [tripHasStarted].
+//
+// [travelStats] partitions on [tripHasStarted], which counts a trip currently
+// under way as traveled — right for an aggregate (an in-progress trip's
+// counter ticks up daily instead of banking all 35 days on day one) and wrong
+// for a row that names ONE trip and claims its length: a 14-day trip on day 2
+// would read "2 days" and change every morning. The trips list already refuses
+// this exact category error (trips_list_screen.dart: the live trip is exempt
+// from the past group). Filtering on [tripIsPast] also makes
+// `traveledDayCount == dayCount` (trip_days.dart), so an index row needs no
+// special day-count rule at all.
+//
+// The colophon is deliberately NOT moved: it keeps [travelStats] and its
+// traveled/planned split exactly as the band renders them.
+
+/// The trips wholly behind [today] — the atlas's membership rule, and the
+/// quantity its door is gated on (2+).
+///
+/// A filter, not a sort: the caller's order is preserved, so passing the
+/// result to [footprintPins] keeps its first-coordinate-wins dedupe answering
+/// exactly as it does for the unfiltered list.
+List<Trip> pastTrips(List<Trip> trips, DateTime today) => [
+      for (final t in trips)
+        if (tripIsPast(t.startDate, t.endDate, today)) t
+    ];
+
+/// The day a trip is FILED under: its first day — [Trip.startDate], falling
+/// back to [Trip.endDate] for start-less trips. Null for an undated trip.
+///
+/// The same first-day rule as [tripHasStarted] and trip_list_order.dart's
+/// `_firstDay`, so the year chips, the row references and the list's own
+/// ordering can't disagree about which year a trip belongs to. A trip spanning
+/// Dec→Jan is therefore ONE trip in ONE year — its first day's.
+DateTime? atlasFirstDay(Trip trip) =>
+    DateTime.tryParse(trip.startDate ?? '') ??
+    DateTime.tryParse(trip.endDate ?? '');
+
+/// The distinct years [pastTrips] fall in, newest first — the year chips.
+///
+/// Every past trip has a parseable first day ([tripIsPast] needs one), so no
+/// past trip can be missing from this list.
+List<int> atlasYears(List<Trip> trips, DateTime today) {
+  final years = <int>{
+    for (final t in pastTrips(trips, today))
+      if (atlasFirstDay(t) case final d?) d.year,
+  }.toList();
+  years.sort((a, b) => b.compareTo(a));
+  return years;
+}
+
+/// Every trip filed under [year] — past AND planned, unlike [pastTrips].
+///
+/// The year chips narrow the whole surface at once, and the map's job there is
+/// unchanged: it shows *everywhere*, with planned cities still hollow. Only
+/// the index is where-you've-been.
+List<Trip> tripsInAtlasYear(List<Trip> trips, int year) => [
+      for (final t in trips)
+        if (atlasFirstDay(t)?.year == year) t
+    ];
+
+/// One row of the atlas index. Carries the facts a row is BUILT from, never
+/// its rendered strings: the name goes through `tripHeadline`/`citiesLabel`,
+/// whose connectors are localized at the call site.
+///
+/// [days] is null — not 0 — for a half-dated trip. Both [dayCount] and
+/// [traveledDayCount] answer 0 when either date is missing, and an
+/// end-date-only trip CAN be past, so a row that trusted the number would
+/// print "0 days" for a trip that plainly took some. Null is the same drop
+/// `_StatGroup` performs on a zero-valued stat, made explicit in the type.
+typedef AtlasRow = ({Trip trip, int year, int month, int? days});
+
+/// The atlas index: [pastTrips], newest first, optionally narrowed to one
+/// [year]. Complete — no cap; the index scrolls with the page, and the screen
+/// that IS the see-all destination has nowhere further to send anyone.
+///
+/// Ordered by the FIRST day, descending, rather than by the last day the way
+/// trip_list_order.dart's past group is. The two keys disagree only for
+/// overlapping trips, and here the first day is PRINTED in the reference
+/// column — an index whose leading column doesn't descend contradicts itself
+/// on screen. Ties break on `createdAt` (newest first), since `List.sort` is
+/// unstable.
+List<AtlasRow> atlasRows(List<Trip> trips, DateTime today, {int? year}) {
+  final rows = <AtlasRow>[];
+  for (final t in pastTrips(trips, today)) {
+    final first = atlasFirstDay(t);
+    if (first == null) continue; // unreachable: past implies a parseable date
+    if (year != null && first.year != year) continue;
+    final days = dayCount(t.startDate, t.endDate, const <int?>[]);
+    rows.add((
+      trip: t,
+      year: first.year,
+      month: first.month,
+      days: days > 0 ? days : null,
+    ));
+  }
+  rows.sort((a, b) {
+    final c = atlasFirstDay(b.trip)!.compareTo(atlasFirstDay(a.trip)!);
+    return c != 0 ? c : b.trip.createdAt.compareTo(a.trip.createdAt);
+  });
+  return rows;
+}

--- a/src/packages/flutter-app/lib/widgets/travel_footprint_card.dart
+++ b/src/packages/flutter-app/lib/widgets/travel_footprint_card.dart
@@ -8,7 +8,7 @@ import '../l10n/l10n.dart';
 import '../theme/spacing.dart';
 import '../utils/trip_list_insights.dart';
 import 'app_map.dart';
-import 'stat_tile_row.dart';
+import 'travel_footprint_parts.dart';
 
 /// Handles for the two stat groups. Locale-free on purpose: "is the traveled
 /// group on screen?" is the invariant this card turns on, and a test that
@@ -121,7 +121,7 @@ class TravelFootprintCard extends StatelessWidget {
                   // help. (It was xl while each group was a 50px-tall tile
                   // grid; the caption lines need less air to stay grouped.)
                   if (i > 0) const SizedBox(height: AppSpacing.lg),
-                  _StatGroup(
+                  TravelStatGroup(
                     key: groups[i].key,
                     label: groups[i].label,
                     stats: groups[i].stats,
@@ -132,64 +132,6 @@ class TravelFootprintCard extends StatelessWidget {
           ),
         ],
       ),
-    );
-  }
-}
-
-/// One labeled side of the split: a quiet title over the group's stat line.
-///
-/// The label is **sentence case** — the same l10n string labels the map's pin
-/// tooltips ("Kraków · Planned"), and one string beats a second key plus a
-/// locale-unsafe toUpperCase(). It must also read quieter than the page-level
-/// "Your travels" SectionHeader above the card: header > group label > stats.
-/// It carried UpNextTripCard's letterspaced treatment until the editorial
-/// pass; a letterspaced label above a heading is an eyebrow in everything but
-/// name, and the brand rulebook allows exactly one of those (the place eyebrow
-/// on destination surfaces). Weight does the work here instead.
-class _StatGroup extends StatelessWidget {
-  final String label;
-  final TravelStats stats;
-
-  const _StatGroup({super.key, required this.label, required this.stats});
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    final l10n = context.l10n;
-    // Zero-valued tiles drop out segment-wise (undated trips contribute no
-    // travel days, city-less legacy rows no cities), the rule this card has
-    // always used. Trips is never zero — the caller drops the whole group.
-    final tiles = [
-      StatTileData(
-        value: '${stats.trips}',
-        label: l10n.tripsListStatTrips(stats.trips),
-      ),
-      if (stats.travelDays > 0)
-        StatTileData(
-          value: '${stats.travelDays}',
-          label: l10n.tripsListStatTravelDays(stats.travelDays),
-        ),
-      if (stats.cities > 0)
-        StatTileData(
-          value: '${stats.cities}',
-          label: l10n.tripsListStatCities(stats.cities),
-        ),
-    ];
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      children: [
-        Text(
-          label,
-          maxLines: 1,
-          overflow: TextOverflow.ellipsis,
-          style: theme.textTheme.labelMedium?.copyWith(
-            color: theme.colorScheme.onSurfaceVariant,
-            fontWeight: FontWeight.w600,
-          ),
-        ),
-        const SizedBox(height: AppSpacing.xs),
-        StatTileRow(tiles: tiles),
-      ],
     );
   }
 }
@@ -286,9 +228,13 @@ class _FootprintMapState extends State<_FootprintMap> {
                     point: LatLng(p.lat, p.lng),
                     width: _pinHitBox,
                     height: _pinHitBox,
-                    child: _FootprintPin(
-                      tooltip: widget.tooltipFor(p),
-                      visited: p.visited,
+                    // The tooltip's tap detector fills the marker's hit box,
+                    // so the whole transparent halo around the 12px dot
+                    // triggers it.
+                    child: Tooltip(
+                      message: widget.tooltipFor(p),
+                      triggerMode: TooltipTriggerMode.tap,
+                      child: FootprintDot(visited: p.visited),
                     ),
                   ),
               ],
@@ -297,56 +243,6 @@ class _FootprintMapState extends State<_FootprintMap> {
           ],
         );
       },
-    );
-  }
-}
-
-/// An unnumbered city dot: the _Pin family's white-ring-and-shadow treatment
-/// over satellite imagery, brand primary, no ordinal. The tooltip's tap
-/// detector fills the marker's hit box, so the whole transparent halo around
-/// the 12px dot triggers it.
-///
-/// [visited] changes only the FILL — brand primary for a city already
-/// travelled, hollow (a dark translucent core) for one still ahead: the
-/// filled-vs-empty idiom, and the same reading as a ticked box. The white ring
-/// and shadow stay on both so the two are equally findable on busy imagery.
-///
-/// Swapping the ring colour instead was tried first and inverted the emphasis:
-/// at 12px a primary ring on a white core just reads "white dot", which shouts
-/// louder than the teal one — the trips you HAVEN'T taken became the loud
-/// pins in a section headed by the ones you have. Both stay hardcoded white
-/// rather than a surface token: these sit on satellite imagery, which looks
-/// the same in either app theme, so a theme-following ring would vanish.
-class _FootprintPin extends StatelessWidget {
-  final String tooltip;
-  final bool visited;
-
-  const _FootprintPin({required this.tooltip, required this.visited});
-
-  @override
-  Widget build(BuildContext context) {
-    final primary = Theme.of(context).colorScheme.primary;
-    return Tooltip(
-      message: tooltip,
-      triggerMode: TooltipTriggerMode.tap,
-      child: Center(
-        child: Container(
-          width: 12,
-          height: 12,
-          decoration: BoxDecoration(
-            color: visited ? primary : Colors.black.withValues(alpha: 0.35),
-            shape: BoxShape.circle,
-            border: Border.all(color: Colors.white, width: 2),
-            boxShadow: [
-              BoxShadow(
-                color: Colors.black.withValues(alpha: 0.35),
-                blurRadius: 4,
-                offset: const Offset(0, 1),
-              ),
-            ],
-          ),
-        ),
-      ),
     );
   }
 }

--- a/src/packages/flutter-app/lib/widgets/travel_footprint_parts.dart
+++ b/src/packages/flutter-app/lib/widgets/travel_footprint_parts.dart
@@ -1,0 +1,124 @@
+import 'package:flutter/material.dart';
+
+import '../l10n/l10n.dart';
+import '../theme/spacing.dart';
+import '../utils/trip_list_insights.dart';
+import 'stat_tile_row.dart';
+
+/// The two pieces the trips-list footprint band and the travel atlas both
+/// paint. They live here rather than privately inside `travel_footprint_card`
+/// because the atlas needs the SAME treatment on a different surface, and a
+/// second copy of either would drift: the dot's filled-vs-hollow reading is
+/// the map's whole legend, and the group's label weight is what keeps the
+/// caption quieter than the section header above it.
+///
+/// The maps themselves are deliberately not shared. The band's camera is
+/// static (a panning map mid-scroll steals the page's scroll gesture) while
+/// the atlas is pan-and-zoom; one widget with an interaction flag would hide
+/// that difference rather than state it.
+
+/// An unnumbered city dot: the _Pin family's white-ring-and-shadow treatment
+/// over satellite imagery, brand primary, no ordinal.
+///
+/// [visited] changes only the FILL — brand primary for a city already
+/// travelled, hollow (a dark translucent core) for one still ahead: the
+/// filled-vs-empty idiom, and the same reading as a ticked box. The white ring
+/// and shadow stay on both so the two are equally findable on busy imagery.
+///
+/// Swapping the ring colour instead was tried first and inverted the emphasis:
+/// at 12px a primary ring on a white core just reads "white dot", which shouts
+/// louder than the teal one — the trips you HAVEN'T taken became the loud
+/// pins in a section headed by the ones you have. Both stay hardcoded white
+/// rather than a surface token: these sit on satellite imagery, which looks
+/// the same in either app theme, so a theme-following ring would vanish.
+class FootprintDot extends StatelessWidget {
+  /// The dot's painted diameter. The marker box around it is much larger (the
+  /// 44px hit-box idiom); this is only the ink.
+  static const double size = 12;
+
+  final bool visited;
+
+  const FootprintDot({super.key, required this.visited});
+
+  @override
+  Widget build(BuildContext context) {
+    final primary = Theme.of(context).colorScheme.primary;
+    return Center(
+      child: Container(
+        width: size,
+        height: size,
+        decoration: BoxDecoration(
+          color: visited ? primary : Colors.black.withValues(alpha: 0.35),
+          shape: BoxShape.circle,
+          border: Border.all(color: Colors.white, width: 2),
+          boxShadow: [
+            BoxShadow(
+              color: Colors.black.withValues(alpha: 0.35),
+              blurRadius: 4,
+              offset: const Offset(0, 1),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// One labeled side of the traveled/planned split: a quiet title over the
+/// group's stat line.
+///
+/// The label is **sentence case** — the same l10n string labels the map's pin
+/// tooltips ("Kraków · Planned"), and one string beats a second key plus a
+/// locale-unsafe toUpperCase(). It must also read quieter than the page-level
+/// heading above it: header > group label > stats. It carried UpNextTripCard's
+/// letterspaced treatment until the editorial pass; a letterspaced label above
+/// a heading is an eyebrow in everything but name, and the brand rulebook
+/// allows exactly one of those (the place eyebrow on destination surfaces).
+/// Weight does the work here instead.
+class TravelStatGroup extends StatelessWidget {
+  final String label;
+  final TravelStats stats;
+
+  const TravelStatGroup({super.key, required this.label, required this.stats});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final l10n = context.l10n;
+    // Zero-valued tiles drop out segment-wise (undated trips contribute no
+    // travel days, city-less legacy rows no cities), the rule this caption has
+    // always used. Trips is never zero — the caller drops the whole group.
+    final tiles = [
+      StatTileData(
+        value: '${stats.trips}',
+        label: l10n.tripsListStatTrips(stats.trips),
+      ),
+      if (stats.travelDays > 0)
+        StatTileData(
+          value: '${stats.travelDays}',
+          label: l10n.tripsListStatTravelDays(stats.travelDays),
+        ),
+      if (stats.cities > 0)
+        StatTileData(
+          value: '${stats.cities}',
+          label: l10n.tripsListStatCities(stats.cities),
+        ),
+    ];
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Text(
+          label,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+          style: theme.textTheme.labelMedium?.copyWith(
+            color: theme.colorScheme.onSurfaceVariant,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+        const SizedBox(height: AppSpacing.xs),
+        StatTileRow(tiles: tiles),
+      ],
+    );
+  }
+}

--- a/src/packages/flutter-app/test/travel_atlas_screen_test.dart
+++ b/src/packages/flutter-app/test/travel_atlas_screen_test.dart
@@ -1,0 +1,484 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:travel_route_planner/l10n/l10n.dart';
+import 'package:travel_route_planner/main.dart';
+import 'package:travel_route_planner/models/city_pin.dart';
+import 'package:travel_route_planner/models/trip.dart';
+import 'package:travel_route_planner/navigation/app_nav.dart';
+import 'package:travel_route_planner/navigation/app_routes.dart';
+import 'package:travel_route_planner/navigation/url_sync.dart';
+import 'package:travel_route_planner/providers/auth_provider.dart';
+import 'package:travel_route_planner/providers/live_trip_provider.dart';
+import 'package:travel_route_planner/providers/resumable_chats_provider.dart';
+import 'package:travel_route_planner/providers/shared_with_me_provider.dart';
+import 'package:travel_route_planner/providers/trip_cache_provider.dart';
+import 'package:travel_route_planner/providers/trips_provider.dart';
+import 'package:travel_route_planner/screens/travel_atlas_screen.dart';
+import 'package:travel_route_planner/screens/trips_list_screen.dart';
+import 'package:travel_route_planner/services/api_client.dart';
+import 'package:travel_route_planner/services/trip_cache.dart';
+import 'package:travel_route_planner/services/trips_api_service.dart';
+import 'package:travel_route_planner/widgets/section_header.dart';
+
+import 'support/l10n_test_app.dart';
+import 'support/url_sync_fakes.dart';
+
+/// The travel atlas — the "See all" destination of "Your travels".
+///
+/// The invariant the whole surface turns on is **membership**: the index holds
+/// finished trips only (`tripIsPast`), never trips merely started. The band on
+/// the trips list partitions on `tripHasStarted` because an aggregate should
+/// count the days already lived through; a row that names ONE trip and claims
+/// its length must not, or a 14-day trip on day 2 renders "2 days" and changes
+/// every morning.
+///
+/// Tile HTTP in widget tests 400s and is silently tolerated, so map assertions
+/// are structural (FlutterMap / camera / pin tooltips), never imagery.
+class _FixedTripsApiService extends TripsApiService {
+  final List<Trip> trips;
+
+  _FixedTripsApiService(this.trips) : super(ApiClient(baseUrl: 'http://test'));
+
+  @override
+  Future<List<Trip>> listTrips() async => trips;
+}
+
+String _iso(DateTime d) => '${d.year.toString().padLeft(4, '0')}-'
+    '${d.month.toString().padLeft(2, '0')}-'
+    '${d.day.toString().padLeft(2, '0')}';
+
+String _rel(int days) => _iso(DateTime.now().add(Duration(days: days)));
+
+/// A whole calendar year that is provably behind us whatever day the suite
+/// runs. Year membership is what the chips key on, so fixtures that care about
+/// it are anchored to a year rather than to a day offset: two trips 40 and 400
+/// days ago land in one calendar year or two depending on the date the suite
+/// runs, which would make the chip row appear and disappear by the season.
+final int _lastYear = DateTime.now().year - 1;
+
+Trip _trip(
+  String id,
+  String title, {
+  String? start,
+  String? end,
+  List<String>? cities,
+  List<CityPin>? pins,
+}) =>
+    Trip(
+      id: id,
+      title: title,
+      startDate: start,
+      endDate: end,
+      cities: cities,
+      cityPins: pins,
+      createdAt: '2026-06-01',
+      updatedAt: '2026-06-01',
+    );
+
+/// Two finished trips in ONE year, plus one still ahead — the shape the door
+/// is gated on, and (being single-year) the shape that shows no chip row.
+List<Trip> _history() => [
+      _trip('past1', 'Iberia Loop',
+          start: '$_lastYear-02-01',
+          end: '$_lastYear-02-08', // 8 days
+          cities: const ['Lisbon', 'Porto'],
+          pins: const [CityPin(city: 'Lisbon', lat: 38.7, lng: -9.1)]),
+      _trip('past2', 'Athens Trip',
+          start: '$_lastYear-09-01',
+          end: '$_lastYear-09-06', // 6 days
+          cities: const ['Athens'],
+          pins: const [CityPin(city: 'Athens', lat: 37.9, lng: 23.7)]),
+      _trip('ahead', 'Madrid Trip',
+          start: _rel(20),
+          end: _rel(24),
+          cities: const ['Madrid'],
+          pins: const [CityPin(city: 'Madrid', lat: 40.4, lng: -3.7)]),
+    ];
+
+/// Mounts the atlas over a fixed trips payload.
+///
+/// **One pump per test.** Re-pumping installs a fresh
+/// `tripsApiServiceProvider` override, which invalidates the `tripsProvider`
+/// that depends on it and resets the list to empty — a second pump would
+/// assert against an account with no trips rather than against a new fixture.
+Future<void> _pumpAtlas(
+  WidgetTester tester, {
+  required List<Trip> trips,
+  Size surface = const Size(390, 844),
+}) async {
+  await tester.binding.setSurfaceSize(surface);
+  addTearDown(() => tester.binding.setSurfaceSize(null));
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        tripsApiServiceProvider.overrideWithValue(_FixedTripsApiService(trips)),
+        tripCacheProvider.overrideWithValue(TripCache('u1')),
+        resumableChatsProvider.overrideWith((ref) async => const []),
+        sharedWithMeProvider.overrideWith((ref) async => const <Trip>[]),
+      ],
+      child: localizedTestApp(home: const TravelAtlasScreen()),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+/// [_history] plus an older year, so the year chip row renders.
+List<Trip> spanningHistory() => [
+      ..._history(),
+      _trip('older', 'Rome Trip',
+          start: '${_lastYear - 2}-09-01',
+          end: '${_lastYear - 2}-09-05',
+          cities: const ['Rome'],
+          pins: const [CityPin(city: 'Rome', lat: 41.9, lng: 12.5)]),
+    ];
+
+/// The live camera of the mounted plate, read from inside its subtree.
+MapCamera _camera(WidgetTester tester) =>
+    MapCamera.of(tester.element(find.byType(TileLayer).first));
+
+Finder _inIndex(Finder matching) =>
+    find.descendant(of: find.byKey(kAtlasIndexKey), matching: matching);
+
+void main() {
+  setUp(() => SharedPreferences.setMockInitialValues({}));
+
+  testWidgets('renders the plate, the colophon and the index', (tester) async {
+    await _pumpAtlas(tester, trips: _history());
+
+    expect(find.byType(FlutterMap), findsOneWidget);
+    expect(find.byKey(kAtlasTraveledStatsKey), findsOneWidget);
+    expect(find.byKey(kAtlasPlannedStatsKey), findsOneWidget);
+    expect(_inIndex(find.byType(SectionHeader)), findsOneWidget);
+    expect(_inIndex(find.text('Iberia Loop')), findsOneWidget);
+    expect(_inIndex(find.text('Athens Trip')), findsOneWidget);
+  });
+
+  testWidgets(
+      'the index holds finished trips only; a planned one stays on the map',
+      (tester) async {
+    await _pumpAtlas(tester, trips: _history());
+
+    // The map is *everywhere*; the index is *where you have been*.
+    expect(_inIndex(find.text('Madrid Trip')), findsNothing);
+    expect(find.byTooltip('Madrid · Planned'), findsOneWidget);
+    expect(find.byTooltip('Lisbon · Traveled'), findsOneWidget);
+  });
+
+  testWidgets('a trip currently under way gets no index row', (tester) async {
+    // The load-bearing distinction: travelStats would count this as traveled,
+    // and its row would claim a length that grows every morning.
+    await _pumpAtlas(tester, trips: [
+      ..._history(),
+      _trip('live', 'Naxos Now',
+          start: _rel(-2), end: _rel(5), cities: const ['Naxos']),
+    ]);
+
+    expect(_inIndex(find.text('Naxos Now')), findsNothing);
+    expect(_inIndex(find.text('Iberia Loop')), findsOneWidget);
+  });
+
+  testWidgets('rows print their length; a half-dated trip prints none',
+      (tester) async {
+    await _pumpAtlas(tester, trips: [
+      ..._history(),
+      // End date only, long past — tripIsPast accepts it, dayCount cannot
+      // measure it, and "0 days" would be a lie about a trip that took some.
+      _trip('half', 'Split & Hvar', end: _rel(-800), cities: const ['Split']),
+    ]);
+
+    expect(_inIndex(find.text('8 days')), findsOneWidget);
+    expect(_inIndex(find.text('6 days')), findsOneWidget);
+    expect(_inIndex(find.text('Split & Hvar')), findsOneWidget);
+    expect(_inIndex(find.text('0 days')), findsNothing);
+  });
+
+  testWidgets('the zoom buttons move the camera', (tester) async {
+    // Required because the plate opts out of scroll-wheel zoom: without them a
+    // full-bleed desktop map could not be zoomed at all.
+    await _pumpAtlas(tester, trips: _history());
+
+    final before = _camera(tester).zoom;
+    await tester.tap(find.byTooltip('Zoom in'));
+    await tester.pumpAndSettle();
+    expect(_camera(tester).zoom, greaterThan(before));
+
+    await tester.tap(find.byTooltip('Zoom out'));
+    await tester.pumpAndSettle();
+    expect(_camera(tester).zoom, closeTo(before, 0.001));
+  });
+
+  // Two pumps, two tests: re-pumping a fresh `tripsApiServiceProvider`
+  // override inside ONE test resets the tripsProvider it feeds, so the second
+  // half would assert against an empty account rather than a narrow layout.
+  testWidgets('at 900 the index reads beside the plate', (tester) async {
+    await _pumpAtlas(tester, trips: _history(), surface: const Size(1200, 900));
+
+    final plate = tester.getRect(find.byType(FlutterMap));
+    final index = tester.getRect(find.byKey(kAtlasIndexKey));
+    expect(index.left, greaterThanOrEqualTo(plate.right),
+        reason: 'the index reads beside the plate, not under it');
+    // Full-bleed: the atlas does not inherit the trips list's capped reading
+    // column, because the surface is map-led.
+    expect(plate.height, greaterThan(600),
+        reason: 'the plate fills the height, it is not a letterboxed band');
+    expect(plate.left, 0.0);
+  });
+
+  testWidgets('below 900 the index stacks under the plate', (tester) async {
+    await _pumpAtlas(tester, trips: _history(), surface: const Size(390, 844));
+
+    final plate = tester.getRect(find.byType(FlutterMap));
+    final index = tester.getRect(find.byKey(kAtlasIndexKey));
+    expect(index.top, greaterThanOrEqualTo(plate.bottom));
+    expect(plate.width, 390.0, reason: 'the plate is full-bleed here too');
+  });
+
+  testWidgets('on the smallest phone the index still reads as a list',
+      (tester) async {
+    // The plate-height decision, pinned — see `_plateHeight`'s doc.
+    //
+    // The binding case, not the easy one: a 375×667 phone carrying the
+    // TALLEST chrome this screen can have — the year chip row (history spans
+    // more than one year) above a colophon rendering BOTH groups. Under that,
+    // the index heading and its first row must sit whole above the fold, and
+    // the second must be cut by it. The whole row says "this is a list"; the
+    // cut one says "there is more". A height that loses either is a height to
+    // re-measure, not a test to relax.
+    await _pumpAtlas(tester,
+        trips: [
+          ...spanningHistory(),
+          _trip('past4', 'Split Trip',
+              start: '${_lastYear - 3}-03-01',
+              end: '${_lastYear - 3}-03-06',
+              cities: const ['Split']),
+        ],
+        surface: const Size(375, 667));
+
+    const fold = 667.0;
+    // Newest first by first day: last September, then last February.
+    for (final label in ['Past trips', 'Athens Trip']) {
+      expect(tester.getRect(find.text(label)).bottom, lessThan(fold),
+          reason: '"$label" must sit whole above the fold');
+    }
+    final second = tester.getRect(find.text('Iberia Loop'));
+    expect(second.top, lessThan(fold),
+        reason: 'the second row must peek over the fold');
+    expect(second.bottom, greaterThan(fold),
+        reason: 'and be cut by it, so the list reads as continuing');
+  });
+
+  testWidgets('with no finished trips it offers the way to make some',
+      (tester) async {
+    // Only reachable by URL — the door is gated on 2+ finished trips — so this
+    // is a degrade, not a designed destination.
+    await _pumpAtlas(tester, trips: [
+      _trip('a', 'Madrid Trip', start: _rel(20), end: _rel(24)),
+      _trip('b', 'Someday Trip'),
+    ]);
+
+    expect(find.byKey(kAtlasIndexKey), findsNothing);
+    expect(find.text('No finished trips yet'), findsOneWidget);
+    expect(find.text('Add past trip'), findsOneWidget);
+  });
+
+  testWidgets('booting /atlas lands on the atlas inside the shell',
+      (tester) async {
+    // The importTrip deep-link shape: a zero-argument screen reconstructible
+    // from its path, restored onto the Trips tab.
+    tester.binding.platformDispatcher.defaultRouteNameTestValue = '/atlas';
+    addTearDown(
+        tester.binding.platformDispatcher.clearDefaultRouteNameTestValue);
+    final reports = <String>[];
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          authProvider.overrideWith((ref) => FakeAuthNotifier(fakeUser())),
+          tripsApiServiceProvider
+              .overrideWithValue(_FixedTripsApiService(_history())),
+          liveTripProvider.overrideWithValue(null),
+          resumableChatsProvider.overrideWith((ref) async => const []),
+          urlReporterProvider.overrideWithValue(reports.add),
+        ],
+        child: const TravelRoutePlannerApp(),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byType(TravelAtlasScreen), findsOneWidget);
+    expect(
+      ProviderScope.containerOf(
+              tester.element(find.byType(TravelRoutePlannerApp)))
+          .read(navIndexProvider),
+      AppTab.trips.index,
+    );
+    expect(reports.last, '/atlas');
+  });
+
+  group('year chips', () {
+    // Last year's two finished trips, an older year's one, and a trip still
+    // ahead — so a year filter has a past row to keep AND a planned pin to
+    // keep showing, in the same year.
+    final older = _lastYear - 2;
+    List<Trip> spanning() => spanningHistory();
+
+    testWidgets('absent when the history spans one year', (tester) async {
+      // A lone year chip beside "All time" is chrome that filters nothing.
+      await _pumpAtlas(tester, trips: _history());
+      expect(find.text('All time'), findsNothing);
+      expect(find.text('$_lastYear'), findsNothing);
+    });
+
+    testWidgets('present at two years', (tester) async {
+      await _pumpAtlas(tester, trips: spanning());
+      expect(find.text('All time'), findsOneWidget);
+      expect(find.text('$_lastYear'), findsOneWidget);
+      expect(find.text('$older'), findsOneWidget);
+    });
+
+    testWidgets('years read newest first, after All time', (tester) async {
+      await _pumpAtlas(tester, trips: spanning());
+      final allTime = tester.getRect(find.text('All time'));
+      final newest = tester.getRect(find.text('$_lastYear'));
+      final oldest = tester.getRect(find.text('$older'));
+      expect(allTime.right, lessThanOrEqualTo(newest.left));
+      expect(newest.right, lessThanOrEqualTo(oldest.left));
+    });
+
+    testWidgets('picking a year narrows the index, the colophon and the map',
+        (tester) async {
+      await _pumpAtlas(tester, trips: spanning());
+      // All time: everything.
+      expect(_inIndex(find.text('Iberia Loop')), findsOneWidget);
+      expect(_inIndex(find.text('Athens Trip')), findsOneWidget);
+      expect(find.byKey(kAtlasPlannedStatsKey), findsOneWidget);
+
+      await tester.tap(find.text('$older'));
+      await tester.pumpAndSettle();
+
+      // Index: only that year's finished trips.
+      expect(_inIndex(find.text('Rome Trip')), findsOneWidget);
+      expect(_inIndex(find.text('Iberia Loop')), findsNothing);
+      // Colophon: degenerates to one group, which the zero-group rule already
+      // handles — there is nothing planned in a year that is over.
+      expect(find.byKey(kAtlasTraveledStatsKey), findsOneWidget);
+      expect(find.byKey(kAtlasPlannedStatsKey), findsNothing);
+      // Map: that year's pins only.
+      expect(find.byTooltip('Rome · Traveled'), findsOneWidget);
+      expect(find.byTooltip('Lisbon · Traveled'), findsNothing);
+      expect(find.byTooltip('Madrid · Planned'), findsNothing);
+    });
+
+    testWidgets(
+        'a filtered year keeps a trip under way on the map, off the index',
+        (tester) async {
+      // The map is *everywhere*: a year chip narrows it, it does not turn it
+      // into the index. A trip that began in that year and is still running is
+      // exactly the case where the two rules differ — travelStats counts it,
+      // the index must not.
+      await _pumpAtlas(tester, trips: [
+        ...spanning(),
+        _trip('live', 'Naxos Now',
+            start: '$_lastYear-12-01', // began last year...
+            end: _rel(30), // ...and is not over
+            cities: const ['Naxos'],
+            pins: const [CityPin(city: 'Naxos', lat: 37.1, lng: 25.4)]),
+      ]);
+      await tester.tap(find.text('$_lastYear'));
+      await tester.pumpAndSettle();
+
+      expect(find.byTooltip('Naxos · Traveled'), findsOneWidget);
+      expect(_inIndex(find.text('Naxos Now')), findsNothing);
+      expect(_inIndex(find.text('Iberia Loop')), findsOneWidget);
+    });
+
+    testWidgets('All time restores the full set', (tester) async {
+      await _pumpAtlas(tester, trips: spanning());
+      await tester.tap(find.text('$older'));
+      await tester.pumpAndSettle();
+      expect(_inIndex(find.text('Iberia Loop')), findsNothing);
+
+      await tester.tap(find.text('All time'));
+      await tester.pumpAndSettle();
+      expect(_inIndex(find.text('Iberia Loop')), findsOneWidget);
+      expect(_inIndex(find.text('Athens Trip')), findsOneWidget);
+      expect(find.byTooltip('Madrid · Planned'), findsOneWidget);
+    });
+
+    testWidgets('a year whose trips are all half-dated still lists them',
+        (tester) async {
+      await _pumpAtlas(tester, trips: [
+        ...spanning(),
+        _trip('half', 'Split & Hvar',
+            end: '${_lastYear - 4}-08-19', cities: const ['Split']),
+      ]);
+      await tester.tap(find.text('${_lastYear - 4}'));
+      await tester.pumpAndSettle();
+
+      expect(_inIndex(find.text('Split & Hvar')), findsOneWidget);
+      expect(_inIndex(find.text('0 days')), findsNothing);
+    });
+
+    testWidgets('the chips keep the 48px touch floor', (tester) async {
+      await _pumpAtlas(tester, trips: spanning());
+      for (final label in ['All time', '$_lastYear', '$older']) {
+        final chip = find.ancestor(
+            of: find.text(label), matching: find.byType(ChoiceChip));
+        expect(tester.getSize(chip).height, greaterThanOrEqualTo(48.0),
+            reason: '"$label" must clear kMinTouchTarget');
+      }
+    });
+  });
+
+  testWidgets('the trips-list door opens the atlas and back returns to it',
+      (tester) async {
+    // The door lives in trips_list_screen (its gate is tested beside the band,
+    // in trips_list_footprint_test); what is asserted here is the other end of
+    // it — openAtlasOnTripsTab needs the shell's tab navigators, so this pumps
+    // the real app the way the other tab-push helpers are tested.
+    tester.binding.platformDispatcher.defaultRouteNameTestValue =
+        kTripsLocation;
+    addTearDown(
+        tester.binding.platformDispatcher.clearDefaultRouteNameTestValue);
+    final reports = <String>[];
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          authProvider.overrideWith((ref) => FakeAuthNotifier(fakeUser())),
+          tripsApiServiceProvider
+              .overrideWithValue(_FixedTripsApiService(_history())),
+          liveTripProvider.overrideWithValue(null),
+          resumableChatsProvider.overrideWith((ref) async => const []),
+          urlReporterProvider.overrideWithValue(reports.add),
+        ],
+        child: const TravelRoutePlannerApp(),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.scrollUntilVisible(find.byKey(kTravelAtlasSeeAllKey), 300,
+        scrollable: find.byType(Scrollable).first);
+    await tester.tap(find.byKey(kTravelAtlasSeeAllKey));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(TravelAtlasScreen), findsOneWidget);
+    expect(reports.last, '/atlas');
+
+    // Back lands on the list it came from, not on a tab root elsewhere.
+    await tester.pageBack();
+    await tester.pumpAndSettle();
+    expect(find.byType(TravelAtlasScreen), findsNothing);
+    expect(find.byType(TripsListScreen), findsOneWidget);
+    expect(reports.last, kTripsLocation);
+  });
+
+  testWidgets('the app bar says what the section that opened it says',
+      (tester) async {
+    await _pumpAtlas(tester, trips: _history());
+    final l10n = await AppLocalizations.delegate.load(const Locale('en'));
+    expect(find.text(l10n.tripsListYourTravels), findsOneWidget);
+  });
+}

--- a/src/packages/flutter-app/test/trip_list_insights_test.dart
+++ b/src/packages/flutter-app/test/trip_list_insights_test.dart
@@ -294,6 +294,164 @@ void main() {
     });
   });
 
+  // The atlas reads the same payload as the band, through a STRICTER
+  // membership rule: tripIsPast, not tripHasStarted. travelStats' partition is
+  // right for an aggregate and wrong for a row that names one trip and claims
+  // its length — an in-progress trip would get a row whose "days" changes every
+  // morning. These cases pin that, plus the two shapes the contract calls out
+  // by name: a half-dated past trip (no length, never "0 days") and a Dec→Jan
+  // trip (one trip, one year — its first day's).
+  group('pastTrips', () {
+    test('a trip in progress is not past', () {
+      final trips = [
+        _trip('live', start: '2026-08-04', end: '2026-08-13'),
+        _trip('done', start: '2026-07-01', end: '2026-07-05'),
+      ];
+      expect(pastTrips(trips, _today).map((t) => t.id), ['done']);
+    });
+
+    test('a trip ending today is not past; one ending yesterday is', () {
+      expect(
+        pastTrips([_trip('t', start: '2026-08-01', end: '2026-08-06')], _today),
+        isEmpty,
+      );
+      expect(
+        pastTrips([_trip('t', start: '2026-08-01', end: '2026-08-05')], _today),
+        hasLength(1),
+      );
+    });
+
+    test('an undated trip is never past', () {
+      expect(pastTrips([_trip('draft', cities: const ['Tokyo'])], _today),
+          isEmpty);
+    });
+
+    test('an end-date-only trip in the past IS past', () {
+      expect(pastTrips([_trip('half', end: '2026-05-20')], _today), hasLength(1));
+    });
+
+    test('preserves the caller order, so footprintPins dedupes unchanged', () {
+      final trips = [
+        _trip('b', start: '2026-01-01', end: '2026-01-05'),
+        _trip('a', start: '2026-03-01', end: '2026-03-05'),
+      ];
+      expect(pastTrips(trips, _today).map((t) => t.id), ['b', 'a']);
+    });
+  });
+
+  group('atlasYears', () {
+    test('distinct years of past trips, newest first', () {
+      final years = atlasYears([
+        _trip('a', start: '2024-05-01', end: '2024-05-10'),
+        _trip('b', start: '2026-02-01', end: '2026-02-10'),
+        _trip('c', start: '2024-10-01', end: '2024-10-10'),
+      ], _today);
+      expect(years, [2026, 2024]);
+    });
+
+    test('excludes a trip in progress and an undated draft', () {
+      final years = atlasYears([
+        _trip('live', start: '2026-08-04', end: '2026-08-13'),
+        _trip('draft', cities: const ['Tokyo']),
+        _trip('done', start: '2025-04-01', end: '2025-04-05'),
+      ], _today);
+      expect(years, [2025]);
+    });
+
+    test('a Dec→Jan trip lands in exactly one year — its first day\'s', () {
+      final years = atlasYears(
+          [_trip('nye', start: '2025-12-28', end: '2026-01-04')], _today);
+      expect(years, [2025]);
+    });
+
+    test('an end-date-only past trip files under its end date', () {
+      expect(atlasYears([_trip('half', end: '2023-09-14')], _today), [2023]);
+    });
+  });
+
+  group('tripsInAtlasYear', () {
+    test('keeps planned trips — the map is everywhere, the index is not', () {
+      final trips = [
+        _trip('past', start: '2026-02-01', end: '2026-02-05'),
+        _trip('planned', start: '2026-11-01', end: '2026-11-05'),
+        _trip('other', start: '2025-02-01', end: '2025-02-05'),
+      ];
+      expect(tripsInAtlasYear(trips, 2026).map((t) => t.id),
+          ['past', 'planned']);
+    });
+
+    test('an undated trip belongs to no year', () {
+      expect(tripsInAtlasYear([_trip('draft')], 2026), isEmpty);
+    });
+  });
+
+  group('atlasRows', () {
+    test('past trips only, newest first, with year/month and length', () {
+      final rows = atlasRows([
+        _trip('older', start: '2024-10-02', end: '2024-10-07'), // 6 days
+        _trip('newer', start: '2026-02-01', end: '2026-02-12'), // 12 days
+        _trip('live', start: '2026-08-04', end: '2026-08-13'),
+        _trip('ahead', start: '2026-09-01', end: '2026-09-03'),
+      ], _today);
+      expect(rows.map((r) => r.trip.id), ['newer', 'older']);
+      expect(rows.first.year, 2026);
+      expect(rows.first.month, 2);
+      expect(rows.first.days, 12);
+      expect(rows.last.days, 6);
+    });
+
+    test('a half-dated past trip has NO length, not 0', () {
+      // dayCount answers 0 whenever either date is missing, and an
+      // end-date-only trip can still be past — a row that trusted the number
+      // would print "0 days" for a trip that plainly took some.
+      final rows = atlasRows([_trip('half', end: '2023-08-19')], _today);
+      expect(rows.single.days, isNull);
+      expect(rows.single.year, 2023);
+      expect(rows.single.month, 8);
+    });
+
+    test('a Dec→Jan trip files under its first day, and is one row', () {
+      final rows = atlasRows(
+          [_trip('nye', start: '2025-12-28', end: '2026-01-04')], _today);
+      expect(rows, hasLength(1));
+      expect((rows.single.year, rows.single.month), (2025, 12));
+      expect(rows.single.days, 8);
+    });
+
+    test('year: n returns only that year, still newest first', () {
+      final rows = atlasRows([
+        _trip('spring', start: '2025-04-01', end: '2025-04-05'),
+        _trip('autumn', start: '2025-09-01', end: '2025-09-05'),
+        _trip('other', start: '2024-06-01', end: '2024-06-05'),
+      ], _today, year: 2025);
+      expect(rows.map((r) => r.trip.id), ['autumn', 'spring']);
+    });
+
+    test('an undated trip gets no row', () {
+      expect(atlasRows([_trip('draft', cities: const ['Tokyo'])], _today),
+          isEmpty);
+    });
+
+    test('overlapping trips order by their FIRST day, the printed one', () {
+      // 'long' ends later but STARTED earlier; the reference column prints the
+      // first day, so ordering by the last day would leave the leading column
+      // reading 2026-01 above 2026-02.
+      final rows = atlasRows([
+        _trip('long', start: '2026-01-15', end: '2026-03-01'),
+        _trip('short', start: '2026-02-01', end: '2026-02-28'),
+      ], _today);
+      expect(rows.map((r) => r.trip.id), ['short', 'long']);
+    });
+
+    test('equal first days break the tie on createdAt, newest first', () {
+      final rows = atlasRows([
+        _trip('old', start: '2026-02-01', end: '2026-02-03', created: '2026-01-01T00:00:00Z'),
+        _trip('new', start: '2026-02-01', end: '2026-02-05', created: '2026-03-01T00:00:00Z'),
+      ], _today);
+      expect(rows.map((r) => r.trip.id), ['new', 'old']);
+    });
+  });
+
   group('Trip insight fields JSON', () {
     test('a payload with every insight key populates and round-trips', () {
       final trip = Trip.fromJson({

--- a/src/packages/flutter-app/test/trips_list_footprint_test.dart
+++ b/src/packages/flutter-app/test/trips_list_footprint_test.dart
@@ -294,6 +294,134 @@ void main() {
     expect(find.text('cities'), findsNothing);
   });
 
+  // The atlas door (the "See all" action in this section's header).
+  //
+  // It is gated on FINISHED trips — tripIsPast — and that predicate is the
+  // whole point. The card's own gate counts owned trips; travelStats counts
+  // trips that have STARTED. Either would open the door for an account whose
+  // atlas has no traveled pins, no Traveled colophon group (it doesn't render
+  // at zero) and an index with no rows at all.
+  //
+  // One pump per test: _pumpList installs a fresh tripsApiServiceProvider
+  // override, which resets the tripsProvider that reads it.
+  group('the atlas door', () {
+    testWidgets('absent with one finished trip', (WidgetTester tester) async {
+      await _pumpList(tester, trips: [
+        _trip('past', 'Iberia Loop', start: _rel(-30), end: _rel(-26)),
+        _trip('next', 'Madrid Trip', start: _rel(10), end: _rel(12)),
+      ]);
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(kTravelAtlasSeeAllKey), findsNothing);
+      // The band itself is present — the two gates ask different questions.
+      expect(find.byType(TravelFootprintCard), findsOneWidget);
+      // And the header keeps the action that fills the history, which is how
+      // this account earns the door.
+      expect(find.byKey(kLogTripSectionActionKey), findsOneWidget);
+    });
+
+    testWidgets('present at two finished trips', (WidgetTester tester) async {
+      await _pumpList(tester, trips: [
+        _trip('past', 'Iberia Loop', start: _rel(-30), end: _rel(-26)),
+        _trip('older', 'Athens Trip', start: _rel(-90), end: _rel(-85)),
+      ]);
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(kTravelAtlasSeeAllKey), findsOneWidget);
+    });
+
+    testWidgets('absent when the second started trip is still under way',
+        (WidgetTester tester) async {
+      // travelStats reports two traveled trips here. One of them is happening
+      // right now, and a retrospective is not where it belongs — the same
+      // category error the list already refuses for "Past trips".
+      await _pumpList(tester, trips: [
+        _trip('past', 'Iberia Loop', start: _rel(-30), end: _rel(-26)),
+        _trip('live', 'Athens Now', start: _rel(-2), end: _rel(5)),
+      ]);
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(kTravelAtlasSeeAllKey), findsNothing);
+      // ...and the band still counts it as traveled, unchanged: the gate moved,
+      // the colophon did not.
+      expect(find.byKey(kTraveledStatsKey), findsOneWidget);
+    });
+
+    testWidgets('both header actions fit a 360dp phone',
+        (WidgetTester tester) async {
+      // 360dp is the commonest Android width and the one that decides this:
+      // SectionHeader's Wrap can drop the action group onto its own line, but
+      // the group must also be able to break INSIDE itself — a Row of these
+      // two buttons overflows by 28px here.
+      //
+      await tester.binding.setSurfaceSize(const Size(360, 800));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+      await _pumpList(tester, trips: [
+        _trip('past', 'Porto', start: _rel(-30), end: _rel(-26)),
+        _trip('older', 'Naxos', start: _rel(-90), end: _rel(-85)),
+      ]);
+      await tester.pumpAndSettle();
+
+      // The "Past trips" collapsible row above overflows by 12px at this
+      // width — its header Row gives the count pill and chevron no room to
+      // give — and it does so on main too, with or without this lane. It is
+      // consumed here so it cannot fail teardown, and asserted to be the ONLY
+      // one: a header that overflowed as well would turn this into "Multiple
+      // exceptions" and fail.
+      expect(tester.takeException().toString(),
+          isNot(contains('Multiple exceptions')));
+      // Both live INSIDE the section header, not one orphaned beside it...
+      final header = find.ancestor(
+          of: find.byKey(kTravelAtlasSeeAllKey),
+          matching: find.byType(SectionHeader));
+      expect(header, findsOneWidget);
+      expect(
+          find.descendant(
+              of: header, matching: find.byKey(kLogTripSectionActionKey)),
+          findsOneWidget);
+      // ...and neither runs past its edge, whichever line it lands on.
+      final bounds = tester.getRect(header);
+      final seeAll = tester.getRect(find.byKey(kTravelAtlasSeeAllKey));
+      final logTrip = tester.getRect(find.byKey(kLogTripSectionActionKey));
+      for (final button in [seeAll, logTrip]) {
+        expect(button.right, lessThanOrEqualTo(bounds.right + 0.5));
+        expect(button.left, greaterThanOrEqualTo(bounds.left - 0.5));
+      }
+      // Measured: at 360 the pair breaks, and the two buttons stack on the
+      // TITLE's left edge rather than on each other's right edge — which is
+      // neither margin and reads as an accident.
+      expect(logTrip.top, greaterThan(seeAll.top));
+      expect(logTrip.left, seeAll.left);
+      // PR #401's pin still holds: the title is a page-level header outside
+      // the card, and the actions did not drag it inside.
+      expect(
+          find.descendant(
+              of: find.byType(TravelFootprintCard),
+              matching: find.text('Your travels')),
+          findsNothing);
+    });
+  });
+
+  testWidgets('at 390dp both header actions share one line',
+      (WidgetTester tester) async {
+    // The artifact predicted a two-line header on a phone and that is what a
+    // 390dp phone gets: the title, then both actions beside each other. Only
+    // at 360 and below does the pair itself have to break.
+    await tester.binding.setSurfaceSize(const Size(390, 800));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    await _pumpList(tester, trips: [
+      _trip('past', 'Porto', start: _rel(-30), end: _rel(-26)),
+      _trip('older', 'Naxos', start: _rel(-90), end: _rel(-85)),
+    ]);
+    await tester.pumpAndSettle();
+    tester.takeException(); // the collapsible's own pre-existing overflow
+
+    final seeAll = tester.getRect(find.byKey(kTravelAtlasSeeAllKey));
+    final logTrip = tester.getRect(find.byKey(kLogTripSectionActionKey));
+    expect(logTrip.top, seeAll.top);
+    expect(logTrip.left, greaterThanOrEqualTo(seeAll.right - 0.5));
+  });
+
   testWidgets('the map marks visited cities apart from planned ones',
       (WidgetTester tester) async {
     await _pumpList(tester, trips: [


### PR DESCRIPTION
> **Merged before its corrections landed.** This PR merged at commit `714aa0c`. A browser walkthrough afterwards found four things — a selected chip rendering in the disabled palette, chips clipped in the ≥900 side column, header test assertions that encoded a layout the real app never produces, and a plate-height measurement that omitted the shell's navigation bar. Those fixes are in **#511**, not here. The "Two retractions" and "Settled in the lane" sections below describe the corrected behaviour and therefore describe #511's tree, not this one.

## Summary

Makes the "Your travels" retrospective explorable, without disturbing it.

- **The band does not change.** Same 140px height, static camera, content and position — PR #488's quiet closing plate, byte-identical below the gate. The case for a separate screen is size and focus: a 140px band is a thumbnail of the whole planet, and growing it would mean promoting the retrospective above the plans.
- **New `lib/screens/travel_atlas_screen.dart`** at `/atlas`: a satellite plate (`InteractiveFlag.all & ~scrollWheelZoom` **plus** explicit zoom buttons — the buttons exist *because* of the wheel opt-out, or a full-bleed desktop map could not be zoomed at all), the same colophon as a caption on paper below it, and a typographic index of finished trips.
- **Year chips** narrow map, colophon and index together. They render only when the history spans 2+ distinct years — a lone chip beside "All time" is chrome that filters nothing.
- **The door** is a marked `See all` action in the existing `SectionHeader`, not a tappable card: the card carries no affordance, and every pin on it is a 44px hit box already spending taps on a tooltip.
- **Additive-only** in `lib/utils/trip_list_insights.dart` (`pastTrips`, `atlasFirstDay`, `atlasYears`, `tripsInAtlasYear`, `AtlasRow`/`atlasRows`) — it reaches Home through `trip_hero_card.dart`, so no existing signature moved. Zero removed lines in that file.
- `_FootprintPin` / `_StatGroup` extracted to `lib/widgets/travel_footprint_parts.dart` as `FootprintDot` / `TravelStatGroup`, so the atlas and the band cannot drift. The card's rendered output is unchanged and `trips_list_footprint_test.dart`'s PR #401 pins pass unmodified.

### The load-bearing decisions

- **`tripIsPast`, never `tripHasStarted`.** `travelStats` partitions on the latter, which counts a trip *currently under way* as traveled — right for an aggregate, wrong for a row that names one trip and claims its length (a 14-day trip on day 2 would read "2 days" and change every morning). It also makes `traveledDayCount == dayCount`, so rows need no special day-count rule; a half-dated trip prints **no** length rather than "0 days".
- **The gate is 2+ finished trips.** Below that there is nothing behind the door: no traveled pins, no Traveled colophon group (it doesn't render at zero), and an index with no rows at all. Those accounts keep the card exactly as today and the header keeps `+ Add past trip`, which is how the history that unlocks the atlas gets here.
- **No text on the satellite image.** `heroScrim` over imagery is a teal-tinted photo — a named instant finding (`brand-guidelines/SKILL.md:83`, `DESIGN.md:338`). The caption sits on paper below the plate, so no scrim is needed at all.
- **Route arcs are cut.** `CityPin` is `{city, lat, lng}` with no ordinal, date or trip id, and the server's hub lateral is a deduped set in first-appearance order — a round trip's return leg is structurally unrepresentable. Arcs need a server change to the list lateral.

### Settled in the lane

| Open question | Settled | Why |
|---|---|---|
| **Plate height** — 280 (wireframe) vs 240 (`_GuideMap`) | **240** (`kAtlasPlateHeight`) | Measured **in the running app** on a 375×667 phone under the tallest chrome this screen can have (chip row + both colophon groups) **and under the shell's 80px navigation bar**. 280 pushes the first index row's text under the bar; 256 leaves one row and nothing after it; 240 gives the heading, one whole row, and the next beginning at the bar. It is also the height this app already ships for an interactive map in a scrolling column, so there is no third map size. A 390×844 phone — the common case — shows four whole rows and a fifth cut by the bar. |
| **Chip order** | **"All time" leads**; years newest-first. Pinned outside the scroll view on a phone; wrapped in the ≥900 side column | `BookingFilterBar` settled the general rule: on ten years of history the strip scrolls, and an exit that can scroll off-screen is not an exit. A clipped trailing chip is the ordinary scroll affordance on a phone; in a fixed 400px column it reads as a rendering fault, so there the chips wrap. |
| **Two-line header at phone width** | **One line at 360dp English; two in Spanish** — the title, then both actions together | Measured in the browser at 320/360/390/430 in both languages. The action group is a `Wrap` rather than a `Row` so it *can* break inside itself at large accessibility text scales, not because it overflows at any shipped width. |

## Two retractions from the browser walkthrough

Both were widget-test artifacts. There is no `flutter_test_config.dart` and no font loading in this suite, so widget tests lay out with Flutter's built-in fixed-width test font — **text-width measurements in them are not evidence about Inter.**

1. **"A `Row` of the two header actions overflows by 28px at 360dp" was wrong.** In the running app at 360dp English the title and both actions sit on one line; Spanish drops the pair together onto a second, and even 320dp Spanish keeps the pair on one line. The `Wrap` stays as a defensive choice; its justification is corrected in the code and above.
2. **The `CollapsibleSection` 12px overflow this branch reported is also not real.** Same cause. In the app the "Past trips" row ellipsizes its summary and fits at every width driven. No follow-up needed.

An earlier revision of `trips_list_footprint_test.dart` pinned a three-line header stack as required behaviour — a test that passed while encoding fiction, and that a correct future change could have failed. Those assertions are gone; what survives is font-independent (both actions inside the `SectionHeader`, neither escaping its bounds, no overflow, PR #401's pin). The atlas's plate-height test likewise now pins the constant and the order of what follows it rather than a pixel claim about where text lands.

## Known characteristic, recorded rather than fixed

**The wide layout's camera is longitude-bound.** With pins from Lisbon to Tokyo, fitting the longitude span on a ~944px-tall plate shows Greenland to Antarctica, so the pins sit in a band across the upper third with a lot of empty ocean below. That is what "fit all pins" means on a tall viewport — the 140px band never showed it because it had no height to waste. Tightening it needs a deliberate rule (e.g. latitude-biased fit padding), which is a design decision for the artifact, not something to smuggle into this PR.

## Testing

- `flutter test` — **1763 passing**, full suite, no skips.
  - New `test/travel_atlas_screen_test.dart` (20): plate/colophon/index render; index excludes planned trips while the map keeps their hollow pins; a trip under way gets no row; half-dated rows print no length; zoom buttons move the camera; ≥900 side-by-side vs <900 stacked; the plate height and the order of the paper below it; the URL-only empty state; `/atlas` deep-link boot; the door round trip (tap → atlas → back to the list, URL reports `/atlas` then `/trips`); and the chip group (absent at one year, present at two, newest-first after "All time", surface-wide filtering, "All time" restores, 48px touch floor).
  - `test/trip_list_insights_test.dart` (+18): the `tripIsPast` membership rule, Dec→Jan trips landing in exactly one year, half-dated rows, per-year narrowing, first-day ordering with a `createdAt` tie-break.
  - `test/trips_list_footprint_test.dart` (+4): the door absent at one finished trip, present at two, absent when the second started trip is still under way, and both actions living inside the header without escaping it. Every pre-existing assertion in the file is untouched.
- `flutter analyze` — clean (3 pre-existing `unnecessary_brace_in_string_interps` infos in `lib/models/route_response.dart`, untouched).
- **Browser walkthrough** against a lane stack, two seeded accounts (five finished trips across 2023–2026 including a half-dated one, plus one upcoming; and a planned-only account), host headless Chrome at 320/360/375/390/430/1440 in both themes and both languages. Verified: the plate reads as satellite; filled-vs-hollow pins are legible at 12px; the index's tabular references self-align; the half-dated row prints no length; a year chip narrows all three views; index rows open the right trip; the thin-history account gets no `See all` and `/atlas` degrades to its empty state. The selected chip's brand tint is pixel-sampled at (224,242,241) on paper and the scheme's `primaryContainer` on dark.
- `flutter gen-l10n` run after all tickets; `l10n_untranslated.json` is `{}`. New keys are all under the lane's reserved `travelAtlas*` prefix, in **both** `.arb` files. The app-bar title, the map's semantics label and the row length reuse existing keys so the door and its destination can never call the place two names.
- `.claude/skills/brand-guidelines/scripts/check.sh` — **1 finding, explained**: `travel_footprint_parts.dart:55` `[adhoc-shadow]`. It is the footprint pin's existing white-ring shadow moved verbatim out of `travel_footprint_card.dart:341`, where the same check reported it before this branch (verified by stashing). A 4px blur under a 12px dot on satellite imagery is pin styling, not an `AppShadows` elevation — the same literal `_GuidePin` carries. Net finding count is unchanged.

Design stack consulted in order: `design-inspiration` (Cereal's typographic index and caption discipline; Airbnb's chip row as the entire secondary navigation) → `lib/theme` tokens → `brand-guidelines`.

Governed by the Atlas artifact, revision 3, and its two cold reads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

