### PR TITLE
fix(plan): the intro's two halves travel together

### DIFF
--- a/src/packages/flutter-app/lib/screens/agent_screen.dart
+++ b/src/packages/flutter-app/lib/screens/agent_screen.dart
@@ -144,25 +144,31 @@ const double _kIntroMeasure = 420;
 /// here is height, so height is what is asked.
 const double _kIntroFieldFloor = 440;
 
-/// Where the reading block sits in its field, as an [Alignment] y.
+/// Where the intro block sits in its field, as an [Alignment] y.
 ///
-/// The leftover height splits between the field ABOVE the heading (the crown)
-/// and the one below it, before the rail (the seam); this number is the split.
-/// The crown keeps the larger share on purpose — space over a heading reads as
-/// composure, the move the editorial references make, while the same space
-/// under it reads as a missing element.
+/// Slightly above centre: the optical centre of a field is above its geometric
+/// one, so an evenly-split block reads as having sagged.
 ///
-/// It was 0.5 (a 3:1 crown), which is right while the leftover is small and
-/// wrong once it is not: the share is taken from an unbounded field, so the
-/// taller the viewport the more of it pours into one void. Measured in the
-/// running app at 1342x988 — a 934px field — 0.5 put a **374px void above the
-/// heading against a 123px seam** and left the whole composition in the bottom
-/// half, with the first fixation landing on nothing. 0.2 is a 3:2 crown: still
-/// dominant, and it lifts the heading into the upper third.
+/// This number exists because the screen used to hold the reading half and the
+/// acting half apart — the rail was pinned to the composer and the heading
+/// floated in whatever was left over. On a phone that is invisible, because
+/// there is nothing left over. On a 934px desktop field there are ~544px of it,
+/// and pinning the rail meant every one of those pixels had to sit either above
+/// the heading or between the heading and the rail. Both were measured in the
+/// running app at 1342x988 and both are wrong: 374/123 leaves the whole
+/// composition in the bottom half, and 303/196 opens a hole through the middle
+/// of it. There is no third split, because the two are the same 544px.
 ///
-/// Both numbers are browser measurements. Nothing here may be asserted from a
-/// widget test — this suite loads no fonts, so its text metrics are fiction.
-const double _kIntroCrownBias = 0.2;
+/// So the halves travel together now and the leftover goes below them, between
+/// the rail and the composer. That gives up the adjacency the previous pass
+/// prized — starters within reach of the input — and it is a real cost on a
+/// short viewport, which is why the branch below [_kIntroFieldFloor] still
+/// stacks them tight. What it buys is one object instead of three zones.
+///
+/// Every number above is a browser measurement. Nothing here may be asserted
+/// from a widget test — this suite loads no fonts, so its text metrics are
+/// fiction.
+const double _kIntroBlockBias = -0.1;
 
 /// The Plan tab before a word is typed.
 ///
@@ -264,22 +270,26 @@ class _PlanIntro extends ConsumerWidget {
             ),
           );
         }
-        return Column(
-          children: [
-            Expanded(
-              // Whatever height is left over splits between the field above
-              // the heading and the seam below it — see [_kIntroCrownBias] for
-              // which way and why it is not the 3:1 it started at.
-              child: Align(
-                alignment: const Alignment(0, _kIntroCrownBias),
-                // Loose constraints from Align, so this shrink-wraps unless
-                // the largest text scales make the block taller than its
-                // share — then it scrolls instead of overflowing.
-                child: SingleChildScrollView(child: reading),
-              ),
+        // The two halves as ONE object, placed in the field together — see
+        // [_kIntroBlockBias] for why the rail no longer rides the composer.
+        return Align(
+          alignment: const Alignment(0, _kIntroBlockBias),
+          // Loose constraints from Align, so this shrink-wraps unless the
+          // largest text scales make the block taller than the field — then it
+          // scrolls instead of overflowing.
+          child: SingleChildScrollView(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                reading,
+                // The block's own seam. A ladder value, not a share of the
+                // leftover: it says how close these two halves are, which is a
+                // fixed relationship, not a function of the viewport.
+                const SizedBox(height: AppSpacing.xxl),
+                acting,
+              ],
             ),
-            acting,
-          ],
+          ),
         );
       },
     );

