### PR TITLE
fix(legs): set_leg_dates stops fighting the traveler and stops misquoting the page

### DIFF
--- a/specs/set-leg-dates/spec.md
+++ b/specs/set-leg-dates/spec.md
@@ -45,6 +45,21 @@ the trip start (confirmed stay still wins), a first-leg start change steers
 to set_trip_dates, and a squeeze NOTE names the consumed next leg and tells
 the agent to chain follow-up set_leg_dates calls.
 
+**Superseded in part 2026-08-24 (v4, specs/leg-departure-dates ticket 2).**
+The boundary rule ended the convention v2 was built on: a leg's rendered end
+is now the NEXT leg's arrival (its own stay's check-out, or the trip's end
+for the final leg), never its own last item day. So item renumbering is
+START-anchored again — the v2 END-anchored drag moved places the traveler
+deliberately kept off the travel day — the previous-boundary extension
+survives only for a confirmed stay's check-out (item-dated neighbours render
+correctly with no write), an explicit `end_date` is honoured only where the
+departure lives on the leg's own rows and refuses-with-steer elsewhere, and
+every range a result states comes from `computeTripLegs` (the gap/squeeze
+NOTEs below, which quoted raw item spans, are gone — a date gap between legs
+is unrepresentable on the page). Acceptance items below describing the
+END-anchored renumber, the placeholder end-carrier, and the squeeze NOTE
+describe v2/v3 behaviour and are pinned no further.
+
 ## User Stories
 
 - As a **traveler refining a saved multi-city trip in chat**, I want to say

--- a/src/packages/api/plan_leg_dates.go
+++ b/src/packages/api/plan_leg_dates.go
@@ -2,24 +2,45 @@ package main
 
 // set_leg_dates (specs/set-leg-dates): the /plan agent's way to change WHEN
 // one city leg of a saved trip happens without moving the rest of the trip.
