### PR TITLE
feat(chat): recover the message you were writing — stop undoes, up recalls

### DIFF
--- a/specs/chat-history-recall/plan.md
+++ b/specs/chat-history-recall/plan.md
@@ -1,0 +1,121 @@
+# Plan: Composer History Recall
+
+> **HOW.** See `spec.md` for what and why, and `../../CLAUDE.md` for repo
+> conventions referenced below.
+
+## Technical Approach
+
+One file (`widgets/chat_panel.dart`), no new provider, no new storage. Three
+decisions carry the whole feature:
+
+### 1. The transcript *is* the history
+
+`_sentHistory()` reads `PlanState.messages` (plus `queuedMessages`) on each
+keystroke rather than maintaining a list. A second copy would be a second
+source of truth for "what the user sent" — the exact shape `docs/zen.md`
+warns about — and it would drift the moment a turn lands, a conversation is
+resumed, or `stopStreaming` undoes a turn (`specs/chat-stop-undo`, which
+*removes* a message the user must not then find in their history).
+
+Cheap enough to not need caching: it runs once per Up/Down keypress, not per
+frame.
+
+Filters: `role == user` (obviously) and `displayLabel == null` — a display
+label means the content is a machine-written seed behind a chip, which is not
+something the user typed. Queued messages are included: they were sent, they
+are only waiting.
+
+### 2. The kept draft *is* the stash
+
+Shell-style recall needs somewhere to park the half-written message while the
+user browses. `chatDraftProvider` is already exactly "what someone has composed
+but not sent yet" and already outlives the panel, so recall simply **doesn't
+write to it**: `_recalling` is set around the controller write, and
+`_saveDraft` returns early when it sees it. Stepping back to index −1 reads the
+draft provider and finds the user's words untouched.
+
+No second field to keep in sync, and it survives the panel being disposed
+mid-browse — the kept draft still holds what the user was writing, not the
+message they were looking at.
+
+The corollary is that `_saveDraft` became the one place that can tell the user
+typed, which is what ends a browse. That needed one more guard: a
+`TextEditingController` notifies for a **caret move** exactly as for a
+keystroke, and clicking into a recalled message to edit it is ordinary. So
+`_saveDraft` compares against `_composerText` (the text it last saw) and does
+nothing when only the selection moved — otherwise a click would end the browse
+*and* overwrite the stash with the message being browsed.
+
+### 3. The handler goes on the field's own focus node
+
+`_inputFocus.onKeyEvent`, set in `initState` — **not** a `Focus` widget wrapped
+around the `TextField`. `konami_listener.dart` documents this trap from the
+other side: an ancestor handler "sits above the focused node in the bubble
+chain and would therefore never see arrow keys while a text field has focus."
+The focused node is dispatched first, which also puts this ahead of
+`DefaultTextEditingShortcuts` near the root.
+
+Returning `KeyEventResult.ignored` is what leaves ordinary caret movement
+completely untouched, so every "don't recall here" case is a decline rather
+than a re-implementation:
+
+| Case | Result |
+|---|---|
+| not Up/Down, or a key-up event | ignored |
+| any modifier held (Shift/Alt/Ctrl/Meta) | ignored |
+| selection not collapsed | ignored |
+| caret not on the first line (Up) / last line (Down) | ignored |
+| already at the oldest (Up) / already at the draft (Down) | ignored |
+| otherwise | recall, `handled` |
+
+The first/last-line test is `!text.substring(0, offset).contains('\n')` (and
+its mirror) — *logical* lines, so a long soft-wrapped single line still
+recalls. That matches readline's `up-line-or-history` and is deterministic to
+test, which a visual-line test would not be.
+
+## Go API Changes
+
+None.
+
+## Flutter Changes
+
+`src/packages/flutter-app/lib/widgets/chat_panel.dart` only:
+
+- **State:** `_historyIndex` (−1 = not browsing, otherwise a position in the
+  history newest-first), `_recalling`, `_composerText`.
+- **`initState`:** assigns `_inputFocus.onKeyEvent`.
+- **`_restoreDraft`:** seeds `_composerText` alongside the controller.
+- **`_saveDraft`:** gains the caret-move guard, the `_recalling` guard, and
+  the `_historyIndex = -1` reset. Behaviour for an ordinary keystroke is
+  unchanged.
+- **New:** `_sentHistory()`, `_recallHistory(delta)`, `_onComposerKey(event)`.
+- **Imports:** `package:flutter/services.dart` (shown-scoped:
+  `HardwareKeyboard`, `KeyDownEvent`, `KeyEvent`, `KeyRepeatEvent`,
+  `LogicalKeyboardKey`).
+
+`_InputBar` is untouched — it stays a layout widget, and all recall policy
+lives in one method on the panel State.
+
+Per-conversation history and per-conversation drafts both fall out of
+`chatDraftKeyFor` / the notifier the panel was handed; no new key.
+
+## Contract Parity
+
+Not applicable — no wire contract changes.
+
+## Testing
+
+`test/chat_panel_history_recall_test.dart`, 11 widget tests driving **real key
+events** (`tester.sendKeyEvent`) through the focus tree — which is the only way
+to prove the interception point in decision 3 actually works, and the main risk
+in this change:
+
+walk back and stop at the oldest · caret at the end · Down forward and back to
+the half-written draft (and no further) · typing restarts the browse and
+becomes the new stash · a caret move does not · Up only from the first line ·
+Down only from the last line · each modifier declines while the bare key
+recalls · empty chat · chip-seeded turns excluded · a queued message is
+recallable.
+
+Per `CLAUDE.md`, no test asserts anything font-dependent — the multi-line cases
+use explicit `\n` and offsets, never wrap positions.

--- a/specs/chat-history-recall/spec.md
+++ b/specs/chat-history-recall/spec.md
@@ -1,0 +1,86 @@
+# Spec: Composer History Recall
+
+> **WHAT & WHY only.** See `plan.md` for the technical approach.
+
+## Context
+
+Chat messages get resent constantly with a word changed — a date moved, a city
+swapped, a question rephrased after the agent misread it. Today every one of
+those means retyping the whole sentence, because the words are visible in the
+bubble above but there is no way to get them back into the composer.
+
+Every terminal, every REPL, and every chat client people already use answers
+this the same way: **Up recalls what you sent last.** This adds that, with the
+behaviour people already have muscle memory for — Up walks back, Down walks
+forward, and the half-written message you were in the middle of is waiting
+where you left it.
+
+It pairs directly with `specs/chat-stop-undo`: stopping a turn hands the
+message back for editing, and Up does the same for any message that already
+got an answer.
+
+## User Stories
+
+- As a **traveler**, I want to press Up in the chat box to get my last message
+  back, so I can change one word and send it again instead of retyping it.
+- As a **traveler**, I want to keep pressing Up to reach older messages, and
+  Down to come back toward the newest.
+- As a **traveler part-way through typing**, I want the message I was writing
+  to still be there after I look through my history — pressing Down past the
+  newest brings it back.
+- As a **traveler writing a long multi-line message**, I want Up and Down to
+  move the cursor through my own text the way they do in every other text
+  box, not yank it away.
+
+## Acceptance Criteria
+
+- [ ] Pressing Up with the chat box focused replaces its contents with the
+  most recent message the traveler sent in this conversation. Pressing Up
+  again reaches the one before it, and so on.
+- [ ] The cursor lands at the **end** of the recalled text, so typing
+  continues the message rather than landing in front of it.
+- [ ] Pressing Up at the oldest message does nothing further.
+- [ ] Pressing Down walks back toward the newest; pressing Down past the
+  newest restores whatever the traveler had typed but not sent before they
+  started looking. Pressing Down again does nothing further.
+- [ ] Typing (or dictating, or pasting) ends the browse: the next Up starts
+  again from the most recent message, and the text now in the box is what
+  Down returns to.
+- [ ] Moving the cursor — clicking into a recalled message, arrowing
+  left/right — is **not** typing: it does not end the browse and does not
+  destroy the unsent draft.
+- [ ] In a multi-line draft, Up only recalls when the cursor is on the first
+  line and Down only when it is on the last line. Anywhere else they move the
+  cursor as usual.
+- [ ] Holding a modifier (Shift, Alt/Option, Ctrl, Cmd) never recalls — those
+  are selection and word/document navigation.
+- [ ] Pressing Up in a conversation with nothing sent yet does nothing.
+- [ ] Messages sent by a **chip** (e.g. "Refine Athens") are not in the
+  history — the traveler did not write them.
+- [ ] A message sent while an earlier turn is still answering (queued) is
+  recallable straight away.
+- [ ] History is per conversation: the Agent tab and a trip's chat each recall
+  their own messages.
+
+## API Surface
+
+None. No endpoint is added or changed.
+
+## Data Model
+
+None. History is the conversation that is already on screen, read backwards.
+
+## Out of Scope
+
+- **Text only.** Images attached to a recalled message do not come back —
+  Up recalls what you *wrote*, and silently re-attaching old photos on the way
+  to editing a sentence would be a surprise. (Stopping a turn *does* return
+  attachments; there the message was never sent to completion. See
+  `specs/chat-stop-undo`.)
+- **No history beyond the conversation.** Starting a new chat starts empty;
+  history is not carried across conversations or persisted separately. The
+  transcript is the only copy, which is also why a resumed conversation's
+  messages are recallable with no extra work.
+- **No search or numbered recall** (no Ctrl-R, no `!!`). Up and Down only.
+- **No duplicate collapsing.** Sending the same message twice puts it in the
+  history twice, because that is what happened.

