### PR TITLE
fix(home): the greeting sets on one line on a phone

### DIFF
--- a/src/packages/flutter-app/lib/l10n/app_en.arb
+++ b/src/packages/flutter-app/lib/l10n/app_en.arb
@@ -1774,6 +1774,15 @@
       }
     }
   },
+  "homeGreetingShort": "Hello {name}",
+  "@homeGreetingShort": {
+    "description": "Home's greeting when the time-of-day one will not set on one line — a phone, a long name, or a large text scale. Must stay MUCH shorter than homeGreetingNamed: it is what carries names the full dress cannot, so a translation that merely trims a word defeats it.",
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
   "homeGreetingSubtitle": "Where are we off to next?",
   "homeHeroTitle": "Plan less. Travel more.",
   "homeHeroSubtitle": "Describe the trip you're dreaming of and I'll build the full itinerary — places, days, and routes.",

--- a/src/packages/flutter-app/lib/l10n/app_es.arb
+++ b/src/packages/flutter-app/lib/l10n/app_es.arb
@@ -734,6 +734,7 @@
   "homeGreetingAfternoon": "Buenas tardes",
   "homeGreetingEvening": "Buenas noches",
   "homeGreetingNamed": "{greeting}, {name}",
+  "homeGreetingShort": "Hola {name}",
   "homeGreetingSubtitle": "¿Adónde vamos ahora?",
   "homeHeroTitle": "Planea menos. Viaja más.",
   "homeHeroSubtitle": "Cuéntame el viaje que sueñas y armaré el itinerario completo — lugares, días y rutas.",

--- a/src/packages/flutter-app/lib/l10n/app_localizations.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations.dart
@@ -4418,6 +4418,12 @@ abstract class AppLocalizations {
   /// **'{greeting}, {name}'**
   String homeGreetingNamed(String greeting, String name);
 
+  /// Home's greeting when the time-of-day one will not set on one line — a phone, a long name, or a large text scale. Must stay MUCH shorter than homeGreetingNamed: it is what carries names the full dress cannot, so a translation that merely trims a word defeats it.
+  ///
+  /// In en, this message translates to:
+  /// **'Hello {name}'**
+  String homeGreetingShort(String name);
+
   /// No description provided for @homeGreetingSubtitle.
   ///
   /// In en, this message translates to:

--- a/src/packages/flutter-app/lib/l10n/app_localizations_en.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations_en.dart
@@ -2617,6 +2617,11 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String homeGreetingShort(String name) {
+    return 'Hello $name';
+  }
+
+  @override
   String get homeGreetingSubtitle => 'Where are we off to next?';
 
   @override

--- a/src/packages/flutter-app/lib/l10n/app_localizations_es.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations_es.dart
@@ -2635,6 +2635,11 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
+  String homeGreetingShort(String name) {
+    return 'Hola $name';
+  }
+
+  @override
   String get homeGreetingSubtitle => '¿Adónde vamos ahora?';
 
   @override

--- a/src/packages/flutter-app/lib/screens/home_screen.dart
+++ b/src/packages/flutter-app/lib/screens/home_screen.dart
@@ -350,6 +350,22 @@ class _PlanStrip extends StatelessWidget {
   }
 }
 
+/// Width at or above which Home greets with the time of day rather than a
+/// plain "Hello".
+///
+/// Browser-measured against the real face at the headline tier's 39px: the
+/// prefix "Good afternoon, " alone is 262px, which leaves 81px for a name on a
+/// 375px phone — about four characters. "Good afternoon, Brian" (346px) was
+/// already wrapping and "Good afternoon, Alexander" (420px) was never close.
+/// 464 is that prefix plus room for a twelve-letter name, and the padding is
+/// the page's own lg on each side.
+///
+/// Every phone lands below this and gets "Hello {name}", which measures 178px
+/// for Brian and still fits Konstantinos at 297px. A long name on a wide
+/// screen can still take two lines — that is today's behavior on a surface
+/// with room to spare, and not what this is here to fix.
+const double _kGreetingFullDressField = 464 + AppSpacing.lg * 2;
+
 class _GreetingHeader extends StatelessWidget {
   final String? displayName;
 
@@ -361,17 +377,36 @@ class _GreetingHeader extends StatelessWidget {
     final l10n = context.l10n;
     final firstName = displayName?.trim().split(RegExp(r'\s+')).first;
     final greeting = greetingText(l10n, greetingForHour(DateTime.now().hour));
+    // The page's one display moment: headlineMedium is the display face via
+    // the theme, a step above the old headlineSmall.
+    final style = theme.textTheme.headlineMedium;
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Text(
-          (firstName == null || firstName.isEmpty)
-              ? greeting
-              : l10n.homeGreetingNamed(greeting, firstName),
-          // The page's one display moment: headlineMedium is the display
-          // face via the theme, a step above the old headlineSmall.
-          style: theme.textTheme.headlineMedium,
-        ),
+        if (firstName == null || firstName.isEmpty)
+          Text(greeting, style: style)
+        else
+          // The time-of-day greeting keeps its place where there is room for
+          // it, and gives way to a plain "Hello" where there is not — the same
+          // short-spelling idiom ChatPanel uses for its composer hint and the
+          // Plan tab's opening uses for its chips.
+          //
+          // A WIDTH gate, not a measurement of the composed string. Measuring
+          // is tempting, because which greeting fits truly does depend on the
+          // name — but this suite loads no fonts, so a TextPainter here reads
+          // the fixed-width test font and decides the full dress wraps at
+          // 800px, which is how the first cut of this silently rendered
+          // "Hello Brian" to every test that asked for the time-of-day one.
+          // A width threshold is the same answer the rest of the app gives,
+          // and it is the same answer in a test as on a phone.
+          LayoutBuilder(
+            builder: (context, constraints) => Text(
+              constraints.maxWidth >= _kGreetingFullDressField
+                  ? l10n.homeGreetingNamed(greeting, firstName)
+                  : l10n.homeGreetingShort(firstName),
+              style: style,
+            ),
+          ),
         const SizedBox(height: AppSpacing.xs),
         Text(
           l10n.homeGreetingSubtitle,

--- a/src/packages/flutter-app/test/home_greeting_test.dart
+++ b/src/packages/flutter-app/test/home_greeting_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/widgets.dart' show Size;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -100,6 +101,23 @@ void main() {
       final greeting = _englishGreetingNow(tester);
       expect(find.text('$greeting, Brian'), findsOneWidget);
       expect(find.text('Where are we off to next?'), findsOneWidget);
+    });
+
+    testWidgets('a phone-width field greets with Hello instead', (tester) async {
+      // The whole point of the width gate: "Good afternoon, Brian" is 346px
+      // against the 343px a 375pt phone leaves, so it wrapped to two lines.
+      // Asserting the STRING, never a measurement — this suite loads no fonts,
+      // so its text metrics are fiction and the widths above were taken in the
+      // browser instead.
+      tester.view.physicalSize = const Size(390, 844);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+
+      await _pumpHome(tester, _user('Brian Dowe'));
+
+      expect(find.text('Hello Brian'), findsOneWidget);
+      final greeting = _englishGreetingNow(tester);
+      expect(find.textContaining('$greeting,'), findsNothing);
     });
 
     testWidgets('falls back to a bare greeting when display name is empty',


### PR DESCRIPTION
"Good afternoon, Brian" measures **346px** in the display face at 39px, against the **343px** a 375pt phone leaves — so it wrapped.

But the wrap was never really about the greeting. The prefix **"Good afternoon, " alone is 262px**, which leaves **81px for the name** — about four characters:

| | Width | 375 (343) |
|---|---|---|
| "Good afternoon, Brian" | 346 | ✗ |
| "Good afternoon, Alexander" | 420 | ✗ |
| "Good afternoon, Bartholomew" | 468 | ✗ |
| "Hello Brian" | 178 | ✓ |
| "Hello Konstantinos" | 297 | ✓ |

The line was going to break for most of the cohort, not occasionally. "Hello {name}" gives a phone a greeting that fits the names people actually have; wide fields keep the time of day, which is the whole reason `greetingForHour` exists.

## The gate is width — and the first cut got that wrong

Worth recording, because the wrong version looked *better*.

Which greeting fits genuinely depends on the **name**, not just the width, so measuring the composed string with a `TextPainter` seemed strictly superior to a threshold. Then the suite ran.

**This suite loads no fonts.** That painter read the fixed-width test font, concluded the full dress wrapped at an 800px surface, and quietly rendered "Hello Brian" to two tests in `home_editorial_style_test` that had asked for the time-of-day greeting. A measurement-driven widget is a widget that behaves differently under test than on a phone.

The threshold is what the rest of the app already does — `ChatPanel`'s `shortInputHint`, `NearMeChip.compact`, the Plan tab's chip spellings — and it gives the same answer in both places. **Both of those tests now pass untouched**, which is the point.

`464` is the measured prefix plus room for a twelve-letter name; the padding is the page's own `lg` on each side. Every phone lands below it. A long name on a wide screen can still take two lines — that's today's behavior on a surface with room to spare, and not what this is for.

## Verified

Full suite **1894 passing**; `analyze` clean; `gen-l10n` clean with `l10n_untranslated.json` = `{}`, re-confirmed after rebasing onto current main. Adds a narrow-width test that's deterministic precisely because the gate is.

**One known failure, not from this diff:** `auth_autofill_submit_test` — it also failed a run in the sibling lane and passed the next, and passes **6/6 in isolation** here. Flaky under full-suite parallelism; this diff touches no auth code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/golden-tempo/codesmith/anemos-travel/pr/549"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790043447&installation_model_id=433099&pr_number=549&repository=golden-tempo%2Fanemos-travel&return_to=https%3A%2F%2Fgithub.com%2Fgolden-tempo%2Fanemos-travel%2Fpull%2F549&signature=2c0a119de82d6f79d278e7f6954a80d9d101ac78cc07c9d446e32bc2ec573a8f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->