### PR TITLE
feat(maps): default the home-airport overlay off on both trip map surfaces

### DIFF
--- a/src/packages/flutter-app/lib/providers/home_overlay_provider.dart
+++ b/src/packages/flutter-app/lib/providers/home_overlay_provider.dart
@@ -2,10 +2,11 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 /// The traveler's explicit choice about the trip map's home-airport overlay
 /// (the flight_takeoff pin plus its dashed journey legs): true = show,
-/// false = hide, null = no choice made this session. Surfaces resolve the
-/// null through [homeOverlayVisible], so the overlay defaults on where the
-/// map has room for the whole journey (wide, pinned layouts) and off where
-/// the leg home would crowd the destinations out of frame (phones).
+/// false = hide, null = no choice made this session. Every surface resolves
+/// the null through [homeOverlayVisible] to OFF: the hop home is context,
+/// not the trip, so the destinations own the frame — on the inline
+/// trip-detail card and the full-screen map alike — until the traveler asks
+/// otherwise.
 ///
 /// App-wide rather than per-trip: this is a framing preference ("do I want
 /// the hop home in frame"), not trip data — the same scope as
@@ -15,8 +16,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 /// directly (the rickRollProvider rationale).
 ///
 /// Session-only, like dailySpendSettingsProvider: the choice resets on
-/// restart so the per-form-factor default re-asserts (a phone's map always
-/// reopens with tight city framing). To persist instead, follow the
+/// restart so the off default re-asserts. To persist instead, follow the
 /// theme_mode_provider pattern — a load() plus a best-effort
 /// shared_preferences write in [HomeOverlayChoiceNotifier.setShown]; the
 /// call sites would not change.
@@ -32,11 +32,7 @@ final homeOverlayChoiceProvider =
     StateNotifierProvider<HomeOverlayChoiceNotifier, bool?>(
         (ref) => HomeOverlayChoiceNotifier());
 
-/// Effective home-overlay visibility for one map surface: the explicit
-/// [choice] when one has been made, else the form-factor default — shown on
-/// wide layouts, hidden on phones. The default is the absence of a choice:
-/// null is never written back as a decision. [wideLayout] is the surface's
-/// own layout question — `_mapPinned` (body width) on the inline trip-detail
-/// card, the window-width rail idiom on the full-screen map.
-bool homeOverlayVisible({required bool? choice, required bool wideLayout}) =>
-    choice ?? wideLayout;
+/// Effective home-overlay visibility: the explicit [choice] when one has
+/// been made, else hidden. The default is the absence of a choice: null is
+/// never written back as a decision.
+bool homeOverlayVisible({required bool? choice}) => choice ?? false;

--- a/src/packages/flutter-app/lib/screens/trip_map_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_map_screen.dart
@@ -6,7 +6,6 @@ import 'package:latlong2/latlong.dart';
 import '../l10n/l10n.dart';
 import '../models/accommodation.dart';
 import '../models/itinerary_item.dart';
-import '../navigation/app_nav.dart';
 import '../providers/flights_provider.dart';
 import '../providers/home_overlay_provider.dart';
 import '../utils/snack.dart';
