### PR TITLE
fix(chat): the parking strip's accent takes brightness like the rest

### DIFF
--- a/src/packages/flutter-app/lib/widgets/chat_panel.dart
+++ b/src/packages/flutter-app/lib/widgets/chat_panel.dart
@@ -1198,7 +1198,7 @@ class _ResultStrips extends ConsumerWidget {
       if (r.parkingSpots != null && r.parkingSpots!.isNotEmpty)
         PlacePhotoStrip(
           icon: Icons.local_parking,
-          accent: AppColors.toolParking,
+          accent: AppColors.toolParking(scheme.brightness),
           label: label(
               l10n.chatStripParking(r.parkingSpots!.length), r.parkingBeach),
           onViewTrip: onHeaderTap,


### PR DESCRIPTION
## What

Main is red: the #534 merge's conflict resolution kept `accent: AppColors.toolParking,` where #533 had made every tool accent a function of brightness — so `flutter analyze` fails at `chat_panel.dart:1201:19` with a `Color Function(Brightness)` tear-off where a `Color` is expected. This is the one line, matching the eleven other `AppColors.tool*` call sites.

## Gates

- `flutter analyze` clean on the file (was the failing gate)
- `flutter test test/chat_panel_parking_strip_test.dart` — 5/5 green
- One-line diff, no other surface touched

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/golden-tempo/codesmith/anemos-travel/pr/536"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789966924&installation_model_id=433099&pr_number=536&repository=golden-tempo%2Fanemos-travel&return_to=https%3A%2F%2Fgithub.com%2Fgolden-tempo%2Fanemos-travel%2Fpull%2F536&signature=a74e55aaf1550cc53d23cbf2467c21d2956ab0cc5909fbc3c30fcb26da8d38d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->