### PR TITLE
fix(home): the hero's map no longer waits for a visit to the trip page

### DIFF
--- a/src/packages/flutter-app/lib/providers/recent_trip_provider.dart
+++ b/src/packages/flutter-app/lib/providers/recent_trip_provider.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -102,12 +103,12 @@ final recentTripProvider =
 });
 
 /// Full cached detail of a trip, feeding a card's map band (TripMapBand).
-/// Cache-first and cache-ONLY: a miss (MRU eviction, fresh device) yields
-/// null and the host card renders its plain row — list surfaces never fetch,
-/// they only decorate what other screens load. The band therefore shows the
-/// trip *as of the last time this device viewed its detail* (accepted
-/// staleness: a collaborator's edit elsewhere appears on the next detail
-/// open).
+/// Cache-first: a miss (MRU eviction, fresh device) yields null, and
+/// [tripDetailForBandProvider] decides whether to go get it.
+///
+/// The band therefore shows the trip *as of the last time this device viewed
+/// its detail* (accepted staleness: a collaborator's edit elsewhere appears on
+/// the next detail open).
 ///
 /// Watches the WHOLE [recentTripProvider] state on purpose: [record] mints a
 /// fresh [RecentTrip] instance on every successful detail load, so this
@@ -120,6 +121,54 @@ final cachedTripDetailProvider =
   ref.watch(recentTripProvider);
   final cached = await ref.watch(tripCacheProvider).readTrip(tripId);
   return cached?.trip;
+});
+
+/// What a hero card's map band actually draws: the cached detail, or — on a
+/// cold cache — one fetch to go and get it.
+///
+/// The band used to be cache-ONLY, under the rule that "list surfaces never
+/// fetch, they only decorate what other screens load". That rule was written
+/// for rows, and the band has never been on one: its three hosts are all
+/// single promoted hero cards ([ContinueTripHero], and [TripHeroCard] behind
+/// the "Up next" and "Happening now" heroes). So the cost it was guarding —
+/// one fetch per row — does not exist, while the cost it imposed was real and
+/// visible: **on a device that had never opened this trip's detail, the hero
+/// had no map at all.** First-run, a fresh browser profile, cleared site data,
+/// or MRU eviction all produced a flat brand slab where the route should be,
+/// and nothing on Home could ever fix it, because only the trip screen writes
+/// that cache.
+///
+/// A fetch is the only way out: the trips LIST payload carries no items and no
+/// coordinates (listTripsHandler sends them nil), so there is nothing on Home
+/// to derive a map from.
+///
+/// Self-limiting by construction:
+///  * Only on a miss. A warm cache never reaches the network.
+///  * The result is written back, so the next cold start is warm — for every
+///    other band on this trip too.
+///  * A failure yields null, which is exactly the old behavior: the band
+///    collapses and the host renders as it always did. A flaky connection can
+///    degrade Home no further than it already would.
+final tripDetailForBandProvider =
+    FutureProvider.family<Trip?, String>((ref, tripId) async {
+  final cached = await ref.watch(cachedTripDetailProvider(tripId).future);
+  if (cached != null) return cached;
+  // A signed-out read misses for a reason that fetching cannot fix — the
+  // cache is auth-keyed, so it returns null the moment the session ends, and
+  // going to the network there buys a guaranteed 401.
+  if (!ref.watch(authProvider).isSignedIn) return null;
+  try {
+    final trip = await ref.read(tripsApiServiceProvider).getTrip(tripId);
+    // Write-through so this costs one fetch per device, not one per visit.
+    // Fire-and-forget: the map does not wait on the disk write, and a cache
+    // failure must not lose the trip we already have in hand.
+    unawaited(ref.read(tripCacheProvider).writeTrip(trip));
+    return trip;
+  } catch (_) {
+    // Signed out, offline, deleted trip, rate-limited — all the same answer,
+    // and it is the answer this band gave for every miss before today.
+    return null;
+  }
 });
 
 /// What Home's "Continue where you left off" card renders: enough to draw the

--- a/src/packages/flutter-app/lib/widgets/trip_map_band.dart
+++ b/src/packages/flutter-app/lib/widgets/trip_map_band.dart
@@ -10,15 +10,21 @@ import '../utils/leg_ranges.dart';
 import 'trip_map.dart';
 import 'trip_map_destinations.dart';
 
