### PR TITLE
feat(nav): back returns to the tab a trip was opened from

### DIFF
--- a/src/packages/flutter-app/lib/navigation/app_nav.dart
+++ b/src/packages/flutter-app/lib/navigation/app_nav.dart
@@ -206,7 +206,7 @@ void pushOnTabWhenReady(List<GlobalKey<NavigatorState>> navKeys, AppTab tab,
 }
 
 /// Open [tripId]'s detail on the Trips tab: the Trips nav item highlights and
-/// back lands on the trips list. Resets the Trips stack inside the (possibly
+/// the trips list sits underneath. Resets the Trips stack inside the (possibly
 /// retried) push action — not eagerly — so a previously-open detail doesn't
 /// sit underneath, and the reset happens next to the push that lands.
 ///
@@ -214,13 +214,21 @@ void pushOnTabWhenReady(List<GlobalKey<NavigatorState>> navKeys, AppTab tab,
 /// run while the Trips tab is still hidden, so an animated reset+push would
 /// freeze and then replay together — the trip you had open sliding out from
 /// under the one you just asked for.
-void openTripOnTripsTab(WidgetRef ref, String tripId) {
+///
+/// [from] is the tab the traveler is standing on, and only Home's trip cards
+/// pass it: the detail still lives on the Trips tab, but back returns them to
+/// Home rather than to a trips list they never opened. It rides the ROUTE (see
+/// [TripDetailScreen.entryOrigin]) rather than a provider, so it cannot outlive
+/// the screen it describes. Passing nothing — or [AppTab.trips] — is the
+/// behavior every caller had before.
+void openTripOnTripsTab(WidgetRef ref, String tripId, {AppTab? from}) {
   ref.read(navIndexProvider.notifier).state = AppTab.trips.index;
   final navKeys = ref.read(tabNavKeysProvider);
   pushOnTabWhenReady(navKeys, AppTab.trips, () {
     resetToRoot(navKeys[AppTab.trips.index].currentState);
     return instantRoute(
-        TripDetailScreen(tripId: tripId), tripDetailLocation(tripId));
+        TripDetailScreen(tripId: tripId, entryOrigin: from),
+        tripDetailLocation(tripId));
   });
 }
 

--- a/src/packages/flutter-app/lib/screens/home_screen.dart
+++ b/src/packages/flutter-app/lib/screens/home_screen.dart
@@ -188,8 +188,10 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
                     // one here would starve it (see TripHeroCard.showMap).
                     showMap: false,
                     // On the Trips tab (not pushed over Home): the Trips nav
-                    // item highlights and back lands on the trips list.
-                    onTap: () => openTripOnTripsTab(ref, liveTrip.id),
+                    // item highlights, and `from` sends back here rather than
+                    // to a trips list this traveler never opened.
+                    onTap: () =>
+                        openTripOnTripsTab(ref, liveTrip.id, from: AppTab.home),
                   ),
                   const SizedBox(height: AppSpacing.xl),
                 ],
@@ -205,8 +207,9 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
                           title: continueTrip.title,
                           dateRange: continueTrip.dateRange,
                           startDate: continueTrip.startDate,
-                          onTap: () =>
-                              openTripOnTripsTab(ref, continueTrip.tripId),
+                          onTap: () => openTripOnTripsTab(
+                              ref, continueTrip.tripId,
+                              from: AppTab.home),
                         )
                       : null,
                 ),

