### PR TITLE
fix(theme): tooltips leave framework defaults for the raised-surface recipe

### DIFF
--- a/src/packages/flutter-app/lib/theme/app_theme.dart
+++ b/src/packages/flutter-app/lib/theme/app_theme.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'app_colors.dart';
+import 'app_shadows.dart';
 import 'app_typography.dart';
 import 'spacing.dart';
 
@@ -224,6 +225,36 @@ abstract final class AppTheme {
         shape: RoundedRectangleBorder(
           borderRadius: BorderRadius.circular(AppRadius.lg),
         ),
+      ),
+      // Tooltips were the one surface left on framework defaults — stock
+      // Flutter paints a grey[700]/white pill at 90% opacity with a 4px
+      // radius, none of it scheme-derived, and its `verticalOffset` of 24 is
+      // measured from the trigger's CENTRE: on a 48px IconButton that leaves
+      // ~0 clearance against whatever sits directly below, which is how the
+      // composer's "Attach images" ended up hard against the input field.
+      // Stated once here instead of per call site: the same raised-surface
+      // recipe as cards and menus (paper surface in light, the explicit tonal
+      // step in dark, the shared downward shadow, no tint) at the small-badge
+      // radius, menu-row text, and an offset that puts real space between the
+      // pill and its trigger. `verticalOffset` is measured on screen from the
+      // trigger's centre — 24 covers the IconButton's lower half, the rest is
+      // the visible gap, chosen against the composer (the tightest neighbour
+      // in the app) rather than derived.
+      tooltipTheme: TooltipThemeData(
+        decoration: BoxDecoration(
+          color:
+              isDark ? colorScheme.surfaceContainerHigh : colorScheme.surface,
+          borderRadius: AppRadius.smAll,
+          boxShadow: AppShadows.soft,
+        ),
+        textStyle: _menuRowStyle(textTheme, colorScheme),
+        padding: const EdgeInsets.symmetric(
+          horizontal: AppSpacing.md,
+          vertical: AppSpacing.sm,
+        ),
+        // Keeps a pill near the app bar or nav rail off the viewport edge.
+        margin: const EdgeInsets.symmetric(horizontal: AppSpacing.md),
+        verticalOffset: 32,
       ),
     );
   }

--- a/src/packages/flutter-app/test/app_theme_tooltip_test.dart
+++ b/src/packages/flutter-app/test/app_theme_tooltip_test.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:travel_route_planner/theme/app_shadows.dart';
+import 'package:travel_route_planner/theme/app_theme.dart';
+import 'package:travel_route_planner/theme/spacing.dart';
+
+/// Pins the tooltip theme (specs/tooltip-theme): tooltips were the last
+/// surface on framework defaults — a grey[700]/white pill at 90% opacity
+/// whose 24px offset, measured from the trigger's CENTRE, left ~0 clearance
+/// below a 48px IconButton (the composer's "Attach images" sat hard against
+/// the input field). The theme states the raised-surface recipe once for
+/// every tooltip in the app.
+void main() {
+  BoxDecoration deco(ThemeData t) =>
+      t.tooltipTheme.decoration! as BoxDecoration;
+
+  test('colors come from the scheme, in both modes', () {
+    // Light: the paper surface. Dark: the explicit tonal step — the same
+    // separation rule cards follow, since a drop shadow is invisible
+    // against a dark canvas.
+    expect(deco(AppTheme.light).color, AppTheme.light.colorScheme.surface);
+    expect(deco(AppTheme.dark).color,
+        AppTheme.dark.colorScheme.surfaceContainerHigh);
+    // Never the framework's fixed grey.
+    expect(deco(AppTheme.light).color, isNot(Colors.grey[700]));
+  });
+
+  test('small-badge radius, shared soft shadow, no tint', () {
+    for (final t in [AppTheme.light, AppTheme.dark]) {
+      expect(deco(t).borderRadius, AppRadius.smAll);
+      expect(deco(t).boxShadow, AppShadows.soft);
+    }
+  });
+
+  test('offset clears a 48px trigger', () {
+    // verticalOffset is measured from the trigger's centre: 24 reaches the
+    // lower edge of a 48px IconButton, so anything less leaves the pill
+    // overlapping whatever sits below. Measured on screen against the
+    // composer (the tightest neighbour): 19px of clear page background
+    // between pill and input field, where the default left ~1px.
+    for (final t in [AppTheme.light, AppTheme.dark]) {
+      expect(t.tooltipTheme.verticalOffset, greaterThan(24));
+    }
+  });
+
+  test('pills stay off the viewport edge', () {
+    for (final t in [AppTheme.light, AppTheme.dark]) {
+      expect(t.tooltipTheme.margin,
+          const EdgeInsets.symmetric(horizontal: AppSpacing.md));
+    }
+  });
+}


### PR DESCRIPTION
## What

A `tooltipTheme` in `app_theme.dart`, beside the eleven component themes already there — tooltips were the one surface still on stock Material: a `grey[700]` pill at 90% opacity with a 4px radius, none of it scheme-derived, and a `verticalOffset` of 24 measured from the trigger's **centre**, which on a 48px `IconButton` leaves ~1px of clearance against whatever sits below. That is how the composer's "Attach images" ended up hard against the input field. 24 call sites render on those defaults, so the fix is stated once, globally.

The recipe is the raised-surface one cards and menus already use: paper surface in light, the explicit tonal step in dark, `AppRadius.sm`, `AppShadows.soft`, menu-row text, a horizontal margin to keep pills off the viewport edge, and `verticalOffset: 32`.

## The number is measured, not derived

Per the spec (the epic's `tooltip-theme` artifact): the offset could not come from source. Measured on the running app against the composer — the tightest neighbour in the app — via CDP pointer hover at 1440×900:

| | pill bottom → input field top |
|---|---|
| framework default (offset 24) | **~1px** |
| this theme (offset 32) | **19px clear** + soft shadow falloff |

Verified on **merged main** (post-`aegean-surfaces`, so the dark pill is the new blue tonal step), light **and** dark, and in **both directions**: the composer tooltip flips above its trigger; the app-bar globe's renders below it, clear of the viewport edge.

## Gates

- `flutter test`: full suite green (1838), incl. 4 new structural tests in `app_theme_tooltip_test.dart` (scheme-derived colors both modes, radius/shadow, offset clears a 48px trigger, viewport margin) — no position assertions, per the house rule
- `flutter analyze` clean on touched files
- `check.sh` clean on `app_theme.dart`
- No call site touched; the 24 existing tooltips pick the theme up unchanged

## Lane notes

Lane work was finished in-session by the orchestrator: the Kimi lane stalled after drafting the theme, so verification (the measurement above), the test file, and this PR are the orchestrator's. The Docker stack on `:3005` is still up if a reviewer wants to poke at it.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/golden-tempo/codesmith/anemos-travel/pr/531"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789952017&installation_model_id=433099&pr_number=531&repository=golden-tempo%2Fanemos-travel&return_to=https%3A%2F%2Fgithub.com%2Fgolden-tempo%2Fanemos-travel%2Fpull%2F531&signature=e935bd7a478ea4fe3213a5d686d62fca0c114c9227665154bb488f3b9c7abc13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->