### PR TITLE
feat(notifications): swipe a row away on the page

### DIFF
--- a/specs/clear-notifications/spec.md
+++ b/specs/clear-notifications/spec.md
@@ -21,6 +21,13 @@ including unread ones the traveler had not acted on yet. Wholesale deletion is
 the wrong price for tidying, so each row now carries its own ✕. Clear-all keeps
 its confirmation dialog and stays the way to empty the feed.
 
+**Amended again, same day — swipe-to-dismiss is in scope on the full page.**
+The ✕ was argued to be enough for both presentations. On the page — the touch
+one — it isn't: swiping a row away is the gesture people already reach for in a
+list of dismissible things, and withholding it makes the ✕ feel like the long
+way round. The popover keeps the ✕ alone; a drag inside a menu overlay fights
+the overlay.
+
 ## User Stories
 
 - As a **signed-in user**, I want to **clear all my notifications at once** so
@@ -70,6 +77,18 @@ Per-notification dismissal (amended):
       and the user sees why — never a row that looks dismissed but was not.
 - [ ] Dismissing the last row leaves the feed in its empty state, with the
       clear-all action gone.
+
+Swipe-to-dismiss (amended):
+
+- [ ] On the full page, a row can be swiped away toward the start edge, and
+      the same row still offers its ✕.
+- [ ] Swiping the other way does nothing — that stroke belongs to the
+      platform's back gesture and must never delete anything.
+- [ ] The row leaves as the gesture finishes rather than waiting on the
+      server, since the swipe has already moved it off screen.
+- [ ] A swipe the server refuses puts the row **back** with the same message a
+      failed ✕ gives, and the restored row can be swiped again.
+- [ ] The popover feed cannot be swiped.
 
 ## API Surface
 
@@ -124,6 +143,12 @@ six more weeks; anything you haven't seen stays until you see it or clear it."
   on the narrow page where hover does not exist. Tapping it removes that row
   with no dialog; the control shows progress while the server is asked, and on
   failure the row stays put under a snackbar saying why.
+- **Swiping one away (amended):** on the page, a row can also be swiped toward
+  the start edge, revealing a quiet destructive field with a delete icon. The
+  two affordances differ in one respect, and only because the gesture demands
+  it: the ✕ waits for the server and shows progress, while the swipe removes
+  the row immediately — it has already been dragged off screen — and restores
+  it if the server refuses.
 
 ## Edge Cases & Error States
 
@@ -144,8 +169,9 @@ six more weeks; anything you haven't seen stays until you see it or clear it."
 
 ## Out of Scope
 
-- Swipe-to-dismiss. The ✕ serves both presentations; swipe would be a second
-  idiom for the same act and only on one of them.
+- Swipe on the popover. A drag gesture inside a menu overlay fights the
+  overlay, and the popover is the pointer presentation, where the ✕ is the
+  natural target.
 - Undo, after clearing or after dismissing one.
 - Soft delete / archive / trash.
 - Muting, deduplicating, or rate-limiting the ops-alert stream itself.
@@ -154,5 +180,6 @@ six more weeks; anything you haven't seen stays until you see it or clear it."
 ## Open Questions
 
 None. Original scope (clear-all only + 45-day read-row retention, hard delete)
-was decided with the product owner on 2026-08-13; per-notification dismissal
-was added at their request on 2026-08-22, superseding that one exclusion.
+was decided with the product owner on 2026-08-13. Per-notification dismissal
+was added at their request on 2026-08-22, and swipe-to-dismiss on the page the
+same day — each superseding an exclusion recorded earlier in this document.

