### PR TITLE
fix(chat): the plan stream ends with a terminal frame, so a dropped connection can't pass as a finished reply

### DIFF
--- a/src/packages/api/ai_health_integration_test.go
+++ b/src/packages/api/ai_health_integration_test.go
@@ -142,8 +142,15 @@ func TestPlanClientAbortRecordsNoAIFailure(t *testing.T) {
 		t.Fatal("planHandler did not return after client abort")
 	}
 
-	if out := rec.Body.String(); strings.Contains(out, `"type":"error"`) {
+	out := rec.Body.String()
+	if strings.Contains(out, `"type":"error"`) {
 		t.Fatalf("stream = %q, want no error event on client abort", out)
+	}
+	// A client abort is the one exit with nobody left to write to: no
+	// turn_end either (unlike the graceful-shutdown drain, which writes
+	// turn_end "server_restart" to a live socket).
+	if strings.Contains(out, `"type":"turn_end"`) {
+		t.Fatalf("stream = %q, want no turn_end on client abort", out)
 	}
 	if s := aiHealth.state(); s.Failing || s.FatalTotal != 0 || s.TransientTotal != 0 {
 		t.Fatalf("tracker after client abort = %+v, want untouched", s)

--- a/src/packages/api/main.go
+++ b/src/packages/api/main.go
@@ -3,13 +3,16 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"log/slog"
 	"net/http"
 	"os"
+	"os/signal"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/getsentry/sentry-go"
@@ -526,11 +529,12 @@ func main() {
 	// reports panics.
 	if initSentry() {
 		slog.SetDefault(slog.New(newSentrySlogHandler(textHandler)))
-		// Best-effort flush of buffered events on return from main. Note the
-		// server has no graceful-shutdown hook today (startServer ends in
-		// log.Fatal, which skips deferred calls), so the flush that matters
-		// in practice is the one in recoveryMiddleware; this defer covers a
-		// future graceful-shutdown path for free.
+		// Best-effort flush of buffered events on return from main. The
+		// graceful-shutdown path reaches this: startServer returns normally
+		// after a SIGTERM/SIGINT drain, so this defer (and dbPool.Close below)
+		// actually run on every deploy. A log.Fatal elsewhere still skips
+		// deferred calls — for crashes the flush in recoveryMiddleware remains
+		// the one that matters.
 		defer sentry.Flush(2 * time.Second)
 	}
 
@@ -1032,6 +1036,30 @@ func startServer(router *mux.Router) {
 		IdleTimeout: 120 * time.Second,
 	}
 
+	// Graceful shutdown on SIGTERM/SIGINT — i.e. on every deploy's
+	// `docker stop`. Order matters: planDrainBegin first ends each in-flight
+	// /plan SSE stream with a terminal turn_end frame (plan_handler.go) —
+	// Shutdown alone would WAIT on those streams until compose's 10s grace
+	// expired in SIGKILL, which is exactly the torn-socket truncation the
+	// frame prevents. Then Shutdown closes the listener and waits out the
+	// remaining short-lived requests; 8s keeps the whole sequence inside the
+	// grace window. ListenAndServe returns ErrServerClosed, startServer
+	// returns, and main's deferred dbPool.Close + sentry.Flush finally run.
+	shutdownDone := make(chan struct{})
+	go func() {
+		defer close(shutdownDone)
+		sig := make(chan os.Signal, 1)
+		signal.Notify(sig, os.Interrupt, syscall.SIGTERM)
+		s := <-sig
+		log.Printf("received %v: draining /plan streams and shutting down", s)
+		planDrainBegin()
+		ctx, cancel := context.WithTimeout(context.Background(), 8*time.Second)
+		defer cancel()
+		if err := server.Shutdown(ctx); err != nil {
+			log.Printf("graceful shutdown incomplete: %v", err)
+		}
+	}()
+
 	log.Printf("Starting Travel Route Planner API server on port %s", port)
 	log.Printf("Available endpoints:")
 	log.Printf("  GET /                        - Hello World")
@@ -1069,7 +1097,8 @@ func startServer(router *mux.Router) {
 	log.Printf("  POST/DELETE /api/v1/trips/{id}/booking-options/{id}/choose - Choose / un-choose one (auth)")
 	log.Printf("  GET  /api/v1/link-preview        - OpenGraph prefill for a pasted booking link (auth)")
 
-	if err := server.ListenAndServe(); err != nil {
+	if err := server.ListenAndServe(); !errors.Is(err, http.ErrServerClosed) {
 		log.Fatal("Server failed to start:", err)
 	}
+	<-shutdownDone
 }

--- a/src/packages/api/plan_handler.go
+++ b/src/packages/api/plan_handler.go
@@ -81,6 +81,30 @@ var planImageMediaTypes = map[string]bool{
 	"image/webp": true,
 }
 
+// planDrainCtx is canceled when graceful shutdown begins (startServer's signal
+// handler calls planDrainBegin before http.Server.Shutdown). Every in-flight
+// /plan request watches it: Shutdown alone cannot end an SSE stream — it waits
+// for active connections, and a stream mid-model-call would hold the process
+// until the deploy's SIGKILL, exactly the torn-socket truncation the turn_end
+// frame exists to prevent. Canceling each request's context instead unwinds
+// the model call promptly, and the handler tells the drain apart from a client
+// disconnect (planDraining) so it still writes the terminal frame to the live
+// socket.
+var planDrainCtx, planDrainBegin = context.WithCancel(context.Background())
+
+// planDraining reports whether graceful shutdown has begun. On a drain the
+// client's socket is still alive and is owed a turn_end frame; on a client
+// disconnect — the other way a request context cancels — there is nobody to
+// write to.
+func planDraining() bool {
+	select {
+	case <-planDrainCtx.Done():
+		return true
+	default:
+		return false
+	}
+}
+
 type PlanRequest struct {
 	Messages []PlanChatMessage `json:"messages"`
 	// Summary is the compacted context from earlier turns, previously handed to
@@ -133,11 +157,41 @@ func planHandler(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "streaming not supported", http.StatusInternalServerError)
 		return
 	}
+
+	// Every stream this handler opens MUST end with one turn_end frame — the
+	// terminal event that lets the client tell "the turn ended, and how" from
+	// "the connection died". Without it both are just bytes stopping, and the
+	// client resolved that by committing whatever partial text had arrived as
+	// a finished reply — which the deferred save below then persisted, so the
+	// next turn's model read its own half-sentence back as a completed
+	// message. Closed stop_reason vocabulary: "end_turn" (the model finished
+	// — the only reason a client may commit the streamed text), "error" (an
+	// error frame preceded this), "server_restart" (graceful shutdown drained
+	// the stream; retry cleanly).
+	endTurn := func(stopReason string) {
+		sendSSE(w, "turn_end", map[string]string{"stop_reason": stopReason})
+	}
+	// An error frame always ends the turn, so the terminal frame rides with
+	// it. New exit paths must go through this (or endTurn), never a bare
+	// sendSSE("error") — a return without a terminal frame reads as a dead
+	// socket and makes the client discard a reply the server priced and sent.
+	sendError := func(message string) {
+		sendSSE(w, "error", map[string]string{"message": message})
+		endTurn("error")
+	}
+
 	// Overall wall-clock ceiling on the whole request (see planMaxDuration): a
 	// stuck stream eventually closes and frees its goroutine + concurrency slot.
 	ctx, cancel := context.WithTimeout(r.Context(), planMaxDuration)
 	defer cancel()
 	r = r.WithContext(ctx)
+
+	// Graceful drain: when shutdown begins, cancel this request's context so a
+	// blocked model call unwinds now rather than at the deploy's SIGKILL. The
+	// Canceled handling in the loop below tells the drain apart from a client
+	// disconnect and writes the terminal frame that lets the client retry.
+	stopDrainWatch := context.AfterFunc(planDrainCtx, cancel)
+	defer stopDrainWatch()
 
 	// INVARIANT: fully consume the request body BEFORE the first response
 	// write or flush. Writing commits the response, and a reverse proxy
@@ -154,13 +208,13 @@ func planHandler(w http.ResponseWriter, r *http.Request) {
 	raw, err := io.ReadAll(r.Body)
 	if err != nil {
 		log.Printf("plan body read: %v (read=%d content_length=%d)", err, len(raw), r.ContentLength)
-		sendSSE(w, "error", map[string]string{"message": "invalid request body"})
+		sendError("invalid request body")
 		return
 	}
 	var req PlanRequest
 	if err := json.Unmarshal(raw, &req); err != nil {
 		log.Printf("plan body decode: %v (read=%d content_length=%d)", err, len(raw), r.ContentLength)
-		sendSSE(w, "error", map[string]string{"message": "invalid request body"})
+		sendError("invalid request body")
 		return
 	}
 
@@ -171,49 +225,55 @@ func planHandler(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprint(w, ": stream-open\n\n")
 	w.(http.Flusher).Flush()
 
+	// Protocol announcement: this server ends every turn with a terminal
+	// turn_end frame. The client requires the terminator only after seeing
+	// this, so a rolled-back API (sending neither event) degrades to the old
+	// commit-on-close behavior instead of erroring on every reply.
+	sendSSE(w, "stream_start", map[string]any{"protocol": 2})
+
 	// Cap the conversation before any model call: the whole history is resent
 	// on every agent-loop iteration, so these bounds are a hard cost lever.
 	if len(req.Messages) > planMaxMessages {
-		sendSSE(w, "error", map[string]string{"message": "This conversation is too long to continue. Please start a new chat to keep planning."})
+		sendError("This conversation is too long to continue. Please start a new chat to keep planning.")
 		return
 	}
 	totalImages := 0
 	for i, m := range req.Messages {
 		if utf8.RuneCountInString(m.Content) > planMaxMessageChars {
-			sendSSE(w, "error", map[string]string{"message": "One of the messages is too long for the planner. Please shorten it and try again."})
+			sendError("One of the messages is too long for the planner. Please shorten it and try again.")
 			return
 		}
 		if utf8.RuneCountInString(m.DisplayLabel) > planMaxDisplayLabelRunes {
 			req.Messages[i].DisplayLabel = truncateRunes(m.DisplayLabel, planMaxDisplayLabelRunes)
 		}
 		if len(m.Images) > 0 && m.Role != "user" {
-			sendSSE(w, "error", map[string]string{"message": "Images can only be attached to your own messages."})
+			sendError("Images can only be attached to your own messages.")
 			return
 		}
 		if len(m.Images) > planMaxImagesPerMessage {
-			sendSSE(w, "error", map[string]string{"message": "A message can include at most 4 images. Please remove some and try again."})
+			sendError("A message can include at most 4 images. Please remove some and try again.")
 			return
 		}
 		totalImages += len(m.Images)
 		if totalImages > planMaxImagesPerRequest {
-			sendSSE(w, "error", map[string]string{"message": "This conversation has too many images to continue. Please start a new chat to keep planning."})
+			sendError("This conversation has too many images to continue. Please start a new chat to keep planning.")
 			return
 		}
 		for _, img := range m.Images {
 			// Empty Data is the stripped placeholder shape from a resumed
 			// transcript — valid on the wire, skipped at conversion time.
 			if img.Data != "" && !planImageMediaTypes[img.MediaType] {
-				sendSSE(w, "error", map[string]string{"message": "That image format isn't supported. Please use a JPEG, PNG, GIF, or WebP image."})
+				sendError("That image format isn't supported. Please use a JPEG, PNG, GIF, or WebP image.")
 				return
 			}
 			if len(img.Data) > planMaxImageBase64Len {
-				sendSSE(w, "error", map[string]string{"message": "One of the images is too large. Please attach images under 5 MB."})
+				sendError("One of the images is too large. Please attach images under 5 MB.")
 				return
 			}
 		}
 	}
 	if utf8.RuneCountInString(req.Summary) > planMaxMessageChars {
-		sendSSE(w, "error", map[string]string{"message": "This conversation is too long to continue. Please start a new chat to keep planning."})
+		sendError("This conversation is too long to continue. Please start a new chat to keep planning.")
 		return
 	}
 
@@ -224,7 +284,7 @@ func planHandler(w http.ResponseWriter, r *http.Request) {
 		// A token was presented but the DB was unreachable — don't silently
 		// downgrade to anonymous (losing personalization + persistence). Ask
 		// the client to retry rather than proceeding half-authenticated.
-		sendSSE(w, "error", map[string]string{"message": "The service is temporarily unavailable. Please try again in a moment."})
+		sendError("The service is temporarily unavailable. Please try again in a moment.")
 		return
 	}
 
@@ -236,13 +296,13 @@ func planHandler(w http.ResponseWriter, r *http.Request) {
 		safeGo("recordAnonPlanCap", func() {
 			recordEventOpt(nil, "anon_plan_cap_hit", nil, map[string]any{"per_day": anonPlanPerDay()})
 		})
-		sendSSE(w, "error", map[string]string{"message": "You've reached today's free planning limit. Sign in to keep planning, or check back tomorrow."})
+		sendError("You've reached today's free planning limit. Sign in to keep planning, or check back tomorrow.")
 		return
 	}
 
 	apiKey := os.Getenv("ANTHROPIC_API_KEY")
 	if apiKey == "" {
-		sendSSE(w, "error", map[string]string{"message": "ANTHROPIC_API_KEY not configured"})
+		sendError("ANTHROPIC_API_KEY not configured")
 		return
 	}
 
@@ -336,12 +396,12 @@ func planHandler(w http.ResponseWriter, r *http.Request) {
 	if strings.TrimSpace(req.TripID) != "" {
 		tid, err := uuid.Parse(req.TripID)
 		if err != nil || !authed {
-			sendSSE(w, "error", map[string]string{"message": "sign in to refine this trip"})
+			sendError("sign in to refine this trip")
 			return
 		}
 		boundTrip, err := store.New(dbPool).GetEditableTripByID(r.Context(), store.GetEditableTripByIDParams{ID: tid, UserID: uid})
 		if err != nil {
-			sendSSE(w, "error", map[string]string{"message": "trip not found"})
+			sendError("trip not found")
 			return
 		}
 		boundTripID = &tid
@@ -388,6 +448,17 @@ func planHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	persistSession := saveTurn != nil
 	var turnText strings.Builder
+	// Set on the exit paths where the CLIENT keeps none of the streamed text —
+	// a graceful-shutdown drain (turn_end "server_restart" makes it discard)
+	// or a client disconnect (stop button, closed tab: the client rolled the
+	// turn back or is gone). The deferred save below then stores the
+	// transcript WITHOUT the half-streamed assistant text, keeping the stored
+	// history identical to what the client kept: a persisted half-reply is
+	// what the next turn's model reads back as its own finished message and
+	// apologises for. Error-frame paths deliberately still persist the
+	// partial — the client commits it there too (plan_provider.dart's error
+	// case), and the two sides must agree.
+	var discardStreamedText bool
 	// Set when an iteration ended in tool calls with text already streamed:
 	// the next text delta opens a new paragraph, in the streamed bytes and
 	// the persisted transcript alike, so live, resumed, and stale-client
@@ -426,7 +497,7 @@ func planHandler(w http.ResponseWriter, r *http.Request) {
 		})
 		defer func() {
 			msgs := persistMsgs
-			if t := turnText.String(); t != "" {
+			if t := turnText.String(); t != "" && !discardStreamedText {
 				msgs = append(append([]PlanChatMessage{}, persistMsgs...),
 					PlanChatMessage{Role: "assistant", Content: t})
 			}
@@ -517,7 +588,7 @@ func planHandler(w http.ResponseWriter, r *http.Request) {
 		planIterations++
 		if planIterations > planMaxIterations {
 			planCapHit = true
-			sendSSE(w, "error", map[string]string{"message": "This planning session hit its step limit. Send another message to continue from where we left off."})
+			sendError("This planning session hit its step limit. Send another message to continue from where we left off.")
 			return
 		}
 
@@ -584,12 +655,21 @@ func planHandler(w http.ResponseWriter, r *http.Request) {
 		}
 		streamErr := stream.Err()
 		cancelCall() // the deadline only needs to cover the streaming call above
-		// Client went away (stop button / closed tab): the model call was torn
-		// down on purpose — not an AI failure. No health record, no ERROR log
-		// (Sentry tee), no SSE to a dead socket. Canceled-only, on the request
+		// The request context cancels mid-call in exactly two ways, told apart
+		// because only one leaves a live socket to write to. A graceful-
+		// shutdown drain (planDraining) owes the client the terminal frame so
+		// it discards the half-reply and offers a clean retry. A client gone
+		// (stop button / closed tab) was a deliberate teardown — not an AI
+		// failure: no health record, no ERROR log (Sentry tee), no SSE to a
+		// dead socket. Either way the client keeps none of the streamed text,
+		// so the deferred save must not either. Canceled-only, on the request
 		// ctx: planModelCallTimeout and planMaxDuration expiries surface as
 		// DeadlineExceeded (here or on callCtx) and keep recording as before.
 		if errors.Is(ctx.Err(), context.Canceled) {
+			discardStreamedText = true
+			if planDraining() {
+				endTurn("server_restart")
+			}
 			return
 		}
 		// Exactly one health record per model call (ai_health.go); nil records
@@ -607,7 +687,7 @@ func planHandler(w http.ResponseWriter, r *http.Request) {
 			if aiClass == aiClassFatal {
 				msg = "The AI planning service is temporarily unavailable. Please try again later."
 			}
-			sendSSE(w, "error", map[string]string{"message": msg})
+			sendError(msg)
 			return
 		}
 		planTokensIn += resp.Usage.InputTokens
@@ -619,7 +699,7 @@ func planHandler(w http.ResponseWriter, r *http.Request) {
 		// previously this failed silently and produced an empty itinerary.
 		// Surface it instead of continuing with garbage.
 		if resp.StopReason == anthropic.StopReasonMaxTokens {
-			sendSSE(w, "error", map[string]string{"message": "The response was cut off before it finished. Try asking for a shorter plan or fewer places at once."})
+			sendError("The response was cut off before it finished. Try asking for a shorter plan or fewer places at once.")
 			return
 		}
 		if resp.StopReason != anthropic.StopReasonToolUse {
@@ -676,10 +756,28 @@ func planHandler(w http.ResponseWriter, r *http.Request) {
 
 		select {
 		case <-ctx.Done():
+			switch {
+			case errors.Is(ctx.Err(), context.DeadlineExceeded):
+				// planMaxDuration expired between model calls. The client is
+				// still connected — say so rather than just closing the pipe.
+				sendError("This planning session ran too long and was stopped. Send another message to continue from where we left off.")
+			case planDraining():
+				discardStreamedText = true
+				endTurn("server_restart")
+			default:
+				// Client gone between iterations — dead socket, nothing to say.
+				discardStreamedText = true
+			}
 			return
 		default:
 		}
 	}
+
+	// The model finished the turn (the loop's one success exit): the terminal
+	// frame with stop_reason "end_turn" is what authorizes the client to
+	// commit the streamed text as a finished reply rather than guessing from
+	// the connection closing.
+	endTurn("end_turn")
 }
 
 // resolveIATA turns a city name or IATA code into an IATA code for flight

--- a/src/packages/api/plan_handler_test.go
+++ b/src/packages/api/plan_handler_test.go
@@ -264,8 +264,29 @@ func TestPlanHandlerRejectsTooManyMessages(t *testing.T) {
 	if !strings.Contains(out, "too long") || !strings.Contains(out, "start a new chat") {
 		t.Fatalf("stream = %q, want the conversation-too-long message", out)
 	}
-	if strings.Count(out, "data: ") != 1 {
-		t.Fatalf("stream = %q, want exactly one event (handler must stop after rejecting)", out)
+	// stream_start + error + turn_end, nothing more: the handler must stop
+	// after rejecting, and every stream must still end with the terminal frame.
+	if strings.Count(out, "data: ") != 3 {
+		t.Fatalf("stream = %q, want exactly stream_start + error + turn_end", out)
+	}
+	assertLastEventIsTurnEnd(t, out, "error")
+}
+
+// assertLastEventIsTurnEnd parses the SSE body and requires its final event to
+// be the terminal turn_end frame carrying the given stop_reason — the contract
+// that lets the client tell a finished turn from a dead socket.
+func assertLastEventIsTurnEnd(t *testing.T, body, stopReason string) {
+	t.Helper()
+	events := planEvents(t, body)
+	if len(events) == 0 {
+		t.Fatalf("stream carried no events: %q", body)
+	}
+	last := events[len(events)-1]
+	if last["type"] != "turn_end" {
+		t.Fatalf("last event = %v, want turn_end (stream must end with the terminal frame)", last)
+	}
+	if got := eventData(last)["stop_reason"]; got != stopReason {
+		t.Fatalf("turn_end stop_reason = %v, want %q", got, stopReason)
 	}
 }
 
@@ -278,9 +299,10 @@ func TestPlanHandlerRejectsOversizedMessage(t *testing.T) {
 	if !strings.Contains(out, `"type":"error"`) || !strings.Contains(out, "too long") {
 		t.Fatalf("stream = %q, want an SSE error event about an oversized message", out)
 	}
-	if strings.Count(out, "data: ") != 1 {
-		t.Fatalf("stream = %q, want exactly one event", out)
+	if strings.Count(out, "data: ") != 3 {
+		t.Fatalf("stream = %q, want exactly stream_start + error + turn_end", out)
 	}
+	assertLastEventIsTurnEnd(t, out, "error")
 }
 
 func TestPlanHandlerRejectsOversizedSummary(t *testing.T) {
@@ -293,9 +315,10 @@ func TestPlanHandlerRejectsOversizedSummary(t *testing.T) {
 	if !strings.Contains(out, `"type":"error"`) || !strings.Contains(out, "too long") {
 		t.Fatalf("stream = %q, want an SSE error event about an oversized summary", out)
 	}
-	if strings.Count(out, "data: ") != 1 {
-		t.Fatalf("stream = %q, want exactly one event", out)
+	if strings.Count(out, "data: ") != 3 {
+		t.Fatalf("stream = %q, want exactly stream_start + error + turn_end", out)
 	}
+	assertLastEventIsTurnEnd(t, out, "error")
 }
 
 func TestNotesPreview(t *testing.T) {

--- a/src/packages/api/plan_images_test.go
+++ b/src/packages/api/plan_images_test.go
@@ -169,16 +169,18 @@ func TestPlanStrippedImageOnlyMessageGetsMarker(t *testing.T) {
 
 // assertSingleFriendlyError asserts the handler wrote exactly one SSE error
 // event containing want, and stopped there (no model call happened — the fake
-// would fail the test on an unscripted turn).
+// would fail the test on an unscripted turn). The reject stream is exactly
+// stream_start + error + the terminal turn_end every stream must end with.
 func assertSingleFriendlyError(t *testing.T, rec interface{ String() string }, want string) {
 	t.Helper()
 	out := rec.String()
 	if !strings.Contains(out, `"type":"error"`) || !strings.Contains(out, want) {
 		t.Fatalf("stream = %q, want an SSE error containing %q", out, want)
 	}
-	if strings.Count(out, "data: ") != 1 {
-		t.Fatalf("stream = %q, want exactly one event (handler must stop after rejecting)", out)
+	if strings.Count(out, "data: ") != 3 {
+		t.Fatalf("stream = %q, want exactly stream_start + error + turn_end", out)
 	}
+	assertLastEventIsTurnEnd(t, out, "error")
 }
 
 func TestPlanRejectsImagesOnAssistantMessage(t *testing.T) {

--- a/src/packages/api/plan_stream_end_test.go
+++ b/src/packages/api/plan_stream_end_test.go
@@ -1,0 +1,252 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// The /plan terminal-frame contract: every stream the handler opens ends with
+// exactly one turn_end frame stating how the turn ended, so the client can
+// tell "the model finished" from "the connection died" — the ambiguity that
+// used to commit (and persist) a half-streamed reply as a finished message.
+
+// planEventsAssertTerminal parses the stream and asserts the turn_end contract:
+// stream_start announces the protocol before any content, and the LAST event
+// is a single turn_end with the given stop_reason.
+func planEventsAssertTerminal(t *testing.T, body, stopReason string) []map[string]any {
+	t.Helper()
+	events := planEvents(t, body)
+	if len(events) == 0 {
+		t.Fatalf("stream carried no events: %q", body)
+	}
+	if events[0]["type"] != "stream_start" {
+		t.Fatalf("first event = %v, want stream_start (the protocol announcement)", events[0])
+	}
+	if ends := eventsOfType(events, "turn_end"); len(ends) != 1 {
+		t.Fatalf("turn_end events = %d, want exactly one", len(ends))
+	}
+	assertLastEventIsTurnEnd(t, body, stopReason)
+	return events
+}
+
+// resetAnonPlanCap gives direct-handler tests headroom on the in-memory
+// anonymous /plan counter (httptest requests share one RemoteAddr, so without
+// this a run's earlier direct tests could exhaust the default per-IP cap).
+func resetAnonPlanCap(t *testing.T) {
+	t.Helper()
+	anonPlanCounter.resetAll()
+	t.Setenv("FREE_ANON_PLAN_PER_DAY", "100")
+}
+
+// swapPlanDrain replaces the process-wide drain signal for one test, so
+// beginning a drain here cannot poison every later /plan test in the package
+// (the real planDrainCtx, once canceled, stays canceled for process life).
+func swapPlanDrain(t *testing.T) (begin func()) {
+	t.Helper()
+	oldCtx, oldBegin := planDrainCtx, planDrainBegin
+	planDrainCtx, planDrainBegin = context.WithCancel(context.Background())
+	t.Cleanup(func() { planDrainCtx, planDrainBegin = oldCtx, oldBegin })
+	return planDrainBegin
+}
+
+// (a) The success path: a plain text turn ends with turn_end "end_turn" as the
+// stream's final event — the frame that authorizes the client to commit.
+func TestPlanSuccessStreamEndsWithTurnEnd(t *testing.T) {
+	resetAnonPlanCap(t)
+	newFakeAnthropic(t, textTurn("Lisbon in May sounds perfect."))
+
+	rec := runPlanHandler(t, PlanRequest{
+		Messages: []PlanChatMessage{{Role: "user", Content: "where in May?"}},
+	})
+	events := planEventsAssertTerminal(t, rec.Body.String(), "end_turn")
+	if got := joinedText(events); got != "Lisbon in May sounds perfect." {
+		t.Fatalf("reassembled text = %q", got)
+	}
+	if errs := eventsOfType(events, "error"); len(errs) != 0 {
+		t.Fatalf("unexpected error events: %v", errs)
+	}
+}
+
+// (b) A mid-turn model failure: the error frame is followed by turn_end
+// "error" — an error always ends the turn, and the terminal frame rides with
+// it on every exit path, not just validation rejects.
+func TestPlanMidTurnModelErrorEndsWithTurnEnd(t *testing.T) {
+	resetAnonPlanCap(t)
+	resetAIHealth(t)
+	newFakeAnthropic(t, errorTurn("overloaded"))
+
+	rec := runPlanHandler(t, PlanRequest{
+		Messages: []PlanChatMessage{{Role: "user", Content: "plan athens"}},
+	})
+	events := planEventsAssertTerminal(t, rec.Body.String(), "error")
+	if errs := eventsOfType(events, "error"); len(errs) != 1 {
+		t.Fatalf("error events = %d, want exactly one", len(errs))
+	}
+}
+
+// (c) The graceful-shutdown drain: a stream parked mid-model-call is unwound
+// when the drain begins and ends with turn_end "server_restart" — the reason
+// the client discards the half-reply and offers a clean retry — with no error
+// frame (the client localizes the copy from the stop_reason alone).
+func TestPlanDrainEmitsServerRestartTurnEnd(t *testing.T) {
+	resetAnonPlanCap(t)
+	resetAIHealth(t)
+	begin := swapPlanDrain(t)
+	stalled := make(chan struct{})
+	newFakeAnthropic(t, stallTurn("Half an answer that a deploy cuts", stalled))
+
+	body, err := json.Marshal(PlanRequest{Messages: []PlanChatMessage{
+		{Role: "user", Content: "plan me a weekend in Athens"},
+	}})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/v1/plan", bytes.NewReader(body))
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		planHandler(rec, req)
+	}()
+
+	// Deltas are on the wire and the model call is parked — begin the drain,
+	// exactly what startServer's signal handler does on SIGTERM.
+	<-stalled
+	begin()
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("planHandler did not return after drain began")
+	}
+
+	out := rec.Body.String()
+	events := planEventsAssertTerminal(t, out, "server_restart")
+	if errs := eventsOfType(events, "error"); len(errs) != 0 {
+		t.Fatalf("stream = %q, want no error frame on a drain (turn_end carries the reason)", out)
+	}
+	// A drained turn is not an AI failure: the health tracker stays untouched,
+	// same as a client abort.
+	if s := aiHealth.state(); s.Failing || s.FatalTotal != 0 || s.TransientTotal != 0 {
+		t.Fatalf("tracker after drain = %+v, want untouched", s)
+	}
+}
+
+// (d) Persistence agreement, drain side: the deferred end-of-turn save stores
+// the transcript WITHOUT the half-streamed assistant text — the client
+// discarded it, and a stored stump is what the next turn's model would read
+// back as its own finished message.
+func TestPlanDrainDoesNotPersistPartialText(t *testing.T) {
+	resetDB(t)
+	begin := swapPlanDrain(t)
+	stalled := make(chan struct{})
+	newFakeAnthropic(t, stallTurn("Half an answer that a deploy cuts", stalled))
+	user, token := createTestUser(t, "drained@example.com")
+
+	body, err := json.Marshal(PlanRequest{
+		ChatID:   "chat-drained",
+		Messages: []PlanChatMessage{{Role: "user", Content: "plan me a week in Japan"}},
+	})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/v1/plan", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		planHandler(rec, req)
+	}()
+	<-stalled
+	begin()
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("planHandler did not return after drain began")
+	}
+	planEventsAssertTerminal(t, rec.Body.String(), "server_restart")
+
+	msgs, _, _, found := chatSessionRow(t, user.ID, "chat-drained")
+	if !found {
+		t.Fatal("session missing after drained turn (the start-of-turn save must still run)")
+	}
+	if len(msgs) != 1 || msgs[0].Role != "user" {
+		t.Fatalf("stored messages = %+v, want ONLY the user message (no half-streamed assistant text)", msgs)
+	}
+}
+
+// (e) Persistence agreement, client-abort side: a stopped/closed turn stores
+// no assistant stump either. Before the terminal-frame work the deferred save
+// appended it, so reloading after a stop resurrected half a reply the client
+// had rolled back (specs/chat-stop-undo documents the client side).
+func TestPlanClientAbortDoesNotPersistPartialText(t *testing.T) {
+	resetDB(t)
+	stalled := make(chan struct{})
+	newFakeAnthropic(t, stallTurn("Half an answer the stop button cuts", stalled))
+	user, token := createTestUser(t, "stopped@example.com")
+
+	body, err := json.Marshal(PlanRequest{
+		ChatID:   "chat-stopped",
+		Messages: []PlanChatMessage{{Role: "user", Content: "plan me a week in Japan"}},
+	})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/v1/plan", bytes.NewReader(body)).WithContext(ctx)
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		planHandler(rec, req)
+	}()
+	<-stalled
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("planHandler did not return after client abort")
+	}
+
+	msgs, _, _, found := chatSessionRow(t, user.ID, "chat-stopped")
+	if !found {
+		t.Fatal("session missing after aborted turn (the start-of-turn save must still run)")
+	}
+	if len(msgs) != 1 || msgs[0].Role != "user" {
+		t.Fatalf("stored messages = %+v, want ONLY the user message (no half-streamed assistant text)", msgs)
+	}
+}
+
+// (f) Persistence agreement, error side: an error-frame turn KEEPS the partial
+// — the client's error case commits it to the visible transcript, and the two
+// sides must store the same conversation.
+func TestPlanModelErrorPersistsPartialText(t *testing.T) {
+	resetDB(t)
+	resetAIHealth(t)
+	newFakeAnthropic(t, errorTurn("overloaded"))
+	user, token := createTestUser(t, "errored@example.com")
+
+	rec := doJSON(t, "POST", "/api/v1/plan", token, PlanRequest{
+		ChatID:   "chat-errored",
+		Messages: []PlanChatMessage{{Role: "user", Content: "plan me a week in Japan"}},
+	})
+	planEventsAssertTerminal(t, rec.Body.String(), "error")
+
+	msgs, _, _, found := chatSessionRow(t, user.ID, "chat-errored")
+	if !found {
+		t.Fatal("session missing after error turn")
+	}
+	// errorTurn streams "One moment" before dying (fake_anthropic_test.go).
+	if len(msgs) != 2 || msgs[1].Role != "assistant" || !strings.Contains(msgs[1].Content, "One moment") {
+		t.Fatalf("stored messages = %+v, want user + the partial assistant text", msgs)
+	}
+}

--- a/src/packages/flutter-app/lib/l10n/app_en.arb
+++ b/src/packages/flutter-app/lib/l10n/app_en.arb
@@ -2419,6 +2419,10 @@
   "chatTryAgain": "Try again",
   "chatQueued": "Queued",
   "chatRemoveQueued": "Remove queued message",
+  "chatStreamInterrupted": "The connection was interrupted before the reply finished, so it wasn't kept.",
+  "@chatStreamInterrupted": {
+    "description": "Error banner when the /plan SSE stream dies mid-reply (server restart, dropped connection): the partial text is discarded, and the banner's Try again regenerates the whole reply."
+  },
   "agentScreenTitle": "Plan your trip",
   "agentScreenStartOver": "Start over",
   "agentScreenEmptyTitle": "Where are we going?",

--- a/src/packages/flutter-app/lib/l10n/app_es.arb
+++ b/src/packages/flutter-app/lib/l10n/app_es.arb
@@ -1013,6 +1013,7 @@
   "chatTryAgain": "Intentar de nuevo",
   "chatQueued": "En cola",
   "chatRemoveQueued": "Quitar mensaje en cola",
+  "chatStreamInterrupted": "La conexión se interrumpió antes de que terminara la respuesta, así que no se conservó.",
   "agentScreenTitle": "Planea tu viaje",
   "agentScreenStartOver": "Empezar de nuevo",
   "agentScreenEmptyTitle": "¿Adónde vamos?",

--- a/src/packages/flutter-app/lib/l10n/app_localizations.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations.dart
@@ -5906,6 +5906,12 @@ abstract class AppLocalizations {
   /// **'Remove queued message'**
   String get chatRemoveQueued;
 
+  /// Error banner when the /plan SSE stream dies mid-reply (server restart, dropped connection): the partial text is discarded, and the banner's Try again regenerates the whole reply.
+  ///
+  /// In en, this message translates to:
+  /// **'The connection was interrupted before the reply finished, so it wasn\'t kept.'**
+  String get chatStreamInterrupted;
+
   /// No description provided for @agentScreenTitle.
   ///
   /// In en, this message translates to:

--- a/src/packages/flutter-app/lib/l10n/app_localizations_en.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations_en.dart
@@ -3589,6 +3589,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get chatRemoveQueued => 'Remove queued message';
 
   @override
+  String get chatStreamInterrupted =>
+      'The connection was interrupted before the reply finished, so it wasn\'t kept.';
+
+  @override
   String get agentScreenTitle => 'Plan your trip';
 
   @override

--- a/src/packages/flutter-app/lib/l10n/app_localizations_es.dart
+++ b/src/packages/flutter-app/lib/l10n/app_localizations_es.dart
@@ -3609,6 +3609,10 @@ class AppLocalizationsEs extends AppLocalizations {
   String get chatRemoveQueued => 'Quitar mensaje en cola';
 
   @override
+  String get chatStreamInterrupted =>
+      'La conexión se interrumpió antes de que terminara la respuesta, así que no se conservó.';
+
+  @override
   String get agentScreenTitle => 'Planea tu viaje';
 
   @override

--- a/src/packages/flutter-app/lib/providers/plan_provider.dart
+++ b/src/packages/flutter-app/lib/providers/plan_provider.dart
@@ -104,9 +104,10 @@ class PlanState {
   /// the record-selects in _ResultStrips depend on) true by construction.
   final HotelStayResults? hotels;
 
-  // Either a friendly String the /plan SSE stream sent, or a raw caught error
-  // (ApiException) from a failed connect. friendlyError() renders both: it
-  // passes a String through unchanged and classifies an ApiException.
+  // Either a friendly String the /plan SSE stream sent, a raw caught error
+  // (ApiException) from a failed connect, or a [StreamInterruptedException]
+  // when the stream died mid-reply. friendlyError() renders all three: it
+  // passes a String through unchanged and classifies the typed errors.
   final Object? error;
 
   /// Messages the user sent while a turn was streaming, waiting FIFO to be
@@ -493,6 +494,13 @@ class PlanNotifier extends StateNotifier<PlanState> {
     // banner owns such a turn, so reply chips are dropped in either event
     // order (specs/chat-quick-replies).
     var itineraryThisTurn = false;
+    // Terminal-frame protocol: a server that sends `stream_start` promises to
+    // end every turn with a `turn_end` frame carrying stop_reason. Only that
+    // frame can tell "the model finished" from "the connection died" — both
+    // otherwise look like the bytes stopping. Absent stream_start (an older
+    // server, e.g. a rollback) the old commit-on-close behavior stands.
+    var terminatedStreams = false;
+    String? turnEndReason;
 
     try {
       await for (final event in _service.streamPlan(history,
@@ -608,6 +616,15 @@ class PlanNotifier extends StateNotifier<PlanState> {
             // hidden until the stream closes.
             state = state.copyWith(
                 suggestedReplies: raw.whereType<String>().toList());
+
+          case 'stream_start':
+            terminatedStreams = true;
+
+          case 'turn_end':
+            // Missing stop_reason defaults to success: the frame's PRESENCE is
+            // what says the server ended the turn deliberately; only a reason
+            // that explicitly names an abnormal end may discard the reply.
+            turnEndReason = event.data['stop_reason'] as String? ?? 'end_turn';
 
           case 'thinking':
             state = state.copyWith(isThinking: true);
@@ -769,6 +786,30 @@ class PlanNotifier extends StateNotifier<PlanState> {
       if (turn != _turn) return;
       _endStreamBuffer();
       if (!mounted) return;
+
+      // The stream closed. On a terminal-frame server, only turn_end
+      // "end_turn" says the model finished; the stream ending without one —
+      // or with an abnormal reason like "server_restart" — means the
+      // connection died mid-reply. The streamed text is a half-reply, not a
+      // message: committing it is how a stump entered the transcript (and,
+      // mirrored by the server's deferred save, durable history, where the
+      // next turn's model read it as its own finished thought). Discard it
+      // and engage the same banner + retryLastSend path a non-200 uses —
+      // retry rolls back to just before the user message and resends.
+      if (terminatedStreams && turnEndReason != 'end_turn') {
+        state = state.copyWith(
+          isStreaming: false,
+          streamingText: null,
+          activeTools: [],
+          isCompacting: false,
+          isThinking: false,
+          // An interrupted turn must not leave reply chips competing with
+          // the error banner's Try again.
+          suggestedReplies: [],
+          error: const StreamInterruptedException(),
+        );
+        return;
+      }
 
       // Commit streamed assistant text as a message
       final assistantText = textBuffer.toString();

--- a/src/packages/flutter-app/lib/services/plan_service.dart
+++ b/src/packages/flutter-app/lib/services/plan_service.dart
@@ -9,6 +9,16 @@ class PlanEvent {
   const PlanEvent({required this.type, required this.data});
 }
 
+/// The /plan SSE stream died mid-reply: it announced the terminal-frame
+/// protocol (`stream_start`) but closed without a `turn_end` saying the model
+/// finished — a deploy killing the API, a crash, a dropped network. The text
+/// streamed so far is a half-reply, not a message, so the provider discards it
+/// and carries this marker as [PlanState.error]; `friendlyError` maps it to a
+/// localized message at render time (providers have no BuildContext/l10n).
+class StreamInterruptedException implements Exception {
+  const StreamInterruptedException();
+}
+
 class PlanService {
   final String baseUrl;
 

--- a/src/packages/flutter-app/lib/utils/errors.dart
+++ b/src/packages/flutter-app/lib/utils/errors.dart
@@ -3,6 +3,7 @@ import 'package:http/http.dart' as http;
 import '../l10n/l10n.dart';
 import '../services/api_client.dart';
 import '../services/auth_service.dart';
+import '../services/plan_service.dart';
 
 /// Maps a caught error to a short, localized, user-facing message so raw
 /// [ApiException] dumps never reach a snackbar or error banner.
@@ -45,6 +46,9 @@ String friendlyError(AppLocalizations l10n, Object? error) {
     if (error.statusCode >= 500) return l10n.errorServer;
     return l10n.errorGeneric;
   }
+  // The /plan stream died mid-reply (server restart, dropped connection): the
+  // half-streamed text was discarded, and the banner's retry regenerates it.
+  if (error is StreamInterruptedException) return l10n.chatStreamInterrupted;
   // A socket-level failure never got an HTTP status: offline, DNS, CORS.
   if (error is http.ClientException) return l10n.errorNetwork;
   return l10n.errorGeneric;

--- a/src/packages/flutter-app/test/friendly_error_test.dart
+++ b/src/packages/flutter-app/test/friendly_error_test.dart
@@ -5,6 +5,7 @@ import 'package:travel_route_planner/l10n/l10n.dart';
 import 'package:travel_route_planner/services/api_client.dart';
 import 'package:http/http.dart' as http;
 import 'package:travel_route_planner/services/auth_service.dart';
+import 'package:travel_route_planner/services/plan_service.dart';
 import 'package:travel_route_planner/utils/errors.dart';
 
 import 'support/l10n_test_app.dart';
@@ -88,5 +89,18 @@ void main() {
     final l10n = await pumpL10n(tester);
     expect(friendlyError(l10n, http.ClientException('Connection refused')),
         l10n.errorNetwork);
+  });
+
+  testWidgets(
+      'maps a mid-reply stream interruption to its own localized message',
+      (tester) async {
+    final l10n = await pumpL10n(tester);
+    expect(friendlyError(l10n, const StreamInterruptedException()),
+        l10n.chatStreamInterrupted);
+
+    final es = await pumpL10n(tester, locale: const Locale('es'));
+    expect(friendlyError(es, const StreamInterruptedException()),
+        es.chatStreamInterrupted);
+    expect(es.chatStreamInterrupted, contains('conexión'));
   });
 }

--- a/src/packages/flutter-app/test/plan_provider_turn_end_test.dart
+++ b/src/packages/flutter-app/test/plan_provider_turn_end_test.dart
@@ -1,0 +1,166 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:travel_route_planner/models/plan_message.dart';
+import 'package:travel_route_planner/providers/plan_provider.dart';
+import 'package:travel_route_planner/services/api_client.dart';
+import 'package:travel_route_planner/services/plan_service.dart';
+
+/// The terminal-frame contract, client side: a server that announces the
+/// protocol (`stream_start`) ends every turn with `turn_end`. Only turn_end
+/// "end_turn" lets the streamed text commit as a finished reply; the stream
+/// closing without it means the connection died mid-reply (a deploy, a crash),
+/// and committing the half-reply is exactly the transcript corruption this
+/// exists to prevent — the next turn's model read its own half-sentence back
+/// as a finished message and apologised for it.
+
+const _streamStart = PlanEvent(type: 'stream_start', data: {'protocol': 2});
+const _turnEndOk = PlanEvent(type: 'turn_end', data: {'stop_reason': 'end_turn'});
+
+/// Replays canned events; each sendMessage consumes the next script in order,
+/// so a retry can be given a different (healthy) stream than the failed turn.
+class _ScriptedPlanService extends PlanService {
+  final List<List<PlanEvent>> scripts;
+  int sends = 0;
+
+  _ScriptedPlanService(this.scripts) : super('http://unused');
+
+  @override
+  Stream<PlanEvent> streamPlan(
+    List<Map<String, dynamic>> messages, {
+    String? bearerToken,
+    String? chatId,
+    String? tripId,
+    String? summary,
+    Future<void>? abortTrigger,
+  }) async* {
+    final script = scripts[sends >= scripts.length ? scripts.length - 1 : sends];
+    sends++;
+    for (final e in script) {
+      yield e;
+    }
+  }
+}
+
+void main() {
+  test('turn_end end_turn commits the streamed text as a finished reply',
+      () async {
+    final notifier = PlanNotifier(
+        _ScriptedPlanService([
+          const [
+            _streamStart,
+            PlanEvent(type: 'text_delta', data: {'text': 'A full reply.'}),
+            _turnEndOk,
+          ]
+        ]),
+        ApiClient());
+
+    await notifier.sendMessage('plan athens');
+    expect(notifier.state.error, isNull);
+    expect(notifier.state.isStreaming, isFalse);
+    expect(notifier.state.messages.map((m) => m.role).toList(),
+        [MessageRole.user, MessageRole.assistant]);
+    expect(notifier.state.messages.last.content, 'A full reply.');
+  });
+
+  test(
+      'a protocol stream that closes WITHOUT turn_end discards the half-reply '
+      'and surfaces the interrupted error',
+      () async {
+    final notifier = PlanNotifier(
+        _ScriptedPlanService([
+          const [
+            _streamStart,
+            PlanEvent(type: 'text_delta', data: {'text': 'But Berlin Mon'}),
+            PlanEvent(type: 'suggest_replies', data: {
+              'replies': ['Sounds good']
+            }),
+            // Connection dies here: no turn_end.
+          ]
+        ]),
+        ApiClient());
+
+    await notifier.sendMessage('plan berlin');
+    // The stump is NOT a message: only the user turn remains, the error is
+    // the typed marker (localized at render time), streaming state cleared,
+    // and no reply chips compete with the banner's Try again.
+    expect(notifier.state.messages.map((m) => m.role).toList(),
+        [MessageRole.user]);
+    expect(notifier.state.error, isA<StreamInterruptedException>());
+    expect(notifier.state.isStreaming, isFalse);
+    expect(notifier.state.streamingText, isNull);
+    expect(notifier.state.suggestedReplies, isEmpty);
+  });
+
+  test('turn_end server_restart (graceful drain) discards and offers retry',
+      () async {
+    final notifier = PlanNotifier(
+        _ScriptedPlanService([
+          const [
+            _streamStart,
+            PlanEvent(type: 'text_delta', data: {'text': 'Half a th'}),
+            PlanEvent(type: 'turn_end', data: {'stop_reason': 'server_restart'}),
+          ],
+          // The retry (after the deploy) gets a healthy stream.
+          const [
+            _streamStart,
+            PlanEvent(type: 'text_delta', data: {'text': 'The whole thought.'}),
+            _turnEndOk,
+          ],
+        ]),
+        ApiClient());
+
+    await notifier.sendMessage('plan berlin');
+    expect(notifier.state.error, isA<StreamInterruptedException>());
+    expect(notifier.state.messages.map((m) => m.role).toList(),
+        [MessageRole.user]);
+
+    // retryLastSend rolls back to just before the user message and re-sends:
+    // exactly one copy of the user message, then the full reply commits.
+    await notifier.retryLastSend();
+    expect(notifier.state.error, isNull);
+    expect(notifier.state.messages.map((m) => m.role).toList(),
+        [MessageRole.user, MessageRole.assistant]);
+    expect(notifier.state.messages.first.content, 'plan berlin');
+    expect(notifier.state.messages.last.content, 'The whole thought.');
+  });
+
+  test(
+      'a pre-protocol stream (no stream_start) keeps the old commit-on-close '
+      'behavior, so a rolled-back API degrades instead of erroring every turn',
+      () async {
+    final notifier = PlanNotifier(
+        _ScriptedPlanService([
+          const [
+            PlanEvent(type: 'text_delta', data: {'text': 'Legacy reply.'}),
+            // Old server: stream just closes, no terminal frame.
+          ]
+        ]),
+        ApiClient());
+
+    await notifier.sendMessage('plan athens');
+    expect(notifier.state.error, isNull);
+    expect(notifier.state.messages.map((m) => m.role).toList(),
+        [MessageRole.user, MessageRole.assistant]);
+    expect(notifier.state.messages.last.content, 'Legacy reply.');
+  });
+
+  test('an interrupted turn does not drain queued messages', () async {
+    final notifier = PlanNotifier(
+        _ScriptedPlanService([
+          const [
+            _streamStart,
+            PlanEvent(type: 'text_delta', data: {'text': 'Half'}),
+          ]
+        ]),
+        ApiClient());
+
+    final first = notifier.sendMessage('plan berlin');
+    // Queued while streaming; must still be queued after the interruption —
+    // the queue drains only on success, same as the explicit-error path.
+    final second = notifier.sendMessage('and munich');
+    await Future.wait([first, second]);
+
+    expect(notifier.state.error, isA<StreamInterruptedException>());
+    expect(notifier.state.queuedMessages, hasLength(1));
+    expect(notifier.state.queuedMessages.single.text, 'and munich');
+  });
+}


### PR DESCRIPTION
## The defect

The `/plan` SSE stream had no terminal event. The handler finished its loop and the response just closed — so the client could not distinguish **"the model finished"** from **"the connection died"**: both were bytes stopping. It resolved that the wrong way, committing whatever partial text had arrived as a **complete assistant message** (no error, no retry), and the server's deferred transcript save persisted the same stump — so the next turn's model read its own half-sentence as a finished reply and apologised for it. Five deploys in two hours on 2026-08-23 made this fire "a couple of times in the last hour" for a live chat: every deploy killed every in-flight stream.

Full diagnosis + decision log: epic artifact `chat-stream-truncation` (2026-08-24).

## The fix

**Server (`plan_handler.go`)**
- Every stream now ends with exactly one `turn_end` frame carrying a closed `stop_reason` vocabulary: `end_turn` (the model finished — the only reason a client may commit), `error` (rides after every `error` frame, via the `sendError` helper all error exits now go through), `server_restart` (graceful drain).
- `stream_start {protocol: 2}` announces the contract right after the priming comment, so a rolled-back API (sending neither event) degrades to the old commit-on-close behavior instead of erroring every reply.
- Every exit path swept: validation rejects, auth/cap/key errors, iteration cap, model stream errors, `max_tokens`, the `planMaxDuration` expiry (previously a silent close — same stump bug), client-abort (deliberately silent — dead socket), and the new drain path.
- The deferred transcript save now **skips the half-streamed text** on drain and client-abort exits, keeping stored history identical to what the client kept. Error-frame paths still persist the partial, because the client commits it there too — the two sides agree in both directions (pinned by tests d/e/f in `plan_stream_end_test.go`).

**Graceful shutdown (`main.go`)**
- SIGTERM/SIGINT → `planDrainBegin()` cancels every in-flight `/plan` request context (the handler writes `turn_end "server_restart"` to the still-live socket) → `http.Server.Shutdown` (8s bound, inside compose's 10s stop grace) → `main()` returns normally, so the deferred `dbPool.Close` and `sentry.Flush` finally run — the "for free" hook the old `main.go:530` comment promised.

**Client (`plan_provider.dart`, `plan_service.dart`, `errors.dart`)**
- A protocol stream that ends without `turn_end "end_turn"` **discards the half-reply** — it never becomes a message — and engages the existing banner + `retryLastSend` machinery via a typed `StreamInterruptedException`, localized EN+ES (`chatStreamInterrupted`). Retry rolls the transcript back to just before the user message and resends, so exactly one copy ends up in history.
- Explicit `error`-frame behavior is unchanged (commit partial + banner), matching the server's persistence.

**Deliberately NOT in this pass: the SSE heartbeat.** Deploys are the confirmed cause; a proxy idle-read cut is plausible but unobserved here. Shipping a heartbeat now would be a guess dressed as a fix — the artifact records this so it isn't rediscovered. If truncations continue *without* correlating to a deploy, that is the next thing to build.

## Verification

- Go: `gofmt` clean, `go vet` clean, full suite with test DB — **1375 passed, 0 failed, 2 skipped** (both pre-existing: a degraded-mode-only test and a share-route 404 skip), exit code captured directly from the runner.
- Flutter: `flutter analyze --no-fatal-infos --fatal-warnings` (CI's exact flags) exit 0 — the only findings are 3 pre-existing infos in `route_response.dart`, untouched since the initial commit; full suite **1983 passed, 0 failed**, exit 0 direct. `l10n_untranslated.json` = `{}`.
- CI's l10n drift check reproduced locally (`flutter pub get` → `flutter gen-l10n` → `git diff --quiet -- lib/l10n`): idempotent on this branch.
- **Real-wire acceptance test**: built the actual API binary, pointed `ANTHROPIC_BASE_URL` at a stalling SSE upstream, streamed `/plan` with `curl -N`, and `kill -TERM`ed the API mid-reply (parked at literally "But Berlin Mon…", the artifact's own trigger text). The wire shows the deltas followed by `turn_end {stop_reason: server_restart}` as the final frame, curl exits 0 on a clean close, and the API process exits in under a second. The client's reaction to exactly those bytes (discard + banner + working retry, one user-message copy after retry) is pinned by `plan_provider_turn_end_test.dart`.

## New tests

- `api/plan_stream_end_test.go` — terminal frame on success / mid-turn model error / drain; persistence agreement in all three directions (drain discards, client-abort discards, error keeps).
- `flutter-app/test/plan_provider_turn_end_test.dart` — commit on `end_turn`; discard + typed error on missing terminator and on `server_restart` (with working retry); legacy commit-on-close when no `stream_start`; queue stays put on interruption.
- Existing "exactly one event" reject-path assertions updated to the new three-frame contract; the client-abort AI-health test now also pins "no `turn_end` to a dead socket".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/golden-tempo/codesmith/anemos-travel/pr/563"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790175996&installation_model_id=433099&pr_number=563&repository=golden-tempo%2Fanemos-travel&return_to=https%3A%2F%2Fgithub.com%2Fgolden-tempo%2Fanemos-travel%2Fpull%2F563&signature=9dd99de3527f671ffc50d9f5678507b67173ccb75d96e8eb432285eaabd2cbdb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->