--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -138,7 +138,30 @@ String _timeOfDayLabel(AppLocalizations l10n, String value) => switch (value) {
 
 class TripDetailScreen extends ConsumerStatefulWidget {
   final String tripId;
-  const TripDetailScreen({super.key, required this.tripId});
+
+  /// The tab the traveler was on when they opened this trip, when that is
+  /// somewhere other than Trips — set only by [openTripOnTripsTab], which is
+  /// how Home's trip cards open a trip. Back then returns them there instead
+  /// of stranding them on the trips list they never visited.
+  ///
+  /// Carried on the ROUTE rather than in a provider on purpose. An ambient
+  /// record would have to be cleared on every path that takes this screen off
+  /// the stack — a plain `pop`, `selectTab`'s re-tap `popUntil`,
+  /// [resetToRoot]'s `removeRoute`, the next [openTripOnTripsTab] — and none
+  /// of those consult [PopScope], so the first one anybody forgot would leave
+  /// the NEXT trip, opened from the list, jumping to Home on back. As a field
+  /// it is born with the route and dies with it.
+  ///
+  /// Null — every other entry point: the trips list, boot restore from a URL,
+  /// import, log-a-trip, the atlas, a shared-trip join, the agent's "open the
+  /// trip" — and null behaves exactly as this screen always has.
+  final AppTab? entryOrigin;
+
+  const TripDetailScreen({
+    super.key,
+    required this.tripId,
+    this.entryOrigin,
+  });
 
   @override
   ConsumerState<TripDetailScreen> createState() => _TripDetailScreenState();
@@ -3308,6 +3331,35 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
     );
   }
 
+  /// Back out of a trip that was opened from another tab
+  /// ([TripDetailScreen.entryOrigin]): clear the Trips stack and hand the
+  /// traveler back to the tab they came from.
+  void _leaveToEntryOrigin(AppTab origin) {
+    // Read the notifier up front. The reset below takes this route out of the
+    // navigator, so reaching for `ref` afterwards is reaching through a widget
+    // already on its way off screen.
+    final navIndex = ref.read(navIndexProvider.notifier);
+    // [resetToRoot], not a pop, and before the tab switch — its own reasoning
+    // with the tab roles reversed. Trips is about to be HIDDEN, and the shell
+    // freezes hidden tabs' tickers (app_shell.dart), so a pop transition here
+    // would park fully painted and then replay in full the next time Trips is
+    // revealed: the trip you just left sliding away in front of you.
+    //
+    // Clearing the stack (rather than removing this one route) is also what
+    // makes the Trips tab honest afterwards. Trips KEEPS its stack
+    // (_stackKeepingTabs), so whatever is left behind is what the next tap on
+    // Trips shows — and back means the traveler closed this trip, not that
+    // they parked it.
+    //
+    // Before the switch, because TabUrlObserver's bookkeeping (url_sync.dart)
+    // then drains while Trips is still the current tab: the removal reports
+    // /trips, and the tab switch that follows reports the origin tab's root,
+    // which is the last word. No new reporting path — the same drain
+    // [selectTab] relies on.
+    resetToRoot(Navigator.of(context));
+    navIndex.state = origin.index;
+  }
+
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
@@ -3357,6 +3409,12 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
       // chrome), so this always agrees with _mapPinned. Plain assignment:
       // we're in build, like _mapPinned's own write.
       _narrow = constraints.maxWidth < kRailBreakpoint;
