### PR TITLE
fix(trip-detail): reorder-section sheet updates in place, without the full-page spinner

### DIFF
--- a/src/packages/flutter-app/lib/widgets/trip_detail/itinerary_tab.dart
+++ b/src/packages/flutter-app/lib/widgets/trip_detail/itinerary_tab.dart
@@ -1954,10 +1954,13 @@ extension on _TripDetailScreenState {
       await ref
           .read(tripsApiServiceProvider)
           .reorderItineraryItems(trip.id, ids);
-      await _load();
+      // Silent, like the other item mutations: a within-section reorder must
+      // not swap the whole body for the full-screen spinner. The failure
+      // reload restores the server's order, also in place.
+      await _refresh();
     } catch (e) {
       _showSnack(l10n.tripReorderFailed(friendlyError(l10n, e)));
-      await _load();
+      await _refresh();
     }
   }
 

--- a/src/packages/flutter-app/test/trip_detail_item_delete_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_item_delete_test.dart
@@ -269,6 +269,47 @@ void main() {
     expect(orsayTop, lessThan(louvreTop));
   });
 
+  testWidgets(
+      'saving the reorder-section sheet updates in place — no full-screen reload',
+      (WidgetTester tester) async {
+    _useTallViewport(tester);
+    // Three items in one section: the "Reorder section" menu entry only
+    // renders for sections longer than two.
+    final fake = await _pump(
+      tester,
+      _tripWith([
+        _item(0, 'Louvre', 'attraction', day: 1, city: 'Paris'),
+        _item(1, 'Orsay', 'attraction', day: 1, city: 'Paris'),
+        _item(2, 'Pompidou', 'attraction', day: 1, city: 'Paris'),
+      ]),
+    );
+
+    await _tapMenuAction(tester, 'Louvre', 'Reorder section');
+    await tester.pumpAndSettle();
+    expect(find.text('Reorder places'), findsOneWidget);
+
+    fake.getTripGate = Completer<void>();
+    await tester.tap(find.text('Save order'));
+    await _pumpUntilReloadInFlight(tester, fake);
+    // Let the sheet's exit animation finish — the reload is still gated, so
+    // this is the frame a loud _load() would have spent on the spinner.
+    await tester.pump(const Duration(milliseconds: 500));
+    await tester.pump();
+
+    // Mid-reload: the sheet is gone and the list stays on screen.
+    expect(find.text('Orsay'), findsOneWidget);
+
+    fake.getTripGate!.complete();
+    await tester.pumpAndSettle();
+    // Save submits the sheet's order through the same PUT /items/order path
+    // as Move up/down (unchanged here — the reload contract is the subject).
+    expect(fake.reorderCalls, [
+      ['i-Louvre', 'i-Orsay', 'i-Pompidou']
+    ]);
+    expect(find.text('Louvre'), findsOneWidget);
+    expect(find.text('Pompidou'), findsOneWidget);
+  });
+
   testWidgets('editing an item updates in place — no full-screen reload',
       (WidgetTester tester) async {
     _useTallViewport(tester);


### PR DESCRIPTION
## What

Follow-up to #565, which moved delete/undo/move/edit onto the silent in-place `_refresh()` and deliberately left one flow loud: the **"Reorder section" sheet**. Saving it awaited `_load()`, flipping `_loading` and swapping the whole body for the full-screen spinner.

Both of `_reorderSection`'s paths (success, and the failure reload that restores the server's order) now await `_refresh()`. With this, every item mutation on the trip detail page updates in place.

## Tests

Extended `test/trip_detail_item_delete_test.dart` with the sheet flow: three-item section (the menu entry only renders for >2), open sheet, Save, gate the post-save fetch mid-flight, pump past the sheet's exit animation, assert the itinerary is still mounted. **Fails against the old code** — 0 "Orsay" widgets on that frame, the list unmounted behind the spinner — and passes with the fix.

- Trip-detail suite: **438 tests, 0 failures** (`flutter test test/trip_detail*.dart`, exit 0 captured directly from the runner)
- `flutter analyze --no-fatal-infos --fatal-warnings`: exit 0 (3 pre-existing infos in route_response.dart, untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/golden-tempo/codesmith/anemos-travel/pr/566"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790306127&installation_model_id=433099&pr_number=566&repository=golden-tempo%2Fanemos-travel&return_to=https%3A%2F%2Fgithub.com%2Fgolden-tempo%2Fanemos-travel%2Fpull%2F566&signature=7d653974cd21d8a49cfcefc727f0e81744a5271007f4d885f3812bec324676e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->