### PR TITLE
feat(home): tell the traveler what their trip still needs

### DIFF
--- a/src/packages/flutter-app/lib/l10n/app_en.arb
+++ b/src/packages/flutter-app/lib/l10n/app_en.arb
@@ -1725,9 +1725,18 @@
   "suggestionPatagonia": "Hiking in Patagonia",
   "suggestionKenya": "Safari in Kenya",
   "homeLocalGuidesTitle": "Local guides",
+  "homeBeforeYouGoTitle": "Before you go",
+  "@homeBeforeYouGoTitle": {
+    "description": "Home section header over the open items for a trip departing soon."
+  },
+  "homeBeforeYouGoMore": "{n, plural, =1{1 more open item} other{{n} more open items}}",
+  "@homeBeforeYouGoMore": {
+    "description": "Count of open trip items beyond the three Home shows.",
+    "placeholders": { "n": { "type": "int" } }
+  },
   "homeInspirationTitle": "Somewhere new",
   "@homeInspirationTitle": {
-    "description": "Header of Home's destination-inspiration rail, shown only when there is no trip to continue"
+    "description": "Header of Home's destination-inspiration rail, which sits below the traveler's own trips"
   },
   "homeGuideByline": "By {name}",
   "@homeGuideByline": {

--- a/src/packages/flutter-app/lib/l10n/app_es.arb
+++ b/src/packages/flutter-app/lib/l10n/app_es.arb
@@ -734,6 +734,15 @@
   "suggestionPatagonia": "Senderismo en la Patagonia",
   "suggestionKenya": "Safari en Kenia",
   "homeLocalGuidesTitle": "Guías locales",
+  "homeBeforeYouGoTitle": "Antes de viajar",
+  "@homeBeforeYouGoTitle": {
+    "description": "Home section header over the open items for a trip departing soon."
+  },
+  "homeBeforeYouGoMore": "{n, plural, =1{1 asunto pendiente más} other{{n} asuntos pendientes más}}",
+  "@homeBeforeYouGoMore": {
+    "description": "Count of open trip items beyond the three Home shows.",
+    "placeholders": { "n": { "type": "int" } }
+  },
   "homeInspirationTitle": "Algún lugar nuevo",
   "homeGuideByline": "Por {name}",
   "shellNavHome": "Inicio",

--- a/src/packages/flutter-app/lib/l10n/app_localizations.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations.dart
@@ -4460,7 +4460,19 @@ abstract class AppLocalizations {
   /// **'Local guides'**
   String get homeLocalGuidesTitle;
 
-  /// Header of Home's destination-inspiration rail, shown only when there is no trip to continue
+  /// Home section header over the open items for a trip departing soon.
+  ///
+  /// In en, this message translates to:
+  /// **'Before you go'**
+  String get homeBeforeYouGoTitle;
+
+  /// Count of open trip items beyond the three Home shows.
+  ///
+  /// In en, this message translates to:
+  /// **'{n, plural, =1{1 more open item} other{{n} more open items}}'**
+  String homeBeforeYouGoMore(int n);
+
+  /// Header of Home's destination-inspiration rail, which sits below the traveler's own trips
   ///
   /// In en, this message translates to:
   /// **'Somewhere new'**

--- a/src/packages/flutter-app/lib/l10n/app_localizations_en.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations_en.dart
@@ -2620,6 +2620,20 @@ class AppLocalizationsEn extends AppLocalizations {
   String get homeLocalGuidesTitle => 'Local guides';
 
   @override
+  String get homeBeforeYouGoTitle => 'Before you go';
+
+  @override
+  String homeBeforeYouGoMore(int n) {
+    String _temp0 = intl.Intl.pluralLogic(
+      n,
+      locale: localeName,
+      other: '$n more open items',
+      one: '1 more open item',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get homeInspirationTitle => 'Somewhere new';
 
   @override

--- a/src/packages/flutter-app/lib/l10n/app_localizations_es.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations_es.dart
@@ -2638,6 +2638,20 @@ class AppLocalizationsEs extends AppLocalizations {
   String get homeLocalGuidesTitle => 'Guías locales';
 
   @override
+  String get homeBeforeYouGoTitle => 'Antes de viajar';
+
+  @override
+  String homeBeforeYouGoMore(int n) {
+    String _temp0 = intl.Intl.pluralLogic(
+      n,
+      locale: localeName,
+      other: '$n asuntos pendientes más',
+      one: '1 asunto pendiente más',
+    );
+    return '$_temp0';
+  }
+
+  @override
   String get homeInspirationTitle => 'Algún lugar nuevo';
 
   @override

--- a/src/packages/flutter-app/lib/screens/home_screen.dart
+++ b/src/packages/flutter-app/lib/screens/home_screen.dart
@@ -16,10 +16,13 @@ import '../theme/app_colors.dart';
 import '../theme/app_shadows.dart';
 import '../theme/spacing.dart';
 import '../widgets/account_menu.dart';
+import '../widgets/before_you_go_section.dart';
 import '../widgets/continue_chats_section.dart';
 import '../widgets/continue_trip_hero.dart';
 import '../widgets/gradient_app_bar.dart';
 import '../widgets/home_inspiration_rail.dart';
+import '../widgets/home_next_step_band.dart';
+import '../widgets/home_travels_band.dart';
 import '../widgets/language_menu_button.dart';
 import '../widgets/live_trip_card.dart';
 import '../widgets/near_me_chip.dart';
@@ -202,27 +205,63 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
                 // only when the account genuinely has nothing to resume.
                 ContinueChatsSection(
                   leading: continueTrip != null
-                      ? ContinueTripHero(
-                          tripId: continueTrip.tripId,
-                          title: continueTrip.title,
-                          dateRange: continueTrip.dateRange,
-                          startDate: continueTrip.startDate,
-                          onTap: () => openTripOnTripsTab(
-                              ref, continueTrip.tripId,
-                              from: AppTab.home),
+                      ? Column(
+                          crossAxisAlignment: CrossAxisAlignment.stretch,
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            ContinueTripHero(
+                              tripId: continueTrip.tripId,
+                              title: continueTrip.title,
+                              dateRange: continueTrip.dateRange,
+                              startDate: continueTrip.startDate,
+                              onTap: () => openTripOnTripsTab(
+                                  ref, continueTrip.tripId,
+                                  from: AppTab.home),
+                            ),
+                            // The hero's quiet sequel: what that trip still
+                            // needs. Collapses to nothing whenever the review
+                            // has no step to report, so the gap below is the
+                            // section's own — see HomeNextStepBand.
+                            const SizedBox(height: AppSpacing.sm),
+                            HomeNextStepBand(
+                              tripId: continueTrip.tripId,
+                              // Same destination AND same origin as the hero
+                              // above it: the pair is one target with two
+                              // rows, so back has to land where the hero's
+                              // back lands (PR #516).
+                              onTap: () => openTripOnTripsTab(
+                                  ref, continueTrip.tripId,
+                                  from: AppTab.home),
+                            ),
+                          ],
                         )
                       : null,
                 ),
 
-                // Inspiration fills the gap only when there is no trip to
-                // continue and nothing live — it must never push a
-                // traveler's actual trips down. New accounts always match,
-                // so the rail doubles as their "get inspired" section under
-                // the photo hero.
-                if (liveTrip == null && continueTrip == null)
-                  HomeInspirationRail(
-                    onPrompt: (text) => startPlanning(initialMessage: text),
+                // Pre-departure readiness for the trip that is close enough to
+                // pack for. Renders nothing outside its window or when it has
+                // no honest row to show (BeforeYouGoSection).
+                if (continueTrip != null)
+                  BeforeYouGoSection(
+                    tripId: continueTrip.tripId,
+                    startDate: continueTrip.startDate,
                   ),
+
+                // Where the traveler has been, and where they are going next.
+                // Carries its own 2+ owned-trips gate, so it cannot appear
+                // half-empty on a first trip.
+                const HomeTravelsBand(),
+
+                // Inspiration no longer disappears the moment there is a trip
+                // to continue. The rule it used to enforce — inspiration must
+                // never push a traveler's actual trips down — is now kept by
+                // POSITION rather than by absence: the rail sits below the
+                // trip content instead of vanishing from the page. Gating it
+                // off inverted the intent in practice, because the traveler
+                // who HAD a trip got the emptiest home screen in the app.
+                HomeInspirationRail(
+                  onPrompt: (text) => startPlanning(initialMessage: text),
+                ),
 
                 // Local guides discover row — published narrative guides
                 // across all cities. Renders nothing while loading, on

--- a/src/packages/flutter-app/lib/widgets/before_you_go_section.dart
+++ b/src/packages/flutter-app/lib/widgets/before_you_go_section.dart
@@ -1,0 +1,197 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../l10n/l10n.dart';
+import '../models/trip_finding.dart';
+import '../providers/trip_review_provider.dart';
+import '../theme/spacing.dart';
+import '../utils/trip_days.dart';
+import 'section_header.dart';
+
+/// What the trip you are about to take still has open, on Home.
+///
+/// The rows are the review's own [TripFinding]s — the same server-derived list
+/// behind the trip page's health sheet — so nothing here is computed twice and
+/// nothing is invented. It reads them off the review [HomeNextStepBand] has
+/// already fetched for this trip, so the whole section costs **no additional
+/// request**: same provider, same family key, one cached call.
+///
+/// **Windowed, not permanent furniture.** It appears only inside
+/// [_windowDays] of departure. A trip eleven months out always has open items
+/// — that is what planning is — and listing them every time Home loads would
+/// turn a real pre-departure signal into wallpaper that gets scrolled past.
+/// Past and undated trips never qualify.
+///
+/// The step already promoted into the band above is filtered out by category,
+/// so the two never say the same thing twice. Everything left is capped at
+/// [_maxRows]: this is a nudge toward the trip page, not a second health
+/// sheet, and the sheet is one tap away with the complete list.
+///
+/// Renders nothing when the window is closed, the review has not arrived, or
+/// nothing is open — an empty "Before you go" is worse than no section.
+class BeforeYouGoSection extends ConsumerWidget {
+  final String tripId;
+
+  /// ISO date-only trip start. Null means the snapshot could not say, which
+  /// closes the window rather than guessing it open.
+  final String? startDate;
+
+  const BeforeYouGoSection({
+    super.key,
+    required this.tripId,
+    required this.startDate,
+  });
+
+  /// How close departure has to be. Two weeks is the span where lodging,
+  /// transport and packing stop being plans and start being errands.
+  static const int _windowDays = 14;
+
+  static const int _maxRows = 3;
+
+  /// Which finding category each ladder step speaks for, so the band above and
+  /// the rows below cannot both report the same gap. Kinds absent from this
+  /// map (a future phase from a newer server) filter nothing, which shows one
+  /// duplicate row at worst — strictly better than hiding a real finding
+  /// because an unknown kind matched nothing.
+  static const _stepCategory = <String, String>{
+    'set_dates': 'dates',
+    'plan_itinerary': 'unscheduled',
+    'schedule_items': 'unscheduled',
+    'add_lodging': 'lodging',
+    'add_transport': 'transit',
+    'add_packing': 'packing',
+    'book_trip': 'bookings',
+  };
+
+  static const _categoryIcons = <String, IconData>{
+    'dates': Icons.event_outlined,
+    'unscheduled': Icons.schedule_outlined,
+    'packing': Icons.luggage_outlined,
+    'lodging': Icons.hotel_outlined,
+    'transit': Icons.directions_transit_outlined,
+    'budget': Icons.account_balance_wallet_outlined,
+    'bookings': Icons.confirmation_number_outlined,
+  };
+
+  /// critical first, then warn, then info — the order a traveler with four
+  /// days left needs them in. Stable within a severity: the server's own
+  /// ordering survives, so the list does not reshuffle between builds.
+  static const _severityRank = <String, int>{
+    'critical': 0,
+    'warn': 1,
+    'info': 2,
+  };
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final days = daysUntilTrip(startDate, DateTime.now());
+    if (days == null || days > _windowDays) return const SizedBox.shrink();
+
+    final review = ref.watch(tripReviewProvider(TripReviewKey(tripId)));
+    final value = review.valueOrNull;
+    if (value == null) return const SizedBox.shrink();
+
+    final promoted = _stepCategory[value.nextStep?.kind ?? ''];
+    final rows = <TripFinding>[
+      for (final f in value.findings)
+        if (f.category != promoted) f
+    ]..sort((a, b) => (_severityRank[a.severity] ?? 2)
+        .compareTo(_severityRank[b.severity] ?? 2));
+    if (rows.isEmpty) return const SizedBox.shrink();
+
+    final shown = rows.take(_maxRows).toList();
+    final theme = Theme.of(context);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        SectionHeader(title: context.l10n.homeBeforeYouGoTitle),
+        const SizedBox(height: AppSpacing.md),
+        Card(
+          // Rows, not tiles: DESIGN.md rules out same-size icon cards as page
+          // structure and the hero-metric template, and a readiness list is
+          // exactly where both are tempting.
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: AppSpacing.lg),
+            child: Column(
+              children: [
+                for (var i = 0; i < shown.length; i++)
+                  _FindingRow(
+                    finding: shown[i],
+                    icon: _categoryIcons[shown[i].category] ??
+                        Icons.info_outline,
+                    showDivider: i < shown.length - 1,
+                  ),
+              ],
+            ),
+          ),
+        ),
+        if (rows.length > shown.length)
+          Padding(
+            padding: const EdgeInsets.only(top: AppSpacing.sm),
+            child: Text(
+              context.l10n.homeBeforeYouGoMore(rows.length - shown.length),
+              style: theme.textTheme.bodySmall
+                  ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+            ),
+          ),
+        const SizedBox(height: AppSpacing.xl),
+      ],
+    );
+  }
+}
+
+/// One open item. Not tappable: applying a fix needs the trip screen's
+/// mutation providers, and a row that looks actionable but only navigates is
+/// the same broken promise [HomeNextStepBand] refuses to make.
+class _FindingRow extends StatelessWidget {
+  final TripFinding finding;
+  final IconData icon;
+  final bool showDivider;
+
+  const _FindingRow({
+    required this.finding,
+    required this.icon,
+    required this.showDivider,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final scheme = theme.colorScheme;
+    return Column(
+      children: [
+        ConstrainedBox(
+          // The house touch floor, kept even though the row is not a target:
+          // it is what makes a list of three read as a list rather than a
+          // paragraph with icons.
+          constraints: const BoxConstraints(minHeight: kMinTouchTarget),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              // outlineVariant for info, exactly as the status vocabulary
+              // does: absence of urgency must never read as a severity.
+              Icon(icon,
+                  size: 20,
+                  color: finding.severity == 'info'
+                      ? scheme.onSurfaceVariant
+                      : scheme.primary),
+              const SizedBox(width: AppSpacing.md),
+              Expanded(
+                child: Padding(
+                  padding:
+                      const EdgeInsets.symmetric(vertical: AppSpacing.sm),
+                  child: Text(
+                    finding.message,
+                    style: theme.textTheme.bodyMedium,
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+        if (showDivider) Divider(height: 1, color: scheme.outlineVariant),
+      ],
+    );
+  }
+}

--- a/src/packages/flutter-app/lib/widgets/home_next_step_band.dart
+++ b/src/packages/flutter-app/lib/widgets/home_next_step_band.dart
@@ -1,0 +1,145 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../l10n/l10n.dart';
+import '../providers/trip_review_provider.dart';
+import '../theme/app_colors.dart';
+import '../theme/spacing.dart';
+import 'next_step_card.dart';
+
+/// The continue-trip hero's quiet sequel on Home: the one planning action that
+/// trip still needs, from the same server-derived ladder the trip page renders
+/// (`specs/next-step-cta`, [NextStepCard]).
+///
+/// Home used to say "here is your trip" and stop, which left a traveler four
+/// days from departure with no idea that six nights in Kraków were unbooked —
+/// the fact was computed, shipped in the review payload, and only visible to
+/// someone who opened the trip. This band is that fact, one screen earlier.
+///
+/// **Deliberately not [NextStepCard].** That card's whole contract is that its
+/// button names what the tap will DO ("Find lodging", and `transportHandsOff`
+/// exists purely so the label can never promise a handoff the action won't
+/// make). Home cannot honor that: the apply-fix plumbing lives on the trip
+/// screen with the mutation providers, so a button here would say "Find
+/// lodging" and deliver a navigation. So this band carries **no action
+/// button** — it states the step and inherits the hero's tap. The traveler
+/// lands on the trip with the real button under their thumb.
+///
+/// It is a band and not a second card for the same reason the saved-
+/// conversation row under [NextStepCard] is one: flat, `AppSpacing.sm` beneath
+/// its primary block (the gap `ContinueChatsSection` already puts after its
+/// `leading`), so the pair scans as one plan block whose second line is
+/// quieter than its first. A shadow here would put the secondary entry above
+/// the primary one in depth.
+///
+/// Renders nothing while the review loads, on error, for a step-less payload,
+/// and on `all_set` — Home is not where a celebration belongs, and an empty
+/// band under the hero would be worse than no band. That absence is also why
+/// this is safe to mount unconditionally: the section it decorates only exists
+/// when there is a trip to continue.
+class HomeNextStepBand extends ConsumerWidget {
+  final String tripId;
+
+  /// Where the band goes — the same destination the hero above it opens, so
+  /// the pair is one target with two rows rather than two competing taps.
+  final VoidCallback onTap;
+
+  const HomeNextStepBand({
+    super.key,
+    required this.tripId,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    // valueOrNull, never `.when`: a spinner or an error box under the hero
+    // would be louder than the fact it is waiting for. Absence is the loading
+    // state and the error state both.
+    final review = ref.watch(tripReviewProvider(TripReviewKey(tripId)));
+    final step = review.valueOrNull?.nextStep;
+    if (step == null || step.kind == 'all_set') return const SizedBox.shrink();
+
+    final theme = Theme.of(context);
+    final l10n = context.l10n;
+    final scheme = theme.colorScheme;
+    final tintFill = AppColors.brandTintFill(scheme);
+    final tintInk = AppColors.onBrandTint(scheme);
+
+    final progress = review.valueOrNull?.planProgress;
+    final counted = progress != null && progress.total > 0;
+    final detail = step.detail;
+
+    return Semantics(
+      button: true,
+      container: true,
+      child: Material(
+        color: tintFill,
+        borderRadius: AppRadius.mdAll,
+        child: InkWell(
+          onTap: onTap,
+          borderRadius: AppRadius.mdAll,
+          child: Padding(
+            padding: const EdgeInsets.all(AppSpacing.lg),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                // Shared with the card on the trip page rather than re-listed
+                // here, so one step cannot wear two icons across two screens.
+                Icon(NextStepCard.iconFor(step.kind),
+                    color: AppColors.brandTintAccent(scheme), size: 24),
+                const SizedBox(width: AppSpacing.md),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        step.title,
+                        maxLines: 2,
+                        overflow: TextOverflow.ellipsis,
+                        style: theme.textTheme.titleSmall
+                            ?.copyWith(color: tintInk),
+                      ),
+                      if (detail != null && detail.isNotEmpty) ...[
+                        const SizedBox(height: AppSpacing.xs),
+                        Text(
+                          detail,
+                          maxLines: 2,
+                          overflow: TextOverflow.ellipsis,
+                          style: theme.textTheme.bodySmall?.copyWith(
+                            color: tintInk.withValues(alpha: 0.78),
+                          ),
+                        ),
+                      ],
+                    ],
+                  ),
+                ),
+                // The counter only, never the card's "NEXT STEP ·" eyebrow:
+                // capitals belong to the wordmark and the one place eyebrow
+                // (DESIGN.md, the One Eyebrow Rule), and the icon beside the
+                // title already says this is a task. Unlike the card's, this
+                // counter does not open the ladder sheet — the trip page is
+                // one tap away and owns that affordance.
+                if (counted) ...[
+                  const SizedBox(width: AppSpacing.md),
+                  Padding(
+                    padding: const EdgeInsets.only(top: AppSpacing.xs),
+                    child: Text(
+                      l10n.nextStepProgress(
+                        (progress.done + 1).clamp(1, progress.total),
+                        progress.total,
+                      ),
+                      style: theme.textTheme.labelSmall?.copyWith(
+                        color: tintInk.withValues(alpha: 0.78),
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                  ),
+                ],
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/src/packages/flutter-app/lib/widgets/home_travels_band.dart
+++ b/src/packages/flutter-app/lib/widgets/home_travels_band.dart
@@ -1,0 +1,60 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../l10n/l10n.dart';
+import '../providers/trips_provider.dart';
+import '../theme/spacing.dart';
+import '../utils/trip_list_insights.dart';
+import 'section_header.dart';
+import 'travel_footprint_card.dart';
+
+/// "Your travels" on Home: the traveled/planned footprint the Trips tab
+/// already shows, so the page ends on where you have been rather than on
+/// nothing.
+///
+/// Reuses [TravelFootprintCard] and [travelStats] outright rather than
+/// restating them — a second arithmetic for the same two counts is how the two
+/// surfaces would start disagreeing about how many cities you have visited.
+/// Both gates come with it: **2+ owned trips**, because an aggregate over one
+/// trip only restates the hero above it, and the card's own pin rules.
+///
+/// Reads `tripsProvider`, which is populated app-wide (the shell keeps
+/// `TripsListScreen` mounted and its `loadTrips()` feeds it), so this costs no
+/// request of its own — the same reason Home can watch it for `returning`.
+///
+/// Owned trips only. Shared-with-me is someone else's travel and its payload
+/// carries no pins anyway, which is the rule the Trips tab already applies.
+class HomeTravelsBand extends ConsumerWidget {
+  const HomeTravelsBand({super.key});
+
+  /// Below this an aggregate says nothing the trip cards above have not.
+  static const int _minTrips = 2;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    // Length only, not the trip objects: a background refresh rebuilds every
+    // Trip, and this band's numbers only change when the SET does. The full
+    // list is read below, once the length says this build runs anyway.
+    final tripCount = ref.watch(tripsProvider.select((s) => s.trips.length));
+    if (tripCount < _minTrips) return const SizedBox.shrink();
+
+    final trips = ref.read(tripsProvider).trips;
+    final now = DateTime.now();
+    final stats = travelStats(trips, now);
+    final pins = footprintPins(trips, now);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        SectionHeader(title: context.l10n.tripsListYourTravels),
+        const SizedBox(height: AppSpacing.md),
+        TravelFootprintCard(
+          pins: pins,
+          traveled: stats.traveled,
+          planned: stats.planned,
+        ),
+        const SizedBox(height: AppSpacing.xl),
+      ],
+    );
+  }
+}

--- a/src/packages/flutter-app/lib/widgets/next_step_card.dart
+++ b/src/packages/flutter-app/lib/widgets/next_step_card.dart
@@ -78,6 +78,16 @@ class NextStepCard extends StatelessWidget {
     'add_packing': Icons.luggage_outlined,
   };
 
+  /// The ladder's icon for [kind], falling back to the same generic pin this
+  /// card uses for an unknown kind (a future phase from a newer server).
+  ///
+  /// Public because Home renders the same step as a quiet band under its
+  /// continue hero ([HomeNextStepBand]) and the two must never disagree about
+  /// what a step looks like. The map itself stays private — a second literal
+  /// copy of it is exactly the drift this accessor exists to prevent.
+  static IconData iconFor(String kind) =>
+      _kindIcons[kind] ?? Icons.place_outlined;
+
   /// Localized primary-action label per ladder kind. An unknown kind (a future
   /// ladder phase from a newer server) falls back to the fix's server-localized
   /// button label, else the generic "View all".

--- a/src/packages/flutter-app/test/home_inspiration_rail_test.dart
+++ b/src/packages/flutter-app/test/home_inspiration_rail_test.dart
@@ -18,13 +18,16 @@ import 'package:travel_route_planner/services/api_client.dart';
 import 'package:travel_route_planner/services/plan_service.dart';
 import 'package:travel_route_planner/widgets/destination_suggestion_card.dart';
 import 'package:travel_route_planner/widgets/home_inspiration_rail.dart';
+import 'package:travel_route_planner/widgets/live_trip_card.dart';
 import 'package:travel_route_planner/widgets/random_suggestions.dart';
 
 import 'support/l10n_test_app.dart';
 
-/// The "Somewhere new" rail's placement contract: inspiration fills the gap
-/// only when there is nothing to continue — no live trip and no continue
-/// card — and a card tap SENDS its prompt into the Plan tab (Home's one-tap
+/// The "Somewhere new" rail's placement contract: inspiration ALWAYS renders,
+/// and always below the traveler's own trips — the ordering replaced an
+/// earlier gate that hid the rail outright whenever there was something to
+/// continue, which left the traveler who had a trip with the emptiest page in
+/// the app. A card tap SENDS its prompt into the Plan tab (Home's one-tap
 /// contract; the landing rail hands off instead).
 class _FakeAuthNotifier extends StateNotifier<AuthState>
     implements AuthNotifier {
@@ -160,21 +163,38 @@ void main() {
     expect(find.byType(HomeInspirationRail), findsOneWidget);
   });
 
-  testWidgets('a live trip hides the rail', (WidgetTester tester) async {
+  // The rail used to be GATED OFF whenever there was a trip to continue, so it
+  // could not push a traveler's own trips down the page. That inverted the
+  // intent in practice: the traveler who HAD a trip got the emptiest home
+  // screen in the app. The rule is now kept by POSITION — the rail always
+  // renders, always below the trip content — so these two pin the ORDER
+  // rather than the absence, which is the property the rule was ever about.
+
+  testWidgets('a live trip keeps the rail, and outranks it',
+      (WidgetTester tester) async {
     await pumpHome(tester, liveTrip: _liveTrip());
 
-    expect(find.byType(HomeInspirationRail), findsNothing);
+    expect(find.byType(HomeInspirationRail), findsOneWidget);
+    expect(
+      tester.getTopLeft(find.byType(LiveTripCard)).dy,
+      lessThan(tester.getTopLeft(find.byType(HomeInspirationRail)).dy),
+    );
   });
 
-  testWidgets('a continue trip hides the rail', (WidgetTester tester) async {
+  testWidgets('a continue trip keeps the rail, and outranks it',
+      (WidgetTester tester) async {
     // The recorded-trip snapshot alone reaches rung 2 — a continue card
-    // exists, so inspiration must yield.
+    // exists, and inspiration now sits under it instead of vanishing.
     await pumpHome(tester, prefs: {
       'recent_trip.user-1': '{"id":"t9","title":"Lisbon Trip"}',
     });
 
     expect(find.text('Lisbon Trip'), findsOneWidget);
-    expect(find.byType(HomeInspirationRail), findsNothing);
+    expect(find.byType(HomeInspirationRail), findsOneWidget);
+    expect(
+      tester.getTopLeft(find.text('Lisbon Trip')).dy,
+      lessThan(tester.getTopLeft(find.byType(HomeInspirationRail)).dy),
+    );
   });
 
   testWidgets('card tap sends the prompt and switches to the Plan tab',

--- a/src/packages/flutter-app/test/home_near_me_test.dart
+++ b/src/packages/flutter-app/test/home_near_me_test.dart
@@ -133,7 +133,13 @@ void main() {
   testWidgets('returning-user strip keeps a near-me chip beneath it',
       (WidgetTester tester) async {
     await pumpHome(tester, liveTrip: _liveTrip());
-    expect(find.text('2 days in Paris'), findsNothing); // strip branch
+    // Scoped to the hero's ActionChip for the same reason the test above is:
+    // the inspiration rail draws from this same pool, and it now renders for a
+    // returning user instead of being gated off, so the BARE text legitimately
+    // appears on a destination card down the page. What marks the strip branch
+    // is the absence of the HERO's suggestion chips, which is what this says.
+    expect(find.widgetWithText(ActionChip, '2 days in Paris'),
+        findsNothing); // strip branch
     expect(find.byType(NearMeChip), findsOneWidget);
   });
 

--- a/src/packages/flutter-app/test/home_next_step_band_test.dart
+++ b/src/packages/flutter-app/test/home_next_step_band_test.dart
@@ -1,0 +1,133 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:travel_route_planner/models/trip_finding.dart';
+import 'package:travel_route_planner/providers/trip_review_provider.dart';
+import 'package:travel_route_planner/widgets/home_next_step_band.dart';
+
+import 'support/l10n_test_app.dart';
+
+/// The continue hero's sequel band on Home. Its whole job is knowing when NOT
+/// to render — the band decorates a section that already exists, so every
+/// absent case has to collapse to zero height rather than leave a tinted strip
+/// under the hero.
+void main() {
+  const tripId = 't1';
+
+  NextStep step({String kind = 'add_lodging', String? detail}) => NextStep(
+        kind: kind,
+        title: 'Book your stay in Kraków',
+        detail: detail,
+      );
+
+  Future<void> pump(
+    WidgetTester tester, {
+    required AsyncValue<TripReview> review,
+  }) async {
+    var taps = 0;
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          tripReviewProvider(const TripReviewKey(tripId))
+              .overrideWith((ref) async => review.value ?? (throw 'pending')),
+        ],
+        child: MaterialApp(
+          localizationsDelegates: testLocalizationsDelegates,
+          home: Scaffold(
+            body: HomeNextStepBand(tripId: tripId, onTap: () => taps++),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump();
+  }
+
+  testWidgets('renders the step, its detail, and the ladder counter',
+      (tester) async {
+    await pump(
+      tester,
+      review: AsyncValue.data(TripReview(
+        findings: const [],
+        nextStep: step(detail: 'No lodging for Aug 29 – Sep 3'),
+        planProgress: const PlanProgress(done: 2, total: 6),
+      )),
+    );
+
+    expect(find.text('Book your stay in Kraków'), findsOneWidget);
+    expect(find.text('No lodging for Aug 29 – Sep 3'), findsOneWidget);
+    // done + 1 — the step being shown is the one in progress, not the last
+    // finished one, exactly as NextStepCard's eyebrow counts.
+    expect(find.text('3 of 6'), findsOneWidget);
+  });
+
+  testWidgets('carries no action button — the trip page owns the real one',
+      (tester) async {
+    await pump(
+      tester,
+      review: AsyncValue.data(TripReview(
+        findings: const [],
+        nextStep: step(),
+      )),
+    );
+
+    // The band states the step and inherits the hero's tap. A button here
+    // would have to name an action Home cannot perform.
+    expect(find.byType(FilledButton), findsNothing);
+    expect(find.byType(TextButton), findsNothing);
+    expect(find.byType(ElevatedButton), findsNothing);
+  });
+
+  testWidgets('the whole band is one tap target', (tester) async {
+    await pump(
+      tester,
+      review: AsyncValue.data(TripReview(
+        findings: const [],
+        nextStep: step(),
+      )),
+    );
+
+    expect(
+      find.descendant(
+          of: find.byType(HomeNextStepBand), matching: find.byType(InkWell)),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('all_set collapses — Home is not where a celebration belongs',
+      (tester) async {
+    await pump(
+      tester,
+      review: AsyncValue.data(TripReview(
+        findings: const [],
+        nextStep: step(kind: 'all_set'),
+      )),
+    );
+
+    expect(find.byType(InkWell), findsNothing);
+    expect(tester.getSize(find.byType(HomeNextStepBand)), Size.zero);
+  });
+
+  testWidgets('a step-less payload collapses', (tester) async {
+    await pump(
+      tester,
+      review: const AsyncValue.data(TripReview(findings: [])),
+    );
+
+    expect(tester.getSize(find.byType(HomeNextStepBand)), Size.zero);
+  });
+
+  testWidgets('no counter when the server sent no ladder', (tester) async {
+    await pump(
+      tester,
+      review: AsyncValue.data(TripReview(
+        findings: const [],
+        nextStep: step(),
+      )),
+    );
+
+    expect(find.text('Book your stay in Kraków'), findsOneWidget);
+    expect(find.textContaining(' of '), findsNothing);
+  });
+}


### PR DESCRIPTION
Home said "here is your trip" and stopped. Four days from departure it had nothing to say about six unbooked nights in Kraków — the fact was computed, shipped in the review payload, and visible only to someone who opened the trip. Below the continue hero the page was empty to the fold.

## The emptiness was a gate, not missing work

Two sections would have filled it, and both switch themselves off for exactly that state:

| Section | Condition |
|---|---|
| `HomeInspirationRail` | renders **only** when `liveTrip == null && continueTrip == null` |
| `_LocalGuidesRow` | renders nothing without published guides |

The rail's rule — *inspiration must never push a traveler's actual trips down* — is right, and gating inverted it in practice: **the traveler who HAD a trip got the emptiest page in the app.** It's now kept by **position** instead, the rail sitting below the trip content rather than vanishing.

## Four additions, all reading data that already exists

- **`HomeNextStepBand`** — the trip's next planning action, from the same server-derived ladder the trip page renders (`specs/next-step-cta`).
- **`BeforeYouGoSection`** — what else is open, from the **same cached review call**, so it costs no extra request. Windowed to 14 days of departure: a trip eleven months out always has open items, and listing them on every Home load turns a real pre-departure signal into wallpaper.
- **`HomeTravelsBand`** — the traveled/planned footprint, reusing `TravelFootprintCard` and `travelStats` outright rather than restating the arithmetic, inheriting the 2+ owned-trips gate with it.
- **The rail**, un-gated and demoted.

## The band is deliberately *not* `NextStepCard`

That card's contract is that its button names what the tap will **do** — `transportHandsOff` exists purely so a label can never promise a handoff the action won't make. Home can't honor that: the apply-fix plumbing lives on the trip screen with the mutation providers, so a button here would say "Find lodging" and deliver a navigation.

So the band carries **no action button at all**. It states the step and inherits the hero's tap, landing you on the trip with the real button under your thumb. Its icon comes from `NextStepCard.iconFor` rather than a second copy of the map, so one step can't wear two icons across two screens.

No eyebrow, unlike the card: capitals belong to the wordmark and the one place eyebrow (DESIGN.md), and the icon beside the title already says this is a task. The counter survives because it's the part carrying information. Readiness is **rows, not tiles** — the hero-metric template and same-size icon grids are both banned as page structure, and a readiness list is exactly where both are tempting.

## Every new section collapses rather than render an empty shell

No step, `all_set`, a closed window, no findings, fewer than two trips — all zero height. Absence is also the loading *and* error state: a spinner under the hero would be louder than the fact it's waiting for.

## Tests

The two that pinned the old gate now pin the **order** instead, which is the property the rule was ever about. `home_near_me`'s strip-branch assertion moved from bare text to the hero's `ActionChip` — the rail draws from the same suggestion pool, so that text now legitimately appears on a card below (the sibling test already documented this exact hazard).

Six new tests cover the band's suppression logic, which is where its real behavior lives.

- `flutter test` — **1778 passed, 0 failed**
- `dart analyze` — clean (3 pre-existing infos in an untouched file)
- brand-check — clean

Not visually confirmed in a running app — no local stack was up. Design brief with a wireframe was reviewed and approved before building.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/golden-tempo/codesmith/anemos-travel/pr/518"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789801068&installation_model_id=433099&pr_number=518&repository=golden-tempo%2Fanemos-travel&return_to=https%3A%2F%2Fgithub.com%2Fgolden-tempo%2Fanemos-travel%2Fpull%2F518&signature=2e576989c01106da1fbc1aa9b271cb516fe736ea689897c929efdb602411324c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->