### PR TITLE
feat(theme): Midnight Harbor joins the Aegean family

### DIFF
--- a/.claude/skills/brand-guidelines/SKILL.md
+++ b/.claude/skills/brand-guidelines/SKILL.md
@@ -66,7 +66,7 @@ Paths below are relative to `src/packages/flutter-app/` unless rooted.
   identity + the primary action; tool accents and status colors appear at
   chip-and-pin scale, **never as fields**. ONE recorded exception (doc
   v1.2): the signed-out landing page commits to the dark
-  `landingCanvas` family (`app_colors.dart` — canvas ≈#00231D, glass
+  `landingCanvas` family (`app_colors.dart` — canvas #091620, glass
   ladder 6/8/10/12/14%, ink ladder 35/60/70/85%). The exception ends at
   sign-in; new landing surfaces pick a ladder rung, never a fresh alpha.
 - **Heritage gold `#E8C452`/`#B98B1E` lives in the mark and nowhere

--- a/.impeccable/design.json
+++ b/.impeccable/design.json
@@ -38,7 +38,7 @@
       "midnight-harbor": {
         "role": "secondary",
         "displayName": "Midnight Harbor",
-        "canonical": "#00231D"
+        "canonical": "#091620"
       },
       "map-scrim": {
         "role": "neutral",

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -8,7 +8,7 @@ colors:
   shallows-tint: "#E0F2F1"
   heritage-gold: "#E8C452"
   heritage-gold-deep: "#B98B1E"
-  midnight-harbor: "#00231D"
+  midnight-harbor: "#091620"
   map-scrim: "rgba(0, 0, 0, 0.6)"
   paper-fill: "#FAFAFA"
 typography:
@@ -138,12 +138,14 @@ Nothing is both.
 ### Secondary
 - **Heritage Gold** (#E8C452 / deep #B98B1E): lives in the wind-rose mark and
   nowhere else. Never text, never a button, never a UI accent.
-- **Midnight Harbor** (≈#00231D, `landingCanvas`): the signed-out landing
-  page's dark canvas — the ONE recorded exception (doc v1.2) to neutral
-  surfaces. On it, every raised fill is a rung of the glass ladder (white at
-  6/8/10/12%, hairline 14%) and every text tone a rung of the ink ladder
-  (white at 35/60/70/85%). New landing surfaces pick a rung, never mint a
-  fresh alpha. The exception ends at sign-in.
+- **Midnight Harbor** (#091620, `landingCanvas`): the signed-out landing
+  page's dark canvas — the one exception to the signed-in canvases, and now
+  inside their family: it is the Aegean-night ladder's deepest rung
+  (`containerLowest`), one step below the dark page. On it, every raised
+  fill is a rung of the glass ladder (white at 6/8/10/12%, hairline 14%) and
+  every text tone a rung of the ink ladder (white at 35/60/70/85%). New
+  landing surfaces pick a rung, never mint a fresh alpha. The exception ends
+  at sign-in.
 
 ### Tertiary
 - **Tool accents** (chip-and-pin scale only, one meaning each), brightness-
@@ -215,9 +217,9 @@ exists only on the signed-out landing. Everywhere else, surfaces are the
 neutral scheme and dark mode is the same build with brightness flipped." Two
 of its three clauses are now false — surfaces are authored rather than
 seed-derived, and dark is composed rather than flipped. Midnight Harbor is
-still the landing's own canvas and still ends at sign-in, but it is now a
-*green*-black sitting in front of a blue app, which is a real inconsistency
-and an open follow-up, not a rule.
+still the landing's own canvas and still ends at sign-in — and it now takes
+the Aegean ladder's deepest rung, so the exception no longer stands in
+front of the app in a different hue.
 
 ## Typography
 

--- a/docs/branding/brand-guidelines.html
+++ b/docs/branding/brand-guidelines.html
@@ -642,18 +642,18 @@
 
   <div class="keep">
   <h3>The landing dark canvas</h3>
-  <p class="small muted" style="margin-bottom:14px">The signed-out landing page is the <strong>one sanctioned exception</strong> to the two Aegean canvases: it commits to a dark brand look in both theme modes, on a teal-derived field of its own. The exception ends at sign-in — no in-app surface may adopt this family. Tokens in <code>app_colors.dart</code> (the landing family).</p>
+  <p class="small muted" style="margin-bottom:14px">The signed-out landing page is the <strong>one sanctioned exception</strong> to the two Aegean canvases: it commits to a dark brand look in both theme modes, on the Aegean-night ladder's deepest rung. The exception ends at sign-in — no in-app surface may adopt this family. Tokens in <code>app_colors.dart</code> (the landing family).</p>
   <div class="swatchcards">
     <div class="sw">
-      <div class="chip" style="background:#00231D"></div>
-      <div class="meta"><b>landingCanvas</b>brandDark lerped 55% toward black (≈#00231D). The full-page field behind every landing section — the second permitted large brand field, after brandGradient.</div>
+      <div class="chip" style="background:#091620"></div>
+      <div class="meta"><b>landingCanvas</b>The Aegean-night ladder’s deepest rung (#091620, <code>containerLowest</code>). The full-page field behind every landing section — the second permitted large brand field, after brandGradient.</div>
     </div>
     <div class="sw">
-      <div class="chip" style="background:linear-gradient(to bottom, rgba(0,35,29,0) , #00231D), url() #4E6963"></div>
+      <div class="chip" style="background:linear-gradient(to bottom, rgba(9,22,32,0) , #091620), url() #4E6963"></div>
       <div class="meta"><b>landingHeroBlend</b>canvas 0% → 100%, top → bottom. A <em>dissolve</em> layer, third beside the two scrims: it ends the hero photo into the canvas. Never used to set text on a photo — that is still heroScrim's job.</div>
     </div>
     <div class="sw">
-      <div class="chip" style="background:#00231D"><div style="margin:14px;height:56px;border-radius:12px;background:rgba(255,255,255,0.06);border:1px solid rgba(255,255,255,0.14)"></div></div>
+      <div class="chip" style="background:#091620"><div style="margin:14px;height:56px;border-radius:12px;background:rgba(255,255,255,0.06);border:1px solid rgba(255,255,255,0.14)"></div></div>
       <div class="meta"><b>Glass &amp; ink ladders</b>Fills are white at named strengths — card 6% · wellFaint 8% · field 10% · well 12% · hairline 14%; text and strokes take the ink ladder (disabled 35% · faint 60% · muted 70% · strong 85%). New landing surfaces pick a rung, never a fresh alpha.</div>
     </div>
   </div>

--- a/src/packages/flutter-app/lib/theme/app_colors.dart
+++ b/src/packages/flutter-app/lib/theme/app_colors.dart
@@ -133,10 +133,13 @@ abstract final class AppColors {
 
   // Landing dark-canvas family (specs/landing-redesign). The signed-out
   // landing page commits to the dark brand look regardless of theme mode, so
-  // its surfaces are named here rather than borrowed from the dark scheme —
-  // the dark cardTheme's neutral grey fights the teal canvas.
-  /// Deep teal page field behind every landing section.
-  static final Color landingCanvas = Color.lerp(brandDark, Colors.black, 0.55)!;
+  // its surfaces are named here rather than borrowed from a scheme that
+  // flips with the theme.
+  /// Deep blue page field behind every landing section: the Aegean-night
+  /// ladder's deepest rung, one step below the signed-in dark page, so the
+  /// signed-out canvas and the app read as one hue family. (Was brandDark
+  /// lerped 55% toward black — a green-black in front of a blue app.)
+  static final Color landingCanvas = aegeanNight.containerLowest;
 
   /// Glass card fill on [landingCanvas] (the feature grid's cards).
   static final Color landingCard = Colors.white.withValues(alpha: 0.06);


### PR DESCRIPTION
## Why

The Aegean-surfaces PR (#527) left this as its one recorded inconsistency: `landingCanvas` was `brandDark` (teal 900) lerped 55% toward black — a **green**-black (`#00231D`) standing one navigation away from a blue app. DESIGN.md carried it as "a real inconsistency and an open follow-up, not a rule."

## What

Midnight Harbor is now the Aegean-night ladder's deepest rung — `aegeanNight.containerLowest`, `#091620`:

- **Same near-black depth** (luminance within a hair of the old value), but the family's 205° hue, one step below the signed-in dark page (`#0C1F2C`). The signed-out → signed-in transition now stays in one blue.
- **The glass and ink ladders needed nothing** — they are alpha whites on the canvas, unaffected by the hue shift.
- **`landingHeroBlend` follows automatically** — it derives from `landingCanvas`.
- The name *Midnight Harbor* stays; a blue-black harbor at night is still a harbor at night.

Doc sync, per the standing rule-that-breaks-gets-written-down commitment: DESIGN.md (frontmatter, the Secondary bullet, and the Two Canvases note no longer records this as open), `brand-guidelines.html`, the brand-guidelines skill, and `design.json`.

## Testing

- `flutter analyze` clean (3 pre-existing infos in untouched `route_response.dart`)
- Full suite: **1838 passed, 1 failed** — `trips_list_header_test: a plain row prints its span on the date line, not as a chip` fails **identically on clean `origin/main`** (expects "· 34 days"; looks like a date-drifted fixture), so it is pre-existing and not from this change

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/golden-tempo/codesmith/anemos-travel/pr/535"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789965523&installation_model_id=433099&pr_number=535&repository=golden-tempo%2Fanemos-travel&return_to=https%3A%2F%2Fgithub.com%2Fgolden-tempo%2Fanemos-travel%2Fpull%2F535&signature=c6f13fefeeec3050919c6c255b348e781209e60f4a2fd631686cd27a7a770742"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->