### PR TITLE
feat(plan): the opening composes to the phone's field, not the desktop's

### DIFF
--- a/src/packages/flutter-app/lib/l10n/app_en.arb
+++ b/src/packages/flutter-app/lib/l10n/app_en.arb
@@ -1718,6 +1718,10 @@
   "connectExpiredTitle": "This request expired",
   "connectExpiredMessage": "Start the connection again from your AI assistant.",
   "importFromAi": "Import from AI chat",
+  "importFromAiShort": "Import chat",
+  "@importFromAiShort": {
+    "description": "Short spelling of importFromAi for the Plan tab's opening on phone-width panels, where the two chips otherwise wrap to a second row. Must still name the action, not just the source."
+  },
   "importExplainer": "Planned a trip in ChatGPT or Claude? Paste the conversation — or its final summary — and we'll turn it into a trip you can edit.",
   "importCopyPrompt": "Copy planning prompt",
   "importPromptCopied": "Prompt copied — paste it into ChatGPT or Claude to start planning.",
@@ -2761,6 +2765,10 @@
   "errorServer": "Something went wrong on our end. Please try again in a moment.",
   "errorGeneric": "Something went wrong. Please try again.",
   "nearMeChipLabel": "What's near me?",
+  "nearMeChipLabelShort": "Near me",
+  "@nearMeChipLabelShort": {
+    "description": "Short spelling of nearMeChipLabel for panels too narrow to fit the full label beside another chip. Keep it well under the full label in every locale — the Plan tab's opening sizes its whole composition assuming these two chips share one row."
+  },
   "nearMeSeedLabel": "Near my current location",
   "nearMeSeedMessage": "My current location is latitude {lat}, longitude {lng} (accuracy about {accuracy} m). What's good to see, do, or eat near me right now?",
   "@nearMeSeedMessage": {

--- a/src/packages/flutter-app/lib/l10n/app_es.arb
+++ b/src/packages/flutter-app/lib/l10n/app_es.arb
@@ -698,6 +698,7 @@
   "connectExpiredTitle": "Esta solicitud caducó",
   "connectExpiredMessage": "Vuelve a iniciar la conexión desde tu asistente de IA.",
   "importFromAi": "Importar de un chat de IA",
+  "importFromAiShort": "Importar chat",
   "importExplainer": "¿Planeaste un viaje en ChatGPT o Claude? Pega la conversación — o su resumen final — y la convertiremos en un viaje que puedes editar.",
   "importCopyPrompt": "Copiar prompt de planificación",
   "importPromptCopied": "Prompt copiado — pégalo en ChatGPT o Claude para empezar a planear.",
@@ -1148,6 +1149,7 @@
   "errorServer": "Algo salió mal de nuestro lado. Inténtalo de nuevo en un momento.",
   "errorGeneric": "Algo salió mal. Inténtalo de nuevo.",
   "nearMeChipLabel": "¿Qué hay cerca de mí?",
+  "nearMeChipLabelShort": "Cerca de mí",
   "nearMeSeedLabel": "Cerca de mi ubicación actual",
   "nearMeSeedMessage": "Mi ubicación actual es latitud {lat}, longitud {lng} (precisión de unos {accuracy} m). ¿Qué hay bueno para ver, hacer o comer cerca de mí ahora mismo?",
   "@nearMeSeedMessage": {

--- a/src/packages/flutter-app/lib/l10n/app_localizations.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations.dart
@@ -4244,6 +4244,12 @@ abstract class AppLocalizations {
   /// **'Import from AI chat'**
   String get importFromAi;
 
+  /// Short spelling of importFromAi for the Plan tab's opening on phone-width panels, where the two chips otherwise wrap to a second row. Must still name the action, not just the source.
+  ///
+  /// In en, this message translates to:
+  /// **'Import chat'**
+  String get importFromAiShort;
+
   /// No description provided for @importExplainer.
   ///
   /// In en, this message translates to:
@@ -6781,6 +6787,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'What\'s near me?'**
   String get nearMeChipLabel;
+
+  /// Short spelling of nearMeChipLabel for panels too narrow to fit the full label beside another chip. Keep it well under the full label in every locale — the Plan tab's opening sizes its whole composition assuming these two chips share one row.
+  ///
+  /// In en, this message translates to:
+  /// **'Near me'**
+  String get nearMeChipLabelShort;
 
   /// No description provided for @nearMeSeedLabel.
   ///

--- a/src/packages/flutter-app/lib/l10n/app_localizations_en.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations_en.dart
@@ -2518,6 +2518,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get importFromAi => 'Import from AI chat';
 
   @override
+  String get importFromAiShort => 'Import chat';
+
+  @override
   String get importExplainer =>
       'Planned a trip in ChatGPT or Claude? Paste the conversation — or its final summary — and we\'ll turn it into a trip you can edit.';
 
@@ -4120,6 +4123,9 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get nearMeChipLabel => 'What\'s near me?';
+
+  @override
+  String get nearMeChipLabelShort => 'Near me';
 
   @override
   String get nearMeSeedLabel => 'Near my current location';

--- a/src/packages/flutter-app/lib/l10n/app_localizations_es.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations_es.dart
@@ -2535,6 +2535,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get importFromAi => 'Importar de un chat de IA';
 
   @override
+  String get importFromAiShort => 'Importar chat';
+
+  @override
   String get importExplainer =>
       '¿Planeaste un viaje en ChatGPT o Claude? Pega la conversación — o su resumen final — y la convertiremos en un viaje que puedes editar.';
 
@@ -4147,6 +4150,9 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get nearMeChipLabel => '¿Qué hay cerca de mí?';
+
+  @override
+  String get nearMeChipLabelShort => 'Cerca de mí';
 
   @override
   String get nearMeSeedLabel => 'Cerca de mi ubicación actual';

--- a/src/packages/flutter-app/lib/screens/agent_screen.dart
+++ b/src/packages/flutter-app/lib/screens/agent_screen.dart
@@ -105,7 +105,19 @@ class _AgentScreenState extends ConsumerState<AgentScreen> {
           // The width-capped column exposes the full-bleed bar's square
           // corners mid-screen; float the composer as a rounded card here.
           floatingComposer: true,
-          emptyState: const _PlanIntro(),
+          // The opening composes to the panel it gets, so it is built from
+          // the panel's constraints rather than handed over as a fixed
+          // widget — see _IntroTier for what the field gives up and when.
+          emptyStateBuilder: (context, panel) => _PlanIntro(
+            tier: _IntroTier.forField(context, panel),
+            railCardWidth: _railCardWidthFor(panel.maxWidth),
+            shortChipLabels: _shortChipLabelsFor(panel.maxWidth),
+          ),
+          // The same derivation, so the two cannot disagree: the field the
+          // chosen tier needs is exactly the height at which joining it to
+          // the composer fits.
+          emptyStateJoinFloor: (context, panel) =>
+              _IntroTier.forField(context, panel).fieldFor(context, panel),
           onViewTrip: _openTrip,
           footerBuilder: (context, state) => state.completedLocations == null
               ? const SizedBox.shrink()
@@ -128,15 +140,136 @@ class _AgentScreenState extends ConsumerState<AgentScreen> {
   }
 }
 
-/// One card of the destination rail. The landing rail's width, because the two
-/// photo rails in the product are the same component doing the same job and a
-/// second number would only be a second number.
-const double _kRailCardWidth = 260;
+/// One card of the destination rail, wide then narrow.
+///
+/// Two numbers because the rail's job is a COUNT — "two and a bit cards, the
+/// next one cut by the edge" — and a count is not a width. 260 is the landing
+/// rail's width and what the 760px column gets. A phone handed that same 260
+/// shows 1.4 cards for 188px of a field that can be as short as 413: the block
+/// that costs the most buying the least of what it exists to do. 150 restores
+/// the count — two whole cards and a sliver at 375 — and hands 52px back.
+///
+/// The photo's aspect is identical either way, because
+/// [DestinationSuggestionCard] scales its image band with the card, so nothing
+/// crops differently. What changes is that the fixed two-line text band stops
+/// being mostly empty.
+const double _kRailCardWide = 260;
+const double _kRailCardNarrow = 150;
+
+/// Panel width at or above which the rail keeps the wide card: two wide cards,
+/// the gap between them, and the rail's own padding. Derived from those parts
+/// rather than written as a device breakpoint, so changing a card width cannot
+/// leave this stale.
+const double _kRailWideField =
+    _kRailCardWide * 2 + AppSpacing.md + AppSpacing.lg * 2;
+
+double _railCardWidthFor(double panelWidth) =>
+    panelWidth >= _kRailWideField ? _kRailCardWide : _kRailCardNarrow;
+
+/// Panel width below which the two chips take their short spelling — and, in
+/// [_ChipStrip], a Row that cannot wrap.
+///
+/// A width question, like the rail's, and keyed to width rather than to how
+/// tall the field is, so the same phone cannot show one row of chips in Safari
+/// and two installed. Browser-measured at 390: "What's near me?" is 170 and
+/// "Import from AI chat" 186, which with the 8 between them is 364 into 358 of
+/// usable width — a second row for the sake of 6px. Spanish is the reason the
+/// Row backs this up rather than the short labels alone: "¿Qué hay cerca de
+/// mí?" is 210, so a Wrap took its second row anyway and pushed the composer
+/// under the nav bar. Above this width the full spelling fits, and it is the
+/// better copy.
+const double _kChipsFullLabelField = 364 + AppSpacing.lg * 2;
+
+bool _shortChipLabelsFor(double panelWidth) =>
+    panelWidth < _kChipsFullLabelField;
 
 /// How wide the intro paragraph is allowed to run. A centered measure, not the
 /// column width: past ~50 characters a line the eye loses the return sweep,
 /// and the whole point of this block is that it reads in one glance.
 const double _kIntroMeasure = 420;
+
+/// How much of the opening the field can actually hold.
+///
+/// Mobile web forced this. Browser-measured on the running app at 390 wide and
+/// default text scale, the whole block plus the composer is 608px, and the
+/// panel a phone offers is the viewport less the 56px app bar and the 84px nav
+/// bar: 704 installed, but 524 in Safari with its chrome showing, and 413 on a
+/// 375x667 device. At 524 both chips fell off the bottom; at 413 the
+/// destination cards were sliced through their labels. Three of the four ways
+/// in were invisible on the one screen whose whole job is offering them.
+///
+/// So the block composes to the field instead of overflowing it, and the order
+/// it gives things up is fixed: air first, then the rail's photo size, then
+/// prose. A way in is never what goes.
+enum _IntroTier {
+  /// Everything: the wide rail, the sentence, the xxl seam. The desktop
+  /// column, a tablet, and an installed app on a modern phone.
+  tall(
+      chrome: 370,
+      seam: AppSpacing.xxl,
+      gapAboveChips: AppSpacing.lg,
+      tailGap: AppSpacing.lg),
+
+  /// Mobile web with browser chrome showing. The seams tighten by a rung;
+  /// the sentence stays.
+  medium(
+      chrome: 354,
+      seam: AppSpacing.xl,
+      gapAboveChips: AppSpacing.lg,
+      tailGap: AppSpacing.sm),
+
+  /// The shortest phones. The explanatory sentence drops so the heading, all
+  /// four ways in, and the composer stay on screen together — a first-timer
+  /// can still act, which is what the sentence only described.
+  short(
+      chrome: 270,
+      seam: AppSpacing.xl,
+      gapAboveChips: AppSpacing.md,
+      tailGap: AppSpacing.sm);
+
+  const _IntroTier({
+    required this.chrome,
+    required this.seam,
+    required this.gapAboveChips,
+    required this.tailGap,
+  });
+
+  /// Everything this composition needs that is NOT the destination rail —
+  /// heading, sentence if it keeps one, seams, the single chip row, and the
+  /// composer it is placed with. Browser-measured on the running app at 390
+  /// wide and default text scale; the rail is added at call time because it
+  /// is the one block whose height still moves with the panel's width.
+  final double chrome;
+
+  /// The block's own seam, between the reading half and the acting half.
+  final double seam;
+
+  final double gapAboveChips;
+
+  /// Below the chips, before [ChatPanel] adds its own lg and the composer's
+  /// padding. Separate from [seam] because the two are answering different
+  /// questions, and tying them together left the short field with 21px above
+  /// the rail and 42px under the chips — the same air, badly spent.
+  final double tailGap;
+
+  bool get showsMessage => this != short;
+
+  /// The field height this composition needs, rail included.
+  double fieldFor(BuildContext context, BoxConstraints panel) =>
+      chrome +
+      DestinationSuggestionCard.heightFor(
+          _railCardWidthFor(panel.maxWidth), MediaQuery.textScalerOf(context));
+
+  /// The tallest composition the field can hold. Below [short] nothing fits —
+  /// an open keyboard, the largest accessibility text — and [ChatPanel] keeps
+  /// the composer on the floor and scrolls the block instead.
+  static _IntroTier forField(BuildContext context, BoxConstraints panel) {
+    for (final tier in values) {
+      if (panel.maxHeight >= tier.fieldFor(context, panel)) return tier;
+    }
+    return short;
+  }
+}
 
 /// The Plan tab before a word is typed.
 ///
@@ -154,7 +287,25 @@ const double _kIntroMeasure = 420;
 /// centered — and this is a designed opening, with a rail that has to run to
 /// the column's edges and a block that has to sit off-centre.
 class _PlanIntro extends ConsumerWidget {
-  const _PlanIntro();
+  /// Which composition this field can hold. Chosen by [ChatPanel], which is
+  /// the only widget that knows the panel's real constraints — inside the
+  /// joined branch this block sits in a scroll view, where its own
+  /// `maxHeight` would be unbounded and every tier would look like [tall].
+  final _IntroTier tier;
+
+  /// The rail's card width, from the panel's WIDTH. A separate question from
+  /// [tier], which answers a question about height: a 1440x600 desktop is a
+  /// short field that still deserves the wide card.
+  final double railCardWidth;
+
+  /// Also from the panel's WIDTH — see [_shortChipLabelsFor].
+  final bool shortChipLabels;
+
+  const _PlanIntro({
+    required this.tier,
+    required this.railCardWidth,
+    required this.shortChipLabels,
+  });
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -174,16 +325,22 @@ class _PlanIntro extends ConsumerWidget {
             textAlign: TextAlign.center,
             style: theme.textTheme.headlineMedium,
           ),
-          const SizedBox(height: AppSpacing.md),
-          ConstrainedBox(
-            constraints: const BoxConstraints(maxWidth: _kIntroMeasure),
-            child: Text(
-              l10n.agentScreenEmptyMessage,
-              textAlign: TextAlign.center,
-              style: theme.textTheme.bodyLarge
-                  ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+          // The sentence is the first thing the field gives up, and the only
+          // thing: on a 375x667 phone in Safari there is no arrangement that
+          // keeps it AND the four ways in, and a way in outranks a
+          // description of one.
+          if (tier.showsMessage) ...[
+            const SizedBox(height: AppSpacing.md),
+            ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: _kIntroMeasure),
+              child: Text(
+                l10n.agentScreenEmptyMessage,
+                textAlign: TextAlign.center,
+                style: theme.textTheme.bodyLarge
+                    ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+              ),
             ),
-          ),
+          ],
         ],
       ),
     );
