### PR TITLE
fix(plan): the opening's heading sets on one line on a phone

### DIFF
--- a/src/packages/flutter-app/lib/l10n/app_en.arb
+++ b/src/packages/flutter-app/lib/l10n/app_en.arb
@@ -2382,7 +2382,10 @@
   "chatRemoveQueued": "Remove queued message",
   "agentScreenTitle": "Plan your trip",
   "agentScreenStartOver": "Start over",
-  "agentScreenEmptyTitle": "Tell me about your trip",
+  "agentScreenEmptyTitle": "Where are we going?",
+  "@agentScreenEmptyTitle": {
+    "description": "The Plan tab's opening heading, in the display face at 39px. It must set on ONE line at a phone's width — 342px at 390, 327px at 375 — or it eats a whole 47px line of a field that is already short enough to drop the sentence beneath it. Measure a replacement against those two numbers, in every locale, before shipping it."
+  },
   "agentScreenEmptyMessage": "A place, a rough idea, a few dates — I'll find real places and build a day-by-day itinerary.",
   "agentScreenItineraryReady": "Itinerary ready — {count} locations",
   "@agentScreenItineraryReady": {

--- a/src/packages/flutter-app/lib/l10n/app_es.arb
+++ b/src/packages/flutter-app/lib/l10n/app_es.arb
@@ -991,7 +991,7 @@
   "chatRemoveQueued": "Quitar mensaje en cola",
   "agentScreenTitle": "Planea tu viaje",
   "agentScreenStartOver": "Empezar de nuevo",
-  "agentScreenEmptyTitle": "Cuéntame sobre tu viaje",
+  "agentScreenEmptyTitle": "¿Adónde vamos?",
   "agentScreenEmptyMessage": "Un lugar, una idea aproximada, unas fechas: buscaré lugares reales y crearé un itinerario día a día.",
   "agentScreenItineraryReady": "Itinerario listo — {count} lugares",
   "agentScreenViewTrip": "Ver viaje",

--- a/src/packages/flutter-app/lib/l10n/app_localizations.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations.dart
@@ -5858,10 +5858,10 @@ abstract class AppLocalizations {
   /// **'Start over'**
   String get agentScreenStartOver;
 
-  /// No description provided for @agentScreenEmptyTitle.
+  /// The Plan tab's opening heading, in the display face at 39px. It must set on ONE line at a phone's width — 342px at 390, 327px at 375 — or it eats a whole 47px line of a field that is already short enough to drop the sentence beneath it. Measure a replacement against those two numbers, in every locale, before shipping it.
   ///
   /// In en, this message translates to:
-  /// **'Tell me about your trip'**
+  /// **'Where are we going?'**
   String get agentScreenEmptyTitle;
 
   /// No description provided for @agentScreenEmptyMessage.

--- a/src/packages/flutter-app/lib/l10n/app_localizations_en.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations_en.dart
@@ -3543,7 +3543,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get agentScreenStartOver => 'Start over';
 
   @override
-  String get agentScreenEmptyTitle => 'Tell me about your trip';
+  String get agentScreenEmptyTitle => 'Where are we going?';
 
   @override
   String get agentScreenEmptyMessage =>

--- a/src/packages/flutter-app/lib/l10n/app_localizations_es.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations_es.dart
@@ -3563,7 +3563,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get agentScreenStartOver => 'Empezar de nuevo';
 
   @override
-  String get agentScreenEmptyTitle => 'Cuéntame sobre tu viaje';
+  String get agentScreenEmptyTitle => '¿Adónde vamos?';
 
   @override
   String get agentScreenEmptyMessage =>

--- a/src/packages/flutter-app/lib/screens/agent_screen.dart
+++ b/src/packages/flutter-app/lib/screens/agent_screen.dart
@@ -190,22 +190,30 @@ const double _kIntroMeasure = 420;
 
 /// How much of the opening the field can actually hold.
 ///
-/// Mobile web forced this. Browser-measured on the running app at 390 wide and
-/// default text scale, the whole block plus the composer is 608px, and the
-/// panel a phone offers is the viewport less the 56px app bar and the 84px nav
-/// bar: 704 installed, but 524 in Safari with its chrome showing, and 413 on a
-/// 375x667 device. At 524 both chips fell off the bottom; at 413 the
-/// destination cards were sliced through their labels. Three of the four ways
-/// in were invisible on the one screen whose whole job is offering them.
+/// Mobile web forced this. The panel a phone offers is the viewport less the
+/// 56px app bar and the 84px nav bar: ~704 installed, but ~525 in Safari with
+/// its chrome showing, and ~418 on a 375x667 device. The block used to be
+/// taller than two of those — at 525 both chips fell off the bottom, and at
+/// 418 the destination cards were sliced through their labels, so three of the
+/// four ways in were invisible on the one screen whose whole job is offering
+/// them.
 ///
 /// So the block composes to the field instead of overflowing it, and the order
 /// it gives things up is fixed: air first, then the rail's photo size, then
 /// prose. A way in is never what goes.
+///
+/// **Every [chrome] below is browser-measured on the running app at default
+/// text scale, and they move whenever the heading's or the sentence's LINE
+/// COUNT does.** They were first taken against a heading that wrapped to two
+/// lines; shortening the copy to one line freed a whole 47px line and every
+/// one of them dropped by it. A copy change here is a layout change — measure
+/// again rather than reasoning about characters, because this suite loads no
+/// fonts and cannot tell you.
 enum _IntroTier {
   /// Everything: the wide rail, the sentence, the xxl seam. The desktop
   /// column, a tablet, and an installed app on a modern phone.
   tall(
-      chrome: 370,
+      chrome: 328,
       seam: AppSpacing.xxl,
       gapAboveChips: AppSpacing.lg,
       tailGap: AppSpacing.lg),
@@ -213,7 +221,7 @@ enum _IntroTier {
   /// Mobile web with browser chrome showing. The seams tighten by a rung;
   /// the sentence stays.
   medium(
-      chrome: 354,
+      chrome: 312,
       seam: AppSpacing.xl,
       gapAboveChips: AppSpacing.lg,
       tailGap: AppSpacing.sm),
@@ -222,7 +230,7 @@ enum _IntroTier {
   /// four ways in, and the composer stay on screen together — a first-timer
   /// can still act, which is what the sentence only described.
   short(
-      chrome: 270,
+      chrome: 235,
       seam: AppSpacing.xl,
       gapAboveChips: AppSpacing.md,
       tailGap: AppSpacing.sm);

--- a/src/packages/flutter-app/test/agent_empty_state_suggestions_test.dart
+++ b/src/packages/flutter-app/test/agent_empty_state_suggestions_test.dart
@@ -136,7 +136,7 @@ void main() {
       (WidgetTester tester) async {
     await pumpAgent(tester, overrides());
 
-    final heading = tester.getRect(find.text('Tell me about your trip'));
+    final heading = tester.getRect(find.text('Where are we going?'));
     final rail =
         tester.getRect(find.byType(DestinationSuggestionCard).first);
     final chips = tester.getRect(find.byType(NearMeChip));
@@ -265,7 +265,7 @@ void main() {
     await pumpAgent(tester, overrides());
 
     expect(tester.takeException(), isNull);
-    expect(find.text('Tell me about your trip'), findsOneWidget);
+    expect(find.text('Where are we going?'), findsOneWidget);
     expect(find.byType(DestinationSuggestionCard), findsWidgets);
   });
 }


### PR DESCRIPTION
"Tell me about your trip" wrapped to two lines on every phone. It measures **355.7px** in the display face at the headline tier's 39px, against the **342px** a 390pt phone leaves after the block's own padding.

That cost 47px of a field already short enough that the composition drops its explanatory sentence to fit — so this isn't only a typographic tidy-up.

**"Where are we going?" is 314.7px** and sets on one line at 375 as well as 390. Spanish "¿Adónde vamos?" is 252.3px against 343.

## Measured, not counted

Candidates were measured against the real `CormorantGaramond-Medium.ttf` at 39px rather than estimated by character count. The method validates against what shipped: the old string measures 355.7, and its first line — "Tell me about your" — 288.5, which is exactly where it broke.

Three otherwise-good options were dropped for **colliding with strings already on this screen**:

| Candidate | Already in use as |
|---|---|
| "Where to next?" | the landing hero |
| "Where to?" | this screen's own composer placeholder, three elements below |
| "Plan your trip" | this screen's app bar title |

One Spanish candidate, "¿Qué viaje planeamos?" (340.2), was dropped for fitting a 390 phone but not a 375 one.

## The part worth reading twice

`_IntroTier`'s `chrome` budgets move with this. They're browser measurements of everything the composition holds *except* the rail, and they were taken against a heading that wrapped to **two** lines. One line frees a whole 47px and every one of them drops by it:

**370 / 354 / 270 → 328 / 312 / 235** — re-measured on the running app, not subtracted.

Left alone they'd have been silently conservative, choosing a smaller tier than the field could actually hold. The enum's doc now says outright that a copy change here is a layout change, and to measure rather than reason about characters.

**Which tier gets chosen does not move.** A 375×667 phone in Safari still takes `short` and still drops the sentence — `medium` needs 447 against the 418 it has. Verified by rendering before and after the recalibration. What changes is the air: the tall tier at 390×664 goes from 19px of leftover to 65.

## Verified

Rendered on the running app at **390×664** and **375×553**, in **English and Spanish**. Full suite **1894/1894**; `analyze` clean; brand-check clean; `gen-l10n` clean with `l10n_untranslated.json` = `{}`, re-confirmed after rebasing onto current main.

Two tests asserted the old literal string and were updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/golden-tempo/codesmith/anemos-travel/pr/548"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790043425&installation_model_id=433099&pr_number=548&repository=golden-tempo%2Fanemos-travel&return_to=https%3A%2F%2Fgithub.com%2Fgolden-tempo%2Fanemos-travel%2Fpull%2F548&signature=4ff2b125abe5c7a8d1585951456660da80c4a770ae4fb470f6e7b5a6c2af317c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->