### PR TITLE
fix(plan): lift the intro out of the bottom half on tall viewports

### DIFF
--- a/src/packages/flutter-app/lib/screens/agent_screen.dart
+++ b/src/packages/flutter-app/lib/screens/agent_screen.dart
@@ -144,6 +144,26 @@ const double _kIntroMeasure = 420;
 /// here is height, so height is what is asked.
 const double _kIntroFieldFloor = 440;
 
+/// Where the reading block sits in its field, as an [Alignment] y.
+///
+/// The leftover height splits between the field ABOVE the heading (the crown)
+/// and the one below it, before the rail (the seam); this number is the split.
+/// The crown keeps the larger share on purpose — space over a heading reads as
+/// composure, the move the editorial references make, while the same space
+/// under it reads as a missing element.
+///
+/// It was 0.5 (a 3:1 crown), which is right while the leftover is small and
+/// wrong once it is not: the share is taken from an unbounded field, so the
+/// taller the viewport the more of it pours into one void. Measured in the
+/// running app at 1342x988 — a 934px field — 0.5 put a **374px void above the
+/// heading against a 123px seam** and left the whole composition in the bottom
+/// half, with the first fixation landing on nothing. 0.2 is a 3:2 crown: still
+/// dominant, and it lifts the heading into the upper third.
+///
+/// Both numbers are browser measurements. Nothing here may be asserted from a
+/// widget test — this suite loads no fonts, so its text metrics are fiction.
+const double _kIntroCrownBias = 0.2;
+
 /// The Plan tab before a word is typed.
 ///
 /// Composed as ONE block that ends at the composer instead of a centered card
@@ -247,13 +267,11 @@ class _PlanIntro extends ConsumerWidget {
         return Column(
           children: [
             Expanded(
-              // Whatever height is left over splits 3:1 in favour of the field
-              // ABOVE the heading. Space over a heading reads as composure —
-              // it is the move the editorial references make — while the same
-              // space under it reads as a missing element, which is exactly
-              // how the centred layout this replaces read.
+              // Whatever height is left over splits between the field above
+              // the heading and the seam below it — see [_kIntroCrownBias] for
+              // which way and why it is not the 3:1 it started at.
               child: Align(
-                alignment: const Alignment(0, 0.5),
+                alignment: const Alignment(0, _kIntroCrownBias),
                 // Loose constraints from Align, so this shrink-wraps unless
                 // the largest text scales make the block taller than its
                 // share — then it scrolls instead of overflowing.


### PR DESCRIPTION
The Plan tab's intro sat in the bottom half of a desktop viewport. One constant.

## What was wrong

`_PlanIntro` gives its reading block (heading + what the agent will do) a field, and splits the leftover height 3:1 in favour of the **crown** — the space *above* the heading. That share is right while the leftover is small and wrong once it is not, because the field is unbounded: the taller the viewport, the more of it pours into one void.

Measured in the running app at 1342x988 (a 934px field):

| | crown | seam | heading top |
|---|---|---|---|
| before — `Alignment(0, 0.5)` | 374px | 123px | 46% of the field |
| **after — `Alignment(0, 0.2)`** | **303px** | **196px** | **38% of the field** |

The first fixation used to land on nothing, ~40% down an empty page.

## What is deliberately untouched

- **The acting half still hangs off the composer.** That adjacency is the redesign this screen shipped — the rail and the two chips sit directly above the input so the eye finishes the sentence on the thing it is meant to use. Nothing here re-opens it, which is also why the rail and chips do not move: within that rule, the reading block is the only thing that *can* move.
- **The short-viewport branch** below `_kIntroFieldFloor` (440) is untouched. On a 390x844 phone the same ratio reads crown 102 / seam 63, nothing clipped.
- The `SingleChildScrollView` escape for large text scales is unchanged.

## No test, on purpose

This suite has no `flutter_test_config.dart` and loads no fonts, so any assertion about where the block lands would be a claim about the fixed-width test font rather than about Inter and Cormorant Garamond. That is the trap that produced three false conclusions in this repo last week (the "28px overflow at 360dp" that wasn't, the `CollapsibleSection` follow-up that wasn't, and the plate-height fold). Both numbers in the constant's dartdoc are browser measurements and say so.

## Gates

- `flutter test` — **1772 passing, exit 0**, captured to a file, zero `[E]`
- `flutter analyze` — clean (3 pre-existing `unnecessary_brace_in_string_interps` infos in `route_response.dart`, untouched)
- `brand-check` — clean on the touched file

## Open question for the reviewer

`0.2` is a 3:2 crown. `0.0` (1:1) was also rendered: crown 253 / seam 245, heading at 33%. It puts the heading higher, but the reading block ends up with near-equal emptiness on both sides and starts to read as the marooned centred block the current dartdoc was written to get away from. 3:2 keeps the crown visibly dominant, so the block still hangs from the top field rather than floating. Happy to switch — it is one number.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/golden-tempo/codesmith/anemos-travel/pr/517"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789799371&installation_model_id=433099&pr_number=517&repository=golden-tempo%2Fanemos-travel&return_to=https%3A%2F%2Fgithub.com%2Fgolden-tempo%2Fanemos-travel%2Fpull%2F517&signature=f177fa9af28303bbb63d9c36ecf8ccfc25af319e4b975e9fe40d1da8eb52cb55"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->