### PR TITLE
perf(trip-detail): render on the trip GET, cache-first on revisits, defer the map and fan-out

### DIFF
--- a/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
+++ b/src/packages/flutter-app/lib/screens/trip_detail_screen.dart
@@ -334,6 +334,36 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
   // any failure — travel times are an enhancement and never block the itinerary.
   Map<int, LocationTiming> _travelByPos = {};
 
+  // ── Deferred first-frame fan-out (time-to-interactive, lever 3) ───────
+  // The first CONTENT frame pays only for what it shows. The live tile map
+  // (two stacked retina layers — dozens of tile fetches and decodes) and
+  // the enhancement fetches (trip review, checklist, per-leg weather, city
+  // events) all used to mount in that exact frame, competing with the
+  // traveler's first scroll. They now mount one frame later, off a
+  // post-frame callback the first content build arms. Until it flips, the
+  // map band paints appMapBackground — the same canvas an unloaded map
+  // paints, so the swap is invisible — and the provider-backed sections
+  // render the no-data state they'd show on a cold first frame anyway.
+  bool _postFirstFrame = false;
+  bool _postFirstFrameArmed = false;
+
+  /// THE gate for enhancement provider watches (lever 3). Watches [provider]
+  /// only once the fan-out is allowed: after the first content frame, or
+  /// immediately when the provider is already alive — every family this
+  /// gates is non-autoDispose, so "alive" means a previous watch created it
+  /// and its cached value can render in the first frame for free (a warm
+  /// revisit keeps its badge and chips; only fetch CREATION is deferred).
+  /// Returns null while deferred — callers treat that as their loading
+  /// state, which renders identically. Two sites can't call this verbatim
+  /// and restate its condition with a pointer here: the day weather chip
+  /// (needs a .select watch) and TripHeaderCard.reviewLive (a separate
+  /// widget file).
+  AsyncValue<T>? _fanOutWatch<T>(
+      WidgetRef ref, ProviderBase<AsyncValue<T>> provider) {
+    if (!_postFirstFrame && !ref.exists(provider)) return null;
+    return ref.watch(provider);
+  }
+
   // ── Derivation memo (specs/perf-program, Wave 4 PR1) ──────────────────
   // The whole per-build pipeline (filtered items, city groups, leg ranges,
   // date chips, booking slots, map inputs) lives in TripDerivation
@@ -401,7 +431,10 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
   void _openHealthOnArrival() {
     if (!mounted || !widget.openHealthSheet || _healthSheetShown) return;
     final trip = _trip;
-    if (trip == null) return;
+    // _error too, not just a null trip: a cache-first paint followed by a
+    // stable failure (403/404) leaves _trip holding the cached copy while
+    // the error page renders — the sheet must not float over it.
+    if (trip == null || _error != null) return;
     _healthSheetShown = true;
     _openHealthSheet(trip);
   }
@@ -568,11 +601,47 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
     // conversation streaming inside it) stays mounted. First load always
     // takes the loud path.
     final quiet = silent && _trip != null;
+    // Captured before the reset below: a Retry from the error screen must
+    // not cache-first-paint a copy of the trip the last load already proved
+    // stale-failed (a 404'd trip flashing up, then the error page again).
+    final retryingFromError = _error != null;
     if (!quiet) {
       setState(() {
         _loading = true;
         _error = null;
       });
+      // Cache-first paint (trip-detail time-to-interactive, lever 2): with
+      // nothing on screen yet, render the saved copy NOW and let the network
+      // fetch land in place behind it — the same silent in-place update the
+      // SSE-bump _refresh path already proves out. Deliberately NOT offline
+      // mode: the fetch is running, so mutations stay armed; if it fails
+      // transiently, the catch below re-enters this same cached copy WITH
+      // the offline affordance, and a stable failure (403/404/500) still
+      // takes the error page — a revoked or deleted trip must not survive
+      // as an interactive cached copy. Gated on `_trip == null` so a loud
+      // reload of an on-screen trip (mutation flows, offline Retry) can
+      // never regress the screen to an older cached copy.
+      if (_trip == null && !retryingFromError) {
+        final cached =
+            await ref.read(tripCacheProvider).readTrip(widget.tripId);
+        if (cached != null && mounted && _trip == null) {
+          setState(() {
+            _trip = cached.trip;
+            _bookingTodos = cached.trip.bookingTodos ?? [];
+            _stays = cached.trip.accommodations ?? [];
+            _segments = cached.trip.segments ?? [];
+            _loading = false;
+            // Today mode treats this as the trip's first paint (the
+            // cached-offline fallback's precedent); the fresh landing
+            // below then no-ops via _autoScrolledToday, so the swap can
+            // never re-scroll out from under the traveler.
+            if (!silent) _maybeAutoScrollToday(cached.trip);
+          });
+        }
+      }
+      // The cache read above added an await before the fetch below; a
+      // screen popped during it must not touch ref again.
+      if (!mounted) return;
     }
     try {
       final trip =
@@ -596,6 +665,14 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
           _stays = trip.accommodations ?? [];
           _segments = trip.segments ?? [];
           _offlineSince = null; // live data — leave offline mode if we were in it
+          // First paint gates on the trip GET alone (time-to-interactive,
+          // lever 1): everything the first frame renders is already in this
+          // payload, and the enhancement pass below — travel times,
+          // preferences, the booking-todo sync — used to hold the spinner
+          // through two-to-three more round trips, each exposed to send()'s
+          // retry backoff. They now land in place after this frame, exactly
+          // like the SSE-bump refresh path.
+          _loading = false;
           // Today mode fires only from loud loads — never from a silent
           // refresh, which shares this success path (PR #51/#53 invariants).
           if (!silent) _maybeAutoScrollToday(trip);
@@ -629,11 +706,24 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
         }
       }
 
