### PR TITLE
docs(brand): record the Aegean canvas tokens and the Two Canvases Rule

### DIFF
--- a/.claude/skills/brand-guidelines/SKILL.md
+++ b/.claude/skills/brand-guidelines/SKILL.md
@@ -57,16 +57,19 @@ Paths below are relative to `src/packages/flutter-app/` unless rooted.
   (ramp: tint `#E0F2F1` · teal-100 `#B2DFDB` · light `#00897B` · brand
   `#00796B` · platform `#00695C` · dark `#004D40`; teal-100 and platform
   live in the SVGs/web shell, not `AppColors`). Both themes share the
-  seed. **Chrome is neutral since v1.4** (the de-gradient pass): the app
+  seed. **Chrome is flat since v1.4** (the de-gradient pass): the app
   bar is flat `surface` under a hairline in both themes, the brand riding
   in the wordmark's ink (`wordmarkInk` — brandDark light / primary dark)
   and the dark-cut rose; `brandGradient` is no longer a sanctioned brand
   surface and survives only on the signed-out photo/guide panels pending
   phase 2 — the boot splash is flat Aegean night.
-- **Proportion**: surfaces neutral (warm, plaster-leaning); teal is
-  identity + the primary action; tool accents and status colors appear at
-  chip-and-pin scale, **never as fields**. ONE recorded exception (doc
-  v1.2): the signed-out landing page commits to the dark
+- **Proportion**: surfaces are the two authored Aegean canvases —
+  `canvasFor(brightness)`, dark Aegean night `#0C1F2C` / light Aegean
+  paper `#F6F9FB`, the one field-scale colour the Earned Color Rule
+  permits; teal is identity + the primary action; tool accents and
+  status colors appear at chip-and-pin scale, **never as fields**. ONE
+  recorded exception (doc v1.2): the signed-out landing page commits to
+  the dark
   `landingCanvas` family (`app_colors.dart` — canvas #091620, glass
   ladder 6/8/10/12/14%, ink ladder 35/60/70/85%). The exception ends at
   sign-in; new landing surfaces pick a ladder rung, never a fresh alpha.
@@ -180,11 +183,12 @@ Each is an instant finding in review:
 - Off-scale magic values: spacing not on the 4/8/12/16/24/32 ladder,
   radii other than 8/12/20/full, ad-hoc `BoxShadow`s.
 - Teal-tinted photos, purple-blue "AI gradients", or any hue used as a
-  large field at all — since v1.4 the only recorded teal-field survivors
-  are the signed-out photo/guide gradient panels (pending phase 2) and
-  `landingCanvas` on the signed-out landing (doc v1.2), plus the
+  large field at all — the only recorded teal-field survivors are the
+  signed-out photo/guide gradient panels (pending phase 2) and the
   continue-trip hero's flat `brandDark` imagery fallback; the boot splash
-  is flat Aegean night.
+  is flat Aegean night. The Aegean canvases — the signed-in
+  surfaces and the landing's Midnight Harbor — are the one sanctioned
+  field-scale colour family (the Two Canvases Rule).
 - M3 defaults where the theme already decided: surface tint, default
   card shadows, `ColorScheme` roles bypassed by raw `Colors.*`.
 