-/// A gradient card's map band: the cached trip's overview map (numbered
-/// destination pins + route line, the trip-detail visual) rendered as a
-/// static preview above the card's title row. Collapses to nothing while the
-/// cache read resolves, on a miss (MRU eviction, fresh device), and when
-/// nothing on the trip is mappable — the host card then renders exactly as it
-/// would without the band. Fed by [cachedTripDetailProvider], so it is
-/// cache-ONLY: the band decorates what other screens loaded, it never
-/// fetches. Hosts: Home's recent-trip card and the shared TripHeroCard (both
-/// the "Up next" and "Happening now" heroes).
+/// A hero card's map band: the trip's overview map (numbered destination pins
+/// + route line, the trip-detail visual) rendered as a static preview above
+/// the card's title row. Collapses to nothing while the trip resolves, when it
+/// cannot be got at all, and when nothing on the trip is mappable — the host
+/// card then renders exactly as it would without the band.
+///
+/// Fed by [tripDetailForBandProvider]: the device's cached detail, or one
+/// fetch when that is cold. It used to be cache-ONLY, which meant a device
+/// that had never opened this trip's detail showed **no map here, ever** —
+/// see that provider for why the no-fetch rule did not survive contact with a
+/// first page load.
+///
+/// Hosts, all of them single promoted heroes rather than list rows: Home's
+/// continue-trip hero and the shared TripHeroCard behind the "Up next" and
+/// "Happening now" cards.
 class TripMapBand extends ConsumerStatefulWidget {
   final String tripId;
 
@@ -82,7 +88,7 @@ class _TripMapBandState extends ConsumerState<TripMapBand> {
     // follows every detail view (record() mints a fresh RecentTrip), so a
     // resolved band never collapses and re-grows on the way back.
     final trip =
-        ref.watch(cachedTripDetailProvider(widget.tripId)).valueOrNull;
+        ref.watch(tripDetailForBandProvider(widget.tripId)).valueOrNull;
     if (trip == null) return const SizedBox.shrink();
     _recompute(trip, context.l10n);
     if (!_mappable) return const SizedBox.shrink();

--- a/src/packages/flutter-app/test/home_recent_trip_map_test.dart
+++ b/src/packages/flutter-app/test/home_recent_trip_map_test.dart
@@ -18,6 +18,8 @@ import 'package:travel_route_planner/providers/resumable_chats_provider.dart';
 import 'package:travel_route_planner/providers/trips_provider.dart';
 import 'package:travel_route_planner/screens/home_screen.dart';
 import 'package:travel_route_planner/screens/trip_detail_screen.dart';
+import 'package:travel_route_planner/services/api_client.dart';
+import 'package:travel_route_planner/services/trips_api_service.dart';
 import 'package:travel_route_planner/widgets/continue_chats_section.dart';
 import 'package:travel_route_planner/widgets/continue_trip_hero.dart';
 import 'package:travel_route_planner/widgets/trip_map.dart';
@@ -26,10 +28,16 @@ import 'support/l10n_test_app.dart';
 import 'support/url_sync_fakes.dart';
 
 /// The continue hero's route imagery (home "Continue where you left off"):
-/// renders the CACHED trip's overview map full-bleed behind the overlaid
-/// title on a cache hit, and falls back to the brand-gradient card (same
-/// text block) on a miss or when nothing is mappable. Cache-only by design —
-/// home never fetches.
+/// renders the trip's overview map full-bleed behind the overlaid title, and
+/// falls back to the brand-gradient card (same text block) when there is
+/// nothing to draw.
+///
+/// The band was cache-ONLY until a cold cache was reported as a bug: a device
+/// that had never opened this trip's DETAIL — first run, a fresh browser
+/// profile, cleared site data, MRU eviction — showed a flat brand slab and had
+/// no way to ever show anything else, since only the trip screen writes that
+/// cache. A miss now fetches once and writes through; a fetch that fails
+/// collapses exactly as a miss always did.
 ///
 /// Seeding writes the raw prefs keys (recent_trip_provider storage format +
 /// TripCache's entry format) in ONE setMockInitialValues call — never
@@ -154,9 +162,34 @@ MapEntry<String, Object> _cachedTripEntry(Trip trip) => MapEntry(
 void _seed(List<MapEntry<String, Object>> entries) =>
     SharedPreferences.setMockInitialValues(Map.fromEntries(entries));
 
+/// Serves [trip] from `getTrip`, counting calls — the counter is what proves
+/// a warm cache never reaches the network. A null [trip] throws instead,
+/// standing in for offline / signed-out / deleted.
+class _CountingTripsApi extends TripsApiService {
+  final Trip? trip;
+  int getTripCalls = 0;
+
+  _CountingTripsApi(this.trip) : super(ApiClient(baseUrl: 'http://test'));
+
+  @override
+  Future<Trip> getTrip(String id) async {
+    getTripCalls++;
+    final t = trip;
+    if (t == null) throw Exception('offline');
+    return t;
+  }
+
+  @override
+  Future<List<Trip>> listTrips() async => const [];
+
+  @override
+  Future<List<Trip>> listSharedWithMe() async => const [];
+}
+
 Future<void> _pumpHome(
   WidgetTester tester, {
   List<ChatSessionSummary> chats = const [],
+  _CountingTripsApi? api,
 }) async {
   await tester.pumpWidget(
     ProviderScope(
@@ -164,6 +197,10 @@ Future<void> _pumpHome(
         authProvider.overrideWith((ref) => _FakeAuthNotifier(_user())),
         liveTripProvider.overrideWithValue(null),
         resumableChatsProvider.overrideWith((ref) async => chats),
+        // Always overridden: without it a cache miss reaches the real client,
+        // whose failure the band swallows — so a "no map" assertion would
+        // pass for the wrong reason.
+        if (api != null) tripsApiServiceProvider.overrideWithValue(api),
       ],
       child: MaterialApp(
           localizationsDelegates: testLocalizationsDelegates,
@@ -177,6 +214,14 @@ Future<void> _pumpHome(
   await tester.pump();
   await tester.pump();
   await tester.pump();
+  // Then settle, for the cold-cache path's extra hops: the getTrip that
+  // follows the miss, and the deferred write-through it queues. That write is
+  // a `Timer.run` whose drain body then awaits prefs several times
+  // (trip_cache.dart's deferred-writes note), so a fixed pump count is a
+  // guess — and leaving it undrained fails on `!timersPending`, and worse,
+  // leaks into the NEXT test: _pendingWrites is static and readTrip drains it
+  // first, so one test's unflushed write becomes the next test's cache hit.
+  await tester.pumpAndSettle();
 }
 
 void main() {
@@ -186,7 +231,8 @@ void main() {
       (WidgetTester tester) async {
     final trip = _mappableTrip('t1', 'Lisbon Trip');
     _seed([_recentTripEntry('t1', 'Lisbon Trip'), _cachedTripEntry(trip)]);
-    await _pumpHome(tester);
+    final api = _CountingTripsApi(trip);
+    await _pumpHome(tester, api: api);
 
     expect(find.byType(TripMap), findsOneWidget);
     // The title overlays the imagery inside the same hero card.
@@ -196,13 +242,44 @@ void main() {
           matching: find.text('Lisbon Trip')),
       findsOneWidget,
     );
+    // A warm cache never reaches the network.
+    expect(api.getTripCalls, 0);
   });
 
-  testWidgets('cache miss keeps the gradient-fallback hero',
+  testWidgets('cache MISS fetches the trip and still draws the map',
+      (WidgetTester tester) async {
+    // The reported bug: on a device that had never opened this trip's detail,
+    // the hero was a flat brand slab with no way to ever become a map.
+    _seed([_recentTripEntry('t1', 'Lisbon Trip')]);
+    final api = _CountingTripsApi(_mappableTrip('t1', 'Lisbon Trip'));
+    await _pumpHome(tester, api: api);
+
+    expect(api.getTripCalls, 1);
+    expect(find.byType(TripMap), findsOneWidget);
+    expect(find.text('Lisbon Trip'), findsOneWidget);
+  });
+
+  testWidgets('a fetch that fails keeps the gradient-fallback hero',
+      (WidgetTester tester) async {
+    // Offline, signed out, deleted, rate-limited — all the same answer, and
+    // it is the answer every miss gave before the fetch existed. A flaky
+    // connection must not degrade Home further than it already would.
+    _seed([_recentTripEntry('t1', 'Lisbon Trip')]);
+    final api = _CountingTripsApi(null);
+    await _pumpHome(tester, api: api);
+
+    expect(api.getTripCalls, 1);
+    expect(find.byType(TripMap), findsNothing);
+    expect(find.text('Lisbon Trip'), findsOneWidget);
+  });
+
+  testWidgets('a fetched trip with nothing mappable also falls back',
       (WidgetTester tester) async {
     _seed([_recentTripEntry('t1', 'Lisbon Trip')]);
-    await _pumpHome(tester);
+    final api = _CountingTripsApi(_unmappableTrip('t1', 'Lisbon Trip'));
+    await _pumpHome(tester, api: api);
 
+    expect(api.getTripCalls, 1);
     expect(find.byType(TripMap), findsNothing);
     expect(find.text('Lisbon Trip'), findsOneWidget);
   });
@@ -211,17 +288,22 @@ void main() {
       (WidgetTester tester) async {
     final trip = _unmappableTrip('t1', 'Lisbon Trip');
     _seed([_recentTripEntry('t1', 'Lisbon Trip'), _cachedTripEntry(trip)]);
-    await _pumpHome(tester);
+    final api = _CountingTripsApi(trip);
+    await _pumpHome(tester, api: api);
 
     expect(find.byType(TripMap), findsNothing);
     expect(find.text('Lisbon Trip'), findsOneWidget);
+    // A hit that simply has nothing to plot is still a hit — no refetch.
+    expect(api.getTripCalls, 0);
   });
 
   testWidgets('band keeps the section order: trip card above chats',
       (WidgetTester tester) async {
     final trip = _mappableTrip('t1', 'Lisbon Trip');
     _seed([_recentTripEntry('t1', 'Lisbon Trip'), _cachedTripEntry(trip)]);
-    await _pumpHome(tester, chats: [_chat('c1', 'Greek islands')]);
+    await _pumpHome(tester,
+        chats: [_chat('c1', 'Greek islands')],
+        api: _CountingTripsApi(trip));
 
     expect(find.byType(TripMap), findsOneWidget);
     expect(


### PR DESCRIPTION
Reported from the running app: on a first page load the continue-trip hero showed a flat brand slab instead of the route — and the map only ever appeared *after* opening that trip's detail page.

That second observation is the whole bug.

## Root cause

`TripMapBand` read `cachedTripDetailProvider` and, by its own doc, **"never fetches"**. The only writer of that cache is `_load` on the trip detail screen. So on any device that had not opened this trip's detail — first run, a fresh browser profile, cleared site data, MRU eviction — the band collapsed to nothing and **nothing on Home could ever change that**.

Not a loading bug. A data-source one.

There was no way to avoid a fetch: the trips **list** payload carries no items and no coordinates (`listTripsHandler` passes them `nil`), so Home has nothing to derive a map from.

## Why the no-fetch rule didn't survive contact

The rule reads *"list surfaces never fetch, they only decorate what other screens load"* — written to stop one request per row. But the band has never been on a row. All three of its hosts are single promoted hero cards: the continue-trip hero, and `TripHeroCard` behind "Up next" and "Happening now". The cost it guarded didn't exist; the cost it imposed was a permanently blank map.

## The change

`tripDetailForBandProvider`: cache-first, then **one** fetch on a miss, then write-through so the next cold start is warm — for every band on that trip, not just this one.

Self-limiting by construction:

- **A warm cache never reaches the network** — asserted with a call counter, not assumed.
- **A signed-out read skips the fetch entirely.** The cache is auth-keyed, so it misses the moment the session ends, and going to the network there buys a guaranteed 401.
- **A failure returns null**, which is precisely what every miss did before today: the band collapses, the host renders as it always did. A flaky connection degrades Home no further than it already would.

## Two things the tests caught

**The old miss test would have kept passing for the wrong reason.** `cache miss keeps the gradient-fallback hero` pinned the old contract, but the harness never overrode the API service — so once a miss started fetching, it would hit the real client, fail, and get swallowed, and the assertion would still be green. It now always injects a fake, and the miss case asserts the map *appears*.

**A static leak between tests.** The write-through queues a deferred `Timer.run`, and leaving it undrained did more than trip `!timersPending`: `TripCache._pendingWrites` is **static** and `readTrip` drains it first, so one test's unflushed write became the *next* test's cache hit — which is what turned the failing-fetch test's expected `1` into `0`. Fixed by settling rather than guessing a pump count.

## Verification

- `flutter analyze` clean — the 3 infos are pre-existing in `route_response.dart`, untouched.
- Map-band and hero suites: **35/35** (continue hero, live trip, trip hero card, trips list live/offline, map band).
- Full suite: **1908 passing, 1 failing**.

**That one failure is not from this PR.** `trips_list_header_test`'s *"a plain row prints its span on the date line"* expects `· 34 days` and finds none. I ran it in a detached worktree at clean `origin/main` (`ed2bb31`) with none of this branch present: **it fails identically there**. `main` is currently red, independent of this change — flagging it rather than folding an unrelated fix into this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/golden-tempo/codesmith/anemos-travel/pr/550"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790052097&installation_model_id=433099&pr_number=550&repository=golden-tempo%2Fanemos-travel&return_to=https%3A%2F%2Fgithub.com%2Fgolden-tempo%2Fanemos-travel%2Fpull%2F550&signature=00a6d3b8b83a1438bf23f34044a074a6757e9a1b0442f352a3531c4508a8e3af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->