### PR TITLE
Guard the agent's remove_booking_todo over state-carrying rows

### DIFF
--- a/src/packages/api/plan_tools_extra.go
+++ b/src/packages/api/plan_tools_extra.go
@@ -124,7 +124,7 @@ var updateBookingTodoTool = anthropic.ToolParam{
 
 var removeBookingTodoTool = anthropic.ToolParam{
 	Name:        "remove_booking_todo",
-	Description: anthropic.String("Remove an item from a saved trip's booking checklist when it no longer applies (e.g. the destination or plan changed and the booking is moot). Items marked 'auto' in get_trip cannot be removed — they track the itinerary automatically. Call get_trip first to get the item's todo_id."),
+	Description: anthropic.String("Remove an item from a saved trip's booking checklist when it no longer applies. A changed destination or plan does NOT by itself make the booking moot — the traveler may hold a real reservation for the old leg, and removing the checklist row cancels nothing with the provider. An item marked booked, carrying saved booking options, or linked to a budget expense is REFUSED without the traveler's explicit confirmation: relay the refusal's stakes, and only if the traveler confirms call again with confirm: true. Items marked 'auto' in get_trip cannot be removed — they track the itinerary automatically. Call get_trip first to get the item's todo_id."),
 	InputSchema: anthropic.ToolInputSchemaParam{
 		Properties: map[string]any{
 			"trip_id": map[string]any{
@@ -134,6 +134,10 @@ var removeBookingTodoTool = anthropic.ToolParam{
 			"todo_id": map[string]any{
 				"type":        "string",
 				"description": "The checklist item's todo_id from get_trip",
+			},
+			"confirm": map[string]any{
+				"type":        "boolean",
+				"description": "Set true only after the traveler has explicitly confirmed removing an item the tool refused as state-carrying (marked booked, saved booking options, or a linked budget expense) — the refusal names what is at stake; relay it first.",
 			},
 		},
 		Required: []string{"trip_id", "todo_id"},
@@ -1014,8 +1018,9 @@ func runUpdateBookingTodoTool(s *planSession, input json.RawMessage) (string, bo
 
 func runRemoveBookingTodoTool(s *planSession, input json.RawMessage) (string, bool) {
 	var in struct {
-		TripID string `json:"trip_id"`
-		TodoID string `json:"todo_id"`
+		TripID  string `json:"trip_id"`
+		TodoID  string `json:"todo_id"`
+		Confirm bool   `json:"confirm"`
 	}
 	json.Unmarshal(input, &in)
 
@@ -1028,6 +1033,21 @@ func runRemoveBookingTodoTool(s *planSession, input json.RawMessage) (string, bo
 		return "That todo_id is not valid; call get_trip to see the checklist with ids.", true
 	}
 
+	// The demote policy guards the sync's delete; this guard is the second
+	// delete path — the one that fired in production (agent_booking_todo_removed,
+	// 2026-08-20 20:49:43 UTC) and hard-deleted the app's last record of a
+	// reservation the traveler holds. The state read is scoped auto = false, so
+	// a wrong id and an auto row stay indistinguishable, exactly as today.
+	st, err := store.New(dbPool).GetBookingTodoDeleteState(s.ctx, store.GetBookingTodoDeleteStateParams{ID: todoID, TripID: tid})
+	if err != nil {
+		return bookingTodoMissingMsg, true
+	}
+	if !in.Confirm {
+		if refusal := bookingTodoStateRefusal(st); refusal != "" {
+			return refusal, true
+		}
+	}
+
 	rows, err := store.New(dbPool).DeleteBookingTodoNonAuto(s.ctx, store.DeleteBookingTodoNonAutoParams{ID: todoID, TripID: tid})
 	if err != nil || rows == 0 {
 		return bookingTodoMissingMsg, true
@@ -1035,5 +1055,57 @@ func runRemoveBookingTodoTool(s *planSession, input json.RawMessage) (string, bo
 	touchTripAs(s.ctx, tid, s.uid)
 	sendSSE(s.w, "trip_updated", map[string]string{"trip_id": tid.String()})
 	safeGo("recordEvent", func() { recordEvent(s.uid, "agent_booking_todo_removed", &tid, nil) })
-	return "Removed the item from the trip's booking checklist — the traveler's trip page has refreshed.", false
+	return bookingTodoRemovedMsg(st), false
+}
+
+func pluralS(n int32) string {
+	if n == 1 {
+		return ""
+	}
+	return "s"
+}
+
+// bookingTodoStateRefusal is the self-correcting rejection for removing a
+// state-carrying checklist row (the errStraySectionItems idiom: name what's
+// wrong, name the stakes, name the call that works). "" when the row carries
+// nothing worth guarding. Nothing has been deleted when this fires, so the
+// model can relay the stakes and retry with confirm: true against an unchanged
+// checklist.
+func bookingTodoStateRefusal(st store.GetBookingTodoDeleteStateRow) string {
+	var stakes []string
+	if st.Booked {
+		stakes = append(stakes, "it is marked booked — a real reservation may still exist with the provider, and only the traveler can cancel it; removing the checklist row does not cancel anything")
+	}
+	if st.OptionCount > 0 {
+		stakes = append(stakes, fmt.Sprintf("it has a saved booking shortlist (%d option%s) that is deleted with the row", st.OptionCount, pluralS(st.OptionCount)))
+	}
+	if st.HasExpense {
+		stakes = append(stakes, "it is linked to a budget expense that stays summed into the trip's spend with nothing pointing back at a booking")
+	}
+	if len(stakes) == 0 {
+		return ""
+	}
+	return fmt.Sprintf("Not removing %q: %s. Nothing was removed. If the traveler has confirmed the booking is cancelled (or was never made), call remove_booking_todo again with confirm: true.",
+		st.Title, strings.Join(stakes, "; "))
+}
+
+// bookingTodoRemovedMsg names the deleted row and — for a confirmed
+// state-carrying delete — what went with it (replace_leg's name-it-back idiom),
+// so the tool_result states the post-state its consumer observes.
+func bookingTodoRemovedMsg(st store.GetBookingTodoDeleteStateRow) string {
+	msg := fmt.Sprintf("Removed %q from the trip's booking checklist", st.Title)
+	var gone []string
+	if st.OptionCount > 0 {
+		gone = append(gone, fmt.Sprintf("its saved booking shortlist (%d option%s) went with it", st.OptionCount, pluralS(st.OptionCount)))
+	}
+	if st.HasExpense {
+		gone = append(gone, "its linked budget expense remains but no longer points at a booking")
+	}
+	if len(gone) > 0 {
+		msg += "; " + strings.Join(gone, "; ")
+	}
+	if st.Booked {
+		msg += ". Removing the checklist row does not cancel any reservation with the provider — only the traveler can do that"
+	}
+	return msg + " — the traveler's trip page has refreshed."
 }

--- a/src/packages/api/plan_tools_extra_test.go
+++ b/src/packages/api/plan_tools_extra_test.go
@@ -501,9 +501,9 @@ func TestRemoveBookingTodoToolConfirmDeletesStateRow(t *testing.T) {
 	}
 	for _, want := range []string{
 		`"Book flights Gothenburg to Sorrento"`, // names the row
-		"shortlist",  // what went with it
-		"expense",    // what went with it
-		"not cancel", // the provider-side reservation warning
+		"shortlist",                             // what went with it
+		"expense",                               // what went with it
+		"not cancel",                            // the provider-side reservation warning
 	} {
 		if !strings.Contains(msg, want) {
 			t.Fatalf("confirmed result missing %q:\n%s", want, msg)

--- a/src/packages/api/plan_tools_extra_test.go
+++ b/src/packages/api/plan_tools_extra_test.go
@@ -354,6 +354,190 @@ func TestBookingTodoToolsRefuseAutoRows(t *testing.T) {
 	}
 }
 
+// seedTodoOption saves a booking-shortlist candidate off the given todo (00065:
+// booking_options CASCADEs off booking_todos, so a delete destroys it).
+func seedTodoOption(t *testing.T, tripID, todoID uuid.UUID, title string) {
+	t.Helper()
+	if _, err := dbPool.Exec(context.Background(),
+		`INSERT INTO booking_options (trip_id, booking_todo_id, title) VALUES ($1, $2, $3)`,
+		tripID, todoID, title); err != nil {
+		t.Fatalf("seed option: %v", err)
+	}
+}
+
+// seedTodoExpense links a paid budget expense to the given todo via 00061's
+// untyped (source_kind, source_id) pair — no FK, so a delete leaves it dangling.
+func seedTodoExpense(t *testing.T, tripID, todoID uuid.UUID) {
+	t.Helper()
+	if _, err := dbPool.Exec(context.Background(),
+		`INSERT INTO trip_expenses (trip_id, label, amount, actual_amount, source_kind, source_id)
+		 VALUES ($1, 'Flight deposit', 120, 120, 'booking_todo', $2)`,
+		tripID, todoID); err != nil {
+		t.Fatalf("seed expense: %v", err)
+	}
+}
+
+func countTodoRows(t *testing.T, id uuid.UUID) int {
+	t.Helper()
+	var n int
+	if err := dbPool.QueryRow(context.Background(),
+		`SELECT count(*) FROM booking_todos WHERE id = $1`, id).Scan(&n); err != nil {
+		t.Fatalf("count todo: %v", err)
+	}
+	return n
+}
+
+// A booked manual row is the production case (agent_booking_todo_removed,
+// 2026-08-20 20:49:43 UTC, trip 4a72c44c): the agent hard-deleted the app's
+// last record of a reservation the traveler actually holds. The tool must
+// refuse, naming the reservation risk and the confirm path.
+func TestRemoveBookingTodoToolRefusesBookedRow(t *testing.T) {
+	resetDB(t)
+	owner, _ := createTestUser(t, "agent@example.com")
+	trip := createTestTrip(t, owner.ID, 1)
+	seed, _ := testPlanSession(true, owner.ID)
+	todoID := seedAgentTodo(t, seed, trip.ID, "Book flights Gothenburg to Sorrento")
+	if _, err := dbPool.Exec(context.Background(),
+		`UPDATE booking_todos SET booked = true WHERE id = $1`, todoID); err != nil {
+		t.Fatalf("mark booked: %v", err)
+	}
+
+	s, rec := testPlanSession(true, owner.ID)
+	msg, isErr := runRemoveBookingTodoTool(s,
+		json.RawMessage(`{"trip_id":"`+trip.ID.String()+`","todo_id":"`+todoID.String()+`"}`))
+	if !isErr {
+		t.Fatalf("booked row removed without confirm: %q", msg)
+	}
+	for _, want := range []string{
+		`"Book flights Gothenburg to Sorrento"`, // names the row
+		"booked",
+		"reservation",
+		"only the traveler can cancel",
+		"confirm: true", // names the call that works
+	} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("refusal missing %q:\n%s", want, msg)
+		}
+	}
+	if strings.Contains(rec.Body.String(), "trip_updated") {
+		t.Fatal("refusal emitted trip_updated")
+	}
+	if n := countTodoRows(t, todoID); n != 1 {
+		t.Fatalf("refusal deleted the row (n=%d)", n)
+	}
+}
+
+// The rest of the demote predicate (minus mode): a saved shortlist and a
+// linked expense are also state a hard delete silently destroys.
+func TestRemoveBookingTodoToolRefusesOptionAndExpenseRows(t *testing.T) {
+	resetDB(t)
+	owner, _ := createTestUser(t, "agent@example.com")
+	trip := createTestTrip(t, owner.ID, 1)
+	seed, _ := testPlanSession(true, owner.ID)
+	s, rec := testPlanSession(true, owner.ID)
+
+	optTodo := seedAgentTodo(t, seed, trip.ID, "Book Naples stay")
+	seedTodoOption(t, trip.ID, optTodo, "Loft near Old Town")
+	seedTodoOption(t, trip.ID, optTodo, "B&B by the port")
+
+	expTodo := seedAgentTodo(t, seed, trip.ID, "Book Sorrento ferry")
+	seedTodoExpense(t, trip.ID, expTodo)
+
+	rec.Body.Reset()
+	msg, isErr := runRemoveBookingTodoTool(s,
+		json.RawMessage(`{"trip_id":"`+trip.ID.String()+`","todo_id":"`+optTodo.String()+`"}`))
+	if !isErr {
+		t.Fatalf("shortlist row removed without confirm: %q", msg)
+	}
+	for _, want := range []string{`"Book Naples stay"`, "shortlist", "2 options", "confirm: true"} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("shortlist refusal missing %q:\n%s", want, msg)
+		}
+	}
+
+	rec.Body.Reset()
+	msg, isErr = runRemoveBookingTodoTool(s,
+		json.RawMessage(`{"trip_id":"`+trip.ID.String()+`","todo_id":"`+expTodo.String()+`"}`))
+	if !isErr {
+		t.Fatalf("expense-linked row removed without confirm: %q", msg)
+	}
+	for _, want := range []string{`"Book Sorrento ferry"`, "expense", "confirm: true"} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("expense refusal missing %q:\n%s", want, msg)
+		}
+	}
+
+	if strings.Contains(rec.Body.String(), "trip_updated") {
+		t.Fatal("refusal emitted trip_updated")
+	}
+	if countTodoRows(t, optTodo) != 1 || countTodoRows(t, expTodo) != 1 {
+		t.Fatal("refusal deleted a row")
+	}
+}
+
+// confirm: true is the escape hatch: the delete proceeds and the result names
+// the row and what went with it (replace_leg's name-it-back idiom).
+func TestRemoveBookingTodoToolConfirmDeletesStateRow(t *testing.T) {
+	resetDB(t)
+	owner, _ := createTestUser(t, "agent@example.com")
+	trip := createTestTrip(t, owner.ID, 1)
+	seed, _ := testPlanSession(true, owner.ID)
+	s, rec := testPlanSession(true, owner.ID)
+
+	todoID := seedAgentTodo(t, seed, trip.ID, "Book flights Gothenburg to Sorrento")
+	if _, err := dbPool.Exec(context.Background(),
+		`UPDATE booking_todos SET booked = true WHERE id = $1`, todoID); err != nil {
+		t.Fatalf("mark booked: %v", err)
+	}
+	seedTodoOption(t, trip.ID, todoID, "Ryanair FR123")
+	seedTodoOption(t, trip.ID, todoID, "Norwegian DY456")
+	seedTodoExpense(t, trip.ID, todoID)
+
+	rec.Body.Reset()
+	msg, isErr := runRemoveBookingTodoTool(s,
+		json.RawMessage(`{"trip_id":"`+trip.ID.String()+`","todo_id":"`+todoID.String()+`","confirm":true}`))
+	if isErr {
+		t.Fatalf("confirmed remove refused: %q", msg)
+	}
+	for _, want := range []string{
+		`"Book flights Gothenburg to Sorrento"`, // names the row
+		"shortlist",  // what went with it
+		"expense",    // what went with it
+		"not cancel", // the provider-side reservation warning
+	} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("confirmed result missing %q:\n%s", want, msg)
+		}
+	}
+	if !strings.Contains(rec.Body.String(), "trip_updated") {
+		t.Fatal("confirmed remove did not emit trip_updated")
+	}
+	if n := countTodoRows(t, todoID); n != 0 {
+		t.Fatalf("confirmed remove left the row (n=%d)", n)
+	}
+	var optCount int
+	if err := dbPool.QueryRow(context.Background(),
+		`SELECT count(*) FROM booking_options WHERE booking_todo_id = $1`, todoID).Scan(&optCount); err != nil || optCount != 0 {
+		t.Fatalf("shortlist survived the cascade (n=%d, err=%v)", optCount, err)
+	}
+	// The expense survives, dangling by design (00061 has no FK).
+	var expCount int
+	if err := dbPool.QueryRow(context.Background(),
+		`SELECT count(*) FROM trip_expenses WHERE source_kind = 'booking_todo' AND source_id = $1`, todoID).Scan(&expCount); err != nil || expCount != 1 {
+		t.Fatalf("linked expense gone (n=%d, err=%v)", expCount, err)
+	}
+
+	// confirm on a plain row is still the ordinary happy path.
+	plainID := seedAgentTodo(t, seed, trip.ID, "Book travel insurance")
+	if msg, isErr := runRemoveBookingTodoTool(s,
+		json.RawMessage(`{"trip_id":"`+trip.ID.String()+`","todo_id":"`+plainID.String()+`","confirm":true}`)); isErr {
+		t.Fatalf("confirmed plain remove refused: %q", msg)
+	}
+	if n := countTodoRows(t, plainID); n != 0 {
+		t.Fatalf("confirmed plain remove left the row (n=%d)", n)
+	}
+}
+
 // boundPlanSession is testPlanSession bound to a trip the caller owns — the
 // setup the three trip-acting tools require.
 func boundPlanSession(uid, tripID uuid.UUID) (*planSession, *httptest.ResponseRecorder) {

--- a/src/packages/api/query/booking_todos.sql
+++ b/src/packages/api/query/booking_todos.sql
@@ -236,3 +236,22 @@ WHERE trip_id = sqlc.arg(trip_id)
 -- to. Added for the booking-options paths (00065), which must confirm the leg
 -- a candidate is being hung off actually belongs to this trip.
 SELECT * FROM booking_todos WHERE id = $1 AND trip_id = $2;
+
+-- name: GetBookingTodoDeleteState :one
+-- Pre-delete read for the agent's remove_booking_todo guard — the second delete
+-- path, the one DemoteStaleAutoBookingTodos' policy does not cover (the demote
+-- preserves a state-carrying row as auto = false; this statement is what stops
+-- the agent then hard-deleting that survivor). Same state-carrying predicate as
+-- the demote MINUS mode: booked, a saved shortlist (booking_options CASCADEs
+-- off this row), or a linked trip_expenses row (00061's untyped pair — the
+-- expense survives a delete, dangling and still summed into `spent`). A mode
+-- override alone is cheap to re-make, so it is deliberately not guarded.
+-- Scoped auto = false so an auto row reads as "no such row" and the caller
+-- answers with the same refusal DeleteBookingTodoNonAuto gives today.
+SELECT b.title, b.booked,
+       (SELECT count(*)::int FROM booking_options o WHERE o.booking_todo_id = b.id) AS option_count,
+       EXISTS (SELECT 1 FROM trip_expenses e
+               WHERE e.trip_id = b.trip_id
+                 AND e.source_kind = 'booking_todo' AND e.source_id = b.id) AS has_expense
+FROM booking_todos b
+WHERE b.id = $1 AND b.trip_id = $2 AND b.auto = false;

--- a/src/packages/api/store/booking_todos.sql.go
+++ b/src/packages/api/store/booking_todos.sql.go
@@ -244,6 +244,50 @@ func (q *Queries) GetBookingTodo(ctx context.Context, arg GetBookingTodoParams) 
 	return i, err
 }
 
