### PR TITLE
fix(api): adapt replace_leg to the shared hub-run classifier (unbreaks main)

### DIFF
--- a/src/packages/api/replace_leg_splice.go
+++ b/src/packages/api/replace_leg_splice.go
@@ -77,7 +77,11 @@ func parseLegAddress(city string) legAddress {
 // spelled the way this tool accepts them back — the self-correcting error
 // payload, in the style of describeSections/legsSummary. Hubless runs are
 // skipped: a leg with no city is not one this tool can address.
-func describeLegRuns(runs []hubRun) string {
+//
+// Takes the runItem slice the runs index into: since the scope-'trip' guard
+// landed, a hubRun is a half-open index RANGE rather than a carried item list,
+// so a run and the list it was computed from travel together.
+func describeLegRuns(runs []hubRun, rits []runItem) string {
 	seen := map[string]int{}
 	var parts []string
 	for _, r := range runs {
@@ -91,7 +95,7 @@ func describeLegRuns(runs []hubRun) string {
 		if seen[k] > 1 {
 			label = fmt.Sprintf("%s#%d", hub, seen[k])
 		}
-		if lo, hi, ok := dayRange(r.Items); ok {
+		if lo, hi, ok := dayRange(r.slice(rits)); ok {
 			parts = append(parts, fmt.Sprintf("%s (trip days %d-%d)", label, lo, hi))
 		} else {
 			parts = append(parts, fmt.Sprintf("%s (no day numbers)", label))
@@ -110,7 +114,7 @@ func describeLegRuns(runs []hubRun) string {
 // leave them alone. So a bare name that matches two runs is answered with a
 // question, never with a guess: replacing the wrong Paris would delete places
 // nobody asked about.
-func selectLegRun(runs []hubRun, addr legAddress) (int, error) {
+func selectLegRun(runs []hubRun, rits []runItem, addr legAddress) (int, error) {
 	var matches []int
 	for i, r := range runs {
 		if strings.TrimSpace(r.Hub) != "" && sameHub(r.Hub, addr.hub) {
@@ -119,13 +123,13 @@ func selectLegRun(runs []hubRun, addr legAddress) (int, error) {
 	}
 	if len(matches) == 0 {
 		return 0, fmt.Errorf("no leg for %q in this trip, so nothing was changed. Its city legs, in order, are: %s. Use the city name exactly as it appears in the itinerary",
-			addr.hub, describeLegRuns(runs))
+			addr.hub, describeLegRuns(runs, rits))
 	}
 	if addr.visit == 0 {
 		if len(matches) > 1 {
 			var spans []string
 			for n, i := range matches {
-				lo, hi, ok := dayRange(runs[i].Items)
+				lo, hi, ok := dayRange(runs[i].slice(rits))
 				if !ok {
 					spans = append(spans, fmt.Sprintf("%s#%d (no day numbers)", runs[i].Hub, n+1))
 					continue
@@ -139,7 +143,7 @@ func selectLegRun(runs []hubRun, addr legAddress) (int, error) {
 	}
 	if addr.visit > len(matches) {
 		return 0, fmt.Errorf("the itinerary visits %s %d time(s), so there is no visit #%d, and nothing was changed. Its city legs are: %s",
-			addr.hub, len(matches), addr.visit, describeLegRuns(runs))
+			addr.hub, len(matches), addr.visit, describeLegRuns(runs, rits))
 	}
 	return matches[addr.visit-1], nil
 }
@@ -206,19 +210,23 @@ func spliceLeg(existing []store.ItineraryItem, city, newCity string, places []ma
 		return legSplice{}, fmt.Errorf("places came back empty, so this call would DELETE the %s leg rather than replace it, and nothing was changed. Send the new city's places — at least the one they arrive at and one easy place for the day they move on", addr.hub)
 	}
 
-	runs := hubRuns(existing)
-	idx, err := selectLegRun(runs, addr)
+	// runItemsOfStored is the shared reduction the run classifier works over
+	// (itinerary_runs.go). Computed once and carried alongside `runs`, because a
+	// hubRun is an index RANGE into the list it was built from — `existing` and
+	// `rits` are parallel, so a run's range slices either one.
+	rits := runItemsOfStored(existing)
+	runs := hubRuns(rits)
+	idx, err := selectLegRun(runs, rits, addr)
 	if err != nil {
 		return legSplice{}, err
 	}
 	run := runs[idx]
 
-	lo, hi, dated := dayRange(run.Items)
+	first, last, dated := dayRange(run.slice(rits))
 	if !dated {
 		return legSplice{}, fmt.Errorf("the %s leg's places carry no day numbers, so it has no span to preserve and replacing it would leave the new city's dates to be guessed. Nothing was changed — give %s's places day numbers with update_itinerary_section scope 'city' first, or set its dates with set_leg_dates",
 			run.Hub, run.Hub)
 	}
-	first, last := int(lo), int(hi)
 
 	newHub := strings.TrimSpace(newCity)
 	if newHub == "" {
@@ -230,13 +238,13 @@ func spliceLeg(existing []store.ItineraryItem, city, newCity string, places []ma
 		return legSplice{}, err
 	}
 
-	out := make([]map[string]any, 0, len(existing)-len(run.Items)+len(newLocs))
+	out := make([]map[string]any, 0, len(existing)-run.len()+len(newLocs))
 	for i, r := range runs {
 		if i == idx {
 			out = append(out, newLocs...)
 			continue
 		}
-		for _, it := range r.Items {
+		for _, it := range existing[r.Start:r.End] {
 			out = append(out, locationFromItem(it))
 		}
 	}
@@ -252,7 +260,7 @@ func spliceLeg(existing []store.ItineraryItem, city, newCity string, places []ma
 		NewHub:    newHub,
 		FirstDay:  first,
 		LastDay:   last,
-		Replaced:  len(run.Items),
+		Replaced:  run.len(),
 		Days:      days,
 	}, nil
 }

--- a/src/packages/api/replace_leg_splice_test.go
+++ b/src/packages/api/replace_leg_splice_test.go
@@ -412,7 +412,7 @@ func TestSpliceLegKeepsDayTripsInsideTheRun(t *testing.T) {
 	// hubRuns groups on day_trip_from ?? city, so all three must land in ONE
 	// run — a day trip that split the run would fragment the leg, which is the
 	// failure this tool makes unreachable.
-	runs := hubRuns(locsAsItems(got.Locations))
+	runs := hubRuns(runItemsOfLocations(got.Locations))
 	var hubs []string
 	for _, r := range runs {
 		hubs = append(hubs, r.Hub)
@@ -565,31 +565,6 @@ func TestSpliceLegRefusesUndatedLeg(t *testing.T) {
 	}
 }
 
-// locsAsItems converts spliced locations back into stored-item shape so run
-// grouping can be asserted with the SAME helper the server uses (hubRuns), not
-// a test-local re-implementation of it.
-func locsAsItems(locs []map[string]any) []store.ItineraryItem {
-	out := make([]store.ItineraryItem, len(locs))
-	for i, loc := range locs {
-		it := store.ItineraryItem{Position: int32(i)}
-		it.Name, _ = loc["name"].(string)
-		if s, ok := loc["city"].(string); ok && s != "" {
-			c := s
-			it.City = &c
-		}
-		if s, ok := loc["day_trip_from"].(string); ok && s != "" {
-			h := s
-			it.DayTripFrom = &h
-		}
-		if d, ok := loc["day"].(float64); ok {
-			v := int32(d)
-			it.Day = &v
-		}
-		out[i] = it
-	}
-	return out
-}
-
 // Replacing a city with one the trip ALREADY visits next door merges the two
 // runs — the traveler now spends both stretches there, which is what they
 // asked for. Pinned so it reads as a decision rather than an accident: the
@@ -602,7 +577,8 @@ func TestSpliceLegMergesIntoAnAdjacentSameCity(t *testing.T) {
 	if err != nil {
 		t.Fatalf("spliceLeg: %v", err)
 	}
-	runs := hubRuns(locsAsItems(got.Locations))
+	rits := runItemsOfLocations(got.Locations)
+	runs := hubRuns(rits)
 	var hubs []string
 	for _, r := range runs {
 		hubs = append(hubs, r.Hub)
@@ -612,11 +588,11 @@ func TestSpliceLegMergesIntoAnAdjacentSameCity(t *testing.T) {
 	}
 	// The merged run runs from the old Copenhagen arrival through Oslo's own
 	// move-on day, and Stockholm's boundary day (10) is untouched.
-	lo, hi, ok := dayRange(runs[1].Items)
+	lo, hi, ok := dayRange(runs[1].slice(rits))
 	if !ok || lo != 4 || hi != 10 {
 		t.Fatalf("merged Oslo run spans days %d-%d (ok=%v), want 4-10", lo, hi, ok)
 	}
-	lo, hi, _ = dayRange(runs[2].Items)
+	lo, hi, _ = dayRange(runs[2].slice(rits))
 	if lo != 10 || hi != 12 {
 		t.Fatalf("Stockholm moved: days %d-%d, want 10-12", lo, hi)
 	}


### PR DESCRIPTION
## Summary

**`main` does not compile.** #522 and #523 were each green against their own base and git found no textual conflict — the lane manifest held, and `replace_leg` has zero diff in `itinerary_section.go` / `itinerary_repair.go`. But #522 did not merely *move* `hubRuns`; it generalized it so one classifier could reduce both stored items and submitted payload locations, and `replace_leg` was calling the shape it had before. A **semantic merge conflict**: invisible to git, and caught by nothing because nobody built the two branches merged. Production is unaffected — the deploy job was skipped because the build failed first.

`hubRun` is now a half-open index **range** (`Start`, `End`) into the slice it was computed from, rather than a struct carrying its own `[]store.ItineraryItem`, and `hubRuns` / `dayRange` take `[]runItem`. Seven call sites, all mechanical:

- `spliceLeg` reduces once with `runItemsOfStored` and carries `rits` alongside `runs` — `existing` and `rits` are parallel, so a run's range slices either one. Real items still come from `existing[r.Start:r.End]` rather than round-tripping through `runItem`, which is lossy for this caller.
- `describeLegRuns` and `selectLegRun` take the `runItem` slice their runs index into.
- `dayRange` returns `int` now, so the `int32` conversion goes.
- `len(run.Items)` → `run.len()`.
- The test's local `locsAsItems` helper is **deleted**: `runItemsOfLocations` is main's own reduction for exactly that shape, so the test stops maintaining a private twin of it.

## Run boundaries are unchanged — the part that actually mattered

This was the correctness question, and it resolves cleanly in source rather than by inspection of behaviour alone:

| | split condition | hub value on the run |
|---|---|---|
| before | `!sameHub(prevRun.Hub, hubOfItem(it))` | `hubOfItem(it)` |
| after | `!sameHub(prevRun.Hub, it.Hub)` | `runItemOfStored(it).Hub` |

and `hubOfItem(it)` **is** `keyOfItem(it).Hub`, which is exactly what `runItemOfStored` puts in `.Hub`. Same predicate over the same value, so the ranges map 1:1 onto `existing` in order and `replace_leg`'s span-preservation invariant is untouched. `dayRange` is likewise unchanged in meaning: `runItem.Day` comes from `keyOfItem`, which copies `*it.Day` whenever non-nil with no `>= 1` filter — exactly what the old `dayRange` did over stored rows. Only the return type widened.

## Testing

Everything below run **on top of merged `main`** (`1b0877a`) in a fresh worktree — the combination that was missing.

- `go build ./...`, `go vet ./...`, `gofmt -l` — clean.
- `go test ./...` against a real Postgres — **`ok`, exit 0, 0 failures** (100s; both lanes' integration suites).
- **All 19 existing mutations re-run and still killed by the same tests**, none survived. That is the direct check on the boundary question: had the refactor moved a boundary, a mutation that used to be killed would suddenly survive.
- **Two NEW mutations** for the failure mode the index-range shape introduces, both killed:
  - *take the day span from the whole trip instead of the leg's range* (`dayRange(rits)` instead of `dayRange(run.slice(rits))`) → kills `TestSpliceLegReplacesRunInPlace`, `TestSpliceLegAddressesTheRequestedVisit`, `TestSpliceLegPreservesSpanOnFirstAndLastLegs`, `TestReplaceLegLeavesOtherCitiesUntouched`;
  - *rebuild each surviving run from the head of the list* (`existing[0:r.len()]`) → kills the order and acceptance tests.
- The combined "honour a day the model sent" mutation re-verified separately (its two halves are one guard, so neither kills in isolation): still fails with `days = [1 99], want [4 7]`.
- `TestWholeTripRewriteMovesOtherLegsDates` still reproduces the three-leg date drift on the pre-`replace_leg` path, so the negative acceptance assertion has not gone vacuous under the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/golden-tempo/codesmith/anemos-travel/pr/524"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789850832&installation_model_id=433099&pr_number=524&repository=golden-tempo%2Fanemos-travel&return_to=https%3A%2F%2Fgithub.com%2Fgolden-tempo%2Fanemos-travel%2Fpull%2F524&signature=23d544e38681e326c7b873d5663314a13d71dc8641b9e23b91f71144b30f98cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->