### PR TITLE
feat(home): fade the rails' edges so a cropped card reads as cropped

### DIFF
--- a/src/packages/flutter-app/lib/screens/home_screen.dart
+++ b/src/packages/flutter-app/lib/screens/home_screen.dart
@@ -19,6 +19,7 @@ import '../widgets/account_menu.dart';
 import '../widgets/before_you_go_section.dart';
 import '../widgets/continue_chats_section.dart';
 import '../widgets/continue_trip_hero.dart';
+import '../widgets/fading_edge_scroll.dart';
 import '../widgets/gradient_app_bar.dart';
 import '../widgets/home_inspiration_rail.dart';
 import '../widgets/home_next_step_band.dart';
@@ -536,14 +537,20 @@ class _LocalGuidesRow extends ConsumerWidget {
         const SizedBox(height: AppSpacing.md),
         SizedBox(
           height: 190,
-          child: ListView.separated(
-            scrollDirection: Axis.horizontal,
-            // Room below the cards so their drop shadow isn't clipped by
-            // the horizontal viewport.
-            padding: const EdgeInsets.only(bottom: AppSpacing.sm),
-            itemCount: guides.length,
-            separatorBuilder: (_, __) => const SizedBox(width: AppSpacing.md),
-            itemBuilder: (context, i) => _GuideCard(guide: guides[i]),
+          // Same treatment as the inspiration rail below it — the two sit on
+          // one page at one card rhythm, so a hard cut on this one would
+          // read as a bug beside a faded one.
+          child: FadingEdgeScroll(
+            builder: (context, controller) => ListView.separated(
+              controller: controller,
+              scrollDirection: Axis.horizontal,
+              // Room below the cards so their drop shadow isn't clipped by
+              // the horizontal viewport.
+              padding: const EdgeInsets.only(bottom: AppSpacing.sm),
+              itemCount: guides.length,
+              separatorBuilder: (_, __) => const SizedBox(width: AppSpacing.md),
+              itemBuilder: (context, i) => _GuideCard(guide: guides[i]),
+            ),
           ),
         ),
         const SizedBox(height: AppSpacing.lg),

--- a/src/packages/flutter-app/lib/widgets/fading_edge_scroll.dart
+++ b/src/packages/flutter-app/lib/widgets/fading_edge_scroll.dart
@@ -1,0 +1,183 @@
+import 'package:flutter/material.dart';
+
+import '../theme/spacing.dart';
+
+/// How much of each edge fades, as a fraction of the viewport, leading
+/// first. The whole rule lives here rather than inside the widget's state so
+/// it can be read — and pinned — without rasterizing a gradient: which edge
+/// fades and when is the entire contract.
+///
+/// Zero on an edge that has nothing past it. A rail resting at either end,
+/// or one whose content fits, gets no fade there, because a fade means
+/// "there is more this way" and must not say so when there isn't.
+///
+/// Capped at 0.4 a side so the two can never meet and wash out the middle of
+/// a narrow rail.
+@visibleForTesting
+(double, double) fadingEdgeFractions({
+  required double pixels,
+  required double minExtent,
+  required double maxExtent,
+  required double viewport,
+  required double fadeWidth,
+}) {
+  if (viewport <= 0) return (0, 0);
+  // Sub-pixel slop, so a rail resting exactly at either end doesn't flicker
+  // its fade on a fractional offset.
+  const epsilon = 1.0;
+  final f = (fadeWidth / viewport).clamp(0.0, 0.4);
+  return (
+    pixels > minExtent + epsilon ? f : 0.0,
+    pixels < maxExtent - epsilon ? f : 0.0,
+  );
+}
+
+/// Wraps a scroll view and dissolves whichever edge still has content past
+/// it, so a rail that continues off-screen says so instead of ending on a
+/// hard cut that reads like the last card.
+///
+/// It fades to TRANSPARENT rather than painting a gradient of the page
+/// colour over the content: the page behind shows through, so the effect is
+/// correct in both themes and on any surface the rail is dropped onto,
+/// without the widget having to know which one it is sitting on.
+///
+/// The edges are computed from the scroll position, never assumed. A rail
+/// whose cards all fit fades neither edge; one scrolled to the end stops
+/// fading the end. A permanent trailing fade would promise more to see at
+/// precisely the moment there is none left — the same reason
+/// `BookingFilterBar` listens to its offset rather than painting a constant
+/// gradient.
+///
+/// The mask stays in the tree at every offset and only its GRADIENT changes.
+/// Swapping the [ShaderMask] in and out instead re-parents the scroll view,
+/// which rebuilds it and drops the [ScrollController]'s position — the trap
+/// `BookingFilterBar` documents, and the reason [builder] hands the caller a
+/// controller rather than taking a finished child.
+class FadingEdgeScroll extends StatefulWidget {
+  /// Builds the scroll view, which MUST take the [ScrollController] it is
+  /// handed — the fade is derived from that controller's position.
+  final Widget Function(BuildContext context, ScrollController controller)
+      builder;
+
+  /// How wide each fade runs, in logical pixels. Resolved against the
+  /// viewport at paint time, so a narrow window gets a proportionate hint
+  /// rather than a wash over half its content.
+  final double fadeWidth;
+
+  /// Two ladder steps, and it is the smaller half of that pair that decides
+  /// it: at [AppSpacing.xxl] alone the dissolve over a 230px card is present
+  /// but easy to miss, which is the complaint this widget answers rather
+  /// than a setting of it. Rendered against the real card rhythm at 24 / 32 /
+  /// 56 / 80 — 80 erases the cropped card, 56 reads as cropped.
+  static const double defaultFadeWidth = AppSpacing.xxl + AppSpacing.xl;
+
+  const FadingEdgeScroll({
+    super.key,
+    required this.builder,
+    this.fadeWidth = defaultFadeWidth,
+  });
+
+  @override
+  State<FadingEdgeScroll> createState() => _FadingEdgeScrollState();
+}
+
+class _FadingEdgeScrollState extends State<FadingEdgeScroll> {
+  final ScrollController _controller = ScrollController();
+
+  /// The two fades as fractions of the viewport, leading first. A record, so
+  /// an unchanged pair is structurally equal and the notifier stays quiet —
+  /// this is written on every scroll frame.
+  final ValueNotifier<(double, double)> _edges =
+      ValueNotifier<(double, double)>((0, 0));
+
+  @override
+  void initState() {
+    super.initState();
+    _controller.addListener(_sync);
+    // First layout may land before any notification arrives; without this a
+    // rail that never gets scrolled could sit with no trailing fade, which
+    // is the one state this widget exists to prevent.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) _sync();
+    });
+  }
+
+  @override
+  void dispose() {
+    _controller.removeListener(_sync);
+    _controller.dispose();
+    _edges.dispose();
+    super.dispose();
+  }
+
+  void _sync() {
+    if (!_controller.hasClients) {
+      _edges.value = (0, 0);
+      return;
+    }
+    final p = _controller.position;
+    if (!p.hasContentDimensions || !p.hasViewportDimension) {
+      _edges.value = (0, 0);
+      return;
+    }
+    _edges.value = fadingEdgeFractions(
+      pixels: p.pixels,
+      minExtent: p.minScrollExtent,
+      maxExtent: p.maxScrollExtent,
+      viewport: p.viewportDimension,
+      fadeWidth: widget.fadeWidth,
+    );
+  }
+
+  /// Opaque through the middle, transparent at whichever ends are fading.
+  /// Both lists stay the same length and the stops stay non-decreasing for
+  /// every combination, since [f] is capped below 0.5.
+  static List<Color> _colors(double lead, double trail) => [
+        if (lead > 0) Colors.transparent,
+        Colors.black,
+        Colors.black,
+        if (trail > 0) Colors.transparent,
+      ];
+
+  static List<double> _stops(double lead, double trail) => [
+        0,
+        if (lead > 0) lead,
+        if (trail > 0) 1 - trail,
+        1,
+      ];
+
+  @override
+  Widget build(BuildContext context) {
+    final direction = Directionality.of(context);
+    return NotificationListener<ScrollMetricsNotification>(
+      // Fires when the extent changes WITHOUT a scroll — first layout, a
+      // window resize, a text-scale bump, a rail whose items arrive late.
+      // Listening to the controller alone would leave the trailing fade
+      // missing until the first drag, which is exactly the moment it has
+      // stopped being useful.
+      onNotification: (_) {
+        _sync();
+        return false;
+      },
+      child: ValueListenableBuilder<(double, double)>(
+        valueListenable: _edges,
+        // The scroll view is built ONCE and passed through as `child`, so a
+        // fade change repaints the mask without rebuilding the rail.
+        child: widget.builder(context, _controller),
+        builder: (context, edges, child) {
+          final (lead, trail) = edges;
+          return ShaderMask(
+            blendMode: BlendMode.dstIn,
+            shaderCallback: (rect) => LinearGradient(
+              begin: AlignmentDirectional.centerStart,
+              end: AlignmentDirectional.centerEnd,
+              colors: _colors(lead, trail),
+              stops: _stops(lead, trail),
+            ).createShader(rect, textDirection: direction),
+            child: child,
+          );
+        },
+      ),
+    );
+  }
+}

