### PR TITLE
feat(plan): the composer joins the block on the empty Plan tab

### DIFF
--- a/src/packages/flutter-app/lib/screens/agent_screen.dart
+++ b/src/packages/flutter-app/lib/screens/agent_screen.dart
@@ -137,49 +137,16 @@ const double _kRailCardWidth = 260;
 /// and the whole point of this block is that it reads in one glance.
 const double _kIntroMeasure = 420;
 
-/// Below this the reading block stops floating in a field of its own and joins
-/// the scroll with everything else. Measured against the shortest viewport the
-/// screen has to hold (a 568pt phone, less the app bar and the composer, is
-/// ~430) rather than guessed from a width breakpoint — the thing that runs out
-/// here is height, so height is what is asked.
-const double _kIntroFieldFloor = 440;
-
-/// Where the intro block sits in its field, as an [Alignment] y.
-///
-/// Slightly above centre: the optical centre of a field is above its geometric
-/// one, so an evenly-split block reads as having sagged.
-///
-/// This number exists because the screen used to hold the reading half and the
-/// acting half apart — the rail was pinned to the composer and the heading
-/// floated in whatever was left over. On a phone that is invisible, because
-/// there is nothing left over. On a 934px desktop field there are ~544px of it,
-/// and pinning the rail meant every one of those pixels had to sit either above
-/// the heading or between the heading and the rail. Both were measured in the
-/// running app at 1342x988 and both are wrong: 374/123 leaves the whole
-/// composition in the bottom half, and 303/196 opens a hole through the middle
-/// of it. There is no third split, because the two are the same 544px.
-///
-/// So the halves travel together now and the leftover goes below them, between
-/// the rail and the composer. That gives up the adjacency the previous pass
-/// prized — starters within reach of the input — and it is a real cost on a
-/// short viewport, which is why the branch below [_kIntroFieldFloor] still
-/// stacks them tight. What it buys is one object instead of three zones.
-///
-/// Every number above is a browser measurement. Nothing here may be asserted
-/// from a widget test — this suite loads no fonts, so its text metrics are
-/// fiction.
-const double _kIntroBlockBias = -0.1;
-
 /// The Plan tab before a word is typed.
 ///
-/// Composed as ONE block that ends at the composer instead of a centered card
-/// marooned in the middle of the panel: the reading half (heading + what the
-/// agent will do) takes an open field over its head, and the acting half
-/// (destination rail, then the two non-typing ways in) sits directly above the
-/// input, so the eye finishes the sentence on the thing it is supposed to use. That adjacency is the redesign — every AI start screen
-/// worth copying (and Mindtrip, the closest competitor) hangs its starters off
-/// the composer, and the old layout hung them off the vertical centre with
-/// ~200px of nothing underneath.
+/// ONE block — the reading half (heading + what the agent will do) over the
+/// acting half (destination rail, then the two non-typing ways in) — that
+/// [ChatPanel] joins with the composer into a single group on any field tall
+/// enough to hold it, so the eye finishes the sentence on the thing it is
+/// supposed to use. That adjacency is the redesign: every AI start screen
+/// worth copying (and Mindtrip, the closest competitor) hangs its starters
+/// off the composer, and the old layouts hung the block off the vertical
+/// centre with hundreds of pixels of nothing underneath.
 ///
 /// Deliberately NOT the shared [EmptyState] widget: that one is the app's
 /// "nothing here yet" voice — icon, title, message, a Wrap of buttons, all
@@ -256,42 +223,22 @@ class _PlanIntro extends ConsumerWidget {
       ],
     );
 