+      // Where back goes once the panel is out of the way. Null is both "opened
+      // from the trips list" and every other entry point, and means the
+      // ordinary pop this screen has always done.
+      final backTo = widget.entryOrigin == AppTab.trips
+          ? null
+          : widget.entryOrigin;
       return PopScope(
         // Back closes the chat before it leaves the trip. The panel is drawn
         // inside the screen rather than pushed as a route, and on narrow it
@@ -3365,9 +3423,26 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
         // (specs/trip-refine-memory). Composes with AppShell's own
         // PopScope(canPop: false), which forwards to this tab navigator's
         // maybePop(); that consults the top route's PopScope, i.e. this one.
-        canPop: !_panelOpen,
+        // The browser's own back arrow arrives here too: on web it dispatches
+        // popRoute, which WidgetsApp turns into maybePop() on the ROOT
+        // navigator — the same chain, so both back buttons agree by
+        // construction rather than by two implementations kept in step.
+        //
+        // ONE PopScope carrying both jobs, deliberately not two nested ones:
+        // ModalRoute hands `didPop: false` to EVERY PopScope registered in its
+        // subtree, not just the innermost (routes.dart —
+        // `onPopInvokedWithResult` loops over `_popEntries`), so a second one
+        // for [TripDetailScreen.entryOrigin] would fire in the same breath as
+        // this one and a single back would close the chat AND switch tabs.
+        // Stated here in priority order instead.
+        canPop: !_panelOpen && backTo == null,
         onPopInvokedWithResult: (didPop, _) {
-          if (!didPop && _panelOpen) setState(() => _panelOpen = false);
+          if (didPop) return;
+          if (_panelOpen) {
+            setState(() => _panelOpen = false);
+            return;
+          }
+          if (backTo != null) _leaveToEntryOrigin(backTo);
         },
         child: Scaffold(
       // Always-reachable chat entry, mirroring the _openRefine guards so it's

--- a/src/packages/flutter-app/test/home_open_trip_on_trips_tab_test.dart
+++ b/src/packages/flutter-app/test/home_open_trip_on_trips_tab_test.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -12,15 +13,26 @@ import 'package:travel_route_planner/providers/auth_provider.dart';
 import 'package:travel_route_planner/providers/live_trip_provider.dart';
 import 'package:travel_route_planner/providers/resumable_chats_provider.dart';
 import 'package:travel_route_planner/providers/trips_provider.dart';
+import 'package:travel_route_planner/screens/home_screen.dart';
 import 'package:travel_route_planner/screens/trip_detail_screen.dart';
 import 'package:travel_route_planner/widgets/live_trip_card.dart';
 
 import 'support/url_sync_fakes.dart';
 
+/// Where a trip opens, and where back puts you afterwards.
+///
 /// Home's trip cards (LiveTripCard + the "Continue where you left off"
-/// recent-trip tile) open the detail on the TRIPS tab via openTripOnTripsTab
-/// — the Trips nav item highlights and back lands on the trips list — instead
-/// of stacking the detail over Home where the Home button would re-reveal it.
+/// recent-trip tile) open the detail on the TRIPS tab via openTripOnTripsTab —
+/// the Trips nav item highlights — instead of stacking the detail over Home
+/// where the Home button would re-reveal it. That half is unchanged and still
+/// pinned here.
+///
+/// What changed: back now returns to the tab you came FROM. Opened from Home,
+/// back lands on Home; opened from the trips list, back lands on the list,
+/// exactly as before. The origin rides the route
+/// ([TripDetailScreen.entryOrigin]), so a trip opened from the list can never
+/// inherit a phantom "came from Home" left behind by an earlier one — the last
+/// two cases below are that guarantee.
 void main() {
   late List<String> reports;
 
@@ -49,6 +61,13 @@ void main() {
     });
   }
 
+  /// The real nav button. The default 800x600 test surface is at
+  /// kRailBreakpoint, so the shell renders a NavigationRail and these taps go
+  /// through selectTab — including its re-tap popUntil, which is the one path
+  /// that takes the detail off the stack without consulting any PopScope.
+  Finder railDestination(String label) => find.descendant(
+      of: find.byType(NavigationRail), matching: find.text(label));
+
   Future<ProviderContainer> pumpApp(WidgetTester tester,
       {Trip? live}) async {
     tester.binding.platformDispatcher.defaultRouteNameTestValue = '/';
@@ -73,7 +92,7 @@ void main() {
 
   setUp(() => SharedPreferences.setMockInitialValues({}));
 
-  testWidgets('live trip card opens the detail on the Trips tab',
+  testWidgets('live trip card opens on the Trips tab and backs out to Home',
       (tester) async {
     final container = await pumpApp(tester, live: liveTrip('t3'));
 
@@ -84,15 +103,21 @@ void main() {
     expect(find.byType(TripDetailScreen), findsOneWidget);
     expect(reports.last, '/trips/t3');
 
-    // Back lands on the trips LIST, not Home.
+    // Back returns to the tab the trip was opened from.
     await tester.pageBack();
     await tester.pumpAndSettle();
-    expect(find.byType(TripDetailScreen), findsNothing);
-    expect(find.text('Lisbon long weekend'), findsOneWidget);
-    expect(reports.last, '/trips');
+    expect(container.read(navIndexProvider), AppTab.home.index);
+    expect(find.byType(HomeScreen), findsOneWidget);
+    expect(reports.last, '/');
+    // skipOffstage: false because the contract is that the trip is CLOSED, not
+    // merely hidden behind the tab switch — the IndexedStack keeps a hidden
+    // tab's subtree mounted, so the default finder would report "gone" either
+    // way. (_IndexedStackElement.debugVisitOnstageChildren visits only the
+    // selected child.)
+    expect(find.byType(TripDetailScreen, skipOffstage: false), findsNothing);
   });
 
-  testWidgets('recent trip card opens the detail on the Trips tab',
+  testWidgets('recent trip card opens on the Trips tab and backs out to Home',
       (tester) async {
     seedRecentTrip('t2', 'Lisbon Trip');
     final container = await pumpApp(tester);
@@ -118,14 +143,16 @@ void main() {
 
     await tester.pageBack();
     await tester.pumpAndSettle();
-    expect(find.byType(TripDetailScreen), findsNothing);
-    expect(reports.last, '/trips');
+    expect(container.read(navIndexProvider), AppTab.home.index);
+    expect(find.byType(HomeScreen), findsOneWidget);
+    expect(find.byType(TripDetailScreen, skipOffstage: false), findsNothing);
+    expect(reports.last, '/');
   });
 
   testWidgets('a detail already on the Trips stack is replaced, not stacked',
       (tester) async {
-    // Pins openTripOnTripsTab's pre-push popUntil: back must land on the
-    // trips list, never on a previously-open detail left underneath.
+    // Pins openTripOnTripsTab's pre-push reset: nothing may be left underneath
+    // the trip you asked for.
     final container = await pumpApp(tester, live: liveTrip('t3'));
 
     container.read(navIndexProvider.notifier).state = AppTab.trips.index;
@@ -159,7 +186,84 @@ void main() {
 
     await tester.pageBack();
     await tester.pumpAndSettle();
+    expect(container.read(navIndexProvider), AppTab.home.index);
+    expect(find.byType(TripDetailScreen, skipOffstage: false), findsNothing);
+    expect(reports.last, '/');
+  });
+
+  testWidgets('backing out to Home leaves the Trips tab on its list',
+      (tester) async {
+    // Trips KEEPS its stack (_stackKeepingTabs), so whatever back leaves
+    // behind is what the next Trips tap shows. Back means the traveler closed
+    // the trip, not that they parked it — otherwise the trip they just backed
+    // out of greets them again, and the trips list becomes unreachable in one
+    // tap.
+    final container = await pumpApp(tester, live: liveTrip('t3'));
+
+    await tester.tap(find.byType(LiveTripCard));
+    await tester.pumpAndSettle();
+    await tester.pageBack();
+    await tester.pumpAndSettle();
+    expect(container.read(navIndexProvider), AppTab.home.index);
+
+    await tester.tap(railDestination('Trips'));
+    await tester.pumpAndSettle();
     expect(find.byType(TripDetailScreen), findsNothing);
+    expect(find.text('Lisbon long weekend'), findsOneWidget);
+    expect(reports.last, '/trips');
+  });
+
+  testWidgets('a trip opened from the trips list still backs out to the list',
+      (tester) async {
+    // The unchanged half: no origin on the route, so back is the ordinary pop
+    // it has always been, and the tab never moves.
+    final container = await pumpApp(tester);
+
+    await tester.tap(railDestination('Trips'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Lisbon long weekend'));
+    await tester.pumpAndSettle();
+    expect(find.byType(TripDetailScreen), findsOneWidget);
+    expect(reports.last, '/trips/t1');
+
+    await tester.pageBack();
+    await tester.pumpAndSettle();
+    expect(container.read(navIndexProvider), AppTab.trips.index);
+    expect(find.byType(TripDetailScreen), findsNothing);
+    expect(find.text('Lisbon long weekend'), findsOneWidget);
+    expect(reports.last, '/trips');
+  });
+
+  testWidgets('a Home-opened trip leaves no origin behind for the next one',
+      (tester) async {
+    // The failure this exists to prevent, and the reason the origin is a field
+    // on the route rather than a provider: leave a Home-opened trip by a path
+    // that never consults PopScope — selectTab's re-tap popUntil is exactly
+    // that path — and then open a trip from the LIST. An ambient origin record
+    // would still be sitting there, and this second trip, which the traveler
+    // reached from the list, would throw them onto Home on back.
+    final container = await pumpApp(tester, live: liveTrip('t3'));
+
+    await tester.tap(find.byType(LiveTripCard));
+    await tester.pumpAndSettle();
+    expect(container.read(navIndexProvider), AppTab.trips.index);
+    expect(find.byType(TripDetailScreen), findsOneWidget);
+
+    // Re-tap the tab we are already on: popUntil(isFirst), no PopScope in the
+    // loop, detail gone, still on Trips.
+    await tester.tap(railDestination('Trips'));
+    await tester.pumpAndSettle();
+    expect(container.read(navIndexProvider), AppTab.trips.index);
+    expect(find.byType(TripDetailScreen), findsNothing);
+
+    await tester.tap(find.text('Lisbon long weekend'));
+    await tester.pumpAndSettle();
+    expect(find.byType(TripDetailScreen), findsOneWidget);
+
+    await tester.pageBack();
+    await tester.pumpAndSettle();
+    expect(container.read(navIndexProvider), AppTab.trips.index,
+        reason: 'this trip was opened from the list, so back stays on Trips');
     expect(find.text('Lisbon long weekend'), findsOneWidget);
     expect(reports.last, '/trips');
   });

--- a/src/packages/flutter-app/test/trip_detail_chat_back_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_chat_back_test.dart
@@ -6,6 +6,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:travel_route_planner/models/itinerary_item.dart';
+import 'package:travel_route_planner/navigation/app_nav.dart';
 import 'package:travel_route_planner/models/trip.dart';
 import 'package:travel_route_planner/providers/plan_provider.dart';
 import 'package:travel_route_planner/providers/trips_provider.dart';
@@ -95,11 +96,14 @@ Trip _trip() => Trip(
 const _homeKey = Key('home-placeholder');
 
 /// Pushes the trip over a placeholder home, so a real pop is observable.
+/// [entryOrigin] is the tab the trip was opened from — set only by Home's trip
+/// cards in the real app (openTripOnTripsTab).
 Widget _app(
   _FakeTripsApiService api, {
   List<PlanEvent> events = const [],
   Completer<void>? gate,
   List<PlanEvent> tailEvents = const [],
+  AppTab? entryOrigin,
 }) =>
     ProviderScope(
       overrides: [
@@ -117,7 +121,8 @@ Widget _app(
             body: Center(
               child: ElevatedButton(
                 onPressed: () => Navigator.of(context).push(MaterialPageRoute(
-                    builder: (_) => const TripDetailScreen(tripId: 't1'))),
+                    builder: (_) => TripDetailScreen(
+                        tripId: 't1', entryOrigin: entryOrigin))),
                 child: const Text('open trip'),
               ),
             ),
@@ -330,6 +335,38 @@ void main() {
     await tester.pump(const Duration(milliseconds: 100));
 
     expect(api.getTripCalls, greaterThan(before));
+  });
+
+  testWidgets('on a Home-opened trip, the panel still goes first',
+      (WidgetTester tester) async {
+    // Both jobs ride ONE PopScope, because ModalRoute hands didPop=false to
+    // EVERY PopScope registered in the route's subtree rather than just the
+    // innermost (routes.dart, onPopInvokedWithResult loops over _popEntries).
+    // Split across two, the first back would close the chat AND switch tabs in
+    // the same breath — the trip vanishing out from under a panel the traveler
+    // only meant to dismiss. So: panel first, origin second, one back each.
+    await tester.pumpWidget(_app(_FakeTripsApiService(_trip()),
+        entryOrigin: AppTab.home));
+    await tester.pumpAndSettle();
+    await _openTripAndChat(tester);
+    final container =
+        ProviderScope.containerOf(tester.element(find.byType(TripDetailScreen)));
+    // Where openTripOnTripsTab leaves the app: the detail lives on the Trips
+    // tab whichever tab it was opened from.
+    container.read(navIndexProvider.notifier).state = AppTab.trips.index;
+
+    expect(await _back(tester), isTrue);
+    await tester.pumpAndSettle();
+    expect(find.byType(TripRefinePanel), findsNothing);
+    expect(find.byType(TripDetailScreen), findsOneWidget);
+    expect(container.read(navIndexProvider), AppTab.trips.index,
+        reason: 'closing the chat is not leaving the trip');
+
+    expect(await _back(tester), isTrue);
+    await tester.pumpAndSettle();
+    expect(find.byType(TripDetailScreen), findsNothing);
+    expect(find.byKey(_homeKey), findsOneWidget);
+    expect(container.read(navIndexProvider), AppTab.home.index);
   });
 
   testWidgets('Escape closes the panel', (WidgetTester tester) async {


### PR DESCRIPTION
Home's trip cards — the Happening-Now `LiveTripCard` and the "Continue where you left off" hero — open a trip through `openTripOnTripsTab`, which switches to the Trips tab and pushes the detail there. That is the right place for it, but it left **back** with only one answer: the trips list, a page the traveler never asked for and, coming from Home, never saw.

## Behavior

| Opened from | Back lands on | |
|---|---|---|
| Home live-trip card | **Home** | changed |
| Home "Continue where you left off" hero | **Home** | changed |
| Trips list | trips list | unchanged |
| URL restore, import, log-a-trip, atlas, shared-trip join, agent | trips list | unchanged |

The detail is still pushed on the **Trips** tab's navigator, the Trips nav item still highlights while you view it, and `_stackKeepingTabs` is untouched — all three were pinned decisions and none of them moved.

## The origin rides the route, not a provider

`TripDetailScreen.entryOrigin`, set only by `openTripOnTripsTab`'s new `from`.

The lane brief proposed a `tripEntryOriginProvider`, and I deviated deliberately — this is the one substantive design difference from the brief. An ambient record has to be cleared on every path that takes the screen off the stack: an ordinary `pop`, `selectTab`'s re-tap `popUntil`, `resetToRoot`'s `removeRoute`, and the next `openTripOnTripsTab`. **None of those consult `PopScope`**, so the first one anybody forgot would leave the NEXT trip — opened from the list — jumping to Home on back. As a field it is born with the route and dies with it, so that failure is unreachable rather than merely handled. User-visible behavior is identical either way.

Proven, not asserted: implementing the provider variant makes `a Home-opened trip leaves no origin behind for the next one` **fail**.

## One PopScope, not two

`ModalRoute` hands `didPop: false` to **every** `PopScope` registered in its subtree, not just the innermost (`routes.dart` — `onPopInvokedWithResult` loops over `_popEntries`). A second `PopScope` for the origin would fire in the same breath as the panel's and one back would close the refine chat **and** switch tabs. So both jobs live in the existing `PopScope`, stated in priority order: panel first, origin second. Splitting them into two makes `on a Home-opened trip, the panel still goes first` fail.

## Leaving

`resetToRoot` before the tab switch. Remove rather than pop, because Trips is about to be *hidden* and the shell freezes hidden tabs' tickers — a pop transition would park fully painted and replay the next time Trips is revealed. Clear the stack rather than remove one route, because Trips **keeps** its stack, so what is left behind is what the next Trips tap shows, and back means the trip was closed, not parked. Before the switch, so `TabUrlObserver`'s drain reports `/trips` while Trips is still current and the tab switch has the last word — no new reporting path, and `url_sync.dart` is untouched.

## Browser back: they agree

**By construction, not by two implementations kept in step.** On web the browser's back arrow dispatches `popRoute`; `WidgetsApp` turns that into `maybePop()` on the **root** navigator; `AppShell`'s `PopScope(canPop: false)` forwards to the active tab's navigator; that consults this same `PopScope`. One hook covers the app-bar arrow, system back, and browser back.

Verified in a real browser (headless Chrome + CDP against the lane stack on `:3002`), **both back buttons for every flow**:

| Flow | App back | Browser back |
|---|---|---|
| Home live card → trip → back | `/` Home | `/` Home |
| Home continue hero → trip → back | `/` Home | `/` Home |
| Trips list → trip → back | `/trips` list | `/trips` list |
| Home → trip → chat open → back → back | panel closes, stays; then Home | panel closes, stays; then Home |
| After backing to Home, tap Trips | trips list (not the closed trip) | — |

A stash → reshoot → pop on unmodified `main` confirms the before-frame: the first flow landed on `/trips`.

### Pre-existing defect found, NOT fixed here

When back is *swallowed* — the chat panel closes and no route changes — the address bar drops to `/` while the screen correctly stays on the trip. Cause: the engine's `SingleEntryBrowserHistory` traverses to its origin entry and restores the flutter entry with that path, and `UrlSyncController` only re-reports on route events or `navIndexProvider`/`chatId` changes, so nothing re-asserts the location. Consequence: a reload at that moment lands on Home instead of the trip.

**Measured on unmodified `main` and on this branch, identically**, using a list-opened trip where `entryOrigin` is null and the code path is provably byte-identical to before. It is not introduced or worsened here, its cause is in `url_sync.dart` (out of this lane's scope), and the origin switch itself is immune because it *does* produce a report. Flagging it for its own lane.

## Tests

`test/home_open_trip_on_trips_tab_test.dart` is **rewritten, never deleted**. Every fact it pinned is still pinned — detail on the Trips tab, the nav item highlighting, no previously-open detail left underneath — now alongside both origins:

- `live trip card opens on the Trips tab and backs out to Home`
- `recent trip card opens on the Trips tab and backs out to Home`
- `a detail already on the Trips stack is replaced, not stacked`
- `backing out to Home leaves the Trips tab on its list`
- `a trip opened from the trips list still backs out to the list`
- `a Home-opened trip leaves no origin behind for the next one` — leaves via `selectTab`'s re-tap `popUntil`, the one path that bypasses `PopScope`

Plus `on a Home-opened trip, the panel still goes first` in `trip_detail_chat_back_test.dart`.

**Non-vacuity, measured against three wrong implementations** rather than asserted:

| Wrong implementation | Tests that fail |
|---|---|
| Pre-change behavior (origin never consulted) | 5 of 6 |
| Origin in an ambient provider, never cleared | `leaves no origin behind for the next one` |
| Origin in its own sibling `PopScope` | `the panel still goes first` |

The one test that does not fail against pre-change behavior is `a trip opened from the trips list still backs out to the list` — by design; it pins the half that must not move.

## Gates

- `flutter test` — **1776 passed, 0 failed** (measured baseline on this worktree at `44997ef`: 1772; +4 net)
- `flutter analyze` — clean (the 3 `route_response.dart` infos are baseline)
- `brand-guidelines/scripts/check.sh` on all three touched Dart files — one finding, `trip_detail_screen.dart` `Radius.circular(literal)`, **pre-existing** (same single finding on `main`, at line 4149 there vs 4224 here because lines were added above it); nothing in this diff touches radius, color, type, or spacing
- No l10n changes; no visual changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/golden-tempo/codesmith/anemos-travel/pr/516"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789798363&installation_model_id=433099&pr_number=516&repository=golden-tempo%2Fanemos-travel&return_to=https%3A%2F%2Fgithub.com%2Fgolden-tempo%2Fanemos-travel%2Fpull%2F516&signature=d0f4b6f630d6f3ddb1d14303c5b2f4adc2d5a9cc62576cb9a39cec0197d45e9e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->