--- a/src/packages/flutter-app/lib/widgets/home_inspiration_rail.dart
+++ b/src/packages/flutter-app/lib/widgets/home_inspiration_rail.dart
@@ -6,6 +6,7 @@ import '../l10n/l10n.dart';
 import '../providers/suggestions_provider.dart';
 import '../theme/spacing.dart';
 import 'destination_suggestion_card.dart';
+import 'fading_edge_scroll.dart';
 import 'random_suggestions.dart';
 import 'section_header.dart';
 
@@ -51,24 +52,30 @@ class HomeInspirationRail extends StatelessWidget {
               behavior: ScrollConfiguration.of(context).copyWith(
                 dragDevices: PointerDeviceKind.values.toSet(),
               ),
-              child: ListView.separated(
-                scrollDirection: Axis.horizontal,
-                // Room below the cards so their drop shadow isn't clipped by
-                // the horizontal viewport (the guides-row rule).
-                padding: const EdgeInsets.only(bottom: AppSpacing.sm),
-                itemCount: prompts.length,
-                separatorBuilder: (_, __) =>
-                    const SizedBox(width: AppSpacing.md),
-                itemBuilder: (context, i) {
-                  final s = prompts[i];
-                  return DestinationSuggestionCard(
-                    prompt: s.text,
-                    asset: s.asset,
-                    credit: s.credit,
-                    width: _cardWidth,
-                    onTap: () => onPrompt(s.text),
-                  );
-                },
+              // The pool is longer than any window, so the rail always runs
+              // off the edge. Without the fade it ended on a hard cut that
+              // read like the last card rather than a cropped one.
+              child: FadingEdgeScroll(
+                builder: (context, controller) => ListView.separated(
+                  controller: controller,
+                  scrollDirection: Axis.horizontal,
+                  // Room below the cards so their drop shadow isn't clipped
+                  // by the horizontal viewport (the guides-row rule).
+                  padding: const EdgeInsets.only(bottom: AppSpacing.sm),
+                  itemCount: prompts.length,
+                  separatorBuilder: (_, __) =>
+                      const SizedBox(width: AppSpacing.md),
+                  itemBuilder: (context, i) {
+                    final s = prompts[i];
+                    return DestinationSuggestionCard(
+                      prompt: s.text,
+                      asset: s.asset,
+                      credit: s.credit,
+                      width: _cardWidth,
+                      onTap: () => onPrompt(s.text),
+                    );
+                  },
+                ),
               ),
             ),
           ),

