### PR TITLE
fix(trip-detail): city headings rejoin the display register they belong to

### DIFF
--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -45,6 +45,7 @@ import '../services/api_client.dart' show isTransientError;
 import '../services/trip_cache.dart';
 import '../services/trips_api_service.dart' show TripEndpointsException;
 import '../theme/app_colors.dart';
+import '../theme/app_typography.dart';
 import '../theme/spacing.dart';
 import '../utils/calendar_links.dart';
 import '../utils/clothing_recs.dart';

--- a/src/packages/flutter-app/lib/widgets/trip_detail/itinerary_tab.dart
+++ b/src/packages/flutter-app/lib/widgets/trip_detail/itinerary_tab.dart
@@ -376,22 +376,6 @@ extension on _TripDetailScreenState {
   }
 
 
-  /// A city section's heading style: the display face, at a size a PINNED row
-  /// can afford.
-  ///
-  /// Composed from two existing slots rather than written as literals —
-  /// `headlineSmall` contributes the face and its explicit `w500` (the
-  /// display weight; anything the family doesn't ship is faux-bold on web),
-  /// `titleLarge` contributes the size. So a face swap or a scale change in
-  /// `app_theme.dart` still reaches this heading, and no number lives here.
-  ///
-  /// A headline slot outright (30/35/39) is a PAGE title: it owns the top of
-  /// a screen and sets its own rhythm. A city header pins while its days
-  /// scroll under it, so it can't spend that height — this is the step that
-  /// reads editorial while staying chrome.
-  TextStyle? _citySectionStyle(ThemeData theme) => theme.textTheme.headlineSmall
-      ?.copyWith(fontSize: theme.textTheme.titleLarge?.fontSize, height: 1.2);
-
 
   /// City group header: name, date range, refine + collapse controls. Pinned
   /// at the top of the scroll area while its group scrolls past; the opaque
@@ -1057,15 +1041,21 @@ extension on _TripDetailScreenState {
       AppLocalizations l10n, CityGroup group, ThemeData theme,
       {Widget? metaLine}) {
     // The one editorial move on this screen: a city is a SECTION HEADING, so
-    // it takes the display face ([_citySectionStyle]). Bold Inter at
-    // titleSmall made a city name the same object as a booking row's title —
-    // the tab's loudest text was a teal date, and nothing said "a new place
-    // starts here". Sentence case is already the data's own.
+    // it takes the display face. Bold Inter at titleSmall made a city name the
+    // same object as a booking row's title — the tab's loudest text was a teal
+    // date, and nothing said "a new place starts here". Sentence case is
+    // already the data's own.
+    //
+    // [AppTextStyles.sectionHeading] rather than a local composition: this
+    // header used to compose the register inline and had silently drifted off
+    // it, dropping [kDisplayOpticalScale] and rendering a city name at the body
+    // face's number in a face with a much smaller x-height — the exact recess
+    // that constant's dartdoc was written about. The token is the register.
     final label = Text(
       groupLabelText(l10n, group.label),
       maxLines: 1,
       overflow: TextOverflow.ellipsis,
-      style: _citySectionStyle(theme),
+      style: AppTextStyles.sectionHeading(theme.textTheme),
     );
     final qualifier = group.qualifier;
     if (qualifier == null && metaLine == null) return label;


### PR DESCRIPTION
## Summary

`itinerary_tab.dart`'s private `_citySectionStyle` composed the section-heading register inline, and had **drifted off the token minted to end exactly that drift**:

```dart
// _citySectionStyle — the raw slot size
fontSize: theme.textTheme.titleLarge?.fontSize                 // 22

// AppTextStyles.sectionHeading — the same size, optically corrected
fontSize: (titleSize * kDisplayOpticalScale).roundToDouble()   // 28
```

**Every city name in the itinerary tab has been rendering ~21% under its own register.** Cormorant Garamond has a 0.386 em x-height against Inter's 0.546, which is what `kDisplayOpticalScale` (1.295) exists to correct; set at the body face's number, a display-face heading goes recessive.

This deletes the private helper rather than correcting its arithmetic, so there is **one spelling of the register** again.

## Both dartdocs called this in advance

> `kDisplayOpticalScale`: *"Leaving it out is not neutral — on the first Cormorant render a trip's own name lost 17% of its x-height and went recessive at the top of its page."*

> `AppTextStyles.sectionHeading`: *"Minted because it was already being spelled two ways… Same intent, two routes, one already-drifted property — which is the case for a token rather than a third inline composition."*

The token's dartdoc even claims *"the itinerary's city header composed exactly this."* It stopped being true and the sentence stayed.

## How it happened

| Commit | Lane | What it did |
|---|---|---|
| `0b81443` | Cormorant display face | minted the token **with** the correction |
| `8a6043c` | itinerary-tab redesign | composed the register **inline, without** it |

Two lanes, in parallel, over one register. Whichever merged second never reconciled — and **nothing failed**: no test, no lint, no review. The full suite is green both before *and* after this fix, which is exactly why the drift survived. No assertion existed at that altitude, and under the repo's standing rule none should be added: a font-metric assertion in this suite is a claim about the test font.

## The inversion worth noticing

This was found from the share-view lane (#528), which adopted this same header onto the shared trip screen and used the **token**. So as of today **the shared trip screen is correct and the owner's trip detail is not** — the opposite of the complaint that started that ticket, which was that the share view had never received the redesign.

## Why two files

`itinerary_tab.dart` is a `part of '../../screens/trip_detail_screen.dart'` and cannot import for itself, so the `app_typography` import goes in the library head. That is the whole of the second file's diff — one line.

## Testing

- `flutter test` — **All tests passed**, exit 0, zero `[E]` markers, grepped from a file rather than judged through `tail`.
- `flutter analyze` clean (3 pre-existing infos in `route_response.dart`, untouched).
- `check.sh` reports 2 findings, **both pre-existing and neither in this diff** — `itinerary_tab.dart:1554` (`palette-shade`, from `9abd4da`) and `trip_detail_screen.dart:4307` (`radius-literal`, from `d012afa`). This diff touches only lines 48, 378 and 1044–1058.

### Visual verification — before/after, both themes

Captured in the running app at 1280px, signed in, on a three-city trip, using the **stash → reshoot → pop → diff-verify** protocol. The pixel diff is confined to `(243, 665)–(1124, 899)` — the city-header band — in both themes.

Measured honestly: the ink run of the word "Amsterdam", taking the **first contiguous run only**. A naive column scan catches the stay row beneath it, which sits *higher* in the BEFORE frame precisely because the header is shorter, and so reports the change backwards.

| | light | dark |
|---|---|---|
| before | 17px | 17px |
| after | **20px** | **21px** |

Frames are in the epic artifact `city-header-optical-scale/` (`before-after-light.png`, `before-after-dark.png`, plus full-page `full-*` frames). **This grows every city name in trip detail visibly — worth a look before merging rather than after.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/golden-tempo/codesmith/anemos-travel/pr/529"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789876848&installation_model_id=433099&pr_number=529&repository=golden-tempo%2Fanemos-travel&return_to=https%3A%2F%2Fgithub.com%2Fgolden-tempo%2Fanemos-travel%2Fpull%2F529&signature=57b6ecfc9b558ee8618457831bd90ff91925dcb2e9f7d9b905590c9e2b8d4917"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->