+const getBookingTodoDeleteState = `-- name: GetBookingTodoDeleteState :one
+SELECT b.title, b.booked,
+       (SELECT count(*)::int FROM booking_options o WHERE o.booking_todo_id = b.id) AS option_count,
+       EXISTS (SELECT 1 FROM trip_expenses e
+               WHERE e.trip_id = b.trip_id
+                 AND e.source_kind = 'booking_todo' AND e.source_id = b.id) AS has_expense
+FROM booking_todos b
+WHERE b.id = $1 AND b.trip_id = $2 AND b.auto = false
+`
+
+type GetBookingTodoDeleteStateParams struct {
+	ID     uuid.UUID `json:"id"`
+	TripID uuid.UUID `json:"trip_id"`
+}
+
+type GetBookingTodoDeleteStateRow struct {
+	Title       string `json:"title"`
+	Booked      bool   `json:"booked"`
+	OptionCount int32  `json:"option_count"`
+	HasExpense  bool   `json:"has_expense"`
+}
+
+// Pre-delete read for the agent's remove_booking_todo guard — the second delete
+// path, the one DemoteStaleAutoBookingTodos' policy does not cover (the demote
+// preserves a state-carrying row as auto = false; this statement is what stops
+// the agent then hard-deleting that survivor). Same state-carrying predicate as
+// the demote MINUS mode: booked, a saved shortlist (booking_options CASCADEs
+// off this row), or a linked trip_expenses row (00061's untyped pair — the
+// expense survives a delete, dangling and still summed into `spent`). A mode
+// override alone is cheap to re-make, so it is deliberately not guarded.
+// Scoped auto = false so an auto row reads as "no such row" and the caller
+// answers with the same refusal DeleteBookingTodoNonAuto gives today.
+func (q *Queries) GetBookingTodoDeleteState(ctx context.Context, arg GetBookingTodoDeleteStateParams) (GetBookingTodoDeleteStateRow, error) {
+	row := q.db.QueryRow(ctx, getBookingTodoDeleteState, arg.ID, arg.TripID)
+	var i GetBookingTodoDeleteStateRow
+	err := row.Scan(
+		&i.Title,
+		&i.Booked,
+		&i.OptionCount,
+		&i.HasExpense,
+	)
+	return i, err
+}
+
 const listBookingTodosByTrip = `-- name: ListBookingTodosByTrip :many
 SELECT id, trip_id, kind, todo_key, title, subtitle, provider, search_url, depart_date, return_date, booked, auto, position, created_at, updated_at, mode, role, origin_label, destination_label, derived_mode FROM booking_todos WHERE trip_id = $1 ORDER BY position ASC, created_at ASC
 `


