### PR TITLE
fix(map): city-focus pins wear category glyphs; route walks break at day boundaries

### DIFF
--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -46,6 +46,7 @@ import '../services/api_client.dart' show isTransientError;
 import '../services/trip_cache.dart';
 import '../services/trips_api_service.dart' show TripEndpointsException;
 import '../theme/app_colors.dart';
+import '../theme/app_icons.dart';
 import '../theme/app_typography.dart';
 import '../theme/spacing.dart';
 import '../utils/calendar_links.dart';

--- a/src/packages/flutter-app/lib/theme/app_icons.dart
+++ b/src/packages/flutter-app/lib/theme/app_icons.dart
@@ -1,0 +1,16 @@
+import 'package:flutter/material.dart';
+
+/// Category glyphs in one place — the icon sibling of AppColors.forCategory:
+/// one mapping from a place's canonical category (API values, never
+/// translated) to the glyph every surface wears for it, so the itinerary
+/// rows' spine markers and the map's pins cannot drift apart.
+abstract final class AppIcons {
+  /// Glyph for an itinerary place by its category. Null means "no glyph" —
+  /// deliberate, not a missing fallback: the itinerary spine then shows the
+  /// stop's number-in-day and the map pin stays a plain tinted dot.
+  static IconData? forCategory(String? category) => switch (category) {
+        'restaurant' => Icons.restaurant,
+        'attraction' => Icons.attractions,
+        _ => null,
+      };
+}