-      await Future.wait([
-        if (mounted && (trip.items ?? const []).isNotEmpty)
-          _computeTravelTimes(trip),
-        syncTodosAfterPrefs(),
-      ]);
+      // Enhancement pass: the screen above is already rendered, so nothing
+      // in here may blank it, re-spinner it, or flip it into offline mode.
+      // Both chains swallow their own errors; this boundary keeps any
+      // residual one (a throwing prefs load, a future refactor) out of the
+      // catch clause below, which would misread it as a failed trip load.
+      // Deliberately still awaited: _load's completion continues to mean
+      // "this load and its follow-ups are done", so _refresh's coalescing
+      // loop can never overlap two booking-todo syncs.
+      try {
+        await Future.wait([
+          if (mounted && (trip.items ?? const []).isNotEmpty)
+            _computeTravelTimes(trip),
+          syncTodosAfterPrefs(),
+        ]);
+      } catch (_) {
+        // Explicitly silenced: enhancements degrade to the payload already
+        // on screen, the same way they do on the silent-refresh path.
+      }
       // Trip Health is a SEPARATE fetch (GET /trips/{id}/review) behind a
       // non-autoDispose provider, so nothing expires it on its own — leaving
       // the screen and coming back re-reads the same cached answer. Every
@@ -652,7 +742,12 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
       // surviving send()'s own retries) — a rate-limited boot with a good
       // cached copy must not dead-end on an error screen. Stable HTTP errors
       // (403/404/500) never match either predicate, so a revoked or deleted
-      // trip can't resurrect from a stale copy.
+      // trip can't resurrect from a stale copy — including one the
+      // cache-first paint above already put on screen: for those, the
+      // fall-through below sets _error and the error page replaces it.
+      // After a cache-first paint the transient branch re-reads the same
+      // entry and re-sets identical data, so the only visible change is the
+      // offline banner arriving — no content swap, no scroll reset.
       if (mounted && !quiet &&
           (TripCache.isNetworkError(e) || isTransientError(e))) {
         final cached = await ref.read(tripCacheProvider).readTrip(widget.tripId);
@@ -699,7 +794,10 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
       }
       if (mounted && !quiet) setState(() => _error = e);
     } finally {
-      if (mounted && !quiet) setState(() => _loading = false);
+      // Guarded: the success path and the cache-first paint clear _loading
+      // themselves, so this only mops up the paths that still show the
+      // spinner (no cached copy + failure), without an extra rebuild.
+      if (mounted && !quiet && _loading) setState(() => _loading = false);
       if (mounted) _syncStatusPolling();
     }
   }
@@ -830,10 +928,11 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
   }
 
   /// One-shot Today trigger, called inside the setState of the loud load
-  /// paths (live success and cached-offline fallback) so the map's today
-  /// focus preselection lands in the same frame as the trip. Never called
-  /// from silent refreshes; a no-op once fired, while the refine panel is
-  /// open, or when the trip is undated/past/future or has no day tags.
+  /// paths (live success, cache-first paint, and cached-offline fallback) so
+  /// the map's today focus preselection lands in the same frame as the trip.
+  /// Never called from silent refreshes; a no-op once fired, while the refine
+  /// panel is open, or when the trip is undated/past/future or has no day
+  /// tags.
   void _maybeAutoScrollToday(Trip trip) {
     if (_autoScrolledToday || _panelOpen) return;
     final today = tripDayOn(trip.startDate, trip.endDate, DateTime.now());
@@ -851,9 +950,10 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
     final todayLeg = d.legKeyForDay(today);
     if (todayLeg != null) _setMapFocus(d, todayLeg);
     // The scroll itself waits for the first build that actually shows the
-    // scroll view: this setState still renders the loading spinner (the
-    // loud path clears _loading later, in its finally), so a post-frame
-    // callback scheduled here could fire before the CustomScrollView exists.
+    // scroll view: a post-frame callback scheduled here could fire before
+    // the CustomScrollView has laid out (and on paths where this setState
+    // precedes _loading clearing, before it even exists), so the pending
+    // day is consumed by the content build instead.
     _pendingTodayScroll = today;
   }
 
