### PR TITLE
feat(share): the share view gets trip detail's city header and real dates

### DIFF
--- a/src/packages/flutter-app/lib/l10n/app_en.arb
+++ b/src/packages/flutter-app/lib/l10n/app_en.arb
@@ -2179,10 +2179,11 @@
   },
   "sharedEmptyTitle": "No places yet",
   "sharedEmptyMessage": "This trip doesn't have an itinerary yet.",
-  "sharedDayN": "Day {day}",
-  "@sharedDayN": {
+  "sharedCityMorePlaces": "+{count} more",
+  "@sharedCityMorePlaces": {
+    "description": "Caps a shared trip's one-line run of place names for a city. Same overflow grammar as citiesMore.",
     "placeholders": {
-      "day": {
+      "count": {
         "type": "int"
       }
     }

--- a/src/packages/flutter-app/lib/l10n/app_es.arb
+++ b/src/packages/flutter-app/lib/l10n/app_es.arb
@@ -911,7 +911,7 @@
   "sharedNoPlacesIn": "No hay lugares fijados en {city}",
   "sharedEmptyTitle": "Aún no hay lugares",
   "sharedEmptyMessage": "Este viaje todavía no tiene itinerario.",
-  "sharedDayN": "Día {day}",
+  "sharedCityMorePlaces": "+{count} más",
   "sharedStays": "Alojamientos",
   "sharedJoinCoPlanner": "Unirme como coplanificador",
   "sharedSaveSeparateCopy": "O guardar una copia aparte",

--- a/src/packages/flutter-app/lib/l10n/app_localizations.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations.dart
@@ -5420,11 +5420,11 @@ abstract class AppLocalizations {
   /// **'This trip doesn\'t have an itinerary yet.'**
   String get sharedEmptyMessage;
 
-  /// No description provided for @sharedDayN.
+  /// Caps a shared trip's one-line run of place names for a city. Same overflow grammar as citiesMore.
   ///
   /// In en, this message translates to:
-  /// **'Day {day}'**
-  String sharedDayN(int day);
+  /// **'+{count} more'**
+  String sharedCityMorePlaces(int count);
 
   /// No description provided for @sharedStays.
   ///

--- a/src/packages/flutter-app/lib/l10n/app_localizations_en.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations_en.dart
@@ -3222,8 +3222,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get sharedEmptyMessage => 'This trip doesn\'t have an itinerary yet.';
 
   @override
-  String sharedDayN(int day) {
-    return 'Day $day';
+  String sharedCityMorePlaces(int count) {
+    return '+$count more';
   }
 
   @override

--- a/src/packages/flutter-app/lib/l10n/app_localizations_es.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations_es.dart
@@ -3241,8 +3241,8 @@ class AppLocalizationsEs extends AppLocalizations {
   String get sharedEmptyMessage => 'Este viaje todavía no tiene itinerario.';
 
   @override
-  String sharedDayN(int day) {
-    return 'Día $day';
+  String sharedCityMorePlaces(int count) {
+    return '+$count más';
   }
 
   @override

--- a/src/packages/flutter-app/lib/screens/shared_trip_screen.dart
+++ b/src/packages/flutter-app/lib/screens/shared_trip_screen.dart
@@ -12,7 +12,9 @@ import '../providers/auth_provider.dart';
 import '../providers/shared_trip_provider.dart';
 import '../providers/shared_with_me_provider.dart';
 import '../providers/trips_provider.dart';
+import '../theme/app_typography.dart';
 import '../theme/spacing.dart';
+import '../utils/date_formats.dart';
 import '../utils/errors.dart';
 import '../utils/leg_ranges.dart';
 import '../utils/trip_days.dart';
@@ -40,6 +42,67 @@ enum SharedLinkKind { share, invite }
 /// definition so a chip can never disagree with the header beneath it.
 String _sharedLegLabel(AppLocalizations l10n, String label) =>
     label == kOtherPlacesLabel ? l10n.sharedPlacesGroup : label;
+
+/// One leg's rendered dates: the formatted range, and a nights label that
+/// carries its OWN leading "· " (see [_legDates]).
+typedef _LegDates = ({String range, String? nights});
+
+/// A leg's date range as this view renders it — the twin of trip detail's
+/// per-leg date chip (`TripDerivation.compute`, trip_detail_derivation.dart).
+/// Both read [visibleLegRanges] and format it identically, so the two surfaces
+/// cannot name the same leg different dates.
+///
+/// Null when the leg has no rendered dates, which is how a **dateless trip**
+/// renders its city names with no range at all: the absence is carried, never
+/// substituted for. There is deliberately no fallback here — a day number or a
+/// guessed date would be this view inventing a fact the trip does not hold.
+_LegDates? _legDates(AppLocalizations l10n, LegRange range) {
+  final start = range.start;
+  final end = range.end;
+  if (start == null || end == null) return null;
+  final nights = nightsBetween(start, end);
+  return (
+    range: formatShortRange(start, end),
+    // `tripLegNights` owns the leading "· ", so a **zero-night** leg drops the
+    // middot structurally rather than through a conditional in a format
+    // string — which is also why the range and the nights stay two Texts at
+    // every render site below, never one interpolated string.
+    nights: nights > 0 ? l10n.tripLegNights(nights) : null,
+  );
+}
+
+/// The date chip's metrics, adopted from trip detail's city header
+/// (`itinerary_tab.dart`) so the two headers measure the same.
+const double _chipIconSize = 14;
+const double _chipIconGap = 4;
+const double _chipInnerGap = 8;
+
+/// Bound for the wide header's date chip. Trip detail sizes its chip to a
+/// per-build width measured across every group so the chips align as columns;
+/// this view has no such column to join — one header, one chip, sized to its
+/// own text — so the shared width buys nothing here and only the pathological
+/// cap carries over: at an extreme text scale the chip stops growing and
+/// ellipsizes instead of pushing the city name off its own row.
+const double _chipMaxWidth = 200;
+
+/// How many place names a city line shows before it caps with "+N more".
+///
+/// A count, not a measured line budget: the number of lines a run of names
+/// occupies depends on the font, and this repo does not let layout be claimed
+/// from anywhere but the running app. Narrow takes the tighter cap for the
+/// reason the design artifact gives — on a phone a dozen names on "one line"
+/// wraps into a paragraph that scans worse than the list it replaced.
+const int _placesCapWide = 6;
+const int _placesCapNarrow = 4;
+
+/// The header's leading pin and the gap after it, adopted from trip detail's
+/// city header. [_pinColumnWidth] is what the places line indents by, so a
+/// city's places hang under its NAME rather than under its pin — an alignment
+/// derived from the two values above it, not a number picked off the spacing
+/// ladder, so it has to move if either of them does.
+const double _pinSize = 18;
+const double _pinGap = 6;
+const double _pinColumnWidth = _pinSize + _pinGap;
 
 /// Public read-only view of a shared trip, reachable at /#/share/<token>
 /// without an account. Signed-in viewers can save a copy to their own trips.
@@ -118,12 +181,28 @@ class _SharedTripBodyState extends ConsumerState<_SharedTripBody> {
 
   /// Groups items by hub city in itinerary order — the same shared [tripLegs]
   /// rule the owner's trip detail uses (day_trip_from ?? city ?? a city
-  /// parsed from the address).
-  List<({String label, List<ItineraryItem> items})> _groups(
-      AppLocalizations l10n) {
+  /// parsed from the address) — each carrying the dates its header renders.
+  ///
+  /// [ranges] is [visibleLegRanges] for this trip, index-aligned with the
+  /// [tripLegs] split by construction: both run that one split over the same
+  /// items, which is the alignment the map chip strip above already rides on.
+  /// The bounds check is belt-and-braces for a caller that ever passes the
+  /// empty list, not a suspicion about the alignment.
+  ///
+  /// Still the only place a group's label is decided, so [kOtherPlacesLabel]
+  /// keeps reaching [_sharedLegLabel] — the section header, the map's
+  /// destination pins and the chip strip all speak that one name, and a header
+  /// that resolved its own label would be the fourth voice.
+  List<({String label, List<ItineraryItem> items, _LegDates? dates})> _groups(
+      AppLocalizations l10n, List<LegRange> ranges) {
+    final legs = tripLegs(_trip.items ?? const <ItineraryItem>[]);
     return [
-      for (final leg in tripLegs(_trip.items ?? const <ItineraryItem>[]))
-        (label: _sharedLegLabel(l10n, leg.label), items: leg.items),
+      for (var i = 0; i < legs.length; i++)
+        (
+          label: _sharedLegLabel(l10n, legs[i].label),
+          items: legs[i].items,
+          dates: i < ranges.length ? _legDates(l10n, ranges[i]) : null,
+        ),
     ];
   }
 
@@ -207,6 +286,11 @@ class _SharedTripBodyState extends ConsumerState<_SharedTripBody> {
     final theme = Theme.of(context);
     final l10n = context.l10n;
     final trip = _trip;
+    // The same width question the map band below already asks, asked once:
+    // narrow is where a city header stacks its dates under the name instead of
+    // carrying them as a chip on the right, which is trip detail's own switch
+    // at this same breakpoint (`_narrow`, trip_detail_screen.dart).
+    final narrow = MediaQuery.sizeOf(context).width < kRailBreakpoint;
     final items = trip.items ?? const <ItineraryItem>[];
     final dates = tripDateRange(trip.startDate, trip.endDate);
     final stays = trip.accommodations ?? const <Accommodation>[];
@@ -229,7 +313,13 @@ class _SharedTripBodyState extends ConsumerState<_SharedTripBody> {
     // view and trip detail name the same leg the same way (leg_ranges.dart:
     // promises about on-screen dates derive from the rendered ranges). The
     // raw ranges above stay the stay-coverage filter's input.
-    final legChips = mapLegChipEntries(l10n, legs, visibleLegRanges(trip),
+    //
+    // Hoisted out of the chip call because the city headers below render these
+    // same ranges: this screen has always COMPUTED them and only ever spent
+    // them on the map's chip strip, so the dates a recipient wanted were one
+    // local away the whole time.
+    final visibleRanges = visibleLegRanges(trip);
+    final legChips = mapLegChipEntries(l10n, legs, visibleRanges,
         labelText: _sharedLegLabel);
     // Legs that would plot something, so unmappable legs get muted chips: a
     // geocoded item in the run, or a geocoded stay on one of its nights —
@@ -317,10 +407,7 @@ class _SharedTripBodyState extends ConsumerState<_SharedTripBody> {
                       child: SizedBox(
                         // Match the trip-detail map band: taller on wide
                         // layouts so the auto-fit can show every pin.
-                        height:
-                            MediaQuery.sizeOf(context).width >= kRailBreakpoint
-                            ? 340
-                            : 240,
+                        height: narrow ? 240 : 340,
                         child: Stack(
                           children: [
                             Positioned.fill(
@@ -374,40 +461,15 @@ class _SharedTripBodyState extends ConsumerState<_SharedTripBody> {
                       message: l10n.sharedEmptyMessage,
                     )
                   else
-                    for (final group in _groups(l10n)) ...[
-                      Padding(
-                        padding: const EdgeInsets.only(
-                            top: AppSpacing.md, bottom: AppSpacing.xs),
-                        // Same header treatment as the Stays section below — one
-                        // type system per screen.
-                        child: SectionHeader(title: group.label),
+                    for (final group in _groups(l10n, visibleRanges)) ...[
+                      SharedCityHeader(
+                        label: group.label,
+                        range: group.dates?.range,
+                        nights: group.dates?.nights,
+                        narrow: narrow,
                       ),
-                      for (final it in group.items)
-                        ListTile(
-                          contentPadding: EdgeInsets.zero,
-                          leading: CircleAvatar(
-                            radius: 14,
-                            backgroundColor: theme.colorScheme.primary
-                                .withValues(alpha: 0.12),
-                            child: Text(
-                              '${it.position + 1}',
-                              style: theme.textTheme.labelSmall
-                                  ?.copyWith(color: theme.colorScheme.primary),
-                            ),
-                          ),
-                          title: Text(it.name),
-                          subtitle:
-                              it.address != null ? Text(it.address!) : null,
-                          trailing: it.day != null
-                              ? Chip(
-                                  label: Text(l10n.sharedDayN(it.day!)),
-                                  visualDensity: VisualDensity.compact,
-                                )
-                              : null,
-                          selected: _selectedPosition == it.position,
-                          onTap: () =>
-                              setState(() => _selectedPosition = it.position),
-                        ),
+                      SharedCityPlacesLine(
+                          items: group.items, narrow: narrow),
                     ],
                   if ((trip.accommodations ?? const []).isNotEmpty) ...[
                     const SizedBox(height: AppSpacing.lg),
@@ -492,6 +554,264 @@ class _SharedTripBodyState extends ConsumerState<_SharedTripBody> {
           ),
         ),
       ],
+    );
+  }
+}
+
+/// A city's header: the primary-tinted pin, the city name in the display
+/// register, and the leg's dates — a chip on the right where there is room,
+/// stacked under the name where there is not.
+///
+/// This is trip detail's city header (`_cityHeader`, `itinerary_tab.dart`)
+/// brought onto this screen, which never got that redesign and still led each
+/// city with a bold sans label. Adopted rather than shared: trip detail's is a
+/// State method wired to that screen's collapse toggle, hover-revealed refine
+/// controls and a chip width measured across every group on the page, and it
+/// resolves its own label through `groupLabelText` — which names the
+/// unresolved-locality run "Other places" where this view deliberately says
+/// "Places" ([_sharedLegLabel]). What is genuinely one rule is already shared
+/// and stays shared: [visibleLegRanges] and `tripLegNights` are the same
+/// derivation on both surfaces, so the two can differ in chrome but never in
+/// what dates they claim.
+///
+/// Public because it is a named part of this screen and the screen's tests
+/// anchor on it — a stable handle for "the city header", rather than walking
+/// widget ancestry to find one, which is how the trip-detail header tests are
+/// pinned and is the more brittle of the two.
+class SharedCityHeader extends StatelessWidget {
+  final String label;
+
+  /// The leg's rendered date range, or null when the trip carries no dates —
+  /// in which case the header renders the city name and nothing else. See
+  /// [_legDates] for why there is no fallback.
+  final String? range;
+
+  /// The nights label, which owns its leading "· ". Kept as a value of its
+  /// own rather than folded into [range] so a zero-night leg drops the middot
+  /// with it, structurally — the two are always rendered as two Texts.
+  final String? nights;
+
+  final bool narrow;
+
+  const SharedCityHeader({
+    super.key,
+    required this.label,
+    required this.range,
+    required this.nights,
+    required this.narrow,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    // Muted, not teal: a leg's dates are a fact about the row, not an action.
+    // With the city name in the display face above, the range reading quietly
+    // is what lets the name be the thing the eye lands on.
+    final chipStyle = theme.textTheme.labelMedium
+        ?.copyWith(color: theme.colorScheme.onSurfaceVariant);
+    final r = range;
+    // Narrow drops the dates OUT of the header row and stacks them under the
+    // name: the chip is rigid, the label's Expanded is the only flex child, so
+    // on a phone row the label absorbs the whole deficit and a city ellipsizes
+    // to "Pra…". Columns are what the chip buys, and a phone has no room to
+    // spend on them.
+    final stack = narrow && r != null;
+    return Padding(
+      // The air goes ABOVE the heading, not below it — whitespace is zero-sum,
+      // and a gap under a title pushes the title away from what it names.
+      padding: const EdgeInsets.only(top: AppSpacing.xl, bottom: AppSpacing.xs),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Padding(
+            // The pin optically centers on the first line of a display-face
+            // name, which sits taller than the 18px glyph.
+            padding: const EdgeInsets.only(top: AppSpacing.xs),
+            child: Icon(Icons.location_on,
+                size: _pinSize, color: theme.colorScheme.primary),
+          ),
+          const SizedBox(width: _pinGap),
+          // The stacked meta line rides INSIDE this Expanded, never as a
+          // second flex child: a sibling Flexible would split the free space
+          // with the label and drag the chip off the right edge.
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(
+                  label,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  // A city is a SECTION HEADING, so it takes the display face
+                  // at the register minted for exactly this — a heading that
+                  // must not inflate into a hero.
+                  style: AppTextStyles.sectionHeading(theme.textTheme),
+                ),
+                if (stack)
+                  _MetaLine(range: r, nights: nights, style: chipStyle),
+              ],
+            ),
+          ),
+          if (r != null && !stack) ...[
+            const SizedBox(width: AppSpacing.sm),
+            MergeSemantics(
+              // One utterance per chip ("Aug 24 – Aug 26 · 2 nights"), the
+              // reading order a single Text would have had.
+              child: ConstrainedBox(
+                constraints: const BoxConstraints(maxWidth: _chipMaxWidth),
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Icon(Icons.event,
+                        size: _chipIconSize,
+                        color: theme.colorScheme.onSurfaceVariant),
+                    const SizedBox(width: _chipIconGap),
+                    // The ONLY flex child in this Row, which is what makes the
+                    // chip shrink-wrap to its text and still not overflow. A
+                    // second Flexible here splits the bounded width EVENLY
+                    // between the two regardless of what either needs, which
+                    // rendered "Aug 24 – Au… · 1 night" — a truncated range
+                    // beside a nights label with room to spare. Caught in the
+                    // browser; a widget test could not have seen it.
+                    Flexible(
+                      child: Text(
+                        r,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: chipStyle,
+                      ),
+                    ),
+                    // Two Texts, never "$range · $nights" — see [_legDates].
+                    if (nights != null) ...[
+                      const SizedBox(width: _chipInnerGap),
+                      ConstrainedBox(
+                        // Intrinsic width, so the nights takes what it needs
+                        // and the range absorbs any deficit. Bounded only for
+                        // the pathological case: at an extreme text scale a
+                        // nights label alone could exceed the whole chip.
+                        constraints: const BoxConstraints(
+                            maxWidth: _chipMaxWidth -
+                                _chipIconSize -
+                                _chipIconGap -
+                                _chipInnerGap),
+                        child: Text(
+                          nights!,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: chipStyle,
+                        ),
+                      ),
+                    ],
+                  ],
+                ),
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+/// The narrow city header's second line: "Aug 24 – Aug 26 · 2 nights".
+///
+/// Carries no calendar icon — the pin beside it already anchors the row, and a
+/// second glyph on a phone is the noise this pass removes. Both parts are
+/// Flexible so an extreme text scale ellipsizes inside the label column
+/// instead of overflowing it.
+class _MetaLine extends StatelessWidget {
+  final String range;
+  final String? nights;
+  final TextStyle? style;
+
+  const _MetaLine(
+      {required this.range, required this.nights, required this.style});
+
+  @override
+  Widget build(BuildContext context) {
+    return MergeSemantics(
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Flexible(
+            child: Text(
+              range,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: style,
+            ),
+          ),
+          // The middot lives in `tripLegNights`, so a zero-night leg loses it
+          // with this whole branch rather than through a format conditional.
+          if (nights != null) ...[
+            const SizedBox(width: AppSpacing.xs),
+            Flexible(
+              child: Text(
+                nights!,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: style,
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+/// One city's places as a single run of names, replacing the per-place rows
+/// this view used to stack under each city.
+///
+/// The separator is "·" and not "|" for a reason that is in the data: a place
+/// name may already carry a pipe — "SOVA | Modern Czech Cuisine" — and a pipe
+/// separator would read as two restaurants. Beyond [_placesCapWide] /
+/// [_placesCapNarrow] names the run caps with "+N more", the same overflow
+/// grammar the travel atlas's `citiesLabel` speaks, so the screen has one way
+/// of saying "and some others" rather than two.
+///
+/// One [Text.rich] rather than a Wrap of chips: names have to be able to wrap
+/// MID-RUN like prose, and the separators have to sit at the muted weight
+/// between them.
+///
+/// Public for the same reason as [SharedCityHeader] — the screen's tests need
+/// a stable handle on "the places under a city".
+class SharedCityPlacesLine extends StatelessWidget {
+  final List<ItineraryItem> items;
+  final bool narrow;
+
+  const SharedCityPlacesLine(
+      {super.key, required this.items, required this.narrow});
+
+  @override
+  Widget build(BuildContext context) {
+    if (items.isEmpty) return const SizedBox.shrink();
+    final theme = Theme.of(context);
+    final l10n = context.l10n;
+    final muted = theme.textTheme.bodyMedium
+        ?.copyWith(color: theme.colorScheme.onSurfaceVariant);
+    final cap = narrow ? _placesCapNarrow : _placesCapWide;
+    final shown = items.length > cap ? items.take(cap).toList() : items;
+    final rest = items.length - shown.length;
+    return Padding(
+      padding: const EdgeInsets.only(
+          left: _pinColumnWidth, bottom: AppSpacing.xs),
+      child: Text.rich(
+        TextSpan(
+          style: theme.textTheme.bodyMedium?.copyWith(height: 1.6),
+          children: [
+            for (var i = 0; i < shown.length; i++) ...[
+              if (i > 0) TextSpan(text: ' · ', style: muted),
+              TextSpan(text: shown[i].name),
+            ],
+            if (rest > 0) ...[
+              TextSpan(text: ' · ', style: muted),
+              TextSpan(text: l10n.sharedCityMorePlaces(rest), style: muted),
+            ],
+          ],
+        ),
+      ),
     );
   }
 }

--- a/src/packages/flutter-app/test/shared_trip_city_header_test.dart
+++ b/src/packages/flutter-app/test/shared_trip_city_header_test.dart
@@ -1,0 +1,355 @@
+// The shared trip view's city header and its one-line run of place names
+// (specs artifact: share-view-calendar-days).
+//
+// **These tests assert structure, presence, ordering and the dateless /
+// zero-night branches — never layout.** This suite installs no
+// `flutter_test_config.dart` and loads no fonts, so every width, line count,
+// wrap point and overflow it could measure would be a fact about Flutter's
+// built-in test font and not about the shipped app. The wide/narrow rendering
+// and the fold of a long places run were verified in the running app at real
+// widths instead, and the assertions that would have pinned them are
+// deliberately absent.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:travel_route_planner/models/itinerary_item.dart';
+import 'package:travel_route_planner/models/shared_trip.dart';
+import 'package:travel_route_planner/models/trip.dart';
+import 'package:travel_route_planner/providers/trips_provider.dart';
+import 'package:travel_route_planner/screens/shared_trip_screen.dart';
+import 'package:travel_route_planner/services/api_client.dart';
+import 'package:travel_route_planner/services/trips_api_service.dart';
+
+import 'support/l10n_test_app.dart';
+
+class _FakeTripsApiService extends TripsApiService {
+  final SharedTrip shared;
+  _FakeTripsApiService(this.shared) : super(ApiClient(baseUrl: 'http://test'));
+
+  @override
+  Future<SharedTrip> getSharedTrip(String token) async => shared;
+}
+
+ItineraryItem _item(int pos, String name, {String? city, String? address}) =>
+    ItineraryItem(
+      id: 'i$pos',
+      position: pos,
+      name: name,
+      latitude: 0,
+      longitude: 0,
+      category: 'attraction',
+      city: city,
+      address: address,
+      // A day number on every item: these tests have to be able to see that
+      // nothing renders "Day N" any more, which needs the data that used to
+      // produce it to still be present.
+      day: pos + 1,
+    );
+
+SharedTrip _shared(
+  List<ItineraryItem> items, {
+  String? startDate = '2026-09-01',
+  String? endDate = '2026-09-05',
+}) =>
+    SharedTrip(
+      ownerName: 'Ann',
+      trip: Trip(
+        id: 't1',
+        title: 'Grand tour',
+        createdAt: '2026-06-01',
+        updatedAt: '2026-06-01',
+        startDate: startDate,
+        endDate: endDate,
+        items: items,
+      ),
+    );
+
+void main() {
+  Future<void> pumpScreen(WidgetTester tester, SharedTrip shared) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          tripsApiServiceProvider
+              .overrideWithValue(_FakeTripsApiService(shared)),
+        ],
+        child: localizedTestApp(home: SharedTripScreen(token: 'tok')),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  /// The rendered text of a city's places run, as one string.
+  String placesTextFor(WidgetTester tester, int index) {
+    final line = tester
+        .widgetList<SharedCityPlacesLine>(find.byType(SharedCityPlacesLine))
+        .toList()[index];
+    // Rebuilt from the widget's own inputs would prove nothing; read what the
+    // element actually painted.
+    final richText = tester.widget<RichText>(
+      find
+          .descendant(
+            of: find.byWidget(line),
+            matching: find.byType(RichText),
+          )
+          .first,
+    );
+    return richText.text.toPlainText();
+  }
+
+  group('the day pills are gone', () {
+    testWidgets('no "Day N" text survives anywhere on the screen',
+        (WidgetTester tester) async {
+      await pumpScreen(
+        tester,
+        _shared([
+          _item(0, 'Louvre', city: 'Paris'),
+          _item(1, 'Orsay', city: 'Paris'),
+        ]),
+      );
+
+      // The items still CARRY day numbers (see [_item]) — nothing renders them.
+      expect(find.textContaining('Day '), findsNothing);
+      // And the numbered circles that shadowed the map's per-CITY pins are
+      // gone with them: no per-place list rows at all.
+      expect(find.byType(ListTile), findsNothing);
+    });
+  });
+
+  group('the city header carries the leg dates', () {
+    testWidgets('a dated trip renders the range, and the nights beside it',
+        (WidgetTester tester) async {
+      await pumpScreen(
+        tester,
+        _shared([
+          _item(0, 'Louvre', city: 'Paris'),
+          _item(1, 'Colosseum', city: 'Rome'),
+        ]),
+      );
+
+      final headers = tester
+          .widgetList<SharedCityHeader>(find.byType(SharedCityHeader))
+          .toList();
+      expect(headers.map((h) => h.label), ['Paris', 'Rome']);
+      // Both legs land inside the trip's own span, so both get a range.
+      expect(headers.every((h) => h.range != null), isTrue);
+      // The nights label owns its leading middot — asserted here so a future
+      // refactor that folds it into the range string fails loudly.
+      for (final h in headers) {
+        if (h.nights != null) expect(h.nights, startsWith('· '));
+      }
+    });
+
+    testWidgets(
+        'a DATELESS trip renders the city name and no range — never a day '
+        'number, never an invented date', (WidgetTester tester) async {
+      await pumpScreen(
+        tester,
+        _shared(
+          [
+            _item(0, 'Louvre', city: 'Paris'),
+            _item(1, 'Colosseum', city: 'Rome'),
+          ],
+          startDate: null,
+          endDate: null,
+        ),
+      );
+
+      final headers = tester
+          .widgetList<SharedCityHeader>(find.byType(SharedCityHeader))
+          .toList();
+      expect(headers.map((h) => h.label), ['Paris', 'Rome']);
+      // The absence is carried, not substituted for.
+      expect(headers.every((h) => h.range == null), isTrue);
+      expect(headers.every((h) => h.nights == null), isTrue);
+      // The city names are still on screen; only the dates are absent.
+      expect(
+        find.descendant(
+          of: find.byType(SharedCityHeader),
+          matching: find.text('Paris'),
+        ),
+        findsOneWidget,
+      );
+      expect(find.textContaining('Day '), findsNothing);
+    });
+
+    testWidgets(
+        'the unresolved-locality run still speaks this view\'s "Places", not '
+        'trip detail\'s "Other places"', (WidgetTester tester) async {
+      await pumpScreen(
+        tester,
+        // No city and no parseable address: falls into the kOtherPlacesLabel
+        // bucket, which this screen renames via _sharedLegLabel. Three
+        // surfaces speak that name and the header must not become a fourth.
+        _shared([_item(0, 'A mystery stop')]),
+      );
+
+      final headers = tester
+          .widgetList<SharedCityHeader>(find.byType(SharedCityHeader))
+          .toList();
+      expect(headers.single.label, 'Places');
+      expect(find.text('Other places'), findsNothing);
+    });
+  });
+
+  group('the zero-night rule is structural', () {
+    // Pinned on the header widget directly rather than through a trip that
+    // collapses a leg: the rule under test is "the middot leaves with the
+    // nights", and the header is where that is decided.
+    testWidgets('nights == null renders the range alone, with no middot',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(localizedTestApp(
+        home: const Scaffold(
+          body: SharedCityHeader(
+            label: 'Naxos',
+            range: 'Sep 3 – Sep 3',
+            nights: null,
+            narrow: false,
+          ),
+        ),
+      ));
+
+      expect(find.text('Sep 3 – Sep 3'), findsOneWidget);
+      // The middot lives in `tripLegNights`; with no nights there is no Text
+      // carrying one, rather than a range string with a dangling separator.
+      expect(find.textContaining('·'), findsNothing);
+    });
+
+    testWidgets('nights present renders as a SECOND Text, not one joined string',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(localizedTestApp(
+        home: const Scaffold(
+          body: SharedCityHeader(
+            label: 'Naxos',
+            range: 'Sep 3 – Sep 6',
+            nights: '· 3 nights',
+            narrow: false,
+          ),
+        ),
+      ));
+
+      // Two Texts, found separately — a joined "$range · $nights" would fail
+      // both of these and pass a single textContaining, which is why the
+      // assertion is spelled this way.
+      expect(find.text('Sep 3 – Sep 6'), findsOneWidget);
+      expect(find.text('· 3 nights'), findsOneWidget);
+    });
+
+    testWidgets('the same two-Text rule holds in the stacked narrow form',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(localizedTestApp(
+        home: const Scaffold(
+          body: SharedCityHeader(
+            label: 'Naxos',
+            range: 'Sep 3 – Sep 6',
+            nights: '· 3 nights',
+            narrow: true,
+          ),
+        ),
+      ));
+
+      expect(find.text('Sep 3 – Sep 6'), findsOneWidget);
+      expect(find.text('· 3 nights'), findsOneWidget);
+      // The stacked form drops the calendar glyph — the pin beside it already
+      // anchors the row.
+      expect(find.byIcon(Icons.event), findsNothing);
+      expect(find.byIcon(Icons.location_on), findsOneWidget);
+    });
+
+    testWidgets('the wide form carries the calendar glyph the stacked one drops',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(localizedTestApp(
+        home: const Scaffold(
+          body: SharedCityHeader(
+            label: 'Naxos',
+            range: 'Sep 3 – Sep 6',
+            nights: '· 3 nights',
+            narrow: false,
+          ),
+        ),
+      ));
+
+      expect(find.byIcon(Icons.event), findsOneWidget);
+    });
+
+    testWidgets('a dateless header renders neither a range nor a glyph',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(localizedTestApp(
+        home: const Scaffold(
+          body: SharedCityHeader(
+            label: 'Naxos',
+            range: null,
+            nights: null,
+            narrow: false,
+          ),
+        ),
+      ));
+
+      expect(find.text('Naxos'), findsOneWidget);
+      expect(find.byIcon(Icons.event), findsNothing);
+    });
+  });
+
+  group('the places run', () {
+    testWidgets('lists a city\'s places in itinerary order, separated by "·"',
+        (WidgetTester tester) async {
+      await pumpScreen(
+        tester,
+        _shared([
+          _item(0, 'Louvre', city: 'Paris'),
+          _item(1, 'Orsay', city: 'Paris'),
+        ]),
+      );
+
+      expect(placesTextFor(tester, 0), 'Louvre · Orsay');
+    });
+
+    testWidgets(
+        'a name that already contains a pipe survives intact — the separator '
+        'is "·" and must never be "|"', (WidgetTester tester) async {
+      await pumpScreen(
+        tester,
+        _shared([
+          _item(0, 'SOVA | Modern Czech Cuisine', city: 'Prague'),
+          _item(1, 'Hemingway Bar', city: 'Prague'),
+        ]),
+      );
+
+      final text = placesTextFor(tester, 0);
+      expect(text, contains('SOVA | Modern Czech Cuisine'));
+      expect(text, 'SOVA | Modern Czech Cuisine · Hemingway Bar');
+    });
+
+    testWidgets('caps a long run with the "+N more" idiom',
+        (WidgetTester tester) async {
+      // Nine places in one city, against the wide cap of six.
+      await pumpScreen(
+        tester,
+        _shared([
+          for (var i = 0; i < 9; i++) _item(i, 'Place $i', city: 'Krakow'),
+        ]),
+      );
+
+      final text = placesTextFor(tester, 0);
+      expect(text, endsWith('+3 more'));
+      // The sixth is shown and the seventh is folded into the count.
+      expect(text, contains('Place 5'));
+      expect(text, isNot(contains('Place 6')));
+    });
+
+    testWidgets('a run at exactly the cap shows every place and no "+N more"',
+        (WidgetTester tester) async {
+      await pumpScreen(
+        tester,
+        _shared([
+          for (var i = 0; i < 6; i++) _item(i, 'Place $i', city: 'Krakow'),
+        ]),
+      );
+
+      final text = placesTextFor(tester, 0);
+      expect(text, contains('Place 5'));
+      expect(text, isNot(contains('more')));
+    });
+  });
+}

--- a/src/packages/flutter-app/test/shared_trip_destination_pins_test.dart
+++ b/src/packages/flutter-app/test/shared_trip_destination_pins_test.dart
@@ -12,7 +12,6 @@ import 'package:travel_route_planner/screens/shared_trip_screen.dart';
 import 'package:travel_route_planner/services/api_client.dart';
 import 'package:travel_route_planner/services/trips_api_service.dart';
 import 'package:travel_route_planner/widgets/map_leg_chips.dart';
-import 'package:travel_route_planner/widgets/section_header.dart';
 
 import 'support/l10n_test_app.dart';
 
@@ -131,7 +130,7 @@ void main() {
     // like the owner's trip detail.
     expect(
       find.descendant(
-        of: find.byType(SectionHeader),
+        of: find.byType(SharedCityHeader),
         matching: find.text('Lyon'),
       ),
       findsOneWidget,
@@ -151,7 +150,7 @@ void main() {
 
     expect(
       find.descendant(
-        of: find.byType(SectionHeader),
+        of: find.byType(SharedCityHeader),
         matching: find.text('Paris'),
       ),
       findsNWidgets(2),


### PR DESCRIPTION
## Summary

The shared trip view (`/#/share/<token>`) never got the trip-detail redesign. It led each city with a small bold sans label and hung a **`Day N`** pill off every row — a recipient saw "Day 1 / Day 3 / Day 6" with no way to turn those into dates, and the gaps read as *missing* rather than as the spine's deliberately empty middle days. Same trip, two visual languages.

Each city now leads with **the pin, the city name, and the leg's date range**, and its places render as **one capped line**.

The dates were already there: `visibleLegRanges(trip)` has been computed on this screen all along to build the map's chip strip, and simply never shown. **No server change, no new payload, no new derivation, no migration.**

### Decisions, not styling

- **The range is a chip on the right where there is room and a stacked second line where there is not**, and the stacked form drops the calendar glyph — the pin already anchors the row, and a second glyph on a phone is noise.
- **The range and the nights stay two `Text`s.** `tripLegNights` owns the leading `"· "`, so a **zero-night** leg drops the middot *structurally* rather than through a conditional in a format string. Never `"$range · $nights"`.
- **A dateless trip renders the city name and no range.** There is deliberately no fallback — a day number or a guessed date would be this view inventing a fact the trip does not hold.
- Long runs cap with **`"+N more"`**, the travel atlas's existing overflow idiom rather than a second overflow grammar.
- The separator is **`·`, not `|`** — a place name may already carry a pipe (*"SOVA | Modern Czech Cuisine"*), which is rendered in the screenshots below.
- `kOtherPlacesLabel` still routes through `_sharedLegLabel`, so the header joins the three surfaces already saying **"Places"** instead of becoming a fourth voice.

### What is removed

- **The `Day N` pills.** Nothing counts days any more, so the gaps stop being visible.
- **The numbered circles.** They were `it.position + 1` — per **place** — while the map's pins are one per **city**. They looked like a cross-reference and were not, so removing them deletes a coincidence rather than a feature.
- **`sharedDayN`** from both `.arb` files. It had exactly one call site.

## Reimplemented rather than extracted — and why

`_cityHeaderLabel` / `_cityHeaderMetaLine` are private to `itinerary_tab.dart`, so this screen cannot call them. **I reimplemented the structure here and did not touch the trip-detail widget set.** Stating that plainly, as the ticket asks.

The honest scope of an extraction is smaller than it looks: trip detail's header is a `State` method wired to that screen's collapse toggle, hover-revealed refine controls and a chip width **measured across every group on the page**, and it resolves its own label through `groupLabelText` — which says *"Other places"* where this view deliberately says *"Places"*. Lifting it would mean parameterising all four away. What is genuinely **one rule is already shared and stays shared**: `visibleLegRanges`, `nightsBetween` and `tripLegNights` are the same derivation on both surfaces, so the two can differ in chrome but never in what dates they claim. My recommendation for a follow-up is in the lane report.

## A bug the tests could not have caught

The first render truncated every range — **"Aug 24 – Au… · 1 night"**, an ellipsized range beside a nights label with room to spare. Two `Flexible` children in a bounded `Row` split the width **evenly regardless of what either needs**. The nights is now intrinsic-width so the range absorbs the deficit, which is what trip detail's measured chip does with `Expanded`. Found in the browser; no widget test in this suite could have seen it.

## Behaviour removed, deliberately

The old per-place rows were **tappable and selected the matching map pin**
(`_selectedPosition`). A one-line run of names cannot carry a >=48px tap target,
so **list -> map pin selection is gone**. Map pin taps still work, and the
selection state is still driven by `onPinTap`. This follows from the ticket's
shape rather than being an oversight, but it is a real removal and should not
have to be inferred from the diff.

## Two decisions made in-lane

- **The overflow cap is a count (6 wide / 4 narrow), not a line budget.** The
  artifact's reason for capping is that a long run "wraps to three or four lines
  of run-on text" -- which is a *line* limit. A line budget cannot be measured
  outside a browser and cannot be asserted in this suite at all, so it would be
  an untestable rule. A count is deterministic; narrow takes the tighter one for
  the artifact's own stated reason. Both widths checked on screen.
- **The wide chip follows trip detail's treatment (calendar glyph + text), not
  the wireframe's bordered pill.** The artifact's prose is explicit -- "copy the
  structure", and the stacked form "drops the calendar glyph", which implies the
  wide form carries one. A pill would be a new treatment trip detail does not
  have, and the brand rulebook would own that decision, not this lane.

## Testing

- `flutter test` — **All tests passed**, exit 0, zero `[E]` markers. Captured to a file and grepped for the verdict, never judged through `tail`.
- 13 new tests in `test/shared_trip_city_header_test.dart` covering the cap, the dateless branch, the zero-night branch, the pipe-in-a-name case, the "Places" routing and the absence of any `Day N`.
- `flutter analyze` clean on the touched files (3 pre-existing infos in `route_response.dart` are untouched).
- `.claude/skills/brand-guidelines/scripts/check.sh` — **clean**.
- `flutter gen-l10n` run last; `l10n_untranslated.json` empty (`{}`). `app_localizations*.dart` regenerated, never hand-edited.

**Layout verified in the running app, never from a widget test.** This suite loads no fonts, so its text metrics are fiction. The new tests assert structure, presence, ordering and the dateless/zero-night branches only — no widths, line counts or overflow — and say so in a header comment.

### A capture trap worth knowing about

**`--window-size=390` silently returns a CROPPED PNG on macOS.** Chrome enforces a minimum window width, so the page lays out WIDER than asked and the image is cut to the requested width -- and the result presents *exactly* as an overflow bug: place names split mid-word at the right edge, text running under the frame. I nearly reported a phantom overflow on a layout that was correct.

The narrow shot is therefore driven through CDP with `Emulation.setDeviceMetricsOverride`, and it **reads `window.innerWidth` back and refuses to write the file if it disagrees** -- a width claim in a report should be one the page itself confirmed. Harness kept alongside the screenshots in the lane artifact.

### Wide (1280px)

Full ranges, no truncation; `SOVA | Modern Czech Cuisine` intact; Kraków capped at six with `+3 more`.

### Narrow (390dp)

Range stacked under the name with no calendar glyph; places wrap and cap at four; nothing overflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/golden-tempo/codesmith/anemos-travel/pr/528"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789875342&installation_model_id=433099&pr_number=528&repository=golden-tempo%2Fanemos-travel&return_to=https%3A%2F%2Fgithub.com%2Fgolden-tempo%2Fanemos-travel%2Fpull%2F528&signature=0c1f9f1ba741201e8493391a590bb43e05684e356b5639934f59c372eae91376"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