@@ -242,12 +241,10 @@ class _TripMapScreenState extends ConsumerState<TripMapScreen> {
     final items = widget.itemsForLeg(_legKey);
     final onAddPlace = widget.onAddPlace;
     final homeCandidates = _homeOverlay();
-    // Whether the wide default applies is a window question here (the
-    // gradient_app_bar idiom) — this screen is a root-navigator dialog
-    // covering the whole window.
+    // Off until the traveler toggles it on — same default as the inline
+    // card this screen is opened from.
     final showHome = homeOverlayVisible(
       choice: ref.watch(homeOverlayChoiceProvider),
-      wideLayout: MediaQuery.sizeOf(context).width >= kRailBreakpoint,
     );
     // Escape closes the map. Two layers on purpose: this shortcut rides the
     // key-event focus chain, catching Escape while anything in the Scaffold

--- a/src/packages/flutter-app/lib/widgets/trip_detail/map_band.dart
+++ b/src/packages/flutter-app/lib/widgets/trip_detail/map_band.dart
@@ -188,11 +188,12 @@ class TripDetailMapBand extends StatelessWidget {
               firstCityPoint: endpoints.first,
               lastCityPoint: endpoints.last,
             );
-            // !expandable == _mapPinned at both _mapCard call sites, so the
-            // wide default rides the same slot-width answer as the layout.
+            // The inline card defaults the overlay OFF at every width: the
+            // hop home is context, not the trip, so the destinations own the
+            // frame until the traveler toggles it on (a choice the shared
+            // provider then carries to the full-screen map too).
             final showHome = homeOverlayVisible(
               choice: ref.watch(homeOverlayChoiceProvider),
-              wideLayout: !expandable,
             );
             return TripMap(
               items: derivation.legFilteredItems(focusKey),

--- a/src/packages/flutter-app/test/home_overlay_provider_test.dart
+++ b/src/packages/flutter-app/test/home_overlay_provider_test.dart
@@ -4,16 +4,13 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:travel_route_planner/providers/home_overlay_provider.dart';
 
 void main() {
-  test('no choice: visibility follows the form factor', () {
-    expect(homeOverlayVisible(choice: null, wideLayout: true), isTrue);
-    expect(homeOverlayVisible(choice: null, wideLayout: false), isFalse);
+  test('no choice: hidden, on every surface', () {
+    expect(homeOverlayVisible(choice: null), isFalse);
   });
 
-  test('an explicit choice overrides the form-factor default both ways', () {
-    expect(homeOverlayVisible(choice: false, wideLayout: true), isFalse);
-    expect(homeOverlayVisible(choice: true, wideLayout: false), isTrue);
-    expect(homeOverlayVisible(choice: true, wideLayout: true), isTrue);
-    expect(homeOverlayVisible(choice: false, wideLayout: false), isFalse);
+  test('an explicit choice wins both ways', () {
+    expect(homeOverlayVisible(choice: true), isTrue);
+    expect(homeOverlayVisible(choice: false), isFalse);
   });
 
   test('the provider starts with no choice and records setShown', () {

--- a/src/packages/flutter-app/test/trip_detail_home_legs_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_home_legs_test.dart
@@ -9,6 +9,7 @@ import 'package:travel_route_planner/models/trip.dart';
 import 'package:travel_route_planner/models/itinerary_item.dart';
 import 'package:travel_route_planner/models/traveler_preferences.dart';
 import 'package:travel_route_planner/providers/flights_provider.dart';
+import 'package:travel_route_planner/providers/home_overlay_provider.dart';
 import 'package:travel_route_planner/providers/preferences_provider.dart';
 import 'package:travel_route_planner/providers/trips_provider.dart';
 import 'package:travel_route_planner/screens/trip_detail_screen.dart';
@@ -161,17 +162,24 @@ void main() {
 
   final trip = makeTrip();
 
+  /// [homeChoice] stands in for the traveler's show/hide toggle: the inline
+  /// card now defaults the overlay OFF, so the leg-gating tests force it on
+  /// to keep exercising a visible overlay. Pass null to test the default.
   Future<void> pumpScreen(
     WidgetTester tester, {
     bool withHome = true,
     Trip? tripOverride,
     List<Override> extraOverrides = const [],
+    bool? homeChoice = true,
   }) async {
     await tester.pumpWidget(
       ProviderScope(
         overrides: [
           tripsApiServiceProvider
               .overrideWithValue(_FakeTripsApiService(tripOverride ?? trip)),
+          if (homeChoice != null)
+            homeOverlayChoiceProvider.overrideWith((ref) =>
+                HomeOverlayChoiceNotifier()..setShown(homeChoice)),
           if (withHome) ...[
             // Populates _homeAirport via the screen's prefs load...
             preferencesApiServiceProvider.overrideWithValue(_FakePrefsApi()),
@@ -230,6 +238,25 @@ void main() {
     expect(home.single.outboundTo, isNotNull);
     expect(home.single.returnFrom, isNotNull);
     expect(home.single.kind, TripMapHomeKind.home);
+    expect(homePin, findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('the overlay defaults off; the toggle turns it on',
+      (WidgetTester tester) async {
+    // No choice made this session: even on the wide pinned card the inline
+    // map opens with the destinations owning the frame, and the toggle —
+    // dimmed, still present — is the way back to the hop home.
+    await pumpScreen(tester, homeChoice: null);
+
+    expect(map(tester).home, isEmpty);
+    expect(homePin, findsNothing);
+    expect(homeToggle, findsOneWidget);
+
+    await tester.tap(homeToggle);
+    await tester.pumpAndSettle();
+
+    expect(map(tester).home, hasLength(1));
     expect(homePin, findsOneWidget);
     expect(tester.takeException(), isNull);
   });
@@ -379,6 +406,8 @@ void main() {
           preferencesApiServiceProvider.overrideWithValue(prefsApi),
           homeAirportPointProvider('EWR')
               .overrideWith((ref) async => homePoint),
+          homeOverlayChoiceProvider.overrideWith(
+              (ref) => HomeOverlayChoiceNotifier()..setShown(true)),
         ],
         child: MaterialApp(
           localizationsDelegates: testLocalizationsDelegates,
@@ -411,8 +440,9 @@ void main() {
       (WidgetTester tester) async {
     await pumpScreen(tester);
 
-    // Default ON at the wide surface: lit toggle, left of the fullscreen
-    // button — beside, not above, the zoom column (PR #291's row shape).
+    // Overlay shown (the forced choice standing in for the toggle): lit
+    // toggle, left of the fullscreen button — beside, not above, the zoom
+    // column (PR #291's row shape).
     expect(homeToggle, findsOneWidget);
     expect(tester.widget<Icon>(homeToggle).color, Colors.white);
     final fullscreen = find.byIcon(Icons.fullscreen);
@@ -479,7 +509,7 @@ void main() {
     await tester.tap(find.byIcon(Icons.fullscreen));
     await tester.pumpAndSettle();
     expect(find.byType(TripMapScreen), findsOneWidget);
-    // The 800px window keeps the wide default, but the explicit choice wins.
+    // The explicit choice rides into the modal, over the off default.
     expect(homePin, findsNothing);
     expect(tester.widget<Icon>(homeToggle).color, Colors.white38);
 
@@ -497,14 +527,15 @@ void main() {
 
   testWidgets('phone flow: bare preview, toggle lives on the full map, '
       'an explicit ON rides back to the preview', (WidgetTester tester) async {
-    // The default is a window question on the full map, so shrink the VIEW —
-    // setSurfaceSize only resizes layout, not MediaQuery.sizeOf.
+    // Shrink the VIEW to get the phone layout (bare preview, no toggle —
+    // the full map carries it): setSurfaceSize only resizes layout, not
+    // MediaQuery.sizeOf.
     tester.view.physicalSize = const Size(375, 667);
     tester.view.devicePixelRatio = 1.0;
     addTearDown(tester.view.resetPhysicalSize);
     addTearDown(tester.view.resetDevicePixelRatio);
 
-    await pumpScreen(tester);
+    await pumpScreen(tester, homeChoice: null);
 
     // Phone default: tight city framing, and no toggle on the preview — the
     // full-screen map (one tap away) carries it.

--- a/src/packages/flutter-app/test/trip_map_screen_test.dart
+++ b/src/packages/flutter-app/test/trip_map_screen_test.dart
@@ -8,6 +8,7 @@ import 'package:latlong2/latlong.dart';
 import 'package:travel_route_planner/models/accommodation.dart';
 import 'package:travel_route_planner/models/itinerary_item.dart';
 import 'package:travel_route_planner/providers/flights_provider.dart';
+import 'package:travel_route_planner/providers/home_overlay_provider.dart';
 import 'package:travel_route_planner/screens/trip_map_screen.dart';
 import 'package:travel_route_planner/widgets/app_map.dart';
 import 'package:travel_route_planner/widgets/map_leg_chips.dart';
@@ -164,20 +165,26 @@ void main() {
       matching: find.byIcon(Icons.flight_takeoff),
     );
 
-    Widget appWithHome() => _app(
+    Widget appWithHome({List<Override> extraOverrides = const []}) => _app(
           homeAirport: 'EWR',
           firstCityPoint: firstCity,
           lastCityPoint: lastCity,
           overrides: [
             homeAirportPointProvider('EWR')
                 .overrideWith((ref) async => homePoint),
+            ...extraOverrides,
           ],
         );
 
     testWidgets(
       'home pin shows on the overview and the endpoint legs, hides mid-trip',
       (tester) async {
-        await tester.pumpWidget(appWithHome());
+        // Leg gating, not the default: force the traveler's choice on (the
+        // off default is covered by the toggle tests below).
+        await tester.pumpWidget(appWithHome(extraOverrides: [
+          homeOverlayChoiceProvider.overrideWith(
+              (ref) => HomeOverlayChoiceNotifier()..setShown(true)),
+        ]));
         await tester.pumpAndSettle();
 
         // Unfocused overview: both legs → home pin present.
@@ -198,35 +205,37 @@ void main() {
       },
     );
 
-    testWidgets('wide window defaults the overlay on; the toggle hides it', (
+    testWidgets('the overlay defaults off; the toggle shows and hides it', (
       tester,
     ) async {
-      // Default 800x600 surface: at kRailBreakpoint, the wide default.
+      // Default 800x600 surface: even with the whole window to spend, the
+      // destinations own the frame until the traveler asks for the hop home.
       await tester.pumpWidget(appWithHome());
       await tester.pumpAndSettle();
 
-      expect(homePin, findsOneWidget);
+      expect(homePin, findsNothing);
       expect(homeToggle, findsOneWidget);
       Tooltip tooltipOf(Finder f) => tester
           .widget<Tooltip>(find.ancestor(of: f, matching: find.byType(Tooltip)));
-      expect(tooltipOf(homeToggle).message, 'Hide home airport');
-
-      await tester.tap(homeToggle);
-      await tester.pumpAndSettle();
-      expect(homePin, findsNothing);
-      expect(homeToggle, findsOneWidget); // the way back on survives
       expect(tooltipOf(homeToggle).message, 'Show home airport');
 
       await tester.tap(homeToggle);
       await tester.pumpAndSettle();
       expect(homePin, findsOneWidget);
+      expect(homeToggle, findsOneWidget); // the way back off survives
+      expect(tooltipOf(homeToggle).message, 'Hide home airport');
+
+      await tester.tap(homeToggle);
+      await tester.pumpAndSettle();
+      expect(homePin, findsNothing);
       expect(tester.takeException(), isNull);
     });
 
-    testWidgets('narrow window defaults the overlay off; the toggle shows it', (
+    testWidgets('narrow window: same off default, same toggle', (
       tester,
     ) async {
-      // The default is a WINDOW question (MediaQuery), so shrink the view —
+      // The form factor no longer changes the default — this guards the
+      // phone layout path (dimmed toggle, tight framing). Shrink the VIEW:
       // setSurfaceSize only resizes layout, not MediaQuery.sizeOf.
       tester.view.physicalSize = const Size(360, 690);
       tester.view.devicePixelRatio = 1.0;
@@ -236,7 +245,7 @@ void main() {
       await tester.pumpWidget(appWithHome());
       await tester.pumpAndSettle();
 
-      // Phone default: tight city framing — no pin, but a dimmed way in.
+      // No pin, but a dimmed way in.
       expect(homePin, findsNothing);
       expect(homeToggle, findsOneWidget);
       expect(tester.widget<Icon>(homeToggle).color, Colors.white38);


### PR DESCRIPTION
## Summary

- The trip detail inline map and the full-screen trip map both open with the home-airport pin and dashed home legs **hidden**, at every window width; the destinations own the frame until the traveler toggles the overlay on.
- The toggle choice is unchanged: shared live between the inline card and the full-screen map, session-only, and the narrow preview still carries no toggle (the full-screen map does).
- With both surfaces on the same default, `homeOverlayVisible` simplifies to `choice ?? false` (the `defaultShown`/`wideLayout` parameter is gone), and `trip_map_screen.dart` drops its now-unused `app_nav.dart` import.

## Testing

- `flutter test` — full suite green (1916 passed; the single `budget_section_test.dart` failure under full-suite load passes standalone, unrelated flake).
- `flutter analyze` — no new issues (3 pre-existing errors in `app_map_visibility_gate_test.dart` exist at the base commit).
- New/updated coverage: off default + toggle-on path on the inline card (`trip_detail_home_legs_test.dart`), off default + show/hide round trip on the full-screen map (`trip_map_screen_test.dart`), and the simplified provider contract (`home_overlay_provider_test.dart`). Leg-gating tests now force the choice on via a provider override so they keep exercising a visible overlay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/golden-tempo/codesmith/anemos-travel/pr/555"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790100058&installation_model_id=433099&pr_number=555&repository=golden-tempo%2Fanemos-travel&return_to=https%3A%2F%2Fgithub.com%2Fgolden-tempo%2Fanemos-travel%2Fpull%2F555&signature=88627c7cb569bf35a457571bfffa08ce001d27c0d24f10c5649e55760f30e0a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->