### PR TITLE
feat(notifications): dismiss one row, not just the whole feed

### DIFF
--- a/specs/clear-notifications/spec.md
+++ b/specs/clear-notifications/spec.md
@@ -14,6 +14,13 @@ missing removal half of the notification lifecycle: an explicit, user-initiated
 "Clear all", plus a server-side retention policy so read history eventually
 expires on its own.
 
+**Amended 2026-08-22 — per-notification dismissal is now in scope.** The
+original decision was clear-all only. In use that made the feed all-or-nothing:
+the only way to remove one stale row was to destroy every other row with it,
+including unread ones the traveler had not acted on yet. Wholesale deletion is
+the wrong price for tidying, so each row now carries its own ✕. Clear-all keeps
+its confirmation dialog and stays the way to empty the feed.
+
 ## User Stories
 
 - As a **signed-in user**, I want to **clear all my notifications at once** so
@@ -23,6 +30,8 @@ expires on its own.
   rather than a permanent log.
 - As a **user**, I want **unread notifications to never disappear on their
   own** so that I can trust nothing was removed before I saw it.
+- As a **signed-in user**, I want to **remove one notification I'm done with**
+  so that tidying the feed doesn't cost me every other notification in it.
 
 ## Acceptance Criteria
 
@@ -45,6 +54,23 @@ expires on its own.
       automatically, no matter how old.
 - [ ] The action and dialog are fully localized (English and Spanish).
 
+Per-notification dismissal (amended):
+
+- [ ] Every row in the feed offers a dismiss control, in both the popover and
+      the full-page presentation, visible without hovering.
+- [ ] Dismissing asks for no confirmation, and removes only that row —
+      server-side, so a reload still shows it gone.
+- [ ] Dismissing an unread row lowers the unread badge by one.
+- [ ] A notification that is not the caller's cannot be dismissed, and the
+      refusal is indistinguishable from one for an id that does not exist, so
+      the response cannot be used to discover other users' notification ids.
+- [ ] Dismissing the same row twice reports that there was nothing to dismiss
+      the second time — unlike clear-all, this names a resource.
+- [ ] If a dismiss fails (offline, server error), the row stays in the feed
+      and the user sees why — never a row that looks dismissed but was not.
+- [ ] Dismissing the last row leaves the feed in its empty state, with the
+      clear-all action gone.
+
 ## API Surface
 
 ### `DELETE /api/v1/notifications`
@@ -58,6 +84,18 @@ expires on its own.
 - **Errors:** `401` when unauthenticated; `503` when the database is
   unavailable (degraded mode); `500` with a generic message on database
   failure.
+
+### `DELETE /api/v1/notifications/{id}`
+- **Purpose:** dismiss one notification (amended 2026-08-22).
+- **Request:** the notification's id in the path; no body. Ownership is not a
+  parameter — the row must belong to the session's user.
+- **Response:** `204 No Content`.
+- **Errors:** `404` when the id names nothing the caller owns — which covers a
+  bad id, an already-dismissed row, and another user's row **with the same
+  response**, so existence cannot be probed. `401` when unauthenticated;
+  `503`/`500` as the sibling endpoints.
+- **Deliberately not idempotent**, unlike clear-all: this call names a
+  resource, so a repeat finds nothing to delete and says so.
 
 **Retention policy (server-side, no endpoint):** an hourly background prune
 deletes notifications that were read more than 45 days ago. The clock starts
@@ -81,6 +119,11 @@ six more weeks; anything you haven't seen stays until you see it or clear it."
   ⋮ menu disappears with it.
 - **States:** loading/error/empty — no ⋮ menu (nothing clearable). Non-empty —
   ⋮ menu present. Clear failure — snackbar with the reason; rows remain.
+- **Dismissing one (amended):** every row carries a trailing ✕ — always
+  visible, not hover-revealed, because the same row renders in the popover and
+  on the narrow page where hover does not exist. Tapping it removes that row
+  with no dialog; the control shows progress while the server is asked, and on
+  failure the row stays put under a snackbar saying why.
 
 ## Edge Cases & Error States
 
@@ -101,13 +144,15 @@ six more weeks; anything you haven't seen stays until you see it or clear it."
 
 ## Out of Scope
 
-- Per-notification dismissal (swipe or ✕) — clear-all only, by decision.
-- Undo after clearing.
+- Swipe-to-dismiss. The ✕ serves both presentations; swipe would be a second
+  idiom for the same act and only on one of them.
+- Undo, after clearing or after dismissing one.
 - Soft delete / archive / trash.
 - Muting, deduplicating, or rate-limiting the ops-alert stream itself.
 - Any change to when notifications are *written*.
 
 ## Open Questions
 
-None — scope (clear-all only + 45-day read-row retention, hard delete) was
-decided with the product owner on 2026-08-13.
+None. Original scope (clear-all only + 45-day read-row retention, hard delete)
+was decided with the product owner on 2026-08-13; per-notification dismissal
+was added at their request on 2026-08-22, superseding that one exclusion.