--- a/src/packages/flutter-app/test/fading_edge_scroll_test.dart
+++ b/src/packages/flutter-app/test/fading_edge_scroll_test.dart
@@ -1,0 +1,150 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:travel_route_planner/widgets/fading_edge_scroll.dart';
+
+// The contract worth pinning is not "there is a gradient" — it is WHICH edge
+// fades and when. A fade means "there is more this way", so a constant one
+// would promise more at exactly the moment there is none left.
+//
+// That rule is a pure function, tested here directly rather than by
+// rasterizing the mask: `Picture.toImage` never completes under the headless
+// test binding, and a pixel sample would pin the same arithmetic through a
+// much more brittle lens. The widget tests below cover the wiring the pure
+// function can't see — that the controller reaches the scroll view, and that
+// the mask survives the fade engaging.
+
+const double _viewport = 400;
+const double _fade = 56; // 0.14 of the viewport
+
+(double, double) _at(double pixels, {double maxExtent = 600}) =>
+    fadingEdgeFractions(
+      pixels: pixels,
+      minExtent: 0,
+      maxExtent: maxExtent,
+      viewport: _viewport,
+      fadeWidth: _fade,
+    );
+
+Future<ScrollController> _pump(WidgetTester tester,
+    {int items = 8, double itemWidth = 120}) async {
+  await tester.binding.setSurfaceSize(const Size(_viewport, 200));
+  addTearDown(() => tester.binding.setSurfaceSize(null));
+  late ScrollController controller;
+  await tester.pumpWidget(MaterialApp(
+    home: Scaffold(
+      body: SizedBox(
+        height: 100,
+        child: FadingEdgeScroll(
+          fadeWidth: _fade,
+          builder: (context, c) {
+            controller = c;
+            return ListView.builder(
+              controller: c,
+              scrollDirection: Axis.horizontal,
+              itemCount: items,
+              itemBuilder: (_, __) =>
+                  Container(width: itemWidth, color: Colors.black),
+            );
+          },
+        ),
+      ),
+    ),
+  ));
+  await tester.pumpAndSettle();
+  return controller;
+}
+
+void main() {
+  group('which edge fades', () {
+    test('at rest only the far edge fades', () {
+      final (lead, trail) = _at(0);
+      // Nothing has scrolled past the start, so dimming it would hide the
+      // first card for no reason.
+      expect(lead, 0);
+      expect(trail, greaterThan(0));
+    });
+
+    test('mid-scroll both edges fade', () {
+      final (lead, trail) = _at(300);
+      expect(lead, greaterThan(0));
+      expect(trail, greaterThan(0));
+    });
+
+    test('at the end the trailing fade stops promising more', () {
+      final (lead, trail) = _at(600);
+      expect(lead, greaterThan(0));
+      // The regression a constant gradient would reintroduce: the last card
+      // has to reach the edge at full ink.
+      expect(trail, 0);
+    });
+
+    test('content that fits fades neither edge', () {
+      // maxScrollExtent 0 — every card is already on screen.
+      expect(_at(0, maxExtent: 0), (0.0, 0.0));
+    });
+
+    test('a rail resting a fraction off an end does not flicker its fade',
+        () {
+      expect(_at(0.4).$1, 0, reason: 'sub-pixel rest at the start');
+      expect(_at(599.6).$2, 0, reason: 'sub-pixel rest at the end');
+    });
+
+    test('the two fades can never meet in the middle', () {
+      final (lead, trail) = fadingEdgeFractions(
+        pixels: 300,
+        minExtent: 0,
+        maxExtent: 600,
+        viewport: 100,
+        fadeWidth: 10000, // absurd on purpose
+        );
+      expect(lead, 0.4);
+      expect(trail, 0.4);
+      expect(lead + trail, lessThan(1));
+    });
+
+    test('a viewport with no width yields no fade', () {
+      expect(
+        fadingEdgeFractions(
+            pixels: 0,
+            minExtent: 0,
+            maxExtent: 600,
+            viewport: 0,
+            fadeWidth: _fade),
+        (0.0, 0.0),
+      );
+    });
+  });
+
+  testWidgets('the mask is present and the rail takes the controller',
+      (tester) async {
+    final c = await _pump(tester);
+
+    expect(find.byType(ShaderMask), findsOneWidget);
+    expect(c.hasClients, isTrue);
+    expect(c.position.maxScrollExtent, greaterThan(0));
+  });
+
+  testWidgets('the scroll position survives the fade engaging', (tester) async {
+    // The trap BookingFilterBar documents: swapping the mask in and out
+    // re-parents the scroll view, rebuilding it and dropping the position.
+    // The mask has to stay in the tree at every offset.
+    final c = await _pump(tester);
+    c.jumpTo(200);
+    await tester.pumpAndSettle();
+    expect(c.offset, 200);
+    expect(find.byType(ShaderMask), findsOneWidget);
+
+    c.jumpTo(c.position.maxScrollExtent);
+    await tester.pumpAndSettle();
+    expect(c.offset, c.position.maxScrollExtent);
+    expect(find.byType(ShaderMask), findsOneWidget);
+  });
+
+  testWidgets('a rail whose content fits still scrolls nothing and shows all',
+      (tester) async {
+    final c = await _pump(tester, items: 2, itemWidth: 100);
+    expect(c.position.maxScrollExtent, 0);
+    expect(find.byType(ShaderMask), findsOneWidget);
+  });
+}


