### PR TITLE
fix(map): contain the world vertically; feat(plan): fade the destination rail's edges

### DIFF
--- a/src/packages/flutter-app/lib/screens/agent_screen.dart
+++ b/src/packages/flutter-app/lib/screens/agent_screen.dart
@@ -11,6 +11,7 @@ import '../widgets/account_menu.dart';
 import '../widgets/gradient_app_bar.dart';
 import '../widgets/chat_panel.dart';
 import '../widgets/destination_suggestion_card.dart';
+import '../widgets/fading_edge_scroll.dart';
 import '../widgets/near_me_chip.dart';
 import '../widgets/random_suggestions.dart';
 import '../providers/auth_provider.dart';
@@ -274,22 +275,29 @@ class _DestinationRail extends ConsumerWidget {
           behavior: ScrollConfiguration.of(context).copyWith(
             dragDevices: PointerDeviceKind.values.toSet(),
           ),
-          child: ListView.separated(
-            scrollDirection: Axis.horizontal,
-            padding: const EdgeInsets.symmetric(horizontal: AppSpacing.lg),
-            itemCount: prompts.length,
-            separatorBuilder: (_, __) => const SizedBox(width: AppSpacing.md),
-            itemBuilder: (context, i) {
-              final p = prompts[i];
-              return DestinationSuggestionCard(
-                prompt: p.text,
-                asset: p.asset,
-                credit: p.credit,
-                width: _kRailCardWidth,
-                onTap: () =>
-                    ref.read(planProvider.notifier).sendMessage(p.text),
-              );
-            },
+          // The pool is longer than any window, so this rail always runs off
+          // the edge. Without the fade it ended on a hard cut that read like
+          // the last card rather than a cropped one — the same complaint the
+          // home rails answered, so the same widget answers it here.
+          child: FadingEdgeScroll(
+            builder: (context, controller) => ListView.separated(
+              controller: controller,
+              scrollDirection: Axis.horizontal,
+              padding: const EdgeInsets.symmetric(horizontal: AppSpacing.lg),
+              itemCount: prompts.length,
+              separatorBuilder: (_, __) => const SizedBox(width: AppSpacing.md),
+              itemBuilder: (context, i) {
+                final p = prompts[i];
+                return DestinationSuggestionCard(
+                  prompt: p.text,
+                  asset: p.asset,
+                  credit: p.credit,
+                  width: _kRailCardWidth,
+                  onTap: () =>
+                      ref.read(planProvider.notifier).sendMessage(p.text),
+                );
+              },
+            ),
           ),
         ),
       ),

