### PR TITLE
feat(review): flag the confirmed booking the route left behind

### DIFF
--- a/src/packages/api/i18n.go
+++ b/src/packages/api/i18n.go
@@ -267,6 +267,7 @@ var messages = map[string]map[string]string{
 	"review.fix.markBooked":       {"en": "Mark booked", "es": "Marcar como reservado"},
 	"review.fix.moveToDay":        {"en": "Move to Day %d", "es": "Mover al día %d"},
 	"review.fix.reschedule":       {"en": "Reschedule", "es": "Reprogramar"},
+	"review.fix.reviewSegment":    {"en": "Review booking", "es": "Revisar reserva"},
 	"review.fix.setDates":         {"en": "Set dates", "es": "Añadir fechas"},
 	"review.itemBeyondSpan":       {"en": "%q is on day %d, past the trip's %d-day span.", "es": "%q está en el día %d, más allá de la duración de %d días del viaje."},
 	// review.ladder.* — rung labels for the plan-progress sheet, needed only by
@@ -320,6 +321,8 @@ var messages = map[string]map[string]string{
 	"review.planOverBudget":             {"en": "Your plan runs %.2f %s over target — nothing overspent yet.", "es": "Tu plan supera el objetivo en %.2f %s — aún no te has pasado."},
 	"review.packedDay":                  {"en": "Day %d has %d items planned — that may be too packed.", "es": "El día %d tiene %d actividades planificadas — puede que sea demasiado."},
 	"review.rainLikely":                 {"en": "Rain likely on Day %d (%s) — pack an umbrella.", "es": "Es probable que llueva el día %d (%s) — lleva paraguas."},
+	"review.staleTransport":             {"en": "Your booking %s no longer matches the route — those two places are not consecutive stops anymore.", "es": "Tu reserva %s ya no coincide con la ruta — esos dos lugares ya no son paradas consecutivas."},
+	"review.staleTransportDates":        {"en": " It also departs %s, outside the current dates of the legs it names.", "es": " Además sale el %s, fuera de las fechas actuales de las etapas que menciona."},
 	"review.timeOfDayCollision":         {"en": "Day %d has %d things scheduled for the %s.", "es": "El día %d tiene %d cosas programadas para %s."},
 	"review.tod.afternoon":              {"en": "afternoon", "es": "la tarde"},
 	"review.tod.evening":                {"en": "evening", "es": "la noche"},

--- a/src/packages/api/trip_review.go
+++ b/src/packages/api/trip_review.go
@@ -44,7 +44,7 @@ type Finding struct {
 // Populated deterministically inside the same checkX helper that emits the
 // finding — never a live/external lookup.
 type FindingFix struct {
-	Action          string  `json:"action"` // add_lodging|add_transport|move_item|mark_booked|add_packing|set_dates|raise_budget
+	Action          string  `json:"action"` // add_lodging|add_transport|move_item|mark_booked|add_packing|set_dates|raise_budget|fix_segment
 	Label           string  `json:"label"`  // human button label, e.g. "Add a stay", "Add ferry", "Move to Day 3"
 	ItemID          *string `json:"item_id,omitempty"`
 	EntityType      *string `json:"entity_type,omitempty"` // "accommodation"|"segment" — disambiguates a bookings ItemID
@@ -98,6 +98,7 @@ func reviewTrip(ctx context.Context, locale string, data exportData, opts review
 	findings = append(findings, checkDensity(locale, data)...)
 	findings = append(findings, checkLodging(locale, data)...)
 	findings = append(findings, checkTransit(locale, data)...)
+	findings = append(findings, checkStaleTransport(locale, data)...)
 	findings = append(findings, checkBudget(locale, data, opts.Budget)...)
 	findings = append(findings, checkBookings(locale, data)...)
 	findings = append(findings, checkWeather(ctx, locale, data, deps.Weather)...)
@@ -946,6 +947,160 @@ func hasWord(s, w string) bool {
 		}
 	}
 	return false
+}
+
+// checkStaleTransport is checkTransit's inverse. checkTransit walks adjacent
+// leg pairs asking whether any segment CONNECTS them, and flags the gap; this
+// walks the trip's own segments asking whether each still connects an
+// adjacent pair, and flags the ones the route left behind. The trigger shape:
+// a city inserted mid-route (Naples between Gothenburg and Sorrento) leaves
+// the confirmed Gothenburg → Sorrento flight naming a pair that is no longer
+// adjacent — exempt from the draft resync, which by design never touches
+// confirmed rows, so nothing else ever notices.
+//
+// It reports and nothing more. An orphaned booking's endpoints are facts
+// about a reservation the traveler holds, so they are never rewritten,
+// re-dated or removed here — degrade, never invent.
+//
+// The rule errs toward silence, because a wrong "your booking is stale" sends
+// the traveler to re-check a reservation that is fine:
+//   - drafts (auto = true) are the resync's to prune; flagging double-reports
+//   - dismissed rows are already dealt with
+//   - a segment whose endpoints are not both legs of the trip — the flight
+//     out of the home airport, a connection city — is none of the route's
+//     business
+//   - "connects" is the shared segmentConnects predicate, fuzzyMatch and all;
+//     a second, stricter copy would be exactly the divergence the Go/Dart
+//     twin rule exists to prevent
+func checkStaleTransport(locale string, d exportData) []Finding {
+	groups := groupExportItems(d.Trip, d.Items)
+	var hubs []string
+	for _, g := range groups {
+		if g.Hub == "" || g.Hub == "Itinerary" {
+			continue
+		}
+		hubs = append(hubs, g.Hub)
+	}
+	if len(hubs) < 2 {
+		return nil
+	}
+	tripID := d.Trip.ID.String()
+	var out []Finding
+	for _, seg := range d.Segments {
+		if seg.Auto || seg.Dismissed {
+			continue
+		}
+		origin := strings.TrimSpace(strPtrVal(seg.Origin))
+		dest := strings.TrimSpace(strPtrVal(seg.Destination))
+		if origin == "" || dest == "" {
+			continue
+		}
+		if !namesLeg(hubs, origin) || !namesLeg(hubs, dest) {
+			continue
+		}
+		one := []store.TripSegment{seg}
+		connected := false
+		for i := 1; i < len(hubs); i++ {
+			if strings.EqualFold(hubs[i-1], hubs[i]) {
+				continue
+			}
+			if segmentConnects(one, hubs[i-1], hubs[i]) {
+				connected = true
+				break
+			}
+		}
+		if connected {
+			continue
+		}
+		name := origin + " → " + dest
+		msg := tr(locale, "review.staleTransport", name)
+		if depart, ok := staleDateEvidence(d.Trip, d.Items, hubs, seg); ok {
+			msg += tr(locale, "review.staleTransportDates",
+				localizedDate(locale, depart, dateStyleWeekdayMonthDay))
+		}
+		id := seg.ID.String()
+		fix := &FindingFix{
+			Action: "fix_segment", Label: tr(locale, "review.fix.reviewSegment"),
+			ItemID: &id, EntityType: ptrTo("segment"),
+			Origin: &origin, Destination: &dest, Mode: ptrTo(seg.Mode),
+		}
+		if seg.DepartDate.Valid {
+			fix.Date = ptrTo(seg.DepartDate.Time.Format(dateLayout))
+		}
+		out = append(out, Finding{
+			Severity: "warn", Category: "transit", TripID: tripID,
+			Message: msg, ItemID: &id, Fix: fix,
+		})
+	}
+	return out
+}
+
+// namesLeg reports whether a segment endpoint names one of the trip's legs,
+// under the same fuzzyMatch the connects predicate uses.
+func namesLeg(hubs []string, endpoint string) bool {
+	e := strings.ToLower(endpoint)
+	for _, hub := range hubs {
+		if fuzzyMatch(e, strings.ToLower(hub)) {
+			return true
+		}
+	}
+	return false
+}
+
+// staleDateEvidence reports whether the segment's departure falls outside the
+// date span of EVERY leg it names — supporting evidence that rides along on
+// the orphan finding's message, never its trigger: a confirmed segment can
+// legitimately depart a day early, so a date mismatch alone flags nothing.
+func staleDateEvidence(trip store.Trip, items []store.ItineraryItem, hubs []string, seg store.TripSegment) (time.Time, bool) {
+	if !seg.DepartDate.Valid {
+		return time.Time{}, false
+	}
+	depart := seg.DepartDate.Time
+	o := strings.ToLower(strings.TrimSpace(strPtrVal(seg.Origin)))
+	dst := strings.ToLower(strings.TrimSpace(strPtrVal(seg.Destination)))
+	anySpan := false
+	for _, hub := range hubs {
+		h := strings.ToLower(hub)
+		if !fuzzyMatch(o, h) && !fuzzyMatch(dst, h) {
+			continue
+		}
+		lo, hi, ok := hubDateSpan(trip, items, hub)
+		if !ok {
+			continue
+		}
+		anySpan = true
+		if !depart.Before(lo) && !depart.After(hi) {
+			return time.Time{}, false
+		}
+	}
+	if !anySpan {
+		return time.Time{}, false
+	}
+	return depart, true
+}
+
+// hubDateSpan is the min→max of a hub's dated items — the span of the leg as
+// the page renders it.
+func hubDateSpan(trip store.Trip, items []store.ItineraryItem, hub string) (time.Time, time.Time, bool) {
+	var lo, hi time.Time
+	found := false
+	for _, it := range items {
+		if !strings.EqualFold(itemHub(it), hub) {
+			continue
+		}
+		dt, ok := itemStartDate(trip, it)
+		if !ok {
+			continue
+		}
+		if !found || dt.Before(lo) {
+			lo = dt
+		}
+		if !found || dt.After(hi) {
+			hi = dt
+		}
+		found = true
+	}
+	return lo, hi, found
 }
 
 // checkBudget flags a trip whose spending exceeds its target — or, failing

--- a/src/packages/api/trip_review_test.go
+++ b/src/packages/api/trip_review_test.go
@@ -1085,3 +1085,188 @@ func TestCheckLegShape(t *testing.T) {
 		t.Fatalf("a well-formed spine raised findings: %+v", fs)
 	}
 }
+
+// --- checkStaleTransport: the booking the route left behind ------------------
+//
+// The trigger shape: Naples inserted between Gothenburg and Sorrento. The legs
+// below are exactly that sequence — the confirmed Gothenburg → Sorrento flight
+// is the orphan.
+
+// staleTransportFixture builds the post-edit leg sequence: Gothenburg (day 1,
+// Sep 10) → Naples (day 4, Sep 13) → Sorrento (day 6, Sep 15) → Rome (day 8,
+// Sep 17).
+func staleTransportFixture(t *testing.T) exportData {
+	return exportData{
+		Trip: store.Trip{ID: uuid.New(),
+			StartDate: dateVal(t, "2026-09-10"), EndDate: dateVal(t, "2026-09-18")},
+		Items: []store.ItineraryItem{
+			rlItem(1, "Gothenburg pin", rlCity("Gothenburg"), 1),
+			rlItem(2, "Naples pin", rlCity("Naples"), 4),
+			rlItem(3, "Sorrento pin", rlCity("Sorrento"), 6),
+			rlItem(4, "Rome pin", rlCity("Rome"), 8),
+		},
+	}
+}
+
+func TestCheckStaleTransport_OrphanedConfirmedSegment(t *testing.T) {
+	d := staleTransportFixture(t)
+	seg := store.TripSegment{
+		ID: uuid.New(), Mode: "flight", Booked: true,
+		Origin: strp("Gothenburg"), Destination: strp("Sorrento"),
+		DepartDate: dateVal(t, "2026-09-11"),
+	}
+	d.Segments = []store.TripSegment{seg}
+
+	fs := checkStaleTransport("en", d)
+	if len(fs) != 1 {
+		t.Fatalf("findings = %+v, want the one orphan", fs)
+	}
+	f := fs[0]
+	if f.Severity != "warn" || f.Category != "transit" {
+		t.Fatalf("severity/category = %q/%q", f.Severity, f.Category)
+	}
+	if f.ItemID == nil || *f.ItemID != seg.ID.String() {
+		t.Fatalf("finding must carry the row's id, got %+v", f.ItemID)
+	}
+	if !strings.Contains(f.Message, "Gothenburg → Sorrento") {
+		t.Fatalf("finding must name the row, got %q", f.Message)
+	}
+	// The optional date signal: Sep 11 is outside both named legs' rendered
+	// spans, so it rides along as evidence.
+	if !strings.Contains(f.Message, "outside the current dates") {
+		t.Fatalf("expected the date evidence in the message, got %q", f.Message)
+	}
+	if f.Fix == nil || f.Fix.Action != "fix_segment" {
+		t.Fatalf("fix = %+v, want action fix_segment", f.Fix)
+	}
+	fix := f.Fix
+	if fix.ItemID == nil || *fix.ItemID != seg.ID.String() ||
+		fix.EntityType == nil || *fix.EntityType != "segment" {
+		t.Fatalf("fix must identify the segment row, got %+v", fix)
+	}
+	if fix.Origin == nil || *fix.Origin != "Gothenburg" ||
+		fix.Destination == nil || *fix.Destination != "Sorrento" ||
+		fix.Date == nil || *fix.Date != "2026-09-11" ||
+		fix.Mode == nil || *fix.Mode != "flight" {
+		t.Fatalf("fix must carry the row's endpoints/date/mode, got %+v", fix)
+	}
+}
+
+func TestCheckStaleTransport_ConnectedPairsSilent(t *testing.T) {
+	d := staleTransportFixture(t)
+	d.Segments = []store.TripSegment{
+		{ID: uuid.New(), Mode: "flight", Origin: strp("Gothenburg"), Destination: strp("Naples")},
+		{ID: uuid.New(), Mode: "train", Origin: strp("Naples"), Destination: strp("Sorrento")},
+		// Either direction counts — a hand-entered segment may read backwards.
+		{ID: uuid.New(), Mode: "train", Origin: strp("Rome"), Destination: strp("Sorrento")},
+	}
+	if fs := checkStaleTransport("en", d); len(fs) != 0 {
+		t.Fatalf("connected segments flagged: %+v", fs)
+	}
+}
+
+func TestCheckStaleTransport_DraftOrphanNotFlagged(t *testing.T) {
+	d := staleTransportFixture(t)
+	d.Segments = []store.TripSegment{{
+		ID: uuid.New(), Mode: "flight", Auto: true,
+		Origin: strp("Gothenburg"), Destination: strp("Sorrento"),
+	}}
+	if fs := checkStaleTransport("en", d); len(fs) != 0 {
+		t.Fatalf("drafts are the resync's to prune — flagging double-reports: %+v", fs)
+	}
+}
+
+func TestCheckStaleTransport_DismissedNotFlagged(t *testing.T) {
+	d := staleTransportFixture(t)
+	d.Segments = []store.TripSegment{{
+		ID: uuid.New(), Mode: "flight", Dismissed: true,
+		Origin: strp("Gothenburg"), Destination: strp("Sorrento"),
+	}}
+	if fs := checkStaleTransport("en", d); len(fs) != 0 {
+		t.Fatalf("a dismissed row is already dealt with: %+v", fs)
+	}
+}
+
+func TestCheckStaleTransport_NonLegPlaceNotFlagged(t *testing.T) {
+	d := staleTransportFixture(t)
+	d.Segments = []store.TripSegment{
+		// The flight out from the home airport: ALB is no leg of this trip, so
+		// this segment is none of the route's business.
+		{ID: uuid.New(), Mode: "flight", Origin: strp("ALB"), Destination: strp("Gothenburg")},
+		// Same for the flight home.
+		{ID: uuid.New(), Mode: "flight", Origin: strp("Rome"), Destination: strp("EWR")},
+		// A connection city.
+		{ID: uuid.New(), Mode: "flight", Origin: strp("Frankfurt"), Destination: strp("Naples")},
+	}
+	if fs := checkStaleTransport("en", d); len(fs) != 0 {
+		t.Fatalf("segments naming non-leg places must stay silent: %+v", fs)
+	}
+}
+
+func TestCheckStaleTransport_OneOrNoLegs(t *testing.T) {
+	seg := store.TripSegment{ID: uuid.New(), Mode: "flight",
+		Origin: strp("Gothenburg"), Destination: strp("Sorrento")}
+
+	noLegs := exportData{Trip: store.Trip{ID: uuid.New(),
+		StartDate: dateVal(t, "2026-09-10"), EndDate: dateVal(t, "2026-09-18")},
+		Segments: []store.TripSegment{seg}}
+	if fs := checkStaleTransport("en", noLegs); len(fs) != 0 {
+		t.Fatalf("no legs, no flags: %+v", fs)
+	}
+
+	oneLeg := exportData{Trip: store.Trip{ID: uuid.New(),
+		StartDate: dateVal(t, "2026-09-10"), EndDate: dateVal(t, "2026-09-18")},
+		Items:    []store.ItineraryItem{rlItem(1, "Rome pin", rlCity("Rome"), 1)},
+		Segments: []store.TripSegment{seg}}
+	if fs := checkStaleTransport("en", oneLeg); len(fs) != 0 {
+		t.Fatalf("one leg, no flags (and no panic): %+v", fs)
+	}
+}
+
+// The date signal is evidence, never a trigger: a confirmed segment can
+// legitimately depart a day early, so a still-adjacent pair with an out-of-leg
+// date stays silent.
+func TestCheckStaleTransport_DateAloneNeverFires(t *testing.T) {
+	d := staleTransportFixture(t)
+	d.Segments = []store.TripSegment{{
+		ID: uuid.New(), Mode: "flight",
+		Origin: strp("Gothenburg"), Destination: strp("Naples"),
+		// Sep 12 is outside both legs' one-day spans (Sep 10, Sep 13) — but the
+		// pair is still adjacent, so there is nothing to flag.
+		DepartDate: dateVal(t, "2026-09-12"),
+	}}
+	if fs := checkStaleTransport("en", d); len(fs) != 0 {
+		t.Fatalf("an early departure on a connected pair must not flag: %+v", fs)
+	}
+}
+
+func TestCheckStaleTransport_Spanish(t *testing.T) {
+	d := staleTransportFixture(t)
+	d.Segments = []store.TripSegment{{
+		ID: uuid.New(), Mode: "flight",
+		Origin: strp("Gothenburg"), Destination: strp("Sorrento"),
+	}}
+	fs := checkStaleTransport("es", d)
+	if len(fs) != 1 || !strings.Contains(fs[0].Message, "ya no coincide con la ruta") {
+		t.Fatalf("es finding = %+v", fs)
+	}
+}
+
+// The check rides reviewTrip like every other — one call, both surfaces.
+func TestReviewTrip_IncludesStaleTransport(t *testing.T) {
+	d := staleTransportFixture(t)
+	d.Segments = []store.TripSegment{{
+		ID: uuid.New(), Mode: "flight",
+		Origin: strp("Gothenburg"), Destination: strp("Sorrento"),
+	}}
+	fs := reviewTrip(context.Background(), "en", d, reviewOptions{}, reviewDeps{})
+	found := false
+	for _, f := range fs {
+		if f.Fix != nil && f.Fix.Action == "fix_segment" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("reviewTrip lost the orphan finding: %+v", fs)
+	}
+}

--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -2639,6 +2639,40 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
           rethrow;
         }
         break;
+      case 'fix_segment':
+        // A confirmed booking the route left behind (checkStaleTransport):
+        // "Review booking" opens the row's own edit sheet so the traveler
+        // re-dates, corrects or detaches it themselves — the fix never
+        // rewrites a reservation's endpoints on its own say-so. The sheet is
+        // prefilled from the fix, which carries the segment's stored values;
+        // fields it doesn't carry (provider, url, notes, arrival) are simply
+        // omitted from the save body and UpdateSegment's COALESCE keeps them.
+        final segmentId = fix.itemId;
+        if (segmentId == null) return;
+        final body = await showModalBottomSheet<Map<String, dynamic>>(
+          context: context,
+          isScrollControlled: true,
+          builder: (_) => AddSegmentSheet(
+            initial: TripSegment(
+              id: segmentId,
+              mode: fix.mode ?? 'flight',
+              origin: fix.origin,
+              destination: fix.destination,
+              departDate: fix.date,
+            ),
+          ),
+        );
+        if (body == null) return;
+        try {
+          await ref
+              .read(transportApiServiceProvider)
+              .updateSegment(tripId, segmentId, body);
+          await _afterFix();
+        } catch (e) {
+          _showSnack(l10n.tripUpdateTransportFailed(friendlyError(l10n, e)));
+          rethrow;
+        }
+        break;
       case 'move_item':
         final itemId = fix.itemId;
         final targetDay = fix.targetDay;

--- a/src/packages/flutter-app/test/trip_detail_fix_actions_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_fix_actions_test.dart
@@ -360,6 +360,50 @@ void main() {
     expect(inSheet('2026-08-03'), findsOneWidget);
   });
 
