### PR TITLE
feat(bookings): removing a booking asks first; a city's reservations sort by date

### DIFF
--- a/specs/booking-remove-confirm/plan.md
+++ b/specs/booking-remove-confirm/plan.md
@@ -1,0 +1,157 @@
+# Plan: Removing a Booking Asks First
+
+> **HOW.** See `spec.md` for what and why, and `../../CLAUDE.md` for repo
+> conventions referenced below.
+
+## Technical Approach
+
+Flutter only. The decisive finding is that **every fact the warning needs is
+already on the client or already on the wire** — the app was simply throwing
+one of them away:
+
+| Stake | Where it already lives |
+|---|---|
+| `booked` | on `BookingTodo`, `Accommodation`, `TripSegment` alike |
+| linked budget expense | `expensesProvider`, already loaded and already matched on `sourceId` by `_removeLinkedAutoExpense` and the booked-expense prompt |
+| saved shortlist count | `booking_options` in the trip payload (`trip_handler.go` ships it to every non-viewer) — **received and dropped**, because the Dart `Trip` never modelled it |
+
+So no endpoint, no query, no migration. The three stakes are not newly
+invented either: they are exactly the ones `bookingTodoStateRefusal`
+(`plan_tools_extra.go`) already refuses the *agent* over. The point of this
+change is that both paths to the same destructive act now warn about the same
+things, so there is one answer to "what does removing a booking cost", stated
+in two places that agree rather than one place that is silent.
+
+### Why a projection and not a `BookingOption` model
+
+`Trip.bookingOptionTodoIds` keeps only each option's `booking_todo_id`. The
+app reads exactly one thing from the shortlist today — how many hang off a
+booking — and a partial `BookingOption` with four of its sixteen fields would
+read as the whole object and invite someone to trust it. The field is named
+for what it is, and when a shortlist UI needs the rest, it becomes a real
+model and this goes with it.
+
+It round-trips through `toJson` deliberately. `TripCache` stores `toJson` and
+reads it back, so a projection that only parsed inbound would make a cached
+(offline) trip report zero saved options — the dialog would promise the
+removal costs nothing at the exact moment it costs the most. Lossless for
+every consumer that exists, because there is no other one.
+
+### Why the ask is unconditional
+
+All three deletes are `DELETE FROM` with no soft delete anywhere in the schema
+(`accommodations.sql`, `booking_todos.sql`), so there is nothing to recover
+from and no basis for skipping the ask on a "cheap" row. What varies is the
+*content*: a row carrying nothing gets the plain ask, and nothing is invented.
+
+### Why stays and segments pass `savedOptions: 0`
+
+`booking_options.booking_todo_id` is the only `ON DELETE CASCADE` in migration
+00065. The pointers back at a confirmed record —
+`promoted_accommodation_id`, `promoted_segment_id` — are `ON DELETE SET NULL`,
+so removing a stay or a segment unlinks a promotion and destroys nothing. The
+literal is passed with a comment at each call site rather than hidden behind a
+default, so the reason is at the place it is claimed.
+
+## Go API Changes
+
+None.
+
+## Flutter Changes
+
+`src/packages/flutter-app/lib/`:
+
+- **`models/trip.dart`** — `bookingOptionTodoIds` (`@JsonKey` with explicit
+  `fromJson`/`toJson`, defaulting to `const []`) plus `savedOptionsFor(id)`,
+  the one place the count is derived. Regenerate with
+  `dart run build_runner build --delete-conflicting-outputs`; **never
+  hand-edit `trip.g.dart`**. (The `make flutter-build-models` target lacks the
+  delete-conflicting-outputs flag and fails on a dirty build cache.)
+- **`widgets/trip_detail/bookings_tab.dart`** — `_confirmRemoval` (the one
+  dialog, following the house `showDialog<bool>` + `AlertDialog` + error-tinted
+  `FilledButton` pattern from `_delete`/`_leaveTrip` in
+  `trip_detail_screen.dart`) and `_hasLinkedExpense`. Wired into all three of
+  `_deleteTodo`, `_deleteStay`, `_deleteSegment`, each of which now returns
+  early unless confirmed and re-checks `mounted` after the await.
+- **`l10n/app_en.arb` + `app_es.arb`** — `bookingRemoveTitle` (placeholder),
+  `bookingRemoveBody`, `bookingRemoveSavedOptions` (ICU plural),
+  `bookingRemoveLinkedExpense`, `bookingRemoveBooked`. Cancel and Remove reuse
+  the existing `commonCancel` / `bookingCardRemove`. Regenerate with
+  `make flutter-gen-l10n`.
+
+`_hasLinkedExpense` swallows a failed expense read and answers "no": a warning
+that cannot be substantiated is not worth refusing a delete over, and the
+dialog still asks.
+
+## Contract Parity
+
+No wire contract changes. The client now reads `booking_options[].
+booking_todo_id`, which `BookingOptionResponse` (`booking_option_handler.go`)
+already sends as a non-optional `string`.
+
+## Testing
+
+`test/trip_detail_booking_remove_confirm_test.dart`, 14 tests — 10 widget
+tests through the real `TripDetailScreen` and 4 unit tests on the projection:
+
+ask-before-delete and cancel-deletes-nothing · confirm deletes · a row
+carrying nothing gets no invented warnings · the shortlist count, plural and
+singular · a linked expense warned about · an expense pointing at a *different*
+row not warned about · a booked row's provider warning · stays ask (and claim
+no shortlist) · segments ask, titled by route · `savedOptionsFor` counts per
+booking · it parses the payload the server actually sends · a viewer payload
+with no shortlist counts zero rather than throwing · and the count survives the
+`TripCache` round-trip.
+
+Per `CLAUDE.md`, no test asserts anything font-dependent.
+
+---
+
+# Reservations sort by date
+
+## Technical Approach
+
+`othersByRun` in `screens/trip_detail_derivation.dart` is the one place a
+city's reservations are collected, so it is the one place they are ordered.
+Sorting at the source means the rendered rows and every count that walks
+`bookingSlotEntries` read the same list and cannot disagree about order.
+
+Three details the sort has to get right:
+
+- **Dart's `List.sort` is not stable.** Same-day reservations could otherwise
+  swap between builds, so the comparator falls back to the row's incoming
+  index (server `position, created_at`) captured before the sort.
+- **Undated rows sort last**, keeping their relative order. `depart_date` is
+  optional, and a row with no date has no position in a date sequence; putting
+  it anywhere among the dated ones would be inventing one.
+- **Per run, not per label.** A revisited city owns two runs; each sorts alone,
+  after the existing claim logic has decided which run a row belongs to. The
+  sort never moves a row between runs.
+
+## Go API Changes
+
+`plan_tools_extra.go` — `add_booking_todo`'s `depart_date` description. It
+said "Optional YYYY-MM-DD the booking is for", which is why the agent has been
+omitting it and writing the date into the title instead. It now says to set it
+whenever the booking is for a particular day, and that the trip page orders a
+city's bookings by it. Description text only: no schema, no handler, no
+migration, and `depart_date` stays out of `Required`.
+
+## Flutter Changes
+
+`screens/trip_detail_derivation.dart` only — the sort described above,
+immediately after the claim loop. No widget, provider, or model change: the
+Bookings tab already renders `slot.others` in list order.
+
+## Testing
+
+`test/trip_detail_derivation_test.dart`, 3 new tests in the existing city
+grouping group: the screenshot's exact out-of-order case sorting correctly
+with same-day ties preserved; undated rows last and in order; and each city
+sorting alone.
+
+One existing test moved — *"a revisited city claims once, into the dated
+run"*. It is about WHICH run each reservation claims, and its expectation
+happened to encode arrival order; the undated row now sorts behind the dated
+ones. Updated with a note pointing at the sorting tests, so it keeps testing
+claiming rather than silently re-pinning order.