--- a/src/packages/flutter-app/test/home_plan_strip_test.dart
+++ b/src/packages/flutter-app/test/home_plan_strip_test.dart
@@ -112,7 +112,13 @@ void main() {
     // Same headline + CTA, no photo, no suggestion chips.
     expect(find.text('Plan less. Travel more.'), findsOneWidget);
     expect(find.text("Let's go"), findsOneWidget);
-    expect(find.text('2 days in Paris'), findsNothing);
+    // Scoped to the chip for the same reason its sibling above is, and the
+    // comment there says why: the inspiration rail draws from the same pool.
+    // The chip PICKER is pinned by the override, but the rail's sibling
+    // provider shuffles the WHOLE pool and the rail is a lazy ListView, so
+    // whether this title is among the built cards is a coin flip. As a bare
+    // find.text this failed ~35% of runs, on main as well as here.
+    expect(find.widgetWithText(ActionChip, '2 days in Paris'), findsNothing);
     expect(find.byIcon(Icons.flight_takeoff), findsOneWidget);
   });
 

--- a/src/packages/flutter-app/test/import_entry_points_test.dart
+++ b/src/packages/flutter-app/test/import_entry_points_test.dart
@@ -71,6 +71,14 @@ void main() {
 
     container.read(navIndexProvider.notifier).state = AppTab.plan.index;
     await tester.pumpAndSettle();
+    // ensureVisible, not a bare tap: the intro is one scrollable block now, and
+    // in the 800x600 test surface the fallback font wraps the heading and the
+    // paragraph far wider than Inter does, which pushes this chip past the
+    // fold. tap() on an off-screen target only WARNS — the test would go green
+    // while selecting nothing. What this test is about is where the chip goes,
+    // not whether the test font happens to leave it above the fold.
+    await tester.ensureVisible(importLabelIn(AgentScreen));
+    await tester.pumpAndSettle();
     await tester.tap(importLabelIn(AgentScreen));
     await tester.pumpAndSettle();
 


### PR DESCRIPTION
Follow-up to #517, which is merged and shipped the wrong half of this. #517 lifted the heading and left the rail pinned to the composer, which put the leftover height through the **middle** of the composition — a visible hole between the paragraph and the cards. This finishes it.

## The gap was forced, not mistuned

With the rail pinned to the composer, the crown absorbs every spare pixel, so the same ~544px of slack on a 934px desktop field has only two places to go. Measured in the running app at 1342x988:

| | crown | seam | below rail |
|---|---|---|---|
| before #517 | 374 | 123 | 0 — whole composition in the bottom half |
| #517 (shipped) | 303 | **196** | 0 — a hole through the middle |
| **this PR** | **214** | **31** | **~256** |

`crown + seam` is a constant. There was no third split, which is why raising the text *necessarily* opened the hole.

## What changed

The reading half and the acting half are **one object** now, placed in the field together with an `AppSpacing.xxl` seam, and the leftover falls below the rail. Heading sits at **29%** of the field; the cards follow the text up.

This gives up the adjacency the previous pass prized — starters within reach of the composer. That was a real argument, so it is written into `_kIntroBlockBias` along with the arithmetic that makes it unaffordable on a tall viewport, rather than deleted. The branch below `_kIntroFieldFloor` still stacks the halves tight, so the short viewport that argument was strongest for is unchanged. Verified at 390x844: block holds, nothing clipped.

## One test change, and it is a real consequence

`import_entry_points_test` needed `ensureVisible`. The intro is a single scrollable block now, so content that overflows scrolls as a unit; before, the chips were pinned and always on screen. In the 800x600 test surface the fallback font pushes the import chip past the fold, and `tap()` on an off-screen target only **warns** — the test would have gone green while selecting nothing. Same cause and fix as the greeting that moved a card to y=617.5 during the Cormorant pass.

## Note on the merge with #519

This branch and #519 independently found and fixed the same flaky assertion in `home_plan_strip_test`, and arrived at the byte-identical line. The conflict was prose only. I resolved it by taking **main's version whole** — its comment names the cause (#518 un-gated the inspiration rail for returning users) where mine only recorded the symptom and its rate. That file is now byte-identical to `main`, so this PR's diff is exactly its subject: two files.

## Gates (on the resolved merge)

- `flutter test` — **1788 passing, exit 0, zero `[E]`**, captured to a file
- `flutter analyze` — clean (3 pre-existing infos in `route_response.dart`)
- `brand-check` — clean on the touched file
- `home_plan_strip_test` — 8/8 runs on the resolved tree
- `origin/main` merged in, not rebased; every gate above run **after** the merge