--- a/src/packages/flutter-app/lib/screens/notification_center_screen.dart
+++ b/src/packages/flutter-app/lib/screens/notification_center_screen.dart
@@ -169,11 +169,68 @@ class NotificationCenterScreen extends ConsumerStatefulWidget {
 
 class _NotificationCenterScreenState
     extends ConsumerState<NotificationCenterScreen> {
+  /// Rows swiped away that the fetched feed still contains.
+  ///
+  /// [Dismissible] requires its child to be gone from the tree by the build
+  /// after it reports a dismissal — leave it there and the framework asserts.
+  /// But the feed is a [FutureProvider] whose contents only change when the
+  /// refetch lands, so something has to bridge those two facts. This set is
+  /// that bridge: the row leaves on the swipe and comes **back** if the server
+  /// refuses.
+  ///
+  /// Ids are not pruned once the refetch confirms them — the entry is
+  /// harmless after that (the row is genuinely gone) and the set dies with the
+  /// screen.
+  final Set<String> _swiped = {};
+
+  /// How many times each row has been restored after a failed swipe.
+  ///
+  /// A [Dismissible] that has reported a dismissal stays dismissed for the
+  /// life of its [State], so putting the row back under the SAME key rebuilds
+  /// that same state and trips *"a dismissed Dismissible widget is still part
+  /// of the tree"*. Bumping the generation gives the restored row a new key,
+  /// and with it a fresh state that has never been dismissed.
+  ///
+  /// Per id rather than one global counter, so one row's failure doesn't
+  /// discard every other row's Dismissible state.
+  final Map<String, int> _swipeGeneration = {};
+
   @override
   void initState() {
     super.initState();
     WidgetsBinding.instance.addPostFrameCallback(
         (_) => markNotificationsSeen(ref, alive: () => mounted));
+  }
+
+  /// Swipe's delete: optimistic, unlike the ✕'s spinner-then-refetch.
+  ///
+  /// The gesture has already moved the row off screen by the time this runs,
+  /// so there is no honest way to show it "pending" — the alternative,
+  /// `confirmDismiss`, parks the row mid-swipe under the user's thumb for the
+  /// length of a network round trip. Removing first and restoring on failure
+  /// is the pattern that matches what the gesture already promised.
+  ///
+  /// The failure path is what keeps it honest: the row comes back and the
+  /// snackbar says why, because a swipe that silently failed would leave the
+  /// traveler certain a notification was gone while the server still has it.
+  Future<void> _swipeAway(AppNotification n) async {
+    setState(() => _swiped.add(n.id));
+    final l10n = context.l10n;
+    try {
+      await ref.read(notificationsApiServiceProvider).delete(n.id);
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _swiped.remove(n.id);
+        // New key for the restored row — see [_swipeGeneration].
+        _swipeGeneration.update(n.id, (v) => v + 1, ifAbsent: () => 1);
+      });
+      showSnack(context, l10n.notifDismissFailed(friendlyError(l10n, e)));
+      return;
+    }
+    if (!mounted) return;
+    ref.invalidate(notificationsProvider);
+    ref.invalidate(notificationsUnreadCountProvider);
   }
 
   void _openSettings() {
@@ -214,7 +271,15 @@ class _NotificationCenterScreenState
             ],
           ),
         ),