--- a/specs/booking-remove-confirm/spec.md
+++ b/specs/booking-remove-confirm/spec.md
@@ -1,0 +1,146 @@
+# Spec: Removing a Booking Asks First
+
+> **WHAT & WHY only.** See `plan.md` for the technical approach.
+>
+> This lane also carries a second, smaller Bookings-tab fix — a city's
+> reservations now render in date order. It rides here rather than in its own
+> lane because `CLAUDE.md` allows at most one in-flight lane touching the
+> `trip_detail_screen.dart` family, and both changes land in it. See
+> **Reservations sort by date** at the end.
+
+## Context
+
+Removing anything from the Bookings tab took one tap of an overflow menu and
+happened instantly, with no ask and no undo. Every one of those removals is a
+hard delete server-side. Brian removed a booking by accident; it was gone.
+
+There is already a considered answer in this codebase for how dangerous this
+is — it just isn't applied to people. The **agent** may not remove a booking
+that carries traveler state: it is refused and told the stakes
+(`bookingTodoStateRefusal`), and must ask the traveler and retry with
+`confirm: true`. A traveler using the UI got no such protection on the same
+destructive act. This closes that asymmetry from the other side.
+
+The ask is not a speed bump. It says what the removal costs beyond the row
+itself, because the expensive parts are invisible: a saved shortlist is
+deleted along with the booking it hangs off, and a linked budget expense is
+*not* — it survives, still counted in what you've spent, pointing at a booking
+that no longer exists.
+
+## User Stories
+
+- As a **traveler**, I want to be asked before a booking is removed, so a
+  mis-tap in an overflow menu doesn't destroy something.
+- As a **traveler who compared three hotels**, I want to be told that removing
+  the booking deletes that shortlist too, because nothing else would tell me
+  and I cannot get it back.
+- As a **traveler with a budget**, I want to know a linked expense will stay
+  in my spend after the booking is gone.
+- As a **traveler with a real reservation**, I want it made clear that
+  removing the row does not cancel anything with the provider — so I don't
+  believe I have cancelled a hotel I have not.
+- As a **traveler**, I don't want to be warned about things that aren't true
+  of the booking I'm removing.
+
+## Acceptance Criteria
+
+- [ ] Removing a booking, a stay, or a transport segment opens a confirmation
+  naming the thing being removed, and nothing is deleted until it's confirmed.
+- [ ] Cancelling — or dismissing the dialog with Escape, the back gesture, or
+  a tap outside — removes nothing and leaves the row in place.
+- [ ] The dialog says the removal cannot be undone.
+- [ ] When the booking has saved shortlist options, the dialog says how many
+  are deleted with it, reading correctly for one ("Its 1 saved option is
+  deleted with it") and for several.
+- [ ] When a budget expense is linked to the row, the dialog says it stays in
+  the budget, still counted in spend, with nothing pointing back at a booking.
+- [ ] When the row is marked booked, the dialog says removing it cancels
+  nothing with the provider and only the traveler can cancel a real
+  reservation.
+- [ ] A booking carrying none of the three gets the plain ask, with no
+  warnings invented.
+- [ ] Removing a stay or a segment never claims a shortlist is at stake —
+  saved options belong to booking checklist rows, and the pointers back at a
+  stay or a segment are cleared rather than deleted.
+- [ ] A transport segment is named by its route ("JFK → Paris"), falling back
+  to its travel mode when neither end is named.
+- [ ] Auto (system-derived) bookings are unaffected — they have no remove
+  action to begin with, and viewers can't remove anything.
+- [ ] Works offline-cached: a trip loaded from cache still reports its saved
+  options correctly rather than promising the removal is free.
+
+## API Surface
+
+None. No endpoint is added or changed — the shortlist the warning counts is
+already in the trip payload, and the expense link is already loaded for the
+Budget tab.
+
+## Data Model
+
+None server-side. The client starts reading a part of the trip payload it was
+previously discarding.
+
+## Out of Scope
+
+- **No undo.** The delete stays a hard delete; this makes it deliberate rather
+  than reversible. Undo would need the server to keep the row (and its
+  CASCADEd shortlist) somewhere recoverable, which is a much larger change.
+- **Recovering the booking already lost.** It was hard-deleted with no soft
+  delete anywhere in the schema; there is nothing to restore it from.
+- **Bulk removal**, which does not exist today.
+
+---
+
+# Reservations sort by date
+
+## Context
+
+A city's reservations rendered in the order they were written, which for
+agent-created rows is effectively arbitrary. A real trip page showed Amsterdam
+as *Aug 25, Aug 25, Aug 24, Aug 26, Aug 24* — a dated list in no order, which
+the eye reads as broken. They should read in the order the traveler will
+actually do them.
+
+## User Stories
+
+- As a **traveler**, I want a city's reservations listed earliest-first, so
+  the list matches the shape of my days there.
+- As a **traveler**, I don't want the order to change between visits to the
+  page.
+
+## Acceptance Criteria
+
+- [ ] Within a city, reservations render earliest date first.
+- [ ] Two reservations on the same day keep a stable relative order — the same
+  one every render.
+- [ ] A reservation with no date renders after every dated one, and two
+  undated ones keep their relative order.
+- [ ] Sorting is per city: one city's later reservation never outranks
+  another city's earlier one, and no reservation moves between cities.
+- [ ] A revisited city's runs each sort independently, and every reservation
+  still attaches to exactly one run.
+- [ ] Counts and filter chips continue to agree with what is rendered.
+
+## Known limitation
+
+The order comes from the row's `depart_date`. That field is **optional**, and
+nothing on the card displays it — which is why the agent has been writing
+human-readable dates into the title text ("Book Rijksmuseum timed entry (Aug
+24)"). A reservation whose date exists only in its title cannot be placed in
+time and sorts to the end with the other undated rows.
+
+Reading a date back out of the title was rejected: `docs/zen.md` is explicit
+that data semantics live in schema and types, never in a convention someone
+must remember, and a title is free text the traveler can edit. The fix is to
+make the field reliably present instead — the agent's `depart_date` is no
+longer described as merely "optional", and now says why setting it matters.
+Rows created before that change keep whatever they were given.
+
+## Out of Scope
+
+- **Showing the date on the row.** It would make the ordering legible and let
+  the agent stop smuggling dates into titles, but it is a visual change to a
+  dense row and wants a design pass.
+- **Backfilling `depart_date`** on existing rows by parsing their titles.
+- **Sorting anything else** — Other bookings stays hand-orderable by drag,
+  which is a traveler's explicit choice and must not be overridden.

--- a/src/packages/api/plan_tools_extra.go
+++ b/src/packages/api/plan_tools_extra.go
@@ -77,7 +77,7 @@ var addBookingTodoTool = anthropic.ToolParam{
 			},
 			"depart_date": map[string]any{
 				"type":        "string",
-				"description": "Optional YYYY-MM-DD the booking is for",
+				"description": "YYYY-MM-DD the booking is for. Set it whenever the booking is for a particular day — a timed entry, a dinner reservation, a ferry — because the trip page orders a city's bookings by this date, and one left unset sorts to the end no matter what the title says. Omit it only when no single day applies (travel insurance, an eSIM).",
 			},
 			"city": map[string]any{
 				"type":        "string",

--- a/src/packages/flutter-app/lib/l10n/app_en.arb
+++ b/src/packages/flutter-app/lib/l10n/app_en.arb
@@ -346,6 +346,25 @@
   "quizLoadErrorBody": "Your saved answers couldn't be loaded, so the quiz can't start yet. Check your connection and try again.",
   "bookingCardEdit": "Edit",
   "bookingCardRemove": "Remove",
+  "bookingRemoveTitle": "Remove \"{title}\"?",
+  "@bookingRemoveTitle": {
+    "placeholders": {
+      "title": {
+        "type": "String"
+      }
+    }
+  },
+  "bookingRemoveBody": "This can't be undone.",
+  "bookingRemoveSavedOptions": "{count, plural, =1{Its 1 saved option is deleted with it.} other{Its {count} saved options are deleted with it.}}",
+  "@bookingRemoveSavedOptions": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "bookingRemoveLinkedExpense": "A linked expense stays in your budget, still counted in what you've spent, with nothing pointing back at a booking.",
+  "bookingRemoveBooked": "This doesn't cancel anything with the provider — if a real reservation exists, only you can cancel it.",
   "bookingCardBooked": "Booked",
   "bookingCardOpenIn": "Open in {provider}",
   "@bookingCardOpenIn": {

--- a/src/packages/flutter-app/lib/l10n/app_es.arb
+++ b/src/packages/flutter-app/lib/l10n/app_es.arb
@@ -254,6 +254,25 @@
   "quizLoadErrorBody": "No se pudieron cargar tus respuestas guardadas, así que el cuestionario aún no puede empezar. Comprueba tu conexión e inténtalo de nuevo.",
   "bookingCardEdit": "Editar",
   "bookingCardRemove": "Quitar",
+  "bookingRemoveTitle": "¿Quitar «{title}»?",
+  "@bookingRemoveTitle": {
+    "placeholders": {
+      "title": {
+        "type": "String"
+      }
+    }
+  },
+  "bookingRemoveBody": "Esto no se puede deshacer.",
+  "bookingRemoveSavedOptions": "{count, plural, =1{Su opción guardada se elimina con él.} other{Sus {count} opciones guardadas se eliminan con él.}}",
+  "@bookingRemoveSavedOptions": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "bookingRemoveLinkedExpense": "Un gasto vinculado permanece en tu presupuesto, aún contado en lo que has gastado, sin nada que apunte a una reserva.",
+  "bookingRemoveBooked": "Esto no cancela nada con el proveedor: si existe una reserva real, solo tú puedes cancelarla.",
   "bookingCardBooked": "Reservado",
   "bookingCardOpenIn": "Abrir en {provider}",
   "bookingCardOpenSearch": "Abrir búsqueda",

--- a/src/packages/flutter-app/lib/l10n/app_localizations.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations.dart
@@ -1622,6 +1622,36 @@ abstract class AppLocalizations {
   /// **'Remove'**
   String get bookingCardRemove;
 
+  /// No description provided for @bookingRemoveTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Remove \"{title}\"?'**
+  String bookingRemoveTitle(String title);
+
+  /// No description provided for @bookingRemoveBody.
+  ///
+  /// In en, this message translates to:
+  /// **'This can\'t be undone.'**
+  String get bookingRemoveBody;
+
+  /// No description provided for @bookingRemoveSavedOptions.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, =1{Its 1 saved option is deleted with it.} other{Its {count} saved options are deleted with it.}}'**
+  String bookingRemoveSavedOptions(int count);
+
+  /// No description provided for @bookingRemoveLinkedExpense.
+  ///
+  /// In en, this message translates to:
+  /// **'A linked expense stays in your budget, still counted in what you\'ve spent, with nothing pointing back at a booking.'**
+  String get bookingRemoveLinkedExpense;
+
+  /// No description provided for @bookingRemoveBooked.
+  ///
+  /// In en, this message translates to:
+  /// **'This doesn\'t cancel anything with the provider — if a real reservation exists, only you can cancel it.'**
+  String get bookingRemoveBooked;
+
   /// No description provided for @bookingCardBooked.
   ///
   /// In en, this message translates to:

--- a/src/packages/flutter-app/lib/l10n/app_localizations_en.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations_en.dart
@@ -822,6 +822,33 @@ class AppLocalizationsEn extends AppLocalizations {
   String get bookingCardRemove => 'Remove';
 
   @override
+  String bookingRemoveTitle(String title) {
+    return 'Remove \"$title\"?';
+  }
+
+  @override
+  String get bookingRemoveBody => 'This can\'t be undone.';
+
+  @override
+  String bookingRemoveSavedOptions(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Its $count saved options are deleted with it.',
+      one: 'Its 1 saved option is deleted with it.',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get bookingRemoveLinkedExpense =>
+      'A linked expense stays in your budget, still counted in what you\'ve spent, with nothing pointing back at a booking.';
+
+  @override
+  String get bookingRemoveBooked =>
+      'This doesn\'t cancel anything with the provider — if a real reservation exists, only you can cancel it.';
+
+  @override
   String get bookingCardBooked => 'Booked';
 
   @override

--- a/src/packages/flutter-app/lib/l10n/app_localizations_es.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations_es.dart
@@ -831,6 +831,33 @@ class AppLocalizationsEs extends AppLocalizations {
   String get bookingCardRemove => 'Quitar';
 
   @override
+  String bookingRemoveTitle(String title) {
+    return '¿Quitar «$title»?';
+  }
+
+  @override
+  String get bookingRemoveBody => 'Esto no se puede deshacer.';
+
+  @override
+  String bookingRemoveSavedOptions(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Sus $count opciones guardadas se eliminan con él.',
+      one: 'Su opción guardada se elimina con él.',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get bookingRemoveLinkedExpense =>
+      'Un gasto vinculado permanece en tu presupuesto, aún contado en lo que has gastado, sin nada que apunte a una reserva.';
+
+  @override
+  String get bookingRemoveBooked =>
+      'Esto no cancela nada con el proveedor: si existe una reserva real, solo tú puedes cancelarla.';
+
+  @override
   String get bookingCardBooked => 'Reservado';
 
   @override

--- a/src/packages/flutter-app/lib/models/trip.dart
+++ b/src/packages/flutter-app/lib/models/trip.dart
@@ -140,6 +140,31 @@ class Trip {
   /// snapshots, where clients fall back to the local derivation.
   final List<TripLegDto>? legs;
 
+  /// The `booking_todo_id` of every saved shortlist option on this trip — one
+  /// entry per option, so the count for a booking is how many times its id
+  /// appears.
+  ///
+  /// A **projection, not the shortlist**. The server sends whole options
+  /// (`booking_options`, editors and above only — a viewer gets none and can
+  /// delete nothing either), and the app reads exactly one thing from them
+  /// today: how many hang off a booking, which is what removing that booking
+  /// must warn it is about to CASCADE away (specs/booking-remove-confirm; the
+  /// FK is `ON DELETE CASCADE` in migration 00065). Kept as the ids alone
+  /// rather than a partial `BookingOption` that would read as the whole
+  /// object; when a shortlist UI needs the rest, that becomes a real model and
+  /// this field goes with it.
+  ///
+  /// Round-trips deliberately: [TripCache] stores `toJson` and reads it back,
+  /// so writing this out as the same `{booking_todo_id: …}` shape is what
+  /// stops a cached (offline) trip from reporting zero saved options and
+  /// promising a removal costs nothing. Lossless for every consumer that
+  /// exists, because no other one does.
+  @JsonKey(
+      name: 'booking_options',
+      fromJson: _bookingOptionTodoIdsFromJson,
+      toJson: _bookingOptionTodoIdsToJson)
+  final List<String> bookingOptionTodoIds;
+
   const Trip({
     required this.id,
     required this.title,
@@ -177,6 +202,7 @@ class Trip {
     this.nextTransportDepart,
     this.cityPins,
     this.legs,
+    this.bookingOptionTodoIds = const [],
   });
 
   /// True when the current user may edit this trip: owner or editor
@@ -189,4 +215,25 @@ class Trip {
 
   factory Trip.fromJson(Map<String, dynamic> json) => _$TripFromJson(json);
   Map<String, dynamic> toJson() => _$TripToJson(this);
+
+  /// How many saved shortlist options would be deleted along with the booking
+  /// [bookingTodoId] — the CASCADE in migration 00065, counted client-side
+  /// from [bookingOptionTodoIds].
+  int savedOptionsFor(String bookingTodoId) =>
+      bookingOptionTodoIds.where((id) => id == bookingTodoId).length;
 }
+
+/// See [Trip.bookingOptionTodoIds]. Tolerant of a missing/garbage list rather
+/// than throwing: a trip that cannot say what its shortlist is must still
+/// render, and the removal dialog degrades to "no saved options" — which is
+/// also what an older cached payload says.
+List<String> _bookingOptionTodoIdsFromJson(Object? raw) => raw is List
+    ? [
+        for (final option in raw.whereType<Map<String, dynamic>>())
+          if (option['booking_todo_id'] is String)
+            option['booking_todo_id'] as String,
+      ]
+    : const [];
+
+List<Map<String, dynamic>> _bookingOptionTodoIdsToJson(List<String> ids) =>
+    [for (final id in ids) {'booking_todo_id': id}];

--- a/src/packages/flutter-app/lib/models/trip.g.dart
+++ b/src/packages/flutter-app/lib/models/trip.g.dart
@@ -59,6 +59,9 @@ Trip _$TripFromJson(Map<String, dynamic> json) => Trip(
       legs: (json['legs'] as List<dynamic>?)
           ?.map((e) => TripLegDto.fromJson(e as Map<String, dynamic>))
           .toList(),
+      bookingOptionTodoIds: json['booking_options'] == null
+          ? const []
+          : _bookingOptionTodoIdsFromJson(json['booking_options']),
     );
 
 Map<String, dynamic> _$TripToJson(Trip instance) => <String, dynamic>{
@@ -99,4 +102,6 @@ Map<String, dynamic> _$TripToJson(Trip instance) => <String, dynamic>{
       'next_transport_depart': instance.nextTransportDepart,
       'city_pins': instance.cityPins?.map((e) => e.toJson()).toList(),
       'legs': instance.legs?.map((e) => e.toJson()).toList(),
+      'booking_options':
+          _bookingOptionTodoIdsToJson(instance.bookingOptionTodoIds),
     };

--- a/src/packages/flutter-app/lib/screens/trip_detail_derivation.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_derivation.dart
@@ -816,6 +816,34 @@ class TripDerivation {
       claimed.add(t.id);
       othersByRun[target].add(t);
     }
+    // Chronological within the city, because that is the order the traveler
+    // will actually do them in — server order is `position, created_at`, which
+    // is the order the AGENT happened to write them and reads as random next
+    // to a dated list ("Aug 25, Aug 25, Aug 24, Aug 26, Aug 24").
+    //
+    // Sorted HERE, at the one place a city's reservations are collected, so
+    // the rows and every count that iterates `bookingSlotEntries` can never
+    // disagree about the order.
+    //
+    // `depart_date` is optional on the row and on the agent's own tool, so an
+    // undated reservation has no place in a date sequence: those keep their
+    // relative order and go last, after everything that can be placed in time.
+    // Ties fall back to the incoming index because Dart's sort is NOT stable —
+    // without it, two reservations on the same day could swap between builds.
+    for (final run in othersByRun) {
+      final order = {for (var i = 0; i < run.length; i++) run[i].id: i};
+      run.sort((a, b) {
+        final da = DateTime.tryParse(a.departDate ?? '');
+        final db = DateTime.tryParse(b.departDate ?? '');
+        if (da == null || db == null) {
+          if (da != null) return -1;
+          if (db != null) return 1;
+        } else if (da != db) {
+          return da.compareTo(db);
+        }
+        return order[a.id]!.compareTo(order[b.id]!);
+      });
+    }
 
     final confirmedStays = stays.where((a) => !a.auto).toList();
     final confirmedSegments = segments.where((s) => !s.auto).toList();

--- a/src/packages/flutter-app/lib/widgets/trip_detail/bookings_tab.dart
+++ b/src/packages/flutter-app/lib/widgets/trip_detail/bookings_tab.dart
@@ -454,9 +454,97 @@ extension on _TripDetailScreenState {
   }
 
 
+  /// Asks before removing anything from the Bookings tab, and says what the
+  /// removal costs beyond the row itself.
+  ///
+  /// Every delete here is a hard `DELETE` server-side with no undo, so the ask
+  /// is unconditional. What varies is the stakes, and they are the same three
+  /// the AGENT is already held to before it may remove a booking
+  /// (`bookingTodoStateRefusal` in plan_tools_extra.go) — stated here so the
+  /// two paths to the same destructive act warn about the same things:
+  ///
+  /// - a saved shortlist, which `booking_options` CASCADEs away with the row
+  ///   (migration 00065) — hand-collected research, the most expensive of the
+  ///   three to lose and the only one that leaves no trace;
+  /// - a linked budget expense, which SURVIVES and stays summed into spend
+  ///   with a dangling `source_id` (migration 00061 has no FK by design);
+  /// - `booked`, because removing a checklist row cancels nothing with the
+  ///   provider and the traveler may believe otherwise.
+  ///
+  /// [savedOptions] is 0 for stays and segments: `booking_options` hangs off a
+  /// booking todo alone, and the promoted-option pointers back at a stay or a
+  /// segment are `ON DELETE SET NULL`, so nothing of theirs is destroyed.
+  ///
+  /// Returns true only on an explicit confirm — a dismissed dialog (barrier
+  /// tap, Escape, back gesture) returns null and is a no.
+  Future<bool> _confirmRemoval({
+    required String title,
+    required bool booked,
+    required int savedOptions,
+    required bool hasLinkedExpense,
+  }) async {
+    final l10n = context.l10n;
+    final stakes = [
+      if (savedOptions > 0) l10n.bookingRemoveSavedOptions(savedOptions),
+      if (hasLinkedExpense) l10n.bookingRemoveLinkedExpense,
+      if (booked) l10n.bookingRemoveBooked,
+    ];
+    final confirm = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: Text(l10n.bookingRemoveTitle(title)),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(l10n.bookingRemoveBody),
+            for (final line in stakes) ...[
+              const SizedBox(height: AppSpacing.md),
+              Text(line),
+            ],
+          ],
+        ),
+        actions: [
+          TextButton(
+              onPressed: () => Navigator.pop(context, false),
+              child: Text(l10n.commonCancel)),
+          FilledButton(
+            style: FilledButton.styleFrom(
+                backgroundColor: Theme.of(context).colorScheme.error),
+            onPressed: () => Navigator.pop(context, true),
+            child: Text(l10n.bookingCardRemove),
+          ),
+        ],
+      ),
+    );
+    return confirm == true;
+  }
+
+  /// Whether a budget expense points at [id]. Read from the already-loaded
+  /// expenses (the same lookup [_removeLinkedAutoExpense] and the booked
+  /// prompt do); a failure answers "no" rather than blocking the removal —
+  /// a warning we cannot substantiate is not worth refusing a delete over.
+  Future<bool> _hasLinkedExpense(String id) async {
+    try {
+      final expenses = await ref.read(expensesProvider(widget.tripId).future);
+      return expenses.any((e) => e.sourceId == id);
+    } catch (_) {
+      return false;
+    }
+  }
+
   Future<void> _deleteTodo(BookingTodo todo) async {
     if (_guardOffline()) return;
     final l10n = context.l10n;
+    if (!await _confirmRemoval(
+      title: todo.title,
+      booked: todo.booked,
+      savedOptions: _trip?.savedOptionsFor(todo.id) ?? 0,
+      hasLinkedExpense: await _hasLinkedExpense(todo.id),
+    )) {
+      return;
+    }
+    if (!mounted) return;
     try {
       await ref
           .read(bookingTodosApiServiceProvider)
@@ -518,6 +606,15 @@ extension on _TripDetailScreenState {
   Future<void> _deleteStay(Accommodation a) async {
     if (_guardOffline()) return;
     final l10n = context.l10n;
+    if (!await _confirmRemoval(
+      title: a.name,
+      booked: a.booked,
+      savedOptions: 0, // a shortlist hangs off a booking todo, not a stay
+      hasLinkedExpense: await _hasLinkedExpense(a.id),
+    )) {
+      return;
+    }
+    if (!mounted) return;
     try {
       await ref
           .read(accommodationsApiServiceProvider)
@@ -576,6 +673,19 @@ extension on _TripDetailScreenState {
   Future<void> _deleteSegment(TripSegment s) async {
     if (_guardOffline()) return;
     final l10n = context.l10n;
+    // The same "Athens → Naxos" the row itself shows (booking_detail_row.dart),
+    // falling back to the mode when neither end is named — a dialog that asks
+    // about "" would be asking about nothing.
+    final route = [s.origin, s.destination].whereType<String>().join(' → ');
+    if (!await _confirmRemoval(
+      title: route.isEmpty ? transportModeLabel(l10n, s.mode) : route,
+      booked: s.booked,
+      savedOptions: 0, // a shortlist hangs off a booking todo, not a segment
+      hasLinkedExpense: await _hasLinkedExpense(s.id),
+    )) {
+      return;
+    }
+    if (!mounted) return;
     try {
       await ref
           .read(transportApiServiceProvider)

--- a/src/packages/flutter-app/test/trip_detail_booking_remove_confirm_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_booking_remove_confirm_test.dart
@@ -1,0 +1,441 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:travel_route_planner/models/accommodation.dart';
+import 'package:travel_route_planner/models/booking_todo.dart';
+import 'package:travel_route_planner/models/expense.dart';
+import 'package:travel_route_planner/models/itinerary_item.dart';
+import 'package:travel_route_planner/models/trip.dart';
+import 'package:travel_route_planner/models/trip_segment.dart';
+import 'package:travel_route_planner/providers/accommodations_provider.dart';
+import 'package:travel_route_planner/providers/booking_todos_provider.dart';
+import 'package:travel_route_planner/providers/budget_provider.dart';
+import 'package:travel_route_planner/providers/transport_provider.dart';
+import 'package:travel_route_planner/providers/trips_provider.dart';
+import 'package:travel_route_planner/screens/trip_detail_screen.dart';
+import 'package:travel_route_planner/services/accommodations_api_service.dart';
+import 'package:travel_route_planner/services/api_client.dart';
+import 'package:travel_route_planner/services/booking_todos_api_service.dart';
+import 'package:travel_route_planner/services/transport_api_service.dart';
+import 'package:travel_route_planner/services/trips_api_service.dart';
+import 'package:travel_route_planner/widgets/booking_detail_row.dart';
+
+import 'support/l10n_test_app.dart';
+
+/// Removing a booking asks first, and the ask names what goes with the row —
+/// the same three stakes the AGENT is held to before it may remove one
+/// (bookingTodoStateRefusal, plan_tools_extra.go): a CASCADEd shortlist, a
+/// surviving budget expense, and a reservation the provider still holds.
+/// specs/booking-remove-confirm.
+
+class _FakeTripsApiService extends TripsApiService {
+  final Trip trip;
+  _FakeTripsApiService(this.trip) : super(ApiClient(baseUrl: 'http://test'));
+
+  @override
+  Future<Trip> getTrip(String id) async => trip;
+}
+
+/// Records deletes instead of issuing them — the assertion is whether one
+/// happened at all.
+class _RecordingBookingTodosApi extends BookingTodosApiService {
+  final List<String> deleted = [];
+  _RecordingBookingTodosApi() : super(ApiClient(baseUrl: 'http://test'));
+
+  @override
+  Future<void> delete(String tripId, String todoId) async {
+    deleted.add(todoId);
+  }
+}
+
+/// A removable (non-auto) booking — the auto ones carry no delete affordance.
+BookingTodo _todo({bool booked = false}) => BookingTodo(
+      id: 'todo-1',
+      kind: 'stay',
+      todoKey: 'custom:museum',
+      title: 'Museum tickets',
+      auto: false,
+      booked: booked,
+    );
+
+Trip _trip({
+  bool booked = false,
+  int savedOptions = 0,
+}) =>
+    Trip(
+      id: 't1',
+      title: 'Athens',
+      createdAt: '2026-06-01',
+      updatedAt: '2026-06-01',
+      bookingTodos: [_todo(booked: booked)],
+      bookingOptionTodoIds: [for (var i = 0; i < savedOptions; i++) 'todo-1'],
+    );
+
+/// The bookings section sits below the default 800x600 viewport's fold and
+/// the itinerary renders lazily, so a tall view keeps it built and findable.
+void _useTallViewport(WidgetTester tester) {
+  tester.view.physicalSize = const Size(800, 2400);
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.reset);
+}
+
+Future<_RecordingBookingTodosApi> _pump(
+  WidgetTester tester, {
+  bool booked = false,
+  int savedOptions = 0,
+  List<Expense> expenses = const [],
+}) async {
+  _useTallViewport(tester);
+  final api = _RecordingBookingTodosApi();
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        tripsApiServiceProvider
+            .overrideWithValue(_FakeTripsApiService(_trip(
+          booked: booked,
+          savedOptions: savedOptions,
+        ))),
+        bookingTodosApiServiceProvider.overrideWithValue(api),
+        expensesProvider('t1').overrideWith((ref) async => expenses),
+      ],
+      child: MaterialApp(
+        localizationsDelegates: testLocalizationsDelegates,
+        home: const TripDetailScreen(tripId: 't1'),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+  return api;
+}
+
+/// Records stay/segment deletes — the confirmed records, whose rows carry
+/// their own "Remove stay" / "Remove transport" menu.
+class _RecordingRecordsApi {
+  final deletedStays = <String>[];
+  final deletedSegments = <String>[];
+}
+
+class _FakeAccommodationsApi extends AccommodationsApiService {
+  final _RecordingRecordsApi sink;
+  _FakeAccommodationsApi(this.sink) : super(ApiClient(baseUrl: 'http://test'));
+
+  @override
+  Future<void> delete(String tripId, String accId) async {
+    sink.deletedStays.add(accId);
+  }
+}
+
+class _FakeTransportApi extends TransportApiService {
+  final _RecordingRecordsApi sink;
+  _FakeTransportApi(this.sink) : super(ApiClient(baseUrl: 'http://test'));
+
+  @override
+  Future<void> deleteSegment(String tripId, String segmentId) async {
+    sink.deletedSegments.add(segmentId);
+  }
+}
+
+/// A trip whose confirmed stay and leg both render a detail row with a
+/// Remove affordance.
+Future<_RecordingRecordsApi> _pumpRecords(WidgetTester tester) async {
+  _useTallViewport(tester);
+  final sink = _RecordingRecordsApi();
+  final trip = Trip(
+    id: 't1',
+    title: 'Paris',
+    startDate: '2026-06-10',
+    endDate: '2026-06-12',
+    createdAt: '2026-06-01',
+    updatedAt: '2026-06-01',
+    // The confirmed records render as detail rows inside the itinerary's city
+    // groups, so the page needs an itinerary for them to hang off.
+    items: const [
+      ItineraryItem(
+          id: 'i0',
+          position: 0,
+          name: 'Louvre',
+          address: 'Paris, France',
+          latitude: 0,
+          longitude: 0,
+          category: 'attraction',
+          day: 1,
+          city: 'Paris'),
+      ItineraryItem(
+          id: 'i1',
+          position: 1,
+          name: 'Café de Flore',
+          address: 'Paris, France',
+          latitude: 0,
+          longitude: 0,
+          category: 'restaurant',
+          day: 2,
+          city: 'Paris'),
+    ],
+    accommodations: const [
+      Accommodation(
+        id: 'acc1',
+        name: 'Hotel Lutetia',
+        address: 'Paris',
+        checkIn: '2026-06-10',
+        checkOut: '2026-06-12',
+      ),
+    ],
+    segments: const [
+      TripSegment(
+        id: 'seg1',
+        mode: 'flight',
+        origin: 'JFK',
+        destination: 'Paris',
+        departDate: '2026-06-10',
+      ),
+    ],
+  );
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        tripsApiServiceProvider
+            .overrideWithValue(_FakeTripsApiService(trip)),
+        accommodationsApiServiceProvider
+            .overrideWithValue(_FakeAccommodationsApi(sink)),
+        transportApiServiceProvider.overrideWithValue(_FakeTransportApi(sink)),
+        expensesProvider('t1').overrideWith((ref) async => const <Expense>[]),
+      ],
+      child: MaterialApp(
+        localizationsDelegates: testLocalizationsDelegates,
+        home: const TripDetailScreen(tripId: 't1'),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+  return sink;
+}
+
+/// Opens the booking card's overflow menu and picks Remove.
+Future<void> _tapRemove(WidgetTester tester) async {
+  await tester.tap(find.byIcon(Icons.more_vert).first);
+  await tester.pumpAndSettle();
+  await tester.tap(find.text('Remove').last);
+  await tester.pumpAndSettle();
+}
+
+/// Opens the overflow menu belonging to the detail row titled [rowTitle] —
+/// scoped, because the page renders several `more_vert`s.
+Future<void> _openRowMenu(WidgetTester tester, String rowTitle) async {
+  await tester.tap(find.descendant(
+    of: find.widgetWithText(BookingDetailRow, rowTitle),
+    matching: find.byIcon(Icons.more_vert),
+  ));
+  await tester.pumpAndSettle();
+}
+
+/// The dialog's own Remove — distinct from the menu entry of the same name.
+Finder get _dialogRemove => find.descendant(
+    of: find.byType(AlertDialog), matching: find.widgetWithText(FilledButton, 'Remove'));
+
+void main() {
+  testWidgets('removing asks first, and cancelling deletes nothing',
+      (WidgetTester tester) async {
+    final api = await _pump(tester);
+
+    await _tapRemove(tester);
+
+    // The ask, before anything has been sent.
+    expect(find.byType(AlertDialog), findsOneWidget);
+    expect(find.text('Remove "Museum tickets"?'), findsOneWidget);
+    expect(find.text("This can't be undone."), findsOneWidget);
+    expect(api.deleted, isEmpty);
+
+    await tester.tap(find.widgetWithText(TextButton, 'Cancel'));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(AlertDialog), findsNothing);
+    expect(api.deleted, isEmpty, reason: 'cancel must not delete');
+    expect(find.text('Museum tickets'), findsWidgets, reason: 'row still there');
+  });
+
+  testWidgets('confirming removes it', (WidgetTester tester) async {
+    final api = await _pump(tester);
+
+    await _tapRemove(tester);
+    await tester.tap(_dialogRemove);
+    await tester.pumpAndSettle();
+
+    expect(api.deleted, ['todo-1']);
+  });
+
+  testWidgets('a booking carrying nothing gets the plain ask',
+      (WidgetTester tester) async {
+    await _pump(tester);
+    await _tapRemove(tester);
+
+    // No stakes invented where there are none.
+    expect(find.textContaining('saved option'), findsNothing);
+    expect(find.textContaining('linked expense'), findsNothing);
+    expect(find.textContaining('cancel anything'), findsNothing);
+  });
+
+  testWidgets('the ask names a shortlist it is about to CASCADE away',
+      (WidgetTester tester) async {
+    await _pump(tester, savedOptions: 3);
+    await _tapRemove(tester);
+
+    expect(find.text('Its 3 saved options are deleted with it.'),
+        findsOneWidget);
+  });
+
+  testWidgets('one saved option reads in the singular',
+      (WidgetTester tester) async {
+    await _pump(tester, savedOptions: 1);
+    await _tapRemove(tester);
+
+    expect(find.text('Its 1 saved option is deleted with it.'), findsOneWidget);
+  });
+
+  testWidgets('the ask names a linked expense that will survive the row',
+      (WidgetTester tester) async {
+    await _pump(tester, expenses: const [
+      Expense(
+        id: 'e1',
+        category: 'activities',
+        label: 'Museum',
+        amount: 30,
+        sourceKind: 'booking_todo',
+        sourceId: 'todo-1',
+      ),
+    ]);
+    await _tapRemove(tester);
+
+    expect(find.textContaining('linked expense stays in your budget'),
+        findsOneWidget);
+  });
+
+  testWidgets('an expense pointing at a DIFFERENT row is not warned about',
+      (WidgetTester tester) async {
+    await _pump(tester, expenses: const [
+      Expense(
+        id: 'e1',
+        category: 'activities',
+        label: 'Something else',
+        amount: 30,
+        sourceKind: 'booking_todo',
+        sourceId: 'another-todo',
+      ),
+    ]);
+    await _tapRemove(tester);
+
+    expect(find.textContaining('linked expense'), findsNothing);
+  });
+
+  testWidgets('a booked row says the provider still holds the reservation',
+      (WidgetTester tester) async {
+    await _pump(tester, booked: true);
+    await _tapRemove(tester);
+
+    expect(find.textContaining("doesn't cancel anything with the provider"),
+        findsOneWidget);
+  });
+
+  testWidgets('a stay asks too, and cancelling keeps it',
+      (WidgetTester tester) async {
+    final api = await _pumpRecords(tester);
+
+    await _openRowMenu(tester, 'Hotel Lutetia');
+    await tester.tap(find.text('Remove stay'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Remove "Hotel Lutetia"?'), findsOneWidget);
+    // No shortlist claim: booking_options hangs off a booking todo, and the
+    // pointer back at a stay is ON DELETE SET NULL, so nothing of its own dies.
+    expect(find.textContaining('saved option'), findsNothing);
+    expect(api.deletedStays, isEmpty);
+
+    await tester.tap(find.widgetWithText(TextButton, 'Cancel'));
+    await tester.pumpAndSettle();
+    expect(api.deletedStays, isEmpty);
+
+    // And confirming does remove it.
+    await _openRowMenu(tester, 'Hotel Lutetia');
+    await tester.tap(find.text('Remove stay'));
+    await tester.pumpAndSettle();
+    await tester.tap(_dialogRemove);
+    await tester.pumpAndSettle();
+    expect(api.deletedStays, ['acc1']);
+  });
+
+  testWidgets('a transport segment asks too, titled by its route',
+      (WidgetTester tester) async {
+    final api = await _pumpRecords(tester);
+
+    await tester.tap(find.byIcon(Icons.more_vert).first);
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Remove transport'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Remove "JFK → Paris"?'), findsOneWidget);
+    expect(api.deletedSegments, isEmpty);
+
+    await tester.tap(_dialogRemove);
+    await tester.pumpAndSettle();
+    expect(api.deletedSegments, ['seg1']);
+  });
+
+  group('Trip.savedOptionsFor', () {
+    test('counts only the options hanging off the given booking', () {
+      final trip = Trip(
+        id: 't1',
+        title: 'Athens',
+        createdAt: '2026-06-01',
+        updatedAt: '2026-06-01',
+        bookingOptionTodoIds: const ['a', 'b', 'a', 'a'],
+      );
+      expect(trip.savedOptionsFor('a'), 3);
+      expect(trip.savedOptionsFor('b'), 1);
+      expect(trip.savedOptionsFor('never-seen'), 0);
+    });
+
+    test('reads the shortlist the server actually sends', () {
+      final trip = Trip.fromJson({
+        'id': 't1',
+        'title': 'Athens',
+        'created_at': '2026-06-01',
+        'updated_at': '2026-06-01',
+        'booking_options': [
+          {'id': 'o1', 'booking_todo_id': 'a', 'title': 'Hotel Grande'},
+          {'id': 'o2', 'booking_todo_id': 'a', 'title': 'Hotel Petit'},
+          {'id': 'o3', 'booking_todo_id': 'b', 'title': 'Ferry'},
+        ],
+      });
+      expect(trip.savedOptionsFor('a'), 2);
+      expect(trip.savedOptionsFor('b'), 1);
+    });
+
+    test('a viewer payload (no shortlist at all) counts zero, not null', () {
+      final trip = Trip.fromJson({
+        'id': 't1',
+        'title': 'Athens',
+        'created_at': '2026-06-01',
+        'updated_at': '2026-06-01',
+      });
+      expect(trip.bookingOptionTodoIds, isEmpty);
+      expect(trip.savedOptionsFor('a'), 0);
+    });
+
+    test('survives the offline cache round-trip', () {
+      // TripCache stores toJson and reads it back. If the count did not
+      // round-trip, a cached trip would promise a removal costs nothing.
+      final trip = Trip.fromJson({
+        'id': 't1',
+        'title': 'Athens',
+        'created_at': '2026-06-01',
+        'updated_at': '2026-06-01',
+        'booking_options': [
+          {'id': 'o1', 'booking_todo_id': 'a'},
+          {'id': 'o2', 'booking_todo_id': 'a'},
+        ],
+      });
+      final cached = Trip.fromJson(trip.toJson());
+      expect(cached.savedOptionsFor('a'), 2);
+    });
+  });
+}

--- a/src/packages/flutter-app/test/trip_detail_derivation_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_derivation_test.dart
@@ -478,6 +478,77 @@ void main() {
       expect(overall, (booked: 1, total: 4));
     });
 
+    // A city's reservations render in the order the traveler will do them,
+    // not the order the agent happened to write them.
+    test("city grouping: a city's reservations sort by date", () {
+      // The order off the wire is `position, created_at` — the shape the trip
+      // page actually showed: Sep 2, Sep 2, Sep 1, Sep 3, Sep 1.
+      final todos = [
+        _todo('custom:door74',
+            kind: 'other', cityLabel: 'Paris', departDate: '2026-09-02'),
+        _todo('custom:renvy',
+            kind: 'other', cityLabel: 'Paris', departDate: '2026-09-02'),
+        _todo('custom:rijksmuseum',
+            kind: 'other', cityLabel: 'Paris', departDate: '2026-09-01'),
+        _todo('custom:lookout',
+            kind: 'other', cityLabel: 'Paris', departDate: '2026-09-03'),
+        _todo('custom:moeders',
+            kind: 'other', cityLabel: 'Paris', departDate: '2026-09-01'),
+      ];
+      final grouped = _compute(bookingTodos: todos).groupedBookings;
+      expect([for (final t in grouped.slots[0].others) t.todoKey], [
+        // Sep 1, in the order they arrived — same-day ties are not reshuffled.
+        'custom:rijksmuseum',
+        'custom:moeders',
+        // Sep 2, likewise.
+        'custom:door74',
+        'custom:renvy',
+        // Sep 3.
+        'custom:lookout',
+      ]);
+    });
+
+    test('city grouping: undated reservations keep their order, at the end',
+        () {
+      // depart_date is optional on the row and on the agent's own tool, so an
+      // undated reservation has no place in a date sequence. It must not
+      // displace one that can be placed, and two of them must not swap.
+      final todos = [
+        _todo('custom:no-date-first', kind: 'other', cityLabel: 'Paris'),
+        _todo('custom:late',
+            kind: 'other', cityLabel: 'Paris', departDate: '2026-09-01'),
+        _todo('custom:no-date-second', kind: 'other', cityLabel: 'Paris'),
+        _todo('custom:early',
+            kind: 'other', cityLabel: 'Paris', departDate: '2026-08-31'),
+      ];
+      final grouped = _compute(bookingTodos: todos).groupedBookings;
+      expect([for (final t in grouped.slots[0].others) t.todoKey], [
+        'custom:early',
+        'custom:late',
+        'custom:no-date-first',
+        'custom:no-date-second',
+      ]);
+    });
+
+    test('city grouping: each city sorts alone', () {
+      // Paris' latest must not outrank Rome's earliest — runs sort separately.
+      final todos = [
+        _todo('custom:paris-late',
+            kind: 'other', cityLabel: 'Paris', departDate: '2026-09-01'),
+        _todo('custom:rome-late',
+            kind: 'other', cityLabel: 'Rome', departDate: '2026-09-05'),
+        _todo('custom:paris-early',
+            kind: 'other', cityLabel: 'Paris', departDate: '2026-08-31'),
+        _todo('custom:rome-early',
+            kind: 'other', cityLabel: 'Rome', departDate: '2026-09-04'),
+      ];
+      final grouped = _compute(bookingTodos: todos).groupedBookings;
+      expect([for (final t in grouped.slots[0].others) t.todoKey],
+          ['custom:paris-early', 'custom:paris-late']);
+      expect([for (final t in grouped.slots[1].others) t.todoKey],
+          ['custom:rome-early', 'custom:rome-late']);
+    });
+
     test('city grouping: no city_label means Other, whatever the date says',
         () {
       // Sep 2 is the Paris→Rome transition day of this fixture — and even an
@@ -529,8 +600,11 @@ void main() {
         _todo('custom:rome-day-dinner',
             kind: 'other', cityLabel: 'Paris', departDate: '2026-09-03'),
       ]).groupedBookings;
+      // WHICH run each claims is what this test is about; the order inside a
+      // run is by date (Sep 1, Sep 3, then the undated one) — see the sorting
+      // tests above.
       expect([for (final t in d.slots[0].others) t.todoKey],
-          ['custom:run1-dinner', 'custom:undated', 'custom:rome-day-dinner']);
+          ['custom:run1-dinner', 'custom:rome-day-dinner', 'custom:undated']);
       expect([for (final t in d.slots[1].others) t.todoKey], isEmpty);
       expect([for (final t in d.slots[2].others) t.todoKey],
           ['custom:run2-dinner']);


### PR DESCRIPTION
## Summary

Two Bookings-tab fixes. They share a lane because `CLAUDE.md` allows at most one in-flight lane touching the `trip_detail_screen.dart` family and both land in it.

### 1. Removing a booking asks first — and says what goes with it

Every removal in that tab was a hard `DELETE` with no ask and no undo. One got removed by accident and was gone.

There was already a considered answer here for how dangerous this is; it just wasn't applied to people. The **agent** may not remove a booking carrying traveler state — it's refused and told the stakes (`bookingTodoStateRefusal`) and must ask and retry with `confirm: true`. A traveler doing the identical thing through the UI got nothing. So the dialog names the **same three stakes** rather than inventing a rule:

| Stake | Why it matters |
|---|---|
| saved shortlist | `booking_options` CASCADEs off the row (00065) — the SQL comment calls it hand-collected research; the only one that leaves no trace |
| linked expense | **survives** the delete, still summed into spend, with a dangling `source_id` (00061 has no FK by design) |
| `booked` | removing a checklist row cancels nothing with the provider |

A row carrying none of them gets the plain ask; nothing is invented. All three removals ask — checklist rows, stays, transport segments — since all three were equally silent and equally permanent. Stays and segments never claim a shortlist is at stake: `booking_options` hangs off a booking todo, and the promoted-option pointers back at them are `ON DELETE SET NULL`.

**No API change.** Every fact the warning needs was already on the client or already on the wire — `booked` is on all three models, `expensesProvider` is already loaded and already matched on `sourceId` twice elsewhere in this file, and `booking_options` ships in the trip payload to every non-viewer. The Dart `Trip` model simply never parsed it.

`Trip.bookingOptionTodoIds` keeps only each option's `booking_todo_id`: the app reads one thing from the shortlist today, and a partial `BookingOption` with four of sixteen fields would read as the whole object and invite someone to trust it. It round-trips through `toJson` deliberately — `TripCache` stores `toJson` and reads it back, so a parse-only projection would make a cached trip report **zero** saved options, promising the removal costs nothing at exactly the moment it costs most. There's a test pinning that.

### 2. A city's reservations render in date order

Amsterdam rendered *Aug 25, Aug 25, Aug 24, Aug 26, Aug 24* — a dated list in no order. Server order is `position, created_at`, i.e. whatever order the agent wrote them.

Sorted in `othersByRun`, the one place a city's reservations are collected, so rows and every count walking `bookingSlotEntries` read the same list. Three details it has to get right: **Dart's `List.sort` is not stable** (same-day rows could swap between builds, so ties fall back to the incoming server index); **undated rows sort last** keeping their order, since a row with no date has no position in a date sequence; and **per run, not per label**, so a revisited city's two runs sort independently and nothing moves between them.

**Known limitation, and reviewers should weigh it.** The order keys on `depart_date`, which is optional *and never displayed on the card* — which is precisely why the agent has been writing dates into title text ("Book Rijksmuseum timed entry (Aug 24)"). A reservation whose date lives only in its title can't be placed in time and sorts to the end. **On existing data this may visibly do little.**

Reading the date back out of the title was rejected: `docs/zen.md` is explicit that data semantics live in schema and types, never in a convention someone must remember — and a title is free text the traveler can edit. Fixed at the source instead: `add_booking_todo`'s `depart_date` no longer reads "Optional YYYY-MM-DD the booking is for" but says to set it whenever the booking is for a particular day, and why. **Description text only** — no schema, no handler, no migration, still not `Required`.

The durable fix is to show the date on the row, which would also remove the agent's reason to smuggle it into the title. That's a visual change to a dense row and wants a design pass, so it's flagged rather than guessed at.

Spec: `specs/booking-remove-confirm/` (covers both).

## Testing

- **Full suite: 1951 passed, 0 failed.**
- `flutter analyze`: 3 issues, all pre-existing `info` in `lib/models/route_response.dart`, untouched here.
- `go fmt` / `go vet`: clean.
- **brand-check: clean** on both touched lib files.
- **17 tests for this change:**
  - `trip_detail_booking_remove_confirm_test.dart` (14, new) — 10 widget tests through the real `TripDetailScreen`: ask-before-delete, cancel-deletes-nothing, confirm-deletes, no invented warnings on a clean row, the shortlist count plural **and** singular, a linked expense warned about, an expense pointing at a *different* row **not** warned about, the booked warning, stays ask (and claim no shortlist), segments ask titled by route. Plus 4 unit tests: per-booking counting, parsing the payload the server actually sends, a viewer payload counting zero rather than throwing, and the `TripCache` round-trip.
  - `trip_detail_derivation_test.dart` (3 new) — the exact out-of-order case sorting correctly with same-day ties preserved; undated rows last and in order; each city sorting alone.
- One existing test **moved**: *"a revisited city claims once, into the dated run"* is about WHICH run each row claims, and its expectation happened to encode arrival order. Updated with a pointer to the new sorting tests so it keeps testing claiming rather than silently re-pinning order.
- Per `CLAUDE.md`, no test asserts anything font-dependent.

**Not verified: neither change has been looked at in a browser.** No dev stack was up. Both are ones where taste matters — whether three stacked warnings on a booked row with a shortlist *and* an expense reads as helpful or as a wall, and whether the reordered list actually looks right.

Also worth a separate fix: `make flutter-build-models` fails on a dirty build cache because it doesn't pass `--delete-conflicting-outputs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/golden-tempo/codesmith/anemos-travel/pr/560"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790134647&installation_model_id=433099&pr_number=560&repository=golden-tempo%2Fanemos-travel&return_to=https%3A%2F%2Fgithub.com%2Fgolden-tempo%2Fanemos-travel%2Fpull%2F560&signature=5528cb70e6939df714bc5ac78b4d88b1ce2d93331e519a7f7c1c0351b1571072"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->