### PR TITLE
perf(shell): tabs build on first visit; hidden tabs leave the semantics tree

### DIFF
--- a/src/packages/flutter-app/lib/navigation/app_nav.dart
+++ b/src/packages/flutter-app/lib/navigation/app_nav.dart
@@ -188,8 +188,17 @@ void selectTab(WidgetRef ref, int index) {
 void goHome(WidgetRef ref) => selectTab(ref, AppTab.home.index);
 
 /// Push a route onto [tab]'s navigator, retrying across frames while the
-/// nested navigator mounts (cold boot, shell remount after a root reset). If
-/// every attempt misses, the user still lands on the selected tab's root.
+/// nested navigator mounts (cold boot, shell remount after a root reset, the
+/// first build of a lazily-built tab). If every attempt misses, the user
+/// still lands on the selected tab's root.
+///
+/// The shell builds tab subtrees on first visit (app_shell.dart), so an
+/// unvisited tab has NO navigator to land on: callers must select the tab —
+/// write [navIndexProvider] — before or alongside the push, because becoming
+/// the index is what builds the slot, and the retries bridge that one build
+/// frame. Every caller does; a push that targets a tab it never selects
+/// would exhaust its attempts and drop.
+///
 /// Takes the keys — not a ref — so callers whose element is about to be
 /// disposed (shared-trip join) capture them up front, and the Ref-holding
 /// UrlSyncController can share it.

--- a/src/packages/flutter-app/lib/screens/app_shell.dart
+++ b/src/packages/flutter-app/lib/screens/app_shell.dart
@@ -4,6 +4,7 @@ import '../l10n/l10n.dart';
 import '../navigation/app_nav.dart';
 import '../navigation/shell_scope.dart';
 import '../navigation/url_sync.dart';
+import '../providers/trips_provider.dart';
 import '../theme/spacing.dart';
 import '../widgets/account_menu.dart';
 import '../widgets/brand_logo.dart';
@@ -18,7 +19,10 @@ import 'trips_list_screen.dart';
 /// root, while Trips keeps your place — first tap returns to the trip you
 /// were viewing, a second tap pops to the list. Programmatic switch+push
 /// flows (Home trip cards, boot restore, shared-trip join) write
-/// [navIndexProvider] directly, so their pushes survive regardless.
+/// [navIndexProvider] directly, so their pushes survive regardless. Tab
+/// subtrees build lazily on first visit and stay mounted from then on
+/// ([_AppShellState._visited]); hidden visited tabs stay out of the
+/// semantics tree.
 ///
 /// [navDestinations] carries the icons and ordering; its labels are display
 /// copy, so the shell renders the localized label for each tab instead
@@ -30,13 +34,56 @@ String _destinationLabel(AppLocalizations l10n, int index) =>
       AppTab.trips => l10n.shellNavTrips,
     };
 
