### PR TITLE
feat(home): "Before you go" names its trip and opens its health sheet

### DIFF
--- a/src/packages/flutter-app/lib/l10n/app_en.arb
+++ b/src/packages/flutter-app/lib/l10n/app_en.arb
@@ -1785,7 +1785,7 @@
   },
   "homeBeforeYouGoMore": "{n, plural, =1{1 more open item} other{{n} more open items}}",
   "@homeBeforeYouGoMore": {
-    "description": "Count of open trip items beyond the three Home shows.",
+    "description": "Count of open trip items beyond the five Home shows. Sits inside the tappable card, which opens that trip's Trip Health sheet with the complete list.",
     "placeholders": { "n": { "type": "int" } }
   },
   "homeInspirationTitle": "Somewhere new",

--- a/src/packages/flutter-app/lib/l10n/app_localizations.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations.dart
@@ -4514,7 +4514,7 @@ abstract class AppLocalizations {
   /// **'Before you go'**
   String get homeBeforeYouGoTitle;
 
-  /// Count of open trip items beyond the three Home shows.
+  /// Count of open trip items beyond the five Home shows. Sits inside the tappable card, which opens that trip's Trip Health sheet with the complete list.
   ///
   /// In en, this message translates to:
   /// **'{n, plural, =1{1 more open item} other{{n} more open items}}'**

--- a/src/packages/flutter-app/lib/navigation/app_nav.dart
+++ b/src/packages/flutter-app/lib/navigation/app_nav.dart
@@ -232,6 +232,32 @@ void openTripOnTripsTab(WidgetRef ref, String tripId, {AppTab? from}) {
   });
 }
 
+/// [openTripOnTripsTab], landing with the Trip Health sheet already open.
+///
+/// The destination for Home's "Before you go" card, which lists a handful of
+/// that trip's open items and has no way to fix any of them — the apply-fix
+/// plumbing lives on the trip screen with the mutation providers. The sheet is
+/// the same list, complete, with a working button on every row, so this is the
+/// one entry point where dropping the traveler on the trip page and leaving
+/// them to find the health badge would be a worse answer than opening the
+/// thing they tapped.
+///
+/// The URL is deliberately [tripDetailLocation] — unchanged from the plain
+/// open. An auto-opened sheet is a transient intent belonging to this one
+/// navigation, not a state a refresh should restore; the same reasoning that
+/// puts [TripDetailScreen.entryOrigin] on the route instead of in a provider.
+void openTripHealthOnTripsTab(WidgetRef ref, String tripId, {AppTab? from}) {
+  ref.read(navIndexProvider.notifier).state = AppTab.trips.index;
+  final navKeys = ref.read(tabNavKeysProvider);
+  pushOnTabWhenReady(navKeys, AppTab.trips, () {
+    resetToRoot(navKeys[AppTab.trips.index].currentState);
+    return instantRoute(
+        TripDetailScreen(
+            tripId: tripId, entryOrigin: from, openHealthSheet: true),
+        tripDetailLocation(tripId));
+  });
+}
+
 /// Open the import-from-AI-chat screen on the Trips tab — every entry point
 /// funnels here so the Trips nav item highlights, back lands on the trips
 /// list, and the URL reports /import (whose refresh restores onto Trips).

--- a/src/packages/flutter-app/lib/providers/departing_trip_provider.dart
+++ b/src/packages/flutter-app/lib/providers/departing_trip_provider.dart
@@ -1,0 +1,100 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../models/trip.dart';
+import '../utils/trip_days.dart';
+import 'live_trip_provider.dart';
+import 'trips_provider.dart';
+
+/// How close departure has to be for Home to raise readiness. Two weeks is the
+/// span where lodging, transport and packing stop being plans and start being
+/// errands.
+///
+/// The ONE owner of that window. [BeforeYouGoSection] used to re-check it
+/// itself against whatever trip it was handed; now the selection below decides
+/// which trip qualifies, so the widget never has to ask again and the two
+/// cannot drift apart on the answer.
+const int kBeforeYouGoWindowDays = 14;
+
+/// The trip Home raises pre-departure readiness for, or null when none is
+/// close enough.
+typedef DepartingTrip = ({
+  String tripId,
+  String title,
+  String? startDate,
+  int daysUntil,
+});
+
+/// The trip [BeforeYouGoSection] is about: **the one departing soonest**
+/// within [kBeforeYouGoWindowDays], not the one this device happened to open
+/// last.
+///
+/// That distinction is the whole point of this selector. The section used to
+/// ride `continueTripOf`, whose job is "offer a way back in" — it answers with
+/// the last trip you VIEWED, falling back to the most recently UPDATED one.
+/// Neither key is departure. So a traveler with two trips who opened the
+/// October one to rename it got October's readiness on Home while the trip
+/// leaving on Friday said nothing, and the header named no trip, so there was
+/// nothing on screen to reveal the swap. Ordering on `daysUntil` makes the
+/// section's subject the same trip the traveler means by "before you go", and
+/// [BeforeYouGoSection] now prints its name either way.
+///
+/// [liveTrip] is excluded, matching [continueTripOf] and for the same reason
+/// plus one of its own: it already has [LiveTripCard] above, and a trip you are
+/// ON is not a trip you are about to take. That exclusion has to be explicit,
+/// because [daysUntilTrip] answers 0 — not null — for a trip that starts today,
+/// which is exactly the trip [liveTripOf] claims.
+///
+/// Undated trips never qualify: [daysUntilTrip] returns null for them, and a
+/// readiness list with no departure to be ready for is a nag, not a signal.
+/// Past trips are excluded by the same call (a start already behind [today] is
+/// null), so no separate [tripIsPast] check is needed.
+///
+/// Exact ties on the departure date — two trips leaving the same morning — go
+/// to the more recently touched one, the [continueTripOf] tie-break, on the
+/// grounds that it is the one being actively planned. Pure and static so the
+/// choice can be unit-tested without a harness.
+DepartingTrip? departingTripOf(
+  List<Trip> trips,
+  Trip? liveTrip,
+  DateTime today,
+) {
+  Trip? best;
+  int? bestDays;
+  for (final t in trips) {
+    if (t.id == liveTrip?.id) continue;
+    final days = daysUntilTrip(t.startDate, today);
+    if (days == null || days > kBeforeYouGoWindowDays) continue;
+    if (bestDays == null ||
+        days < bestDays ||
+        // updatedAt is a required ISO-8601 string off the wire, so
+        // lexicographic order is chronological order — the convention
+        // trip_list_order.dart and continueTripOf both sort by.
+        (days == bestDays && t.updatedAt.compareTo(best!.updatedAt) > 0)) {
+      best = t;
+      bestDays = days;
+    }
+  }
+  if (best == null || bestDays == null) return null;
+  return (
+    tripId: best.id,
+    title: best.title,
+    startDate: best.startDate,
+    daysUntil: bestDays,
+  );
+}
+
+/// The trip Home's "Before you go" section reports on — see [departingTripOf]
+/// for which trip that is and why it is not the continue-trip.
+///
+/// Returns a record, so the recompute that every trips refresh triggers only
+/// rebuilds Home when the answer actually changed — the narrow-watch doctrine
+/// the home screen documents at the top of its build.
+///
+/// "Now" is sampled at build time, exactly like [liveTripProvider] and
+/// [continueTripProvider]: a trip that ages into the window at midnight shows
+/// up on the next list refresh rather than spontaneously.
+final departingTripProvider = Provider<DepartingTrip?>((ref) {
+  final trips = ref.watch(tripsProvider.select((s) => s.trips));
+  final liveTrip = ref.watch(liveTripProvider);
+  return departingTripOf(trips, liveTrip, DateTime.now());
+});