--- a/specs/chat-stop-undo/plan.md
+++ b/specs/chat-stop-undo/plan.md
@@ -1,0 +1,140 @@
+# Plan: Stop Undoes the Turn
+
+> **HOW.** See `spec.md` for what and why, and `../../CLAUDE.md` for repo
+> conventions referenced below.
+
+## Technical Approach
+
+Two files, no new provider, no new endpoint. The pieces this needs already
+exist and were built for adjacent reasons:
+
+- `PlanNotifier` already owns the transcript and already knows how to roll a
+  user message back out of it — `retryLastSend` does exactly that so a retry
+  doesn't double-append. Stop now does the same rollback and simply doesn't
+  resend.
+- `ChatPanel` already owns the composer, and `chatDraftProvider` already
+  holds its text and attachments so they survive the panel being disposed.
+  Putting a message back is `_send` run backwards.
+
+The one new thing is the seam between them: **`stopStreaming()` returns the
+message it took out**, and the panel puts it where it belongs. A return value
+rather than a callback handed to the constructor (the shape
+`onProfileFieldsChanged` uses) because there is nothing asynchronous here —
+the panel calls stop and is the only caller — and because a plain result is
+what the zen rule asks of a mutating operation: *state the post-state the
+consumer will observe*.
+
+### Where the message goes back to — one rule
+
+The stopped message was at the head of the line of things waiting to be sent.
+It goes back to the head of that line:
+
+| Queue behind it | Goes back to | `stopStreaming()` returns |
+|---|---|---|
+| empty | the composer — the head of an empty line | the message |
+| non-empty | the front of `queuedMessages` | `null` |
+
+Handing it to the composer while messages sit in the queue would be the one
+genuinely wrong answer: the user would resend it and `sendMessage` would
+enqueue it at the *back*, so a message they sent second would be answered
+first. The queue is the existing UI for "waiting to be sent" (chips with
+remove buttons), so nothing new is needed to show it.
+
+### Seeded turns
+
+A `PlanMessage.displayLabel` means the content is a machine-written seed
+behind a short chip label — "Refine Athens", "Plan from scratch". The turn is
+undone like any other, but nothing goes to the composer: there is no composer
+form of a seed, and dumping several hundred words of generated prompt into
+the text box would be worse than the problem being solved. The chip that sent
+it is still on screen, which is its way back. `stopStreaming()` returns
+`null`, so the panel needs no knowledge of what a `displayLabel` means.
+
+## Go API Changes
+
+None.
+
+## Flutter Changes
+
+`src/packages/flutter-app/lib/`:
+
+- **`providers/plan_provider.dart`** — `stopStreaming()` changes from
+  `void` to `PlanMessage?`. It no longer commits the streamed partial as an
+  assistant message; instead it drops the partial, removes the trailing user
+  message, and routes that message per the table above. Unchanged: it
+  supersedes the turn (`_turn++`) before anything else so the dying stream's
+  tail is a no-op, ends the stream buffer before the state write so a pending
+  48 ms flush can't resurrect a ghost bubble, fires the transport abort, and
+  does **not** auto-drain the queue (stopping is not success).
+
+  Two guards worth naming:
+  - The trailing message is *checked* to be a user message rather than
+    assumed. It always is — `_sendNow` appends it before the first event and
+    nothing else appends while streaming — but if that ever stops holding,
+    leaving the transcript alone beats deleting somebody else's message.
+  - `compactedCount` is re-clamped to the shortened transcript. A compaction
+    that landed mid-turn can already have counted the message now leaving,
+    and a boundary past the end would make the next turn slice history past
+    its own end.
+
+- **`widgets/chat_panel.dart`** — new `_stop()`, the inverse of `_send()`,
+  wired to the existing `onStop`. Assigns `_controller.value` (never
+  `controller.text` — that setter parks the selection at −1 and the next
+  keystroke lands in *front* of the restored text; the same trap
+  `_restoreDraft` and `airport_field.dart` document), refills `_pending`,
+  saves the attachment half of the draft, and focuses the field. The text
+  half needs no explicit save: the controller's own listener mirrors it into
+  `chatDraftProvider`, exactly as when the user types.
+
+  Restoring wholesale is safe because the button is only a stop while the
+  composer is empty, so there is no draft to clobber.
+
+## Contract Parity
+
+Not applicable — no wire contract changes.
+
+## Testing
+
+- `test/plan_provider_stop_test.dart` (rewritten, 8 tests) — the rollback and
+  hand-back, the typing-indicator phase (stop before any text), idle/
+  double-tap, attachments riding back by identity, seeded turns returning
+  null, the queue going to the head with FIFO preserved through the next
+  send, exactly one copy in history after a resend, and the `compactedCount`
+  clamp.
+- `test/chat_panel_stop_button_test.dart` (extended, 5 tests) — the existing
+  send/stop swap tests plus: the bubble and partial leaving while the text
+  lands in the field with the caret at the end and focus, attachments coming
+  back as chips, and a seeded turn leaving the composer empty.
+
+Per `CLAUDE.md`, no test asserts anything font-dependent.
+
+## Known Gap — the server's copy
+
+`plan_handler.go` upserts the whole transcript at turn **start**, on a
+`context.Background()` with its own timeout, with the comment that a canceled
+stream must not cancel the write "because the user's message surviving a dead
+stream is the entire point of it." A deferred end-of-turn upsert follows with
+whatever text streamed. Both survive the client's abort by design.
+
+The client cannot undo either: `main.go` registers only
+`GET`/`DELETE /trips/{id}/refine-chat` and `GET`/`DELETE /chats/{chatId}`.
+There is no way to *write* a transcript except by running a turn.
+
+Consequence, and it is a real one: after a stop, the stored conversation still
+contains the stopped message (and any partial reply). The next successful turn
+sends the rolled-back history and the wholesale upsert overwrites it, so the
+window closes as soon as the traveler sends anything. It does **not** close on
+its own — a full app reload inside that window resurrects the message, and it
+can surface in the resumable-chats list.
+
+Scoped out deliberately rather than overlooked. Closing it means either:
+
+1. `PUT /chats/{chatId}` (and the trip-bound equivalent) so the client can
+   push a corrected transcript — the general fix, and the one that would also
+   let other client-side transcript edits persist; or
+2. a narrower `DELETE .../last-turn` that drops the trailing user message and
+   any assistant message after it — smaller surface, but a second way to say
+   "what the transcript is", which is the shape `docs/zen.md` warns about.
+
+(1) is the better shape. Neither is needed for the feature to be right in the
+session it happens in, which is where stop is used.