--- a/src/packages/flutter-app/lib/widgets/trip_detail/itinerary_tab.dart
+++ b/src/packages/flutter-app/lib/widgets/trip_detail/itinerary_tab.dart
@@ -86,11 +86,7 @@ extension on _TripDetailScreenState {
   Widget _itemLeading(String? category, int position, ThemeData theme,
       {required bool selected}) {
     final scheme = theme.colorScheme;
-    final glyph = switch (category) {
-      'restaurant' => Icons.restaurant,
-      'attraction' => Icons.attractions,
-      _ => null,
-    };
+    final glyph = AppIcons.forCategory(category);
     final ink = selected ? scheme.onPrimary : scheme.onSurfaceVariant;
     return SizedBox(
       width: _spineMarker,

--- a/src/packages/flutter-app/lib/widgets/trip_map.dart
+++ b/src/packages/flutter-app/lib/widgets/trip_map.dart
@@ -9,6 +9,7 @@ import '../l10n/l10n.dart';
 import '../models/accommodation.dart';
 import '../models/itinerary_item.dart';
 import '../theme/app_colors.dart';
+import '../theme/app_icons.dart';
 import '../theme/app_shadows.dart';
 import '../theme/spacing.dart';
 import '../utils/trip_format.dart';
@@ -105,9 +106,13 @@ class TripMapDestination {
   });
 }
 
-/// Plots a trip's itinerary on a satellite basemap: a numbered, category-tinted
-/// pin per place, a route line connecting them in itinerary order, auto-fit to
-/// the trip's extent. Tapping a pin calls [onPinTap] with that item's position.
+/// Plots a trip's itinerary on a satellite basemap: a category-tinted pin per
+/// place wearing the same category glyph as the itinerary rows (or a plain
+/// dot when the category has none), and a route line connecting each day's
+/// stops in itinerary order — a day boundary breaks the line, so a multi-day
+/// city renders one disconnected walk per day rather than cross-town
+/// spaghetti. Auto-fits to the trip's extent.
+/// Tapping a pin calls [onPinTap] with that item's position.
 /// When [selectedPosition] changes the camera recenters on that place.
 /// [accommodations] render as distinct stay markers (see [_StayPin]) that join
 /// the auto-fit bounds but stay out of the route line and numbering.
@@ -132,6 +137,9 @@ class TripMap extends StatefulWidget {
 
   /// Label text (e.g. "12 min") for the within-city leg leaving the item at the
   /// given position. Drawn at the midpoint of that segment. Empty => no labels.
+  /// A pair the route line doesn't connect (a day boundary) never shows its
+  /// label: the upstream keying is same-city, not same-day, so a cross-day
+  /// entry can exist here and must drop with its segment.
   final Map<int, String> segmentLabels;
 
   /// When this value changes (by `==`), the camera re-fits to the current
@@ -274,6 +282,14 @@ class _TripMapState extends State<TripMap> {
 
   static bool _hasCoords(ItineraryItem i) =>
       i.latitude != 0 || i.longitude != 0;
+
+  /// Whether the route may connect two adjacent mapped stops: same
+  /// [ItineraryItem.day], failing OPEN when either day is unset so undated
+  /// items keep the pre-day-aware behavior (one continuous walk). The ONE
+  /// predicate behind the polyline runs, the direction arrows, and the
+  /// travel-time labels, so a day boundary breaks all three at once.
+  static bool _dayConnects(ItineraryItem a, ItineraryItem b) =>
+      a.day == null || b.day == null || a.day == b.day;
 
   /// Destination (trip-overview) mode: at least two pinnable destinations
   /// supplied. 0/1 entries — a single-city trip, or every destination
@@ -479,9 +495,14 @@ class _TripMapState extends State<TripMap> {
   /// `widget.onPinTap` lazily, so a cached marker never captures stale
   /// state — the cache key is only (items identity, tappable-or-not).
   ///
-  /// Labels count 1..N over what this map view shows (the whole trip on All,
-  /// one day on Day N) — not the item's trip-wide position, which reads as
-  /// arbitrary once the view filters or skips ungeocoded items.
+  /// Pin faces are the itinerary rows' category glyphs (see [_Pin]), never
+  /// ordinals. The 1..N labels this used to draw dated from the map's day
+  /// views; once leg chips replaced day chips (the map city-focus work) a
+  /// focused leg shows a whole city across all days — a stop order the
+  /// product surfaces nowhere else — and clustering swallowed arbitrary
+  /// labels anyway, leaving gappy sequences beside count bubbles wearing the
+  /// same white-ringed circle. Cluster counts are now the only numbers in
+  /// this mode, so a count unambiguously reads "N places here".
   List<Marker> _clusterMarkers(
       List<({ItineraryItem item, LatLng point})> mapped) {
     final tappable = widget.onPinTap != null;
@@ -491,7 +512,7 @@ class _TripMapState extends State<TripMap> {
       return _markerCache!;
     }
     final markers = <Marker>[
-      for (final (k, m) in mapped.indexed)
+      for (final m in mapped)
         Marker(
           point: m.point,
           // Transparent 44px halo around the 24/28px dot, tap handling on
@@ -510,7 +531,6 @@ class _TripMapState extends State<TripMap> {
                   return SizedBox.square(
                     dimension: selected ? 28 : 24,
                     child: _Pin(
-                      label: '${k + 1}',
                       category: m.item.category,
                       selected: selected,
                     ),
@@ -585,6 +605,26 @@ class _TripMapState extends State<TripMap> {
     final routePoints = destMode
         ? [for (final d in widget.destinations!) d.point]
         : mapped.map((m) => m.point).toList();
+    // The polyline as runs: in item mode consecutive stops connect only when
+    // [_dayConnects] allows, so a day boundary starts a new disconnected
+    // walk (day 2 starts back across town — one line through all days is
+    // the crisscross spaghetti this replaces). Single-point runs draw
+    // nothing. Destination mode stays one run: city→city legs are the
+    // trip's shape, not a day's walk.
+    final routeRuns = <List<LatLng>>[];
+    if (destMode) {
+      routeRuns.add(routePoints);
+    } else {
+      var run = <LatLng>[];
+      for (var k = 0; k < mapped.length; k++) {
+        if (k > 0 && !_dayConnects(mapped[k - 1].item, mapped[k].item)) {
+          if (run.length >= 2) routeRuns.add(run);
+          run = <LatLng>[];
+        }
+        run.add(mapped[k].point);
+      }
+      if (run.length >= 2) routeRuns.add(run);
+    }
     final homes = _effectiveHomes(widget.home);
     // Camera framing covers stays and the journey endpoints too; the route
     // polyline sticks to [routePoints].
@@ -597,8 +637,9 @@ class _TripMapState extends State<TripMap> {
 
     // Journey-endpoint legs (outbound airport → first city, return last city →
     // airport). Kept out of [mapped]/[routePoints]: appending there would
-    // silently reindex the numbered pins and break segment-label adjacency,
-    // so the legs get their own dashed polylines and arrow markers below.
+    // splice the airports into the itinerary walk and break the index
+    // alignment the arrow/label loops rely on, so the legs get their own
+    // dashed polylines and arrow markers below.
     final homeSegments = <({LatLng a, LatLng b})>[
       for (final h in homes) ...[
         if (h.outboundTo != null) (a: h.point, b: h.outboundTo!),
@@ -617,16 +658,20 @@ class _TripMapState extends State<TripMap> {
         final a = mapped[k];
         final b = mapped[k + 1];
         if (b.item.position != a.item.position + 1) continue;
+        // segmentLabels are same-city keyed upstream, not same-day, so a
+        // cross-day entry can exist — it drops with its segment.
+        if (!_dayConnects(a.item, b.item)) continue;
         final label = widget.segmentLabels[a.item.position];
         if (label == null) continue;
         labelSegments.add((a: a.point, b: b.point, text: label));
       }
     }
 
-    // Direction arrows on every drawn segment (each consecutive pair of route
-    // points, matching the polyline). Placed at the midpoint, or further along
-    // when a travel-time label already occupies the midpoint. Placement stays
-    // static even though labels hide dynamically on short legs: on such a leg
+    // Direction arrows on every drawn segment (each consecutive pair the
+    // polyline connects — a day boundary drops the pair with its line).
+    // Placed at the midpoint, or further along when a travel-time label
+    // already occupies the midpoint. Placement stays static even though
+    // labels hide dynamically on short legs: on such a leg
     // (< _SegmentLabelLayer.minLegPx on screen) t=0.7 vs 0.5 differs by a few
     // px and the arrow tucks behind the pins anyway. In destination mode
     // [routePoints] and [mapped] no longer align, so the label lookup (an
@@ -636,6 +681,9 @@ class _TripMapState extends State<TripMap> {
       final a = routePoints[k];
       final b = routePoints[k + 1];
       if (a == b) continue;
+      if (!destMode && !_dayConnects(mapped[k].item, mapped[k + 1].item)) {
+        continue;
+      }
       final hasLabel = !destMode &&
           mapped[k + 1].item.position == mapped[k].item.position + 1 &&
           widget.segmentLabels[mapped[k].item.position] != null;
@@ -732,21 +780,24 @@ class _TripMapState extends State<TripMap> {
               options: options,
               children: [
                 ...appMapTileLayers(context),
-                if (routePoints.length >= 2)
+                if (routeRuns.isNotEmpty)
                   PolylineLayer(
                     polylines: [
                       // Two passes make a thin line with a soft glow that stays
-                      // legible over satellite imagery.
-                      Polyline(
-                        points: routePoints,
-                        strokeWidth: 6,
-                        color: Colors.white.withValues(alpha: 0.25),
-                      ),
-                      Polyline(
-                        points: routePoints,
-                        strokeWidth: 2,
-                        color: Colors.white.withValues(alpha: 0.95),
-                      ),
+                      // legible over satellite imagery — glows first so a run
+                      // crossing another never lays its halo over a line.
+                      for (final run in routeRuns)
+                        Polyline(
+                          points: run,
+                          strokeWidth: 6,
+                          color: Colors.white.withValues(alpha: 0.25),
+                        ),
+                      for (final run in routeRuns)
+                        Polyline(
+                          points: run,
+                          strokeWidth: 2,
+                          color: Colors.white.withValues(alpha: 0.95),
+                        ),
                     ],
                   ),
                 if (homeSegments.isNotEmpty)
@@ -779,7 +830,7 @@ class _TripMapState extends State<TripMap> {
                 if (labelSegments.isNotEmpty)
                   _SegmentLabelLayer(segments: labelSegments),
                 // The journey endpoints, like stays, sit outside the
-                // clusterer and beneath the numbered pins: they are fixed
+                // clusterer and beneath the itinerary pins: they are fixed
                 // endpoints, not itinerary stops. Two pins when the trip comes
                 // home into a different airport than it left from.
                 if (homes.isNotEmpty)
@@ -809,7 +860,7 @@ class _TripMapState extends State<TripMap> {
                 // Stays live in their own layer, outside the clusterer: a trip has
                 // few of them and "where am I sleeping" should never collapse into
                 // an anonymous count bubble with sightseeing pins. Drawn beneath
-                // the numbered pins so the primary interaction stays on top.
+                // the itinerary pins so the primary interaction stays on top.
                 if (stays.isNotEmpty)
                   MarkerLayer(
                     markers: [
@@ -967,7 +1018,7 @@ class _SegmentArrow extends StatelessWidget {
 
 /// Renders travel-time pills only for legs long enough on screen to have room
 /// for one — zoomed out, same-city stops converge and the midpoint pill would
-/// just sit behind the numbered pins. Rebuilds on every camera move/zoom
+/// just sit behind the pins. Rebuilds on every camera move/zoom
 /// because MapCamera.of registers an InheritedModel dependency.
 class _SegmentLabelLayer extends StatelessWidget {
   /// Minimum on-screen leg length (px) before its pill is drawn: pin radius
@@ -1062,8 +1113,15 @@ class _ClusterBubble extends StatelessWidget {
 
 /// The painted itinerary dot. Purely visual: tap handling lives on the
 /// marker-level GestureDetector so the whole [_pinHitBox] halo is tappable.
+///
+/// Two faces on one ring: a per-item pin (null [label]) wears its category
+/// glyph — the same [AppIcons.forCategory] vocabulary as the itinerary rows'
+/// spine markers, so pin and row read as the same place — or nothing (a
+/// plain tinted dot) when the category has no glyph. [_DestinationPin]
+/// passes a [label] for its 1..N visit-order face.
 class _Pin extends StatelessWidget {
-  final String label;
+  /// Ordinal text face; null renders the category-glyph face.
+  final String? label;
   final String? category;
   final bool selected;
 
@@ -1071,7 +1129,7 @@ class _Pin extends StatelessWidget {
   final Color? color;
 
   const _Pin({
-    required this.label,
+    this.label,
     required this.category,
     required this.selected,
     this.color,
@@ -1084,6 +1142,7 @@ class _Pin extends StatelessWidget {
   Widget build(BuildContext context) {
     final scheme = Theme.of(context).colorScheme;
     final color = _color(scheme);
+    final glyph = label == null ? AppIcons.forCategory(category) : null;
     return Container(
       // A permanent white ring keeps the small dots crisp over satellite
       // imagery; selection thickens the ring (and the dot itself grows).
@@ -1094,21 +1153,31 @@ class _Pin extends StatelessWidget {
         boxShadow: selected ? AppShadows.pinSelected : AppShadows.pin,
       ),
       alignment: Alignment.center,
-      child: Text(
-        label,
-        style: const TextStyle(
-          color: Colors.white,
-          fontSize: 11,
-          fontWeight: FontWeight.bold,
-        ),
-      ),
+      child: label != null
+          ? Text(
+              label!,
+              style: const TextStyle(
+                color: Colors.white,
+                fontSize: 11,
+                fontWeight: FontWeight.bold,
+              ),
+            )
+          : glyph != null
+              // 14px like the stay/home glyphs — the size at which the
+              // sibling square markers already read over satellite imagery
+              // (and the largest whose box still inscribes the 24px dot's
+              // 20px interior).
+              ? Icon(glyph, size: 14, color: Colors.white)
+              : null,
     );
   }
 }
 
 /// A destination (city-leg) pin for the trip-overview mode: the same round
-/// numbered dot as itinerary pins, in one consistent color (category tinting
-/// is meaningless for a whole city). Destinations sit outside the
+/// white-ringed dot as itinerary pins but wearing its 1..N visit-order
+/// number — that ordering is real (it matches the leg chips) where a
+/// per-item stop ordinal was not — in one consistent color (category
+/// tinting is meaningless for a whole city). Destinations sit outside the
 /// position-based selection sync: with [onTap] wired the tap drives
 /// [TripMap.onDestinationTap] (the tooltip stays on hover/long-press);
 /// without it a tap shows a self-contained tooltip (city + dates) like

--- a/src/packages/flutter-app/test/shared_trip_destination_pins_test.dart
+++ b/src/packages/flutter-app/test/shared_trip_destination_pins_test.dart
@@ -104,14 +104,22 @@ void main() {
     );
     expect(tooltip.message, 'Rome');
 
-    // Focusing a city: per-item pins return.
+    // Focusing a city: per-item pins return — category glyphs, not numbers
+    // (visit-order ordinals belong to the All view alone).
     await tester.tap(find.descendant(
       of: find.byType(MapLegChips),
       matching: find.text('Paris'),
     ));
     await tester.pumpAndSettle();
     expect(find.byType(MarkerClusterLayerWidget), findsOneWidget);
-    expect(inMap('1'), findsOneWidget);
+    expect(
+      find.descendant(
+        of: find.byType(FlutterMap),
+        matching: find.byIcon(Icons.attractions),
+      ),
+      findsOneWidget,
+    );
+    expect(inMap('1'), findsNothing);
   });
 
   testWidgets(

--- a/src/packages/flutter-app/test/trip_detail_destination_map_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_destination_map_test.dart
@@ -104,11 +104,19 @@ void main() {
     );
     expect(tooltip.message, startsWith('Rome'));
 
-    // Focusing Paris: per-item stop pins return, inside the clusterer.
+    // Focusing Paris: per-item stop pins return, inside the clusterer —
+    // wearing category glyphs, never ordinals (visit-order numbers are the
+    // All view's alone).
     await tapChip(tester, 'Paris');
     expect(find.byType(MarkerClusterLayerWidget), findsOneWidget);
-    expect(inMap('1'), findsOneWidget);
-    expect(inMap('2'), findsOneWidget);
+    expect(
+      find.descendant(
+        of: find.byType(FlutterMap),
+        matching: find.byIcon(Icons.attractions),
+      ),
+      findsNWidgets(2),
+    );
+    expect(inMap('1'), findsNothing);
 
     // The reset restores the overview.
     await tapMapReset(tester);

--- a/src/packages/flutter-app/test/trip_map_test.dart
+++ b/src/packages/flutter-app/test/trip_map_test.dart
@@ -11,14 +11,16 @@ import 'package:travel_route_planner/widgets/trip_map.dart';
 
 import 'support/l10n_test_app.dart';
 
-ItineraryItem _item(int pos, String name, double lat, double lng) =>
+ItineraryItem _item(int pos, String name, double lat, double lng,
+        {String? category = 'attraction', int? day}) =>
     ItineraryItem(
       id: 'i$pos',
       position: pos,
       name: name,
       latitude: lat,
       longitude: lng,
-      category: 'attraction',
+      category: category,
+      day: day,
     );
 
 /// Hosts the map at a fixed size (FlutterMap needs bounded constraints).
@@ -379,28 +381,132 @@ void main() {
     expect(dy, greaterThanOrEqualTo(48));
   });
 
-  testWidgets('pins number 1..N over the shown items, not trip-wide position', (
+  testWidgets('pins wear category glyphs, never ordinals', (
     WidgetTester tester,
   ) async {
-    // A day-filtered (or partially geocoded) view hands the map items whose
-    // positions start mid-trip; the labels must still read 1, 2 in route
-    // order rather than exposing positions 5, 6 as "6", "7".
+    // A leg focus hands the map a city's items whose positions start
+    // mid-trip and span days: no pin may surface a number (neither a 1..N
+    // view ordinal nor the trip-wide position — both reference orderings
+    // the product surfaces nowhere else). Faces are the itinerary rows'
+    // category glyphs; a category without one leaves a plain tinted dot.
     await tester.pumpWidget(
       _host(
         TripMap(
           items: [
             _item(5, 'Louvre', 48.8606, 2.3376),
-            _item(6, 'Café de Flore', 48.8540, 2.3326),
+            _item(6, 'Chez Janou', 48.8540, 2.3326, category: 'restaurant'),
+            _item(7, 'Pont Neuf', 48.8567, 2.3416, category: null),
           ],
+        ),
+      ),
+    );
+    // Let the cluster layer's split animation settle: mid-flight it renders
+    // transient count bubbles even for markers that end up unclustered.
+    await tester.pumpAndSettle();
+
+    expect(find.byIcon(Icons.attractions), findsOneWidget);
+    expect(find.byIcon(Icons.restaurant), findsOneWidget);
+
+    // The glyph rides the category tint (the row/pin pairing the itinerary
+    // list already speaks).
+    final restaurantDot = tester.widget<Container>(
+      find
+          .ancestor(
+            of: find.byIcon(Icons.restaurant),
+            matching: find.byType(Container),
+          )
+          .first,
+    );
+    expect(
+      (restaurantDot.decoration as BoxDecoration).color,
+      Colors.deepOrange,
+    );
+
+    // The category-less pin is a bare dot: a circle-decorated Container with
+    // no face at all.
+    final scheme = Theme.of(tester.element(find.byType(FlutterMap)))
+        .colorScheme;
+    expect(
+      find.byWidgetPredicate(
+        (w) =>
+            w is Container &&
+            w.decoration is BoxDecoration &&
+            (w.decoration as BoxDecoration).shape == BoxShape.circle &&
+            (w.decoration as BoxDecoration).color == scheme.secondary &&
+            w.child == null,
+      ),
+      findsOneWidget,
+    );
+
+    // No ordinal text anywhere: the three pins sit beyond cluster range, so
+    // the only numbers this mode may show (cluster counts) are absent too.
+    expect(find.textContaining(RegExp(r'^\d+$')), findsNothing);
+  });
+
+  testWidgets('a day boundary splits the route into disconnected walks', (
+    WidgetTester tester,
+  ) async {
+    // Two days in one city, two stops each, roughly collinear so every
+    // within-day leg stays long on screen. One line through all four points
+    // (with an arrow on the cross-town day-2 hop back) is the crisscross
+    // this replaced.
+    final twoDay = [
+      _item(0, 'Louvre', 48.8606, 2.3376, day: 1),
+      _item(1, 'Café de Flore', 48.8540, 2.3326, day: 1),
+      _item(2, 'Panthéon', 48.8474, 2.3276, day: 2),
+      _item(3, 'Catacombes', 48.8408, 2.3226, day: 2),
+    ];
+    await tester.pumpWidget(_host(TripMap(items: twoDay)));
+    await tester.pump();
+
+    // One arrow per connected pair — none across the boundary.
+    expect(find.byIcon(Icons.navigation), findsNWidgets(2));
+
+    // The polyline layer draws two runs (each as glow + line), and no run
+    // bridges the last day-1 stop to the first day-2 stop.
+    final layer = tester.widget<PolylineLayer>(
+      find.byWidgetPredicate((w) => w is PolylineLayer),
+    );
+    final runs = layer.polylines.map((p) => p.points).toList();
+    expect(runs, hasLength(4)); // 2 runs × (glow + line)
+    for (final run in runs) {
+      expect(run, hasLength(2));
+    }
+    final day1End = LatLng(twoDay[1].latitude, twoDay[1].longitude);
+    final day2Start = LatLng(twoDay[2].latitude, twoDay[2].longitude);
+    for (final run in runs) {
+      expect(
+        run.contains(day1End) && run.contains(day2Start),
+        isFalse,
+        reason: 'no run may bridge the day boundary',
+      );
+    }
+  });
+
+  testWidgets('a travel-time label drops with its cross-day segment', (
+    WidgetTester tester,
+  ) async {
+    // segmentLabels are keyed same-city upstream, not same-day, so the
+    // derivation CAN hand the map a label for the pair a day boundary
+    // disconnects — it must drop with the segment while the within-day
+    // label survives.
+    final twoDay = [
+      _item(0, 'Louvre', 48.8606, 2.3376, day: 1),
+      _item(1, 'Café de Flore', 48.8540, 2.3326, day: 1),
+      _item(2, 'Panthéon', 48.8474, 2.3276, day: 2),
+    ];
+    await tester.pumpWidget(
+      _host(
+        TripMap(
+          items: twoDay,
+          segmentLabels: const {0: '12 min', 1: '9 min'},
         ),
       ),
     );
     await tester.pump();
 
-    expect(find.text('1'), findsOneWidget);
-    expect(find.text('2'), findsOneWidget);
-    expect(find.text('6'), findsNothing);
-    expect(find.text('7'), findsNothing);
+    expect(find.text('12 min'), findsOneWidget);
+    expect(find.text('9 min'), findsNothing);
   });
 
   group('home-airport overlay', () {
@@ -425,9 +531,8 @@ void main() {
       expect(find.byIcon(Icons.navigation), findsOneWidget);
     });
 
-    testWidgets('overlay adds the pin and two leg arrows, numbering intact', (
-      WidgetTester tester,
-    ) async {
+    testWidgets('overlay adds the pin and two leg arrows, cluster count intact',
+        (WidgetTester tester) async {
       await tester.pumpWidget(_host(TripMap(items: items, home: [home])));
       await tester.pump();
       await tester.pump();
@@ -437,7 +542,7 @@ void main() {
       expect(find.byIcon(Icons.navigation), findsNWidgets(3));
       // At the whole-journey zoom the two Paris pins collapse into a cluster
       // bubble; its count proves the home point never joined [mapped] (a "3"
-      // here would mean the overlay leaked into the numbered pins).
+      // here would mean the overlay leaked into the clustered item pins).
       expect(find.text('2'), findsOneWidget);
       expect(find.text('3'), findsNothing);
 
@@ -735,7 +840,7 @@ void main() {
     final projected = _camera(
       tester,
     ).latLngToScreenOffset(const LatLng(48.8606, 2.3376));
-    final pinCenter = tester.getCenter(find.text('1'));
+    final pinCenter = tester.getCenter(find.byIcon(Icons.attractions));
     expect((pinCenter - (mapTopLeft + projected)).distance, lessThan(1.0));
   });
 
@@ -749,7 +854,9 @@ void main() {
     await tester.pump();
 
     // 18px below the dot center: outside the 24px dot, inside the 44px box.
-    await tester.tapAt(tester.getCenter(find.text('1')) + const Offset(0, 18));
+    await tester.tapAt(
+      tester.getCenter(find.byIcon(Icons.attractions)) + const Offset(0, 18),
+    );
     expect(tappedPos, 0);
   });
 
@@ -869,9 +976,17 @@ void main() {
       );
       await tester.pump();
 
+      // Per-item mode: the clusterer mounts and both fixture items render
+      // their glyph pins (no visit-order numbers — those are the ≥2 mode's).
       expect(find.byType(MarkerClusterLayerWidget), findsOneWidget);
-      expect(inMap('1'), findsOneWidget);
-      expect(inMap('2'), findsOneWidget);
+      expect(
+        find.descendant(
+          of: find.byType(FlutterMap),
+          matching: find.byIcon(Icons.attractions),
+        ),
+        findsNWidgets(2),
+      );
+      expect(inMap('1'), findsNothing);
     });
 
     testWidgets('destination mode renders with no mappable items (lens-proof)',


### PR DESCRIPTION
## What

City-focus (per-item) map pins now speak the itinerary list's language, and the route line respects days. Fixes the Amsterdam report: circles labeled 14, 6, 3, 4, 3, 2, 8 joined by crisscrossing arrows, where cluster COUNTS and stop ORDINALS shared one visual and the ordinals referenced an ordering surfaced nowhere in the product.

- **Per-item pins: category glyphs, not ordinals** (`trip_map.dart`). The pin face is the same mapping the itinerary rows' spine markers use — `Icons.restaurant` / `Icons.attractions` / plain tinted dot — extracted into one shared helper, `AppIcons.forCategory` (`lib/theme/app_icons.dart`, the icon sibling of `AppColors.forCategory`), consumed by both `_itemLeading` and `_Pin`. Tint, white ring, 24→28 selected grow, shadow, selection sync, and the identity-keyed marker cache are all unchanged. Glyph draws at 14px, matching the stay/home square markers.
- **Cluster bubbles: unchanged.** With ordinals gone the count is the only number in city view, so "6" unambiguously reads "6 places here".
- **Route line, arrows, travel-time labels: same-day only** (item mode; destination mode untouched). One predicate — `_dayConnects`: `a.day == null || b.day == null || a.day == b.day` (fail open on null) — applied to the polyline (per-day runs; a 2-day city renders 2 disconnected walks), the direction arrows, and the label segments (which are same-city keyed upstream, so a cross-day label could exist and now drops with its segment).
- **All-view destination pins keep their 1..N labels** — that ordering is real (matches chip order) and tooltipped.
- Stale docs updated: `_clusterMarkers` still described per-day 1..N labels from the dead day views (leg chips replaced day chips in the map city-focus work); class-level "numbered pin per place" doc likewise.

## Tests

- Rewrote the per-item ordinal assertions for the glyph contract: `trip_map_test.dart` (glyph faces + deepOrange tint + bare-dot + no digit text; pin-anchor and halo-tap relocated via `find.byIcon`), the city-focus halves of `trip_detail_destination_map_test.dart` and `shared_trip_destination_pins_test.dart`, and the single-destination fallback.
- New pins, each verified fail-against-old (lib stashed → red with the right signature → unstashed → green):
  - `pins wear category glyphs, never ordinals` — old code: 0 `Icons.attractions` found where 1 expected.
  - `a day boundary splits the route into disconnected walks` — old code: 3 arrows where 2 expected; asserts 2×(glow+line) polyline runs and that no run bridges the boundary.
  - `a travel-time label drops with its cross-day segment` — old code: '9 min' rendered where none expected.
- Destination-mode (All view) assertions pass unchanged. Cluster-count assertion (home overlay leak guard) passes unchanged. Marker-cache identity tests pass unchanged.

## Verification

- `flutter analyze --no-fatal-infos --fatal-warnings` → exit 0 (only the 3 known pre-existing `route_response.dart` infos).
- Full `flutter test` → **+2000, All tests passed, EXIT=0** (exit captured directly via `echo "EXIT=$?" >> log`, no pipe). An earlier mid-work full run under a load-128 host (131-min run) flaked 3 files — the brief-named `auth_autofill_submit` burst test plus two 12-minute *loading* timeouts (`trip_cache_test`, `home_editorial_style_test`); all three passed standalone and in the final green run.
- Brand check (`brand-guidelines/scripts/check.sh`) on touched Dart files: 1 finding — `Colors.amber.shade700` at `itinerary_tab.dart:1553`, the pre-existing weather glyph, untouched by this diff (my only edit in that file is the `_itemLeading` switch extraction).
- No l10n changes (no new user-facing strings; tooltips unchanged). No Go/API changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/golden-tempo/codesmith/anemos-travel/pr/567"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790306171&installation_model_id=433099&pr_number=567&repository=golden-tempo%2Fanemos-travel&return_to=https%3A%2F%2Fgithub.com%2Fgolden-tempo%2Fanemos-travel%2Fpull%2F567&signature=88d7875432b37d9cd142fe33ef0bf13d645e7204802e6a57c67ad8222fd8fab6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->