--- a/src/packages/flutter-app/lib/screens/home_screen.dart
+++ b/src/packages/flutter-app/lib/screens/home_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../l10n/l10n.dart';
 import '../models/local_guide.dart';
 import '../providers/auth_provider.dart';
+import '../providers/departing_trip_provider.dart';
 import '../providers/live_trip_provider.dart';
 import '../providers/local_provider.dart';
 import '../providers/plan_provider.dart';
@@ -105,6 +106,10 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
     // storage, domain move) — precedence in continueTripOf. It already
     // excludes the live trip, so nothing here has to.
     final continueTrip = ref.watch(continueTripProvider);
+    // A SEPARATE question from the one above: the trip departing soonest
+    // inside the readiness window, which is what "before you go" means. Also
+    // live-trip-excluding, so nothing here has to. See departingTripOf.
+    final departingTrip = ref.watch(departingTripProvider);
     // Populated app-wide: AppShell's IndexedStack keeps TripsListScreen
     // mounted, and its loadTrips() feeds tripsProvider — no fetch from here.
     //
@@ -240,12 +245,24 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
                 ),
 
                 // Pre-departure readiness for the trip that is close enough to
-                // pack for. Renders nothing outside its window or when it has
+                // pack for — which is departingTripProvider's trip, NOT the
+                // continue-trip above. The two answer different questions
+                // ("what am I about to take" vs "what did I last open"), and
+                // reading readiness off the second one silently reported the
+                // wrong trip whenever they disagreed. The card prints the name
+                // it is talking about either way. Renders nothing when it has
                 // no honest row to show (BeforeYouGoSection).
-                if (continueTrip != null)
+                if (departingTrip != null)
                   BeforeYouGoSection(
-                    tripId: continueTrip.tripId,
-                    startDate: continueTrip.startDate,
+                    tripId: departingTrip.tripId,
+                    tripTitle: departingTrip.title,
+                    startDate: departingTrip.startDate,
+                    // The health sheet, not the trip page: this card's rows
+                    // ARE that sheet's rows, and it is the only surface with
+                    // buttons that can act on them.
+                    onTap: () => openTripHealthOnTripsTab(
+                        ref, departingTrip.tripId,
+                        from: AppTab.home),
                   ),
 
                 // Where the traveler has been, and where they are going next.