--- a/specs/chat-stop-undo/spec.md
+++ b/specs/chat-stop-undo/spec.md
@@ -1,0 +1,83 @@
+# Spec: Stop Undoes the Turn
+
+> **WHAT & WHY only.** See `plan.md` for the technical approach.
+
+## Context
+
+Stopping a reply almost always means the traveler wants to *change what they
+asked* — they hit send, watched the agent start answering the wrong question,
+and killed it. Until now stop left the mistake behind: the message stayed in
+the transcript with a truncated half-answer under it, and rephrasing meant
+retyping the sentence from scratch while the abandoned pair sat above it
+forever. The stop button was an emergency brake when what people reach for is
+an undo.
+
+This makes stop mean undo. The message comes out of the chat and goes back
+into the composer, cursor at the end, exactly as it was — so the next thing
+the traveler does is edit one word and send again.
+
+No new button, no new surface: the same stop control that already appears
+while a turn streams with an empty composer.
+
+## User Stories
+
+- As a **traveler**, when I stop a reply I want my message back in the text
+  box so I can fix a word and resend, instead of retyping it.
+- As a **traveler**, I want the stopped exchange to disappear from the chat,
+  so my transcript is the conversation I meant to have.
+- As a **traveler who attached photos**, I want them back on the composer too
+  — re-picking four images is worse than retyping a sentence.
+- As a **traveler**, I never want stopping to reorder my messages: anything I
+  sent after the stopped one must still be answered after it.
+
+## Acceptance Criteria
+
+- [ ] While a turn is streaming and the composer is empty, the send button is
+  a stop button (unchanged).
+- [ ] Tapping stop removes the stopped message's bubble from the chat, along
+  with whatever the agent had streamed so far. No truncated reply is left
+  behind and no error banner appears.
+- [ ] The stopped message's text appears in the composer, with the cursor at
+  the end and the field focused, so typing continues the sentence rather than
+  landing in front of it.
+- [ ] Images attached to the stopped message reappear as removable chips
+  above the composer.
+- [ ] Because the composer now holds a draft, the button reads as send again.
+- [ ] Sending the restored message puts exactly one copy of it in the
+  conversation — no duplicate of the stopped attempt.
+- [ ] If other messages were queued behind the stopped one, the stopped
+  message goes back to the **front of that queue** instead of the composer,
+  and the queue still runs oldest-first. Stopping never causes a later
+  message to be answered before an earlier one.
+- [ ] Stopping a turn started by a **chip** (e.g. "Refine Athens") removes the
+  chip from the chat and leaves the composer empty — the chip's text was
+  written by the app, not typed, and the chip itself is still there to tap.
+- [ ] Tapping stop when nothing is streaming does nothing — in particular it
+  never removes an already-finished exchange (covers a double-tap).
+- [ ] The agent stops generating server-side, rather than finishing the reply
+  into a closed connection.
+
+## API Surface
+
+None. No endpoint is added or changed.
+
+## Data Model
+
+None. The change is to which messages the client keeps, not to what a message
+is.
+
+## Out of Scope / Known Gap
+
+- **The server's copy of the transcript is not rewound.** A conversation is
+  saved server-side at the *start* of a turn, deliberately on a connection
+  that a client abort cannot cancel — that write is why an interrupted
+  message survives a dropped network at all. Nothing in the app can unwrite
+  it: a stored conversation can only be read or deleted wholesale. So until
+  the traveler's next successful turn (which overwrites the stored copy in
+  full), a **full app reload** — not navigating away and back, which keeps the
+  chat in memory — brings the stopped message back, and it can appear in
+  "continue where you left off" in the meantime. Closing it needs a way to
+  rewrite a stored conversation; see `plan.md` → Known Gap.
+- **No confirmation or undo-the-undo.** Stop is treated as deliberate. The
+  message is never lost — it is in the composer or the queue — so there is
+  nothing to confirm.

--- a/src/packages/flutter-app/lib/providers/plan_provider.dart
+++ b/src/packages/flutter-app/lib/providers/plan_provider.dart
@@ -835,20 +835,68 @@ class PlanNotifier extends StateNotifier<PlanState> {
         displayLabel: failed.displayLabel, attachments: failed.attachments);
   }
 
