### PR TITLE
fix(trip-detail): item delete/edit/move update in place, without the full-page spinner

### DIFF
--- a/src/packages/flutter-app/lib/widgets/trip_detail/itinerary_tab.dart
+++ b/src/packages/flutter-app/lib/widgets/trip_detail/itinerary_tab.dart
@@ -1979,10 +1979,13 @@ extension on _TripDetailScreenState {
       await ref
           .read(tripsApiServiceProvider)
           .reorderItineraryItems(trip.id, ids);
-      await _load();
+      // Silent, like the delete flow: a one-swap move must not swap the
+      // whole body for the full-screen spinner. The failure reload restores
+      // the server's order, also in place.
+      await _refresh();
     } catch (e) {
       _showSnack(l10n.tripReorderFailed(friendlyError(l10n, e)));
-      await _load();
+      await _refresh();
     }
   }
 
@@ -2000,7 +2003,12 @@ extension on _TripDetailScreenState {
       _showSnack(l10n.tripRemoveItemFailed(item.name, friendlyError(l10n, e)));
       return;
     }
-    await _load();
+    // _refresh(), not a bare _load(): the silent path keeps the screen
+    // mounted (a loud load would swap in the full-screen spinner for a
+    // one-item change), and it serializes with any reload the refine panel
+    // has in flight so a pre-delete snapshot can't land after us and
+    // momentarily resurrect the just-deleted item.
+    await _refresh();
     if (!mounted) return;
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(
@@ -2034,7 +2042,11 @@ extension on _TripDetailScreenState {
     };
     try {
       await ref.read(tripsApiServiceProvider).addItineraryItem(tripId, body);
-      await _load();
+      // Armed like the add path: the restored item slots in at the end of
+      // its day and must be visible even if that section is folded.
+      // _refresh() keeps this an in-place update — no full-screen spinner.
+      _armRevealOfNewItems();
+      await _refresh();
     } catch (e) {
       _showSnack(l10n.tripRestoreItemFailed(item.name, friendlyError(l10n, e)));
     }
@@ -2056,7 +2068,9 @@ extension on _TripDetailScreenState {
       await ref
           .read(tripsApiServiceProvider)
           .updateItineraryItem(trip.id, item.id, changes);
-      await _load();
+      // Silent, like the delete flow: the edited row updates in place — no
+      // full-screen spinner.
+      await _refresh();
     } catch (e) {
       _showSnack(l10n.tripUpdateItemFailed(item.name, friendlyError(l10n, e)));
     }

--- a/src/packages/flutter-app/test/trip_detail_item_delete_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_item_delete_test.dart
@@ -1,0 +1,303 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:travel_route_planner/models/trip.dart';
+import 'package:travel_route_planner/models/itinerary_item.dart';
+import 'package:travel_route_planner/services/api_client.dart';
+import 'package:travel_route_planner/services/trips_api_service.dart';
+import 'package:travel_route_planner/providers/trips_provider.dart';
+import 'package:travel_route_planner/screens/trip_detail_screen.dart';
+
+import 'support/l10n_test_app.dart';
+
+ItineraryItem _item(int pos, String name, String category,
+        {int? day, String? city}) =>
+    ItineraryItem(
+      id: 'i-$name',
+      position: pos,
+      name: name,
+      address: '$name address',
+      // Zero coords so the screen skips the map widget in the test env.
+      latitude: 0,
+      longitude: 0,
+      category: category,
+      day: day,
+      city: city,
+    );
+
+Trip _tripWith(List<ItineraryItem> items) => Trip(
+      id: 't1',
+      title: 'Paris',
+      startDate: '2026-09-01',
+      endDate: '2026-09-03',
+      createdAt: '2026-08-01',
+      updatedAt: '2026-08-01',
+      items: items,
+    );
+
+/// Serves the seeded trip and mirrors the server: a successful DELETE drops
+/// the item from the served list, a successful add (undo) appends it back,
+/// so the screen's silent refresh after either call sees the new state.
+///
+/// [getTripGate] can hold a fetch mid-flight, which is what lets a test
+/// observe the frame a loud `_load()` would have spent on the full-screen
+/// spinner.
+class _FakeTripsApiService extends TripsApiService {
+  List<ItineraryItem> items;
+  final List<String> deletedIds = [];
+  final List<List<String>> reorderCalls = [];
+  final List<Map<String, dynamic>> updateCalls = [];
+  Completer<void>? getTripGate;
+  bool getTripInFlight = false;
+  _FakeTripsApiService(Trip trip)
+      : items = trip.items!,
+        super(ApiClient(baseUrl: 'http://test'));
+
+  // A fresh list per fetch, like a real JSON parse.
+  @override
+  Future<Trip> getTrip(String id) async {
+    final gate = getTripGate;
+    if (gate != null) {
+      getTripInFlight = true;
+      await gate.future;
+    }
+    return _tripWith(List.of(items));
+  }
+
+  @override
+  Future<void> deleteItineraryItem(String tripId, String itemId) async {
+    deletedIds.add(itemId);
+    items = items.where((it) => it.id != itemId).toList();
+  }
+
+  @override
+  Future<void> reorderItineraryItems(
+      String tripId, List<String> itemIds) async {
+    reorderCalls.add(itemIds);
+    final byId = {for (final it in items) it.id: it};
+    items = [for (final id in itemIds) byId[id]!];
+  }
+
+  @override
+  Future<ItineraryItem> updateItineraryItem(
+      String tripId, String itemId, Map<String, dynamic> body) async {
+    updateCalls.add(body);
+    items = [
+      for (final it in items)
+        if (it.id == itemId)
+          ItineraryItem(
+            id: it.id,
+            position: it.position,
+            name: (body['name'] as String?) ?? it.name,
+            address: it.address,
+            latitude: it.latitude,
+            longitude: it.longitude,
+            category: (body['category'] as String?) ?? it.category,
+            day: (body['day'] as int?) ?? it.day,
+            city: (body['city'] as String?) ?? it.city,
+            timeOfDay: (body['time_of_day'] as String?) ?? it.timeOfDay,
+          )
+        else
+          it,
+    ];
+    return items.firstWhere((it) => it.id == itemId);
+  }
+
+  @override
+  Future<Trip> addItineraryItem(String tripId, Map<String, dynamic> body) async {
+    items = [
+      ...items,
+      ItineraryItem(
+        id: 'i-restored-${body['name']}',
+        position: items.length,
+        name: body['name'] as String,
+        address: body['address'] as String?,
+        latitude: (body['latitude'] as num?)?.toDouble() ?? 0,
+        longitude: (body['longitude'] as num?)?.toDouble() ?? 0,
+        category: body['category'] as String?,
+        day: body['day'] as int?,
+        city: body['city'] as String?,
+      ),
+    ];
+    return _tripWith(List.of(items));
+  }
+}
+
+/// Item rows render inside lazy slivers; a tall viewport keeps the whole
+/// itinerary built and findable.
+void _useTallViewport(WidgetTester tester) {
+  tester.view.physicalSize = const Size(800, 2400);
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.reset);
+}
+
+Future<_FakeTripsApiService> _pump(WidgetTester tester, Trip trip) async {
+  final fake = _FakeTripsApiService(trip);
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [tripsApiServiceProvider.overrideWithValue(fake)],
+      child: MaterialApp(
+      localizationsDelegates: testLocalizationsDelegates,home: TripDetailScreen(tripId: 't1')),
+    ),
+  );
+  await tester.pumpAndSettle();
+  return fake;
+}
+
+/// Opens [name]'s kebab menu and taps [action]. Returns without waiting, so
+/// the caller can observe frames while the action's reload is still in
+/// flight.
+Future<void> _tapMenuAction(
+    WidgetTester tester, String name, String action) async {
+  final row =
+      find.ancestor(of: find.text(name), matching: find.byType(ListTile));
+  await tester.tap(
+      find.descendant(of: row, matching: find.byIcon(Icons.more_vert)));
+  await tester.pumpAndSettle();
+  await tester.tap(find.text(action));
+}
+
+Future<void> _deleteViaMenu(WidgetTester tester, String name) =>
+    _tapMenuAction(tester, name, 'Remove');
+
+/// Drives frames until the fake reports a gated getTrip in flight, then one
+/// more so the frame asserting against reflects any setState the reload
+/// issued on its way in (the loud _load() flips _loading synchronously
+/// before awaiting getTrip).
+Future<void> _pumpUntilReloadInFlight(
+    WidgetTester tester, _FakeTripsApiService fake) async {
+  for (var i = 0; i < 40 && !fake.getTripInFlight; i++) {
+    await tester.pump(const Duration(milliseconds: 25));
+  }
+  expect(fake.getTripInFlight, isTrue,
+      reason: 'the mutation should be followed by a reload');
+  await tester.pump();
+}
+
+void main() {
+  testWidgets('deleting an item removes it in place — no full-screen reload',
+      (WidgetTester tester) async {
+    _useTallViewport(tester);
+    final fake = await _pump(
+      tester,
+      _tripWith([
+        _item(0, 'Louvre', 'attraction', day: 1, city: 'Paris'),
+        _item(1, 'Orsay', 'attraction', day: 1, city: 'Paris'),
+      ]),
+    );
+
+    fake.getTripGate = Completer<void>();
+    await _deleteViaMenu(tester, 'Louvre');
+    await _pumpUntilReloadInFlight(tester, fake);
+
+    // Mid-reload: the list stays on screen. The loud _load() this replaced
+    // swapped the whole body for a spinner on exactly this frame.
+    expect(find.text('Orsay'), findsOneWidget);
+
+    fake.getTripGate!.complete();
+    await tester.pumpAndSettle();
+    expect(fake.deletedIds, ['i-Louvre']);
+    expect(find.text('Louvre'), findsNothing);
+    expect(find.text('Orsay'), findsOneWidget);
+    expect(find.text('Removed Louvre'), findsOneWidget);
+  });
+
+  testWidgets('undo restores the item in place — no full-screen reload',
+      (WidgetTester tester) async {
+    _useTallViewport(tester);
+    final fake = await _pump(
+      tester,
+      _tripWith([
+        _item(0, 'Louvre', 'attraction', day: 1, city: 'Paris'),
+        _item(1, 'Orsay', 'attraction', day: 1, city: 'Paris'),
+      ]),
+    );
+
+    await _deleteViaMenu(tester, 'Louvre');
+    await tester.pumpAndSettle();
+    expect(find.text('Louvre'), findsNothing);
+
+    fake.getTripGate = Completer<void>();
+    await tester.tap(find.text('Undo'));
+    await _pumpUntilReloadInFlight(tester, fake);
+
+    // Same contract on the way back: the undo's reload never replaces the
+    // list with a spinner.
+    expect(find.text('Orsay'), findsOneWidget);
+
+    fake.getTripGate!.complete();
+    await tester.pumpAndSettle();
+    expect(find.text('Louvre'), findsOneWidget);
+    expect(find.text('Orsay'), findsOneWidget);
+  });
+
+  testWidgets('moving an item down swaps in place — no full-screen reload',
+      (WidgetTester tester) async {
+    _useTallViewport(tester);
+    final fake = await _pump(
+      tester,
+      _tripWith([
+        _item(0, 'Louvre', 'attraction', day: 1, city: 'Paris'),
+        _item(1, 'Orsay', 'attraction', day: 1, city: 'Paris'),
+      ]),
+    );
+
+    fake.getTripGate = Completer<void>();
+    await _tapMenuAction(tester, 'Louvre', 'Move down');
+    await _pumpUntilReloadInFlight(tester, fake);
+
+    // Same contract as delete: the reload behind a one-swap move never
+    // replaces the list with the full-screen spinner.
+    expect(find.text('Orsay'), findsOneWidget);
+
+    fake.getTripGate!.complete();
+    await tester.pumpAndSettle();
+    expect(fake.reorderCalls, [
+      ['i-Orsay', 'i-Louvre']
+    ]);
+    final orsayTop = tester
+        .getTopLeft(find.ancestor(
+            of: find.text('Orsay'), matching: find.byType(ListTile)))
+        .dy;
+    final louvreTop = tester
+        .getTopLeft(find.ancestor(
+            of: find.text('Louvre'), matching: find.byType(ListTile)))
+        .dy;
+    expect(orsayTop, lessThan(louvreTop));
+  });
+
+  testWidgets('editing an item updates in place — no full-screen reload',
+      (WidgetTester tester) async {
+    _useTallViewport(tester);
+    final fake = await _pump(
+      tester,
+      _tripWith([
+        _item(0, 'Louvre', 'attraction', day: 1, city: 'Paris'),
+        _item(1, 'Orsay', 'attraction', day: 1, city: 'Paris'),
+      ]),
+    );
+
+    await _tapMenuAction(tester, 'Louvre', 'Edit');
+    await tester.pumpAndSettle();
+    // The edit sheet: rename in the Name field and save.
+    await tester.enterText(
+        find.widgetWithText(TextField, 'Name'), 'Louvre Museum');
+
+    fake.getTripGate = Completer<void>();
+    await tester.tap(find.text('Save'));
+    await _pumpUntilReloadInFlight(tester, fake);
+
+    expect(find.text('Orsay'), findsOneWidget);
+
+    fake.getTripGate!.complete();
+    await tester.pumpAndSettle();
+    expect(fake.updateCalls, [
+      {'name': 'Louvre Museum'}
+    ]);
+    expect(find.text('Louvre Museum'), findsOneWidget);
+    expect(find.text('Orsay'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## What

Deleting an itinerary item on the trip detail page triggered a full page refresh: `_deleteItem` awaited the loud `_load()`, which flips `_loading` and swaps the entire body for the full-screen spinner. Undo, move up/down, and edit had the same defect.

All four flows now await `_refresh()` — the silent, coalescing in-place reload the chat panel and add-to-trip flows already use. The list updates in place; the snackbar appears over a screen that never left. Undo additionally arms `_armRevealOfNewItems()` so a restored item is visible even when its day section is folded (same contract as the add flow).

`_refresh()` also serializes with any reload the refine panel has in flight, so a pre-delete snapshot can't land after the delete and momentarily resurrect the removed item.

## Tests

New `test/trip_detail_item_delete_test.dart` covers all four flows (delete, undo, move down, edit-rename): it gates the post-mutation fetch mid-flight and asserts the itinerary stays mounted through the reload. All four fail against the old code — the body swaps to the spinner on exactly that frame — and pass with the fix.

- Full trip-detail suite: **437 tests, 0 failures** (`flutter test test/trip_detail*.dart`, exit 0 captured directly from the runner)
- `flutter analyze --no-fatal-infos --fatal-warnings`: exit 0 (3 pre-existing infos in route_response.dart, untouched)

## Deliberately left loud

The "Reorder section" sheet (`_reorderSection`) still awaits `_load()` — a third menu flow outside the reported ones. Same two-line change if wanted later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/golden-tempo/codesmith/anemos-travel/pr/565"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790295665&installation_model_id=433099&pr_number=565&repository=golden-tempo%2Fanemos-travel&return_to=https%3A%2F%2Fgithub.com%2Fgolden-tempo%2Fanemos-travel%2Fpull%2F565&signature=0bd3e5cb2debd03d1acfe54e661fe6d3b316fc1c56a97fcf1c72a05a5b1b10b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->