-        data: (list) {
+        data: (fetched) {
+          // Swiped rows are subtracted before anything else reads the feed, so
+          // "is the feed empty" and "should the clear-all footer show" both
+          // answer about what is on screen rather than what the last refetch
+          // happened to return.
+          final list = [
+            for (final n in fetched)
+              if (!_swiped.contains(n.id)) n
+          ];
           if (list.isEmpty) {
             return PageContainer(
               child: EmptyState(
@@ -252,7 +317,13 @@ class _NotificationCenterScreenState
                       mainAxisSize: MainAxisSize.min,
                       crossAxisAlignment: CrossAxisAlignment.stretch,
                       children: [
-                        ..._feedChildren(context, list),
+                        // Swipe is the page's alone: it is the touch
+                        // presentation, and a drag gesture inside the
+                        // popover would fight the menu overlay it sits in.
+                        ..._feedChildren(context, list,
+                            onSwipeDismiss: _swipeAway,
+                            swipeGeneration: (id) =>
+                                _swipeGeneration[id] ?? 0),
                         const _ClearAllFooter(),
                       ],
                     ),
@@ -362,15 +433,34 @@ List<Widget> _feedChildren(
   BuildContext context,
   List<AppNotification> list, {
   VoidCallback? onBeforeNavigate,
+
+  /// Non-null on the page, which wraps each row in a [Dismissible]. Null in
+  /// the popover, where the rows are identical but un-swipeable.
+  Future<void> Function(AppNotification)? onSwipeDismiss,
+
+  /// Supplied with [onSwipeDismiss] — how many times this row has been
+  /// restored after a failed swipe, which its Dismissible key needs.
+  int Function(String id)? swipeGeneration,
 }) {
   final l10n = context.l10n;
   List<Widget> rows(List<AppNotification> section) => [
         for (var i = 0; i < section.length; i++) ...[
           if (i > 0) const Divider(height: 1),
-          _NotificationRow(
-            notification: section[i],
-            onBeforeNavigate: onBeforeNavigate,
-          ),
+          if (onSwipeDismiss == null)
+            _NotificationRow(
+              notification: section[i],
+              onBeforeNavigate: onBeforeNavigate,
+            )
+          else
+            _SwipeToDismiss(
+              notification: section[i],
+              generation: swipeGeneration?.call(section[i].id) ?? 0,
+              onDismissed: onSwipeDismiss,
+              child: _NotificationRow(
+                notification: section[i],
+                onBeforeNavigate: onBeforeNavigate,
+              ),
+            ),
         ],
       ];
 
@@ -393,6 +483,93 @@ List<Widget> _feedChildren(
       ...rows(earlier),
     ],
   ];
+}
+
+/// The swipe field: the row's own card surface pulled toward the **saturated**
+/// member of the error pair, rather than replaced by a red panel.
+///
+/// Which role carries the chroma swaps between brightnesses, and getting that
+/// backwards is silent: in light it is `error` (a dark red) with
+/// `errorContainer` as the pale tint, and in **dark those trade places** —
+/// `error` is the pale one. Blending the pale role over the Aegean night
+/// canvas lightens it toward slate, producing a field that reads *disabled*
+/// rather than *destructive*. Verified by rendering both, not by reading the
+/// role names.
+///
+/// The two alphas differ for the same reason: a light card needs only a touch
+/// of a dark red to go rose, while a near-black canvas needs most of one
+/// before it reads as red at all.
+///
+/// Tinting rather than substituting keeps the field in the surface family — it
+/// reads as this row going wrong, not as a foreign panel — and leaves the
+/// destructive meaning to be carried at full strength by the icon, which is
+/// small enough to afford it. That is the status vocabulary's own rule: the
+/// glyph takes the severity colour.
+Color _swipeFieldColor(ThemeData theme) {
+  final scheme = theme.colorScheme;
+  final isDark = theme.brightness == Brightness.dark;
+  return Color.alphaBlend(
+    (isDark ? scheme.errorContainer : scheme.error)
+        .withValues(alpha: isDark ? 0.62 : 0.22),
+    theme.cardTheme.color ?? scheme.surface,
+  );
+}
+
+/// Swipe-away wrapper for one feed row, on the page only.
+///
+/// **One direction, not `horizontal`.** A delete on the start→end stroke would
+/// share a gesture with iOS's edge-back swipe, so backing out of this screen
+/// would sometimes eat a notification instead. End→start is also the platform
+/// convention for destroy-in-a-list, so the affordance needs no teaching.
+///
+/// No confirmation, matching the ✕ it duplicates: the two are the same act
+/// reached two ways, and gating one but not the other would make the gesture
+/// feel like the more dangerous of them when it is not.
+class _SwipeToDismiss extends StatelessWidget {
+  final AppNotification notification;
+
+  /// Restore count for this row — part of the key, so a row brought back
+  /// after a failed swipe gets a Dismissible that has never been dismissed.
+  final int generation;
+
+  final Future<void> Function(AppNotification) onDismissed;
+  final Widget child;
+
+  const _SwipeToDismiss({
+    required this.notification,
+    required this.generation,
+    required this.onDismissed,
+    required this.child,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    return Dismissible(
+      // The notification's own id, not its position: rows are re-created on
+      // every refetch, so a positional key would let a dismissal land on
+      // whichever row inherited the index. The generation suffix is what makes
+      // a restored row usable again.
+      key: ValueKey('notif-dismiss-${notification.id}-$generation'),
+      direction: DismissDirection.endToStart,
+      // A tinted field, not a red slab — see [_swipeFieldColor]. A
+      // full-strength destructive panel sliding out from under every swipe is
+      // the loudest thing in an app whose register is engraved-not-shouted,
+      // and it would be shouting at a gesture the traveler chose on purpose.
+      background: ColoredBox(
+        color: _swipeFieldColor(Theme.of(context)),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: AppSpacing.lg),
+          child: Align(
+            alignment: AlignmentDirectional.centerEnd,
+            child: Icon(Icons.delete_outline, size: 20, color: scheme.error),
+          ),
+        ),
+      ),
+      onDismissed: (_) => onDismissed(notification),
+      child: child,
+    );
+  }
 }
 
 /// Sentence-case Inter section label — row-header register (weight, not size,

--- a/src/packages/flutter-app/test/notification_center_test.dart
+++ b/src/packages/flutter-app/test/notification_center_test.dart
@@ -552,6 +552,105 @@ void main() {
 
   });
 
+  // Swipe-to-dismiss, on the page only. Same act as the ✕ reached a second
+  // way, so the interesting cases are the ones the gesture makes different:
+  // the row is off screen before the server has answered.
+  group('swipe to dismiss', () {
+    /// Drags [text]'s row from its end edge toward the start — the delete
+    /// direction — far enough to pass the dismiss threshold.
+    Future<void> swipeAway(WidgetTester tester, String text) async {
+      await tester.drag(find.text(text), const Offset(-600, 0));
+      await tester.pumpAndSettle();
+    }
+
+    testWidgets('swiping deletes that row and leaves the rest', (tester) async {
+      final service = await _pump(
+          tester, [_priceDrop(id: 'a'), _ops(id: 'b')]);
+
+      await swipeAway(tester, 'System degraded');
+
+      expect(service.deletedIds, ['b']);
+      expect(find.text('System degraded'), findsNothing);
+      expect(find.text('BOS → CDG'), findsOneWidget);
+    });
+
+    testWidgets('the row is gone before the server answers', (tester) async {
+      // The gesture already moved it off screen; parking it mid-swipe for a
+      // network round trip would contradict what the swipe promised.
+      final service = await _pump(tester, [_priceDrop(id: 'a')]);
+
+      await swipeAway(tester, 'BOS → CDG');
+
+      expect(service.deletedIds, ['a']);
+      expect(find.text('No notifications yet'), findsOneWidget);
+    });
+
+    testWidgets('a failed swipe brings the row BACK and says why',
+        (tester) async {
+      final service = await _pump(
+          tester, [_priceDrop(id: 'a'), _ops(id: 'b')]);
+      service.deleteError = Exception('nope');
+
+      await swipeAway(tester, 'BOS → CDG');
+
+      // The whole risk of removing optimistically: a swipe that silently
+      // failed would leave the traveler certain it was gone.
+      expect(service.deletedIds, isEmpty);
+      expect(find.text('BOS → CDG'), findsOneWidget);
+      expect(find.text('System degraded'), findsOneWidget);
+      expect(find.textContaining('Could not dismiss'), findsOneWidget);
+    });
+
+    testWidgets('a restored row can be swiped again', (tester) async {
+      // The real proof the restore works. A Dismissible stays dismissed for
+      // the life of its State, so bringing the row back under the same key
+      // gives it a state that refuses to swipe (and asserts on the way).
+      final service = await _pump(tester, [_priceDrop(id: 'a')]);
+      service.deleteError = Exception('nope');
+      await swipeAway(tester, 'BOS → CDG');
+      expect(find.text('BOS → CDG'), findsOneWidget);
+
+      service.deleteError = null;
+      await swipeAway(tester, 'BOS → CDG');
+
+      expect(tester.takeException(), isNull);
+      expect(service.deletedIds, ['a']);
+      expect(find.text('No notifications yet'), findsOneWidget);
+    });
+
+    testWidgets('swiping the last row lands on the empty state',
+        (tester) async {
+      await _pump(tester, [_priceDrop(id: 'a')]);
+
+      await swipeAway(tester, 'BOS → CDG');
+
+      expect(find.text('No notifications yet'), findsOneWidget);
+      expect(find.text('Clear all'), findsNothing);
+    });
+
+    testWidgets('swiping the other way does nothing — that stroke is back',
+        (tester) async {
+      final service = await _pump(tester, [_priceDrop(id: 'a')]);
+
+      await tester.drag(find.text('BOS → CDG'), const Offset(600, 0));
+      await tester.pumpAndSettle();
+
+      // startToEnd is iOS's edge-back gesture; a delete there would sometimes
+      // eat a notification on the way out of the screen.
+      expect(service.deletedIds, isEmpty);
+      expect(find.text('BOS → CDG'), findsOneWidget);
+    });
+
+    testWidgets('the ✕ still works on the page alongside it', (tester) async {
+      final service = await _pump(tester, [_priceDrop(id: 'a')]);
+
+      await tester.tap(find.byTooltip('Dismiss'));
+      await tester.pumpAndSettle();
+
+      expect(service.deletedIds, ['a']);
+    });
+  });
+
   group('clear all', () {
     testWidgets('clear-all footer hidden on an empty feed, shown with rows',
         (tester) async {


### PR DESCRIPTION
The ✕ shipped one PR ago (#542) on the argument that it served both presentations. On the page — the touch one — it doesn't: swiping a row away is the gesture people already reach for in a list of dismissible things, and withholding it makes the ✕ the long way round.

**This reverses an exclusion recorded in `specs/clear-notifications` one PR earlier**, by me. The spec is amended with the reasoning rather than quietly edited, so the reversal is visible in the diff.

## Scope

Page only. `_feedChildren` takes an `onSwipeDismiss` callback that is null in the popover, where a drag gesture would fight the menu overlay it sits inside — and where the pointer already has a perfectly good ✕.

**End-to-start only, never `horizontal`.** The other stroke is the platform's edge-back gesture; a delete there would sometimes eat a notification on your way out of the screen. Pinned by a test.

## The one deliberate inconsistency

`Dismissible` requires its child gone from the tree by the build after it reports a dismissal, but the feed is a `FutureProvider` that only changes when the refetch lands. The page holds a `_swiped` set to bridge the two.

That makes swipe **optimistic** where the ✕ is server-confirmed. The difference belongs to the gesture, not to a preference: the row has already been dragged off screen, so there is no honest way to show it pending. The alternative — `confirmDismiss` — parks the row half-swiped under the user's thumb for the length of a network round trip. Both paths fail identically: row back, same snackbar.

## The bug worth reading the diff for

A `Dismissible` that has reported a dismissal **stays dismissed for the life of its `State`**. So restoring a row after a failed swipe under the same key rebuilt that same state and threw:

```
A dismissed Dismissible widget is still part of the tree.
```

My "a failed swipe brings the row BACK" test caught it on its first run. The key now carries a per-id restore count, so a restored row gets a state that has never been dismissed — per id rather than one global counter, so one row's failure doesn't discard every other row's Dismissible state.

There is a second test that swipes the **restored** row again, because *"it reappeared"* and *"it works"* are different claims and only the second one matters.

## The colour, and a trap in it

The field is the row's own card colour **pulled toward** the error hue, not replaced by a red panel. A full-strength destructive slab sliding out from under every swipe is the loudest thing in an app whose register is engraved-not-shouted, and it would be shouting at a gesture the traveler chose on purpose. The icon carries the destructive meaning at full strength instead — the status vocabulary's own rule, where only the glyph takes the severity colour.

**Which error role carries the chroma swaps between brightnesses, and getting it backwards fails silently.** In light, `error` is the dark red and `errorContainer` the pale tint; **in dark they trade places**. Blending the pale role over the Aegean night canvas lightens it toward slate — a field that reads *disabled*, not *destructive*. I shipped exactly that in a first pass and only caught it by rendering dark mode; the role names give no hint. The helper now blends the saturated member per brightness, and the alphas differ for the same reason: a light card needs only a touch of a dark red to go rose, while a near-black canvas needs most of one before it reads red at all.

Both brightnesses were rendered mid-swipe and looked at.

## Verification

- `flutter analyze` clean — the 3 infos are pre-existing in `route_response.dart`, untouched here.
- **47/47** on the notification suite, 7 new swipe tests: deletes the right row, leaves before the server answers, restores on failure, the restored row swipes again, the wrong direction does nothing, the last row lands on the empty state, and the ✕ still works alongside it.
- Full suite re-running against this exact tree; I will post the number rather than quote an earlier one.
- Rendered **mid-swipe in both brightnesses** with the real theme and the shipped Inter/Cormorant faces. Worth knowing for anyone writing a similar harness: the first render showed no swipe at all, because a single large `moveBy` is ambiguous to the gesture arena and the horizontal drag never wins — it needs incremental moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)