+  testWidgets('fix_segment opens the row\'s edit sheet and PATCHes it',
+      (tester) async {
+    // checkStaleTransport's finding: a confirmed booking the route left
+    // behind. "Review booking" opens the segment's own edit sheet (not the
+    // add sheet) prefilled with its stored values, and Save PATCHes the row.
+    final review = _FakeReviewApiService([
+      _finding(
+          'transit',
+          'Your booking Gothenburg → Sorrento no longer matches the route',
+          const FindingFix(
+              action: 'fix_segment',
+              label: 'Review booking',
+              itemId: 'seg-9',
+              entityType: 'segment',
+              origin: 'Gothenburg',
+              destination: 'Sorrento',
+              mode: 'flight',
+              date: '2026-09-11')),
+    ]);
+    final transport = _FakeTransportApiService();
+    await _pumpScreen(tester,
+        trip: _trip(), review: review, transport: transport);
+
+    await tester.tap(find.widgetWithText(FilledButton, 'Review booking'));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(AddSegmentSheet), findsOneWidget);
+    Finder inSheet(String text) => find.descendant(
+        of: find.byType(AddSegmentSheet), matching: find.text(text));
+    expect(inSheet('Gothenburg'), findsOneWidget);
+    expect(inSheet('Sorrento'), findsOneWidget);
+    expect(inSheet('2026-09-11'), findsOneWidget);
+
+    // Saving PATCHes the existing row — no second segment is created.
+    review.resolved = true;
+    await tester.tap(find.widgetWithText(FilledButton, 'Save'));
+    await tester.pumpAndSettle();
+
+    expect(transport.patches, hasLength(1));
+    expect(transport.patches.single['id'], 'seg-9');
+    expect(transport.patches.single['origin'], 'Gothenburg');
+    expect(transport.added, isEmpty);
+  });
+
   testWidgets(
       'health and packing live in the app bar; Budget is a header tab',
       (tester) async {


### PR DESCRIPTION
## What

Ticket 1 of the epic's `stale-transport-orphans` spec — detect the orphan; the correct/remove tool is ticket 2, deliberately not here.

Insert Naples between Gothenburg and Sorrento and the confirmed `Gothenburg → Sorrento` flight survives everything: the draft resync by design never touches confirmed rows (`DeleteStaleDraftSegments` is `WHERE … auto = true`), and trip review only ever asked the inverse — `checkTransit` walks adjacent leg pairs asking whether a segment **connects** them and flags the *gap*. Nothing asked whether a confirmed segment still connects a pair that is adjacent.

`checkStaleTransport` is that inverse pass, and it **reuses `segmentConnects`** rather than growing a second predicate — the Go/Dart twin rule (`trip_detail_derivation.dart`, mirrored fixtures) is untouched because the predicate itself never moved.

## What fires, and what stays silent

The finding reports and nothing more — an orphaned booking's endpoints are facts about a reservation the traveler holds (*degrade, never invent*, applied to someone's money).

| Case | Result |
|---|---|
| Confirmed segment connecting a pair no longer adjacent | **flagged** (warn/transit), naming the row |
| Still-adjacent pair | silent |
| Draft (`auto = true`) orphan | silent — the resync prunes it; flagging double-reports |
| Dismissed row | silent — already dealt with |
| Segment naming a non-leg place (home airport, connection city) | silent — none of the route's business |
| Departure outside every named leg's span | rides along as **evidence** in the message; never fires alone — a confirmed segment can legitimately depart a day early |
| One leg, no legs | no flags, no panic |

A wrong "your booking is stale" is worse than a missed one: it tells a traveler to re-check a reservation that is fine. Every silence above is a test.

## The `Action` decision the ticket asked for

New value: **`fix_segment`**. None of `add_lodging|add_transport|move_item|mark_booked|add_packing|set_dates|raise_budget` means "this booking no longer matches the plan" — and `add_transport` on a finding about an *existing* booking would offer the traveler a second row for the flight they already hold. The fix carries the row (`ItemID`, `EntityType: "segment"`, origin/destination/date/mode).

Client side, "Review booking" opens the segment's **own edit sheet** (the bookings tab's existing `AddSegmentSheet(initial:)` → `updateSegment` path), prefilled from the fix's values — so the traveler re-dates, corrects or detaches the row themselves. Fields the fix doesn't carry (provider, url, notes, arrival) are omitted from the save body and `UpdateSegment`'s COALESCE keeps them. Endpoints are *not* locked: after a re-book, correcting Gothenburg → Sorrento to Gothenburg → Naples is exactly what the traveler needs to type.

