### PR TITLE
fix(trips): brand-tint the selected year chip, and de-fictionalize the header tests

### DIFF
--- a/src/packages/flutter-app/lib/screens/travel_atlas_screen.dart
+++ b/src/packages/flutter-app/lib/screens/travel_atlas_screen.dart
@@ -10,6 +10,7 @@ import '../l10n/l10n.dart';
 import '../navigation/app_nav.dart';
 import '../navigation/app_routes.dart';
 import '../providers/trips_provider.dart';
+import '../theme/app_colors.dart';
 import '../theme/spacing.dart';
 import '../utils/trip_days.dart';
 import '../utils/trip_format.dart';
@@ -31,6 +32,40 @@ import 'trip_detail_screen.dart';
 const kAtlasTraveledStatsKey = ValueKey('travelAtlas.stats.traveled');
 const kAtlasPlannedStatsKey = ValueKey('travelAtlas.stats.planned');
 const kAtlasIndexKey = ValueKey('travelAtlas.index');
+
+/// The plate's height below the wide seam.
+///
+/// Measured, not picked between the wireframe's 280 and `_GuideMap`'s shipped
+/// 240 — and measured **in the running app**, because the thing being measured
+/// is where text lands, and widget tests lay out with Flutter's fixed-width
+/// test font rather than Inter. A number taken from a widget test would not be
+/// a number about this app.
+///
+/// The binding case is the smallest phone this app supports (375×667) carrying
+/// the tallest chrome this screen can have — the year chip row above a
+/// colophon rendering BOTH groups — and, crucially, **under the shell's
+/// [NavigationBar]**, whose 80px means the fold sits ~80px above the viewport
+/// floor. Each index row is 49 tall, so the candidates differ only in what
+/// survives that fold:
+///
+///   * **280** — the heading, with the first row's text under the bar.
+///   * **256** — the heading and one row, nothing after it.
+///   * **240** — the heading and one whole row, the second beginning right at
+///     the bar: the most a phone this small has room to promise.
+///
+/// So 240 — which is also, independently, the height this app already ships
+/// for an interactive map inside a scrolling column (`_GuideMap`), so the
+/// atlas introduces no third map size. It is genuinely tight at 667pt and
+/// comfortable everywhere else: a 390×844 phone shows the heading and FOUR
+/// whole rows with a fifth cut by the bar. Going shorter to buy the smallest
+/// phone a second row would cost every other phone the map room this screen
+/// exists to give.
+///
+/// The screen's test pins this constant and the order of what follows it —
+/// both font-independent. The fold numbers above are browser measurements and
+/// deliberately are not asserted anywhere: a pixel claim about text in a
+/// widget test would be a claim about the test font.
+const double kAtlasPlateHeight = 240;
 
 /// The travel atlas: everywhere this traveler has been, given room.
 ///