### PR DESCRIPTION
Home's two carousels ended on a hard vertical cut. A card sliced by the viewport edge looks a lot like a card that simply *ends* there — so "Somewhere new" read as three destinations rather than the head of a pool.

`FadingEdgeScroll` wraps a scroll view and dissolves whichever edge still has content past it. It fades to **transparent** rather than painting a gradient of the page colour over the content, so it's correct in both themes and on any surface without having to know which one it's sitting on.

## The edges are computed, never assumed

| state | leading | trailing |
|---|---|---|
| at rest | — | fades |
| mid-scroll | fades | fades |
| scrolled to the end | fades | **—** |
| content fits | — | — |

A constant trailing gradient would promise more to see at precisely the moment there is none left. `BookingFilterBar` already listens to its offset for the same reason — and it documents the trap this widget had to honour:

> Swapping the ShaderMask in and out re-parents the scroll view, which rebuilds it and drops the ScrollController's position.

So the mask stays in the tree at every offset and only its gradient changes. That's why the widget hands the caller a `ScrollController` through a builder instead of taking a finished child.

## Testing

The rule is a pure function (`fadingEdgeFractions`) rather than state buried in the widget, so *which edge and when* is pinned directly — including the sub-pixel rest case and the clamp that stops the two fades meeting on a narrow rail. Sampling the rasterised mask instead would have pinned the same arithmetic through a much more brittle lens, and hangs anyway: `Picture.toImage` never completes under the headless test binding. Widget tests cover the wiring the pure function can't see.