### PR DESCRIPTION
## Why

**Production event, 2026-08-20, trip `4a72c44c` ("Euro Trip Part 2"):** the todo sync demoted a stale **booked** `gothenburg>>sorrento` row to manual at 20:43:37 UTC, working as designed — and at **20:49:43 UTC** the agent hard-deleted it (`agent_booking_todo_removed`). That row was the last record anywhere in the app of a reservation the traveler actually holds.

The demote policy guards only the sync's delete. The survivor it produces is `auto = false`, and `remove_booking_todo` ran `DeleteBookingTodoNonAuto` — one hard `DELETE`, no state check — over exactly those survivors. The delete is not shallow: `booking_options` CASCADEs off the row (a saved shortlist dies with it) and a linked `trip_expenses` row dangles, still summed into `spent`.

## What changed

- `runRemoveBookingTodoTool` now reads the row's state first via a new `GetBookingTodoDeleteState` query — the demote predicate **minus mode**: booked, `booking_options` count, linked `trip_expenses` row (a mode override alone is cheap to re-make).
- A state-carrying row is **refused** (nothing is written), in the `errStraySectionItems` idiom: it names the row, what's wrong, the stakes — *a real reservation may still exist with the provider, and only the traveler can cancel it* — and the call that works: `remove_booking_todo` with `confirm: true`.
- `confirm: true` is the escape hatch for a traveler who says "yes, delete it". The result then names the row and what went with it (shortlist, expense link), per `replace_leg`'s name-it-back idiom.
- The tool description stops inviting the dangerous case: it keeps "no longer applies", qualifies "the booking is moot" (a route change is precisely when the booking may NOT be moot), and states that booked/shortlist/expense rows are refused without confirmation.
- Auto rows get the same refusal as before (the state query is scoped `auto = false`, keeping wrong-id and auto-row indistinguishable).