--- a/src/packages/api/main.go
+++ b/src/packages/api/main.go
@@ -908,13 +908,18 @@ func buildRouter() *mux.Router {
 	// Generalized notifications feed (Wave 16): the Flutter notification
 	// center + badge read these. Writers: the re-engagement checkers (trip
 	// reminders, weekly nudge), collab/share activity (notifications_writer.go),
-	// and the ops self-check monitor (admin-only rows). DELETE is clear-all
+	// and the ops self-check monitor (admin-only rows). Two deletes, and the
+	// difference is deliberate: collection DELETE is clear-all
 	// (specs/clear-notifications) — user-scoped, idempotent, dialog-confirmed
-	// client-side, so the general limiter suffices like its siblings.
+	// client-side; item DELETE dismisses one row, 404s when it isn't yours, and
+	// needs no dialog. The general limiter suffices for both, like their
+	// siblings. `/read` and `/unread-count` are registered BEFORE the `{id}`
+	// route so those literals can never be captured as notification ids.
 	api.Handle("/notifications", authMiddleware(http.HandlerFunc(listNotificationsHandler))).Methods("GET")
 	api.Handle("/notifications", authMiddleware(http.HandlerFunc(clearNotificationsHandler))).Methods("DELETE")
 	api.Handle("/notifications/read", authMiddleware(http.HandlerFunc(markNotificationsReadHandler))).Methods("POST")
 	api.Handle("/notifications/unread-count", authMiddleware(http.HandlerFunc(unreadNotificationsCountHandler))).Methods("GET")
+	api.Handle("/notifications/{id}", authMiddleware(http.HandlerFunc(deleteNotificationHandler))).Methods("DELETE")
 	api.Handle("/preferences", authMiddleware(http.HandlerFunc(getPreferencesHandler))).Methods("GET")
 	api.Handle("/preferences", authMiddleware(http.HandlerFunc(putPreferencesHandler))).Methods("PUT")
 	api.HandleFunc("/accommodation-links", accommodationLinksHandler).Methods("GET")

--- a/src/packages/api/notifications_handler.go
+++ b/src/packages/api/notifications_handler.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/gorilla/mux"
 
 	"travel-route-planner/store"
 )
