### PR TITLE
feat(home): "Your travels" gets the atlas door the trips list has

### DIFF
--- a/src/packages/flutter-app/lib/widgets/home_travels_band.dart
+++ b/src/packages/flutter-app/lib/widgets/home_travels_band.dart
@@ -2,11 +2,23 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../l10n/l10n.dart';
+import '../navigation/app_nav.dart';
+import '../navigation/app_routes.dart';
 import '../providers/trips_provider.dart';
+import '../screens/travel_atlas_screen.dart';
 import '../theme/spacing.dart';
 import '../utils/trip_list_insights.dart';
 import 'section_header.dart';
 import 'travel_footprint_card.dart';
+
+/// Home's way into the atlas.
+///
+/// Its own key rather than the Trips header's `kTravelAtlasSeeAllKey`, because
+/// both headers are alive at the same time — the shell keeps `TripsListScreen`
+/// mounted under Home, which is the same fact this band relies on for its data
+/// — so one key would match two widgets and every finder using it would go
+/// ambiguous the moment this shipped.
+const kHomeTravelAtlasSeeAllKey = ValueKey('travelAtlas.entry.home');
 
 /// "Your travels" on Home: the traveled/planned footprint the Trips tab
 /// already shows, so the page ends on where you have been rather than on
@@ -43,10 +55,45 @@ class HomeTravelsBand extends ConsumerWidget {
     final stats = travelStats(trips, now);
     final pins = footprintPins(trips, now);
 
+    // The Trips header's gate, borrowed whole, and deliberately NOT this
+    // band's own [_minTrips]: the two count different things. This band asks
+    // for 2+ OWNED trips, because below that an aggregate only restates the
+    // hero above it. The atlas asks for 2+ PAST trips, because below that
+    // there is nothing behind the door — no traveled pins, no Traveled
+    // colophon group, an index with no rows. A traveler with two trips still
+    // ahead of them gets the band and no door, which is correct: the map they
+    // are looking at is all of it.
+    final showAtlas = pastTrips(trips, now).length >= 2;
+
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
-        SectionHeader(title: context.l10n.tripsListYourTravels),
+        SectionHeader(
+          title: context.l10n.tripsListYourTravels,
+          // Pushed on Home's OWN stack, the way Home's other "See all" (local
+          // guides) already goes to its screen — so back returns here rather
+          // than stranding the traveler on the Trips list they never asked
+          // for. `openAtlasOnTripsTab` is the Trips-tab caller's helper and
+          // exists to keep that tab's back button honest; from Home the same
+          // concern points the other way.
+          //
+          // Only "See all" comes across. "+ Add past trip" stays in the Trips
+          // header by a recorded decision (specs/log-past-trip) that a copy
+          // here would quietly re-open.
+          action: showAtlas
+              ? TextButton(
+                  key: kHomeTravelAtlasSeeAllKey,
+                  onPressed: () => pushOnce(
+                    context,
+                    locatedRoute(const TravelAtlasScreen(),
+                        utilityLocation(BootUtility.travelAtlas)),
+                  ),
+                  // The Trips entry's string, not `commonSeeAll`: one action,
+                  // one label, so a future rewording moves both doors at once.
+                  child: Text(context.l10n.travelAtlasSeeAll),
+                )
+              : null,
+        ),
         const SizedBox(height: AppSpacing.md),
         TravelFootprintCard(
           pins: pins,

--- a/src/packages/flutter-app/test/home_travels_band_test.dart
+++ b/src/packages/flutter-app/test/home_travels_band_test.dart
@@ -1,0 +1,133 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:travel_route_planner/models/trip.dart';
+import 'package:travel_route_planner/providers/trip_cache_provider.dart';
+import 'package:travel_route_planner/providers/trips_provider.dart';
+import 'package:travel_route_planner/services/api_client.dart';
+import 'package:travel_route_planner/services/trip_cache.dart';
+import 'package:travel_route_planner/services/trips_api_service.dart';
+import 'package:travel_route_planner/widgets/home_travels_band.dart';
+import 'package:travel_route_planner/widgets/travel_footprint_card.dart';
+
+import 'support/l10n_test_app.dart';
+
+/// Home's "Your travels" band, and the atlas door in its header.
+///
+/// The band and the door ask DIFFERENT questions, and that is what this pins.
+/// The band wants 2+ OWNED trips, because below that an aggregate only
+/// restates the hero above it. The door wants 2+ FINISHED trips, because below
+/// that the atlas has no traveled pins, no Traveled colophon group (it does not
+/// render at zero) and an index with no rows — a door onto nothing. A traveler
+/// with two trips still ahead of them therefore gets the band and no door, and
+/// these tests exist so that pair cannot quietly collapse into one number.
+///
+/// Deliberately the same three cases the trips-list header is held to in
+/// trips_list_footprint_test, including the under-way trip: two doors onto one
+/// screen that disagreed about when to appear would be worse than either rule.
+/// The other end of the door — that it opens the atlas and comes BACK to Home
+/// rather than to the Trips list — is asserted in travel_atlas_screen_test,
+/// beside the trips-list door's own, because it needs the real shell.
+///
+/// Dates are relative to DateTime.now() so the past/ahead split stays
+/// deterministic.
+class _FixedTripsApiService extends TripsApiService {
+  final List<Trip> trips;
+
+  _FixedTripsApiService(this.trips) : super(ApiClient(baseUrl: 'http://test'));
+
+  @override
+  Future<List<Trip>> listTrips() async => trips;
+}
+
+String _iso(DateTime d) => '${d.year.toString().padLeft(4, '0')}-'
+    '${d.month.toString().padLeft(2, '0')}-'
+    '${d.day.toString().padLeft(2, '0')}';
+
+String _rel(int days) => _iso(DateTime.now().add(Duration(days: days)));
+
+Trip _trip(String id, String title, {String? start, String? end}) => Trip(
+      id: id,
+      title: title,
+      startDate: start,
+      endDate: end,
+      createdAt: '2026-06-01',
+      updatedAt: '2026-06-01',
+    );
+
+Future<void> _pumpBand(WidgetTester tester,
+    {List<Trip> trips = const []}) async {
+  SharedPreferences.setMockInitialValues({});
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        tripsApiServiceProvider.overrideWithValue(_FixedTripsApiService(trips)),
+        tripCacheProvider.overrideWithValue(TripCache('u1')),
+      ],
+      child: MaterialApp(
+        localizationsDelegates: testLocalizationsDelegates,
+        home: const Scaffold(body: HomeTravelsBand()),
+      ),
+    ),
+  );
+
+  // The band is a READER, never a fetcher — its dartdoc's whole point is that
+  // the shell's mounted TripsListScreen already feeds tripsProvider, so Home
+  // costs no request of its own. Nothing in this tree plays that part, so the
+  // load is triggered here rather than papered over by overriding
+  // tripsProvider itself, which would also stub out the notifier this band is
+  // meant to be reading through.
+  final container =
+      ProviderScope.containerOf(tester.element(find.byType(HomeTravelsBand)));
+  await container.read(tripsProvider.notifier).loadTrips();
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  testWidgets('no band at all below two owned trips', (tester) async {
+    await _pumpBand(tester, trips: [
+      _trip('past', 'Iberia Loop', start: _rel(-30), end: _rel(-26)),
+    ]);
+
+    expect(find.byType(TravelFootprintCard), findsNothing);
+    expect(find.byKey(kHomeTravelAtlasSeeAllKey), findsNothing);
+  });
+
+  group('the atlas door', () {
+    testWidgets('absent with one finished trip', (tester) async {
+      await _pumpBand(tester, trips: [
+        _trip('past', 'Iberia Loop', start: _rel(-30), end: _rel(-26)),
+        _trip('next', 'Madrid Trip', start: _rel(10), end: _rel(12)),
+      ]);
+
+      expect(find.byKey(kHomeTravelAtlasSeeAllKey), findsNothing);
+      // The band itself is present — the two gates ask different questions.
+      expect(find.byType(TravelFootprintCard), findsOneWidget);
+    });
+
+    testWidgets('present at two finished trips', (tester) async {
+      await _pumpBand(tester, trips: [
+        _trip('past', 'Iberia Loop', start: _rel(-30), end: _rel(-26)),
+        _trip('older', 'Athens Trip', start: _rel(-90), end: _rel(-85)),
+      ]);
+
+      expect(find.byKey(kHomeTravelAtlasSeeAllKey), findsOneWidget);
+    });
+
+    testWidgets('absent when the second started trip is still under way',
+        (tester) async {
+      // travelStats reports two traveled trips here. One of them is happening
+      // right now, and a retrospective is not where it belongs — the same
+      // category error the trips list already refuses for "Past trips".
+      await _pumpBand(tester, trips: [
+        _trip('past', 'Iberia Loop', start: _rel(-30), end: _rel(-26)),
+        _trip('live', 'Athens Now', start: _rel(-2), end: _rel(5)),
+      ]);
+
+      expect(find.byKey(kHomeTravelAtlasSeeAllKey), findsNothing);
+      expect(find.byType(TravelFootprintCard), findsOneWidget);
+    });
+  });
+}

