### PR TITLE
feat(theme): brightness-aware tool accents clear 3:1 on Aegean night

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -146,9 +146,13 @@ Nothing is both.
   fresh alpha. The exception ends at sign-in.
 
 ### Tertiary
-- **Tool accents** (chip-and-pin scale only, one meaning each): route
-  deep-orange 600 · flights blue 700 · stays pink 600 · events purple 600 ·
-  ferries cyan 700 · local amber 800 · parking blue-grey 700.
+- **Tool accents** (chip-and-pin scale only, one meaning each), brightness-
+  aware like the status marks — light shade / dark shade: route deep-orange
+  600/400 · flights blue 700/400 · stays pink 600/300 · events purple 600/300
+  · ferries cyan 700/400 · local amber 800/400 · parking blue-grey 700/300.
+  Dark takes the lightest rung that keeps the hue and clears 3:1 on the
+  Aegean-night card (#153851); as fixed shades, flights, stays, events and
+  parking sat at 1.7–2.7:1 there.
 - **Semantic pairs, two registers**: translucent containers (green 15% /
   amber 20% alpha with shade-800/900 foregrounds) for pills on cards; solid
   brightness-aware marks (`upMark`/`degradedMark`/`downMark`, shade 400 dark /

--- a/src/packages/flutter-app/lib/screens/guides_screen.dart
+++ b/src/packages/flutter-app/lib/screens/guides_screen.dart
@@ -108,7 +108,8 @@ class _GuideListTile extends StatelessWidget {
       clipBehavior: Clip.antiAlias,
       child: ListTile(
         leading: CircleAvatar(
-          backgroundColor: AppColors.toolLocal.withValues(alpha: 0.15),
+          backgroundColor: AppColors.toolLocal(theme.brightness)
+              .withValues(alpha: 0.15),
           // Bound the decode to the 40px avatar slot (default CircleAvatar
           // radius 20, DPR-scaled) — the source photo is full-size.
           foregroundImage: guide.sourcePhotoUrl.isNotEmpty
@@ -119,7 +120,7 @@ class _GuideListTile extends StatelessWidget {
                 )
               : null,
           child: Icon(Icons.menu_book_outlined,
-              size: 18, color: AppColors.toolLocal),
+              size: 18, color: AppColors.toolLocal(theme.brightness)),
         ),
         title: Text(guide.title, maxLines: 2, overflow: TextOverflow.ellipsis),
         subtitle: guide.sourceName.isEmpty

--- a/src/packages/flutter-app/lib/screens/home_screen.dart
+++ b/src/packages/flutter-app/lib/screens/home_screen.dart
@@ -569,7 +569,7 @@ class _GuideCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final accent = AppColors.toolLocal;
+    final accent = AppColors.toolLocal(theme.brightness);
 
     return SizedBox(
       width: 230,

--- a/src/packages/flutter-app/lib/screens/local_guide_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/local_guide_detail_screen.dart
@@ -104,7 +104,7 @@ class _GuideBody extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final l10n = context.l10n;
-    final accent = AppColors.toolLocal;
+    final accent = AppColors.toolLocal(Theme.of(context).brightness);
     final title = _pick(guide.title, fallback.title);
     final body = _pick(guide.body, fallback.body);
     final heroUrl = _pick(guide.heroImageUrl, fallback.heroImageUrl);
@@ -440,7 +440,7 @@ class _GuidePin extends StatelessWidget {
   Widget build(BuildContext context) {
     return Container(
       decoration: BoxDecoration(
-        color: AppColors.toolLocal,
+        color: AppColors.toolLocal(Theme.of(context).brightness),
         shape: BoxShape.circle,
         border: Border.all(color: Colors.white, width: 2),
         // The trip_map pin family's shared drop — this pin says outright that

--- a/src/packages/flutter-app/lib/theme/app_colors.dart
+++ b/src/packages/flutter-app/lib/theme/app_colors.dart
@@ -343,20 +343,35 @@ abstract final class AppColors {
     }
   }
 
-  // Planning-toolkit tool accents (Home screen).
-  static Color get toolRoute => Colors.deepOrange.shade600;
-  static Color get toolFlights => Colors.blue.shade700;
+  // Planning-toolkit tool accents (Home screen). Brightness-aware, like the
+  // status marks above: light keeps the shades these replaced byte-for-byte;
+  // dark takes a lighter rung of the same family so every accent clears 3:1
+  // on the Aegean-night card (#153851) — as fixed shades, flights, stays,
+  // events and parking sank to 1.7–2.7:1 there. Dark is shade 400 where that
+  // clears with margin, 300 where 400 lands thin on the card (stays 3.25,
+  // events 2.54, parking 3.65).
+  static Color toolRoute(Brightness b) => b == Brightness.dark
+      ? Colors.deepOrange.shade400
+      : Colors.deepOrange.shade600;
+  static Color toolFlights(Brightness b) =>
+      b == Brightness.dark ? Colors.blue.shade400 : Colors.blue.shade700;
   /// Lodging accent — stay pins on the map and the chat's hotel rail. Named
   /// toolAirbnb until search_hotels arrived; the app links to Booking.com and
   /// surfaces hotels and vacation rentals from several sources, so a colour
   /// named after one provider was a stale name, not a meaning.
-  static Color get toolStays => Colors.pink.shade600;
-  static Color get toolEvents => Colors.purple.shade600;
-  static Color get toolFerries => Colors.cyan.shade700;
-  static Color get toolLocal => Colors.amber.shade800;
+  static Color toolStays(Brightness b) =>
+      b == Brightness.dark ? Colors.pink.shade300 : Colors.pink.shade600;
+  static Color toolEvents(Brightness b) =>
+      b == Brightness.dark ? Colors.purple.shade300 : Colors.purple.shade600;
+  static Color toolFerries(Brightness b) =>
+      b == Brightness.dark ? Colors.cyan.shade400 : Colors.cyan.shade700;
+  static Color toolLocal(Brightness b) =>
+      b == Brightness.dark ? Colors.amber.shade400 : Colors.amber.shade800;
   // Blue-grey reads as the universal "P" signage family; distinct from
   // toolFlights blue and toolFerries cyan.
-  static Color get toolParking => Colors.blueGrey.shade700;
+  static Color toolParking(Brightness b) => b == Brightness.dark
+      ? Colors.blueGrey.shade300
+      : Colors.blueGrey.shade700;
 
   /// The wordmark's ink on the neutral app bar (the de-gradient pass): Harbor
   /// Dark on light surfaces — the exact ink DESIGN.md records for the

--- a/src/packages/flutter-app/lib/widgets/account_menu.dart
+++ b/src/packages/flutter-app/lib/widgets/account_menu.dart
@@ -190,7 +190,8 @@ List<PopupMenuEntry<String>> _items(
       PopupMenuItem<String>(
         value: 'local_admin',
         child: _menuRow(
-          Icon(Icons.verified, size: 20, color: AppColors.toolLocal),
+          Icon(Icons.verified,
+              size: 20, color: AppColors.toolLocal(theme.brightness)),
           l10n.accountMenuLocalIntelAdmin,
         ),
       ),

--- a/src/packages/flutter-app/lib/widgets/add_to_trip_sheet.dart
+++ b/src/packages/flutter-app/lib/widgets/add_to_trip_sheet.dart
@@ -522,7 +522,8 @@ class AddToTripButton extends StatelessWidget {
   Widget build(BuildContext context) {
     return IconButton(
       icon: Icon(Icons.add_location_alt_outlined,
-          size: 20, color: color ?? AppColors.toolLocal),
+          size: 20,
+          color: color ?? AppColors.toolLocal(Theme.of(context).brightness)),
       tooltip: context.l10n.addToTripTitle,
       visualDensity: VisualDensity.compact,
       onPressed: onPressed,

--- a/src/packages/flutter-app/lib/widgets/chat_panel.dart
+++ b/src/packages/flutter-app/lib/widgets/chat_panel.dart
@@ -1083,7 +1083,7 @@ class _ResultStrips extends ConsumerWidget {
       if (r.localRecs != null && r.localRecs!.isNotEmpty)
         PlacePhotoStrip(
           icon: Icons.verified,
-          accent: AppColors.toolLocal,
+          accent: AppColors.toolLocal(scheme.brightness),
           label: label(
               l10n.chatChipLocalPicks(r.localRecs!.length), r.localRecsCity),
           onViewTrip: onHeaderTap,
@@ -1091,7 +1091,8 @@ class _ResultStrips extends ConsumerWidget {
             for (final rec in r.localRecs!.take(_maxCards))
               PlacePhotoCard(
                 data: PlaceCardData.localRec(rec,
-                    photoUrl: photoUrl(rec.photoRef)),
+                    photoUrl: photoUrl(rec.photoRef),
+                    brightness: scheme.brightness),
                 onTap: () => openMaps(rec.name, rec.placeId),
                 onAddToTrip: signedIn
                     ? () => addToTrip(AddToTripPayload.fromLocalRec(rec))
@@ -1102,13 +1103,13 @@ class _ResultStrips extends ConsumerWidget {
       if (r.events != null && r.events!.isNotEmpty)
         PlacePhotoStrip(
           icon: Icons.local_activity,
-          accent: AppColors.toolEvents,
+          accent: AppColors.toolEvents(scheme.brightness),
           label: label(l10n.chatChipEvents(r.events!.length), r.eventsCity),
           onViewTrip: onHeaderTap,
           cards: [
             for (final event in r.events!.take(_maxCards))
               PlacePhotoCard(
-                data: PlaceCardData.event(event),
+                data: PlaceCardData.event(event, brightness: scheme.brightness),
                 onTap: event.url.isEmpty
                     ? null
                     : () => trackedLaunchUrl(context, event.url,
@@ -1123,7 +1124,7 @@ class _ResultStrips extends ConsumerWidget {
       if (r.parkingSpots != null && r.parkingSpots!.isNotEmpty)
         PlacePhotoStrip(
           icon: Icons.local_parking,
-          accent: AppColors.toolParking,
+          accent: AppColors.toolParking(scheme.brightness),
           label: label(l10n.chatStripParking(r.parkingSpots!.length),
               r.parkingBeach),
           onViewTrip: onHeaderTap,
@@ -1132,7 +1133,8 @@ class _ResultStrips extends ConsumerWidget {
               PlacePhotoCard(
                 data: PlaceCardData.parking(spot,
                     photoUrl: photoUrl(spot.photoRef),
-                    freeLabel: l10n.chatCardFreeListed),
+                    freeLabel: l10n.chatCardFreeListed,
+                    brightness: scheme.brightness),
                 onTap: () => openMaps(spot.name, spot.placeId),
                 onAddToTrip: signedIn
                     ? () => addToTrip(AddToTripPayload.fromPlace(spot))
@@ -1143,7 +1145,7 @@ class _ResultStrips extends ConsumerWidget {
       if (r.hotels != null && r.hotels!.stays.isNotEmpty)
         PlacePhotoStrip(
           icon: Icons.hotel,
-          accent: AppColors.toolStays,
+          accent: AppColors.toolStays(scheme.brightness),
           // The "no live rates" caveat rides the HEADER, not the cards: the
           // tier is a property of the whole result set, and a 200x160 card
           // showing a rating has no room for a disclaimer anyway.
@@ -1160,6 +1162,7 @@ class _ResultStrips extends ConsumerWidget {
               PlacePhotoCard(
                 data: PlaceCardData.hotel(
                   stay,
+                  brightness: scheme.brightness,
                   photoUrl: stay.resolvedPhotoUrl(apiBase),
                   priceLabel: stay.ratePerNight == null || stay.currency == null
                       ? null
@@ -1232,7 +1235,7 @@ class _ResultChips extends ConsumerWidget {
       if (r.flights != null && r.flights!.isNotEmpty)
         ResultSummaryChip(
           icon: Icons.flight,
-          accent: AppColors.toolFlights,
+          accent: AppColors.toolFlights(Theme.of(context).brightness),
           label: label(
               l10n.chatChipFlightOptions(r.flights!.length), r.flightRoute),
           onTap: onTap,
@@ -1240,7 +1243,7 @@ class _ResultChips extends ConsumerWidget {
       if (r.ferries != null && r.ferries!.isNotEmpty)
         ResultSummaryChip(
           icon: Icons.directions_boat,
-          accent: AppColors.toolFerries,
+          accent: AppColors.toolFerries(Theme.of(context).brightness),
           label:
               label(l10n.chatChipFerryOptions(r.ferries!.length), r.ferryRoute),
           onTap: onTap,
@@ -1248,7 +1251,7 @@ class _ResultChips extends ConsumerWidget {
       if (r.eventLinks != null && r.eventLinks!.isNotEmpty)
         ResultSummaryChip(
           icon: Icons.link,
-          accent: AppColors.toolEvents,
+          accent: AppColors.toolEvents(Theme.of(context).brightness),
           label: label(l10n.chatChipEventSources(r.eventLinks!.length),
               r.eventLinksCity),
           onTap: onTap,
@@ -1296,14 +1299,14 @@ class _ResultLinks extends ConsumerWidget {
       if (r.stayLinks != null && r.stayLinks!.isNotEmpty)
         SourceLinksCard(
           icon: Icons.hotel,
-          accent: AppColors.toolStays,
+          accent: AppColors.toolStays(Theme.of(context).brightness),
           title: title(l10n.chatLinksStays, r.stayWhere),
           links: r.stayLinks!,
         ),
       if (r.transportLinks != null && r.transportLinks!.isNotEmpty)
         SourceLinksCard(
           icon: Icons.directions,
-          accent: AppColors.toolFlights,
+          accent: AppColors.toolFlights(Theme.of(context).brightness),
           title: title(l10n.chatLinksTransport, r.transportRoute),
           links: r.transportLinks!,
         ),

--- a/src/packages/flutter-app/lib/widgets/city_events_sheet.dart
+++ b/src/packages/flutter-app/lib/widgets/city_events_sheet.dart
@@ -87,7 +87,9 @@ class CityEventsSheetBody extends StatelessWidget {
           padding: const EdgeInsets.only(bottom: AppSpacing.sm),
           child: Row(
             children: [
-              Icon(Icons.local_activity, size: 20, color: AppColors.toolEvents),
+              Icon(Icons.local_activity,
+                  size: 20,
+                  color: AppColors.toolEvents(theme.brightness)),
               const SizedBox(width: AppSpacing.sm),
               Expanded(
                 child: Text(

--- a/src/packages/flutter-app/lib/widgets/event_card.dart
+++ b/src/packages/flutter-app/lib/widgets/event_card.dart
@@ -55,7 +55,7 @@ class EventCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final accent = AppColors.toolEvents;
+    final accent = AppColors.toolEvents(theme.brightness);
     final subtitle = [
       if (event.venue.isNotEmpty) event.venue,
       if (event.category.isNotEmpty) event.category,

--- a/src/packages/flutter-app/lib/widgets/local_rec_card.dart
+++ b/src/packages/flutter-app/lib/widgets/local_rec_card.dart
@@ -20,7 +20,7 @@ class LocalRecCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final accent = AppColors.toolLocal;
+    final accent = AppColors.toolLocal(theme.brightness);
     final subtitle = [
       if (rec.neighborhood.isNotEmpty) rec.neighborhood,
       if (rec.category.isNotEmpty) rec.category,

--- a/src/packages/flutter-app/lib/widgets/place_photo_card.dart
+++ b/src/packages/flutter-app/lib/widgets/place_photo_card.dart
@@ -87,6 +87,7 @@ class PlaceCardData {
   factory PlaceCardData.localRec(
     LocalRecommendation rec, {
     required String? photoUrl,
+    required Brightness brightness,
   }) {
     return PlaceCardData(
       title: rec.name,
@@ -97,7 +98,7 @@ class PlaceCardData {
         if (rec.category.isNotEmpty) rec.category,
       ].join(' · '),
       fallbackIcon: Icons.verified,
-      accent: AppColors.toolLocal,
+      accent: AppColors.toolLocal(brightness),
       localBadge: true,
       localCredit: rec.creditLine,
     );
@@ -112,6 +113,7 @@ class PlaceCardData {
     AgentPlace place, {
     required String? photoUrl,
     required String freeLabel,
+    required Brightness brightness,
   }) {
     return PlaceCardData(
       title: place.name,
@@ -125,18 +127,21 @@ class PlaceCardData {
       rating: place.freeListed ? null : place.rating,
       priceLevel: place.freeListed ? null : place.priceLevel,
       fallbackIcon: Icons.local_parking,
-      accent: AppColors.toolParking,
+      accent: AppColors.toolParking(brightness),
       metaIsAccent: place.freeListed,
     );
   }
 
-  factory PlaceCardData.event(Event event) {
+  factory PlaceCardData.event(
+    Event event, {
+    required Brightness brightness,
+  }) {
     return PlaceCardData(
       title: event.name,
       photoUrl: event.imageUrl.isEmpty ? null : event.imageUrl,
       metaLine: eventWhenLabel(event),
       fallbackIcon: Icons.local_activity,
-      accent: AppColors.toolEvents,
+      accent: AppColors.toolEvents(brightness),
       externalLink: event.url.isNotEmpty,
       metaIsAccent: true,
     );
@@ -151,6 +156,7 @@ class PlaceCardData {
     HotelStay stay, {
     required String? photoUrl,
     required String? priceLabel,
+    required Brightness brightness,
   }) {
     return PlaceCardData(
       title: stay.name,
@@ -162,7 +168,7 @@ class PlaceCardData {
       priceLabel: priceLabel,
       fallbackIcon:
           stay.kind == 'vacation_rental' ? Icons.house_outlined : Icons.hotel,
-      accent: AppColors.toolStays,
+      accent: AppColors.toolStays(brightness),
       externalLink: stay.bookingUrl.isNotEmpty,
     );
   }
@@ -283,8 +289,12 @@ class PlacePhotoCard extends StatelessWidget {
                                 color: Colors.white,
                                 shape: BoxShape.circle,
                               ),
+                              // The badge disc is white in both themes, so
+                              // the glyph always takes the light shade.
                               child: Icon(Icons.verified,
-                                  size: 14, color: AppColors.toolLocal),
+                                  size: 14,
+                                  color: AppColors.toolLocal(
+                                      Brightness.light)),
                             ),
                           ),
                         ),

--- a/src/packages/flutter-app/lib/widgets/trip_detail/itinerary_tab.dart
+++ b/src/packages/flutter-app/lib/widgets/trip_detail/itinerary_tab.dart
@@ -648,13 +648,15 @@ extension on _TripDetailScreenState {
                   left: AppSpacing.md, top: AppSpacing.sm, bottom: AppSpacing.xs),
               child: Row(
                 children: [
-                  Icon(Icons.verified, size: 16, color: AppColors.toolLocal),
+                  Icon(Icons.verified,
+                      size: 16,
+                      color: AppColors.toolLocal(theme.brightness)),
                   const SizedBox(width: 6),
                   Text(
                     context.l10n.tripLocalIntel,
                     style: theme.textTheme.labelLarge?.copyWith(
                       fontWeight: FontWeight.w600,
-                      color: AppColors.toolLocal,
+                      color: AppColors.toolLocal(theme.brightness),
                     ),
                   ),
                 ],
@@ -677,7 +679,7 @@ extension on _TripDetailScreenState {
   /// A tappable "Local guide" row inside the Local intel section that opens the
   /// full narrative guide (story + ordered pins + map).
   Widget _guideChip(LocalGuide guide, ThemeData theme) {
-    final accent = AppColors.toolLocal;
+    final accent = AppColors.toolLocal(theme.brightness);
     return Card(
       margin: const EdgeInsets.symmetric(vertical: AppSpacing.xs),
       clipBehavior: Clip.antiAlias,
@@ -805,7 +807,7 @@ extension on _TripDetailScreenState {
               padding: const EdgeInsets.only(left: AppSpacing.md),
               child: PlacePhotoStrip(
                 icon: Icons.local_activity,
-                accent: AppColors.toolEvents,
+                accent: AppColors.toolEvents(theme.brightness),
                 // Counts everything found, not the cards shown — otherwise 8
                 // reads as "that's all there is". At the server's per-city cap
                 // the true total is unknown, so the count says "30+".
@@ -826,7 +828,8 @@ extension on _TripDetailScreenState {
                 cards: [
                   for (final e in picks)
                     PlacePhotoCard(
-                      data: PlaceCardData.event(e),
+                      data: PlaceCardData.event(e,
+                          brightness: theme.brightness),
                       onTap: e.url.isEmpty
                           ? null
                           : () => trackedLaunchUrl(context, e.url,
@@ -855,7 +858,7 @@ extension on _TripDetailScreenState {
       if (links == null || links.isEmpty) return const SizedBox.shrink();
       return SourceLinksCard(
         icon: Icons.local_activity,
-        accent: AppColors.toolEvents,
+        accent: AppColors.toolEvents(theme.brightness),
         title: context.l10n.tripFindEventsIn(query.city),
         links: links,
       );
@@ -1702,14 +1705,15 @@ extension on _TripDetailScreenState {
                         mainAxisSize: MainAxisSize.min,
                         children: [
                           Icon(Icons.verified,
-                              size: 13, color: AppColors.toolLocal),
+                              size: 13,
+                              color: AppColors.toolLocal(theme.brightness)),
                           const SizedBox(width: 4),
                           Flexible(
                             child: Text(
                               context.l10n
                                   .tripRecommendedBy(item.localSourceName!),
                               style: theme.textTheme.labelSmall?.copyWith(
-                                color: AppColors.toolLocal,
+                                color: AppColors.toolLocal(theme.brightness),
                                 fontWeight: FontWeight.w600,
                               ),
                               maxLines: 1,

--- a/src/packages/flutter-app/lib/widgets/trip_map.dart
+++ b/src/packages/flutter-app/lib/widgets/trip_map.dart
@@ -1193,7 +1193,7 @@ class _HomePin extends StatelessWidget {
           width: 26,
           height: 26,
           decoration: BoxDecoration(
-            color: AppColors.toolFlights,
+            color: AppColors.toolFlights(Theme.of(context).brightness),
             borderRadius: BorderRadius.circular(AppRadius.sm),
             border: Border.all(color: Colors.white, width: 2),
             boxShadow: AppShadows.pin,
@@ -1236,7 +1236,7 @@ class _StayPin extends StatelessWidget {
           // Same white ring + shadow treatment as _Pin so it reads as part
           // of the family, but square where itinerary pins are round.
           decoration: BoxDecoration(
-            color: AppColors.toolStays,
+            color: AppColors.toolStays(Theme.of(context).brightness),
             borderRadius: BorderRadius.circular(AppRadius.sm),
             border: Border.all(color: Colors.white, width: 2),
             boxShadow: AppShadows.pin,


### PR DESCRIPTION
## Why

PR #527 (Aegean-night surfaces) surfaced this and deliberately deferred it: the seven planning-tool accents were fixed Material shades, and on the new dark card `#153851` four of them sat under the 3:1 control floor — flights 2.66, stays 2.47, events 1.74, parking 1.69.

## What

The accents now follow the repo's existing status-mark pattern (`upMark`/`degradedMark`/`downMark`): a function of `Brightness`, lighter rung in dark, **light mode byte-identical**.

| accent | light (unchanged) | dark (new) | was on card | now on card |
| --- | --- | --- | --- | --- |
| route | deep-orange 600 | deep-orange 400 | 3.52 : 1 | 4.46 : 1 |
| flights | blue 700 | blue 400 | 2.66 : 1 | 4.62 : 1 |
| stays | pink 600 | pink 300 | 2.47 : 1 | 4.00 : 1 |
| events | purple 600 | purple 300 | 1.74 : 1 | 3.44 : 1 |
| ferries | cyan 700 | cyan 400 | 3.49 : 1 | 5.93 : 1 |
| local | amber 800 | amber 400 | 5.35 : 1 | 8.00 : 1 |
| parking | blue-grey 700 | blue-grey 300 | 1.69 : 1 | 4.72 : 1 |

All seven also clear 3:1 on the page `#0C1F2C`. Dark is shade 400 where that clears with margin, 300 where 400 lands thin (stays 3.25, events 2.54, parking 3.65); purple 300 at 3.44 is the best the family does without washing out the hue.

## Judgment calls

- **All seven moved**, not just the four failures — one rule ("lighter rung in dark") instead of seven exceptions.
- **The verified badge keeps the light shade deliberately**: its disc is hardcoded white in both themes, so amber 400 there would be 1.6:1 on white.
- **Map pins follow brightness** — the white ring + shadow keeps them separated from the tiles.
- `PlaceCardData.localRec/parking/event/hotel` take a required `brightness:`, mirroring `.place`'s existing `scheme` param.
- DESIGN.md's Tertiary rule records the light/dark pairs (the standing rule-that-breaks-gets-written-down commitment).

## Testing

- `flutter analyze` clean (3 pre-existing infos in untouched `route_response.dart`)
- Full suite green: **1834 tests passed**

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/golden-tempo/codesmith/anemos-travel/pr/533"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789952306&installation_model_id=433099&pr_number=533&repository=golden-tempo%2Fanemos-travel&return_to=https%3A%2F%2Fgithub.com%2Fgolden-tempo%2Fanemos-travel%2Fpull%2F533&signature=1f18a49aa78e7d7e6e5318f4ad9bca089d180378eb67517ae5d6c87a9ca7b4d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->