### PR TITLE
feat(brand): the logo's blue becomes the app's surfaces

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -110,8 +110,13 @@ glassmorphism as decoration, and the hero-metric template.
 
 ## Colors
 
-One deep-teal spine seeded into the whole Material 3 scheme; warm neutral
-surfaces; accents at chip-and-pin scale only.
+One deep-teal spine seeded into every Material 3 **role**; the wind rose's own
+blue carrying every **surface**; accents at chip-and-pin scale only.
+
+Those are two different jobs and they are deliberately given to two different
+hues. Teal is what you act on — the primary button, selection, the brand's
+signature. Blue is what you act *on top of* — the page, the cards, the sheets.
+Nothing is both.
 
 ### Primary
 - **Aegean Teal** (#00796B): the brand seed (`AppColors.brand`, teal-700). The
@@ -150,23 +155,65 @@ surfaces; accents at chip-and-pin scale only.
   600–700 light) for status strips. "No data" deliberately has no token — it
   takes `outlineVariant` so absence can never read as a severity.
 
-### Neutral
-- Surfaces are the seed-derived M3 neutrals — warm, plaster-leaning; light
-  input fields take **Paper Fill** (#FAFAFA), dark takes
-  `surfaceContainerHighest`.
-- **Map Scrim** (black 60%): the one translucent layer for text and controls
-  over satellite imagery.
+### Surfaces — the two Aegean canvases
+
+Surfaces are **not** the seed-derived M3 neutrals. They are two authored
+ladders, one hue at rising lightness, stated as `AppColors.aegeanNight` and
+`AppColors.aegeanPaper` and selected by `AppColors.canvasFor(brightness)` —
+the one place a theme mode becomes a set of surfaces.
+
+The hue is **205°**, sitting between the mark's own petrol blue
+(`markPetrol` #236684, 198°) and the rebrand's recorded Aegean-night canvas
+(209°). It is the blue the logo is drawn in, not a blue chosen to go with it.
+
+| role | dark (`aegeanNight`) | light (`aegeanPaper`) |
+|---|---|---|
+| `surfaceContainerLowest` | `#091620` | `#FFFFFF` |
+| `surfaceDim` | `#0A1924` | `#CEDFEB` |
+| **`surface`** (page, chrome) | **`#0C1F2C`** | **`#F6F9FB`** |
+| `surfaceContainerLow` | `#0F2738` | `#EFF4F8` |
+| `surfaceContainer` | `#123044` | `#E7F0F5` |
+| **`surfaceContainerHigh`** (cards, menus) | **`#153851`** | **`#E0EBF2`** |
+| `surfaceContainerHighest` | `#1A4361` | `#D9E6EF` |
+| `surfaceBright` | `#205479` | `#F6F9FB` |
+| `onSurface` | `#E3E9ED` | `#101B23` |
+| `onSurfaceVariant` | `#C0CBD3` | `#364754` |
+| `outline` / `outlineVariant` | `#7A8F9F` / `#405564` | `#697D8C` / `#BCC9D2` |
+
+Light input fields take **Paper Fill** (`#F3F7F9`, `AppColors.paperFill`),
+dark takes `surfaceContainerHighest`. **Map Scrim** (black 60%) stays the one
+translucent layer for text and controls over satellite imagery.
+
+Every tone is measured against both inks; the tightest pair in either canvas
+is **4.88:1**, over the 4.5:1 body floor, and `app_theme_surfaces_test.dart`
+re-measures all of them rather than trusting the ladder.
 
 ### Named Rules
 **The Earned Color Rule.** Every non-teal color means exactly one thing and
 appears at chip-and-pin scale, never as a field. Color is never decoration.
+The Aegean canvases are the one thing this rule does not reach — a canvas is
+what colour appears *on*, and its meaning is "surface", which is exactly one
+thing.
 
 **The Gold-in-the-Mark Rule.** Heritage Gold enters a screen only inside the
-wind-rose mark. Anywhere else it is a finding.
+wind-rose mark. Anywhere else it is a finding. Unchanged by the blue: the
+mark's `markBronze` (#D2A24C) is named in `AppColors` so this rule has
+something to point at, never so a widget can reach for it.
 
-**The One Dark Exception Rule.** Midnight Harbor exists only on the signed-out
-landing. Everywhere else, surfaces are the neutral scheme and dark mode is the
-same build with brightness flipped.
+**The Two Canvases Rule.** Every surface in the signed-in app comes from
+`AppColors.canvasFor(brightness)` — dark is Aegean night, light is Aegean
+paper, and they are the same design in two keys rather than one inverted
+into the other. A widget that needs a surface takes a `ColorScheme` role; it
+never mixes its own.
+
+*This replaced the One Dark Exception Rule*, which read: "Midnight Harbor
+exists only on the signed-out landing. Everywhere else, surfaces are the
+neutral scheme and dark mode is the same build with brightness flipped." Two
+of its three clauses are now false — surfaces are authored rather than
+seed-derived, and dark is composed rather than flipped. Midnight Harbor is
+still the landing's own canvas and still ends at sign-in, but it is now a
+*green*-black sitting in front of a blue app, which is a real inconsistency
+and an open follow-up, not a rule.
 
 ## Typography
 

--- a/docs/branding/brand-guidelines.html
+++ b/docs/branding/brand-guidelines.html
@@ -501,7 +501,7 @@
           <circle r="34" fill="#FFFFFF" stroke="#004D40" stroke-width="13"/>
         </g>
       </svg>
-      <p class="cap"><b>Dark cut — mark.svg</b>Neutral page surfaces and scrimmed imagery: auth screen, nav rail, favicon.</p>
+      <p class="cap"><b>Dark cut — mark.svg</b>Aegean page surfaces and scrimmed imagery: auth screen, nav rail, favicon.</p>
     </div>
     <div class="cut on-grad">
       <svg viewBox="0 0 540 540" aria-hidden="true">
@@ -642,7 +642,7 @@
 
   <div class="keep">
   <h3>The landing dark canvas</h3>
-  <p class="small muted" style="margin-bottom:14px">The signed-out landing page is the <strong>one sanctioned exception</strong> to "surfaces stay neutral": it commits to a dark brand look in both theme modes, on a teal-derived field of its own. The exception ends at sign-in — no in-app surface may adopt this family. Tokens in <code>app_colors.dart</code> (the landing family).</p>
+  <p class="small muted" style="margin-bottom:14px">The signed-out landing page is the <strong>one sanctioned exception</strong> to the two Aegean canvases: it commits to a dark brand look in both theme modes, on a teal-derived field of its own. The exception ends at sign-in — no in-app surface may adopt this family. Tokens in <code>app_colors.dart</code> (the landing family).</p>
   <div class="swatchcards">
     <div class="sw">
       <div class="chip" style="background:#00231D"></div>
@@ -695,8 +695,20 @@
     <span class="accent"><i style="background:#455A64"></i>parking <code>#455A64</code></span>
   </div>
 
+  <h3>The two Aegean canvases <span class="small muted">— new in v1.6</span></h3>
+  <p><strong>Surfaces are no longer neutral, and they are no longer seed-derived.</strong> They come from the wind rose's own blue, authored as two ladders — <code>AppColors.aegeanNight</code> (dark) and <code>AppColors.aegeanPaper</code> (light) — selected by <code>AppColors.canvasFor(brightness)</code>, the one place a theme mode becomes a set of surfaces.</p>
+  <p class="small muted">The hue is <b>205°</b>, between the mark's petrol blue (<code>markPetrol</code> #236684, 198°) and the rebrand's recorded Aegean-night canvas (209°). It is the blue the logo is drawn in, not a blue picked to go beside it. The neutrals it replaced were never neutral either: teal-seeded dark surfaces came out at <code>#0E1513</code>, a near-black with a green cast too weak to name. The idea is unchanged — surfaces carry the brand's hue quietly — only the hue is, and the chroma it is allowed.</p>
+
+  <div class="gradband" style="background:linear-gradient(90deg,#091620,#0C1F2C 22%,#0F2738 40%,#123044 58%,#153851 76%,#1A4361 92%,#205479);color:#E3E9ED">aegeanNight · lowest #091620 · <b>surface #0C1F2C</b> · low #0F2738 · container #123044 · <b>high #153851 (cards)</b> · highest #1A4361 · bright #205479</div>
+  <div class="gradband" style="background:linear-gradient(90deg,#FFFFFF,#F6F9FB 22%,#EFF4F8 45%,#E7F0F5 62%,#E0EBF2 80%,#D9E6EF);color:#101B23">aegeanPaper · lowest #FFFFFF · <b>surface #F6F9FB</b> · low #EFF4F8 · container #E7F0F5 · <b>high #E0EBF2 (cards)</b> · highest #D9E6EF</div>
+
+  <p class="small muted" style="margin-top:12px">Inks: dark <code>onSurface #E3E9ED</code> / <code>onSurfaceVariant #C0CBD3</code>; light <code>#101B23</code> / <code>#364754</code>. Hairlines: dark <code>outlineVariant #405564</code>, light <code>#BCC9D2</code>. Light input fields take <b>Paper Fill <code>#F3F7F9</code></b> — cooled onto the canvas, because the old warm <code>#FAFAFA</code> read as a smudge once the fields around it went cool. Every tone is measured against both inks; the tightest pair in either canvas is <b>4.88 : 1</b>, and <code>app_theme_surfaces_test.dart</code> re-measures all sixteen rather than trusting the ladder.</p>
+
+  <p><strong>Two hues, two jobs, no overlap.</strong> Teal still seeds every Material <em>role</em> — primary, secondary, error and their <code>on</code> pairs — so the action colour is untouched. Blue owns every <em>surface</em>. Teal is what you act <em>with</em>; blue is what you act <em>on top of</em>. A filled teal button is easier to find on Aegean night than it was on grey, which is the check that says the split is working.</p>
+
   <h3>Proportion</h3>
-  <p>Surfaces stay neutral — white cards on quiet ground, warm where the direction section leads, <b>chrome included since v1.4</b>: the app bar is flat surface under a hairline in both themes, and the brand rides in the wordmark's ink (brandDark on light, scheme primary on dark), the rose, typography, and imagery. Teal as a fill is the primary action — the one filled button that matters on a screen. Gold belongs to the mark. Tool accents and status colors appear at chip-and-pin scale, never as fields. Both themes are seeded from the same <code>brand</code>; dark mode is the same build with brightness flipped, chrome included.</p>
+  <p>Cards sit a rung above their page on an authored ladder, <b>chrome included since v1.4</b>: the app bar is flat surface under a hairline in both themes, and the brand rides in the wordmark's ink (brandDark on light, scheme primary on dark), the rose, typography, and imagery. Teal as a fill is the primary action — the one filled button that matters on a screen. Gold belongs to the mark. Tool accents and status colors appear at chip-and-pin scale, never as fields. Both themes take their roles from the same <code>brand</code> seed; <b>dark mode is no longer the light build with brightness flipped</b> — the two canvases are composed separately, one design in two keys.</p>
+  <p class="small muted"><b>Superseded in v1.6:</b> "Surfaces stay neutral — white cards on quiet ground, warm where the direction section leads" and "dark mode is the same build with brightness flipped." Both were true of a seed-derived scheme and are not true of an authored one. The <b>warm-plaster</b> direction on the market page above is likewise now cool plaster — the register (quiet ground, photography carries the heat) survives the temperature change; the swatches there do not.</p>
 
   <div class="keep">
   <h3>Contrast, measured</h3>
@@ -898,7 +910,7 @@
       </svg>
       <span class="w">ANEMOS</span>
     </div>
-    <div class="small" style="text-align:right">Brand guidelines · v1.5 · August 2026<br>Maintained in <code style="background:rgba(255,255,255,0.12);color:#B2DFDB">docs/branding</code></div>
+    <div class="small" style="text-align:right">Brand guidelines · v1.6 · August 2026<br>Maintained in <code style="background:rgba(255,255,255,0.12);color:#B2DFDB">docs/branding</code></div>
   </div>
 </footer>
 

--- a/src/packages/flutter-app/lib/screens/home_screen.dart
+++ b/src/packages/flutter-app/lib/screens/home_screen.dart
@@ -19,6 +19,7 @@ import '../widgets/account_menu.dart';
 import '../widgets/before_you_go_section.dart';
 import '../widgets/continue_chats_section.dart';
 import '../widgets/continue_trip_hero.dart';
+import '../widgets/fading_edge_scroll.dart';
 import '../widgets/gradient_app_bar.dart';
 import '../widgets/home_inspiration_rail.dart';
 import '../widgets/home_next_step_band.dart';
@@ -536,14 +537,20 @@ class _LocalGuidesRow extends ConsumerWidget {
         const SizedBox(height: AppSpacing.md),
         SizedBox(
           height: 190,
-          child: ListView.separated(
-            scrollDirection: Axis.horizontal,
-            // Room below the cards so their drop shadow isn't clipped by
-            // the horizontal viewport.
-            padding: const EdgeInsets.only(bottom: AppSpacing.sm),
-            itemCount: guides.length,
-            separatorBuilder: (_, __) => const SizedBox(width: AppSpacing.md),
-            itemBuilder: (context, i) => _GuideCard(guide: guides[i]),
+          // Same treatment as the inspiration rail below it — the two sit on
+          // one page at one card rhythm, so a hard cut on this one would
+          // read as a bug beside a faded one.
+          child: FadingEdgeScroll(
+            builder: (context, controller) => ListView.separated(
+              controller: controller,
+              scrollDirection: Axis.horizontal,
+              // Room below the cards so their drop shadow isn't clipped by
+              // the horizontal viewport.
+              padding: const EdgeInsets.only(bottom: AppSpacing.sm),
+              itemCount: guides.length,
+              separatorBuilder: (_, __) => const SizedBox(width: AppSpacing.md),
+              itemBuilder: (context, i) => _GuideCard(guide: guides[i]),
+            ),
           ),
         ),
         const SizedBox(height: AppSpacing.lg),

--- a/src/packages/flutter-app/lib/theme/app_colors.dart
+++ b/src/packages/flutter-app/lib/theme/app_colors.dart
@@ -1,5 +1,28 @@
 import 'package:flutter/material.dart';
 
+/// One canvas: the eight Material surface tones, plus the two inks and two
+/// hairlines that sit on them. A theme mode picks a canvas; nothing else
+/// chooses a surface colour.
+///
+/// It exists as a record rather than sixteen loose constants because the
+/// tones are only meaningful as a LADDER — the interval between rungs is
+/// what makes a card read as raised, so a rung can't be re-tuned in
+/// isolation.
+typedef SurfaceCanvas = ({
+  Color surface,
+  Color surfaceDim,
+  Color surfaceBright,
+  Color containerLowest,
+  Color containerLow,
+  Color container,
+  Color containerHigh,
+  Color containerHighest,
+  Color onSurface,
+  Color onSurfaceVariant,
+  Color outline,
+  Color outlineVariant,
+});
+
 /// Brand and category colors in one place. The teal family is the spine of the
 /// app (the Material 3 scheme is seeded from `Colors.teal.shade700`); the
 /// gradients below are the exact pair the app bar, hero, and recent-trip card
@@ -7,6 +30,84 @@ import 'package:flutter/material.dart';
 abstract final class AppColors {
   // Brand teal ramp.
   static final Color brand = Colors.teal.shade700;
+
+  // ---- The wind rose's own two colours ----
+  // Named because they are the source the surface canvases below are derived
+  // from, and because "the blues in the logo" had no token at all until now:
+  // the mark shipped in the rebrand, the app kept a teal-seeded grey world,
+  // and the two identities never met on a screen.
+
+  /// The mark's petrol blue — its bezel ring, the ticks, the needle. 45 of
+  /// the drawing's 51 paths. Hue 198°.
+  static const Color markPetrol = Color(0xFF236684);
+
+  /// The mark's sun-bronze rose. Lives INSIDE the mark and nowhere else (the
+  /// Gold-in-the-Mark rule) — named here so the guideline has something to
+  /// point at, not so widgets can reach for it.
+  static const Color markBronze = Color(0xFFD2A24C);
+
+  // ---- Surface canvases ----
+  // Both ladders are one hue (205°, between the mark's ring at 198° and the
+  // rebrand's recorded Aegean-night canvas at 209°) at rising lightness.
+  //
+  // These REPLACE the seed-derived M3 neutrals. That is a deliberate break
+  // with "surfaces are the seed-derived neutrals, warm, plaster-leaning" —
+  // DESIGN.md carries the rewritten rule. The neutrals were never actually
+  // neutral: teal-seeded dark surfaces came out at #0E1513, a near-black
+  // with a green cast too weak to name. This keeps the idea (surfaces carry
+  // the brand's hue quietly) and changes the hue to the one the logo
+  // actually uses, at a chroma that can be seen.
+  //
+  // Every tone is measured against both inks: the tightest pair in either
+  // canvas is 4.88:1, over the 4.5:1 body-text floor, and
+  // `app_theme_surfaces_test.dart` re-measures all of them.
+
+  /// Dark mode. `surface` is Aegean night — the field the mark already
+  /// stands on in the brand assets, to within two points of the hex the
+  /// rebrand recorded for it.
+  static const SurfaceCanvas aegeanNight = (
+    surface: Color(0xFF0C1F2C),
+    surfaceDim: Color(0xFF0A1924),
+    surfaceBright: Color(0xFF205479),
+    containerLowest: Color(0xFF091620),
+    containerLow: Color(0xFF0F2738),
+    container: Color(0xFF123044),
+    containerHigh: Color(0xFF153851),
+    containerHighest: Color(0xFF1A4361),
+    onSurface: Color(0xFFE3E9ED),
+    onSurfaceVariant: Color(0xFFC0CBD3),
+    outline: Color(0xFF7A8F9F),
+    outlineVariant: Color(0xFF405564),
+  );
+
+  /// Light mode. The same hue at a fraction of the chroma — near white, high
+  /// chroma reads as a colour rather than a cast, so the ladder holds the
+  /// hue and lets it go. This is the "sun-bleached plaster" register moved
+  /// from warm to cool, not a blue page.
+  static const SurfaceCanvas aegeanPaper = (
+    surface: Color(0xFFF6F9FB),
+    surfaceDim: Color(0xFFCEDFEB),
+    surfaceBright: Color(0xFFF6F9FB),
+    containerLowest: Color(0xFFFFFFFF),
+    containerLow: Color(0xFFEFF4F8),
+    container: Color(0xFFE7F0F5),
+    containerHigh: Color(0xFFE0EBF2),
+    containerHighest: Color(0xFFD9E6EF),
+    onSurface: Color(0xFF101B23),
+    onSurfaceVariant: Color(0xFF364754),
+    outline: Color(0xFF697D8C),
+    outlineVariant: Color(0xFFBCC9D2),
+  );
+
+  /// The canvas for [brightness] — the ONE place a theme mode turns into a
+  /// set of surfaces.
+  static SurfaceCanvas canvasFor(Brightness brightness) =>
+      brightness == Brightness.dark ? aegeanNight : aegeanPaper;
+
+  /// Light-mode input fill: paper, cooled onto the canvas's hue. It was
+  /// `Colors.grey[50]` (#FAFAFA), which read as a warm smudge once the
+  /// fields around it went cool.
+  static const Color paperFill = Color(0xFFF3F7F9);
   static final Color brandLight = Colors.teal.shade600;
   static final Color brandDark = Colors.teal.shade900;
   static final Color brandTint = Colors.teal.shade50;

--- a/src/packages/flutter-app/lib/theme/app_theme.dart
+++ b/src/packages/flutter-app/lib/theme/app_theme.dart
@@ -13,9 +13,39 @@ abstract final class AppTheme {
 
   static ThemeData _build(Brightness brightness) {
     final isDark = brightness == Brightness.dark;
+    // Teal still seeds every ROLE — primary, secondary, error, and their
+    // `on` pairs — so the action colour and the brand spine are unchanged.
+    // What the seed no longer decides is the CANVAS: M3 strips almost all
+    // the chroma out of its neutrals, which left dark mode at #0E1513, a
+    // near-black carrying a green cast too weak to read as anything but
+    // grey. The surfaces now come from the wind rose's own blue instead,
+    // stated as a ladder in AppColors (specs/aegean-surfaces).
+    final canvas = AppColors.canvasFor(brightness);
     final colorScheme = ColorScheme.fromSeed(
       seedColor: AppColors.brand, // Teal theme (matches the home banner)
       brightness: brightness,
+    ).copyWith(
+      surface: canvas.surface,
+      surfaceDim: canvas.surfaceDim,
+      surfaceBright: canvas.surfaceBright,
+      surfaceContainerLowest: canvas.containerLowest,
+      surfaceContainerLow: canvas.containerLow,
+      surfaceContainer: canvas.container,
+      surfaceContainerHigh: canvas.containerHigh,
+      surfaceContainerHighest: canvas.containerHighest,
+      onSurface: canvas.onSurface,
+      onSurfaceVariant: canvas.onSurfaceVariant,
+      outline: canvas.outline,
+      outlineVariant: canvas.outlineVariant,
+      // The inverse pair is a SnackBar's field: it has to be the other
+      // canvas, or a toast in dark mode lands on a light green-grey that
+      // belongs to neither.
+      inverseSurface: isDark
+          ? AppColors.aegeanPaper.onSurface
+          : AppColors.aegeanNight.surface,
+      onInverseSurface: isDark
+          ? AppColors.aegeanPaper.surface
+          : AppColors.aegeanNight.onSurface,
     );
 
     // Inter as the app-wide UI font (Cormorant Garamond carries the wordmark
@@ -163,10 +193,13 @@ abstract final class AppTheme {
       inputDecorationTheme: InputDecorationTheme(
         border: const OutlineInputBorder(borderRadius: AppRadius.smAll),
         filled: true,
-        // grey[50] reads as paper in light but would glow on a dark surface;
-        // dark takes the M3 filled-field container instead.
-        fillColor:
-            isDark ? colorScheme.surfaceContainerHighest : Colors.grey[50],
+        // Paper reads as a recessed field in light but would glow on a dark
+        // surface; dark takes the filled-field container instead. It was
+        // grey[50] until the canvas went cool, at which point a warm smudge
+        // sat inside every cool field.
+        fillColor: isDark
+            ? colorScheme.surfaceContainerHighest
+            : AppColors.paperFill,
       ),
       elevatedButtonTheme: ElevatedButtonThemeData(
         style: ElevatedButton.styleFrom(

--- a/src/packages/flutter-app/lib/widgets/fading_edge_scroll.dart
+++ b/src/packages/flutter-app/lib/widgets/fading_edge_scroll.dart
@@ -1,0 +1,183 @@
+import 'package:flutter/material.dart';
+
+import '../theme/spacing.dart';
+
+/// How much of each edge fades, as a fraction of the viewport, leading
+/// first. The whole rule lives here rather than inside the widget's state so
+/// it can be read — and pinned — without rasterizing a gradient: which edge
+/// fades and when is the entire contract.
+///
+/// Zero on an edge that has nothing past it. A rail resting at either end,
+/// or one whose content fits, gets no fade there, because a fade means
+/// "there is more this way" and must not say so when there isn't.
+///
+/// Capped at 0.4 a side so the two can never meet and wash out the middle of
+/// a narrow rail.
+@visibleForTesting
+(double, double) fadingEdgeFractions({
+  required double pixels,
+  required double minExtent,
+  required double maxExtent,
+  required double viewport,
+  required double fadeWidth,
+}) {
+  if (viewport <= 0) return (0, 0);
+  // Sub-pixel slop, so a rail resting exactly at either end doesn't flicker
+  // its fade on a fractional offset.
+  const epsilon = 1.0;
+  final f = (fadeWidth / viewport).clamp(0.0, 0.4);
+  return (
+    pixels > minExtent + epsilon ? f : 0.0,
+    pixels < maxExtent - epsilon ? f : 0.0,
+  );
+}
+
+/// Wraps a scroll view and dissolves whichever edge still has content past
+/// it, so a rail that continues off-screen says so instead of ending on a
+/// hard cut that reads like the last card.
+///
+/// It fades to TRANSPARENT rather than painting a gradient of the page
+/// colour over the content: the page behind shows through, so the effect is
+/// correct in both themes and on any surface the rail is dropped onto,
+/// without the widget having to know which one it is sitting on.
+///
+/// The edges are computed from the scroll position, never assumed. A rail
+/// whose cards all fit fades neither edge; one scrolled to the end stops
+/// fading the end. A permanent trailing fade would promise more to see at
+/// precisely the moment there is none left — the same reason
+/// `BookingFilterBar` listens to its offset rather than painting a constant
+/// gradient.
+///
+/// The mask stays in the tree at every offset and only its GRADIENT changes.
+/// Swapping the [ShaderMask] in and out instead re-parents the scroll view,
+/// which rebuilds it and drops the [ScrollController]'s position — the trap
+/// `BookingFilterBar` documents, and the reason [builder] hands the caller a
+/// controller rather than taking a finished child.
+class FadingEdgeScroll extends StatefulWidget {
+  /// Builds the scroll view, which MUST take the [ScrollController] it is
+  /// handed — the fade is derived from that controller's position.
+  final Widget Function(BuildContext context, ScrollController controller)
+      builder;
+
+  /// How wide each fade runs, in logical pixels. Resolved against the
+  /// viewport at paint time, so a narrow window gets a proportionate hint
+  /// rather than a wash over half its content.
+  final double fadeWidth;
+
+  /// Two ladder steps, and it is the smaller half of that pair that decides
+  /// it: at [AppSpacing.xxl] alone the dissolve over a 230px card is present
+  /// but easy to miss, which is the complaint this widget answers rather
+  /// than a setting of it. Rendered against the real card rhythm at 24 / 32 /
+  /// 56 / 80 — 80 erases the cropped card, 56 reads as cropped.
+  static const double defaultFadeWidth = AppSpacing.xxl + AppSpacing.xl;
+
+  const FadingEdgeScroll({
+    super.key,
+    required this.builder,
+    this.fadeWidth = defaultFadeWidth,
+  });
+
+  @override
+  State<FadingEdgeScroll> createState() => _FadingEdgeScrollState();
+}
+
+class _FadingEdgeScrollState extends State<FadingEdgeScroll> {
+  final ScrollController _controller = ScrollController();
+
+  /// The two fades as fractions of the viewport, leading first. A record, so
+  /// an unchanged pair is structurally equal and the notifier stays quiet —
+  /// this is written on every scroll frame.
+  final ValueNotifier<(double, double)> _edges =
+      ValueNotifier<(double, double)>((0, 0));
+
+  @override
+  void initState() {
+    super.initState();
+    _controller.addListener(_sync);
+    // First layout may land before any notification arrives; without this a
+    // rail that never gets scrolled could sit with no trailing fade, which
+    // is the one state this widget exists to prevent.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) _sync();
+    });
+  }
+
+  @override
+  void dispose() {
+    _controller.removeListener(_sync);
+    _controller.dispose();
+    _edges.dispose();
+    super.dispose();
+  }
+
+  void _sync() {
+    if (!_controller.hasClients) {
+      _edges.value = (0, 0);
+      return;
+    }
+    final p = _controller.position;
+    if (!p.hasContentDimensions || !p.hasViewportDimension) {
+      _edges.value = (0, 0);
+      return;
+    }
+    _edges.value = fadingEdgeFractions(
+      pixels: p.pixels,
+      minExtent: p.minScrollExtent,
+      maxExtent: p.maxScrollExtent,
+      viewport: p.viewportDimension,
+      fadeWidth: widget.fadeWidth,
+    );
+  }
+
+  /// Opaque through the middle, transparent at whichever ends are fading.
+  /// Both lists stay the same length and the stops stay non-decreasing for
+  /// every combination, since [f] is capped below 0.5.
+  static List<Color> _colors(double lead, double trail) => [
+        if (lead > 0) Colors.transparent,
+        Colors.black,
+        Colors.black,
+        if (trail > 0) Colors.transparent,
+      ];
+
+  static List<double> _stops(double lead, double trail) => [
+        0,
+        if (lead > 0) lead,
+        if (trail > 0) 1 - trail,
+        1,
+      ];
+
+  @override
+  Widget build(BuildContext context) {
+    final direction = Directionality.of(context);
+    return NotificationListener<ScrollMetricsNotification>(
+      // Fires when the extent changes WITHOUT a scroll — first layout, a
+      // window resize, a text-scale bump, a rail whose items arrive late.
+      // Listening to the controller alone would leave the trailing fade
+      // missing until the first drag, which is exactly the moment it has
+      // stopped being useful.
+      onNotification: (_) {
+        _sync();
+        return false;
+      },
+      child: ValueListenableBuilder<(double, double)>(
+        valueListenable: _edges,
+        // The scroll view is built ONCE and passed through as `child`, so a
+        // fade change repaints the mask without rebuilding the rail.
+        child: widget.builder(context, _controller),
+        builder: (context, edges, child) {
+          final (lead, trail) = edges;
+          return ShaderMask(
+            blendMode: BlendMode.dstIn,
+            shaderCallback: (rect) => LinearGradient(
+              begin: AlignmentDirectional.centerStart,
+              end: AlignmentDirectional.centerEnd,
+              colors: _colors(lead, trail),
+              stops: _stops(lead, trail),
+            ).createShader(rect, textDirection: direction),
+            child: child,
+          );
+        },
+      ),
+    );
+  }
+}

--- a/src/packages/flutter-app/lib/widgets/home_inspiration_rail.dart
+++ b/src/packages/flutter-app/lib/widgets/home_inspiration_rail.dart
@@ -6,6 +6,7 @@ import '../l10n/l10n.dart';
 import '../providers/suggestions_provider.dart';
 import '../theme/spacing.dart';
 import 'destination_suggestion_card.dart';
+import 'fading_edge_scroll.dart';
 import 'random_suggestions.dart';
 import 'section_header.dart';
 
@@ -51,24 +52,30 @@ class HomeInspirationRail extends StatelessWidget {
               behavior: ScrollConfiguration.of(context).copyWith(
                 dragDevices: PointerDeviceKind.values.toSet(),
               ),
-              child: ListView.separated(
-                scrollDirection: Axis.horizontal,
-                // Room below the cards so their drop shadow isn't clipped by
-                // the horizontal viewport (the guides-row rule).
-                padding: const EdgeInsets.only(bottom: AppSpacing.sm),
-                itemCount: prompts.length,
-                separatorBuilder: (_, __) =>
-                    const SizedBox(width: AppSpacing.md),
-                itemBuilder: (context, i) {
-                  final s = prompts[i];
-                  return DestinationSuggestionCard(
-                    prompt: s.text,
-                    asset: s.asset,
-                    credit: s.credit,
-                    width: _cardWidth,
-                    onTap: () => onPrompt(s.text),
-                  );
-                },
+              // The pool is longer than any window, so the rail always runs
+              // off the edge. Without the fade it ended on a hard cut that
+              // read like the last card rather than a cropped one.
+              child: FadingEdgeScroll(
+                builder: (context, controller) => ListView.separated(
+                  controller: controller,
+                  scrollDirection: Axis.horizontal,
+                  // Room below the cards so their drop shadow isn't clipped
+                  // by the horizontal viewport (the guides-row rule).
+                  padding: const EdgeInsets.only(bottom: AppSpacing.sm),
+                  itemCount: prompts.length,
+                  separatorBuilder: (_, __) =>
+                      const SizedBox(width: AppSpacing.md),
+                  itemBuilder: (context, i) {
+                    final s = prompts[i];
+                    return DestinationSuggestionCard(
+                      prompt: s.text,
+                      asset: s.asset,
+                      credit: s.credit,
+                      width: _cardWidth,
+                      onTap: () => onPrompt(s.text),
+                    );
+                  },
+                ),
               ),
             ),
           ),

--- a/src/packages/flutter-app/test/app_theme_dark_test.dart
+++ b/src/packages/flutter-app/test/app_theme_dark_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import 'package:travel_route_planner/theme/app_colors.dart';
 import 'package:travel_route_planner/theme/app_theme.dart';
 
 /// Pins the light/dark divergences in AppTheme (specs/dark-mode): the dark
@@ -14,7 +15,9 @@ void main() {
   });
 
   test('input fill: paper in light, tonal surface in dark', () {
-    expect(AppTheme.light.inputDecorationTheme.fillColor, Colors.grey[50]);
+    // Paper is a token now, not grey[50]: once the canvas went cool a warm
+    // #FAFAFA sat inside every field as a visible smudge.
+    expect(AppTheme.light.inputDecorationTheme.fillColor, AppColors.paperFill);
     expect(AppTheme.dark.inputDecorationTheme.fillColor,
         AppTheme.dark.colorScheme.surfaceContainerHighest);
   });

--- a/src/packages/flutter-app/test/app_theme_surfaces_test.dart
+++ b/src/packages/flutter-app/test/app_theme_surfaces_test.dart
@@ -1,0 +1,138 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:travel_route_planner/theme/app_colors.dart';
+import 'package:travel_route_planner/theme/app_theme.dart';
+
+// The Aegean canvases replaced M3's seed-derived neutrals, so the contrast
+// the scheme used to guarantee is now ours to prove. DESIGN.md states a
+// tightest pair; this re-measures every pair rather than trusting it.
+
+/// WCAG relative luminance.
+double _luminance(Color c) {
+  double channel(double v) =>
+      v <= 0.03928 ? v / 12.92 : math.pow((v + 0.055) / 1.055, 2.4).toDouble();
+  return 0.2126 * channel(c.r) +
+      0.7152 * channel(c.g) +
+      0.0722 * channel(c.b);
+}
+
+double _contrast(Color a, Color b) {
+  final la = _luminance(a), lb = _luminance(b);
+  return (math.max(la, lb) + 0.05) / (math.min(la, lb) + 0.05);
+}
+
+/// Every tone a widget can legitimately put text on.
+List<(String, Color)> _fields(SurfaceCanvas c) => [
+      ('surface', c.surface),
+      ('surfaceDim', c.surfaceDim),
+      ('surfaceBright', c.surfaceBright),
+      ('containerLowest', c.containerLowest),
+      ('containerLow', c.containerLow),
+      ('container', c.container),
+      ('containerHigh', c.containerHigh),
+      ('containerHighest', c.containerHighest),
+    ];
+
+void main() {
+  group('every surface tone carries both inks at AA', () {
+    for (final (mode, canvas) in [
+      ('dark', AppColors.aegeanNight),
+      ('light', AppColors.aegeanPaper),
+    ]) {
+      test(mode, () {
+        for (final (name, field) in _fields(canvas)) {
+          expect(
+            _contrast(canvas.onSurface, field),
+            greaterThanOrEqualTo(4.5),
+            reason: '$mode onSurface on $name is body text',
+          );
+          expect(
+            _contrast(canvas.onSurfaceVariant, field),
+            greaterThanOrEqualTo(4.5),
+            reason: '$mode onSurfaceVariant on $name is body text too — it '
+                'carries secondary copy, not decoration',
+          );
+        }
+      });
+    }
+  });
+
+  test('the ladder steps one way without a flat rung', () {
+    // A card reads as raised because of the INTERVAL between rungs, so a
+    // duplicate or inverted step is a silently invisible surface.
+    //
+    // The two canvases step in OPPOSITE directions, and that is M3, not a
+    // mistake: in dark a higher container is lighter, in light it is darker
+    // (containerLowest is plain white). Asserting "rises" in both is what
+    // this test did on its first pass, and light failed it correctly.
+    for (final (mode, canvas, sign) in [
+      ('dark', AppColors.aegeanNight, 1),
+      ('light', AppColors.aegeanPaper, -1),
+    ]) {
+      final rungs = [
+        canvas.containerLowest,
+        canvas.containerLow,
+        canvas.container,
+        canvas.containerHigh,
+        canvas.containerHighest,
+      ];
+      for (var i = 1; i < rungs.length; i++) {
+        final step = (_luminance(rungs[i]) - _luminance(rungs[i - 1])) * sign;
+        expect(step, greaterThan(0),
+            reason: '$mode rung $i must step away from rung ${i - 1}');
+      }
+    }
+  });
+
+  test('the two canvases are one design in two keys, not an inversion', () {
+    // Same hue both ways: the light canvas is not the dark one flipped, but
+    // it is not a different family either.
+    double hue(Color c) => HSLColor.fromColor(c).hue;
+    expect(hue(AppColors.aegeanNight.surface),
+        closeTo(hue(AppColors.aegeanPaper.surface), 12));
+    // ...and near white the chroma has to come off, or the page reads blue
+    // rather than cool.
+    expect(HSLColor.fromColor(AppColors.aegeanPaper.surface).saturation,
+        lessThan(HSLColor.fromColor(AppColors.aegeanNight.surface).saturation));
+  });
+
+  test('the canvas is what the theme actually paints', () {
+    for (final (theme, canvas) in [
+      (AppTheme.dark, AppColors.aegeanNight),
+      (AppTheme.light, AppColors.aegeanPaper),
+    ]) {
+      final s = theme.colorScheme;
+      expect(s.surface, canvas.surface);
+      expect(s.surfaceContainerHigh, canvas.containerHigh);
+      expect(s.onSurface, canvas.onSurface);
+      expect(s.outlineVariant, canvas.outlineVariant);
+    }
+    // Dark cards take the explicit tonal step, because the surface tint that
+    // would otherwise separate them is off everywhere.
+    expect(AppTheme.dark.cardTheme.color,
+        AppColors.aegeanNight.containerHigh);
+  });
+
+  test('teal still seeds every role — the canvas took surfaces only', () {
+    // The split the whole change rests on: blue is what you act ON, teal is
+    // what you act WITH. A regression here would be the button going blue.
+    final dark = AppTheme.dark.colorScheme;
+    final light = AppTheme.light.colorScheme;
+    for (final (mode, primary, field) in [
+      ('dark', dark.primary, dark.surface),
+      ('light', light.primary, light.surface),
+    ]) {
+      final h = HSLColor.fromColor(primary).hue;
+      expect(h, greaterThan(140),
+          reason: '$mode primary must stay in the teal family');
+      expect(h, lessThan(190),
+          reason: '$mode primary must not drift into the canvas blue');
+      expect(_contrast(primary, field), greaterThanOrEqualTo(3.0),
+          reason: '$mode primary is the action — it has to be findable on '
+              'its own page');
+    }
+  });
+}

--- a/src/packages/flutter-app/test/fading_edge_scroll_test.dart
+++ b/src/packages/flutter-app/test/fading_edge_scroll_test.dart
@@ -1,0 +1,150 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:travel_route_planner/widgets/fading_edge_scroll.dart';
+
+// The contract worth pinning is not "there is a gradient" — it is WHICH edge
+// fades and when. A fade means "there is more this way", so a constant one
+// would promise more at exactly the moment there is none left.
+//
+// That rule is a pure function, tested here directly rather than by
+// rasterizing the mask: `Picture.toImage` never completes under the headless
+// test binding, and a pixel sample would pin the same arithmetic through a
+// much more brittle lens. The widget tests below cover the wiring the pure
+// function can't see — that the controller reaches the scroll view, and that
+// the mask survives the fade engaging.
+
+const double _viewport = 400;
+const double _fade = 56; // 0.14 of the viewport
+
+(double, double) _at(double pixels, {double maxExtent = 600}) =>
+    fadingEdgeFractions(
+      pixels: pixels,
+      minExtent: 0,
+      maxExtent: maxExtent,
+      viewport: _viewport,
+      fadeWidth: _fade,
+    );
+
+Future<ScrollController> _pump(WidgetTester tester,
+    {int items = 8, double itemWidth = 120}) async {
+  await tester.binding.setSurfaceSize(const Size(_viewport, 200));
+  addTearDown(() => tester.binding.setSurfaceSize(null));
+  late ScrollController controller;
+  await tester.pumpWidget(MaterialApp(
+    home: Scaffold(
+      body: SizedBox(
+        height: 100,
+        child: FadingEdgeScroll(
+          fadeWidth: _fade,
+          builder: (context, c) {
+            controller = c;
+            return ListView.builder(
+              controller: c,
+              scrollDirection: Axis.horizontal,
+              itemCount: items,
+              itemBuilder: (_, __) =>
+                  Container(width: itemWidth, color: Colors.black),
+            );
+          },
+        ),
+      ),
+    ),
+  ));
+  await tester.pumpAndSettle();
+  return controller;
+}
+
+void main() {
+  group('which edge fades', () {
+    test('at rest only the far edge fades', () {
+      final (lead, trail) = _at(0);
+      // Nothing has scrolled past the start, so dimming it would hide the
+      // first card for no reason.
+      expect(lead, 0);
+      expect(trail, greaterThan(0));
+    });
+
+    test('mid-scroll both edges fade', () {
+      final (lead, trail) = _at(300);
+      expect(lead, greaterThan(0));
+      expect(trail, greaterThan(0));
+    });
+
+    test('at the end the trailing fade stops promising more', () {
+      final (lead, trail) = _at(600);
+      expect(lead, greaterThan(0));
+      // The regression a constant gradient would reintroduce: the last card
+      // has to reach the edge at full ink.
+      expect(trail, 0);
+    });
+
+    test('content that fits fades neither edge', () {
+      // maxScrollExtent 0 — every card is already on screen.
+      expect(_at(0, maxExtent: 0), (0.0, 0.0));
+    });
+
+    test('a rail resting a fraction off an end does not flicker its fade',
+        () {
+      expect(_at(0.4).$1, 0, reason: 'sub-pixel rest at the start');
+      expect(_at(599.6).$2, 0, reason: 'sub-pixel rest at the end');
+    });
+
+    test('the two fades can never meet in the middle', () {
+      final (lead, trail) = fadingEdgeFractions(
+        pixels: 300,
+        minExtent: 0,
+        maxExtent: 600,
+        viewport: 100,
+        fadeWidth: 10000, // absurd on purpose
+        );
+      expect(lead, 0.4);
+      expect(trail, 0.4);
+      expect(lead + trail, lessThan(1));
+    });
+
+    test('a viewport with no width yields no fade', () {
+      expect(
+        fadingEdgeFractions(
+            pixels: 0,
+            minExtent: 0,
+            maxExtent: 600,
+            viewport: 0,
+            fadeWidth: _fade),
+        (0.0, 0.0),
+      );
+    });
+  });
+
+  testWidgets('the mask is present and the rail takes the controller',
+      (tester) async {
+    final c = await _pump(tester);
+
+    expect(find.byType(ShaderMask), findsOneWidget);
+    expect(c.hasClients, isTrue);
+    expect(c.position.maxScrollExtent, greaterThan(0));
+  });
+
+  testWidgets('the scroll position survives the fade engaging', (tester) async {
+    // The trap BookingFilterBar documents: swapping the mask in and out
+    // re-parents the scroll view, rebuilding it and dropping the position.
+    // The mask has to stay in the tree at every offset.
+    final c = await _pump(tester);
+    c.jumpTo(200);
+    await tester.pumpAndSettle();
+    expect(c.offset, 200);
+    expect(find.byType(ShaderMask), findsOneWidget);
+
+    c.jumpTo(c.position.maxScrollExtent);
+    await tester.pumpAndSettle();
+    expect(c.offset, c.position.maxScrollExtent);
+    expect(find.byType(ShaderMask), findsOneWidget);
+  });
+
+  testWidgets('a rail whose content fits still scrolls nothing and shows all',
+      (tester) async {
+    final c = await _pump(tester, items: 2, itemWidth: 100);
+    expect(c.position.maxScrollExtent, 0);
+    expect(find.byType(ShaderMask), findsOneWidget);
+  });
+}


### PR DESCRIPTION
The rebrand shipped a mark drawn in **petrol blue and sun-bronze**, and left the app on a **teal-seeded grey world**. The two identities never met on a screen. This closes that.

## Two hues, two jobs, no overlap

Teal still seeds every Material **role** — primary, secondary, error and their `on` pairs — so the action colour is untouched. Blue owns every **surface**.

> Teal is what you act *with*; blue is what you act *on top of*.

The filled teal button is now *easier* to find than it was on grey, which is the check that says the split works.

## The two Aegean canvases

Authored ladders — `AppColors.aegeanNight` / `aegeanPaper`, selected by `canvasFor(brightness)`, the one place a theme mode becomes a set of surfaces. Hue **205°**, between the mark's ring (198°) and the rebrand's recorded Aegean-night canvas (209°): the blue the logo is drawn in, not a blue picked to sit beside it.

| | dark before → after | light before → after |
|---|---|---|
| page (`surface`) | `#0E1513` → **`#0C1F2C`** | `#F4FBF8` → **`#F6F9FB`** |
| cards (`surfaceContainerHigh`) | `#252B2A` → **`#153851`** | `#E3EAE7` → **`#E0EBF2`** |

**The neutrals this replaces were never neutral.** Teal-seeded dark surfaces came out at `#0E1513` — a near-black carrying a green cast too weak to name. The idea is unchanged (surfaces carry the brand's hue quietly); only the hue is, and the chroma it's allowed. Near white that chroma comes off, or the light page reads *blue* rather than *cool*.

Light input fill left `Colors.grey[50]` for `paperFill #F3F7F9`: a warm `#FAFAFA` sat inside every cool field as a visible smudge.

## Rules rewritten in the same PR

Per the standing "a rule that must break gets written into the guideline doc" commitment:

- **The One Dark Exception Rule → The Two Canvases Rule.** Two of its three clauses are now false: surfaces are authored rather than seed-derived, and dark is *composed* rather than the light build with brightness flipped.
- **"Surfaces are the seed-derived M3 neutrals — warm, plaster-leaning"** — still true of light's *register*, no longer of its temperature.

`brand-guidelines.html` goes to **v1.6** with both ladders, their inks and hairlines, and an explicit note on what it superseded.

## Contrast is now ours to prove

The scheme no longer guarantees it, so `app_theme_surfaces_test.dart` **measures all sixteen tone/ink pairs** rather than trusting the ladder. Tightest is **4.88:1**, over the 4.5:1 body floor. It also pins that the ladder steps one way without a flat rung — which caught a real mistake on its first run, since the two canvases step in *opposite* directions (in light, `containerLowest` is white).

## What this does NOT fix

The seven **tool accents** are fixed Material shades rather than brightness-aware like the status marks already are:

| accent | old card | new card |
|---|---|---|
| local amber 800 | 6.30:1 | 5.35:1 |
| route deep-orange 600 | 4.15:1 | 3.52:1 |
| ferries cyan 700 | 4.11:1 | 3.49:1 |
| **flights blue 700** | **3.13:1** | **2.66:1** |
| stays pink 600 | 2.91:1 | 2.47:1 |
| events purple 600 | 2.05:1 | 1.74:1 |
| parking blue-grey 700 | 1.99:1 | 1.69:1 |

Five of seven were **already** under the 3:1 control floor on grey — pre-existing debt, not something the navy created. But flights crossed the line *because of this change*. It isn't an AA failure as shipped: each accent is an icon tint beside a text label, so colour is never the sole carrier. Re-toning seven categorical accents app-wide is its own change with its own look-over, so it's a follow-up, not a fold-in.

Also open: `landingCanvas` (Midnight Harbor, ≈`#00231D`) is a **green**-black now sitting one navigation away from a blue app. DESIGN.md records that as an inconsistency rather than a rule.

## Verification

- `flutter test`: **1821 passed, 0 failed** (6 new). One existing test pinned `grey[50]` and now encodes the token.
- `dart analyze` clean (3 pre-existing infos in `route_response.dart`); brand `check.sh` clean.
- **Rendered and inspected in both modes** against the real Home cards, the real photography, and the real teal buttons — three candidate depths were rendered before picking this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/golden-tempo/codesmith/anemos-travel/pr/530"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789925185&installation_model_id=433099&pr_number=530&repository=golden-tempo%2Fanemos-travel&return_to=https%3A%2F%2Fgithub.com%2Fgolden-tempo%2Fanemos-travel%2Fpull%2F530&signature=1cff41e9857667499f9bd20850487a59f2b8120d85ced48769423d2c6501a127"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->