-class AppShell extends ConsumerWidget {
+class AppShell extends ConsumerStatefulWidget {
   const AppShell({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<AppShell> createState() => _AppShellState();
+}
+
+class _AppShellState extends ConsumerState<AppShell> {
+  /// Tabs that have been the selected index at least once this shell
+  /// lifetime. A tab's subtree builds on FIRST VISIT and stays mounted for
+  /// good; an unvisited tab's IndexedStack slot holds an empty box instead
+  /// (lazy first build — 2026-08 perf audit, finding-3 hardening: boot
+  /// builds one tab's subtree, not three, and the live widget/semantics
+  /// surface starts at one tab). Once every tab has been visited the steady
+  /// state is identical to the always-mounted shell this replaces.
+  ///
+  /// Programmatic switch+push flows (Home trip cards, boot restore,
+  /// shared-trip join) need no special casing: they write [navIndexProvider]
+  /// before pushing onto the target tab's navigator, and becoming the index
+  /// IS what builds the slot — pushOnTabWhenReady's frame-retry loop
+  /// (app_nav.dart) bridges the one frame between the write and the
+  /// navigator mounting, exactly as it already did for cold boot. Boot
+  /// deep-links are the same story one frame earlier: the boot target sets
+  /// the index before this widget first builds, so the targeted tab is the
+  /// one slot built on frame one.
+  final Set<int> _visited = {};
+
+  @override
+  void initState() {
+    super.initState();
+    // The boot trips load lives HERE, not in TripsListScreen's initState,
+    // because Home consumes tripsProvider too (live-trip hero, travels band,
+    // the returning-user gate) and under lazy first build no tab screen can
+    // be assumed mounted. The shell is the one widget that always mounts
+    // when a signed-in session starts — and it remounts on the same root
+    // resets that used to remount the trips list, so the load-and-refresh
+    // cadence is unchanged: once per shell lifetime. TripsListScreen keeps a
+    // guarded self-load for mounts outside the shell (its widget tests).
+    // Post-frame because loadTrips writes provider state, illegal mid-build.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      ref.read(tripsProvider.notifier).loadTrips();
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
     final l10n = context.l10n;
     final index = ref.watch(navIndexProvider);
+    _visited.add(index);
     final navKeys = ref.watch(tabNavKeysProvider);
     final urlSync = ref.watch(urlSyncProvider);
     final isWide = MediaQuery.sizeOf(context).width >= kRailBreakpoint;
@@ -57,32 +104,58 @@ class AppShell extends ConsumerWidget {
         index: index,
         children: [
           for (var i = 0; i < navKeys.length; i++)
-            // TickerMode freezes hidden tabs' animations/tickers (an open
-            // TripDetailScreen on a background tab otherwise keeps animating
-            // offscreen) while keeping their state, scroll positions, and
-            // GlobalKeys mounted — deliberately NOT unmounting or swapping
-            // placeholders, and NOT keyed off ModalRoute.isCurrent (a hidden
-            // tab's top route still reports current). It doubles as the
-            // visibility signal AppMapVisibilityGate (app_map.dart) reads,
-            // so a hidden tab's map bands mount no live FlutterMap.
-            //
-            // The catch, and it bites: a nested Navigator is the vsync for its
-            // own route transitions and sits INSIDE this TickerMode, so a
-            // push or pop started on a hidden tab does not advance — it parks
-            // fully painted and then plays its whole transition the moment
-            // this IndexedStack reveals the tab. Anything that changes a
-            // hidden tab's stack must therefore remove routes, never pop
-            // them: see resetToRoot and instantRoute (app_nav.dart).
-            TickerMode(
-              enabled: i == index,
-              child: _TabNavigator(
-                navKey: navKeys[i],
-                // Fresh observer instances every build: an observer may only
-                // be attached to one navigator at a time (url_sync.dart).
-                observers: [TabUrlObserver(urlSync, i)],
-                child: _tabRoots[i],
+            if (!_visited.contains(i))
+              // Lazy first build: this tab has never been selected, so its
+              // slot holds nothing — no screen subtree, no Navigator, no
+              // TabUrlObserver. First selection swaps the real subtree in
+              // (see [_visited]) and it stays mounted from then on.
+              const SizedBox.shrink()
+            else
+              // Hidden VISITED tabs drop out of the semantics tree while
+              // staying fully mounted: what a screen reader (or a
+              // DOM-scanning extension content script) can read is the tab
+              // on screen, nothing else. State, scroll positions, providers
+              // and in-flight fetches are untouched — only semantics
+              // exposure changes. Flutter's own IndexedStack already strips
+              // hidden children (its per-child Visibility omits
+              // maintainSemantics, and RenderIndexedStack visits only the
+              // displayed child for semantics), so this wrapper is the
+              // app-owned pin of that contract: stated here beside the
+              // shell's other lifecycle gates rather than inherited silently
+              // from SDK internals an upgrade could rework.
+              ExcludeSemantics(
+                excluding: i != index,
+                // TickerMode freezes hidden tabs' animations/tickers (an open
+                // TripDetailScreen on a background tab otherwise keeps
+                // animating offscreen) while keeping their state, scroll
+                // positions, and GlobalKeys mounted — deliberately NOT
+                // unmounting or swapping placeholders once a tab has been
+                // visited, and NOT keyed off ModalRoute.isCurrent (a hidden
+                // tab's top route still reports current). It doubles as the
+                // visibility signal AppMapVisibilityGate (app_map.dart)
+                // reads, so a hidden tab's map bands mount no live
+                // FlutterMap.
+                //
+                // The catch, and it bites: a nested Navigator is the vsync
+                // for its own route transitions and sits INSIDE this
+                // TickerMode, so a push or pop started on a hidden tab does
+                // not advance — it parks fully painted and then plays its
+                // whole transition the moment this IndexedStack reveals the
+                // tab. Anything that changes a hidden tab's stack must
+                // therefore remove routes, never pop them: see resetToRoot
+                // and instantRoute (app_nav.dart).
+                child: TickerMode(
+                  enabled: i == index,
+                  child: _TabNavigator(
+                    navKey: navKeys[i],
+                    // Fresh observer instances every build: an observer may
+                    // only be attached to one navigator at a time
+                    // (url_sync.dart).
+                    observers: [TabUrlObserver(urlSync, i)],
+                    child: _tabRoots[i],
+                  ),
+                ),
               ),
-            ),
         ],
       ),
     ));

--- a/src/packages/flutter-app/lib/screens/home_screen.dart
+++ b/src/packages/flutter-app/lib/screens/home_screen.dart
@@ -110,8 +110,9 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
     // inside the readiness window, which is what "before you go" means. Also
     // live-trip-excluding, so nothing here has to. See departingTripOf.
     final departingTrip = ref.watch(departingTripProvider);
-    // Populated app-wide: AppShell's IndexedStack keeps TripsListScreen
-    // mounted, and its loadTrips() feeds tripsProvider — no fetch from here.
+    // Populated app-wide: AppShell fires the boot loadTrips() from its own
+    // initState (tab subtrees build lazily, so no tab screen can be assumed
+    // mounted) — no fetch from here.
     //
     // Every trips refresh rebuilds the Trip objects, so watching the derived
     // Trip? directly would fire on identical data. Watch an identity-stable

--- a/src/packages/flutter-app/lib/screens/trips_list_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trips_list_screen.dart
@@ -80,13 +80,25 @@ class _TripsListScreenState extends ConsumerState<TripsListScreen> {
   void initState() {
     super.initState();
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      ref.read(tripsProvider.notifier).loadTrips();
-      // Boot dedup: this screen mounts at shell boot (IndexedStack keeps all
-      // tabs alive), when HomeScreen's very first resumable-chats fetch is
-      // still in flight — invalidating then would throw that request away and
-      // issue a duplicate /chats call. Skip the refresh while a fetch is
-      // already loading; on later remounts the provider has data (or an
-      // error) and the refresh proceeds as before.
+      // The shell owns the boot loadTrips() (app_shell.dart: Home consumes
+      // tripsProvider too, and under lazy first build this screen doesn't
+      // mount until the Trips tab is first selected). Self-load only when
+      // that hasn't happened — a mount outside the shell (widget tests) —
+      // recognized by tripsProvider still holding its virgin state. The one
+      // ambiguity: a zero-trip account's loaded state is indistinguishable
+      // from virgin, so its first visit refetches once; harmless.
+      final trips = ref.read(tripsProvider);
+      if (!trips.loading &&
+          trips.trips.isEmpty &&
+          trips.error == null &&
+          trips.offlineSince == null) {
+        ref.read(tripsProvider.notifier).loadTrips();
+      }
+      // Boot dedup: the first mount can land while HomeScreen's very first
+      // resumable-chats fetch is still in flight (frame one, when Trips is
+      // the boot target) — invalidating then would throw that request away
+      // and issue a duplicate /chats call. Skip the refresh while a fetch is
+      // already loading; with data (or an error) present it proceeds.
       if (!ref.read(resumableChatsProvider).isLoading) {
         ref.invalidate(resumableChatsProvider);
       }

--- a/src/packages/flutter-app/lib/widgets/home_travels_band.dart
+++ b/src/packages/flutter-app/lib/widgets/home_travels_band.dart
@@ -14,10 +14,10 @@ import 'travel_footprint_card.dart';
 /// Home's way into the atlas.
 ///
 /// Its own key rather than the Trips header's `kTravelAtlasSeeAllKey`, because
-/// both headers are alive at the same time — the shell keeps `TripsListScreen`
-/// mounted under Home, which is the same fact this band relies on for its data
-/// — so one key would match two widgets and every finder using it would go
-/// ambiguous the moment this shipped.
+/// both headers are alive at the same time once the Trips tab has been visited
+/// — the shell keeps visited tabs mounted under the active one — so one key
+/// would match two widgets and every finder using it would go ambiguous the
+/// moment this shipped.
 const kHomeTravelAtlasSeeAllKey = ValueKey('travelAtlas.entry.home');
 
 /// "Your travels" on Home: the traveled/planned footprint the Trips tab
@@ -30,9 +30,9 @@ const kHomeTravelAtlasSeeAllKey = ValueKey('travelAtlas.entry.home');
 /// Both gates come with it: **2+ owned trips**, because an aggregate over one
 /// trip only restates the hero above it, and the card's own pin rules.
 ///
-/// Reads `tripsProvider`, which is populated app-wide (the shell keeps
-/// `TripsListScreen` mounted and its `loadTrips()` feeds it), so this costs no
-/// request of its own — the same reason Home can watch it for `returning`.
+/// Reads `tripsProvider`, which is populated app-wide (`AppShell` fires the
+/// boot `loadTrips()` from its own initState), so this costs no request of
+/// its own — the same reason Home can watch it for `returning`.
 ///
 /// Owned trips only. Shared-with-me is someone else's travel and its payload
 /// carries no pins anyway, which is the rule the Trips tab already applies.

--- a/src/packages/flutter-app/test/app_map_visibility_gate_test.dart
+++ b/src/packages/flutter-app/test/app_map_visibility_gate_test.dart
@@ -78,8 +78,8 @@ void main() {
       (city: 'Lisbon', lat: 38.7, lng: -9.1, visited: true),
       (city: 'Athens', lat: 37.9, lng: 23.7, visited: false),
     ];
-    const traveled = (trips: 1, travelDays: 5, cities: 1);
-    const planned = (trips: 1, travelDays: 3, cities: 1);
+    const traveled = (trips: 1, travelDays: 5, cities: 1, countries: 1);
+    const planned = (trips: 1, travelDays: 3, cities: 1, countries: 1);
 
     Future<void> pumpCard(WidgetTester tester, {required bool enabled}) {
       return tester.pumpWidget(

--- a/src/packages/flutter-app/test/app_shell_lazy_tabs_test.dart
+++ b/src/packages/flutter-app/test/app_shell_lazy_tabs_test.dart
@@ -1,0 +1,188 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:travel_route_planner/main.dart';
+import 'package:travel_route_planner/navigation/app_nav.dart';
+import 'package:travel_route_planner/navigation/app_routes.dart';
+import 'package:travel_route_planner/navigation/url_sync.dart';
+import 'package:travel_route_planner/providers/auth_provider.dart';
+import 'package:travel_route_planner/providers/live_trip_provider.dart';
+import 'package:travel_route_planner/providers/resumable_chats_provider.dart';
+import 'package:travel_route_planner/providers/trips_provider.dart';
+import 'package:travel_route_planner/screens/agent_screen.dart';
+import 'package:travel_route_planner/screens/home_screen.dart';
+import 'package:travel_route_planner/screens/trip_detail_screen.dart';
+import 'package:travel_route_planner/screens/trips_list_screen.dart';
+
+import 'support/url_sync_fakes.dart';
+
+/// Lazy tab lifecycle (2026-08 perf audit, finding-3 hardening): the shell
+/// builds a tab's subtree on FIRST VISIT — boot builds one tab, not three —
+/// and a visited tab stays mounted through later switches exactly as the
+/// always-mounted shell did. Hidden visited tabs leave the semantics tree:
+/// what a screen reader can read is the tab on screen, nothing else.
+///
+/// The programmatic switch+push contract rides on the same mechanism and is
+/// pinned here too: writing navIndexProvider is what builds the slot, so a
+/// push targeting a never-visited tab lands once pushOnTabWhenReady's
+/// frame-retries meet the freshly built navigator.
+void main() {
+  late List<String> reports;
+
+  Finder railDestination(String label) => find.descendant(
+      of: find.byType(NavigationRail), matching: find.text(label));
+
+  Future<ProviderContainer> pumpApp(WidgetTester tester) async {
+    tester.binding.platformDispatcher.defaultRouteNameTestValue = '/';
+    reports = <String>[];
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          authProvider.overrideWith((ref) => FakeAuthNotifier(fakeUser())),
+          tripsApiServiceProvider
+              .overrideWithValue(FakeTripsApiService(fakeTrip('t1'))),
+          liveTripProvider.overrideWithValue(null),
+          resumableChatsProvider.overrideWith((ref) async => const []),
+          urlReporterProvider.overrideWithValue(reports.add),
+        ],
+        child: const TravelRoutePlannerApp(),
+      ),
+    );
+    await tester.pumpAndSettle();
+    return ProviderScope.containerOf(
+        tester.element(find.byType(TravelRoutePlannerApp)));
+  }
+
+  setUp(() => SharedPreferences.setMockInitialValues({}));
+
+  testWidgets('boot builds only the boot tab; a visit builds and keeps',
+      (tester) async {
+    await pumpApp(tester);
+
+    // skipOffstage: false throughout — the claim is about what EXISTS in the
+    // tree, not what is on screen. An unvisited tab must not exist at all.
+    expect(find.byType(HomeScreen, skipOffstage: false), findsOneWidget);
+    expect(find.byType(AgentScreen, skipOffstage: false), findsNothing);
+    expect(find.byType(TripsListScreen, skipOffstage: false), findsNothing);
+
+    await tester.tap(railDestination('Trips'));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(TripsListScreen), findsOneWidget);
+    expect(reports.last, kTripsLocation);
+    // Lazy is first-BUILD only: the tab switched away from stays mounted.
+    expect(find.byType(HomeScreen, skipOffstage: false), findsOneWidget);
+    // Never-visited Plan still builds nothing.
+    expect(find.byType(AgentScreen, skipOffstage: false), findsNothing);
+  });
+
+  testWidgets('the boot trips load no longer depends on the trips tab',
+      (tester) async {
+    // Home's live-trip hero, travels band and returning-user gate all read
+    // tripsProvider, which the mounted-at-boot TripsListScreen used to feed.
+    // Under lazy build that screen may never mount, so the SHELL owns the
+    // boot load — pinned by watching the provider fill while the Trips tab
+    // stays unbuilt.
+    final container = await pumpApp(tester);
+
+    expect(find.byType(TripsListScreen, skipOffstage: false), findsNothing);
+    expect(
+      container.read(tripsProvider).trips.map((t) => t.id),
+      contains('t1'),
+      reason: 'the shell must load trips without the trips list mounting',
+    );
+  });
+
+  testWidgets('a visited tab keeps its pushed stack across switches',
+      (tester) async {
+    // Trips-keeps-your-place survives lazy build: visit, open a trip, leave,
+    // come back — the detail is parked, not rebuilt and not discarded.
+    final container = await pumpApp(tester);
+
+    await tester.tap(railDestination('Trips'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Lisbon long weekend'));
+    await tester.pumpAndSettle();
+    expect(find.byType(TripDetailScreen), findsOneWidget);
+
+    await tester.tap(railDestination('Home'));
+    await tester.pumpAndSettle();
+    expect(container.read(navIndexProvider), AppTab.home.index);
+    // Hidden, not gone:
+    expect(find.byType(TripDetailScreen, skipOffstage: false), findsOneWidget);
+
+    await tester.tap(railDestination('Trips'));
+    await tester.pumpAndSettle();
+    expect(find.byType(TripDetailScreen), findsOneWidget);
+    expect(reports.last, '/trips/t1');
+  });
+
+  testWidgets('a hidden visited tab leaves the semantics tree', (tester) async {
+    // The probe is a marker page pushed inside the Trips tab, so the claim
+    // cannot be confused by strings Home and the trips list share (the trip
+    // title renders on both). Mounted-but-unreadable is the contract.
+    final handle = tester.ensureSemantics();
+    final container = await pumpApp(tester);
+
+    List<String> readable() => tester.semantics
+        .simulatedAccessibilityTraversal()
+        .map((node) => node.label)
+        .where((label) => label.isNotEmpty)
+        .toList();
+
+    await tester.tap(railDestination('Trips'));
+    await tester.pumpAndSettle();
+    container
+        .read(tabNavKeysProvider)[AppTab.trips.index]
+        .currentState!
+        .push(MaterialPageRoute(
+            builder: (_) =>
+                const Scaffold(body: Text('inside the trips tab'))));
+    await tester.pumpAndSettle();
+    expect(readable(), anyElement(contains('inside the trips tab')));
+
+    await tester.tap(railDestination('Home'));
+    await tester.pumpAndSettle();
+    // Still mounted — state intact — but nothing of it is readable.
+    expect(find.text('inside the trips tab', skipOffstage: false),
+        findsOneWidget);
+    expect(readable(), isNot(anyElement(contains('inside the trips tab'))));
+
+    // Reveal restores the exact same subtree to the semantics tree.
+    await tester.tap(railDestination('Trips'));
+    await tester.pumpAndSettle();
+    expect(readable(), anyElement(contains('inside the trips tab')));
+
+    handle.dispose();
+  });
+
+  testWidgets('a programmatic push builds the never-visited tab it targets',
+      (tester) async {
+    // The raw switch+push pattern every programmatic flow uses (Home trip
+    // cards, boot restore, shared-trip join): write navIndexProvider, then
+    // pushOnTabWhenReady — here against a tab whose navigator does not exist
+    // yet. The index write force-builds the slot; the push retries must land
+    // on the fresh navigator, never be dropped.
+    final container = await pumpApp(tester);
+
+    expect(find.byType(TripsListScreen, skipOffstage: false), findsNothing);
+    final navKeys = container.read(tabNavKeysProvider);
+    expect(navKeys[AppTab.trips.index].currentState, isNull,
+        reason: 'the premise: no navigator exists to push onto yet');
+
+    container.read(navIndexProvider.notifier).state = AppTab.trips.index;
+    pushOnTabWhenReady(
+        navKeys,
+        AppTab.trips,
+        () => instantRoute(
+            TripDetailScreen(tripId: 't1'), tripDetailLocation('t1')));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(TripsListScreen, skipOffstage: false), findsOneWidget,
+        reason: 'targeting the tab must have built it');
+    expect(find.byType(TripDetailScreen), findsOneWidget);
+    expect(reports.last, '/trips/t1');
+  });
+}

--- a/src/packages/flutter-app/test/app_shell_ticker_mode_test.dart
+++ b/src/packages/flutter-app/test/app_shell_ticker_mode_test.dart
@@ -14,11 +14,14 @@ import 'package:travel_route_planner/screens/app_shell.dart';
 
 import 'support/url_sync_fakes.dart';
 
-/// The shell keeps every tab mounted in an IndexedStack (state, scroll,
-/// GlobalKeys survive tab switches) but hidden tabs must not keep animating:
-/// each child is wrapped in a TickerMode enabled only for the active index,
-/// so an open TripDetailScreen on a background tab freezes its tickers
-/// instead of burning frames offscreen.
+/// The shell keeps every VISITED tab mounted in an IndexedStack (state,
+/// scroll, GlobalKeys survive tab switches; unvisited tabs are empty
+/// placeholder slots until first selected — app_shell_lazy_tabs_test) but
+/// hidden tabs must not keep animating: each built slot wraps its navigator
+/// in a TickerMode enabled only for the active index, so an open
+/// TripDetailScreen on a background tab freezes its tickers instead of
+/// burning frames offscreen. The slot's ExcludeSemantics rides the same
+/// i == index signal, one negation apart.
 void main() {
   setUp(() => SharedPreferences.setMockInitialValues({}));
 
@@ -43,18 +46,28 @@ void main() {
         .descendant(
             of: find.byType(AppShell), matching: find.byType(IndexedStack))
         .first);
+    // A built slot is ExcludeSemantics > TickerMode > navigator; an unvisited
+    // slot is a bare SizedBox and by definition ticks nothing.
+    TickerMode? tickerOf(Widget slot) =>
+        slot is ExcludeSemantics ? slot.child as TickerMode : null;
     List<int> enabledIndexes(IndexedStack stack) => [
           for (var i = 0; i < stack.children.length; i++)
-            if ((stack.children[i] as TickerMode).enabled) i,
+            if (tickerOf(stack.children[i])?.enabled ?? false) i,
+        ];
+    List<int> semanticIndexes(IndexedStack stack) => [
+          for (var i = 0; i < stack.children.length; i++)
+            if (stack.children[i] is ExcludeSemantics &&
+                !(stack.children[i] as ExcludeSemantics).excluding)
+              i,
         ];
 
     var stack = shellStack();
-    // Every tab is wrapped; exactly the active one ticks.
-    expect(stack.children, everyElement(isA<TickerMode>()));
+    // Exactly the active slot ticks, and exactly it keeps its semantics.
     expect(enabledIndexes(stack), [stack.index]);
+    expect(semanticIndexes(stack), [stack.index]);
 
     // Switch tabs: the enabled TickerMode follows the active index and the
-    // previous tab's freezes.
+    // previous tab's freezes — its semantics gate flips in lockstep.
     final container = ProviderScope.containerOf(
         tester.element(find.byType(TravelRoutePlannerApp)));
     container.read(navIndexProvider.notifier).state = AppTab.trips.index;
@@ -63,5 +76,9 @@ void main() {
     stack = shellStack();
     expect(stack.index, AppTab.trips.index);
     expect(enabledIndexes(stack), [AppTab.trips.index]);
+    expect(semanticIndexes(stack), [AppTab.trips.index]);
+    // The tab switched away from froze rather than unmounting: its slot is
+    // still the built shape, just disabled and semantics-excluded.
+    expect(tickerOf(stack.children[AppTab.home.index]), isNotNull);
   });
 }


### PR DESCRIPTION
## Summary
- **Lazy first build** (perf audit finding-3 hardening): the shell's `IndexedStack` slots hold an empty box until a tab is first selected — boot builds one tab's subtree instead of three. After first visit a tab stays mounted exactly as before, so Trips-keeps-your-place, TickerMode parking, per-tab GlobalKey navigators, and the per-build TabUrlObserver rule are all unchanged in steady state.
- **Programmatic switch+push flows** (Home trip cards, boot restore, shared-trip join) force-build the tab they target: writing `navIndexProvider` is what builds the slot, and `pushOnTabWhenReady`'s existing frame-retry loop bridges the build frame. The precondition is now documented on the helper and pinned by a test that pushes onto a never-visited tab's not-yet-existing navigator.
- **Hidden visited tabs leave the semantics tree** via `ExcludeSemantics` driven by the same `i == index` signal as TickerMode — a tab you cannot see is not readable by a screen reader (or a DOM-scanning extension content script). Flutter 3.35's IndexedStack already strips hidden children's semantics (per-child `Visibility` without `maintainSemantics`, plus `RenderIndexedStack`'s displayed-child-only semantics visitor), so the wrapper pins that contract app-side instead of inheriting it silently from SDK internals; the semantics test asserts the behavior, not the wrapper.
- **The boot trips load moves to the shell**: `TripsListScreen.initState` was what fed `tripsProvider` for Home's live-trip hero, travels band, and returning-user gate — comments in both files said so. Under lazy build no tab screen can be assumed mounted, so `AppShell.initState` owns the once-per-shell-lifetime load (same cadence, shell remounts included); the screen keeps a virgin-state-guarded self-load for standalone mounts (its widget tests).
- **Repairs the suite on main**: `test/app_map_visibility_gate_test.dart` (#553) crossed the trips-insights merge that added `countries` to `TravelStats` — its two record literals were two fields short and the suite did not compile. Two-line fix carried here.
- `AppMapVisibilityGate`'s TickerMode signal chain is untouched (`ExcludeSemantics` sits outside the `TickerMode`).

## Testing
- `flutter analyze` — clean (3 pre-existing infos in untouched `route_response.dart` only).
- Full `flutter test` — **1926 passing, 0 failing** (exit code checked directly, not through a pipe).
- New `test/app_shell_lazy_tabs_test.dart`: boot builds only the boot tab; visit builds and keeps; shell-owned trips load fills `tripsProvider` with the trips tab unbuilt; pushed stacks survive switches; hidden tab is mounted but absent from the accessibility traversal (and readable again on reveal); programmatic push builds the never-visited tab it targets and lands.
- `app_shell_ticker_mode_test.dart` updated to the new slot shape (built slots = `ExcludeSemantics` > `TickerMode`; unvisited = placeholder), asserting ticker and semantics gates flip in lockstep.
- Brand `check.sh` clean on all touched lib files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/golden-tempo/codesmith/anemos-travel/pr/554"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790097699&installation_model_id=433099&pr_number=554&repository=golden-tempo%2Fanemos-travel&return_to=https%3A%2F%2Fgithub.com%2Fgolden-tempo%2Fanemos-travel%2Fpull%2F554&signature=e01dc0b84b7d3991de681daa699bb6eb998722990d5e772f6faca482b257a092"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->