## Gates

- `go test ./...` green, `gofmt`/`go vet` clean — 8 new tests incl. the orphan shape, the silences above, Spanish copy, and `reviewTrip` end-to-end
- `flutter test` full suite green (1835), incl. a new `fix_segment` widget test (opens the edit sheet prefilled; Save PATCHes the row, never creates a second segment) — **watched failing** with the handler reverted, passing with it
- `flutter analyze` clean on touched files
- `check.sh`: 1 finding on `trip_detail_screen.dart:4341` — **pre-existing** (`adb67b8`), not in this diff

## Lane notes

Lane work was finished in-session by the orchestrator: the Kimi lane stalled after writing tests + i18n + wiring, so the `checkStaleTransport` implementation, the `fix_segment` client handler, and this PR are the orchestrator's. The plan's open question (which path renders the orphan under the Sorrento leg) stays open and untouched — it needs production data, and neither part A nor this PR depends on it.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/golden-tempo/codesmith/anemos-travel/pr/532"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789952058&installation_model_id=433099&pr_number=532&repository=golden-tempo%2Fanemos-travel&return_to=https%3A%2F%2Fgithub.com%2Fgolden-tempo%2Fanemos-travel%2Fpull%2F532&signature=93721273d32f94233fa14e176d531201a780c98565acec7048aef15b34692792"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->