### PR TITLE
feat(api): guard scope 'trip', the write path that had no validation

### DIFF
--- a/src/packages/api/itinerary_repair.go
+++ b/src/packages/api/itinerary_repair.go
@@ -359,7 +359,7 @@ func auditTripScopeGuard(ctx context.Context, q *store.Queries, only string, ver
 		}
 	}
 
-	var rejected, fragmented, dayBroken int
+	var rejected, fragmented, dayBroken, fragOnly int
 	for _, id := range ids {
 		items, err := q.GetItineraryItemsByTrip(ctx, id)
 		if err != nil {
@@ -367,11 +367,20 @@ func auditTripScopeGuard(ctx context.Context, q *store.Queries, only string, ver
 		}
 		v := inspectTripScope(runItemsOfStored(items))
 		if v.ok() {
+			// Fragmentation with no day break does NOT reject — it is the
+			// measured false-positive class (a revisit that repeats a place).
+			// Reported anyway, marked as a non-rejection, because how often it
+			// occurs in real data is the number that would justify ever
+			// tightening the rule.
+			if len(v.Fragmented) > 0 {
+				fragOnly++
+				log.Printf("trip %s: allowed, but fragmented with no day break: %s", id, describeFragments(v))
+			}
 			continue
 		}
 		rejected++
 		log.Printf("trip %s: WOULD BE REJECTED by the scope 'trip' guard", id)
-		if len(v.Fragmented) > 0 {
+		if v.fragmentationRejects() {
 			fragmented++
 			log.Printf("    fragmented: %s", describeFragments(v))
 		}
@@ -396,8 +405,9 @@ func auditTripScopeGuard(ctx context.Context, q *store.Queries, only string, ver
 	}
 
 	log.Printf("guard audit (report only, nothing written): scanned %d trip(s) with itinerary items — "+
-		"%d would be rejected (%d fragmented, %d day-order), %d would pass",
-		len(ids), rejected, fragmented, dayBroken, len(ids)-rejected)
+		"%d would be rejected (%d fragmented, %d day-order), %d would pass "+
+		"(%d of those fragmented but allowed: no day break)",
+		len(ids), rejected, fragmented, dayBroken, len(ids)-rejected, fragOnly)
 	if len(ids) == 0 {
 		log.Printf("guard audit: NO TRIPS TO CHECK — this database is empty, so this is not evidence " +
 			"that the guard is safe. Point DATABASE_URL at a database with real trips.")

--- a/src/packages/api/itinerary_repair.go
+++ b/src/packages/api/itinerary_repair.go
@@ -12,66 +12,21 @@ package main
 // because the duplicate copy carried the pre-edit `day` numbers.
 //
 // Run it with `make api-repair-sections` (report only) or
-// `make api-repair-sections APPLY=1`. Reuses the same hub predicate as the guard
-// (sameHub/keyOfItem), so detection and enforcement cannot drift apart.
+// `make api-repair-sections APPLY=1`. The hub predicate, the run split and the
+// "is this fragmented or a real revisit?" call all live in itinerary_runs.go and
+// are SHARED with the scope-'trip' write guard, so detection and enforcement
+// cannot drift apart.
 
 import (
 	"context"
 	"flag"
 	"fmt"
 	"log"
-	"sort"
-	"strings"
 
 	"github.com/google/uuid"
 
 	"travel-route-planner/store"
 )
-
-// hubRun is one contiguous same-hub stretch in position order — the same
-// grouping computeTripLegs renders a leg from.
-type hubRun struct {
-	Hub   string
-	Items []store.ItineraryItem
-}
-
-func hubRuns(items []store.ItineraryItem) []hubRun {
-	var runs []hubRun
-	for _, it := range items {
-		hub := hubOfItem(it)
-		if len(runs) == 0 || !sameHub(runs[len(runs)-1].Hub, hub) {
-			runs = append(runs, hubRun{Hub: hub})
-		}
-		runs[len(runs)-1].Items = append(runs[len(runs)-1].Items, it)
-	}
-	return runs
-}
-
-// itemIdentity is what a verbatim splice copy preserves byte-for-byte. `day` is
-// deliberately EXCLUDED: the duplicate's stale day is the whole reason the two
-// copies differ, so keying on it would hide exactly the pairs we're looking for.
-// Position is excluded for the same reason.
-type itemIdentity struct {
-	Name, PlaceID, City, DayTripFrom string
-	LatE5, LngE5                     int64
-}
-
-func identityOf(it store.ItineraryItem) itemIdentity {
-	deref := func(p *string) string {
-		if p == nil {
-			return ""
-		}
-		return strings.ToLower(foldHub(*p))
-	}
-	return itemIdentity{
-		Name:        strings.ToLower(foldHub(it.Name)),
-		PlaceID:     deref(it.PlaceID),
-		City:        deref(it.City),
-		DayTripFrom: deref(it.DayTripFrom),
-		LatE5:       int64(it.Latitude * 1e5),
-		LngE5:       int64(it.Longitude * 1e5),
-	}
-}
 
 // repairPlan is what a dry run prints and an apply run executes.
 type repairPlan struct {
@@ -85,60 +40,6 @@ type repairPlan struct {
 
 func (p repairPlan) empty() bool { return len(p.DeleteIDs) == 0 }
 
-// dayOrderViolations counts adjacent pairs (in position order) whose day numbers
-// run backwards. The splice bug leaves the stale copy's days out of order with
-// everything around it, so removing the stale run drops this count while
-// removing the fresh one does not.
-func dayOrderViolations(items []store.ItineraryItem) int {
-	n := 0
-	var prev *int32
-	for _, it := range items {
-		if it.Day == nil {
-			continue
-		}
-		if prev != nil && *it.Day < *prev {
-			n++
-		}
-		d := *it.Day
-		prev = &d
-	}
-	return n
-}
-
-func identityCounts(items []store.ItineraryItem) map[itemIdentity]int {
-	m := make(map[itemIdentity]int, len(items))
-	for _, it := range items {
-		m[identityOf(it)]++
-	}
-	return m
-}
-
-// subsetOf reports whether every identity in a appears in b at least as often.
-func subsetOf(a, b map[itemIdentity]int) bool {
-	for k, n := range a {
-		if b[k] < n {
-			return false
-		}
-	}
-	return true
-}
-
-func dayRange(items []store.ItineraryItem) (lo, hi int32, ok bool) {
-	for _, it := range items {
-		if it.Day == nil {
-			continue
-		}
-		if !ok || *it.Day < lo {
-			lo = *it.Day
-		}
-		if !ok || *it.Day > hi {
-			hi = *it.Day
-		}
-		ok = true
-	}
-	return lo, hi, ok
-}
-
 func describeItem(it store.ItineraryItem) string {
 	day := "no day"
 	if it.Day != nil {
@@ -151,83 +52,51 @@ func describeItem(it store.ItineraryItem) string {
 	return fmt.Sprintf("  pos %3d  %-32s (%s, %s)", it.Position, it.Name, hub, day)
 }
 
-// planTripRepair classifies a trip's hub runs and returns what collapsing the
-// duplicates would delete. Pure: no DB, no I/O, so it is unit-testable without
-// Postgres.
+// planTripRepair decides which duplicate run to collapse, given the shared
+// classifier's verdict about which hubs are fragmented at all. Pure: no DB, no
+// I/O, so it is unit-testable without Postgres.
 //
-// It is deliberately conservative. A hub occupying two runs is NOT by itself
-// corruption — computeTripLegs supports genuine revisits (Paris → Rome → Paris),
-// and those must be left alone. A run is only dropped when it is also a content
-// duplicate of its twin AND the two disagree about dates.
+// The conservatism that keeps a genuine revisit (Paris → Rome → Paris) out of
+// this plan lives in classifyHubRuns — see itinerary_runs.go. What is left here
+// is repair-only: which of the twin runs is the stale copy, and the refusal
+// backstop.
+//
+// The four-item floor is a repair heuristic, not part of the predicate: a trip
+// this small predates the splice bug's reach and is not worth a destructive
+// guess. The write-path guard deliberately has no such floor — it rejects rather
+// than deletes, so it has nothing to be careful with.
 func planTripRepair(items []store.ItineraryItem) repairPlan {
 	plan := repairPlan{}
 	if len(items) < 4 {
 		return plan
 	}
-	runs := hubRuns(items)
-
-	byHub := map[string][]int{}
-	var order []string
-	for i, r := range runs {
-		if strings.TrimSpace(r.Hub) == "" {
-			continue // hubless runs group together by a different rule; skip
-		}
-		k := strings.ToLower(foldHub(r.Hub))
-		if _, seen := byHub[k]; !seen {
-			order = append(order, k)
-		}
-		byHub[k] = append(byHub[k], i)
-	}
-	sort.Strings(order)
+	rits := runItemsOfStored(items)
+	c := classifyHubRuns(rits)
+	plan.Skipped = c.Skipped
 
 	drop := map[int]bool{}
-	for _, k := range order {
-		idx := byHub[k]
-		if len(idx) < 2 {
-			continue
-		}
-		hub := runs[idx[0]].Hub
-		if len(idx) > 2 {
-			plan.Skipped = append(plan.Skipped,
-				fmt.Sprintf("%s: %d runs — too many to classify automatically", hub, len(idx)))
-			continue
-		}
-		a, b := runs[idx[0]], runs[idx[1]]
-		ca, cb := identityCounts(a.Items), identityCounts(b.Items)
-		if !subsetOf(ca, cb) && !subsetOf(cb, ca) {
-			plan.Skipped = append(plan.Skipped,
-				fmt.Sprintf("%s: two runs hold different places — looks like a real revisit", hub))
-			continue
-		}
-		aLo, aHi, aOK := dayRange(a.Items)
-		bLo, bHi, bOK := dayRange(b.Items)
-		if aOK && bOK && aLo == bLo && aHi == bHi {
-			plan.Skipped = append(plan.Skipped,
-				fmt.Sprintf("%s: duplicate runs share the same days — not the splice bug", hub))
-			continue
-		}
-
+	for _, f := range c.Fragmented {
 		// Which copy is stale? Whichever removal leaves the trip's day numbers
 		// running forwards. Neither "first" nor "last" is right on its own: the
 		// stale copy lands last when the model targeted the other city first,
 		// and first when it targeted this one.
-		without := func(skip int) []store.ItineraryItem {
-			var out []store.ItineraryItem
-			for i, r := range runs {
+		without := func(skip int) []runItem {
+			var out []runItem
+			for i, r := range c.Runs {
 				if i == skip {
 					continue
 				}
-				out = append(out, r.Items...)
+				out = append(out, r.slice(rits)...)
 			}
 			return out
 		}
-		va, vb := dayOrderViolations(without(idx[0])), dayOrderViolations(without(idx[1]))
-		victim := idx[1]
+		va, vb := dayOrderViolations(without(f.A)), dayOrderViolations(without(f.B))
+		victim := f.B
 		switch {
 		case va < vb:
-			victim = idx[0]
+			victim = f.A
 		case vb < va:
-			victim = idx[1]
+			victim = f.B
 		default:
 			plan.Tied = true
 		}
@@ -239,14 +108,14 @@ func planTripRepair(items []store.ItineraryItem) repairPlan {
 	}
 
 	var kept []store.ItineraryItem
-	for i, r := range runs {
+	for i, r := range c.Runs {
 		if drop[i] {
-			for _, it := range r.Items {
+			for _, it := range items[r.Start:r.End] {
 				plan.DeleteIDs = append(plan.DeleteIDs, it.ID)
 			}
 			continue
 		}
-		kept = append(kept, r.Items...)
+		kept = append(kept, items[r.Start:r.End]...)
 	}
 	// Backstop, not a live path: two duplicate runs can never exceed half a
 	// trip's items, so this cannot fire under today's rules. It exists so that
@@ -426,5 +295,112 @@ func runRepairSections(ctx context.Context, args []string) error {
 	}
 	log.Printf("checked %d candidate trip(s): %d with duplicates, %d left alone; %s",
 		len(ids), flagged, skipped, mode)
+
+	return auditTripScopeGuard(ctx, q, *only, *verbose)
+}
+
+// auditGuardTripsSQL is the guard audit's own candidate set, and it is
+// deliberately NOT candidateTripsSQL. That query prefilters to trips where some
+// hub occupies two or more runs, which can only ever answer the fragmentation
+// half — a trip whose day numbers run backwards without any repeated hub would
+// never be looked at, and the audit's day-monotonicity number would be a
+// statement about the prefilter rather than about the data. The guard runs on
+// every payload, so the audit scans every trip that has items.
+//
+// Ordered, unlike candidateTripsSQL, so two runs over an unchanged database
+// produce the same report in the same order.
+const auditGuardTripsSQL = `
+SELECT DISTINCT trip_id FROM itinerary_items ORDER BY trip_id
+`
+
+// auditTripScopeGuard answers, for every trip: would these items, resubmitted as
+// a scope-'trip' payload, be REJECTED by the guard? It writes nothing and
+// changes no verdict above it — its only job is to turn "the guard is probably
+// safe on real data" into a number somebody can read.
+//
+// Reading a stored trip as a payload is exact rather than approximate: an
+// itinerary IS what a scope-'trip' payload becomes, and inspectTripScope is
+// literally the function the write path calls, reached through the SAME
+// classifier via the stored-row reducer (pinned by
+// TestStoredAndSubmittedReduceIdentically).
+//
+// What a reader has to judge, and what the output is shaped to let them judge:
+// a flagged trip is either corruption that already happened — these are the
+// trips the repair pass above exists for — or a legitimate itinerary the guard
+// would wrongly block. Only the second kind invalidates the guard, so every
+// finding names its places.
+//
+// It runs AFTER the repair pass, deliberately: under -apply that means it
+// reports the state the database is actually left in, not the state it was
+// found in. Under the default dry run the two are the same thing.
+func auditTripScopeGuard(ctx context.Context, q *store.Queries, only string, verbose bool) error {
+	var ids []uuid.UUID
+	if only != "" {
+		id, err := uuid.Parse(only)
+		if err != nil {
+			return fmt.Errorf("bad -trip id: %w", err)
+		}
+		ids = append(ids, id)
+	} else {
+		rows, err := dbPool.Query(ctx, auditGuardTripsSQL)
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var id uuid.UUID
+			if err := rows.Scan(&id); err != nil {
+				return err
+			}
+			ids = append(ids, id)
+		}
+		if err := rows.Err(); err != nil {
+			return err
+		}
+	}
+
+	var rejected, fragmented, dayBroken int
+	for _, id := range ids {
+		items, err := q.GetItineraryItemsByTrip(ctx, id)
+		if err != nil {
+			return err
+		}
+		v := inspectTripScope(runItemsOfStored(items))
+		if v.ok() {
+			continue
+		}
+		rejected++
+		log.Printf("trip %s: WOULD BE REJECTED by the scope 'trip' guard", id)
+		if len(v.Fragmented) > 0 {
+			fragmented++
+			log.Printf("    fragmented: %s", describeFragments(v))
+		}
+		if len(v.Breaks) > 0 {
+			dayBroken++
+			for i, b := range v.Breaks {
+				if i == straySampleCap {
+					log.Printf("    day order: and %d more", len(v.Breaks)-i)
+					break
+				}
+				log.Printf("    day order: %s is day %d, after day %d", b.Name, b.Day, b.Prev)
+			}
+		}
+		if verbose {
+			for _, it := range items {
+				log.Print(describeItem(it))
+			}
+			for _, s := range v.Skipped {
+				log.Printf("    also: %s", s)
+			}
+		}
+	}
+
+	log.Printf("guard audit (report only, nothing written): scanned %d trip(s) with itinerary items — "+
+		"%d would be rejected (%d fragmented, %d day-order), %d would pass",
+		len(ids), rejected, fragmented, dayBroken, len(ids)-rejected)
+	if len(ids) == 0 {
+		log.Printf("guard audit: NO TRIPS TO CHECK — this database is empty, so this is not evidence " +
+			"that the guard is safe. Point DATABASE_URL at a database with real trips.")
+	}
 	return nil
 }

--- a/src/packages/api/itinerary_repair_test.go
+++ b/src/packages/api/itinerary_repair_test.go
@@ -142,27 +142,6 @@ func TestPlanTripRepairIgnoresTinyTrips(t *testing.T) {
 	}
 }
 
-func TestHubRunsFoldCase(t *testing.T) {
-	runs := hubRuns([]store.ItineraryItem{
-		ritem(0, "a", 1, "Krakow"),
-		ritem(1, "b", 2, "krakow"),
-		ritem(2, "c", 3, "Prague"),
-	})
-	if len(runs) != 2 {
-		t.Fatalf("mixed case is one hub run, got %d runs", len(runs))
-	}
-	if len(runs[0].Items) != 2 {
-		t.Fatalf("first run should hold both Krakow items, got %d", len(runs[0].Items))
-	}
-}
-
-func TestDayOrderViolationsCountsBackwardSteps(t *testing.T) {
-	fwd := []store.ItineraryItem{ritem(0, "a", 1, "X"), ritem(1, "b", 2, "X"), ritem(2, "c", 3, "X")}
-	if n := dayOrderViolations(fwd); n != 0 {
-		t.Fatalf("ascending days have no violations, got %d", n)
-	}
-	back := []store.ItineraryItem{ritem(0, "a", 3, "X"), ritem(1, "b", 1, "X"), ritem(2, "c", 2, "X")}
-	if n := dayOrderViolations(back); n != 1 {
-		t.Fatalf("one backward step, got %d", n)
-	}
-}
+// hubRuns and dayOrderViolations moved to the shared classifier with the
+// predicate they belong to; their tests moved with them, to
+// itinerary_runs_test.go.

--- a/src/packages/api/itinerary_runs.go
+++ b/src/packages/api/itinerary_runs.go
@@ -308,7 +308,54 @@ type tripScopeVerdict struct {
 	Skipped    []string
 }
 
-func (v tripScopeVerdict) ok() bool { return len(v.Fragmented) == 0 && len(v.Breaks) == 0 }
+// fragmentationRejects: a fragmentation finding only rejects a WRITE when the
+// payload's days ALSO run backwards.
+//
+// This is the one place the guard is deliberately weaker than classifyHubRuns,
+// and the reason is a measured false positive, not a hunch. A genuine revisit
+// that repeats a place — Paris days 1-2, Rome, then the Louvre again on day 5 —
+// satisfies the classifier's predicate outright: run B's identities are a
+// SUBSET of run A's and the day ranges differ. Nothing about it is corrupt. And
+// because a scope-'trip' payload is always the COMPLETE itinerary, rejecting it
+// would block every whole-trip edit on that trip forever, silently. That is a
+// REGRESSION — the write succeeds on main today — whereas failing to catch a
+// corrupt payload is only a smaller improvement, since main validates nothing
+// here at all. The two failure modes are not symmetric, so the bar is
+// strictly-non-regressive.
+//
+// The repair tool deliberately does NOT compose this way: it proposes a delete
+// in a dry run for a human to confirm (and marks that very shape `[TIED]`), so
+// it can afford the wider net. Same predicate, different consequence — do not
+// "unify" these by making planTripRepair call this.
+//
+// Note what the composition reduces to today: fragmentation cannot reject
+// without a day break, and a day break rejects on its own, so DAY ORDER is what
+// decides and fragmentation decides only WHICH message the model gets. That is
+// the honest state of it. It is still written as two independent rules because
+// they are two independent rules — see the known gap below.
+//
+// KNOWN GAP, measured and deliberately not closed here: an interleaved
+// transition day (Prague d5, Kraków d6, Prague d6, Kraków d7 — the arriving
+// city's item emitted BEFORE the departing city's morning item) is fragmented,
+// has non-decreasing days, and so passes. It passed before this guard existed
+// too, so it is not a regression. The leading candidate for closing it is a
+// run-interleaving test (A,B,A,B), on the principle that a correct itinerary is
+// a SEQUENCE of stays — once you leave A for B you are in B until you leave B,
+// so A,B,A,B means each city was interrupted by the other, which is two lists
+// spliced together. It is unshipped because it was fitted to a self-authored
+// corpus and needs adversarial shapes plus the production audit first.
+func (v tripScopeVerdict) fragmentationRejects() bool {
+	return len(v.Fragmented) > 0 && len(v.Breaks) > 0
+}
+
+// rejects composes the two checks. Written as a disjunction of two
+// independently-changeable rules rather than collapsed to its current truth
+// value, so that tightening or loosening either half stays a local edit.
+func (v tripScopeVerdict) rejects() bool {
+	return v.fragmentationRejects() || len(v.Breaks) > 0
+}
+
+func (v tripScopeVerdict) ok() bool { return !v.rejects() }
 
 // inspectTripScope runs both checks over a whole-trip list. It is the one entry
 // point the write-path guard and the report-only audit share, so what the audit

--- a/src/packages/api/itinerary_runs.go
+++ b/src/packages/api/itinerary_runs.go
@@ -1,0 +1,389 @@
+package main
+
+// The shared hub-run classifier: the ONE answer to "does this list of places,
+// in position order, fragment a city into duplicate runs, and do its day
+// numbers run forwards?"
+//
+// It exists because two callers need that answer and must never disagree about
+// it: itinerary_repair.go's offline `repair-sections` (detection, after the
+// fact) and itinerary_section.go's scope-'trip' guard (enforcement, on the
+// write path). itinerary_repair.go's header already set the rule — reuse the
+// same hub predicate "so detection and enforcement cannot drift apart" — and a
+// second copy of "what counts as a fragmented city" is precisely the drift that
+// rule forbids.
+//
+// Everything here is pure: no DB, no I/O, no clock. That is what lets the guard
+// run it on a payload inside a transaction and the repair tool run it on a
+// stored trip, from one implementation.
+//
+// The predicate is deliberately conservative, and the reason is the single most
+// load-bearing fact in this file: A HUB OCCUPYING TWO RUNS IS NOT BY ITSELF
+// CORRUPTION. computeTripLegs supports genuine revisits (Paris → Rome → Paris)
+// and renders them as two legs on purpose. A run is only called fragmented when
+// it is ALSO a content duplicate of its twin AND the two disagree about dates.
+// A check that merely counted "each city appears once" would reject a supported
+// itinerary shape, and a guard that rejects legal itineraries gets turned off.
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"travel-route-planner/store"
+)
+
+// runItem is the neutral shape both a stored itinerary row and a submitted
+// agent location reduce to before any run reasoning happens — the same
+// one-shape-two-writers discipline sectionKey already applies to section
+// membership, for the same reason: a stored trip and a submitted payload judged
+// by two predicates is how they drift.
+//
+// It carries only what run classification needs. Ids, positions and tags stay
+// with the caller, which maps a run's index range back onto its own richer
+// rows.
+type runItem struct {
+	Hub      string // day_trip_from ?? city, trimmed. "" = unspecified.
+	Day      *int   // nil = unscheduled/unspecified.
+	Name     string // for naming the offending place in a report or rejection.
+	Identity itemIdentity
+}
+
+// itemIdentity is what a verbatim splice copy preserves byte-for-byte. `day` is
+// deliberately EXCLUDED: the duplicate's stale day is the whole reason the two
+// copies differ, so keying on it would hide exactly the pairs we're looking for.
+// Position is excluded for the same reason.
+type itemIdentity struct {
+	Name, PlaceID, City, DayTripFrom string
+	LatE5, LngE5                     int64
+}
+
+// foldIdentity normalizes one identity field: trimmed, diacritic-folded and
+// lowercased, so the model re-typing "Kraków" as "Krakow" doesn't read as a
+// different place. Same folding sameHub uses, for the same reason.
+func foldIdentity(s string) string { return strings.ToLower(foldHub(s)) }
+
+// coordE5 quantizes a coordinate to ~1 m so a re-serialized copy of the same
+// place still compares equal.
+func coordE5(v float64) int64 { return int64(v * 1e5) }
+
+// runItemOfStored reduces a stored row. Hub and day come from keyOfItem, so the
+// runs the classifier sees are grouped by the SAME predicate section membership
+// uses.
+func runItemOfStored(it store.ItineraryItem) runItem {
+	k := keyOfItem(it)
+	return runItem{
+		Hub:  k.Hub,
+		Day:  k.Day,
+		Name: it.Name,
+		Identity: itemIdentity{
+			Name:        foldIdentity(it.Name),
+			PlaceID:     foldIdentity(strPtrVal(it.PlaceID)),
+			City:        foldIdentity(strPtrVal(it.City)),
+			DayTripFrom: foldIdentity(strPtrVal(it.DayTripFrom)),
+			LatE5:       coordE5(it.Latitude),
+			LngE5:       coordE5(it.Longitude),
+		},
+	}
+}
+
+// runItemOfLocation is [runItemOfStored] for the agent's location-map shape. The
+// field coercion matches itemParamsFromLocation and keyOfLocation exactly, so
+// the guard can never reject on a value the writer would itself have ignored.
+func runItemOfLocation(loc map[string]any) runItem {
+	k := keyOfLocation(loc)
+	str := func(key string) string {
+		s, _ := loc[key].(string)
+		return foldIdentity(s)
+	}
+	name, _ := loc["name"].(string)
+	lat, _ := loc["latitude"].(float64)
+	lng, _ := loc["longitude"].(float64)
+	return runItem{
+		Hub:  k.Hub,
+		Day:  k.Day,
+		Name: name,
+		Identity: itemIdentity{
+			Name:        foldIdentity(name),
+			PlaceID:     str("place_id"),
+			City:        str("city"),
+			DayTripFrom: str("day_trip_from"),
+			LatE5:       coordE5(lat),
+			LngE5:       coordE5(lng),
+		},
+	}
+}
+
+func runItemsOfStored(items []store.ItineraryItem) []runItem {
+	out := make([]runItem, len(items))
+	for i, it := range items {
+		out[i] = runItemOfStored(it)
+	}
+	return out
+}
+
+func runItemsOfLocations(locs []map[string]any) []runItem {
+	out := make([]runItem, len(locs))
+	for i, loc := range locs {
+		out[i] = runItemOfLocation(loc)
+	}
+	return out
+}
+
+// hubRun is one contiguous same-hub stretch in position order — the same
+// grouping computeTripLegs renders a leg from. Start/End is a half-open index
+// range into the slice the runs were computed from, so contiguity is structural
+// and a caller holding richer rows can slice its own list by the same range.
+type hubRun struct {
+	Hub        string
+	Start, End int
+}
+
+func (r hubRun) len() int { return r.End - r.Start }
+
+func (r hubRun) slice(items []runItem) []runItem { return items[r.Start:r.End] }
+
+func hubRuns(items []runItem) []hubRun {
+	var runs []hubRun
+	for i, it := range items {
+		if len(runs) == 0 || !sameHub(runs[len(runs)-1].Hub, it.Hub) {
+			runs = append(runs, hubRun{Hub: it.Hub, Start: i})
+		}
+		runs[len(runs)-1].End = i + 1
+	}
+	return runs
+}
+
+// fragmentedHub is one hub occupying two runs that are content duplicates
+// disagreeing about dates — the corruption shape described in
+// itinerary_repair.go's header, where "the city appeared twice: once with its
+// dates, once collapsed to a zero-night stop".
+type fragmentedHub struct {
+	Hub  string // as first spelled in the list
+	A, B int    // indexes into runClassification.Runs, in position order
+}
+
+// runClassification is everything classifyHubRuns decided about one list.
+// Skipped records the hubs it deliberately left alone and why — a genuine
+// revisit is a SKIP, not a finding, and the repair tool prints those reasons.
+type runClassification struct {
+	Runs       []hubRun
+	Fragmented []fragmentedHub
+	Skipped    []string
+}
+
+// classifyHubRuns is THE fragmentation predicate. Hubs are examined in
+// alphabetical (folded) order so the reasons it reports are stable regardless of
+// map iteration.
+func classifyHubRuns(items []runItem) runClassification {
+	c := runClassification{Runs: hubRuns(items)}
+
+	byHub := map[string][]int{}
+	var order []string
+	for i, r := range c.Runs {
+		if strings.TrimSpace(r.Hub) == "" {
+			continue // hubless runs group together by a different rule; skip
+		}
+		k := foldIdentity(r.Hub)
+		if _, seen := byHub[k]; !seen {
+			order = append(order, k)
+		}
+		byHub[k] = append(byHub[k], i)
+	}
+	sort.Strings(order)
+
+	for _, k := range order {
+		idx := byHub[k]
+		if len(idx) < 2 {
+			continue
+		}
+		hub := c.Runs[idx[0]].Hub
+		if len(idx) > 2 {
+			c.Skipped = append(c.Skipped,
+				fmt.Sprintf("%s: %d runs — too many to classify automatically", hub, len(idx)))
+			continue
+		}
+		a, b := c.Runs[idx[0]].slice(items), c.Runs[idx[1]].slice(items)
+		ca, cb := identityCounts(a), identityCounts(b)
+		if !subsetOf(ca, cb) && !subsetOf(cb, ca) {
+			c.Skipped = append(c.Skipped,
+				fmt.Sprintf("%s: two runs hold different places — looks like a real revisit", hub))
+			continue
+		}
+		aLo, aHi, aOK := dayRange(a)
+		bLo, bHi, bOK := dayRange(b)
+		if aOK && bOK && aLo == bLo && aHi == bHi {
+			c.Skipped = append(c.Skipped,
+				fmt.Sprintf("%s: duplicate runs share the same days — not the splice bug", hub))
+			continue
+		}
+		c.Fragmented = append(c.Fragmented, fragmentedHub{Hub: hub, A: idx[0], B: idx[1]})
+	}
+	return c
+}
+
+func identityCounts(items []runItem) map[itemIdentity]int {
+	m := make(map[itemIdentity]int, len(items))
+	for _, it := range items {
+		m[it.Identity]++
+	}
+	return m
+}
+
+// subsetOf reports whether every identity in a appears in b at least as often.
+func subsetOf(a, b map[itemIdentity]int) bool {
+	for k, n := range a {
+		if b[k] < n {
+			return false
+		}
+	}
+	return true
+}
+
+func dayRange(items []runItem) (lo, hi int, ok bool) {
+	for _, it := range items {
+		if it.Day == nil {
+			continue
+		}
+		if !ok || *it.Day < lo {
+			lo = *it.Day
+		}
+		if !ok || *it.Day > hi {
+			hi = *it.Day
+		}
+		ok = true
+	}
+	return lo, hi, ok
+}
+
+// dayBreak is one place whose day number runs BACKWARDS from the dated place
+// before it in position order.
+type dayBreak struct {
+	Index int
+	Name  string
+	Day   int
+	Prev  int
+}
+
+// dayOrderBreaks walks a list in position order and returns every backward step.
+// Undated places are skipped rather than treated as day 0 — a spine leaves the
+// middle of a stay empty and an unscheduled tail is legitimate, so "no day" is
+// an absence of evidence, not a violation.
+//
+// The comparison is strictly `<`, which is what makes a SHARED TRANSITION DAY
+// legal: the day a traveler moves between cities carries the same number in the
+// city they leave and the one they reach (itineraryLocationSchema's `day`
+// description), so day 4 following day 4 is the design, not a break.
+func dayOrderBreaks(items []runItem) []dayBreak {
+	var out []dayBreak
+	var prev *int
+	for i, it := range items {
+		if it.Day == nil {
+			continue
+		}
+		if prev != nil && *it.Day < *prev {
+			out = append(out, dayBreak{Index: i, Name: it.Name, Day: *it.Day, Prev: *prev})
+		}
+		d := *it.Day
+		prev = &d
+	}
+	return out
+}
+
+// dayOrderViolations counts what dayOrderBreaks names. The splice bug leaves the
+// stale copy's days out of order with everything around it, so removing the
+// stale run drops this count while removing the fresh one does not — which is
+// how planTripRepair decides which copy to drop. Counting what the namer returns
+// (rather than walking a second time) keeps the count and the names from ever
+// disagreeing.
+func dayOrderViolations(items []runItem) int { return len(dayOrderBreaks(items)) }
+
+// tripScopeVerdict is the guard's whole answer about one list of places treated
+// as a complete trip: both checks, computed independently so a report can show
+// both at once even though the rejection names only the first.
+type tripScopeVerdict struct {
+	Runs       []hubRun
+	Items      []runItem
+	Fragmented []fragmentedHub
+	Breaks     []dayBreak
+	Skipped    []string
+}
+
+func (v tripScopeVerdict) ok() bool { return len(v.Fragmented) == 0 && len(v.Breaks) == 0 }
+
+// inspectTripScope runs both checks over a whole-trip list. It is the one entry
+// point the write-path guard and the report-only audit share, so what the audit
+// predicts and what the guard does cannot come apart.
+func inspectTripScope(items []runItem) tripScopeVerdict {
+	c := classifyHubRuns(items)
+	return tripScopeVerdict{
+		Runs:       c.Runs,
+		Items:      items,
+		Fragmented: c.Fragmented,
+		Skipped:    c.Skipped,
+		Breaks:     dayOrderBreaks(items),
+	}
+}
+
+// describeDayRange renders a run's days the way both the rejection and the audit
+// name them.
+func describeDayRange(items []runItem) string {
+	lo, hi, ok := dayRange(items)
+	switch {
+	case !ok:
+		return "no days"
+	case lo == hi:
+		return fmt.Sprintf("day %d", lo)
+	default:
+		return fmt.Sprintf("days %d-%d", lo, hi)
+	}
+}
+
+// fragmentSampleNames bounds how many place names a fragment names, so a
+// whole-itinerary mistake can't blow up the tool_result. straySampleCap bounds
+// the fragments; this bounds each one.
+const fragmentSampleNames = 2
+
+// describeFragment names one fragmented hub, both of its day ranges and a couple
+// of the places involved — enough for the model to see which city to reassemble
+// without reprinting the itinerary.
+func describeFragment(v tripScopeVerdict, f fragmentedHub) string {
+	a, b := v.Runs[f.A].slice(v.Items), v.Runs[f.B].slice(v.Items)
+	names := make([]string, 0, fragmentSampleNames)
+	for _, it := range b {
+		if len(names) == fragmentSampleNames {
+			break
+		}
+		n := strings.TrimSpace(it.Name)
+		if n == "" {
+			n = "(unnamed place)"
+		}
+		names = append(names, n)
+	}
+	sample := strings.Join(names, ", ")
+	if rest := len(b) - len(names); rest > 0 {
+		sample += fmt.Sprintf(" and %d more", rest)
+	}
+	hub := strings.TrimSpace(f.Hub)
+	if hub == "" {
+		hub = "(no city)"
+	}
+	return fmt.Sprintf("%s (%s, then again on %s: %s)",
+		hub, describeDayRange(a), describeDayRange(b), sample)
+}
+
+// describeFragments joins the fragments, capped at straySampleCap the way
+// describeStrays caps its sample.
+func describeFragments(v tripScopeVerdict) string {
+	parts := make([]string, 0, straySampleCap)
+	for _, f := range v.Fragmented {
+		if len(parts) == straySampleCap {
+			break
+		}
+		parts = append(parts, describeFragment(v, f))
+	}
+	s := strings.Join(parts, ", ")
+	if rest := len(v.Fragmented) - len(parts); rest > 0 {
+		s += fmt.Sprintf(" and %d more", rest)
+	}
+	return s
+}

--- a/src/packages/api/itinerary_runs_test.go
+++ b/src/packages/api/itinerary_runs_test.go
@@ -1,0 +1,306 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"travel-route-planner/store"
+)
+
+// --- fixture helpers ---
+
+// rl builds one payload location. day 0 means the model left `day` out;
+// city/dayTripFrom "" mean the field is absent. Coordinates default to a
+// per-place value derived from the name, because identityOf keys on lat/lng and
+// a shared default would make every place a content duplicate of every other —
+// which would make the "different content" fixtures pass for the wrong reason.
+func rl(name string, day int, city, dayTripFrom string) map[string]any {
+	m := loc(name, day, city, dayTripFrom)
+	var h float64
+	for _, r := range name {
+		h = h*31 + float64(r)
+	}
+	m["latitude"] = 10 + float64(int64(h)%1000)/1000
+	m["longitude"] = 20 + float64(int64(h)%997)/1000
+	return m
+}
+
+func inspectLocs(locs []map[string]any) tripScopeVerdict {
+	return inspectTripScope(runItemsOfLocations(locs))
+}
+
+func fragmentedHubs(v tripScopeVerdict) []string {
+	out := make([]string, 0, len(v.Fragmented))
+	for _, f := range v.Fragmented {
+		out = append(out, f.Hub)
+	}
+	return out
+}
+
+func assertNotFlagged(t *testing.T, why string, locs []map[string]any) tripScopeVerdict {
+	t.Helper()
+	v := inspectLocs(locs)
+	if len(v.Fragmented) > 0 {
+		t.Fatalf("%s: must not read as fragmented, got %v (%s)", why, fragmentedHubs(v), describeFragments(v))
+	}
+	if len(v.Breaks) > 0 {
+		t.Fatalf("%s: must not read as a day-order break, got %+v", why, v.Breaks)
+	}
+	if !v.ok() {
+		t.Fatalf("%s: verdict should be ok", why)
+	}
+	return v
+}
+
+// --- the shapes that must NOT flag (ticket 1's table) ---
+
+// A trip that genuinely revisits a city renders as two legs on purpose.
+// planTripRepair's own comment: "computeTripLegs supports genuine revisits… and
+// those must be left alone."
+func TestClassifyAllowsGenuineRevisit(t *testing.T) {
+	v := assertNotFlagged(t, "Paris → Rome → Paris", []map[string]any{
+		rl("Louvre", 1, "Paris", ""),
+		rl("Orsay", 2, "Paris", ""),
+		rl("Colosseum", 3, "Rome", ""),
+		rl("Forum", 4, "Rome", ""),
+		rl("Sacre-Coeur", 5, "Paris", ""),
+		rl("Montmartre", 6, "Paris", ""),
+	})
+	if len(v.Runs) != 3 {
+		t.Fatalf("a revisit is three runs, got %d", len(v.Runs))
+	}
+	if len(v.Skipped) == 0 {
+		t.Fatal("a skipped revisit should say why")
+	}
+}
+
+// The day a traveler moves between cities carries the SAME day number in both —
+// itineraryLocationSchema's `day` description. Two hubs on one day is the
+// design, so the day check compares strictly `<`.
+func TestClassifyAllowsSharedTransitionDay(t *testing.T) {
+	assertNotFlagged(t, "shared transition day", []map[string]any{
+		rl("Louvre", 1, "Paris", ""),
+		rl("Orsay", 2, "Paris", ""),
+		rl("Sainte-Chapelle", 3, "Paris", ""),  // morning of the move day
+		rl("Trastevere dinner", 3, "Rome", ""), // evening of the SAME day, in Rome
+		rl("Colosseum", 4, "Rome", ""),
+	})
+}
+
+// A day trip belongs to its hub's run: renderHubOf resolves day_trip_from ?? city,
+// so Versailles inside a Paris stay is one run, not three.
+func TestClassifyFoldsDayTripIntoItsHubRun(t *testing.T) {
+	v := assertNotFlagged(t, "Versailles inside Paris", []map[string]any{
+		rl("Louvre", 1, "Paris", ""),
+		rl("Versailles", 2, "Versailles", "Paris"),
+		rl("Orsay", 3, "Paris", ""),
+	})
+	if len(v.Runs) != 1 {
+		t.Fatalf("a day trip does not split its hub's run, got %d runs", len(v.Runs))
+	}
+}
+
+// hubRuns skips empty hubs; computeTripLegs groups hubless items into "Other
+// places". A hubless item between two runs of one city must not read as
+// fragmentation, and repeated HUBLESS runs must never be classified at all.
+func TestClassifySkipsHublessRuns(t *testing.T) {
+	assertNotFlagged(t, "hubless item between two Paris runs", []map[string]any{
+		rl("Louvre", 1, "Paris", ""),
+		rl("Somewhere", 2, "", ""),
+		rl("Orsay", 3, "Paris", ""),
+	})
+	// The sharper case: two hubless runs holding the SAME place on different
+	// days. Were hubless runs classified, this is exactly the fragmented shape —
+	// so this fixture fails the moment the empty-hub skip is dropped.
+	assertNotFlagged(t, "duplicate hubless runs", []map[string]any{
+		rl("Mystery stop", 1, "", ""),
+		rl("Louvre", 2, "Paris", ""),
+		rl("Mystery stop", 3, "", ""),
+	})
+}
+
+// A spine is a complete valid itinerary whose middle days are deliberately empty
+// (create_itinerary's description). Sparse days are not corruption, and the gaps
+// must not read as a backwards step.
+func TestClassifyAllowsSpineWithEmptyMiddleDays(t *testing.T) {
+	assertNotFlagged(t, "spine", []map[string]any{
+		rl("Arrive Paris", 1, "Paris", ""),
+		rl("Leave Paris", 4, "Paris", ""),
+		rl("Arrive Rome", 4, "Rome", ""),
+		rl("Leave Rome", 8, "Rome", ""),
+	})
+}
+
+// Undated places are an absence of evidence, not a violation: an unscheduled
+// tail is legitimate and must not read as day 0 running backwards.
+func TestClassifyIgnoresUndatedPlaces(t *testing.T) {
+	assertNotFlagged(t, "unscheduled tail", []map[string]any{
+		rl("Louvre", 1, "Paris", ""),
+		rl("Orsay", 2, "Paris", ""),
+		rl("Maybe: Pompidou", 0, "Paris", ""),
+	})
+}
+
+// --- the true positive ---
+
+// The 2026-08-20 corruption, verbatim from itinerary_repair.go's header: the
+// city appears twice, once with its dates and once collapsed to the pre-edit
+// days. Prague(d1-2) → Krakow(d3-4), asked to swap, spliced Krakow in twice.
+func TestClassifyFlagsDuplicateRunsDisagreeingOnDates(t *testing.T) {
+	v := inspectLocs([]map[string]any{
+		rl("Wawel Castle", 1, "Krakow", ""),
+		rl("Rynek Glowny", 2, "Krakow", ""),
+		rl("Charles Bridge", 3, "Prague", ""),
+		rl("Old Town Square", 4, "Prague", ""),
+		rl("Wawel Castle", 3, "Krakow", ""), // stale: pre-swap days
+		rl("Rynek Glowny", 4, "Krakow", ""), // stale
+	})
+	if got := fragmentedHubs(v); len(got) != 1 || got[0] != "Krakow" {
+		t.Fatalf("the stale Krakow run must be flagged, got %v", got)
+	}
+	if v.ok() {
+		t.Fatal("verdict must not be ok")
+	}
+	d := describeFragments(v)
+	for _, want := range []string{"Krakow", "days 1-2", "days 3-4", "Wawel Castle"} {
+		if !strings.Contains(d, want) {
+			t.Fatalf("description %q should name %q", d, want)
+		}
+	}
+}
+
+// Twin runs holding the same places on the same days aren't the splice bug —
+// whatever produced them, the classifier must not guess.
+func TestClassifySkipsIdenticalDayRanges(t *testing.T) {
+	v := inspectLocs([]map[string]any{
+		rl("Charles Bridge", 1, "Prague", ""),
+		rl("Wawel Castle", 3, "Krakow", ""),
+		rl("Charles Bridge", 1, "Prague", ""),
+	})
+	if len(v.Fragmented) != 0 {
+		t.Fatalf("identical day ranges must be skipped, got %v", fragmentedHubs(v))
+	}
+	if len(v.Skipped) == 0 {
+		t.Fatal("a skip should say why")
+	}
+}
+
+// --- day monotonicity ---
+
+func TestDayOrderBreaksNamesTheBackwardStep(t *testing.T) {
+	fwd := runItemsOfLocations([]map[string]any{
+		rl("a", 1, "X", ""), rl("b", 2, "X", ""), rl("c", 3, "X", ""),
+	})
+	if n := dayOrderViolations(fwd); n != 0 {
+		t.Fatalf("ascending days have no violations, got %d", n)
+	}
+	back := runItemsOfLocations([]map[string]any{
+		rl("a", 3, "X", ""), rl("b", 1, "X", ""), rl("c", 2, "X", ""),
+	})
+	breaks := dayOrderBreaks(back)
+	if len(breaks) != 1 {
+		t.Fatalf("one backward step, got %d", len(breaks))
+	}
+	if breaks[0].Name != "b" || breaks[0].Day != 1 || breaks[0].Prev != 3 {
+		t.Fatalf("break should name b (day 1 after day 3), got %+v", breaks[0])
+	}
+	if dayOrderViolations(back) != len(breaks) {
+		t.Fatal("the count and the names must never disagree")
+	}
+}
+
+// --- the two reducers must agree ---
+
+// The audit reads stored rows; the guard reads submitted locations. If those two
+// reductions disagreed, the audit's prediction would not be about the guard's
+// behaviour at all — which is the whole failure the shared classifier exists to
+// prevent. locationFromItem is the round-trip the write path itself performs.
+func TestStoredAndSubmittedReduceIdentically(t *testing.T) {
+	items := []store.ItineraryItem{
+		item("Wawel Castle", 1, "Krakow", ""),
+		item("Rynek Glowny", 2, "Krakow", ""),
+		item("Charles Bridge", 3, "Prague", ""),
+		item("Versailles", 3, "Versailles", "Prague"),
+		item("Wawel Castle", 3, "Krakow", ""),
+		item("Rynek Glowny", 4, "Krakow", ""),
+	}
+	locs := make([]map[string]any, len(items))
+	for i, it := range items {
+		locs[i] = locationFromItem(it)
+	}
+	stored, submitted := inspectTripScope(runItemsOfStored(items)), inspectLocs(locs)
+	if len(stored.Runs) != len(submitted.Runs) {
+		t.Fatalf("runs differ: %d stored vs %d submitted", len(stored.Runs), len(submitted.Runs))
+	}
+	if fs, fl := fragmentedHubs(stored), fragmentedHubs(submitted); strings.Join(fs, ",") != strings.Join(fl, ",") {
+		t.Fatalf("fragmentation differs: stored %v vs submitted %v", fs, fl)
+	}
+	if len(stored.Breaks) != len(submitted.Breaks) {
+		t.Fatalf("day breaks differ: %d stored vs %d submitted", len(stored.Breaks), len(submitted.Breaks))
+	}
+	if stored.ok() || submitted.ok() {
+		t.Fatal("this fixture is the corruption shape; both sides must flag it")
+	}
+}
+
+func TestHubRunsFoldCase(t *testing.T) {
+	runs := hubRuns(runItemsOfLocations([]map[string]any{
+		rl("a", 1, "Krakow", ""),
+		rl("b", 2, "krakow", ""),
+		rl("c", 3, "Prague", ""),
+	}))
+	if len(runs) != 2 {
+		t.Fatalf("mixed case is one hub run, got %d runs", len(runs))
+	}
+	if runs[0].len() != 2 {
+		t.Fatalf("first run should hold both Krakow items, got %d", runs[0].len())
+	}
+}
+
+// Kraków and Krakow are one hub, so a run split on spelling alone would report a
+// revisit that isn't one.
+func TestHubRunsFoldDiacritics(t *testing.T) {
+	runs := hubRuns(runItemsOfLocations([]map[string]any{
+		rl("a", 1, "Kraków", ""),
+		rl("b", 2, "Krakow", ""),
+	}))
+	if len(runs) != 1 {
+		t.Fatalf("Kraków and Krakow are one run, got %d", len(runs))
+	}
+}
+
+func TestInspectTripScopeEmptyPayload(t *testing.T) {
+	if v := inspectTripScope(nil); !v.ok() || len(v.Runs) != 0 {
+		t.Fatalf("an empty list has nothing to flag, got %+v", v)
+	}
+}
+
+// KNOWN LIMITATION, deliberately pinned rather than fixed here.
+//
+// A genuine revisit whose return run REPEATS a place from the first run is
+// flagged: run B's identities are a subset of run A's, and the day ranges
+// differ, which is the whole predicate. Nothing about this shape is corrupt —
+// the traveler simply ate at the same bistro on the way home.
+//
+// It is left flagged because ticket 1 may not change what repair-sections
+// decides, and because the fix is a predicate change that belongs to whoever
+// owns the audit's result, not to the extraction. Note that such a shape has NO
+// day-order break (its days run 1…7 forwards), whereas the 2026-08-20
+// corruption always has one — so `fragmented && a day break` separates them
+// exactly. If this test ever starts failing, it is because that tightening
+// landed, and the fixture should become an assertNotFlagged.
+func TestClassifyFlagsPartiallyRepeatedRevisit_KnownLimitation(t *testing.T) {
+	v := inspectLocs([]map[string]any{
+		rl("Louvre", 1, "Paris", ""),
+		rl("Orsay", 2, "Paris", ""),
+		rl("Colosseum", 3, "Rome", ""),
+		rl("Forum", 4, "Rome", ""),
+		rl("Louvre", 5, "Paris", ""), // same place, genuinely revisited
+	})
+	if len(v.Fragmented) != 1 {
+		t.Fatalf("documenting today's behaviour: expected Paris flagged, got %v", fragmentedHubs(v))
+	}
+	if len(v.Breaks) != 0 {
+		t.Fatalf("a genuine revisit's days run forwards; got breaks %+v", v.Breaks)
+	}
+}

--- a/src/packages/api/itinerary_runs_test.go
+++ b/src/packages/api/itinerary_runs_test.go
@@ -216,13 +216,17 @@ func TestDayOrderBreaksNamesTheBackwardStep(t *testing.T) {
 // behaviour at all — which is the whole failure the shared classifier exists to
 // prevent. locationFromItem is the round-trip the write path itself performs.
 func TestStoredAndSubmittedReduceIdentically(t *testing.T) {
+	// The real 2026-08-20 shape (so the verdict compared is a REJECTION, not
+	// just two matching "fine"s), plus a day trip so the reducers' day_trip_from
+	// folding is part of what has to agree. Days 1,2,3,4,3,4 — the stale Krakow
+	// run carries its pre-swap days, which is what breaks the order.
 	items := []store.ItineraryItem{
 		item("Wawel Castle", 1, "Krakow", ""),
 		item("Rynek Glowny", 2, "Krakow", ""),
 		item("Charles Bridge", 3, "Prague", ""),
-		item("Versailles", 3, "Versailles", "Prague"),
-		item("Wawel Castle", 3, "Krakow", ""),
-		item("Rynek Glowny", 4, "Krakow", ""),
+		item("Kutna Hora", 4, "Kutna Hora", "Prague"),
+		item("Wawel Castle", 3, "Krakow", ""), // stale
+		item("Rynek Glowny", 4, "Krakow", ""), // stale
 	}
 	locs := make([]map[string]any, len(items))
 	for i, it := range items {
@@ -238,8 +242,17 @@ func TestStoredAndSubmittedReduceIdentically(t *testing.T) {
 	if len(stored.Breaks) != len(submitted.Breaks) {
 		t.Fatalf("day breaks differ: %d stored vs %d submitted", len(stored.Breaks), len(submitted.Breaks))
 	}
-	if stored.ok() || submitted.ok() {
-		t.Fatal("this fixture is the corruption shape; both sides must flag it")
+	if stored.fragmentationRejects() != submitted.fragmentationRejects() || stored.ok() != submitted.ok() {
+		t.Fatalf("verdicts differ: stored ok=%v fragRejects=%v, submitted ok=%v fragRejects=%v",
+			stored.ok(), stored.fragmentationRejects(), submitted.ok(), submitted.fragmentationRejects())
+	}
+	// Compared on a shape that actually REJECTS, so agreement is asserted on a
+	// real verdict rather than on two matching "fine"s.
+	if stored.ok() {
+		t.Fatal("this fixture is the corruption shape; it must be rejected")
+	}
+	if len(stored.Runs) != 3 {
+		t.Fatalf("Kutna Hora folds into the Prague run: expected 3 runs, got %d", len(stored.Runs))
 	}
 }
 
@@ -275,32 +288,82 @@ func TestInspectTripScopeEmptyPayload(t *testing.T) {
 	}
 }
 
-// KNOWN LIMITATION, deliberately pinned rather than fixed here.
+// THE measured false positive, and the reason the guard composes the two checks
+// rather than rejecting on fragmentation alone.
 //
-// A genuine revisit whose return run REPEATS a place from the first run is
-// flagged: run B's identities are a subset of run A's, and the day ranges
-// differ, which is the whole predicate. Nothing about this shape is corrupt —
-// the traveler simply ate at the same bistro on the way home.
+// A genuine revisit whose return run REPEATS a place satisfies the classifier's
+// predicate outright — run B's identities are a SUBSET of run A's, and the day
+// ranges differ. Nothing about it is corrupt: the traveler went back to the
+// Louvre. Rejecting it would be a REGRESSION (it writes fine on main) and,
+// because a scope-'trip' payload is always the complete itinerary, it would
+// block every whole-trip edit on that trip forever.
 //
-// It is left flagged because ticket 1 may not change what repair-sections
-// decides, and because the fix is a predicate change that belongs to whoever
-// owns the audit's result, not to the extraction. Note that such a shape has NO
-// day-order break (its days run 1…7 forwards), whereas the 2026-08-20
-// corruption always has one — so `fragmented && a day break` separates them
-// exactly. If this test ever starts failing, it is because that tightening
-// landed, and the fixture should become an assertNotFlagged.
-func TestClassifyFlagsPartiallyRepeatedRevisit_KnownLimitation(t *testing.T) {
-	v := inspectLocs([]map[string]any{
+// Both halves are asserted on purpose. The classifier must STILL flag it — the
+// repair tool depends on that and its verdicts are pinned byte-identical — while
+// the guard must NOT reject it. That split is the whole design; a test that
+// checked only one half would let the other drift.
+func TestFragmentationAloneDoesNotRejectAGenuineRevisit(t *testing.T) {
+	locs := []map[string]any{
 		rl("Louvre", 1, "Paris", ""),
 		rl("Orsay", 2, "Paris", ""),
 		rl("Colosseum", 3, "Rome", ""),
 		rl("Forum", 4, "Rome", ""),
 		rl("Louvre", 5, "Paris", ""), // same place, genuinely revisited
-	})
+	}
+	v := inspectLocs(locs)
 	if len(v.Fragmented) != 1 {
-		t.Fatalf("documenting today's behaviour: expected Paris flagged, got %v", fragmentedHubs(v))
+		t.Fatalf("the classifier must still flag it (repair depends on that), got %v", fragmentedHubs(v))
 	}
 	if len(v.Breaks) != 0 {
 		t.Fatalf("a genuine revisit's days run forwards; got breaks %+v", v.Breaks)
+	}
+	if v.fragmentationRejects() {
+		t.Fatal("fragmentation with no day break must not reject a write")
+	}
+	if !v.ok() {
+		t.Fatal("a genuine revisit that repeats a place must be writable")
+	}
+}
+
+// The shape that decides whether a "return must be separated in time" rule would
+// be safe — it would not. A genuine revisit can ARRIVE on a shared transition
+// day: Rome that morning, back in Paris that same evening, both day 4. Legal,
+// and it has no gap between the runs at all.
+func TestClassifyAllowsRevisitArrivingOnATransitionDay(t *testing.T) {
+	assertNotFlagged(t, "revisit arriving on a transition day", []map[string]any{
+		rl("Louvre", 1, "Paris", ""),
+		rl("Orsay", 2, "Paris", ""),
+		rl("Colosseum", 3, "Rome", ""),
+		rl("Forum", 4, "Rome", ""),
+		rl("Gare du Nord", 4, "Paris", ""), // same day 4, back in Paris
+		rl("Montmartre", 5, "Paris", ""),
+	})
+}
+
+// The measured gap, pinned so it is a known quantity rather than a surprise.
+//
+// An interleaved transition day — the ARRIVING city's item emitted before the
+// DEPARTING city's morning item — fragments the trip while leaving the days
+// non-decreasing, so neither check fires. It passed before this guard existed
+// too, so it is a gap and not a regression. The leading candidate for closing
+// it is a run-interleaving test (A,B,A,B): a correct itinerary is a SEQUENCE of
+// stays, so each city being interrupted by the other is two lists spliced
+// together. Held pending adversarial shapes and the production audit.
+func TestInterleavedTransitionDayIsAKnownGap(t *testing.T) {
+	v := inspectLocs([]map[string]any{
+		rl("Charles Bridge", 5, "Prague", ""),
+		rl("Wawel", 6, "Krakow", ""),       // arriving city, afternoon
+		rl("Old Town Sq", 6, "Prague", ""), // departing city, morning — emitted AFTER
+		rl("Rynek", 7, "Krakow", ""),
+	})
+	if len(v.Runs) != 4 {
+		t.Fatalf("this shape renders as four legs, got %d runs", len(v.Runs))
+	}
+	if len(v.Breaks) != 0 {
+		t.Fatalf("documenting the gap: days 5,6,6,7 do not run backwards; got %+v", v.Breaks)
+	}
+	if !v.ok() {
+		t.Fatal("documenting the gap: this is NOT caught today. If this now fails, " +
+			"the interleave rule landed — delete this test and assert the rejection instead")
 	}
 }

--- a/src/packages/api/itinerary_section.go
+++ b/src/packages/api/itinerary_section.go
@@ -232,6 +232,18 @@ func locationFromItem(it store.ItineraryItem) map[string]any {
 func spliceSection(existing []store.ItineraryItem, sel sectionSelector, newLocs []map[string]any) ([]map[string]any, error) {
 	switch sel.Scope {
 	case "trip":
+		// Scope 'trip' hand-authors the global position order and every day
+		// number for the whole trip at once, and both the tool description and
+		// the system prompt route EVERY cross-section edit here — so the most
+		// error-prone work arrives on what used to be the only unvalidated
+		// path. The two guards below are the ones the 2026-08-20 corruption
+		// walked straight through. Like every other rejection in this file they
+		// fire before anything is written: replaceTripSection calls
+		// spliceSection before its delete, so the model retries against an
+		// unchanged trip.
+		if err := errInvalidTripScopePayload(newLocs); err != nil {
+			return nil, err
+		}
 		return newLocs, nil
 	case "day":
 		if sel.Day == nil {
@@ -349,6 +361,53 @@ func errStraySectionItems(sel sectionSelector, newLocs, strays []map[string]any,
 		"To change only this section, resend just the places that are in %s. The trip has %s",
 		len(strays), len(newLocs), describeSelector(sel), describeStrays(strays), hint,
 		describeSelector(sel), describeSections(existing))
+}
+
+// errInvalidTripScopePayload is the self-correcting rejection for a whole-trip
+// rewrite that would fragment a city or run its days backwards. Returns nil when
+// the payload is fine.
+//
+// Both checks come from inspectTripScope — the SAME classifier the offline
+// repair tool runs, so what `repair-sections` predicts and what this rejects can
+// never come apart. Neither check is a "each city appears once" rule: a hub in
+// two runs is a supported itinerary shape (Paris → Rome → Paris) and passes.
+//
+// Fragmentation is reported first when both fire. A model told to reassemble a
+// city usually fixes the day sequence in the same edit, whereas fixing the days
+// alone leaves the city split — so leading with the city costs one round trip
+// instead of two.
+func errInvalidTripScopePayload(newLocs []map[string]any) error {
+	v := inspectTripScope(runItemsOfLocations(newLocs))
+	switch {
+	case len(v.Fragmented) > 0:
+		return fmt.Errorf("%d of the %d places sent would split a city into two separate legs with different dates: %s; "+
+			"a city sent as two runs renders TWICE — once with its dates and once collapsed to a near-zero-night stop — so nothing was changed. "+
+			"Resend the COMPLETE itinerary with every place in a city grouped together in ONE unbroken run, in the order the traveler visits them, and one day sequence that only ever moves forward. "+
+			"A city the traveler genuinely returns to later is fine: send that return visit's OWN places on its OWN later days, not a second copy of the first visit's list",
+			fragmentedItemCount(v), len(newLocs), describeFragments(v))
+	case len(v.Breaks) > 0:
+		b := v.Breaks[0]
+		more := ""
+		if n := len(v.Breaks) - 1; n > 0 {
+			more = fmt.Sprintf(" (and %d more place(s) further down)", n)
+		}
+		return fmt.Errorf("the day numbers stop running forwards partway through the list: %q is day %d but comes after day %d%s; "+
+			"day numbers increase across the whole trip in the order the places are sent, and a backwards step is what silently moves a city's dates and night count — so nothing was changed. "+
+			"Resend the COMPLETE itinerary in visit order with one forward-running day sequence. "+
+			"The day the traveler MOVES between cities is shared, not repeated backwards: it carries the SAME number in the city they leave and the city they reach",
+			b.Name, b.Day, b.Prev, more)
+	}
+	return nil
+}
+
+// fragmentedItemCount counts the places caught up in the fragmentation, so the
+// rejection opens the way errStraySectionItems does — "N of the M places sent".
+func fragmentedItemCount(v tripScopeVerdict) int {
+	n := 0
+	for _, f := range v.Fragmented {
+		n += v.Runs[f.A].len() + v.Runs[f.B].len()
+	}
+	return n
 }
 
 // describeSections summarizes the days and hubs present in a trip for the

--- a/src/packages/api/itinerary_section.go
+++ b/src/packages/api/itinerary_section.go
@@ -370,7 +370,9 @@ func errStraySectionItems(sel sectionSelector, newLocs, strays []map[string]any,
 // Both checks come from inspectTripScope — the SAME classifier the offline
 // repair tool runs, so what `repair-sections` predicts and what this rejects can
 // never come apart. Neither check is a "each city appears once" rule: a hub in
-// two runs is a supported itinerary shape (Paris → Rome → Paris) and passes.
+// two runs is a supported itinerary shape (Paris → Rome → Paris) and passes, and
+// so does a revisit that repeats a place, which fragmentation alone would
+// wrongly catch (see tripScopeVerdict.fragmentationRejects).
 //
 // Fragmentation is reported first when both fire. A model told to reassemble a
 // city usually fixes the day sequence in the same edit, whereas fixing the days
@@ -379,7 +381,7 @@ func errStraySectionItems(sel sectionSelector, newLocs, strays []map[string]any,
 func errInvalidTripScopePayload(newLocs []map[string]any) error {
 	v := inspectTripScope(runItemsOfLocations(newLocs))
 	switch {
-	case len(v.Fragmented) > 0:
+	case v.fragmentationRejects():
 		return fmt.Errorf("%d of the %d places sent would split a city into two separate legs with different dates: %s; "+
 			"a city sent as two runs renders TWICE — once with its dates and once collapsed to a near-zero-night stop — so nothing was changed. "+
 			"Resend the COMPLETE itinerary with every place in a city grouped together in ONE unbroken run, in the order the traveler visits them, and one day sequence that only ever moves forward. "+

--- a/src/packages/api/itinerary_section_integration_test.go
+++ b/src/packages/api/itinerary_section_integration_test.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"travel-route-planner/store"
+)
+
+// seedSectionTrip writes items in position order and returns the trip.
+func seedSectionTrip(t *testing.T, owner uuid.UUID, rows []store.ItineraryItem) store.Trip {
+	t.Helper()
+	ctx := context.Background()
+	q := store.New(dbPool)
+	chat := uuid.NewString()
+	trip, err := q.CreateTrip(ctx, store.CreateTripParams{
+		UserID: owner, Title: "Section Guard Trip", ChatID: &chat,
+	})
+	if err != nil {
+		t.Fatalf("CreateTrip: %v", err)
+	}
+	for i, it := range rows {
+		p := itemParamsFromLocation(trip.ID, int32(i), locationFromItem(it))
+		if _, err := q.CreateItineraryItem(ctx, p); err != nil {
+			t.Fatalf("CreateItineraryItem %d: %v", i, err)
+		}
+	}
+	return trip
+}
+
+func tripItemSummary(t *testing.T, tripID uuid.UUID) string {
+	t.Helper()
+	items, err := store.New(dbPool).GetItineraryItemsByTrip(context.Background(), tripID)
+	if err != nil {
+		t.Fatalf("GetItineraryItemsByTrip: %v", err)
+	}
+	var b strings.Builder
+	for _, it := range items {
+		// describeItem already carries position, name, hub and day — the whole
+		// of what a rewrite could have changed.
+		b.WriteString(describeItem(it) + "\n")
+	}
+	return b.String()
+}
+
+// THE ordering guarantee this guard depends on: replaceTripSection calls
+// spliceSection BEFORE its delete, so a rejected whole-trip rewrite leaves the
+// trip byte-for-byte unchanged and the model retries against real state. If that
+// ordering ever inverts, the guard turns from a safety net into a way to empty
+// somebody's itinerary — a rejection that has already deleted every row.
+//
+// Asserted against Postgres rather than by reading the source, because the claim
+// is about what the transaction leaves behind, not about statement order.
+func TestReplaceTripSectionWritesNothingWhenTripScopeRejected(t *testing.T) {
+	resetDB(t)
+	owner, _ := createTestUser(t, "section-guard@example.com")
+	trip := seedSectionTrip(t, owner.ID, []store.ItineraryItem{
+		item("Charles Bridge", 1, "Prague", ""),
+		item("Old Town Square", 2, "Prague", ""),
+		item("Wawel Castle", 3, "Krakow", ""),
+		item("Rynek Glowny", 4, "Krakow", ""),
+	})
+	before := tripItemSummary(t, trip.ID)
+	if strings.TrimSpace(before) == "" {
+		t.Fatal("fixture did not seed: nothing to prove unchanged")
+	}
+
+	// The 2026-08-20 shape: Krakow split into twin runs disagreeing about dates.
+	bad := []map[string]any{
+		rl("Wawel Castle", 1, "Krakow", ""),
+		rl("Rynek Glowny", 2, "Krakow", ""),
+		rl("Charles Bridge", 3, "Prague", ""),
+		rl("Old Town Square", 4, "Prague", ""),
+		rl("Wawel Castle", 3, "Krakow", ""),
+		rl("Rynek Glowny", 4, "Krakow", ""),
+	}
+	err := replaceTripSection(context.Background(), trip.ID, owner.ID,
+		sectionSelector{Scope: "trip"}, bad)
+	if err == nil {
+		t.Fatal("a fragmented whole-trip payload must be rejected")
+	}
+	if !strings.Contains(err.Error(), "Krakow") {
+		t.Fatalf("rejection %q should name the offending city", err)
+	}
+	if after := tripItemSummary(t, trip.ID); after != before {
+		t.Fatalf("a rejected rewrite wrote to the trip:\nbefore:\n%safter:\n%s", before, after)
+	}
+}
+
+// The complement, and the reason the test above is not just asserting that
+// nothing works: a legal whole-trip rewrite through the SAME path must still
+// land. Paris → Rome → Paris, written for real.
+func TestReplaceTripSectionWritesGenuineRevisit(t *testing.T) {
+	resetDB(t)
+	owner, _ := createTestUser(t, "section-guard-ok@example.com")
+	trip := seedSectionTrip(t, owner.ID, []store.ItineraryItem{
+		item("Louvre", 1, "Paris", ""),
+		item("Colosseum", 3, "Rome", ""),
+	})
+
+	revisit := []map[string]any{
+		rl("Louvre", 1, "Paris", ""),
+		rl("Orsay", 2, "Paris", ""),
+		rl("Colosseum", 3, "Rome", ""),
+		rl("Forum", 4, "Rome", ""),
+		rl("Sacre-Coeur", 5, "Paris", ""),
+	}
+	if err := replaceTripSection(context.Background(), trip.ID, owner.ID,
+		sectionSelector{Scope: "trip"}, revisit); err != nil {
+		t.Fatalf("Paris → Rome → Paris must still write: %v", err)
+	}
+	items, err := store.New(dbPool).GetItineraryItemsByTrip(context.Background(), trip.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(items) != 5 {
+		t.Fatalf("expected 5 items written, got %d", len(items))
+	}
+	// The revisit must survive as two Paris runs — that is the shape under test.
+	runs := hubRuns(runItemsOfStored(items))
+	if len(runs) != 3 {
+		t.Fatalf("expected Paris/Rome/Paris to persist as 3 runs, got %d", len(runs))
+	}
+}

--- a/src/packages/api/itinerary_section_test.go
+++ b/src/packages/api/itinerary_section_test.go
@@ -281,8 +281,11 @@ func TestSpliceSectionFoldsDiacritics(t *testing.T) {
 	assertOrder(t, got, []string{"Sukiennice"})
 }
 
-// scope 'trip' is the escape hatch the rejection points at, so it must stay
-// unguarded — it replaces everything and cannot duplicate.
+// scope 'trip' is the escape hatch the stray-items rejection points at: it
+// replaces everything, so carrying another city's places is exactly what it is
+// FOR and can never duplicate. It is guarded (below) only against the two ways a
+// whole-trip payload can be internally wrong, never against which cities it
+// names.
 func TestSpliceSectionTripScopeAcceptsAnyCity(t *testing.T) {
 	repl := []map[string]any{loc("Wawel Castle", 1, "Krakow", ""), loc("Charles Bridge", 2, "Prague", "")}
 	got, err := spliceSection(pragueKrakow(), sectionSelector{Scope: "trip"}, repl)
@@ -290,6 +293,149 @@ func TestSpliceSectionTripScopeAcceptsAnyCity(t *testing.T) {
 		t.Fatal(err)
 	}
 	assertOrder(t, got, []string{"Wawel Castle", "Charles Bridge"})
+}
+
+// --- the scope 'trip' guard ---
+
+// tl is rl with the section tests' loc shape: distinct coordinates per place, so
+// two different places are never content duplicates of each other.
+func tl(name string, day int, city, dayTripFrom string) map[string]any {
+	return rl(name, day, city, dayTripFrom)
+}
+
+// The 2026-08-20 corruption, arriving the way it actually arrived: a whole-trip
+// payload in which one city occupies two runs carrying different dates. Before
+// this guard, spliceSection returned this list verbatim and replaceTripSection
+// wrote both copies as real rows — the city then rendered twice, once with its
+// dates and once collapsed to a near-zero-night stop.
+func TestSpliceSectionTripScopeRejectsFragmentedCity(t *testing.T) {
+	repl := []map[string]any{
+		tl("Wawel Castle", 1, "Krakow", ""),
+		tl("Rynek Glowny", 2, "Krakow", ""),
+		tl("Charles Bridge", 3, "Prague", ""),
+		tl("Old Town Square", 4, "Prague", ""),
+		tl("Wawel Castle", 3, "Krakow", ""), // stale: pre-swap days
+		tl("Rynek Glowny", 4, "Krakow", ""), // stale
+	}
+	err := spliceSection2Err(t, pragueKrakow(), sectionSelector{Scope: "trip"}, repl)
+	// Name what's wrong, name the offending places, and name the call that works
+	// — the errStraySectionItems shape.
+	for _, want := range []string{"Krakow", "days 1-2", "days 3-4", "Wawel Castle", "nothing was changed", "COMPLETE itinerary"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error %q should mention %q", err, want)
+		}
+	}
+	// The rejection must not read as a ban on revisiting a city, or the model
+	// will "fix" a legal itinerary by deleting the return leg.
+	if !strings.Contains(err.Error(), "genuinely returns") {
+		t.Fatalf("error %q should say a genuine revisit is allowed", err)
+	}
+}
+
+// Days going backwards mid-payload: the signature of a hand-reordered list, and
+// what silently moves a leg's dates and night count.
+func TestSpliceSectionTripScopeRejectsBackwardsDays(t *testing.T) {
+	repl := []map[string]any{
+		tl("Colosseum", 4, "Rome", ""),
+		tl("Forum", 5, "Rome", ""),
+		tl("Louvre", 1, "Paris", ""),
+		tl("Orsay", 2, "Paris", ""),
+	}
+	err := spliceSection2Err(t, parisRome(), sectionSelector{Scope: "trip"}, repl)
+	for _, want := range []string{"Louvre", "day 1", "day 5", "nothing was changed"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error %q should mention %q", err, want)
+		}
+	}
+	// It must also say what the model is NOT being told to do, or the obvious
+	// repair is to bump the shared move day — which breaks the transition.
+	if !strings.Contains(err.Error(), "SAME number") {
+		t.Fatalf("error %q should protect the shared transition day", err)
+	}
+}
+
+// ACCEPTANCE. Paris → Rome → Paris is a supported itinerary shape:
+// computeTripLegs renders the revisit as its own leg on purpose. A guard that
+// rejects this gets turned off, so this test is worth as much as the rejections.
+func TestSpliceSectionTripScopeAcceptsGenuineRevisit(t *testing.T) {
+	repl := []map[string]any{
+		tl("Louvre", 1, "Paris", ""),
+		tl("Orsay", 2, "Paris", ""),
+		tl("Colosseum", 3, "Rome", ""),
+		tl("Forum", 4, "Rome", ""),
+		tl("Sacre-Coeur", 5, "Paris", ""),
+		tl("Montmartre", 6, "Paris", ""),
+	}
+	got, err := spliceSection(parisRome(), sectionSelector{Scope: "trip"}, repl)
+	if err != nil {
+		t.Fatalf("Paris → Rome → Paris is a legal itinerary: %v", err)
+	}
+	assertOrder(t, got, []string{"Louvre", "Orsay", "Colosseum", "Forum", "Sacre-Coeur", "Montmartre"})
+}
+
+// ACCEPTANCE. The day a traveler moves between cities carries the SAME day
+// number in both — a morning place in the city they leave and an afternoon or
+// evening place in the one they reach. Two hubs on one day number is the design.
+func TestSpliceSectionTripScopeAcceptsSharedTransitionDay(t *testing.T) {
+	repl := []map[string]any{
+		tl("Louvre", 1, "Paris", ""),
+		tl("Orsay", 2, "Paris", ""),
+		tl("Sainte-Chapelle", 3, "Paris", ""),  // morning of the move day
+		tl("Trastevere dinner", 3, "Rome", ""), // evening of the SAME day
+		tl("Colosseum", 4, "Rome", ""),
+	}
+	got, err := spliceSection(parisRome(), sectionSelector{Scope: "trip"}, repl)
+	if err != nil {
+		t.Fatalf("a shared transition day is the design, not a bug: %v", err)
+	}
+	if len(got) != 5 {
+		t.Fatalf("expected all 5 places written, got %d", len(got))
+	}
+}
+
+// ACCEPTANCE. A day trip belongs to its hub's run, so Versailles between two
+// Paris places does not split Paris in two.
+func TestSpliceSectionTripScopeAcceptsDayTrip(t *testing.T) {
+	repl := []map[string]any{
+		tl("Louvre", 1, "Paris", ""),
+		tl("Versailles", 2, "Versailles", "Paris"),
+		tl("Orsay", 3, "Paris", ""),
+		tl("Colosseum", 4, "Rome", ""),
+	}
+	if _, err := spliceSection(parisRome(), sectionSelector{Scope: "trip"}, repl); err != nil {
+		t.Fatalf("a day trip sits inside its hub's run: %v", err)
+	}
+}
+
+// ACCEPTANCE. A spine is a complete valid itinerary whose middle days are
+// deliberately empty, and an undated "maybe" at the tail is legitimate. Neither
+// is a backwards step.
+func TestSpliceSectionTripScopeAcceptsSpineAndUndatedTail(t *testing.T) {
+	repl := []map[string]any{
+		tl("Arrive Paris", 1, "Paris", ""),
+		tl("Leave Paris", 4, "Paris", ""),
+		tl("Arrive Rome", 4, "Rome", ""),
+		tl("Leave Rome", 8, "Rome", ""),
+		tl("Maybe: Pantheon", 0, "Rome", ""),
+	}
+	if _, err := spliceSection(parisRome(), sectionSelector{Scope: "trip"}, repl); err != nil {
+		t.Fatalf("a spine with an undated tail is legitimate: %v", err)
+	}
+}
+
+// The existing whole-trip callers send a bare list with no city and no day.
+// Omission is not evidence of anything and must keep working.
+func TestSpliceSectionTripScopeAcceptsUnspecifiedFields(t *testing.T) {
+	repl := []map[string]any{
+		{"name": "Only", "latitude": 1.0, "longitude": 1.0},
+		{"name": "Also", "latitude": 2.0, "longitude": 2.0},
+	}
+	if _, err := spliceSection(parisRome(), sectionSelector{Scope: "trip"}, repl); err != nil {
+		t.Fatalf("a bare whole-trip list must still write: %v", err)
+	}
+	if _, err := spliceSection(parisRome(), sectionSelector{Scope: "trip"}, nil); err != nil {
+		t.Fatalf("an empty whole-trip list must still write: %v", err)
+	}
 }
 
 // keyOfLocation must coerce `day` exactly as the writer does, or the guard could

--- a/src/packages/api/itinerary_section_test.go
+++ b/src/packages/api/itinerary_section_test.go
@@ -393,6 +393,43 @@ func TestSpliceSectionTripScopeAcceptsSharedTransitionDay(t *testing.T) {
 	}
 }
 
+// ACCEPTANCE, and the regression this guard was tuned to avoid shipping. A
+// revisit that goes back to the SAME place is a content duplicate of its own
+// first run with a different day range — the classifier flags it, and the guard
+// must still write it, because a scope-'trip' payload is the complete itinerary
+// and rejecting this would block every whole-trip edit on that trip forever.
+func TestSpliceSectionTripScopeAcceptsRevisitRepeatingAPlace(t *testing.T) {
+	repl := []map[string]any{
+		tl("Louvre", 1, "Paris", ""),
+		tl("Orsay", 2, "Paris", ""),
+		tl("Colosseum", 3, "Rome", ""),
+		tl("Forum", 4, "Rome", ""),
+		tl("Louvre", 5, "Paris", ""), // back to the Louvre on the way home
+	}
+	got, err := spliceSection(parisRome(), sectionSelector{Scope: "trip"}, repl)
+	if err != nil {
+		t.Fatalf("returning to a place you liked is not corruption: %v", err)
+	}
+	if len(got) != 5 {
+		t.Fatalf("expected all 5 places written, got %d", len(got))
+	}
+}
+
+// ACCEPTANCE. A revisit may ARRIVE on a shared transition day — Rome that
+// morning, Paris that evening, both day 4.
+func TestSpliceSectionTripScopeAcceptsRevisitOnATransitionDay(t *testing.T) {
+	repl := []map[string]any{
+		tl("Louvre", 1, "Paris", ""),
+		tl("Colosseum", 3, "Rome", ""),
+		tl("Forum", 4, "Rome", ""),
+		tl("Gare du Nord", 4, "Paris", ""),
+		tl("Montmartre", 5, "Paris", ""),
+	}
+	if _, err := spliceSection(parisRome(), sectionSelector{Scope: "trip"}, repl); err != nil {
+		t.Fatalf("a revisit arriving on a transition day is legal: %v", err)
+	}
+}
+
 // ACCEPTANCE. A day trip belongs to its hub's run, so Versailles between two
 // Paris places does not split Paris in two.
 func TestSpliceSectionTripScopeAcceptsDayTrip(t *testing.T) {

--- a/src/packages/api/testdata/guard_audit_corpus.sql
+++ b/src/packages/api/testdata/guard_audit_corpus.sql
@@ -1,0 +1,182 @@
+-- Seeded corpus for the scope-'trip' guard audit (specs: trip-scope-guard ticket 2).
+--
+-- WHY THIS FILE EXISTS: the audit's whole point is to check the guard against
+-- real itineraries before it starts rejecting writes, and the local dev database
+-- was destroyed and recreated on 2026-08-19 — it holds zero trips. Production is
+-- on DO and is Brian's to run. So the numbers this lane can produce come from a
+-- SEEDED corpus, and this file is it, written down so the numbers are
+-- reproducible and so a reader can see exactly which shapes were and were not
+-- covered.
+--
+-- A run over this corpus is NOT a substitute for a production run. It proves the
+-- predicate's behaviour on the shapes we know how to name; it cannot prove
+-- anything about shapes real travelers produced that nobody thought of.
+--
+-- Usage (against a migrated, otherwise-empty database):
+--   psql "$DATABASE_URL" -f testdata/guard_audit_corpus.sql
+--   go run . repair-sections
+--
+-- Trip titles are prefixed LEGIT- or CORRUPT- so the audit's output can be read
+-- against the intent without cross-referencing ids.
+
+BEGIN;
+
+INSERT INTO users (id, email)
+VALUES ('00000000-0000-0000-0000-0000000000aa', 'guard-audit@example.test')
+ON CONFLICT (email) DO NOTHING;
+
+-- Each trip gets a fixed uuid so re-running is idempotent and reports are stable.
+INSERT INTO trips (id, user_id, title) VALUES
+  ('10000000-0000-0000-0000-000000000001', '00000000-0000-0000-0000-0000000000aa', 'LEGIT-01 linear two cities'),
+  ('10000000-0000-0000-0000-000000000002', '00000000-0000-0000-0000-0000000000aa', 'LEGIT-02 genuine revisit Paris-Rome-Paris'),
+  ('10000000-0000-0000-0000-000000000003', '00000000-0000-0000-0000-0000000000aa', 'LEGIT-03 shared transition day'),
+  ('10000000-0000-0000-0000-000000000004', '00000000-0000-0000-0000-0000000000aa', 'LEGIT-04 day trip from hub'),
+  ('10000000-0000-0000-0000-000000000005', '00000000-0000-0000-0000-0000000000aa', 'LEGIT-05 hubless item between two city runs'),
+  ('10000000-0000-0000-0000-000000000006', '00000000-0000-0000-0000-0000000000aa', 'LEGIT-06 spine with empty middle days'),
+  ('10000000-0000-0000-0000-000000000007', '00000000-0000-0000-0000-0000000000aa', 'LEGIT-07 unscheduled tail'),
+  ('10000000-0000-0000-0000-000000000008', '00000000-0000-0000-0000-0000000000aa', 'LEGIT-08 diacritic spelling variance'),
+  ('10000000-0000-0000-0000-000000000009', '00000000-0000-0000-0000-0000000000aa', 'LEGIT-09 five-city trip with transitions and a day trip'),
+  ('10000000-0000-0000-0000-00000000000a', '00000000-0000-0000-0000-0000000000aa', 'LEGIT-10 single city'),
+  ('10000000-0000-0000-0000-00000000000b', '00000000-0000-0000-0000-0000000000aa', 'LEGIT-11 revisit repeating one place (known limitation)'),
+  ('10000000-0000-0000-0000-00000000000c', '00000000-0000-0000-0000-0000000000aa', 'LEGIT-12 island hop, every city once'),
+  ('20000000-0000-0000-0000-000000000001', '00000000-0000-0000-0000-0000000000aa', 'CORRUPT-01 stale trailing run (2026-08-20 shape)'),
+  ('20000000-0000-0000-0000-000000000002', '00000000-0000-0000-0000-0000000000aa', 'CORRUPT-02 stale leading run'),
+  ('20000000-0000-0000-0000-000000000003', '00000000-0000-0000-0000-0000000000aa', 'CORRUPT-03 days run backwards, no repeated hub'),
+  ('20000000-0000-0000-0000-000000000004', '00000000-0000-0000-0000-0000000000aa', 'CORRUPT-04 four cities fragmented (observed incident)')
+ON CONFLICT (id) DO NOTHING;
+
+-- position, name, city, day_trip_from, day. Coordinates are distinct per place:
+-- itemIdentity keys on lat/lng, so reusing one coordinate everywhere would make
+-- every place a content duplicate of every other and the corpus would flag for
+-- the wrong reason.
+INSERT INTO itinerary_items (trip_id, position, name, latitude, longitude, city, day_trip_from, day) VALUES
+-- LEGIT-01: the ordinary case, and by far the commonest.
+('10000000-0000-0000-0000-000000000001', 0, 'Louvre',        48.8606, 2.3376, 'Paris', NULL, 1),
+('10000000-0000-0000-0000-000000000001', 1, 'Orsay',         48.8600, 2.3266, 'Paris', NULL, 2),
+('10000000-0000-0000-0000-000000000001', 2, 'Eiffel Tower',  48.8584, 2.2945, 'Paris', NULL, 3),
+('10000000-0000-0000-0000-000000000001', 3, 'Colosseum',     41.8902, 12.4922, 'Rome', NULL, 4),
+('10000000-0000-0000-0000-000000000001', 4, 'Forum',         41.8925, 12.4853, 'Rome', NULL, 5),
+('10000000-0000-0000-0000-000000000001', 5, 'Pantheon',      41.8986, 12.4769, 'Rome', NULL, 6),
+
+-- LEGIT-02: two Paris runs, different places in each. computeTripLegs renders
+-- this as three legs on purpose; the guard must leave it alone.
+('10000000-0000-0000-0000-000000000002', 0, 'Louvre',        48.8606, 2.3376, 'Paris', NULL, 1),
+('10000000-0000-0000-0000-000000000002', 1, 'Orsay',         48.8600, 2.3266, 'Paris', NULL, 2),
+('10000000-0000-0000-0000-000000000002', 2, 'Colosseum',     41.8902, 12.4922, 'Rome', NULL, 3),
+('10000000-0000-0000-0000-000000000002', 3, 'Forum',         41.8925, 12.4853, 'Rome', NULL, 4),
+('10000000-0000-0000-0000-000000000002', 4, 'Sacre-Coeur',   48.8867, 2.3431, 'Paris', NULL, 5),
+('10000000-0000-0000-0000-000000000002', 5, 'Montmartre',    48.8867, 2.3406, 'Paris', NULL, 6),
+
+-- LEGIT-03: the move day carries the SAME day number in both cities.
+('10000000-0000-0000-0000-000000000003', 0, 'Louvre',            48.8606, 2.3376, 'Paris', NULL, 1),
+('10000000-0000-0000-0000-000000000003', 1, 'Orsay',             48.8600, 2.3266, 'Paris', NULL, 2),
+('10000000-0000-0000-0000-000000000003', 2, 'Sainte-Chapelle',   48.8554, 2.3450, 'Paris', NULL, 3),
+('10000000-0000-0000-0000-000000000003', 3, 'Trastevere dinner', 41.8890, 12.4700, 'Rome', NULL, 3),
+('10000000-0000-0000-0000-000000000003', 4, 'Colosseum',         41.8902, 12.4922, 'Rome', NULL, 4),
+
+-- LEGIT-04: Versailles sits inside the Paris run via day_trip_from.
+('10000000-0000-0000-0000-000000000004', 0, 'Louvre',      48.8606, 2.3376, 'Paris', NULL, 1),
+('10000000-0000-0000-0000-000000000004', 1, 'Versailles',  48.8049, 2.1204, 'Versailles', 'Paris', 2),
+('10000000-0000-0000-0000-000000000004', 2, 'Orsay',       48.8600, 2.3266, 'Paris', NULL, 3),
+('10000000-0000-0000-0000-000000000004', 3, 'Colosseum',   41.8902, 12.4922, 'Rome', NULL, 4),
+
+-- LEGIT-05: a hubless place between two Paris runs; "Other places" in the UI.
+('10000000-0000-0000-0000-000000000005', 0, 'Louvre',           48.8606, 2.3376, 'Paris', NULL, 1),
+('10000000-0000-0000-0000-000000000005', 1, 'Roadside viewpoint', 48.7000, 2.2000, NULL, NULL, 2),
+('10000000-0000-0000-0000-000000000005', 2, 'Orsay',            48.8600, 2.3266, 'Paris', NULL, 3),
+('10000000-0000-0000-0000-000000000005', 3, 'Colosseum',        41.8902, 12.4922, 'Rome', NULL, 4),
+
+-- LEGIT-06: a spine — first and last day of each city only, middles empty.
+('10000000-0000-0000-0000-000000000006', 0, 'Arrive Paris', 48.8606, 2.3376, 'Paris', NULL, 1),
+('10000000-0000-0000-0000-000000000006', 1, 'Leave Paris',  48.8600, 2.3266, 'Paris', NULL, 4),
+('10000000-0000-0000-0000-000000000006', 2, 'Arrive Rome',  41.8902, 12.4922, 'Rome', NULL, 4),
+('10000000-0000-0000-0000-000000000006', 3, 'Leave Rome',   41.8925, 12.4853, 'Rome', NULL, 8),
+
+-- LEGIT-07: an undated "maybe" at the tail.
+('10000000-0000-0000-0000-000000000007', 0, 'Louvre',         48.8606, 2.3376, 'Paris', NULL, 1),
+('10000000-0000-0000-0000-000000000007', 1, 'Orsay',          48.8600, 2.3266, 'Paris', NULL, 2),
+('10000000-0000-0000-0000-000000000007', 2, 'Maybe: Pompidou', 48.8607, 2.3522, 'Paris', NULL, NULL),
+
+-- LEGIT-08: the model re-typing Kraków as Krakow must stay ONE run.
+('10000000-0000-0000-0000-000000000008', 0, 'Wawel Castle',   50.0540, 19.9354, 'Kraków', NULL, 1),
+('10000000-0000-0000-0000-000000000008', 1, 'Sukiennice',     50.0616, 19.9373, 'Krakow', NULL, 2),
+('10000000-0000-0000-0000-000000000008', 2, 'Rynek Glowny',   50.0617, 19.9370, 'KRAKOW', NULL, 3),
+('10000000-0000-0000-0000-000000000008', 3, 'Charles Bridge', 50.0865, 14.4114, 'Prague', NULL, 4),
+
+-- LEGIT-09: a long realistic itinerary — five cities, shared transition days,
+-- a day trip, an undated maybe. The shape most like a real saved trip.
+('10000000-0000-0000-0000-000000000009', 0,  'Sagrada Familia', 41.4036, 2.1744, 'Barcelona', NULL, 1),
+('10000000-0000-0000-0000-000000000009', 1,  'Park Guell',      41.4145, 2.1527, 'Barcelona', NULL, 2),
+('10000000-0000-0000-0000-000000000009', 2,  'Montserrat',      41.5934, 1.8380, 'Montserrat', 'Barcelona', 3),
+('10000000-0000-0000-0000-000000000009', 3,  'Boqueria',        41.3817, 2.1717, 'Barcelona', NULL, 4),
+('10000000-0000-0000-0000-000000000009', 4,  'Alhambra',        37.1761, -3.5881, 'Granada', NULL, 4),
+('10000000-0000-0000-0000-000000000009', 5,  'Albaicin',        37.1809, -3.5926, 'Granada', NULL, 5),
+('10000000-0000-0000-0000-000000000009', 6,  'Mezquita',        37.8790, -4.7794, 'Cordoba', NULL, 6),
+('10000000-0000-0000-0000-000000000009', 7,  'Alcazar',         37.3830, -5.9903, 'Seville', NULL, 7),
+('10000000-0000-0000-0000-000000000009', 8,  'Plaza de Espana', 37.3772, -5.9869, 'Seville', NULL, 8),
+('10000000-0000-0000-0000-000000000009', 9,  'Prado',           40.4138, -3.6921, 'Madrid', NULL, 9),
+('10000000-0000-0000-0000-000000000009', 10, 'Retiro',          40.4153, -3.6844, 'Madrid', NULL, 10),
+('10000000-0000-0000-0000-000000000009', 11, 'Maybe: Toledo',   39.8628, -4.0273, 'Toledo', 'Madrid', NULL),
+
+-- LEGIT-10: one city, nothing to fragment.
+('10000000-0000-0000-0000-00000000000a', 0, 'Louvre', 48.8606, 2.3376, 'Paris', NULL, 1),
+('10000000-0000-0000-0000-00000000000a', 1, 'Orsay',  48.8600, 2.3266, 'Paris', NULL, 2),
+
+-- LEGIT-11: a genuine revisit whose return run REPEATS a place from the first.
+-- Days run forwards throughout; nothing here is corrupt. This is the shape the
+-- conservative predicate is expected to flag anyway — see the lane report.
+('10000000-0000-0000-0000-00000000000b', 0, 'Louvre',    48.8606, 2.3376, 'Paris', NULL, 1),
+('10000000-0000-0000-0000-00000000000b', 1, 'Orsay',     48.8600, 2.3266, 'Paris', NULL, 2),
+('10000000-0000-0000-0000-00000000000b', 2, 'Colosseum', 41.8902, 12.4922, 'Rome', NULL, 3),
+('10000000-0000-0000-0000-00000000000b', 3, 'Forum',     41.8925, 12.4853, 'Rome', NULL, 4),
+('10000000-0000-0000-0000-00000000000b', 4, 'Louvre',    48.8606, 2.3376, 'Paris', NULL, 5),
+
+-- LEGIT-12: Greek island hop, every island once, shared transition days.
+('10000000-0000-0000-0000-00000000000c', 0, 'Acropolis',      37.9715, 23.7257, 'Athens', NULL, 1),
+('10000000-0000-0000-0000-00000000000c', 1, 'Plaka dinner',   37.9725, 23.7300, 'Athens', NULL, 2),
+('10000000-0000-0000-0000-00000000000c', 2, 'Oia sunset',     36.4618, 25.3753, 'Santorini', NULL, 2),
+('10000000-0000-0000-0000-00000000000c', 3, 'Red Beach',      36.3487, 25.3940, 'Santorini', NULL, 3),
+('10000000-0000-0000-0000-00000000000c', 4, 'Little Venice',  37.4467, 25.3289, 'Mykonos', NULL, 4),
+('10000000-0000-0000-0000-00000000000c', 5, 'Delos',          37.3936, 25.2686, 'Delos', 'Mykonos', 5),
+
+-- CORRUPT-01: the 2026-08-20 shape. Krakow twice — the fresh copy on days 1-2,
+-- the stale copy still carrying its pre-swap days 3-4.
+('20000000-0000-0000-0000-000000000001', 0, 'Wawel Castle',    50.0540, 19.9354, 'Krakow', NULL, 1),
+('20000000-0000-0000-0000-000000000001', 1, 'Rynek Glowny',    50.0617, 19.9370, 'Krakow', NULL, 2),
+('20000000-0000-0000-0000-000000000001', 2, 'Charles Bridge',  50.0865, 14.4114, 'Prague', NULL, 3),
+('20000000-0000-0000-0000-000000000001', 3, 'Old Town Square', 50.0870, 14.4207, 'Prague', NULL, 4),
+('20000000-0000-0000-0000-000000000001', 4, 'Wawel Castle',    50.0540, 19.9354, 'Krakow', NULL, 3),
+('20000000-0000-0000-0000-000000000001', 5, 'Rynek Glowny',    50.0617, 19.9370, 'Krakow', NULL, 4),
+
+-- CORRUPT-02: the mirror, from the same user action targeting the other city.
+('20000000-0000-0000-0000-000000000002', 0, 'Charles Bridge',  50.0865, 14.4114, 'Prague', NULL, 1),
+('20000000-0000-0000-0000-000000000002', 1, 'Old Town Square', 50.0870, 14.4207, 'Prague', NULL, 2),
+('20000000-0000-0000-0000-000000000002', 2, 'Wawel Castle',    50.0540, 19.9354, 'Krakow', NULL, 1),
+('20000000-0000-0000-0000-000000000002', 3, 'Rynek Glowny',    50.0617, 19.9370, 'Krakow', NULL, 2),
+('20000000-0000-0000-0000-000000000002', 4, 'Charles Bridge',  50.0865, 14.4114, 'Prague', NULL, 3),
+('20000000-0000-0000-0000-000000000002', 5, 'Old Town Square', 50.0870, 14.4207, 'Prague', NULL, 4),
+
+-- CORRUPT-03: a hand-reordered list whose days zig-zag. No hub repeats at all,
+-- so candidateTripsSQL never sees it — only the day-monotonicity check does.
+('20000000-0000-0000-0000-000000000003', 0, 'Colosseum',   41.8902, 12.4922, 'Rome', NULL, 4),
+('20000000-0000-0000-0000-000000000003', 1, 'Forum',       41.8925, 12.4853, 'Rome', NULL, 5),
+('20000000-0000-0000-0000-000000000003', 2, 'Louvre',      48.8606, 2.3376, 'Paris', NULL, 1),
+('20000000-0000-0000-0000-000000000003', 3, 'Orsay',       48.8600, 2.3266, 'Paris', NULL, 2),
+('20000000-0000-0000-0000-000000000003', 4, 'Duomo',       45.4642, 9.1900, 'Milan', NULL, 6),
+
+-- CORRUPT-04: the observed incident — Prague and Kraków appearing twice, Rome
+-- and Sorrento split, two legs carrying wrong dates.
+('20000000-0000-0000-0000-000000000004', 0,  'Charles Bridge',  50.0865, 14.4114, 'Prague', NULL, 1),
+('20000000-0000-0000-0000-000000000004', 1,  'Old Town Square', 50.0870, 14.4207, 'Prague', NULL, 2),
+('20000000-0000-0000-0000-000000000004', 2,  'Wawel Castle',    50.0540, 19.9354, 'Kraków', NULL, 3),
+('20000000-0000-0000-0000-000000000004', 3,  'Rynek Glowny',    50.0617, 19.9370, 'Kraków', NULL, 4),
+('20000000-0000-0000-0000-000000000004', 4,  'Colosseum',       41.8902, 12.4922, 'Rome', NULL, 5),
+('20000000-0000-0000-0000-000000000004', 5,  'Marina Grande',   40.6263, 14.3757, 'Sorrento', NULL, 7),
+('20000000-0000-0000-0000-000000000004', 6,  'Charles Bridge',  50.0865, 14.4114, 'Prague', NULL, 5),
+('20000000-0000-0000-0000-000000000004', 7,  'Old Town Square', 50.0870, 14.4207, 'Prague', NULL, 6),
+('20000000-0000-0000-0000-000000000004', 8,  'Wawel Castle',    50.0540, 19.9354, 'Krakow', NULL, 7),
+('20000000-0000-0000-0000-000000000004', 9,  'Rynek Glowny',    50.0617, 19.9370, 'Krakow', NULL, 8),
+('20000000-0000-0000-0000-000000000004', 10, 'Forum',           41.8925, 12.4853, 'Rome', NULL, 9),
+('20000000-0000-0000-0000-000000000004', 11, 'Marina Grande',   40.6263, 14.3757, 'Sorrento', NULL, 10);
+
+COMMIT;


### PR DESCRIPTION
> ### ⚠️ What this PR actually is, named plainly
>
> **As merged, this is a day-monotonicity guard.** Not partly — entirely. The shipped rule is `(fragmented AND day-break) OR day-break`, and that is not a tendency or an approximation, it is a **logical identity**: it *is* `day-break`. The fragmentation half contributes **nothing to any rejection decision**. The shared classifier, as shipped, does messaging and nothing else — it picks which error text the model receives, never whether the write is refused.
>
> Taking "fragmentation guard" at face value would mean believing the write path is protected against a shape it demonstrably is not: **the interleaved transition day passes, and that is the traveler's own reported shape.** The remaining interleave work is *finishing this job, not polishing it*.
>
> This is not an argument against merging — it is non-regressive, catches all four splice shapes, and strictly improves a path that validated nothing. It just has to be called what it is.

## Summary

`spliceSection` returned a scope-`'trip'` payload **verbatim** — the stray-items guard and the self-correcting miss error both sat *below* that return and ran only for `'day'` and `'city'`. Meanwhile the tool description and `plan_handler.go`'s system prompt route **every** cross-section edit into that scope, so the least-validated path carried the most error-prone work. Observed 2026-08-20: a city swap through it fragmented four cities and moved two legs' dates.

- **Shared classifier** (`itinerary_runs.go`) — `hubRuns` and the conservative corruption predicate moved out of the offline repair tool into a pure, DB-free unit both callers use. `itinerary_repair.go`'s header already required that detection and enforcement not drift apart; two copies of "what counts as a fragmented city" *is* that drift. `repair-sections` verdicts are **byte-identical to `main`** — verified three times, including after the rule change below.
- **Report-only audit** — `repair-sections` now also reports what the guard *would* reject, on its **own** candidate query. The existing `candidateTripsSQL` prefilters to trips with a repeated hub, so it structurally cannot see a day-order-only fault; one seeded trip proved that (invisible to the repair pass, caught by the audit).
- **The guard** — a scope-`'trip'` payload is rejected when its day numbers run backwards in position order. (The fragmentation check is written as a second, independent rejection rule, but as composed it can only fire when a day break already has — see the callout above. It is structured that way so the interleave clause is a local edit later, and it does real work choosing the error message.) Rejection writes nothing: `replaceTripSection` calls `spliceSection` before its delete.

Two things deliberately **not** done:

- **A hub in two runs is not by itself corruption.** `computeTripLegs` supports genuine revisits, so a naive "each city appears once" check would break Paris → Rome → Paris. The day check is strictly `<`, so a **shared transition day** stays legal. Both have acceptance tests, watched failing under a too-strict guard.
- **`create_itinerary` is not guarded.** A false positive there blocks trip creation entirely. Its one caller (`persistTrip`) is a separate path — confirmed by grep that `replaceTripSection` has exactly one caller.

## The audit finding, and the rule it produced

The audit's job was to answer whether the guard would reject historical good writes **before** it started rejecting anything. It found one legitimate shape:

```
Louvre (Paris, d1) · Orsay (Paris, d2) · Colosseum (Rome, d3) · Forum (Rome, d4) · Louvre (Paris, d5)
   → fragmented: Paris (days 1-2, then again on day 5: Louvre)
```

A genuine revisit that **repeats a place** satisfies the predicate outright — run B's identities are a *subset* of run A's, and the day ranges differ. Nothing about it is corrupt.

This was **reported rather than tuned away**, and the fix chosen is a composition, not a relaxation: **a fragmentation finding rejects only when the days also run backwards.** Day monotonicity still rejects on its own — one seeded corruption (days reordered, no repeated hub) is caught by nothing else.

**Why that rule, as a principle rather than a score.** The two failure modes are not symmetric:

- **A false rejection is a regression.** That write succeeds on `main` today, and since a scope-`'trip'` payload is always the COMPLETE itinerary, rejecting it blocks *every* whole-trip edit on that trip — permanently, silently, with no message that explains it.
- **A gap is not a regression.** `main` validates nothing here, so a missed shape is a smaller improvement, never a new harm.

The bar is therefore **strictly non-regressive**. Two alternatives were tested and rejected on evidence: a **day-range overlap** test is *strictly worse than shipping unchanged* (an interleaved transition day yields adjacent-but-disjoint ranges `[5,5]`/`[6,6]` that never intersect, and it cannot be evaluated without deleting the identical-day-ranges skip, which would change `repair-sections` verdicts); a **return-gap** test catches every corruption but rejects a genuine revisit *arriving on a shared transition day*.

The offline repair tool deliberately does **not** compose this way — it proposes a delete in a dry run for a human to confirm, and marks this very shape `[TIED]`. Same predicate, different consequence.

### Audit numbers, and the corpus

**Seeded, not production.** The local dev DB holds 0 trips (destroyed/recreated 2026-08-19); production is on DO. `testdata/guard_audit_corpus.sql` (16 trips / 90 items, fixed uuids) is committed so the run is reproducible. **The production run is still owed and nothing here substitutes for it.**

```
scanned 16 trip(s) — 4 would be rejected (3 fragmented, 4 day-order),
12 would pass (1 of those fragmented but allowed: no day break)
```

All 4 rejections are the seeded corruption. **0 false rejections.** A fragmented-but-allowed trip is now reported as an explicit non-rejection, because how often it occurs in real data is the number that would justify ever tightening the rule.

### Two known gaps — pre-existing, not regressions

An **interleaved transition day** (the arriving city's item emitted *before* the departing city's morning item) fragments the trip while leaving days non-decreasing, so it passes. It passed before this guard existed too. Pinned by `TestInterleavedTransitionDayIsAKnownGap`, which fails loudly if it ever starts being caught.

The leading candidate for closing it, recorded because the reasoning stands on its own rather than on the corpus: a **run-interleaving** test (`A,B,A,B`). *A correct itinerary is a sequence of stays — once you leave A for B you are in B until you leave B, so the runs partition time into ordered stays.* `A,B,A,B` means each city was interrupted by the other, which is two lists spliced together: the corruption mechanism itself. It scored 0 false rejections / 0 misses and is **deliberately unshipped** — that clause was added *after* earlier candidates failed, against a self-authored corpus, which is the shape of tuning-until-quiet even when each step has a story. It needs adversarial shapes and the production audit first.

Worth checking before more is built on the inference: *"day 6 has both Prague AND Kraków places"* describes the **legal** shared transition day. The reported duplication only implies illegal ordering if Prague's items sit on *both sides* of a Kraków item in position order. If the real rows turn out legal, this is a `computeTripLegs` rendering question and this guard is not the fix.

## Testing

`go test ./...` from `src/packages/api`, captured to a file and grepped for the verdict (not judged through `tail`) — green both without a DB and with `TEST_DATABASE_URL` set, so the two integration tests actually ran rather than skipped. `gofmt -l` and `go vet ./...` clean.

**Every test was watched failing before it counted.** The mutations that matter most are the *too-strict* ones — an acceptance test cannot be killed by removing the guard, so only tightening proves it isn't vacuous:

| Mutation | Tests it killed |
|---|---|
| **fragmentation rejects on its own** (the reverted rule) | **genuine revisit repeating a place accepted** (classifier + splice) |
| **`<` → `<=` in the day check** | **shared transition day accepted** · **revisit arriving on a transition day accepted** · spine accepted · interleave-gap pin |
| guard call removed (= today's `main`) | fragmented-city rejected · backwards-days rejected · **nothing written on rejection** |
| naive "each hub appears once" | Paris → Rome → Paris accepted · revisit-on-transition-day accepted · hubless skip · identical-day-ranges skip · 3 pre-existing `planTripRepair` tests |
| classifier never flags | 2026-08-20 shape · genuine-revisit composition · stored-vs-submitted agreement · nothing-written · 2 pre-existing repair tests |
| hub resolution ignores `day_trip_from` | day-trip folding · stored-vs-submitted agreement |

One genuine catch worth noting: applying the rule change broke `TestStoredAndSubmittedReduceIdentically`, whose fixture turned out to have non-decreasing days and so no longer rejected. It was rebuilt on the real 2026-08-20 shape plus a day trip, so the two reducers are now compared on an actual **rejection** rather than on two matching "fine"s.

**Extraction acceptance test, run three times** — a 14-shape in-process corpus (deletes, skip reasons, tie flags, before/after listings), a live `repair-sections` run against the seeded Postgres, and again after the rule change: **byte-identical to `main`** every time (`md5` match / empty `diff`).

Also verified: the command runs clean against an empty database and says so explicitly (`NO TRIPS TO CHECK — this database is empty, so this is not evidence`) rather than reporting `0 would be rejected` as a pass; `-v` and `-trip` both reach the new verdict.

## Lane notes

Touches only `itinerary_section.go`, `itinerary_repair.go`, their tests, the new shared classifier and a new `testdata/` fixture. `plan_tool_registry.go`, `migrations/`, the `.arb` files, `main.go` and all Flutter code are untouched. No migration, no l10n keys, no client change.

`replaceTripSection` has exactly one caller (`update_itinerary_section`), so that is the guard's entire blast radius. For the `replace-leg` lane: if it ever submits a whole-trip payload through this path it is now validated — a leg swap should pass, but it is no longer an unchecked write.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