-    return LayoutBuilder(
-      builder: (context, constraints) {
-        if (constraints.maxHeight < _kIntroFieldFloor) {
-          return SingleChildScrollView(
-            child: Column(
-              children: [
-                const SizedBox(height: AppSpacing.xl),
-                reading,
-                const SizedBox(height: AppSpacing.xl),
-                acting,
-              ],
-            ),
-          );
-        }
-        // The two halves as ONE object, placed in the field together — see
-        // [_kIntroBlockBias] for why the rail no longer rides the composer.
-        return Align(
-          alignment: const Alignment(0, _kIntroBlockBias),
-          // Loose constraints from Align, so this shrink-wraps unless the
-          // largest text scales make the block taller than the field — then it
-          // scrolls instead of overflowing.
-          child: SingleChildScrollView(
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                reading,
-                // The block's own seam. A ladder value, not a share of the
-                // leftover: it says how close these two halves are, which is a
-                // fixed relationship, not a function of the viewport.
-                const SizedBox(height: AppSpacing.xxl),
-                acting,
-              ],
-            ),
-          ),
-        );
-      },
+    // ONE shrink-wrapped block; where it sits is not this widget's question
+    // anymore. ChatPanel owns the vertical distribution: on a tall field the
+    // composer joins the block and the air splits below it; on a short one
+    // the block scrolls and the composer keeps the floor. (What must never
+    // return here is a bias constant whose dartdoc explains machinery that
+    // no longer runs.)
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        reading,
+        // The block's own seam. A ladder value, not a share of the leftover:
+        // it says how close these two halves are, which is a fixed
+        // relationship, not a function of the viewport.
+        const SizedBox(height: AppSpacing.xxl),
+        acting,
+      ],
     );
   }
 }

--- a/src/packages/flutter-app/lib/widgets/chat_panel.dart
+++ b/src/packages/flutter-app/lib/widgets/chat_panel.dart
@@ -29,6 +29,28 @@ import 'place_photo_card.dart';
 import 'source_links_card.dart';
 import 'result_summary_chip.dart';
 
+/// The panel height below which the Plan tab's empty state keeps the
+/// composer on the floor and scrolls the intro, instead of joining them
+/// into one [intro, gap, composer] group.
+///
+/// Height is what is asked because height is what runs out (the rule
+/// _PlanIntro's old field floor stated): a 568pt phone offers the panel
+/// ~510px once the app bar is gone, and an open keyboard takes most of any
+/// field — both must keep the composer at the floor, which is the layout
+/// the app has always had. The joined group measures ~471px at default
+/// text scale (browser-measured at 1440x900: intro 263→634, the 33px seam,
+/// composer 667→734), so 650 admits it with at least ~100px of air above
+/// and ~75 below — less, and the split reads as crowding rather than
+/// composition.
+const double _kComposerJoinFloor = 650;
+
+/// Where the Plan tab's joined [intro, gap, composer] group sits in its
+/// field, as an [Alignment] y. 1/7 splits the leftover air 4:3 above/below:
+/// at the 938px field this composition was measured against that is ~215
+/// over ~156 — the heading holds the position #517 set for it while the
+/// 268px void #520 left between the block and the input closes.
+const double _kComposerGroupBias = 1 / 7;
+
 /// The plan-agent chat surface (messages, tool chips, result chips, input bar)
 /// decoupled from any screen, so the full-screen Agent tab and the trip-detail
 /// refine panel share one implementation. The provider pair is passed in:
@@ -384,54 +406,14 @@ class _ChatPanelState extends ConsumerState<ChatPanel> {
     // window, or dock bubbles run the full dock width on desktop.
     return LayoutBuilder(builder: (context, constraints) {
       final bubbleMaxWidth = _bubbleMaxWidthFor(constraints.maxWidth);
-      final panel = Column(
+      // The composer and its pending-attachments row as ONE unit. On the
+      // Plan tab's empty state it leaves the floor and joins the intro
+      // block — see _kComposerJoinFloor — so it is built once, here, and
+      // placed by the branch below rather than hard-coded to the column's
+      // tail.
+      final composer = Column(
+        mainAxisSize: MainAxisSize.min,
         children: [
-          Expanded(
-            child: isEmpty
-                ? (widget.emptyState ?? const SizedBox.shrink())
-                // SelectionArea wraps only the message list: the composer's
-                // TextField below has native selection and must keep its own
-                // gesture handling.
-                : SelectionArea(
-                    child: NotificationListener<ScrollNotification>(
-                      onNotification: _onScrollNotification,
-                      child: ListView.builder(
-                        controller: _scrollController,
-                        padding: const EdgeInsets.symmetric(
-                            horizontal: AppSpacing.lg, vertical: AppSpacing.md),
-                        itemCount: messages.length + 1,
-                        itemBuilder: (context, i) {
-                          if (i < messages.length) {
-                            final msg = messages[i];
-                            // Labeled messages (e.g. the machine-built refine
-                            // seed) collapse to a context chip; the full content
-                            // still went to the server history.
-                            if (msg.displayLabel != null) {
-                              return _SeedContextChip(
-                                key: ValueKey('msg-$i'),
-                                label: msg.displayLabel!,
-                              );
-                            }
-                            // Append-only list, so index keys are stable.
-                            return ChatMessageBubble(
-                              key: ValueKey('msg-$i'),
-                              message: msg,
-                              maxWidth: bubbleMaxWidth,
-                            );
-                          }
-                          return _ChatTail(
-                            key: const ValueKey('chat-tail'),
-                            state: widget.state,
-                            notifier: widget.notifier,
-                            footerBuilder: widget.footerBuilder,
-                            onViewTrip: widget.onViewTrip,
-                            bubbleMaxWidth: bubbleMaxWidth,
-                          );
-                        },
-                      ),
-                    ),
-                  ),
-          ),
           if (_pending.isNotEmpty || _processingCount > 0)
             _PendingAttachmentsRow(
               pending: _pending,
@@ -456,6 +438,99 @@ class _ChatPanelState extends ConsumerState<ChatPanel> {
           ),
         ],
       );
+
+      final Widget panel;
+      if (isEmpty && widget.emptyState != null) {
+        // The Plan tab before a word is typed. The gate is HEIGHT — the
+        // thing that runs out — never width. Below the floor (a phone, an
+        // open keyboard) the composer keeps the floor and the intro
+        // scrolls, exactly as _PlanIntro's old field rule arranged. At or
+        // above it the composer joins the block as [intro, gap,
+        // composer], placed by _kComposerGroupBias. The scroll wrapper only
+        // ever runs when text scaling makes the group taller than the
+        // field.
+        panel = constraints.maxHeight < _kComposerJoinFloor
+            ? Column(
+                children: [
+                  Expanded(
+                    child: SingleChildScrollView(
+                      padding: const EdgeInsets.only(top: AppSpacing.xl),
+                      child: widget.emptyState!,
+                    ),
+                  ),
+                  composer,
+                ],
+              )
+            : Align(
+                alignment: const Alignment(0, _kComposerGroupBias),
+                // Loose constraints from Align, so the group shrink-wraps
+                // unless the largest text scales make it taller than the
+                // field — then it scrolls instead of overflowing.
+                child: SingleChildScrollView(
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      widget.emptyState!,
+                      const SizedBox(height: AppSpacing.lg),
+                      composer,
+                    ],
+                  ),
+                ),
+              );
+      } else {
+        panel = Column(
+          children: [
+            Expanded(
+              child: isEmpty
+                  ? const SizedBox.shrink()
+                  // SelectionArea wraps only the message list: the composer's
+                  // TextField below has native selection and must keep its own
+                  // gesture handling.
+                  : SelectionArea(
+                      child: NotificationListener<ScrollNotification>(
+                        onNotification: _onScrollNotification,
+                        child: ListView.builder(
+                          controller: _scrollController,
+                          padding: const EdgeInsets.symmetric(
+                              horizontal: AppSpacing.lg,
+                              vertical: AppSpacing.md),
+                          itemCount: messages.length + 1,
+                          itemBuilder: (context, i) {
+                            if (i < messages.length) {
+                              final msg = messages[i];
+                              // Labeled messages (e.g. the machine-built refine
+                              // seed) collapse to a context chip; the full content
+                              // still went to the server history.
+                              if (msg.displayLabel != null) {
+                                return _SeedContextChip(
+                                  key: ValueKey('msg-$i'),
+                                  label: msg.displayLabel!,
+                                );
+                              }
+                              // Append-only list, so index keys are stable.
+                              return ChatMessageBubble(
+                                key: ValueKey('msg-$i'),
+                                message: msg,
+                                maxWidth: bubbleMaxWidth,
+                              );
+                            }
+                            return _ChatTail(
+                              key: const ValueKey('chat-tail'),
+                              state: widget.state,
+                              notifier: widget.notifier,
+                              footerBuilder: widget.footerBuilder,
+                              onViewTrip: widget.onViewTrip,
+                              bubbleMaxWidth: bubbleMaxWidth,
+                            );
+                          },
+                        ),
+                      ),
+                    ),
+            ),
+            composer,
+          ],
+        );
+      }
 
       // DropTarget is a no-op on platforms without drag-drop (mobile), so the
       // wrap is unconditional. The overlay invites the drop while a drag
@@ -1112,8 +1187,7 @@ class _ResultStrips extends ConsumerWidget {
                 onTap: event.url.isEmpty
                     ? null
                     : () => trackedLaunchUrl(context, event.url,
-                        provider: 'ticketmaster',
-                        surface: 'chat_event_card'),
+                        provider: 'ticketmaster', surface: 'chat_event_card'),
                 onAddToTrip: signedIn
                     ? () => addToTrip(AddToTripPayload.fromEvent(event))
                     : null,
@@ -1124,8 +1198,8 @@ class _ResultStrips extends ConsumerWidget {
         PlacePhotoStrip(
           icon: Icons.local_parking,
           accent: AppColors.toolParking,
-          label: label(l10n.chatStripParking(r.parkingSpots!.length),
-              r.parkingBeach),
+          label: label(
+              l10n.chatStripParking(r.parkingSpots!.length), r.parkingBeach),
           onViewTrip: onHeaderTap,
           cards: [
             for (final spot in r.parkingSpots!.take(_maxCards))

--- a/src/packages/flutter-app/test/chat_panel_empty_state_test.dart
+++ b/src/packages/flutter-app/test/chat_panel_empty_state_test.dart
@@ -1,0 +1,110 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:travel_route_planner/models/plan_message.dart';
+import 'package:travel_route_planner/providers/plan_provider.dart';
+import 'package:travel_route_planner/services/api_client.dart';
+import 'package:travel_route_planner/services/plan_service.dart';
+import 'package:travel_route_planner/widgets/chat_panel.dart';
+
+import 'support/l10n_test_app.dart';
+
+/// The Plan tab's empty state joins the composer into one block on a field
+/// tall enough to hold it, and keeps the composer on the floor below that.
+/// These assert STRUCTURE and WHICH BRANCH is taken — never positions: this
+/// suite loads no fonts, so its text metrics are fiction and every number
+/// that matters was measured in the browser instead (1440x900 joined,
+/// 390x844 joined, 1440x600 floor, non-empty floor).
+
+class _SeededPlanNotifier extends PlanNotifier {
+  _SeededPlanNotifier(PlanState seeded)
+      : super(PlanService('http://unused'), ApiClient()) {
+    state = seeded;
+  }
+}
+
+/// The joined branch places the [intro, gap, composer] group with an Align
+/// whose y splits the leftover air 4:3. Private to chat_panel.dart, so the
+/// branch is detected by the alignment value itself.
+final _joinBias = Alignment(0, 1 / 7);
+
+Future<void> _pump(
+  WidgetTester tester,
+  Size size, {
+  PlanState? seeded,
+  Widget? emptyState,
+}) async {
+  tester.view.physicalSize = size;
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.resetPhysicalSize);
+  addTearDown(tester.view.resetDevicePixelRatio);
+
+  final provider = StateNotifierProvider<PlanNotifier, PlanState>(
+      (ref) => _SeededPlanNotifier(seeded ?? PlanState()));
+  await tester.pumpWidget(
+    ProviderScope(
+      child: localizedTestApp(
+        home: Scaffold(
+          body: ChatPanel(
+            state: provider,
+            notifier: provider.notifier,
+            emptyState: emptyState,
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+Finder _joinAlign() => find.byWidgetPredicate(
+      (w) => w is Align && w.alignment == _joinBias,
+    );
+
+void main() {
+  testWidgets('tall field: empty state and composer join as one group',
+      (tester) async {
+    await _pump(tester, const Size(800, 900),
+        emptyState: const Text('INTRO-BLOCK'));
+
+    expect(find.text('INTRO-BLOCK'), findsOneWidget);
+    expect(find.byType(TextField), findsOneWidget);
+    expect(_joinAlign(), findsOneWidget);
+  });
+
+  testWidgets('short field: composer keeps the floor, intro scrolls',
+      (tester) async {
+    await _pump(tester, const Size(800, 500),
+        emptyState: const Text('INTRO-BLOCK'));
+
+    expect(find.text('INTRO-BLOCK'), findsOneWidget);
+    expect(find.byType(TextField), findsOneWidget);
+    expect(_joinAlign(), findsNothing);
+  });
+
+  testWidgets('empty without an emptyState (the refine dock) never joins',
+      (tester) async {
+    await _pump(tester, const Size(800, 900));
+
+    expect(find.byType(TextField), findsOneWidget);
+    expect(_joinAlign(), findsNothing);
+  });
+
+  testWidgets('a non-empty panel keeps the transcript and the floor composer',
+      (tester) async {
+    await _pump(
+      tester,
+      const Size(800, 900),
+      seeded: PlanState(messages: [
+        PlanMessage(role: MessageRole.user, content: 'Weekend in Lisbon'),
+      ]),
+      emptyState: const Text('INTRO-BLOCK'),
+    );
+
+    expect(find.text('INTRO-BLOCK'), findsNothing);
+    expect(find.text('Weekend in Lisbon'), findsOneWidget);
+    expect(find.byType(TextField), findsOneWidget);
+    expect(_joinAlign(), findsNothing);
+  });
+}


### PR DESCRIPTION
## What

The third pass on the Plan tab's empty state, finishing what #517 and #520 started. #520 made the reading half and the acting half one object and moved the leftover below the rail — all **268px** of it, measured from the traveler's screenshot (heading top 264, chips bottom 630, composer top 898 at 1341×988). The composer was the piece still stranded outside the object; this brings it in.

`ChatPanel` owns the vertical distribution now, gated on **height, never width** (the thing that runs out is height, as `_PlanIntro`'s old field floor already stated):

- **Field ≥ 650** (`_kComposerJoinFloor`): the empty branch lays out `[intro, gap, composer]` as one shrink-wrapped group, placed by `_kComposerGroupBias = 1/7` so the leftover air splits **4:3 above/below**.
- **Below it** (a 568pt phone's ~510px panel, an open keyboard): the composer keeps the floor and the intro scrolls — the layout the app has always had.
- **The refine dock is unreachable by construction**: it passes no `emptyState`, so the joined branch can't fire there.

`_kIntroBlockBias` and `_kIntroFieldFloor` are **retired honestly** — deleted, their reasoning moved to the new constants — rather than left describing machinery that no longer runs.

## Measured in the running app, not from source

Browser-verified (CDP, real pointer, on the lane's Docker stack) in all four states:

| State | Result |
|---|---|
| 1440×900 (joined) | heading ink starts at **y=263** — the approved position at 1341×988 was **264**; composer top **33px** under the chips; group 471px, air split 207/166 ≈ 4:3 |
| 390×844 (joined) | composition holds — block, composer, air below |
| 1440×600 (floor) | composer on the floor, intro top-aligned — the short-field branch |
| after sending (non-empty) | transcript fills, composer back on the floor — that branch is structurally untouched |

The first layout attempt (Spacer 4:3 around a `Flexible` scroll) put the group in a 105px scroll window — `Flexible` *shares* flex space rather than shrink-wrapping — and was caught on screen, which is why the shipped code uses the `Align` + loose-constraints pattern the old bias used.

## Gates

- `flutter test`: full suite green (1838), incl. 4 new structural tests in `chat_panel_empty_state_test.dart` (joined/floor/refine-dock/non-empty — **watched failing** with the change reverted). Structure and branch only, no positions — the suite loads no fonts
- `flutter analyze` clean on touched files
- `check.sh`: 17 findings on the two touched files, **all pre-existing, none in this diff** (verified line-by-line against the diff)

## Lane notes

Lane work was done in-session by the orchestrator from the epic's `plan-composer-rise` artifact (the Kimi lane stalled before writing code). The Docker stack on `:3004` is still up if a reviewer wants to resize the window and watch the gate trip.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/golden-tempo/codesmith/anemos-travel/pr/534"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789953641&installation_model_id=433099&pr_number=534&repository=golden-tempo%2Fanemos-travel&return_to=https%3A%2F%2Fgithub.com%2Fgolden-tempo%2Fanemos-travel%2Fpull%2F534&signature=bab2ec37b15bc972bccdb1a31c4a46886278770284a409391c6661db7353a8d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->