--- a/src/packages/flutter-app/test/travel_atlas_screen_test.dart
+++ b/src/packages/flutter-app/test/travel_atlas_screen_test.dart
@@ -17,11 +17,13 @@ import 'package:travel_route_planner/providers/resumable_chats_provider.dart';
 import 'package:travel_route_planner/providers/shared_with_me_provider.dart';
 import 'package:travel_route_planner/providers/trip_cache_provider.dart';
 import 'package:travel_route_planner/providers/trips_provider.dart';
+import 'package:travel_route_planner/screens/home_screen.dart';
 import 'package:travel_route_planner/screens/travel_atlas_screen.dart';
 import 'package:travel_route_planner/screens/trips_list_screen.dart';
 import 'package:travel_route_planner/services/api_client.dart';
 import 'package:travel_route_planner/services/trip_cache.dart';
 import 'package:travel_route_planner/services/trips_api_service.dart';
+import 'package:travel_route_planner/widgets/home_travels_band.dart';
 import 'package:travel_route_planner/widgets/section_header.dart';
 import 'package:travel_route_planner/widgets/travel_footprint_parts.dart';
 
@@ -577,6 +579,50 @@ void main() {
     expect(find.byType(TravelAtlasScreen), findsNothing);
     expect(find.byType(TripsListScreen), findsOneWidget);
     expect(reports.last, kTripsLocation);
+  });
+
+  testWidgets('the home door opens the atlas and back returns to HOME',
+      (tester) async {
+    // The second door onto this screen, and the reason it is worth its own
+    // test rather than trusting the twin above: it does NOT go through
+    // openAtlasOnTripsTab. Home pushes the atlas on its own stack, the way
+    // Home's other "See all" already reaches the guides, so the back button
+    // owes the traveler the page they left. Sending them to the Trips list
+    // instead is the exact stranding the tab-push helper exists to prevent —
+    // from Home the same concern simply points the other way.
+    tester.binding.platformDispatcher.defaultRouteNameTestValue = kHomeLocation;
+    addTearDown(
+        tester.binding.platformDispatcher.clearDefaultRouteNameTestValue);
+    final reports = <String>[];
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          authProvider.overrideWith((ref) => FakeAuthNotifier(fakeUser())),
+          tripsApiServiceProvider
+              .overrideWithValue(_FixedTripsApiService(_history())),
+          liveTripProvider.overrideWithValue(null),
+          resumableChatsProvider.overrideWith((ref) async => const []),
+          urlReporterProvider.overrideWithValue(reports.add),
+        ],
+        child: const TravelRoutePlannerApp(),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.scrollUntilVisible(find.byKey(kHomeTravelAtlasSeeAllKey), 300,
+        scrollable: find.byType(Scrollable).first);
+    await tester.tap(find.byKey(kHomeTravelAtlasSeeAllKey));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(TravelAtlasScreen), findsOneWidget);
+    expect(reports.last, '/atlas');
+
+    // Home, not the trips list — and the Trips tab was never switched to.
+    await tester.pageBack();
+    await tester.pumpAndSettle();
+    expect(find.byType(TravelAtlasScreen), findsNothing);
+    expect(find.byType(HomeScreen), findsOneWidget);
+    expect(reports.last, kHomeLocation);
   });
 
   testWidgets('the app bar says what the section that opened it says',


### PR DESCRIPTION
The same band renders in two places and only one of them offered a way in. On the trips list its header carries "See all"; on Home it carried the title alone — so the atlas was reachable from exactly one of the two screens showing the map that leads to it.

## The gate is the door's, not the band's

These are deliberately different numbers:

| | Opens at | Because |
|---|---|---|
| The band | 2+ **owned** trips | below that an aggregate only restates the hero above it |
| The door | 2+ **finished** trips | below that the atlas has no traveled pins, no Traveled colophon group (it doesn't render at zero), an index with no rows |

Gating the button on the band's own count would have handed a traveler with two trips *still ahead of them* a door onto an empty room. It reuses `pastTrips(trips, now)` — the same call `trips_list_screen` makes — so the two doors can't drift apart. A trip **currently under way** doesn't count either, which is the rule the trips list already applies and which is now pinned on both screens.

## Back returns to Home

`openAtlasOnTripsTab` exists and was deliberately not used: it switches to the Trips tab, so from Home the back button would strand the traveler on a list they never asked for.

Home's other "See all" — local guides — already pushes onto Home's own stack via `pushOnce`/`locatedRoute`, and this follows it. The tab-push helper exists to keep the Trips tab's back button honest; from Home the identical concern points the other way.

## What deliberately did not come across

**"+ Add past trip" stays where it is.** The trips header says in as many words that `specs/log-past-trip` placed it there deliberately and that relocating it re-opens that decision. A copy on Home would be a product call smuggled in as a consistency fix — that's the maintainer's to make, not this PR's.

The action also gets **its own key** (`kHomeTravelAtlasSeeAllKey`) rather than sharing the trips list's: both headers are alive at once, because the shell keeps `TripsListScreen` mounted — the same fact this band relies on for its data — so one key would match two widgets and make every finder using it ambiguous.

## Verified

Driven over CDP against a seeded account (two finished trips, one ahead) on the running app: the header renders **"Your travels — See all"** on Home, and tapping it lands on **`/atlas`**.

- **5 new tests**, suite **1899/1899**
- `home_travels_band_test.dart` (new) mirrors the three cases the trips header is held to — including the under-way trip — plus the band's own gate
- One test beside the trips-list door's asserts this one opens the atlas and comes back to **`HomeScreen` at `/`**, not to the trips list
- `flutter analyze` clean; **brand-check clean**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/golden-tempo/codesmith/anemos-travel/pr/546"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790019991&installation_model_id=433099&pr_number=546&repository=golden-tempo%2Fanemos-travel&return_to=https%3A%2F%2Fgithub.com%2Fgolden-tempo%2Fanemos-travel%2Fpull%2F546&signature=22d73aac892d7d127d74be904e996ba0133740fc6583e162ce6289845ee3680c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->