-// set_trip_dates shifts everything by one delta; a leg move is endpoint-
-// anchored instead — the start and end can shift by different amounts (LA
-// Sep 20-24 -> Sep 24-27 is +4 on check-in, +3 on check-out). One transaction
-// renumbers the leg's item days END-anchored (the old last day is the
-// departure day the trip screen renders), moves its matched confirmed stays
-// and boundary transport, and extends the trip's end date when the leg now
-// runs past it. The PREVIOUS leg's end extends to meet a later start in the
-// same transaction (decided 2026-08-05 — the screen draws a leg from the
-// neighbor's end, so an unmoved boundary makes the change invisible); an
-// earlier start (overlap) and the NEXT leg still only narrate — including a
-// SQUEEZE note when the new end consumes all the next leg's nights, which
-// the agent resolves by chaining further set_leg_dates calls. The FIRST
-// dated leg's visible start is the trip's start date (anchored, mirroring
-// the client's _locationGroupRanges clamp) so a first-leg start change
-// steers to set_trip_dates. A zero-change call commits nothing and reports
-// actual saved state — never the requested range, and no trip_updated SSE.
-// Gated authedOnly (per-conversation stable, prompt-cache safe); target-trip
-// resolution reuses resolveDateShiftTrip.
+// set_trip_dates shifts everything by one delta; shift_days_from moves a
+// suffix; this tool moves ONE leg.
+//
+// Under the boundary rule (specs/leg-departure-dates) a leg's items carry its
+// ARRIVAL and nothing else: the page renders a leg from its own arrival (first
+// item day / stay check-in, the trip's start for the first city) until the
+// NEXT city's arrival, with the last city running through the trip's end. So
+// a start move renumbers the run's item days START-anchored — every item
+// keeps its within-leg offset, and no item is ever dragged onto a departure
+// day (the old END-anchored renumber moved places the traveler deliberately
+// kept off the travel day; ticket 2 removed it). One transaction renumbers
+// the items, moves the leg's matched confirmed stays and boundary transport,
+// and extends the trip's end date when the leg now runs past it.
+//
+// An explicit end_date is honoured only where the departure actually lives on
+// this leg's own rows: a confirmed stay's check-out, or — for the trip's
+// final rendered leg — the trip's end date. Any other leg's end IS the next
+// city's arrival, so an end-change there refuses and steers to the call that
+// moves it (set_leg_dates on the next city, or shift_days_from); an end_date
+// merely echoing what the page already renders is treated as omitted.
+//
+// A PREVIOUS leg pinned by a confirmed stay has its check-out extended to
+// meet a later start in the same transaction — computeTripLegs closes a gap
+// after a stay by pulling THIS leg's rendered start back to the check-out, so
+// without the write the move would be invisible on screen. Item-dated
+// neighbours need no write at all: their rendered end is this leg's arrival,
+// wherever it lands. The FIRST dated leg's visible start is the trip's start
+// date (anchored) so a first-leg start change steers to set_trip_dates. A
+// zero-change call commits nothing and reports actual saved state — never
+// the requested range, and no trip_updated SSE.
+//
+// Everything a result says about what the traveler SEES derives from
+// computeTripLegs (renderedLegForRun) — the derivation the page, the `legs`
+// payload and legsRenderSummary share. The leg-dates arc paid for this rule:
+// the renumbering math above needs item-day semantics, but anything speaking
+// about the dates on screen derives from the dates on screen; quoting raw
+// item spans as neighbour dates is how the tool once reported a "2-night gap"
+// the page never drew. Gated authedOnly (per-conversation stable,
+// prompt-cache safe); target-trip resolution reuses resolveDateShiftTrip.
 
 import (
 	"encoding/json"
@@ -36,11 +57,12 @@ import (
 
 var setLegDatesTool = anthropic.ToolParam{
 	Name: "set_leg_dates",
-	Description: anthropic.String("Change the dates of ONE city's leg within the traveler's saved trip — 'make LA Sep 24 to 27', 'arrive in Rome a day later' — without moving the rest of the trip. " +
-		"It moves that city's itinerary days, its stay's check-in/check-out, and the transport into and out of that city, extending the trip's end date when the new leg runs past it. " +
-		"Moving a leg later also extends the PREVIOUS city's end to meet the new start (the result says so); other cities do not move — the result reports any remaining gap or overlap with neighboring legs, so relay every change it describes to the traveler and offer to fix those legs too. " +
-		"Omit end_date to keep the leg the same length. " +
+	Description: anthropic.String("Change when ONE city's leg of the traveler's saved trip happens — 'arrive in Rome a day later' — without moving the rest of the trip. " +
+		"start_date moves the city's ARRIVAL: its itinerary days shift together, its stay's dates move, and the transport into and out of the city follows. " +
+		"A city's departure day is the NEXT city's arrival, so to change when the traveler LEAVES a city, move the next city's start_date (or use shift_days_from to push it and everything after it together). " +
+		"end_date is honoured only where the departure lives on this city's own plan: its confirmed stay's check-out, or — for the trip's final city — the trip's end date, which extends when the leg runs past it. Anywhere else an explicit end_date is refused with the call to make instead. Omit end_date to keep the leg's saved length. " +
 		"When the WHOLE trip moves, use set_trip_dates instead. " +
+		"The result reports the dates the trip page now renders — relay any range that doesn't match what the traveler asked for. " +
 		"Only the saved plan changes: anything already booked with a real provider keeps its original dates, so remind the traveler to re-check those bookings."),
 	InputSchema: anthropic.ToolInputSchemaParam{
 		Properties: map[string]any{
@@ -54,7 +76,7 @@ var setLegDatesTool = anthropic.ToolParam{
 			},
 			"end_date": map[string]any{
 				"type":        "string",
-				"description": "Optional new last day (the departure day) as YYYY-MM-DD; omit to keep the leg's current length. Must not be before start_date.",
+				"description": "Optional new departure day as YYYY-MM-DD; only honoured when this city's departure lives on its own plan (a confirmed stay's check-out, or the trip's end for the final city). Must not be before start_date. Omit to keep the leg's saved length.",
 			},
 		},
 		Required: []string{"city", "start_date"},
@@ -190,31 +212,38 @@ func anchoredLegDisplayRange(runs []legRun, i int, stays []store.Accommodation, 
 	return s, e
 }
 
-// renderedLegRange resolves the span the trip page RENDERS for a hub, from
-// computeTripLegs — the one derivation the page, the `legs` payload and
-// legsRenderSummary already share.
-//
-// It replaced a third twin (visibleLegDisplayRange) that re-implemented the
-// arrival rule here. The twins ABOVE stay, deliberately: the renumbering math
-// needs item-day semantics, where a leg ends on its last item day. But a
-// result that promises what the traveler SEES cannot be built from those —
-// the page anchors the final leg to the trip's end date (computeTripLegs step
-// 6), which item days no longer imply now that the day home is left empty.
-// The leg-dates arc paid for this rule: anything speaking about the dates on
-// screen derives from the dates on screen. ok=false when the hub has no
-// spanned leg, in which case the caller must say nothing rather than quote a
-// number from the wrong derivation.
-func renderedLegRange(trip store.Trip, items []store.ItineraryItem, stays []store.Accommodation, hub string) (start, end time.Time, ok bool) {
-	want := strings.TrimSpace(hub)
-	for _, leg := range computeTripLegs(trip, items, stays) {
-		if leg.Start == nil || leg.End == nil || leg.Hub == nil {
-			continue
+// prevSpannedRenderedLeg / nextSpannedRenderedLeg find the spanned leg the
+// page renders immediately before/after `at` (a pointer into legs, the
+// renderedLegForRun convention). Nil when there is none, in which case the
+// caller must say nothing rather than quote a number from the wrong
+// derivation. These are how neighbour narration reads the screen: the
+// renumbering twins above keep item-day semantics, but anything speaking
+// about the dates on screen derives from the dates on screen.
+func prevSpannedRenderedLeg(legs []RenderLeg, at *RenderLeg) *RenderLeg {
+	var prev *RenderLeg
+	for i := range legs {
+		if &legs[i] == at {
+			return prev
 		}
-		if strings.EqualFold(strings.TrimSpace(*leg.Hub), want) {
-			return *leg.Start, *leg.End, true
+		if legs[i].Start != nil && legs[i].End != nil {
+			prev = &legs[i]
 		}
 	}
-	return time.Time{}, time.Time{}, false
+	return nil
+}
+
+func nextSpannedRenderedLeg(legs []RenderLeg, at *RenderLeg) *RenderLeg {
+	seen := false
+	for i := range legs {
+		if &legs[i] == at {
+			seen = true
+			continue
+		}
+		if seen && legs[i].Start != nil && legs[i].End != nil {
+			return &legs[i]
+		}
+	}
+	return nil
 }
 
 // legDateChange is the pure outcome of a leg move: the resolved new span,
@@ -270,16 +299,18 @@ func nightsText(nights int) string {
 	return fmt.Sprintf("%d nights", nights)
 }
 
-// legsSummary lists the trip's movable legs with their current spans — the
-// honest error payload when the requested city doesn't resolve.
-func legsSummary(runs []legRun, stays []store.Accommodation, tripStart time.Time) string {
+// legsSummary lists the trip's movable city legs with the spans the trip page
+// RENDERS for them (computeTripLegs) — the honest error payload when the
+// requested city doesn't resolve. Only legs a set_leg_dates/shift_days_from
+// call can actually address are listed: a named hub and at least one dated
+// item (matchLegRuns' criteria); hubless "Other places" legs are skipped.
+func legsSummary(trip store.Trip, items []store.ItineraryItem, stays []store.Accommodation) string {
 	var parts []string
-	for i, r := range runs {
-		if r.minDay < 1 || r.hub == "" {
+	for _, leg := range computeTripLegs(trip, items, stays) {
+		if leg.Hub == nil || leg.Start == nil || leg.End == nil || len(leg.itemDays) == 0 {
 			continue
 		}
-		s, e := anchoredLegDisplayRange(runs, i, stays, tripStart)
-		parts = append(parts, fmt.Sprintf("%s (%s)", r.hub, legRangeText(s, e)))
+		parts = append(parts, fmt.Sprintf("%s (%s)", leg.Label, legRangeText(*leg.Start, *leg.End)))
 	}
 	return strings.Join(parts, ", ")
 }
@@ -307,7 +338,7 @@ func legsSummary(runs []legRun, stays []store.Accommodation, tripStart time.Time
 func legsRenderSummary(trip store.Trip, items []store.ItineraryItem, stays []store.Accommodation) string {
 	legs := computeTripLegs(trip, items, stays)
 	var b strings.Builder
-	b.WriteString(legsRenderWarning(legs))
+	b.WriteString(legsRenderWarning(trip, legs))
 	for _, leg := range legs {
 		if leg.Start == nil || leg.End == nil {
 			continue
@@ -393,38 +424,76 @@ func legDateSourceText(source string) string {
 	}
 }
 
-// legsRenderWarning names, ABOVE the list, the legs whose spans are wrong in
-// the two ways a sparse itinerary goes wrong — a leg that lost the place fixing
-// its departure date, and a leg whose dates were guessed. It leads because the
-// last-day arc showed a rule buried under a table gets averaged away ("putting
-// it FIRST fixed it outright"), and because both failures are silent on every
-// other surface: the trip page renders no nights label for a zero-night leg,
-// and RenderLeg.ZeroNight has never had a consumer.
+// legsRenderWarning names, ABOVE the list, the legs whose rendered spans
+// contradict the traveler's plan in the three ways that are silent on every
+// other surface — two cities sharing an arrival day (ZeroNight: the next
+// leg's arrival is on or before this leg's own), a place dated after the day
+// its leg ends on the page (itemsPastEnd — read from the derivation, never
+// re-derived here: a second derivation of the same condition is the defect
+// specs/leg-departure-dates exists to kill), and a span that was guessed
+// because no place carries a day. It leads because the last-day arc showed a
+// rule buried under a table gets averaged away ("putting it FIRST fixed it
+// outright"). The remedy deliberately never says to add a place: a
+// placeholder invented to hold a date is the corruption the boundary rule
+// retired (the Prague Airport Starbucks), and a leg's dates move by moving
+// arrivals, not by planting items.
 //
-// The FINAL leg is exempt from the zero-night check: it legitimately ends the
-// day the traveler flies home, and the trip-end anchor has already stretched it
-// if it could. Legs without a span are skipped — they print nothing either.
-func legsRenderWarning(legs []RenderLeg) string {
-	var problems []string
-	for i, leg := range legs {
+// A second, SOFT block follows for unplanned stretches — a leg whose last
+// place sits two or more nights before its rendered end. That is a true fact
+// about the page, not a render defect: under the boundary rule a leg runs to
+// the next city's arrival whether or not its tail nights hold plans, and the
+// honest narration for what used to be misreported as a "gap between legs"
+// (unrepresentable on screen) is unplanned nights INSIDE a leg. ONE night
+// stays silent: a place-free departure morning is the normal spine — every
+// correctly-built trip has one — and a line that fires on everything gets
+// averaged away with the hard warning above it.
+func legsRenderWarning(trip store.Trip, legs []RenderLeg) string {
+	var problems, unplanned []string
+	for i := range legs {
+		leg := &legs[i]
 		if leg.Start == nil || leg.End == nil {
 			continue
 		}
-		last := i == len(legs)-1
-		if !last && nightsBetween(*leg.Start, *leg.End) == 0 {
-			problems = append(problems, fmt.Sprintf("%s renders ZERO nights — the traveler arrives and leaves the same day, because no place sits on the day they move on; the next city has absorbed those nights", leg.Label))
+		if leg.ZeroNight {
+			nextLabel := "the next city"
+			if next := nextSpannedRenderedLeg(legs, leg); next != nil {
+				nextLabel = next.Label
+			}
+			problems = append(problems, fmt.Sprintf("%s renders ZERO nights — the next city (%s) arrives on or before it, so the traveler arrives and moves straight on", leg.Label, nextLabel))
+			continue
+		}
+		if leg.itemsPastEnd {
+			problems = append(problems, fmt.Sprintf("%s has a place dated after %s, the day it ends on the page — that place sits outside its own city's rendered dates", leg.Label, leg.End.Format(dateLayout)))
 			continue
 		}
 		if leg.DateSource == "auto" {
 			problems = append(problems, fmt.Sprintf("%s has no dated place, so its range is a guess, not the nights that were agreed", leg.Label))
+			continue
+		}
+		if trip.StartDate.Valid && len(leg.itemDays) > 0 {
+			last := leg.itemDays[0]
+			for _, d := range leg.itemDays[1:] {
+				if d > last {
+					last = d
+				}
+			}
+			lastDate := trip.StartDate.Time.AddDate(0, 0, int(last)-1)
+			if n := nightsBetween(lastDate, *leg.End); n >= 2 {
+				unplanned = append(unplanned, fmt.Sprintf("%s renders %s (%s) but its last place is %s — %d nights with nothing planned", leg.Label, legRangeText(*leg.Start, *leg.End), nightsText(nightsBetween(*leg.Start, *leg.End)), lastDate.Format(dateLayout), n))
+			}
 		}
 	}
-	if len(problems) == 0 {
-		return ""
+	var b strings.Builder
+	if len(problems) > 0 {
+		b.WriteString("WARNING — the page is not rendering what the traveler agreed to: " +
+			strings.Join(problems, "; ") +
+			". Fix it before you reply: a leg ends at the NEXT city's arrival, so adjust arrivals with set_leg_dates (start_date) or shift the schedule with shift_days_from — never add a place just to hold a date.\n")
 	}
-	return "WARNING — the page is not rendering what the traveler agreed to: " +
-		strings.Join(problems, "; ") +
-		". Fix it before you reply: give the city a place on the day they move on to the next one, or set its dates with set_leg_dates.\n"
+	if len(unplanned) > 0 {
+		b.WriteString("Unplanned stretches — true on the page, fine if intended (mention, don't fix): " +
+			strings.Join(unplanned, "; ") + ".\n")
+	}
+	return b.String()
 }
 
 func runSetLegDatesTool(s *planSession, input json.RawMessage) (string, bool) {
@@ -496,16 +565,20 @@ func runSetLegDatesTool(s *planSession, input json.RawMessage) (string, bool) {
 	runs := legRuns(items)
 	matched := matchLegRuns(runs, city)
 	if len(matched) == 0 {
-		if legs := legsSummary(runs, stays, tripStart); legs != "" {
+		if legs := legsSummary(trip, items, stays); legs != "" {
 			return fmt.Sprintf("No leg for '%s' in this trip. The legs are: %s. Use the city name as it appears in the itinerary.", city, legs), true
 		}
 		return "This trip's itinerary has no day-numbered city legs to move. Use set_trip_dates for the whole trip instead.", true
 	}
+	// Rendered spans, not raw item-day math, label the pre-move state: anything
+	// speaking about the dates on screen derives from the dates on screen.
+	legsNow := computeTripLegs(trip, items, stays)
 	if len(matched) > 1 {
 		var spans []string
 		for _, i := range matched {
-			s0, e0 := anchoredLegDisplayRange(runs, i, stays, tripStart)
-			spans = append(spans, legRangeText(s0, e0))
+			if leg := renderedLegForRun(legsNow, runs[i]); leg != nil && leg.Start != nil && leg.End != nil {
+				spans = append(spans, legRangeText(*leg.Start, *leg.End))
+			}
 		}
 		return fmt.Sprintf("The itinerary visits %s more than once (%s), and moving just one of several visits isn't supported yet — tell the traveler plainly what you couldn't do.", runs[matched[0]].hub, strings.Join(spans, "; ")), true
 	}
@@ -513,6 +586,11 @@ func runSetLegDatesTool(s *planSession, input json.RawMessage) (string, bool) {
 	run := runs[matched[0]]
 	hubLower := strings.ToLower(run.hub)
 	oldLegStart, oldLegEnd := anchoredLegDisplayRange(runs, matched[0], stays, tripStart)
+	movedLegNow := renderedLegForRun(legsNow, run)
+	var nextSpannedNow *RenderLeg
+	if movedLegNow != nil {
+		nextSpannedNow = nextSpannedRenderedLeg(legsNow, movedLegNow)
+	}
 
 	// The first leg's arrival IS the trip's start date (its span is anchored
 	// there), so a different start is really a trip-start change — steer to
@@ -520,23 +598,67 @@ func runSetLegDatesTool(s *planSession, input json.RawMessage) (string, bool) {
 	// screen can't show. Carve-out: a confirmed stay anchors the leg's start
 	// instead, and its check-in stays movable like any other leg's.
 	if matched[0] == firstDatedRunIdx(runs) && matchedConfirmedStay(run, stays) == nil && !start.Time.Equal(tripStart) {
-		return fmt.Sprintf("%s is the trip's first city, so its arrival IS the trip's start date (%s). To move when the trip begins, use set_trip_dates; to change only the departure from %s, call set_leg_dates again with start_date=%s and the new end_date.",
-			run.hub, tripStart.Format(dateLayout), run.hub, tripStart.Format(dateLayout)), true
+		return fmt.Sprintf("%s is the trip's first city, so its arrival IS the trip's start date (%s). To move when the trip begins, use set_trip_dates; a city's departure day is the NEXT city's arrival, so to change when the traveler leaves %s, move the next city's start_date instead.",
+			run.hub, tripStart.Format(dateLayout), run.hub), true
 	}
 
-	// The previous leg's end is what the trip screen renders as this leg's
-	// visible start (arrival = the neighbor's departure), so a later start
-	// must drag that boundary along. Resolve it before any writes.
+	// What an explicit end_date means changed with the boundary rule
+	// (specs/leg-departure-dates): the page renders a leg's end as the NEXT
+	// city's arrival, its own confirmed stay's check-out, or — for the final
+	// leg — the trip's end date. Only the last two live on rows this leg owns,
+	// so those are the only end-moves this tool performs. An end_date merely
+	// echoing what the page already renders is treated as omitted ("make LA
+	// Sep 24 to 27" when Sep 27 is already the on-screen end is a start move);
+	// anything else refuses with the call that actually moves the boundary —
+	// applying the start half anyway would be the tool fighting the traveler.
+	endBasis := oldLegEnd
+	if newEnd != nil && matchedConfirmedStay(run, stays) == nil {
+		switch {
+		case movedLegNow != nil && movedLegNow.End != nil && newEnd.Equal(*movedLegNow.End):
+			newEnd = nil
+		case nextSpannedNow != nil:
+			steer := fmt.Sprintf("move those items to other days or use shift_days_from(city=%q, days=N)", nextSpannedNow.Label)
+			if nextSpannedNow.Hub != nil {
+				steer = fmt.Sprintf("call set_leg_dates(city=%q, start_date=%q) to move %s (keeping its length), or shift_days_from(city=%q, days=N) to push it and everything after it together",
+					nextSpannedNow.Label, newEnd.Format(dateLayout), nextSpannedNow.Label, nextSpannedNow.Label)
+			}
+			onScreen := ""
+			if movedLegNow.End != nil {
+				onScreen = fmt.Sprintf(" — the page currently shows %s ending %s because %s arrives then", run.hub, movedLegNow.End.Format(dateLayout), nextSpannedNow.Label)
+			}
+			return fmt.Sprintf("%s's departure day is the next city's arrival, not a date of its own%s. Nothing was changed. To have the traveler leave %s on %s, %s. To change only %s's arrival, call set_leg_dates again with start_date and no end_date.",
+				run.hub, onScreen, run.hub, newEnd.Format(dateLayout), steer, run.hub), true
+		case trip.EndDate.Valid && newEnd.Before(trip.EndDate.Time):
+			return fmt.Sprintf("%s is the trip's last city, so it runs through the trip's end date (%s) — an earlier end_date would shorten the whole trip. Nothing was changed. Use set_trip_dates (start_date=%s, end_date=%s) to end the trip on %s, or call set_leg_dates again with start_date only to move just %s's arrival.",
+				run.hub, trip.EndDate.Time.Format(dateLayout), tripStart.Format(dateLayout), newEnd.Format(dateLayout), newEnd.Format(dateLayout), run.hub), true
+		case trip.EndDate.Valid:
+			// Extending the final leg: the departure being moved is the trip's
+			// end date, so the end delta (departing transport) is measured off
+			// it — the raw last item day runs short of it by however many
+			// place-free tail nights the leg holds.
+			endBasis = trip.EndDate.Time
+		}
+	}
+
+	// A confirmed stay on the PREVIOUS leg pins that leg's rendered end to its
+	// check-out (explicit dates never chase an arrival), and computeTripLegs
+	// closes a gap after such a stay by pulling THIS leg's rendered start BACK
+	// to the check-out — which would silently undo the move on screen. So a
+	// later start extends that check-out in the same transaction: the write
+	// edits the same source that renders the boundary. Item-dated neighbours
+	// need no write at all — their rendered end IS this leg's arrival,
+	// wherever it lands. (The old items-case drag — the previous leg's last
+	// item moved onto the new boundary day — died with the end-anchored
+	// renumber: both wrote the retired "last item day = departure" convention
+	// onto days the traveler chose deliberately.) Resolve before any writes.
 	var prevRun *legRun
-	var prevEnd time.Time
 	var prevStay *store.Accommodation
 	if pi := prevDatedRunIdx(runs, matched[0]); pi >= 0 {
 		prevRun = &runs[pi]
-		_, prevEnd = anchoredLegDisplayRange(runs, pi, stays, tripStart)
 		prevStay = matchedConfirmedStay(*prevRun, stays)
 	}
 
-	ch, err := computeLegDateChange(tripStart, oldLegStart, oldLegEnd, start.Time, newEnd)
+	ch, err := computeLegDateChange(tripStart, oldLegStart, endBasis, start.Time, newEnd)
 	switch err {
 	case nil:
 	case errLegEndBeforeStart:
@@ -547,16 +669,21 @@ func runSetLegDatesTool(s *planSession, input json.RawMessage) (string, bool) {
 		return "Could not compute the leg's new dates.", true
 	}
 
-	// Renumber the run's dated items endpoint-anchored: the old last day IS
-	// the leg's departure day (the trip screen renders a leg as [previous
-	// leg's end → max item day]), so its items ride the new END — a
-	// single-item placeholder leg is an end-carrier, not a start-carrier.
-	// Everything else keeps its within-leg offset and folds into the new span
-	// (the item-beyond-span review finding covers the same shape for manual
-	// edits). The shift is the DISPLAY start's delta, not min-item-day
+	// Renumber the run's dated items START-anchored: a leg's items carry its
+	// ARRIVAL and nothing else under the boundary rule, so every item keeps
+	// its within-leg offset and rides the start's delta — a single-item
+	// placeholder leg is a start-carrier. No item is ever dragged onto the new
+	// end: the old END-anchored drag encoded the retired "last item day = the
+	// departure day" convention and moved places the traveler deliberately
+	// kept off the travel day (the Prague Saturday loop). The leg's rendered
+	// end comes from its neighbour, its stay, or the trip's end — never from
+	// where its own items land. When the window shrinks (a stay's check-out
+	// moved earlier), items past the new end fold onto it and the result says
+	// so (the item-beyond-span review finding covers the same shape for
+	// manual edits). The shift is the DISPLAY start's delta, not min-item-day
 	// anchored: for the trip-start-anchored first leg a same-start ask yields
-	// zero, so interior items hold still while only the end-carrier moves;
-	// item-anchored legs get the identical value either way.
+	// zero, so items hold still; item-anchored legs get the identical value
+	// either way.
 	dayShift := ch.startDelta
 	itemsMoved, itemsClamped := 0, 0
 	for _, it := range run.items {
@@ -565,9 +692,7 @@ func runSetLegDatesTool(s *planSession, input json.RawMessage) (string, bool) {
 		}
 		nd := int(*it.Day) + dayShift
 		clamped := false
-		if int(*it.Day) == run.maxDay {
-			nd = ch.newEndIdx
-		} else if nd > ch.newEndIdx {
+		if nd > ch.newEndIdx {
 			nd, clamped = ch.newEndIdx, true
 		} else if nd < ch.newStartIdx {
 			nd = ch.newStartIdx
@@ -654,41 +779,25 @@ func runSetLegDatesTool(s *planSession, input json.RawMessage) (string, bool) {
 		}
 	}
 
-	// Previous-boundary extension (decided 2026-08-05): when the leg now
-	// starts after the previous leg's end, drag that boundary to the new
-	// start in the same transaction — editing the SAME source that produced
-	// prevEnd (its confirmed stay's check-out, else its departure-day items),
-	// so the visible arrival matches the ask. Gap-only: an earlier start
-	// (overlap) still narrates-and-asks, neighbors never shrink.
+	// Previous-boundary extension, stay case only (see the resolution comment
+	// above): a later start drags a pinned check-out along so the page's
+	// arrival matches the ask. Gap-only: an earlier start (overlap between two
+	// explicit stays) renders as it is and the result's legs block shows it —
+	// neighbors never shrink. Skipped when prevStay already moved as part of
+	// THIS leg (degenerate double-hub match): never move a boundary twice.
 	prevExtended := false
 	var prevWasEnd time.Time
-	if prevRun != nil && ch.newStart.After(prevEnd) {
-		prevWasEnd = prevEnd
-		switch {
-		case prevStay != nil && !movedStayIDs[prevStay.ID]:
-			// UpdateAccommodation flips auto=false — harmless, prevStay is
-			// already confirmed; COALESCE keeps check_in.
-			if _, err := q.UpdateAccommodation(s.ctx, store.UpdateAccommodationParams{
-				CheckOut: pgtype.Date{Time: ch.newStart, Valid: true},
-				ID:       prevStay.ID, TripID: tid,
-			}); err != nil {
-				return "Could not extend the previous leg's stay.", true
-			}
-			prevExtended = true
-		case prevStay == nil:
-			for _, it := range prevRun.items {
-				if it.Day == nil || int(*it.Day) != prevRun.maxDay {
-					continue
-				}
-				d32 := int32(ch.newStartIdx)
-				if _, err := q.UpdateItineraryItem(s.ctx, store.UpdateItineraryItemParams{Day: &d32, ID: it.ID, TripID: tid}); err != nil {
-					return "Could not extend the previous leg's days.", true
-				}
-				prevExtended = true
-			}
+	if prevStay != nil && !movedStayIDs[prevStay.ID] && ch.newStart.After(prevStay.CheckOut.Time) {
+		prevWasEnd = prevStay.CheckOut.Time
+		// UpdateAccommodation flips auto=false — harmless, prevStay is
+		// already confirmed; COALESCE keeps check_in.
+		if _, err := q.UpdateAccommodation(s.ctx, store.UpdateAccommodationParams{
+			CheckOut: pgtype.Date{Time: ch.newStart, Valid: true},
+			ID:       prevStay.ID, TripID: tid,
+		}); err != nil {
+			return "Could not extend the previous leg's stay.", true
 		}
-		// prevStay already moved as part of THIS leg (degenerate double-hub
-		// match): leave the boundary alone rather than moving it twice.
+		prevExtended = true
 	}
 
 	tripEndExtended := false
@@ -718,11 +827,11 @@ func runSetLegDatesTool(s *planSession, input json.RawMessage) (string, bool) {
 		if a := matchedConfirmedStay(run, stays); a != nil {
 			fmt.Fprintf(&b, "; its confirmed stay %q runs %s", a.Name, legRangeText(a.CheckIn.Time, a.CheckOut.Time))
 		}
-		if prevRun != nil {
-			fmt.Fprintf(&b, "; the previous leg (%s) ends %s", prevRun.hub, prevEnd.Format(dateLayout))
+		if prevSpanned := prevSpannedRenderedLeg(legsNow, movedLegNow); prevSpanned != nil {
+			fmt.Fprintf(&b, "; on the page the previous leg (%s) runs through %s", prevSpanned.Label, prevSpanned.End.Format(dateLayout))
 		}
-		if visStart, visEnd, ok := renderedLegRange(trip, items, stays, run.hub); ok {
-			fmt.Fprintf(&b, ". The trip page shows this leg as %s (a leg renders from its arrival — the previous leg's visible end, or the trip's start date for the first leg — when that comes first, collapses to a zero-night stop at that arrival when the previous leg has run past this leg's last day, and the LAST leg runs through the trip's end date because the day home carries no places) and was NOT refreshed.", legRangeText(visStart, visEnd))
+		if movedLegNow != nil && movedLegNow.Start != nil && movedLegNow.End != nil {
+			fmt.Fprintf(&b, ". The trip page shows this leg as %s (a leg runs from its own arrival — its first place's day, its stay's check-in, or the trip's start date for the first city — until the NEXT city's arrival; the LAST leg runs through the trip's end date; a leg's own last place never sets its departure) and was NOT refreshed.", legRangeText(*movedLegNow.Start, *movedLegNow.End))
 		} else {
 			b.WriteString(". The trip page was NOT refreshed.")
 		}
@@ -763,21 +872,28 @@ func runSetLegDatesTool(s *planSession, input json.RawMessage) (string, bool) {
 		safeGo("notifyCollabEdit", func() { notifyCollabEdit(tid, s.uid) })
 	}
 
-	rangeText := legRangeText(ch.newStart, ch.newEnd)
+	// The result speaks in the ranges the PAGE now renders, re-read after the
+	// commit (the in-scope items and stays are the pre-move values this
+	// function loaded before the transaction). ch.newStart/newEnd are item-day
+	// arithmetic; quoting them as leg dates is how a call that worked once
+	// reported a span the traveler's screen contradicted, and quoting raw
+	// neighbour spans is how the tool reported a "2-night gap" the page never
+	// drew — a date gap between legs is unrepresentable, the boundary rule
+	// closes it inside the earlier leg. renderedLegForRun keys by position, so
+	// a revisited hub cannot alias.
+	post, postOK := postMoveState(s, tid)
+	var postLegs []RenderLeg
+	var movedAfter *RenderLeg
+	if postOK {
+		postLegs = computeTripLegs(post.trip, post.items, post.stays)
+		movedAfter = renderedLegForRun(postLegs, run)
+	}
 
 	var b strings.Builder
-	fmt.Fprintf(&b, "%s is now %s.", run.hub, rangeText)
-	// ...and then what the PAGE draws, which is not the same claim. rangeText is
-	// item-day math; the rendered span runs from the previous leg's departure
-	// and, on the last leg, through the trip's end date. The no-op branch above
-	// has echoed the rendered range since the Sep-24-27 loop; the SUCCESS branch
-	// never did, so a call that worked reported a span the traveler's screen
-	// contradicted. That gap was one day while every day carried places — the
-	// day-home rule — and is a whole leg once a spine leaves the last city a
-	// single dated place. Re-read post-commit: the in-scope items and stays are
-	// the pre-move values this function loaded before the transaction.
-	if legs := postMoveRenderedLeg(s, tid, run.hub); legs != "" && legs != rangeText {
-		fmt.Fprintf(&b, " The trip page renders this leg as %s — that, not the range above, is what the traveler sees.", legs)
+	if movedAfter != nil && movedAfter.Start != nil && movedAfter.End != nil {
+		fmt.Fprintf(&b, "%s is now %s on the trip page (%s).", run.hub, legRangeText(*movedAfter.Start, *movedAfter.End), nightsText(nightsBetween(*movedAfter.Start, *movedAfter.End)))
+	} else {
+		fmt.Fprintf(&b, "%s's saved dates changed; call get_trip to read the range the page now renders.", run.hub)
 	}
 	var parts []string
 	if itemsMoved > 0 {
@@ -802,39 +918,31 @@ func runSetLegDatesTool(s *planSession, input json.RawMessage) (string, bool) {
 		fmt.Fprintf(&b, " Trip end extended to %s.", ch.newEnd.Format(dateLayout))
 	}
 	if prevExtended {
-		if prevStay != nil {
-			fmt.Fprintf(&b, " %s now ends %s (was %s) — its stay's check-out moved to match this leg's start.", prevRun.hub, ch.newStart.Format(dateLayout), prevWasEnd.Format(dateLayout))
-		} else {
-			fmt.Fprintf(&b, " %s now ends %s (was %s) — its last itinerary day moved to match this leg's start.", prevRun.hub, ch.newStart.Format(dateLayout), prevWasEnd.Format(dateLayout))
+		fmt.Fprintf(&b, " %s now ends %s (was %s) — its stay's check-out moved to match this leg's arrival.", prevRun.hub, ch.newStart.Format(dateLayout), prevWasEnd.Format(dateLayout))
+	}
+
+	// Overlaps ARE representable on the page (an explicit stay running past a
+	// neighbour's arrival), so they are the one neighbour condition still
+	// named here — from the RENDERED spans, never raw item math. Contiguous
+	// legs compare equal (prev.End == this.Start) and stay silent.
+	if movedAfter != nil && movedAfter.Start != nil && movedAfter.End != nil {
+		if prev := prevSpannedRenderedLeg(postLegs, movedAfter); prev != nil && prev.End.After(*movedAfter.Start) {
+			fmt.Fprintf(&b, " NOTE: %s still runs through %s on the page, overlapping this leg's new start — point that out and offer to shorten one of them.", prev.Label, prev.End.Format(dateLayout))
+		}
+		if next := nextSpannedRenderedLeg(postLegs, movedAfter); next != nil && movedAfter.End.After(*next.Start) {
+			fmt.Fprintf(&b, " NOTE: this leg now runs through %s, past %s's arrival (%s) — the two overlap on the page; point that out and offer to fix one of them.", movedAfter.End.Format(dateLayout), next.Label, next.Start.Format(dateLayout))
 		}
 	}
 
-	// Deterministic neighbor narration: the prompt's "point out the gap"
-	// instruction only works if the gap is computed here, not hoped for.
-	// prevEnd is the pre-move value, so the gap branch is skipped once the
-	// boundary extension closed it.
-	if prevRun != nil && !prevExtended {
-		if n := int(ch.newStart.Sub(prevEnd).Hours() / 24); n > 0 {
-			fmt.Fprintf(&b, " NOTE: the previous leg (%s) ends %s but this leg now starts %s — %d uncovered night(s). Point this out to the traveler and offer to extend that stay or fix it with another set_leg_dates call.", prevRun.hub, prevEnd.Format(dateLayout), ch.newStart.Format(dateLayout), n)
-		} else if n < 0 {
-			fmt.Fprintf(&b, " NOTE: the previous leg (%s) ends %s, which now overlaps this leg's start %s by %d night(s). Point this out to the traveler and offer to fix it.", prevRun.hub, prevEnd.Format(dateLayout), ch.newStart.Format(dateLayout), -n)
-		}
-	}
-	if ni := nextDatedRunIdx(runs, matched[0]); ni >= 0 {
-		next := &runs[ni]
-		nextStart, nextEnd := anchoredLegDisplayRange(runs, ni, stays, tripStart)
-		n := int(nextStart.Sub(ch.newEnd).Hours() / 24)
-		switch {
-		// Squeeze first: the next leg's visible span is [this leg's end → its
-		// own departure day], so newEnd reaching its END consumes ALL its
-		// nights even when the starts compare as contiguous (n == 0) — the
-		// exact case gap/overlap math is silent on.
-		case !ch.newEnd.Before(nextEnd):
-			fmt.Fprintf(&b, " NOTE: this leg now ends %s, which reaches the end of the next leg (%s, currently ending %s) — %s has no nights left. Point this out and offer to move %s later with set_leg_dates; if the traveler agrees, also move any legs after it, calling set_leg_dates once per leg in order (earliest first) in this same turn.", ch.newEnd.Format(dateLayout), next.hub, nextEnd.Format(dateLayout), next.hub, next.hub)
-		case n < 0:
-			fmt.Fprintf(&b, " NOTE: this leg now ends %s, overlapping the next leg (%s) which starts %s. Point this out to the traveler and offer to fix it.", ch.newEnd.Format(dateLayout), next.hub, nextStart.Format(dateLayout))
-		case n > 0:
-			fmt.Fprintf(&b, " NOTE: this leg now ends %s but the next leg (%s) starts %s — %d uncovered night(s). Point this out to the traveler and offer to fix it.", ch.newEnd.Format(dateLayout), next.hub, nextStart.Format(dateLayout), n)
+	// The full rendered picture, warning lines included (zero-night arrivals,
+	// stranded places, unplanned tail nights): what used to be bespoke
+	// gap/squeeze NOTEs computed from raw item spans — numbers the page never
+	// drew — is now the ONE summary every legs surface shares (the
+	// shift_days_from result convention).
+	if postOK {
+		if block := legsRenderSummary(post.trip, post.items, post.stays); block != "" {
+			b.WriteString(" The page now renders these city legs:\n" + block +
+				"That, not day arithmetic, is what the traveler sees — relay any range that doesn't match what they asked for, and act on any WARNING above the list.")
 		}
 	}
 
@@ -842,46 +950,42 @@ func runSetLegDatesTool(s *planSession, input json.RawMessage) (string, bool) {
 	return b.String(), false
 }
 
-// postMoveRenderedLeg re-reads a trip a leg-date move just committed and
-// returns the span the page now renders for one hub, or "" when it can't say.
-// Best-effort by design: the write has already committed, so a failed read
-// costs the extra sentence, never the result.
-func postMoveRenderedLeg(s *planSession, tripID uuid.UUID, hub string) string {
+// postMoveTripState is a trip re-read after a leg-date move committed — the
+// state the traveler's refreshed page derives from.
+type postMoveTripState struct {
+	trip  store.Trip
+	items []store.ItineraryItem
+	stays []store.Accommodation
+}
+
+// postMoveState re-reads a trip a leg-date move just committed. Best-effort
+// by design: the write has already committed, so a failed read costs the
+// rendered-range sentences, never the result — and the fallback text sends
+// the model to get_trip rather than letting it quote unverified spans.
+func postMoveState(s *planSession, tripID uuid.UUID) (postMoveTripState, bool) {
 	q := store.New(dbPool)
 	trip, err := q.GetEditableTripByID(s.ctx, store.GetEditableTripByIDParams{ID: tripID, UserID: s.uid})
 	if err != nil {
-		return ""
+		return postMoveTripState{}, false
 	}
 	items, err := q.GetItineraryItemsByTrip(s.ctx, tripID)
 	if err != nil {
-		return ""
+		return postMoveTripState{}, false
 	}
 	stays, err := q.ListAccommodationsByTrip(s.ctx, tripID)
 	if err != nil {
-		return ""
+		return postMoveTripState{}, false
 	}
-	start, end, ok := renderedLegRange(trip, items, stays, hub)
-	if !ok {
-		return ""
-	}
-	return legRangeText(start, end)
+	return postMoveTripState{trip: trip, items: items, stays: stays}, true
 }
 
-// prevDatedRunIdx / nextDatedRunIdx find the nearest movable neighbor for
-// the boundary moves and gap/overlap/squeeze narration; hubless or undated
-// filler runs are skipped. -1 when there is none. Index-returning so callers
-// can resolve ranges through anchoredLegDisplayRange.
+// prevDatedRunIdx finds the nearest movable neighbor before a run — the leg
+// whose confirmed stay, when it has one, pins the boundary this leg's start
+// must drag along. Hubless or undated filler runs are skipped. -1 when there
+// is none. (Its next-side twin died with the raw-span neighbour narration:
+// everything said about a following leg now reads the rendered legs.)
 func prevDatedRunIdx(runs []legRun, i int) int {
 	for j := i - 1; j >= 0; j-- {
-		if runs[j].minDay >= 1 && runs[j].hub != "" {
-			return j
-		}
-	}
-	return -1
-}
-
-func nextDatedRunIdx(runs []legRun, i int) int {
-	for j := i + 1; j < len(runs); j++ {
 		if runs[j].minDay >= 1 && runs[j].hub != "" {
 			return j
 		}

--- a/src/packages/api/plan_leg_dates_test.go
+++ b/src/packages/api/plan_leg_dates_test.go
@@ -1,20 +1,28 @@
 package main
 
-// set_leg_dates (specs/set-leg-dates): one city leg's dates move, the rest of
-// the trip doesn't — except the PREVIOUS leg's end, which extends to meet a
-// later start (the trip screen draws a leg from its neighbor's end, so an
-// unmoved boundary makes the change invisible). Unit tables cover the pure
-// run-splitting and endpoint-anchored delta math; the DB tests assert the
-// headline dogfood scenario (Panama City -> LA -> EWR, "change LA to Sep
-// 24-27"), the placeholder end-carrier shape, honest zero-change results
-// (no commit, no trip_updated), the shrink clamp, the auto-draft skip,
-// overlap narrate-only, validation atomicity, collaborator authz, and
-// lineage resolution on a later turn.
+// set_leg_dates (specs/set-leg-dates + specs/leg-departure-dates ticket 2):
+// one city leg's dates move, the rest of the trip doesn't. Items are
+// START-anchored — they carry the leg's arrival and are never dragged onto a
+// departure day — and a PREVIOUS leg pinned by a confirmed stay has its
+// check-out extended to meet a later start (computeTripLegs would otherwise
+// pull the moved leg's rendered start back to that check-out). An explicit
+// end_date is honoured only where the departure lives on this leg's own rows
+// (stay check-out, or the trip end for the final leg); elsewhere it refuses
+// and steers. Every range a result states about any leg comes from
+// computeTripLegs — the acceptance-5 sweep below asserts it date by date.
+// Unit tables cover the pure run-splitting and delta math; the DB tests
+// assert the headline dogfood scenario (Panama City -> LA -> EWR, "change LA
+// to Sep 24-27"), the placeholder start-carrier shape, honest zero-change
+// results (no commit, no trip_updated), the end_date gate's three verdicts,
+// the shrink clamp, the auto-draft skip, overlap narration from rendered
+// spans, validation atomicity, collaborator authz, and lineage resolution on
+// a later turn.
 
 import (
 	"context"
 	"fmt"
 	"net/http"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -143,6 +151,13 @@ func TestLegRunsAndMatching(t *testing.T) {
 // LAST (the trip has no end date, so its single item day is all it has), and
 // the last leg legitimately ends on the day the traveler flies home.
 // TestLegsRenderWarning covers the case that does warn.
+//
+// The "Unplanned stretches" soft block leads on this placeholder-shaped trip
+// and that is deliberate: each city's single item is its arrival marker, so
+// the tail nights genuinely hold no plans — a true, softly-framed fact
+// ("mention, don't fix"), not a render defect. It is also the honest
+// replacement for the retired "gap between legs" narration: the unplanned
+// nights sit INSIDE Prague, they are not a hole between Prague and Kraków.
 func TestLegsRenderSummary(t *testing.T) {
 	items := []store.ItineraryItem{
 		legItem(0, "Prague", "", 4),  // first leg, anchored to trip start
@@ -150,7 +165,10 @@ func TestLegsRenderSummary(t *testing.T) {
 		legItem(2, "Berlin", "", 12), // Sep 4
 	}
 	got := legsRenderSummary(rlTrip("2026-08-24", ""), items, nil)
-	want := "- Prague: 2026-08-24 to 2026-09-02 (9 nights, dated by its places)\n" +
+	want := "Unplanned stretches — true on the page, fine if intended (mention, don't fix): " +
+		"Prague renders 2026-08-24 to 2026-09-02 (9 nights) but its last place is 2026-08-27 — 6 nights with nothing planned; " +
+		"Kraków renders 2026-09-02 to 2026-09-04 (2 nights) but its last place is 2026-09-02 — 2 nights with nothing planned.\n" +
+		"- Prague: 2026-08-24 to 2026-09-02 (9 nights, dated by its places)\n" +
 		"- Kraków: 2026-09-02 to 2026-09-04 (2 nights, dated by its places)\n" +
 		"- Berlin: 2026-09-04 to 2026-09-04 (0 nights, dated by its places)\n"
 	if got != want {
@@ -257,6 +275,61 @@ func daysEqual(a []int, b ...int) bool {
 	return true
 }
 
+var legDateRe = regexp.MustCompile(`\d{4}-\d{2}-\d{2}`)
+
+// assertDatesFromRenderedLegs is acceptance 5 of specs/leg-departure-dates,
+// date by date: every YYYY-MM-DD a set_leg_dates result states must be a date
+// the trip's CURRENT rendered legs also state — or the trip row's own dates,
+// a saved item's calendar day (results may cite where places sit), or a date
+// the caller's ask itself supplied (extra). Anything else is a number from a
+// derivation the page doesn't render, the class of defect that produced the
+// "2-night gap" report over a gapless screen.
+func assertDatesFromRenderedLegs(t *testing.T, msg string, tripID, ownerID uuid.UUID, extra ...string) {
+	t.Helper()
+	ctx := context.Background()
+	q := store.New(dbPool)
+	trip, err := q.GetEditableTripByID(ctx, store.GetEditableTripByIDParams{ID: tripID, UserID: ownerID})
+	if err != nil {
+		t.Fatalf("sweep trip read: %v", err)
+	}
+	items, err := q.GetItineraryItemsByTrip(ctx, tripID)
+	if err != nil {
+		t.Fatalf("sweep items read: %v", err)
+	}
+	stays, err := q.ListAccommodationsByTrip(ctx, tripID)
+	if err != nil {
+		t.Fatalf("sweep stays read: %v", err)
+	}
+	allowed := map[string]bool{}
+	for _, d := range extra {
+		allowed[d] = true
+	}
+	if trip.StartDate.Valid {
+		allowed[trip.StartDate.Time.Format(dateLayout)] = true
+		for _, it := range items {
+			if it.Day != nil && *it.Day >= 1 {
+				allowed[trip.StartDate.Time.AddDate(0, 0, int(*it.Day)-1).Format(dateLayout)] = true
+			}
+		}
+	}
+	if trip.EndDate.Valid {
+		allowed[trip.EndDate.Time.Format(dateLayout)] = true
+	}
+	for _, leg := range computeTripLegs(trip, items, stays) {
+		if leg.Start != nil {
+			allowed[leg.Start.Format(dateLayout)] = true
+		}
+		if leg.End != nil {
+			allowed[leg.End.Format(dateLayout)] = true
+		}
+	}
+	for _, d := range legDateRe.FindAllString(msg, -1) {
+		if !allowed[d] {
+			t.Fatalf("result states %s, a date neither the rendered legs, the trip row, the saved items, nor the ask carries:\n%s", d, msg)
+		}
+	}
+}
+
 // The headline dogfood scenario: "change LA to Sep 24-27" moves the LA items,
 // stay, and boundary flights (by DIFFERENT deltas), extends the trip end,
 // drags Panama City's stay check-out to the new arrival (boundary extension),
@@ -295,19 +368,30 @@ func TestPlanSetLegDatesMovesOneLeg(t *testing.T) {
 	}
 	followUp := string(reqs[1])
 	for _, want := range []string{
-		"Los Angeles is now 2026-09-24 to 2026-09-27",
+		// The headline and every neighbour range are the PAGE's — from
+		// computeTripLegs, re-read after the commit (acceptance 5).
+		"Los Angeles is now 2026-09-24 to 2026-09-27 on the trip page (3 nights)",
 		"Trip end extended to 2026-09-27",
 		"Panama City now ends 2026-09-24 (was 2026-09-20)",
-		"check-out moved to match this leg's start",
+		"check-out moved to match this leg's arrival",
+		"The page now renders these city legs:",
+		"- Panama City: 2026-09-15 to 2026-09-24",
+		"- Los Angeles: 2026-09-24 to 2026-09-27",
 		"ORIGINAL dates",
 	} {
 		if !strings.Contains(followUp, want) {
 			t.Fatalf("tool_result round-trip missing %q:\n%s", want, followUp)
 		}
 	}
-	// The boundary extension closed the gap, so no uncovered-nights NOTE.
-	if strings.Contains(followUp, "uncovered night(s)") {
-		t.Fatalf("gap NOTE should be suppressed after the boundary extension:\n%s", followUp)
+	// A date gap between two legs is unrepresentable on the page — no result
+	// may claim one. (followUp is the whole model request, and the system
+	// prompt still says "gap" until ticket 4 rewrites it, so this pins the
+	// retired TOOL strings; TestPlanSetLegDatesResultQuotesOnlyRenderedDates
+	// sweeps the bare result text.)
+	for _, stale := range []string{"uncovered night(s)", "has no nights left", "set_leg_dates once per leg in order"} {
+		if strings.Contains(followUp, stale) {
+			t.Fatalf("result carries the retired raw-span NOTE %q:\n%s", stale, followUp)
+		}
 	}
 
 	if got := legDays(t, trip.ID, "Los Angeles"); !daysEqual(got, 10, 11, 12, 13) {
@@ -351,8 +435,10 @@ func TestPlanSetLegDatesMovesOneLeg(t *testing.T) {
 
 // seedPlaceholderTwoCityTrip is the shape import + placeholder itineraries
 // produce (and the real dogfood trip that exposed the invisible-move bug):
-// one city-filler item per city whose single day encodes the leg's DEPARTURE,
-// no stays or segments at all.
+// one city-filler item per city, no stays or segments at all. The day values
+// were historically written to encode each leg's DEPARTURE; the boundary rule
+// reads a leg's items as its ARRIVAL evidence, so this same shape renders
+// Panama City Sep 15–24 and Los Angeles Sep 24–27 (the trip end).
 func seedPlaceholderTwoCityTrip(t *testing.T, trip store.Trip, owner uuid.UUID) {
 	t.Helper()
 	ctx := context.Background()
@@ -378,11 +464,15 @@ func seedPlaceholderTwoCityTrip(t *testing.T, trip store.Trip, owner uuid.UUID) 
 	}
 }
 
-// A single-item placeholder leg is an END-carrier: its one day is the
-// departure day the screen renders, so "LA Sep 24-27" must land that item on
-// Sep 27 and drag Panama City's departure day to Sep 24 — the exact ask that
-// used to "succeed" while the page never changed.
-func TestPlanSetLegDatesPlaceholderEndCarrier(t *testing.T) {
+// A single-item placeholder leg is a START-carrier under the boundary rule:
+// its one day is the ARRIVAL the screen renders, its end comes from the trip
+// (or the next city). "LA Sep 24-27" on this trip asks for exactly what the
+// page already shows — LA's item sits on Sep 24 and the trip ends Sep 27 — so
+// the honest answer is a no-op that SAYS the page already shows it. The old
+// end-anchored renumber instead dragged LA's item to Sep 27 and Panama
+// City's to Sep 24, "succeeding" into a corrupted spine that rendered LA as
+// a Sep 27 arrival-day visit.
+func TestPlanSetLegDatesPlaceholderAlreadyRenderedIsNoOp(t *testing.T) {
 	resetDB(t)
 	user, _ := createTestUser(t, "placeholder@example.com")
 	trip := createTestTrip(t, user.ID, 0)
@@ -392,68 +482,98 @@ func TestPlanSetLegDatesPlaceholderEndCarrier(t *testing.T) {
 	s.boundTripID = &trip.ID
 	msg, isErr := runSetLegDatesTool(s, []byte(`{"city":"Los Angeles","start_date":"2026-09-24","end_date":"2026-09-27"}`))
 	if isErr {
-		t.Fatalf("placeholder move errored: %s", msg)
+		t.Fatalf("placeholder no-op errored: %s", msg)
 	}
 	for _, want := range []string{
-		"Los Angeles is now 2026-09-24 to 2026-09-27",
-		"Panama City now ends 2026-09-24 (was 2026-09-20)",
-		"last itinerary day moved to match this leg's start",
+		"No saved rows changed",
+		"shows this leg as 2026-09-24 to 2026-09-27",
+		"was NOT refreshed",
 	} {
 		if !strings.Contains(msg, want) {
 			t.Fatalf("result missing %q: %s", want, msg)
 		}
 	}
-	if !strings.Contains(rec.Body.String(), "trip_updated") {
-		t.Fatal("placeholder move did not emit trip_updated")
+	if strings.Contains(rec.Body.String(), "trip_updated") {
+		t.Fatal("no-op emitted trip_updated")
 	}
-	if got := legDays(t, trip.ID, "Los Angeles"); !daysEqual(got, 13) {
-		t.Fatalf("LA day = %v, want [13] (Sep 27, the departure day)", got)
+	if got := legDays(t, trip.ID, "Los Angeles"); !daysEqual(got, 10) {
+		t.Fatalf("LA day = %v, want [10] (Sep 24, the arrival) unmoved", got)
 	}
-	if got := legDays(t, trip.ID, "Panama City"); !daysEqual(got, 10) {
-		t.Fatalf("PC day = %v, want [10] (Sep 24, the new boundary)", got)
+	if got := legDays(t, trip.ID, "Panama City"); !daysEqual(got, 6) {
+		t.Fatalf("PC day = %v, want [6] unmoved — item-dated neighbours need no boundary write", got)
 	}
 	if start, end := tripDates(t, trip.ID); start != "2026-09-15" || end != "2026-09-27" {
 		t.Fatalf("trip dates = %s/%s, want unchanged 2026-09-15/2026-09-27", start, end)
 	}
 }
 
-// Re-asking for a state the trip already holds must commit nothing, emit NO
+// A real placeholder move rides the START: "arrive LA Sep 22" lands LA's
+// single item on Sep 22 and touches nothing else — Panama City's rendered end
+// follows LA's arrival by derivation, with no physical write to its items.
+func TestPlanSetLegDatesPlaceholderRidesTheStart(t *testing.T) {
+	resetDB(t)
+	user, _ := createTestUser(t, "placestart@example.com")
+	trip := createTestTrip(t, user.ID, 0)
+	seedPlaceholderTwoCityTrip(t, trip, user.ID)
+
+	s, rec := testPlanSession(true, user.ID)
+	s.boundTripID = &trip.ID
+	msg, isErr := runSetLegDatesTool(s, []byte(`{"city":"Los Angeles","start_date":"2026-09-22"}`))
+	if isErr {
+		t.Fatalf("placeholder start move errored: %s", msg)
+	}
+	for _, want := range []string{
+		"Los Angeles is now 2026-09-22 to 2026-09-27 on the trip page (5 nights)",
+		"- Panama City: 2026-09-15 to 2026-09-22",
+		"- Los Angeles: 2026-09-22 to 2026-09-27",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("result missing %q: %s", want, msg)
+		}
+	}
+	if !strings.Contains(rec.Body.String(), "trip_updated") {
+		t.Fatal("start move did not emit trip_updated")
+	}
+	if got := legDays(t, trip.ID, "Los Angeles"); !daysEqual(got, 8) {
+		t.Fatalf("LA day = %v, want [8] (Sep 22, the arrival — never an end anchor)", got)
+	}
+	if got := legDays(t, trip.ID, "Panama City"); !daysEqual(got, 6) {
+		t.Fatalf("PC day = %v, want [6] unmoved", got)
+	}
+	if start, end := tripDates(t, trip.ID); start != "2026-09-15" || end != "2026-09-27" {
+		t.Fatalf("trip dates = %s/%s, want unchanged 2026-09-15/2026-09-27", start, end)
+	}
+}
+
+// Asking for a state the trip already holds must commit nothing, emit NO
 // trip_updated (no phantom "Trip updated" chip), and report the ACTUAL saved
-// state — never echo the requested range as if it were achieved.
+// state — the raw item positions labelled as such, the neighbour's RENDERED
+// end, and the range the page shows — never echo the requested range as if it
+// were achieved. Under the boundary rule "LA Sep 24-27" on this placeholder
+// trip is already what the page renders, so the very first call is a no-op:
+// the old renumber instead "succeeded" by dragging both cities' items.
 func TestPlanSetLegDatesNoOpIsHonest(t *testing.T) {
 	resetDB(t)
 	user, _ := createTestUser(t, "noophonest@example.com")
 	trip := createTestTrip(t, user.ID, 0)
 	seedPlaceholderTwoCityTrip(t, trip, user.ID)
-
-	s1, _ := testPlanSession(true, user.ID)
-	s1.boundTripID = &trip.ID
-	if msg, isErr := runSetLegDatesTool(s1, []byte(`{"city":"Los Angeles","start_date":"2026-09-24","end_date":"2026-09-27"}`)); isErr {
-		t.Fatalf("first move errored: %s", msg)
-	}
 	var touchedAt time.Time
 	if err := dbPool.QueryRow(context.Background(),
 		`SELECT updated_at FROM trips WHERE id = $1`, trip.ID).Scan(&touchedAt); err != nil {
 		t.Fatalf("updated_at query: %v", err)
 	}
 
-	s2, rec2 := testPlanSession(true, user.ID)
-	s2.boundTripID = &trip.ID
-	msg, isErr := runSetLegDatesTool(s2, []byte(`{"city":"Los Angeles","start_date":"2026-09-24","end_date":"2026-09-27"}`))
+	s, rec := testPlanSession(true, user.ID)
+	s.boundTripID = &trip.ID
+	msg, isErr := runSetLegDatesTool(s, []byte(`{"city":"Los Angeles","start_date":"2026-09-24","end_date":"2026-09-27"}`))
 	if isErr {
 		t.Fatalf("no-op errored: %s", msg)
 	}
 	for _, want := range []string{
 		"No saved rows changed",
-		"itinerary items sit on 2026-09-27 to 2026-09-27 (trip days 13-13)",
-		"the previous leg (Panama City) ends 2026-09-24",
-		// LA's single placeholder item sits on its DEPARTURE day (the old
-		// end-anchored renumber's doing), and under the boundary rule a leg's
-		// first item day is its arrival — so the page renders LA as a Sep 27
-		// arrival-day visit and the no-op quotes exactly that, not the range
-		// the earlier call requested. Ticket 2 (specs/leg-departure-dates)
-		// re-anchors the renumber; until then the honest quote IS the point.
-		"shows this leg as 2026-09-27 to 2026-09-27",
+		"itinerary items sit on 2026-09-24 to 2026-09-24 (trip days 10-10)",
+		"on the page the previous leg (Panama City) runs through 2026-09-24",
+		"shows this leg as 2026-09-24 to 2026-09-27",
 		"was NOT refreshed",
 	} {
 		if !strings.Contains(msg, want) {
@@ -463,14 +583,14 @@ func TestPlanSetLegDatesNoOpIsHonest(t *testing.T) {
 	if strings.Contains(msg, "already spans") {
 		t.Fatalf("no-op result echoes the request as achieved: %s", msg)
 	}
-	if strings.Contains(rec2.Body.String(), "trip_updated") {
+	if strings.Contains(rec.Body.String(), "trip_updated") {
 		t.Fatal("no-op emitted trip_updated")
 	}
-	if s2.tripID != nil || s2.itineraryEmitted {
+	if s.tripID != nil || s.itineraryEmitted {
 		t.Fatal("no-op set session itinerary state")
 	}
-	if got := legDays(t, trip.ID, "Los Angeles"); !daysEqual(got, 13) {
-		t.Fatalf("LA day = %v, want [13] unchanged", got)
+	if got := legDays(t, trip.ID, "Los Angeles"); !daysEqual(got, 10) {
+		t.Fatalf("LA day = %v, want [10] unchanged", got)
 	}
 	var after time.Time
 	if err := dbPool.QueryRow(context.Background(),
@@ -483,7 +603,9 @@ func TestPlanSetLegDatesNoOpIsHonest(t *testing.T) {
 }
 
 // Moving a leg EARLIER than the previous leg's end never shrinks the
-// neighbor — the overlap is narrated for the agent to raise instead.
+// neighbor — the overlap (two explicit stays covering the same nights, which
+// the page really does draw) is narrated from the RENDERED spans for the
+// agent to raise instead.
 func TestPlanSetLegDatesOverlapNarratesOnly(t *testing.T) {
 	resetDB(t)
 	user, _ := createTestUser(t, "overlap@example.com")
@@ -496,8 +618,13 @@ func TestPlanSetLegDatesOverlapNarratesOnly(t *testing.T) {
 	if isErr {
 		t.Fatalf("overlap move errored: %s", msg)
 	}
-	if !strings.Contains(msg, "overlaps this leg's start 2026-09-18 by 2 night(s)") {
-		t.Fatalf("result missing the overlap NOTE: %s", msg)
+	for _, want := range []string{
+		"Los Angeles is now 2026-09-18 to 2026-09-20 on the trip page (2 nights)",
+		"NOTE: Panama City still runs through 2026-09-20 on the page, overlapping this leg's new start",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("result missing %q: %s", want, msg)
+		}
 	}
 	if in, out := scanDates(t, `SELECT check_in, check_out FROM accommodations WHERE trip_id = $1 AND name = $2`, trip.ID, "Hotel Casco Viejo"); in != "2026-09-15" || out != "2026-09-20" {
 		t.Fatalf("PC stay = %s/%s, want untouched (neighbors never shrink)", in, out)
@@ -505,10 +632,10 @@ func TestPlanSetLegDatesOverlapNarratesOnly(t *testing.T) {
 }
 
 // seedPragueKrakowBerlinTrip is Brian's real post-move trip head: single
-// placeholder items whose day encodes each city's DEPARTURE, first city's
-// item pushed past day 1 by an earlier boundary extension, no stays or
-// segments. krakowDay parameterizes the middle leg (9 = the squeezed state,
-// 6 = the pre-squeeze state).
+// placeholder items (read as each city's ARRIVAL evidence under the boundary
+// rule), the first city's item sitting past day 1, no stays or segments.
+// krakowDay parameterizes the middle leg (9 = sharing Berlin's arrival day,
+// 6 = a clean chain, 10 = inverted past Berlin).
 func seedPragueKrakowBerlinTrip(t *testing.T, trip store.Trip, owner uuid.UUID, krakowDay int) {
 	t.Helper()
 	ctx := context.Background()
@@ -546,14 +673,14 @@ func TestPlanSetLegDatesFirstLegNoOpReportsAnchoredRange(t *testing.T) {
 
 	s, rec := testPlanSession(true, user.ID)
 	s.boundTripID = &trip.ID
-	msg, isErr := runSetLegDatesTool(s, []byte(`{"city":"Prague","start_date":"2026-08-24","end_date":"2026-08-27"}`))
+	msg, isErr := runSetLegDatesTool(s, []byte(`{"city":"Prague","start_date":"2026-08-24"}`))
 	if isErr {
 		t.Fatalf("first-leg no-op errored: %s", msg)
 	}
 	for _, want := range []string{
 		"No saved rows changed",
 		"itinerary items sit on 2026-08-27 to 2026-08-27 (trip days 4-4)",
-		// The anchored START is still quoted; the end is now Kraków's day-9
+		// The anchored START is still quoted; the end is Kraków's day-9
 		// arrival (Sep 1), the boundary rule — not Prague's own item day.
 		"shows this leg as 2026-08-24 to 2026-09-01",
 		"was NOT refreshed",
@@ -567,6 +694,45 @@ func TestPlanSetLegDatesFirstLegNoOpReportsAnchoredRange(t *testing.T) {
 	}
 	if got := legDays(t, trip.ID, "Prague"); !daysEqual(got, 4) {
 		t.Fatalf("Prague day = %v, want [4] unchanged", got)
+	}
+}
+
+// An explicit end_date on a leg whose departure belongs to its neighbour
+// refuses and steers — including on the FIRST leg, whose old steer text
+// promised "call again with the new end_date", a promise the tool no longer
+// keeps. The refusal names the next city, quotes only rendered dates, and
+// spells the exact replacement call.
+func TestPlanSetLegDatesFirstLegEndSteersToNextArrival(t *testing.T) {
+	resetDB(t)
+	user, _ := createTestUser(t, "firstlegend@example.com")
+	trip := createTestTrip(t, user.ID, 0)
+	seedPragueKrakowBerlinTrip(t, trip, user.ID, 9)
+
+	s, rec := testPlanSession(true, user.ID)
+	s.boundTripID = &trip.ID
+	msg, isErr := runSetLegDatesTool(s, []byte(`{"city":"Prague","start_date":"2026-08-24","end_date":"2026-08-27"}`))
+	if !isErr {
+		t.Fatalf("first-leg end change did not refuse: %s", msg)
+	}
+	for _, want := range []string{
+		"Prague's departure day is the next city's arrival",
+		"shows Prague ending 2026-09-01 because Kraków arrives then",
+		`set_leg_dates(city="Kraków", start_date="2026-08-27")`,
+		"shift_days_from",
+		"Nothing was changed",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("steer missing %q: %s", want, msg)
+		}
+	}
+	if strings.Contains(rec.Body.String(), "trip_updated") {
+		t.Fatal("refusal emitted trip_updated")
+	}
+	if got := legDays(t, trip.ID, "Prague"); !daysEqual(got, 4) {
+		t.Fatalf("Prague day = %v, want [4] untouched", got)
+	}
+	if got := legDays(t, trip.ID, "Kraków"); !daysEqual(got, 9) {
+		t.Fatalf("Kraków day = %v, want [9] untouched", got)
 	}
 }
 
@@ -596,11 +762,15 @@ func TestPlanSetLegDatesFirstLegStartSteersToTripDates(t *testing.T) {
 	}
 }
 
-// Extending a leg onto the next leg's departure day consumes ALL its nights
-// while the start math reads as contiguous (n == 0) — the squeeze NOTE must
-// name the eaten leg and tell the agent to chain fixes. This replays exactly
-// how Kraków's extension silently zeroed Berlin on Brian's trip.
-func TestPlanSetLegDatesSqueezeNoteNamesNextLeg(t *testing.T) {
+// The squeeze, in its post-boundary-rule shape: an END can no longer consume
+// the next leg (an interior end_date refuses), but a START moved onto the
+// next city's arrival pinches the MOVED leg to zero nights. The result's
+// rendered-legs block carries the warning — computed by the one derivation,
+// naming the city that shares the day — and the moved leg's own headline
+// states the zero-night range. The acceptance-5 sweep runs here: every date
+// this success result states is a date the rendered legs (or the saved
+// items, or the trip row) also state.
+func TestPlanSetLegDatesStartOntoNextArrivalWarnsZeroNight(t *testing.T) {
 	resetDB(t)
 	user, _ := createTestUser(t, "squeeze@example.com")
 	trip := createTestTrip(t, user.ID, 0)
@@ -608,27 +778,34 @@ func TestPlanSetLegDatesSqueezeNoteNamesNextLeg(t *testing.T) {
 
 	s, rec := testPlanSession(true, user.ID)
 	s.boundTripID = &trip.ID
-	msg, isErr := runSetLegDatesTool(s, []byte(`{"city":"Kraków","start_date":"2026-08-27","end_date":"2026-09-01"}`))
+	msg, isErr := runSetLegDatesTool(s, []byte(`{"city":"Kraków","start_date":"2026-09-01"}`))
 	if isErr {
-		t.Fatalf("squeeze move errored: %s", msg)
+		t.Fatalf("zero-night move errored: %s", msg)
 	}
 	for _, want := range []string{
-		"Kraków is now 2026-08-27 to 2026-09-01",
-		"Berlin has no nights left",
-		"set_leg_dates once per leg in order",
+		"Kraków is now 2026-09-01 to 2026-09-01 on the trip page (0 nights)",
+		"WARNING",
+		"Kraków renders ZERO nights — the next city (Berlin) arrives on or before it",
+		"- Prague: 2026-08-24 to 2026-09-01",
 	} {
 		if !strings.Contains(msg, want) {
 			t.Fatalf("result missing %q: %s", want, msg)
 		}
 	}
-	if !strings.Contains(rec.Body.String(), "trip_updated") {
-		t.Fatal("squeeze move did not emit trip_updated")
+	for _, stale := range []string{"has no nights left", "set_leg_dates once per leg in order", "uncovered night(s)"} {
+		if strings.Contains(msg, stale) {
+			t.Fatalf("result carries the retired raw-span NOTE %q: %s", stale, msg)
+		}
 	}
+	if !strings.Contains(rec.Body.String(), "trip_updated") {
+		t.Fatal("zero-night move did not emit trip_updated")
+	}
+	assertDatesFromRenderedLegs(t, msg, trip.ID, user.ID)
 	if got := legDays(t, trip.ID, "Kraków"); !daysEqual(got, 9) {
-		t.Fatalf("Kraków day = %v, want [9] (Sep 1, the departure)", got)
+		t.Fatalf("Kraków day = %v, want [9] (Sep 1, the new arrival)", got)
 	}
 	if got := legDays(t, trip.ID, "Prague"); !daysEqual(got, 4) {
-		t.Fatalf("Prague day = %v, want [4] (contiguous — no boundary move)", got)
+		t.Fatalf("Prague day = %v, want [4] (item-dated neighbours get no boundary write)", got)
 	}
 	if got := legDays(t, trip.ID, "Berlin"); !daysEqual(got, 9) {
 		t.Fatalf("Berlin day = %v, want [9] (next leg never auto-moves)", got)
@@ -638,26 +815,28 @@ func TestPlanSetLegDatesSqueezeNoteNamesNextLeg(t *testing.T) {
 // An INVERTED pair (Kraków's item day sits past Berlin's) no longer collapses
 // Berlin: under the boundary rule Berlin's day-9 item is its ARRIVAL and the
 // trip-end anchor runs it to Sep 27, while Kraków is the leg that pinches.
-// The no-op report must quote the range the page actually renders, not the
-// stale item dates; and the natural fix ask (move Berlin to Kraków's end) must
-// be a real move, not a no-op.
+// The no-op report must quote the range the page actually renders — and the
+// neighbour's RENDERED end, not its raw item day; and the natural fix ask
+// (move Berlin's arrival to Sep 2) must be a real move, not a no-op.
 func TestPlanSetLegDatesInvertedLegNoOpQuotesRenderedRange(t *testing.T) {
 	resetDB(t)
 	user, _ := createTestUser(t, "inverted@example.com")
 	trip := createTestTrip(t, user.ID, 0)
-	// Kraków day 10 (Sep 2) ends AFTER Berlin's day 9 (Sep 1): strict inversion.
+	// Kraków day 10 (Sep 2) sits AFTER Berlin's day 9 (Sep 1): strict inversion.
 	seedPragueKrakowBerlinTrip(t, trip, user.ID, 10)
 
 	s1, rec1 := testPlanSession(true, user.ID)
 	s1.boundTripID = &trip.ID
-	msg, isErr := runSetLegDatesTool(s1, []byte(`{"city":"Berlin","start_date":"2026-09-01","end_date":"2026-09-01"}`))
+	msg, isErr := runSetLegDatesTool(s1, []byte(`{"city":"Berlin","start_date":"2026-09-01"}`))
 	if isErr {
 		t.Fatalf("inverted no-op errored: %s", msg)
 	}
 	for _, want := range []string{
 		"No saved rows changed",
 		"itinerary items sit on 2026-09-01 to 2026-09-01 (trip days 9-9)",
-		"the previous leg (Kraków) ends 2026-09-02",
+		// Kraków pinches to a zero-night stop at its own Sep 2 arrival — that
+		// is its rendered end, and the only end a result may quote.
+		"on the page the previous leg (Kraków) runs through 2026-09-02",
 		"shows this leg as 2026-09-01 to 2026-09-27",
 		"was NOT refreshed",
 	} {
@@ -672,15 +851,15 @@ func TestPlanSetLegDatesInvertedLegNoOpQuotesRenderedRange(t *testing.T) {
 		t.Fatalf("Berlin day = %v, want [9] unchanged", got)
 	}
 
-	// The fix: move Berlin to the arrival day — a real move.
+	// The fix: move Berlin's arrival to Sep 2 — a real move.
 	s2, rec2 := testPlanSession(true, user.ID)
 	s2.boundTripID = &trip.ID
-	msg, isErr = runSetLegDatesTool(s2, []byte(`{"city":"Berlin","start_date":"2026-09-02","end_date":"2026-09-02"}`))
+	msg, isErr = runSetLegDatesTool(s2, []byte(`{"city":"Berlin","start_date":"2026-09-02"}`))
 	if isErr {
 		t.Fatalf("fix move errored: %s", msg)
 	}
-	if !strings.Contains(msg, "Berlin is now 2026-09-02 to 2026-09-02") {
-		t.Fatalf("fix result missing new range: %s", msg)
+	if !strings.Contains(msg, "Berlin is now 2026-09-02 to 2026-09-27 on the trip page") {
+		t.Fatalf("fix result missing new rendered range: %s", msg)
 	}
 	if !strings.Contains(rec2.Body.String(), "trip_updated") {
 		t.Fatal("fix move did not emit trip_updated")
@@ -703,9 +882,9 @@ func TestPlanSetLegDatesShrinkClampsItems(t *testing.T) {
 	if isErr {
 		t.Fatalf("shrink errored: %s", msg)
 	}
-	// Day 9 is the end-carrier (an anchor move, not a fold), so only day 8
-	// counts as clamped.
-	for _, want := range []string{"folded onto 2026-09-25", "1 item(s)"} {
+	// Items ride the start (+4 → days 10..13); the window ends day 11, so days
+	// 12 and 13 both fold — no end-carrier exemption exists anymore.
+	for _, want := range []string{"folded onto 2026-09-25", "2 item(s)"} {
 		if !strings.Contains(msg, want) {
 			t.Fatalf("result missing %q: %s", want, msg)
 		}
@@ -907,13 +1086,14 @@ func TestPlanSetLegDatesFreshChatNextTurnLineage(t *testing.T) {
 	if got := legDays(t, tid, "Santorini"); !daysEqual(got, 3, 4) {
 		t.Fatalf("Santorini days = %v, want [3 4]", got)
 	}
-	// Athens has no confirmed stay, so the boundary extension moves its last
-	// itinerary day to Santorini's new start — and the result says so.
-	if got := legDays(t, tid, "Athens"); !daysEqual(got, 3) {
-		t.Fatalf("Athens days = %v, want [3] (boundary extension)", got)
+	// Athens is item-dated, so it needs NO boundary write: its rendered end IS
+	// Santorini's new arrival, and the result's legs block states it. (The old
+	// items-case extension physically dragged Athens' day-1 item to day 3.)
+	if got := legDays(t, tid, "Athens"); !daysEqual(got, 1) {
+		t.Fatalf("Athens days = %v, want [1] untouched", got)
 	}
-	if reqs := fa2.requestBodies(); len(reqs) < 2 || !strings.Contains(string(reqs[1]), "Athens now ends 2026-06-03 (was 2026-06-01)") {
-		t.Fatalf("missing Athens boundary narration in follow-up request")
+	if reqs := fa2.requestBodies(); len(reqs) < 2 || !strings.Contains(string(reqs[1]), "- Athens: 2026-06-01 to 2026-06-03") {
+		t.Fatalf("missing Athens rendered range in follow-up request")
 	}
 	if _, end := tripDates(t, tid); end != "2026-06-04" {
 		t.Fatalf("trip end = %s, want extended to 2026-06-04", end)
@@ -928,13 +1108,172 @@ func TestPlanSetLegDatesFreshChatNextTurnLineage(t *testing.T) {
 	}
 }
 
-// The two ways a spine's dates go wrong, named ABOVE the leg list so the model
-// meets them before the ranges they describe.
+// The ticket's spine — the Berlin/Gothenburg incident, replayed against the
+// gate. The observed failure: Berlin's places end Sep 10, Gothenburg's first
+// place is Sep 12, and the tool reported "a 2-night gap between Berlin (ends
+// Sep 10) and Gothenburg (starts Sep 12)" while the page drew Berlin running
+// to Sep 12 — raw item spans quoted as screen dates. Now: the end-change
+// refuses (Berlin's departure IS Gothenburg's arrival), the refusal quotes
+// only rendered dates, names the exact replacement call, and claims no gap.
+func TestPlanSetLegDatesEndOnInteriorLegRefusesAndSteers(t *testing.T) {
+	resetDB(t)
+	user, _ := createTestUser(t, "berlingot@example.com")
+	trip := createTestTrip(t, user.ID, 0)
+	ctx := context.Background()
+	q := store.New(dbPool)
+	if _, err := q.UpdateTrip(ctx, store.UpdateTripParams{
+		ID: trip.ID, UserID: user.ID,
+		StartDate: validDate("2026-09-07"), EndDate: validDate("2026-09-15"),
+	}); err != nil {
+		t.Fatalf("seed trip dates: %v", err)
+	}
+	for i, seed := range []struct {
+		name, city string
+		day        int
+	}{
+		{"Museum Island", "Berlin", 1},
+		{"East Side Gallery", "Berlin", 4}, // Sep 10 — Berlin's last place
+		{"Haga District", "Gothenburg", 6}, // Sep 12 — Berlin's rendered end
+		{"Liseberg", "Gothenburg", 8},
+	} {
+		d := int32(seed.day)
+		city := seed.city
+		if _, err := q.CreateItineraryItem(ctx, store.CreateItineraryItemParams{
+			TripID: trip.ID, Position: int32(i), Name: seed.name,
+			City: &city, Day: &d, Latitude: 52.51, Longitude: 13.39,
+		}); err != nil {
+			t.Fatalf("seed item %s: %v", seed.name, err)
+		}
+	}
+
+	s, rec := testPlanSession(true, user.ID)
+	s.boundTripID = &trip.ID
+	msg, isErr := runSetLegDatesTool(s, []byte(`{"city":"Berlin","start_date":"2026-09-07","end_date":"2026-09-10"}`))
+	if !isErr {
+		t.Fatalf("interior end change did not refuse: %s", msg)
+	}
+	for _, want := range []string{
+		"Berlin's departure day is the next city's arrival",
+		"shows Berlin ending 2026-09-12 because Gothenburg arrives then",
+		`set_leg_dates(city="Gothenburg", start_date="2026-09-10")`,
+		"shift_days_from",
+		"Nothing was changed",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("steer missing %q: %s", want, msg)
+		}
+	}
+	// No result text claims a date gap between two legs — a gap is
+	// unrepresentable on the page under the boundary rule.
+	for _, banned := range []string{"gap", "uncovered"} {
+		if strings.Contains(msg, banned) {
+			t.Fatalf("refusal claims a between-legs %s the page cannot draw: %s", banned, msg)
+		}
+	}
+	assertDatesFromRenderedLegs(t, msg, trip.ID, user.ID, "2026-09-10")
+	if strings.Contains(rec.Body.String(), "trip_updated") {
+		t.Fatal("refusal emitted trip_updated")
+	}
+	if got := legDays(t, trip.ID, "Berlin"); !daysEqual(got, 1, 4) {
+		t.Fatalf("Berlin days = %v, want [1 4] untouched", got)
+	}
+	if got := legDays(t, trip.ID, "Gothenburg"); !daysEqual(got, 6, 8) {
+		t.Fatalf("Gothenburg days = %v, want [6 8] untouched", got)
+	}
+}
+
+// A place on the leg's last item day survives a set_leg_dates call unmoved —
+// the ticket's headline regression. An end-only move on a stay-anchored leg
+// used to drag the last item onto the new check-out day; now the check-out
+// (and the departing transport, and the trip end) move while every place
+// stays exactly where the traveler put it.
+func TestPlanSetLegDatesEndMoveLeavesItemsAlone(t *testing.T) {
+	resetDB(t)
+	user, _ := createTestUser(t, "endonly@example.com")
+	trip := createTestTrip(t, user.ID, 0)
+	seedMultiCityTrip(t, trip, user.ID)
+
+	s, rec := testPlanSession(true, user.ID)
+	s.boundTripID = &trip.ID
+	msg, isErr := runSetLegDatesTool(s, []byte(`{"city":"Los Angeles","start_date":"2026-09-20","end_date":"2026-09-26"}`))
+	if isErr {
+		t.Fatalf("end-only move errored: %s", msg)
+	}
+	for _, want := range []string{
+		"Los Angeles is now 2026-09-20 to 2026-09-26 on the trip page (6 nights)",
+		"Trip end extended to 2026-09-26",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("result missing %q: %s", want, msg)
+		}
+	}
+	if strings.Contains(msg, "folded onto") {
+		t.Fatalf("a lengthening end move folded items: %s", msg)
+	}
+	if !strings.Contains(rec.Body.String(), "trip_updated") {
+		t.Fatal("end-only move did not emit trip_updated")
+	}
+	assertDatesFromRenderedLegs(t, msg, trip.ID, user.ID)
+	if got := legDays(t, trip.ID, "Los Angeles"); !daysEqual(got, 6, 7, 8, 9) {
+		t.Fatalf("LA days = %v, want [6 7 8 9] — no place rides a departure day", got)
+	}
+	if in, out := scanDates(t, `SELECT check_in, check_out FROM accommodations WHERE trip_id = $1 AND name = $2`, trip.ID, "Stay in Los Angeles"); in != "2026-09-20" || out != "2026-09-26" {
+		t.Fatalf("LA stay = %s/%s, want 2026-09-20/2026-09-26", in, out)
+	}
+	if dep, _ := scanDates(t, `SELECT depart_date, arrive_date FROM trip_segments WHERE trip_id = $1 AND origin = $2`, trip.ID, "Los Angeles"); dep != "2026-09-26" {
+		t.Fatalf("departure segment departs %s, want 2026-09-26 (rides the check-out)", dep)
+	}
+	if _, end := tripDates(t, trip.ID); end != "2026-09-26" {
+		t.Fatalf("trip end = %s, want extended to 2026-09-26", end)
+	}
+}
+
+// Shortening the FINAL leg is shortening the trip: its rendered end is the
+// trip's end date, which this tool only extends. The refusal steers to
+// set_trip_dates with the exact dates, and start-only remains offered.
+func TestPlanSetLegDatesLastLegShrinkSteersToTripDates(t *testing.T) {
+	resetDB(t)
+	user, _ := createTestUser(t, "lastshrink@example.com")
+	trip := createTestTrip(t, user.ID, 0)
+	seedPragueKrakowBerlinTrip(t, trip, user.ID, 6)
+
+	s, rec := testPlanSession(true, user.ID)
+	s.boundTripID = &trip.ID
+	msg, isErr := runSetLegDatesTool(s, []byte(`{"city":"Berlin","start_date":"2026-09-01","end_date":"2026-09-05"}`))
+	if !isErr {
+		t.Fatalf("last-leg shrink did not refuse: %s", msg)
+	}
+	for _, want := range []string{
+		"Berlin is the trip's last city",
+		"2026-09-27",
+		"set_trip_dates",
+		"end_date=2026-09-05",
+		"start_date only",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("steer missing %q: %s", want, msg)
+		}
+	}
+	if strings.Contains(rec.Body.String(), "trip_updated") {
+		t.Fatal("refusal emitted trip_updated")
+	}
+	if got := legDays(t, trip.ID, "Berlin"); !daysEqual(got, 9) {
+		t.Fatalf("Berlin day = %v, want [9] untouched", got)
+	}
+	if _, end := tripDates(t, trip.ID); end != "2026-09-27" {
+		t.Fatalf("trip end = %s, want untouched 2026-09-27", end)
+	}
+}
+
+// The ways a spine's rendered dates go wrong, named ABOVE the leg list so the
+// model meets them before the ranges they describe — plus the SOFT unplanned-
+// stretches block and its one-night silence threshold.
 func TestLegsRenderWarning(t *testing.T) {
 	// Porto and Madrid share the Sep 4 arrival: Porto is a genuine zero-night
-	// stop, and it is NOT the last leg, so this must warn. (An arrival-anchor
-	// spine no longer collapses — a leg runs to the next arrival — so a shared
-	// arrival day is the one shape left that renders zero nights.)
+	// stop (ZeroNight, read from the derivation), it is NOT the last leg, and
+	// the line names the city that arrives with it. The remedy must steer to
+	// arrival moves — never to planting a place on a day (the retired
+	// convention that produced the Prague Airport Starbucks).
 	collapsed := legsRenderSummary(rlTrip("2026-09-01", "2026-09-08"), []store.ItineraryItem{
 		rlItem(0, "Time Out Market", rlCity("Lisbon"), 1),
 		rlItem(1, "Livraria Lello", rlCity("Porto"), 4),
@@ -943,9 +1282,36 @@ func TestLegsRenderWarning(t *testing.T) {
 	if !strings.HasPrefix(collapsed, "WARNING") {
 		t.Fatalf("a zero-night interior leg did not lead with a warning:\n%s", collapsed)
 	}
-	for _, want := range []string{"Porto renders ZERO nights", "set_leg_dates"} {
+	for _, want := range []string{
+		"Porto renders ZERO nights",
+		"the next city (Madrid) arrives on or before it",
+		"set_leg_dates", "shift_days_from",
+		"never add a place just to hold a date",
+	} {
 		if !strings.Contains(collapsed, want) {
 			t.Fatalf("warning missing %q:\n%s", want, collapsed)
+		}
+	}
+	for _, stale := range []string{"no place sits on the day they move on", "give the city a place"} {
+		if strings.Contains(collapsed, stale) {
+			t.Fatalf("warning still carries the retired convention %q:\n%s", stale, collapsed)
+		}
+	}
+
+	// A place dated after the day its leg ends on the page: the boundary rule
+	// strands it instead of widening the leg, and the warning reads the
+	// derivation's own finding (RenderLeg.itemsPastEnd) — never a re-derived
+	// condition. Kraków ends at Berlin's Sep 1 arrival; its Sep 2 item is
+	// outside its own city's dates.
+	stranded := legsRenderSummary(rlTrip("2026-08-24", "2026-09-27"), []store.ItineraryItem{
+		rlItem(0, "Old Town Square", rlCity("Prague"), 4),
+		rlItem(1, "Wawel Castle", rlCity("Kraków"), 6),
+		rlItem(2, "Schindler's Factory", rlCity("Kraków"), 10),
+		rlItem(3, "Brandenburg Gate", rlCity("Berlin"), 9),
+	}, nil)
+	for _, want := range []string{"WARNING", "Kraków has a place dated after 2026-09-01", "outside its own city's rendered dates"} {
+		if !strings.Contains(stranded, want) {
+			t.Fatalf("stranded-item warning missing %q:\n%s", want, stranded)
 		}
 	}
 
@@ -961,6 +1327,42 @@ func TestLegsRenderWarning(t *testing.T) {
 		t.Fatalf("an auto-dated leg's line did not state its provenance:\n%s", guessed)
 	}
 
+	// The unplanned-stretches threshold, both sides of it. ONE place-free
+	// night before a departure is the normal spine — every correctly-built
+	// trip has one — and must stay silent or the block fires on everything
+	// and gets averaged away. TWO earn the soft line (the Berlin/Gothenburg
+	// shape: Berlin's last place Sep 10, Gothenburg arrives Sep 12 — the
+	// nights are unplanned INSIDE Berlin; there is no gap between legs).
+	oneNight := legsRenderSummary(rlTrip("2026-09-01", "2026-09-06"), []store.ItineraryItem{
+		rlItem(0, "Time Out Market", rlCity("Lisbon"), 1),
+		rlItem(1, "Pastéis de Belém", rlCity("Lisbon"), 3), // departs Sep 4: 1 free night
+		rlItem(2, "Livraria Lello", rlCity("Porto"), 4),
+		rlItem(3, "Cais da Ribeira", rlCity("Porto"), 5), // trip ends Sep 6: 1 free night
+	}, nil)
+	if strings.Contains(oneNight, "Unplanned") || strings.Contains(oneNight, "WARNING") {
+		t.Fatalf("the normal one-night spine was not silent:\n%s", oneNight)
+	}
+	twoNights := legsRenderSummary(rlTrip("2026-09-07", "2026-09-14"), []store.ItineraryItem{
+		rlItem(0, "Museum Island", rlCity("Berlin"), 1),
+		rlItem(1, "East Side Gallery", rlCity("Berlin"), 4), // Sep 10
+		rlItem(2, "Haga District", rlCity("Gothenburg"), 6), // arrives Sep 12
+	}, nil)
+	for _, want := range []string{
+		"Unplanned stretches",
+		"Berlin renders 2026-09-07 to 2026-09-12 (5 nights) but its last place is 2026-09-10 — 2 nights with nothing planned",
+		"mention, don't fix",
+	} {
+		if !strings.Contains(twoNights, want) {
+			t.Fatalf("two free nights missing %q:\n%s", want, twoNights)
+		}
+	}
+	if strings.Contains(twoNights, "WARNING") {
+		t.Fatalf("an unplanned stretch is not a render defect and must not be a WARNING:\n%s", twoNights)
+	}
+	if strings.Contains(twoNights, "gap") {
+		t.Fatalf("no result text may claim a date gap between legs:\n%s", twoNights)
+	}
+
 	// A healthy spine says nothing extra — the warning must not become noise
 	// every itinerary write carries.
 	clean := legsRenderSummary(rlTrip("2026-09-01", "2026-09-08"), []store.ItineraryItem{
@@ -969,8 +1371,9 @@ func TestLegsRenderWarning(t *testing.T) {
 		rlItem(2, "Livraria Lello", rlCity("Porto"), 4),
 		rlItem(3, "Cais da Ribeira", rlCity("Porto"), 6),
 		rlItem(4, "Museo del Prado", rlCity("Madrid"), 6),
+		rlItem(5, "Mercado San Miguel", rlCity("Madrid"), 7),
 	}, nil)
-	if strings.Contains(clean, "WARNING") {
+	if strings.Contains(clean, "WARNING") || strings.Contains(clean, "Unplanned") {
 		t.Fatalf("a well-formed spine warned:\n%s", clean)
 	}
 }

--- a/src/packages/api/plan_tools_shift_days.go
+++ b/src/packages/api/plan_tools_shift_days.go
@@ -201,7 +201,7 @@ func runShiftDaysFromTool(s *planSession, input json.RawMessage) (string, bool) 
 	addr := parseLegAddress(in.City)
 	matched := matchLegRuns(runs, addr.hub)
 	if len(matched) == 0 {
-		if legs := legsSummary(runs, stays, tripStart); legs != "" {
+		if legs := legsSummary(trip, items, stays); legs != "" {
 			return fmt.Sprintf("No leg for '%s' in this trip. The legs are: %s. Use the city name as it appears in the itinerary.", addr.hub, legs), true
 		}
 		return "This trip's itinerary has no day-numbered city legs to shift from. Use set_trip_dates to move the whole trip instead.", true


### PR DESCRIPTION
**specs/leg-departure-dates, ticket 2** (of 4). Ticket 1 = #559, ticket 3 = #558, both merged; base is `main` (the briefed stacked base `fix/leg-departure-dates` merged and was deleted mid-flight).

One file and one story: make `set_leg_dates` consistent with the boundary rule (#559: a leg's rendered end is the NEXT city's arrival) in what it **writes** and what it **says**.

## Part A — the write stops dragging the last item
- The renumber is **START-anchored**: items carry the leg's arrival, keep their within-leg offsets, and are never dragged onto a departure day. The `:568` end-anchored drag — which moved places the traveler deliberately kept off the travel day (the Prague Saturday loop) — is gone. A single-item placeholder leg is a start-carrier.
- The previous-boundary extension survives **only for a confirmed stay's check-out** (computeTripLegs would otherwise pull the moved leg's rendered start back to it, visually undoing the move). The items-case drag died with `:568`: an item-dated neighbour's rendered end follows this leg's arrival with **no physical write**, so its deliberately-placed items stay put. The headline consequence: the dogfood "LA Sep 24–27" ask on a placeholder trip is now an **honest no-op** reporting the correct render, where it used to "succeed" by corrupting both cities' items.

## The end-date question (spec Open Question 3) — narrowed, with two honest exceptions
`end_date` is carried out only where the departure lives on the leg's **own rows**:
- a **confirmed stay's check-out** (the page renders it), and
- the **final rendered leg**, via the trip-end extension — its transport delta now measured off the trip end, not the raw last item day (which runs short by the tail nights).

An **interior** leg's end IS the next city's arrival → the call **refuses and steers** to the exact replacement (`set_leg_dates(city="<next>", start_date=X)`, or `shift_days_from` to push everything after together — #558 makes that option real). An `end_date` merely **echoing the on-screen end is treated as omitted**, so "make LA Sep 24 to 27" still works as the start move it is. Shrinking the final leg steers to `set_trip_dates`. The tool description now promises exactly what the tool does.

## Parts B + C — everything said about the screen derives from the screen
- The four raw model-facing callers (`legsSummary`, multi-match spans, the no-op's neighbour line, the success NOTEs) now read `computeTripLegs`; the renumbering math (`:515`/`:535`) stays on item-day semantics per the module's own documented split.
- The gap/overlap/squeeze NOTEs — whose trigger conditions are their own falsification under the boundary rule (the "2-night gap" Berlin/Gothenburg incident) — are replaced by the `shift_days_from` result convention: the full rendered-legs block, warnings included, plus rendered-span **overlap** NOTEs (overlaps are representable; gaps are not, and no result text claims one).
- `legsRenderWarning` reads the derivation instead of re-deriving: **ZeroNight** = two cities sharing an arrival day, and says so naming the city; **`RenderLeg.itemsPastEnd`** (added in #559) becomes the stranded-place line; the *"give the city a place on the day they move on"* remedy — the instruction that produced the invented Prague Airport Starbucks — is deleted and the new remedy says never to add a place just to hold a date; a **soft "Unplanned stretches" block** states two-plus place-free nights inside a leg (*"Berlin renders Sep 7–12 (5 nights) but its last place is Sep 10 — 2 nights with nothing planned"*), **silent at one night** — the normal spine — so it can't cry wolf.

## Tests
Rewritten to the new contract: the placeholder end-carrier fixture inverts into the honest-no-op + start-carrier pair, the squeeze test becomes the start-onto-next-arrival zero-night warning, and the **Berlin/Gothenburg incident is pinned as the ticket's spine** — `assertDatesFromRenderedLegs` sweeps every `YYYY-MM-DD` a result states and requires it to be a date the rendered legs (or the trip row / saved items / the ask itself) also state (acceptance 5). New gate tests cover all three end-date verdicts; `TestPlanSetLegDatesEndMoveLeavesItemsAlone` pins the Done-when bullet that a place on the leg's last item day survives unmoved.

Also: a v4 amendment note in `specs/set-leg-dates/spec.md` marking the v2 END-anchored renumber and the squeeze NOTE as superseded (this repo treats stale docs as load-bearing).

**Out of scope** (ticket 4): the prompt's five sites in `plan_handler.go` and the two registry result strings — the prompt still teaches the dead invariant, harmlessly.

## Verification
- Full Go suite against throwaway Postgres 16: **1,086 tests + 288 subtests, 0 failures, 2 pre-existing env-gated skips, `go test` exit 0 captured directly** (not through a pipe).
- `gofmt` clean, `go vet` clean.
- No Flutter/wire changes: `RenderLeg` JSON and the legs payload are untouched, so the parity soak sees nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/golden-tempo/codesmith/anemos-travel/pr/562"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790137666&installation_model_id=433099&pr_number=562&repository=golden-tempo%2Fanemos-travel&return_to=https%3A%2F%2Fgithub.com%2Fgolden-tempo%2Fanemos-travel%2Fpull%2F562&signature=d8f6768cbbb0e17ededc50a5945243e2d33e0e53ceb738bae2bb478a1ac7a4d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->