@@ -191,19 +348,26 @@ class _PlanIntro extends ConsumerWidget {
     final acting = Column(
       mainAxisSize: MainAxisSize.min,
       children: [
-        const _DestinationRail(),
-        const SizedBox(height: AppSpacing.lg),
+        _DestinationRail(cardWidth: railCardWidth),
+        SizedBox(height: tier.gapAboveChips),
         // The two ways in that aren't typing and aren't a destination. Both
         // are chips now: side by side they are the same kind of offer, and a
         // chip beside an outlined button read as two ranks of one thing.
         Padding(
           padding: const EdgeInsets.symmetric(horizontal: AppSpacing.lg),
-          child: Wrap(
-            spacing: AppSpacing.sm,
-            runSpacing: AppSpacing.sm,
-            alignment: WrapAlignment.center,
+          child: _ChipStrip(
+            // On a narrow panel this is a Row, not a Wrap, so ONE ROW is a
+            // structural fact rather than a hope about label lengths. The
+            // tier's chrome budget is measured against one row, and a Wrap
+            // silently spending a second one is not a wrapped chip — it is
+            // the composer pushed off the bottom of the screen, which is
+            // exactly what Spanish did. Short labels keep the ellipsis from
+            // ever being reached; the Row keeps a locale nobody measured
+            // from breaking the composition.
+            singleRow: shortChipLabels,
             children: [
               NearMeChip(
+                compact: shortChipLabels,
                 onSend: (text, {displayLabel}) => ref
                     .read(planProvider.notifier)
                     .sendMessage(text, displayLabel: displayLabel),
@@ -214,13 +378,17 @@ class _PlanIntro extends ConsumerWidget {
               // putting words in the chat.
               ActionChip(
                 avatar: const Icon(Icons.content_paste_go, size: 16),
-                label: Text(l10n.importFromAi),
+                label: Text(
+                  shortChipLabels ? l10n.importFromAiShort : l10n.importFromAi,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
                 onPressed: () => openImportOnTripsTab(ref),
               ),
             ],
           ),
         ),
-        const SizedBox(height: AppSpacing.lg),
+        SizedBox(height: tier.tailGap),
       ],
     );
 
@@ -236,9 +404,46 @@ class _PlanIntro extends ConsumerWidget {
         reading,
         // The block's own seam. A ladder value, not a share of the leftover:
         // it says how close these two halves are, which is a fixed
-        // relationship, not a function of the viewport.
-        const SizedBox(height: AppSpacing.xxl),
+        // relationship, not a function of the viewport — the tier picks WHICH
+        // rung, never a fraction between them.
+        SizedBox(height: tier.seam),
         acting,
+      ],
+    );
+  }
+}
+
+/// The opening's two chips, laid out so their row count is knowable.
+///
+/// [singleRow] false is the old [Wrap] — a wide panel has room for the full
+/// labels and can afford a second row if some locale ever needs one. True is a
+/// [Row] of [Flexible] chips: on a narrow panel the composition's whole height
+/// budget is measured against one row of chips, so a Wrap that quietly takes a
+/// second one costs 41px the field does not have.
+class _ChipStrip extends StatelessWidget {
+  final bool singleRow;
+  final List<Widget> children;
+
+  const _ChipStrip({required this.singleRow, required this.children});
+
+  @override
+  Widget build(BuildContext context) {
+    if (!singleRow) {
+      return Wrap(
+        spacing: AppSpacing.sm,
+        runSpacing: AppSpacing.sm,
+        alignment: WrapAlignment.center,
+        children: children,
+      );
+    }
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        for (final (i, child) in children.indexed) ...[
+          if (i > 0) const SizedBox(width: AppSpacing.sm),
+          Flexible(child: child),
+        ],
       ],
     );
   }
@@ -258,7 +463,10 @@ class _PlanIntro extends ConsumerWidget {
 /// traveler's own transcript, so an English message they never wrote would read
 /// as a bug. The agent answers in their language anyway (specs/i18n-spanish).
 class _DestinationRail extends ConsumerWidget {
-  const _DestinationRail();
+  /// Set by [_PlanIntro] from the panel's width — see [_railCardWidthFor].
+  final double cardWidth;
+
+  const _DestinationRail({required this.cardWidth});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -268,7 +476,7 @@ class _DestinationRail extends ConsumerWidget {
       picker: suggestionOrderProvider,
       builder: (context, prompts) => SizedBox(
         height: DestinationSuggestionCard.heightFor(
-            _kRailCardWidth, MediaQuery.textScalerOf(context)),
+            cardWidth, MediaQuery.textScalerOf(context)),
         child: ScrollConfiguration(
           // Without this a mouse cannot drag the rail on web/desktop — the
           // same reason the landing rail and the chat photo strips set it.
@@ -292,7 +500,7 @@ class _DestinationRail extends ConsumerWidget {
                   prompt: p.text,
                   asset: p.asset,
                   credit: p.credit,
-                  width: _kRailCardWidth,
+                  width: cardWidth,
                   onTap: () =>
                       ref.read(planProvider.notifier).sendMessage(p.text),
                 );

--- a/src/packages/flutter-app/lib/widgets/chat_panel.dart
+++ b/src/packages/flutter-app/lib/widgets/chat_panel.dart
@@ -29,21 +29,6 @@ import 'place_photo_card.dart';
 import 'source_links_card.dart';
 import 'result_summary_chip.dart';
 
-/// The panel height below which the Plan tab's empty state keeps the
-/// composer on the floor and scrolls the intro, instead of joining them
-/// into one [intro, gap, composer] group.
-///
-/// Height is what is asked because height is what runs out (the rule
-/// _PlanIntro's old field floor stated): a 568pt phone offers the panel
-/// ~510px once the app bar is gone, and an open keyboard takes most of any
-/// field — both must keep the composer at the floor, which is the layout
-/// the app has always had. The joined group measures ~471px at default
-/// text scale (browser-measured at 1440x900: intro 263→634, the 33px seam,
-/// composer 667→734), so 650 admits it with at least ~100px of air above
-/// and ~75 below — less, and the split reads as crowding rather than
-/// composition.
-const double _kComposerJoinFloor = 650;
-
 /// Where the Plan tab's joined [intro, gap, composer] group sits in its
 /// field, as an [Alignment] y. 1/7 splits the leftover air 4:3 above/below:
 /// at the 938px field this composition was measured against that is ~215
@@ -73,8 +58,28 @@ class ChatPanel extends ConsumerStatefulWidget {
   /// narrow for the full one. Null falls back to the generic short hint.
   final String? shortInputHint;
 
-  /// Shown instead of the message list while the conversation is empty.
-  final Widget? emptyState;
+  /// Builds what replaces the message list while the conversation is empty.
+  ///
+  /// A builder over the panel's own constraints, not a finished widget,
+  /// because the Plan tab's opening composes itself to the field it gets —
+  /// the destination rail narrows and the explanatory sentence drops on short
+  /// fields. The block cannot work that out for itself: in the joined branch
+  /// it sits inside a scroll view, where its own `maxHeight` is unbounded.
+  final Widget Function(BuildContext context, BoxConstraints panel)?
+      emptyStateBuilder;
+
+  /// The panel height at or above which the empty block and the composer are
+  /// placed as one [intro, gap, composer] group; below it the composer keeps
+  /// the floor and the block scrolls. Null — the refine dock, which has no
+  /// empty block — never joins.
+  ///
+  /// Supplied by whoever supplies [emptyStateBuilder], because only that
+  /// widget knows how tall it composes for a given field. This used to be a
+  /// constant here, measured once at 1440x900; every phone in mobile web then
+  /// fell under it and got the scrolling layout, which is what put three of
+  /// the Plan tab's four ways in below the fold.
+  final double Function(BuildContext context, BoxConstraints panel)?
+      emptyStateJoinFloor;
 
   /// Optional extra content rendered after the messages (e.g. the Agent tab's
   /// completed-itinerary banner).
@@ -103,7 +108,8 @@ class ChatPanel extends ConsumerStatefulWidget {
     required this.notifier,
     this.inputHint,
     this.shortInputHint,
-    this.emptyState,
+    this.emptyStateBuilder,
+    this.emptyStateJoinFloor,
     this.footerBuilder,
     this.onViewTrip,
     this.attachmentPipeline = const ImageAttachmentPipeline(),
@@ -440,22 +446,28 @@ class _ChatPanelState extends ConsumerState<ChatPanel> {
       );
 
       final Widget panel;
-      if (isEmpty && widget.emptyState != null) {
+      final emptyBlock = isEmpty
+          ? widget.emptyStateBuilder?.call(context, constraints)
+          : null;
+      if (emptyBlock != null) {
         // The Plan tab before a word is typed. The gate is HEIGHT — the
-        // thing that runs out — never width. Below the floor (a phone, an
-        // open keyboard) the composer keeps the floor and the intro
-        // scrolls, exactly as _PlanIntro's old field rule arranged. At or
-        // above it the composer joins the block as [intro, gap,
-        // composer], placed by _kComposerGroupBias. The scroll wrapper only
-        // ever runs when text scaling makes the group taller than the
-        // field.
-        panel = constraints.maxHeight < _kComposerJoinFloor
+        // thing that runs out — never width, and the height asked for is the
+        // one the block itself reports for this field, so a block that
+        // composes smaller is admitted rather than sent to the floor for
+        // failing a number measured on a desktop. Below it nothing fits (an
+        // open keyboard, the largest text scales): the composer keeps the
+        // floor and the block scrolls. At or above, the composer joins it as
+        // [intro, gap, composer], placed by _kComposerGroupBias.
+        final joinFloor =
+            widget.emptyStateJoinFloor?.call(context, constraints) ??
+                double.infinity;
+        panel = constraints.maxHeight < joinFloor
             ? Column(
                 children: [
                   Expanded(
                     child: SingleChildScrollView(
                       padding: const EdgeInsets.only(top: AppSpacing.xl),
-                      child: widget.emptyState!,
+                      child: emptyBlock,
                     ),
                   ),
                   composer,
@@ -470,7 +482,7 @@ class _ChatPanelState extends ConsumerState<ChatPanel> {
                   child: Column(
                     mainAxisSize: MainAxisSize.min,
                     children: [
-                      widget.emptyState!,
+                      emptyBlock,
                       const SizedBox(height: AppSpacing.lg),
                       composer,
                     ],

--- a/src/packages/flutter-app/lib/widgets/near_me_chip.dart
+++ b/src/packages/flutter-app/lib/widgets/near_me_chip.dart
@@ -27,12 +27,20 @@ class NearMeChip extends StatefulWidget {
   final Color? foregroundColor;
   final TextStyle? labelStyle;
 
+  /// Takes the chip's short spelling — the same idiom [ChatPanel] uses for its
+  /// composer hint. Set by hosts whose panel is too narrow for the full label
+  /// to share a row: "¿Qué hay cerca de mí?" is 210px, so the Plan tab's
+  /// opening wrapped to a second row of chips in Spanish and pushed its own
+  /// composer under the nav bar.
+  final bool compact;
+
   const NearMeChip({
     super.key,
     required this.onSend,
     this.backgroundColor,
     this.foregroundColor,
     this.labelStyle,
+    this.compact = false,
   });
 
   @override
@@ -82,7 +90,14 @@ class _NearMeChipState extends State<NearMeChip> {
               child: CircularProgressIndicator(strokeWidth: 2, color: color),
             )
           : Icon(Icons.my_location, size: 16, color: color),
-      label: Text(context.l10n.nearMeChipLabel, style: widget.labelStyle),
+      label: Text(
+        widget.compact
+            ? context.l10n.nearMeChipLabelShort
+            : context.l10n.nearMeChipLabel,
+        style: widget.labelStyle,
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+      ),
       backgroundColor: widget.backgroundColor,
       side: widget.backgroundColor != null ? BorderSide.none : null,
       onPressed: _locating ? null : _locate,

--- a/src/packages/flutter-app/test/chat_panel_empty_state_test.dart
+++ b/src/packages/flutter-app/test/chat_panel_empty_state_test.dart
@@ -34,6 +34,11 @@ Future<void> _pump(
   Size size, {
   PlanState? seeded,
   Widget? emptyState,
+
+  /// The field height the block claims to need. Passed explicitly so these
+  /// stay structure tests: the real screen derives this from measured text,
+  /// and text measured in this suite is fiction.
+  double? joinFloor,
 }) async {
   tester.view.physicalSize = size;
   tester.view.devicePixelRatio = 1.0;
@@ -49,7 +54,10 @@ Future<void> _pump(
           body: ChatPanel(
             state: provider,
             notifier: provider.notifier,
-            emptyState: emptyState,
+            emptyStateBuilder:
+                emptyState == null ? null : (context, panel) => emptyState,
+            emptyStateJoinFloor:
+                emptyState == null ? null : (context, panel) => joinFloor ?? 650,
           ),
         ),
       ),
@@ -80,6 +88,29 @@ void main() {
 
     expect(find.text('INTRO-BLOCK'), findsOneWidget);
     expect(find.byType(TextField), findsOneWidget);
+    expect(_joinAlign(), findsNothing);
+  });
+
+  testWidgets('a block that composes smaller is joined on that same field',
+      (tester) async {
+    // The mobile-web fix in one assertion: the field is the 500px that the
+    // test above sends to the floor, and the only thing that changed is the
+    // block reporting it needs 420. A single constant here could not tell
+    // those two cases apart, so every phone got the floor.
+    await _pump(tester, const Size(800, 500),
+        emptyState: const Text('INTRO-BLOCK'), joinFloor: 420);
+
+    expect(find.text('INTRO-BLOCK'), findsOneWidget);
+    expect(_joinAlign(), findsOneWidget);
+  });
+
+  testWidgets('a field below even the smallest composition keeps the floor',
+      (tester) async {
+    // An open keyboard, or the largest accessibility text scales.
+    await _pump(tester, const Size(800, 300),
+        emptyState: const Text('INTRO-BLOCK'), joinFloor: 420);
+
+    expect(find.text('INTRO-BLOCK'), findsOneWidget);
     expect(_joinAlign(), findsNothing);
   });
 


### PR DESCRIPTION
The Plan tab's empty state is the one screen whose whole job is offering a way to start, and in mobile web it was hiding three of the four.

## The measurement

Everything below was browser-measured on the running app over CDP at default text scale. This suite loads no fonts, so widget-test text metrics are fiction and nothing here was taken from one.

The block plus composer is **608px** at 390 wide. The panel a phone offers is the viewport less the 56px app bar and the 84px nav bar:

| Case | Viewport | Panel | Before |
|---|---|---|---|
| Installed / PWA | 390×844 | 704 | fit |
| **Safari, iPhone 14** | 390×664 | **524** | **both chips off-screen** |
| **Safari, iPhone SE** | 375×553 | **413** | **cards sliced through their labels** |

At 413 you could not read which destination you were being offered.

## Why one constant could not do it

`_kComposerJoinFloor = 650` was measured once at 1440×900. It was not a wrong number for the content it described — the content really is 608px — but one number cannot answer the question for a field it never saw, so every phone in mobile web fell under it and got the scrolling layout.

`ChatPanel` now asks the block how tall it composes for this field, via `emptyStateJoinFloor`, so the gate and the composition cannot disagree. Below even the smallest composition (an open keyboard, the largest text scales) the composer keeps the floor and the block scrolls, exactly as before.

## Three tiers

The order the composition gives things up is fixed: **air, then the rail's photo size, then prose. A way in is never what goes.**

| Tier | Field | Composition |
|---|---|---|
| `tall` | ≥ chrome 370 + rail | Everything, xxl seam |
| `medium` | ≥ chrome 354 + rail | Seams tighten a rung; sentence stays |
| `short` | ≥ chrome 270 + rail | Sentence drops; heading, all four ways in, composer stay |

The sentence goes only where no arrangement keeps it *and* the four ways in — and a first-timer who can act beats one who has read a description of acting.

## Width and height are different questions

They run out independently, so they are answered separately. The rail's card width and the chips' spelling are **width** questions; the tiers are a **height** question.

The rail at 260 showed **1.4 cards for 188px** of a phone's field — the most expensive block buying the least of what it exists to do. Below a derived 564 it takes 150 and shows **two whole cards and a sliver**, the count the rail was designed around. The photo's aspect is identical either way, so nothing crops differently; the fixed two-line text band just stops being mostly empty.

Keeping the axes apart is what lets a 1440×600 desktop stay a wide rail on a short field, and stops one phone showing a different chip row in Safari than installed.

## Spanish is why the chip strip is a Row

`"¿Qué hay cerca de mí?"` is 210px against the 170 English spends, so short labels alone still wrapped to a second row — and a wrapped chip here is not a wrapped chip, it is **the composer pushed under the nav bar**. One row is now structural (`_ChipStrip`), with short spellings keeping the ellipsis out of reach. A locale nobody measured can no longer break the composition.

New keys, both locales, `l10n_untranslated.json` = `{}`: `importFromAiShort`, `nearMeChipLabelShort`.

## Verified

Rendered in the running app at 390×844, 390×664, 375×553, 375×553 in Spanish, 1440×900 (desktop unchanged — wide rail, full labels), and 390×400 to prove the floor branch still catches a field too short for any tier. Re-verified after rebasing onto current `main`.

- `flutter analyze lib` — 3 info-level lints, all pre-existing in `models/route_response.dart`, none in this diff
- `flutter test` — **1888/1888**
- `gen-l10n` re-run post-rebase, no drift; translations complete

**One caveat, stated rather than smoothed over:** across three full-suite runs on the rebased tree, one run reported a single failure. My log filter dropped the failing test's name and I could not recover it; the two runs since are clean at 1888/1888 with zero `[E]` markers, including one under `--reporter=failures-only`. The neighbourhood of the failure was `budget_section_test.dart`, which this diff does not touch, and those files carry known `tap()` hit-test warnings — but I did not confirm the identity, so treat it as unverified flakiness rather than as cleared.

**brand-check:** 17 findings in `chat_panel.dart`, all pre-existing on `origin/main` (verified by running the check against the unmodified file) and none on a line this touches. `agent_screen.dart` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/golden-tempo/codesmith/anemos-travel/pr/544"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790013717&installation_model_id=433099&pr_number=544&repository=golden-tempo%2Fanemos-travel&return_to=https%3A%2F%2Fgithub.com%2Fgolden-tempo%2Fanemos-travel%2Fpull%2F544&signature=ac5bd7d8146a58ea0fedb7a287a6a0c03bb891ef5a080d8542779db07fc177f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->