--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -159,10 +159,23 @@ class TripDetailScreen extends ConsumerStatefulWidget {
   /// trip" — and null behaves exactly as this screen always has.
   final AppTab? entryOrigin;
 
+  /// Open the Trip Health sheet as soon as the trip has loaded — set only by
+  /// [openTripHealthOnTripsTab], which is how Home's "Before you go" card opens
+  /// a trip. That card lists open items it cannot fix; this lands the traveler
+  /// on the complete list with the buttons that can.
+  ///
+  /// On the ROUTE for the same reason as [entryOrigin], and fired exactly once
+  /// (see [_TripDetailScreenState._healthSheetShown]): it describes the
+  /// navigation that created this screen, so no later reload — a pull to
+  /// refresh, a `trip_updated` bump, an offline fallback — can reopen the sheet
+  /// over a traveler who already closed it.
+  final bool openHealthSheet;
+
   const TripDetailScreen({
     super.key,
     required this.tripId,
     this.entryOrigin,
+    this.openHealthSheet = false,
   });
 
   @override
@@ -197,6 +210,11 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
   RefineChatPhase _chatPhase = RefineChatPhase.ready;
   Object? _chatError;
   bool _chatResumeTried = false;
+
+  /// Whether [TripDetailScreen.openHealthSheet] has already been honored.
+  /// Once-per-screen like `_chatResumeTried`, and load-driven, so the sheet
+  /// cannot reappear over a traveler who closed it.
+  bool _healthSheetShown = false;
 
   // The active view state. 'all' renders the grouped itinerary; 'bookings'
   // and 'unbooked' are the Bookings view (entered from the header tab) and
@@ -363,7 +381,26 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
     super.initState();
     WidgetsBinding.instance.addObserver(this);
     _scroll.addListener(_syncCollapsedTitle);
-    _load();
+    // `_load` renders its own error state and never rethrows, so this always
+    // runs; `_openHealthOnArrival` decides from what actually landed.
+    _load().then((_) => _openHealthOnArrival());
+  }
+
+  /// Honors [TripDetailScreen.openHealthSheet], once, after the first load.
+  ///
+  /// After the load rather than in [initState] because the sheet is wired to a
+  /// [Trip] — it needs one to apply a fix against — and `_load` is also what
+  /// fetches the review it lists. A load that failed into the error screen
+  /// leaves `_trip` null and opens nothing: the traveler gets the error, not a
+  /// sheet floating over it. An offline fallback DOES open it — that path sets
+  /// a real cached trip, and the sheet's own `isOffline` wiring makes it
+  /// read-only.
+  void _openHealthOnArrival() {
+    if (!mounted || !widget.openHealthSheet || _healthSheetShown) return;
+    final trip = _trip;
+    if (trip == null) return;
+    _healthSheetShown = true;
+    _openHealthSheet(trip);
   }
 
   @override

--- a/src/packages/flutter-app/lib/widgets/before_you_go_section.dart
+++ b/src/packages/flutter-app/lib/widgets/before_you_go_section.dart
@@ -17,34 +17,58 @@ import 'section_header.dart';
 /// request**: same provider, same family key, one cached call.
 ///
 /// **Windowed, not permanent furniture.** It appears only inside
-/// [_windowDays] of departure. A trip eleven months out always has open items
-/// — that is what planning is — and listing them every time Home loads would
-/// turn a real pre-departure signal into wallpaper that gets scrolled past.
-/// Past and undated trips never qualify.
+/// [kBeforeYouGoWindowDays] of departure. A trip eleven months out always has
+/// open items — that is what planning is — and listing them every time Home
+/// loads would turn a real pre-departure signal into wallpaper that gets
+/// scrolled past. Past and undated trips never qualify. That gate now lives
+/// entirely in [departingTripOf], which also decides WHICH trip this is about;
+/// re-checking it here would be the same rule in two places.
 ///
-/// The step already promoted into the band above is filtered out by category,
-/// so the two never say the same thing twice. Everything left is capped at
-/// [_maxRows]: this is a nudge toward the trip page, not a second health
-/// sheet, and the sheet is one tap away with the complete list.
+/// **It names its trip, and it goes somewhere.** Both were missing, and each
+/// made the other worse. The header said only "Before you go" over a list that
+/// belonged to whichever trip [continueTripOf] had picked — so on an account
+/// with two trips there was no way to tell which, and no way to find out. And
+/// nothing here was tappable, on the reasoning that a row promising a fix it
+/// cannot perform is the promise [HomeNextStepBand] refuses to make. True of a
+/// BUTTON; the band itself is tapped end to end. So the card now carries the
+/// trip's name and countdown on its first line and takes one tap into that
+/// trip's health sheet — the complete list, with the buttons this surface
+/// cannot host, exactly where "10 more open items" was pointing all along.
 ///