`DeleteBookingTodoNonAuto` itself is unchanged — the guard belongs in the agent tool, the path without judgement.

## Verification

Every new test watched failing first (against the unguarded path), then passing:

| Case | Result |
| --- | --- |
| Unbooked manual row, no options/expense | removed, as today (pre-existing test) |
| Booked manual row | refused, naming the row, the reservation risk, and `confirm: true`; row and SSE untouched |
| Row with a saved shortlist (2 options) | refused, naming the shortlist and count |
| Row with a linked budget expense | refused, naming the expense |
| Same rows with `confirm: true` | deleted; result names the row and what went with it; shortlist cascades, expense dangles by design |
| Auto row | refused with the unchanged message (pre-existing test) |

Gates: `go test ./...` green (43.9s, TEST_DATABASE_URL against this lane's postgres), `go vet` clean, `gofmt` clean. Branch forked from `dba4257`; `origin/main` had not moved, so no merge was needed.

Ref: ticket `stale-transport-orphans/tickets/03-agent-delete-guard`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/golden-tempo/codesmith/anemos-travel/pr/540"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790005766&installation_model_id=433099&pr_number=540&repository=golden-tempo%2Fanemos-travel&return_to=https%3A%2F%2Fgithub.com%2Fgolden-tempo%2Fanemos-travel%2Fpull%2F540&signature=1f3d922505d41340cbad34d127c900975780459fdede644de321b085fee8d22b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->