--- a/src/packages/flutter-app/lib/widgets/app_map.dart
+++ b/src/packages/flutter-app/lib/widgets/app_map.dart
@@ -100,11 +100,11 @@ MapOptions appMapOptions({
   return MapOptions(
     crs: const AppMapCrs(),
     backgroundColor: appMapBackground,
-    // Keeps the world edges outside the viewport horizontally (no background
-    // bars from a pan or an off-meridian fit) and the camera center on the
-    // planet vertically. Deliberately not CameraConstraint.contain: that one
+    // Keeps the world edges outside the viewport on both axes, so no pan can
+    // end on background. Deliberately not CameraConstraint.contain: that one
     // rejects any camera it cannot fit inside the bounds (returning null),
-    // which would freeze a map taller than the world is wide.
+    // which would freeze a map taller than the world is wide — the case this
+    // one handles by centering instead.
     cameraConstraint: const AppMapCameraConstraint(),
     // Without a floor, zooming out shrinks the single world to a postage
     // stamp and then past the smallest tile level into empty background.
@@ -121,22 +121,39 @@ MapOptions appMapOptions({
 }
 
 /// Camera constraint for the single-world [AppMapCrs]: contains the world
-/// *edges* horizontally (a pan or off-center fit can never drag ±180° inside
-/// the viewport and expose [appMapBackground] as side bars) while only
-/// containing the camera *center* vertically at ±85° (edge-containing
-/// latitude would freeze any map taller than the world, per the note on
-/// [appMapOptions]).
+/// *edges* on both axes, so no pan can drag ±180° or the ±85.05° Mercator
+/// limit inside the viewport and expose [appMapBackground] as bars.
 ///
-/// Horizontal containment is only possible when the world is at least as
-/// wide as the viewport — [appMapMinZoomFor] guarantees that; below the
-/// floor (transient states only) the camera is returned unchanged rather
-/// than `null`, which would freeze the map.
+/// Edge containment needs the world to cover the viewport on the axis being
+/// contained, and the two axes reach that differently — which is why their
+/// fallbacks differ:
+///
+///  * **Horizontally** [appMapMinZoomFor] guarantees it. Falling short is a
+///    transient state (a resize or a fresh fit, corrected post-frame), so the
+///    camera is handed back unchanged rather than snapped — and never `null`,
+///    which freezes the map and is why stock [CameraConstraint.contain] is
+///    unusable here.
+///  * **Vertically** nothing guarantees it: the drawn world is square, so a
+///    map box taller than it is wide has *no* zoom at which the world both
+///    fills the width and covers the height. That state is permanent, not
+///    transient, so the world is centered in the box instead — the leftover
+///    background splits evenly top and bottom rather than pooling on
+///    whichever side the last drag left it.
 @immutable
 class AppMapCameraConstraint extends CameraConstraint {
   /// Create the app's single-world camera constraint.
   const AppMapCameraConstraint();
 
+  /// Latitude the camera center is held to before the edge math runs.
+  ///
+  /// The edge clamp is strictly tighter wherever it applies, so this now only
+  /// governs degenerate viewports — it keeps "the center is on the planet"
+  /// true even there.
   static const double _maxLatitude = 85;
+
+  /// The world's north and south edges. [SphericalMercator] clamps latitude
+  /// symmetrically to this, so it *is* the top and bottom of the drawn square.
+  static const double _worldEdgeLatitude = SphericalMercator.maxLatitude;
 
   @override
   MapCamera constrain(MapCamera camera) {
@@ -146,7 +163,9 @@ class AppMapCameraConstraint extends CameraConstraint {
     final size = camera.nonRotatedSize;
     if (size == MapCamera.kImpossibleSize ||
         !size.width.isFinite ||
-        size.width <= 0) {
+        !size.height.isFinite ||
+        size.width <= 0 ||
+        size.height <= 0) {
       return camera;
     }
 
@@ -156,28 +175,37 @@ class AppMapCameraConstraint extends CameraConstraint {
       camera.center.longitude,
     );
 
-    // Mirror ContainCamera's x-axis math against the whole world.
-    final westPix = camera.projectAtZoom(const LatLng(0, -180), zoom);
-    final eastPix = camera.projectAtZoom(const LatLng(0, 180), zoom);
-    final halfWidth = camera.size.width / 2;
-    final leftOkCenter = math.min(westPix.dx, eastPix.dx) + halfWidth;
-    final rightOkCenter = math.max(westPix.dx, eastPix.dx) - halfWidth;
-
-    // World narrower than the viewport: no horizontal containment exists
-    // (transiently possible below the [appMapMinZoomFor] floor).
-    if (leftOkCenter > rightOkCenter) {
-      if (center == camera.center) return camera;
-      return camera.withPosition(center: center);
-    }
+    // Mirror ContainCamera's math against the whole world, both axes at once:
+    // the north-west and south-east corners of the drawn square. Longitude
+    // projects independently of latitude, so the x limits are unchanged by
+    // taking them off the corners rather than off the equator.
+    final nwPix =
+        camera.projectAtZoom(const LatLng(_worldEdgeLatitude, -180), zoom);
+    final sePix =
+        camera.projectAtZoom(const LatLng(-_worldEdgeLatitude, 180), zoom);
+    final half = camera.size / 2;
+    final leftOkCenter = math.min(nwPix.dx, sePix.dx) + half.width;
+    final rightOkCenter = math.max(nwPix.dx, sePix.dx) - half.width;
+    final topOkCenter = math.min(nwPix.dy, sePix.dy) + half.height;
+    final botOkCenter = math.max(nwPix.dy, sePix.dy) - half.height;
 
     final centerPix = camera.projectAtZoom(center, zoom);
-    final newX = centerPix.dx.clamp(leftOkCenter, rightOkCenter);
-    if (newX == centerPix.dx) {
+    // An inverted range means the world doesn't cover the viewport on that
+    // axis: x keeps its center (transient), y takes the range's midpoint,
+    // which is exactly the world's vertical middle.
+    final newX = leftOkCenter <= rightOkCenter
+        ? centerPix.dx.clamp(leftOkCenter, rightOkCenter)
+        : centerPix.dx;
+    final newY = topOkCenter <= botOkCenter
+        ? centerPix.dy.clamp(topOkCenter, botOkCenter)
+        : (topOkCenter + botOkCenter) / 2;
+
+    if (newX == centerPix.dx && newY == centerPix.dy) {
       if (center == camera.center) return camera;
       return camera.withPosition(center: center);
     }
     return camera.withPosition(
-      center: camera.unprojectAtZoom(Offset(newX, centerPix.dy), zoom),
+      center: camera.unprojectAtZoom(Offset(newX, newY), zoom),
     );
   }
 

--- a/src/packages/flutter-app/test/agent_empty_state_suggestions_test.dart
+++ b/src/packages/flutter-app/test/agent_empty_state_suggestions_test.dart
@@ -13,6 +13,7 @@ import 'package:travel_route_planner/screens/agent_screen.dart';
 import 'package:travel_route_planner/services/api_client.dart';
 import 'package:travel_route_planner/services/plan_service.dart';
 import 'package:travel_route_planner/widgets/destination_suggestion_card.dart';
+import 'package:travel_route_planner/widgets/fading_edge_scroll.dart';
 import 'package:travel_route_planner/widgets/near_me_chip.dart';
 
 import 'support/l10n_test_app.dart';
@@ -155,6 +156,25 @@ void main() {
     // keeps the field above it that makes the block read as composed.
     expect(heading.top, greaterThan(tester.getRect(find.byType(AppBar)).bottom),
         reason: 'the heading sits below the app bar, in its own field');
+  });
+
+  testWidgets('the rail dissolves at its edges, like the home rails',
+      (WidgetTester tester) async {
+    await pumpAgent(tester, overrides());
+
+    expect(find.byType(FadingEdgeScroll), findsOneWidget);
+
+    // The fade is derived from the controller FadingEdgeScroll hands out, so
+    // a ListView that builds its own (or none) leaves the mask frozen at
+    // "no edges" and the rail silently reverts to a hard cut. Pinning the
+    // wiring, not the pixels: the gradient itself is covered by
+    // fading_edge_scroll_test.
+    final rail = tester.widget<ListView>(find.descendant(
+      of: find.byType(FadingEdgeScroll),
+      matching: find.byType(ListView),
+    ));
+    expect(rail.controller, isNotNull,
+        reason: 'the rail must take the controller it is handed');
   });
 
   testWidgets('near-me and import are the two starter chips',

--- a/src/packages/flutter-app/test/app_map_min_zoom_test.dart
+++ b/src/packages/flutter-app/test/app_map_min_zoom_test.dart
@@ -10,6 +10,11 @@ import 'package:travel_route_planner/widgets/app_map.dart';
 /// World pixel width at [zoom] under Web Mercator (256px tiles).
 double _worldWidth(double zoom) => 256 * math.pow(2, zoom).toDouble();
 
+/// The top and bottom of the drawn square: [SphericalMercator] clamps
+/// latitude symmetrically here, so these are the world's real edges.
+const _northEdge = LatLng(SphericalMercator.maxLatitude, 0);
+const _southEdge = LatLng(-SphericalMercator.maxLatitude, 0);
+
 MapCamera _camera({
   required double zoom,
   LatLng center = const LatLng(0, 0),
@@ -68,11 +73,52 @@ void main() {
       expect(identical(constraint.constrain(camera), camera), isTrue);
     });
 
-    test('clamps center latitude to ±85 like the old containCenter', () {
+    test('keeps the world edges outside the viewport vertically', () {
+      // A drag hard to the north. The old constraint only clamped the center
+      // latitude to ±85, which parks the pole mid-box and leaves half the
+      // viewport painted in appMapBackground.
       final constrained =
           constraint.constrain(_camera(zoom: 5, center: const LatLng(89, 10)));
-      expect(constrained.center.latitude, 85);
-      expect(constrained.center.longitude, 10);
+
+      // The world's north edge sits at or above the viewport's top edge.
+      expect(
+        constrained.latLngToScreenOffset(_northEdge).dy,
+        lessThanOrEqualTo(0.5),
+      );
+      // Pulled well south of the old ±85 parking spot, and x untouched.
+      expect(constrained.center.latitude, lessThan(85));
+      expect(constrained.center.longitude, closeTo(10, 1e-9));
+    });
+
+    test('keeps the world edges outside the viewport at the south pole', () {
+      final constrained =
+          constraint.constrain(_camera(zoom: 5, center: const LatLng(-89, 10)));
+      expect(
+        constrained.latLngToScreenOffset(_southEdge).dy,
+        greaterThanOrEqualTo(239.5), // the 240px-tall test viewport
+      );
+      expect(constrained.center.latitude, greaterThan(-85));
+      expect(constrained.center.longitude, closeTo(10, 1e-9));
+    });
+
+    test(
+        'centers the world vertically when it is shorter than the viewport '
+        '(a box taller than it is wide)', () {
+      // The world is square, so no zoom fills a 400x900 box on both axes.
+      // Rather than freeze, or let a drag pool the background on one side,
+      // the world is centered and the leftover splits evenly.
+      const size = Size(400, 900);
+      final constrained = constraint.constrain(
+          _camera(zoom: 1, center: const LatLng(40, 10), size: size));
+
+      expect(constrained.center.latitude, closeTo(0, 1e-9));
+      expect(constrained.center.longitude, closeTo(10, 1e-9));
+
+      final top = constrained.latLngToScreenOffset(_northEdge).dy;
+      final bottom = constrained.latLngToScreenOffset(_southEdge).dy;
+      expect(top, closeTo(size.height - bottom, 1e-6),
+          reason: 'background must split evenly top and bottom');
+      expect(top, greaterThan(0)); // world genuinely shorter than the box
     });
 
     test('keeps the world edges outside the viewport at the zoom floor', () {


### PR DESCRIPTION
Two independent UI fixes, one per commit — review them separately.

## 1. `fix(map)` — contain the world's edges vertically, not just its centre

**Reported:** on the atlas you can drag until the map sits halfway down the screen.

`AppMapCameraConstraint` contained the world's **edges** on the x-axis but only the camera's **centre** on the y-axis:

```dart
static const double _maxLatitude = 85;
final center = LatLng(
  camera.center.latitude.clamp(-_maxLatitude, _maxLatitude),  // ← centre only
  camera.center.longitude,
);
```

Clamping the *centre* to ±85° parks the pole mid-box, so everything past it paints `appMapBackground` (`#0A0F1A`). The same drag was already impossible horizontally. The two axes disagreed about what a map edge means, and the atlas — whose map box runs the full height of the window — is where it showed.

The asymmetry was reasoned, not accidental. The old comment:

> edge-containing latitude would freeze any map taller than the world

True of stock `CameraConstraint.contain`, which returns `null` for any camera it cannot fit, and `null` freezes the map. That is a reason to avoid *that implementation*, not a reason to allow half-empty screens.

**Now:** both axes contain the edges, with different fallbacks because they reach coverage differently.

| Axis | Coverage guaranteed by | Fallback | Why |
|---|---|---|---|
| **x** | `appMapMinZoomFor(width)` | camera handed back untouched | Falling short is **transient** — a resize or a fresh fit, corrected post-frame. Snapping would make the correction visible as a jump. Unchanged behaviour. |
| **y** | nothing | world centred in the box | Falling short is **permanent**: the drawn world is square, so a box taller than it is wide has *no* zoom that both fills the width and covers the height. Centring splits the leftover evenly instead of letting the last drag pool it on one side. |

Neither path returns `null`, so the map still cannot freeze.

**Scope:** this is the shared `app_map.dart`, so it lands on all five maps — the atlas, the trip-detail band, the trip map screen, the home recent-trip card, the guide map. Fixing only the atlas would ship the same defect four more times.

**Known and deliberate:** the zoom floor is still derived from width alone, so a box taller than it is wide keeps a thin, evenly-split band of background at full zoom-out — roughly 32px a side on a 1355×989 window, and only between z1.75 and z1.86. Above that band there is none; wide windows never reach it. Flooring on `max(width, height)` would delete it, but a 390×700 full-screen map would then floor at a ~706px world and the whole planet could never be seen at once. Wrong trade for a travel atlas.

## 2. `feat(plan)` — the destination rail dissolves at its edges, like home's

The Plan tab's rail always runs off the edge (the pool is longer than any window) and ended on a hard cut that read like the last card rather than a cropped one. That is the complaint the home rails already answered, so the same `FadingEdgeScroll` answers it here rather than a second implementation of the same idea.

`FadingEdgeScroll` hands the `ListView` its controller instead of taking a finished child, because the fade is derived from that controller's position — a rail that quietly builds its own compiles, renders, and leaves the mask frozen at "no edges", silently reverting to the hard cut. The new test pins that **wiring**, not the pixels: the gradient rule already has coverage in `fading_edge_scroll_test`, and a second copy here would guard nothing. The home rails have no such test, so this is the first guard against that regression.

**Not touched:** the rail reserves no room below its cards for the `Card`'s elevation-3 shadow, where the home rail reserves `AppSpacing.sm`. A real difference from home, but vertical, pre-existing, and unrelated to the fade — and growing the rail shifts a deliberately tuned `_PlanIntro` layout.

## Verification

- `flutter analyze` clean — 3 pre-existing infos in `route_response.dart`, a file neither commit touches.
- Full suite green.
- The map constraint group went 6 → 9 cases. The test that pinned the old ±85 centre clamp is **rewritten**, since that contract was the defect. New: north and south drags leave the world's edge at or outside the viewport's; a 400×900 box centres the world with the background split evenly. The x-axis cases pass unchanged — longitude projects independently of latitude, so taking the x limits off the world's corners rather than off the equator moves nothing.
- The plan rail was **rendered before committing**, at rest (trailing fade only, leading edge crisp — a leading fade at rest would promise content behind you that isn't there) and mid-scroll (both edges dissolving), through the real dark theme and the shipped Inter/Cormorant faces rather than the stock-light test harness. The harness was throwaway and is not in the diff.

One incidental change worth knowing when reading the map diff: a constrained camera's longitude now round-trips through `unprojectAtZoom` when y also moves, so it lands within ~1e-14 of exact rather than exact. Assertions relaxed to `closeTo`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/golden-tempo/codesmith/anemos-travel/pr/537"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789971900&installation_model_id=433099&pr_number=537&repository=golden-tempo%2Fanemos-travel&return_to=https%3A%2F%2Fgithub.com%2Fgolden-tempo%2Fanemos-travel%2Fpull%2F537&signature=7371b3cb809f416298dcffa0007df224ac285ce5a9c10e6538aaccc3baf6e66d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->