## Two judgement calls

- **Fade width is 56** — two ladder steps. Rendered against the real card rhythm at 24 / 32 / 56 / 80: at 32 the dissolve over a 230px card is present but easy to miss, which is the complaint rather than a setting of it; 80 erases the cropped card instead of cropping it.
- **Both of Home's rails, not just the one reported.** The guides row sits on the same page at the same card rhythm, so a hard cut there beside a faded one would read as a bug. The landing, atlas, chat and map-chip rails are untouched and can adopt it later.

## Verification

- `flutter test`: **1815 passed, 0 failed** (10 new).
- `dart analyze` clean (3 pre-existing infos in `route_response.dart`, untouched); brand `check.sh` clean on all three touched files.
- **Rendered and inspected** at rest, mid-scroll and scrolled to the end, via a throwaway golden harness with the shipped fonts loaded. Not in this PR — the repo keeps no golden infrastructure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/golden-tempo/codesmith/anemos-travel/pr/526"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789874875&installation_model_id=433099&pr_number=526&repository=golden-tempo%2Fanemos-travel&return_to=https%3A%2F%2Fgithub.com%2Fgolden-tempo%2Fanemos-travel%2Fpull%2F526&signature=3eccd55eb96a6058b155ebb65fcf15741fb7d03c3d972d525cc5556c71346e43"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->