@@ -16,8 +17,8 @@ import (
 // bag the client switches on. Writers: the re-engagement checkers (trip
 // reminders, weekly nudge), collab/share activity (notifications_writer.go),
 // and the ops self-check monitor (admin-only rows). This file reads, marks,
-// and clears (clear-all is the one delete: user-initiated, whole-feed). All
-// routes require auth.
+// and deletes — wholesale (clear-all) or one row at a time. All routes require
+// auth.
 
 const (
 	defaultNotificationsLimit = 50
@@ -110,6 +111,50 @@ func clearNotificationsHandler(w http.ResponseWriter, r *http.Request) {
 	user, _ := userFromContext(r.Context())
 	if _, err := store.New(dbPool).DeleteNotificationsByUser(r.Context(), user.ID); err != nil {
 		writeJSONError(w, http.StatusInternalServerError, "could not clear notifications")
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// deleteNotificationHandler dismisses ONE notification. The single-resource
+// counterpart to clear-all, and it takes the opposite convention deliberately:
+// this one names a resource, so zero affected rows means the named thing was
+// not the caller's to delete and the answer is 404, matching the other
+// single-resource deletes in this API.
+//
+// The 404 is the same for "no such id", "someone else's row", and "already
+// gone", because ownership lives in the query's WHERE clause — there is no
+// fetch-then-check that could tell those apart, and no response that leaks
+// which notification ids exist.
+//
+// No confirmation gate, unlike clear-all: dismissing one row of an ephemeral
+// signal is not the same act as emptying the feed, and a dialog per row would
+// make the affordance unusable. The client refetches the feed on 204 and leaves
+// the row in place on any failure, so a failed dismiss never reads as a
+// successful one.
+func deleteNotificationHandler(w http.ResponseWriter, r *http.Request) {
+	if dbPool == nil {
+		writeJSONError(w, http.StatusServiceUnavailable, "database unavailable")
+		return
+	}
+	user, _ := userFromContext(r.Context())
+	// An unparseable id is a 404 rather than a 400: it names no notification,
+	// which is the same outcome as naming one that isn't yours (the
+	// deleteAccommodationHandler convention).
+	id, err := uuid.Parse(mux.Vars(r)["id"])
+	if err != nil {
+		writeJSONError(w, http.StatusNotFound, "notification not found")
+		return
+	}
+	n, err := store.New(dbPool).DeleteNotification(r.Context(), store.DeleteNotificationParams{
+		ID: id, UserID: user.ID,
+	})
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "could not delete notification")
+		return
+	}
+	if n == 0 {
+		writeJSONError(w, http.StatusNotFound, "notification not found")
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)

--- a/src/packages/api/notifications_integration_test.go
+++ b/src/packages/api/notifications_integration_test.go
@@ -210,6 +210,89 @@ func TestNotificationsClearAll(t *testing.T) {
 	}
 }
 
+// Per-item dismissal: the single-resource counterpart to clear-all, and the
+// conventions diverge on purpose. This one NAMES a resource, so zero affected
+// rows is a 404 rather than an idempotent 204 — and that 404 is the same
+// answer for "no such id", "already dismissed" and "somebody else's row",
+// because ownership lives in the DELETE's WHERE clause. A caller cannot use it
+// to learn which notification ids exist.
+func TestNotificationDismissOne(t *testing.T) {
+	resetDB(t)
+	owner, ownerToken := createTestUser(t, "notif-dismiss-owner@example.com")
+	other, otherToken := createTestUser(t, "notif-dismiss-other@example.com")
+
+	keep := insertTestNotification(t, owner.ID, "price_drop", map[string]any{"price": 450.0}, nil)
+	drop := insertTestNotification(t, owner.ID, "trip_reminder", map[string]any{"title": "soon"}, nil)
+	theirs := insertTestNotification(t, other.ID, "weekly_nudge", map[string]any{"reason": "resume_planning"}, nil)
+
+	if n := notifUnreadCount(t, ownerToken); n != 2 {
+		t.Fatalf("unread before dismiss = %v, want 2", n)
+	}
+
+	// Dismissing one leaves the rest of the feed alone.
+	if rec := doJSON(t, "DELETE", "/api/v1/notifications/"+drop.ID.String(), ownerToken, nil); rec.Code != http.StatusNoContent {
+		t.Fatalf("dismiss own = %d, want 204: %s", rec.Code, rec.Body.String())
+	}
+	got := decodeNotifList(t, doJSON(t, "GET", "/api/v1/notifications", ownerToken, nil).Body.Bytes())
+	if len(got) != 1 {
+		t.Fatalf("owner feed after dismiss = %d rows, want 1", len(got))
+	}
+	if got[0]["id"] != keep.ID.String() {
+		t.Fatalf("dismiss removed the wrong row: left %v, want %v", got[0]["id"], keep.ID)
+	}
+	// An unread row leaving the feed has to move the badge with it.
+	if n := notifUnreadCount(t, ownerToken); n != 1 {
+		t.Fatalf("unread after dismissing an unread row = %v, want 1", n)
+	}
+
+	// Dismissing the same row again finds nothing to delete.
+	if rec := doJSON(t, "DELETE", "/api/v1/notifications/"+drop.ID.String(), ownerToken, nil); rec.Code != http.StatusNotFound {
+		t.Fatalf("second dismiss = %d, want 404", rec.Code)
+	}
+
+	// Another user's row is not the caller's to dismiss — and answers exactly
+	// as an unknown id does, so the response leaks no existence.
+	if rec := doJSON(t, "DELETE", "/api/v1/notifications/"+theirs.ID.String(), ownerToken, nil); rec.Code != http.StatusNotFound {
+		t.Fatalf("cross-user dismiss = %d, want 404", rec.Code)
+	}
+	if got := decodeNotifList(t, doJSON(t, "GET", "/api/v1/notifications", otherToken, nil).Body.Bytes()); len(got) != 1 {
+		t.Fatalf("other feed after a stranger's dismiss = %d rows, want 1 (row was deleted)", len(got))
+	}
+
+	if rec := doJSON(t, "DELETE", "/api/v1/notifications/"+uuid.NewString(), ownerToken, nil); rec.Code != http.StatusNotFound {
+		t.Fatalf("unknown id = %d, want 404", rec.Code)
+	}
+	// A non-uuid names no notification, which is the same outcome as naming
+	// one that isn't yours — 404, not 400.
+	if rec := doJSON(t, "DELETE", "/api/v1/notifications/not-a-uuid", ownerToken, nil); rec.Code != http.StatusNotFound {
+		t.Fatalf("malformed id = %d, want 404", rec.Code)
+	}
+	if rec := doJSON(t, "DELETE", "/api/v1/notifications/"+keep.ID.String(), "", nil); rec.Code != http.StatusUnauthorized {
+		t.Fatalf("anonymous dismiss = %d, want 401", rec.Code)
+	}
+}
+
+// The literal sub-routes must never be captured as notification ids by the
+// `{id}` route registered after them.
+func TestNotificationSubroutesNotCapturedAsIDs(t *testing.T) {
+	resetDB(t)
+	_, token := createTestUser(t, "notif-routes@example.com")
+
+	// POST /notifications/read still marks read (it is not a DELETE, so the
+	// id route cannot claim it) and GET unread-count still counts.
+	if rec := doJSON(t, "POST", "/api/v1/notifications/read", token, nil); rec.Code != http.StatusNoContent {
+		t.Fatalf("mark read = %d, want 204: %s", rec.Code, rec.Body.String())
+	}
+	if n := notifUnreadCount(t, token); n != 0 {
+		t.Fatalf("unread-count = %v, want 0", n)
+	}
+	// And DELETE on those literals is a 404 (no such notification), never a
+	// 405 or a silent match against a real row.
+	if rec := doJSON(t, "DELETE", "/api/v1/notifications/read", token, nil); rec.Code != http.StatusNotFound {
+		t.Fatalf("DELETE /notifications/read = %d, want 404", rec.Code)
+	}
+}
+
 // The retention prune expires READ rows 45 days after read_at and never
 // touches unread rows, however old. Runs through janitorTick itself so the
 // wiring (not just the query) is pinned — this is the first janitor test.

--- a/src/packages/api/query/notifications.sql
+++ b/src/packages/api/query/notifications.sql
@@ -15,7 +15,8 @@ LIMIT $2;
 
 -- name: MarkNotificationsRead :execrows
 -- Mark-all is the read model: opening the notification center clears the badge
--- wholesale. No per-notification variant yet.
+-- wholesale. Still no per-notification variant — unlike DELETE, which has one:
+-- a row you are done with is dismissed outright rather than marked read.
 UPDATE notifications
 SET read_at = now()
 WHERE user_id = $1 AND read_at IS NULL;
@@ -69,11 +70,22 @@ SELECT user_id, 'collab_edit',
 FROM targets;
 
 -- name: DeleteNotificationsByUser :execrows
--- Clear-all is the delete model, mirroring MarkNotificationsRead's mark-all:
--- one user-scoped wholesale action, no per-notification variant. Hard delete —
--- a notification is an ephemeral signal, not a record of account activity.
+-- Clear-all: one user-scoped wholesale action, mirroring MarkNotificationsRead.
+-- Hard delete — a notification is an ephemeral signal, not a record of account
+-- activity. DeleteNotification below is the single-row sibling.
 DELETE FROM notifications
 WHERE user_id = $1;
+
+-- name: DeleteNotification :execrows
+-- Dismiss one row. Ownership is structural in the WHERE clause rather than a
+-- separate fetch-then-check: a row owned by somebody else deletes nothing and
+-- is therefore indistinguishable from one that does not exist, so the handler's
+-- 404 cannot be used to probe which notification ids are real.
+--
+-- :execrows, not :exec — the affected count is what separates "deleted" from
+-- "was never yours", and the handler needs that to choose 204 over 404.
+DELETE FROM notifications
+WHERE id = $1 AND user_id = $2;
 
 -- name: DeleteOldReadNotifications :exec
 -- Retention (janitor): read rows expire 45 days after they were SEEN (read_at,

--- a/src/packages/api/store/notifications.sql.go
+++ b/src/packages/api/store/notifications.sql.go
@@ -24,14 +24,39 @@ func (q *Queries) CountUnreadNotifications(ctx context.Context, userID uuid.UUID
 	return count, err
 }
 
+const deleteNotification = `-- name: DeleteNotification :execrows
+DELETE FROM notifications
+WHERE id = $1 AND user_id = $2
+`
+
+type DeleteNotificationParams struct {
+	ID     uuid.UUID `json:"id"`
+	UserID uuid.UUID `json:"user_id"`
+}
+
+// Dismiss one row. Ownership is structural in the WHERE clause rather than a
+// separate fetch-then-check: a row owned by somebody else deletes nothing and
+// is therefore indistinguishable from one that does not exist, so the handler's
+// 404 cannot be used to probe which notification ids are real.
+//
+// :execrows, not :exec — the affected count is what separates "deleted" from
+// "was never yours", and the handler needs that to choose 204 over 404.
+func (q *Queries) DeleteNotification(ctx context.Context, arg DeleteNotificationParams) (int64, error) {
+	result, err := q.db.Exec(ctx, deleteNotification, arg.ID, arg.UserID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
 const deleteNotificationsByUser = `-- name: DeleteNotificationsByUser :execrows
 DELETE FROM notifications
 WHERE user_id = $1
 `
 
-// Clear-all is the delete model, mirroring MarkNotificationsRead's mark-all:
-// one user-scoped wholesale action, no per-notification variant. Hard delete —
-// a notification is an ephemeral signal, not a record of account activity.
+// Clear-all: one user-scoped wholesale action, mirroring MarkNotificationsRead.
+// Hard delete — a notification is an ephemeral signal, not a record of account
+// activity. DeleteNotification below is the single-row sibling.
 func (q *Queries) DeleteNotificationsByUser(ctx context.Context, userID uuid.UUID) (int64, error) {
 	result, err := q.db.Exec(ctx, deleteNotificationsByUser, userID)
 	if err != nil {
@@ -201,7 +226,8 @@ WHERE user_id = $1 AND read_at IS NULL
 `
 
 // Mark-all is the read model: opening the notification center clears the badge
-// wholesale. No per-notification variant yet.
+// wholesale. Still no per-notification variant — unlike DELETE, which has one:
+// a row you are done with is dismissed outright rather than marked read.
 func (q *Queries) MarkNotificationsRead(ctx context.Context, userID uuid.UUID) (int64, error) {
 	result, err := q.db.Exec(ctx, markNotificationsRead, userID)
 	if err != nil {

--- a/src/packages/flutter-app/lib/l10n/app_en.arb
+++ b/src/packages/flutter-app/lib/l10n/app_en.arb
@@ -2086,6 +2086,19 @@
       }
     }
   },
+  "notifDismiss": "Dismiss",
+  "@notifDismiss": {
+    "description": "Tooltip and screen-reader label on the ✕ that removes one notification from the feed. Not a confirm-gated action, unlike Clear all."
+  },
+  "notifDismissFailed": "Could not dismiss: {error}",
+  "@notifDismissFailed": {
+    "description": "Snackbar when removing one notification fails. The row stays in the feed.",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
   "notifLoadErrorTitle": "Could not load notifications",
   "notifEmptyTitle": "No notifications yet",
   "notifEmptyMessage": "Trip reminders and co-planning updates will show up here.",

--- a/src/packages/flutter-app/lib/l10n/app_es.arb
+++ b/src/packages/flutter-app/lib/l10n/app_es.arb
@@ -886,6 +886,8 @@
   "notifClearAllTitle": "¿Borrar todas las notificaciones?",
   "notifClearAllBody": "Se eliminarán todas las notificaciones, incluidas las no leídas. Esta acción no se puede deshacer.",
   "notifClearAllFailed": "No se pudieron borrar las notificaciones: {error}",
+  "notifDismiss": "Descartar",
+  "notifDismissFailed": "No se pudo descartar: {error}",
   "notifLoadErrorTitle": "No se pudieron cargar las notificaciones",
   "notifEmptyTitle": "Aún no tienes notificaciones",
   "notifEmptyMessage": "Aquí aparecerán los recordatorios de viaje y las novedades de planificación compartida.",

--- a/src/packages/flutter-app/lib/l10n/app_localizations.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations.dart
@@ -5270,6 +5270,18 @@ abstract class AppLocalizations {
   /// **'Could not clear notifications: {error}'**
   String notifClearAllFailed(String error);
 
+  /// Tooltip and screen-reader label on the ✕ that removes one notification from the feed. Not a confirm-gated action, unlike Clear all.
+  ///
+  /// In en, this message translates to:
+  /// **'Dismiss'**
+  String get notifDismiss;
+
+  /// Snackbar when removing one notification fails. The row stays in the feed.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not dismiss: {error}'**
+  String notifDismissFailed(String error);
+
   /// No description provided for @notifLoadErrorTitle.
   ///
   /// In en, this message translates to:

--- a/src/packages/flutter-app/lib/l10n/app_localizations_en.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations_en.dart
@@ -3128,6 +3128,14 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String get notifDismiss => 'Dismiss';
+
+  @override
+  String notifDismissFailed(String error) {
+    return 'Could not dismiss: $error';
+  }
+
+  @override
   String get notifLoadErrorTitle => 'Could not load notifications';
 
   @override

--- a/src/packages/flutter-app/lib/l10n/app_localizations_es.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations_es.dart
@@ -3147,6 +3147,14 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
+  String get notifDismiss => 'Descartar';
+
+  @override
+  String notifDismissFailed(String error) {
+    return 'No se pudo descartar: $error';
+  }
+
+  @override
   String get notifLoadErrorTitle => 'No se pudieron cargar las notificaciones';
 
   @override

--- a/src/packages/flutter-app/lib/screens/notification_center_screen.dart
+++ b/src/packages/flutter-app/lib/screens/notification_center_screen.dart
@@ -22,10 +22,13 @@ import 'admin_metrics_screen.dart';
 /// opens (account_menu.dart), and [NotificationCenterScreen] stays the full
 /// page for narrow widths and URL deep links. Rows are flat and
 /// hairline-divided — a leading type-icon chip, weight-not-size unread
-/// emphasis, a trailing unread dot — grouped into New/Earlier while unread
-/// rows exist. Clear-all lives as a quiet footer action (the confirm dialog
-/// remains the gate); the server has no per-item or archive endpoints, so
-/// those are the whole inbox vocabulary.
+/// emphasis, a trailing unread dot then a dismiss ✕ — grouped into New/Earlier
+/// while unread rows exist.
+///
+/// Two ways out, and the difference is the point: the row ✕ removes one
+/// notification with no dialog, and the quiet clear-all footer empties the feed
+/// behind a confirm. There is still no archive endpoint, so removal is
+/// permanent either way.
 ///
 /// Type-agnostic as before: each row renders from `type` + `payload`, so trip
 /// signals, ops alerts and future types share one feed.
@@ -101,6 +104,42 @@ Future<void> _confirmAndClearAll(BuildContext context, WidgetRef ref) async {
   } catch (e) {
     if (context.mounted) {
       showSnack(context, l10n.notifClearAllFailed(friendlyError(l10n, e)));
+    }
+    return;
+  }
+  if (!context.mounted) return;
+  ref.invalidate(notificationsProvider);
+  ref.invalidate(notificationsUnreadCountProvider);
+}
+
+/// Dismiss one row. The single-row sibling of [_confirmAndClearAll], and
+/// deliberately unlike it in two ways.
+///
+/// **No confirmation.** Clear-all is gated because it empties the feed
+/// wholesale and cannot be undone; removing one row of an ephemeral signal is
+/// a different act, and a dialog on every ✕ would make the affordance cost
+/// more than the clutter it removes.
+///
+/// **It refetches rather than removing the row locally.** The feed is a
+/// [FutureProvider], so the row leaves when the server confirms it is gone —
+/// which is why the button shows a spinner in the meantime instead of nothing.
+/// On failure the row stays exactly where it was and the snackbar says why: a
+/// dismiss that silently failed would look identical to one that worked, and
+/// the traveler would believe a notification was gone when it was not.
+///
+/// The unread count is invalidated too — dismissing an unread row has to move
+/// the badge, and nothing else would.
+Future<void> _dismissNotification(
+  BuildContext context,
+  WidgetRef ref,
+  String id,
+) async {
+  final l10n = context.l10n;
+  try {
+    await ref.read(notificationsApiServiceProvider).delete(id);
+  } catch (e) {
+    if (context.mounted) {
+      showSnack(context, l10n.notifDismissFailed(friendlyError(l10n, e)));
     }
     return;
   }
@@ -523,9 +562,65 @@ class _NotificationRow extends ConsumerWidget {
                   ),
                 ),
               ),
+            // Always present, never hover-revealed. The popover is the
+            // pointer presentation but NotificationCenterScreen is the same
+            // rows at narrow widths, where a hover affordance is no
+            // affordance — and an inbox whose only exit was "clear all" is
+            // what this row is here to fix.
+            _DismissButton(id: notification.id),
           ],
         ),
       ),
+    );
+  }
+}
+
+/// The per-row ✕. Stateful only to hold `_busy`, which does two jobs: it
+/// disarms the button so a double tap cannot fire a second DELETE (the second
+/// would 404 on an already-deleted row and raise an error for something that
+/// in fact succeeded), and it replaces the glyph with a spinner so the wait
+/// for the refetch reads as progress rather than a dead click.
+class _DismissButton extends ConsumerStatefulWidget {
+  final String id;
+  const _DismissButton({required this.id});
+
+  @override
+  ConsumerState<_DismissButton> createState() => _DismissButtonState();
+}
+
+class _DismissButtonState extends ConsumerState<_DismissButton> {
+  bool _busy = false;
+
+  Future<void> _dismiss() async {
+    setState(() => _busy = true);
+    await _dismissNotification(context, ref, widget.id);
+    // On success this row is on its way out with the refetch, so the setState
+    // may land after unmount — on failure the row stays and the button has to
+    // be usable again. `mounted` covers both.
+    if (mounted) setState(() => _busy = false);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    return IconButton(
+      // Full 48 target (kMinTouchTarget) rather than a dense 32: rows with a
+      // two-line body are already taller than this, so it costs height only on
+      // the shortest ones.
+      iconSize: 18,
+      visualDensity: VisualDensity.standard,
+      tooltip: context.l10n.notifDismiss,
+      onPressed: _busy ? null : _dismiss,
+      icon: _busy
+          ? SizedBox(
+              width: 16,
+              height: 16,
+              child: CircularProgressIndicator(
+                strokeWidth: 2,
+                color: scheme.onSurfaceVariant,
+              ),
+            )
+          : Icon(Icons.close, color: scheme.onSurfaceVariant),
     );
   }
 }

--- a/src/packages/flutter-app/lib/services/notifications_api_service.dart
+++ b/src/packages/flutter-app/lib/services/notifications_api_service.dart
@@ -3,8 +3,8 @@ import '../models/notification.dart';
 import 'api_client.dart';
 
 /// Client for the generalized notifications feed (Wave 16): `/notifications`
-/// (GET list / DELETE clear-all), `/notifications/read`,
-/// `/notifications/unread-count`.
+/// (GET list / DELETE clear-all), `/notifications/{id}` (DELETE one),
+/// `/notifications/read`, `/notifications/unread-count`.
 class NotificationsApiService {
   final ApiClient apiClient;
 
@@ -53,6 +53,21 @@ class NotificationsApiService {
   Future<void> clearAll() async {
     final res = await apiClient.httpClient.delete(
       Uri.parse('${apiClient.baseUrl}/notifications'),
+      headers: apiClient.jsonHeaders(),
+    );
+    if (res.statusCode != 204) {
+      throw Exception(_errorMessage(res.body, res.statusCode));
+    }
+  }
+
+  /// Dismisses ONE notification. Returns 204; **404 when the row is not the
+  /// caller's** — which covers "already gone" and "someone else's" alike,
+  /// because the server resolves ownership inside the delete rather than in a
+  /// separate lookup. Not idempotent, unlike [clearAll]: this one names a
+  /// resource, so a second call finds nothing to delete and says so.
+  Future<void> delete(String id) async {
+    final res = await apiClient.httpClient.delete(
+      Uri.parse('${apiClient.baseUrl}/notifications/$id'),
       headers: apiClient.jsonHeaders(),
     );
     if (res.statusCode != 204) {

--- a/src/packages/flutter-app/test/notification_center_test.dart
+++ b/src/packages/flutter-app/test/notification_center_test.dart
@@ -57,11 +57,23 @@ class _FakeNotificationsApiService extends NotificationsApiService {
   bool clearAllCalled = false;
   Exception? clearAllError; // set to make clearAll throw
 
+  /// Ids handed to [delete], in order — the per-row dismiss.
+  final List<String> deletedIds = [];
+  Exception? deleteError; // set to make delete throw
+
   _FakeNotificationsApiService(this.notifications)
       : super(ApiClient(baseUrl: 'http://test'));
 
-  // Post-clear refetches observe the cleared feed, matching the real
-  // contract (the client re-lists to see post-state).
+  /// The feed the server would return now: empty once cleared, otherwise
+  /// minus anything dismissed. Refetches observe post-state on both paths,
+  /// matching the real contract (the client re-lists to see it).
+  List<AppNotification> get _live => clearAllCalled
+      ? const []
+      : [
+          for (final n in notifications)
+            if (!deletedIds.contains(n.id)) n
+        ];
+
   @override
   Future<List<AppNotification>> list({int limit = 50}) async {
     if (failLists) throw Exception('list down');
@@ -70,7 +82,7 @@ class _FakeNotificationsApiService extends NotificationsApiService {
       failNextList = null;
       throw err;
     }
-    return clearAllCalled ? const [] : notifications;
+    return _live;
   }
 
   @override
@@ -80,16 +92,24 @@ class _FakeNotificationsApiService extends NotificationsApiService {
     clearAllCalled = true;
   }
 
+  /// Throws before recording when [deleteError] is set — a failed dismiss
+  /// must leave the row in the feed, so the fake must not "half" delete it.
+  @override
+  Future<void> delete(String id) async {
+    final err = deleteError;
+    if (err != null) throw err;
+    deletedIds.add(id);
+  }
+
   @override
   Future<void> markRead() async {
     markReadCalled = true;
   }
 
-  // Mirrors list(): a cleared feed has nothing unread, so the badge a
-  // post-clear refetch observes is 0.
+  // Mirrors list(): the badge a refetch observes counts only what is still
+  // in the feed, so dismissing an unread row moves it.
   @override
-  Future<int> unreadCount() async =>
-      clearAllCalled ? 0 : notifications.where((n) => n.isUnread).length;
+  Future<int> unreadCount() async => _live.where((n) => n.isUnread).length;
 }
 
 UserModel _user() => UserModel(
@@ -437,6 +457,101 @@ void main() {
     expect(find.text('Paris trip starts soon'), findsOneWidget);
   });
 
+  // Per-row dismissal — the half of the lifecycle the feed shipped without.
+  // Clear-all was the only exit, so removing one stale row meant destroying
+  // the whole feed. Deliberately unlike clear-all: no confirmation gate, and
+  // the row leaves only once the server says it is gone.
+  group('dismiss one', () {
+    testWidgets('every row carries its own dismiss control', (tester) async {
+      await _pump(tester, [_priceDrop(id: 'a'), _ops(id: 'b')]);
+
+      expect(find.byTooltip('Dismiss'), findsNWidgets(2));
+    });
+
+    testWidgets('dismissing deletes that id and drops only that row',
+        (tester) async {
+      final service = await _pump(
+          tester, [_priceDrop(id: 'a'), _ops(id: 'b')]);
+
+      // The ops row is second; dismiss it and the price drop must survive.
+      await tester.tap(find.byTooltip('Dismiss').last);
+      await tester.pumpAndSettle();
+
+      expect(service.deletedIds, ['b']);
+      expect(find.text('System degraded'), findsNothing);
+      expect(find.text('BOS → CDG'), findsOneWidget);
+      expect(find.byTooltip('Dismiss'), findsNWidgets(1));
+    });
+
+    testWidgets('it asks nothing first — a dialog per row would cost more '
+        'than the clutter it removes', (tester) async {
+      final service = await _pump(tester, [_priceDrop(id: 'a')]);
+
+      await tester.tap(find.byTooltip('Dismiss'));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(AlertDialog), findsNothing);
+      expect(service.deletedIds, ['a']);
+    });
+
+    testWidgets('dismissing the last row lands on the empty state',
+        (tester) async {
+      await _pump(tester, [_priceDrop(id: 'a')]);
+
+      await tester.tap(find.byTooltip('Dismiss'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('No notifications yet'), findsOneWidget);
+      // Nothing left to clear, so the destructive footer goes with it.
+      expect(find.text('Clear all'), findsNothing);
+    });
+
+    testWidgets('dismissing an unread row moves the badge', (tester) async {
+      final service = await _pump(tester,
+          [_priceDrop(id: 'a'), _ops(id: 'b', readAt: '2026-07-16T00:00:00Z')]);
+      expect(await service.unreadCount(), 1);
+
+      await tester.tap(find.byTooltip('Dismiss').first);
+      await tester.pumpAndSettle();
+
+      // The unread row left the feed, so the count a refetch observes drops.
+      expect(service.deletedIds, ['a']);
+      expect(await service.unreadCount(), 0);
+    });
+
+    testWidgets('a failed dismiss keeps the row and says why', (tester) async {
+      final service = await _pump(tester, [_priceDrop(id: 'a'), _ops(id: 'b')]);
+      service.deleteError = Exception('nope');
+
+      await tester.tap(find.byTooltip('Dismiss').first);
+      await tester.pumpAndSettle();
+
+      // A dismiss that silently failed would look exactly like one that
+      // worked, and the row would be believed gone when the server still
+      // has it.
+      expect(service.deletedIds, isEmpty);
+      expect(find.text('BOS → CDG'), findsOneWidget);
+      expect(find.byTooltip('Dismiss'), findsNWidgets(2));
+      expect(find.textContaining('Could not dismiss'), findsOneWidget);
+    });
+
+    testWidgets('the button re-arms after a failure', (tester) async {
+      final service = await _pump(tester, [_priceDrop(id: 'a')]);
+      service.deleteError = Exception('nope');
+      await tester.tap(find.byTooltip('Dismiss'));
+      await tester.pumpAndSettle();
+
+      // The busy flag must clear on the failure path, or the row would be
+      // left with a permanently dead ✕.
+      service.deleteError = null;
+      await tester.tap(find.byTooltip('Dismiss'));
+      await tester.pumpAndSettle();
+
+      expect(service.deletedIds, ['a']);
+    });
+
+  });
+
   group('clear all', () {
     testWidgets('clear-all footer hidden on an empty feed, shown with rows',
         (tester) async {
@@ -575,6 +690,54 @@ void main() {
       await tester.pumpAndSettle();
       return service;
     }
+
+    testWidgets('rows carry the dismiss control here too, not just the page',
+        (tester) async {
+      final service = await pumpPanel(tester, [_priceDrop(id: 'a')]);
+
+      // One _NotificationRow serves both presentations. A hover-revealed ✕
+      // would have been no affordance at all on the narrow page, which is
+      // the touch one.
+      expect(find.byTooltip('Dismiss'), findsOneWidget);
+
+      await tester.tap(find.byTooltip('Dismiss'));
+      await tester.pumpAndSettle();
+
+      expect(service.deletedIds, ['a']);
+      expect(find.text('No notifications yet'), findsOneWidget);
+    });
+
+    testWidgets('dismissing a TAPPABLE row does not also follow the row',
+        (tester) async {
+      // ops rows navigate to admin metrics, and the ✕ sits inside that same
+      // InkWell. If the button let the tap through, dismissing one would
+      // silently yank the traveler onto another screen. onClose is the
+      // observable: the panel always closes itself before navigating.
+      var closes = 0;
+      final service = _FakeNotificationsApiService([_ops(id: 'o')]);
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            authProvider.overrideWith((ref) => _FakeAuthNotifier(_user())),
+            notificationsApiServiceProvider.overrideWithValue(service),
+          ],
+          child: MaterialApp(
+            localizationsDelegates: testLocalizationsDelegates,
+            home: Scaffold(
+              body: Center(
+                  child: NotificationsPanel(onClose: () => closes++)),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byTooltip('Dismiss'));
+      await tester.pumpAndSettle();
+
+      expect(service.deletedIds, ['o']);
+      expect(closes, 0, reason: 'the ✕ must not trigger the row navigation');
+    });
 
     testWidgets('panel renders header, rows and the clear-all footer',
         (tester) async {


### PR DESCRIPTION
The notification center offered exactly one way to remove anything: **Clear all**. Reported from the running app: *"no way to clear individual notifications, only the clear all."*

So tidying one stale row meant destroying every other row with it — including unread ones the traveler hadn't acted on yet. Wholesale deletion is the wrong price for tidying.

## This reverses a recorded decision, not an oversight

`specs/clear-notifications/spec.md` listed per-notification dismissal under **Out of Scope**: *"(swipe or ✕) — clear-all only, by decision,"* settled with the product owner on 2026-08-13. Rather than leave the spec asserting the opposite of what ships, it's amended here — with the reason, the new acceptance criteria, and the endpoint. Clear-all keeps its confirmation dialog and stays the way to empty the feed.

## Server — `DELETE /api/v1/notifications/{id}`

Ownership lives in the DELETE's `WHERE` clause rather than a fetch-then-check, which makes one security property structural: **"no such id", "already dismissed", and "another user's row" all return the same 404**, so the endpoint can't be used to probe which notification ids exist. A non-uuid is a 404 too — it names no notification, same outcome as naming one that isn't yours (the `deleteAccommodationHandler` convention).

**Deliberately not idempotent**, unlike clear-all. That endpoint's own comment already drew the line: it "mirrors mark-all-read, not the single-resource deletes (which 404 on zero rows)... clear-all names no resource." This one does name one, so a repeat finds nothing and says so.

The `{id}` route is registered *after* `/read` and `/unread-count` so those literals can never be captured as notification ids — pinned by a test.

## Client

An **always-visible ✕ per row, never hover-revealed.** One `_NotificationRow` serves the desktop popover *and* `NotificationCenterScreen`, which is the narrow/touch presentation — a hover affordance there is no affordance at all.

**No confirmation**, unlike clear-all. Dismissing one row of an ephemeral signal is a different act from emptying the feed, and a dialog on every ✕ would cost more than the clutter it removes.

The button **spins and disarms while the server is asked**, which does two jobs: a double-tap can't fire a second DELETE that would 404 on a row that in fact succeeded, and the wait for the refetch reads as progress rather than a dead click. On failure **the row stays put** under a snackbar — a silently-failed dismiss looks identical to one that worked, and the traveler would believe a notification was gone when the server still has it.

Row size is unchanged in practice: the ✕ takes the full `kMinTouchTarget` (48) rather than a dense 32, and rows with a two-line body are already taller than that.

## Verification

- **Go suite green against a real database.** Worth stating plainly: these integration tests *silently skip* without `TEST_DATABASE_URL`, which is the local default — so they were actually run, not assumed. 3 new tests cover the 204, the cross-user 404, the repeat 404, the unknown/malformed id, the unread-badge move, and the sub-route capture guard.
- `go vet`, `gofmt`, and sqlc regeneration clean (CI has a drift check).
- `flutter analyze` clean — the 3 infos are pre-existing in `route_response.dart`, untouched here.
- **40/40** on the notification suite, including 9 new dismiss tests.
- Translations complete — `l10n_untranslated.json` is `{}` (en + es).
- The panel was rendered with the real dark theme and shipped fonts to check a ✕ per row didn't wreck row density. It doesn't; it aligns with the row's icon chip.

One test worth calling out: the ✕ sits inside the same `InkWell` that makes ops rows navigate to admin metrics. If it let the tap through, dismissing one would silently yank you onto another screen — pinned via the panel's `onClose` callback.

## Split note

This and #541 were developed in one tree and split. I verified the split is lossless by merging both branches in a scratch worktree and byte-comparing against a reconstruction of the pre-split tree: **identical**. So the full-suite number that covered both (1885 passing) applies to their union.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/golden-tempo/codesmith/anemos-travel/pr/542"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790009951&installation_model_id=433099&pr_number=542&repository=golden-tempo%2Fanemos-travel&return_to=https%3A%2F%2Fgithub.com%2Fgolden-tempo%2Fanemos-travel%2Fpull%2F542&signature=aa97ab124908d631a641953f69853e7eaffa94f07d8b576dd98b6bd0c0ce528f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->