@@ -70,35 +105,6 @@ class TravelAtlasScreen extends ConsumerStatefulWidget {
 }
 
 class _TravelAtlasScreenState extends ConsumerState<TravelAtlasScreen> {
-  /// The plate's height below the wide seam.
-  ///
-  /// Measured, not picked between the wireframe's 280 and `_GuideMap`'s
-  /// shipped 240 — and measured against the **binding** case rather than the
-  /// comfortable one: a 375×667 phone (the smallest this app supports)
-  /// carrying the tallest chrome this screen can have, which is the year chip
-  /// row above a colophon rendering BOTH groups. On a roomier phone every
-  /// candidate looks fine, so the roomy case decides nothing.
-  ///
-  /// Under that chrome, the first index row's bottom edge lands at
-  /// `240 + 424`, and each row after it is 49 tall. What separates the
-  /// candidates is therefore only what sits ON the 667px fold:
-  ///
-  ///   * **280** — the heading and one whole row; the second starts below the
-  ///     fold. Reads as a list of one.
-  ///   * **256** — the same, with a 2px sliver of the second row's box and
-  ///     none of its text. Still reads as a list of one.
-  ///   * **240** — the heading, one whole row, and the second cut through its
-  ///     text: the plainest "there is more" a list can give.
-  ///
-  /// So 240 — which is also, independently, the height this app already ships
-  /// for an interactive map inside a scrolling column (`_GuideMap`), so the
-  /// atlas is not introducing a third map size. With no chip row (a history
-  /// inside one year) the same height clears two whole rows and cuts a third.
-  ///
-  /// Pinned by the smallest-phone case in this screen's test: change this and
-  /// re-measure, don't change this and re-guess.
-  static const double _plateHeight = 240;
-
   /// Width at which the index moves beside the plate instead of under it, and
   /// the width it takes there. 900 is this app's established side-by-side seam
   /// (the trip detail docks its chat panel at exactly 900, in a 400px column);
@@ -195,18 +201,20 @@ class _TravelAtlasScreenState extends ConsumerState<TravelAtlasScreen> {
     final pins = footprintPins(filtered, now);
     final stats = travelStats(filtered, now);
 
-    final paper = _AtlasPaper(
-      // A lone "2026" beside "All time" is chrome that filters nothing — the
-      // empty affordance the artifact's thin-history drawing was written to
-      // catch. Under two distinct years the row does not render at all.
-      years: years.length >= 2 ? years : const <int>[],
-      selectedYear: year,
-      onYearSelected: (y) => setState(() => _year = y),
-      traveled: stats.traveled,
-      planned: stats.planned,
-      rows: year == null ? rows : atlasRows(trips, now, year: year),
-      onOpenTrip: _openTrip,
-    );
+    _AtlasPaper paper({required bool wide}) => _AtlasPaper(
+          // A lone "2026" beside "All time" is chrome that filters nothing —
+          // the empty affordance the artifact's thin-history drawing was
+          // written to catch. Under two distinct years the row does not
+          // render at all.
+          years: years.length >= 2 ? years : const <int>[],
+          selectedYear: year,
+          onYearSelected: (y) => setState(() => _year = y),
+          wrapChips: wide,
+          traveled: stats.traveled,
+          planned: stats.planned,
+          rows: year == null ? rows : atlasRows(trips, now, year: year),
+          onOpenTrip: _openTrip,
+        );
 
     return scaffold(LayoutBuilder(
       builder: (context, constraints) {
@@ -225,7 +233,9 @@ class _TravelAtlasScreenState extends ConsumerState<TravelAtlasScreen> {
               SizedBox(
                 width: hasPlate ? _sideColumnWidth : constraints.maxWidth,
                 child: SingleChildScrollView(
-                  child: hasPlate ? paper : PageContainer(child: paper),
+                  child: hasPlate
+                      ? paper(wide: true)
+                      : PageContainer(child: paper(wide: true)),
                 ),
               ),
             ],
@@ -237,8 +247,8 @@ class _TravelAtlasScreenState extends ConsumerState<TravelAtlasScreen> {
           // map-led. The paper below supplies its own margins.
           padding: EdgeInsets.zero,
           children: [
-            if (hasPlate) SizedBox(height: _plateHeight, child: _plate(pins)),
-            PageContainer(child: paper),
+            if (hasPlate) SizedBox(height: kAtlasPlateHeight, child: _plate(pins)),
+            PageContainer(child: paper(wide: false)),
           ],
         );
       },
@@ -275,6 +285,9 @@ class _AtlasPaper extends StatelessWidget {
   final List<int> years;
   final int? selectedYear;
   final ValueChanged<int?> onYearSelected;
+
+  /// Passed through to [_YearChips]: wrap the chips instead of scrolling them.
+  final bool wrapChips;
   final TravelStats traveled;
   final TravelStats planned;
   final List<AtlasRow> rows;
@@ -284,6 +297,7 @@ class _AtlasPaper extends StatelessWidget {
     required this.years,
     required this.selectedYear,
     required this.onYearSelected,
+    required this.wrapChips,
     required this.traveled,
     required this.planned,
     required this.rows,
@@ -317,6 +331,7 @@ class _AtlasPaper extends StatelessWidget {
             years: years,
             selected: selectedYear,
             onSelected: onYearSelected,
+            wrap: wrapChips,
           ),
           const Divider(height: 1),
         ],
@@ -369,31 +384,56 @@ class _AtlasPaper extends StatelessWidget {
 /// pan-and-zoom gesture arena. `DESIGN.md` blesses this shape outright —
 /// *"filter chip rows are the entire secondary navigation on list screens"*.
 ///
-/// **"All time" leads and is pinned outside the scroll view.** It is both the
-/// resting state and the only way back, and [BookingFilterBar] already settled
-/// what happens otherwise: on ten years of history the strip scrolls, and an
-/// exit that can scroll off-screen is not an exit. Re-tapping a selected year
-/// is a dead gesture rather than a second, invisible way to clear — the years
-/// have somewhere to say it, and All time is already saying it.
+/// **"All time" leads.** It is both the resting state and the only way back.
+/// In the scrolling form it is pinned OUTSIDE the scroll view, because
+/// [BookingFilterBar] already settled what happens otherwise: on ten years of
+/// history the strip scrolls, and an exit that can scroll off-screen is not an
+/// exit. There is no leading fade under it — a year half-scrolled beneath
+/// reads as a clipped number, not as a stray count attaching itself to the
+/// wrong chip, which is the specific harm that mask exists to prevent.
 ///
-/// Unlike that strip there is no leading fade under the pinned chip: a year
-/// half-scrolled under it reads as a clipped number, not as a stray count
-/// attaching itself to the wrong chip, which is the specific harm that mask
-/// exists to prevent.
+/// [wrap] picks the form. A clipped trailing chip is the ordinary
+/// horizontal-scroll affordance on a phone and reads as intended; in the
+/// ≥900 layout's fixed 400px side column the same clipping reads as a
+/// rendering fault, and the column has vertical room a phone does not — so
+/// there the chips wrap onto a second line instead.
 class _YearChips extends StatelessWidget {
   final List<int> years;
   final int? selected;
   final ValueChanged<int?> onSelected;
 
+  /// True in the wide layout's side column: lay the chips out as a [Wrap]
+  /// rather than a pinned chip beside a horizontal scroll view.
+  final bool wrap;
+
   const _YearChips({
     required this.years,
     required this.selected,
     required this.onSelected,
+    required this.wrap,
   });
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
     final l10n = context.l10n;
+    final allTime = _chip(
+      theme,
+      label: l10n.travelAtlasAllTime,
+      isSelected: selected == null,
+      onTap: () => onSelected(null),
+    );
+    final yearChips = [
+      for (final y in years)
+        _chip(
+          theme,
+          // Formatted, never translated — and never through an ICU int
+          // placeholder, which would group 2026 as "2,026".
+          label: '$y',
+          isSelected: selected == y,
+          onTap: () => onSelected(y),
+        ),
+    ];
     // Bare year numbers say nothing about what tapping one does; the row says
     // it once, for a screen reader, instead of every chip repeating it.
     return Semantics(
@@ -402,56 +442,78 @@ class _YearChips extends StatelessWidget {
       child: Padding(
         padding: const EdgeInsets.symmetric(
             horizontal: AppSpacing.lg, vertical: AppSpacing.sm),
-        child: Row(
-          children: [
-            _chip(
-              label: l10n.travelAtlasAllTime,
-              isSelected: selected == null,
-              onTap: () => onSelected(null),
-            ),
-            const SizedBox(width: AppSpacing.sm),
-            Expanded(
-              child: SingleChildScrollView(
-                scrollDirection: Axis.horizontal,
-                // A traveler with ten years of history overflows any phone.
-                child: Row(
-                  children: [
-                    for (var i = 0; i < years.length; i++) ...[
-                      if (i > 0) const SizedBox(width: AppSpacing.sm),
-                      _chip(
-                        // Formatted, never translated — and never through an
-                        // ICU int placeholder, which would group 2026 as
-                        // "2,026".
-                        label: '${years[i]}',
-                        isSelected: selected == years[i],
-                        onTap: () => onSelected(years[i]),
+        child: wrap
+            ? Wrap(
+                spacing: AppSpacing.sm,
+                runSpacing: AppSpacing.xs,
+                children: [allTime, ...yearChips],
+              )
+            : Row(
+                children: [
+                  allTime,
+                  const SizedBox(width: AppSpacing.sm),
+                  Expanded(
+                    child: SingleChildScrollView(
+                      scrollDirection: Axis.horizontal,
+                      // A traveler with ten years of history overflows any
+                      // phone.
+                      child: Row(
+                        children: [
+                          for (var i = 0; i < yearChips.length; i++) ...[
+                            if (i > 0) const SizedBox(width: AppSpacing.sm),
+                            yearChips[i],
+                          ],
+                        ],
                       ),
-                    ],
-                  ],
-                ),
+                    ),
+                  ),
+                ],
               ),
-            ),
-          ],
-        ),
       ),
     );
   }
 
   /// The house filter chip: fully round, no checkmark, and a padded tap target
   /// so the 48px floor holds even though the chip paints compact.
-  Widget _chip({
+  ///
+  /// **The selected chip stays ENABLED.** Re-tapping it is inert either way,
+  /// but `onSelected: null` marks a [ChoiceChip] *disabled*, and M3 then paints
+  /// the SELECTED chip in the disabled palette — `onSurface` at 12% under
+  /// dimmed ink. Measured in the browser at (217,224,221) against the brand
+  /// tint's (224,242,241): it reads as "unavailable", and it leaves the
+  /// unselected chips looking louder than the active one. On the row that IS
+  /// this surface's navigation, that inverts the hierarchy — and `DESIGN.md`
+  /// is explicit that a selected chip takes the brand tint family.
+  ///
+  /// [AppColors.brandTintFill] rather than the raw tint because that constant
+  /// is teal-50: correct on paper, a light block punched into a dark page
+  /// anywhere else.
+  Widget _chip(
+    ThemeData theme, {
     required String label,
     required bool isSelected,
     required VoidCallback onTap,
-  }) =>
-      ChoiceChip(
-        label: Text(label),
-        selected: isSelected,
-        onSelected: isSelected ? null : (_) => onTap(),
-        showCheckmark: false,
-        visualDensity: VisualDensity.standard,
-        materialTapTargetSize: MaterialTapTargetSize.padded,
-      );
+  }) {
+    final scheme = theme.colorScheme;
+    return ChoiceChip(
+      label: Text(label),
+      selected: isSelected,
+      // Inert, not disabled: All time is the way back, so a re-tap must not
+      // become a second, invisible way to clear.
+      onSelected: isSelected ? (_) {} : (_) => onTap(),
+      selectedColor: AppColors.brandTintFill(scheme),
+      // Stated outright on both sides: an M3 label style left to default
+      // paints onSurface, which is the wrong ink on a tinted fill.
+      labelStyle: theme.textTheme.labelLarge?.copyWith(
+        color: isSelected
+            ? AppColors.onBrandTint(scheme)
+            : scheme.onSurfaceVariant,
+      ),
+      showCheckmark: false,
+      visualDensity: VisualDensity.standard,
+      materialTapTargetSize: MaterialTapTargetSize.padded,
+    );
+  }
 }
 
 /// One finished trip, as an index entry: `2026–02 · Lisbon & Porto · 12 days`.

--- a/src/packages/flutter-app/lib/screens/trips_list_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trips_list_screen.dart
@@ -374,25 +374,25 @@ class _TripsListScreenState extends ConsumerState<TripsListScreen> {
                       child: SectionHeader(
                         title: l10n.tripsListYourTravels,
                         // Two actions, passed as one WRAP — not a Row.
-                        // SectionHeader's own Wrap can drop this whole group
-                        // onto a second line, which is what its dartdoc
-                        // promises, but a Row inside it still cannot be
-                        // narrower than its two buttons: at 360dp (the
-                        // commonest Android width) the English pair measures
-                        // wider than the column and a Row overflows it by
-                        // 28px. Wrapping instead lets the second button take a
-                        // third line on exactly those widths and changes
-                        // nothing anywhere else.
+                        // SectionHeader's own Wrap already drops this whole
+                        // group onto its own line, which is what its dartdoc
+                        // promises and what a phone gets: verified in the
+                        // browser, 360dp English keeps the title and both
+                        // actions on ONE line, and Spanish drops the pair
+                        // together onto a second. A Row would render
+                        // identically at every shipped width — the Wrap is
+                        // here so the pair CAN break inside itself if it ever
+                        // has to (a large accessibility text scale, a longer
+                        // translation) instead of overflowing.
                         //
                         // Both actions stay here. "+ Add past trip" does not
                         // move: specs/log-past-trip placed it in this header
                         // deliberately, and relocating it re-opens that
                         // decision.
-                        // Runs stack flush-LEFT when the pair breaks, so the
-                        // buttons land on the title's own edge. Right-aligning
-                        // them instead lines them up on the wider button's
-                        // right edge, which is neither margin and reads as an
-                        // accident.
+                        // Runs stack flush-LEFT in the rare case the pair
+                        // does break, so the buttons land on the title's own
+                        // edge rather than lining up on the wider button's
+                        // right edge, which is neither margin.
                         action: Wrap(
                           crossAxisAlignment: WrapCrossAlignment.center,
                           children: [

--- a/src/packages/flutter-app/test/travel_atlas_screen_test.dart
+++ b/src/packages/flutter-app/test/travel_atlas_screen_test.dart
@@ -99,7 +99,15 @@ List<Trip> _history() => [
           pins: const [CityPin(city: 'Madrid', lat: 40.4, lng: -3.7)]),
     ];
 
-/// Mounts the atlas over a fixed trips payload.
+/// The shell's bottom navigation bar, which this screen is always pushed
+/// under at phone widths. 80 is [NavigationBar]'s M3 height, and it is the
+/// difference between the viewport and the actual fold — measuring without it
+/// reads one index row too many.
+const double kShellNavBarHeight = 80;
+
+/// Mounts the atlas over a fixed trips payload, under a stand-in for the
+/// shell's bottom navigation bar so vertical measurements are against the
+/// fold a traveler actually sees.
 ///
 /// **One pump per test.** Re-pumping installs a fresh
 /// `tripsApiServiceProvider` override, which invalidates the `tripsProvider`
@@ -120,7 +128,12 @@ Future<void> _pumpAtlas(
         resumableChatsProvider.overrideWith((ref) async => const []),
         sharedWithMeProvider.overrideWith((ref) async => const <Trip>[]),
       ],
-      child: localizedTestApp(home: const TravelAtlasScreen()),
+      child: localizedTestApp(
+        home: const Scaffold(
+          body: TravelAtlasScreen(),
+          bottomNavigationBar: SizedBox(height: kShellNavBarHeight),
+        ),
+      ),
     ),
   );
   await tester.pumpAndSettle();
@@ -237,38 +250,25 @@ void main() {
     expect(plate.width, 390.0, reason: 'the plate is full-bleed here too');
   });
 
-  testWidgets('on the smallest phone the index still reads as a list',
+  testWidgets('the plate takes its measured height, and the paper follows it',
       (tester) async {
-    // The plate-height decision, pinned — see `_plateHeight`'s doc.
+    // What [kAtlasPlateHeight] is worth was measured in the running app, not
+    // here: widget tests lay out with Flutter's fixed-width test font, so a
+    // pixel claim about where a row's TEXT lands would be a claim about that
+    // font. See the constant's doc for the browser numbers and the reasoning.
     //
-    // The binding case, not the easy one: a 375×667 phone carrying the
-    // TALLEST chrome this screen can have — the year chip row (history spans
-    // more than one year) above a colophon rendering BOTH groups. Under that,
-    // the index heading and its first row must sit whole above the fold, and
-    // the second must be cut by it. The whole row says "this is a list"; the
-    // cut one says "there is more". A height that loses either is a height to
-    // re-measure, not a test to relax.
+    // What this pins is font-independent — the plate is exactly that tall, and
+    // the chips, the colophon and the index follow it in that order.
     await _pumpAtlas(tester,
-        trips: [
-          ...spanningHistory(),
-          _trip('past4', 'Split Trip',
-              start: '${_lastYear - 3}-03-01',
-              end: '${_lastYear - 3}-03-06',
-              cities: const ['Split']),
-        ],
-        surface: const Size(375, 667));
+        trips: spanningHistory(), surface: const Size(375, 667));
 
-    const fold = 667.0;
-    // Newest first by first day: last September, then last February.
-    for (final label in ['Past trips', 'Athens Trip']) {
-      expect(tester.getRect(find.text(label)).bottom, lessThan(fold),
-          reason: '"$label" must sit whole above the fold');
-    }
-    final second = tester.getRect(find.text('Iberia Loop'));
-    expect(second.top, lessThan(fold),
-        reason: 'the second row must peek over the fold');
-    expect(second.bottom, greaterThan(fold),
-        reason: 'and be cut by it, so the list reads as continuing');
+    final plate = tester.getRect(find.byType(FlutterMap));
+    expect(plate.height, kAtlasPlateHeight);
+    expect(plate.top, lessThan(tester.getRect(find.text('All time')).top));
+    expect(tester.getRect(find.text('All time')).bottom,
+        lessThanOrEqualTo(tester.getRect(find.text('Traveled')).top));
+    expect(tester.getRect(find.text('Traveled')).bottom,
+        lessThanOrEqualTo(tester.getRect(find.text('Past trips')).top));
   });
 
   testWidgets('with no finished trips it offers the way to make some',

--- a/src/packages/flutter-app/test/trips_list_footprint_test.dart
+++ b/src/packages/flutter-app/test/trips_list_footprint_test.dart
@@ -347,13 +347,20 @@ void main() {
       expect(find.byKey(kTraveledStatsKey), findsOneWidget);
     });
 
-    testWidgets('both header actions fit a 360dp phone',
+    testWidgets('both header actions live in the header, and neither escapes it',
         (WidgetTester tester) async {
-      // 360dp is the commonest Android width and the one that decides this:
-      // SectionHeader's Wrap can drop the action group onto its own line, but
-      // the group must also be able to break INSIDE itself — a Row of these
-      // two buttons overflows by 28px here.
+      // Deliberately NO assertion about which line each action lands on, or
+      // about one overflowing: those are text-width claims, and a widget test
+      // lays out with Flutter's fixed-width test font rather than Inter. An
+      // earlier version of this test pinned a three-line stack that the real
+      // app never produces — verified in the browser, where 360dp English puts
+      // the title and both actions on ONE line and 360dp Spanish drops the
+      // pair together onto a second.
       //
+      // The action group is a Wrap rather than a Row so that it CAN break
+      // inside itself if it ever needs to — large accessibility text scales,
+      // a longer translation. That is a defensive choice, not a fix for an
+      // overflow at any shipped width.
       await tester.binding.setSurfaceSize(const Size(360, 800));
       addTearDown(() => tester.binding.setSurfaceSize(null));
       await _pumpList(tester, trips: [
@@ -362,14 +369,16 @@ void main() {
       ]);
       await tester.pumpAndSettle();
 
-      // The "Past trips" collapsible row above overflows by 12px at this
-      // width — its header Row gives the count pill and chevron no room to
-      // give — and it does so on main too, with or without this lane. It is
-      // consumed here so it cannot fail teardown, and asserted to be the ONLY
-      // one: a header that overflowed as well would turn this into "Multiple
-      // exceptions" and fail.
+      // The test font is wider than Inter, so rigid chrome elsewhere on the
+      // page (the "Past trips" collapsible's title + count pill) overflows
+      // HERE and not in the app — checked in the browser at this width in both
+      // languages, where that row ellipsizes its summary and fits. Consumed so
+      // it cannot fail teardown; asserted to be the only one, so a header that
+      // overflowed as well would turn this into "Multiple exceptions" and
+      // fail.
       expect(tester.takeException().toString(),
           isNot(contains('Multiple exceptions')));
+
       // Both live INSIDE the section header, not one orphaned beside it...
       final header = find.ancestor(
           of: find.byKey(kTravelAtlasSeeAllKey),
@@ -381,17 +390,11 @@ void main() {
           findsOneWidget);
       // ...and neither runs past its edge, whichever line it lands on.
       final bounds = tester.getRect(header);
-      final seeAll = tester.getRect(find.byKey(kTravelAtlasSeeAllKey));
-      final logTrip = tester.getRect(find.byKey(kLogTripSectionActionKey));
-      for (final button in [seeAll, logTrip]) {
+      for (final key in [kTravelAtlasSeeAllKey, kLogTripSectionActionKey]) {
+        final button = tester.getRect(find.byKey(key));
         expect(button.right, lessThanOrEqualTo(bounds.right + 0.5));
         expect(button.left, greaterThanOrEqualTo(bounds.left - 0.5));
       }
-      // Measured: at 360 the pair breaks, and the two buttons stack on the
-      // TITLE's left edge rather than on each other's right edge — which is
-      // neither margin and reads as an accident.
-      expect(logTrip.top, greaterThan(seeAll.top));
-      expect(logTrip.left, seeAll.left);
       // PR #401's pin still holds: the title is a page-level header outside
       // the card, and the actions did not drag it inside.
       expect(
@@ -400,26 +403,6 @@ void main() {
               matching: find.text('Your travels')),
           findsNothing);
     });
-  });
-
-  testWidgets('at 390dp both header actions share one line',
-      (WidgetTester tester) async {
-    // The artifact predicted a two-line header on a phone and that is what a
-    // 390dp phone gets: the title, then both actions beside each other. Only
-    // at 360 and below does the pair itself have to break.
-    await tester.binding.setSurfaceSize(const Size(390, 800));
-    addTearDown(() => tester.binding.setSurfaceSize(null));
-    await _pumpList(tester, trips: [
-      _trip('past', 'Porto', start: _rel(-30), end: _rel(-26)),
-      _trip('older', 'Naxos', start: _rel(-90), end: _rel(-85)),
-    ]);
-    await tester.pumpAndSettle();
-    tester.takeException(); // the collapsible's own pre-existing overflow
-
-    final seeAll = tester.getRect(find.byKey(kTravelAtlasSeeAllKey));
-    final logTrip = tester.getRect(find.byKey(kLogTripSectionActionKey));
-    expect(logTrip.top, seeAll.top);
-    expect(logTrip.left, greaterThanOrEqualTo(seeAll.right - 0.5));
   });
 
   testWidgets('the map marks visited cities apart from planned ones',


### PR DESCRIPTION
Follow-up to #510, which merged nine minutes before these corrections were pushed. Everything here was found by a browser walkthrough of the merged atlas; none of it is in `main`.

## Summary

**1. The selected year chip rendered as DISABLED, not brand-tinted.** `onSelected: null` marks a `ChoiceChip` disabled, so M3 painted the *selected* chip in the disabled palette — `onSurface` at 12%, pixel-sampled at (217,224,221) against the brand tint's (224,242,241), under dimmed ink. It read as "unavailable", and it left the unselected chips looking louder than the active one — an inverted hierarchy on the row that *is* this surface's navigation, and against `DESIGN.md`'s "selected takes the brand tint family".

The re-tap stays inert (`onSelected: (_) {}`) while the chip stays enabled, and it takes `AppColors.brandTintFill` — teal-50 on paper, the scheme's own `primaryContainer` on a dark page. Verified after the fix at exactly (224,242,241) light and (0,80,71) dark. **`BookingFilterBar` is deliberately untouched**: it ships the same construction, and that is a house-pattern fix for its own lane.

**2. The chips wrap in the ≥900 side column** instead of scrolling. A clipped trailing chip is the ordinary horizontal-scroll affordance on a phone and reads as intended; in the fixed 400px column it read as a rendering fault, and that column has vertical room a phone does not.

**3. The header tests asserted a three-line stack the real app never produces.** There is no `flutter_test_config.dart` and no font loading in this suite, so widget tests lay out with Flutter's built-in fixed-width test font — **text-width measurements in them are not evidence about Inter.** In the browser, 360dp English keeps the title and both actions on ONE line, and 360dp Spanish drops the pair together onto a second (320dp Spanish too). The stacking assertions are gone; what survives is font-independent — both actions inside the `SectionHeader`, neither escaping its bounds, no overflow, PR #401's pin. The action group stays a `Wrap` as a defensive choice for large accessibility text scales, not as a fix for an overflow that does not happen.

This also **retracts the `CollapsibleSection` 12px overflow** #510 reported as a pre-existing bug deserving its own lane: same cause. In the app that row ellipsizes its summary and fits at every width driven.

**4. The plate-height measurement omitted the shell's navigation bar** — 80px of the viewport is chrome, so the first pass read one index row too many. `kAtlasPlateHeight` is now public, its doc carries the browser numbers *with* the bar (280 pushes the first row's text under it; 256 leaves one row and nothing after; 240 gives the heading, one whole row, and the next beginning at the bar — and a 390×844 phone, the common case, shows four whole rows and a fifth cut). 240 still wins. The test now pins the constant and the order of what follows it — both font-independent — instead of a pixel claim about where text lands.

## Testing

- `flutter test` — **1763 passing**, full suite, no skips. One test fewer than #510: the 390dp "both actions share one line" case was entirely a font-metric claim and was deleted rather than relaxed.
- `flutter analyze` — clean (3 pre-existing infos in `lib/models/route_response.dart`, untouched).
- `.claude/skills/brand-guidelines/scripts/check.sh` — the same single `[adhoc-shadow]` finding #510 explained (the footprint pin's ring shadow, moved verbatim from `travel_footprint_card.dart:341`); no new findings.
- Re-verified in the browser after the fix at 390dp and 1440px, both themes: the selected chip is the brand tint in light and `primaryContainer` in dark, the wide column wraps all five chips with none clipped, and the phone form keeps its pinned "All time" plus scroll.

## Not changed, on purpose

The wide layout's camera is longitude-bound — fitting Lisbon→Tokyo on a tall plate shows a lot of ocean. That is what "fit all pins" means on a tall viewport, not a defect; a latitude-biased fit is a design decision for the artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/golden-tempo/codesmith/anemos-travel/pr/511"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789771158&installation_model_id=433099&pr_number=511&repository=golden-tempo%2Fanemos-travel&return_to=https%3A%2F%2Fgithub.com%2Fgolden-tempo%2Fanemos-travel%2Fpull%2F511&signature=8344f47299776b746a7710deca0519ba43a3f011764d333f1c9b92c4ce054759"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->