--- a/.impeccable/design.json
+++ b/.impeccable/design.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 2,
-  "generatedAt": "2026-08-18T00:00:00Z",
+  "generatedAt": "2026-08-22T00:00:00Z",
   "title": "Design System: Anemos",
   "extensions": {
     "colorMeta": {
@@ -40,6 +40,16 @@
         "displayName": "Midnight Harbor",
         "canonical": "#091620"
       },
+      "aegean-night": {
+        "role": "neutral",
+        "displayName": "Aegean Night",
+        "canonical": "#0C1F2C"
+      },
+      "aegean-paper": {
+        "role": "neutral",
+        "displayName": "Aegean Paper",
+        "canonical": "#F6F9FB"
+      },
       "map-scrim": {
         "role": "neutral",
         "displayName": "Map Scrim",
@@ -48,7 +58,7 @@
       "paper-fill": {
         "role": "neutral",
         "displayName": "Paper Fill",
-        "canonical": "#FAFAFA"
+        "canonical": "#F3F7F9"
       }
     },
     "typographyMeta": {
@@ -92,7 +102,7 @@
       "refersTo": "card",
       "description": "The standard raised surface — 12px radius, real downward shadow, no Material tonal tint.",
       "html": "<div class=\"ds-card\"><div class=\"ds-card-title\">4 nights in Naxos</div><div class=\"ds-card-body\">Old Town stay, ferry to Santorini on Friday morning.</div></div>",
-      "css": ".ds-card { background: #fff; border-radius: 12px; padding: 16px; box-shadow: 0 3px 6px rgba(0,0,0,0.16); max-width: 320px; } .ds-card-title { font-family: Inter, system-ui, sans-serif; font-size: 16px; font-weight: 700; color: #191c1c; margin-bottom: 8px; } .ds-card-body { font-family: Inter, system-ui, sans-serif; font-size: 14px; font-weight: 400; line-height: 1.43; color: #3f4947; }"
+      "css": ".ds-card { background: #E0EBF2; border-radius: 12px; padding: 16px; box-shadow: 0 3px 6px rgba(0,0,0,0.16); max-width: 320px; } .ds-card-title { font-family: Inter, system-ui, sans-serif; font-size: 16px; font-weight: 700; color: #101B23; margin-bottom: 8px; } .ds-card-body { font-family: Inter, system-ui, sans-serif; font-size: 14px; font-weight: 400; line-height: 1.43; color: #364754; }"
     },
     {
       "name": "Trip Hero Card",
@@ -100,7 +110,7 @@
       "refersTo": "card",
       "description": "The promoted-trip hero — a flat photo-led card (de-gradient pass): route imagery on top, Circle-style date square, serif title, one when-line, state pills. Promotion is imagery and typography, never a colored field.",
       "html": "<div class=\"ds-hero-card\"><div class=\"ds-hero-date\"><div class=\"ds-hero-day\">14</div><div class=\"ds-hero-mon\">Sep</div></div><div><div class=\"ds-hero-title\">Island hopping, September</div><div class=\"ds-hero-when\">Sep 14 – 21 · 8 days</div></div></div>",
-      "css": ".ds-hero-card { display: flex; gap: 16px; align-items: flex-start; background: #fff; border-radius: 12px; padding: 16px; box-shadow: 0 3px 6px rgba(0,0,0,0.16); max-width: 360px; } .ds-hero-date { border: 1px solid #bec9c6; border-radius: 8px; width: 52px; padding: 8px 4px; text-align: center; flex: none; } .ds-hero-day { font-family: Inter, system-ui, sans-serif; font-size: 22px; font-weight: 700; color: #191c1c; } .ds-hero-mon { font-family: Inter, system-ui, sans-serif; font-size: 11px; font-weight: 600; color: #6f7977; } .ds-hero-title { font-family: 'Cormorant Garamond', Georgia, serif; font-size: 34px; font-weight: 500; line-height: 1.2; color: #191c1c; } .ds-hero-when { font-family: Inter, system-ui, sans-serif; font-size: 14px; font-weight: 500; color: #3f4947; margin-top: 4px; }"
+      "css": ".ds-hero-card { display: flex; gap: 16px; align-items: flex-start; background: #E0EBF2; border-radius: 12px; padding: 16px; box-shadow: 0 3px 6px rgba(0,0,0,0.16); max-width: 360px; } .ds-hero-date { border: 1px solid #BCC9D2; border-radius: 8px; width: 52px; padding: 8px 4px; text-align: center; flex: none; } .ds-hero-day { font-family: Inter, system-ui, sans-serif; font-size: 22px; font-weight: 700; color: #101B23; } .ds-hero-mon { font-family: Inter, system-ui, sans-serif; font-size: 11px; font-weight: 600; color: #697D8C; } .ds-hero-title { font-family: 'Cormorant Garamond', Georgia, serif; font-size: 34px; font-weight: 500; line-height: 1.2; color: #101B23; } .ds-hero-when { font-family: Inter, system-ui, sans-serif; font-size: 14px; font-weight: 500; color: #364754; margin-top: 4px; }"
     },
     {
       "name": "Input Field",
@@ -108,7 +118,7 @@
       "refersTo": "input",
       "description": "Outlined, filled field — paper fill, 8px radius, primary outline on focus, no glow.",
       "html": "<input class=\"ds-input\" type=\"text\" placeholder=\"Where to?\" />",
-      "css": ".ds-input { background: #FAFAFA; border: 1px solid #6f7977; border-radius: 8px; padding: 12px 16px; font-family: Inter, system-ui, sans-serif; font-size: 14px; color: #191c1c; width: 260px; transition: border-color 0.2s; } .ds-input::placeholder { color: #6f7977; } .ds-input:focus { outline: none; border: 2px solid #00796B; padding: 11px 15px; }"
+      "css": ".ds-input { background: #F3F7F9; border: 1px solid #697D8C; border-radius: 8px; padding: 12px 16px; font-family: Inter, system-ui, sans-serif; font-size: 14px; color: #101B23; width: 260px; transition: border-color 0.2s; } .ds-input::placeholder { color: #697D8C; } .ds-input:focus { outline: none; border: 2px solid #00796B; padding: 11px 15px; }"
     },
     {
       "name": "Filter Chip",
@@ -116,7 +126,7 @@
       "refersTo": "chip",
       "description": "Fully-rounded chip; chip rows are the entire secondary navigation on list screens. Selected takes the brand tint family.",
       "html": "<span class=\"ds-chip\">Flights</span> <span class=\"ds-chip ds-chip-selected\">Stays</span>",
-      "css": ".ds-chip { display: inline-block; font-family: Inter, system-ui, sans-serif; font-size: 14px; font-weight: 500; color: #3f4947; background: transparent; border: 1px solid #bec9c6; border-radius: 999px; padding: 8px 16px; cursor: pointer; transition: background 0.2s; } .ds-chip:hover { background: rgba(0,121,107,0.06); } .ds-chip-selected { background: #E0F2F1; border-color: #E0F2F1; color: #004D40; font-weight: 600; }"
+      "css": ".ds-chip { display: inline-block; font-family: Inter, system-ui, sans-serif; font-size: 14px; font-weight: 500; color: #364754; background: transparent; border: 1px solid #BCC9D2; border-radius: 999px; padding: 8px 16px; cursor: pointer; transition: background 0.2s; } .ds-chip:hover { background: rgba(0,121,107,0.06); } .ds-chip-selected { background: #E0F2F1; border-color: #E0F2F1; color: #004D40; font-weight: 600; }"
     },
     {
       "name": "Wordmark",
@@ -146,9 +156,9 @@
       "Card-and-sheet vocabulary, comfortable density, 48px touch floor"
     ],
     "rules": [
-      { "name": "The Earned Color Rule", "body": "Every non-teal color means exactly one thing and appears at chip-and-pin scale, never as a field. Color is never decoration.", "section": "colors" },
+      { "name": "The Earned Color Rule", "body": "Every non-teal color means exactly one thing and appears at chip-and-pin scale, never as a field. Color is never decoration. The Aegean canvases are the one thing this rule does not reach — a canvas is what colour appears on, and its meaning is \"surface\", which is exactly one thing.", "section": "colors" },
       { "name": "The Gold-in-the-Mark Rule", "body": "Heritage Gold enters a screen only inside the wind-rose mark. Anywhere else it is a finding.", "section": "colors" },
-      { "name": "The One Dark Exception Rule", "body": "Midnight Harbor exists only on the signed-out landing. Everywhere else, surfaces are the neutral scheme and dark mode is the same build with brightness flipped.", "section": "colors" },
+      { "name": "The Two Canvases Rule", "body": "Every surface in the signed-in app comes from AppColors.canvasFor(brightness) — dark is Aegean night, light is Aegean paper, the same design in two keys rather than one inverted into the other. Midnight Harbor remains the signed-out landing's own canvas (now the Aegean ladder's deepest rung, #091620); the exception ends at sign-in.", "section": "colors" },
       { "name": "The One Weight Rule", "body": "Cormorant Garamond ships exactly two real files — 500 (display) and 600 (wordmark) — so each AppFonts constant has one legal weight and every style naming the family states it explicitly, or the web synthesizes faux-bold and smears the serif.", "section": "typography" },
       { "name": "The Weight-Not-Size Rule", "body": "Below the headline line, hierarchy is built with Inter's weight ladder (400/500/600/700), not with size steps.", "section": "typography" },
       { "name": "The One Eyebrow Rule", "body": "Capitals belong to the wordmark and to ONE display device: the letterspaced small-caps place eyebrow on destination surfaces (the Amanzoe move). No other kickers or eyebrows exist.", "section": "typography" },
@@ -158,7 +168,7 @@
     "dos": [
       "Do build only with tokens — AppColors, AppFonts/textTheme, AppSpacing, AppRadius, AppShadows, BrandLogo/BrandWordmark; a value that isn't a token becomes one in lib/theme/ first.",
       "Do keep photography real — real places in real light, credited in CREDITS.md/LICENSES.md — and put a scrim under any text on it.",
-      "Do check both themes; the bar is surface in both — dark mode is the same build with brightness flipped, chrome included.",
+      "Do check both themes; the bar is surface in both — dark is Aegean night, composed, not a brightness flip of light.",
       "Do state the weight on every Cormorant Garamond style — w500 for AppFonts.display, w600 for AppFonts.wordmark — and set numbers in Inter.",
       "Do run .claude/skills/brand-guidelines/scripts/check.sh on touched Dart files before shipping."
     ],

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -9,8 +9,10 @@ colors:
   heritage-gold: "#E8C452"
   heritage-gold-deep: "#B98B1E"
   midnight-harbor: "#091620"
+  aegean-night: "#0C1F2C"
+  aegean-paper: "#F6F9FB"
   map-scrim: "rgba(0, 0, 0, 0.6)"
-  paper-fill: "#FAFAFA"
+  paper-fill: "#F3F7F9"
 typography:
   wordmark:
     fontFamily: "Cormorant Garamond, Georgia, serif"
@@ -128,7 +130,7 @@ Nothing is both.
   `heroScrim` (0.88 alpha lower-left → 0.35 upper-right — the layer under any
   text on a photo), and the flat fallback field under the continue-trip
   hero's imagery. **`brandGradient` is no longer a sanctioned brand surface**
-  (the de-gradient pass, 2026-08): chrome and hero cards are neutral
+  (the de-gradient pass, 2026-08): chrome and hero cards are scheme
   surfaces whose brand is the wordmark's ink, the rose, typography, and
   imagery; the gradient survives only on the signed-out photo/guide
   panels until phase 2 flattens or retires each — the boot splash left it
@@ -362,7 +364,7 @@ mark on the boot splash's night field.
   200×160 chat cards so images never reflow the transcript.
 
 ### Inputs / Fields
-- **Style:** outlined at 8px radius, filled — Paper Fill (#FAFAFA) light,
+- **Style:** outlined at 8px radius, filled — Paper Fill (#F3F7F9) light,
   `surfaceContainerHighest` dark; on the landing canvas, the glass-ladder
   field rung (white 10%).
 - **Focus:** scheme primary outline; no glow.
@@ -411,8 +413,8 @@ gradient never carries text.
   value that isn't a token becomes one in `lib/theme/` first.
 - **Do** keep photography real — real places in real light, credited in
   `CREDITS.md`/`LICENSES.md` — and put a scrim under any text on it.
-- **Do** check both themes; the bar is `surface` in both — dark mode is the
-  same build with brightness flipped, chrome included.
+- **Do** check both themes; the bar is `surface` in both — dark is Aegean
+  night, composed, not a brightness flip of light.
 - **Do** state the weight on every style naming Cormorant Garamond — `w500`
   for `AppFonts.display`, `w600` for `AppFonts.wordmark` — and set numbers in
   Inter.


### PR DESCRIPTION
Follow-up to #538, which merged moments before this commit reached its branch.

DESIGN.md, .impeccable/design.json, and the brand-guidelines skill now carry what the splash PR shipped but didn't document:

- New tokens: `aegean-night` (#0C1F2C) and `aegean-paper` (#F6F9FB); `paper-fill` retuned to #F3F7F9.
- The One Dark Exception Rule becomes **the Two Canvases Rule**: every signed-in surface comes from `AppColors.canvasFor(brightness)` — dark is composed Aegean night, not a brightness flip of light; Midnight Harbor remains the signed-out landing's canvas as the ladder's deepest rung.
- design.json component swatches (card, hero card, input, chip) moved onto the Aegean ladder.

Docs-only; no code changes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/golden-tempo/codesmith/anemos-travel/pr/539"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789975367&installation_model_id=433099&pr_number=539&repository=golden-tempo%2Fanemos-travel&return_to=https%3A%2F%2Fgithub.com%2Fgolden-tempo%2Fanemos-travel%2Fpull%2F539&signature=2ad70e6ecb61e2370da3350344f3ef70a39db5f3180ca842ce4bf734338903cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->