### PR TITLE
chore(deps): flutter_secure_storage ^10.3.1 — clears the sole dart2wasm blocker

### DIFF
--- a/src/packages/flutter-app/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/src/packages/flutter-app/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -7,7 +7,7 @@ import Foundation
 
 import desktop_drop
 import file_picker
-import flutter_secure_storage_macos
+import flutter_secure_storage_darwin
 import path_provider_foundation
 import record_macos
 import share_plus
@@ -18,7 +18,7 @@ import url_launcher_macos
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   DesktopDropPlugin.register(with: registry.registrar(forPlugin: "DesktopDropPlugin"))
   FilePickerPlugin.register(with: registry.registrar(forPlugin: "FilePickerPlugin"))
-  FlutterSecureStoragePlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStoragePlugin"))
+  FlutterSecureStorageDarwinPlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStorageDarwinPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   RecordMacOsPlugin.register(with: registry.registrar(forPlugin: "RecordMacOsPlugin"))
   SharePlusMacosPlugin.register(with: registry.registrar(forPlugin: "SharePlusMacosPlugin"))

--- a/src/packages/flutter-app/pubspec.lock
+++ b/src/packages/flutter-app/pubspec.lock
@@ -383,50 +383,50 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_secure_storage
-      sha256: "9cad52d75ebc511adfae3d447d5d13da15a55a92c9410e50f67335b6d21d16ea"
+      sha256: "7686b1d6a29985dcbb808c59518226e603e3bfa7c0ddfd1a0d00e4cda77c868e"
       url: "https://pub.dev"
     source: hosted
-    version: "9.2.4"
+    version: "10.3.1"
+  flutter_secure_storage_darwin:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_darwin
+      sha256: "82329fa5cdf343773b1b6897dea959105a29f092454259edff92f9f6637e8149"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.2"
   flutter_secure_storage_linux:
     dependency: transitive
     description:
       name: flutter_secure_storage_linux
-      sha256: be76c1d24a97d0b98f8b54bce6b481a380a6590df992d0098f868ad54dc8f688
+      sha256: "76fa9c841b3b1619fc5b5bc36efc7d158fa2356f223b6caeb1d0c80a54168546"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.3"
-  flutter_secure_storage_macos:
-    dependency: transitive
-    description:
-      name: flutter_secure_storage_macos
-      sha256: "6c0a2795a2d1de26ae202a0d78527d163f4acbb11cde4c75c670f3a0fc064247"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.1.3"
+    version: "3.0.2"
   flutter_secure_storage_platform_interface:
     dependency: transitive
     description:
       name: flutter_secure_storage_platform_interface
-      sha256: cf91ad32ce5adef6fba4d736a542baca9daf3beac4db2d04be350b87f69ac4a8
+      sha256: "788060052712555182aba55ecb5f8b6e5cb9cfe8f776c83249a61fe3ce877db4"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.2"
+    version: "2.0.3"
   flutter_secure_storage_web:
     dependency: transitive
     description:
       name: flutter_secure_storage_web
-      sha256: f4ebff989b4f07b2656fb16b47852c0aab9fed9b4ec1c70103368337bc1886a9
+      sha256: "073a62b3aeb866ab4ce795f960413948e51e5a42a9b0c8333b6daf5bb3208a1c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "2.1.1"
   flutter_secure_storage_windows:
     dependency: transitive
     description:
       name: flutter_secure_storage_windows
-      sha256: b20b07cb5ed4ed74fc567b78a72936203f587eba460af1df11281c9326cd3709
+      sha256: "3b7c8e068875dfd46719ff57c90d8c459c87f2302ed6b00ff006b3c9fcad1613"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.2"
+    version: "4.1.0"
   flutter_svg:
     dependency: "direct main"
     description:

--- a/src/packages/flutter-app/pubspec.yaml
+++ b/src/packages/flutter-app/pubspec.yaml
@@ -59,8 +59,11 @@ dependencies:
   # JSON serialization
   json_annotation: ^4.8.1
   
-  # Secure on-device storage for the session token
-  flutter_secure_storage: ^9.2.2
+  # Secure on-device storage for the session token. Keep at v10+: its web
+  # implementation is js_interop-based, while 9.x's dart:html one is the
+  # repo's sole dart2wasm blocker (specs/perf-program deferred --wasm
+  # experiment; probed 2026-08-26 — everything else compiles).
+  flutter_secure_storage: ^10.3.1
 
   # Plain on-device storage (last viewed trip)
   shared_preferences: ^2.3.0


### PR DESCRIPTION
## Summary
- Bumps `flutter_secure_storage` ^9.2.2 → ^10.3.1. Its 1.x web implementation (`dart:html`/`dart:js_util`) is the **only** package in the dependency graph that fails `flutter build web --wasm` — proven by a real probe build on 2026-08-26, where this bump alone took the build from failing to `✓ Built build/web`. Full probe write-up lives in the epic artifact `trip-detail-first-paint/wasm-build`.
- Web session survival was verified in both packages' source, not assumed: same localStorage naming, same AES-GCM 256 raw-JWK scheme, same default `publicKey` — existing signed-in web users should keep their session. Worst case if byte-level encoding differs anywhere: a one-time re-login.
- v10 folds `flutter_secure_storage_macos` into a unified `darwin` package; `GeneratedPluginRegistrant.swift` is pub get's regeneration for that.
- The pubspec comment pins v10 as the floor so a future downgrade can't silently re-block the wasm build.
- Deliberately independent of any wasm build change: this is green under today's JS build, and the wasm lane (nginx `.mjs` MIME, no-cache regex additions, `--wasm` flags) can follow separately per the artifact's work list.

## Testing
- Full suite: **2005 passed, 0 failed**.
- `flutter analyze`: only the 3 pre-existing `route_response.dart` infos.
- All 34 tests across the six auth-flow files (SSO callback, connect-app, auth restore timeout, auth polish, SSO buttons, Apple sign-in) pass.
- Not verified here: a live web session surviving the upgrade (smoke it on a dev stack or watch the first deploy — worst case is one re-login), and native Keychain/Keystore behavior on mobile platforms the app doesn't ship to today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/golden-tempo/codesmith/anemos-travel/pr/569"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790307725&installation_model_id=433099&pr_number=569&repository=golden-tempo%2Fanemos-travel&return_to=https%3A%2F%2Fgithub.com%2Fgolden-tempo%2Fanemos-travel%2Fpull%2F569&signature=6b7c9c9a400d2ca01ec1755ef039b1aefeb2278c97ca65071b403bd2df0b17a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->