### PR TITLE
fix(home): walk "Before you go" in itinerary order, not by severity

### DIFF
--- a/src/packages/flutter-app/lib/widgets/before_you_go_section.dart
+++ b/src/packages/flutter-app/lib/widgets/before_you_go_section.dart
@@ -46,22 +46,7 @@ class BeforeYouGoSection extends ConsumerWidget {
   /// transport and packing stop being plans and start being errands.
   static const int _windowDays = 14;
 
-  static const int _maxRows = 3;
-
-  /// Which finding category each ladder step speaks for, so the band above and
-  /// the rows below cannot both report the same gap. Kinds absent from this
-  /// map (a future phase from a newer server) filter nothing, which shows one
-  /// duplicate row at worst — strictly better than hiding a real finding
-  /// because an unknown kind matched nothing.
-  static const _stepCategory = <String, String>{
-    'set_dates': 'dates',
-    'plan_itinerary': 'unscheduled',
-    'schedule_items': 'unscheduled',
-    'add_lodging': 'lodging',
-    'add_transport': 'transit',
-    'add_packing': 'packing',
-    'book_trip': 'bookings',
-  };
+  static const int _maxRows = 5;
 
   static const _categoryIcons = <String, IconData>{
     'dates': Icons.event_outlined,
@@ -73,14 +58,95 @@ class BeforeYouGoSection extends ConsumerWidget {
     'bookings': Icons.confirmation_number_outlined,
   };
 
-  /// critical first, then warn, then info — the order a traveler with four
-  /// days left needs them in. Stable within a severity: the server's own
-  /// ordering survives, so the list does not reshuffle between builds.
+  /// critical first, then warn, then info. Only breaks ties among the UNDATED
+  /// tail — the dated rows are ordered by the trip itself (see [openItems]).
   static const _severityRank = <String, int>{
     'critical': 0,
     'warn': 1,
     'info': 2,
   };
+
+  /// The date a finding's fix acts on, or null when it is not a leg of the
+  /// journey. The two shapes the server emits carry it under different names
+  /// because they mean different things — a stay's `checkIn` is the night it
+  /// starts, a transport leg's `date` is "the destination hub's first day"
+  /// (trip_review.go) — but both are the point in the trip where that gap
+  /// sits, which is exactly what orders them.
+  static String? _fixDate(TripFinding f) => f.fix?.checkIn ?? f.fix?.date;
+
+  /// Two rows on the same date: you travel, then you sleep there. Anything
+  /// else keeps its relative order.
+  static int _sameDayRank(TripFinding f) => switch (f.category) {
+        'transit' => 0,
+        'lodging' => 1,
+        _ => 2,
+      };
+
+  /// The trip's open items **in the order the trip is actually travelled** —
+  /// the same walk the next-step ladder's phase 3 makes ("Book travel & stays,
+  /// in itinerary order… outbound leg → stay → next leg → … → return leg",
+  /// specs/next-step-cta).
+  ///
+  /// It is reproduced here rather than read off the server because the ladder
+  /// only ever names its FIRST open slot; the walk itself lives behind
+  /// `syncTodos`, which is a POST that upserts the derived checklist, so Home
+  /// must not call it. Findings carry enough to rebuild the sequence: every
+  /// lodging gap knows its `checkIn` and every transport gap its leg date, so
+  /// sorting on that one key yields stay-in-Kraków → fly-to-Copenhagen →
+  /// stay-in-Copenhagen without inventing an ordering of its own.
+  ///
+  /// Undated findings — packing, budget, a whole-trip warning — cannot join a
+  /// chronological walk, so they fall to the tail in severity order rather
+  /// than being dropped or being given a date they do not have.
+  ///
+  /// [promoted] is the step already showing in the band above, and exactly one
+  /// row is removed for it: the one its fix names. Filtering by CATEGORY
+  /// instead — which this did first — deleted every lodging gap on the trip
+  /// the moment the ladder reached lodging, leaving a "Before you go" that
+  /// listed nothing but transport.
+  ///
+  /// Pure and static so the order can be unit-tested without a harness, the
+  /// way [NextStepCard] is.
+  @visibleForTesting
+  static List<TripFinding> openItems(List<TripFinding> findings,
+      {NextStep? promoted}) {
+    final rows = [
+      for (final f in findings)
+        if (!_isPromoted(f, promoted)) f
+    ];
+    rows.sort((a, b) {
+      final da = _fixDate(a), db = _fixDate(b);
+      if (da != null && db != null) {
+        // ISO-8601 date-only strings: lexicographic IS chronological.
+        final byDate = da.compareTo(db);
+        if (byDate != 0) return byDate;
+        return _sameDayRank(a).compareTo(_sameDayRank(b));
+      }
+      // A dated row is a place in the journey; an undated one is a chore.
+      if (da != null) return -1;
+      if (db != null) return 1;
+      return (_severityRank[a.severity] ?? 2)
+          .compareTo(_severityRank[b.severity] ?? 2);
+    });
+    return rows;
+  }
+
+  /// Whether [f] is the very gap [promoted] already names — matched on what
+  /// the two fixes ACT ON, never on category. A lodging step is the same gap
+  /// as a lodging finding when they book the same city on the same night; a
+  /// transport step matches on the leg's endpoints.
+  static bool _isPromoted(TripFinding f, NextStep? promoted) {
+    final step = promoted?.fix;
+    if (step == null) return false;
+    if (step.action != f.fix?.action) return false;
+    return switch (step.action) {
+      'add_lodging' => step.city == f.fix?.city &&
+          step.checkIn == f.fix?.checkIn,
+      'add_transport' => step.origin == f.fix?.origin &&
+          step.destination == f.fix?.destination,
+      _ => false,
+    };
+  }
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -91,12 +157,7 @@ class BeforeYouGoSection extends ConsumerWidget {
     final value = review.valueOrNull;
     if (value == null) return const SizedBox.shrink();
 
-    final promoted = _stepCategory[value.nextStep?.kind ?? ''];
-    final rows = <TripFinding>[
-      for (final f in value.findings)
-        if (f.category != promoted) f
-    ]..sort((a, b) => (_severityRank[a.severity] ?? 2)
-        .compareTo(_severityRank[b.severity] ?? 2));
+    final rows = openItems(value.findings, promoted: value.nextStep);
     if (rows.isEmpty) return const SizedBox.shrink();
 
     final shown = rows.take(_maxRows).toList();

--- a/src/packages/flutter-app/test/before_you_go_order_test.dart
+++ b/src/packages/flutter-app/test/before_you_go_order_test.dart
@@ -1,0 +1,143 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:travel_route_planner/models/trip_finding.dart';
+import 'package:travel_route_planner/widgets/before_you_go_section.dart';
+
+/// "Before you go" orders the trip's open items the way the trip is actually
+/// travelled — the same walk the next-step ladder's phase 3 makes — not by
+/// severity, and not by category.
+TripFinding lodging(String city, String checkIn, {String sev = 'warn'}) =>
+    TripFinding(
+      severity: sev,
+      category: 'lodging',
+      message: 'No lodging in $city',
+      tripId: 't1',
+      fix: FindingFix(
+        action: 'add_lodging',
+        label: 'Find a stay',
+        city: city,
+        checkIn: checkIn,
+        checkOut: checkIn,
+      ),
+    );
+
+TripFinding transit(String from, String to, String date) => TripFinding(
+      severity: 'warn',
+      category: 'transit',
+      message: 'No transport from $from to $to',
+      tripId: 't1',
+      fix: FindingFix(
+        action: 'add_transport',
+        label: 'Find flights',
+        origin: from,
+        destination: to,
+        date: date,
+      ),
+    );
+
+TripFinding chore(String category, String message, {String sev = 'info'}) =>
+    TripFinding(
+      severity: sev,
+      category: category,
+      message: message,
+      tripId: 't1',
+    );
+
+void main() {
+  test('walks the trip in order: stay, then the leg out, then the next stay',
+      () {
+    // Deliberately shuffled on the way in — the server groups findings by
+    // check, so they never arrive in itinerary order.
+    final ordered = BeforeYouGoSection.openItems([
+      transit('Copenhagen', 'Berlin', '2026-09-08'),
+      lodging('Copenhagen', '2026-09-03'),
+      lodging('Kraków', '2026-08-29'),
+      transit('Kraków', 'Copenhagen', '2026-09-03'),
+    ]);
+
+    expect(ordered.map((f) => f.message).toList(), [
+      'No lodging in Kraków',
+      'No transport from Kraków to Copenhagen',
+      'No lodging in Copenhagen',
+      'No transport from Copenhagen to Berlin',
+    ]);
+  });
+
+  test('you travel before you sleep there, on a shared date', () {
+    final ordered = BeforeYouGoSection.openItems([
+      lodging('Copenhagen', '2026-09-03'),
+      transit('Kraków', 'Copenhagen', '2026-09-03'),
+    ]);
+
+    expect(ordered.first.category, 'transit');
+    expect(ordered.last.category, 'lodging');
+  });
+
+  test('undated chores fall to the tail, in severity order', () {
+    final ordered = BeforeYouGoSection.openItems([
+      chore('budget', 'Budget looks thin', sev: 'info'),
+      chore('packing', 'Nothing packed', sev: 'warn'),
+      lodging('Kraków', '2026-08-29'),
+    ]);
+
+    expect(ordered.map((f) => f.category).toList(),
+        ['lodging', 'packing', 'budget']);
+  });
+
+  test('the promoted step drops ONE row, not its whole category', () {
+    // The regression this test exists for: filtering by category deleted every
+    // lodging gap the moment the ladder reached lodging, so the section
+    // listed nothing but transport.
+    final ordered = BeforeYouGoSection.openItems(
+      [
+        lodging('Kraków', '2026-08-29'),
+        transit('Kraków', 'Copenhagen', '2026-09-03'),
+        lodging('Copenhagen', '2026-09-03'),
+      ],
+      promoted: NextStep(
+        kind: 'add_lodging',
+        title: 'Book your stay in Kraków',
+        fix: FindingFix(
+          action: 'add_lodging',
+          label: 'Find a stay',
+          city: 'Kraków',
+          checkIn: '2026-08-29',
+        ),
+      ),
+    );
+
+    // Kraków's stay is the one in the band above; Copenhagen's survives.
+    expect(ordered.map((f) => f.message).toList(), [
+      'No transport from Kraków to Copenhagen',
+      'No lodging in Copenhagen',
+    ]);
+  });
+
+  test('a promoted step matching nothing removes nothing', () {
+    final rows = [lodging('Kraków', '2026-08-29')];
+    final ordered = BeforeYouGoSection.openItems(
+      rows,
+      promoted: NextStep(
+        kind: 'add_lodging',
+        title: 'Book your stay in Rome',
+        fix: FindingFix(
+          action: 'add_lodging',
+          label: 'Find a stay',
+          city: 'Rome',
+          checkIn: '2026-09-20',
+        ),
+      ),
+    );
+
+    expect(ordered, hasLength(1));
+  });
+
+  test('a step with no fix (a chat-seeded rung) filters nothing', () {
+    final ordered = BeforeYouGoSection.openItems(
+      [lodging('Kraków', '2026-08-29')],
+      promoted: const NextStep(kind: 'plan_itinerary', title: 'Plan your days'),
+    );
+
+    expect(ordered, hasLength(1));
+  });
+}

--- a/src/packages/flutter-app/test/home_plan_strip_test.dart
+++ b/src/packages/flutter-app/test/home_plan_strip_test.dart
@@ -112,7 +112,14 @@ void main() {
     // Same headline + CTA, no photo, no suggestion chips.
     expect(find.text('Plan less. Travel more.'), findsOneWidget);
     expect(find.text("Let's go"), findsOneWidget);
-    expect(find.text('2 days in Paris'), findsNothing);
+    // Scoped to the hero's ActionChip, like the assertion above it and the two
+    // in home_near_me_test: the inspiration rail draws from this same pool and
+    // now renders for a returning user instead of being gated off, so the BARE
+    // text appears on a destination card further down the page. It did so only
+    // SOMETIMES — the rail is a lazy horizontal ListView over a shuffled pool,
+    // so whether the Paris card got built varied run to run, which is what made
+    // this fail intermittently instead of immediately.
+    expect(find.widgetWithText(ActionChip, '2 days in Paris'), findsNothing);
     expect(find.byIcon(Icons.flight_takeoff), findsOneWidget);
   });
 


### PR DESCRIPTION
Reported: "Before you go" only shows transport. Two bugs, and the second is the cause.

## It deleted a whole category

Rows were filtered against the promoted step by **category**. So the moment the ladder reached lodging — exactly when a traveler most needs to see their stays — *every* lodging gap on the trip disappeared, leaving transit findings alone on screen.

The match is now on what the two fixes **act on**: same city and check-in for a stay, same endpoints for a leg. One row goes, never a category. There's a named regression test for it.

## It ordered by severity

Severity says how loud a finding is, not where it sits in the journey — and every lodging and transit gap is `warn`, so the list came out in whatever order the server's checks happened to run.

The order that means something is the one the ladder's phase 3 already uses:

> **Book travel & stays, in itinerary order** — outbound leg → stay → next leg → … → return leg (`specs/next-step-cta`)

**That walk isn't fetchable from Home.** The ladder only ever names its *first* open slot, and the walk itself lives behind `syncTodos` — a POST that upserts the derived checklist, which Home has no business calling.

But the findings already carry enough to rebuild it. A lodging gap knows its `checkIn`; a transport gap knows its leg date ("the destination hub's first day", `trip_review.go`). Different field names because they mean different things — but the same meaning for ordering: the point in the trip where the gap sits. Sorting on that one key yields

```
stay in Kraków → fly Kraków→Copenhagen → stay in Copenhagen → …
```

with **no request added** and no ordering invented client-side. Same-date ties break transport-before-lodging: you travel, then you sleep there.

Undated findings — packing, budget, a whole-trip warning — can't join a chronological walk, so they fall to the tail in severity order rather than being dropped or handed a date they don't have.

## Also

Cap raised 3 → 5 now that the rows are a *sequence* rather than a sample: the rhythm of stay-leg-stay is the information, and three rows couldn't show it.

`openItems` is static and `@visibleForTesting`, so the order unit-tests without a harness the way `NextStepCard` does.

## Verification

- `flutter test` — **1788 passed, 0 failed** (6 new, including the shuffled-input walk and the category-filter regression)
- `dart analyze` — clean (3 pre-existing infos in an untouched file)
- brand-check — clean

Not visually confirmed in a running app — no local stack was up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/golden-tempo/codesmith/anemos-travel/pr/519"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789829573&installation_model_id=433099&pr_number=519&repository=golden-tempo%2Fanemos-travel&return_to=https%3A%2F%2Fgithub.com%2Fgolden-tempo%2Fanemos-travel%2Fpull%2F519&signature=e7159d6a612d6eedb585046eab91bb37f425ddde3418d29e012b8febb1331502"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->