### PR TITLE
fix(splash): the boot splash paints at its own size, not 40% of it

### DIFF
--- a/src/packages/flutter-app/web/index.html
+++ b/src/packages/flutter-app/web/index.html
@@ -29,6 +29,24 @@
 
   <meta charset="UTF-8">
   <meta content="IE=Edge" http-equiv="X-UA-Compatible">
+
+  <!-- The boot splash's scale depends on this tag existing BEFORE the engine
+       does. Flutter injects exactly this content itself once it boots, so the
+       app has always ended up correct — but the splash below paints for
+       seconds first, and without a viewport a phone lays the document out in a
+       980px virtual viewport and scales it to fit. On a 390px screen that is
+       0.4x: the 128px mark painted 45px and the wordmark was barely legible,
+       then snapped to full size mid-boot when the engine injected its own copy.
+       One splash, one geometry, two scales — the "small logo that grows" was
+       this and nothing else.
+
+       Content is Flutter's string verbatim, not a considered variant: matching
+       it is the point, because anything else reintroduces a reflow at the
+       handoff. If a future Flutter changes what it injects, change this with
+       it. (maximum-scale/user-scalable are Flutter's call, not a
+       pinch-zoom policy chosen here.) -->
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+
   <meta name="description" content="Plan trips and build day-by-day itineraries with an AI travel assistant.">
 
   <!-- SEO / social sharing (app landing; per-trip share links are prerendered


### PR DESCRIPTION
On a phone the splash comes up small, then jumps to full size partway through boot.

## It isn't two logos

`web/index.html` and `splash_screen.dart` are already pixel-matched on purpose — **128px** mark, `-28` mark offset, `+80` wordmark offset, 6px dots — and each carries a comment telling the next person to change them together. Neither had drifted.

The cause: **`index.html` had no viewport meta.** Flutter's engine injects one when it boots, which is why the *app* always ended up correct and why this never looked like a bug worth chasing. But the splash paints for seconds before the engine exists, and a phone handed a document with no viewport lays it out in a **980px virtual viewport** and scales it to fit. On a 390px screen that's **0.4×**.

Browser-measured over CDP on the running app:

| t | `innerWidth` | viewport meta | Mark paints at |
|---|---|---|---|
| 0.25–4s | **980** | absent | **~45px** |
| 8s | **390** | injected by the engine | **128px** |

One splash, one geometry, two scales. It's also why the wordmark underneath was hard to read.

## The fix

One tag, using **Flutter's own string verbatim**:

```html
<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
```

Matching exactly is the point — anything else reintroduces a reflow at the handoff, which is the thing being fixed. `maximum-scale`/`user-scalable` come along because they're what Flutter sets a moment later; this is not a pinch-zoom policy being chosen here, and iOS Safari ignores both regardless.

## Verified on the running app

At 390×844:

- `innerWidth` is **390 from the first frame**
- the mark measures **128.5px** against the specified 128
- the lockup sits on its stated geometry — mark centre **393.5** vs 394, wordmark centre **501** vs 502
- exactly **one** viewport meta throughout, so the engine replaces rather than duplicates
- the frame at **t=24s is pixel-identical to t=1.15s** apart from the dots' animation phase — the handoff no longer shows

Also checked at **375×667**, since every element is now 2.5× what it was: `scrollHeight == innerHeight`, nothing overflows. Desktop is untouched by construction — the 980 fallback only shrinks viewports narrower than 980, and the measurement confirms 1440 is unchanged.

CI's prod-parity web build passes, and the built `index.html` carries both the templated `<base href="/app/">` and the meta. Flutter suite **1894/1894**.

## One deliberate omission

**Not** bumping the service-worker manifest suffix. This will reach returning clients on the SW's normal update cycle; a splash scale fix is not worth spending the one-shot cache eviction that fires on every client. Flagging it so the delay is expected rather than discovered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/golden-tempo/codesmith/anemos-travel/pr/545"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790019970&installation_model_id=433099&pr_number=545&repository=golden-tempo%2Fanemos-travel&return_to=https%3A%2F%2Fgithub.com%2Fgolden-tempo%2Fanemos-travel%2Fpull%2F545&signature=29df40ab86d586ccc48b6c3fb3ecfb1bc30f53016f12b668ba0cd199c46afa63"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->