-  /// Stops the in-flight turn: commits whatever the model already streamed as
-  /// a normal assistant message (matching what the server persists — its
-  /// deferred transcript upsert survives the abort) and aborts the transport.
-  void stopStreaming() {
-    if (!state.isStreaming) return; // idle / double-tap: no-op
+  /// Stops the in-flight turn and **undoes** it: the half-streamed reply is
+  /// discarded and the user message that started the turn leaves the
+  /// transcript, going back to where it was in line. It was at the head of
+  /// that line, so it returns to the head — pushed onto the front of
+  /// [PlanState.queuedMessages] when other messages are already waiting behind
+  /// it, and otherwise handed back here for the composer, which is what the
+  /// head of an empty line is. Either way it can never end up behind a message
+  /// that was sent after it.
+  ///
+  /// Post-state the caller will observe: `isStreaming` false, `streamingText`
+  /// null, no new assistant message, and a transcript identical to the one
+  /// before the stopped turn was sent. The transport is aborted, so the server
+  /// stops generating rather than streaming to a dead client.
+  ///
+  /// Returns the message for the composer to put back, or null when there is
+  /// nothing for it to put back — an idle notifier (double-tap), a turn that
+  /// went back to the queue instead, or a chip-seeded turn. A
+  /// [PlanMessage.displayLabel] means the text is a machine-written seed the
+  /// user never typed (a "Refine Athens" chip), so it has no composer form;
+  /// undoing it puts the chip back within reach, which is its way back.
+  ///
+  /// One thing this cannot undo: the server's own copy. `plan_handler.go`
+  /// upserts the transcript at turn START on a background context, precisely
+  /// so a client abort cannot cancel it, and the API exposes only GET and
+  /// DELETE for a stored transcript — nothing here can rewrite it. The next
+  /// successful turn's wholesale upsert overwrites it; until then a full app
+  /// reload resurrects the stopped message. See specs/chat-stop-undo/plan.md.
+  PlanMessage? stopStreaming() {
+    if (!state.isStreaming) return null; // idle / double-tap: no-op
     // Supersede FIRST: the abort surfaces in _sendNow as a stream teardown,
-    // and the turn guards must make it a no-op — never a second commit or an
-    // error banner.
+    // and the turn guards must make it a no-op — never a late commit or an
+    // error banner writing into the transcript we are about to roll back.
     _turn++;
-    // Read before _endStreamBuffer nulls the buffer; using the buffer (not
-    // state.streamingText) captures the un-flushed 48ms coalescing tail,
-    // exactly like the error-path commit.
-    final partial = _streamBuffer?.toString() ?? '';
+    // The partial is deliberately dropped, not read: undoing the turn means
+    // the reply goes too. Ending the buffer before the state write keeps a
+    // pending 48ms flush from resurrecting a ghost streaming bubble.
     _endStreamBuffer();
+
+    // The turn's own user message is the transcript tail — _sendNow appends it
+    // before the first event and nothing else appends while streaming (the
+    // assistant text commits only at turn end). Checked rather than assumed:
+    // if that ever stops holding, leaving the transcript alone beats deleting
+    // somebody else's message.
+    final messages = state.messages;
+    final sent = messages.isNotEmpty && messages.last.role == MessageRole.user
+        ? messages.last
+        : null;
+    final rolledBack =
+        sent == null ? messages : messages.sublist(0, messages.length - 1);
+
+    // A compaction that landed mid-turn can already have counted the message
+    // now leaving: the summary must never claim to cover more than remains.
+    final compacted = state.compactedCount.clamp(0, rolledBack.length);
+
+    final requeued = sent != null && state.queuedMessages.isNotEmpty
+        ? QueuedMessage(
+            id: _nextQueuedId++,
+            text: sent.content,
+            displayLabel: sent.displayLabel,
+            attachments: sent.attachments)
+        : null;
+
     state = state.copyWith(
       isStreaming: false,
       streamingText: null,
@@ -856,16 +904,20 @@ class PlanNotifier extends StateNotifier<PlanState> {
       isCompacting: false,
       isThinking: false,
       suggestedReplies: [],
-      messages: partial.isEmpty
-          ? state.messages
-          : [
-              ...state.messages,
-              PlanMessage(role: MessageRole.assistant, content: partial),
-            ],
+      messages: rolledBack,
+      compactedCount: compacted,
+      queuedMessages: requeued == null
+          ? state.queuedMessages
+          : [requeued, ...state.queuedMessages],
     );
-    // Queue stays put (same as post-error): stopping is not "success", and
-    // auto-draining would immediately start a turn the user just killed.
+    // No auto-drain (same as post-error): stopping is not "success", and
+    // draining would immediately start a turn the user just killed.
     _abortInFlight();
+
+    if (requeued != null || sent == null || sent.displayLabel != null) {
+      return null;
+    }
+    return sent;
   }
 
   void reset() {

--- a/src/packages/flutter-app/lib/widgets/chat_panel.dart
+++ b/src/packages/flutter-app/lib/widgets/chat_panel.dart
@@ -5,6 +5,13 @@ import 'package:desktop_drop/desktop_drop.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart' show ScrollDirection;
+import 'package:flutter/services.dart'
+    show
+        HardwareKeyboard,
+        KeyDownEvent,
+        KeyEvent,
+        KeyRepeatEvent,
+        LogicalKeyboardKey;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:gpt_markdown/gpt_markdown.dart';
 import '../l10n/l10n.dart';
@@ -157,6 +164,21 @@ class _ChatPanelState extends ConsumerState<ChatPanel> {
   /// Whether a drag hovers over the panel — drives the drop overlay.
   bool _dragging = false;
 
+  /// Where Up/Down have walked back to in [_sentHistory], newest first.
+  /// **-1 means not browsing** — the composer holds the user's own words.
+  /// Typing resets it (see [_saveDraft]), so the next Up always starts from
+  /// the most recent message.
+  int _historyIndex = -1;
+
+  /// True only while [_recallHistory] writes [_controller], so [_saveDraft]
+  /// can tell a browse step from the user actually typing.
+  bool _recalling = false;
+
+  /// The text the composer last held. [_saveDraft] compares against it so a
+  /// caret move — which notifies identically to a keystroke — is not mistaken
+  /// for an edit.
+  String _composerText = '';
+
   static const _maxAttachments = 4;
 
   @override
@@ -166,6 +188,13 @@ class _ChatPanelState extends ConsumerState<ChatPanel> {
     // host ever swaps the notifier it passes.
     _draftKey = chatDraftKeyFor(ref.read(widget.notifier).tripId);
     _restoreDraft();
+    // On the field's OWN node, not a Focus above it: an ancestor handler sits
+    // above the focused node in the bubble chain and never sees arrow keys
+    // while a text field has focus (konami_listener.dart explains the same
+    // trap from the other side). The focused node is dispatched first, so this
+    // also gets Up/Down before DefaultTextEditingShortcuts near the root — and
+    // declining leaves that default caret movement completely untouched.
+    _inputFocus.onKeyEvent = (_, event) => _onComposerKey(event);
     _dictation = ref.read(dictationControllerFactoryProvider)(_controller);
     _dictation.addListener(_onDictationChanged);
     // Paste-from-clipboard (web only): focus-gated so exactly one mounted
@@ -194,6 +223,7 @@ class _ChatPanelState extends ConsumerState<ChatPanel> {
       selection: TextSelection.collapsed(offset: draft.text.length),
     );
     _pending.addAll(draft.attachments);
+    _composerText = draft.text;
     // After the seed, so restoring cannot echo back into the draft it read.
     _controller.addListener(_saveDraft);
   }
@@ -203,9 +233,29 @@ class _ChatPanelState extends ConsumerState<ChatPanel> {
   /// the trip body re-inflating when it opens or crosses the docked width —
   /// and by the time `dispose` runs the element is already unmounted, so `ref`
   /// throws there.
-  void _saveDraft() => ref
-      .read(chatDraftProvider(_draftKey).notifier)
-      .setText(_controller.text);
+  ///
+  /// Also the one place that can tell the user typed something, which is what
+  /// ends a history browse — every other write to [_controller] announces
+  /// itself with [_recalling].
+  void _saveDraft() {
+    final text = _controller.text;
+    // A [TextEditingController] notifies for a caret move exactly as it does
+    // for a keystroke, and clicking into a recalled message to edit it is an
+    // ordinary thing to do. Treating that as typing would end the browse and
+    // overwrite the stash with the message being browsed — losing the draft
+    // the user was actually writing.
+    if (text == _composerText) return;
+    _composerText = text;
+    // A browse step must not overwrite the kept draft either: while browsing,
+    // the draft IS the stash of what the user was composing, and holding it
+    // there rather than in a second field is what lets Down walk back to it.
+    if (_recalling) return;
+    // A keystroke, a dictated phrase, a paste — whatever it was, the composer
+    // holds the user's own words again, so browsing is over and these are the
+    // words to keep.
+    _historyIndex = -1;
+    ref.read(chatDraftProvider(_draftKey).notifier).setText(text);
+  }
 
   /// The attachment half. Separate from [_saveDraft] because the two are
   /// edited by different gestures and the list write copies.
@@ -282,6 +332,131 @@ class _ChatPanelState extends ConsumerState<ChatPanel> {
     ref.read(widget.notifier).sendMessage(text, attachments: attachments);
     _stickToBottom = true;
     _scrollToBottom();
+  }
+
+  /// The inverse of [_send]. The notifier rolls the in-flight turn out of the
+  /// transcript and hands back the message that started it; it goes into the
+  /// composer exactly as it left — same text, same attachments, caret at the
+  /// end, focus back in the field — so the thing the user stopped to change is
+  /// already there to change.
+  ///
+  /// A null hand-back still stopped the turn; it means there is nothing for
+  /// the composer to take (a chip-seeded turn, or one that went back to the
+  /// queue). See [PlanNotifier.stopStreaming] for which is which.
+  void _stop() {
+    final restored = ref.read(widget.notifier).stopStreaming();
+    if (restored == null) return;
+    // Never assign `controller.text` — that setter parks the selection at -1
+    // and the next keystroke lands in front of the restored text (see
+    // [_restoreDraft]). The controller's own listener mirrors this into the
+    // kept draft, so as in [_send] only the attachment half is said twice.
+    _controller.value = TextEditingValue(
+      text: restored.content,
+      selection: TextSelection.collapsed(offset: restored.content.length),
+    );
+    // Taken wholesale: the button is a Stop only while the composer is empty,
+    // and an in-flight message's attachments are the real bytes the composer
+    // handed over a moment ago — resume placeholders (null `bytes`) only ever
+    // belong to messages that were already sent.
+    setState(() {
+      _pending
+        ..clear()
+        ..addAll(restored.attachments);
+    });
+    _saveDraftAttachments();
+    _inputFocus.requestFocus();
+  }
+
+  /// What Up walks back through: every message the user actually typed and
+  /// sent in this chat, oldest first. Read fresh each keystroke rather than
+  /// cached — the transcript is the only copy, and a second one would drift
+  /// the moment a turn lands, is resumed, or is undone by [_stop].
+  ///
+  /// Two exclusions. Chip-seeded turns ([PlanMessage.displayLabel]) are the
+  /// app's words, not the user's — recalling several hundred words of
+  /// generated seed is not what Up is for. Assistant messages, obviously.
+  /// Queued messages ARE included: they were sent, they are only waiting.
+  List<String> _sentHistory() {
+    final chat = ref.read(widget.state);
+    return [
+      for (final m in chat.messages)
+        if (m.role == MessageRole.user && m.displayLabel == null) m.content,
+      for (final q in chat.queuedMessages)
+        if (q.displayLabel == null) q.text,
+    ];
+  }
+
+  /// Steps [delta] entries back (+1, Up) or forward (-1, Down) through
+  /// [_sentHistory]. Returns false when there is nowhere left to go, so the
+  /// key falls through to its ordinary caret movement instead of dead-ending.
+  ///
+  /// Text only: attachments stay where they were. Up recalls what you *wrote*,
+  /// and silently re-attaching photos from an old message would be a surprise
+  /// on the way to editing a sentence.
+  bool _recallHistory(int delta) {
+    final history = _sentHistory();
+    if (history.isEmpty) return false;
+    final next = _historyIndex + delta;
+    // -1 is a real destination (back to the draft); past either end is not.
+    if (next < -1 || next >= history.length) return false;
+
+    // Leaving history: the kept draft was never overwritten while browsing
+    // (see [_saveDraft]), so what the user was composing is still exactly
+    // there — no separate stash to keep in sync.
+    final text = next == -1
+        ? ref.read(chatDraftProvider(_draftKey)).text
+        : history[history.length - 1 - next];
+
+    _historyIndex = next;
+    _recalling = true;
+    // Never assign `controller.text` — see [_restoreDraft] for why. Caret at
+    // the end so editing a recalled message continues it.
+    _controller.value = TextEditingValue(
+      text: text,
+      selection: TextSelection.collapsed(offset: text.length),
+    );
+    _recalling = false;
+    return true;
+  }
+
+  /// Up/Down in the composer recall history, shell-style — but only from the
+  /// edge of the text, so a multi-line draft still moves the caret by line the
+  /// way every other text field does. Declining (`ignored`) is what leaves
+  /// that default behaviour in place.
+  KeyEventResult _onComposerKey(KeyEvent event) {
+    if (event is! KeyDownEvent && event is! KeyRepeatEvent) {
+      return KeyEventResult.ignored;
+    }
+    final up = event.logicalKey == LogicalKeyboardKey.arrowUp;
+    if (!up && event.logicalKey != LogicalKeyboardKey.arrowDown) {
+      return KeyEventResult.ignored;
+    }
+    // Any modifier makes this a different gesture — Shift extends a selection,
+    // Alt/Ctrl/Meta jump by word or to the ends — and none of them mean
+    // "history".
+    final keys = HardwareKeyboard.instance;
+    if (keys.isShiftPressed ||
+        keys.isControlPressed ||
+        keys.isAltPressed ||
+        keys.isMetaPressed) {
+      return KeyEventResult.ignored;
+    }
+
+    final selection = _controller.selection;
+    if (!selection.isValid || !selection.isCollapsed) {
+      return KeyEventResult.ignored;
+    }
+    // First line for Up, last line for Down: mid-draft the arrows are the
+    // user navigating their own text, not asking for history.
+    final text = _controller.text;
+    final onEdgeLine = up
+        ? !text.substring(0, selection.baseOffset).contains('\n')
+        : !text.substring(selection.baseOffset).contains('\n');
+    if (!onEdgeLine) return KeyEventResult.ignored;
+
+    return _recallHistory(up ? 1 : -1)
+        ? KeyEventResult.handled
+        : KeyEventResult.ignored;
   }
 
   void _notify(String message) {
@@ -436,7 +611,7 @@ class _ChatPanelState extends ConsumerState<ChatPanel> {
             hint: widget.inputHint ?? context.l10n.chatInputHint,
             shortHint: widget.shortInputHint ?? context.l10n.chatInputHintShort,
             onSend: _send,
-            onStop: () => ref.read(widget.notifier).stopStreaming(),
+            onStop: _stop,
             hasDraftAttachments: _pending.isNotEmpty || _processingCount > 0,
             onAttach: _pickImages,
             dictation: _dictation,

--- a/src/packages/flutter-app/test/chat_panel_history_recall_test.dart
+++ b/src/packages/flutter-app/test/chat_panel_history_recall_test.dart
@@ -1,0 +1,323 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:travel_route_planner/providers/plan_provider.dart';
+import 'package:travel_route_planner/services/api_client.dart';
+import 'package:travel_route_planner/services/plan_service.dart';
+import 'package:travel_route_planner/widgets/chat_panel.dart';
+
+import 'support/l10n_test_app.dart';
+
+/// Shell-style history recall in the composer: Up walks back through what the
+/// user has sent in this chat, Down walks forward and finally back to the
+/// draft they were part-way through writing. Only from the edge of the text,
+/// so a multi-line draft still navigates by line.
+
+/// Answers every turn instantly, so messages land in the transcript (which is
+/// the history) without a test having to drive a stream.
+class _InstantPlanService extends PlanService {
+  _InstantPlanService() : super('http://unused');
+
+  @override
+  Stream<PlanEvent> streamPlan(
+    List<Map<String, dynamic>> messages, {
+    String? bearerToken,
+    String? chatId,
+    String? tripId,
+    String? summary,
+    Future<void>? abortTrigger,
+  }) async* {
+    yield const PlanEvent(type: 'text_delta', data: {'text': 'ok'});
+  }
+}
+
+/// Parks every turn, so a test can leave messages sitting in the queue.
+class _ParkedPlanService extends PlanService {
+  final gate = Completer<void>();
+
+  _ParkedPlanService() : super('http://unused');
+
+  @override
+  Stream<PlanEvent> streamPlan(
+    List<Map<String, dynamic>> messages, {
+    String? bearerToken,
+    String? chatId,
+    String? tripId,
+    String? summary,
+    Future<void>? abortTrigger,
+  }) async* {
+    await gate.future;
+  }
+}
+
+Future<PlanNotifier> _pumpPanel(WidgetTester tester, PlanService service) async {
+  final notifier = PlanNotifier(service, ApiClient());
+  final provider =
+      StateNotifierProvider<PlanNotifier, PlanState>((ref) => notifier);
+  await tester.pumpWidget(
+    ProviderScope(
+      child: MaterialApp(
+        localizationsDelegates: testLocalizationsDelegates,
+        home: Scaffold(
+          body: ChatPanel(state: provider, notifier: provider.notifier),
+        ),
+      ),
+    ),
+  );
+  return notifier;
+}
+
+TextEditingController _controller(WidgetTester tester) =>
+    tester.widget<TextField>(find.byType(TextField)).controller!;
+
+String _text(WidgetTester tester) => _controller(tester).text;
+
+/// Types [text] and sends it, leaving the composer focused and empty.
+Future<void> _send(WidgetTester tester, String text) async {
+  await tester.enterText(find.byType(TextField), text);
+  await tester.pump();
+  await tester.tap(find.byIcon(Icons.send));
+  await tester.pumpAndSettle();
+}
+
+Future<void> _press(WidgetTester tester, LogicalKeyboardKey key) async {
+  await tester.sendKeyEvent(key);
+  await tester.pump();
+}
+
+Future<void> _up(WidgetTester tester) =>
+    _press(tester, LogicalKeyboardKey.arrowUp);
+Future<void> _down(WidgetTester tester) =>
+    _press(tester, LogicalKeyboardKey.arrowDown);
+
+void main() {
+  testWidgets('up walks back through sent messages and stops at the oldest',
+      (WidgetTester tester) async {
+    await _pumpPanel(tester, _InstantPlanService());
+
+    await _send(tester, 'first');
+    await _send(tester, 'second');
+    await _send(tester, 'third');
+    expect(_text(tester), isEmpty);
+
+    await _up(tester);
+    expect(_text(tester), 'third', reason: 'newest first');
+    await _up(tester);
+    expect(_text(tester), 'second');
+    await _up(tester);
+    expect(_text(tester), 'first');
+
+    // Nowhere further back: the key falls through rather than dead-ending.
+    await _up(tester);
+    expect(_text(tester), 'first');
+  });
+
+  testWidgets('the caret lands at the end, so editing continues the message',
+      (WidgetTester tester) async {
+    await _pumpPanel(tester, _InstantPlanService());
+    await _send(tester, 'move Xplore Fitness to wednesday');
+
+    await _up(tester);
+
+    expect(_text(tester), 'move Xplore Fitness to wednesday');
+    expect(_controller(tester).selection.baseOffset,
+        'move Xplore Fitness to wednesday'.length);
+  });
+
+  testWidgets('down walks forward and back to the half-written draft',
+      (WidgetTester tester) async {
+    await _pumpPanel(tester, _InstantPlanService());
+    await _send(tester, 'first');
+    await _send(tester, 'second');
+
+    // Part-way through a new message when they reach for history.
+    await tester.enterText(find.byType(TextField), 'half-writ');
+    await tester.pump();
+
+    await _up(tester);
+    expect(_text(tester), 'second');
+    await _up(tester);
+    expect(_text(tester), 'first');
+    await _down(tester);
+    expect(_text(tester), 'second');
+
+    // Past the newest is the draft they were writing — never lost.
+    await _down(tester);
+    expect(_text(tester), 'half-writ');
+
+    // And no further.
+    await _down(tester);
+    expect(_text(tester), 'half-writ');
+  });
+
+  testWidgets('typing ends the browse; the next up starts from the newest',
+      (WidgetTester tester) async {
+    await _pumpPanel(tester, _InstantPlanService());
+    await _send(tester, 'first');
+    await _send(tester, 'second');
+
+    await _up(tester);
+    await _up(tester);
+    expect(_text(tester), 'first');
+
+    // Editing a recalled message makes it the draft.
+    await tester.enterText(find.byType(TextField), 'first, but in autumn');
+    await tester.pump();
+
+    await _up(tester);
+    expect(_text(tester), 'second', reason: 'browse restarted from the newest');
+    await _down(tester);
+    expect(_text(tester), 'first, but in autumn', reason: 'the edit is the draft');
+  });
+
+  testWidgets('a caret move is not an edit and keeps the browse alive',
+      (WidgetTester tester) async {
+    await _pumpPanel(tester, _InstantPlanService());
+    await _send(tester, 'first');
+    await _send(tester, 'second');
+
+    await tester.enterText(find.byType(TextField), 'half-writ');
+    await tester.pump();
+    await _up(tester);
+    expect(_text(tester), 'second');
+
+    // Clicking into a recalled message to edit it notifies the controller
+    // exactly as a keystroke does. It must not eat the stash.
+    _controller(tester).selection = const TextSelection.collapsed(offset: 3);
+    await tester.pump();
+
+    await _down(tester);
+    expect(_text(tester), 'half-writ');
+  });
+
+  testWidgets('up only recalls from the first line of a multi-line draft',
+      (WidgetTester tester) async {
+    await _pumpPanel(tester, _InstantPlanService());
+    await _send(tester, 'first');
+
+    await tester.enterText(find.byType(TextField), 'line one\nline two');
+    await tester.pump();
+    // enterText leaves the caret at the end — on the last line.
+    expect(_controller(tester).selection.baseOffset, 17);
+
+    // Caret sits on the last line: Up belongs to the caret, not to history.
+    await _up(tester);
+    expect(_text(tester), 'line one\nline two');
+    // And declining really does leave the default behaviour intact — the
+    // caret moved up a line rather than the key being swallowed.
+    expect(_controller(tester).selection.baseOffset, lessThan(9),
+        reason: 'caret should have moved onto line one');
+
+    // On the first line it recalls.
+    _controller(tester).selection = const TextSelection.collapsed(offset: 2);
+    await tester.pump();
+    await _up(tester);
+    expect(_text(tester), 'first');
+  });
+
+  testWidgets('down only recalls from the last line of a multi-line draft',
+      (WidgetTester tester) async {
+    await _pumpPanel(tester, _InstantPlanService());
+    await _send(tester, 'first');
+
+    await tester.enterText(find.byType(TextField), 'line one\nline two');
+    await tester.pump();
+    _controller(tester).selection = const TextSelection.collapsed(offset: 2);
+    await tester.pump();
+
+    await _up(tester);
+    expect(_text(tester), 'first');
+
+    // Back to a multi-line draft, caret on the FIRST line: Down moves it.
+    await _down(tester);
+    expect(_text(tester), 'line one\nline two');
+    _controller(tester).selection = const TextSelection.collapsed(offset: 2);
+    await tester.pump();
+    await _down(tester);
+    expect(_text(tester), 'line one\nline two', reason: 'caret moved instead');
+  });
+
+  testWidgets('a modifier makes it a different gesture, never a recall',
+      (WidgetTester tester) async {
+    await _pumpPanel(tester, _InstantPlanService());
+    await _send(tester, 'first');
+
+    // Set up the exact state a bare Up WOULD recall from, so the only thing
+    // under test is the modifier.
+    await tester.enterText(find.byType(TextField), 'draft');
+    await tester.pump();
+
+    for (final modifier in [
+      LogicalKeyboardKey.shiftLeft, // extends a selection
+      LogicalKeyboardKey.altLeft, // moves by word / paragraph
+      LogicalKeyboardKey.metaLeft, // jumps to the start of the document
+    ]) {
+      await tester.sendKeyDownEvent(modifier);
+      await _up(tester);
+      await tester.sendKeyUpEvent(modifier);
+      expect(_text(tester), 'draft', reason: '${modifier.keyLabel}+up recalled');
+    }
+
+    // The same keystroke without one does recall — so it really is the
+    // modifier doing the work above, not some other guard.
+    await _up(tester);
+    expect(_text(tester), 'first');
+  });
+
+  testWidgets('up on an empty chat does nothing', (WidgetTester tester) async {
+    await _pumpPanel(tester, _InstantPlanService());
+    await tester.tap(find.byType(TextField));
+    await tester.pump();
+
+    await _up(tester);
+    expect(_text(tester), isEmpty);
+  });
+
+  testWidgets('chip-seeded turns are not in history',
+      (WidgetTester tester) async {
+    final notifier = await _pumpPanel(tester, _InstantPlanService());
+
+    await _send(tester, 'typed this');
+    // What a "Refine Athens" chip sends: the app's words, not the user's.
+    await notifier.sendMessage('<long machine-written seed prompt>',
+        displayLabel: 'Refine Athens');
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byType(TextField));
+    await tester.pump();
+    await _up(tester);
+    expect(_text(tester), 'typed this');
+
+    // The seed is not one step further back either — it is not in the list.
+    await _up(tester);
+    expect(_text(tester), 'typed this');
+  });
+
+  testWidgets('a queued message is recallable before it has been answered',
+      (WidgetTester tester) async {
+    final service = _ParkedPlanService();
+    await _pumpPanel(tester, service);
+
+    // First turn parks; the second message queues behind it.
+    await tester.enterText(find.byType(TextField), 'streaming one');
+    await tester.pump();
+    await tester.tap(find.byIcon(Icons.send));
+    await tester.pump();
+    await tester.enterText(find.byType(TextField), 'queued two');
+    await tester.pump();
+    await tester.tap(find.byIcon(Icons.send));
+    await tester.pump();
+
+    await _up(tester);
+    expect(_text(tester), 'queued two', reason: 'sent, just waiting its turn');
+    await _up(tester);
+    expect(_text(tester), 'streaming one');
+
+    service.gate.complete();
+    await tester.pumpAndSettle();
+  });
+}

--- a/src/packages/flutter-app/test/chat_panel_stop_button_test.dart
+++ b/src/packages/flutter-app/test/chat_panel_stop_button_test.dart
@@ -1,20 +1,24 @@
 import 'dart:async';
+import 'dart:convert';
+import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import 'package:travel_route_planner/models/plan_message.dart';
 import 'package:travel_route_planner/providers/plan_provider.dart';
 import 'package:travel_route_planner/services/api_client.dart';
+import 'package:travel_route_planner/services/image_attachment_pipeline.dart';
 import 'package:travel_route_planner/services/plan_service.dart';
 import 'package:travel_route_planner/widgets/chat_panel.dart';
 
 import 'support/l10n_test_app.dart';
 
 /// Contextual send/stop swap: while a turn streams with nothing drafted the
-/// send button becomes a stop button; typing a follow-up flips it back to
-/// send so queue-ahead keeps working; tapping stop commits the partial reply
-/// as a normal bubble and reverts the button.
+/// send button becomes a stop button; typing a follow-up flips it back to send
+/// so queue-ahead keeps working. Tapping stop UNDOES the turn — the message
+/// leaves the chat and lands back in the composer, ready to edit and resend.
 
 /// Plays [script] in order: [PlanEvent]s are yielded, [Completer]s are
 /// awaited — so a test can park the stream mid-turn and observe the UI.
@@ -42,7 +46,26 @@ class _StagedPlanService extends PlanService {
   }
 }
 
-Future<void> _pumpPanel(WidgetTester tester, _StagedPlanService service) async {
+/// A 1×1 PNG — real bytes for Image.memory to render in a chip.
+final _tinyPng = base64Decode(
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==');
+
+/// Echoes bytes through unchanged — engine image decoding can't complete
+/// inside a widget test's fake-async zone (see chat_panel_attachments_test).
+class _EchoPipeline extends ImageAttachmentPipeline {
+  const _EchoPipeline();
+
+  @override
+  Future<PlanAttachment?> process(Uint8List bytes, String mediaType) async =>
+      PlanAttachment(bytes: bytes, mediaType: mediaType);
+}
+
+/// Files the next paperclip tap will "pick".
+List<(Uint8List, String)> _nextPick = [];
+
+Future<PlanNotifier> _pumpPanel(
+    WidgetTester tester, _StagedPlanService service) async {
+  _nextPick = [];
   final notifier = PlanNotifier(service, ApiClient());
   final provider =
       StateNotifierProvider<PlanNotifier, PlanState>((ref) => notifier);
@@ -51,19 +74,28 @@ Future<void> _pumpPanel(WidgetTester tester, _StagedPlanService service) async {
       child: MaterialApp(
         localizationsDelegates: testLocalizationsDelegates,
         home: Scaffold(
-          body: ChatPanel(state: provider, notifier: provider.notifier),
+          body: ChatPanel(
+            state: provider,
+            notifier: provider.notifier,
+            attachmentPipeline: const _EchoPipeline(),
+            pickImages: () async => _nextPick,
+          ),
         ),
       ),
     ),
   );
+  return notifier;
 }
 
-Future<void> _send(WidgetTester tester) async {
-  await tester.enterText(find.byType(TextField), 'hi');
+Future<void> _send(WidgetTester tester, [String text = 'hi']) async {
+  await tester.enterText(find.byType(TextField), text);
   await tester.pump();
   await tester.tap(find.byIcon(Icons.send));
   await tester.pump();
 }
+
+TextField _field(WidgetTester tester) =>
+    tester.widget<TextField>(find.byType(TextField));
 
 void main() {
   testWidgets('idle shows send; streaming with an empty composer shows stop',
@@ -115,30 +147,95 @@ void main() {
     await tester.pumpAndSettle();
   });
 
-  testWidgets('tapping stop commits the partial bubble and reverts the button',
+  testWidgets('stop takes the message out of the chat and back to the composer',
       (WidgetTester tester) async {
     final gate = Completer<void>();
     final service = _StagedPlanService([
       const PlanEvent(type: 'text_delta', data: {'text': 'Hello there'}),
       gate,
     ]);
-    await _pumpPanel(tester, service);
+    final notifier = await _pumpPanel(tester, service);
 
-    await _send(tester);
+    await _send(tester, 'move Xplore Fitness to thursday');
     // Let the 48ms flush render the live streaming bubble first.
     await tester.pump(const Duration(milliseconds: 60));
+    expect(find.text('move Xplore Fitness to thursday'), findsOneWidget);
     expect(find.text('Hello there'), findsOneWidget);
 
     await tester.tap(find.byIcon(Icons.stop));
     await tester.pump();
 
-    // The partial survives as a committed assistant bubble — no error banner,
-    // no ghost streaming bubble later.
-    expect(find.text('Hello there'), findsOneWidget);
+    // Both halves of the turn leave the transcript: the user bubble and the
+    // half-streamed reply the old contract used to commit.
+    expect(notifier.state.messages, isEmpty);
+    expect(find.text('Hello there'), findsNothing);
+
+    // The words are back in the text box — the one place they now live, so
+    // finding them still finds exactly one widget (the TextField's own text).
+    expect(_field(tester).controller!.text, 'move Xplore Fitness to thursday');
+    expect(find.text('move Xplore Fitness to thursday'), findsOneWidget);
+
+    // Ready to edit: caret parked at the END (assigning `controller.text`
+    // instead would leave it at -1 and the next keystroke would land in
+    // front), and the field has focus so typing goes straight in.
+    expect(_field(tester).controller!.selection.baseOffset,
+        'move Xplore Fitness to thursday'.length);
+    expect(_field(tester).focusNode!.hasFocus, isTrue);
+
+    // A restored draft is a draft: the button is a Send again, not a Stop.
     expect(find.byIcon(Icons.send), findsOneWidget);
     expect(find.byIcon(Icons.stop), findsNothing);
+
+    // No ghost streaming bubble once the late flush timer fires.
     await tester.pump(const Duration(milliseconds: 80));
-    expect(find.text('Hello there'), findsOneWidget);
+    expect(find.text('Hello there'), findsNothing);
+    await tester.pumpAndSettle();
+  });
+
+  testWidgets('stop brings attached images back as pending chips',
+      (WidgetTester tester) async {
+    final gate = Completer<void>();
+    final service = _StagedPlanService([gate]);
+    final notifier = await _pumpPanel(tester, service);
+
+    _nextPick = [(_tinyPng, 'image/png')];
+    await tester.tap(find.byIcon(Icons.attach_file));
+    await tester.pumpAndSettle();
+    expect(find.byType(Image), findsOneWidget, reason: 'pending chip');
+
+    await _send(tester, 'what is this?');
+    expect(notifier.state.messages.single.attachments, hasLength(1));
+
+    await tester.tap(find.byIcon(Icons.stop));
+    await tester.pumpAndSettle();
+
+    // Re-picking four photos is worse than retyping a sentence, so the image
+    // comes back with the text rather than being dropped on the floor.
+    expect(notifier.state.messages, isEmpty);
+    expect(_field(tester).controller!.text, 'what is this?');
+    expect(find.byType(Image), findsOneWidget, reason: 'chip, not a bubble');
+  });
+
+  testWidgets('stopping a chip-seeded turn leaves the composer empty',
+      (WidgetTester tester) async {
+    final gate = Completer<void>();
+    final service = _StagedPlanService([gate]);
+    final notifier = await _pumpPanel(tester, service);
+
+    // What a "Refine Athens" chip sends: a machine-written seed behind a short
+    // label. Nobody typed it, so nothing belongs in the text box.
+    unawaited(notifier.sendMessage('<long machine-written seed prompt>',
+        displayLabel: 'Refine Athens'));
+    await tester.pump();
+    expect(find.text('Refine Athens'), findsOneWidget);
+
+    await tester.tap(find.byIcon(Icons.stop));
+    await tester.pump();
+
+    expect(notifier.state.messages, isEmpty);
+    expect(find.text('Refine Athens'), findsNothing);
+    expect(_field(tester).controller!.text, isEmpty);
+    expect(find.text('<long machine-written seed prompt>'), findsNothing);
     await tester.pumpAndSettle();
   });
 }

--- a/src/packages/flutter-app/test/plan_provider_stop_test.dart
+++ b/src/packages/flutter-app/test/plan_provider_stop_test.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:travel_route_planner/models/plan_message.dart';
@@ -6,9 +7,12 @@ import 'package:travel_route_planner/providers/plan_provider.dart';
 import 'package:travel_route_planner/services/api_client.dart';
 import 'package:travel_route_planner/services/plan_service.dart';
 
-/// stopStreaming(): commits whatever streamed so far as a normal assistant
-/// message, fires the transport abort trigger, and supersedes the turn so any
-/// tail from the dying stream (late events, teardown) touches nothing.
+/// stopStreaming() undoes the in-flight turn: the half-streamed reply is
+/// dropped, the user message that started it leaves the transcript, and it
+/// goes back to where it was in line — returned for the composer, or onto the
+/// FRONT of the queue when other messages are already waiting behind it. The
+/// transport is aborted and the turn superseded, so any tail from the dying
+/// stream touches nothing.
 
 /// Plays [script] in order — [PlanEvent]s yield, [Completer]s park the stream
 /// — and records the abort trigger each turn hands to the transport.
@@ -39,7 +43,7 @@ class _StagedPlanService extends PlanService {
 }
 
 void main() {
-  test('stop mid-stream commits the partial, aborts, and ignores the tail',
+  test('stop mid-stream undoes the turn, hands the text back, and aborts',
       () async {
     final gate = Completer<void>();
     final service = _StagedPlanService([
@@ -56,23 +60,24 @@ void main() {
     await Future<void>.delayed(const Duration(milliseconds: 5));
     expect(notifier.state.isStreaming, isTrue);
 
-    notifier.stopStreaming();
+    final restored = notifier.stopStreaming();
 
-    // The un-flushed buffer (not state.streamingText) is what commits — the
-    // 48ms coalescing tail must not be lost.
+    // Handed back verbatim, for the composer to put in the text box.
+    expect(restored?.content, 'plan athens');
+    expect(restored?.role, MessageRole.user);
+    // Both halves of the turn are gone: the user message AND the partial the
+    // old contract used to commit as an assistant bubble.
+    expect(notifier.state.messages, isEmpty);
     expect(notifier.state.isStreaming, isFalse);
     expect(notifier.state.streamingText, isNull);
     expect(notifier.state.error, isNull);
-    expect(notifier.state.messages.last.role, MessageRole.assistant);
-    expect(notifier.state.messages.last.content, 'Half an ans');
     await Future<void>.delayed(Duration.zero);
     expect(service.aborted, isTrue);
 
     // Release the parked stream: the superseded turn must change nothing.
     gate.complete();
     await send;
-    expect(notifier.state.messages.length, 2);
-    expect(notifier.state.messages.last.content, 'Half an ans');
+    expect(notifier.state.messages, isEmpty);
     expect(notifier.state.suggestedReplies, isEmpty);
     expect(notifier.state.isStreaming, isFalse);
 
@@ -81,7 +86,7 @@ void main() {
     expect(notifier.state.streamingText, isNull);
   });
 
-  test('stop before any text commits nothing (typing-indicator phase)',
+  test('stop before any text undoes the turn too (typing-indicator phase)',
       () async {
     final gate = Completer<void>();
     final service = _StagedPlanService([gate]);
@@ -91,36 +96,72 @@ void main() {
     await Future<void>.delayed(const Duration(milliseconds: 5));
     expect(notifier.state.isStreaming, isTrue);
 
-    notifier.stopStreaming();
+    final restored = notifier.stopStreaming();
 
+    expect(restored?.content, 'plan athens');
+    expect(notifier.state.messages, isEmpty);
     expect(notifier.state.isStreaming, isFalse);
-    // Only the user message — no empty assistant bubble.
-    expect(notifier.state.messages.map((m) => m.role).toList(),
-        [MessageRole.user]);
     await Future<void>.delayed(Duration.zero);
     expect(service.aborted, isTrue);
   });
 
-  test('stop while idle is a no-op (covers double-tap)', () async {
+  test('stop while idle returns null and changes nothing (covers double-tap)',
+      () async {
     final service = _StagedPlanService([
       const PlanEvent(type: 'text_delta', data: {'text': 'Done.'}),
     ]);
     final notifier = PlanNotifier(service, ApiClient());
 
-    // Never started: nothing happens.
-    notifier.stopStreaming();
+    // Never started: nothing happens, and nothing comes back.
+    expect(notifier.stopStreaming(), isNull);
     expect(notifier.state.messages, isEmpty);
 
     await notifier.sendMessage('hi');
-    final committed = notifier.state.messages.length;
+    final settled = notifier.state.messages.length;
 
-    // Turn already ended naturally: the second "tap" changes nothing.
-    notifier.stopStreaming();
-    expect(notifier.state.messages.length, committed);
+    // Turn already ended naturally: the second "tap" must not eat the
+    // completed exchange now sitting at the transcript tail.
+    expect(notifier.stopStreaming(), isNull);
+    expect(notifier.state.messages.length, settled);
     expect(notifier.state.isStreaming, isFalse);
   });
 
-  test('stop keeps the queue; the next explicit send drains it FIFO',
+  test('attachments ride back with the message', () async {
+    final gate = Completer<void>();
+    final service = _StagedPlanService([gate]);
+    final notifier = PlanNotifier(service, ApiClient());
+
+    final photo = PlanAttachment(
+        bytes: Uint8List.fromList([1, 2, 3]), mediaType: 'image/png');
+    unawaited(notifier.sendMessage('what is this', attachments: [photo]));
+    await Future<void>.delayed(const Duration(milliseconds: 5));
+
+    final restored = notifier.stopStreaming();
+
+    // Same objects, so the composer's chips come back without re-picking.
+    expect(restored?.attachments, hasLength(1));
+    expect(restored!.attachments.single, same(photo));
+    expect(notifier.state.messages, isEmpty);
+  });
+
+  test('a chip-seeded turn is undone with nothing handed back', () async {
+    final gate = Completer<void>();
+    final service = _StagedPlanService([gate]);
+    final notifier = PlanNotifier(service, ApiClient());
+
+    // What a "Refine Athens" chip sends: a long machine-written seed behind a
+    // short label. There is no composer form of it to restore.
+    unawaited(notifier.sendMessage('<long machine-written seed prompt>',
+        displayLabel: 'Refine Athens'));
+    await Future<void>.delayed(const Duration(milliseconds: 5));
+
+    expect(notifier.stopStreaming(), isNull);
+    // Undone all the same — the chip leaves the transcript.
+    expect(notifier.state.messages, isEmpty);
+    expect(notifier.state.isStreaming, isFalse);
+  });
+
+  test('with a queue the message goes back to the HEAD, not the composer',
       () async {
     final gate = Completer<void>();
     final service = _StagedPlanService([
@@ -133,13 +174,20 @@ void main() {
     await Future<void>.delayed(const Duration(milliseconds: 5));
     await notifier.sendMessage('two'); // queued behind the live turn
 
-    notifier.stopStreaming();
-
-    // Stopping is not "success": no auto-drain of a turn the user just killed.
-    expect(notifier.state.queuedMessages.map((m) => m.text).toList(), ['two']);
+    // Nothing for the composer: handing 'one' to the text box would let the
+    // user resend it BEHIND 'two', inverting the order they were sent in.
+    expect(notifier.stopStreaming(), isNull);
+    expect(notifier.state.messages, isEmpty);
+    expect(notifier.state.queuedMessages.map((m) => m.text).toList(),
+        ['one', 'two']);
     expect(notifier.state.isStreaming, isFalse);
 
-    // A fresh explicit send drains the backlog FIFO ahead of itself.
+    // Stopping is still not "success": no auto-drain of a turn just killed.
+    await Future<void>.delayed(const Duration(milliseconds: 20));
+    expect(notifier.state.isStreaming, isFalse);
+
+    // A fresh explicit send drains the backlog FIFO ahead of itself, and the
+    // stopped message is first in line again.
     service.script = [
       const PlanEvent(type: 'text_delta', data: {'text': 'ok'}),
     ];
@@ -152,10 +200,10 @@ void main() {
           .toList(),
       ['one', 'two', 'three'],
     );
-    expect(notifier.state.isStreaming, isFalse);
   });
 
-  test('stop then immediate send starts a clean fresh turn', () async {
+  test('re-sending a stopped message leaves exactly one copy in history',
+      () async {
     final gate = Completer<void>();
     final service = _StagedPlanService([
       const PlanEvent(type: 'text_delta', data: {'text': 'Stale half'}),
@@ -165,15 +213,47 @@ void main() {
 
     unawaited(notifier.sendMessage('plan athens'));
     await Future<void>.delayed(const Duration(milliseconds: 5));
-    notifier.stopStreaming();
+    final restored = notifier.stopStreaming();
 
     service.script = [
       const PlanEvent(type: 'text_delta', data: {'text': 'Fresh answer.'}),
     ];
-    await notifier.sendMessage('actually, kyoto');
+    // The composer would send an edited version of what came back.
+    await notifier.sendMessage('${restored!.content}, in autumn');
 
+    expect(
+      notifier.state.messages
+          .where((m) => m.role == MessageRole.user)
+          .map((m) => m.content)
+          .toList(),
+      ['plan athens, in autumn'],
+    );
     expect(notifier.state.messages.last.content, 'Fresh answer.');
-    expect(notifier.state.isStreaming, isFalse);
     expect(notifier.state.error, isNull);
+  });
+
+  test('a mid-turn compaction cannot outlive the message it counted',
+      () async {
+    final gate = Completer<void>();
+    final service = _StagedPlanService([
+      const PlanEvent(type: 'compacted', data: {
+        'through_index': 1,
+        'summary': 'They asked about Athens.',
+      }),
+      gate,
+    ]);
+    final notifier = PlanNotifier(service, ApiClient());
+
+    unawaited(notifier.sendMessage('plan athens'));
+    await Future<void>.delayed(const Duration(milliseconds: 5));
+    // The boundary now covers the one message in the transcript.
+    expect(notifier.state.compactedCount, 1);
+
+    notifier.stopStreaming();
+
+    // That message is gone, so the boundary cannot still claim it — otherwise
+    // the next turn slices history past its own end.
+    expect(notifier.state.messages, isEmpty);
+    expect(notifier.state.compactedCount, 0);
   });
 }


### PR DESCRIPTION
## Summary

Two ways the composer used to lose your words, fixed the same way: put them back where you can edit them. Both are in `ChatPanel`, so both surfaces get them — the trip-detail refine dock and the Agent tab.

**Stop now undoes the turn.** Stopping a reply almost always means you want to change what you asked, but stop left the mistake behind: your message in the transcript with a truncated half-answer under it, so rephrasing meant retyping while the abandoned pair sat above you forever.

| | Before | After |
|---|---|---|
| your message | stays in the chat | leaves the chat |
| half-streamed reply | committed as a bubble | discarded |
| composer | untouched | holds the message, caret at end, focused |
| attachments | stranded on the sent message | back as pending chips |
| queue | left alone | stopped message returns to its **front** |

`stopStreaming()` now returns the message it removed and the panel decides where it lands. With messages queued behind it the message goes to the front of that queue rather than the text box — otherwise you'd resend it *behind* a message you sent later.

**Up/Down recall sent messages**, shell-style, so resending with one word changed doesn't mean retyping the sentence. Up walks back newest-first, Down walks forward, and past the newest it restores the half-written draft you were in the middle of. Caret lands at the end. Typing ends the browse; *moving the caret* does not. In a multi-line draft Up/Down move the caret unless you're on the first/last line. Any modifier held is a different gesture, never a recall.

Three decisions worth reviewing:

- **The transcript IS the history** — read fresh per keypress, not kept as a list. A second copy would drift the moment a turn lands, a chat is resumed, or stop undoes a turn (which *removes* a message that must then not be findable in history). Resumed conversations and per-chat history fall out for free.
- **The kept draft IS the stash** — `chatDraftProvider` already means "composed but not sent", so recall simply doesn't write to it. No second field to sync, and it survives the panel being disposed mid-browse. This needed one guard: a `TextEditingController` notifies for a *caret move* exactly as for a keystroke, so without a text-changed check one click inside a recalled message would end the browse **and** overwrite the stash with the message being browsed.
- **The key handler goes on the field's own focus node** — `konami_listener.dart` documents why an ancestor `Focus` would never see arrow keys while a text field has focus. Every "don't recall here" case declines (`KeyEventResult.ignored`), so ordinary caret movement is untouched code.

Chip-seeded turns (`displayLabel`) are the app's words, not yours: undone by stop and absent from history, with the re-tappable chip as their way back.

Specs: `specs/chat-stop-undo/`, `specs/chat-history-recall/`.

## Known gap (scoped out deliberately, not overlooked)

`plan_handler.go` upserts the transcript at turn **start** on a `context.Background()` precisely so a client abort cannot cancel it — its own comment says the user's message surviving a dead stream "is the entire point of it." The API exposes only `GET`/`DELETE` for a stored transcript, so nothing client-side can rewind it.

So a stopped message survives server-side until your next successful turn overwrites the stored copy wholesale. Navigating away and back is fine (the transcript is kept in memory); a **full app reload** inside that window resurrects it, and it can appear in "continue where you left off". Closing it means `PUT /chats/{chatId}` — written up in `specs/chat-stop-undo/plan.md` → Known Gap.

## Testing

- **Full suite: 1943 passed, 0 failed.** No flakes (the intermittent `budget_section_test.dart` failure seen on recent runs did not recur).
- `flutter analyze`: 3 issues, all pre-existing `info` in `lib/models/route_response.dart`, untouched here.
- **brand-check**: 17 findings, all pre-existing lines in `chat_panel.dart` (618–2161 — `radius-literal` and one `adhoc-shadow`). This PR's edits to that file are at 167–465; `plan_provider.dart` is clean. Nothing new introduced.
- **24 tests across three files** for this change:
  - `plan_provider_stop_test.dart` (8, rewritten for the new contract) — rollback + hand-back, stop before any text, idle/double-tap, attachments riding back by identity, seeded turns, queue-to-head with FIFO preserved through the next send, exactly one copy in history after a resend, and the `compactedCount` re-clamp (a mid-turn compaction must not outlive the message it counted).
  - `chat_panel_stop_button_test.dart` (5) — the existing send/stop swap pair, plus bubble-and-partial leaving while the text lands with caret at end and focus, attachments back as chips, and a seeded turn leaving the composer empty.
  - `chat_panel_history_recall_test.dart` (11, new) — driving **real key events** through the focus tree, which is the only way to prove the interception point works. Walk back and stop at the oldest; caret at end; Down forward and back to the half-written draft; typing restarts the browse and becomes the new stash; a caret move does not; Up only from the first line (and the caret *does* move when the handler declines — proving the key isn't swallowed); Down only from the last line; each modifier declines while the bare key recalls; empty chat; chip-seeded turns excluded; a queued message is recallable.
- Per `CLAUDE.md`, no test asserts anything font-dependent.

**Not verified: nobody has pressed the key in a browser.** No dev stack was up. Web is the one place up-arrow could behave differently — the browser also moves the caret in Flutter's hidden input element, and whether returning `handled` suppresses that is engine behaviour a widget test can't reach. The framework-level contract is proven; the web-level one is not. Symptom if wrong would be obvious: Up recalls *and* the caret jumps, or Up does nothing. Whether a message *vanishing* on stop reads as intentional rather than as a bug is also a taste call a widget test can't make.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/golden-tempo/codesmith/anemos-travel/pr/557"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790103231&installation_model_id=433099&pr_number=557&repository=golden-tempo%2Fanemos-travel&return_to=https%3A%2F%2Fgithub.com%2Fgolden-tempo%2Fanemos-travel%2Fpull%2F557&signature=aaf28915c51d29e5c897ff97c9ae25be79a736c189c9764e2c736c62b83dc6af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->