@@ -3052,13 +3152,14 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
     for (final r in derivation.visibleRanges) {
       final start = r.start, end = r.end;
       if (r.label == _kOtherPlaces || start == null || end == null) continue;
-      final report = ref
-          .watch(weatherByCityProvider(WeatherQuery(
-            city: r.label,
-            startDate: _fmt(start),
-            endDate: _fmt(end),
-          )))
-          .valueOrNull;
+      final report = _fanOutWatch(
+              ref,
+              weatherByCityProvider(WeatherQuery(
+                city: r.label,
+                startDate: _fmt(start),
+                endDate: _fmt(end),
+              )))
+          ?.valueOrNull;
       if (report == null) continue;
       final rec = clothingRec(report);
       if (rec == null) continue;
@@ -3107,10 +3208,13 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
   Widget _healthAppBarAction(Trip trip, ThemeData theme) {
     return Consumer(
       builder: (context, ref, _) {
-        final findings = ref
-            .watch(tripReviewProvider(TripReviewKey(trip.id)))
-            .valueOrNull
-            ?.findings;
+        // _fanOutWatch: deferred (null) renders exactly the no-value gate
+        // below — the badge appears when the review lands, one frame's
+        // deferral later than before on a cold visit, immediately on warm.
+        final findings =
+            _fanOutWatch(ref, tripReviewProvider(TripReviewKey(trip.id)))
+                ?.valueOrNull
+                ?.findings;
         if (findings == null) return const SizedBox.shrink();
         const icon = Icon(Icons.fact_check_outlined);
         final l10n = context.l10n;
@@ -3188,7 +3292,8 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
   /// point is to subscribe one app-bar widget rather than the screen.
   ({bool available, List<WearRegionRec> regions}) _wearState(
       WidgetRef ref, Trip trip) {
-    final items = ref.watch(checklistProvider(trip.id)).valueOrNull;
+    final items =
+        _fanOutWatch(ref, checklistProvider(trip.id))?.valueOrNull;
     final showChecklist = items != null && !(items.isEmpty && _readOnly);
     final recs = _legClothingRecs(trip, ref);
     return (available: recs.isNotEmpty || showChecklist, regions: recs);
@@ -3724,6 +3829,19 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
               : trip == null
                   ? const SizedBox.shrink()
                   : LayoutBuilder(builder: (context, constraints) {
+                      // Deferred fan-out arming (lever 3): the FIRST content
+                      // frame schedules everything deferred behind
+                      // _postFirstFrame — the live map, the enhancement
+                      // fetches — for the frame after it, so this frame's
+                      // paint costs only what it shows.
+                      if (!_postFirstFrame && !_postFirstFrameArmed) {
+                        _postFirstFrameArmed = true;
+                        WidgetsBinding.instance.addPostFrameCallback((_) {
+                          if (mounted) {
+                            setState(() => _postFirstFrame = true);
+                          }
+                        });
+                      }
                       // Phones get the scroll-away tap-to-expand map; wide
                       // layouts keep the pinned header. Keyed to the width
                       // the body actually gets (like the refine-dock check
@@ -3874,6 +3992,15 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
                                     isOffline: _isOffline,
                                     readOnly: _readOnly,
                                     panelOpen: _panelOpen,
+                                    // _fanOutWatch's condition, resolved
+                                    // here because the card lives in its
+                                    // own file: the review watch may run
+                                    // once the fan-out frame has arrived
+                                    // or when a previous watch already
+                                    // created the provider (warm revisit).
+                                    reviewLive: _postFirstFrame ||
+                                        ref.exists(tripReviewProvider(
+                                            TripReviewKey(trip.id))),
                                     displayTitle: _displayTitle(trip),
                                     titleKey: _headerTitleKey,
                                     overview: _overviewText(trip),
@@ -3911,6 +4038,7 @@ class _TripDetailScreenState extends ConsumerState<TripDetailScreen>
                                 trip: trip,
                                 derivation: derivation,
                                 expandable: expandable,
+                                live: _postFirstFrame,
                                 focusedLegKey: _focusedLegKey,
                                 selectedPosition: _selectedPosition,
                                 homeAirport: _homeAirport,

--- a/src/packages/flutter-app/lib/widgets/trip_detail/itinerary_tab.dart
+++ b/src/packages/flutter-app/lib/widgets/trip_detail/itinerary_tab.dart
@@ -286,6 +286,14 @@ extension on _TripDetailScreenState {
           final md = _fmt(tripStart.add(Duration(days: day - 1))).substring(5);
           weatherChip = Consumer(
             builder: (context, ref, _) {
+              // _fanOutWatch's condition, restated because this watch needs
+              // .select (a resolving report repaints only this chip): defer
+              // the fetch-creating first watch past the first content
+              // frame, but read an already-alive report immediately.
+              if (!_postFirstFrame &&
+                  !ref.exists(weatherByCityProvider(weatherQuery))) {
+                return const SizedBox.shrink();
+              }
               final report = ref.watch(weatherByCityProvider(weatherQuery)
                   .select((a) => a.valueOrNull));
               final wd = report?.dayFor(md);
@@ -766,7 +774,10 @@ extension on _TripDetailScreenState {
     );
     return SliverToBoxAdapter(
       child: Consumer(builder: (context, ref, _) {
-        final async = ref.watch(eventsByCityProvider(query));
+        // Deferred first frame renders the loading branch below — visually
+        // identical to the cold watch it becomes one frame later.
+        final async = _fanOutWatch(ref, eventsByCityProvider(query)) ??
+            const AsyncLoading();
         return async.when(
           loading: () => Padding(
             padding: const EdgeInsets.symmetric(vertical: AppSpacing.sm),

--- a/src/packages/flutter-app/lib/widgets/trip_detail/map_band.dart
+++ b/src/packages/flutter-app/lib/widgets/trip_detail/map_band.dart
@@ -108,6 +108,16 @@ class TripDetailMapBand extends StatelessWidget {
   final Trip trip;
   final TripDerivation derivation;
   final bool expandable;
+
+  /// Whether the live tile map mounts. False during the screen's first
+  /// content frame (time-to-interactive, lever 3): [TripMap] and its two
+  /// stacked retina tile layers cost dozens of fetches and decodes, so the
+  /// deferred frame paints [appMapBackground] instead — the exact canvas an
+  /// unloaded map paints ([AppMapVisibilityGate]'s stand-in), so the live
+  /// mount one frame later changes nothing visually. Chips and the expand
+  /// control render either way: they are part of what the first frame
+  /// shows, and their layout must not shift when the map arrives.
+  final bool live;
   final ValueNotifier<String?> focusedLegKey;
   final ValueNotifier<int?> selectedPosition;
   final String? homeAirport;
@@ -127,6 +137,7 @@ class TripDetailMapBand extends StatelessWidget {
     required this.trip,
     required this.derivation,
     required this.expandable,
+    required this.live,
     required this.focusedLegKey,
     required this.selectedPosition,
     required this.homeAirport,
@@ -175,6 +186,13 @@ class TripDetailMapBand extends StatelessWidget {
         // map subtree — resolution landing must not rebuild the screen.
         Widget map = Consumer(
           builder: (context, ref, _) {
+            if (!live) {
+              // Deferred first frame (see [live]): paint the canvas the
+              // unloaded map would — no provider watches, no [TripMap], no
+              // tile traffic — and let the frame after it mount the rest.
+              return const SizedBox.expand(
+                  child: ColoredBox(color: appMapBackground));
+            }
             final candidates = homeOverlayFor(
               ref,
               homeAirport: homeAirport,

--- a/src/packages/flutter-app/lib/widgets/trip_detail/trip_header_card.dart
+++ b/src/packages/flutter-app/lib/widgets/trip_detail/trip_header_card.dart
@@ -27,6 +27,17 @@ class TripHeaderCard extends ConsumerStatefulWidget {
   final bool isOffline;
   final bool readOnly;
   final bool panelOpen;
+
+  /// Whether the Next Step card's trip-review watch may run this frame.
+  /// False only during the screen's deferred first content frame, and only
+  /// when no previous watch already created the provider — the screen
+  /// resolves both terms (see `_TripDetailScreenState._fanOutWatch`) so the
+  /// review fetch fires one frame after first paint on a cold visit and the
+  /// cached card still renders in the first frame on a warm one. While
+  /// false this area renders the same nothing it renders before the review
+  /// resolves.
+  final bool reviewLive;
+
   final String displayTitle;
 
   /// Attached to the title Text so the screen can measure where it sits and
@@ -51,6 +62,7 @@ class TripHeaderCard extends ConsumerStatefulWidget {
     required this.isOffline,
     required this.readOnly,
     required this.panelOpen,
+    required this.reviewLive,
     required this.displayTitle,
     this.titleKey,
     required this.overview,
@@ -269,6 +281,9 @@ class _TripHeaderCardState extends ConsumerState<TripHeaderCard> {
   Widget _nextStepArea() {
     final trip = widget.trip;
     if (widget.readOnly) return const SizedBox.shrink();
+    // Deferred first frame (see [TripHeaderCard.reviewLive]): don't create
+    // the review fetch yet — identical render to the unresolved watch.
+    if (!widget.reviewLive) return const SizedBox.shrink();
     return Consumer(
       builder: (context, ref, _) {
         final review =

--- a/src/packages/flutter-app/test/trip_detail_first_paint_test.dart
+++ b/src/packages/flutter-app/test/trip_detail_first_paint_test.dart
@@ -1,0 +1,536 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:travel_route_planner/models/booking_todo.dart';
+import 'package:travel_route_planner/models/itinerary_item.dart';
+import 'package:travel_route_planner/models/route_request.dart';
+import 'package:travel_route_planner/models/route_response.dart';
+import 'package:travel_route_planner/models/trip.dart';
+import 'package:travel_route_planner/models/trip_finding.dart';
+import 'package:travel_route_planner/models/weather.dart';
+import 'package:travel_route_planner/providers/api_client_provider.dart';
+import 'package:travel_route_planner/providers/booking_todos_provider.dart';
+import 'package:travel_route_planner/providers/trip_cache_provider.dart';
+import 'package:travel_route_planner/providers/trip_review_provider.dart';
+import 'package:travel_route_planner/providers/trips_provider.dart';
+import 'package:travel_route_planner/providers/weather_provider.dart';
+import 'package:travel_route_planner/screens/trip_detail_screen.dart';
+import 'package:travel_route_planner/services/api_client.dart';
+import 'package:travel_route_planner/services/booking_todos_api_service.dart';
+import 'package:travel_route_planner/services/trip_cache.dart';
+import 'package:travel_route_planner/services/trip_review_api_service.dart';
+import 'package:travel_route_planner/services/trips_api_service.dart';
+import 'package:travel_route_planner/services/weather_api_service.dart';
+import 'package:travel_route_planner/widgets/app_map.dart';
+import 'package:travel_route_planner/widgets/trip_map.dart';
+
+import 'support/l10n_test_app.dart';
+
+/// Trip-detail time-to-interactive (this lane's three levers):
+///  1. the first frame gates on the trip GET alone — travel times and the
+///     booking-todo sync land in place behind it and degrade silently;
+///  2. a cached trip paints immediately (no spinner) with the network fetch
+///     running behind it, updating in place;
+///  3. the live tile map and the enhancement fetches (review, weather) mount
+///     one frame AFTER first paint, so the first frame costs only what it
+///     shows — except providers that are already alive (warm revisit), whose
+///     cached value renders in the first frame for free.
+///
+/// All assertions here are structural (widget presence, call counts, scroll
+/// offsets set programmatically) — nothing measures rendered text (the
+/// widget-test font is not Inter; see CLAUDE.md).
+
+/// getTrip answers from a queue: a Trip resolves, a Completer stays pending
+/// until the test completes it, anything else throws.
+class _QueuedTripsApiService extends TripsApiService {
+  final List<Object> responses;
+  int calls = 0;
+
+  _QueuedTripsApiService(this.responses)
+      : super(ApiClient(baseUrl: 'http://test'));
+
+  @override
+  Future<Trip> getTrip(String id) {
+    final next =
+        responses[calls < responses.length ? calls : responses.length - 1];
+    calls++;
+    if (next is Trip) return Future.value(next);
+    if (next is Completer<Trip>) return next.future;
+    return Future.error(next);
+  }
+}
+
+/// /optimize-route held pending or failing, so lever 1 can observe the
+/// screen render while travel times are still (or never) landing.
+class _GatedApiClient extends ApiClient {
+  /// A Completer<RouteResponse> serves its future; anything else throws.
+  final Object gate;
+  int calls = 0;
+
+  _GatedApiClient(this.gate) : super(baseUrl: 'http://test');
+
+  @override
+  Future<RouteResponse> optimizeRoute(RouteRequest request) {
+    calls++;
+    final g = gate;
+    if (g is Completer<RouteResponse>) return g.future;
+    return Future.error(g);
+  }
+}
+
+/// Booking-todo sync held pending, failing, or answering instantly.
+class _GatedBookingTodosApiService extends BookingTodosApiService {
+  /// List<BookingTodo> resolves, a Completer serves its future, anything
+  /// else throws.
+  final Object gate;
+  int calls = 0;
+
+  _GatedBookingTodosApiService(this.gate)
+      : super(ApiClient(baseUrl: 'http://test'));
+
+  @override
+  Future<List<BookingTodo>> syncTodos(
+      String tripId, List<Map<String, dynamic>> derived) {
+    calls++;
+    final g = gate;
+    if (g is List<BookingTodo>) return Future.value(g);
+    if (g is Completer<List<BookingTodo>>) return g.future;
+    return Future.error(g);
+  }
+}
+
+/// Counts review fetches, so lever 3 can pin WHEN the fetch fires.
+class _CountingReviewApiService extends TripReviewApiService {
+  final TripReview review;
+  int calls = 0;
+
+  _CountingReviewApiService(this.review)
+      : super(ApiClient(baseUrl: 'http://test'));
+
+  @override
+  Future<TripReview> getReview(String tripId,
+      {bool checkHours = false}) async {
+    calls++;
+    return review;
+  }
+}
+
+/// Counts weather fetches (returns an empty report — count is the point).
+class _CountingWeatherApiService extends WeatherApiService {
+  int calls = 0;
+
+  _CountingWeatherApiService() : super(ApiClient(baseUrl: 'http://test'));
+
+  @override
+  Future<WeatherReport> getTripWeather(String city, String startDate,
+      {String? endDate}) async {
+    calls++;
+    return const WeatherReport();
+  }
+}
+
+ItineraryItem _item(int pos, String name,
+        {double lat = 0, double lng = 0, int? day, String? city}) =>
+    ItineraryItem(
+      id: 'i$pos',
+      position: pos,
+      name: name,
+      address: '$name street, ${city ?? 'Athens'}',
+      latitude: lat,
+      longitude: lng,
+      category: 'attraction',
+      day: day,
+      city: city,
+    );
+
+/// Undated, zero-coord single stop: no map, no weather, no events — the
+/// minimal screen for levers 1–2.
+Trip _trip(String title) => Trip(
+      id: 't1',
+      title: title,
+      createdAt: '2026-06-01',
+      updatedAt: '2026-06-01',
+      items: [_item(0, 'Acropolis')],
+    );
+
+/// Two coordinated stops: the map band renders and travel times fire.
+Trip _coordTrip() => Trip(
+      id: 't1',
+      title: 'Paris Trip',
+      createdAt: '2026-06-01',
+      updatedAt: '2026-06-01',
+      items: [
+        _item(0, 'Louvre', lat: 48.86, lng: 2.33, city: 'Paris'),
+        _item(1, 'Orsay', lat: 48.85, lng: 2.32, city: 'Paris'),
+      ],
+    );
+
+/// Dated city trip: visible leg ranges carry dates, so the weather lookups
+/// (wear action + day chips) have a real query to fire.
+Trip _datedTrip() => Trip(
+      id: 't1',
+      title: 'Paris Trip',
+      createdAt: '2026-06-01',
+      updatedAt: '2026-06-01',
+      startDate: '2026-09-10',
+      endDate: '2026-09-11',
+      items: [
+        _item(0, 'Louvre', day: 1, city: 'Paris'),
+        _item(1, 'Orsay', day: 2, city: 'Paris'),
+      ],
+    );
+
+/// Enough zero-coord stops that the itinerary scrolls in any font.
+Trip _longTrip(String title) => Trip(
+      id: 't1',
+      title: title,
+      createdAt: '2026-06-01',
+      updatedAt: '2026-06-01',
+      items: [for (var i = 0; i < 30; i++) _item(i, 'Stop $i')],
+    );
+
+/// The header's Refine entry (ActionChip since the wave-2 redesign): its
+/// onPressed is the screen's clearest "not in offline mode" signal.
+ActionChip _refineChip(WidgetTester tester) =>
+    tester.widget<ActionChip>(find.ancestor(
+      of: find.text('Refine with AI'),
+      matching: find.byType(ActionChip),
+    ));
+
+Future<void> _pumpDetail(WidgetTester tester, List<Override> overrides) {
+  return tester.pumpWidget(
+    ProviderScope(
+      overrides: overrides,
+      child: MaterialApp(
+          localizationsDelegates: testLocalizationsDelegates,
+          home: TripDetailScreen(tripId: 't1')),
+    ),
+  );
+}
+
+/// Pumps single frames until [finder] matches (bounded), leaving the tree on
+/// the exact frame where it first appeared. For a content finder that means
+/// the FIRST content frame: the fan-out flag flips in that frame's post-frame
+/// callback, so what's deferred is still absent from the tree under test —
+/// the next pump is the fan-out frame.
+Future<void> _pumpUntil(WidgetTester tester, Finder finder,
+    {int maxPumps = 12}) async {
+  for (var i = 0; i < maxPumps && finder.evaluate().isEmpty; i++) {
+    await tester.pump(const Duration(milliseconds: 50));
+  }
+  expect(finder, findsWidgets);
+}
+
+void main() {
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  group('lever 1 — first frame gates on the trip GET alone', () {
+    testWidgets(
+        'content renders while travel times and the todo sync are still in flight',
+        (WidgetTester tester) async {
+      final optimizeGate = Completer<RouteResponse>();
+      final syncGate = Completer<List<BookingTodo>>();
+      final api = _GatedApiClient(optimizeGate);
+      final sync = _GatedBookingTodosApiService(syncGate);
+
+      await _pumpDetail(tester, [
+        tripsApiServiceProvider
+            .overrideWithValue(_QueuedTripsApiService([_coordTrip()])),
+        apiClientProvider.overrideWithValue(api),
+        bookingTodosApiServiceProvider.overrideWithValue(sync),
+      ]);
+      await _pumpUntil(tester, find.text('Paris Trip'));
+
+      // The old gate held the spinner until optimize-route AND the
+      // prefs→todo-sync chain completed; both are provably still pending.
+      expect(optimizeGate.isCompleted, isFalse);
+      expect(syncGate.isCompleted, isFalse);
+      expect(find.byType(CircularProgressIndicator), findsNothing);
+      expect(find.text('Could not load this trip'), findsNothing);
+
+      // The follow-ups land in place afterwards — no spinner, no blanking.
+      optimizeGate.complete(RouteResponse(
+        optimizedRoute: const [],
+        totalDistanceKm: 0,
+        totalTravelTimeMin: 0,
+        totalVisitTimeMin: 0,
+        totalTripTimeMin: 0,
+        locationTimings: const [],
+        algorithm: 'preserve_order',
+        locationCount: 2,
+        status: 'success',
+      ));
+      syncGate.complete(<BookingTodo>[]);
+      await tester.pumpAndSettle();
+      expect(find.text('Paris Trip'), findsWidgets);
+      expect(find.byType(CircularProgressIndicator), findsNothing);
+      expect(find.text('Could not load this trip'), findsNothing);
+    });
+
+    testWidgets('failing follow-up calls degrade silently behind the screen',
+        (WidgetTester tester) async {
+      await _pumpDetail(tester, [
+        tripsApiServiceProvider
+            .overrideWithValue(_QueuedTripsApiService([_coordTrip()])),
+        apiClientProvider.overrideWithValue(_GatedApiClient(const ApiException(
+            statusCode: 503, message: 'shed', endpoint: '/optimize-route'))),
+        bookingTodosApiServiceProvider.overrideWithValue(
+            _GatedBookingTodosApiService(http.ClientException('down'))),
+      ]);
+      await tester.pumpAndSettle();
+
+      // Rendered screen, never blanked: no error page, no offline banner,
+      // no re-spinner — and mutations stay armed (not offline mode).
+      expect(find.text('Paris Trip'), findsWidgets);
+      expect(find.text('Could not load this trip'), findsNothing);
+      expect(find.textContaining('Offline — showing saved copy from'),
+          findsNothing);
+      expect(find.byType(CircularProgressIndicator), findsNothing);
+      expect(_refineChip(tester).onPressed, isNotNull);
+    });
+  });
+
+  group('lever 2 — cache-first render', () {
+    testWidgets(
+        'a cached trip paints immediately with no spinner while the fetch runs behind',
+        (WidgetTester tester) async {
+      final cache = TripCache('u1');
+      await cache.writeTrip(_trip('Athens Trip'));
+      final pending = Completer<Trip>();
+      final sync = _GatedBookingTodosApiService(<BookingTodo>[]);
+
+      await _pumpDetail(tester, [
+        tripsApiServiceProvider
+            .overrideWithValue(_QueuedTripsApiService([pending])),
+        tripCacheProvider.overrideWithValue(cache),
+        bookingTodosApiServiceProvider.overrideWithValue(sync),
+      ]);
+      await _pumpUntil(tester, find.text('Athens Trip'));
+
+      // Cached content on screen, fetch still in flight: no spinner, no
+      // offline banner (mutations stay armed), no error page — and none of
+      // the network side-effects have run against the cached copy.
+      expect(find.text('Acropolis'), findsOneWidget);
+      expect(find.byType(CircularProgressIndicator), findsNothing);
+      expect(find.textContaining('Offline — showing saved copy from'),
+          findsNothing);
+      expect(find.text('Could not load this trip'), findsNothing);
+      expect(sync.calls, 0,
+          reason: 'the todo sync must wait for the fresh payload');
+
+      // The fresh payload lands in place — new data, no spinner, no banner.
+      pending.complete(_trip('Athens Trip (fresh)'));
+      await tester.pumpAndSettle();
+      expect(find.text('Athens Trip (fresh)'), findsWidgets);
+      expect(find.byType(CircularProgressIndicator), findsNothing);
+      expect(find.textContaining('Offline — showing saved copy from'),
+          findsNothing);
+      expect(sync.calls, 1, reason: 'sync runs once the fresh trip landed');
+    });
+
+    testWidgets('the cached→fresh swap preserves scroll position',
+        (WidgetTester tester) async {
+      final cache = TripCache('u1');
+      await cache.writeTrip(_longTrip('Athens Trip'));
+      final pending = Completer<Trip>();
+
+      await _pumpDetail(tester, [
+        tripsApiServiceProvider
+            .overrideWithValue(_QueuedTripsApiService([pending])),
+        tripCacheProvider.overrideWithValue(cache),
+        bookingTodosApiServiceProvider
+            .overrideWithValue(_GatedBookingTodosApiService(<BookingTodo>[])),
+      ]);
+      await _pumpUntil(tester, find.text('Athens Trip'));
+
+      // The traveler scrolls the cached copy…
+      final scrollView =
+          tester.widget<CustomScrollView>(find.byType(CustomScrollView));
+      scrollView.controller!.jumpTo(150);
+      await tester.pump();
+      expect(scrollView.controller!.offset, 150);
+
+      // …and the fresh payload landing must not move them.
+      pending.complete(_longTrip('Athens Trip (fresh)'));
+      await tester.pumpAndSettle();
+      expect(find.text('Athens Trip (fresh)'), findsWidgets);
+      expect(scrollView.controller!.offset, 150);
+      expect(find.byType(CircularProgressIndicator), findsNothing);
+    });
+
+    testWidgets(
+        'cached render + network failure keeps the content and adds the offline affordance',
+        (WidgetTester tester) async {
+      final cache = TripCache('u1');
+      await cache.writeTrip(_trip('Athens Trip'));
+      final pending = Completer<Trip>();
+
+      await _pumpDetail(tester, [
+        tripsApiServiceProvider
+            .overrideWithValue(_QueuedTripsApiService([pending])),
+        tripCacheProvider.overrideWithValue(cache),
+      ]);
+      await _pumpUntil(tester, find.text('Athens Trip'));
+      expect(find.textContaining('Offline — showing saved copy from'),
+          findsNothing);
+
+      pending.completeError(http.ClientException('down'));
+      await tester.pumpAndSettle();
+
+      // Same cached content, now clearly marked offline — never an error
+      // page, never a blank.
+      expect(find.text('Acropolis'), findsOneWidget);
+      expect(find.textContaining('Offline — showing saved copy from'),
+          findsOneWidget);
+      expect(find.text('Could not load this trip'), findsNothing);
+      expect(_refineChip(tester).onPressed, isNull,
+          reason: 'offline mode disables mutations');
+    });
+
+    testWidgets(
+        'cached render + a stable 404 still shows the error page (no resurrected trip)',
+        (WidgetTester tester) async {
+      final cache = TripCache('u1');
+      await cache.writeTrip(_trip('Athens Trip'));
+      final pending = Completer<Trip>();
+
+      await _pumpDetail(tester, [
+        tripsApiServiceProvider
+            .overrideWithValue(_QueuedTripsApiService([pending])),
+        tripCacheProvider.overrideWithValue(cache),
+      ]);
+      await _pumpUntil(tester, find.text('Athens Trip'));
+
+      pending.completeError(const ApiException(
+          statusCode: 404, message: 'gone', endpoint: '/trips/t1'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Could not load this trip'), findsOneWidget);
+      expect(find.text('Acropolis'), findsNothing);
+      expect(find.textContaining('Offline — showing saved copy from'),
+          findsNothing);
+    });
+  });
+
+  group('lever 3 — deferred first-frame fan-out', () {
+    testWidgets('the live map mounts one frame after first paint, same canvas',
+        (WidgetTester tester) async {
+      await _pumpDetail(tester, [
+        tripsApiServiceProvider
+            .overrideWithValue(_QueuedTripsApiService([_coordTrip()])),
+        bookingTodosApiServiceProvider
+            .overrideWithValue(_GatedBookingTodosApiService(<BookingTodo>[])),
+      ]);
+      await _pumpUntil(tester, find.text('Paris Trip'));
+
+      // First content frame: no live map — the band paints the exact canvas
+      // an unloaded map paints, so the swap is invisible.
+      expect(find.byType(TripMap), findsNothing);
+      expect(
+          find.byWidgetPredicate(
+              (w) => w is ColoredBox && w.color == appMapBackground),
+          findsOneWidget);
+
+      // One frame later the live map is up.
+      await tester.pump();
+      expect(find.byType(TripMap), findsOneWidget);
+      await tester.pumpAndSettle();
+      expect(find.byType(TripMap), findsOneWidget);
+    });
+
+    testWidgets('cold visit: the review fetch fires after first paint, not in it',
+        (WidgetTester tester) async {
+      final review =
+          _CountingReviewApiService(const TripReview(findings: []));
+      // Sync held pending so _load's end-of-load review invalidation can't
+      // fire a second fetch and blur the count under assertion.
+      final syncGate = Completer<List<BookingTodo>>();
+
+      await _pumpDetail(tester, [
+        tripsApiServiceProvider
+            .overrideWithValue(_QueuedTripsApiService([_trip('Athens Trip')])),
+        tripReviewApiServiceProvider.overrideWithValue(review),
+        bookingTodosApiServiceProvider
+            .overrideWithValue(_GatedBookingTodosApiService(syncGate)),
+      ]);
+      await _pumpUntil(tester, find.text('Athens Trip'));
+
+      // First content frame: no review fetch, no badge.
+      expect(review.calls, 0);
+      expect(find.byIcon(Icons.fact_check_outlined), findsNothing);
+
+      // The fan-out frame creates the watch → exactly one fetch.
+      await tester.pump();
+      expect(review.calls, 1);
+      await tester.pumpAndSettle();
+      expect(find.byIcon(Icons.fact_check_outlined), findsOneWidget);
+      expect(review.calls, 1);
+    });
+
+    testWidgets('warm revisit: an already-fetched review renders in frame one',
+        (WidgetTester tester) async {
+      final review =
+          _CountingReviewApiService(const TripReview(findings: []));
+      final container = ProviderContainer(overrides: [
+        tripsApiServiceProvider
+            .overrideWithValue(_QueuedTripsApiService([_trip('Athens Trip')])),
+        tripReviewApiServiceProvider.overrideWithValue(review),
+        bookingTodosApiServiceProvider.overrideWithValue(
+            _GatedBookingTodosApiService(Completer<List<BookingTodo>>())),
+      ]);
+      addTearDown(container.dispose);
+
+      // A previous visit fetched the review (non-autoDispose: it stays).
+      await container
+          .read(tripReviewProvider(const TripReviewKey('t1')).future);
+      expect(review.calls, 1);
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: MaterialApp(
+              localizationsDelegates: testLocalizationsDelegates,
+              home: TripDetailScreen(tripId: 't1')),
+        ),
+      );
+      await _pumpUntil(tester, find.text('Athens Trip'));
+
+      // The badge is up in the FIRST content frame — reading alive state is
+      // free; only fetch creation is deferred — and nothing refetched.
+      expect(find.byIcon(Icons.fact_check_outlined), findsOneWidget);
+      expect(review.calls, 1);
+    });
+
+    testWidgets('weather lookups fire after first paint, not in it',
+        (WidgetTester tester) async {
+      final weather = _CountingWeatherApiService();
+      final syncGate = Completer<List<BookingTodo>>();
+
+      await _pumpDetail(tester, [
+        tripsApiServiceProvider
+            .overrideWithValue(_QueuedTripsApiService([_datedTrip()])),
+        weatherApiServiceProvider.overrideWithValue(weather),
+        bookingTodosApiServiceProvider
+            .overrideWithValue(_GatedBookingTodosApiService(syncGate)),
+      ]);
+      await _pumpUntil(tester, find.text('Paris Trip'));
+
+      // First content frame: no weather traffic (the wear action and the
+      // day chips both build a byte-identical query, so one call total once
+      // allowed).
+      expect(weather.calls, 0);
+
+      await tester.pump();
+      expect(weather.calls, 1);
+      await tester.pumpAndSettle();
+      expect(weather.calls, 1);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- The spinner clears the moment the trip GET lands. The optimize-route POST and prefs→booking-todos sync run behind the rendered screen as a fenced enhancement pass — their failures can never blank a rendered screen — while `_load`'s completion contract is unchanged, so refresh coalescing and pull-to-refresh semantics hold.
- Revisited trips paint instantly from TripCache (no spinner, mutations armed) with the network refresh landing in place: same widgets, no scroll reset. Transient failure keeps the cached content under the offline banner; a real 403/404/500 still wins with the error page, so a revoked/deleted trip can't survive as an interactive cached copy; retrying from the error page skips the cache paint. Network side-effects (todo-sync, travel times, review invalidation) fire exclusively on fresh payloads.
- The first content frame renders only what the payload shows: the dual-layer satellite map mounts one frame later behind `appMapBackground` (pixel-identical to what a loading map paints), and the review/Next-Step/checklist/per-leg + day weather/city-events fetches fire post-frame. Providers already alive are exempt (`ref.exists`), so warm revisits keep their badges with zero pop-in.
- Diagnosis in the epic artifact `trip-detail-first-paint`: the 2–3 s was three-to-four serialized round trips each exposed to the 429/503 retry backoff, a write-through cache that was never read, and a first-frame stampede.

## Testing
- Full suite on the merged tree (lane + current main incl. #565–#567): **2015 passed, 0 failed**.
- 10 new structural tests in `trip_detail_first_paint_test.dart` (2 lever-1, 4 lever-2, 4 lever-3): widget presence/absence across specific frames, service call counts, programmatic scroll offsets — none font-dependent.
- Semantic-drift check against main's new tests (item-delete no-reload, reorder no-spinner, destination map/pins): 69 tests pass together.
- `flutter analyze`: only the 3 pre-existing `route_response.dart` infos. Brand check clean on added lines. PR #560's cache round-trip pin passes.

## Caveats for review
- Cold opens fetch the review twice (an optimistic post-frame GET, then the authoritative refetch after todo-sync) — deliberate and flagged in the commit body; the review is a cheap derivation and Riverpod holds previous data through the refetch, but say the word if you want it single-shot.
- Nobody has watched this in a browser: tests prove ordering and gating, not the felt smoothness of the cached→fresh swap, the one-frame map handoff at real frame rates, or real tile-request behavior on the deferred mount.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/golden-tempo/codesmith/anemos-travel/pr/568"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790307417&installation_model_id=433099&pr_number=568&repository=golden-tempo%2Fanemos-travel&return_to=https%3A%2F%2Fgithub.com%2Fgolden-tempo%2Fanemos-travel%2Fpull%2F568&signature=db33b9f538e2e97bf195ed36b91021580cf14f067f5d0021d18413ca0b172185"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->