### PR TITLE
fix(brand): bust the icon cache the bezel swap left stale

### DIFF
--- a/src/packages/flutter-app/web/index.html
+++ b/src/packages/flutter-app/web/index.html
@@ -49,15 +49,22 @@
   <meta name="apple-mobile-web-app-status-bar-style" content="black">
   <meta name="apple-mobile-web-app-title" content="Anemos">
   <!-- The ?v= series dates from when nginx served /app/icons/* immutable for a
-       year; it is now no-cache, so this is belt-and-braces for pre-2026-08-15
-       caches. Bumped to 4 for the switch to the Threaded Bezel mark, which
-       redrew every icon. manifest.json carries the same version — move them
-       together. -->
-  <link rel="apple-touch-icon" href="icons/Icon-192.png?v=4">
+       year; nginx is now no-cache, but Cloudflare still caches these by URL, so
+       this is what actually busts them. manifest.json and the splash <img>
+       below carry the same version — move all three together.
 
-  <!-- Favicon: ?v=4 because Chrome's favicon cache is keyed by URL and
+       **Bump this on any deploy that changes the art, even if the last bump has
+       not been released yet.** 4 was set for the mark-size pass and shipped;
+       the Threaded Bezel swap then rewrote every icon and kept 4, reasoning
+       the bump was still unreleased. It was not — the size pass had merged and
+       deployed in between — so `favicon.png?v=4` served the previous mark from
+       edge cache with `age: 3322` after the bezel went live. The version is
+       cheap; a stale favicon lasts weeks in Chrome. -->
+  <link rel="apple-touch-icon" href="icons/Icon-192.png?v=5">
+
+  <!-- Favicon: ?v=5 because Chrome's favicon cache is keyed by URL and
        refreshes lazily — new bytes at the same URL can stay stale for weeks. -->
-  <link rel="icon" type="image/png" href="favicon.png?v=4"/>
+  <link rel="icon" type="image/png" href="favicon.png?v=5"/>
 
   <title>Anemos</title>
   <link rel="manifest" href="manifest.json">
@@ -213,8 +220,14 @@
   <div id="splash">
     <div class="splash-mark">
       <!-- Empty alt: the wordmark below is the visible, readable name, so a
-           labelled image here would just announce "Anemos" twice. -->
-      <img src="splash/anemos_mark_light.png" alt="">
+           labelled image here would just announce "Anemos" twice.
+
+           ?v= for the same reason the icons above carry one, and it was missing
+           here until the Threaded Bezel swap: brand-render.sh rewrites this
+           file whenever the mark art changes, at a path Cloudflare caches, so
+           the boot splash served the PREVIOUS mark from edge cache for ~15
+           minutes after that deploy. Bump it with the icons. -->
+      <img src="splash/anemos_mark_light.png?v=5" alt="">
     </div>
     <div class="splash-wordmark">Anemos</div>
     <!-- Decorative: the loading state is announced by the app once it boots;

--- a/src/packages/flutter-app/web/manifest.json
+++ b/src/packages/flutter-app/web/manifest.json
@@ -12,23 +12,23 @@
     "prefer_related_applications": false,
     "icons": [
         {
-            "src": "icons/Icon-192.png?v=4",
+            "src": "icons/Icon-192.png?v=5",
             "sizes": "192x192",
             "type": "image/png"
         },
         {
-            "src": "icons/Icon-512.png?v=4",
+            "src": "icons/Icon-512.png?v=5",
             "sizes": "512x512",
             "type": "image/png"
         },
         {
-            "src": "icons/Icon-maskable-192.png?v=4",
+            "src": "icons/Icon-maskable-192.png?v=5",
             "sizes": "192x192",
             "type": "image/png",
             "purpose": "maskable"
         },
         {
-            "src": "icons/Icon-maskable-512.png?v=4",
+            "src": "icons/Icon-maskable-512.png?v=5",
             "sizes": "512x512",
             "type": "image/png",
             "purpose": "maskable"


### PR DESCRIPTION
`favicon.png?v=4` is serving the **previous mark** from Cloudflare's edge cache. Measured against production after #514 deployed:

| URL | Returns | |
|---|---|---|
| `favicon.png?v=4` | bare Waypoint Thread rose | `age: 3322` |
| `favicon.png?cb=<random>` | the bezel, byte-identical to the repo | fresh |

So the deploy is correct and only the cache key is wrong.

## The mistake

I reasoned about the **version** instead of the **art**. #509 set `v=4` for the mark-size pass. #514 redrew every icon and kept `v=4`, on the argument that the bump hadn't been released yet — but #509 merged and deployed in between, so it had. The one mechanism that exists to stop a stale favicon was defeated by exactly the case it exists for.

The rule the comment now states: **bump on any deploy that changes the art, released or not.** A version is free; a stale favicon lasts weeks in Chrome, whose favicon cache is keyed by URL and refreshes lazily.

## Also: the boot splash mark never had a version

`splash/anemos_mark_light.png` carried no `?v=` at all. It's re-rendered by `brand-render.sh` on every art change and sits at a path Cloudflare caches by URL, so it served the previous mark for ~15 minutes after #514 went live (`age: 874` when measured). It now moves with the icons, and the comment says to keep it moving.

## Scope

Two files, `web/index.html` and `web/manifest.json`. The PWA icons at `v=4` and `og-card.png` both already return fresh bytes and were not stale — they're bumped anyway, because these versions only mean anything if they move together.

## Verification

- Staleness **measured against production**, not inferred — versioned URL vs. random-query URL, per asset
- `flutter test test/brand_everywhere_test.dart test/splash_screen_test.dart` — 23 passed, 0 failed
- No art regenerated; this changes only the URLs that reference it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/golden-tempo/codesmith/anemos-travel/pr/515"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789796890&installation_model_id=433099&pr_number=515&repository=golden-tempo%2Fanemos-travel&return_to=https%3A%2F%2Fgithub.com%2Fgolden-tempo%2Fanemos-travel%2Fpull%2F515&signature=5c15c63c886ba771c971de1e0916ad477cfff631e13bba660d72a9c30c37bb97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->