-/// Renders nothing when the window is closed, the review has not arrived, or
-/// nothing is open — an empty "Before you go" is worse than no section.
+/// One target for the whole card, not one per row: every row would go to the
+/// same sheet, so per-row taps would be five ways to say the same thing while
+/// implying each row had its own destination.
+///
+/// The step already promoted into the band above is filtered out, so the two
+/// never say the same thing twice. Everything left is capped at [_maxRows] —
+/// this is a nudge toward the trip page, not a second health sheet.
+///
+/// Renders nothing when the review has not arrived or nothing is open — an
+/// empty "Before you go" is worse than no section.
 class BeforeYouGoSection extends ConsumerWidget {
   final String tripId;
 
-  /// ISO date-only trip start. Null means the snapshot could not say, which
-  /// closes the window rather than guessing it open.
+  /// The trip's name, printed on the card. Required rather than optional: a
+  /// readiness list that cannot say whose readiness it is describing is the
+  /// defect this section was reworked to fix.
+  final String tripTitle;
+
+  /// ISO date-only trip start, for the countdown beside the name. Null only
+  /// where the trip genuinely has no start date on hand, which drops the
+  /// countdown and keeps the name.
   final String? startDate;
+
+  /// Where the card goes: that trip's Trip Health sheet
+  /// ([openTripHealthOnTripsTab]).
+  final VoidCallback onTap;
 
   const BeforeYouGoSection({
     super.key,
     required this.tripId,
+    required this.tripTitle,
     required this.startDate,
+    required this.onTap,
   });
-
-  /// How close departure has to be. Two weeks is the span where lodging,
-  /// transport and packing stop being plans and start being errands.
-  static const int _windowDays = 14;
 
   static const int _maxRows = 5;
 
@@ -150,9 +174,6 @@ class BeforeYouGoSection extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final days = daysUntilTrip(startDate, DateTime.now());
-    if (days == null || days > _windowDays) return const SizedBox.shrink();
-
     final review = ref.watch(tripReviewProvider(TripReviewKey(tripId)));
     final value = review.valueOrNull;
     if (value == null) return const SizedBox.shrink();
@@ -162,49 +183,148 @@ class BeforeYouGoSection extends ConsumerWidget {
 
     final shown = rows.take(_maxRows).toList();
     final theme = Theme.of(context);
+    final l10n = context.l10n;
+    // Sampled at build like ContinueTripHero's: a countdown that ages out
+    // updates on the next rebuild, not spontaneously.
+    final days = daysUntilTrip(startDate, DateTime.now());
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
-        SectionHeader(title: context.l10n.homeBeforeYouGoTitle),
+        SectionHeader(title: l10n.homeBeforeYouGoTitle),
         const SizedBox(height: AppSpacing.md),
-        Card(
-          // Rows, not tiles: DESIGN.md rules out same-size icon cards as page
-          // structure and the hero-metric template, and a readiness list is
-          // exactly where both are tempting.
-          child: Padding(
-            padding: const EdgeInsets.symmetric(horizontal: AppSpacing.lg),
-            child: Column(
-              children: [
-                for (var i = 0; i < shown.length; i++)
-                  _FindingRow(
-                    finding: shown[i],
-                    icon: _categoryIcons[shown[i].category] ??
-                        Icons.info_outline,
-                    showDivider: i < shown.length - 1,
-                  ),
-              ],
+        Semantics(
+          button: true,
+          container: true,
+          child: Card(
+            // Rows, not tiles: DESIGN.md rules out same-size icon cards as
+            // page structure and the hero-metric template, and a readiness
+            // list is exactly where both are tempting.
+            //
+            // The ink goes INSIDE the Card rather than wrapping it, so the
+            // splash is clipped to the card's own radius instead of painting
+            // a rectangle over its rounded corners.
+            child: InkWell(
+              onTap: onTap,
+              borderRadius: AppRadius.mdAll,
+              child: Padding(
+                padding:
+                    const EdgeInsets.symmetric(horizontal: AppSpacing.lg),
+                child: Column(
+                  children: [
+                    _TripLine(
+                      title: tripTitle,
+                      countdown: days == null ? null : l10n.upNextStartsIn(days),
+                    ),
+                    Divider(height: 1, color: theme.colorScheme.outlineVariant),
+                    for (var i = 0; i < shown.length; i++)
+                      _FindingRow(
+                        finding: shown[i],
+                        icon: _categoryIcons[shown[i].category] ??
+                            Icons.info_outline,
+                        showDivider: i < shown.length - 1,
+                      ),
+                    // Inside the card, not stranded under it. As grey text
+                    // below a dead card this was the one line that named the
+                    // complete list and the one place a traveler was most
+                    // likely to reach for — with nothing behind it. It is now
+                    // part of the target that goes there.
+                    if (rows.length > shown.length) ...[
+                      Divider(
+                          height: 1, color: theme.colorScheme.outlineVariant),
+                      Padding(
+                        padding: const EdgeInsets.symmetric(
+                            vertical: AppSpacing.md),
+                        child: Align(
+                          alignment: AlignmentDirectional.centerStart,
+                          child: Text(
+                            l10n.homeBeforeYouGoMore(
+                                rows.length - shown.length),
+                            style: theme.textTheme.bodySmall?.copyWith(
+                                color: theme.colorScheme.onSurfaceVariant),
+                          ),
+                        ),
+                      ),
+                    ],
+                  ],
+                ),
+              ),
             ),
           ),
         ),
-        if (rows.length > shown.length)
-          Padding(
-            padding: const EdgeInsets.only(top: AppSpacing.sm),
-            child: Text(
-              context.l10n.homeBeforeYouGoMore(rows.length - shown.length),
-              style: theme.textTheme.bodySmall
-                  ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
-            ),
-          ),
         const SizedBox(height: AppSpacing.xl),
       ],
     );
   }
 }
 
-/// One open item. Not tappable: applying a fix needs the trip screen's
-/// mutation providers, and a row that looks actionable but only navigates is
-/// the same broken promise [HomeNextStepBand] refuses to make.
+/// The card's first line: whose readiness this is, how long there is left, and
+/// the chevron that says the whole card goes somewhere.
+///
+/// It carries the trip's name because the section header cannot be relied on to
+/// — [ContinueChatsSection] renders any in-progress conversations between the
+/// continue-trip block and this section, so the nearest thing naming a trip can
+/// be scrolled well off screen even on an account with exactly one trip.
+class _TripLine extends StatelessWidget {
+  final String title;
+  final String? countdown;
+
+  const _TripLine({required this.title, required this.countdown});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final scheme = theme.colorScheme;
+    return ConstrainedBox(
+      constraints: const BoxConstraints(minHeight: kMinTouchTarget),
+      child: Row(
+        children: [
+          Expanded(
+            child: Padding(
+              padding: const EdgeInsets.symmetric(vertical: AppSpacing.sm),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(
+                    title,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: theme.textTheme.titleSmall
+                        ?.copyWith(fontWeight: FontWeight.w600),
+                  ),
+                  if (countdown != null)
+                    Text(
+                      countdown!,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: theme.textTheme.bodySmall
+                          ?.copyWith(color: scheme.onSurfaceVariant),
+                    ),
+                ],
+              ),
+            ),
+          ),
+          const SizedBox(width: AppSpacing.md),
+          // The only affordance the card gets. A button here would have to
+          // name an action, and every honest name for it ("Fix these") belongs
+          // to the sheet this opens — the HomeNextStepBand rule.
+          Icon(Icons.chevron_right, size: 20, color: scheme.onSurfaceVariant),
+        ],
+      ),
+    );
+  }
+}
+
+/// One open item. Carries no tap of its own — the card around it does, and it
+/// goes to the health sheet where this row's fix has a working button. A tap
+/// per row would be five routes to one destination.
+///
+/// It carries no BUTTON for the [HomeNextStepBand] reason, which is the part of
+/// the original rule that still holds: applying a fix needs the trip screen's
+/// mutation providers, so a "Find a stay" here could only ever navigate, and a
+/// button that names an action it does not perform is a broken promise. Stating
+/// the gap and inheriting the card's tap is not.
 class _FindingRow extends StatelessWidget {
   final TripFinding finding;
   final IconData icon;

--- a/src/packages/flutter-app/test/before_you_go_section_test.dart
+++ b/src/packages/flutter-app/test/before_you_go_section_test.dart
@@ -1,0 +1,231 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:travel_route_planner/models/trip_finding.dart';
+import 'package:travel_route_planner/providers/trip_review_provider.dart';
+import 'package:travel_route_planner/widgets/before_you_go_section.dart';
+
+import 'support/l10n_test_app.dart';
+
+/// The two things "Before you go" has to do that a list of findings does not:
+/// say **whose** trip it is describing, and **go somewhere** that can act on
+/// it. It shipped without either — a nameless list of gaps with no tap on it,
+/// under a header that was one scroll away from any trip name — and the
+/// "N more open items" line, the one that named the complete list, was grey
+/// text stranded outside the card with nothing behind it.
+///
+/// Ordering has its own suite (before_you_go_order_test.dart); this one pins
+/// the wiring.
+void main() {
+  const tripId = 't1';
+
+  /// A date-only ISO string [days] from today, by calendar arithmetic (the
+  /// constructor normalizes month overflow) so the countdown is exact rather
+  /// than a Duration that a DST boundary could shave.
+  String inDays(int days) {
+    final now = DateTime.now();
+    final d = DateTime(now.year, now.month, now.day + days);
+    return '${d.year.toString().padLeft(4, '0')}-'
+        '${d.month.toString().padLeft(2, '0')}-'
+        '${d.day.toString().padLeft(2, '0')}';
+  }
+
+  TripFinding lodging(String city, String checkIn) => TripFinding(
+        severity: 'warn',
+        category: 'lodging',
+        message: 'No lodging booked in $city',
+        tripId: tripId,
+        fix: FindingFix(
+          action: 'add_lodging',
+          label: 'Find a stay',
+          city: city,
+          checkIn: checkIn,
+          checkOut: checkIn,
+        ),
+      );
+
+  /// n findings, chronological so the cap takes a predictable slice.
+  List<TripFinding> findings(int n) => [
+        for (var i = 0; i < n; i++)
+          lodging('City $i', '2026-09-${(i + 1).toString().padLeft(2, '0')}'),
+      ];
+
+  late int taps;
+
+  /// [startsIn] is days until departure; null means the trip has no start date
+  /// at all, which is the only way to reach the countdown-less card.
+  Future<void> pump(
+    WidgetTester tester, {
+    required TripReview review,
+    String title = 'Northern Europe',
+    int? startsIn = 6,
+  }) async {
+    taps = 0;
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          tripReviewProvider(const TripReviewKey(tripId))
+              .overrideWith((ref) async => review),
+        ],
+        child: MaterialApp(
+          localizationsDelegates: testLocalizationsDelegates,
+          home: Scaffold(
+            body: BeforeYouGoSection(
+              tripId: tripId,
+              tripTitle: title,
+              startDate: startsIn == null ? null : inDays(startsIn),
+              onTap: () => taps++,
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump();
+  }
+
+  group('it says which trip it is about', () {
+    testWidgets('the card prints the trip name', (tester) async {
+      await pump(tester, review: TripReview(findings: findings(2)));
+
+      expect(find.text('Northern Europe'), findsOneWidget);
+    });
+
+    testWidgets('the name sits INSIDE the card, not in the section header',
+        (tester) async {
+      // ContinueChatsSection can render any number of saved conversations
+      // between the trip block and this section, so a name that lived only in
+      // the header could be scrolled off with it.
+      await pump(tester, review: TripReview(findings: findings(2)));
+
+      expect(
+        find.descendant(
+            of: find.byType(Card), matching: find.text('Northern Europe')),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('and how long is left', (tester) async {
+      await pump(tester, review: TripReview(findings: findings(2)));
+
+      expect(find.text('Starts in 6 days'), findsOneWidget);
+    });
+
+    testWidgets('a trip with no start date keeps the name, drops the countdown',
+        (tester) async {
+      await pump(tester,
+          review: TripReview(findings: findings(2)), startsIn: null);
+
+      expect(find.text('Northern Europe'), findsOneWidget);
+      expect(find.textContaining('Starts in'), findsNothing);
+    });
+
+    testWidgets('departing today reads "Starts today", not "in 0 days"',
+        (tester) async {
+      await pump(tester,
+          review: TripReview(findings: findings(2)), startsIn: 0);
+
+      expect(find.text('Starts today'), findsOneWidget);
+    });
+  });
+
+  group('it goes somewhere', () {
+    testWidgets('the whole card is one tap target', (tester) async {
+      await pump(tester, review: TripReview(findings: findings(3)));
+
+      // One, not one per row: every row would go to the same health sheet.
+      expect(
+        find.descendant(
+            of: find.byType(BeforeYouGoSection), matching: find.byType(InkWell)),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('tapping a finding row fires the section tap', (tester) async {
+      await pump(tester, review: TripReview(findings: findings(3)));
+
+      await tester.tap(find.text('No lodging booked in City 0'));
+      await tester.pump();
+
+      expect(taps, 1);
+    });
+
+    testWidgets('tapping the trip line fires it too', (tester) async {
+      await pump(tester, review: TripReview(findings: findings(3)));
+
+      await tester.tap(find.text('Northern Europe'));
+      await tester.pump();
+
+      expect(taps, 1);
+    });
+
+    testWidgets('it carries no button — the sheet owns the real ones',
+        (tester) async {
+      await pump(tester, review: TripReview(findings: findings(3)));
+
+      // A "Find a stay" here could only navigate; applying a fix needs the
+      // trip screen's mutation providers (the HomeNextStepBand rule).
+      expect(find.byType(FilledButton), findsNothing);
+      expect(find.byType(TextButton), findsNothing);
+      expect(find.byType(ElevatedButton), findsNothing);
+    });
+  });
+
+  group('the overflow line', () {
+    testWidgets('counts what the cap hid', (tester) async {
+      await pump(tester, review: TripReview(findings: findings(15)));
+
+      expect(find.text('No lodging booked in City 0'), findsOneWidget);
+      expect(find.text('No lodging booked in City 4'), findsOneWidget);
+      expect(find.text('No lodging booked in City 5'), findsNothing);
+      expect(find.text('10 more open items'), findsOneWidget);
+    });
+
+    testWidgets('is inside the tap target, not stranded under the card',
+        (tester) async {
+      // The whole defect in one assertion: this line names the complete list,
+      // so it must be part of the thing that opens it.
+      await pump(tester, review: TripReview(findings: findings(15)));
+
+      expect(
+        find.descendant(
+            of: find.byType(InkWell), matching: find.text('10 more open items')),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('is absent when nothing was hidden', (tester) async {
+      await pump(tester, review: TripReview(findings: findings(4)));
+
+      expect(find.textContaining('more open item'), findsNothing);
+    });
+  });
+
+  group('when it renders nothing at all', () {
+    testWidgets('no open items — an empty "Before you go" is worse than none',
+        (tester) async {
+      await pump(tester, review: const TripReview(findings: []));
+
+      expect(tester.getSize(find.byType(BeforeYouGoSection)), Size.zero);
+    });
+
+    testWidgets('every item is the one already promoted into the band above',
+        (tester) async {
+      final gap = lodging('Kraków', '2026-09-01');
+      await pump(
+        tester,
+        review: TripReview(
+          findings: [gap],
+          nextStep: NextStep(
+            kind: 'add_lodging',
+            title: 'Book your stay in Kraków',
+            fix: gap.fix,
+          ),
+        ),
+      );
+
+      expect(tester.getSize(find.byType(BeforeYouGoSection)), Size.zero);
+    });
+  });
+}

--- a/src/packages/flutter-app/test/departing_trip_test.dart
+++ b/src/packages/flutter-app/test/departing_trip_test.dart
@@ -1,0 +1,152 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:travel_route_planner/models/trip.dart';
+import 'package:travel_route_planner/providers/departing_trip_provider.dart';
+
+/// Which trip Home's "Before you go" section is about.
+///
+/// It used to be whichever trip [continueTripOf] returned — the last one this
+/// device VIEWED, falling back to the most recently UPDATED. Neither key is
+/// departure, so an account with two trips could get readiness for the wrong
+/// one, under a header that named no trip at all. [departingTripOf] orders on
+/// the only thing "before you go" can mean: how soon you leave.
+void main() {
+  final today = DateTime(2026, 8, 22);
+
+  Trip trip(
+    String id, {
+    String title = 'A trip',
+    String? start,
+    String? end,
+    String updatedAt = '2026-08-01T00:00:00Z',
+    String createdAt = '2026-07-01T00:00:00Z',
+  }) =>
+      Trip(
+        id: id,
+        title: title,
+        startDate: start,
+        endDate: end,
+        createdAt: createdAt,
+        updatedAt: updatedAt,
+      );
+
+  group('picks the trip departing soonest', () {
+    test('the nearest departure wins, not the most recently touched', () {
+      // The regression, exactly: the October trip is the one just edited, so
+      // continueTripOf would name it — while Friday's trip goes unmentioned.
+      final trips = [
+        trip('october',
+            title: 'Kyoto in October',
+            start: '2026-10-12',
+            updatedAt: '2026-08-22T09:00:00Z'),
+        trip('friday',
+            title: 'Northern Europe',
+            start: '2026-08-28',
+            updatedAt: '2026-07-02T00:00:00Z'),
+      ];
+
+      final result = departingTripOf(trips, null, today);
+
+      expect(result?.tripId, 'friday');
+      expect(result?.title, 'Northern Europe');
+      expect(result?.daysUntil, 6);
+    });
+
+    test('list order does not decide it', () {
+      final trips = [
+        trip('later', start: '2026-09-02'),
+        trip('sooner', start: '2026-08-25'),
+        trip('latest', start: '2026-09-04'),
+      ];
+
+      expect(departingTripOf(trips, null, today)?.tripId, 'sooner');
+    });
+
+    test('same departure date breaks to the more recently touched trip', () {
+      final trips = [
+        trip('stale', start: '2026-08-25', updatedAt: '2026-08-01T00:00:00Z'),
+        trip('fresh', start: '2026-08-25', updatedAt: '2026-08-20T00:00:00Z'),
+      ];
+
+      expect(departingTripOf(trips, null, today)?.tripId, 'fresh');
+    });
+  });
+
+  group('the window', () {
+    test('a trip on the last day of the window still qualifies', () {
+      final trips = [trip('t', start: '2026-09-05')]; // exactly 14 days out
+
+      expect(departingTripOf(trips, null, today)?.daysUntil,
+          kBeforeYouGoWindowDays);
+    });
+
+    test('a trip one day past the window does not', () {
+      final trips = [trip('t', start: '2026-09-06')]; // 15 days out
+
+      expect(departingTripOf(trips, null, today), isNull);
+    });
+
+    test('a nearer trip outside nothing — an empty list — is null', () {
+      expect(departingTripOf([], null, today), isNull);
+    });
+
+    test('a far trip does not suppress a near one', () {
+      final trips = [
+        trip('far', start: '2027-01-01'),
+        trip('near', start: '2026-08-24'),
+      ];
+
+      expect(departingTripOf(trips, null, today)?.tripId, 'near');
+    });
+  });
+
+  group('what never qualifies', () {
+    test('an undated trip', () {
+      expect(departingTripOf([trip('t')], null, today), isNull);
+    });
+
+    test('a trip whose start has already gone by', () {
+      final trips = [trip('t', start: '2026-08-10', end: '2026-08-12')];
+
+      expect(departingTripOf(trips, null, today), isNull);
+    });
+
+    test('the live trip — it has its own card, and it has begun', () {
+      final live = trip('live', start: '2026-08-20', end: '2026-08-30');
+
+      expect(departingTripOf([live], live, today), isNull);
+    });
+
+    test(
+        'the live trip is skipped even when it starts TODAY, where daysUntil '
+        'is 0 rather than null', () {
+      final live = trip('live', start: '2026-08-22', end: '2026-08-30');
+      final next = trip('next', title: 'The one after', start: '2026-09-01');
+
+      final result = departingTripOf([live, next], live, today);
+
+      expect(result?.tripId, 'next');
+    });
+  });
+
+  test('a trip departing today qualifies when it is not the live one', () {
+    // No end date and not claimed by liveTripOf: departure is today, which is
+    // when readiness matters most.
+    final trips = [trip('t', title: 'Wheels up', start: '2026-08-22')];
+
+    final result = departingTripOf(trips, null, today);
+
+    expect(result?.tripId, 't');
+    expect(result?.daysUntil, 0);
+  });
+
+  test('carries the values the card prints', () {
+    final trips = [trip('t', title: 'Northern Europe', start: '2026-08-28')];
+
+    final result = departingTripOf(trips, null, today);
+
+    expect(result?.title, 'Northern Europe');
+    expect(result?.startDate, '2026-08-28');
+    expect(result?.daysUntil, 6);
+  });
+}

--- a/src/packages/flutter-app/test/trip_detail_open_health_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_open_health_test.dart
@@ -1,0 +1,168 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:travel_route_planner/models/itinerary_item.dart';
+import 'package:travel_route_planner/models/trip.dart';
+import 'package:travel_route_planner/models/trip_finding.dart';
+import 'package:travel_route_planner/providers/trip_review_provider.dart';
+import 'package:travel_route_planner/providers/trips_provider.dart';
+import 'package:travel_route_planner/screens/trip_detail_screen.dart';
+import 'package:travel_route_planner/services/api_client.dart';
+import 'package:travel_route_planner/services/trip_review_api_service.dart';
+import 'package:travel_route_planner/services/trips_api_service.dart';
+
+import 'support/l10n_test_app.dart';
+
+/// [TripDetailScreen.openHealthSheet] — the landing half of Home's "Before you
+/// go" card. That card lists a trip's open items and can fix none of them, so
+/// it opens the sheet that can rather than dropping the traveler on the trip
+/// page to go hunting for the health badge.
+class _FakeTripsApiService extends TripsApiService {
+  final Trip? trip;
+  final Object? error;
+
+  /// Counted so the "a refresh must not reopen it" test can prove a second
+  /// load actually ran, rather than passing because the fling did nothing.
+  int loads = 0;
+
+  _FakeTripsApiService({this.trip, this.error})
+      : super(ApiClient(baseUrl: 'http://test'));
+
+  @override
+  Future<Trip> getTrip(String id) async {
+    loads++;
+    if (error != null) throw error!;
+    return trip!;
+  }
+}
+
+class _FakeReviewApiService extends TripReviewApiService {
+  final TripReview review;
+  _FakeReviewApiService(this.review) : super(ApiClient(baseUrl: 'http://test'));
+
+  @override
+  Future<TripReview> getReview(String tripId, {bool checkHours = false}) async =>
+      review;
+}
+
+void main() {
+  Trip trip() => Trip(
+        id: 't1',
+        title: 'Northern Europe',
+        startDate: '2026-09-01',
+        endDate: '2026-09-05',
+        createdAt: '2026-07-01',
+        updatedAt: '2026-07-01',
+        items: [
+          ItineraryItem(
+            id: 'i0',
+            position: 0,
+            name: 'Brandenburg Gate',
+            address: 'Berlin, Germany',
+            latitude: 0,
+            longitude: 0,
+            category: 'attraction',
+            day: 1,
+            city: 'Berlin',
+          ),
+        ],
+      );
+
+  const review = TripReview(
+    findings: [
+      TripFinding(
+        severity: 'warn',
+        category: 'lodging',
+        message: 'No lodging booked for the night of Sep 1.',
+        tripId: 't1',
+        day: 1,
+      ),
+    ],
+  );
+
+  void useTallViewport(WidgetTester tester) {
+    tester.view.physicalSize = const Size(800, 3000);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+  }
+
+  Future<_FakeTripsApiService> pump(
+    WidgetTester tester, {
+    required bool openHealthSheet,
+    Object? loadError,
+  }) async {
+    useTallViewport(tester);
+    final trips = loadError != null
+        ? _FakeTripsApiService(error: loadError)
+        : _FakeTripsApiService(trip: trip());
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          tripsApiServiceProvider.overrideWithValue(trips),
+          tripReviewApiServiceProvider
+              .overrideWithValue(_FakeReviewApiService(review)),
+        ],
+        child: MaterialApp(
+          localizationsDelegates: testLocalizationsDelegates,
+          home: TripDetailScreen(
+              tripId: 't1', openHealthSheet: openHealthSheet),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    return trips;
+  }
+
+  testWidgets('the flag lands with the health sheet already open',
+      (tester) async {
+    await pump(tester, openHealthSheet: true);
+
+    expect(find.byType(BottomSheet), findsOneWidget);
+    // The complete list, on the sheet — with the buttons Home could not host.
+    expect(
+      find.descendant(
+        of: find.byType(BottomSheet),
+        matching: find.text('No lodging booked for the night of Sep 1.'),
+      ),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('every other entry point is unchanged — no sheet',
+      (tester) async {
+    await pump(tester, openHealthSheet: false);
+
+    expect(find.byType(BottomSheet), findsNothing);
+  });
+
+  testWidgets('closing it is final — a later refresh must not reopen it',
+      (tester) async {
+    final trips = await pump(tester, openHealthSheet: true);
+    expect(find.byType(BottomSheet), findsOneWidget);
+    expect(trips.loads, 1);
+
+    Navigator.of(tester.element(find.byType(TripDetailScreen))).pop();
+    await tester.pumpAndSettle();
+    expect(find.byType(BottomSheet), findsNothing);
+
+    // Pull to refresh runs the same _load the arrival hook rides on. Driven
+    // through the indicator's own state rather than a fling, and the load
+    // count is asserted, so this cannot pass because the gesture missed.
+    tester
+        .state<RefreshIndicatorState>(find.byType(RefreshIndicator))
+        .show();
+    await tester.pumpAndSettle();
+
+    expect(trips.loads, greaterThan(1), reason: 'the refresh must have run');
+    expect(find.byType(BottomSheet), findsNothing);
+  });
+
+  testWidgets('a failed load opens nothing — the error is what to show',
+      (tester) async {
+    await pump(tester,
+        openHealthSheet: true, loadError: Exception('boom'));
+
+    expect(find.byType(BottomSheet), findsNothing);
+  });
+}


### PR DESCRIPTION
Home's pre-departure readiness section listed a trip's open items under a header that named no trip, with nothing on it to tap. Reported from the running app: *"It's not clear which trip this applies to (in this case I have one trip but what if I had multiple), and there is nothing clickable here, so no way to take action."*

## Which trip it was about — and why that was worse than it looked

The section rode `continueTripOf`, whose job is "offer a way back in": it answers with the last trip **viewed**, falling back to the most recently **updated**. Neither key is departure. So a traveler with two trips who opened the October one to rename it got October's readiness on Home while the trip leaving Friday said nothing — and since the header named no trip, nothing on screen revealed the swap.

New `departingTripOf` orders on the only thing "before you go" can mean: how soon you leave. The live trip is excluded explicitly, because `daysUntilTrip` answers `0` — not `null` — for a trip starting today, which is exactly the trip `liveTripOf` claims. The 14-day window constant moves in with the selection, so the widget no longer re-checks a rule it doesn't own.

## Saying which

The card's first line is now the trip's name and countdown — **inside the card**, not in the section header. That placement is load-bearing: `ContinueChatsSection` renders any in-progress conversations *between* the continue-trip block and this section, so the nearest thing naming a trip can be scrolled well off screen even on an account with exactly one trip.

## Going somewhere

The whole card is one tap into that trip's Trip Health sheet — the same findings, complete, with the fix buttons Home cannot host. One target, not one per row: every row leads to the same place, so per-row taps would be five ways to say one thing.

`"N more open items"` moved inside the card. It named the complete list and was the likeliest thing a traveler would reach for, and it was grey text stranded *outside* a dead card with nothing behind it.

New: `TripDetailScreen.openHealthSheet` + `openTripHealthOnTripsTab`. Route-borne like `entryOrigin` — an auto-opened sheet is a transient intent, not state a refresh should restore, so the URL is unchanged — and fired once off the first load. A failed load opens nothing; the traveler gets the error, not a sheet over it.

## The rule that had blocked this

`_FindingRow`'s doc said a row that "only navigates" is "the same broken promise `HomeNextStepBand` refuses to make." But the band **is** tapped end to end. What it refuses is a *button* that names a mutation Home can't perform. The rule was over-applied, which is why the card, every row, and the overflow line were all inert. Both comments now record which half survives — this card still carries no button.

## Verification

- `flutter analyze` clean — the 3 infos are pre-existing in `route_response.dart`, untouched here.
- **37/37** on the four affected suites, run against this branch alone.
- Full suite green at **1885** on the tree this was split from.
- The card was rendered with the real dark theme and the shipped Inter/Cormorant faces and looked at, rather than assumed.

One test caught itself: "a refresh must not reopen the sheet" passed vacuously at first, because the fling never triggered the refresh. It now asserts the load count went up and drives `RefreshIndicatorState.show()` directly.

## Behavior change worth a reviewer's eye

Home can now show **two different trips at once** — "Continue where you left off" for trip A, "Before you go" for trip B. That is correct, and it is legible only because the card names its trip; before this change the same divergence was silent.

Decision record: `artifacts/before-you-go-rework/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/golden-tempo/codesmith/anemos-travel/pr/541"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790009736&installation_model_id=433099&pr_number=541&repository=golden-tempo%2Fanemos-travel&return_to=https%3A%2F%2Fgithub.com%2Fgolden-tempo%2Fanemos-travel%2Fpull%2F541&signature=4a0b896acec7f57cfc415a4881ab492f3b36a7f45c8afd24f2c9ab41b700fdff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->